### PR TITLE
Updates/fixes CSS paths

### DIFF
--- a/cfgov/v1/preprocessed/css/cf-theme-overrides.less
+++ b/cfgov/v1/preprocessed/css/cf-theme-overrides.less
@@ -18,7 +18,7 @@
 @wall-min:                      1200px;
 
 // Font variables
-@import (less) 'licensed-fonts.css';
+@import (less) '/cf-typography/src/licensed-fonts.css';
 
 @webfont-regular: 'AvenirNextLTW01-Regular';
 @webfont-italic: 'AvenirNextLTW01-Italic';
@@ -147,7 +147,7 @@
 /* cf-grid
    ========================================================================== */
 
-@grid_box-sizing-polyfill-path: '@{loc-dist}/static/js';
+@grid_box-sizing-polyfill-path: '/static/js';
 @grid_wrapper-width:            1200px;
 @grid_gutter-width:             30px;
 @grid_total-columns:            12;

--- a/cfgov/v1/preprocessed/css/main.less
+++ b/cfgov/v1/preprocessed/css/main.less
@@ -3,11 +3,6 @@
    Master Less File.
    ========================================================================== */
 
-// Set up directory variables.
-// These should be consistent with the directory variables in Gruntfile.js.
-// TODO: Add "/dist" when `dist` directory is ready.
-@loc-dist: "";
-
 // @import Normalize before all other Less/CSS
 @import (less) "/normalize-css/normalize.css";
 @import (less) "/normalize-legacy-addon/normalize-legacy-addon.css";

--- a/gulp/config.js
+++ b/gulp/config.js
@@ -47,10 +47,7 @@ module.exports = {
     src:      '/main.less',
     dest:     paths.processed + '/css',
     settings: {
-      paths: [
-        paths.lib,
-        paths.lib + '/cf-typography/src'
-      ],
+      paths:    [ paths.lib ],
       compress: true
     }
   },


### PR DESCRIPTION
Updates/fixes CSS paths.

## Changes

- Moves `licensed-fonts.css` base path to `cf-theme-overrides.less` from `gulp/config.js`.
- Removes unused `@{loc-dist}` variable

## Testing

- Should be no change in fonts between this PR and flapjack branch.

## Review

- @jimmynotjim 
- @sebworks 
- @KimberlyMunoz 
