### PR TITLE
Fixes #1047 - focusTarget unit test timeout

### DIFF
--- a/test/unit_tests/modules/focus-target-spec.js
+++ b/test/unit_tests/modules/focus-target-spec.js
@@ -13,10 +13,10 @@ describe( 'The focusTarget function', function() {
   before( function() {
     $ = require( 'jquery' );
     focusTarget = require( '../../../cfgov/v1/preprocessed/js/modules/focus-target.js' );
-    sandbox = sinon.sandbox.create();
   } );
 
   beforeEach( function() {
+    sandbox = sinon.sandbox.create();
     // Adding a simplified version of the thing we want to test.
     // Then calling the jQuery to test after
     $( 'body' ).html( $( '<a id="skip-nav"' +


### PR DESCRIPTION
I had an issue in https://github.com/cfpb/cfgov-refresh/pull/1026 that it would timeout and stall every. single. time. Moving the sinon sandbox creation from `before` to `beforeEach` as shown in https://gist.github.com/jgable/fd7fbd0516c849731404 seems to fix it.
Fixes https://github.com/cfpb/cfgov-refresh/issues/1047

## Changes

- Moves the sinon sandbox creation from `before` to `beforeEach` in `focus-target-spec.js`

## Testing

- `gulp test` should not stall or give the error shown in https://github.com/cfpb/cfgov-refresh/issues/1047

## Review

- @jimmynotjim 
- @sebworks 
- @KimberlyMunoz 
