### PR TITLE
Exempt govdeliver_subscribe view from csrf protection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Changes `quote-props` rule attribute to `consistent-as-needed`.
 - Added href URL to primary nav top-level menu link.
 - Changed DB backend from sqlite ==> MYSQL.
+- Govdelivery subscribe view is now exempt from csrf verification
 
 ### Removed
 - Removed unused exportsOverride section,

--- a/cfgov/core/views.py
+++ b/cfgov/core/views.py
@@ -1,6 +1,7 @@
 import os
 
 from django.views.decorators.http import require_http_methods
+from django.views.decorators.csrf import csrf_exempt
 from django.shortcuts import redirect
 from django.http import JsonResponse
 from govdelivery.api import GovDelivery
@@ -11,6 +12,7 @@ ACCOUNT_CODE = os.environ.get('GOVDELIVERY_ACCOUNT_CODE')
 REQUIRED_PARAMS = ['email', 'code']
 
 
+@csrf_exempt
 @require_http_methods(['POST'])
 def govdelivery_subscribe(request):
     """


### PR DESCRIPTION
@kave 
@rosskarchner 

### Test
Before pulling, visit /blog/ and enter in an email to subscribe. It shouldn't respond. Looking on the access log will show that it returns a 403. Pull it down and then retry. It should succeed. Keep in mind you need the GOVDELIVERY_ACCOUNT_CODE, GOVDELIVERY_USER, and GOVDELIVERY_PASS set in the env. If you need the credentials, they're in the wsgi file on the server.