### PR TITLE
Changes clear to clean in setup.sh

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -25,8 +25,8 @@ init(){
   fi
 }
 
-# Clear project dependencies.
-clear(){
+# Clean project dependencies.
+clean(){
   # If the node and bower directories already exist,
   # clear them so we know we're working with a clean
   # slate of the dependencies listed in package.json
@@ -54,6 +54,6 @@ build(){
 }
 
 init
-clear
+clean
 install
 build


### PR DESCRIPTION
Changes `clear` task to `clean` in `setup.sh` to be more consistent with the wording use in grunt, gulp, etc.

## Changes

- Changes `clear` task to `clean` in `setup.sh`.

## Testing

- `./setup.sh` should still work as expected.

## Review

- @jimmynotjim 
- @sebworks 
- @KimberlyMunoz 

## Notes

- Per https://github.com/cfpb/front-end/issues/49#issuecomment-125229214