### PR TITLE
Modifying forms.py to allow mm/dd/yyyy format on CalenderPDFFilterForm

### DIFF
--- a/cfgov/v1/forms.py
+++ b/cfgov/v1/forms.py
@@ -6,10 +6,8 @@ from sheerlike.templates import date_formatter
 
 class CalenderPDFFilterForm(forms.Form):
     filter_calendar = forms.CharField()
-    filter_range_date_gte = forms.DateField(input_formats=['%m/%d/%Y',
-                                                           '%Y-%m-%d'])
-    filter_range_date_lte = forms.DateField(input_formats=['%m/%d/%Y',
-                                                           '%Y-%m-%d'])
+    filter_range_date_gte = forms.DateField()
+    filter_range_date_lte = forms.DateField()
 
     def clean_filter_calendar(self):
         return self.cleaned_data['filter_calendar'].replace(' ', '+')

--- a/cfgov/v1/forms.py
+++ b/cfgov/v1/forms.py
@@ -4,19 +4,23 @@ from v1.models.events import EventPage
 from sheerlike.templates import date_formatter
 
 
+class FormDateField(forms.DateField):
+
+    def to_python(self, value):
+        if value:
+            try:
+                value = date_formatter(value)
+            except Exception as e:
+                raise forms.ValidationError(self.error_messages['invalid'])
+        return super(FormDateField, self).to_python(value)
+
 class CalenderPDFFilterForm(forms.Form):
     filter_calendar = forms.CharField()
-    filter_range_date_gte = forms.DateField()
-    filter_range_date_lte = forms.DateField()
+    filter_range_date_gte = FormDateField(required=False)
+    filter_range_date_lte = FormDateField(required=False)
 
     def clean_filter_calendar(self):
         return self.cleaned_data['filter_calendar'].replace(' ', '+')
-
-    def clean_filter_range_date_gte(self):
-        return date_formatter(self.cleaned_data['filter_range_date_gte'])
-
-    def clean_filter_range_date_lte(self):
-        return date_formatter(self.cleaned_data['filter_range_date_lte'])
 
 
 class EventsFilterForm(forms.Form):

--- a/cfgov/v1/forms.py
+++ b/cfgov/v1/forms.py
@@ -22,6 +22,15 @@ class CalenderPDFFilterForm(forms.Form):
     def clean_filter_calendar(self):
         return self.cleaned_data['filter_calendar'].replace(' ', '+')
 
+    def clean(self, *args, **kwargs):
+        if {'filter_range_date_lte','filter_range_date_lte'} <= set(self.cleaned_data):
+            date_gte = self.cleaned_data['filter_range_date_gte']
+            date_lte = self.cleaned_data['filter_range_date_lte']
+            if date_gte > date_lte:
+                self.cleaned_data['filter_range_date_gte'] = date_lte
+                self.cleaned_data['filter_range_date_lte'] = date_gte
+        return self.cleaned_data
+
 
 class EventsFilterForm(forms.Form):
     tags_select_attrs = {

--- a/cfgov/v1/forms.py
+++ b/cfgov/v1/forms.py
@@ -1,12 +1,27 @@
 from django import forms
 from django.forms.widgets import DateInput, SelectMultiple
 from v1.models.events import EventPage
+from sheerlike.templates import date_formatter
 
 
 class CalenderPDFFilterForm(forms.Form):
     filter_calendar = forms.CharField()
     filter_range_date_gte = forms.DateField(input_formats=['%Y-%m-%d'])
     filter_range_date_lte = forms.DateField(input_formats=['%Y-%m-%d'])
+
+    def __init__(self, *args, **kwargs):
+        if(args[0]):
+            formDict = args[0].copy()
+            date_gte = formDict.get('filter_range_date_gte')
+            date_lte = formDict.get('filter_range_date_lte')
+            if(date_gte):
+                formDict.__setitem__('filter_range_date_gte', date_formatter(date_gte))
+            if(date_lte):
+                formDict.__setitem__('filter_range_date_lte', date_formatter(date_lte))
+            args = list(args)
+            args[0] = formDict
+
+        super(CalenderPDFFilterForm, self).__init__(*args, **kwargs)
 
     def clean_filter_calendar(self):
         return self.cleaned_data['filter_calendar'].replace(' ', '+')

--- a/cfgov/v1/forms.py
+++ b/cfgov/v1/forms.py
@@ -6,25 +6,19 @@ from sheerlike.templates import date_formatter
 
 class CalenderPDFFilterForm(forms.Form):
     filter_calendar = forms.CharField()
-    filter_range_date_gte = forms.DateField(input_formats=['%Y-%m-%d'])
-    filter_range_date_lte = forms.DateField(input_formats=['%Y-%m-%d'])
-
-    def __init__(self, *args, **kwargs):
-        if(args[0]):
-            formDict = args[0].copy()
-            date_gte = formDict.get('filter_range_date_gte')
-            date_lte = formDict.get('filter_range_date_lte')
-            if(date_gte):
-                formDict.__setitem__('filter_range_date_gte', date_formatter(date_gte))
-            if(date_lte):
-                formDict.__setitem__('filter_range_date_lte', date_formatter(date_lte))
-            args = list(args)
-            args[0] = formDict
-
-        super(CalenderPDFFilterForm, self).__init__(*args, **kwargs)
+    filter_range_date_gte = forms.DateField(input_formats=['%m/%d/%Y',
+                                                           '%Y-%m-%d'])
+    filter_range_date_lte = forms.DateField(input_formats=['%m/%d/%Y',
+                                                           '%Y-%m-%d'])
 
     def clean_filter_calendar(self):
         return self.cleaned_data['filter_calendar'].replace(' ', '+')
+
+    def clean_filter_range_date_gte(self):
+        return date_formatter(self.cleaned_data['filter_range_date_gte'])
+
+    def clean_filter_range_date_lte(self):
+        return date_formatter(self.cleaned_data['filter_range_date_lte'])
 
 
 class EventsFilterForm(forms.Form):


### PR DESCRIPTION
Modifying forms.py to allow various formats on CalenderPDFFilterForm. We are currently using javascript to format date fields from 'mm/dd/yyyy' to 'YYYY-MM-DD' before submitting the form to the server. This change would allow us to remove that functionality from the front-end and just focus on validation. In addition this would provide a fallback when javsacript isn't enabled and leverage `dateutil.parser`.

## Additions
- Updated `cfgov/v1/forms.py` to coerce various date formats to 'YYYY-MM-DD'.

## Notes
- This PR doesn't address the date fields on other filters such as Blog and Events. This approach might not work for various reasons including the fact that I've never written any Django/Python before.

## Review
- @kurtw 
- @kave 
- @rosskarchner  