### PR TITLE
Adds Sidebar contact info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,9 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Added wagtail specific demoPage only available in development for displaying moleclues/organisms.
 - Added `license` field to `package.json`.
 - EventArchivePage, EventRequestSpeakerPage, and EventFilterForm.
+- Added templates and CSS for the Full Width Text organism.
+- Added templates and CSS for the Contact Method molecule.
+- Added templates and CSS for the Sidebar Contact Info organism.
 
 ### Changed
 - Updated the primary nav to move focus as user enters and leaves nav levels

--- a/cfgov/jinja2/v1/_includes/molecules/contact-address.html
+++ b/cfgov/jinja2/v1/_includes/molecules/contact-address.html
@@ -1,0 +1,38 @@
+{% from 'macros/util/format/contact.html' import format_phone as format_phone %}
+
+{# ==========================================================================
+
+   contact_address.render()
+
+   ==========================================================================
+
+   Description:
+
+   Create a Contact-Address molecule.
+   See [GHE]/flapjack/Modules-V1/wiki/Contact-Address
+
+   address:          An object containing address information.
+   address.label:    A string containing a label for the address.
+   address.title:    A string containing a address name.
+   address.street:   A string containing a street address.
+   address.city:     A string containing a city.
+   address.state:    A string containing a state.
+   address.zip_code: A string containing a zip code.
+
+   ========================================================================== #}
+
+{% macro render(address) %}
+<div class="m-contact-address">
+    {% set icon = 'cf-icon-mail' %}
+    {% set title = address.label %}
+    <span class="cf-icon {{ icon }} list_icon"></span>
+    <span class="h5 list_text">{{ title }}</span>
+    <p class="short-desc">
+        <span>{{ address.title }}</span><br>
+        <span>{{ address.street }}</span><br>
+        <span>{{ address.city }}</span>,
+        <span>{{ address.state }}</span>
+        <span>{{ address.zip_code }}</span>
+    </p>
+</div>
+{% endmacro %}

--- a/cfgov/jinja2/v1/_includes/molecules/contact-email.html
+++ b/cfgov/jinja2/v1/_includes/molecules/contact-email.html
@@ -1,0 +1,33 @@
+{% from 'macros/util/format/contact.html' import format_phone as format_phone %}
+
+{# ==========================================================================
+
+   contact_email.render()
+
+   ==========================================================================
+
+   Description:
+
+   Create a Contact-Email molecule.
+   See [GHE]/flapjack/Modules-V1/wiki/Contact-Email
+
+   emails: An array containing the email addresses.
+
+   ========================================================================== #}
+
+{% macro render(emails) %}
+<div class="m-contact-email">
+    {% set icon = 'cf-icon-email' %}
+    {% set title = 'Email' %}
+
+    <span class="cf-icon {{ icon }} list_icon"></span>
+    <span class="h5 list_text">{{ title }}</span>
+    <p class="short-desc">
+        {% for email in emails %}
+            <a class="list_link" href="mailto:{{ email }}">
+            {{ email }}
+            </a><br>
+        {% endfor %}
+    </p>
+</div>
+{% endmacro %}

--- a/cfgov/jinja2/v1/_includes/molecules/contact-phone.html
+++ b/cfgov/jinja2/v1/_includes/molecules/contact-phone.html
@@ -1,0 +1,48 @@
+{# ==========================================================================
+
+   contact_phone.render()
+
+   ==========================================================================
+
+   Description:
+
+   Create a Contact-Phone molecule.
+   See [GHE]/flapjack/Modules-V1/wiki/Contact-Phone
+
+   phones:                   An array containing phone number information.
+   phones.number:            A phone number.
+   phones.vanity (Optional): An associated vanity phone number.
+   phones.tty (Optional):    An associated TTY/TDD number.
+
+   is_fax (Optional):        Boolean for phone type.
+                             Is a fax number if value is `true`.
+                             Default is `false`.
+
+   ========================================================================== #}
+
+{% macro render(phones, is_fax=false) %}
+{% from 'macros/util/format/contact.html' import format_phone as format_phone %}
+<div class="m-contact-phone">
+    {% if is_fax == true %}
+        {% set icon = 'cf-icon-fax' %}
+        {% set title = 'Fax' %}
+    {% else %}
+        {% set icon = 'cf-icon-phone' %}
+        {% set title = 'Phone' %}
+    {% endif %}
+
+    <span class="cf-icon {{ icon }} list_icon"></span>
+    <span class="h5 list_text">{{ title }}</span>
+    <p class="short-desc">
+        {% for phone in phones %}
+            <span>{{ format_phone(phone.number) }}</span>
+            {% if phone.vanity %}
+            | <span>{{ format_phone(phone.vanity) }}</span>
+            {% endif %}
+            {% if phone.tty %}
+                <br>TTY/TDD: {{ format_phone(phone.tty) }}<br>
+            {% endif %}
+        {% endfor %}
+    </p>
+</div>
+{% endmacro %}

--- a/cfgov/jinja2/v1/_includes/organisms/sidebar-contact-info.html
+++ b/cfgov/jinja2/v1/_includes/organisms/sidebar-contact-info.html
@@ -1,0 +1,82 @@
+{# ==========================================================================
+
+   sidebar_contact_info.render()
+
+   ==========================================================================
+
+   Description:
+
+   Create a Contact Information Sidebar organism.
+   See [GHE]/flapjack/Modules-V1/wiki/Contact-Information-(Sidebar)
+
+   content:                  An object containing sidebar content.
+   content.heading:          A string containing a sidebar heading.
+   content.body:             A string containing sidebar paragraph content.
+
+   contact:                  An object with contact details.
+   contact.emails:           An array containing email addresses.
+
+   contact.phones:           An array containing phone number information.
+   contact.phones.number:    An phone number.
+   contact.phones.vanity:    An associated vanity phone number.
+   contact.phones.tty:       An associated TTY/TDD number.
+
+   contact.faxes:            An object containing fax numbers.
+
+   contact.address:          An object containing address information.
+   contact.address.title:    A string containing a address name.
+   contact.address.street:   A string containing a street address.
+   contact.address.city:     A string containing a city.
+   contact.address.state:    A string containing a state.
+   contact.address.zip_code: A string containing a zip code.
+
+   ========================================================================== #}
+
+{% macro render(content, contact) %}
+{% import 'molecules/contact-email.html' as contact_email %}
+{% import 'molecules/contact-phone.html' as contact_phone %}
+{% import 'molecules/contact-address.html' as contact_address %}
+
+<div class="o-sidebar-contact-info">
+    <div class="o-sidebar-contact-info_heading">
+        <h2 class="header-slug">
+            <span class="header-slug_inner">
+                Contact Information
+            </span>
+        </h2>
+    </div>
+
+    <div class="o-sidebar-contact-info_column">
+        {% set map_details = (contact.address.street + ', ' +
+                              contact.address.city + ' ' +
+                              contact.address.state + ' ' +
+                              contact.address.zip_code) | urlencode %}
+        <figure>
+            <a href="https://www.google.com/maps/place/{{ map_details }}">
+                <img src="http://maps.googleapis.com/maps/api/staticmap?zoom=16&size=330x250&markers=color:red%7C{{ administrative_offices_map }}&scale=2" alt="">
+            </a>
+        </figure>
+
+        <h3>{{ content.heading }}</h3>
+        <p>{{ content.body }}</p>
+    </div>
+
+    <div class="o-sidebar-contact-info_column">
+
+        {{ contact_email.render(contact.emails) }}
+
+        {{ contact_phone.render(contact.phones) }}
+
+        {{ contact_phone.render(contact.faxes, true) }}
+
+        {{ contact_address.render({
+            'label':    'Mailing Address',
+            'title':    contact.address.title,
+            'street':   contact.address.street,
+            'city':     contact.address.city,
+            'state':    contact.address.state,
+            'zip_code': contact.address.zip_code
+        }) }}
+    </div>
+</div>
+{% endmacro %}

--- a/cfgov/jinja2/v1/landing-page-1/index.html
+++ b/cfgov/jinja2/v1/landing-page-1/index.html
@@ -2,10 +2,10 @@
 
 {# Import organisms and molecules used in the template. #}
 {% import 'molecules/hero.html' as hero %}
-{% import 'organisms/well.html' as well %}
 {% import 'molecules/half-width-link-blob.html' as link_blob %}
 {% import 'molecules/image-text-25-75.html' as image_text_25_75 %}
 {% import 'molecules/call-to-action.html' as call_to_action %}
+{% import 'organisms/well.html' as well %}
 
 {% block title -%}
     TODO: This is a prototype page for testing landing page layouts.

--- a/cfgov/jinja2/v1/sublanding-page-1/index.html
+++ b/cfgov/jinja2/v1/sublanding-page-1/index.html
@@ -3,6 +3,7 @@
 {# Import organisms and molecules used in the template. #}
 {% import 'molecules/text-introduction.html' as text_introduction %}
 {% import 'organisms/full-width-text.html' as full_width_text %}
+{% import 'organisms/sidebar-contact-info.html' as sidebar_contact_info %}
 
 {% block title -%}
     TODO: This is a prototype page for testing landing page layouts.
@@ -16,13 +17,16 @@
         - Sidebar with latest activities
 #}
 
+{# TODO: Remove lipsumText when and if it is no longer needed. #}
+{% set lipsumText = lipsum(1, false, 10, 25) | safe %}
+
 {% block content_main %}
     <div class="block
                 block__flush-top">
-        {{ text_introduction.render( {
+        {{ text_introduction.render({
             'heading': 'Text Introduction',
             'intro': 'Content Intro Lorem Ipsum',
-            'body': 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.',
+            'body': lipsumText,
             'link_text': 'Placeholder link',
             'link_url': '#'
         }, true ) }}
@@ -34,7 +38,23 @@
 {% endblock %}
 
 {% block content_sidebar scoped -%}
-    <aside>
-        {# TODO: Add sidebar organisms. #}
-    </aside>
+    {# TODO: Add sidebar organisms. #}
+    {{ sidebar_contact_info.render( {
+        'heading': 'Header for text below',
+        'body': lipsumText
+    }, {
+        'emails':  ['test@example.com'],
+        'phones':  [{'number': '1234567899',
+                     'vanity': '123456AAAA',
+                     'tty': '1234567899'}],
+        'faxes':   [{'number': '1234567899'}],
+        'address': {
+            'title':    'Consumer Financial Protection Bureau',
+            'street':   '1700 G Street, NW',
+            'city':     'Washington',
+            'state':    'DC',
+            'zip_code': '20552-0003'
+        }
+    }) }}
+
 {%- endblock %}

--- a/cfgov/preprocessed/css/main.less
+++ b/cfgov/preprocessed/css/main.less
@@ -73,9 +73,11 @@
 @import (less) "molecules/text-introduction.less";
 @import (less) "molecules/call-to-action.less";
 
+
 /* Organism pieces
    ========================================================================== */
 
+@import (less) "organisms/sidebar-contact-info.less";
 @import (less) "organisms/well.less";
 @import (less) "organisms/full-width-text.less";
 

--- a/cfgov/preprocessed/css/organisms/sidebar-contact-info.less
+++ b/cfgov/preprocessed/css/organisms/sidebar-contact-info.less
@@ -1,0 +1,58 @@
+
+/* topdoc
+  name: Contact Information (Sidebar)
+  family: cfgov-organisms
+  patterns:
+    - name: Default example
+      markup: |
+        <div class="o-sidebar-contact-info">
+            <h2 class="header-slug">
+                <span class="header-slug_inner">
+                    Contact Information
+                </span>
+            </h2>
+            <div class="o-sidebar-contact-info_column">
+                <figure>
+                    <a href="#">
+                        <img src="map.png" alt="">
+                    </a>
+                </figure>
+
+                <h3>Content heading</h3>
+                <p>Content body</p>
+            </div>
+            <div class="o-sidebar-contact-info_column">
+                Contact methods.
+            </div>
+        </div>
+      codenotes:
+        - |
+          Structural cheat sheet:
+          -----------------------
+          .o-sidebar-contact-info
+            .o-sidebar-contact-info_column
+  tags:
+    - cfgov-organisms
+*/
+
+.o-sidebar-contact-info {
+    margin-top: unit( @grid_gutter-width / @base-font-size-px, em );
+    margin-bottom: unit( ( @grid_gutter-width * 2 ) / @base-font-size-px, em );
+
+    &_heading {
+        .respond-to-range( @mobile-max, @tablet-max {
+            .grid_column(12);
+        } );
+    }
+
+    &_column {
+        .respond-to-range( @mobile-max, @tablet-max {
+            .grid_column(6);
+        } );
+    }
+}
+
+/* topdoc
+    name: EOF
+    eof: true
+*/


### PR DESCRIPTION
Adds Sidebar contact info organism and contact method molecule.

## Additions

- Added templates and CSS for the Contact Method molecule.
- Added templates and CSS for the Sidebar Contact Info organism.

## Testing

- Visit `/sublanding-page-1/`

## Review

- @jimmynotjim 
- @KimberlyMunoz 
- @sebworks 

## Screenshots

Desktop/Mobile:
<img width="345" alt="screen shot 2015-10-19 at 4 56 46 pm" src="https://cloud.githubusercontent.com/assets/704760/10591146/a395e510-7682-11e5-85b3-c2895da7f930.png">

Tablet:
<img width="686" alt="screen shot 2015-10-19 at 4 56 55 pm" src="https://cloud.githubusercontent.com/assets/704760/10591147/a3972b3c-7682-11e5-99b6-c2515ecc4836.png">

