### PR TITLE
Update jsdom from 7.2.2. to 8.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,13 +17,11 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 
 ### Added
 - Added Backend sidebar contact
-- Added Related Metadata molecule to backend
+- Add Related Metadata molecule to backend
 - Added `ClearableInput` class for clearable input behavior
   in `input-contains-label` CF class.
-- Add Related Metadata molecule to backend
 - Added Github specific Issue and PR templates.
 - included paragraph rich text field to related links
-
 
 ### Changed
 - Converted the project to Capital Framework v3
@@ -32,6 +30,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Changed BrowseFilterablePage and related-metadata.html molecule templates to account for new backend
 - Abstracted info unit into a helper mixin to make it easier to re-use the inline version.
 - Moved Home page specific layout changes to it's own file.
+- Updated jsdom from `7.2.2` to `8.0.4`.
 
 ### Removed
 - Removed normalize and normalize-legacy from main less file because CF already includes it.

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "jasmine-reporters": "^2.0.7",
     "jasmine-spec-reporter": "^2.4.0",
     "jquery": "1.11.3",
-    "jsdom": "^7.2.2",
+    "jsdom": "^8.0.4",
     "map-stream": "^0.0.6",
     "minimist": "^1.1.3",
     "mkdirp": "^0.5.1",


### PR DESCRIPTION
## Changes

- Update jsdom from 7.2.2. to [8.0.4](https://github.com/tmpvar/jsdom/blob/master/Changelog.md#800)

## Testing

- `./setup.sh`
- `gulp test:acceptance --sauce=false` or `gulp test:acceptance`

## Review

- @sebworks 
- @KimberlyMunoz 
- @jimmynotjim 