### PR TITLE
Fixes DF-1649 - removes McLean info

### DIFF
--- a/newsroom/press-resources/index.html
+++ b/newsroom/press-resources/index.html
@@ -77,21 +77,6 @@
             </section>
 
             <section class="contact-person content-l_col-1-2">
-                <h1 class="contact-person_name">Mallory McLean</h1>
-                <div class="contact-person_title">Regional Spokesperson</div>
-                <ul class="contact-person_methods list list__unstyled">
-                    <li class="list_item">
-                        <a href="mailto:mallory.mclean@cfpb.gov">
-                            mallory.mclean@cfpb.gov
-                        </a>
-                    </li>
-                    <li class="list_item">
-                        <a href="tel:2024357955">(202) 435-7955</a>
-                    </li>
-                </ul>
-            </section>
-
-            <section class="contact-person content-l_col-1-2">
                 <h1 class="contact-person_name">Moira Vahey</h1>
                 <div class="contact-person_title">Spokesperson</div>
                 <ul class="contact-person_methods list list__unstyled">


### PR DESCRIPTION
Removes Mallory McLean info (she is no longer at the CFPB).

## Removals

- Removes McLean section from press resources page.

## Testing

- Visit /newsroom/press-resources/ and note McLean section is gone.

## Review

- @sebworks 
- @jimmynotjim 