### PR TITLE
Leadership Calendar PDF Form validation

### DIFF
--- a/cfgov/cfgov/urls.py
+++ b/cfgov/cfgov/urls.py
@@ -111,6 +111,9 @@ urlpatterns = [
     url(r'^the-bureau/', include([
         url(r'^$', SheerTemplateView.as_view(template_name='the-bureau/index.html'),
             name='index'),
+        url(r'^leadership-calendar/$',
+            SheerTemplateView.as_view(),
+            name='leadership-calendar'),
         url(r'^(?P<page_slug>[\w-]+)/$',
             SheerTemplateView.as_view(),
             name='page'),

--- a/cfgov/core/services.py
+++ b/cfgov/core/services.py
@@ -11,7 +11,9 @@ from django.core.exceptions import ImproperlyConfigured
 from pytz import timezone
 from dateutil.parser import parse
 from v1.forms import CalenderPDFFilterForm
-
+from django.core.urlresolvers import reverse
+from django.contrib import messages
+from django.http import HttpResponseRedirect
 
 class PDFReactorNotConfigured(Exception):
     pass
@@ -97,8 +99,10 @@ class PDFGeneratorView(View):
 
             return self.generate_pdf(query_opts)
         else:
-            return Exception('Error query values are not in expected format')
-
+            for error in form.errors.itervalues():
+                messages.error(request, str(error), extra_tags='leadership-calendar')
+            return HttpResponseRedirect(reverse('%s:leadership-calendar' %
+                                                 self.request.resolver_match.namespace))
 
 class ICSView(ContextMixin, View):
     """

--- a/cfgov/jinja2/v1/_includes/macros/filters.html
+++ b/cfgov/jinja2/v1/_includes/macros/filters.html
@@ -160,6 +160,9 @@
         </span>
     </button>
     <div class="expandable_content">
+      {%- if options.show_errors -%}
+        {{ _errors() }}
+      {% endif %}
        {{ _filters_form(filters, query, doc_type, options) }}
     </div>
 </div>
@@ -352,6 +355,25 @@
 </form>
 {% endmacro %}
 
+
+{# A helper macro for filters()
+   ========================================================================== #}
+{% macro _errors(errors=[]) %}
+    {% set errors = errors or get_messages(request) %}
+    {%- if errors -%}
+        {% set error_messages = [] %}
+        {% for error in errors %}
+           {% do error_messages.append(error|string) %}
+        {% endfor %}
+        {% set value = {
+            'message': '</br>'.join(error_messages) | safe,
+            'type': 'error'
+        } %}
+        <div class="u-mt15 u-mb15">
+            {% include 'molecules/notification.html' with context %}
+        </div>
+    {%- endif -%}
+{% endmacro %}
 
 {# A helper macro for filters()
    ========================================================================== #}

--- a/cfgov/jinja2/v1/the-bureau/leadership-calendar/index.html
+++ b/cfgov/jinja2/v1/the-bureau/leadership-calendar/index.html
@@ -83,8 +83,9 @@
                 'show_current_filters': false,
                 'action'              : 'pdf/',
                 'submit_label'        : 'Download PDF',
-                'additional_classes'  : 'js-validate_form-not-empty',
-                'form_method'         : 'post'
+                'additional_classes'  : 'js-validate_form-not-empty, js-validate_require-date',
+                'form_method'         : 'post',
+                'show_errors'         :  True
             }
         ) }}
     </section>

--- a/cfgov/unprocessed/js/config/error-messages-config.js
+++ b/cfgov/unprocessed/js/config/error-messages-config.js
@@ -1,0 +1,19 @@
+/* ==========================================================================
+  Error Messages Config
+
+  These messages are manually mirrored on the Python side in config.py
+   ========================================================================== */
+
+'use strict';
+
+var ERROR_MESSAGES = {
+  CHECKBOX_ERRORS : {
+    required : 'Please select at least one of the "%s" options.'
+  },
+  DATE_ERRORS : {
+    invalid : 'You have entered an invalid date.',
+    one_required : 'Please enter at least one date.'
+  }
+};
+
+module.exports = ERROR_MESSAGES;

--- a/cfgov/unprocessed/js/modules/post-filter.js
+++ b/cfgov/unprocessed/js/modules/post-filter.js
@@ -7,6 +7,7 @@
 
 var $ = require( 'jquery' );
 var dateRangeFormatter = require( './util/date-range-formatter' );
+var DATE_ERRORS = require( '../config/error-messages-config' ).DATE_ERRORS;
 
 /**
  * Set up jQuery plugin initialization.
@@ -101,15 +102,31 @@ PostFilter.prototype = {
     return this;
   },
 
-  onSubmit: function( e ) {
-    var dateRange =
-      dateRangeFormatter.format( this.$gte.val(), this.$lte.val() );
+  onSubmit: function( event ) {
+    var $form = $( event.target );
+    var fromDateValue = this.$gte.val();
+    var toDateValue = this.$lte.val();
+    var dateRange = dateRangeFormatter.format( fromDateValue, toDateValue );
+    var error_messages = [];
+
     if ( dateRange && dateRange.isValid ) {
       this.$gte.val( dateRange.startDate );
       this.$lte.val( dateRange.endDate );
     } else {
-      e.preventDefault();
-      // TODO: Add inline notifcation;
+      error_messages.push(DATE_ERRORS.invalid);
+    }
+
+    if ( $form.hasClass( 'js-validate_require-date' ) &&
+    toDateValue === '' && fromDateValue === '' ) {
+      error_messages.push(DATE_ERRORS.one_required);
+    }
+
+    if( error_messages.length ) {
+      event.preventDefault();
+      $form.trigger( 'cf_notifier:notify', {
+        message: error_messages.join('</br>'),
+        state:   'error'
+      } );
     }
 
     return this;

--- a/cfgov/v1/__init__.py
+++ b/cfgov/v1/__init__.py
@@ -2,6 +2,7 @@ from django.contrib.staticfiles.storage import staticfiles_storage
 from django.core.urlresolvers import reverse
 from django.template.defaultfilters import slugify
 from wagtail.wagtailcore.templatetags import wagtailcore_tags
+from django.contrib import messages
 
 import HTMLParser
 from jinja2 import Environment, contextfunction, Markup
@@ -27,7 +28,8 @@ def environment(**options):
         'render_stream_child': render_stream_child,
         'flag_enabled': flag_enabled,
         'flag_disabled': flag_disabled,
-        'get_unique_id': get_unique_id
+        'get_unique_id': get_unique_id,
+        'get_messages': messages.get_messages
     })
     env.filters.update({
         'slugify': slugify,

--- a/cfgov/v1/forms.py
+++ b/cfgov/v1/forms.py
@@ -1,16 +1,58 @@
 from django import forms
+from django.forms.utils import ErrorList
 from django.forms.widgets import DateInput, SelectMultiple
-from v1.models.events import EventPage
 
+from sheerlike.query import QueryFinder
+from sheerlike.templates import date_formatter
+from v1.models.events import EventPage
+from util import ERROR_MESSAGES
+
+class FilterErrorList(ErrorList):
+    def __str__(self):
+        return '\n'.join(str(e) for e in self)
+
+class FilterDateField(forms.DateField):
+    def to_python(self, value):
+        if value:
+            try:
+                value = date_formatter(value)
+            except Exception as e:
+                pass
+        return super(FilterDateField, self).to_python(value)
+
+class FilterCheckboxList(forms.CharField):
+    def validate(self, value):
+        if value in self.empty_values and self.required:
+            msg = self.error_messages['required']
+            if self.label and '%s' in msg:
+                msg = msg % self.label
+            raise forms.ValidationError(msg, code='required')
 
 class CalenderPDFFilterForm(forms.Form):
-    filter_calendar = forms.CharField()
-    filter_range_date_gte = forms.DateField(input_formats=['%Y-%m-%d'])
-    filter_range_date_lte = forms.DateField(input_formats=['%Y-%m-%d'])
+    filter_calendar = FilterCheckboxList(label='Calendar',
+        error_messages=ERROR_MESSAGES['CHECKBOX_ERRORS'])
+    filter_range_date_gte = FilterDateField(required=False,
+        error_messages=ERROR_MESSAGES['DATE_ERRORS'])
+    filter_range_date_lte = FilterDateField(required=False,
+        error_messages=ERROR_MESSAGES['DATE_ERRORS'])
+
+    def __init__(self, *args, **kwargs):
+        kwargs['error_class'] = FilterErrorList
+        super(CalenderPDFFilterForm, self).__init__(*args, **kwargs)
 
     def clean_filter_calendar(self):
         return self.cleaned_data['filter_calendar'].replace(' ', '+')
 
+    def clean(self):
+        cleaned_data = super(CalenderPDFFilterForm, self).clean()
+        from_date_empty = 'filter_range_date_gte' in cleaned_data and \
+                          cleaned_data['filter_range_date_gte']  == None
+        to_date_empty = 'filter_range_date_lte' in cleaned_data and \
+                        cleaned_data['filter_range_date_lte'] == None
+
+        if from_date_empty and to_date_empty :
+            raise forms.ValidationError(ERROR_MESSAGES['DATE_ERRORS']['one_required'])
+        return cleaned_data
 
 class EventsFilterForm(forms.Form):
     tags_select_attrs = {
@@ -34,7 +76,6 @@ class EventsFilterForm(forms.Form):
                               widget=DateInput(attrs=to_select_attrs))
     topics = forms.MultipleChoiceField(required=False, choices=[],
                                        widget=SelectMultiple(attrs=tags_select_attrs))
-
     @property
     def field_queries(self):
         return zip(['start_dt__gte', 'end_dt__lte', 'tags__name__in'],
@@ -42,6 +83,7 @@ class EventsFilterForm(forms.Form):
 
     def __init__(self, *args, **kwargs):
         super(EventsFilterForm, self).__init__(*args, **kwargs)
+
         if 'topics' in self.fields:
             options = list(set([tag for tags in [event.tags.names() for event
                                                  in EventPage.objects.live()]

--- a/cfgov/v1/util/util.py
+++ b/cfgov/v1/util/util.py
@@ -14,3 +14,15 @@ def to_camel_case(snake_str):
     snake_str = snake_str.capitalize()
     components = snake_str.split('_')
     return components[0] + "".join(x.title() for x in components[1:])
+
+ # These messages are manually mirrored on the
+ # Javascript side in error-messages-config.js
+ERROR_MESSAGES = {
+	'CHECKBOX_ERRORS' : {
+		'required' : 'Please select at least one of the "%s" options.'
+	},
+	'DATE_ERRORS' :{
+		'invalid' : 'You have entered an invalid date.',
+		'one_required': 'Please enter at least one date.'
+	}
+}


### PR DESCRIPTION
Adds server side and client side validation for the Leadership Calendar PDF Form.

## Additions

- Added client side/server side validation for the Leadership Calendar PDF Form.

## Testing

- Turn off Javascript and browse to the `http://localhost:8000/the-bureau/leadership-calendar/` page. Submit the calendar PDF form without selecting any options. You should see error notifications once redirected.

## Review

- @jimmynotjim 
- @anselmbradford 
- @kurtw 
- @kave 

## Notes
- There is still some ongoing work related to converted the Filters to Django Forms.