### PR TITLE
Accounts for missing start/end dates in Events

### DIFF
--- a/cfgov/jinja2/v1/events/event.html
+++ b/cfgov/jinja2/v1/events/event.html
@@ -1,6 +1,8 @@
 {% extends 'layout-2-1-bleedbar.html' %}
 {% import '_vars-events.html' as vars with context %}
-{% set event_state = when(page.start_dt | date('%c'), page.end_dt | date('%c')) %}
+{% if page.start_dt and page.end_dt %}
+    {% set event_state = when(page.start_dt | date('%c'), page.end_dt | date('%c')) %}
+{% endif %}
 
 {% block title -%}
     {{ page.seo_title }}
@@ -29,13 +31,13 @@
         {{ event_agenda(page) }}
     {% endif %}
     <div class="event-footer">
-        {% if event_state != 'past' %}
-        <p class="event-footer_banner">
-            <span class="event-footer_banner-message h4">This event requires an RSVP. Reserve your spot here: </span>
-            <a href="mailto:reserve@cfpb.gov?subject=Event RSVP&body=To RSVP, please fill in your first and last name below and send this email.%0D%0A%0D%0AFirst name:%0D%0ALast name:" class="btn">
-                <span class="btn_icon__left cf-icon cf-icon-email-social"></span>
-                 reserve@cfpb.gov</a>
-        </p>
+        {% if event_state and event_state != 'past' %}
+            <p class="event-footer_banner">
+                <span class="event-footer_banner-message h4">This event requires an RSVP. Reserve your spot here: </span>
+                <a href="mailto:reserve@cfpb.gov?subject=Event RSVP&body=To RSVP, please fill in your first and last name below and send this email.%0D%0A%0D%0AFirst name:%0D%0ALast name:" class="btn">
+                    <span class="btn_icon__left cf-icon cf-icon-email-social"></span>
+                     reserve@cfpb.gov</a>
+            </p>
         {% endif %}
         <div class="content-l">
             <section class="content-l_col content-l_col-1-2 event-footer_col">


### PR DESCRIPTION
Events page without a start/end date break the template

## Testing

- View an imported event page without a start/end date

## Review

- @kurtw 
- @anselmbradford 



