### PR TITLE
Removing bottom spacing from last li in a bulleted list

### DIFF
--- a/cfgov/unprocessed/css/cf-enhancements.less
+++ b/cfgov/unprocessed/css/cf-enhancements.less
@@ -1585,6 +1585,17 @@ select[multiple] {
 }
 
 /* topdoc
+  name: Adjustment to remove spacing on last item on lists
+  family: cf-core
+  tags:
+    - cf-core
+*/
+
+:not(nav) li:last-child {
+    margin-bottom: 0
+}
+
+/* topdoc
     name: EOF
     eof: true
 */


### PR DESCRIPTION
Part of the work to bring spacing into Design's spacing specs including fixes cases where the spacing at the bottom of a list adds to the spacing at the bottom of a group. I've fixed this by adding a cf-enhancements rule to remove the padding.

**Before**
![image](https://cloud.githubusercontent.com/assets/1860176/12902955/3e9ebdb8-ce92-11e5-8f8e-20a94ffe2be3.png)

**After**
![image](https://cloud.githubusercontent.com/assets/1860176/12922850/28a98efe-cf21-11e5-8cc8-1e95fcdf8ac5.png)

## Review
- @jimmynotjim 
- @sebworks 
- @anselmbradford 