### PR TITLE
Adding Open Government link to footer.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Updated percentages based on recent updates.
 - Updated activities_snippet macro to make column markup dynamic.
 - Replaced placeholder images on /careers/working-at-cfpb/
+- Updated footer to add offices links.
 
 ### Removed
 - Removed `list_link__disabled` class.

--- a/_includes/templates/footer.html
+++ b/_includes/templates/footer.html
@@ -94,8 +94,8 @@
                         </a>
                     </li>
                     <li class="list_item">
-                        <a class="list_link u-link__disabled">
-                            TBD Content
+                        <a class="list_link" href="/offices/open-government/">
+                            Open Government
                         </a>
                     </li>
                 </ul>


### PR DESCRIPTION
Adding Open Government link to footer.

## Changes
- Updated '_includes/templates/footer.html' to add link to footer.

## Test
- Visit 'http://localhost:7000/' and view footer.

## Screenshots
-
<img width="1274" alt="screen shot 2015-07-13 at 7 11 41 pm" src="https://cloud.githubusercontent.com/assets/1696212/8663045/3bf51650-2994-11e5-80c6-c0bf6ff0f54e.png">


## Review
@jimmynotjim
@anselmbradford 