### PR TITLE
Fixes #836 - removes redundant ul block

### DIFF
--- a/src/_includes/macros/active-filters.html
+++ b/src/_includes/macros/active-filters.html
@@ -1,7 +1,9 @@
 
 {# ==========================================================================
 
-   active_filters()
+   active_filters.render()
+
+   ==========================================================================
 
    Description:
 
@@ -51,9 +53,9 @@
 {%- set active_filters_total = active_filters | length + active_date_filters | length -%}
 
 {%- if active_filters_total > 0 and use_list == false -%}
-  {{ _active_filters_notification() }}
+    {{ _active_filters_notification() }}
 {% elif use_list == true %}
-  {{ _active_filters_list(active_filters_total, active_filters, active_date_filters, options) }}
+    {{ _active_filters_list(active_filters_total, active_filters, active_date_filters, options) }}
 {% endif %}
 
 {% endmacro %}
@@ -62,9 +64,9 @@
 {# A helper macro to display the active_filters as a list.
   ========================================================================== #}
 {% macro _active_filters_list(active_filters_total, active_filters, active_date_filters, options) %}
+<ul class="filtered-by filtered-by__align-with-btn list__horizontal">
 {%- if active_filters_total > 0 -%}
-    <ul class="filtered-by filtered-by__align-with-btn list__horizontal">
-        {%- if options.show_filters_label -%}
+    {%- if options.show_filters_label -%}
         <li class="list_item filtered-by_header">
         {%- if posts | list | length > 0 -%}
             {{ posts.total }} filtered result{{ 's' if posts.total > 1 }} for
@@ -91,45 +93,43 @@
         {%- endfor -%}
         </li>
     {%- endif %}
-    </ul>
 {%- else -%}
     {% if options.show_unfiltered_count and options.show_filters_label %}
-    <ul class="filtered-by filtered-by__align-with-btn list__horizontal">
         <li class="list_item">
             <span class="filtered-by_header">
                 {{ posts.total }} results
             </span>
         </li>
-    </ul>
     {% endif %}
 {%- endif -%}
+</ul>
 {% endmacro %}
 
 
 {# A helper macro to display the active_filters as a notification.
    ========================================================================== #}
 {% macro _active_filters_notification() %}
-    {%- if posts | list | length > 0 -%}
-        {% set text = posts.total | string
-                      + ' filtered result'
-                      + ('s' if posts.total > 1 else '') %}
-        {% set type = 'success' %}
-    {%- else -%}
-      {% macro _no_results_text () %}
-          Sorry, there were no results based on your filter selections.
-          <p class="short-desc u-mt15">
+{%- if posts | list | length > 0 -%}
+    {% set text = posts.total | string
+                  + ' filtered result'
+                  + ('s' if posts.total > 1 else '') %}
+    {% set type = 'success' %}
+{%- else -%}
+    {% macro _no_results_text () %}
+        Sorry, there were no results based on your filter selections.
+        <p class="short-desc u-mt15">
             Please clear the filter or change your selections and try again.
-          </p>
-      {% endmacro %}
-      {% set text = _no_results_text() %}
-      {% set type = 'warning' %}
-    {%- endif -%}
+        </p>
+    {% endmacro %}
+    {% set text = _no_results_text() %}
+    {% set type = 'warning' %}
+{%- endif -%}
 
-    {% import 'macros/notification.html' as notification %}
-    <div class='filtered-by'>
+{% import 'macros/notification.html' as notification %}
+<div class='filtered-by'>
     {{ notification.render({
         'text': text,
         'type': type
     }) }}
-  </div>
+</div>
 {% endmacro %}


### PR DESCRIPTION
Fixes #836 - removes redundant ul block.

## Removals

- Removes redundant ul block in `active_filters` macro.

## Testing

- Places that use the `_active_filters_list` macro, ~~like `/blog/` should function the same.~~ Oops, only used on `/the-bureau/leadership-calendar/print/`

## Review

- @KimberlyMunoz 
- @sebworks 
- @jimmynotjim 
