### PR TITLE
DF-1735 Fixed "Blog" category issue

### DIFF
--- a/_includes/post-macros.html
+++ b/_includes/post-macros.html
@@ -567,7 +567,7 @@
             {% endfor %}
             {% if doc_type == 'newsroom' -%}
                 <label class="form-group_item">
-                    {{ filter_checkbox('type', 'post', 'Blog')|safe }}
+                    {{ filter_checkbox('category', 'Blog', 'Blog')|safe }}
                 </label>
             {%- endif %}
             </div>
@@ -585,7 +585,7 @@
                 {% if category.key != 'cfpb_newsroom' %}
                     {% if category.key == 'post' %}
                         <label class="form-group_item">
-                            {{ filter_checkbox('type', category.key, 'Blog')|safe }}
+                            {{ filter_checkbox('category', 'Blog', 'Blog')|safe }}
                         </label>
                     {% else %}
                         <label class="form-group_item">


### PR DESCRIPTION
Fixed an issue within Newsroom and Activity Log filters where selecting "Blog" + another category would return zero results.
 
## Additions
 
None

## Removals
 
None
 
## Changes
 
- Updated filter macro to set "Blog" options
 
## Testing
 
Fork, open locally, and test category filters. "Blog" + another category should return results.
- /newsroom
- /activity-log
 
## Review
 
- @schaferjh 
- @dpford 
- @sebworks 
- @anselmbradford 
 
## Preview
 
![screen shot 2015-03-27 at 1 07 46 pm](https://cloud.githubusercontent.com/assets/1280430/6872838/49deb49a-d482-11e4-8caf-37da5a857f11.png)
 
## Notes
 
- when selected "Blog" was passing as a "format_type" instead of "filter_category"
- will need blog posts set correctly in prod content