### PR TITLE
Fixes #931 - Standardizes calling js tests scripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 
 ### Changed
 - Updated Video Code to make it usable on Events pages.
-
+- Changed gulp JS unit testing task from `gulp:unit:js` to `gulp:unit:scripts`
 
 ### Removed
 - Disables tests for landing page events, since we don't currently have events.

--- a/gulp/tasks/test.js
+++ b/gulp/tasks/test.js
@@ -9,7 +9,7 @@ var config = require( '../config' ).test;
 var minimist = require( 'minimist' );
 var path = require( 'path' );
 
-gulp.task( 'test:unit:js', function( cb ) {
+gulp.task( 'test:unit:scripts', function( cb ) {
   gulp.src( config.src )
     .pipe( $.istanbul( {
       includeUntested: true
@@ -134,7 +134,7 @@ gulp.task( 'test',
 
 gulp.task( 'test:unit',
   [
-    'test:unit:js',
+    'test:unit:scripts',
     'test:unit:macro'
   ]
 );


### PR DESCRIPTION
Fixes #931 - Standardizes calling js tests scripts

Test by running gulp:unit and checking for a green travis checkmark.