### PR TITLE
Refactoring Beta Banner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -165,6 +165,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Added new info-unit molecule that combines (but doesn't replace) the half width link blob, image and text 50/50, and 25/75 into one base molecule using modifiers.
 - Added new (undocumented) card molecule.
 - Add wagtailuserbar to the base.html
+- Added unit test for beta-banner.js.
 
 ### Changed
 - Updated the primary nav to move focus as user enters and leaves nav levels
@@ -286,6 +287,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Updated brand colors to updates in generator-cf.
 - Disabled JavaScript in IE8 and earlier.
 - Removed max_length validation until [later review](https://github.com/cfpb/cfgov-refresh/issues/1258) after release
+- Refactored beta-banner.js to demonstrate general lifecycle.
 
 ### Removed
 - Removed unused exportsOverride section,

--- a/cfgov/jinja2/v1/_layouts/base.html
+++ b/cfgov/jinja2/v1/_layouts/base.html
@@ -132,22 +132,33 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <a href="#main" id="skip-nav">Skip to main content</a>
 
 {% if flag_enabled('BETA_NOTICE') %}
-<div class="beta-banner expandable" id="beta-banner">
+<div class="beta-banner
+            m-expandable
+            m-expandable__expanded"
+     id="beta-banner">
     <div class="wrapper wrapper__match-content">
         <div class="beta-banner_head">
-            <span class="cf-icon cf-icon-error-round beta-banner_icon"></span>
+            <span class="cf-icon
+                         cf-icon-error-round
+                         beta-banner_icon"></span>
             This beta site is a work in progress.
         </div>
-        <p class="beta-banner_desc expandable_content">
-            We’re prototyping new designs. Things may not work as expected.
-            Our regular site continues to be at
-            <a href="http://www.consumerfinance.gov/">www.consumerfinance.gov</a>.
-        </p>
-        <button class="btn beta-banner_btn expandable_target" id="beta-banner_btn">
-            <span class="expandable_cue-close">
+        <div class="m-expandable_content">
+            <p class="beta-banner_desc  m-expandable_content-animated">
+                We’re prototyping new designs. Things may not work as expected.
+                Our regular site continues to be at
+                <a href="http://www.consumerfinance.gov/">www.consumerfinance.gov</a>.
+            </p>
+        </div>
+        <button class="btn
+                       beta-banner_btn
+                       m-expandable_target
+                       m-expandable_link"
+                id="beta-banner_btn">
+            <span class="m-expandable_cue m-expandable_cue-close">
                 Collapse <span class="cf-icon cf-icon-up"></span>
             </span>
-            <span class="expandable_cue-open">
+            <span class="m-expandable_cue m-expandable_cue-open">
                 More info <span class="cf-icon cf-icon-down"></span>
             </span>
         </button>

--- a/cfgov/unprocessed/css/pages/beta.less
+++ b/cfgov/unprocessed/css/pages/beta.less
@@ -12,8 +12,12 @@
     font-size: 0.875em;
     transition: padding 0.2s ease-out;
 
-    &.expandable__expanded {
+    &.m-expandable__expanded {
         padding: @grid_gutter-width 0;
+    }
+
+    .m-expandable_content {
+        border-bottom: none;
     }
 
     .respond-to-min(@bp-sm-min, {
@@ -25,7 +29,7 @@
     .h4();
     margin-bottom: 0;
 
-    .expandable__expanded & {
+    .m-expandable__expanded & {
         margin-bottom: unit(5px / @base-font-size-px, em);
     }
 }
@@ -36,6 +40,8 @@
 
 .beta-banner_desc {
     margin-bottom: 0;
+    padding: 0;
+    background: @gold-20;
 }
 
 .beta-banner_btn {
@@ -75,6 +81,12 @@
         // so the button position has to be adjusted accordingly.
         top: unit(-12px/@base-font-size-px, em);
     });
+}
+
+.no-js {
+    .beta-banner_btn {
+        display: none;
+    }
 }
 
 .beta-hero {

--- a/cfgov/unprocessed/js/modules/beta-banner-state.js
+++ b/cfgov/unprocessed/js/modules/beta-banner-state.js
@@ -5,54 +5,65 @@
 
 'use strict';
 
-// Import modules
-var $ = require( 'jquery' );
+// Required modules.
+var Expandable = require( '../molecules/Expandable' );
 var _storage = require( './util/web-storage-proxy' );
 
 // Private variables.
-var _key = 'betaBannerIsCollapsed';
+var _expandable;
+
+// Constants.
+var EXPANDED_STATE = 'betaBannerIsExpanded';
+
 
 /**
  * Set up DOM references and event handlers.
  */
 function init() {
 
-  // DOM references.
-  var btnDOM = $( '#beta-banner_btn' );
-  var bannerDOM = $( '#beta-banner' );
+  // Init Expandable.
+  var betaBannerDom = document.querySelector( '#beta-banner' );
+  var isExpanded = _storage.getItem( EXPANDED_STATE ) !== 'false';
 
-  // Event handlers.
-  btnDOM.click( _betaBannerClicked );
+  _expandable = new Expandable( betaBannerDom );
+  _expandable.init( isExpanded && _expandable.EXPANDED );
 
-  // Initial state.
-  if ( _storage.getItem( _key ) !== 'true' ) {
-    bannerDOM.get( 0 ).expand();
-  }
+  _initEvents();
 }
 
 /**
  * Run when the beta in-progress banner has been clicked.
- * @returns {boolean} always returns false.
  */
-function _betaBannerClicked() {
-  _toggleStorage();
-  return false;
+function _initEvents() {
+  _expandable.addEventListener( 'click', toggleStoredState );
+}
+
+/**
+ * Remove event handlers and local storage data.
+ */
+function destroy() {
+  _expandable.removeEventListener( 'click', toggleStoredState );
+  _storage.removeItem( EXPANDED_STATE, true );
 }
 
 /**
  * Toggle the boolean value stored in a web storage.
  * @returns {boolean} Returns value stored in the web storage,
- *   either true or false.
+ * either true or false.
  */
-function _toggleStorage() {
-  var value = _storage.getItem( _key );
+function toggleStoredState() {
+  var value = _storage.getItem( EXPANDED_STATE );
+
   if ( value === 'false' ) {
-    _storage.setItem( _key, true );
+    _storage.setItem( EXPANDED_STATE, true );
   } else {
-    _storage.setItem( _key, false );
+    _storage.setItem( EXPANDED_STATE, false );
   }
   return value;
 }
 
 // Expose public methods.
-module.exports = { init: init };
+module.exports = { init:              init,
+                   destroy:           destroy,
+                   toggleStoredState: toggleStoredState
+                 };

--- a/test/unit_tests/fixtures/StorageMock.js
+++ b/test/unit_tests/fixtures/StorageMock.js
@@ -1,0 +1,35 @@
+'use strict';
+
+
+function StorageMock() {
+  this.storage = {};
+}
+
+function setItem( _key, value ) {
+  this.storage[_key] = value.toString() || '';
+}
+
+function getItem( _key ) {
+  return this.storage[_key];
+}
+
+function removeItem( _key ) {
+  delete this.storage[_key];
+}
+
+function length() {
+  return Object.keys( this.storage ).length;
+}
+
+function key( index ) {
+  var keys = Object.keys( this.storage );
+  return keys[index] || null;
+}
+
+StorageMock.prototype.setItem = setItem;
+StorageMock.prototype.getItem = getItem;
+StorageMock.prototype.removeItem = removeItem;
+StorageMock.prototype.length = length;
+StorageMock.prototype.key = key;
+
+module.exports = StorageMock;

--- a/test/unit_tests/modules/beta-banner-state-spec.js
+++ b/test/unit_tests/modules/beta-banner-state-spec.js
@@ -1,0 +1,137 @@
+'use strict';
+
+var chai = require( 'chai' );
+var expect = chai.expect;
+var jsdom = require( 'mocha-jsdom' );
+var sinon = require( 'sinon' );
+var StorageMock = require( '../fixtures/StorageMock' );
+
+var BASE_JS_PATH = '../../../cfgov/unprocessed/js/';
+var betaBanner;
+var contentDom;
+var contentAnimatedDom;
+var targetDom;
+var clickEvent;
+var webStorageProxy;
+
+describe( 'Beta Banner State', function() {
+
+  jsdom( {
+    created: function( error, win ) {
+      if ( error ) console.log( error );
+      win.Modernizr = {};
+    }
+  } );
+
+  before( function() {
+    webStorageProxy =
+      require( BASE_JS_PATH + 'modules/util/web-storage-proxy.js' );
+  } );
+
+  beforeEach( function() {
+
+    document.body.innerHTML =
+    '<div class="beta-banner m-expandable m-expandable__expanded"' +
+    'id="beta-banner">' +
+      '<div class="wrapper wrapper__match-content">' +
+          '<div class="beta-banner_head">' +
+              '<span class="cf-icon cf-icon-error-round beta-banner_icon">' +
+              '</span>' +
+              'This beta site is a work in progress.' +
+          '</div>' +
+          '<div class="m-expandable_content" aria-expanded="true">' +
+              '<p class="beta-banner_desc  m-expandable_content-animated">' +
+                  'We’re prototyping new designs.' +
+                  'Things may not work as expected.' +
+                  'Our regular site continues to be at' +
+                  '<a href="http://www.consumerfinance.gov/">' +
+                  'www.consumerfinance.gov</a>.' +
+              '</p>' +
+          '</div>' +
+          '<button class="btn beta-banner_btn m-expandable_target ' +
+          'm-expandable_link" id="beta-banner_btn">' +
+              '<span class="m-expandable_cue m-expandable_cue-close">' +
+                  'Collapse <span class="cf-icon cf-icon-up"></span>' +
+              '</span>' +
+              '<span class="m-expandable_cue m-expandable_cue-open">' +
+                  'More info <span class="cf-icon cf-icon-down"></span>' +
+              '</span>' +
+          '</button>' +
+      '</div>' +
+    '</div>';
+
+    contentDom = document.querySelector( '.m-expandable_content' );
+    contentAnimatedDom =
+      document.querySelector( '.m-expandable_content-animated' );
+    contentAnimatedDom.offsetHeight = 300;
+    targetDom = document.querySelector( '.m-expandable_target' );
+
+    clickEvent = document.createEvent( 'Event' );
+    clickEvent.initEvent( 'click', true, true );
+
+    betaBanner = require( BASE_JS_PATH + 'modules/beta-banner-state.js' );
+
+    window.localStorage = new StorageMock();
+    window.sessionStorage = new StorageMock();
+
+  } );
+
+  describe( 'init', function() {
+    it( 'should have instantiated an Expandable instance', function() {
+      betaBanner.init();
+      var isExpandable = contentDom.hasAttribute( 'style' );
+      expect( isExpandable ).to.be.true;
+    } );
+
+    it( 'should have called the initEvents function', function() {
+      var toggleStoredStateSpy = sinon.spy( betaBanner, 'toggleStoredState' );
+      betaBanner.init();
+      targetDom.dispatchEvent( clickEvent );
+
+      window.setTimeout( function() {
+        expect( toggleStoredStateSpy.called ).to.be.true;
+      }, 0 );
+    } );
+  } );
+
+  describe( 'toggleStoredState', function() {
+    it( 'should set the localStorage state to collasped', function() {
+      expect( webStorageProxy.getItem( 'betaBannerIsExpanded' ) )
+       .to.be.undefined;
+      betaBanner.init();
+      betaBanner.toggleStoredState();
+      expect( webStorageProxy.getItem( 'betaBannerIsExpanded' ) === 'true' );
+    } );
+
+    it( 'should set the localStorage state to expanded', function() {
+      expect( webStorageProxy.getItem( 'betaBannerIsExpanded' ) )
+        .to.be.undefined;
+      betaBanner.init();
+      betaBanner.toggleStoredState();
+      betaBanner.toggleStoredState();
+      expect( webStorageProxy.getItem( 'betaBannerIsExpanded' ) === 'false' );
+    } );
+  } );
+
+  describe( 'destroy', function() {
+    it( 'should remove event handlers and local storage data', function() {
+      betaBanner.toggleStoredState.restore();
+      var toggleStoredStateSpy = sinon.spy( betaBanner, 'toggleStoredState' );
+      betaBanner.init();
+      betaBanner.toggleStoredState();
+      expect( webStorageProxy.getItem( 'betaBannerIsExpanded' ) === 'true' );
+      betaBanner.destroy();
+      expect( webStorageProxy.getItem( 'betaBannerIsExpanded' ) )
+       .to.be.undefined;
+
+      targetDom.dispatchEvent( clickEvent );
+      window.setTimeout( function() {
+        expect( toggleStoredStateSpy.called ).to.be.false;
+      }, 0 );
+
+    } );
+  } );
+
+
+} );
+


### PR DESCRIPTION
Refactoring Beta Banner to use a general life cycle (`init`, `initEvents`, `destroy`). Also switched the code to use the Atomic Expandable.

## Testing

- Visit  `http://localhost:3000/`.

## Review

- @anselmbradford 
- @KimberlyMunoz 
- @jimmynotjim 

## Notes

- Currently working on the testing spec and trying to figure out how to test private functions.
- We should also consider passing boolean values instead of integers to set the initial state of the Expandable.

## Screenshots
<img width="1436" alt="screen shot 2016-01-27 at 10 54 16 am" src="https://cloud.githubusercontent.com/assets/1696212/12619055/6b27a7ee-c4e4-11e5-905a-3e9bdafa24c2.png">

