### PR TITLE
Adds a `grunt watch` config to watch for changes to .html files, and execute the copy task

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -410,6 +410,10 @@ module.exports = function(grunt) {
       js: {
         files: ['<%= loc.src %>/static/js/**/*.js'],
         tasks: ['js']
+      },
+      jinja2: {
+        files: ['<%= loc.src %>/**/*.html'],  
+        tasks: ['copy']
       }
     },
 


### PR DESCRIPTION
I wonder if there's a way to make this more surgical: ie, only copy the file that
changed.