### PR TITLE
Fix main contact info breaking pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Removed unnecessary Wagtail streamdata retrieval function from v1/utils/util.py
 - Removed old beta styles.
 - Removed prototype language, such as instances of setting `value`, `page`, and `global_dict`
+- Imports of contact info macros that were breaking the page
 
 ### Fixed
 - Fix bug where publised pages were showing shared content

--- a/cfgov/jinja2/v1/_includes/organisms/main-contact-info.html
+++ b/cfgov/jinja2/v1/_includes/organisms/main-contact-info.html
@@ -36,9 +36,6 @@
 
    ========================================================================== #}
 
-{% import 'molecules/contact-email.html' as contact_email %}
-{% import 'molecules/contact-phone.html' as contact_phone %}
-{% import 'molecules/contact-address.html' as contact_address %}
 {% if value.contact %}
     <div class="o-main-contact-info">
         <h2>{{ value.contact.heading }}</h2>


### PR DESCRIPTION
Jinja2 imports were unnecessary and breaking the page that the organism main contact info exists on.

## Removals

- jinja2 imports that were unnecessary and breaking the page

## Testing

- Go to a page with that organism.

## Review

- @richaagarwal 
- @kave 
