### PR TITLE
Adding Acceptance tests for the-bureau pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Django Server
 - Django related urls to access links
 - Django-Sheerlike integration
+- Added Acceptance tests for `the-bureau` pages.
+- Added test utility to retreive QA elements.
 
 ### Changed
 - Updated Video Code to make it usable on Events pages.

--- a/src/the-bureau/about-deputy-director/index.html
+++ b/src/the-bureau/about-deputy-director/index.html
@@ -15,15 +15,15 @@
 
 	{% import 'macros/share.html' as share %}
 
-    <div class="block block__flush-top">
-        <h1>
+    <div class="block block__flush-top" data-qa-hook="director-bio">
+        <h1 data-qa-hook="director-bio-title">
             Deputy Director Meredith Fuchs
         </h1>
-        <p class="h3">
+        <p class="h3" data-qa-hook="director-bio-summary">
             Meredith Fuchs currently serves as the Acting Deputy Director
             as well as the General Counsel at the Consumer Financial Protection Bureau (CFPB).
         </p>
-        <figure class="media float-media rwd-crop">
+        <figure class="media float-media rwd-crop" data-qa-hook="director-bio-image">
             <img class="media_image media_image__150 rwd-crop_item"
                  src="/static/img/deputy-director-fuchs-300x400.jpg"
                  alt="Portrait of Deputy Director Meredith Fuchs">
@@ -61,7 +61,7 @@
                              src="/static/img/deputy-director-fuchs-round-200x200.jpg"
                              alt="Portrait of Deputy Director Meredith Fuchs">
                     </div>
-                    <div class="media_body">
+                    <div class="media_body" data-qa-hook="director-media-downloads">
                         <h2 class="h4 u-mb5">
                             Downloads
                         </h2>
@@ -82,7 +82,8 @@
                     </div>
                 </div>
             </div>
-            <div class="content-l_col content-l_col-1-2">
+            <div class="content-l_col content-l_col-1-2"
+                 data-qa-hook="director-speaking-info">
                 <h2 class="h4 u-mb5">
                     Request the deputy director’s speaking info
                 </h2>
@@ -97,7 +98,8 @@
 
     <aside>
 
-        <section class="block block__padded-top block__border-top">
+        <section class="block block__padded-top block__border-top"
+                 data-qa-hook="director-more-info">
             <h2>
                 More information about Meredith Fuchs
             </h2>

--- a/src/the-bureau/about-director/index.html
+++ b/src/the-bureau/about-director/index.html
@@ -15,16 +15,16 @@
 
 	{% import 'macros/share.html' as share %}
 
-    <div class="block block__flush-top">
-        <h1>
+    <div class="block block__flush-top" data-qa-hook="director-bio">
+        <h1 data-qa-hook="director-bio-title">
             Director Richard Cordray
         </h1>
-        <p class="h3">
+        <p class="h3" data-qa-hook="director-bio-summary">
             Richard Cordray serves as the first Director of the
             Consumer Financial Protection Bureau. He previously
             led the Bureau’s Enforcement Division.
         </p>
-        <figure class="media float-media rwd-crop">
+        <figure class="media float-media rwd-crop" data-qa-hook="director-bio-image">
             <img class="media_image media_image__150 rwd-crop_item"
                  src="/static/img/director-cordray-300x400.jpg"
                  alt="Portrait of Director Richard Cordray">
@@ -89,7 +89,7 @@
                              src="/static/img/director-cordray-round-200x200.jpg"
                              alt="Portrait of Director Richard Cordray">
                     </div>
-                    <div class="media_body">
+                    <div class="media_body" data-qa-hook="director-media-downloads">
                         <h2 class="h4 u-mb5">
                             Downloads
                         </h2>
@@ -117,7 +117,8 @@
                 </div>
             </div>
             <div class="content-l_col
-                        content-l_col-1-2">
+                        content-l_col-1-2"
+                 data-qa-hook="director-speaking-info">
                 <h2 class="h4 u-mb5">
                     Request the director’s speaking info
                 </h2>
@@ -134,7 +135,8 @@
 
         <section class="block
                         block__padded-top
-                        block__border-top">
+                        block__border-top"
+                 data-qa-hook="director-more-info">
             <h2>
                 More information about Richard Cordray
             </h2>
@@ -184,7 +186,8 @@
         <div class="block
                     block__padded-top
                     block__border-top">
-            <div class="content-l content-l__main content-l__large-gutters">
+            <div class="content-l content-l__main content-l__large-gutters"
+                 data-qa-hook="director-corner">
                 <section class="content-l_col content-l_col-1-2">
                     <h2>
                         Cordray’s Corner
@@ -208,7 +211,8 @@
                 </section>
                 <section class="content-l_col
                                 content-l_col-1-2
-                                content-l_col__before-divider">
+                                content-l_col__before-divider"
+                         data-qa-hook="director-history">
                     <h2>
                         CFPB history
                     </h2>

--- a/src/the-bureau/bureau-structure/index.html
+++ b/src/the-bureau/bureau-structure/index.html
@@ -131,7 +131,8 @@
 
     <aside class="block block__padded-top block__padded-bottom block__border-top">
         <div class="content-l content-l__main">
-            <div class="content-l_col content-l_col-1-2">
+            <div class="content-l_col content-l_col-1-2"
+                 data-qa-hook="org-chart-download-info">
                 <h2 class="h3">Download a copy</h2>
                 <p>
                     Download a printable, PDF copy of this organizational chart. This version
@@ -143,7 +144,8 @@
                     Download PDF
                 </a>
             </div>
-            <div class="content-l_col content-l_col-1-2">
+            <div class="content-l_col content-l_col-1-2"
+                 data-qa-hook="org-chart-speaking-info">
                 <h2 class="h3">Request speaking info</h2>
                 <p>
                     Ask a CFPB employee to be involved in a forum, publication, discussion, or

--- a/src/the-bureau/history/index.html
+++ b/src/the-bureau/history/index.html
@@ -18,11 +18,12 @@
 
     {% set query = queries.history %}
 
-    <div class="block block__flush-top">
-        <h1>
+    <div class="block block__flush-top"
+         data-qa-hook="history-intro">
+        <h1 data-qa-hook="history-title">
             The history of the Consumer Financial Protection Bureau
         </h1>
-        <p class="h3">
+        <p class="h3" data-qa-hook="history-summary">
             Richard Cordray serves as the first Director of the
             Consumer Financial Protection Bureau.
             He previously led the Bureau’s Enforcement Division.
@@ -37,7 +38,8 @@
 
 {% for section in sections %}
 
-    <section class="block block__padded-top block__border-top">
+    <section class="block block__padded-top block__border-top"
+             data-qa-hook="history-section">
         <div class="content-l content-l__main">
             <div class="content-l_col content-l_col-2-3">
                 <h2>{{ section.title|safe }}</h2>

--- a/src/the-bureau/index.html
+++ b/src/the-bureau/index.html
@@ -123,8 +123,8 @@
                     block__border
                     block__flush-sides
                     block__flush-top
-                    block__flush-bottom
-                    ">
+                    block__flush-bottom"
+             data-qa-hook="bureau-core-functions">
         <h2>Our core functions</h2>
         <p>Congress created the CFPB to create a single point of accountability for enforcing
         federal consumer financial laws and protecting consumers in the financial marketplace.

--- a/src/the-bureau/leadership-calendar/index.html
+++ b/src/the-bureau/leadership-calendar/index.html
@@ -25,9 +25,10 @@
     <div class="block
                 block__flush-top
                 block__padded-bottom
-                block__border-bottom">
+                block__border-bottom"
+         data-qa-hook="leadership-calendar-intro">
         <h1>Leadership Calendar</h1>
-        <p class="h3">
+        <p class="h3" data-qa-hook="leadership-calendar-summary">
             At the Consumer Financial Protection Bureau, we are committed to letting you
             know how we’re working for you every day by, among other things, providing you
             with a view into the workday of the CFPB’s senior leadership.
@@ -50,7 +51,7 @@
 
     <div id="pagination_content"></div>
 
-    <div class="block block__flush-top">
+    <div class="block block__flush-top" data-qa-hook="leadership-calendar-filter">
 
     {% set query = queries.calendar_event %}
     {% set posts = query.search(size=20) %}

--- a/test/browser_tests/page_objects/page_about-director.js
+++ b/test/browser_tests/page_objects/page_about-director.js
@@ -1,0 +1,59 @@
+'use strict';
+
+var _getQAElement = require( '../util/QAelement' ).get;
+
+function TheAboutDirectorPage() {
+
+  this.get = function( page ) {
+    var baseUrl = '/the-bureau/';
+
+    var pageLookup = {
+      director:       baseUrl + 'about-director/',
+      deputyDirector: baseUrl + 'about-deputy-director/'
+    };
+
+    browser.get( pageLookup[page] );
+  };
+
+  this.pageTitle = function() { return browser.getTitle(); };
+
+  this.sideNav = element( by.css( '.nav-secondary' ) );
+
+  this.directorBio = _getQAElement( 'director-bio' );
+
+  this.directorBioSummary = _getQAElement( 'director-bio-summary' );
+
+  this.directorCorner = _getQAElement( 'director-corner' );
+
+  this.directorHistory = _getQAElement( 'director-history' );
+
+  this.directorTitle = _getQAElement( 'director-bio-title' );
+
+  this.directorImage = _getQAElement( 'director-bio-image' );
+
+  this.mediaDownloads = element.all(
+  by.css( '[data-qa-hook="director-media-downloads"] .jump-link__download' ) );
+
+  this.bioDownload = this.mediaDownloads.get( 0 );
+
+  this.highResImageDownload = this.mediaDownloads.get( 1 );
+
+  this.lowResImageDownload = this.mediaDownloads.get( 2 );
+
+  this.moreInfo = _getQAElement( 'director-more-info' );
+
+  this.moreInfoTitle = this.moreInfo.element( by.css( 'h2' ) );
+
+  this.moreInfoItems = this.moreInfo.all( by.css( '.content-l_col-1-3' ) );
+
+  this.relatedLinks = element( by.css( '.related-links' ) );
+
+  this.socialMediaShare = element( by.css( '.share' ) );
+
+  this.speakingInfo = _getQAElement( 'director-speaking-info' );
+
+  this.speakingInfoEmail = this.speakingInfo.element( by.css( 'a' ) );
+
+}
+
+module.exports = TheAboutDirectorPage;

--- a/test/browser_tests/page_objects/page_bureau-history.js
+++ b/test/browser_tests/page_objects/page_bureau-history.js
@@ -1,0 +1,29 @@
+'use strict';
+
+var _getQAElement = require( '../util/QAelement' ).get;
+
+function TheBureauHistoryPage() {
+
+  this.get = function( ) {
+    browser.get( '/the-bureau/history/' );
+  };
+
+  this.pageTitle = function() { return browser.getTitle(); };
+
+  this.sideNav = element( by.css( '.nav-secondary' ) );
+
+  this.intro = _getQAElement( 'history-intro' );
+
+  this.introTitle = _getQAElement( 'history-title' );
+
+  this.introSummary = _getQAElement( 'history-summary' );
+
+  this.socialMediaShare = this.intro.element( by.css( '.share' ) );
+
+  this.historySections = _getQAElement( 'history-section', true );
+
+  this.historySectionExpandables =
+  element.all( by.css( '.history-section-expandable' ) );
+}
+
+module.exports = TheBureauHistoryPage;

--- a/test/browser_tests/page_objects/page_bureau-structure.js
+++ b/test/browser_tests/page_objects/page_bureau-structure.js
@@ -1,0 +1,43 @@
+'use strict';
+
+function TheBureauStructurePage() {
+
+  this.get = function( ) {
+    browser.get( '/the-bureau/bureau-structure/' );
+  };
+
+  this.pageTitle = function() { return browser.getTitle(); };
+
+  this.sideNav = element( by.css( '.nav-secondary' ) );
+
+  this.orgChartRoot = element( by.css( '.org-chart_root' ) );
+
+  this.directorImage =
+  this.orgChartRoot.element( by.css( '.media_image__150' ) );
+
+  this.directorName = this.orgChartRoot.element( by.css( '.h2' ) );
+
+  this.directorTitle = this.orgChartRoot.element( by.css( 'h2' ) );
+
+  this.orgChartBranches = element.all( by.css( '.org-chart_branch' ) );
+
+  this.orgChartParentNodes =
+  this.orgChartBranches.all( by.css( '.org-chart_nodes > .org-chart_node' ) );
+
+  this.orgChartChildNodes =
+  this.orgChartParentNodes.all( by.css( '.org-chart_node' ) );
+
+  this.downloadInfo =
+  element( by.css( '[data-qa-hook="org-chart-download-info"]' ) );
+
+  this.downloadBtn =
+  this.downloadInfo.element( by.css( 'a.btn' ) );
+
+  this.speakingInfo =
+  element( by.css( '[data-qa-hook="org-chart-speaking-info"]' ) );
+
+  this.speakingInfoEmail = this.speakingInfo.element( by.css( 'a' ) );
+
+}
+
+module.exports = TheBureauStructurePage;

--- a/test/browser_tests/page_objects/page_leadership-calendar.js
+++ b/test/browser_tests/page_objects/page_leadership-calendar.js
@@ -1,0 +1,42 @@
+'use strict';
+
+function TheLeadershipCalendarPage() {
+
+  this.get = function( ) {
+    browser.get( '/the-bureau/leadership-calendar/' );
+  };
+
+  this.pageTitle = function() { return browser.getTitle(); };
+
+  this.sideNav = element( by.css( '.nav-secondary' ) );
+
+  this.intro =
+  element( by.css( '[data-qa-hook="leadership-calendar-intro"]' ) );
+
+  this.introTitle = this.intro.all( by.css( 'h1' ) ).first();
+
+  this.introSummary =
+  this.intro.element(
+    by.css( '[data-qa-hook="leadership-calendar-summary"]' )
+  );
+
+  this.socialMediaShare = this.intro.element( by.css( '.share' ) );
+
+  this.searchFilter = element.all( by.css( '.js-post-filter' ) ).get( 0 );
+
+  this.searchFilterBtn =
+  this.searchFilter.all( by.css( '.expandable_target' ) ).first();
+
+  this.downloadFilter = element.all( by.css( '.js-post-filter' ) ).get( 1 );
+
+  this.downloadFilterBtn =
+  this.downloadFilter.all( by.css( '.expandable_target' ) ).first();
+
+  this.searchFilterResults =
+  element.all( by.css( '[data-qa-hook="leadership-calendar-filter"] tbody' ) );
+
+  this.paginationForm = element( by.css( '.pagination_form' ) );
+
+}
+
+module.exports = TheLeadershipCalendarPage;

--- a/test/browser_tests/page_objects/page_the-bureau.js
+++ b/test/browser_tests/page_objects/page_the-bureau.js
@@ -6,6 +6,30 @@ function TheBureauPage() {
   };
 
   this.pageTitle = function() { return browser.getTitle(); };
+
+  this.sideNav = element( by.css( '.nav-secondary' ) );
+
+  this.hero = element( by.css( '.hero__bureau' ) );
+
+  this.heroVideoPlayer = this.hero.element( by.css( '.video-player' ) );
+
+  this.bureauHistory = element( by.css( '.bureau-history' ) );
+
+  this.bureauMission =
+  element.all( by.css( '.js-mobile-carousel .media-stack_item' ) );
+
+  this.bureauFunctions =
+  element( by.css( '[data-qa-hook="bureau-core-functions"]' ) );
+
+  this.directorsBio = element.all( by.css( '.bureau-bio' ) ).first();
+
+  this.directorsName =
+  this.directorsBio.element( by.css( '.bureau-bio_name' ) );
+
+  this.deputyDirectorsBio = element.all( by.css( '.bureau-bio' ) ).last();
+
+  this.deputyDirectorsName =
+  this.deputyDirectorsBio.element( by.css( '.bureau-bio_name' ) );
 }
 
 module.exports = TheBureauPage;

--- a/test/browser_tests/spec_suites/about-deputy-director.js
+++ b/test/browser_tests/spec_suites/about-deputy-director.js
@@ -1,0 +1,105 @@
+'use strict';
+
+var TheAboutDirectorPage = require( '../page_objects/page_about-director.js' );
+
+describe( 'The About Deputy Director Page', function() {
+  var page;
+
+  beforeAll( function() {
+    page = new TheAboutDirectorPage( );
+    page.get( 'deputyDirector' );
+  } );
+
+  it( 'should properly load in a browser',
+    function() {
+      expect( page.pageTitle() ).toBe( 'About Meredith Fuchs' );
+    }
+  );
+
+  it( 'should have a side nav',
+    function() {
+      expect( page.sideNav.isPresent() ).toBe( true );
+    }
+  );
+
+  it( 'should include the Deputy Director’s bio',
+    function() {
+      expect( page.directorBioSummary.isPresent() ).toBe( true );
+    }
+  );
+
+  it( 'should include the Deputy Director’s summary',
+    function() {
+      expect( page.directorBioSummary.isPresent() ).toBe( true );
+    }
+  );
+
+  it( 'should include the Deputy Director’s title',
+    function() {
+      expect( page.directorTitle.getText() )
+      .toEqual( 'Deputy Director Meredith Fuchs' );
+    }
+  );
+
+  it( 'should include the Deputy Director’s image',
+    function() {
+      expect( page.directorImage.isPresent() ).toBe( true );
+    }
+  );
+
+  it( 'should include a More Info section',
+    function() {
+      expect( page.moreInfo.isPresent() ).toBe( true );
+    }
+  );
+
+  it( 'should include a More Info title',
+    function() {
+      expect( page.moreInfoTitle.getText() )
+      .toEqual( 'More information about Meredith Fuchs' );
+    }
+  );
+
+  it( 'should include three More Info items',
+    function() {
+      expect( page.moreInfoItems.count() ).toEqual( 3 );
+    }
+  );
+
+  it( 'should include a bio download link',
+    function() {
+      expect( page.bioDownload.isPresent() ).toBe( true );
+    }
+  );
+
+  it( 'should include the Deputy Director’s high resolution image',
+    function() {
+      var highResImageDownload = page.mediaDownloads.get( 0 );
+      expect( highResImageDownload.isPresent() ).toBe( true );
+      expect( highResImageDownload.getText() )
+      .toEqual( 'High-res portrait' );
+    }
+  );
+
+  it( 'should include the Deputy Director’s low resolution image',
+    function() {
+      var lowResImageDownload = page.mediaDownloads.get( 1 );
+      expect( lowResImageDownload.isPresent() ).toBe( true );
+      expect( lowResImageDownload.getText() )
+      .toEqual( 'Low-res portrait' );
+    }
+  );
+
+  it( 'should include a Related Links section',
+    function() {
+      expect( page.relatedLinks.isPresent() ).toBe( true );
+    }
+  );
+
+  it( 'should include a Share section',
+    function() {
+      expect( page.socialMediaShare.isPresent() ).toBe( true );
+    }
+  );
+
+} );

--- a/test/browser_tests/spec_suites/about-director.js
+++ b/test/browser_tests/spec_suites/about-director.js
@@ -1,0 +1,136 @@
+'use strict';
+
+var TheAboutDirectorPage = require( '../page_objects/page_about-director.js' );
+
+describe( 'The About Director Page', function() {
+  var page;
+
+  beforeAll( function() {
+    page = new TheAboutDirectorPage( );
+    page.get( 'director' );
+  } );
+
+
+  it( 'should properly load in a browser',
+    function() {
+      expect( page.pageTitle() ).toBe( 'About Richard Cordray' );
+    }
+  );
+
+  it( 'should have a side nav',
+    function() {
+      expect( page.sideNav.isPresent() ).toBe( true );
+    }
+  );
+
+  it( 'should include the Director’s bio',
+    function() {
+      expect( page.directorBioSummary.isPresent() ).toBe( true );
+    }
+  );
+
+  it( 'should include the Director’s summary',
+    function() {
+      expect( page.directorBioSummary.isPresent() ).toBe( true );
+    }
+  );
+
+  it( 'should include the Director’s Corner',
+    function() {
+      expect( page.directorCorner.isPresent() ).toBe( true );
+    }
+  );
+
+  it( 'should include the Director’s history',
+    function() {
+      expect( page.directorHistory.isPresent() ).toBe( true );
+    }
+  );
+
+  it( 'should include Director’s title',
+    function() {
+      expect( page.directorTitle.getText() )
+      .toEqual( 'Director Richard Cordray' );
+    }
+  );
+
+  it( 'should include Director’s image',
+    function() {
+      expect( page.directorImage.isPresent() ).toBe( true );
+    }
+  );
+
+  it( 'should include the More Info section',
+    function() {
+      expect( page.moreInfo.isPresent() ).toBe( true );
+    }
+  );
+
+  it( 'should include the bio download link',
+    function() {
+      expect( page.bioDownload.isPresent() ).toBe( true );
+    }
+  );
+
+  it( 'should include the Director’s high resolution image',
+    function() {
+      expect( page.highResImageDownload.isPresent() ).toBe( true );
+      expect( page.highResImageDownload.getText() )
+      .toEqual( 'High-res portrait' );
+    }
+  );
+
+  it( 'should include the Director’s low resolution image',
+    function() {
+      expect( page.lowResImageDownload.isPresent() ).toBe( true );
+      expect( page.lowResImageDownload.getText() )
+      .toEqual( 'Low-res portrait' );
+    }
+  );
+
+  it( 'should include the More Info section',
+    function() {
+      expect( page.moreInfo.isPresent() ).toBe( true );
+    }
+  );
+
+  it( 'should include the More Info title',
+    function() {
+      expect( page.moreInfoTitle.getText() )
+      .toEqual( 'More information about Richard Cordray' );
+    }
+  );
+
+  it( 'should include three More Info items',
+    function() {
+      expect( page.moreInfoItems.count() ).toEqual( 3 );
+    }
+  );
+
+  it( 'should include the Related Links section',
+    function() {
+      expect( page.relatedLinks.isPresent() ).toBe( true );
+    }
+  );
+
+  it( 'should include the Share section',
+    function() {
+      expect( page.socialMediaShare.isPresent() ).toBe( true );
+    }
+  );
+
+  it( 'should include the Speaking info section',
+    function() {
+      expect( page.speakingInfo.isPresent() ).toBe( true );
+    }
+  );
+
+  it( 'should include the Speaking info link',
+    function() {
+      expect( page.speakingInfoEmail.isPresent() ).toBe( true );
+      expect( page.speakingInfoEmail.getText() )
+      .toEqual( 'externalaffairs@cfpb.gov' );
+    }
+  );
+
+} );

--- a/test/browser_tests/spec_suites/bureau-history.js
+++ b/test/browser_tests/spec_suites/bureau-history.js
@@ -1,0 +1,60 @@
+'use strict';
+
+var TheBureauHistoryPage =
+require( '../page_objects/page_bureau-history.js' );
+
+describe( 'The Bureau History Page', function() {
+  var page;
+
+  beforeAll( function() {
+    page = new TheBureauHistoryPage();
+    page.get();
+  } );
+
+
+  it( 'should properly load in a browser',
+    function() {
+      expect( page.pageTitle() ).toBe( 'History' );
+    }
+  );
+
+  it( 'should have a side nav',
+    function() {
+      expect( page.sideNav.isPresent() ).toBe( true );
+    }
+  );
+
+  it( 'should include an intro title',
+    function() {
+      expect( page.introTitle.getText() )
+      .toBe( 'The history of the Consumer Financial Protection Bureau' );
+    }
+  );
+
+  it( 'should include an intro summary',
+    function() {
+      expect( page.introSummary.isPresent() ).toBe( true );
+    }
+  );
+
+  it( 'should include a share section',
+    function() {
+      expect( page.socialMediaShare.isPresent() ).toBe( true );
+    }
+  );
+
+  it( 'should include history sections',
+    function() {
+      expect( page.historySections.count() ).toBeGreaterThan( 1 );
+    }
+  );
+
+  it( 'should include history section expandables',
+    function() {
+      expect( page.historySectionExpandables.count() ).toBeGreaterThan( 1 );
+      expect( page.historySectionExpandables.first().getText() )
+      .toContain( 'Timeline' );
+    }
+  );
+
+} );

--- a/test/browser_tests/spec_suites/bureau-structure.js
+++ b/test/browser_tests/spec_suites/bureau-structure.js
@@ -1,0 +1,81 @@
+'use strict';
+
+var TheBureauStructurePage =
+require( '../page_objects/page_bureau-structure.js' );
+
+describe( 'The Bureau Structure Page', function() {
+  var page;
+
+  beforeAll( function() {
+    page = new TheBureauStructurePage();
+    page.get();
+  } );
+
+
+  it( 'should properly load in a browser',
+    function() {
+      expect( page.pageTitle() ).toBe( 'Bureau Structure' );
+    }
+  );
+
+  it( 'should have a side nav',
+    function() {
+      expect( page.sideNav.isPresent() ).toBe( true );
+    }
+  );
+
+  it( 'should include the Director’s image',
+    function() {
+      expect( page.directorImage.isPresent() ).toBe( true );
+    }
+  );
+
+  it( 'should include the Director’s name',
+    function() {
+      expect( page.directorName.isPresent() ).toBe( true );
+    }
+  );
+
+  it( 'should include the Director’s title',
+    function() {
+      expect( page.directorTitle.isPresent() ).toBe( true );
+    }
+  );
+
+  it( 'should include two org chart branches',
+    function() {
+      expect( page.orgChartBranches.count() ).toEqual( 2 );
+    }
+  );
+
+  it( 'should include org chart parent nodes',
+    function() {
+      expect( page.orgChartParentNodes.count() ).toBeGreaterThan( 0 );
+    }
+  );
+
+  it( 'should show org chart child nodes and they should be hidden',
+    function() {
+      expect( page.orgChartChildNodes.count() ).toBeGreaterThan( 0 );
+
+      page.orgChartChildNodes.each( function( childNode ) {
+        expect( childNode.isDisplayed() ).toBe( false );
+      } );
+    }
+  );
+
+  it( 'should include the download button',
+    function() {
+      expect( page.downloadBtn.isPresent() ).toBe( true );
+    }
+  );
+
+  it( 'should include the speaking info',
+    function() {
+      expect( page.speakingInfo.isPresent() ).toBe( true );
+      expect( page.speakingInfoEmail.getText() )
+      .toEqual( 'cfpb.events@cfpb.gov' );
+    }
+  );
+
+} );

--- a/test/browser_tests/spec_suites/leadership-calendar.js
+++ b/test/browser_tests/spec_suites/leadership-calendar.js
@@ -1,0 +1,87 @@
+'use strict';
+
+var TheLeadershipCalendarPage =
+require( '../page_objects/page_leadership-calendar.js' );
+
+describe( 'The Leadership Calendar Page', function() {
+  var page;
+
+  beforeAll( function() {
+    page = new TheLeadershipCalendarPage();
+    page.get();
+  } );
+
+
+  it( 'should properly load in a browser',
+    function() {
+      expect( page.pageTitle() ).toBe( 'Leadership calendar' );
+    }
+  );
+
+  it( 'should include the side nav',
+    function() {
+      expect( page.sideNav.isPresent() ).toBe( true );
+    }
+  );
+
+  it( 'should include an intro title',
+    function() {
+      expect( page.introTitle.getText() ).toBe( 'Leadership Calendar' );
+    }
+  );
+
+  it( 'should include an intro summary',
+    function() {
+      expect( page.introSummary.isPresent() ).toBe( true );
+    }
+  );
+
+  it( 'should include a share section',
+    function() {
+      expect( page.socialMediaShare.isPresent() ).toBe( true );
+    }
+  );
+
+  it( 'should include a search filter',
+    function() {
+      expect( page.searchFilter.isPresent() ).toBe( true );
+    }
+  );
+
+  it( 'should include a search filter button',
+    function() {
+      var searchFilterBtn = page.searchFilterBtn;
+      expect( searchFilterBtn.isPresent() ).toBe( true );
+      expect( searchFilterBtn.getText() ).toContain( 'Filter calendars' );
+      expect( searchFilterBtn.getText() ).toContain( 'Show' );
+    }
+  );
+
+  it( 'should include a search filter search filter results',
+    function() {
+      expect( page.searchFilterResults.count() ).toBeGreaterThan( 0 );
+    }
+  );
+
+  it( 'should include a download filter',
+    function() {
+      expect( page.paginationForm.isPresent() ).toBe( true );
+    }
+  );
+
+  it( 'should include a download filter button',
+    function() {
+      var downloadFilterBtn = page.downloadFilterBtn;
+      expect( downloadFilterBtn.isPresent() ).toBe( true );
+      expect( downloadFilterBtn.getText() ).toContain( 'Download options' );
+      expect( downloadFilterBtn.getText() ).toContain( 'Show' );
+    }
+  );
+
+  it( 'should include pagination form',
+    function() {
+      expect( page.paginationForm.isPresent() ).toBe( true );
+    }
+  );
+
+} );

--- a/test/browser_tests/spec_suites/the-bureau.js
+++ b/test/browser_tests/spec_suites/the-bureau.js
@@ -15,4 +15,55 @@ describe( 'The Bureau Page', function() {
       expect( page.pageTitle() ).toBe( 'The Bureau' );
     }
   );
+
+  it( 'should have a hero',
+    function() {
+      expect( page.hero.isPresent() ).toBe( true );
+    }
+  );
+
+  it( 'should have a video player',
+    function() {
+      expect( page.heroVideoPlayer.isPresent() ).toBe( true );
+    }
+  );
+
+  it( 'should have a side nav',
+    function() {
+      expect( page.sideNav.isPresent() ).toBe( true );
+    }
+  );
+
+  it( 'should include Bureau history',
+    function() {
+      expect( page.bureauHistory.isPresent() ).toBe( true );
+    }
+  );
+
+  it( 'should include Bureau functions',
+    function() {
+      expect( page.bureauFunctions.isPresent() ).toBe( true );
+    }
+  );
+
+  it( 'should include the Director’s Bio',
+    function() {
+      expect( page.directorsName.getText() ).toEqual( 'Richard Cordray' );
+      expect( page.directorsBio.isPresent() ).toBe( true );
+    }
+  );
+
+  it( 'should include the Deputy Director’s Bio',
+    function() {
+      expect( page.deputyDirectorsName.getText() ).toEqual( 'Meredith Fuchs' );
+      expect( page.deputyDirectorsBio.isPresent() ).toBe( true );
+    }
+  );
+
+  it( 'should include three Bureau mission statements',
+    function() {
+      expect( page.bureauMission.count() ).toEqual( 3 );
+    }
+  );
+
 } );

--- a/test/browser_tests/util/QAelement.js
+++ b/test/browser_tests/util/QAelement.js
@@ -1,0 +1,23 @@
+/* ==========================================================================
+   Quality Assurance Element
+   ========================================================================== */
+
+'use strict';
+
+/**
+ * Retrieves QA Protractor ElementFinder when provided
+ * with the following params:
+ *
+ * @param {integer} selector - dom selector.
+ * @param {boolean} getAllFlag - flag indicating wether to use element.all.
+ * @returns {ElementFinder|ElementArrayFinder}
+ * - Protractor ElementFinder or ElementFinder array.
+ */
+function get( selector, getAllFlag ) {
+  var domQuery = getAllFlag ? element.all : element;
+
+  return domQuery( by.css( '[data-qa-hook="' + selector + '"]' ) );
+}
+
+// Expose public methods.
+module.exports = { get: get };


### PR DESCRIPTION
Adding Acceptance tests for `the-bureau` pages

## Changes
 - Added acceptance tests for the `the-bureau` pages. 

## Testing
-  Run `gulp test:acceptance`

## Notes
- This PR does add the `data-qa-hook` attribute as discussed in issue https://github.com/cfpb/cfgov-refresh/issues/930


## Review
@anselmbradford 
@jimmynotjim 
@KimberlyMunoz 