### PR TITLE
Add new manager to deal with shared vs live appropriately

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - David Silberman's assets
 - Frontend: Added JS init scripts for /offices/, /sub-pages/, and /budget/.
 - Frontend: Added data-* attribute JS utility class.
+- New manager to query for the most appropriate pages (shared and/or live)
 
 ### Changed
 - Converted the project to Capital Framework v3

--- a/cfgov/v1/models/browse_filterable_page.py
+++ b/cfgov/v1/models/browse_filterable_page.py
@@ -48,7 +48,7 @@ class BrowseFilterablePage(base.CFGOVPage):
         form_class = self.get_form_class()
         form_specific_filters = self.get_form_specific_filter_data(form_class,
                                                                    request.GET)
-        forms = [form_class(form_specific_filters[filters_id], parent=self)
+        forms = [form_class(form_specific_filters[filters_id], parent=self, hostname=request.site.hostname)
                  for filters_id in form_specific_filters.keys()]
         for form in forms:
             if form.is_valid():
@@ -109,14 +109,8 @@ class BrowseFilterablePage(base.CFGOVPage):
                 if not categories or 'blog' in categories:
                     blog_cats = [c[0] for c in ref.categories[1][1]]
                     blog_q = Q('categories__name__in', blog_cats)
-        # If this is the staging site, then return pages that are
-        # shared. Else, make sure that the pages are published.
-        if getattr(settings, 'STAGING_HOSTNAME', 'content') in hostname:
-            return AbstractFilterPage.objects.filter(
-                shared=True).descendant_of(self).filter(form.generate_query() | blog_q)
-        else:
-            return AbstractFilterPage.objects.live().descendant_of(
-                self).filter(form.generate_query() | blog_q)
+        return AbstractFilterPage.objects.live_shared(hostname).descendant_of(
+            self).filter(form.generate_query() | blog_q)
 
 
 class EventArchivePage(BrowseFilterablePage):

--- a/cfgov/v1/models/learn_page.py
+++ b/cfgov/v1/models/learn_page.py
@@ -75,6 +75,8 @@ class AbstractFilterPage(CFGOVPage):
     # This page class cannot be created.
     is_creatable = False
 
+    objects = CFGOVPage.objects
+
     class Meta:
         ordering = ('date_published',)
 


### PR DESCRIPTION
Makes sure the right pages are served by adding a query method to get a set of pages according to their status and hostname.

## Additions

- New manager

## Testing
These should work. Look at the comments and change the command as needed.

```
./cfgov/manage shell
from v1.models import CFGOVPage, AbstractFilterPage
CFGOVPage.objects.shared() # should return shared pages

# this will only really work if you have the two sites set up (content.localhost, localhost)
CFGOVPage.objects.live_shared('content.localhost') #should return shared or live pages 

# the manager should be accessible via the AbstractFilterPage as well
pages = AbstractFilterPage.objects.live_shared('content.localhost')
```

## Review

- @kave 
- @richaagarwal 
- @rosskarchner 

