### PR TITLE
Updated runserver script for easier startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -161,6 +161,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
   to use `jinja2/v1/_includes/` template locations.
 - Updated protractor from 2.5.1 to 3.0.0.
 - Updated gulp-sitespeedio from 0.0.7 to 0.0.8.
+- Update runserver script to start MYSQL if it isn't running
 
 ### Removed
 - Removed unused exportsOverride section,

--- a/runserver.sh
+++ b/runserver.sh
@@ -9,11 +9,17 @@
 # Set script to exit on any errors.
 set -e
 
+mysql(){
+  if ! mysql.server status; then
+    mysql.server start
+  fi
+}
+
 # Run tasks to build the project for distribution.
-run(){
-  echo 'Running Server...'
-  echo 'note: this now does the same thing as ./cfgov/manage.py runserver'
+server(){
+  echo 'Starting the Server...'
   python cfgov/manage.py runserver
 }
 
-run
+mysql
+server


### PR DESCRIPTION
If you reboot and don't run setup.sh, MYSQL won't be running leading you to start the server, then quit the server, then start MYSQL, then start the server again. I hate remembering all that, I just want the server up and running so I can get on with my work. This fixes that.

__Note:__ I removed the comment about the script being a duplicate, because at this point we all know. I personally just use the script so I don't have to type so much and don't have to switch to a new command when something inevitably changes. I can revert that part if everyone disagrees with me.