### PR TITLE
Switch over ElasticSearch q usage to filters, update mappings

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,11 +338,12 @@ We have a handy function `search_with_url_arguments()` that:
 
 URL query string filters can be further broken down into two types:
 
-1. Bool - Used when you want to filter by whether a field matches a keyword,
-  is True or False, etc.
+1. Term - Used when you want to filter by whether a field matches a term.  Note that in order
+to use this type of filter, the field you are matching it against must have `"index": "not_analyzed"`
+set in the mapping.
 2. Range - Used for when you want to filter something by a range (e.g. dates or numbers)
 
-An example of Bool is:
+An example of Term is:
 
 `?filter_category=Op-Ed`
 
@@ -373,24 +374,22 @@ defined in the `_queries/object-name.json` file,
 then mixes them in with any additional arguments
 from the URL query string in addition to what is passed into the function itself.
 
-The list of available arguments are outlined in elasticsearch-py's
-[search method](http://elasticsearch-
-py.readthedocs.org/en/master/api.html#elasticsearch.Elasticsearch.search).
+When using `search_with_url_arguments()`, you can also pass in filters with the same `filter_` syntax as above.
 
-The most common ones we use are `size` (to change the number of results returned)
-and `q` (to query based on specific fields).
+For example:
 
-When using `q`, you'll need to use the
-[Lucene Query Parser Syntax](http://lucene.apache.org/core/2_9_4/queryparsersyntax.html).
+`search_with_url_arguments(filter_category='Op-Ed')`
 
-Here is an example of using `q`:
+Multiple term filters on the same field will be combined in an OR clause, while
+term filters of different fields will be combined in an AND clause.
 
-```
-{% set events_jan2014 = queries.calendar_event.search_with_url_arguments(q="dtstart:[2014-01-01 TO 2014-01-31]") %}
-```
+For example:
 
-This will return a queryset of calendar_event objects which,
-for the field 'dtstart', have a date in January, 2014.
+`search_with_url_arguments(filter_tag='Students', filter_tag='Finance', filter_author='Batman')`
+
+This will return documents that have the tag Students OR Finance, AND have an author of Batman.
+
+If you need more control over your filter than that, enter it manually in the _queries/filtername.json file.
 
 ----
 

--- a/_includes/post-macros.html
+++ b/_includes/post-macros.html
@@ -138,34 +138,39 @@
         {% set doc_type = activity_type %}
         {% set icon = category_icon('blog') %}
         {% set header = 'Blog' %}
-        {% set querystring = 'tags:"' + tags + '"' %}
+        {% set feed = queries[doc_type].search_with_url_arguments(size=quantity,
+            filter_tags=tags) %}
     {% elif activity_type|lower == 'op-ed' %}
         {% set doc_type = 'newsroom' %}
         {% set icon = category_icon(activity_type) %}
         {% set header = 'Op-Ed' %}
-        {% set querystring = 'category:"Op-Ed" AND tags:"' + tags + '"' %}
+        {% set feed = queries[doc_type].search_with_url_arguments(size=quantity,
+            filter_category='Op-Ed', filter_tags=tags) %}
     {% elif activity_type|lower == 'press release' %}
         {% set doc_type = 'newsroom' %}
         {% set icon = category_icon(activity_type) %}
         {% set header = 'Press Release' %}
-        {% set querystring = 'category:"Press Release" AND tags:"' + tags + '"' %}
+        {% set feed = queries[doc_type].search_with_url_arguments(size=quantity,
+            filter_category='Press Release', filter_tags=tags) %}
     {% elif activity_type|lower == 'speech' %}
         {% set doc_type = 'newsroom' %}
         {% set icon = category_icon(activity_type) %}
         {% set header = 'Speech' %}
-        {% set querystring = 'category:"Speech" AND tags:"' + tags + '"' %}
+        {% set feed = queries[doc_type].search_with_url_arguments(size=quantity,
+            filter_category='Speech', filter_tags=tags) %}
     {% elif activity_type|lower == 'testimony' %}
         {% set doc_type = 'newsroom' %}
         {% set icon = category_icon(activity_type) %}
         {% set header = 'Testimony' %}
-        {% set querystring = 'category:"Testimony" AND tags:"' + tags + '"' %}
+        {% set feed = queries[doc_type].search_with_url_arguments(size=quantity,
+            filter_category='Testimony', filter_tags=tags) %}
     {% else %}
         {% set doc_type = 'posts' %}
         {% set icon = category_icon('blog') %}
         {% set header = 'Feed' %}
-        {% set querystring = 'tags:"' + tags + '"' %}
+        {% set feed = queries[doc_type].search_with_url_arguments(size=quantity,
+            filter_tags=tags) %}
     {% endif %}
-    {% set feed = queries[doc_type].search_with_url_arguments(size=quantity,q=querystring) %}
     {% if feed.total > 0 %}
     <aside class="activity">
         <h1 class="h4">{{ icon }} {{ header }}</h1>

--- a/_settings/initiative_mappings.json
+++ b/_settings/initiative_mappings.json
@@ -1,0 +1,8 @@
+{
+  "properties": {
+    "related_office": {
+      "type": "string",
+      "index": "not_analyzed"
+    }
+  }
+}

--- a/_settings/orgmember_mappings.json
+++ b/_settings/orgmember_mappings.json
@@ -15,6 +15,10 @@
     "has_parent": {
       "type":  "string",
       "index": "not_analyzed"
+    },
+    "category": {
+      "type": "string",
+      "index": "not_analyzed"
     }
   }
 }

--- a/_settings/processors.json
+++ b/_settings/processors.json
@@ -16,7 +16,8 @@
   },
   "initiative": {
     "url":       "$WORDPRESS/api/get_posts/?post_type=initiative",
-    "processor": "wordpress_initiative_processor"
+    "processor": "wordpress_initiative_processor",
+    "mappings": "_settings/initiative_mappings.json"
   },
   "office": {
     "url":       "$WORDPRESS/api/get_posts/?post_type=office",

--- a/offices/_offices-index.html
+++ b/offices/_offices-index.html
@@ -17,6 +17,8 @@
 
     {% from "post-macros.html" import activity_snippets as activity_snippets with context %}
     {% import "contact-macro.html" as contact_macro %}
+    {{activity_type}}
+    asdfasdfasdf
     {% set activities_feed = activity_snippets(activity_type) %}
     
     {% if office.title %}

--- a/offices/_offices-index.html
+++ b/offices/_offices-index.html
@@ -17,8 +17,6 @@
 
     {% from "post-macros.html" import activity_snippets as activity_snippets with context %}
     {% import "contact-macro.html" as contact_macro %}
-    {{activity_type}}
-    asdfasdfasdf
     {% set activities_feed = activity_snippets(activity_type) %}
     
     {% if office.title %}

--- a/offices/_vars-offices.html
+++ b/offices/_vars-offices.html
@@ -1,7 +1,6 @@
 
 {% set query = queries.initiative %}
-{% set filter = 'related_office:' + office.slug %}
-{% set initiatives = query.search_with_url_arguments(size=100,q=filter) %}
+{% set initiatives = query.search_with_url_arguments(size=100,filter_related_office=office.slug) %}
 
 {% set nav_items = [(path, 'index', office.title)] -%}
 {% for initiative in initiatives %}

--- a/offices/students-2/_single.html
+++ b/offices/students-2/_single.html
@@ -1,6 +1,4 @@
-
-{% set results = queries.office.search_with_url_arguments(q="_id:students-2",size=1) %}
-{% set office = results | first %}
+{% set office = get_document("office", "students-2") %}
 {% set path = '/offices/' + office.slug + '/' %}
 {% set initiative = students_initiative %}
 {% set activity_type = "Students" %}

--- a/offices/students-2/index.html
+++ b/offices/students-2/index.html
@@ -1,11 +1,10 @@
 
 {% set query = queries.office %}
-{% set results = query.search_with_url_arguments(q="_id:students-2",size=1) %}
-{% set office = results | first %}
+{% set office = get_document("office", "students-2") %}
 {% set path = '/offices/' + office.slug + '/' %}
 {% set resource_title = "Student resources" %}
 {% set activity_type = "Students" %}
 
-{% set initiatives = queries.initiative.search_with_url_arguments(q="related_office:students-2") %}
+{% set initiatives = queries.initiative.search_with_url_arguments(filter_related_office="students-2") %}
 
 {% include "_offices-index.html" %}

--- a/the-bureau/bureau-structure/index.html
+++ b/the-bureau/bureau-structure/index.html
@@ -58,12 +58,12 @@
                         </button>
                     </li>
                 {% set parents = queries.orgmember.search_with_url_arguments(
-                   q="has_parent:false AND category:{}".format(category)) %}
+                   filter_has_parent='false', filter_category=category) %}
                 {% for parent in parents %}
                     {% set par_loop = loop %}
                     <li class="org-chart_node expandable">
                         {% set children = queries.orgmember.search_with_url_arguments(
-                           q="parent:{}".format(parent.id)) %}
+                           filter_parent=parent.id) %}
                     {% if children|list|length %}
                         <button class="org-chart_role expandable_target expandable_header content-show" 
                                 data-content=".nodes{{ cat_loop.index }}_{{ par_loop.index }}">

--- a/the-bureau/history/index.html
+++ b/the-bureau/history/index.html
@@ -29,7 +29,7 @@
         {{ share(self.title(), true) }}
     </div>
 
-	{% set sections = query.search_with_url_arguments(q="has_parent:false") -%}
+	{% set sections = query.search_with_url_arguments(filter_has_parent='false') -%}
 
 {% for section in sections %}
 
@@ -54,7 +54,7 @@
             <div class="expandable_content history-section-expandable_content">
                 <div class="history-timeline">
     {# Run a query for the first item in this section to get the starting year. #}
-    {% set first = query.search_with_url_arguments(q="parent:{}".format(section.id),
+    {% set first = query.search_with_url_arguments(filter_parent=section.id,
                                                    size=1) %}
     {# Using this history_vars dictionary instead of a simple variable lets us
        share the value between the different scopes created by the foor loops.
@@ -65,7 +65,7 @@
     {% endfor %}
                     <h2 class="history-year">{{ history_vars.current_year }}</h2>
                     <ol class="history-list">
-    {% set histories = query.search_with_url_arguments(q="parent:{}".format(section.id)) %}
+    {% set histories = query.search_with_url_arguments(filter_parent=section.id) %}
     {% for history in histories %}
         {% if history.date|date("%Y")|int < history_vars.current_year %}
             {% if history_vars.update({'current_year': history.date|date("%Y")|int}) %} {% endif %}


### PR DESCRIPTION
Previously, we were making heavy use of ElasticSearch queries (via q=) in our templates, but in 100% of these cases, we should have been using filters.  Queries, which are much slower, should generally only be used for text search.

Now that sheer allows you to use the same URL filter syntax within search_with_url_arguments() (https://github.com/cfpb/sheer/commit/9d1ad908d2bfcb1f62f8fef1438bf21f52972810), I've converted the existing instances of queries over to filters.

In order to use these types of filters, the field in question must be indexed as `not_analyzed` in ElasticSearch, so I had to declare that in a couple mapping files.

I've also updated documentation to reflect the change.