### PR TITLE
Fix for Step Slug symmetry

### DIFF
--- a/static/css/misc.less
+++ b/static/css/misc.less
@@ -1030,24 +1030,24 @@
     - cfgov-misc
 */
 
+
+// Size of cicular background.
+@size: 1.5em;
+
 .char-icon {
     &:before {
         display: inline-block;
         box-sizing: border-box;
-        width: 1.5em;
-        height: 1.5em;
-        padding: 0.25em 0;
+        width: @size;
+        height: @size;
+        padding: 0;
         border-radius: 100%;
         margin-right: 0.375em;
-
         position: relative;
-        top: -( unit(1px / 13px, em) );
-
         background: @green;
         color: @white;
         .webfont-medium();
-        font-size: percentage(13 / 14);
-        line-height: 1;
+        line-height: @size;
         text-align: center;
     }
 

--- a/static/css/misc.less
+++ b/static/css/misc.less
@@ -1040,7 +1040,6 @@
         box-sizing: border-box;
         width: @size;
         height: @size;
-        padding: 0;
         border-radius: 100%;
         margin-right: 0.375em;
         position: relative;

--- a/static/css/misc.less
+++ b/static/css/misc.less
@@ -1032,21 +1032,21 @@
 
 
 // Size of cicular background.
-@size: 1.5em;
+@icon-size: 1.5em;
 
 .char-icon {
     &:before {
         display: inline-block;
         box-sizing: border-box;
-        width: @size;
-        height: @size;
+        width: @icon-size;
+        height: @icon-size;
         border-radius: 100%;
         margin-right: 0.375em;
         position: relative;
         background: @green;
         color: @white;
         .webfont-medium();
-        line-height: @size;
+        line-height: @icon-size;
         text-align: center;
     }
 


### PR DESCRIPTION
Fixes symmetry issues with Step Slug #363 
 
## Changes
 
- Updated 'static/css/misc.less' to fix issues with padding and size.

## Review
 
- @jimmynotjim  
- @anselmbradford 
- @ajbush 
- @duelj 

## Preview
 
![screen shot 2015-03-25 at 8 53 19 am](https://cloud.githubusercontent.com/assets/1696212/6825950/9c8fa00a-d2d4-11e4-8941-d5fc74e44acd.png)


## Notes
- Removed the adjustment to the font-size of the circle for symmetry purposes. Wasn't able to adjust font-size without adding extra markup. 

- Will require Design sign-off