### PR TITLE
Fixes #405 - reduces CSS specificity

### DIFF
--- a/static/css/budget.less
+++ b/static/css/budget.less
@@ -21,32 +21,32 @@
                 .list__links .list_item();
                 .list__icons .list_item();
                 margin-left: 0;
+            }
 
-                a {
-                    .list_link();
-                    .jump-link();
+            a {
+                .list_link();
+                .jump-link();
 
-                    // Override the jump-link padding, left, display values.
-                    // TODO: Explore creating a jump-link-icon pattern.
-                    // TODO: Avoid using !important if possible.
-                    padding-left: 1.25em !important;
-                    left: 0;
-                    display: block;
+                // Override the jump-link padding, left, display values.
+                // TODO: Explore creating a jump-link-icon pattern.
+                // TODO: Avoid using !important if possible.
+                padding-left: 1.25em !important;
+                left: 0;
+                display: block;
 
-                    &:before {
-                        .list__icons .list_icon();
-                        .cf-icon();
-                        content: "\e406";
-                        color: @pacific;
+                &:before {
+                    .list__icons .list_icon();
+                    .cf-icon();
+                    content: "\e406";
+                    color: @pacific;
 
-                        // Override the jump-link line-height.
-                        line-height: @base-line-height;
+                    // Override the jump-link line-height.
+                    line-height: @base-line-height;
 
-                        .respond-to-max(599px, {
-                            // Add jump-link padding offset on small screens.
-                            top: unit(10px / @base-font-size-px, em);
-                        });
-                    }
+                    .respond-to-max(599px, {
+                        // Add jump-link padding offset on small screens.
+                        top: unit(10px / @base-font-size-px, em);
+                    });
                 }
             }
         }


### PR DESCRIPTION
Fixes #405 - reduces CSS specificity.

## Changes

- Moves `a` outside `li` in Less file, since parent `ul` can only have `li` or a non-visual element as its child, so it's implied that `a` is the child of `li` even though that's not shown in the CSS.

## Review

- @sebworks 
- @jimmynotjim 