### PR TITLE
Adds browse-basic prototype w/ Expandable/ExpandableGroup atomic components

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,2 @@
+# Ignore 3rd-party polyfills.
+cfgov/preprocessed/js/modules/polyfill/**/*.js

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,11 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Added template for post-preview molecule
 - Added templates and CSS for the Signup Form organism.
 - Added templates and CSS for the Content Sidebar organism.
+- Added `/browse-basic` template page.
+- Added templates and CSS for Expandable molecule and ExpandableGroup organism.
+- Added `classlist` JS polyfill.
+- Added `u-hide` utility class to hide an element.
+- Added `EventObserver` for adding event broadcaster capability to JS classes.
 
 ### Changed
 - Updated the primary nav to move focus as user enters and leaves nav levels
@@ -135,6 +140,8 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Updates `jsdom` to `7.0.2` from `6.5.1`.
 - Move staging hostname variable from django settings to be an environment variable
 - Uses globally installed Protractor in setup.sh, if available.
+- Reduced padding on expandables per direction of design.
+- Hid cues on expandables when JS is turned off.
 
 ### Removed
 - Removed unused exportsOverride section,

--- a/cfgov/cfgov/urls.py
+++ b/cfgov/cfgov/urls.py
@@ -214,6 +214,7 @@ if settings.DEBUG :
     urlpatterns.append(url(r'^landing-page-2/$', SheerTemplateView.as_view(template_name='landing-page-2/index.html'), name='landing-page-2'))
     urlpatterns.append(url(r'^sublanding-page-1/$', SheerTemplateView.as_view(template_name='sublanding-page-1/index.html'), name='sublanding-page-1'))
     urlpatterns.append(url(r'^sublanding-page-2/$', SheerTemplateView.as_view(template_name='sublanding-page-2/index.html'), name='sublanding-page-2'))
+    urlpatterns.append(url(r'^browse-basic/$', SheerTemplateView.as_view(template_name='browse-basic/index.html'), name='browse-basic'))
     urlpatterns.append(url(r'^browse-filterable/$', SheerTemplateView.as_view(template_name='browse-filterable/index.html'), name='browse-filterable'))
     urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
 

--- a/cfgov/jinja2/v1/_includes/molecules/expandable.html
+++ b/cfgov/jinja2/v1/_includes/molecules/expandable.html
@@ -1,0 +1,46 @@
+{# ==========================================================================
+
+   expandable.render()
+
+   ==========================================================================
+
+   Description:
+
+   Create an Expandable molecule when given:
+
+   label:       Label you want on the Expandable.
+                Default is an empty string.
+
+   is_expanded: Whether the Expandable is expanded or not.
+                Default is false.
+
+   ========================================================================== #}
+
+{% macro render(label="", is_expanded=false) %}
+<div class="expandable
+            expandable__padded
+            {{ 'expandable__expanded' if is_expanded else '' }}">
+    <button class="expandable_header
+                   expandable_target">
+        <span class="expandable_header-left
+                     expandable_label">
+            {{ label }}
+        </span>
+        <span class="expandable_header-right
+                     expandable_link
+                     u-hide">
+            <span class="expandable_cue-open">
+                Show
+                <span class="cf-icon cf-icon-plus-round"></span>
+            </span>
+            <span class="expandable_cue-close">
+                Hide
+                <span class="cf-icon cf-icon-minus-round"></span>
+            </span>
+        </span>
+    </button>
+    <div class="expandable_content">
+        {{ caller() }}
+    </div>
+</div>
+{% endmacro %}

--- a/cfgov/jinja2/v1/_includes/organisms/expandable-group.html
+++ b/cfgov/jinja2/v1/_includes/organisms/expandable-group.html
@@ -1,0 +1,28 @@
+{# ==========================================================================
+
+   expandable_group.render()
+
+   ==========================================================================
+
+   Description:
+
+   Create an Expandable Group organism when given:
+
+   label:        Label you want on the Expandable Group.
+                 Default is an empty string.
+
+   is_accordion: Whether this group is an accordion or not.
+                 Default is false.
+   ========================================================================== #}
+
+{% macro render(label="", is_accordion=false) %}
+<div class="expandable-group" data-accordion="{{ is_accordion }}">
+    {% if label %}
+        <div class="expandable-group_header">{{ label }}</div>
+    {% endif %}
+
+    {# Should be a stack of Expandable instances. #}
+    {{ caller() }}
+</div>
+
+{% endmacro %}

--- a/cfgov/jinja2/v1/browse-basic/index.html
+++ b/cfgov/jinja2/v1/browse-basic/index.html
@@ -12,6 +12,10 @@
 {% block content_main %}
     <div class="block
                 block__flush-top">
+        {% call expandable.render("Single Expandable") %}
+            {{ lipsum(1, false, 10, 225) | safe }}
+        {% endcall %}
+
         {% call expandable_group.render("Group Header") %}
             {% call expandable.render("Expand 1 - initially open", true) %}
                 {{ lipsum(1, false, 10, 225) | safe }}
@@ -41,7 +45,6 @@
 {% block content_sidebar scoped -%}
     <aside>
         {# TODO: Add sidebar organisms. #}
-        Breadcrumbs<br>
         Side Navigation
     </aside>
 {%- endblock %}

--- a/cfgov/jinja2/v1/browse-basic/index.html
+++ b/cfgov/jinja2/v1/browse-basic/index.html
@@ -1,0 +1,47 @@
+{% extends 'layout-side-nav.html' %}
+
+{# Import organisms and molecules used in the template. #}
+{% import 'molecules/expandable.html' as expandable %}
+{% import 'organisms/expandable-group.html' as expandable_group %}
+
+{% block title -%}
+    TODO: This is a prototype page for testing landing page layouts.
+    Remove when fully implemented elsewhere.
+{%- endblock %}
+
+{% block content_main %}
+    <div class="block
+                block__flush-top">
+        {% call expandable_group.render("Group Header") %}
+            {% call expandable.render("Expand 1 - initially open", true) %}
+                {{ lipsum(1, false, 10, 225) | safe }}
+            {% endcall %}
+
+            {% call expandable.render("Expand 2") %}
+                {{ lipsum(1, false, 10, 225) | safe }}
+            {% endcall %}
+        {% endcall %}
+
+        {% call expandable_group.render("Accordion-style Group", true) %}
+            {% call expandable.render("Expand 1") %}
+                {{ lipsum(1, false, 10, 225) | safe }}
+            {% endcall %}
+
+            {% call expandable.render("Expand 2") %}
+                {{ lipsum(1, false, 10, 225) | safe }}
+            {% endcall %}
+
+            {% call expandable.render("Expand 3") %}
+                {{ lipsum(1, false, 10, 225) | safe }}
+            {% endcall %}
+        {% endcall %}
+    </div>
+{% endblock %}
+
+{% block content_sidebar scoped -%}
+    <aside>
+        {# TODO: Add sidebar organisms. #}
+        Breadcrumbs<br>
+        Side Navigation
+    </aside>
+{%- endblock %}

--- a/cfgov/jinja2/v1/browse-filterable/index.html
+++ b/cfgov/jinja2/v1/browse-filterable/index.html
@@ -77,7 +77,6 @@
 {% block content_sidebar scoped -%}
     <aside>
         {# TODO: Add sidebar organisms. #}
-        Breadcrumbs<br>
         Side Navigation
     </aside>
 {%- endblock %}

--- a/cfgov/preprocessed/css/cf-enhancements.less
+++ b/cfgov/preprocessed/css/cf-enhancements.less
@@ -520,6 +520,74 @@ tbody {
 
 
 /* topdoc
+  name: Hide
+  family: cf-core
+  patterns:
+    - name: Utility class
+      markup: |
+        <h1 class="u-hide">
+          Show using JavaScript
+        </h1>
+      codenotes:
+        - .u-hidden;
+      notes:
+        - "Use this class to hide something,
+          perhaps to be shown using JavaScript."
+  tags:
+    - cf-core
+*/
+
+.u-hide {
+  display: none;
+}
+
+
+/* topdoc
+  name: Padded expandable modifier
+  family: cf-expandables
+  patterns:
+  - name: .expandable__padded (modifier)
+    codenotes:
+      - |
+        .expandable__padded
+    notes:
+      - "Adds padding and a background color to .expandable_header and
+         .expandable_content."
+      - "In addition to using the .expandable__padded modifier you also need
+         to make sure you are using .expandable_header."
+  tags:
+  - cf-expandables
+*/
+
+// TODO: remove !important when migrating this to cf-expandables.
+.expandable__padded {
+    .expandable_header {
+        // Includes optical offset eyeballed at 15px.
+        padding: unit(((@grid_gutter-width / 2) - 5px) / @base-font-size-px, em)
+                 unit((@grid_gutter-width / 2) / @base-font-size-px, em) !important;
+    }
+
+    .expandable_content {
+        // Margin collapsing trick for more consistent bottom padding.
+        // Includes optical offset eyeballed at 15px.
+        margin: 0
+                unit(((@grid_gutter-width / 2) - 1px) / @base-font-size-px, em)
+                unit((@grid_gutter-width / 2) / @base-font-size-px, em) !important;
+
+        // The divider between _header and _content.
+        &:before {
+            content: '';
+            display: block;
+            height: 1px;
+            // Includes optical offset eyeballed at 15px.
+            margin-bottom: unit(((@grid_gutter-width / 2) - 1px) / @base-font-size-px, em) !important;
+            background: @expandable__padded-divider;
+        }
+    }
+}
+
+
+/* topdoc
     name: Expandable header modifier
     family: cfgov-cf-enhancements
     patterns:

--- a/cfgov/preprocessed/css/cf-enhancements.less
+++ b/cfgov/preprocessed/css/cf-enhancements.less
@@ -529,7 +529,7 @@ tbody {
           Show using JavaScript
         </h1>
       codenotes:
-        - .u-hidden;
+        - .u-hide;
       notes:
         - "Use this class to hide something,
           perhaps to be shown using JavaScript."

--- a/cfgov/preprocessed/css/cf-enhancements.less
+++ b/cfgov/preprocessed/css/cf-enhancements.less
@@ -538,7 +538,7 @@ tbody {
 */
 
 .u-hide {
-  display: none;
+    display: none;
 }
 
 

--- a/cfgov/preprocessed/js/modules/polyfill/class-list.js
+++ b/cfgov/preprocessed/js/modules/polyfill/class-list.js
@@ -1,0 +1,237 @@
+/*
+ * classList.js: Cross-browser full element.classList implementation.
+ * 2014-07-23
+ *
+ * By Eli Grey, http://eligrey.com
+ * Public Domain.
+ * NO WARRANTY EXPRESSED OR IMPLIED. USE AT YOUR OWN RISK.
+ */
+
+/*global self, document, DOMException */
+
+/*! @source http://purl.eligrey.com/github/classList.js/blob/master/classList.js*/
+
+if ("document" in self) {
+
+// Full polyfill for browsers with no classList support
+if (!("classList" in document.createElement("_"))) {
+
+(function (view) {
+
+"use strict";
+
+if (!('Element' in view)) return;
+
+var
+    classListProp = "classList"
+  , protoProp = "prototype"
+  , elemCtrProto = view.Element[protoProp]
+  , objCtr = Object
+  , strTrim = String[protoProp].trim || function () {
+    return this.replace(/^\s+|\s+$/g, "");
+  }
+  , arrIndexOf = Array[protoProp].indexOf || function (item) {
+    var
+        i = 0
+      , len = this.length
+    ;
+    for (; i < len; i++) {
+      if (i in this && this[i] === item) {
+        return i;
+      }
+    }
+    return -1;
+  }
+  // Vendors: please allow content code to instantiate DOMExceptions
+  , DOMEx = function (type, message) {
+    this.name = type;
+    this.code = DOMException[type];
+    this.message = message;
+  }
+  , checkTokenAndGetIndex = function (classList, token) {
+    if (token === "") {
+      throw new DOMEx(
+          "SYNTAX_ERR"
+        , "An invalid or illegal string was specified"
+      );
+    }
+    if (/\s/.test(token)) {
+      throw new DOMEx(
+          "INVALID_CHARACTER_ERR"
+        , "String contains an invalid character"
+      );
+    }
+    return arrIndexOf.call(classList, token);
+  }
+  , ClassList = function (elem) {
+    var
+        trimmedClasses = strTrim.call(elem.getAttribute("class") || "")
+      , classes = trimmedClasses ? trimmedClasses.split(/\s+/) : []
+      , i = 0
+      , len = classes.length
+    ;
+    for (; i < len; i++) {
+      this.push(classes[i]);
+    }
+    this._updateClassName = function () {
+      elem.setAttribute("class", this.toString());
+    };
+  }
+  , classListProto = ClassList[protoProp] = []
+  , classListGetter = function () {
+    return new ClassList(this);
+  }
+;
+// Most DOMException implementations don't allow calling DOMException's toString()
+// on non-DOMExceptions. Error's toString() is sufficient here.
+DOMEx[protoProp] = Error[protoProp];
+classListProto.item = function (i) {
+  return this[i] || null;
+};
+classListProto.contains = function (token) {
+  token += "";
+  return checkTokenAndGetIndex(this, token) !== -1;
+};
+classListProto.add = function () {
+  var
+      tokens = arguments
+    , i = 0
+    , l = tokens.length
+    , token
+    , updated = false
+  ;
+  do {
+    token = tokens[i] + "";
+    if (checkTokenAndGetIndex(this, token) === -1) {
+      this.push(token);
+      updated = true;
+    }
+  }
+  while (++i < l);
+
+  if (updated) {
+    this._updateClassName();
+  }
+};
+classListProto.remove = function () {
+  var
+      tokens = arguments
+    , i = 0
+    , l = tokens.length
+    , token
+    , updated = false
+    , index
+  ;
+  do {
+    token = tokens[i] + "";
+    index = checkTokenAndGetIndex(this, token);
+    while (index !== -1) {
+      this.splice(index, 1);
+      updated = true;
+      index = checkTokenAndGetIndex(this, token);
+    }
+  }
+  while (++i < l);
+
+  if (updated) {
+    this._updateClassName();
+  }
+};
+classListProto.toggle = function (token, force) {
+  token += "";
+
+  var
+      result = this.contains(token)
+    , method = result ?
+      force !== true && "remove"
+    :
+      force !== false && "add"
+  ;
+
+  if (method) {
+    this[method](token);
+  }
+
+  if (force === true || force === false) {
+    return force;
+  } else {
+    return !result;
+  }
+};
+classListProto.toString = function () {
+  return this.join(" ");
+};
+
+if (objCtr.defineProperty) {
+  var classListPropDesc = {
+      get: classListGetter
+    , enumerable: true
+    , configurable: true
+  };
+  try {
+    objCtr.defineProperty(elemCtrProto, classListProp, classListPropDesc);
+  } catch (ex) { // IE 8 doesn't support enumerable:true
+    if (ex.number === -0x7FF5EC54) {
+      classListPropDesc.enumerable = false;
+      objCtr.defineProperty(elemCtrProto, classListProp, classListPropDesc);
+    }
+  }
+} else if (objCtr[protoProp].__defineGetter__) {
+  elemCtrProto.__defineGetter__(classListProp, classListGetter);
+}
+
+}(self));
+
+} else {
+// There is full or partial native classList support, so just check if we need
+// to normalize the add/remove and toggle APIs.
+
+(function () {
+  "use strict";
+
+  var testElement = document.createElement("_");
+
+  testElement.classList.add("c1", "c2");
+
+  // Polyfill for IE 10/11 and Firefox <26, where classList.add and
+  // classList.remove exist but support only one argument at a time.
+  if (!testElement.classList.contains("c2")) {
+    var createMethod = function(method) {
+      var original = DOMTokenList.prototype[method];
+
+      DOMTokenList.prototype[method] = function(token) {
+        var i, len = arguments.length;
+
+        for (i = 0; i < len; i++) {
+          token = arguments[i];
+          original.call(this, token);
+        }
+      };
+    };
+    createMethod('add');
+    createMethod('remove');
+  }
+
+  testElement.classList.toggle("c3", false);
+
+  // Polyfill for IE 10 and Firefox <24, where classList.toggle does not
+  // support the second argument.
+  if (testElement.classList.contains("c3")) {
+    var _toggle = DOMTokenList.prototype.toggle;
+
+    DOMTokenList.prototype.toggle = function(token, force) {
+      if (1 in arguments && !this.contains(token) === !force) {
+        return force;
+      } else {
+        return _toggle.call(this, token);
+      }
+    };
+
+  }
+
+  testElement = null;
+}());
+
+}
+
+}

--- a/cfgov/preprocessed/js/modules/util/EventObserver.js
+++ b/cfgov/preprocessed/js/modules/util/EventObserver.js
@@ -1,0 +1,79 @@
+'use strict';
+
+/**
+ * EventObserver
+ * @class
+ *
+ * @classdesc Used for creating an object
+ *   that can be used to dispatch and listen to custom events.
+ * @returns {Object} An EventObserver instance.
+ */
+function EventObserver() {
+
+  // The events registered on this instance.
+  var _events = {};
+
+  /**
+   * Register an event listener.
+   * @param {string} evt The event name to listen for.
+   * @param {Function} callback The function called when the event has fired.
+   * @returns {Object} The instance this EventObserver instance is decorating.
+   */
+  function addEventListener( evt, callback ) {
+    if ( _events.hasOwnProperty( evt ) ) {
+      _events[evt].push( callback );
+    } else {
+      _events[evt] = [ callback ];
+    }
+
+    return this;
+  }
+
+  /**
+   * Remove an added event listener.
+   * Must match a call made to addEventListener.
+   * @param {string} evt The event name to remove.
+   * @param {Function} callback The function attached to the event.
+   * @returns {Object} The instance this EventObserver instance is decorating.
+   */
+  function removeEventListener( evt, callback ) {
+    if ( !_events.hasOwnProperty( evt ) ) {
+      return this;
+    }
+
+    var index = _events[evt].indexOf( callback );
+    if ( index !== -1 ) {
+      _events[evt].splice( index, 1 );
+    }
+
+    return this;
+  }
+
+  /**
+   * Broadcast an event.
+   * @param {string} evt The type of event to broadcast.
+   * @param {Object} options The event object to pass to the event handler.
+   * @returns {Object} The instance this EventObserver instance is decorating.
+   */
+  function dispatchEvent( evt, options ) {
+    if ( !_events.hasOwnProperty( evt ) ) {
+      return this;
+    }
+
+    options = options || {};
+
+    var evts = _events[evt];
+    for ( var e = 0, len = evts.length; e < len; e++ ) {
+      evts[e].call( this, options );
+    }
+
+    return this;
+  }
+
+  EventObserver.prototype.addEventListener = addEventListener;
+  EventObserver.prototype.removeEventListener = removeEventListener;
+  EventObserver.prototype.dispatchEvent = dispatchEvent;
+  return this;
+}
+
+module.exports = EventObserver;

--- a/cfgov/preprocessed/js/molecules/Expandable.js
+++ b/cfgov/preprocessed/js/molecules/Expandable.js
@@ -1,0 +1,251 @@
+'use strict';
+
+// Required polyfills for <IE9.
+require( '../modules/polyfill/query-selector' );
+require( '../modules/polyfill/event-listener' );
+require( '../modules/polyfill/class-list' );
+
+// Required modules.
+var EventObserver = require( '../modules/util/EventObserver' );
+var $ = require( 'jquery' );
+
+/**
+ * Expandable
+ * @class
+ *
+ * @classdesc Initializes a new Expandable molecule.
+ *
+ * @param {Object} context
+ *   The DOM element within which to search for the molecule.
+ * @returns {Object} An Expandable instance.
+ */
+function Expandable( context ) { // eslint-disable-line max-statements, inline-comments, max-len
+
+  // TODO: Remove this when difference between atomic Expandable
+  //       and cf-expandables is resolved.
+  // ==========================================================================
+  // Unsets global expandables logic.
+  if ( $.fn.expandable ) {
+    var html = context.innerHTML;
+    context.innerHTML = html;
+
+    var $this = $( context );
+    var $cueOpen = $this.find( '.expandable_cue-open' ).not( $this.find( '.expandable .expandable_cue-open' ) );
+    var $cueClose = $this.find( '.expandable_cue-close' ).not( $this.find( '.expandable .expandable_cue-close' ) );
+    var $content = $this.find( '.expandable_content' ).not( $this.find( '.expandable .expandable_content' ) );
+
+    $cueOpen.attr( 'style', '' );
+    $cueClose.attr( 'style', '' );
+    $content.attr( 'style', '' );
+
+  }
+  // ==========================================================================
+
+
+  // The Expandable context will directly be the Expandable when used in an ExpandableGroup.
+  var _dom = context.classList.contains( 'expandable' ) ?
+             context : context.querySelector( '.expandable' );
+  var _target = _dom.querySelector( '.expandable_target' );
+  var _content = _dom.querySelector( '.expandable_content' );
+  var _link = _dom.querySelector( '.expandable_link' );
+  var _cueOpen = _link.querySelector( '.expandable_cue-open' );
+  var _cueClose = _link.querySelector( '.expandable_cue-close' );
+  var _isAnimating = false;
+  var _clickQueue = 0;
+  var _isExpanded;
+  var _that = this;
+  var _contentHeight = $( _content ).height();
+
+  /**
+   * @returns {Object} The Expandable instance.
+   */
+  function init() {
+    _isExpanded = _dom.classList.contains( 'expandable__expanded' );
+    if ( _isExpanded ) {
+      _setExpandedState();
+    } else {
+      _content.style.display = 'none';
+      _setCollapsedState();
+    }
+    _link.classList.remove( 'u-hide' );
+
+    _target.addEventListener( 'click', _handleClick );
+    return this;
+  }
+
+  /**
+   * @param {number} duration
+   *   The duration of the sliding animation in milliseconds.
+   * @returns {Object} The Expandable instance.
+   */
+  function toggle( duration ) {
+    if ( !_isExpanded ) {
+      this.expand( duration );
+    } else {
+      this.collapse( duration );
+    }
+    return this;
+  }
+
+  /**
+   * @param {number} duration
+   *   The duration of the sliding animation in milliseconds.
+   * @returns {Object} The Expandable instance.
+   */
+  function expand( duration ) {
+    duration = duration || _calculateExpandDuration( _contentHeight );
+
+    this.dispatchEvent( 'beginExpand', { target: _that } );
+    _isAnimating = true;
+    $( _content ).slideDown( {
+      duration: duration,
+      easing: 'easeOutExpo',
+      complete: _expandComplete
+    } );
+
+    return this;
+  }
+
+  /**
+   * @param {number} duration
+   *   The duration of the sliding animation in milliseconds.
+   * @returns {Object} The Expandable instance.
+   */
+  function collapse( duration ) {
+    duration = duration || _calculateCollapseDuration( _contentHeight );
+
+    this.dispatchEvent( 'beginCollapse', { target: _that } );
+    _isAnimating = true;
+    $( _content ).slideUp( {
+      duration: duration,
+      easing: 'easeOutExpo',
+      complete: _collapseComplete
+    } );
+
+    return this;
+  }
+
+  /**
+   * Configure the expanded state appearance.
+   */
+  function _setExpandedState() {
+    _showCollapseCue();
+    _dom.classList.add( 'expandable__expanded' );
+    _content.setAttribute( 'aria-expanded', 'true' );
+    _target.setAttribute( 'aria-pressed', 'true' );
+    _isExpanded = true;
+  }
+
+  /**
+   * Configure the collapsed state appearance.
+   */
+  function _setCollapsedState() {
+    _showExpandCue();
+    _dom.classList.remove( 'expandable__expanded' );
+    _content.setAttribute( 'aria-expanded', 'false' );
+    _target.setAttribute( 'aria-pressed', 'false' );
+    _isExpanded = false;
+  }
+
+  /**
+   * Expand animation has completed.
+   */
+  function _expandComplete() {
+    _setExpandedState();
+    _animationComplete();
+    _that.dispatchEvent( 'endExpand', { target: _that } );
+  }
+
+  /**
+   * Collapse animation has completed.
+   */
+  function _collapseComplete() {
+    _setCollapsedState();
+    _animationComplete();
+    _that.dispatchEvent( 'endCollapse', { target: _that } );
+  }
+
+  /**
+   * Animation for content has completed.
+   */
+  function _animationComplete() {
+    _isAnimating = false;
+    if ( _clickQueue === 1 ) {
+      _handleClick();
+      _clickQueue = 0;
+    }
+  }
+
+  /**
+   * Handle click of the Expandable target.
+   */
+  function _handleClick() {
+    if ( !_isAnimating ) {
+      _that.toggle();
+    } else {
+      _clickQueue = 1;
+    }
+  }
+
+  /**
+   * Show the expand cue and hide the collapse cue.
+   */
+  function _showExpandCue() {
+    _cueOpen.classList.remove( 'u-hide' );
+    _cueClose.classList.add( 'u-hide' );
+  }
+
+  /**
+   * Show the collapse cue and hide the expand cue.
+   */
+  function _showCollapseCue() {
+    _cueOpen.classList.add( 'u-hide' );
+    _cueClose.classList.remove( 'u-hide' );
+  }
+
+  // Attach public events.
+  var eventObserver = new EventObserver();
+  this.addEventListener = eventObserver.addEventListener;
+  this.removeEventListener = eventObserver.removeEventListener;
+  this.dispatchEvent = eventObserver.dispatchEvent;
+
+  this.init = init;
+  this.toggle = toggle;
+  this.expand = expand;
+  this.collapse = collapse;
+  return this;
+}
+
+/**
+ * @param {number} height The height of the expandable content area in pixels.
+ * @returns {number} The amount of time over which to expand in milliseconds.
+ */
+function _calculateExpandDuration( height ) {
+  return _constrainValue( 450, 900, height * 4 );
+}
+
+/**
+ * @param {number} height The height of the expandable content area in pixels.
+ * @returns {number} The amount of time over which to expand in milliseconds.
+ */
+function _calculateCollapseDuration( height ) {
+  return _constrainValue( 350, 900, height * 2 );
+}
+
+/**
+ * @param {number} min The minimum height in pixels.
+ * @param {number} max The maximum height in pixels.
+ * @param {number} duration The amount of time over which to expand in milliseconds.
+ * @returns {number} The amount of time over which to expand in milliseconds,
+ *   constrained to within the min/max values.
+ */
+function _constrainValue( min, max, duration ) {
+  if ( duration > max ) {
+    return max;
+  } else if ( duration < min ) {
+    return min;
+  }
+  return duration;
+}
+
+module.exports = Expandable;

--- a/cfgov/preprocessed/js/organisms/ExpandableGroup.js
+++ b/cfgov/preprocessed/js/organisms/ExpandableGroup.js
@@ -1,0 +1,61 @@
+'use strict';
+
+// Required polyfills for <IE9.
+require( '../modules/polyfill/query-selector' );
+require( '../modules/polyfill/event-listener' );
+
+var Expandable = require( '../molecules/Expandable' );
+
+/**
+ * ExpandableGroup
+ * @class
+ *
+ * @classdesc Initializes a new Expandable Group organism.
+ *
+ * @param {Object} context
+ *   The DOM element within which to search for the organism.
+ * @returns {Object} An ExpandableGroup instance.
+ */
+function ExpandableGroup( context ) {
+
+  var _dom = context.classList.contains( 'expandable-group' ) ?
+             context : context.querySelector( '.expandable-group' );
+  var _domChildren = _dom.querySelectorAll( '.expandable' );
+  var _lastOpenChild;
+  var _isAccordion;
+
+  /**
+   * @returns {Object} The ExpandableGroup instance.
+   */
+  function init() {
+    _isAccordion = _dom.getAttribute( 'data-accordion' ) === 'True';
+
+    var child;
+    var len = _domChildren.length;
+
+    for ( var i = 0; i < len; i++ ) {
+      child = new Expandable( _domChildren[i] ).init();
+      child.addEventListener( 'beginExpand', _childOpened );
+    }
+
+    return this;
+  }
+
+  /**
+   * Handle opening event of a child Expandable instance.
+   * @param {Object} ev An object that references the event target.
+   */
+  function _childOpened( ev ) {
+    if ( _isAccordion ) {
+      if ( _lastOpenChild ) {
+        _lastOpenChild.collapse();
+      }
+      _lastOpenChild = ev.target;
+    }
+  }
+
+  this.init = init;
+  return this;
+}
+
+module.exports = ExpandableGroup;

--- a/cfgov/preprocessed/js/routes/browse-basic/index.js
+++ b/cfgov/preprocessed/js/routes/browse-basic/index.js
@@ -1,0 +1,16 @@
+/* ==========================================================================
+   Scripts for /browse-basic/.
+   ========================================================================== */
+
+'use strict';
+
+// List of organisms used.
+var ExpandableGroup = require( '../../organisms/ExpandableGroup' );
+
+var expandables = document.querySelectorAll( '.expandable-group' );
+
+var regularExpandableGroup = new ExpandableGroup( expandables[0] );
+var accordionExpandableGroup = new ExpandableGroup( expandables[1] );
+
+regularExpandableGroup.init();
+accordionExpandableGroup.init();


### PR DESCRIPTION
Adds browse-basic prototype.
DFJR-508 - Atomizes Expandable/ExpandableGroup components.
Required for DFJR-501.

## Additions

- Adds browse-basic prototype page and URL.
- Adds Expandable molecule.
- Adds ExpandableGroup organism.
- Adds `classList` JS polyfill.
- Adds `u-hide` utility class to hide an element.
- Adds `EventObserver.js` for adding event broadcaster capability to JS classes.

## Changes

- Edits expandable styles in cf-enhancements to use new padding from Design mocks.

## Testing

- Visit `http://localhost:8000/browse-basic/`

## Review

- @KimberlyMunoz 
- @sebworks 
- @jimmynotjim 
- @ajbush 

## Screenshots

JS
![screen shot 2015-11-03 at 11 50 01 am](https://cloud.githubusercontent.com/assets/704760/10915196/b9dfb998-8223-11e5-8276-1dd255e4b9aa.png)

no-JS
![screen shot 2015-11-03 at 12 00 15 pm](https://cloud.githubusercontent.com/assets/704760/10915209/c182cce4-8223-11e5-8023-9dd02f82c8c2.png)

## Todos

- **Atomic expandables vs cf-expandables**. This removes some of the jQuery dependencies from the Expandables for DOM querying, however, we're currently loading cf-expandable JS globally so this contains a block of code to negate the global code for this prototype. This will need to be removed when that discrepancy is resolved.
- **aria attributes**. Should the aria attributes be set in the HTML at the macro level or is it okay to set them via JS only?
- **Atomic class names**. I wasn't sure if the expandable classes should be recreated as `m-expandable` and `o-expandable-group`.