### PR TITLE
Post-Preview Organism

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Added templates and CSS for the Main Contact Info organism.
 - Added templates and CSS for the Related Posts molecule.
 - Added templates for the Hero molecule (CSS is in CF-Layout v1.3.0)
+- Added template for post-preview molecule
 
 ### Changed
 - Updated the primary nav to move focus as user enters and leaves nav levels

--- a/cfgov/jinja2/v1/_includes/organisms/post-preview.html
+++ b/cfgov/jinja2/v1/_includes/organisms/post-preview.html
@@ -1,0 +1,115 @@
+
+{# ==========================================================================
+
+   post_preview.render()
+
+   ==========================================================================
+
+   Description:
+
+   Render an article when given:
+
+   settings:
+
+   settings.heading:            A string with the title of the post.
+   settings.body:               A string with content of post preview/post summary.
+   settings.author:             An array with authors of the post.
+   settings.published_date:     A datetime object with published date.
+
+   settings.image_url:          A string with the url of the thumbnail image.
+   settings.image_alt:          A string with the alt text of the thumbnail image.
+
+   settings.post_category:      An array with the categories for the post. Up to 2.
+   settings.post_tags:          An array with the post tags for the post.
+
+   settings.event_location:     A string with the event location.
+   settings.event_date:         A datetime object with the time of the event.
+
+   settings.comments_close_date: A datetime object marking the deadline of the comment period.
+   settings.link_text:      A string with the description text of an external link.
+   settings.link_url:  A string with the url of an external link.
+
+   path:                        A string with the path for the homepage of the pagetype
+                                `/blog/`, `/newsroom/`
+
+   ========================================================================== #}
+
+{% macro render(settings, path) %}
+
+{% import 'macros/share.html' as share with context %}
+{% import 'category-slug.html' as category_slug %}
+{% import 'macros/time.html' as time %}
+
+<article class="o-post-preview">
+    <div class="meta-header">
+        <span class="date meta-header_right">
+            Published {{ time.render(settings.published_date, {'date':true}) }}
+        </span>
+        {% if settings.post_category.0 %}
+            {% set use_post_category = true %}
+            {{ category_slug.render(settings.post_category.0,
+                                    path,
+                                    'post_slug meta-header_left',
+                                    use_post_category) }}
+        {% endif %}
+        {% if settings.post_category.1 %}
+            |
+            {{ category_slug.render(settings.post_category.1,
+                                    path,
+                                    'post_slug meta-header_left',
+                                    use_post_category) }}
+        {% endif %}
+    </div>
+    {% if settings.image_url %}
+        <div class="o-post-preview_image-container">
+            <img class="o-post-preview_image"
+                 src="{{ settings.image_url }}"
+                 alt="{{ settings.image_alt if settings.image_alt else '' }}">
+        </div>
+    {% endif %}
+    <div class="o-post-preview_content">
+        <h3 class="o-post-preview_title">
+            {{ settings.heading | safe }}
+        </h3>
+        {% if settings.event_location %}
+            <span class="o-post-preview_subtitle h6">
+            {{settings.event_location}} - {{ time.render(settings.event_date) }}
+            </span>
+        {% endif %}
+        {% if settings.comments_close_date %}
+            <span class="o-post-preview_subtitle">
+            Comments close {{ time.render(settings.comments_close_date, {'date':true}) }}
+            </span>
+        {% endif %}
+        {% if settings.post_content %}
+            <p class="o-post-preview_description">
+                {{ settings.body | safe }}
+            </p>
+        {% endif %}
+        <div class="post_meta">
+            {% if settings.author | length %}
+                    <span class="o-post-preview_byline">
+                        By <a href="{{ path }}?filter_author={{ settings.author.0 }}">
+                            {{ settings.author.0 }}
+                        </a>
+                        {% if settings.author.1 %}
+                            and <a href="{{ path }}?filter_author={{ settings.author.1 }}">
+                                {{ settings.author.1 }}
+                            </a>
+                        {% endif %}
+                    </span>
+            {% endif %}
+            {% if settings.post_tags | length %}
+                {%- import 'tags.html' as tags %}
+                {{ tags.render(settings.post_tags, path, true, false) }}
+            {% endif %}
+        </div>
+        {% if settings.link_url %}
+            <a href="{{ settings.link_url }}" class="jump-link jump-link__underline">
+                {{ settings.link_text }}
+            </a>
+        {% endif %}
+    </div>
+</article>
+
+{% endmacro %}

--- a/cfgov/jinja2/v1/_includes/tags.html
+++ b/cfgov/jinja2/v1/_includes/tags.html
@@ -31,7 +31,7 @@
 
 {% macro render(tags, path, hide_heading=false, display_block=false) %}
 <div class="tags {{'tags__hide-heading' if hide_heading else ''}} {{'tags__block-list' if display_block else '' }}">
-    <span class="tags_heading {{'u-visually-hidden' if hide_heading}}">Topics:</span>
+    <span class="{{'u-visually-hidden' if hide_heading else 'tags_heading' }}">Topics:</span>
     <ul class="tags_list">
     {% for tag in tags %}
         <li class="tags_tag">

--- a/cfgov/jinja2/v1/browse-filterable/index.html
+++ b/cfgov/jinja2/v1/browse-filterable/index.html
@@ -2,6 +2,7 @@
 
 {# Import organisms and molecules used in the template. #}
 {% import 'molecules/text-introduction.html' as text_introduction %}
+{% import 'organisms/post-preview.html' as post_preview %}
 
 {% block title -%}
     TODO: This is a prototype page for testing landing page layouts.
@@ -22,6 +23,54 @@
             'link_text': 'Placeholder link',
             'link_url': '#'
         }) }}
+    </div>
+    <div class="block">
+        {{ post_preview.render({
+            'heading': 'This is a blog post',
+            'body': lipsumText,
+            'published_date': '20030805T213611',
+            'image_url': 'http://www.placehold.it/160x90',
+            'post_category': ['Info for Consumers', 'At the CFPB'],
+            'author': ['Tom', 'Jerry'],
+            'post_tags': ['FOIA', 'Mortgage']
+            },
+            '/blog/') }}
+    </div>
+    <div class="block">
+        {{ post_preview.render({
+            'heading': 'This is a newsroom post',
+            'body': lipsumText,
+            'published_date': '20030805T213611',
+            'post_category': ['Press Release'],
+            'author': ['Tom', 'Jerry'],
+            'post_tags': ['FOIA', 'Mortgage']
+            },
+            '/newsroom/') }}
+    </div>
+    <div class="block">
+        {{ post_preview.render({
+            'heading': 'This is a event post',
+            'body': lipsumText,
+            'published_date': '20030805T213611',
+            'image_url': 'http://www.placehold.it/160x90',
+            'post_category': ['Speech'],
+            'post_tags': ['FOIA', 'Mortgage'],
+            'event_location': 'The White House, Washington, DC',
+            'event_date': '20030805T213611'
+            },
+            '/events/') }}
+    </div>
+    <div class="block">
+        {{ post_preview.render({
+            'heading': 'This is a notice & comment post',
+            'body': lipsumText,
+            'published_date': '20030805T213611',
+            'post_category': ['Notice of request for public comment'],
+            'external_link': 'Submit a comment',
+            'external_link_url': 'http://www.google.com/',
+            'comments_close_date': '20030805T213611'
+            },
+            '') }}
     </div>
 {% endblock %}
 

--- a/cfgov/preprocessed/css/cf-enhancements.less
+++ b/cfgov/preprocessed/css/cf-enhancements.less
@@ -1458,6 +1458,23 @@ ul:last-child,
 }
 
 /* topdoc
+  name: Adjustments to meta-header
+  family: cf-typography
+  notes:
+    - "Temporary changes to meta-header to be ported to cf-typography to allow better adjustments on mobile"
+  tags:
+    - cf-layout
+*/
+
+
+.meta-header_right {
+    .respond-to-max(@mobile-max, {
+        margin-bottom: unit( (@grid_gutter-width / 2) / @base-font-size-px, em);
+    });
+}
+
+
+/* topdoc
     name: EOF
     eof: true
 */

--- a/cfgov/preprocessed/css/main.less
+++ b/cfgov/preprocessed/css/main.less
@@ -89,6 +89,7 @@
 @import (less) "organisms/well.less";
 @import (less) "organisms/full-width-text.less";
 @import (less) "organisms/link-blob-group.less";
+@import (less) "organisms/post-preview.less";
 
 
 /* Template pieces

--- a/cfgov/preprocessed/css/meta.less
+++ b/cfgov/preprocessed/css/meta.less
@@ -253,7 +253,7 @@
         .u-link__colors(@gray, @gray, @gray, @gray, @gray,
                         @gold-80, @gold-80, @gold-80, @gold-80, @gold-80);
 
-        .respond-to-max(@tablet-max, {
+        .respond-to-max(@mobile-max, {
             .u-link__no-border();
         });
 

--- a/cfgov/preprocessed/css/organisms/post-preview.less
+++ b/cfgov/preprocessed/css/organisms/post-preview.less
@@ -1,0 +1,108 @@
+/* topdoc
+  name: Post Preview
+  family: cfgov-organisms
+  patterns:
+     - name: Default post
+      markup: |
+        <article class="o-post-preview">
+            <div class="meta-header">
+                <span class="date meta-header_right">
+                    Published
+                    <span class="datetime">
+                        <time class="datetime_date" datetime="2003-08-05T21:36:11.000000-0400">
+                            AUG 05, 2003
+                        </time>
+                    </span>
+                </span>
+                <a href="/blog/?filter_blog_category=Info+for+Consumers" class="category-slug post_slug meta-header_left">
+                    <span class="category-slug_icon cf-icon cf-icon-information"></span>
+                    <span class="u-visually-hidden">Category:</span>
+                    Info for Consumers
+                </a>
+            </div>
+            <div class="o-post-preview_image-container">
+                <img class="o-post-preview_image" src="http://www.placehold.it/160x90" alt="">
+            </div>
+            <div class="o-post-preview_content">
+                <h3 class="o-post-preview_title">
+                    This is a blog post
+                </h3>
+                <p class="o-post-preview_description">
+                    Sed senectus feugiat arcu tempor, ac vulputate sem pulvinar porta hendrerit magnis, interdum habitasse taciti.
+                </p>
+                <div class="post_meta">
+                    <span class="o-post-preview_byline">
+                        By <a href="/blog/?filter_author=Tom">
+                            Tom
+                        </a> and
+                        <a href="/blog/?filter_author=Jerry">
+                            Jerry
+                        </a>
+                    </span>
+                </div>
+                <div class="tags tags__hide-heading">
+                    <span class="u-visually-hidden">Topics:</span>
+                    <ul class="tags_list">
+                        <li class="tags_tag">
+                            <a class="tags_link" href="/blog/?filter_tags=FOIA&amp;filter_topics=FOIA">
+                                <span class="tags_bullet" aria-hidden="true">•</span>
+                                FOIA
+                            </a>
+                        </li>
+                        <li class="tags_tag">
+                            <a class="tags_link" href="/blog/?filter_tags=Mortgage&amp;filter_topics=Mortgage">
+                                <span class="tags_bullet" aria-hidden="true">•</span>
+                                Mortgage
+                            </a>
+                        </li>
+                    </ul>
+                </div>
+          </div>
+      </article>
+      codenotes:
+        - |
+          Structural cheat sheet:
+          -----------------------
+          article.o-post-preview
+            div.meta-header
+            div.o-post-preview_image-container
+                img.o-post-preview_image
+            div.o-post-preview_content
+                h3.o-post-preview_title
+                p.o-post-preview_description
+            p.post_dek
+            div.post_meta
+              span.post_byline
+              span.post_date
+              div.post_meta
+                span.o-post-preview_byline
+                div.tags
+  tags:
+    - cfgov-organisms
+*/
+
+.o-post-preview {
+    .webfont-regular();
+    &_image-container {
+        .respond-to-max(@tablet-max, {
+            margin-bottom: unit( @grid_gutter-width / @base-font-size-px, em );
+        });
+        .respond-to-min(@desktop-min, {
+            .grid_column(4);
+        });
+    }
+    &_image {
+        display: block;
+        width: 100%;
+  }
+}
+
+.o-post-preview_image-container + .o-post-preview_content {
+    .respond-to-min(@desktop-min, {
+        .grid_column(8);
+    });
+}
+/* topdoc
+    name: EOF
+    eof: true
+*/


### PR DESCRIPTION
The Post Preview organism which will be used for newsroom, blog posts, events and notices. The map/calendar icon for the events is still being worked on in a separate PR, but wanted to get this in since it's a large organism.

## Additions

- Added post-preview organism

## Changes

- Fixed specs on topic tag 
- Fixed spacing for meta-header

## Testing
- Visit http://localhost:3000/browse-filterable/

## Review

- @jimmynotjim 
- @anselmbradford 
- @sebworks 

## Preview

![image](https://cloud.githubusercontent.com/assets/1860176/10827018/e5bca88a-7e42-11e5-8a28-6530073b834e.png)

[Preview this PR without the whitespace changes](?w=0)

## Notes

- DFJR-425
- GHE/flapjack/Modules-V1/issues/16