### PR TITLE
Fixing Email Links on Contact Info

### DIFF
--- a/cfgov/jinja2/v1/_includes/molecules/contact-email.html
+++ b/cfgov/jinja2/v1/_includes/molecules/contact-email.html
@@ -21,7 +21,7 @@
         <p>
             {% for email in value.emails %}
                 <a href="mailto:{{ email.url }}">
-                    {{ email.text }}
+                    {{ email.url }}
                 </a><br>
             {% endfor %}
         </p>
@@ -29,8 +29,8 @@
         {% macro render(emails) %}
             <p>
                 {% for email in emails %}
-                    <a href="mailto:{{ email }}">
-                        {{ email }}
+                    <a href="mailto:{{ email.url }}">
+                        {{ email.text }}
                     </a><br>
                 {% endfor %}
             </p>

--- a/cfgov/jinja2/v1/_includes/organisms/sidebar-contact-info.html
+++ b/cfgov/jinja2/v1/_includes/organisms/sidebar-contact-info.html
@@ -43,9 +43,9 @@
     <div class="o-sidebar-contact-info">
         <div class="o-sidebar-contact-info_heading">
             <h2 class="header-slug">
-            <span class="header-slug_inner">
-                Contact Information
-            </span>
+                <span class="header-slug_inner">
+                    Contact Information
+                </span>
             </h2>
         </div>
 
@@ -72,7 +72,6 @@
 
         <div class="o-sidebar-contact-info_column">
             {% if page.contact.contact_info %}
-
                 {% for block in page.contact.contact_info %}
                     {{ render_stream_child(block) }}
                 {% endfor %}
@@ -84,9 +83,9 @@
         <div class="o-sidebar-contact-info">
             <div class="o-sidebar-contact-info_heading">
                 <h2 class="header-slug">
-            <span class="header-slug_inner">
-                Contact Information
-            </span>
+                    <span class="header-slug_inner">
+                        Contact Information
+                    </span>
                 </h2>
             </div>
 
@@ -108,21 +107,28 @@
             </div>
 
             <div class="o-sidebar-contact-info_column">
+                {% if contact.emails %}
+                    {{ contact_email.render(contact.emails) }}
+                {% endif %}
 
-                {{ contact_email.render(contact.emails) }}
+                {% if contact.phones %}
+                    {{ contact_phone.render(contact.phones) }}
+                {% endif %}
 
-                {{ contact_phone.render(contact.phones) }}
+                {% if contact.faxes %}
+                    {{ contact_phone.render(contact.faxes, true) }}
+                {% endif %}
 
-                {{ contact_phone.render(contact.faxes, true) }}
-
-                {{ contact_address.render({
-                        'label':    'Mailing Address',
-                        'title':    contact.address.title,
-                        'street':   contact.address.street,
-                        'city':     contact.address.city,
-                        'state':    contact.address.state,
-                        'zip_code': contact.address.zip_code
-                        }) }}
+                {% if contact.address %}
+                    {{ contact_address.render({
+                            'label':    'Mailing Address',
+                            'title':    contact.address.title,
+                            'street':   contact.address.street,
+                            'city':     contact.address.city,
+                            'state':    contact.address.state,
+                            'zip_code': contact.address.zip_code
+                            }) }}
+                {% endif %}
             </div>
         </div>
     {% endmacro %}


### PR DESCRIPTION
This fixes the issue where the email would appear as "email"
Fixes DFJR-745.

## Testing

- Create a sublanding page with a "Contact Info" molecule in the sidebar
- Select a contact with email like "Accessibility Feedback"
- Preview page

## Screenshot

![image](https://cloud.githubusercontent.com/assets/1860176/12854948/9ca2e8ec-cc0a-11e5-818f-21e4bb66dff6.png)

## Review

- @jimmynotjim 
- @anselmbradford 
- @sebworks 