### PR TITLE
Fixed issue with Publish data deleting saved content

### DIFF
--- a/cfgov/v1/wagtail_hooks.py
+++ b/cfgov/v1/wagtail_hooks.py
@@ -9,6 +9,7 @@ from wagtail.wagtailcore import hooks
 @hooks.register('after_create_page')
 @hooks.register('after_edit_page')
 def share_the_page(request, page):
+    page = page.specific
     parent_page = page.get_ancestors(inclusive=False).reverse()[0].specific
     parent_page_perms = parent_page.permissions_for_user(request.user)
 
@@ -16,15 +17,11 @@ def share_the_page(request, page):
     is_sharing = bool(request.POST.get('action-share')) and parent_page_perms.can_publish()
 
     if is_sharing or is_publishing:
-        if isinstance(page, CFGOVPage):
-            page.shared = True
+        page.shared = True
     else:
         page.shared = False
 
     page.save()
-    revision = page.save_revision()
-    if is_publishing:
-        revision.publish()
 
 
 @hooks.register('before_serve_page')

--- a/cfgov/v1/wagtail_hooks.py
+++ b/cfgov/v1/wagtail_hooks.py
@@ -22,6 +22,9 @@ def share_the_page(request, page):
         page.shared = False
 
     page.save()
+    revision = page.save_revision()
+    if is_publishing:
+        revision.publish()
 
 
 @hooks.register('before_serve_page')


### PR DESCRIPTION
wagtail hooks only return `Page` object, resolved by using id to get child `CFGOVPage` object and saving share field.

@kurtw 
@rosskarchner 