### PR TITLE
Fix Related Posts organism

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,6 +117,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - S3 Image Upload support for Refresh/Prod
 - Dev Landing Page Demo
 - Add Image Text 25/75 and Full Width Text into SublandingPage
+- Add related_posts_function to the global context in Jinja2 for prototyping of related posts
 
 ### Changed
 - Updated the primary nav to move focus as user enters and leaves nav levels
@@ -195,6 +196,9 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Fix related post molecule to be used in multiple places
 - Convert Sidefoot paragraph streamfield block to Textblock
 - Updated headings for changes in Capital Framework
+- Temporarily comment out related posts section of single blog post browser test until BlogPage's are in Wagtail
+- Add `show_heading` checkbox to Related Posts organism to toggle the heading
+  and icon.
 
 ### Removed
 - Removed unused exportsOverride section,
@@ -216,6 +220,9 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Fixed setup.sh to use argument correctly
 - Fixed title for Small & Minority Businesses
 - Fix page header rendering for Sublanding page
+- Fix related post molecule to be used in multiple places
+- Fix failing tests relating to Related Posts organism
+- Fix related-posts.html logic
 
 
 ## 3.0.0-2.4.0 - 2015-09-29

--- a/cfgov/jinja2/v1/_includes/molecules/related-posts.html
+++ b/cfgov/jinja2/v1/_includes/molecules/related-posts.html
@@ -24,6 +24,9 @@
     "events"   : ("Events", "speech-bubble")
   }
 %}
+{% set page = page or global_dict.page %}
+{% set related_post_types = page.related_posts(block) %}
+{% if related_post_types %}
 <div class="m-related-posts
             {{'m-related-posts__half-width'
               if is_half_width else ''}}">
@@ -34,23 +37,20 @@
         </span>
     </h2>
     {% endif %}
-    {% set page = page or global_dict.page %}
-    {% set related_post_types = page.related_posts(block) %}
-    {% if related_post_types | length  > 1 %}
     {% for post_type, post_type_list in related_post_types.iteritems() %}
     {% set title, icon = title_icon_lookup[post_type] or ("Blog", "speech-bubble") %}
     <div class="m-related-posts_list-container">
+    {% if block.value.show_heading %}
         <h3 class="h4">
              <span class="cf-icon cf-icon-{{icon}}"></span>
             {{ title }}
         </h3>
+    {% endif %}
         {{ _related_posts_list(post_type_list) }}
     </div>
     {% endfor %}
-    {% else %}
-        {{ _related_posts_list(related_post_types.values() | first) }}
-    {% endif %}
 </div>
+{% endif %}
 {% endmacro %}
 
 
@@ -89,7 +89,7 @@
         </p>
         {% endif %}
         <p class="date">
-            {{ time.render(post.date, {'date':true}) }}
+            {{ time.render(post.latest_revision_created_at, {'date':true}) }}
         </p>
     </li>
     {% endfor %}

--- a/cfgov/jinja2/v1/events/event.html
+++ b/cfgov/jinja2/v1/events/event.html
@@ -53,8 +53,12 @@
 
 {% block content_sidebar %}
     <section class="block block__flush-top">
-        {% import 'molecules/related-posts.html' as related_posts with context %}
-        {{ related_posts.render() }}
+        {% for block in page.sidefoot %}
+            {% if 'related_posts' in block.block_type %}
+                {% import 'molecules/related-posts.html' as related_posts with context %}
+                {{ related_posts.render(block) }}
+            {% endif %}
+        {% endfor %}
     </section>
     <section class="block">
         <h1 class="header-slug">

--- a/cfgov/jinja2/v1/landing-page/index.html
+++ b/cfgov/jinja2/v1/landing-page/index.html
@@ -128,12 +128,4 @@
             {{ render_stream_child(block) }}
         {% endif %}
     {% endfor %}
-
-    {% for block in page.sidefoot %}
-        {% if 'related_posts' in block.block_type %}
-            {{ related_posts.render() }}
-        {% else %}
-            {{ render_stream_child(block) }}
-        {% endif %}
-    {% endfor %}
 {%- endblock %}

--- a/cfgov/v1/__init__.py
+++ b/cfgov/v1/__init__.py
@@ -13,9 +13,16 @@ def environment(**options):
     options.setdefault('extensions', []).append(CompressorExtension)
     env = sheerlike_environment(**options)
     env.autoescape = True
+    from v1.models import CFGOVPage
     env.globals.update({
         'static': staticfiles_storage.url,
-        'global_dict': {},
+        'global_dict': {
+            'related_posts_function': lambda x: {
+                'posts': CFGOVPage.objects.all()[:x['value']['limit']],
+                'newsroom': CFGOVPage.objects.all()[:x['value']['limit']],
+                'events': CFGOVPage.objects.all()[:x['value']['limit']]
+            }
+        },
         'reverse': reverse,
         'render_stream_child': render_stream_child
     })

--- a/cfgov/v1/migrations/0014_addshowheading_relatedposts.py
+++ b/cfgov/v1/migrations/0014_addshowheading_relatedposts.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import wagtail.wagtailsnippets.blocks
+import v1.models.snippets
+import wagtail.wagtailimages.blocks
+import wagtail.wagtailcore.fields
+import wagtail.wagtailcore.blocks
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('v1', '0013_add_sublanding'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='cfgovpage',
+            name='sidefoot',
+            field=wagtail.wagtailcore.fields.StreamField([(b'slug', wagtail.wagtailcore.blocks.CharBlock(icon=b'title')), (b'heading', wagtail.wagtailcore.blocks.CharBlock(icon=b'title')), (b'paragraph', wagtail.wagtailcore.blocks.TextBlock(icon=b'edit')), (b'hyperlink', wagtail.wagtailcore.blocks.StructBlock([(b'text', wagtail.wagtailcore.blocks.CharBlock(max_length=100, required=False)), (b'url', wagtail.wagtailcore.blocks.CharBlock(default=b'/', required=False))])), (b'call_to_action', wagtail.wagtailcore.blocks.StructBlock([(b'slug_text', wagtail.wagtailcore.blocks.CharBlock(max_length=100, required=True)), (b'paragraph_text', wagtail.wagtailcore.blocks.RichTextBlock(required=True)), (b'button', wagtail.wagtailcore.blocks.StructBlock([(b'text', wagtail.wagtailcore.blocks.CharBlock(max_length=100, required=False)), (b'url', wagtail.wagtailcore.blocks.CharBlock(default=b'/', required=False))]))])), (b'related_posts', wagtail.wagtailcore.blocks.StructBlock([(b'limit', wagtail.wagtailcore.blocks.CharBlock(default=b'3', label=b'Limit')), (b'show_heading', wagtail.wagtailcore.blocks.BooleanBlock(help_text=b'This toggles the heading and icon for the related types.', default=True, required=False, label=b'Show Heading and Icon?')), (b'relate_posts', wagtail.wagtailcore.blocks.BooleanBlock(default=True, required=False, editable=False, label=b'Blog Posts')), (b'relate_newsroom', wagtail.wagtailcore.blocks.BooleanBlock(default=True, required=False, editable=False, label=b'Newsroom')), (b'relate_events', wagtail.wagtailcore.blocks.BooleanBlock(default=True, required=False, label=b'Events')), (b'view_more', wagtail.wagtailcore.blocks.StructBlock([(b'text', wagtail.wagtailcore.blocks.CharBlock(max_length=100, required=False)), (b'url', wagtail.wagtailcore.blocks.CharBlock(default=b'/', required=False))]))])), (b'email_signup', wagtail.wagtailcore.blocks.StructBlock([(b'heading', wagtail.wagtailcore.blocks.CharBlock(max_length=100, required=True)), (b'text', wagtail.wagtailcore.blocks.CharBlock(required=True)), (b'gd_code', wagtail.wagtailcore.blocks.CharBlock(required=False)), (b'form_field', wagtail.wagtailcore.blocks.ListBlock(wagtail.wagtailcore.blocks.StructBlock([(b'btn_text', wagtail.wagtailcore.blocks.CharBlock(max_length=100, required=True)), (b'required', wagtail.wagtailcore.blocks.BooleanBlock(required=False)), (b'id', wagtail.wagtailcore.blocks.CharBlock(max_length=100, required=True)), (b'info', wagtail.wagtailcore.blocks.RichTextBlock(required=False, label=b'Disclaimer')), (b'label', wagtail.wagtailcore.blocks.CharBlock(max_length=100, required=True)), (b'type', wagtail.wagtailcore.blocks.ChoiceBlock(choices=[(b'text', b'Text'), (b'checkbox', b'Checkbox'), (b'email', b'Email'), (b'number', b'Number'), (b'url', b'URL'), (b'radio', b'Radio')])), (b'placeholder', wagtail.wagtailcore.blocks.CharBlock(max_length=100, required=False))]), required=False, icon=b'mail'))])), (b'contact', wagtail.wagtailcore.blocks.StructBlock([(b'header', wagtail.wagtailcore.blocks.CharBlock()), (b'body', wagtail.wagtailcore.blocks.RichTextBlock()), (b'contact', wagtail.wagtailsnippets.blocks.SnippetChooserBlock(v1.models.snippets.Contact))]))], blank=True),
+        ),
+        migrations.AlterField(
+            model_name='sublandingpage',
+            name='sidebar_breakout',
+            field=wagtail.wagtailcore.fields.StreamField([(b'slug', wagtail.wagtailcore.blocks.CharBlock(icon=b'title')), (b'heading', wagtail.wagtailcore.blocks.CharBlock(icon=b'title')), (b'paragraph', wagtail.wagtailcore.blocks.RichTextBlock(icon=b'edit')), (b'breakout_image', wagtail.wagtailcore.blocks.StructBlock([(b'image', wagtail.wagtailimages.blocks.ImageChooserBlock()), (b'is_round', wagtail.wagtailcore.blocks.BooleanBlock(default=True, required=False, label=b'Round?')), (b'icon', wagtail.wagtailcore.blocks.CharBlock(help_text=b'Enter icon class name.')), (b'heading', wagtail.wagtailcore.blocks.CharBlock(label=b'Introduction Heading')), (b'body', wagtail.wagtailcore.blocks.TextBlock(label=b'Introduction Body'))], heading=b'Breakout Image', icon=b'image')), (b'related_posts', wagtail.wagtailcore.blocks.StructBlock([(b'limit', wagtail.wagtailcore.blocks.CharBlock(default=b'3', label=b'Limit')), (b'show_heading', wagtail.wagtailcore.blocks.BooleanBlock(help_text=b'This toggles the heading and icon for the related types.', default=True, required=False, label=b'Show Heading and Icon?')), (b'relate_posts', wagtail.wagtailcore.blocks.BooleanBlock(default=True, required=False, editable=False, label=b'Blog Posts')), (b'relate_newsroom', wagtail.wagtailcore.blocks.BooleanBlock(default=True, required=False, editable=False, label=b'Newsroom')), (b'relate_events', wagtail.wagtailcore.blocks.BooleanBlock(default=True, required=False, label=b'Events')), (b'view_more', wagtail.wagtailcore.blocks.StructBlock([(b'text', wagtail.wagtailcore.blocks.CharBlock(max_length=100, required=False)), (b'url', wagtail.wagtailcore.blocks.CharBlock(default=b'/', required=False))]))]))], blank=True),
+        ),
+    ]

--- a/cfgov/v1/models/base.py
+++ b/cfgov/v1/models/base.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import os
 import sys
 
@@ -88,47 +87,30 @@ class CFGOVPage(Page):
         ObjectList(settings_panels, heading='Configuration'),
     ])
 
-    # TODO: After all search types are migrated to Wagtail this should relate
-    # pages based on tags.
     def related_posts(self, block):
-        # After all search types are migrated to Wagtail, comment out below. If
-        # we decide we'd like to use the more_like_this feature of
-        # Elasticsearch, we can always revert back to this.
-        results = {}
-        for search_type in ['posts', 'newsroom', 'events']:
+        related = {}
+        query = models.Q(('tags__name__in', self.tags.names()))
+        # TODO: Replace this in a more global scope when Filterable List gets
+        # implemented in the backend.
+        # Import classes that use this class here to maintain proper import
+        # order.
+        from . import EventPage
+        search_types = {
+            'events': EventPage,
+        }
+        # End TODO
+        for search_type, page_class in search_types.items():
             if 'relate_%s' % search_type in block.value \
                and block.value['relate_%s' % search_type]:
-                results.update({search_type: []})
+                related[search_type] = \
+                    page_class.objects.filter(query).order_by(
+                        '-latest_revision_created_at').exclude(
+                        slug=self.slug)[:block.value['limit']]
 
-        try:
-            # Gets an ES document across all types by the slug of the
-            # page.
-            document = get_document('_all', self.slug)
-            for search_type in results.keys():
-                results[search_type] = \
-                    more_like_this(document, search_types=search_type,
-                                   search_size=
-                                   block.value['limit'])
-        except NotFoundError:
-            print('ES document not found for page.', file=sys.stderr)
-            return
-        return results
-        # Comment out above
-
-        # TODO:After all search types are migrated to Wagtail, uncomment below.
-        # query = Q(('tags__name__in', self.tags))
-        # search_types = {
-        #     'blog_posts': 'BlogPostPage',
-        #     'newsroom_items': 'NewsroomPage',
-        #     'events': 'EventPage',
-        # }
-        # related = []
-        # for search_type in ['posts', 'newsroom', 'events']:
-        #     if eval('self.is_relating_%s' % search_type):
-        #         related += eval('%s.objects.filter(query)[:%s]' %
-        #                         search_types[search_type],
-        #                         self.related_limit)
-        # return related
+        # Return a dictionary of lists of each type when there's at least one
+        # hit for that type.
+        return {search_type: queryset for search_type, queryset in
+                related.items() if queryset}
 
     @property
     def status_string(self):

--- a/cfgov/v1/models/organisms.py
+++ b/cfgov/v1/models/organisms.py
@@ -66,9 +66,16 @@ class EmailSignUp(blocks.StructBlock):
 
 class RelatedPosts(blocks.StructBlock):
     limit = blocks.CharBlock(default='3', label='Limit')
-    relate_posts = blocks.BooleanBlock(required=False, default=True, label='Blog Posts')
-    relate_newsroom = blocks.BooleanBlock(required=False, default=True, label='Newsroom')
-    relate_events = blocks.BooleanBlock(required=False, default=True, label='Events')
+    show_heading = blocks.BooleanBlock(required=False, default=True,
+                                       label='Show Heading and Icon?',
+                                       help_text='This toggles the heading and'
+                                       + ' icon for the related types.')
+    relate_posts = blocks.BooleanBlock(required=False, default=True,
+                                       label='Blog Posts', editable=False)
+    relate_newsroom = blocks.BooleanBlock(required=False, default=True,
+                                          label='Newsroom', editable=False)
+    relate_events = blocks.BooleanBlock(required=False, default=True,
+                                        label='Events')
     view_more = atoms.Hyperlink(required=False)
 
     class Meta:

--- a/test/browser_tests/page_objects/page_blog-single.js
+++ b/test/browser_tests/page_objects/page_blog-single.js
@@ -28,11 +28,12 @@ function BlogSingle() {
 
   this.contentSidebar = element( by.css( '.content_sidebar' ) );
 
-  this.relatedPosts =
-  this.contentSidebar.element( by.css( '.related-posts' ) );
+  // TODO: Uncomment after blog post pages have been added to  Wagtail
+  // this.relatedPosts =
+  // this.contentSidebar.element( by.css( '.related-posts' ) );
 
-  this.relatedPostsTitle =
-  this.relatedPosts.element( by.css( '.header-slug_inner' ) );
+  // this.relatedPostsTitle =
+  // this.relatedPosts.element( by.css( '.header-slug_inner' ) );
 }
 
 module.exports = BlogSingle;


### PR DESCRIPTION
- Revert related_posts method logic to use tags instead of elasticsearch
- Fix jinja2 logic in related-posts.html
- Add `show_heading` boolean to Related Posts molecule backend
- Disable blog post and newsroom checkboxes temporarily
- Add related_posts_function to the global context in Jinja2 for prototyping of related posts
- Temporarily comment out related posts browser test for single blog page
 - Keep commented out until BlogPage is in Wagtail

@kave 