### PR TITLE
Fixed email subscribe on office page template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Updated grunt-browserify to `^3.8.0`.
 
 ### Fixed
+- Fixed macro on offices page template
 
 ## 3.0.0-1.0.0
 

--- a/offices/_offices-index.html
+++ b/offices/_offices-index.html
@@ -40,8 +40,8 @@
             <section class="content-l_col content-l_col-1-2 content-l_col__before-divider">
                 <p class="h3 u-show-on-mobile">Stay informed</p>
                 <p class="short-desc">Stay up to date with our email newsletter</p>
-                {% import "email-subscribe-form.html" as subscribe with context %}
-                {{ subscribe.render(null, office.intro_govdelivery_code) }}
+                {% from "macros.html" import subscribe as subscribe with context %}
+                {{ subscribe(office.intro_govdelivery_code) }}
             </section>
         {% endif %}
     </section>


### PR DESCRIPTION
This fixes the jinja error on the Office Page template by updating the macro from #505.

## Changes

- Changed email macro on office template

## Testing

1. Index on a server that has the offices post_page type.
2. Navigate to /offices/students-2/
3. No more Jinja error!

## Review

- @jimmynotjim 
- @anselmbradford 
- @sebworks 

## Notes

- Resolves DF-1873