### PR TITLE
Creating 50-50 module and using CF two-column css

### DIFF
--- a/cfgov/jinja2/v1/_includes/molecules/half-width-link-blob.html
+++ b/cfgov/jinja2/v1/_includes/molecules/half-width-link-blob.html
@@ -47,7 +47,9 @@
     %}
     {% set value = global_dict.half_width_link_blob %}
 {% endif %}
-<div class="m-half-width-link-blob">
+<div class="m-half-width-link-blob
+            content-l_col
+            content-l_col-1-2">
     <h2 class="h3">{{ value.heading }}</h2>
     <div class="m-half-width-link-blob_paragraph">
         {{ value.body.source | safe }}

--- a/cfgov/jinja2/v1/_includes/molecules/image-text-50-50.html
+++ b/cfgov/jinja2/v1/_includes/molecules/image-text-50-50.html
@@ -56,7 +56,9 @@
     {% set value = global_dict.image_text_50_50 %}
     {% set prototype = true %}
 {% endif %}
-<div class="m-image-text-50-50">
+<div class="m-image-text-50-50
+            content-l_col
+            content-l_col-1-2">
     {# TODO: Change to HR #}
     {% if value.has_rule %}
         <div class="a-rule-break"></div>

--- a/cfgov/jinja2/v1/_includes/organisms/half-width-link-blob-group.html
+++ b/cfgov/jinja2/v1/_includes/organisms/half-width-link-blob-group.html
@@ -11,7 +11,7 @@
     } %}
 {% endif %}
 
-<div class="o-link-blob-group">
+<div class="o-link-blob-group content-l">
     <h2>{{ value.heading }}</h2>
     {% for block in value.link_blobs %}
         {{ block }}

--- a/cfgov/jinja2/v1/_includes/organisms/image-text-50-50-group.html
+++ b/cfgov/jinja2/v1/_includes/organisms/image-text-50-50-group.html
@@ -6,12 +6,14 @@
         'heading': 'Image Text 50 50 Group Header',
         'image_texts': [
             _image_text_50_50_markup(),
+            _image_text_50_50_markup(),
+            _image_text_50_50_markup(),
             _image_text_50_50_markup()
         ]
     } %}
 {% endif %}
 
-<div class="o-image-text-50-50-group">
+<div class="o-image-text-50-50-group content-l">
     <h2>{{ value.heading }}</h2>
     {% for block in value.image_texts %}
         {{ block }}

--- a/cfgov/jinja2/v1/_includes/organisms/layout-two-columns.html
+++ b/cfgov/jinja2/v1/_includes/organisms/layout-two-columns.html
@@ -1,0 +1,22 @@
+{# ==========================================================================
+
+   layout-two-columns.render()
+
+   ========================================================================== #}
+
+{% if not value %}
+    {% set lipsumText = lipsum(1, false, 10, 25) | safe %}
+    {% do global_dict.update({
+      'two_columns':
+      { 'column1' :  lipsumText,
+        'column2' :  lipsumText  }
+    }) %}
+{% endif %}
+{% set value = value or global_dict.two_columns %}
+
+<div class="content-l_col content-l_col-1-2">
+    {{ value.column1 }}
+</div>
+<div class="content-l_col content-l_col-1-2">
+    {{ value.column2 }}
+</div>

--- a/cfgov/unprocessed/css/molecules/half-width-link-blob.less
+++ b/cfgov/unprocessed/css/molecules/half-width-link-blob.less
@@ -4,7 +4,9 @@
   patterns:
     - name: Default example
       markup: |
-        <div class="m-half-width-link-blob">
+        <div class="m-half-width-link-blob
+                    content-l_col
+                    content-l_col-1-2">
             <h2 class="h3">Heading</h2>
             <p>Body content</p>
             <ul class="list list__links">

--- a/cfgov/unprocessed/css/molecules/half-width-link-blob.less
+++ b/cfgov/unprocessed/css/molecules/half-width-link-blob.less
@@ -35,10 +35,6 @@
         }
     });
 
-    .respond-to-min(@bp-sm-min, {
-        .grid_column(6);
-    });
-
     &_paragraph {
         margin-bottom: unit( @grid_gutter-width / @base-font-size-px, em);
     }

--- a/cfgov/unprocessed/css/molecules/image-text-50-50.less
+++ b/cfgov/unprocessed/css/molecules/image-text-50-50.less
@@ -26,7 +26,9 @@
   patterns:
     - name: Image and Text 50-50 molecule
       markup: |
-        <div class="m-image-text-50-50">
+        <div class="m-image-text-50-50
+                    content-l_col
+                    content-l_col-1-2">
           <div class="m-image-text-50-50_widescreen-container">
               <img src="http://placeholdit.com/1600x800"
                    alt=""

--- a/cfgov/unprocessed/css/organisms/image-text-50-50-group.less
+++ b/cfgov/unprocessed/css/organisms/image-text-50-50-group.less
@@ -4,7 +4,7 @@
   patterns:
     - name: Default example
       markup: |
-        <div class="o-image-text-50-50-group">
+        <div class="o-image-text-50-50-group content-l">
             Link blobs live inside the wrapper
         </div>
       codenotes:

--- a/cfgov/unprocessed/css/organisms/image-text-50-50-group.less
+++ b/cfgov/unprocessed/css/organisms/image-text-50-50-group.less
@@ -20,8 +20,9 @@
     margin-bottom: unit( @grid_gutter-width * -2 / @base-font-size-px, em );
 
     > h2 {
-        margin-left: @grid_gutter-width / 2;
-        margin-right: @grid_gutter-width / 2;
+          .heading-2();
+          margin-left: unit( @grid_gutter-width / 2 / @font-size, em );
+          margin-right: unit( @grid_gutter-width / 2 / @font-size, em );
     }
 }
 

--- a/cfgov/unprocessed/css/organisms/image-text-50-50-group.less
+++ b/cfgov/unprocessed/css/organisms/image-text-50-50-group.less
@@ -19,11 +19,6 @@
     // TODO: Find another way to handle spacing
     margin-bottom: unit( @grid_gutter-width * -2 / @base-font-size-px, em );
 
-    .respond-to-min(@bp-sm-min, {
-        margin-left: -@grid_gutter-width / 2;
-        margin-right: -@grid_gutter-width / 2;
-    });
-
     > h2 {
         margin-left: @grid_gutter-width / 2;
         margin-right: @grid_gutter-width / 2;

--- a/cfgov/unprocessed/css/organisms/link-blob-group.less
+++ b/cfgov/unprocessed/css/organisms/link-blob-group.less
@@ -4,7 +4,7 @@
   patterns:
     - name: Default example
       markup: |
-        <div class="o-link-blob-group">
+        <div class="o-link-blob-group content-l">
             Link blobs live inside the wrapper
         </div>
       codenotes:
@@ -16,10 +16,10 @@
     - cfgov-molecules
 */
 .o-link-blob-group {
-  > h2 {
-        .heading-2();
-        margin-left: unit( @grid_gutter-width / 2 / @font-size, em );
-        margin-right: unit( @grid_gutter-width / 2 / @font-size, em );
+    > h2 {
+          .heading-2();
+          margin-left: unit( @grid_gutter-width / 2 / @font-size, em );
+          margin-right: unit( @grid_gutter-width / 2 / @font-size, em );
     }
 }
 

--- a/cfgov/unprocessed/css/organisms/link-blob-group.less
+++ b/cfgov/unprocessed/css/organisms/link-blob-group.less
@@ -20,6 +20,11 @@
     margin-left: -@grid_gutter-width / 2;
     margin-right: -@grid_gutter-width / 2;
   });
+
+  > h2 {
+        margin-left: @grid_gutter-width / 2;
+        margin-right: @grid_gutter-width / 2;
+    }
 }
 
 /* topdoc

--- a/cfgov/unprocessed/css/organisms/link-blob-group.less
+++ b/cfgov/unprocessed/css/organisms/link-blob-group.less
@@ -16,14 +16,10 @@
     - cfgov-molecules
 */
 .o-link-blob-group {
-  .respond-to-min(@bp-sm-min, {
-    margin-left: -@grid_gutter-width / 2;
-    margin-right: -@grid_gutter-width / 2;
-  });
-
   > h2 {
-        margin-left: @grid_gutter-width / 2;
-        margin-right: @grid_gutter-width / 2;
+        .heading-2();
+        margin-left: unit( @grid_gutter-width / 2 / @font-size, em );
+        margin-right: unit( @grid_gutter-width / 2 / @font-size, em );
     }
 }
 


### PR DESCRIPTION
## Additions
- Creates two-column module for @kave and @kurtw to add to well organism

## Changes
- Changes all the two-columns modules to use `content-l_col-1-2` and removes unnecessary LESS
- Less LESS!

## Testing
- Check out the 50-50 text image module and the half link blob on the landing page

## Review
- @jimmynotjim 
- @anselmbradford 
- @sebworks 