### PR TITLE
Add browsersync port

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Made `/the-bureau/bureau-structure/role-macro.html` private.
 - Updated `gulp clean` to leave the `dist` directory and remove the inner
   contents
+- Use `HTTP_PORT` environment variable for port in `gulp watch`, if available.
 
 ### Removed
 - Removed Grunt plugins from package.json

--- a/gulp/tasks/browserSync.js
+++ b/gulp/tasks/browserSync.js
@@ -5,7 +5,7 @@ var util = require( 'gulp-util' );
 var browserSync = require( 'browser-sync' );
 
 gulp.task( 'browserSync', function() {
-  var port = util.env.port || '7000';
+  var port = util.env.port || process.env.HTTP_PORT || '7000'; // eslint-disable-line no-process-env, no-inline-comments, max-len
   browserSync.init( {
     proxy: 'localhost:' + port
   } );


### PR DESCRIPTION
Pull browserSync port from environment variable if available.

## Changes

- Use `HTTP_PORT` environment variable for port in `gulp watch`, if available.

## Testing

- `gulp watch` should use the port number set in the `HTTP_PORT` value in `.env`, if it's set. `--port` command-line flag should still work and override the environment variable.

## Review

- @jimmynotjim 
- @KimberlyMunoz 
- @sebworks 