### PR TITLE
Updated request a speaker w/ static content

### DIFF
--- a/events/request-a-speaker/_faq.html
+++ b/events/request-a-speaker/_faq.html
@@ -5,9 +5,10 @@
             Frequently asked questions about requesting a speaker
         </h1>
         <p class="short-desc">
-            Adipisci velit, sed quia non numquam eius modi tempora incidunt ut
-            labore et dolore magnam aliquam quaerat voluptatem. Ut enim ad minima
-            veniam, quis nostrum.
+            If you don’t see your question below, contact us at
+            <a href="mailto:Invitations2cfpb@consumerfinance.gov">
+                Invitations2cfpb@consumerfinance.gov
+            </a>.
         </p>
     </div>
 
@@ -16,7 +17,8 @@
             <div class="expandable expandable__padded">
                 <button class="expandable_header expandable_target">
                     <span class="expandable_header-left expandable_label">
-                        How can I aute irure dolor in reprehenderit in voluptate?
+                        When will I hear back from the CFPB after I
+                        submit my initial request?
                     </span>
                     <span class="expandable_header-right expandable_link">
                         <span class="expandable_cue-open">
@@ -31,18 +33,15 @@
                 </button>
                 <div class="expandable_content">
                     <p>
-                        Lorem ipsum dolor sit amet, consectetur adipisicing
-                        elit. Neque ipsa voluptatibus soluta nobis unde quisquam
-                        temporibus magnam debitis quidem. Ducimus ratione
-                        corporis nesciunt earum vel est quaerat blanditiis
-                        dolore ipsa?
+                        You will receive an acknowledgement of your request
+                        from the Bureau within five business days.
                     </p>
                 </div>
             </div>
             <div class="expandable expandable__padded">
                 <button class="expandable_header expandable_target">
                     <span class="expandable_header-left expandable_label">
-                        When will the tempore, cum soluta nobis est eligendi optiimpedit?
+                        How long will it take to process my request?
                     </span>
                     <span class="expandable_header-right expandable_link">
                         <span class="expandable_cue-open">
@@ -57,65 +56,9 @@
                 </button>
                 <div class="expandable_content">
                     <p>
-                        Lorem ipsum dolor sit amet, consectetur adipisicing
-                        elit. Neque ipsa voluptatibus soluta nobis unde quisquam
-                        temporibus magnam debitis quidem. Ducimus ratione
-                        corporis nesciunt earum vel est quaerat blanditiis
-                        dolore ipsa?
-                    </p>
-                </div>
-            </div>
-            <div class="expandable expandable__padded">
-                <button class="expandable_header expandable_target">
-                    <span class="expandable_header-left expandable_label">
-                        How often does xercitationem ullam corporis suscipit
-                        laboriosam how often does xercitationem ullam corporis suscipit
-                        laboriosam atione?
-                    </span>
-                    <span class="expandable_header-right expandable_link">
-                        <span class="expandable_cue-open">
-                            Show
-                            <span class="cf-icon cf-icon-plus-round"></span>
-                        </span>
-                        <span class="expandable_cue-close">
-                            Hide
-                            <span class="cf-icon cf-icon-minus-round"></span>
-                        </span>
-                    </span>
-                </button>
-                <div class="expandable_content">
-                    <p>
-                        Lorem ipsum dolor sit amet, consectetur adipisicing
-                        elit. Neque ipsa voluptatibus soluta nobis unde quisquam
-                        temporibus magnam debitis quidem. Ducimus ratione
-                        corporis nesciunt earum vel est quaerat blanditiis
-                        dolore ipsa?
-                    </p>
-                </div>
-            </div>
-            <div class="expandable expandable__padded">
-                <button class="expandable_header expandable_target">
-                    <span class="expandable_header-left expandable_label">
-                        How can I aute irure dolor in reprehenderit in voluptate?
-                    </span>
-                    <span class="expandable_header-right expandable_link">
-                        <span class="expandable_cue-open">
-                            Show
-                            <span class="cf-icon cf-icon-plus-round"></span>
-                        </span>
-                        <span class="expandable_cue-close">
-                            Hide
-                            <span class="cf-icon cf-icon-minus-round"></span>
-                        </span>
-                    </span>
-                </button>
-                <div class="expandable_content">
-                    <p>
-                        Lorem ipsum dolor sit amet, consectetur adipisicing
-                        elit. Neque ipsa voluptatibus soluta nobis unde quisquam
-                        temporibus magnam debitis quidem. Ducimus ratione
-                        corporis nesciunt earum vel est quaerat blanditiis
-                        dolore ipsa?
+                        Depending on the nature of the request,
+                        processing time may vary for the Bureau to review your request, identify an appropriate speaker,
+                        and ensure that staff schedules allow for participation.
                     </p>
                 </div>
             </div>

--- a/events/request-a-speaker/index.html
+++ b/events/request-a-speaker/index.html
@@ -18,93 +18,24 @@
 {% block content_main %}
 
     <h1>Request a Speaker</h1>
-    {# TODO Replace ipsum with latest upcoming event content. #}
     <p class="h3">
-        Lorem ipsum dolor sit amet, ea has partem perpetua.
-        Eu graeci adipisci evertitur mei, id maiestatis elaboraret
-        dissentias his dolor sit sed.
-        If you have issues with completing this form please
-        <a href="#">contact us.</a>
+        Thank you for your interest in the work of the Consumer Financial
+        Protection Bureau. To submit a request for a CFPB official to speak
+        at your event or conference, please contact us at
+        <a href="mailto:Invitations2cfpb@consumerfinance.gov">
+            Invitations2cfpb@consumerfinance.gov
+        </a>.
     </p>
 
-    <section class="block
-                    block__bg
-                    block__border
-                    block__flush-sides
-                    block__business-step_container
-                    ">
-        <h1 class="h2">Getting started</h1>
-        <div class="content-l content-l__main">
-            <div class="content-l_col
-                        content-l_col-1-3
-                        block
-                        block__flush-top
-                        block__border-bottom
-                        block__padded-bottom
-                        block__business-step
-                        ">
-                <h2 class="h4">
-                    <span class="step-slug
-                                char-icon
-                                char-icon__1
-                                u-mb15">Step one</span>
-                    Download the PDF form
-                </h2>
-                <p class="short-desc">
-                    In order to begin the process to request a
-                    speaker please download the Request a Speaker
-                    form by clicking the button below.
-                </p>
-                {# TODO: Remove `btn__disabled` class when PDF URL is added. #}
-                <a class="btn btn__disabled" href="#">
-                    <span class="btn_icon__left cf-icon cf-icon-save"></span>
-                    Download PDF
-                </a>
-            </div>
-
-            <div class="content-l_col
-                        content-l_col-1-3
-                        block
-                        block__border-bottom
-                        block__padded-bottom
-                        block__business-step
-                        ">
-                <h2 class="h4">
-                    <span class="step-slug
-                                char-icon
-                                char-icon__2
-                                u-mb15">Step two</span>
-                    Complete the form electronically
-                </h2>
-                <p class="short-desc">
-                    You will need to fill out the form electronically
-                    and use Acrobat reader to open the PDF form.
-                    If you don't have Adobe reader you
-                    can install it on your device.
-                </p>
-                <a class="jump-link jump-link__external-link"
-                   href="https://get.adobe.com/reader/">
-                    <span class="jump-link_text">Download Adobe Reader</span>
-                </a>
-            </div>
-
-            <div class="content-l_col content-l_col-1-3">
-                <h2 class="h4">
-                    <span class="step-slug
-                                char-icon
-                                char-icon__3
-                                u-mb15">Step three</span>
-                    Email the completed form
-                </h2>
-                <p class="short-desc">
-                    Send us the completed request a speaker PDF form.
-                </p>
-                <a class="icon-link icon-link__email icon-link__before" href="mailto:longemailname@cfpb.gov">
-                    <span class="icon-link_text">
-                    longemailname@cfpb.gov</span>
-                </a>
-            </div>
-        </div>
+    <section class="sub-page_content
+                    block
+                    block__flush-top">
+        <p>While we welcome invitations for CFPB officials to speak on behalf
+        of the Bureau’s work, please note that we cannot accept every request.
+        For scheduling purposes, please provide at least one month’s notice in
+        advance of your event.</p>
+        <p>Once your request has been received, we will review it and contact
+        you if we require additional information.</p>
     </section>
 
     {%- include "_faq.html" %}


### PR DESCRIPTION
Updated request a speaker template w/ static content instead of relying on the CMS content

## Additions

- None

## Removals

- None

## Changes

- Replaced placeholder content with true content

## Testing

- navigate to `/events/request-a-speaker/`

## Review

- @KimberlyMunoz 
- @anselmbradford 
- @sebworks 

## Preview

![screen shot 2015-06-12 at 3 58 31 pm](https://cloud.githubusercontent.com/assets/1280430/8138783/e66ed3f0-111b-11e5-85b3-47068d499a0b.png)

[Preview this PR without the whitespace changes](?w=0)

## Notes

- RaS is not related to an office, using static content until further notice
- All content copied from RaS sub-page and FAQ on WordPress