### PR TITLE
Bugfix/heros

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,11 +52,12 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Removed Link Blob, 25/75, and 50/50 styles.
 - Removed need for negative margin tweaks after groups.
 - Removed need for positive margin tweaks aroung group headings.
+- Removed heros from old WordPress pages.
 
 ### Fixed
 - Fix bug where publised pages were showing shared content
 - Fixed Contacts import-data script to set phone numbers correctly
-
+- Fixed an issue where heros were not displaying on new Wagtail pages.
 
 ## 3.0.0-3.0.0 - 2016-02-11
 

--- a/cfgov/jinja2/v1/_includes/molecules/hero.html
+++ b/cfgov/jinja2/v1/_includes/molecules/hero.html
@@ -30,41 +30,29 @@
    See [GHE]/flapjack/Modules-V1/wiki/Heros
 
    ========================================================================== #}
-{% macro render(value) %}
-  <section class="hero"
-    {{ value.body.source }}
-           {{ 'style=background-color:' +
-               value.background_color + ';'
-               if value.background_color else '' }}>
-      <div class="wrapper hero_wrapper">
-          <div class="hero_text">
-              <h1 class="hero_heading">{{ value.heading | safe}}</h1>
-              <div class="hero_subhead">{{ value.body.source |safe}}</div>
-              {% for link in value.links %}
-                  <a href="{{ link.url }}"
-                     class="hero_cta
-                     {{ 'btn' if value.is_button
-                     else '' }}">
-                      {{ link.text }}
-                  </a>
-              {% endfor %}
-          </div>
+<section class="hero"
+         {{ 'style=background-color:' +
+             value.background_color + ';'
+             if value.background_color else '' }}>
+    <div class="wrapper hero_wrapper">
+        <div class="hero_text">
+            <h1 class="hero_heading">{{ value.heading | safe}}</h1>
+            <div class="hero_subhead">{{ value.body.source |safe}}</div>
+            {% for link in value.links %}
+                <a href="{{ link.url }}"
+                   class="hero_cta
+                   {{ 'btn' if value.is_button else '' }}">
+                    {{ link.text }}
+                </a>
+            {% endfor %}
+        </div>
 
-
-          {# TODO: Remove this when /the-bureau/ has been converted to wagtail #}
-          {% if value.macro_image %}
-              <div class="hero_image"
-                   style="background-image: url( {{ value.macro_image.url }} );">
-              </div>
-          {% else %}
-              {% if value.image.upload.url %}
-                  {% set photo=image(value.image.upload, 'original') %}
-                  <div class="hero_image"
-                       style="background-image: url( {{ photo.url }} );">
-              {% endif %}
-          {% endif %}
-      </div>
-  </section>
-{% endmacro %}
+        {% if value.image.upload %}
+            {% set photo=image(value.image.upload, 'original') %}
+            <div class="hero_image"
+                 style="background-image: url( {{ photo.url }} );"></div>
+        {% endif %}
+    </div>
+</section>
 
 

--- a/cfgov/jinja2/v1/careers/application-process/index.html
+++ b/cfgov/jinja2/v1/careers/application-process/index.html
@@ -2,7 +2,6 @@
 {% import '_vars-careers.html' as vars with context %}
 {%- set active_nav_id = 'application-process' -%}
 {% set breadcrumb_items = vars.breadcrumb_items %}
-{% import 'molecules/hero.html' as hero %}
 
 
 {% block title -%}
@@ -20,26 +19,6 @@
 
 {% block content_main_modifiers -%}
     {{ super() }} content__flush-bottom
-{%- endblock %}
-
-{% block hero -%}
-    {{ hero.render({
-            'heading':   'CFPB Hiring Video',
-            'body': {
-                'source': 'We are a government agency created after the 2008
-                          financial crisis. We protect American consumers.
-                          Allow us to introduce ourselves.'
-            },
-            'macro_image': {
-                'url': '/static/img/applying-video-screenshot.png'
-            },
-            'background_color': '#d5e7e6',
-            'link': {
-                'text': 'See the history of the CFPB',
-                'url':  '/the-bureau/history/'
-            }
-        })
-    }}
 {%- endblock %}
 
 {% block content_main %}

--- a/cfgov/jinja2/v1/landing-page/index.html
+++ b/cfgov/jinja2/v1/landing-page/index.html
@@ -28,16 +28,10 @@
         {% endif %}
     {%- endfor %}
     {% for block in page.content -%}
-        {% if loop.index == 1 %}
-            <div class="block
-                        block__flush-top">
-                {{ render_stream_child(block) }}
-            </div>
-        {% else %}
-            <div class="block">
-                {{ render_stream_child(block) }}
-            </div>
-        {% endif %}
+        <div class="block
+                    {{ 'block__flush-top' if loop.index == 1 else '' }}">
+            {{ render_stream_child(block) }}
+        </div>
     {%- endfor %}
 {% endblock %}
 

--- a/cfgov/jinja2/v1/sublanding-page/index.html
+++ b/cfgov/jinja2/v1/sublanding-page/index.html
@@ -21,15 +21,11 @@
     {% endif %}
 {% endblock %}
 
+
 {% block content_main %}
     {% for block in page.content -%}
-        {% if loop.index == 1 %}
-            <div class="block
-                        block__flush-top">
-        {% else %}
-            <div class="block">
-        {% endif %}
-
+        <div class="block
+                    {{ 'block__flush-top' if loop.index == 1 else '' }}">
         {% if 'post_preview_snapshot' in block.block_type %}
             {% set posts = page.get_browsefilterable_posts(request) %}
             {% set limit = block.value.limit | int %}

--- a/cfgov/jinja2/v1/the-bureau/index.html
+++ b/cfgov/jinja2/v1/the-bureau/index.html
@@ -1,6 +1,5 @@
 {% extends 'layout-side-nav.html' %}
 {% import '_vars-the-bureau.html' as vars with context %}
-{% import 'molecules/hero.html' as hero %}
 
 {% block title -%}
     The Bureau
@@ -25,26 +24,6 @@
 {% block content_modifiers -%}
     {{ super() }}
     the-bureau
-{%- endblock %}
-
-{% block hero -%}
-    {{ hero.render({
-            'heading':   'We are the CFPB',
-            'body': {
-                'source': 'We are a government agency created after the 2008
-                          financial crisis. We protect American consumers.
-                          Allow us to introduce ourselves.'
-            },
-            'macro_image': {
-                'url': 'https://img.youtube.com/vi/en0Iq8II4fA/maxresdefault.jpg'
-            },
-            'background_color': '#d5e7e6',
-            'link': {
-                'text': 'See the history of the CFPB',
-                'url':  '/the-bureau/history/'
-            }
-        })
-    }}
 {%- endblock %}
 
 {% block content_main_modifiers -%}

--- a/test/browser_tests/page_objects/page_the-bureau.js
+++ b/test/browser_tests/page_objects/page_the-bureau.js
@@ -9,8 +9,6 @@ function TheBureauPage() {
 
   this.sideNav = element( by.css( '.o-secondary-navigation' ) );
 
-  this.hero = element( by.css( '.hero' ) );
-
   this.bureauHistory = element( by.css( '.bureau-history' ) );
 
   this.bureauMission =

--- a/test/browser_tests/spec_suites/the-bureau.js
+++ b/test/browser_tests/spec_suites/the-bureau.js
@@ -16,12 +16,6 @@ describe( 'The Bureau Page', function() {
     }
   );
 
-  it( 'should have a hero',
-    function() {
-      expect( page.hero.isPresent() ).toBe( true );
-    }
-  );
-
   it( 'should have a side nav',
     function() {
       expect( page.sideNav.isPresent() ).toBe( true );


### PR DESCRIPTION
Fixes an issue where heros were not displaying on new Wagtail pages

## Removals

- Removed heros from old WordPress pages

## Changes

- Updated hero molecule to just import (values are passed by wagtail)
- Snuck in a simplification of the flush top modifier to the landing and sub-landing templates

## Testing

- you'll need to import Wagtail data to see it locally or create your own landing or sub-landing pages w/ heros
- `/the-bureau/` and `/careers/application-process/` should not have heros (to be replaced by FCM) soonly

## Review

- @kave 
- @KimberlyMunoz 
- @anselmbradford 
- @sebworks 

## Screenshots

Hero (image missing due to not having assets locally)

![screen shot 2016-02-22 at 5 17 43 pm](https://cloud.githubusercontent.com/assets/1280430/13234745/3443308c-d988-11e5-82e8-ac10619aba48.png)

No longer a Hero

![screen shot 2016-02-22 at 5 17 34 pm](https://cloud.githubusercontent.com/assets/1280430/13234757/42815a3e-d988-11e5-889a-be1745b4c654.png)

## Notes

- Thanks @kave for the boost on debugging this.

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices
* [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
