### PR TITLE
Added overlay atom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Added new content flush sides on small modifier to fix an issue where margin was set on the molecule level instead of the template.
 - Added Info Unit Macro.
 - URL field to the Post Preview organism
+- Frontend: Added overlay atom.
 
 ### Changed
 - Converted the project to Capital Framework v3

--- a/cfgov/jinja2/v1/_layouts/base.html
+++ b/cfgov/jinja2/v1/_layouts/base.html
@@ -129,6 +129,9 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 
 {% block body %}
 
+{# Overlay for the page. Used for the mobile mega menu. #}
+<div class="a-overlay u-hidden"></div>
+
 <a href="#main" id="skip-nav">Skip to main content</a>
 
 {% if flag_enabled('BETA_NOTICE') %}

--- a/cfgov/unprocessed/css/atoms/overlay.less
+++ b/cfgov/unprocessed/css/atoms/overlay.less
@@ -1,0 +1,36 @@
+/* topdoc
+  name: Overlay
+  family: cfgov-atoms
+  patterns:
+    - name: Default example
+      markup: |
+          <div class="a-overlay"></div>
+      codenotes:
+        - |
+          Structural cheat sheet:
+          -----------------------
+          .a-overlay
+  tags:
+    - cfgov-atoms
+*/
+
+.a-overlay {
+    // Only show overlay at mobile/tablet size.
+    .respond-to-max( @bp-sm-max, {
+        height: 100%;
+        width: 100%;
+
+        position: fixed;
+        // TODO: Update z-index value with standard z-index variable.
+        z-index: 10;
+
+        background: @black;
+        opacity: 0.6;
+    } );
+}
+
+
+/* topdoc
+    name: EOF
+    eof: true
+*/

--- a/cfgov/unprocessed/css/main.less
+++ b/cfgov/unprocessed/css/main.less
@@ -67,6 +67,7 @@
 
 @import (less) "atoms/rule-break.less";
 @import (less) "atoms/multi-select.less";
+@import (less) "atoms/overlay.less";
 
 
 /* Molecule pieces

--- a/cfgov/unprocessed/css/mobile-carousel.less
+++ b/cfgov/unprocessed/css/mobile-carousel.less
@@ -47,7 +47,8 @@
             // which may vary. Find a way to set this value with the
             // .media_image__100 and .media_image__130-to-150 classes.
             top: 140px;
-            z-index: 1000;
+            // TODO: Update z-index value with standard z-index variable.
+            z-index: 9;
 
             &:hover:before {
                 color: @gray-40;

--- a/cfgov/unprocessed/js/organisms/Header.js
+++ b/cfgov/unprocessed/js/organisms/Header.js
@@ -23,17 +23,22 @@ function Header( element ) {
     atomicCheckers.validateDomElement( element, BASE_CLASS, 'Header' );
   var _globalSearch;
   var _megaMenu;
+  var _overlay;
 
   /**
+   * @param {HTMLNode} overlay
+   *   Overlay to show/hide when mobile mega menu is shown.
    * @returns {Object} The Header instance.
    */
-  function init() {
+  function init( overlay ) {
+    _overlay = overlay;
     _globalSearch = new GlobalSearch( _dom );
     _globalSearch.addEventListener( 'toggle', _searchClicked );
     _globalSearch.init();
 
     _megaMenu = new MegaMenu( _dom );
-    _megaMenu.addEventListener( 'triggerClick', _megaMenuClicked );
+    _megaMenu.addEventListener( 'rootExpandBegin', _megaMenuExpandBegin );
+    _megaMenu.addEventListener( 'rootCollapseEnd', _megaMenuCollapseEnd );
     _megaMenu.init();
 
     return this;
@@ -46,11 +51,22 @@ function Header( element ) {
     _megaMenu.collapse();
   }
 
+
   /**
-   * Handler for opening the mega menu.
+   * Handler for when the mega menu begins expansion.
+   * Collapse the global search.
    */
-  function _megaMenuClicked() {
+  function _megaMenuExpandBegin() {
     _globalSearch.collapse();
+    _overlay.classList.remove( 'u-hidden' );
+  }
+
+  /**
+   * Handler for when the mega menu ends collapsing.
+   * Show an overlay.
+   */
+  function _megaMenuCollapseEnd() {
+    _overlay.classList.add( 'u-hidden' );
   }
 
   this.init = init;

--- a/cfgov/unprocessed/js/organisms/MegaMenu.js
+++ b/cfgov/unprocessed/js/organisms/MegaMenu.js
@@ -65,8 +65,9 @@ function MegaMenu( element ) {
    */
   function _initEvents( menu ) {
     menu.addEventListener( 'toggle', _handleToggle.bind( this ) );
-    menu.addEventListener( 'expandBegin', _handleExpandBegin );
+    menu.addEventListener( 'expandBegin', _handleExpandBegin.bind( this ) );
     menu.addEventListener( 'collapseBegin', _handleCollapseBegin );
+    menu.addEventListener( 'collapseEnd', _handleCollapseEnd.bind( this ) );
   }
 
   /**
@@ -168,8 +169,12 @@ function MegaMenu( element ) {
   /**
    * Event handler for when FlyoutMenu expand transition begins.
    * Use this to perform post-expandBegin actions.
+   * @param {Event} event - A FlyoutMenu event.
    */
-  function _handleExpandBegin() {
+  function _handleExpandBegin( event ) {
+    if ( event.target === _flyoutMenu ) {
+      this.dispatchEvent( 'rootExpandBegin', { target: this } );
+    }
     // If on a submenu, focus the back button, otherwise focus the first link.
     var firstMenuLink;
     if ( _activeMenu === _flyoutMenu ) {
@@ -187,6 +192,18 @@ function MegaMenu( element ) {
    * Use this to perform post-collapseBegin actions.
    */
   function _handleCollapseBegin() {
+    document.body.removeEventListener( 'mousedown', _handleBodyClick );
+  }
+
+  /**
+   * Event handler for when FlyoutMenu collapse transition ends.
+   * Use this to perform post-collapseEnd actions.
+   * @param {Event} event - A FlyoutMenu event.
+   */
+  function _handleCollapseEnd( event ) {
+    if ( event.target === _flyoutMenu ) {
+      this.dispatchEvent( 'rootCollapseEnd', { target: this } );
+    }
     document.body.removeEventListener( 'mousedown', _handleBodyClick );
   }
 

--- a/cfgov/unprocessed/js/routes/common.js
+++ b/cfgov/unprocessed/js/routes/common.js
@@ -27,4 +27,4 @@ require( '../modules/external-site-redirect.js' ).init();
 // Organisms.
 var Header = require( '../organisms/Header.js' );
 var header = new Header( document.body );
-header.init();
+header.init( document.body.querySelector( '.a-overlay' ) );


### PR DESCRIPTION
Adds atom for covering the page content with a semi-opaque overlay that's shown when the mobile mega menu is shown.

## Additions

- Added overlay atom

## Changes

- Added `rootExpandBegin` and `rootCollapseEnd` events to the mega menu to respond when the base level menu is opened/closed so that events can be tied to when the menu first opens and completely closes.

## Testing

- `gulp build`
- Resize page to mobile size.
- Click hamburger menu, observe overlay appear and menu slide in from left.
- Click hamburger menu, observe menu slide to left and overlay disappear.

## Review

- @KimberlyMunoz 
- @sebworks 
- @jimmynotjim 
- @duelj 
- @ajbush 

## Screenshots

![overlay](https://cloud.githubusercontent.com/assets/704760/13290516/e8cf004e-dae1-11e5-80bd-cf77b2c0b1d7.gif)


## Notes

- @duelj @ajbush Since the overlay is a new atom it could be added to the wiki and the mega menu. Note that the mega menu doesn't include the overlay. The overlay reference is handed to the Header organism at the template level, and the Header shows/hides it when the mega menu expands/collapses.

## Todos

- Please ignore no-js and keyboard state for the mega menu (still WIP), but note any no-js or keyboard state issues for the overlay atom directly.
