### PR TITLE
Changing text of H1 above The Bureau intro paragraph

### DIFF
--- a/the-bureau/index.html
+++ b/the-bureau/index.html
@@ -62,7 +62,7 @@
 
 {% block content_main %}
 
-    <h1>Who we are</h1>
+    <h1>The Bureau</h1>
     <p class="h3">We work to make markets for consumer financial products and services work
     for Americans. We arm people with the information they need to make smart financial
     decisions, and we protect them from unfair, deceptive, and abusive practices.</p>

--- a/the-bureau/index.html
+++ b/the-bureau/index.html
@@ -62,7 +62,7 @@
 
 {% block content_main %}
 
-    <h1>Our mission</h1>
+    <h1>Who we are</h1>
     <p class="h3">We work to make markets for consumer financial products and services work
     for Americans. We arm people with the information they need to make smart financial
     decisions, and we protect them from unfair, deceptive, and abusive practices.</p>


### PR DESCRIPTION
## Change
The existing text, "Our mission," is not 100% accurate and ended up confusing people in testing. After some discussion, we decided to change.

"The Bureau" was also under consideration, as it mirrors the sidebar text. But the video hero at the top made putting the title there seem a bit anticlimactic. And it felt like that intro paragraph would need a bit of rework. "Who we are" seems like we can leave that text as-is.

## Review
* @schaferjh 