### PR TITLE
Adds block__flush, organizes block CSS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Backend for Staging vs Production publishing
 - Django template tags
 - A temporary blog page template for testing
+- Added `block__flush` to cf-enhancements to remove margin from all sides.
 
 ### Changed
 - Updated Video Code to make it usable on Events pages.

--- a/cfgov/v1/jinja2/v1/careers/_template-careers-related-links.html
+++ b/cfgov/v1/jinja2/v1/careers/_template-careers-related-links.html
@@ -2,9 +2,7 @@
                 block__bg
                 block__border-top
                 block__border-right
-                block__flush-top
-                block__flush-bottom
-                block__flush-sides">
+                block__flush">
             {%- import 'related-links.html' as related_links -%}
             {{- related_links.render([
                 [ '/blog/',

--- a/cfgov/v1/jinja2/v1/careers/index.html
+++ b/cfgov/v1/jinja2/v1/careers/index.html
@@ -50,7 +50,10 @@
                     </p>
                 </div>
             </section>
-            <aside class="content-l_col content-l_col-1-3 block block__flush-top"
+            <aside class="content-l_col
+                          content-l_col-1-3
+                          block
+                          block__flush-top"
                    data-qa-hook="openings-section">
                 <h2 class="h3">Newest Openings</h2>
                 <ul class="list list__unstyled">

--- a/cfgov/v1/jinja2/v1/the-bureau/index.html
+++ b/cfgov/v1/jinja2/v1/the-bureau/index.html
@@ -121,9 +121,7 @@
     <section class="block
                     block__bg
                     block__border
-                    block__flush-sides
-                    block__flush-top
-                    block__flush-bottom"
+                    block__flush"
              data-qa-hook="bureau-core-functions">
         <h2>Our core functions</h2>
         <p>Congress created the CFPB to create a single point of accountability for enforcing

--- a/cfgov/v1/preprocessed/css/cf-enhancements.less
+++ b/cfgov/v1/preprocessed/css/cf-enhancements.less
@@ -1229,10 +1229,40 @@ tbody {
         - .block.block__border-right
       notes:
         - "Adds right border to .block."
+    - name: Flush modifier
+      markup: |
+        <main class="content content__1-3" role="main">
+            <div class="content_wrapper">
+                <aside class="content_sidebar">
+                    Section navigation
+                </aside>
+                <section class="content_main">
+                    Main content...
+                    <aside class="block block__flush">
+                        Content block with no margins.
+                    </aside>
+                </section>
+            </div>
+        </main>
+      codenotes:
+        - .block.block__flush
+      notes:
+        - "Removes the side, top, and bottom margin from .block."
+    - name: Background modifier
+      markup: |
+        Main content...
+        <div class="block block__bg">
+            Content block with a background
+        </div>
+      codenotes:
+        - .block.block__bg
+      notes:
+        - "Adds a background color and padding to .block."
+        - "Setup to have 30px padding on top and 60px on bottom, in ems."
   tags:
     - cf-layout
 */
-@block__border: #BABBBD; // Gray 50%
+@block__border: @gray-50;
 .block {
     &__border {
         border: 1px solid @block__border;
@@ -1245,7 +1275,30 @@ tbody {
     &__border-right {
         border-right: 1px solid @block__border;
     }
+
+    &__flush {
+        margin-top: 0 !important;
+        margin-bottom: 0 !important;
+        margin-right: -(@grid_gutter-width / 2);
+        margin-left: -(@grid_gutter-width / 2);
+        .respond-to-min(600px, {
+            margin-right: -@grid_gutter-width;
+            margin-left: -@grid_gutter-width;
+        });
+    }
+
+    &__bg {
+        padding: unit(@grid_gutter-width / @base-font-size-px, em)
+                 unit((@grid_gutter-width / 2) / @base-font-size-px, em);
+        padding-bottom: unit((@grid_gutter-width * 2) / @base-font-size-px, em);
+        background: @block__bg;
+        .respond-to-min(600px, {
+            padding: unit(45 / @base-font-size-px, em)
+                     unit(@grid_gutter-width / @base-font-size-px, em);
+        });
+    }
 }
+
 
 /* topdoc
   name: Block
@@ -1540,21 +1593,6 @@ dd {
 ul:last-child,
 .list__links .list_item:last-child {
     margin-bottom: 0;
-}
-
-
-/* topdoc
-  name: Update block__bg padding
-  family: cf-layout
-  notes:
-    - "Updates the padding in block__bg to match feedback from Justin James"
-  tags:
-    - cf-layout
-*/
-
-.block__bg {
-    padding-top: 30px;
-    padding-bottom: 60px;
 }
 
 


### PR DESCRIPTION
Adds block__flush, organizes block CSS.
Fixes https://github.com/cfpb/cfgov-refresh/issues/838

## Additions

- Added `block__flush` to cf-enhancements to remove margin from all sides.

## Changes

- Change hardcoded 50% grey to color variable.
- Consolidates `block` CSS in cf-enhancements.

## Testing

- `./setup.sh local`
- Navigation to `/the-bureau/` there should be no change from refresh.demo.

## Review

- @KimberlyMunoz 
- @jimmynotjim 
- @sebworks 

## Screenshots
![screen shot 2015-09-25 at 4 48 25 pm](https://cloud.githubusercontent.com/assets/704760/10111929/61bb5912-63a5-11e5-9564-6b40d34f84bc.png)