### PR TITLE
Events Tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Added `event-listener.js` and `query-selector.js` polyfills for IE8.
 - Added `@tr-border` variable to `cf-enhancements.less`
   for simple-table border color.
+- Added tests for events and event archive landing pages
 
 ### Changed
 - Updated primary navigation to match new mega menu design.
@@ -56,11 +57,15 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Updated all careers images to 2x size and have the same markup structure.
 - Updated event macros to use Sheer 'when' function in order to
   display content based on state.
-- Tied careers data into single template and renamed to `_single.html`.
+- Tied careers data into single template and renamed to _single.html
 - Replaced career pages mock jobs data with data from the jobs API.
 - Made jobs list table on /careers/current-openings/ have linkable rows.
 - Adds eslint ignore lines for polyfills, which will not be changing.
 - Moved CF table color overrides to `cf-theme-overrides.less`.
+- Updated the existing missions browser test to be stronger
+- Updated the browser test specs in conf.js because the shared spec was being
+  fired on the desktop test, even though those tests had already been run in
+  Chrome. Now the desktop test only runs the desktop spec
 
 ### Removed
 - Removed requestAnimationFrame polyfill.
@@ -76,6 +81,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Added browser tests to linting task
 - Fixed MobileOnlyExpandable error on office page.
 - Normalized use of jinja quotes to single quote
+- Fixed existing linting errors and warnings in browser tests
 
 ## 3.0.0-2.0.0 - 2015-07-24
 

--- a/test/browser_tests/conf.js
+++ b/test/browser_tests/conf.js
@@ -3,22 +3,23 @@
 var env = require( './environment.js' );
 
 exports.config = {
-  specs: [ 'spec_suites/shared/*.js' ],
   multiCapabilities: [
     {
-      browserName: 'chrome'
+      browserName: 'chrome',
+      specs:       [ 'spec_suites/shared/*.js' ]
     },
     {
-      browserName: 'firefox'
+      browserName: 'firefox',
+      specs:       [ 'spec_suites/shared/*.js' ]
     },
     // Large Screen only tests
     {
-      browserName: 'chrome',
+      browserName:   'chrome',
+      specs:         [ 'spec_suites/large_screen/*.js' ],
       chromeOptions: {
         args: [ '--lang=en',
                 '--window-size=1200,900' ]
-      },
-      specs: [ 'spec_suites/large_screen/*.js' ]
+      }
     }
   ],
 

--- a/test/browser_tests/jenkins_conf.js
+++ b/test/browser_tests/jenkins_conf.js
@@ -4,8 +4,8 @@ exports.config = {
   framework:    'jasmine2',
   specs:        [ 'spec_suites/shared/*.js' ],
   capabilities: {
-    'browserName': 'chrome',
-    'name':        'flapjack-browser-tests ' + process.env.SITE_DESC,
+    browserName:         'chrome',
+    name:                'flapjack-browser-tests ' + process.env.SITE_DESC,
     'tunnel-identifier': process.env.SAUCE_TUNNEL
   },
 

--- a/test/browser_tests/page_objects/page_events.js
+++ b/test/browser_tests/page_objects/page_events.js
@@ -1,0 +1,52 @@
+'use strict';
+
+function EventsPage() {
+  this.get = function() {
+    browser.get( '/events/' );
+  };
+
+  this.pageTitle = function() { return browser.getTitle(); };
+  this.nav = element( by.css( '.nav-secondary_list' ) );
+  this.heroElem = element( by.css( '.hero' ) );
+  this.hero = {
+    maps:    element.all( by.css( '.hero .hero_img' ) ),
+    heading: this.heroElem.element( by.css( '.summary_heading' ) ),
+    date:    this.heroElem.element( by.css( '.event-meta_date' ) ),
+    time:    this.heroElem.element( by.css( '.event-meta_time' ) )
+  };
+  this.events = element.all( by.css( '.post-preview__event' ) );
+  this.eventElem = this.events.first();
+  this.first = {
+    map:     this.eventElem.element( by.css( '.post-summary-image img' ) ),
+    heading: this.eventElem.element( by.css( '.summary_heading' ) ),
+    city:    this.eventElem.element( by.css( '.event-meta_city' ) ),
+    state:   this.eventElem.element( by.css( '.event-meta_state' ) ),
+    date:    this.eventElem.element( by.css( '.event-meta_date' ) ),
+    time:    this.eventElem.element( by.css( '.event-meta_time' ) ),
+    tags:    this.eventElem.element( by.css( '.tags_list' ) )
+  };
+}
+
+function ArchivePage() {
+  this.get = function() {
+    browser.get( '/events/archive' );
+  };
+
+  this.pageTitle = function() { return browser.getTitle(); };
+  this.nav = element.all( by.css( '.nav-secondary_list a' ) );
+  this.events = element.all( by.css( '.post-preview__event' ) );
+  this.eventElem = this.events.first();
+  this.first = {
+    heading: this.eventElem.element( by.css( '.summary_heading' ) ),
+    city:    this.eventElem.element( by.css( '.event-meta_city' ) ),
+    state:   this.eventElem.element( by.css( '.event-meta_state' ) ),
+    date:    this.eventElem.element( by.css( '.event-meta_date' ) ),
+    time:    this.eventElem.element( by.css( '.event-meta_time' ) ),
+    tags:    this.eventElem.element( by.css( '.tags_list' ) )
+  };
+}
+
+module.exports = {
+  EventsPage:  EventsPage,
+  ArchivePage: ArchivePage
+};

--- a/test/browser_tests/page_objects/page_the-bureau.js
+++ b/test/browser_tests/page_objects/page_the-bureau.js
@@ -6,7 +6,13 @@ function TheBureauPage() {
   };
 
   this.pageTitle = function() { return browser.getTitle(); };
-  this.missions = element.all( by.css( '.the-bureau .mobile-carousel h1' ) );
+  this.missions = element.all( by.css( '.the-bureau .mobile-carousel h1' ) )
+    .map( function( elm, index ) {
+      return {
+        index: index,
+        text:  elm.getText()
+      };
+    } );
 }
 
 module.exports = TheBureauPage;

--- a/test/browser_tests/spec_suites/large_screen/large_contact-us.js
+++ b/test/browser_tests/spec_suites/large_screen/large_contact-us.js
@@ -16,7 +16,9 @@ describe( 'Beta Contact Page', function() {
 
   it( 'should include 48 individual offices in alpha order', function() {
     expect( page.offices.count() ).toEqual( 48 );
-    expect( page.firstOfficeLabel.getText() ).toMatch( 'Academic Research Council' );
-    expect( page.lastOfficeLabel.getText() ).toMatch( 'Your Money, Your Goals Toolkit' );
+    expect( page.firstOfficeLabel.getText() )
+      .toMatch( 'Academic Research Council' );
+    expect( page.lastOfficeLabel.getText() )
+      .toMatch( 'Your Money, Your Goals Toolkit' );
   } );
 } );

--- a/test/browser_tests/spec_suites/shared/shared_about-us.js
+++ b/test/browser_tests/spec_suites/shared/shared_about-us.js
@@ -21,12 +21,10 @@ describe( 'About Landing Page', function() {
   } );
 
   it( 'should have Blog & Newspaper section in the Activity feed', function() {
-    expect(
-      page.firstIcon.getAttribute( 'class' )
-    ).toMatch( 'cf-icon cf-icon-speech-bubble' );
+    expect( page.firstIcon.getAttribute( 'class' ) )
+      .toMatch( 'cf-icon cf-icon-speech-bubble' );
 
-    expect(
-      page.secondIcon.getAttribute( 'class' )
-    ).toContain( 'cf-icon cf-icon-newspaper' );
+    expect( page.secondIcon.getAttribute( 'class' ) )
+      .toContain( 'cf-icon cf-icon-newspaper' );
   } );
 } );

--- a/test/browser_tests/spec_suites/shared/shared_careers-students-and-graduates.js
+++ b/test/browser_tests/spec_suites/shared/shared_careers-students-and-graduates.js
@@ -18,7 +18,8 @@ describe( 'Careers/Student-and-graduates', function() {
 
   it( 'should have 4 opportunities for students and graduates', function() {
     expect( page.opportunities.count() ).toEqual( 4 );
-    expect( page.opportunities.getText() ).toContain( 'Presidential Management Fellow' );
+    expect( page.opportunities.getText() )
+      .toContain( 'Presidential Management Fellow' );
   } );
 
 } );

--- a/test/browser_tests/spec_suites/shared/shared_contact-us.js
+++ b/test/browser_tests/spec_suites/shared/shared_contact-us.js
@@ -21,7 +21,8 @@ describe( 'Contact Us Page', function() {
     var secondPhone = page.complaintPhone.last();
 
     expect( page.complaintPhone.count() ).toEqual( 2 );
-    expect( page.complaintPhone.getAttribute( 'class' ) ).toMatch( phoneClass );
+    expect( page.complaintPhone.getAttribute( 'class' ) )
+      .toMatch( phoneClass );
     expect( firstPhone.getText() ).toBe( '(855) 411-CFPB (2372)' );
     expect( firstPhone.getAttribute( 'href' ) ).toBe( 'tel:8554112372' );
     expect( secondPhone.getText() ).toBe( '(855) 729-CFPB (2372) TTY' );
@@ -34,16 +35,14 @@ describe( 'Contact Us Page', function() {
 
     expect( complaintLink.getText() ).toBeDefined();
     expect( complaintLink.getAttribute( 'href' ) ).toMatch( '/complaint/' );
-    expect( complaintLink.getAttribute( 'class' ) ).toMatch(
-      'jump-link__underline'
-    );
+    expect( complaintLink.getAttribute( 'class' ) )
+      .toMatch( 'jump-link__underline' );
   } );
 
   it( 'should include General Inquiries contact details', function() {
     expect( page.giEmail.getText() ).toBeDefined();
-    expect( page.giEmail.getAttribute( 'href' ) ).toBe(
-      'mailto:info@consumerfinance.gov'
-    );
+    expect( page.giEmail.getAttribute( 'href' ) )
+      .toBe( 'mailto:info@consumerfinance.gov' );
     expect( page.giPhone.getText() ).toBeDefined();
     expect( page.giPhone.getAttribute( 'href' ) ).toBe( 'tel:2024357000' );
     expect( page.giPhone.getAttribute( 'class' ) ).toMatch( phoneClass );

--- a/test/browser_tests/spec_suites/shared/shared_events.js
+++ b/test/browser_tests/spec_suites/shared/shared_events.js
@@ -1,0 +1,72 @@
+'use strict';
+
+var events = require( '../../page_objects/page_events.js' );
+var EventsPage = events.EventsPage;
+var ArchivePage = events.ArchivePage;
+
+describe( 'Events Landing page', function() {
+  var googleAPI = 'https://maps.googleapis.com/maps/api/staticmap?';
+  var page;
+
+  beforeEach( function() {
+    page = new EventsPage();
+    page.get();
+  } );
+
+  it( 'should properly load in a browser', function() {
+    expect( page.pageTitle() ).toBe( 'Upcoming Events' );
+  } );
+
+  it( 'should include a hero', function() {
+    expect( page.heroElem.isPresent() ).toBeTruthy();
+    expect( page.hero.maps.count() ).toEqual( 2 );
+    expect( page.hero.maps.get( 0 ).getAttribute( 'style' ) )
+      .toContain( googleAPI );
+    expect( page.hero.maps.get( 1 ).getAttribute( 'style' ) )
+      .toContain( googleAPI );
+    expect( page.hero.heading.getText() ).toBeDefined();
+    expect( page.hero.date.getText() ).toBeDefined();
+    expect( page.hero.time.getText() ).toBeDefined();
+  } );
+
+  it( 'should include at least one event', function() {
+    expect( page.events.count() ).toBeGreaterThan( 0 );
+  } );
+
+  it( 'should include all event meta data', function() {
+    expect( page.first.map.getAttribute( 'src' ) ).toContain( googleAPI );
+    expect( page.first.heading.getText() ).toBeDefined();
+    expect( page.first.city.getText() ).toBeDefined();
+    expect( page.first.state.getText() ).toBeDefined();
+    expect( page.first.date.getText() ).toBeDefined();
+    expect( page.first.time.getText() ).toBeDefined();
+    expect( page.first.tags ).toBeTruthy();
+  } );
+} );
+
+
+describe( 'Events Archive page', function() {
+  var page;
+
+  beforeEach( function() {
+    page = new ArchivePage();
+    page.get();
+  } );
+
+  it( 'should properly load in a browser', function() {
+    expect( page.pageTitle() ).toBe( 'Past Events' );
+  } );
+
+  it( 'should include at least one event', function() {
+    expect( page.events.count() ).toBeGreaterThan( 0 );
+  } );
+
+  it( 'should include all event meta data', function() {
+    expect( page.first.heading.getText() ).toBeDefined();
+    expect( page.first.city.getText() ).toBeDefined();
+    expect( page.first.state.getText() ).toBeDefined();
+    expect( page.first.date.getText() ).toBeDefined();
+    expect( page.first.time.getText() ).toBeDefined();
+    expect( page.first.tags ).toBeTruthy();
+  } );
+} );

--- a/test/browser_tests/spec_suites/shared/shared_the-bureau.js
+++ b/test/browser_tests/spec_suites/shared/shared_the-bureau.js
@@ -18,10 +18,22 @@ describe( 'The Bureau Page', function() {
 
   it( 'should include 3 bureau missions, Educate, Enforce, Empower',
     function() {
-      expect( page.missions.count() ).toEqual( 3 );
-      expect( page.missions.getText() ).toEqual['Educate',
-                                                'Enforce',
-                                                'Empower'];
+      expect( page.missions ).toEqual(
+        [
+          {
+            index: 0,
+            text:  'Educate'
+          },
+          {
+            index: 1,
+            text:  'Enforce'
+          },
+          {
+            index: 2,
+            text:  'Empower'
+          }
+        ]
+      );
     }
   );
 } );


### PR DESCRIPTION
Added tests for events and events archive

## Additions

- Added page objects for both pages
- Added specs for both pages

## Removals

- None

## Changes

- Updated the specs in `conf.js` because the shared spec was being fired on the desktop test, even though those tests had already been run in Chrome. Now the desktop test only runs the desktop spec

## Testing

- `grunt build && protractor ./tests/browser_tests/conf.js`

## Review

- @sebworks 
- @KimberlyMunoz 
- @anselmbradford 
- @imuchnik 

[Preview this PR without the whitespace changes](?w=0)

## Notes

- The tests hang and crash if you search for an element that doesn't exist. I wanted to search for the map on the archive page knowing it shouldn't be there, but it seems this is an issue that needs to be fixed first.
