### PR TITLE
Fixing the related links module on /newsroom

### DIFF
--- a/newsroom/index.html
+++ b/newsroom/index.html
@@ -1,6 +1,5 @@
 {% extends "layout-side-nav.html" %}
 {% import "_vars-newsroom.html" as vars with context %}
-{% set view = get_document('views', 'newsroom') %}
 
 {% block title -%}
     Newsroom
@@ -58,7 +57,16 @@
             <div class="content-l content-l__main">
                 <section class="block u-mt0 content-l_col content-l_col-1-2">
                     {% import "related-links.html" as related_links %}
-                    {{ related_links.render(view.related_links) }}
+                    {{- related_links.render([
+                        [
+                            '/blog/',
+                            'The blog'
+                        ],
+                        [
+                            '/the-bureau/',
+                            'About us'
+                        ]
+                    ]) -}}
                 </section>
                 <section class="block content-l_col content-l_col-1-2">
                     {% include "upcoming-events.html" %}


### PR DESCRIPTION
Fixed the related links module by replacing the WP `view` with a manual list of links
 
## Additions
 
- none
 
## Removals
 
- removed unnecessary `view` var
 
## Changes
 
- created a manual list of related links in `/newsroom`

## Testing
 
- navigate to `/newsroom` and check the related links at the bottom of the page
 
## Review
 
- @duelj 
- @anselmbradford 
- @sebworks 
 
## Preview
 
![screen shot 2015-04-03 at 10 30 11 am](https://cloud.githubusercontent.com/assets/1280430/6983480/70fbbfe0-d9ec-11e4-856a-14782f33378d.png)

## Notes
 
- temporarily using a static list of links. BEWDs will need to update the data returned by the `view` to pull in the related links from WP