### PR TITLE
Permissions Error

### DIFF
--- a/cfgov/v1/templatetags/share.py
+++ b/cfgov/v1/templatetags/share.py
@@ -29,7 +29,6 @@ def staging_url(context, page):
 
 @register.assignment_tag(takes_context=True)
 def v1page_permissions(context, page):
-    page = page.specific
     if 'user_page_permissions' not in context:
         context['user_page_permissions'] = CFGOVUserPagePermissionsProxy(context['request'].user)
 


### PR DESCRIPTION
checks permissions for all page types. creates an error when pages don't exist.

@kurtw 

### Testing
- Start from a fresh database, and create any kind of page i.e landing page.
- Log out => Log back in and try to access your landing page
![screen shot 2016-01-04 at 9 30 52 am](https://cloud.githubusercontent.com/assets/254877/12091574/ecf1f332-b2c5-11e5-91fc-7e50d01f381b.png)


```
DoesNotExist at /admin/pages/2/
EventRequestSpeakerPage matching query does not exist.
Request Method:	GET
Request URL:	http://localhost:8000/admin/pages/2/
Django Version:	1.8.7
Exception Type:	DoesNotExist
Exception Value:	
EventRequestSpeakerPage matching query does not exist.
```