### PR TITLE
Fixed Contact-Us Page Test

### DIFF
--- a/test/browser_tests/spec_suites/shared/shared_contact-us.js
+++ b/test/browser_tests/spec_suites/shared/shared_contact-us.js
@@ -34,12 +34,16 @@ describe( 'Contact Us Page', function() {
 
     expect( complaintLink.getText() ).toBeDefined();
     expect( complaintLink.getAttribute( 'href' ) ).toMatch( '/complaint/' );
-    expect( complaintLink.getAttribute( 'class' ) ).toMatch( 'jump-link__right' );
+    expect( complaintLink.getAttribute( 'class' ) ).toMatch(
+      'jump-link__underline'
+    );
   } );
 
   it( 'should include General Inquiries contact details', function() {
     expect( page.giEmail.getText() ).toBeDefined();
-    expect( page.giEmail.getAttribute( 'href' ) ).toBe( 'mailto:info@consumerfinance.gov' );
+    expect( page.giEmail.getAttribute( 'href' ) ).toBe(
+      'mailto:info@consumerfinance.gov'
+    );
     expect( page.giPhone.getText() ).toBeDefined();
     expect( page.giPhone.getAttribute( 'href' ) ).toBe( 'tel:2024357000' );
     expect( page.giPhone.getAttribute( 'class' ) ).toMatch( phoneClass );


### PR DESCRIPTION
I broke the test on `/contact-us/` when I changed all our arrow links in #793. I also spaced out that line and one other in the file to fix two eslint warnings.

## Testing
- run `protractor test/browser_tests/conf.js`

## Preview
![image](https://cloud.githubusercontent.com/assets/1860176/8860362/56fb80aa-3151-11e5-9a12-191bad4907ea.png)

## Review
- @anselmbradford 
- @jimmynotjim 
- @sebworks 
