### PR TITLE
Removing extra class from #799

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,7 +52,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Removed requestAnimationFrame polyfill.
 - Removed `_tests/browser_tests/README.md`, `_tests/macro_testing/README.md`, `_tests/processor_tests/README.md`.
 - Removed `grunt vendor` from `setup.sh`.
-- Removed unused CSS
+- Removed unused CSS on `office.less`
 
 ### Fixed
 - Fixed issue on IE11 when using the dates to filter caused

--- a/src/static/css/pages/offices.less
+++ b/src/static/css/pages/offices.less
@@ -24,12 +24,6 @@
     }
 }
 
-.initiative {
-    &_description p:first-child {
-        .h3();
-    }
-}
-
 .office_activities + .office_contact {
     padding-top: 0;
 }

--- a/src/sub-pages/foia-records/index.html
+++ b/src/sub-pages/foia-records/index.html
@@ -18,7 +18,7 @@
     {% endif %}
 
     {% if sub_page.content %}
-    <section class="initiative_description block block__flush-top">
+    <section class="sub-page_content block block__flush-top">
         {{ sub_page.content | safe }}
     </section>
     {% endif %}


### PR DESCRIPTION
@sebworks brought up in #799 that there's an old class from the old office design. This PR removes the old `initiative` class and bringing foia-records in line with other sub-page templates. It also fixes the CHANGELOG update from #799 to make it more specific per @anselmbradford request.