### PR TITLE
Removing social media from the top of browse pages.

### DIFF
--- a/cfgov/jinja2/v1/browse-basic/index.html
+++ b/cfgov/jinja2/v1/browse-basic/index.html
@@ -2,7 +2,6 @@
 
 {# Import organisms and molecules used in the template. #}
 {% import 'molecules/expandable.html' as expandable %}
-{% import 'molecules/social-media.html' as social_media %}
 
 {% import 'organisms/expandable-group.html' as expandable_group %}
 
@@ -40,10 +39,6 @@
 {%- endblock %}
 
 {% block content_main %}
-    <div class="block">
-        {{ social_media.render() }}
-    </div>
-
     {% for block in page.header -%}
         <div class="block">
             {{ render_stream_child(block) }}


### PR DESCRIPTION
This was unnecessarily added and shouldn't be on this type of page. I just checked with @schaferjh to confirm.

This fixes the issues in #1370 that were all occurring on browse-basic pages.

## Review
- @jimmynotjim 
- @anselmbradford 
- @sebworks 