### PR TITLE
Remove postprocessing of date field in view processor

### DIFF
--- a/_lib/wordpress_view_processor.py
+++ b/_lib/wordpress_view_processor.py
@@ -44,9 +44,6 @@ def process_view(post):
         if key in custom_fields:
             related.append(custom_fields[key])
     post['related_links'] = related
-    dt = dateutil.parser.parse(post['date'])
-    dt_string = dt.strftime('%Y-%m-%dT%H:%M:%SZ')
-    post['date'] = dt_string
 
     # append the hero information
     if 'related_hero' in custom_fields and custom_fields['related_hero'][0] != '':


### PR DESCRIPTION
This reverts the only change made to the view processor since the previous successful deploy to beta.  Indexing views tripped up the deployment process recently, so I'm hoping this fixes it.  We're not using the date field of this post type, so the formatting of the date isn't important.