### PR TITLE
Fixes broken test for email address

### DIFF
--- a/test/browser_tests/spec_suites/doing-business-with-us.js
+++ b/test/browser_tests/spec_suites/doing-business-with-us.js
@@ -34,7 +34,7 @@ describe( 'The Doing Business with Us Page', function() {
 
   it( 'should have a contact link with main summary', function() {
     expect( page.mainSummaryContactLink.getAttribute( 'href' ) )
-    .toBe( 'mailto:david.gragan@cfpb.gov' );
+    .toBe( 'mailto:CFPB_procurement@consumerfinance.gov' );
   } );
 
   it( 'should have a Business Opportunity section', function() {


### PR DESCRIPTION
Fixes broken test introduced in https://github.com/cfpb/cfgov-refresh/commit/93ebe6e35583ab89c7de87af5e1833ee85a1c83c

## Changes

- Updates email address set in the doing business with us test.

## Testing

- `gulp test` or `gulp test --sauce=false` should not have error with `The Doing Business with Us Page should have a contact link with main summary` test.

## Review

- @jimmynotjim 
- @KimberlyMunoz 
- @sebworks 