### PR TITLE
Updated mocha and sinon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -272,6 +272,8 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Updated filterable-list-controls organism to allow for multiple option
 - Password Policy & Lockout criteria for login, account password change & forgot my password.
 - Updated the project to use Avenir font by default
+- Updated `mocha` from `2.2.4` from `2.4.2`.
+- Updated `sinon` from `1.14.1` from `1.17.3`.
 
 ### Removed
 - Removed unused exportsOverride section,

--- a/package.json
+++ b/package.json
@@ -53,10 +53,10 @@
     "map-stream": "^0.0.6",
     "minimist": "^1.1.3",
     "mkdirp": "^0.5.1",
-    "mocha": "^2.2.4",
+    "mocha": "^2.4.2",
     "mocha-jsdom": "^1.0.0",
     "protractor": "^3.0.0",
-    "sinon": "^1.14.1",
+    "sinon": "^1.17.3",
     "sinon-chai": "^2.8.0",
     "wcag": "^0.2.2"
   },


### PR DESCRIPTION
## Changes

- Updated `mocha` from `2.2.4` from `2.4.2` and Updated `sinon` from `1.14.1` from `1.17.3`.

## Testing

- `npm install && gulp test --sauce=false` should work as before.

## Review

- @jimmynotjim 
- @KimberlyMunoz 
- @sebworks 
