### PR TITLE
Eslint quiet flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 ## Unreleased - unreleased
 
 ### Added
+- Added `--quiet` grunt CLI flag for suppressing linter warnings.
 
 ### Changed
 

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -7,6 +7,12 @@ module.exports = function(grunt) {
 
   var path = require('path');
 
+  // Allows a `--quiet` flag to be passed to Grunt from the command-line.
+  // If the flag is present the value is true, otherwise it is false.
+  // This flag can be used to, for example, suppress warning output
+  // from linters.
+  var envQuiet = grunt.option('quiet') ? true : false;
+
   var config = {
 
     /**
@@ -293,7 +299,7 @@ module.exports = function(grunt) {
        */
       eslint: {
         options: {
-            quiet: false
+            quiet: envQuiet
         },
         src: [
             'src/static/js/**/*.js',


### PR DESCRIPTION
Adds `--quiet` grunt option so that CLI can suppress linter warnings, if desired.

## Additions

- Adds `--quiet` grunt option, with false as a default value.

## Changes

- Sets eslint `quiet` option to use value of `--quiet` flag.

## Testing

- Run `grunt lintjs` and see warnings in the output, run `grunt lintjs --quiet` and see no warnings. It can also be attached to other commands, such as `grunt test --quiet` and `grunt jsdev --quiet`.

## Review

- @jimmynotjim 
- @sebworks 
- @KimberlyMunoz 