### PR TITLE
Updated the two heros outside of wagtail and the prototype

### DIFF
--- a/cfgov/jinja2/v1/careers/application-process/index.html
+++ b/cfgov/jinja2/v1/careers/application-process/index.html
@@ -23,16 +23,31 @@
 {%- endblock %}
 
 {% block hero -%}
-    {{ hero.render({
-        'heading':   'CFPB Hiring Video',
-        'body':      'We are a government agency created after the 2008
-                      financial crisis. We protect American consumers.
-                      Allow us to introduce ourselves.',
-        'image_url': '/static/img/applying-video-screenshot.png'
-    }, {
-        'link_text': 'See the history of the CFPB',
-        'link_url':  '/the-bureau/history/'
-    }) }}
+    {% do global_dict.update(
+        {
+            'hero': {
+                'heading':   'CFPB Hiring Video',
+                'body': {
+                    'source': 'We are a government agency created after the 2008
+                              financial crisis. We protect American consumers.
+                              Allow us to introduce ourselves.'
+                },
+                'image': {
+                    'upload': {
+                        'url': '/static/img/applying-video-screenshot.png'
+                    }
+                },
+                'background_color': '#d5e7e6',
+                'link': {
+                    'text': 'See the history of the CFPB',
+                    'url':  '/the-bureau/history/'
+                }
+            }
+        })
+    %}
+    {% set value = global_dict.hero %}
+    {% set prototype = true %}
+    {% include 'molecules/hero.html' with context %}
 {%- endblock %}
 
 {% block content_main %}

--- a/cfgov/jinja2/v1/the-bureau/index.html
+++ b/cfgov/jinja2/v1/the-bureau/index.html
@@ -28,16 +28,31 @@
 {%- endblock %}
 
 {% block hero -%}
-    {{ hero.render({
-        'heading':   'We are the CFPB',
-        'body':      'We are a government agency created after the 2008
-                      financial crisis. We protect American consumers.
-                      Allow us to introduce ourselves.',
-        'image_url': 'https://img.youtube.com/vi/en0Iq8II4fA/maxresdefault.jpg'
-    }, {
-        'link_text': 'See the history of the CFPB',
-        'link_url':  '/the-bureau/history/'
-    }) }}
+    {% do global_dict.update(
+        {
+            'hero': {
+                'heading':   'We are the CFPB',
+                'body': {
+                    'source': 'We are a government agency created after the 2008
+                              financial crisis. We protect American consumers.
+                              Allow us to introduce ourselves.'
+                },
+                'image': {
+                    'upload': {
+                        'url': 'https://img.youtube.com/vi/en0Iq8II4fA/maxresdefault.jpg'
+                    }
+                },
+                'background_color': '#d5e7e6',
+                'link': {
+                    'text': 'See the history of the CFPB',
+                    'url':  '/the-bureau/history/'
+                }
+            }
+        })
+    %}
+    {% set value = global_dict.hero %}
+    {% set prototype = true %}
+    {% include 'molecules/hero.html' with context %}
 {%- endblock %}
 
 {% block content_main_modifiers -%}


### PR DESCRIPTION
The heros broke during the transition to wagtail. Updated where they were used to pass values to the hero macro.

## Changes

- Updated `the-bureau` and `careers/application-process` to correctly pass data to the hero macro.

## Testing

- checkout `/careers/application-process/` and `/the-bureau/` locally

## Review

- @kave 
- @kurtw 
- @rosskarchner 

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices 
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
