### PR TITLE
Set g++ in TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,13 @@ python:
 
 sudo: false
 
+addons:
+  apt:
+    sources:
+    - ubuntu-toolchain-r-test
+    packages:
+    - g++-4.8
+
 services:
   - elasticsearch
 
@@ -12,6 +19,9 @@ install:
   # Project configuration requirements.
   - pip install virtualenv virtualenvwrapper
   - pip install autoenv
+  # Set g++ version for npm nan.
+  - export CXX=g++-4.8
+  - $CXX --version
   - npm install nvm
   - nvm install 5.2.0
   - nvm use 5.2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -225,6 +225,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Changed the ImageBasic atom to always include an optional alt by default
 - Removed field validation on content creation
   ([Fixed 1252](https://github.com/cfpb/cfgov-refresh/issues/1252)).
+- Sets npm install on frontend.sh to warning level.
 
 ### Removed
 - Removed unused exportsOverride section,

--- a/frontend.sh
+++ b/frontend.sh
@@ -82,7 +82,7 @@ install(){
     # Protractor - JavaScript acceptance testing.
     if [ $(is_installed protractor) = 0 ]; then
       echo 'Installing Protractor dependencies locally...'
-      npm install protractor
+      npm install protractor --loglevel warn
       ./$NODE_DIR/protractor/bin/webdriver-manager update
     else
       echo 'Global Protractor installed. Copying global install locally...'
@@ -98,9 +98,9 @@ install(){
       rm -rf ./$NODE_DIR/protractor/node_modules/
     fi
 
-    npm install -d
+    npm install -d --loglevel warn
   else
-    npm install --production
+    npm install --production --loglevel warn
   fi
   bower install --config.interactive=false
 }


### PR DESCRIPTION
Explicitly sets g++ version on Travis for handling nan errors and sets loglevel on npm install to warning to remove `npm info` clutter from the output log.

## Changes

- sets g++ version on Travis
- sets npm install loglevel to warn in `frontend.sh`.

## Testing

- `./setup.sh` should have less output and Travis log in this PR should be shorter.

## Review

- @KimberlyMunoz 
- @sebworks 
- @kave