### PR TITLE
restore wagtail URL patterns

### DIFF
--- a/cfgov/cfgov/urls.py
+++ b/cfgov/cfgov/urls.py
@@ -266,7 +266,7 @@ if settings.DEBUG :
 
 # Catch remaining URL patterns that did not match a route thus far.
 
-# urlpatterns.append(url(r'', include(wagtail_urls)))
+urlpatterns.append(url(r'', include(wagtail_urls)))
 
 from sheerlike import register_permalink
 


### PR DESCRIPTION
Short description explaining the high-level reason for the pull request

## Additions

In a previous pull request, I commented out the line that serves all of wagtails URL's.

This uncomments it