### PR TITLE
Fixes/Unit Test for assign.js

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Added breadcrumbs to blog, newsroom, careers, business, bureau
   and budget pages
 - Added Meredith Fuchs to Leadership calendar filter.
+- Added unit test for `assign` utility.
 
 ### Changed
 - Moved `.meta-header`, `.jump-link`,
@@ -61,6 +62,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Updated `/about-rich-cordray/` URL to `/about-director/`.
 - Updated `/about-meredith-fuchs/` URL to `/about-deputy-director/`.
 - Normalized director and deputy director photos to be format `NAME-WxH.jpg`.
+- Changed name of `shallow-extend` utility to 'assign'.
 
 ### Removed
 - Removed styles from codebase that have already been migrated

--- a/src/static/js/modules/util/assign.js
+++ b/src/static/js/modules/util/assign.js
@@ -1,6 +1,10 @@
 /* ==========================================================================
-   Shallow Extends
-   Copyright (c) 2014 Alexey Maslennikov
+   Assign
+
+   Code copied from the following with moderate modifications :
+
+   - https://github.com/maslennikov/shallow-extend
+     Copyright (c) 2014 Alexey Maslennikov
    ========================================================================== */
 
 'use strict';
@@ -17,14 +21,14 @@ function _isPlainObject( object ) {
 
 /**
 * Copies properties of all sources to the destination object overriding its own
-* existing properties. When extending from multiple sources, fields of every
+* existing properties. When assigning from multiple sources, fields of every
 * next source will override same named fields of previous sources.
 *
 * @param {object} destination object.
-* @returns {bbject} extended destination object.
+* @returns {object} assigned destination object.
 */
 
-function extend( destination ) {
+function assign( destination ) {
   destination = destination || {};
 
   for ( var i = 1; i < arguments.length; i++ ) {
@@ -33,7 +37,7 @@ function extend( destination ) {
       if ( source.hasOwnProperty( key ) ) {
         var value = source[key];
         if ( _isPlainObject( value ) ) {
-          extend( destination[key] = {}, value );
+          assign( destination[key] = {}, value );
         }else {
           destination[key] = source[key];
         }
@@ -44,4 +48,4 @@ function extend( destination ) {
 }
 
 // Expose public methods.
-module.exports = { extend: extend };
+module.exports = { assign: assign };

--- a/src/static/js/modules/util/date-range-formatter.js
+++ b/src/static/js/modules/util/date-range-formatter.js
@@ -5,7 +5,7 @@
 'use strict';
 
 var _dateFormat = require( 'dateformat' );
-var _extend = require( './shallow-extend' ).extend;
+var _assign = require( './assign' ).assign;
 var _uTc = require( './type-checkers' );
 var _isDate = _uTc.isDate;
 
@@ -31,7 +31,7 @@ var _properties = {};
 * @returns {object} An object with startDate and endDate properties.
 */
 function format( startDate, endDate, options ) {
-  _extend( _properties, _defaults, options || {} );
+  _assign( _properties, _defaults, options || {} );
   var dateRange = _properties.dateRange;
   var steps = [];
   var stepsResult;

--- a/test/unit_tests/modules/util/assign-spec.js
+++ b/test/unit_tests/modules/util/assign-spec.js
@@ -1,0 +1,79 @@
+'use strict';
+
+var chai = require( 'chai' );
+var expect = chai.expect;
+var assign = require( '../../../../src/static/js/modules/util/assign.js' )
+             .assign;
+var testObjectA;
+var testObjectB;
+var testObjectC;
+var undefinedVar;
+
+
+beforeEach( function() {
+
+  testObjectA = {
+    str:  'test',
+    func: function() { return 'testStr'; },
+    num:  1
+  };
+
+  testObjectB = {
+    obj:   { test: 2 },
+    arr:   [ 3 ],
+    _null: null
+  };
+
+  testObjectC = {
+    bool:  Boolean( false ),
+    undef: undefinedVar,
+    num:   4
+  };
+
+} );
+
+describe( 'Assign', function() {
+
+  it( 'should assign properties from source to destination', function() {
+    assign( testObjectA, testObjectB );
+
+    expect( testObjectA.hasOwnProperty( 'obj' ) ).to.be.true;
+    expect( testObjectA.hasOwnProperty( 'arr' ) ).to.be.true;
+    expect( testObjectA.hasOwnProperty( '_null' ) ).to.be.true;
+  } );
+
+  it( 'should assign values from source to destination', function() {
+    assign( testObjectA, testObjectB );
+
+    expect( testObjectA.obj.test === 2 ).to.be.true;
+    expect( testObjectA.arr[0] === 3 ).to.be.true;
+    expect( testObjectA._null === null ).to.be.true;
+  } );
+
+  it( 'should assign multiple source properties to destination', function() {
+    assign( testObjectA, testObjectB, testObjectC );
+
+    expect( testObjectA.hasOwnProperty( 'bool' ) ).to.be.true;
+    expect( testObjectA.hasOwnProperty( 'undef' ) ).to.be.true;
+    expect( testObjectA.hasOwnProperty( 'num' ) ).to.be.true;
+  } );
+
+  it( 'should assign multiple source values to destination', function() {
+    assign( testObjectA, testObjectB, testObjectC );
+
+    expect( testObjectA.bool === false ).to.be.true;
+    expect( typeof testObjectA.undef === 'undefined' ).to.be.true;
+    expect( testObjectA.num === 4 ).to.be.true;
+  } );
+
+  it( 'should selectively overwrite existing source properties', function() {
+    expect( testObjectA.num === 1 ).to.be.true;
+
+    assign( testObjectA, testObjectC );
+
+    expect( testObjectA.str === 'test' ).to.be.true;
+    expect( testObjectA.func() === 'testStr' ).to.be.true;
+    expect( testObjectA.num === 4 ).to.be.true;
+  } );
+
+} );


### PR DESCRIPTION
Copy Fixes/Unit Test for assign.js

## Changes
- Updated `src/static/js/modules/util/assign.js` to add more code source information. Changed name to better match purpose.
- Added `test/unit_tests/modules/util/assign-spec.js` to add unit test for `assign.js`
- Updated `src/static/js/modules/util/date-range-formatter.js` to use `assign.js`

## Testing
-  Run `gulp test:unit:js`. Unit test should complete successfully.

## Review
@anselmbradford 
@jimmynotjim
@KimberlyMunoz 