### PR TITLE
Fixes missing text on Navigation field in IE8

### DIFF
--- a/cfgov/unprocessed/css/nav-primary.less
+++ b/cfgov/unprocessed/css/nav-primary.less
@@ -170,6 +170,7 @@
         padding: 0 @grid_gutter-width / 2;
 
         position: relative;
+        visibility: visible;
     }
 
     &_title {
@@ -184,6 +185,7 @@
         .u-link__colors(@black, @black);
 
         display: block;
+        visibility: visible;
     }
 
     .list_link {


### PR DESCRIPTION
Fixes #1029. IE8 has some weird issues with painting and the visibility property. For example, on the pre-fix mega menu, everything would paint/render as soon as you highlighted or tabbed to a thing. The About Us link rendered because we shifted focus there for accessibility.

That's been your IE8 fun-fact for the day.

## Preview

![image](https://cloud.githubusercontent.com/assets/1860176/11150072/f7de8404-89f3-11e5-8a7b-8613a51cadf3.png)
