### PR TITLE
Fix handlebars path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,7 +106,8 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Govdelivery subscribe view is now exempt from csrf verification
 - Fixed issue w/ gulp watch task not compiling JS on change
 - Refactored `BreakpointHandler.js` to remove jQuery dependency and unneeded code.
-- Changed from single cf import to individual module imports
+- Changed from single cf import to individual module imports.
+- Move handlebars dependency to npm from bower.
 
 ### Removed
 - Removed unused exportsOverride section,

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
   },
   "browser": {
     "dateformat": "./node_modules/dateformat/lib/dateformat.js",
-    "handlebars": "./vendor/handlebars/handlebars.min.js",
+    "handlebars": "./node_modules/handlebars/dist/handlebars.min.js",
     "history": "./vendor/history.js/scripts/bundled-uncompressed/html5/jquery.history.js",
     "jquery": "./node_modules/jquery/dist/jquery.js",
     "jquery-easing": "./vendor/jquery.easing/js/jquery.easing.js",


### PR DESCRIPTION
Fix handlebars path to pull from `node_modules` instead of `vendor`.

## Changes

- Pulls in handlebars via npm instead of bower.

## Testing

- `./setup.sh local` should pass.

## Review

- @sebworks 
- @jimmynotjim 
- @KimberlyMunoz 
