### PR TITLE
Update to protractor 3.0.0.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -156,7 +156,9 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Changes .env Project configuration workon control flow to direct stdout and stderr to /dev/null.
 - Upgrade wagtail to 1.2
 - Cleaned up and rebuilt the secondary nav to reduce complexity and fix bugs
-- Routed landing page type related molecules and organisms to use jinja2/v1/_includes/ template locations
+- Routed landing page type related molecules and organisms
+  to use `jinja2/v1/_includes/` template locations.
+- Updated protractor from 2.5.1 to 3.0.0.
 
 ### Removed
 - Removed unused exportsOverride section,

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "mkdirp": "^0.5.1",
     "mocha": "^2.2.4",
     "mocha-jsdom": "^1.0.0",
-    "protractor": "^2.2.0",
+    "protractor": "^3.0.0",
     "require-dir": "^0.3.0",
     "sinon": "^1.14.1",
     "sinon-chai": "^2.8.0",

--- a/setup.sh
+++ b/setup.sh
@@ -63,6 +63,7 @@ install(){
     protractor_full_path=$(dirname $protractor_symlink)/$(dirname $protractor_binary)/../../protractor
     mkdir -p ./$NODE_DIR/protractor
     cp -r $protractor_full_path ./$NODE_DIR/
+    rm -rf ./$NODE_DIR/protractor/node_modules/
   fi
 
   npm install


### PR DESCRIPTION
## Changes

- Updates protractor from 2.5.1. to 3.0.0.

## Testing

- If you have global protractor installed run `npm uninstall -g protractor && npm install -g protractor`
- Run `./setup.sh && gulp test --sauce=false` or `./setup.sh && gulp test`. Should not have new issues (we have an existing test that times out).

## Review

- @sebworks 
- @jimmynotjim 
- @KimberlyMunoz 
