### PR TITLE
Updated `lodash` from `3.10.0` from `4.0.1`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -278,6 +278,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Updated the project to use Avenir font by default
 - Updated `mocha` from `2.2.4` from `2.4.2`.
 - Updated `sinon` from `1.14.1` from `1.17.3`.
+- Updated `lodash` from `3.10.0` from `4.0.1`.
 - Change jinja2 templates to handle Wagtail page
 
 ### Removed

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "jasmine-spec-reporter": "^2.4.0",
     "jquery": "1.11.3",
     "jsdom": "^7.2.2",
-    "lodash": "^3.10.0",
+    "lodash": "^4.0.1",
     "map-stream": "^0.0.6",
     "minimist": "^1.1.3",
     "mkdirp": "^0.5.1",

--- a/test/browser_tests/page_objects/page_blog-single.js
+++ b/test/browser_tests/page_objects/page_blog-single.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var _assign = require( 'lodash' ).assign;
+var _assign = require( 'lodash.assign' );
 var stayInformedSection = require( '../shared_objects/stay-informed-section' );
 var rssSection = require( '../shared_objects/rss-section' );
 

--- a/test/browser_tests/page_objects/page_blog.js
+++ b/test/browser_tests/page_objects/page_blog.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var _assign = require( 'lodash' ).assign;
+var _assign = require( 'lodash.assign' );
 var filter = require( '../shared_objects/filter.js' );
 var pagination = require( '../shared_objects/pagination' );
 var stayInformedSection = require( '../shared_objects/stay-informed-section' );

--- a/test/browser_tests/page_objects/page_careers-application-process.js
+++ b/test/browser_tests/page_objects/page_careers-application-process.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var _assign = require( 'lodash' ).assign;
+var _assign = require( 'lodash.assign' );
 var _getQAelement = require( '../util/QAelement' ).get;
 var careersSocialSection =
 require( '../shared_objects/careers-social-section' );

--- a/test/browser_tests/page_objects/page_careers-current-openings.js
+++ b/test/browser_tests/page_objects/page_careers-current-openings.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var _assign = require( 'lodash' ).assign;
+var _assign = require( 'lodash.assign' );
 var _getQAelement = require( '../util/QAelement' ).get;
 var careersSocialSection =
 require( '../shared_objects/careers-social-section' );

--- a/test/browser_tests/page_objects/page_careers-working-at-cfpb.js
+++ b/test/browser_tests/page_objects/page_careers-working-at-cfpb.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var _assign = require( 'lodash' ).assign;
+var _assign = require( 'lodash.assign' );
 var _getQAelement = require( '../util/QAelement' ).get;
 var careersSocialSection =
 require( '../shared_objects/careers-social-section' );

--- a/test/browser_tests/page_objects/page_careers.js
+++ b/test/browser_tests/page_objects/page_careers.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var _assign = require( 'lodash' ).assign;
+var _assign = require( 'lodash.assign' );
 var _getQAelement = require( '../util/QAelement' ).get;
 var careersSocialSection =
 require( '../shared_objects/careers-social-section' );

--- a/test/browser_tests/page_objects/page_newsroom-press-resources.js
+++ b/test/browser_tests/page_objects/page_newsroom-press-resources.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var _assign = require( 'lodash' ).assign;
+var _assign = require( 'lodash.assign' );
 var stayInformedSection = require( '../shared_objects/stay-informed-section' );
 var rssSection = require( '../shared_objects/rss-section' );
 var _getQAElement = require( '../util/QAelement' ).get;

--- a/test/browser_tests/page_objects/page_newsroom.js
+++ b/test/browser_tests/page_objects/page_newsroom.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var _assign = require( 'lodash' ).assign;
+var _assign = require( 'lodash.assign' );
 var filter = require( '../shared_objects/filter.js' );
 var pagination = require( '../shared_objects/pagination' );
 var stayInformedSection = require( '../shared_objects/stay-informed-section' );


### PR DESCRIPTION
## Changes

- Updated `lodash` from `3.10.0` from `4.0.1` and requires `lodash.assign` as a module instead of importing the full lodash and calling the assign method.

## Testing

- `npm install && gulp test --sauce=false` should work as before.

## Review

- @sebworks 
- @KimberlyMunoz 
- @jimmynotjim 