### PR TITLE
Removes unneeded default override

### DIFF
--- a/src/static/js/routes/careers/working-at-cfpb/index.js
+++ b/src/static/js/routes/careers/working-at-cfpb/index.js
@@ -4,8 +4,6 @@
 
 'use strict';
 
-var breakpointsConfig = require( '../../../config/breakpoints-config' );
 var MobileCarousel = require( '../../../modules/classes/MobileCarousel' );
-
-var mobileCarousel = new MobileCarousel( breakpointsConfig.mobile.max );
+var mobileCarousel = new MobileCarousel();
 mobileCarousel.enableOn( '.js-mobile-carousel' );


### PR DESCRIPTION
Remove default override for MobileCarousel noted by @sebworks in https://github.com/cfpb/cfgov-refresh/pull/968

## Removals

- Unneeded default being passed to MobileCarousel constructor since it is being set in https://github.com/cfpb/cfgov-refresh/blob/flapjack/src/static/js/modules/classes/MobileCarousel.js#L20

## Testing

- `/careers/working-at-cfpb/` JS should work at mobile.

## Review

- @sebworks 
- @KimberlyMunoz 
- @jimmynotjim 