### PR TITLE
Changed email signup language

### DIFF
--- a/newsroom/index.html
+++ b/newsroom/index.html
@@ -43,7 +43,7 @@
             <div class="content-l content-l__main">
                 <div class="block__sub content-l_col content-l_col-1-2">
                     <p class="short-desc">
-                        Subscribe to our email newsletter. We will update you on new newsroom updates.
+                        Subscribe to get our press releases by email.
                     </p>
                     {% import "email-subscribe-form.html" as subscribe with context %}
                     {{ subscribe.render(vars.query) }}


### PR DESCRIPTION
We don't send out all testimony or speeches, I don't believe, so I limited it to "press releases." I'd rather underpromise and overdeliver on our comms emails than the other way around. We can verify with comms about the language on future updates.