### PR TITLE
Adding Breakpoints Config File

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Added time macro.
 - Added `gulp test:unit` and `gulp test:acceptance` tasks for test stages.
 - Added support for link buttons to disabled link utility class.
+- Added `breakpoints-config.js` config file to use for responsive JS.
 
 ### Changed
 - Site's "About" text to "About Us".
@@ -68,6 +69,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
   (including legacy browsers) on Sauce Labs when Sauce credentials are present.
 - Updated test instructions to use the gulp test subtasks.
 - Updated Travis CI settings to use `setup.sh`.
+- Updated files to use `breakpoints-config.js`.
 
 ### Removed
 - Removed Grunt plugins from package.json

--- a/src/static/js/config/breakpoints-config.js
+++ b/src/static/js/config/breakpoints-config.js
@@ -1,0 +1,21 @@
+'use strict';
+
+// TODO: Read these values directly from cf-vars.less.
+// All values are pixel based.
+
+module.exports = {
+  mobile: {
+    max: 599
+  },
+  tablet: {
+    min: 600,
+    max: 800
+  },
+  desktop: {
+    min: 801,
+    max: 1199
+  },
+  wall: {
+    min: 1200
+  }
+};

--- a/src/static/js/modules/classes/MobileCarousel.js
+++ b/src/static/js/modules/classes/MobileCarousel.js
@@ -7,6 +7,7 @@
 var $ = require( 'jquery' );
 require( 'slick' );
 var BreakpointHandler = require( './BreakpointHandler' );
+var breakpointsConfig = require( '../../config/breakpoints-config' );
 
 /**
 * MobileCarousel
@@ -16,7 +17,7 @@ var BreakpointHandler = require( './BreakpointHandler' );
 */
 function MobileCarousel( breakpointPx ) {
   // Initialization can happen here, like an `init` method.
-  var _breakpointPx = breakpointPx;
+  var _breakpointPx = breakpointPx || breakpointsConfig.mobile.max;
   var _targetDom;
 
   function _enterBreakpoint() {

--- a/src/static/js/modules/classes/MobileOnlyExpandable.js
+++ b/src/static/js/modules/classes/MobileOnlyExpandable.js
@@ -3,6 +3,7 @@
 var $ = require( 'jquery' );
 var jQuery = $;
 var BreakpointHandler = require( './BreakpointHandler' );
+var breakpointsConfig = require( '../../config/breakpoints-config' );
 
 /**
  * MobileOnlyExpandable
@@ -20,7 +21,7 @@ var BreakpointHandler = require( './BreakpointHandler' );
 function MobileOnlyExpandable( elem, breakpoint ) {
   this.expandable = elem;
   this.expandableTarget = this.expandable.children( '.expandable_target' );
-  this.breakpoint = breakpoint;
+  this.breakpoint = breakpoint || breakpointsConfig.mobile.max;
 
   // Make sure we have necessary elements before proceeding.
   if ( this.expandable instanceof jQuery &&

--- a/src/static/js/routes/careers/application-process/index.js
+++ b/src/static/js/routes/careers/application-process/index.js
@@ -18,7 +18,7 @@ function init() {
   }
 
   $( '.expandable__mobile-only' ).each( function() {
-    new MobileOnlyExpandable( $( this ), 599 ); // eslint-disable-line
+    new MobileOnlyExpandable( $( this ) ); // eslint-disable-line no-new, no-inline-comments, max-len
   } );
 }
 

--- a/src/static/js/routes/offices/index.js
+++ b/src/static/js/routes/offices/index.js
@@ -15,11 +15,8 @@ function init() {
     return;
   }
 
-  var breakpointPx = 599;
-
   $( '.expandable__mobile-only' ).each( function() {
-    // ESLint no-new rule ignored
-    new MobileOnlyExpandable( $( this ), breakpointPx ); // eslint-disable-line
+    new MobileOnlyExpandable( $( this ) ); // eslint-disable-line no-new, no-inline-comments, max-len
   } );
 }
 

--- a/src/static/js/routes/the-bureau/index.js
+++ b/src/static/js/routes/the-bureau/index.js
@@ -10,6 +10,7 @@ var MobileCarousel = require( '../../modules/classes/MobileCarousel' );
 var MobileOnlyExpandable =
   require( '../../modules/classes/MobileOnlyExpandable' );
 
+
 function init() {
 
   // TODO: Remove this when per-page JS is introduced.
@@ -17,12 +18,11 @@ function init() {
     return;
   }
 
-  var breakpointPx = 599;
-  var mobileCarousel = new MobileCarousel( breakpointPx );
+  var mobileCarousel = new MobileCarousel();
   mobileCarousel.enableOn( '.js-mobile-carousel' );
 
   $( '.expandable__mobile-only' ).each( function() {
-    new MobileOnlyExpandable( $( this ), breakpointPx ); // eslint-disable-line
+    new MobileOnlyExpandable( $( this ) ); // eslint-disable-line no-new, no-inline-comments, max-len
   } );
 }
 


### PR DESCRIPTION
The PR is part of a move towards using config files, which may or may not be mirrored in Jinja/Less. 

## Changes
- Added  `config/breakpoints-config.js` to add config file to mirror `cf-vars.less.`
- Updated `src/static/js/modules/classes/MobileOnlyExpandable.js` to use breakpoints config.
- Updated `src/static/js/routes/careers/application-process/index.js` to use breakpoints config.
- Updated `src/static/js/routes/the-bureau/index.js` to use breakpoints config.
- Updated `src/static/js/routes/offices/index.js` to use breakpoints config.

## Testing
- Visit 'http://localhost:7000/the-bureau/` using a mobile emulator and observe the expandable/carousel.

## Review
@anselmbradford 
@KimberlyMunoz 