### PR TITLE
Df 1505 archive events detail

### DIFF
--- a/_settings/lookups.json
+++ b/_settings/lookups.json
@@ -28,5 +28,10 @@
     "url":       "/events/<id>/",
     "type":      "posts",
     "permalink": true
+  },
+  "event_archive": {
+    "url":       "/events/archive/<id>/",
+    "type":      "posts",
+    "permalink": true
   }
 }

--- a/events/_event-post-macros.html
+++ b/events/_event-post-macros.html
@@ -277,6 +277,7 @@
         <footer>
             <figure class="event-media_container">
                 {% if (request.url_rule.endpoint == 'event_archive') %}
+                    {# TODO Replace image URL with actual post url #}
                     <img src="http://upload.wikimedia.org/wikipedia/commons/9/94/Large.mc.arp.750pix.jpg" />
                 {% else %}
                     {{ event_location_image(post, {

--- a/events/_event-post-macros.html
+++ b/events/_event-post-macros.html
@@ -252,6 +252,7 @@
 {% macro event_venue(post) %} 
     {%- set city =  post.city  | default('Washington, DC') -%}
     
+
     <section class="event-venue">
         <header class="event-venue_header">
             <h2 class="event-venue_heading">{{ city }}</h2>
@@ -262,20 +263,28 @@
                     ) }}
                 </div>
                 <div class="content-l_col content-l_col-1-2 event-calendar_container">
+                    {% if (request.url_rule.endpoint == 'event_archive') %}
+                        Video Replay will be<br> available shortly
+                    {% else %}
                         {{ event_meta_datetime(post.date) }}
                         <a class="event-calendar_download jump-link jump-link__download" href="#">
                             <span class="jump_link_text">Download .ics</span>
                         </a>
+                    {% endif %}
                 </div>
           </div>
         </header>
         <footer>
             <figure class="event-media_container">
-                {{ event_location_image(post, {
-                    'zoom': '12',
-                    'scale': '2',
-                    'size': '640x320'
-                }) }}
+                {% if (request.url_rule.endpoint == 'event_archive') %}
+                    <img src="http://upload.wikimedia.org/wikipedia/commons/9/94/Large.mc.arp.750pix.jpg" />
+                {% else %}
+                    {{ event_location_image(post, {
+                        'zoom': '12',
+                        'scale': '2',
+                        'size': '640x320'
+                    }) }}
+                {% endif %}
             </figure>
         </footer>
     </section>

--- a/events/_event.html
+++ b/events/_event.html
@@ -58,31 +58,33 @@
     {{ event_venue(post) }}
     </header>
     <div class="post_body">
-        <aside class="post_inset post_inset__right line-container event-status">
-            <div class="line-container_body">
-                <h1 class="u-visually-hidden">Event reservation and viewing details</h1>
-                <p>
-                    <strong>This event requires an RSVP.</strong>
-                </p>
-                <p>
-                    <a href="mailto:reserve@cfpb.gov?subject=Event RSVP&body=To RSVP, please fill in your first and last name below and send this email.%0D%0A%0D%0AFirst name:%0D%0ALast name:" class="btn"><span class="btn_icon__left cf-icon cf-icon-email-social"></span> reserve@cfpb.gov</a>
-                </p>
-                <p>
-                    {# TODO Change to livestream icon when that's added to cf-icons. #}
-                    <span class="cf-icon cf-icon-wifi"></span>
-                    <strong>Available on Live stream.</strong>
-                </p>
-                <p class="event-meta">
-                    <span class="event-meta_description event-meta_description__block">
-                        Video link available :
-                    </span>
-                    <time class="event-meta_datetime dt-start" datetime="2014-01-21 2:30 PM CST">
-                        <span class="event-meta_date">1/21/2014</span>
-                        <span class="event-meta_time">2:30 PM CST</span>
-                    </time>
-                </p>
-            </div>
-      </aside>
+        {% if (request.url_rule.endpoint != 'event_archive') %}
+            <aside class="post_inset post_inset__right line-container event-status">
+                <div class="line-container_body">
+                    <h1 class="u-visually-hidden">Event reservation and viewing details</h1>
+                    <p>
+                        <strong>This event requires an RSVP.</strong>
+                    </p>
+                    <p>
+                        <a href="mailto:reserve@cfpb.gov?subject=Event RSVP&body=To RSVP, please fill in your first and last name below and send this email.%0D%0A%0D%0AFirst name:%0D%0ALast name:" class="btn"><span class="btn_icon__left cf-icon cf-icon-email-social"></span> reserve@cfpb.gov</a>
+                    </p>
+                    <p>
+                        {# TODO Change to livestream icon when that's added to cf-icons. #}
+                        <span class="cf-icon cf-icon-wifi"></span>
+                        <strong>Available on Live stream.</strong>
+                    </p>
+                    <p class="event-meta">
+                        <span class="event-meta_description event-meta_description__block">
+                            Video link available :
+                        </span>
+                        <time class="event-meta_datetime dt-start" datetime="2014-01-21 2:30 PM CST">
+                            <span class="event-meta_date">1/21/2014</span>
+                            <span class="event-meta_time">2:30 PM CST</span>
+                        </time>
+                    </p>
+                </div>
+            </aside>
+        {% endif %}
       {{ post.content|safe }}
     </div>
 {% if post.tags|length %}

--- a/events/archive/_single.html
+++ b/events/archive/_single.html
@@ -1,0 +1,82 @@
+{% extends "layout-2-1-bleedbar.html" %}
+{% import "_vars-events.html" as vars with context %}
+
+{% block title -%}
+    {{ vars.mock_event.title }} {# TODO Replace mock data #}
+{%- endblock %}
+
+{% block desc -%}
+    {{ vars.mock_event.excerpt|striptags }} {# TODO Replace mock data #}
+{%- endblock %}
+
+{% block og_type -%}
+    article
+{%- endblock %}
+
+{% block og_article_prefix -%}
+    article: http://ogp.me/ns/article#
+{%- endblock %}
+
+{% block og_article_author -%}
+    <meta property="article:author" content="https://www.facebook.com/CFPB">
+{%- endblock %}
+
+{% block content_main %}
+    {% import "_event.html" as article with context %}
+
+    {{ article.render(vars.mock_event, vars.path) }}
+
+    {% from "_event-post-macros.html" import event_agenda as event_agenda %}
+    {{ event_agenda(vars.mock_event) }}
+
+    <div class="event-footer">
+        <div class="content-l">
+            <section class="content-l_col content-l_col-1-2 event-footer_col">
+                <h3 class="h4 u-mb5">Downloads</h3>
+                <a href="#" class="event-footer_link">Download event PDF <span class="cf-icon cf-icon-pdf"></span></a>
+            </section>
+            <section class="content-l_col content-l_col-1-2 event-footer_col">
+                <h3 class="h4 u-mb5">Do you have event questions?</h3>
+                <a href="mailto:reserve@cfpb.gov?subject=Event Question&body=Please include your question and fill in your first and last name below and send this email.%0D%0A%0D%0AQuestion:%0D%0AFirst name:%0D%0ALast name:" class="event-footer_link"><span class="cf-icon cf-icon-email-social"></span> reserve@cfpb.gov</a>
+            </section>
+        </div>
+    </div>
+{% endblock %}
+
+{% block content_sidebar %}
+    <section class="block u-mt0">
+        {% import "related-posts.html" as related_posts with context %}
+        {{ related_posts.render(event_archive) }}
+    </section>
+    <section class="block">
+        <h1 class="header-slug">
+            <span class="header-slug_inner">
+                Stay informed
+            </span>
+        </h1>
+        <div class="block block__sub u-mt0">
+            <p class="short-desc">
+                Subscribe to our email newsletter. We will update you on new blogs.
+            </p>
+            {% import "email-subscribe-form.html" as subscribe with context %}
+            {{ subscribe.render(vars.query) }}
+        </div>
+        <div class="block block__sub">
+            {% import "rss.html" as rss %}
+            {{ rss.render(vars.rss_path) }}
+        </div>
+    </section>
+    <section class="block">
+        {%- import "related-links.html" as related_links -%}
+        {{- related_links.render([
+            [
+                '/the-bureau/',
+                'About us'
+            ],
+            [
+                '/contact-us/',
+                'Contact us'
+            ],
+        ]) -}}
+    </section>
+{% endblock %}


### PR DESCRIPTION

Add Events Archive page

## Changes

- Updates '_events.html" file to add condition for omitting inset markup when even/archive path.
- Updates 'lookups.json" file to display the event archive post type.
- Updates 'event-post-macros" file to add condition for displaying image and text.
- Added 'archive/_single.html' file to display the event archive page. 

## Review

- @jimmynotjim 
- @anselmbradford 


et al

## Preview
![event-archive](https://cloud.githubusercontent.com/assets/1696212/6538529/89b2bb5e-c431-11e4-8739-8fca8368dd79.png)
