### PR TITLE
Update grunt-browserify to 3.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Added `--quiet` grunt CLI flag for suppressing linter warnings.
 
 ### Changed
+- Updated grunt-browserify to `^3.8.0`.
 
 ### Fixed
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
     "url": "http://github.com/cfpb/cfgov-refresh.git"
   },
   "devDependencies": {
-    "browserify": "^9.0.3",
     "browserify-shim": "^3.8.6",
     "cf-component-demo": "git://github.com/cfpb/cf-component-demo.git#0.8.2",
     "chai": "^2.3.0",
@@ -12,7 +11,7 @@
     "grunt-autoprefixer": "~0.6.5",
     "grunt-banner": "~0.2.2",
     "grunt-bower-task": "~0.4.0",
-    "grunt-browserify": "^3.7.0",
+    "grunt-browserify": "^3.8.0",
     "grunt-concurrent": "~1.0.0",
     "grunt-contrib-concat": "~0.4.0",
     "grunt-contrib-copy": "~0.5.0",

--- a/static/js/routes/common.min.js
+++ b/static/js/routes/common.min.js
@@ -11,7 +11,7 @@
  *                   $$
  *                   ""
  *
- *  cfgov-refresh - v3.0.0-0.3.0
+ *  cfgov-refresh - v3.0.0-1.0.0
  *  https://github.com/cfpb/cfgov-refresh *  A public domain work of the Consumer Financial Protection Bureau
  */
 (function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeof require=="function"&&require;if(!u&&a)return a(o,!0);if(i)return i(o,!0);var f=new Error("Cannot find module '"+o+"'");throw f.code="MODULE_NOT_FOUND",f}var l=n[o]={exports:{}};t[o][0].call(l.exports,function(e){var n=t[o][1][e];return s(n?n:e)},l,l.exports,e,t,n,r)}return n[o].exports}var i=typeof require=="function"&&require;for(var o=0;o<r.length;o++)s(r[o]);return s})({1:[function(require,module,exports){


### PR DESCRIPTION
Update grunt-browserify to 3.8.0 and removes redundant browserify dependency.

## Removals

- Removes browserify module from package.json, because browserify is downloaded via grunt-browserify already.

## Changes

- Fixes typo and order of grunt-browserify module to minimize conflicts with https://github.com/cfpb/cfgov-refresh/pull/527
- Update grunt-browserify to 3.8.0 from 3.7.0, which updates Browserify to 10.0.

## Testing

- Throw out node_modules and re-install with `npm update`. Run `grunt vendor` and `grunt jsdev` to regenerate assets and see that the site doesn't break.

## Review

- @KimberlyMunoz 
- @sebworks 
- @jimmynotjim 