### PR TITLE
Career Pages Adjustments from Design

### DIFF
--- a/src/careers/_template-block-social.html
+++ b/src/careers/_template-block-social.html
@@ -1,13 +1,19 @@
 <div class="block
-            block__padded-top
             block__border-top
-            content-l">
-    <section class="content-l_col
-                    content-l_col-1-2">
-        {% include "_template-linkedin.html" %}
-    </section>
-    <section class="content-l_col
-                    content-l_col-1-2">
-        {% include "_template-provide-feedback.html" %}
-    </section>
+            ">
+    {# This extra div is to keep the horizontal lines size consistent #}
+    <div class="content-l">
+        <section class="content-l_col
+                        content-l_col-1-2
+                        block
+                        block__padded-top">
+            {% include "_template-linkedin.html" %}
+        </section>
+        <section class="content-l_col
+                        content-l_col-1-2
+                        block
+                        block__padded-top">
+            {% include "_template-provide-feedback.html" %}
+        </section>
+    </div>
 </div>

--- a/src/careers/_template-block-social.html
+++ b/src/careers/_template-block-social.html
@@ -6,13 +6,19 @@
         <section class="content-l_col
                         content-l_col-1-2
                         block
-                        block__padded-top">
+                        block__padded-top
+                        block__padded-bottom
+                        block__flush-top
+                        block__flush-bottom">
             {% include "_template-linkedin.html" %}
         </section>
         <section class="content-l_col
                         content-l_col-1-2
                         block
-                        block__padded-top">
+                        block__padded-top
+                        block__padded-bottom
+                        block__flush-top
+                        block__flush-bottom">
             {% include "_template-provide-feedback.html" %}
         </section>
     </div>

--- a/src/careers/application-process/index.html
+++ b/src/careers/application-process/index.html
@@ -279,19 +279,32 @@
     </section>
 
     <div class="block
-                block__padded-top
                 block__border-top
-                block__flush-bottom
-                content-l">
-        <section class="content-l_col content-l_col-1-3">
-            {% include "_template-current-openings.html" %}
-        </section>
-        <section class="content-l_col content-l_col-1-3">
-            {% include "_template-working-at-cfpb.html" %}
-        </section>
-        <section class="content-l_col content-l_col-1-3">
-            {% include "_template-students-and-graduates.html" %}
-        </section>
+                block__flush-bottom">
+        {# This extra div is to keep the horizontal lines size consistent #}
+        <div class="content-l">
+            <section class="content-l_col
+                            content-l_col-1-3
+                            block
+                            block__padded-top
+                            block__flush-bottom">
+                {% include "_template-current-openings.html" %}
+            </section>
+            <section class="content-l_col
+                            content-l_col-1-3
+                            block
+                            block__padded-top
+                            block__flush-bottom">
+                {% include "_template-working-at-cfpb.html" %}
+            </section>
+            <section class="content-l_col
+                            content-l_col-1-3
+                            block
+                            block__padded-top
+                            block__flush-bottom">
+                {% include "_template-students-and-graduates.html" %}
+            </section>
+        </div>
     </div>
 
     {% include "_template-block-social.html" %}

--- a/src/careers/application-process/index.html
+++ b/src/careers/application-process/index.html
@@ -194,8 +194,7 @@
 
     <section class="block
                     block__padded-top
-                    block__border-top
-                    block__flush-bottom">
+                    block__border-top">
         <h3>Preparing a Résumé to Apply to a Federal Government Position</h3>
         <p>
             It is important not to leave something out
@@ -221,8 +220,7 @@
 
     <section class="block
                     block__padded-top
-                    block__border-top
-                    block__flush-bottom">
+                    block__border-top">
         <h3>Federally Recognized Status and Eligibility for a Position</h3>
         <p>
             Sometimes very similar jobs will be posted simultaneously,
@@ -239,8 +237,7 @@
 
     <section class="block
                     block__padded-top
-                    block__border-top
-                    block__flush-bottom">
+                    block__border-top">
         <h3>Federal Ethics Rules and CFPB Ethics Regulations</h3>
         <p>
             We hold ourselves to an exemplary standard of integrity in all that we do.
@@ -263,8 +260,7 @@
 
     <section class="block
                     block__padded-top
-                    block__border-top
-                    block__flush-bottom">
+                    block__border-top">
         <h3>Equal Employment Opportunity</h3>
         <p>
             The CFPB is an equal opportunity employer
@@ -287,6 +283,8 @@
                             content-l_col-1-3
                             block
                             block__padded-top
+                            block__flush-top
+                            block__padded-bottom
                             block__flush-bottom">
                 {% include "_template-current-openings.html" %}
             </section>
@@ -294,6 +292,8 @@
                             content-l_col-1-3
                             block
                             block__padded-top
+                            block__flush-top
+                            block__padded-bottom
                             block__flush-bottom">
                 {% include "_template-working-at-cfpb.html" %}
             </section>
@@ -301,6 +301,8 @@
                             content-l_col-1-3
                             block
                             block__padded-top
+                            block__flush-top
+                            block__padded-bottom
                             block__flush-bottom">
                 {% include "_template-students-and-graduates.html" %}
             </section>

--- a/src/careers/current-openings/index.html
+++ b/src/careers/current-openings/index.html
@@ -104,6 +104,8 @@
                             content-l_col-1-2
                             block
                             block__padded-top
+                            block__padded-bottom
+                            block__flush-top
                             block__flush-bottom">
                 {% include "_template-job-app-process.html" %}
             </section>
@@ -111,6 +113,8 @@
                             content-l_col-1-2
                             block
                             block__padded-top
+                            block__padded-bottom
+                            block__flush-top
                             block__flush-bottom">
                 {% include "_template-working-at-cfpb.html" %}
             </section>

--- a/src/careers/current-openings/index.html
+++ b/src/careers/current-openings/index.html
@@ -96,16 +96,25 @@
     </div>
 
     <div class="block
-                block__padded-top
                 block__border-top
-                block__flush-bottom
-                content-l">
-        <section class="content-l_col content-l_col-1-2">
-            {% include "_template-job-app-process.html" %}
-        </section>
-        <section class="content-l_col content-l_col-1-2">
-            {% include "_template-working-at-cfpb.html" %}
-        </section>
+                block__flush-bottom">
+        {# This extra div is to keep the horizontal lines size consistent #}
+        <div class="content-l">
+            <section class="content-l_col
+                            content-l_col-1-2
+                            block
+                            block__padded-top
+                            block__flush-bottom">
+                {% include "_template-job-app-process.html" %}
+            </section>
+            <section class="content-l_col
+                            content-l_col-1-2
+                            block
+                            block__padded-top
+                            block__flush-bottom">
+                {% include "_template-working-at-cfpb.html" %}
+            </section>
+        </div>
     </div>
 
     {% include "_template-block-social.html" %}

--- a/src/careers/index.html
+++ b/src/careers/index.html
@@ -49,37 +49,37 @@
                 </div>
             </section>
             <aside class="content-l_col content-l_col-1-3 block block__flush-top">
-                <h1 class="h3">Newest Openings</h1>
-                <ul class="list list__unstyled">
+                <h2 class="h3">Newest Openings</h2>
+                <ul class="list list__spaced list__unstyled">
                     <li class="list_item">
-                        <a class="list_link u-link__disabled">Senior Designer</a>
-                        <p class="summary_text">
-                            <small>CLOSING JUN 22, 2015</small>
-                        </p>
+                        <a class="list_link u-link__disabled">
+                            Senior Designer
+                        </a>
+                        <p class="date">Closing Jun 22, 2015</p>
                     </li>
                     <li class="list_item">
-                        <a class="list_link u-link__disabled">Assistance director, Procurement</a>
-                        <p class="summary_text">
-                            <small>CLOSING JUN 22, 2015</small>
-                        </p>
+                        <a class="list_link u-link__disabled">
+                            Assistance director, Procurement
+                        </a>
+                        <p class="date">Closing Jun 22, 2015</p>
                     </li>
                     <li class="list_item">
-                        <a class="list_link u-link__disabled">Data quality analyst</a>
-                        <p class="summary_text">
-                            <small>CLOSING JUN 22, 2015</small>
-                        </p>
+                        <a class="list_link u-link__disabled">
+                            Data quality analyst
+                        </a>
+                        <p class="date">Closing Jun 22, 2015</p>
                     </li>
                     <li class="list_item">
-                        <a class="list_link u-link__disabled">Public affairs specialist</a>
-                        <p class="summary_text">
-                            <small>CLOSING JUN 22, 2015</small>
-                        </p>
+                        <a class="list_link u-link__disabled">
+                            Public affairs specialist
+                        </a>
+                        <p class="date">Closing Jun 22, 2015</p>
                     </li>
                     <li class="list_item">
-                        <a class="list_link u-link__disabled">Security engineer - IT specialist</a>
-                        <p class="summary_text">
-                            <small>CLOSING JUN 22, 2015</small>
-                        </p>
+                        <a class="list_link u-link__disabled">
+                            Security engineer - IT specialist
+                        </a>
+                        <p class="date">Closing Jun 22, 2015</p>
                     </li>
                 </ul>
                 <a class="jump-link jump-link__right" href="/careers/current-openings/">
@@ -139,12 +139,12 @@
 {% endblock %}
 
 {% block content_sidebar %}
-    <section>
+    <section class="block block__flush-top">
         {% import "macros/activity-snippets.html" as activity_snippets with context %}
         {% set activities_feed = activity_snippets.render(tags, ['blog'],include_date_flag=true) %}
         {% include 'templates/activities-feed.html' %}
     </section>
-    <section>
+    <section class="block">
         {# TODO: Add OCR URL. #}
         {%- import "related-links.html" as related_links -%}
         {{- related_links.render([

--- a/src/careers/students-and-graduates/index.html
+++ b/src/careers/students-and-graduates/index.html
@@ -137,6 +137,8 @@
                             content-l_col-1-2
                             block
                             block__padded-top
+                            block__padded-bottom
+                            block__flush-top
                             block__flush-bottom">
                 {% include "_template-job-app-process.html" %}
             </section>
@@ -144,7 +146,9 @@
                             content-l_col-1-2
                             block
                             block__padded-top
-                            block__flush-bottom">
+                            block__padded-bottom
+                            block__flush-top
+                            ">
                 {% include "_template-working-at-cfpb.html" %}
             </section>
         </div>

--- a/src/careers/students-and-graduates/index.html
+++ b/src/careers/students-and-graduates/index.html
@@ -129,16 +129,25 @@
     </section>
 
     <div class="block
-                block__padded-top
                 block__border-top
-                block__flush-bottom
-                content-l">
-        <section class="content-l_col content-l_col-1-2">
-            {% include "_template-job-app-process.html" %}
-        </section>
-        <section class="content-l_col content-l_col-1-2">
-            {% include "_template-working-at-cfpb.html" %}
-        </section>
+                block__flush-bottom">
+        <div class="content-l">
+        {# This extra div is to keep the horizontal lines size consistent #}
+            <section class="content-l_col
+                            content-l_col-1-2
+                            block
+                            block__padded-top
+                            block__flush-bottom">
+                {% include "_template-job-app-process.html" %}
+            </section>
+            <section class="content-l_col
+                            content-l_col-1-2
+                            block
+                            block__padded-top
+                            block__flush-bottom">
+                {% include "_template-working-at-cfpb.html" %}
+            </section>
+        </div>
     </div>
 
     {% include "_template-block-social.html" %}

--- a/src/careers/working-at-cfpb/index.html
+++ b/src/careers/working-at-cfpb/index.html
@@ -120,19 +120,32 @@
     </div>
 
     <div class="block
-                block__padded-top
                 block__border-top
-                block__flush-bottom
-                content-l">
-        <section class="content-l_col content-l_col-1-3">
-            {% include "_template-current-openings.html" %}
-        </section>
-        <section class="content-l_col content-l_col-1-3">
-            {% include "_template-job-app-process.html" %}
-        </section>
-        <section class="content-l_col content-l_col-1-3">
-            {% include "_template-students-and-graduates.html" %}
-        </section>
+                block__flush-bottom">
+        {# This extra div is to keep the horizontal lines size consistent #}
+        <div class="content-l">
+            <section class="content-l_col
+                            content-l_col-1-3
+                            block
+                            block__padded-top
+                            block__flush-bottom">
+                {% include "_template-current-openings.html" %}
+            </section>
+            <section class="content-l_col
+                            content-l_col-1-3
+                            block
+                            block__padded-top
+                            block__flush-bottom">
+                {% include "_template-job-app-process.html" %}
+            </section>
+            <section class="content-l_col
+                            content-l_col-1-3
+                            block
+                            block__padded-top
+                            block__flush-bottom">
+                {% include "_template-students-and-graduates.html" %}
+            </section>
+        </div>
     </div>
 
     {% include "_template-block-social.html" %}

--- a/src/careers/working-at-cfpb/index.html
+++ b/src/careers/working-at-cfpb/index.html
@@ -128,6 +128,8 @@
                             content-l_col-1-3
                             block
                             block__padded-top
+                            block__flush-top
+                            block__padded-bottom
                             block__flush-bottom">
                 {% include "_template-current-openings.html" %}
             </section>
@@ -135,6 +137,8 @@
                             content-l_col-1-3
                             block
                             block__padded-top
+                            block__flush-top
+                            block__padded-bottom
                             block__flush-bottom">
                 {% include "_template-job-app-process.html" %}
             </section>
@@ -142,6 +146,8 @@
                             content-l_col-1-3
                             block
                             block__padded-top
+                            block__flush-top
+                            block__padded-bottom
                             block__flush-bottom">
                 {% include "_template-students-and-graduates.html" %}
             </section>


### PR DESCRIPTION
A batch of changes from @duelj based on his feedback in JIRA

## Changes

- Changing job posting date heading level
- Adjusting spacing between sidebar modules
- Mobile Module spacing adjustment
- Fixing Horizontal rule spacing inconsistency

## Testing
- Visit `/careers/` and look for the following
 1. there should be appropriate spacing between modules on mobile
 2. The job posting dates should be the same as the other job posting dates in the sidebar
 3. All horizontal rules should be the same size

## Notes
- This corresponds to JIRA issues: DF-2228, DF-2229, DF-2230, DF-2231