### PR TITLE
Fixed issue where duplicate hero displayed in main content

### DIFF
--- a/cfgov/jinja2/v1/landing-page/index.html
+++ b/cfgov/jinja2/v1/landing-page/index.html
@@ -20,7 +20,9 @@
 
 {% block content_main %}
     {% for block in page.header -%}
-        {% include 'templates/render_block.html' with context %}
+        {% if block.block_type != 'hero' %}
+            {% include 'templates/render_block.html' with context %}
+        {% endif %}
     {%- endfor %}
     {% for block in page.content -%}
         {% if loop.index == 1 %}


### PR DESCRIPTION
Fixed issue where hero displayed in main content

## Changes

- Conditioned off hero from the `page.head` block loop.

## Testing

- view `/data-research/`if you have content data. Otherwise view any landing page w/ a hero.

## Review

- @kave 
- @anselmbradford 
- @sebworks 
- @KimberlyMunoz 

## Screenshots

__Before__
![screen shot 2016-02-23 at 5 59 50 pm](https://cloud.githubusercontent.com/assets/1280430/13269748/76dfad92-da57-11e5-8d26-b9779df9b08a.png)

__After__
![screen shot 2016-02-23 at 5 59 57 pm](https://cloud.githubusercontent.com/assets/1280430/13269750/79d4c74e-da57-11e5-8cd8-30e8d0154fcc.png)

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)

