### PR TITLE
DF-1436_Privacy_page

### DIFF
--- a/_includes/email-subscribe-form.html
+++ b/_includes/email-subscribe-form.html
@@ -17,6 +17,11 @@
                name="email"
                placeholder="example@mail.com">
     </div>
+    <p class="short-desc u-mt10">
+      The information you provide will permit the Consumer Financial 
+      Protection Bureau to process your request or inquiry.
+      <a href="/privacy-policy">See More</a>
+    </p>
     {# Uncomment this and remove condition to test
     {% if 'is_event' %}
     <div class="form-group reveal-on-focus_content u-clearfix">

--- a/privacy-policy/_vars-privacy-policy.html
+++ b/privacy-policy/_vars-privacy-policy.html
@@ -1,0 +1,7 @@
+
+{% set path = '/privacy-policy/' %}
+{% set rss_path = '/feed/privacy-policy/' %}
+{% set nav_items = [
+    (path, 'index', 'Privacy Act Statement')
+] %}
+

--- a/privacy-policy/index.html
+++ b/privacy-policy/index.html
@@ -1,0 +1,46 @@
+{% extends "layout-side-nav.html" %}
+{% import "_vars-privacy-policy.html" as vars with context %}
+
+{# TODO: Remove and replace with Privacy View #}
+{% set view = get_document('views', 'newsroom') %}
+
+{% block title -%}
+    Privacy policy
+{%- endblock %}
+
+{% block desc -%}
+    Privacy policy
+{%- endblock %}
+
+{% block content_main_modifiers -%}
+    {{ super() }} content__flush-bottom
+{%- endblock %}
+
+{% block content_main %}
+    <h1>Privacy Act Statement</h1>
+    <h2>5 U.S.C. 552(a)(e)(3)</h2>
+    <p class="h3">The information you provide will permit the Consumer Financial Protection Bureau to process
+        your request or inquiry. Information about your request or inquiry (including your personally
+        identifiable information) may be shared pursuant to the CFPB’s published Privacy Act system
+        of records notice CFPB.013 CFPB External Contact Database.
+    </p>
+    <p class="h3">
+        This collection of information is authorized by 12 U.S.C. § 5491, 5492, or 5511.
+    </p>
+    <p class="h3">Your submission of information is entirely voluntary. You are not required to submit any
+        information. However, if you do not submit the requested information, the CFPB may not be
+        able to process your request or inquiry.
+    </p>
+
+    {# Footer #}
+    <aside>
+        <div class="block u-mb0 block__flush-sides block__bg related_content">
+            <div class="content-l content-l__main">
+                <section class="block u-mt0 content-l_col content-l_col-1-2">
+                    {% import "related-links.html" as related_links %}
+                    {{ related_links.render(view.related_links) }}
+                </section>
+            </div>
+        </div>
+    </aside>
+{% endblock %}


### PR DESCRIPTION
Include privacy statement next to email sign-up fields 
## Changes
 
- Updated ' _includes/email-subscribe-form.html' to include privacy act copy.
- Added  'privacy-policy/_vars-privacy-policy.html' to include privacy navigation.
- Added 'privacy-policy/index.html' to add privacy page.


## Notes
- This hasn't been seen or vetted by the design team so will need to show in Design Review for approval.

## Review
 
- @jimmynotjim  
- @anselmbradford 
- @duelj 
- @juidai 

## Preview
 
![screen shot 2015-04-06 at 10 03 14 am](https://cloud.githubusercontent.com/assets/1696212/7005479/3e14e29e-dc46-11e4-86b4-a09f98d16973.png)

![screen shot 2015-04-06 at 10 02 59 am](https://cloud.githubusercontent.com/assets/1696212/7005480/3e1a2092-dc46-11e4-85c1-79dac17e1ca9.png)

![screen shot 2015-04-06 at 10 02 41 am](https://cloud.githubusercontent.com/assets/1696212/7005481/3e1d5ff0-dc46-11e4-9aa8-b618d419ad55.png)


