### PR TITLE
Add URL field to Post Preview Organism

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - included paragraph rich text field to related links
 - Added new content flush sides on small modifier to fix an issue where margin was set on the molecule level instead of the template.
 - Added Info Unit Macro.
-
+- URL field to the Post Preview organism
 
 ### Changed
 - Converted the project to Capital Framework v3

--- a/cfgov/jinja2/v1/_includes/organisms/post-preview.html
+++ b/cfgov/jinja2/v1/_includes/organisms/post-preview.html
@@ -160,7 +160,7 @@
                     {{ tags.render(post.tags.names(), url, true, false, form_id) }}
                 {% endif %}
             </div>
-            {% if post.preview_link_text and post.preview_link_url %}
+            {% if post.preview_link_url and post.preview_link_text %}
                 <a href="{{ post.preview_link_url }}" class="jump-link jump-link__underline">
                     {{ post.preview_link_text }}
                 </a>

--- a/cfgov/v1/migrations/0051_abstractfilterpage_preview_link_url.py
+++ b/cfgov/v1/migrations/0051_abstractfilterpage_preview_link_url.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('v1', '0050_auto_20160218_2013'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='abstractfilterpage',
+            name='preview_link_url',
+            field=models.CharField(max_length=500, null=True, blank=True),
+        ),
+    ]

--- a/cfgov/v1/models/learn_page.py
+++ b/cfgov/v1/models/learn_page.py
@@ -25,6 +25,7 @@ class AbstractFilterPage(CFGOVPage):
     preview_title = models.CharField(max_length=255, null=True, blank=True)
     preview_subheading = models.CharField(max_length=255, null=True, blank=True)
     preview_description = RichTextField(null=True, blank=True)
+    preview_link_url = models.CharField(max_length=500, null=True, blank=True)
     preview_link_text = models.CharField(max_length=255, null=True, blank=True)
     preview_image = models.ForeignKey(
         'v1.CFGOVImage',
@@ -50,6 +51,7 @@ class AbstractFilterPage(CFGOVPage):
             FieldPanel('preview_title', classname="full"),
             FieldPanel('preview_subheading', classname="full"),
             FieldPanel('preview_description', classname="full"),
+            FieldPanel('preview_link_url', classname="full"),
             FieldPanel('preview_link_text', classname="full"),
             ImageChooserPanel('preview_image'),
         ], heading='Page Preview Fields', classname='collapsible collapsed'),


### PR DESCRIPTION
Add URL field to Post Preview Organism

## Additions

- URL field to Post Preview Organism

## Testing

- Go to a Learn, Doc Detail, or Event page that is a child of a browse filterable page
- Add a url and text to the post preview fields for a link
- Go to it's browse filterable page and filter for it
- Check that the link exists

## Review

- @richaagarwal 
- @kave 
- @KimberlyMunoz 

## Screenshots
![screen shot 2016-02-22 at 12 31 08 pm](https://cloud.githubusercontent.com/assets/1412978/13226600/42da3104-d960-11e5-91a8-4f664727fdb6.png)
