### PR TITLE
Remove `copy:static-legacy` and `grunt-contrib-copy`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - alert macro
 - Unused index.html file from /initiatives/
 - Unnecessary setting of template variables
+- Removes `copy:static-legacy` and `grunt-contrib-copy` package.
 
 
 ## 3.0.0-1.0.1 - 2015-05-18

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -222,44 +222,6 @@ module.exports = function(grunt) {
     },
 
     /**
-     * Copy: https://github.com/gruntjs/grunt-contrib-copy
-     *
-     * Copy files and folders.
-     */
-    copy: {
-      'static-legacy': {
-        files:
-        [
-          {
-            expand: true,
-            cwd: 'vendor/cf-core/',
-            src: [
-              'licensed-fonts.css'
-            ],
-            dest: 'static-legacy/css/'
-          }
-        ]
-      },
-      vendor: {
-        files:
-        [
-          {
-            expand: true,
-            cwd: '',
-            src: [
-              // Only include vendor files that we use independently
-              'vendor/html5shiv/html5shiv-printshiv.min.js',
-              'vendor/box-sizing-polyfill/boxsizing.htc',
-              'vendor/slick-carousel/slick.min.js',
-              'vendor/slick-carousel/slick.css'
-            ],
-            dest: 'static'
-          }
-        ]
-      }
-    },
-
-    /**
      * Lint the JavaScript.
      */
     lintjs: {
@@ -394,8 +356,7 @@ module.exports = function(grunt) {
   /**
    * Create custom task aliases and combinations.
    */
-  grunt.registerTask('vendor', ['bower:install', 'string-replace:chosen',
-                                'copy:static-legacy', 'concat:cf-less']);
+  grunt.registerTask('vendor', ['bower:install', 'string-replace:chosen', 'concat:cf-less']);
   grunt.registerTask('css', ['less', 'autoprefixer', 'legacssy', 'usebanner:css']);
   grunt.registerTask('js', ['browserify:build', 'usebanner:js']);
   grunt.registerTask('test', ['lintjs', 'mocha_istanbul']);
@@ -404,6 +365,6 @@ module.exports = function(grunt) {
     grunt.task.run(this.target);
   });
 
-  grunt.registerTask('build', ['test', 'css', 'js', 'copy:vendor']);
+  grunt.registerTask('build', ['test', 'css', 'js']);
   grunt.registerTask('default', ['build']);
 };

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
     "grunt-browserify": "^3.8.0",
     "grunt-concurrent": "~1.0.0",
     "grunt-contrib-concat": "~0.4.0",
-    "grunt-contrib-copy": "~0.5.0",
     "grunt-contrib-less": "~0.11.0",
     "grunt-contrib-watch": "~0.5.3",
     "grunt-eslint": "^13.0.0",


### PR DESCRIPTION
Removes legacy copy static-legacy task and associated package.

## Removals

- Remove `copy:static-legacy` and `grunt-contrib-copy` package.

## Testing

- No change.

## Review

- @Scotchester 
- @KimberlyMunoz 
- @sebworks 
- @jimmynotjim 

## Notes

- Like https://github.com/cfpb/cfgov-refresh/pull/544 this task appears only to be needed if the CF font was updated and the legacy pages at `/budget/strategic-plan/interactive/` needed those updated fonts, or if another legacy page was added. See https://github.com/cfpb/cfgov-refresh/issues/543#issuecomment-102077254 