### PR TITLE
Adding Acceptance tests for the blog pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Django template tags
 - A temporary blog page template for testing
 - Added `block__flush` to cf-enhancements to remove margin from all sides.
+- Added Acceptance tests for `blog` pages.
 
 ### Changed
 - Updated Video Code to make it usable on Events pages.

--- a/cfgov/v1/jinja2/v1/_includes/macros/filters.html
+++ b/cfgov/v1/jinja2/v1/_includes/macros/filters.html
@@ -180,7 +180,7 @@
     {# Category filters #}
     {% if filter in ['blog_category', 'category'] %}
         <div class="form-l_col form-l_col-1-3">
-            <div class="form-group">
+            <div class="form-group" data-qa-hook="filter-categories">
                 <label class="form-label-header">
                     Categories
                 </label>

--- a/cfgov/v1/jinja2/v1/blog/_single.html
+++ b/cfgov/v1/jinja2/v1/blog/_single.html
@@ -33,7 +33,7 @@
         {% import 'related-posts.html' as related_posts with context %}
         {{ related_posts.render(post) }}
     </section>
-    <section class="block">
+    <section class="block" data-qa-hook="stay-informed-section">
         <h2 class="header-slug">
             <span class="header-slug_inner">
                 Stay informed
@@ -46,7 +46,7 @@
             {% import 'macros/subscribe.html' as subscribe with context %}
             {{ subscribe.render('USCFPB_91') }}
         </div>
-        <div class="block block__sub">
+        <div class="block block__sub" data-qa-hook="rss-subscribe-section">
             {% import 'rss.html' as rss %}
             {{ rss.render(vars.rss_path) }}
         </div>

--- a/cfgov/v1/jinja2/v1/blog/index.html
+++ b/cfgov/v1/jinja2/v1/blog/index.html
@@ -32,7 +32,7 @@
 
 {% block content_main %}
 
-    <h1>Blog</h1>
+    <h1 data-qa-hook="main-title">Blog</h1>
 
     {% set filter_by = ['blog_category', 'tags', 'author', 'range_date'] %}
     {% import 'macros/filters.html' as filters with context %}
@@ -49,7 +49,7 @@
             {{ popular_stories.render(view.popular_posts) }}
         {% endif %}
     </section>
-    <section class="block">
+    <section class="block" data-qa-hook="stay-informed-section">
         <h2 class="header-slug">
             <span class="header-slug_inner">
                 Stay informed
@@ -62,7 +62,7 @@
             {% import 'macros/subscribe.html' as subscribe with context %}
             {{ subscribe.render('USCFPB_91') }}
         </div>
-        <div class="block block__sub">
+        <div class="block block__sub" data-qa-hook="rss-subscribe-section">
             {% import 'rss.html' as rss %}
             {{ rss.render(vars.rss_path) }}
         </div>

--- a/test/browser_tests/.eslintrc
+++ b/test/browser_tests/.eslintrc
@@ -11,3 +11,4 @@ rules:
   no-unused-expressions: 0
   max-nested-callbacks: 0
   require-jsdoc: 0
+  max-statements: 0

--- a/test/browser_tests/page_objects/page_blog-single.js
+++ b/test/browser_tests/page_objects/page_blog-single.js
@@ -1,0 +1,38 @@
+'use strict';
+
+var _assign = require( 'lodash' ).assign;
+var stayInformedSection = require( '../shared_objects/stay-informed-section' );
+var rssSection = require( '../shared_objects/rss-section' );
+
+function BlogSingle() {
+
+  _assign( this, stayInformedSection, rssSection );
+
+  this.get = function() {
+    browser.get( '/blog/lessons-weve-learned/' );
+  };
+
+  this.pageTitle = function() { return browser.getTitle(); };
+
+  this.postTitle = element( by.css( 'header .post_heading' ) );
+
+  this.postByLine = element( by.css( 'header .post_byline' ) );
+
+  this.postBody = element( by.css( '.post .post_body' ) );
+
+  this.share = element( by.css( 'header .share' ) );
+
+  this.breadcrumbs = element( by.css( '.breadcrumbs' ) );
+
+  this.tags = element( by.css( '.tags' ) );
+
+  this.contentSidebar = element( by.css( '.content_sidebar' ) );
+
+  this.relatedPosts =
+  this.contentSidebar.element( by.css( '.related-posts' ) );
+
+  this.relatedPostsTitle =
+  this.relatedPosts.element( by.css( '.header-slug_inner' ) );
+}
+
+module.exports = BlogSingle;

--- a/test/browser_tests/page_objects/page_blog.js
+++ b/test/browser_tests/page_objects/page_blog.js
@@ -1,0 +1,31 @@
+'use strict';
+
+var _assign = require( 'lodash' ).assign;
+var filter = require( '../shared_objects/filter.js' );
+var pagination = require( '../shared_objects/pagination' );
+var stayInformedSection = require( '../shared_objects/stay-informed-section' );
+var rssSection = require( '../shared_objects/rss-section' );
+var _getQAelement = require( '../util/QAelement' ).get;
+
+function Blog() {
+
+  _assign( this, filter, pagination, stayInformedSection, rssSection );
+
+  this.get = function() {
+    browser.get( '/blog/' );
+  };
+
+  this.pageTitle = function() { return browser.getTitle(); };
+
+  this.mainTitle = _getQAelement( 'main-title' );
+
+  this.contentSidebar = element( by.css( '.content_sidebar' ) );
+
+  this.popularStories =
+  this.contentSidebar.element( by.css( '.popular-stories' ) );
+
+  this.popularStoriesTitle =
+  this.popularStories.element( by.css( '.header-slug_inner' ) );
+}
+
+module.exports = Blog;

--- a/test/browser_tests/shared_objects/careers-social-section.js
+++ b/test/browser_tests/shared_objects/careers-social-section.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var _getQAelement = require( '../util/QAelement' ).get;
+
 var _socialSection = _getQAelement( 'social-section' );
 
 var careersSocialSection = {

--- a/test/browser_tests/shared_objects/filter.js
+++ b/test/browser_tests/shared_objects/filter.js
@@ -1,0 +1,27 @@
+'use strict';
+
+var _searchFilter = element( by.css( '.js-post-filter' ) );
+
+function _getFilterElement( selector ) {
+  return _searchFilter.element( by.css( selector ) );
+}
+
+var filter = {
+  searchFilter: _searchFilter,
+
+  searchFilterCategories:
+  _getFilterElement( '[data-qa-hook="filter-categories"]' ),
+
+  searchFilterBtn: _getFilterElement( '.expandable_target' ),
+
+  searchFilterShowBtn: _getFilterElement( '.expandable_cue-open' ),
+
+  searchFilterHideBtn: _getFilterElement( '.expandable_cue-close' ),
+
+  searchFilterResetBtn: _getFilterElement( '.js-form_clear' ),
+
+  searchFilterSubmitBtn: _getFilterElement( 'btn[type="submit"]' )
+
+};
+
+module.exports = filter;

--- a/test/browser_tests/shared_objects/pagination.js
+++ b/test/browser_tests/shared_objects/pagination.js
@@ -1,0 +1,20 @@
+'use strict';
+
+var pagination = {
+
+  paginationContent: element.all( by.css( '#pagination_content' ) ),
+
+  paginationResults:
+  element.all( by.css( '#pagination_content .post-preview' ) ),
+
+  paginationForm: element( by.css( '.pagination_form' ) ),
+
+  paginationPrevBtn: element( by.css( '.pagination_prev' ) ),
+
+  paginationNextBtn: element( by.css( '.pagination_next' ) ),
+
+  paginationPageInput: element( by.css( '.pagination_current-page' ) )
+
+};
+
+module.exports = pagination;

--- a/test/browser_tests/shared_objects/rss-section.js
+++ b/test/browser_tests/shared_objects/rss-section.js
@@ -1,0 +1,18 @@
+'use strict';
+
+var _getQAelement = require( '../util/QAelement' ).get;
+
+var _rssSubscribeSection = _getQAelement( 'rss-subscribe-section' );
+
+var rssSubscribeSection = {
+  rssSubscribeSection: _rssSubscribeSection,
+
+  rssSubscribeDescription:
+  _rssSubscribeSection.element( by.css( '.short-desc' ) ),
+
+  rssSubscribeBtn:
+  _rssSubscribeSection.element( by.css( '.btn' ) )
+
+};
+
+module.exports = rssSubscribeSection;

--- a/test/browser_tests/shared_objects/stay-informed-section.js
+++ b/test/browser_tests/shared_objects/stay-informed-section.js
@@ -1,0 +1,33 @@
+'use strict';
+
+var _getQAelement = require( '../util/QAelement' ).get;
+
+var _stayInformedSection = _getQAelement( 'stay-informed-section' );
+
+var _emailSubscribeForm =
+_stayInformedSection.element( by.css( '#email-subscribe-form' ) );
+
+var stayInformedSection = {
+
+  stayInformedSection: _stayInformedSection,
+
+  stayInformedSectionTitle:
+  _stayInformedSection.element( by.css( '.header-slug_inner' ) ),
+
+  emailSubscribeForm: _emailSubscribeForm,
+
+  emailFormInput:
+  _emailSubscribeForm.element( by.css( 'input[type="email"]' ) ),
+
+  emailFormLabel: _emailSubscribeForm.element( by.css( 'label' ) ),
+
+  emailFormDescription: _emailSubscribeForm.element( by.css( '.short-desc' ) ),
+
+  emailFormHiddenField:
+  _emailSubscribeForm.element( by.css( 'input[type="hidden"]' ) ),
+
+  emailFormBtn: _emailSubscribeForm.element( by.css( 'input[type="submit"]' ) )
+
+};
+
+module.exports = stayInformedSection;

--- a/test/browser_tests/spec_suites/blog-single.js
+++ b/test/browser_tests/spec_suites/blog-single.js
@@ -1,0 +1,95 @@
+'use strict';
+
+var BlogSingle = require(
+    '../page_objects/page_blog-single.js'
+  );
+
+describe( 'The Blog single Page', function() {
+  var page;
+
+  beforeAll( function() {
+    page = new BlogSingle();
+    page.get();
+  } );
+
+  it( 'should properly load in a browser', function() {
+    expect( page.pageTitle() ).toBe( 'Lessons we’ve learned' );
+  } );
+
+  it( 'should include a post title', function() {
+    expect( page.postTitle.getText() ).toBe( 'Lessons we’ve learned' );
+  } );
+
+  it( 'should include a post byline', function() {
+    expect( page.postByLine.isPresent() ).toBe( true );
+  } );
+
+  it( 'should include a post body', function() {
+    expect( page.postByLine.isPresent() ).toBe( true );
+  } );
+
+  it( 'should include breadcrumbs', function() {
+    expect( page.breadcrumbs.getText() ).toBe( 'Blog' );
+  } );
+
+  it( 'should include tags', function() {
+    expect( page.tags.isPresent() ).toBe( true );
+  } );
+
+  it( 'should include a content sidebar', function() {
+    expect( page.contentSidebar.isPresent() ).toBe( true );
+  } );
+
+  it( 'might include Related Posts in the sidebar', function() {
+    if ( page.relatedPosts ) {
+      expect( page.relatedPostsTitle.getText() ).toBe( 'RELATED POSTS' );
+    }
+  } );
+
+  it( 'should include a Stay Informed section in the sidebar', function() {
+    expect( page.stayInformedSection.isPresent() ).toBe( true );
+  } );
+
+  it( 'should include a Stay Informed section title', function() {
+    expect( page.stayInformedSectionTitle.getText() ).toBe( 'STAY INFORMED' );
+  } );
+
+  it( 'should include an Email Subscribe form', function() {
+    expect( page.emailSubscribeForm.isPresent() ).toBe( true );
+  } );
+
+  it( 'should include an Email Subscribe label', function() {
+    expect( page.emailFormLabel.getText() ).toBe( 'Email address' );
+  } );
+
+  it( 'should include an Email Subscribe input', function() {
+    expect( page.emailFormInput.isPresent() ).toBe( true );
+    expect( page.emailFormInput.getAttribute( 'placeholder' ) )
+    .toBe( 'example@mail.com' );
+  } );
+
+  it( 'should include an Email Subscribe hidden field', function() {
+    expect( page.emailFormHiddenField.getAttribute( 'value' ) )
+    .toBe( 'USCFPB_91' );
+    expect( page.emailFormHiddenField.getAttribute( 'name' ) )
+    .toBe( 'code' );
+  } );
+
+  it( 'should include an Email Subscribe button', function() {
+    expect( page.emailFormBtn.getAttribute( 'value' ) )
+    .toBe( 'Sign up' );
+  } );
+
+  it( 'should include an Email Subscribe description', function() {
+    expect( page.emailFormDescription.isPresent() ).toBe( true );
+  } );
+
+  it( 'should include an RSS Subscribe section', function() {
+    expect( page.rssSubscribeSection.isPresent() ).toBe( true );
+  } );
+
+  it( 'should include an RSS Subscribe button', function() {
+    expect( page.rssSubscribeBtn.getText() ).toContain( 'Subscribe to RSS' );
+  } );
+
+} );

--- a/test/browser_tests/spec_suites/blog.js
+++ b/test/browser_tests/spec_suites/blog.js
@@ -1,0 +1,138 @@
+'use strict';
+
+var Blog = require(
+    '../page_objects/page_blog.js'
+  );
+
+describe( 'The Blog Page', function() {
+  var page;
+
+  beforeAll( function() {
+    page = new Blog();
+    page.get();
+  } );
+
+  it( 'should properly load in a browser', function() {
+    expect( page.pageTitle() ).toBe( 'Blog' );
+  } );
+
+  it( 'should include a main title', function() {
+    expect( page.mainTitle.getText() ).toBe( 'Blog' );
+  } );
+
+  it( 'should include a content sidebar', function() {
+    expect( page.contentSidebar.isPresent() ).toBe( true );
+  } );
+
+  it( 'might include Popular Stories in the sidebar', function() {
+    if ( page.popularStories ) {
+      expect( page.popularStoriesTitle.getText() ).toBe( 'POPULAR STORIES' );
+    }
+  } );
+
+  it( 'should include a Stay Informed section in the sidebar', function() {
+    expect( page.stayInformedSection.isPresent() ).toBe( true );
+  } );
+
+  it( 'should include a Stay Informed section title', function() {
+    expect( page.stayInformedSectionTitle.getText() ).toBe( 'STAY INFORMED' );
+  } );
+
+  it( 'should include an Email Subscribe form', function() {
+    expect( page.emailSubscribeForm.isPresent() ).toBe( true );
+  } );
+
+  it( 'should include an Email Subscribe label', function() {
+    expect( page.emailFormLabel.getText() ).toBe( 'Email address' );
+  } );
+
+  it( 'should include an Email Subscribe input', function() {
+    expect( page.emailFormInput.isPresent() ).toBe( true );
+    expect( page.emailFormInput.getAttribute( 'placeholder' ) )
+    .toBe( 'example@mail.com' );
+  } );
+
+  it( 'should include an Email Subscribe hidden field', function() {
+    expect( page.emailFormHiddenField.getAttribute( 'value' ) )
+    .toBe( 'USCFPB_91' );
+    expect( page.emailFormHiddenField.getAttribute( 'name' ) )
+    .toBe( 'code' );
+  } );
+
+  it( 'should include an Email Subscribe button', function() {
+    expect( page.emailFormBtn.getAttribute( 'value' ) )
+    .toBe( 'Sign up' );
+  } );
+
+  it( 'should include an Email Subscribe description', function() {
+    expect( page.emailFormDescription.isPresent() ).toBe( true );
+  } );
+
+  it( 'should include an RSS Subscribe section', function() {
+    expect( page.rssSubscribeSection.isPresent() ).toBe( true );
+  } );
+
+  it( 'should include an RSS Subscribe button', function() {
+    expect( page.rssSubscribeBtn.getText() ).toContain( 'Subscribe to RSS' );
+  } );
+
+  it( 'should include a search filter', function() {
+      expect( page.searchFilter.isPresent() ).toBe( true );
+    }
+  );
+
+  it( 'should include a search filter button', function() {
+      expect( page.searchFilterBtn.getText() ).toContain( 'posts' );
+    }
+  );
+
+  it( 'should include a search filter categories', function() {
+    var searchFilterBtn = page.searchFilterBtn;
+    var searchFilterCategories = page.searchFilterCategories;
+    searchFilterBtn.click();
+    browser.sleep( 1000 );
+    searchFilterCategories.getText().then( function() {
+      searchFilterBtn.click();
+      browser.sleep( 1000 );
+    } );
+  } );
+
+  it( 'should include a visible Show button', function() {
+      expect( page.searchFilterShowBtn.isDisplayed() ).toBe( true );
+      expect( page.searchFilterShowBtn.getText() ).toBe( 'Show' );
+    }
+  );
+
+  it( 'should include a hidden Hide button', function() {
+      expect( page.searchFilterHideBtn.isDisplayed() ).toBe( false );
+    }
+  );
+
+  it( 'should include pagination results', function() {
+      expect( page.paginationResults.count() ).toBeGreaterThan( 0 );
+    }
+  );
+
+  it( 'should include pagination form', function() {
+      expect( page.paginationForm.isPresent() ).toBe( true );
+    }
+  );
+
+  it( 'should include a previous button within the pagination element',
+    function() {
+      expect( page.paginationPrevBtn.getText() ).toBe( 'Newer' );
+    }
+  );
+
+  it( 'should include a next button within the pagination element',
+    function() {
+      expect( page.paginationNextBtn.getText() ).toBe( 'Older' );
+    }
+  );
+
+  it( 'should include a page input with value set to 1', function() {
+      expect( page.paginationPageInput.getAttribute( 'value' ) === 1 );
+    }
+  );
+
+} );


### PR DESCRIPTION
Acceptance tests for the `blog` pages

## Changes
 - Added acceptance tests for the `blog` pages. 

## Testing
-  Run `gulp test:acceptance`

## Notes
- This PR does introduce the concept of mixins. This would allow us to have reusable page components.


## Review
@anselmbradford 
@jimmynotjim 
@KimberlyMunoz 