### PR TITLE
Fixes DF-1463 - single event page

### DIFF
--- a/_settings/lookups.json
+++ b/_settings/lookups.json
@@ -23,5 +23,10 @@
     "url":       "/watchroom/<id>/",
     "type":      "watchroom",
     "permalink": true
+  },
+  "event": {
+    "url":       "/events/<id>/",
+    "type":      "posts",
+    "permalink": true
   }
 }

--- a/events/_event.html
+++ b/events/_event.html
@@ -1,0 +1,67 @@
+
+{# ==========================================================================
+
+   render()
+
+   ==========================================================================
+
+   Description:
+
+   Render an article when given:
+
+   post:               The Sheer document that is available to a _single.html
+                       template. For example in events/_single.html the variable
+                       `event` is available and represents the event for the
+                       `_single` page.
+
+   path:               The path to which post filters are applies. For example,
+                       if the post is an event post then path should be '/events/'.
+                       Remember to leverage vars.path instead of using the
+                       literal string '/events/'. Path is used to create the
+                       filtered URL: {{ path }}?filter_tags={{ tag }}
+
+   ========================================================================== #}
+
+{% macro render(post, path) %}
+
+{% from "macros.html" import share as share %}
+
+<article class="post">
+    <header>
+        <h1 class="post_header">
+            {{ post.title|safe }}
+        </h1>
+    {% if post.dek %}
+        <div class="post_dek">
+            {{ post.dek|safe }}
+        </div>
+    {% endif %}
+        <div class="post_meta">
+            <span class="post_date date">
+                Updated at: {{ post.modified|date("%m/%d/%Y") }}
+            </span>
+        </div>
+        {{ share(post.title, false, {
+           'text':     post.twtr_text,
+           'related':  post.twtr_rel,
+           'language': post.twtr_lang,
+           'hashtags': post.twtr_hash
+        }) }}
+    {% if post.thumbnail.images %}
+        <img class="post_featured-img"
+             src="{{ post.thumbnail.images.full.url }}"
+             alt="{{ post.thumbnail.alt_text }}">
+    {% endif %}
+    </header>
+    <div class="post_body">
+        {{ post.content|safe }}
+    </div>
+{% if post.tags|length %}
+    <footer>
+        {%- import "tags.html" as tags %}
+        {{ tags.render(post.tags, path) }}
+    </footer>
+{% endif %}
+</article>
+
+{% endmacro %}

--- a/events/_single.html
+++ b/events/_single.html
@@ -1,0 +1,54 @@
+{% extends "layout-2-1-bleedbar.html" %}
+{% import "_vars-events.html" as vars with context %}
+
+{% block title -%}
+    {{ vars.mock_event.title }}
+{%- endblock %}
+
+{% block desc -%}
+    {{ vars.mock_event.excerpt|striptags }}
+{%- endblock %}
+
+{% block og_type -%}
+    article
+{%- endblock %}
+
+{% block og_article_prefix -%}
+    article: http://ogp.me/ns/article#
+{%- endblock %}
+
+{% block og_article_author -%}
+    <meta property="article:author" content="https://www.facebook.com/CFPB">
+{%- endblock %}
+
+{% block content_main %}
+    {% import "_event.html" as article with context %}
+    {{ article.render(vars.mock_event, vars.path) }}
+{% endblock %}
+
+{# TEMP disable related posts sidebar till we need it in DF-1473.
+{% block content_sidebar %}
+    <section class="block u-mt0">
+        {% import "related-posts.html" as related_posts with context %}
+        {{ related_posts.render(post) }}
+    </section>
+    <section class="block">
+        <h1 class="header-slug">
+            <span class="header-slug_inner">
+                Stay informed
+            </span>
+        </h1>
+        <div class="block block__sub u-mt0">
+            <p class="short-desc">
+                Subscribe to our email newsletter. We will update you on new blogs.
+            </p>
+            {% import "email-subscribe-form.html" as subscribe with context %}
+            {{ subscribe.render(vars.query) }}
+        </div>
+        <div class="block block__sub">
+            {% import "rss.html" as rss %}
+            {{ rss.render(vars.rss_path) }}
+        </div>
+    </section>
+{% endblock %}
+#}

--- a/events/_vars-events.html
+++ b/events/_vars-events.html
@@ -8,17 +8,16 @@
 %}
 
 {# TEMP Mock object for events #}
-{%
-	set mock_post = {'taxonomy_post_format': [],
+{% set mock_event = {'taxonomy_post_format': [],
 'attachments': [],
-'excerpt': 'Today, we’re posting a semi-annual update of our rulemaking agenda.',
+'excerpt': 'THIS IS THE EXCERPT Today, we’re posting a semi-annual update of our rulemaking agenda.',
 'taxonomy_author': [],
 'id': 61737.0,
 'custom_fields': {},
 'category': ['Announcements & updates'],
 'author': ['Jane Doe'],
 'taxonomy_post_tag': [],
-'content': 'Our regulatory agenda includes rulemaking actions in the following stages: pre-rule, proposed rule, final rule, long term actions, and completed actions.',
+'content': 'THIS IS THE CONTENT Our regulatory agenda includes rulemaking actions in the following stages: pre-rule, proposed rule, final rule, long term actions, and completed actions.',
 'comment_count': 0.0,
 'categories': [],
 'type': 'posts',
@@ -29,21 +28,32 @@
 'tags': ['Debt collection', 'Mortgages', 'Payday loans', 'Regulations', 'Rulemaking'],
 'taxonomy_fj_category': [],
 'taxonomy_category': [],
-'date': '2014-05-23 04:02:29+00:00',
+'date': '2014-05-23',
 'twtr_text': 'This is an example tweet',
 'slug': 'spring-2014-rulemaking-agenda',
 'comment_status': 'open',
-'title_plain': 'Spring 2014 rulemaking agenda',
+'title_plain': 'TITLE PLAIN Spring 2014 rulemaking agenda',
 'url': 'http://consumerfinance.gov/blog/spring-2014-rulemaking-agenda/',
-'title': 'Spring 2014 rulemaking agenda',
-'modified': '2014-10-20 15:12:40',
+'title': 'TITLE Spring 2014 rulemaking agenda',
+'modified': '2014-10-20',
 'twtr_hash': 'hashtag',
-'dek': 'Portions of the Unified Agenda are published in the Federal Register, and the full set of materials is also available.',
+'dek': 'THIS IS THE DEK Portions of the Unified Agenda are published in the Federal Register, and the full set of materials is also available.',
 '_id': 'spring-2014-rulemaking-agenda',
 'order': 0.0}
 %}
 
-{# SAVED THESE FOR LATER
+{# TODO Once the events post type is created,
+the following needs to be added to `_settings/lookups.json`.
+
+  "event": {
+    "url":       "/events/<id>/",
+    "type":      "events",
+    "permalink": true
+  }
+
+#}
+
+{# TODO SAVED THESE FOR LATER
 
 {% set nav_items = [
     (path, 'index', 'Upcoming events and field hearings'),


### PR DESCRIPTION
Adds initial event detail page, with mocked data. URL is handled by creating a path in the lookups table for sheer that points to a blog post, while template is rendered using mocked data in the `events/_vars-event.html` file.

## Additions

- Adds TEMP entry in `lookups.json` for events type.
- Adds `_single.html` template for viewing an individual event.
- Adds `_event.html` template analogous to `article.html` for rendering
individual events.

## Changes

- Updates event mock data to clarify what fields are showing and fix issue
with the date. Also changes the mock name.

## Testing

- Visit http://localhost:7000/events/spring-2014-rulemaking-agenda/

## Review

- @jimmynotjim 
- @sebworks 
- @Scotchester 

et al

## Preview

![screen shot 2015-02-20 at 10 46 07 am](https://cloud.githubusercontent.com/assets/704760/6289377/b77ff74e-b8ed-11e4-8898-df1820f52e64.png)