### PR TITLE
Change processors and mappings to include specification of FAQ

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Added `primary_nav` jinja block to `base.html` template.
 - Added FAQ processor and mapping
 - Added `use_form` field to sub_pages
+ - Added `related_faq` field to sub_pages and offices
 
 ### Changed
 - Relaxed ESLint `key-spacing` rule to warning.

--- a/_lib/wordpress_office_processor.py
+++ b/_lib/wordpress_office_processor.py
@@ -91,7 +91,7 @@ def process_office(post):
         if name in custom_fields:
             post[name] = custom_fields[name]
 
-    for related in ["related_hero", "related_contact"]:
+    for related in ["related_hero", "related_contact", 'related_faq']:
         if related in custom_fields:
             if isinstance(custom_fields[related], basestring):
                 post[related] = custom_fields[related]

--- a/_lib/wordpress_sub_page_processor.py
+++ b/_lib/wordpress_sub_page_processor.py
@@ -29,26 +29,28 @@ def process_sub_page(post):
 
     del post['comments']
     post['_id'] = post['slug']
+    custom_fields = post['custom_fields']
 
     names = ['og_title', 'og_image', 'og_desc', 'twtr_text', 'twtr_lang',
              'twtr_rel', 'twtr_hash', 'utm_campaign', 'utm_term',
              'utm_content', 'show_in_office', 'use_filtered_feed', 'use_form',
              'body_content', 'related_links']
     for name in names:
-        if name in post['custom_fields']:
-            post[name] = post['custom_fields'][name]
-    if 'related_office' in post['custom_fields']:
-        if isinstance(post['custom_fields']['related_office'], basestring):
-            post['related_office'] = post['custom_fields']['related_office']
-        else:
-            post['related_office'] = post['custom_fields']['related_office'][0]
+        if name in custom_fields:
+            post[name] = custom_fields[name]
+    for related in ['related_office', 'related_faq']:
+        if related in custom_fields:
+            if isinstance(custom_fields[related], basestring):
+                post[related] = custom_fields[related]
+            else:
+                post[related] = custom_fields[related][0]
     if 'related_links' not in post:
         related = []
         for x in range(5):
             key = 'related_links_%s' % x
-            if key in post['custom_fields']:
-                related.append({'url': post['custom_fields'][key][0],
-                                'label': post['custom_fields'][key][1]})
+            if key in custom_fields:
+                related.append({'url': custom_fields[key][0],
+                                'label': custom_fields[key][1]})
         if related:
             post['related_links'] = related
     del post['custom_fields']

--- a/_settings/mappings/office.json
+++ b/_settings/mappings/office.json
@@ -74,10 +74,16 @@
       "type": "long"
     },
     "related_contact": {
-      "type": "string"
+      "type": "string",
+      "index": "not_analyzed"
+    },
+    "related_faq": {
+      "type": "string",
+      "index": "not_analyzed"
     },
     "related_hero": {
-      "type": "string"
+      "type": "string",
+      "index": "not_analyzed"
     },
     "relative_url": {
       "type": "string"

--- a/_settings/mappings/sub_page.json
+++ b/_settings/mappings/sub_page.json
@@ -75,6 +75,10 @@
     "parent": {
       "type": "long"
     },
+    "related_faq": {
+      "type": "string",
+      "index": "not_analyzed"
+    },
     "related_links": {
       "properties": {
         "label": {


### PR DESCRIPTION
Currently, we are associating FAQ's with sub-pages. We need them to be associated with offices as well, so it seems that forcing the sub_page and the office to specify the FAQ makes the most sense. This adds the related_faq field that contains the slug of the FAQ to retrieve. 

@dpford 