### PR TITLE
Updates INSTALL.md

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -142,6 +142,15 @@ npm install -g gulp bower
 
 ## 3. Install dependencies
 
+> **NOTE:**
+  Protractor (for the test suite)
+  can be installed globally to avoid downloading Chromedriver repeatedly.
+  To do so, run:
+  ```bash
+  npm install -g protractor && webdriver-manager update
+  ```
+
+
 Next, install dependencies with:
 
 ```bash


### PR DESCRIPTION
## Additions

- Adds note about how to install and initialize global protractor. If protractor is installed globally but chromedriver isn't downloaded setup.sh will fail.

## Review

- @sebworks 
