### PR TITLE
Optimizes category-icon macro

### DIFF
--- a/cfgov/jinja2/v1/_includes/macros/category-icon.html
+++ b/cfgov/jinja2/v1/_includes/macros/category-icon.html
@@ -17,27 +17,23 @@
    ========================================================================== #}
 
 {% macro render(category, additional_classes) %}
-    {%- if category|lower == 'info for consumers' -%}
-    <span class="{{ additional_classes }} cf-icon cf-icon-information"></span>
-    {%- elif category|lower == 'at the cfpb' -%}
-    <span class="{{ additional_classes }} cf-icon cf-icon-bullhorn"></span>
-    {%- elif category|lower == 'data, research & reports' -%}
-    <span class="{{ additional_classes }} cf-icon cf-icon-chart"></span>
-    {%- elif category|lower == 'policy & compliance' -%}
-    <span class="{{ additional_classes }} cf-icon cf-icon-bank-account"></span>
-    {%- elif category|lower == 'speech' -%}
-    <span class="{{ additional_classes }} cf-icon cf-icon-microphone"></span>
-    {%- elif category|lower == 'press release' -%}
-    <span class="{{ additional_classes }} cf-icon cf-icon-bullhorn"></span>
-    {%- elif category|lower == 'op-ed' -%}
-    <span class="{{ additional_classes }} cf-icon cf-icon-contract"></span>
-    {%- elif category|lower == 'testimony' -%}
-    <span class="{{ additional_classes }} cf-icon cf-icon-double-quote"></span>
-    {%- elif category|lower == 'cfpb_report' -%}
-    <span class="{{ additional_classes }}"></span>
-    {%- elif category|lower == 'blog' -%}
-    <span class="{{ additional_classes }} cf-icon cf-icon-speech-bubble"></span>
-    {%- elif category|lower == 'newsroom' -%}
-    <span class="{{ additional_classes }} cf-icon cf-icon-newspaper"></span>
+    {% set icons = {
+        'info for consumers': 'cf-icon-information',
+        'at the cfpb': 'cf-icon-bullhorn',
+        'data, research & reports': 'cf-icon-chart',
+        'policy & compliance': 'cf-icon-bank-account',
+        'speech': 'cf-icon-microphone',
+        'press release': 'cf-icon-bullhorn',
+        'op-ed': 'cf-icon-contract',
+        'testimony': 'cf-icon-double-quote',
+        'blog': 'cf-icon-speech-bubble',
+        'newsroom': 'cf-icon-newspaper'
+      }
+    %}
+    {% set category = category | lower %}
+    {%- if icons[category] -%}
+    <span class="cf-icon
+                 {{ icons[category] }}
+                 {{ additional_classes }}"></span>
     {%- endif -%}
 {% endmacro %}


### PR DESCRIPTION
Optimizes category-icon macro. Part of item introduction task.

## Changes

- Removes redundant code in favor of lookup table.
- Removes `cfpb_report` entry because it was just including an empty span element.

## Testing

- `/blog/` categories should be as before.

## Review

- @jimmynotjim 
- @KimberlyMunoz 
- @sebworks 

## Screenshots

![screen shot 2015-12-17 at 2 20 14 pm](https://cloud.githubusercontent.com/assets/704760/11879451/6b8c513e-a4c9-11e5-9291-1b0e6cba9c4c.png)
