### PR TITLE
Fix for Grandchild pages on /sub-pages/.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 
 ### Fixed
 - Fixed contact-us templates to make them private.
+- Fixed issue displaying grandchild pages on sub-pages.
 
 
 ## 3.0.0-1.2.2 - 2015-07-02

--- a/_includes/macros/sub_pages.html
+++ b/_includes/macros/sub_pages.html
@@ -1,0 +1,91 @@
+{# ==========================================================================
+
+   sub_pages.render()
+
+   ==========================================================================
+
+   Description:
+
+   Builds sub-pages markup when given:
+
+   sub_pages : An array containing sub-pages.
+
+   ========================================================================== #}
+
+{% macro render( sub_pages ) %}
+    {% set is_office_page = request.path.find('/offices/') > -1 %}
+    {% for page in sub_pages | sort(attribute='order') %}
+        {% set title = page.short_title or page.title  %}
+        {% if loop.first %}
+            <section class="block
+                            block__sub
+                            block__padded-top
+                            block__border-top
+                            {{ 'block__border-bottom' if is_office_page == false }}">
+                  <h1 class="h2">
+                      Our Work
+                  </h1>
+                  <div class="content-l
+                              content-l__main
+                              content-l__large-gutters
+                              expandables-group">
+        {% endif %}
+                      <div class="expandable
+                                  expandable__expanded
+                                  expandable__mobile-only
+                                  content-l_col
+                                  {# TODO: When we upgrade to Jinja2 2.8
+                                           we can use loop.length to
+                                           conditionally set this to one column or two.
+                                  #}
+                                  content-l_col-1-2
+                                  ">
+                      <button class="expandable_header expandable_target u-show-on-mobile">
+                          {% if title %}
+                              <span class="expandable_header-left expandable_label">
+                                  {{ title | safe }}
+                              </span>
+                          {% endif %}
+                          <span class="expandable_header-right expandable_link">
+                              <span class="expandable_cue-open">
+                                  <span class="cf-icon cf-icon-plus-round"></span>
+                              </span>
+                              <span class="expandable_cue-close">
+                                  <span class="cf-icon cf-icon-minus-round"></span>
+                              </span>
+                          </span>
+                      </button>
+                      <div class="expandable_content">
+                          {% if title %}
+                              <h2 class="h4 u-hide-on-mobile">
+                                  {{ title | safe }}
+                              </h2>
+                          {% endif %}
+                          {% if page.excerpt %}
+                              <p class="short-desc">
+                                  {{ page.excerpt | safe }}
+                              </p>
+                          {% endif %}
+                          {% if is_office_page == false and page.related_links %}
+                              <ul class="list__links">
+                                  {% for link in page.related_links %}
+                                      <li class="list_item">
+                                          <a class="jump-link jump-link__right list_link" href="{{link.url}}">
+                                              {{ link.label }}
+                                          </a>
+                                      </li>
+                                  {% endfor %}
+                              </ul>
+                          {% elif is_office_page or not page.related_links %}
+                              <a class="jump-link jump-link__right" href="{{ page.permalink }}">
+                                  {{ page.preview_text or 'Read more' }}
+                              </a>
+                          {% endif %}
+                      </div>
+                  </div><!-- END .expandable -->
+        {% if loop.last %}
+                </div>
+            </section>
+        {% endif %}
+    {% endfor %}
+{% endmacro %}

--- a/offices/_single.html
+++ b/offices/_single.html
@@ -27,7 +27,7 @@
                     content-l__large-gutters">
         {% set intro = office.intro %}
         {% set show_subscription = intro.subscribe_form and intro.govdelivery_code %}
-        <section class="office_intro content-l_col
+        <section class="content-l_col
                         {% if show_subscription -%}
                             content-l_col-1-2
                         {% else -%}
@@ -51,8 +51,7 @@
 
     {% if office.top_story.head %}
     {% set top_story = office.top_story %}
-    <section class="office_featured
-                    block
+    <section class="block
                     block__padded-top
                     block__border-top">
         {% if top_story.head %}
@@ -90,16 +89,14 @@
     </section>
     {% endif %}
     {% if office.resources %}
-    <section class="office_resources
-                    block
+    <section class="block
                     block__padded-top
                     block__border-top">
         <h1 class="h2">
             {{ resource_title }}
         </h1>
         {% for resource in office.resources %}
-            <div class="media office_resource
-                        block__sub">
+            <div class="media block__sub">
                 {% if resource.icon %}
                 <div class="media_image-container
                             media_image-container__wide-margin">
@@ -129,73 +126,13 @@
     </section>
     {% endif %}
 
-    {% for page in vars.sub_pages|sort(attribute='order') if page.show_in_office == "on" %}
-    {% if loop.first %}
-    <section class="office_sub_pages
-                    block
-                    block__sub
-                    block__padded-top
-                    block__border-top">
-        <h1 class="h2">
-            Our Work
-        </h1>
-        <div class="content-l
-                    content-l__main
-                    content-l__large-gutters
-                    expandables-group">
+    {% if vars.sub_pages %}
+        {% import "macros/sub_pages.html" as sub_pages_macro with context %}
+        {{ sub_pages_macro.render( vars.sub_pages ) }}
     {% endif %}
-            <div class="office_initiative
-                        expandable
-                        expandable__expanded
-                        expandable__mobile-only
-                        content-l_col
-                        {# TODO: When we upgrade to Jinja2 2.8 we can use loop.length
-                                 to conditionally set this to one column or two. #}
-                        content-l_col-1-2
-                        ">
-                <button class="expandable_header expandable_target u-show-on-mobile">
-                    {% if page.short_title or page.title %}
-                    <span class="expandable_header-left expandable_label">
-                        {{ (page.short_title or page.title) | safe }}
-                    </span>
-                    {% endif %}
-                    <span class="expandable_header-right expandable_link">
-                        <span class="expandable_cue-open">
-                            <span class="cf-icon cf-icon-plus-round"></span>
-                        </span>
-                        <span class="expandable_cue-close">
-                            <span class="cf-icon cf-icon-minus-round"></span>
-                        </span>
-                    </span>
-                </button>
-                <div class="expandable_content">
-                    {% if page.short_title or page.title %}
-                    <h2 class="h4 u-hide-on-mobile">
-                        {{ (page.short_title or page.title) | safe }}
-                    </h2>
-                    {% endif %}
-                    {% if page.excerpt %}
-                    <p class="short-desc">
-                        {{ page.excerpt | safe }}
-                    </p>
-                    {% endif %}
-                    {% if page.slug %}
-                    <a class="jump-link jump-link__right" href="{{ page.permalink }}">
-                        {{ page.preview_text or 'Read more' }}
-                    </a>
-                    {% endif %}
-                </div>
-            </div><!-- END .expandable -->
-        {% if loop.last %}
-        </div>
-    </section>
-        {% endif %}
-    {% endfor %}
-
 
     {% if activities_feed %}
-    <section class="office_activities
-                    block
+    <section class="block
                     block__bg
                     block__flush-sides
                     block__flush-top

--- a/sub-pages/_single.html
+++ b/sub-pages/_single.html
@@ -28,60 +28,15 @@
     {% endif %}
 
     {% if sub_page.content %}
-    <section class="sub-page_content
-                    block
+    <section class="block
                     block__flush-top
                     block__flush-bottom">
         {{ sub_page.content | safe }}
     </section>
     {% endif %}
 
-    {% if sub_pages and sub_pages.total %}
-    <section class="block
-                    block__padded-top
-                    block__border-top
-                    block__flush-bottom">
-        <div class="content-l content-l__main">
-            {% for page in sub_pages|sort(attribute='order') %}
-            <!-- TODO: link header styles -->
-            <div class="sub-page_topic
-                        block__sub
-                        block__flush-top
-                        {{ 'office_col' if vars.sub_pages.result_dict|length > 1 else 'content-l_col-1' -}}">
-
-                {% if page.short_title or page.title %}
-                <h2 class="h3">
-                    {{ (page.short_title or page.title) | safe }}
-                </h2>
-                {% endif %}
-
-                {% if page.content %}
-                <p class="short-desc">
-                    {{ page.content | safe }}
-                </p>
-                {% endif %}
-
-                {% if page.related_links %}
-                <ul class="list__links">
-                {% for link in page.related_links %}
-                    <li class="list_item">
-                        <a class="jump-link jump-link__right list_link" href="{{link.url}}">
-                            {{ link.label }}
-                        </a>
-                    </li>
-                {% endfor %}
-                </ul>
-                {% endif %}
-
-            </div>
-            {% endfor %}
-        </div>
-    </section>
-    {% endif %}
-
     {% if sub_page.body_content %}
-    <section class="sub-page_content
-                    sub-page_{{sub_page.slug}}
+    <section class="sub-page_{{sub_page.slug}}
                     block
                     block__padded-top
                     block__border-top">
@@ -100,9 +55,22 @@
     </section>
     {% endif %}
 
+    {% if sub_pages and sub_pages.total %}
+        {% import "macros/sub_pages.html" as sub_pages_macro with context %}
+        {{ sub_pages_macro.render( vars.sub_pages ) }}
+    {% endif %}
+
+    {% if sub_page.related_faq %}
+        {% set related_faq = get_document('faq', sub_page.related_faq) %}
+        {% import "macros/expandable.html" as expandable with context %}
+        {{ expandable.render(
+                related_faq.faq, 'question', 'answer', {"title": "FAQS"}
+           ) if related_faq.faq
+        }}
+    {% endif %}
+
     {% if activities_feed and display_activity_flag == true %}
-    <section class="office_activities
-                    block
+    <section class="block
                     block__flush-sides
                     block__bg
                     u-mb0
@@ -113,15 +81,6 @@
             View all of our activities
         </a>
     </section>
-    {% endif %}
-
-    {% if sub_page.related_faq %}
-        {% set related_faq = get_document('faq', sub_page.related_faq) %}
-        {% import "macros/expandable.html" as expandable with context %}
-        {{ expandable.render(
-                related_faq.faq, 'question', 'answer', {"title": "FAQS"}
-           ) if related_faq.faq
-        }}
     {% endif %}
 
     {% set office = vars.office %}


### PR DESCRIPTION
Fixes issues with displaying grandchild pages on /sub-pages/.

## Changes
- Updated  'offices/_single.html' to use macro for displaying sub pages.
- Updated  'sub-pages/_single.html' to use macro for displaying grandchild pages.
- Added  '_includes/macros/sub-pages.html' to display sub page excerpts.

## Test
- Visit 'http://localhost:7000/sub-pages/civil-penalty-fund/'

## Screenshots
<img width="1104" alt="screen shot 2015-07-08 at 8 37 32 am" src="https://cloud.githubusercontent.com/assets/1696212/8570163/9c3006b6-254c-11e5-81f4-b44825a47d66.png">

## Notes
- Some of the content of the page needs to be updated.
- Links are currently inoperable and will be implemented in separate PR.

## Review
@jimmynotjim
@anselmbradford
@KimberlyMunoz
@kurtw 