### PR TITLE
Added CFGOVImage and CFGOVRendition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -148,7 +148,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Added a new nav-link molecule macro and styles.
 - Added Related Links to Sidebar/Footer.
 - Added Related Metadata molecule.
-
+- Added custom image and rendition models CFGOVImage and CFGOVRendition
 
 ### Changed
 - Updated the primary nav to move focus as user enters and leaves nav levels

--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -154,6 +154,7 @@ ALLOWED_HOSTS = ['*']
 # Wagtail settings
 
 WAGTAIL_SITE_NAME = 'v1'
+WAGTAILIMAGES_IMAGE_MODEL = 'v1.CFGOVImage'
 
 SHEER_SITES = [V1_TEMPLATE_ROOT]
 SHEER_ELASTICSEARCH_SERVER = os.environ.get('ES_HOST', 'localhost') + ':' + os.environ.get('ES_PORT', '9200')

--- a/cfgov/v1/migrations/0032_cfgovimage_cfgovrendition.py
+++ b/cfgov/v1/migrations/0032_cfgovimage_cfgovrendition.py
@@ -1,0 +1,78 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import wagtail.wagtailadmin.taggable
+import wagtail.wagtailimages.models
+import django.db.models.deletion
+from django.conf import settings
+import taggit.managers
+
+
+def migrate_images_data(apps, schema_editor):
+    CFGOVImageModel = apps.get_model('v1.CFGOVImage')
+    UserModel = apps.get_model(settings.AUTH_USER_MODEL)
+
+    # Migrate image data
+    for image in wagtail.wagtailimages.models.Image.objects.all():
+        new_image = CFGOVImageModel()
+        for field in ['title', 'file', 'width', 'height', 'focal_point_x',
+                      'focal_point_y', 'focal_point_width',
+                      'focal_point_height', 'file_size', 'tags']:
+            value = getattr(image, field)
+            setattr(new_image, field, value)
+        user = UserModel.objects.get(id=image.uploaded_by_user.id)
+        new_image.uploaded_by_user = user
+        new_image.save()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('taggit', '0002_auto_20150616_2121'),
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+        ('wagtailimages', '0010_change_on_delete_behaviour'),
+        ('v1', '0031_addrelatedlinks_sidefoot'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='CFGOVImage',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('title', models.CharField(max_length=255, verbose_name='title')),
+                ('file', models.ImageField(height_field='height', upload_to=wagtail.wagtailimages.models.get_upload_to, width_field='width', verbose_name='file')),
+                ('width', models.IntegerField(verbose_name='width', editable=False)),
+                ('height', models.IntegerField(verbose_name='height', editable=False)),
+                ('created_at', models.DateTimeField(auto_now_add=True, verbose_name='created at', db_index=True)),
+                ('focal_point_x', models.PositiveIntegerField(null=True, blank=True)),
+                ('focal_point_y', models.PositiveIntegerField(null=True, blank=True)),
+                ('focal_point_width', models.PositiveIntegerField(null=True, blank=True)),
+                ('focal_point_height', models.PositiveIntegerField(null=True, blank=True)),
+                ('file_size', models.PositiveIntegerField(null=True, editable=False)),
+                ('alt', models.CharField(max_length=100, blank=True)),
+                ('tags', taggit.managers.TaggableManager(to='taggit.Tag', through='taggit.TaggedItem', blank=True, help_text=None, verbose_name='tags')),
+                ('uploaded_by_user', models.ForeignKey(on_delete=django.db.models.deletion.SET_NULL, blank=True, editable=False, to=settings.AUTH_USER_MODEL, null=True, verbose_name='uploaded by user')),
+            ],
+            options={
+                'abstract': False,
+            },
+            bases=(models.Model, wagtail.wagtailadmin.taggable.TagSearchable),
+        ),
+        migrations.CreateModel(
+            name='CFGOVRendition',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('file', models.ImageField(height_field='height', width_field='width', upload_to='images')),
+                ('width', models.IntegerField(editable=False)),
+                ('height', models.IntegerField(editable=False)),
+                ('focal_point_key', models.CharField(default='', max_length=255, editable=False, blank=True)),
+                ('filter', models.ForeignKey(related_name='+', to='wagtailimages.Filter')),
+                ('image', models.ForeignKey(related_name='renditions', to='v1.CFGOVImage')),
+            ],
+            options={
+                'abstract': False,
+            },
+        ),
+        migrations.RunPython(migrate_images_data),
+    ]

--- a/cfgov/v1/migrations/9999_init_data.py
+++ b/cfgov/v1/migrations/9999_init_data.py
@@ -37,7 +37,7 @@ def initial_data(apps, schema_editor):
 
 class Migration(migrations.Migration):
     dependencies = [
-        ('v1', '0031_addrelatedlinks_sidefoot'),
+        ('v1', '0032_cfgovimage_cfgovrendition'),
     ]
 
     operations = [


### PR DESCRIPTION
- Added data migration for old images saved under previous type.

@kave 
@rosskarchner 

## To Test
- **Before you run migrate** make sure you have images in your DB to see if they convert properly
- run migrate
- check images
- check to see if alt is there
- check to see if you can save alt data
- check that deletion deletes the instances from BOTH CFGOVImage and CFGOVRendition (just go into shell and query)