### PR TITLE
addressed,security concerns with redirect_field_name

### DIFF
--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -301,3 +301,4 @@ CFPB_COMMON_PASSWORD_RULES = [
 LOGIN_FAIL_TIME_PERIOD = os.environ.get('LOGIN_FAIL_TIME_PERIOD', 120 * 60)
 # number of failed attempts
 LOGIN_FAILS_ALLOWED = os.environ.get('LOGIN_FAILS_ALLOWED', 5)
+LOGIN_REDIRECT_URL='/admin/'

--- a/cfgov/v1/views.py
+++ b/cfgov/v1/views.py
@@ -137,8 +137,7 @@ def login_with_lockout(request, template_name='wagtailadmin/login.html'):
     """
     Displays the login form and handles the login action.
     """
-    redirect_to = request.POST.get(REDIRECT_FIELD_NAME,
-                                   request.GET.get(REDIRECT_FIELD_NAME, ''))
+    redirect_to = request.GET.get(REDIRECT_FIELD_NAME, '')
 
     if request.method == "POST":
         form = forms.LoginForm(request, data=request.POST)


### PR DESCRIPTION
Set settings.LOGIN_REDIRECT_URL field to get proper usage of Django is_safe_url which returns True when the URL is safe to be used as a redirect; in the case of a False return, you'd simply use a default path to redirect to.

Also edited request to get redirect_field_name from GET request only.

@kurtw 
