### PR TITLE
Fix for get_unique_id method

### DIFF
--- a/cfgov/v1/__init__.py
+++ b/cfgov/v1/__init__.py
@@ -9,6 +9,7 @@ from jinja2 import Environment, contextfunction, Markup
 from sheerlike import environment as sheerlike_environment
 from compressor.contrib.jinja2ext import CompressorExtension
 from flags.template_functions import flag_enabled, flag_disabled
+from util.util import get_unique_id
 
 def environment(**options):
     options.setdefault('extensions', []).append(CompressorExtension)
@@ -35,14 +36,6 @@ def environment(**options):
         'slugify': slugify,
     })
     return env
-
-@contextfunction
-def get_unique_id(context, prefix='', suffix=''):
-    if hasattr(context, 'unique_id_index'):
-        context.unique_id_index += 1
-    else:
-        context.unique_id_index = 0
-    return prefix + str(context.unique_id_index) + suffix
 
 @contextfunction
 def render_stream_child(context, stream_child):

--- a/cfgov/v1/util/util.py
+++ b/cfgov/v1/util/util.py
@@ -1,5 +1,7 @@
 import re
 from django.conf import settings
+from time import time
+
 
 
 def id_validator(id_string, search=re.compile(r'[^a-zA-Z0-9-_]').search):
@@ -15,14 +17,20 @@ def to_camel_case(snake_str):
     components = snake_str.split('_')
     return components[0] + "".join(x.title() for x in components[1:])
 
+
+def get_unique_id(prefix='', suffix=''):
+    index = hex(int(time()*10000000))[2:]
+    return prefix + str(index) + suffix
+
+
  # These messages are manually mirrored on the
  # Javascript side in error-messages-config.js
 ERROR_MESSAGES = {
-	'CHECKBOX_ERRORS' : {
-		'required' : 'Please select at least one of the "%s" options.'
-	},
-	'DATE_ERRORS' :{
-		'invalid' : 'You have entered an invalid date.',
-		'one_required': 'Please enter at least one date.'
-	}
+    'CHECKBOX_ERRORS' : {
+        'required' : 'Please select at least one of the "%s" options.'
+    },
+    'DATE_ERRORS' :{
+        'invalid' : 'You have entered an invalid date.',
+        'one_required': 'Please enter at least one date.'
+    }
 }


### PR DESCRIPTION
Fixing get_unique_id method to return hex based time stamp

## Additions

- Fixing get_unique_id method to return hex based time stamp

## Testing

- View filter checkbox ids on the `http://localhost:8000/the-bureau/leadership-calendar/` page.

## Review
- @anselmbradford 
- @KimberlyMunoz 
- @kave 