### PR TITLE
Fixes DF-1469/Event Detail Venue

### DIFF
--- a/_includes/event-post-macros.html
+++ b/_includes/event-post-macros.html
@@ -1,0 +1,246 @@
+
+
+{# ==========================================================================
+
+   calendar_icon()
+
+   ==========================================================================
+
+   Description:
+
+   Create an HTML calendar icon when given:
+
+   date:           A valid date.
+
+   additional_classes: Extra classes you wish to add to the icon, space
+                       separated.
+
+   ========================================================================== #}
+
+{% macro calendar_icon(calendar_date, additional_classes) %}
+    <time class="calendar-icon {{ additional_classes }}" data-month="{{ calendar_date | date('%b') }}" data-day="{{ calendar_date | date('%d') }}" datetime="{{ calendar_date }}">
+        <span class="u-visually-hidden">{{ calendar_date | date('%b %d, %Y') }}</span>
+    </time>
+{% endmacro %}
+
+
+
+{# ==========================================================================
+
+   event_location_image()
+
+   ==========================================================================
+
+   Description:
+
+   Create HTML image when given:
+
+   post: A post from a query result.
+
+   options (optional): An object to use for customizing a event location image using
+                       Google Maps.
+
+   options.class:    A class name to be applied to the img element.
+
+   options.location: A location as either a comma-separated {latitude,longitude} 
+                     pair (e.g. "40.714728,-73.998672") or a string address 
+                     (e.g. "city hall, new york, ny"). 
+
+   options.scale:    Affects the number of pixels that are returned.    
+                     Accepted values are 1, 2 and 4.    
+
+   options.size:     Defines the rectangular dimensions of the map image. 
+                     {horizontal_value}x{vertical_value} (e.g. 500x400)
+
+   options.zoom:     Determines the magnification level of the map. 
+
+      
+
+   ========================================================================== #}
+
+{% macro event_location_image(post, options) %}
+
+    {%- set location = (post.location or 'Washington DC') -%}
+    {%- set scale = ('&scale=' + (options.scale or '1')) -%}
+    {%- set size = ('&size=' + (options.size or '276x155')) -%}
+    {%- set zoom = ('&zoom=' + (options.zoom or '12')) -%}
+    {%- set url = 'https://maps.googleapis.com/maps/api/staticmap?center=' -%}
+    
+    <img class="{{ options.class }}" src="{{ url ~ location ~ size ~ zoom ~ scale }}" alt="Google Maps image of {{ location }}">
+{% endmacro %}
+
+
+  
+{# ==========================================================================
+
+   event_meta()
+
+   ==========================================================================
+
+   Description:
+
+   Create HTML event meta markup when given:
+
+   post: A post from a query result.
+
+   ========================================================================== #}
+
+{% macro event_meta(post) %}
+
+    {%- set city = (post.location or 'Washington DC') -%}    
+    {%- set state = (post.state or '') -%}
+    {%- set venue = (post.venue or 'CFPB') -%}
+    
+    <div class="event-meta h-event">
+        event_meta_datetime(post.date)
+    </div>
+{% endmacro %}
+
+
+
+{# ==========================================================================
+
+   event_meta_address()
+
+   ==========================================================================
+
+   Description:
+
+   Create HTML event meta date/time markup when given:
+
+   date: A post date from a query result.
+
+   ========================================================================== #}
+
+{% macro event_meta_address(date) %}
+    <p class="event-meta_address h-adr">
+        <span class="event-meta_city p-locality">{{ city }}</span>
+        <span class="event-meta_state p-region">{{ state }}</span>
+        <span class="event-meta_venue p-extended-address">{{ venue }}</span>
+    </p>
+{% endmacro %}
+
+
+
+{# ==========================================================================
+
+   event_meta_datetime()
+
+   ==========================================================================
+
+   Description:
+
+   Create HTML event meta date/time markup when given:
+
+   date: A post date from a query result.
+
+   ========================================================================== #}
+
+{% macro event_meta_datetime(date) %}
+    <time class="event-meta_datetime dt-start" datetime="{{ date | date('%Y-%m-%d %H:%M %p %Z') }}">
+      <span class="event-meta_date">{{ date | date('%b %m, %Y') }}</span>
+      <span class="event-meta_time">{{ date | date('%H:%M %p %Z') }}</span>
+    </time>
+{% endmacro %}
+
+
+
+{# ==========================================================================
+
+   post_summary()
+
+   ==========================================================================
+
+   Description:
+
+   Create an event post summary when given:
+
+   post: A post from a query result.
+
+   path: The path to which post filters are applied.
+
+   ========================================================================== #}
+
+
+{% macro post_summary(post, path) %}
+
+{%- import "tags.html" as tags %}
+    <a href="{{ post.permalink }}">
+        <header class="summary_header">
+            {{ calendar_icon(post.date) }}
+                <div class="summary-meta_container">
+                    <h1 class="summary_heading">{{ post.title|safe }}</h1>
+                    {{ event_meta(post) }}
+                </div>
+        </header>
+        <p class="summary_text">
+            {% if post.dek %}
+                {{ post.dek|striptags }}
+            {% else %}
+                {{ post.excerpt|striptags }}
+            {% endif %}
+        </p>
+    </a>
+    <footer>
+      {{ tags.render(post.tags, path) }}
+    </footer>
+{% endmacro %}
+
+
+
+{# ==========================================================================
+
+   event_venue()
+
+   ==========================================================================
+
+   Description:
+
+   Create an event post venue when given:
+
+   post: A post from a query result.
+
+   path: The path to which post filters are applies.
+
+   ========================================================================== #}
+
+
+{% macro event_venue(post) %}
+    {%- set city =  (post.location or 'Washington, DC') -%}    
+    {%- set street = (post.street or '1275 First St NE') -%}
+    {%- set venue = (post.venue or 'CFPB') -%}
+    {%- set zip = (post.zip_code or '20002') -%}
+
+    <section class="event-venue">
+        <header class="event-venue_header">
+            <h2 class="event-venue_heading">{{ city }}</h2>
+            <div class="content-l">
+                <div class="event-meta content-l_col content-l_col-1-2">
+                    <p class="event-meta_address h-adr">
+                      <span class="event-meta_venue p-extended-address">{{ venue }}</span>
+                      <span class="event-meta_street p-street-address">{{ street }}</span>
+                      <span class="event-meta_city p-locality">{{ city }}</span>
+                      <span class="event-meta_zip p-postal-code">{{ zip }}</span>
+                    </p>
+                </div>
+                <div class="content-l_col content-l_col-1-2 event-calendar_container">
+                      {{ event_meta_datetime(post.date) }}
+                      <a class="event-calendar_download jump-link jump-link__download" href="#">
+                          <span class="jump_link_text">Download .ics</span>
+                      </a>
+                </div>
+          </div>
+        </header>
+        <footer>
+            <figure class="event-media_container">
+                {{ event_location_image(post, {
+                    'zoom': '12',
+                    'scale': '2',
+                    'size': '640x320'
+                }) }}
+            </figure>
+        </footer>
+    </section>
+{% endmacro %}
+
+

--- a/_includes/events-posts.html
+++ b/_includes/events-posts.html
@@ -1,0 +1,22 @@
+
+{% macro render(posts) %}
+
+{% import "event-post-macros.html" as event_post_macros with context %}
+
+{% for post in posts%}
+
+    <article class="post-preview event-post-preview">
+        <div class="media-object" >
+            <a class="media-object_image-container" href="{{ post.permalink }}">
+                {{ event_post_macros.event_location_image(post, {'class': 'media-object_image'}) }}
+            </a>
+            <div class="media-object_text-container summary">
+                {{ event_post_macros.post_summary(post) }}
+            </div>
+        </div>    
+    </article>
+
+{% endfor %}  
+
+
+{% endmacro %}

--- a/events/_event.html
+++ b/events/_event.html
@@ -53,6 +53,8 @@
              src="{{ post.thumbnail.images.full.url }}"
              alt="{{ post.thumbnail.alt_text }}">
     {% endif %}
+    {% from "event-post-macros.html" import event_venue as event_venue %}
+    {{ event_venue(post) }}
     </header>
     <div class="post_body">
         <aside class="post_inset post_inset__right line-container event-status">

--- a/static/css/event-meta.less
+++ b/static/css/event-meta.less
@@ -58,9 +58,9 @@
 
     // Adding em dash after address
     &:before{
-      content: "\2014";
-      margin-right: .2em;
-  }
+        content: "\2014";
+        margin-right: .2em;
+    }
 }
 
 // Adding comma after city
@@ -77,6 +77,133 @@
     content: "\40";
     margin-right: .2em;
 }
+
+/* topdoc
+  name: Event Detail Venue
+  family: cfgov-event-meta
+  patterns:
+    - name: Event Detail Venue
+      markup: |
+        <section class="event-venue">
+          <header class="event-venue_header">
+            <h2 class="event-venue_heading">Washington, DC</h2>
+            <div class="content-l">
+              <div class="event-meta content-l_col content-l_col-1-2">
+                <p class="event-meta_address h-adr">
+                  <span class="event-meta_venue p-extended-address">Verizon Center</span>
+                  <span class="event-meta_street p-street-address">1275 First St NE</span>
+                  <span class="event-meta_city p-locality">Washington, DC</span>
+                  <span class="event-meta_zip p-postal-code">20002</span>
+                </p>
+              </div>
+              <div class="content-l_col content-l_col-1-2 event-calendar_container">
+                <time class="event-meta_datetime dt-start" datetime="2014-01-21 2:30 PM CST">
+                  <span class="event-meta_date">April 12, 2014</span>
+                  <span class="event-meta_time">2:30 PM CST</span>
+                </time>
+                <a class="event-calendar_download jump-link jump-link__download" href="#">
+                  <span class="jump_link_text">Download .ics</span>
+                </a>
+              </div>
+            </div>
+          </header>
+          <footer>
+            <figure class="event-media_container">
+                <img src="https://maps.googleapis.com/maps/api/staticmap?center=Washington,DC&zoom=12&scale=2&size=640x320" alt="Google image of Washington, DC">
+            </figure>
+          </footer>
+        </section>
+
+      codenotes:
+        - |
+          Structural cheat sheet:
+          -----------------------
+          section.event-venue
+            header.event-venue_header
+              h2.event-venue_heading
+              div.content-l
+                div.content-l.content-l_col-1-2
+                  p.event-meta_address.h-adr
+                    span.event-meta_venue.p-extended-address
+                    span.event-meta_street.p-street-address
+                    span.event-meta_city.p-locality
+                    span.event-meta_zip.p-postal-code
+                div.content-l.content-l_col-1-2.event-calendar_container
+                  time.event-meta_datetime.dt-start
+                    span.event-meta_date
+                    span.event-meta_time
+                  a.event-calendar_download.jump-link.jump-link__download
+                    span.icon-link_text
+            footer
+              figure.event-media_container
+                img        
+  tags:
+    - cfgov-event-meta
+*/
+
+.event-venue {
+    background: @gray-10;
+    border-top: 5px solid @green;
+    
+    .event-media_container  {
+        max-height:  400px;
+        overflow: hidden;
+    }
+}
+
+.event-venue_header {
+    padding: 1.5em 1.5em .5em;
+    .webfont-regular();
+
+    .respond-to-max(@mobile-max {
+        padding: 1.5em;
+    });
+
+    .event-calendar_container {
+        .h5();
+        text-transform: uppercase;
+    }
+
+    .event-calendar_download {
+        display: block;
+        font-weight: bold;
+        padding-top: .2em;
+        text-decoration: none;
+        text-transform: none;
+
+        .respond-to-max(@mobile-max {
+            margin-top: 1em;
+            padding-top: .5em;
+        });
+    }
+
+    .event-meta {
+        .webfont-regular();
+     }
+
+    .event-meta_address {
+        &:before {
+            content : none;
+        }
+
+        .respond-to-max(@mobile-max {
+            margin: 0;
+        });
+    }
+
+    .event-meta_city:after {
+        content : none;
+    }
+
+    .event-meta_venue {
+        display: block;
+    }
+}
+
+.event-venue_heading {
+    display: inline-block;
+}
+
 
 /* topdoc
   name: EOF


### PR DESCRIPTION

Display the Event Detail Venue 

## Changes

- Updates 'meta.less' file to include patterns for displaying the venue.
- Updates '_events.html" file to display the venue and map.
- Updates 'events-posts" file to display the venue and map.
- Updates 'event-post-macros" file to display the venue and map.

## Review

- @jimmynotjim 
- @anselmbradford 


et al

## Preview

![event-venue](https://cloud.githubusercontent.com/assets/1696212/6373437/a9d49822-bcd8-11e4-82c9-21a118dae76f.png)
