### PR TITLE
Fixes #928 - Removes unnecessary CSS

### DIFF
--- a/src/static/css/pages/offices.less
+++ b/src/static/css/pages/offices.less
@@ -20,7 +20,7 @@
 
         ul {
             .list__branded();
-            padding: 0 0 0 20px;
+            padding-left: 20px;
         }
     }
 }


### PR DESCRIPTION
Fixes #928 - Removes unnecessary CSS.

Let me know if this merits a changelog update. 

Test by visiting Project Catalyst or Office of Civil Rights.