### PR TITLE
Moves testing to setup.sh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,7 +65,9 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Updated the existing missions browser test to be stronger
 - Updated the browser test specs in conf.js because the shared spec was being
   fired on the desktop test, even though those tests had already been run in
-  Chrome. Now the desktop test only runs the desktop spec
+  Chrome. Now the desktop test only runs the desktop spec.
+- Separated `grunt test` task from `grunt build`
+  and made default task test + build.
 
 ### Removed
 - Removed requestAnimationFrame polyfill.

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -508,11 +508,11 @@ module.exports = function(grunt) {
                                 'string-replace:slick-carousel', 'concat:cf-less']);
   grunt.registerTask('css', ['less', 'autoprefixer', 'legacssy', 'usebanner:css']);
   grunt.registerTask('js', ['browserify:build', 'usebanner:js']);
-  grunt.registerTask('test', ['lintjs', 'mocha_istanbul']);
   grunt.registerMultiTask('lintjs', 'Lint the JavaScript', function(){
     grunt.config.set(this.target, this.data);
     grunt.task.run(this.target);
   });
-  grunt.registerTask('build', ['vendor', 'test', 'css', 'js', 'copy']);
-  grunt.registerTask('default', ['build']);
+  grunt.registerTask('test', ['lintjs', 'mocha_istanbul']);
+  grunt.registerTask('build', ['vendor', 'css', 'js', 'copy']);
+  grunt.registerTask('default', ['test', 'build']);
 };

--- a/setup.sh
+++ b/setup.sh
@@ -1,5 +1,11 @@
 #!/bin/sh
 
+# ==========================================================================
+# Setup script for installing project dependencies.
+# NOTE: Run this script while in the project root directory.
+#       It will not run correctly when run from another directory.
+# ==========================================================================
+
 # Set script to exit on any errors.
 set -e
 
@@ -44,7 +50,7 @@ install(){
 build(){
   echo 'Building project...'
   grunt clean
-  grunt build
+  grunt
 }
 
 init


### PR DESCRIPTION
Decouples `grunt test` from `grunt build` and moves it to `setup.sh`.

The reason for this is:
  - Now that we we're using /dist/, running `grunt build` happens more frequently.
  - Our test suite is growing larger/slower, so having it on-demand becomes more important.
  - Travis is running our tests so will catch errors if `grunt test` is forgotten to run before submitting a PR (which should be done before a PR is opened).

## Changes

- Removes test task from `grunt build` pipeline and moves it to `setup.sh`.
- Moves order of test task below lintjs task in Gruntfile.

## Testing

- `./setup.sh` should run test suites.
- `grunt build` should not.
- `grunt test` should.

## Review

- @jimmynotjim 
- @KimberlyMunoz 
- @sebworks