### PR TITLE
Added atomic landing page template prototypes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,8 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Added Acceptance tests for `newsroom` pages.
 - Added Acceptance tests for `doing-business-with-us` pages.
 - Added Acceptance tests for `budget` pages.
+- Added atomic landing page template prototypes.
+- Added `/organisms/` and `/molecules/` directories to includes directory.
 
 ### Changed
 - Updated Video Code to make it usable on Events pages.

--- a/cfgov/cfgov/urls.py
+++ b/cfgov/cfgov/urls.py
@@ -1,4 +1,5 @@
 from django.contrib import admin
+from django.conf import settings
 from django.conf.urls import include, url
 from django.views.generic.base import TemplateView
 from sheerlike.views.generic import SheerTemplateView
@@ -16,6 +17,7 @@ urlpatterns = [
     url(r'^admin/pages/(\d+)/unshare/$', unshare, name='unshare'),
     url(r'^admin/', include(wagtailadmin_urls)),
     url(r'^documents/', include(wagtaildocs_urls)),
+    # TODO: Enable search route when search is available.
     # url(r'^search/$', 'search.views.search', name='search'),
 
     url(r'^$', SheerTemplateView.as_view(), name='home'),
@@ -212,9 +214,15 @@ urlpatterns = [
             name='how-to-apply-for-a-federal-job-with-the-cfpb'),
     ],
         namespace='transcripts')),
-
-    url(r'', include(wagtail_urls)),
 ]
+
+# TODO: Remove prototype landing page routes when all organisms and molecules have been implemented elsewhere.
+if settings.DEBUG :
+    urlpatterns.append(url(r'^landing-page-1/$', SheerTemplateView.as_view(template_name='landing-page-1/index.html'), name='landing-page-1'))
+    urlpatterns.append(url(r'^landing-page-2/$', SheerTemplateView.as_view(template_name='landing-page-2/index.html'), name='landing-page-2'))
+
+# Catch remaining URL patterns that did not match a route thus far.
+urlpatterns.append(url(r'', include(wagtail_urls)))
 
 from sheerlike import register_permalink
 

--- a/cfgov/v1/jinja2/v1/_includes/molecules/hero.html
+++ b/cfgov/v1/jinja2/v1/_includes/molecules/hero.html
@@ -1,0 +1,19 @@
+
+{# ==========================================================================
+
+   hero.render()
+
+   ==========================================================================
+
+   Description:
+
+   Create a hero molecule. See [GHE]/flapjack/Modules-V1/wiki/Heros
+
+   ========================================================================== #}
+
+{% macro render() %}
+<div>
+  {# TODO: Implement hero macro with actual content. #}
+  HERO
+</div>
+{% endmacro %}

--- a/cfgov/v1/jinja2/v1/_includes/organisms/image-and-text-50-50.html
+++ b/cfgov/v1/jinja2/v1/_includes/organisms/image-and-text-50-50.html
@@ -1,0 +1,20 @@
+
+{# ==========================================================================
+
+   image_and_text_50_50.render()
+
+   ==========================================================================
+
+   Description:
+
+   Create an image and text 50/50 organism.
+   See [GHE]/flapjack/Modules-V1/wiki/50-50-Text-&-Image
+
+   ========================================================================== #}
+
+{% macro render() %}
+<div>
+  {# TODO: Implement image and text 50/50 macro with actual content. #}
+  IMAGE AND TEXT 50/50
+</div>
+{% endmacro %}

--- a/cfgov/v1/jinja2/v1/landing-page-1/index.html
+++ b/cfgov/v1/jinja2/v1/landing-page-1/index.html
@@ -1,0 +1,23 @@
+{% extends 'layout-2-1-bleedbar.html' %}
+
+{# Import organisms and molecules used in the template. #}
+{% import 'molecules/hero.html' as hero %}
+
+{% block title -%}
+    TODO: This is a prototype page for testing landing page layouts.
+    Remove when fully implemented elsewhere.
+{%- endblock %}
+
+{% block content_main %}
+    <div class="block
+                block__flush-top">
+        {# TODO: Add main molecules and organisms. #}
+        {{ hero.render() }}
+    </div>
+{% endblock %}
+
+{% block content_sidebar scoped -%}
+    <aside>
+        {# TODO: Add sidebar organisms. #}
+    </aside>
+{%- endblock %}

--- a/cfgov/v1/jinja2/v1/landing-page-2/index.html
+++ b/cfgov/v1/jinja2/v1/landing-page-2/index.html
@@ -1,0 +1,25 @@
+{% extends 'layout-2-1-bleedbar.html' %}
+
+{# Import organisms and molecules used in the template. #}
+{% import 'organisms/image-and-text-50-50.html' as image_and_text_50_50 %}
+
+{% block title -%}
+    TODO: This is a prototype page for testing landing page layouts.
+    Remove when fully implemented elsewhere.
+{%- endblock %}
+
+
+{% block content_main %}
+    <div class="block
+                block__flush-top">
+        {# TODO: Add main molecules and organisms. #}
+        <h1>Landing Page Prototype</h1>
+        {{ image_and_text_50_50.render() }}
+    </div>
+{% endblock %}
+
+{% block content_sidebar scoped -%}
+    <aside>
+        {# TODO: Add sidebar organisms. #}
+    </aside>
+{%- endblock %}


### PR DESCRIPTION
Part of DFJR-327.
Added atomic landing page template prototypes so that we can add test atomic design components together in one landing page and then migrate them to pages that use them.

## Additions

- Added atomic landing page template prototypes.
- Added `/organisms/` and `/molecules/` directories to includes directory.

## Testing

- `./setup.sh local`
- Restart the server.
- `/landing-page-1/` and `/landing-page-2/` should work.

## Review

- @KimberlyMunoz 
- @sebworks 
- @jimmynotjim 
- @kurtw 


## Todos

- Add testing to our test suites as these get moved from the prototype to actual page implementations.
- Added an example molecule and organism to fill in the paths, but the implementation of these are covered in subtasks of DFJR-327.