### PR TITLE
Fix wsgi to use env settings

### DIFF
--- a/cfgov/cfgov/wsgi.py
+++ b/cfgov/cfgov/wsgi.py
@@ -11,6 +11,6 @@ import os
 
 from django.core.wsgi import get_wsgi_application
 
-os.environ.setdefault("DJANGO_SETTINGS_MODULE", "cfgov.settings")
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "cfgov.settings." + os.environ.get('DJANGO_ENV'))
 
 application = get_wsgi_application()


### PR DESCRIPTION
Right now WSGI points to the module init file that contains nothing so no settings are set. This replicates manage.py to give wsgi.py the same settings file to use.

@kave 