### PR TITLE
This removes usage of DJANGO_ENV (which is generally a less-flexible than the built-in DJANGO_SETTINGS_MODULE)

### DIFF
--- a/.env_SAMPLE
+++ b/.env_SAMPLE
@@ -7,6 +7,8 @@
 # Django Application Server.
 ############################
 
+#export DJANGO_STATIC_ROOT=<path_to_static_files>
+
 #############################################
 # V1 - application feature related variables.
 #############################################

--- a/.env_SAMPLE
+++ b/.env_SAMPLE
@@ -7,9 +7,6 @@
 # Django Application Server.
 ############################
 
-export DJANGO_ENV=base
-#export DJANGO_STATIC_ROOT=<path_to_static_files>
-
 #############################################
 # V1 - application feature related variables.
 #############################################

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -195,9 +195,6 @@ if you don't already have one.
 
 Inside the `.env` file you can customize the project environment configuration.
 
-> **NOTE:**
-  For local development ensure you change the `DJANGO_ENV` variable to `local`.
-
 If you would like to manually copy the environment settings,
 copy the `.env_SAMPLE` file and un-comment each variable after
 adding your own values.

--- a/cfgov/cfgov/wsgi.py
+++ b/cfgov/cfgov/wsgi.py
@@ -11,6 +11,6 @@ import os
 
 from django.core.wsgi import get_wsgi_application
 
-os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'cfgov.settings.' + os.environ.get('DJANGO_ENV', 'base'))
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'cfgov.settings.test')
 
 application = get_wsgi_application()

--- a/cfgov/cfgov/wsgi.py
+++ b/cfgov/cfgov/wsgi.py
@@ -11,6 +11,6 @@ import os
 
 from django.core.wsgi import get_wsgi_application
 
-os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'cfgov.settings.test')
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'cfgov.settings.local')
 
 application = get_wsgi_application()

--- a/cfgov/manage.py
+++ b/cfgov/manage.py
@@ -3,7 +3,7 @@ import os
 import sys
 
 if __name__ == '__main__':
-    os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'cfgov.settings.' + os.environ.get('DJANGO_ENV', 'base'))
+    os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'cfgov.settings.local')
 
     from django.core.management import execute_from_command_line
 

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,6 @@ recreate = True
 setenv =
     GOVDELIVERY_ACCOUNT_CODE = fake_account_code
     DJANGO_SETTINGS_MODULE = cfgov.settings.test
-    DJANGO_ENV=test
     ES_PORT=9200
     ES_HOST=localhost
     SHEER_ELASTICSEARCH_INDEX=content


### PR DESCRIPTION
Also, makes the default DJANGO_SETTINGS_MODULE suitable for local development,
cfgov.settings.local