### PR TITLE
Removes requestNextAnimationFrame from Terms

### DIFF
--- a/TERMS.md
+++ b/TERMS.md
@@ -58,7 +58,6 @@ author or the affirmer.
   MIT License.
 - [box-sizing Polyfill](http://github.com/Schepp/box-sizing-polyfill) by
   Christian Schepp Schaefer is licensed under LGPL 3.0.
-- requestNextAnimationFrame by David Geary is licensed under the MIT License.
 - [Slick](http://kenwheeler.github.io/slick/) by Ken Wheeler is licensed under
   the MIT License.
 - [Chosen](https://github.com/harvesthq/chosen) by Patrick Filler for Harvest is
@@ -69,4 +68,3 @@ author or the affirmer.
   Smith is licensed under the BSD License.
 - [String Scoring Algorithm](https://github.com/joshaven/string_score) by
   Joshaven Potter is licensed under the MIT License.
-  


### PR DESCRIPTION
Forgot to remove requestAnimationFrame from Terms in https://github.com/cfpb/cfgov-refresh/pull/749

## Removals

- Removes requestAnimationFrame from `TERMS.md` 

## Review

- @jimmynotjim 
- @sebworks 
- @KimberlyMunoz 
- @Scotchester 

## Notes

- **Question:** Should we remove all the entries in the Exceptions area in `TERMS.md` that are coming from third-party sources, such as Rainbow (part of cf-component-demo). Anything in that list only needs to be there if the third-party code is committed to this repo, right? When we move to having a /dist/ directory the majority of those can be removed.