### PR TITLE
DF-1858 - Responsive Js

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
   and budget pages
 - Added Meredith Fuchs to Leadership calendar filter.
 - Added unit test for `assign` utility.
+- Added `get-breakpoint-state.js` to add support for responsive JS.
 
 ### Changed
 - Moved `.meta-header`, `.jump-link`,
@@ -64,6 +65,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Normalized director and deputy director photos to be format `NAME-WxH.jpg`.
 - Changed name of `shallow-extend` utility to 'assign'.
 - Superscripts `st` in `21st` on About Us page.
+- Updated `BreakpointHandler.js` to support usage of `breakpoints-config.js`.
 
 ### Removed
 - Removed styles from codebase that have already been migrated

--- a/src/static/js/config/breakpoints-config.js
+++ b/src/static/js/config/breakpoints-config.js
@@ -5,6 +5,7 @@
 
 module.exports = {
   mobile: {
+    min: 0,
     max: 599
   },
   tablet: {

--- a/src/static/js/modules/classes/BreakpointHandler.js
+++ b/src/static/js/modules/classes/BreakpointHandler.js
@@ -1,6 +1,8 @@
 'use strict';
 
 var $ = require( 'jquery' );
+var getBreakpointState = require( '../util/breakpoint-state' ).get;
+var _breakpointsConfig = require( '../../config/breakpoints-config' );
 
 // Used for checking browser capabilities.
 // TODO: Check what browsers this is necessary for and
@@ -32,11 +34,16 @@ function BreakpointHandler( opts ) {
     throw new Error( 'BreakpointHandler constructor requires arguments!' );
   }
 
+  var breakpoint = opts.breakpoint;
+  var type = opts.type || 'max';
+
   this.match = false;
-  this.breakpoint = opts.breakpoint;
+  this.type = type;
+  this.breakpoint = _breakpointsConfig[breakpoint] &&
+                    _breakpointsConfig[breakpoint][type] ||
+                    breakpoint;
   this.enter = opts.enter;
   this.leave = opts.leave;
-  this.type = opts.type || 'max';
 
   _init( this );
 }
@@ -70,10 +77,12 @@ function watchWindowResize() {
 function handleViewportChange() {
   var width = _viewportEl[_propPrefix + 'Width'];
   var match = this.testBreakpoint( width );
+  var breakpointState;
 
   if ( match !== this.match ) {
-    if ( match && this.enter ) this.enter();
-    else if ( this.leave ) this.leave();
+    breakpointState = getBreakpointState( width );
+    if ( match && this.enter ) this.enter( breakpointState );
+    else if ( this.leave ) this.leave( breakpointState );
   }
 
   this.match = match;
@@ -92,5 +101,6 @@ function testBreakpoint( width ) {
 BreakpointHandler.prototype.watchWindowResize = watchWindowResize;
 BreakpointHandler.prototype.handleViewportChange = handleViewportChange;
 BreakpointHandler.prototype.testBreakpoint = testBreakpoint;
+BreakpointHandler.getBreakpointState = getBreakpointState;
 
 module.exports = BreakpointHandler;

--- a/src/static/js/modules/secondary-nav-toggle.js
+++ b/src/static/js/modules/secondary-nav-toggle.js
@@ -6,6 +6,7 @@
 'use strict';
 
 var $ = require( 'jquery' );
+var getBreakpointState = require( './util/breakpoint-state' ).get;
 
 function init() {
   // Call this right away to test if we need to expand the nav.
@@ -25,11 +26,12 @@ function _navSecondaryToggle() {
 
 // Tests whether or not the secondary nav should be toggled.
 function _navSecondaryToggleTest() {
-  var isSmall =
-    $( '.nav-secondary .nav-secondary_link__button' ).is( ':visible' );
+  var breakpointState = getBreakpointState();
+  var isSmall = breakpointState.isMobile || breakpointState.isTablet;
+
   var isExpanded =
     $( '.nav-secondary .expandable_content' )
-      .attr( 'aria-expanded' ) === 'true';
+    .attr( 'aria-expanded' ) === 'true';
   return isSmall && isExpanded || !isSmall && !isExpanded;
 }
 

--- a/src/static/js/modules/util/breakpoint-state.js
+++ b/src/static/js/modules/util/breakpoint-state.js
@@ -1,0 +1,39 @@
+/* ==========================================================================
+   Get Breakpoint State
+   ========================================================================== */
+
+'use strict';
+
+var _breakpointsConfig = require( '../../config/breakpoints-config' );
+var _getViewportDimensions = require( './get-viewport-dimensions' )
+                             .getViewportDimensions;
+
+function _inBreakpointRange( breakpointRange, width ) {
+  var min = breakpointRange.min || 0;
+  var max = breakpointRange.max || Number.POSITIVE_INFINITY;
+
+  return min <= width && width <= max;
+}
+
+/**
+ * @returns {object} An object literal with Boolean
+ * isMobile, isTablet, isDesktop, isWall, isSmall properties.
+ * @param {integer} width Current window width.
+ */
+function get( width ) {
+  var breakpointState = {};
+  var breakpointKey;
+  width = width || _getViewportDimensions().width;
+
+  for ( var rangeKey in _breakpointsConfig ) { // eslint-disable-line guard-for-in, no-inline-comments, max-len
+    breakpointKey = 'is' + rangeKey.charAt( 0 ).toUpperCase() +
+                    rangeKey.slice( 1 );
+    breakpointState[breakpointKey] =
+    _inBreakpointRange( _breakpointsConfig[rangeKey], width );
+  }
+
+  return breakpointState;
+}
+
+// Expose public methods.
+module.exports = { get: get };

--- a/test/unit_tests/modules/util/breakpoint-state-spec.js
+++ b/test/unit_tests/modules/util/breakpoint-state-spec.js
@@ -1,0 +1,61 @@
+'use strict';
+var chai = require( 'chai' );
+var expect = chai.expect;
+var jsdom = require( 'mocha-jsdom' );
+var getBreakpointState =
+require( '../../../../src/static/js/modules/util/breakpoint-state.js' ).get;
+var breakpointConfig =
+require( '../../../../src/static/js/config/breakpoints-config.js' );
+
+var breakpointState;
+var configKeys;
+
+beforeEach( function() {
+  configKeys = Object.keys( breakpointConfig );
+} );
+
+describe( 'getBreakpointState', function() {
+
+  jsdom();
+
+  it( 'should return an object with properties from config file', function() {
+    var breakpointStatekeys =
+        Object.keys( breakpointConfig ).map( function( key ) {
+          return key.toLowerCase().replace( 'is', '' );
+        } );
+
+    breakpointState = getBreakpointState();
+
+    expect( breakpointState instanceof Object ).to.be.true;
+    expect( configKeys.sort().join() === breakpointStatekeys.sort().join() )
+    .to.be.true;
+  } );
+
+  it( 'should return an object with one ' +
+      'state property set to true', function() {
+    var trueValueCount = 0;
+
+    breakpointState = getBreakpointState();
+    for ( var stateKey in breakpointState ) { // eslint-disable-line guard-for-in, no-inline-comments, max-len
+      if ( breakpointState[stateKey] === true ) trueValueCount++;
+    }
+
+    expect( trueValueCount === 1 ).to.be.true;
+  } );
+
+  it( 'should set the correct state' +
+      'property when passed width', function() {
+    var width;
+    var breakpointStateKey;
+
+    for ( var rangeKey in breakpointConfig ) { // eslint-disable-line guard-for-in, no-inline-comments, max-len
+      width = breakpointConfig[rangeKey].max || breakpointConfig[rangeKey].min;
+      breakpointState = getBreakpointState( width );
+      breakpointStateKey =
+      'is' + rangeKey.charAt( 0 ).toUpperCase() + rangeKey.slice( 1 );
+
+      expect( breakpointState[breakpointStateKey] ).to.be.true;
+    }
+  } );
+
+} );


### PR DESCRIPTION
DF-1858 - Responsive Js

## Changes
- Updated `src/static/js/config/breakpoints-config.js` to add min to mobile config.
- Updated `src/static/js/modules/classes/BreakpointHandler.js` to use `breakpoints-config` and pass back state param on `enter/leave` events.
- Updated `src/static/js/modules/secondary-nav-toggle.js` to use `get-breakpoint-state.js`.
- Added `src/static/js/modules/util/get-breakpoint-state.js` to create module for determining responsive state. 

## Testing
-  Visit `http://localhost:7000/the-bureau/` and resize window. Observe secondary nav.

## Notes 
~~~- Will create a separate PR for unit tests.~~~~

Update: Unit test added in https://github.com/cfpb/cfgov-refresh/commit/6c9bd90cc9e4323b06358c5dd570f138d7474f6c

## Review
@anselmbradford 
@jimmynotjim