### PR TITLE
Included atomic element specific css modifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Converted 25/75 Macro to Info Unit Macro.
 - Converted 50/50 Macro to Info Unit Macro.
 - Updated Home Page to Info Unit Macro.
+- Included use of wagtail `classname` meta field for block css modifiers
 
 ### Removed
 - Removed normalize and normalize-legacy from main less file because CF already includes it.

--- a/cfgov/jinja2/v1/_includes/molecules/featured-content.html
+++ b/cfgov/jinja2/v1/_includes/molecules/featured-content.html
@@ -29,7 +29,6 @@
 
 <section class="block
                 block__border
-                block__flush
                 featured-content-module">
     <div class="featured-content-module_text">
         <p class="h4">

--- a/cfgov/jinja2/v1/_includes/molecules/featured-content.html
+++ b/cfgov/jinja2/v1/_includes/molecules/featured-content.html
@@ -27,9 +27,7 @@
 
 {% import 'macros/category-icon.html' as category_icon %}
 
-<section class="block
-                block__border
-                featured-content-module">
+<section class="featured-content-module">
     <div class="featured-content-module_text">
         <p class="h4">
             {{ category_icon.render( fcm_label(value.category) ) | safe }}

--- a/cfgov/jinja2/v1/_includes/molecules/text-introduction.html
+++ b/cfgov/jinja2/v1/_includes/molecules/text-introduction.html
@@ -18,17 +18,16 @@
    value.links:     A collection of links with URL & Text.
 
    ========================================================================== #}
-<div>
-    <h1>{{ value.heading }}</h1>
-    <div class="lead-paragraph">{{ value.intro.source | safe }}</div>
-    {{ value.body.source | safe }}
-    <ul class="list list__links">
-        {% for link in value.links %}
-            <li class="list_item">
-                <a class="list_link" href="{{ link.url }}">
-                    {{ link.text }}
-                </a>
-            </li>
-        {% endfor %}
-    </ul>
-</div>
+
+<h1>{{ value.heading }}</h1>
+<div class="lead-paragraph">{{ value.intro.source | safe }}</div>
+{{ value.body.source | safe }}
+<ul class="list list__links">
+    {% for link in value.links %}
+        <li class="list_item">
+            <a class="list_link" href="{{ link.url }}">
+                {{ link.text }}
+            </a>
+        </li>
+    {% endfor %}
+</ul>

--- a/cfgov/jinja2/v1/_includes/templates/render_block.html
+++ b/cfgov/jinja2/v1/_includes/templates/render_block.html
@@ -1,3 +1,3 @@
-<div class="block {{ block.block.meta.classname  if block.block.meta.classname else '' }} {{ 'block__flush-top' if loop.index == 1 else '' }}">
+<div class="block {{ block.block.meta.classname  if block.block.meta.classname else '' }}">
     {{ render_stream_child(block) }}
 </div>

--- a/cfgov/jinja2/v1/_includes/templates/render_block.html
+++ b/cfgov/jinja2/v1/_includes/templates/render_block.html
@@ -1,9 +1,3 @@
-{% if block.block.meta.classname %}
-    <div class="block {{ block.block.meta.classname }} {{ 'block__flush-top' if loop.index == 1 else '' }}">
-        {{ render_stream_child(block) }}
-    </div>
-{% else %}
-    <div class="block {{ 'block__flush-top' if loop.index == 1 else '' }}">
-        {{ render_stream_child(block) }}
-    </div>
-{% endif %}
+<div class="block {{ block.block.meta.classname  if block.block.meta.classname else '' }} {{ 'block__flush-top' if loop.index == 1 else '' }}">
+    {{ render_stream_child(block) }}
+</div>

--- a/cfgov/jinja2/v1/_includes/templates/render_block.html
+++ b/cfgov/jinja2/v1/_includes/templates/render_block.html
@@ -1,0 +1,9 @@
+{% if block.block.meta.classname %}
+    <div class="block {{ block.block.meta.classname }} {{ 'block__flush-top' if loop.index == 1 else '' }}">
+        {{ render_stream_child(block) }}
+    </div>
+{% else %}
+    <div class="block {{ 'block__flush-top' if loop.index == 1 else '' }}">
+        {{ render_stream_child(block) }}
+    </div>
+{% endif %}

--- a/cfgov/jinja2/v1/browse-basic/index.html
+++ b/cfgov/jinja2/v1/browse-basic/index.html
@@ -28,9 +28,7 @@
     {%- endfor %}
 
     {% for block in page.content -%}
-        <div class="block">
-            {{ render_stream_child(block) }}
-        </div>
+        {% include 'templates/render_block.html' with context %}
     {%- endfor %}
 
     <aside class="prefooter">
@@ -53,8 +51,12 @@
 
 {% block content_sidebar scoped -%}
     {% for block in page.side_navigation -%}
-        <div class="block">
-            {{ render_stream_child(block) }}
+        <div class="block block__flush-top">
+            {% if 'related_posts' in block.block_type %}
+                {{ related_posts.render(block) }}
+            {% else %}
+                {{ render_stream_child(block) }}
+            {% endif %}
         </div>
     {%- endfor %}
 {%- endblock %}

--- a/cfgov/jinja2/v1/browse-filterable/index.html
+++ b/cfgov/jinja2/v1/browse-filterable/index.html
@@ -21,16 +21,17 @@
         </div>
     {% endfor %}
     {% for block in page.content %}
-        <div class="block
+        {% if 'filter_controls' in block.block_type %}
+            <div class="block
                     block__flush-top">
-            {% if 'filter_controls' in block.block_type %}
+
                 {% set f = forms.pop(0) %}
                 {% from 'organisms/filterable-list-controls.html' import render as flc with context %}
                 {{ flc(block.value, f, loop.index0) }}
-            {% else %}
-                {{ render_stream_child(block) }}
-            {% endif %}
-        </div>
+            </div>
+        {% else %}
+            {% include 'templates/render_block.html' with context %}
+        {% endif %}
     {% endfor %}
     <aside class="prefooter">
         {% for block in page.sidefoot %}

--- a/cfgov/jinja2/v1/document-detail/index.html
+++ b/cfgov/jinja2/v1/document-detail/index.html
@@ -23,9 +23,7 @@
     {%- endfor %}
 
     {% for block in page.content -%}
-        <div class="block">
-            {{ render_stream_child(block) }}
-        </div>
+        {% include 'templates/render_block.html' with context %}
     {%- endfor %}
 {% endblock %}
 

--- a/cfgov/jinja2/v1/landing-page/index.html
+++ b/cfgov/jinja2/v1/landing-page/index.html
@@ -20,18 +20,10 @@
 
 {% block content_main %}
     {% for block in page.header -%}
-        {% if 'text_introduction' in block.block_type %}
-            <div class="block
-                        block__flush-top">
-                {{ render_stream_child(block) }}
-            </div>
-        {% endif %}
+        {% include 'templates/render_block.html' with context %}
     {%- endfor %}
     {% for block in page.content -%}
-        <div class="block
-                    {{ 'block__flush-top' if loop.index == 1 else '' }}">
-            {{ render_stream_child(block) }}
-        </div>
+        {% include 'templates/render_block.html' with context %}
     {%- endfor %}
 {% endblock %}
 

--- a/cfgov/jinja2/v1/landing-page/index.html
+++ b/cfgov/jinja2/v1/landing-page/index.html
@@ -23,7 +23,14 @@
         {% include 'templates/render_block.html' with context %}
     {%- endfor %}
     {% for block in page.content -%}
-        {% include 'templates/render_block.html' with context %}
+        {% if loop.index == 1 %}
+            <div class="block
+                        block__flush-top">
+                {{ render_stream_child(block) }}
+            </div>
+        {% else %}
+             {% include 'templates/render_block.html' with context %}
+        {% endif %}
     {%- endfor %}
 {% endblock %}
 

--- a/cfgov/jinja2/v1/learn-page/index.html
+++ b/cfgov/jinja2/v1/learn-page/index.html
@@ -23,9 +23,7 @@
     {%- endfor %}
 
     {% for block in page.content -%}
-        <div class="block">
-            {{ render_stream_child(block) }}
-        </div>
+        {% include 'templates/render_block.html' with context %}
     {%- endfor %}
 {% endblock %}
 

--- a/cfgov/jinja2/v1/sublanding-page/index.html
+++ b/cfgov/jinja2/v1/sublanding-page/index.html
@@ -24,16 +24,19 @@
 
 {% block content_main %}
     {% for block in page.content -%}
-        {% if 'post_preview_snapshot' in block.block_type %}
+        {% if loop.index == 1 %}
             <div class="block
-                        {{ 'block__flush-top' if loop.index == 1 else '' }}">
-
-                {% set posts = page.get_browsefilterable_posts(request) %}
-                {% set limit = block.value.limit | int %}
-                {% set num_posts = limit if limit <= posts | length else posts | length %}
-                {% for i in range(num_posts) %}
-                    {{ post_preview.render(posts[i], '', 0, pageurl(posts[i].parent())) }}
-                {% endfor %}
+                        block__flush-top">
+                {% if 'post_preview_snapshot' in block.block_type %}
+                    {% set posts = page.get_browsefilterable_posts(request) %}
+                    {% set limit = block.value.limit | int %}
+                    {% set num_posts = limit if limit <= posts | length else posts | length %}
+                    {% for i in range(num_posts) %}
+                        {{ post_preview.render(posts[i], '', 0, pageurl(posts[i].parent())) }}
+                    {% endfor %}
+                {% else %}
+                    {{ render_stream_child(block) }}
+                {% endif %}
              </div>
         {% else %}
              {% include 'templates/render_block.html' with context %}

--- a/cfgov/jinja2/v1/sublanding-page/index.html
+++ b/cfgov/jinja2/v1/sublanding-page/index.html
@@ -24,19 +24,20 @@
 
 {% block content_main %}
     {% for block in page.content -%}
-        <div class="block
-                    {{ 'block__flush-top' if loop.index == 1 else '' }}">
         {% if 'post_preview_snapshot' in block.block_type %}
-            {% set posts = page.get_browsefilterable_posts(request) %}
-            {% set limit = block.value.limit | int %}
-            {% set num_posts = limit if limit <= posts | length else posts | length %}
-            {% for i in range(num_posts) %}
-                {{ post_preview.render(posts[i], '', 0, pageurl(posts[i].parent())) }}
-            {% endfor %}
+            <div class="block
+                        {{ 'block__flush-top' if loop.index == 1 else '' }}">
+
+                {% set posts = page.get_browsefilterable_posts(request) %}
+                {% set limit = block.value.limit | int %}
+                {% set num_posts = limit if limit <= posts | length else posts | length %}
+                {% for i in range(num_posts) %}
+                    {{ post_preview.render(posts[i], '', 0, pageurl(posts[i].parent())) }}
+                {% endfor %}
+             </div>
         {% else %}
-            {{ render_stream_child(block) }}
+             {% include 'templates/render_block.html' with context %}
         {% endif %}
-        </div>
     {%- endfor %}
 {% endblock %}
 

--- a/cfgov/jinja2/v1/wagtail/demo/index.html
+++ b/cfgov/jinja2/v1/wagtail/demo/index.html
@@ -16,13 +16,12 @@
     </div>
 
     {% for block in page.molecules %}
-        <div class="block">
-            {{ render_stream_child(block) }}
-        </div>
+
+        {% include 'templates/render_block.html' with context %}
     {% endfor %}
 
     {% for block in page.organisms %}
-        {{ render_stream_child(block) }}
+        {% include 'templates/render_block.html' with context %}
     {% endfor %}
     </div>
 {% endblock content_main %}
@@ -33,7 +32,7 @@
         {% if 'related_posts' in block.block_type %}
             {{ related_posts.render() }}
         {% else %}
-            {{ render_stream_child(block) }}
+            {% include 'templates/render_block.html' with context %}
         {% endif %}
     {% endfor %}
 </aside>

--- a/cfgov/jinja2/v1/wagtail/demo/index.html
+++ b/cfgov/jinja2/v1/wagtail/demo/index.html
@@ -16,7 +16,6 @@
     </div>
 
     {% for block in page.molecules %}
-
         {% include 'templates/render_block.html' with context %}
     {% endfor %}
 

--- a/cfgov/v1/models/molecules.py
+++ b/cfgov/v1/models/molecules.py
@@ -56,6 +56,7 @@ class TextIntroduction(blocks.StructBlock):
     class Meta:
         icon = 'title'
         template = '_includes/molecules/text-introduction.html'
+        classname = 'block__flush-top'
 
 
 class Hero(blocks.StructBlock):
@@ -132,6 +133,7 @@ class FeaturedContent(blocks.StructBlock):
         template = '_includes/molecules/featured-content.html'
         icon = 'doc-full-inverse'
         label = 'Featured Content'
+        classname = 'block__flush'
 
 
 class CallToAction(blocks.StructBlock):

--- a/cfgov/v1/models/organisms.py
+++ b/cfgov/v1/models/organisms.py
@@ -11,6 +11,7 @@ class Well(blocks.StructBlock):
     class Meta:
         icon = 'title'
         template = '_includes/organisms/well.html'
+        classname = 'block__flush'
 
 
 class ImageText5050Group(blocks.StructBlock):
@@ -170,6 +171,7 @@ class ItemIntroduction(blocks.StructBlock):
     class Meta:
         icon = 'form'
         template = '_includes/organisms/item-introduction.html'
+        classname = 'block__flush-top'
 
 
 class FilterControls(molecules.BaseExpandable):


### PR DESCRIPTION
## Additions

- Included atomic element specific css modifier

## Testing

- Create a Sublanding page, with any element first then a `Well` 2nd. 
- Should see that the grey background touches the sidebar

## Review

- @jimmynotjim 
- @KimberlyMunoz 
- @kurtw 
- @richaagarwal 

## Screenshots
Before:
![screen shot 2016-02-22 at 3 13 27 pm](https://cloud.githubusercontent.com/assets/254877/13231234/dcddff68-d976-11e5-8a02-c198294e3ee5.png)

After:
![screen shot 2016-02-22 at 3 10 13 pm](https://cloud.githubusercontent.com/assets/254877/13231196/a91ca03a-d976-11e5-86e2-d90f1764e3af.png)

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
