### PR TITLE
Fixed watch task for scripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Added href URL to primary nav top-level menu link.
 - Changed DB backend from sqlite ==> MYSQL.
 - Govdelivery subscribe view is now exempt from csrf verification
+- Fixed issue w/ gulp watch task not compiling JS on change
 
 ### Removed
 - Removed unused exportsOverride section,

--- a/gulp/config.js
+++ b/gulp/config.js
@@ -42,6 +42,9 @@ module.exports = {
   clean: {
     dest: paths.processed
   },
+  scripts: {
+    src: paths.preproccesed + '/js/**/*.js'
+  },
   styles: {
     cwd:      paths.preproccesed + '/css',
     src:      '/main.less',

--- a/gulp/tasks/scripts.js
+++ b/gulp/tasks/scripts.js
@@ -14,14 +14,7 @@ var webpackConfig = require( '../../config/webpack-config.js' );
 var webpackStream = require( 'webpack-stream' );
 var paths = require( '../../config/environment' ).paths;
 
-/**
- * Use webpack to bundle JavaScript.
- * @param {boolean} watch Whether to run with the watch flag or not.
- * @returns {Object} Returns a stream from gulp.
- */
-function webpackTask( watch ) {
-  webpackConfig.watch = watch || false;
-
+gulp.task( 'scripts', function() {
   return gulp.src( paths.preproccesed + '/js/routes/common.js' )
     .pipe( webpackStream( webpackConfig ) )
     .on( 'error', handleErrors )
@@ -29,14 +22,4 @@ function webpackTask( watch ) {
     .pipe( browserSync.reload( {
       stream: true
     } ) );
-}
-
-gulp.task( 'scripts', function() {
-  return webpackTask();
 } );
-
-// Exporting the task so we can call it directly in our watch task,
-// with the 'watch' option.
-module.exports = {
-  webpackTask: webpackTask
-};

--- a/gulp/tasks/watch.js
+++ b/gulp/tasks/watch.js
@@ -7,11 +7,9 @@
 
 var gulp = require( 'gulp' );
 var config = require( '../config' );
-var scripts = require( './scripts' );
 
 gulp.task( 'watch', [ 'browserSync' ], function() {
-  scripts.webpackTask( true );
+  gulp.watch( config.scripts.src, [ 'scripts' ] );
   gulp.watch( config.styles.cwd + '/**/*.less', [ 'styles' ] );
   gulp.watch( config.images.src, [ 'images' ] );
-  gulp.watch( config.copy.files.src, [ 'copy:files' ] );
 } );


### PR DESCRIPTION
Fixed up the watch task when saving source scripts

## Removals

- Removed old copy:files task

## Changes

- Replaced watch option from webpack-stream (was conflicting with gulp watch) with default gulp watch task

## Testing

- run `gulp watch` and update any of the source JS files, it should compile them

## Review

- @anselmbradford 
- @sebworks 
- @KimberlyMunoz 

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices 
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
