### PR TITLE
DF-1679: Remove logo and usage section on Press page

### DIFF
--- a/newsroom/press-resources/index.html
+++ b/newsroom/press-resources/index.html
@@ -187,33 +187,7 @@
         </a>
 
     </section><!-- END .press-section.press-photos-bios -->
-
-    <section class="press-section press-logo">
-
-        <h1 class="press-section_title press-logo_title">Logo and usage</h1>
-
-        <div class="content-l content-l__main">
-
-            <p class="press-section_intro press-logo_intro content-l_col-2-3">
-                The CFPB logo was designed to symbolize vigilance, transparency, and
-                a consumer focus. Consumers are the foundation and focus of our mission and
-                our logo reflects that. A soft beam of light symbolizes our efforts to
-                illuminate the financial landscape and foster transparency in the
-                marketplace.</p>
-
-            <figure class="press-logo_logo">
-                <img src="/static/img/CFPB_2Tone_isolated_RGB_352.png" alt="CFPB logo" width="176">
-            </figure>
-
-        </div><!-- END .content-l -->
-
-        <a class="jump-link jump-link__large"
-           href="https://cfpb.github.io/design-manual/identity/logo.html">
-            Logo files and more in the CFPB Design Manual
-        </a>
-
-    </section><!-- END .press-section.press-logo -->
-
+    
     <aside class="block block__bg block__flush-sides u-mb0">
         <div class="content-l content-l__main">
             <section class="content-l_col content-l_col-1-2">

--- a/static/css/press-resources.less
+++ b/static/css/press-resources.less
@@ -47,10 +47,6 @@
     }
 }
 
-.press-logo_logo {
-    text-align: center;
-}
-
 .respond-to-min(768px, {
     .press-section_title {
         .h2();
@@ -76,11 +72,6 @@
             .h3();
             margin-bottom: unit(15px / @font-size, em);
         }
-    }
-
-    .press-logo_logo {
-        .grid_column(3);
-        .grid_push(1);
     }
 });
 


### PR DESCRIPTION
DF-1679: Remove logo and usage section
 
## Changes
 
- Updated 'newsroom/press-resources/index.html' to remove Press page logo section.
- Updated 'static/css/press-resources.less' to remove Press logo styling.

## Review
 
- @jimmynotjim  
- @anselmbradford 
 
## Preview
 
![screen shot 2015-03-23 at 11 57 25 am](https://cloud.githubusercontent.com/assets/1696212/6784052/cdd8b282-d153-11e4-89e0-5123c9da01cf.png)


## Notes
 
None