### PR TITLE
Do not index press release authors

### DIFF
--- a/_lib/wordpress_post_processor.py
+++ b/_lib/wordpress_post_processor.py
@@ -49,8 +49,8 @@ def process_post(post, newsroom = False):
         post['links'] = links
     else:
         post['tags'] = [tag['title'] for tag in post['taxonomy_fj_tag']]
-        post['author'] = [author['title'] for author in \
-            post['taxonomy_fj_author'] if 'Press Release' not in \
+        post['author'] = [author['title'] for author in
+            post['taxonomy_fj_author'] if 'Press Release' not in
             post['category']]
     if newsroom and post['type'] == 'post':
         post['category'][0] = "Blog"

--- a/_lib/wordpress_post_processor.py
+++ b/_lib/wordpress_post_processor.py
@@ -49,7 +49,9 @@ def process_post(post, newsroom = False):
         post['links'] = links
     else:
         post['tags'] = [tag['title'] for tag in post['taxonomy_fj_tag']]
-        post['author'] = [author['title'] for author in post['taxonomy_fj_author']]
+        post['author'] = [author['title'] for author in \
+            post['taxonomy_fj_author'] if 'Press Release' not in \
+            post['category']]
     if newsroom and post['type'] == 'post':
         post['category'][0] = "Blog"
     author_template = Template("$first_name $last_name")


### PR DESCRIPTION
Previously, for Newsroom, we were indexing Press Release authors, which included some user names and other less than desirable outcomes.  This first checks to see if it's in the Press Release category, and doesn't index the author if it is a Press Release.

Review: @willbarton @kurtw