### PR TITLE
Fixes to spacing on 50-50 and 25-75 text-image molecules

### DIFF
--- a/cfgov/jinja2/v1/_includes/molecules/image-text-50-50.html
+++ b/cfgov/jinja2/v1/_includes/molecules/image-text-50-50.html
@@ -56,8 +56,11 @@
     {% set value = global_dict.image_text_50_50 %}
     {% set prototype = true %}
 {% endif %}
-<div class="m-image-text-50-50
-            {{ 'm-image-text-50-50__bottom-rule' if value.has_rule else '' }}">
+<div class="m-image-text-50-50">
+    {# TODO: Change to HR #}
+    {% if value.has_rule %}
+        <div class="a-rule-break"></div>
+    {% endif %}
 
     <div class="{{ 'm-image-text-50-50_widescreen-container' if value.is_widescreen
             else 'm-image-text-50-50_container'}}">

--- a/cfgov/unprocessed/css/molecules/image-text-25-75.less
+++ b/cfgov/unprocessed/css/molecules/image-text-25-75.less
@@ -87,6 +87,10 @@
                                  @grid_gutter-width ) / @base-font-size-px, em );
         } );
     }
+
+    &:last-child {
+        padding: 0;
+    }
 }
 
 /* topdoc

--- a/cfgov/unprocessed/css/molecules/image-text-50-50.less
+++ b/cfgov/unprocessed/css/molecules/image-text-50-50.less
@@ -82,7 +82,8 @@
 */
 
 .m-image-text-50-50 {
-    padding-bottom: unit( @grid_gutter-width * 2 / @base-font-size-px, em );
+
+    margin-bottom: unit( @grid_gutter-width * 2 / @base-font-size-px, em );
 
     &_container {
         height: 150px;
@@ -119,10 +120,6 @@
         });
     }
 
-    &__bottom-rule {
-        border-bottom: 1px solid @m-image-text-50-50_rule;
-        margin-bottom: unit( @grid_gutter-width / @base-font-size-px, em );
-    }
     .respond-to-min(@bp-sm-min, {
         .grid_column(6);
     });

--- a/cfgov/unprocessed/css/organisms/image-text-50-50-group.less
+++ b/cfgov/unprocessed/css/organisms/image-text-50-50-group.less
@@ -16,10 +16,18 @@
     - cfgov-molecules
 */
 .o-image-text-50-50-group {
+    // TODO: Find another way to handle spacing
+    margin-bottom: unit( @grid_gutter-width * -2 / @base-font-size-px, em );
+
     .respond-to-min(@bp-sm-min, {
         margin-left: -@grid_gutter-width / 2;
         margin-right: -@grid_gutter-width / 2;
     });
+
+    > h2 {
+        margin-left: @grid_gutter-width / 2;
+        margin-right: @grid_gutter-width / 2;
+    }
 }
 
 /* topdoc


### PR DESCRIPTION
Fixes #1235 by removing the spacing from the molecule to have it handled by `.block` and fixing the spacing on the header for the 50-50 molecule.

![image](https://cloud.githubusercontent.com/assets/1860176/12158011/31f9bc14-b4a4-11e5-8709-f5cc788c949c.png)

## Review
- @jimmynotjim 
- @anselmbradford 
- @sebworks
