### PR TITLE
Removed Ombudsman from nav for beta freeze

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 
 ### Removed
 - Disables tests for landing page events, since we don't currently have events.
+- Removed Ombudsman from nav for beta freeze.
 
 ### Fixed
 - Fixed issue with logic displaying the Event summary state.

--- a/src/_includes/templates/nav/_vars-primary-nav.html
+++ b/src/_includes/templates/nav/_vars-primary-nav.html
@@ -22,8 +22,7 @@
             ('/budget/', 'budget', 'Budget and Strategy'),
             ('/offices/payments-to-harmed-consumers/',
              'payments-to-harmed-consumers',
-             'Payments to Harmed Consumers'),
-            ('/offices/cfpb-ombudsman/', 'cfpb-ombudsman', 'CFPB Ombudsman')
+             'Payments to Harmed Consumers')
         ),
         (
             ('/blog/', 'blog', 'Blog'),


### PR DESCRIPTION
The Ombudsman's office has requested that they only appear in the site footer and would like to be removed from the mega menu.