### PR TITLE
Normalizes office section titles, removes legacy code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,9 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Added `related_faq` field to sub_pages and offices
 - Added `inset-divider` class for providing an inset horizontal rule
   independent of the list or list item widths within the side navigation bar.
-- Added `preview_text` and `short_title` fields to sub_pages
+- Added `preview_text` and `short_title` fields to sub_pages.
+- Added `templates/activities-feed.html` HTML template for the activity feed
+  area on the offices and sub_pages.
 
 ### Changed
 - Relaxed ESLint `key-spacing` rule to warning.
@@ -72,6 +74,8 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Updated side navigation bar to keep page order at mobile sizes and adds
   "IN THIS SECTION" header text to the navigation bar dropdown menu.
 - Updated processors to use Elasticsearch bulk indexing
+- Office and sub-pages activity feed title to "Latest Activities"
+  and contacts to "Contact Information."
 
 ### Fixed
 - Fixed an issue where scripts were being initialized out of order

--- a/_includes/templates/activities-feed.html
+++ b/_includes/templates/activities-feed.html
@@ -1,0 +1,6 @@
+<h1 class="header-slug">
+    <span class="header-slug_inner">
+        Latest Activities
+    </span>
+</h1>
+{{ activities_feed }}

--- a/offices/_single.html
+++ b/offices/_single.html
@@ -179,15 +179,10 @@
                 block__flush-sides">
         {% if activities_feed %}
         <section class="office_activities">
-            <h1 class="header-slug">
-                <span class="header-slug_inner">
-                    Latest Office Activities
-                </span>
-            </h1>
-            {{ activities_feed }}
-            <!-- link to activities page? -->
-            <a class="jump-link jump-link__right" href="/activity-log/">
-                View all of our activity
+            {% include 'templates/activities-feed.html' %}
+            <a class="jump-link jump-link__right"
+               href="/activity-log/{{ ('?filter_tags=' ~ office.tags | join('&') ) if office.tags }}">
+                View all of our activities
             </a>
         </section>
         {% endif %}
@@ -198,7 +193,7 @@
         <section class="office_content block u-mb0">
             <h1 class="header-slug">
                 <span class="header-slug_inner">
-                    Office Contact Information
+                    Contact Information
                 </span>
             </h1>
             <div class="content-l content-l__main content-l__large-gutters">

--- a/sub-pages/_single.html
+++ b/sub-pages/_single.html
@@ -90,12 +90,7 @@
                   u-mb0
                   u-mt0">
         <section class="office_activities">
-            <h1 class="header-slug">
-                <span class="header-slug_inner">
-                    Activities
-                </span>
-            </h1>
-            {{ activities_feed }}
+            {% include "templates/activities-feed.html" %}
         </section>
     </aside>
     {% endif %}

--- a/sub-pages/_vars-sub-pages.html
+++ b/sub-pages/_vars-sub-pages.html
@@ -3,9 +3,6 @@
 {% set nav_sub_pages = query.search_with_url_arguments(size=15, filter_related_office=sub_page.related_office, filter_has_parent=false) %}
 {% set office = get_document('office', sub_page.related_office) %}
 
-{% set tag = "foia" %}
-{% set activity_type = ["cfpb_report"] %}
-
 {% set path = '/sub_pages/' %}
 {% set nav_items =
     [(office.permalink, office.slug, office.title)]


### PR DESCRIPTION
Normalizes office section titles and removes legacy code.

## Additions

- Creates HTML template for activity feed that offices and sub-pages
templates share.

## Removals

- Removes hardcoded values from sub-pages vars.

## Changes

- Normalizes office section titles for activity feed and contacts.

## Testing

- Offices pages and subpages should contain the text `LATEST ACTIVITIES` and `Contact Information` (NOTE: contacts aren't currently showing up, so that title can't be previewed).

## Review

- @sebworks 
- @KimberlyMunoz 
- @jimmynotjim 
- @kurtw 

## Preview

![screen shot 2015-06-12 at 12 24 36 pm](https://cloud.githubusercontent.com/assets/704760/8134536/01d014f6-10fe-11e5-9438-f786310ac90e.png)

## Notes

- https://github.com/cfpb/cfgov-refresh/pull/644 will likely change the Contact Information to the same thing, so I'll just rebase here if needed.