### PR TITLE
Add ImageText2575 molecule backend and template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Added instruction to create superuser for admin access.
 - Adds new file to commands module in the core app called `_helpers.py`
 - Adds ability to import snippets
+- Added ImageText2575 molecule backend model and template
 
 ### Changed
 - Updated the primary nav to move focus as user enters and leaves nav levels

--- a/cfgov/jinja2/v1/wagtail/molecules/image-text-25-75.html
+++ b/cfgov/jinja2/v1/wagtail/molecules/image-text-25-75.html
@@ -1,0 +1,27 @@
+<div class="m-image-text-25-75">
+
+    {% if has_rule %}
+        <div class="a-rule-break"></div>
+    {% endif %}
+
+    <div class="m-image-text-25-75_image-container">
+
+    {# Use a div if this is a decorative image,
+       in which case the alt attribute is empty. #}
+    {% if settings.image_alt == '' %}
+        <div class="m-image-text-25-75_image u-centered-on-mobile"
+             style="background-image:url({{ settings.image_path }})"></div>
+    {% else %}
+        <img class="m-image-text-25-75_image u-centered-on-mobile"
+             src="{{ settings.image_path }}"
+             alt="{{ settings.image_alt }}">
+    {% endif %}
+    </div>
+    <div class="m-image-text-25-75_content">
+        <h3 class="m-image-text-25-75_heading">{{ settings.heading }}</h3>
+        <p class="m-image-text-25-75_body">{{ settings.body }}</p>
+        <a class="jump-link m-image-text-25-75_link" href="{{ settings.link_url }}">
+            {{ settings.link_text }}
+        </a>
+    </div>
+</div>

--- a/cfgov/v1/models/molecules.py
+++ b/cfgov/v1/models/molecules.py
@@ -1,12 +1,12 @@
-import datetime
+from django.core.exceptions import ValidationError
 
 from wagtail.wagtailcore import blocks
 from wagtail.wagtailimages.blocks import ImageChooserBlock
-from django.core.exceptions import ValidationError
-from .base import CFGOVPage
+
 
 def isRequired(field_name):
     return [str(field_name) + ' is required.']
+
 
 class HalfWidthLinkBlob(blocks.StructBlock):
     heading = blocks.CharBlock(max_length=100, required=True)
@@ -62,6 +62,47 @@ class ImageText5050(blocks.StructBlock):
     class Meta:
         icon = 'image'
         template = 'v1/demo/molecules/image_text_5050.html'
+
+
+class ImageText2575(blocks.StructBlock):
+    heading = blocks.CharBlock(max_length=100, required=True)
+    body = blocks.RichTextBlock(required=True)
+    image = ImageChooserBlock(required=False)
+    image_path = blocks.CharBlock(required=False)
+    image_alt = blocks.CharBlock(required=False)
+    link_url = blocks.URLBlock(required=False)
+    link_text = blocks.CharBlock(max_length=100, required=False)
+    has_rule = blocks.BooleanBlock(required=False)
+
+    def clean(self, data):
+        error_dict = {}
+        try:
+            block_data = super(ImageText5050, self).clean(data)
+        except ValidationError as e:
+            error_dict.update(e.params)
+            block_data = data
+
+        if not block_data['image'] and not block_data['image_path'] and not block_data['image_alt']:
+            img_err = ['Please upload or enter an image path']
+            error_dict.update({'image': img_err, 'image_path': img_err, 'image_alt': isRequired('Image alt')})
+
+        if block_data['image'] and block_data['image_path']:
+            img_err = ['Please select one method of image rendering']
+            error_dict.update({
+                'image': img_err,
+                'image_path': img_err})
+
+        if block_data['image_path'] and not block_data['image_alt']:
+            error_dict.update({'image_alt': isRequired('Image Alt')})
+
+        if error_dict:
+            raise ValidationError("ImageText2575 validation errors", params=error_dict)
+        else:
+            return block_data
+
+    class Meta:
+        icon = 'image'
+        template = 'v1/wagtail/molecules/image_text_2575.html'
 
 
 class TextIntroduction(blocks.StructBlock):


### PR DESCRIPTION
This uses the same **clean()** logic as the ImageText5050 molecule, but has slightly different fields.

@kave @rosskarchner @anselmbradford 