### PR TITLE
Fixed sublanding duplicate entries

### DIFF
--- a/cfgov/jinja2/v1/landing-page/index.html
+++ b/cfgov/jinja2/v1/landing-page/index.html
@@ -54,12 +54,6 @@
                 <h3 class="o-sidebar-breakout_heading">
                     {{ render_stream_child(block) }}
                 </h3>
-            {% elif 'slug' in block.block_type %}
-                <h2 class="header-slug">
-                    <span class="header-slug_inner">
-                        {{ render_stream_child(block) }}
-                    </span>
-                </h2>
             {% else %}
                 {{ render_stream_child(block) }}
             {% endif %}

--- a/cfgov/jinja2/v1/sublanding-page/index.html
+++ b/cfgov/jinja2/v1/sublanding-page/index.html
@@ -57,12 +57,6 @@
                 <h3 class="o-sidebar-breakout_heading">
                     {{ render_stream_child(block) }}
                 </h3>
-            {% elif 'slug' in block.block_type %}
-                <h2 class="header-slug">
-                    <span class="header-slug_inner">
-                        {{ render_stream_child(block) }}
-                    </span>
-                </h2>
             {% else %}
                 {{ render_stream_child(block) }}
             {% endif %}

--- a/cfgov/jinja2/v1/sublanding-page/index.html
+++ b/cfgov/jinja2/v1/sublanding-page/index.html
@@ -26,33 +26,21 @@
         {% if loop.index == 1 %}
             <div class="block
                         block__flush-top">
-                {{ render_stream_child(block) }}
-            </div>
         {% else %}
             <div class="block">
-                {{ render_stream_child(block) }}
-            </div>
         {% endif %}
 
-        {% for block in page.content -%}
-            {% if loop.index == 1 %}
-                <div class="block
-                            block__flush-top">
-            {% else %}
-                <div class="block">
-            {% endif %}
-            {% if 'post_preview_snapshot' in block.block_type %}
-                {% set posts = page.get_browsefilterable_posts(request) %}
-                {% set limit = block.value.limit | int %}
-                {% set num_posts = limit if limit <= posts | length else posts | length %}
-                {% for i in range(num_posts) %}
-                    {{ post_preview.render(posts[i], '', 0, pageurl(posts[i].parent())) }}
-                {% endfor %}
-            {% else %}
-                {{ render_stream_child(block) }}
-            {% endif %}
-                </div>
-        {%- endfor %}
+        {% if 'post_preview_snapshot' in block.block_type %}
+            {% set posts = page.get_browsefilterable_posts(request) %}
+            {% set limit = block.value.limit | int %}
+            {% set num_posts = limit if limit <= posts | length else posts | length %}
+            {% for i in range(num_posts) %}
+                {{ post_preview.render(posts[i], '', 0, pageurl(posts[i].parent())) }}
+            {% endfor %}
+        {% else %}
+            {{ render_stream_child(block) }}
+        {% endif %}
+        </div>
     {%- endfor %}
 {% endblock %}
 
@@ -62,26 +50,22 @@
 
 {% block content_sidebar scoped -%}
     {% for block in page.sidefoot %}
-        {% if 'related_posts' in block.block_type %}
-            {{ related_posts.render(block) }}
-        {% elif 'email_signup' in block.block_type %}
-            {{ render_stream_child(block) }}
-        {% else %}
-            {% if 'heading' in block.block_type %}
+        <div class="block block__flush-top">
+            {% if 'related_posts' in block.block_type %}
+                {{ related_posts.render(block) }}
+            {% elif 'heading' in block.block_type %}
                 <h3 class="o-sidebar-breakout_heading">
                     {{ render_stream_child(block) }}
                 </h3>
             {% elif 'slug' in block.block_type %}
                 <h2 class="header-slug">
-                        <span class="header-slug_inner">
-                            {{ render_stream_child(block) }}
-                        </span>
+                    <span class="header-slug_inner">
+                        {{ render_stream_child(block) }}
+                    </span>
                 </h2>
-            {% elif 'paragraph' in block.block_type %}
-                {{ render_stream_child(block) }}
             {% else %}
                 {{ render_stream_child(block) }}
             {% endif %}
-        {% endif %}
+        </div>
     {%- endfor %}
 {%- endblock %}


### PR DESCRIPTION
Sublanding pages were incorrectly showing elements due to multiple for loops

## Additions

-

## Removals

-

## Changes

- removed duplicate for loops

## Testing

- Create and preview a sublanding page. Should only show elements once

## Review

- @kurtw 
- @richaagarwal 

## Screenshots


## Notes

-

## Todos

-

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)

