### PR TITLE
Fixing post-preview organism

### DIFF
--- a/cfgov/jinja2/v1/_includes/organisms/post-preview.html
+++ b/cfgov/jinja2/v1/_includes/organisms/post-preview.html
@@ -31,8 +31,8 @@
    settings.event_zip:          A string with the event zip.
 
    settings.comments_close_date: A datetime object marking the deadline of the comment period.
-   settings.link_text:           A string with the description text of an external link.
-   settings.link_url:            A string with the url of an external link.
+   settings.preview_link_text:   A string with the description text of an external link.
+   settings.preview_link_url:    A string with the url of an external link.
 
    path:                        A string with the path for the homepage of the pagetype
                                 `/blog/`, `/newsroom/`
@@ -107,9 +107,13 @@
             </div>
         {% endif %}
         <div class="o-post-preview_content">
+
             <h3 class="o-post-preview_title">
-                {{ post.preview_title | safe if post.preview_title else post.title }}
+                <a href="{{ get_page_state_url({'request':request}, page) }}">
+                    {{ post.preview_title | safe if post.preview_title else post.title }}
+                </a>
             </h3>
+
             {% if 'EventPage' in post.specific_class.__name__ %}
                 {% if post.specific.start_dt %}
                     <span class="o-post-preview_subtitle h6">
@@ -157,8 +161,8 @@
                     {{ tags.render(post.tags.names(), url, true, false, form_id) }}
                 {% endif %}
             </div>
-            {% if post.preview_link_text %}
-                <a href="{{ get_page_state_url({'request':request}, page) }}" class="jump-link jump-link__underline">
+            {% if post.preview_link_text and post.preview_link_url %}
+                <a href="{{ post.preview_link_url }}" class="jump-link jump-link__underline">
                     {{ post.preview_link_text }}
                 </a>
             {% endif %}

--- a/cfgov/unprocessed/css/cf-enhancements.less
+++ b/cfgov/unprocessed/css/cf-enhancements.less
@@ -1550,11 +1550,15 @@ ul:last-child,
   name: Adjustments to meta-header
   family: cf-typography
   notes:
-    - "Temporary changes to meta-header to be ported to cf-typography to allow better adjustments on mobile"
+    - "Changes to meta-header to be ported to cf-typography to allow better adjustments on mobile"
+    - "Changes to better control spacing when a category isn't set"
   tags:
     - cf-typography
 */
 
+.meta-header {
+    overflow: auto;
+}
 
 .meta-header_right {
     .respond-to-max(@mobile-max, {

--- a/cfgov/unprocessed/css/organisms/post-preview.less
+++ b/cfgov/unprocessed/css/organisms/post-preview.less
@@ -82,6 +82,11 @@
 */
 
 .o-post-preview {
+
+    + .o-post-preview {
+        margin-top: unit( @grid_gutter-width * 2 / @base-font-size-px, em);
+    }
+
     &_image-container {
         .respond-to-max(@bp-sm-max, {
             margin-bottom: unit( @grid_gutter-width / @base-font-size-px, em );
@@ -93,6 +98,9 @@
     &_image {
         display: block;
         width: 100%;
+    }
+    &_title a {
+        .u-link__colors( @black, @pacific-80 );
     }
 }
 


### PR DESCRIPTION
- Post preview headline is now a link to the post
- Adds .external_link_text and .external_link_url for the ability to add an additional link to post preview
- Fixes a few spacing issues with post-preview organism.
- Resolves issue #1434

## Testing
- Create a browse filterable page and publish it locally with the "Amicus Brief" filter
- Create lots of document-detail pages under the browse-filterable page with "amicus brief" page types.
- Test~

## Review
- @kave 
- @jimmynotjim 
- @sebworks 
- @anselmbradford 