### PR TITLE
Bugfix for jsdom errors in unit tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -248,6 +248,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Updated `gulp-load-plugins` to `1.2.0` from `1.1.0`.
 - Included breadcrumb data from page context
 - Added development environment data initialization
+- Pinned jQuery to `1.11.3` due to changes in `1.12.0` that cause errors in jsdom.
 
 ### Removed
 - Removed unused exportsOverride section,

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "handlebars": "^4.0.3",
     "jasmine-reporters": "^2.0.7",
     "jasmine-spec-reporter": "^2.4.0",
-    "jquery": "^1.11.3",
+    "jquery": "1.11.3",
     "jsdom": "^7.2.2",
     "lodash": "^3.10.0",
     "map-stream": "^0.0.6",


### PR DESCRIPTION
jQuery `1.12.0` changes cause jsdom to throw errors during unit tests.

## Changes

- Pinning jQuery version to fix jsdom errors during unit tests

## Testing

- run `./setup.sh` and `gulp test:unit:scripts`

## Review

- @sebworks 
- @anselmbradford 

## Todos

- Update jsdom to `8.0.0` when it's released and retest with jquery `1.12.0`

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices 
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)