### PR TITLE
Updates disabled link to support button links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Added `/offices/office-of-civil-rights/` page, tests, and link in footer.
 - Added time macro.
 - Added `gulp test:unit` and `gulp test:acceptance` tasks for test stages.
+- Added support for link buttons to disabled link utility class.
 
 ### Changed
 - Site's "About" text to "About Us".

--- a/src/static/css/cf-enhancements.less
+++ b/src/static/css/cf-enhancements.less
@@ -1427,7 +1427,7 @@ textarea.input__long {
 */
 
 .u-hidden {
-  display: none;
+    display: none;
 }
 
 
@@ -1443,9 +1443,10 @@ textarea.input__long {
       codenotes:
         - .u-link__disabled;
       notes:
-        - "Use this as a general class to give links disabled styling.
-           Sets the color,
-           removes the border and sets the cursor to not-allowed"
+        - "Use this as a general class to give links
+           or button links disabled styling.
+           Sets the color, background-color,
+           removes the border, and sets the cursor to not-allowed."
   tags:
     - cf-core
 */
@@ -1453,6 +1454,10 @@ textarea.input__long {
     color: @gray-50 !important;
     border: none !important;
     cursor: not-allowed !important;
+
+    &.btn {
+        background-color: @gray-20 !important;
+    }
 }
 
 

--- a/src/the-bureau/bureau-structure/index.html
+++ b/src/the-bureau/bureau-structure/index.html
@@ -136,7 +136,8 @@
                     Download a printable, PDF copy of this organizational chart. This version
                     is expanded to show all offices.
                 </p>
-                <a class="btn btn__secondary" href="#">
+                {# Add PDF download URL when it's available. #}
+                <a class="btn btn__secondary u-link__disabled">
                     <span class="btn_icon__left cf-icon cf-icon-save"></span>
                     Download PDF
                 </a>


### PR DESCRIPTION
Updates disabled link to support button links.

## Additions

- Adds `&.btn` class to `u-link__disabled` class.

## Changes

- Properly disables download PDF button on the bureau-structure page.

## Testing

- Visit `/the-bureau/bureau-structure/`, download PDF button should be disabled.

## Review

- @sebworks 
- @jimmynotjim 

## Screenshots

Before:
![btn-disabled-before](https://cloud.githubusercontent.com/assets/704760/9279339/dcfe33de-4284-11e5-8f72-b3fc30ee202a.gif)

After:
![btn-disabled-after](https://cloud.githubusercontent.com/assets/704760/9279341/dfcb40ac-4284-11e5-8bc9-f423f9908202.gif)