### PR TITLE
Improve contact processor

### DIFF
--- a/_lib/wordpress_contact_processor.py
+++ b/_lib/wordpress_contact_processor.py
@@ -29,8 +29,9 @@ def documents(name, url, **kwargs):
         yield process_contact(post)
 
 def convert_custom_field(post_type, attribute, index=0, new_attribute=None):
-    
-    if attribute in post_type['custom_fields']:
+    # Check to make sure the index is in range for the list
+    if attribute in post_type['custom_fields'] and \
+        len(post_type['custom_fields'][attribute]) >= (index + 1):
         if new_attribute is None:
             post_type[attribute] = post_type['custom_fields'][attribute][index]
         else:


### PR DESCRIPTION
Before, the processor was grabbing an index location of a list whether or not there exists anything at that location.  As a result, indexing items without all the required custom fields was failing.  This will make sure the index location is there before attempting to grab the value out of it.