### PR TITLE
Google Analytics Changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Removed Ombudsman from nav for beta freeze.
 - Removed unnecessary mobile-only expandables
 - Removed link from Cordray's corner image `/the-bureau/about-director/`.
+- Removed extra Google Analytics code
 
 ### Fixed
 - Fixed issue with logic displaying the Event summary state.

--- a/cfgov/v1/jinja2/v1/_layouts/base.html
+++ b/cfgov/v1/jinja2/v1/_layouts/base.html
@@ -116,33 +116,14 @@
     Analytics
     =========
 -->
-    <!-- CLASSIC ANALYTICS -->
-    {# TODO: Remove Google Analytics code snippet once GTM is stable.
-             We are double tagging with classic analytics and tag manager
-             so that we can test any differences between the two.
-             See: https://github.com/cfpb/cfgov-refresh/issues/496 #}
-    <script>
-        var _gaq=[['_setAccount','UA-20466645-3'],['_setDomainName', '.consumerfinance.gov'],['_trackPageview']];
-        (function(d,t){var g=d.createElement(t),s=d.getElementsByTagName(t)[0];
-        g.src=('https:'==location.protocol?'//ssl':'//www')+'.google-analytics.com/ga.js';
-        s.parentNode.insertBefore(g,s)}(document,'script'));
-    </script>
-
-    <!-- GOOGLE TAG MANAGER -->
-    <noscript><iframe src="//www.googletagmanager.com/ns.html?id=GTM-KMMLRS"
-    height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
-    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-    '//www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-    })(window,document,'script','dataLayer','GTM-KMMLRS');</script>
-    <!-- /GOOGLE TAG MANAGER -->
-
-<!--
-    =================
-    Begin page source
-    =================
--->
+<!-- GOOGLE TAG MANAGER -->
+<noscript><iframe src="//www.googletagmanager.com/ns.html?id=GTM-KMMLRS"
+height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'//www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','GTM-KMMLRS');</script>
 
 {% block body %}
 


### PR DESCRIPTION
Hey all. I confirmed with @bethannenc that it's time to remove the extra Google Analytics code and we'll be relying on GTM from now on. I also asked about moving GTM to the footer of the page for performance reasons. After this PR is merged, Beth can test it on Flapjack to make sure GTM is working as it should.

## Removals
- Removes duplicate Google Analytics code

## Changes
- Moves Google Tag Manager code and jQuery to the bottom of the page

## Notes
- This PR brings our Critical Path Rendering score from 77 to 95 out of 100, moves our DOM loaded time from 1324ms to 1100ms on my connection and from 4085ms to 3587ms on sitespeed.io's mobile emulator