### PR TITLE
Add career type to lookups.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Added `offices/project-catalyst`.
 - Careers processor/mapping/query.
 - Added `office_[office slug]` class to offices template.
+- Careers to the lookups.py
 
 ### Changed
 - Updated primary navigation to match new mega menu design.

--- a/src/_settings/lookups.json
+++ b/src/_settings/lookups.json
@@ -4,6 +4,11 @@
     "type":      "contact",
     "permalink": true
   },
+  "career": {
+    "url":       "/careers/<id>/",
+    "type":      "career",
+    "permalink": true
+  },
   "sub_page": {
     "url":       "/sub-pages/<id>/",
     "type":      "sub_page",


### PR DESCRIPTION
Careers wasn't in lookups.py which caused permalinks for that document type to not work. This adds it in the the file.

@anselmbradford @jimmynotjim 