### PR TITLE
Add tox unit tests to gulp flow

### DIFF
--- a/.env_SAMPLE
+++ b/.env_SAMPLE
@@ -65,10 +65,12 @@ export WORDPRESS=http://www.consumerfinance.gov
 #export HTTP_HOST=localhost
 #export HTTP_PORT=8000
 #export SELENIUM_URL=http://localhost:4444/wd/hub
-#export TOXENV=py27
 
 # Web service ID for accessibility testing via http://achecker.ca site.
 #export ACHECKER_ID=<web_service_id>
+
+# Tox Django unit testing Python version.
+export TOXENV=py27
 
 #################################################################
 # SAUCE LABS (optional) - for handling cloud testing of the site.

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ install:
   # Project configuration requirements.
   - pip install virtualenv virtualenvwrapper
   - pip install autoenv
-  - pip install tox
   - git clone https://github.com/cfpb/django-sheerlike
   - pip install -e django-sheerlike
   - pip install -r django-sheerlike/requirements.txt
@@ -34,7 +33,6 @@ script:
   - gulp lint
   - gulp test:unit
   - gulp test:coveralls
-  - tox
 
 env:
   - TOXENV=py27

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Added `/organisms/` and `/molecules/` directories to includes directory.
 - Added `gulp test:perf` task to test for performance rules.
 - MYSQL backend to project settings & a database creation script
+- Added `gulp test:unit:server` for running Django unit tests via gulp.
 
 ### Changed
 - Updated Video Code to make it usable on Events pages.
@@ -103,7 +104,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
   to individual mode with `mode: minimum` option set.
 - Changes `quote-props` rule attribute to `consistent-as-needed`.
 - Added href URL to primary nav top-level menu link.
-- Changed DB backend from sqlite ==> MYSQL  
+- Changed DB backend from sqlite ==> MYSQL.
 
 ### Removed
 - Disables tests for landing page events, since we don't currently have events.
@@ -127,6 +128,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Fixed heading structure throughout website
 - Fixed setup.sh to use argument correctly
 - Fixed title for Small & Minority Businesses
+
 
 ## 3.0.0-2.3.0 - 2015-08-27
 

--- a/TEST.md
+++ b/TEST.md
@@ -137,11 +137,7 @@ Enjoy! :relieved:
 
 # Template Macro Tests
 
-Test the Jinja2 templates.
-
-## Running MacroPolo Tests
-
-From within the root project directory run `gulp test:unit:macro`.
+Test the Jinja2 templates. From within the root project directory run `gulp test:unit:macro`.
 
 ## Writing Tests
 
@@ -157,6 +153,13 @@ The audit will run against [sitespeed.io performance rules](https://www.sitespee
 and crawl the website from the homepage.
 You can adjust the settings to skip rules and change the crawling depth
 by editing `/gulp/tasks/test.js`.
+
+# Django Server Unit Tests
+
+To run the server unit tests using Tox,
+make sure the `TOXENV` variable is set in your `.env` file and
+run `gulp test:unit:server` from the command-line in the project root.
+
 
 # Accessibility Testing
 

--- a/gulp/tasks/test.js
+++ b/gulp/tasks/test.js
@@ -45,6 +45,17 @@ gulp.task( 'test:unit:macro', function( cb ) {
   );
 } );
 
+gulp.task( 'test:unit:server', function() {
+  spawn(
+    'tox',
+    [ 'cfgov/core/tests' ],
+    { stdio: 'inherit' }
+  )
+    .once( 'close', function() {
+      $.util.log( 'Tox tests done!' );
+    } );
+} );
+
 /**
  * Add a command-line flag to a list of Protractor parameters, if present.
  * @param {object} protractorParams Parameters to pass to Protractor binary.
@@ -214,6 +225,7 @@ gulp.task( 'test',
 gulp.task( 'test:unit',
   [
     'test:unit:scripts',
-    'test:unit:macro'
+    'test:unit:macro',
+    'test:unit:server'
   ]
 );

--- a/setup.sh
+++ b/setup.sh
@@ -54,11 +54,14 @@ install(){
 
   # Update test dependencies.
 
-  # Protractor.
+  # Protractor - JavaScript acceptance testing.
   ./$NODE_DIR/protractor/bin/webdriver-manager update
 
-  # Macro Polo.
+  # Macro Polo - Jinja template unit testing.
   pip install -r ./test/macro_tests/requirements.txt
+
+  # Tox - Django server unit testing.
+  pip install tox
 
   # Django Server
   if [ -z "$1" ]; then


### PR DESCRIPTION
Short description explaining the high-level reason for the pull request

## Additions

- Added `gulp test:unit:server` for running Django unit tests via gulp.

## Testing

- Uncomment `TOXENV` in `.env`.
- `./setup.sh local && gulp test --sauce=false` or `./setup.sh local && gulp test` should pass.

## Review

- @sebworks 
- @KimberlyMunoz 
- @jimmynotjim 
- @kurtw 
