### PR TITLE
Add signal receiver to handle unpublish all revisions for a page when unpublishing.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Added Info Unit Macro.
 - URL field to the Post Preview organism
 - Frontend: Added overlay atom.
+- Signal receiver function to unpublish all revisions for a page when a page is unpublished
 
 ### Changed
 - Converted the project to Capital Framework v3

--- a/cfgov/v1/migrations/0052_remove_browsepage_side_navigation.py
+++ b/cfgov/v1/migrations/0052_remove_browsepage_side_navigation.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('v1', '0051_abstractfilterpage_preview_link_url'),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name='browsepage',
+            name='side_navigation',
+        ),
+    ]


### PR DESCRIPTION
#1458 introduced a bug (while it was fixing another) because it changed the way that we're routing pages in the CFGOVPage model. So now what's going on is that `unpublish` doesn't work because it looks for  the last published version of the page. This will fix that by unpublishing every version in the history of the page.

Edit: this now does the same thing for "unsharing" pages.

## Additions

- Signal handler to unpublish all page versions
- Signal handler to unshare all page versions

## Changes

- Unpublishing unpublishes all versions of the page, instead of just creating a latest version that is not published. same for unsharing.

## Testing

- Publish a page.
- Unpublish it.
- Make sure it's not there.
- Do the same for sharing/unsharing.

## Review

- @kave 
- @richaagarwal 
@rosskarchner 
