### PR TITLE
Relaxes ESLint complexity to max 4

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -156,7 +156,7 @@ rules:
   # Enforces specific maximum cyclomatic complexity.
   complexity:
     - 1
-    - 3
+    - 4
 
   # Enforces return statements to either always or never specify values.
   consistent-return: 2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,6 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
   navigation menu items.
 - Added external url redirect page, styles, and JavaScript.
 
-
 ### Changed
 - Relaxed ESLint `key-spacing` rule to warning.
 - Refactored breakpoint-handler module into separate class modules
@@ -46,6 +45,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Added custom template for FOIA records page.
 - Refactored code for Wordpress updates
 - Initiatives renamed to Sub-pages
+- Relaxed ESLint cyclomatic `complexity` rule to max 4 complexity.
 
 ### Fixed
 - Fixed an issue where scripts were being initialized out of order


### PR DESCRIPTION
Relaxes ESLint complexity to max 4 to conform to fewd standards setting.

## Changes

- Relax ESLint complexity setting from max 3 complexity to 4. See https://github.com/cfpb/front-end/pull/51 for background reading.

## Testing

- ESlint won't show warnings for cyclomatic complexity 4 code. (For example an if/elseif/elseif statement.)

## Review

- @sebworks 
- @KimberlyMunoz 
- @jimmynotjim 