### PR TITLE
Add global variable to Jinja2 context for easier prototyping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Added Related Posts molecule to the CFGOVPage
 - Add Main Contact Info molecule
 - Add Sidefoot Streamfield to CFGOVPage for sidebar/footer content
+- Add global context variable `global_dict` for easier prototyping
 
 ### Changed
 - Updated the primary nav to move focus as user enters and leaves nav levels

--- a/cfgov/v1/__init__.py
+++ b/cfgov/v1/__init__.py
@@ -15,6 +15,7 @@ def environment(**options):
     env.autoescape = True
     env.globals.update({
         'static': staticfiles_storage.url,
+        'global_dict': {},
         'reverse': reverse,
         'render_stream_child': render_stream_child
     })


### PR DESCRIPTION
As we finalize the templates to be used by Wagtail, it limits how we can use the template code because we won't be able to pass data into the included (or imported) template unless it's in the context ( see instances of `with context`). When rendering in Wagtail, `page` is passed into the context, while when prototyping it won't be. 

Essentially, this PR gives us an empty dictionary to modify that these included templates will have access too.

For example, related-posts.html template could be used like this:
```python
{# In prototype #}
...
{% set doc = get_document('doc-type', 'slug-of-something-in-es') %}
{% do global_dict.update({'page':  {
    'related_posts': {
        'posts': more_like_this(doc, search_types='posts', search_size=3),
        'newsroom': more_like_this(doc, search_types='newsroom', search_size=3),
        'events': more_like_this(doc, search_types='events', search_size=3),
    }
}}) %}
{% import 'molecules/related-posts.html' as related_posts with context %}
{{ related_posts.render() }}
...

{# In related-posts.html #}
...
{% if not page %}
      {% set page = global_dict.page %}
{% endif %}
```
@kave 
@KimberlyMunoz 
@anselmbradford 