### PR TITLE
Fixes DF-1642 - changes https to http

### DIFF
--- a/index.html
+++ b/index.html
@@ -136,7 +136,7 @@
                             </p>
                             <ul class="list__links">
                                 <li class="list_item">
-                                    <a class="list_link jump-link" href="https://www.consumerfinance.gov/">
+                                    <a class="list_link jump-link" href="http://www.consumerfinance.gov/">
                                         Go to consumerfinance.gov
                                     </a>
                                 </li>


### PR DESCRIPTION
## Changes

- Changes link to cf.gov from https to http.

## Testing

- Visit landing page, click `Go to consumerfinance.gov`, note http:// is used.

## Review

- @jimmynotjim 
- @sebworks 

## Notes

- Just checking that we don't want to be directing people to https for some reason? cc @Scotchester 