### PR TITLE
Fix Navigation for Office/Subpage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,8 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Added `cfpb_report` activity type to activities feed macro.
 - Added breadcrumbs macro and temporarily set breadcrumbs for all office sub-pages.
 - Added download icons to `privacy-impact-assessments-pias`
+- Added `short_title` to Office/Subpage
+- Added ordering to the navigation on Office/Subpage
 
 ### Changed
 - Relaxed ESLint `key-spacing` rule to warning.
@@ -99,6 +101,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
   and adds render method.
 - Moved `string_length` macro from `macros.html` to `macros/util/text.html`.
 - Events processor/mapping/queries for new Event type structure
+- Changed the way navigation works for Office/Subpage
 
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ For any kind of repeating content, this is the basic process:
 
   ```jinja
   {% set query = queries.posts %}
-  {% set posts = query.search_with_url_arguments(size=10) %}
+  {% set posts = query.search(size=10) %}
   ```
 
 2. If you want to display the repeating content within a template,
@@ -287,7 +287,7 @@ Sometimes you'll want to create queries in your templates to filter the data.
 The two main ways of injecting filters into your data are in the URL's query
 string and within the template code itself.
 
-We have a handy function `search_with_url_arguments()` that:
+We have a handy function `search()` that:
 
 1. Pulls in filters from the URL query string.
 2. Allows you to add additional filters by passing them in as arguments to the function.
@@ -308,7 +308,7 @@ An example of Term is:
 `filter_[field]=[value]`
 
 When you go to a URL such as http://localhost:7000/blog/?filter_category=Op-Ed
-and you use `search_with_url_arguments()`,
+and you use `search()`,
 the queryset returned will only include objects with a category of 'Op-Ed'.
 
 An example of Range is:
@@ -319,7 +319,7 @@ An example of Range is:
 
 Continuing with the example above, if you go to a URL such as
 `http://localhost:7000/blog/?filter_range_date_gte=2014-01`
-and you use `search_with_url_arguments()`,
+and you use `search()`,
 you'll get a queryset of objects where the 'date' field is in January, 2014, or later.
 
 URL query string filters are convenient for many of the filtered queries you'll need to run,
@@ -327,23 +327,23 @@ but often there are cases where you'll need more flexibility.
 
 #### More complex filters
 
-By default, `search_with_url_arguments()` uses the default query parameters
+By default, `search()` uses the default query parameters
 defined in the `_queries/object-name.json` file,
 then mixes them in with any additional arguments
 from the URL query string in addition to what is passed into the function itself.
 
-When using `search_with_url_arguments()`, you can also pass in filters with the same `filter_` syntax as above.
+When using `search()`, you can also pass in filters with the same `filter_` syntax as above.
 
 For example:
 
-`search_with_url_arguments(filter_category='Op-Ed')`
+`search(filter_category='Op-Ed')`
 
 Multiple term filters on the same field will be combined in an OR clause, while
 term filters of different fields will be combined in an AND clause.
 
 For example:
 
-`search_with_url_arguments(filter_tag='Students', filter_tag='Finance', filter_author='Batman')`
+`search(filter_tag='Students', filter_tag='Finance', filter_author='Batman')`
 
 This will return documents that have the tag Students OR Finance, AND have an author of Batman.
 

--- a/_includes/macros/activity-snippets.html
+++ b/_includes/macros/activity-snippets.html
@@ -71,43 +71,43 @@
         {% set doc_type = activity_type %}
         {% set icon = category_icon.render('blog') %}
         {% set header = 'Blog' %}
-        {% set feed = queries[doc_type].search_with_url_arguments(size=quantity,
+        {% set feed = queries[doc_type].search(size=quantity,
             filter_tags=tags) %}
     {% elif activity_type|lower == 'op-ed' %}
         {% set doc_type = 'newsroom' %}
         {% set icon = category_icon.render(activity_type) %}
         {% set header = 'Op-Ed' %}
-        {% set feed = queries[doc_type].search_with_url_arguments(size=quantity,
+        {% set feed = queries[doc_type].search(size=quantity,
             filter_category='Op-Ed', filter_tags=tags) %}
     {% elif activity_type|lower == 'press release' %}
         {% set doc_type = 'newsroom' %}
         {% set icon = category_icon.render(activity_type) %}
         {% set header = 'Press Release' %}
-        {% set feed = queries[doc_type].search_with_url_arguments(size=quantity,
+        {% set feed = queries[doc_type].search(size=quantity,
             filter_category='Press Release', filter_tags=tags) %}
     {% elif activity_type|lower == 'speech' %}
         {% set doc_type = 'newsroom' %}
         {% set icon = category_icon.render(activity_type) %}
         {% set header = 'Speech' %}
-        {% set feed = queries[doc_type].search_with_url_arguments(size=quantity,
+        {% set feed = queries[doc_type].search(size=quantity,
             filter_category='Speech', filter_tags=tags) %}
     {% elif activity_type|lower == 'testimony' %}
         {% set doc_type = 'newsroom' %}
         {% set icon = category_icon.render(activity_type) %}
         {% set header = 'Testimony' %}
-        {% set feed = queries[doc_type].search_with_url_arguments(size=quantity,
+        {% set feed = queries[doc_type].search(size=quantity,
             filter_category='Testimony', filter_tags=tags) %}
     {% elif activity_type|lower == 'cfpb_report' %}
         {% set doc_type = 'newsroom' %}
         {% set icon = category_icon.render(activity_type) %}
         {% set header = 'Reports' %}
-        {% set feed = queries[doc_type].search_with_url_arguments(size=quantity,
+        {% set feed = queries[doc_type].search(size=quantity,
             filter_category='Reports', filter_tags=tags) %}
     {% else %}
         {% set doc_type = 'posts' %}
         {% set icon = category_icon.render('blog') %}
         {% set header = 'Feed' %}
-        {% set feed = queries[doc_type].search_with_url_arguments(size=quantity,
+        {% set feed = queries[doc_type].search(size=quantity,
             filter_tags=tags) %}
     {% endif %}
     {% if feed.total > 0 %}

--- a/_lib/wordpress_office_processor.py
+++ b/_lib/wordpress_office_processor.py
@@ -88,7 +88,7 @@ def process_office(post):
     # add other custom fields
     names = ['og_title', 'og_image', 'og_desc', 'twtr_text', 'twtr_lang',
              'twtr_rel', 'twtr_hash', 'utm_campaign', 'utm_term',
-             'utm_content', 'short_title']
+             'utm_content', 'short_title', 'related_sub_pages']
     for name in names:
         if name in custom_fields:
             post[name] = custom_fields[name]

--- a/_lib/wordpress_sub_page_processor.py
+++ b/_lib/wordpress_sub_page_processor.py
@@ -38,12 +38,11 @@ def process_sub_page(post):
     for name in names:
         if name in custom_fields:
             post[name] = custom_fields[name]
-    for related in ['related_office', 'related_faq']:
-        if related in custom_fields:
-            if isinstance(custom_fields[related], basestring):
-                post[related] = custom_fields[related]
-            else:
-                post[related] = custom_fields[related][0]
+    if 'related_faq' in custom_fields:
+        if isinstance(custom_fields['related_faq'], basestring):
+            post['related_faq'] = custom_fields['related_faq']
+        else:
+            post['related_faq'] = custom_fields['related_faq'][0]
     if 'related_links' not in post:
         related = []
         for x in range(5):

--- a/_settings/mappings/office.json
+++ b/_settings/mappings/office.json
@@ -85,6 +85,10 @@
       "type": "string",
       "index": "not_analyzed"
     },
+    "related_sub_pages": {
+      "type": "string",
+      "index": "not_analyzed"
+    },
     "relative_url": {
       "type": "string"
     },
@@ -115,7 +119,8 @@
       "type": "string"
     },
     "slug": {
-      "type": "string"
+      "type": "string",
+      "index": "not_analyzed"
     },
     "status": {
       "type": "string"

--- a/_settings/mappings/sub_page.json
+++ b/_settings/mappings/sub_page.json
@@ -92,10 +92,6 @@
         }
       }
     },
-    "related_office": {
-      "type": "string",
-      "index": "not_analyzed"
-    },
     "relative_url": {
       "type": "string"
     },
@@ -106,7 +102,8 @@
       "type": "string"
     },
     "slug": {
-      "type": "string"
+      "type": "string",
+      "index": "not_analyzed"
     },
     "status": {
       "type": "string"

--- a/activity-log/index.html
+++ b/activity-log/index.html
@@ -11,7 +11,7 @@
 
 {% block content_main %}
 
-    {% set archives = vars.query.search_with_url_arguments(size=30) %}
+    {% set archives = vars.query.search(size=30) %}
     {% from "post-macros.html" import filters as filters with context %}
     {% import "macros/category-icon.html" as category_icon %}
     {% from "post-macros.html" import pagination as pagination with context %}

--- a/blog/_vars-blog.html
+++ b/blog/_vars-blog.html
@@ -2,4 +2,4 @@
 {% set path = '/blog/' %}
 {% set rss_path = '/feed/posts/' %}
 {% set query = queries.posts %}
-{% set posts = query.search_with_url_arguments(size=10) %}
+{% set posts = query.search(size=10) %}

--- a/contact-us/index.html
+++ b/contact-us/index.html
@@ -27,7 +27,7 @@
 {% endblock %}
 
 {% block content_main %}
-    {% set contacts = vars.query.search_with_url_arguments(size=100) %}
+    {% set contacts = vars.query.search(size=100) %}
     {%- include "contact-list.html" %}
 {% endblock %}
 

--- a/events/_vars-events.html
+++ b/events/_vars-events.html
@@ -164,5 +164,5 @@
 {% else %}
     {% set query = queries.events %}
 {% endif %}
-{% set events = query.search_with_url_arguments(size=10) %}
+{% set events = query.search(size=10) %}
 

--- a/newsroom/_vars-newsroom.html
+++ b/newsroom/_vars-newsroom.html
@@ -7,4 +7,4 @@
 ] %}
 
 {% set query = queries.newsroom %}
-{% set newsrooms = query.search_with_url_arguments(size=10) %}
+{% set newsrooms = query.search(size=10) %}

--- a/newsroom/index.html
+++ b/newsroom/index.html
@@ -19,7 +19,7 @@
 
     {# Get the latest Featured Topic #}
     {% import "featured-topic.html" as featured_topics %}
-    {{ featured_topics.render(queries.featured_topic.search_with_url_arguments(size=1)) }}
+    {{ featured_topics.render(queries.featured_topic.search(size=1)) }}
 
     {# Set the filters #}
     {% from "post-macros.html" import filters as filters with context %}

--- a/offices/_single.html
+++ b/offices/_single.html
@@ -128,7 +128,7 @@
     </section>
     {% endif %}
 
-    {% for page in vars.sub_pages if page.show_in_office == "on" %}
+    {% for page in vars.sub_pages|sort(attribute='order') if page.show_in_office == "on" %}
     {% if loop.first %}
     <section class="office_sub_pages
                     block
@@ -155,11 +155,7 @@
                 <button class="expandable_header expandable_target u-show-on-mobile">
                     {% if page.short_title or page.title %}
                     <span class="expandable_header-left expandable_label">
-                        {% if page.short_title %}
-                            {{ page.short_title | safe }}
-                        {% elif page.title %}
-                            {{ page.title | safe }}
-                        {% endif %}
+                        {{ page.short_title|safe if page.short_title else page.title|safe }}
                     </span>
                     {% endif %}
                     <span class="expandable_header-right expandable_link">
@@ -174,11 +170,7 @@
                 <div class="expandable_content">
                     {% if page.short_title or page.title %}
                     <h2 class="h4 u-hide-on-mobile">
-                        {% if page.short_title %}
-                            {{ page.short_title | safe }}
-                        {% elif page.title %}
-                            {{ page.title | safe }}
-                        {% endif %}
+                        {{ page.short_title|safe if page.short_title else page.title|safe }}
                     </h2>
                     {% endif %}
                     {% if page.excerpt %}

--- a/offices/_single.html
+++ b/offices/_single.html
@@ -155,7 +155,7 @@
                 <button class="expandable_header expandable_target u-show-on-mobile">
                     {% if page.short_title or page.title %}
                     <span class="expandable_header-left expandable_label">
-                        {{ page.short_title|safe if page.short_title else page.title|safe }}
+                        {{ (page.short_title or page.title) | safe }}
                     </span>
                     {% endif %}
                     <span class="expandable_header-right expandable_link">
@@ -170,7 +170,7 @@
                 <div class="expandable_content">
                     {% if page.short_title or page.title %}
                     <h2 class="h4 u-hide-on-mobile">
-                        {{ page.short_title|safe if page.short_title else page.title|safe }}
+                        {{ (page.short_title or page.title) | safe }}
                     </h2>
                     {% endif %}
                     {% if page.excerpt %}

--- a/offices/_vars-offices.html
+++ b/offices/_vars-offices.html
@@ -1,8 +1,12 @@
 {% set path = '/offices/' %}
-{% set query = queries.sub_page %}
-{% set sub_pages = query.search_with_url_arguments(size=15, filter_has_parent="false", filter_related_office=office.slug) %}
+{% set sub_pages = [] %}
+{% for slug in office.related_sub_pages %}
+    {% set _ignore = sub_pages.append(get_document('sub_page', slug)) %}
+{% endfor %}
 
-{% set nav_items = [(office.permalink, 'index', office.title)] -%}
-{% for page in sub_pages %}
-    {%- set _ignore = nav_items.append((page.permalink, page.slug, page.title|safe)) -%}
+{% set title = office.short_title|safe if office.short_title else office.title|safe %}
+{% set nav_items = [(office.permalink, 'index', title)] -%}
+{% for page in sub_pages|sort(attribute='order') %}
+    {% set title = page.short_title|safe if page.short_title else page.title|safe %}
+    {%- set _ignore = nav_items.append((page.permalink, page.slug, title)) -%}
 {% endfor %}

--- a/sub-pages/_single.html
+++ b/sub-pages/_single.html
@@ -2,7 +2,7 @@
 {% import "_vars-sub-pages.html" as vars with context %}
 {% set active_nav_id = sub_page.slug %}
 {% set sub_pages = vars.sub_pages %}
-{% set breadcrumb_items = [(vars.office.permalink, vars.office.slug, vars.office.title)] %}
+{% set breadcrumb_items = vars.breadcrumb_items %}
 
 
 {% set display_activity_slugs = ["plain-writing-act"] %}
@@ -41,16 +41,16 @@
                     block__border-top
                     block__flush-bottom">
         <div class="content-l content-l__main">
-            {% for page in sub_pages %}
+            {% for page in sub_pages|sort(attribute='order') %}
             <!-- TODO: link header styles -->
             <div class="sub-page_topic
                         block__sub
                         block__flush-top
                         {{ 'office_col' if vars.sub_pages.result_dict|length > 1 else 'content-l_col-1' -}}">
 
-                {% if page.title %}
+                {% if page.short_title or page.title %}
                 <h2 class="h3">
-                    {{ page.title | safe }}
+                    {{ page.short_title | safe if page.short_title else page.title | safe }}
                 </h2>
                 {% endif %}
 

--- a/sub-pages/_single.html
+++ b/sub-pages/_single.html
@@ -50,7 +50,7 @@
 
                 {% if page.short_title or page.title %}
                 <h2 class="h3">
-                    {{ page.short_title | safe if page.short_title else page.title | safe }}
+                    {{ (page.short_title or page.title) | safe }}
                 </h2>
                 {% endif %}
 

--- a/sub-pages/_vars-sub-pages.html
+++ b/sub-pages/_vars-sub-pages.html
@@ -1,22 +1,29 @@
 {% set query = queries.sub_page %}
-{% set sub_pages = query.search_with_url_arguments(size=6, filter_has_parent=true, filter_parent=sub_page.id) %}
-{% set nav_sub_pages = query.search_with_url_arguments(size=15, filter_related_office=sub_page.related_office, filter_has_parent=false) %}
-{% set office = get_document('office', sub_page.related_office) %}
+{% set sub_pages = query.search(use_url_arguments=False, size=6, filter_has_parent=true, filter_parent=sub_page.id) %}
+{% set office_query = queries.office %}
+{% set offices = office_query.search(use_url_arguments=False, size=1, filter_related_sub_pages=sub_page.slug) %}
 
 {% set path = '/sub_pages/' %}
-{% set nav_items =
-    [(office.permalink, office.slug, office.title)]
--%}
-
-{% for page in nav_sub_pages %}
-    {%- set _ignore = nav_items.append((page.permalink, page.slug, page.title|safe)) -%}
+{% set nav_items = [] -%}
+{% set nav_sub_pages = [] -%}
+{% set breadcrumb_items = [] -%}
+{% for office in offices %}
+    {% set _ignore = breadcrumb_items.append((office.permalink, office.slug, office.title)) %}
+    {% for slug in office.related_sub_pages %}
+        {% set _ignore = nav_sub_pages.append(get_document('sub_page', slug)) %}
+    {% endfor %}
+    {% set title = office.short_title|safe if office.short_title else office.title|safe %}
+    {% set _ignore = nav_items.append((office.permalink, office.slug, title)) -%}
+    {% for page in nav_sub_pages|sort(attribute='order') %}
+        {% set title = page.short_title|safe if page.short_title else page.title|safe %}
+        {%- set _ignore = nav_items.append((page.permalink, page.slug, title)) -%}
+    {% endfor %}
 {% endfor %}
 
 {# This to fake data for records sub-pages #}
 {# TODO: Update _queries/records.json when we have real record posts #}
 {% set record_query = queries.records %}
-{% set records = record_query.search_with_url_arguments(size=10) %}
-
+{% set records = record_query.search(size=10) %}
 {# Forms for sub-pages #}
 {% set forms = ['Amending-and-correcting-records-under-the-Privacy-Act-form',
                 'File-a-Privacy-Complaint-form',

--- a/sub-pages/_vars-sub-pages.html
+++ b/sub-pages/_vars-sub-pages.html
@@ -1,29 +1,35 @@
+{# Get subpages and the related office #}
 {% set query = queries.sub_page %}
 {% set sub_pages = query.search(use_url_arguments=False, size=6, filter_has_parent=true, filter_parent=sub_page.id) %}
 {% set office_query = queries.office %}
 {% set offices = office_query.search(use_url_arguments=False, size=1, filter_related_sub_pages=sub_page.slug) %}
+{% set office_list = offices|list %}
+{% set office = office_list[0] %}
 
+{# Get set the correct title #}
+{% set title = (office.short_title or office.title) | safe %}
+
+{# Set up the navigation #}
 {% set path = '/sub_pages/' %}
 {% set nav_items = [] -%}
 {% set nav_sub_pages = [] -%}
 {% set breadcrumb_items = [] -%}
-{% for office in offices %}
-    {% set _ignore = breadcrumb_items.append((office.permalink, office.slug, office.title)) %}
-    {% for slug in office.related_sub_pages %}
-        {% set _ignore = nav_sub_pages.append(get_document('sub_page', slug)) %}
-    {% endfor %}
-    {% set title = office.short_title|safe if office.short_title else office.title|safe %}
-    {% set _ignore = nav_items.append((office.permalink, office.slug, title)) -%}
-    {% for page in nav_sub_pages|sort(attribute='order') %}
-        {% set title = page.short_title|safe if page.short_title else page.title|safe %}
-        {%- set _ignore = nav_items.append((page.permalink, page.slug, title)) -%}
-    {% endfor %}
+{% set _ignore = breadcrumb_items.append((office.permalink, office.slug, office.title)) %}
+{% for slug in office.related_sub_pages %}
+    {% set _ignore = nav_sub_pages.append(get_document('sub_page', slug)) %}
+{% endfor %}
+{% set _ignore = nav_items.append((office.permalink, office.slug, title)) -%}
+{% for page in nav_sub_pages|sort(attribute='order') %}
+    {% set title = page.short_title|safe if page.short_title else page.title|safe %}
+    {%- set _ignore = nav_items.append((page.permalink, page.slug, title)) -%}
 {% endfor %}
 
+{# Get the records for latest activities #}
 {# This to fake data for records sub-pages #}
 {# TODO: Update _queries/records.json when we have real record posts #}
 {% set record_query = queries.records %}
 {% set records = record_query.search(size=10) %}
+
 {# Forms for sub-pages #}
 {% set forms = ['Amending-and-correcting-records-under-the-Privacy-Act-form',
                 'File-a-Privacy-Complaint-form',

--- a/the-bureau/bureau-structure/index.html
+++ b/the-bureau/bureau-structure/index.html
@@ -72,12 +72,12 @@
                             {{ category }}
                         </button>
                     </li>
-                {% set parents = queries.orgmember.search_with_url_arguments(
+                {% set parents = queries.orgmember.search(
                    filter_has_parent='false', filter_category=category) %}
                 {% for parent in parents %}
                     {% set par_loop = loop %}
                     <li class="org-chart_node expandable">
-                        {% set children = queries.orgmember.search_with_url_arguments(
+                        {% set children = queries.orgmember.search(
                            filter_parent=parent.id) %}
                     {% if children|list|length %}
                         <button class="org-chart_role expandable_target expandable_header content-show"

--- a/the-bureau/history/index.html
+++ b/the-bureau/history/index.html
@@ -29,7 +29,7 @@
         {{ share(self.title(), true) }}
     </div>
 
-	{% set sections = query.search_with_url_arguments(filter_has_parent='false') -%}
+	{% set sections = query.search(filter_has_parent='false') -%}
 
 {% for section in sections %}
 
@@ -54,7 +54,7 @@
             <div class="expandable_content history-section-expandable_content">
                 <div class="history-timeline">
     {# Run a query for the first item in this section to get the starting year. #}
-    {% set first = query.search_with_url_arguments(filter_parent=section.id,
+    {% set first = query.search(filter_parent=section.id,
                                                    size=1) %}
     {# Using this history_vars dictionary instead of a simple variable lets us
        share the value between the different scopes created by the foor loops.
@@ -65,7 +65,7 @@
     {% endfor %}
                     <h2 class="history-year">{{ history_vars.current_year }}</h2>
                     <ol class="history-list">
-    {% set histories = query.search_with_url_arguments(filter_parent=section.id) %}
+    {% set histories = query.search(filter_parent=section.id) %}
     {% for history in histories %}
         {% if history.date|date("%Y")|int < history_vars.current_year %}
             {% if history_vars.update({'current_year': history.date|date("%Y")|int}) %} {% endif %}

--- a/the-bureau/leadership-calendar/index.html
+++ b/the-bureau/leadership-calendar/index.html
@@ -46,7 +46,7 @@
     <div class="block u-mt0">
 
     {% set query = queries.calendar_event %}
-    {% set posts = query.search_with_url_arguments(size=20) %}
+    {% set posts = query.search(size=20) %}
 
         {{ filters(
             ['calendar', 'range_date'], query, posts, 'calendar_event',

--- a/the-bureau/leadership-calendar/print/index.html
+++ b/the-bureau/leadership-calendar/print/index.html
@@ -27,7 +27,7 @@
             <div class="content_main">
                 <div class="print-header">
                     {% set query = queries.calendar_event -%}
-                    {%- set posts = query.search_with_url_arguments(size=20000) -%}
+                    {%- set posts = query.search(size=20000) -%}
                     <h1 class="superheader">Leadership Calendar</h1>
                     {{ active_filters(posts, ['calendar', 'range_date'], {
                         'show_filters_label': false, 'show_unfiltered_count': true


### PR DESCRIPTION
The relationship between Offices and Subpages changed. The Office will now be designating which Subpage will associated with it, not the other way around. These changes reflect that.

To test, create two Subpages. One parent and one child. I'd put some info in the fields just so you know what you're looking at. Second, create an Office that points to the parent Subpage. The dropdown will only include parent Subpages so you shouldn't have to worry about choosing the wrong one.

**WARNING** This will not working without [this code pulled into sheer.](https://github.com/cfpb/sheer/pull/108)

## Testing
Pull in production data, and make sure [you have pulled this into sheer](https://github.com/cfpb/sheer/pull/108). The navigation on Office's and Subpage's should be working properly. This, and if `short_title` is set in the prod data, the `short_title` should be shown in the nav and subpage modules on the parent subpage and the office page. These modules should also be ordered just like the nav is ordered. This order is determined by the `order` attribute that's set in Wordpress.

@dpford @jimmynotjim @sebworks @anselmbradford @KimberlyMunoz 