### PR TITLE
DB data initialization

### DIFF
--- a/.env_SAMPLE
+++ b/.env_SAMPLE
@@ -16,6 +16,7 @@ export STAGING_HOSTNAME='content.localhost'
 
 #export PDFREACTOR_LICENSE=<license_key>
 #export PDFREACTOR_LIB=<python_wrapper_lib_path>
+#export ADMIN_PW=<admin_user_password>
 
 ############################
 # Mysql Database Server.

--- a/.env_SAMPLE
+++ b/.env_SAMPLE
@@ -16,7 +16,7 @@ export STAGING_HOSTNAME='content.localhost'
 
 #export PDFREACTOR_LICENSE=<license_key>
 #export PDFREACTOR_LIB=<python_wrapper_lib_path>
-#export ADMIN_PW=<admin_user_password>
+#export WAGTAIL_ADMIN_PW=<wagtail_admin_user_password>
 
 ############################
 # Mysql Database Server.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -247,6 +247,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Moved html5shiv into modernizr.
 - Updated `gulp-load-plugins` to `1.2.0` from `1.1.0`.
 - Included breadcrumb data from page context
+- Added development environment data initialization
 
 ### Removed
 - Removed unused exportsOverride section,

--- a/backend.sh
+++ b/backend.sh
@@ -69,6 +69,10 @@ build(){
   pip install tox
 
   dbsetup
+
+  if [ "$cli_flag" = "development" ]; then
+    ./initial-data.sh
+  fi
 }
 
 # Setup MYSQL Server.

--- a/cfgov/v1/migrations/0031_init_data.py
+++ b/cfgov/v1/migrations/0031_init_data.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+import os
+
+from django.contrib.auth.hashers import make_password
+from django.contrib.auth.models import User
+from django.db import migrations, models
+from django.conf import settings
+
+from ..models.events import EventLandingPage
+from ..models.base import CFGOVPage
+
+from wagtail.wagtailcore.models import Page
+
+
+def initial_data(apps, schema_editor):
+    if settings.DEBUG:
+        admin_user = User(username='admin',
+                          password=make_password(os.environ.get('ADMIN_PW')),
+                          is_superuser=True, is_active=True, is_staff=True)
+        admin_user.save()
+
+        # Renaming Site root name to `V1`
+        site_root = Page.objects.get(id=2)
+        site_root.title = 'V1'
+        site_root.save()
+
+        # Events Landing Page required for event `import-data` command
+        events = EventLandingPage(title='Events', slug='events')
+        site_root.add_child(instance=events)
+        revision = events.save_revision(
+            user=admin_user,
+            submitted_for_moderation=False,
+        )
+        revision.publish()
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('v1', '0030_documentdetailpage'),
+    ]
+
+    operations = [
+        migrations.RunPython(initial_data)
+    ]

--- a/initial-data.sh
+++ b/initial-data.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+# ==========================================================================
+# Setup script for installing project dependencies.
+# NOTE: Run this script while in the project root directory.
+#       It will not run correctly when run from another directory.
+# ==========================================================================
+
+# Set script to exit on any errors.
+set -e
+
+# Import Data
+import_data(){
+    echo 'Creating DB Tables and initial data..'
+    ./cfgov/manage.py migrate
+    echo 'Importing Events...'
+    ./cfgov/manage.py import-data contact contact --snippet -u admin -p $ADMIN_PW
+    echo 'Importing Contacts...'
+    ./cfgov/manage.py import-data events eventpage --parent events -u admin -p $ADMIN_PW
+}
+
+import_data

--- a/initial-data.sh
+++ b/initial-data.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # ==========================================================================
-# Setup script for installing project dependencies.
+# Initialization script for a wagtail user and imported data
 # NOTE: Run this script while in the project root directory.
 #       It will not run correctly when run from another directory.
 # ==========================================================================


### PR DESCRIPTION
It was bothering me how many times i had to recreate my admin user every-time i dropped my db during branch switching. This data initialization should be helpful and it'll load the event pages & contacts from ES

### Added
- Data initialization script

### Changed
- Appended data initialization during debug mode of `./setup.sh`

### Test
- set environment variable `WAGTAIL_ADMIN_PW`
- drop database
- run `./create-mysql-db.sh`
- run `./initial-data.sh`
- log into wagtail

@anselmbradford 
@jimmynotjim 
@sebworks 
@KimberlyMunoz 
@rosskarchner 
@kurtw 