### PR TITLE
Add gulp beep task

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ Thumbs.db
 # Environment vars #
 ####################
 .env
+beep-build.mp3
 
 # npm packages #
 ####################

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,8 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Added templates and CSS for the Image and Text 25/75 molecule.
 - Added templates and CSS for the Image and Text 50/50 molecule.
 - Added templates and CSS for the Call to Action molecule.
+- Added `gulp beep` task for optional alerting when the build process
+  has completed.
 
 ### Changed
 - Updated the primary nav to move focus as user enters and leaves nav levels

--- a/gulp/tasks/beep.js
+++ b/gulp/tasks/beep.js
@@ -1,0 +1,47 @@
+'use strict';
+
+var fs = require( 'fs' );
+var gulp = require( 'gulp' );
+var path = require( 'path' );
+var Player;
+
+// See that the player module has loaded.
+// If this is run on TravisCI it will not have loaded
+// and the rest of the code goes through its normal error handling.
+/* eslint-disable global-require, handle-callback-err, no-console, lines-around-comment, max-len */
+try {
+  Player = require( 'player' );
+} catch ( e ) {
+  console.log( 'Warning: NPM Player module did not load!' );
+}
+/* eslint-enable */
+
+var SONG_PATH = 'beep-build.mp3';
+
+/**
+ * Play an mp3 file using the Player npm module.
+ * @param {string} soundPath The path to a sound file.
+ */
+function _playSound( soundPath ) {
+  var player = new Player( soundPath );
+  player.play();
+
+  player.on( 'error', function() { // eslint-disable-line handle-callback-err, no-inline-comments, max-len
+    // Ignore playback errors because
+    // it's not critical if the beep doesn't play.
+  } );
+}
+
+gulp.task( 'beep', function() {
+
+  try {
+    var soundPath = path.join( __dirname, '../../' + SONG_PATH );
+    var stats = fs.lstatSync( soundPath ); // eslint-disable-line no-sync, no-inline-comments, max-len
+    if ( stats.isFile() ) {
+      _playSound( soundPath );
+    }
+  } catch ( e ) {
+    console.log( 'No build alert beep configured. Add a sound file as "' + // eslint-disable-line no-console, no-inline-comments, max-len
+                 SONG_PATH + '" in the project root directory.' );
+  }
+} );

--- a/package.json
+++ b/package.json
@@ -54,6 +54,9 @@
     "webpack-stream": "^2.1.0",
     "wcag": "^0.2.2"
   },
+  "optionalDependencies": {
+    "player": "^0.5.1"
+  },
   "browser": {
     "dateformat": "./node_modules/dateformat/lib/dateformat.js",
     "handlebars": "./node_modules/handlebars/dist/handlebars.min.js",

--- a/setup.sh
+++ b/setup.sh
@@ -77,6 +77,7 @@ build(){
   gulp clean
   gulp build
   dbsetup
+  gulp beep
 }
 
 # Setup MYSQL Server


### PR DESCRIPTION
Got sick of not being alerted when the build is done. Adds the ability to optionally add an mp3 file in your project root which plays when `setup.sh` completes.

## Additions

- Adds `gulp beep` task.

## Changes

- Includes `gulp beep` at the end of the `setup.sh` build process.

## Testing

- Download a MP3 sound from freesound.org or whereever. I like [this one](www.freesound.org/data/previews/72/72129_1028972-lq.mp3)
- Rename it `build-beep.mp3`
- Place it in your project root directory.
- Try `gulp beep` to test.
- Run `./setup.sh local` and it should play at the end.

## Review

- @jimmynotjim 
- @sebworks 
- @KimberlyMunoz 
- @kurtw 
- @kave 
