### PR TITLE
Fix bug where publised pages were showing shared content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 
 
 ### Fixed
+- Fix bug where publised pages were showing shared content
 
 
 

--- a/cfgov/v1/wagtail_hooks.py
+++ b/cfgov/v1/wagtail_hooks.py
@@ -18,13 +18,29 @@ def share_the_page(request, page):
     is_publishing = bool(request.POST.get('action-publish')) and parent_page_perms.can_publish()
     is_sharing = bool(request.POST.get('action-share')) and parent_page_perms.can_publish()
 
+    # If the page is being shared or published, set `shared` to True or else False
+    # and save the page.
     if is_sharing or is_publishing:
         page.shared = True
     else:
         page.shared = False
-
     page.save()
+
+    # If the page isn't being published but the page is live and the editor
+    # wants to share updated content that doesn't show on the production site,
+    # we must set the page.live to True, delete the latest revision, and save
+    # a new revision with `live` = False. This doesn't affect the page's published
+    # status, as the saved page object in the database still has `live` equal to
+    # True and we're never commiting the change. As seen in CFGOVPage's route
+    # method, `route()` will select the latest revision of the page where `live`
+    # is set to True and return that revision as a page object to serve the request with.
+    if not is_publishing:
+        page.live = False
+    latest = page.get_latest_revision()
+    latest.delete()
     revision = page.save_revision()
+
+    # If the page is being published, the publish the newly created revision.
     if is_publishing:
         revision.publish()
 


### PR DESCRIPTION
- Also solved memory leak of double revisions created for a single Page save
- Added comments for clarity

Explained in code comments.

If a page was published then it's content is updated and shared but not published, the published page will show the updated content.

## Test
- BEFORE pulling down, try publishing a page, then editing and sharing the updated page. You will see the update on both the live version and shared version of the page.
- Pull down the code. Repeat publishing, editing, and sharing. You should see the desired behavior.

@kave 
@richaagarwal 
@rosskarchner 