### PR TITLE
Fixes issue where secnav tries to init a non-existant nav

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Fix bug where publised pages were showing shared content
 - Fixed Contacts import-data script to set phone numbers correctly
 - Fixed an issue where heros were not displaying on new Wagtail pages.
+- Fixed an error where the secondary nav script was trying to initialize on pages it wasn't used.
 
 ## 3.0.0-3.0.0 - 2016-02-11
 

--- a/cfgov/unprocessed/js/routes/browse-basic/index.js
+++ b/cfgov/unprocessed/js/routes/browse-basic/index.js
@@ -5,8 +5,11 @@
 'use strict';
 
 // List of organisms used.
+var SecondaryNavigation = require( '../../organisms/SecondaryNavigation' );
 var Expandable = require( '../../molecules/Expandable' );
 var ExpandableGroup = require( '../../organisms/ExpandableGroup' );
+
+var secondaryNavigation = new SecondaryNavigation( document.body ).init();
 
 var selector = '.expandable-prototypes .m-expandable';
 var expandables = document.querySelectorAll( selector );

--- a/cfgov/unprocessed/js/routes/browse-filterable/index.js
+++ b/cfgov/unprocessed/js/routes/browse-filterable/index.js
@@ -5,15 +5,19 @@
 'use strict';
 
 // List of organisms used.
+var SecondaryNavigation = require( '../../organisms/SecondaryNavigation' );
 var Notification = require( '../../molecules/Notification' );
 var FilterableListControls = require( '../../organisms/FilterableListControls' );
 var Multiselect = require( '../../molecules/Multiselect' );
+
+var secondaryNavigation = new SecondaryNavigation( document.body ).init();
 
 var notifications = document.querySelectorAll( '.m-notification' );
 var notification;
 for ( var i = 0, len = notifications.length; i < len; i++ ) {
 	notification = new Notification( notifications[i] ).init();
 }
+
 var filterableListControls = new FilterableListControls( document.body ).init();
 var multiselect = new Multiselect( document.querySelector( 'select[multiple]' ) );
 multiselect.init();

--- a/cfgov/unprocessed/js/routes/common.js
+++ b/cfgov/unprocessed/js/routes/common.js
@@ -28,7 +28,3 @@ require( '../modules/external-site-redirect.js' ).init();
 var Header = require( '../organisms/Header.js' );
 var header = new Header( document.body );
 header.init();
-
-// Secondary Navigation
-var SecondaryNavigation = require( '../organisms/SecondaryNavigation' );
-var secondaryNavigation = new SecondaryNavigation( document.body ).init();


### PR DESCRIPTION
The SecondaryNav script was trying to initialize on pages the nav isn't used.

## Changes

- Updated JS routes to only init on the browse and browse-filterable page types.

## Testing

- `gulp build` and check the console for `Uncaught Error: o-secondary-navigation not found on or in passed DOM node.` to be removed.

## Review

- @sebworks 
- @KimberlyMunoz 
- @anselmbradford 

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices
* [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)

