### PR TITLE
Adding Expandable Observe

### DIFF
--- a/cfgov/unprocessed/js/molecules/Expandable.js
+++ b/cfgov/unprocessed/js/molecules/Expandable.js
@@ -94,26 +94,19 @@ function Expandable( element ) { // eslint-disable-line max-statements, inline-c
     if ( MutationObserver ) {
       observeDOM = function() {
         var observer = new MutationObserver( function( mutations ) {
-          mutations.forEach( function( ) {
-            _refreshHeight();
-          } );
+          mutations.forEach( _refreshHeight );
         } );
 
         observer.observe( _content, { childList: true, subtree: true } );
       };
     } else {
       observeDOM = function() {
-          _content.addEventListener( "DOMNodeInserted", function( event ){
-          _refreshHeight();
-        }, false );
-
-        _content.addEventListener( "DOMNodeRemoved", _refreshHeight, false );
+        _content.addEventListener( 'DOMNodeInserted', _refreshHeight, false );
+        _content.addEventListener( 'DOMNodeRemoved', _refreshHeight, false );
       };
     }
 
-    window.setTimeout( function(){
-      observeDOM();
-    }, 0 )
+    window.setTimeout( observeDOM, 0 );
 
     return _that;
   }

--- a/cfgov/unprocessed/js/molecules/Expandable.js
+++ b/cfgov/unprocessed/js/molecules/Expandable.js
@@ -75,7 +75,47 @@ function Expandable( element ) { // eslint-disable-line max-statements, inline-c
     if ( window.addEventListener ) {
       window.addEventListener( 'resize', _refreshHeight );
     }
+
+    _initObserver();
+
     return this;
+  }
+
+  /**
+   * Watch for the insertion/removal of DOM nodes.
+   * @returns {Object} The Expandable instance.
+   */
+  function _initObserver() {
+    var MutationObserver = window.MutationObserver ||
+                           window.WebKitMutationObserver ||
+                           window.MozMutationObserver;
+    var observeDOM;
+
+    if ( MutationObserver ) {
+      observeDOM = function() {
+        var observer = new MutationObserver( function( mutations ) {
+          mutations.forEach( function( ) {
+            _refreshHeight();
+          } );
+        } );
+
+        observer.observe( _content, { childList: true, subtree: true } );
+      };
+    } else {
+      observeDOM = function() {
+          _content.addEventListener( "DOMNodeInserted", function( event ){
+          _refreshHeight();
+        }, false );
+
+        _content.addEventListener( "DOMNodeRemoved", _refreshHeight, false );
+      };
+    }
+
+    window.setTimeout( function(){
+      observeDOM();
+    }, 0 )
+
+    return _that;
   }
 
   /**

--- a/cfgov/unprocessed/js/molecules/Multiselect.js
+++ b/cfgov/unprocessed/js/molecules/Multiselect.js
@@ -67,7 +67,7 @@ function Multiselect( element ) { // eslint-disable-line max-statements, inline-
     if ( _optionData.length > 0 ) {
       _populateMarkup();
       _bindEvents();
-      _dom.remove();
+      _dom.parentNode.removeChild(_dom);
     }
 
     return this;
@@ -79,9 +79,8 @@ function Multiselect( element ) { // eslint-disable-line max-statements, inline-
    */
   function expand() {
     _container.classList.add( 'active' );
-    _fieldset
-      .setAttribute( 'visibility', 'visible' )
-      .setAttribute( 'aria-hidden', false );
+    _fieldset.setAttribute( 'visibility', 'visible' );
+    _fieldset.setAttribute( 'aria-hidden', false );
 
     return this;
   }
@@ -92,9 +91,8 @@ function Multiselect( element ) { // eslint-disable-line max-statements, inline-
    */
   function collapse() {
     _container.classList.remove( 'active' );
-    _fieldset
-      .setAttribute( 'visibility', 'hidden' )
-      .setAttribute( 'aria-hidden', true );
+    _fieldset.setAttribute( 'visibility', 'hidden' );
+    _fieldset.setAttribute( 'aria-hidden', true );
     _index = -1;
 
     return this;
@@ -173,10 +171,10 @@ function Multiselect( element ) { // eslint-disable-line max-statements, inline-
       } );
 
       _create( 'label', {
-        'for':       option.value,
-        'innerText': option.text,
-        'className': 'cf-multi-select_label',
-        'inside':    li
+        'for':         option.value,
+        'textContent': option.text,
+        'className':   'cf-multi-select_label',
+        'inside':      li
       } );
 
       _list.appendChild( li );


### PR DESCRIPTION
Adding code to refresh the height of the Expandable on DOM insertion/deletion. Also fixed some minor bugs so I could test on IE9/Firefox. 

Having written this I believe I took the wrong approach. @ans, how would you feel about exploring using css to handle showing/hiding the `m-expandable_content` instead of Javascript? This would probably involve using `margin-top ` instead of setting the height. 

## Testing

- Visit  `http://localhost:8000/browse-filterable/`.

## Review


## Notes

Firefox just recently added `innerText` and its better to use `textContent` per https://developer.mozilla.org/en-US/docs/Web/API/Node/textContent. Of course this won't work in IE8 which I'm happy about. 

We should also consider throttling or debouncing `_refreshHeight`  to prevent costly reflows caused by accessing `offsetHeight`.

- @anselmbradford 
- @KimberlyMunoz 
- @jimmynotjim 

## Screenshots
<img width="1062" alt="screen shot 2016-01-22 at 11 54 16 am" src="https://cloud.githubusercontent.com/assets/1696212/12517286/f9fdd04e-c0ff-11e5-923c-3d0e4bbec5a7.png">
