### PR TITLE
Update ESLint config for version 1.5.1 compatibility

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -30,11 +30,14 @@ parser: espree
 env:
   browser: true
   node: true
+  commonjs: false
   worker: false
   amd: true
   mocha: false
   jasmine: false
+  jest: false
   phantomjs: false
+  protractor: false
   qunit: false
   jquery: false
   prototypejs: false
@@ -337,6 +340,9 @@ rules:
   # Disallows use of void operator.
   no-void: 2
 
+  # Disallow unnecessary concatenation of literals or template literals.
+  no-useless-concat: 2
+
   # Disallows use of configurable warning terms in comments, e. g. TODO.
   no-warning-comments:
     - 1
@@ -434,6 +440,9 @@ rules:
       - cb
       - next
 
+  # Disallow require() outside of the top-level module scope.
+  global-require: 2
+
   # Enforce error handling in callbacks.
   # Matches any string that contains err or Err (err, error, anyError, an_err).
   handle-callback-err:
@@ -468,6 +477,11 @@ rules:
   # Enforce spacing inside array brackets.
   array-bracket-spacing:
     - 1
+    - always
+
+  # Enforce spacing inside single line blocks.
+  block-spacing:
+    - 2
     - always
 
   # Enforce one true brace style.
@@ -525,6 +539,7 @@ rules:
     -
       min: 3
       max: 10
+      properties: never
       exceptions:
         - i
 
@@ -538,6 +553,11 @@ rules:
         var: 2
         let: 2
         const: 3
+
+  # Enforce whether double or single quotes should be used in JSX attributes.
+  jsx-quotes:
+    - 2
+    - prefer-single
 
   # Enforce spacing between keys and values in object literal properties.
   key-spacing:
@@ -613,6 +633,11 @@ rules:
   # Disallows use of the Object constructor.
   no-new-object: 2
 
+  # Disallow use of certain syntax in code.
+  no-restricted-syntax:
+    - 1
+    - WithStatement
+
   # Disallows space between function identifier and invocation.
   no-spaced-func: 2
 
@@ -662,12 +687,20 @@ rules:
   quote-props:
     - 1
     - as-needed
+    -
+      keywords: true
+      unnecessary: true
+      numbers: true
 
   # Specifies whether double or single quotes should be used.
   quotes:
     - 2
     - single
     - avoid-escape
+
+  # Require JSDoc comment.
+  require-jsdoc:
+    - 1
 
   # Require identifiers to match the provided regular expression.
   id-match:
@@ -693,6 +726,11 @@ rules:
 
   # Requires a space after certain keywords.
   space-after-keywords:
+    - 2
+    - always
+
+  # Requires a space before certain keywords.
+  space-before-keywords:
     - 2
     - always
 
@@ -773,6 +811,9 @@ rules:
   # Disallow modifying variables that are declared using const.
   no-const-assign: 2
 
+  # Disallow duplicate name in class members.
+  no-dupe-class-members: 2
+
   # Disallow to use this/super before super() calling in constructors.
   no-this-before-super: 2
 
@@ -785,6 +826,10 @@ rules:
     - 0
     - always
 
+  # Suggest using arrow functions as callbacks.
+  # Should not be enabled in ES3/5 environments.
+  prefer-arrow-callback: 0
+
   # Suggest using of const declaration for variables that are never modified.
   prefer-const: 1
 
@@ -795,6 +840,10 @@ rules:
   # Suggest using Reflect methods where applicable.
   # Should not be enabled in ES3/5 environments.
   prefer-reflect: 0
+
+  # Suggest using template literals instead of strings concatenation.
+  # Should not be enabled in ES3/5 environments.
+  prefer-template: 0
 
   # Disallow generator functions that do not have yield.
   require-yield: 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,14 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Wagtail CMS
 - Added `gulp test:a11y` accessibility testing using node-wcag.
 - Added node 4.1.0 engine requirement in `package.json`.
+- Added `commonjs`, `jest`, `protractor` environments.
+- Added new ESLint `no-useless-concat`, `global-require`,
+  `jsx-quotes`, `no-restricted-syntax`, `block-spacing`, `require-jsdoc`,
+  `space-before-keywords`, `no-dupe-class-members`, `prefer-arrow-callback`,
+  and `prefer-template` rules.
+- Added `properties` attribute of `id-length` rule.
+- Added `keywords`, `unnecessary`, and `numbers` attributes
+  to `quote-props` rules.
 
 ### Changed
 - Updated Video Code to make it usable on Events pages.
@@ -56,6 +64,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Updated mocha-jsdom from `0.3.0` to `1.0.0`.
 - Updated istanbul from `0.3.13` to `0.3.20`.
 - Updated TravisCI node version to `4.1.0`.
+- Updated ESLint configuration from `1.0.0` to `1.5.1`.
 
 ### Removed
 - Disables tests for landing page events, since we don't currently have events.

--- a/gulp/tasks/lint.js
+++ b/gulp/tasks/lint.js
@@ -6,13 +6,22 @@ var config = require( '../config' ).lint;
 var handleErrors = require( '../utils/handleErrors' );
 
 /**
- * Lints the gulpfile for errors
+ * Generic lint a script source.
+ * @param {string} src The path to the source JavaScript.
+ * @returns {Object} An output stream from gulp.
  */
-gulp.task( 'lint:build', function() {
-  return gulp.src( config.gulp )
+function _genericLint( src ) {
+  return gulp.src( src )
     .pipe( $.eslint() )
     .pipe( $.eslint.format() )
     .on( 'error', handleErrors );
+}
+
+/**
+ * Lints the gulpfile for errors
+ */
+gulp.task( 'lint:build', function() {
+  return _genericLint( config.gulp );
 } );
 
 
@@ -20,10 +29,7 @@ gulp.task( 'lint:build', function() {
  * Lints the source js files for errors
  */
 gulp.task( 'lint:scripts', function() {
-  return gulp.src( config.src )
-    .pipe( $.eslint() )
-    .pipe( $.eslint.format() )
-    .on( 'error', handleErrors );
+  return _genericLint( config.src );
 } );
 
 /**

--- a/src/static/js/modules/util/assign.js
+++ b/src/static/js/modules/util/assign.js
@@ -38,7 +38,7 @@ function assign( destination ) {
         var value = source[key];
         if ( _isPlainObject( value ) ) {
           assign( destination[key] = {}, value );
-        }else {
+        } else {
           destination[key] = source[key];
         }
       }

--- a/test/browser_tests/.eslintrc
+++ b/test/browser_tests/.eslintrc
@@ -1,6 +1,7 @@
 env:
   node: true
   jasmine: true
+  protractor: true
 globals:
   by: true
   browser: true
@@ -9,3 +10,4 @@ rules:
   no-process-env: 0
   no-unused-expressions: 0
   max-nested-callbacks: 0
+  require-jsdoc: 0

--- a/test/browser_tests/conf.js
+++ b/test/browser_tests/conf.js
@@ -129,8 +129,8 @@ function _copyParameters( params, capabilities ) { // eslint-disable-line comple
 }
 
 var config = {
-  baseUrl: environment.baseUrl,
-  framework: 'jasmine2',
+  baseUrl:         environment.baseUrl,
+  framework:       'jasmine2',
   jasmineNodeOpts: {
     defaultTimeoutInterval: 60000
   },

--- a/test/browser_tests/jenkins_conf.js
+++ b/test/browser_tests/jenkins_conf.js
@@ -1,5 +1,9 @@
 'use strict';
 
+var JasmineReporters = require( 'jasmine-reporters' );
+var JasmineSpecReporter = require( 'jasmine-spec-reporter' );
+var mkdirp = require( 'mkdirp' );
+
 exports.config = {
   framework:    'jasmine2',
   specs:        [ 'spec_suites/*.js' ],
@@ -14,10 +18,6 @@ exports.config = {
 
   onPrepare: function() {
     browser.ignoreSynchronization = true;
-
-    var JasmineReporters = require( 'jasmine-reporters' );
-    var mkdirp = require( 'mkdirp' );
-    var JasmineSpecReporter = require( 'jasmine-spec-reporter' );
 
     // add jasmine spec reporter
     jasmine.getEnv().addReporter(

--- a/test/browser_tests/spec_suites/footer.js
+++ b/test/browser_tests/spec_suites/footer.js
@@ -50,14 +50,12 @@ describe( 'The Footer Component', function() {
   } );
 
   it( 'should properly load in a browser', function() {
-      expect( _sharedObject.footer.isPresent() ).toBe( true );
-    }
-  );
+    expect( _sharedObject.footer.isPresent() ).toBe( true );
+  } );
 
   it( 'should include navList', function() {
-      expect( _sharedObject.navList.isPresent() ).toBe( true );
-    }
-  );
+    expect( _sharedObject.navList.isPresent() ).toBe( true );
+  } );
 
   it( 'should include links and links should be valid', function() {
     var _baseURL;
@@ -86,13 +84,11 @@ describe( 'The Footer Component', function() {
   } );
 
   it( 'should include post', function() {
-      expect( _sharedObject.post.isPresent() ).toBe( true );
-    }
-  );
+    expect( _sharedObject.post.isPresent() ).toBe( true );
+  } );
 
   it( 'should include officialWebsite', function() {
-      expect( _sharedObject.officialWebsite.isPresent() ).toBe( true );
-    }
-  );
+    expect( _sharedObject.officialWebsite.isPresent() ).toBe( true );
+  } );
 
 } );

--- a/test/browser_tests/spec_suites/header.js
+++ b/test/browser_tests/spec_suites/header.js
@@ -35,40 +35,34 @@ describe( 'The Header Component', function() {
   } );
 
   it( 'should load the stylesheet', function() {
-      var stylesheet = browser.baseUrl + '/static/css';
+    var stylesheet = browser.baseUrl + '/static/css';
 
-      if ( browser.name === 'internet explorer' && browser.version === '8' ) {
-        stylesheet += '/main.ie.css';
-      } else {
-        stylesheet += '/main.css';
-      }
-
-      expect( browser.styleSheets ).toContain( stylesheet );
+    if ( browser.name === 'internet explorer' && browser.version === '8' ) {
+      stylesheet += '/main.ie.css';
+    } else {
+      stylesheet += '/main.css';
     }
-  );
+
+    expect( browser.styleSheets ).toContain( stylesheet );
+  } );
 
   it( 'should properly load in a browser', function() {
-      expect( _sharedObject.header.isPresent() ).toBe( true );
-    }
-  );
+    expect( _sharedObject.header.isPresent() ).toBe( true );
+  } );
 
   it( 'should include the logo', function() {
-      expect( _sharedObject.logo.isPresent() ).toBe( true );
-    }
-  );
+    expect( _sharedObject.logo.isPresent() ).toBe( true );
+  } );
 
   it( 'should include navList', function() {
-      expect( _sharedObject.navList.isPresent() ).toBe( true );
-    }
-  );
+    expect( _sharedObject.navList.isPresent() ).toBe( true );
+  } );
 
   it( 'should include four Primary Nav Links', function() {
-      expect( _sharedObject.primaryLinks.count() ).toEqual( 4 );
-    }
-  );
+    expect( _sharedObject.primaryLinks.count() ).toEqual( 4 );
+  } );
 
   it( 'should include multiple Sub Nav Links', function() {
-      expect( _sharedObject.subLinks.count() ).toBeGreaterThan( 1 );
-    }
-  );
+    expect( _sharedObject.subLinks.count() ).toBeGreaterThan( 1 );
+  } );
 } );

--- a/test/browser_tests/spec_suites/subpage-accessibility-file-a-formal-accessibility-complaint-or-website-feedback.js
+++ b/test/browser_tests/spec_suites/subpage-accessibility-file-a-formal-accessibility-complaint-or-website-feedback.js
@@ -2,54 +2,56 @@
 
 var SubPage = require( '../page_objects/page_sub-pages.js' );
 
-describe( "The Accessibility Office's " +
-          'File A Formal Accessibility Complaint ' +
-          'Or Website Feedback Sub-Page', function() {
-  var page;
+describe(
+  "The Accessibility Office's File A Formal Accessibility Complaint " +
+  'Or Website Feedback Sub-Page',
+  function() {
+    var page;
 
-  beforeAll( function() {
-    page = new SubPage();
-    page.get( 'FileAFormalAccessibilityComplaintOrWebsiteFeedback' );
-  } );
+    beforeAll( function() {
+      page = new SubPage();
+      page.get( 'FileAFormalAccessibilityComplaintOrWebsiteFeedback' );
+    } );
 
-  it( 'should properly load in a browser', function() {
-    expect( page.pageTitle() )
-      .toBe( 'File a Formal Accessibility Complaint or Website Feedback' );
-  } );
+    it( 'should properly load in a browser', function() {
+      expect( page.pageTitle() )
+        .toBe( 'File a Formal Accessibility Complaint or Website Feedback' );
+    } );
 
-  it( 'should include page content', function() {
-    expect( page.pageContent.getText() ).toContain( 'accessible as possible' );
-  } );
+    it( 'should include page content', function() {
+      expect( page.pageContent.getText() )
+        .toContain( 'accessible as possible' );
+    } );
 
-  it( 'should NOT include related link', function() {
-    expect( page.relatedLink.isPresent() ).toBe( false );
-  } );
+    it( 'should NOT include related link', function() {
+      expect( page.relatedLink.isPresent() ).toBe( false );
+    } );
 
-  it( 'should include a form', function() {
-    expect( page.contentForm.isPresent() ).toBe( true );
-  } );
+    it( 'should include a form', function() {
+      expect( page.contentForm.isPresent() ).toBe( true );
+    } );
 
-  it( 'should include content markup', function() {
-    expect( page.contentMarkup.isPresent() ).toBe( true );
-  } );
+    it( 'should include content markup', function() {
+      expect( page.contentMarkup.isPresent() ).toBe( true );
+    } );
 
-  it( 'should NOT have subpages', function() {
-    expect( page.subpages.isPresent() ).toBe( false );
-  } );
+    it( 'should NOT have subpages', function() {
+      expect( page.subpages.isPresent() ).toBe( false );
+    } );
 
-  it( 'should NOT have related FAQ', function() {
-    expect( page.relatedFAQ.isPresent() ).toBe( false );
-  } );
+    it( 'should NOT have related FAQ', function() {
+      expect( page.relatedFAQ.isPresent() ).toBe( false );
+    } );
 
-  it( 'should NOT have tags', function() {
-    expect( page.contentTags.isPresent() ).toBe( false );
-  } );
+    it( 'should NOT have tags', function() {
+      expect( page.contentTags.isPresent() ).toBe( false );
+    } );
 
-  it( 'should have office contacts', function() {
-    expect( page.officeContact.isPresent() ).toBe( true );
-    expect( page.officeContactEmail.getText() )
-      .toBe( 'CFPB_Accessibility@consumerfinance.gov' );
-    expect( page.officeContactEmail.getAttribute( 'href' ) )
-      .toBe( 'mailto:CFPB_Accessibility@consumerfinance.gov' );
+    it( 'should have office contacts', function() {
+      expect( page.officeContact.isPresent() ).toBe( true );
+      expect( page.officeContactEmail.getText() )
+        .toBe( 'CFPB_Accessibility@consumerfinance.gov' );
+      expect( page.officeContactEmail.getAttribute( 'href' ) )
+        .toBe( 'mailto:CFPB_Accessibility@consumerfinance.gov' );
+    } );
   } );
-} );

--- a/test/browser_tests/spec_suites/subpage-accessibility-social-media-accessibility.js
+++ b/test/browser_tests/spec_suites/subpage-accessibility-social-media-accessibility.js
@@ -2,52 +2,53 @@
 
 var SubPage = require( '../page_objects/page_sub-pages.js' );
 
-describe( "The Accessibility Office's " +
-          'Social Media Accessibility Sub-Page', function() {
-  var page;
+describe(
+  "The Accessibility Office's Social Media Accessibility Sub-Page",
+  function() {
+    var page;
 
-  beforeAll( function() {
-    page = new SubPage();
-    page.get( 'SocialMediaAccessibility' );
-  } );
+    beforeAll( function() {
+      page = new SubPage();
+      page.get( 'SocialMediaAccessibility' );
+    } );
 
-  it( 'should properly load in a browser', function() {
-    expect( page.pageTitle() ).toBe( 'Social Media Accessibility' );
-  } );
+    it( 'should properly load in a browser', function() {
+      expect( page.pageTitle() ).toBe( 'Social Media Accessibility' );
+    } );
 
-  it( 'should include page content', function() {
-    expect( page.pageContent.getText() ).toContain( 'Twitter and Facebook' );
-  } );
+    it( 'should include page content', function() {
+      expect( page.pageContent.getText() ).toContain( 'Twitter and Facebook' );
+    } );
 
-  it( 'should NOT include related link', function() {
-    expect( page.relatedLink.isPresent() ).toBe( false );
-  } );
+    it( 'should NOT include related link', function() {
+      expect( page.relatedLink.isPresent() ).toBe( false );
+    } );
 
-  it( 'should NOT include a form', function() {
-    expect( page.contentForm.isPresent() ).toBe( false );
-  } );
+    it( 'should NOT include a form', function() {
+      expect( page.contentForm.isPresent() ).toBe( false );
+    } );
 
-  it( 'should include content markup', function() {
-    expect( page.contentMarkup.isPresent() ).toBe( true );
-  } );
+    it( 'should include content markup', function() {
+      expect( page.contentMarkup.isPresent() ).toBe( true );
+    } );
 
-  it( 'should NOT have subpages', function() {
-    expect( page.subpages.isPresent() ).toBe( false );
-  } );
+    it( 'should NOT have subpages', function() {
+      expect( page.subpages.isPresent() ).toBe( false );
+    } );
 
-  it( 'should NOT have related FAQ', function() {
-    expect( page.relatedFAQ.isPresent() ).toBe( false );
-  } );
+    it( 'should NOT have related FAQ', function() {
+      expect( page.relatedFAQ.isPresent() ).toBe( false );
+    } );
 
-  it( 'should NOT have tags', function() {
-    expect( page.contentTags.isPresent() ).toBe( false );
-  } );
+    it( 'should NOT have tags', function() {
+      expect( page.contentTags.isPresent() ).toBe( false );
+    } );
 
-  it( 'should have office contacts', function() {
-    expect( page.officeContact.isPresent() ).toBe( true );
-    expect( page.officeContactEmail.getText() )
-      .toBe( 'CFPB_Accessibility@consumerfinance.gov' );
-    expect( page.officeContactEmail.getAttribute( 'href' ) )
-      .toBe( 'mailto:CFPB_Accessibility@consumerfinance.gov' );
+    it( 'should have office contacts', function() {
+      expect( page.officeContact.isPresent() ).toBe( true );
+      expect( page.officeContactEmail.getText() )
+        .toBe( 'CFPB_Accessibility@consumerfinance.gov' );
+      expect( page.officeContactEmail.getAttribute( 'href' ) )
+        .toBe( 'mailto:CFPB_Accessibility@consumerfinance.gov' );
+    } );
   } );
-} );

--- a/test/browser_tests/spec_suites/subpage-accessibility-submit-an-accommodation-request.js
+++ b/test/browser_tests/spec_suites/subpage-accessibility-submit-an-accommodation-request.js
@@ -2,52 +2,53 @@
 
 var SubPage = require( '../page_objects/page_sub-pages.js' );
 
-describe( "The Accessibility Office's " +
-          'Submit An Accommodation Request Sub-Page', function() {
-  var page;
+describe(
+  "The Accessibility Office's Submit An Accommodation Request Sub-Page",
+  function() {
+    var page;
 
-  beforeAll( function() {
-    page = new SubPage();
-    page.get( 'SubmitAnAccommodationRequest' );
-  } );
+    beforeAll( function() {
+      page = new SubPage();
+      page.get( 'SubmitAnAccommodationRequest' );
+    } );
 
-  it( 'should properly load in a browser', function() {
-    expect( page.pageTitle() ).toBe( 'Submit an Accommodation Request' );
-  } );
+    it( 'should properly load in a browser', function() {
+      expect( page.pageTitle() ).toBe( 'Submit an Accommodation Request' );
+    } );
 
-  it( 'should include page content', function() {
-    expect( page.pageContent.getText() ).toContain( 'CFPB seeks to ensure' );
-  } );
+    it( 'should include page content', function() {
+      expect( page.pageContent.getText() ).toContain( 'CFPB seeks to ensure' );
+    } );
 
-  it( 'should NOT include related link', function() {
-    expect( page.relatedLink.isPresent() ).toBe( false );
-  } );
+    it( 'should NOT include related link', function() {
+      expect( page.relatedLink.isPresent() ).toBe( false );
+    } );
 
-  it( 'should NOT include a form', function() {
-    expect( page.contentForm.isPresent() ).toBe( false );
-  } );
+    it( 'should NOT include a form', function() {
+      expect( page.contentForm.isPresent() ).toBe( false );
+    } );
 
-  it( 'should include content markup', function() {
-    expect( page.contentMarkup.isPresent() ).toBe( true );
-  } );
+    it( 'should include content markup', function() {
+      expect( page.contentMarkup.isPresent() ).toBe( true );
+    } );
 
-  it( 'should NOT have subpages', function() {
-    expect( page.subpages.isPresent() ).toBe( false );
-  } );
+    it( 'should NOT have subpages', function() {
+      expect( page.subpages.isPresent() ).toBe( false );
+    } );
 
-  it( 'should NOT have related FAQ', function() {
-    expect( page.relatedFAQ.isPresent() ).toBe( false );
-  } );
+    it( 'should NOT have related FAQ', function() {
+      expect( page.relatedFAQ.isPresent() ).toBe( false );
+    } );
 
-  it( 'should NOT have tags', function() {
-    expect( page.contentTags.isPresent() ).toBe( false );
-  } );
+    it( 'should NOT have tags', function() {
+      expect( page.contentTags.isPresent() ).toBe( false );
+    } );
 
-  it( 'should have office contacts', function() {
-    expect( page.officeContact.isPresent() ).toBe( true );
-    expect( page.officeContactEmail.getText() )
-      .toBe( 'CFPB_Accessibility@consumerfinance.gov' );
-    expect( page.officeContactEmail.getAttribute( 'href' ) )
-      .toBe( 'mailto:CFPB_Accessibility@consumerfinance.gov' );
+    it( 'should have office contacts', function() {
+      expect( page.officeContact.isPresent() ).toBe( true );
+      expect( page.officeContactEmail.getText() )
+        .toBe( 'CFPB_Accessibility@consumerfinance.gov' );
+      expect( page.officeContactEmail.getAttribute( 'href' ) )
+        .toBe( 'mailto:CFPB_Accessibility@consumerfinance.gov' );
+    } );
   } );
-} );

--- a/test/browser_tests/spec_suites/subpage-civil-rights-diversity-policy.js
+++ b/test/browser_tests/spec_suites/subpage-civil-rights-diversity-policy.js
@@ -2,52 +2,53 @@
 
 var SubPage = require( '../page_objects/page_sub-pages.js' );
 
-describe( "The Office of Civil Rights' " +
-          'Diversity Policy Sub-Page', function() {
-  var page;
+describe(
+  'The Office of Civil Rights Diversity Policy Sub-Page',
+  function() {
+    var page;
 
-  beforeAll( function() {
-    page = new SubPage();
-    page.get( 'DiversityPolicy' );
-  } );
+    beforeAll( function() {
+      page = new SubPage();
+      page.get( 'DiversityPolicy' );
+    } );
 
-  it( 'should properly load in a browser', function() {
-    expect( page.pageTitle() ).toBe( 'Diversity & Inclusion Statement' );
-  } );
+    it( 'should properly load in a browser', function() {
+      expect( page.pageTitle() ).toBe( 'Diversity & Inclusion Statement' );
+    } );
 
-  it( 'should include page content', function() {
-    expect( page.pageContent.getText() ).toContain( 'Respect for diversity' );
-  } );
+    it( 'should include page content', function() {
+      expect( page.pageContent.getText() ).toContain( 'Respect for diversity' );
+    } );
 
-  it( 'should NOT include related link', function() {
-    expect( page.relatedLink.isPresent() ).toBe( false );
-  } );
+    it( 'should NOT include related link', function() {
+      expect( page.relatedLink.isPresent() ).toBe( false );
+    } );
 
-  it( 'should NOT include a form', function() {
-    expect( page.contentForm.isPresent() ).toBe( false );
-  } );
+    it( 'should NOT include a form', function() {
+      expect( page.contentForm.isPresent() ).toBe( false );
+    } );
 
-  it( 'should include content markup', function() {
-    expect( page.contentMarkup.isPresent() ).toBe( true );
-  } );
+    it( 'should include content markup', function() {
+      expect( page.contentMarkup.isPresent() ).toBe( true );
+    } );
 
-  it( 'should NOT have subpages', function() {
-    expect( page.subpages.isPresent() ).toBe( false );
-  } );
+    it( 'should NOT have subpages', function() {
+      expect( page.subpages.isPresent() ).toBe( false );
+    } );
 
-  it( 'should NOT have related FAQ', function() {
-    expect( page.relatedFAQ.isPresent() ).toBe( false );
-  } );
+    it( 'should NOT have related FAQ', function() {
+      expect( page.relatedFAQ.isPresent() ).toBe( false );
+    } );
 
-  it( 'should NOT have tags', function() {
-    expect( page.contentTags.isPresent() ).toBe( false );
-  } );
+    it( 'should NOT have tags', function() {
+      expect( page.contentTags.isPresent() ).toBe( false );
+    } );
 
-  it( 'should have office contacts', function() {
-    expect( page.officeContact.isPresent() ).toBe( true );
-    expect( page.officeContactEmail.getText() )
-      .toBe( 'CFPB_EEO@consumerfinance.gov' );
-    expect( page.officeContactEmail.getAttribute( 'href' ) )
-      .toBe( 'mailto:CFPB_EEO@consumerfinance.gov' );
+    it( 'should have office contacts', function() {
+      expect( page.officeContact.isPresent() ).toBe( true );
+      expect( page.officeContactEmail.getText() )
+        .toBe( 'CFPB_EEO@consumerfinance.gov' );
+      expect( page.officeContactEmail.getAttribute( 'href' ) )
+        .toBe( 'mailto:CFPB_EEO@consumerfinance.gov' );
+    } );
   } );
-} );

--- a/test/browser_tests/spec_suites/subpage-civil-rights-equal-opportunity-policy.js
+++ b/test/browser_tests/spec_suites/subpage-civil-rights-equal-opportunity-policy.js
@@ -2,52 +2,53 @@
 
 var SubPage = require( '../page_objects/page_sub-pages.js' );
 
-describe( "The Office of Civil Rights' " +
-          'Equal Employment Opportunity Policy Sub-Page', function() {
-  var page;
+describe(
+  'The Office of Civil Rights Equal Employment Opportunity Policy Sub-Page',
+  function() {
+    var page;
 
-  beforeAll( function() {
-    page = new SubPage();
-    page.get( 'EEOPolicyAndReports' );
-  } );
+    beforeAll( function() {
+      page = new SubPage();
+      page.get( 'EEOPolicyAndReports' );
+    } );
 
-  it( 'should properly load in a browser', function() {
-    expect( page.pageTitle() ).toBe( 'Equal Employment Opportunity Policy' );
-  } );
+    it( 'should properly load in a browser', function() {
+      expect( page.pageTitle() ).toBe( 'Equal Employment Opportunity Policy' );
+    } );
 
-  it( 'should NOT include page content', function() {
-    expect( page.pageContent.isPresent() ).toBe( false );
-  } );
+    it( 'should NOT include page content', function() {
+      expect( page.pageContent.isPresent() ).toBe( false );
+    } );
 
-  it( 'should include related links', function() {
-    expect( page.relatedLink.isPresent() ).toBe( true );
-  } );
+    it( 'should include related links', function() {
+      expect( page.relatedLink.isPresent() ).toBe( true );
+    } );
 
-  it( 'should NOT include a form', function() {
-    expect( page.contentForm.isPresent() ).toBe( false );
-  } );
+    it( 'should NOT include a form', function() {
+      expect( page.contentForm.isPresent() ).toBe( false );
+    } );
 
-  it( 'should include content markup', function() {
-    expect( page.contentMarkup.isPresent() ).toBe( true );
-  } );
+    it( 'should include content markup', function() {
+      expect( page.contentMarkup.isPresent() ).toBe( true );
+    } );
 
-  it( 'should NOT have subpages', function() {
-    expect( page.subpages.isPresent() ).toBe( false );
-  } );
+    it( 'should NOT have subpages', function() {
+      expect( page.subpages.isPresent() ).toBe( false );
+    } );
 
-  it( 'should NOT have related FAQ', function() {
-    expect( page.relatedFAQ.isPresent() ).toBe( false );
-  } );
+    it( 'should NOT have related FAQ', function() {
+      expect( page.relatedFAQ.isPresent() ).toBe( false );
+    } );
 
-  it( 'should have tags', function() {
-    expect( page.contentTags.isPresent() ).toBe( true );
-  } );
+    it( 'should have tags', function() {
+      expect( page.contentTags.isPresent() ).toBe( true );
+    } );
 
-  it( 'should have office contacts', function() {
-    expect( page.officeContact.isPresent() ).toBe( true );
-    expect( page.officeContactEmail.getText() )
-      .toBe( 'CFPB_EEO@consumerfinance.gov' );
-    expect( page.officeContactEmail.getAttribute( 'href' ) )
-      .toBe( 'mailto:CFPB_EEO@consumerfinance.gov' );
+    it( 'should have office contacts', function() {
+      expect( page.officeContact.isPresent() ).toBe( true );
+      expect( page.officeContactEmail.getText() )
+        .toBe( 'CFPB_EEO@consumerfinance.gov' );
+      expect( page.officeContactEmail.getAttribute( 'href' ) )
+        .toBe( 'mailto:CFPB_EEO@consumerfinance.gov' );
+    } );
   } );
-} );

--- a/test/browser_tests/spec_suites/subpage-civil-rights-no-fear-act.js
+++ b/test/browser_tests/spec_suites/subpage-civil-rights-no-fear-act.js
@@ -2,52 +2,53 @@
 
 var SubPage = require( '../page_objects/page_sub-pages.js' );
 
-describe( "The Office of Civil Rights' " +
-          'No FEAR Act Sub-Page', function() {
-  var page;
+describe(
+  'The Office of Civil Rights No FEAR Act Sub-Page',
+  function() {
+    var page;
 
-  beforeAll( function() {
-    page = new SubPage();
-    page.get( 'NoFEARAct' );
-  } );
+    beforeAll( function() {
+      page = new SubPage();
+      page.get( 'NoFEARAct' );
+    } );
 
-  it( 'should properly load in a browser', function() {
-    expect( page.pageTitle() ).toBe( 'No FEAR Act' );
-  } );
+    it( 'should properly load in a browser', function() {
+      expect( page.pageTitle() ).toBe( 'No FEAR Act' );
+    } );
 
-  it( 'should include page content', function() {
-    expect( page.pageContent.getText() ).toContain( 'The No FEAR Act' );
-  } );
+    it( 'should include page content', function() {
+      expect( page.pageContent.getText() ).toContain( 'The No FEAR Act' );
+    } );
 
-  it( 'should NOT include related link', function() {
-    expect( page.relatedLink.isPresent() ).toBe( false );
-  } );
+    it( 'should NOT include related link', function() {
+      expect( page.relatedLink.isPresent() ).toBe( false );
+    } );
 
-  it( 'should NOT include a form', function() {
-    expect( page.contentForm.isPresent() ).toBe( false );
-  } );
+    it( 'should NOT include a form', function() {
+      expect( page.contentForm.isPresent() ).toBe( false );
+    } );
 
-  it( 'should include content markup', function() {
-    expect( page.contentMarkup.isPresent() ).toBe( true );
-  } );
+    it( 'should include content markup', function() {
+      expect( page.contentMarkup.isPresent() ).toBe( true );
+    } );
 
-  it( 'should NOT have subpages', function() {
-    expect( page.subpages.isPresent() ).toBe( false );
-  } );
+    it( 'should NOT have subpages', function() {
+      expect( page.subpages.isPresent() ).toBe( false );
+    } );
 
-  it( 'should NOT have related FAQ', function() {
-    expect( page.relatedFAQ.isPresent() ).toBe( false );
-  } );
+    it( 'should NOT have related FAQ', function() {
+      expect( page.relatedFAQ.isPresent() ).toBe( false );
+    } );
 
-  it( 'should NOT have tags', function() {
-    expect( page.contentTags.isPresent() ).toBe( false );
-  } );
+    it( 'should NOT have tags', function() {
+      expect( page.contentTags.isPresent() ).toBe( false );
+    } );
 
-  it( 'should have office contacts', function() {
-    expect( page.officeContact.isPresent() ).toBe( true );
-    expect( page.officeContactEmail.getText() )
-      .toBe( 'CFPB_EEO@consumerfinance.gov' );
-    expect( page.officeContactEmail.getAttribute( 'href' ) )
-      .toBe( 'mailto:CFPB_EEO@consumerfinance.gov' );
+    it( 'should have office contacts', function() {
+      expect( page.officeContact.isPresent() ).toBe( true );
+      expect( page.officeContactEmail.getText() )
+        .toBe( 'CFPB_EEO@consumerfinance.gov' );
+      expect( page.officeContactEmail.getAttribute( 'href' ) )
+        .toBe( 'mailto:CFPB_EEO@consumerfinance.gov' );
+    } );
   } );
-} );

--- a/test/browser_tests/spec_suites/subpage-civil-rights-raise-an-eeo-issue.js
+++ b/test/browser_tests/spec_suites/subpage-civil-rights-raise-an-eeo-issue.js
@@ -2,54 +2,55 @@
 
 var SubPage = require( '../page_objects/page_sub-pages.js' );
 
-describe( "The Office of Civil Rights' " +
-          'Raise an EEO Issue Sub-Page', function() {
-  var page;
+describe(
+  'The Office of Civil Rights Raise an EEO Issue Sub-Page',
+  function() {
+    var page;
 
-  beforeAll( function() {
-    page = new SubPage();
-    page.get( 'RaiseAnEEOIssue' );
-  } );
+    beforeAll( function() {
+      page = new SubPage();
+      page.get( 'RaiseAnEEOIssue' );
+    } );
 
-  it( 'should properly load in a browser', function() {
-    expect( page.pageTitle() ).toBe( 'Raise an EEO Issue' );
-  } );
+    it( 'should properly load in a browser', function() {
+      expect( page.pageTitle() ).toBe( 'Raise an EEO Issue' );
+    } );
 
-  it( 'should include page content', function() {
-    expect( page.pageContent.getText() ).toContain(
-      'If you believe you have been discriminated'
-    );
-  } );
+    it( 'should include page content', function() {
+      expect( page.pageContent.getText() ).toContain(
+        'If you believe you have been discriminated'
+      );
+    } );
 
-  it( 'should NOT include related links', function() {
-    expect( page.relatedLink.isPresent() ).toBe( false );
-  } );
+    it( 'should NOT include related links', function() {
+      expect( page.relatedLink.isPresent() ).toBe( false );
+    } );
 
-  it( 'should include a form', function() {
-    expect( page.contentForm.isPresent() ).toBe( true );
-  } );
+    it( 'should include a form', function() {
+      expect( page.contentForm.isPresent() ).toBe( true );
+    } );
 
-  it( 'should include content markup', function() {
-    expect( page.contentMarkup.isPresent() ).toBe( true );
-  } );
+    it( 'should include content markup', function() {
+      expect( page.contentMarkup.isPresent() ).toBe( true );
+    } );
 
-  it( 'should NOT have subpages', function() {
-    expect( page.subpages.isPresent() ).toBe( false );
-  } );
+    it( 'should NOT have subpages', function() {
+      expect( page.subpages.isPresent() ).toBe( false );
+    } );
 
-  it( 'should NOT have related FAQ', function() {
-    expect( page.relatedFAQ.isPresent() ).toBe( false );
-  } );
+    it( 'should NOT have related FAQ', function() {
+      expect( page.relatedFAQ.isPresent() ).toBe( false );
+    } );
 
-  it( 'should NOT have tags', function() {
-    expect( page.contentTags.isPresent() ).toBe( false );
-  } );
+    it( 'should NOT have tags', function() {
+      expect( page.contentTags.isPresent() ).toBe( false );
+    } );
 
-  it( 'should have office contacts', function() {
-    expect( page.officeContact.isPresent() ).toBe( true );
-    expect( page.officeContactEmail.getText() )
-      .toBe( 'CFPB_EEO@consumerfinance.gov' );
-    expect( page.officeContactEmail.getAttribute( 'href' ) )
-      .toBe( 'mailto:CFPB_EEO@consumerfinance.gov' );
+    it( 'should have office contacts', function() {
+      expect( page.officeContact.isPresent() ).toBe( true );
+      expect( page.officeContactEmail.getText() )
+        .toBe( 'CFPB_EEO@consumerfinance.gov' );
+      expect( page.officeContactEmail.getAttribute( 'href' ) )
+        .toBe( 'mailto:CFPB_EEO@consumerfinance.gov' );
+    } );
   } );
-} );

--- a/test/browser_tests/spec_suites/subpage-civil-rights-reasonable-accomodation-request-policy.js
+++ b/test/browser_tests/spec_suites/subpage-civil-rights-reasonable-accomodation-request-policy.js
@@ -2,55 +2,56 @@
 
 var SubPage = require( '../page_objects/page_sub-pages.js' );
 
-describe( "The Office of Civil Rights' " +
-          'Reasonable Accomodation Request Policy Sub-Page', function() {
-  var page;
+describe(
+  "The Office of Civil Rights' Reasonable Accomodation Request Policy Sub-Page",
+  function() {
+    var page;
 
-  beforeAll( function() {
-    page = new SubPage();
-    page.get( 'ReasonableAccommodationRequestPolicy' );
-  } );
+    beforeAll( function() {
+      page = new SubPage();
+      page.get( 'ReasonableAccommodationRequestPolicy' );
+    } );
 
-  it( 'should properly load in a browser', function() {
-    expect( page.pageTitle() )
-      .toBe( 'Reasonable Accommodation Request Policy' );
-  } );
+    it( 'should properly load in a browser', function() {
+      expect( page.pageTitle() )
+        .toBe( 'Reasonable Accommodation Request Policy' );
+    } );
 
-  it( 'should include page content', function() {
-    expect( page.pageContent.getText() ).toContain(
-      'ensure equal access and employment opportunities'
-    );
-  } );
+    it( 'should include page content', function() {
+      expect( page.pageContent.getText() ).toContain(
+        'ensure equal access and employment opportunities'
+      );
+    } );
 
-  it( 'should include related links', function() {
-    expect( page.relatedLink.isPresent() ).toBe( true );
-  } );
+    it( 'should include related links', function() {
+      expect( page.relatedLink.isPresent() ).toBe( true );
+    } );
 
-  it( 'should NOT include a form', function() {
-    expect( page.contentForm.isPresent() ).toBe( false );
-  } );
+    it( 'should NOT include a form', function() {
+      expect( page.contentForm.isPresent() ).toBe( false );
+    } );
 
-  it( 'should include content markup', function() {
-    expect( page.contentMarkup.isPresent() ).toBe( true );
-  } );
+    it( 'should include content markup', function() {
+      expect( page.contentMarkup.isPresent() ).toBe( true );
+    } );
 
-  it( 'should NOT have subpages', function() {
-    expect( page.subpages.isPresent() ).toBe( false );
-  } );
+    it( 'should NOT have subpages', function() {
+      expect( page.subpages.isPresent() ).toBe( false );
+    } );
 
-  it( 'should NOT have related FAQ', function() {
-    expect( page.relatedFAQ.isPresent() ).toBe( false );
-  } );
+    it( 'should NOT have related FAQ', function() {
+      expect( page.relatedFAQ.isPresent() ).toBe( false );
+    } );
 
-  it( 'should NOT have tags', function() {
-    expect( page.contentTags.isPresent() ).toBe( false );
-  } );
+    it( 'should NOT have tags', function() {
+      expect( page.contentTags.isPresent() ).toBe( false );
+    } );
 
-  it( 'should have office contacts', function() {
-    expect( page.officeContact.isPresent() ).toBe( true );
-    expect( page.officeContactEmail.getText() )
-      .toBe( 'CFPB_EEO@consumerfinance.gov' );
-    expect( page.officeContactEmail.getAttribute( 'href' ) )
-      .toBe( 'mailto:CFPB_EEO@consumerfinance.gov' );
+    it( 'should have office contacts', function() {
+      expect( page.officeContact.isPresent() ).toBe( true );
+      expect( page.officeContactEmail.getText() )
+        .toBe( 'CFPB_EEO@consumerfinance.gov' );
+      expect( page.officeContactEmail.getAttribute( 'href' ) )
+        .toBe( 'mailto:CFPB_EEO@consumerfinance.gov' );
+    } );
   } );
-} );

--- a/test/browser_tests/spec_suites/subpage-civil-rights-whistleblowers.js
+++ b/test/browser_tests/spec_suites/subpage-civil-rights-whistleblowers.js
@@ -2,54 +2,55 @@
 
 var SubPage = require( '../page_objects/page_sub-pages.js' );
 
-describe( "The Office of Civil Rights' " +
-          'Whistleblowers Sub-Page', function() {
-  var page;
+describe(
+  "The Office of Civil Rights' Whistleblowers Sub-Page",
+  function() {
+    var page;
 
-  beforeAll( function() {
-    page = new SubPage();
-    page.get( 'Whistleblowers' );
-  } );
+    beforeAll( function() {
+      page = new SubPage();
+      page.get( 'Whistleblowers' );
+    } );
 
-  it( 'should properly load in a browser', function() {
-    expect( page.pageTitle() ).toBe( 'Whistleblowers' );
-  } );
+    it( 'should properly load in a browser', function() {
+      expect( page.pageTitle() ).toBe( 'Whistleblowers' );
+    } );
 
-  it( 'should include page content', function() {
-    expect( page.pageContent.getText() ).toContain(
-      'potential wrongdoing by CFPB'
-    );
-  } );
+    it( 'should include page content', function() {
+      expect( page.pageContent.getText() ).toContain(
+        'potential wrongdoing by CFPB'
+      );
+    } );
 
-  it( 'should include related links', function() {
-    expect( page.relatedLink.isPresent() ).toBe( true );
-  } );
+    it( 'should include related links', function() {
+      expect( page.relatedLink.isPresent() ).toBe( true );
+    } );
 
-  it( 'should NOT include a form', function() {
-    expect( page.contentForm.isPresent() ).toBe( false );
-  } );
+    it( 'should NOT include a form', function() {
+      expect( page.contentForm.isPresent() ).toBe( false );
+    } );
 
-  it( 'should include content markup', function() {
-    expect( page.contentMarkup.isPresent() ).toBe( true );
-  } );
+    it( 'should include content markup', function() {
+      expect( page.contentMarkup.isPresent() ).toBe( true );
+    } );
 
-  it( 'should NOT have subpages', function() {
-    expect( page.subpages.isPresent() ).toBe( false );
-  } );
+    it( 'should NOT have subpages', function() {
+      expect( page.subpages.isPresent() ).toBe( false );
+    } );
 
-  it( 'should NOT have related FAQ', function() {
-    expect( page.relatedFAQ.isPresent() ).toBe( false );
-  } );
+    it( 'should NOT have related FAQ', function() {
+      expect( page.relatedFAQ.isPresent() ).toBe( false );
+    } );
 
-  it( 'should NOT have tags', function() {
-    expect( page.contentTags.isPresent() ).toBe( false );
-  } );
+    it( 'should NOT have tags', function() {
+      expect( page.contentTags.isPresent() ).toBe( false );
+    } );
 
-  it( 'should have office contacts', function() {
-    expect( page.officeContact.isPresent() ).toBe( true );
-    expect( page.officeContactEmail.getText() )
-      .toBe( 'CFPB_EEO@consumerfinance.gov' );
-    expect( page.officeContactEmail.getAttribute( 'href' ) )
-      .toBe( 'mailto:CFPB_EEO@consumerfinance.gov' );
+    it( 'should have office contacts', function() {
+      expect( page.officeContact.isPresent() ).toBe( true );
+      expect( page.officeContactEmail.getText() )
+        .toBe( 'CFPB_EEO@consumerfinance.gov' );
+      expect( page.officeContactEmail.getAttribute( 'href' ) )
+        .toBe( 'mailto:CFPB_EEO@consumerfinance.gov' );
+    } );
   } );
-} );

--- a/test/unit_tests/.eslintrc
+++ b/test/unit_tests/.eslintrc
@@ -4,3 +4,5 @@ env:
 rules:
   no-unused-expressions: 0
   dot-notation: 0
+  require-jsdoc: 0
+  global-require: 0

--- a/test/unit_tests/modules/cf_notifier-spec.js
+++ b/test/unit_tests/modules/cf_notifier-spec.js
@@ -1,4 +1,5 @@
 'use strict';
+
 var chai = require( 'chai' );
 require( 'sinon' );
 var expect = chai.expect;

--- a/test/unit_tests/modules/focus-target-spec.js
+++ b/test/unit_tests/modules/focus-target-spec.js
@@ -1,4 +1,5 @@
 'use strict';
+
 var chai = require( 'chai' );
 var sinon = require( 'sinon' );
 var expect = chai.expect;

--- a/test/unit_tests/modules/footer-button-spec.js
+++ b/test/unit_tests/modules/footer-button-spec.js
@@ -1,4 +1,5 @@
 'use strict';
+
 var chai = require( 'chai' );
 var sinon = require( 'sinon' );
 var expect = chai.expect;

--- a/test/unit_tests/modules/nav-primary-spec.js
+++ b/test/unit_tests/modules/nav-primary-spec.js
@@ -1,4 +1,5 @@
 'use strict';
+
 var chai = require( 'chai' );
 var sinon = require( 'sinon' );
 var expect = chai.expect;

--- a/test/unit_tests/modules/util/aria-state-spec.js
+++ b/test/unit_tests/modules/util/aria-state-spec.js
@@ -35,16 +35,16 @@ describe( 'ARIA state', function() {
 
   it( 'should define the correct ARIA state property and attribute',
     function() {
-    ariaState.define( 'invalid', element, obj );
-    expect( obj.hasOwnProperty( 'isInvalid' ) ).to.be.true;
-    expect( element.getAttribute( 'aria-invalid' ) === 'false' ).to.be.true;
+      ariaState.define( 'invalid', element, obj );
+      expect( obj.hasOwnProperty( 'isInvalid' ) ).to.be.true;
+      expect( element.getAttribute( 'aria-invalid' ) === 'false' ).to.be.true;
 
-    this.isGrabbed = true;
-    ariaState.define( 'grabbed', element, this );
-    expect( this.hasOwnProperty( 'isGrabbed' ) ).to.be.true;
-    expect( element.getAttribute( 'aria-grabbed' ) === 'true' ).to.be.true;
-    delete this.isGrabbed;
-  } );
+      this.isGrabbed = true;
+      ariaState.define( 'grabbed', element, this );
+      expect( this.hasOwnProperty( 'isGrabbed' ) ).to.be.true;
+      expect( element.getAttribute( 'aria-grabbed' ) === 'true' ).to.be.true;
+      delete this.isGrabbed;
+    } );
 
   it( 'should change the ARIA state after state property changes', function() {
     var state = ariaState.create( 'hidden', element );

--- a/test/unit_tests/modules/util/breakpoint-state-spec.js
+++ b/test/unit_tests/modules/util/breakpoint-state-spec.js
@@ -31,31 +31,34 @@ describe( 'getBreakpointState', function() {
     .to.be.true;
   } );
 
-  it( 'should return an object with one ' +
-      'state property set to true', function() {
-    var trueValueCount = 0;
+  it(
+    'should return an object with one state property set to true',
+    function() {
 
-    breakpointState = getBreakpointState();
-    for ( var stateKey in breakpointState ) { // eslint-disable-line guard-for-in, no-inline-comments, max-len
-      if ( breakpointState[stateKey] === true ) trueValueCount++;
-    }
+      var trueValueCount = 0;
 
-    expect( trueValueCount === 1 ).to.be.true;
-  } );
+      breakpointState = getBreakpointState();
+      for ( var stateKey in breakpointState ) { // eslint-disable-line guard-for-in, no-inline-comments, max-len
+        if ( breakpointState[stateKey] === true ) trueValueCount++;
+      }
 
-  it( 'should set the correct state' +
-      'property when passed width', function() {
-    var width;
-    var breakpointStateKey;
+      expect( trueValueCount === 1 ).to.be.true;
+    } );
 
-    for ( var rangeKey in breakpointConfig ) { // eslint-disable-line guard-for-in, no-inline-comments, max-len
-      width = breakpointConfig[rangeKey].max || breakpointConfig[rangeKey].min;
-      breakpointState = getBreakpointState( width );
-      breakpointStateKey =
-      'is' + rangeKey.charAt( 0 ).toUpperCase() + rangeKey.slice( 1 );
+  it(
+    'should set the correct state property when passed width',
+    function() {
+      var width;
+      var breakpointStateKey;
 
-      expect( breakpointState[breakpointStateKey] ).to.be.true;
-    }
-  } );
+      for ( var rangeKey in breakpointConfig ) { // eslint-disable-line guard-for-in, no-inline-comments, max-len
+        width = breakpointConfig[rangeKey].max || breakpointConfig[rangeKey].min;
+        breakpointState = getBreakpointState( width );
+        breakpointStateKey =
+        'is' + rangeKey.charAt( 0 ).toUpperCase() + rangeKey.slice( 1 );
+
+        expect( breakpointState[breakpointStateKey] ).to.be.true;
+      }
+    } );
 
 } );

--- a/test/unit_tests/modules/util/expanded-state-spec.js
+++ b/test/unit_tests/modules/util/expanded-state-spec.js
@@ -1,4 +1,5 @@
 'use strict';
+
 var chai = require( 'chai' );
 var sinon = require( 'sinon' );
 var expect = chai.expect;


### PR DESCRIPTION
Update ESLint config for  version 1.5.1 compatibility.
Fixes ESLint errors that were breaking on Travis.

## Additions

- Added additional environments and rules for version 1.5.1 ESLint compatibility.

## Changes

- Fixes linting errors:
  - Formats tests to fix indenting errors.
  - Moves requires to top of files in tests.
- Moves gulp linting implementation to a helper function.

## Testing

- `gulp build && gulp lint` should have no errors

## Review

- @jimmynotjim 
- @sebworks 
- @KimberlyMunoz 

## Todos

- ~~I have a PR open with gulp-eslint for updating that to [1.5.1](https://github.com/adametry/gulp-eslint/pull/96), but this doesn't appear to add any breaking changes so should be able to go in before that is merged.~~ Not necessary, the caret versioning actually already brings in `1.5.1` without an updated needed in gulp-eslint.