### PR TITLE
Fixes 275-hides, not removes, header.

### DIFF
--- a/_includes/article.html
+++ b/_includes/article.html
@@ -59,7 +59,7 @@
                 {{ post.date|date("%b %d, %Y") }}
             </span>
         </div>
-        {{ share(post.title, false, {
+        {{ share(post.title, true, {
            'text':     post.twtr_text,
            'related':  post.twtr_rel,
            'language': post.twtr_lang,

--- a/_includes/macros.html
+++ b/_includes/macros.html
@@ -66,7 +66,7 @@
    title:                      The title of the thing to share. Used by the
                                'share via email'.
 
-   show_header (optional):     Toggles the heading. Defaults to false.
+   hide_heading (optional):    Toggles the heading. Defaults to true.
 
    twitter_options (optional): See `options` under the `share_twitter_url()`
                                macro.
@@ -80,11 +80,9 @@
 
    ========================================================================== #}
 
-{% macro share(title, show_header=false, twitter_options={}) %}
+{% macro share(title, hide_heading=true, twitter_options={}) %}
     <aside>
-    {% if show_header %}
-        <h1 class="h5">Share this page</h1>
-    {% endif %}
+        <h1 class="h5 {{'u-visually-hidden' if hide_heading}}">Share this page</h1>
         <ul class="post_share list__horizontal">
             <li class="list_item">
                 <a class="share-icon"

--- a/events/_event.html
+++ b/events/_event.html
@@ -43,7 +43,7 @@
                 {{ update_date[1:] if update_date[0] == '0' else update_date }}
             </time>
         </div>
-        {{ share(post.title, false, {
+        {{ share(post.title, true, {
            'text':     post.twtr_text,
            'related':  post.twtr_rel,
            'language': post.twtr_lang,


### PR DESCRIPTION
Makes it so heading content in sharing macro is hidden, not removed, so that it still shows up in the document outline when hidden.

## Changes

- Fixes #275 - hides, not removes, header in sharing macro.

## Testing

- Visit http://localhost:7000/events/spring-2014-rulemaking-agenda/ and note that sharing heading "SHARE THIS PAGE" does not show up. View page source and notice `<h1 class="h5 u-visually-hidden">Share this page</h1>` exists. Change `false` parameter to `true` in https://github.com/cfpb/cfgov-refresh/blob/gh-pages/events/_event.html#L45 and reload the page and note that the heading "SHARE THIS PAGE" does show up.

## Review

- @sebworks 
- @jimmynotjim

## Preview

Sharing macro looks like:
![screen shot 2015-03-06 at 11 45 48 am](https://cloud.githubusercontent.com/assets/704760/6529388/59d9cb60-c3f6-11e4-9013-451c5b622177.png)