### PR TITLE
Changes .env Project configuration

### DIFF
--- a/.env_SAMPLE
+++ b/.env_SAMPLE
@@ -86,7 +86,7 @@ export TOXENV=py27
 # Project configuration - set up working state.
 ###############################################
 
-if ! type "$workon" 2>/dev/null; then
+if ! type "$workon" &>/dev/null; then
   workon $VIRTUAL_ENV &&
   echo Virtualenv \"$VIRTUAL_ENV\" activated. ||
   echo Virtualenv was not activated.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -149,6 +149,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Changes the way the processor module is imported so it imports it using the [app] argument
 - Moves the processors module from the core.management.commands module to the v1 app
 - Contact molecule templates
+- Changes .env Project configuration workon control flow to direct stdout and stderr to /dev/null.
 
 ### Removed
 - Removed unused exportsOverride section,


### PR DESCRIPTION
Changes .env Project configuration workon control flow to direct stdout and stderr to /dev/null so that no output will show as a result of the `if` statement.

Seems that in zsh the `type` command outputs to stdout when a command cannot be found, not stderr.

@anselmbradford 
@sebworks 
@kave 