### PR TITLE
Adds main contact info organism

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Added templates and CSS for the Contact Method molecule.
 - Added templates and CSS for the Sidebar Contact Info organism.
 - Added `/browse-filterable` template page
+- Added templates and CSS for the Main Contact Info organism.
 
 ### Changed
 - Updated the primary nav to move focus as user enters and leaves nav levels

--- a/cfgov/jinja2/v1/_includes/molecules/contact-address.html
+++ b/cfgov/jinja2/v1/_includes/molecules/contact-address.html
@@ -1,5 +1,3 @@
-{% from 'macros/util/format/contact.html' import format_phone as format_phone %}
-
 {# ==========================================================================
 
    contact_address.render()
@@ -13,7 +11,7 @@
 
    address:          An object containing address information.
    address.label:    A string containing a label for the address.
-   address.title:    A string containing a address name.
+   address.title:    A string containing an address name.
    address.street:   A string containing a street address.
    address.city:     A string containing a city.
    address.state:    A string containing a state.
@@ -23,12 +21,12 @@
 
 {% macro render(address) %}
 <div class="m-contact-address">
-    {% set icon = 'cf-icon-mail' %}
-    {% set title = address.label %}
-    <span class="cf-icon {{ icon }}"></span>
-    <span class="h5">{{ title }}</span>
+    <span class="cf-icon cf-icon-mail"></span>
+    <span class="h5">{{ address.label }}</span>
     <p class="short-desc">
-        <span>{{ address.title }}</span><br>
+        {% if address.title %}
+            <span>{{ address.title }}</span><br>
+        {% endif %}
         <span>{{ address.street }}</span><br>
         <span>{{ address.city }}</span>,
         <span>{{ address.state }}</span>

--- a/cfgov/jinja2/v1/_includes/molecules/contact-email.html
+++ b/cfgov/jinja2/v1/_includes/molecules/contact-email.html
@@ -1,5 +1,3 @@
-{% from 'macros/util/format/contact.html' import format_phone as format_phone %}
-
 {# ==========================================================================
 
    contact_email.render()
@@ -17,11 +15,8 @@
 
 {% macro render(emails) %}
 <div class="m-contact-email">
-    {% set icon = 'cf-icon-email' %}
-    {% set title = 'Email' %}
-
-    <span class="cf-icon {{ icon }}"></span>
-    <span class="h5">{{ title }}</span>
+    <span class="cf-icon cf-icon-email"></span>
+    <span class="h5">Email</span>
     <p class="short-desc">
         {% for email in emails %}
             <a href="mailto:{{ email }}">

--- a/cfgov/jinja2/v1/_includes/molecules/contact-phone.html
+++ b/cfgov/jinja2/v1/_includes/molecules/contact-phone.html
@@ -25,14 +25,14 @@
 <div class="m-contact-phone">
     {% if is_fax == true %}
         {% set icon = 'cf-icon-fax' %}
-        {% set title = 'Fax' %}
+        {% set label = 'Fax' %}
     {% else %}
         {% set icon = 'cf-icon-phone' %}
-        {% set title = 'Phone' %}
+        {% set label = 'Phone' %}
     {% endif %}
 
     <span class="cf-icon {{ icon }}"></span>
-    <span class="h5">{{ title }}</span>
+    <span class="h5">{{ label }}</span>
     <p class="short-desc">
         {% for phone in phones %}
             <span>{{ format_phone(phone.number) }}</span>

--- a/cfgov/jinja2/v1/_includes/organisms/main-contact-info.html
+++ b/cfgov/jinja2/v1/_includes/organisms/main-contact-info.html
@@ -1,0 +1,73 @@
+{# ==========================================================================
+
+   main_contact_info.render()
+
+   ==========================================================================
+
+   Description:
+
+   Create a Main Contact Information organism.
+   See [GHE]/flapjack/Modules-V1/wiki/Contact-Information-(Main-Content-Area)
+
+   content:                  An object containing main content.
+   content.heading:          A string containing a heading.
+   content.body:             A string containing paragraph content.
+
+   contact:                  An object with contact details.
+   contact.emails:           An array containing email addresses.
+
+   contact.phones:           An array containing phone number information.
+   contact.phones.number:    A phone number.
+   contact.phones.vanity:    An associated vanity phone number.
+   contact.phones.tty:       An associated TTY/TDD number.
+
+   contact.faxes:            An object containing fax numbers.
+   contact.faxes.number:     A fax number.
+   contact.faxes.vanity:     An associated vanity fax number.
+   contact.faxes.tty:        An associated TTY/TDD number.
+                             This value can be used, but is not applicable.
+
+   contact.address:          An object containing address information.
+   contact.address.title:    A string containing an address name.
+   contact.address.street:   A string containing a street address.
+   contact.address.city:     A string containing a city.
+   contact.address.state:    A string containing a state.
+   contact.address.zip_code: A string containing a zip code.
+
+   ========================================================================== #}
+
+{% macro render(content, contact) %}
+{% import 'molecules/contact-email.html' as contact_email %}
+{% import 'molecules/contact-phone.html' as contact_phone %}
+{% import 'molecules/contact-address.html' as contact_address %}
+
+<div class="o-main-contact-info">
+    <h2>{{ content.heading }}</h2>
+    <p>{{ content.body }}</p>
+
+    {% if contact %}
+        {% if contact.emails %}
+            {{ contact_email.render(contact.emails) }}
+        {% endif %}
+
+        {% if contact.phones %}
+            {{ contact_phone.render(contact.phones) }}
+        {% endif %}
+
+        {% if contact.faxes %}
+            {{ contact_phone.render(contact.faxes, true) }}
+        {% endif %}
+
+        {% if contact.address %}
+            {{ contact_address.render({
+                'label':    'Mailing Address',
+                'title':    contact.address.title,
+                'street':   contact.address.street,
+                'city':     contact.address.city,
+                'state':    contact.address.state,
+                'zip_code': contact.address.zip_code
+            }) }}
+        {% endif %}
+    {% endif %}
+</div>
+{% endmacro %}

--- a/cfgov/jinja2/v1/sublanding-page-1/index.html
+++ b/cfgov/jinja2/v1/sublanding-page-1/index.html
@@ -46,7 +46,7 @@
         'emails':  ['test@example.com'],
         'phones':  [{'number': '1234567899',
                      'vanity': '123456AAAA',
-                     'tty': '1234567899'}],
+                     'tty':    '1234567899'}],
         'faxes':   [{'number': '1234567899'}],
         'address': {
             'title':    'Consumer Financial Protection Bureau',

--- a/cfgov/jinja2/v1/sublanding-page-2/index.html
+++ b/cfgov/jinja2/v1/sublanding-page-2/index.html
@@ -1,7 +1,7 @@
 {% extends 'layout-2-1-bleedbar.html' %}
 
 {# Import organisms and molecules used in the template. #}
-{% import 'molecules/hero.html' as hero %}
+{% import 'organisms/main-contact-info.html' as main_contact_info %}
 
 {% block title -%}
     TODO: This is a prototype page for testing landing page layouts.
@@ -10,16 +10,29 @@
 
 {#
     TODO: Add the following molecules
+        - Hero
         - Post feed
         - Grey well
         - Sidebar with related content and mailing list
 #}
 
+{# TODO: Remove lipsumText when and if it is no longer needed. #}
+{% set lipsumText = lipsum(1, false, 10, 25) | safe %}
+
 {% block content_main %}
     <div class="block
                 block__flush-top">
         {# TODO: Add main molecules and organisms. #}
-        {{ hero.render() }}
+
+        {{ main_contact_info.render( {
+            'heading': 'Whistleblower tips',
+            'body': lipsumText
+        }, {
+            'emails':  ['test@example.com'],
+            'phones':  [{'number': '1234567899',
+                         'vanity': '123456AAAA',
+                         'tty':    '1234567899'}]
+        }) }}
     </div>
 
 {% endblock %}


### PR DESCRIPTION
[GHE]/flapjack/Modules-V1/wiki/Contact-Information-(Main-Content-Area)

## Additions

- Adds templates and CSS for the Main Contact Info organism.

## Removals

- Unneeded phone format imports.

## Changes

- Adds logic for optional contact fields.
- Renames contact method title to label, to disambiguate address title and label.
- Fixes code comment grammar.
- Moves placeholder hero text to code comment.

## Testing

- Visit `/sublanding-page-2/`

## Review

- @KimberlyMunoz 
- @sebworks 
- @jimmynotjim 

## Screenshots

![screen shot 2015-10-27 at 12 34 03 pm](https://cloud.githubusercontent.com/assets/704760/10765253/32dff852-7ca8-11e5-8c72-99cd7e7916d8.png)