### PR TITLE
Adds handlebars dependency explicitly

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "gulp-replace": "^0.5.3",
     "gulp-sourcemaps": "^1.5.2",
     "gulp-util": "^3.0.6",
+    "handlebars": "^4.0.2",
     "handlebars-loader": "^1.1.0",
     "imports-loader": "^0.6.4",
     "istanbul": "^0.3.13",


### PR DESCRIPTION
handlebars-loader needs handlebars to be added to the dependencies list as it won't handle the dependency itself.

## Additions

- Adds handlebars 4.0.2 to package.json.

## Testing

- `gulp build && gulp test` should run.

## Review

- @jimmynotjim 
- @sebworks 
- @KimberlyMunoz 
