### PR TITLE
Adds browse-basic page, Expandable/ExpandableGroup protos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,10 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Added cf-tables and tables molecule
 - Landing Page Type
 - Initial Data json file for preloading pages
+- Added `/browse-basic` template page.
+- Added templates and CSS for Expandable molecule and ExpandableGroup organism.
+- Added `classlist` JS polyfill.
+- Added `EventObserver` for adding event broadcaster capability to JS classes.
 
 ### Changed
 - Updated the primary nav to move focus as user enters and leaves nav levels
@@ -162,6 +166,8 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Updated protractor from 2.5.1 to 3.0.0.
 - Updated gulp-sitespeedio from 0.0.7 to 0.0.8.
 - Update runserver script to start MYSQL if it isn't running
+- Reduced padding on expandables per direction of design.
+- Hide cues on expandables when JS is turned off.
 
 ### Removed
 - Removed unused exportsOverride section,
@@ -326,12 +332,6 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 ## 3.0.0-2.1.0 - 2015-08-05
 
 ### Added
-- Added `sub-pages/civil-penalty-fund-allocation-schedule/` page.
-- Added `sub-pages/sub-pages/consumer-education-financial-literacy-programs/` page.
-- Added `u-hidden` utility class for fully hiding an element.
-- Added `TEST.md` readme file for testing instructions.
-- Added `grunt clean` and `grunt copy` tasks.
-- Added `grunt clean` step to `setup.sh`.
 - Added `map` and `filter` array polyfills.
 - Added `about-us` page and tests
 - Added `newsroom` type to Activity Snippets

--- a/cfgov/cfgov/urls.py
+++ b/cfgov/cfgov/urls.py
@@ -212,6 +212,7 @@ urlpatterns = [
 if settings.DEBUG :
     urlpatterns.append(url(r'^sublanding-page-1/$', SheerTemplateView.as_view(template_name='sublanding-page-1/index.html'), name='sublanding-page-1'))
     urlpatterns.append(url(r'^sublanding-page-2/$', SheerTemplateView.as_view(template_name='sublanding-page-2/index.html'), name='sublanding-page-2'))
+    urlpatterns.append(url(r'^browse-basic/$', SheerTemplateView.as_view(template_name='browse-basic/index.html'), name='browse-basic'))
     urlpatterns.append(url(r'^browse-filterable/$', SheerTemplateView.as_view(template_name='browse-filterable/index.html'), name='browse-filterable'))
     urlpatterns.append(url(r'^learn-page/$', SheerTemplateView.as_view(template_name='learn-page/index.html'), name='learn-page'))
     urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/cfgov/jinja2/v1/_includes/molecules/expandable.html
+++ b/cfgov/jinja2/v1/_includes/molecules/expandable.html
@@ -1,0 +1,61 @@
+{# ==========================================================================
+
+   expandable.render()
+
+   ==========================================================================
+
+   Description:
+
+   Create an Expandable molecule when given:
+
+   label:                Label you want on the Expandable.
+                         Default is an empty string.
+
+   settings
+   settings.is_bordered: Whether the Expandable has a bottom border or not.
+                         Default is true.
+   settings.is_midtone:  Whether the Expandable is gray or not.
+                         Default is false.
+   settings.is_expanded: Whether the Expandable is expanded or not.
+                         Default is false.
+   ========================================================================== #}
+
+{% macro render(label="", settings) %}
+{# Add the __expanded modifier class by default so all expandables are open
+   when JS is switched off, but add a data-js-hook to tell JS to remove it. #}
+<div class="m-expandable
+            m-expandable__expanded
+            {{ 'm-expandable__borders' if settings.is_bordered else '' }}
+            {{ 'm-expandable__midtone' if settings.is_midtone else '' }}"
+     {{ 'data-state=expanded' if settings.is_expanded else '' }}>
+
+    <button class="m-expandable_target">
+        <div class="m-expandable_header">
+            <span class="m-expandable_header-left
+                         m-expandable_label">
+                {{ label }}
+            </span>
+            <span class="m-expandable_header-right
+                         m-expandable_link
+                         u-hidden">
+                <span class="m-expandable_cue
+                             m-expandable_cue-open">
+                    <span class="m-expandable_cue-label">Show</span>
+                    <span class="cf-icon cf-icon-plus-round"></span>
+                </span>
+                <span class="m-expandable_cue
+                             m-expandable_cue-close">
+                    <span class="m-expandable_cue-label">Hide</span>
+                    <span class="cf-icon cf-icon-minus-round"></span>
+                </span>
+            </span>
+        </div>
+    </button>
+    <div class="m-expandable_content"
+         {{ 'aria-expanded=true' if settings.is_expanded else '' }}>
+        <div class="m-expandable_content-animated">
+            {{ caller() }}
+        </div>
+    </div>
+</div>
+{% endmacro %}

--- a/cfgov/jinja2/v1/_includes/organisms/expandable-group.html
+++ b/cfgov/jinja2/v1/_includes/organisms/expandable-group.html
@@ -1,0 +1,46 @@
+{# ==========================================================================
+
+   expandable_group.render()
+
+   ==========================================================================
+
+   Description:
+
+   Create an Expandable Group organism when given:
+
+   settings:              An object with the following options for settings.
+                          Defaults to an empty object.
+
+   settings.heading:      Heading text.
+
+   settings.intro:        Body introduction text.
+
+   settings.is_accordion: Whether this group is an accordion or not.
+                          Default is false.
+
+   settigns.has_rule:     Whether there is a top gray rule.
+                          Default is false.
+
+   ========================================================================== #}
+
+{% macro render(settings={}) %}
+<div class="o-expandable-group
+            {{ 'o-expandable-group__accordion' if settings.is_accordion else '' }}">
+
+    {% if settings.has_rule %}
+        <div class="a-rule-break"></div>
+    {% endif %}
+
+    {% if settings.heading %}
+        <h3>{{ settings.heading }}</h3>
+    {% endif %}
+
+    {% if settings.intro %}
+        <p>{{ settings.intro }}</p>
+    {% endif %}
+
+    {# Should be a stack of Expandable instances. #}
+    {{ caller() }}
+</div>
+
+{% endmacro %}

--- a/cfgov/jinja2/v1/browse-basic/index.html
+++ b/cfgov/jinja2/v1/browse-basic/index.html
@@ -1,0 +1,101 @@
+{% extends 'layout-side-nav.html' %}
+
+{# Import organisms and molecules used in the template. #}
+{% import 'molecules/expandable.html' as expandable %}
+{% import 'organisms/expandable-group.html' as expandable_group %}
+
+{% block title -%}
+    TODO: This is a prototype page for testing landing page layouts.
+    Remove when fully implemented elsewhere.
+{%- endblock %}
+
+{% block content_main %}
+    <div class="block
+                block__flush-top">
+        <div class="expandable-prototypes">
+            {% call expandable.render("Default Expandable") %}
+                {{ lipsum(1, false, 10, 225) | safe }}
+            {% endcall %}
+
+            {% call expandable.render("Bordered Expandable", {
+                    'is_bordered': true
+                }) %}
+                {{ lipsum(1, false, 10, 225) | safe }}
+            {% endcall %}
+
+            {% call expandable.render("Midtone Expandable", {
+                    'is_midtone': true
+                }) %}
+                {{ lipsum(1, false, 10, 225) | safe }}
+            {% endcall %}
+
+            {% call expandable.render("Midtone, Bordered Expandable", {
+                    'is_bordered': true,
+                    'is_midtone':  true
+                }) %}
+                {{ lipsum(1, false, 10, 225) | safe }}
+            {% endcall %}
+
+            {% call expandable.render("Midtone, Bordered, Expandable - Expanded", {
+                    'is_bordered': true,
+                    'is_midtone':  true,
+                    'is_expanded': true
+                }) %}
+                {{ lipsum(1, false, 10, 225) | safe }}
+            {% endcall %}
+        </div>
+
+        <div class="expandable-group-prototypes">
+            {% call expandable_group.render({
+                    'heading': 'Group Header',
+                    'has_rule': true
+                }) %}
+                {% call expandable.render("Expand 1 - initially open", {
+                    'is_expanded': true,
+                    'is_bordered': true,
+                    'is_midtone':  true
+                }) %}
+                    {{ lipsum(1, false, 10, 225) | safe }}
+                {% endcall %}
+
+                {% call expandable.render("Expand 2",  {
+                    'is_bordered': true,
+                    'is_midtone':  true
+                }) %}
+                    {{ lipsum(1, false, 10, 225) | safe }}
+                {% endcall %}
+            {% endcall %}
+
+            {% call expandable_group.render({
+                    'heading': 'Accordion-style Group',
+                    'intro': 'Intro paragraph blah blah blah',
+                    'is_accordion': true
+                }) %}
+                {% call expandable.render("Expand 1") %}
+                    {{ lipsum(1, false, 10, 225) | safe }}
+                {% endcall %}
+
+                {% call expandable.render("Expand 2 - bordered, midtone", {
+                    'is_bordered': true,
+                    'is_midtone':  true
+                }) %}
+                    {{ lipsum(1, false, 10, 225) | safe }}
+                {% endcall %}
+
+                {% call expandable.render("Expand 3 - bordered", {
+                    'is_bordered': true
+                }) %}
+                    {{ lipsum(1, false, 10, 225) | safe }}
+                {% endcall %}
+            {% endcall %}
+        </div>
+
+    </div>
+{% endblock %}
+
+{% block content_sidebar scoped -%}
+    <aside>
+        {# TODO: Add sidebar organisms. #}
+        Side Navigation
+    </aside>
+{%- endblock %}

--- a/cfgov/jinja2/v1/browse-filterable/index.html
+++ b/cfgov/jinja2/v1/browse-filterable/index.html
@@ -92,7 +92,6 @@
 {% block content_sidebar scoped -%}
     <aside>
         {# TODO: Add sidebar organisms. #}
-        Breadcrumbs<br>
         Side Navigation
     </aside>
 {%- endblock %}

--- a/cfgov/unprocessed/css/main.less
+++ b/cfgov/unprocessed/css/main.less
@@ -75,6 +75,7 @@
 /* Molecule pieces
    ========================================================================== */
 
+@import (less) "molecules/expandable.less";
 @import (less) "molecules/image-text-50-50.less";
 @import (less) "molecules/image-text-25-75.less";
 @import (less) "molecules/text-introduction.less";
@@ -87,6 +88,7 @@
 /* Organism pieces
    ========================================================================== */
 
+@import (less) "organisms/expandable-group.less";
 @import (less) "organisms/sidebar-contact-info.less";
 @import (less) "organisms/well.less";
 @import (less) "organisms/full-width-text.less";

--- a/cfgov/unprocessed/css/molecules/expandable.less
+++ b/cfgov/unprocessed/css/molecules/expandable.less
@@ -1,0 +1,266 @@
+
+/* topdoc
+  name: Theme variables
+  family: cf-molecules
+  notes:
+    - "The following color and sizing variables are exposed,
+       allowing you to easily override them before compiling."
+  patterns:
+  - name: Colors
+    codenotes:
+      - |
+        @expandable_label-text
+        @expandable_link-text
+  - name: Sizing
+    codenotes:
+      - |
+        @expandable_label-font-size
+        @expandable_link-font-size
+  tags:
+  - cf-molecules
+  - less
+*/
+
+// Color variables
+// $color- variables are from 18F's US Web Design Standards
+// https://github.com/18F/web-design-standards/blob/18f-pages/assets/_scss/core/_variables.scss
+
+// .expandable_label
+@expandable_label-text:         #000000;
+
+// .expandable_link
+@expandable_link-text:          #046b99; // $color-primary-alt-darkest
+
+// Sizing variables
+
+// .expandable_link
+@expandable_label-font-size:    @base-font-size-px;
+
+// .expandable_label
+@expandable_link-font-size:     14px;
+
+
+/* topdoc
+  name: Expandable molecule
+  family: cf-molecules
+  notes:
+    - "Styles a Expandable molecule in the open and closed state."
+  patterns:
+  - name: Expandable molecule
+    markup: |
+      <div class="m-expandable">
+          <button class="m-expandable_target" aria-pressed="false">
+              <div class="m-expandable_header">
+                  <span class="m-expandable_header-left
+                               m-expandable_label">
+                      Default Expandable
+                  </span>
+                  <span class="m-expandable_header-right
+                               m-expandable_link">
+                      <span class="m-expandable_cue
+                                   m-expandable_cue-open">
+                          <span class="m-expandable_cue-label">Show</span>
+                          <span class="cf-icon cf-icon-plus-round"></span>
+                      </span>
+                      <span class="m-expandable_cue
+                                   m-expandable_cue-close u-hidden">
+                          <span class="m-expandable_cue-label">Hide</span>
+                          <span class="cf-icon cf-icon-minus-round"></span>
+                      </span>
+                  </span>
+              </div>
+          </button>
+          <div class="m-expandable_content" aria-expanded="false">
+          </div>
+      </div>
+    codenotes:
+      - |
+        Pattern structure
+        -----------------
+        .m-expandable
+          button.m-expandable_target
+            .m-expandable_header
+              .m-expandable_header-left.m-expandable_label
+              .m-expandable_header-right.m-expandable_link
+                .m-expandable_cue-open
+                  .m-expandable_cue-label
+                .m-expandable_cue-close
+                  .m-expandable_cue-label
+          .m-expandable_content
+    notes:
+      - "Use the button tag for the .expandable_target element to allow for
+         keyboard access."
+      - "The 'Show' and 'Hide' messages can be customized directly in the HTML
+         by editing the contents of .m-expandable_cue-label."
+      - "The aria-pressed attribute on .m-expandable_target gets automatically
+         added and updated by JavaScript."
+      - "The aria-expanded attribute on .m-expandable_content gets automatically
+         updated by JavaScript."
+  - name: .m-expandable__expanded (modifier)
+    codenotes:
+      - |
+        .m-expandable__expanded
+    notes:
+      - "Sometimes you may want the expandable to be open by default. This
+         is as easy as adding the .m-expandable__expanded modifier to the
+         .m-expandable block."
+  tags:
+  - cf-molecules
+*/
+.m-expandable {
+    .webfont-regular();
+    padding-bottom: unit( ( @grid_gutter-width * 2 ) / @base-font-size-px, em );
+
+    &_target,
+    &_content-animated {
+        padding: unit( ( @grid_gutter-width / 2 ) / @base-font-size-px, em );
+    }
+
+    &_target {
+        // Override button default styles.
+        display: block;
+        background: @white;
+        border: none;
+        border-top: 1px solid @gray-50;
+        width: 100%;
+        position: relative;
+        cursor: pointer;
+    }
+
+    &_content {
+        background: @white;
+        border-bottom: 1px solid @gray-50;
+        height: 0;
+        overflow: hidden;
+        position: relative;
+    }
+
+    &_content-animated {
+        padding-bottom: unit( @grid_gutter-width / @base-font-size-px, em );
+        position: relative;
+        bottom: 0;
+    }
+
+    &__expanded .m-expandable_content {
+        height: 100%;
+    }
+
+    // Show/hide cues
+    .m-expandable_cue-open {
+        display: block;
+    }
+
+    .m-expandable_cue-close {
+        display: none;
+    }
+
+    &__expanded {
+        .m-expandable_cue-open {
+            display: none;
+        }
+
+        .m-expandable_cue-close {
+            display: block;
+        }
+    }
+}
+
+.m-expandable {
+    // Modifiers
+    &__borders {
+        .m-expandable_target,
+        .m-expandable_content {
+            border: 1px solid @gray-50;
+        }
+
+        .m-expandable_target {
+            border-bottom: none;
+        }
+
+        .m-expandable_content {
+            border-top: none;
+        }
+    }
+
+    &__midtone {
+        .m-expandable_target,
+        .m-expandable_content {
+            background: @gray-5;
+            border-color: @gray-50;
+        }
+    }
+}
+
+
+/* topdoc
+  name: Expandable header elements
+  family: cf-molecules
+  codenotes:
+    - |
+      Pattern structure
+      -----------------
+      .m-expandable_header
+        .m-expandable_header-left.m-expandable_label
+        .m-expandable_header-right.m-expandable_link
+          .m-expandable_cue-open
+            .m-expandable_cue-label
+          .m-expandable_cue-close
+            .m-expandable_cue-label
+  patterns:
+  - name: .m-expandable_header (element)
+    codenotes:
+      - |
+        .m-expandable_header
+          .m-expandable_header-left.m-expandable_label
+          .m-expandable_header-right.m-expandable_link
+            .m-expandable_cue-open
+              .m-expandable_cue-label
+            .m-expandable_cue-close
+              .m-expandable_cue-label
+    notes:
+      - "Creates a full-width container to house information that is always
+         visible."
+      - "Combine .m-expandable_header with .m-expandable_target for a full-width
+         trigger."
+      - "Allows you to float information left and right."
+  tags:
+  - cf-molecules
+*/
+.m-expandable {
+    &_header-left {
+        width: 78%;
+        float: left;
+        text-align: left;
+    }
+
+    &_header-right {
+        width: 22%;
+        float: right;
+        text-align: right;
+    }
+
+    &_label {
+        color: @expandable_label-text;
+        font-size: unit(@expandable_label-font-size / @base-font-size-px, em);
+    }
+
+    &_link {
+        color: @expandable_link-text;
+        font-size: unit(@expandable_link-font-size / @base-font-size-px, em);
+    }
+
+    .respond-to-max(@bp-xs-max, {
+        &_cue-label {
+            display: none;
+        }
+    });
+
+    &_content {
+        .u-clearfix();
+    }
+}
+
+/* topdoc
+    name: EOF
+    eof: true
+*/

--- a/cfgov/unprocessed/css/organisms/expandable-group.less
+++ b/cfgov/unprocessed/css/organisms/expandable-group.less
@@ -1,0 +1,58 @@
+/* topdoc
+  name: Expandable groups
+  family: cf-organisms
+  patterns:
+  - name: Standard expandable group
+    markup: |
+      <div class="o-expandable-group">
+          <h3>Expandable group header</h3>
+          <p>Intro text</p>
+          <div class="m-expandable"></div>
+          <div class="m-expandable"></div>
+          <div class="m-expandable"></div>
+      </div>
+    codenotes:
+      - |
+        Pattern structure
+        -----------------
+        .m-expandable-group
+          h3 (optional)
+          p (optional)
+          .expandable
+            [...]
+          .expandable
+            [...]
+          .expandable
+            [...]
+  - name: Accordion-style group
+    markup: |
+      <div class="o-expandable-group o-expandable-group__accordion">
+          <h3>Expandable group header</h3>
+          <p>Intro text</p>
+          <div class="m-expandable"></div>
+          <div class="m-expandable"></div>
+          <div class="m-expandable"></div>
+      </div>
+    notes:
+      - "Accordions can only show one open expandable at a time."
+  tags:
+  - cf-organisms
+*/
+
+.o-expandable-group {
+    .webfont-regular();
+    margin-bottom: unit(30px / @base-font-size-px, em);
+    .m-expandable {
+        padding: 0;
+    }
+}
+
+.o-expandable-group .m-expandable:not(:last-child) .m-expandable_content {
+    border-bottom: none;
+}
+
+
+/* topdoc
+    name: EOF
+    eof: true
+*/

--- a/cfgov/unprocessed/js/modules/polyfill/class-list.js
+++ b/cfgov/unprocessed/js/modules/polyfill/class-list.js
@@ -1,0 +1,237 @@
+/*
+ * classList.js: Cross-browser full element.classList implementation.
+ * 2014-07-23
+ *
+ * By Eli Grey, http://eligrey.com
+ * Public Domain.
+ * NO WARRANTY EXPRESSED OR IMPLIED. USE AT YOUR OWN RISK.
+ */
+
+/*global self, document, DOMException */
+
+/*! @source http://purl.eligrey.com/github/classList.js/blob/master/classList.js*/
+
+if ("document" in self) {
+
+// Full polyfill for browsers with no classList support
+if (!("classList" in document.createElement("_"))) {
+
+(function (view) {
+
+"use strict";
+
+if (!('Element' in view)) return;
+
+var
+    classListProp = "classList"
+  , protoProp = "prototype"
+  , elemCtrProto = view.Element[protoProp]
+  , objCtr = Object
+  , strTrim = String[protoProp].trim || function () {
+    return this.replace(/^\s+|\s+$/g, "");
+  }
+  , arrIndexOf = Array[protoProp].indexOf || function (item) {
+    var
+        i = 0
+      , len = this.length
+    ;
+    for (; i < len; i++) {
+      if (i in this && this[i] === item) {
+        return i;
+      }
+    }
+    return -1;
+  }
+  // Vendors: please allow content code to instantiate DOMExceptions
+  , DOMEx = function (type, message) {
+    this.name = type;
+    this.code = DOMException[type];
+    this.message = message;
+  }
+  , checkTokenAndGetIndex = function (classList, token) {
+    if (token === "") {
+      throw new DOMEx(
+          "SYNTAX_ERR"
+        , "An invalid or illegal string was specified"
+      );
+    }
+    if (/\s/.test(token)) {
+      throw new DOMEx(
+          "INVALID_CHARACTER_ERR"
+        , "String contains an invalid character"
+      );
+    }
+    return arrIndexOf.call(classList, token);
+  }
+  , ClassList = function (elem) {
+    var
+        trimmedClasses = strTrim.call(elem.getAttribute("class") || "")
+      , classes = trimmedClasses ? trimmedClasses.split(/\s+/) : []
+      , i = 0
+      , len = classes.length
+    ;
+    for (; i < len; i++) {
+      this.push(classes[i]);
+    }
+    this._updateClassName = function () {
+      elem.setAttribute("class", this.toString());
+    };
+  }
+  , classListProto = ClassList[protoProp] = []
+  , classListGetter = function () {
+    return new ClassList(this);
+  }
+;
+// Most DOMException implementations don't allow calling DOMException's toString()
+// on non-DOMExceptions. Error's toString() is sufficient here.
+DOMEx[protoProp] = Error[protoProp];
+classListProto.item = function (i) {
+  return this[i] || null;
+};
+classListProto.contains = function (token) {
+  token += "";
+  return checkTokenAndGetIndex(this, token) !== -1;
+};
+classListProto.add = function () {
+  var
+      tokens = arguments
+    , i = 0
+    , l = tokens.length
+    , token
+    , updated = false
+  ;
+  do {
+    token = tokens[i] + "";
+    if (checkTokenAndGetIndex(this, token) === -1) {
+      this.push(token);
+      updated = true;
+    }
+  }
+  while (++i < l);
+
+  if (updated) {
+    this._updateClassName();
+  }
+};
+classListProto.remove = function () {
+  var
+      tokens = arguments
+    , i = 0
+    , l = tokens.length
+    , token
+    , updated = false
+    , index
+  ;
+  do {
+    token = tokens[i] + "";
+    index = checkTokenAndGetIndex(this, token);
+    while (index !== -1) {
+      this.splice(index, 1);
+      updated = true;
+      index = checkTokenAndGetIndex(this, token);
+    }
+  }
+  while (++i < l);
+
+  if (updated) {
+    this._updateClassName();
+  }
+};
+classListProto.toggle = function (token, force) {
+  token += "";
+
+  var
+      result = this.contains(token)
+    , method = result ?
+      force !== true && "remove"
+    :
+      force !== false && "add"
+  ;
+
+  if (method) {
+    this[method](token);
+  }
+
+  if (force === true || force === false) {
+    return force;
+  } else {
+    return !result;
+  }
+};
+classListProto.toString = function () {
+  return this.join(" ");
+};
+
+if (objCtr.defineProperty) {
+  var classListPropDesc = {
+      get: classListGetter
+    , enumerable: true
+    , configurable: true
+  };
+  try {
+    objCtr.defineProperty(elemCtrProto, classListProp, classListPropDesc);
+  } catch (ex) { // IE 8 doesn't support enumerable:true
+    if (ex.number === -0x7FF5EC54) {
+      classListPropDesc.enumerable = false;
+      objCtr.defineProperty(elemCtrProto, classListProp, classListPropDesc);
+    }
+  }
+} else if (objCtr[protoProp].__defineGetter__) {
+  elemCtrProto.__defineGetter__(classListProp, classListGetter);
+}
+
+}(self));
+
+} else {
+// There is full or partial native classList support, so just check if we need
+// to normalize the add/remove and toggle APIs.
+
+(function () {
+  "use strict";
+
+  var testElement = document.createElement("_");
+
+  testElement.classList.add("c1", "c2");
+
+  // Polyfill for IE 10/11 and Firefox <26, where classList.add and
+  // classList.remove exist but support only one argument at a time.
+  if (!testElement.classList.contains("c2")) {
+    var createMethod = function(method) {
+      var original = DOMTokenList.prototype[method];
+
+      DOMTokenList.prototype[method] = function(token) {
+        var i, len = arguments.length;
+
+        for (i = 0; i < len; i++) {
+          token = arguments[i];
+          original.call(this, token);
+        }
+      };
+    };
+    createMethod('add');
+    createMethod('remove');
+  }
+
+  testElement.classList.toggle("c3", false);
+
+  // Polyfill for IE 10 and Firefox <24, where classList.toggle does not
+  // support the second argument.
+  if (testElement.classList.contains("c3")) {
+    var _toggle = DOMTokenList.prototype.toggle;
+
+    DOMTokenList.prototype.toggle = function(token, force) {
+      if (1 in arguments && !this.contains(token) === !force) {
+        return force;
+      } else {
+        return _toggle.call(this, token);
+      }
+    };
+
+  }
+
+  testElement = null;
+}());
+
+}
+
+}

--- a/cfgov/unprocessed/js/modules/util/EventObserver.js
+++ b/cfgov/unprocessed/js/modules/util/EventObserver.js
@@ -1,0 +1,79 @@
+'use strict';
+
+/**
+ * EventObserver
+ * @class
+ *
+ * @classdesc Used for creating an object
+ *   that can be used to dispatch and listen to custom events.
+ * @returns {Object} An EventObserver instance.
+ */
+function EventObserver() {
+
+  // The events registered on this instance.
+  var _events = {};
+
+  /**
+   * Register an event listener.
+   * @param {string} evt The event name to listen for.
+   * @param {Function} callback The function called when the event has fired.
+   * @returns {Object} The instance this EventObserver instance is decorating.
+   */
+  function addEventListener( evt, callback ) {
+    if ( _events.hasOwnProperty( evt ) ) {
+      _events[evt].push( callback );
+    } else {
+      _events[evt] = [ callback ];
+    }
+
+    return this;
+  }
+
+  /**
+   * Remove an added event listener.
+   * Must match a call made to addEventListener.
+   * @param {string} evt The event name to remove.
+   * @param {Function} callback The function attached to the event.
+   * @returns {Object} The instance this EventObserver instance is decorating.
+   */
+  function removeEventListener( evt, callback ) {
+    if ( !_events.hasOwnProperty( evt ) ) {
+      return this;
+    }
+
+    var index = _events[evt].indexOf( callback );
+    if ( index !== -1 ) {
+      _events[evt].splice( index, 1 );
+    }
+
+    return this;
+  }
+
+  /**
+   * Broadcast an event.
+   * @param {string} evt The type of event to broadcast.
+   * @param {Object} options The event object to pass to the event handler.
+   * @returns {Object} The instance this EventObserver instance is decorating.
+   */
+  function dispatchEvent( evt, options ) {
+    if ( !_events.hasOwnProperty( evt ) ) {
+      return this;
+    }
+
+    options = options || {};
+
+    var evts = _events[evt];
+    for ( var e = 0, len = evts.length; e < len; e++ ) {
+      evts[e].call( this, options );
+    }
+
+    return this;
+  }
+
+  EventObserver.prototype.addEventListener = addEventListener;
+  EventObserver.prototype.removeEventListener = removeEventListener;
+  EventObserver.prototype.dispatchEvent = dispatchEvent;
+  return this;
+}
+
+module.exports = EventObserver;

--- a/cfgov/unprocessed/js/molecules/Expandable.js
+++ b/cfgov/unprocessed/js/molecules/Expandable.js
@@ -1,0 +1,343 @@
+'use strict';
+
+// Required polyfills for <IE9.
+require( '../modules/polyfill/query-selector' );
+require( '../modules/polyfill/event-listener' );
+require( '../modules/polyfill/class-list' );
+
+// Required modules.
+var EventObserver = require( '../modules/util/EventObserver' );
+
+/**
+ * Expandable
+ * @class
+ *
+ * @classdesc Initializes a new Expandable molecule.
+ *
+ * @param {HTMLNode} element
+ *   The DOM element within which to search for the molecule.
+ * @returns {Object} An Expandable instance.
+ */
+function Expandable( element ) { // eslint-disable-line max-statements, inline-comments, max-len
+
+  var BASE_CLASS = 'm-expandable';
+
+  // Bitwise flags for the state of this Expandable.
+  var COLLAPSED = 0;
+  var COLLAPSING = 1;
+  var EXPANDING = 2;
+  var EXPANDED = 3;
+
+  // The Expandable element will directly be the Expandable
+  // when used in an ExpandableGroup, otherwise it can be the parent container.
+  var _dom = element.classList.contains( BASE_CLASS ) ?
+             element : element.querySelector( '.' + BASE_CLASS );
+  var _target = _dom.querySelector( '.' + BASE_CLASS + '_target' );
+  var _content = _dom.querySelector( '.' + BASE_CLASS + '_content' );
+  var _contentAnimated =
+    _content.querySelector( '.' + BASE_CLASS + '_content-animated' );
+  var _link = _dom.querySelector( '.' + BASE_CLASS + '_link' );
+
+  var _state = COLLAPSED;
+  var _transitionEndEvent = _getTransitionEndEvent( _content );
+  var _contentHeight;
+
+  // TODO: Replace function of _that with Function.prototype.bind.
+  var _that = this;
+
+  /**
+   * @param {number} state
+   *   Allows passing of EXPANDED flag to set expanded state.
+   * @returns {Object} The Expandable instance.
+   */
+  function init( state ) {
+    _calcHeight();
+    if ( state === EXPANDED ||
+         _dom.getAttribute( 'data-state' ) === 'expanded' ) {
+      // If expanded by default, we need to set the height inline so the
+      // inline transition to collapse the Expandable works.
+      // TODO: Handle issue of height calculating before
+      //       web fonts have loaded and changed height.
+      _setMaxHeight();
+      _setExpandedState();
+    } else {
+      _setCollapsedState();
+    }
+
+    // Show the show/hide links, which otherwise are hidden if JS is off.
+    _link.classList.remove( 'u-hidden' );
+
+    _target.addEventListener( 'click', _handleClick );
+
+    // TODO: Remove if statement if polyfill that
+    //       adds addEventListener to window is used.
+    if ( window.addEventListener ) {
+      window.addEventListener( 'resize', _refreshHeight );
+    }
+    return this;
+  }
+
+  /**
+   * @param {number} duration
+   *   The duration of the sliding animation in milliseconds.
+   * @returns {Object} The Expandable instance.
+   */
+  function toggle( duration ) {
+    if ( _isExpanded() ) {
+      _that.collapse( duration );
+    } else {
+      _that.expand( duration );
+    }
+    return _that;
+  }
+
+  /**
+   * @param {number} duration
+   *   The duration of the sliding animation in milliseconds.
+   * @returns {Object} The Expandable instance.
+   */
+  function expand( duration ) {
+    if ( _isExpanded() || _isExpanding() ) {
+      return this;
+    }
+
+    duration = duration || _calculateExpandDuration( _contentHeight );
+
+    _setStateTo( EXPANDING );
+    this.dispatchEvent( 'beginExpand', { target: _that } );
+    _setMaxHeight();
+    _transitionHeight( _expandComplete, duration );
+    return this;
+  }
+
+  /**
+   * @param {number} duration
+   *   The duration of the sliding animation in milliseconds.
+   * @returns {Object} The Expandable instance.
+   */
+  function collapse( duration ) {
+    if ( _isCollapsed() || _isCollapsing() ) {
+      return this;
+    }
+
+    duration = duration || _calculateCollapseDuration( _contentHeight );
+
+    _setStateTo( COLLAPSING );
+    this.dispatchEvent( 'beginCollapse', { target: _that } );
+    _setMinHeight();
+    _transitionHeight( _collapseComplete, duration );
+    return this;
+  }
+
+  /**
+   * Transition height property and call a callback function.
+   * Call callback directly if CSS transitions aren't supported.
+   * @param {Function} callback Callback function for completion of transition.
+   * @param {number} duration
+   *   The duration of the sliding animation in milliseconds.
+   */
+  function _transitionHeight( callback, duration ) {
+    if ( _transitionEndEvent ) {
+      _content.addEventListener( _transitionEndEvent, callback );
+      _content.style.transition = 'height ' + duration + 's ease-out';
+    } else {
+      // TODO: Remove callback-return ESLint ignore
+      callback(); // eslint-disable-line callback-return, inline-comments, max-len
+    }
+  }
+
+  /**
+   * Configure the expanded state appearance.
+   */
+  function _setExpandedState() {
+    _dom.classList.add( BASE_CLASS + '__expanded' );
+    _content.setAttribute( 'aria-expanded', 'true' );
+    _target.setAttribute( 'aria-pressed', 'true' );
+    _setStateTo( EXPANDED );
+  }
+
+  /**
+   * Configure the collapsed state appearance.
+   */
+  function _setCollapsedState() {
+    _dom.classList.remove( BASE_CLASS + '__expanded' );
+    _content.setAttribute( 'aria-expanded', 'false' );
+    _target.setAttribute( 'aria-pressed', 'false' );
+    _setStateTo( COLLAPSED );
+  }
+
+  /**
+   * Expand animation has completed.
+   */
+  function _expandComplete() {
+    _content.removeEventListener( _transitionEndEvent, _expandComplete );
+    _setExpandedState();
+    _that.dispatchEvent( 'endExpand', { target: _that } );
+  }
+
+  /**
+   * Collapse animation has completed.
+   */
+  function _collapseComplete() {
+    _content.removeEventListener( _transitionEndEvent, _collapseComplete );
+    _setCollapsedState();
+    _that.dispatchEvent( 'endCollapse', { target: _that } );
+  }
+
+  /**
+   * Handle click of the Expandable target.
+   */
+  function _handleClick() {
+    // Bubble click event outside of the Expandable.
+    _that.dispatchEvent( 'click', { target: _that } );
+    if ( _isCollapsed() || _isExpanded() ) {
+      _that.toggle();
+    }
+  }
+
+  /**
+   * Refresh calculated height of content area.
+   */
+  function _calcHeight() {
+    _contentHeight = _contentAnimated.offsetHeight;
+  }
+
+  /**
+   * Reset the height of the Expandables, when e.g. resizing the window.
+   */
+  function _refreshHeight() {
+    if ( _isExpanded() ) {
+      _setMaxHeight();
+    } else {
+      _setMinHeight();
+    }
+  }
+
+  /**
+   * Calculate and set the height based on the contents' height.
+   */
+  function _setMaxHeight() {
+    _calcHeight();
+    _content.style.height = _contentHeight + 'px';
+  }
+
+  /**
+   * Set the height to zero.
+   */
+  function _setMinHeight() {
+    _content.style.height = '0';
+  }
+
+  /**
+   * @returns {boolean} Whether Expandable is in a collapsed state.
+   */
+  function _isCollapsed() {
+    return _state === COLLAPSED;
+  }
+
+  /**
+   * @returns {boolean} Whether Expandable is collapsing.
+   */
+  function _isCollapsing() {
+    return _state === COLLAPSING;
+  }
+
+  /**
+   * @returns {boolean} Whether Expandable is expanding.
+   */
+  function _isExpanding() {
+    return _state === EXPANDING;
+  }
+
+  /**
+   * @returns {boolean} Whether Expandable is in a expanded state.
+   */
+  function _isExpanded() {
+    return _state === EXPANDED;
+  }
+
+  /**
+   * @param {number} state Set the hide/show state flag for the Expandable.
+   * @returns {number} Whether Expandable is in a expanded state.
+   */
+  function _setStateTo( state ) {
+    _state = state;
+    return _state;
+  }
+
+  // Attach public events.
+  var eventObserver = new EventObserver();
+  this.addEventListener = eventObserver.addEventListener;
+  this.removeEventListener = eventObserver.removeEventListener;
+  this.dispatchEvent = eventObserver.dispatchEvent;
+
+  this.init = init;
+  this.toggle = toggle;
+  this.expand = expand;
+  this.collapse = collapse;
+
+  // Export constants so initialization signature can support, e.g.
+  // var item = new Expandable( '.item' );
+  // item.init( item.EXPANDED );
+  this.COLLAPSED = COLLAPSED;
+  this.EXPANDED = EXPANDED;
+
+  return this;
+}
+
+/**
+ * @param {HTMLNode} elm
+ *   The element to check for support of transition end event.
+ * @returns {string} The browser-prefixed transition end event.
+ */
+function _getTransitionEndEvent( elm ) {
+  var transition;
+  var transitions = {
+    'WebkitTransition' : 'webkitTransitionEnd',
+    'MozTransition'    : 'transitionend',
+    'OTransition'      : 'oTransitionEnd otransitionend',
+    'transition'       : 'transitionend'
+  };
+
+  for ( var t in transitions ) {
+    if ( transitions.hasOwnProperty( t ) && typeof elm.style[t] !== 'undefined' ) {
+      transition = transitions[t];
+      break;
+    }
+  }
+  return transition;
+}
+
+/**
+ * @param {number} height The height of the expandable content area in pixels.
+ * @returns {number} The amount of time over which to expand in seconds.
+ */
+function _calculateExpandDuration( height ) {
+  return _constrainValue( 225, 450, height ) / 1000;
+}
+
+/**
+ * @param {number} height The height of the expandable content area in pixels.
+ * @returns {number} The amount of time over which to expand in seconds.
+ */
+function _calculateCollapseDuration( height ) {
+  return _constrainValue( 175, 450, height / 2 ) / 1000;
+}
+
+/**
+ * @param {number} min The minimum height in pixels.
+ * @param {number} max The maximum height in pixels.
+ * @param {number} duration The amount of time over which to expand in milliseconds.
+ * @returns {number} The amount of time over which to expand in milliseconds,
+ *   constrained to within the min/max values.
+ */
+function _constrainValue( min, max, duration ) {
+  if ( duration > max ) {
+    return max;
+  } else if ( duration < min ) {
+    return min;
+  }
+  return duration;
+}
+
+module.exports = Expandable;

--- a/cfgov/unprocessed/js/organisms/ExpandableGroup.js
+++ b/cfgov/unprocessed/js/organisms/ExpandableGroup.js
@@ -1,0 +1,64 @@
+'use strict';
+
+// Required polyfills for <IE9.
+require( '../modules/polyfill/query-selector' );
+require( '../modules/polyfill/event-listener' );
+require( '../modules/polyfill/class-list' );
+
+var Expandable = require( '../molecules/Expandable' );
+
+/**
+ * ExpandableGroup
+ * @class
+ *
+ * @classdesc Initializes a new Expandable Group organism.
+ *
+ * @param {HTMLNode} element
+ *   The DOM element within which to search for the organism.
+ * @returns {Object} An ExpandableGroup instance.
+ */
+function ExpandableGroup( element ) {
+
+  var BASE_CLASS = 'o-expandable-group';
+
+  var _dom = element.classList.contains( BASE_CLASS ) ?
+             element : element.querySelector( '.' + BASE_CLASS );
+  var _domChildren = _dom.querySelectorAll( '.m-expandable' );
+  var _lastOpenChild;
+  var _isAccordion;
+
+  /**
+   * @returns {Object} The ExpandableGroup instance.
+   */
+  function init() {
+    _isAccordion = _dom.classList.contains( BASE_CLASS + '__accordion' );
+
+    var child;
+    var len = _domChildren.length;
+
+    for ( var i = 0; i < len; i++ ) {
+      child = new Expandable( _domChildren[i] ).init();
+      child.addEventListener( 'beginExpand', _childBeginExpand );
+    }
+
+    return this;
+  }
+
+  /**
+   * Handle opening event of a child Expandable instance.
+   * @param {Object} ev An object that references the event target.
+   */
+  function _childBeginExpand( ev ) {
+    if ( _isAccordion ) {
+      if ( _lastOpenChild ) {
+        _lastOpenChild.collapse();
+      }
+      _lastOpenChild = ev.target;
+    }
+  }
+
+  this.init = init;
+  return this;
+}
+
+module.exports = ExpandableGroup;

--- a/cfgov/unprocessed/js/routes/browse-basic/index.js
+++ b/cfgov/unprocessed/js/routes/browse-basic/index.js
@@ -1,0 +1,26 @@
+/* ==========================================================================
+   Scripts for /browse-basic/.
+   ========================================================================== */
+
+'use strict';
+
+// Required polyfills for <IE8.
+require( '../../modules/polyfill/query-selector' );
+
+// List of organisms used.
+var Expandable = require( '../../molecules/Expandable' );
+var ExpandableGroup = require( '../../organisms/ExpandableGroup' );
+
+var expandables = document.querySelectorAll( '.expandable-prototypes .m-expandable' );
+
+var expandable;
+for ( var i = 0, len = expandables.length; i < len; i++ ) {
+  expandable = new Expandable( expandables[i] ).init();
+}
+
+var expandableGroup = document.querySelectorAll( '.expandable-group-prototypes .o-expandable-group' );
+var regularExpandableGroup = new ExpandableGroup( expandableGroup[0] );
+var accordionExpandableGroup = new ExpandableGroup( expandableGroup[1] );
+
+regularExpandableGroup.init();
+accordionExpandableGroup.init();


### PR DESCRIPTION
Adds browse-basic page, Expandable/ExpandableGroup prototypes. Re-submission of https://github.com/cfpb/cfgov-refresh/pull/1134

## Additions

- Adds browse-basic prototype page and URL.
- Adds Expandable molecule.
- Adds ExpandableGroup organism.
- Adds `classList` JS polyfill.
- Adds `u-hide` utility class to hide an element.
- Adds `EventObserver.js` for adding event broadcaster capability to JS classes.

## Testing

- Visit `http://localhost:8000/browse-basic/`

## Review

- @KimberlyMunoz 
- @sebworks 
- @jimmynotjim 

## Todos

- There a a few TODOs in Expandables.js source code.
