### PR TITLE
Fixes #669 - unnecessary var; wrong boolean case

### DIFF
--- a/src/_includes/article.html
+++ b/src/_includes/article.html
@@ -31,7 +31,7 @@
     <header>
         {%- import 'category-slug.html' as category_slug %}
         {% if path == '/blog/' and post.blog_category.0 %}
-            {% set use_blog_category = True %}
+            {% set use_blog_category = true %}
             {{ category_slug.render(post.blog_category.0,
                                     path,
                                     'post_slug',

--- a/src/_includes/macros/contact-layout.html
+++ b/src/_includes/macros/contact-layout.html
@@ -35,7 +35,6 @@
             {%- endfor %}
         {%- endif %}
         {%- if contact.phone %}
-            {%- set first = True %}
             {%- for phone in contact.phone %}
                 <li class="list_item">
                     {%- if loop.index == 1 %}

--- a/src/_includes/posts-paginated.html
+++ b/src/_includes/posts-paginated.html
@@ -12,10 +12,10 @@
         rather than the normal 'category' #}
     {%- if vars.path == '/blog/' %}
         {% set category = post.blog_category %}
-        {% set use_blog_category = True %}
+        {% set use_blog_category = true %}
     {% elif post.category %}
         {% set category = post.category %}
-        {% set use_blog_category = False %}
+        {% set use_blog_category = false %}
     {% endif -%}
     {%- import 'category-slug.html' as category_slug %}
 


### PR DESCRIPTION
Fixes #669 - unnecessary var; wrong boolean case.

## Changes

- Removes unnecessary jinja `First` var.
- Downcases boolean values, per jinja docs.

## Testing

- `/contact-us/` should look the same.

## Review

- @KimberlyMunoz 
- @sebworks 
- @jimmynotjim 
