### PR TITLE
Fixes skip-nav

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,8 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 
 ### Fixed
 - Fixed issue with logic displaying the Event summary state.
-- Fixed missing IE only stylesheet for older systems/browsers
+- Fixed missing IE only stylesheet for older systems/browsers.
+- Fixed skip-navigation link for keyboard navigation.
 
 
 ## 3.0.0-2.3.0 - 2015-08-27

--- a/src/static/css/skip-nav.less
+++ b/src/static/css/skip-nav.less
@@ -16,7 +16,7 @@
     left: unit(@grid_gutter-width / @base-font-size-px, em);
     background: transparent;
     transition: transform 1s ease, background .5s linear;
-    z-index: 10;
+    z-index: 11;
 }
 
 #skip-nav:focus {


### PR DESCRIPTION
Ans pointed out that the skip nav link isn't working on Flapjack. Z-index got added to the beta-banner in the mega-menu refactor and is covering up the skip link. The fix is to give it a slightly higher z-index.

## Fixes
- Fixes skip-nav link

## Testing
- Hit tab to see the skip-nav button

## Review
- @anselmbradford 
- @jimmynotjim 
- @sebworks 
