### PR TITLE
Removes string-replace:static-legacy task from Gruntfile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,9 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 
 - Replaced missing string_score library for the type-and-filter plugin
 
+### Removed
+- Removed string-replace:static-legacy Grunt task.
+
 ## 3.0.0-1.0.0
 
 ### Added

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -52,47 +52,6 @@ module.exports = function(grunt) {
      * Replace strings on files by using string or regex patters.
      */
     'string-replace': {
-      'static-legacy': {
-        files: {
-          'static-legacy/css/styles.css': 'static-legacy/css/styles.css'
-        },
-        options: {
-          replacements: [
-            {
-              pattern: /"Avenir Next"/ig,
-              replacement: '"AvenirNextLTW01-Regular"'
-            },
-            {
-              pattern: /"Avenir Next Regular"/ig,
-              replacement: '"AvenirNextLTW01-Regular"'
-            },
-            {
-              pattern: /"Avenir Next Demi"/ig,
-              replacement: '"AvenirNextLTW01-Demi"'
-            },
-            {
-              pattern: /"Avenir Next Demi Italic"/ig,
-              replacement: '"AvenirNextLTW01-Demi"'
-            },
-            {
-              pattern: /"Avenir Next Medium"/ig,
-              replacement: '"AvenirNextLTW01-Medium"'
-            },
-            {
-              pattern: /font-weight:(?:\s)*400;/ig,
-              replacement: 'font-family: "AvenirNextLTW01-Regular", Arial, sans-serif;'
-            },
-            {
-              pattern: /font-weight:(?:\s)*500;/ig,
-              replacement: 'font-family: "AvenirNextLTW01-Medium", Arial, sans-serif;'
-            },
-            {
-              pattern: /font-weight:(?:\s)*600;/ig,
-              replacement: 'font-family: "AvenirNextLTW01-Demi", Arial, sans-serif;'
-            }
-          ]
-        }
-      },
       chosen: {
         files: {
           'vendor/chosen/': 'vendor/chosen/chosen.css'
@@ -424,7 +383,7 @@ module.exports = function(grunt) {
   /**
    * Create custom task aliases and combinations.
    */
-  grunt.registerTask('vendor', ['bower:install', 'string-replace:chosen', 'string-replace:static-legacy',
+  grunt.registerTask('vendor', ['bower:install', 'string-replace:chosen',
                                 'copy:static-legacy', 'concat:cf-less']);
   grunt.registerTask('cssdev', ['less', 'autoprefixer', 'legacssy', 'usebanner:css']);
   grunt.registerTask('jsdev', ['lintjs', 'browserify:build', 'usebanner:js']);


### PR DESCRIPTION
Removes string-replace:static-legacy task. Fixes #543.

## Removals

- Removes Grunt `string-replace:static-legacy` task and references to that task.

## Testing

- Grunt should still work as expected. Grunt vendor will have one less task.

## Review

- @KimberlyMunoz 
- @sebworks 
- @jimmynotjim 
