### PR TITLE
Adding breadcrumbs to browse pages

### DIFF
--- a/cfgov/jinja2/v1/_layouts/content-base-sidebar-first.html
+++ b/cfgov/jinja2/v1/_layouts/content-base-sidebar-first.html
@@ -1,5 +1,14 @@
 {% extends 'content-base.html' %}
 
+{% block pre_content scoped -%}
+    {% if breadcrumb_items | length > 0 %}
+        <div class="wrapper">
+        {%- import 'breadcrumbs.html' as breadcrumbs -%}
+        {{ breadcrumbs.render(breadcrumb_items, 'breadcrumbs__sidebar-first') }}
+        </div>
+    {% endif %}
+{%- endblock %}
+
 {% block body_content scoped %}
 <div class="wrapper content_wrapper">
     <aside class="content_sidebar {% block content_sidebar_modifiers -%}{%- endblock %}">

--- a/cfgov/jinja2/v1/browse-basic/index.html
+++ b/cfgov/jinja2/v1/browse-basic/index.html
@@ -2,7 +2,10 @@
 
 {# Import organisms and molecules used in the template. #}
 {% import 'molecules/expandable.html' as expandable %}
+
 {% import 'organisms/expandable-group.html' as expandable_group %}
+
+{% set breadcrumb_items = [('#', '#', 'Sample Breadcrumb')] %}
 
 {% block title -%}
     TODO: This is a prototype page for testing landing page layouts.

--- a/cfgov/jinja2/v1/browse-filterable/index.html
+++ b/cfgov/jinja2/v1/browse-filterable/index.html
@@ -4,6 +4,8 @@
 {% import 'molecules/text-introduction.html' as text_introduction %}
 {% import 'organisms/post-preview.html' as post_preview %}
 
+{% set breadcrumb_items = [('#', '#', 'Sample Breadcrumb')] %}
+
 {% block title -%}
     TODO: This is a prototype page for testing landing page layouts.
     Remove when fully implemented elsewhere.

--- a/cfgov/unprocessed/css/breadcrumbs.less
+++ b/cfgov/unprocessed/css/breadcrumbs.less
@@ -2,8 +2,8 @@
     .webfont-regular();
     .grid_column(1,1);
 
-    padding-top: 30px;
-    font-size: 14px;
+    padding-top: unit(@grid_gutter-width / 14px, em);
+    font-size: unit(14px / @base-font-size-px, em);
     overflow-x: auto;
     white-space: nowrap;
 
@@ -14,8 +14,8 @@
     }
 
     .respond-to-max(@bp-sm-max, {
-        padding-top: 15px;
-        padding-bottom: 15px;
+        padding-top: unit(@grid_gutter-width / 2 / 14px, em);
+        padding-bottom: unit(@grid_gutter-width / 2 / 14px, em);
     });
 
     &_link {
@@ -30,5 +30,11 @@
 }
 
 .breadcrumbs__main-first {
-    margin-bottom: -15px;
+    margin-bottom: unit(@grid_gutter-width / 2 / 14px, em);
+}
+
+.breadcrumbs__sidebar-first {
+    .respond-to-min(@bp-med-min, {
+        margin-bottom: unit(@grid_gutter-width / 2 / 14px, em);
+    });
 }

--- a/cfgov/unprocessed/css/cf-enhancements.less
+++ b/cfgov/unprocessed/css/cf-enhancements.less
@@ -1282,13 +1282,11 @@ textarea.input__long {
   tags: cf-layout
 */
 .content__half-top-on-desk {
-    // A new breakpoint needs to be added to Capital Framework
-    // before we port this
     .respond-to-min(@bp-med-min, {
-        padding-top: 20px;
+        padding-top: unit( @grid_gutter-width / @base-font-size-px, em);
 
         &:after {
-            top: 20px !important;
+            top: unit( @grid_gutter-width / @base-font-size-px, em) !important;
         }
     });
 }


### PR DESCRIPTION
This adds breadcrumbs to the browse-basic and browse-filterable pages with the appropriate amount of spacing.

## Test
- Visit /browse-basic/ and /browse-filterable/ and check spacing in mobile and desktop sizes against GHE/flapjack/Modules-V1/wiki/Breadcrumbs

## Review
- @anselmbradford 
- @jimmynotjim 
- @sebworks 

## Notes
- All the styles for breadcrumbs were in pixels and not ems, is that because of something with layout or should they be converted over?