### PR TITLE
Updating project to use environment config

### DIFF
--- a/.env_SAMPLE
+++ b/.env_SAMPLE
@@ -1,0 +1,10 @@
+//export WORDPRESS=http://wordpress.domain
+//export GOVDELIVERY_BASE_URL=https://govdelivery.domain
+//export GOVDELIVERY_ACCOUNT_CODE=GODELIVERY_ACCT
+//export GOVDELIVERY_USER=godelivery@user.acct
+//export GOVDELIVERY_PASSWORD=P@$$w0rd
+//export SUBSCRIPTION_SUCCESS_URL=/govdelivery-subscribe-path
+//export SUBSCRIPTION_USER_ERROR_URL=/govdelivery-subscribe-error-path
+//export SUBSCRIPTION_SERVER_ERROR_URL=/govdelivery-subscribe-server-error-path
+workon cfgov-refresh
+echo 'Virtualenv "cfgov-refresh" activated'

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,46 +1,120 @@
-# 1. Back-end setup
+# Installation and Configuration for cfgov-refresh
 
-Follow the [Sheer installation instructions](https://github.com/cfpb/sheer#installation)
-to get Sheer installed.
-**NOTE:** We suggest creating a virtualenv variable specific to this project,
-such as `cfgov-refresh` instead of `sheer` used in the Sheer installation instructions:
+## 1. Back-end setup
 
+### Virtualenv & Virtualenvwrapper Python modules
+
+Install [Virtualenv](https://virtualenv.pypa.io/en/latest/index.html) and
+[virtualenvwrapper](https://virtualenvwrapper.readthedocs.org/en/latest/)
+to create a local environment for your server:
 ```bash
-$ mkvirtualenv cfgov-refresh
+pip install virtualenv virtualenvwrapper
 ```
 
-Install the following dependencies into your virtual environment.
-We called ours `cfgov-refresh` (see previous step above):
+### Autoenv module
 
+[Install Autoenv](https://github.com/kennethreitz/autoenv#install) however you’d like.
+(We use [Homebrew](http://brew.sh)):
+
+Run:
 ```bash
-$ workon cfgov-refresh
-
-$ pip install git+git://github.com/dpford/flask-govdelivery
-$ pip install git+git://github.com/rosskarchner/govdelivery
+brew install autoenv
 ```
 
-## Back-end environment variables
+After installation, Homebrew will output instructions similar to:
+```bash
+To finish the installation, source activate.sh in your shell:
+  source /Users/[YOUR MAC OSX USERNAME]/homebrew/opt/autoenv/activate.sh
+```
 
-The project needs a number of environment variables.
-The project uses a WordPress API URL to pull in content
-and GovDelivery for running the subscription forms:
+Any time you run the project you’ll need to run that last line. If you’ll be working with
+the project consistently, we suggest adding it to your bash profile by running:
+```bash
+echo 'source /Users/[YOUR MAC OSX USERNAME]/homebrew/opt/autoenv/activate.sh' >> ~/.bash_profile
+```
 
-- `WORDPRESS` (URL to WordPress install)
-- `GOVDELIVERY_BASE_URL`
-- `GOVDELIVERY_ACCOUNT_CODE` (GovDelivery account variable)
-- `GOVDELIVERY_USER` (GovDelivery account variable)
-- `GOVDELIVERY_PASSWORD` (GovDelivery account variable)
-- `SUBSCRIPTION_SUCCESS_URL` (Forwarding location on Subscription Success)
+If you need to find this info again later, you can run:
+```bash
+brew info autoenv
+```
 
-> You can also export the above environment variables to your `.bash_profile`,
-or use your favorite alternative method of setting environment variables.
+> **NOTE:** If you use ZSH you’ll need to use [zsh-autoenv](https://github.com/Tarrasch/zsh-autoenv),
+  but we can’t provide support for issues that may arise.
 
-**NOTE:** GovDelivery is a third-party web service that powers our subscription forms.
-Users may decide to swap this tool out for another third-party service.
-The application will function but throw an error if the above GovDelivery values are not set.
+### Elasticsearch
+
+[Install Elasticsearch](http://www.elastic.co/guide/en/elasticsearch/reference/current/setup.html)
+however you’d like. (We use [Homebrew](http://brew.sh)):
+```bash
+brew install elasticsearch
+```
+
+Just as with autoenv, Homebrew will output similar instructions after installation:
+```bash
+To have launchd start elasticsearch at login:
+    ln -sfv /Users/[YOUR MAC OSX USERNAME]/homebrew/opt/elasticsearch/*.plist ~/Library/LaunchAgents
+Then to load elasticsearch now:
+    launchctl load ~/Library/LaunchAgents/homebrew.mxcl.elasticsearch.plist
+Or, if you don’t want/need launchctl, you can just run:
+    elasticsearch --config=/Users/[YOUR MAC OSX USERNAME]/homebrew/opt/elasticsearch/config/elasticsearch.yml
+```
+
+Any time you work on the project, you’ll need to open a new tab and run that last line.
+If you’ll be working on the project consistently, we suggest using the first option
+utilizing `launchd`.
+
+If you need to find this info again later, you can run:
+```bash
+brew info elasticsearch
+```
+
+### Sheer
+
+To [install Sheer](https://github.com/cfpb/sheer#installation), start by cloning the
+Sheer GitHub project to wherever you keep your projects (not inside cfgov-refresh directory):
+```bash
+git clone https://github.com/cfpb/sheer.git
+```
+
+Create a virtualenv for Sheer, which you’ll name `cfgov-refresh`:
+```bash
+mkvirtualenv cfgov-refresh
+```
+
+The new virtualenv will activate right away. To activate it later on
+(say, in a new terminal session) use the command `workon cfgov-refresh`.
+You’ll know you have a virtual environment activated if you see the name of it in
+parentheses before your terminal prompt. Ex:
+```bash
+(cfgov-refresh)$
+```
+
+Install Sheer into the virtualenv with the `-e` flag (which allows you to make changes to
+Sheer itself). The path to Sheer is the root directory of the GitHub repository you
+cloned earlier, which will likely be `../sheer`:
+```bash
+pip install -e ~/path/to/sheer
+```
+
+Install Sheer’s Python requirements:
+```bash
+pip install -r ~/path/to/sheer/requirements.txt
+```
+
+### GovDelivery
+
+Install the following GovDelivery dependencies into your virtual environment:
+```bash
+pip install git+git://github.com/dpford/flask-govdelivery
+pip install git+git://github.com/rosskarchner/govdelivery
+```
+
+> **NOTE:** GovDelivery is a third-party web service that powers our subscription forms.
+  Users may decide to swap this tool out for another third-party service.
+  The application will function but throw an error if the above GovDelivery values are not set.
 
 
-# 2. Front-end setup
+## 2. Front-end setup
 
 The cfgov-refresh front-end currently uses the following frameworks / tools:
 
@@ -51,34 +125,60 @@ The cfgov-refresh front-end currently uses the following frameworks / tools:
 - [Capital Framework](https://cfpb.github.io/capital-framework/getting-started):
   User interface pattern-library produced by the CFPB.
 
-**NOTE:** If you're new to Capital Framework, we encourage you to
-[start here](https://cfpb.github.io/capital-framework/getting-started).
+> **NOTE:** If you’re new to Capital Framework, we encourage you to
+  [start here](https://cfpb.github.io/capital-framework/getting-started).
 
-1. Install [Node.js](http://nodejs.org) however you'd like.
+1. Install [Node.js](http://nodejs.org) however you’d like.
 2. Install [Grunt](http://gruntjs.com) and [Bower](http://bower.io):
 
 ```bash
-$ npm install -g grunt-cli bower
+npm install -g grunt-cli bower
 ```
 
-# 3. Clone project and install dependencies
+## 3. Clone project and install dependencies
 
 Using the console, navigate to your project directory (`cd ~/Projects` or equivalent).
-Clone this project's repository and switch to it's directory with:
+Clone this project’s repository and switch to it’s directory with:
 
 ```bash
-$ git clone git@github.com:cfpb/cfgov-refresh.git
-$ cd cfgov-refresh
+git clone git@github.com:cfpb/cfgov-refresh.git
+cd cfgov-refresh
 ```
 
 Next, install dependencies with:
 
 ```bash
-$ npm install
-$ grunt vendor
+npm install
+grunt vendor
 ```
 
-> Note: After installing dependencies,
-rebuild all the site's assets by running `grunt`.
-See the usage section
-[updating all the project dependencies](README.md#updating-all-dependencies).
+> **NOTE**: After installing dependencies, rebuild all the site’s assets by running `grunt`.
+See the usage section [updating all the project dependencies](README.md#updating-all-dependencies).
+
+
+## 4. Project configuration
+
+The project uses a number of environment variables. The project uses a WordPress API URL
+to pull in content and GovDelivery for running the subscription forms:
+
+- `WORDPRESS` (URL to WordPress install)
+- `GOVDELIVERY_BASE_URL`
+- `GOVDELIVERY_ACCOUNT_CODE` (GovDelivery account variable)
+- `GOVDELIVERY_USER` (GovDelivery account variable)
+- `GOVDELIVERY_PASSWORD` (GovDelivery account variable)
+- `SUBSCRIPTION_SUCCESS_URL` (Forwarding location on subscription success)
+
+To set these permenantly, copy the `.env-SAMPLE` file and un-comment each variable after
+adding your own values. `WORDPRESS` is the only one that’s absolutely necessary to run the site.
+```bash
+cp .env_SAMPLE .env && open .env
+```
+
+If you need to test this project without Autoenv, you can set each of these with:
+```
+export [CONSTANTNAME]=[CONSTANTVALUE]
+```
+
+## 5. Usage
+
+Continue following the [Usage instructions](README.md#usage) in the README.

--- a/README.md
+++ b/README.md
@@ -3,12 +3,13 @@
 The in-progress redesign of the [consumerfinance.gov](http://consumerfinance.gov) website.
 This project includes the front-end assets and build tools,
 [Jinja templates](http://jinja.pocoo.org) for front-end rendering,
-and [Sheer](https://github.com/cfpb/sheer) configurations for loading
-content from the WordPress and Django back-ends through Elasticsearch.
+and [Sheer](https://github.com/cfpb/sheer) configurations for loading content from the
+WordPress and Django back-ends through Elasticsearch.
 
 **Technology stack**:
 - Mac OSX.
-- [Homebrew](http://brew.sh) - package manager for installing system software on Mac OSX.
+- [Homebrew](http://brew.sh) - package manager for installing system
+  software on Mac OSX.
 - Python and PIP (Python package installer).
 - WordPress API data source URL.
 
@@ -33,12 +34,12 @@ Follow the instructions in [INSTALL](INSTALL.md).
 
 ## Configuration
 
-For necessary server-side configurations, follow instructions in [Back-end environment variables](INSTALL.md#back-end-environment-variables).
+For necessary server-side configurations, follow instructions in
+[INSTALL - Configuration](INSTALL.md#configuration).
 
 ## Usage
 
-Generally you will have four tabs (or windows)
-open in your terminal when using this project.
+Generally you will have four tabs (or windows) open in your terminal when using this project.
 These will be used for:
  1. **Git operations**.
     Perform Git operations and general development in the repository.
@@ -54,12 +55,11 @@ What follows are the specific steps for each of these tabs.
 ### 1. Git operations
 
 From this tab you can do Git operations,
-such as checking out our different branches:
+such as checking out our development branches:
 
 ```bash
-$ git checkout flapjack # Branch for our staging-development server.
-$ git checkout refresh  # Branch for our staging-stable server.
-$ git checkout beta     # Branch for our production-stable server.
+git checkout flapjack # Branch for our staging-development server.
+git checkout refresh  # Branch for our staging-stable server.
 ```
 
 #### Updating all dependencies
@@ -69,36 +69,31 @@ you should install and update dependencies with npm and `grunt vendor`,
 and then run `grunt` to rebuild all the site's assets:
 
 ```bash
-$ npm install
-$ npm update
-$ grunt vendor
-$ grunt
+npm install
+npm update
+grunt vendor
+grunt
 ```
 
 
 ### 2. Run Elasticsearch
 
-> Note: This Elasticsearch tab (or window) might not be necessary if you set Elasticsearch to start at login when [installing Sheer](https://github.com/cfpb/sheer#installation).
+> Note: This Elasticsearch tab (or window) might not be necessary if you opted for the `launchd`
+option when [installing Elasticsearch](INSTALL.md#elasticsearch).
 
 To launch Elasticsearch, first find out where your Elasticsearch config file is located.
 You can do this with [Homebrew](http://brew.sh) using:
 
 ```bash
-$ brew info elasticsearch
+brew info elasticsearch
 ```
 
-The last line of that output should be the command you need to launch Elasticsearch
-with the proper path to its configuration file. For example, it may look like:
+The last line of that output should be the command you need to launch Elasticsearch with the
+proper path to its configuration file. For example, it may look like:
 
+```bash
+elasticsearch --config=/Users/[YOUR MAC OSX USERNAME]/homebrew/opt/elasticsearch/config/elasticsearch.yml
 ```
-$ elasticsearch --config=/Users/[YOUR MAC OSX USERNAME]/homebrew/opt/elasticsearch/config/elasticsearch.yml
-```
-
-> Note: You can add the following to your `.bash_profile` that will allow launching of Elasticsearch with the `elsup` command:
-  ```
-  $ alias elsup="elasticsearch --config=/Users/[MAC OSX USERNAME]/homebrew/opt/elasticsearch/config/elasticsearch.yml"
-  ```
-
 
 ### 3. Launch Sheer to serve the site
 
@@ -107,13 +102,14 @@ To do this, run the following:
 
 ```bash
 # Use the cfgov-refresh virtualenv.
-$ workon cfgov-refresh
+workon cfgov-refresh
 
 # Index the latest content from the API output from a WordPress and Django back-end.
-$ sheer index
+# **This requires the constants in INSTALL - Configuration to be set**
+sheer index
 
 # Start sheer.
-$ sheer serve --debug
+sheer serve --debug
 ```
 
 To view the site browse to: <http://localhost:7000>
@@ -128,6 +124,16 @@ To view the indexed content you can use a tool called
 serve Sheer with the `--port` argument,
 e.g. to run on port 7001 use `sheer serve --port 7001 --debug`.
 
+**NOTE:** You may see the following errors when running Sheer. This is expected.
+```bash
+Error importing package flask_pdfreactor
+Error importing package flask_eventics
+INFO:werkzeug: * Running on http://0.0.0.0:7000/
+INFO:werkzeug: * Restarting with reloader
+Error importing package flask_pdfreactor
+Error importing package flask_eventics
+```
+
 ### 4. Launch the Grunt watch task
 
 To watch for changes in the source code and automatically update the running site,
@@ -137,8 +143,8 @@ open a terminal and run:
 $ grunt watch
 ```
 
-*Alternatively, if you don't want to run the full watch task, there are two available
-sub-tasks:*
+*Alternatively, if you don't want to run the full watch task,
+there are two available sub-tasks:*
 
 ``` bash
 # Watch & compile CSS only
@@ -168,8 +174,8 @@ the chromedriver directory. Use this path, but include the chromedriver name at 
 
 ## Getting help
 
-Use the [issue tracker](https://github.com/cfpb/cfgov-refresh/issues)
-to follow the development conversation.
+Use the [issue tracker](https://github.com/cfpb/cfgov-refresh/issues) to follow the
+development conversation.
 If you find a bug not listed in the issue tracker,
 please [file a bug report](https://github.com/cfpb/cfgov-refresh/issues/new?body=
 %23%23%20URL%0D%0D%0D%23%23%20Actual%20Behavior%0D%0D%0D%23%23%20Expected%20Behavior


### PR DESCRIPTION
Updated the project to use the same `.env` config OAH is using. Will hopefully simplify the on-boarding process for new team members.

## Additions

- Adds .env example to get users started

## Removals

- `$`s, because we work for the people
- Section on adding the `cfgov-refresh-venv` function

## Changes

- Updates the relevant instructions in INSTALL
- Updates the relevant instructions in README

## Testing

Uninstall everything and try getting the project running following the updated instructions (refer to the internal docs for the `.env` variables)

## Review

- @cfarm
- @KimberlyMunoz 
- @anselmbradford 
- @sebworks 
- et al.

## Preview

![screen shot 2015-04-16 at 4 03 03 pm](https://cloud.githubusercontent.com/assets/1280430/7190173/190f1d48-e452-11e4-9843-041ee4f6bae6.png)

## Notes

- I left out the public WP API endpoint from the `.env_SAMPLE` but I'd argue we should include it by default. Let's discuss the pros and cons of that in the comments.