### PR TITLE
Removing colons

### DIFF
--- a/_includes/contact-macro.html
+++ b/_includes/contact-macro.html
@@ -22,7 +22,7 @@
                 <li class="list_item u-break-word">
                     {%- if loop.index == 1 %}
                         <span class="cf-icon cf-icon-email list_icon"></span>
-                        <span class="h5 list_text">Email:</span>
+                        <span class="h5 list_text">Email</span>
                     {%- endif %}
                     {%- if email.addr %}
                         <p>
@@ -40,7 +40,7 @@
                 <li class="list_item">
                     {%- if loop.index == 1 %}
                         <span class="cf-icon cf-icon-phone list_icon"></span>
-                        <span class="h5 list_text">Phone:</span>
+                        <span class="h5 list_text">Phone</span>
                     {%- endif %}
                     <p class="short-desc">
                         <a class="list_link list_link__phone" href="tel:{{ phone.num }}">
@@ -58,7 +58,7 @@
         {%- if contact.fax %}
             <li class="list_item">
                 <span class="cf-icon cf-icon-fax list_icon"></span>
-                <span class="h5 list_text">Fax:</span>
+                <span class="h5 list_text">Fax</span>
                 <p class="short-desc">
                     {{ format_phone(contact.fax.num) if contact.fax.num }}
                 </p>
@@ -67,7 +67,7 @@
         {%- if contact.street %}
             <li class="list_item">
                 <span class="cf-icon cf-icon-mail list_icon"></span>
-                <span class="h5 list_text">Mailing Address:</span>
+                <span class="h5 list_text">Mailing Address</span>
                 <p class="short-desc">
                     Consumer Financial Protection Bureau<br>
                     {{ contact.attn if contact.attn }}<br>

--- a/contact-us/general-inquiries.html
+++ b/contact-us/general-inquiries.html
@@ -15,7 +15,7 @@
                 <li class="list_item u-break-word">
                 {%- if loop.index == 1 %}
                     <span class="cf-icon cf-icon-email list_icon"></span>
-                    <span class="h5 list_text">Email:</span>
+                    <span class="h5 list_text">Email</span>
                 {%- endif %}
                     <p>
                         <a class="list_link" href="mailto:{{ email.addr }}">
@@ -33,7 +33,7 @@
                 <li class="list_item">
                 {%- if loop.index == 1 %}
                     <span class="cf-icon cf-icon-phone list_icon"></span>
-                    <span class="h5 list_text">Phone:</span>
+                    <span class="h5 list_text">Phone</span>
                 {%- endif %}
                     <p>
                         <a class="list_link list_link__phone" href="tel:{{ phone.num }}">
@@ -47,7 +47,7 @@
     {%- if general_inquiries.fax %}
         <li class="list_item">
             <span class="cf-icon cf-icon-fax list_icon"></span>
-            <span class="h5 list_text">Fax:</span>
+            <span class="h5 list_text">Fax</span>
             <p class="short-desc">
                 {{ format_phone(general_inquiries.fax.num) if general_inquiries.fax.num }}
             </p>


### PR DESCRIPTION
Fixes #688.

This is a tiny PR and should only affect `/contact-us/` to bring it in line with the new way we're doing labels.