### PR TITLE
Removes jQuery from nav-primary.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -141,6 +141,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Backend Browse Page
 - Added Backend Item Intro Organism
 - Added Backend: Notification
+- `dom-traverse.js` for dom querying not covered by native dom.
 
 ### Changed
 - Updated the primary nav to move focus as user enters and leaves nav levels

--- a/cfgov/unprocessed/js/modules/util/aria-state.js
+++ b/cfgov/unprocessed/js/modules/util/aria-state.js
@@ -11,19 +11,19 @@
 
 require( '../polyfill/object-defineproperty-polyfill' );
 var ariaStatesConfig = require( '../../config/aria-states-config' );
+
+// Properties
 var ariaState;
 
-
-// Private Properties
-
-var _statePrefix = 'is';
-var _ariaStatePrefix = 'aria-';
+// Constants
+var STATE_PREFIX = 'is';
+var ARIA_STATE_PREFIX = 'aria-';
 
 
 // Private Methods
 
 /**
- ** Defines ARIA state propery on an object.
+ * Defines ARIA state propery on an object.
  *
  * @param {string} state - ARIA state.
  * @param {HTMLElement} element - Element in which to apply
@@ -62,7 +62,7 @@ function _defineProperty( state, element, object ) {
  * @returns {Boolean} - Value indicating if ARIA state is valid.
  */
 function _validateState( state ) {
-  return Boolean( ariaStatesConfig[_ariaStatePrefix + state] );
+  return Boolean( ariaStatesConfig[ARIA_STATE_PREFIX + state] );
 }
 
 
@@ -99,7 +99,7 @@ ariaState = {
    */
   define: function define( state, element, object ) {
     if ( _validateState( state ) ) {
-      state = _statePrefix + state.charAt( 0 ).toUpperCase() +
+      state = STATE_PREFIX + state.charAt( 0 ).toUpperCase() +
               state.substring( 1 );
       _defineProperty( state, element, object );
     }
@@ -116,7 +116,7 @@ ariaState = {
    * @returns {value} - ARIA state attribute value.
    */
   get: function get( state, element ) {
-    return element.getAttribute( ariaStatesConfig[_ariaStatePrefix + state] );
+    return element.getAttribute( ariaStatesConfig[ARIA_STATE_PREFIX + state] );
   },
 
   /**
@@ -129,10 +129,10 @@ ariaState = {
    * @returns {element} - dom element.
    */
   set: function set( state, element, value ) {
-    state = state.substr( 0, 2 ) === 'is' && state.substr( 2 ) || state;
+    state = state.substr( 0, 2 ) === STATE_PREFIX && state.substr( 2 ) || state;
     state = state.toLowerCase();
     if ( _validateState( state ) ) {
-      state = _ariaStatePrefix + state;
+      state = ARIA_STATE_PREFIX + state;
       element.setAttribute( state, value );
     }
 

--- a/cfgov/unprocessed/js/modules/util/dom-traverse.js
+++ b/cfgov/unprocessed/js/modules/util/dom-traverse.js
@@ -1,0 +1,69 @@
+'use strict';
+
+require( '../polyfill/class-list' );
+
+/**
+ * Get the sibling nodes of a dom node.
+ *
+ * @param {HTMLNode} elem - DOM element to get siblings of.
+ * @param {string} selector - a selector string.
+ * @returns {Array} List of sibling nodes.
+ */
+function getSiblings( elem, selector ) {
+  var siblings = [];
+  var sibling;
+  var parent = elem.parentNode;
+  var possibleSiblings = parent.querySelectorAll( selector );
+  for ( var i = 0, len = possibleSiblings.length; i < len; i++ ) {
+    sibling = possibleSiblings[i];
+    // Check that sibling is not the original element,
+    // and that it shares the same parent.
+    if ( sibling !== elem &&
+         sibling.parentNode === parent ) {
+      siblings[siblings.length] = sibling;
+    }
+  }
+  return siblings;
+}
+
+/**
+ * Return a list, with an element excluded.
+ *
+ * @param {NodeList} elems - List of DOM elements.
+ * @param {HTMLNode} exclude - DOM element to exlude from elems.
+ * @returns {Array} edited elems list or original elems list,
+ *   if exlude was not found.
+ */
+function not( elems, exclude ) {
+  var elemsArr = Array.prototype.slice.call( elems );
+  var index = elemsArr.indexOf( exclude );
+  if ( index > -1 ) {
+    return elemsArr.splice( index, 1 );
+  }
+  return elemsArr;
+}
+
+/**
+ * Get the nearest parent node of an element.
+ *
+ * @param {HTMLNode} elem - A DOM element.
+ * @param {string} className - CSS classname.
+ * @returns {HTMLNode} Nearest parent node that contains className, or null.
+ */
+function closest( elem, className ) {
+  elem = elem.parentNode;
+  do {
+    if ( elem.classList && elem.classList.contains( className ) ) {
+      return elem;
+    }
+    elem = elem.parentNode;
+  } while ( elem );
+
+  return null;
+}
+
+module.exports = {
+  getSiblings: getSiblings,
+  not:         not,
+  closest:     closest
+};

--- a/cfgov/unprocessed/js/modules/util/expanded-state.js
+++ b/cfgov/unprocessed/js/modules/util/expanded-state.js
@@ -4,33 +4,32 @@
 
 'use strict';
 
-var $ = require( 'jquery' );
 var navTimeOut;
 
 /**
- * @param {Object} $elem Element to test.
+ * @param {HTMLNode} elem Element to test.
  * @returns {boolean} True if element's aria-expanded value equals "true".
  */
-function isThisExpanded( $elem ) {
-  return $elem.attr( 'aria-expanded' ) === 'true';
+function isThisExpanded( elem ) {
+  return elem.getAttribute( 'aria-expanded' ) === 'true';
 }
 
 /**
  * Check if at least one element has a value of "true" set to an
- * aria-expanded attr.
+ * aria-expanded attribute.
  *
- * @param {Object} $elems Elements to test.
+ * @param {NodeList} elems List of elements to test.
  * @returns {boolean} True if at least one elements' aria-expanded value
  *   equals "true".
  */
-function isOneExpanded( $elems ) {
+function isOneExpanded( elems ) {
   var oneExpanded = false;
 
-  $elems.each( function() {
-    if ( isThisExpanded( $( this ) ) ) {
+  for ( var i = 0, len = elems.length; i < len; i++ ) {
+    if ( isThisExpanded( elems[i] ) ) {
       oneExpanded = true;
     }
-  } );
+  }
 
   return oneExpanded;
 }
@@ -39,20 +38,27 @@ function isOneExpanded( $elems ) {
  * Change the value of the element's aria-expanded attribute based on it's
  * current state if one is not passed. Allows for a delayed event for
  * animated elements.
- * @param {Object}   $elem The element to change the aria-expanded attr of.
- * @param {string}   state The value, if any, to set the aria-expanded attr
- *                         to. Options are "true", "false" or null.
- * @param {Function} cb    The callback function to execute after a delay.
- * @param {integer}  delay The length of time to delay the execution of the
- *                         passed callback.
+ * @param {NodeList|Array|HTMLNode} elems
+ *   List of elements or single element on which to set the aria-expanded attribute.
+ * @param {string} state The value, if any, to set the aria-expanded
+ *   attribute to. Options are "true", "false" or null.
+ * @param {Function} cb The callback function to execute after a delay.
+ * @param {integer} delay The length of time to delay the execution of
+ *   the passed callback.
  */
-function toggleExpandedState( $elem, state, cb, delay ) {
+function toggleExpandedState( elems, state, cb, delay ) {
   var navTimeout;
+  if ( elems.constructor !== NodeList &&
+       elems.constructor !== Array ) {
+    elems = [elems];
+  }
 
   delay = delay || 300;
-  state = state || !isThisExpanded( $elem );
+  state = state || !isOneExpanded( elems );
 
-  $elem.attr( 'aria-expanded', state );
+  for ( var i = 0, len = elems.length; i < len; i++ ) {
+    elems[i].setAttribute( 'aria-expanded', state );
+  }
 
   if ( cb ) {
     clearTimeout( navTimeOut );
@@ -64,11 +70,7 @@ function toggleExpandedState( $elem, state, cb, delay ) {
 }
 
 module.exports = {
-  get: {
-    isThisExpanded: isThisExpanded,
-    isOneExpanded:  isOneExpanded
-  },
-  set: {
-    toggleExpandedState: toggleExpandedState
-  }
+  isThisExpanded: isThisExpanded,
+  isOneExpanded:  isOneExpanded,
+  toggleExpandedState: toggleExpandedState
 };

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "jasmine-reporters": "^2.0.7",
     "jasmine-spec-reporter": "^2.4.0",
     "jquery": "^1.11.3",
-    "jsdom": "^7.0.2",
+    "jsdom": "^7.2.2",
     "lodash": "^3.10.0",
     "map-stream": "^0.0.6",
     "minimist": "^1.1.3",

--- a/test/unit_tests/modules/nav-primary-spec.js
+++ b/test/unit_tests/modules/nav-primary-spec.js
@@ -1,28 +1,27 @@
 'use strict';
 
+var BASE_JS_PATH = '../../../cfgov/unprocessed/js/';
+
 var chai = require( 'chai' );
 var sinon = require( 'sinon' );
 var expect = chai.expect;
 var jsdom = require( 'mocha-jsdom' );
 
 describe( 'Get Event States', function() {
-  var $, navPrimary, sandbox, $link;
+  var navPrimary, sandbox, link;
 
   jsdom();
 
   before( function() {
-    $ = require( 'jquery' );
-    navPrimary =
-      require( '../../../cfgov/unprocessed/js/modules/nav-primary.js' );
+    navPrimary = require( BASE_JS_PATH + 'modules/nav-primary.js' );
     sandbox = sinon.sandbox.create();
   } );
 
   beforeEach( function() {
     //  Adding a simplified version of the thing we want to test.
-    //  Then calling jQuery to test after.
-    $( 'body' ).html(
-      '<div class="js-primary-nav">' +
-        '<div class="js-primary-nav_trigger"></div>' +
+    document.body.innerHTML =
+      '<button class="primary-nav_trigger js-primary-nav_trigger" aria-expanded="false"></button>' +
+      '<nav class="js-primary-nav">' +
         '<div class="nav-item-1 js-primary-nav_item">' +
           '<a class="nav-link-1 js-primary-nav_link" ' +
              'href="http:// github.com">Link</a>' +
@@ -39,8 +38,7 @@ describe( 'Get Event States', function() {
             '<a href="some-url">First Link</a>' +
           '</div>' +
         '</div>' +
-      '</div>'
-    );
+      '</nav>';
     navPrimary.init();
   } );
 
@@ -50,9 +48,9 @@ describe( 'Get Event States', function() {
 
   describe( 'Primary Nav Link Events - Default state', function() {
     beforeEach( function() {
-      $link = $( $( '.sub-nav-1' ).find( 'a' )[0] );
+      link = document.querySelector( '.sub-nav-1 a' );
 
-      $( '.nav-link-1' ).trigger( 'click' );
+      document.querySelector( '.nav-link-1' ).dispatchEvent( new Event( 'click', { 'bubbles': true } ) );
     } );
 
     it( 'should not navigate away from the page', function() {
@@ -60,26 +58,28 @@ describe( 'Get Event States', function() {
     } );
 
     it( 'should toggle the sibling sub nav', function() {
-      expect( $( '.sub-nav-1' ).attr( 'aria-expanded' ) ).to.equal( 'true' );
+      expect( document.querySelector( '.sub-nav-1' )
+        .getAttribute( 'aria-expanded' ) ).to.equal( 'true' );
     } );
 
     it( 'should not toggle a non-sibling sub nav', function() {
-      expect( $( '.sub-nav-2' ).attr( 'aria-expanded' ) ).to.equal( 'false' );
+      expect( document.querySelector( '.sub-nav-2' )
+        .getAttribute( 'aria-expanded' ) ).to.equal( 'false' );
     } );
 
     it( 'should focus the first link in the sibling sub nav', function( done ) {
       setTimeout( function() { // eslint-disable-line max-nested-callbacks, no-inline-comments, max-len
-        expect( $link.is( ':focus' ) ).to.be.true;
+        expect( link === document.activeElement ).to.be.true;
         done();
       }, 500 );
     } );
 
     it( 'should not focus the first link in a non-sibling sub nav',
       function( done ) {
-        var $nextlink = $( $( '.sub-nav-2' ).find( 'a' )[0] );
+        var nextlink = document.querySelector( '.sub-nav-2 a' );
 
         setTimeout( function() { // eslint-disable-line max-nested-callbacks, no-inline-comments, max-len
-          expect( $nextlink.is( ':focus' ) ).to.be.false;
+          expect( nextlink === document.activeElement ).to.be.false;
           done();
         }, 500 );
       } );
@@ -87,45 +87,48 @@ describe( 'Get Event States', function() {
 
   describe( 'Primary Nav Link Events - One expanded', function() {
     beforeEach( function() {
-      $link = $( $( '.sub-nav-2' ).find( 'a' )[0] );
+      link = document.querySelector( '.sub-nav-2 a' );
 
-      $( '.sub-nav-1' ).attr( 'aria-expanded', 'true' );
-      $( '.nav-link-2' ).trigger( 'click' );
+      document.querySelector( '.sub-nav-1' ).getAttribute( 'aria-expanded', 'true' );
+      document.querySelector( '.nav-link-2' ).dispatchEvent( new Event( 'click', { 'bubbles': true } ) );
     } );
 
     it( 'should close others', function() {
-      expect( $( '.sub-nav-1' ).attr( 'aria-expanded' ) ).to.equal( 'false' );
+      expect( document.querySelector( '.sub-nav-1' )
+        .getAttribute( 'aria-expanded' ) ).to.equal( 'false' );
     } );
 
     it( 'should open the sibling sub nav', function( done ) {
       setTimeout( function() { // eslint-disable-line max-nested-callbacks, no-inline-comments, max-len
-        expect( $( '.sub-nav-2' ).attr( 'aria-expanded' ) ).to.equal( 'true' );
+        expect( document.querySelector( '.sub-nav-2' )
+          .getAttribute( 'aria-expanded' ) ).to.equal( 'true' );
         done();
       }, 500 );
     } );
 
     it( 'should focus the first link in sibling sub nav', function( done ) {
       setTimeout( function() { // eslint-disable-line max-nested-callbacks, no-inline-comments, max-len
-        expect( $link.is( ':focus' ) ).to.be.true;
+        expect( link === document.activeElement ).to.be.true;
         done();
       }, 500 );
     } );
 
     it( 'should close itself', function( done ) {
       setTimeout( function() { // eslint-disable-line max-nested-callbacks, no-inline-comments, max-len
-        $( '.nav-link-2' ).trigger( 'click' );
+        document.querySelector( '.nav-link-2' ).dispatchEvent( new Event( 'click', { 'bubbles': true } ) );
 
-        expect( $( '.sub-nav-2' ).attr( 'aria-expanded' ) ).to.equal( 'false' );
+        expect( document.querySelector( '.sub-nav-2' )
+          .getAttribute( 'aria-expanded' ) ).to.equal( 'false' );
         done();
       }, 500 );
     } );
 
     it( 'should focus the primary link after closing', function( done ) {
       setTimeout( function() { // eslint-disable-line max-nested-callbacks, no-inline-comments, max-len
-        $( '.nav-link-2' ).trigger( 'click' );
+        document.querySelector( '.nav-link-2' ).dispatchEvent( new Event( 'click', { 'bubbles': true } ) );
 
         setTimeout( function() { // eslint-disable-line max-nested-callbacks, no-inline-comments, max-len
-          expect( $( '.nav-link-2' ).is( ':focus' ) ).to.be.true;
+          expect( document.querySelector( '.nav-link-2' ) === document.activeElement ).to.be.true;
           done();
         }, 500 );
       }, 500 );
@@ -134,35 +137,38 @@ describe( 'Get Event States', function() {
 
   describe( 'Primary Nav Trigger Events', function() {
     beforeEach( function() {
-      $link = $( '.nav-link-1' );
+      link = document.querySelector( '.nav-link-1' );
 
-      $( '.js-primary-nav_trigger' ).trigger( 'click' );
+      document.querySelector( '.js-primary-nav_trigger' ).dispatchEvent( new Event( 'click' ) );
     } );
 
     it( 'should open the primary nav', function() {
-      expect( $( '.js-primary-nav' ).attr( 'aria-expanded' ) )
+      expect( document.querySelector( '.js-primary-nav' )
+        .getAttribute( 'aria-expanded' ) )
         .to.equal( 'true' );
     } );
 
     it( 'should focus the first primary link', function( done ) {
       setTimeout( function() { // eslint-disable-line max-nested-callbacks, no-inline-comments, max-len
-        expect( $link.is( ':focus' ) ).to.be.true;
+        expect( link === document.activeElement ).to.be.true;
         done();
       }, 500 );
     } );
 
     it( 'should close the open primary nav', function() {
-      $( '.js-primary-nav_trigger' ).trigger( 'click' );
+      document.querySelector( '.js-primary-nav_trigger' ).dispatchEvent( new Event( 'click' ) );
 
-      expect( $( '.js-primary-nav' ).attr( 'aria-expanded' ) )
+      expect( document.querySelector( '.js-primary-nav' )
+        .getAttribute( 'aria-expanded' ) )
         .to.equal( 'false' );
     } );
 
     it( 'should focus the trigger after closing', function( done ) {
-      $( '.js-primary-nav_trigger' ).trigger( 'click' );
+      document.querySelector( '.js-primary-nav_trigger' ).dispatchEvent( new Event( 'click' ) );
 
       setTimeout( function() { // eslint-disable-line max-nested-callbacks, no-inline-comments, max-len
-        expect( $( '.js-primary-nav_trigger' ).is( ':focus' ) ).to.be.true;
+        expect( document.querySelector( '.js-primary-nav_trigger' ) === document.activeElement )
+          .to.be.true;
         done();
       }, 500 );
     } );
@@ -170,19 +176,21 @@ describe( 'Get Event States', function() {
 
   describe( 'Sub Nav Back Events', function() {
     beforeEach( function() {
-      $link = $( '.nav-link-1' );
+      link = document.querySelector( '.nav-link-1' );
 
-      $( '.sub-nav-1' ).attr( 'aria-expanded', 'true' );
-      $( '.sub-nav-back-1' ).trigger( 'click' );
+      document.querySelector( '.sub-nav-1' ).getAttribute( 'aria-expanded', 'true' );
+      document.querySelector( '.sub-nav-back-1' ).dispatchEvent( new Event( 'click' ) );
     } );
 
     it( 'should close the sub nav', function() {
-      expect( $( '.sub-nav-1' ).attr( 'aria-expanded' ) ).to.equal( 'false' );
+      expect( document.querySelector( '.sub-nav-1' )
+        .getAttribute( 'aria-expanded' ) )
+        .to.equal( 'false' );
     } );
 
     it( 'should focus the primary link after closing', function( done ) {
       setTimeout( function() { // eslint-disable-line max-nested-callbacks, no-inline-comments, max-len
-        expect( $link.is( ':focus' ) ).to.be.true;
+        expect( link === document.activeElement ).to.be.true;
         done();
       }, 500 );
     } );

--- a/test/unit_tests/modules/util/expanded-state-spec.js
+++ b/test/unit_tests/modules/util/expanded-state-spec.js
@@ -8,20 +8,21 @@ var expect = chai.expect;
 var jsdom = require( 'mocha-jsdom' );
 
 describe( 'Event States', function() {
-  var $, es, sandbox, divExpanded, divClosed, openMenu;
+  var expandedState, sandbox, divExpanded, divClosed, openMenu;
 
   jsdom();
 
   before( function() {
-    $ = require( 'jquery' );
-    es = require( BASE_JS_PATH + 'modules/util/expanded-state.js' );
+    expandedState = require( BASE_JS_PATH + 'modules/util/expanded-state.js' );
     sandbox = sinon.sandbox.create();
   } );
 
   beforeEach( function() {
-    divExpanded = $( '<div class="div-expanded" aria-expanded="true" />' );
-    divClosed = $( '<div class="div-closed" aria-expanded="false" />' );
-    openMenu = $( [] ).add( divClosed ).add( divExpanded );
+    document.body.innerHTML = '<div class="div-expanded" aria-expanded="true" />' +
+                              '<div class="div-closed" aria-expanded="false" />';
+    divExpanded = document.querySelector( '.div-expanded' );
+    divClosed = document.querySelector( '.div-closed' );
+    openMenu = document.querySelectorAll( 'div' );
   } );
 
   afterEach( function() {
@@ -30,51 +31,51 @@ describe( 'Event States', function() {
 
   describe( 'get expanded state', function() {
     it( 'should return true when expanded', function() {
-      expect( es.get.isThisExpanded( divExpanded ) ).to.be.true;
+      expect( expandedState.isThisExpanded( divExpanded ) ).to.be.true;
     } );
 
     it( 'should return false when closed', function() {
-      expect( es.get.isThisExpanded( divClosed ) ).to.be.false;
+      expect( expandedState.isThisExpanded( divClosed ) ).to.be.false;
     } );
 
     it( 'should return true if at least one is expanded', function() {
-      var testExpandedDivs = $( [] ).add( divClosed ).add( divExpanded );
+      var testExpandedDivs = document.querySelectorAll( 'div' );
 
-      expect( es.get.isOneExpanded( testExpandedDivs ) ).to.be.true;
+      expect( expandedState.isOneExpanded( testExpandedDivs ) ).to.be.true;
     } );
 
     it( 'should return false if at least one isn’t expanded', function() {
-      var testClosedDivs = $( [] ).add( divClosed ).add( divClosed );
-
-      expect( es.get.isOneExpanded( testClosedDivs ) ).to.be.false;
+      var testClosedDivs = document.querySelectorAll( 'div' );
+      for ( var i = 0, len = testClosedDivs.length; i < len; i++ ) {
+        expect( expandedState.isOneExpanded( testClosedDivs[i] ) ).to.be.false;
+      }
     } );
   } );
 
-
   describe( 'set expanded state - default state', function() {
     it( 'should toggle a closed div open', function() {
-      es.set.toggleExpandedState( divClosed );
-      expect( es.get.isThisExpanded( divClosed ) ).to.be.true;
+      expandedState.toggleExpandedState( divClosed );
+      expect( expandedState.isThisExpanded( divClosed ) ).to.be.true;
     } );
 
     it( 'should toggle an open div closed', function() {
-      es.set.toggleExpandedState( divExpanded );
-      expect( es.get.isThisExpanded( divExpanded ) ).to.be.false;
+      expandedState.toggleExpandedState( divExpanded );
+      expect( expandedState.isThisExpanded( divExpanded ) ).to.be.false;
     } );
 
     it( 'should use null state to toggle an open div closed', function() {
-      es.set.toggleExpandedState( divExpanded, null );
-      expect( es.get.isThisExpanded( divExpanded ) ).to.be.false;
+      expandedState.toggleExpandedState( divExpanded, null );
+      expect( expandedState.isThisExpanded( divExpanded ) ).to.be.false;
     } );
 
     it( 'should use false state to close an open div', function() {
-      es.set.toggleExpandedState( divExpanded, 'false' );
-      expect( es.get.isThisExpanded( divExpanded ) ).to.be.false;
+      expandedState.toggleExpandedState( divExpanded, 'false' );
+      expect( expandedState.isThisExpanded( divExpanded ) ).to.be.false;
     } );
 
     it( 'should use true state to open a closed div', function() {
-      es.set.toggleExpandedState( divClosed, 'true' );
-      expect( es.get.isThisExpanded( divClosed ) ).to.be.true;
+      expandedState.toggleExpandedState( divClosed, 'true' );
+      expect( expandedState.isThisExpanded( divClosed ) ).to.be.true;
     } );
   } );
 
@@ -84,15 +85,19 @@ describe( 'Event States', function() {
     } );
 
     it( 'should close all open divs', function() {
-      es.set.toggleExpandedState( openMenu, 'false' );
-      expect( es.get.isOneExpanded( openMenu ) ).to.be.false;
+      for ( var i = 0, len = openMenu.length; i < len; i++ ) {
+        expandedState.toggleExpandedState( openMenu[i], 'false' );
+        expect( expandedState.isOneExpanded( openMenu[i] ) ).to.be.false;
+      }
     } );
 
     it( 'should fire a callback after toggling', function( done ) {
-      es.set.toggleExpandedState( openMenu, null, function() { // eslint-disable-line max-nested-callbacks, no-inline-comments, max-len
-        expect( es.get.isThisExpanded( divClosed ) ).to.be.true;
-        done();
-      } );
+      for ( var i = 0, len = openMenu.length; i < len; i++ ) {
+        expandedState.toggleExpandedState( openMenu[i], null, function() { // eslint-disable-line no-loop-func, no-inline-comments, max-len
+          expect( expandedState.isThisExpanded( divClosed ) ).to.be.true;
+          done();
+        } );
+      }
     } );
   } );
 } );


### PR DESCRIPTION
Prep for global search to share JS with nav.

## Additions

- `dom-traverse.js` for dom querying not covered by native dom.

## Changes

- removes jquery from primary nav JS and replaces with native querying.

## Testing

- Resize site to mobile size and navigate primary menu. Should work as before.

## Review

- @KimberlyMunoz 
- @sebworks 
