### PR TITLE
283-readme-add-subtasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,17 @@ open a terminal and run:
 $ grunt watch
 ```
 
+*Alternatively, if you don't want to run the full watch task, there are two available
+sub-tasks:*
+
+``` bash
+# Watch & compile CSS only
+$ grunt watch:css
+
+# Watch & compile CSS & JS only
+$ grunt watch:cssjs
+```
+
 ## How to test the software
 
 To run browser tests, you'll need to perform the following steps:


### PR DESCRIPTION
Include available grunt sub-tasks in readme for easier discovery

## Additions

- Added `grunt watch` sub-tasks to readme

## Removals

- None

## Changes

- None

## Testing

- None

## Review

- @Scotchester 
- @anselmbradford 
- @sebworks 

## Preview

None

## Notes

- `:css` and `:cssjs` sub-tasks are much faster and make working locally easier
- Fixes 283