### PR TITLE
Reconciled multiple categories for blog posts

### DIFF
--- a/_includes/article.html
+++ b/_includes/article.html
@@ -29,8 +29,14 @@
 
 <article class="post">
     <header>
-        {% if post.category.0 %}
-            {%- import "category-slug.html" as category_slug %}
+        {%- import "category-slug.html" as category_slug %}
+        {% if path == '/blog/' and post.blog_category.0 %}
+            {% set use_blog_category = True %}
+            {{ category_slug.render(post.blog_category.0,
+                                    path,
+                                    'post_slug',
+                                    use_blog_category) }}
+        {% elif post.category.0 %}
             {{ category_slug.render(post.category.0, path, 'post_slug') }}
         {% endif %}
         <h1 class="post_heading">

--- a/_includes/category-slug.html
+++ b/_includes/category-slug.html
@@ -21,10 +21,10 @@
 
    ========================================================================== #}
 
-{%- macro render(category, path, classes) %}
+{%- macro render(category, path, classes, use_blog_category=False) %}
 {%- from "post-macros.html" import category_icon as category_icon -%}
-{%- if category|lower == 'blog' %}
-    {% set filter_path = path + '?filter_type=post' %}
+{%- if use_blog_category %}
+    {% set filter_path = path + '?filter_blog_category=' + category|urlencode|replace('%20', '+') %}
 {%- else -%}
     {% set filter_path = path + '?filter_category=' + category|urlencode|replace('%20', '+') %}
 {% endif -%}

--- a/_includes/post-macros.html
+++ b/_includes/post-macros.html
@@ -550,27 +550,24 @@
 {% for filter in filters %}
 
     {# Category filters #}
-    {% if filter == 'category' %}
+    {% if filter in ['blog_category', 'category'] %}
         <div class="form-l_col form-l_col-1-3">
             <div class="form-group">
                 <label class="form-label-header">
                     Categories
                 </label>
-            {% if doc_type == 'newsroom' -%}
-                {% set categories = query.possible_values_for('category', doc_type='newsroom')|sort(attribute='key') %}
+            {% if doc_type == 'posts' -%}
+                {% set categories = query.possible_values_for('blog_category')|sort(attribute='key') %}
+                {% set category_field = 'blog_category' %}
             {%- else -%}
                 {% set categories = query.possible_values_for('category')|sort(attribute='key') %}
+                {% set category_field = 'category' %}
             {% endif -%}
             {% for category in categories -%}
                 <label class="form-group_item">
-                    {{ filter_checkbox('category', category.key)|safe }}
+                    {{ filter_checkbox(category_field, category.key)|safe }}
                 </label>
             {% endfor %}
-            {% if doc_type == 'newsroom' -%}
-                <label class="form-group_item">
-                    {{ filter_checkbox('category', 'Blog', 'Blog')|safe }}
-                </label>
-            {%- endif %}
             </div>
         </div>
 
@@ -581,23 +578,9 @@
                 <label class="form-label-header">
                     Category type
                 </label>
-            {% set categories = query.possible_values_for('type')|sort(attribute='key') -%}
+            {% set categories =
+               query.possible_values_for('category')|sort(attribute='key') %}
             {% for category in categories -%}
-                {% if category.key != 'cfpb_newsroom' %}
-                    {% if category.key == 'post' %}
-                        <label class="form-group_item">
-                            {{ filter_checkbox('category', 'Blog', 'Blog')|safe }}
-                        </label>
-                    {% else %}
-                        <label class="form-group_item">
-                            {{ filter_checkbox('type', category.key)|safe }}
-                        </label>
-                    {% endif %}
-                {% endif %}
-            {% endfor %}
-            {% set newsroom_categories =
-               query.possible_values_for('category', doc_type='newsroom')|sort(attribute='key') %}
-            {% for category in newsroom_categories -%}
                 <label class="form-group_item">
                     {{ filter_checkbox('category', category.key)|safe }}
                 </label>

--- a/_includes/posts-paginated.html
+++ b/_includes/posts-paginated.html
@@ -11,24 +11,33 @@
         so on that page we'll need to tell category_slug to use that field
         rather than the normal 'category' #}
     {%- if vars.path == '/blog/' %}
-        {% set category = post.blog_category.0 %}
+        {% set category = post.blog_category %}
         {% set use_blog_category = True %}
-    {% elif post.category.0 %}
-        {% set category = post.category.0 %}
+    {% elif post.category %}
+        {% set category = post.category %}
         {% set use_blog_category = False %}
     {% endif -%}
     {%- import "category-slug.html" as category_slug %}
-    {%- set slug = category_slug.render(category,
-                                        vars.path,
-                                        'meta-header_left',
-                                        use_blog_category) -%}
 
     <article class="post-preview">
         <div class="meta-header">
             <span class="date meta-header_right">
                 {{ post.date|date('%b %d, %Y') }}
             </span>
-            {{ slug if category else '&nbsp;' }}
+            {% if not category %}
+                {{ '&nbsp;'|safe }}
+            {% else %}
+                {% for cat in category %}
+                    {% if loop.index > 1 %}
+                        |
+                    {% endif %}
+                    {% set slug = category_slug.render(cat,
+                                                       vars.path,
+                                                       'meta-header_left',
+                                                       use_blog_category) %}
+                    {{ slug }}
+                {% endfor %}
+            {% endif %}
         </div>
     {% if post.thumbnail.images and post.thumbnail.images.fj_thumbnail %}
         <a class="media" href="{{ post.permalink }}">

--- a/_includes/posts-paginated.html
+++ b/_includes/posts-paginated.html
@@ -7,18 +7,21 @@
 
 {% for post in posts %}
 
-    {#- Newsroom contains select Blog posts.
-        These Newsroom Blog posts can be identified by a special
-        `display_in_newsroom` property.
-        When a Blog post is listed in Newsroom we should ignore its category
-        name and instead categorize it as "Blog". #}
-    {%- if vars.path == '/newsroom/' and post.custom_fields.display_in_newsroom %}
-        {% set category = 'Blog' %}
+    {#- Blog uses a different category field ('blog_category')
+        so on that page we'll need to tell category_slug to use that field
+        rather than the normal 'category' #}
+    {%- if vars.path == '/blog/' %}
+        {% set category = post.blog_category.0 %}
+        {% set use_blog_category = True %}
     {% elif post.category.0 %}
         {% set category = post.category.0 %}
+        {% set use_blog_category = False %}
     {% endif -%}
     {%- import "category-slug.html" as category_slug %}
-    {%- set slug = category_slug.render(category, vars.path, 'meta-header_left') -%}
+    {%- set slug = category_slug.render(category,
+                                        vars.path,
+                                        'meta-header_left',
+                                        use_blog_category) -%}
 
     <article class="post-preview">
         <div class="meta-header">
@@ -49,8 +52,15 @@
 
 {% endfor %}
 
+{% if vars.path == '/blog/' %}
+    {% set category_field = 'blog_category' %}
+{% else %}
+    {% set category_field = 'category' %}
+
+{% endif %}
+
 {{ post_macros.pagination(posts, [
-    'category',
+    category_field,
     'tags',
     'author',
     'range_date_gte',

--- a/_settings/mappings/posts.json
+++ b/_settings/mappings/posts.json
@@ -29,6 +29,10 @@
       "type": "string",
       "index": "not_analyzed"
     },
+    "blog_category": {
+      "type": "string",
+      "index": "not_analyzed"
+    },
     "categories": {
       "properties": {
         "id": {

--- a/_tests/browser_testing/features/environment.py
+++ b/_tests/browser_testing/features/environment.py
@@ -26,6 +26,7 @@ except ImportError:
 index_name = "cfgov_test"
 root = os.path.join(os.getcwd(), '../..')
 
+
 class LiveServer(object):
     def __init__(self):
         config = dict(debug=False,
@@ -34,9 +35,8 @@ class LiveServer(object):
                       index=index_name)
         self.app = app_with_config(config)
         worker = lambda app, port: app.run(host='0.0.0.0', port=7000, use_reloader=False)
-        self.process = multiprocessing.Process(
-                    target=worker, args=(self.app, 7000)
-                  )
+        self.process = multiprocessing.Process(target=worker, 
+                                               args=(self.app, 7000))
         self.process.start()
 
     def terminate(self):
@@ -84,7 +84,8 @@ def before_all(context):
     context.base = Base(context.logger, context.directory,
                         context.base_url, driver, 10, context.delay_secs)
     context.newsroom = Newsroom(context.logger, context.directory,
-                        context.base_url, driver, 10, context.delay_secs)
+                                context.base_url, driver, 10, context.delay_secs
+                                )
     context.navigation = Navigation(context.logger, context.directory,
                                     context.base_url,
                                     driver, 10, context.delay_secs)
@@ -102,16 +103,14 @@ def before_all(context):
     es.indices.create(index=index_name)
 
     # Create the mappings
-    create_mapping('newsroom', os.path.join(root, '_settings/posts_mappings.json'))
-    create_mapping('featured_topic', os.path.join(root, '_settings/posts_mappings.json'))
+    create_mapping('newsroom', os.path.join(root, '_settings/mappings/newsroom.json'))
+    create_mapping('featured_topic', os.path.join(root, '_settings/mappings/posts.json'))
 
     # Index the documents
     index_documents('newsroom', os.path.join(root, '_tests/browser_testing/fixtures/newsroom.json'))
     index_documents('views', os.path.join(root, '_tests/browser_testing/fixtures/views.json'))
     index_documents('featured_topic', os.path.join(root, '_tests/browser_testing/fixtures/featured_topic.json'))
 
-    
-    
 
 def before_feature(context, feature):
     context.logger.info('STARTING FEATURE %s' % feature)
@@ -157,7 +156,7 @@ def after_all(context):
             if http_proxy.startswith("http://"):
                 http_proxy = http_proxy[7:]
             connection = httplib.HTTPConnection(http_proxy)
-        else:    
+        else:
             connection = httplib.HTTPConnection("saucelabs.com")
 
         connection.request('PUT', 'http://saucelabs.com/rest/v1/%s/jobs/%s' %
@@ -237,6 +236,7 @@ def setup_config(context):
     else:
         context.take_screenshots = False
 
+
 def create_mapping(doc_type, mapping_json_path):
     es = Elasticsearch()
     mapping_json = open(os.path.join(root, mapping_json_path))
@@ -244,6 +244,7 @@ def create_mapping(doc_type, mapping_json_path):
     es.indices.put_mapping(index=index_name,
                            doc_type=doc_type,
                            body={doc_type: mapping})
+
 
 def index_documents(doc_type, json_path):
     es = Elasticsearch()

--- a/_tests/browser_testing/features/pages/newsroom.py
+++ b/_tests/browser_testing/features/pages/newsroom.py
@@ -44,12 +44,13 @@ TOPIC_SEARCH_INPUT = '//input[@value="Search for topics"]'
 SELECT_AUTHOR = '//div[@id="filter_author_chosen"]/div/ul[@class="chosen-results"]/li/em[contains(text(),"author_name")]/..'
 SELECT_TOPIC = '//div[@id="filter_tags_chosen"]/div/ul[@class="chosen-results"]/li/em[contains(text(),"topic_name")]/..'
 
+
 class Newsroom(Base):
 
     def __init__(self, logger, directory, base_url=r'http://localhost/',
                  driver=None, driver_wait=10, delay_secs=0):
         super(Newsroom, self).__init__(logger, directory, base_url,
-                                          driver, driver_wait, delay_secs)
+                                       driver, driver_wait, delay_secs)
         self.logger = logger
         self.driver_wait = driver_wait
 
@@ -83,7 +84,8 @@ class Newsroom(Base):
                                       )
         )
         checkbox.click()
-    def set_date_filter(self, from_month=None, from_year=None, to_month=None, 
+
+    def set_date_filter(self, from_month=None, from_year=None, to_month=None,
                         to_year=None):
         if from_month:
             from_month = self.driver.find_element_by_xpath(

--- a/blog/index.html
+++ b/blog/index.html
@@ -19,7 +19,7 @@
     #}
     {% import "hero.html" as hero with context %}
     {% set active_filters_total =
-       selected_filters_for_field('category')|length +
+       selected_filters_for_field('blog_category')|length +
        selected_filters_for_field('tags')|length +
        selected_filters_for_field('author')|length +
        selected_filters_for_field('range_date_gte')|length +
@@ -34,7 +34,7 @@
 
     <h1>Blog</h1>
 
-    {% set filter_by = ['category', 'tags', 'author', 'range_date'] %}
+    {% set filter_by = ['blog_category', 'tags', 'author', 'range_date'] %}
     {% from "post-macros.html" import filters as filters with context %}
     {{ filters(filter_by, vars.query, vars.posts, 'posts',
        { 'expand_label': 'Filter posts' }) }}


### PR DESCRIPTION
Right now, filtering for blog posts within the Newsroom is not working.  The checkbox for "Blog" in the Newsroom filters is being set manually.  There are similar manually-set code smells in the Activity Log.

This PR creates a new field for blog categories called `blog_category`.  All of the categories for blog posts (that were previously included in `category`) are now housed there.  All other categories (at this point, just Newsroom objects) still live in the `category` field.  From the Newsroom's and Activity Log's perspective, all blog posts have a category of Blog.

**To test**: try using the filter in the /blog/, /newsroom/, /activity-log/ sections of the site, including filtering for blog posts.  The browser tests have also been updated.

**Review**: @Scotchester @jimmynotjim @anselmbradford @sebworks @kurtw 