### PR TITLE
Updating Office pages for Advisory Group office

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Upgraded Travis to container-based infrastructure
 - Updated Offices pages to change activity feed logic.
 - Updated block-bg padding in cf-enhancements based on JJames feedback.
+- Updated Offices sub pages to display related documents.
+- Updated Offices sub pages to always display activity feed.
 
 ### Removed
 - Removed requestAnimationFrame polyfill.

--- a/src/offices/_single.html
+++ b/src/offices/_single.html
@@ -31,7 +31,7 @@
                             content-l_col-1
                         {%- endif %}
                         ">
-            <p class="h3">{{ intro.text | safe if intro.text }}</p>
+            <div class="h3">{{ intro.text | safe }}</div>
         </div>
         {% if show_subscription %}
         <div class="content-l_col
@@ -73,11 +73,11 @@
                         content-l_col__before-divider">
                 <ul class="list__links">
                 {% for link in top_story.links %}
-                    <li class="list_item">
-                        <a class="jump-link jump-link__right list_link" href="{{ link.url }}">
-                            {{link.label}}
-                        </a>
-                    </li>
+                <li class="list_item">
+                    <a class="jump-link jump-link__right list_link" href="{{ link.url }}">
+                        {{link.label}}
+                    </a>
+                </li>
                 {% endfor %}
                 </ul>
             </div>
@@ -90,9 +90,9 @@
     <section class="block
                     block__padded-top
                     block__border-top">
-        <h1 class="h2">
-            {{ resource_title }}
-        </h1>
+        <h2 class="u-visually-hidden">
+            Resources
+        </h2>
         {% for resource in office.resources %}
         <div class="media block__sub">
             {% if resource.icon %}

--- a/src/sub-pages/_single.html
+++ b/src/sub-pages/_single.html
@@ -4,8 +4,6 @@
 {% set active_nav_id = sub_page.slug %}
 {% set sub_pages = vars.sub_pages %}
 {% set breadcrumb_items = vars.breadcrumb_items %}
-{% set display_activity_slugs = ["plain-writing-act", "court-orders-settlements", "civil-penalty-fund"] %}
-{% set display_activity_flag = sub_page.slug in display_activity_slugs %}
 
 {% block title -%}
     {{ sub_page.title | safe if sub_page.title }}
@@ -29,11 +27,25 @@
     </section>
     {% endif %}
 
-    {% if sub_page.body_content %}
+    {% if sub_page.body_content or sub_page.related_links %}
     <section class="sub-page_{{sub_page.slug}}
                     block
                     block__padded-top
                     block__border-top">
+
+        {% if sub_page.related_links %}
+        <section class="block
+                        block__flush-top
+                        block_padded-bottom">
+            <h3>Related Documents</h3>
+            {% for link in sub_page.related_links %}
+            <p>
+                <a href="{{link.url}}">{{ link.label }}</a>
+            </p>
+            {% endfor %}
+        </section>
+        {% endif %}
+
         {% set content = { 'markup' : sub_page.body_content } %}
         {% for form_name in vars.forms %}
             {% set form_token = '[' + form_name + ']' %}
@@ -63,7 +75,7 @@
         }}
     {% endif %}
 
-    {% if sub_page.tags and display_activity_flag == true %}
+    {% if sub_page.tags %}
     {% import "macros/activity-snippets.html" as activity_snippets with context %}
     {% set activities_feed = activity_snippets.render(sub_page.tags, include_date_flag=true, number_columns=2)%}
     <section class="block


### PR DESCRIPTION
Updating Office pages for Advisory Group office

## Changes
- Updated 'src/offices/_single.html' to surrounding nesting of `p` tags.
- Updated 'src/sub-pages/_single.html' to always display activity feed when tags present.  
- Updated 'src/sub-pages/_single.html' to display related documents.

## Test
- Reindex Sheer.
- Visit 'http://localhost:7000/offices/advisory-groups/'.

## Notes
- This PR will cause  the "Related Documents" section (related_links) to appear on a number of sub pages. 

## Screenshots
<img width="1057" alt="screen shot 2015-07-20 at 10 00 50 am" src="https://cloud.githubusercontent.com/assets/1696212/8777494/4be61c44-2ec6-11e5-8c59-f790b45e6360.png">


## Review
@jimmynotjim
@anselmbradford 
@KimberlyMunoz 
@schaferjh 