### PR TITLE
DF_2292 FAQ restyling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Updated block-bg padding in cf-enhancements based on JJames feedback.
 - Updated Offices sub pages to display related documents.
 - Updated Offices sub pages to always display activity feed.
+- Updated Expandable macro to update design and add FAQ options.
 
 ### Removed
 - Removed requestAnimationFrame polyfill.

--- a/src/_includes/macros/expandable.html
+++ b/src/_includes/macros/expandable.html
@@ -8,26 +8,45 @@
 
    Builds Expandable markup when given:
 
-   items                     : An array of expandable items.
+   items                      : An array of expandable items.
 
-   header_key                : A string used to denote the header dictionary key.
+   header_key                 : A string used to denote the header dictionary key.
 
-   content_key               : A string used to denote the content dictionary key.
+   content_key                : A string used to denote the content dictionary key.
 
-   options (optional)        : An object used to customize
-                               the expandable markup.
+   options (optional)         : An object used to customize
+                                the expandable markup.
 
-   options.title             : Title to use for expandable markup.
+   options.title              : A string to use for expandable title.
 
-   options.additional_classes: Extra classes added to the expandable markup.
+   options.additional_classes : Extra classes added to the expandable markup.
+
+   options.faq_description    : A string to use for FAQ description.
+
+   options.faq_title          : A string to use for FAQ title.
 
    ========================================================================== #}
 {% macro render(items=[], header_key='', content_key='', options={}) -%}
-    {% set title = options.title | default('&nbsp;') | safe %}
+    {% if options.faq_title or options.faq_description %}
+    <div class="u-js-only">
+        {% if options.faq_title %}
+        <h2>
+            Frequently asked questions about {{ options.faq_title | safe }}
+        </h2>
+        {% endif %}
+        {% if options.faq_description %}
+        <p class="short-desc">
+            {{ options.faq_description | safe }}
+        </p>
+        {% endif %}
+    </div>
+    {% endif %}
     <div class="expandable-group {{ options.additional_classes }}">
+        {% if options.title %}
         <div class="expandable-group_header">
-            {{ title }}
+            {{ options.title | safe }}
         </div>
+        {% endif %}
         <div class="expandable-group_items">
             {% for item in items %}
                 <div class="expandable expandable__padded">

--- a/src/offices/_single.html
+++ b/src/offices/_single.html
@@ -139,13 +139,13 @@
     {% endif %}
 
     {% if office.tags %}
-    {% import "macros/activity-snippets.html" as activity_snippets with context %}
-    {% set activities_feed = activity_snippets.render(office.tags, include_date_flag=true, number_columns=2) %}
     <section class="block
                     block__bg
                     block__flush-sides
                     block__flush-top
                     block__flush-bottom">
+        {% import "macros/activity-snippets.html" as activity_snippets with context %}
+        {% set activities_feed = activity_snippets.render(office.tags, include_date_flag=true, number_columns=2) %}
         {% include 'templates/activities-feed.html' %}
         <a class="jump-link jump-link__right"
            href="/activity-log/{{ ('?filter_tags=' ~ office.tags | join('&') ) if office.tags }}">

--- a/src/sub-pages/_single-grandchild-pages.html
+++ b/src/sub-pages/_single-grandchild-pages.html
@@ -48,23 +48,26 @@
     {% endif %}
 
     {% if sub_page.related_faq %}
+    <section class="block
+                    block__flush-top">
         {% set related_faq = get_document('faq', sub_page.related_faq) %}
         {% import "macros/expandable.html" as expandable with context %}
         {{ expandable.render(
-                related_faq.faq, 'question', 'answer', {"title": "FAQS"}
+                related_faq.faq, 'question', 'answer', {"faq_title": sub_page.title}
            ) if related_faq.faq
         }}
+    </section>
     {% endif %}
 {% endblock %}
 
 
 {% block content_sidebar %}
     {% if sub_page.tags %}
-    {% import "macros/activity-snippets.html" as activity_snippets with context %}
-    {% set activities_feed = activity_snippets.render(sub_page.tags, include_date_flag=true, number_columns=1)%}
     <section class="block
                     block__flush-top
                     block__left-border">
+        {% import "macros/activity-snippets.html" as activity_snippets with context %}
+        {% set activities_feed = activity_snippets.render(sub_page.tags, include_date_flag=true, number_columns=1)%}
         {% include 'templates/activities-feed.html' %}
         <a class="jump-link jump-link__right"
            href="/activity-log/{{ ('?filter_tags=' ~ sub_page.tags | join('&') ) if sub_page.tags }}">

--- a/src/sub-pages/_single.html
+++ b/src/sub-pages/_single.html
@@ -67,22 +67,28 @@
     {% endif %}
 
     {% if sub_page.related_faq %}
+    <section class="block
+                    block__flush-top">
         {% set related_faq = get_document('faq', sub_page.related_faq) %}
+        {% set faq_title = vars.office.title if sub_page.slug == 'frequently-asked-questions'
+                                             else sub_page.title
+        %}
         {% import "macros/expandable.html" as expandable with context %}
         {{ expandable.render(
-                related_faq.faq, 'question', 'answer', {"title": "FAQS"}
+                related_faq.faq, 'question', 'answer', {"faq_title": faq_title}
            ) if related_faq.faq
         }}
+    </section>
     {% endif %}
 
     {% if sub_page.tags %}
-    {% import "macros/activity-snippets.html" as activity_snippets with context %}
-    {% set activities_feed = activity_snippets.render(sub_page.tags, include_date_flag=true, number_columns=2)%}
     <section class="block
                     block__flush-sides
                     block__bg
                     block__flush-top
                     block__flush-bottom">
+        {% import "macros/activity-snippets.html" as activity_snippets with context %}
+        {% set activities_feed = activity_snippets.render(sub_page.tags, include_date_flag=true, number_columns=2)%}
         {% include 'templates/activities-feed.html' %}
         <a class="jump-link jump-link__right"
            href="/activity-log/{{ ('?filter_tags=' ~ sub_page.tags | join('&') ) if sub_page.tags }}">


### PR DESCRIPTION
Update styling for FAQs.

Closes issue https://github.com/cfpb/cfgov-refresh/issues/778.

## Changes
- Updated 'src/_includes/macros/expandable.htmll' to add specific arguments and logic for FAQs.
- Updated 'src/offices/_single.html' to move import statement block if condition.
- Updated 'src/sub-pages/_single.html' to pass in FAQ title.
- Updated 'src/sub-pages/_single-grandchild-pages.html' to pass in FAQ title.

## Test
- Visit 'http://localhost:7000/sub-pages/civil-penalty-fund/.

## Notes
- @sarahsimpson09 , /sub-pages/frequently-asked-questions/ will need to be changed to remove some unnecessary copy. 

## Screenshots
<img width="1051" alt="screen shot 2015-07-20 at 3 41 09 pm" src="https://cloud.githubusercontent.com/assets/1696212/8785468/d415a13c-2ef5-11e5-8199-2a10287ad2af.png">




## Review
@jimmynotjim
@anselmbradford 
@KimberlyMunoz 