### PR TITLE
Color and display fix for global header cta

### DIFF
--- a/cfgov/unprocessed/css/molecules/global-header-cta.less
+++ b/cfgov/unprocessed/css/molecules/global-header-cta.less
@@ -34,6 +34,8 @@
 
     a {
         .webfont-medium();
+        // Colors for :link, :visited, :hover, :focus, :active.
+        .u-link__colors( @pacific, @pacific, @pacific-60, @pacific, @dark-navy );
 
         &:before {
             position: relative;
@@ -54,7 +56,8 @@
         padding-bottom: unit( @grid_gutter-width / 3 / @base-font-size-px, em );
     }
 
-    &__list {
+    &__list a {
+        display: block;
         padding-top: unit( @grid_gutter-width / 2 / @base-font-size-px, em );
         padding-bottom: unit( @grid_gutter-width / 2 / @base-font-size-px, em );
     }


### PR DESCRIPTION
## Changes

- Turns out the global header cta (and mega menu) shouldn't have visited link colors. This fixes the colors in the global header cta.
- Sets the padding on the link itself so that the "focus" state occupies the whole padded area.

## Testing

- `gulp build`
- Check global header cta in header. It should always be pacific blue and shouldn't have a visited link color.

## Review

- @jimmynotjim 
- @KimberlyMunoz 
- @sebworks 

## Screenshots

![screen shot 2016-02-08 at 12 09 09 pm](https://cloud.githubusercontent.com/assets/704760/12893859/9e9d46f2-ce61-11e5-9259-49753dbb9892.png)