### PR TITLE
Fix for DF-1577 - Events Mobile Nav

### DIFF
--- a/_includes/sidenav.html
+++ b/_includes/sidenav.html
@@ -1,7 +1,26 @@
+{# ==========================================================================
 
-{% macro render(items, active_item_id) %}
+   render()
 
-<nav class="nav-secondary expandable">
+   ==========================================================================
+
+   Description:
+
+   Create nav markup when given:
+
+   items:               An array of tuples used to display nav items. 
+                        format: (href, id, caption)
+
+   active_item_id:      A string indicating the id of the nav item 
+                        to be activated.
+
+   additional_classes:  Extra classes you wish to add to the nav, space separated.
+
+   ========================================================================== #}
+
+{% macro render(items, active_item_id, additional_classes) %}
+
+<nav class="nav-secondary expandable {{ additional_classes }}">
     <h1 class="u-visually-hidden">
 {%- for href, id, caption in items %}
     {% if id == 'index' %}

--- a/events/index.html
+++ b/events/index.html
@@ -13,27 +13,36 @@
     Events description...
 {%- endblock %}
 
+
+{# Only show the hero when:
+    1. We are on the first page of paginated results
+    2. A hero exists
+#}
+
+{# TODO remove commented line #}
+{# set show_hero = (vars.events.current_page == 1 and view.hero) %#}
+{% set show_hero = true %}
+
+{% block content_sidebar_modifiers %}
+    {{ super() }}
+    {% if show_hero %}
+        u-hide-on-mobile
+    {% endif %}
+{% endblock %}
+
 {% block hero %}
-    {# Only show the hero when:
-       1. We are on the first page of paginated results
-       2. A hero exists
-    #}
-
-    {%
-        set current_page = 1
-    %}
-
-    {%
-        set hero = true
-    %}
-
-    {#{% if vars.events.current_page == 1 and view.hero %}#}
-    {% from "_event-landing-macros.html" import event_hero as event_hero %}
-    {% if current_page == 1 and hero %}
+    {% if show_hero %}
+        {% import "sidenav.html" as sidenav %}
+        {{ sidenav.render(
+            vars.nav_items, 
+            'index',
+            'u-show-on-mobile u-mb0'
+        ) }}
+        {% from "_event-landing-macros.html" import event_hero as event_hero %}
         {{ event_hero(hero) }}
     {% endif %}
-
 {% endblock %}
+
 
 {% block content_main_modifiers -%}
     {{ super() }} content__flush-bottom


### PR DESCRIPTION
Fixes position of nav on mobile for Events landing page.

## Changes

- Updates '_includes/sidenav.htm' file to allow for additional classes on nav.
- Updates ' events/index.html' file to show/hide mobile menus depending on context. 


## Review

- @jimmynotjim 
- @anselmbradford 


et al

## Preview
![screen shot 2015-03-12 at 12 27 36 pm](https://cloud.githubusercontent.com/assets/1696212/6622502/5f1f7cac-c8b3-11e4-9852-38e8eebd97f7.png)
