### PR TITLE
Fixes font on expandables

### DIFF
--- a/cfgov/unprocessed/css/molecules/expandable.less
+++ b/cfgov/unprocessed/css/molecules/expandable.less
@@ -122,6 +122,7 @@
         width: 100%;
         position: relative;
         cursor: pointer;
+        font-family: @webfont-medium;
     }
 
     &_content {


### PR DESCRIPTION
Adds font family to button override on expandables. Fixes #1442!

## Testing
- Create a document detail page with an expandable
- Fonts should no longer be "Sans Serif" but Avenir Medium

## Review
- @sebworks 
- @jimmynotjim 
- @anselmbradford 