### PR TITLE
Enabling Django Asset compression

### DIFF
--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -7,6 +7,7 @@ from django.conf import global_settings
 # Repository root is 4 levels above this file
 REPOSITORY_ROOT = Path(__file__).ancestor(4)
 
+
 # This is the root of the Django project, 'cfgov'
 PROJECT_ROOT = REPOSITORY_ROOT.child('cfgov')
 V1_TEMPLATE_ROOT = PROJECT_ROOT.child('jinja2', 'v1')
@@ -160,6 +161,13 @@ STATIC_ROOT = os.environ.get('DJANGO_STATIC_ROOT', '/var/www/html/static')
 
 MEDIA_ROOT = os.path.join(PROJECT_ROOT, 'f')
 MEDIA_URL = '/f/'
+
+#Enabling compression for use in base.html
+COMPRESS_ENABLED = True
+
+COMPRESS_ROOT = MEDIA_ROOT
+
+COMPRESS_JS_FILTERS = []
 
 # List of finder classes that know how to find static files in
 # various locations.

--- a/cfgov/jinja2/v1/_layouts/base.html
+++ b/cfgov/jinja2/v1/_layouts/base.html
@@ -105,6 +105,8 @@
         docElement.className = docElement.className.replace( /(^|\s)js(\s|$)/, '$1no-js$2' );
     </script>
     <![endif]-->
+    
+    <!--[if IE 9]><script src="{{ static('js/ie/common.ie.js') }}"></script><![endif]-->
 
     {# TODO: jQuery CDN is provided in the head to satisfy
              Google Tag Manager (GTM) requirements.
@@ -171,7 +173,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 {% block javascript %}
 <!--[if gt IE 8]><!-->
 {# Include site-wide JavaScript. #}
-<script type='text/javascript' src=" {{ get_js_bundle_name( '/js/routes/*.js' ) }} "></script>
+<script type='text/javascript' src=" {{ get_js_bundle_name( '/js/routes/common.*.js' ) }} "></script>
 
 {# Remove after sheer has been completely phased out #}
 {% if not page %}

--- a/cfgov/jinja2/v1/_layouts/base.html
+++ b/cfgov/jinja2/v1/_layouts/base.html
@@ -106,8 +106,6 @@
     </script>
     <![endif]-->
 
-    <!--[if IE 9]><script src="{{ static('js/ie/common.ie.js') }}"></script><![endif]-->
-
     {# TODO: jQuery CDN is provided in the head to satisfy
              Google Tag Manager (GTM) requirements.
              Ideally GTM would handle its own dependency management
@@ -173,9 +171,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 {% block javascript %}
 <!--[if gt IE 8]><!-->
 {# Include site-wide JavaScript. #}
-<script type='text/javascript'>
-    {% include '/js/routes/common.js' %}
-</script>
+<script type='text/javascript' src=" {{ get_js_bundle_name( '/js/routes/*.js' ) }} "></script>
 
 {# Remove after sheer has been completely phased out #}
 {% if not page %}
@@ -202,10 +198,13 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     {% endif %}
 {% endmacro %}
 {% set js_source = page_template_js() | trim %}
+
 {% if js_source | length > 0 %}
+{% compress js %}
 <script type='text/javascript'>
     {{ js_source }}
 </script>
+{% endcompress %}
 {% endif %}
 <!--<![endif]-->
 {% endblock javascript %}

--- a/cfgov/v1/__init__.py
+++ b/cfgov/v1/__init__.py
@@ -11,7 +11,7 @@ from jinja2 import Environment, contextfunction, Markup
 from sheerlike import environment as sheerlike_environment
 from compressor.contrib.jinja2ext import CompressorExtension
 from flags.template_functions import flag_enabled, flag_disabled
-from util.util import get_unique_id
+from util.util import get_unique_id, get_js_bundle_name
 
 from wagtail.wagtailcore.rich_text import expand_db_html, RichText
 from bs4 import BeautifulSoup
@@ -44,6 +44,7 @@ def environment(**options):
         'parse_links': external_links_filter,
         'get_protected_url': get_protected_url,
         'related_metadata_tags': related_metadata_tags,
+        'get_js_bundle_name': get_js_bundle_name
     })
     env.filters.update({
         'slugify': slugify,

--- a/cfgov/v1/util/util.py
+++ b/cfgov/v1/util/util.py
@@ -1,4 +1,5 @@
 import collections
+import glob
 import re
 import os
 from itertools import chain
@@ -7,6 +8,9 @@ from django.conf import settings
 from wagtail.wagtailcore.blocks.stream_block import StreamValue
 from wagtail.wagtailcore.blocks.struct_block import StructValue
 from ref import related_posts_categories
+from django.contrib.staticfiles.finders import find
+
+
 
 def id_validator(id_string, search=re.compile(r'[^a-zA-Z0-9-_]').search):
     if id_string:
@@ -26,6 +30,12 @@ def get_unique_id(prefix='', suffix=''):
     index = hex(int(time() * 10000000))[2:]
     return prefix + str(index) + suffix
 
+def get_js_bundle_name( path ):
+    search_path = settings.STATICFILES_DIRS[0] + path
+    file_path = glob.glob( search_path )
+    if file_path:
+        path = file_path[0].replace(settings.STATICFILES_DIRS[0], settings.STATIC_URL)
+    return path
 
     # These messages are manually mirrored on the
     # Javascript side in error-messages-config.js

--- a/cfgov/v1/util/util.py
+++ b/cfgov/v1/util/util.py
@@ -8,7 +8,6 @@ from django.conf import settings
 from wagtail.wagtailcore.blocks.stream_block import StreamValue
 from wagtail.wagtailcore.blocks.struct_block import StructValue
 from ref import related_posts_categories
-from django.contrib.staticfiles.finders import find
 
 
 

--- a/config/webpack-config.js
+++ b/config/webpack-config.js
@@ -27,12 +27,10 @@ module.exports = {
   plugins: [
     new webpack.optimize.CommonsChunkPlugin( COMMON_BUNDLE_NAME ),
     new webpack.optimize.CommonsChunkPlugin( COMMON_BUNDLE_NAME,
-                                             [ COMMON_BUNDLE_NAME ] ),
+                                             'common.[chunkhash].js' ),
     // Change warnings flag to true to view linter-style warnings at runtime.
     new webpack.optimize.UglifyJsPlugin( {
       compress: { warnings: false }
     } ),
-    // Wrap JS in raw Jinja tags so included JS won't get parsed by Jinja.
-    new BannerFooterPlugin( '{% raw %}', '{% endraw %}', { raw: true } )
   ]
 };


### PR DESCRIPTION
Enabling Django Asset compression for performance benefits (one script/caching ).

## Testing

- Visit  `http://localhost:3000/` and view source.

## Review

- @anselmbradford 
- @KimberlyMunoz 
- @jimmynotjim 
- @rosskarchner 
- @kurtw 

## Notes

- I'm not sure if/how this impacts deployment of assets on production. Also not sure how cached assets are expired/refreshed.

## Screenshots
 Before : 

<img width="1399" alt="screen shot 2016-02-05 at 7 37 07 am" src="https://cloud.githubusercontent.com/assets/1696212/12846604/5f8c1660-cbdb-11e5-8286-bb21f7c91586.png">

After:
<img width="880" alt="screen shot 2016-02-05 at 7 37 31 am" src="https://cloud.githubusercontent.com/assets/1696212/12846612/6d9c8492-cbdb-11e5-800a-b5f4afd85b16.png">


