### PR TITLE
Adds Authors and Tags to CFGOV Model and to the import-data script for Events

### DIFF
--- a/cfgov/core/management/commands/processors/eventpage.py
+++ b/cfgov/core/management/commands/processors/eventpage.py
@@ -8,6 +8,16 @@ def convert(doc):
         'body':       doc.get('content', u''),
         'flickr_url': doc.get('flickr_url', u''),
     }
+    tags = ''
+    for tag in doc.get('tags'):
+        if ' ' in tag:
+            tag = '"%s"' % tag
+        tags += tag + ', '
+    if tags:
+        tags = tags[0:-2]
+    post_dict['tags'] = tags
+    post_dict['authors'] = '"%s"' % doc.get('author', {}).get('name', '')
+
     times = [('beginning_time', 'start_dt'), ('ending_time', 'end_dt')]
     for t in times:
         if doc.get(t[0]):

--- a/cfgov/v1/migrations/0003_add_tags-authors_for_cfgovpage.py
+++ b/cfgov/v1/migrations/0003_add_tags-authors_for_cfgovpage.py
@@ -1,0 +1,68 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import modelcluster.fields
+import wagtail.wagtailcore.fields
+import wagtail.wagtailcore.blocks
+import modelcluster.contrib.taggit
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('taggit', '0002_auto_20150616_2121'),
+        ('v1', '0002_create_event_pages'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='CFGOVAuthoredPages',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('content_object', modelcluster.fields.ParentalKey(to='v1.CFGOVPage')),
+                ('tag', models.ForeignKey(related_name='v1_cfgovauthoredpages_items', to='taggit.Tag')),
+            ],
+            options={
+                'verbose_name': 'Author',
+                'verbose_name_plural': 'Authors',
+            },
+        ),
+        migrations.CreateModel(
+            name='CFGOVTaggedPages',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('content_object', modelcluster.fields.ParentalKey(to='v1.CFGOVPage')),
+                ('tag', models.ForeignKey(related_name='v1_cfgovtaggedpages_items', to='taggit.Tag')),
+            ],
+            options={
+                'verbose_name': 'Tag',
+                'verbose_name_plural': 'Tags',
+            },
+        ),
+        migrations.AlterField(
+            model_name='eventpage',
+            name='agenda_items',
+            field=wagtail.wagtailcore.fields.StreamField([(b'item', wagtail.wagtailcore.blocks.StructBlock([(b'start_dt', wagtail.wagtailcore.blocks.DateTimeBlock(required=False, label=b'Start')), (b'end_dt', wagtail.wagtailcore.blocks.DateTimeBlock(required=False, label=b'End')), (b'description', wagtail.wagtailcore.blocks.CharBlock(max_length=100, required=False)), (b'location', wagtail.wagtailcore.blocks.CharBlock(max_length=100, required=False)), (b'speakers', wagtail.wagtailcore.blocks.ListBlock(wagtail.wagtailcore.blocks.StructBlock([(b'name', wagtail.wagtailcore.blocks.CharBlock(required=False)), (b'url', wagtail.wagtailcore.blocks.URLBlock(required=False))], required=False, icon=b'user')))]))], blank=True),
+        ),
+        migrations.AlterField(
+            model_name='eventpage',
+            name='end_dt',
+            field=models.DateTimeField(null=True, verbose_name=b'End', blank=True),
+        ),
+        migrations.AlterField(
+            model_name='eventpage',
+            name='start_dt',
+            field=models.DateTimeField(null=True, verbose_name=b'Start', blank=True),
+        ),
+        migrations.AddField(
+            model_name='cfgovpage',
+            name='authors',
+            field=modelcluster.contrib.taggit.ClusterTaggableManager(to='taggit.Tag', through='v1.CFGOVAuthoredPages', blank=True, help_text=b'A comma separated list of authors.', verbose_name=b'Authors'),
+        ),
+        migrations.AddField(
+            model_name='cfgovpage',
+            name='tags',
+            field=modelcluster.contrib.taggit.ClusterTaggableManager(to='taggit.Tag', through='v1.CFGOVTaggedPages', blank=True, help_text='A comma-separated list of tags.', verbose_name='Tags'),
+        ),
+    ]

--- a/cfgov/v1/models/__init__.py
+++ b/cfgov/v1/models/__init__.py
@@ -1,0 +1,2 @@
+from .base import *
+from .events import *

--- a/cfgov/v1/models/base.py
+++ b/cfgov/v1/models/base.py
@@ -1,0 +1,143 @@
+from django.db import models
+from django.http import Http404
+from django.conf import settings
+from django.utils.translation import ugettext_lazy as _
+
+from wagtail.wagtailcore.models import Page, PagePermissionTester, UserPagePermissionsProxy
+from wagtail.wagtailcore.url_routing import RouteResult
+from wagtail.wagtailadmin.edit_handlers import FieldPanel, MultiFieldPanel
+
+from taggit.models import TaggedItemBase
+from modelcluster.fields import ParentalKey
+from modelcluster.tags import ClusterTaggableManager
+
+
+class CFGOVAuthoredPages(TaggedItemBase):
+    content_object = ParentalKey('CFGOVPage')
+
+    class Meta:
+        verbose_name = _("Author")
+        verbose_name_plural = _("Authors")
+
+
+class CFGOVTaggedPages(TaggedItemBase):
+    content_object = ParentalKey('CFGOVPage')
+
+    class Meta:
+        verbose_name = _("Tag")
+        verbose_name_plural = _("Tags")
+
+
+class CFGOVPage(Page):
+    authors = ClusterTaggableManager(through=CFGOVAuthoredPages, blank=True,
+                                     verbose_name='Authors',
+                                     help_text='A comma separated list of authors.',
+                                     related_name='authored_pages')
+    tags = ClusterTaggableManager(through=CFGOVTaggedPages, blank=True,
+                                  related_name='tagged_pages')
+    shared = models.BooleanField(default=False)
+
+    # This is used solely for subclassing pages we want to make at the CFPB.
+    is_creatable = False
+
+    promote_panels = [
+        MultiFieldPanel(Page.promote_panels, "Page configuration"),
+        FieldPanel('tags', 'Tags'),
+        FieldPanel('authors', 'Authors'),
+    ]
+
+    @property
+    def status_string(self):
+        if not self.live:
+            if self.expired:
+                return _("expired")
+            elif self.approved_schedule:
+                return _("scheduled")
+            elif self.shared:
+                return _("shared")
+            else:
+                return _("draft")
+        else:
+            if self.has_unpublished_changes:
+                return _("live + draft")
+            else:
+                return _("live")
+
+    def sharable_pages(self):
+        """Return a queryset of the pages that this user has permission to share"""
+        # Deal with the trivial cases first...
+        if not self.user.is_active:
+            return Page.objects.none()
+        if self.user.is_superuser:
+            return Page.objects.all()
+
+        sharable_pages = Page.objects.none()
+
+        for perm in self.permissions.filter(permission_type='share'):
+            # User has share permission on any subpage of perm.page
+            # (including perm.page itself).
+            sharable_pages |= Page.objects.descendant_of(perm.page, inclusive=True)
+
+        return sharable_pages
+
+    def can_share_pages(self):
+        """Return True if the user has permission to publish any pages"""
+        return self.sharable_pages().exists()
+
+    def route(self, request, path_components):
+        if path_components:
+            # Request is for a child of this page.
+            child_slug = path_components[0]
+            remaining_components = path_components[1:]
+
+            try:
+                subpage = self.get_children().get(slug=child_slug)
+            except Page.DoesNotExist:
+                raise Http404
+
+            return subpage.specific.route(request, remaining_components)
+
+        else:
+            # Request is for this very page.
+            if self.live or self.shared and request.site.hostname == settings.STAGING_HOSTNAME:
+                return RouteResult(self)
+            else:
+                raise Http404
+
+    def permissions_for_user(self, user):
+        """
+        Return a CFGOVPagePermissionTester object defining what actions the user can perform on this page
+        """
+        user_perms = CFGOVUserPagePermissionsProxy(user)
+        return user_perms.for_page(self)
+
+    class Meta:
+        app_label = 'v1'
+
+
+class CFGOVPagePermissionTester(PagePermissionTester):
+    def can_unshare(self):
+        if not self.user.is_active:
+            return False
+        if not self.page.shared or self.page_is_root:
+            return False
+
+        # Must check edit in self.permissions because `share` cannot be added.
+        return self.user.is_superuser or ('edit' in self.permissions)
+
+    def can_share(self):
+        if not self.user.is_active:
+            return False
+        if self.page_is_root:
+            return False
+
+        # Must check edit in self.permissions because `share` cannot be added.
+        return self.user.is_superuser or ('edit' in self.permissions)
+
+
+class CFGOVUserPagePermissionsProxy(UserPagePermissionsProxy):
+    def for_page(self, page):
+        """Return a CFGOVPagePermissionTester object that can be used to query
+            whether this user has permission to perform specific tasks on the
+            given page."""
+        return CFGOVPagePermissionTester(self, page)


### PR DESCRIPTION
This adds the tags and authors members to the CFGOVPage for use in the Promote panel of all page models that inherit from CFGOVPage. It also adds them in the Event's import-data script.

This is so we can set up the filterable list in the view logic for the Event template logic conversion for this sprints' hypotheses.

### Test
Run the `import-data` command for events to see if they convert the tags and authors correctly. Note, there's only one author of these events.
`./cfgov/manage.py import-data events eventpage events -u <super_user> -p <super_user_pw>`
@kave 
@rosskarchner 