### PR TITLE
Minor update to testing readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,11 +201,12 @@ To run browser tests, you'll need to perform the following steps:
   - Mac: `brew install chromedriver`
   - Manual (Linux/Mac): Download the latest
     [Chromedriver](http://chromedriver.storage.googleapis.com/index.html)
-    binary and put it somehwere on your path (e.g. `/path/to/your/venv/bin`)
+    binary and put it somewhere on your path (e.g. `/path/to/your/venv/bin`)
 2. In `_tests/browser_testing/features/`, copy `example-environment.cfg` to
 `environment.cfg` and change the `chrome_driver` path to the proper path
 for your webdriver binary.  If you installed via homebrew,
-this will be `/path/to/homebrew/bin/chromedriver`.
+you can find the path with `brew info chromedriver`, which will give you
+the chromedriver directory. Use this path, but include the chromedriver name at the end to target the executable, something like `/path/to/homebrew/bin/chromedriver`.
 3. `pip install -r _tests/browser_testing/requirements.txt`
 4. `cd _tests/browser_testing/`
 5. Start the tests: `behave`


### PR DESCRIPTION
Updates typo and adds more instructions for brew to the testing section
of the readme.

## Additions

- Adds instructions for running `brew info` to find chromedriver installation path.

## Changes

- Updates typo in `somewhere` text.

## Review

- @sebworks 
- @jimmynotjim 
