### PR TITLE
Lint fixes

### DIFF
--- a/test/browser_tests/page_objects/page_office.js
+++ b/test/browser_tests/page_objects/page_office.js
@@ -3,13 +3,13 @@
 function OfficePage() {
   this.get = function( officePage ) {
     var examplePages = {
-        CFPBOmbudsman:              '/offices/cfpb-ombudsman/',
-        FOIARequests:               '/offices/foia-requests/',
-        OpenGovernment:             '/offices/open-government/',
-        PaymentsToHarmedConsumer:   '/offices/payments-to-harmed-consumers/',
-        PlainWriting:               '/offices/plain-writing/',
-        Privacy:                    '/offices/privacy/',
-        ProjectCatalyst:            '/offices/project-catalyst/'
+        CFPBOmbudsman:            '/offices/cfpb-ombudsman/',
+        FOIARequests:             '/offices/foia-requests/',
+        OpenGovernment:           '/offices/open-government/',
+        PaymentsToHarmedConsumer: '/offices/payments-to-harmed-consumers/',
+        PlainWriting:             '/offices/plain-writing/',
+        Privacy:                  '/offices/privacy/',
+        ProjectCatalyst:          '/offices/project-catalyst/'
     };
 
     browser.get( examplePages[officePage] );
@@ -21,7 +21,7 @@ function OfficePage() {
 
   this.introText = element( by.css( '.office_intro-text' ) );
 
-  this.subscription = element( by.css( '.qa-subscription') );
+  this.subscription = element( by.css( '.qa-subscription' ) );
 
   this.topStoryHead = element( by.css( '.qa-top-story-head' ) );
 

--- a/test/browser_tests/spec_suites/shared/shared_office-project-catalyst.js
+++ b/test/browser_tests/spec_suites/shared/shared_office-project-catalyst.js
@@ -37,7 +37,8 @@ describe( 'The Project Catalyst Page', function() {
   it( 'should include top story link', function() {
     expect( page.topStoryLink.getText() ).toContain( 'Email us at' );
     expect( page.topStoryLink.getAttribute( 'href' ) )
-      .toBe( 'mailto:ProjectCatalyst@cfpb.gov?subject=I%27ve%20got%20an%20idea...' );
+      .toBe( 'mailto:ProjectCatalyst@cfpb.gov' +
+             '?subject=I%27ve%20got%20an%20idea...' );
   } );
 
   it( 'should NOT have resource image', function() {


### PR DESCRIPTION
Accidentally introduced some linting warnings in https://github.com/cfpb/cfgov-refresh/pull/786

## Changes

- Fixed key-spacing and max-len warnings in office tests.

## Testing

- `gulp lint`

## Review

- @KimberlyMunoz 
- @sebworks 