### PR TITLE
Adding Acceptance tests for the Activity Log page.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Added Favicon
 - New and improved primary nav (both look and interaction)
 - Added expanded-state utility for getting/setting aria-expanded
+- Added Acceptance tests for the `activity-log` page.
 
 ### Changed
 - Updated Video Code to make it usable on Events pages.

--- a/src/activity-log/index.html
+++ b/src/activity-log/index.html
@@ -17,8 +17,8 @@
     {% import 'macros/category-icon.html' as category_icon %}
     {% from 'post-macros.html' import pagination as pagination with context %}
 
-    <h1>Activity Log</h1>
-    <p class="h3">
+    <h1 data-qa-hook="main-title">Activity Log</h1>
+    <p class="h3" data-qa-hook="main-summary">
         Find the latest CFPB activities and publications here. Use the filters
         below to browse by date, specific topics, or types of posts.
     </p>
@@ -32,7 +32,7 @@
                 { 'expand_label': 'Filter activities' }
             ) }}
 
-        <table class="u-w100pct">
+        <table class="u-w100pct" data-qa-hook="filter-results">
             <tbody>
             {%- for item in archives %}
                 <tr>

--- a/test/browser_tests/page_objects/page_activity-log.js
+++ b/test/browser_tests/page_objects/page_activity-log.js
@@ -1,0 +1,37 @@
+'use strict';
+
+function ActivityLog() {
+  this.get = function() {
+    browser.get( '/activity-log/' );
+  };
+
+  this.pageTitle = function() { return browser.getTitle(); };
+
+  this.mainTitle = element( by.css( '[data-qa-hook="main-title"]' ) );
+
+  this.mainSummary = element( by.css( '[data-qa-hook="main-summary"]' ) );
+
+  this.searchFilter = element( by.css( '.js-post-filter' ) );
+
+  this.searchFilterBtn =
+  this.searchFilter.element( by.css( '.expandable_target' ) );
+
+  this.searchFilterShowBtn =
+  this.searchFilter.element( by.css( '.expandable_cue-open' ) );
+
+  this.searchFilterHideBtn =
+  this.searchFilter.element( by.css( '.expandable_cue-close' ) );
+
+  this.searchFilterResults =
+  element.all( by.css( '[data-qa-hook="filter-results"] tr' ) );
+
+  this.paginationForm = element( by.css( '.pagination_form' ) );
+
+  this.paginationPrevBtn = element( by.css( '.pagination_prev' ) );
+
+  this.paginationNextBtn = element( by.css( '.pagination_next' ) );
+
+  this.paginationPageInput = element( by.css( '.pagination_current-page' ) );
+}
+
+module.exports = ActivityLog;

--- a/test/browser_tests/shared_objects/footer.js
+++ b/test/browser_tests/shared_objects/footer.js
@@ -1,8 +1,8 @@
 'use strict';
 
-function Footer() {
+function Footer( url ) {
   this.get = function() {
-    browser.get( '/' );
+    browser.get( url || '/' );
   };
 
   this.footer = element( by.css( '.footer' ) );

--- a/test/browser_tests/shared_objects/header.js
+++ b/test/browser_tests/shared_objects/header.js
@@ -1,8 +1,8 @@
 'use strict';
 
-function Header() {
+function Header( url ) {
   this.get = function() {
-    browser.get( '/' );
+    browser.get( url || '/' );
   };
 
   this.header = element( by.css( '.header' ) );

--- a/test/browser_tests/spec_suites/activity-log.js
+++ b/test/browser_tests/spec_suites/activity-log.js
@@ -1,0 +1,82 @@
+'use strict';
+
+var ActivityLog = require(
+    '../page_objects/page_activity-log.js'
+  );
+
+describe( 'The Activity Log Page', function() {
+  var page;
+
+  beforeAll( function() {
+    page = new ActivityLog();
+    page.get();
+  } );
+
+  it( 'should properly load in a browser', function() {
+    expect( page.pageTitle() ).toBe( 'Activity Log' );
+  } );
+
+  it( 'should include a main title', function() {
+    expect( page.mainTitle.getText() ).toBe( 'Activity Log' );
+  } );
+
+  it( 'should include a main summary', function() {
+    expect( page.mainSummary.isPresent() ).toBe( true );
+  } );
+
+  it( 'should include a search filter',
+    function() {
+      expect( page.searchFilter.isPresent() ).toBe( true );
+    }
+  );
+
+  it( 'should include a search filter button',
+    function() {
+      expect( page.searchFilterBtn.getText() ).toContain( 'Filter activities' );
+    }
+  );
+
+  it( 'should include a visible Show button',
+    function() {
+      expect( page.searchFilterShowBtn.isDisplayed() ).toBe( true );
+      expect( page.searchFilterShowBtn.getText() ).toBe( 'Show' );
+    }
+  );
+
+  it( 'should include a hidden Hide button',
+    function() {
+      expect( page.searchFilterHideBtn.isDisplayed() ).toBe( false );
+    }
+  );
+
+  it( 'should include search filter results',
+    function() {
+      expect( page.searchFilterResults.count() ).toBeGreaterThan( 0 );
+    }
+  );
+
+  it( 'should include pagination form',
+    function() {
+      expect( page.paginationForm.isPresent() ).toBe( true );
+    }
+  );
+
+  it( 'should include a previous buttton within the pagination element',
+    function() {
+      expect( page.paginationPrevBtn.getText() ).toBe( 'Newer' );
+    }
+  );
+
+  it( 'should include a next buttton within the pagination element',
+    function() {
+      expect( page.paginationNextBtn.getText() ).toBe( 'Older' );
+    }
+  );
+
+  it( 'should include a page input with value set to 1',
+    function() {
+      expect( page.paginationPageInput.getAttribute( 'value' ) === 1 );
+    }
+  );
+
+} );

--- a/test/browser_tests/spec_suites/header.js
+++ b/test/browser_tests/spec_suites/header.js
@@ -13,7 +13,7 @@ describe( 'The Header Component', function() {
       var sheets = document.styleSheets;
       var hrefs = [];
 
-      for( i = 0; i < sheets.length; i++ ) {
+      for ( var i = 0; i < sheets.length; i++ ) {
         hrefs.push( sheets[i].href );
       }
 
@@ -23,12 +23,12 @@ describe( 'The Header Component', function() {
     }
 
     browser.executeScript( getStylesheets ).then(
-      function ( styleSheets ) {
+      function( styleSheets ) {
         browser.styleSheets = styleSheets;
       }
     );
 
-    browser.getCapabilities().then( function ( cap ) {
+    browser.getCapabilities().then( function( cap ) {
       browser.name = cap.caps_.browserName;
       browser.version = cap.caps_.version;
     } );


### PR DESCRIPTION
Adding Acceptance tests for the `activity-log` page.

## Changes

- Updated `src/activity-log/index.html` to add qa hooks.
- Added `test/browser_tests/page_objects/page_activity-log.js` to support Acceptance testing.
- Added `test/browser_tests/spec_suites/activity-log.js` to support Acceptance testing.
-  Updated `test/browser_tests/shared_objects/footer.js` to support pages other than `/`.
-  Updated `test/browser_tests/shared_objects/header.js` to support pages other than `/`.
- Updated `test/browser_tests/spec_suites/header.js` to fix linting issues.

## Testing
-  Run `gulp test:acceptance`

## Notes
- This PR does add the `data-qa-hook` attribute as discussed in issue https://github.com/cfpb/cfgov-refresh/issues/930


## Review
@anselmbradford 
@jimmynotjim 
@KimberlyMunoz 