### PR TITLE
Fixing wagtail and style bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -144,6 +144,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - `dom-traverse.js` for dom querying not covered by native dom.
 - Added Backend Learn Page model
 - Added Related Topics molecule.
+- Added full_width_sans setting for correct font face usage.
 
 ### Changed
 - Updated the primary nav to move focus as user enters and leaves nav levels
@@ -271,6 +272,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Fix failing tests relating to Related Posts organism
 - Fix related-posts.html logic
 - Minor PEP8 compliance changes
+- Fixed the markup for the 25/75 organism.
 
 
 ## 3.0.0-2.4.0 - 2015-09-29

--- a/cfgov/jinja2/v1/_includes/molecules/image-text-25-75.html
+++ b/cfgov/jinja2/v1/_includes/molecules/image-text-25-75.html
@@ -27,12 +27,15 @@
 
 {% if not value %}
     {% set lipsumText = lipsum(1, false, 10, 25) | safe %}
+    {% macro _lipsum_paragraph() %}
+        <p>{{ lipsumText }}</p>
+    {% endmacro %}
     {% do global_dict.update(
         {
             'image_text_25_75': {
                 'heading' :       'Placeholder',
                 'body': {
-                    'source': lipsumText
+                    'source': _lipsum_paragraph()
                 },
                 'image': {
                       'upload': {
@@ -81,7 +84,9 @@
 
     <div class="m-image-text-25-75_content">
         <h3>{{ value.heading }}</h3>
-        <p class="short-desc">{{ value.body.source | safe }}</p>
+        <div class="short-desc">
+            {{ value.body.source }}
+        </div>
 
         <ul class="list list__links">
             {% for link in value.links %}

--- a/cfgov/jinja2/v1/_includes/organisms/full-width-text.html
+++ b/cfgov/jinja2/v1/_includes/organisms/full-width-text.html
@@ -30,12 +30,6 @@
                             <li>Lorem ipsum dolor sit amet</li>
                             <li>Lorem ipsum dolor sit amet</li>
                         </ul>
-                        <p>
-                            Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-                            Sed metus tortor, lacinia vel arcu a, convallis consequat
-                            velit. Nam non turpis ac leo porta elementum id euismod
-                            erat. Nullam pretium purus ac ultricies pharetra.
-                        </p>
                     """,
                 }
             },
@@ -47,6 +41,12 @@
                 'block_type': 'content',
                 'value': {
                     'source': """
+                        <p>
+                            Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+                            Sed metus tortor, lacinia vel arcu a, convallis consequat
+                            velit. Nam non turpis ac leo porta elementum id euismod
+                            erat. Nullam pretium purus ac ultricies pharetra.
+                        </p>
                         <p>
                             Lorem ipsum dolor sit amet, consectetur adipiscing elit.
                             Sed metus tortor, lacinia vel arcu a, convallis consequat
@@ -85,7 +85,9 @@
 <div class="o-full-width-text-group">
     {% for block in value %}
         {% if 'content' in block.block_type %}
-            <div class="m-full-width-text">
+            <div class="m-full-width-text
+                        {{ 'm-full-width-text__sans' if
+                        full_width_sans else '' }}">
                 {{ block.value.source | safe }}
             </div>
         {% else %}

--- a/cfgov/jinja2/v1/browse-basic/index.html
+++ b/cfgov/jinja2/v1/browse-basic/index.html
@@ -50,6 +50,11 @@
         </div>
     {%- endfor %}
 
+    <div class="block">
+        {% set full_width_sans = true %}
+        {% include 'organisms/full-width-text.html' with context %}
+    </div>
+
     {% for block in page.content -%}
         <div class="block">
             {{ render_stream_child(block) }}

--- a/cfgov/jinja2/v1/document-detail/index.html
+++ b/cfgov/jinja2/v1/document-detail/index.html
@@ -70,7 +70,8 @@
         {# Area 2 #}
         <div class="block">
             {# NOTE: includes Bulleted List and Inset molecules. #}
-            {% include 'organisms/full-width-text.html' %}
+            {% set full_width_sans = true %}
+            {% include 'organisms/full-width-text.html' with context %}
         </div>
         <div class="block">
             {% include 'organisms/table.html' %}

--- a/cfgov/jinja2/v1/sublanding-page/index.html
+++ b/cfgov/jinja2/v1/sublanding-page/index.html
@@ -86,7 +86,8 @@
             {% include 'organisms/half-width-link-blob-group.html' %}
         </div>
         <div class="block">
-            {% include 'organisms/full-width-text.html' %}
+            {% set full_width_sans = true %}
+            {% include 'organisms/full-width-text.html' with context %}
         </div>
         <div class="block">
             {{ main_contact_info.render({

--- a/cfgov/unprocessed/css/molecules/full-width-text.less
+++ b/cfgov/unprocessed/css/molecules/full-width-text.less
@@ -6,10 +6,15 @@
       markup: |
         <div class="o-full-width-text-group">
             <div class="m-full-width-text">
-              <ul>
-                <li>Gray Well</li>
-                <li>Well's content</li>
-              </ul>
+                <h2>Full Width Text Molecule</h2>
+                <p>The full width text molecule contains headings,
+                paragraphs, lists or a grey line rule</p>
+                <ul>
+                    <li>Should always default to text styling and spacing
+                    dictated in the Design Manual</li>
+                    <li>Convert the font-face from Georgia to Avenir by using
+                    the `__sans` modifier</li>
+                </ul>
             </div>
         </div>
       codenotes:
@@ -18,28 +23,20 @@
           -----------------------
           .o-full-width-text
             .m-full-width-text
+              h#
+              p
               ul
                 li
   tags:
     - cfgov-molecules
   notes:
-    - Since content will be entered by content managers,
-      these styles are applied on the ul li elements directly when needed.
     - These are held in a full-width-text-group container to be held with
       various insets and tables as needed.
 */
 
 .m-full-width-text {
-    ul {
-        padding-left: unit(30px / @base-font-size-px, em);
-        li {
-            .custom-bullet( @text:"\25AA",
-                            @color: @black,
-                            @offset: unit(15px / @base-font-size-px, em),
-                            @size: unit(22px / @base-font-size-px, em)
-                          );
-            margin-bottom: unit( @grid_gutter-width / @base-font-size-px, em );
-        }
+    &__sans {
+        .webfont-regular();
     }
 }
 


### PR DESCRIPTION
Fixes bugs reported in #1304 and #1206

## Removals

- List style modifications (now defaults to CF styles)

## Changes

- Added `sans` modifier option to global dict (this is temporary, BEWDs should plan on this changing to a `serif` modifier)

## Testing

- navigate to `/sublanding-page/`

## Review

- @kave 
- @tnferrell 
- @KimberlyMunoz 
- @anselmbradford 
- @sebworks 

## Screenshots

![screen shot 2016-01-06 at 3 30 56 pm](https://cloud.githubusercontent.com/assets/1280430/12153913/80118202-b48a-11e5-8cf6-bd4533e57d6d.png)

![screen shot 2016-01-06 at 3 31 26 pm](https://cloud.githubusercontent.com/assets/1280430/12153922/9280c5ec-b48a-11e5-932c-3611009f6e2b.png)

## Notes

- @duelj and I discussed the font-family of full-width-text and according to the latest decisions, the font-family should be Avenir (sans-serif) on all full-width-text molecules except learn pages (blog, newsroom, events, etc).

- I discussed changing the default font-family to Avenir with the rest of the v1 FEWDs and we agreed it makes the most sense, but want to bring it up with all FEWDs and possibly Designers in the Design Manual (@duelj has an [open issue already](https://github.com/cfpb/design-manual/issues/347#issuecomment-149667820))

- We could eliminate a lot of styles that are currently setting the font-family to Avenir

## Todos

- [ ] Convert the default `body` font-family to Avenir and utilize a `serif` modifier to convert large chunks of text to Georgia.

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices 
* [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)