### PR TITLE
Add in support for ICS file generator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Added `the-bureau` page wrapper class.
 - Added `media-stack` CSS block for stacked media objects.
 - Added fixes for `open-government` pages.
+- Support in Event processor for ICS file generator
 
 ### Changed
 - Fixed background and border on secondary navigation.

--- a/_lib/wordpress_event_processor.py
+++ b/_lib/wordpress_event_processor.py
@@ -59,23 +59,36 @@ def process_event(event):
             event[field] = custom_fields[field]
 
     if 'taxonomy_beginning_time' in event and event['taxonomy_beginning_time']:
-            event['beginning_time'] = \
-                event['taxonomy_beginning_time'][0]['title']
+        event['beginning_time'] = {}
+        event['beginning_time']['date'] = \
+            event['taxonomy_beginning_time'][0]['title']
+        event['beginning_time']['timezone'] = \
+            event['taxonomy_beginning_time'][0]['description']
     if 'taxonomy_ending_time' in event and event['taxonomy_ending_time']:
-            event['ending_time'] = \
-                event['taxonomy_ending_time'][0]['title']
+        event['ending_time'] = {}
+        event['ending_time']['date'] = \
+            event['taxonomy_ending_time'][0]['title']
+        event['ending_time']['timezone'] = \
+            event['taxonomy_ending_time'][0]['description']
 
-    if 'agenda' in event:
-        for agenda in event['agenda']:
-            if 'beginning_time' in agenda and \
-                    'date' in agenda['beginning_time']:
-                agenda['beginning_time'] = agenda['beginning_time']['date']
-            if 'ending_time' in agenda and 'date' in agenda['ending_time']:
-                agenda['ending_time'] = agenda['ending_time']['date']
-
-    if 'live_stream' in event:
-        if event['live_stream'] and 'date' in event['live_stream']:
-            event['live_stream'] = event['live_stream']['date']
+    # Create ICS data dictionary
+    event['ics'] = {}
+    if 'title' in event:
+        event['ics']['summary'] = event['title']
+    if 'venue' in event:
+        if 'city' and 'state' in event['venue']:
+            event['ics']['location'] = "%s, %s" % (event['venue']['city'],
+                                                   event['venue']['state'])
+    if 'beginning_time' in event:
+        event['ics']['dtstart'] = event['beginning_time']['date']
+        event['ics']['starting_tzinfo'] = event['beginning_time']['timezone']
+    if 'ending_time' in event:
+        event['ics']['dtend'] = event['ending_time']['date']
+        event['ics']['ending_tzinfo'] = event['ending_time']['timezone']
+    ics_dict = {'date': 'dtstamp', 'relative_url': 'uid'}
+    for wp_field, ics_field in ics_dict.items():
+        if wp_field in event and event[wp_field]:
+            event['ics'][ics_field] = event[wp_field]
 
     # Delete taxonomy data and custom fields
     del event['custom_fields']

--- a/_settings/mappings/event.json
+++ b/_settings/mappings/event.json
@@ -3,15 +3,29 @@
     "agenda": {
       "properties": {
         "beginning_time": {
-          "type": "date",
-          "format": "dateOptionalTime"
+          "properties": {
+            "date": {
+              "type": "date",
+            "format": "dateOptionalTime"
+            },
+            "timezone": {
+              "type": "string"
+            }
+          }
         },
         "desc": {
           "type": "string"
         },
         "ending_time": {
-          "type": "date",
-          "format": "dateOptionalTime"
+          "properties": {
+            "date": {
+              "type": "date",
+            "format": "dateOptionalTime"
+            },
+            "timezone": {
+              "type": "string"
+            }
+          }
         },
         "location": {
           "type": "string"
@@ -206,7 +220,7 @@
             }
           }
         },
-      "mime_type": {
+        "mime_type": {
           "type": "string"
         },
         "parent": {
@@ -252,8 +266,15 @@
       }
     },
     "beginning_time": {
-      "type": "date",
-      "format": "dateOptionalTime"
+      "properties": {
+        "date": {
+          "type": "date",
+          "format": "dateOptionalTime"
+        },
+        "timezone": {
+          "type": "string"
+        }
+      }
     },
     "comment_count": {
       "type": "long"
@@ -261,17 +282,58 @@
     "comment_status": {
       "type": "string"
     },
+    "content": {
+      "type": "string"
+    },
     "date": {
       "type": "date",
       "format": "dateOptionalTime"
     },
     "ending_time": {
-      "type": "date",
-      "format": "dateOptionalTime"
+      "properties": {
+        "date": {
+          "type": "date",
+          "format": "dateOptionalTime"
+        },
+        "timezone": {
+          "type": "string"
+        }
+      }
+    },
+    "excerpt": {
+      "type": "string"
     },
     "future": {
       "properties": {
         "summary": {
+          "type": "string"
+        }
+      }
+    },
+    "ics": {
+      "properties": {
+        "dtend": {
+          "type": "date",
+          "format": "dateOptionalTime"
+        },
+        "dtstamp": {
+          "type": "date",
+          "format": "dateOptionalTime"
+        },
+        "dtstart": {
+          "type": "date",
+          "format": "dateOptionalTime"
+        },
+        "ending_tzinfo": {
+          "type": "string"
+        },
+        "starting_tzinfo": {
+          "type": "string"
+        },
+        "summary": {
+          "type": "string"
+        },
+        "uid": {
           "type": "string"
         }
       }
@@ -288,11 +350,21 @@
     },
     "live_stream": {
       "properties": {
-        "date": {
-          "type": "date",
-            "format": "dateOptionalTime"
+        "available": {
+          "type": "string"
         },
-        "timezone": {
+        "date": {
+          "properties": {
+            "date": {
+              "type": "date",
+              "format": "dateOptionalTime"
+            },
+            "timezone": {
+              "type": "string"
+            }
+          }
+        },
+        "url": {
           "type": "string"
         }
       }
@@ -301,14 +373,39 @@
       "type": "date",
       "format": "dateOptionalTime"
     },
-    "og_desc": {
-      "type": "string"
-    },
-    "og_image": {
-      "type": "string"
-    },
-    "og_title": {
-      "type": "string"
+    "open_graph": {
+      "properties": {
+        "og_desc": {
+          "type": "string"
+        },
+        "og_image": {
+          "type": "string"
+        },
+        "og_title": {
+          "type": "string"
+        },
+        "twtr_hash": {
+          "type": "string"
+        },
+        "twtr_lang": {
+          "type": "string"
+        },
+        "twtr_rel": {
+          "type": "string"
+        },
+        "twtr_text": {
+          "type": "string"
+        },
+        "utm_campaign": {
+          "type": "string"
+        },
+        "utm_content": {
+          "type": "string"
+        },
+        "utm_term": {
+          "type": "string"
+        }
+      }
     },
     "order": {
       "type": "long"
@@ -341,104 +438,16 @@
     "tags": {
       "type": "string"
     },
-    "taxonomy_beginning_time": {
-      "properties": {
-        "id": {
-          "type": "long"
-        },
-        "post_count": {
-          "type": "long"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "title": {
-          "type": "date",
-          "format": "dateOptionalTime"
-        }
-      }
-    },
-    "taxonomy_ending_time": {
-      "properties": {
-        "id": {
-          "type": "long"
-        },
-        "post_count": {
-          "type": "long"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "title": {
-          "type": "date",
-          "format": "dateOptionalTime"
-        }
-      }
-    },
-    "taxonomy_fj_tag": {
-      "properties": {
-        "id": {
-          "type": "long"
-        },
-        "post_count": {
-          "type": "long"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        }
-      }
-    },
-    "taxonomy_live_stream_available_time": {
-      "properties": {
-        "id": {
-          "type": "long"
-        },
-        "post_count": {
-          "type": "long"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "title": {
-          "type": "date",
-          "format": "dateOptionalTime"
-        }
-      }
-    },
     "title": {
       "type": "string"
     },
     "title_plain": {
       "type": "string"
     },
-    "twtr_hash": {
-      "type": "string"
-    },
-    "twtr_lang": {
-      "type": "string"
-    },
-    "twtr_rel": {
-      "type": "string"
-    },
-    "twtr_text": {
-      "type": "string"
-    },
     "type": {
       "type": "string"
     },
     "url": {
-      "type": "string"
-    },
-    "utm_campaign": {
-      "type": "string"
-    },
-    "utm_content": {
-      "type": "string"
-    },
-    "utm_term": {
       "type": "string"
     },
     "venue": {

--- a/_settings/processors.json
+++ b/_settings/processors.json
@@ -39,6 +39,11 @@
     "processor": "wordpress_post_processor",
     "mappings": "_settings/mappings/posts.json"
   },
+  "events": {
+    "url": "$WORDPRESS/api/get_posts/?post_type=event",
+    "processor": "wordpress_event_processor",
+    "mappings": "_settings/mappings/events.json"
+  },
   "newsroom": {
     "url": "$WORDPRESS/api/get_posts/?post_type=cfpb_newsroom",
     "processor": "wordpress_newsroom_processor",


### PR DESCRIPTION
This adds in support for the [ICS file generator](https://github.com/cfpb/flask-eventics/pull/2) within the Event processor by creating a dictionary for the necessary information the generator needs. It also deletes the taxonomy data that isn't used afterwards, and sorts the data by key; both of which are for the purpose of readability when examining the event data.

### Testing
Go to the linked ICS generator and clone it into your folder where cfgov-refresh lays. Then follow the instructions to install its dependencies and install it into your venv. After you've done that:
- Create a Event with the latest plugin code in Unitybox (wp-flapjack, cms-toolkit)
- Index it! (that being Unitybox)
- Make sure there's a dictionary in the data called `ics` after indexing. It should look like this
```json
"ics": {
        "dtstamp": "2015-06-30T11:39:58-0400",
        "uid": "/event/future-event-2/",
        "summary": "Future Event",
        "dtend": "2015-07-05T05:00:00-04:00",
        "dtstart": "2015-07-04T05:10:00-04:00",
        "starting_tzinfo": "America/New_York",
        "ending_tzinfo": "America/New_York"
}
```
- serve sheer
- Go to the url `localhost:7000/events/<event-slug>/ics`
- If that generates an ICS file, you're good to go!

@jimmynotjim @sebworks @anselmbradford @KimberlyMunoz 