### PR TITLE
DF-1625_Email_signup:Disable Topic Expansion

### DIFF
--- a/_includes/email-subscribe-form.html
+++ b/_includes/email-subscribe-form.html
@@ -1,7 +1,5 @@
 
 {% macro render(query, code) %}
-{% set url_path = request.path.lower() %}
-{% set is_blog_or_event = ('/blog/' in url_path) or ('/events/' in url_path) %}
 
 <form class="reveal-on-focus"
       id="email-subscribe-form"
@@ -36,7 +34,8 @@
     </div>
     {% endif %}
     #}
-    {% if query and is_blog_or_event == false -%}
+    {# TODO: Remove "and false" when topics are available for email sign-ups. #}
+    {% if query and false -%}
     <div class="form-group reveal-on-focus_content u-clearfix">
     {% for category in query.possible_values_for('category')|sort(attribute='key') -%}
     {% set govdelivery_categories = [

--- a/_includes/email-subscribe-form.html
+++ b/_includes/email-subscribe-form.html
@@ -1,5 +1,7 @@
 
 {% macro render(query, code) %}
+{% set url_path = request.path.lower() %}
+{% set is_blog_or_event = ('/blog/' in url_path) or ('/events/' in url_path) %}
 
 <form class="reveal-on-focus"
       id="email-subscribe-form"
@@ -34,7 +36,7 @@
     </div>
     {% endif %}
     #}
-    {% if query -%}
+    {% if query and is_blog_or_event == false -%}
     <div class="form-group reveal-on-focus_content u-clearfix">
     {% for category in query.possible_values_for('category')|sort(attribute='key') -%}
     {% set govdelivery_categories = [


### PR DESCRIPTION
Disable the Topic Expansion on Blog or Event

## Changes
- Updates '_includes/email-subscribe-form.html' to disable email topic functionality on blog/event pages.

## Review

- @anselmbradford  
- @jimmynotjim 

## Preview
![screen shot 2015-03-19 at 2 47 36 pm](https://cloud.githubusercontent.com/assets/1696212/6738309/90122eb0-ce47-11e4-932b-4cfdc2cff40a.png)
