### PR TITLE
use clang when NPM needs to compile c++

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,8 @@ install:
   - pip install virtualenv virtualenvwrapper
   - pip install autoenv
   # Set g++ version for npm nan.
+  # this is terrible
+  - find / -name "g++-*"
   - export CXX=g++-4.8
   - $CXX --version
   - npm install nvm

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ install:
   # Project configuration requirements.
   - pip install virtualenv virtualenvwrapper
   - pip install autoenv
+  - export CXX=clang++
   - npm install nvm
   - nvm install 5.2.0
   - nvm use 5.2.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,11 +19,6 @@ install:
   # Project configuration requirements.
   - pip install virtualenv virtualenvwrapper
   - pip install autoenv
-  # Set g++ version for npm nan.
-  # this is terrible
-  - find / -name "g++-*"
-  - export CXX=g++-4.8
-  - $CXX --version
   - npm install nvm
   - nvm install 5.2.0
   - nvm use 5.2.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,13 +5,6 @@ python:
 
 sudo: false
 
-addons:
-  apt:
-    sources:
-    - ubuntu-toolchain-r-test
-    packages:
-    - g++-4.8
-
 services:
   - elasticsearch
 


### PR DESCRIPTION
Our travis build had been depending on g++48 from the [ubuntu-toolchain-r](https://launchpad.net/~ubuntu-toolchain-r/+archive/ubuntu/test?field.series_filter=precise) PPA, which no longer seems to carry it.

This PR switches us to the built-in clang++ compiler now, which appears to work fine.

@anselmbradford 