### PR TITLE
Fixes #948 - makes specs flag accept array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Updated Meredith Fuchs bio and images.
 - Added indent rules for `var`, `let`, and `const` in ESLint config file.
 - Replaced old Grunt legaccsy plugin with Gulp mq-remove plugin
+- Added ability for acceptance --specs test flag to accept list of test files.
 
 ### Removed
 - Disables tests for landing page events, since we don't currently have events.

--- a/TEST.md
+++ b/TEST.md
@@ -53,12 +53,20 @@ Sauce Labs can be used to run tests remotely in the cloud.
 
 A number of command-line arguments can be set to test particular configurations:
 
- - `--specs`: Choose a particular spec suite to run. For example, `gulp test:acceptance --specs=shared_contact-us.js`.
- - `--windowSize`: Set the window size in pixels in `w,h` format. For example, `gulp test:acceptance --windowSize=900,400`.
- - `--browserName`: Set the browser to run. For example, `gulp test:acceptance --browserName=firefox`.
- - `--version`: Set the browser version to run. For example, `gulp test:acceptance --version='44.0'`.
- - `--platform`: Set the OS platform to run. For example, `gulp test:acceptance --platform='osx 10.10'`.
- - `--sauce`: Whether to run on Sauce Labs or not. For example, `gulp test:acceptance --sauce=false`.
+ - `--specs`: Choose a particular spec suite to run.
+   For example, `gulp test:acceptance --specs=contact-us.js`.
+   Multiple tests can be run by passing in a comma-separated list of test suite filenames.
+   For example, `gulp test:acceptance --specs=contact-us.js,about-us.js`.
+ - `--windowSize`: Set the window size in pixels in `w,h` format.
+   For example, `gulp test:acceptance --windowSize=900,400`.
+ - `--browserName`: Set the browser to run.
+   For example, `gulp test:acceptance --browserName=firefox`.
+ - `--version`: Set the browser version to run.
+   For example, `gulp test:acceptance --version='44.0'`.
+ - `--platform`: Set the OS platform to run.
+   For example, `gulp test:acceptance --platform='osx 10.10'`.
+ - `--sauce`: Whether to run on Sauce Labs or not.
+   For example, `gulp test:acceptance --sauce=false`.
 
 ## Pages
 

--- a/test/browser_tests/conf.js
+++ b/test/browser_tests/conf.js
@@ -70,7 +70,11 @@ function _retrieveProtractorParams( params ) { // eslint-disable-line complexity
   var parsedParams = {};
 
   if ( _paramIsSet( params.specs ) ) {
-    parsedParams.specs = environment.specsBasePath + params.specs;
+    var specsArray = params.specs.split( ',' );
+    for ( var i = 0, len = specsArray.length; i < len; i++ ) {
+      specsArray[i] = environment.specsBasePath + specsArray[i];
+    }
+    parsedParams.specs = specsArray;
   }
 
   if ( _paramIsSet( params.browserName ) ) {


### PR DESCRIPTION
Fixes #948 - makes specs flag accept array.

## Changes

- Added ability for acceptance --specs test flag to accept list of test files.

## Testing

- Add a comma-separated list to the `--specs` flag value. For example, to run two tests: `gulp build && gulp test:acceptance --sauce=false --specs=about-us.js,contact-us.js`

## Review

- @sebworks 
- @jimmynotjim 
- @KimberlyMunoz 
