### PR TITLE
Adding Acceptance tests for Newsroom pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - A temporary blog page template for testing
 - Added `block__flush` to cf-enhancements to remove margin from all sides.
 - Added Acceptance tests for `blog` pages.
+- Added Acceptance tests for `newsroom` pages.
 
 ### Changed
 - Updated Video Code to make it usable on Events pages.

--- a/cfgov/v1/jinja2/v1/newsroom/index.html
+++ b/cfgov/v1/jinja2/v1/newsroom/index.html
@@ -15,7 +15,7 @@
 
 {% block content_main %}
 
-    <h1 class="u-mb30">Newsroom</h1>
+    <h1 class="u-mb30" data-qa-hook="main-title">Newsroom</h1>
 
     {# Get the latest Featured Topic #}
     {% import 'featured-topic.html' as featured_topics %}
@@ -33,7 +33,7 @@
 
     {# Footer #}
     <aside>
-        <section class="block">
+        <section class="block" data-qa-hook="stay-informed-section">
             <h2 class="header-slug">
                 <span class="header-slug_inner">
                     Stay informed
@@ -47,7 +47,8 @@
                     {% import 'macros/subscribe.html' as subscribe with context %}
                     {{ subscribe.render('USCFPB_23') }}
                 </div>
-                <div class="block__sub content-l_col content-l_col-1-2">
+                <div class="block__sub content-l_col content-l_col-1-2"
+                     data-qa-hook="rss-subscribe-section">
                     {% import 'rss.html' as rss %}
                     {{ rss.render(vars.rss_path) }}
                 </div>

--- a/cfgov/v1/jinja2/v1/newsroom/press-resources/index.html
+++ b/cfgov/v1/jinja2/v1/newsroom/press-resources/index.html
@@ -17,7 +17,7 @@
 
 {% block content_main %}
 
-    <h1>Press Resources</h1>
+    <h1 data-qa-hook="main-title">Press Resources</h1>
 
     <section class="press-section press-contacts">
 
@@ -195,7 +195,8 @@
                   block__flush-bottom
                   ">
         <div class="content-l content-l__main">
-            <section class="content-l_col content-l_col-1-2">
+            <section class="content-l_col content-l_col-1-2"
+                     data-qa-hook="stay-informed-section">
                 <h2 class="header-slug">
                     <span class="header-slug_inner">
                         Stay informed
@@ -208,7 +209,8 @@
                     {% import 'macros/subscribe.html' as subscribe with context %}
                     {{ subscribe.render('USCFPB_23') }}
                 </div>
-                <div class="block block__sub">
+                <div class="block block__sub"
+                     data-qa-hook="rss-subscribe-section">
                     {% import 'rss.html' as rss %}
                     {{ rss.render(vars.rss_path) }}
                 </div>

--- a/test/browser_tests/page_objects/page_careers-application-process.js
+++ b/test/browser_tests/page_objects/page_careers-application-process.js
@@ -26,7 +26,7 @@ function ApplicationProcess() {
   this.introSectionLink = this.introSection.element( by.css( 'a' ) );
 
   this.jobApplicationsInterfaces =
-  element.all( by.css( '.job-applications-interfaces .expandable' ) );
+  element.all( by.css( '.job-applications-interfaces .media' ) );
 
   this.ethicsLink = element( by.css( 'a[href="mailto:EthicsHelp@cfpb.gov"' ) );
 

--- a/test/browser_tests/page_objects/page_newsroom-press-resources.js
+++ b/test/browser_tests/page_objects/page_newsroom-press-resources.js
@@ -1,0 +1,74 @@
+'use strict';
+
+var _assign = require( 'lodash' ).assign;
+var stayInformedSection = require( '../shared_objects/stay-informed-section' );
+var rssSection = require( '../shared_objects/rss-section' );
+var _getQAElement = require( '../util/QAelement' ).get;
+
+function PressResources() {
+
+  _assign( this, stayInformedSection, rssSection );
+
+  this.get = function() {
+    browser.get( '/newsroom/press-resources/' );
+  };
+
+  this.pageTitle = browser.getTitle;
+
+  this.mainTitle = _getQAElement( 'main-title' );
+
+  this.subTitle = element( by.css( '.press-contacts_title' ) );
+
+  this.sideNav = element( by.css( '.nav-secondary' ) );
+
+  this.contactList = element( by.css( '.press-contacts_main-contact-list' ) );
+
+  this.contactListEmail = element.all(
+  by.css( '.press-contacts_main-contact-list .list_link' ) ).get( 0 );
+
+  this.contactListPhone = element.all(
+  by.css( '.press-contacts_main-contact-list .list_link' ) ).get( 1 );
+
+  this.contactPersons =
+  element.all( by.css( '.press-contacts_people .contact-person' ) );
+
+  this.pressSectionTitle = element( by.css( '.press-photos-bios_title' ) );
+
+  this.pressSectionIntro = element( by.css( '.press-section_intro' ) );
+
+  this.directorsBio =
+  element.all( by.css( '.press-photos-bios .contact-person' ) ).get( 0 );
+
+  this.directorsImage =
+  this.directorsBio.all( by.css( '.contact-person_photo' ) ).get( 0 );
+
+  this.directorsName =
+  this.directorsBio.all( by.css( '.contact-person_name' ) ).get( 0 );
+
+  this.directorsBioLink =
+  this.directorsBio.all( by.css( '.list__links .list__link' ) ).get( 0 );
+
+  this.directorsHighResImageLink =
+  this.directorsBio.all( by.css( '.list__links .list_link' ) ).get( 1 );
+
+  this.directorsLowResImageLink =
+  this.directorsBio.all( by.css( '.list__links .list_link' ) ).get( 2 );
+
+  this.deputyDirectorBio =
+  element.all( by.css( '.press-photos-bios .contact-person' ) ).get( 1 );
+
+  this.deputyDirectorsName =
+  this.deputyDirectorBio.all( by.css( '.contact-person_name' ) ).get( 0 );
+
+  this.deputyDirectorsImage =
+  this.deputyDirectorBio.all( by.css( '.contact-person_photo' ) ).get( 0 );
+
+  this.deputyDirectorsHighResImageLink =
+  this.deputyDirectorBio.all( by.css( '.list__links .list_link' ) ).get( 0 );
+
+  this.deputyDirectorsLowResImageLink =
+  this.deputyDirectorBio.all( by.css( '.list__links .list_link' ) ).get( 1 );
+
+}
+
+module.exports = PressResources;

--- a/test/browser_tests/page_objects/page_newsroom.js
+++ b/test/browser_tests/page_objects/page_newsroom.js
@@ -1,0 +1,46 @@
+'use strict';
+
+var _assign = require( 'lodash' ).assign;
+var filter = require( '../shared_objects/filter.js' );
+var pagination = require( '../shared_objects/pagination' );
+var stayInformedSection = require( '../shared_objects/stay-informed-section' );
+var rssSection = require( '../shared_objects/rss-section' );
+
+var _getQAElement = require( '../util/QAelement' ).get;
+
+function Newsroom() {
+
+  _assign( this, filter, pagination, stayInformedSection, rssSection );
+
+  this.get = function() {
+    browser.get( '/newsroom/' );
+  };
+
+  this.pageTitle = browser.getTitle;
+
+  this.mainTitle = _getQAElement( 'main-title' );
+
+  this.sideNav = element( by.css( '.nav-secondary' ) );
+
+  this.featuredTopic = element( by.css( '.featured-topic' ) );
+
+  this.featuredTopicTitle =
+  this.featuredTopic.element( by.css( '.summary_header' ) );
+
+  this.featuredTopicSummaryText =
+  this.featuredTopic.all( by.css( '.summary_cols' ) ).get( 0 );
+
+  this.featuredTopicSummaryLinks =
+  this.featuredTopic.all( by.css( '.summary_cols' ) ).get( 1 );
+
+  this.relatedContent = element( by.css( '.related_content' ) );
+
+  this.relatedLinks =
+  this.relatedContent.element( by.css( '.related_content' ) );
+
+  this.upcomingEvents =
+  this.relatedContent.element( by.css( '.upcoming-events' ) );
+
+}
+
+module.exports = Newsroom;

--- a/test/browser_tests/spec_suites/newsroom-press-resources.js
+++ b/test/browser_tests/spec_suites/newsroom-press-resources.js
@@ -1,0 +1,128 @@
+'use strict';
+
+var PressResources = require(
+    '../page_objects/page_newsroom-press-resources.js'
+  );
+
+describe( 'The Newsroom Press Resources Page', function() {
+  var page;
+
+  beforeAll( function() {
+    page = new PressResources();
+    page.get();
+  } );
+
+  it( 'should properly load in a browser', function() {
+    expect( page.pageTitle() ).toBe( 'Press resources' );
+  } );
+
+  it( 'should include a main title', function() {
+    expect( page.mainTitle.getText() ).toBe( 'Press Resources' );
+  } );
+
+  it( 'should have a side nav', function() {
+    expect( page.sideNav.isPresent() ).toBe( true );
+  } );
+
+  it( 'should include a sub title', function() {
+    expect( page.subTitle.getText() ).toBe( 'Press contacts' );
+  } );
+
+  it( 'should include a Press contact email address', function() {
+    expect( page.contactListEmail .getText() )
+    .toBe( 'press@consumerfinance.gov' );
+    expect( page.contactListEmail .getAttribute( 'href' ) )
+    .toBe( 'mailto:inquiries@consumerfinance.gov' );
+  } );
+
+  it( 'should include a Press contact list phone number', function() {
+    expect( page.contactListPhone.getText() ).toBe( '(202) 435-7170' );
+    expect( page.contactListPhone.getAttribute( 'href' ) )
+    .toBe( 'tel:2024357170' );
+  } );
+
+  it( 'should include a Press section title', function() {
+    expect( page.pressSectionTitle.getText() ).toBe( 'Photos and bios' );
+  } );
+
+  it( 'should include a Press section intro', function() {
+    expect( page.pressSectionIntro.isPresent() ).toBe( true );
+  } );
+
+  it( 'should include Director’s bio', function() {
+    expect( page.directorsImage.getAttribute( 'src' ) )
+    .toBe( browser.baseUrl + '/static/img/director-cordray-round-300x300.jpg' );
+    expect( page.directorsName.getText() ).toBe( 'Richard Cordray' );
+    expect( page.directorsHighResImageLink.getText() )
+    .toBe( 'High-res portrait' );
+    expect( page.directorsLowResImageLink.getText() )
+    .toBe( 'Low-res portrait' );
+  } );
+
+  it( 'should include the Deputy Director bio', function() {
+    expect( page.deputyDirectorsImage.getAttribute( 'src' ) ).toBe(
+    browser.baseUrl + '/static/img/deputy-director-fuchs-round-300x300.jpg' );
+    expect( page.deputyDirectorsName.getText() )
+    .toBe( 'Meredith Fuchs' );
+    expect( page.deputyDirectorsHighResImageLink.getText() )
+    .toBe( 'High-res portrait' );
+    expect( page.deputyDirectorsLowResImageLink.getText() )
+    .toBe( 'Low-res portrait' );
+
+  } );
+
+  it( 'should include a Press section intro', function() {
+    expect( page.pressSectionIntro.isPresent() ).toBe( true );
+  } );
+
+  it( 'should include more than one contact person', function() {
+    expect( page.contactPersons .count() ).toBeGreaterThan( 1 );
+  } );
+
+  it( 'should include a Stay Informed section', function() {
+    expect( page.stayInformedSection.isPresent() ).toBe( true );
+  } );
+
+  it( 'should include a Stay Informed section title', function() {
+    expect( page.stayInformedSectionTitle.getText() ).toBe( 'STAY INFORMED' );
+  } );
+
+  it( 'should include a Email Subscribe form', function() {
+    expect( page.emailSubscribeForm.isPresent() ).toBe( true );
+  } );
+
+  it( 'should include a Email Subscribe label', function() {
+    expect( page.emailFormLabel.getText() ).toBe( 'Email address' );
+  } );
+
+  it( 'should include a Email Subscribe input', function() {
+    expect( page.emailFormInput.isPresent() ).toBe( true );
+    expect( page.emailFormInput.getAttribute( 'placeholder' ) )
+    .toBe( 'example@mail.com' );
+  } );
+
+  it( 'should include a Email Subscribe hidden field', function() {
+    expect( page.emailFormHiddenField.getAttribute( 'value' ) )
+    .toBe( 'USCFPB_23' );
+    expect( page.emailFormHiddenField.getAttribute( 'name' ) )
+    .toBe( 'code' );
+  } );
+
+  it( 'should include a Email Subscribe button', function() {
+    expect( page.emailFormBtn.getAttribute( 'value' ) )
+    .toBe( 'Sign up' );
+  } );
+
+  it( 'should include a Email Subscribe description', function() {
+    expect( page.emailFormDescription.isPresent() ).toBe( true );
+  } );
+
+  it( 'should include a RSS Subscribe section', function() {
+    expect( page.rssSubscribeSection.isPresent() ).toBe( true );
+  } );
+
+  it( 'should include a RSS Subscribe button', function() {
+    expect( page.rssSubscribeBtn.getText() ).toBe( 'Subscribe to RSS' );
+  } );
+
+} );

--- a/test/browser_tests/spec_suites/newsroom.js
+++ b/test/browser_tests/spec_suites/newsroom.js
@@ -1,33 +1,31 @@
 'use strict';
 
-var Blog = require(
-    '../page_objects/page_blog.js'
+var Newsroom = require(
+    '../page_objects/page_newsroom.js'
   );
 
-describe( 'The Blog Page', function() {
+describe( 'The Newsroom Page', function() {
   var page;
 
   beforeAll( function() {
-    page = new Blog();
+    page = new Newsroom();
     page.get();
   } );
 
   it( 'should properly load in a browser', function() {
-    expect( page.pageTitle() ).toBe( 'Blog' );
+    expect( page.pageTitle() ).toBe( 'Newsroom' );
   } );
 
   it( 'should include a main title', function() {
-    expect( page.mainTitle.getText() ).toBe( 'Blog' );
+    expect( page.mainTitle.getText() ).toBe( 'Newsroom' );
   } );
 
-  it( 'should include a content sidebar', function() {
-    expect( page.contentSidebar.isPresent() ).toBe( true );
+  it( 'should have a side nav', function() {
+    expect( page.sideNav.isPresent() ).toBe( true );
   } );
 
-  it( 'might include Popular Stories in the sidebar', function() {
-    if ( page.popularStories ) {
-      expect( page.popularStoriesTitle.getText() ).toBe( 'POPULAR STORIES' );
-    }
+  it( 'should include a featured topic', function() {
+    expect( page.featuredTopic.isPresent() ).toBe( true );
   } );
 
   it( 'should include a Stay Informed section in the sidebar', function() {
@@ -38,11 +36,11 @@ describe( 'The Blog Page', function() {
     expect( page.stayInformedSectionTitle.getText() ).toBe( 'STAY INFORMED' );
   } );
 
-  it( 'should include an Email Subscribe form', function() {
+  it( 'should include a Email Subscribe form', function() {
     expect( page.emailSubscribeForm.isPresent() ).toBe( true );
   } );
 
-  it( 'should include an Email Subscribe label', function() {
+  it( 'should include a Email Subscribe label', function() {
     expect( page.emailFormLabel.getText() ).toBe( 'Email address' );
   } );
 
@@ -52,27 +50,27 @@ describe( 'The Blog Page', function() {
     .toBe( 'example@mail.com' );
   } );
 
-  it( 'should include an Email Subscribe hidden field', function() {
+  it( 'should include a Email Subscribe hidden field', function() {
     expect( page.emailFormHiddenField.getAttribute( 'value' ) )
-    .toBe( 'USCFPB_91' );
+    .toBe( 'USCFPB_23' );
     expect( page.emailFormHiddenField.getAttribute( 'name' ) )
     .toBe( 'code' );
   } );
 
-  it( 'should include an Email Subscribe button', function() {
+  it( 'should include a Email Subscribe button', function() {
     expect( page.emailFormBtn.getAttribute( 'value' ) )
     .toBe( 'Sign up' );
   } );
 
-  it( 'should include an Email Subscribe description', function() {
+  it( 'should include a Email Subscribe description', function() {
     expect( page.emailFormDescription.isPresent() ).toBe( true );
   } );
 
-  it( 'should include an RSS Subscribe section', function() {
+  it( 'should include a RSS Subscribe section', function() {
     expect( page.rssSubscribeSection.isPresent() ).toBe( true );
   } );
 
-  it( 'should include an RSS Subscribe button', function() {
+  it( 'should include a RSS Subscribe button', function() {
     expect( page.rssSubscribeBtn.getText() ).toContain( 'Subscribe to RSS' );
   } );
 


### PR DESCRIPTION
Acceptance tests for the `Newsroom` pages

## Changes
 - Added acceptance tests for the `Newsroom` pages. 

## Testing
-  Run `gulp test:acceptance`

## Notes
- This PR does introduce the concept of mixins. This would allow us to have reusable page components.


## Review
@anselmbradford 
@jimmynotjim 
@KimberlyMunoz 