### PR TITLE
Relaxes ESLint key-spacing rule to warning

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -470,7 +470,7 @@ rules:
 
   # Enforce spacing between keys and values in object literal properties.
   key-spacing:
-    - 2
+    - 1
     -
       align: value
       beforeColon: false
@@ -557,7 +557,6 @@ rules:
   operator-assignment:
     - 2
     - always
-
 
   # Enforce operators to be placed before or after line breaks.
   operator-linebreak:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Updated 404 image to the latest image provided by the design team.
 - Office folder and files for Office pages
 - Updated template for office pages
+- Relaxed ESLint `key-spacing` rule to warning.
 
 ### Fixed
 - Fixed macro on offices page template


### PR DESCRIPTION
Relaxes key-spacing rule to warning for consistency with space-in-parens and space-in-bracket settings.

## Changes

- Changes key-spacing to warning.
- Removes unneeded newline.

## Testing

- Misalignment of property values in an object literal should throw a warning, not an error, and thus won't break a build.

## Review

- @sebworks 
- @jimmynotjim 
- @KimberlyMunoz 

## Notes
- Per update in https://github.com/cfpb/front-end/pull/50