### PR TITLE
HOTFIX nav links and order of nav items on office page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,8 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 ### Removed
 
 ### Fixed
-
+- Office/Subpage navigation links on beta
+- Ordering of subpages in the nav on Office page
 
 ## 3.0.0-1.2.1 - 2015-06-29
 

--- a/offices/_vars-offices.html
+++ b/offices/_vars-offices.html
@@ -6,8 +6,8 @@
 
 {% set office_title = office.short_title|safe if office.short_title else office.title|safe %}
 {% set child_pages = [] %}
-{% for page in sub_pages %}
+{% for page in sub_pages | sort(attribute='order') %}
     {% set child_title = page.short_title|safe if page.short_title else page.title|safe %}
-    {%- set _ignore = child_pages.append((page.permalink, page.slug, child_title)) -%}
+    {%- set _ignore = child_pages.append(('/sub-pages/' + page.slug + '/', page.slug, child_title)) -%}
 {% endfor %}
-{% set nav_items = [(office.permalink, 'index', office_title, child_pages)] -%}
+{% set nav_items = [('/offices/' + office.slug + '/', 'index', office_title, child_pages)] -%}

--- a/sub-pages/_vars-sub-pages.html
+++ b/sub-pages/_vars-sub-pages.html
@@ -16,11 +16,11 @@
 {% endfor %}
 {% for page in nav_sub_pages | sort(attribute='order') %}
     {% set child_title = page.short_title|safe if page.short_title else page.title|safe %}
-    {%- set _ignore = child_pages.append((page.permalink, page.slug, child_title)) -%}
+    {%- set _ignore = child_pages.append(('/sub-pages/' + page.slug + '/', page.slug, child_title)) -%}
 {% endfor %}
-{% set nav_items = [(office.permalink, office.slug, office.title, child_pages)] -%}
+{% set nav_items = [('/offices/' + office.slug + '/', office.slug, office.title, child_pages)] -%}
 {% set breadcrumb_items = [] -%}
-{% set _ignore = breadcrumb_items.append((office.permalink, office.slug, office.title)) %}
+{% set _ignore = breadcrumb_items.append(('/offices/' + office.slug + '/', office.slug, office.title)) %}
 
 {# Get the records for latest activities #}
 {# This to fake data for records sub-pages #}


### PR DESCRIPTION
This fixes the links in the navigation for offices and subpages on beta, and fixes the ordering of subpages in the nav on the office page.

Currently we don't know why, but the permalink feature of sheer is unstable on beta, though seems to act normally in staging. This removes that complexity and "hard-codes" the slug into the appropriate url pattern. We know the slug is available on beta, so we deem this appropriate to fix that issue. Additionally, the subpages in the navigation should be ordered based on the order given in the CMS. This is not happening when visiting an office page.

@jimmynotjim @sebworks @anselmbradford @KimberlyMunoz 