### PR TITLE
Adds accessibility testing

### DIFF
--- a/.env_SAMPLE
+++ b/.env_SAMPLE
@@ -57,6 +57,9 @@ export WORDPRESS=http://www.consumerfinance.gov
 #export SELENIUM_URL=http://localhost:4444/wd/hub
 #export TOXENV=py27
 
+# Web service ID for accessibility testing via http://achecker.ca site.
+#export ACHECKER_ID=<web_service_id>
+
 #################################################################
 # SAUCE LABS (optional) - for handling cloud testing of the site.
 #################################################################

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Added `Object.defineProperty` polyfill.
 - Added unit test for `aria-state.js`.
 - Wagtail CMS
+- Added `gulp test:a11y` accessibility testing using node-wcag.
 
 ### Changed
 - Updated Video Code to make it usable on Events pages.
@@ -49,7 +50,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Server port is now at 8000
 - Updated Dep Dir title to include "Acting"
 - included with context flag for macros that make a call to request object
-
+- Added `binaryDirectory` parameter to `fsHelper.getBinary` helper function.
 
 ### Removed
 - Disables tests for landing page events, since we don't currently have events.
@@ -64,6 +65,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Fixed instructions for gulp watch
 - New way to run the server documented in the INSTALL.MD
 - New way to define url routing, no longer automatically set by file path
+
 
 ## 3.0.0-2.3.0 - 2015-08-27
 

--- a/TEST.md
+++ b/TEST.md
@@ -147,3 +147,15 @@ From within the root project directory run `gulp test:unit:macro`.
 
 Please see [Macro Polo](https://github.com/cfpb/macropolo) for
 documentation about writing tests.
+
+
+# Accessibility Testing
+
+To audit a page's WCAG and Section 508 accessibility:
+  1. Enable the environment variable `ACHECKER_ID` in your `.env` file.
+     Get a free [AChecker API ID](http://achecker.ca/register.php) for the value.
+  2. Reload your `.env` with `. ./.env` while in the project root directory.
+  3. Run `gulp test:a11y` to run an audit on the homepage.
+  4. To test a page aside from the homepage, add the `--u=<path_to_test>` flag.
+     For example, `gulp test:a11y --u=contact-us`
+     or `gulp test:a11y --u=the-bureau/bureau-structure/`.

--- a/gulp/tasks/test.js
+++ b/gulp/tasks/test.js
@@ -6,9 +6,8 @@ var childProcess = require( 'child_process' );
 var exec = childProcess.exec;
 var spawn = childProcess.spawn;
 var config = require( '../config' ).test;
-var minimist = require( 'minimist' );
-var path = require( 'path' );
 var fsHelper = require( '../utils/fsHelper' );
+var minimist = require( 'minimist' );
 
 gulp.task( 'test:unit:scripts', function( cb ) {
   gulp.src( config.src )
@@ -72,8 +71,7 @@ function _getProtractorParams() {
   var params = [ 'test/browser_tests/conf.js' ];
   var commandLineParams = minimist( process.argv.slice( 2 ) );
 
-  // If --specs=path/to/js flag is added on the command-line,
-  // pass the value to protractor to override the default specs to run.
+  // If --sauce=false flag is added on the command-line.
   params = _addCommandLineFlag( params, commandLineParams, 'sauce' );
 
   // If --specs=path/to/js flag is added on the command-line,
@@ -99,10 +97,55 @@ gulp.task( 'test:acceptance:browser', function() {
   spawn(
     fsHelper.getBinary( 'protractor' ),
     _getProtractorParams(),
-    { stdio: 'inherit' } )
-      .once( 'close', function() {
-        $.util.log( 'Protractor tests done!' );
-      } );
+    { stdio: 'inherit' }
+  )
+    .once( 'close', function() {
+      $.util.log( 'Protractor tests done!' );
+    } );
+} );
+
+/**
+ * Processes command-line and environment variables
+ * for passing to the wcag executable.
+ * The URL host, port, and AChecker web API ID come from
+ * environment variables, while the URL path comes
+ * from the command-line `--u=` flag.
+ * @returns {Array} Array of command-line arguments for wcag binary.
+ */
+function _getWCAGParams() {
+  var commandLineParams = minimist( process.argv.slice( 2 ) );
+  var host = process.env.HTTP_HOST || 'localhost'; // eslint-disable-line no-process-env, no-inline-comments, max-len
+  var port = process.env.HTTP_PORT || '8000'; // eslint-disable-line no-process-env, no-inline-comments, max-len
+  var checkerId = process.env.ACHECKER_ID || ''; // eslint-disable-line no-process-env, no-inline-comments, max-len
+  var urlPath = _parsePath( commandLineParams.u );
+  var url = host + ':' + port + urlPath;
+  $.util.log( 'WCAG tests checking URL: http://' + url );
+  return [ '--u=' + url, '--id=' + checkerId ];
+}
+
+/**
+ * Process a path and set it to an empty string if it's undefined
+ * and add a leading slash if one is not present.
+ * @param {string} urlPath The unprocessed path.
+ * @returns {string} The processed path.
+ */
+function _parsePath( urlPath ) {
+  urlPath = urlPath || '';
+  if ( urlPath.charAt( 0 ) !== '/' ) {
+    urlPath = '/' + urlPath;
+  }
+  return urlPath;
+}
+
+gulp.task( 'test:a11y', function() {
+  spawn(
+    fsHelper.getBinary( 'wcag', '.bin' ),
+    _getWCAGParams(),
+    { stdio: 'inherit' }
+  )
+    .once( 'close', function() {
+      $.util.log( 'WCAG tests done!' );
+    } );
 } );
 
 // This task will only run on Travis

--- a/gulp/utils/fsHelper.js
+++ b/gulp/utils/fsHelper.js
@@ -5,13 +5,16 @@ var path = require( 'path' );
 /**
  * Retrieve a reference path to a binary.
  * @param {string} binaryName The name of the binary to retrieve.
+ * @param {string} binaryDir The name of the binary directory to use.
+ *   `bin` by default.
  * @returns {string} Path to the binary to run.
  */
-function getBinary( binaryName ) {
+function getBinary( binaryName, binaryDir ) {
+  binaryDir = binaryDir || 'bin';
   var winExt = ( /^win/ ).test( process.platform ) ? '.cmd' : '';
   var pkgPath = require.resolve( binaryName );
-  var binaryDir = path.resolve(
-    path.join( path.dirname( pkgPath ), '..', 'bin' )
+  binaryDir = path.resolve(
+    path.join( path.dirname( pkgPath ), '..', binaryDir )
   );
   return path.join( binaryDir, '/' + binaryName + winExt );
 }

--- a/package.json
+++ b/package.json
@@ -48,7 +48,8 @@
     "sinon": "^1.14.1",
     "sinon-chai": "^2.7.0",
     "webpack": "^1.12.0",
-    "webpack-stream": "^2.1.0"
+    "webpack-stream": "^2.1.0",
+    "wcag": "^0.2.2"
   },
   "browser": {
     "dateformat": "./node_modules/dateformat/lib/dateformat.js",


### PR DESCRIPTION
Adds accessibility testing.

## Additions

- Adds `gulp test:a11y` accessibility testing using node-wcag.

## Changes

- Adds binaryDirectory parameter to fsHelper.getBinary helper function.

## Testing

- See bottom of `TEST.md`

## Review

- @sebworks 
- @KimberlyMunoz 
- @jimmynotjim 

## Todos

- **NOTE: The change noted in https://github.com/cfpb/node-wcag/issues/35 needs to be fixed before merging this PR or this will only work with the homepage.**
