### PR TITLE
Fixes DF-1501 - adds footer link

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -241,6 +241,15 @@
                         Ombudsman
                     </a>
                 </li>
+                <li class="list_item">
+                    <!-- TODO Add href for link to
+                    http://www.consumerfinance.gov/open/
+                    when that address is finalized.
+                    -->
+                    <a class="list_link list_link__disabled">
+                        Open Government
+                    </a>
+                </li>
             </ul>
 
         </div><!-- END .footer-post -->


### PR DESCRIPTION
Adds Open Government link to the footer.

## Additions

- Fixes DF-1501 - adds footer link for “Open Government.”

## Testing

- Visit homepage and note disabled "Open Government" link in the footer after "Ombudsman."

## Review

- @sebworks 
- @jimmynotjim 
- @schaferjh 

## Preview

![screen shot 2015-03-02 at 10 07 15 am](https://cloud.githubusercontent.com/assets/704760/6443294/eaa18c86-c0c3-11e4-93be-7e112cfbfc96.png)

## Notes

- For now the link is disabled, but the expected URL is provided in a code comment above.
- The "Open Government" link doesn't fit on the same line as everything else on desktop sizes, so creates a new line in the footer, which isn't aesthetically the best.