### PR TITLE
Removes demo text in title

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,11 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 ### Fixed
 
 
+### Removed
+
+- Removed demo text suffix from page titles.
+
+
 ## 3.0.0-0.3.0 - 2015-04-23
 
 ### Added

--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -43,7 +43,7 @@
     ==================
 -->
 
-    <title>{% block title %}MISSING TITLE{% endblock title %} - cfgov-refresh demo</title>
+    <title>{% block title %}MISSING TITLE{% endblock title %}</title>
     <meta name="description"
           content="{% block desc %}Prototyping for the consumerfinance.gov refresh{% endblock %}">
 


### PR DESCRIPTION
Since this code eventually gets pushed publicly to beta this is probably the time to remove the demo text from the title (or alternatively name it something that doesn't include cfgov-refresh)

## Removals

- demo text suffix from page titles.

## Testing

- Visit any page, note page title.

## Review

- @KimberlyMunoz 
- @sebworks 
- @jimmynotjim 