### PR TITLE
Fixes DF-2212 - fixes the bureau isocon sizes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Removed Grunt plugins from package.json
 - Removed the Gruntfile.
 - Removed homepage progress charts and related content and JS.
+- Removed 80px to 120px sizing for the isocon sizes on the-bureau page.
 
 ### Fixed
 - Fixed issue on IE11 when using the dates to filter caused
@@ -105,13 +106,9 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Normalized use of jinja quotes to single quote
 - Fixed a large chunk of the existing linting errors and warnings
 - Fixed issue with active filters on`/the-bureau/leadership-calendar/print/` page.
-<<<<<<< HEAD
-- Fixed margins on site footer
-- Switched the two forms under Privacy to their correct positions
-=======
 - Fixed margins on site footer.
+- Switched the two forms under Privacy to their correct positions
 - Fixed incorrect email href reference on offices contact email link.
->>>>>>> c75f0735681d019a362f5ab4b91f4b1e28376595
 
 
 ## 3.0.0-2.0.0 - 2015-07-24

--- a/src/static/css/pages/bureau.less
+++ b/src/static/css/pages/bureau.less
@@ -32,13 +32,6 @@
         });
     }
 
-    .media_image {
-        width: 120px;
-        .respond-to-max(@tablet-max, {
-            width: 80px;
-        });
-    }
-
     .slick-prev,
     .slick-next {
         // TODO:


### PR DESCRIPTION
Removes small bureau isocon sizes. 

## Removals

- Removed 80px to 120px sizing for the isocon sizes on the-bureau page.

## Testing

- visit `/the-bureau/`

## Review

- @KimberlyMunoz 
- @sebworks 
- @duelj 

## Screenshots

Before:
<img width="385" alt="screen shot 2015-08-04 at 2 05 26 pm" src="https://cloud.githubusercontent.com/assets/704760/9068556/130cc902-3ab2-11e5-99e0-174eed7b5a20.png">

After:
<img width="425" alt="screen shot 2015-08-04 at 2 05 09 pm" src="https://cloud.githubusercontent.com/assets/704760/9068560/17d026aa-3ab2-11e5-8846-baba72da82e6.png">