### PR TITLE
Eslint one point oh

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -16,12 +16,14 @@ ecmaFeatures:
   octalLiterals: false
   regexUFlag: false
   regexYFlag: false
+  restParams: true
   spread: false
   superInFunctions: false
   templateStrings: false
   unicodeCodePointEscapes: false
   globalReturn: false
   jsx: true
+  experimentalObjectRestSpread: false
 
 parser: espree
 
@@ -32,13 +34,16 @@ env:
   amd: true
   mocha: false
   jasmine: false
-  phantomjs: true
+  phantomjs: false
+  qunit: false
   jquery: false
   prototypejs: false
   shelljs: false
   meteor: false
   mongo: false
   applescript: false
+  serviceworker: true
+  embertest: false
   es6: false
 
 globals:
@@ -125,10 +130,6 @@ rules:
 
   # Disallows multiple spaces in a regular expression literal.
   no-regex-spaces: 2
-
-  # Disallows reserved words being used as object literal keys.
-  # Unneeded in ECMAScript 5+ environments.
-  no-reserved-keys: 2
 
   # Disallows sparse arrays.
   # Array values should be explicitly defined.
@@ -238,8 +239,19 @@ rules:
   # Disallows use of leading or trailing decimal points in numeric literals.
   no-floating-decimal: 2
 
+  # Disallow the type conversions with shorter notations.
+  no-implicit-coercion:
+    - 1
+    -
+      boolean: true
+      number: true
+      string: true
+
   # Disallows use of eval()-like methods.
   no-implied-eval: 2
+
+  # Disallow this keyword outside of classes or class-like objects.
+  no-invalid-this: 0
 
   # Disallows usage of __iterator__ property.
   no-iterator: 2
@@ -284,7 +296,10 @@ rules:
   no-octal: 2
 
   # Disallow reassignment of function parameters.
-  no-param-reassign: 0
+  no-param-reassign:
+    - 0
+    -
+      props: false
 
   # Disallows use of process.env.
   # Only applicable to Node.js.
@@ -315,6 +330,9 @@ rules:
 
   # Disallows usage of expressions in statement position.
   no-unused-expressions: 2
+
+  # Disallow unnecessary .call() and .apply().
+  no-useless-call: 2
 
   # Disallows use of void operator.
   no-void: 2
@@ -407,6 +425,15 @@ rules:
 
   # Rules for NODE.JS.
 
+  # Enforce return after a callback.
+  # callback, cb, and next are possible callback function names.
+  callback-return :
+    - 2
+    -
+      - callback
+      - cb
+      - next
+
   # Enforce error handling in callbacks.
   # Matches any string that contains err or Err (err, error, anyError, an_err).
   handle-callback-err:
@@ -492,12 +519,22 @@ rules:
     - 1
     - declaration
 
+  # Enforces min/max identifier lengths (variable names, property names etc.).
+  id-length:
+    - 0
+    -
+      min: 3
+      max: 10
+      exceptions:
+        - i
+
   # Set a specific tab width for your code.
   indent:
     - 2
     - 2
     -
-      indentSwitchCase: false
+      SwitchCase: 1
+      VariableDeclarator: 1
 
   # Enforce spacing between keys and values in object literal properties.
   key-spacing:
@@ -629,6 +666,13 @@ rules:
     - single
     - avoid-escape
 
+  # Require identifiers to match the provided regular expression.
+  id-match:
+    - 0
+    - '^[a-z]+([A-Z][a-z]+)*$'
+    -
+      properties: false
+
   # Disallows space before semicolon.
   semi-spacing:
     - 2
@@ -700,6 +744,16 @@ rules:
   # Rules for ECMASCRIPT 6.
   # These rules are only relevant to ES6 environments.
 
+  # Require parens in arrow function arguments.
+  arrow-parens: 2
+
+  # Require space before/after arrow function's arrow.
+  arrow-spacing:
+    - 2
+    -
+      before: true
+      after: true
+
   # Verify super() callings in constructors.
   constructor-super: 2
 
@@ -709,6 +763,12 @@ rules:
     -
       before: true
       after: false
+
+  # Disallow modifying variables of class declarations.
+  no-class-assign: 2
+
+  # Disallow modifying variables that are declared using const.
+  no-const-assign: 2
 
   # Disallow to use this/super before super() calling in constructors.
   no-this-before-super: 2
@@ -724,6 +784,17 @@ rules:
 
   # Suggest using of const declaration for variables that are never modified.
   prefer-const: 1
+
+  # Suggest using the spread operator instead of .apply().
+  # Should not be enabled in ES3/5 environments.
+  prefer-spread: 0
+
+  # Suggest using Reflect methods where applicable.
+  # Should not be enabled in ES3/5 environments.
+  prefer-reflect: 0
+
+  # Disallow generator functions that do not have yield.
+  require-yield: 1
 
 
   # Rules for LEGACY SUPPORT.

--- a/.eslintrc
+++ b/.eslintrc
@@ -427,7 +427,7 @@ rules:
 
   # Enforce return after a callback.
   # callback, cb, and next are possible callback function names.
-  callback-return :
+  callback-return:
     - 2
     -
       - callback

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Moved filters macro from `post-macros.html` to `/macros/filter.html`.
 - Makes filters macro helpers private.
 - Moved getViewportDimensions out of utilities.js and into own module.
+- Updated ESLint to v1.0.0.
 
 ### Removed
 - Removed Grunt plugins from package.json

--- a/gulp/tasks/test.js
+++ b/gulp/tasks/test.js
@@ -42,7 +42,7 @@ gulp.task( 'test:browser', function() {
     .pipe( protractor( {
         configFile:          config.tests + '/browser_tests/conf.js',
         autoStartStopServer: true
-    } ) )
+      } ) )
     .on( 'error', function( e ) { throw e; } );
 } );
 

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "gulp-changed": "^1.2.1",
     "gulp-concat": "^2.6.0",
     "gulp-coveralls": "^0.1.4",
-    "gulp-eslint": "^0.15.0",
+    "gulp-eslint": "^1.0.0",
     "gulp-header": "^1.2.2",
     "gulp-imagemin": "^2.3.0",
     "gulp-istanbul": "^0.10.0",

--- a/src/static/js/modules/classes/ContentSlider.js
+++ b/src/static/js/modules/classes/ContentSlider.js
@@ -62,9 +62,9 @@ ContentSlider.prototype.init = function() {
 
 ContentSlider.prototype.slideInContent = function( e ) {
   e.preventDefault();
-  var contents,
-      $div = $( '<div>' ),
-      $node = $( $( e.currentTarget ).data( 'content' ) );
+  var contents;
+  var $div = $( '<div>' );
+  var $node = $( $( e.currentTarget ).data( 'content' ) );
   if ( $node.length ) {
     // TODO: Move content instead of cloning; use ids instead of classes.
     contents = $node.first().clone().show().appendTo( $div );

--- a/src/static/js/modules/clear-form-buttons.js
+++ b/src/static/js/modules/clear-form-buttons.js
@@ -11,8 +11,8 @@ var $ = require( 'jquery' );
 
 function init() {
   $( '.js-form_clear' ).on( 'click', function() {
-    var $this = $( this ),
-        $form = $this.parents( 'form' );
+    var $this = $( this );
+    var $form = $this.parents( 'form' );
 
     // Clear text inputs
     $form.find( 'input[type="text"]' ).val( '' );

--- a/src/static/js/modules/desktop-primary-nav.js
+++ b/src/static/js/modules/desktop-primary-nav.js
@@ -8,13 +8,13 @@
 var $ = require( 'jquery' );
 
 function init() {
-  var $desktopMenu = $( '.primary-nav' ),
-      $desktopMenuTrigger = $( '.primary-nav_top-level-list > li' ),
-      $subNavs = $( '.sub-nav_wrapper' ),
-      mouseIsInsideMenu = false,
-      mouseIsInsideMenuItem = false,
-      aMenuItemWasOpened = false,
-      isSmall = $( '.sliding-nav_trigger' ).is( ':visible' );
+  var $desktopMenu = $( '.primary-nav' );
+  var $desktopMenuTrigger = $( '.primary-nav_top-level-list > li' );
+  var $subNavs = $( '.sub-nav_wrapper' );
+  var mouseIsInsideMenu = false;
+  var mouseIsInsideMenuItem = false;
+  var aMenuItemWasOpened = false;
+  var isSmall = $( '.sliding-nav_trigger' ).is( ':visible' );
 
   // On window resize, set the isSmall variable again.
   $( window ).resize( function() {

--- a/src/static/js/modules/jquery/cf_notifier.js
+++ b/src/static/js/modules/jquery/cf_notifier.js
@@ -7,7 +7,8 @@
 var $ = require( 'jquery' );
 var handlebars = require( 'handlebars' );
 
-var _notifierTemplate = '<div class="cf-notification cf-notification__{{ state }}" ' +
+var _notifierTemplate = '<div class="cf-notification ' +
+                                    'cf-notification__{{ state }}" ' +
                              'style="display: none;">' +
   '<span class="cf-notification_icon ' +
                'cf-notification_icon__{{ state }} ' +
@@ -63,10 +64,10 @@ var _notifier = {
           $( this ).remove();
           _notifier.existing = false;
           if ( callback ) {
-            callback();
+            return callback();
           }
         }
-    } );
+      } );
   },
 
   // Create a notification

--- a/src/static/js/modules/jquery/custom-select.js
+++ b/src/static/js/modules/jquery/custom-select.js
@@ -71,7 +71,7 @@ function init() {
           $( this ).trigger( 'updateState' );
           changeCallback( {
               select: $select
-          } );
+            } );
         } )
         .on( 'focus', function() {
           $this.addClass( 'is-focused' );

--- a/src/static/js/modules/mobile-primary-nav.js
+++ b/src/static/js/modules/mobile-primary-nav.js
@@ -8,13 +8,13 @@ require( './jquery/cfpb-aria-button' ).init();
 var $ = require( 'jquery' );
 
 function init() {
-  var $body = $( 'body' ),
-      $slidingNav = $( '.sliding-nav' ),
-      $slidingNavTrigger = $( '.sliding-nav_trigger' ),
-      $slidingNavNav = $( '.sliding-nav_nav' ),
-      $slidingNavPage = $( '.sliding-nav_page' ),
-      $slidingNavPageOverlay = $( '.sliding-nav_page-overlay' ),
-      subNavItemsSelector = '.list-expanding_child-list, .sub-nav_title';
+  var $body = $( 'body' );
+  var $slidingNav = $( '.sliding-nav' );
+  var $slidingNavTrigger = $( '.sliding-nav_trigger' );
+  var $slidingNavNav = $( '.sliding-nav_nav' );
+  var $slidingNavPage = $( '.sliding-nav_page' );
+  var $slidingNavPageOverlay = $( '.sliding-nav_page-overlay' );
+  var subNavItemsSelector = '.list-expanding_child-list, .sub-nav_title';
 
   $slidingNavTrigger.click( function( e ) {
     e.preventDefault();

--- a/src/static/js/modules/util/date-range-formatter.js
+++ b/src/static/js/modules/util/date-range-formatter.js
@@ -10,17 +10,17 @@ var _uTc = require( './type-checkers' );
 var _isDate = _uTc.isDate;
 
 var _defaults = {
-      dateFormat:         'yyyy-mm-dd',
-      fillRangeStartDate: new Date( '01/01/2011' ),
-      fillRangeEndDate:   new Date(),
-      fillRangeFlag:      true,
-      sortRangeFlag:      true,
-      dateRange:          {
-        startDate: '',
-        endDate:   '',
-        isValid:   true
-      }
-    };
+  dateFormat:         'yyyy-mm-dd',
+  fillRangeStartDate: new Date( '01/01/2011' ),
+  fillRangeEndDate:   new Date(),
+  fillRangeFlag:      true,
+  sortRangeFlag:      true,
+  dateRange:          {
+    startDate: '',
+    endDate:   '',
+    isValid:   true
+  }
+};
 
 var _properties = {};
 
@@ -127,9 +127,9 @@ function _fillDateRange( startDate, endDate ) {
 */
 function _formatDateRange( startDate, endDate, dateFormat ) {
   return [
-          _dateFormat( startDate, dateFormat ),
-          _dateFormat( endDate, dateFormat )
-         ];
+    _dateFormat( startDate, dateFormat ),
+    _dateFormat( endDate, dateFormat )
+  ];
 }
 
 /**

--- a/src/static/js/modules/util/js-loader.js
+++ b/src/static/js/modules/util/js-loader.js
@@ -21,13 +21,17 @@ function loadScript( url, callback ) {
         script.readyState === 'complete'
       ) {
         script.onreadystatechange = null;
-        if ( callback ) callback();
+        if ( callback ) {
+          return callback();
+        }
       }
     };
   // Other browsers.
   } else {
     script.onload = function() {
-      if ( callback ) callback();
+      if ( callback ) {
+        return callback();
+      }
     };
   }
 

--- a/src/static/js/modules/util/web-storage-proxy.js
+++ b/src/static/js/modules/util/web-storage-proxy.js
@@ -97,4 +97,4 @@ module.exports = {
     getItem:        getItem,
     removeItem:     removeItem,
     setSessionType: setSessionType
-};
+  };

--- a/src/static/js/routes/common.js
+++ b/src/static/js/routes/common.js
@@ -6,7 +6,7 @@
 
 var $ = require( 'jquery' );
 
-$( document ).ready( function() {
+$( document ).ready( function() { // eslint-disable-line max-statements, no-inline-comments, max-len
 
   // Shimmed-Browserify modules (other than jQuery).
   require( 'jquery-easing' );

--- a/test/browser_tests/jenkins_conf.js
+++ b/test/browser_tests/jenkins_conf.js
@@ -28,7 +28,7 @@ exports.config = {
 
     mkdirp( newFolder, function( err ) {
       if ( err ) {
-        console.error( err );
+        console.error( err ); // eslint-disable-line no-console, no-inline-comments, max-len
       } else {
         var jUnitXmlReporter = new JasmineReporters.JUnitXmlReporter(
           {

--- a/test/browser_tests/page_objects/page_office.js
+++ b/test/browser_tests/page_objects/page_office.js
@@ -13,7 +13,7 @@ function OfficePage() {
         PlainWriting:             baseUrl + 'plain-writing/',
         Privacy:                  baseUrl + 'privacy/',
         ProjectCatalyst:          baseUrl + 'project-catalyst/'
-    };
+      };
 
     browser.get( examplePages[page] );
   };
@@ -48,7 +48,9 @@ function OfficePage() {
 
   this.officeContact = element( by.css( '.office_contact' ) );
 
-  this.officeContactEmail = element( by.css( '.office_contact a[href^="mailto:"]' ) );
+  this.officeContactEmail = element(
+    by.css( '.office_contact a[href^="mailto:"]' )
+  );
 }
 
 module.exports = OfficePage;

--- a/test/browser_tests/page_objects/page_sub-pages.js
+++ b/test/browser_tests/page_objects/page_sub-pages.js
@@ -10,7 +10,8 @@ function SubPage() {
         SocialMediaAccessibility:
           baseUrl + 'social-media-accessibility/',
         FileAFormalAccessibilityComplaintOrWebsiteFeedback:
-          baseUrl + 'file-a-formal-accessibility-complaint-or-website-feedback/',
+          baseUrl +
+          'file-a-formal-accessibility-complaint-or-website-feedback/',
         // Office of Civil Rights
         DiversityPolicy:
           baseUrl + 'diversity-inclusion-statement/',
@@ -24,7 +25,7 @@ function SubPage() {
           baseUrl + 'reasonable-accommodation-request-policy/',
         Whistleblowers:
           baseUrl + 'whistleblowers/'
-    };
+      };
 
     browser.get( examplePages[page] );
   };
@@ -47,7 +48,9 @@ function SubPage() {
 
   this.officeContact = element( by.css( '.office_contact' ) );
 
-  this.officeContactEmail = element( by.css( '.office_contact a[href^="mailto:"]' ) );
+  this.officeContactEmail = element(
+    by.css( '.office_contact a[href^="mailto:"]'
+  ) );
 }
 
 module.exports = SubPage;

--- a/test/browser_tests/shared_objects/footer.js
+++ b/test/browser_tests/shared_objects/footer.js
@@ -13,7 +13,9 @@ function Footer() {
   ) );
   this.post = this.footer.element( by.css( '.footer-post' ) );
   this.shareList = this.footer.element( by.css( '.footer_share-icon-list' ) );
-  this.officialWebsite = this.footer.element( by.css( '.footer_official-website' ) );
+  this.officialWebsite = this.footer.element(
+    by.css( '.footer_official-website' )
+  );
 }
 
 module.exports = Footer;

--- a/test/browser_tests/spec_suites/shared/shared_subpage-civil-rights-reasonable-accomodation-request-policy.js
+++ b/test/browser_tests/spec_suites/shared/shared_subpage-civil-rights-reasonable-accomodation-request-policy.js
@@ -12,7 +12,8 @@ describe( "The Office of Civil Rights' " +
   } );
 
   it( 'should properly load in a browser', function() {
-    expect( page.pageTitle() ).toBe( 'Reasonable Accommodation Request Policy' );
+    expect( page.pageTitle() )
+      .toBe( 'Reasonable Accommodation Request Policy' );
   } );
 
   it( 'should include page content', function() {


### PR DESCRIPTION
Updates ESLint to v1.0.0. and fixes errors/warnings.

## Additions

- Adds `restParams: true` to ESLint config, to allow use of ...rest syntax.
- Adds `experimentalObjectRestSpread: false` to ESLint config.
- Adds `qunit: false` to environments.
- Adds `serviceworker: true` to environments to support use of serviceworker API.
- Adds `embertest: false` to environments.
- Adds new rules: `no-implicit-coercion`, `no-invalid-this`, `no-param-reassign`, `no-useless-call`, `callback-return`, `id-length`, `id-match`, `arrow-parens`, `arrow-spacing`, `no-class-assign`, `no-const-assign`, `prefer-spread`, `prefer-reflect`, `require-yield`.

## Removals

- Removed deprecated `no-reserved-keys` rule.

## Changes

- Changes `phantomjs` environment to `false` since this should be overridden if needed in a test directory eslintrc file.
- Fixed linting warnings/errors, some new, some old.
- Added eslint ignore lines where they won't be updated: common.js and jenkins config.

## Testing

- `gulp lint`

## Review

- @KimberlyMunoz 
- @sebworks 


## Todos

- `no-invalid-this` rule is a good best practice, but the existing codebase has far too many invalid uses of this and expect the wider bureau codebase is this way as well. Perhaps after refactoring the JS we can elevate this to a warning level at some point.
- `id-match` rule is potentially very useful for creating consistent naming conventions around CF variables, for example, but the rule would require careful study before enabling.
