### PR TITLE
Default grunt task fix

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -514,5 +514,5 @@ module.exports = function(grunt) {
   });
   grunt.registerTask('test', ['lintjs', 'mocha_istanbul']);
   grunt.registerTask('build', ['vendor', 'css', 'js', 'copy']);
-  grunt.registerTask('default', ['test', 'build']);
+  grunt.registerTask('default', ['build', 'test']);
 };


### PR DESCRIPTION
Oops, realized since tests run on the production site, the `test` task needs to run after `build`, not before.

## Changes

- Moves `test` task after `build` task in grunt default task. 

## Review

- @jimmynotjim 
- @KimberlyMunoz 
- @sebworks 