### PR TITLE
Updated the primary nav to move focus as appropriate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Replaced old Grunt legaccsy plugin with Gulp mq-remove plugin
 - Added ability for acceptance --specs test flag to accept list of test files.
 - Changes `big_radio` macro to `radio_big` and `checkbox_bg` to `checkbox_big`.
+- Updated the primary nav to move focus as user enters and leaves nav levels
 
 ### Removed
 - Disables tests for landing page events, since we don't currently have events.

--- a/src/_includes/templates/nav/primary-nav.html
+++ b/src/_includes/templates/nav/primary-nav.html
@@ -11,7 +11,7 @@
                 sub_nav_title,
                 sub_nav_media,
                 sub_nav_items in vars.nav_items %}
-            <li class="list_item primary-nav_item">
+            <li class="list_item primary-nav_item js-primary-nav_item">
                 {%- if sub_nav_items | length > 0 %}
                     {# TODO: Make this a button, it is not a real link. #}
                     <a class="list_link

--- a/src/static/css/nav-primary.less
+++ b/src/static/css/nav-primary.less
@@ -127,7 +127,9 @@
     z-index: 10;
 
     transition: transform 0.2s ease-in,
-                max-height 0.2s ease-in;
+                max-height 0.2s ease-in,
+                visibility 0s 0.5s;
+    visibility: hidden;
 
     &[aria-expanded="true"] {
         transition: transform 0.25s ease-out,
@@ -222,14 +224,17 @@
         transform: translateX(-100%);
         z-index: 10;
 
-        border-top: 1px solid @gray-50;
-        transition: transform 0.2s ease-in;
         background-color: @gray-10;
+        border-top: 1px solid @gray-50;
+        transition: transform 0.2s ease-in,
+                    visibility 0s 0.5s;
+        visibility: hidden;
 
         &[aria-expanded="true"] {
             transform: translateY(0);
             transition: transform 0.25s ease-out;
             box-shadow: 5px 0 0 @gray-50;
+            visibility: visible;
         }
 
         &_trigger {
@@ -276,6 +281,7 @@
 
         &[aria-expanded="true"] {
             transform: translateX(100%);
+            visibility: visible;
         }
 
         &_btn__back {
@@ -360,6 +366,7 @@
 
             border-top: 1px solid @gray-50;
             border-bottom: 4px solid @gray-50;
+            visibility: visible;
         }
 
         &_title {

--- a/src/static/js/modules/nav-primary.js
+++ b/src/static/js/modules/nav-primary.js
@@ -15,9 +15,17 @@ function init() {
   var $subNavs = $( '.js-sub-nav' );
   var $subBack = $( '.js-sub-nav_back' );
 
-  /* TODO: Add Unit Tests */
   $primaryTrigger.on( 'click', function() {
-    es.set.toggleExpandedState( $primaryNav );
+    if ( es.get.isThisExpanded( $primaryNav ) ) {
+      es.set.toggleExpandedState( $primaryNav, 'false', function() {
+        $primaryTrigger.focus();
+      } );
+    } else {
+      es.set.toggleExpandedState( $primaryNav, 'true', function() {
+        $primaryLink[0].focus();
+      } );
+    }
+
     es.set.toggleExpandedState( $primaryTrigger );
     es.set.toggleExpandedState( $( 'body' ) );
   } );
@@ -28,16 +36,26 @@ function init() {
     var $this = $( this );
     var $thisSubNav = $this.siblings( '.js-sub-nav' );
     var $otherSubNavs = $subNavs.not( $thisSubNav );
+    var $firstLink = $thisSubNav.find( 'a' )[0];
 
     if ( es.get.isOneExpanded( $otherSubNavs ) ) {
       es.set.toggleExpandedState( $primaryLink, 'false' );
       es.set.toggleExpandedState(
         $otherSubNavs,
         'false',
-        es.set.toggleExpandedState( $thisSubNav )
+        function() {
+          es.set.toggleExpandedState( $thisSubNav );
+          $firstLink.focus();
+        }
       );
+    } else if ( es.get.isThisExpanded( $thisSubNav ) ) {
+      es.set.toggleExpandedState( $thisSubNav, 'false', function() {
+        $this.focus();
+      } );
     } else {
-      es.set.toggleExpandedState( $thisSubNav );
+      es.set.toggleExpandedState( $thisSubNav, null, function() {
+        $firstLink.focus();
+      } );
     }
 
     es.set.toggleExpandedState( $this );
@@ -45,9 +63,13 @@ function init() {
 
   $subBack.on( 'click', function() {
     var $thisSubNav = $( this ).closest( '.js-sub-nav' );
-
+    var $thisPrimaryLink = $( this )
+                           .closest( '.js-primary-nav_item' )
+                           .find( '.js-primary-nav_link' );
     es.set.toggleExpandedState( $primaryLink, 'false' );
-    es.set.toggleExpandedState( $thisSubNav, 'false' );
+    es.set.toggleExpandedState( $thisSubNav, 'false', function() {
+      $thisPrimaryLink.focus();
+    } );
   } );
 
 /*

--- a/src/static/js/modules/util/expanded-state.js
+++ b/src/static/js/modules/util/expanded-state.js
@@ -47,13 +47,16 @@ function isOneExpanded( $elems ) {
  *                         passed callback.
  */
 function toggleExpandedState( $elem, state, cb, delay ) {
+  var navTimeout;
+
   delay = delay || 300;
   state = state || !isThisExpanded( $elem );
-  clearTimeout( navTimeOut );
 
   $elem.attr( 'aria-expanded', state );
 
   if ( cb ) {
+    clearTimeout( navTimeOut );
+
     navTimeOut = setTimeout( function() {
       return cb();
     }, delay );

--- a/test/unit_tests/modules/nav-primary-spec.js
+++ b/test/unit_tests/modules/nav-primary-spec.js
@@ -5,7 +5,7 @@ var expect = chai.expect;
 var jsdom = require( 'mocha-jsdom' );
 
 describe( 'Get Event States', function() {
-  var $, navPrimary, sandbox;
+  var $, navPrimary, sandbox, $link;
 
   jsdom();
 
@@ -21,18 +21,20 @@ describe( 'Get Event States', function() {
     $( 'body' ).html(
       '<div class="js-primary-nav">' +
         '<div class="js-primary-nav_trigger"></div>' +
-        '<div class="nav-item-1">' +
+        '<div class="nav-item-1 js-primary-nav_item">' +
           '<a class="nav-link-1 js-primary-nav_link" ' +
              'href="http:// github.com">Link</a>' +
           '<div class="sub-nav-1 js-sub-nav" aria-expanded="false">' +
             '<button class="sub-nav-back-1 js-sub-nav_back">Back</button>' +
+            '<a href="some-url">First Link</a>' +
           '</div>' +
         '</div>' +
-        '<div class="nav-item-2">' +
+        '<div class="nav-item-2 js-primary-nav_item">' +
           '<a class="nav-link-2 js-primary-nav_link" ' +
              'href="http:// github.com">Link</a>' +
           '<div class="sub-nav-2 js-sub-nav" aria-expanded="false">' +
             '<button class="js-sub-nav_back">Back</button>' +
+            '<a href="some-url">First Link</a>' +
           '</div>' +
         '</div>' +
       '</div>'
@@ -45,61 +47,142 @@ describe( 'Get Event States', function() {
   } );
 
   describe( 'Primary Nav Link Events - Default state', function() {
+    beforeEach( function() {
+      $link = $( $( '.sub-nav-1' ).find( 'a' )[0] );
+
+      $( '.nav-link-1' ).trigger( 'click' );
+    } );
 
     it( 'should not navigate away from the page', function() {
-      $( '.nav-link-1' ).trigger( 'click' );
-
       expect( window.location.href ).to.not.equal( 'http:// www.google.com/' );
     } );
 
     it( 'should toggle the sibling sub nav', function() {
-      $( '.nav-link-1' ).trigger( 'click' );
-
       expect( $( '.sub-nav-1' ).attr( 'aria-expanded' ) ).to.equal( 'true' );
     } );
 
     it( 'should not toggle a non-sibling sub nav', function() {
-      $( '.nav-link-2' ).trigger( 'click' );
-
-      expect( $( '.sub-nav-1' ).attr( 'aria-expanded' ) ).to.equal( 'false' );
+      expect( $( '.sub-nav-2' ).attr( 'aria-expanded' ) ).to.equal( 'false' );
     } );
+
+    it( 'should focus the first link in the sibling sub nav', function( done ) {
+      setTimeout( function() { // eslint-disable-line max-nested-callbacks, no-inline-comments, max-len
+        expect( $link.is( ':focus' ) ).to.be.true;
+        done();
+      }, 500 );
+    } );
+
+    it( 'should not focus the first link in a non-sibling sub nav',
+      function( done ) {
+        var $nextlink = $( $( '.sub-nav-2' ).find( 'a' )[0] );
+
+        setTimeout( function() { // eslint-disable-line max-nested-callbacks, no-inline-comments, max-len
+          expect( $nextlink.is( ':focus' ) ).to.be.false;
+          done();
+        }, 500 );
+      } );
   } );
 
   describe( 'Primary Nav Link Events - One expanded', function() {
-    it( 'should close itself', function() {
-      $( '.sub-nav-1' ).attr( 'aria-expanded', 'true' );
-      $( '.nav-link-1' ).trigger( 'click' );
+    beforeEach( function() {
+      $link = $( $( '.sub-nav-2' ).find( 'a' )[0] );
 
+      $( '.sub-nav-1' ).attr( 'aria-expanded', 'true' );
+      $( '.nav-link-2' ).trigger( 'click' );
+    } );
+
+    it( 'should close others', function() {
       expect( $( '.sub-nav-1' ).attr( 'aria-expanded' ) ).to.equal( 'false' );
     } );
 
-    it( 'should close others, then open sibling sub nav', function() {
-      $( '.sub-nav-1' ).attr( 'aria-expanded', 'true' );
-      $( '.nav-link-2' ).trigger( 'click' );
-
-      expect( $( '.sub-nav-1' ).attr( 'aria-expanded' ) ).to.equal( 'false' );
-
+    it( 'should open the sibling sub nav', function( done ) {
       setTimeout( function() { // eslint-disable-line max-nested-callbacks, no-inline-comments, max-len
         expect( $( '.sub-nav-2' ).attr( 'aria-expanded' ) ).to.equal( 'true' );
+        done();
+      }, 500 );
+    } );
+
+    it( 'should focus the first link in sibling sub nav', function( done ) {
+      setTimeout( function() { // eslint-disable-line max-nested-callbacks, no-inline-comments, max-len
+        expect( $link.is( ':focus' ) ).to.be.true;
+        done();
+      }, 500 );
+    } );
+
+    it( 'should close itself', function( done ) {
+      setTimeout( function() { // eslint-disable-line max-nested-callbacks, no-inline-comments, max-len
+        $( '.nav-link-2' ).trigger( 'click' );
+
+        expect( $( '.sub-nav-2' ).attr( 'aria-expanded' ) ).to.equal( 'false' );
+        done();
+      }, 500 );
+    } );
+
+    it( 'should focus the primary link after closing', function( done ) {
+      setTimeout( function() { // eslint-disable-line max-nested-callbacks, no-inline-comments, max-len
+        $( '.nav-link-2' ).trigger( 'click' );
+
+        setTimeout( function() { // eslint-disable-line max-nested-callbacks, no-inline-comments, max-len
+          expect( $( '.nav-link-2' ).is( ':focus' ) ).to.be.true;
+          done();
+        }, 500 );
       }, 500 );
     } );
   } );
 
   describe( 'Primary Nav Trigger Events', function() {
-    it( 'should toggle the primary nav', function() {
+    beforeEach( function() {
+      $link = $( '.nav-link-1' );
+
+      $( '.js-primary-nav_trigger' ).trigger( 'click' );
+    } );
+
+    it( 'should open the primary nav', function() {
+      expect( $( '.js-primary-nav' ).attr( 'aria-expanded' ) )
+        .to.equal( 'true' );
+    } );
+
+    it( 'should focus the first primary link', function( done ) {
+      setTimeout( function() { // eslint-disable-line max-nested-callbacks, no-inline-comments, max-len
+        expect( $link.is( ':focus' ) ).to.be.true;
+        done();
+      }, 500 );
+    } );
+
+    it( 'should close the open primary nav', function() {
       $( '.js-primary-nav_trigger' ).trigger( 'click' );
 
       expect( $( '.js-primary-nav' ).attr( 'aria-expanded' ) )
-        .to.equal( 'true' );
+        .to.equal( 'false' );
+    } );
+
+    it( 'should focus the trigger after closing', function( done ) {
+      $( '.js-primary-nav_trigger' ).trigger( 'click' );
+
+      setTimeout( function() { // eslint-disable-line max-nested-callbacks, no-inline-comments, max-len
+        expect( $( '.js-primary-nav_trigger' ).is( ':focus' ) ).to.be.true;
+        done();
+      }, 500 );
     } );
   } );
 
   describe( 'Sub Nav Back Events', function() {
-    it( 'should close the sub nav', function() {
+    beforeEach( function() {
+      $link = $( '.nav-link-1' );
+
       $( '.sub-nav-1' ).attr( 'aria-expanded', 'true' );
       $( '.sub-nav-back-1' ).trigger( 'click' );
+    } );
 
+    it( 'should close the sub nav', function() {
       expect( $( '.sub-nav-1' ).attr( 'aria-expanded' ) ).to.equal( 'false' );
+    } );
+
+    it( 'should focus the primary link after closing', function( done ) {
+      setTimeout( function() { // eslint-disable-line max-nested-callbacks, no-inline-comments, max-len
+        expect( $link.is( ':focus' ) ).to.be.true;
+        done();
+      }, 500 );
     } );
   } );
 } );

--- a/test/unit_tests/modules/util/expanded-state-spec.js
+++ b/test/unit_tests/modules/util/expanded-state-spec.js
@@ -5,7 +5,7 @@ var expect = chai.expect;
 var jsdom = require( 'mocha-jsdom' );
 
 describe( 'Event States', function() {
-  var $, es, sandbox, divExpanded, divClosed;
+  var $, es, sandbox, divExpanded, divClosed, openMenu;
 
   jsdom();
 
@@ -18,71 +18,78 @@ describe( 'Event States', function() {
   beforeEach( function() {
     divExpanded = $( '<div class="div-expanded" aria-expanded="true" />' );
     divClosed = $( '<div class="div-closed" aria-expanded="false" />' );
+    openMenu = $( [] ).add( divClosed ).add( divExpanded );
   } );
 
   afterEach( function() {
     sandbox.restore();
   } );
 
-  it( 'should return true when expanded', function() {
-    expect( es.get.isThisExpanded( divExpanded ) ).to.be.true;
+  describe( 'get expanded state', function() {
+    it( 'should return true when expanded', function() {
+      expect( es.get.isThisExpanded( divExpanded ) ).to.be.true;
+    } );
+
+    it( 'should return false when closed', function() {
+      expect( es.get.isThisExpanded( divClosed ) ).to.be.false;
+    } );
+
+    it( 'should return true if at least one is expanded', function() {
+      var testExpandedDivs = $( [] ).add( divClosed ).add( divExpanded );
+
+      expect( es.get.isOneExpanded( testExpandedDivs ) ).to.be.true;
+    } );
+
+    it( 'should return false if at least one isn’t expanded', function() {
+      var testClosedDivs = $( [] ).add( divClosed ).add( divClosed );
+
+      expect( es.get.isOneExpanded( testClosedDivs ) ).to.be.false;
+    } );
   } );
 
-  it( 'should return false when closed', function() {
-    expect( es.get.isThisExpanded( divClosed ) ).to.be.false;
+
+  describe( 'set expanded state - default state', function() {
+    it( 'should toggle a closed div open', function() {
+      es.set.toggleExpandedState( divClosed );
+      expect( es.get.isThisExpanded( divClosed ) ).to.be.true;
+    } );
+
+    it( 'should toggle an open div closed', function() {
+      es.set.toggleExpandedState( divExpanded );
+      expect( es.get.isThisExpanded( divExpanded ) ).to.be.false;
+    } );
+
+    it( 'should use null state to toggle an open div closed', function() {
+      es.set.toggleExpandedState( divExpanded, null );
+      expect( es.get.isThisExpanded( divExpanded ) ).to.be.false;
+    } );
+
+    it( 'should use false state to close an open div', function() {
+      es.set.toggleExpandedState( divExpanded, 'false' );
+      expect( es.get.isThisExpanded( divExpanded ) ).to.be.false;
+    } );
+
+    it( 'should use true state to open a closed div', function() {
+      es.set.toggleExpandedState( divClosed, 'true' );
+      expect( es.get.isThisExpanded( divClosed ) ).to.be.true;
+    } );
   } );
 
-  it( 'should return true if at least one is expanded', function() {
-    var testExpandedDivs = $( [] ).add( divClosed ).add( divExpanded );
+  describe( 'set expanded state - open state', function() {
+    beforeEach( function() {
 
-    expect( es.get.isOneExpanded( testExpandedDivs ) ).to.be.true;
-  } );
+    } );
 
-  it( 'should return false if at least one isn’t expanded', function() {
-    var testClosedDivs = $( [] ).add( divClosed ).add( divClosed );
+    it( 'should close all open divs', function() {
+      es.set.toggleExpandedState( openMenu, 'false' );
+      expect( es.get.isOneExpanded( openMenu ) ).to.be.false;
+    } );
 
-    expect( es.get.isOneExpanded( testClosedDivs ) ).to.be.false;
-  } );
-
-  it( 'should toggle a closed div open', function() {
-    es.set.toggleExpandedState( divClosed );
-    expect( es.get.isThisExpanded( divClosed ) ).to.be.true;
-  } );
-
-  it( 'should toggle an open div closed', function() {
-    es.set.toggleExpandedState( divExpanded );
-    expect( es.get.isThisExpanded( divExpanded ) ).to.be.false;
-  } );
-
-  it( 'should use null state to toggle an open div closed', function() {
-    es.set.toggleExpandedState( divExpanded, null );
-    expect( es.get.isThisExpanded( divExpanded ) ).to.be.false;
-  } );
-
-  it( 'should use false state to close an open div', function() {
-    es.set.toggleExpandedState( divExpanded, 'false' );
-    expect( es.get.isThisExpanded( divExpanded ) ).to.be.false;
-  } );
-
-  it( 'should use true state to open a closed div', function() {
-    es.set.toggleExpandedState( divClosed, 'true' );
-    expect( es.get.isThisExpanded( divClosed ) ).to.be.true;
-  } );
-
-  it( 'should close all open divs', function() {
-    var closeAllDivs = $( [] ).add( divClosed ).add( divExpanded );
-
-    es.set.toggleExpandedState( closeAllDivs, 'false' );
-    expect( es.get.isOneExpanded( closeAllDivs ) ).to.be.false;
-  } );
-
-  it( 'should fire a callback after toggling', function( done ) {
-    var callbackSpy = sinon.spy();
-
-    es.set.toggleExpandedState( divClosed, null, function() {
-      callbackSpy();
-      expect( callbackSpy.called ).to.be.ok;
-      done();
+    it( 'should fire a callback after toggling', function( done ) {
+      es.set.toggleExpandedState( openMenu, null, function() { // eslint-disable-line max-nested-callbacks, no-inline-comments, max-len
+        expect( es.get.isThisExpanded( divClosed ) ).to.be.true;
+        done();
+      } );
     } );
   } );
 } );


### PR DESCRIPTION
Updated the primary nav to move focus as appropriate

## Additions

- Added focus triggers when opening nav levels, the focus moves to the first link in that level
- Added focus trigger when closing nav levels, the focus moves to the trigger that opened it

## Fixes

- Fixed callback timeout in expanded-state
- Fixed test for callback timeout in expanded-state-spec

## Removals

- None

## Changes

- Added focus triggers while navigating by tab
- Added tests to support new focus triggers

## Testing

- Use the nav by keyboard, focus should move into and out of each level depending on which trigger you use
- Run `gulp test:unit:scripts`

## Review

- @KimberlyMunoz 
- @sebworks 
- @anselmbradford 

## Screenshots

<img width="1021" alt="screen shot 2015-09-10 at 2 45 15 pm" src="https://cloud.githubusercontent.com/assets/1280430/9797689/93095bf4-57ca-11e5-9a6d-8cf17fdbe342.png">

<img width="400" alt="screen shot 2015-09-10 at 2 47 33 pm" src="https://cloud.githubusercontent.com/assets/1280430/9797771/e6fb2490-57ca-11e5-8526-a1ef0afdf0c9.png">

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices 
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)