### PR TITLE
Minor Sprint 32-2 fixes

### DIFF
--- a/src/_includes/macros/sub_pages.html
+++ b/src/_includes/macros/sub_pages.html
@@ -32,7 +32,7 @@
                   <div class="content-l
                               content-l__main
                               content-l__large-gutters
-                              expandables-group">
+                              ">
         {% endif %}
                       <div class="expandable
                                   expandable__expanded
@@ -44,7 +44,10 @@
                                   #}
                                   content-l_col-1-2
                                   ">
-                      <button class="expandable_header expandable_target u-show-on-mobile">
+                      <button class="expandable_header
+                                     expandable_header__jump-link
+                                     expandable_target
+                                     u-show-on-mobile">
                           {% if expandable_title %}
                               <span class="expandable_header-left expandable_label">
                                   {{ expandable_title | safe }}

--- a/src/_includes/templates/nav/about-us-media.html
+++ b/src/_includes/templates/nav/about-us-media.html
@@ -1,5 +1,5 @@
 <a href="/the-bureau/">
-    <img src="../../static/img/nav-about-us-video.png"
+    <img src="/static/img/nav-about-us-video.png"
          alt="About Us video image" />
     <h4 class="short-desc u-mt15">
       The CFPB: Working for you.

--- a/src/careers/application-process/index.html
+++ b/src/careers/application-process/index.html
@@ -42,7 +42,7 @@
                         </p>
                         <footer class="summary_footer">
                             <a class="jump-link jump-link__right" href="/the-bureau/history/">
-                                <span class="icon-link_text">See the history of the CFPB</span>
+                                See the history of the CFPB
                             </a>
                         </footer>
                     </div>

--- a/src/static/css/footer.less
+++ b/src/static/css/footer.less
@@ -183,11 +183,11 @@
     }
 
     &-post {
+        margin-top: unit(@grid_gutter-width / @base-font-size-px, em);
+
         .respond-to-min(@tablet-min {
             padding-top: unit(@grid_gutter-width / @base-font-size-px, em);
-            margin-top: unit(@grid_gutter-width / @base-font-size-px, em);
             border-top: 1px solid @gray-50;
-
         });
 
         .footer_official-website {

--- a/src/the-bureau/index.html
+++ b/src/the-bureau/index.html
@@ -46,11 +46,11 @@
                             We protect American consumers. Allow us to introduce ourselves.
                         </p>
                         <footer class="summary_footer">
-                            <a class="jump-link jump-link__right" href="/history/">
-                                <span class="icon-link_text">See the history of the CFPB</span>
+                            <a class="jump-link jump-link__right" href="/the-bureau/history/">
+                                See the history of the CFPB
                             </a>
                             <a class="jump-link jump-link__right" href="/the-bureau/about-rich-cordray/">
-                                <span class="icon-link_text">Meet Director Richard Cordray</span>
+                                Meet Director Richard Cordray
                             </a>
                         </footer>
                     </div>


### PR DESCRIPTION
Fixes minor issues for Sprint-32-2

## Changes
- Updated  `src/_includes/macros/sub_pages.html` to fix issue with expendables on Office pages.
- Updated `src/static/css/footer.less`  to fix issue with footer margin.
- Updated `src/the-bureau/index.html`  and `src/careers/application-process/index.html` to fix double link issue on mobile.
- Updated  `src/_includes/templates/nav/about-us-media.html` to fix issue with relative path for About-Us image.

## Screenshots
<img width="425" alt="screen shot 2015-07-29 at 9 39 07 am" src="https://cloud.githubusercontent.com/assets/1696212/8958916/b6460bc4-35d5-11e5-9af5-1da1fff7d728.png">
<img width="387" alt="screen shot 2015-07-29 at 9 38 41 am" src="https://cloud.githubusercontent.com/assets/1696212/8958918/b64be404-35d5-11e5-83dd-216548a4f9d9.png">
<img width="392" alt="screen shot 2015-07-29 at 9 38 18 am" src="https://cloud.githubusercontent.com/assets/1696212/8958917/b64b10c4-35d5-11e5-9790-e95d38dcb568.png">

## Review
@jimmynotjim
@anselmbradford 
@KimberlyMunoz 