### PR TITLE
Fixed issue displaying About Overview page on mobile

### DIFF
--- a/src/_includes/macros/sub-nav.html
+++ b/src/_includes/macros/sub-nav.html
@@ -23,7 +23,7 @@
     <div class="sub-nav_inner-wrapper
                 wrapper">
         <section class="sub-nav_menu">
-            <h4 class="sub-nav_title u-show-on-desktop">
+            <h4 class="sub-nav_title">
                 <a href="{{ sub_nav_landing }}">{{ sub_nav_title }}</a>
             </h4>
             <hr class="content-line content-line__nav u-show-on-desktop">

--- a/src/static/css/nav-primary.less
+++ b/src/static/css/nav-primary.less
@@ -71,6 +71,11 @@
     .webfont-regular();
 }
 
+.sub-nav_title {
+    .webfont-regular();
+    font-size: 1em;
+    color: @pacific;
+}
 
 /* Sliding nav for portrait tablets and smaller
    ========================================================================== */
@@ -100,6 +105,14 @@
     .sub-nav_menu-list .list_link {
         // Override standard visited link color.
         .u-link__colors(@pacific, @pacific, @pacific-50, @pacific, @navy);
+    }
+
+    .sub-nav_title {
+        margin-bottom: 0;
+
+        a {
+            background: @gray-10 !important;
+        }
     }
 
     .primary-nav_top-level-list.list-expanding {
@@ -421,11 +434,7 @@
         .grid_column(4);
     }
 
-    .sub-nav_title {
-        .webfont-regular();
-        font-size: 1em;
-        color: @pacific;
-    }
+
 
 });
 

--- a/src/static/js/modules/desktop-primary-nav.js
+++ b/src/static/js/modules/desktop-primary-nav.js
@@ -49,6 +49,7 @@ function init() {
       $subNav.attr( 'aria-expanded', 'true' );
 
       // Show the child list, previously hidden by default for the mobile menu.
+      $subNav.find( '.sub-nav_title' ).css('display', 'block');
       $subNav.find( '.list-expanding_child-list' ).css('display', 'inline-block');
 
       if ( aMenuItemWasOpened === false ) {

--- a/src/static/js/modules/mobile-primary-nav.js
+++ b/src/static/js/modules/mobile-primary-nav.js
@@ -13,7 +13,8 @@ function init() {
       $slidingNavTrigger = $( '.sliding-nav_trigger' ),
       $slidingNavNav = $( '.sliding-nav_nav' ),
       $slidingNavPage = $( '.sliding-nav_page' ),
-      $slidingNavPageOverlay = $( '.sliding-nav_page-overlay' );
+      $slidingNavPageOverlay = $( '.sliding-nav_page-overlay' ),
+      subNavItemsSelector = '.list-expanding_child-list, .sub-nav_title';
 
   $slidingNavTrigger.click( function( e ) {
     e.preventDefault();
@@ -53,17 +54,17 @@ function init() {
   $( '.list-expanding_trigger' ).cfpbAriaButton();
   $( '.list-expanding_trigger' ).click( function( e ) {
     e.preventDefault();
-    $( this ).next().find( '.list-expanding_child-list' ).slideToggle( 100 );
+    $( this ).next().find( subNavItemsSelector ).slideToggle( 100 );
   } );
   $( '.list-expanding_trigger' ).keyup( function( e ) {
     // Space key pressed.
     if ( e.which === 32 ) {
       e.preventDefault();
-      $( this ).next().find( '.list-expanding_child-list' ).slideToggle( 100 );
+      $( this ).next().find( subNavItemsSelector ).slideToggle( 100 );
     }
   } );
   // Hide the child lists initially.
-  $( '.list-expanding_child-list' ).hide();
+  $( subNavItemsSelector ).hide();
 }
 
 // Expose public methods.


### PR DESCRIPTION
Fixed issue displaying About Overview page on mobile

## Changes
- Updated src/static/js/modules/mobile-primary-nav.js to display sub-nav heading on desktop.
- Updated src/static/js/modules/mobile-primary-nav.js to display sub-nav heading on mobile.
-  Updated  src/static/css/nav-primary.less  to always display sub-nav heading and override background color.

## Testing
- Visit 'http://localhost:7000/' on mobile and invoke the navigation. Observe the About Overview nav item.

## Screenshots
<img width="311" alt="screen shot 2015-07-27 at 4 41 37 pm" src="https://cloud.githubusercontent.com/assets/1696212/8917325/5d77865a-347f-11e5-8df9-6d83f12faf14.png">

## Review
@jimmynotjim
@anselmbradford 
@KimberlyMunoz 