### PR TITLE
Bugfix for default gulp task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,7 +57,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
   constants to `.env_SAMPLE`.
 - Moved aggregate `gulp lint` task to bottom of file to avoid duplicate
   lint task entries in `gulp --tasks`.
-- Renamed `gulp lint:src` to `gulp lint:js` to future-proof type of linting.
+- Renamed `gulp lint:src` to `gulp lint:styles` to future-proof type of linting.
 - Renamed `gulp test:macro` to `gulp test:unit:macro`.
 - Renamed `gulp test:processor` to `gulp test:unit:processor`.
 - Renamed `gulp test:browser` to `gulp test:acceptance:browser`.
@@ -84,6 +84,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Fixed incorrect email href reference on offices contact email link.
 - Fixed borders on sub-footers across the website
 - Fixed 'Return to top' button width on footer
+- Fixed default gulp task
 
 
 ## 3.0.0-2.1.0 - 2015-08-05

--- a/gulp/tasks/default.js
+++ b/gulp/tasks/default.js
@@ -4,10 +4,8 @@ var gulp = require( 'gulp' );
 
 gulp.task( 'default',
   [
-    'lint:src',
+    'lint:scripts',
     'test:unit',
-    'test:macro',
-    'test:processor',
     'build'
   ]
 );

--- a/gulp/tasks/lint.js
+++ b/gulp/tasks/lint.js
@@ -8,7 +8,7 @@ var handleErrors = require( '../utils/handleErrors' );
 /**
  * Lints the gulpfile for errors
  */
-gulp.task( 'lint:gulp', function() {
+gulp.task( 'lint:build', function() {
   return gulp.src( config.gulp )
     .pipe( $.eslint() )
     .pipe( $.eslint.format() )
@@ -19,7 +19,7 @@ gulp.task( 'lint:gulp', function() {
 /**
  * Lints the source js files for errors
  */
-gulp.task( 'lint:js', function() {
+gulp.task( 'lint:scripts', function() {
   return gulp.src( config.src )
     .pipe( $.eslint() )
     .pipe( $.eslint.format() )
@@ -30,6 +30,6 @@ gulp.task( 'lint:js', function() {
  * Lints all the js files for errors
  */
 gulp.task( 'lint', [
-  'lint:gulp',
-  'lint:js'
+  'lint:build',
+  'lint:scripts'
 ] );


### PR DESCRIPTION
Fixed default gulp task and renamed script liniting to match the processing task

## Additions

- None

## Removals

- None

## Changes

- updated default task for correct lint and test tasks
- updated name of lint:js to lint:scripts to match the script processing task

## Testing

- run `gulp` and there should be no messages about tasks not being in your gulpfile

## Review

- @anselmbradford 
- @sebworks 
- @KimberlyMunoz 

## Preview

None

[Preview this PR without the whitespace changes](?w=0)

## Notes

- Gulp is JS too, so naming the lint task `scripts` ties it to the type of JS files we're linting in this task