### PR TITLE
Convert breadcrumb handling to Wagtail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Converted 50/50 Macro to Info Unit Macro.
 - Updated Home Page to Info Unit Macro.
 - Included use of wagtail `classname` meta field for block css modifiers
+- Breadcrumbs for Wagtail pages now handled by Wagtail
 
 ### Removed
 - Removed normalize and normalize-legacy from main less file because CF already includes it.

--- a/cfgov/jinja2/v1/_includes/molecules/breadcrumbs.html
+++ b/cfgov/jinja2/v1/_includes/molecules/breadcrumbs.html
@@ -1,0 +1,28 @@
+{# ==========================================================================
+
+   breadcrumbs.render()
+
+   ==========================================================================
+
+   Description:
+
+   Create breadcrumb markup when given:
+
+   items:              An array of tuples used to display nav items.
+                       format: (href, id, caption)
+
+   additional_classes: Extra classes you wish to add to the nav,
+                       space separated.
+
+   ========================================================================== #}
+
+{# TODO: Remove additional_classes parameter from macros. #}
+{% macro render(breadcrumbs, additional_classes) %}
+    <nav class="breadcrumbs {{ additional_classes }}" aria-label="Breadcrumbs">
+        {% for crumb in breadcrumbs %}
+        <a class="breadcrumbs_link" href="{{ get_page_state_url({}, crumb) }}">
+            {{ crumb.title | e }}
+        </a>
+        {% endfor %}
+    </nav>
+{% endmacro %}

--- a/cfgov/jinja2/v1/_layouts/content-base-main-first.html
+++ b/cfgov/jinja2/v1/_layouts/content-base-main-first.html
@@ -1,12 +1,23 @@
 {% extends 'content-base.html' %}
 
 {% block pre_content scoped -%}
-  {% if breadcrumb_items | length > 0 %}
-      <div class="content_wrapper">
-      {%- import 'breadcrumbs.html' as breadcrumbs -%}
-      {{ breadcrumbs.render(breadcrumb_items, 'breadcrumbs__main-first') }}
-      </div>
-  {% endif %}
+    {# TODO: Remove non-wagtail logic once old pages have been converted #}
+    {% if page %}
+        {% set breadcrumb_items = page.get_breadcrumbs(request.site) %}
+        {% if breadcrumb_items | length > 0 %}
+            <div class="content_wrapper">
+                {%- import 'molecules/breadcrumbs.html' as breadcrumbs with context -%}
+                {{ breadcrumbs.render(breadcrumb_items, 'breadcrumbs__main-first') }}
+            </div>
+        {% endif %}
+    {% else %}
+        {% if breadcrumb_items | length > 0 %}
+            <div class="content_wrapper">
+                {%- import 'breadcrumbs.html' as breadcrumbs -%}
+                {{ breadcrumbs.render(breadcrumb_items, 'breadcrumbs__main-first') }}
+            </div>
+        {% endif %}
+    {% endif %}
 {%- endblock %}
 
 {% block body_content scoped %}

--- a/cfgov/jinja2/v1/_layouts/content-base-sidebar-first.html
+++ b/cfgov/jinja2/v1/_layouts/content-base-sidebar-first.html
@@ -1,11 +1,22 @@
 {% extends 'content-base.html' %}
 
 {% block pre_content scoped -%}
-    {% if breadcrumb_items | length > 0 %}
-        <div class="wrapper">
-        {%- import 'breadcrumbs.html' as breadcrumbs -%}
-        {{ breadcrumbs.render(breadcrumb_items, 'breadcrumbs__sidebar-first') }}
-        </div>
+    {# TODO: Remove non-wagtail logic once old pages have been converted #}
+    {% if page %}
+        {% set breadcrumb_items = page.get_breadcrumbs(request.site) %}
+        {% if breadcrumb_items | length > 0 %}
+            <div class="content_wrapper">
+                {%- import 'molecules/breadcrumbs.html' as breadcrumbs with context -%}
+                {{ breadcrumbs.render(breadcrumb_items, 'breadcrumbs__main-first') }}
+            </div>
+        {% endif %}
+    {% else %}
+        {% if breadcrumb_items | length > 0 %}
+            <div class="wrapper">
+                {%- import 'breadcrumbs.html' as breadcrumbs -%}
+                {{ breadcrumbs.render(breadcrumb_items, 'breadcrumbs__sidebar-first') }}
+            </div>
+        {% endif %}
     {% endif %}
 {%- endblock %}
 

--- a/cfgov/jinja2/v1/browse-basic/index.html
+++ b/cfgov/jinja2/v1/browse-basic/index.html
@@ -3,7 +3,6 @@
 {% import 'molecules/related-posts.html' as related_posts with context %}
 
 {% set parent = page.parent() %}
-{% set breadcrumb_items = [(parent.url, parent.url, parent.title)] %}
 
 {% block title -%}
     {{ page.seo_title }}

--- a/cfgov/jinja2/v1/browse-filterable/index.html
+++ b/cfgov/jinja2/v1/browse-filterable/index.html
@@ -11,7 +11,6 @@
 {%- endblock %}
 
 {% set parent = page.parent() %}
-{% set breadcrumb_items = [(parent.url, parent.url, parent.title)] %}
 
 {% block content_main %}
     {% for block in page.header %}

--- a/cfgov/jinja2/v1/document-detail/index.html
+++ b/cfgov/jinja2/v1/document-detail/index.html
@@ -4,7 +4,6 @@
 {% import 'molecules/related-metadata.html' as related_metadata with context %}
 
 {% set parent = page.parent() %}
-{% set breadcrumb_items = [(parent.url, parent.url, parent.title)] %}
 
 {% block title -%}
     {{ page.seo_title }}

--- a/cfgov/jinja2/v1/learn-page/index.html
+++ b/cfgov/jinja2/v1/learn-page/index.html
@@ -4,7 +4,6 @@
 {% import 'molecules/related-metadata.html' as related_metadata with context %}
 
 {% set parent = page.parent() %}
-{% set breadcrumb_items = [(parent.url, parent.url, parent.title)] %}
 
 {% block title -%}
     {{ page.seo_title }}

--- a/cfgov/v1/models/base.py
+++ b/cfgov/v1/models/base.py
@@ -121,6 +121,13 @@ class CFGOVPage(Page):
         return {search_type: queryset for search_type, queryset in
                 related.items() if queryset}
 
+    def get_breadcrumbs(self, site):
+        ancestors = self.get_ancestors()
+        home_page_children = site.root_page.get_children()
+        for i, ancestor in enumerate(ancestors):
+            if ancestor in home_page_children:
+                return ancestors[i+1:]
+
     @property
     def status_string(self):
         if not self.live:

--- a/cfgov/v1/models/browse_page.py
+++ b/cfgov/v1/models/browse_page.py
@@ -28,8 +28,6 @@ class BrowsePage(CFGOVPage):
         ('table', organisms.Table()),
     ], blank=True)
 
-    side_navigation = StreamField([], blank=True)
-
 
     # General content tab
     content_panels = CFGOVPage.content_panels + [
@@ -37,12 +35,11 @@ class BrowsePage(CFGOVPage):
         StreamFieldPanel('content'),
     ]
 
-    sidebar_panels = [StreamFieldPanel('side_navigation')] + CFGOVPage.sidefoot_panels
 
     # Tab handler interface
     edit_handler = TabbedInterface([
         ObjectList(content_panels, heading='General Content'),
-        ObjectList(sidebar_panels, heading='Sidebar'),
+        ObjectList(CFGOVPage.sidefoot_panels, heading='Sidebar'),
         ObjectList(CFGOVPage.settings_panels, heading='Configuration'),
     ])
 


### PR DESCRIPTION
- For page types:
 - Learn
 - Document Detail
 - Browse
 - Browse Filterable

Breadcrumbs appear on pages below landing/sub-landing pages. (Most often this means breadcrumbs first appear on "browse" type pages with a left-side nav.)
e.g
```
Landing Page
          -> Sublanding Page
                          (Breadcrumbs appear here!)
                         -> Browse Page
                         -> Landing Page
```

## Changes

- Wagtail pages that have breadcrumbs are now handled by Wagtail

## Testing

- Just go to an existing page of the type listed above.

## Review

- @richaagarwal 
- @kave 
- @jimmynotjim 

## Screenshots
![breadcrumb](https://cloud.githubusercontent.com/assets/1412978/13185145/9b942764-d70d-11e5-8bb4-31d962e40a81.png)



## Notes

- Shouldn't include any of the parent pages (e.g. Policy and Compliance)

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)

