### PR TITLE
Eslint comments

### DIFF
--- a/_settings/eslint.yaml
+++ b/_settings/eslint.yaml
@@ -428,6 +428,7 @@ rules:
   key-spacing:
     - 2
     -
+      align: value
       beforeColon: false
       afterColon: true
 

--- a/_settings/eslint.yaml
+++ b/_settings/eslint.yaml
@@ -16,88 +16,87 @@ rules:
 
   # Rules for flagging POSSIBLE ERRORS.
 
-  # Disallow trailing commas in object literals.
+  # Consistent use of trailing commas in object and array literals.
   # This rule is needed for IE8- support.
   comma-dangle:
     - never
 
-  # Disallow assignment in conditional expressions.
-  # Unless they are enclosed in parentheses.
+  # Disallows assignment in conditional expressions.
   no-cond-assign:
     - 2
     - except-parens
 
-  # Warn of use of the console.
+  # Enforces flagging use of the console.
   no-console: 1
 
-  # Disallow use of constant expressions in conditions.
+  # Disallows use of constant expressions in conditions.
   no-constant-condition: 2
 
-  # Disallow control characters in regular expressions.
+  # Disallows control characters in regular expressions.
   no-control-regex: 2
 
-  # Disallow use of debugger.
+  # Enforces flagging use of the debugger.
   no-debugger: 2
 
-  # Disallow duplicate keys when creating object literals.
+  # Disallows duplicate keys when creating object literals.
   no-dupe-keys: 2
 
-  # Disallow empty statements.
+  # Disallows empty statements.
   no-empty: 2
 
-  # Disallow the use of empty character classes in regular expressions.
+  # Disallows use of empty character classes in regular expressions.
   no-empty-class: 2
 
-  # Disallow assigning to the exception in a catch block.
+  # Disallows assigning to the exception in a catch block.
   no-ex-assign: 2
 
-  # Disallow double-negation boolean casts in a boolean context.
+  # Disallows double-negation boolean casts in a boolean context.
   no-extra-boolean-cast: 2
 
-  # Warn about unnecessary parentheses.
+  # Disallows unnecessary parentheses.
   no-extra-parens: 1
 
-  # Disallow unnecessary semicolons.
+  # Disallows unnecessary semicolons.
   no-extra-semi: 2
 
-  # Disallow overwriting functions written as function declarations.
+  # Disallows overwriting functions written as declarations.
   no-func-assign: 2
 
-  # Disallow function declarations in nested blocks.
+  # Disallows function declarations in nested blocks.
   no-inner-declarations:
     - 2
     - functions
 
-  # Disallow invalid regular expression strings in the RegExp constructor.
+  # Disallows invalid regex strings in the RegExp constructor.
   no-invalid-regexp: 2
 
-  # Disallow irregular whitespace outside of strings and comments.
+  # Disallows irregular whitespace outside of strings and comments.
   no-irregular-whitespace: 2
 
-  # Disallow negation of the left operand of an in expression.
+  # Disallows negation of the left operand of an in expression.
   no-negated-in-lhs: 2
 
-  # Disallow the use of the global Math and JSON objects as functions.
+  # Disallows use of the global Math and JSON objects as functions.
   no-obj-calls: 2
 
-  # Disallow multiple spaces in a regular expression literal.
+  # Disallows multiple spaces in a regular expression literal.
   no-regex-spaces: 2
 
-  # Disallow reserved words being used as object literal keys.
+  # Disallows reserved words being used as object literal keys.
   # Unneeded in ECMAScript 5+ environments.
   no-reserved-keys: 2
 
-  # Disallow sparse arrays. Array values should be explicitly defined.
+  # Disallows sparse arrays.
+  # Array values should be explicitly defined.
   no-sparse-arrays: 2
 
-  # Disallow unreachable statements after a return, throw, continue, or break.
+  # Disallows unreachable statements after a return, throw, continue, or break.
   no-unreachable: 2
 
-  # Disallow comparisons with the value NaN.
+  # Disallows comparisons with the value NaN.
   use-isnan: 2
 
-  # Ensure JSDoc comments are valid.
-  # Prefer @returns syntax over @return.
+  # Enforces valid JSDoc parameters and return types comments.
   valid-jsdoc:
     - 2
     -
@@ -107,36 +106,32 @@ rules:
       requireParamDescription: true
       requireReturnDescription: true
 
-  # Ensure that the results of typeof are compared against a valid string.
+  # Enforces that the results of typeof are compared against a valid string.
   valid-typeof: 2
 
 
   # Rules for encouraging BEST PRACTICES.
 
-  # Treat var statements as if they were block scoped.
-  # Warn if used outside of binding context.
+  # Enforces treating var statements as if they were block scoped.
   block-scoped-var: 1
 
-  # Specify the maximum cyclomatic complexity allowed in a program.
-  # Warn when maximum is exceeded.
+  # Enforces specific maximum cyclomatic complexity.
   complexity:
     - 1
     - 3
 
-  # Require return statements to either always or never specify values.
+  # Enforces return statements to either always or never specify values.
   consistent-return: 2
 
-  # Specify curly brace conventions for all control statements.
-  # Same-line exclusion of braces is permitted.
+  # Enforces curly brace conventions for all control statements.
   curly:
     - 1
     - multi-line
 
-  # Require default case in switch statements.
-  # Include `// no default` at end of the statement if there is no default.
+  # Enforces default case in switch statements.
   default-case: 2
 
-  # Encourages use of dot notation whenever possible.
+  # Enforces use of dot notation whenever possible.
   # `allowKeywords` = false follows ECMAScript version 3 compatible style.
   dot-notation:
     - 2
@@ -144,63 +139,63 @@ rules:
       allowKeywords: false
       allowPattern: ''
 
-  # Require the use of === and !==.
+  # Enforces use of === and !== over == and !=.
   eqeqeq:
      - 2
      - smart
 
-  # Warn whether for-in loops are missing an if statement.
+  # Enforces necessary if statements in for-in loops.
   guard-for-in: 1
 
-  # Disallow the use of alert, confirm, and prompt.
+  # Disallows use of alert, confirm, and prompt.
   no-alert: 2
 
-  # Disallow use of arguments.caller or arguments.callee.
+  # Disallows use of arguments.caller or arguments.callee.
   no-caller: 2
 
-  # Disallow division operators explicitly at beginning of regular expression.
+  # Disallows division operators explicitly at beginning of regex.
   no-div-regex: 2
 
-  # Disallow else after a return in an if.
+  # Disallows else after a return in an if.
   no-else-return: 2
 
-  # Disallow use of labels for anything other then loops and switches.
+  # Disallows use of labels, other than in loops and switches.
   no-empty-label: 2
 
-  # Disallow comparisons to null without a type-checking operator.
+  # Disallows comparisons to null without a type-checking operator.
   no-eq-null: 2
 
-  # Disallow use of eval().
+  # Disallows use of eval().
   no-eval: 2
 
-  # Disallow adding to native types.
+  # Disallows adding to native types.
   no-extend-native: 2
 
-  # Disallow unnecessary function binding.
+  # Disallows unnecessary function binding.
   no-extra-bind: 2
 
-  # Warn for fallthrough of case statements.
+  # Disallows fallthrough of case statements.
   no-fallthrough: 1
 
-  # Disallow the use of leading or trailing decimal points in numeric literals.
+  # Disallows use of leading or trailing decimal points in numeric literals.
   no-floating-decimal: 2
 
-  # Disallow use of eval()-like methods.
+  # Disallows use of eval()-like methods.
   no-implied-eval: 2
 
-  # Disallow usage of __iterator__ property.
+  # Disallows usage of __iterator__ property.
   no-iterator: 2
 
-  # Disallow use of labeled statements.
+  # Disallows use of labeled statements.
   no-labels: 2
 
-  # Disallow unnecessary nested blocks.
+  # Disallows unnecessary nested blocks.
   no-lone-blocks: 2
 
-  # Disallow creation of functions within loops.
+  # Disallows creation of functions within loops.
   no-loop-func: 2
 
-  # Disallow use of multiple spaces, except in property definitions.
+  # Disallows use of multiple spaces.
   no-multi-spaces:
     - 2
     -
@@ -208,60 +203,60 @@ rules:
         BinaryExpression: false
         Property: true
 
-  # Disallow use of multiline strings with a trailing backslash.
+  # Disallows use of multiline strings with a trailing backslash.
   # This rule is needed for ECMAScript environments earlier than 5.
   no-multi-str: 2
 
-  # Disallow reassignments of native objects.
+  # Disallows reassignments of native objects.
   no-native-reassign: 2
 
-  # Warn use of new operator when not part of the assignment or comparison.
+  # Disallows use of new operator when not part of the assignment or comparison.
   no-new: 1
 
-  # Disallow use of new operator for Function object.
+  # Disallows use of new operator for Function object.
   no-new-func: 2
 
   # Disallows creating new instances of String, Number, and Boolean.
   no-new-wrappers: 2
 
-  # Disallow use of octal literals.
+  # Disallows use of octal literals.
   no-octal: 2
 
-  # Disallow use of octal escape sequences in string literals, e.g. "\251".
+  # Disallows use of octal escape sequences in string literals, e.g. "\251".
   no-octal-escape: 2
 
-  # Disallow use of process.env.
+  # Disallows use of process.env.
   # Only applicable to Node.js.
   no-process-env: 2
 
-  # Disallow usage of __proto__ property.
+  # Disallows usage of __proto__ property.
   no-proto: 2
 
-  # Disallow declaring the same variable more then once.
+  # Disallows declaring the same variable more then once.
   no-redeclare: 2
 
-  # Disallow use of assignment in return statement.
+  # Disallows use of assignment in return statement.
   no-return-assign: 2
 
-  # Disallow use of javascript: urls.
+  # Disallows use of javascript: urls.
   no-script-url: 2
 
-  # Disallow comparisons where both sides are exactly the same.
+  # Disallows comparisons where both sides are exactly the same.
   no-self-compare: 2
 
-  # Warn about use of comma operator.
+  # Disallows use of comma operator.
   no-sequences: 1
 
   # Restrict what can be thrown as an exception.
   no-throw-literal: 2
 
-  # Disallow usage of expressions in statement position.
+  # Disallows usage of expressions in statement position.
   no-unused-expressions: 2
 
-  # Disallow use of void operator.
+  # Disallows use of void operator.
   no-void: 2
 
-  # Warn usage of configurable warning terms in comments, e. g. TODO.
+  # Disallows use of configurable warning terms in comments, e. g. TODO.
   no-warning-comments:
     - 1
     -
@@ -271,13 +266,13 @@ rules:
         - xxx
       location: start
 
-  # Disallow use of the with statement.
+  # Disallows use of the with statement.
   no-with: 2
 
   # Require use of the second argument for parseInt().
   radix: 2
 
-  # Don't require all vars on top of their containing scope.
+  # Require all vars on top of their containing scope.
   vars-on-top: 0
 
   # Require immediate function invocation to be wrapped in parentheses.
@@ -285,7 +280,7 @@ rules:
     - 2
     - inside
 
-  # Disallow Yoda conditions, except in ranges.
+  # Disallows Yoda conditions.
   yoda:
     - 2
     - never
@@ -306,40 +301,40 @@ rules:
 
   # Rules for VARIABLES.
 
-  # Disallow the catch clause parameter name being the same as a variable
+  # Disallows the catch clause parameter name being the same as a variable
   # in the outer scope.
   # This rule is needed for IE8- support.
   no-catch-shadow: 2
 
-  # Disallow deletion of variables.
+  # Disallows deletion of variables.
   no-delete-var: 2
 
-  # Disallow labels that share a name with a variable.
+  # Disallows labels that share a name with a variable.
   no-label-var: 2
 
-  # Warn when declaring variables already declared in the outer scope.
+  # Disallows declaring variables already declared in the outer scope.
   no-shadow: 1
 
-  # Disallow shadowing of names such as arguments.
+  # Disallows shadowing of names such as arguments.
   no-shadow-restricted-names: 2
 
-  # Disallow use of undeclared vars unless mentioned in a /*global */ block.
+  # Disallows use of undeclared vars unless mentioned in a /*global */ block.
   no-undef: 2
 
-  # Disallow use of undefined when initializing variables.
+  # Disallows use of undefined when initializing variables.
   no-undef-init: 2
 
-  # Disallow use of undefined variable.
+  # Disallows use of undefined variable.
   no-undefined: 2
 
-  # Warn when declaration of variables that are not used in the code.
+  # Disallows declaration of variables that are not used in the code.
   no-unused-vars:
     - 1
     -
       vars: all
       args: after-used
 
-  # Disallow use of variables before they are defined.
+  # Disallows use of variables before they are defined.
   no-use-before-define:
     - 2
     - nofunc
@@ -347,39 +342,38 @@ rules:
 
   # Rules for NODE.JS.
 
-  # Enforces error handling in callbacks.
+  # Enforce error handling in callbacks.
   # Matches any string that contains err or Err (err, error, anyError, an_err).
   handle-callback-err:
     - 2
     - ^.*(e|E)rr
 
-  # Warn mixing regular variable and require declarations.
+  # Disallows mixing regular variable and require declarations.
   # This rule may have inaccurate behavior in Node 0.6- and if UMD is used.
   no-mixed-requires:
     - 1
     - true
 
-  # Disallow use of new operator with the require function.
+  # Disallows use of new operator with the require function.
   no-new-require: 2
 
-  # Disallow string concatenation with __dirname and __filename.
+  # Disallows string concatenation with __dirname and __filename.
   no-path-concat: 2
 
-  # Warn on use of process.exit().
+  # Disallows use of process.exit().
   no-process-exit: 1
 
-  # Don't restrict usage of specific node modules.
+  # Restrict usage of specific node modules.
   no-restricted-modules: 0
 
-  # Disallow use of synchronous methods.
+  # Disallows use of synchronous methods.
   no-sync: 2
 
 
   # Rules for STYLISTIC ISSUES.
   # These rules are purely matters of style and are quite subjective.
 
-  # This option sets a specific tab width for your code.
-  # Enforces 4 spaces indention.
+  # Set a specific tab width for your code.
   indent:
     - 2
     - 4
@@ -393,7 +387,7 @@ rules:
     -
       allowSingleLine: true
 
-  # Warn about non-camel case names.
+  # Enforce camel case names.
   camelcase:
     - 1
     -
@@ -411,7 +405,7 @@ rules:
     - 2
     - last
 
-  # Allow any naming when capturing the current execution context.
+  # Enforce consistent naming when capturing the current execution context.
   # This should be turned on if ESLint supports a regex for the
   # matching value in the future for the ^[_]?self regex.
   consistent-this:
@@ -421,16 +415,16 @@ rules:
   # Enforce newline at the end of file, with no multiple empty lines.
   eol-last: 2
 
-  # Warn about function expressions not having a name.
+  # Enforce function expressions not having a name.
   func-names: 1
 
-  # Prefer function declarations because of variable hoisting behavior.
-  # Warn for use of function expressions.
+  # Enforce use of function declarations or expressions
+  # because of variable hoisting behavior.
   func-style:
     - 1
     - declaration
 
-  # Enforces spacing between keys and values in object literal properties.
+  # Enforce spacing between keys and values in object literal properties.
   key-spacing:
     - 2
     -
@@ -451,145 +445,145 @@ rules:
       newIsCapExceptions: []
       capIsNewExceptions: []
 
-  # Disallow omission of parentheses when invoking a constructor with no arguments.
+  # Disallows omission of parentheses when invoking a constructor with no arguments.
   new-parens: 2
 
-  # Disallow use of the Array constructor.
+  # Disallows use of the Array constructor.
   no-array-constructor: 2
 
-  # Warn comments inline after code.
+  # Disallows inline after code.
   no-inline-comments: 1
 
-  # Disallow if as the only statement in an else block.
+  # Disallows if as the only statement in an else block.
   no-lonely-if: 2
 
-  # Disallow mixed spaces and tabs for indentation.
+  # Disallows mixed spaces and tabs for indentation.
   # Include "smart-tabs" option to suppresses warnings tabs used for alignment.
   no-mixed-spaces-and-tabs: 2
 
-  # Warn when more than 2 blank lines are used.
+  # Disallows when more than 2 blank lines are used.
   no-multiple-empty-lines:
     - 1
     -
       max: 2
 
-  # Disallow nested ternary expressions.
+  # Disallows nested ternary expressions.
   no-nested-ternary: 2
 
-  # Disallow use of the Object constructor.
+  # Disallows use of the Object constructor.
   no-new-object: 2
 
-  # Disallow space between function identifier and invocation.
+  # Disallows space between function identifier and invocation.
   no-spaced-func: 2
 
-  # Allow the use of ternary operators.
+  # Disallows the use of ternary operators.
   no-ternary: 0
 
-  # Disallow trailing whitespace at the end of lines.
+  # Disallows trailing whitespace at the end of lines.
   no-trailing-spaces: 2
 
-  # Allow dangling underscores in identifiers.
+  # Disallows dangling underscores in identifiers.
   no-underscore-dangle: 0
 
-  # Disallow wrapping of non-IIFE statements in parens.
+  # Disallows wrapping of non-IIFE statements in parens.
   no-wrap-func: 2
 
-  # Allow multiple var statements per function.
+  # Disallows multiple var statements per function.
   one-var: 0
 
-  # Require assignment operator shorthand or prohibit it entirely.
+  # Requires assignment operator shorthand or prohibit it entirely.
   operator-assignment:
     - 2
     - always
 
-  # Don't enforce padding within blocks.
+  # Enforces padding within blocks.
   padded-blocks:
     - 0
     - always
 
-  # Warn about unnecessary quotes around object literal property names.
+  # Requires quotes around object literal property names.
   quote-props:
     - 1
     - as-needed
 
-  # Require single quotes, unless escaping quotes would be necessary.
+  # Specifies whether double or single quotes should be used.
   quotes:
     - 2
     - single
     - avoid-escape
 
-  # Require or disallow use of semicolons instead of ASI.
+  # Requires or disallows use of semicolons instead of ASI.
   semi:
     - 2
     - always
 
-  # Disallow space before semicolon.
+  # Disallows space before semicolon.
   semi-spacing:
     - 2
     -
       before: false
       after: true
 
-  # Don't enforce sorting variables within the same declaration block.
+  # Enforces sorting variables within the same declaration block.
   sort-vars: 0
 
-  # Require a space after certain keywords.
+  # Requires a space after certain keywords.
   space-after-keywords:
     - 2
     - always
 
-  # Require space before blocks.
+  # Requires space before blocks.
   space-before-blocks:
     - 2
     - always
 
-  # Warn about no space before function parentheses.
+  # Requires space before function parentheses.
   space-before-function-paren:
     - 1
     -
       anonymous: never
       named: never
 
-  # Warn about spaces inside brackets.
+  # Requires spaces inside brackets.
   space-in-brackets:
     - 1
     - always
 
-  # Warn about no spaces inside parentheses.
+  # Requires spaces inside parentheses.
   space-in-parens:
     - 1
     - never
 
-  # Require spaces around operators.
+  # Requires spaces around operators.
   space-infix-ops: 2
 
-  # Require a space after return, throw, and case.
+  # Requires a space after return, throw, and case.
   space-return-throw-case: 2
 
-  # Require spaces before/after unary operators.
+  # Requires spaces before/after unary operators.
   space-unary-ops:
     - 2
     -
       words: true
       nonwords: false
 
-  # Require a space immediately following the // in a line comment.
+  # Requires a space immediately following the // in a line comment.
   spaced-line-comment:
     - 2
     - always
 
-  # Require regex literals to be wrapped in parentheses.
+  # Requires regex literals to be wrapped in parentheses.
   wrap-regex: 2
 
 
   # Rules for ECMASCRIPT 6.
   # These rules are only relevant to ES6 environments.
 
-  # Don't warn about using let or const instead of var.
+  # Requires using let or const instead of var.
   # This should be turned on when browser support is better.
   no-var: 0
 
-  # Enforce the position of the * in generator functions.
+  # Enforces the position of the * in generator functions.
   generator-star-spacing:
     - 2
     - before
@@ -598,32 +592,29 @@ rules:
   # Rules for LEGACY SUPPORT.
   # These rules provide compatibility with JSHint/JSLint rules.
 
-  # Specify the maximum depth that blocks can be nested.
+  # Specifies maximum depth that blocks can be nested.
   max-depth:
     - 1
     - 5
 
-  # Specify the maximum length of a line in your program.
-  # Warn when exceeding a maximum length of 80 characters.
+  # Specifies maximum length of a line in your program.
   max-len:
     - 1
     - 80
     - 4
 
-  # Limits the number of parameters that can be used in the function declaration.
-  # Warn when exceeding five parameters.
+  # Limits number of parameters that can be used in the function declaration.
   max-params:
     - 1
     - 5
 
-  # Specify the maximum number of statement allowed in a function.
-  # Warn when exceeding twenty-five statements.
+  # Specifies maximum number of statement allowed in a function.
   max-statements:
     - 1
     - 25
 
-  # Allow use of bitwise operators.
+  # Disallows use of bitwise operators.
   no-bitwise: 0
 
-  # Allow use of unary operators, ++ and --.
+  # Disallows use of unary operators, ++ and --.
   no-plusplus: 0

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -249,12 +249,12 @@ $('.reveal-on-focus')
    ========================================================================== */
 
 $('.type-and-filter').typeAndFilter({
-   $input: $('.js-type-and-filter_input'),
-   $items: $('.js-type-and-filter_item'),
-   $button: $('.js-type-and-filter_button'),
-   $clear: $('.js-type-and-filter_clear'),
-   $messages: $('.js-type-and-filter_message'),
-   allMessage: 'Showing all {{ count }} contacts.',
+   $input:                  $('.js-type-and-filter_input'),
+   $items:                  $('.js-type-and-filter_item'),
+   $button:                 $('.js-type-and-filter_button'),
+   $clear:                  $('.js-type-and-filter_clear'),
+   $messages:               $('.js-type-and-filter_message'),
+   allMessage:              'Showing all {{ count }} contacts.',
    filteredMessageSingular: 'There is 1 contact result for "{{ term }}".',
    filteredMessageMultiple: 'There are {{ count }} contact results for "{{ term }}".'
 });
@@ -296,7 +296,7 @@ $('#contact-list_btn').on( 'click', function () {
    ========================================================================== */
 
 $('.chosen-select').chosen({
-    width: '100%',
+    width:           '100%',
     no_results_text: 'Oops, nothing found!'
 });
 
@@ -363,13 +363,13 @@ $('.js-filter_range-date-wrapper').each(function( index ) {
     var $this = $( this );
     var $newThis = $this.next('.js-filter_range-date-replacement');
     var options = {
-        newHTML: $newThis,
+        newHTML:        $newThis,
         newInputsOrder: [
             '#' + $newThis.find('.js-filter_year').attr('id'),
             '#' + $newThis.find('.js-filter_month').attr('id')
         ],
-        initialValues: $this.find('.js-filter_range-date').val().split('-'),
-        delimiter: '-'
+        initialValues:  $this.find('.js-filter_range-date').val().split('-'),
+        delimiter:      '-'
     };
     $this.cf_inputSplit( options );
     $( options.newInputsOrder ).trigger('updateState');

--- a/static/js/breakpoint-handler.js
+++ b/static/js/breakpoint-handler.js
@@ -5,7 +5,10 @@ var modernBrowser = 'innerWidth' in window,
     propPrefix = modernBrowser ? 'inner' : 'client';
 
 function getViewportDimensions() {
-    return {'width': viewportEl[propPrefix + 'Width'], 'height': viewportEl[propPrefix + 'Height']};
+    return {
+            'width':  viewportEl[propPrefix + 'Width'],
+            'height': viewportEl[propPrefix + 'Height']
+        };
 }
 
 
@@ -104,9 +107,9 @@ MobileOnlyExpandable.prototype.init = function () {
     if (this.expandable instanceof jQuery && this.expandableTarget instanceof jQuery) {
         this.breakpointHandler = new BreakpointHandler({
             breakpoint: this.breakpoint,
-            type: 'max',
-            enter: $.proxy(this.closeExpandable, this),
-            leave: $.proxy(this.openExpandable, this)
+            type:       'max',
+            enter:      $.proxy(this.closeExpandable, this),
+            leave:      $.proxy(this.openExpandable, this)
         });
     }
 };

--- a/static/js/content-slider.js
+++ b/static/js/content-slider.js
@@ -25,12 +25,12 @@ function contentSlider(elem, slideCount) {
 
     // Initialize slick carousel.
     this.$container.slick({
-        dots: false,
-        infinite: false,
-        swipe: false,
-        speed: this.speed,
+        dots:           false,
+        infinite:       false,
+        swipe:          false,
+        speed:          this.speed,
         adaptiveHeight: true,
-        arrows: false,
+        arrows:         false,
         onBeforeChange: function (slider, currInd, targetInd) {
             // when slide is changed, animate height of container to accommodate
             // new slide's height.

--- a/static/js/jquery.cf_input-split.js
+++ b/static/js/jquery.cf_input-split.js
@@ -74,20 +74,20 @@
         return this.each(function() {
 
             var options = $.extend({
-                newHTML: '',
+                newHTML:        '',
                 newInputsOrder: [],
-                initialValues: [],
-                delimiter: '',
-                genericFields: 'input, select, textarea'
+                initialValues:  [],
+                delimiter:      '',
+                genericFields:  'input, select, textarea'
             }, userOptions);
 
             var inputSplit = {
-                $oldHTML: $(this),
-                $newHTML: $(options.newHTML),
-                $oldInput: $(),
-                newInputs: options.newInputsOrder,
+                $oldHTML:      $(this),
+                $newHTML:      $(options.newHTML),
+                $oldInput:     $(),
+                newInputs:     options.newInputsOrder,
                 initialValues: options.initialValues,
-                delimiter: options.delimiter,
+                delimiter:     options.delimiter,
                 genericFields: options.genericFields,
 
                 init: function() {

--- a/static/js/jquery.type-and-filter.js
+++ b/static/js/jquery.type-and-filter.js
@@ -24,20 +24,20 @@
 
         return $( this ).each(function() {
             var settings = $.extend( {
-                    minLength: 3,
-                    fuzzy: true,
-                    fuzziness: 0.5,
-                    threshold: 0.35,
-                    $button: $(),
-                    $clear: $(),
-                    $input: $(),
-                    $items: $(),
-                    $messages: $(),
-                    allMessage: 'Showing all {{ count }}.',
+                    minLength:               3,
+                    fuzzy:                   true,
+                    fuzziness:               0.5,
+                    threshold:               0.35,
+                    $button:                 $(),
+                    $clear:                  $(),
+                    $input:                  $(),
+                    $items:                  $(),
+                    $messages:               $(),
+                    allMessage:              'Showing all {{ count }}.',
                     filteredMessageSingular: 'There is 1 result for "{{ term }}".',
                     filteredMessageMultiple: 'There are {{ count }} results for "{{ term }}"',
-                    minTermMessage: '<i>The search term "{{ term }}" is not long enough.<br>Please use a minimum of 3 characters.</i>',
-                    'clickCallback': function( e ) {}
+                    minTermMessage:          '<i>The search term "{{ term }}" is not long enough.<br>Please use a minimum of 3 characters.</i>',
+                    'clickCallback':         function( e ) {}
                 }, userSettings ),
                 $this = $( this ),
                 $button = settings.$button,


### PR DESCRIPTION
ESLint file cleanup.

## Additions

- Adds `align: value` property to `key-spacing` rule, which left-aligns values of properties in an object literal declaration.

## Changes

- Generalizes comments to describe the rule not the state of the rule.

## Review

- @sebworks 
- @jimmynotjim 
