### PR TITLE
Removing office_initiatives styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Removed requestAnimationFrame polyfill.
 - Removed `_tests/browser_tests/README.md`, `_tests/macro_testing/README.md`, `_tests/processor_tests/README.md`.
 - Removed `grunt vendor` from `setup.sh`.
+- Removed unused CSS
 
 ### Fixed
 - Fixed issue on IE11 when using the dates to filter caused

--- a/src/static/css/pages/offices.less
+++ b/src/static/css/pages/offices.less
@@ -22,30 +22,6 @@
             .list__branded();
         }
     }
-
-    &_initiatives {
-        .expandables-group {
-            .respond-to-max(@mobile-max, {
-                  border-top: 1px solid @gray-20;
-            });
-        }
-
-        .expandable.content-l_col {
-            margin-bottom: unit(@grid_gutter-width / @base-font-size-px, em);
-
-            .respond-to-max(@mobile-max, {
-                .expandable__padded();
-                margin-bottom: 0;
-                margin-top: 0;
-                border-bottom: 1px solid @gray-20;
-
-                .expandable_content {
-                    padding-bottom: unit(@grid_gutter-width / @base-font-size-px, em);
-                    margin-bottom: 0;
-                }
-            });
-        }
-    }
 }
 
 .initiative {


### PR DESCRIPTION
Closes #783.

## Removals

- Removed extraneous css not in use by project 
## Testing

- Visit any office page with an "Our Work" section

## Review

- @sebworks 
- @anselmbradford 
- @jimmynotjim 
