### PR TITLE
Fixes for sidebar contact organism

### DIFF
--- a/cfgov/jinja2/v1/_includes/molecules/contact-address.html
+++ b/cfgov/jinja2/v1/_includes/molecules/contact-address.html
@@ -25,8 +25,8 @@
 <div class="m-contact-address">
     {% set icon = 'cf-icon-mail' %}
     {% set title = address.label %}
-    <span class="cf-icon {{ icon }} list_icon"></span>
-    <span class="h5 list_text">{{ title }}</span>
+    <span class="cf-icon {{ icon }}"></span>
+    <span class="h5">{{ title }}</span>
     <p class="short-desc">
         <span>{{ address.title }}</span><br>
         <span>{{ address.street }}</span><br>

--- a/cfgov/jinja2/v1/_includes/molecules/contact-email.html
+++ b/cfgov/jinja2/v1/_includes/molecules/contact-email.html
@@ -20,11 +20,11 @@
     {% set icon = 'cf-icon-email' %}
     {% set title = 'Email' %}
 
-    <span class="cf-icon {{ icon }} list_icon"></span>
-    <span class="h5 list_text">{{ title }}</span>
+    <span class="cf-icon {{ icon }}"></span>
+    <span class="h5">{{ title }}</span>
     <p class="short-desc">
         {% for email in emails %}
-            <a class="list_link" href="mailto:{{ email }}">
+            <a href="mailto:{{ email }}">
             {{ email }}
             </a><br>
         {% endfor %}

--- a/cfgov/jinja2/v1/_includes/molecules/contact-phone.html
+++ b/cfgov/jinja2/v1/_includes/molecules/contact-phone.html
@@ -31,8 +31,8 @@
         {% set title = 'Phone' %}
     {% endif %}
 
-    <span class="cf-icon {{ icon }} list_icon"></span>
-    <span class="h5 list_text">{{ title }}</span>
+    <span class="cf-icon {{ icon }}"></span>
+    <span class="h5">{{ title }}</span>
     <p class="short-desc">
         {% for phone in phones %}
             <span>{{ format_phone(phone.number) }}</span>

--- a/cfgov/jinja2/v1/_includes/organisms/sidebar-contact-info.html
+++ b/cfgov/jinja2/v1/_includes/organisms/sidebar-contact-info.html
@@ -17,14 +17,18 @@
    contact.emails:           An array containing email addresses.
 
    contact.phones:           An array containing phone number information.
-   contact.phones.number:    An phone number.
+   contact.phones.number:    A phone number.
    contact.phones.vanity:    An associated vanity phone number.
    contact.phones.tty:       An associated TTY/TDD number.
 
    contact.faxes:            An object containing fax numbers.
+   contact.faxes.number:     A fax number.
+   contact.faxes.vanity:     An associated vanity fax number.
+   contact.faxes.tty:        An associated TTY/TDD number.
+                             This value can be used, but is not applicable.
 
    contact.address:          An object containing address information.
-   contact.address.title:    A string containing a address name.
+   contact.address.title:    A string containing an address name.
    contact.address.street:   A string containing a street address.
    contact.address.city:     A string containing a city.
    contact.address.state:    A string containing a state.
@@ -53,7 +57,7 @@
                               contact.address.zip_code) | urlencode %}
         <figure>
             <a href="https://www.google.com/maps/place/{{ map_details }}">
-                <img src="http://maps.googleapis.com/maps/api/staticmap?zoom=16&size=330x250&markers=color:red%7C{{ administrative_offices_map }}&scale=2" alt="">
+                <img src="http://maps.googleapis.com/maps/api/staticmap?zoom=16&size=330x250&markers=color:red%7C{{ map_details }}&scale=2" alt="">
             </a>
         </figure>
 

--- a/cfgov/jinja2/v1/sublanding-page-1/index.html
+++ b/cfgov/jinja2/v1/sublanding-page-1/index.html
@@ -24,11 +24,11 @@
     <div class="block
                 block__flush-top">
         {{ text_introduction.render({
-            'heading': 'Text Introduction',
-            'intro': 'Content Intro Lorem Ipsum',
-            'body': lipsumText,
+            'heading':   'Text Introduction',
+            'intro':     'Content Intro Lorem Ipsum',
+            'body':      lipsumText,
             'link_text': 'Placeholder link',
-            'link_url': '#'
+            'link_url':  '#'
         }, true ) }}
     </div>
 
@@ -39,9 +39,9 @@
 
 {% block content_sidebar scoped -%}
     {# TODO: Add sidebar organisms. #}
-    {{ sidebar_contact_info.render( {
+    {{ sidebar_contact_info.render({
         'heading': 'Header for text below',
-        'body': lipsumText
+        'body':    lipsumText
     }, {
         'emails':  ['test@example.com'],
         'phones':  [{'number': '1234567899',

--- a/cfgov/preprocessed/css/organisms/sidebar-contact-info.less
+++ b/cfgov/preprocessed/css/organisms/sidebar-contact-info.less
@@ -40,13 +40,13 @@
     margin-bottom: unit( ( @grid_gutter-width * 2 ) / @base-font-size-px, em );
 
     &_heading {
-        .respond-to-range( @mobile-max, @tablet-max {
+        .respond-to-range( @tablet-min, @tablet-max {
             .grid_column(12);
         } );
     }
 
     &_column {
-        .respond-to-range( @mobile-max, @tablet-max {
+        .respond-to-range( @tablet-min, @tablet-max {
             .grid_column(6);
         } );
     }


### PR DESCRIPTION
Fixes for sidebar contact organism based on feedback in https://github.com/cfpb/cfgov-refresh/pull/1099.

## Removals

- Unneeded list classes.
- Unneeded `administrative_offices_map`.

## Changes

- Code comment formatting, missing fax values, and grammatical errors.
- Replaces `@mobile-max` with `@tablet-min` in range value.

## Testing

- Visit `/sublanding-page-1/`
Only change is email address link is no longer bold without the link classes, which I believe is correct anyway:

![screen shot 2015-10-27 at 10 53 55 am](https://cloud.githubusercontent.com/assets/704760/10761733/156b3372-7c99-11e5-8714-01ce07d80d91.png)

![screen shot 2015-10-27 at 10 54 00 am](https://cloud.githubusercontent.com/assets/704760/10761734/1579c78e-7c99-11e5-9a77-2d7cf0cbd1ca.png)


## Review

- @jimmynotjim 
- @sebworks 
- @KimberlyMunoz 
