### PR TITLE
Global search close button

### DIFF
--- a/cfgov/unprocessed/css/brand-palette.less
+++ b/cfgov/unprocessed/css/brand-palette.less
@@ -21,13 +21,14 @@
 
 @darkgray:          #43484E;
 
-@gray:              #75787B;
-@gray-80:           #919395;
-@gray-50:           #BABBBD;
-@gray-40:           #b4b5b6; // Close to what was known as "Gray 50"
-@gray-20:           #E3E4E5;
-@gray-10:           #F1F2F2;
-@gray-5:            #F8F8F8;
+@gray:         #5a5d61;
+@gray-80:      #75787b; // Formerly known as regular ol' "Gray"
+@gray-60:      #919395; // Formerly known as "Gray 80"
+@gray-50:      #BABBBD; // DEPRECATED. TODO: Remove when cf-layout is updated.
+@gray-40:      #b4b5b6; // Close to what was known as "Gray 50"
+@gray-20:      #d2d3d5;
+@gray-10:      #e7e8e9; // Close to what was known as "Gray 20"
+@gray-5:       #f7f8f9;
 
 
 // Secondary colors:

--- a/cfgov/unprocessed/css/molecules/global-search.less
+++ b/cfgov/unprocessed/css/molecules/global-search.less
@@ -152,28 +152,13 @@
 
             &[aria-expanded="true"] {
                 background: @gray-10;
-                border: 1px solid @gray-50;
-                border-bottom: none;
+                border-left: 1px solid @gray-40;
                 color: @black;
 
                 .cf-icon:before {
                     content: @cf-icon-delete;
                 }
 
-                // Cover up the border edge of the flyout so that it is attached
-                // visually to the trigger button.
-                &:after {
-                    display: block;
-                    height: 1px;
-                    width: 100%;
-
-                    position: absolute;
-                    left: 0;
-                    bottom: -1px;
-
-                    content: '\a0';
-                    background: @gray-10;
-                }
             }
         } );
 
@@ -217,11 +202,12 @@
             top: 60px;
             z-index: 10;
 
-            background-color: @gray-10;
-            border: 1px solid @gray-50;
+            background-color: @gray-5;
+            border-top: 1px solid @gray-40;
+            border-bottom: 1px solid @gray-40;
             pointer-events: auto;
 
-            transform: translateX(100%);
+            transform: translateX( 100% );
             transition: transform 0.25s ease-out;
 
             &-form {


### PR DESCRIPTION
## Changes

- Update the Global Search close button and content style to match the grays in https://github.com/cfpb/cfgov-refresh/pull/1399 for the mega menu hamburger menu.

## Testing

- `gulp build`
- Visit any page, change size to mobile, expand and collapse the global search.

## Review

- @duelj 
- @jimmynotjim 
- @sebworks 
- @KimberlyMunoz 

## Screenshots

![screen shot 2016-02-02 at 3 00 17 pm](https://cloud.githubusercontent.com/assets/704760/12762639/3602ac38-c9be-11e5-9dba-b1c3f80a00e1.png)

![screen shot 2016-02-02 at 3 00 27 pm](https://cloud.githubusercontent.com/assets/704760/12762640/3b0cb4ee-c9be-11e5-858f-299bf809501e.png)