### PR TITLE
Adds license field to package.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,8 +71,9 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Added templates and CSS for the Call to Action molecule.
 - Added `gulp beep` task for optional alerting when the build process
   has completed.
-- Added Molecule/Organism Streamfields  
-- Added wagtail specific demoPage only available in development for displaying moleclues/organisms
+- Added Molecule/Organism Streamfields.
+- Added wagtail specific demoPage only available in development for displaying moleclues/organisms.
+- Added `license` field to `package.json`.
 
 ### Changed
 - Updated the primary nav to move focus as user enters and leaves nav levels

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
     "type": "git",
     "url": "http://github.com/cfpb/cfgov-refresh.git"
   },
+  "license": "SEE LICENSE IN TERMS.md",
   "engines": {
     "node": ">=4.1.0"
   },


### PR DESCRIPTION
Removes npm warning.

## Additions

- Added `license` field to `package.json`.

## Testing

- `npm install` should not show `npm WARN package.json @ No license field.`

## Review

- @sebworks 
- @KimberlyMunoz 
- @jimmynotjim 