### PR TITLE
Adds accessibility sub-page tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,9 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Added gulp tasks split up into their own files
 - Added acceptance tests for `/offices/*` pages accessible through site's menu.
 - Added Accessibility page to footer and adds Accessibility page tests.
+- Added acceptance tests for `/sub-pages/*`.
+- Added `activities-block` shared template for activity feed
+  on offices and sub-pages.
 
 ### Changed
 - Updated primary navigation to match new mega menu design.

--- a/src/_includes/macros/activities-block.html
+++ b/src/_includes/macros/activities-block.html
@@ -1,0 +1,32 @@
+
+{# ==========================================================================
+
+   activities_block.render()
+
+   ==========================================================================
+
+   Description:
+
+   Render activities block when given:
+
+   tags: List of activities tags.
+
+   ========================================================================== #}
+
+{% macro render(tags) %}
+{% from 'macros/util/text.html' import string_length as string_length %}
+<section class="block
+                block__bg
+                block__flush-sides
+                block__flush-top
+                block__flush-bottom
+                qa-tags">
+    {% import 'macros/activity-snippets.html' as activity_snippets with context %}
+    {% set activities_feed = activity_snippets.render(tags, include_date_flag=true, number_columns=2) %}
+    {% include 'templates/activities-feed.html' %}
+    <a class="jump-link jump-link__underline"
+       href="/activity-log/{{ ('?filter_tags=' ~ tags | join('&') ) if tags }}">
+        View all of our activities
+    </a>
+</section>
+{% endmacro %}

--- a/src/offices/_single.html
+++ b/src/offices/_single.html
@@ -150,20 +150,8 @@
     {% endif %}
 
     {% if office.tags %}
-    <section class="block
-                    block__bg
-                    block__flush-sides
-                    block__flush-top
-                    block__flush-bottom
-                    qa-office-tags">
-        {% import 'macros/activity-snippets.html' as activity_snippets with context %}
-        {% set activities_feed = activity_snippets.render(office.tags, include_date_flag=true, number_columns=2) %}
-        {% include 'templates/activities-feed.html' %}
-        <a class="jump-link jump-link__underline"
-           href="/activity-log/{{ ('?filter_tags=' ~ office.tags | join('&') ) if office.tags }}">
-            View all of our activities
-        </a>
-    </section>
+        {% import 'macros/activities-block.html' as activities_block with context %}
+        {{ activities_block.render(office.tags) }}
     {% endif %}
 
     {% include 'templates/office-contact.html' %}

--- a/src/sub-pages/_single.html
+++ b/src/sub-pages/_single.html
@@ -34,16 +34,22 @@
     {% if sub_page.body_content or sub_page.related_links %}
     <section class="block
                     block__padded-top
-                    block__border-top">
+                    block__border-top
+                    qa-body-content">
 
         {% if sub_page.related_links %}
         <section class="block
                         block__flush-top
-                        block_padded-bottom">
+                        block_padded-bottom
+                        qa-related-links">
             <h3>Related Documents</h3>
             <ul class="list list__links">
             {% for link in sub_page.related_links %}
-                <li class="list_item"><a href="{{link.url}}" class="list_link">{{ link.label }}</a></li>
+                <li class="list_item">
+                    <a href="{{link.url}}" class="list_link">
+                        {{ link.label }}
+                    </a>
+                </li>
             {% endfor %}
             </ul>
         </section>
@@ -73,7 +79,8 @@
 
     {% if sub_page.related_faq %}
     <section class="block
-                    block__flush-top">
+                    block__flush-top
+                    qa-related-faq">
         {% set related_faq = get_document('faq', sub_page.related_faq) %}
         {% set faq_title = vars.office.title if sub_page.slug == 'frequently-asked-questions'
                                              else sub_page.title
@@ -87,19 +94,8 @@
     {% endif %}
 
     {% if sub_page.tags %}
-    <section class="block
-                    block__flush-sides
-                    block__bg
-                    block__flush-top
-                    block__flush-bottom">
-        {% import 'macros/activity-snippets.html' as activity_snippets with context %}
-        {% set activities_feed = activity_snippets.render(sub_page.tags, include_date_flag=true, number_columns=2)%}
-        {% include 'templates/activities-feed.html' %}
-        <a class="jump-link jump-link__underline"
-           href="/activity-log/{{ ('?filter_tags=' ~ sub_page.tags | join('&') ) if sub_page.tags }}">
-            View all of our activities
-        </a>
-    </section>
+        {% import 'macros/activities-block.html' as activities_block with context %}
+        {{ activities_block.render(sub_page.tags) }}
     {% endif %}
 
     {% set office = vars.office %}

--- a/test/browser_tests/page_objects/page_office.js
+++ b/test/browser_tests/page_objects/page_office.js
@@ -1,7 +1,7 @@
 'use strict';
 
 function OfficePage() {
-  this.get = function( officePage ) {
+  this.get = function( page ) {
     var baseUrl = '/offices/';
     var examplePages = {
         Accessibility:            baseUrl + 'accessibility/',
@@ -14,7 +14,7 @@ function OfficePage() {
         ProjectCatalyst:          baseUrl + 'project-catalyst/'
     };
 
-    browser.get( examplePages[officePage] );
+    browser.get( examplePages[page] );
   };
 
   this.pageTitle = function() { return browser.getTitle(); };
@@ -43,7 +43,7 @@ function OfficePage() {
 
   this.officeContent = element( by.css( '.qa-office-content h2' ) );
 
-  this.officeTags = element( by.css( '.qa-office-tags h1' ) );
+  this.contentTags = element( by.css( '.qa-tags' ) );
 
   this.officeContact = element( by.css( '.office_contact' ) );
 

--- a/test/browser_tests/page_objects/page_sub-pages.js
+++ b/test/browser_tests/page_objects/page_sub-pages.js
@@ -1,0 +1,38 @@
+'use strict';
+
+function SubPage() {
+  this.get = function( page ) {
+    var baseUrl = '/sub-pages/';
+    var examplePages = {
+        SubmitAnAccommodationRequest:
+          baseUrl + 'submit-an-accommodation-request/',
+        SocialMediaAccessibility: baseUrl + 'social-media-accessibility/',
+        FileAFormalAccessibilityComplaintOrWebsiteFeedback:
+          baseUrl + 'file-a-formal-accessibility-complaint-or-website-feedback/'
+    };
+
+    browser.get( examplePages[page] );
+  };
+
+  this.pageTitle = function() { return browser.getTitle(); };
+
+  this.pageContent = element( by.css( '.sub-page_content' ) );
+
+  this.relatedLink = element( by.css( '.qa-related-links li' ) );
+
+  this.contentForm = element( by.css( '.qa-body-content form' ) );
+
+  this.contentMarkup = element( by.css( '.sub-page_content-markup' ) );
+
+  this.subpages = element( by.css( '.qa-subpage h2' ) );
+
+  this.relatedFAQ = element( by.css( '.qa-related-faq' ) );
+
+  this.contentTags = element( by.css( '.qa-tags' ) );
+
+  this.officeContact = element( by.css( '.office_contact' ) );
+
+  this.officeContactEmail = element( by.css( '.office_contact a[href^="mailto:"]' ) );
+}
+
+module.exports = SubPage;

--- a/test/browser_tests/spec_suites/shared/shared_office-accessibility.js
+++ b/test/browser_tests/spec_suites/shared/shared_office-accessibility.js
@@ -62,8 +62,8 @@ describe( 'The Accessibility Office Page', function() {
     expect( page.officeContent.isPresent() ).toBe( false );
   } );
 
-  it( 'should NOT have office tags', function() {
-    expect( page.officeTags.isPresent() ).toBe( false );
+  it( 'should NOT have tags', function() {
+    expect( page.contentTags.isPresent() ).toBe( false );
   } );
 
   it( 'should have office contacts', function() {

--- a/test/browser_tests/spec_suites/shared/shared_office-cfpb-ombudsman.js
+++ b/test/browser_tests/spec_suites/shared/shared_office-cfpb-ombudsman.js
@@ -62,8 +62,8 @@ describe( 'The CFPB Ombudsman Office Page', function() {
     expect( page.officeContent.isPresent() ).toBe( false );
   } );
 
-  it( 'should have office tags', function() {
-    expect( page.officeTags.isPresent() ).toBe( true );
+  it( 'should have tags', function() {
+    expect( page.contentTags.isPresent() ).toBe( true );
   } );
 
   it( 'should have office contacts', function() {

--- a/test/browser_tests/spec_suites/shared/shared_office-foia-requests.js
+++ b/test/browser_tests/spec_suites/shared/shared_office-foia-requests.js
@@ -62,8 +62,8 @@ describe( 'The Office of FOIA Requests Page', function() {
     expect( page.officeContent.isPresent() ).toBe( false );
   } );
 
-  it( 'should have office tags', function() {
-    expect( page.officeTags.isPresent() ).toBe( true );
+  it( 'should have tags', function() {
+    expect( page.contentTags.isPresent() ).toBe( true );
   } );
 
   it( 'should have office contacts', function() {

--- a/test/browser_tests/spec_suites/shared/shared_office-open-government.js
+++ b/test/browser_tests/spec_suites/shared/shared_office-open-government.js
@@ -62,8 +62,8 @@ describe( 'The Open Government Office Page', function() {
     expect( page.officeContent.isPresent() ).toBe( false );
   } );
 
-  it( 'should have office tags', function() {
-    expect( page.officeTags.isPresent() ).toBe( true );
+  it( 'should have tags', function() {
+    expect( page.contentTags.isPresent() ).toBe( true );
   } );
 
   it( 'should NOT have office contacts', function() {

--- a/test/browser_tests/spec_suites/shared/shared_office-payments-to-harmed-consumers.js
+++ b/test/browser_tests/spec_suites/shared/shared_office-payments-to-harmed-consumers.js
@@ -62,8 +62,8 @@ describe( 'The Payments to Harmed Consumers Office Page', function() {
     expect( page.officeContent.isPresent() ).toBe( false );
   } );
 
-  it( 'should have office tags', function() {
-    expect( page.officeTags.isPresent() ).toBe( true );
+  it( 'should have tags', function() {
+    expect( page.contentTags.isPresent() ).toBe( true );
   } );
 
   it( 'should NOT have office contacts', function() {

--- a/test/browser_tests/spec_suites/shared/shared_office-plain-writing.js
+++ b/test/browser_tests/spec_suites/shared/shared_office-plain-writing.js
@@ -62,8 +62,8 @@ describe( 'The Plain Writing Page', function() {
     expect( page.officeContent.isPresent() ).toBe( false );
   } );
 
-  it( 'should have office tags', function() {
-    expect( page.officeTags.isPresent() ).toBe( true );
+  it( 'should have tags', function() {
+    expect( page.contentTags.isPresent() ).toBe( true );
   } );
 
   it( 'should have office contacts', function() {

--- a/test/browser_tests/spec_suites/shared/shared_office-privacy.js
+++ b/test/browser_tests/spec_suites/shared/shared_office-privacy.js
@@ -62,8 +62,8 @@ describe( 'The Privacy Office Page', function() {
     expect( page.officeContent.isPresent() ).toBe( false );
   } );
 
-  it( 'should have office tags', function() {
-    expect( page.officeTags.isPresent() ).toBe( true );
+  it( 'should have tags', function() {
+    expect( page.contentTags.isPresent() ).toBe( true );
   } );
 
   it( 'should have office contacts', function() {

--- a/test/browser_tests/spec_suites/shared/shared_office-project-catalyst.js
+++ b/test/browser_tests/spec_suites/shared/shared_office-project-catalyst.js
@@ -66,8 +66,8 @@ describe( 'The Project Catalyst Page', function() {
       .toBe( 'How we’ll handle your information' );
   } );
 
-  it( 'should have office tags', function() {
-    expect( page.officeTags.isPresent() ).toBe( true );
+  it( 'should have tags', function() {
+    expect( page.contentTags.isPresent() ).toBe( true );
   } );
 
   it( 'should have office contacts', function() {

--- a/test/browser_tests/spec_suites/shared/shared_subpage-accessibility-file-a-formal-accessibility-complaint-or-website-feedback.js
+++ b/test/browser_tests/spec_suites/shared/shared_subpage-accessibility-file-a-formal-accessibility-complaint-or-website-feedback.js
@@ -1,0 +1,59 @@
+'use strict';
+
+var SubPage = require( '../../page_objects/page_sub-pages.js' );
+
+describe( "The Accessibility Office's " +
+          'File A Formal Accessibility Complaint ' +
+          'Or Website Feedback Sub-Page', function() {
+  var page;
+
+  beforeEach( function() {
+    page = new SubPage();
+    page.get( 'FileAFormalAccessibilityComplaintOrWebsiteFeedback' );
+  } );
+
+  it( 'should properly load in a browser', function() {
+    expect( page.pageTitle() )
+      .toBe( 'File a Formal Accessibility Complaint or Website Feedback' );
+  } );
+
+  it( 'should include page content', function() {
+    expect( page.pageContent.getText() ).toContain( 'accessible as possible' );
+  } );
+
+  it( 'should NOT include related link', function() {
+    expect( page.relatedLink.isPresent() ).toBe( false );
+  } );
+
+  it( 'should NOT include a form', function() {
+    expect( page.contentForm.isPresent() ).toBe( false );
+  } );
+
+  it( 'should include content markup', function() {
+    expect( page.contentMarkup.isPresent() ).toBe( true );
+  } );
+
+  it( 'should NOT have subpages', function() {
+    expect( page.subpages.isPresent() ).toBe( false );
+  } );
+
+  it( 'should NOT have related FAQ', function() {
+    expect( page.relatedFAQ.isPresent() ).toBe( false );
+  } );
+
+  it( 'should NOT have related FAQ', function() {
+    expect( page.relatedFAQ.isPresent() ).toBe( false );
+  } );
+
+  it( 'should NOT have tags', function() {
+    expect( page.contentTags.isPresent() ).toBe( false );
+  } );
+
+  it( 'should have office contacts', function() {
+    expect( page.officeContact.isPresent() ).toBe( true );
+    expect( page.officeContactEmail.getText() )
+      .toBe( 'CFPB_Accessibility@consumerfinance.gov' );
+    expect( page.officeContactEmail.getAttribute( 'href' ) )
+      .toBe( 'mailto:CFPB_Accessibility@consumerfinance.gov' );
+  } );
+} );

--- a/test/browser_tests/spec_suites/shared/shared_subpage-accessibility-social-media-accessibility.js
+++ b/test/browser_tests/spec_suites/shared/shared_subpage-accessibility-social-media-accessibility.js
@@ -1,0 +1,57 @@
+'use strict';
+
+var SubPage = require( '../../page_objects/page_sub-pages.js' );
+
+describe( "The Accessibility Office's " +
+          'Social Media Accessibility Sub-Page', function() {
+  var page;
+
+  beforeEach( function() {
+    page = new SubPage();
+    page.get( 'SocialMediaAccessibility' );
+  } );
+
+  it( 'should properly load in a browser', function() {
+    expect( page.pageTitle() ).toBe( 'Social Media Accessibility' );
+  } );
+
+  it( 'should include page content', function() {
+    expect( page.pageContent.getText() ).toContain( 'Twitter and Facebook' );
+  } );
+
+  it( 'should NOT include related link', function() {
+    expect( page.relatedLink.isPresent() ).toBe( false );
+  } );
+
+  it( 'should NOT include a form', function() {
+    expect( page.contentForm.isPresent() ).toBe( false );
+  } );
+
+  it( 'should include content markup', function() {
+    expect( page.contentMarkup.isPresent() ).toBe( true );
+  } );
+
+  it( 'should NOT have subpages', function() {
+    expect( page.subpages.isPresent() ).toBe( false );
+  } );
+
+  it( 'should NOT have related FAQ', function() {
+    expect( page.relatedFAQ.isPresent() ).toBe( false );
+  } );
+
+  it( 'should NOT have related FAQ', function() {
+    expect( page.relatedFAQ.isPresent() ).toBe( false );
+  } );
+
+  it( 'should NOT have tags', function() {
+    expect( page.contentTags.isPresent() ).toBe( false );
+  } );
+
+  it( 'should have office contacts', function() {
+    expect( page.officeContact.isPresent() ).toBe( true );
+    expect( page.officeContactEmail.getText() )
+      .toBe( 'CFPB_Accessibility@consumerfinance.gov' );
+    expect( page.officeContactEmail.getAttribute( 'href' ) )
+      .toBe( 'mailto:CFPB_Accessibility@consumerfinance.gov' );
+  } );
+} );

--- a/test/browser_tests/spec_suites/shared/shared_subpage-accessibility-submit-an-accommodation-request.js
+++ b/test/browser_tests/spec_suites/shared/shared_subpage-accessibility-submit-an-accommodation-request.js
@@ -1,0 +1,57 @@
+'use strict';
+
+var SubPage = require( '../../page_objects/page_sub-pages.js' );
+
+describe( "The Accessibility Office's " +
+          'Submit An Accommodation Request Sub-Page', function() {
+  var page;
+
+  beforeEach( function() {
+    page = new SubPage();
+    page.get( 'SubmitAnAccommodationRequest' );
+  } );
+
+  it( 'should properly load in a browser', function() {
+    expect( page.pageTitle() ).toBe( 'Submit an Accommodation Request' );
+  } );
+
+  it( 'should include page content', function() {
+    expect( page.pageContent.getText() ).toContain( 'CFPB seeks to ensure' );
+  } );
+
+  it( 'should NOT include related link', function() {
+    expect( page.relatedLink.isPresent() ).toBe( false );
+  } );
+
+  it( 'should NOT include a form', function() {
+    expect( page.contentForm.isPresent() ).toBe( false );
+  } );
+
+  it( 'should include content markup', function() {
+    expect( page.contentMarkup.isPresent() ).toBe( true );
+  } );
+
+  it( 'should NOT have subpages', function() {
+    expect( page.subpages.isPresent() ).toBe( false );
+  } );
+
+  it( 'should NOT have related FAQ', function() {
+    expect( page.relatedFAQ.isPresent() ).toBe( false );
+  } );
+
+  it( 'should NOT have related FAQ', function() {
+    expect( page.relatedFAQ.isPresent() ).toBe( false );
+  } );
+
+  it( 'should NOT have tags', function() {
+    expect( page.contentTags.isPresent() ).toBe( false );
+  } );
+
+  it( 'should have office contacts', function() {
+    expect( page.officeContact.isPresent() ).toBe( true );
+    expect( page.officeContactEmail.getText() )
+      .toBe( 'CFPB_Accessibility@consumerfinance.gov' );
+    expect( page.officeContactEmail.getAttribute( 'href' ) )
+      .toBe( 'mailto:CFPB_Accessibility@consumerfinance.gov' );
+  } );
+} );


### PR DESCRIPTION
Adds sub-page tests for accessibility pages.

## Additions

- Adds acceptance tests for accessibility subpages.

## Changes

- Creates `activities-block` template for activities feed on offices and subpages.

## Testing

- Run `gulp test`

## Review

- @sebworks 
- @KimberlyMunoz 