### PR TITLE
Fix for DF-1639:General Contact Info

### DIFF
--- a/_lib/wordpress_contact_processor.py
+++ b/_lib/wordpress_contact_processor.py
@@ -40,14 +40,14 @@ def convert_custom_field(post_type, attribute, index=0, new_attribute=None):
 def process_contact(contact):
     del contact['comments']
     contact['_id'] = contact['slug']
+    convert_custom_field(contact, 'email_0_addr')
+    convert_custom_field(contact, 'email_0_desc')
     convert_custom_field(contact, 'email_1_addr')
     convert_custom_field(contact, 'email_1_desc')
-    convert_custom_field(contact, 'email_2_addr')
-    convert_custom_field(contact, 'email_2_desc')
+    convert_custom_field(contact, 'phone_0_num')
+    convert_custom_field(contact, 'phone_0_desc')
     convert_custom_field(contact, 'phone_1_num')
     convert_custom_field(contact, 'phone_1_desc')
-    convert_custom_field(contact, 'phone_2_num')
-    convert_custom_field(contact, 'phone_2_desc')
     convert_custom_field(contact, 'fax_num')
     convert_custom_field(contact, 'fax_desc')
     convert_custom_field(contact, 'sitewide_desc')
@@ -57,10 +57,6 @@ def process_contact(contact):
     convert_custom_field(contact, 'state')
     convert_custom_field(contact, 'zip_code')
     convert_custom_field(contact, 'addr_desc')
-    convert_custom_field(contact, 'email_0_addr', index=0, new_attribute='email_addr')
-    convert_custom_field(contact, 'email_0_addr', index=0, new_attribute='email_desc')
-    convert_custom_field(contact, 'phone_0_num', index=0, new_attribute='phone_num')
-    convert_custom_field(contact, 'phone_0_desc', index=0, new_attribute='phone_desc')
     convert_custom_field(contact, 'web_0', index=0, new_attribute='web_addr')
     convert_custom_field(contact, 'web_0', index=1, new_attribute='web_desc')
     return contact

--- a/_lib/wordpress_contact_processor.py
+++ b/_lib/wordpress_contact_processor.py
@@ -40,12 +40,12 @@ def convert_custom_field(post_type, attribute, index=0, new_attribute=None):
 def process_contact(contact):
     del contact['comments']
     contact['_id'] = contact['slug']
-    convert_custom_field(contact, 'email_addr')
-    convert_custom_field(contact, 'email_desc')
+    convert_custom_field(contact, 'email_1_addr')
+    convert_custom_field(contact, 'email_1_desc')
     convert_custom_field(contact, 'email_2_addr')
     convert_custom_field(contact, 'email_2_desc')
-    convert_custom_field(contact, 'phone_num')
-    convert_custom_field(contact, 'phone_desc')
+    convert_custom_field(contact, 'phone_1_num')
+    convert_custom_field(contact, 'phone_1_desc')
     convert_custom_field(contact, 'phone_2_num')
     convert_custom_field(contact, 'phone_2_desc')
     convert_custom_field(contact, 'fax_num')
@@ -57,6 +57,10 @@ def process_contact(contact):
     convert_custom_field(contact, 'state')
     convert_custom_field(contact, 'zip_code')
     convert_custom_field(contact, 'addr_desc')
+    convert_custom_field(contact, 'email_0_addr', index=0, new_attribute='email_addr')
+    convert_custom_field(contact, 'email_0_addr', index=0, new_attribute='email_desc')
+    convert_custom_field(contact, 'phone_0_num', index=0, new_attribute='phone_num')
+    convert_custom_field(contact, 'phone_0_desc', index=0, new_attribute='phone_desc')
     convert_custom_field(contact, 'web_0', index=0, new_attribute='web_addr')
     convert_custom_field(contact, 'web_0', index=1, new_attribute='web_desc')
     return contact

--- a/contact-us/general-inqueries.html
+++ b/contact-us/general-inqueries.html
@@ -8,19 +8,20 @@
     {{ general_inqueries.sitewide_desc }}
 </p>
 <ul class="list list__icons">
-{%- if general_inqueries.email_addr %}
+{%- if general_inqueries.email_0_addr %}
     <li class="list_item u-break-word">
         <span class="cf-icon cf-icon-email list_icon"></span>
-        <a class="list_link" href="mailto:{{ general_inqueries.email_addr }}">
-            {{ general_inqueries.email_addr }}
+        <a class="list_link" href="mailto:{{ general_inqueries.email_0_addr }}">
+            {{ general_inqueries.email_0_addr }}
         </a>
     </li>
 {%- endif %}
-{%- if general_inqueries.phone_num %}
+
+{%- if general_inqueries.phone_0_num %}
     <li class="list_item">
         <span class="cf-icon cf-icon-phone list_icon"></span>
         <span class="short-desc">
-            {{ format_phone(general_inqueries.phone_num) }}
+            {{ format_phone(general_inqueries.phone_0_num) }}
         </span>
     </li>
 {%- endif %}

--- a/contact-us/submit-a-complaint.html
+++ b/contact-us/submit-a-complaint.html
@@ -10,12 +10,12 @@
 <div class="content-l">
     <div class="content-l_col content-l_col-1-2">
         <ul class="list list__unstyled">
-        {%- if submit_a_complaint.phone_num %}
+        {%- if submit_a_complaint.phone_0_num %}
             <li class="list_item short-desc">
-                {{ format_phone(submit_a_complaint.phone_num) }}
-            {%- if submit_a_complaint.phone_desc %}
+                {{ format_phone(submit_a_complaint.phone_0_num) }}
+            {%- if submit_a_complaint.phone_0_desc %}
                 <span class="micro-copy micro-copy__large">
-                    {{ submit_a_complaint.phone_desc }}
+                    {{ submit_a_complaint.phone_0_desc }}
                 </span>
             {%- endif %}
             </li>

--- a/contact-us/submit-a-complaint.html
+++ b/contact-us/submit-a-complaint.html
@@ -12,7 +12,6 @@
         <ul class="list list__unstyled">
         {%- if submit_a_complaint.phone_num %}
             <li class="list_item short-desc">
-                <span class="cf-icon cf-icon-phone list_icon"></span>
                 {{ format_phone(submit_a_complaint.phone_num) }}
             {%- if submit_a_complaint.phone_desc %}
                 <span class="micro-copy micro-copy__large">
@@ -21,13 +20,12 @@
             {%- endif %}
             </li>
         {%- endif %}
-        {%- if submit_a_complaint.phone_2_num %}
+        {%- if submit_a_complaint.phone_1_num %}
             <li class="list_item short-desc">
-                <span class="cf-icon cf-icon-phone list_icon"></span>
-                {{ format_phone(submit_a_complaint.phone_2_num) }}
-            {%- if submit_a_complaint.phone_2_desc %}
+                {{ format_phone(submit_a_complaint.phone_1_num) }}
+            {%- if submit_a_complaint.phone_1_desc %}
                 <span class="micro-copy micro-copy__large">
-                    {{ submit_a_complaint.phone_2_desc }}
+                    {{ submit_a_complaint.phone_1_desc }}
                 </span>
             {%- endif %}
             </li>
@@ -43,7 +41,7 @@
     </div>
 </div>
 {%- if submit_a_complaint.web_addr %}
-<a class="jump-link" href="{{ submit_a_complaint.web_addr }}">
+<a class="jump-link jump-link__right" href="{{ submit_a_complaint.web_addr }}">
     {{ submit_a_complaint.web_desc if submit_a_complaint.web_desc else submit_a_complaint.web_addr }}
 </a>
 {%- endif %}


### PR DESCRIPTION
Fix expandable cue position for multi-line text on Small Business page.

## Changes

- Updates ' _lib/wordpress_contact_processor.py' file to fix errors with email address and phone number.
- Updates 'contact-us/submit-a-complaint.html' file to populate correct content.

## Review

- @jimmynotjim 
- @anselmbradford 
- @willbarton 

## Notes
  You will need to reindex Sheer by running :
      Sheer index --reindex

  Unsure on what field should be populating 'Address desc'
  Document is available at http://localhost:9200/content/contact/submit-a-complaint

## Preview
![screen shot 2015-03-16 at 6 00 31 pm](https://cloud.githubusercontent.com/assets/1696212/6677628/39e3e060-cc08-11e4-9412-eeda7dfd32d6.png)