### PR TITLE
Hotfix: corrects JS paths for 400 and 500 error pages

### DIFF
--- a/_layouts/404.html
+++ b/_layouts/404.html
@@ -42,5 +42,5 @@
 {% endblock %}
 
 {% block javascript %}
-<script src="{{ url_for('static', filename='js/routes/common.js') }}"></script>
+<script src="{{ url_for('static', filename='js/routes/common.min.js') }}"></script>
 {% endblock javascript %}

--- a/_layouts/500.html
+++ b/_layouts/500.html
@@ -43,6 +43,6 @@
 {% endblock %}
 
 {% block javascript %}
-<script src="{{ url_for('static', filename='js/routes/common.js') }}"></script>
+<script src="{{ url_for('static', filename='js/routes/common.min.js') }}"></script>
 {% endblock javascript %}
 


### PR DESCRIPTION
400 and 500 error pages had unminified JS path for common.js. This
commit changes it to the minified version in use.

## Changes

- Corrects JS path in 400 and 500 pages.

## Review

- @sebworks 
- @KimberlyMunoz 
- @jimmynotjim 