### PR TITLE
Adds offices tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Added gulp and the required npm plugins
 - Added gulp config file to lay out configs for each task
 - Added gulp tasks split up into their own files
+- Adds integration tests for `/offices/*` pages accessible through site's menu.
 
 ### Changed
 - Updated primary navigation to match new mega menu design.

--- a/src/_includes/macros/sub_pages.html
+++ b/src/_includes/macros/sub_pages.html
@@ -23,6 +23,7 @@
                             block__sub
                             block__padded-top
                             block__border-top
+                            qa-subpage
                             {{ 'block__border-bottom' if is_office_page == false }}">
                   {% if title %}
                       <h1 class="h2">

--- a/src/offices/_single.html
+++ b/src/offices/_single.html
@@ -15,7 +15,7 @@
 {% block content_main %}
 
     {% if office.title %}
-    <h1>{{ office.title | safe }}</h1>
+    <h1 class="qa-main-title">{{ office.title | safe }}</h1>
     {% endif %}
 
     {% if office.intro.text %}
@@ -37,7 +37,8 @@
         {% if show_subscription %}
         <div class="content-l_col
                         content-l_col-1-2
-                        content-l_col__before-divider">
+                        content-l_col__before-divider
+                        qa-subscription">
             <p class="h3 u-show-on-mobile">Stay informed</p>
             <p class="short-desc">Stay up to date with our email newsletter</p>
             {% import 'macros/subscribe.html' as subscribe with context %}
@@ -53,7 +54,7 @@
                     block__padded-top
                     block__border-top">
         {% if top_story.head %}
-        <h2>{{ top_story.head | safe }}</h2>
+        <h2 class="qa-top-story-head">{{ top_story.head | safe }}</h2>
         {% endif %}
         <div class="content-l
                     content-l__main
@@ -65,7 +66,10 @@
                         {% else -%}
                         content-l_col-1
                         {% endif -%}">
-                <p class="short-desc">{{ top_story.desc | safe }}</p>
+                <div class="short-desc
+                          qa-top-story-desc">
+                    {{ top_story.desc | safe }}
+                </div>
             </div>
             {% endif %}
             {% if top_story.links %}
@@ -75,7 +79,7 @@
                 <ul class="list__links">
                 {% for link in top_story.links %}
                     <li class="list_item">
-                        <a class="list_link" href="{{ link.url }}">
+                        <a class="jump-link qa-top-story-link" href="{{ link.url }}">
                             {{link.label}}
                         </a>
                     </li>
@@ -100,22 +104,30 @@
             {% if resource.icon %}
             <div class="media_image-container
                         media_image-container__wide-margin">
-                <img class="media_image u-centered-on-mobile"
-                     width="150"
+                <img class="media_image
+                            media_image__150
+                            u-centered-on-mobile
+                            qa-resource-img"
                      src="{{ resource.icon }}">
             </div>
             {% endif %}
             <div class="media_body">
                 {% if resource.title %}
-                <h2>{{ resource.title | safe }}</h2>
+                <h2 class="qa-resource-title">
+                    {{ resource.title | safe }}
+                </h2>
                 {% endif %}
 
                 {% if resource.desc %}
-                <p class="short-desc">{{ resource.desc | safe }}</p>
+                <p class="short-desc qa-resource-desc">
+                    {{ resource.desc | safe }}
+                </p>
                 {% endif %}
 
                 {% if resource.link %}
-                <a class="jump-link jump-link__underline"
+                <a class="jump-link
+                          jump-link__underline
+                          qa-resource-link"
                    href="{{ resource.link.url }}">
                       {{ resource.link.label }}
                 </a>
@@ -134,7 +146,8 @@
     {% if office.content %}
     <section class="block
                     block__padded-top
-                    block__border-top">
+                    block__border-top
+                    qa-office-content">
         {{ office.content }}
     </section>
     {% endif %}
@@ -144,7 +157,8 @@
                     block__bg
                     block__flush-sides
                     block__flush-top
-                    block__flush-bottom">
+                    block__flush-bottom
+                    qa-office-tags">
         {% import 'macros/activity-snippets.html' as activity_snippets with context %}
         {% set activities_feed = activity_snippets.render(office.tags, include_date_flag=true, number_columns=2) %}
         {% include 'templates/activities-feed.html' %}

--- a/test/browser_tests/page_objects/page_office.js
+++ b/test/browser_tests/page_objects/page_office.js
@@ -1,0 +1,49 @@
+'use strict';
+
+function OfficePage() {
+  this.get = function( officePage ) {
+    var examplePages = {
+        CFPBOmbudsman:              '/offices/cfpb-ombudsman/',
+        FOIARequests:               '/offices/foia-requests/',
+        OpenGovernment:             '/offices/open-government/',
+        PaymentsToHarmedConsumer:   '/offices/payments-to-harmed-consumers/',
+        PlainWriting:               '/offices/plain-writing/',
+        Privacy:                    '/offices/privacy/',
+        ProjectCatalyst:            '/offices/project-catalyst/'
+    };
+
+    browser.get( examplePages[officePage] );
+  };
+
+  this.pageTitle = function() { return browser.getTitle(); };
+
+  this.mainTitle = element( by.css( '.qa-main-title' ) );
+
+  this.introText = element( by.css( '.office_intro-text' ) );
+
+  this.subscription = element( by.css( '.qa-subscription') );
+
+  this.topStoryHead = element( by.css( '.qa-top-story-head' ) );
+
+  this.topStoryDesc = element( by.css( '.qa-top-story-desc' ) );
+
+  this.topStoryLink = element( by.css( '.qa-top-story-link' ) );
+
+  this.resourceImg = element( by.css( '.qa-resource-img' ) );
+
+  this.resourceTitle = element( by.css( '.qa-resource-title' ) );
+
+  this.resourceDesc = element( by.css( '.qa-resource-desc' ) );
+
+  this.resourceLink = element( by.css( '.qa-resource-link' ) );
+
+  this.subpages = element( by.css( '.qa-subpage h2' ) );
+
+  this.officeContent = element( by.css( '.qa-office-content h2' ) );
+
+  this.officeTags = element( by.css( '.qa-office-tags h1' ) );
+
+  this.officeContact = element( by.css( '.office_contact' ) );
+}
+
+module.exports = OfficePage;

--- a/test/browser_tests/spec_suites/shared/shared_office-cfpb-ombudsman.js
+++ b/test/browser_tests/spec_suites/shared/shared_office-cfpb-ombudsman.js
@@ -1,0 +1,72 @@
+'use strict';
+
+var Office = require( '../../page_objects/page_office.js' );
+
+describe( 'The CFPB Ombudsman Office Page', function() {
+  var page;
+
+  beforeEach( function() {
+    page = new Office();
+    page.get( 'CFPBOmbudsman' );
+  } );
+
+  it( 'should properly load in a browser', function() {
+    expect( page.pageTitle() ).toBe( 'CFPB Ombudsman' );
+  } );
+
+  it( 'should include main title', function() {
+    expect( page.mainTitle.getText() ).toBe( 'CFPB Ombudsman' );
+  } );
+
+  it( 'should include intro text', function() {
+    expect( page.introText.getText() ).toContain( 'CFPB Ombudsman' );
+  } );
+
+  it( 'should NOT include subscription', function() {
+    expect( page.subscription.isPresent() ).toBe( false );
+  } );
+
+  it( 'should include top story head', function() {
+    expect( page.topStoryHead.getText() ).toBe( 'Our Role' );
+  } );
+
+  it( 'should NOT include top story description', function() {
+    expect( page.topStoryDesc.getText() ).toContain( 'ombudsman principles' );
+  } );
+
+  it( 'should NOT include top story link', function() {
+    expect( page.topStoryLink.isPresent() ).toBe( false );
+  } );
+
+  it( 'should NOT have resource image', function() {
+    expect( page.resourceImg.isPresent() ).toBe( false );
+  } );
+
+  it( 'should NOT have resource title', function() {
+    expect( page.resourceTitle.isPresent() ).toBe( false );
+  } );
+
+  it( 'should NOT have resource description', function() {
+    expect( page.resourceDesc.isPresent() ).toBe( false );
+  } );
+
+  it( 'should NOT have resource link', function() {
+    expect( page.resourceLink.isPresent() ).toBe( false );
+  } );
+
+  it( 'should have subpages', function() {
+    expect( page.subpages.isPresent() ).toBe( true );
+  } );
+
+  it( 'should NOT have office content', function() {
+    expect( page.officeContent.isPresent() ).toBe( false );
+  } );
+
+  it( 'should NOT have office tags', function() {
+    expect( page.officeTags.isPresent() ).toBe( false );
+  } );
+
+  it( 'should have office contacts', function() {
+    expect( page.officeContact.isPresent() ).toBe( true );
+  } );
+} );

--- a/test/browser_tests/spec_suites/shared/shared_office-foia-requests.js
+++ b/test/browser_tests/spec_suites/shared/shared_office-foia-requests.js
@@ -1,0 +1,72 @@
+'use strict';
+
+var Office = require( '../../page_objects/page_office.js' );
+
+describe( 'The Office of FOIA Requests Page', function() {
+  var page;
+
+  beforeEach( function() {
+    page = new Office();
+    page.get( 'FOIARequests' );
+  } );
+
+  it( 'should properly load in a browser', function() {
+    expect( page.pageTitle() ).toBe( 'FOIA Requests' );
+  } );
+
+  it( 'should include main title', function() {
+    expect( page.mainTitle.getText() ).toBe( 'FOIA Requests' );
+  } );
+
+  it( 'should include intro text', function() {
+    expect( page.introText.getText() ).toContain( 'Freedom of Information' );
+  } );
+
+  it( 'should NOT include subscription', function() {
+    expect( page.subscription.isPresent() ).toBe( false );
+  } );
+
+  it( 'should NOT include top story head', function() {
+    expect( page.topStoryHead.isPresent() ).toBe( false );
+  } );
+
+  it( 'should NOT include top story description', function() {
+    expect( page.topStoryDesc.isPresent() ).toBe( false );
+  } );
+
+  it( 'should NOT include top story link', function() {
+    expect( page.topStoryLink.isPresent() ).toBe( false );
+  } );
+
+  it( 'should NOT have resource image', function() {
+    expect( page.resourceImg.isPresent() ).toBe( false );
+  } );
+
+  it( 'should have resource title', function() {
+    expect( page.resourceTitle.getText() ).toBe( 'Expected timeframe' );
+  } );
+
+  it( 'should have resource description', function() {
+    expect( page.resourceDesc.getText() ).toContain( 'Processing time' );
+  } );
+
+  it( 'should NOT have resource link', function() {
+    expect( page.resourceLink.isPresent() ).toBe( false );
+  } );
+
+  it( 'should have subpages', function() {
+    expect( page.subpages.isPresent() ).toBe( true );
+  } );
+
+  it( 'should NOT have office content', function() {
+    expect( page.officeContent.isPresent() ).toBe( false );
+  } );
+
+  it( 'should have office tags', function() {
+    expect( page.officeTags.isPresent() ).toBe( true );
+  } );
+
+  it( 'should have office contacts', function() {
+    expect( page.officeContact.isPresent() ).toBe( true );
+  } );
+} );

--- a/test/browser_tests/spec_suites/shared/shared_office-open-government.js
+++ b/test/browser_tests/spec_suites/shared/shared_office-open-government.js
@@ -1,0 +1,72 @@
+'use strict';
+
+var Office = require( '../../page_objects/page_office.js' );
+
+describe( 'The Open Government Office Page', function() {
+  var page;
+
+  beforeEach( function() {
+    page = new Office();
+    page.get( 'OpenGovernment' );
+  } );
+
+  it( 'should properly load in a browser', function() {
+    expect( page.pageTitle() ).toBe( 'Open Government' );
+  } );
+
+  it( 'should include main title', function() {
+    expect( page.mainTitle.getText() ).toBe( 'Open Government' );
+  } );
+
+  it( 'should include intro text', function() {
+    expect( page.introText.getText() ).toContain( 'Our mission' );
+  } );
+
+  it( 'should NOT include subscription', function() {
+    expect( page.subscription.isPresent() ).toBe( false );
+  } );
+
+  it( 'should NOT include top story head', function() {
+    expect( page.topStoryHead.isPresent() ).toBe( false );
+  } );
+
+  it( 'should NOT include top story description', function() {
+    expect( page.topStoryDesc.isPresent() ).toBe( false );
+  } );
+
+  it( 'should NOT include top story link', function() {
+    expect( page.topStoryLink.isPresent() ).toBe( false );
+  } );
+
+  it( 'should NOT have resource image', function() {
+    expect( page.resourceImg.isPresent() ).toBe( false );
+  } );
+
+  it( 'should NOT have resource title', function() {
+    expect( page.resourceTitle.isPresent() ).toBe( false );
+  } );
+
+  it( 'should NOT have resource description', function() {
+    expect( page.resourceDesc.isPresent() ).toBe( false );
+  } );
+
+  it( 'should NOT have resource link', function() {
+    expect( page.resourceLink.isPresent() ).toBe( false );
+  } );
+
+  it( 'should have subpages', function() {
+    expect( page.subpages.isPresent() ).toBe( true );
+  } );
+
+  it( 'should NOT have office content', function() {
+    expect( page.officeContent.isPresent() ).toBe( false );
+  } );
+
+  it( 'should have office tags', function() {
+    expect( page.officeTags.isPresent() ).toBe( true );
+  } );
+
+  it( 'should NOT have office contacts', function() {
+    expect( page.officeContact.isPresent() ).toBe( false );
+  } );
+} );

--- a/test/browser_tests/spec_suites/shared/shared_office-payments-to-harmed-consumers.js
+++ b/test/browser_tests/spec_suites/shared/shared_office-payments-to-harmed-consumers.js
@@ -1,0 +1,72 @@
+'use strict';
+
+var Office = require( '../../page_objects/page_office.js' );
+
+describe( 'The Payments to Harmed Consumers Office Page', function() {
+  var page;
+
+  beforeEach( function() {
+    page = new Office();
+    page.get( 'PaymentsToHarmedConsumer' );
+  } );
+
+  it( 'should properly load in a browser', function() {
+    expect( page.pageTitle() ).toBe( 'Payments to Harmed Consumers' );
+  } );
+
+  it( 'should include main title', function() {
+    expect( page.mainTitle.getText() ).toBe( 'Payments to Harmed Consumers' );
+  } );
+
+  it( 'should include intro text', function() {
+    expect( page.introText.getText() ).toContain( 'Congress has authorized' );
+  } );
+
+  it( 'should NOT include subscription', function() {
+    expect( page.subscription.isPresent() ).toBe( false );
+  } );
+
+  it( 'should NOT include top story head', function() {
+    expect( page.topStoryHead.isPresent() ).toBe( false );
+  } );
+
+  it( 'should NOT include top story description', function() {
+    expect( page.topStoryDesc.isPresent() ).toBe( false );
+  } );
+
+  it( 'should NOT include top story link', function() {
+    expect( page.topStoryLink.isPresent() ).toBe( false );
+  } );
+
+  it( 'should NOT have resource image', function() {
+    expect( page.resourceImg.isPresent() ).toBe( false );
+  } );
+
+  it( 'should NOT have resource title', function() {
+    expect( page.resourceTitle.isPresent() ).toBe( false );
+  } );
+
+  it( 'should NOT have resource description', function() {
+    expect( page.resourceDesc.isPresent() ).toBe( false );
+  } );
+
+  it( 'should NOT have resource link', function() {
+    expect( page.resourceLink.isPresent() ).toBe( false );
+  } );
+
+  it( 'should have subpages', function() {
+    expect( page.subpages.isPresent() ).toBe( true );
+  } );
+
+  it( 'should NOT have office content', function() {
+    expect( page.officeContent.isPresent() ).toBe( false );
+  } );
+
+  it( 'should have office tags', function() {
+    expect( page.officeTags.isPresent() ).toBe( true );
+  } );
+
+  it( 'should NOT have office contacts', function() {
+    expect( page.officeContact.isPresent() ).toBe( false );
+  } );
+} );

--- a/test/browser_tests/spec_suites/shared/shared_office-plain-writing.js
+++ b/test/browser_tests/spec_suites/shared/shared_office-plain-writing.js
@@ -1,0 +1,72 @@
+'use strict';
+
+var Office = require( '../../page_objects/page_office.js' );
+
+describe( 'The Plain Writing Page', function() {
+  var page;
+
+  beforeEach( function() {
+    page = new Office();
+    page.get( 'PlainWriting' );
+  } );
+
+  it( 'should properly load in a browser', function() {
+    expect( page.pageTitle() ).toBe( 'Plain Writing' );
+  } );
+
+  it( 'should include main title', function() {
+    expect( page.mainTitle.getText() ).toBe( 'Plain Writing' );
+  } );
+
+  it( 'should include intro text', function() {
+    expect( page.introText.getText() ).toContain( 'adopted plain language' );
+  } );
+
+  it( 'should NOT include subscription', function() {
+    expect( page.subscription.isPresent() ).toBe( false );
+  } );
+
+  it( 'should NOT include top story head', function() {
+    expect( page.topStoryHead.isPresent() ).toBe( false );
+  } );
+
+  it( 'should NOT include top story description', function() {
+    expect( page.topStoryDesc.isPresent() ).toBe( false );
+  } );
+
+  it( 'should NOT include top story link', function() {
+    expect( page.topStoryLink.isPresent() ).toBe( false );
+  } );
+
+  it( 'should NOT have resource image', function() {
+    expect( page.resourceImg.isPresent() ).toBe( false );
+  } );
+
+  it( 'should NOT have resource title', function() {
+    expect( page.resourceTitle.isPresent() ).toBe( false );
+  } );
+
+  it( 'should NOT have resource description', function() {
+    expect( page.resourceDesc.isPresent() ).toBe( false );
+  } );
+
+  it( 'should NOT have resource link', function() {
+    expect( page.resourceLink.isPresent() ).toBe( false );
+  } );
+
+  it( 'should have subpages', function() {
+    expect( page.subpages.isPresent() ).toBe( true );
+  } );
+
+  it( 'should NOT have office content', function() {
+    expect( page.officeContent.isPresent() ).toBe( false );
+  } );
+
+  it( 'should have office tags', function() {
+    expect( page.officeTags.isPresent() ).toBe( true );
+  } );
+
+  it( 'should have office contacts', function() {
+    expect( page.officeContact.isPresent() ).toBe( true );
+  } );
+} );

--- a/test/browser_tests/spec_suites/shared/shared_office-privacy.js
+++ b/test/browser_tests/spec_suites/shared/shared_office-privacy.js
@@ -1,0 +1,72 @@
+'use strict';
+
+var Office = require( '../../page_objects/page_office.js' );
+
+describe( 'The Privacy Office Page', function() {
+  var page;
+
+  beforeEach( function() {
+    page = new Office();
+    page.get( 'Privacy' );
+  } );
+
+  it( 'should properly load in a browser', function() {
+    expect( page.pageTitle() ).toBe( 'Privacy' );
+  } );
+
+  it( 'should include main title', function() {
+    expect( page.mainTitle.getText() ).toBe( 'Privacy' );
+  } );
+
+  it( 'should include intro text', function() {
+    expect( page.introText.getText() ).toContain( 'information (PII)' );
+  } );
+
+  it( 'should NOT include subscription', function() {
+    expect( page.subscription.isPresent() ).toBe( false );
+  } );
+
+  it( 'should NOT include top story head', function() {
+    expect( page.topStoryHead.isPresent() ).toBe( false );
+  } );
+
+  it( 'should NOT include top story description', function() {
+    expect( page.topStoryDesc.isPresent() ).toBe( false );
+  } );
+
+  it( 'should NOT include top story link', function() {
+    expect( page.topStoryLink.isPresent() ).toBe( false );
+  } );
+
+  it( 'should NOT have resource image', function() {
+    expect( page.resourceImg.isPresent() ).toBe( false );
+  } );
+
+  it( 'should NOT have resource title', function() {
+    expect( page.resourceTitle.isPresent() ).toBe( false );
+  } );
+
+  it( 'should NOT have resource description', function() {
+    expect( page.resourceDesc.isPresent() ).toBe( false );
+  } );
+
+  it( 'should NOT have resource link', function() {
+    expect( page.resourceLink.isPresent() ).toBe( false );
+  } );
+
+  it( 'should have subpages', function() {
+    expect( page.subpages.isPresent() ).toBe( true );
+  } );
+
+  it( 'should NOT have office content', function() {
+    expect( page.officeContent.isPresent() ).toBe( false );
+  } );
+
+  it( 'should have office tags', function() {
+    expect( page.officeTags.isPresent() ).toBe( true );
+  } );
+
+  it( 'should have office contacts', function() {
+    expect( page.officeContact.isPresent() ).toBe( true );
+  } );
+} );

--- a/test/browser_tests/spec_suites/shared/shared_office-project-catalyst.js
+++ b/test/browser_tests/spec_suites/shared/shared_office-project-catalyst.js
@@ -1,0 +1,75 @@
+'use strict';
+
+var Office = require( '../../page_objects/page_office.js' );
+
+describe( 'The Project Catalyst Page', function() {
+  var page;
+
+  beforeEach( function() {
+    page = new Office();
+    page.get( 'ProjectCatalyst' );
+  } );
+
+  it( 'should properly load in a browser', function() {
+    expect( page.pageTitle() ).toBe( 'Project Catalyst' );
+  } );
+
+  it( 'should include main title', function() {
+    expect( page.mainTitle.getText() ).toBe( 'Project Catalyst' );
+  } );
+
+  it( 'should include intro text', function() {
+    expect( page.introText.getText() ).toContain( 'Our mission' );
+  } );
+
+  it( 'should NOT include subscription', function() {
+    expect( page.subscription.isPresent() ).toBe( false );
+  } );
+
+  it( 'should include top story head', function() {
+    expect( page.topStoryHead.getText() ).toBe( 'Talk to Us' );
+  } );
+
+  it( 'should include top story description', function() {
+    expect( page.topStoryDesc.getText() ).toContain( 'We have a lot to talk' );
+  } );
+
+  it( 'should include top story link', function() {
+    expect( page.topStoryLink.getText() ).toContain( 'Email us at' );
+    expect( page.topStoryLink.getAttribute( 'href' ) )
+      .toBe( 'mailto:ProjectCatalyst@cfpb.gov?subject=I%27ve%20got%20an%20idea...' );
+  } );
+
+  it( 'should NOT have resource image', function() {
+    expect( page.resourceImg.isPresent() ).toBe( false );
+  } );
+
+  it( 'should have resource title', function() {
+    expect( page.resourceTitle.isPresent() ).toBe( true );
+  } );
+
+  it( 'should have resource description', function() {
+    expect( page.resourceDesc.isPresent() ).toBe( true );
+  } );
+
+  it( 'should have resource link', function() {
+    expect( page.resourceLink.isPresent() ).toBe( true );
+  } );
+
+  it( 'should NOT have subpages', function() {
+    expect( page.subpages.isPresent() ).toBe( true );
+  } );
+
+  it( 'should have office content', function() {
+    expect( page.officeContent.getText() )
+      .toBe( 'How we’ll handle your information' );
+  } );
+
+  it( 'should have office tags', function() {
+    expect( page.officeTags.isPresent() ).toBe( true );
+  } );
+
+  it( 'should have office contacts', function() {
+    expect( page.officeContact.isPresent() ).toBe( true );
+  } );
+} );


### PR DESCRIPTION
Adds offices tests

## Additions

- Adds page object and shared spec suite for /offices/ pages content.

## Testing

- Follow `TEST.md` instructions for browser tests.

## Review

- @imuchnik 
- @jimmynotjim 
- @KimberlyMunoz 
- @sebworks 

## Notes

- ~~So when I run these I get `FATAL ERROR: CALL_AND_RETRY_2 Allocation failed - process out of memory` and the Selenium browser instances remain open. A few notes:~~

 - ~~The selectors are very long because I leaned toward not cluttering the markup with classes that are just used for test suite hooks. It didn't seem problematic to have them long since they can be recreated with inspect element > Copy CSS Path. But could this be the issue?~~ Fixed with `qa-` selectors.

 - There are three different page options in the get method of the page object because not all office pages have all the possible content available.
