### PR TITLE
Fixing spacing for half link blob and email signup

### DIFF
--- a/cfgov/jinja2/v1/_includes/molecules/form-field-with-button.html
+++ b/cfgov/jinja2/v1/_includes/molecules/form-field-with-button.html
@@ -56,7 +56,7 @@
                class="m-form-field-with-button_field"
                {{ 'required' if value.required else '' }}>
     </div>
-    <p class="short-desc">{{ value.info.source | safe }}</p>
+    <div class="short-desc">{{ value.info.source | safe }}</div>
     <input class="btn btn__full" type="submit" value="{{ value.btn_text }}">
 </div>
 

--- a/cfgov/jinja2/v1/_includes/molecules/half-width-link-blob.html
+++ b/cfgov/jinja2/v1/_includes/molecules/half-width-link-blob.html
@@ -49,8 +49,9 @@
 {% endif %}
 <div class="m-half-width-link-blob">
     <h2 class="h3">{{ value.heading }}</h2>
-
-    <div>{{ value.body.source | safe }}</div>
+    <div class="m-half-width-link-blob_paragraph">
+        {{ value.body.source | safe }}
+    </div>
     <ul class="list list__links">
         {% for link in value.links %}
             <li class="list_item">

--- a/cfgov/jinja2/v1/_includes/organisms/email-signup.html
+++ b/cfgov/jinja2/v1/_includes/organisms/email-signup.html
@@ -71,7 +71,7 @@
       method="POST"
       enctype="application/x-www-form-urlencoded">
     {% if value.text %}
-        <p class='short-desc'>
+        <p class="short-desc">
             {{ value.text }}
         </p>
     {% endif %}

--- a/cfgov/unprocessed/css/molecules/half-width-link-blob.less
+++ b/cfgov/unprocessed/css/molecules/half-width-link-blob.less
@@ -25,20 +25,26 @@
 */
 
 .m-half-width-link-blob {
-  margin-bottom: unit( (@grid_gutter-width * 2) / @base-font-size-px, em);
+    margin-bottom: unit( (@grid_gutter-width * 2) / @base-font-size-px, em);
 
-  .webfont-regular();
+    .webfont-regular();
 
-  .respond-to-max(@bp-xs-max, {
-    & + & {
-      margin-top: unit(@grid_gutter-width / @base-font-size-px, em);
+    .respond-to-max(@bp-xs-max, {
+        & + & {
+            margin-top: unit(@grid_gutter-width / @base-font-size-px, em);
+        }
+    });
+
+    .respond-to-min(@bp-sm-min, {
+        .grid_column(6);
+    });
+
+    &_paragraph {
+        margin-bottom: unit( @grid_gutter-width / @base-font-size-px, em);
     }
-  });
-
-  .respond-to-min(@bp-sm-min, {
-    .grid_column(6);
-  });
 }
+
+
 
 /* topdoc
     name: EOF

--- a/cfgov/v1/models/molecules.py
+++ b/cfgov/v1/models/molecules.py
@@ -81,7 +81,7 @@ class FormFieldWithButton(blocks.StructBlock):
     id = blocks.CharBlock(max_length=100, required=False,
                           help_text="Type of form i.e emailForm, submission-form. Should be unique if multiple forms are used")
     info = blocks.RichTextBlock(required=False, label="Disclaimer")
-    label = blocks.CharBlock(max_length=100, required=False)
+    label = blocks.CharBlock(max_length=100, required=True)
     type = blocks.ChoiceBlock(choices=[
         ('text', 'Text'),
         ('checkbox', 'Checkbox'),


### PR DESCRIPTION
In #1277, Schlachtmeyer pointed out some spacing issues on the link blobs and email signup. This fixes them and also marks the label as required since this is necessary for accessibility.

![image](https://cloud.githubusercontent.com/assets/1860176/12056396/ef5711b8-af03-11e5-8e9e-072db7433a9e.png)

## Review
- @anselmbradford 
- @sebworks 
- @kave 