### PR TITLE
Fixing the spacing around o-well module

### DIFF
--- a/cfgov/unprocessed/css/organisms/well.less
+++ b/cfgov/unprocessed/css/organisms/well.less
@@ -42,6 +42,7 @@
     padding-bottom: unit( ( @grid_gutter-width * 2 )  / @base-font-size-px, em );
     padding-left: unit( ( @grid_gutter-width / 2 ) / @base-font-size-px, em );
     border: 1px solid @o-well_border;
+    border-right: 0;
     background-color: @o-well_bg;
 
     .respond-to-min( @bp-sm-min, {
@@ -50,6 +51,18 @@
     } );
 }
 
+
+.block {
+    .o-well {
+        margin-left: unit( ( @grid_gutter-width / -2) / @base-font-size-px, em );
+        margin-right: unit( ( @grid_gutter-width / -2 ) / @base-font-size-px, em );
+
+        .respond-to-min( @bp-sm-min, {
+            margin-left: unit( ( -@grid_gutter-width ) / @base-font-size-px, em );
+            margin-right: unit( ( -@grid_gutter-width ) / @base-font-size-px, em );
+        } );
+    }
+}
 /* topdoc
     name: EOF
     eof: true


### PR DESCRIPTION
When the well is in a block, the spacing is off. This PR fixes the spacing without removing the block every time the well is being used. Fixes DF-677.

## Testing
- Check on landing page.

## Preview
![image](https://cloud.githubusercontent.com/assets/1860176/12338155/45905d12-badc-11e5-8cea-8717398c6d53.png)
