### PR TITLE
Bugfix: Re-adding missing content_sidebar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Fixed FOIA pages from the template/processor changes
 - Fixed missing states from `.nav-secondary_link__disabled` class for
   visited and active links.
+- Fixed missing sidebar
 
 ### Removed
 - Removed `copy:static-legacy` and `grunt-contrib-copy` package.

--- a/contact-us/index.html
+++ b/contact-us/index.html
@@ -31,4 +31,8 @@
     {%- include "contact-list.html" %}
 {% endblock %}
 
-
+{% block content_sidebar %}
+    {%- include "mailing-addresses.html" %}
+    <div class="content_line"></div>
+    {%- include "promoted-contacts.html" %}
+{% endblock %}


### PR DESCRIPTION
Where did the sidebar go?

![peek-a-boo-owl2](https://cloud.githubusercontent.com/assets/1860176/8260421/9374c576-1691-11e5-8172-b353bd5d4c60.gif)

Oh, there it is!

## Fixed

- Fixed missing sidebar on `contact-us`

## Testing

- Visit `/contact-us`

## Review

- @sebworks

## Preview

Before:

![image](https://cloud.githubusercontent.com/assets/1860176/8260474/f8fbb29c-1691-11e5-8e7f-be2b60ece159.png)

After:

![image](https://cloud.githubusercontent.com/assets/1860176/8260466/ec9d300c-1691-11e5-8422-a45b946367ff.png)

[Preview this PR without the whitespace changes](?w=0)
