### PR TITLE
Add short_title and preview_text fields to sub_page document

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Added `related_faq` field to sub_pages and offices
 - Added `inset-divider` class for providing an inset horizontal rule
   independent of the list or list item widths within the side navigation bar.
+- Added `preview_text` and `short_title` fields to sub_pages
 
 ### Changed
 - Relaxed ESLint `key-spacing` rule to warning.

--- a/_lib/wordpress_sub_page_processor.py
+++ b/_lib/wordpress_sub_page_processor.py
@@ -34,7 +34,7 @@ def process_sub_page(post):
     names = ['og_title', 'og_image', 'og_desc', 'twtr_text', 'twtr_lang',
              'twtr_rel', 'twtr_hash', 'utm_campaign', 'utm_term',
              'utm_content', 'show_in_office', 'use_filtered_feed', 'use_form',
-             'body_content', 'related_links']
+             'body_content', 'related_links', 'short_title', 'preview_text']
     for name in names:
         if name in custom_fields:
             post[name] = custom_fields[name]

--- a/_settings/mappings/sub_page.json
+++ b/_settings/mappings/sub_page.json
@@ -75,6 +75,9 @@
     "parent": {
       "type": "long"
     },
+    "preview_text": {
+      "type": "string"
+    },
     "related_faq": {
       "type": "string",
       "index": "not_analyzed"
@@ -94,6 +97,9 @@
       "index": "not_analyzed"
     },
     "relative_url": {
+      "type": "string"
+    },
+    "short_title": {
       "type": "string"
     },
     "show_in_office": {


### PR DESCRIPTION
This merely adds the short_title and preview_text fields to the sub_page document for use in the templates.

- `short_title` is used for the `Our Work` section and the navigation so the actual title's of the sub_page's won't be too long for the module
- `preview_text` is the content used for specifying what the link to the sub_page should have as the text.

@sebworks @anselmbradford @dpford @KimberlyMunoz 