### PR TITLE
Adding ARIA states and config code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,9 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Django-Sheerlike integration
 - Added Acceptance tests for `the-bureau` pages.
 - Added test utility to retreive QA elements.
+- Added ARIA state utility to enable decorating dom elements with ARIA states.
+- Added `Object.defineProperty` polyfill.
+- Added unit test for `aria-state.js`.
 
 ### Changed
 - Updated Video Code to make it usable on Events pages.

--- a/src/static/js/config/aria-states-config.js
+++ b/src/static/js/config/aria-states-config.js
@@ -1,0 +1,79 @@
+/* ==========================================================================
+   Aria State
+
+   Code copied from the following with minor modifications:
+
+   - https://github.com/IBM-Watson/a11y.js
+     Copyright (c) 2014 IBM
+
+   - http://www.w3.org/TR/wai-aria/states_and_properties
+   ========================================================================== */
+'use strict';
+
+var UNDEFINED;
+
+var states = {
+  // Indicates whether an element, and its subtree,
+  // are currently being updated.
+  'aria-busy': {
+    validElements: [ 'all' ],
+    validValues:   [ true, false ]
+  },
+
+  // Indicates the current "checked" state of checkboxes, radio buttons,
+  // and other widgets. See related aria-pressed and aria-selected.
+  'aria-checked': {
+    validElements: [ 'all' ],
+    validValues:   [ true, false, 'mixed', UNDEFINED ]
+  },
+
+  // Indicates that the element is perceivable but disabled, so it is
+  // not editable or otherwise operable. See related aria-hidden
+  // and aria-readonly.
+  'aria-disabled': {
+    validElements: [ 'all' ],
+    validValues:   [ true, false, 'mixed', UNDEFINED ]
+  },
+
+  // Indicates whether the element, or another grouping element
+  // it controls, is currently expanded or collapsed.
+  'aria-expanded': {
+    validElements: [ 'button', 'document', 'link', 'section', 'sectionhead',
+      'separator', 'window' ],
+    validValues: [ true, false, UNDEFINED ]
+  },
+  // Indicates an element's "grabbed" state in a drag-and-drop operation.
+  'aria-grabbed': {
+    validElements: [ 'all' ],
+    validValues:   [ true, false, UNDEFINED ]
+  },
+
+  // Indicates that the element and all of its descendants are not visible
+  // or perceivable to any user as implemented by the author. See related
+  // aria-disabled.
+  'aria-hidden': {
+    validElements: [ 'all' ],
+    validValues:   [ true, false, UNDEFINED ]
+  },
+
+  // Indicates the entered value does not conform to the format
+  // expected by the application.
+  'aria-invalid': {
+    validElements: [ 'all' ],
+    validValues:   [ true, false, 'grammar', 'spelling' ]
+  },
+
+  // Indicates the current "pressed" state of toggle buttons.
+  'aria-pressed': {
+    validElements: [ 'all' ],
+    validValues:   [ true, false, 'mixed', UNDEFINED ]
+  },
+
+  // Indicates the current "selected" state of various widgets.
+  'aria-selected': {
+    validElements: [ 'gridcell', 'option', 'row', 'tab' ],
+    validValues:   [ true, false, UNDEFINED ]
+  }
+};
+
+module.exports = states;

--- a/src/static/js/modules/polyfill/object-defineproperty-polyfill.js
+++ b/src/static/js/modules/polyfill/object-defineproperty-polyfill.js
@@ -1,0 +1,66 @@
+/* ==========================================================================
+ Polyfill for Object defineProperty.
+ Copied from the following with minor modifications:
+
+  - https://developer.mozilla.org/en-US/docs/Web
+    /JavaScript/Reference/Global_Objects/Array/map.
+ ========================================================================== */
+'use strict';
+
+( function() {
+  if ( Object.defineProperty ) {
+    return;
+  }
+  var supportsAccessors = Object.prototype.hasOwnProperty( '__defineGetter__' );
+  var ERR_ACCESSORS_NOT_SUPPORTED =
+  'Getters & setters cannot be defined on this javascript engine';
+  var ERR_VALUE_ACCESSORS =
+    'A property cannot both have accessors and be writable or have a value';
+  Object.defineProperty = function defineProperty( object, property, // eslint-disable-line max-statements, complexity, max-len
+    descriptor ) {
+    // handle object
+    if ( object === null || !( object instanceof Object || typeof object ===
+      'object' ) ) {
+      throw new TypeError( 'Object must be an object' );
+    }
+
+    // handle descriptor
+    if ( !( descriptor instanceof Object ) ) {
+      throw new TypeError( 'Descriptor must be an object' );
+    }
+    var propertyString = String( property );
+    var getterType = 'get' in descriptor && typeof descriptor.get;
+    var setterType = 'set' in descriptor && typeof descriptor.set;
+    var hasValueOrWritable = 'value' in descriptor || 'writable' in descriptor;
+    // handle descriptor.get
+    if ( getterType ) {
+      if ( getterType !== 'function' ) {
+        throw new TypeError( 'Getter expected a function' );
+      }
+      if ( !supportsAccessors ) {
+        throw new TypeError( ERR_ACCESSORS_NOT_SUPPORTED );
+      }
+      if ( hasValueOrWritable ) {
+        throw new TypeError( ERR_VALUE_ACCESSORS );
+      }
+      object.__defineGetter__( propertyString, descriptor.get );
+    } else {
+      object[propertyString] = descriptor.value;
+    }
+    // handle descriptor.set
+    if ( setterType ) {
+      if ( setterType !== 'function' ) {
+        throw new TypeError( 'Setter expected a function' );
+      }
+      if ( !supportsAccessors ) {
+        throw new TypeError( ERR_ACCESSORS_NOT_SUPPORTED );
+      }
+      if ( hasValueOrWritable ) {
+        throw new TypeError( ERR_VALUE_ACCESSORS );
+      }
+      object.__defineSetter__( propertyString, descriptor.set );
+    }
+    // return object
+    return object;
+  };
+} )();

--- a/src/static/js/modules/util/aria-state.js
+++ b/src/static/js/modules/util/aria-state.js
@@ -1,0 +1,144 @@
+/* ==========================================================================
+   ARIA State
+
+   Code conventions copied from the following with major modifications:
+
+   - https://github.com/IBM-Watson/a11y.js
+     Copyright (c) 2014 IBM
+   ========================================================================== */
+
+'use strict';
+
+require( '../polyfill/object-defineproperty-polyfill' );
+var ariaStatesConfig = require( '../../config/aria-states-config' );
+var ariaState;
+
+
+// Private Properties
+
+var _statePrefix = 'is';
+var _ariaStatePrefix = 'aria-';
+
+
+// Private Methods
+
+/**
+ ** Defines ARIA state propery on an object.
+ *
+ * @param {string} state - ARIA state.
+ * @param {HTMLElement} element - Element in which to apply
+                                  the ARIA state attribute.
+ * @param {object} object - Object in which to apply the ARIA state.
+ * @returns {object}.
+ */
+function _defineProperty( state, element, object ) {
+  var _value = object[state] || false;
+  var _state = state;
+  var _element = element;
+
+  Object.defineProperty( object, state, {
+    enumerable:   true,
+    configurable: true,
+
+    get: function() {
+      return _value;
+    },
+
+    set: function( value ) {
+      _value = value;
+      ariaState.set( _state, _element, _value );
+    }
+  } );
+
+  ariaState.set( _state, _element, _value );
+
+  return object;
+}
+
+/**
+ * Validates ARIA state exists using config file.
+ *
+ * @param {string} state - ARIA state.
+ * @returns {Boolean} - Value indicating if ARIA state is valid.
+ */
+function _validateState( state ) {
+  return Boolean( ariaStatesConfig[_ariaStatePrefix + state] );
+}
+
+
+// Public Methods
+
+ariaState = {
+
+  /**
+   * Creates ARIA state on an object.
+   *
+   * @param {string} state - ARIA state.
+   * @param {HTMLElement} element - Element in which to apply
+                                    the ARIA state attribute.
+   * @returns {object} - Object with defined ARIA state.
+   */
+  create: function create( state, element ) {
+    if ( _validateState( state ) === false ||
+         element instanceof HTMLElement === false ) {
+      throw new Error( 'Invalid Arguments' );
+    }
+
+    return this.define( state, element, {} );
+  },
+
+  /**
+   * Defines ARIA state string using prefix. Calls internal
+   * function to define ARIA state property on an object.
+   *
+   * @param {string} state - ARIA state.
+   * @param {HTMLElement} element - Element in which to apply
+                                    the ARIA state attribute.
+   * @param {object} object - Value of the ARIA state attribute.
+   * @returns {object} - Object with define ARIA state.
+   */
+  define: function define( state, element, object ) {
+    if ( _validateState( state ) ) {
+      state = _statePrefix + state.charAt( 0 ).toUpperCase() +
+              state.substring( 1 );
+      _defineProperty( state, element, object );
+    }
+
+    return object;
+  },
+
+  /**
+   * Gets ARIA state attribute value from dom element.
+   *
+   * @param {string} state - ARIA state.
+   * @param {HTMLElement} element - Element in which to apply
+                                    the ARIA state attribute.
+   * @returns {value} - ARIA state attribute value.
+   */
+  get: function get( state, element ) {
+    return element.getAttribute( ariaStatesConfig[_ariaStatePrefix + state] );
+  },
+
+  /**
+   * Sets ARIA state attribute on a dom elment.
+   *
+   * @param {string} state - ARIA state.
+   * @param {HTMLElement} element - Element in which to apply
+                                    the ARIA state attribute.
+   * @param {string} value - Value of the ARIA state attribute.
+   * @returns {element} - dom element.
+   */
+  set: function set( state, element, value ) {
+    state = state.substr( 0, 2 ) === 'is' && state.substr( 2 ) || state;
+    state = state.toLowerCase();
+    if ( _validateState( state ) ) {
+      state = _ariaStatePrefix + state;
+      element.setAttribute( state, value );
+    }
+
+    return element;
+  }
+
+};
+
+module.exports = ariaState;

--- a/test/unit_tests/modules/util/aria-state-spec.js
+++ b/test/unit_tests/modules/util/aria-state-spec.js
@@ -1,0 +1,61 @@
+'use strict';
+var chai = require( 'chai' );
+var expect = chai.expect;
+var jsdom = require( 'mocha-jsdom' );
+var ariaState =
+require( '../../../../src/static/js/modules/util/aria-state.js' );
+var element;
+var obj;
+
+describe( 'ARIA state', function() {
+
+  jsdom();
+
+  beforeEach( function() {
+    obj = { isTest: true };
+    element = document.createElement( 'div' );
+    document.body.appendChild( element );
+  } );
+
+  it( 'should create a state object with the correct ARIA state', function() {
+    var state = ariaState.create( 'expanded', element );
+    expect( state.isExpanded ).to.be.false;
+    expect( element.getAttribute( 'aria-expanded' ) === 'false' ).to.be.true;
+
+    state = ariaState.create( 'disabled', element );
+    expect( state.isDisabled ).to.be.false;
+    expect( element.getAttribute( 'aria-disabled' ) === 'false' ).to.be.true;
+  } );
+
+  it( 'should throw errors when created with invalid arguments', function() {
+    var errorTxt = 'Invalid Arguments';
+    expect( ariaState.create.bind( 'expanded', '' ) ).to.throw( errorTxt );
+    expect( ariaState.create.bind( 'closed', element ) ).to.throw( errorTxt );
+  } );
+
+  it( 'should define the correct ARIA state property and attribute',
+    function() {
+    ariaState.define( 'invalid', element, obj );
+    expect( obj.hasOwnProperty( 'isInvalid' ) ).to.be.true;
+    expect( element.getAttribute( 'aria-invalid' ) === 'false' ).to.be.true;
+
+    this.isGrabbed = true;
+    ariaState.define( 'grabbed', element, this );
+    expect( this.hasOwnProperty( 'isGrabbed' ) ).to.be.true;
+    expect( element.getAttribute( 'aria-grabbed' ) === 'true' ).to.be.true;
+    delete this.isGrabbed;
+  } );
+
+  it( 'should change the ARIA state after state property changes', function() {
+    var state = ariaState.create( 'hidden', element );
+    expect( element.getAttribute( 'aria-hidden' ) === 'false' ).to.be.true;
+    state.isHidden = true;
+    expect( element.getAttribute( 'aria-hidden' ) === 'true' ).to.be.true;
+
+    ariaState.define( 'selected', element, obj );
+    expect( element.getAttribute( 'aria-selected' ) === 'false' ).to.be.true;
+    obj.isSelected = true;
+    expect( element.getAttribute( 'aria-selected' ) === 'true' ).to.be.true;
+  } );
+
+} );


### PR DESCRIPTION
Adding ARIA states and config code.

## Changes
 - Added `src/static/js/config/aria-states-config.j` to create ARIA states config file with valid elements lookup. 

- Added `src/static/js/modules/util/aria-state.js` to create ARIA states and update dom elements based on object properties. 

## Testing
-  Still working on a Unit test for this PR.

Update: Added Unit Test in https://github.com/cfpb/cfgov-refresh/commit/0781acc7c56c707491c140fe78abc114ee6f06c8

## Notes
- The basic use cases are as follows : 
```
var state = ariaState.create( 'expanded', element ); 
// 'aria-expanded' attribute is now created on the element and set to false.
// state has an `isExpanded` property which is also set to false;
   
state.isExpanded = true; 
//  'aria-expanded' attribute is now set to true on the element.

var obj = {'isSmall' : true};

var state = ariaState.define( 'checked', element, obj );  
// 'aria-checked' attribute is now created on the element and set to false.
// obj has an `isChecked` property which is also set to false.
  
state.isChecked = true;
// 'aria-checked' attribute is now set to true on the element.

```


## Review
@anselmbradford 
@jimmynotjim 
@KimberlyMunoz 