### PR TITLE
Add Call to Action and Hyperlink atom backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Adds new file to commands module in the core app called `_helpers.py`
 - Adds ability to import snippets
 - Added ImageText2575 molecule backend model and template
+- Added Call to Action backend and template
 
 ### Changed
 - Updated the primary nav to move focus as user enters and leaves nav levels

--- a/cfgov/jinja2/v1/wagtail/molecules/call-to-action.html
+++ b/cfgov/jinja2/v1/wagtail/molecules/call-to-action.html
@@ -1,0 +1,4 @@
+{% from 'v1/_includes/molecules/call-to-action.html'
+   import render as call_to_action %}
+
+{{ call_to_action(value) }}

--- a/cfgov/v1/models/atoms.py
+++ b/cfgov/v1/models/atoms.py
@@ -1,0 +1,6 @@
+from wagtail.wagtailcore import blocks
+
+
+class Hyperlink(blocks.StructBlock):
+    label = blocks.CharBlock(max_length=22)
+    href = blocks.CharBlock(default='/')

--- a/cfgov/v1/models/molecules.py
+++ b/cfgov/v1/models/molecules.py
@@ -3,6 +3,8 @@ from django.core.exceptions import ValidationError
 from wagtail.wagtailcore import blocks
 from wagtail.wagtailimages.blocks import ImageChooserBlock
 
+from . import atoms
+
 
 def isRequired(field_name):
     return [str(field_name) + ' is required.']
@@ -116,3 +118,14 @@ class TextIntroduction(blocks.StructBlock):
     class Meta:
         icon = 'title'
         template = 'v1/demo/molecules/text_introduction.html'
+
+
+class CallToAction(blocks.StructBlock):
+    slug = blocks.CharBlock(required=True)
+    paragraph = blocks.RichTextBlock()
+    button = atoms.Hyperlink()
+
+    class Meta:
+        template = 'v1/wagtail/molecules/call-to-action.html'
+        icon = 'grip'
+        label = 'Call to Action'


### PR DESCRIPTION
- Add Call to Action backend model
- Add template to use CtA model for rendering
- Remove unused imports in v1/models/__init__.py file

@kave 
@rosskarchner 
@sebworks 