### PR TITLE
DF-2293-single-careers-data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Updated all careers images to 2x size and have the same markup structure.
 - Updated event macros to use Sheer 'when' function in order to
   display content based on state.
+- Tied careers data into single template and renamed to _single.html
 
 ### Removed
 - Removed requestAnimationFrame polyfill.

--- a/src/_settings/lookups.json
+++ b/src/_settings/lookups.json
@@ -5,7 +5,7 @@
     "permalink": true
   },
   "career": {
-    "url":       "/careers/<id>/",
+    "url":       "/careers/current-openings/<id>/",
     "type":      "career",
     "permalink": true
   },

--- a/src/careers/_vars-careers.html
+++ b/src/careers/_vars-careers.html
@@ -7,3 +7,6 @@
       (path + 'current-openings/', 'current-openings', 'Current Openings')
     ])
 ] -%}
+
+{% set query = queries.careers %}
+{% set careers = query.search() %}

--- a/src/careers/current-openings/_single.html
+++ b/src/careers/current-openings/_single.html
@@ -1,14 +1,14 @@
 {% extends "layout-side-nav.html" %}
 {% import "_vars-careers.html" as vars with context %}
-{%- set active_nav_id = 'current-openings' -%}
 
 {% block title -%}
-    {# TODO: Add real page meta title. #}
-    Test Opening
+    {{ career.title }}
 {%- endblock %}
 
 {% block desc -%}
-    {# TODO: Add page meta description. #}
+    {# TODO: Update admin to include excerpt #}
+    {{ career.excerpt | striptags }}
+    }
 {%- endblock %}
 
 {% block content_main_modifiers -%}
@@ -23,23 +23,33 @@
     <section class="block
                     block__flush-top
                     block__sub">
-        {# TODO: Add real page details. #}
-        <h1>Test Opening Title</h1>
-        <dl class="u-mb0">
+        <h1>{{ career.title }}</h1>
+        {# TODO: Discuss careers with multiple grades #}
+        {% set grade = career.grades[0] %}
+        <dl>
             <dt>Expiration Date:</dt>
-            <dd>Month XX, XXXX</dd>
+            <dd>
+                <time datetime="{{ career.close_date | date('%Y-%m-%-dT%H:%M:%S%z') }}">
+                    {{ career.close_date | date('%b %-d, %Y') }}
+                </time>
+            </dd>
             <dt>Region:</dt>
-            <dd>Headquarters</dd>
+            <dd>{{ career.locations[0].region_long }}</dd>
             <dt>Grade:</dt>
-            <dd><strong>(33)</strong> $XX,XXX - $XXX,XXX</dd>
+            <dd>
+                <strong>({{ grade.grade }})</strong>
+                ${{ '{:,d}'.format( grade.salary_min ) }}–${{ '{:,d}'.format( grade.salary_max ) }}
+            </dd>
         </dl>
         <div class="content-l">
             <div class="content-l_col content-l_col-1-2">
-                <a href="#" class="btn">Interested in applying?</a>
+                <a href="#interested" class="btn">
+                    Interested in applying?
+                </a>
             </div>
             <div class="content-l_col content-l_col-1-2">
             {{ share.render({
-                'title': 'Test Opening Title',
+                'title': career.title,
                 'heading': 'Share this job',
                 'hide_heading': false,
                 'show_linkedin': true,
@@ -54,8 +64,10 @@
                 block__padded-top
                 block__border-top">
         <h2>Job Description</h2>
-        <p>Lorem ipsum...place description text here</p>
+        {{ career.description }}
 
+        {# TODO: Discuss how to break duties and departments out of
+        the description
         <h2>Duties</h2>
         <h3>As a test opening, you will:</h3>
         <ul class="list__branded">
@@ -66,6 +78,7 @@
 
         <h2>Departments</h2>
         <p>Multiple offices</p>
+        #}
     </section>
 
     <section class="block
@@ -73,7 +86,7 @@
                 block__border-top">
         <div class="content-l">
             <div class="content-l_col content-l_col-1-2">
-                <h2 class="u-mb0">Interested in Applying?</h2>
+                <h2 class="u-mb0" id="interested">Interested in Applying?</h2>
             </div>
             <div class="content-l_col content-l_col-1-2">
                 {{ share.render({
@@ -81,7 +94,8 @@
                     'heading': 'Share this job',
                     'hide_heading': false,
                     'show_linkedin': true,
-                    'additional_classes': 'share__horizontal share__align-right'
+                    'additional_classes':
+                        'share__horizontal share__align-right'
                 }) }}
             </div>
         </div>
@@ -91,32 +105,39 @@
                     block__sub">
             <h3>Before you apply</h3>
             <p class="short-desc">
-                Lorem impsum...replace with application info paragraph
+                {# TODO: Replace with real content #}
             </p>
 
             <ul class="list list__links">
                 <li class="list_item">
-                    <a class="jump-link" href="#">
+                    <a class="jump-link"
+                       href="/careers/working-at-cfpb/">
                         Learn about working @ CFPB
                     </a>
                 </li>
                 <li class="list_item">
-                    <a class="jump-link" href="#">
+                    <a class="jump-link"
+                       href="/careers/application-process/">
                         Learn about the application process
                     </a>
                 </li>
             </ul>
         </div>
         <div class="block block__flush-top">
-            <h4>Open to All Citizens (Excepted service - Permanent)</h4>
-            <p class="short-desc">Applications will be accepted from U.S. citizens....</p>
+            {% set applicant_type = career.applicant_types[0] %}
+            <h4>{{ applicant_type.application_type.name }}</h4>
+            <p class="short-desc">{{ applicant_type.application_type.description | striptags }}</p>
             <div class="content-l">
                 <div class="content-l_col content-l_col-1-4">
-                    <a class="btn" href="#">Apply now</a>
+                    <a class="btn" href="{{ applicant_type.usajobs_url }}">Apply now</a>
                 </div>
                 <div class="content-l_col content-l_col-3-4">
-                    <h4 class="u-mb0">You are about to leave consumerfinance.gov.</h4>
-                    <p class="short-desc">To finish the application, you must go to USAJobs.gov.</p>
+                    <h4 class="u-mb0">
+                        You are about to leave consumerfinance.gov.
+                        </h4>
+                    <p class="short-desc">
+                        To finish the application, you must go to USAJobs.gov.
+                    </p>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
Tied data into single career template

## Additions

- Added query for careers to vars-careers

## Removals

- None

## Changes

- Fixed the url in lookups
- Updated name of single career template and replaced placeholder content with data from the API

## Testing

- `sheer index -p careers`
- navigate to `/careers/current-openings/1853/`

## Review

- @anselmbradford 
- @sebworks 
- @ajbush 
- @schaferjh
- @sarahsimpson09 

## Preview

<img width="809" alt="screen shot 2015-07-24 at 3 29 48 pm" src="https://cloud.githubusercontent.com/assets/1280430/8882909/e0473224-3218-11e5-8adc-124d713f8297.png">
<img width="804" alt="screen shot 2015-07-24 at 3 29 55 pm" src="https://cloud.githubusercontent.com/assets/1280430/8882910/e1b20328-3218-11e5-83ae-8baadb6de6e1.png">


[Preview this PR without the whitespace changes](?w=0)

## Notes

- Currently forcing just one applicant type, will PR for the multiple applicant types post Sprint
- There's lorem ipsum in the "Before you apply" block and I don't know what I'm supposed to replace it with, @sarahsimpson09 any ideas?