### PR TITLE
Updating mega-menu to add Advisory Groups

### DIFF
--- a/src/_includes/templates/nav/_vars-primary-nav.html
+++ b/src/_includes/templates/nav/_vars-primary-nav.html
@@ -23,8 +23,7 @@
             ('/offices/payments-to-harmed-consumers/',
              'payments-to-harmed-consumers',
              'Payments to Harmed<br>Consumers'),
-            ('/offices/project-catalyst/',
-             'project-catalyst', 'Project Catalyst')
+            ('/offices/cfpb-ombudsman/', 'cfpb-ombudsman', 'CFPB Ombudsman')
         ),
         (
             ('/blog/', 'blog', 'Blog'),
@@ -35,7 +34,8 @@
         (
             ('/careers/', 'careers', 'Careers'),
             ('/doing-business-with-us/', 'doing-business-with-us', 'Doing Business With Us'),
-            ('/offices/cfpb-ombudsman/', 'cfpb-ombudsman', 'CFPB Ombudsman'),
+            ('/offices/advisory-groups/', 'advisory-groups', 'Advisory Groups'),
+            ('/offices/project-catalyst/', 'project-catalyst', 'Project Catalyst'),
             ('/contact-us/', 'contact-us', 'Contact Us')
         )
     ])


### PR DESCRIPTION
Updating mega menu to add 'Advisory Groups'.

## Changes
- Updated 'src/_includes/templates/nav/_vars-primary-nav.html' to add advisory group to nav.

## Test
- Visit 'http://localhost:7000/' and hover on 'About'. Observe the omnipotent mega menu. 

## Screenshots
<img width="1385" alt="screen shot 2015-07-22 at 10 00 55 am" src="https://cloud.githubusercontent.com/assets/1696212/8827120/ad932f7a-3058-11e5-9729-583ccf83e22e.png">


## Review
@jimmynotjim
@anselmbradford 
@KimberlyMunoz 