### PR TITLE
Take out event processor to fix python indexing error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,12 +13,12 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 
 ---------------------------------------
 
-## Unreleased
+## 3.0.0-1.2.1 - 2015-06-29
 
 ### Added
 
 ### Removed
-
+- Event processor to fix indexing error
 ### Changed
 
 ## 3.0.0-1.2.0 - 2015-06-19

--- a/_settings/processors.json
+++ b/_settings/processors.json
@@ -39,16 +39,6 @@
     "processor": "wordpress_post_processor",
     "mappings": "_settings/mappings/posts.json"
   },
-  "events": {
-    "url": "$WORDPRESS/api/get_posts/?post_type=event",
-    "processor": "wordpress_event_processor",
-    "mappings": "_settings/mappings/events.json"
-  },
-  "events_archive": {
-    "url": "$WORDPRESS/api/get_posts/",
-    "processor": "wordpress_post_processor",
-    "mappings": "_settings/mappings/posts.json"
-  },
   "newsroom": {
     "url": "$WORDPRESS/api/get_posts/?post_type=cfpb_newsroom",
     "processor": "wordpress_newsroom_processor",


### PR DESCRIPTION
This removes the event's processor that's causing the indexing error.

Tested and nav is working.

### Test
just index and serve
go to office pages
go to their sub-pages

@jimmynotjim @anselmbradford @KimberlyMunoz @dpford 