### PR TITLE
Fix Event tag filtering on Event Archives page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Fixed issue displaying grandchild pages on sub-pages.
 - Fixed issue on IE11 when using the dates to filter caused
   by toString method.
+- Event tag filtering on archive page
 
 
 ## 3.0.0-1.2.2 - 2015-07-02

--- a/_settings/mappings/events.json
+++ b/_settings/mappings/events.json
@@ -436,7 +436,8 @@
       "type": "string"
     },
     "tags": {
-      "type": "string"
+      "type": "string",
+      "index": "not_analyzed"
     },
     "title": {
       "type": "string"


### PR DESCRIPTION
Stop ES from analyzing tag data, which causes filtering on the Event's archive page to not return expected results.

@jimmynotjim @dpford 