### PR TITLE
Adding Code for Related Posts molecule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Added templates and CSS for the Sidebar Contact Info organism.
 - Added `/browse-filterable` template page
 - Added templates and CSS for the Main Contact Info organism.
+- Added templates and CSS for the Related Posts molecule.
 
 ### Changed
 - Updated the primary nav to move focus as user enters and leaves nav levels

--- a/cfgov/jinja2/v1/_includes/molecules/related-posts.html
+++ b/cfgov/jinja2/v1/_includes/molecules/related-posts.html
@@ -1,0 +1,85 @@
+{# ==========================================================================
+
+   related_posts.render()
+
+   ==========================================================================
+
+   Description:
+
+   Creates related posts markup when given:
+
+   settings:            An object used to customize the markup.
+
+   settings.posts:      An array of related posts.
+
+   settings.half_width: A Boolean indicating whether the posts should be
+                        at half width.
+
+   ========================================================================== #}
+
+{% macro render(settings) %}
+{% from 'macros/util/format/url.html' import slugify as slugify %}
+{% set defaults = {
+    'search_types': 'posts, newsroom, press release, speech, testimony',
+    'search_size':  5
+} %}
+{% do settings.update(defaults) %}
+{% set posts = settings.posts or
+               more_like_this(settings.post,
+                              search_types=settings.search_types,
+                              search_size=settings.search_size)
+%}
+<div class="m-related-posts
+            {{ 'm-related-posts__half-width'
+               if settings.half_width else '' }}">
+    <h2 class="header-slug">
+        <span class="header-slug_inner">
+            Related Posts
+        </span>
+    </h2>
+    {#% TODO: Add condition to display various related post types %#}
+    {{ _related_posts_list(posts) }}
+</div>
+{% endmacro %}
+
+
+{# ==========================================================================
+
+   _related_posts_list()
+
+   ==========================================================================
+
+   Description:
+
+   Creates related posts markup when given:
+
+   posts:      An array of related posts.
+
+   ========================================================================== #}
+
+{% macro _related_posts_list(posts) %}
+{% from 'macros/util/format/url.html' import slugify as slugify %}
+{% import 'macros/time.html' as time %}
+<ul class="m-related-posts_list
+           list list__unstyled
+           list__spaced">
+    {% for post in posts %}
+    <li class="list_item">
+        <h4 class="u-mb5">
+            <a class="list_link"
+               href="{{ post.permalink }}">
+                {{ post.title | safe }}
+            </a>
+        </h4>
+        {% if post.text %}
+        <p class="short-desc">
+            {{ post.text | safe }}
+        </p>
+        {% endif %}
+        <p class="date">
+            {{ time.render(post.date, {'date':true}) }}
+        </p>
+    </li>
+    {% endfor %}
+</ul>
+{% endmacro %}

--- a/cfgov/jinja2/v1/landing-page-2/index.html
+++ b/cfgov/jinja2/v1/landing-page-2/index.html
@@ -1,9 +1,16 @@
-{% extends 'layout-2-1-bleedbar.html' %}
+
+{% set use_side_nav_layout = request.GET['layout'] == 'sideNav' or false %}
+{% if use_side_nav_layout %}
+    {% extends 'layout-side-nav.html' %}
+{% else %}
+    {% extends 'layout-2-1-bleedbar.html' %}
+{% endif %}
 
 {# Import organisms and molecules used in the template. #}
 {% import 'molecules/text-introduction.html' as text_introduction %}
 {% import 'molecules/image-text-50-50.html' as image_text_50_50 %}
 {% import 'molecules/image-text-25-75.html' as image_text_25_75 %}
+{% import 'molecules/related-posts.html' as related_posts %}
 
 {% block title -%}
     TODO: This is a prototype page for testing landing page layouts.
@@ -12,6 +19,12 @@
 
 {# TODO: Remove lipsumText when and if it is no longer needed. #}
 {% set lipsumText = lipsum(1, false, 10, 25) | safe %}
+
+{% block content_main_modifiers -%}
+    {% if use_side_nav_layout == true %}
+    content__flush-bottom
+    {% endif %}
+{%- endblock %}
 
 {% block content_main %}
     <div class="block
@@ -78,10 +91,31 @@
 
         </div>
     </div>
+
+    {% if use_side_nav_layout == true %}
+    <div class='block
+                block__bg
+                block__flush-sides
+                block__flush-bottom
+                block__border-top
+                block__border-right'>
+        {# TODO: Add sidebar organisms. #}
+        {{ related_posts.render({
+            'post':       get_document('posts', 'four-years-working-for-you'),
+            'half_width': true
+        }) }}
+    </div>
+    {% endif %}
 {% endblock %}
 
+
 {% block content_sidebar scoped -%}
+    {% if use_side_nav_layout == false %}
     <aside>
         {# TODO: Add sidebar organisms. #}
+        {{ related_posts.render({
+            'post': get_document('posts', 'four-years-working-for-you')
+        }) }}
     </aside>
+    {% endif %}
 {%- endblock %}

--- a/cfgov/preprocessed/css/main.less
+++ b/cfgov/preprocessed/css/main.less
@@ -78,6 +78,7 @@
 @import (less) "molecules/image-text-25-75.less";
 @import (less) "molecules/text-introduction.less";
 @import (less) "molecules/call-to-action.less";
+@import (less) "molecules/related-posts.less";
 
 
 /* Organism pieces

--- a/cfgov/preprocessed/css/molecules/related-posts.less
+++ b/cfgov/preprocessed/css/molecules/related-posts.less
@@ -1,0 +1,103 @@
+/* topdoc
+  name: Related Posts
+  family: cfgov-molecules
+  patterns:
+    - name: Default example
+      markup: |
+    <div class="m-related-posts">
+        <h2 class="header-slug">
+            <span class="header-slug_inner">
+                Related Posts
+            </span>
+        </h2>
+        <section class="m-related-posts_section">
+            <h4>
+                <span class="cf-icon"></span>
+            </h4>
+            <ul class="m-related-posts_list">
+                <li class="list_item">
+                    <h4 class="u-mb5">
+                        <a class="list_link" >
+                        </a>
+                    </h4>
+                    <p class="date">
+                        <span class="datetime">
+                            <time class="datetime_date" datetime="">
+                            </time>
+                        </span>
+                    </p>
+                </li>
+            </ul>
+        </section>
+    </div>
+    codenotes:
+      - |
+        Structural cheat sheet:
+        -----------------------
+        .m-related-posts
+          .header-slug
+            .header-slug_inner
+          .m-related-posts_section
+            .h4
+              .cf-icon
+            .m-related-posts_list
+              .list-item
+                h4
+                  .list-link
+                .date
+                  .datetime
+                    .time.datetime_date
+  tags:
+    - cfgov-molecules
+*/
+
+@margin_half__em: unit(15px / @base-font-size-px, em);
+
+@list_half-width: {
+    .grid_nested-col-group();
+
+    .list_item {
+        .grid_column(6);
+    }
+
+    // Using .list__spaced items within a grid column causes unwanted
+    // extra margins because grid columns suppress margin collapsing.
+    // To counteract that we need to use a negative margin on the list.
+    // This means we also need to add a top margin to the first list
+    // item since the default .list__spaced only applies margins to
+    // .list_item + .list_item.
+    &.list__spaced {
+        margin-top: @margin_half__em * -1;
+
+        .list_item {
+            margin-top: @margin_half__em;
+        }
+    }
+};
+
+.m-related-posts__half-width {
+    .m-related-posts_list {
+        @list_half-width();
+    }
+}
+
+.m-related-posts_list {
+    .list_link {
+        .u-link__colors(@pacific, @pacific, @pacific-50, @pacific, @navy);
+        .u-link__no-border();
+
+        &:hover {
+            border-bottom: 1px dotted;
+        }
+    }
+
+    .respond-to-range(@tablet-min, @tablet-max, {
+        @list_half-width();
+    });
+}
+
+
+/* topdoc
+    name: EOF
+    eof: true
+*/


### PR DESCRIPTION

Adding Code for Related Posts molecule

## Additions

- Adding Code for Related Posts molecule.

## Testing

- Visit  `/landing-page-2/` and `landing-page-2/?layout=sideNav`.

## Review

- @jimmynotjim 
- @sebworks 
- @KimberlyMunoz 
- @Scotchester 

## Screenshots

<img width="448" alt="screen shot 2015-10-16 at 11 14 25 am" src="https://cloud.githubusercontent.com/assets/1696212/10545533/28d19726-73f7-11e5-9e79-c4e2b7d72e11.png">
<img width="675" alt="screen shot 2015-10-16 at 11 14 47 am" src="https://cloud.githubusercontent.com/assets/1696212/10545534/28d55b54-73f7-11e5-842a-da7661911764.png">

