### PR TITLE
Gulp Plugin for Sitespeed rules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,6 +87,7 @@ static/
 #################
 test/macro_tests/src/
 test/unit_test_coverage/
+test/perf_test_results/
 htmlcov/
 .tox/
 .coverage

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Added Acceptance tests for `budget` pages.
 - Added atomic landing page template prototypes.
 - Added `/organisms/` and `/molecules/` directories to includes directory.
+- Added `gulp test:perf` task to test for performance rules.
 
 ### Changed
 - Updated Video Code to make it usable on Events pages.

--- a/TEST.md
+++ b/TEST.md
@@ -148,6 +148,15 @@ From within the root project directory run `gulp test:unit:macro`.
 Please see [Macro Polo](https://github.com/cfpb/macropolo) for
 documentation about writing tests.
 
+# Performance Testing
+
+To audit if the site complies with performance best practices and guidelines,
+run `gulp test:perf`.
+
+The audit will run against [sitespeed.io performance rules](https://www.sitespeed.io/rules/)
+and crawl the website from the homepage.
+You can adjust the settings to skip rules and change the crawling depth
+by editing `/gulp/tasks/test.js`.
 
 # Accessibility Testing
 

--- a/gulp/tasks/test.js
+++ b/gulp/tasks/test.js
@@ -2,6 +2,7 @@
 
 var gulp = require( 'gulp' );
 var $ = require( 'gulp-load-plugins' )();
+var sitespeedio = require('gulp-sitespeedio');
 var childProcess = require( 'child_process' );
 var exec = childProcess.exec;
 var spawn = childProcess.spawn;
@@ -93,6 +94,48 @@ function _getProtractorParams() {
   return params;
 }
 
+/**
+ * Processes environment variables to find homepage URL
+ * where the site is running.
+ * @returns {string} URL of website homepage.
+ */
+
+function _getSiteUrl() {
+  var host = process.env.HTTP_HOST || 'localhost'; // eslint-disable-line no-process-env, no-inline-comments, max-len
+  var port = process.env.HTTP_PORT || '8000'; // eslint-disable-line no-process-env, no-inline-comments, max-len
+  return 'http://' + host + ':' + port;
+}
+
+gulp.task( 'test:perf', sitespeedio( {
+  url: _getSiteUrl(),
+  depth: 1,
+  html: true,
+  resultBaseDir: config.tests + '/perf_test_results/',
+  showFailedOnly: true,
+  skipTest: 'jsnumreq,' +
+            'ycompress,' +
+            'ydns,' +
+            'yfavicon,' +
+            'thirdpartyasyncjs,' +
+            'syncjsinhead,' +
+            'avoidfont,' +
+            'expiresmod,' +
+            'longexpirehead,' +
+            'textcontent,' +
+            'thirdpartyversions,' +
+            'ycdn,' +
+            'connectionclose,'+
+            'ycookiefree,'+
+            'yexpressions,'+
+            'inlinecsswhenfewrequest,'+
+            'nodnslookupswhenfewrequests',
+  budget: {
+    rules: {
+      default: 90
+    }
+  }
+} ) );
+
 gulp.task( 'test:acceptance:browser', function() {
   spawn(
     fsHelper.getBinary( 'protractor' ),
@@ -166,11 +209,5 @@ gulp.task( 'test:unit',
   [
     'test:unit:scripts',
     'test:unit:macro'
-  ]
-);
-
-gulp.task( 'test:acceptance',
-  [
-    'test:acceptance:browser'
   ]
 );

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "gulp-plumber": "^1.0.1",
     "gulp-rename": "^1.2.2",
     "gulp-replace": "^0.5.3",
+    "gulp-sitespeedio": "0.0.6",
     "gulp-sourcemaps": "^1.5.2",
     "gulp-util": "^3.0.6",
     "handlebars": "^4.0.2",


### PR DESCRIPTION
Adds a plug-in that checks against sitespeed.io performance rules for rule violations that may be slowing down the website. [Full list of rules are here](https://www.sitespeed.io/rules/). I disabled some rules on caching that we couldn't do much about on the front-end, but feel free to comment if you think a rule should be off or on. 

~~ This plugin will fail when run because some clean up is needed. ~~ 

## Additions

- Adds sitespeed.io plugin with performance rules for Flapjack

## Testing

- run `gulp test:perf`

## Review

- @anselmbradford 
- @sebworks 
- @jimmynotjim 