### PR TITLE
Converted two macros to use proper prototype data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,9 +120,13 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Add related_posts_function to the global context in Jinja2 for prototyping of related posts
 - Added the featured content module molecule and included it in the landing-page prototype
 - Add ImageText2575Group organism
-- Add ImageText2575Group to Sublanding and Landing pages 
+- Add ImageText2575Group to Sublanding and Landing pages
 - Add the insets Quote and Related Links.
 - Added templates and CSS for the Notification molecule.
+- Added prototype data to the form-field-with-button molecule
+- Added prototype data to the email-signup organism
+- Added the email-signup organism to landing-page template
+
 
 ### Changed
 - Updated the primary nav to move focus as user enters and leaves nav levels

--- a/cfgov/jinja2/v1/_includes/molecules/form-field-with-button.html
+++ b/cfgov/jinja2/v1/_includes/molecules/form-field-with-button.html
@@ -24,43 +24,39 @@
    settings.field.placeholder: The placeholder used for the input.
 
    ========================================================================== #}
-
-{% if value %}
-    <div class="m-form-field-with-button">
-        <div class="form-group">
-            <label for="{{ value.id }}">
-                <b>{{ value.label }}</b>
-                {% if value.required %}
-                    (required)
-                {% endif %}
-            </label>
-            <input id="{{ value.id }}"
-                   type="{{ value.type }}"
-                   placeholder="{{ value.placeholder }}"
-                   class="m-form-field-with-button_field"
-                    {{ "required" if value.required else "" }}>
-        </div>
-        {{ value.info | safe }}
-        <input class="btn btn__full" type="submit" value="{{ value.btn_text }}">
-    </div>
-{% else %}
-    {% macro render(settings) %}
-        <div class="m-form-field-with-button">
-            <div class="form-group">
-                <label for="{{ settings.field.id }}">
-                    <b>{{ settings.field.label }}</b>
-                    {% if settings.field.required %}
-                        (required)
-                    {% endif %}
-                </label>
-                <input id="{{ settings.field.id }}"
-                       type="{{ settings.field.type }}"
-                       placeholder="{{ settings.field.placeholder }}"
-                       class="m-form-field-with-button_field"
-                       {{ "required" if settings.field.required else "" }}>
-            </div>
-            {{ settings.field.info or '' }}
-            <input class="btn btn__full" type="submit" value="{{ settings.btn_text }}">
-        </div>
-    {% endmacro %}
+{% if not value %}
+    {% do global_dict.update({
+        'form_field': {
+            'label':       'Form Field with Button',
+            'name':        'm-form-field-with-button',
+            'id':          'form-field-with-button',
+            'placeholder': 'form field with button',
+            'type':        'text',
+            'info':        {
+                'source': 'This is a form field with a button. Isn\'t it awesome?'
+            },
+            'required':    false,
+            'btn_text':    'The Awesome Button'
+        }
+    }) %}
+    {% set value = global_dict.form_field %}
+    {% set prototype = true %}
 {% endif %}
+
+<div class="m-form-field-with-button">
+    <div class="form-group">
+        <label for="{{ value.id }}">
+            <b>{{ value.label }}</b>
+            {{ '(required)' if value.required else '' }}
+        </label>
+        <input id="{{ value.id }}"
+               type="{{ value.type }}"
+               placeholder="{{ value.placeholder }}"
+               name="{{ value.name }}"
+               class="m-form-field-with-button_field"
+               {{ 'required' if value.required else '' }}>
+    </div>
+    <p class="short-desc">{{ value.info.source | safe }}</p>
+    <input class="btn btn__full" type="submit" value="{{ value.btn_text }}">
+</div>
+

--- a/cfgov/jinja2/v1/_includes/molecules/hero.html
+++ b/cfgov/jinja2/v1/_includes/molecules/hero.html
@@ -85,4 +85,5 @@
                  style="background-image: url( {{ photo.url }} );">
         {% endif %}
         </div>
+    </div>
 </section>

--- a/cfgov/jinja2/v1/_includes/organisms/email-signup.html
+++ b/cfgov/jinja2/v1/_includes/organisms/email-signup.html
@@ -20,17 +20,43 @@
 
 {% if not value %}
     {% set lipsumText = lipsum(1, false, 10, 25) | safe %}
-    {% do global_dict.update(
-        {
-            'email_signup': {
-                  'heading':    'Slug Title',
-                  'text': lipsumText
+    {% macro _privacy_statement() %}
+        The information you provide will permit the Consumer Financial
+        Protection Bureau to process your request or inquiry.
+        <a href="/sub-pages/privacy-policy/">See More</a>
+    {% endmacro %}
+
+    {% macro _form_field() %}
+        {% do global_dict.update({
+            'form_field': {
+                'label':       'Email Address',
+                'name':        'o-email-signup_email',
+                'placeholder': 'mail@example.com',
+                'type':        'email',
+                'info':        {
+                    'source': _privacy_statement()
+                },
+                'required':    true,
+                'btn_text':    'Sign up'
             }
-        })
-    %}
+        }) %}
+        {% set value = global_dict.form_field %}
+        {% include 'molecules/form-field-with-button.html' %}
+    {% endmacro %}
+
+    {% do global_dict.update({
+        'email_signup': {
+            'heading':    'Slug Title',
+            'text':       lipsumText,
+            'form_field': [
+                _form_field()
+            ]
+        }
+    }) %}
     {% set value = global_dict.email_signup %}
     {% set prototype = true %}
 {% endif %}
+
 {% if value.heading %}
     <h2 class="header-slug">
         <span class="header-slug_inner">
@@ -38,6 +64,7 @@
         </span>
     </h2>
 {% endif %}
+
 <form class="o-email-signup"
       id="{{ value.id or ('o-email-signup_' ~ range(1, 100) | random) }}"
       action="/subscriptions/new/"
@@ -49,36 +76,7 @@
         </p>
     {% endif %}
 
-    {% if prototype %}
-        {% import 'molecules/form-field-with-button.html' as form_field_with_button %}
-        {% macro _privacy_statement() %}
-            <p class="short-desc">
-                The information you provide will permit the Consumer Financial
-                Protection Bureau to process your request or inquiry.
-                <a href="/sub-pages/privacy-policy/">See More</a>
-            </p>
-        {% endmacro %}
-        {{ form_field_with_button.render( {
-                'field': {
-                'label':       'Email Address',
-                'name':        'o-email-signup_email',
-                'placeholder': 'example@mail.com',
-                'type':        'email',
-                'info':        _privacy_statement(),
-                'required':    true
-                },
-                'btn_text': 'Sign up'
-                } ) }}
-
-
-    {% else %}
-        {% for form in value.form_field %}
-            {{ form |safe }}
-        {% endfor %}
-    {% endif %}
+    {% for form in value.form_field %}
+        {{ form | safe }}
+    {% endfor %}
 </form>
-
-
-
-
-


### PR DESCRIPTION
Updated the `form-field-with-button` and `email-signup` to use proper prototyped data and remove extra conditional markup.

## Additions

- Added prototype data to the `form-field-with-button` molecule
- Added prototype data to the `email-signup` organism
- Added the `email-signup` organism to `landing-page` template

## Testing

- `gulp build` and navigate to `/landing-page/`

## Review

- @kave 
- @kurtw 
- @KimberlyMunoz 
- @sebworks 
- @anselmbradford 

## Screenshots

![screen shot 2015-12-16 at 1 33 34 pm](https://cloud.githubusercontent.com/assets/1280430/11850154/9fd89d06-a3f9-11e5-8220-c5c93e0d034e.png)

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices 
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
