### PR TITLE
Adds URL to primary-nav href

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Changes `align: value` attribute in ESLint `key-spacing` rule
   to individual mode with `mode: minimum` option set.
 - Changes `quote-props` rule attribute to `consistent-as-needed`.
+- Added href URL to primary nav top-level menu link.
 
 ### Removed
 - Disables tests for landing page events, since we don't currently have events.

--- a/cfgov/v1/jinja2/v1/_includes/templates/nav/primary-nav.html
+++ b/cfgov/v1/jinja2/v1/_includes/templates/nav/primary-nav.html
@@ -15,11 +15,10 @@
                 sub_nav_items in vars.nav_items %}
             <li class="list_item primary-nav_item js-primary-nav_item">
                 {%- if sub_nav_items | length > 0 %}
-                    {# TODO: Make this a button, it is not a real link. #}
                     <a class="list_link
                               primary-nav_link
                               js-primary-nav_link"
-                       href="#">
+                       href="{{ sub_nav_landing }}">
                         {{ nav_title }}
                     </a>
                     {{ sub_nav.render(sub_nav_title, sub_nav_landing, sub_nav_items, sub_nav_media) }}


### PR DESCRIPTION
Adds URL to primary-nav href.
FIxes #967

## Changes

- Added href URL to primary nav top-level menu link.

## Testing

- No change, unless JS is turned off and menu item is clicked, in which case it should go to the About Us Landing page.

## Review

- @jimmynotjim 
- @sebworks 