### PR TITLE
Add script to index all links on our site

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Added download icons to `privacy-impact-assessments-pias`
 - Added `short_title` to Office/Subpage
 - Added ordering to the navigation on Office/Subpage
+- Added script to index all links on our site
 
 ### Changed
 - Relaxed ESLint `key-spacing` rule to warning.

--- a/_queries/links.json
+++ b/_queries/links.json
@@ -1,0 +1,6 @@
+{
+  "name": "Links",
+  "query": {
+    "doc_type": "link"
+  }
+}

--- a/links.sh
+++ b/links.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+
+# This script finds all the URLs in our code, as well as in elasticsearch, and
+# indexes them as a type "link" which can then be queried against.
+
+
+ES_HOST=localhost:9200
+ES_INDEX=content
+ES_DOC_TYPE=link
+
+# Remove the existing links
+curl -XDELETE $ES_HOST/$ES_INDEX/$ES_DOC_TYPE
+
+# Create mapping
+curl -XPUT $ES_HOST/$ES_INDEX/_mapping/$ES_DOC_TYPE -d '{"link":{"properties":{"url":{"type":"string"}}}}'
+
+FILESYSTEM="$(find . -name '*.html' ! -path './src/*' ! -path './node_modules/*' ! -path './_tests/*' -exec cat {} \;)"
+ELASTICSEARCH="$(curl -XPOST "http://$ES_HOST/$ES_INDEX/_search?format=yaml" -d '{"size" :1000000, "query": { "query_string": { "query" : "\"a href\"" } } }')"
+
+# We need this to run some commands with sudo if on a server, but not locally
+if [ "$1" = "needs_sudo" ] ; then
+    echo "$FILESYSTEM$ELASTICSEARCH" \
+    | perl -ne 'if (/href=\\?.https?:\/\/(?:www\.)?(?!.*gov)([^"|\/\\|\{}]*)/g) { $url = lc $1; print "{\"index\" : {\"_type\": \"'"$ES_DOC_TYPE"'\", \"_id\": \"$url\"}}\n{\"url\": \"$url\"}\n" }' | sudo tee bulk
+    DELETE_CMD="sudo rm bulk"
+else
+    echo "$FILESYSTEM$ELASTICSEARCH" \
+    | perl -ne 'if (/href=\\?.https?:\/\/(?:www\.)?(?!.*gov)([^"|\/\\|\{}]*)/g) { $url = lc $1; print "{\"index\" : {\"_type\": \"'"$ES_DOC_TYPE"'\", \"_id\": \"$url\"}}\n{\"url\": \"$url\"}\n" }' > bulk
+    DELETE_CMD="rm bulk"
+fi
+
+curl -XPOST $ES_HOST/$ES_INDEX/_bulk --data-binary @bulk
+
+$DELETE_CMD


### PR DESCRIPTION
When sending people to external links, we need the ability to check that the link originated on our site.  This script gathers all of the links from A) cfgov-refresh codebase, and B) the Elasticsearch index associated with the site, and indexes them as a new type called "link".   This requires [Sheer 3.0.0](https://github.com/cfpb/sheer/releases/tag/3.0.0) or greater.

To try it locally, simply run `./links.sh` from the root of cfgov-refresh.  Once merged, this will be placed into a Jenkins job to be run on each `sheer index` and each deploy of new code.

Here's an example usage from within a template:

```
{% set query = queries.links %}

{% set vetted_urls = query.possible_values_for('url') | possibles_to_list %}

{% if request.args.get('ext_url') and request.args.get('ext_url') | domain_name in vetted_urls %}
   You are probably clicking an external URL on our site
{% else %}
   Nice try.  CFPB would never send you to THAT site!
{% endif %}
```

Review: @kurtw @sebworks @jimmynotjim @KimberlyMunoz @anselmbradford 