### PR TITLE
Adding full-width-text module and styles for bullets

### DIFF
--- a/cfgov/jinja2/v1/_includes/organisms/full-width-text.html
+++ b/cfgov/jinja2/v1/_includes/organisms/full-width-text.html
@@ -1,0 +1,22 @@
+
+{# ==========================================================================
+
+   full_width_text.render()
+
+   ==========================================================================
+
+   Description:
+
+   Create a gray well organism.
+   See [GHE]/flapjack/Modules-V1/wiki/Full-Width-Copy
+
+   template: Template URL for content to include.
+
+   ========================================================================== #}
+
+{% macro render(template) %}
+{% import template as content %}
+<div class="o-full-width-text">
+  {{ content }}
+</div>
+{% endmacro %}

--- a/cfgov/jinja2/v1/_includes/organisms/full-width-text.html
+++ b/cfgov/jinja2/v1/_includes/organisms/full-width-text.html
@@ -7,7 +7,7 @@
 
    Description:
 
-   Create a gray well organism.
+   Create a full width text organism.
    See [GHE]/flapjack/Modules-V1/wiki/Full-Width-Copy
 
    template: Template URL for content to include.

--- a/cfgov/jinja2/v1/sublanding-page-1/_template-prototype-full-width-content.html
+++ b/cfgov/jinja2/v1/sublanding-page-1/_template-prototype-full-width-content.html
@@ -1,9 +1,9 @@
 <h2>Full-width text module</h2>
-  <p>
-      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed metus tortor, lacinia vel arcu a, convallis consequat velit. Nam non turpis ac leo porta elementum id euismod erat. Nullam pretium purus ac ultricies pharetra.
-  </p>
-  <ul>
-      <li>Lorem ipsum dolor sit amet</li>
-      <li>Lorem ipsum dolor sit amet</li>
-      <li>Lorem ipsum dolor sit amet</li>
-  </ul>
+<p>
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed metus tortor, lacinia vel arcu a, convallis consequat velit. Nam non turpis ac leo porta elementum id euismod erat. Nullam pretium purus ac ultricies pharetra.
+</p>
+<ul>
+    <li>Lorem ipsum dolor sit amet</li>
+    <li>Lorem ipsum dolor sit amet</li>
+    <li>Lorem ipsum dolor sit amet</li>
+</ul>

--- a/cfgov/jinja2/v1/sublanding-page-1/_template-prototype-full-width-content.html
+++ b/cfgov/jinja2/v1/sublanding-page-1/_template-prototype-full-width-content.html
@@ -1,0 +1,9 @@
+<h2>Full-width text module</h2>
+  <p>
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed metus tortor, lacinia vel arcu a, convallis consequat velit. Nam non turpis ac leo porta elementum id euismod erat. Nullam pretium purus ac ultricies pharetra.
+  </p>
+  <ul>
+      <li>Lorem ipsum dolor sit amet</li>
+      <li>Lorem ipsum dolor sit amet</li>
+      <li>Lorem ipsum dolor sit amet</li>
+  </ul>

--- a/cfgov/jinja2/v1/sublanding-page-1/index.html
+++ b/cfgov/jinja2/v1/sublanding-page-1/index.html
@@ -2,6 +2,7 @@
 
 {# Import organisms and molecules used in the template. #}
 {% import 'molecules/text-introduction.html' as text_introduction %}
+{% import 'organisms/full-width-text.html' as full_width_text %}
 
 {% block title -%}
     TODO: This is a prototype page for testing landing page layouts.
@@ -11,7 +12,6 @@
 {#
     TODO: Add the following molecules
         - Featured Content module
-        - Full width text field with bullets
         - Half link blobs
         - Sidebar with latest activities
 #}
@@ -26,6 +26,10 @@
             'link_text': 'Placeholder link',
             'link_url': '#'
         }, true ) }}
+    </div>
+
+    <div class="block">
+        {{ full_width_text.render( 'sublanding-page-1/_template-prototype-full-width-content.html' ) }}
     </div>
 {% endblock %}
 

--- a/cfgov/preprocessed/css/main.less
+++ b/cfgov/preprocessed/css/main.less
@@ -67,6 +67,7 @@
    ========================================================================== */
 
 @import (less) "organisms/well.less";
+@import (less) "organisms/full-width-well.less";
 
 
 /* Template pieces

--- a/cfgov/preprocessed/css/main.less
+++ b/cfgov/preprocessed/css/main.less
@@ -67,7 +67,7 @@
    ========================================================================== */
 
 @import (less) "organisms/well.less";
-@import (less) "organisms/full-width-well.less";
+@import (less) "organisms/full-width-text.less";
 
 
 /* Template pieces

--- a/cfgov/preprocessed/css/organisms/full-width-text.less
+++ b/cfgov/preprocessed/css/organisms/full-width-text.less
@@ -27,14 +27,14 @@
 .o-full-width-text {
     ul {
         padding-left: 30px;
-
         li {
-          @font-size: 16px;
-          @offset: unit(15px / @font-size, em);
-          @size: unit(22px / @base-font-size-px, em);
-          .custom-bullet( @text:"\25AA", @color: @black, @offset: @offset, @size: @size );
-          // Spacing has been eyeballed to be 30px.
-          margin-bottom: unit( 21px / @font-size, em );
+            .custom-bullet( @text:"\25AA",
+                            @color: @black,
+                            @offset: unit(15px / @base-font-size-px, em),
+                            @size: unit(22px / @base-font-size-px, em)
+                          );
+            // Spacing has been eyeballed to be 30px.
+            margin-bottom: unit( 21px / @base-font-size-px, em );
         }
     }
 }

--- a/cfgov/preprocessed/css/organisms/full-width-well.less
+++ b/cfgov/preprocessed/css/organisms/full-width-well.less
@@ -1,0 +1,45 @@
+/* topdoc
+  name: Bullet Points for full width text
+  family: cfgov-organisms
+  patterns:
+    - name: Default example
+      markup: |
+        <div class="o-full-width-text">
+            <ul>
+              <li>Gray Well</li>
+              <li>Well's content</li>
+            </ul>
+        </div>
+      codenotes:
+        - |
+          Structural cheat sheet:
+          -----------------------
+          .o-full-width-text
+            ul
+              li
+  tags:
+    - cfgov-organisms
+  notes:
+    - Since content will be entered by content managers,
+      these styles are applied on the ul li elements directly when needed.
+*/
+
+.o-full-width-text {
+    ul {
+        padding-left: 30px;
+
+        li {
+          @font-size: 16px;
+          @offset: unit(15px / @font-size, em);
+          @size: unit(22px / @base-font-size-px, em);
+          .custom-bullet( @text:"\25AA", @color: @black, @offset: @offset, @size: @size );
+          // Spacing has been eyeballed to be 30px.
+          margin-bottom: unit( 21px / @font-size, em );
+        }
+    }
+}
+
+/* topdoc
+    name: EOF
+    eof: true
+*/


### PR DESCRIPTION
Short description explaining the high-level reason for the pull request

## Additions

- Added the full-width-text module in the same style Ans did the well module
- Added styles for the bullet points. We might want to eventually port these to CF or even all bullet points, but I want to make sure the styles get approved here first.

## Testing

- Visit http://localhost:8000/sublanding-page-1/

## Review

- @jimmynotjim 
- @sebworks 
- @anselmbradford

## Screenshots

![image](https://cloud.githubusercontent.com/assets/1860176/10405082/af264d60-6ea4-11e5-9fd3-fd484e25a29f.png)


## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices 
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)