### PR TITLE
Adds Contact to the backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,8 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Adds ability to import snippets
 - Added ImageText2575 molecule backend model and template
 - Added Call to Action backend and template
+- Added Contact snippet and molecule backends
+- Added temporary folder for converted Jinja2 Wagtail field template files
 
 ### Changed
 - Updated the primary nav to move focus as user enters and leaves nav levels
@@ -146,6 +148,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Modifies command line options to allow specifying arguments for importing pages or snippets
 - Changes the way the processor module is imported so it imports it using the [app] argument
 - Moves the processors module from the core.management.commands module to the v1 app
+- Contact molecule templates
 
 ### Removed
 - Removed unused exportsOverride section,

--- a/cfgov/jinja2/v1/wagtail/molecules/contact-address.html
+++ b/cfgov/jinja2/v1/wagtail/molecules/contact-address.html
@@ -1,0 +1,34 @@
+{# ==========================================================================
+
+   contact_address
+
+   ==========================================================================
+
+   Description:
+
+   Create a Contact-Address molecule.
+   See [GHE]/flapjack/Modules-V1/wiki/Contact:-Address
+
+   value:          An object containing address information.
+   value.label:    A string containing a label for the address.
+   value.title:    A string containing an address name.
+   value.street:   A string containing a street address.
+   value.city:     A string containing a city.
+   value.state:    A string containing a state.
+   value.zip_code: A string containing a zip code.
+
+   ========================================================================== #}
+
+<div class="m-contact-address">
+    <span class="cf-icon cf-icon-mail"></span>
+    <span class="h5">{{ value.label }}</span>
+    <p class="short-desc">
+        {% if value.title %}
+            <span>{{ value.title }}</span><br>
+        {% endif %}
+        <span>{{ value.street }}</span><br>
+        <span>{{ value.city }}</span>,
+        <span>{{ value.state }}</span>
+        <span>{{ value.zip_code }}</span>
+    </p>
+</div>

--- a/cfgov/jinja2/v1/wagtail/molecules/contact-email.html
+++ b/cfgov/jinja2/v1/wagtail/molecules/contact-email.html
@@ -1,0 +1,26 @@
+{# ==========================================================================
+
+   contact_email
+
+   ==========================================================================
+
+   Description:
+
+   Create a Contact-Email molecule.
+   See [GHE]/flapjack/Modules-V1/wiki/Contact:-Email
+
+   value.emails: An array containing the email addresses.
+
+   ========================================================================== #}
+
+<div class="m-contact-email">
+    <span class="cf-icon cf-icon-email"></span>
+    <span class="h5">Email</span>
+    <p class="short-desc">
+        {% for email in value.emails %}
+            <a href="mailto:{{ email.href }}">
+              {{ email.label }}
+            </a><br>
+        {% endfor %}
+    </p>
+</div>

--- a/cfgov/jinja2/v1/wagtail/molecules/contact-phone.html
+++ b/cfgov/jinja2/v1/wagtail/molecules/contact-phone.html
@@ -1,0 +1,46 @@
+{# ==========================================================================
+
+   contact_phone
+
+   ==========================================================================
+
+   Description:
+
+   Create a Contact-Phone molecule.
+   See [GHE]/flapjack/Modules-V1/wiki/Contact:-Phone
+
+   value:                  An object containing phone number information.
+   value.phones.number:    A phone number.
+   value.phones.vanity:    An associated vanity phone number.
+   value.phones.tty:       An associated TTY/TDD number.
+
+   value.is_fax:           Boolean for phone type.
+                             Is a fax number if value is `true`.
+                             Default is `false`.
+
+   ========================================================================== #}
+
+{% from 'macros/util/format/contact.html' import format_phone as format_phone %}
+<div class="m-contact-phone">
+    {% if value.is_fax %}
+        {% set icon = 'cf-icon-fax' %}
+        {% set label = 'Fax' %}
+    {% else %}
+        {% set icon = 'cf-icon-phone' %}
+        {% set label = 'Phone' %}
+    {% endif %}
+
+    <span class="cf-icon {{ icon }}"></span>
+    <span class="h5">{{ label }}</span>
+    <p class="short-desc">
+        {% for phone in value.phones %}
+            <span>{{ format_phone(phone.number) }}</span>
+            {% if phone.vanity %}
+            | <span>{{ format_phone(phone.vanity) }}</span>
+            {% endif %}
+            {% if phone.tty %}
+                <br>TTY/TDD: {{ format_phone(phone.tty) }}<br>
+            {% endif %}
+        {% endfor %}
+    </p>
+</div>

--- a/cfgov/jinja2/v1/wagtail/organisms/main-contact-info.html
+++ b/cfgov/jinja2/v1/wagtail/organisms/main-contact-info.html
@@ -1,0 +1,26 @@
+{# ==========================================================================
+
+   main_contact_info
+
+   ==========================================================================
+
+   Description:
+
+   Create a Main Contact Information organism.
+   See [GHE]/flapjack/Modules-V1/wiki/Contact-Information-(Main-Content-Area)
+
+   page.contact:             An object containing contact metadata.
+   page.contact.heading:     A string containing a heading.
+   page.contact.body:        A string containing paragraph content.
+
+   page.contact.contact_info: An object with contact details.                            
+
+   ========================================================================== #}
+
+<div class="o-main-contact-info">
+    <h2>{{ page.contact.heading }}</h2>
+    <p>{{ page.contact.body }}</p>
+    {% for item in page.contact.contact_info %}
+        {{ item }}
+    {% endfor %}
+</div>

--- a/cfgov/jinja2/v1/wagtail/organisms/sidebar-contact-info.html
+++ b/cfgov/jinja2/v1/wagtail/organisms/sidebar-contact-info.html
@@ -1,0 +1,55 @@
+{# ==========================================================================
+
+   sidebar_contact_info
+
+   ==========================================================================
+
+   Description:
+
+   Create a Contact Information Sidebar organism.
+   See [GHE]/flapjack/Modules-V1/wiki/Contact-Information-(Sidebar)
+
+   page.contact:             An object containing contact metadata.
+   page.contact.heading:     A string containing a heading.
+   page.contact.body:        A string containing paragraph content.
+
+   page.contact.contact_info:
+                             An object with contact details.
+
+   ========================================================================== #}
+
+<div class="o-sidebar-contact-info">
+    <div class="o-sidebar-contact-info_heading">
+        <h2 class="header-slug">
+            <span class="header-slug_inner">
+                Contact Information
+            </span>
+        </h2>
+    </div>
+
+    <div class="o-sidebar-contact-info_column">
+        {% for block in page.contact.contact_info %}
+            {% if block.block_type == 'address' %}
+                {% set map_details = (block.bound_blocks.street + ', ' +
+                                      block.bound_blocks.city + ' ' +
+                                      block.bound_blocks.state + ' ' +
+                                      block.bound_blocks.zip_code)
+                                      | urlencode %}
+            {% endif %}
+        {% endfor %}
+        <figure>
+            <a href="https://www.google.com/maps/place/{{ map_details }}">
+                <img src="http://maps.googleapis.com/maps/api/staticmap?zoom=16&size=330x250&markers=color:red%7C{{ map_details }}&scale=2" alt="">
+            </a>
+        </figure>
+
+        <h3>{{ page.contact.heading }}</h3>
+        <p>{{ page.contact.body }}</p>
+    </div>
+
+    <div class="o-sidebar-contact-info_column">
+        {% for block in page.contact.contact_info %}
+            {{ block }}
+        {% endfor %}
+    </div>
+</div>

--- a/cfgov/v1/migrations/0006_contactsnippet_contactmolecules.py
+++ b/cfgov/v1/migrations/0006_contactsnippet_contactmolecules.py
@@ -1,0 +1,101 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import wagtail.wagtailimages.blocks
+import wagtail.wagtailcore.fields
+import wagtail.wagtailcore.blocks
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('v1', '0005_eventarchivepage_eventrequestspeakerpage'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='Contact',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('heading', models.CharField(max_length=22)),
+                ('body', wagtail.wagtailcore.fields.RichTextField(blank=True)),
+                ('contact_info', wagtail.wagtailcore.fields.StreamField(
+                    [
+                        (b'email', wagtail.wagtailcore.blocks.StructBlock(
+                            [
+                                (b'emails', wagtail.wagtailcore.blocks.ListBlock(wagtail.wagtailcore.blocks.StructBlock(
+                                        [
+                                            (b'label', wagtail.wagtailcore.blocks.CharBlock(max_length=22)),
+                                            (b'href', wagtail.wagtailcore.blocks.CharBlock(default=b'/'))
+                                        ], label=b'Email')))
+                            ])
+                        ),
+                        (b'phone', wagtail.wagtailcore.blocks.StructBlock(
+                            [
+                                (b'fax', wagtail.wagtailcore.blocks.BooleanBlock(default=False, required=False, label=b'Fax?')),
+                                (b'phones', wagtail.wagtailcore.blocks.ListBlock(wagtail.wagtailcore.blocks.StructBlock(
+                                    [
+                                        (b'number', wagtail.wagtailcore.blocks.CharBlock(max_length=15)),
+                                        (b'vanity', wagtail.wagtailcore.blocks.CharBlock(max_length=15, required=False)),
+                                        (b'tty', wagtail.wagtailcore.blocks.CharBlock(max_length=15, required=False))
+                                    ]))
+                                )
+                            ])
+                        ),
+                        (b'address', wagtail.wagtailcore.blocks.StructBlock(
+                            [
+                                (b'label', wagtail.wagtailcore.blocks.CharBlock(max_length=50)),
+                                (b'title', wagtail.wagtailcore.blocks.CharBlock(max_length=100, required=False)),
+                                (b'street', wagtail.wagtailcore.blocks.CharBlock(max_length=100)),
+                                (b'city', wagtail.wagtailcore.blocks.CharBlock(max_length=50)),
+                                (b'state', wagtail.wagtailcore.blocks.CharBlock(max_length=25)),
+                                (b'zip_code', wagtail.wagtailcore.blocks.CharBlock(max_length=15, required=False))
+                            ])
+                        )
+                    ])
+                ),
+            ],
+        ),
+        migrations.AlterField(
+            model_name='demopage',
+            name='molecules',
+            field=wagtail.wagtailcore.fields.StreamField(
+                [
+                    (b'half_width_link_blob', wagtail.wagtailcore.blocks.StructBlock(
+                        [
+                            (b'heading', wagtail.wagtailcore.blocks.CharBlock(max_length=100, required=True)),
+                            (b'content', wagtail.wagtailcore.blocks.RichTextBlock(blank=True)),
+                            (b'links', wagtail.wagtailcore.blocks.ListBlock(wagtail.wagtailcore.blocks.StructBlock(
+                                [
+                                    (b'text', wagtail.wagtailcore.blocks.CharBlock(required=False)),
+                                    (b'url', wagtail.wagtailcore.blocks.URLBlock(required=False))
+                                ], required=False, icon=b'user')))
+                        ])
+                    ),
+                    (b'text_introduction', wagtail.wagtailcore.blocks.StructBlock(
+                        [
+                            (b'heading', wagtail.wagtailcore.blocks.CharBlock(max_length=100, required=True)),
+                            (b'intro', wagtail.wagtailcore.blocks.CharBlock(max_length=100, required=True)),
+                            (b'body', wagtail.wagtailcore.blocks.RichTextBlock(required=False)),
+                            (b'link_url', wagtail.wagtailcore.blocks.URLBlock(required=False)),
+                            (b'link_text', wagtail.wagtailcore.blocks.CharBlock(max_length=100, required=False)),
+                            (b'has_rule', wagtail.wagtailcore.blocks.BooleanBlock(required=False))
+                        ])
+                    ),
+                    (b'image_text_5050', wagtail.wagtailcore.blocks.StructBlock(
+                        [
+                            (b'title', wagtail.wagtailcore.blocks.CharBlock(max_length=100, required=True)),
+                            (b'description', wagtail.wagtailcore.blocks.RichTextBlock(blank=True)),
+                            (b'image', wagtail.wagtailimages.blocks.ImageChooserBlock(required=False)),
+                            (b'image_path', wagtail.wagtailcore.blocks.CharBlock(required=False)),
+                            (b'image_alt', wagtail.wagtailcore.blocks.CharBlock(required=False)),
+                            (b'is_widescreen', wagtail.wagtailcore.blocks.BooleanBlock(required=False)),
+                            (b'is_button', wagtail.wagtailcore.blocks.BooleanBlock(required=False)),
+                            (b'link_url', wagtail.wagtailcore.blocks.URLBlock(required=False)),
+                            (b'link_text', wagtail.wagtailcore.blocks.CharBlock(max_length=100, required=False))
+                        ])
+                    )
+                ], blank=True),
+        ),
+    ]

--- a/cfgov/v1/models/__init__.py
+++ b/cfgov/v1/models/__init__.py
@@ -3,5 +3,7 @@ from .base import *
 from .events import *
 from .molecules import *
 from .organisms import *
-if settings.DEBUG :
+from .snippets import *
+
+if settings.DEBUG:
     from .demo import *

--- a/cfgov/v1/models/molecules.py
+++ b/cfgov/v1/models/molecules.py
@@ -129,3 +129,42 @@ class CallToAction(blocks.StructBlock):
         template = 'v1/wagtail/molecules/call-to-action.html'
         icon = 'grip'
         label = 'Call to Action'
+
+
+class ContactAddress(blocks.StructBlock):
+    label = blocks.CharBlock(max_length=50)
+    title = blocks.CharBlock(max_length=100, required=False)
+    street = blocks.CharBlock(max_length=100)
+    city = blocks.CharBlock(max_length=50)
+    state = blocks.CharBlock(max_length=25)
+    zip_code = blocks.CharBlock(max_length=15, required=False)
+
+    class Meta:
+        template = 'v1/wagtail/molecules/contact-address.html'
+        icon = 'mail'
+        label = 'Address'
+
+
+class ContactEmail(blocks.StructBlock):
+    emails = blocks.ListBlock(atoms.Hyperlink(label='Email'))
+
+    class Meta:
+        icon = 'mail'
+        template = 'v1/wagtail/molecules/contact-email.html'
+        label = 'Email'
+
+
+class ContactPhone(blocks.StructBlock):
+    fax = blocks.BooleanBlock(default=False, required=False,
+                              label='Is this number a fax?')
+    phones = blocks.ListBlock(
+        blocks.StructBlock([
+            ('number', blocks.CharBlock(max_length=15)),
+            ('vanity', blocks.CharBlock(max_length=15, required=False)),
+            ('tty', blocks.CharBlock(max_length=15, required=False)),
+        ]))
+
+    class Meta:
+        icon = 'mail'
+        template = 'v1/wagtail/molecules/contact-phone.html'
+        label = 'Phone'

--- a/cfgov/v1/models/organisms.py
+++ b/cfgov/v1/models/organisms.py
@@ -1,7 +1,5 @@
 from wagtail.wagtailcore import blocks
 
-from .base import CFGOVPage
-
 
 class Well(blocks.StructBlock):
     template_path = blocks.CharBlock(required=True)

--- a/cfgov/v1/models/snippets.py
+++ b/cfgov/v1/models/snippets.py
@@ -1,0 +1,27 @@
+from django.db import models
+
+from wagtail.wagtailsnippets.models import register_snippet
+from wagtail.wagtailcore.fields import RichTextField, StreamField
+from wagtail.wagtailadmin.edit_handlers import FieldPanel, StreamFieldPanel
+
+from . import molecules
+
+
+@register_snippet
+class Contact(models.Model):
+    heading = models.CharField(max_length=22, blank=False)
+    body = RichTextField(blank=True)
+    contact_info = StreamField([
+        ('email', molecules.ContactEmail()),
+        ('phone', molecules.ContactPhone()),
+        ('address', molecules.ContactAddress()),
+    ])
+
+    panels = [
+        FieldPanel('heading'),
+        FieldPanel('body'),
+        StreamFieldPanel('contact_info'),
+    ]
+
+    def __str__(self):
+        return self.heading


### PR DESCRIPTION
- Add Contact snippet
- Add Contact molecule backends
- Change Contact templates for Wagtail rendering
- Add temporary folder for storing converted templates: `cfgov/jinja2/v1/wagtail/`

Run `./cfgov/manage.py migrate` then run the server. A "Snippets" option on the sidebar of the admin in Wagtail should appear with the option to create a Contact.

@kave 
@sebworks 
@rosskarchner 