### PR TITLE
Adds setup.sh script for bootstrapping the project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Added ajax subscription submission.
 - Initiative folder and files for Initiative pages
 - Added custom template for FOIA faqs page
+- Added `setup.sh` script for bootstrapping the project.
 
 ### Changed
 - Updated grunt-browserify to `^3.8.0`.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -148,11 +148,10 @@ cd cfgov-refresh
 Next, install dependencies with:
 
 ```bash
-npm install
-grunt vendor
+./setup.sh
 ```
 
-> **NOTE**: After installing dependencies, rebuild all the site’s assets by running `grunt`.
+> **NOTE**: To re-install and rebuild all the site’s assets run `./setup.sh` again.
 See the usage section [updating all the project dependencies](README.md#updating-all-dependencies).
 
 

--- a/README.md
+++ b/README.md
@@ -65,15 +65,7 @@ git checkout refresh  # Branch for our staging-stable server.
 #### Updating all dependencies
 
 Each time you fetch from the upstream repository (this repo),
-you should install and update dependencies with npm and `grunt vendor`,
-and then run `grunt` to rebuild all the site's assets:
-
-```bash
-npm install
-npm update
-grunt vendor
-grunt
-```
+you should install and update dependencies by running `./setup.sh`.
 
 
 ### 2. Run Elasticsearch

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,53 @@
+#!/bin/sh
+
+# Set script to exit on any errors.
+set -e
+
+# Initialize project dependency directories.
+init(){
+  NODE_DIR=node_modules
+  BOWER_DIR=bower_components
+
+  if [ -f .bowerrc ]; then
+    # Get the "directory" line from .bowerrc
+    BOWER_DIR=$(grep "directory" .bowerrc)
+    # Strip off the first part of that line.
+    BOWER_DIR=${BOWER_DIR/\"directory\"\: \"/}
+    # Strip off the final " from the line.
+    BOWER_DIR="${BOWER_DIR%?}"
+    echo 'Bower components directory:' $BOWER_DIR
+  fi
+}
+
+# Clear project dependencies.
+clear(){
+  # If the node and bower directories already exist,
+  # clear them so we know we're working with a clean
+  # slate of the dependencies listed in package.json
+  # and bower.json.
+  if [ -d $NODE_DIR ] || [ -d $BOWER_DIR ]; then
+    echo 'Removing project dependency directories...'
+    rm -rf $NODE_DIR
+    rm -rf $BOWER_DIR
+  fi
+  echo 'Project dependencies have been removed.'
+}
+
+# Install project dependencies.
+install(){
+  echo 'Installing project dependencies...'
+  npm install
+  bower install
+}
+
+# Run tasks to build the project for distribution.
+build(){
+  echo 'Building project...'
+  grunt vendor
+  grunt build
+}
+
+init
+clear
+install
+build


### PR DESCRIPTION
Adds setup.sh script for bootstrapping the project and updates
installation instructions.

## Additions

- Adds setup.sh script for bootstrapping the project.

## Changes

- Updates README.md and INSTALL.md.

## Testing

- From the root directory, run `./setup.sh`. That's all. YESSS! Want to re-install everything? Run `./setup.sh`.

Site should function/look the same.

## Review

- @KimberlyMunoz 
- @jimmynotjim 
- @sebworks 

## Notes

- See background in https://github.com/cfpb/front-end/issues/49
- Sorry for the weekend update. Since I'm out most of next week I wanted to get it in before I forgot what on earth I was doing. Doesn't have to be in this sprint.
