### PR TITLE
Updates students-and-graduates page to use templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,8 +26,8 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
   image sizes on mobile carousel.
 - Added `u-link__disabled` utility class for styling disabled links.
 - Added `/careers/working-at-cfpb/` page.
-- Added block templates for current openings, job app process,
-  linkedin info, and provide feedback link.
+- Added block templates for LinkedIn info, provide feedback link,
+  and career page summaries.
 - Added `.content-l_col__before-inset-divider` CF enhancement
   for a column divider in cf-layout that has a gap between the
   top of the divider and the top border.

--- a/_includes/templates/summaries/linkedin.html
+++ b/_includes/templates/summaries/linkedin.html
@@ -10,5 +10,5 @@
 </p>
 <a href="https://www.linkedin.com/company/consumer-financial-protection-bureau"
    class="jump-link jump-link__external-link">
-	Follow Us on LinkedIn
+	Follow us on LinkedIn
 </a>

--- a/careers/_template-careers-related-links.html
+++ b/careers/_template-careers-related-links.html
@@ -1,0 +1,20 @@
+<div class="block
+            block__bg
+            block__border-top
+            block__border-right
+            block__flush-top
+            block__flush-bottom
+            block__flush-sides">
+    <div class="">
+            {# TODO: Add Office of Civil Rights URL. #}
+            {%- import "related-links.html" as related_links -%}
+            {{- related_links.render([
+                [ '/blog/',
+                  'CFPB Blog' ],
+                [ '/newsroom/',
+                  'Newsroom' ],
+                [ '',
+                  'Office of Civil Rights' ]
+            ]) -}}
+    </div>
+</div>

--- a/careers/_template-current-openings.html
+++ b/careers/_template-current-openings.html
@@ -3,7 +3,7 @@
     We post new openings frequently. See them here.
 </p>
 <p class="short-desc">
-    <a class="jump-link jump-link__right">
+    <a class="jump-link jump-link__right u-link__disabled">
         Browse CFPB job openings
     </a>
 </p>

--- a/careers/_template-job-app-process.html
+++ b/careers/_template-job-app-process.html
@@ -5,7 +5,7 @@
     Learn how it works.
 </p>
 <p class="short-desc">
-    <a class="jump-link jump-link__right">
+    <a class="jump-link jump-link__right u-link__disabled">
         Learn how the job application process works
     </a>
 </p>

--- a/careers/_template-students-and-graduates.html
+++ b/careers/_template-students-and-graduates.html
@@ -1,0 +1,9 @@
+<h2 class="h4">Students & Recent Graduates</h2>
+<p class="short-desc">
+    Find opportunities in public service for a new generation of leaders.
+</p>
+<p class="short-desc">
+    <a href="/careers/students-and-graduates/" class="jump-link jump-link__right">
+        Learn about students & graduates opportunities
+    </a>
+</p>

--- a/careers/_template-working-at-cfpb.html
+++ b/careers/_template-working-at-cfpb.html
@@ -1,0 +1,11 @@
+<h2 class="h4">Working at the CFPB</h2>
+<p class="short-desc">
+    Help us continue to grow
+    and develop our 21st century agency.
+    The work you do will directly impact the lives of consumers.
+</p>
+<p class="short-desc">
+    <a href="/careers/working-at-cfpb/" class="jump-link jump-link__right">
+        Learn what it's like to work at the CFPB
+    </a>
+</p>

--- a/careers/students-and-graduates/index.html
+++ b/careers/students-and-graduates/index.html
@@ -7,7 +7,7 @@
 {%- endblock %}
 
 {% block desc -%}
-
+    {# TODO: Add page meta description. #}
 {%- endblock %}
 
 {% block content_modifiers -%}
@@ -15,11 +15,16 @@
     careers-students-and-graduates
 {%- endblock %}
 
+{% block content_main_modifiers -%}
+    {{ super() }}
+    content__flush-bottom
+{%- endblock %}
+
 {% block content_main %}
 
     <section class="block block__flush-top block__sub">
 
-            <h1>Students and graduates</h1>
+            <h1>Students and Recent Graduates</h1>
             <p class="h3">
                 The CFPB is committed to creating and sustaining
                 a new generation of leaders.
@@ -27,203 +32,118 @@
             </p>
     </section>
 
-    <section>
-
-        <section class="media
-                        block
-                        block__padded-top
-                        block__border-top
-                        block__flush-bottom">
-            <div class="media_image-container media_image-container__wide-margin">
-                <img class="u-hide-on-mobile"
-                     src="/static/img/gavel-round.png">
-            </div>
-            <div class="media_body">
-                <h2>Brandeis Honor Attorney Program</h2>
-                <h3 class="h5">Look for applications here starting Summer 2015</h3>
-                <p class="short-desc">
-                    A two-year fellowship that provides law students
-                    and recent law school graduates
-                    early, substantive opportunities to use and develop
-                    their legal skills
-                    and make a difference in the lives of American consumers.
-                </p>
-            </div>
-        </section>
-
-        <section class="media
-                        block
-                        block__padded-top
-                        block__border-top
-                        block__flush-bottom">
-            <div class="media_image-container media_image-container__wide-margin">
-                <img class="u-hide-on-mobile"
-                     src="/static/img/computer-round.png">
-            </div>
-            <div class="media_body">
-                <h2>CFPB Summer Internship</h2>
-                <h3 class="h5">Look for applications here starting Fall 2015</h3>
-                <p class="short-desc">
-                    A twelve-week, paid summer internship program
-                    for high-potential students to assist
-                    in a variety of operational and mission-oriented projects.
-                    Students receive on-the-job training in the technical aspects
-                    of the organization's work.
-                    The students' interests, knowledge, and academic background
-                    play a large role in determining assignments.
-                </p>
-            </div>
-        </section>
-
-        <section class="media
-                        block
-                        block__padded-top
-                        block__border-top
-                        block__flush-bottom">
-            <div class="media_image-container media_image-container__wide-margin">
-                <img class="u-hide-on-mobile"
-                     src="/static/img/charts-round.png">
-            </div>
-            <div class="media_body">
-                <h2>Director's Financial Analyst</h2>
-                <h3 class="h5">Look for applications here starting Fall 2015</h3>
-                <p class="short-desc">
-                    Our highly selective, two-year rotational program.
-                    We seek out a small group of talented college graduates
-                    and challenge them to use their analytical skills
-                    to make financial markets work better for all.
-                </p>
-            </div>
-        </section>
-
-        <section class="media
-                        block
-                        block__padded-top
-                        block__border-top
-                        block__flush-bottom">
-            <div class="media_image-container media_image-container__wide-margin">
-                <img class="u-hide-on-mobile"
-                     src="/static/img/white-house-round.png">
-            </div>
-            <div class="media_body">
-                <h2>Presidential Management Fellow</h2>
-                <h3 class="h5">Applications due by XX/XX/XXXX</h3>
-                <p class="short-desc">
-                    The Federal government's flagship leadership development program
-                    at the entry level for advanced degree candidates.
-                    The two-year appointment provides a fast-paced opportunity
-                    to gain experience and develop talents.
-                    Fellows will be challenged with opportunities
-                    to flourish into problem solvers, strategic thinkers, and future leaders.
-                </p>
-                <p class="short-desc">
-                    <a href="http://www.pmf.gov/" class="jump-link jump-link__external-link">
-                        Here's how to apply to be a Presidential Management Fellow
-                    </a>
-                </p>
-            </div>
-        </section>
-
-        <div class="block
+    <section class="media
+                    block
                     block__padded-top
                     block__border-top
-                    content-l">
-            <section class="content-l_col-1-2">
-                <h2 class="h3">Job Application Process</h2>
-                <p class="short-desc">
-                    The application can be tricky.
-                    We can help.
-                    Learn how it works.
-                </p>
-                <p class="short-desc">
-                    <a href="#" class="jump-link jump-link__right">
-                        Learn how the application process works
-                    </a>
-                </p>
-            </section>
-            <section class="content-l_col-1-2">
-                <h2 class="h3">Working at the CFPB</h2>
-                <p class="short-desc">
-                    Help us continue to grow
-                    and develop our 21st century agency.
-                    The work you do will directly impact the lives of consumers
-                </p>
-                <p class="short-desc">
-                    <a href="#" class="jump-link jump-link__right">
-                        Learn what it's like to work at the CFPB
-                    </a>
-                </p>
-            </section>
+                    block__flush-bottom">
+        <div class="media_image-container media_image-container__wide-margin">
+            <img class="u-hide-on-mobile"
+                 src="/static/img/gavel-round.png">
         </div>
-        <div class="block
-                    block__padded-top
-                    block__border-top
-                    content-l">
-            <section class="content-l_col-1-2">
-                <h2 class="h3">
-                    <span class="cf-icon cf-icon-linkedin-square"></span>
-                    Follow us on LinkedIn
-                </h2>
-                <p class="short-desc">
-                    The CFPB is one of the most searched for agencies
-                    in the federal government.
-                    Connect with us to stay updated on the work
-                    we do and new opportunities to be a part of it.
-                </p>
-                <p class="short-desc">
-                    <a href="https://www.linkedin.com/company/consumer-financial-protection-bureau"
-                       class="jump-link jump-link__external-link">
-                        Go to our LinkedIn
-                    </a>
-                </p>
-            </section>
-            <section class="content-l_col-1-2">
-                <h2 class="h3">Provide Us With Feedback</h2>
-                <p class="short-desc">
-                    {# TODO: Have Content look at this paragraph
-                    and the weird link break. #}
-
-                    We take pride in our feedback-centered culture
-                    that helps us recruit great people.
-                    If you have any feedback, or any specific questions,
-                    let us know at:
-                </p>
-                <p class="short-desc">
-                    <ul class="list list__icons">
-                        <li class="list_item">
-                            <span class="cf-icon cf-icon-email list_icon"></span>
-                            <span class="h5 list_text">Email</span>
-                            <p><a href="mailto:jobs@consumerfinance.gov"
-                               class="jump-link">
-                                jobs@consumerfinance.gov
-                            </a></p>
-                        </li>
-                    </ul>
-                </p>
-            </section>
+        <div class="media_body">
+            <h2>Brandeis Honor Attorney Program</h2>
+            <h3 class="h5">Look for applications here starting Summer 2015</h3>
+            <p class="short-desc">
+                A two-year fellowship that provides law students
+                and recent law school graduates
+                early, substantive opportunities to use and develop
+                their legal skills
+                and make a difference in the lives of American consumers.
+            </p>
         </div>
     </section>
 
-    {# Footer #}
-    <aside>
-        <div class="block
-                    block__flush-sides
-                    block__flush-bottom
-                    block__flush-top
-                    block__bg">
-            <div class="">
-                    {# Add Office of Civil Rights URL #}
-                    {%- import "related-links.html" as related_links -%}
-                    {{- related_links.render([
-                        [ '/blog/',
-                          'CFPB Blog' ],
-                        [ '/newsroom/',
-                          'Newsroom' ],
-                        [ '',
-                          'Office of Civil Rights' ]
-                    ]) -}}
-            </div>
+    <section class="media
+                    block
+                    block__padded-top
+                    block__border-top
+                    block__flush-bottom">
+        <div class="media_image-container media_image-container__wide-margin">
+            <img class="u-hide-on-mobile"
+                 src="/static/img/computer-round.png">
         </div>
+        <div class="media_body">
+            <h2>CFPB Summer Internship</h2>
+            <h3 class="h5">Look for applications here starting Fall 2015</h3>
+            <p class="short-desc">
+                A twelve-week, paid summer internship program
+                for high-potential students to assist
+                in a variety of operational and mission-oriented projects.
+                Students receive on-the-job training in the technical aspects
+                of the organization’s work.
+                The students’ interests, knowledge, and academic background
+                play a large role in determining assignments.
+            </p>
+        </div>
+    </section>
+
+    <section class="media
+                    block
+                    block__padded-top
+                    block__border-top
+                    block__flush-bottom">
+        <div class="media_image-container media_image-container__wide-margin">
+            <img class="u-hide-on-mobile"
+                 src="/static/img/charts-round.png">
+        </div>
+        <div class="media_body">
+            <h2>Director’s Financial Analyst</h2>
+            <h3 class="h5">Look for applications here starting Fall 2015</h3>
+            <p class="short-desc">
+                Our highly selective, two-year rotational program.
+                We seek out a small group of talented college graduates
+                and challenge them to use their analytical skills
+                to make financial markets work better for all.
+            </p>
+        </div>
+    </section>
+
+    <section class="media
+                    block
+                    block__padded-top
+                    block__border-top
+                    block__flush-bottom">
+        <div class="media_image-container media_image-container__wide-margin">
+            <img class="u-hide-on-mobile"
+                 src="/static/img/white-house-round.png">
+        </div>
+        <div class="media_body">
+            <h2>Presidential Management Fellow</h2>
+            {# TODO: Replace filler date with actual date info. #}
+            <h3 class="h5">Applications due by XX/XX/XXXX</h3>
+            <p class="short-desc">
+                The Federal government’s flagship leadership development program
+                at the entry level for advanced degree candidates.
+                The two-year appointment provides a fast-paced opportunity
+                to gain experience and develop talents.
+                Fellows will be challenged with opportunities
+                to flourish into problem solvers, strategic thinkers, and future leaders.
+            </p>
+            <p class="short-desc">
+                <a href="http://www.pmf.gov/" class="jump-link jump-link__external-link">
+                    Here’s how to apply to be a Presidential Management Fellow
+                </a>
+            </p>
+        </div>
+    </section>
+
+    <div class="block
+                block__padded-top
+                block__border-top
+                content-l">
+        <section class="content-l_col content-l_col-1-2">
+            {% include "_template-job-app-process.html" %}
+        </section>
+        <section class="content-l_col content-l_col-1-2">
+            {% include "_template-working-at-cfpb.html" %}
+        </section>
+    </div>
+
+    {% include "templates/summaries/block-social.html" %}
+
+    <aside>
+        {% include "./_template-careers-related-links.html" %}
     </aside>
 
 {% endblock %}

--- a/careers/working-at-cfpb/index.html
+++ b/careers/working-at-cfpb/index.html
@@ -130,37 +130,21 @@
                 block__padded-top
                 block__border-top
                 content-l">
-        <section class="content-l_col content-l_col-1-2">
-            {% include "templates/summaries/current-openings.html" %}
+        <section class="content-l_col content-l_col-1-3">
+            {% include "_template-current-openings.html" %}
         </section>
-        <section class="content-l_col content-l_col-1-2">
-            {% include "templates/summaries/job-app-process.html" %}
+        <section class="content-l_col content-l_col-1-3">
+            {% include "_template-job-app-process.html" %}
+        </section>
+        <section class="content-l_col content-l_col-1-3">
+            {% include "_template-students-and-graduates.html" %}
         </section>
     </div>
 
     {% include "templates/summaries/block-social.html" %}
 
     <aside>
-        <div class="block
-                    block__bg
-                    block__border-top
-                    block__border-right
-                    block__flush-top
-                    block__flush-bottom
-                    block__flush-sides">
-            <div class="">
-                    {# TODO: Add Office of Civil Rights URL. #}
-                    {%- import "related-links.html" as related_links -%}
-                    {{- related_links.render([
-                        [ '/blog/',
-                          'CFPB Blog' ],
-                        [ '/newsroom/',
-                          'Newsroom' ],
-                        [ '',
-                          'Office of Civil Rights' ]
-                    ]) -}}
-            </div>
-        </div>
+        {% include "./_template-careers-related-links.html" %}
     </aside>
 
 {% endblock %}


### PR DESCRIPTION
Updates students-and-graduates page to use templates introduced in https://github.com/cfpb/cfgov-refresh/pull/686

## Additions

- Added templates for career page summaries.

## Changes

- LinkedIn text per @sarahsimpson09 comment.
- Minor apostrophe fixes.
- Moved careers-specific templates from the global _includes folder to the careers folder.
- Updated students and graduates page to:
  - Remove wrapper `section`.
  - Use templates for bottom half of page, for blocks that get reused elsewhere in careers.
  - Changes title to "Students and Recent Graduates."
  - Adds borders and removes bottom margin from footer.
  - Adds disabled link styling.
- Updated working at the CFPB page to:
  - Use related links template.

## Testing

- Appearance of `/careers/working-at-cfpb/` and `/careers/students-and-graduates/` should be similar.

## Review

- @KimberlyMunoz 
- @jimmynotjim 
- @sebworks 

## Preview

![screen shot 2015-07-01 at 5 46 46 pm](https://cloud.githubusercontent.com/assets/704760/8465847/03fed920-201b-11e5-9101-c7be14e2a1a4.png)

Full bottom area:
![screen shot 2015-07-01 at 6 00 18 pm](https://cloud.githubusercontent.com/assets/704760/8465856/1530f6ec-201b-11e5-84a9-2b1ec3fb5e59.png)

## Notes

- I don't think we have a pattern for includes that are for one section only. Unfortunately I don't think we can include a directory there to match the `./_includes` structure so I prefixed the templates with `_template-` to match `_vars-`. If this works, /events/ should follow the pattern too for its local includes.