### PR TITLE
Adds atomic HTMLNode checker utility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,8 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Added templates and CSS for Expandable molecule and ExpandableGroup organism.
 - Added `classlist` JS polyfill.
 - Added `EventObserver` for adding event broadcaster capability to JS classes.
+- Added `atomic-checkers.js` and `validateDomElement`
+  utility method for checking atomic element DOM nodes.
 
 ### Changed
 - Updated the primary nav to move focus as user enters and leaves nav levels

--- a/cfgov/unprocessed/js/modules/util/atomic-checkers.js
+++ b/cfgov/unprocessed/js/modules/util/atomic-checkers.js
@@ -1,0 +1,44 @@
+/* ==========================================================================
+   Atomic Checkers.
+
+   Utilities for helping validate atomic design element architecture.
+   ========================================================================= */
+
+'use strict';
+
+// Required polyfills for <IE9.
+require( '../polyfill/class-list' );
+
+/**
+ * @param {HTMLNode} element
+ *   The DOM element within which to search for the atomic element class.
+ * @param {string} baseClass The CSS class name for the atomic element.
+ * @param {string} atomicName
+ *   The name of the atomic element in CapitalizedCamelCase.
+ * @returns {HTMLNode} The DOM element for the atomic element.
+ * @throws {Error} If DOM element passed into the atomic element is not valid.
+ */
+function validateDomElement( element, baseClass, atomicName ) {
+  var msg;
+  var dom;
+  if ( !element || !element.classList ) {
+    msg = element + ' passed to ' + atomicName + '.js is not valid. ' +
+          'Check that element is a valid DOM node';
+    throw new Error( msg );
+  }
+
+  dom = element.classList.contains( baseClass ) ?
+        element : element.querySelector( '.' + baseClass );
+
+  if ( !dom ) {
+    msg = baseClass + ' not found on or in passed DOM node.';
+    throw new Error( msg );
+  }
+
+  return dom;
+}
+
+// Expose public methods.
+module.exports = {
+  validateDomElement: validateDomElement
+};

--- a/cfgov/unprocessed/js/molecules/Expandable.js
+++ b/cfgov/unprocessed/js/molecules/Expandable.js
@@ -7,6 +7,7 @@ require( '../modules/polyfill/class-list' );
 
 // Required modules.
 var EventObserver = require( '../modules/util/EventObserver' );
+var atomicCheckers = require( '../modules/util/atomic-checkers' );
 
 /**
  * Expandable
@@ -30,8 +31,7 @@ function Expandable( element ) { // eslint-disable-line max-statements, inline-c
 
   // The Expandable element will directly be the Expandable
   // when used in an ExpandableGroup, otherwise it can be the parent container.
-  var _dom = element.classList.contains( BASE_CLASS ) ?
-             element : element.querySelector( '.' + BASE_CLASS );
+  var _dom = atomicCheckers.validateDomElement( element, BASE_CLASS, 'Expandable' );
   var _target = _dom.querySelector( '.' + BASE_CLASS + '_target' );
   var _content = _dom.querySelector( '.' + BASE_CLASS + '_content' );
   var _contentAnimated =

--- a/cfgov/unprocessed/js/organisms/ExpandableGroup.js
+++ b/cfgov/unprocessed/js/organisms/ExpandableGroup.js
@@ -5,7 +5,9 @@ require( '../modules/polyfill/query-selector' );
 require( '../modules/polyfill/event-listener' );
 require( '../modules/polyfill/class-list' );
 
+// Required modules.
 var Expandable = require( '../molecules/Expandable' );
+var atomicCheckers = require( '../modules/util/atomic-checkers' );
 
 /**
  * ExpandableGroup
@@ -21,8 +23,7 @@ function ExpandableGroup( element ) {
 
   var BASE_CLASS = 'o-expandable-group';
 
-  var _dom = element.classList.contains( BASE_CLASS ) ?
-             element : element.querySelector( '.' + BASE_CLASS );
+  var _dom = atomicCheckers.validateDomElement( element, BASE_CLASS, 'ExpandableGroup' );
   var _domChildren = _dom.querySelectorAll( '.m-expandable' );
   var _lastOpenChild;
   var _isAccordion;


### PR DESCRIPTION
Adds atomic HTMLNode checker utility.

## Additions

- Adds `atomic-checkers.js` and `validateDomElement` method for validating base atomic element base element and throwing a useful error if the incorrect CSS class name is used or not referenced properly.

## Testing

- Pass an incorrect dom element to an Expandable or ExpandableGroup instance in `/unprocessed/js/routes/browse-basic/index.js`
- Run `gulp build`
- Check console in `localhost:8000/browse-basic/` for error thrown.

## Review

- @sebworks 
- @KimberlyMunoz 
- @jimmynotjim 
