### PR TITLE
Fix for notifier classes

### DIFF
--- a/cfgov/unprocessed/js/modules/jquery/cf_notifier.js
+++ b/cfgov/unprocessed/js/modules/jquery/cf_notifier.js
@@ -7,14 +7,14 @@
 var $ = require( 'jquery' );
 var handlebars = require( 'handlebars' );
 
-var _notifierTemplate = '<div class="cf-notification ' +
-                                    'cf-notification__{{ state }}" ' +
+var _notifierTemplate = '<div class="m-notification ' +
+                                    'm-notification__{{ state }}" ' +
                              'style="display: none;">' +
-  '<span class="cf-notification_icon ' +
-               'cf-notification_icon__{{ state }} ' +
-               'cf-icon cf-icon-{{ icon }}-round"></span>' +
-  '<p class="cf-notification_text">{{{ message }}}</p>' +
-  '</div>';
+                          '<span class="m-notification_icon cf-icon"></span>' +
+                          '<div class="m-notification_content">' +
+                              '<p class="h4 m-notification_message">{{{ message }}}</p>' +
+                          '</div>' +
+                        '</div>';
 
 var _notifier = {
   defaults: {


### PR DESCRIPTION
Updating the notifier markup to use the atomic classes.

## Testing

- Visit  `http://localhost:blog/` and enter invalid email address.

## Review

- @anselmbradford 
- @KimberlyMunoz 
- @jimmynotjim 

## Screenshots
 Before : 

<img width="340" alt="screen shot 2016-02-12 at 9 18 41 am" src="https://cloud.githubusercontent.com/assets/1696212/13009327/d3fc2092-d169-11e5-9fb0-b9c2344655e6.png">

After:

<img width="365" alt="screen shot 2016-02-12 at 9 18 22 am" src="https://cloud.githubusercontent.com/assets/1696212/13009365/fab7927a-d169-11e5-84ef-a4a41c16ad79.png">

