### PR TITLE
Don't specify index in processor files

### DIFF
--- a/src/_lib/django_calendar_event_processor.py
+++ b/src/_lib/django_calendar_event_processor.py
@@ -41,7 +41,6 @@ def process_event(event):
         else:
             event['description'] = event['description'].strip()
 
-    return {'_index': 'content',
-            '_type': 'calendar_event',
+    return {'_type': 'calendar_event',
             '_id': event['id'],
             '_source': event}

--- a/src/_lib/wordpress_contact_processor.py
+++ b/src/_lib/wordpress_contact_processor.py
@@ -82,7 +82,6 @@ def process_contact(contact):
 
     del contact['custom_fields']
 
-    return {'_index': 'content',
-            '_type': 'contact',
+    return {'_type': 'contact',
             '_id': contact['slug'],
             '_source': contact}

--- a/src/_lib/wordpress_event_processor.py
+++ b/src/_lib/wordpress_event_processor.py
@@ -98,7 +98,6 @@ def process_event(event):
 
     event = OrderedDict(sorted(event.items(), key=lambda k: k[0]))
 
-    return {'_index': 'content',
-            '_type': 'events',
+    return {'_type': 'events',
             '_id': event['slug'],
             '_source': event}

--- a/src/_lib/wordpress_faq_processor.py
+++ b/src/_lib/wordpress_faq_processor.py
@@ -41,7 +41,6 @@ def process_post(post):
 
     del post['custom_fields']
 
-    return {'_index': 'content',
-            '_type': 'faq',
+    return {'_type': 'faq',
             '_id': post['slug'],
             '_source': post}

--- a/src/_lib/wordpress_featured_topic_processor.py
+++ b/src/_lib/wordpress_featured_topic_processor.py
@@ -51,7 +51,6 @@ def process_post(post):
 
     del post['custom_fields']
 
-    return {'_index': 'content',
-            '_type': 'featured_topic',
+    return {'_type': 'featured_topic',
             '_id': post['slug'],
             '_source': post}

--- a/src/_lib/wordpress_history_processor.py
+++ b/src/_lib/wordpress_history_processor.py
@@ -46,7 +46,6 @@ def process_history(item):
 
     del item['custom_fields']
 
-    return {'_index': 'content',
-            '_type': 'history',
+    return {'_type': 'history',
             '_id': item['slug'],
             '_source': item}

--- a/src/_lib/wordpress_newsroom_processor.py
+++ b/src/_lib/wordpress_newsroom_processor.py
@@ -48,7 +48,6 @@ def process_post(post):
 
     del post['custom_fields']
 
-    return {'_index': 'content',
-            '_type': 'newsroom',
+    return {'_type': 'newsroom',
             '_id': post['slug'],
             '_source': post}

--- a/src/_lib/wordpress_office_processor.py
+++ b/src/_lib/wordpress_office_processor.py
@@ -104,7 +104,6 @@ def process_office(post):
 
     del post['custom_fields']
 
-    return {'_index': 'content',
-            '_type': 'office',
+    return {'_type': 'office',
             '_id': post['slug'],
             '_source': post}

--- a/src/_lib/wordpress_orgmember_processor.py
+++ b/src/_lib/wordpress_orgmember_processor.py
@@ -47,7 +47,6 @@ def process_orgmember(member):
                             if member['custom_fields'].get(title)]
     del member['custom_fields']
 
-    return {'_index': 'content',
-            '_type': 'orgmember',
+    return {'_type': 'orgmember',
             '_id': member['slug'],
             '_source': member}

--- a/src/_lib/wordpress_page_processor.py
+++ b/src/_lib/wordpress_page_processor.py
@@ -31,7 +31,6 @@ def process_post(page):
     del page['comments']
     page['_id'] = page['id']
 
-    return {'_index': 'content',
-            '_type': 'pages',
+    return {'_type': 'pages',
             '_id': page['id'],
             '_source': page}

--- a/src/_lib/wordpress_post_processor.py
+++ b/src/_lib/wordpress_post_processor.py
@@ -64,7 +64,6 @@ def process_post(post):
 
     del post['custom_fields']
 
-    return {'_index': 'content',
-            '_type': 'posts',
+    return {'_type': 'posts',
             '_id': post['slug'],
             '_source': post}

--- a/src/_lib/wordpress_sub_page_processor.py
+++ b/src/_lib/wordpress_sub_page_processor.py
@@ -62,7 +62,6 @@ def process_sub_page(post):
     else:
         post['has_parent'] = False
 
-    return {'_index': 'content',
-            '_type': 'sub_page',
+    return {'_type': 'sub_page',
             '_id': post['slug'],
             '_source': post}

--- a/src/_lib/wordpress_view_processor.py
+++ b/src/_lib/wordpress_view_processor.py
@@ -80,7 +80,6 @@ def process_view(post):
 
     del post['custom_fields']
 
-    return {'_index': 'content',
-            '_type': 'views',
+    return {'_type': 'views',
             '_id': post['slug'],
             '_source': post}


### PR DESCRIPTION
**REQUIRES VERSION [3.3.1](https://github.com/cfpb/sheer/releases/tag/3.3.1) OF SHEER, RELEASED 7/9**

Instead of supplying the ES index name in the processors, sheer has been updated to respect the index name provided by the user (otherwise it'll use the default).  As such, we no longer need to be defining this in the processor files.