### PR TITLE
Offices activity feed logic fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Changed `/_tests/macro_testing` directory name to `/test/macro_tests`.
 - Moved `browserify-shims.js` to `/config/` directory.
 - Upgraded Travis to container-based infrastructure
+- Updated Offices pages to change activity feed logic.
 
 ### Removed
 - Removed requestAnimationFrame polyfill.

--- a/src/offices/_single.html
+++ b/src/offices/_single.html
@@ -11,11 +11,8 @@
 
 {% block content_main %}
 
-    {% import "macros/activity-snippets.html" as activity_snippets with context %}
-    {% set activities_feed = activity_snippets.render(office.tags if office.tags, include_date_flag=true, number_columns=2) %}
-
     {% if office.title %}
-        <h1>{{ office.title | safe }}</h1>
+    <h1>{{ office.title | safe }}</h1>
     {% endif %}
 
     {% if office.intro.text %}
@@ -27,7 +24,7 @@
                     content-l__large-gutters">
         {% set intro = office.intro %}
         {% set show_subscription = intro.subscribe_form and intro.govdelivery_code %}
-        <section class="content-l_col
+        <div class="content-l_col
                         {% if show_subscription -%}
                             content-l_col-1-2
                         {% else -%}
@@ -35,16 +32,16 @@
                         {%- endif %}
                         ">
             <p class="h3">{{ intro.text | safe if intro.text }}</p>
-        </section>
+        </div>
         {% if show_subscription %}
-            <section class="content-l_col
-                            content-l_col-1-2
-                            content-l_col__before-divider">
-                <p class="h3 u-show-on-mobile">Stay informed</p>
-                <p class="short-desc">Stay up to date with our email newsletter</p>
-                {% import "macros/subscribe.html" as subscribe with context %}
-                {{ subscribe.render(intro.govdelivery_code) }}
-            </section>
+        <div class="content-l_col
+                        content-l_col-1-2
+                        content-l_col__before-divider">
+            <p class="h3 u-show-on-mobile">Stay informed</p>
+            <p class="short-desc">Stay up to date with our email newsletter</p>
+            {% import "macros/subscribe.html" as subscribe with context %}
+            {{ subscribe.render(intro.govdelivery_code) }}
+        </div>
         {% endif %}
     </section>
     {% endif %}
@@ -88,6 +85,7 @@
         </div>
     </section>
     {% endif %}
+
     {% if office.resources %}
     <section class="block
                     block__padded-top
@@ -96,32 +94,30 @@
             {{ resource_title }}
         </h1>
         {% for resource in office.resources %}
-            <div class="media block__sub">
-                {% if resource.icon %}
-                <div class="media_image-container
-                            media_image-container__wide-margin">
-                    <img class="media_image u-centered-on-mobile"
-                         width="150"
-                         src="{{resource.icon}}">
-                </div>
-                {% endif %}
-                <div class="media_body">
-                    {% if resource.title %}
-                    <h2 class="h3">{{ resource.title | safe }}</h2>
-                    {% endif %}
-
-                    {% if resource.desc %}
-                    <p class="short-desc">{{ resource.desc | safe }}</p>
-                    {% endif %}
-
-                    {% if resource.link %}
-                    <a class="jump-link jump-link__right"
-                       href="{{ resource.link.url if resource.link }}">
-                          {{ resource.link.label }}
-                    </a>
-                    {% endif %}
-                </div>
+        <div class="media block__sub">
+            {% if resource.icon %}
+            <div class="media_image-container
+                        media_image-container__wide-margin">
+                <img class="media_image u-centered-on-mobile"
+                     width="150"
+                     src="{{resource.icon}}">
             </div>
+            {% endif %}
+            <div class="media_body">
+                {% if resource.title %}
+                <h2 class="h3">{{ resource.title | safe }}</h2>
+                {% endif %}
+                {% if resource.desc %}
+                <p class="short-desc">{{ resource.desc | safe }}</p>
+                {% endif %}
+                {% if resource.link %}
+                <a class="jump-link jump-link__right"
+                   href="{{ resource.link.url if resource.link }}">
+                      {{ resource.link.label }}
+                </a>
+                {% endif %}
+            </div>
+        </div>
         {% endfor %}
     </section>
     {% endif %}
@@ -131,7 +127,9 @@
         {{ sub_pages_macro.render( vars.sub_pages, 'Our Work') }}
     {% endif %}
 
-    {% if activities_feed %}
+    {% if office.tags %}
+    {% import "macros/activity-snippets.html" as activity_snippets with context %}
+    {% set activities_feed = activity_snippets.render(office.tags, include_date_flag=true, number_columns=2) %}
     <section class="block
                     block__bg
                     block__flush-sides

--- a/src/sub-pages/_single-grandchild-pages.html
+++ b/src/sub-pages/_single-grandchild-pages.html
@@ -2,8 +2,8 @@
 {% extends "layout-2-1-bleedbar.html" %}
 
 {% set _breadcrumb_items = [('/offices/' + vars.office.slug + '/', vars.office.slug, vars.office.title),
-                           ('/sub-pages/' + vars.parent_sub_page.slug + '/',
-                             vars.parent_sub_page.slug, vars.parent_sub_page.title)]
+                            ('/sub-pages/' + vars.parent_sub_page.slug + '/',
+                            vars.parent_sub_page.slug, vars.parent_sub_page.title)]
 %}
 
 {% block pre_content_main -%}
@@ -23,23 +23,23 @@
 
 {% block content_main %}
     {% if sub_page.title %}
-        <h1>{{ sub_page.title | safe }}</h1>
+    <h1>{{ sub_page.title | safe }}</h1>
     {% endif %}
 
     {% if sub_page.content %}
-        <section class="block
-                        block__flush-top
-                        block__flush-bottom">
-            {{ sub_page.content | safe }}
-        </section>
+    <section class="block
+                    block__flush-top
+                    block__flush-bottom">
+        {{ sub_page.content | safe }}
+    </section>
     {% endif %}
 
     {% if sub_page.body_content %}
-        <section class="block
-                        block__padded-top
-                        block__border-top">
-            {{ sub_page.body_content | safe}}
-        </section>
+    <section class="block
+                    block__padded-top
+                    block__border-top">
+        {{ sub_page.body_content | safe}}
+    </section>
     {% endif %}
 
     {% if vars.sub_pages %}
@@ -59,17 +59,17 @@
 
 
 {% block content_sidebar %}
+    {% if sub_page.tags %}
     {% import "macros/activity-snippets.html" as activity_snippets with context %}
-    {% set activities_feed = activity_snippets.render(sub_page.tags if sub_page.tags, include_date_flag=true, number_columns=1)%}
-    {% if activities_feed %}
-        <section class="block
-                        block__flush-top
-                        block__left-border">
-            {% include 'templates/activities-feed.html' %}
-            <a class="jump-link jump-link__right"
-               href="/activity-log/{{ ('?filter_tags=' ~ sub_page.tags | join('&') ) if sub_page.tags }}">
-                View all of our activities
-            </a>
-        </section>
+    {% set activities_feed = activity_snippets.render(sub_page.tags, include_date_flag=true, number_columns=1)%}
+    <section class="block
+                    block__flush-top
+                    block__left-border">
+        {% include 'templates/activities-feed.html' %}
+        <a class="jump-link jump-link__right"
+           href="/activity-log/{{ ('?filter_tags=' ~ sub_page.tags | join('&') ) if sub_page.tags }}">
+            View all of our activities
+        </a>
+    </section>
     {% endif %}
 {% endblock %}

--- a/src/sub-pages/_single.html
+++ b/src/sub-pages/_single.html
@@ -1,10 +1,9 @@
 {% extends "layout-side-nav.html" %}
 {% import "_vars-sub-pages.html" as vars with context %}
+
 {% set active_nav_id = sub_page.slug %}
 {% set sub_pages = vars.sub_pages %}
 {% set breadcrumb_items = vars.breadcrumb_items %}
-
-
 {% set display_activity_slugs = ["plain-writing-act", "court-orders-settlements", "civil-penalty-fund"] %}
 {% set display_activity_flag = sub_page.slug in display_activity_slugs %}
 
@@ -18,41 +17,36 @@
 
 {% block content_main %}
 
-    {% import "macros/activity-snippets.html" as activity_snippets with context %}
-    {% set activities_feed = activity_snippets.render(sub_page.tags if sub_page.tags, include_date_flag=true, number_columns=2)
-                             if display_activity_flag
-    %}
-
     {% if sub_page.title %}
-        <h1>{{ sub_page.title | safe }}</h1>
+    <h1>{{ sub_page.title | safe }}</h1>
     {% endif %}
 
     {% if sub_page.content %}
-        <section class="block
-                        block__flush-top
-                        block__flush-bottom">
-            {{ sub_page.content | safe }}
-        </section>
+    <section class="block
+                    block__flush-top
+                    block__flush-bottom">
+        {{ sub_page.content | safe }}
+    </section>
     {% endif %}
 
     {% if sub_page.body_content %}
-        <section class="sub-page_{{sub_page.slug}}
-                        block
-                        block__padded-top
-                        block__border-top">
-            {% set content = { 'markup' : sub_page.body_content } %}
-            {% for form_name in vars.forms %}
-                {% set form_token = '[' + form_name + ']' %}
-                {% if (sub_page.body_content).find(form_token) > -1 %}
-                    {% import 'templates/forms/' + form_name | lower  + '.html' as form %}
-                    {% set _ignore = content.update(
-                        { 'markup' : sub_page.body_content | replace(form_token, form) }
-                    )%}
-                {% endif %}
-            {% endfor %}
+    <section class="sub-page_{{sub_page.slug}}
+                    block
+                    block__padded-top
+                    block__border-top">
+        {% set content = { 'markup' : sub_page.body_content } %}
+        {% for form_name in vars.forms %}
+            {% set form_token = '[' + form_name + ']' %}
+            {% if (sub_page.body_content).find(form_token) > -1 %}
+                {% import 'templates/forms/' + form_name | lower  + '.html' as form %}
+                {% set _ignore = content.update(
+                    { 'markup' : sub_page.body_content | replace(form_token, form) }
+                )%}
+            {% endif %}
+        {% endfor %}
 
-            {{ content.markup | safe}}
-        </section>
+        {{ content.markup | safe}}
+    </section>
     {% endif %}
 
     {% if sub_pages and sub_pages.total %}
@@ -69,18 +63,20 @@
         }}
     {% endif %}
 
-    {% if activities_feed and display_activity_flag == true %}
-        <section class="block
-                        block__flush-sides
-                        block__bg
-                        block__flush-top
-                        block__flush-bottom">
-            {% include 'templates/activities-feed.html' %}
-            <a class="jump-link jump-link__right"
-               href="/activity-log/{{ ('?filter_tags=' ~ sub_page.tags | join('&') ) if sub_page.tags }}">
-                View all of our activities
-            </a>
-        </section>
+    {% if sub_page.tags and display_activity_flag == true %}
+    {% import "macros/activity-snippets.html" as activity_snippets with context %}
+    {% set activities_feed = activity_snippets.render(sub_page.tags, include_date_flag=true, number_columns=2)%}
+    <section class="block
+                    block__flush-sides
+                    block__bg
+                    block__flush-top
+                    block__flush-bottom">
+        {% include 'templates/activities-feed.html' %}
+        <a class="jump-link jump-link__right"
+           href="/activity-log/{{ ('?filter_tags=' ~ sub_page.tags | join('&') ) if sub_page.tags }}">
+            View all of our activities
+        </a>
+    </section>
     {% endif %}
 
     {% set office = vars.office %}


### PR DESCRIPTION
Fixes activity feed logic to only display when tags are present. 

## Changes
- Updated 'src/sub-pages/_single.html' to display activity feed only when tags present.
- Updated 'src/offices/_single.html' to display activity feed only when tags present.
- Updated 'src/sub-pages/_single-grandchild-pages.html' to display activity feed only when tags present.

## Test
- Visit 'http://localhost:7000/offices/privacy/' and observe the activity feed.
- Visit 'http://localhost:7000/sub-pages/civil-penalty-fund/' and observe the activity feed.


## Review
@jimmynotjim
@anselmbradford 
@KimberlyMunoz 