### PR TITLE
Adds JS config to linter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,8 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Settings file and template loaders
 - Updated gulp-autoprefixer from `2.3.1` to `3.0.2`.
 - Added pixel dimensions to Cordrary corner video image.
+- Added JS in `./config` directory to `gulp lint:build` task
+  and merged that and gulp config together in `config.build`.
 
 ### Removed
 - Disables tests for landing page events, since we don't currently have events.

--- a/config/environment.js
+++ b/config/environment.js
@@ -5,12 +5,12 @@
 'use strict';
 
 var paths = {
-  preproccesed:  './cfgov/v1/preprocessed',
-  processed: './cfgov/v1/static',
-  lib:  './vendor',
-  test: './test'
+  preproccesed: './cfgov/v1/preprocessed',
+  processed:    './cfgov/v1/static',
+  lib:          './vendor',
+  test:         './test'
 };
 
 module.exports = {
   paths: paths
-}
+};

--- a/config/webpack-config.js
+++ b/config/webpack-config.js
@@ -4,7 +4,7 @@
 
 'use strict';
 
-var BannerFooterPlugin = require('banner-footer-webpack-plugin');
+var BannerFooterPlugin = require( 'banner-footer-webpack-plugin' );
 var path = require( 'path' );
 var paths = require( '../config/environment' ).paths;
 var scriptsManifest = require( '../gulp/utils/scriptsManifest' );
@@ -16,19 +16,22 @@ var COMMON_BUNDLE_NAME = 'common.js';
 
 module.exports = {
   // jQuery is exported in the global space in the head.
-  externals: { jquery: "jQuery" },
-  context: __dirname + '/../' + paths.preproccesed + JS_ROUTES_PATH,
-  entry: scriptsManifest.getDirectoryMap( paths.preproccesed + JS_ROUTES_PATH ),
+  externals: { jquery: 'jQuery' },
+  context:   path.join( __dirname, '/../', paths.preproccesed, JS_ROUTES_PATH ),
+  entry:     scriptsManifest.getDirectoryMap( paths.preproccesed +
+                                              JS_ROUTES_PATH ),
   output: {
-    path: path.join(__dirname, 'js'),
+    path:     path.join( __dirname, 'js' ),
     filename: '[name]'
   },
   plugins: [
     new webpack.optimize.CommonsChunkPlugin( COMMON_BUNDLE_NAME ),
     new webpack.optimize.CommonsChunkPlugin( COMMON_BUNDLE_NAME,
-                                             [COMMON_BUNDLE_NAME] ),
+                                             [ COMMON_BUNDLE_NAME ] ),
     // Change warnings flag to true to view linter-style warnings at runtime.
-    new webpack.optimize.UglifyJsPlugin( { compress: { warnings: false } } ),
+    new webpack.optimize.UglifyJsPlugin( {
+      compress: { warnings: false }
+    } ),
     // Wrap JS in raw Jinja tags so included JS won't get parsed by Jinja.
     new BannerFooterPlugin( '{% raw %}', '{% endraw %}', { raw: true } )
   ],
@@ -37,5 +40,5 @@ module.exports = {
       // Disable incompatible AMD pattern in dateformat module.
       { test: require.resolve( 'dateformat' ), loader: 'imports?define=>false' }
     ]
-  },
+  }
 };

--- a/gulp/config.js
+++ b/gulp/config.js
@@ -29,7 +29,8 @@ module.exports = {
       paths.test + '/unit_tests/**/*.js',
       paths.test + '/browser_tests/**/*.js'
     ],
-    gulp: [
+    build: [
+      'config/**/*.js',
       'gulpfile.js',
       'gulp/**/*.js'
     ]

--- a/gulp/tasks/lint.js
+++ b/gulp/tasks/lint.js
@@ -21,7 +21,7 @@ function _genericLint( src ) {
  * Lints the gulpfile for errors
  */
 gulp.task( 'lint:build', function() {
-  return _genericLint( config.gulp );
+  return _genericLint( config.build );
 } );
 
 


### PR DESCRIPTION
Adds JS config to linter.

## Changes

- Added JS in `./config` directory to `gulp lint:build` task and merged that and gulp config together in `config.build`.
- Fixes linter errors/warnings from JS config files.

## Testing

- `gulp lint:build` should return no errors. `gulp build && gulp test` should pass.

## Review

- @sebworks 
- @KimberlyMunoz 
- @jimmynotjim 
