### PR TITLE
Added Email Sign-up Form Organism

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,8 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Added templates and CSS for the Related Posts molecule.
 - Added templates for the Hero molecule (CSS is in CF-Layout v1.3.0)
 - Added template for post-preview molecule
+- Added templates and CSS for the Signup Form organism.
+- Added templates and CSS for the Content Sidebar organism.
 
 ### Changed
 - Updated the primary nav to move focus as user enters and leaves nav levels

--- a/cfgov/jinja2/v1/_includes/molecules/form-field-with-button.html
+++ b/cfgov/jinja2/v1/_includes/molecules/form-field-with-button.html
@@ -1,0 +1,50 @@
+{# ==========================================================================
+
+   form_field_with_button.render()
+
+   ==========================================================================
+
+   Description:
+
+   Creates a form field with text when given:
+
+   settings:  An object used to customize the markup.
+
+   settings.btn_text:          The text for the submit button.
+
+   settings.field.required:    Boolean indicating whether the field is
+                               required.
+
+   settings.field.id:          The id for the input.
+
+   settings.field.info:        The text information to display above the field.
+
+   settings.field.label:       The label for the input.
+
+   settings.field.name:        The name for the input.
+
+   settings.field.placeholder: The placeholder used for the input.
+
+   ========================================================================== #}
+
+{% macro render(settings) %}
+<div class="m-form-field-with-button">
+    <div class="form-group">
+        <label for="{{ settings.field.name }}">
+            <b>{{ settings.field.label }}</b>
+            {% if settings.field.required %}
+                (required)
+            {% endif %}
+        </label>
+        <input id="{{ (settings.field.id or settings.field.name) ~
+                   '_' ~ range(1, 100) | random }}"
+               type="{{ settings.field.type }}"
+               name="{{ settings.field.name }}"
+               placeholder="{{ settings.field.placeholder }}"
+               class="m-form-field-with-button_field"
+               {{ settings.field.attributes or '' }}>
+    </div>
+    {{ settings.field.info or '' }}
+    <input class="btn btn__full" type="submit" value="{{ settings.btn_text }}">
+</div>
+{% endmacro %}

--- a/cfgov/jinja2/v1/_includes/organisms/email-signup.html
+++ b/cfgov/jinja2/v1/_includes/organisms/email-signup.html
@@ -1,0 +1,52 @@
+{# ==========================================================================
+
+   email_signup.render()
+
+   ==========================================================================
+
+   Description:
+
+   Creates an email sign up form when given:
+
+   settings:      An object used to customize the markup.
+
+   settings.text: The text used within the description markup.
+
+   gd_code:       A GovDelivery code for a specified mailing list.
+
+   ========================================================================== #}
+
+{% macro render(settings, gd_code='') %}
+{% import 'molecules/form-field-with-button.html' as form_field_with_button %}
+<form class="o-email-signup"
+      id="{{ settings.id or ('o-email-signup_' ~ range(1, 100) | random) }}"
+      action="/subscriptions/new/"
+      method="POST"
+      enctype="application/x-www-form-urlencoded">
+      {% if settings.text %}
+      <p class='short-desc'>
+          {{ settings.text }}
+      </p>
+      {% endif %}
+      {{ form_field_with_button.render( {
+          'field': {
+              'label':       'Email Address',
+              'name':        'o-email-signup_email',
+              'placeholder': 'example@mail.com',
+              'type':        'email',
+              'info':        _privacy_statement(),
+              'required':    true
+          },
+          'btn_text': 'Sign up'
+      } ) }}
+</form>
+{% endmacro %}
+
+
+{% macro _privacy_statement() %}
+<p class="short-desc">
+    The information you provide will permit the Consumer Financial
+    Protection Bureau to process your request or inquiry.
+    <a href="/sub-pages/privacy-policy/">See More</a>
+</p>
+{% endmacro %}

--- a/cfgov/jinja2/v1/landing-page-1/index.html
+++ b/cfgov/jinja2/v1/landing-page-1/index.html
@@ -1,3 +1,4 @@
+
 {% extends 'layout-2-1-bleedbar.html' %}
 
 {# Import organisms and molecules used in the template. #}
@@ -6,6 +7,8 @@
 {% import 'molecules/image-text-25-75.html' as image_text_25_75 %}
 {% import 'molecules/call-to-action.html' as call_to_action %}
 {% import 'organisms/well.html' as well %}
+{% import 'organisms/email-signup.html' as email_signup %}
+{% import 'molecules/related-posts.html' as related_posts %}
 
 {% block title -%}
     TODO: This is a prototype page for testing landing page layouts.
@@ -102,14 +105,27 @@
     </div>
 {% endblock %}
 
+{% block content_sidebar_modifiers -%}
+    o-content-sidebar
+{%- endblock %}
+
 {% block content_sidebar scoped -%}
     <aside>
         {# TODO: Add sidebar organisms. #}
+        <h2 class="header-slug">
+            <span class="header-slug_inner">
+                Slug Title
+            </span>
+        </h2>
         {{ call_to_action.render( {
           'button': {
               'text': 'Call to Action'
           },
           'text': lipsumText
+        }) }}
+        {{ email_signup.render({
+            'text':     lipsumText,
+            'required': true
         }) }}
     </aside>
 {%- endblock %}

--- a/cfgov/jinja2/v1/landing-page-2/index.html
+++ b/cfgov/jinja2/v1/landing-page-2/index.html
@@ -124,6 +124,9 @@
     {% endif %}
 {% endblock %}
 
+{% block content_sidebar_modifiers -%}
+    o-content-sidebar
+{%- endblock %}
 
 {% block content_sidebar scoped -%}
     {% if use_side_nav_layout == false %}

--- a/cfgov/preprocessed/css/main.less
+++ b/cfgov/preprocessed/css/main.less
@@ -80,7 +80,8 @@
 @import (less) "molecules/call-to-action.less";
 @import (less) "molecules/related-posts.less";
 @import (less) "molecules/half-width-link-blob.less";
-
+@import (less) "molecules/form-field-with-button.less";
+@import (less) "molecules/related-posts.less";
 
 /* Organism pieces
    ========================================================================== */
@@ -90,6 +91,8 @@
 @import (less) "organisms/full-width-text.less";
 @import (less) "organisms/link-blob-group.less";
 @import (less) "organisms/post-preview.less";
+@import (less) "organisms/content-sidebar.less";
+@import (less) "organisms/email-signup.less";
 
 
 /* Template pieces

--- a/cfgov/preprocessed/css/molecules/form-field-with-button.less
+++ b/cfgov/preprocessed/css/molecules/form-field-with-button.less
@@ -1,0 +1,61 @@
+/* topdoc
+  name: Form Field with Button
+  family: cfgov-molecules
+  patterns:
+    - name: Default example
+      markup: |
+        <div class="m-form-field-with-button">
+            <div class="form-group">
+                <label for="name">
+                    <b>label text</b>(required)
+                </label>
+                <input id="" type="" name="" placeholder=""
+                class="m-form-field-with-button_field">
+            </div>
+            <p class="short-desc">
+            </p>
+            <input class="btn btn__full" type="" value="">
+        </div>
+      codenotes:
+        - |
+          Structural cheat sheet:
+          -----------------------
+          .m-form-field-with-button
+            .form-group
+              label
+                b
+              .m-form-field-with-button_field
+            .short-desc
+            .btn btn__full
+  tags:
+    - cfgov-molecules
+*/
+
+@margin__em: unit( @grid_gutter-width / @base-font-size-px, em );
+
+.m-form-field-with-button {
+    input[type="text"],
+    input[type="search"],
+    input[type="email"],
+    input[type="url"],
+    input[type="tel"],
+    input[type="number"] {
+        width: 100%;
+        box-sizing: border-box;
+        margin-bottom: @margin__em;
+    }
+
+    label {
+        // Optical adjustment to set margin to 15px.
+        margin-bottom: @margin__em / 3;
+    }
+
+    .btn {
+        margin-bottom: @margin__em * 2;
+    }
+}
+
+/* topdoc
+    name: EOF
+    eof: true
+*/

--- a/cfgov/preprocessed/css/molecules/related-posts.less
+++ b/cfgov/preprocessed/css/molecules/related-posts.less
@@ -54,7 +54,6 @@
 @margin_half__em: unit(15px / @base-font-size-px, em);
 
 @list_half-width: {
-    .grid_nested-col-group();
 
     .list_item {
         .grid_column(6);

--- a/cfgov/preprocessed/css/organisms/content-sidebar.less
+++ b/cfgov/preprocessed/css/organisms/content-sidebar.less
@@ -1,0 +1,34 @@
+/* topdoc
+  name: Content Sidebar
+  family: cfgov-organism
+  patterns:
+    - name: Default example
+      markup: |
+          <aside class="o-content-sidebar">
+              <*></*>
+          </aside>
+      codenotes:
+        - |
+          Structural cheat sheet:
+          -----------------------
+          .o-content-sidebar
+  tags:
+    - cfgov-molecules
+*/
+
+.o-content-sidebar {
+    border-width: 0;
+
+    .respond-to-range(@tablet-min, @tablet-max {
+
+        .header-slug {
+            margin-left: unit(@grid_gutter-width / @base-font-size-px, em) / 2;
+            margin-right: unit(@grid_gutter-width / @base-font-size-px, em) / 2;
+        }
+    });
+}
+
+/* topdoc
+    name: EOF
+    eof: true
+*/

--- a/cfgov/preprocessed/css/organisms/email-signup.less
+++ b/cfgov/preprocessed/css/organisms/email-signup.less
@@ -1,0 +1,53 @@
+/* topdoc
+  name: Signup Form
+  family: cfgov-organism
+  patterns:
+    - name: Default example
+      markup: |
+          <form class="o-email-signup"
+                action="/subscriptions/new/"
+                method="POST"
+                enctype="application/x-www-form-urlencoded">
+              <p class='short-desc'>
+              </p>
+              <div class="m-form-field-with-button">
+                  <div class="form-group">
+                      <label>
+                          <b></b>
+                          (required)
+                      </label>
+                      <input type="email"
+                             class="m-form-field-with-button_field">
+                  </div>
+                  <input class="btn btn__full" type="submit">
+              </div>
+          </form>
+      codenotes:
+        - |
+          Structural cheat sheet:
+          -----------------------
+          .o-email-signup
+            .short-desc
+            .m-form-field-with-button
+              .form-group
+                .m-form-field-with-button_field
+              .btn.btn_full
+  tags:
+    - cfgov-organisms
+*/
+
+.o-email-signup {
+
+    .respond-to-range(@tablet-min, @tablet-max {
+        .grid_column(6);
+
+        &:last-child:nth-last-child(2) {
+            .grid_column(12);
+        }
+    });
+}
+
+/* topdoc
+    name: EOF
+    eof: true
+*/


### PR DESCRIPTION
Added Email Sign-up Form Organism per [GHE]/flapjack/Modules-V1/wiki/Email-Sign-Up

## Additions

- Added Email signup form Organism.

## Testing

- Added Email Sign-up Form Organism on `/landing-page-1/`.

## Review

- @jimmynotjim 
- @sebworks 
- @KimberlyMunoz 
- @Scotchester 

## Screenshots

<img width="393" alt="screen shot 2015-10-06 at 12 49 14 pm" src="https://cloud.githubusercontent.com/assets/1696212/10315507/b78831d6-6c28-11e5-903c-ebbeb3f78859.png">
<img width="708" alt="screen shot 2015-10-06 at 12 49 07 pm" src="https://cloud.githubusercontent.com/assets/1696212/10315505/b786028a-6c28-11e5-9f26-194b7e1f31d9.png">
<img width="518" alt="screen shot 2015-10-06 at 12 48 59 pm" src="https://cloud.githubusercontent.com/assets/1696212/10315506/b786cda0-6c28-11e5-995e-0c9a653d5ab1.png">


## Notes
- I'm using `calc` to limit width of text input in `cfgov/v1/preprocessed/css/molecules/form-field-with-button.less`.