### PR TITLE
Exclude 3rd-party polyfills from linting

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,2 @@
+# Ignore 3rd-party polyfills.
+cfgov/preprocessed/js/modules/polyfill/**/*.js

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -136,6 +136,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Move staging hostname variable from django settings to be an environment variable
 - Uses globally installed Protractor in setup.sh, if available.
 - Updated the existing breakpoint variables and values to the ones released in cf-core v1.2.0
+- Excludes 3rd-party JS polyfills from linting.
 
 ### Removed
 - Removed unused exportsOverride section,

--- a/cfgov/preprocessed/js/modules/polyfill/.eslintrc
+++ b/cfgov/preprocessed/js/modules/polyfill/.eslintrc
@@ -1,6 +1,0 @@
-# ESLint overrides for polyfills.
-rules:
-  no-extend-native:
-    - 1
-    - exceptions:
-      - Array

--- a/cfgov/preprocessed/js/modules/polyfill/array-filter-polyfill.js
+++ b/cfgov/preprocessed/js/modules/polyfill/array-filter-polyfill.js
@@ -10,8 +10,7 @@
 'use strict';
 
 if ( !Array.prototype.filter ) {
-  // Ignore complexity eslint offense for polyfill.
-  Array.prototype.filter = function filter( fun ) { //eslint-disable-line
+  Array.prototype.filter = function filter( fun ) {
 
     if ( typeof this === 'undefined' || this === null ) {
       throw new TypeError();

--- a/cfgov/preprocessed/js/modules/polyfill/array-foreach-polyfill.js
+++ b/cfgov/preprocessed/js/modules/polyfill/array-foreach-polyfill.js
@@ -10,8 +10,7 @@
 'use strict';
 
 if ( !Array.prototype.forEach ) {
-  // Ignore complexity eslint offense for polyfill.
-  Array.prototype.forEach = function( callback, thisArg ) { //eslint-disable-line
+  Array.prototype.forEach = function( callback, thisArg ) {
 
     var T, k;
 

--- a/cfgov/preprocessed/js/modules/polyfill/array-map-polyfill.js
+++ b/cfgov/preprocessed/js/modules/polyfill/array-map-polyfill.js
@@ -10,8 +10,7 @@
 'use strict';
 
 if ( !Array.prototype.map ) {
-  // Ignore complexity eslint offense for polyfill.
-  Array.prototype.map = function map( callback, thisArg ) { //eslint-disable-line
+  Array.prototype.map = function map( callback, thisArg ) {
 
     var T, A, k;
 

--- a/cfgov/preprocessed/js/modules/polyfill/event-listener.js
+++ b/cfgov/preprocessed/js/modules/polyfill/event-listener.js
@@ -9,8 +9,7 @@
 
 if ( !Element.prototype.addEventListener ) {
   var oListeners = {};
-  // Ignore no-inner-declarations and complexity eslint offense for polyfill.
-  function runListeners( oEvent ) { //eslint-disable-line
+  function runListeners( oEvent ) {
     if ( !oEvent ) {
       oEvent = window.event;
 
@@ -30,22 +29,19 @@ if ( !Element.prototype.addEventListener ) {
     }
   }
   // NOTE: useCapture (will be ignored!).
-  // Ignore complexity eslint offense for polyfill.
-  Element.prototype.addEventListener = function( sEventType, fListener ) { //eslint-disable-line
+  Element.prototype.addEventListener = function( sEventType, fListener ) {
     if ( oListeners.hasOwnProperty( sEventType ) ) {
       var oEvtListeners = oListeners[sEventType];
       for ( var nElIdx = -1, iElId = 0; iElId < oEvtListeners.aEls.length;
             iElId++ ) {
         if ( oEvtListeners.aEls[iElId] === this ) { nElIdx = iElId; break; }
       }
-      // Ignore block-scoped-var eslint offense for polyfill.
-      if ( nElIdx === -1 ) { //eslint-disable-line
+      if ( nElIdx === -1 ) {
         oEvtListeners.aEls.push( this );
         oEvtListeners.aEvts.push( [ fListener ] );
         this['on' + sEventType] = runListeners;
       } else {
-        // Ignore block-scoped-var eslint offense for polyfill.
-        var aElListeners = oEvtListeners.aEvts[nElIdx]; //eslint-disable-line
+        var aElListeners = oEvtListeners.aEvts[nElIdx];
         if ( this['on' + sEventType] !== runListeners ) {
           aElListeners.splice( 0 );
           this['on' + sEventType] = runListeners;
@@ -63,8 +59,7 @@ if ( !Element.prototype.addEventListener ) {
     }
   };
   // NOTE: useCapture (will be ignored!).
-  // Ignore complexity eslint offense for polyfill.
-  Element.prototype.removeEventListener = function( sEventType, fListener ) { //eslint-disable-line
+  Element.prototype.removeEventListener = function( sEventType, fListener ) {
     if ( !oListeners.hasOwnProperty( sEventType ) ) {
       return;
     }
@@ -75,12 +70,10 @@ if ( !Element.prototype.addEventListener ) {
         nElIdx = iElId; break;
       }
     }
-    // Ignore block-scoped-var eslint offense for polyfill.
-    if ( nElIdx === -1 ) { //eslint-disable-line
+    if ( nElIdx === -1 ) {
       return;
     }
-    // Ignore block-scoped-var eslint offense for polyfill.
-    for ( var iLstId = 0, aElListeners = oEvtListeners.aEvts[nElIdx]; //eslint-disable-line
+    for ( var iLstId = 0, aElListeners = oEvtListeners.aEvts[nElIdx];
           iLstId < aElListeners.length; iLstId++ ) {
       if ( aElListeners[iLstId] === fListener ) {
         aElListeners.splice( iLstId, 1 );

--- a/cfgov/preprocessed/js/modules/polyfill/object-defineproperty-polyfill.js
+++ b/cfgov/preprocessed/js/modules/polyfill/object-defineproperty-polyfill.js
@@ -16,7 +16,7 @@
   'Getters & setters cannot be defined on this javascript engine';
   var ERR_VALUE_ACCESSORS =
     'A property cannot both have accessors and be writable or have a value';
-  Object.defineProperty = function defineProperty( object, property, // eslint-disable-line max-statements, complexity, max-len
+  Object.defineProperty = function defineProperty( object, property,
     descriptor ) {
     // handle object
     if ( object === null || !( object instanceof Object || typeof object ===


### PR DESCRIPTION
Syntax changes to polyfills could potentially create bugs in older browsers that would go unnoticed, this excludes the 3rd party polyfills directory from linting.

## Changes

- Excludes 3rd-party JS polyfills from linting.

## Testing

- `gulp lint` should not have new errors.

## Review

- @sebworks 
- @KimberlyMunoz 
- @jimmynotjim 
