### PR TITLE
Added half width link blob

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - EventPage and EventLandingPage
 - Management command to convert Wordpress data into Wagtail based Django models
 - Script to convert Event WP data into Wagtail specific POST data for wagtailcore view `create()`
+- Added half-width-link-blob macro and styles
 
 ### Changed
 - Updated the primary nav to move focus as user enters and leaves nav levels

--- a/cfgov/jinja2/v1/_includes/molecules/half-width-link-blob.html
+++ b/cfgov/jinja2/v1/_includes/molecules/half-width-link-blob.html
@@ -1,0 +1,41 @@
+{# ==========================================================================
+
+   half-width-link-blob.render()
+
+   ==========================================================================
+
+   Description:
+
+   Create a half-width-link-blob molecule when given:
+
+   settings: An object with the following options for settings.
+
+    settings.heading: A string containing title of module.
+
+    settings.content: A string containing the content  to display below the
+                      heading (typically a paragraph).
+
+    settings.links: A tuple of items to create a list of links. Objects include
+                    a url and text to display.
+
+                    link_url: A string for the URL of the link.
+                    link_text: A string for the text of the link.
+
+   ========================================================================== #}
+
+{% macro render( settings ) %}
+<div class="m-half-width-link-blob">
+    <h2 class="h3">{{ settings.heading }}</h2>
+    <p>{{ settings.content | safe }}</p>
+    <ul class="list list__links">
+        {% for link in settings.links %}
+        <li class="list_item">
+            <a class="list_link" href="{{ link.url }}">
+                {{ link.text }}
+            </a>
+        </li>
+        {% endfor %}
+    </ul>
+</div>
+{% endmacro %}
+

--- a/cfgov/jinja2/v1/landing-page-1/index.html
+++ b/cfgov/jinja2/v1/landing-page-1/index.html
@@ -3,6 +3,7 @@
 {# Import organisms and molecules used in the template. #}
 {% import 'molecules/hero.html' as hero %}
 {% import 'organisms/well.html' as well %}
+{% import 'molecules/half-width-link-blob.html' as link_blob %}
 
 {% block title -%}
     TODO: This is a prototype page for testing landing page layouts.
@@ -16,6 +17,37 @@
         {{ hero.render() }}
         <div class="block">
             {{ well.render( 'landing-page-1/_template-prototype-well-content.html' ) }}
+        </div>
+        <div class="o-link-blob-group">
+            {{ link_blob.render({
+                'heading': 'This is an example of a Half Width Link Blob',
+                'content': 'To highlight navigational links and provide
+                            context about what users can expect on the linked
+                            page',
+                'links': [
+                    {
+                        'text': 'This is a Link List molecule inside the blob',
+                        'url': '/some-url/'
+                    },
+                    {
+                        'text': 'This is another Link List molecule inside the
+                                 blob',
+                        'url': '/some-other-url/'
+                    }
+                ]
+            }) }}
+            {{ link_blob.render({
+                'heading': 'This is another example of a Half Width Link Blob',
+                'content': '<strong>Example:</strong> About Us landing page,
+                            sub-page descriptors on "office" pages and
+                            wireframed on Rulemaking landing page.',
+                'links': [
+                    {
+                        'text': 'This is a Link List molecule inside the blob',
+                        'url': '/some-url/'
+                    }
+                ]
+            }) }}
         </div>
     </div>
 {% endblock %}

--- a/cfgov/preprocessed/css/main.less
+++ b/cfgov/preprocessed/css/main.less
@@ -100,6 +100,12 @@
 @import (less) "pages/press-resources.less";
 @import (less) "pages/sub-pages.less";
 
+/* Molecules */
+@import (less) "molecules/half-width-link-blob.less";
+
+/* Organisms */
+@import (less) "organisms/link-blob-group.less";
+
 
 /* Demo-specific styles
    ========================================================================== */

--- a/cfgov/preprocessed/css/molecules/half-width-link-blob.less
+++ b/cfgov/preprocessed/css/molecules/half-width-link-blob.less
@@ -1,0 +1,46 @@
+/* topdoc
+  name: Half Width Link Blob
+  family: cfgov-molecules
+  patterns:
+    - name: Default example
+      markup: |
+        <div class="m-half-width-link-blob">
+            <h2 class="h3">Heading</h2>
+            <p>Body content</p>
+            <ul class="list list__links">
+                <li class="list_item">
+                    <a class="list_link" href="/some-url/">
+                        Link
+                    </a>
+                </li>
+            </ul>
+        </div>
+      codenotes:
+        - |
+          Structural cheat sheet:
+          -----------------------
+          .m-half-width-link-blob
+  tags:
+    - cfgov-molecules
+*/
+
+.m-half-width-link-blob {
+  margin-bottom: unit( (@grid_gutter-width * 2) / @base-font-size-px, em);
+
+  .webfont-regular();
+
+  .respond-to-max(@mobile-max, {
+    & + & {
+      margin-top: unit(@grid_gutter-width / @base-font-size-px, em);
+    }
+  });
+
+  .respond-to-min(@tablet-min, {
+    .grid_column(6);
+  });
+}
+
+/* topdoc
+    name: EOF
+    eof: true
+*/

--- a/cfgov/preprocessed/css/organisms/link-blob-group.less
+++ b/cfgov/preprocessed/css/organisms/link-blob-group.less
@@ -1,0 +1,33 @@
+/* topdoc
+  name: Link Blob Group
+  family: cfgov-molecules
+  patterns:
+    - name: Default example
+      markup: |
+        <div class="o-link-blob-group">
+            Link blobs live inside the wrapper
+        </div>
+      codenotes:
+        - |
+          Structural cheat sheet:
+          -----------------------
+          .o-link-blob-group
+  tags:
+    - cfgov-molecules
+*/
+.o-link-blob-group {
+  .respond-to-min(@tablet-min, {
+    margin-left: -@grid_gutter-width / 2;
+    margin-right: -@grid_gutter-width / 2;
+  });
+
+  .respond-to-min(@desktop-min, {
+    margin-right: -@grid_gutter-width;
+    margin-left: -@grid_gutter-width;
+  });
+}
+
+/* topdoc
+    name: EOF
+    eof: true
+*/


### PR DESCRIPTION
Added the half-width-link blob

## Additions

- Added half-width-link-blob macro to automate creating blobs when given a heading, text and list of links from the CMS.
- Added styles to set up layout for link-blob molecule and organism (named link-blob-group).
 
## Removals

- None

## Changes

- None

## Testing

- visit `/landing-page-1/` and check out the blobs

## Review

- @ajbush 
- @duelj 
- @sebworks 
- @KimberlyMunoz 
- @anselmbradford 

## Preview

![blobfish](http://www.acma.gov.au/~/media/mediacomms/Social%20Media/Images/Blobfish%20SMH%20jpg.JPG)

__Sorry, wrong blob :)__

<img width="521" alt="screen shot 2015-10-06 at 9 36 40 am" src="https://cloud.githubusercontent.com/assets/1280430/10310024/cb27e7ce-6c0d-11e5-8464-84eb068b92bd.png">

<img width="491" alt="screen shot 2015-10-06 at 9 36 51 am" src="https://cloud.githubusercontent.com/assets/1280430/10310025/cd610912-6c0d-11e5-99ee-346cc8c1c205.png">


[Preview this PR without the whitespace changes](?w=0)

## Notes

- Individual link blob uses link list molecule (yes, molecules in molecules)
- Must be used with the link-blob-group organism, even if there's only one blob
- Will always be 50% at tablet and above, even if there's only one blob
- For now content is limited to heading, text, and links