### PR TITLE
Cleaned up and rebuilt the secondary nav

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -154,6 +154,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Contact molecule templates
 - Changes .env Project configuration workon control flow to direct stdout and stderr to /dev/null.
 - Upgrade wagtail to 1.2
+- Cleaned up and rebuilt the secondary nav to reduce complexity and fix bugs
 
 ### Removed
 - Removed unused exportsOverride section,

--- a/cfgov/jinja2/v1/_includes/sidenav.html
+++ b/cfgov/jinja2/v1/_includes/sidenav.html
@@ -22,25 +22,25 @@
 
 {% macro render(items, active_item_id, additional_classes) %}
 
-<nav class="nav-secondary expandable {{ additional_classes }}"
+<nav class="nav-secondary expandable {{ additional_classes if additional_classes else '' }}"
      aria-label="Section navigation">
     <div class="expandable_header nav-secondary_header">
-        <button class="expandable_target nav-secondary_link nav-secondary_link__button">
+        <button class="expandable_target nav-secondary_button">
             <span class="expandable_header-left">
                 In this section
             </span>
             <span class="expandable_header-right">
                 <span class="expandable_cue-open">
-                    <span class="cf-icon cf-icon-down cf-icon__green"></span>
+                    <span class="cf-icon cf-icon-down"></span>
                 </span>
                 <span class="expandable_cue-close">
-                    <span class="cf-icon cf-icon-up cf-icon__green"></span>
+                    <span class="cf-icon cf-icon-up"></span>
                 </span>
             </span>
         </button>
     </div>
     <div class="expandable_content nav-secondary_content">
-        <ul class="nav-secondary_list">
+        <ul class="nav-secondary_list nav-secondary_list__parents">
         {%- for item in items %}
             {%- set href, id, caption, children = item[0], item[1], item[2], item[3:] %}
             <li class="nav-secondary_item nav-secondary_item__parent">
@@ -55,9 +55,9 @@
                 {% endif -%}
             {%- if children -%}
                 {% set children = children[0] %}
-                <ul class="nav-secondary_list">
+                <ul class="nav-secondary_list nav-secondary_list__children">
                 {%- for href, id, caption in children %}
-                    <li class="nav-secondary_item nav-secondary_item__child">
+                    <li class="nav-secondary_item">
                     {%- if id == active_item_id %}
                         <a class="nav-secondary_link nav-secondary_link__current">
                             {{ caption|e }}

--- a/cfgov/unprocessed/css/nav-primary.less
+++ b/cfgov/unprocessed/css/nav-primary.less
@@ -72,6 +72,10 @@
   tags:
     - cfgov-nav-primary
 */
+
+// TODO: Refactor these variable to use existing CF font size variables.
+@font-size-large: 18px;
+
 .primary-nav {
     .list_link {
         .webfont-regular();

--- a/cfgov/unprocessed/css/nav-secondary.less
+++ b/cfgov/unprocessed/css/nav-secondary.less
@@ -1,17 +1,7 @@
-/* ==========================================================================
+/* =========================================================================
    cfgov-refresh
    nav-secondary
-   ========================================================================== */
-
-// .nav-secondary_link__disabled
-@nav-secondary_link__disabled-text:            @gray-50;
-@nav-secondary_link__disabled-bg:              @white;
-@nav-secondary_link__disabled-outline:         @gray-20;
-@nav-secondary_link__disabled-border:          @nav-secondary_link__disabled-bg;
-
-// TODO: Refactor these variable to use existing CF font size variables.
-@font-size-small: 16px;
-@font-size-large: 18px;
+   ========================================================================= */
 
 /* topdoc
   name: Secondary navigation
@@ -20,21 +10,22 @@
     - name: Default example
       markup: |
         <nav class="nav-secondary">
-            <button class="nav-secondary_link nav-secondary_link__button">
-                Item 1
+            <button class="nav-secondary_button">
+                Nav Button
             </button>
-            <ul class="nav-secondary_list">
-                <li class="nav-secondary_item">
+            <ul class="nav-secondary_list nav-secondary_list__parents">
+                <li class="nav-secondary_item nav-secondary_item__parent">
                     <a class="nav-secondary_link" href="#">
                        Item 1
                     </a>
                 </li>
-                <li class="nav-secondary_item">
-                    <a class="nav-secondary_link nav-secondary_link__current" href="#">
+                <li class="nav-secondary_item nav-secondary_item__parent">
+                    <a class="nav-secondary_link
+                              nav-secondary_link__current" href="#">
                        Item 2
                     </a>
                 </li>
-                <li class="nav-secondary_item">
+                <li class="nav-secondary_item nav-secondary_item__parent">
                     <a class="nav-secondary_link" href="#">
                        Item 3
                     </a>
@@ -46,10 +37,11 @@
           Structural cheat sheet:
           -----------------------
           .nav-secondary
-            .nav-secondary_link.nav-secondary_link__button
+            .nav-secondary_button
             .nav-secondary_list
               .nav-secondary_item
-                .nav-secondary_link / .nav-secondary_link.nav-secondary_link__current
+                .nav-secondary_link /
+                .nav-secondary_link.nav-secondary_link__current
     - name: Current link modifier
       markup: |
         <a class="nav-secondary_link nav-secondary_link__current" href="#">
@@ -58,67 +50,44 @@
       codenotes:
         - ".nav-secondary_link__current"
       notes:
-        - "Current links are hidden on small screens and the link button is
+        - "Current links are hidden on small screens and the menu button is
            revealed."
-        - "Currentl links have a left green border on large screens."
-    - name: Link button modifier
-      markup: |
-        <button class="nav-secondary_link nav-secondary_link__button">
-            Button nav link
-        </button>
-      codenotes:
-        - ".nav-secondary_link__button"
-      notes:
-        - "This modifier is only visible on smaller screens."
-        - "The button link modifier is used to convey the current link for small
-           screens. It also acts as a toggle button when mixing this pattern
-           with the expandable pattern."
-        - "The inline style is for demonstration purposes only and is needed
-           because the modifier hides the element at larger screen size.
-           Please do not use it in production."
-    - name: disabled link modifier
-      markup: |
-        <a class="nav-secondary_link nav-secondary_link__disabled">
-            Disabled nav link
-        </a>
-      codenotes:
-        - ".nav-secondary_link__disabled"
-      notes:
-        - "Gives the link disabled link styles,
-           for when there is no href value, for instance."
+        - "Current links have a left green border on all screens."
     - name: Secondary nav mixed with cf-expandable
       markup: |
         <nav class="nav-secondary expandable">
             <div class="expandable_header">
                 <button class="expandable_target
-                        nav-secondary_link
-                        nav-secondary_link__button">
+                               nav-secondary_button">
                     <span class="expandable_header-left">
-                        Item 2
+                        Nav Button
                     </span>
                     <span class="expandable_header-right">
                         <span class="expandable_cue-open">
-                            <span class="cf-icon cf-icon-down cf-icon__green"></span>
+                            <span class="cf-icon
+                                         cf-icon-down"></span>
                         </span>
                         <span class="expandable_cue-close">
-                            <span class="cf-icon cf-icon-up cf-icon__green"></span>
+                            <span class="cf-icon
+                                         cf-icon-up"></span>
                         </span>
                     </span>
                 </button>
             </div>
             <div class="expandable_content">
                 <ul class="nav-secondary_list">
-                    <li class="nav-secondary_item">
+                    <li class="nav-secondary_item nav-secondary_item__parent">
                         <a class="nav-secondary_link" href="#">
                            Item 1
                         </a>
                     </li>
-                    <li class="nav-secondary_item">
-                        <a class="nav-secondary_link nav-secondary_link__current" href="#">
+                    <li class="nav-secondary_item nav-secondary_item__parent">
+                        <a class="nav-secondary_link
+                           nav-secondary_link__current" href="#">
                            Item 2
                         </a>
                     </li>
-                    <li class="nav-secondary_item">
+                    <li class="nav-secondary_item nav-secondary_item__parent">
                         <a class="nav-secondary_link" href="#">
                            Item 3
                         </a>
@@ -132,175 +101,116 @@
           -----------------------
           .nav-secondary.expandable
             .expandable_header
-              .expandable_target.nav-secondary_link.nav-secondary_link__button
+              .expandable_target.nav-secondary_button
                 .expandable_header-left
                 .expandable_header-right
                   .expandable_cue-open
-                    .cf-icon.cf-icon-down.cf-icon__green
+                    .cf-icon.cf-icon-down
                   .expandable_cue-close
-                    .cf-icon.cf-icon-up.cf-icon__green
+                    .cf-icon.cf-icon-up
             .expandable_content
               .nav-secondary_list
                 .nav-secondary_item
-                  .nav-secondary_link / .nav-secondary_link.nav-secondary_link__current
+                  .nav-secondary_link /
+                  .nav-secondary_link.nav-secondary_link__current
   tags:
     - cfgov-nav-secondary
 */
 
 .nav-secondary {
+    .webfont-regular();
 
     .respond-to-max(@bp-sm-max, {
+        margin-bottom: unit(@grid_gutter-width / @base-font-size-px, em);
+
         background-color: @gray-10;
         border-top: 1px solid @gray-20;
         border-bottom: 1px solid @gray-20;
-        margin-bottom: unit(@grid_gutter-width / @base-font-size-px, em);
     });
 
-    // Inset horizontal rule between "IN THIS SECTION" text and page links.
-    & .inset-divider {
-      margin: 0 @grid_gutter-width / 2 @grid_gutter-width / 2;
-      border: 0;
-      height: 1px;
-      background-color: @gray-20;
+    &_button {
+        width: 100%;
+        padding: unit( (@grid_gutter-width / 2) / @base-font-size-px, em);
 
-      // Only shown on tablet/mobile sizes.
-      .respond-to-min(@bp-lg-min, {
-        display: none;
-      });
+        .webfont-demi();
+
+        text-align: left;
+        text-transform: uppercase;
+
+        &:focus {
+            outline: 1px dotted;
+        }
+
+        .cf-icon {
+            color: @green;
+        }
+
+        .respond-to-min(@bp-med-min, {
+            display: none;
+        });
     }
 
     &_list {
         margin: 0;
         padding: 0;
-    }
-    &_item, &_item__child {
-        list-style: none;
-        .webfont-regular();
 
-        .respond-to-min(@bp-lg-min, {
-            & + & {
-                margin-top: 10px;
-            }
-        });
-    }
+        &__parents {
+            .respond-to-max(@bp-sm-max, {
+                padding-bottom: unit( (@grid_gutter-width / 2) / @base-font-size-px, em);
+                margin-left: unit( (@grid_gutter-width / 2) / @base-font-size-px, em);
+                margin-right: unit( (@grid_gutter-width / 2) / @base-font-size-px, em);
 
-    &_item {
-        .respond-to-min(@bp-med-min, {
-            & + &,
-            &__child {
-              margin-top: 10px;
-            }
-        });
-    }
+                border-top: 1px solid @gray-50;
+            });
+        }
 
-    &_item__parent {
-        .h4();
-        .webfont-medium();
-        margin-bottom: 0;
-        padding-bottom: 0;
-    }
+        &__children {
+            margin-left: unit( (@grid_gutter-width / 2) / @base-font-size-px, em);
 
-    &_item__child {
-        // Gutter width minus optical offset.
-        margin-left: @grid_gutter-width - 13px;
+            .respond-to-min(@bp-med-min, {
+                // Add 5px for the border to half the gutter
+                margin-left: unit( (@grid_gutter-width / 2 + 5px ) / @base-font-size-px, em) ;
+            });
+        }
     }
 
     &_link {
         .u-inline-block();
-        margin-left: unit(-15px / @font-size-large, em);
-        padding: unit(5px / @font-size-large, em)
-                 unit(10px / @font-size-large, em);
-        border-left-style: solid;
-        border-left-width: 5px;
-        font-size: unit(@font-size-large / @base-font-size-px, em);
+
         .u-link__colors(@pacific, @pacific, @black, @black, @black,
                         transparent, transparent, @green, @green, @green);
 
+        border-left-style: solid;
+        border-left-width: 5px;
+
         .respond-to-max(@bp-sm-max, {
             display: block;
+
             padding: unit((@grid_gutter-width / 2) / @base-font-size-px, em);
-            font-size: unit(@font-size-small / @base-font-size-px, em);
-            .u-link__colors(@darkgray, @darkgray, @darkgray, @darkgray, @darkgray,
-                            transparent, transparent, @green, @green, @green);
-            margin: 0 @grid_gutter-width / 2;
+
+            .u-link__colors(@darkgray, @darkgray, @darkgray, @darkgray,
+                            @darkgray, transparent, transparent, @green,
+                            @green, @green);
         });
 
-        .respond-to-max(@bp-xs-max, {
-            padding-left: unit((@grid_gutter-width / 2) / @font-size-small, em);
-            padding-right: unit((@grid_gutter-width / 2) / @font-size-small, em);
+        .respond-to-min(@bp-med-min, {
+            padding-top: unit(10px / @base-font-size-px, em);
+            padding-bottom: unit(10px / @base-font-size-px, em);
+            padding-left: unit( (@grid_gutter-width / 2) / @base-font-size-px, em);
         });
 
         &__current {
             .u-link__colors(@black, @black, @black, @black, @black,
                             @green, @green, @green, @green, @green);
+
             cursor: default;
         }
 
-        &__button {
-            width: 100%;
-            .webfont-demi();
-            text-align: left;
-            text-transform: uppercase;
+        .nav-secondary_item__parent > & {
+            .h4();
 
-            &:focus {
-                outline: thin dotted;
-            }
-
-            .respond-to-min(@bp-med-min, {
-                display: none;
-            });
+            margin-bottom: initial;
         }
-
-        &__disabled {
-            background-color: @nav-secondary_link__disabled-bg;
-            color: @nav-secondary_link__disabled-text;
-            cursor: default; // Fallback for IE/Opera.
-            cursor: not-allowed;
-
-            &:hover,
-            &:visited,
-            &:active,
-            &:focus {
-                border-left-color: @nav-secondary_link__disabled-border;
-                color: @nav-secondary_link__disabled-text;
-                outline-color: @nav-secondary_link__disabled-outline;
-            }
-        }
-    }
-
-    // Border below "IN THIS SECTION" link on mobile.
-    .nav-secondary_item {
-        &:last-child {
-            .respond-to-max(@bp-med-max, {
-                padding-bottom: @grid_gutter-width / 2;
-            });
-        }
-    }
-
-    // This modifier should be moved to cf-icons.
-    .cf-icon__green {
-        color: @green;
-    }
-
-    // Overrides the overflow: hidden set in .expandable_header for float clearing.
-    // In cf-expandables we should try to change this to our clear float utility
-    // instead so we don't have to do this here.
-    & .expandable_header {
-        overflow: visible;
-
-        // Override base style for the header "IN THIS SECTION" link.
-        & .nav-secondary_link {
-            border-left: none;
-            margin: 0;
-        }
-    }
-
-    // Overrides the 1px padding used to prevent margin collapse. It's noticeable
-    // in this pattern because of the background colors and bottom borders.
-    // In cf-expandables we should try to change this to our clear float utility
-    // instead so we don't have to do this here.
-    & .expandable_content {
-        padding: 0;
     }
 }
 


### PR DESCRIPTION
Cleaned up and rebuilt the secondary nav to reduce complexity and fix bugs

## Changes

- Reduced styles for simpler code management
- Updated nav macro for new styles
- Fixed font-size issue
- Fixed Jinja error when additional_classes weren't defined
- Moved font size variable to primary nav where it's used

## Testing

- run `gulp build` and test any page w/ a left side nav

## Review

- @ajbush 
- @anselmbradford 
- @KimberlyMunoz 
- @sebworks 

## Preview

![screen shot 2015-11-10 at 10 03 28 am](https://cloud.githubusercontent.com/assets/1280430/11067480/5889d27c-8792-11e5-920c-6570bb03aecb.png)

![screen shot 2015-11-10 at 10 03 46 am](https://cloud.githubusercontent.com/assets/1280430/11067481/5ae0fbf4-8792-11e5-8a0d-eb291a0150c8.png)

[Preview this PR without the whitespace changes](?w=0)

## Notes

- Replaces PR #1128 
- Updates #637, but the `@font-size-large` still needs to be refactored out of the primary nav in another PR