### PR TITLE
Fixes DF-2307 - About Us text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
   Chrome. Now the desktop test only runs the desktop spec.
 - Separated `grunt test` task from `grunt build`
   and made default task test + build.
+- Site's "About" text to "About Us".
 
 ### Removed
 - Removed requestAnimationFrame polyfill.

--- a/src/_includes/templates/nav/_vars-primary-nav.html
+++ b/src/_includes/templates/nav/_vars-primary-nav.html
@@ -16,7 +16,7 @@
     nav_tbd,
     nav_tbd,
     nav_tbd,
-    ('About', '/about-us/',  'About Overview', about_us_media , [
+    ('About Us', '/about-us/',  'About Us Overview', about_us_media , [
         (
             ('/the-bureau/', 'the-bureau', 'The Bureau'),
             ('/budget/', 'budget', 'Budget and Strategy'),

--- a/src/index.html
+++ b/src/index.html
@@ -29,7 +29,7 @@
         'value': '0%'
     },
     {
-        'name': 'About',
+        'name': 'About Us',
         'value': '80%'
     }
 ] %}


### PR DESCRIPTION
Updates text from "About" to "About Us"

## Changes

- Site's "About" text to "About Us".

## Testing

- Visit the homepage and observe the glory of the About Us text in the progress graph and the megamenu! 

## Review

- @sebworks 
- @KimberlyMunoz 
- @jimmynotjim 

## Preview

![screen shot 2015-07-30 at 10 21 59 am](https://cloud.githubusercontent.com/assets/704760/8985419/4fad54e6-36a5-11e5-915d-e4894aca5fa5.png)

![screen shot 2015-07-30 at 10 21 53 am](https://cloud.githubusercontent.com/assets/704760/8985420/4fb08fbc-36a5-11e5-9dc1-b8a4a345f214.png)
