### PR TITLE
Fix for Related Post molecule

### DIFF
--- a/cfgov/preprocessed/css/molecules/related-posts.less
+++ b/cfgov/preprocessed/css/molecules/related-posts.less
@@ -77,7 +77,9 @@
 
 .m-related-posts__half-width {
     .m-related-posts_list {
-        @list_half-width();
+        .respond-to-min(@tablet-min {
+            @list_half-width();
+        });
     }
 }
 


### PR DESCRIPTION
Fix for Related Post molecule

## Updating

- Updating `cfgov/preprocessed/css/molecules/related-posts.less` to fix half width issue on mobile.

## Testing

- Visit  `http://localhost:8000/landing-page-2/?layout=sideNav` and resize window to 599px.

## Review

- @jimmynotjim 
- @sebworks 
- @KimberlyMunoz 

## Screenshots
<img width="386" alt="screen shot 2015-10-29 at 1 11 47 pm" src="https://cloud.githubusercontent.com/assets/1696212/10826149/b2a8502e-7e3e-11e5-884f-e03091ad90e2.png">
