### PR TITLE
Fix for DF-1579/DF-1578

### DIFF
--- a/events/_event-post-macros.html
+++ b/events/_event-post-macros.html
@@ -98,7 +98,7 @@
    ========================================================================== #}
 
 {% macro event_meta(post, address_format='{city}, {state}', datetime_format={})%}
-    <div class="event-meta event-meta__medium h-event">
+    <div class="event-meta h-event">
         {{ event_meta_address(post, address_format) }}
         {{ event_meta_datetime(post.date, datetime_format) }}
     </div>

--- a/static/css/event.less
+++ b/static/css/event.less
@@ -18,7 +18,7 @@
 
 .post-preview__event {
     border-top: 1px solid @gray-50;
-    padding-top: 1em;
+    padding-top: unit(30px  / @base-font-size-px, em);
 
     .media-object_image-container {
         top: 0;
@@ -41,7 +41,7 @@
     }
 
     .event-meta {
-        color: @black;
+        color: @darkgray;
     }
 
     .event-meta_address {
@@ -70,6 +70,11 @@
     .summary_heading {
         // Setting margin-top to align with calendar icon.
         margin: -1 * unit(2px  / @base-font-size-px, em) 0 0 0;
+
+        .respond-to-max(@mobile-max {
+            .h3();
+            margin-bottom: 0;
+        });
     }
 
     .summary-meta_container {


### PR DESCRIPTION
Fixes for JIRA issues DF-1578 and DF-1579

 - Adjust type sizes/weights so that they match the design files for a better hierarchy on the page.
 - Make padding between rule and event text 30px and padding below event text and the follwing event post 60px

## Changes

- Updates 'events/_event-post-macros.html' file to fix padding issue and font issue.
- Updates 'events.less' file to fix padding issue and font issue.

## Review

- @jimmynotjim 
- @anselmbradford 


et al


