### PR TITLE
Changing Bullet Points on Office Pages

### DIFF
--- a/src/static/css/pages/offices.less
+++ b/src/static/css/pages/offices.less
@@ -20,6 +20,7 @@
 
         ul {
             .list__branded();
+            padding: 0 0 0 20px;
         }
     }
 }

--- a/src/sub-pages/_single.html
+++ b/src/sub-pages/_single.html
@@ -34,8 +34,7 @@
     {% if sub_page.body_content or sub_page.related_links %}
     <section class="block
                     block__padded-top
-                    block__border-top
-                    sub-page_content-markup">
+                    block__border-top">
 
         {% if sub_page.related_links %}
         <section class="block
@@ -61,7 +60,9 @@
             {% endif %}
         {% endfor %}
 
-        {{ content.markup | safe}}
+        <div class="sub-page_content-markup">
+            {{ content.markup | safe}}
+        </div>
     </section>
     {% endif %}
 


### PR DESCRIPTION
Feedback from @ajbush:

> Across the site there are different stylings of bullet points. We would like to make these as cohesive as possible by:
>
> -making bullet points green
> -not adding indentation to bullets so that they will align with the content block they exist in.

Luckily, @anselmbradford already took care of point 1, but this PR adjusts the indentation to bring them in with what design wants.

## Preview

![image](https://cloud.githubusercontent.com/assets/1860176/8940264/fc2c244c-3536-11e5-9b3c-b1bdf92f2ee5.png)

## Notes
- To be merged in the next sprint.

 