### PR TITLE
Adding Code for Event Transcript and RSVP

### DIFF
--- a/src/events/_event-post-macros.html
+++ b/src/events/_event-post-macros.html
@@ -432,10 +432,10 @@
                      src='https://placeholdit.imgix.net/~text?&w=360&h=202'>
             </p>
             <p class="speech_link-container">
-                <a href="#" class="jump-link
-                                   jump-link__external-link
-                                   jump-link__underline
-                                   u-link__disabled">
+                <a class="jump-link
+                          jump-link__external-link
+                          jump-link__underline
+                          u-link__disabled">
                     See the album for the Event
                 </a>
             </p>

--- a/src/events/_event-post-macros.html
+++ b/src/events/_event-post-macros.html
@@ -286,7 +286,7 @@
 
    Description:
 
-   Create an event agenda table when given
+   Create an event agenda table when given:
 
    post: A post from a query result.
 
@@ -300,6 +300,7 @@
       'location_col_classes': 'u-w25pct',
       'speaker_col_classes': 'u-w25pct',
   } %}
+
   <div class="block
               block__padded-top
               block__border-top">
@@ -352,4 +353,137 @@
     </table>
   </div>
   {% endif %}
+{% endmacro %}
+
+{# ==========================================================================
+
+   event_mailto_button()
+
+   ==========================================================================
+
+   Description:
+
+   Create an event mailto button when given:
+
+   event: An event from a query result.
+
+   ========================================================================== #}
+
+{% macro event_mailto_button( event ) %}
+{% if event.rsvp %}
+    {% set rsvp = {
+          'contact': event.rsvp.contact | list | last,
+          'subject': event.rsvp.email_subject,
+          'body'   : event.rsvp.email_body | striptags
+      }
+    %}
+{% else %}
+    {% set rsvp = {
+          'contact': 'reserve@cfpb.gov',
+          'subject': 'Event RSVP',
+          'body'   : 'To RSVP, please fill in your first and last
+                     name below and send this email.%0D%0A%0D%0A
+                     First name:%0D%0A
+                     Last name:'
+      }
+    %}
+{% endif %}
+<a href="mailto:{{rsvp.contact}}?subject={{rsvp.subject}}&body={{rsvp.body}}"
+   class="btn">
+   <span class="btn_icon__left cf-icon cf-icon-email-social"></span>
+      {{ rsvp.contact | safe }}
+</a>
+{% endmacro %}
+
+
+{# ==========================================================================
+
+   event_media()
+
+   ==========================================================================
+
+   Description:
+
+   Create event archive media markup when given:
+
+   event: An event from a query result.
+
+   TODO: Replace lorem ipsum and placeholder image.
+
+   ========================================================================== #}
+
+{% macro event_media( event ) %}
+
+{% set col_classes = 'content-l_col
+                      content-l_col-1-2
+                      block
+                      block__padded-top
+                      block__flush-top
+                      block__flush-bottom'
+%}
+
+<div class="block block__border-top">
+    <div class="event-archive_media-container
+                content-l
+                content-l__large-gutters">
+        <section class="{{ col_classes }} block__padded-bottom">
+            <h4>Photography</h4>
+            <p class="u-flexible-container">
+                <img class="u-flexible-container_inner"
+                     src='https://placeholdit.imgix.net/~text?&w=360&h=202'>
+            </p>
+            <p class="speech_link-container">
+                <a href="#" class="jump-link
+                                   jump-link__external-link
+                                   jump-link__underline
+                                   u-link__disabled">
+                    See the album for the Event
+                </a>
+            </p>
+        </section>
+        <section class="{{ col_classes }}">
+            {% if event.archive.video_transcript %}
+            <section class="block block__flush-top">
+                <h4>Speech text</h4>
+                <p class="short-desc">
+                    Curae natoque in aptent sagittis,
+                    montes amet quis mattis tempus
+                    nullam, primis sit libero diam arcu nascetur,
+                    per sociis quisque nostra. Mus litora dignissim
+                    mattis, est cum montes elit, dictum sociosqu
+                    cras condimentum, pellentesque lacus arcu hac.
+                </p>
+                <p>
+                    <a href="{{ event.archive.speech_transcript.url }}"
+                       class="jump-link
+                              jump-link__underline">
+                       Download speech
+                       <span class="cf-icon cf-icon-pdf"></span>
+                    </a>
+                </p>
+            </section>
+            {% endif %}
+
+            {% if  event.archive.video_transcript %}
+            <section class="block block__flush-bottom">
+                <h4>Video transcript</h4>
+                <p class="short-desc">
+                    Curae natoque in aptent sagittis,
+                    montes amet quis mattis tempus
+                    nullam, primis sit libero diam arcu nascetur,
+                    per sociis quisque nostra. Mus litora dignissim
+                </p>
+                <p>
+                    <a href="{{ event.archive.video_transcript.url }}"
+                       class="jump-link
+                              jump-link__underline">
+                       Download transcript
+                       <span class="cf-icon cf-icon-pdf"></span>
+                    </a>
+                </p>
+            </section>
+            {% endif %}
+        </section>
+    </div>
+</div>
 {% endmacro %}

--- a/src/events/_event-post-macros.html
+++ b/src/events/_event-post-macros.html
@@ -413,7 +413,6 @@
    ========================================================================== #}
 
 {% macro event_media( event ) %}
-
 {% set col_classes = 'content-l_col
                       content-l_col-1-2
                       block

--- a/src/events/_event.html
+++ b/src/events/_event.html
@@ -28,10 +28,6 @@
 {% macro render(post, path, event_state) %}
 
 {% import 'macros/share.html' as share %}
-<script>
-   console.log( {{ event.json_compatible() | tojson }} );
-</script>
-
 <article class="post post__event">
     <header>
         <h1 class="post_heading">

--- a/src/events/_event.html
+++ b/src/events/_event.html
@@ -28,6 +28,9 @@
 {% macro render(post, path, event_state) %}
 
 {% import 'macros/share.html' as share %}
+<script>
+   console.log( {{ event.json_compatible() | tojson }} );
+</script>
 
 <article class="post post__event">
     <header>
@@ -36,9 +39,9 @@
         </h1>
         <p class="post_dek">
         {% if (event_state == 'past')  %}
-          {{ event.archive.summary | striptags }}
+            {{ event.archive.summary | striptags }}
         {% else %}
-          {{ event.future.summary | striptags }}
+            {{ event.future.summary | striptags }}
         {% endif %}
         </p>
         <div class="modification-date date u-right">
@@ -74,11 +77,8 @@
                       <strong>This event requires an RSVP.</strong>
                   </p>
                   <p>
-                      <a href="mailto:reserve@cfpb.gov?subject=Event RSVP&body=To RSVP, please fill in your first and last name below and send this email.%0D%0A%0D%0AFirst name:%0D%0ALast name:"
-                         class="btn">
-                          <span class="btn_icon__left cf-icon cf-icon-email-social"></span>
-                           reserve@cfpb.gov
-                      </a>
+                  {% from '_event-post-macros.html' import event_mailto_button %}
+                  {{ event_mailto_button(event) }}
                   </p>
                 </div>
                 {% if (event.live_stream) %}

--- a/src/events/_single.html
+++ b/src/events/_single.html
@@ -26,16 +26,18 @@
     {% import '_event.html' as article with context %}
     {{ article.render(event, vars.path, event_state) }}
 
-    {% from '_event-post-macros.html' import event_agenda as event_agenda %}
+    {% from '_event-post-macros.html' import event_media %}
+    {{ event_media(event) }}
+
+    {% from '_event-post-macros.html' import event_agenda %}
     {{ event_agenda(event) }}
 
     <div class="event-footer">
         {% if event_state != 'past' %}
         <p class="event-footer_banner">
             <span class="event-footer_banner-message h4">This event requires an RSVP. Reserve your spot here: </span>
-            <a href="mailto:reserve@cfpb.gov?subject=Event RSVP&body=To RSVP, please fill in your first and last name below and send this email.%0D%0A%0D%0AFirst name:%0D%0ALast name:" class="btn">
-                <span class="btn_icon__left cf-icon cf-icon-email-social"></span>
-                 reserve@cfpb.gov</a>
+            {% from '_event-post-macros.html' import event_mailto_button %}
+            {{ event_mailto_button(event) }}
         </p>
         {% endif %}
         <div class="content-l">

--- a/src/static/css/pages/event.less
+++ b/src/static/css/pages/event.less
@@ -15,6 +15,7 @@
 }
 
 
+
 /* Event-Post-Preview
    ========================================================================== */
 
@@ -252,4 +253,26 @@
             display: block;
         });
     }
+}
+
+
+/* Event-Archive-Media
+   ========================================================================== */
+
+.event-archive_media-container {
+
+    .respond-to-max(@mobile-max, {
+        .speech_link-container {
+            margin-bottom: 0;
+        }
+    });
+
+    .respond-to-min(@tablet-min, {
+        display: flex;
+
+        .speech_link-container {
+            position: absolute;
+            bottom: 0;
+        }
+    });
 }


### PR DESCRIPTION
Event Transcript/RSVP

## Changes
- Updated `src/events/_event-post-macros.html` to add `event_mailto_button` and `event_media` macros. 
- Updated `src/events/_event.html`  to call `event_mailto_button` macro.
- Updated `src/events/_single.html` to call `event_mailto_button` macro.
- Updated `src/static/css/pages/event.less` to add styles for event archive media.

## Testing
-  Visit `http://localhost:7000/events/summer-consumer-advisory-board-meeting-in-omaha-ne/` and observe archive media block.

## Notes 
- I am using Flexbox to help align the links. May cause issues on legacy browsers.

**Update**
- Currently, the download links are inoperable (`Download speech`, `Download transcript`) .  Working with content to resolve the issue.

## Screenshots

Desktop
<img width="903" alt="screen shot 2015-08-21 at 5 25 18 pm" src="https://cloud.githubusercontent.com/assets/1696212/9419433/a4e0676a-4829-11e5-9d74-912b5223f0d4.png">

Tablet
<img width="899" alt="screen shot 2015-08-21 at 5 26 43 pm" src="https://cloud.githubusercontent.com/assets/1696212/9419456/d65b9fbc-4829-11e5-914b-bff199dbef58.png">

Mobile
<img width="388" alt="screen shot 2015-08-21 at 5 28 52 pm" src="https://cloud.githubusercontent.com/assets/1696212/9419501/2537c78c-482a-11e5-8757-d5cddc60cfbc.png">


## Review
@anselmbradford 
@jimmynotjim
@KimberlyMunoz 
