### PR TITLE
Switch from terms facet to aggregations

### DIFF
--- a/_includes/email-subscribe-form.html
+++ b/_includes/email-subscribe-form.html
@@ -19,7 +19,7 @@
     </div>
     {% if query -%}
     <div class="form-group reveal-on-focus_content u-clearfix">
-    {% for category in query.possible_values_for('category')|sort(attribute='term') -%}
+    {% for category in query.possible_values_for('category')|sort(attribute='key') -%}
     {% set govdelivery_categories = [
         { 'name': 'Announcements & updates', 'code': 'USCFPB_9' },
         { 'name': 'Consumer information', 'code': 'USCFPB_10' },
@@ -32,13 +32,13 @@
         { 'name': 'Testimony', 'code': 'USCFPB_17' }
     ] %}
     {% for allowed_category in govdelivery_categories -%}
-    {% if category.term == allowed_category.name %}
+    {% if category.key == allowed_category.name %}
         <label class="form-group_item">
             <input class="custom-input"
                    type="checkbox"
                    name="code"
                    value="{{ allowed_category.code }}">
-            {{ category.term }}
+            {{ category.key }}
         </label>
     {% endif %}
     {% endfor %}

--- a/_includes/post-macros.html
+++ b/_includes/post-macros.html
@@ -548,13 +548,13 @@
                     Categories
                 </label>
             {% if doc_type == 'newsroom' -%}
-                {% set categories = query.possible_values_for('category', doc_type='newsroom')|sort(attribute='term') %}
+                {% set categories = query.possible_values_for('category', doc_type='newsroom')|sort(attribute='key') %}
             {%- else -%}
-                {% set categories = query.possible_values_for('category')|sort(attribute='term') %}
+                {% set categories = query.possible_values_for('category')|sort(attribute='key') %}
             {% endif -%}
             {% for category in categories -%}
                 <label class="form-group_item">
-                    {{ filter_checkbox('category', category.term)|safe }}
+                    {{ filter_checkbox('category', category.key)|safe }}
                 </label>
             {% endfor %}
             {% if doc_type == 'newsroom' -%}
@@ -572,25 +572,25 @@
                 <label class="form-label-header">
                     Category type
                 </label>
-            {% set categories = query.possible_values_for('type')|sort(attribute='term') -%}
+            {% set categories = query.possible_values_for('type')|sort(attribute='key') -%}
             {% for category in categories -%}
-                {% if category.term != 'cfpb_newsroom' %}
-                    {% if category.term == 'post' %}
+                {% if category.key != 'cfpb_newsroom' %}
+                    {% if category.key == 'post' %}
                         <label class="form-group_item">
-                            {{ filter_checkbox('type', category.term, 'Blog')|safe }}
+                            {{ filter_checkbox('type', category.key, 'Blog')|safe }}
                         </label>
                     {% else %}
                         <label class="form-group_item">
-                            {{ filter_checkbox('type', category.term)|safe }}
+                            {{ filter_checkbox('type', category.key)|safe }}
                         </label>
                     {% endif %}
                 {% endif %}
             {% endfor %}
             {% set newsroom_categories =
-               query.possible_values_for('category', doc_type='newsroom')|sort(attribute='term') %}
+               query.possible_values_for('category', doc_type='newsroom')|sort(attribute='key') %}
             {% for category in newsroom_categories -%}
                 <label class="form-group_item">
-                    {{ filter_checkbox('category', category.term)|safe }}
+                    {{ filter_checkbox('category', category.key)|safe }}
                 </label>
             {% endfor %}
             </div>
@@ -638,14 +638,14 @@
             {# Top 3 tags come first #}
             {%- for tags in possible_tags -%}
                 {%- if loop.index < 4 -%}
-                    {{ filter_option('tags', tags.term)|safe }}
+                    {{ filter_option('tags', tags.key)|safe }}
                 {%- endif -%}
             {%- endfor -%}
                 </optgroup>
                 <optgroup label="All other topics">
             {# Then the rest of the tags #}
-            {%- for tags in possible_tags[3:]|sort(attribute='term') -%}
-                    {{ filter_option('tags', tags.term)|safe }}
+            {%- for tags in possible_tags[3:]|sort(attribute='key') -%}
+                    {{ filter_option('tags', tags.key)|safe }}
             {%- endfor -%}
                 </optgroup>
             </select>
@@ -663,12 +663,12 @@
                     multiple
                     data-placeholder="Search for authors">
             {% if doc_type == 'newsroom' -%}
-                {% set authors = query.possible_values_for('author', doc_type='newsroom')|sort(attribute='term') %}
+                {% set authors = query.possible_values_for('author', doc_type='newsroom')|sort(attribute='key') %}
             {%- else -%}
-                {% set authors = query.possible_values_for('author')|sort(attribute='term') %}
+                {% set authors = query.possible_values_for('author')|sort(attribute='key') %}
             {% endif -%}
             {% for author in authors %}
-                {{ filter_option('author', author.term)|safe }}
+                {{ filter_option('author', author.key)|safe }}
             {% endfor %}
             </select>
         </div>


### PR DESCRIPTION
NOTE: There is a complementary sheer PR that should be merged at the same time as this one: https://github.com/cfpb/sheer/pull/88

Facets are deprecated in ElasticSearch and will be removed in a future release. This migrates them to aggregations which work pretty much the same way as facets.

This PR essentially makes the change from {"term": "term-you-want"} to {"key": "term-you-want"} to reflect the minor difference between the ElasticSearch results for facets and aggregations.