### PR TITLE
Adds input-contains-label class

### DIFF
--- a/cfgov/jinja2/v1/browse-basic/index.html
+++ b/cfgov/jinja2/v1/browse-basic/index.html
@@ -185,6 +185,89 @@
         {% endfor %}
     {% endif %}
 
+
+    {# TODO: Remove the below when input-contains-label
+             class is added cf-enhancements. #}
+    <div class="block">
+        <div class="block">
+            <div class="input-contains-label">
+                <label for="search-input1"
+                       class="input-contains-label_before
+                              input-contains-label_before__search">
+                </label>
+                <label for="search-input1"
+                       class="input-contains-label_after
+                              input-contains-label_after__clear">
+                </label>
+                <input id="search-input1"
+                       type="text"
+                       value="This is some really long text to make sure that the button doesn't overlap the content in such a way that this input becomes unusable.">
+            </div>
+        </div>
+
+        <div class="block">
+            <div class="input-contains-label
+                        input__super">
+                <label for="search-input2"
+                       class="input-contains-label_before
+                              input-contains-label_before__search">
+                </label>
+                <label for="search-input2"
+                       class="input-contains-label_after
+                              input-contains-label_after__clear">
+                </label>
+                <input class="input__super"
+                       id="search-input2"
+                       type="text"
+                       value="This is some really long text to make sure that the button doesn't overlap the content in such a way that this input becomes unusable.">
+            </div>
+        </div>
+
+
+        <div class="input-with-btn">
+            <div class="input-with-btn_input
+                        input-contains-label">
+                <label for="search-input3"
+                       class="input-contains-label_before
+                              input-contains-label_before__search">
+                </label>
+                <label for="search-input3"
+                       class="input-contains-label_after
+                              input-contains-label_after__clear">
+                </label>
+                <input type="text"
+                       id="search-input3"
+                       value="This is some really long text to make sure that the button doesn't overlap the content in such a way that this input becomes unusable.">
+            </div>
+            <div class="input-with-btn_btn">
+                <button class="btn">Search</button>
+            </div>
+        </div>
+
+        <div class="input-with-btn">
+            <div class="input-with-btn_input
+                        input-contains-label
+                        input__super">
+                <label for="search-input4"
+                       class="input-contains-label_before
+                              input-contains-label_before__search">
+                </label>
+                <label for="search-input4"
+                       class="input-contains-label_after
+                              input-contains-label_after__clear">
+                </label>
+                <input class="input__super"
+                       type="text"
+                       id="search-input4"
+                       value="This is some really long text to make sure that the button doesn't overlap the content in such a way that this input becomes unusable.">
+            </div>
+            <div class="input-with-btn_btn">
+                <button class="btn btn__super">Search</button>
+            </div>
+        </div>
+
+    </div>
+
 {% endblock %}
 
 {% block content_sidebar scoped -%}

--- a/cfgov/unprocessed/css/cf-enhancements.less
+++ b/cfgov/unprocessed/css/cf-enhancements.less
@@ -1127,6 +1127,199 @@ textarea {
 }
 
 /* topdoc
+  name: Icon inside input
+  family: cf-forms
+  patterns:
+    - name: Default icons before and after a default input.
+      markup: |
+        <div class="input-contains-label">
+            <label for="search-input"
+                   class="input-contains-label_before
+                          input-contains-label_before__search">
+            </label>
+            <label for="search-input"
+                   class="input-contains-label_after
+                          input-contains-label_after__clear">
+            </label>
+            <input type="text"
+                   value="This is some really long text to make sure that the button doesn't overlap the content in such a way that this input becomes unusable.">
+        </div>
+    - name: Super-sized icons before and after a super input.
+      markup: |
+        <div class="input-contains-label
+                    input__super">
+            <label for="search-input"
+                   class="input-contains-label_before
+                          input-contains-label_before__search">
+            </label>
+            <label for="search-input"
+                   class="input-contains-label_after
+                          input-contains-label_after__clear">
+            </label>
+            <input class="input__super"
+                   type="text"
+                   value="This is some really long text to make sure that the button doesn't overlap the content in such a way that this input becomes unusable.">
+        </div>
+    - name: Default icons before and after a default input, with a button.
+      markup: |
+        <div class="input-with-btn">
+            <div class="input-with-btn_input
+                        input-contains-label">
+                <label for="search-input"
+                       class="input-contains-label_before
+                              input-contains-label_before__search">
+                </label>
+                <label for="search-input"
+                       class="input-contains-label_after
+                              input-contains-label_after__clear">
+                </label>
+                <input type="text"
+                       id="search-input"
+                       value="This is some really long text to make sure that the button doesn't overlap the content in such a way that this input becomes unusable.">
+            </div>
+            <div class="input-with-btn_btn">
+                <button class="btn">Search</button>
+            </div>
+        </div>
+    - name: Super-sized icons before and after a super input, with a button.
+      markup: |
+        <div class="input-with-btn">
+            <div class="input-with-btn_input
+                        input-contains-label
+                        input__super">
+                <label for="search-input"
+                       class="input-contains-label_before
+                              input-contains-label_before__search">
+                </label>
+                <label for="search-input"
+                       class="input-contains-label_after
+                              input-contains-label_after__clear">
+                </label>
+                <input class="input__super"
+                       type="text"
+                       id="search-input"
+                       value="This is some really long text to make sure that the button doesn't overlap the content in such a way that this input becomes unusable.">
+            </div>
+            <div class="input-with-btn_btn">
+                <button class="btn btn__super">Search</button>
+            </div>
+        </div>
+  tags:
+    - cf-forms
+*/
+
+.input-contains-label {
+    position: relative;
+
+    input[type="text"],
+    input[type="search"],
+    input[type="email"],
+    input[type="url"],
+    input[type="tel"],
+    input[type="number"] {
+        box-sizing: border-box;
+        width: 100%;
+    }
+
+    &_before ~ input[type="text"],
+    &_before ~ input[type="search"],
+    &_before ~ input[type="email"],
+    &_before ~ input[type="url"],
+    &_before ~ input[type="tel"],
+    &_before ~ input[type="number"] {
+        padding-left: unit( 25px / @btn-font-size, em );
+
+        &.input__super {
+            padding-left: unit( 35px / @super-btn-font-size, em );
+        }
+    }
+
+    &_after ~ input[type="text"],
+    &_after ~ input[type="search"],
+    &_after ~ input[type="email"],
+    &_after ~ input[type="url"],
+    &_after ~ input[type="tel"],
+    &_after ~ input[type="number"] {
+        padding-right: unit( 30px / @btn-font-size, em );
+
+        &.input__super {
+            padding-right: unit( 35px / @super-btn-font-size, em );
+        }
+    }
+
+    &_before,
+    &_after {
+        position: absolute;
+        top: unit( 7px / @btn-font-size, em );
+        cursor: pointer;
+        font-size: unit( @btn-font-size / @base-font-size-px, em );
+    }
+
+    &_before {
+        left: unit( 12px / @btn-font-size, em );
+    }
+
+    &_after {
+        right: unit( 14px / @btn-font-size, em );
+    }
+
+    &.input__super {
+        .input-contains-label_before,
+        .input-contains-label_after {
+            font-size: unit( @super-btn-font-size / @base-font-size-px, em );
+        }
+
+        .input-contains-label_before {
+            left: unit( 12px / @super-btn-font-size, em );
+        }
+
+        .input-contains-label_after {
+            right: unit( 12px / @super-btn-font-size, em );
+        }
+    }
+
+
+    // Specific adjustments for particular icon/label combinations.
+
+    // Example of icon without label.
+    // Add magnifying glass icon to input field.
+    &_before__search {
+        &:before {
+            .cf-icon();
+            content: @cf-icon-search;
+        }
+    }
+
+    // Example of icon + label.
+    // Add "x Clear" button to input field.
+    &_after__clear {
+        &:before {
+            .cf-icon();
+            content: @cf-icon-delete;
+        }
+
+        .respond-to-min( @bp-sm-min, {
+            &:after {
+                content: 'Clear';
+            }
+
+            & ~ input[type="text"],
+            & ~ input[type="search"],
+            & ~ input[type="email"],
+            & ~ input[type="url"],
+            & ~ input[type="tel"],
+            & ~ input[type="number"] {
+                padding-right: unit( 65px / @btn-font-size, em );
+
+                &.input__super {
+                    padding-right: unit( 80px / @super-btn-font-size, em );
+                }
+            }
+        } );
+    }
+}
+
+/* topdoc
   name: Reset all
   family: cf-core
   patterns:
@@ -1398,6 +1591,7 @@ select[multiple] {
         margin-bottom: unit(10px / @base-font-size-px, em);
     }
 }
+
 /* topdoc
     name: EOF
     eof: true


### PR DESCRIPTION
## Additions

- ~~`input-contains-icon`~~ `input-contains-label` for placing an icon in front and at the end of an input field, plus modifiers for specific icons.

## Testing

- Demo at bottom of `/browse-basic/`.

## Review

- @jimmynotjim 
- @sebworks 
- @KimberlyMunoz 

## Screenshots

Mobile:
<img width="359" alt="screen shot 2016-01-12 at 10 31 48 am" src="https://cloud.githubusercontent.com/assets/704760/12267774/b4f7b6c6-b917-11e5-85d1-b98d948c6c98.png">

Tablet:
<img width="562" alt="screen shot 2016-01-12 at 10 06 05 am" src="https://cloud.githubusercontent.com/assets/704760/12267780/bdd78136-b917-11e5-839f-8bb94eb373b4.png">

Desktop:
<img width="628" alt="screen shot 2016-01-12 at 10 05 57 am" src="https://cloud.githubusercontent.com/assets/704760/12267786/c3b621f2-b917-11e5-84d3-789d45eb0547.png">


## Todos

-  `btn-inside-input` in cf-forms is deprecated by `input-contains-icon`, so that the classes can follow the format of `input-with-btn`. Also, the modifiers are added so that the spacing is controlled. `btn-inside-input` allows a button and a label but doesn't adjust the input padding based on the content of button.