### PR TITLE
Support for django-sheerlike: less code this time

### DIFF
--- a/_includes/contact-macro.html
+++ b/_includes/contact-macro.html
@@ -3,7 +3,7 @@
 
 {% from "macros/util/format.html" import format_phone as format_phone %}
 
-<div class="content-l content-l__large-gutters{{ ' ' + classes if classes }}">
+<div class="content-l content-l__large-gutters{{ ' ' + classes if classes else '' }}">
     <div class="content-l_col content-l_col-1-2">
         {{ contact.content|safe }}
     {%- if contact.web %}

--- a/_includes/macros/util/format.html
+++ b/_includes/macros/util/format.html
@@ -18,10 +18,10 @@
 
 {% macro format_phone(number) %}
     {%- for char in number -%}
-        {{- '(' if loop.index == 1 -}}
+        {{- '(' if loop.index == 1 else '' -}}
         {{ char }}
-        {{- ') ' if loop.index == 3 -}}
-        {{- '-' if loop.index == 6 -}}
+        {{- ') ' if loop.index == 3 else '' -}}
+        {{- '-' if loop.index == 6 else '' -}}
     {%- endfor %}
 {% endmacro %}
 
@@ -47,10 +47,10 @@
 
 {% macro format_address(contact) %}
     {{ contact.street if contact.street }}<br>
-    {{ contact.street_2 + '<br>'|safe if contact.street_2 }}
-    {{ contact.city + ',' if contact.city }}
-    {{ (contact.state + '&nbsp;')|safe if contact.state }}
-    {{ contact.zip_code if contact.zip_code }}
+    {{ contact.street_2 + '<br>'|safe if contact.street_2 else '' }}
+    {{ contact.city + ',' if contact.city else '' }}
+    {{ (contact.state + '&nbsp;')|safe if contact.state else '' }}
+    {{ contact.zip_code if contact.zip_code else '' }}
 {% endmacro %}
 
 

--- a/_includes/post-macros.html
+++ b/_includes/post-macros.html
@@ -298,7 +298,7 @@
 <div class="expandable
             expandable__filters
             expandable__padded
-            {{ 'expandable__expanded' if is_expanded }}
+            {{ 'expandable__expanded' if is_expanded else ''}}
             js-post-filter">
     <button class="expandable_header expandable_target">
         <span class="expandable_header-left expandable_label">
@@ -515,7 +515,7 @@
                        id="{{ options.id_range_date_gte }}"
                        name="filter_range_date_gte"
                        type="text"
-                       value="{{ from_date_formatted if from_date_formatted }}"
+                       value="{{ from_date_formatted if from_date_formatted else ''}}"
                        placeholder="YYYY-MM">
             </div>
             {#
@@ -533,7 +533,7 @@
                        id="{{ options.id_range_date_lte }}"
                        name="filter_range_date_lte"
                        type="text"
-                       value="{{ to_date_formatted if to_date_formatted }}"
+                       value="{{ to_date_formatted if to_date_formatted else ''}}"
                        placeholder="YYYY-MM">
             </div>
           </div>

--- a/_includes/post-macros.html
+++ b/_includes/post-macros.html
@@ -298,7 +298,7 @@
 <div class="expandable
             expandable__filters
             expandable__padded
-            {{ 'expandable__expanded' if is_expanded else ''}}
+            {{ 'expandable__expanded' if is_expanded else '' }}
             js-post-filter">
     <button class="expandable_header expandable_target">
         <span class="expandable_header-left expandable_label">
@@ -515,7 +515,7 @@
                        id="{{ options.id_range_date_gte }}"
                        name="filter_range_date_gte"
                        type="text"
-                       value="{{ from_date_formatted if from_date_formatted else ''}}"
+                       value="{{ from_date_formatted if from_date_formatted else '' }}"
                        placeholder="YYYY-MM">
             </div>
             {#
@@ -533,7 +533,7 @@
                        id="{{ options.id_range_date_lte }}"
                        name="filter_range_date_lte"
                        type="text"
-                       value="{{ to_date_formatted if to_date_formatted else ''}}"
+                       value="{{ to_date_formatted if to_date_formatted else '' }}"
                        placeholder="YYYY-MM">
             </div>
           </div>


### PR DESCRIPTION
I spent time today figuring out how to support a true global request object in django, AND a non-asinine ways to allow relative template imports. django-sheerlike (pull request pending) now supports both of these.

TLDR;  the only necessary template changes left relate to adding 'else' clauses to inline 'if' statements.

This is needed to suppress warnings that you will only see in debug mode. It's worth fixing because, when you're *in* debug mode, the warnings sometime appear inside text fields, which can interfere with filtering, etc.

