### PR TITLE
Changing p tags in introductions to divs

### DIFF
--- a/cfgov/jinja2/v1/_includes/molecules/text-introduction.html
+++ b/cfgov/jinja2/v1/_includes/molecules/text-introduction.html
@@ -20,9 +20,8 @@
    ========================================================================== #}
 <div>
     <h1>{{ value.heading }}</h1>
-    <p class="lead-paragraph">{{ value.intro.source | safe }}</p>
-    {# TODO: should the source include the p tags? What if there needs to be something other than a p? #}
-    <p>{{ value.body.source | safe }}</p>
+    <div class="lead-paragraph">{{ value.intro.source | safe }}</div>
+    {{ value.body.source | safe }}
     <ul class="list list__links">
         {% for link in value.links %}
             <li class="list_item">

--- a/cfgov/jinja2/v1/_includes/organisms/item-introduction.html
+++ b/cfgov/jinja2/v1/_includes/organisms/item-introduction.html
@@ -32,7 +32,7 @@
     <h1>{{ value.heading }}</h1>
 
     {% if value.paragraph %}
-        <p class="lead-paragraph">{{ value.paragraph.source | safe }}</p>
+        <div class="lead-paragraph">{{ value.paragraph.source | safe }}</div>
     {% endif %}
     {% if value.date or value.authors.text %}
         <p>


### PR DESCRIPTION
In item and text introductions, any hard enter will break the formatting
on rendered pages. This changes the p tags into divs to fix this.

Also resolves issue #1336 and #1466.

## Testing
- Create a page with a text introduction and item introduction. The document detail page is the best place to do both at once.

## Screenshot

![image](https://cloud.githubusercontent.com/assets/1860176/13152773/c482b08e-d63e-11e5-9bb8-8aca233d07de.png)
