### PR TITLE
Spin off ClearableInput behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,9 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 
 ### Added
 - Added Backend sidebar contact
-- Add Related Metadata molecule to backend 
+- Added Related Metadata molecule to backend
+- Added `ClearableInput` class for clearable input behavior
+  in `input-contains-label` CF class.
 
 ### Changed
 - Converted the project to Capital Framework v3

--- a/cfgov/unprocessed/js/modules/ClearableInput.js
+++ b/cfgov/unprocessed/js/modules/ClearableInput.js
@@ -1,0 +1,96 @@
+'use strict';
+
+// Required polyfills for IE9.
+if ( !Modernizr.classlist ) { require( '../modules/polyfill/class-list' ); } // eslint-disable-line no-undef, global-require, no-inline-comments, max-len
+
+// Required modules.
+var atomicCheckers = require( '../modules/util/atomic-checkers' );
+
+/**
+ * ClearableInput
+ * @class
+ *
+ * @classdesc Initializes a new ClearableInput molecule.
+ *
+ * @param {HTMLNode} element
+ *   The DOM element within which to search for the molecule.
+ * @returns {Object} A ClearableInput instance.
+ */
+function ClearableInput( element ) {
+  var BASE_CLASS = 'input-contains-label';
+
+  var _dom =
+    atomicCheckers.validateDomElement( element, BASE_CLASS, 'ClearableInput' );
+  var _inputDom = _dom.querySelector( 'input' );
+  var _clearBtnDom = _dom.querySelector( '.' + BASE_CLASS + '_after__clear' );
+
+  var _isClearShowing = true;
+
+  /**
+   * @returns {Object} The ClearableInput instance.
+   */
+  function init() {
+    _clearBtnDom.addEventListener( 'mousedown', _clearClicked );
+    _inputDom.addEventListener( 'keyup', _inputTyped );
+
+    _setClearBtnState( _inputDom.value );
+
+    return this;
+  }
+
+  /**
+   * Event handler for when the clear input label was clicked.
+   * @param {MouseEvent} event - The event object for the mousedown event.
+   */
+  function _clearClicked( event ) {
+    _inputDom.value = _setClearBtnState( '' );
+    _inputDom.focus();
+
+    // Prevent event bubbling up to the input, which would blur otherwise.
+    event.preventDefault();
+  }
+
+  /**
+   * Event handler for when the user typed in the input.
+   */
+  function _inputTyped() {
+    _setClearBtnState( _inputDom.value );
+  }
+
+  /**
+   * @param {string} value - The input value in the search box.
+   * @returns {string} The input value in the search box.
+   */
+  function _setClearBtnState( value ) {
+    if ( _isClearShowing && value === '' ) {
+      _hideClearBtn();
+    } else if ( !_isClearShowing ) {
+      _showClearBtn();
+    }
+    return value;
+  }
+
+  /**
+   * Add a hidden class to the input search label.
+   * Used when there is no text input.
+   */
+  function _hideClearBtn() {
+    _clearBtnDom.classList.add( 'u-hidden' );
+    _isClearShowing = false;
+  }
+
+  /**
+   * Remove a hidden class from the input search label.
+   * Used when there is text input.
+   */
+  function _showClearBtn() {
+    _clearBtnDom.classList.remove( 'u-hidden' );
+    _isClearShowing = true;
+  }
+
+  this.init = init;
+
+  return this;
+}
+
+module.exports = ClearableInput;

--- a/cfgov/unprocessed/js/molecules/GlobalSearch.js
+++ b/cfgov/unprocessed/js/molecules/GlobalSearch.js
@@ -6,6 +6,7 @@ if ( !Modernizr.classlist ) { require( '../modules/polyfill/class-list' ); } // 
 // Required modules.
 var atomicCheckers = require( '../modules/util/atomic-checkers' );
 var breakpointState = require( '../modules/util/breakpoint-state' );
+var ClearableInput = require( '../modules/ClearableInput' );
 var EventObserver = require( '../modules/util/EventObserver' );
 var FlyoutMenu = require( '../modules/FlyoutMenu' );
 
@@ -44,13 +45,19 @@ function GlobalSearch( element ) { // eslint-disable-line max-statements, no-inl
    * @returns {Object} The GlobalSearch instance.
    */
   function init() {
-    var inputSel = '.' + BASE_CLASS + '_content-form input';
     var clearBtnSel = '.' + BASE_CLASS + ' .input-contains-label_after__clear';
+    var inputContainsLabelSel =
+      '.' + BASE_CLASS + '_content-form .input-contains-label';
     var searchBtnSel = '.' + BASE_CLASS + ' .input-with-btn_btn button';
 
-    _searchInputDom = _contentDom.querySelector( inputSel );
-    _searchBtnDom = _contentDom.querySelector( searchBtnSel );
     _clearBtnDom = _contentDom.querySelector( clearBtnSel );
+    var inputContainsLabel = _contentDom.querySelector( inputContainsLabelSel );
+    _searchInputDom = inputContainsLabel.querySelector( 'input' );
+    _searchBtnDom = _contentDom.querySelector( searchBtnSel );
+
+    // Initialize new clearable input behavior on the input-contains-label.
+    var clearableInput = new ClearableInput( inputContainsLabel );
+    clearableInput.init();
 
     _flyoutMenu.addEventListener( 'toggle',
                                   _handleToggle.bind( this ) );
@@ -58,11 +65,7 @@ function GlobalSearch( element ) { // eslint-disable-line max-statements, no-inl
     _flyoutMenu.addEventListener( 'collapseBegin', _handleCollapseBegin );
     _flyoutMenu.addEventListener( 'collapseEnd', _handleCollapseEnd );
 
-    _clearBtnDom.addEventListener( 'mousedown', _clearClicked );
-    _searchInputDom.addEventListener( 'keyup', _inputTyped );
     _tabTriggerDom.addEventListener( 'keyup', _handleTabPress );
-
-    _setClearBtnState( _searchInputDom.value );
 
     // Set initial collapse state.
     _handleCollapseEnd();
@@ -191,54 +194,6 @@ function GlobalSearch( element ) { // eslint-disable-line max-statements, no-inl
     _flyoutMenu.collapse();
 
     return this;
-  }
-
-  /**
-   * Event handler for when the clear input label was clicked.
-   * @param {MouseEvent} event The event object for the mousedown event.
-   */
-  function _clearClicked( event ) {
-    _searchInputDom.value = _setClearBtnState( '' );
-    _searchInputDom.focus();
-
-    // Prevent event bubbling up to the input, which would blur otherwise.
-    event.preventDefault();
-  }
-
-  /**
-   * Event handler for when the user typed in the input.
-   */
-  function _inputTyped() {
-    _setClearBtnState( _searchInputDom.value );
-  }
-
-  /**
-   * @param {string} value - The input value in the search box.
-   * @returns {string} The input value in the search box.
-   */
-  function _setClearBtnState( value ) {
-    if ( value === '' ) {
-      _hideClearBtn();
-    } else {
-      _showClearBtn();
-    }
-    return value;
-  }
-
-  /**
-   * Add a hidden class to the input search label.
-   * Used when there is no text input.
-   */
-  function _hideClearBtn() {
-    _clearBtnDom.classList.add( 'u-hidden' );
-  }
-
-  /**
-   * Remove a hidden class from the input search label.
-   * Used when there is text input.
-   */
-  function _showClearBtn() {
-    _clearBtnDom.classList.remove( 'u-hidden' );
   }
 
   // Attach public events.


### PR DESCRIPTION
Spins clearable input behavior out of the Global Search molecule.

## Additions

- Adds `ClearableInput` class for encapsulating `input-contains-label` clearable label behavior.

## Changes

- Updates Global Search to use ClearableInput instance.

## Testing

- `gulp build`
- Expand global search.
- Type something.
- Click (x) clear.
- Try at different screen sizes.
- Should work and be error-free.

## Review

- @KimberlyMunoz 
- @sebworks 
- @jimmynotjim 

## Todos

- Note that since the clear label is a label of input, it is not directly tab accessible as tabbing to the clear button automatically moves to the associated input. I think this is okay because the delete key can be used to remove the input? This is existing behavior.