### PR TITLE
Fixed font-sizing issue in left seconadry navigation

### DIFF
--- a/cfgov/preprocessed/css/nav-secondary.less
+++ b/cfgov/preprocessed/css/nav-secondary.less
@@ -194,10 +194,14 @@
     }
 
     &_item__parent {
-        .h4();
         .webfont-medium();
-        margin-bottom: 0;
+
         padding-bottom: 0;
+        margin-bottom: 0;
+
+        .respond-to-min(@desktop-min, {
+          font-size: 18px;
+        });
     }
 
     &_item__child {
@@ -212,14 +216,12 @@
                  unit(10px / @font-size-large, em);
         border-left-style: solid;
         border-left-width: 5px;
-        font-size: unit(@font-size-large / @base-font-size-px, em);
         .u-link__colors(@pacific, @pacific, @black, @black, @black,
                         transparent, transparent, @green, @green, @green);
 
         .respond-to-max(@tablet-max, {
             display: block;
             padding: unit((@grid_gutter-width / 2) / @base-font-size-px, em);
-            font-size: unit(@font-size-small / @base-font-size-px, em);
             .u-link__colors(@darkgray, @darkgray, @darkgray, @darkgray, @darkgray,
                             transparent, transparent, @green, @green, @green);
             margin: 0 @grid_gutter-width / 2;


### PR DESCRIPTION
Fixed font-sizing issue in left secondary navigation due to parent font-size

## Additions

- None

## Removals

- Removed font-size settings on individual links

## Changes

- Set font-size and style correctly in parent item

## Testing

- Build and check any page w/ the secondary nav

## Review

- @KimberlyMunoz 
- @anselmbradford 
- @sebworks 

## Screenshots

<img width="197" alt="screen shot 2015-11-02 at 12 52 08 pm" src="https://cloud.githubusercontent.com/assets/1280430/10889540/995f44cc-8160-11e5-9225-7fdc6cd4e770.png">

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices 
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)