### PR TITLE
Timeline expandable label

### DIFF
--- a/the-bureau/history/index.html
+++ b/the-bureau/history/index.html
@@ -110,7 +110,7 @@
             </div><!-- END .history-section-expandable .expandable_content -->
             <button class="expandable_header expandable_target history-section-expandable_header">
                 <span class="expandable_header-left expandable_label">
-                    Timeline of our current history
+                    Timeline
                 </span>
                 <span class="expandable_header-right expandable_link">
                     <span class="expandable_cue-open">


### PR DESCRIPTION
"of our current history" isn't as good for the older ones as it is for the work since July 21, 2011. So I just excised it.