### PR TITLE
Add Share page permission

### DIFF
--- a/cfgov/templates/wagtailadmin/pages/create.html
+++ b/cfgov/templates/wagtailadmin/pages/create.html
@@ -1,6 +1,7 @@
 {% extends "wagtailadmin/base.html" %}
 {% load wagtailadmin_tags %}
 {% load i18n %}
+{% load share %}
 
 {% block titletag %}{% blocktrans with page_type=content_type.model_class.get_verbose_name %}New {{ page_type }}{% endblocktrans %}{% endblock %}
 {% block bodyclass %}page-editor create model-{{ content_type.model }}{% endblock %}
@@ -21,7 +22,7 @@
         {% csrf_token %}
         {{ edit_handler.render_form_content }}
 
-        {% page_permissions parent_page as parent_page_perms %}
+        {% v1page_permissions parent_page as parent_page_perms %}
         <footer>
             <ul>
                 <li class="actions">
@@ -33,6 +34,8 @@
                                 <li>
                                     <button type="submit" name="action-publish" value="action-publish" class="button-longrunning" tabindex="3" data-clicked-text="{% trans 'Publishing...' %}" {% if page.locked %}disabled {% endif %}><span class="icon icon-spinner"></span><em>{% trans 'Publish to WWW' %}</em></button>
                                 </li>
+                            {% endif %}
+                            {% if parent_page_perms.can_share %}
                                 <li>
                                     <button type="submit" name="action-share" value="action-share" class="button-longrunning" tabindex="3" data-clicked-text="{% trans 'Sharing...' %}" {% if page.locked %}disabled {% endif %}><span class="icon icon-spinner"></span><em>{% trans 'Share on Content' %}</em></button>
                                 </li>

--- a/cfgov/templates/wagtailadmin/pages/edit.html
+++ b/cfgov/templates/wagtailadmin/pages/edit.html
@@ -2,11 +2,12 @@
 {% load wagtailadmin_tags %}
 {% load gravatar %}
 {% load i18n %}
+{% load share %}
 {% block titletag %}{% blocktrans with title=page.title page_type=content_type.model_class.get_verbose_name %}Editing {{ page_type }}: {{ title }}{% endblocktrans %}{% endblock %}
 {% block bodyclass %}page-editor {% if page.live %}page-is-live{% endif %} model-{{ content_type.model }}{% endblock %}
 
 {% block content %}
-    {% page_permissions page as page_perms %}
+    {% v1page_permissions page as page_perms %}
     <header class="merged tab-merged nice-padding">
         {% include "wagtailadmin/shared/breadcrumb.html" with page=page %}
 
@@ -37,19 +38,21 @@
                         {% if not page.locked %}
                             <div class="dropdown-toggle icon icon-arrow-up"></div>
                             <ul role="menu">
-                                {% if page_perms.can_unpublish %}
-                                    <li><a href="{% url 'wagtailadmin_pages:unpublish' page.id %}">{% trans 'Unpublish' %}</a></li>
-                                {% endif %}
                                 {% if page_perms.can_delete %}
                                     <li><a href="{% url 'wagtailadmin_pages:delete' page.id %}" class="shortcut">{% trans 'Delete' %}</a></li>
                                 {% endif %}
-                                {% if page_perms.can_edit and page.shared %}
+                                {% if page_perms.can_unpublish %}
+                                    <li><a href="{% url 'wagtailadmin_pages:unpublish' page.id %}">{% trans 'Unpublish' %}</a></li>
+                                {% endif %}
+                                {% if page_perms.can_unshare %}
                                     <li><a href="{% url 'unshare' page.id %}">{% trans 'Unshare' %}</a></li>
                                 {% endif %}
                                 {% if page_perms.can_publish %}
                                     <li>
                                         <button type="submit" name="action-publish" value="action-publish" class="button-longrunning" tabindex="3" data-clicked-text="{% trans 'Publishing...' %}" {% if page.locked %}disabled {% endif %}><span class="icon icon-spinner"></span><em>{% trans 'Publish to WWW' %}</em></button>
                                     </li>
+                                {% endif %}
+                                {% if page_perms.can_share %}
                                     <li>
                                         <button type="submit" name="action-share" value="action-share" class="button-longrunning" tabindex="3" data-clicked-text="{% trans 'Sharing...' %}" {% if page.locked %}disabled {% endif %}><span class="icon icon-spinner"></span><em>{% trans 'Share on Content' %}</em></button>
                                     </li>

--- a/cfgov/v1/migrations/0012_share_perms.py
+++ b/cfgov/v1/migrations/0012_share_perms.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations
+
+
+def create_share_permissions(apps, schema_editor):
+    ContentType = apps.get_model('contenttypes.ContentType')
+    Permission = apps.get_model('auth.Permission')
+    Group = apps.get_model('auth.Group')
+
+    v1_content_type = ContentType.objects.create(app_label="v1", model="cfgovpage")
+
+    # Create share permission
+    share_permission = Permission.objects.create(
+        content_type=v1_content_type,
+        codename='share_page',
+        name='Can share pages'
+    )
+
+    # Assign it to Editors and Moderators groups
+    for group in Group.objects.all():
+        group.permissions.add(share_permission)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('v1', '0011_auto_20151207_1725'),
+    ]
+
+    operations = [
+        migrations.RunPython(create_share_permissions),
+    ]

--- a/cfgov/v1/templatetags/share.py
+++ b/cfgov/v1/templatetags/share.py
@@ -3,6 +3,8 @@ import os
 from django import template
 from wagtail.wagtailcore.models import Page
 
+from v1.models import CFGOVUserPagePermissionsProxy
+
 register = template.Library()
 
 
@@ -28,4 +30,7 @@ def staging_url(context, page):
 @register.assignment_tag(takes_context=True)
 def v1page_permissions(context, page):
     page = page.specific
-    return page.permissions_for_user(context['request'].user)
+    if 'user_page_permissions' not in context:
+        context['user_page_permissions'] = CFGOVUserPagePermissionsProxy(context['request'].user)
+
+    return context['user_page_permissions'].for_page(page)

--- a/cfgov/v1/wagtail_hooks.py
+++ b/cfgov/v1/wagtail_hooks.py
@@ -1,9 +1,11 @@
 import os
 
 from django.http import Http404
-from v1.models import CFGOVPage
+from django.contrib.auth.models import Permission
 
 from wagtail.wagtailcore import hooks
+
+from v1.models import CFGOVPage
 
 
 @hooks.register('after_create_page')
@@ -33,3 +35,8 @@ def check_request_site(page, request, serve_args, serve_kwargs):
         if isinstance(page, CFGOVPage):
             if not page.shared:
                 raise Http404
+
+
+@hooks.register('register_permissions')
+def register_share_permissions():
+    return Permission.objects.filter(codename='share_page')


### PR DESCRIPTION
Adds Share page permission to the V1 CFGOVPage model and then adds it as an option for a Group.

@kave 
@rosskarchner 