### PR TITLE
Fixed borders on sub-footers across the website

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Fixed margins on site footer.
 - Switched the two forms under Privacy to their correct positions
 - Fixed incorrect email href reference on offices contact email link.
+- Fixed borders on sub-footers across the website
 
 
 ## 3.0.0-2.1.0 - 2015-08-05

--- a/src/_includes/macros/activities-block.html
+++ b/src/_includes/macros/activities-block.html
@@ -17,7 +17,6 @@
 {% from 'macros/util/text.html' import string_length as string_length %}
 <section class="block
                 block__bg
-                block__flush-sides
                 block__flush-top
                 block__flush-bottom
                 qa-tags">

--- a/src/_includes/templates/office-contact.html
+++ b/src/_includes/templates/office-contact.html
@@ -2,7 +2,6 @@
 {% if contact %}
     {% import 'macros/contact-layout.html' as contact_layout %}
     <section class="block
-                    block__flush-sides
                     block__flush-top
                     block__flush-bottom
                     block__bg

--- a/src/budget/index.html
+++ b/src/budget/index.html
@@ -113,7 +113,12 @@
 
     {# Footer #}
     <aside>
-        <div class="block u-mb0 block__flush-sides block__bg">
+        <div class="block
+                    block__flush-bottom
+                    block__flush-sides
+                    block__bg
+                    block__border-top
+                    block__border-right">
             <div class="content-l content-l__main">
                 <section class="content-l_col content-l_col-1-2">
                     <h1 class="header-slug">

--- a/src/newsroom/index.html
+++ b/src/newsroom/index.html
@@ -57,6 +57,8 @@
                     block__bg
                     block__flush-sides
                     block__flush-bottom
+                    block__border-top
+                    block__border-right
                     related_content
                     ">
             <div class="content-l content-l__main">

--- a/src/offices/_single.html
+++ b/src/offices/_single.html
@@ -148,12 +148,16 @@
         {{ office.content }}
     </section>
     {% endif %}
+    <div class="block
+                block__flush-sides
+                block__flush-bottom
+                block__border-top
+                block__border-right">
+        {% if office.tags %}
+            {% import 'macros/activities-block.html' as activities_block with context %}
+            {{ activities_block.render(office.tags) }}
+        {% endif %}
 
-    {% if office.tags %}
-        {% import 'macros/activities-block.html' as activities_block with context %}
-        {{ activities_block.render(office.tags) }}
-    {% endif %}
-
-    {% include 'templates/office-contact.html' %}
-
+        {% include 'templates/office-contact.html' %}
+    </div>
 {% endblock %}

--- a/src/privacy-policy/index.html
+++ b/src/privacy-policy/index.html
@@ -38,6 +38,8 @@
                     block
                     block__bg
                     block__flush-sides
+                    block__border-top
+                    block__border-right
                     related_content">
             <div class="content-l content-l__main">
                 <section class="block block__flush-top content-l_col content-l_col-1-2">

--- a/src/sub-pages/_single.html
+++ b/src/sub-pages/_single.html
@@ -92,13 +92,17 @@
         }}
     </section>
     {% endif %}
+    <div class="block
+                block__flush-sides
+                block__flush-bottom
+                block__border-top
+                block__border-right">
+        {% if sub_page.tags %}
+            {% import 'macros/activities-block.html' as activities_block with context %}
+            {{ activities_block.render(sub_page.tags) }}
+        {% endif %}
 
-    {% if sub_page.tags %}
-        {% import 'macros/activities-block.html' as activities_block with context %}
-        {{ activities_block.render(sub_page.tags) }}
-    {% endif %}
-
-    {% set office = vars.office %}
-    {% include 'templates/office-contact.html' %}
-
+        {% set office = vars.office %}
+        {% include 'templates/office-contact.html' %}
+    </div>
 {% endblock %}

--- a/src/the-bureau/leadership-calendar/index.html
+++ b/src/the-bureau/leadership-calendar/index.html
@@ -92,7 +92,9 @@
     <aside class="block
                   block__flush-bottom
                   block__flush-sides
-                  block__bg">
+                  block__bg
+                  block__border-top
+                  block__border-right">
         {# TODO: Add FOIA and Open government URLs. #}
         {%- import 'related-links.html' as related_links -%}
         {{- related_links.render([


### PR DESCRIPTION
Issue #183 is one of the oldest Github issues we have in our project. This closes it once and for all.

![tumblr_m726cprdp31rsy50k-1438277398](https://cloud.githubusercontent.com/assets/1860176/9212036/16667420-4054-11e5-85b3-118bdc3256b3.gif)

## Changes

- Fixes borders on sub-footers across the website

## Testing
- Visit the Newsroom
- Visit the Budget
- Visit the leadership calendar
- Visit a couple different office and sub-pages

Make sure the borders look good.

## Review

- @anselmbradford 
- @sebworks 

## Preview

Include any screenshots that will make reviewing/testing easier

_Newsroom_
![image](https://cloud.githubusercontent.com/assets/1860176/9212164/ee5f4046-4054-11e5-8c57-797e8fee8ded.png)

_Office of Civil Rights_
![image](https://cloud.githubusercontent.com/assets/1860176/9212173/0346c894-4055-11e5-9ff6-eef1d34d5242.png)

_Leadership Calendar_
![image](https://cloud.githubusercontent.com/assets/1860176/9212186/1ad02eba-4055-11e5-8c33-63ed52d83126.png)

[Preview this PR without the whitespace changes](?w=0)

## Notes

- Closes #183
