### PR TITLE
Language dropdown for pages, which defaults to english

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -158,6 +158,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Added Frontend: Mega Menu.
 - Added Frontend: Global Eyebrow.
 - Added Frontend: Global Search molecule.
+- Added language dropdown for pages, which defaults to english
 
 ### Changed
 - Updated the primary nav to move focus as user enters and leaves nav levels

--- a/cfgov/jinja2/v1/wagtail/demo/index.html
+++ b/cfgov/jinja2/v1/wagtail/demo/index.html
@@ -12,7 +12,7 @@
 {% block content_main %}
     <div class="block
                 block__flush-top">
-        {{ page.title }}
+        {{ page.title }} ({{ page.language }})
     </div>
 
     {% for block in page.molecules %}

--- a/cfgov/v1/migrations/0035_cfgovpage_language.py
+++ b/cfgov/v1/migrations/0035_cfgovpage_language.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('v1', '0034_failedloginattempt'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='cfgovpage',
+            name='language',
+            field=models.CharField(default=b'en', max_length=2, choices=[(b'en', b'English'), (b'es', b'Spanish'), (b'zh', b'Chinese'), (b'vi', b'Vietnamese'), (b'ko', b'Korean'), (b'tl', b'Tagalog'), (b'ru', b'Russian'), (b'ar', b'Arabic'), (b'ht', b'Haitian Creole')]),
+        ),
+    ]

--- a/cfgov/v1/models/base.py
+++ b/cfgov/v1/models/base.py
@@ -56,6 +56,8 @@ class CFGOVPage(Page):
                                   related_name='tagged_pages')
     shared = models.BooleanField(default=False)
 
+    language = models.CharField(choices=ref.supported_languagues, default='en', max_length=2)
+
     # This is used solely for subclassing pages we want to make at the CFPB.
     is_creatable = False
 
@@ -82,6 +84,7 @@ class CFGOVPage(Page):
         MultiFieldPanel(Page.promote_panels, 'Settings'),
         FieldPanel('tags', 'Tags'),
         FieldPanel('authors', 'Authors'),
+        FieldPanel('language', 'language'),
         InlinePanel('categories', label="Categories", max_num=2),
         MultiFieldPanel(Page.settings_panels, 'Scheduled Publishing'),
     ]

--- a/cfgov/v1/models/ref.py
+++ b/cfgov/v1/models/ref.py
@@ -19,3 +19,15 @@ notification_types = [
     ('warning', 'warning'),
     ('error', 'error'),
 ]
+
+supported_languagues = [
+    ('en', 'English'),
+    ('es', 'Spanish'),
+    ('zh', 'Chinese'),
+    ('vi', 'Vietnamese'),
+    ('ko', 'Korean'),
+    ('tl', 'Tagalog'),
+    ('ru', 'Russian'),
+    ('ar', 'Arabic'),
+    ('ht', 'Haitian Creole'),
+]


### PR DESCRIPTION
Included a Language selector for Pages, which defaults to English.
This was included because the use case for multiple languages on 1 page is not valid.

@KimberlyMunoz 
@kurtw 

### Testing
- Template tag: {{ page.language }}

### Screenshots
<img width="1283" alt="screen shot 2016-01-22 at 9 41 50 am" src="https://cloud.githubusercontent.com/assets/254877/12513761/81f7cc1a-c0ed-11e5-96f8-5244f66a26b6.png">

<img width="348" alt="screen shot 2016-01-22 at 9 42 26 am" src="https://cloud.githubusercontent.com/assets/254877/12513763/85fd8b10-c0ed-11e5-8e1c-0a9d9f7ae367.png">
