### PR TITLE
Fixes #520 - extraneous parens

### DIFF
--- a/src/_includes/macros/util/format/contact.html
+++ b/src/_includes/macros/util/format/contact.html
@@ -41,7 +41,8 @@
 
    When given:
 
-   contact: A contact document object.
+   contact: A contact document object that contains street, street_2, city,
+            state, and zip_code fields.
 
    ========================================================================== #}
 
@@ -49,6 +50,6 @@
     {{ contact.street if contact.street }}<br>
     {{ contact.street_2 + '<br>' | safe if contact.street_2 else '' }}
     {{ contact.city + ',' if contact.city else '' }}
-    {{ (contact.state + '&nbsp;') | safe if contact.state else '' }}
+    {{ contact.state + '&nbsp;' | safe if contact.state else '' }}
     {{ contact.zip_code if contact.zip_code else '' }}
 {% endmacro %}


### PR DESCRIPTION
Fixes #520 - removes extraneous parens.

## Additions

- Additional code comment on fields needed for object passed to format_address macro.

## Removals

- Removes extraneous parens in format_address macro.

## Testing

- `/contact-us/` addresses should look the same.

## Review

- @KimberlyMunoz 
- @sebworks 
- @jimmynotjim 