### PR TITLE
Moves getBinary method to filesystem helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Added webpack module loader for per-page JavaScript.
 - Added external-site page-specific script.
 - Added `config/environment.js` for project JS path configuration.
+- Added filesystem helper to gulp utilities for retrieving a binary executable.
 
 ### Changed
 - Updated Video Code to make it usable on Events pages.

--- a/gulp/tasks/test.js
+++ b/gulp/tasks/test.js
@@ -8,6 +8,7 @@ var spawn = childProcess.spawn;
 var config = require( '../config' ).test;
 var minimist = require( 'minimist' );
 var path = require( 'path' );
+var fsHelper = require( '../utils/fsHelper' );
 
 gulp.task( 'test:unit:scripts', function( cb ) {
   gulp.src( config.src )
@@ -43,20 +44,6 @@ gulp.task( 'test:unit:macro', function( cb ) {
     }
   );
 } );
-
-/**
- * Retrieve a reference path to a binary.
- * @param {string} binaryName The name of the binary to retrieve.
- * @returns {string} Path to the binary to run.
- */
-function _getBinary( binaryName ) {
-  var winExt = ( /^win/ ).test( process.platform ) ? '.cmd' : '';
-  var pkgPath = require.resolve( 'protractor' );
-  var protractorDir = path.resolve(
-    path.join( path.dirname( pkgPath ), '..', 'bin' )
-  );
-  return path.join( protractorDir, '/' + binaryName + winExt );
-}
 
 /**
  * Add a command-line flag to a list of Protractor parameters, if present.
@@ -110,7 +97,7 @@ function _getProtractorParams() {
 
 gulp.task( 'test:acceptance:browser', function() {
   spawn(
-    _getBinary( 'protractor' ),
+    fsHelper.getBinary( 'protractor' ),
     _getProtractorParams(),
     { stdio: 'inherit' } )
       .once( 'close', function() {

--- a/gulp/utils/fsHelper.js
+++ b/gulp/utils/fsHelper.js
@@ -18,4 +18,4 @@ function getBinary( binaryName ) {
 
 module.exports = {
   getBinary: getBinary
-}
+};

--- a/gulp/utils/fsHelper.js
+++ b/gulp/utils/fsHelper.js
@@ -1,0 +1,21 @@
+'use strict';
+
+var path = require( 'path' );
+
+/**
+ * Retrieve a reference path to a binary.
+ * @param {string} binaryName The name of the binary to retrieve.
+ * @returns {string} Path to the binary to run.
+ */
+function getBinary( binaryName ) {
+  var winExt = ( /^win/ ).test( process.platform ) ? '.cmd' : '';
+  var pkgPath = require.resolve( binaryName );
+  var binaryDir = path.resolve(
+    path.join( path.dirname( pkgPath ), '..', 'bin' )
+  );
+  return path.join( binaryDir, '/' + binaryName + winExt );
+}
+
+module.exports = {
+  getBinary: getBinary
+}


### PR DESCRIPTION
Moves getBinary method to gulp file system helper.

## Additions

- Moves getBinary method to gulp file system helper.

## Testing

- `gulp test` should work as expected.

## Review

- @KimberlyMunoz 
- @jimmynotjim 
- @sebworks 