### PR TITLE
Updates jsdom, mocha-jsdom, istanbul, and node to latest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,11 +8,6 @@ sudo: false
 services:
   - elasticsearch
 
-addons:
-  apt:
-    package:
-      - nodejs-0.12
-
 install:
   # Project configuration requirements.
   - pip install virtualenv virtualenvwrapper
@@ -24,6 +19,9 @@ install:
   - git clone https://github.com/cfpb/sheer
   - pip install -e sheer
   - pip install -r sheer/requirements.txt
+  - npm install nvm
+  - nvm install 4.1.0
+  - nvm use 4.1.0
   - npm install -g gulp
   - npm install -g bower
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Added unit test for `aria-state.js`.
 - Wagtail CMS
 - Added `gulp test:a11y` accessibility testing using node-wcag.
+- Added node 4.1.0 engine requirement in `package.json`.
 
 ### Changed
 - Updated Video Code to make it usable on Events pages.
@@ -51,6 +52,10 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Updated Dep Dir title to include "Acting"
 - included with context flag for macros that make a call to request object
 - Added `binaryDirectory` parameter to `fsHelper.getBinary` helper function.
+- Updated jsdom from `3.1.2` to `6.5.1`.
+- Updated mocha-jsdom from `0.3.0` to `1.0.0`.
+- Updated istanbul from `0.3.13` to `0.3.20`.
+- Updated TravisCI node version to `4.1.0`.
 
 ### Removed
 - Disables tests for landing page events, since we don't currently have events.

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
     "type": "git",
     "url": "http://github.com/cfpb/cfgov-refresh.git"
   },
+  "engines": {
+    "node": ">=4.1.0"
+  },
   "devDependencies": {
     "banner-footer-webpack-plugin": "git://github.com/dtothefp/banner-footer-webpack-plugin.git",
     "browser-sync": "^2.8.0",
@@ -33,16 +36,16 @@
     "handlebars": "^4.0.2",
     "handlebars-loader": "^1.1.0",
     "imports-loader": "^0.6.4",
-    "istanbul": "^0.3.13",
+    "istanbul": "^0.3.20",
     "jasmine-reporters": "^2.0.7",
     "jasmine-spec-reporter": "^2.4.0",
     "jquery": "^1.11.3",
-    "jsdom": "^3.1.2",
+    "jsdom": "^6.5.1",
     "lodash": "^3.10.0",
     "minimist": "^1.1.3",
     "mkdirp": "^0.5.1",
     "mocha": "^2.2.4",
-    "mocha-jsdom": "^0.3.0",
+    "mocha-jsdom": "^1.0.0",
     "protractor": "^2.2.0",
     "require-dir": "^0.3.0",
     "sinon": "^1.14.1",


### PR DESCRIPTION
I can't build jsdom without updating to the latest (or at least 4+). I'm running the latest node `v4.1.0`.

## Changes

- Updated jsdom from `3.1.2` to `6.5.1`.
- Updated mocha-jsdom from `0.3.0` to `1.0.0`.
- Updated istanbul from `0.3.13` to `0.3.20`.
- Updated TravisCI node version to `4.1.0`.

## Testing

- Install Xcode 7 via Self Service.
- `brew update && brew doctor`
- `brew upgrade node`
- `./setup.sh local`
- `gulp test` should pass.

## Review

- @sebworks 
- @jimmynotjim 
- @KimberlyMunoz 