### PR TITLE
sub-pages and offices fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,8 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Created 1/4 and 3/4 layout columns.
 - Added DL styles to cf-enhancements.
 - Added `offices/project-catalyst`.
-- Careers processor/mapping/query
+- Careers processor/mapping/query.
+- Added `office_[office slug]` class to offices template.
 
 ### Changed
 - Updated primary navigation to match new mega menu design.
@@ -43,6 +44,9 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Updated Offices sub pages to display related documents.
 - Updated Offices sub pages to always display activity feed.
 - Updated Expandable macro to update design and add FAQ options.
+- Moved `sub-page_[sub-page slug]` class to main content area of sub_pages template.
+- Styled unordered lists as branded lists in the `office_intro-text`,
+  `sub-page_content`, and `sub-page_content-markup` class areas.
 
 ### Removed
 - Removed requestAnimationFrame polyfill.
@@ -55,6 +59,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Event tag filtering on archive page
 - Added browser tests to linting task
 - Fixed MobileOnlyExpandable error on office page.
+
 
 ## 3.0.0-1.3.0 - 2015-07-16
 

--- a/src/offices/_single.html
+++ b/src/offices/_single.html
@@ -9,6 +9,7 @@
     {{ super() }}
     content__flush-bottom
     office
+    office_{{office.slug}}
 {%- endblock %}
 
 {% block content_main %}

--- a/src/static/css/pages/offices.less
+++ b/src/static/css/pages/offices.less
@@ -11,12 +11,13 @@
         });
     }
 
-    // NOTE: This is to accommodate the variety of content that can be
+    // NOTE: This is to accommodate the variety of HTML tags that can be
     //       delivered to the custom_fields > intro_text field in the CMS.
     &_intro-text {
         p {
             .h3();
         }
+
         ul {
             .list__branded();
         }

--- a/src/static/css/pages/sub-pages.less
+++ b/src/static/css/pages/sub-pages.less
@@ -4,7 +4,16 @@
    ========================================================================== */
 
 .sub-page {
+
     .webfont-regular();
+
+    &_content,
+    &_content-markup {
+        // Make all lists in the content area of the sub-pages branded lists.
+        ul {
+            .list__branded();
+        }
+    }
 
     a[href $='.pdf']:after {
         .cf-icon();
@@ -19,12 +28,6 @@
 .sub-page__grandchild,
 .sub-page__grandchild + .content_sidebar {
     padding-top: @grid_gutter-width;
-}
-
-// cfpb-ombudsman office
-
-.sub-page_frequently-asked-questions {
-    .h2();
 }
 
 // privacy office
@@ -43,15 +46,5 @@
             color: @pacific;
             text-align: right;
         }
-    }
-}
-
-// open-government office
-
-.sub-page_information-quality-guidelines,
-.sub-page_our-open-government-activities {
-    ul {
-        .list__branded();
-        .list__spaced();
     }
 }

--- a/src/sub-pages/_single-grandchild-pages.html
+++ b/src/sub-pages/_single-grandchild-pages.html
@@ -12,9 +12,11 @@
 {% endblock -%}
 
 {% block content_main_modifiers -%}
-    {{ super() }} content__flush-bottom
-                  sub-page
-                  sub-page__grandchild
+    {{ super() }}
+    sub-page
+    sub-page__grandchild
+    sub-page_{{sub_page.slug}}
+    content__flush-bottom
 {%- endblock %}
 
 {% block title -%}

--- a/src/sub-pages/_single.html
+++ b/src/sub-pages/_single.html
@@ -10,7 +10,10 @@
 {%- endblock %}
 
 {% block content_main_modifiers -%}
-    {{ super() }} content__flush-bottom sub-page
+    {{ super() }}
+    sub-page
+    sub-page_{{sub_page.slug}}
+    content__flush-bottom
 {%- endblock %}
 
 {% block content_main %}
@@ -22,16 +25,17 @@
     {% if sub_page.content %}
     <section class="block
                     block__flush-top
-                    block__flush-bottom">
+                    block__flush-bottom
+                    sub-page_content">
         {{ sub_page.content | safe }}
     </section>
     {% endif %}
 
     {% if sub_page.body_content or sub_page.related_links %}
-    <section class="sub-page_{{sub_page.slug}}
-                    block
+    <section class="block
                     block__padded-top
-                    block__border-top">
+                    block__border-top
+                    sub-page_content-markup">
 
         {% if sub_page.related_links %}
         <section class="block


### PR DESCRIPTION
Fixes to the sub-pages and office pages.

## Additions

- Adds `sub-page_content` and `sub-page_content-markup` classes.
- Adds office page specific class for consistency with the classes added in the sub-pages template.

## Changes

- Moves page specific sub-page class to enclosing content area (it wasn't including the intro block).
- Set branded list styles on known areas where unordered lists appear.

## Testing

- Observe branded lists on /offices/project-catalyst/ page and subpages.

## Review

- @sebworks 
- @KimberlyMunoz 
- @jimmynotjim 

## Preview

<img width="809" alt="screen shot 2015-07-21 at 3 47 14 pm" src="https://cloud.githubusercontent.com/assets/704760/8810871/017aabca-2fc0-11e5-8882-c6bb36748cf4.png">

<img width="845" alt="screen shot 2015-07-21 at 3 47 20 pm" src="https://cloud.githubusercontent.com/assets/704760/8810875/09a0faa2-2fc0-11e5-914c-727813b9ca28.png">


## Notes

- I hate that extra classes are needed for this, but some links are in lists in the CMS so I can't just blanket apply the branded list to the main content area.