### PR TITLE
Global search - keyboard + hiding

### DIFF
--- a/cfgov/jinja2/v1/_includes/molecules/global-search.html
+++ b/cfgov/jinja2/v1/_includes/molecules/global-search.html
@@ -44,6 +44,7 @@
             <div class="m-global-search_content-suggestions">
                 <p class="h5">Suggested search terms:</p>
                 <ul class="list list__horizontal">
+                    {# TODO: Add suggested link URLs. #}
                     <li class="list_item"><a class="list_link" href="#">Regulations</a></li>
                     <li class="list_item"><a class="list_link" href="#">Compliance guides</a></li>
                     <li class="list_item"><a class="list_link" href="#">Mortgage</a></li>
@@ -51,5 +52,6 @@
                 </ul>
             </div>
         </form>
+        <button class="m-global-search_tab-trigger" aria-hidden></button>
     </div>
 </div>

--- a/cfgov/unprocessed/css/cf-enhancements.less
+++ b/cfgov/unprocessed/css/cf-enhancements.less
@@ -1369,11 +1369,7 @@ textarea {
   patterns:
     - name: Utility class
       markup: |
-        <h1>
-            <a href="#">
-                <span class="u-hidden">Not shown</span>
-            </a>
-        </h1>
+        <span class="u-hidden">Not shown</span>
       codenotes:
         - .u-hidden;
       notes:
@@ -1386,6 +1382,29 @@ textarea {
 
 .u-hidden {
     display: none;
+}
+
+
+/* topdoc
+  name: Invisible
+  family: cf-core
+  patterns:
+    - name: Utility class
+      markup: |
+        <span class="u-invisible">Not shown</span>
+      codenotes:
+        - .u-invisible;
+      notes:
+        - "Use this class to make something invisible.
+           Useful for hiding off-screen elements that
+           are part of an animation, but you don't want
+           as part of the tabindex."
+  tags:
+    - cf-core
+*/
+
+.u-invisible {
+    visibility: hidden;
 }
 
 

--- a/cfgov/unprocessed/css/misc.less
+++ b/cfgov/unprocessed/css/misc.less
@@ -631,6 +631,22 @@
     text-transform: uppercase;
 }
 
+// Creates semi-transparent drop-shadow after element.
+.u-drop-shadow-after() {
+    &:after {
+        display: block;
+        height: 5px;
+        width: 100%;
+
+        position: relative;
+        top: 5px;
+
+        background: @gray;
+        // Whitespace in content so element can have dimensions set.
+        content: '\a0';
+        opacity: 0.2;
+    }
+}
 
 /* topdoc
   name: EOF

--- a/cfgov/unprocessed/css/molecules/global-search.less
+++ b/cfgov/unprocessed/css/molecules/global-search.less
@@ -94,21 +94,7 @@
     - cfgov-molecules
 */
 
-.m-global-search {
-
-    // Absolute position when there is a flyout at mobile/tablet sizes.
-    .respond-to-max( @bp-sm-max, {
-        // Make the height large so that the overflowing flyout can be hidden,
-        // but not get cropped when it's visible.
-        height: 500px;
-        width: 100%;
-        position: absolute;
-        top: 0;
-        overflow-x: hidden;
-        // TODO: This will be ignored in IE8-10,
-        //       leading to the overflow preventing clicks on the links.
-        pointer-events: none;
-    } );
+.js .m-global-search {
 
     &_trigger {
         height: unit( 45px / 18px, em );
@@ -134,21 +120,50 @@
             content: @cf-icon-search;
             font-size: unit( 20px / 18px, em );
         }
+    }
 
-        // Show "Search" text in trigger at tablet sizes.
-        .respond-to-min( @bp-sm-min {
-            &-label:before {
-                .webfont-medium();
-                content: 'Search';
+    &_content {
+        padding-top: unit( @grid_gutter-width / 4 / @base-font-size-px, em );
+
+        transform: translateX( 100% );
+        transition: transform 0.25s ease-out;
+
+        &[aria-expanded="true"] {
+            display: block;
+
+            transform: translateX( 0 );
+        }
+
+        &-suggestions {
+            display: none;
+
+            .h5,
+            .list {
+                display: inline-block;
             }
-        } );
+        }
+    }
 
-        // Only show flyout and close trigger at tablet/mobile sizes.
-        .respond-to-max( @bp-sm-max, {
+    // Tablet size and below.
+    .respond-to-max( @bp-sm-max, {
+        // Absolute position when there is a flyout at mobile/tablet sizes.
+        // Make the height large so that the overflowing flyout can be hidden,
+        // but not get cropped when it's visible.
+        height: 500px;
+        width: 100%;
+        position: absolute;
+        top: 0;
+        overflow-x: hidden;
+        // TODO: This will be ignored in IE8-10,
+        //       leading to the overflow preventing clicks on the links.
+        pointer-events: none;
+
+        &_trigger {
             height: unit( 60px / 18px, em );
             min-width: unit( 60px / 18px, em );
             padding-top: unit( @grid_gutter-width / 2 / 18px, em );
             padding-bottom: unit( @grid_gutter-width / 2 / 18px, em );
+            display: block;
 
             &[aria-expanded="true"] {
                 background: @gray-10;
@@ -158,41 +173,10 @@
                 .cf-icon:before {
                     content: @cf-icon-delete;
                 }
-
             }
-        } );
-
-        // Show "Close" text in trigger at tablet sizes.
-        .respond-to-range( @bp-sm-min, @bp-med-min, {
-            &[aria-expanded="true"] {
-                .m-global-search_trigger-label:before {
-                    content: 'Close';
-                }
-            }
-        } );
-
-        .respond-to-min( @bp-med-min {
-            &[aria-expanded="true"] {
-                display: none;
-            }
-        } );
-    }
-
-    &_content {
-        .respond-to-min( @bp-med-min {
-            display: none;
-        } );
-
-        padding-top: unit( @grid_gutter-width / 4 / @base-font-size-px, em );
-
-        &[aria-expanded="true"] {
-            display: block;
-
-            transform: translateX(0);
         }
 
-        // Create flyout at table/mobile size.
-        .respond-to-max( @bp-sm-max, {
+        &_content {
             box-sizing: border-box;
             width: 100%;
 
@@ -207,9 +191,6 @@
             border-bottom: 1px solid @gray-40;
             pointer-events: auto;
 
-            transform: translateX( 100% );
-            transition: transform 0.25s ease-out;
-
             &-form {
                 padding-top: @margin__em;
                 padding-left: @margin_half__em;
@@ -217,37 +198,77 @@
                 padding-bottom: @margin_half__em;
             }
 
-            // Drop-shadow under the search flyout menu at mobile/tablet size.
-            &:after {
-                position: relative;
-                top: 5px;
-                content: '\a0';
-                display: block;
-                height: 5px;
-                width: 100%;
-                opacity: 0.2;
-                background: @gray;
-            }
-        } );
+            .u-drop-shadow-after();
+        }
+    } );
 
-        &-suggestions {
-            display: none;
-
-            // Only show search suggestions at tablet size.
-            .respond-to-range( @bp-sm-min, @bp-sm-max, {
-                & {
-                    display: block;
-                }
-            } );
-
-            .h5,
-            .list {
-                display: inline-block;
+    // Tablet size and above.
+    .respond-to-min( @bp-sm-min {
+        &_trigger {
+            // Show "Search" text in trigger at tablet sizes.
+            &-label:before {
+                .webfont-medium();
+                content: 'Search';
             }
         }
-    }
+    } );
+
+    // Tablet size only.
+    .respond-to-range( @bp-sm-min, @bp-med-min, {
+        // Show "Close" text in trigger at tablet sizes.
+        &_trigger {
+            &[aria-expanded="true"] {
+                .m-global-search_trigger-label:before {
+                    content: 'Close';
+                }
+            }
+        }
+
+        // Only show search suggestions at tablet size.
+        &_content-suggestions {
+            display: block;
+        }
+    } );
+
+    // Desktop size.
+    .respond-to-min( @bp-med-min {
+      overflow: hidden;
+
+      // Match height of Search button at desktop size.
+      // Used to make overflow cover one line only.
+      // 1px offset is to expand overflow area by 1px
+      // so that the focus outline is not cropped.
+      max-height: 47px;
+      position: relative;
+      left: -1px;
+      top: -1px;
+
+      &_trigger,
+      &_trigger:focus,
+       {
+        position: relative;
+        top: 1px;
+      }
+      &_content {
+        position: relative;
+        left: 1px;
+      }
+
+
+      &_trigger {
+          &[aria-expanded="true"] {
+              display: none;
+          }
+      }
+
+      &_content {
+          padding-right: @margin_half__em;
+      }
+
+    } );
 
     // TODO: Move these styles to cf-enhancements/cf-forms.
+    // Mobile size.
     .respond-to-min( 480px, {
         &_content-form {
             // Attach button to input.
@@ -265,6 +286,22 @@
             }
         }
     } );
+}
+
+.m-global-search {
+    // Tab trigger is used to capture press of the tab key so that
+    // global search can be collapsed when it hits this element.
+    &_tab-trigger {
+        position: absolute;
+        top: -9999px;
+        left: -9999px;
+    }
+}
+
+.no-js .m-global-search {
+    &_trigger {
+        display: none;
+    }
 }
 
 /* topdoc

--- a/cfgov/unprocessed/css/organisms/header.less
+++ b/cfgov/unprocessed/css/organisms/header.less
@@ -82,10 +82,6 @@
 
             & > .m-global-search {
                 float: right;
-
-                .m-global-search_content {
-                    padding-right: @margin_half__em;
-                }
             }
         } );
 

--- a/cfgov/unprocessed/js/modules/FlyoutMenu.js
+++ b/cfgov/unprocessed/js/modules/FlyoutMenu.js
@@ -1,0 +1,165 @@
+'use strict';
+
+// Required modules.
+var EventObserver = require( '../modules/util/EventObserver' );
+
+/**
+ * FlyoutMenu
+ * @class
+ *
+ * @classdesc Initializes a new FlyoutMenu molecule.
+ *
+ * @param {HTMLNode} element
+ *   The DOM element within which to search for the molecule.
+ * @param {string} triggerSel - The selector for the menu trigger.
+ * @param {string} contentSel - The selector for the menu content.
+ * @param {string} altTriggerSel - The selector for a second menu trigger.
+ * @returns {Object} A FlyoutMenu instance.
+ */
+function FlyoutMenu( element, triggerSel, contentSel, altTriggerSel ) {
+
+  var _isExpanded = false;
+
+  var _triggerDom = element.querySelector( triggerSel );
+  var _contentDom = element.querySelector( contentSel );
+  var _altTriggerDom = element.querySelector( altTriggerSel );
+
+  var _transitionEndEvent = _getTransitionEndEvent( _contentDom );
+  var _isAnimating = false;
+
+  // Needed to add and remove events to transitions.
+  var _expandEndBinded = _expandEnd.bind( this );
+  var _collapseEndBinded = _collapseEnd.bind( this );
+
+  /**
+   * @returns {Object} The FlyoutMenu instance.
+   */
+  function init() {
+    _triggerDom.addEventListener( 'click', _triggerClicked.bind( this ) );
+
+    if ( altTriggerSel ) {
+      _altTriggerDom.addEventListener( 'click', _triggerClicked.bind( this ) );
+    }
+
+    return this;
+  }
+
+  /**
+   * Event handler for when the search input trigger is clicked,
+   * which opens/closes the search input.
+   * @param {MouseEvent} event - The flyout trigger was clicked.
+   */
+  function _triggerClicked( event ) {
+    event.preventDefault();
+    this.dispatchEvent( 'triggerClick', { target: event.target } );
+    if ( _isExpanded ) {
+      this.collapse();
+    } else {
+      this.expand();
+    }
+  }
+
+  /**
+   * Open the search box.
+   * @returns {Object} A FlyoutMenu instance.
+   */
+  function expand() {
+    if ( !_isExpanded && !_isAnimating ) {
+      this.dispatchEvent( 'toggle', { target: this } );
+      this.dispatchEvent( 'expandBegin', { target: this } );
+      _isExpanded = true;
+      _isAnimating = true;
+      // If transition is not supported, call handler directly (IE9/OperaMini).
+      if ( _transitionEndEvent ) {
+        _contentDom.addEventListener( _transitionEndEvent, _expandEndBinded );
+      } else {
+        _expandEndBinded();
+      }
+      _triggerDom.setAttribute( 'aria-expanded', 'true' );
+      _contentDom.setAttribute( 'aria-expanded', 'true' );
+    }
+
+    return this;
+  }
+
+  /**
+   * Close the search box.
+   * @returns {Object} A FlyoutMenu instance.
+   */
+  function collapse() {
+    if ( _isExpanded && !_isAnimating ) {
+      this.dispatchEvent( 'toggle', { target: this } );
+      this.dispatchEvent( 'collapseBegin', { target: this } );
+      _isExpanded = false;
+      _isAnimating = true;
+      // If transition is not supported, call handler directly (IE9/OperaMini).
+      if ( _transitionEndEvent ) {
+        _contentDom.addEventListener( _transitionEndEvent, _collapseEndBinded );
+      } else {
+        _collapseEndBinded();
+      }
+      _triggerDom.setAttribute( 'aria-expanded', 'false' );
+      _contentDom.setAttribute( 'aria-expanded', 'false' );
+      _triggerDom.focus();
+    }
+
+    return this;
+  }
+
+  /**
+   * Expand animation has completed.
+   */
+  function _expandEnd() {
+    _isAnimating = false;
+    _contentDom.removeEventListener( _transitionEndEvent, _expandEndBinded );
+    this.dispatchEvent( 'expandEnd', { target: this } );
+  }
+
+  /**
+   * Collapse animation has completed.
+   */
+  function _collapseEnd() {
+    _isAnimating = false;
+    _contentDom.removeEventListener( _transitionEndEvent, _collapseEndBinded );
+    this.dispatchEvent( 'collapseEnd', { target: this } );
+  }
+
+  // Attach public events.
+  var eventObserver = new EventObserver();
+  this.addEventListener = eventObserver.addEventListener;
+  this.removeEventListener = eventObserver.removeEventListener;
+  this.dispatchEvent = eventObserver.dispatchEvent;
+
+  this.init = init;
+  this.expand = expand;
+  this.collapse = collapse;
+
+  return this;
+}
+
+// TODO: Move to a utility module and share this between Expandables and here.
+/**
+ * @param {HTMLNode} elm
+ *   The element to check for support of transition end event.
+ * @returns {string} The browser-prefixed transition end event.
+ */
+function _getTransitionEndEvent( elm ) {
+  var transition;
+  var transitions = {
+    WebkitTransition: 'webkitTransitionEnd',
+    MozTransition:    'transitionend',
+    OTransition:      'oTransitionEnd otransitionend',
+    transition:       'transitionend'
+  };
+
+  for ( var t in transitions ) {
+    if ( transitions.hasOwnProperty( t ) &&
+         typeof elm.style[t] !== 'undefined' ) {
+      transition = transitions[t];
+      break;
+    }
+  }
+  return transition;
+}
+
+module.exports = FlyoutMenu;

--- a/cfgov/unprocessed/js/molecules/GlobalSearch.js
+++ b/cfgov/unprocessed/js/molecules/GlobalSearch.js
@@ -6,6 +6,8 @@ if ( !Modernizr.classlist ) { require( '../modules/polyfill/class-list' ); } // 
 // Required modules.
 var atomicCheckers = require( '../modules/util/atomic-checkers' );
 var breakpointState = require( '../modules/util/breakpoint-state' );
+var EventObserver = require( '../modules/util/EventObserver' );
+var FlyoutMenu = require( '../modules/FlyoutMenu' );
 
 /**
  * GlobalSearch
@@ -17,19 +19,22 @@ var breakpointState = require( '../modules/util/breakpoint-state' );
  *   The DOM element within which to search for the molecule.
  * @returns {Object} An GlobalSearch instance.
  */
-function GlobalSearch( element ) {
+function GlobalSearch( element ) { // eslint-disable-line max-statements, no-inline-comments, max-len
 
   var BASE_CLASS = 'm-global-search';
 
   var _dom =
     atomicCheckers.validateDomElement( element, BASE_CLASS, 'GlobalSearch' );
-  var _triggerDom = _dom.querySelector( '.' + BASE_CLASS + '_trigger' );
+  var _triggerSel = '.' + BASE_CLASS + '_trigger';
+  var _triggerDom = _dom.querySelector( _triggerSel );
+  var _flyoutMenu =
+    new FlyoutMenu( _dom, _triggerSel, '.' + BASE_CLASS + '_content' ).init();
   var _contentDom = _dom.querySelector( '.' + BASE_CLASS + '_content' );
   var _searchInputDom;
+  var _searchBtnDom;
   var _clearBtnDom;
-
-  var _isExpanded = false;
-  var _tabPressed = false;
+  var _tabTriggerDom =
+    _contentDom.querySelector( '.' + BASE_CLASS + '_tab-trigger' );
 
   var KEY_TAB = 9;
 
@@ -37,96 +42,141 @@ function GlobalSearch( element ) {
    * @returns {Object} The GlobalSearch instance.
    */
   function init() {
-    var inputSelector = '.' + BASE_CLASS + '_content-form input';
-    var clearBtnSelector =
-      '.' + BASE_CLASS + ' .input-contains-label_after__clear';
-    var searchIconSelector =
-      '.' + BASE_CLASS + ' .input-contains-label_before__search';
-    var searchBtnSelector = '.' + BASE_CLASS + ' .input-with-btn_btn button';
+    var inputSel = '.' + BASE_CLASS + '_content-form input';
+    var clearBtnSel = '.' + BASE_CLASS + ' .input-contains-label_after__clear';
+    var searchBtnSel = '.' + BASE_CLASS + ' .input-with-btn_btn button';
 
-    _searchInputDom = _contentDom.querySelector( inputSelector );
-    var searchIconDom = _contentDom.querySelector( searchIconSelector );
-    var searchBtnDom = _contentDom.querySelector( searchBtnSelector );
-    _clearBtnDom = _contentDom.querySelector( clearBtnSelector );
+    _searchInputDom = _contentDom.querySelector( inputSel );
+    _searchBtnDom = _contentDom.querySelector( searchBtnSel );
+    _clearBtnDom = _contentDom.querySelector( clearBtnSel );
 
-    _triggerDom.addEventListener( 'click', _triggerClicked );
+    _flyoutMenu.addEventListener( 'toggle',
+                                  _handleToggle.bind( this ) );
+    _flyoutMenu.addEventListener( 'expandBegin', _handleExpandBegin );
+    _flyoutMenu.addEventListener( 'collapseBegin', _handleCollapseBegin );
+    _flyoutMenu.addEventListener( 'collapseEnd', _handleCollapseEnd );
+
     _clearBtnDom.addEventListener( 'mousedown', _clearClicked );
     _searchInputDom.addEventListener( 'keyup', _inputTyped );
-    _searchInputDom.addEventListener( 'blur', _searchBlurred );
-    searchBtnDom.addEventListener( 'mousedown', _searchBtnClicked );
-    searchIconDom.addEventListener( 'click', _searchIconClicked );
-
-    _contentDom.addEventListener( 'keydown', _handleTabPress );
+    _tabTriggerDom.addEventListener( 'keyup', _handleTabPress );
 
     _setClearBtnState( _searchInputDom.value );
+
+    // Set initial collapse state.
+    _handleCollapseEnd();
 
     return this;
   }
 
   /**
-   * Event handler for when the keyboard is pressed on the HTML document body.
-   * If the tab key was pressed, record the press so that when
-   * getting to the search input, the input won't collapse when
-   * tabbing between the input and the search button.
-   * @param {KeyboardEvent} event The event object for the keyboard key press.
+   * Event handler for when there's a click on the page's body.
+   * Used to close the global search, if needed.
+   * @param {MouseEvent} event The event object for the mousedown event.
+   */
+  function _handleBodyClick( event ) {
+    var target = event.target;
+
+    var isInDesktop = _isInDesktop();
+    if ( isInDesktop && !_isDesktopTarget( target ) ||
+         !isInDesktop && !_isMobileTarget( target ) ) {
+      collapse();
+    }
+  }
+
+  /**
+   * Whether currently in the desktop view.
+   * @returns {boolean} True if in the desktop view, otherwise false.
+   */
+  function _isInDesktop() {
+    var isInDesktop = false;
+    var currentBreakpoint = breakpointState.get();
+    if ( currentBreakpoint.isBpMED ||
+         currentBreakpoint.isBpLG ||
+         currentBreakpoint.isBpXL ) {
+      isInDesktop = true;
+    }
+    return isInDesktop;
+  }
+
+  /**
+   * Whether a target is one of the ones that appear in the desktop view.
+   * @param {HTMLNode} target - The target of a mouse event (most likely).
+   * @returns {boolean} True if the passed target is in the desktop view.
+   */
+  function _isDesktopTarget( target ) {
+    return target === _searchInputDom ||
+           target === _searchBtnDom ||
+           target === _clearBtnDom;
+  }
+
+  /**
+   * Whether a target is one of the ones that appear in the mobile view.
+   * @param {HTMLNode} target - The target of a mouse event (most likely).
+   * @returns {boolean} True if the passed target is in the mobile view.
+   */
+  function _isMobileTarget( target ) {
+    var bodyElem = document.body;
+    target = target.parentNode;
+    do {
+      if ( target === _dom ) {
+        return true;
+      } else if ( target === bodyElem ) {
+        return false;
+      }
+      target = target.parentNode;
+    } while ( target );
+  }
+
+  /**
+   * Event handler for when the tab key is pressed.
+   * @param {KeyboardEvent} event
+   *   The event object for the keyboard key press.
    */
   function _handleTabPress( event ) {
     if ( event.keyCode === KEY_TAB ) {
-      _tabPressed = true;
-    }
-  }
-
-  /**
-   * Event handler for when the search icon is clicked in the
-   * expanded state at desktop sizes. Closes the search box.
-   */
-  function _searchIconClicked() {
-    _collapseIfDesktop();
-  }
-
-  /**
-   * Force a click on the search button after it has been clicked.
-   * This is necessary to handle the button before the search input blurs.
-   * @param {MouseEvent} event The event object for mousedown event.
-   */
-  function _searchBtnClicked( event ) {
-    event.target.click();
-  }
-
-  /**
-   * Event handler for when the search input loses focus.
-   * Closes the search input if the tab key was not pressed.
-   */
-  function _searchBlurred() {
-    if ( !_tabPressed ) {
-      _collapseIfDesktop();
-    } else {
-      _tabPressed = false;
-    }
-  }
-
-  /**
-   * Collapse the search box if screen is at desktop sizes.
-   */
-  function _collapseIfDesktop() {
-    var currentBreakpoint = breakpointState.get();
-    if ( ( currentBreakpoint.isBpMED ||
-         currentBreakpoint.isBpLG ||
-         currentBreakpoint.isBpXL ) ) {
       collapse();
     }
   }
 
   /**
-   * Event handler for when the search input trigger is clicked,
+   * Event handler for when the search input flyout is toggled,
    * which opens/closes the search input.
    */
-  function _triggerClicked() {
-    if ( _isExpanded ) {
-      collapse();
-    } else {
-      expand();
-    }
+  function _handleToggle() {
+    this.dispatchEvent( 'toggle', { target: this } );
+  }
+
+  /**
+   * Event handler for when FlyoutMenu expand transition begins.
+   * Use this to perform post-expandBegin actions.
+   */
+  function _handleExpandBegin() {
+    if ( _isInDesktop() ) { _triggerDom.classList.add( 'u-hidden' ); }
+    _contentDom.classList.remove( 'u-invisible' );
+    _searchInputDom.select();
+
+    document.body.addEventListener( 'mousedown', _handleBodyClick );
+  }
+
+  /**
+   * Event handler for when FlyoutMenu collapse transition begins.
+   * Use this to perform post-collapseBegin actions.
+   */
+  function _handleCollapseBegin() {
+    _triggerDom.classList.remove( 'u-hidden' );
+    document.body.removeEventListener( 'mousedown', _handleBodyClick );
+  }
+
+  /**
+   * Event handler for when FlyoutMenu collapse transition ends.
+   * Use this to perform post-collapseEnd actions.
+   */
+  function _handleCollapseEnd() {
+    // TODO: When tabbing is used to collapse the search flyout
+    //       it will not animate with the below line.
+    //       Investigate why this is the case for tab key
+    //       but not with mouse clicks.
+    _contentDom.classList.add( 'u-invisible' );
   }
 
   /**
@@ -134,12 +184,7 @@ function GlobalSearch( element ) {
    * @returns {Object} An GlobalSearch instance.
    */
   function expand() {
-    if ( !_isExpanded ) {
-      _isExpanded = true;
-      _triggerDom.setAttribute( 'aria-expanded', 'true' );
-      _contentDom.setAttribute( 'aria-expanded', 'true' );
-      _searchInputDom.select();
-    }
+    _flyoutMenu.expand();
 
     return this;
   }
@@ -149,11 +194,7 @@ function GlobalSearch( element ) {
    * @returns {Object} An GlobalSearch instance.
    */
   function collapse() {
-    if ( _isExpanded ) {
-      _isExpanded = false;
-      _triggerDom.setAttribute( 'aria-expanded', 'false' );
-      _contentDom.setAttribute( 'aria-expanded', 'false' );
-    }
+    _flyoutMenu.collapse();
 
     return this;
   }
@@ -166,8 +207,7 @@ function GlobalSearch( element ) {
     _searchInputDom.value = _setClearBtnState( '' );
     _searchInputDom.focus();
 
-    // Prevent event bubbling up to the input,
-    // which would blur and trigger a collapse otherwise.
+    // Prevent event bubbling up to the input, which would blur otherwise.
     event.preventDefault();
   }
 
@@ -183,12 +223,11 @@ function GlobalSearch( element ) {
    * @returns {string} The input value in the search box.
    */
   function _setClearBtnState( value ) {
-    if ( value !== '' ) {
-      _showClearBtn();
-    } else {
+    if ( value === '' ) {
       _hideClearBtn();
+    } else {
+      _showClearBtn();
     }
-
     return value;
   }
 
@@ -208,9 +247,16 @@ function GlobalSearch( element ) {
     _clearBtnDom.classList.remove( 'u-hidden' );
   }
 
+  // Attach public events.
+  var eventObserver = new EventObserver();
+  this.addEventListener = eventObserver.addEventListener;
+  this.removeEventListener = eventObserver.removeEventListener;
+  this.dispatchEvent = eventObserver.dispatchEvent;
+
   this.init = init;
   this.expand = expand;
   this.collapse = collapse;
+
   return this;
 }
 


### PR DESCRIPTION
## Changes

- Updates Global search to:
  - Handle tabbing through the search
  - Clicking off the search box to close it.
  - Add basic no-js state.

## Testing

- `gulp build`

Keyboard:
- Resize to mobile size.
- tab through to highlight search magnifying glass, continue tabbing to pass by hidden search input.
- click in beta banner.
- tab through to highlight search magnifying glass.
- Press spacebar to expand menu.
- Press tab to tab off of global search and observe it closes.
- Repeat for desktop

Mouse:
- Resize to mobile size.
- Click magnifying glass to expand search.
- Click off global search element to close it.
- Repeat for desktop.

## Review

- @KimberlyMunoz 
- @sebworks 
- @jimmynotjim 

## Screenshots

![search](https://cloud.githubusercontent.com/assets/704760/12861388/f1314676-cc30-11e5-8cb3-b617dd4f1c50.gif)


## Todos

- Basic no-js state is present but stacking and padding will need to be added when no-js hamburger menu is added.