### PR TITLE
Adds text-introduction prototype

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Added `gulp test:perf` task to test for performance rules.
 - MYSQL backend to project settings & a database creation script
 - Added `gulp test:unit:server` for running Django unit tests via gulp.
+- Added templates and CSS for the Text Introduction molecule.
 
 ### Changed
 - Updated the primary nav to move focus as user enters and leaves nav levels

--- a/cfgov/jinja2/v1/_includes/molecules/image-and-text-50-50.html
+++ b/cfgov/jinja2/v1/_includes/molecules/image-and-text-50-50.html
@@ -9,7 +9,7 @@
    When image conveys critical information and text is supporting it --
    i.e. chart, excerpt from document
 
-   See [GHE]/flapjack/Modules-V1/wiki/50-50-Text-&-Image
+   See [GHE]/flapjack/Modules-V1/wiki/50-50-Image-&-Text
 
    settings:              An object with the following options for settings.
    settings.title:        A string containing title of module

--- a/cfgov/jinja2/v1/_includes/molecules/text-introduction.html
+++ b/cfgov/jinja2/v1/_includes/molecules/text-introduction.html
@@ -1,0 +1,42 @@
+{# ==========================================================================
+
+   text_introduction.render()
+
+   ==========================================================================
+
+   Description:
+
+   Create a Text Introduction molecule.
+   See [GHE]/flapjack/Modules-V1/wiki/Text-Introduction
+
+   settings:
+
+      heading:   Heading text.
+
+      intro:     Body introduction text.
+
+      body:      Body text.
+
+      link_url:  Link URL.
+
+      link_text: Link text.
+
+   has_rule:  Whether there is a bottom gray rule.
+
+   ========================================================================== #}
+
+{% macro render(settings, has_rule=false) %}
+<div class="m-text-introduction
+            {{ 'm-text-introduction__bottom-rule' if has_rule else '' }}">
+   <h1 class='m-text-introduction_heading'>{{ settings.heading }}</h1>
+
+   <p class='m-text-introduction_intro'>{{ settings.intro }}</p>
+
+   <p class='m-text-introduction_body'>{{ settings.body }}</p>
+
+   <div class='m-text-introduction_link-container'>
+      <a class='jump-link' href='{{ settings.link_url }}'>{{ settings.link_text }}</a>
+   </div>
+
+</div>
+{% endmacro %}

--- a/cfgov/jinja2/v1/landing-page-2/index.html
+++ b/cfgov/jinja2/v1/landing-page-2/index.html
@@ -1,35 +1,38 @@
 {% extends 'layout-2-1-bleedbar.html' %}
 
 {# Import organisms and molecules used in the template. #}
-{% import 'organisms/image-and-text-50-50.html' as image_and_text_50_50 %}
+{% import 'molecules/text-introduction.html' as text_introduction %}
+{% import 'molecules/image-and-text-50-50.html' as image_and_text_50_50 %}
 
 {% block title -%}
     TODO: This is a prototype page for testing landing page layouts.
     Remove when fully implemented elsewhere.
 {%- endblock %}
 
-
 {% block content_main %}
     <div class="block
                 block__flush-top">
-        {# TODO: Add main molecules and organisms. #}
-        <h1>Landing Page Prototype</h1>
-
-
+        {{ text_introduction.render( {
+            'heading': 'Text Introduction',
+            'intro': 'Content Intro Lorem Ipsum',
+            'body': 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.',
+            'link_text': 'Placeholder link',
+            'link_url': '#'
+        }, true ) }}
     </div>
     <div class="content-l">
         <div class="content-l_col-1-2">
-                {{ image_and_text_50_50.render({
-                                'title' : 'Image and Text 50-50',
-                                'image_path': 'http://placehold.it/1600x900',
-                                'image_alt': 'This is a placeholder image',
-                                'is_widescreen': true,
-                                'description': 'When image conveys critical information and text is supporting it --
-                                i.e. chart, excerpt from document',
-                                'is_button' : true,
-                                'link_url': 'http://www.google.com',
-                                'link_text' : 'Visit Google'
-                                }) }}
+            {{ image_and_text_50_50.render({
+                            'title' : 'Image and Text 50-50',
+                            'image_path': 'http://placehold.it/1600x900',
+                            'image_alt': 'This is a placeholder image',
+                            'is_widescreen': true,
+                            'description': 'When image conveys critical information and text is supporting it --
+                            i.e. chart, excerpt from document',
+                            'is_button' : true,
+                            'link_url': 'http://www.google.com',
+                            'link_text' : 'Visit Google'
+                            }) }}
         </div>
     </div>
 {% endblock %}

--- a/cfgov/preprocessed/css/cf-enhancements.less
+++ b/cfgov/preprocessed/css/cf-enhancements.less
@@ -4,6 +4,24 @@
    ========================================================================== */
 
 /* topdoc
+  name: Theme variables
+  family: cf-core
+  notes:
+    - "The following color and sizing variables are exposed, allowing you to
+       easily override them before compiling."
+  patterns:
+    - name: Colors
+      codenotes:
+        - |
+          @horizontal-rule
+  tags:
+    - cf-core
+*/
+
+@horizontal-rule: @gray-50;
+
+
+/* topdoc
   name: Code styles
   family: cfgov-cf-enhancements
   patterns:

--- a/cfgov/preprocessed/css/main.less
+++ b/cfgov/preprocessed/css/main.less
@@ -60,6 +60,7 @@
    ========================================================================== */
 
 @import (less) "molecules/image-text-50-50.less";
+@import (less) "molecules/text-introduction.less";
 
 
 /* Organism pieces

--- a/cfgov/preprocessed/css/molecules/text-introduction.less
+++ b/cfgov/preprocessed/css/molecules/text-introduction.less
@@ -1,0 +1,68 @@
+/* topdoc
+  name: Theme variables
+  family: cfgov-molecules
+  notes:
+    - "The following color and sizing variables are exposed,
+       allowing you to easily override them before compiling."
+  patterns:
+  - name: Colors
+    codenotes:
+      - |
+        @m-text-introduction_rule
+  tags:
+  - less
+*/
+@m-text-introduction_rule: @horizontal-rule;
+
+
+/* topdoc
+  name: Text Introduction
+  family: cfgov-molecules
+  patterns:
+    - name: Default example
+      markup: |
+        <div class="m-text-introduction">
+            <h1 class="m-text-introduction_heading">Heading</h1>
+            <h2 class="m-text-introduction_subheading">Subheading</h2>
+            <p class="m-text-introduction_body">Body content</p>
+            <a class="m-text-introduction_link">Link</a>
+        </div>
+      codenotes:
+        - |
+          Structural cheat sheet:
+          -----------------------
+          .m-text-introduction
+            h1.m-text-introduction_heading
+            h2.m-text-introduction_subheading
+            p.m-text-introduction_body
+            a.m-text-introduction_link
+  tags:
+    - cfgov-molecules
+*/
+
+.m-text-introduction {
+    &_body,
+    &_link-container {
+        margin-bottom: unit( @grid_gutter-width / @base-font-size-px, em );
+    }
+
+    &_heading {
+      .h1(); /* Expose @font-size */
+      margin-bottom: unit( @grid_gutter-width / @font-size, em );
+    }
+
+    &_intro {
+      .h2(); /* Expose @font-size */
+      margin-bottom: unit( @grid_gutter-width / @font-size, em );
+    }
+
+    &__bottom-rule {
+        border-bottom: 1px solid @m-text-introduction_rule;
+        margin-bottom: unit( @grid_gutter-width / @base-font-size-px, em );
+    }
+}
+
+/* topdoc
+    name: EOF
+    eof: true
+*/


### PR DESCRIPTION
Adds well organism architecture per [GHE]/flapjack/Modules-V1/wiki/Text-Introduction

## Additions

- Added templates and CSS for the Text Introduction molecule.

## Testing

- Updates Text Introduction Molecule on `/landing-page-2/`.

## Review

- @jimmynotjim 
- @sebworks 
- @KimberlyMunoz 
- @Scotchester 

## Screenshots

![screen shot 2015-10-01 at 5 49 44 pm](https://cloud.githubusercontent.com/assets/704760/10234757/fb2f2f24-6864-11e5-8abc-44d58dd64b1e.png)

## Todo
- Pending resolution of approval of how this architecture will look.