### PR TITLE
Fixing initial load state of Filter

### DIFF
--- a/cfgov/unprocessed/css/molecules/expandable.less
+++ b/cfgov/unprocessed/css/molecules/expandable.less
@@ -164,6 +164,17 @@
     }
 }
 
+// Setting height to prevent flash on load.
+.m-expandable_content:not([aria-expanded='true']) {
+    height: 0;
+}
+
+.no-js {
+    .m-expandable_content:not([aria-expanded='true']) {
+        height: 100%;
+    }
+}
+
 .m-expandable {
     // Modifiers
     &__borders {


### PR DESCRIPTION
Fixing initial load state of Filter

## Changes

-  Modified `cfgov/unprocessed/css/molecules/expandable.less` to target `.m-expandable_content[aria-expanded='true']`

## Testing

- Visit `http://localhost:8000/browse-filterable/` and turn your js off. 

## Review
- @anselmbradford 
- @KimberlyMunoz 
