### PR TITLE
Adding two missing links to Related Links section

### DIFF
--- a/cfgov/jinja2/v1/budget/index.html
+++ b/cfgov/jinja2/v1/budget/index.html
@@ -139,14 +139,13 @@
                     </a>
                 </section>
                 <section class="u-mb20 content-l_col content-l_col-1-2">
-                    {# TODO: Add Civil Penalty Fund URL. #}
                     {%- import 'related-links.html' as related_links -%}
                     {{- related_links.render([
                         [ '/the-bureau/',
                           'About the CFPB' ],
                         [ '/blog/',
                           'The blog' ],
-                        [ '',
+                        [ '/sub-pages/civil-penalty-fund/',
                           'Civil Penalty Fund' ]
                     ]) -}}
                 </section>

--- a/cfgov/jinja2/v1/careers/index.html
+++ b/cfgov/jinja2/v1/careers/index.html
@@ -140,14 +140,13 @@
         {% include 'templates/activities-feed.html' %}
     </section>
     <section class="block">
-        {# TODO: Add OCR URL. #}
         {%- import 'related-links.html' as related_links -%}
         {{- related_links.render([
             [ '/blog/',
               'CFPB Blog' ],
             [ '/newsroom/',
               'Newsroom' ],
-            [ '',
+            [ '/offices/office-of-civil-rights/',
               'Office of Civil Rights' ]
         ]) -}}
     </section>


### PR DESCRIPTION
I was fixing an unrelated issue when I noticed two links to pages we hadn't changed.

## Review
- @sebworks 
- @anselmbradford 
- @jimmynotjim 