### PR TITLE
Updates hierarchy of careers nav

### DIFF
--- a/careers/_vars-careers.html
+++ b/careers/_vars-careers.html
@@ -1,11 +1,9 @@
 {% set path = '/careers/' %}
 {% set nav_items = [
-    (path, 'index', 'Careers at the CFPB'),
-    (path + 'working-at-cfpb/', 'working-at-cfpb', 'Working at the CFPB'),
-    (path + 'application-process/', 'application-process', 'Job Application Process'),
-    (path + 'students-and-graduates/', 'students-and-graduates', 'Students & Recent Graduates'),
-    (path + 'current-openings/', 'current-openings', 'All Current Openings'),
-    (path + 'skillsets/', 'skillsets', 'Jobs by Skill-Set'),
-    (path + 'veterans/', 'veterans', 'Veterans')
-]
-%}
+    (path, 'index', 'Careers at the CFPB', [
+      (path + 'working-at-cfpb/', 'working-at-cfpb', 'Working at the CFPB'),
+      (path + 'application-process/', 'application-process', 'Job Application Process'),
+      (path + 'students-and-graduates/', 'students-and-graduates', 'Students & Recent Graduates'),
+      (path + 'current-openings/', 'current-openings', 'Current Openings')
+    ])
+] -%}


### PR DESCRIPTION
Updates hierarchy and entries in the careers nav.

## Removals

- Removes careers entries that are not a part of this sprint.

## Changes

- Updates careers nav vars file to nest all careers entries under main careers landing page.

## Testing

- e.g. `/careers/students-and-graduates` should show a hierarchy and reduced number of sidenav options.

## Review

- @jimmynotjim 
- @KimberlyMunoz 
- @sebworks 

## Preview

![screen shot 2015-07-02 at 10 31 37 am](https://cloud.githubusercontent.com/assets/704760/8479396/8d49aa86-20a5-11e5-9b1e-7155f51409a9.png)

## Notes

- Part of DF-2099
