### PR TITLE
Image rendering issues in rich-text and San-serif fonts for Full-width-text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -248,6 +248,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Updated `gulp-load-plugins` to `1.2.0` from `1.1.0`.
 - Included breadcrumb data from page context
 - Added development environment data initialization
+- [Fixed 1320] (https://github.com/cfpb/cfgov-refresh/issues/1320)
 
 ### Removed
 - Removed unused exportsOverride section,

--- a/cfgov/jinja2/v1/_includes/organisms/full-width-text.html
+++ b/cfgov/jinja2/v1/_includes/organisms/full-width-text.html
@@ -87,8 +87,8 @@
         {% if 'content' in block.block_type %}
             <div class="m-full-width-text
                         {{ 'm-full-width-text__sans' if
-                        full_width_sans else '' }}">
-                {{ block.value.source | safe }}
+                        global_dict.full_width_sans else '' }}">
+                {{ render_stream_child(block) }}
             </div>
         {% else %}
             <div class="m-inset">

--- a/cfgov/jinja2/v1/_includes/organisms/sidebar-breakout.html
+++ b/cfgov/jinja2/v1/_includes/organisms/sidebar-breakout.html
@@ -96,7 +96,7 @@
                         </h2>
                     {% elif 'paragraph' in block.block_type %}
                         <div class="short-desc">
-                            {{ block.value.source | safe }}
+                            {{ block.value | safe }}
                         </div>
                     {% endif %}
                 {% endfor %}

--- a/cfgov/jinja2/v1/browse-basic/index.html
+++ b/cfgov/jinja2/v1/browse-basic/index.html
@@ -40,6 +40,8 @@
 {%- endblock %}
 
 {% block content_main %}
+    {% do global_dict.update({ 'full_width_sans': true }) %}
+
     <div class="block">
         {{ social_media.render() }}
     </div>
@@ -58,7 +60,6 @@
 
     {% if prototype %}
         <div class="block">
-            {% set full_width_sans = true %}
             {% include 'organisms/full-width-text.html' with context %}
 
             <div class="expandable-prototypes">

--- a/cfgov/jinja2/v1/browse-basic/index.html
+++ b/cfgov/jinja2/v1/browse-basic/index.html
@@ -60,7 +60,7 @@
 
     {% if prototype %}
         <div class="block">
-            {% include 'organisms/full-width-text.html' with context %}
+            {% include 'organisms/full-width-text.html' %}
 
             <div class="expandable-prototypes">
                 {% include 'molecules/expandable.html' with context %}

--- a/cfgov/jinja2/v1/browse-basic/index.html
+++ b/cfgov/jinja2/v1/browse-basic/index.html
@@ -50,11 +50,6 @@
         </div>
     {%- endfor %}
 
-    <div class="block">
-        {% set full_width_sans = true %}
-        {% include 'organisms/full-width-text.html' with context %}
-    </div>
-
     {% for block in page.content -%}
         <div class="block">
             {{ render_stream_child(block) }}
@@ -63,6 +58,9 @@
 
     {% if prototype %}
         <div class="block">
+            {% set full_width_sans = true %}
+            {% include 'organisms/full-width-text.html' with context %}
+
             <div class="expandable-prototypes">
                 {% include 'molecules/expandable.html' with context %}
 

--- a/cfgov/jinja2/v1/document-detail/index.html
+++ b/cfgov/jinja2/v1/document-detail/index.html
@@ -43,6 +43,7 @@
 {% set lipsumText = lipsum(1, false, 10, 25) | safe %}
 
 {% block content_main %}
+    {% do global_dict.update({ 'full_width_sans': true }) %}
     {% for block in page.header -%}
             <div class="block
                         block__flush-top">
@@ -70,7 +71,6 @@
         {# Area 2 #}
         <div class="block">
             {# NOTE: includes Bulleted List and Inset molecules. #}
-            {% set full_width_sans = true %}
             {% include 'organisms/full-width-text.html' with context %}
         </div>
         <div class="block">

--- a/cfgov/jinja2/v1/learn-page/index.html
+++ b/cfgov/jinja2/v1/learn-page/index.html
@@ -223,6 +223,7 @@
 {%- endblock %}
 
 {% block content_sidebar scoped -%}
+    {% do global_dict.update({ 'full_width_sans': false }) %}
     {% if prototype %}
         {{ related_posts.render(global_dict.related_posts_settings) }}
         {% include 'molecules/related-topics.html' %}

--- a/cfgov/jinja2/v1/sublanding-page/index.html
+++ b/cfgov/jinja2/v1/sublanding-page/index.html
@@ -112,8 +112,6 @@
     {% else %}
         {% for block in page.content -%}
             {% if loop.index == 1 %}
-                {% set full_width_sans = true %}
-
                 <div class="block
                             block__flush-top">
                     {{ render_stream_child(block) }}

--- a/cfgov/jinja2/v1/sublanding-page/index.html
+++ b/cfgov/jinja2/v1/sublanding-page/index.html
@@ -49,6 +49,7 @@
 {% endblock %}
 
 {% block content_main %}
+    {% do global_dict.update({ 'full_width_sans': true }) %}
     {% if prototype %}
         {% if not page.sidebar_breakout %}
             <div class="block">
@@ -86,7 +87,6 @@
             {% include 'organisms/half-width-link-blob-group.html' %}
         </div>
         <div class="block">
-            {% set full_width_sans = true %}
             {% include 'organisms/full-width-text.html' with context %}
         </div>
         <div class="block">
@@ -112,6 +112,8 @@
     {% else %}
         {% for block in page.content -%}
             {% if loop.index == 1 %}
+                {% set full_width_sans = true %}
+
                 <div class="block
                             block__flush-top">
                     {{ render_stream_child(block) }}


### PR DESCRIPTION
Resolved san-serif font for full-text elements during wagtail rendering 
fixed richtext fields not being able to render images

@jimmynotjim 

- [Fixed 1320] (https://github.com/cfpb/cfgov-refresh/issues/1320)
- completes https://github.com/cfpb/cfgov-refresh/issues/1304