### PR TITLE
Fix setup.sh to actually use the passed argument now

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - New way to run the server documented in the INSTALL.MD
 - New way to define url routing, no longer automatically set by file path
 - Fixed heading structure throughout website
+- Fixed setup.sh to use argument correctly
 
 ## 3.0.0-2.3.0 - 2015-08-27
 

--- a/setup.sh
+++ b/setup.sh
@@ -77,5 +77,5 @@ build(){
 
 init
 clean
-install
+install $1
 build


### PR DESCRIPTION
When the function `install()` is actually called, it has to be passed arguments that it uses.

@kave 