### PR TITLE
Fixed icon links for budget section and business section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Fixed borders on sub-footers across the website
 - Fixed 'Return to top' button width on footer
 - Fixed default gulp task
+- Fixed icon links to match CFPB Design Manual
 
 
 ## 3.0.0-2.1.0 - 2015-08-05

--- a/src/doing-business-with-us/small-businesses/index.html
+++ b/src/doing-business-with-us/small-businesses/index.html
@@ -35,19 +35,25 @@
             </p>
             <ul class="list__links list__icons">
                 <li class="list_item">
-                    <a class="list_link icon-link icon-link__before icon-link__pdf"
+                    <a class="list_link
+                              icon-link
+                              icon-link__download"
                        href="http://files.consumerfinance.gov/f/201305_cfpb_Small-business-guide.pdf">
                         <span class="icon-link_text">Read our small business guidelines</span>
                     </a>
                 </li>
                 <li class="list_item">
-                    <a class="list_link icon-link icon-link__before icon-link__pdf"
+                    <a class="list_link
+                              icon-link
+                              icon-link__download"
                        href="http://files.consumerfinance.gov/f/201310_cfpb_sb-intake-form.pdf">
                         <span class="icon-link_text">Complete our small business intake form</span>
                     </a>
                 </li>
                 <li class="list_item">
-                    <a class="list_link icon-link icon-link__before icon-link__pdf"
+                    <a class="list_link
+                              icon-link
+                              icon-link__download"
                        href="http://files.consumerfinance.gov/f/201310_cfpb_omwi_opportunities_trifold_final.pdf">
                         <span class="icon-link_text">Info for women- and minority-owned businesses</span>
                     </a>

--- a/src/static/css/cf-enhancements.less
+++ b/src/static/css/cf-enhancements.less
@@ -768,11 +768,6 @@ tbody {
         .list__links();
         .list__icons();
 
-        // TODO: Check if `left` could be used instead,
-        // like what is done with the jump-links.
-        // Optical offset for left-aligning list with text.
-        margin-left: unit( 2px / @base-font-size-px, em );
-
         li {
             .list__links .list_item();
             .list__icons .list_item();
@@ -789,11 +784,13 @@ tbody {
                 .list__icons .list_text();
             }
 
-            &:before {
+            &:after {
                 .cf-icon();
-                .list__icons .list_icon();
-                content: "\e406";
+                content: @cf-icon-download;
                 color: @pacific;
+                // Offset to address lack of space between text and icon
+                width: 1em;
+                text-align: right;
             }
         }
 

--- a/src/static/css/pages/business.less
+++ b/src/static/css/pages/business.less
@@ -6,10 +6,6 @@
 // Used to set padding to 30px
 @padding: unit(@grid_gutter-width / @base-font-size-px, em);
 
-.business_page-content {
-    .list__download();
-}
-
 .block__business-step {
     .respond-to-min(@desktop-min, {
         margin-bottom: 0;
@@ -38,4 +34,8 @@
         });
         top: @base-font-size-px;
     }
+}
+
+.business_page-content{
+    .list__download();
 }


### PR DESCRIPTION
Closes DF-2222 and brings multiple pages under the guidelines set in the design manual.

## Changes
- Fixes icon links to correct guidelines in design manual
- Fixes `list__download` to show icons after links.

## Testing
- Reindex sheer
- Test the following pages: 
  - Performance Plan & Report
  - Financial Reports & Updates
  - Funding Requests
  - Procurement History
  - Small Businesses & Minorities