### PR TITLE
Fix for MobileOnlyExpandable on office page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
   by toString method.
 - Event tag filtering on archive page
 - Added browser tests to linting task
+- Fixed MobileOnlyExpandable error on office page.
 
 ## 3.0.0-1.3.0 - 2015-07-16
 

--- a/src/offices/_single.html
+++ b/src/offices/_single.html
@@ -146,17 +146,3 @@
     {% include "templates/office-contact.html" %}
 
 {% endblock %}
-
-{% block javascript %}
-    {{ super() }}
-    <!-- TODO: Move this to a Browserify module. -->
-    <script>
-        $('document').ready(function () {
-            if (!$('html').hasClass('lt-ie9')) {
-                $('.expandable__mobile-only').each(function (i) {
-                    new MobileOnlyExpandable($(this), 599);
-                });
-            }
-        });
-    </script>
-{% endblock %}

--- a/src/static/js/routes/common.js
+++ b/src/static/js/routes/common.js
@@ -40,4 +40,5 @@ $( document ).ready( function() {
   require( './careers/application-process/index.js' ).init();
   require( './the-bureau/index.js' ).init();
   require( './the-bureau/bureau-structure/index.js' ).init();
+  require( './offices/index.js' ).init();
 } );

--- a/src/static/js/routes/offices/index.js
+++ b/src/static/js/routes/offices/index.js
@@ -1,0 +1,25 @@
+/* ==========================================================================
+   Scripts for `/offices/`.
+   ========================================================================== */
+
+'use strict';
+
+var $ = require( 'jquery' );
+var MobileOnlyExpandable = require( '../../modules/classes/MobileOnlyExpandable' );
+
+function init() {
+
+  // TODO: Remove this when per-page JS is introduced.
+  if ( document.querySelectorAll( '.office' ).length === 0 ) {
+    return;
+  }
+
+  var breakpointPx = 599;
+
+  $( '.expandable__mobile-only' ).each( function() {
+    // ESLint no-new rule ignored
+    new MobileOnlyExpandable( $( this ), breakpointPx ); // eslint-disable-line
+  } );
+}
+
+module.exports = { init: init };


### PR DESCRIPTION
Fix for MobileOnlyExpandable on office page

Closes issue https://github.com/cfpb/cfgov-refresh/issues/642

## Changes
- Updated 'src/offices/_single.html' to remove MobileOnlyExpandable code.
- Updated 'src/static/js/routes/common.js' to use page specific javascript for Office page.
- Added 'src/static/js/routes/offices/index.js' to use page specific javascript for Office page.

## Test
- Visit 'http://localhost:7000/offices/privacy/', open console, and observe error free goodness.

## Review
@jimmynotjim
@anselmbradford 
@KimberlyMunoz 