### PR TITLE
Watch task should build files before watching for changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,8 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Made `/the-bureau/bureau-structure/role-macro.html` private.
 - Updated `gulp clean` to leave the `dist` directory and remove the inner
   contents
+- Updated `gulp watch` to build files if necessary before watching
+  (useful for new project or after running `gulp clean`)
 
 ### Removed
 - Removed Grunt plugins from package.json

--- a/gulp/tasks/watch.js
+++ b/gulp/tasks/watch.js
@@ -8,7 +8,7 @@
 var gulp = require( 'gulp' );
 var config = require( '../config' );
 
-gulp.task( 'watch', [ 'watchify', 'browserSync' ], function() {
+gulp.task( 'watch', [ 'build', 'watchify', 'browserSync' ], function() {
   gulp.watch( config.styles.cwd + '/**/*.less', [ 'styles' ] );
   gulp.watch( config.images.src, [ 'images' ] );
   gulp.watch( config.copy.files.src, [ 'copy:files' ] );


### PR DESCRIPTION
Updated `gulp watch` to build files if necessary before watching (useful for new project or after running `gulp clean`)

Fixes #912 