### PR TITLE
Fixing margins on footer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Normalized use of jinja quotes to single quote
 - Fixed a large chunk of the existing linting errors and warnings
 - Fixed issue with active filters on`/the-bureau/leadership-calendar/print/` page.
+- Fixed margins on site footer
 
 
 ## 3.0.0-2.0.0 - 2015-07-24

--- a/src/static/css/footer.less
+++ b/src/static/css/footer.less
@@ -163,9 +163,12 @@
         .respond-to-min(@tablet-min {
             .grid_column(8);
             border-right: 1px solid @gray-50;
+            border-left: 0;
 
             .footer_col {
                 .grid_column(6);
+                border-left: 0;
+                border-right: 0;
             }
         });
 


### PR DESCRIPTION
From @ajbush:

>Ideally all content in the first column where "FOIA, "Plain Writing", "Privacy, Policy, & Legal Notices" live will align left instead of having a slight indent.

## Changes

- Fixes footer to be flush with sides.

## Testing

- Look at it!

## Preview

![image](https://cloud.githubusercontent.com/assets/1860176/8991755/ab0ffbf4-36c8-11e5-816d-c16036b0d868.png)


[Preview this PR without the whitespace changes](?w=0)

## Notes

- Closes DF-2284
