### PR TITLE
Fixed email subscribe form ID error.

### DIFF
--- a/_includes/email-subscribe-form.html
+++ b/_includes/email-subscribe-form.html
@@ -11,18 +11,17 @@
         <label for="email-subscribe-form_email">
             Email address
         </label>
-        <input class="reveal-on-focus_target"
-               id="email-subscribe-form_email"
+        <input id="email-subscribe-form_email"
                type="email"
                name="email"
                placeholder="example@mail.com">
     </div>
     <p class="short-desc u-mt10">
-      The information you provide will permit the Consumer Financial 
+      The information you provide will permit the Consumer Financial
       Protection Bureau to process your request or inquiry.
       <a href="/privacy-policy">See More</a>
     </p>
-    {# Uncomment this and remove condition to test
+    {# TODO: Update this if/when zip code is supported
     {% if 'is_event' %}
     <div class="form-group reveal-on-focus_content u-clearfix">
       <label class="form-group_item">
@@ -39,43 +38,9 @@
     </div>
     {% endif %}
     #}
-    {# TODO: Remove "and false" when topics are available for email sign-ups. #}
-    {% if query and false -%}
-    <div class="form-group reveal-on-focus_content u-clearfix">
-    {% for category in query.possible_values_for('category')|sort(attribute='key') -%}
-    {% set govdelivery_categories = [
-        { 'name': 'Announcements & updates', 'code': 'USCFPB_9' },
-        { 'name': 'Consumer information', 'code': 'USCFPB_10' },
-        { 'name': 'Engagement', 'code': 'USCFPB_11' },
-        { 'name': 'Innovation & data', 'code': 'USCFPB_12' },
-        { 'name': 'Blog', 'code': 'USCFPB_13' },
-        { 'name': 'Op-Ed', 'code': 'USCFPB_14' },
-        { 'name': 'Press Release', 'code': 'USCFPB_15' },
-        { 'name': 'Speech', 'code': 'USCFPB_16' },
-        { 'name': 'Testimony', 'code': 'USCFPB_17' }
-    ] %}
-    {% for allowed_category in govdelivery_categories -%}
-    {% if category.key == allowed_category.name %}
-        <label class="form-group_item">
-            <input class="custom-input"
-                   type="checkbox"
-                   name="code"
-                   value="{{ allowed_category.code }}">
-            {{ category.key }}
-        </label>
-    {% endif %}
-    {% endfor %}
-    {% endfor %}
-    </div>
-    {% elif code -%}
-    <div class="form-group">
-        <input type="hidden"
-               name="code"
-               value="{{ code }}">
-    </div>
-    {% endif -%}
 
     <div class="form-group">
+        <input type="hidden" name="code" value="{{ code }}">
         <input class="btn" type="submit" class="btn" value="Sign up">
     </div>
 

--- a/blog/index.html
+++ b/blog/index.html
@@ -60,7 +60,7 @@
                 Subscribe to our email newsletter. We will update you on new blogs.
             </p>
             {% import "email-subscribe-form.html" as subscribe with context %}
-            {{ subscribe.render(vars.query) }}
+            {{ subscribe.render(vars.query, 'USCFPB_91') }}
         </div>
         <div class="block block__sub">
             {% import "rss.html" as rss %}

--- a/events/index.html
+++ b/events/index.html
@@ -89,7 +89,7 @@
                             Subscribe to our email newsletter. We will update you on new event updates.
                         </p>
                         {% import "email-subscribe-form.html" as subscribe with context %}
-                        {{ subscribe.render(vars.query) }}
+                        {{ subscribe.render(vars.query, 'USCFPB_93') }}
                     </div>
                     <div>
                         {% import "rss.html" as rss %}

--- a/newsroom/index.html
+++ b/newsroom/index.html
@@ -45,7 +45,7 @@
                         Subscribe to get our press releases by email.
                     </p>
                     {% import "email-subscribe-form.html" as subscribe with context %}
-                    {{ subscribe.render(vars.query) }}
+                    {{ subscribe.render(vars.query, 'USCFPB_23') }}
                 </div>
                 <div class="block__sub content-l_col content-l_col-1-2">
                     {% import "rss.html" as rss %}


### PR DESCRIPTION
Fixed error when submitting an email subscription due to missing category IDs.

## Additions

- None

## Removals

- None

## Changes

- Set list IDs when calling macro from each post type landing page
- Removed categories list from form options

## Testing

Fetch branch and navigate to:

- `/blog/`
- `/newsroom/`
- `/events/`

You shouldn't see the "We're still building this" error page

## Review

- @sebworks 
- @anselmbradford 
- @KimberlyMunoz 
- @dpford 

## Preview

None

## Notes

- The generic "We're working on this" error page will need updating. @jameshupp is working on content and I'll include that later.

- Although the error due to missing IDs is fixed, I'm now running into a GovDelivery server error. Not sure if this is expected due to running locally or something else. Any ideas @dpford?

![screen shot 2015-04-30 at 3 40 45 pm](https://cloud.githubusercontent.com/assets/1280430/7421023/55e6d5e6-ef4f-11e4-9e6b-376d48b48411.png)