### PR TITLE
Fixes DF-1498 - fixes typo in footer

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,249 +1,249 @@
-    <footer class="footer" role="contentinfo">
-        <aside class="wrapper wrapper__match-content">
+<footer class="footer" role="contentinfo">
+    <aside class="wrapper wrapper__match-content">
 
-            <div class="footer-pre">
+        <div class="footer-pre">
 
-                <ul class="footer_share-icon-list">
-                    <li class="list_item">
-                        <a class="share-icon share-icon__large"
-                           href="https://facebook.com/cfpb">
-                            <span class="cf-icon cf-icon-facebook-square"></span>
-                            <span class="u-visually-hidden">Visit us on Facebook</span>
-                        </a>
-                    </li>
-                    <li class="list_item">
-                        <a class="share-icon share-icon__large"
-                           href="https://twitter.com/cfpb">
-                            <span class="cf-icon cf-icon-twitter-square"></span>
-                            <span class="u-visually-hidden">Visit us on Twitter</span>
-                        </a>
-                    </li>
-                    <li class="list_item">
-                        <a class="share-icon share-icon__large"
-                           href="https://www.linkedin.com/company/consumer-financial-protection-bureau">
-                            <span class="cf-icon cf-icon-linkedin-square"></span>
-                            <span class="u-visually-hidden">Visit us on Linkedin</span>
-                        </a>
-                    </li>
-                    <li class="list_item">
-                        <a class="share-icon share-icon__large"
-                           href="https://www.youtube.com/user/cfpbvideo">
-                            <span class="cf-icon cf-icon-youtube-square"></span>
-                            <span class="u-visually-hidden">Visit us on YouTube</span>
-                        </a>
-                    </li>
-                    <li class="list_item">
-                        <a class="share-icon share-icon__large"
-                           href="https://www.flickr.com/photos/cfpbphotos">
-                            <span class="cf-icon cf-icon-flickr-square"></span>
-                            <span class="u-visually-hidden">Visit us on Flickr</span>
-                        </a>
-                    </li>
-                </ul>
-                <ul class="footer_nav-list">
-                    <li class="list_item">
-                        <a class="list_link" href="/contact-us/">
-                            Contact us
-                        </a>
-                    </li>
-                    <li class="list_item">
-                        <a class="list_link" href="/newsroom/">
-                            Newsroom
-                        </a>
-                    </li>
-                    <li class="list_item">
-                        <a class="list_link list_link__disabled">
-                            Careers
-                        </a>
-                    </li>
-                    <li class="list_item">
-                        <a class="list_link list_link__disabled">
-                            Español
-                        </a>
-                    </li>
-                </ul>
+            <ul class="footer_share-icon-list">
+                <li class="list_item">
+                    <a class="share-icon share-icon__large"
+                       href="https://facebook.com/cfpb">
+                        <span class="cf-icon cf-icon-facebook-square"></span>
+                        <span class="u-visually-hidden">Visit us on Facebook</span>
+                    </a>
+                </li>
+                <li class="list_item">
+                    <a class="share-icon share-icon__large"
+                       href="https://twitter.com/cfpb">
+                        <span class="cf-icon cf-icon-twitter-square"></span>
+                        <span class="u-visually-hidden">Visit us on Twitter</span>
+                    </a>
+                </li>
+                <li class="list_item">
+                    <a class="share-icon share-icon__large"
+                       href="https://www.linkedin.com/company/consumer-financial-protection-bureau">
+                        <span class="cf-icon cf-icon-linkedin-square"></span>
+                        <span class="u-visually-hidden">Visit us on Linkedin</span>
+                    </a>
+                </li>
+                <li class="list_item">
+                    <a class="share-icon share-icon__large"
+                       href="https://www.youtube.com/user/cfpbvideo">
+                        <span class="cf-icon cf-icon-youtube-square"></span>
+                        <span class="u-visually-hidden">Visit us on YouTube</span>
+                    </a>
+                </li>
+                <li class="list_item">
+                    <a class="share-icon share-icon__large"
+                       href="https://www.flickr.com/photos/cfpbphotos">
+                        <span class="cf-icon cf-icon-flickr-square"></span>
+                        <span class="u-visually-hidden">Visit us on Flickr</span>
+                    </a>
+                </li>
+            </ul>
+            <ul class="footer_nav-list">
+                <li class="list_item">
+                    <a class="list_link" href="/contact-us/">
+                        Contact us
+                    </a>
+                </li>
+                <li class="list_item">
+                    <a class="list_link" href="/newsroom/">
+                        Newsroom
+                    </a>
+                </li>
+                <li class="list_item">
+                    <a class="list_link list_link__disabled">
+                        Careers
+                    </a>
+                </li>
+                <li class="list_item">
+                    <a class="list_link list_link__disabled">
+                        Español
+                    </a>
+                </li>
+            </ul>
 
-            </div><!-- END .footer-pre -->
+        </div><!-- END .footer-pre -->
 
-            <div class="footer-left-right footer_nested-col-group">
+        <div class="footer-left-right footer_nested-col-group">
 
-                <div class="footer-right">
-                    <div class="footer_nested-col-group">
-                        <div class="footer_col">
-                            <h2 class="h6">
-                                Researchers
-                            </h2>
-                            <ul class="footer_list">
-                                <li class="list_item">
-                                    <a class="list_link list_link__disabled">
-                                        Datasets
-                                    </a>
-                                </li>
-                                <li class="list_item">
-                                    <a class="list_link list_link__disabled">
-                                        Reports
-                                    </a>
-                                </li>
-                            </ul>
-                        </div>
-                        <div class="footer_col">
-                            <h2 class="h6">
-                                Developers
-                            </h2>
-                            <ul class="footer_list">
-                                <li class="list_item">
-                                    <a class="list_link list_link__disabled">
-                                        APIs
-                                    </a>
-                                </li>
-                                <li class="list_item">
-                                    <a class="list_link list_link__disabled">
-                                        Open source projects
-                                    </a>
-                                </li>
-                            </ul>
-                        </div>
-                        <div class="footer_col">
-                            <h2 class="h6">
-                                Educators
-                            </h2>
-                            <ul class="footer_list">
-                                <li class="list_item">
-                                    <a class="list_link list_link__disabled">
-                                        Toolkits
-                                    </a>
-                                </li>
-                                <li class="list_item">
-                                    <a class="list_link list_link__disabled">
-                                        Online learning
-                                    </a>
-                                </li>
-                                <li class="list_item">
-                                    <a class="list_link list_link__disabled">
-                                        Brochures
-                                    </a>
-                                </li>
-                            </ul>
-                        </div>
-                        <div class="footer_col">
-                            <h2 class="h6">
-                                Regulated entities
-                            </h2>
-                            <ul class="footer_list">
-                                <li class="list_item">
-                                    <a class="list_link list_link__disabled">
-                                        Regulations
-                                    </a>
-                                </li>
-                                <li class="list_item">
-                                    <a class="list_link list_link__disabled">
-                                        Notice and comment
-                                    </a>
-                                </li>
-                                <li class="list_item">
-                                    <a class="list_link list_link__disabled">
-                                        Compliance guides
-                                    </a>
-                                </li>
-                            </ul>
-                        </div>
+            <div class="footer-right">
+                <div class="footer_nested-col-group">
+                    <div class="footer_col">
+                        <h2 class="h6">
+                            Researchers
+                        </h2>
+                        <ul class="footer_list">
+                            <li class="list_item">
+                                <a class="list_link list_link__disabled">
+                                    Datasets
+                                </a>
+                            </li>
+                            <li class="list_item">
+                                <a class="list_link list_link__disabled">
+                                    Reports
+                                </a>
+                            </li>
+                        </ul>
+                    </div>
+                    <div class="footer_col">
+                        <h2 class="h6">
+                            Developers
+                        </h2>
+                        <ul class="footer_list">
+                            <li class="list_item">
+                                <a class="list_link list_link__disabled">
+                                    APIs
+                                </a>
+                            </li>
+                            <li class="list_item">
+                                <a class="list_link list_link__disabled">
+                                    Open source projects
+                                </a>
+                            </li>
+                        </ul>
+                    </div>
+                    <div class="footer_col">
+                        <h2 class="h6">
+                            Educators
+                        </h2>
+                        <ul class="footer_list">
+                            <li class="list_item">
+                                <a class="list_link list_link__disabled">
+                                    Toolkits
+                                </a>
+                            </li>
+                            <li class="list_item">
+                                <a class="list_link list_link__disabled">
+                                    Online learning
+                                </a>
+                            </li>
+                            <li class="list_item">
+                                <a class="list_link list_link__disabled">
+                                    Brochures
+                                </a>
+                            </li>
+                        </ul>
+                    </div>
+                    <div class="footer_col">
+                        <h2 class="h6">
+                            Regulated entities
+                        </h2>
+                        <ul class="footer_list">
+                            <li class="list_item">
+                                <a class="list_link list_link__disabled">
+                                    Regulations
+                                </a>
+                            </li>
+                            <li class="list_item">
+                                <a class="list_link list_link__disabled">
+                                    Notice and comment
+                                </a>
+                            </li>
+                            <li class="list_item">
+                                <a class="list_link list_link__disabled">
+                                    Compliance guides
+                                </a>
+                            </li>
+                        </ul>
+                    </div>
 
-                    </div><!-- END .footer_nested-col-group -->
-                </div><!-- END .footer-right -->
+                </div><!-- END .footer_nested-col-group -->
+            </div><!-- END .footer-right -->
 
-                <div class="footer-left">
-                    <div class="footer_nested-col-group">
+            <div class="footer-left">
+                <div class="footer_nested-col-group">
 
-                        <div class="footer_logo">
-                            <img class="logo u-js-only"
-                                 src="/static/img/logo_sm-exec.svg"
-                                 onerror="this.onerror=null;this.src='/static/img/logo_sm-exec.png';"
+                    <div class="footer_logo">
+                        <img class="logo u-js-only"
+                             src="/static/img/logo_sm-exec.svg"
+                             onerror="this.onerror=null;this.src='/static/img/logo_sm-exec.png';"
+                             alt="Consumer Financial Protection Bureau"
+                             width="237"
+                             height="50">
+                        <noscript>
+                            <img class="logo logo__no-js"
+                                 src="/static/img/logo_sm-exec.png"
                                  alt="Consumer Financial Protection Bureau"
                                  width="237"
                                  height="50">
-                            <noscript>
-                                <img class="logo logo__no-js"
-                                     src="/static/img/logo_sm-exec.png"
-                                     alt="Consumer Financial Protection Bureau"
-                                     width="237"
-                                     height="50">
-                            </noscript>
-                        </div>
-                        <p class="footer_address">
-                            <span class="footer_address-word-break">
-                                Consumer Financial
-                            </span>
-                            Protection Bureau<br>
-                            1700 G Street, NW<br>
-                            Washington, D.C. 20552
-                        </p>
-                        <div class="footer_general-inqueries">
-                            <b class="footer_general-inqueries-label">For general inquiries only</b>
-                            <ul class="list list__links">
-                                <li class="list_item">
-                                    <a class="list_link footer_general-inqueries-phone" href="tel:202-435-7000">
-                                        (202) 435-7000
-                                    </a>
-                                </li>
-                                <li class="list_item">
-                                    <a class="list_link" href="mailto:info@consumerfinance.gov">
-                                        info@consumerfinance.gov
-                                    </a>
-                                </li>
-                            </ul>
-                        </div>
+                        </noscript>
+                    </div>
+                    <p class="footer_address">
+                        <span class="footer_address-word-break">
+                            Consumer Financial
+                        </span>
+                        Protection Bureau<br>
+                        1700 G Street, NW<br>
+                        Washington, D.C. 20552
+                    </p>
+                    <div class="footer_general-inqueries">
+                        <b class="footer_general-inqueries-label">For general inquiries only</b>
+                        <ul class="list list__links">
+                            <li class="list_item">
+                                <a class="list_link footer_general-inqueries-phone" href="tel:202-435-7000">
+                                    (202) 435-7000
+                                </a>
+                            </li>
+                            <li class="list_item">
+                                <a class="list_link" href="mailto:info@consumerfinance.gov">
+                                    info@consumerfinance.gov
+                                </a>
+                            </li>
+                        </ul>
+                    </div>
 
-                    </div><!-- END .footer_nested-col-group -->
-                </div><!-- END .footer-left -->
-                
-            </div><!-- END .footer_nested-col-group -->
+                </div><!-- END .footer_nested-col-group -->
+            </div><!-- END .footer-left -->
 
-            <div class="footer-post">
+        </div><!-- END .footer_nested-col-group -->
 
-                <ul class="footer_long-list">
-                    <li class="list_item">
-                        <a class="list_link list_link__disabled">
-                            Privacy policy & legal notices
-                        </a>
-                    </li>
-                    <li class="list_item">
-                        <a class="list_link list_link__disabled">
-                            Accessiblity
-                        </a>
-                    </li>
-                    <li class="list_item">
-                        <a class="list_link list_link__disabled">
-                            Plain writing
-                        </a>
-                    </li>
-                    <li class="list_item">
-                        <a class="list_link list_link__disabled">
-                            No FEAR Act
-                        </a>
-                    </li>
-                    <li class="list_item">
-                        <a class="list_link list_link__disabled">
-                            FOIA
-                        </a>
-                    </li>
-                    <li class="list_item">
-                        <a class="list_link" href="http://usa.gov/">
-                            USA.gov
-                        </a>
-                    </li>
-                    <li class="list_item">
-                        <a class="list_link" href="http://www.federalreserve.gov/oig/default.htm">
-                            Office of Inspector General
-                        </a>
-                    </li>
-                    <li class="list_item">
-                        <a class="list_link list_link__disabled">
-                            Ombudsman
-                        </a>
-                    </li>
-                </ul>
+        <div class="footer-post">
 
-            </div><!-- END .footer-post -->
-            
-        </aside><!-- END .wrapper.wrapper__match-content -->
-    </footer><!-- END .footer -->
+            <ul class="footer_long-list">
+                <li class="list_item">
+                    <a class="list_link list_link__disabled">
+                        Privacy policy & legal notices
+                    </a>
+                </li>
+                <li class="list_item">
+                    <a class="list_link list_link__disabled">
+                        Accessibility
+                    </a>
+                </li>
+                <li class="list_item">
+                    <a class="list_link list_link__disabled">
+                        Plain writing
+                    </a>
+                </li>
+                <li class="list_item">
+                    <a class="list_link list_link__disabled">
+                        No FEAR Act
+                    </a>
+                </li>
+                <li class="list_item">
+                    <a class="list_link list_link__disabled">
+                        FOIA
+                    </a>
+                </li>
+                <li class="list_item">
+                    <a class="list_link" href="http://usa.gov/">
+                        USA.gov
+                    </a>
+                </li>
+                <li class="list_item">
+                    <a class="list_link" href="http://www.federalreserve.gov/oig/default.htm">
+                        Office of Inspector General
+                    </a>
+                </li>
+                <li class="list_item">
+                    <a class="list_link list_link__disabled">
+                        Ombudsman
+                    </a>
+                </li>
+            </ul>
+
+        </div><!-- END .footer-post -->
+
+    </aside><!-- END .wrapper.wrapper__match-content -->
+</footer><!-- END .footer -->


### PR DESCRIPTION
Fixes typo in global footer and removes excess whitespace.

## Changes

- Fixes DF-1498 - fixes typo in footer, "Accessiblity."
- Removes excess whitespace.
- Moves entire code block 4-spaces to the left.

## Testing

- Visit the homepage and view in the footer the corrected text "Accessibility."

## Review

- @sebworks 
- @jimmynotjim 

## Preview

![screen shot 2015-03-02 at 9 51 03 am](https://cloud.githubusercontent.com/assets/704760/6442955/a7f056da-c0c1-11e4-82a9-c1780441dddb.png)

## Notes

- The entire code block had an extra indent level. I removed this, but let me know if you can think of a reason why an include might need the entire file to be indented one level (such as to nest properly in the context where it's included?)
