### PR TITLE
Changed copy on email signup error

### DIFF
--- a/govdelivery-subscribe/error/index.html
+++ b/govdelivery-subscribe/error/index.html
@@ -9,10 +9,11 @@
 {%- endblock %}
 
 {% block content_main %}
-    <h1><span class="cf-icon cf-icon-error-round"></span> Not just yet!</h1>
+    <h1><span class="cf-icon cf-icon-error-round"></span> That didn't work.</h1>
     <p class="short-desc">
-        We couldn’t complete your signup request. Try<br>
-        again in a little while. For now:
+        We couldn’t complete your signup request. Try <br>
+        to submit your address again in a little while. For <br>
+        now:
     </p>
     <ol class="short-desc">
         <li>Keep exploring <a href="http://beta.consumerfinance.gov">beta.consumerfinance.gov</a>.</li>

--- a/govdelivery-subscribe/error/index.html
+++ b/govdelivery-subscribe/error/index.html
@@ -17,7 +17,7 @@
     <ol class="short-desc">
         <li>Keep exploring <a href="http://beta.consumerfinance.gov">beta.consumerfinance.gov</a>.</li>
         <li>Check back often to follow our progress and find new sources of information.</li>
-        <li><a href="/contact-us/"></a>Let us know</a> if there’s a particular line of work you want to hear about regularly.</li>
+        <li><a href="/contact-us/">Let us know</a> if there’s a particular line of work you want to hear about regularly.</li>
     </ol>
     <!-- TODO: Commented out until email signup is ready to use.
     <h1><span class="cf-icon cf-icon-error-round"></span> Please try again.</h1>

--- a/govdelivery-subscribe/error/index.html
+++ b/govdelivery-subscribe/error/index.html
@@ -11,13 +11,13 @@
 {% block content_main %}
     <h1><span class="cf-icon cf-icon-error-round"></span> Not just yet!</h1>
     <p class="short-desc">
-        We’re still building the email signup function for <br>
-        this beta release. It will be available soon. For now:
+        We couldn’t complete your signup request. Try<br>
+        again in a little while. For now:
     </p>
     <ol class="short-desc">
         <li>Keep exploring <a href="http://beta.consumerfinance.gov">beta.consumerfinance.gov</a>.</li>
-        <li>Check back often to follow our progress.</li>
-        <li>Sign up for general CFPB updates at <a href="http://www.consumerfinance.gov">www.consumerfinance.gov</a>.</li>
+        <li>Check back often to follow our progress and find new sources of information.</li>
+        <li><a href="/contact-us/"></a>Let us know</a> if there’s a particular line of work you want to hear about regularly.</li>
     </ol>
     <!-- TODO: Commented out until email signup is ready to use.
     <h1><span class="cf-icon cf-icon-error-round"></span> Please try again.</h1>

--- a/govdelivery-subscribe/error/index.html
+++ b/govdelivery-subscribe/error/index.html
@@ -9,7 +9,7 @@
 {%- endblock %}
 
 {% block content_main %}
-    <h1><span class="cf-icon cf-icon-error-round"></span> That didn't work.</h1>
+    <h1><span class="cf-icon cf-icon-error-round"></span> That didn’t work.</h1>
     <p class="short-desc">
         We couldn’t complete your signup request. Try <br>
         to submit your address again in a little while. For <br>


### PR DESCRIPTION
## Changes

Adjusted copy to reflect:
1. The signup functions.
2. Signup errors are most likely to be about communicating with the vendor, so sending them to another signup is not going to be super helpful.

## Review
@jimmynotjim 
@sarahsimpson09 

## Note
The last line might be a little odd. I just thought it might be a way to get more business units excited about sending emails. Regular communication is good for us!