### PR TITLE
Adds path variables to gruntfile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Updated grunt-banner to `^0.4.0` and updates banner ascii art and format.
 - Changed bower.json authors array field to use `homepage` in place of `url`,
   and adds `email` field.
+- Adds path variables to Gruntfile.
 
 ### Fixed
 - Fixed macro on offices page template

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -21,6 +21,15 @@ module.exports = function(grunt) {
     pkg: grunt.file.readJSON('bower.json'),
 
     /**
+     * Set some src and dist location variables.
+     */
+    loc: {
+      src: './src',
+      dist: '.',
+      test: './_tests'
+    },
+
+    /**
      * Bower: https://github.com/yatskevich/grunt-bower-task
      *
      * Install Bower packages and migrate static assets.
@@ -138,11 +147,13 @@ module.exports = function(grunt) {
           paths: grunt.file.expand('vendor/**/'),
           compress: true,
           sourceMap: true,
-          sourceMapFilename: 'static/css/main.css.map', // where file is generated and located
-          sourceMapURL: 'main.css.map', // the complete url and filename put in the compiled css file
+          // Where the sourcemap file is generated and located.
+          sourceMapFilename: '<%= loc.dist %>/static/css/main.css.map',
+          // The complete URL and sourcemap filename put in the compiled CSS file.
+          sourceMapURL: 'main.css.map',
         },
         files: {
-          'static/css/main.css': ['static/css/main.less']
+          '<%= loc.dist %>/static/css/main.css': ['static/css/main.less']
         }
       }
     },
@@ -161,7 +172,7 @@ module.exports = function(grunt) {
       main: {
         // Prefix `static/css/main.css` and overwrite.
         expand: true,
-        src: ['static/css/main.css']
+        src: ['<%= loc.dist %>/static/css/main.css']
       },
     },
 
@@ -175,8 +186,8 @@ module.exports = function(grunt) {
      */
     browserify: {
       build: {
-        src: 'src/static/js/routes/**/*.js',
-        dest: 'static/js/routes/common.min.js'
+        src: '<%= loc.src %>/static/js/routes/**/*.js',
+        dest: '<%= loc.dist %>/static/js/routes/common.min.js'
       },
       options: {
         // Note: The transforms for minification and
@@ -217,7 +228,7 @@ module.exports = function(grunt) {
           linebreak: true
         },
         files: {
-          src: ['static/css/*.min.css']
+          src: ['<%= loc.dist %>/static/css/*.min.css']
         }
       },
       js: {
@@ -227,7 +238,7 @@ module.exports = function(grunt) {
           linebreak: true
         },
         files: {
-          src: ['static/js/**/*.min.js']
+          src: ['<%= loc.dist %>/static/js/**/*.min.js']
         }
       }
     },
@@ -241,12 +252,12 @@ module.exports = function(grunt) {
       'ie-alternate': {
         options: {
           // Flatten all media queries with a min-width over 960 or lower.
-          // All media queries over 960 will be excluded fromt he stylesheet.
+          // All media queries over 960 will be excluded from the stylesheet.
           // EM calculation: 960 / 16 = 60
           legacyWidth: 60
         },
         files: {
-          'static/css/main.ie.css': 'static/css/main.css'
+          '<%= loc.dist %>/static/css/main.ie.css': '<%= loc.dist %>/static/css/main.css'
         }
       }
     },
@@ -302,8 +313,8 @@ module.exports = function(grunt) {
             quiet: envQuiet
         },
         src: [
-            'src/static/js/**/*.js',
-            '_tests/unit_tests/*.js'
+            '<%= loc.src %>/static/js/**/*.js',
+            '<%= loc.test %>/unit_tests/*.js'
         ]
       }
     },
@@ -313,10 +324,10 @@ module.exports = function(grunt) {
      */
     mocha_istanbul: {
       coverage: {
-        src: ['_tests/unit_tests/**/*.js'],
+        src: ['<%= loc.test %>/unit_tests/**/*.js'],
         options: {
-          coverageFolder: '_tests/unit_test_coverage',
-          excludes: ['_tests/unit_tests/**/*.js']
+          coverageFolder: '<%= loc.test %>/unit_test_coverage',
+          excludes: ['<%= loc.test %>/unit_tests/**/*.js']
         }
       }
     },
@@ -329,7 +340,7 @@ module.exports = function(grunt) {
      */
     watch: {
       all: {
-        files: ['static/css/*.less', 'src/static/js/**/*.js', 'Gruntfile.js'],
+        files: ['static/css/*.less', '<%= loc.src %>/static/js/**/*.js', 'Gruntfile.js'],
         tasks: ['default']
       },
       css: {
@@ -337,7 +348,7 @@ module.exports = function(grunt) {
         tasks: ['cssdev']
       },
       cssjs: {
-        files: ['static/css/*.less', 'src/static/js/**/*.js'],
+        files: ['static/css/*.less', '<%= loc.src %>/static/js/**/*.js'],
         tasks: ['cssdev', 'jsdev']
       }
     },


### PR DESCRIPTION
Adds path variables to Gruntfile for consistency with generator-cf, with the addition of a test directory path. Part of DF-1857.

## Additions

- Adds `loc.src`, `loc.dist`, and `loc.test` path variables to Gruntfile.

## Testing

- All grunt tasks should not have changed.

## Review

- @jimmynotjim 
- @sebworks 
- @KimberlyMunoz 

## Notes

- Paths in the gruntfile that are not prefixed with the path variables are the vendor paths, which will be moving to /src/, the CSS source paths, which will also be moving to /src/, and the legacy-static paths, which are special snowflakes.


