### PR TITLE
Change the name "Watchroom" to "Featured Topic"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 All notable changes to this project will be documented in this file.
 See the [README](README.md) for an explanation of our versioning conventions.
 
+## 3.0.0-0.2.4 - 2015-04-01
+
+### Changed
+- The name "Watchroom" to "Featured Topic"
+
 ## 3.0.0-0.2.3 - 2015-03-23
 
 ### Changed

--- a/_includes/posts-paginated.html
+++ b/_includes/posts-paginated.html
@@ -32,7 +32,7 @@
             <div class="media_image-container post-summary-image">
                 <div class="post-summary-image_container">
                     <img class="media_image"
-                         src="{{ post.thumbnail.images.fj_thumbnail.url }}"
+                         src="{{ post.thumbnail.images.full.url }}"
                          alt="{{ post.thumbnail.alt_text }}">
                 </div>
             </div>

--- a/_includes/posts-paginated.html
+++ b/_includes/posts-paginated.html
@@ -32,7 +32,7 @@
             <div class="media_image-container post-summary-image">
                 <div class="post-summary-image_container">
                     <img class="media_image"
-                         src="{{ post.thumbnail.images.full.url }}"
+                         src="{{ post.thumbnail.images.fj_thumbnail.url }}"
                          alt="{{ post.thumbnail.alt_text }}">
                 </div>
             </div>

--- a/_lib/wordpress_post_processor.py
+++ b/_lib/wordpress_post_processor.py
@@ -37,13 +37,13 @@ def process_post(post, newsroom = False):
         post['category'] = [cat['title'].replace('&amp;', '&') for cat in post['taxonomy_cfpb_newsroom_cat_taxonomy']]
     elif post['type'] == 'post':
         post['category'] = [cat['title'].replace('&amp;', '&') for cat in post['taxonomy_fj_category']]
-    if post['type'] == 'watchroom':
+    if post['type'] == 'featured_topic':
         post['author'] = [post['author']['name']]
-        # convert watchroom_data_x into a proper list
+        # convert featured_topic_data_x into a proper list
         links = []
         for x in xrange(0,10):
             custom_fields = post['custom_fields']
-            key = 'watchroom_data_%s_link' % x
+            key = 'featured_topic_data_%s_link' % x
             if key in custom_fields:
                 links.append(custom_fields[key])
         post['links'] = links

--- a/_queries/featured_topic.json
+++ b/_queries/featured_topic.json
@@ -1,0 +1,8 @@
+{
+  "name": "CFPB Featured Topic",
+  "query": {
+    "doc_type": "featured_topic",
+    "size": 10,
+    "sort": "date:desc"
+  }
+}

--- a/_queries/watchroom.json
+++ b/_queries/watchroom.json
@@ -1,8 +1,0 @@
-{
-  "name": "CFPB Watchroom",
-  "query": {
-    "doc_type": "watchroom",
-    "size": 10,
-    "sort": "date:desc"
-  }
-}

--- a/_settings/lookups.json
+++ b/_settings/lookups.json
@@ -19,9 +19,9 @@
     "type":      "posts",
     "permalink": true
   },
-  "watchroom": {
-    "url":       "/watchroom/<id>/",
-    "type":      "watchroom",
+  "featured_topic": {
+    "url":       "/featured_topic/<id>/",
+    "type":      "featured_topic",
     "permalink": true
   },
   "event_archive": {

--- a/_settings/processors.json
+++ b/_settings/processors.json
@@ -57,8 +57,8 @@
     "url":       "$WORDPRESS/api/get_posts/?post_type=view",
     "processor": "wordpress_view_processor"
   },
-  "watchroom": {
-    "url":       "$WORDPRESS/api/get_posts/?post_type=watchroom",
+  "featured_topic": {
+    "url":       "$WORDPRESS/api/get_posts/?post_type=featured_topic",
     "processor": "wordpress_post_processor",
     "mappings":  "_settings/posts_mappings.json"
   }

--- a/_tests/browser_testing/features/environment.py
+++ b/_tests/browser_testing/features/environment.py
@@ -103,12 +103,12 @@ def before_all(context):
 
     # Create the mappings
     create_mapping('newsroom', os.path.join(root, '_settings/posts_mappings.json'))
-    create_mapping('watchroom', os.path.join(root, '_settings/posts_mappings.json'))
+    create_mapping('featured_topic', os.path.join(root, '_settings/posts_mappings.json'))
 
     # Index the documents
     index_documents('newsroom', os.path.join(root, '_tests/browser_testing/fixtures/newsroom.json'))
     index_documents('views', os.path.join(root, '_tests/browser_testing/fixtures/views.json'))
-    index_documents('watchroom', os.path.join(root, '_tests/browser_testing/fixtures/watchroom.json'))
+    index_documents('featured_topic', os.path.join(root, '_tests/browser_testing/fixtures/featured_topic.json'))
 
     
     

--- a/_tests/browser_testing/fixtures/featured_topic.json
+++ b/_tests/browser_testing/fixtures/featured_topic.json
@@ -18,15 +18,15 @@
   "excerpt": "<p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat [&hellip;]</p>\n",
   "id": 62449,
   "custom_fields": {
-    "watchroom_data_2": [
+    "featured_topic_data_2": [
       "http://www.facebook.com",
       "Facebook"
     ],
-    "watchroom_data_0": [
+    "featured_topic_data_0": [
       "http://www.google.com",
       "Google"
     ],
-    "watchroom_data_1": [
+    "featured_topic_data_1": [
       "http://www.yahoo.com",
       "Yahoo"
     ]
@@ -37,18 +37,18 @@
   "content": "<p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>\n",
   "comment_count": 0,
   "categories": [],
-  "type": "watchroom",
+  "type": "featured_topic",
   "status": "publish",
   "parent": 0,
   "tags": [],
   "date": "2014-07-28T16:19:46Z",
-  "slug": "who-watches-the-watchroom",
+  "slug": "who-watches-the-featured_topic",
   "comment_status": "closed",
-  "title_plain": "Who watches the watchroom",
-  "title": "Who watches the watchroom",
+  "title_plain": "Who watches the Featured Topic",
+  "title": "Who watches the Featured Topic",
   "modified": "2014-08-13 13:36:30",
   "dek": "",
-  "_id": "who-watches-the-watchroom",
+  "_id": "who-watches-the-featured_topic",
   "order": 0
 }
 ]

--- a/_tests/processor_tests/tests/test_wordpress_orgmember_processor.py
+++ b/_tests/processor_tests/tests/test_wordpress_orgmember_processor.py
@@ -27,7 +27,7 @@ class WordpressOrgmemberProcessorTestCase(unittest.TestCase):
                                     'test_wordpress_orgmember_processor.json')).read()
         mock_requests_get.return_value = mock_response
 
-        name = 'featured_topic'
+        name = 'orgmember'
         url = 'http://mockmockmock/api/get_posts/?post_type=orgmember'
 
         documents = list(wordpress_orgmember_processor.documents(name, url))

--- a/_tests/processor_tests/tests/test_wordpress_orgmember_processor.py
+++ b/_tests/processor_tests/tests/test_wordpress_orgmember_processor.py
@@ -27,7 +27,7 @@ class WordpressOrgmemberProcessorTestCase(unittest.TestCase):
                                     'test_wordpress_orgmember_processor.json')).read()
         mock_requests_get.return_value = mock_response
 
-        name = 'watchroom'
+        name = 'featured_topic'
         url = 'http://mockmockmock/api/get_posts/?post_type=orgmember'
 
         documents = list(wordpress_orgmember_processor.documents(name, url))

--- a/_tests/processor_tests/tests/test_wordpress_post_processor.py
+++ b/_tests/processor_tests/tests/test_wordpress_post_processor.py
@@ -16,7 +16,7 @@ class WordpressPostProcessorTestCase(unittest.TestCase):
     It is currently used for the types:
         post
         newsroom
-        watchroom
+        featured_topic
 
     This doesn't unittest individual functions within the module. It
     tests the `documents()` function, which is what Sheer calls, and
@@ -25,14 +25,14 @@ class WordpressPostProcessorTestCase(unittest.TestCase):
 
     @mock.patch('requests.get')
     def test_watchrooom(self, mock_requests_get):
-        # /api/get_posts/?post_type=watchroom
+        # /api/get_posts/?post_type=featured_topic
         mock_response = mock.Mock()
         mock_response.content = open(os.path.join(os.path.dirname(__file__),
-                                    'test_wordpress_post_processor_watchroom.json')).read()
+                                    'test_wordpress_post_processor_featured_topic.json')).read()
         mock_requests_get.return_value = mock_response
 
-        name = 'watchroom'
-        url = 'http://mockmockmock/api/get_posts/?post_type=watchroom'
+        name = 'featured_topic'
+        url = 'http://mockmockmock/api/get_posts/?post_type=featured_topic'
 
         documents = list(wordpress_post_processor.documents(name, url))
         document = documents[0]

--- a/_tests/processor_tests/tests/test_wordpress_post_processor_featured_topic.json
+++ b/_tests/processor_tests/tests/test_wordpress_post_processor_featured_topic.json
@@ -8,43 +8,43 @@
             "excerpt": "<p>Lorem ipsum dolor sit amet</p>\n", 
             "id": 1, 
             "custom_fields": {
-                "watchroom_data_0_link": [
+                "featured_topic_data_0_link": [
                     "http://somewhere/", 
                     "Testing a first link"
                 ], 
-                "watchroom_data_1_link": [
+                "featured_topic_data_1_link": [
                     "http://somewhere/", 
                     "Testing a second link"
                 ], 
-                "watchroom_data_2_link": [
+                "featured_topic_data_2_link": [
                     "http://somewhere/", 
                     "Testing a third link"
                 ],
-                "watchroom_data_3_link": [
+                "featured_topic_data_3_link": [
                     "http://somewhere/", 
                     "Testing a fourth link"
                 ],
-                "watchroom_data_4_link": [
+                "featured_topic_data_4_link": [
                     "http://somewhere/", 
                     "Testing a fifth link"
                 ],
-                "watchroom_data_5_link": [
+                "featured_topic_data_5_link": [
                     "http://somewhere/", 
                     "Testing a sixth link"
                 ],
-                "watchroom_data_6_link": [
+                "featured_topic_data_6_link": [
                     "http://somewhere/", 
                     "Testing a seventh link"
                 ],
-                "watchroom_data_7_link": [
+                "featured_topic_data_7_link": [
                     "http://somewhere/", 
                     "Testing a eighth link"
                 ],
-                "watchroom_data_8_link": [
+                "featured_topic_data_8_link": [
                     "http://somewhere/", 
                     "Testing a ninth link"
                 ],
-                "watchroom_data_9_link": [
+                "featured_topic_data_9_link": [
                     "http://somewhere/", 
                     "Testing a tenth link"
                 ]
@@ -63,16 +63,16 @@
             "content": "<p>Lorem ipsum dolor sit amet</p>\n", 
             "comment_count": 0, 
             "categories": [], 
-            "type": "watchroom", 
+            "type": "featured_topic", 
             "status": "publish", 
             "parent": 0, 
             "tags": [], 
             "date": "2014-07-28 16:19:46", 
-            "slug": "who-watches-the-watchroom", 
+            "slug": "who-watches-the-featured_topic", 
             "comment_status": "closed", 
-            "title_plain": "Who Watches the Watchroom?", 
-            "url": "http://somewhere/watchroom/who-watches-the-watchroom/", 
-            "title": "Who Watches the Watchroom?", 
+            "title_plain": "Who Watches the Featured Topic?", 
+            "url": "http://somewhere/featured_topic/who-watches-the-featured_topic/", 
+            "title": "Who Watches the Featured Topic?", 
             "modified": "2014-08-13 13:36:30", 
             "dek": "", 
             "order": 0
@@ -80,7 +80,7 @@
     ], 
     "query": {
         "count": "-1", 
-        "post_type": "watchroom", 
+        "post_type": "featured_topic", 
         "page": "1", 
         "ignore_sticky_posts": true
     }, 

--- a/newsroom/index.html
+++ b/newsroom/index.html
@@ -20,7 +20,7 @@
 
     {# Get the latest Featured Topic #}
     {% import "featured-topic.html" as featured_topics %}
-    {{ featured_topics.render(queries.watchroom.search_with_url_arguments(size=1)) }}
+    {{ featured_topics.render(queries.featured_topic.search_with_url_arguments(size=1)) }}
 
     {# Set the filters #}
     {% from "post-macros.html" import filters as filters with context %}


### PR DESCRIPTION
This changes the name of "Watchroom" to "Featured Topic" to make it clear to the content editors what they are editing. The changes correspond to the Newsroom page where the latest "Featured Topic" is displayed at the top. 

This PR also corresponds to a change in the flapjack plugin that holds the post type and metabox. Both do renaming and should be reviewed/approved simultaneously. 

@dpford @willbarton @Scotchester @jimmynotjim @anselmbradford 

I can't find Steven's username. If someone could tag him that would be great.