### PR TITLE
Updated secondary navigation organism

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
   in `input-contains-label` CF class.
 - Added Github specific Issue and PR templates.
 - included paragraph rich text field to related links
+- Added new content flush sides on small modifier to fix an issue where margin was set on the molecule level instead of the template.
 
 ### Changed
 - Converted the project to Capital Framework v3
@@ -31,6 +32,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Abstracted info unit into a helper mixin to make it easier to re-use the inline version.
 - Moved Home page specific layout changes to it's own file.
 - Updated jsdom from `7.2.2` to `8.0.4`.
+- Updated secondary-nav to use new expandable molecule in place of old CF Expandable.
 
 ### Removed
 - Removed normalize and normalize-legacy from main less file because CF already includes it.

--- a/cfgov/jinja2/v1/_includes/molecules/expandable.html
+++ b/cfgov/jinja2/v1/_includes/molecules/expandable.html
@@ -24,6 +24,8 @@
    value.is_expanded: Whether the Expandable is expanded or not.
                       Default is false.
 
+   TODO: Add description to `filter` param, and possibly reconsider name to
+         avoid confusion w/ the filter controls that use it.
    ========================================================================== #}
 
 {% macro expandable(value, filter=false) %}
@@ -63,7 +65,7 @@
             {% else %}
                 {% for block in value.content %}
                     {% if 'paragraph' in block.block_type %}
-                        {{ block |safe }}
+                        {{ block | safe }}
                     {% else %}
                         {{ render_stream_child(block) }}
                     {% endif %}

--- a/cfgov/jinja2/v1/_includes/organisms/secondary-navigation.html
+++ b/cfgov/jinja2/v1/_includes/organisms/secondary-navigation.html
@@ -16,57 +16,43 @@
 
    ========================================================================== #}
 
-{% macro secondary_navigation(items, active_item_id) %}
+{% macro _secondary_navigation(items, active_item_id) %}
 {% from 'molecules/nav-link.html' import nav_link as nav_link %}
-{# TODO: Update to the atomic expandable #}
-<nav class="expandable
-            o-secondary-navigation"
-     aria-label="Section navigation">
+<ul class="o-secondary-navigation_list
+           o-secondary-navigation_list__parents">
+    {%- for item in items %}
+        {%- set href, id, caption, children = item[0], item[1], item[2], item[3:] %}
 
-    <div class="expandable_header
-                o-secondary-navigation_header">
-        <button class="expandable_target
-                       o-secondary-navigation_button">
-            <span class="expandable_header-left">
-                In this section
-            </span>
-            <span class="expandable_header-right">
-                <span class="expandable_cue-open">
-                    <span class="cf-icon cf-icon-down"></span>
-                </span>
-                <span class="expandable_cue-close">
-                    <span class="cf-icon cf-icon-up"></span>
-                </span>
-            </span>
-        </button>
-    </div>
-
-    <div class="expandable_content
-                o-secondary-navigation_content">
+    <li>
+        {{ nav_link(caption, href, true, id == active_item_id) }}
+    {%- if children -%}
+        {% set children = children[0] %}
         <ul class="o-secondary-navigation_list
-                   o-secondary-navigation_list__parents">
-        {%- for item in items %}
-            {%- set href, id, caption, children = item[0], item[1], item[2], item[3:] %}
-
-            <li class="o-secondary-navigation_item
-                       o-secondary-navigation_item__parent">
-                {{ nav_link(caption, href, true, id == active_item_id) }}
-            {%- if children -%}
-                {% set children = children[0] %}
-                <ul class="o-secondary-navigation_list
-                           o-secondary-navigation_list__children">
-                {%- for href, id, caption in children %}
-                    <li class="o-secondary-navigation_item">
-                        {{ nav_link(caption, href, false, id == active_item_id) }}
-                    </li>
-                {%- endfor %}
-                </ul>
-            {%- endif %}
+                   o-secondary-navigation_list__children">
+        {%- for href, id, caption in children %}
+            <li>
+                {{ nav_link(caption, href, false, id == active_item_id) }}
             </li>
-
         {%- endfor %}
         </ul>
-    </div>
+    {%- endif %}
+    </li>
 
-</nav>
+    {%- endfor %}
+</ul>
 {% endmacro %}
+
+<nav class="o-secondary-navigation"
+     aria-label="Section navigation">
+    {% set sec_nav_settings = {
+        'label': 'In this section',
+        'is_bordered': false,
+        'is_midtone': true,
+        'is_expanded': false
+    } %}
+
+    {% from 'molecules/expandable.html' import expandable with context %}
+    {% call() expandable(sec_nav_settings, true) %}
+        {{ _secondary_navigation(sec_nav_items, active_nav_id) | safe }}
+    {% endcall %}
+</nav>

--- a/cfgov/jinja2/v1/_layouts/layout-side-nav.html
+++ b/cfgov/jinja2/v1/_layouts/layout-side-nav.html
@@ -8,26 +8,17 @@
     add the nav macro.
 #}
 
-{# Side nav vars #}
-
-{# Set default value for nav_items array. #}
-{% set nav_items = [(
-    '/docs/sheer-layouts/layout-side-nav/',
-    '',
-    'Please review the instructions in _layouts/layout-side-nav.html for setting up the side nav.'
-)] %}
-
-{% set active_nav_id = active_nav_id|default('index') -%}
-
-{# Adding the side nav macro #}
 {% block content_sidebar %}
-    {% from 'organisms/secondary-navigation.html' import secondary_navigation as sec_nav %}
-    {{ sec_nav(vars.nav_items, active_nav_id) }}
+    {% set active_nav_id = active_nav_id | default('index') -%}
+    {% set sec_nav_items = vars.nav_items %}
+
+    {% include 'organisms/secondary-navigation.html' with context %}
 {% endblock %}
 
 {# Extra classes needed for .content_sidebar #}
 {% block content_sidebar_modifiers -%}
-    content__flush-all-on-small
+    content__flush-top-on-small
+    content__flush-sides-on-small
     {{ 'content__half-top-on-desk' if breadcrumb_items | length > 0 else '' }}
 {%- endblock %}
 

--- a/cfgov/unprocessed/css/cf-enhancements.less
+++ b/cfgov/unprocessed/css/cf-enhancements.less
@@ -1464,6 +1464,29 @@ textarea {
 
 
 /* topdoc
+  name: Flush sides on small devices
+  family: cf-layout
+  patterns:
+    - name: .content__flush-sides-on-small
+      markup: |
+        <aside class="content_sidebar content__flush-sides-on-small">
+          <!-- sidebar components -->
+        </aside>
+        <div class="content_main content__flush-sides-on-small">
+          <!-- main content components -->
+        </div>
+  tags: cf-layout
+*/
+.content__flush-sides-on-small {
+    .respond-to-max(@bp-sm-max, {
+        padding-left: 0;
+        padding-right: 0;
+        border-width: 0;
+    });
+}
+
+
+/* topdoc
   name: Code styles
   family: cf-layout
   notes:

--- a/cfgov/unprocessed/css/organisms/secondary-navigation.less
+++ b/cfgov/unprocessed/css/organisms/secondary-navigation.less
@@ -15,18 +15,12 @@
             </button>
             <ul class="o-secondary-navigation_list
                        o-secondary-navigation_list__parents">
-                <li class="o-secondary-navigation_item
-                           o-secondary-navigation_item__parent">
+                li
                     m-nav-link
-                </li>
-                <li class="o-secondary-navigation_item
-                           o-secondary-navigation_item__parent">
+                li
                     m-nav-link
-                </li>
-                <li class="o-secondary-navigation_item
-                           o-secondary-navigation_item__parent">
+                li
                     m-nav-link
-                </li>
             </ul>
         </nav>
       codenotes:
@@ -36,7 +30,8 @@
           .o-secondary-navigation
             .o-secondary-navigation_button
             .o-secondary-navigation_list.o-secondary-navigation_list__parents
-              .o-secondary-navigation_item.o-secondary-navigation_item__parent
+              li
+                m-nav-link
     - name: Secondary nav mixed with cf-expandable
       markup: |
         <nav class="expandable
@@ -62,18 +57,12 @@
             <div class="expandable_content">
                 <ul class="o-secondary-navigation_list
                            o-secondary-navigation_list__parents">
-                    <li class="o-secondary-navigation_item
-                               o-secondary-navigation_item__parent">
-                        nav-link
-                    </li>
-                    <li class="o-secondary-navigation_item
-                               o-secondary-navigation_item__parent">
-                        nav-link
-                    </li>
-                    <li class="o-secondary-navigation_item
-                               o-secondary-navigation_item__parent">
-                        nav-link
-                    </li>
+                    li
+                        m-nav-link
+                    li
+                        m-nav-link
+                    li
+                      m-nav-link
                 </ul>
             </div>
         </nav>
@@ -92,41 +81,35 @@
                     .cf-icon.cf-icon-up
             .expandable_content
               .o-secondary-navigation_list.o-secondary-navigation_list__parents
-                .o-secondary-navigation_item.o-secondary-navigation_item__parent
+                li
+                  m-nav-link
   tags:
     - cfgov-organisms
 */
 
 .o-secondary-navigation {
-    .respond-to-max(@bp-sm-max, {
-        // TODO: Move margin/spacing to template level styles
-        margin-bottom: unit(@grid_gutter-width / @base-font-size-px, em);
+    .webfont-regular();
 
-        background-color: @gray-10;
-        border-top: 1px solid @gray-20;
-        border-bottom: 1px solid @gray-20;
-    });
-
-    &_button {
-        width: 100%;
-        padding: unit( (@grid_gutter-width / 2) / @base-font-size-px, em);
-
+    .m-expandable_target {
         .webfont-demi();
 
-        text-align: left;
         text-transform: uppercase;
 
-        &:focus {
-            outline: 1px dotted;
-        }
-
-        .cf-icon {
-            color: @green;
-        }
-
         .respond-to-min(@bp-med-min, {
-            display: none;
+          display: none;
         });
+    }
+
+    .m-expandable_content {
+        .respond-to-min(@bp-med-min, {
+          background: none;
+          border: none;
+          height: auto !important;
+        });
+
+        &-animated {
+          padding: 0;
+        }
     }
 
     &_list {

--- a/cfgov/unprocessed/js/organisms/SecondaryNavigation.js
+++ b/cfgov/unprocessed/js/organisms/SecondaryNavigation.js
@@ -1,0 +1,34 @@
+'use strict';
+
+// Required modules.
+var atomicCheckers = require( '../modules/util/atomic-checkers' );
+var Expandable = require( '../molecules/Expandable' );
+
+/**
+ * SecondaryNavigation
+ * @class
+ *
+ * @classdesc Initializes a new Filterable-List-Controls organism.
+ *
+ * @param {HTMLNode} element
+ *   The DOM element within which to search for the organism.
+ */
+function SecondaryNavigation( element ) {
+  var BASE_CLASS = 'o-secondary-navigation';
+
+  var _dom = atomicCheckers.validateDomElement(
+    element, BASE_CLASS, 'SecondaryNavigation' );
+
+  /**
+   * Initialize FilterableListControls instance.
+  */
+  function init() {
+    var expandable = new Expandable( _dom );
+    expandable.init();
+  }
+
+  this.init = init;
+  return this;
+}
+
+module.exports = SecondaryNavigation;

--- a/cfgov/unprocessed/js/routes/common.js
+++ b/cfgov/unprocessed/js/routes/common.js
@@ -11,7 +11,6 @@ require( 'cf-expandables' );
 
 // Global modules.
 require( '../modules/beta-banner-state' ).init();
-require( '../modules/secondary-nav-toggle' ).init();
 require( '../modules/footer-button' ).init();
 require( '../modules/focus-target' ).init();
 require( '../modules/post-filter' ).init();
@@ -29,3 +28,7 @@ require( '../modules/external-site-redirect.js' ).init();
 var Header = require( '../organisms/Header.js' );
 var header = new Header( document.body );
 header.init();
+
+// Secondary Navigation
+var SecondaryNavigation = require( '../organisms/SecondaryNavigation' );
+var secondaryNavigation = new SecondaryNavigation( document.body ).init();


### PR DESCRIPTION
Updated secondary navigation organism

## Additions

- Adds new content flush sides on small modifier to fix an issue where margin was set on the molecule level instead of the template

## Removals

- Removes prototype code from expandable

## Changes

- Updated the secondary nav to utilize new expandable molecule instead of old CF Expandable


## Testing

- checkout and `gulp build`, then visit `/the-bureau/`

## Review

- @anselmbradford 
- @sebworks 
- @KimberlyMunoz 

## Screenshots

<img width="317" alt="screen shot 2016-01-20 at 5 49 06 pm" src="https://cloud.githubusercontent.com/assets/1280430/12465832/2ad340e0-bf9e-11e5-87c5-ddc8ca647d19.png">

<img width="400" alt="screen shot 2016-01-20 at 5 49 13 pm" src="https://cloud.githubusercontent.com/assets/1280430/12465835/2c29f6d2-bf9e-11e5-8abd-e3f7a402261d.png">

<img width="402" alt="screen shot 2016-01-20 at 5 49 20 pm" src="https://cloud.githubusercontent.com/assets/1280430/12465837/2dd78d32-bf9e-11e5-88c9-e7357f614fc0.png">

## Notes

- The expand/collapse icon displayed on smaller screens is now the default expandable icon/text

## Todos

- Split Expandable into a base expandable styles and scripts to be adjusted by the main expandable and secondary nav, rather than overwriting the expandable styles in the sec nav styles

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices 
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
