### PR TITLE
Sprint PR cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Updated `/about-meredith-fuchs/` URL to `/about-deputy-director/`.
 - Normalized director and deputy director photos to be format `NAME-WxH.jpg`.
 - Changed name of `shallow-extend` utility to 'assign'.
+- Superscripts `st` in `21st` on About Us page.
 
 ### Removed
 - Removed styles from codebase that have already been migrated
@@ -94,7 +95,6 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Added accessibility complaint form.
 - Added "File an EEO Issue" form.
 - Added `/offices/office-of-civil-rights/` page, tests, and link in footer.
-- Added time macro.
 
 ### Changed
 - Site's "About" text to "About Us".

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -111,7 +111,7 @@ pip install git+git://github.com/rosskarchner/govdelivery
 
 > **NOTE:** GovDelivery is a third-party web service that powers our subscription forms.
   Users may decide to swap this tool out for another third-party service.
-  The application will function but throw an error
+  The application will throw an error
   if the GovDelivery environment variables are not set
   in the [Project Configuration](https://github.com/cfpb/cfgov-refresh/blob/flapjack/INSTALL.md#4-project-configuration).
 
@@ -167,9 +167,8 @@ if you don't already have one.
 Inside the `.env` file you can customize the project environment configuration.
 
 If you would like to manually copy the environment settings,
-copy the `.env-SAMPLE` file and un-comment each variable after
+copy the `.env_SAMPLE` file and un-comment each variable after
 adding your own values.
-`WORDPRESS` is the only one that’s absolutely necessary to run the site.
 ```bash
 cp -a .env_SAMPLE .env && open .env
 ```

--- a/TEST.md
+++ b/TEST.md
@@ -31,6 +31,7 @@ Sauce Labs can be used to run tests remotely in the cloud.
    and run that in your Terminal window.
    Once you see `Sauce Connect is up` in the Terminal,
    that means the tunnel has successfully been established
+
    > The Terminal command should already have your Sauce username and access key filled in.
      If it doesn't, make sure you're logged in.
 5. Update and uncomment the `SAUCE_USERNAME`, `SAUCE_ACCESS_KEY`,

--- a/src/_includes/macros/activity-snippets.html
+++ b/src/_includes/macros/activity-snippets.html
@@ -131,9 +131,9 @@
                     {{ item.title | safe  }}
                     {%- if include_date_flag and item.date -%}
                         <span class="date">
-                          &ndash;
-                          {% import 'macros/time.html' as time %}
-                          {{ time.render(item.date, {'date':true}) }}
+                            &ndash;
+                            {% import 'macros/time.html' as time %}
+                            {{ time.render(item.date, {'date':true}) }}
                         </span>
                     {%- endif -%}
                 </a>

--- a/src/_includes/macros/filters.html
+++ b/src/_includes/macros/filters.html
@@ -218,26 +218,21 @@
 
     {# Calendar filters #}
     {% elif filter == 'calendar' %}
+    {% set directors_list = ['Richard Cordray',
+                             'Meredith Fuchs',
+                             'Steve Antonakes',
+                             'Raj Date',
+                             'Elizabeth Warren'] %}
         <div class="form-l_col form-l_col-1-3">
             <div class="form-group required-check-group">
                 <label class="form-label-header">
                     Calendars
                 </label>
+                {% for director in directors_list %}
                 <label class="form-group_item">
-                    {{ _filter_checkbox('calendar', 'Richard Cordray')|safe }}
+                    {{ _filter_checkbox('calendar', director) | safe }}
                 </label>
-                <label class="form-group_item">
-                    {{ _filter_checkbox('calendar', 'Meredith Fuchs')|safe }}
-                </label>
-                <label class="form-group_item">
-                    {{ _filter_checkbox('calendar', 'Steve Antonakes')|safe }}
-                </label>
-                <label class="form-group_item">
-                    {{ _filter_checkbox('calendar', 'Raj Date')|safe }}
-                </label>
-                <label class="form-group_item">
-                    {{ _filter_checkbox('calendar', 'Elizabeth Warren')|safe }}
-                </label>
+                {% endfor %}
             </div>
         </div>
 

--- a/src/_includes/macros/util/format/datetime.html
+++ b/src/_includes/macros/util/format/datetime.html
@@ -15,7 +15,7 @@
    datetime: A datetime object.
 
    timezone (optional): Whether to include the timezone or not.
-                        Provide '' to default to 'US/Eastern',
+                        Provide '' to default to 'America/New_York',
                         otherwise provide actual timezone.
 
    ========================================================================== #}

--- a/src/_includes/templates/forms/accessibility-feedback-form.html
+++ b/src/_includes/templates/forms/accessibility-feedback-form.html
@@ -12,7 +12,8 @@
         </div>
 
         <div class="form-l_col form-l_col-1-2">
-            <label class="form-label-header" for="accessibility-form_first-name">
+            <label class="form-label-header"
+                   for="accessibility-form_first-name">
                 First name*
             </label>
             <input class="input__long"
@@ -22,7 +23,8 @@
         </div>
 
         <div class="form-l_col form-l_col-1-2">
-            <label class="form-label-header" for="accessibility-form_last-name">
+            <label class="form-label-header"
+                   for="accessibility-form_last-name">
                 Last name*
             </label>
             <input class="input__long"
@@ -141,8 +143,8 @@
                       <option>8:00 a.m</option>
                  </select>
                  <span class="custom-select_icon
-                                 cf-icon
-                                 cf-icon-down"></span>
+                              cf-icon
+                              cf-icon-down"></span>
             </div>
         </div>
 
@@ -182,8 +184,8 @@
                       <option>PDF</option>
                  </select>
                  <span class="custom-select_icon
-                                 cf-icon
-                                 cf-icon-down"></span>
+                              cf-icon
+                              cf-icon-down"></span>
             </div>
         </div>
 
@@ -194,7 +196,7 @@
             <input class="btn form-actions_item"
                    type="submit"
                    value="Generate PDF">
-            <a href="#" class="btn btn__link form-actions_item">
+            <a class="btn btn__link form-actions_item u-link__disabled">
                 Sample Letter
                 <span class="cf-icon cf-icon-pdf"></span>
             </a>

--- a/src/_includes/templates/forms/amending-and-correcting-records-under-the-privacy-act-form.html
+++ b/src/_includes/templates/forms/amending-and-correcting-records-under-the-privacy-act-form.html
@@ -96,8 +96,8 @@
                       <option>8:00 a.m</option>
                  </select>
                  <span class="custom-select_icon
-                                 cf-icon
-                                 cf-icon-down"></span>
+                              cf-icon
+                              cf-icon-down"></span>
             </div>
         </div>
        <div class="form-l_col form-l_col-1-2">
@@ -172,11 +172,11 @@
                       required>
             </textarea>
         </div>
-        <div class="form-actions form-actions__right-on-med ">
+        <div class="form-actions form-actions__right-on-med">
             <input class="btn form-actions_item"
                    type="submit"
                    value="Generate PDF">
-            <a href="#" class="btn btn__link form-actions_item">
+            <a class="btn btn__link form-actions_item u-link__disabled">
                 Sample Letter
                 <span class="cf-icon cf-icon-pdf"></span>
             </a>

--- a/src/_includes/templates/forms/file-a-privacy-complaint-form.html
+++ b/src/_includes/templates/forms/file-a-privacy-complaint-form.html
@@ -100,8 +100,8 @@
                       <option>8:00 a.m</option>
                  </select>
                  <span class="custom-select_icon
-                                 cf-icon
-                                 cf-icon-down"></span>
+                              cf-icon
+                              cf-icon-down"></span>
             </div>
         </div>
         <div class="form-l_col form-l_col-1-2">
@@ -159,11 +159,11 @@
                       required>
             </textarea>
         </div>
-        <div class="form-actions form-actions__right-on-med ">
+        <div class="form-actions form-actions__right-on-med">
             <input class="btn form-actions_item"
                    type="submit"
                    value="Generate PDF">
-            <a href="#" class="btn btn__link form-actions_item">
+            <a class="btn btn__link form-actions_item u-link__disabled">
                 Sample Letter
                 <span class="cf-icon cf-icon-pdf"></span>
             </a>

--- a/src/_includes/templates/forms/form-eeo-issue.html
+++ b/src/_includes/templates/forms/form-eeo-issue.html
@@ -151,7 +151,7 @@
                 <input class="btn form-actions_item"
                        type="submit"
                        value="Generate PDF">
-                <a href="#" class="btn btn__link form-actions_item">
+                <a class="btn btn__link form-actions_item u-link__disabled">
                     Sample Letter
                     <span class="cf-icon cf-icon-pdf"></span>
                 </a>

--- a/src/_includes/templates/forms/plain-writing-feedback-form.html
+++ b/src/_includes/templates/forms/plain-writing-feedback-form.html
@@ -4,7 +4,8 @@
                     block__flush-sides">
         <form class="form-l js-validate-filters">
             <div class="form-l_col form-l_col-1-2">
-                <label class="form-label-header" for="plain-writing-fb_first-name">
+                <label class="form-label-header"
+                       for="plain-writing-fb_first-name">
                     First name
                 </label>
                 <input class="input__long"
@@ -14,7 +15,8 @@
             </div>
 
             <div class="form-l_col form-l_col-1-2">
-                <label class="form-label-header" for="plain-writing-fb_last-name">
+                <label class="form-label-header"
+                       for="plain-writing-fb_last-name">
                     Last name
                 </label>
                 <input class="input__long"
@@ -91,7 +93,8 @@
 
 
             <div class="form-l_col form-l_col-1">
-                <label class="form-label-header" for="plain-writing-fb_request-desc">
+                <label class="form-label-header"
+                       for="plain-writing-fb_request-desc">
                     Plain writing feedback
                 </label>
                 <textarea class="input__long"
@@ -116,11 +119,11 @@
                        type="text">
             </div>
 
-            <div class="form-actions form-actions__right-on-med ">
+            <div class="form-actions form-actions__right-on-med">
                 <input class="btn form-actions_item"
                        type="submit"
                        value="Generate PDF">
-                <a href="#" class="btn btn__link form-actions_item">
+                <a class="btn btn__link form-actions_item u-link__disabled">
                     Sample Letter
                     <span class="cf-icon cf-icon-pdf"></span>
                 </a>
@@ -143,7 +146,9 @@
                 </h5>
 
                 <p class="short-desc">
-                    <a href="mailto:Plain_Writing_Act@consumerfinance.gov">Plain_Writing_Act@consumerfinance.gov</a>
+                    <a href="mailto:Plain_Writing_Act@consumerfinance.gov">
+                        Plain_Writing_Act@consumerfinance.gov
+                    </a>
                 </p>
             </div>
             <div class="content-l_col

--- a/src/_includes/templates/forms/submit-a-request-form.html
+++ b/src/_includes/templates/forms/submit-a-request-form.html
@@ -4,7 +4,8 @@
                     block__flush-sides">
         <form class="form-l js-validate-filters">
             <div class="form-l_col form-l_col-1-2">
-                <label class="form-label-header" for="foia-request_first-name">
+                <label class="form-label-header"
+                       for="foia-request_first-name">
                     First name
                 </label>
                 <input class="input__long"
@@ -14,7 +15,8 @@
             </div>
 
             <div class="form-l_col form-l_col-1-2">
-                <label class="form-label-header" for="foia-request_last-name">
+                <label class="form-label-header"
+                       for="foia-request_last-name">
                     Last name
                 </label>
                 <input class="input__long"
@@ -57,7 +59,9 @@
                     </span><br/>
                     <span class="micro-copy micro-copy__large">
                         Describe the records you seek from the CFPB.
-                        <a href="../foia-faqs" target="_blank">Review our FAQs for additional guidance.</a>
+                        <a href="../foia-faqs" target="_blank">
+                            Review our FAQs for additional guidance.
+                        </a>
                     </span>
                 </label>
                 <textarea class="input__long"
@@ -147,7 +151,9 @@
                             form-l-inset">
                     <div class="form-l-inset_container">
                         <label>
-                            <input class="custom-input" type="radio" name="expedite_button">
+                            <input class="custom-input"
+                                   type="radio"
+                                   name="expedite_button">
                             No
                         </label>
                     </div>
@@ -157,7 +163,9 @@
                             form-l-inset">
                     <div class="form-l-inset_container">
                         <label>
-                            <input class="custom-input" type="radio" name="expedite_button">
+                            <input class="custom-input"
+                                   type="radio"
+                                   name="expedite_button">
                             Yes
                         </label>
                     </div>
@@ -178,7 +186,9 @@
                             form-l-inset">
                     <div class="form-l-inset_container">
                         <label>
-                            <input class="custom-input" type="radio" name="response-method_button">
+                            <input class="custom-input"
+                                   type="radio"
+                                   name="response-method_button">
                             Email
                         </label>
                     </div>

--- a/src/about-us/index.html
+++ b/src/about-us/index.html
@@ -11,7 +11,7 @@
         <h1>About Us</h1>
         <p class="h3">
             The Consumer Financial Protection Bureau (CFPB)
-            is a 21st century agency that helps consumer finance markets work
+            is a 21<sup>st</sup> century agency that helps consumer finance markets work
             by making rules more effective,
             by consistently and fairly enforcing those rules,
             and by empowering consumers to take more control

--- a/src/events/_event-post-macros.html
+++ b/src/events/_event-post-macros.html
@@ -252,7 +252,10 @@
                         {% import 'macros/time.html' as time %}
                         {{ time.render(post.beginning_time.date) }}
                         {# TODO: Replace with real download link #}
-                        <a class="event-calendar_download jump-link jump-link__download" href="#">
+                        <a class="event-calendar_download
+                                  jump-link
+                                  jump-link__download
+                                  u-link__disabled">
                             <span class="jump_link_text">Download .ics</span>
                         </a>
                     {% endif %}

--- a/src/offices/_single.html
+++ b/src/offices/_single.html
@@ -64,7 +64,7 @@
                         content-l_col-1
                         {% endif -%}">
                 <div class="short-desc
-                          qa-top-story-desc">
+                            qa-top-story-desc">
                     {{ top_story.desc | safe }}
                 </div>
             </div>

--- a/src/static-legacy/js/functions.js
+++ b/src/static-legacy/js/functions.js
@@ -1,73 +1,73 @@
-// trigger when page is ready
-$(document).ready(function() {
+// Trigger when page is ready.
+$( document ).ready( function() {
 
-    // Remove styles from feature images
-    $("a > img").each(function() {
-        $(this).parent().addClass("noStyles");
+    // Remove styles from feature images.
+    $( 'a > img' ).each( function() {
+        $( this ).parent().addClass( 'noStyles' );
     });
 
-    // Add pdf class to pdf links
-    $('a[href$="pdf"]').each(function() {
-        $(this).addClass("pdf");
+    // Add pdf class to pdf links.
+    $( 'a[href$="pdf"]' ).each( function() {
+        $( this ).addClass( 'pdf' );
     });
 
     // Stripe table rows in older browsers
-    // if jquery is running and IE > 9
+    // if jquery is running and IE < 9.
     if (typeof $ !== 'undefined' && typeof is_lt_IE9 !== 'undefined') {
-        $('table tbody tr:even').addClass('even');
-        $('table tbody tr:odd').addClass('odd');
+        $( 'table tbody tr:even' ).addClass( 'even' );
+        $( 'table tbody tr:odd' ).addClass( 'odd' );
     }
 
     // Report specific js for sticky nav
     $(window).scroll( stickyNav );
 
     // Init cShowHide plugin
-    $('.show-hide').cShowHide();
+    $( '.show-hide' ).cShowHide();
 });
 
 
 $.fn.cShowHide = function cShowHide() {
 
-    this.filter(".default-hidden").find(".show-hide-content").hide();
+    this.filter( '.default-hidden' ).find( '.show-hide-content' ).hide();
 
-    this.find(".show-hide-link").click(function(e) {
+    this.find( '.show-hide-link' ).click( function( e ) {
 
         e.preventDefault();
-        var $clicked_show_hide_a = $(this);
+        var $clicked_show_hide_a = $( this );
 
         // The entire SHow/Hide DOM object:
-        var $show_hide = $(this).parent(".show-hide");
+        var $show_hide = $( this ).parent( '.show-hide' );
 
-        var $show_hide_content = $show_hide.find("> .show-hide-content");
+        var $show_hide_content = $show_hide.find( '> .show-hide-content' );
 
-        var textshow = $(this).attr('data-textshow');
+        var textshow = $( this ).attr( 'data-textshow' );
 
-        var texthide = $(this).attr('data-texthide');
+        var texthide = $( this ).attr( 'data-texthide' );
 
-        if ($show_hide.hasClass("default-hidden")) {
-            $show_hide.removeClass("default-hidden");
-            $show_hide_content.slideDown(500);
-            $clicked_show_hide_a.find("span").html(texthide);
+        if ( $show_hide.hasClass( 'default-hidden' ) ) {
+            $show_hide.removeClass( 'default-hidden' );
+            $show_hide_content.slideDown( 500 );
+            $clicked_show_hide_a.find( 'span' ).html( texthide );
         } else {
-            $show_hide.addClass("default-hidden");
-            $show_hide_content.slideUp(500);
-            $clicked_show_hide_a.find("span").html(textshow);
+            $show_hide.addClass( 'default-hidden' );
+            $show_hide_content.slideUp( 500 );
+            $clicked_show_hide_a.find( 'span' ).html( textshow );
         }
     });
 };
 
 function stickyNav() {
-  $('.report header h2').each(function() {
-      var scrtop = $(window).scrollTop();
-      var positioner = $(this).parent().parent();
+  $( '.report header h2' ).each( function() {
+      var scrtop = $( window ).scrollTop();
+      var positioner = $( this ).parent().parent();
       var offset = positioner.offset();
       offset.bottom = positioner.height() + offset.top;
-      var id = positioner.attr('id');
-      section_link = $('#nav-list').find('a[href="#' + id + '"]');
-      if ((offset.top <= scrtop) && (offset.bottom > scrtop)) {
-          section_link.css("color", "#010101");
+      var id = positioner.attr( 'id' );
+      section_link = $( '#nav-list' ).find( 'a[href="#' + id + '"]' );
+      if ( ( offset.top <= scrtop ) && ( offset.bottom > scrtop ) ) {
+          section_link.css( 'color', '#010101' );
       } else {
-          section_link.css("color", "");
+          section_link.css( 'color', '' );
       }
   });
 }

--- a/test/macro_tests/test_macros.py
+++ b/test/macro_tests/test_macros.py
@@ -19,7 +19,8 @@ class CFGovTestCase(SheerEnvironment, MacroTestCase):
         # lives three levels above the cfgov-refresh root.
         root_dir = os.path.abspath(os.path.join(
             os.path.dirname(__file__),
-            os.pardir, os.pardir,
+            os.pardir,
+            os.pardir,
             'src'))
         return root_dir
 


### PR DESCRIPTION
Addresses comments from Sprint 34 and beta PRs. 

## Changes

- Fixes typos.
- Removes incorrect copy from readme.
- Moves generation of HTML for director checkboxes in calendar filters to list instead of hardcoded values. 
- Updates timezone default to be consistent between datetime macros.
- Properly disables non-functional links.
- General code style formatting.

## Testing

- Should be no change, but double-check `/the-bureau/leadership-calendar/` filter and `/budget/strategic-plan/interactive/`

## Review

- @jimmynotjim 
- @sebworks 
- @KimberlyMunoz 