### PR TITLE
Adding multi-language screenreader support

### DIFF
--- a/cfgov/jinja2/v1/_includes/macros/accessible-languages.html
+++ b/cfgov/jinja2/v1/_includes/macros/accessible-languages.html
@@ -1,0 +1,20 @@
+{# ==========================================================================
+
+   accessible-languages.render()
+
+   ==========================================================================
+
+   Use this in a section or div to set the language and letter direction
+   settings. This may need to be updated when more right-to-left languages
+   are added.
+
+   ========================================================================== #}
+
+{% macro render() %}
+    {%- if page -%}
+        lang="{{ page.language if page.language else 'en' }}"
+              {%- if page.language in ['ar'] -%}
+                  dir="rtl"
+              {%- endif -%}
+    {%- endif -%}
+{% endmacro %}

--- a/cfgov/jinja2/v1/_layouts/content-base-main-first.html
+++ b/cfgov/jinja2/v1/_layouts/content-base-main-first.html
@@ -12,7 +12,10 @@
 {% block body_content scoped %}
 <div class="wrapper content_wrapper">
     <div class="content_main {% block content_main_modifiers -%}{%- endblock %}">
-        <section>
+        <section lang="{{ page.language }}"
+        {%- if page.language in ['ar'] -%}
+          dir="rtl"
+        {%- endif -%}>
             {% block content_main scoped -%}{%- endblock %}
         </section>
     </div>

--- a/cfgov/jinja2/v1/_layouts/content-base-main-first.html
+++ b/cfgov/jinja2/v1/_layouts/content-base-main-first.html
@@ -12,10 +12,8 @@
 {% block body_content scoped %}
 <div class="wrapper content_wrapper">
     <div class="content_main {% block content_main_modifiers -%}{%- endblock %}">
-        <section lang="{{ page.language }}"
-        {%- if page.language in ['ar'] -%}
-          dir="rtl"
-        {%- endif -%}>
+        {%- import 'macros/accessible-languages.html' as accessible_languages with context-%}
+        <section {{ accessible_languages.render() }}>
             {% block content_main scoped -%}{%- endblock %}
         </section>
     </div>

--- a/cfgov/jinja2/v1/_layouts/content-base-main-only.html
+++ b/cfgov/jinja2/v1/_layouts/content-base-main-only.html
@@ -3,7 +3,10 @@
 {% block body_content scoped %}
 <div class="wrapper content_wrapper">
     <div class="content_main {% block content_main_modifiers -%}{%- endblock %}">
-        <section>
+        <section lang="{{ page.language if page.language else '' }}"
+        {%- if page.language in ['ar'] -%}
+          dir="rtl"
+        {%- endif -%}>
             {% block content_main scoped -%}{%- endblock %}
         </section>
     </div>

--- a/cfgov/jinja2/v1/_layouts/content-base-main-only.html
+++ b/cfgov/jinja2/v1/_layouts/content-base-main-only.html
@@ -3,10 +3,8 @@
 {% block body_content scoped %}
 <div class="wrapper content_wrapper">
     <div class="content_main {% block content_main_modifiers -%}{%- endblock %}">
-        <section lang="{{ page.language if page.language else '' }}"
-        {%- if page.language in ['ar'] -%}
-          dir="rtl"
-        {%- endif -%}>
+        {%- import 'macros/accessible-languages.html' as accessible_languages with context-%}
+        <section {{ accessible_languages.render() }}>
             {% block content_main scoped -%}{%- endblock %}
         </section>
     </div>

--- a/cfgov/jinja2/v1/_layouts/content-base-sidebar-first.html
+++ b/cfgov/jinja2/v1/_layouts/content-base-sidebar-first.html
@@ -15,7 +15,10 @@
         {% block content_sidebar scoped -%}{%- endblock %}
     </aside>
     <div class="content_main {% block content_main_modifiers -%}{%- endblock %}">
-        <section>
+        <section lang="{{ page.language }}"
+        {%- if page.language in ['ar'] -%}
+          dir="rtl"
+        {%- endif -%}>
             {% block content_main scoped -%}{%- endblock %}
         </section>
     </div>

--- a/cfgov/jinja2/v1/_layouts/content-base-sidebar-first.html
+++ b/cfgov/jinja2/v1/_layouts/content-base-sidebar-first.html
@@ -15,10 +15,8 @@
         {% block content_sidebar scoped -%}{%- endblock %}
     </aside>
     <div class="content_main {% block content_main_modifiers -%}{%- endblock %}">
-        <section lang="{{ page.language }}"
-        {%- if page.language in ['ar'] -%}
-          dir="rtl"
-        {%- endif -%}>
+        {%- import 'macros/accessible-languages.html' as accessible_languages with context-%}
+        <section {{ accessible_languages.render() }}>
             {% block content_main scoped -%}{%- endblock %}
         </section>
     </div>


### PR DESCRIPTION
This builds on the work in #1361 to allow content editors to specify a language for the main content to be in. This assumes that most of the sidebar content will remain in English or be dealt with separately. This also adds RTL support for arabic.

## Testing
- Go to the admin panel and create a page in a different language and in arabic
- Arabic should render RTL and the appropriate `lang` tag should be added to main content section.

## Review
- @anselmbradford 
- @jimmynotjim 
- @sebworks 
- @kave 
