### PR TITLE
Updated key names in contact info condition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Sheer indexing error when related posts are deleted
 - Office and Initiative processors
 - Slick carousel site-wide JS error.
+- Fixed issue with some contacts not showing phone numbers and email addresses
 
 ### Removed
 - Removed string-replace:static-legacy Grunt task.

--- a/_includes/contact-macro.html
+++ b/_includes/contact-macro.html
@@ -15,7 +15,7 @@
     {%- endif %}
     </div>
     <div class="content-l_col content-l_col-1-2">
-    {%- if contact.email_addr or contact.phone_num or contact.fax_num or contact.street %}
+    {%- if contact.email_0_addr or contact.phone_0_num or contact.fax_num or contact.street %}
         <ul class="list list__icons">
         {%- if contact.email_0_addr %}
             <li class="list_item u-break-word">


### PR DESCRIPTION
Updated key names in contact info condition. Fixes issue where some contacts weren't showing phone numbers and email addrs

## Additions

- None

## Removals

- None

## Changes

- Updated contact condition in contact-macro 

## Testing

- Checkout branch and check offices in `/contact-us`

## Review

- @KimberlyMunoz 
- @sebworks 
- @anselmbradford 

## Preview

![screen shot 2015-05-19 at 11 04 29 am](https://cloud.githubusercontent.com/assets/1280430/7706189/d7beabcc-fe16-11e4-9490-ee271b228fb5.png)

[Preview this PR without the whitespace changes](?w=0)

## Notes

- Hat toss to @dpford for finding this