### PR TITLE
Modifies the `import-data` management command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,8 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Added templates and CSS for the Signup Form organism.
 - Added templates and CSS for the Content Sidebar organism.
 - Added instruction to create superuser for admin access.
+- Adds new file to commands module in the core app called `_helpers.py`
+- Adds ability to import snippets
 
 ### Changed
 - Updated the primary nav to move focus as user enters and leaves nav levels
@@ -138,6 +140,10 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Uses globally installed Protractor in setup.sh, if available.
 - Updated the existing breakpoint variables and values to the ones released in cf-core v1.2.0
 - Excludes 3rd-party JS polyfills from linting.
+- Abstracts code into helper class `DataImporter`
+- Modifies command line options to allow specifying arguments for importing pages or snippets
+- Changes the way the processor module is imported so it imports it using the [app] argument
+- Moves the processors module from the core.management.commands module to the v1 app
 
 ### Removed
 - Removed unused exportsOverride section,

--- a/README.md
+++ b/README.md
@@ -133,22 +133,59 @@ To view the indexed content you can use a tool called
 than 8000 use `python cfgov/manage.py runserver <port number>`, e.g. `8001`.
 
 ### Load data into Django models
-The Django management command `import-data` will import data from the specified source into the specified model.
-
-`python cfgov/manage.py import-data data_type wagtail_type parent_page_slug -u username -p password`
+The Django management command `import-data` will import data from the specified
+source into the specified model.
+```
+usage: manage.py import-data [-h] [--version] [-v {0,1,2,3}] [--settings SETTINGS]
+        [--pythonpath PYTHONPATH] [--traceback] [--no-color] [--parent PARENT] 
+        [--snippet] -u USERNAME -p PASSWORD [--app APP] [--overwrite]
+        data_type wagtail_type
+```
 - `data_type` is the WP post type defined in the `processors.py` file.
 - `wagtail_type` is the Django model name where the data is going to go.
-- `parent_page_slug` is the slug of the parent page that the pages will exist under.
 - `-u` and `-p` are credentials to an admin account.
 
-Optional parameters:
+Required option:
+- `--parent` is the slug of the parent page that the pages will exist
+  under.
+- `--snippet` is a flag that's used to signify that the importing data will be
+  inserted into a Django model, registered as a [Wagtail snippet](http://docs.wagtail.io/en/v1.1/topics/snippets.html).
+  One of these options must be set for the command to run.
+
+Other options:
 - `--app` is the name of the app the Django models from `wagtail_type` exist in.
-It defaults to our app, `v1`
+  It defaults to our app, `v1`.
 - `--overwrite` overwrites existing pages in Wagtail based on comparing slugs.
 Be careful when using this as it will overwrite the data in Wagtail with data
 from the source. Default is `False`.
 - `--verbosity` is set to 1 by default. Set it to 2 or higher and expect the
 name of the slugs to appear where appropriate.
+
+For now, in order for this command to import the data, one of the things it 
+needs is a file for "sheer logic" to use to retrieve the data. For us, the
+processors are already done from our last backend. This part of the command 
+will change as we move away from our dependency on "sheer logic". This is set
+by putting the file in a `processors` module in the top level of the project
+and adding it to the setting SHEER_PROCESSORS.
+
+The command needs a `processors` module in the app that's passed to it, as well
+as a file with the same name as the Django model specified that defines a class
+named `DataConverter` that subclasses either `_helpers.PageDataConverter` or
+`_helpers.SnippetDataConverter` and implements their method(s) explained below:
+- **PageDataConverter**
+ - **convert(self, imported_data)**
+   For converting pages or snippets, the processor file must implement the
+   **convert()** function with one argument. That argument represents the
+   imported data dictionary. That function must take the dictionary and map it
+   to a new one that uses the keys that Wagtail's **create()** and **edit()**
+   admin/snippet view functions expect in the `request.POST` dictionary to
+   actually migrate the data over, and then returns that dictionary where it
+   will be assigned to `request.POST`.
+- **SnippetDataConverter(PageDataConverter)**
+ - **get_existing_snippet()**
+   This also accepts the imported data dictionary. It's used to find an
+   existing snippet given the imported data, returning it if found or `None` if
+   not.
 
 ### 4. Launch the Gulp watch task
 

--- a/cfgov/core/management/commands/_helpers.py
+++ b/cfgov/core/management/commands/_helpers.py
@@ -1,0 +1,139 @@
+import traceback
+
+from django.contrib.auth import authenticate
+from django.core.exceptions import PermissionDenied, ValidationError
+from django.http import HttpRequest
+from django.contrib.messages.api import MessageFailure
+
+from wagtail.wagtailcore.models import Page
+from wagtail.wagtailadmin.views import pages as pages_views
+from wagtail.wagtailsnippets.views import snippets as snippets_views
+
+
+class Importer:
+    def __init__(self, *args, **kwargs):
+        self.data_type = kwargs.get('data_type')
+        self.wagtail_type = kwargs.get('wagtail_type')
+        self.parent = kwargs.get('parent')
+        self.snippet = kwargs.get('snippet')
+        self.username = kwargs.get('username')
+        self.password = kwargs.get('password')
+        self.app = kwargs.get('app', 'v1')
+        self.overwrite = kwargs.get('overwrite')
+        self.verbosity = kwargs.get('verbosity')
+        self.results = {
+            'migrated': 0,
+            'overwritten': 0,
+            'existed': 0,
+            'errors': 0,
+            'migrated_slugs': [],
+            'overwritten_slugs': [],
+            'existed_slugs': [],
+            'errors_slugs': [],
+        }
+
+    def migrate(self, imported_data, converter):
+        # Create the request object then pass it an authenticated user.
+        request = HttpRequest()
+        request.user = self.authenticate_user()
+
+        if self.snippet:
+            self.migrate_snippet(request, imported_data, converter)
+        else:
+            self.migrate_page(request, imported_data, converter)
+
+    def migrate_page(self, request, imported_data, converter):
+        try:
+            existing = Page.objects.get(slug=imported_data.get('slug'))
+        except Page.DoesNotExist:
+            existing = None
+
+        if existing and not self.overwrite:
+            self.results['existed'] += 1
+            self.results['existed_slugs'].append(imported_data.get('slug'))
+            return
+
+        # Get parent. If parent doesn't exist, then raise Page.DoesNotExist
+        try:
+            parent_page = Page.objects.get(slug=self.parent)
+        except:
+            raise Page.DoesNotExist('Parent page does not exist')
+
+        # Convert the imported data into Wagtail readable data then publish it.
+        request.POST = converter.convert(imported_data)
+        request.POST['action-publish'] = u'Publish on WWW'
+
+        # Create the page or overwrite the existing one. Since we aren't
+        # hitting the middleware we have to catch the MessageFailure exception.
+        try:
+            if self.overwrite and existing:
+                pages_views.edit(request, existing.id)
+            else:
+                pages_views.create(request, self.app, self.wagtail_type,
+                                   parent_page.id)
+        except MessageFailure:
+            self.is_valid(existing, imported_data)
+
+    def migrate_snippet(self, request, imported_data, converter):
+        existing = converter.get_existing_snippet(imported_data)
+
+        if existing and not self.overwrite:
+            self.results['existed'] += 1
+            self.results['existed_slugs'].append(imported_data.get('slug'))
+            return
+
+        # Convert the imported data into Wagtail readable data then save it.
+        request.POST = converter.convert(imported_data)
+        request.POST['save'] = u'Save'
+
+        # Create the snippet or overwrite the existing one. Since we aren't
+        # hitting the middleware we have to catch the MessageFailure exception.
+        try:
+            if self.overwrite and existing:
+                snippets_views.edit(request, existing.id)
+            else:
+                snippets_views.create(request, self.app, self.wagtail_type)
+        except MessageFailure:
+            self.is_valid(existing, imported_data)
+
+    def authenticate_user(self):
+        user = authenticate(username=self.username, password=self.password)
+        if user:
+            if not user.is_active or not user.is_superuser:
+                raise PermissionDenied('This user does not have permissions to'
+                                       + 'perform this operation.')
+        else:
+            raise ValidationError('The username and password were incorrect.')
+
+        return user
+
+    # Because the middleware isn't being used, we have to catch the
+    # MessageFailure and analyze the actual traceback to see if it was a
+    # success or failure.
+    def is_valid(self, existing, imported_data):
+        if 'messages.error' in traceback.format_exc():
+            self.results['errors'] += 1
+            self.results['errors_slugs'].append(imported_data.get('slug'))
+        elif existing and self.overwrite:
+            self.results['overwritten'] += 1
+            self.results['overwritten_slugs'].append(imported_data.get('slug'))
+        else:
+            self.results['migrated'] += 1
+            self.results['migrated_slugs'].append(imported_data.get('slug'))
+
+    def print_results(self):
+        for state in ['migrated', 'overwritten', 'existed', 'errors']:
+            print '%s %s' % (self.results[state], state)
+            if self.verbosity > 1:
+                for slug in self.results[state + '_slugs']:
+                    print slug
+
+
+class PageDataConverter:
+    def convert(self, imported_data):
+        raise NotImplementedError()
+
+
+class SnippetDataConverter(PageDataConverter):
+    def get_existing_snippet(self, imported_data):
+        raise NotImplementedError()

--- a/cfgov/core/management/commands/import-data.py
+++ b/cfgov/core/management/commands/import-data.py
@@ -1,29 +1,19 @@
-import sys
-import os.path
-from unipath import Path
-import codecs
-import json
-import traceback
 from importlib import import_module
 
-from django.core.management.base import BaseCommand, CommandError
 from django.conf import settings
-from django.http import HttpRequest
-from django.contrib.auth import authenticate
-from django.core.exceptions import PermissionDenied, ValidationError
-from django.contrib.messages.api import MessageFailure
+from django.core.management.base import BaseCommand, CommandError
 
-from wagtail.wagtailadmin.views.pages import create, edit
-from wagtail.wagtailcore.models import Page
+from ._helpers import Importer
 
 
 class Command(BaseCommand):
-    help = "populate a Django model using a Sheer indexer"
+    help = 'Populate a Django model using a Sheer indexer and a processor.'
 
     def add_arguments(self, parser):
         parser.add_argument('data_type')
         parser.add_argument('wagtail_type')
-        parser.add_argument('parent_page_slug')
+        parser.add_argument('--parent', action='store', required=False)
+        parser.add_argument('--snippet', action='store_true')
         parser.add_argument('-u', '--username', action='store', required=True)
         parser.add_argument('-p', '--password', action='store', required=True)
         parser.add_argument('--app', action='store', default='v1')
@@ -32,116 +22,43 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         data_type = options['data_type']
         wagtail_type = options['wagtail_type'].lower()
-        parent_page_slug = options['parent_page_slug']
-        username = options['username']
-        password = options['password']
         app = options['app']
-        overwrite = options['overwrite']
 
-        sheer_sites = settings.SHEER_SITES
-        sheer_libs = [Path(s).child('_lib') for s in sheer_sites]
-        sys.path += sheer_libs
+        if not options['parent'] and not options['snippet']:
+            raise CommandError('manage.py import-data: error: you must specify'
+                               + ' either a parent page to import pages or'
+                               + ' flag the importing as a snippet.')
 
-        processors = {}
+        # Sheer settings: uses sheer processors to retrieve the original data.
+        processors = settings.SHEER_PROCESSORS
 
-        possible_processor_configs = \
-            [Path(s).child('_settings').child('processors.json')
-             for s in sheer_sites]
-
-        for procjson in possible_processor_configs:
-            if os.path.exists(procjson):
-                with codecs.open(procjson, encoding='utf8') as jsonfile:
-                    raw_json = jsonfile.read()
-                    merged_json = os.path.expandvars(raw_json)
-                    config = json.loads(merged_json)
-                    processors.update(config)
-
+        # Looks for the correct sheer processor to use for data retrieval.
         if data_type in processors:
             mod = import_module(processors[data_type]['processor'])
             generator = mod.documents(data_type, **processors[data_type])
-            try:  # to import the module from the arg: wagtail_type
-                wagtail_type_module = __import__('processors.%s' % wagtail_type,
-                                                 globals(), locals(),
-                                                 [data_type])
+            # Looks for a processor in this directory to import the module from
+            # using the command line argument: wagtail_type
+            try:
+                module = import_module('%s.processors.%s' %
+                                       (app, wagtail_type))
             except ImportError:
-                raise ImportError("No module found in .helpers for name (%s)"
-                                  % data_type)
-            results = {
-                'migrated': 0,
-                'overwritten': 0,
-                'existed': 0,
-                'errors': 0,
-                'migrated_slugs': [],
-                'overwritten_slugs': [],
-                'existed_slugs': [],
-                'errors_slugs': [],
-            }
+                raise ImportError(('No module found in %s.processors named '
+                                  + '(%s)') % (app, wagtail_type))
+
+            if 'DataImporter' in dir(module):
+                importer = module.DataImporter(**options)
+            else:
+                importer = Importer(**options)
+            try:
+                converter = module.DataConverter()
+            except AttributeError:
+                raise AttributeError('You must define a DataConverter class.')
             for doc in generator:
-                # Map the document to the given model name
-                results = migrate(doc['_source'], username, password,
-                                  parent_page_slug, wagtail_type_module, app,
-                                  overwrite, wagtail_type, results)
+                # Maps the retrieved sheer document to the given model name
+                # using the imported module.
+                importer.migrate(doc['_source'], converter)
 
-            for state in ['migrated', 'overwritten', 'existed', 'errors']:
-                print "%s %s" % (results[state], state)
-                if options['verbosity'] > 1:
-                    for slug in results[state + '_slugs']:
-                        print slug
+            importer.print_results()
         else:
-            raise CommandError('could not find a processor for %s' % data_type)
-
-
-def migrate(doc, username, password, parent_page_slug, module, app, overwrite, wagtail_type, results):
-    request = HttpRequest()
-    user = authenticate(username=username, password=password)
-    if user:
-        if user.is_active and user.is_superuser:
-            request.user = user
-        else:
-            raise PermissionDenied('This user does not have permissions to perform this operation')
-    else:
-        # the authentication system was unable to verify the username and password
-        raise ValidationError("The username and password were incorrect.")
-
-    # Check to see if the post already exists. We don't want WP data overwriting
-    # unless the --overwrite option is set.
-    try:
-        wagtail_page = Page.objects.get(slug=doc.get('slug'))
-    except Page.DoesNotExist:
-        wagtail_page = None
-        pass
-    if wagtail_page:
-        if not overwrite:
-            results['existed'] += 1
-            results['existed_slugs'].append(doc.get('slug'))
-            return results
-
-    # Get parent. If parent doesn't exist, then raise Page.DoesNotExist
-    try:
-        parent = Page.objects.get(slug=parent_page_slug)
-    except:
-        raise Page.DoesNotExist('Parent page does not exist')
-
-    # Convert the document data into Wagtail readable data then publish it.
-    request.POST = module.convert(doc)
-    request.POST['action-publish'] = u'Publish on WWW'
-
-    # Create the page or overwrite the existing one. Since we aren't hitting
-    # the middleware we have to catch the MessageFailure exception.
-    try:
-        if overwrite and wagtail_page:
-            edit(request, wagtail_page.id)
-        else:
-            create(request, app, wagtail_type, parent.id)
-    except MessageFailure:
-        if 'messages.error' in traceback.format_exc():
-            results['errors'] += 1
-            results['errors_slugs'].append(doc.get('slug'))
-            return results
-        if wagtail_page and overwrite:
-            results['overwritten'] += 1
-            results['overwritten_slugs'].append(doc.get('slug'))
-        else:
-            results['migrated'] += 1
-            results['migrated_slugs'].append(doc.get('slug'))
-        return results
+            raise CommandError('Could not find a processor for %s.'
+                               % data_type)

--- a/cfgov/core/management/commands/processors/eventpage.py
+++ b/cfgov/core/management/commands/processors/eventpage.py
@@ -1,80 +1,87 @@
 import dateutil
 
+from core.management.commands._helpers import PageDataConverter
 
-def convert(doc):
-    post_dict = {
-        'title':      doc.get('title', u''),
-        'slug':       doc.get('slug', u''),
-        'body':       doc.get('content', u''),
-        'flickr_url': doc.get('flickr_url', u''),
-    }
-    tags = ''
-    for tag in doc.get('tags'):
-        if ' ' in tag:
-            tag = '"%s"' % tag
-        tags += tag + ', '
-    if tags:
-        tags = tags[0:-2]
-    post_dict['tags'] = tags
-    post_dict['authors'] = '"%s"' % doc.get('author', {}).get('name', '')
 
-    times = [('beginning_time', 'start_dt'), ('ending_time', 'end_dt')]
-    for t in times:
-        if doc.get(t[0]):
-            time = doc.get(t[0]).get('date', u'')
-            if time:
-                dt = dateutil.parser.parse(time)
-                post_dict[t[1]] = dt.strftime('%Y-%m-%d %H:%M')
+class DataConverter(PageDataConverter):
+    def convert(self, doc):
+        post_dict = {
+            'title':      doc.get('title', u''),
+            'slug':       doc.get('slug', u''),
+            'body':       doc.get('content', u''),
+            'flickr_url': doc.get('flickr_url', u''),
+        }
+        tags = ''
+        for tag in doc.get('tags'):
+            if ' ' in tag:
+                tag = '"%s"' % tag
+            tags += tag + ', '
+        if tags:
+            tags = tags[0:-2]
+        post_dict['tags'] = tags
+        post_dict['authors'] = '"%s"' % doc.get('author', {}).get('name', '')
 
-    if doc.get('venue'):
-        post_dict['venue_name'] = doc['venue'].get('name', u'')
-        if doc['venue'].get('address', u''):
-            for info in ['state', 'city', 'street', 'suite', 'zip']:
-                post_dict['venue_' + info] = doc['venue']['address'].get(info, u'')
+        times = [('beginning_time', 'start_dt'), ('ending_time', 'end_dt')]
+        for t in times:
+            if doc.get(t[0]):
+                time = doc.get(t[0]).get('date', u'')
+                if time:
+                    dt = dateutil.parser.parse(time)
+                    post_dict[t[1]] = dt.strftime('%Y-%m-%d %H:%M')
 
-    if doc.get('live_stream'):
-        for info in ['url', 'available', 'date']:
-            post_dict['live_stream_' + info] = doc['live_stream'].get(info, u'')
+        if doc.get('venue'):
+            post_dict['venue_name'] = doc['venue'].get('name', u'')
+            if doc['venue'].get('address', u''):
+                for info in ['state', 'city', 'street', 'suite', 'zip']:
+                    post_dict['venue_'+info] = \
+                        doc['venue']['address'].get(info, u'')
 
-    for tense in ['archive', 'live', 'future']:
-        if doc.get(tense):
-            summary = doc[tense].get('summary', u'')
-            if 'http://content' in summary:
-                summary = summary.replace('http://content', 'http://www')
-            post_dict[tense+'_body'] = summary
-            if tense == 'archive':
-                post_dict['flickr_url'] = doc['archive'].get('flickr', u'')
-                post_dict['youtube_url'] = doc['archive'].get('youtube', u'')
+        if doc.get('live_stream'):
+            for info in ['url', 'available', 'date']:
+                post_dict['live_stream_'+info] = doc['live_stream'].get(info,
+                                                                        u'')
 
-    post_dict['agenda_items-count'] = len(doc.get('agenda', u''))
-    if doc.get('agenda'):
-        for i in range(len(doc.get('agenda', u''))):
-            for info in (('order', i), ('type', 'item'), ('deleted', u'')):
-                post_dict['agenda_items-' + str(i) + '-' + info[0]] = info[1]
-            times = [('beginning_time', 'start_dt'), ('ending_time', 'end_dt')]
-            for t in times:
-                if doc['agenda'][i].get(t[0], u''):
-                    time = doc['agenda'][i].get(t[0]).get('date', u'')
-                    if time:
-                        dt = dateutil.parser.parse(time)
-                        post_dict['agenda_items-' + str(i) + '-value-' +
-                                  t[1]] = dt.strftime('%Y-%m-%d %H:%M')
-            post_dict['agenda_items-' + str(i) + '-value-description'] = \
-                doc['agenda'][i].get('desc', u'')
-            post_dict['agenda_items-' + str(i) + '-value-location'] = \
-                doc['agenda'][i].get('location', u'')
-            post_dict['agenda_items-' + str(i) + '-value-speakers-count'] = \
-                len(doc['agenda'][i].get('speakers', u''))
-            if doc['agenda'][i].get('speakers'):
-                for y in range(len(doc['agenda'][i].get('speakers', u''))):
-                    post_dict['agenda_items-' + str(i) + '-value-speakers-' +
-                              str(y) + '-value-name'] = \
-                        doc['agenda'][i]['speakers'][y].get('name', u'')
-                    post_dict['agenda_items-' + str(i) + '-value-speakers-' +
-                              str(y) + '-value-url'] = \
-                        doc['agenda'][i]['speakers'][y].get('url', u'')
-                    post_dict['agenda_items-' + str(i) + '-value-speakers-' +
-                              str(y) + '-order'] = y
-                    post_dict['agenda_items-' + str(i) + '-value-speakers-' +
-                              str(y) + '-deleted'] = u''
-    return post_dict
+        for tense in ['archive', 'live', 'future']:
+            if doc.get(tense):
+                summary = doc[tense].get('summary', u'')
+                if 'http://content' in summary:
+                    summary = summary.replace('http://content', 'http://www')
+                post_dict[tense+'_body'] = summary
+                if tense == 'archive':
+                    post_dict['flickr_url'] = doc['archive'].get('flickr', u'')
+                    post_dict['youtube_url'] = doc['archive'].get('youtube',
+                                                                  u'')
+
+        post_dict['agenda_items-count'] = len(doc.get('agenda', u''))
+        if doc.get('agenda'):
+            for i in range(len(doc.get('agenda', u''))):
+                for info in (('order', i), ('type', 'item'), ('deleted', u'')):
+                    post_dict['agenda_items-'+str(i)+'-'+info[0]] = info[1]
+                times = [('beginning_time', 'start_dt'),
+                         ('ending_time', 'end_dt')]
+                for t in times:
+                    if doc['agenda'][i].get(t[0], u''):
+                        time = doc['agenda'][i].get(t[0]).get('date', u'')
+                        if time:
+                            dt = dateutil.parser.parse(time)
+                            post_dict['agenda_items-'+str(i)+'-value-' +
+                                      t[1]] = dt.strftime('%Y-%m-%d %H:%M')
+                post_dict['agenda_items-'+str(i)+'-value-description'] = \
+                    doc['agenda'][i].get('desc', u'')
+                post_dict['agenda_items-'+str(i)+'-value-location'] = \
+                    doc['agenda'][i].get('location', u'')
+                post_dict['agenda_items-'+str(i)+'-value-speakers-count'] = \
+                    len(doc['agenda'][i].get('speakers', u''))
+                if doc['agenda'][i].get('speakers'):
+                    for y in range(len(doc['agenda'][i].get('speakers', u''))):
+                        post_dict['agenda_items-'+str(i)+'-value-speakers-' +
+                                  str(y)+'-value-name'] = \
+                            doc['agenda'][i]['speakers'][y].get('name', u'')
+                        post_dict['agenda_items-'+str(i)+'-value-speakers-' +
+                                  str(y)+'-value-url'] = \
+                            doc['agenda'][i]['speakers'][y].get('url', u'')
+                        post_dict['agenda_items-'+str(i)+'-value-speakers-' +
+                                  str(y)+'-order'] = y
+                        post_dict['agenda_items-'+str(i)+'-value-speakers-' +
+                                  str(y)+'-deleted'] = u''
+        return post_dict

--- a/cfgov/v1/processors/eventpage.py
+++ b/cfgov/v1/processors/eventpage.py
@@ -9,7 +9,6 @@ class DataConverter(PageDataConverter):
             'title':      doc.get('title', u''),
             'slug':       doc.get('slug', u''),
             'body':       doc.get('content', u''),
-            'flickr_url': doc.get('flickr_url', u''),
         }
         tags = ''
         for tag in doc.get('tags'):


### PR DESCRIPTION
This makes some changes to the `import-data` command that makes it more maintainable, object-oriented, pythonic and adds the ability to import data that won't be fully fledged pages into what wagtail calls snippets. [Here's some documentation on snippets](http://docs.wagtail.io/en/v1.1/topics/snippets.html). These are things that we want to define once in the CMS but use in multiple areas e.g. Contacts. 

There's also a change to the way that we execute the command.
```
usage: manage.py import-data [-h] [--version] [-v {0,1,2,3}] [--settings SETTINGS] [--pythonpath PYTHONPATH] [--traceback] [--no-color] [--parent PARENT] [--snippet] -u
                             USERNAME -p PASSWORD [--app APP] [--overwrite]
                             data_type wagtail_type
```
**Note** that the `--parent` has become an option, and that the `--parent` or `--snippet` option must be used for the command to execute. The `--parent` option requires the name of the parent's slug whereas the `--snippet` option only needs to be present, as the `wagtail_type` parameter would be the name of the snippet.

Here's an example of importing pages:
```
./cfgov/manage.py import-data events eventpage --parent events -u username -p pass
```
And here's an example of importing snippets:
```
./cfgov/manage.py import-data contact contact --snippet -u username -p pass
```

One more **BIG** thing. It's not in this PR right now, but it will be necessary that the processor file for snippets include both a function called **convert(imported_data)** (which is also necessary for a page processor) and a function called **get_existing_snippet(imported_data)** that accepts one argument (the imported data) and will return either the snippet that already exists based the imported data or `None` if there isn't an existing one.

## Additions

- Adds new file to commands module in the core app called _helpers.py
- Adds ability to import snippets

## Changes

- Abstracts code into helper class DataImporter
- Modifies command line options to allow specifying arguments for importing pages or snippets
- Changes the way the processor module is imported so it imports it using the [app] argument
- Moves the processors module from the core.management.commands module to the v1 app

## Testing

- Run it. Unfortunately, the snippet functionality can't be tested until a snippet's processor is available (soon).

## Review

- @rosskarchner 
- @kave 
- @anselmbradford 
- @KimberlyMunoz 
- @sebworks 
- @jimmynotjim 

## Notes

- It's entirely possible for migrating snippets to require some editing after a 