### PR TITLE
Removes color variable

### DIFF
--- a/cfgov/unprocessed/css/molecules/global-header-cta.less
+++ b/cfgov/unprocessed/css/molecules/global-header-cta.less
@@ -34,7 +34,6 @@
 
     a {
         .webfont-medium();
-        color: @pacific;
 
         &:before {
             position: relative;


### PR DESCRIPTION
## Testing

- Visit the homepage in an incognito window. You should see the link color change on rollover:

![screen shot 2016-01-22 at 6 26 57 pm](https://cloud.githubusercontent.com/assets/704760/12525851/c93fd23c-c135-11e5-81ae-cf6dee6670d7.png)


## Review
@jimmynotjim You were right, the link color set on the Global Header CTA can be removed. The color change is due to the global header CTA being a visited link color.