### PR TITLE
Feeds for blog, newsroom

### DIFF
--- a/_queries/newsroom.json
+++ b/_queries/newsroom.json
@@ -20,5 +20,15 @@
         }
       ]
     }
-  ]
+  ],
+  "feed": {
+    "feed_title": "CFPB Newsroom",
+    "feed_url": "/newsroom/",
+    "entry_title": "$$title$$",
+    "entry_author": "$$author$$",
+    "entry_content": "$$content$$",
+    "entry_summary": "$$excerpt$$",
+    "entry_url": "$$url$$",
+    "entry_updated": "$$modified$$"
+  }
 }

--- a/_queries/posts.json
+++ b/_queries/posts.json
@@ -4,5 +4,15 @@
     "doc_type": "posts",
     "size": 10,
     "sort": "date:desc"
+  },
+  "feed": {
+    "feed_title": "CFPB Blog",
+    "feed_url": "/blog/",
+    "entry_title": "$$title$$",
+    "entry_author": "$$author$$",
+    "entry_content": "$$content$$",
+    "entry_summary": "$$excerpt$$",
+    "entry_url": "$$url$$",
+    "entry_updated": "$$modified$$"
   }
 }


### PR DESCRIPTION
**This PR requires a slight modification to sheer which was made [here](https://github.com/cfpb/sheer/pull/95)**

This adds the required settings to the blog and newsroom files in `/_queries/` to enable RSS feeds.  This pattern can be followed for other post types that require feeds.