### PR TITLE
Removes empty pre-content block when no breakout sidebar is present

### DIFF
--- a/cfgov/jinja2/v1/sublanding-page/index.html
+++ b/cfgov/jinja2/v1/sublanding-page/index.html
@@ -13,7 +13,7 @@
 {% endblock %}
 
 {% block pre_content %}
-    {% if page.header or page.sidebar_breakout %}
+    {% if page.sidebar_breakout %}
         {% include 'organisms/sidebar-breakout.html' %}
     {% endif %}
 {% endblock %}


### PR DESCRIPTION
In #1277, @Schlachtmeyer pointed out a weird gap between the hero and content area. I've removed that by checking for a sidebar breakout before rendering since the introduction text in the pre-content area should always be paired with one. This might make debugging a little tricky for content people, so I'm open to other solutions.

# Before
![image](https://cloud.githubusercontent.com/assets/1860176/12055306/01a18b6e-aefa-11e5-9c1a-8c8382fb2b84.png)

# After
![image](https://cloud.githubusercontent.com/assets/1860176/12055348/6db5c504-aefa-11e5-9db9-30f45623123e.png)

# Review
- @kave 
- @sebworks 
- @anselmbradford 