### PR TITLE
Add Wagtail secondary navigation handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Updated Home Page to Info Unit Macro.
 - Included use of wagtail `classname` meta field for block css modifiers
 - Breadcrumbs for Wagtail pages now handled by Wagtail
+- Changed Wagtail pages extending from `layout-side-nav.html` to use new side navigation handling
 
 ### Removed
 - Removed normalize and normalize-legacy from main less file because CF already includes it.

--- a/cfgov/jinja2/v1/_includes/molecules/expandable.html
+++ b/cfgov/jinja2/v1/_includes/molecules/expandable.html
@@ -24,11 +24,9 @@
    value.is_expanded: Whether the Expandable is expanded or not.
                       Default is false.
 
-   TODO: Add description to `filter` param, and possibly reconsider name to
-         avoid confusion w/ the filter controls that use it.
    ========================================================================== #}
 
-{% macro expandable(value, filter=false) %}
+{% macro expandable(value) %}
 <div class="m-expandable
             m-expandable__expanded
             {{ 'm-expandable__borders' if value.is_bordered else '' }}
@@ -60,7 +58,7 @@
     <div class="m-expandable_content"
             {{ 'aria-expanded=true' if value.is_expanded else '' }}>
         <div class="m-expandable_content-animated">
-            {% if filter %}
+            {% if caller is defined %}
                 {{ caller() }}
             {% else %}
                 {% for block in value.content %}

--- a/cfgov/jinja2/v1/_includes/organisms/filterable-list-controls.html
+++ b/cfgov/jinja2/v1/_includes/organisms/filterable-list-controls.html
@@ -182,7 +182,7 @@
 {% macro render(controls, form, index) %}
     <div class="o-filterable-list-controls">
         {% set form_markup = _filters_form(controls, form, index) %}
-        {% call() expandable(controls, true) %}
+        {% call() expandable(controls) %}
             {{ form_markup | safe }}
         {% endcall %}
         {% for field in form %}

--- a/cfgov/jinja2/v1/_includes/secondary-navigation.html
+++ b/cfgov/jinja2/v1/_includes/secondary-navigation.html
@@ -1,3 +1,5 @@
+{# TODO: This can go away once the old pages have been migrated. #}
+
 {# ==========================================================================
 
    secondary_navigation.render()
@@ -18,30 +20,31 @@
 
 {% macro _secondary_navigation(items, active_item_id) %}
 {% from 'molecules/nav-link.html' import nav_link as nav_link %}
-    <ul class="o-secondary-navigation_list
-               o-secondary-navigation_list__parents">
-        {%- for item in items %}
-            <li>
-                {{ nav_link(item.title, item.url, true, item.url == request.url) }}
-                {%- for child in item.children -%}
-                    <ul class="o-secondary-navigation_list
-                               o-secondary-navigation_list__children">
-                        <li>
-                            {{ nav_link(child.title, child.url, false, child.url == request.url) }}
-                        </li>
-                    </ul>
-                {%- endfor %}
-            </li>
+<ul class="o-secondary-navigation_list
+           o-secondary-navigation_list__parents">
+    {%- for item in items %}
+        {%- set href, id, caption, children = item[0], item[1], item[2], item[3:] %}
 
+    <li>
+        {{ nav_link(caption, href, true, id == active_item_id) }}
+    {%- if children -%}
+        {% set children = children[0] %}
+        <ul class="o-secondary-navigation_list
+                   o-secondary-navigation_list__children">
+        {%- for href, id, caption in children %}
+            <li>
+                {{ nav_link(caption, href, false, id == active_item_id) }}
+            </li>
         {%- endfor %}
-    </ul>
+        </ul>
+    {%- endif %}
+    </li>
+
+    {%- endfor %}
+</ul>
 {% endmacro %}
 
-{% set nav_items, has_children = get_secondary_nav_items(page) %}
-
-{# TODO: This should be hidden on tablets as well. #}
-<nav class="o-secondary-navigation
-            {{ 'u-hide-on-mobile' if not has_children else '' }}"
+<nav class="o-secondary-navigation"
      aria-label="Section navigation">
     {% set sec_nav_settings = {
         'label': 'In this section',
@@ -52,6 +55,6 @@
 
     {% from 'molecules/expandable.html' import expandable with context %}
     {% call() expandable(sec_nav_settings) %}
-        {{ _secondary_navigation(nav_items, active_nav_id) | safe }}
+        {{ _secondary_navigation(sec_nav_items, active_nav_id) | safe }}
     {% endcall %}
 </nav>

--- a/cfgov/jinja2/v1/_layouts/layout-side-nav.html
+++ b/cfgov/jinja2/v1/_layouts/layout-side-nav.html
@@ -9,10 +9,13 @@
 #}
 
 {% block content_sidebar %}
-    {% set active_nav_id = active_nav_id | default('index') -%}
-    {% set sec_nav_items = vars.nav_items %}
-
-    {% include 'organisms/secondary-navigation.html' with context %}
+    {% if page %}
+        {% include 'organisms/secondary-navigation.html' with context %}
+    {% else %}
+        {% set active_nav_id = active_nav_id | default('index') -%}
+        {% set sec_nav_items = vars.nav_items %}
+        {% include 'secondary-navigation.html' with context %}
+    {% endif %}
 {% endblock %}
 
 {# Extra classes needed for .content_sidebar #}

--- a/cfgov/jinja2/v1/browse-basic/index.html
+++ b/cfgov/jinja2/v1/browse-basic/index.html
@@ -48,14 +48,3 @@
     </aside>
 {% endblock %}
 
-{% block content_sidebar scoped -%}
-    {% for block in page.side_navigation -%}
-        <div class="block block__flush-top">
-            {% if 'related_posts' in block.block_type %}
-                {{ related_posts.render(block) }}
-            {% else %}
-                {{ render_stream_child(block) }}
-            {% endif %}
-        </div>
-    {%- endfor %}
-{%- endblock %}

--- a/cfgov/jinja2/v1/browse-filterable/index.html
+++ b/cfgov/jinja2/v1/browse-filterable/index.html
@@ -44,9 +44,3 @@
         {% endfor %}
     </aside>
 {% endblock %}
-
-{% block content_sidebar scoped -%}
-    <aside>
-        {# TODO: Add sidebar organisms. #}
-    </aside>
-{%- endblock %}

--- a/cfgov/v1/models/browse_filterable_page.py
+++ b/cfgov/v1/models/browse_filterable_page.py
@@ -11,6 +11,7 @@ from wagtail.wagtailadmin.edit_handlers import TabbedInterface, ObjectList
 from . import base, molecules, organisms, ref
 from .learn_page import AbstractFilterPage
 from .. import forms
+from ..util.util import get_secondary_nav_items
 
 
 class BrowseFilterablePage(base.CFGOVPage):
@@ -41,6 +42,8 @@ class BrowseFilterablePage(base.CFGOVPage):
     def get_context(self, request, *args, **kwargs):
         context = super(BrowseFilterablePage, self).get_context(request, *args,
                                                                 **kwargs)
+        context.update({'get_secondary_nav_items': get_secondary_nav_items})
+
         context['forms'] = []
         form_class = self.get_form_class()
         form_specific_filters = self.get_form_specific_filter_data(form_class,

--- a/cfgov/v1/models/browse_page.py
+++ b/cfgov/v1/models/browse_page.py
@@ -9,7 +9,7 @@ from wagtail.wagtailcore.models import PAGE_TEMPLATE_VAR
 from .base import CFGOVPage
 from . import molecules
 from . import organisms
-
+from ..util.util import get_secondary_nav_items
 
 class BrowsePage(CFGOVPage):
     header = StreamField([
@@ -50,3 +50,8 @@ class BrowsePage(CFGOVPage):
 
     def full_width_serif(self):
         return true
+
+    def get_context(self, request, *args, **kwargs):
+        context = super(BrowsePage, self).get_context(request, *args, **kwargs)
+        context.update({'get_secondary_nav_items': get_secondary_nav_items})
+        return context


### PR DESCRIPTION
Changes handling of secondary navigation for Wagtail pages so they're built by the backend.

## Additions

- `get_secondary_nav_items()` to the util/util.py to build the nav items

## Changes

- Diverts pages using Wagtail to the backend rendering while maintaining the original generation for non-Wagtail pages

## Testing
`gulp build` then:
Verify it shows on
 1. Browse page with siblings but no children
  - verify that the nav does not show on mobile sizes
 2. Browse page with children
  - verify that the nav shows on mobile sizes
 3. Visit a child page
   - verify that the nav shows on mobile sizes (should be the same as before but with the current page modifier)
 - Browse page with siblings and children

### Page Structure
```
Landing Page
   |---> Sublanding Page
             |---> Browse Page 1: (test 1)
             |---> Browse Page 2 (test 2)
                         |---> Browse Child Page (test 3)
```

## Review

- @richaagarwal 
- @kave  
- @jimmynotjim  

## Screenshots
![screen shot 2016-02-22 at 4 28 32 pm](https://cloud.githubusercontent.com/assets/1412978/13233365/690b88e8-d981-11e5-9424-b1c6b8d24654.png)


- Direct Wagtail pages to use new handling
 - maintains old handling for sheer pages