### PR TITLE
Add sauce tunnel config for jenkins

### DIFF
--- a/test/browser_tests/jenkins_conf.js
+++ b/test/browser_tests/jenkins_conf.js
@@ -4,8 +4,9 @@ exports.config = {
   framework:    'jasmine2',
   specs:        [ 'spec_suites/shared/*.js' ],
   capabilities: {
-    browserName: 'chrome',
-    name:        'flapjack-browser-tests'
+    'browserName': 'chrome',
+    'name':        'flapjack-browser-tests ' + process.env.SITE_DESC,
+    'tunnel-identifier': process.env.SAUCE_TUNNEL
   },
 
   sauceUser: process.env.SAUCE_USER,


### PR DESCRIPTION
This adds the saucelabs tunnel we need for saucelabs to access our servers from Jenkins.  It also makes the name more descriptive in saucelabs.

Review: @jimmynotjim @kurtw @imuchnik 