### PR TITLE
Fixes awkwardly floating insets

### DIFF
--- a/cfgov/unprocessed/css/molecules/full-width-text.less
+++ b/cfgov/unprocessed/css/molecules/full-width-text.less
@@ -1,6 +1,6 @@
 /* topdoc
   name: Full width text
-  family: cfgov-organisms
+  family: cfgov-molecules
   patterns:
     - name: Default example
       markup: |
@@ -21,7 +21,7 @@
               ul
                 li
   tags:
-    - cfgov-organisms
+    - cfgov-molecules
   notes:
     - Since content will be entered by content managers,
       these styles are applied on the ul li elements directly when needed.

--- a/cfgov/unprocessed/css/molecules/inset.less
+++ b/cfgov/unprocessed/css/molecules/inset.less
@@ -1,6 +1,6 @@
 /* topdoc
   name: Insets near Full Width Text
-  family: cfgov-organisms
+  family: cfgov-molecules
   patterns:
     - name: Default example
       markup: |
@@ -24,7 +24,7 @@
               .m-call-to-action
             .m-full-width-text
   tags:
-    - cfgov-organisms
+    - cfgov-molecules
   notes:
     - These are held in a full-width-text-group container to be held with
       various full-width text blocks,  insets and tables as needed.
@@ -34,6 +34,7 @@
     margin-top: unit( @grid_gutter-width / @base-font-size-px, em );
     margin-bottom: unit( @grid_gutter-width / @base-font-size-px, em );
     width: 100%;
+    clear: right;
 
     .respond-to-min(@bp-med-min, {
         float: right;

--- a/cfgov/unprocessed/css/organisms/full-width-text-group.less
+++ b/cfgov/unprocessed/css/organisms/full-width-text-group.less
@@ -1,0 +1,25 @@
+/* topdoc
+  name: Full width text
+  family: cfgov-organisms
+  patterns:
+    - name: Default example
+      markup: |
+        <div class="o-full-width-text-group">
+            <div class="m-full-width-text"></div>
+            <div class="m-inset"></div>
+            <div class="m-full-width-text"></div>
+        </div>
+      codenotes:
+        - |
+          Structural cheat sheet:
+          -----------------------
+          .o-full-width-text
+            .m-full-width-text
+            .m-inset
+  tags:
+    - cfgov-organisms
+*/
+
+.o-full-width-text-group {
+    overflow: auto;
+}


### PR DESCRIPTION
Fixes issue where small amounts of text or strange placement would cause awkward floats

In #1209, we got really awkward floats if the full width text was too short or if the article ended with an inset. This fixes the issue with a few lines of CSS.

## Preview

![image](https://cloud.githubusercontent.com/assets/1860176/11858069/06f11a72-a42c-11e5-9520-4330422bdb36.png)

## Review
- @kurtw 
- @jimmynotjim 