### PR TITLE
Changing to block__flush-top/bottom

### DIFF
--- a/src/_includes/leadership-calendar-table.html
+++ b/src/_includes/leadership-calendar-table.html
@@ -10,7 +10,7 @@
 {% set _ignore = options.update(user_options) %}
 
 {% for days in posts|groupby('day')|reverse %}
-<table class="u-w100pct block u-mt0">
+<table class="u-w100pct block block__flush-top">
     <thead>
         <tr>
             <th colspan="3">

--- a/src/_includes/templates/office-contact.html
+++ b/src/_includes/templates/office-contact.html
@@ -4,9 +4,9 @@
     <section class="office_contact
                     block
                     block__flush-sides
-                    block__bg
-                    u-mb0
-                    u-mt0">
+                    block__flush-top
+                    block__flush-bottom
+                    block__bg">
         <h1 class="header-slug">
             <span class="header-slug_inner">
                 Contact Information

--- a/src/blog/_single.html
+++ b/src/blog/_single.html
@@ -28,7 +28,7 @@
 {% endblock %}
 
 {% block content_sidebar %}
-    <section class="block u-mt0">
+    <section class="block block__flush-top">
         {% import "related-posts.html" as related_posts with context %}
         {{ related_posts.render(post) }}
     </section>
@@ -38,7 +38,7 @@
                 Stay informed
             </span>
         </h1>
-        <div class="block block__sub u-mt0">
+        <div class="block block__sub block__flush-top">
             <p class="short-desc">
                 Subscribe to our email newsletter. We will update you on new blogs.
             </p>

--- a/src/blog/index.html
+++ b/src/blog/index.html
@@ -43,7 +43,7 @@
 {% endblock %}
 
 {% block content_sidebar %}
-    <section class="block u-mt0">
+    <section class="block block__flush-top">
         {% if view.popular_posts %}
             {% import "popular-stories.html" as popular_stories with context %}
             {{ popular_stories.render(view.popular_posts) }}
@@ -55,7 +55,7 @@
                 Stay informed
             </span>
         </h1>
-        <div class="block block__sub u-mt0">
+        <div class="block block__sub block__flush-top">
             <p class="short-desc">
                 Subscribe to our email newsletter. We will update you on new blogs.
             </p>

--- a/src/careers/_macro-table-current-openings.html
+++ b/src/careers/_macro-table-current-openings.html
@@ -16,7 +16,10 @@
 
 {% from "macros/util/format.html" import format_time as format_time %}
 
-<table class="u-w100pct block u-mt0 simple-table">
+<table class="u-w100pct
+              block
+              block__flush-top
+              simple-table">
     <thead>
         <tr>
             <th>

--- a/src/contact-us/_template-contact-list.html
+++ b/src/contact-us/_template-contact-list.html
@@ -14,8 +14,15 @@
 
         <div class="input-with-btn">
             <div class="input-with-btn_input btn-inside-input">
-                <input class="js-type-and-filter_input input__super" type="text" placeholder="Filter contacts by keyword" required>
-                <button class="js-type-and-filter_clear btn btn__super btn__link btn__secondary" type="reset">
+                <input class="js-type-and-filter_input input__super"
+                       type="text"
+                       placeholder="Filter contacts by keyword"
+                       required>
+                <button class="js-type-and-filter_clear
+                               btn
+                               btn__super
+                               btn__link
+                               btn__secondary" type="reset">
                     Clear
                     <span class="cf-icon cf-icon-delete"></span>
                 </button>
@@ -45,7 +52,10 @@
 
     </form>
 
-    <div class="block u-mt0 expandable-group contact-list"
+    <div class="block
+                block__flush-top
+                expandable-group
+                contact-list"
          data-accordion="true"
          id ="contact-list">
         <div class="expandable-group_header"

--- a/src/contact-us/_template-mailing-addresses.html
+++ b/src/contact-us/_template-mailing-addresses.html
@@ -3,7 +3,10 @@
 {% set administrative_offices = vars.administrative_offices %}
 {% set consumer_contact_center = vars.consumer_contact_center  %}
 
-<section class="block u-mt0 content-l content-l__sidebar">
+<section class="block
+                block__flush-top
+                content-l
+                content-l__sidebar">
 
     <h1 class="h3 content-l_col content-l_col-1-2">
         Mailing addresses

--- a/src/contact-us/_template-submit-a-complaint.html
+++ b/src/contact-us/_template-submit-a-complaint.html
@@ -13,7 +13,7 @@
     <li class="list_item">
     {% if loop.index == 1 %}
         <span class="cf-icon cf-icon-phone list_icon"></span>
-        <span class="h5 list_text">Phone:</span>
+        <span class="h5 list_text">Phone</span>
     {% endif %}
         <p>
             <a class="list_link list_link__phone" href="tel:{{ phone.num }}">

--- a/src/events/_event-post-macros.html
+++ b/src/events/_event-post-macros.html
@@ -319,7 +319,10 @@
               block__padded-top
               block__border-top">
     <h2>Agenda</h2>
-    <table class="u-w100pct block u-mt0 simple-table">
+    <table class="u-w100pct
+                  block
+                  block__flush-top
+                  simple-table">
         <thead>
             <tr>
                 <th class="{{ options.time_col_classes }}">Time</th>

--- a/src/events/_single.html
+++ b/src/events/_single.html
@@ -48,7 +48,7 @@
 {% endblock %}
 
 {% block content_sidebar %}
-    <section class="block u-mt0">
+    <section class="block block__flush-top">
         {% import "related-posts.html" as related_posts with context %}
         {{ related_posts.render(event) }}
     </section>
@@ -58,7 +58,7 @@
                 Stay informed
             </span>
         </h1>
-        <div class="block block__sub u-mt0">
+        <div class="block block__sub block__flush-top">
             <p class="short-desc">
                 Subscribe to our email newsletter. We will update you on new blogs.
             </p>

--- a/src/events/archive/_single.html
+++ b/src/events/archive/_single.html
@@ -45,7 +45,7 @@
 {% endblock %}
 
 {% block content_sidebar %}
-    <section class="block u-mt0">
+    <section class="block block__flush-top">
         {% import "related-posts.html" as related_posts with context %}
         {{ related_posts.render(event_archive) }}
     </section>
@@ -55,7 +55,7 @@
                 Stay informed
             </span>
         </h1>
-        <div class="block block__sub u-mt0">
+        <div class="block block__sub block__flush-top">
             <p class="short-desc">
                 Subscribe to our email newsletter. We will update you on new blogs.
             </p>

--- a/src/newsroom/_single.html
+++ b/src/newsroom/_single.html
@@ -40,7 +40,7 @@
 {% endblock %}
 
 {% block content_sidebar %}
-    <section class="block u-mt0">
+    <section class="block block__flush-top">
         {% import "related-posts.html" as related_posts with context %}
         {{ related_posts.render(newsroom, 'posts,newsroom', 5) }}
     </section>

--- a/src/newsroom/index.html
+++ b/src/newsroom/index.html
@@ -53,14 +53,17 @@
                 </div>
             </div>
         </section>
-        <div class="u-mb0
-                    block
+        <div class="block
                     block__bg
                     block__flush-sides
+                    block__flush-bottom
                     related_content
                     ">
             <div class="content-l content-l__main">
-                <section class="block u-mt0 content-l_col content-l_col-1-2">
+                <section class="block
+                                block__flush-top
+                                content-l_col
+                                content-l_col-1-2">
                     {% import "related-links.html" as related_links %}
                     {{- related_links.render([
                         [

--- a/src/newsroom/press-resources/index.html
+++ b/src/newsroom/press-resources/index.html
@@ -192,10 +192,10 @@
 
     </section><!-- END .press-section.press-photos-bios -->
 
-    <aside class="u-mb0
-                  block
+    <aside class="block
                   block__bg
                   block__flush-sides
+                  block__flush-bottom
                   ">
         <div class="content-l content-l__main">
             <section class="content-l_col content-l_col-1-2">
@@ -204,7 +204,7 @@
                         Stay informed
                     </span>
                 </h1>
-                <div class="block block__sub u-mt0">
+                <div class="block block__sub block__flush-top">
                     <p class="short-desc">
                         Subscribe to get our press releases by email.
                     </p>

--- a/src/privacy-policy/index.html
+++ b/src/privacy-policy/index.html
@@ -40,7 +40,7 @@
                     block__flush-sides
                     related_content">
             <div class="content-l content-l__main">
-                <section class="block u-mt0 content-l_col content-l_col-1-2">
+                <section class="block block__flush-top content-l_col content-l_col-1-2">
                     {% import "related-links.html" as related_links %}
                     {{ related_links.render(view.related_links) }}
                 </section>

--- a/src/the-bureau/about-rich-cordray/index.html
+++ b/src/the-bureau/about-rich-cordray/index.html
@@ -14,7 +14,7 @@
 
 	{% import "macros/share.html" as share %}
 
-    <div class="block u-mt0">
+    <div class="block block__flush-top">
         <h1>
             Director Richard Cordray
         </h1>

--- a/src/the-bureau/about-steve-antonakes/index.html
+++ b/src/the-bureau/about-steve-antonakes/index.html
@@ -14,7 +14,7 @@
 
 	{% import "macros/share.html" as share %}
 
-    <div class="block u-mt0">
+    <div class="block block__flush-top">
         <h1>
             Deputy Director Steven Antonakes
         </h1>
@@ -135,7 +135,7 @@
             </div>
         </section>
 
-        <section class="block u-mb0">
+        <section class="block block__flush-bottom">
             {%- import "related-links.html" as related_links -%}
             {{- related_links.render([
                 [ vars.path + 'about-rich-cordray/',

--- a/src/the-bureau/history/index.html
+++ b/src/the-bureau/history/index.html
@@ -17,7 +17,7 @@
 
     {% set query = queries.history %}
 
-    <div class="block u-mt0">
+    <div class="block block__flush-top">
         <h1>
             The history of the Consumer Financial Protection Bureau
         </h1>

--- a/src/the-bureau/index.html
+++ b/src/the-bureau/index.html
@@ -109,12 +109,12 @@
         })
     }}
 
-    <section class="u-mb0
-                    u-mt0
-                    block
+    <section class="block
                     block__bg
                     block__border
                     block__flush-sides
+                    block__flush-top
+                    block__flush-bottom
                     ">
         <h1 class="h2">Our core functions</h1>
         <p>Congress created the CFPB to create a single point of accountability for enforcing
@@ -143,7 +143,7 @@
                 </span>
             </button>
             <div class="expandable_content">
-                <section class="block__padded-top u-mb0 u-mt0">
+                <section class="block__padded-top block__flush-top block__flush-bottom">
                     <h1 class="h4">Among other things, we:</h1>
                     <ul class="list list__branded bureau-functions_list u-mb0">
                         <li>Write rules, supervise companies, and enforce federal consumer
@@ -163,7 +163,7 @@
         </div><!-- END .bureau-functions -->
     </section><!-- END .content-block -->
 
-    <section class="block block__padded-top u-mt0">
+    <section class="block block__padded-top block__flush-top">
         <h1 class="h2">CFPB leadership</h1>
         <p class="short-desc">In January of 2012, President Barack Obama appointed
         Richard Cordray to be the first Director of the CFPB.</p>

--- a/src/the-bureau/leadership-calendar/index.html
+++ b/src/the-bureau/leadership-calendar/index.html
@@ -21,7 +21,10 @@
     {% from "post-macros.html" import filters as filters with context %}
     {% from "post-macros.html" import pagination as pagination with context %}
 
-    <div class="block u-mt0 block__padded-bottom block__border-bottom">
+    <div class="block
+                block__flush-top
+                block__padded-bottom
+                block__border-bottom">
         <h1>Leadership Calendar</h1>
         <p class="h3">
             At the Consumer Financial Protection Bureau, we are committed to letting you
@@ -46,7 +49,7 @@
 
     <div id="pagination_content"></div>
 
-    <div class="block u-mt0">
+    <div class="block block__flush-top">
 
     {% set query = queries.calendar_event %}
     {% set posts = query.search(size=20) %}
@@ -86,7 +89,10 @@
         ) }}
     </section>
 
-    <aside class="block u-mb0 block__flush-sides block__bg">
+    <aside class="block
+                  block__flush-bottom
+                  block__flush-sides
+                  block__bg">
         {# TODO: Add FOIA and Open government URLs. #}
         {%- import "related-links.html" as related_links -%}
         {{- related_links.render([


### PR DESCRIPTION
We have been over-using u-mt0 and u-mb0. This fixes #696.

## Changes

- Making changes to use block__flush-top or block__flush-bottom instead of u-mb0 and u-mt0

## Review

- @anselmbradford 
- @jimmynotjim 
- @sebworks 

## Preview

[Preview this PR without the whitespace changes](?w=0)
