### PR TITLE
DF-2251 - Project Catalyst

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Created initial career posting template.
 - Created 1/4 and 3/4 layout columns.
 - Added DL styles to cf-enhancements.
+- Added `offices/project-catalyst`.
 
 ### Changed
 - Updated primary navigation to match new mega menu design.

--- a/src/_includes/templates/nav/_vars-primary-nav.html
+++ b/src/_includes/templates/nav/_vars-primary-nav.html
@@ -23,7 +23,8 @@
             ('/offices/payments-to-harmed-consumers/',
              'payments-to-harmed-consumers',
              'Payments to Harmed<br>Consumers'),
-            sub_nav_tbd
+            ('/offices/project-catalyst/',
+             'project-catalyst', 'Project Catalyst')
         ),
         (
             ('/blog/', 'blog', 'Blog'),

--- a/src/offices/_single.html
+++ b/src/offices/_single.html
@@ -6,7 +6,9 @@
 {%- endblock %}
 
 {% block content_main_modifiers -%}
-    {{ super() }} content__flush-bottom office
+    {{ super() }}
+    content__flush-bottom
+    office
 {%- endblock %}
 
 {% block content_main %}
@@ -16,22 +18,20 @@
     {% endif %}
 
     {% if office.intro.text %}
+    {% set intro = office.intro %}
+    {% set show_subscription = intro.subscribe_form and intro.govdelivery_code %}
     <section class="block
                     block__flush-top
                     block__flush-bottom
                     content-l
                     content-l__main
                     content-l__large-gutters">
-        {% set intro = office.intro %}
-        {% set show_subscription = intro.subscribe_form and intro.govdelivery_code %}
         <div class="content-l_col
-                        {% if show_subscription -%}
-                            content-l_col-1-2
-                        {% else -%}
-                            content-l_col-1
-                        {%- endif %}
-                        ">
-            <div class="h3">{{ intro.text | safe }}</div>
+                    {{ 'content-l_col-1-1' if show_subscription else 'content-l_col-1' }}
+                    ">
+            {# Note this is a div to accommodate paragraph markup
+               coming from the CMS for the intro.text content. #}
+            <div class="office_intro-text">{{ intro.text | safe }}</div>
         </div>
         {% if show_subscription %}
         <div class="content-l_col
@@ -52,7 +52,7 @@
                     block__padded-top
                     block__border-top">
         {% if top_story.head %}
-        <h1 class="h3">{{ top_story.head | safe }}</h1>
+        <h2>{{ top_story.head | safe }}</h2>
         {% endif %}
         <div class="content-l
                     content-l__main
@@ -73,11 +73,11 @@
                         content-l_col__before-divider">
                 <ul class="list__links">
                 {% for link in top_story.links %}
-                <li class="list_item">
-                    <a class="jump-link jump-link__right list_link" href="{{ link.url }}">
-                        {{link.label}}
-                    </a>
-                </li>
+                    <li class="list_item">
+                        <a class="jump-link jump-link__right list_link" href="{{ link.url }}">
+                            {{link.label}}
+                        </a>
+                    </li>
                 {% endfor %}
                 </ul>
             </div>
@@ -90,6 +90,7 @@
     <section class="block
                     block__padded-top
                     block__border-top">
+        {# Heading added for screenreaders to have a section title. #}
         <h2 class="u-visually-hidden">
             Resources
         </h2>
@@ -100,19 +101,21 @@
                         media_image-container__wide-margin">
                 <img class="media_image u-centered-on-mobile"
                      width="150"
-                     src="{{resource.icon}}">
+                     src="{{ resource.icon }}">
             </div>
             {% endif %}
             <div class="media_body">
                 {% if resource.title %}
-                <h2 class="h3">{{ resource.title | safe }}</h2>
+                <h2>{{ resource.title | safe }}</h2>
                 {% endif %}
+
                 {% if resource.desc %}
                 <p class="short-desc">{{ resource.desc | safe }}</p>
                 {% endif %}
+
                 {% if resource.link %}
                 <a class="jump-link jump-link__right"
-                   href="{{ resource.link.url if resource.link }}">
+                   href="{{ resource.link.url }}">
                       {{ resource.link.label }}
                 </a>
                 {% endif %}
@@ -125,6 +128,14 @@
     {% if vars.sub_pages %}
         {% import "macros/sub_pages.html" as sub_pages_macro with context %}
         {{ sub_pages_macro.render( vars.sub_pages, 'Our Work') }}
+    {% endif %}
+
+    {% if office.content %}
+    <section class="block
+                    block__padded-top
+                    block__border-top">
+        {{ office.content }}
+    </section>
     {% endif %}
 
     {% if office.tags %}

--- a/src/static/css/pages/offices.less
+++ b/src/static/css/pages/offices.less
@@ -11,6 +11,17 @@
         });
     }
 
+    // NOTE: This is to accommodate the variety of content that can be
+    //       delivered to the custom_fields > intro_text field in the CMS.
+    &_intro-text {
+        p {
+            .h3();
+        }
+        ul {
+            .list__branded();
+        }
+    }
+
     &_initiatives {
         .expandables-group {
             .respond-to-max(@mobile-max, {


### PR DESCRIPTION
Adds changes for Project Catalyst

## Additions

- Adds Project Catalyst to the mega menu. 
- Adds `office.content` block.

## Changes

- Updates headings for `top_story` and `resource.title` to h2 to match heading level of `Our Work`.

## Testing

- /offices/project-catalyst/

## Review

- @sebworks 
- @KimberlyMunoz 
- @jimmynotjim 

## Preview

<img width="1324" alt="screen shot 2015-07-20 at 11 22 07 am" src="https://cloud.githubusercontent.com/assets/704760/8779458/94a68c7e-2ed1-11e5-91d1-4774fe769740.png">


## Notes

- There is a list of content updates that will go to Sarah after this PR, so if something doesn't look right, inspect element and see that it's not because of hardcoded inline styles coming from the CMS.
- Incorporates changes in https://github.com/cfpb/cfgov-refresh/pull/776, with the assumption that that PR will be merged first.