### PR TITLE
Adds mock blog post

### DIFF
--- a/events/_vars-events.html
+++ b/events/_vars-events.html
@@ -7,6 +7,42 @@
 ]
 %}
 
+{# TEMP Mock object for events #}
+{%
+	set mock_post = {'taxonomy_post_format': [],
+'attachments': [],
+'excerpt': 'Today, we’re posting a semi-annual update of our rulemaking agenda.',
+'taxonomy_author': [],
+'id': 61737.0,
+'custom_fields': {},
+'category': ['Announcements & updates'],
+'author': ['Jane Doe'],
+'taxonomy_post_tag': [],
+'content': 'Our regulatory agenda includes rulemaking actions in the following stages: pre-rule, proposed rule, final rule, long term actions, and completed actions.',
+'comment_count': 0.0,
+'categories': [],
+'type': 'posts',
+'thumbnail': {},
+'status': 'publish',
+'twtr_rel': 'anselmbradford',
+'parent': 0.0,
+'tags': ['Debt collection', 'Mortgages', 'Payday loans', 'Regulations', 'Rulemaking'],
+'taxonomy_fj_category': [],
+'taxonomy_category': [],
+'date': '2014-05-23 04:02:29+00:00',
+'twtr_text': 'This is an example tweet',
+'slug': 'spring-2014-rulemaking-agenda',
+'comment_status': 'open',
+'title_plain': 'Spring 2014 rulemaking agenda',
+'url': 'http://consumerfinance.gov/blog/spring-2014-rulemaking-agenda/',
+'title': 'Spring 2014 rulemaking agenda',
+'modified': '2014-10-20 15:12:40',
+'twtr_hash': 'hashtag',
+'dek': 'Portions of the Unified Agenda are published in the Federal Register, and the full set of materials is also available.',
+'_id': 'spring-2014-rulemaking-agenda',
+'order': 0.0}
+%}
+
 {# SAVED THESE FOR LATER
 
 {% set nav_items = [

--- a/events/index.html
+++ b/events/index.html
@@ -41,7 +41,10 @@
 
 {% block content_main %}
 
-    Events content goes here
+    {# TEMP The mocked event content is in the following paragraph #}
+    <p>
+        Events content goes here: {{vars.mock_post.content}}
+    </p>
 
     {# Footer #}
     <aside>


### PR DESCRIPTION
Adds a mock blog post object for testing purposes on the events page
till the server-side events type is available. 

To inspect an actual blog post object, post the following inside https://github.com/cfpb/cfgov-refresh/blob/gh-pages/blog/_single.html#L24

```jinja
    <p>
        <dl>
        {% for key, value in post.json_compatible().iteritems() %}
            <dt>{{ key }}</dt>
            <dd>{{ value }}</dd>
        {% endfor %}
        </dl>
    </p>
```

Save, and visit `localhost:7000/blog/spring-2014-rulemaking-agenda/`