### PR TITLE
DF 2146 career posting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Added `grunt clean` and `grunt copy` tasks.
 - Added `grunt clean` step to `setup.sh`.
 - Added `map` and `filter` array polyfills.
+- Created initial career posting template.
+- Created 1/4 and 3/4 layout columns.
+- Added DL styles to cf-enhancements.
 
 ### Changed
 - Updated primary navigation to match new mega menu design.
@@ -32,6 +35,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Moved `browserify-shims.js` to `/config/` directory.
 - Upgraded Travis to container-based infrastructure
 - Updated Offices pages to change activity feed logic.
+- Updated block-bg padding in cf-enhancements based on JJames feedback.
 
 ### Removed
 - Removed requestAnimationFrame polyfill.

--- a/src/careers/current-openings/opening.html
+++ b/src/careers/current-openings/opening.html
@@ -1,0 +1,125 @@
+{% extends "layout-side-nav.html" %}
+{% import "_vars-careers.html" as vars with context %}
+{%- set active_nav_id = 'current-openings' -%}
+
+{% block title -%}
+    {# TODO: Add real page meta title. #}
+    Test Opening
+{%- endblock %}
+
+{% block desc -%}
+    {# TODO: Add page meta description. #}
+{%- endblock %}
+
+{% block content_main_modifiers -%}
+    {{ super() }}
+    content__flush-bottom
+{%- endblock %}
+
+{% block content_main %}
+
+{% import "macros/share.html" as share %}
+
+    <section class="block
+                    block__flush-top
+                    block__sub">
+        {# TODO: Add real page details. #}
+        <h1>Test Opening Title</h1>
+        <dl class="u-mb0">
+            <dt>Expiration Date:</dt>
+            <dd>Month XX, XXXX</dd>
+            <dt>Region:</dt>
+            <dd>Headquarters</dd>
+            <dt>Grade:</dt>
+            <dd><strong>(33)</strong> $XX,XXX - $XXX,XXX</dd>
+        </dl>
+        <div class="content-l">
+            <div class="content-l_col content-l_col-1-2">
+                <a href="#" class="btn">Interested in applying?</a>
+            </div>
+            <div class="content-l_col content-l_col-1-2">
+            {{ share.render({
+                'title': 'Test Opening Title',
+                'heading': 'Share this job',
+                'hide_heading': false,
+                'show_linkedin': true,
+                'additional_classes':
+                    'share__horizontal share__align-right'
+            }) }}
+            </div>
+        </div>
+    </section>
+
+    <section class="block
+                block__padded-top
+                block__border-top">
+        <h2>Job Description</h2>
+        <p>Lorem ipsum...place description text here</p>
+
+        <h2>Duties</h2>
+        <h3>As a test opening, you will:</h3>
+        <ul class="list__branded">
+            <li>Lorem ipsum...place first duty here</li>
+            <li>Lorem ipsum..place second duty here</li>
+            <li>Etc, etc, etc</li>
+        </ul>
+
+        <h2>Departments</h2>
+        <p>Multiple offices</p>
+    </section>
+
+    <section class="block
+                block__padded-top
+                block__border-top">
+        <div class="content-l">
+            <div class="content-l_col content-l_col-1-2">
+                <h2 class="u-mb0">Interested in Applying?</h2>
+            </div>
+            <div class="content-l_col content-l_col-1-2">
+                {{ share.render({
+                    'title': 'Test Opening Title',
+                    'heading': 'Share this job',
+                    'hide_heading': false,
+                    'show_linkedin': true,
+                    'additional_classes': 'share__horizontal share__align-right'
+                }) }}
+            </div>
+        </div>
+        <div class="block
+                    block__bg
+                    block__border
+                    block__sub">
+            <h3>Before you apply</h3>
+            <p class="short-desc">
+                Lorem impsum...replace with application info paragraph
+            </p>
+
+            <ul class="list list__links">
+                <li class="list_item">
+                    <a class="jump-link" href="#">
+                        Learn about working @ CFPB
+                    </a>
+                </li>
+                <li class="list_item">
+                    <a class="jump-link" href="#">
+                        Learn about the application process
+                    </a>
+                </li>
+            </ul>
+        </div>
+        <div class="block block__flush-top">
+            <h4>Open to All Citizens (Excepted service - Permanent)</h4>
+            <p class="short-desc">Applications will be accepted from U.S. citizens....</p>
+            <div class="content-l">
+                <div class="content-l_col content-l_col-1-4">
+                    <a class="btn" href="#">Apply now</a>
+                </div>
+                <div class="content-l_col content-l_col-3-4">
+                    <h4 class="u-mb0">You are about to leave consumerfinance.gov.</h4>
+                    <p class="short-desc">To finish the application, you must go to USAJobs.gov.</p>
+                </div>
+            </div>
+        </div>
+    </section>
+
+{% endblock %}

--- a/src/static/css/cf-enhancements.less
+++ b/src/static/css/cf-enhancements.less
@@ -1116,6 +1116,93 @@ textarea.input__long {
 
 
 /* topdoc
+  name: Base styles for definition lists
+  family: cf-core
+  notes:
+    - "Sets the term and definition in-line to each other but broken into rows"
+  tags:
+    - cf-core
+*/
+dt {
+    .h5();
+    .u-inline-block();
+
+    margin-bottom: 0.5em;
+
+    &:last-of-type {
+      margin-bottom: 0;
+    }
+}
+
+dd {
+    .webfont-regular();
+
+    display: inline;
+
+    margin-left: 0.2em;
+
+    &:after {
+        display: block;
+
+        content: '';
+    }
+}
+
+
+/* topdoc
+  name: Remove margin from last-children
+  family: cf-core
+  notes:
+    - "Remove margin bottom for items that close out a block to ensure the
+      60px margin on the block is concistent"
+  tags:
+    - cf-core
+*/
+
+ul:last-child,
+.list__links .list_item:last-child {
+    margin-bottom: 0;
+}
+
+
+/* topdoc
+  name: Update block__bg padding
+  family: cf-layout
+  notes:
+    - "Updates the padding in block__bg to match feedback from Justin James"
+  tags:
+    - cf-layout
+*/
+
+.block__bg {
+    padding-top: 30px;
+    padding-bottom: 60px;
+}
+
+
+/* topdoc
+  name: Add 1/4 and 3/4 columns
+  family: cf-layout
+  notes:
+    - "Temporary addition until latest cf-layout is included in the project"
+  tags:
+    - cf-layout
+*/
+
+.content-l_col-1-4 {
+    .respond-to-min(@tablet-min, {
+        .grid_column(3);
+    });
+}
+
+.content-l_col-3-4 {
+    .respond-to-min(@tablet-min, {
+        margin-top: 0 !important;
+        .grid_column(9);
+    });
+}
+
+/* topdoc
     name: EOF
     eof: true
 */

--- a/src/static/css/share.less
+++ b/src/static/css/share.less
@@ -73,7 +73,9 @@
 */
 
 .share__align-right {
-    text-align: right;
+    .respond-to-min(@tablet-min, {
+        text-align: right;
+    });
 }
 
 /* topdoc


### PR DESCRIPTION
Initial template for the single career postings

## Additions

- created initial template
- created 1/4 and 3/4 layout columns
- added DL styles to cf-enhancements

## Removals

- None

## Changes

- updated block-bg padding in cf-enhancements based on JJames feedback

## Testing

- navigate to `/careers/current-openings/opening.html`

## Review

- @duelj 
- @ajbush 
- @sebworks 
- @anselmbradford 
- @KimberlyMunoz 

## Preview

![test-opening](https://cloud.githubusercontent.com/assets/1280430/8749713/66eed668-2c71-11e5-98a0-61e11e4e25a2.png)

![test-opening-mobile](https://cloud.githubusercontent.com/assets/1280430/8749718/69b485fa-2c71-11e5-9fe1-07d10b14f2a5.jpg)

[Preview this PR without the whitespace changes](?w=0)

## Notes

- template should be renamed _single and tied to data when ready