### PR TITLE
Update test_macros.py for new macro path and add working event-landing-macros

### DIFF
--- a/test/macro_tests/test_macros.py
+++ b/test/macro_tests/test_macros.py
@@ -17,8 +17,10 @@ class CFGovTestCase(SheerEnvironment, MacroTestCase):
         # Get the cfgov-refresh root dir, ../../../
         # PLEASE NOTE: This presumes that the file containing the test always
         # lives three levels above the cfgov-refresh root.
-        root_dir = os.path.abspath(os.path.join(os.path.dirname( __file__ ),
-                                                os.pardir, os.pardir))
+        root_dir = os.path.abspath(os.path.join(
+            os.path.dirname(__file__),
+            os.pardir, os.pardir,
+            'src'))
         return root_dir
 
 

--- a/test/macro_tests/tests/event-landing-macros.json
+++ b/test/macro_tests/tests/event-landing-macros.json
@@ -1,0 +1,66 @@
+{
+    "file": "_event-landing-macros.html",
+    "tests": [
+        {
+            "macro_name": "event_preview",
+            "skip": false,
+            "context": {
+                "request": {
+                    "url_rule": "foo"
+                }
+            },
+            "template_macros": {
+                "_event-post-macros.html":{
+                    "post_summary()": "YAY",
+                    "event_location_image(options={})": "foo"
+                }
+            },
+            "arguments": [
+                {
+                    "title": "Test Post",
+                    "dek": "A dek",
+                    "excerpt": "An excerpt",
+                    "author": ["Me"],
+                    "date": "2014-10-28",
+                    "beginning_time": {
+                        "date": "2014-10-28T10:00:00-04:00",
+                        "timezone": "America/Detroit"
+                    },
+                    "venue":
+                        {
+                            "address":
+                                {
+                                    "city": "New York",
+                                    "state": "NY"
+                                }
+
+                        },
+                    "future": "future"
+                 }
+            ],
+            "assertions": [
+                {
+                    "selector": ".summary_heading",
+                    "index": 0,
+                    "assertion": "in",
+                    "value": "Test Post"
+                },
+                {
+                    "selector": ".calendar-icon span",
+                    "index": 0,
+                    "value": "u-visually-hidden",
+                    "assertion": "equal",
+                    "attribute": "class"
+                },
+                {
+                    "selector": ".calendar-icon span",
+                    "index": 0,
+                    "value": "Oct 28, 2014",
+                    "assertion": "in"
+                }
+
+            ]
+        }
+    ]
+}
+


### PR DESCRIPTION
Update `tests/macro_tests/test_macros.py` for the new directory structure and adds a working example `event-landing-macros.json` file to test `_event-landing-macros.html`. The test may or may not be adequate to test `_event-landing-macros.html`, but it is intended to be a working starting point.

This PR requires using Macro Polo from this PR: cfpb/macropolo#3 (See Testing below).

## Additions

- Example tests for `_event-landing-macros.html`

## Removals

- None

## Changes

- Changes the path to templates in `test_macros.py` to make templates discoverable.

## Testing

- `pip install git+https://github.com/willbarton/macropolo@other-templates` (cfpb/macropolo#3)
- `python test/macro_tests/test_macros.py`

## Review

- @jimmynotjim  
- @KimberlyMunoz 
- @dpford 
- @kurtw  
- @imuchnik 

## Notes

Because this PR depends on unmerged Macro Polo changes, I anticipate Travis will fail. This PR is intended to test those Macro Polo changes so that can be merged first, then we can trigger Travis again here before merging.