### PR TITLE
Fixes #1004 - Uses globally installed protractor, if available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -129,6 +129,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Move Event filter over to a Django form.
 - Updates `jsdom` to `7.0.2` from `6.5.1`.
 - Move staging hostname variable from django settings to be an environment variable
+- Uses globally installed Protractor in setup.sh, if available.
 
 ### Removed
 - Removed unused exportsOverride section,

--- a/setup.sh
+++ b/setup.sh
@@ -49,13 +49,26 @@ clean(){
 # Install project dependencies.
 install(){
   echo 'Installing project dependencies...'
+
+  # Copy globally-installed packages.
+  # Protractor - JavaScript acceptance testing.
+  if [ $(program_is_installed protractor) = 0 ]; then
+    echo 'Installing Protractor dependencies locally...'
+    npm install protractor
+    ./$NODE_DIR/protractor/bin/webdriver-manager update
+  else
+    echo 'Global Protractor installed. Copying global install locally...'
+    protractor_symlink=$(command -v protractor)
+    protractor_binary=$(readlink $protractor_symlink)
+    protractor_full_path=$(dirname $protractor_symlink)/$(dirname $protractor_binary)/../../protractor
+    mkdir -p ./$NODE_DIR/protractor
+    cp -r $protractor_full_path ./$NODE_DIR/
+  fi
+
   npm install
   bower install --config.interactive=false
 
   # Update test dependencies.
-
-  # Protractor - JavaScript acceptance testing.
-  ./$NODE_DIR/protractor/bin/webdriver-manager update
 
   # Macro Polo - Jinja template unit testing.
   pip install -r ./test/macro_tests/requirements.txt
@@ -80,7 +93,7 @@ build(){
   gulp beep
 }
 
-# Setup MYSQL Server
+# Setup MYSQL Server.
 dbsetup(){
   if which mysql.server; then
     if mysql.server status; then
@@ -93,6 +106,18 @@ dbsetup(){
     echo 'Please install MYSQL Server'
     exit
   fi
+}
+
+# Returns 1 if a global command-line program installed, else 0.
+# For example, echo "node: $(program_is_installed node)".
+program_is_installed(){
+  # Set to 1 initially.
+  local return_=1
+
+  # Set to 0 if program is not found.
+  type $1 >/dev/null 2>&1 || { local return_=0; }
+
+  echo "$return_"
 }
 
 init


### PR DESCRIPTION
Fixes #1004 - Uses globally installed protractor, if available. Chromedriver takes awhile to download. With this PR if protractor is installed globally, it will be copied into the `node_modules` directory, instead of downloading it every time. This cuts the time of `setup.sh` by approximately 40%.

## Changes

- Uses globally installed protractor in `setup.sh`, if available.

## Testing

- `npm install -g protractor && webdriver-manager update` if you don't have global protractor.
- Run `./setup.sh local`. Time should be around 2.5min, depending on Internet connection.
- `npm uninstall -g protractor`
- Run  `./setup.sh local`. Time should be about 4min, depending on Internet connection.
- Re-install global protractor, if you want the faster build time.

## Review

- @jimmynotjim 
- @KimberlyMunoz 
- @sebworks 