### PR TITLE
Automating our unit tests and macro tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,42 @@
+language: python
+
+python:
+  - "2.7"
+  - "3.3"
+
+env:
+  global:
+    - secure: NV5XM/xM7k4Qupdw1EJNOEuqU3aiPRgyI1j2C1KYdN/fT9AoVUEnmbFruOfPflqgyutJP6SlYtbYvoDau/BsD1Xqb9YSd+I5EgBzrJ7o7FIkuHB1hH8PXYDKRqCsSMUPW+h6K2h1wL5fizkLN9VAGWNfRAhkityu5qprvPzEd/4=
+    - secure: WGVk3/WczG1JaDqAS9wTU8pbpt548s9NkuWRS7AVHk+uNqO7lwfUesPSUU+U4DYwwxsX8KwpZ3+TiWtR+A/jUgk917rVTPtTpPflHacekxS2WTuKiMnXTXgqb3+rKX8/dcld9jj+ivwKUp65iVNgZ34kyzYNyWGwjeUqKSGKph8=
+
+addons:
+  sauce_connect: true
+
+services:
+  - elasticsearch
+
+install:
+  # Python test requirements
+  - pip install virtualenv virtualenvwrapper
+  - pip install autoenv
+  - git clone https://github.com/cfpb/sheer
+  - pip install -e sheer
+  - pip install -r sheer/requirements.txt
+  - cp .env_SAMPLE .env
+  - sheer index
+  - pip install -r _tests/processor_tests/requirements.txt
+
+  # JavaScript test requirements
+  - sudo add-apt-repository -y ppa:chris-lea/node.js
+  - sudo apt-get -y update
+  - sudo apt-get -y install nodejs
+  - sudo npm install -g grunt-cli
+  - sudo npm install -g bower
+  - sudo npm install
+
+script:
+  # Run tests for JavaScript
+  - grunt test
+
+  - cd _tests/processor_tests
+  - python test_processors.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: python
 
 python:
   - "2.7"
-  - "3.3"
 
 services:
   - elasticsearch
@@ -16,7 +15,7 @@ install:
   - pip install -r sheer/requirements.txt
   - cp .env_SAMPLE .env
   - sheer index
-  - pip install -r _tests/processor_tests/requirements.txt
+  - pip install -r _tests/macro_testing/requirements.txt
 
   # JavaScript test requirements
   - sudo add-apt-repository -y ppa:chris-lea/node.js
@@ -30,5 +29,5 @@ script:
   # Run tests for JavaScript
   - grunt test
 
-  - cd _tests/processor_tests
-  - python test_processors.py
+  - cd _tests/macro_testing
+  - python test_macros.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,14 +4,6 @@ python:
   - "2.7"
   - "3.3"
 
-env:
-  global:
-    - secure: NV5XM/xM7k4Qupdw1EJNOEuqU3aiPRgyI1j2C1KYdN/fT9AoVUEnmbFruOfPflqgyutJP6SlYtbYvoDau/BsD1Xqb9YSd+I5EgBzrJ7o7FIkuHB1hH8PXYDKRqCsSMUPW+h6K2h1wL5fizkLN9VAGWNfRAhkityu5qprvPzEd/4=
-    - secure: WGVk3/WczG1JaDqAS9wTU8pbpt548s9NkuWRS7AVHk+uNqO7lwfUesPSUU+U4DYwwxsX8KwpZ3+TiWtR+A/jUgk917rVTPtTpPflHacekxS2WTuKiMnXTXgqb3+rKX8/dcld9jj+ivwKUp65iVNgZ34kyzYNyWGwjeUqKSGKph8=
-
-addons:
-  sauce_connect: true
-
 services:
   - elasticsearch
 

--- a/_tests/macro_testing/requirements.txt
+++ b/_tests/macro_testing/requirements.txt
@@ -1,1 +1,1 @@
-macropolo==0.1.0
+-e git://github.com/cfpb/macropolo#egg=macropolo

--- a/_tests/macro_testing/tests/post-macros.json
+++ b/_tests/macro_testing/tests/post-macros.json
@@ -3,7 +3,7 @@
     "tests": [
         {
             "macro_name": "category_icon",
-            "arguments": ["announcements & updates", ""],
+            "arguments": ["at the cfpb", ""],
             "assertions": [
                 {
                     "selector": ".cf-icon-bullhorn",
@@ -13,10 +13,10 @@
         },
         {
             "macro_name": "category_icon",
-            "arguments": ["innovation & data", ""],
+            "arguments": ["data, research & reports", ""],
             "assertions": [
                 {
-                    "selector": ".cf-icon-lightbulb",
+                    "selector": ".cf-icon-chart",
                     "assertion": "exists"
                 }
             ]


### PR DESCRIPTION
Added our unit tests, the sheer installation and @willbarton's macro tests to Travis.

## Additions 

- Added travis.yml for Travis CI integration

## Changes

- Fixed requirements for our macro tests
- Updated the macro tests. (I think I was the one who originally broke them before I realized these existed. 😳)

## Testing

- If all goes according to plan there should be a green check mark below here in a couple minutes.

## Review

- @anselmbradford 
- @sebworks 
- @imuchnik & @contolini
- @willbarton

## Notes

- Browser tests will be added to Jenkins after this
- The processor tests will need to be fixed before we add them
- I left the Sheer installation in there since processor changes can sometimes mess with sheer indexing and it'd be great to have a heads up for those changes. ~~However I noticed that Travis will sometimes error out while installing the dependencies on Python 3.3.~~