### PR TITLE
Creates Grunt build task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Added cf-notifications stylesheet to style notifications
 - Added cf_notifier plugin for sending UI notifications
 - Added cf_formValidator plugin for validating form inputs
+- Added Grunt `build` task and set it as default.
 
 ### Changed
 - Updated grunt-browserify to `^3.8.0`.
@@ -32,6 +33,8 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
   and adds `email` field.
 - Adds path variables to Gruntfile.
 - Updated form-validation script to use cf_formValidator and cf_notifier
+- Changed Grunt `jsdev` and `cssdev` to `js` and `css`.
+- Moved testing to build task.
 
 ### Fixed
 - Fixed macro on offices page template

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -304,11 +304,11 @@ module.exports = function(grunt) {
       },
       css: {
         files: ['static/css/*.less'],
-        tasks: ['cssdev']
+        tasks: ['css']
       },
       cssjs: {
         files: ['static/css/*.less', '<%= loc.src %>/static/js/**/*.js'],
-        tasks: ['cssdev', 'jsdev']
+        tasks: ['css', 'js']
       }
     },
 
@@ -396,12 +396,14 @@ module.exports = function(grunt) {
    */
   grunt.registerTask('vendor', ['bower:install', 'string-replace:chosen',
                                 'copy:static-legacy', 'concat:cf-less']);
-  grunt.registerTask('cssdev', ['less', 'autoprefixer', 'legacssy', 'usebanner:css']);
-  grunt.registerTask('jsdev', ['lintjs', 'browserify:build', 'usebanner:js']);
-  grunt.registerTask('default', ['cssdev', 'jsdev', 'copy:vendor', 'concurrent:topdoc']);
+  grunt.registerTask('css', ['less', 'autoprefixer', 'legacssy', 'usebanner:css']);
+  grunt.registerTask('js', ['browserify:build', 'usebanner:js']);
   grunt.registerTask('test', ['lintjs', 'mocha_istanbul']);
   grunt.registerMultiTask('lintjs', 'Lint the JavaScript', function(){
     grunt.config.set(this.target, this.data);
     grunt.task.run(this.target);
   });
+
+  grunt.registerTask('build', ['test', 'css', 'js', 'copy:vendor']);
+  grunt.registerTask('default', ['build']);
 };


### PR DESCRIPTION
Creates Grunt build task. Part of DF-1857.

## Additions

- Adds Grunt build task.

## Changes

- Sets build task to Grunt default.
- Changes `jsdev` and `cssdev` task names to `js` and `css`.
- Moves testing to build task.

## Testing

- `grunt` and `grunt build` should both build the assets. `grunt js` and `grunt css` should work, and `grunt jsdev` and `grunt cssdev` should not.

## Review

- @jimmynotjim 
- @sebworks 
- @KimberlyMunoz 

## Notes

- JS/CSS names are based on generator-cf https://github.com/cfpb/generator-cf/blob/master/app/templates/_Gruntfile.js#L296-L297