### PR TITLE
Added full width button modifier

### DIFF
--- a/contact-us/contact-list.html
+++ b/contact-us/contact-list.html
@@ -22,7 +22,7 @@
                 <button class="js-type-and-filter_button btn btn__super">Filter</button>
             </div>
         </div>
-        
+
         <div class="helpful-terms">
             <span class="helpful-terms_header">Helpful filter terms:</span>
             <button class="btn btn__link js-helpful-term">Regulations</button>
@@ -33,7 +33,7 @@
 
         <p class="type-and-filter_message js-type-and-filter_message"></p>
 
-        <button class="btn btn__super btn__secondary u-js-only contact-list_btn"
+        <button class="btn btn__super btn__secondary btn__full u-js-only contact-list_btn"
                 id="contact-list_btn">
             Show all contacts
         </button>

--- a/static/css/cf-enhancements.less
+++ b/static/css/cf-enhancements.less
@@ -660,3 +660,34 @@ tbody {
     name: EOF
     eof: true
 */
+
+
+/* topdoc
+  name: Full Width Buttons
+  family: cf-enhancements
+  notes:
+    - "Modifier to buttons full width at small screen sizes"
+  patterns:
+    - name: Default example
+      markup: |
+        <btn class="btn btn__full">Button Text</btn>
+  tags:
+    - cf-buttons
+*/
+
+.btn__full {
+
+    .respond-to-max(599px , {
+        display: block;
+        width: 100%;
+
+        + .btn__full {
+            margin-left: initial;
+        }
+    });
+}
+
+/* topdoc
+    name: EOF
+    eof: true
+*/

--- a/static/css/contact-us.less
+++ b/static/css/contact-us.less
@@ -37,7 +37,6 @@
 }
 
 .contact-list_btn {
-    width: 100%;
     margin: unit(30px / @super-btn-font-size, em) 0;
     .respond-to-min(801px, {
         display: none;


### PR DESCRIPTION
Added full width button modifier for buttons on smaller screens
 
## Additions
 
- added `btn__full` modifier to CF Enhancements
 
## Removals
 
- removed set width on `contact-list_btn`
 
## Changes
 
- added `btn__full` class to "show all" button

## Testing
 
- navigate to /contact-us and test "show all" button
 
## Review
 
- @anselmbradford 
- @sebworks 

## Preview
 
![screen shot 2015-04-02 at 11 09 26 am](https://cloud.githubusercontent.com/assets/1280430/6966709/fced72e2-d928-11e4-96bb-508b0946a420.png)

## Notes
 
- useful for small screens where a button should fill the space left to right
- added to cf-enhancements for testing purposes, should be integrated with cf-buttons in the future