### PR TITLE
Fixes DF-1677 - scopes multi-line list styles.

### DIFF
--- a/doing-business-with-us/past-awards/index.html
+++ b/doing-business-with-us/past-awards/index.html
@@ -27,9 +27,11 @@
         <a href="/budget/">see our budget and strategy</a>.
     </p>
 
-    {% set page = get_document('pages', '36603') %}
-    {{ page.content | safe }}
+    <div class="business_page-content">
+        {% set page = get_document('pages', '36603') %}
+        {{ page.content | safe }}
 
-    {% include "_process-smbiz-footer.html" %}
+        {% include "_process-smbiz-footer.html" %}
+    </div>
 
 {% endblock %}

--- a/static/css/cf-enhancements.less
+++ b/static/css/cf-enhancements.less
@@ -533,21 +533,28 @@ tbody {
     - cf-typography
 */
 
-.list__icons {
-    .list__unstyled();
+// TODO: Move multi-line list__icons outside of budget and procurement pages.
+// Currently, they conflict with the default list__links style
+// when the classes are placed directly in markup, for example
+// see the lists on /newsroom/press-resources/.
+.budget_page-content,
+.business_page-content {
+    .list__icons {
+        .list__unstyled();
 
-    .list_item {
-        margin-left: 2em;
-        position: relative;
-    }
+        .list_item {
+            margin-left: 2em;
+            position: relative;
+        }
 
-    .list_icon {
-        position: absolute;
-        width: 1.5em;
-        left: 0;
-        top: 0;
-        line-height: @base-line-height;
-        .list__icons .list_icon__left();
+        .list_icon {
+            position: absolute;
+            width: 1.5em;
+            left: 0;
+            top: 0;
+            line-height: @base-line-height;
+            .list__icons .list_icon__left();
+        }
     }
 }
 


### PR DESCRIPTION
Till the multi-line link list pattern is fleshed out completely this PR
scopes the styles for that in cf-enhancements so it doesn’t conflict
with un-migrated styles on the press resources page.

## Changes

- Scopes multi-line list styles. 
- Additionally, adds a class wrapper for the procurement history page
so styles can be targeted there as well.

## Testing

- visit /budget/financial-report/,  /newsroom/press-resources/, and /doing-business-with-us/past-awards/ and all should look okay in the icon lists.

## Review

- @jimmynotjim 
- @sebworks 

## Notes

- This is a patch and will need to be re-worked to allow the multi-line icon lists to handle when the classes for them are added directly in the markup instead of in pure CSS.
