### PR TITLE
Fixed issue with Active_Filters macro 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Fixed MobileOnlyExpandable error on office page.
 - Normalized use of jinja quotes to single quote
 - Fixed existing linting errors and warnings in browser tests
+- Fixed issue with active filters on`/the-bureau/leadership-calendar/print/` page.
 
 ## 3.0.0-2.0.0 - 2015-07-24
 

--- a/src/_includes/macros/active-filters.html
+++ b/src/_includes/macros/active-filters.html
@@ -1,0 +1,143 @@
+
+{# ==========================================================================
+
+   active_filters()
+
+   Description:
+
+   Create active filters markup when given:
+
+   filters:  An array of the filters that you want.
+             Possible values: activity_category, author, calendar, category,
+             range_date, tags.
+
+   query:    The post type query object like `queries.posts`.
+             Needed so we can utilize `query.possible_values_for()` to get access to
+             the values of each filter.
+
+   posts:    The query object search results.
+             Used to show how many filtered items resulted.
+
+   doc_type: The type of document that posts contains.
+             Mainly used for conditionals needed to support newsroom filters.
+
+   options:  An object of non-required options that can be overriden.
+
+   options.expand_label:          The label you want on the expandable button.
+
+   options.show_unfiltered_count: Allows you to enable the count
+                                  label when no filters are applied.
+
+   options.show_filters_label:    Allows you to disable showing the count label.
+
+   options.use_list :             Boolean indicating wether to use list markup.
+
+   ========================================================================== #}
+
+{% macro render(posts, filters, options) %}
+
+{% set active_filters = [] %}
+{% set active_date_filters = [] %}
+{% set use_list = options.use_list or false %}
+
+{# This is a hack. `_ignore` is a variable we will never use but we can use
+   its var expression as a means to write the expression needed to update
+   `active_date_filters`. #}
+{%- for filter in filters %}
+    {%- if filter == 'range_date' -%}
+        {% set _ignore = active_date_filters.extend(selected_filters_for_field('range_date_gte')) %}
+        {% set _ignore = active_date_filters.extend(selected_filters_for_field('range_date_lte')) %}
+    {%- elif filter == 'activity_category' -%}
+        {% set _ignore = active_filters.extend(selected_filters_for_field('type')) %}
+        {% set _ignore = active_filters.extend(selected_filters_for_field('category')) %}
+    {%- else -%}
+        {% set _ignore = active_filters.extend(selected_filters_for_field(filter)) %}
+    {%- endif -%}
+{% endfor -%}
+
+{%- set active_filters_total = active_filters|length + active_date_filters|length -%}
+
+{%- if active_filters_total > 0 and use_list == false -%}
+  {{ _active_filters_notification() }}
+{% elif use_list == true %}
+  {{ _active_filters_list(active_filters_total, active_filters, active_date_filters, options) }}
+{% endif %}
+
+{% endmacro %}
+
+
+{# A helper macro to display the active_filters as a list.
+  ========================================================================== #}
+{% macro _active_filters_list(active_filters_total, active_filters, active_date_filters, options) %}
+{%- if active_filters_total > 0 -%}
+    <ul class="filtered-by filtered-by__align-with-btn list__horizontal">
+        {%- if options.show_filters_label -%}
+        <li class="list_item filtered-by_header">
+        {%- if posts|list|length > 0 -%}
+            {{ posts.total }} filtered result{{ 's' if posts.total > 1 }} for
+        {%- else -%}
+            No results for
+        {%- endif -%}
+        </li>
+        {%- endif %}
+    {%- for filter in active_filters %}
+        <li class="list_item filtered-by_filter">
+            {{ 'Blog' if filter == 'post' else filter }}
+        {%- if not loop.last -%}
+            ,
+        {%- elif active_date_filters|length > 0 -%}
+            ,
+        {%- endif %}
+        </li>
+    {% endfor %}
+    {%- if active_date_filters|length > 0 -%}
+        <li class="list_item filtered-by_filter">
+        {%- for filter in active_date_filters %}
+            {{ filter|date("%B %Y") }}
+            {{ '&ndash;'|safe if not loop.last }}
+        {%- endfor -%}
+        </li>
+    {%- endif %}
+    </ul>
+{%- else -%}
+    {% if options.show_unfiltered_count and options.show_filters_label %}
+    <ul class="filtered-by filtered-by__align-with-btn list__horizontal">
+        <li class="list_item">
+            <span class="filtered-by_header">
+                {{ posts.total }} results
+            </span>
+        </li>
+    </ul>
+    {% endif %}
+{%- endif -%}
+{% endmacro %}
+
+
+{# A helper macro to display the active_filters as a notification.
+   ========================================================================== #}
+{% macro _active_filters_notification() %}
+    {%- if posts|list|length > 0 -%}
+        {% set text =  posts.total | string
+                    + ' filtered result'
+                    + ('s' if posts.total > 1 else '') %}
+        {% set type = 'success' %}
+    {%- else -%}
+      {% macro _no_results_text () %}
+          Sorry, there were no results based
+          on your filter selections.
+          <p class="short-desc u-mt15">Please clear the filter or
+            change your selections and try again.
+          </p>
+      {% endmacro %}
+      {% set text = _no_results_text() %}
+      {% set type = 'warning' %}
+    {%- endif -%}
+
+    {% import 'macros/notification.html' as notification %}
+    <div class='filtered-by'>
+    {{ notification.render({
+        'text': text,
+        'type': type
+    }) }}
+  </div>
+{% endmacro %}

--- a/src/_includes/post-macros.html
+++ b/src/_includes/post-macros.html
@@ -262,36 +262,9 @@
 }) -%}
 {%- endif -%}
 
-{#- Determine the active filters. -#}
-{%- set active_filters = [] -%}
-{%- set active_date_filters = [] -%}
-
-{# This is a hack. `_ignore` is a variable we will never use but we can use
-   its var expression as a means to write the expression needed to update
-   `active_date_filters`. #}
-{%- for filter in filters %}
-    {%- if filter == 'range_date' -%}
-        {% set _ignore = active_date_filters.extend(selected_filters_for_field('range_date_gte')) %}
-        {# Only show one date if the start & end range values are the same. #}
-        {%- if selected_filters_for_field('range_date_gte') != selected_filters_for_field('range_date_lte') -%}
-          {% set _ignore = active_date_filters.extend(selected_filters_for_field('range_date_lte')) %}
-        {%- endif -%}
-    {%- elif filter == 'activity_category' -%}
-        {% set _ignore = active_filters.extend(selected_filters_for_field('type')) %}
-        {% set _ignore = active_filters.extend(selected_filters_for_field('category')) %}
-    {%- else -%}
-        {% set _ignore = active_filters.extend(selected_filters_for_field(filter)) %}
-    {%- endif -%}
-{% endfor -%}
-
-{%- set active_filters_total = active_filters|length + active_date_filters|length -%}
-
-{%- set filter_dict = {
-    'filters': filters,
-    'active_filters_total': active_filters_total
-} -%}
-
-{% set is_expanded = active_filters_total > 0
+{%- import 'macros/active-filters.html' as active_filters with context %}
+{% set active_filters_markup = active_filters.render(posts, filters, user_options) %}
+{% set is_expanded = active_filters_markup | trim | length > 0
                      and options.show_current_filters
 %}
 
@@ -321,43 +294,7 @@
 </div>
 
 {%- if options.show_current_filters -%}
-    {{ active_filters_helper(posts, filter_dict, options) }}
-{%- endif -%}
-
-{% endmacro %}
-
-
-{# A helper macro for filters()
-   ========================================================================== #}
-{% macro active_filters_helper(posts, filter_dict, options) %}
-{%- set filters = filter_dict.filters -%}
-{%- set active_filters_total = filter_dict.active_filters_total -%}
-{% import 'macros/notification.html' as notification %}
-
-{%- if active_filters_total > 0 and options.show_filters_label -%}
-    <div class="filtered-by">
-        {%- if posts|list|length > 0 -%}
-            {% set text =  posts.total | string
-                        + ' filtered result'
-                        + ('s' if posts.total > 1 else '') %}
-            {% set type = 'success' %}
-        {%- else -%}
-            {% macro _no_results_text (posts, filter_dict, options) %}
-                Sorry, there were no results based
-                on your filter selections.
-                <p class="short-desc u-mt15">Please clear the filter or
-                  change your selections and try again.
-                </p>
-            {% endmacro %}
-            {% set text = _no_results_text() %}
-            {% set type = 'warning' %}
-        {%- endif -%}
-
-        {{ notification.render({
-            'text': text,
-            'type': type
-        }) }}
-    </div>
+{{ active_filters_markup }}
 {%- endif -%}
 
 {% endmacro %}

--- a/src/the-bureau/leadership-calendar/print/index.html
+++ b/src/the-bureau/leadership-calendar/print/index.html
@@ -19,7 +19,7 @@
 
 {% block body %}
 
-    {% from 'post-macros.html' import active_filters as active_filters with context %}
+    {% import 'macros/active-filters.html' as active_filters with context %}
     {% import 'leadership-calendar-table.html' as calendar %}
 
     <main class="content print" id="main" role="main">
@@ -29,8 +29,10 @@
                     {% set query = queries.calendar_event -%}
                     {%- set posts = query.search(size=20000) -%}
                     <h1 class="superheader">Leadership Calendar</h1>
-                    {{ active_filters(posts, ['calendar', 'range_date'], {
-                        'show_filters_label': false, 'show_unfiltered_count': true
+                    {{ active_filters.render(posts, ['calendar', 'range_date'], {
+                        'show_filters_label': false,
+                        'show_unfiltered_count': true,
+                        'use_list'  : true
                     }) }}
                 </div>
                 {{ calendar.render(posts, {


### PR DESCRIPTION
Fixed issue with Active_Filters macro on the `/leadership-calendar/print/` page. Macro relied upon legacy code in which I removed when working on filters. This PR creates a separate activity filters macro and restores the legacy code.

## Changes
- Added  `src/_includes/macros/active-filters.html` to separate logic and fix issue on  `/leadership-calendar/print/` page.
- Updated `src/_includes/post-macros.htm`  to separate logic.
- Updated `src/the-bureau/leadership-calendar/print/index.html` to fix activity filter rendering issue.

## Testing
- Visit 'http://localhost:7000/the-bureau/leadership-calendar/print/?filter_calendar=Richard+Cordray&filter_range_date_gte=2014-01&filter_range_date_lte=2014-02' and observe the majestic leadership calendar with filters.

## Screenshots
<img width="1367" alt="screen shot 2015-07-28 at 8 10 01 am" src="https://cloud.githubusercontent.com/assets/1696212/8931053/70f868b6-3501-11e5-816d-786017fcb976.png">


## Review
@jimmynotjim
@anselmbradford 
@KimberlyMunoz 
@dpford 