### PR TITLE
Adding map/filter Array polyfills

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Added `TEST.md` readme file for testing instructions.
 - Added `grunt clean` and `grunt copy` tasks.
 - Added `grunt clean` step to `setup.sh`.
+- Added `map` and `filter` array polyfills.
 
 ### Changed
 - Updated primary navigation to match new mega menu design.

--- a/src/static/js/modules/jquery/cf_formValidator.js
+++ b/src/static/js/modules/jquery/cf_formValidator.js
@@ -5,7 +5,7 @@
 'use strict';
 
 var $ = require( 'jquery' );
-require( '../polyfill/array-foreach-polyfill' );
+require( '../polyfill/array-polyfills' );
 var _validate = require( 'validate' );
 
 var _validator = {

--- a/src/static/js/modules/polyfill/array-filter-polyfill.js
+++ b/src/static/js/modules/polyfill/array-filter-polyfill.js
@@ -1,0 +1,44 @@
+/* ==========================================================================
+ Polyfill for Array filter.
+ Copied from https://developer.mozilla.org/en-US/docs/Web
+                   /JavaScript/Reference/Global_Objects/Array/map.
+
+ Production steps of ECMA-262, Edition 5, 15.4.4.19
+ Reference: http://es5.github.io/#x15.4.4.19
+ ========================================================================== */
+
+'use strict';
+
+if ( !Array.prototype.filter ) {
+  Array.prototype.filter = function filter( fun ) {
+
+    if ( typeof this === 'undefined' || this === null ) {
+      throw new TypeError();
+    }
+
+    var t = Object( this );
+    var len = t.length >>> 0;
+    if ( typeof fun !== 'function' ) {
+      throw new TypeError();
+    }
+
+    var res = [];
+    var thisArg = arguments.length >= 2 ? arguments[1] : null;
+    for ( var i = 0; i < len; i++ ) {
+      if ( i in t ) {
+        var val = t[i];
+
+        // NOTE: Technically this should Object.defineProperty at
+        //       the next index, as push can be affected by
+        //       properties on Object.prototype and Array.prototype.
+        //       But that method's new, and collisions should be
+        //       rare, so use the more-compatible alternative.
+        if ( fun.call( thisArg, val, i, t ) ) {
+          res.push( val );
+        }
+      }
+    }
+
+    return res;
+  };
+}

--- a/src/static/js/modules/polyfill/array-map-polyfill.js
+++ b/src/static/js/modules/polyfill/array-map-polyfill.js
@@ -1,0 +1,97 @@
+/* ==========================================================================
+ Polyfill for Array map.
+ Copied from https://developer.mozilla.org/en-US/docs/Web
+                   /JavaScript/Reference/Global_Objects/Array/map.
+
+ Production steps of ECMA-262, Edition 5, 15.4.4.19
+ Reference: http://es5.github.io/#x15.4.4.19
+ ========================================================================== */
+
+'use strict';
+
+if ( !Array.prototype.map ) {
+  Array.prototype.map = function map( callback, thisArg ) {
+
+    var T, A, k;
+
+    if ( this === null ) {
+      throw new TypeError( ' this is null or not defined' );
+    }
+
+    // 1. Let O be the result of calling ToObject passing the |this|
+    //    value as the argument.
+    var O = Object( this );
+
+    // 2. Let lenValue be the result of calling the Get internal
+    //    method of O with the argument "length".
+    // 3. Let len be ToUint32(lenValue).
+    var len = O.length >>> 0;
+
+    // 4. If IsCallable(callback) is false, throw a TypeError exception.
+    // See: http://es5.github.com/#x9.11
+    if ( typeof callback !== 'function' ) {
+      throw new TypeError( callback + ' is not a function' );
+    }
+
+    // 5. If thisArg was supplied, let T be thisArg; else let T be undefined.
+    if ( arguments.length > 1 ) {
+      T = thisArg;
+    }
+
+    // 6. Let A be a new array created as if by the expression new Array(len)
+    //    where Array is the standard built-in constructor with that name and
+    //    len is the value of len.
+    A = new Array( len );
+
+    // 7. Let k be 0
+    k = 0;
+
+    // 8. Repeat, while k < len
+    while ( k < len ) {
+
+      var kValue, mappedValue;
+
+      // a. Let Pk be ToString(k).
+      //   This is implicit for LHS operands of the in operator
+      // b. Let kPresent be the result of calling the HasProperty internal
+      //    method of O with argument Pk.
+      //   This step can be combined with c
+      // c. If kPresent is true, then
+      if ( k in O ) {
+
+        // i. Let kValue be the result of calling the Get internal
+        //    method of O with argument Pk.
+        kValue = O[k];
+
+        // ii. Let mappedValue be the result of calling the Call internal
+        //     method of callback with T as the this value and argument
+        //     list containing kValue, k, and O.
+        mappedValue = callback.call( T, kValue, k, O );
+
+        // iii. Call the DefineOwnProperty internal method of A with arguments
+        // Pk, Property Descriptor
+        // { Value: mappedValue,
+        //   Writable: true,
+        //   Enumerable: true,
+        //   Configurable: true },
+        // and false.
+
+        // In browsers that support Object.defineProperty, use the following:
+        // Object.defineProperty(A, k, {
+        //   value: mappedValue,
+        //   writable: true,
+        //   enumerable: true,
+        //   configurable: true
+        // });
+
+        // For best browser support, use the following:
+        A[k] = mappedValue;
+      }
+      // d. Increase k by 1.
+      k++;
+    }
+
+    // 9. return A
+    return A;
+  };
+}

--- a/src/static/js/modules/polyfill/array-polyfills.js
+++ b/src/static/js/modules/polyfill/array-polyfills.js
@@ -1,0 +1,9 @@
+/* ==========================================================================
+ Polyfills for Array.
+ ========================================================================== */
+
+'use strict';
+
+require( './array-filter-polyfill' );
+require( './array-map-polyfill' );
+require( './array-foreach-polyfill' );


### PR DESCRIPTION
Input validation is currently inoperable on IE8 when submitting forms. 

Closes issue https://github.com/cfpb/cfgov-refresh/issues/758

## Changes
- Updated 'src/static/js/modules/jquery/cf_formValidator.js' to require array polyfills.
- Added 'src/static/js/modules/polyfill/array-filter-polyfill.js' to polyfill the array filter method.
- Added 'src/static/js/modules/polyfill/array-map-polyfill.js' to polyfill the array map method.
- Added 'src/static/js/modules/polyfill/array-polyfills.js' to group polyfills.

## Test
- Visit 'http://localhost:7000/blog', expand the filter and enter '01/11/2011' in the `From` field.

## Screenshot
- 
![ie8](https://cloud.githubusercontent.com/assets/1696212/8721621/0f5aacfc-2b8a-11e5-8983-12fee46c2a74.png)


## Review
@jimmynotjim
@anselmbradford 