### PR TITLE
Integrate notification into filter

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -36,7 +36,6 @@
     "html5shiv": "latest",
     "jquery.easing": "~1.3.0",
     "string_score": "git://github.com/joshaven/string_score#0.1.20",
-    "slick-carousel": "~1.3.7",
-    "validate": "~0.7.1"
+    "slick-carousel": "~1.3.7"
   }
 }

--- a/cfgov/jinja2/v1/_includes/molecules/notification.html
+++ b/cfgov/jinja2/v1/_includes/molecules/notification.html
@@ -26,17 +26,16 @@
 {% if not value %}
     {% do global_dict.update(
         {
-            'expandable': {
-                'label': 'Default Expandable',
-                'paragraph': lipsum(1, false, 10, 225),
-                'is_bordered': true,
-                'is_midtone': false,
-                'is_expanded': false
+            'notification': {
+                'is_visible': false,
+                'type': 'success',
+                'message': 'Success!',
+                'explanation': 'Explanation text paragraph.'
             }
         })
     %}
 {% endif %}
-{% set value = value or global_dict.expandable %}
+{% set value = value or global_dict.notification %}
 
 {% set is_visible = value.is_visible if value.is_visible else false %}
 {% set type  =  value.type if value.type in ['success', 'warning', 'error'] else 'success' %}
@@ -50,17 +49,15 @@
 {% set message  =  value.message | default( message ) %}
 
 {% set notification_type = ('m-notification__' + type) if type %}
-{% set notification_icon_type = (' m-notification_icon__' + type) if type %}
-{% set cf_icon_style = (' cf-icon-' + icon + '-round') if type %}
 <div class="m-notification
             {{ notification_type }}
             {{ 'm-notification__visible' if is_visible else '' }}">
     <span class="m-notification_icon
-                 {{ notification_icon_type }}
-                 cf-icon
-                 {{ cf_icon_style }}"></span>
-    <p class="h4">{{ message }}</p>
-    {% if value.explanation %}
-        <p class="h4 m-notification_explanation">{{ value.explanation }}</p>
-    {% endif %}
+                 cf-icon"></span>
+    <div class="m-notification_content">
+        <p class="h4 m-notification_message">{{ message }}</p>
+        {% if value.explanation %}
+            <p class="h4 m-notification_explanation">{{ value.explanation }}</p>
+        {% endif %}
+    </div>
 </div>

--- a/cfgov/jinja2/v1/_includes/organisms/filterable-list-controls.html
+++ b/cfgov/jinja2/v1/_includes/organisms/filterable-list-controls.html
@@ -54,27 +54,6 @@
 
    ========================================================================== #}
 
-{# =========================================================================
-
-   Text Introduction
-
-   =========================================================================
-
-   Description:
-
-   Create a Text Introduction molecule.
-   See [GHE]/flapjack/Modules-V1/wiki/Text-Introduction
-
-   value:           An object with the following options for value.
-
-   value.heading:   Heading text.
-   value.intro:     Body introduction text.
-   value.body:      Body text.
-
-   value.links:     A collection of links with URL & Text.
-
-   ========================================================================== #}
-
 {% macro _filters_form(value) %}
 {% if value.action and value.action != '/' %}
 {% set action = value.action %}
@@ -325,4 +304,18 @@
     %}
     {% set value = global_dict.expandable %}
     {% include 'molecules/expandable.html' with context %}
+
+    {% do global_dict.update(
+        {
+            'notification': {
+                'type':        'error',
+                'message':     'Custom text',
+                'explanation': 'And an explanation with a <a href="#">link</a>' | safe
+            }
+
+        })
+    %}
+    {% set value = global_dict.notification %}
+    {% include 'molecules/notification.html' with context %}
+
 </div>

--- a/cfgov/unprocessed/css/main.less
+++ b/cfgov/unprocessed/css/main.less
@@ -89,6 +89,7 @@
 @import (less) "organisms/content-sidebar.less";
 @import (less) "organisms/expandable-group.less";
 @import (less) "organisms/email-signup.less";
+@import (less) "organisms/filterable-list-controls.less";
 @import (less) "organisms/full-width-text-group.less";
 @import (less) "organisms/image-text-50-50-group.less";
 @import (less) "organisms/item-introduction.less";

--- a/cfgov/unprocessed/css/molecules/expandable.less
+++ b/cfgov/unprocessed/css/molecules/expandable.less
@@ -109,7 +109,6 @@
 */
 .m-expandable {
     .webfont-regular();
-    padding-bottom: unit( ( @grid_gutter-width * 2 ) / @base-font-size-px, em );
 
     &_target,
     &_content-animated {

--- a/cfgov/unprocessed/css/molecules/notification.less
+++ b/cfgov/unprocessed/css/molecules/notification.less
@@ -13,16 +13,16 @@
     - name: Default Usage
       markup: |
         <div class="m-notification m-notification__error">
-          <span class="cf-notification_icon
-                       cf-notification_icon__error
-                       cf-icon
-                       cf-icon-error-round"></span>
-          <p class="h4>
-              This is a default alert.
-          </p>
-          <p class="h4 m-notification_explanation">
-              This is a default explanation with a <a href="#">link</a>.
-          </p>
+          <span class="m-notification_icon
+                       cf-icon"></span>
+          <div class="m-notification_content">
+            <p class="h4>
+                This is a default alert.
+            </p>
+            <p class="h4 m-notification_explanation">
+                This is a default explanation with a <a href="#">link</a>.
+            </p>
+          </div>
         </div>
   tags:
     - cf-molecules
@@ -31,7 +31,7 @@
 @m-notification-padding__px: 15px;
 
 .m-notification {
-    /* display: none; TODO: uncomment this line when prototype is merged into filters. x*/
+    display: none;
     position: relative;
 
     padding: @m-notification-padding__px;
@@ -43,16 +43,44 @@
     &__success {
         background: @green-tint;
         border-color: @input-success;
+
+        .m-notification_icon:before {
+            .cf-icon();
+
+            content: @cf-icon-approved-round;
+            vertical-align: middle;
+            color: @green;
+        }
     }
 
     &__warning {
         background: @gold-20;
         border-color: @input-warning;
+
+        .m-notification_icon:before {
+            .cf-icon();
+
+            content: @cf-icon-error-round;
+            vertical-align: middle;
+            color: @gold;
+        }
     }
 
     &__error {
         background: @redorange-20;
         border-color: @input-error;
+
+        .m-notification_icon:before {
+            .cf-icon();
+
+            content: @cf-icon-delete-round;
+            vertical-align: middle;
+            color: @redorange;
+        }
+    }
+
+    &__visible {
+        display: block;
     }
 
     &_icon {
@@ -62,18 +90,6 @@
 
         color: @gray-20;
         font-size: unit( 18px / @base-font-size-px, em );
-
-        &__success {
-            color: @green;
-        }
-
-        &__warning {
-            color: @gold;
-        }
-
-        &__error {
-            color: @redorange;
-        }
     }
 
     p:last-child {

--- a/cfgov/unprocessed/css/organisms/expandable-group.less
+++ b/cfgov/unprocessed/css/organisms/expandable-group.less
@@ -42,9 +42,6 @@
 .o-expandable-group {
     .webfont-regular();
     margin-bottom: unit(30px / @base-font-size-px, em);
-    .m-expandable {
-        padding: 0;
-    }
 }
 
 .o-expandable-group .m-expandable:not(:last-child) .m-expandable_content {

--- a/cfgov/unprocessed/css/organisms/filterable-list-controls.less
+++ b/cfgov/unprocessed/css/organisms/filterable-list-controls.less
@@ -1,0 +1,43 @@
+/* topdoc
+  name: Filterable List Controls
+  family: cf-organisms
+  patterns:
+  - name: Filterable List Controls
+    markup: |
+      <div class="o-filterable-list-controls">
+          <div class="m-expandable
+                      m-expandable__borders
+                      m-expandable__midtone
+                      m-expandable__expanded">
+              …
+          </div>
+          <div class="m-notification"></div>
+      </div>
+    codenotes:
+      - |
+        Pattern structure
+        -----------------
+        .o-filterable-list-controls
+          .m-expandable
+            [...]
+          .m-notification
+            [...]
+  tags:
+  - cf-organisms
+*/
+
+.o-filterable-list-controls {
+    // TODO: Ideally this would be in a block surrounding the notification.
+    //       However, that leads to a gap when the notification is hidden.
+    //       See https://github.com/cfpb/cfgov-refresh/pull/1274#discussion_r48609669
+    // Add gap between expandable and notification.
+    .m-notification {
+        margin-top: unit( @grid_gutter-width / @base-font-size-px, em );
+    }
+}
+
+
+/* topdoc
+    name: EOF
+    eof: true
+*/

--- a/cfgov/unprocessed/js/modules/post-filter.js
+++ b/cfgov/unprocessed/js/modules/post-filter.js
@@ -121,7 +121,7 @@ PostFilter.prototype = {
       error_messages.push(DATE_ERRORS.one_required);
     }
 
-    if( error_messages.length ) {
+    if ( error_messages.length ) {
       event.preventDefault();
       $form.trigger( 'cf_notifier:notify', {
         message: error_messages.join('</br>'),

--- a/cfgov/unprocessed/js/molecules/Notification.js
+++ b/cfgov/unprocessed/js/molecules/Notification.js
@@ -1,0 +1,148 @@
+'use strict';
+
+// Required polyfills for <IE9.
+require( '../modules/polyfill/query-selector' );
+require( '../modules/polyfill/class-list' );
+
+// Required modules.
+var atomicCheckers = require( '../modules/util/atomic-checkers' );
+
+/**
+ * Notification
+ * @class
+ *
+ * @classdesc Initializes a new Notification molecule.
+ *
+ * @param {HTMLNode} element
+ *   The DOM element within which to search for the molecule.
+ * @returns {Object} An Notification instance.
+ */
+function Notification( element ) { // eslint-disable-line max-statements, inline-comments, max-len
+
+  var BASE_CLASS = 'm-notification';
+
+  // Constants for the state of this Notification.
+  var SUCCESS = 'success';
+  var WARNING = 'warning';
+  var ERROR = 'error';
+
+  // Constants for the Notification modifiers.
+  var MODIFIER_VISIBLE = BASE_CLASS + '__visible';
+
+  var _dom =
+    atomicCheckers.validateDomElement( element, BASE_CLASS, 'Notification' );
+  var _contentDom = _dom.querySelector( '.' + BASE_CLASS + '_content' );
+
+  var _currentType;
+
+  /**
+   * @returns {Object} The Notification instance.
+   */
+  function init() {
+    // Check and set default type of notification.
+    var classList = _dom.classList;
+    if ( classList.contains( BASE_CLASS + '__' + SUCCESS ) ) {
+      _currentType = SUCCESS;
+    } else if ( classList.contains( BASE_CLASS + '__' + WARNING ) ) {
+      _currentType = WARNING;
+    } else if ( classList.contains( BASE_CLASS + '__' + ERROR ) ) {
+      _currentType = ERROR;
+    }
+
+    return this;
+  }
+
+  /**
+   * @param {number} type The notifiation type.
+   * @param {string} messageText The content of the notifiation message.
+   * @param {string|HTMLNode} explanationText
+   *   The content of the notifiation explanation.
+   * @returns {Object} The Notification instance.
+   */
+  function setTypeAndContent( type, messageText, explanationText ) {
+    _setType( type );
+    setContent( messageText, explanationText );
+
+    return this;
+  }
+
+  /**
+   * @param {string} messageText The content of the notifiation message.
+   * @param {string|HTMLNode} explanationText
+   *   The content of the notifiation explanation.
+   * @returns {Object} The Notification instance.
+   */
+  function setContent( messageText, explanationText ) {
+    var content = '<p class="h4">' +
+                  messageText +
+                  '</p>';
+    if ( typeof explanationText !== 'undefined' ) {
+      content += '<p class="h4 m-notification_explanation">' +
+                 explanationText +
+                 '</p>';
+    }
+    _contentDom.innerHTML = content;
+
+    return this;
+  }
+
+  /**
+   * @param {number} type The notifiation type.
+   * @returns {Object} The Notification instance.
+   */
+  function _setType( type ) {
+    // If type hasn't changed, return.
+    if ( _currentType === type ) {
+      return this;
+    }
+
+    var classList = _dom.classList;
+    classList.remove( BASE_CLASS + '__' + _currentType );
+
+    if ( type === SUCCESS ||
+         type === WARNING ||
+         type === ERROR ) {
+      classList.add( BASE_CLASS + '__' + type );
+      _currentType = type;
+    } else {
+      throw new Error( type + ' is not a supported notification type!' );
+    }
+
+    return this;
+  }
+
+  /**
+   * @returns {Object} The Notification instance.
+   */
+  function show() {
+    if ( _currentType === ERROR || _currentType === WARNING ) {
+      _contentDom.setAttribute( 'role', 'alert' );
+    } else {
+      _contentDom.removeAttribute( 'role' );
+    }
+    _dom.classList.add( MODIFIER_VISIBLE );
+    return this;
+  }
+
+  /**
+   * @returns {Object} The Notification instance.
+   */
+  function hide() {
+    _dom.classList.remove( MODIFIER_VISIBLE );
+    return this;
+  }
+
+  this.SUCCESS = SUCCESS;
+  this.WARNING = WARNING;
+  this.ERROR = ERROR;
+
+  this.init = init;
+  this.setContent = setContent;
+  this.setTypeAndContent = setTypeAndContent;
+  this.show = show;
+  this.hide = hide;
+
+  return this;
+}
+
+module.exports = Notification;

--- a/cfgov/unprocessed/js/organisms/FilterableListControls.js
+++ b/cfgov/unprocessed/js/organisms/FilterableListControls.js
@@ -3,6 +3,11 @@
 // Required modules.
 var atomicCheckers = require( '../modules/util/atomic-checkers' );
 var Expandable = require( '../molecules/Expandable' );
+var Notification = require( '..molecules/Notification' );
+// TODO: Implement form data client-side validation.
+// var validate = require( 'validate' );
+
+require( '../modules/polyfill/array-polyfills' );
 
 /**
  * FilterableListControls
@@ -10,13 +15,162 @@ var Expandable = require( '../molecules/Expandable' );
  *
  * @classdesc Initializes a new Filterable-List-Controls organism.
  *
- * @param {HTMLNode} element The DOM element within which to search for the organism.
+ * @param {HTMLNode} element
+ *   The DOM element within which to search for the organism.
  */
 function FilterableListControls( element ) {
   var BASE_CLASS = 'o-filterable-list-controls';
 
   var _dom = atomicCheckers.validateDomElement( element, BASE_CLASS, 'FilterableListControls' );
-  var _expandable = new Expandable( _dom ).init();
+  var _form = _dom.querySelector( 'form' );
+  var _notification;
+  var _fields = [];
+
+  var _validatorDefaults = {
+    inputs: [
+      'input',
+      'textarea',
+      'select'
+    ]
+  };
+
+  /**
+   * Initialize FilterableListControls instance.
+  */
+  function init() {
+    var expandable = new Expandable( _dom );
+    expandable.init();
+    _notification = new Notification( _dom );
+    _notification.init();
+    _form.addEventListener( 'submit', _formSubmitted );
+
+    var inputs = _validatorDefaults.inputs;
+    var fields;
+    var field;
+    var type;
+    for ( var i = 0, len = inputs.length; i < len; i++ ) {
+      fields = _form.querySelectorAll( inputs[i] );
+      for ( var f = 0, flen = fields.length; f < flen; f++ ) {
+        field = fields[f];
+        type = field.getAttribute( 'type' );
+        if ( type !== 'hidden' &&
+             type !== 'button' &&
+             type !== 'submit' &&
+             type !== 'reset' &&
+             typeof field.getAttribute( 'disabled' ) !== 'undefined' ) {
+          _fields.push( field );
+        }
+      }
+    }
+  }
+
+  /**
+   * Show error notification.
+   * @param {Object} event Form submitted event.
+  */
+  function _formSubmitted( event ) {
+    event.preventDefault();
+    var validatedFields = _validateFields( _fields );
+
+    if ( validatedFields.invalid.length > 0 ) {
+      _showError();
+    } else {
+      _showSuccess();
+    }
+  }
+
+  /**
+   * Show error notification.
+  */
+  function _showError() {
+    _notification.setTypeAndContent( _notification.ERROR, 'Error!' );
+    _notification.show();
+  }
+
+  /**
+   * Show success notification.
+  */
+  function _showSuccess() {
+    _notification.setTypeAndContent( _notification.SUCCESS, 'Success!' );
+    _notification.show();
+  }
+
+  /**
+   * Validate the fields of our form.
+   * @param  {Array} fields The list of input fields we're testing.
+   * @returns {Object}
+   *   The tested list of fields broken into valid and invalid blocks.
+  */
+  function _validateFields( fields ) {
+    var checkgroups = {};
+    var validatedFields = {
+      valid:   [],
+      invalid: []
+    };
+
+    var field;
+    var name;
+    for ( var f = 0, flen = fields.length; f < flen; f++ ) {
+      field = fields[f];
+      name = field.getAttribute( 'name' );
+      if ( !checkgroups[name] ) {
+        checkgroups[name] = [];
+      }
+      checkgroups[name].push( field );
+    }
+
+    var status;
+    for ( var group in checkgroups ) {
+      if ( checkgroups.hasOwnProperty( group ) ) {
+        status = group.length > 1 ?
+                 _validateCheckGroup( group ) : _validateInput( group );
+
+        for ( var prop in status.status ) {
+          if ( status.status[prop] === false ) {
+            validatedFields.valid.push( field );
+          } else {
+            validatedFields.invalid.push( field );
+          }
+        }
+      }
+    }
+
+    return validatedFields;
+  }
+
+  /**
+   * @param {Object} elem The check group we're testing.
+   * @returns {Object}
+   *   The formatted validation object of the tested check group.
+   */
+  function _validateCheckGroup( elem ) {
+    // TODO: Replace mock data with real validation data.
+    return {
+      elem:   elem,
+      value:  null,
+      label:  null,
+      status: {
+        checkgroup: false
+      }
+    };
+  }
+
+  /**
+   * @param {Object} elem The input we're testing.
+   * @returns {Object} The formatted validation object of the tested input.
+   */
+  function _validateInput( elem ) {
+    // TODO: Replace mock data with real validation data.
+    return {
+      elem:   elem,
+      value:  null,
+      label:  null,
+      status: false
+    };
+  }
+
+  this.init = init;
+  return this;
 }
 
 module.exports = FilterableListControls;

--- a/cfgov/unprocessed/js/routes/browse-filterable/index.js
+++ b/cfgov/unprocessed/js/routes/browse-filterable/index.js
@@ -5,5 +5,12 @@
 'use strict';
 
 // List of organisms used.
+var Notification = require( '../../molecules/Notification' );
 var FilterableListControls = require( '../../organisms/FilterableListControls' );
-var filterableListControls = new FilterableListControls( document.body );
+
+var notifications = document.querySelectorAll( '.m-notification' );
+var notification;
+for ( var i = 0, len = notifications.length; i < len; i++ ) {
+	notification = new Notification( notifications[i] ).init();
+}
+var filterableListControls = new FilterableListControls( document.body ).init();

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "gulp-replace": "^0.5.3",
     "imports-loader": "^0.6.4",
     "require-dir": "^0.3.0",
+    "validate.js": "^0.9.0",
     "webpack": "^1.12.0",
     "webpack-stream": "^3.1.0"
   },
@@ -70,6 +71,6 @@
     "chosen": "./vendor/chosen/chosen.jquery.js",
     "slick": "./vendor/slick-carousel/slick/slick.js",
     "string_score": "./vendor/string_score/string_score.js",
-    "validate": "./vendor/validate/validate.js"
+    "validate": "./node_modules/validate.js/validate.js"
   }
 }


### PR DESCRIPTION
Integrate notification into filter.

## Additions
- Adds JS file for Notification instance to change content, show, and hide at runtime.

## Changes

- Integrates notification into filter. 
- Moves validation library from bower to npm.
- Wraps notification content in a div so that it can be overwritten at once.

## Removes
- Padding below the expandables. I don't think this is required and it messes things up for, e.g. the spacing of an expandable inside a filter.

## Testing

- Submit filter on `/browse-filterable/`

## Review

- @KimberlyMunoz 
- @sebworks 

## Screenshots

![notify](https://cloud.githubusercontent.com/assets/704760/12027894/37d1ba1a-ad9c-11e5-9783-26f3b208e3bd.gif)


## Todos

- Validation needs to be added. This PR adds some of the skeleton for it, but the existing validation JS needs to be integrated.