### PR TITLE
Updates gulp-sitespeedio to 0.0.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -114,6 +114,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Changed from single cf import to individual module imports.
 - Move handlebars dependency to npm from bower.
 - Change Doing Business With Us email to office email
+- Updates `gulp-sitespeedio` from `0.0.6` to `0.0.7`.
 
 ### Removed
 - Removed unused exportsOverride section,

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "gulp-plumber": "^1.0.1",
     "gulp-rename": "^1.2.2",
     "gulp-replace": "^0.5.3",
-    "gulp-sitespeedio": "0.0.6",
+    "gulp-sitespeedio": "^0.0.7",
     "gulp-sourcemaps": "^1.5.2",
     "gulp-util": "^3.0.6",
     "handlebars": "^4.0.3",


### PR DESCRIPTION
Updates gulp-sitespeedio to [0.0.7](https://github.com/dreamzmaster/gulp-sitespeedio/pull/5)

## Changes

- Updates `gulp-sitespeedio` from `0.0.6` to `0.0.7`. Also adds caret so this'll autoupdate to minor versions in the future.

## Testing

- `gulp build` should not log `Analyze your sites web performance`. `gulp test:perf` should log `Analyze your site’s web performance`.

## Review

- @KimberlyMunoz 
- @sebworks 
- @jimmynotjim 