### PR TITLE
DF-1438 Fixed featured topic links

### DIFF
--- a/newsroom/featured-topic.html
+++ b/newsroom/featured-topic.html
@@ -23,7 +23,7 @@
                 {% for link in post.links %}
                     <li class="list_item">
                         <!-- <span class="category-slug_icon cf-icon cf-icon-bullhorn"></span> -->
-                        <a class="list_link"
+                        <a class="list_link jump-link jump-link__right"
                            href="{{ link[0] }}">
                            {{ link[1] }}
                        </a>


### PR DESCRIPTION
Fixed featured topic links
 
## Additions
 
- None
 
## Removals
 
- None
 
## Changes
 
- Added `jump-link` with the `__right` modifier

## Testing
 
Fork and navigate to /newsroom at a smaller browser size
 
## Review
 
- @duelj 
- @sebworks 
- @anselmbradford 
 
## Preview

![screen shot 2015-03-27 at 5 02 19 pm](https://cloud.githubusercontent.com/assets/1280430/6876982/120e505e-d4a3-11e4-9192-ea4db4a8aee3.png)

## Notes
 
- links were missing jump-link and right styles