### PR TITLE
Content bar fix

### DIFF
--- a/cfgov/jinja2/v1/index.html
+++ b/cfgov/jinja2/v1/index.html
@@ -13,7 +13,6 @@
 
     <main class="content" id="main" role="main">
 
-        <div class="content_bar"></div>
         {% include 'molecules/home-hero.html' %}
 
         <div class="o-well

--- a/cfgov/unprocessed/css/footer.less
+++ b/cfgov/unprocessed/css/footer.less
@@ -20,7 +20,7 @@
     // There is a 10px margin-bottom on the  last .footer_list li's, plus the
     // 50px bottom padding = 60px of total padding at the bottom of the footer.
     padding-bottom: unit(50px / @base-font-size-px, em);
-    border-top: 10px solid @green;
+    border-top: 5px solid @green;
     background: @gray-5;
 
     &_share-icon-list {


### PR DESCRIPTION
content_bar is not needed in homepage template as it's added by the header.

## Removals

- content_bar div from homepage template.

## Changes

- Narrows footer upper bar to 5px, per specs.

## Testing

- `gulp build` and check homepage header and footer green bars. Should be 5px.

## Review

- @jimmynotjim
- @sebworks 
- @KimberlyMunoz  
- @duelj 

## Screenshots

Header
![screen shot 2016-02-08 at 2 25 59 pm](https://cloud.githubusercontent.com/assets/704760/12896474/33b788de-ce70-11e5-9bd8-1a698cb9eb1b.png)

Footer
![screen shot 2016-02-08 at 2 26 05 pm](https://cloud.githubusercontent.com/assets/704760/12896479/3a61ea80-ce70-11e5-940e-174622f7b82a.png)
