### PR TITLE
Moves installation instructions to INSTALL.md

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -19,6 +19,27 @@ $ pip install git+git://github.com/dpford/flask-govdelivery
 $ pip install git+git://github.com/rosskarchner/govdelivery
 ```
 
+#### Back-end environment variables
+
+The project needs a number of environment variables.
+The project uses a WordPress API URL to pull in content
+and GovDelivery for running the subscription forms:
+
+- `WORDPRESS` (URL to WordPress install)
+- `GOVDELIVERY_BASE_URL`
+- `GOVDELIVERY_ACCOUNT_CODE` (GovDelivery account variable)
+- `GOVDELIVERY_USER` (GovDelivery account variable)
+- `GOVDELIVERY_PASSWORD` (GovDelivery account variable)
+- `SUBSCRIPTION_SUCCESS_URL` (Forwarding location on Subscription Success)
+
+> You can also export the above environment variables to your `.bash_profile`,
+or use your favorite alternative method of setting environment variables.
+
+**NOTE:** GovDelivery is a third-party web service that powers our subscription forms.
+Users may decide to swap this tool out for another third-party service.
+The application will function but throw an error if the above GovDelivery values are not set.
+
+
 ### 2. Front-end setup
 
 The cfgov-refresh front-end currently uses the following frameworks / tools:

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -78,15 +78,6 @@ $ npm install
 $ grunt vendor
 ```
 
-# 4. Updating all dependencies
-
-Each time you fetch from the upstream repository (this repo),
-you should install and update dependencies with npm and `grunt vendor`,
-and then run `grunt` to rebuild all the site's assets:
-
-```bash
-$ npm install
-$ npm update
-$ grunt vendor
-$ grunt
-```
+> Note: You might also need to rebuild all the site's assets by
+  running `grunt`. See the usage section
+  [updating all the project dependencies](README.md#updating-all-dependencies).

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,0 +1,71 @@
+### 1. Back-end setup
+
+Follow the [Sheer installation instructions](https://github.com/cfpb/sheer#installation)
+to get Sheer installed.
+**NOTE:** We suggest creating a virtualenv variable specific to this project,
+such as `cfgov-refresh` instead of `sheer` used in the Sheer installation instructions:
+
+```bash
+$ mkvirtualenv cfgov-refresh
+```
+
+Install the following dependencies into your virtual environment.
+We called ours `cfgov-refresh` (see previous step above):
+
+```bash
+$ workon cfgov-refresh
+
+$ pip install git+git://github.com/dpford/flask-govdelivery
+$ pip install git+git://github.com/rosskarchner/govdelivery
+```
+
+### 2. Front-end setup
+
+The cfgov-refresh front-end currently uses the following frameworks / tools:
+
+- [Grunt](http://gruntjs.com): task management for pulling in assets,
+  linting and concatenating code, etc.
+- [Bower](http://bower.io): Package manager for front-end dependencies.
+- [Less](http://lesscss.org): CSS pre-processor.
+- [Capital Framework](https://cfpb.github.io/capital-framework/getting-started):
+  User interface pattern-library produced by the CFPB.
+
+**NOTE:** If you're new to Capital Framework, we encourage you to
+[start here](https://cfpb.github.io/capital-framework/getting-started).
+
+1. Install [Node.js](http://nodejs.org) however you'd like.
+2. Install [Grunt](http://gruntjs.com) and [Bower](http://bower.io):
+
+```bash
+$ npm install -g grunt-cli bower
+```
+
+### 3. Clone project and install dependencies
+
+Using the console, navigate to your project directory (`cd ~/Projects` or equivalent).
+Clone this project's repository and switch to it's directory with:
+
+```bash
+$ git clone git@github.com:cfpb/cfgov-refresh.git
+$ cd cfgov-refresh
+```
+
+Next, install dependencies with:
+
+```bash
+$ npm install
+$ grunt vendor
+```
+
+### 4. Updating all dependencies
+
+Each time you fetch from the upstream repository (this repo),
+you should install and update dependencies with npm and `grunt vendor`,
+and then run `grunt` to rebuild all the site's assets:
+
+```bash
+$ npm install
+$ npm update
+$ grunt vendor
+$ grunt
+```

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -78,6 +78,7 @@ $ npm install
 $ grunt vendor
 ```
 
-> Note: You might also need to rebuild all the site's assets by
-  running `grunt`. See the usage section
-  [updating all the project dependencies](README.md#updating-all-dependencies).
+> Note: After installing dependencies,
+rebuild all the site's assets by running `grunt`.
+See the usage section
+[updating all the project dependencies](README.md#updating-all-dependencies).

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,4 +1,4 @@
-### 1. Back-end setup
+# 1. Back-end setup
 
 Follow the [Sheer installation instructions](https://github.com/cfpb/sheer#installation)
 to get Sheer installed.
@@ -19,7 +19,7 @@ $ pip install git+git://github.com/dpford/flask-govdelivery
 $ pip install git+git://github.com/rosskarchner/govdelivery
 ```
 
-#### Back-end environment variables
+## Back-end environment variables
 
 The project needs a number of environment variables.
 The project uses a WordPress API URL to pull in content
@@ -40,7 +40,7 @@ Users may decide to swap this tool out for another third-party service.
 The application will function but throw an error if the above GovDelivery values are not set.
 
 
-### 2. Front-end setup
+# 2. Front-end setup
 
 The cfgov-refresh front-end currently uses the following frameworks / tools:
 
@@ -61,7 +61,7 @@ The cfgov-refresh front-end currently uses the following frameworks / tools:
 $ npm install -g grunt-cli bower
 ```
 
-### 3. Clone project and install dependencies
+# 3. Clone project and install dependencies
 
 Using the console, navigate to your project directory (`cd ~/Projects` or equivalent).
 Clone this project's repository and switch to it's directory with:
@@ -78,7 +78,7 @@ $ npm install
 $ grunt vendor
 ```
 
-### 4. Updating all dependencies
+# 4. Updating all dependencies
 
 Each time you fetch from the upstream repository (this repo),
 you should install and update dependencies with npm and `grunt vendor`,

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Follow the instructions in [INSTALL](INSTALL.md).
 
 ## Configuration
 
-For necessary server-side configurations, follow instructions in [Back-end-environment-variables](INSTALL.md#back-end-environment-variables).
+For necessary server-side configurations, follow instructions in [Back-end environment variables](INSTALL.md#back-end-environment-variables).
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -24,52 +24,12 @@ or wiki—is a final product unless it is marked as such or appears on consumerf
   Sheer is a Jekyll-inspired, Elasticsearch-powered, CMS-less publishing tool.
 - [Elasticsearch](http://www.elasticsearch.org):
   Used for full-text search capabilities and content indexing.
-- [Node](http://nodejs.org) and NPM (Node Project Manager):
+- [Node](http://nodejs.org) and npm (Node Package Manager):
   Used for downloading and managing front-end dependencies and assets.
 
 ## Installation
 
-#### 1. Back-end setup
-
-Follow the [Sheer installation instructions](https://github.com/cfpb/sheer#installation)
-to get Sheer installed.
-**NOTE:** We suggest creating a virtualenv variable specific to this project,
-such as `cfgov-refresh` instead of `sheer` used in the Sheer installation instructions:
-
-```bash
-$ mkvirtualenv cfgov-refresh
-```
-
-Install the following dependencies into your virtual environment.
-We called ours `cfgov-refresh` (see previous step above):
-
-```bash
-$ workon cfgov-refresh
-
-$ pip install git+git://github.com/dpford/flask-govdelivery
-$ pip install git+git://github.com/rosskarchner/govdelivery
-```
-
-#### 2. Front-end setup
-
-The cfgov-refresh front-end currently uses the following frameworks / tools:
-
-- [Grunt](http://gruntjs.com): task management for pulling in assets,
-  linting and concatenating code, etc.
-- [Bower](http://bower.io): Package manager for front-end dependencies.
-- [Less](http://lesscss.org): CSS pre-processor.
-- [Capital Framework](https://cfpb.github.io/capital-framework/getting-started):
-  User interface pattern-library produced by the CFPB.
-
-**NOTE:** If you're new to Capital Framework, we encourage you to
-[start here](https://cfpb.github.io/capital-framework/getting-started).
-
-1. Install [Node.js](http://nodejs.org) however you'd like.
-2. Install [Grunt](http://gruntjs.com) and [Bower](http://bower.io):
-
-```bash
-$ npm install -g grunt-cli bower
-```
+Follow the instructions in [INSTALL](INSTALL.md).
 
 ## Configuration
 
@@ -93,35 +53,34 @@ The application will function but throw an error if the above GovDelivery values
 
 ## Usage
 
-Generally you will have four tabs (or windows) open in your terminal when using this project.
+Generally you will have four tabs (or windows)
+open in your terminal when using this project.
 These will be used for:
- 1. **Git operations**. Perform git operations and general development in the repository.
- 2. **Elasticsearch**. Run Elasticsearch instance.
- 3. **Sheer web server**. Run the web server.
- 4. **Grunt watch**. Run Grunt watch task for watching for changes to content.
+ 1. **Git operations**.
+    Perform git operations and general development in the repository.
+ 2. **Elasticsearch**.
+    Run an Elasticsearch instance.
+ 3. **Sheer web server**.
+    Run the web server.
+ 4. **Grunt watch**.
+    Run the Grunt watch task for watching for changes to content.
 
 What follows are the specific steps for each of these tabs.
 
-### 1. Clone project and pull in latest updates
+### 1. Git operations
 
-Using Terminal, navigate to your project directory (`cd ~/Projects` or equivalent).
-Clone the project with:
-
-```bash
-$ git clone git@github.com:cfpb/cfgov-refresh.git
-$ cd cfgov-refresh
-```
-
-Each time you fetch from the upstream repository (this repo),
-you should install dependencies with NPM and `grunt vendor`,
-then run `grunt` to rebuild everything:
+From this tab you can do git operations,
+such as checking out our different branches:
 
 ```bash
-$ npm install
-$ npm update
-$ grunt vendor
-$ grunt
+$ git checkout flapjack # Branch for our staging-development server.
+$ git checkout refresh  # Branch for our staging-stable server.
+$ git checkout beta     # Branch for our production-stable server.
 ```
+
+> Note: You might also use this tab to rebuild all the site's assets by
+  running `grunt`. See the installation section on
+  [updating all the project dependencies](INSTALL.md#4-updating-all-dependencies).
 
 ### 2. Run Elasticsearch
 
@@ -151,8 +110,8 @@ To work on the app you will need Sheer running to compile the templates.
 To do this, run the following:
 
 ```bash
-# Use the sheer virtualenv.
-$ workon sheer
+# Use the cfgov-refresh virtualenv.
+$ workon cfgov-refresh
 
 # Index the latest content from the API output from a WordPress and Django back-end.
 $ sheer index
@@ -173,7 +132,7 @@ To view the indexed content you can use a tool called
 serve Sheer with the `--port` argument,
 e.g. to run on port 7001 use `sheer serve --port 7001 --debug`.
 
-### 4. Launch Grunt watch task
+### 4. Launch the Grunt watch task
 
 To watch for changes in the source code and automatically update the running site,
 open a terminal and run:

--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ $ grunt
 
 ### 2. Run Elasticsearch
 
+> Note: This Elasticsearch tab (or window) might not be necessary if you set Elasticsearch to start at login when [installing Sheer](https://github.com/cfpb/sheer#installation).
+
 To launch Elasticsearch, first find out where your Elasticsearch config file is located.
 You can do this with [Homebrew](http://brew.sh) using:
 
@@ -96,8 +98,6 @@ $ elasticsearch --config=/Users/[YOUR MAC OSX USERNAME]/homebrew/opt/elasticsear
   ```
   $ alias elsup="elasticsearch --config=/Users/[MAC OSX USERNAME]/homebrew/opt/elasticsearch/config/elasticsearch.yml"
   ```
-
-> Note: This Elasticsearch tab (or window) might not be necessary if you set Elasticsearch to start at login when [installing Sheer](https://github.com/cfpb/sheer#installation).
 
 
 ### 3. Launch Sheer to serve the site

--- a/README.md
+++ b/README.md
@@ -62,9 +62,19 @@ $ git checkout refresh  # Branch for our staging-stable server.
 $ git checkout beta     # Branch for our production-stable server.
 ```
 
-> Note: You might also use this tab to rebuild all the site's assets by
-  running `grunt`. See the installation section on
-  [updating all the project dependencies](INSTALL.md#4-updating-all-dependencies).
+#### Updating all dependencies
+
+Each time you fetch from the upstream repository (this repo),
+you should install and update dependencies with npm and `grunt vendor`,
+and then run `grunt` to rebuild all the site's assets:
+
+```bash
+$ npm install
+$ npm update
+$ grunt vendor
+$ grunt
+```
+
 
 ### 2. Run Elasticsearch
 

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ with the proper path to its configuration file. For example, it may look like:
 $ elasticsearch --config=/Users/[YOUR MAC OSX USERNAME]/homebrew/opt/elasticsearch/config/elasticsearch.yml
 ```
 
-> You can add the following to your `.bash_profile` that will allow launching of Elasticsearch with the `elsup` command:
+> Note: You can add the following to your `.bash_profile` that will allow launching of Elasticsearch with the `elsup` command:
   ```
   $ alias elsup="elasticsearch --config=/Users/[MAC OSX USERNAME]/homebrew/opt/elasticsearch/config/elasticsearch.yml"
   ```

--- a/README.md
+++ b/README.md
@@ -33,23 +33,7 @@ Follow the instructions in [INSTALL](INSTALL.md).
 
 ## Configuration
 
-The project needs a number of environment variables.
-The project uses a WordPress API URL to pull in content
-and GovDelivery for running the subscription forms:
-
-- `WORDPRESS`(URL to WordPress install)
-- `GOVDELIVERY_BASE_URL`
-- `GOVDELIVERY_ACCOUNT_CODE` (GovDelivery account variable)
-- `GOVDELIVERY_USER` (GovDelivery account variable)
-- `GOVDELIVERY_PASSWORD` (GovDelivery account variable)
-- `SUBSCRIPTION_SUCCESS_URL` (Forwarding location on Subscription Success)
-
-> You can also export the above environment variables to your `.bash_profile`,
-or use your favorite alternative method of setting environment variables.
-
-**NOTE:** GovDelivery is a third-party web service that powers our subscription forms.
-Users may decide to swap this tool out for another third-party service.
-The application will function but throw an error if the above GovDelivery values are not set.
+For necessary server-side configurations, follow instructions in [Back-end-environment-variables](INSTALL.md#Back-end-environment-variables).
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Follow the instructions in [INSTALL](INSTALL.md).
 
 ## Configuration
 
-For necessary server-side configurations, follow instructions in [Back-end-environment-variables](INSTALL.md#Back-end-environment-variables).
+For necessary server-side configurations, follow instructions in [Back-end-environment-variables](INSTALL.md#back-end-environment-variables).
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -97,6 +97,8 @@ $ elasticsearch --config=/Users/[YOUR MAC OSX USERNAME]/homebrew/opt/elasticsear
   $ alias elsup="elasticsearch --config=/Users/[MAC OSX USERNAME]/homebrew/opt/elasticsearch/config/elasticsearch.yml"
   ```
 
+> Note: This Elasticsearch tab (or window) might not be necessary if you set Elasticsearch to start at login when [installing Sheer](https://github.com/cfpb/sheer#installation).
+
 
 ### 3. Launch Sheer to serve the site
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Generally you will have four tabs (or windows)
 open in your terminal when using this project.
 These will be used for:
  1. **Git operations**.
-    Perform git operations and general development in the repository.
+    Perform Git operations and general development in the repository.
  2. **Elasticsearch**.
     Run an Elasticsearch instance.
  3. **Sheer web server**.
@@ -53,7 +53,7 @@ What follows are the specific steps for each of these tabs.
 
 ### 1. Git operations
 
-From this tab you can do git operations,
+From this tab you can do Git operations,
 such as checking out our different branches:
 
 ```bash


### PR DESCRIPTION
Moves installation instructions to INSTALL.md to de-clutter Readme.

## Additions

- Adds INSTALL.md

## Changes

- Moves installation instructions from Readme to INSTALL.md.
- Downcases `NPM` > `npm`, since that's how it's written on npmjs.org.
- Fixes misnamed `sheer` virtualenv.
- Misc. minor copy updates.

## Testing

- See that Readme and INSTALL.md order and content makes sense.

## Review

- @sebworks 
- @jimmynotjim 
et al