### PR TITLE
Doing Business with Us title fix

### DIFF
--- a/cfgov/v1/jinja2/v1/doing-business-with-us/_vars-doing-business-with-us.html
+++ b/cfgov/v1/jinja2/v1/doing-business-with-us/_vars-doing-business-with-us.html
@@ -7,4 +7,4 @@
       (path + 'small-businesses/', 'small-businesses', 'Small, Women-Owned, and Minority-Owned Businesses')
     ])
 ] -%}
-{% set breadcrumb_items = [(path, path, 'Doing Business with us')] %}
+{% set breadcrumb_items = [(path, path, 'Doing Business with Us')] %}


### PR DESCRIPTION
Scott brought up that the breadcrumb didn't match the navigation. I think the thinking was that all words under four letters were lowercase, but I know there can be multiple interpretations on how "Doing Business with Us" should be capitalized. 

This pull request standardizes it with the navigation menu and page title. Tagging in Team Content to approve this.

## Screenshot

![image](https://cloud.githubusercontent.com/assets/1860176/10112792/235df66e-63ac-11e5-94fa-d90d0fd10e85.png)

## Review
- @sarahsimpson09 
- Tanya