### PR TITLE
Adding Acceptance tests for Budget pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Added Acceptance tests for `blog` pages.
 - Added Acceptance tests for `newsroom` pages.
 - Added Acceptance tests for `doing-business-with-us` pages.
+- Added Acceptance tests for `budget` pages.
 
 ### Changed
 - Updated Video Code to make it usable on Events pages.

--- a/cfgov/v1/jinja2/v1/budget/index.html
+++ b/cfgov/v1/jinja2/v1/budget/index.html
@@ -23,13 +23,14 @@
         </div>
         <div class="media_body">
             <h1>Budget and strategy</h1>
-            <p class="h3">
+            <p class="h3" data-qa-hook="mission-summary">
                 The mission of the CFPB is to make consumer finance rules more effective,
                 to consistently and fairly enforce those rules,
                 and to empower consumers to take more control over their economic lives.
                 Our vision is a consumer finance marketplace:
             </p>
-            <ul class="h3 list list__branded">
+            <ul class="h3 list list__branded"
+                data-qa-hook="mission-statements">
                 <li>
                     where customers can see prices
                     and risks up front and where they can easily make product comparisons;
@@ -51,7 +52,8 @@
         </div>
     </section>
 
-    <section class="block block__sub block__padded-top block__border-top">
+    <section class="block block__sub block__padded-top block__border-top"
+             data-qa-hook="budget-section">
 
         <div class="content-l content-l__main content-l__large-gutters">
             <div class="content-l_col content-l_col-1-2 block block__flush-top block__sub">
@@ -120,7 +122,8 @@
                     block__border-top
                     block__border-right">
             <div class="content-l content-l__main">
-                <section class="content-l_col content-l_col-1-2">
+                <section class="content-l_col content-l_col-1-2"
+                         data-qa-hook="business-with-CFPB-section">
                     <h2 class="header-slug">
                         <span class="header-slug_inner">
                             Doing business with the CFPB

--- a/test/browser_tests/page_objects/page_budget-financial-report.js
+++ b/test/browser_tests/page_objects/page_budget-financial-report.js
@@ -1,0 +1,25 @@
+'use strict';
+
+function BudgetFinancialReport() {
+
+  this.get = function() {
+    browser.get( 'budget/financial-report/' );
+  };
+
+  this.pageTitle = function() { return browser.getTitle(); };
+
+  this.sideNav = element( by.css( '.nav-secondary' ) );
+
+  this.breadcrumb = element( by.css( '.breadcrumbs_link' ) );
+
+  this.mainTitle = element( by.css( '.content_main h1' ) );
+
+  this.mainSummary = element( by.css( '.content_main p.h3' ) );
+
+  this.financialReportTitles = element.all( by.css( '.financial-report h4' ) );
+
+  this.financialReportLinks = element.all( by.css( '.financial-report a' ) );
+
+}
+
+module.exports = BudgetFinancialReport;

--- a/test/browser_tests/page_objects/page_budget-funding-request.js
+++ b/test/browser_tests/page_objects/page_budget-funding-request.js
@@ -1,0 +1,25 @@
+'use strict';
+
+function BudgetFundingRequest() {
+
+  this.get = function() {
+    browser.get( 'budget/funding-request/' );
+  };
+
+  this.pageTitle = function() { return browser.getTitle(); };
+
+  this.sideNav = element( by.css( '.nav-secondary' ) );
+
+  this.breadcrumb = element( by.css( '.breadcrumbs_link' ) );
+
+  this.mainTitle = element( by.css( '.content_main h1' ) );
+
+  this.mainSummary = element( by.css( '.content_main p.h3' ) );
+
+  this.fundingRequestTitles = element.all( by.css( '.funding-request h4' ) );
+
+  this.fundingRequestLinks = element.all( by.css( '.funding-request a' ) );
+
+}
+
+module.exports = BudgetFundingRequest;

--- a/test/browser_tests/page_objects/page_budget-performance-plan-report.js
+++ b/test/browser_tests/page_objects/page_budget-performance-plan-report.js
@@ -1,0 +1,25 @@
+'use strict';
+
+function BudgetPerformancePlanReport() {
+
+  this.get = function() {
+    browser.get( 'budget/performance-plan-report/' );
+  };
+
+  this.pageTitle = function() { return browser.getTitle(); };
+
+  this.sideNav = element( by.css( '.nav-secondary' ) );
+
+  this.breadcrumb = element( by.css( '.breadcrumbs_link' ) );
+
+  this.mainTitle = element( by.css( '.content_main h1' ) );
+
+  this.mainSummary = element( by.css( '.content_main p.h3' ) );
+
+  this.performancePlanTitles = element.all( by.css( '.performance-plan h4' ) );
+
+  this.performancePlanLinks = element.all( by.css( '.performance-plan a' ) );
+
+}
+
+module.exports = BudgetPerformancePlanReport;

--- a/test/browser_tests/page_objects/page_budget-strategic-plan.js
+++ b/test/browser_tests/page_objects/page_budget-strategic-plan.js
@@ -1,0 +1,25 @@
+'use strict';
+
+function BudgetStrategicPlan() {
+
+  this.get = function() {
+    browser.get( 'budget/strategic-plan/' );
+  };
+
+  this.pageTitle = function() { return browser.getTitle(); };
+
+  this.sideNav = element( by.css( '.nav-secondary' ) );
+
+  this.breadcrumb = element( by.css( '.breadcrumbs_link' ) );
+
+  this.mainTitle = element( by.css( '.content_main h1' ) );
+
+  this.mainSummary = element( by.css( '.content_main p.h3' ) );
+
+  this.mainSubTitle = element( by.css( '.content_main h2' ) );
+
+  this.mainLinks = element.all( by.css( '.content_main a' ) );
+
+}
+
+module.exports = BudgetStrategicPlan;

--- a/test/browser_tests/page_objects/page_budget.js
+++ b/test/browser_tests/page_objects/page_budget.js
@@ -1,0 +1,50 @@
+'use strict';
+
+var _getQAElement = require( '../util/QAelement' ).get;
+
+function Budget() {
+
+  this.get = function() {
+    browser.get( '/budget/' );
+  };
+
+  this.pageTitle = function() { return browser.getTitle(); };
+
+  this.sideNav = element( by.css( '.nav-secondary' ) );
+
+  this.mainTitle = element( by.css( '.media_body h1' ) );
+
+  this.missionSummary = _getQAElement( 'mission-summary' );
+
+  this.missionStatements =
+  _getQAElement( 'mission-statements', true ).all( by.css( 'li' ) );
+
+  this.budgetSections =
+  _getQAElement( 'budget-section', true ).all( by.css('.content-l_col' ) );
+
+  this.budgetSectionTitles = this.budgetSections.all( by.css( 'h2' ) );
+
+  this.budgetSectionDescriptions =
+  this.budgetSections.all( by.css( '.short-desc' ) );
+
+  this.budgetSectionLinks = this.budgetSections.all( by.css( 'a' ) );
+
+  this.businessWithCFPBSection = _getQAElement( 'business-with-CFPB-section' );
+
+  this.businessWithCFPBTitle =
+  this.businessWithCFPBSection.element( by.css( '.header-slug_inner' ) );
+
+  this.businessWithCFPBDescription =
+  this.businessWithCFPBSection.element( by.css( '.short-desc' ) );
+
+  this.businessWithCFPBLink =
+  this.businessWithCFPBSection.element( by.css( 'a' ) );
+
+  this.relatedLinksTitle =
+  element( by.css( '.related-links .header-slug_inner' ) );
+
+  this.relatedLinks = element.all( by.css( '.related-links a' ) );
+
+}
+
+module.exports = Budget;

--- a/test/browser_tests/spec_suites/budget-financial-report.js
+++ b/test/browser_tests/spec_suites/budget-financial-report.js
@@ -1,0 +1,40 @@
+'use strict';
+
+var BudgetPerformancePlanReport = require(
+    '../page_objects/page_budget-financial-report.js'
+  );
+
+describe( 'The Budget Financial Report Page', function() {
+  var page;
+
+  beforeAll( function() {
+    page = new BudgetPerformancePlanReport();
+    page.get();
+  } );
+
+  it( 'should properly load in a browser', function() {
+    expect( page.pageTitle() ).toBe( 'Financial Report & Update' );
+  } );
+
+  it( 'should load a side nav', function() {
+    expect( page.sideNav.isPresent() ).toBe( true );
+  } );
+
+  it( 'should have a breadcrumb', function() {
+    expect( page.breadcrumb.getText() ).toBe( 'Budget and Strategy' );
+  } );
+
+  it( 'should have a main title', function() {
+    expect( page.mainTitle.getText() ).toBe( 'Financial Reports & Updates' );
+  } );
+
+  it( 'should have multiple Financial Reports', function() {
+    expect( page.financialReportTitles.count() ).toBeGreaterThan( 0 );
+    expect( page.financialReportLinks.count() ).toBeGreaterThan( 0 );
+    page.financialReportLinks.getAttribute( 'href' )
+    .then( function( values ) {
+      expect( values.join().indexOf( '.pdf' ) > -1 ).toBe( true );
+    } );
+  } );
+
+} );

--- a/test/browser_tests/spec_suites/budget-funding-request.js
+++ b/test/browser_tests/spec_suites/budget-funding-request.js
@@ -1,0 +1,40 @@
+'use strict';
+
+var BudgetFundingRequest = require(
+    '../page_objects/page_budget-funding-request.js'
+  );
+
+describe( 'The Budget Funding Request Page', function() {
+  var page;
+
+  beforeAll( function() {
+    page = new BudgetFundingRequest();
+    page.get();
+  } );
+
+  it( 'should properly load in a browser', function() {
+    expect( page.pageTitle() ).toBe( 'Funding Requests' );
+  } );
+
+  it( 'should load a side nav', function() {
+    expect( page.sideNav.isPresent() ).toBe( true );
+  } );
+
+  it( 'should have a breadcrumb', function() {
+    expect( page.breadcrumb.getText() ).toBe( 'Budget and Strategy' );
+  } );
+
+  it( 'should have a main title', function() {
+    expect( page.mainTitle.getText() ).toBe( 'Funding Requests' );
+  } );
+
+  it( 'should have multiple Funding Requests', function() {
+    expect( page.fundingRequestTitles.count() ).toBeGreaterThan( 0 );
+    expect( page.fundingRequestLinks.count() ).toBeGreaterThan( 0 );
+    page.fundingRequestLinks.getAttribute( 'href' )
+    .then( function( values ) {
+      expect( values.join().indexOf( '.pdf' ) > -1 ).toBe( true );
+    } );
+  } );
+
+} );

--- a/test/browser_tests/spec_suites/budget-performance-plan-report.js
+++ b/test/browser_tests/spec_suites/budget-performance-plan-report.js
@@ -1,0 +1,40 @@
+'use strict';
+
+var BudgetPerformancePlanReport = require(
+    '../page_objects/page_budget-performance-plan-report.js'
+  );
+
+describe( 'The Budget Performance Plan Report Page', function() {
+  var page;
+
+  beforeAll( function() {
+    page = new BudgetPerformancePlanReport();
+    page.get();
+  } );
+
+  it( 'should properly load in a browser', function() {
+    expect( page.pageTitle() ).toBe( 'Annual Performance Plan and Report' );
+  } );
+
+  it( 'should load a side nav', function() {
+    expect( page.sideNav.isPresent() ).toBe( true );
+  } );
+
+  it( 'should have a breadcrumb', function() {
+    expect( page.breadcrumb.getText() ).toBe( 'Budget and Strategy' );
+  } );
+
+  it( 'should have a main title', function() {
+    expect( page.mainTitle.getText() ).toBe( 'Performance Plan & Report' );
+  } );
+
+  it( 'should have multiple Performance Plans', function() {
+    expect( page.performancePlanTitles.count() ).toBeGreaterThan( 0 );
+    expect( page.performancePlanLinks.count() ).toBeGreaterThan( 0 );
+    page.performancePlanLinks.getAttribute( 'href' )
+    .then( function( values ) {
+      expect( values.join().indexOf( '.pdf' ) > -1 ).toBe( true );
+    } );
+  } );
+
+} );

--- a/test/browser_tests/spec_suites/budget-strategic-plan.js
+++ b/test/browser_tests/spec_suites/budget-strategic-plan.js
@@ -1,0 +1,52 @@
+'use strict';
+
+var BudgetStrategicPlan = require(
+    '../page_objects/page_budget-strategic-plan.js'
+  );
+
+var Urlmatcher = require( '../util/url-matcher' );
+
+describe( 'The Budget Strategic Plan Page', function() {
+  var page;
+
+  beforeAll( function() {
+    page = new BudgetStrategicPlan();
+    page.get();
+
+    jasmine.addMatchers( Urlmatcher );
+  } );
+
+  it( 'should properly load in a browser', function() {
+    expect( page.pageTitle() ).toBe( 'Strategic Plan' );
+  } );
+
+  it( 'should have a side nav', function() {
+    expect( page.sideNav.isPresent() ).toBe( true );
+  } );
+
+  it( 'should have a breadcrumb', function() {
+    expect( page.breadcrumb.getText() ).toBe( 'Budget and Strategy' );
+  } );
+
+  it( 'should have a main title', function() {
+    expect( page.mainTitle.getText() ).toBe( 'Strategic Plan' );
+  } );
+
+  it( 'should have a main summary', function() {
+    expect( page.mainSummary.isPresent() ).toBe( true );
+  } );
+
+  it( 'should have a sub title', function() {
+    expect( page.mainSubTitle.getText() ).toBe( 'CFPB Strategic Plan' );
+  } );
+
+  it( 'should have multiple main links', function() {
+    var mainLinks =
+    [ '/budget/strategic-plan/interactive/',
+    'http://files.consumerfinance.gov/f/strategic-plan.pdf' ];
+
+    expect( page.mainLinks.getAttribute( 'href' ) )
+    .toEqualUrl( mainLinks );
+  } );
+
+} );

--- a/test/browser_tests/spec_suites/budget.js
+++ b/test/browser_tests/spec_suites/budget.js
@@ -1,0 +1,59 @@
+'use strict';
+
+var Budget = require(
+    '../page_objects/page_budget.js'
+  );
+
+var Urlmatcher = require( '../util/url-matcher' );
+
+describe( 'The Budget Page', function() {
+  var page;
+
+  beforeAll( function() {
+    page = new Budget();
+    page.get();
+
+    jasmine.addMatchers( Urlmatcher );
+  } );
+
+  it( 'should properly load in a browser', function() {
+    expect( page.pageTitle() ).toBe( 'Budget and Strategy' );
+  } );
+
+  it( 'should load a side nav', function() {
+    expect( page.sideNav.isPresent() ).toBe( true );
+  } );
+
+  it( 'should have a mission summary', function() {
+    expect( page.missionSummary.isPresent() ).toBe( true );
+  } );
+
+  it( 'should more than one mission statements', function() {
+    expect( page.missionStatements.count() ).toBeGreaterThan( 1 );
+  } );
+
+  it( 'should have Budget sections', function() {
+    var budgetSectionTitles =
+    [ 'Strategic plan', 'Performance plans and reports',
+    'Financial reports and updates', 'Funding requests' ];
+    var budgetSectionLinks =
+    [ '/budget/strategic-plan/', '/budget/performance-plan-report/',
+    '/budget/financial-report/', '/budget/funding-request/' ];
+
+    expect( page.budgetSectionTitles.getText() )
+    .toEqual( budgetSectionTitles );
+    expect( page.budgetSectionDescriptions.count() ).toEqual( 4 );
+    expect( page.budgetSectionLinks.getAttribute( 'href' ) )
+    .toEqualUrl( budgetSectionLinks );
+  } );
+
+  it( 'should have a Business With CFPB section', function() {
+    var budgetSectionLinks = [ '/the-bureau/', '/blog/', null ];
+
+    expect( page.relatedLinksTitle.getText() )
+    .toBe( 'RELATED LINKS' );
+    expect( page.relatedLinks.getAttribute( 'href' ) )
+    .toEqualUrl( budgetSectionLinks );
+  } );
+
+} );

--- a/test/browser_tests/util/url-matcher.js
+++ b/test/browser_tests/util/url-matcher.js
@@ -11,7 +11,11 @@
  * @returns {string} - An absolute URL.
  */
 function _getAbsoluteUrl( url ) {
-  return url.indexOf( 'http' ) > -1 ? url : browser.baseUrl + url;
+  if ( url ) {
+    url = url.indexOf( 'http' ) > -1 ? url : browser.baseUrl + url;
+  }
+
+  return url;
 }
 
 /**


### PR DESCRIPTION
Adding Acceptance tests for the `Budget` pages

## Changes
 - Added acceptance tests for the `Budget` pages. 

## Testing
-  Run `gulp test:acceptance`

## Review
@anselmbradford 
@jimmynotjim 
@KimberlyMunoz 