### PR TITLE
Adding specific script for IE legacy versions

### DIFF
--- a/cfgov/jinja2/v1/_layouts/base.html
+++ b/cfgov/jinja2/v1/_layouts/base.html
@@ -100,6 +100,8 @@
     </script>
     <![endif]-->
 
+    <!--[if IE 9]><script src="{{ static('js/ie/common.ie.js') }}"></script><![endif]-->
+
     {# TODO: jQuery CDN is provided in the head to satisfy
              Google Tag Manager (GTM) requirements.
              Ideally GTM would handle its own dependency management

--- a/cfgov/unprocessed/js/ie/common.ie.js
+++ b/cfgov/unprocessed/js/ie/common.ie.js
@@ -1,0 +1,8 @@
+/* ==========================================================================
+   Common application-wide scripts for Internet Explorer legacy versions
+   ========================================================================== */
+
+'use strict';
+
+// Global modules.
+require( '../modules/polyfill/class-list' )

--- a/cfgov/unprocessed/js/modules/ClearableInput.js
+++ b/cfgov/unprocessed/js/modules/ClearableInput.js
@@ -1,8 +1,5 @@
 'use strict';
 
-// Required polyfills for IE9.
-if ( !Modernizr.classlist ) { require( '../modules/polyfill/class-list' ); } // eslint-disable-line no-undef, global-require, no-inline-comments, max-len
-
 // Required modules.
 var atomicCheckers = require( '../modules/util/atomic-checkers' );
 

--- a/cfgov/unprocessed/js/modules/util/atomic-checkers.js
+++ b/cfgov/unprocessed/js/modules/util/atomic-checkers.js
@@ -6,9 +6,6 @@
 
 'use strict';
 
-// Required polyfills for IE9.
-if ( !Modernizr.classlist ) { require( '../polyfill/class-list' ); } // eslint-disable-line no-undef, global-require, no-inline-comments, max-len
-
 /**
  * @param {HTMLNode} element
  *   The DOM element within which to search for the atomic element class.

--- a/cfgov/unprocessed/js/molecules/Expandable.js
+++ b/cfgov/unprocessed/js/molecules/Expandable.js
@@ -1,8 +1,5 @@
 'use strict';
 
-// Required polyfills for IE9.
-if ( !Modernizr.classlist ) { require( '../modules/polyfill/class-list' ); } // eslint-disable-line no-undef, global-require, no-inline-comments, max-len
-
 // Required modules.
 var EventObserver = require( '../modules/util/EventObserver' );
 var atomicCheckers = require( '../modules/util/atomic-checkers' );

--- a/cfgov/unprocessed/js/molecules/GlobalSearch.js
+++ b/cfgov/unprocessed/js/molecules/GlobalSearch.js
@@ -1,8 +1,5 @@
 'use strict';
 
-// Required polyfills for IE9.
-if ( !Modernizr.classlist ) { require( '../modules/polyfill/class-list' ); } // eslint-disable-line no-undef, global-require, no-inline-comments, max-len
-
 // Required modules.
 var atomicCheckers = require( '../modules/util/atomic-checkers' );
 var breakpointState = require( '../modules/util/breakpoint-state' );

--- a/cfgov/unprocessed/js/molecules/Multiselect.js
+++ b/cfgov/unprocessed/js/molecules/Multiselect.js
@@ -1,8 +1,5 @@
 'use strict';
 
-// Required polyfills for IE9.
-if ( !Modernizr.classlist ) { require( '../modules/polyfill/class-list' ); } // eslint-disable-line no-undef, global-require, no-inline-comments, max-len
-
 // Required modules.
 var arrayHelpers = require( '../modules/util/array-helpers' );
 var typeCheckers = require( '../modules/util/type-checkers' );

--- a/cfgov/unprocessed/js/molecules/Notification.js
+++ b/cfgov/unprocessed/js/molecules/Notification.js
@@ -1,8 +1,5 @@
 'use strict';
 
-// Required polyfills for IE9.
-if ( !Modernizr.classlist ) { require( '../modules/polyfill/class-list' ); } // eslint-disable-line no-undef, global-require, no-inline-comments, max-len
-
 // Required modules.
 var atomicCheckers = require( '../modules/util/atomic-checkers' );
 

--- a/cfgov/unprocessed/js/organisms/ExpandableGroup.js
+++ b/cfgov/unprocessed/js/organisms/ExpandableGroup.js
@@ -1,8 +1,5 @@
 'use strict';
 
-// Required polyfills for IE9.
-if ( !Modernizr.classlist ) { require( '../modules/polyfill/class-list' ); } // eslint-disable-line no-undef, global-require, no-inline-comments, max-len
-
 // Required modules.
 var Expandable = require( '../molecules/Expandable' );
 var atomicCheckers = require( '../modules/util/atomic-checkers' );

--- a/gulp/tasks/scripts.js
+++ b/gulp/tasks/scripts.js
@@ -17,7 +17,7 @@ var paths = require( '../../config/environment' ).paths;
 var webpackConfig = require( '../../config/webpack-config.js' );
 var webpackStream = require( 'webpack-stream' );
 
-gulp.task( 'scripts', function() {
+gulp.task( 'scripts:modern', function() {
   return gulp.src( paths.unprocessed + '/js/routes/common.js' )
     .pipe( gulpModernizr( {
       tests:   [ 'csspointerevents', 'classlist' ],
@@ -35,3 +35,23 @@ gulp.task( 'scripts', function() {
       stream: true
     } ) );
 } );
+
+gulp.task( 'scripts:ie', function() {
+  return gulp.src( paths.unprocessed + '/js/ie/common.ie.js' )
+    .pipe( webpackStream( {
+        entry: paths.unprocessed + '/js/ie/common.ie.js' ,
+        output: {
+          filename: 'common.ie.js',
+    } } ) )
+    .on( 'error', handleErrors )
+    .pipe( gulpUglify() )
+    .pipe( gulp.dest( paths.processed + '/js/ie/' ) )
+    .pipe( browserSync.reload( {
+      stream: true
+    } ) );
+} );
+
+gulp.task( 'scripts', [
+  'scripts:modern',
+  'scripts:ie'
+] );


### PR DESCRIPTION
Adding specific script for IE legacy versions which allows us to remove legacy code for scripts. 

## Additions

- Adding specific script for IE legacy versions.

## Removals

- Removed conditional `class-list` check from various files.

## Testing
- Browse site on IE9 virtual machine.

## Review

- @anselmbradford 
- @KimberlyMunoz 
- @jimmynotjim 

## Notes

- Wasn't sure if other scripts should be included in the legacy build. 

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
