### PR TITLE
Spacing fixes to intro molecule, about us page and wells

### DIFF
--- a/cfgov/jinja2/v1/about-us/index.html
+++ b/cfgov/jinja2/v1/about-us/index.html
@@ -4,10 +4,11 @@
     About Us
 {%- endblock %}
 
-
 {% block content_main %}
     <div class="block
-                block__flush-top">
+                block__flush-top
+                block__flush-bottom
+                block__padded-bottom">
         <h1>About Us</h1>
         <p class="h3">
             The Consumer Financial Protection Bureau (CFPB)
@@ -43,6 +44,7 @@
             <section class="block
                             block__border-top
                             block__padded-top
+                            block__padded-bottom
                             block__flush-bottom">
                 <h2>CFPB Leadership</h2>
                 <div class="media bureau-bio u-mb30">
@@ -89,6 +91,7 @@
             <section class="block
                             block__border-top
                             block__padded-top
+                            block__padded-bottom
                             block__flush-bottom">
                 <h2>Strategy & Budget</h2>
                 <p>
@@ -120,8 +123,7 @@
         <div class="content-l_col-1-2">
             <section class="block
                             block__border-top
-                            block__padded-top
-                            block__flush-bottom">
+                            block__padded-top">
                 <h2>Engage in our Work</h2>
                 <p>
                     We actively seek opportunities to collaborate
@@ -148,8 +150,7 @@
         <div class="content-l_col-1-2">
             <section class="block
                             block__border-top
-                            block__padded-top
-                            block__flush-bottom">
+                            block__padded-top">
                 <h2>Careers</h2>
                 <p>
                     We are always looking for talented individuals

--- a/cfgov/jinja2/v1/budget/strategic-plan/index.html
+++ b/cfgov/jinja2/v1/budget/strategic-plan/index.html
@@ -12,16 +12,17 @@
 {%- endblock %}
 
 {% block content_main %}
-
-    <h1>
-        Strategic Plan
-    </h1>
-    <p class="h3">
-        The CFPB Strategic Plan outlines four goals in pursuit of the Bureau’s mission.
-        For each, the plan also describes desired outcomes, required strategies and investments,
-        and specific measures of success. This is the work you should expect us to take
-        on over the coming years.
-    <p>
+    <div class="block block__flush-top">
+        <h1>
+            Strategic Plan
+        </h1>
+        <p class="lead-paragraph">
+            The CFPB Strategic Plan outlines four goals in pursuit of the Bureau’s mission.
+            For each, the plan also describes desired outcomes, required strategies and investments,
+            and specific measures of success. This is the work you should expect us to take
+            on over the coming years.
+        <p>
+    </div>
     <div class="block block__sub">
         <h2 class="h4">
             CFPB Strategic Plan

--- a/cfgov/jinja2/v1/doing-business-with-us/past-awards/index.html
+++ b/cfgov/jinja2/v1/doing-business-with-us/past-awards/index.html
@@ -16,17 +16,18 @@
 {% endblock %}
 
 {% block content_main %}
-
-    <h1 data-qa-hook="main-title">Procurement History</h1>
-    <p class="h3" data-qa-hook="main-summary">
-        Each year, we publish information about our contracts and awards from the preceding fiscal year.
-        This can be helpful in understanding the kinds of products and services we procure and how that may
-        change over time. In recent years, we have published three procurement review documents: a summary
-        worksheet of our largest awards, an inventory of all of our service contracts, and a memo to the
-        Office of Management and Budget that describes any planned analysis. For other types of financial
-        information,
-        <a href="/budget/">see our budget and strategy</a>.
-    </p>
+    <div class="block block__flush-top">
+        <h1 data-qa-hook="main-title">Procurement History</h1>
+        <p class="lead-paragraph" data-qa-hook="main-summary">
+            Each year, we publish information about our contracts and awards from the preceding fiscal year.
+            This can be helpful in understanding the kinds of products and services we procure and how that may
+            change over time. In recent years, we have published three procurement review documents: a summary
+            worksheet of our largest awards, an inventory of all of our service contracts, and a memo to the
+            Office of Management and Budget that describes any planned analysis. For other types of financial
+            information,
+            <a href="/budget/">see our budget and strategy</a>.
+        </p>
+    </div>
 
     <div class="business_page-content">
         {% set page = get_document('pages', '36603') %}

--- a/cfgov/jinja2/v1/doing-business-with-us/small-businesses/index.html
+++ b/cfgov/jinja2/v1/doing-business-with-us/small-businesses/index.html
@@ -16,17 +16,17 @@
 {% endblock %}
 
 {% block content_main %}
-
-    <h1 data-qa-hook="main-title">Small & Minority Businesses</h1>
-    <p class="lead-paragraph" data-qa-hook="main-summary">
-        We offer information here to help small, women-owned, and minority-owned businesses particpate in the
-        procurement and award process. We also publish information about existing awards to Small Business
-        Administration-designated business classes. We are dedicated to working with small business
-        owners—particularly women, minorities, and service-disabled veterans—and we welcome feedback about how
-        we're doing.
-        <a href="/budget/">See our strategy and budget</a>.
-    </p>
-
+    <div class="block block__flush-top">
+        <h1 data-qa-hook="main-title">Small & Minority Businesses</h1>
+        <p class="lead-paragraph" data-qa-hook="main-summary">
+            We offer information here to help small, women-owned, and minority-owned businesses particpate in the
+            procurement and award process. We also publish information about existing awards to Small Business
+            Administration-designated business classes. We are dedicated to working with small business
+            owners—particularly women, minorities, and service-disabled veterans—and we welcome feedback about how
+            we're doing.
+            <a href="/budget/">See our strategy and budget</a>.
+        </p>
+    </div>
     <div class="block content-l content-l__main" data-qa-hook="small-business-info">
 
         <div class="content-l_col

--- a/cfgov/jinja2/v1/doing-business-with-us/upcoming-procurement-needs/index.html
+++ b/cfgov/jinja2/v1/doing-business-with-us/upcoming-procurement-needs/index.html
@@ -16,7 +16,7 @@
 {% endblock %}
 
 {% block content_main %}
-
+<div class="block block__flush-top">
     <h1 data-qa-hook="main-title">Upcoming Procurement Needs</h1>
     <p class="lead-paragraph" data-qa-hook="main-summary">
         These are the procurement needs we expect to make in the near future. Each of the needs
@@ -31,7 +31,7 @@
         The needs below are forecasted, not current. Our fiscal year starts in October, so, for example,
         FY2015 Q1 is October–December 2014.
     </p>
-
+</div>
     {% set page = get_document('pages', '36601') %}
     {{ page.content | safe }}
 

--- a/cfgov/jinja2/v1/the-bureau/about-deputy-director/index.html
+++ b/cfgov/jinja2/v1/the-bureau/about-deputy-director/index.html
@@ -23,10 +23,12 @@
         <h1 data-qa-hook="director-bio-title">
             Deputy Director Meredith Fuchs (Acting)
         </h1>
-        <p class="h3" data-qa-hook="director-bio-summary">
+        <p class="lead-paragraph" data-qa-hook="director-bio-summary">
             Meredith Fuchs currently serves as the Acting Deputy Director
             as well as the General Counsel at the Consumer Financial Protection Bureau (CFPB).
         </p>
+    </div>
+    <div class="block">
         <figure class="media float-media rwd-crop" data-qa-hook="director-bio-image">
             <img class="media_image media_image__150 rwd-crop_item"
                  src="/static/img/deputy-director-fuchs-300x400.jpg"

--- a/cfgov/jinja2/v1/the-bureau/about-director/index.html
+++ b/cfgov/jinja2/v1/the-bureau/about-director/index.html
@@ -23,11 +23,13 @@
         <h1 data-qa-hook="director-bio-title">
             Director Richard Cordray
         </h1>
-        <p class="h3" data-qa-hook="director-bio-summary">
+        <p class="lead-paragraph" data-qa-hook="director-bio-summary">
             Richard Cordray serves as the first Director of the
             Consumer Financial Protection Bureau. He previously
             led the Bureau’s Enforcement Division.
         </p>
+    </div>
+    <div class="block">
         <figure class="media float-media rwd-crop" data-qa-hook="director-bio-image">
             <img class="media_image media_image__150 rwd-crop_item"
                  src="/static/img/director-cordray-300x400.jpg"

--- a/cfgov/jinja2/v1/the-bureau/bureau-structure/index.html
+++ b/cfgov/jinja2/v1/the-bureau/bureau-structure/index.html
@@ -23,6 +23,11 @@
     <link rel="stylesheet" href="/static/css/slick.css">
 {%- endblock %}
 
+{% block content_main_modifiers -%}
+    {{ super() }}
+    content__flush-bottom
+{%- endblock %}
+
 {% block content_main %}
 
     {% import '_macro-role.html' as role with context %}
@@ -129,7 +134,9 @@
 
     </div>
 
-    <aside class="block block__padded-top block__padded-bottom block__border-top">
+    <aside class="block
+                  block__padded-top
+                  block__border-top">
         <div class="content-l content-l__main">
             <div class="content-l_col content-l_col-1-2"
                  data-qa-hook="org-chart-download-info">

--- a/cfgov/jinja2/v1/the-bureau/index.html
+++ b/cfgov/jinja2/v1/the-bureau/index.html
@@ -102,34 +102,32 @@
             }]
         })
     }}
+    <div class="block block__flush">
+        <section class="o-well"
+                 data-qa-hook="bureau-core-functions">
+            <h2>Our core functions</h2>
+            <p>Congress created the CFPB to create a single point of accountability for enforcing
+            federal consumer financial laws and protecting consumers in the financial marketplace.
+            Before, that responsibility was divided among several agencies. Today, it’s our job.</p>
 
-    <section class="block
-                    block__bg
-                    block__border
-                    block__flush"
-             data-qa-hook="bureau-core-functions">
-        <h2>Our core functions</h2>
-        <p>Congress created the CFPB to create a single point of accountability for enforcing
-        federal consumer financial laws and protecting consumers in the financial marketplace.
-        Before, that responsibility was divided among several agencies. Today, it’s our job.</p>
-
-        <section class="bureau-functions block__padded-top">
-            <h3 class="h4">Among other things, we:</h3>
-            <ul class="list list__branded bureau-functions_list u-mb0">
-                <li>Write rules, supervise companies, and enforce federal consumer
-                financial protection laws</li>
-                <li>Restrict unfair, deceptive, or abusive acts or practices</li>
-                <li>Take consumer complaints</li>
-                <li>Promote financial education</li>
-            </ul>
-            <ul class="list list__branded bureau-functions_list">
-                <li>Research consumer behavior</li>
-                <li>Monitor financial markets for new risks to consumers</li>
-                <li>Enforce laws that outlaw discrimination and other unfair treatment
-                in consumer finance</li>
-            </ul>
-        </section>
-    </section><!-- END .content-block -->
+            <section class="bureau-functions block__padded-top">
+                <h3 class="h4">Among other things, we:</h3>
+                <ul class="list list__branded bureau-functions_list u-mb0">
+                    <li>Write rules, supervise companies, and enforce federal consumer
+                    financial protection laws</li>
+                    <li>Restrict unfair, deceptive, or abusive acts or practices</li>
+                    <li>Take consumer complaints</li>
+                    <li>Promote financial education</li>
+                </ul>
+                <ul class="list list__branded bureau-functions_list">
+                    <li>Research consumer behavior</li>
+                    <li>Monitor financial markets for new risks to consumers</li>
+                    <li>Enforce laws that outlaw discrimination and other unfair treatment
+                    in consumer finance</li>
+                </ul>
+            </section>
+        </section><!-- END .content-block -->
+    </div>
 
     <section class="block block__padded-top block__flush-top">
         <h2>CFPB leadership</h2>


### PR DESCRIPTION
A number of spacing fixes:
- About us page spacing fixes to bring things in line with #1396
- Fixed well spacing for new CF changes
- Made intro paragraphs as consistent with new wagtail intro paragraphs as possible with a light touch (since these might get ported to wagtail)

## Testing
- Check about us page, budget, bureau and doing business pages

## Review
- @jimmynotjim 
- @anselmbradford 
- @sebworks 
