### PR TITLE
Add wagtailsites app back into settings

### DIFF
--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -22,6 +22,7 @@ INSTALLED_APPS = (
     'wagtail.wagtailsearch',
     'wagtail.wagtailredirects',
     'wagtail.wagtailforms',
+    'wagtail.wagtailsites',
 
     'modelcluster',
     'compressor',


### PR DESCRIPTION
The site app of wagtail was removed by accident. This adds it back in.

@kave 