### PR TITLE
Fixes #592 - removes legacy section_vars

### DIFF
--- a/_layouts/layout-side-nav.html
+++ b/_layouts/layout-side-nav.html
@@ -1,7 +1,7 @@
 {% extends "layout-1-3.html" %}
 
 {#
-    docs/layout-side-nav.html
+    docs/sheer-layouts/layout-side-nav/
 
     Since layout-side-nav.html extends from layout-1-3.html all we need to do
     is set some side nav variables and override the `content_sidebar` block to
@@ -9,11 +9,14 @@
 #}
 
 {# Side nav vars #}
-{% if section_vars and section_vars.nav_items %}
-    {% set nav_items = section_vars.nav_items %}
-{% else %}
-    {% set nav_items = [("/_layouts/layout-side-nav.html", "", "Please review the instructions in _layouts/layout-side-nav.html for setting up the side nav.")] %}
-{% endif %}
+
+{# Set default value for nav_items array. #}
+{% set nav_items = [(
+    "/docs/sheer-layouts/layout-side-nav/",
+    "",
+    "Please review the instructions in _layouts/layout-side-nav.html for setting up the side nav."
+)] %}
+
 {% set active_nav_id = active_nav_id|default("index") -%}
 
 {# Adding the side nav macro #}


### PR DESCRIPTION
Fixes #592 - removes legacy `section_vars`.

## Removals

- Fixes #592 - removes legacy section_vars, which is unused.

## Changes

- Updates URL in code comment to correct docs URL.

## Testing

- Site should function the same.

## Review

- @KimberlyMunoz 
- @jimmynotjim 
- @sebworks 
