### PR TITLE
DF-2255 - adds accessibility page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Added gulp config file to lay out configs for each task
 - Added gulp tasks split up into their own files
 - Adds integration tests for `/offices/*` pages accessible through site's menu.
+- Adds Accessibility page to footer and adds Accessibility page tests.
 
 ### Changed
 - Updated primary navigation to match new mega menu design.

--- a/src/_includes/templates/footer.html
+++ b/src/_includes/templates/footer.html
@@ -103,8 +103,8 @@
             <div class="footer_col">
                 <ul class="footer_list">
                     <li class="list_item">
-                        <a class="list_link u-link__disabled">
-                            TBD Content
+                        <a class="list_link" href="/offices/accessibility/">
+                            Accessibility
                         </a>
                     </li>
                     <li class="list_item">

--- a/test/browser_tests/page_objects/page_office.js
+++ b/test/browser_tests/page_objects/page_office.js
@@ -2,14 +2,16 @@
 
 function OfficePage() {
   this.get = function( officePage ) {
+    var baseUrl = '/offices/';
     var examplePages = {
-        CFPBOmbudsman:            '/offices/cfpb-ombudsman/',
-        FOIARequests:             '/offices/foia-requests/',
-        OpenGovernment:           '/offices/open-government/',
-        PaymentsToHarmedConsumer: '/offices/payments-to-harmed-consumers/',
-        PlainWriting:             '/offices/plain-writing/',
-        Privacy:                  '/offices/privacy/',
-        ProjectCatalyst:          '/offices/project-catalyst/'
+        Accessibility:            baseUrl + 'accessibility/',
+        CFPBOmbudsman:            baseUrl + 'cfpb-ombudsman/',
+        FOIARequests:             baseUrl + 'foia-requests/',
+        OpenGovernment:           baseUrl + 'open-government/',
+        PaymentsToHarmedConsumer: baseUrl + 'payments-to-harmed-consumers/',
+        PlainWriting:             baseUrl + 'plain-writing/',
+        Privacy:                  baseUrl + 'privacy/',
+        ProjectCatalyst:          baseUrl + 'project-catalyst/'
     };
 
     browser.get( examplePages[officePage] );

--- a/test/browser_tests/spec_suites/shared/shared_office-accessibility.js
+++ b/test/browser_tests/spec_suites/shared/shared_office-accessibility.js
@@ -2,36 +2,36 @@
 
 var Office = require( '../../page_objects/page_office.js' );
 
-describe( 'The CFPB Ombudsman Office Page', function() {
+describe( 'The Accessibility Office Page', function() {
   var page;
 
   beforeEach( function() {
     page = new Office();
-    page.get( 'CFPBOmbudsman' );
+    page.get( 'Accessibility' );
   } );
 
   it( 'should properly load in a browser', function() {
-    expect( page.pageTitle() ).toBe( 'CFPB Ombudsman' );
+    expect( page.pageTitle() ).toBe( 'Accessibility' );
   } );
 
   it( 'should include main title', function() {
-    expect( page.mainTitle.getText() ).toBe( 'CFPB Ombudsman' );
+    expect( page.mainTitle.getText() ).toBe( 'Accessibility' );
   } );
 
   it( 'should include intro text', function() {
-    expect( page.introText.getText() ).toContain( 'CFPB Ombudsman' );
+    expect( page.introText.getText() ).toContain( 'Rehabilitation Act' );
   } );
 
   it( 'should NOT include subscription', function() {
     expect( page.subscription.isPresent() ).toBe( false );
   } );
 
-  it( 'should include top story head', function() {
-    expect( page.topStoryHead.getText() ).toBe( 'Our Role' );
+  it( 'should NOT include top story head', function() {
+    expect( page.topStoryHead.isPresent() ).toBe( false );
   } );
 
   it( 'should NOT include top story description', function() {
-    expect( page.topStoryDesc.getText() ).toContain( 'ombudsman principles' );
+    expect( page.topStoryDesc.isPresent() ).toBe( false );
   } );
 
   it( 'should NOT include top story link', function() {
@@ -54,7 +54,7 @@ describe( 'The CFPB Ombudsman Office Page', function() {
     expect( page.resourceLink.isPresent() ).toBe( false );
   } );
 
-  it( 'should have subpages', function() {
+  it( 'should NOT have subpages', function() {
     expect( page.subpages.isPresent() ).toBe( true );
   } );
 
@@ -62,8 +62,8 @@ describe( 'The CFPB Ombudsman Office Page', function() {
     expect( page.officeContent.isPresent() ).toBe( false );
   } );
 
-  it( 'should have office tags', function() {
-    expect( page.officeTags.isPresent() ).toBe( true );
+  it( 'should NOT have office tags', function() {
+    expect( page.officeTags.isPresent() ).toBe( false );
   } );
 
   it( 'should have office contacts', function() {


### PR DESCRIPTION
Adds accessibility page.

## Additions

- Adds link to accessibility page in footer.
- Adds acceptance tests for accessibility page in form of offices pattern.

## Testing

- Reindex sheer, visit homepage, navigate to footer. Find `Accessibility` link and open to reach page. 
- Run tests with `gulp test`

## Review

- @KimberlyMunoz 
- @sebworks 

## Screenshots

<img width="1258" alt="screen shot 2015-08-03 at 3 57 07 pm" src="https://cloud.githubusercontent.com/assets/704760/9046392/52638c0e-39f8-11e5-9106-53bffdcee375.png">

## Todos

- Add tests for subpages.
