### PR TITLE
Adding a missing hero to sublanding page 2

### DIFF
--- a/cfgov/jinja2/v1/sublanding-page-2/index.html
+++ b/cfgov/jinja2/v1/sublanding-page-2/index.html
@@ -2,6 +2,7 @@
 
 {# Import organisms and molecules used in the template. #}
 {% import 'organisms/main-contact-info.html' as main_contact_info %}
+{% import 'molecules/hero.html' as hero %}
 
 {% block title -%}
     TODO: This is a prototype page for testing landing page layouts.


### PR DESCRIPTION
Sublanding page 2 has a error because of a missing hero. Someone call [Enrique Iglesias](https://www.youtube.com/watch?v=HnOlw8HdVIw).

## Fixes
- Adds missing macro to sublanding-page-2

## Test
- Visit http://localhost:8000/sublanding-page-2/
- Add your favorite song that mentions heros in the comments.

## Notes
- If someone thinks [we don't need this hero](https://www.youtube.com/watch?v=dq4aOaDXIfY), I can rip the whole thing out.
