### PR TITLE
Adding Related Metadata molecule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -146,7 +146,9 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Added Related Topics molecule.
 - Added full_width_sans setting for correct font face usage.
 - Added a new nav-link molecule macro and styles.
-- Added Related Links to Sidebar/Footer
+- Added Related Links to Sidebar/Footer.
+- Added Related Metadata molecule.
+
 
 ### Changed
 - Updated the primary nav to move focus as user enters and leaves nav levels

--- a/cfgov/jinja2/v1/_includes/molecules/related-metadata.html
+++ b/cfgov/jinja2/v1/_includes/molecules/related-metadata.html
@@ -1,0 +1,109 @@
+{# ==========================================================================
+
+   related_metadata.render()
+
+   ==========================================================================
+
+   Description:
+
+   Creates related metadata markup when given:
+
+   related_metadata_list: A list of relatated metadata items.
+
+   is_half_width:         A Boolean indicating whether the list items should be at half
+                          width. Defaults to False.
+
+   ========================================================================== #}
+
+{% macro render(related_metadata_list, is_half_width=false) %}
+{% set types_lookup = {
+    'date': _date,
+    'list': _list,
+    'text': _text
+} %}
+<div class="m-related-metadata
+            {{ 'm-related-metadata__half-width' if is_half_width else '' }}">
+    <h2 class="header-slug">
+        <span class="header-slug_inner">
+            Related Metadata
+        </span>
+    </h2>
+    {% for list_item in related_metadata_list %}
+    <div class="m-related-metadata_item-container">
+        <h3 class="h4">
+            {{ list_item.title }}
+        </h3>
+        {{ types_lookup[list_item.type](list_item.value) }}
+    </div>
+    {% endfor %}
+</div>
+{% endmacro %}
+
+{# ==========================================================================
+
+   _list()
+
+   ==========================================================================
+
+   Description:
+
+   Creates related metadata list markup when given:
+
+   list: A list of dictionaries containing links.
+
+   ========================================================================== #}
+
+{% macro _list(list) %}
+<ul class="list
+           list__unstyled
+           list__links">
+    {% for list_item in list %}
+    <li class="list_item">
+        <a href="{{ list_item.url }}" class="list_link">
+            {{ list_item.text }}
+        </a>
+    </li>
+    {% endfor %}
+</ul>
+{% endmacro %}
+
+{# ==========================================================================
+
+   _date()
+
+   ==========================================================================
+
+   Description:
+
+   Creates related metadata date markup when given:
+
+   date: A string representing a date.
+
+   ========================================================================== #}
+
+{% macro _date(date) %}
+{% import 'macros/time.html' as time %}
+<p class="date u-mb0">
+    {{ time.render(date, {'date':true}) }}
+</p>
+{% endmacro %}
+
+{# ==========================================================================
+
+   _text()
+
+   ==========================================================================
+
+   Description:
+
+   Creates related metadata text markup when given:
+
+   text: A string representing text.
+
+   ========================================================================== #}
+
+{% macro _text(text) %}
+<p class="short-desc u-mb0">
+    {{ text }}
+</p>
+{% endmacro %}

--- a/cfgov/jinja2/v1/document-detail/index.html
+++ b/cfgov/jinja2/v1/document-detail/index.html
@@ -24,6 +24,7 @@
 {% endif %}
 
 {% import 'molecules/related-posts.html' as related_posts with context %}
+{% import 'molecules/related-metadata.html' as related_metadata with context %}
 {% import 'organisms/sidebar-contact-info.html' as sidebar_contact_info %}
 
 {% if not breadcrumb_items %}
@@ -103,7 +104,23 @@
     {# TODO: Add Related Metadata and Topics Sidebar molecules. #}
     {% if prototype %}
         {{ related_posts.render(global_dict.related_posts_settings) }}
-
+        {{ related_metadata.render([{
+                'title': 'Metadata Label 1',
+                'type':  'date',
+                'value': '04/11/2015'
+           },{
+                'title': 'Metadata Label 2',
+                'type':  'list',
+                'value': [{ 'url': '/' , 'text': 'Link 1' },
+                          { 'url': '/' , 'text': 'Link 2' }
+                         ]
+           },{
+                'title': 'Metadata Label 3',
+                'type':  'text',
+                'value': 'Line of Text'
+           }])
+       }}
+       {% include 'molecules/related-topics.html' %}
         {{ sidebar_contact_info.render({
             'heading': 'Header for text below',
             'body':    lipsumText

--- a/cfgov/unprocessed/css/main.less
+++ b/cfgov/unprocessed/css/main.less
@@ -82,6 +82,7 @@
 @import (less) "molecules/nav-link.less";
 @import (less) "molecules/notification.less";
 @import (less) "molecules/pagination.less";
+@import (less) "molecules/related-metadata.less";
 @import (less) "molecules/related-posts.less";
 @import (less) "molecules/related-topics.less";
 @import (less) "molecules/social-media.less";

--- a/cfgov/unprocessed/css/molecules/related-metadata.less
+++ b/cfgov/unprocessed/css/molecules/related-metadata.less
@@ -1,0 +1,82 @@
+/* topdoc
+  name: Related Metadata
+  family: cfgov-molecules
+  patterns:
+    - name: Default example
+      markup: |
+    <div class="m-related-metadata">
+        <h2 class="header-slug">
+            <span class="header-slug_inner">
+                Related Metadata
+            </span>
+        </h2>
+        <div class="m-related-metadata_item-container">
+            <h4></h4>
+            <ul class="list
+                       list__unstyled
+                       list__links">
+                <li class="list_item">
+                    <a class="list_link">
+                    </a>
+                </li>
+            </ul>
+            <p class="date u-mb0"></p>
+            <p class="short-desc u-mb0"></p>
+        </div>
+    </div>
+    codenotes:
+      - |
+        Structural cheat sheet:
+        -----------------------
+        .m-related-metadata
+          .header-slug
+            .header-slug_inner
+        .m-related-metadata_item-container
+          h4
+          .list
+            .list_item
+              .list_link
+          .date .u-mb0
+          .short-desc .u-mb0
+  tags:
+    - cfgov-molecules
+*/
+
+@margin_half__em: unit(15px / @base-font-size-px, em);
+
+.m-related-metadata {
+    .list_link {
+        .u-link__colors(@pacific, @pacific, @pacific-50, @pacific, @navy);
+    }
+
+    .respond-to-range(@bp-sm-min, @bp-sm-max, {
+        border-left: @margin_half__em solid transparent;
+        border-right: @margin_half__em solid transparent;
+    });
+}
+
+.m-related-metadata_item-container {
+    &:not(:last-child) {
+        margin-bottom: @margin_half__em * 2;
+    }
+}
+
+.m-related-metadata__half-width {
+    .respond-to-range(@bp-sm-min, @bp-sm-max, {
+        border: 0;
+
+        .m-related-metadata_item-container {
+            .grid_column(6);
+        };
+
+        .header-slug {
+            margin-left: @margin_half__em;
+            margin-right: @margin_half__em;
+        }
+    });
+}
+
+/* topdoc
+    name: EOF
+    eof: true
+*/


### PR DESCRIPTION
Adding Related Metadata Molecule

## Additions

- Adding Related Metadata Molecule

## Testing

- Visit  `http://localhost:8000/document-detail/`.

## Review

- @anselmbradford 
- @KimberlyMunoz 
- @jimmynotjim 

## Screenshots
Mobile:
<img width="390" alt="screen shot 2016-01-12 at 12 41 04 pm" src="https://cloud.githubusercontent.com/assets/1696212/12271583/d8dad7a0-b929-11e5-8b71-2280774ea56c.png">


Tablet:
<img width="727" alt="screen shot 2016-01-12 at 12 40 50 pm" src="https://cloud.githubusercontent.com/assets/1696212/12271586/de595c74-b929-11e5-88fe-196f29dae7fc.png">


Desktop:
<img width="496" alt="screen shot 2016-01-12 at 12 40 36 pm" src="https://cloud.githubusercontent.com/assets/1696212/12271589/e3b0c6d0-b929-11e5-9421-72492cc68bbd.png">
