### PR TITLE
Fixed missing text in post-preview organism

### DIFF
--- a/cfgov/jinja2/v1/_includes/organisms/post-preview.html
+++ b/cfgov/jinja2/v1/_includes/organisms/post-preview.html
@@ -81,7 +81,7 @@
             Comments close {{ time.render(settings.comments_close_date, {'date':true}) }}
             </span>
         {% endif %}
-        {% if settings.post_content %}
+        {% if settings.body %}
             <p class="o-post-preview_description">
                 {{ settings.body | safe }}
             </p>


### PR DESCRIPTION
Something seemed missing. It was the body of the post-preview molecule!

## Review
- @jimmynotjim 
- @sebworks 
- @anselmbradford 