### PR TITLE
Change imports for macros that use request to use `with context`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Added jQuery CDN with fallback to head to satisfy GTM requirements.
 - Changes the location of the /dist folder to cfgov/v1/jinja2/v1
 - Server port is now at 8000
+- Importing macros that use the request object to use `with context`
 
 ### Removed
 - Disables tests for landing page events, since we don't currently have events.

--- a/src/_includes/macros/video-player.html
+++ b/src/_includes/macros/video-player.html
@@ -26,7 +26,7 @@
    ========================================================================== #}
 
 {% macro render(options={}) -%}
-    {% import 'macros/share.html' as share %}
+    {% import 'macros/share.html' as share with context %}
     {% set video_player = options.video.player | default('youtube') %}
     {% set video_id     = options.video.id     | default('') %}
     {% set video_url    = options.video.url    | default('/') %}

--- a/src/_includes/templates/nav/primary-nav.html
+++ b/src/_includes/templates/nav/primary-nav.html
@@ -1,5 +1,5 @@
 {% import 'templates/nav/_vars-primary-nav.html' as vars with context %}
-{% import 'macros/sub-nav.html' as sub_nav %}
+{% import 'macros/sub-nav.html' as sub_nav with context %}
 <nav class="primary-nav
             js-primary-nav"
      aria-expanded="false"

--- a/src/careers/current-openings/_single.html
+++ b/src/careers/current-openings/_single.html
@@ -22,7 +22,7 @@
 
 {% block content_main %}
 
-{% import 'macros/share.html' as share %}
+{% import 'macros/share.html' as share with context %}
 
     <section class="block
                     block__flush-top

--- a/src/events/_event.html
+++ b/src/events/_event.html
@@ -27,7 +27,7 @@
 
 {% macro render(post, path, event_state) %}
 
-{% import 'macros/share.html' as share %}
+{% import 'macros/share.html' as share with context %}
 
 <article class="post post__event">
     <header>

--- a/src/the-bureau/about-deputy-director/index.html
+++ b/src/the-bureau/about-deputy-director/index.html
@@ -13,7 +13,7 @@
 
 {% block content_main %}
 
-	{% import 'macros/share.html' as share %}
+	{% import 'macros/share.html' as share with context %}
 
     <div class="block block__flush-top" data-qa-hook="director-bio">
         <h1 data-qa-hook="director-bio-title">

--- a/src/the-bureau/about-director/index.html
+++ b/src/the-bureau/about-director/index.html
@@ -13,7 +13,7 @@
 
 {% block content_main %}
 
-	{% import 'macros/share.html' as share %}
+	{% import 'macros/share.html' as share with context %}
 
     <div class="block block__flush-top" data-qa-hook="director-bio">
         <h1 data-qa-hook="director-bio-title">

--- a/src/the-bureau/history/index.html
+++ b/src/the-bureau/history/index.html
@@ -14,7 +14,7 @@
 {% block content_main %}
 
     {% import 'post-macros.html' as post_macros %}
-    {% import 'macros/share.html' as share %}
+    {% import 'macros/share.html' as share with context %}
 
     {% set query = queries.history %}
 

--- a/src/the-bureau/leadership-calendar/index.html
+++ b/src/the-bureau/leadership-calendar/index.html
@@ -18,7 +18,7 @@
 {% block content_main %}
 
     {% import 'leadership-calendar-table.html' as calendar %}
-    {% import 'macros/share.html' as share %}
+    {% import 'macros/share.html' as share with context %}
     {% import 'macros/filters.html' as filters with context %}
     {% from 'post-macros.html' import pagination as pagination with context %}
 


### PR DESCRIPTION
@kave and @rosskarchner this makes the changes that allow the request object to be available to the context of the macro when it's rendered.

Maybe this is the way we want to do it, instead of making `DEBUG=True`?