### PR TITLE
No more arrows

### DIFF
--- a/src/_includes/macros/activity-snippets.html
+++ b/src/_includes/macros/activity-snippets.html
@@ -126,7 +126,7 @@
         <ul class="list list__unstyled list__spaced list__links">
         {% for item in feed %}
             <li class="list_item">
-                <a class="list_link jump-link jump-link__right"
+                <a class="list_link"
                    href="{{ item.permalink }}">
                     {{ item.title | safe  }}
                     {%- if item.date and include_date_flag -%}

--- a/src/_includes/macros/sub_pages.html
+++ b/src/_includes/macros/sub_pages.html
@@ -74,14 +74,14 @@
                               <ul class="list__links">
                                   {% for link in page.related_links %}
                                       <li class="list_item">
-                                          <a class="jump-link jump-link__right list_link" href="{{link.url}}">
+                                          <a class="list_link" href="{{link.url}}">
                                               {{ link.label }}
                                           </a>
                                       </li>
                                   {% endfor %}
                               </ul>
                           {% elif is_office_page or not page.related_links %}
-                              <a class="jump-link jump-link__right" href="{{ page.permalink }}">
+                              <a class="jump-link jump-link__underline" href="{{ page.permalink }}">
                                   {{ page.preview_text or 'Read more' }}
                               </a>
                           {% endif %}

--- a/src/_includes/related-links.html
+++ b/src/_includes/related-links.html
@@ -65,9 +65,9 @@
 
 {%- macro link_template(link) %}
 {% if link[0] == '' %}
-<a class="list_link jump-link jump-link__underline u-link__disabled">
+<a class="list_link u-link__disabled">
 {% else %}
-<a class="list_link jump-link jump-link__underline"
+<a class="list_link"
    href="{{ link[0] }}">
 {% endif %}
     {{ link[1] }}

--- a/src/_includes/related-links.html
+++ b/src/_includes/related-links.html
@@ -65,9 +65,9 @@
 
 {%- macro link_template(link) %}
 {% if link[0] == '' %}
-<a class="list_link jump-link jump-link__right u-link__disabled">
+<a class="list_link jump-link jump-link__underline u-link__disabled">
 {% else %}
-<a class="list_link jump-link jump-link__right"
+<a class="list_link jump-link jump-link__underline"
    href="{{ link[0] }}">
 {% endif %}
     {{ link[1] }}

--- a/src/about-us/index.html
+++ b/src/about-us/index.html
@@ -56,7 +56,7 @@
                     <div class="media_body">
                         <span class="h6">Director</span>
                         <h3 class="h2 bureau-bio_name">Richard Cordray</h3>
-                        <a class="jump-link jump-link__right"
+                        <a class="jump-link jump-link__underline"
                            href="/the-bureau/about-rich-cordray">
                             Cordray's bio
                         </a>
@@ -71,13 +71,13 @@
                     <div class="media_body">
                         <span class="h6">Deputy Director</span>
                         <h3 class="h2 bureau-bio_name">Steve Antonakes</h3>
-                        <a class="jump-link jump-link__right"
+                        <a class="jump-link jump-link__underline"
                            href="/the-bureau/about-steve-antonakes">
                             Antonakes's bio
                         </a>
                     </div>
                 </div>
-                <a class="jump-link jump-link__right"
+                <a class="jump-link jump-link__underline"
                    href="/the-bureau/bureau-structure/">
                     Organizational structure and leadership
                 </a>
@@ -181,7 +181,7 @@
     {% import "macros/activity-snippets.html" as activity_snippets with context %}
     {% set activities_feed = activity_snippets.render(tags, ['posts', 'newsroom'],include_date_flag=true) %}
     {% include 'templates/activities-feed.html' %}
-    <a class="jump-link jump-link__right"
+    <a class="jump-link jump-link__underline"
        href="/activity-log/">
         View all of our activities
     </a>

--- a/src/budget/index.html
+++ b/src/budget/index.html
@@ -35,7 +35,7 @@
                 <li>that works for American consumers, responsible providers, and the economy
                 as a whole.</li>
             </ul>
-            <p class="h3">We publish our budget, strategy, and regular updates to provide transparency and to hold 
+            <p class="h3">We publish our budget, strategy, and regular updates to provide transparency and to hold
             ourselves accountable to the public.<p>
         </div>
     </section>
@@ -49,7 +49,8 @@
                 strategy for pursuing our mission and vision.</p>
                 <ul class="list list__links">
                     <li class="list_item">
-                        <a class="list_link jump-link jump-link__right" href="/budget/strategic-plan/">
+                        <a class="list_link"
+                           href="/budget/strategic-plan/">
                             Review the CFPB’s strategic plan
                         </a>
                     </li>
@@ -61,7 +62,7 @@
                 plan and explain how we will continue to make progress.</p>
                 <ul class="list list__links">
                     <li class="list_item">
-                        <a class="list_link jump-link jump-link__right"
+                        <a class="list_link"
                            href="/budget/performance-plan-report/">
                             See our performance plans and reports
                         </a>
@@ -74,7 +75,8 @@
                 <h2 class="h3">Financial reports and updates</h2>
                 <p class="short-desc">Our budget describes what it takes to execute our plan. We
                 detail the budget in annual reports and quarterly updates.</p>
-                <a class="jump-link jump-link__right" href="/budget/financial-report/">
+                <a class="jump-link jump-link__underline"
+                   href="/budget/financial-report/">
                     Review our financial reports and updates
                 </a>
             </div>
@@ -82,7 +84,8 @@
                 <h2 class="h3">Funding requests</h2>
                 <p class="short-desc">We receive funding from the Federal Reserve Board. We publish
                 all our funding requests and the Fed’s replies.</p>
-                <a class="jump-link jump-link__right" href="/budget/funding-request/">
+                <a class="jump-link jump-link__underline"
+                   href="/budget/funding-request/">
                     Review our funding requests
                 </a>
             </div>
@@ -103,7 +106,8 @@
                         We work with vendors who can help us achieve our mission. We publish
                         information about both existing and future procurements.
                     </p>
-                    <a class="jump-link" href="/doing-business-with-us/">
+                    <a class="jump-link jump-link__underline"
+                       href="/doing-business-with-us/">
                         Learn more about opportunities to work with the CFPB
                     </a>
                 </section>

--- a/src/careers/_template-current-openings.html
+++ b/src/careers/_template-current-openings.html
@@ -3,7 +3,7 @@
     We post new openings frequently. See them here.
 </p>
 <p class="short-desc">
-    <a class="jump-link jump-link__right" href="/careers/current-openings/">
+    <a class="jump-link jump-link__underline" href="/careers/current-openings/">
         Browse CFPB job openings
     </a>
 </p>

--- a/src/careers/_template-job-app-process.html
+++ b/src/careers/_template-job-app-process.html
@@ -6,7 +6,7 @@
 </p>
 <p class="short-desc">
     <a href="/careers/application-process/"
-       class="jump-link jump-link__right">
+       class="jump-link jump-link__underline">
         Learn how the job application process works
     </a>
 </p>

--- a/src/careers/_template-linkedin.html
+++ b/src/careers/_template-linkedin.html
@@ -9,6 +9,6 @@
     we do and new opportunities to be a part of it.
 </p>
 <a href="https://www.linkedin.com/company/consumer-financial-protection-bureau"
-   class="jump-link jump-link__external-link">
+   class="jump-link jump-link__external-link jump-link__underline">
 	Follow us on LinkedIn
 </a>

--- a/src/careers/_template-provide-feedback.html
+++ b/src/careers/_template-provide-feedback.html
@@ -9,7 +9,7 @@
         <span class="cf-icon cf-icon-email list_icon"></span>
         <span class="h5 list_text">Email</span>
         <a href="mailto:jobs@consumerfinance.gov"
-           class="jump-link">
+           class="jump-link jump-link__underline">
             jobs@consumerfinance.gov
         </a>
     </li>

--- a/src/careers/_template-students-and-graduates.html
+++ b/src/careers/_template-students-and-graduates.html
@@ -3,7 +3,7 @@
     Find opportunities in public service for a new generation of leaders.
 </p>
 <p class="short-desc">
-    <a href="/careers/students-and-graduates/" class="jump-link jump-link__right">
+    <a href="/careers/students-and-graduates/" class="jump-link jump-link__underline">
         Learn about students & graduates opportunities
     </a>
 </p>

--- a/src/careers/_template-working-at-cfpb.html
+++ b/src/careers/_template-working-at-cfpb.html
@@ -5,7 +5,7 @@
     The work you do will directly impact the lives of consumers.
 </p>
 <p class="short-desc">
-    <a href="/careers/working-at-cfpb/" class="jump-link jump-link__right">
+    <a href="/careers/working-at-cfpb/" class="jump-link jump-link__underline">
         Learn what it's like to work at the CFPB
     </a>
 </p>

--- a/src/careers/index.html
+++ b/src/careers/index.html
@@ -42,7 +42,8 @@
                         Help us continue to grow and develop our 21st century agency. The work you do will directly impact the lives of American consumers.
                     </p>
                     <p>
-                        <a class="jump-link jump-link__right" href="/careers/working-at-cfpb/">
+                        <a class="jump-link jump-link__underline"
+                           href="/careers/working-at-cfpb/">
                             Learn what it’s like to work at the CFPB
                         </a>
                     </p>
@@ -82,7 +83,8 @@
                         </p>
                     </li>
                 </ul>
-                <a class="jump-link jump-link__right" href="/careers/current-openings/">
+                <a class="jump-link jump-link__underline"
+                   href="/careers/current-openings/">
                     <span class="jump-link_text">View all job openings</span>
                 </a>
             </aside>
@@ -109,7 +111,8 @@
             <div class="media_body u-centered-on-mobile">
                 <h1 class="h3">Job Application Process</h1>
                 <p class="short-desc">The application process can be tricky. We can help.</p>
-                <a class="jump-link jump-link__right" href="/careers/application-process/">
+                <a class="jump-link jump-link__underline"
+                   href="/careers/application-process/">
                     <span class="jump-link_text">Learn how the application process works</span>
                 </a>
             </div>
@@ -127,7 +130,8 @@
             <div class="media_body u-centered-on-mobile">
                 <h1 class="h3">Students and Recent Graduates</h1>
                 <p class="short-desc">Find opportunities in public service for a new generation of leaders.</p>
-                <p><a class="jump-link jump-link__right" href="/careers/students-and-graduates/">
+                <p><a class="jump-link jump-link__underline"
+                      href="/careers/students-and-graduates/">
                     <span class="jump-link_text">Learn about students and graduates opportunities</span>
                 </a></p>
             </div>

--- a/src/contact-us/_template-submit-a-complaint.html
+++ b/src/contact-us/_template-submit-a-complaint.html
@@ -30,7 +30,7 @@
 {%- endif %}
 </ul>
 {%- if submit_a_complaint.web.url %}
-<a class="jump-link jump-link__right" href="{{ submit_a_complaint.web.url }}">
+<a class="jump-link jump-link__underline" href="{{ submit_a_complaint.web.url }}">
     {{ submit_a_complaint.web.label if submit_a_complaint.web.label else submit_a_complaint.web.url }}
 </a>
 {%- endif %}

--- a/src/doing-business-with-us/_future-block.html
+++ b/src/doing-business-with-us/_future-block.html
@@ -5,7 +5,7 @@
         We provide a list of significant procurement requests
         we expect to make in the near future.
     </p>
-    <a class="jump-link jump-link__right" href="/doing-business-with-us/upcoming-procurement-needs/">
+    <a class="jump-link jump-link__underline" href="/doing-business-with-us/upcoming-procurement-needs/">
         <span class="jump-link_text">More information on upcoming requests</span>
     </a>
 </section>

--- a/src/doing-business-with-us/_smbiz-block.html
+++ b/src/doing-business-with-us/_smbiz-block.html
@@ -5,7 +5,7 @@
         We are committed to inclusive contracting opportunities for
         women, minorities, and small businesses.
     </p>
-    <a class="jump-link jump-link__right" href="/doing-business-with-us/small-businesses/">
+    <a class="jump-link jump-link__underline" href="/doing-business-with-us/small-businesses/">
         <span class="jump-link_text">Learn about our work with small, women-owned, and minority-owned
             businesses.</span>
     </a>

--- a/src/doing-business-with-us/index.html
+++ b/src/doing-business-with-us/index.html
@@ -84,7 +84,7 @@
                     We publish a list of any significant vendor services we expect to need in the
                     near future.
                 </p>
-                <a class="jump-link jump-link__right" href="upcoming-procurement-needs/">
+                <a class="jump-link jump-link__underline" href="upcoming-procurement-needs/">
                     <span class="jump-link_text">See a timetable of upcoming procurement
                         needs</span>
                 </a>
@@ -101,7 +101,7 @@
                 our largest contracts. We also send a memo to the Office of Management and Budget
                 describing budget analysis we are planning to do.
             </p>
-            <a class="jump-link jump-link__right" href="past-awards/">
+            <a class="jump-link jump-link__underline" href="past-awards/">
                 <span class="jump-link_text">See our yearly service contract information</span>
             </a>
         </section>
@@ -113,7 +113,7 @@
                 women-owned, and minority-owned businesses. You can also see data on existing work
                 we do with these businesses.
             </p>
-            <a class="jump-link jump-link__right" href="small-businesses/">
+            <a class="jump-link jump-link__underline" href="small-businesses/">
                 <span class="jump-link_text">More information for small, women-owned, and minority-owned
                     businesses</span>
             </a>

--- a/src/newsroom/featured-topic.html
+++ b/src/newsroom/featured-topic.html
@@ -23,7 +23,7 @@
                 {% for link in post.links %}
                     <li class="list_item">
                         <!-- <span class="category-slug_icon cf-icon cf-icon-bullhorn"></span> -->
-                        <a class="list_link jump-link jump-link__right"
+                        <a class="list_link"
                            href="{{ link.url }}">
                             {{ link.label if link.label else link.url }}
                        </a>

--- a/src/newsroom/press-resources/index.html
+++ b/src/newsroom/press-resources/index.html
@@ -134,7 +134,7 @@
                 <h1 class="contact-person_name">Richard Cordray</h1>
                 <ul class="list list__links">
                     <li class="list_item">
-                        <a class="list_link jump-link"
+                        <a class="list_link"
                            href="/the-bureau/about-rich-cordray/">
                             Biography
                         </a>
@@ -142,13 +142,13 @@
                     <li class="list_item">
                         <a class="list_link jump-link jump-link__download"
                            href="/static/img/201402_cfpb_photo_richard-cordray_high-res.jpg">
-                            High-res portrait
+                            <span class="jump-link_text">High-res portrait</span>
                         </a>
                     </li>
                     <li class="list_item">
                         <a class="list_link jump-link jump-link__download"
                            href="/static/img/201402_cfpb_photo_richard-cordray_low-res.jpg">
-                            Low-res portrait
+                            <span class="jump-link_text">Low-res portrait</span>
                         </a>
                     </li>
                 </ul>
@@ -171,13 +171,13 @@
                     <li class="list_item">
                         <a class="list_link jump-link jump-link__download"
                            href="/static/img/201405_cfpb_photo_steve-antonakes_high-res.jpg">
-                            High-res portrait
+                            <span class="jump-link_text">High-res portrait</span>
                         </a>
                     </li>
                     <li class="list_item">
                         <a class="list_link jump-link jump-link__download"
                            href="/static/img/201405_cfpb_photo_steve-antonakes_low-res.jpg">
-                            Low-res portrait
+                            <span class="jump-link_text">Low-res portrait</span>
                         </a>
                     </li>
                 </ul>
@@ -185,7 +185,7 @@
 
         </div><!-- END .content-l -->
 
-        <a class="jump-link jump-link__large"
+        <a class="jump-link jump-link__large jump-link__underline"
            href="/the-bureau/bureau-structure/">
             Find out more about our leadership
         </a>

--- a/src/offices/_single.html
+++ b/src/offices/_single.html
@@ -74,7 +74,7 @@
                 <ul class="list__links">
                 {% for link in top_story.links %}
                     <li class="list_item">
-                        <a class="jump-link jump-link__right list_link" href="{{ link.url }}">
+                        <a class="list_link" href="{{ link.url }}">
                             {{link.label}}
                         </a>
                     </li>
@@ -114,7 +114,7 @@
                 {% endif %}
 
                 {% if resource.link %}
-                <a class="jump-link jump-link__right"
+                <a class="jump-link jump-link__underline"
                    href="{{ resource.link.url }}">
                       {{ resource.link.label }}
                 </a>
@@ -147,7 +147,7 @@
         {% import "macros/activity-snippets.html" as activity_snippets with context %}
         {% set activities_feed = activity_snippets.render(office.tags, include_date_flag=true, number_columns=2) %}
         {% include 'templates/activities-feed.html' %}
-        <a class="jump-link jump-link__right"
+        <a class="jump-link jump-link__underline"
            href="/activity-log/{{ ('?filter_tags=' ~ office.tags | join('&') ) if office.tags }}">
             View all of our activities
         </a>

--- a/src/static/css/misc.less
+++ b/src/static/css/misc.less
@@ -321,6 +321,10 @@
         font-size: unit(18px / @base-font-size-px, em);
     }
 
+    &__underline {
+        border-bottom-width: 1px;
+    }
+
     .respond-to-max(@mobile-max, {
         .block-link();
 

--- a/src/static/css/pages/sub-pages.less
+++ b/src/static/css/pages/sub-pages.less
@@ -48,8 +48,8 @@
 
 // open-government office
 
-.sub-page_information-quality-guidelines,
-.sub-page_our-open-government-activities {
+.sub-page_information-quality-guidelines .sub-page_content,
+.sub-page_our-open-government-activities .sub-page_content{
     ul {
         .list__branded();
         .list__spaced();

--- a/src/sub-pages/_single-grandchild-pages.html
+++ b/src/sub-pages/_single-grandchild-pages.html
@@ -69,7 +69,7 @@
         {% import "macros/activity-snippets.html" as activity_snippets with context %}
         {% set activities_feed = activity_snippets.render(sub_page.tags, include_date_flag=true, number_columns=1)%}
         {% include 'templates/activities-feed.html' %}
-        <a class="jump-link jump-link__right"
+        <a class="jump-link jump-link__underline"
            href="/activity-log/{{ ('?filter_tags=' ~ sub_page.tags | join('&') ) if sub_page.tags }}">
             View all of our activities
         </a>

--- a/src/sub-pages/_single.html
+++ b/src/sub-pages/_single.html
@@ -38,11 +38,11 @@
                         block__flush-top
                         block_padded-bottom">
             <h3>Related Documents</h3>
+            <ul class="list list__links">
             {% for link in sub_page.related_links %}
-            <p>
-                <a href="{{link.url}}">{{ link.label }}</a>
-            </p>
+                <li class="list_item"><a href="{{link.url}}" class="list_link">{{ link.label }}</a></li>
             {% endfor %}
+            </ul>
         </section>
         {% endif %}
 
@@ -90,7 +90,7 @@
         {% import "macros/activity-snippets.html" as activity_snippets with context %}
         {% set activities_feed = activity_snippets.render(sub_page.tags, include_date_flag=true, number_columns=2)%}
         {% include 'templates/activities-feed.html' %}
-        <a class="jump-link jump-link__right"
+        <a class="jump-link jump-link__underline"
            href="/activity-log/{{ ('?filter_tags=' ~ sub_page.tags | join('&') ) if sub_page.tags }}">
             View all of our activities
         </a>

--- a/src/the-bureau/about-rich-cordray/index.html
+++ b/src/the-bureau/about-rich-cordray/index.html
@@ -63,13 +63,13 @@
                             <li class="list_item">
                                 <a class="list_link jump-link jump-link__download"
                                    href="/static/img/201402_cfpb_photo_richard-cordray_high-res.jpg">
-                                    High-res photo
+                                    <span class="jump-link_text">High-res photo</span>
                                 </a>
                             </li>
                             <li class="list_item">
                                 <a class="list_link jump-link jump-link__download"
                                    href="201410_cfpb_bio_cordray.pdf">
-                                    Biography
+                                    <span class="jump-link_text">Biography</span>
                                 </a>
                             </li>
                         </ul>
@@ -107,7 +107,7 @@
                     <p class="short-desc">
                         Get the latest CFPB news, including speeches, testimony, and op-eds by the director.
                     </p>
-                    <a class="jump-link jump-link__right"
+                    <a class="jump-link jump-link__underline"
                        href="/newsroom/?filter_author=Richard+Cordray">
                         See how our director is making headlines
                     </a>
@@ -120,7 +120,8 @@
                     <p class="short-desc">
                         Read blogs written by the director on a variety of consumer financial topics.
                     </p>
-                    <a href="/blog/?filter_author=Richard+Cordray" class="jump-link jump-link__right">
+                    <a href="/blog/?filter_author=Richard+Cordray"
+                       class="jump-link jump-link__underline">
                         Browse blogs by the director
                     </a>
                 </div>
@@ -132,7 +133,7 @@
                     <p class="short-desc">
                         See how the director spends his time working for consumers.
                     </p>
-                    <a class="jump-link jump-link__right"
+                    <a class="jump-link jump-link__underline"
                        href="{{ vars.path + 'leadership-calendar/' }}">
                         View the director’s public calendar
                     </a>
@@ -160,7 +161,9 @@
                     </p>
                     <a class="jump-link jump-link__external-link"
                        href="https://www.youtube.com/user/cfpbvideo/search?query=Cordray%27s+Corner">
-                        View Cordray’s Corner videos on YouTube
+                        <span class="jump-link_text">
+                            View Cordray’s Corner videos on YouTube
+                        </span>
                     </a>
                 </section>
                 <section class="content-l_col
@@ -176,7 +179,7 @@
                         In January of 2012, President Barack Obama appointed Richard Cordray to be the first
                         Director of the CFPB.
                     </p>
-                    <a class="jump-link jump-link__right"
+                    <a class="jump-link jump-link__underline"
                        href="{{ vars.path + 'history/' }}">
                         Learn more about our history
                     </a>

--- a/src/the-bureau/about-steve-antonakes/index.html
+++ b/src/the-bureau/about-steve-antonakes/index.html
@@ -60,13 +60,13 @@
                             <li class="list_item">
                                 <a class="list_link jump-link jump-link__download"
                                    href="/static/img/201405_cfpb_photo_steve-antonakes_high-res.jpg">
-                                    High-res photo
+                                    <span class="jump-link_text">High-res photo</span>
                                 </a>
                             </li>
                             <li class="list_item">
                                 <a class="list_link jump-link jump-link__download"
                                    href="201410_cfpb_bio_antonakes.pdf">
-                                    Biography
+                                    <span class="jump-link_text">Biography</span>
                                 </a>
                             </li>
                         </ul>
@@ -101,7 +101,7 @@
                     <p class="short-desc">
                         Get the latest CFPB news, including speeches, testimony and op-eds by the assistant director.
                     </p>
-                    <a class="jump-link jump-link__right"
+                    <a class="jump-link jump-link__underline"
                        href="/newsroom/?filter_author=Steve+Antonakes">
                         See how our deputy director is making headlines
                     </a>
@@ -114,7 +114,7 @@
                     <p class="short-desc">
                         Read blogs written by the deputy director on a variety of consumer financial topics.
                     </p>
-                    <a class="jump-link jump-link__right"
+                    <a class="jump-link jump-link__underline"
                        href="/blog/?filter_author=Steve+Antonakes">
                         Browse blogs by the deputy director
                     </a>
@@ -127,7 +127,7 @@
                     <p class="short-desc">
                         See how the deputy director spends his time working for consumers.
                     </p>
-                    <a class="jump-link jump-link__right"
+                    <a class="jump-link jump-link__underline"
                        href="{{ vars.path + 'leadership-calendar/' }}">
                         View the deputy director’s public calendar
                     </a>

--- a/src/the-bureau/index.html
+++ b/src/the-bureau/index.html
@@ -177,7 +177,7 @@
                     <div class="media_body">
                         <h1 class="h6">Director</h1>
                         <h2 class="bureau-bio_name">Richard Cordray</h2>
-                        <a class="jump-link jump-link__right" href="about-rich-cordray">
+                        <a class="jump-link jump-link__underline" href="about-rich-cordray">
                             Read bio
                         </a>
                     </div>
@@ -191,7 +191,7 @@
                     <div class="media_body">
                         <h1 class="h6">Deputy Director</h1>
                         <h2 class="bureau-bio_name">Steve Antonakes</h2>
-                        <a class="jump-link jump-link__right" href="about-steve-antonakes">
+                        <a class="jump-link jump-link__underline" href="about-steve-antonakes">
                             Read bio
                         </a>
                     </div>
@@ -201,22 +201,22 @@
 
         <ul class="list list__links">
             <li class="list_item u-show-on-mobile">
-                <a class="list_link jump-link jump-link__right" href="about-rich-cordray">
+                <a class="list_link" href="about-rich-cordray">
                     Learn more about Director Richard Cordray
                 </a>
             </li>
             <li class="list_item u-show-on-mobile">
-                <a class="list_link jump-link jump-link__right" href="about-steve-antonakes">
+                <a class="list_link" href="about-steve-antonakes">
                     Learn more about Deputy Director Steve Antonakes
                 </a>
             </li>
             <li class="list_item">
-                <a class="list_link jump-link jump-link__right" href="leadership-calendar">
+                <a class="list_link" href="leadership-calendar">
                     Review our leadership’s calendar
                 </a>
             </li>
             <li class="list_item">
-                <a class="list_link jump-link jump-link__right" href="bureau-structure">
+                <a class="list_link" href="bureau-structure">
                     Organizational structure and leadership
                 </a>
             </li>
@@ -234,7 +234,7 @@
                     <p class="h4">From the financial crisis through our work returning
                     billions of dollars to consumers, find out where we came from and what
                     we’ve been doing.</p>
-                    <a class="jump-link jump-link__right" href="history">
+                    <a class="jump-link jump-link__underline" href="history">
                         Learn about the history of the CFPB
                     </a>
                 </div>


### PR DESCRIPTION
(Except on heroes). According to guidelines from @schaferjh, blog posts will remain un-underlined, but everything else should be underlined.

## Additions

- Added `.jump-link__underline` for links that need to be underlined on desktop and block on mobile.

## Changes

- Changed many links with right arrows to use underline links instead

## Testing

- Tests should still pass
- Look at every page and there should be arrows only on heroes

## Review

- @jimmynotjim 
- @anselmbradford 
- @sebworks 

## Preview

![screen shot 2015-07-21 at 5 52 55 pm](https://cloud.githubusercontent.com/assets/1860176/8813416/58237a36-2fd1-11e5-9d12-990fe2c8cb87.png)

![screen shot 2015-07-21 at 5 53 17 pm](https://cloud.githubusercontent.com/assets/1860176/8813423/6510cdb6-2fd1-11e5-8a4e-bc8c3a8ab45e.png)


[Preview this PR without the whitespace changes](?w=0)

## Notes

- Related Design Manual Discussion and Oscar Nomination for Best Github Selfie by @duelj : https://github.com/cfpb/design-manual/issues/264
- JIRA Issue: DF-2211
- Fixes #679