### PR TITLE
Fix for error page paths

### DIFF
--- a/src/_layouts/404.html
+++ b/src/_layouts/404.html
@@ -42,5 +42,8 @@
 {% endblock %}
 
 {% block javascript %}
-<script src="{{ url_for('static', filename='js/routes/common.js') }}"></script>
+{# Include site-wide JavaScript. #}
+<script type='text/javascript'>
+    {% include '/static/js/routes/common.js' %}
+</script>
 {% endblock javascript %}

--- a/src/_layouts/500.html
+++ b/src/_layouts/500.html
@@ -43,6 +43,9 @@
 {% endblock %}
 
 {% block javascript %}
-<script src="{{ url_for('static', filename='js/routes/common.js') }}"></script>
+{# Include site-wide JavaScript. #}
+<script type='text/javascript'>
+    {% include '/static/js/routes/common.js' %}
+</script>
 {% endblock javascript %}
 


### PR DESCRIPTION
Runs JS paths through Jinja to ignore raw tags.

## Changes

- Runs JS paths through Jinja to ignore raw tags.

## Testing

- Error page should not throw a Jinja error.

## Review

- @sebworks 
- @jimmynotjim 
- @KimberlyMunoz 