### PR TITLE
Updated clean task to keep the dist dir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,8 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Updated Travis CI settings to use `setup.sh`.
 - Updated files to use `breakpoints-config.js`.
 - Made `/the-bureau/bureau-structure/role-macro.html` private.
+- Updated `gulp clean` to leave the `dist` directory and remove the inner
+  contents
 
 ### Removed
 - Removed Grunt plugins from package.json

--- a/gulp/tasks/clean.js
+++ b/gulp/tasks/clean.js
@@ -5,5 +5,5 @@ var del = require( 'del' );
 var config = require( '../config' ).clean;
 
 gulp.task( 'clean', function() {
-  del( config.dest );
+  del( config.dest + '/**/*' );
 } );


### PR DESCRIPTION
When running sheer from the `/dist` directory it crashes when you delete the directory during cleaning. This update fixes that so that only the files and folders within `/dist` and not the directory itself are removed.