### PR TITLE
Fixed 'Return to top' button width on footer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Switched the two forms under Privacy to their correct positions
 - Fixed incorrect email href reference on offices contact email link.
 - Fixed borders on sub-footers across the website
+- Fixed 'Return to top' button width on footer
 
 
 ## 3.0.0-2.1.0 - 2015-08-05

--- a/src/static/css/footer.less
+++ b/src/static/css/footer.less
@@ -119,8 +119,8 @@
 
         .footer_top-button {
             display: block;
-            width: 90%;
-            max-width: 350px;
+            width: 100%;
+            text-align: center;
             // There's a standard margin between the top
             // of the footer and the links. The button comes between
             // that margin in the wireframes.


### PR DESCRIPTION
Fixes DF-2208. Design wants the "Return to top" button to span the full width of the screen. 

## Changes

- Fixed 'Return to top' button width on footer

## Preview

![image](https://cloud.githubusercontent.com/assets/1860176/9257362/2d5dfa66-41c3-11e5-87c3-6a21eafb5058.png)
