### PR TITLE
Fix for DF-1623-Blog/Events/Events Archive urls

### DIFF
--- a/_queries/events.json
+++ b/_queries/events.json
@@ -1,0 +1,8 @@
+{
+  "name": "CFPB Events",
+  "query": {
+    "doc_type": "events",
+    "size": 10,
+    "sort": "date:desc"
+  }
+}

--- a/_queries/events_archive.json
+++ b/_queries/events_archive.json
@@ -1,0 +1,8 @@
+{
+  "name": "CFPB Events Archive",
+  "query": {
+    "doc_type": "events_archive",
+    "size": 10,
+    "sort": "date:desc"
+  }
+}

--- a/_settings/lookups.json
+++ b/_settings/lookups.json
@@ -24,14 +24,14 @@
     "type":      "watchroom",
     "permalink": true
   },
-  "event": {
-    "url":       "/events/<id>/",
-    "type":      "posts",
-    "permalink": true
-  },
   "event_archive": {
     "url":       "/events/archive/<id>/",
-    "type":      "posts",
+    "type":      "events_archive",
+    "permalink": true
+  },
+  "event": {
+    "url":       "/events/<id>/",
+    "type":      "events",
     "permalink": true
   }
 }

--- a/_settings/processors.json
+++ b/_settings/processors.json
@@ -38,6 +38,16 @@
     "processor": "wordpress_post_processor",
     "mappings":  "_settings/posts_mappings.json"
   },
+  "events": {
+    "url":       "$WORDPRESS/api/get_posts/",
+    "processor": "wordpress_post_processor",
+    "mappings":  "_settings/posts_mappings.json"
+  },
+  "events_archive": {
+    "url":       "$WORDPRESS/api/get_posts/",
+    "processor": "wordpress_post_processor",
+    "mappings":  "_settings/posts_mappings.json"
+  },
   "newsroom": {
     "url":       "$WORDPRESS/api/get_posts/?post_type=cfpb_newsroom",
     "processor": "wordpress_post_processor",

--- a/events/_vars-events.html
+++ b/events/_vars-events.html
@@ -154,18 +154,14 @@
 }
 %}
 
-{# TODO Once the events post type is created,
-the following needs to be added to `_settings/lookups.json`.
-
-  "event": {
-    "url":       "/events/<id>/",
-    "type":      "events",
-    "permalink": true
-  }
-
+{# TODO Once the events post type is created:
+    The events/events_archive processors need the correct links
 #}
 
-
-{# Temp using blog query to render the signup form #}
-{% set query = queries.posts %}
+{% if ('/events/archive/' in request.path.lower()) %}
+    {% set query = queries.events_archive %}
+{% else %}
+    {% set query = queries.events %}
+{% endif %}
 {% set events = query.search_with_url_arguments(size=10) %}
+


### PR DESCRIPTION
Fixed url issues for Blog/Events/Event Archives

## Changes

- Updates '_vars-events.html' file to use appropriate post type depending on path.
- Updates '/lookups.json' file to use appropriate post type.
- Updates '/processors.json' file to build mock events/events archives types.
- Adds '_queries/events_archive.json' file to allow for Elasticsearch query.
- Adds '_queries/events.json' file to allow for Elasticsearch query.

## Notes
  You will need to re-index Sheer by running :
      sheer index --reindex

## Review

- @jimmynotjim 
- @anselmbradford 