### PR TITLE
Updates gulp-load-plugins to 1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -242,6 +242,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Upgrade version of Wagtail to 1.3
 - Change method of CFGOVPage called `children` to be called `elements`
 - Moved html5shiv into modernizr.
+- Updated `gulp-load-plugins` to `1.2.0` from `1.1.0`.
 
 ### Removed
 - Removed unused exportsOverride section,

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "gulp-cssmin": "^0.1.7",
     "gulp-header": "^1.2.2",
     "gulp-less": "^3.0.3",
-    "gulp-load-plugins": "^1.1.0",
+    "gulp-load-plugins": "^1.2.0",
     "gulp-imagemin": "^2.3.0",
     "gulp-modernizr": "^1.0.0-alpha",
     "gulp-mq-remove": "0.0.2",


### PR DESCRIPTION
## Changes

- Updates gulp-load-plugins to 1.2.0. I don't get why the caret isn't autoupdating this, but it isn't.

## Review

- @jimmynotjim 
- @sebworks 
- @KimberlyMunoz 