### PR TITLE
Adds code quality badges to repo for flapjack branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # cfgov-refresh
 
+[![Build Status](https://travis-ci.org/cfpb/cfgov-refresh.png?branch=flapjack)](https://travis-ci.org/cfpb/cfgov-refresh?branch=flapjack)
+[![Coverage Status](https://coveralls.io/repos/cfpb/cfgov-refresh/badge.png?branch=flapjack)](https://coveralls.io/r/cfpb/cfgov-refresh?branch=flapjack)
+[![Code Climate](https://codeclimate.com/github/cfpb/cfgov-refresh.png?branch=flapjack)](https://codeclimate.com/github/cfpb/cfgov-refresh?branch=flapjack)
+
 The in-progress redesign of the [consumerfinance.gov](http://consumerfinance.gov) website.
 This project includes the front-end assets and build tools,
 [Jinja templates](http://jinja.pocoo.org) for front-end rendering,


### PR DESCRIPTION
Adds TravisCI, Coveralls, and Code Climate code quality badges to repo for flapjack branch.

## Additions

- Adds TravisCI, Coveralls, and Code Climate code quality badges to repo for flapjack branch in README.md.

## Testing

- Check URLs for badges.

## Review

- @KimberlyMunoz 
- @sebworks 
- @jimmynotjim 

## Screenshots

![screen shot 2015-08-25 at 2 38 07 pm](https://cloud.githubusercontent.com/assets/704760/9475803/f79a3354-4b36-11e5-90bc-c60ff26b75ed.png)

