### PR TITLE
Fixing category icons and small typo in activity log

### DIFF
--- a/_includes/category-slug.html
+++ b/_includes/category-slug.html
@@ -33,5 +33,5 @@
     {{ category_icon(category, 'category-slug_icon')|safe }}
     <span class="u-visually-hidden">Category:</span>
     {{ category }}
-</a> 
+</a>
 {% endmacro -%}

--- a/_includes/post-macros.html
+++ b/_includes/post-macros.html
@@ -17,14 +17,14 @@
    ========================================================================== #}
 
 {% macro category_icon(category, additional_classes) %}
-    {%- if category|lower == 'announcements & updates' -%}
-    <span class="{{ additional_classes }} cf-icon cf-icon-bullhorn"></span>
-    {%- elif category|lower == 'consumer information' -%}
+    {%- if category|lower == 'info for consumers' -%}
     <span class="{{ additional_classes }} cf-icon cf-icon-information"></span>
-    {%- elif category|lower == 'engagement' -%}
-    <span class="{{ additional_classes }} cf-icon cf-icon-dialogue"></span>
-    {%- elif category|lower == 'innovation & data' -%}
-    <span class="{{ additional_classes }} cf-icon cf-icon-lightbulb"></span>
+    {%- elif category|lower == 'at the cfpb' -%}
+    <span class="{{ additional_classes }} cf-icon cf-icon-bullhorn"></span>
+    {%- elif category|lower == 'data, research & reports' -%}
+    <span class="{{ additional_classes }} cf-icon cf-icon-chart"></span>
+    {%- elif category|lower == 'policy & compliance' -%}
+    <span class="{{ additional_classes }} cf-icon cf-icon-bank-account"></span>
     {%- elif category|lower == 'speech' -%}
     <span class="{{ additional_classes }} cf-icon cf-icon-microphone"></span>
     {%- elif category|lower == 'press release' -%}

--- a/activity-log/index.html
+++ b/activity-log/index.html
@@ -18,12 +18,12 @@
 
     <h1>Activity Log</h1>
     <p class="h3">
-        Find the latest CFPB activities and publications here. Use the filters 
+        Find the latest CFPB activities and publications here. Use the filters
         below to browse by date, specific topics, or types of posts.
     </p>
 
     <div class="block__sub u-mb0">
-        
+
         <div id="pagination_content"></div>
 
         {{ filters(
@@ -41,7 +41,7 @@
                                 {%- set activity_type = item.category.0 %}
                             {%- endif -%}
                         {%- elif item.type == 'posts' -%}
-                            {% set activity_type = 'blog' %}
+                            {% set activity_type = 'Blog' %}
                         {%- endif %}
                         <span class="category-slug u-mb0">
                             {{ category_icon(activity_type, 'category-slug_icon')|safe }}


### PR DESCRIPTION
Fixing category icons on the blog. 

## Additions

- Added new categories with their appropriate icons

## Removals

- Removed old category names

## Changes

- Made a small change to `action-log/index.html` to fix #511
 
## Testing

- Visit /blog/ to see it in action
- This macro is also being used at /activity-log/, so test that page too.

## Review

- @anselmbradford 
- @sebworks 
- @jimmynotjim 

## Preview

![image](https://cloud.githubusercontent.com/assets/1860176/7484753/653b94d2-f35a-11e4-82c2-6fdbe781100b.png)

![image](https://cloud.githubusercontent.com/assets/1860176/7484771/a8b1f198-f35a-11e4-938e-b03fd7eed37d.png)

![image](https://cloud.githubusercontent.com/assets/1860176/7484781/c160478a-f35a-11e4-9792-8ff02503f71c.png)

[Preview this PR without the whitespace changes](?w=0)

## Notes
- A lot of the posts don't have new categories and look blank like this. From my understanding, this is a longer-term issue and outside of the scope of the review.

![image](https://cloud.githubusercontent.com/assets/1860176/7484769/94d0410c-f35a-11e4-837a-265858b3599f.png)