### PR TITLE
Check that Chromedriver is downloaded

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -61,6 +61,10 @@ install(){
     protractor_symlink=$(command -v protractor)
     protractor_binary=$(readlink $protractor_symlink)
     protractor_full_path=$(dirname $protractor_symlink)/$(dirname $protractor_binary)/../../protractor
+    if [ ! -d $protractor_full_path/selenium ]; then
+      echo '\033[33;31m ERROR: Please run `webdriver-manager update` and try again!'
+      exit
+    fi
     mkdir -p ./$NODE_DIR/protractor
     cp -r $protractor_full_path ./$NODE_DIR/
     rm -rf ./$NODE_DIR/protractor/node_modules/


### PR DESCRIPTION
## Changes

- Quits setup.sh if Chromedriver hasn't been downloaded into global protractor.

## Testing

- Throw out `/Users/[MAC OSX USERNAME]/homebrew/lib/node_modules/protractor/selenium`
- Run `./setup.sh` and follow prompts. Should show error 
```
ERROR: Please run `webdriver-manager update` and try again!
```

## Review

- @sebworks 
