### PR TITLE
DF-1473 Event Sidebar

### DIFF
--- a/_includes/email-subscribe-form.html
+++ b/_includes/email-subscribe-form.html
@@ -8,15 +8,32 @@
       enctype="application/x-www-form-urlencoded">
 
     <div class="form-group">
-        <label class="u-visually-hidden" for="email-subscribe-form_email">
+        <label for="email-subscribe-form_email">
             Email address
         </label>
         <input class="reveal-on-focus_target"
                id="email-subscribe-form_email"
                type="email"
                name="email"
-               placeholder="Your email">
+               placeholder="example@mail.com">
     </div>
+    {# Uncomment this and remove condition to test
+    {% if 'is_event' %}
+    <div class="form-group reveal-on-focus_content u-clearfix">
+      <label class="form-group_item">
+        <input class="custom-input"
+               type="checkbox"
+               name="email-subscribe-form_zip-only"
+               value="limit_event_area">
+               Only events near my ZIP code
+      </label>
+      <label for="email-subscribe-form_zip-code">Zip code</label>
+      <input type="text"
+              name="email-subscribe-form_zip-code"
+              placeholder="00000">
+    </div>
+    {% endif %}
+    #}
     {% if query -%}
     <div class="form-group reveal-on-focus_content u-clearfix">
     {% for category in query.possible_values_for('category')|sort(attribute='term') -%}
@@ -51,7 +68,7 @@
                value="{{ code }}">
     </div>
     {% endif -%}
-    
+
     <div class="form-group">
         <input class="btn" type="submit" class="btn" value="Sign up">
     </div>

--- a/events/_single.html
+++ b/events/_single.html
@@ -26,11 +26,10 @@
     {{ article.render(vars.mock_event, vars.path) }}
 {% endblock %}
 
-{# TEMP disable related posts sidebar till we need it in DF-1473.
 {% block content_sidebar %}
     <section class="block u-mt0">
         {% import "related-posts.html" as related_posts with context %}
-        {{ related_posts.render(post) }}
+        {{ related_posts.render(event) }}
     </section>
     <section class="block">
         <h1 class="header-slug">
@@ -50,5 +49,17 @@
             {{ rss.render(vars.rss_path) }}
         </div>
     </section>
+    <section class="block">
+        {%- import "related-links.html" as related_links -%}
+        {{- related_links.render([
+            [
+                '/the-bureau/',
+                'About us'
+            ],
+            [
+                '/contact-us/',
+                'Contact us'
+            ],
+        ]) -}}
+    </section>
 {% endblock %}
-#}


### PR DESCRIPTION
Updated the event sidebar to include some demo content

## Additions

- None

## Removals

- None

## Changes

- Updated the object passed to `post_related.render()`
- Updated the list of related links

## Testing

Navigate to
- events/spring-2014-rulemaking-agenda/

## Review

- @anselmbradford 
- @sebworks 

## Preview

![screen shot 2015-02-23 at 5 21 03 pm](https://cloud.githubusercontent.com/assets/1280430/6338924/62b5ad04-bb80-11e4-8369-18a32c3e6de5.png)


## Notes

- Subscribe form can't currently support zip codes or event type
- Used existing Related Posts macro for code consistency