### PR TITLE
Adds Global Search, initial Submit a complaint CTA, & Header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -157,6 +157,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Added Frontend: Header.
 - Added Frontend: Mega Menu.
 - Added Frontend: Global Eyebrow.
+- Added Frontend: Global Search molecule.
 
 ### Changed
 - Updated the primary nav to move focus as user enters and leaves nav levels

--- a/cfgov/jinja2/v1/_includes/molecules/global-search.html
+++ b/cfgov/jinja2/v1/_includes/molecules/global-search.html
@@ -1,0 +1,55 @@
+{# ==========================================================================
+
+   Global Search
+
+   ==========================================================================
+
+   Description:
+
+   Creates a global search box.
+
+   ========================================================================== #}
+
+<div class="m-global-search">
+    <button class="m-global-search_trigger">
+        <span class="cf-icon"></span>
+        <span class="m-global-search_trigger-label">
+            <span class="u-visually-hidden">Search</span>
+        </span>
+    </button>
+    <div class="m-global-search_content" aria-expanded="false">
+        <form class="m-global-search_content-form">
+            <div class="input-with-btn">
+                <div class="input-with-btn_input
+                            input-contains-label">
+                    <label for="search-input"
+                           class="input-contains-label_before
+                                  input-contains-label_before__search">
+                    </label>
+                    <label for="search-input"
+                           class="input-contains-label_after
+                                  input-contains-label_after__clear
+                                  u-hidden">
+                    </label>
+                    <input type="text"
+                           id="search-input"
+                           value=""
+                           placeholder="Search the CFPB">
+                </div>
+                <div class="input-with-btn_btn">
+                    <button class="btn" type="submit">Search</button>
+                </div>
+            </div>
+
+            <div class="m-global-search_content-suggestions">
+                <p class="h5">Suggested search terms:</p>
+                <ul class="list list__horizontal">
+                    <li class="list_item"><a class="list_link" href="#">Regulations</a></li>
+                    <li class="list_item"><a class="list_link" href="#">Compliance guides</a></li>
+                    <li class="list_item"><a class="list_link" href="#">Mortgage</a></li>
+                    <li class="list_item"><a class="list_link" href="#">College loans</a></li>
+                </ul>
+            </div>
+        </form>
+    </div>
+</div>

--- a/cfgov/jinja2/v1/_includes/templates/header.html
+++ b/cfgov/jinja2/v1/_includes/templates/header.html
@@ -13,7 +13,8 @@
     {% set value = global_dict.global_eyebrow %}
     {% include 'molecules/global-eyebrow.html' with context %}
 
-    <div class="wrapper">
+    <div class="o-header_content
+                wrapper">
         <button class="primary-nav_trigger js-primary-nav_trigger">
             <span class="u-visually-hidden">Menu</span>
         </button>
@@ -23,16 +24,23 @@
                 'global_header_cta': {
                     'is_in_list': false
                 }
-
             })
         %}
         {% set value = global_dict.global_header_cta %}
         {% include 'molecules/global-header-cta.html' with context %}
 
-        <a href="/">
-            <img class="header_logo u-js-only"
-                 src="/static/img/logo_sm-exec.svg"
-                 onerror="this.onerror=null;this.src='/static/img/logo_sm-exec.png';"
+    {% include 'molecules/global-search.html' with context %}
+
+    <a href="/">
+        <img class="o-header_logo header_logo u-js-only"
+             src="/static/img/logo_sm-exec.svg"
+             onerror="this.onerror=null;this.src='/static/img/logo_sm-exec.png';"
+             alt="Consumer Financial Protection Bureau"
+             width="237"
+             height="50">
+        <noscript>
+            <img class="header_logo logo__no-js"
+                 src="/static/img/logo_sm-exec.png"
                  alt="Consumer Financial Protection Bureau"
                  width="237"
                  height="50">
@@ -50,3 +58,4 @@
         {% endblock primary_nav %}
     </div>
 </header>
+<div class="content_bar"></div>

--- a/cfgov/jinja2/v1/_layouts/content-base.html
+++ b/cfgov/jinja2/v1/_layouts/content-base.html
@@ -2,7 +2,6 @@
 
 {% block content scoped %}
     <main class="content {% block content_modifiers -%}{%- endblock %}" id="main" role="main">
-        <div class="content_bar"></div>
         {% block hero -%}{%- endblock %}
         {% block pre_content scoped -%}
             {% if breadcrumb_items | length > 0 %}

--- a/cfgov/unprocessed/css/cf-enhancements.less
+++ b/cfgov/unprocessed/css/cf-enhancements.less
@@ -1144,7 +1144,7 @@ textarea {
                           input-contains-label_after__clear">
             </label>
             <input type="text"
-                   value="This is some really long text to make sure that the button doesn't overlap the content in such a way that this input becomes unusable.">
+                   value="">
         </div>
     - name: Super-sized icons before and after a super input.
       markup: |
@@ -1160,7 +1160,7 @@ textarea {
             </label>
             <input class="input__super"
                    type="text"
-                   value="This is some really long text to make sure that the button doesn't overlap the content in such a way that this input becomes unusable.">
+                   value="">
         </div>
     - name: Default icons before and after a default input, with a button.
       markup: |
@@ -1177,7 +1177,7 @@ textarea {
                 </label>
                 <input type="text"
                        id="search-input"
-                       value="This is some really long text to make sure that the button doesn't overlap the content in such a way that this input becomes unusable.">
+                       value="">
             </div>
             <div class="input-with-btn_btn">
                 <button class="btn">Search</button>
@@ -1200,7 +1200,7 @@ textarea {
                 <input class="input__super"
                        type="text"
                        id="search-input"
-                       value="This is some really long text to make sure that the button doesn't overlap the content in such a way that this input becomes unusable.">
+                       value="">
             </div>
             <div class="input-with-btn_btn">
                 <button class="btn btn__super">Search</button>

--- a/cfgov/unprocessed/css/header.less
+++ b/cfgov/unprocessed/css/header.less
@@ -42,7 +42,7 @@
     vertical-align: middle; // removes typical inline vertical whitespace
 
     .respond-to-min(@bp-med-min, {
-        margin: @grid_gutter-width 0 unit(20px / @base-font-size-px, em) 0;
+        margin: 0 0 unit(20px / @base-font-size-px, em) 0;
         height: 50px;
         width: 237px;
     });

--- a/cfgov/unprocessed/css/main.less
+++ b/cfgov/unprocessed/css/main.less
@@ -78,6 +78,7 @@
 @import (less) "molecules/full-width-text.less";
 @import (less) "molecules/global-eyebrow.less";
 @import (less) "molecules/global-header-cta.less";
+@import (less) "molecules/global-search.less";
 @import (less) "molecules/half-width-link-blob.less";
 @import (less) "molecules/image-text-50-50.less";
 @import (less) "molecules/image-text-25-75.less";

--- a/cfgov/unprocessed/css/molecules/global-header-cta.less
+++ b/cfgov/unprocessed/css/molecules/global-header-cta.less
@@ -31,8 +31,6 @@
 */
 
 .m-global-header-cta {
-    padding-top: unit( @grid_gutter-width / 3 / @base-font-size-px, em );
-    padding-bottom: unit( @grid_gutter-width / 3 / @base-font-size-px, em );
 
     a {
         .webfont-medium();

--- a/cfgov/unprocessed/css/molecules/global-search.less
+++ b/cfgov/unprocessed/css/molecules/global-search.less
@@ -1,0 +1,287 @@
+
+// TODO: Move the theme variables to cf-enhancements.
+/* topdoc
+  name: Theme variables
+  family: cf-core
+  notes:
+    - "The following color and sizing variables are exposed, allowing you to
+       easily override them before compiling."
+  patterns:
+    - name: Sizing
+      codenotes:
+        - |
+          @margin__em
+          @margin_half__em
+  tags:
+    - cf-core
+*/
+
+@margin__em: unit( @grid_gutter-width / @base-font-size-px, em );
+@margin_half__em: unit( @grid_gutter-width / 2 / @base-font-size-px, em );
+
+/* topdoc
+  name: Global Search molecule
+  family: cfgov-molecules
+  patterns:
+    - name: Default example
+      markup: |
+          <div class="m-global-search">
+              <button class="m-global-search_trigger">
+                  <span class="cf-icon"></span>
+                  <span class="m-global-search_trigger-label">
+                      <span class="u-visually-hidden">Search</span>
+                  </span>
+              </button>
+              <div class="m-global-search_content" aria-expanded="false">
+                  <form class="m-global-search_content-form">
+                      <div class="input-with-btn">
+                          <div class="input-with-btn_input
+                                      input-contains-label">
+                              <label for="search-input"
+                                     class="input-contains-label_before
+                                            input-contains-label_before__search">
+                              </label>
+                              <label for="search-input"
+                                     class="input-contains-label_after
+                                            input-contains-label_after__clear
+                                            u-hidden">
+                              </label>
+                              <input type="text"
+                                     id="search-input"
+                                     value=""
+                                     placeholder="Search the CFPB">
+                          </div>
+                          <div class="input-with-btn_btn">
+                              <button class="btn">Search</button>
+                          </div>
+                      </div>
+
+                      <div class="m-global-search_content-suggestions">
+                          <p class="h5">Suggested search terms:</p>
+                          <ul class="list list__horizontal">
+                              <li class="list_item"><a class="list_link" href="#">Regulations</a></li>
+                              <li class="list_item"><a class="list_link" href="#">Compliance guides</a></li>
+                              <li class="list_item"><a class="list_link" href="#">Mortgage</a></li>
+                              <li class="list_item"><a class="list_link" href="#">College loans</a></li>
+                          </ul>
+                      </div>
+                  </form>
+              </div>
+          </div>
+      codenotes:
+        - |
+          Structural cheat sheet:
+          -----------------------
+          .m-global-search
+            button.m-global-search_trigger
+              span.cf-icon
+              span.m-global-search_trigger-label
+                span.u-visually-hidden
+            .m-global-search_content
+              form.m-global-search_content-form
+                […
+                .input-with-btn
+                .input-contains-label
+                from cf-forms
+                …]
+                .m-global-search_content-suggestions
+                  .h5
+                  […
+                  .list.list__horizontal
+                  from cf-typography
+                  …]
+  tags:
+    - cfgov-molecules
+*/
+
+.m-global-search {
+
+    // Absolute position when there is a flyout at mobile/tablet sizes.
+    .respond-to-max( @bp-sm-max, {
+        // Make the height large so that the overflowing flyout can be hidden,
+        // but not get cropped when it's visible.
+        height: 500px;
+        width: 100%;
+        position: absolute;
+        top: 0;
+        overflow-x: hidden;
+        // TODO: This will be ignored in IE8-10,
+        //       leading to the overflow preventing clicks on the links.
+        pointer-events: none;
+    } );
+
+    &_trigger {
+        height: unit( 45px / 18px, em );
+        min-width: unit( 45px / 18px, em );
+        padding-left: unit( @grid_gutter-width / 2 / 18px, em );
+        padding-right: unit( @grid_gutter-width / 2 / 18px, em );
+
+        float: right;
+        position: relative;
+        z-index: 20;
+
+        background: @white;
+        border: none;
+        color: @black;
+        font-size: unit( 18px / @base-font-size-px, em );
+        pointer-events: auto;
+
+        &:focus {
+            outline: 1px dotted @black;
+        }
+
+        .cf-icon:before {
+            content: @cf-icon-search;
+            font-size: unit( 20px / 18px, em );
+        }
+
+        // Show "Search" text in trigger at tablet sizes.
+        .respond-to-min( @bp-sm-min {
+            &-label:before {
+                .webfont-medium();
+                content: 'Search';
+            }
+        } );
+
+        // Only show flyout and close trigger at tablet/mobile sizes.
+        .respond-to-max( @bp-sm-max, {
+            height: unit( 60px / 18px, em );
+            min-width: unit( 60px / 18px, em );
+            padding-top: unit( @grid_gutter-width / 2 / 18px, em );
+            padding-bottom: unit( @grid_gutter-width / 2 / 18px, em );
+
+            &[aria-expanded="true"] {
+                background: @gray-10;
+                border: 1px solid @gray-50;
+                border-bottom: none;
+                color: @black;
+
+                .cf-icon:before {
+                    content: @cf-icon-delete;
+                }
+
+                // Cover up the border edge of the flyout so that it is attached
+                // visually to the trigger button.
+                &:after {
+                    display: block;
+                    height: 1px;
+                    width: 100%;
+
+                    position: absolute;
+                    left: 0;
+                    bottom: -1px;
+
+                    content: '\a0';
+                    background: @gray-10;
+                }
+            }
+        } );
+
+        // Show "Close" text in trigger at tablet sizes.
+        .respond-to-range( @bp-sm-min, @bp-med-min, {
+            &[aria-expanded="true"] {
+                .m-global-search_trigger-label:before {
+                    content: 'Close';
+                }
+            }
+        } );
+
+        .respond-to-min( @bp-med-min {
+            &[aria-expanded="true"] {
+                display: none;
+            }
+        } );
+    }
+
+    &_content {
+        .respond-to-min( @bp-med-min {
+            display: none;
+        } );
+
+        padding-top: unit( @grid_gutter-width / 4 / @base-font-size-px, em );
+
+        &[aria-expanded="true"] {
+            display: block;
+
+            transform: translateX(0);
+        }
+
+        // Create flyout at table/mobile size.
+        .respond-to-max( @bp-sm-max, {
+            box-sizing: border-box;
+            width: 100%;
+
+            position: absolute;
+            left: 0;
+            // Offset for height of trigger button.
+            top: 60px;
+            z-index: 10;
+
+            background-color: @gray-10;
+            border: 1px solid @gray-50;
+            pointer-events: auto;
+
+            transform: translateX(100%);
+            transition: transform 0.25s ease-out;
+
+            &-form {
+                padding-top: @margin__em;
+                padding-left: @margin_half__em;
+                padding-right: @margin_half__em;
+                padding-bottom: @margin_half__em;
+            }
+
+            // Drop-shadow under the search flyout menu at mobile/tablet size.
+            &:after {
+                position: relative;
+                top: 5px;
+                content: '\a0';
+                display: block;
+                height: 5px;
+                width: 100%;
+                opacity: 0.2;
+                background: @gray;
+            }
+        } );
+
+        &-suggestions {
+            display: none;
+
+            // Only show search suggestions at tablet size.
+            .respond-to-range( @bp-sm-min, @bp-sm-max, {
+                & {
+                    display: block;
+                }
+            } );
+
+            .h5,
+            .list {
+                display: inline-block;
+            }
+        }
+    }
+
+    // TODO: Move these styles to cf-enhancements/cf-forms.
+    .respond-to-min( 480px, {
+        &_content-form {
+            // Attach button to input.
+            .input-with-btn_input {
+                width: 70%;
+            }
+            .input-with-btn_btn {
+                width: 30%;
+                border-left: 0;
+
+                button {
+                    border-top-left-radius: 0;
+                    border-bottom-left-radius: 0;
+                }
+            }
+        }
+    } );
+}
+
+/* topdoc
+    name: EOF
+    eof: true
+*/

--- a/cfgov/unprocessed/css/organisms/header.less
+++ b/cfgov/unprocessed/css/organisms/header.less
@@ -1,3 +1,22 @@
+
+// TODO: Move the theme variables to cf-enhancements.
+/* topdoc
+  name: Theme variables
+  family: cf-core
+  notes:
+    - "The following color and sizing variables are exposed, allowing you to
+       easily override them before compiling."
+  patterns:
+    - name: Sizing
+      codenotes:
+        - |
+          @margin_half__em
+  tags:
+    - cf-core
+*/
+
+@margin_half__em: unit( @grid_gutter-width / 2 / @base-font-size-px, em );
+
 /* topdoc
   name: Header
   family: cfgov-organisms
@@ -26,14 +45,29 @@
         } );
     }
 
-    // Position and display Global Header Call to Action (CTA).
-    .wrapper > .m-global-header-cta {
-        .respond-to-max( @bp-sm-max, {
-            display: none;
-        } );
+    &_content {
 
         .respond-to-min( @bp-med-min, {
-            float: right;
+            padding-top: unit( @grid_gutter-width / 2 / @base-font-size-px, em );
+
+            & > .m-global-header-cta {
+                    float: right;
+            }
+
+            & > .m-global-search {
+                float: right;
+
+                .m-global-search_content {
+                    padding-right: @margin_half__em;
+                }
+            }
+        } );
+
+        // Hide Global Header Call to Action at tablet/mobile sizes.
+        .respond-to-max( @bp-sm-max, {
+            & > .m-global-header-cta {
+                display: none;
+            }
         } );
     }
 }

--- a/cfgov/unprocessed/js/molecules/GlobalSearch.js
+++ b/cfgov/unprocessed/js/molecules/GlobalSearch.js
@@ -1,0 +1,219 @@
+'use strict';
+
+// Required polyfills for <IE9.
+require( '../modules/polyfill/query-selector' );
+require( '../modules/polyfill/event-listener' );
+require( '../modules/polyfill/class-list' );
+
+// Required modules.
+var atomicCheckers = require( '../modules/util/atomic-checkers' );
+var breakpointState = require( '../modules/util/breakpoint-state' );
+
+/**
+ * GlobalSearch
+ * @class
+ *
+ * @classdesc Initializes a new GlobalSearch molecule.
+ *
+ * @param {HTMLNode} element
+ *   The DOM element within which to search for the molecule.
+ * @returns {Object} An GlobalSearch instance.
+ */
+function GlobalSearch( element ) {
+
+  var BASE_CLASS = 'm-global-search';
+
+  var _dom =
+    atomicCheckers.validateDomElement( element, BASE_CLASS, 'GlobalSearch' );
+  var _triggerDom = _dom.querySelector( '.' + BASE_CLASS + '_trigger' );
+  var _contentDom = _dom.querySelector( '.' + BASE_CLASS + '_content' );
+  var _searchInputDom;
+  var _clearBtnDom;
+
+  var _isExpanded = false;
+  var _tabClicked = false;
+
+  var KEY_TAB = 9;
+
+  /**
+   * @returns {Object} The GlobalSearch instance.
+   */
+  function init() {
+    var inputSelector = '.' + BASE_CLASS + '_content-form input';
+    var clearBtnSelector =
+      '.' + BASE_CLASS + ' .input-contains-label_after__clear';
+    var searchIconSelector =
+      '.' + BASE_CLASS + ' .input-contains-label_before__search';
+    var searchBtnSelector = '.' + BASE_CLASS + ' .input-with-btn_btn button';
+
+    _searchInputDom = _contentDom.querySelector( inputSelector );
+    var searchIconDom = _contentDom.querySelector( searchIconSelector );
+    var searchBtnDom = _contentDom.querySelector( searchBtnSelector );
+    _clearBtnDom = _contentDom.querySelector( clearBtnSelector );
+
+    _triggerDom.addEventListener( 'click', _triggerClicked );
+    _clearBtnDom.addEventListener( 'mousedown', _clearClicked );
+    _searchInputDom.addEventListener( 'keyup', _inputTyped );
+    _searchInputDom.addEventListener( 'blur', _searchBlurred );
+    searchBtnDom.addEventListener( 'mousedown', _searchBtnClicked );
+    searchIconDom.addEventListener( 'click', _searchIconClicked );
+
+    _contentDom.addEventListener( 'keydown', _checkTabClicked );
+
+    _setClearBtnState( _searchInputDom.value );
+
+    return this;
+  }
+
+  /**
+   * Event handler for when the keyboard is pressed on the body.
+   * If the tab key was pressed, record the press so that when
+   * getting to the search input, the input won't collapse when
+   * tabbing between the input and the search button.
+   * @param {KeyboardEvent} event The event object for the keyboard key press.
+   */
+  function _checkTabClicked( event ) {
+    if ( event.keyCode === KEY_TAB ) {
+      _tabClicked = true;
+    }
+  }
+
+  /**
+   * Event handler for when the search icon is clicked in the
+   * expanded state at desktop sizes. Closes the search box.
+   */
+  function _searchIconClicked() {
+    _collapseIfDesktop();
+  }
+
+  /**
+   * Force a click on the search button after it has been clicked.
+   * This is necessary to handle the button before the search input blurs.
+   * @param {MouseEvent} event The event object for mousedown event.
+   */
+  function _searchBtnClicked( event ) {
+    event.target.click();
+  }
+
+  /**
+   * Event handler for when the search input loses focus.
+   * Closes the search input if the tab key was not pressed.
+   */
+  function _searchBlurred() {
+    if ( !_tabClicked ) {
+      _collapseIfDesktop();
+    } else {
+      _tabClicked = false;
+    }
+  }
+
+  /**
+   * Collapse the search box if screen is at desktop sizes.
+   */
+  function _collapseIfDesktop() {
+    var currentBreakpoint = breakpointState.get();
+    if ( ( currentBreakpoint.isBpMED ||
+         currentBreakpoint.isBpLG ||
+         currentBreakpoint.isBpXL ) ) {
+      collapse();
+    }
+  }
+
+  /**
+   * Event handler for when the search input trigger is clicked,
+   * which opens/closes the search input.
+   */
+  function _triggerClicked() {
+    if ( _isExpanded ) {
+      collapse();
+    } else {
+      expand();
+    }
+  }
+
+  /**
+   * Open the search box.
+   * @returns {Object} An GlobalSearch instance.
+   */
+  function expand() {
+    if ( !_isExpanded ) {
+      _isExpanded = true;
+      _triggerDom.setAttribute( 'aria-expanded', 'true' );
+      _contentDom.setAttribute( 'aria-expanded', 'true' );
+      _searchInputDom.select();
+    }
+
+    return this;
+  }
+
+  /**
+   * Close the search box.
+   * @returns {Object} An GlobalSearch instance.
+   */
+  function collapse() {
+    if ( _isExpanded ) {
+      _isExpanded = false;
+      _triggerDom.setAttribute( 'aria-expanded', 'false' );
+      _contentDom.setAttribute( 'aria-expanded', 'false' );
+    }
+
+    return this;
+  }
+
+  /**
+   * Event handler for when the clear input label was clicked.
+   * @param {MouseEvent} event The event object for the mousedown event.
+   */
+  function _clearClicked( event ) {
+    _searchInputDom.value = _setClearBtnState( '' );
+    _searchInputDom.focus();
+
+    // Prevent event bubbling up to the input,
+    // which would blur and trigger a collapse otherwise.
+    event.preventDefault();
+  }
+
+  /**
+   * Event handler for when the user typed in the input.
+   */
+  function _inputTyped() {
+    _setClearBtnState( _searchInputDom.value );
+  }
+
+  /**
+   * @param {string} value - The input value in the search box.
+   * @returns {string} The input value in the search box.
+   */
+  function _setClearBtnState( value ) {
+    if ( value !== '' ) {
+      _showClearBtn();
+    } else {
+      _hideClearBtn();
+    }
+
+    return value;
+  }
+
+  /**
+   * Add a hidden class to the input search label.
+   * Used when there is no text input.
+   */
+  function _hideClearBtn() {
+    _clearBtnDom.classList.add( 'u-hidden' );
+  }
+
+  /**
+   * Remove a hidden class from the input search label.
+   * Used when there is text input.
+   */
+  function _showClearBtn() {
+    _clearBtnDom.classList.remove( 'u-hidden' );
+  }
+
+  this.init = init;
+  this.expand = expand;
+  this.collapse = collapse;
+  return this;
+}
+
+module.exports = GlobalSearch;

--- a/cfgov/unprocessed/js/routes/common.js
+++ b/cfgov/unprocessed/js/routes/common.js
@@ -24,3 +24,9 @@ require( '../modules/youtube' ).init();
 require( '../modules/pagination-validation.js' ).init();
 require( '../modules/show-hide-fields.js' ).init();
 require( '../modules/external-site-redirect.js' ).init();
+
+// GLOBAL ATOMIC ELEMENTS.
+// Molecules.
+var GlobalSearch = require( '../molecules/GlobalSearch.js' );
+var globalSearch = new GlobalSearch( document.body );
+globalSearch.init();


### PR DESCRIPTION
Adds Global Search, initial Submit a complaint CTA, & Header

## Additions

- Atomic Global Search molecule.
- Initial atomic Submit a Complaint CTA.
- Initial atomic Header.

## Changes

- Moves initial styling from non-atomic to atomic header.

## Testing

- Visit the site, click on search, enter text, resize window.

## Review

- @sebworks 
- @jimmynotjim 
- @KimberlyMunoz 

## Screenshots

Desktop size, contracted:
![screen shot 2016-01-14 at 3 56 29 pm](https://cloud.githubusercontent.com/assets/704760/12337635/1dea1d6e-bad9-11e5-9a97-967addd68921.png)

Desktop size, expanded:
![screen shot 2016-01-14 at 3 56 04 pm](https://cloud.githubusercontent.com/assets/704760/12337591/eb17e2ea-bad8-11e5-8b1b-1ccba3b09dfa.png)

Tablet size, contracted:
![screen shot 2016-01-14 at 3 56 40 pm](https://cloud.githubusercontent.com/assets/704760/12337643/2e0959a8-bad9-11e5-9878-4e9423d4d3a4.png)

Tablet size, shows button text:
![screen shot 2016-01-14 at 3 55 45 pm](https://cloud.githubusercontent.com/assets/704760/12337573/d2b7029e-bad8-11e5-9495-682cb95704cc.png)

Tablet size, full suggestions width:
![screen shot 2016-01-14 at 3 55 53 pm](https://cloud.githubusercontent.com/assets/704760/12337583/dde4e8b6-bad8-11e5-8e76-ddd73dbd2310.png)

Mobile size, contracted:
![screen shot 2016-01-14 at 3 56 47 pm](https://cloud.githubusercontent.com/assets/704760/12337650/393cf60e-bad9-11e5-9732-289dd4a0327c.png)

Mobile size, smallest size, expanded:
![screen shot 2016-01-14 at 3 55 37 pm](https://cloud.githubusercontent.com/assets/704760/12337665/51a868ae-bad9-11e5-893b-177fb3a65865.png)

Mobile size, expanded:
![screen shot 2016-01-14 at 3 55 28 pm](https://cloud.githubusercontent.com/assets/704760/12337599/f3c32882-bad8-11e5-8476-939c55626844.png)

Entering text:
![screen shot 2016-01-14 at 3 56 21 pm](https://cloud.githubusercontent.com/assets/704760/12337608/faebab52-bad8-11e5-8999-796928cf0346.png)




## Todos

- **There's a bug in cf-forms where the button and input heights are different (https://github.com/cfpb/capital-framework/issues/261), which shows up in this PR.**
- Submit a complaint CTA needs to be incorporated into the Mega Menu mobile nav.
- It will likely make sense to make the button and input attached by default and a gap should be added to separate them through a modifier. This is currently set directly in the Global Search molecule, but should be set in cf-enhancements/cf-forms.