### PR TITLE
removed reference to prod static folder location

### DIFF
--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -134,7 +134,6 @@ STATICFILES_STORAGE = 'django.contrib.staticfiles.storage.StaticFilesStorage'
 # app-specific 'static' directories.
 STATICFILES_DIRS = [
     PROJECT_ROOT.child('static_built'),
-    PROJECT_ROOT.child('static'),
     ('legacy', PROJECT_ROOT.child('v1','static-legacy')),
 ]
 


### PR DESCRIPTION
@kurtw @rosskarchner 

Cannot have the same location of the static_root included in the static_dirs. tested & verified on flapjack server