### PR TITLE
Converts mousedown to click event on simple table row links

### DIFF
--- a/src/static/js/modules/simple-table-row-links.js
+++ b/src/static/js/modules/simple-table-row-links.js
@@ -12,7 +12,7 @@ function init() {
   var tables = document.querySelectorAll( '.simple-table__row-links' );
 
   for ( var i = tables.length - 1; i >= 0; i-- ) {
-    tables[i].addEventListener( 'mousedown', _tableClicked, false );
+    tables[i].addEventListener( 'click', _tableClicked, false );
   }
 }
 


### PR DESCRIPTION
Converts click event to `click` from `mousedown`

## Changes

- Converts click event to `click` from `mousedown` on simple table.

## Testing

- @jimmynotjim 
- @KimberlyMunoz 
- @sebworks 