### PR TITLE
Update gulp-sitespeedio to 0.0.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -160,6 +160,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Routed landing page type related molecules and organisms
   to use `jinja2/v1/_includes/` template locations.
 - Updated protractor from 2.5.1 to 3.0.0.
+- Updated gulp-sitespeedio from 0.0.7 to 0.0.8.
 
 ### Removed
 - Removed unused exportsOverride section,

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "gulp-plumber": "^1.0.1",
     "gulp-rename": "^1.2.2",
     "gulp-replace": "^0.5.3",
-    "gulp-sitespeedio": "^0.0.7",
+    "gulp-sitespeedio": "^0.0.8",
     "gulp-sourcemaps": "^1.5.2",
     "gulp-util": "^3.0.6",
     "handlebars": "^4.0.3",


### PR DESCRIPTION
Updates gulp-sitespeedio. This should automatically update in our current setup, but for some reason isn't without explicitly telling it to.

## Changes

- Updates gulp-sitespeedio to 0.0.8 from 0.0.7.

## Testing

- `./setup.sh && gulp test:perf` should run (though the performance tests will fail, which is expected).

## Review

- @KimberlyMunoz 
- @jimmynotjim 
- @sebworks 
