### PR TITLE
Fixing 50-50 image container to center circle images

### DIFF
--- a/cfgov/unprocessed/css/molecules/image-text-50-50.less
+++ b/cfgov/unprocessed/css/molecules/image-text-50-50.less
@@ -82,23 +82,18 @@
 */
 
 .m-image-text-50-50 {
-    position: relative;
     padding-bottom: unit( @grid_gutter-width * 2 / @base-font-size-px, em );
 
     &_container {
-        position: relative;
-        width: 100%;
-        padding-bottom: 75%;
-        margin-bottom: unit( @grid_gutter-width / @base-font-size-px, em );
-        > img {
-            position: absolute;
-            top: 0;
-            right: 0;
-            bottom: 0;
-            left: 0;
-            height: 100%;
-            width: 100%;
-        }
+        height: 150px;
+        width: 150px;
+        margin-right: auto;
+        margin-left: auto;
+        margin-bottom: unit( @grid_gutter-width / 2 / @base-font-size-px, em );
+        .respond-to-max(@bp-sm-max, {
+            height: 130px;
+            width: 130px;
+        });
     }
 
     &_widescreen-container {


### PR DESCRIPTION
Last one! #1281 has an issue where the 50-50 images are distorted. This was because of a misunderstanding on how this molecule would be implemented. I talked it over with @duelj and now the spacing should be fixed.

# Before

![image](https://cloud.githubusercontent.com/assets/1860176/12058549/3db4ed82-af1b-11e5-9515-b416c561a737.png)

# After

![image](https://cloud.githubusercontent.com/assets/1860176/12058555/4886cb7c-af1b-11e5-9645-265b7f5958cf.png)

# Review
- @duelj -- can you review the size and spacing? I couldn't find specs in the wiki.
- @anselmbradford 
- @sebworks 
