### PR TITLE
Switching heading structure to traditional outline

### DIFF
--- a/src/_includes/breadcrumbs.html
+++ b/src/_includes/breadcrumbs.html
@@ -17,7 +17,7 @@
    ========================================================================== #}
 
 {% macro render(items, additional_classes) %}
-<nav class="breadcrumbs {{ additional_classes }}">
+<nav class="breadcrumbs {{ additional_classes }}" aria-label="Breadcrumbs">
     {% for href, id, caption in items %}
     <a class="breadcrumbs_link" href="{{ href }}">
         {{ caption|e }}

--- a/src/_includes/hero.html
+++ b/src/_includes/hero.html
@@ -27,6 +27,7 @@
                 {% endif %}
                 <div class="summary">
                     <header class="summary_header">
+                        {# TODO: Change to H2 when hero is placed under title #}
                         <h1 class="summary_heading">{{ hero.title }}</h1>
                     </header>
                     <p class="summary_text">

--- a/src/_includes/macros/activity-snippets.html
+++ b/src/_includes/macros/activity-snippets.html
@@ -121,8 +121,8 @@
             filter_tags=tags) %}
     {% endif %}
     {% if feed.total > 0 %}
-    <aside class="activity">
-        <h1 class="h4">{{ icon }} {{ header }}</h1>
+    <div class="activity">
+        <h3 class="h4">{{ icon }} {{ header }}</h3>
         <ul class="list list__unstyled list__spaced list__links">
         {% for item in feed %}
             <li class="list_item">
@@ -140,6 +140,6 @@
             </li>
         {% endfor %}
         </ul>
-    </aside>
+    </div>
     {% endif %}
 {% endmacro %}

--- a/src/_includes/macros/mobile-carousel.html
+++ b/src/_includes/macros/mobile-carousel.html
@@ -39,7 +39,7 @@
                          src="{{ slides.image_base_url + slide.image_filename }}">
                 </div>
                 <div class="media_body u-centered-on-mobile">
-                    <h1 class="h3">{{ slide.title }}</h1>
+                    <h2 class="h3">{{ slide.title }}</h2>
                     <p class="short-desc">{{ slide.desc }}</p>
                 </div>
             </section>

--- a/src/_includes/macros/share.html
+++ b/src/_includes/macros/share.html
@@ -107,14 +107,14 @@
     } %}
   {% set _ignore = settings.update(options) %}
 
-    <aside class="share
+    <div class="share
                  {{ settings.additional_classes
                  if settings.additional_classes }}">
-        <h1 class="h6 share_heading
+        <span class="h6 share_heading
                   {{'u-visually-hidden'
                   if settings.hide_heading}}">
             {{ settings.heading }}
-        </h1>
+        </span>
         <ul class="list__horizontal share_items">
             {% if settings.show_email %}
             <li class="list_item">
@@ -156,5 +156,5 @@
             </li>
             {% endif %}
         </ul>
-    </aside>
+    </div>
 {% endmacro %}

--- a/src/_includes/macros/sub-nav.html
+++ b/src/_includes/macros/sub-nav.html
@@ -22,7 +22,7 @@
 <div class="sub-nav js-sub-nav">
     <div class="wrapper wrapper__sub-nav">
         <button class="sub-nav_btn__back js-sub-nav_back">Back</button>
-        <section class="sub-nav_menu">
+        <div class="sub-nav_menu">
             <span class="sub-nav_title">
                 <a class="sub-nav_link" href="{{ sub_nav_landing }}">
                     {{ sub_nav_title }}
@@ -50,7 +50,7 @@
                 </ul>
             {%- endfor %}
             </div>
-        </section>
+        </div>
         <aside class="sub-nav_media">
             {{ sub_nav_media }}
         </aside>

--- a/src/_includes/macros/sub_pages.html
+++ b/src/_includes/macros/sub_pages.html
@@ -26,9 +26,9 @@
                             qa-subpage
                             {{ 'block__border-bottom' if is_office_page == false }}">
                   {% if title %}
-                      <h1 class="h2">
+                      <h2>
                           {{ title }}
-                      </h1>
+                      </h2>
                   {% endif %}
                   <div class="content-l
                               content-l__main
@@ -65,9 +65,9 @@
                       </button>
                       <div class="expandable_content">
                           {% if expandable_title %}
-                              <h2 class="h4 u-hide-on-mobile">
+                              <h3 class="h4 u-hide-on-mobile">
                                   {{ expandable_title | safe }}
-                              </h2>
+                              </h3>
                           {% endif %}
                           {% if page.excerpt %}
                               <p class="short-desc">

--- a/src/_includes/popular-stories.html
+++ b/src/_includes/popular-stories.html
@@ -2,21 +2,21 @@
 {% macro render(popular_posts) %}
 
 <div class="popular-stories">
-    <h1 class="header-slug">
+    <h2 class="header-slug">
         <span class="header-slug_inner">
             Popular stories
         </span>
-    </h1>
+    </h2>
     <ul class="list list__unstyled list__spaced">
     {% for slug in popular_posts %}
         {% set pop_post = get_document('posts', slug) %}
         <li class="list_item">
-            <h4 class='u-mb5'>
+            <h3 class="h4 u-mb5">
                 <a class="list_link"
                    href="{{ pop_post.permalink }}">
                     {{ pop_post.title|safe }}
                 </a>
-            </h4>
+            </h3>
             {# <p class="short-desc u-mb0">
                  TODO: Use real content description
             </p> #}

--- a/src/_includes/post-macros.html
+++ b/src/_includes/post-macros.html
@@ -15,7 +15,7 @@
 
 {% macro post_summary(post) %}
     <header class="summary_header">
-        <h1 class="summary_heading">{{ post.title|safe }}</h1>
+        <h2 class="summary_heading">{{ post.title|safe }}</h2>
     </header>
     <p class="summary_text summary_text__max">
     {% if post.dek %}
@@ -116,11 +116,9 @@
             {%- endif -%}
         {%- endfor -%}
     {%- endfor -%}
-            <label class="pagination_label">
-                <span aria-hidden="true">
-                    of {{ query_obj.pages }}
-                </span>
-            </label>
+            <span class="pagination_label" aria-hidden="true">
+                of {{ query_obj.pages }}
+            </span>
             <button class="btn btn__link pagination_submit"
                     id="pagination_submit"
                     type="submit">

--- a/src/_includes/related-links.html
+++ b/src/_includes/related-links.html
@@ -22,11 +22,11 @@
 
 {%- macro render(related_links, related_links_2) -%}
 <div class="related-links">
-    <h1 class="header-slug">
+    <h2 class="header-slug">
         <span class="header-slug_inner">
             Related links
         </span>
-    </h1>
+    </h2>
 {%- if related_links_2 %}
     <div class="content-l content-l__main content-l__large-gutters">
         <div class="content-l_col content-l_col-1-2">

--- a/src/_includes/related-posts.html
+++ b/src/_includes/related-posts.html
@@ -4,20 +4,20 @@
 {% from 'macros/util/format/url.html' import slugify as slugify %}
 
 <div class="{{ slugify(header) }}">
-    <h1 class="header-slug">
+    <h2 class="header-slug">
         <span class="header-slug_inner">
             {{ header }}
         </span>
-    </h1>
+    </h2>
     <ul class="list list__unstyled list__spaced">
     {% for similar in more_like_this(post, search_types=doc_types, search_size=quantity) %}
         <li class="list_item">
-            <h4 class='u-mb5'>
+            <h3 class="h4 u-mb5">
                 <a class="list_link"
                     href="{{ similar.permalink }}">
                     {{ similar.title|safe }}
                 </a>
-            </h4>
+            </h3>
             {# <p class="short-desc u-mb0">
                 TODO: Use real content description
             </p> #}

--- a/src/_includes/sidenav.html
+++ b/src/_includes/sidenav.html
@@ -22,8 +22,8 @@
 
 {% macro render(items, active_item_id, additional_classes) %}
 
-<nav class="nav-secondary expandable {{ additional_classes }}">
-    <h2 class="u-visually-hidden">Section navigation</h2>
+<nav class="nav-secondary expandable {{ additional_classes }}"
+     aria-label="Section navigation">
     <div class="expandable_header nav-secondary_header">
         <button class="expandable_target nav-secondary_link nav-secondary_link__button">
             <span class="expandable_header-left">

--- a/src/_includes/tags.html
+++ b/src/_includes/tags.html
@@ -31,7 +31,7 @@
 
 {% macro render(tags, path, hide_heading=false, display_block=false) %}
 <div class="tags {{'tags__hide-heading' if hide_heading}} {{'tags__block-list' if display_block}}">
-    <h1 class="tags_heading {{'u-visually-hidden' if hide_heading}}">Topics:</h1>
+    <span class="tags_heading {{'u-visually-hidden' if hide_heading}}">Topics:</span>
     <ul class="tags_list">
     {% for tag in tags %}
         <li class="tags_tag">

--- a/src/_includes/templates/activities-feed.html
+++ b/src/_includes/templates/activities-feed.html
@@ -1,6 +1,6 @@
-<h1 class="header-slug">
+<h2 class="header-slug">
     <span class="header-slug_inner">
         Latest Activities
     </span>
-</h1>
+</h2>
 {{ activities_feed }}

--- a/src/_includes/templates/footer.html
+++ b/src/_includes/templates/footer.html
@@ -1,5 +1,5 @@
 <footer class="footer" role="contentinfo">
-    <aside class="wrapper wrapper__match-content">
+    <div class="wrapper wrapper__match-content">
 
         <div class="footer-pre">
 
@@ -144,5 +144,5 @@
             </p>
         </div><!-- END .footer-post -->
 
-    </aside><!-- END .wrapper.wrapper__match-content -->
+    </div><!-- END .wrapper.wrapper__match-content -->
 </footer><!-- END .footer -->

--- a/src/_includes/templates/nav/about-us-media.html
+++ b/src/_includes/templates/nav/about-us-media.html
@@ -1,9 +1,9 @@
 <a href="/the-bureau/">
     <img src="/static/img/nav-about-us-video.png"
          alt="About Us video image" />
-    <h4 class="short-desc u-mt15">
+    <p class="h4 short-desc u-mt15">
       The CFPB: Working for you.
-    </h4>
+    </p>
 </a>
 <div class="short-desc">
     This short video covers what the CFPB is and

--- a/src/_includes/templates/nav/primary-nav.html
+++ b/src/_includes/templates/nav/primary-nav.html
@@ -2,7 +2,9 @@
 {% import 'macros/sub-nav.html' as sub_nav %}
 <nav class="primary-nav
             js-primary-nav"
-     aria-expanded="false">
+     aria-expanded="false"
+     aria-label="main navigation"
+     role="navigation">
     <ul class="list
                list__unstyled
                primary-nav_menu-list">

--- a/src/_includes/templates/office-contact.html
+++ b/src/_includes/templates/office-contact.html
@@ -6,17 +6,17 @@
                     block__flush-bottom
                     block__bg
                     office_contact">
-        <h1 class="header-slug">
+        <h2 class="header-slug">
             <span class="header-slug_inner">
                 Contact Information
             </span>
-        </h1>
+        </h2>
         <div class="content-l
                     content-l__main
                     content-l__large-gutters">
             <div class="content-l_col
                         content-l_col-1">
-                <h5>{{ contact.title }}</h5>
+                <h3 class="h5">{{ contact.title }}</h3>
             </div>
         </div>
         {{ contact_layout.render( contact, 'block block__flush-top block__flush-bottom' ) }}

--- a/src/_includes/templates/upcoming-events.html
+++ b/src/_includes/templates/upcoming-events.html
@@ -1,10 +1,9 @@
-
 <div class="upcoming-events">
-    <h1 class="header-slug">
+    <h2 class="header-slug">
         <span class="header-slug_inner">
             Upcoming events
         </span>
-    </h1>
+    </h2>
     <div class="demo-placeholder">
         placeholder
     </div>

--- a/src/about-us/index.html
+++ b/src/about-us/index.html
@@ -6,7 +6,7 @@
 
 
 {% block content_main %}
-    <section class="block
+    <div class="block
                     block__flush-top">
         <h1>About Us</h1>
         <p class="h3">
@@ -36,7 +36,7 @@
                 </a>
             </li>
         </ul>
-    </section>
+    </div>
     <div class="content-l">
         {# The extra div is to prevent border tapering from combining block__border and content-l classes #}
         <div class="content-l_col-1-2">
@@ -54,7 +54,7 @@
                     </div>
                     <div class="media_body">
                         <span class="h6">Director</span>
-                        <h2 class="bureau-bio_name">Richard Cordray</h2>
+                        <h3 class="bureau-bio_name">Richard Cordray</h3>
                         <a class="jump-link jump-link__underline"
                            href="/the-bureau/about-director/">
                             Cordray’s bio
@@ -70,7 +70,7 @@
                     </div>
                     <div class="media_body">
                         <span class="h6">Deputy Director</span>
-                        <h2 class="bureau-bio_name">Meredith Fuchs</h2>
+                        <h3 class="bureau-bio_name">Meredith Fuchs</h3>
                         <a class="jump-link jump-link__underline"
                            href="/the-bureau/about-deputy-director/">
                             Fuchs’s bio
@@ -173,15 +173,15 @@
 {% endblock %}
 
 {% block content_sidebar scoped -%}
+    <aside>
+        {# TODO Add Events to the Activity Snippets #}
 
-    {# TODO Add Events to the Activity Snippets #}
-
-    {% import 'macros/activity-snippets.html' as activity_snippets with context %}
-    {% set activities_feed = activity_snippets.render(tags, ['posts', 'newsroom'], include_date_flag=true) %}
-    {% include 'templates/activities-feed.html' %}
-    <a class="jump-link jump-link__underline"
-       href="/activity-log/">
-        View all of our activities
-    </a>
-
+        {% import 'macros/activity-snippets.html' as activity_snippets with context %}
+        {% set activities_feed = activity_snippets.render(tags, ['posts', 'newsroom'], include_date_flag=true) %}
+        {% include 'templates/activities-feed.html' %}
+        <a class="jump-link jump-link__underline"
+           href="/activity-log/">
+            View all of our activities
+        </a>
+    </aside>
 {%- endblock %}

--- a/src/activity-log/index.html
+++ b/src/activity-log/index.html
@@ -34,6 +34,17 @@
 
         <table class="u-w100pct">
             <tbody>
+                <tr class="u-visually-hidden">
+                    <th>
+                        Category
+                    </th>
+                    <th>
+                        Title
+                    </th>
+                    <th>
+                        Date published
+                    </th>
+                </tr>
             {%- for item in archives %}
                 <tr>
                     <td class="u-w20pct">
@@ -52,9 +63,9 @@
                     </td>
                     <td class="u-w65pct">
                         <a href="{{ item.permalink }}">
-                            <h4 class="u-mb0">
+                            <span class="h4 u-mb0">
                                 {{ item.title }}
-                            </h4>
+                            </span>
                         </a>
                     </td>
                     <td class="u-w15pct">

--- a/src/blog/_single.html
+++ b/src/blog/_single.html
@@ -34,11 +34,11 @@
         {{ related_posts.render(post) }}
     </section>
     <section class="block">
-        <h1 class="header-slug">
+        <h2 class="header-slug">
             <span class="header-slug_inner">
                 Stay informed
             </span>
-        </h1>
+        </h2>
         <div class="block block__sub block__flush-top">
             <p class="short-desc">
                 Subscribe to our email newsletter. We will update you on new blogs.

--- a/src/blog/index.html
+++ b/src/blog/index.html
@@ -50,11 +50,11 @@
         {% endif %}
     </section>
     <section class="block">
-        <h1 class="header-slug">
+        <h2 class="header-slug">
             <span class="header-slug_inner">
                 Stay informed
             </span>
-        </h1>
+        </h2>
         <div class="block block__sub block__flush-top">
             <p class="short-desc">
                 Subscribe to our email newsletter. We will update you on new blogs.

--- a/src/careers/_template-careers-related-links.html
+++ b/src/careers/_template-careers-related-links.html
@@ -1,20 +1,17 @@
-<div class="block
-            block__bg
-            block__border-top
-            block__border-right
-            block__flush-top
-            block__flush-bottom
-            block__flush-sides">
-    <div class="">
-            {# TODO: Add Office of Civil Rights URL. #}
+<section class="block
+                block__bg
+                block__border-top
+                block__border-right
+                block__flush-top
+                block__flush-bottom
+                block__flush-sides">
             {%- import 'related-links.html' as related_links -%}
             {{- related_links.render([
                 [ '/blog/',
                   'CFPB Blog' ],
                 [ '/newsroom/',
                   'Newsroom' ],
-                [ '',
+                [ '/offices/office-of-civil-rights/',
                   'Office of Civil Rights' ]
             ]) -}}
-    </div>
-</div>
+</section>

--- a/src/careers/application-process/index.html
+++ b/src/careers/application-process/index.html
@@ -204,7 +204,7 @@
     <section class="block
                     block__padded-top
                     block__border-top">
-        <h3>Preparing a Résumé to Apply to a Federal Government Position</h3>
+        <h2 class="h3">Preparing a Résumé to Apply to a Federal Government Position</h2>
         <p>
             It is important not to leave something out
             just because it seems less relevant to you.
@@ -230,7 +230,7 @@
     <section class="block
                     block__padded-top
                     block__border-top">
-        <h3>Federally Recognized Status and Eligibility for a Position</h3>
+        <h2 class="h3">Federally Recognized Status and Eligibility for a Position</h2>
         <p>
             Sometimes very similar jobs will be posted simultaneously,
             with one of the primary differences being who is eligible to apply.
@@ -247,7 +247,7 @@
     <section class="block
                     block__padded-top
                     block__border-top">
-        <h3>Federal Ethics Rules and CFPB Ethics Regulations</h3>
+        <h2 class="h3">Federal Ethics Rules and CFPB Ethics Regulations</h2>
         <p>
             We hold ourselves to an exemplary standard of integrity in all that we do.
             Should you join us, you will be subject to federal government-wide ethics rules
@@ -270,7 +270,7 @@
     <section class="block
                     block__padded-top
                     block__border-top">
-        <h3>Equal Employment Opportunity</h3>
+        <h2 class="h3">Equal Employment Opportunity</h2>
         <p>
             The CFPB is an equal opportunity employer
             and seeks to create and maintain a vibrant and diverse workforce.
@@ -282,45 +282,44 @@
             See our Equal Employment Opportunity page for more.
         </p>
     </section>
-
-    <div class="block
-                block__border-top
-                block__flush-bottom">
-        {# This extra div is to keep the horizontal lines size consistent #}
-        <div class="content-l">
-            <section class="content-l_col
-                            content-l_col-1-3
-                            block
-                            block__padded-top
-                            block__flush-top
-                            block__padded-bottom
-                            block__flush-bottom">
-                {% include '_template-current-openings.html' %}
-            </section>
-            <section class="content-l_col
-                            content-l_col-1-3
-                            block
-                            block__padded-top
-                            block__flush-top
-                            block__padded-bottom
-                            block__flush-bottom">
-                {% include '_template-working-at-cfpb.html' %}
-            </section>
-            <section class="content-l_col
-                            content-l_col-1-3
-                            block
-                            block__padded-top
-                            block__flush-top
-                            block__padded-bottom
-                            block__flush-bottom">
-                {% include '_template-students-and-graduates.html' %}
-            </section>
-        </div>
-    </div>
-
-    {% include '_template-block-social.html' %}
-
     <aside>
+        <div class="block
+                    block__border-top
+                    block__flush-bottom">
+            {# This extra div is to keep the horizontal lines size consistent #}
+            <div class="content-l">
+                <section class="content-l_col
+                                content-l_col-1-3
+                                block
+                                block__padded-top
+                                block__flush-top
+                                block__padded-bottom
+                                block__flush-bottom">
+                    {% include '_template-current-openings.html' %}
+                </section>
+                <section class="content-l_col
+                                content-l_col-1-3
+                                block
+                                block__padded-top
+                                block__flush-top
+                                block__padded-bottom
+                                block__flush-bottom">
+                    {% include '_template-working-at-cfpb.html' %}
+                </section>
+                <section class="content-l_col
+                                content-l_col-1-3
+                                block
+                                block__padded-top
+                                block__flush-top
+                                block__padded-bottom
+                                block__flush-bottom">
+                    {% include '_template-students-and-graduates.html' %}
+                </section>
+            </div>
+        </div>
+
+        {% include '_template-block-social.html' %}
+
         {% include './_template-careers-related-links.html' %}
     </aside>
 

--- a/src/careers/current-openings/index.html
+++ b/src/careers/current-openings/index.html
@@ -37,9 +37,9 @@
 
     {% import '_macro-table-current-openings.html' as table_current_openings %}
 
-    <section class="block
-                    block__flush-top
-                    block__sub">
+    <div class="block
+                block__flush-top
+                block__sub">
             <h1>Current Openings</h1>
             <p class="h3">
                 Find the position that’s right for you.
@@ -53,42 +53,41 @@
                 Creating this kind of market takes a dedication to service,
                 leadership and innovation.
             </p>
-    </section>
+    </div>
 
     <div class="block
                 block__flush-top">
         {{ table_current_openings.render(vars.careers) }}
     </div>
-
-    <div class="block
-                block__border-top
-                block__flush-bottom">
-        {# This extra div is to keep the horizontal lines size consistent #}
-        <div class="content-l">
-            <section class="content-l_col
-                            content-l_col-1-2
-                            block
-                            block__padded-top
-                            block__padded-bottom
-                            block__flush-top
-                            block__flush-bottom">
-                {% include '_template-job-app-process.html' %}
-            </section>
-            <section class="content-l_col
-                            content-l_col-1-2
-                            block
-                            block__padded-top
-                            block__padded-bottom
-                            block__flush-top
-                            block__flush-bottom">
-                {% include '_template-working-at-cfpb.html' %}
-            </section>
-        </div>
-    </div>
-
-    {% include '_template-block-social.html' %}
-
     <aside>
+        <div class="block
+                    block__border-top
+                    block__flush-bottom">
+            {# This extra div is to keep the horizontal lines size consistent #}
+            <div class="content-l">
+                <section class="content-l_col
+                                content-l_col-1-2
+                                block
+                                block__padded-top
+                                block__padded-bottom
+                                block__flush-top
+                                block__flush-bottom">
+                    {% include '_template-job-app-process.html' %}
+                </section>
+                <section class="content-l_col
+                                content-l_col-1-2
+                                block
+                                block__padded-top
+                                block__padded-bottom
+                                block__flush-top
+                                block__flush-bottom">
+                    {% include '_template-working-at-cfpb.html' %}
+                </section>
+            </div>
+        </div>
+
+        {% include '_template-block-social.html' %}
+
         {% include '_template-careers-related-links.html' %}
     </aside>
 

--- a/src/careers/index.html
+++ b/src/careers/index.html
@@ -50,7 +50,7 @@
                 </div>
             </section>
             <aside class="content-l_col content-l_col-1-3 block block__flush-top">
-                <h1 class="h3">Newest Openings</h1>
+                <h2 class="h3">Newest Openings</h2>
                 <ul class="list list__unstyled">
                     {% for career in vars.careers %}
                     <li class="list_item">
@@ -79,46 +79,48 @@
     <div class="block
                 block__flush-top
                 block__flush-bottom">
-        <div class="media
-                    block
-                    block__flush-top
-                    block__flush-bottom
-                    block__padded-bottom">
+        <section class="media
+                        block
+                        block__flush-top
+                        block__flush-bottom
+                        block__padded-bottom">
             <div class="media_image-container
                         media_image-container__wide-margin">
                 <img class="media_image media_image__150 u-centered-on-mobile"
-                     src="/static/img/clipboard-round-300x300.png">
+                     src="/static/img/clipboard-round-300x300.png"
+                     alt="">
 
             </div>
             <div class="media_body u-centered-on-mobile">
-                <h1 class="h3">Job Application Process</h1>
+                <h2 class="h3">Job Application Process</h2>
                 <p class="short-desc">The application process can be tricky. We can help.</p>
                 <a class="jump-link jump-link__underline"
                    href="/careers/application-process/">
                     <span class="jump-link_text">Learn how the application process works</span>
                 </a>
             </div>
-        </div>
+        </section>
 
-        <div class="media
-                    block
-                    block__padded-top
-                    block__border-top
-                    block__flush-bottom">
+        <section class="media
+                        block
+                        block__padded-top
+                        block__border-top
+                        block__flush-bottom">
             <div class="media_image-container
                         media_image-container__wide-margin">
                 <img class="media_image media_image__150 u-centered-on-mobile"
-                     src="/static/img/grad-cap-round-300x300.png">
+                     src="/static/img/grad-cap-round-300x300.png"
+                     alt="">
             </div>
             <div class="media_body u-centered-on-mobile">
-                <h1 class="h3">Students and Recent Graduates</h1>
+                <h2 class="h3">Students and Recent Graduates</h2>
                 <p class="short-desc">Find opportunities in public service for a new generation of leaders.</p>
                 <p><a class="jump-link jump-link__underline"
                       href="/careers/students-and-graduates/">
                     <span class="jump-link_text">Learn about students and graduates opportunities</span>
                 </a></p>
             </div>
-        </div>
+        </section>
     </div>
 
     {% include '_template-block-social.html' %}

--- a/src/careers/students-and-graduates/index.html
+++ b/src/careers/students-and-graduates/index.html
@@ -23,7 +23,7 @@
 
 {% block content_main %}
 
-    <section class="block block__flush-top block__sub">
+    <div class="block block__flush-top block__sub">
 
             <h1>Students and Recent Graduates</h1>
             <p class="h3">
@@ -31,7 +31,7 @@
                 a new generation of leaders.
                 There are many opportunities for you to make an immediate impact.
             </p>
-    </section>
+    </div>
 
     <section class="media
                     block
@@ -128,36 +128,34 @@
             </p>
         </div>
     </section>
-
-    <div class="block
-                block__border-top
-                block__flush-bottom">
-        <div class="content-l">
-        {# This extra div is to keep the horizontal lines size consistent #}
-            <section class="content-l_col
-                            content-l_col-1-2
-                            block
-                            block__padded-top
-                            block__padded-bottom
-                            block__flush-top
-                            block__flush-bottom">
-                {% include '_template-job-app-process.html' %}
-            </section>
-            <section class="content-l_col
-                            content-l_col-1-2
-                            block
-                            block__padded-top
-                            block__padded-bottom
-                            block__flush-top
-                            ">
-                {% include '_template-working-at-cfpb.html' %}
-            </section>
-        </div>
-    </div>
-
-    {% include '_template-block-social.html' %}
-
     <aside>
+        <div class="block
+                    block__border-top
+                    block__flush-bottom">
+            <div class="content-l">
+            {# This extra div is to keep the horizontal lines size consistent #}
+                <section class="content-l_col
+                                content-l_col-1-2
+                                block
+                                block__padded-top
+                                block__padded-bottom
+                                block__flush-top
+                                block__flush-bottom">
+                    {% include '_template-job-app-process.html' %}
+                </section>
+                <section class="content-l_col
+                                content-l_col-1-2
+                                block
+                                block__padded-top
+                                block__padded-bottom
+                                block__flush-top">
+                    {% include '_template-working-at-cfpb.html' %}
+                </section>
+            </div>
+        </div>
+
+        {% include '_template-block-social.html' %}
+
         {% include './_template-careers-related-links.html' %}
     </aside>
 

--- a/src/careers/working-at-cfpb/index.html
+++ b/src/careers/working-at-cfpb/index.html
@@ -119,45 +119,44 @@
             learning, and pushing ourselves to be great.
         </p>
     </div>
-
-    <div class="block
-                block__border-top
-                block__flush-bottom">
-        {# This extra div is to keep the horizontal lines size consistent #}
-        <div class="content-l">
-            <section class="content-l_col
-                            content-l_col-1-3
-                            block
-                            block__padded-top
-                            block__flush-top
-                            block__padded-bottom
-                            block__flush-bottom">
-                {% include '_template-current-openings.html' %}
-            </section>
-            <section class="content-l_col
-                            content-l_col-1-3
-                            block
-                            block__padded-top
-                            block__flush-top
-                            block__padded-bottom
-                            block__flush-bottom">
-                {% include '_template-job-app-process.html' %}
-            </section>
-            <section class="content-l_col
-                            content-l_col-1-3
-                            block
-                            block__padded-top
-                            block__flush-top
-                            block__padded-bottom
-                            block__flush-bottom">
-                {% include '_template-students-and-graduates.html' %}
-            </section>
-        </div>
-    </div>
-
-    {% include '_template-block-social.html' %}
-
     <aside>
+        <div class="block
+                    block__border-top
+                    block__flush-bottom">
+            {# This extra div is to keep the horizontal lines size consistent #}
+            <div class="content-l">
+                <section class="content-l_col
+                                content-l_col-1-3
+                                block
+                                block__padded-top
+                                block__flush-top
+                                block__padded-bottom
+                                block__flush-bottom">
+                    {% include '_template-current-openings.html' %}
+                </section>
+                <section class="content-l_col
+                                content-l_col-1-3
+                                block
+                                block__padded-top
+                                block__flush-top
+                                block__padded-bottom
+                                block__flush-bottom">
+                    {% include '_template-job-app-process.html' %}
+                </section>
+                <section class="content-l_col
+                                content-l_col-1-3
+                                block
+                                block__padded-top
+                                block__flush-top
+                                block__padded-bottom
+                                block__flush-bottom">
+                    {% include '_template-students-and-graduates.html' %}
+                </section>
+            </div>
+        </div>
+
+        {% include '_template-block-social.html' %}
+
         {% include '_template-careers-related-links.html' %}
     </aside>
 

--- a/src/contact-us/_template-contact-list.html
+++ b/src/contact-us/_template-contact-list.html
@@ -3,9 +3,9 @@
 <div class="type-and-filter">
 
     <form class="js-type-and-filter_form u-js-only">
-        <p class="h2">
+        <h2>
             Looking for something more specific?
-        </p>
+        </h2>
         <p class="short-desc">
             We have a number of offices that work directly with the public.
             Scroll through the list, or enter the office, product,

--- a/src/contact-us/_template-general-inquiries.html
+++ b/src/contact-us/_template-general-inquiries.html
@@ -1,9 +1,9 @@
 {% from 'macros/util/format/contact.html' import format_phone as format_phone %}
 {% set general_inquiries = get_document('contact', 'general-inqueries') %}
 
-<h1 class="h4">
+<h2 class="h4">
     {{ general_inquiries.title }}
-</h1>
+</h2>
 <p class="short-desc">
     {{ general_inquiries.sitewide_desc }}
 </p>

--- a/src/contact-us/_template-mailing-addresses.html
+++ b/src/contact-us/_template-mailing-addresses.html
@@ -8,9 +8,9 @@
                 content-l
                 content-l__sidebar">
 
-    <h1 class="h3 content-l_col content-l_col-1-2">
+    <h2 class="h3 content-l_col content-l_col-1-2">
         Mailing addresses
-    </h1>
+    </h2>
 
     {# Google Image Maps API Docs:
        https://developers.google.com/maps/documentation/staticmaps/index #}
@@ -30,16 +30,16 @@
     {% endif %}
 
     <div class="content-l_col content-l_col-1-2">
-        <h2 class="h5">
+        <h3 class="h5">
             {{ administrative_offices.title }}
-        </h2>
+        </h3>
         <p class="short-desc">
             {{- administrative_offices.name -}}<br>
             {{- format_address(administrative_offices) -}}
         </p>
-        <h2 class="h5">
+        <h3 class="h5">
             {{ consumer_contact_center.title }}
-        </h2>
+        </h3>
         <p class="short-desc">
             {{- consumer_contact_center.name -}}<br>
             {{- format_address(consumer_contact_center) -}}

--- a/src/contact-us/_template-promoted-contacts.html
+++ b/src/contact-us/_template-promoted-contacts.html
@@ -8,9 +8,9 @@
 <div class="block u-mb0 content-l content-l__sidebar">
 
     <section class="block content-l_col content-l_col-1-2">
-        <h1 class="h5">
+        <h2 class="h5">
             {{ accessibility_feedback.title }}
-        </h1>
+        </h2>
     {%- if accessibility_feedback.sitewide_desc %}
         <p>
             {{ accessibility_feedback.sitewide_desc }}
@@ -24,9 +24,9 @@
     </section>
 
     <section class="block content-l_col content-l_col-1-2">
-        <h1 class="h5">
+        <h2 class="h5">
             {{ whistleblowers.title }}
-        </h1>
+        </h2>
     {%- if whistleblowers.sitewide_desc %}
         <p>
             {{ whistleblowers.sitewide_desc }}
@@ -69,9 +69,9 @@
     </section>
 
     <section class="block content-l_col content-l_col-1-2">
-        <h1 class="h5">
+        <h2 class="h5">
             {{ tribal_consultation.title }}
-        </h1>
+        </h2>
     {%- if tribal_consultation.sitewide_desc %}
         <p>
             {{ tribal_consultation.sitewide_desc }}

--- a/src/contact-us/_template-submit-a-complaint.html
+++ b/src/contact-us/_template-submit-a-complaint.html
@@ -1,9 +1,9 @@
 {% from 'macros/util/format/contact.html' import format_phone as format_phone %}
 {% set submit_a_complaint = get_document('contact', 'submit-a-complaint') %}
 
-<h1 class="h4">
+<h2 class="h4">
     {{ submit_a_complaint.title }}
-</h1>
+</h2>
 <p class="short-desc">
     {{ submit_a_complaint.sitewide_desc }}
 </p>

--- a/src/events/archive/index.html
+++ b/src/events/archive/index.html
@@ -16,7 +16,7 @@
 
 {% block content_main %}
 
-    <section class="media block block__flush-top block__sub">
+    <div class="media block block__flush-top block__sub">
         <div class="media_body">
             <h1>Archived events</h1>
             <p class="h3">
@@ -41,7 +41,7 @@
                 'range_date_lte'
             ]) }}
          </div>
-    </section>
+    </div>
 
     {# Footer #}
     <aside>

--- a/src/events/index.html
+++ b/src/events/index.html
@@ -53,7 +53,6 @@
          </div>
     </section>
 
-    {# Footer #}
     <aside>
         <div class="u-mb0
                     block
@@ -65,11 +64,11 @@
             <div class="content-l content-l__main">
                 <section class="u-mb20 content-l_col content-l_col-1-2">
                     <div class="u-mb30">
-                        <h1 class="header-slug">
+                        <h2 class="header-slug">
                             <span class="header-slug_inner">
                                 Stay informed
                             </span>
-                        </h1>
+                        </h2>
                         <p class="short-desc">
                             Subscribe to our email newsletter. We will update you on new event updates.
                         </p>

--- a/src/events/request-a-speaker/_faq.html
+++ b/src/events/request-a-speaker/_faq.html
@@ -1,9 +1,9 @@
 <section>
 
     <div class="u-js-only">
-        <h1 class="h2">
+        <h2>
             Frequently asked questions about requesting a speaker
-        </h1>
+        </h2>
         <p class="short-desc">
             If you don’t see your question below, contact us at
             <a href="mailto:Invitations2cfpb@consumerfinance.gov">

--- a/src/events/request-a-speaker/index.html
+++ b/src/events/request-a-speaker/index.html
@@ -27,16 +27,16 @@
         </a>.
     </p>
 
-    <section class="sub-page_content
-                    block
-                    block__flush-top">
+    <div class="sub-page_content
+                block
+                block__flush-top">
         <p>While we welcome invitations for CFPB officials to speak on behalf
         of the Bureau’s work, please note that we cannot accept every request.
         For scheduling purposes, please provide at least one month’s notice in
         advance of your event.</p>
         <p>Once your request has been received, we will review it and contact
         you if we require additional information.</p>
-    </section>
+    </div>
 
     {%- include '_faq.html' %}
 

--- a/src/index.html
+++ b/src/index.html
@@ -13,22 +13,22 @@
 
     <main class="content" id="main" role="main">
 
-        <section class="content_hero hero beta-hero">
+        <div class="content_hero hero beta-hero">
             <h1 class="beta-hero_title">Welcome to beta.<wbr>consumerfinance.gov!</h1>
             <p class="beta-hero_desc">
                 We’re redesigning consumerfinance.gov to make it easier to use.
                 Follow our work here as we build in the open.
             </p>
-        </section>
+        </div>
 
         <!-- .content_bar must come after .content_hero and before .content_wrapper -->
         <div class="content_bar"></div>
 
         <div class="wrapper content_wrapper">
-            <section class="content_main">
+            <div class="content_main">
                 <div class="content-l content-l__large-gutters">
                     <section class="content-l_col content-l_col-1-2">
-                        <h3>Why are we redesigning in beta?</h3>
+                        <h2 class="h3">Why are we redesigning in beta?</h2>
                         <p class="short_desc">
                             A beta release gives both users and developers a sense of
                             new features and capabilities.
@@ -46,7 +46,7 @@
                     </section>
 
                     <section class="content-l_col content-l_col-1-2 content-l_col__before-divider">
-                        <h3>Open government, open code</h3>
+                        <h2 class="h3">Open government, open code</h2>
                         <p class="short_desc">
                             The new consumerfinance.gov is an open source project,
                             but it’s not our only one.
@@ -69,9 +69,8 @@
                         </ul>
                     </section>
                 </div><!-- END .content-l -->
-            </section><!-- END .content_main -->
+            </div><!-- END .content_main -->
         </div><!-- END .content_wrapper -->
-
     </main>
 
 {% endblock content %}

--- a/src/newsroom/_single.html
+++ b/src/newsroom/_single.html
@@ -26,11 +26,11 @@
     {% import 'article.html' as article with context %}
     {{ article.render(newsroom, vars.path) }}
     <aside class="press-information">
-        <h1 class="header-slug">
+        <h2 class="header-slug">
             <span class="header-slug_inner">
                 Press information
             </span>
-        </h1>
+        </h2>
         <p class="short-desc">
             If you want to republish the article or have questions about the content,
             please contact the press office.
@@ -47,11 +47,11 @@
     </section>
     <section class="block stay-informed">
         <div class="block__sub">
-            <h1 class="header-slug">
+            <h2 class="header-slug">
                 <span class="header-slug_inner">
                     Stay informed
                 </span>
-            </h1>
+            </h2>
             <p class="short-desc">
                 Subscribe to our email newsletter. We will update you on new newsroom updates.
             </p>

--- a/src/newsroom/featured-topic.html
+++ b/src/newsroom/featured-topic.html
@@ -11,9 +11,9 @@
                 <span class="fancy-slug_ribbon-right"></span>
             </span>
         </div>
-        <h1 class="summary_header summary_header__large">
+        <h2 class="summary_header summary_header__large">
             {{ post.title }}
-        </h1>
+        </h2>
         <div class="summary_cols">
             <div class="summary_col summary_text summary_text__dark">
                 {{ post.content|safe }}
@@ -22,7 +22,6 @@
                 <ul class="list list__spaced list__unstyled">
                 {% for link in post.links %}
                     <li class="list_item">
-                        <!-- <span class="category-slug_icon cf-icon cf-icon-bullhorn"></span> -->
                         <a class="list_link"
                            href="{{ link.url }}">
                             {{ link.label if link.label else link.url }}

--- a/src/newsroom/index.html
+++ b/src/newsroom/index.html
@@ -34,11 +34,11 @@
     {# Footer #}
     <aside>
         <section class="block">
-            <h1 class="header-slug">
+            <h2 class="header-slug">
                 <span class="header-slug_inner">
                     Stay informed
                 </span>
-            </h1>
+            </h2>
             <div class="content-l content-l__main">
                 <div class="block__sub content-l_col content-l_col-1-2">
                     <p class="short-desc">

--- a/src/newsroom/press-resources/index.html
+++ b/src/newsroom/press-resources/index.html
@@ -21,7 +21,7 @@
 
     <section class="press-section press-contacts">
 
-        <h1 class="press-section_title press-contacts_title">Press contacts</h1>
+        <h2 class="press-section_title press-contacts_title">Press contacts</h2>
 
         <p>
             We are committed to engaging with the public and members of the media regularly
@@ -52,7 +52,7 @@
         <div class="press-contacts_people content-l content-l__main">
 
             <section class="contact-person content-l_col-1-2">
-                <h1 class="contact-person_name">Jen Howard</h1>
+                <h3 class="contact-person_name">Jen Howard</h3>
                 <div class="contact-person_title">Assistant Director of Communications</div>
                 <ul class="contact-person_methods list list__unstyled">
                     <li class="list_item">
@@ -67,7 +67,7 @@
             </section>
 
             <section class="contact-person content-l_col-1-2">
-                <h1 class="contact-person_name">Walter Suskind</h1>
+                <h3 class="contact-person_name">Walter Suskind</h3>
                 <div class="contact-person_title">Press Assistant</div>
                 <ul class="contact-person_methods list list__unstyled">
                     <li class="list_item">
@@ -82,7 +82,7 @@
             </section>
 
             <section class="contact-person content-l_col-1-2">
-                <h1 class="contact-person_name">Moira Vahey</h1>
+                <h3 class="contact-person_name">Moira Vahey</h3>
                 <div class="contact-person_title">Spokesperson</div>
                 <ul class="contact-person_methods list list__unstyled">
                     <li class="list_item">
@@ -97,7 +97,7 @@
             </section>
 
             <section class="contact-person content-l_col-1-2">
-                <h1 class="contact-person_name">Sam Gilford</h1>
+                <h3 class="contact-person_name">Sam Gilford</h3>
                 <div class="contact-person_title">Spokesperson</div>
                 <ul class="contact-person_methods list list__unstyled">
                     <li class="list_item">
@@ -117,7 +117,7 @@
 
     <section class="press-section press-photos-bios">
 
-        <h1 class="press-section_title press-photos-bios_title">Photos and bios</h1>
+        <h2 class="press-section_title press-photos-bios_title">Photos and bios</h2>
 
         <p class="press-section_intro">Our director is appointed by the president and
             confirmed by the Senate. He heads a bureau of more than 1,200 people working for
@@ -132,7 +132,7 @@
                          src="/static/img/director-cordray-round-300x300.jpg"
                          alt="Director Richard Cordray">
                     <div class="contact-person_title">Director</div>
-                    <h1 class="contact-person_name">Richard Cordray</h1>
+                    <h3 class="contact-person_name">Richard Cordray</h3>
                     <ul class="list list__links">
                         <li class="list_item">
                             <a class="list_link"
@@ -162,7 +162,7 @@
                          src="/static/img/deputy-director-fuchs-round-300x300.jpg"
                          alt="Deputy Director Meredith Fuchs">
                     <div class="contact-person_title">Deputy Director</div>
-                    <h1 class="contact-person_name">Meredith Fuchs</h1>
+                    <h3 class="contact-person_name">Meredith Fuchs</h3>
                     <ul class="list list__links">
                         {# TODO: Add high-res portrait when we have one for meredith. #}
                         <li class="list_item">
@@ -196,11 +196,11 @@
                   ">
         <div class="content-l content-l__main">
             <section class="content-l_col content-l_col-1-2">
-                <h1 class="header-slug">
+                <h2 class="header-slug">
                     <span class="header-slug_inner">
                         Stay informed
                     </span>
-                </h1>
+                </h2>
                 <div class="block block__sub block__flush-top">
                     <p class="short-desc">
                         Subscribe to get our press releases by email.

--- a/src/offices/_single.html
+++ b/src/offices/_single.html
@@ -110,9 +110,9 @@
             {% endif %}
             <div class="media_body">
                 {% if resource.title %}
-                <h2 class="qa-resource-title">
+                <h3 class="h2 qa-resource-title">
                     {{ resource.title | safe }}
-                </h2>
+                </h3>
                 {% endif %}
 
                 {% if resource.desc %}
@@ -148,16 +148,18 @@
         {{ office.content }}
     </section>
     {% endif %}
-    <div class="block
-                block__flush-sides
-                block__flush-bottom
-                block__border-top
-                block__border-right">
-        {% if office.tags %}
-            {% import 'macros/activities-block.html' as activities_block with context %}
-            {{ activities_block.render(office.tags) }}
-        {% endif %}
+    <aside>
+        <div class="block
+                    block__flush-sides
+                    block__flush-bottom
+                    block__border-top
+                    block__border-right">
+            {% if office.tags %}
+                {% import 'macros/activities-block.html' as activities_block with context %}
+                {{ activities_block.render(office.tags) }}
+            {% endif %}
 
-        {% include 'templates/office-contact.html' %}
-    </div>
+            {% include 'templates/office-contact.html' %}
+        </div>
+    </aside>
 {% endblock %}

--- a/src/sub-pages/_single.html
+++ b/src/sub-pages/_single.html
@@ -42,7 +42,7 @@
                         block__flush-top
                         block_padded-bottom
                         qa-related-links">
-            <h3>Related Documents</h3>
+            <h2 class="h3">Related Documents</h2>
             <ul class="list list__links">
             {% for link in sub_page.related_links %}
                 <li class="list_item">
@@ -92,17 +92,19 @@
         }}
     </section>
     {% endif %}
-    <div class="block
-                block__flush-sides
-                block__flush-bottom
-                block__border-top
-                block__border-right">
-        {% if sub_page.tags %}
-            {% import 'macros/activities-block.html' as activities_block with context %}
-            {{ activities_block.render(sub_page.tags) }}
-        {% endif %}
+    <aside>
+        <div class="block
+                    block__flush-sides
+                    block__flush-bottom
+                    block__border-top
+                    block__border-right">
+            {% if sub_page.tags %}
+                {% import 'macros/activities-block.html' as activities_block with context %}
+                {{ activities_block.render(sub_page.tags) }}
+            {% endif %}
 
-        {% set office = vars.office %}
-        {% include 'templates/office-contact.html' %}
-    </div>
+            {% set office = vars.office %}
+            {% include 'templates/office-contact.html' %}
+        </div>
+    </aside>
 {% endblock %}

--- a/src/the-bureau/about-deputy-director/index.html
+++ b/src/the-bureau/about-deputy-director/index.html
@@ -62,9 +62,9 @@
                              alt="Portrait of Deputy Director Meredith Fuchs">
                     </div>
                     <div class="media_body">
-                        <h1 class="h4 u-mb5">
+                        <h2 class="h4 u-mb5">
                             Downloads
-                        </h1>
+                        </h2>
                         <ul class="list list__links">
                             <li class="list_item">
                                 <a class="list_link jump-link jump-link__download"
@@ -83,9 +83,9 @@
                 </div>
             </div>
             <div class="content-l_col content-l_col-1-2">
-                <h1 class="h4 u-mb5">
+                <h2 class="h4 u-mb5">
                     Request the deputy director’s speaking info
-                </h1>
+                </h2>
                 <a class="styled-link"
                    href="mailto:externalaffairs@cfpb.gov">
                     <span class="cf-icon cf-icon-email"></span>
@@ -98,15 +98,15 @@
     <aside>
 
         <section class="block block__padded-top block__border-top">
-            <h1 class="h2">
+            <h2>
                 More information about Meredith Fuchs
-            </h1>
+            </h2>
             <div class="content-l content-l__main">
                 <div class="content-l_col content-l_col-1-3">
-                    <h2 class="h5">
+                    <h3 class="h5">
                         <span class="cf-icon cf-icon-newspaper"></span>
                         Newsroom
-                    </h2>
+                    </h3>
                     <p class="short-desc">
                         Get the latest CFPB news, including speeches, testimony and op-eds by the assistant director.
                     </p>
@@ -116,10 +116,10 @@
                     </a>
                 </div>
                 <div class="content-l_col content-l_col-1-3">
-                    <h2 class="h5">
+                    <h3 class="h5">
                         <span class="cf-icon cf-icon-newspaper"></span>
                         Blogs
-                    </h2>
+                    </h3>
                     <p class="short-desc">
                         Read blogs written by the deputy director on a variety of consumer financial topics.
                     </p>
@@ -129,10 +129,10 @@
                     </a>
                 </div>
                 <div class="content-l_col content-l_col-1-3">
-                    <h2 class="h5">
+                    <h3 class="h5">
                         <span class="cf-icon cf-icon-newspaper"></span>
                         Calendar
-                    </h2>
+                    </h3>
                     <p class="short-desc">
                         See how the deputy director spends his time working for consumers.
                     </p>

--- a/src/the-bureau/about-director/index.html
+++ b/src/the-bureau/about-director/index.html
@@ -90,9 +90,9 @@
                              alt="Portrait of Director Richard Cordray">
                     </div>
                     <div class="media_body">
-                        <h4 class="u-mb5">
+                        <h2 class="h4 u-mb5">
                             Downloads
-                        </h4>
+                        </h2>
                         <ul class="list list__links">
                             <li class="list_item">
                                 <a class="list_link jump-link jump-link__download"
@@ -118,9 +118,9 @@
             </div>
             <div class="content-l_col
                         content-l_col-1-2">
-                <h4 class="u-mb5">
+                <h2 class="h4 u-mb5">
                     Request the director’s speaking info
-                </h4>
+                </h2>
                 <a class="styled-link"
                    href="mailto:externalaffairs@cfpb.gov">
                     <span class="cf-icon cf-icon-email"></span>
@@ -135,15 +135,15 @@
         <section class="block
                         block__padded-top
                         block__border-top">
-            <h1 class="h2">
+            <h2>
                 More information about Richard Cordray
-            </h1>
+            </h2>
             <div class="content-l content-l__main">
                 <div class="content-l_col content-l_col-1-3">
-                    <h2 class="h5">
+                    <h3 class="h5">
                         <span class="cf-icon cf-icon-newspaper"></span>
                         Newsroom
-                    </h2>
+                    </h3>
                     <p class="short-desc">
                         Get the latest CFPB news, including speeches, testimony, and op-eds by the director.
                     </p>
@@ -153,10 +153,10 @@
                     </a>
                 </div>
                 <div class="content-l_col content-l_col-1-3">
-                    <h2 class="h5">
+                    <h3 class="h5">
                         <span class="cf-icon cf-icon-speech-bubble"></span>
                         Blogs
-                    </h2>
+                    </h3>
                     <p class="short-desc">
                         Read blogs written by the director on a variety of consumer financial topics.
                     </p>
@@ -166,10 +166,10 @@
                     </a>
                 </div>
                 <div class="content-l_col content-l_col-1-3">
-                    <h2 class="h5">
+                    <h3 class="h5">
                         <span class="cf-icon cf-icon-date"></span>
                         Calendar
-                    </h2>
+                    </h3>
                     <p class="short-desc">
                         See how the director spends his time working for consumers.
                     </p>
@@ -209,9 +209,9 @@
                 <section class="content-l_col
                                 content-l_col-1-2
                                 content-l_col__before-divider">
-                    <h1 class="h2">
+                    <h2>
                         CFPB history
-                    </h1>
+                    </h2>
                     <figure class="figure__bordered">
                         <img src="/static/img/obama_cordray.jpg" alt="Director Richard Cordray shaking hands with President Barack Obama">
                     </figure>

--- a/src/the-bureau/bureau-structure/index.html
+++ b/src/the-bureau/bureau-structure/index.html
@@ -26,12 +26,12 @@
 {% block content_main %}
 
     {% import '_macro-role.html' as role with context %}
-
+    <h1 class="u-visually-hidden">Bureau Structure</h1>
     <div class="org-chart">
 
         <div class="media org-chart_root">
             <img class="media_image media_image__150" src="/static/img/director-cordray-round-300x300.jpg">
-            <h1 class="h2 u-mb0">Richard Cordray</h1>
+            <p class="h2 u-mb0">Richard Cordray</p>
             <h2 class="h4">Director</h2>
         </div>
 
@@ -157,5 +157,5 @@
                 </span>
             </div>
         </div>
-
+    </aside>
 {% endblock %}

--- a/src/the-bureau/history/index.html
+++ b/src/the-bureau/history/index.html
@@ -40,7 +40,7 @@
     <section class="block block__padded-top block__border-top">
         <div class="content-l content-l__main">
             <div class="content-l_col content-l_col-2-3">
-                <h1 class="h2">{{ section.title|safe }}</h1>
+                <h2>{{ section.title|safe }}</h2>
                 <p class="short-desc">
                     {{ section.section_date_from }} &ndash; {{ section.section_date_to }}
                 </p>
@@ -67,14 +67,14 @@
     {% for history in first %}
         {% if history_vars.update({'current_year': history.date|date('%Y')|int}) %} {% endif %}
     {% endfor %}
-                    <h2 class="history-year">{{ history_vars.current_year }}</h2>
+                    <h3 class="history-year">{{ history_vars.current_year }}</h3>
                     <ol class="history-list">
     {% set histories = query.search(filter_parent=section.id) %}
     {% for history in histories %}
         {% if history.date|date('%Y')|int < history_vars.current_year %}
             {% if history_vars.update({'current_year': history.date|date('%Y')|int}) %} {% endif %}
                     </ol>
-                    <h2 class="history-year">{{ history_vars.current_year }}</h2>
+                    <h3 class="history-year">{{ history_vars.current_year }}</h3>
                     <ol class="history-list">
         {% endif %}
                         <li class="history-item expandable expandable__padded">
@@ -89,13 +89,13 @@
                                         <span class="cf-icon cf-icon-minus-round"></span>
                                     </span>
                                 </span>
-                                <h3 class="expandable_header-left history-item_title">
+                                <h4 class="expandable_header-left history-item_title">
                                     <span class="history-item_date">
                                         {{ history.item_date if history.item_date
                                            else history.date|date('%b %d, %Y') }}
                                     </span>
                                     {{ history.title|safe }}
-                                </h3>
+                                </h4>
                             </button>
                             <div class="expandable_content">
                             {% if history.thumbnail.images %}

--- a/src/the-bureau/index.html
+++ b/src/the-bureau/index.html
@@ -47,6 +47,7 @@
                 <article class="hero_preview">
                     <div class="summary">
                         <header class="summary_header">
+                            {# TODO: Change to h2 when hero moves under title #}
                             <h1 class="summary_heading">We are the CFPB</h1>
                         </header>
                         <p class="summary_text">
@@ -124,7 +125,7 @@
                     block__flush-top
                     block__flush-bottom
                     ">
-        <h1 class="h2">Our core functions</h1>
+        <h2>Our core functions</h2>
         <p>Congress created the CFPB to create a single point of accountability for enforcing
         federal consumer financial laws and protecting consumers in the financial marketplace.
         Before, that responsibility was divided among several agencies. Today, it’s our job.</p>
@@ -151,7 +152,7 @@
             </button>
             <div class="expandable_content">
                 <section class="block__padded-top block__flush-top block__flush-bottom">
-                    <h1 class="h4">Among other things, we:</h1>
+                    <h3 class="h4">Among other things, we:</h3>
                     <ul class="list list__branded bureau-functions_list u-mb0">
                         <li>Write rules, supervise companies, and enforce federal consumer
                         financial protection laws</li>
@@ -171,7 +172,7 @@
     </section><!-- END .content-block -->
 
     <section class="block block__padded-top block__flush-top">
-        <h1 class="h2">CFPB leadership</h1>
+        <h2>CFPB leadership</h2>
         <p class="short-desc">In January of 2012, President Barack Obama appointed
         Richard Cordray to be the first Director of the CFPB.</p>
 
@@ -184,8 +185,8 @@
                              alt="Director Richard Cordray">
                     </div>
                     <div class="media_body">
-                        <h1 class="h6">Director</h1>
-                        <h2 class="bureau-bio_name">Richard Cordray</h2>
+                        <span class="h6">Director</span>
+                        <h3 class="bureau-bio_name">Richard Cordray</h3>
                         <a class="jump-link jump-link__underline"
                            href="about-director/">
                             Read bio
@@ -201,8 +202,8 @@
                              alt="Deputy Director Meredith Fuchs">
                     </div>
                     <div class="media_body">
-                        <h1 class="h6">Deputy Director</h1>
-                        <h2 class="bureau-bio_name">Meredith Fuchs</h2>
+                        <span class="h6">Deputy Director</span>
+                        <h3 class="bureau-bio_name">Meredith Fuchs</h3>
                         <a class="jump-link jump-link__underline"
                            href="about-deputy-director/">
                             Read bio
@@ -237,7 +238,7 @@
     </section><!-- END .block leadership -->
 
     <section class="block block__padded-top block__border-top bureau-history">
-        <h1 class="h2 bureau-history_header">CFPB history</h1>
+        <h2 class="bureau-history_header">CFPB history</h2>
         <div class="media">
             <div class="media_image-container media_image-container__wide-margin">
                 <img class="media_image bureau-history_image" src="/static/img/obama_cordray.jpg" alt="Director Richard Cordray shaking hands with President Barack Obama">

--- a/src/the-bureau/leadership-calendar/index.html
+++ b/src/the-bureau/leadership-calendar/index.html
@@ -69,9 +69,9 @@
     {{ pagination(posts, ['calendar', 'range_date_gte', 'range_date_lte']) }}
 
     <section class="block block__padded-top block__border-top">
-        <h1 class="h2">
+        <h2>
             Download a copy
-        </h1>
+        </h2>
         <p>
             Choose the names and dates for which you want to see the calendar. Appointments are
             only available for months when someone was serving in Bureau leadership. We’ll
@@ -96,12 +96,11 @@
                   block__bg
                   block__border-top
                   block__border-right">
-        {# TODO: Add FOIA and Open government URLs. #}
         {%- import 'related-links.html' as related_links -%}
         {{- related_links.render([
-            [ '',
+            [ '/offices/foia-requests/',
               'Read more about FOIA' ],
-            [ '',
+            [ '/offices/open-government/',
               'Open government' ],
             [ vars.path + 'history/',
               'About our history' ]

--- a/test/browser_tests/page_objects/page_about-us.js
+++ b/test/browser_tests/page_objects/page_about-us.js
@@ -7,7 +7,7 @@ function AboutUs() {
 
   this.pageTitle = function() { return browser.getTitle(); };
   this.activityBlock = element.all( by.css( '.activity' ) );
-  this.feedIcons = element.all( by.css( '.activity h1 .cf-icon' ) );
+  this.feedIcons = element.all( by.css( '.activity .cf-icon' ) );
   this.firstIcon = this.feedIcons.first();
   this.secondIcon = this.feedIcons.last();
 }


### PR DESCRIPTION
Big PR. I made a bunch of changes to the outline to bring it more in line with the traditional heading outline while also making changes that would allow for a reasonable HTML5 outline if that ever becomes a thing.

## Changes
- Substantial changes to the heading structure of most pages to bring them inline with traditional outline and away from the HTML5 outlining algorithm.
- Removed redundant sectioning elements that would be title-less or redundant 
- Moved away from h1s everywhere to one h1 per page (the page title)

## Testing
- To test for the traditional outline, I used the tota11y bookmarklet: http://khan.github.io/tota11y/
- To test for the HTML5 outline, I used h5o chrome extension: https://github.com/h5o/h5o-chrome
- When in doubt, I went for consistency with other pages and avoiding errors in the traditional outline

## Notes
- Fixes #665
- Fixes #276: While I was touching up outlines, I removed some sectioning content from macros because it made sense to have one aside with all the sections version one section with multiple asides.