### PR TITLE
Adding event-specific calendar icon and location preview to post-preview organism

### DIFF
--- a/cfgov/jinja2/v1/_includes/organisms/post-preview.html
+++ b/cfgov/jinja2/v1/_includes/organisms/post-preview.html
@@ -22,12 +22,17 @@
    settings.post_category:      An array with the categories for the post. Up to 2.
    settings.post_tags:          An array with the post tags for the post.
 
-   settings.event_location:     A string with the event location.
-   settings.event_date:         A datetime object with the time of the event.
+   settings.event_start_dt:     A datetime object with the time of the event.
+   settings.event_stream_link:  A string with livestream link
+   settings.event_venue:        A string with the event venue.
+   settings.event_street:       A string with the event street.
+   settings.event_city:         A string with the event city.
+   settings.event_state:        A string with the event state.
+   settings.event_zip:          A string with the event zip.
 
    settings.comments_close_date: A datetime object marking the deadline of the comment period.
-   settings.link_text:      A string with the description text of an external link.
-   settings.link_url:  A string with the url of an external link.
+   settings.link_text:           A string with the description text of an external link.
+   settings.link_url:            A string with the url of an external link.
 
    path:                        A string with the path for the homepage of the pagetype
                                 `/blog/`, `/newsroom/`
@@ -39,6 +44,7 @@
 {% import 'macros/share.html' as share with context %}
 {% import 'category-slug.html' as category_slug %}
 {% import 'macros/time.html' as time %}
+{% from 'macros/util/format/url.html' import location_image_url as location_image_url %}
 
 <article class="o-post-preview">
     <div class="meta-header">
@@ -60,7 +66,32 @@
                                     use_post_category) }}
         {% endif %}
     </div>
-    {% if settings.image_url %}
+    {% if settings.event_start_dt %}
+        <div class="o-post-preview_image-container">
+            <time class="calendar-icon"
+                data-month="{{ settings.event_start_dt | date('%b') }}"
+                data-day="{{ settings.event_start_dt | date('%-d') }}"
+                datetime="{{ settings.event_start_dt | date('%c') }}">
+                <span class="u-visually-hidden">{{ settings.event_start_dt| date('%b %-d, %Y') }}</span>
+            </time>
+            {% if settings.event_stream_link %}
+                <img class="o-post-preview_image"
+                     src="http://placehold.it/160x90"
+                     alt="Livestream event">
+            {% else %}
+                <img class="o-post-preview_image"
+                     src="{{ location_image_url({
+                                'location': settings.event_city
+                                            | default('Washington, DC', true)
+                                            | urlencode,
+                                'zoom':     '12',
+                                'scale':    '2',
+                                'size':     '276x155'
+                            }) }}"
+                     alt="Google Maps image of {{ settings.event_venue }}">
+            {% endif %}
+        </div>
+    {% elif settings.image_url %}
         <div class="o-post-preview_image-container">
             <img class="o-post-preview_image"
                  src="{{ settings.image_url }}"
@@ -71,13 +102,19 @@
         <h3 class="o-post-preview_title">
             {{ settings.heading | safe }}
         </h3>
-        {% if settings.event_location %}
+        {% if settings.event_start_dt %}
             <span class="o-post-preview_subtitle h6">
-            {{settings.event_location}} - {{ time.render(settings.event_date) }}
+            {% if settings.event_city and settings.event_state %}
+                {{ settings.event_city }}, {{ settings.event_state }}
+            {% endif %}
+            {{ settings.event_venue if settings.event_venue else '' }}
+            {{ 'Livecast' if settings.event_stream_link else '' }}
+             -
+            {{ time.render(settings.event_start_dt) }}
             </span>
         {% endif %}
         {% if settings.comments_close_date %}
-            <span class="o-post-preview_subtitle">
+            <span class="o-post-preview_subtitle h6">
             Comments close {{ time.render(settings.comments_close_date, {'date':true}) }}
             </span>
         {% endif %}

--- a/cfgov/jinja2/v1/browse-filterable/index.html
+++ b/cfgov/jinja2/v1/browse-filterable/index.html
@@ -52,11 +52,26 @@
             'heading': 'This is a event post',
             'body': lipsumText,
             'published_date': '20030805T213611',
-            'image_url': 'http://www.placehold.it/160x90',
+            'event_venue': 'The White House',
+            'event_street': '1600 pennsylvania avenue',
+            'event_city': 'Washington',
+            'event_state': 'DC',
+            'event_zip': '20500',
+            'event_start_dt':'20030805T213611',
             'post_category': ['Speech'],
-            'post_tags': ['FOIA', 'Mortgage'],
-            'event_location': 'The White House, Washington, DC',
-            'event_date': '20030805T213611'
+            'post_tags': ['FOIA', 'Mortgage']
+            },
+            '/events/') }}
+    </div>
+    <div class="block">
+        {{ post_preview.render({
+            'heading': 'This is a event livestream post',
+            'body': lipsumText,
+            'published_date': '20030805T213611',
+            'event_stream_link': 'http://www.whitehouse.gov',
+            'event_start_dt':'20030805T213611',
+            'post_category': ['Speech'],
+            'post_tags': ['FOIA', 'Mortgage']
             },
             '/events/') }}
     </div>

--- a/cfgov/preprocessed/css/organisms/post-preview.less
+++ b/cfgov/preprocessed/css/organisms/post-preview.less
@@ -94,7 +94,7 @@
     &_image {
         display: block;
         width: 100%;
-  }
+    }
 }
 
 .o-post-preview_image-container + .o-post-preview_content {
@@ -102,6 +102,17 @@
         .grid_column(8);
     });
 }
+
+.o-post-preview_image-container {
+    position: relative;
+
+    .calendar-icon {
+        position: absolute;
+        top: 15px;
+        left: 15px;
+    }
+}
+
 /* topdoc
     name: EOF
     eof: true


### PR DESCRIPTION
This adds any event-specific styles to the post-preview organism

## Testing
- Visit http://localhost:8000/browse-filterable/

## Review
- @jimmynotjim 
- @anselmbradford 
- @sebworks 

## Preview

![image](https://cloud.githubusercontent.com/assets/1860176/10893248/d3edc9f0-8175-11e5-8dc4-9666bdf3abce.png)

![image](https://cloud.githubusercontent.com/assets/1860176/10893551/5ed1536a-8177-11e5-9081-895870a76585.png)