### PR TITLE
Fixing spacing on top element in cases when page-intro isn't on the page

### DIFF
--- a/cfgov/jinja2/v1/landing-page/index.html
+++ b/cfgov/jinja2/v1/landing-page/index.html
@@ -72,9 +72,16 @@
             {% endif %}
         {%- endfor %}
         {% for block in page.content -%}
-            <div class="block">
-                {{ render_stream_child(block) }}
-            </div>
+            {% if loop.index == 1 %}
+                <div class="block
+                            block__flush-top">
+                    {{ render_stream_child(block) }}
+                </div>
+            {% else %}
+                <div class="block">
+                    {{ render_stream_child(block) }}
+                </div>
+            {% endif %}
         {%- endfor %}
     {% endif %}
 {% endblock %}
@@ -89,7 +96,7 @@
         {% include 'organisms/email-signup.html' %}
     {% else %}
         {% for block in page.sidefoot %}
-            <div class="block">
+            <div class="block block__flush-top">
                 {% if 'related_posts' in block.block_type %}
                     {{ related_posts.render(block) }}
                 {% else %}


### PR DESCRIPTION
In #1281, @Schlachtmeyer pointed out the spacing on one of the landing pages is off when there is no page intro. I moved over some code from the sublanding to fix this.

# Before

![image](https://cloud.githubusercontent.com/assets/1860176/12054024/0222f3f0-aeed-11e5-891d-3aa3a24c2cad.png)

# After

![image](https://cloud.githubusercontent.com/assets/1860176/12054140/710e448a-aeee-11e5-8b71-15a1364a8383.png)


## Review
- @kave 
- @anselmbradford 
- @sebworks 