### PR TITLE
Adds top and first-level nav items configuration file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Added `grunt watch:js` task for completeness.
 - Added vendor directory variable to `main.less`.
 - Added warning for concat:cf-less Grunt task when sourcefiles are missing.
+- Added toplevel navigation items config file for removing hardcoded
+  navigation menu items.
 
 ### Changed
 - Relaxed ESLint `key-spacing` rule to warning.

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -6,10 +6,11 @@
                    list__horizontal
                    list-expanding">
             {%- for top_level, first_level in vars.nav_items_toplevel %}
+            {% set first_level_length = first_level|length %}
             <li class="list_item list-expanding_list-item">
-                <a class="list_link
-                          {{ ' list-expanding_trigger' if first_level|length > 0
-                          else ' list_link__disabled' }}">
+                {%- if first_level_length > 0 %}
+                {# TODO: Make this a <button>, it is not a real link. #}
+                <a class="list_link list-expanding_trigger" href="#">
                     {{ top_level }}
                 </a>
                 <div class="desktop-menu_full-wrapper">
@@ -27,6 +28,11 @@
                         </ul>
                     </div>
                 </div>
+                {%- else %}
+                <a class="list_link list_link__disabled">
+                    {{ top_level }}
+                </a>
+                {%- endif %}
             </li>
             {%- endfor %}
         </ul><!-- END .primary-nav_top-level-list -->

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -6,9 +6,8 @@
                    list__horizontal
                    list-expanding">
             {%- for top_level, first_level in vars.nav_items_toplevel %}
-            {% set first_level_length = first_level|length %}
             <li class="list_item list-expanding_list-item">
-                {%- if first_level_length > 0 %}
+                {%- if first_level|length > 0 %}
                 {# TODO: Make this a <button>, it is not a real link. #}
                 <a class="list_link list-expanding_trigger" href="#">
                     {{ top_level }}

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,24 +1,17 @@
+{% import "nav-items-toplevel.html" as vars with context %}
     <nav class="primary-nav">
         <ul class="primary-nav_top-level-list
                    wrapper
                    list__unstyled
                    list__horizontal
                    list-expanding">
+            {%- for top_level, first_level in vars.nav_items_toplevel %}
             <li class="list_item list-expanding_list-item">
-                <a class="list_link list_link__disabled">TBD Content</a>
-            </li>
-            <li class="list_item list-expanding_list-item">
-                <a class="list_link list_link__disabled">TBD Content</a>
-            </li>
-            <li class="list_item list-expanding_list-item">
-                <a class="list_link list_link__disabled">TBD Content</a>
-            </li>
-            <li class="list_item list-expanding_list-item">
-                <a class="list_link list_link__disabled">TBD Content</a>
-            </li>
-            <li class="list_item list-expanding_list-item">
-                <!-- TODO: Make this a <button>, it is not a real link -->
-                <a class="list_link list-expanding_trigger" href="#">About</a>
+                <a class="list_link
+                          {{ ' list-expanding_trigger' if first_level|length > 0
+                          else ' list_link__disabled' }}">
+                    {{ top_level }}
+                </a>
                 <div class="desktop-menu_full-wrapper">
                     <div class="desktop-menu_full-wrapper_decoration">
                         <ul class="wrapper
@@ -26,31 +19,16 @@
                                    list__horizontal
                                    desktop-menu_horizontal-list
                                    list-expanding list-expanding_child-list">
+                            {%- for href, id, caption in first_level %}
                             <li class="list_item list-expanding_list-item">
-                                <a class="list_link" href="/blog/">Blog</a>
+                                <a class="list_link" href="{{ href|e }}">{{ caption|e }}</a>
                             </li>
-                            <li class="list_item list-expanding_list-item">
-                                <a class="list_link" href="/newsroom/">Newsroom</a>
-                            </li>
-                            <li class="list_item list-expanding_list-item">
-                                <a class="list_link" href="/contact-us/">Contact Us</a>
-                            </li>
-                            <li class="list_item list-expanding_list-item">
-                                <a class="list_link" href="/the-bureau/">About the Bureau</a>
-                            </li>
-                            <li class="list_item list-expanding_list-item">
-                                <a class="list_link" href="/activity-log/">Activity Log</a>
-                            </li>
-                            <li class="list_item list-expanding_list-item">
-                                <a class="list_link" href="/budget/">Budget and Strategy</a>
-                            </li>
-                            <li class="list_item list-expanding_list-item">
-                                <a class="list_link" href="/doing-business-with-us/">Doing Business with Us</a>
-                            </li>
+                            {%- endfor %}
                         </ul>
                     </div>
                 </div>
             </li>
+            {%- endfor %}
         </ul><!-- END .primary-nav_top-level-list -->
     </nav><!-- END .primary-nav -->
 
@@ -81,6 +59,8 @@
             </noscript>
         </a>
 
+        {# TODO: Re-add this block when the content is cleared for release,
+                 and an Español link exists. #}
         {#
         <div class="header_misc">
             Contact us: <a class="header_misc_tel" href="tel:8554112372">(855) 411-2372</a>

--- a/_includes/nav-items-toplevel.html
+++ b/_includes/nav-items-toplevel.html
@@ -1,0 +1,20 @@
+
+{#
+  Top and first-level menu items,
+  used to populate the contents of the site's navigation menus.
+#}
+{% set nav_items_toplevel = [
+    ('TBD Content', []),
+    ('TBD Content', []),
+    ('TBD Content', []),
+    ('TBD Content', []),
+    ('About', [
+      ('/blog/', 'blog', 'Blog'),
+      ('/newsroom/', 'newsroom', 'Newsroom'),
+      ('/contact-us/', 'contact-us', 'Contact Us'),
+      ('/the-bureau/', 'the-bureau', 'About the Bureau'),
+      ('/activity-log/', 'activity-log', 'Activity Log'),
+      ('/budget/', 'budget', 'Budget and Strategy'),
+      ('/doing-business-with-us/', 'doing-business-with-us', 'Doing Business with Us')
+    ])
+] -%}


### PR DESCRIPTION
Adds top and first-level nav items configuration file to remove hardcoded
navigation menu items.

## Additions

- Added top and first-level navigation items config file for removing hardcoded navigation menu items in the main menu.
- Adds TODO comment for commented out Español code block.

## Changes

- Builds main menu from global nav-items configuration file.

## Testing

- Main menu should function/look the same.

## Review

- @jimmynotjim 
- @KimberlyMunoz 
- @sebworks 

## Notes

- Part of DF-1963, because I need a list for the sidenav menu to build the structure from. This is a self-contained change so I wanted to spin it off for feedback while I worked on the sidenav implementation.