### PR TITLE
Relaxes key-spacing rule slightly

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -563,9 +563,9 @@ rules:
   key-spacing:
     - 1
     -
-      align: value
       beforeColon: false
       afterColon: true
+      mode: minimum
 
   # Enforces empty lines around comments.
   lines-around-comment:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,8 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Added pixel dimensions to Cordrary corner video image.
 - Added JS in `./config` directory to `gulp lint:build` task
   and merged that and gulp config together in `config.build`.
+- Changes `align: value` attribute in ESLint `key-spacing` rule
+  to individual mode with `mode: minimum` option set.
 
 ### Removed
 - Disables tests for landing page events, since we don't currently have events.


### PR DESCRIPTION
Relaxes key-spacing rule slightly.

The key-spacing rule can get a bit funky when properties in an object have other objects as values, reading to less readability than before the rule is applied! It also can cause issues with exceeding the max line length when it otherwise wouldn't if alignment was not happening on the property values. This tweak makes property keys have at least 1 space after the colon, allowing the values to aligned when it makes sense, or not when it doesn't.

## Changes

- Changes `align: value` attribute in ESLint `key-spacing` rule to individual mode with `mode: minimum` option set.

## Testing

- `gulp lint` shouldn't complain about key-spacing violations.

## Review

- @sebworks 
- @jimmynotjim 
