### PR TITLE
Mega structure update of mega menu - initial 3rd level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Backend: HomePage Model
 - David Silberman's assets
 - Frontend: Added JS init scripts for /offices/, /sub-pages/, and /budget/.
+- Frontend: Added data-* attribute JS utility class.
 
 ### Changed
 - Converted the project to Capital Framework v3
@@ -52,6 +53,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Changed FilterableListControls.js to add validation for email, date, and checkbox fields.
 - Converted references and asset urls from Fuchs to Silberman.
 - Fix blog post template to use sheerlike related posts method.
+- Restructured mega menu to include submenus recursively to allow for a third-level.
 
 ### Removed
 - Removed normalize and normalize-legacy from main less file because CF already includes it.

--- a/cfgov/jinja2/v1/_includes/molecules/global-search.html
+++ b/cfgov/jinja2/v1/_includes/molecules/global-search.html
@@ -10,8 +10,8 @@
 
    ========================================================================== #}
 
-<div class="m-global-search">
-    <button class="m-global-search_trigger">
+<div class="m-global-search" data-js-hook="flyout-menu">
+    <button class="m-global-search_trigger" data-js-hook="flyout-menu_trigger">
         <span class="m-global-search_trigger-label">
             <span class="u-visually-hidden">Search</span>
         </span>

--- a/cfgov/jinja2/v1/_includes/organisms/_vars-mega-menu.html
+++ b/cfgov/jinja2/v1/_includes/organisms/_vars-mega-menu.html
@@ -1,44 +1,61 @@
 
 {#
-  TODO: Rename file as _vars-mega-menu.html.
-
   Navigation and Sub-Navigation menu items,
-  used to populate the contents of the site's navigation menus.
-  Format: navigation title {{ string }},
-          sub-navigation title {{ string }},
-          sub-navigation media {{ HTML string }},
-          sub-navigation items {{ array of tuples }}
+  used to populate the contents of the site's navigation menus (Mega Menu).
+
+  Format:
+
+  media_items:     Array of tuples containing a media item lookup map.
+  media_items.url: The URL of the menu item.
+                   Used to look up the featured menu content.
+  media_item.fmc:  Featured Menu Content.
+
+  nav_items:                       Multi-dimensional array of tuples.
+  nav_items.nav_group:             Tuple defining groupings of nav items.
+                                   Rendered as UL HTML element.
+  nav_items.nav_group.nav_caption: Menu item link text.
+  nav_items.nav_group.nav_url:     Menu item link URL.
+  nav_items.nav_group.children:    Array of menu item submenus,
+                                   recursively repeats nav_group structure.
 #}
 
 {# TODO: Update file path for Featured Menu Content module when that is added. #}
 {% import 'templates/nav/about-us-media.html' as about_us_media %}
 
-{% set sub_nav_tbd =  ('', '', 'TBD Content') %}
-{% set nav_items = [
-    ('Consumer Tools', '#', '', '', []),
-    ('Educational Resources', '#', '', '', []),
-    ('Data & Research', '#', '', '', []),
-    ('Policy & Compliance', '#', '', '', []),
-    ('About Us', '/about-us/',  'About Us Overview', about_us_media , [
+{% set media_items = [
+  ('/about-us/', about_us_media)
+] %}
+{% set nav_items = [(
+    ('Consumer Tools', '', []),
+    ('Educational Resources', '', []),
+    ('Data & Research', '', []),
+    ('Policy & Compliance', '', []),
+    ('About Us', '/about-us/', [
         (
-            ('/the-bureau/', 'the-bureau', 'The Bureau'),
-            ('/budget/', 'budget', 'Budget and Strategy'),
-            ('/offices/payments-to-harmed-consumers/',
-             'payments-to-harmed-consumers',
-             'Payments to Harmed Consumers')
+            ('The Bureau', '/the-bureau/', []),
+            ('Budget and Strategy', '/budget/', []),
+            ('Payments to Harmed Consumers',
+             '/offices/payments-to-harmed-consumers/', [])
         ),
         (
-            ('/blog/', 'blog', 'Blog'),
-            ('/newsroom/', 'newsroom', 'Newsroom'),
-            ('/events/', 'events', 'Events'),
-            ('/activity-log/', 'activity-log', 'Activity Log')
+            ('Blog','/blog/', []),
+            ('Newsroom', '/newsroom/', []),
+            ('Events', '/events/', []),
+            ('Activity Log', '/activity-log/', [])
         ),
         (
-            ('/careers/', 'careers', 'Careers'),
-            ('/doing-business-with-us/', 'doing-business-with-us', 'Doing Business With Us'),
-            ('/offices/advisory-groups/', 'advisory-groups', 'Advisory Groups'),
-            ('/offices/project-catalyst/', 'project-catalyst', 'Project Catalyst'),
-            ('/contact-us/', 'contact-us', 'Contact Us')
+            ('Careers', '/careers/', [
+                (
+                    ('Working at the CFPB', '/careers/working-at-cfpb/', []),
+                    ('Job Application Process', '/careers/application-process/', []),
+                    ('Students & Recent Graduates', '/careers/students-and-graduates/', []),
+                    ('Current Openings', '/careers/current-openings/', [])
+                )
+            ]),
+            ('Doing Business With Us', '/doing-business-with-us/', []),
+            ('Advisory Groups', '/offices/advisory-groups/', []),
+            ('Project Catalyst', '/offices/project-catalyst/', []),
+            ('Contact Us', '/contact-us/', [])
         )
     ])
-] -%}
+)] -%}

--- a/cfgov/jinja2/v1/_includes/organisms/mega-menu.html
+++ b/cfgov/jinja2/v1/_includes/organisms/mega-menu.html
@@ -1,61 +1,147 @@
+{% import '_vars-mega-menu.html' as vars with context %}
+{% set base_class = 'o-mega-menu' %}
 
 {# ==========================================================================
 
-   sub_nav()
+   _classes()
 
    ==========================================================================
 
    Description:
 
-   Creates a mega menu sub menu content markup when given:
+   Creates mega menu CSS classes when given:
 
-   sub_nav_title:   A string used for the sub nav title.
+   nav_depth:    Level of menu nesting. 1 equals the root menu.
 
-   sub_nav_landing: A string used for the url of the sub nav landing page.
-
-   sub_nav_items:   An array of tuples.
-
-   sub_nav_media:   A string composed of html markup.
+   suffix:       Suffix to add to the classes.
+                 Default is ''.
 
    ========================================================================== #}
 
-{% macro _sub_nav(sub_nav_title, sub_nav_landing, sub_nav_items, sub_nav_media) %}
-<div class="o-mega-menu_subcontent" aria-expanded="false">
-    <div class="o-mega-menu_subcontent-wrapper">
+{# TODO: Move to external macro so it can be shared with secondary nav. #}
+{%- macro _classes( nav_depth, suffix='' ) -%}
+{%- set general_class = base_class ~ '_content' -%}
+{%- set depth_class = general_class ~ '-' ~ nav_depth -%}
+{{ general_class ~ suffix ~ ' ' ~ depth_class ~ suffix }}
+{%- endmacro -%}
+
+
+{# ==========================================================================
+
+   _nav_list()
+
+   ==========================================================================
+
+   Description:
+
+   Creates a mega menu sub menu list markup when given:
+
+   nav_depth: Level of menu nesting. 1 equals the root menu.
+
+   nav_items: An array of tuples containing menu link info.
+
+   ========================================================================== #}
+
+{% macro _nav_list( nav_depth, nav_items ) %}
+{%- for nav_group in nav_items %}
+<ul class="list
+           list__unstyled
+           {{ _classes( nav_depth, '-list' ) }}">
+    {% if nav_depth == 1 -%}
+    <li class="list_item
+               {{ _classes( nav_depth, '-item' ) }}">
+        {% import 'molecules/global-header-cta.html' as global_header_cta with context %}
+        {{ global_header_cta.render() }}
+    </li>
+    {%- endif %}
+    {%- for nav_caption,
+            nav_url,
+            nav_children in nav_group %}
+    <li class="list_item
+               {{ _classes( nav_depth, '-item' ) }}"
+        {{ 'data-js-hook=flyout-menu' if nav_children | count > 0 else '' }}>
+        {# TODO: Remove nav_depth < 2 check on has-children class when 3rd level transitions are in. #}
+        <a class="{{ 'u-link__disabled' if nav_url == '' else '' }}
+                  {{ _classes( nav_depth, '-link' ) }}
+                  {{ _classes( nav_depth, '-link__has-children' ) if nav_children | count > 0 and nav_depth < 2 else '' }}
+                  {{ _classes( nav_depth, '-link__current' ) if nav_url == request.path else '' }}"
+           {{ '' if nav_url == '' or nav_url == request.path else 'href=' + nav_url | e }}
+           {{ 'data-js-hook=flyout-menu_trigger' if nav_children | count > 0 else '' }}>
+            {{ nav_caption }}
+        </a>
+        {% if nav_children | count > 0 %}
+            {{ _nav( nav_depth | int + 1, nav_children, nav_caption ~ ' Overview', nav_url, vars.media_items ) }}
+        {% endif %}
+    </li>
+    {%- endfor %}
+</ul>
+{%- endfor %}
+{% endmacro %}
+
+{# ==========================================================================
+
+   _nav()
+
+   ==========================================================================
+
+   Description:
+
+   Creates menu content markup when given:
+
+   nav_depth:        Level of menu nesting. 1 equals the root menu.
+
+   nav_items:        An array of tuples containing menu link info.
+
+   nav_overview:     A string used for a sub nav overview title.
+
+   nav_overview_url: A string used for a sub nav overview title URL.
+
+   media_items:      A tuple of strings composed of HTML markup.
+
+   ========================================================================== #}
+
+{% macro _nav( nav_depth, nav_items, nav_overview, nav_overview_url, media_items ) %}
+<div class="{{ _classes( nav_depth ) }}"
+     aria-expanded="false"
+     data-js-hook="flyout-menu_content">
+
+    <div class="{{ _classes( nav_depth, '-wrapper' ) }}">
         <div class="wrapper">
-            <button class="o-mega-menu_subcontent-btn__back">Back</button>
-            <div class="o-mega-menu_subcontent-grid">
-                <span class="o-mega-menu_subcontent-title">
-                    <a class="o-mega-menu_subcontent-link" href="{{ sub_nav_landing }}">
-                        {{ sub_nav_title }}
+            {% if nav_depth > 1 %}
+            <button class="{{ _classes( nav_depth, '-alt-trigger' ) }}"
+                    data-js-hook="flyout-menu_alt-trigger">
+                Back
+            </button>
+            {% endif %}
+            <div class="{{ _classes( nav_depth, '-grid' ) }}">
+                {% if nav_depth > 1 %}
+                <span class="{{ _classes( nav_depth, '-overview' ) }}">
+                    <a class="{{ _classes( nav_depth, '-overview-link' ) }}
+                              {{ _classes( nav_depth, '-overview-link__current' ) if nav_overview_url == request.path else '' }}"
+                       {{ '' if nav_overview_url == '' or nav_overview_url == request.path else 'href=' + nav_overview_url | e }}>
+                        {{ nav_overview }}
                     </a>
                 </span>
-                <div class="o-mega-menu_subcontent-lists">
-                {%- for sub_nav_item in sub_nav_items %}
-                    <ul class="list
-                               list__unstyled
-                               o-mega-menu_subcontent-list">
-                        {%- for href, id, caption in sub_nav_item %}
-                            <li class="list_item
-                                       o-mega-menu_subcontent-item">
-                                <a class="list_link
-                                          {{ 'list_link__current' if href == request.path else '' }}
-                                          {{ 'u-link__disabled' if href == '' else '' }}
-                                          o-mega-menu_subcontent-link"
-                                   {{ 'href=' + href | e if href != '' else '' }}>
-                                    {{ caption | safe }}
-                                 </a>
-                            </li>
-                        {%- endfor %}
-                    </ul>
-                {%- endfor %}
+                {% endif %}
+                <div class="{{ _classes( nav_depth, '-lists' ) }}">
+                    {{ _nav_list( nav_depth, nav_items ) }}
                 </div>
             </div>
+            {% for url, fmc in media_items %}
+            {% if url == nav_overview_url %}
             <aside class="sub-nav_media">
-                {{ sub_nav_media }}
+                {{ fmc }}
             </aside>
+            {% endif %}
+            {% endfor %}
         </div>
     </div>
+
+    {% if nav_depth == 1 %}
+    {% import 'molecules/global-eyebrow.html' as global_eyebrow with context %}
+    {{ global_eyebrow.render() }}
+    {% endif %}
+
 </div>
 {% endmacro %}
 
@@ -70,56 +156,15 @@
    Creates a mega menu primary navigation menu.
 
    ========================================================================== #}
-{% import '_vars-mega-menu.html' as vars with context %}
-<div class="o-mega-menu">
-    <button class="o-mega-menu_trigger">
-        <span class="o-mega-menu_trigger-label">
-            <span class="u-visually-hidden">Menu</span>
-        </span>
+<nav class="{{ base_class }}"
+     data-js-hook="flyout-menu"
+     aria-label="main navigation"
+     role="navigation">
+    <button class="{{ base_class ~ '_trigger' }}" data-js-hook="flyout-menu_trigger">
+        <span class="u-visually-hidden">Menu</span>
     </button>
-    <nav class="o-mega-menu_content"
-         aria-expanded="false"
-         aria-label="main navigation"
-         role="navigation">
-
-        <ul class="list
-                   list__unstyled
-                   o-mega-menu_content-list">
-
-            <li class="list_item
-                       o-mega-menu_content-item">
-                {% import 'molecules/global-header-cta.html' as global_header_cta with context %}
-                {{ global_header_cta.render() }}
-            </li>
-
-            {%- for nav_title,
-                    sub_nav_landing,
-                    sub_nav_title,
-                    sub_nav_media,
-                    sub_nav_items in vars.nav_items %}
-                <li class="list_item
-                           o-mega-menu_content-item">
-                    {%- if sub_nav_items | length > 0 %}
-                        <a class="list_link
-                                  o-mega-menu_content-link"
-                           href="{{ sub_nav_landing }}">
-                            {{ nav_title }}
-                        </a>
-                        {{ _sub_nav(sub_nav_title, sub_nav_landing, sub_nav_items, sub_nav_media) }}
-                    {%- else %}
-                      <a class="list_link
-                                o-mega-menu_content-link
-                                u-link__disabled">
-                          {{ nav_title }}
-                      </a>
-                    {%- endif %}
-                </li>
-            {%- endfor %}
-        </ul>
-
-        {% import 'molecules/global-eyebrow.html' as global_eyebrow with context %}
-        {{ global_eyebrow.render() }}
-
-    </nav>
-    <button class="o-mega-menu_tab-trigger" aria-hidden></button>
-</div>
+    {# Create a root menu at depth one.
+       This is the 1st level of a 3-level menu. #}
+    {{ _nav( 1, vars.nav_items ) }}
+    <button class="{{ base_class ~ '_tab-trigger' }}" aria-hidden="true"></button>
+</nav>

--- a/cfgov/unprocessed/css/organisms/mega-menu.less
+++ b/cfgov/unprocessed/css/organisms/mega-menu.less
@@ -4,132 +4,135 @@
   patterns:
     - name: Default example
       markup: |
-        <div class="o-mega-menu">
+        <nav class="o-mega-menu"
+             aria-label="main navigation"
+             role="navigation">
             <button class="o-mega-menu_trigger" aria-expanded="false">
-                <span class="o-mega-menu_trigger-label">
-                    <span class="u-visually-hidden">Menu</span>
-                </span>
+                <span class="u-visually-hidden">Menu</span>
             </button>
-            <nav class="o-mega-menu_content"
-                 aria-expanded="false"
-                 aria-label="main navigation"
-                 role="navigation">
-                <ul class="o-mega-menu_content-list">
-                    <li class="o-mega-menu_content-item">
-                        [Global Header CTA]
-                    </li>
-                    <li class="o-mega-menu_content-item">
-                        <a class="o-mega-menu_content-link"
-                           href="/about-us/"
-                           aria-expanded="false">
-                            About Us
-                        </a>
-                        <div class="o-mega-menu_subcontent"
-                             aria-expanded="false">
-                            <div class="o-mega-menu_subcontent-wrapper">
-                                <div class="wrapper">
-                                    <button class="o-mega-menu_subcontent-btn__back">
-                                        Back
-                                    </button>
-                                    <div class="o-mega-menu_subcontent-menu">
-                                        <span class="o-mega-menu_subcontent-title">
-                                            <a class="o-mega-menu_subcontent-link"
-                                               href="/about-us/">
-                                                About Us Overview
-                                            </a>
-                                        </span>
-                                        <div class="o-mega-menu_subcontent-lists">
-                                            <ul class="list
-                                                       list__unstyled
-                                                       o-mega-menu_subcontent-list">
-                                                <li class="list_item
-                                                           o-mega-menu_subcontent-item">
-                                                    <a class="list_link
-                                                              o-mega-menu_subcontent-link"
-                                                       href="/the-bureau/">
-                                                        The Bureau
-                                                     </a>
-                                                </li>
-                                                …
-                                            </ul>
-                                            <ul class="list
-                                                       list__unstyled
-                                                       o-mega-menu_subcontent-list">
-                                                    <li class="list_item
-                                                               o-mega-menu_subcontent-item">
-                                                        <a class="list_link
-                                                                  list_link__current
-                                                                  o-mega-menu_subcontent-link"
-                                                           href="/careers/">
-                                                            Careers
-                                                         </a>
-                                                    </li>
-                                                    …
-                                            </ul>
-                                            …
-                                        </div>
-                                    </div>
-                                    <aside class="sub-nav_media">
-                                        <a href="/the-bureau/">
-                                            <img src="/static/img/nav-about-us-video.png"
-                                                 alt="About Us video image">
-                                            <p class="h4 u-mt15">
-                                              The CFPB: Working for you.
-                                            </p>
+            <div class="o-mega-menu_content"
+                 aria-expanded="false">
+                <div class="o-mega-menu_content-wrapper">
+                    <div class="wrapper">
+                        <div class="o-mega-menu_content-grid">
+                            <div class="o-mega-menu-lists">
+                                <ul class="o-mega-menu_content-list">
+                                    <li class="o-mega-menu_content-item">
+                                        [Global Header CTA]
+                                    </li>
+                                    <li class="o-mega-menu_content-item">
+                                        <a class="o-mega-menu_content-link"
+                                           href="/about-us/"
+                                           aria-expanded="false">
+                                            About Us
                                         </a>
-                                        <p>
-                                            This short video covers what the CFPB is and
-                                            how we are working for American consumers.
-                                        </p>
-                                    </aside>
-                                </div>
+                                        <div class="o-mega-menu_content"
+                                             aria-expanded="false">
+                                            <div class="o-mega-menu_content-wrapper">
+                                                <div class="wrapper">
+                                                    <button class="o-mega-menu_content-alt-trigger">
+                                                        Back
+                                                    </button>
+                                                    <div class="o-mega-menu_content-grid">
+                                                        <span class="o-mega-menu_content-overview">
+                                                            <a class="o-mega-menu_content-overview-link"
+                                                               href="/about-us/">
+                                                                About Us Overview
+                                                            </a>
+                                                        </span>
+                                                        <div class="o-mega-menu_content-lists">
+                                                            <ul class="list
+                                                                       list__unstyled
+                                                                       o-mega-menu_content-list">
+                                                                <li class="list_item
+                                                                           o-mega-menu_content-item">
+                                                                    <a class="o-mega-menu_content-link"
+                                                                       href="/the-bureau/">
+                                                                        The Bureau
+                                                                     </a>
+                                                                </li>
+                                                                …
+                                                            </ul>
+                                                            <ul class="list
+                                                                       list__unstyled
+                                                                       o-mega-menu_content-list">
+                                                                    <li class="list_item
+                                                                               o-mega-menu_content-item">
+                                                                        <a class="o-mega-menu_content-link__current
+                                                                                  o-mega-menu_content-link"
+                                                                           href="/careers/">
+                                                                            Careers
+                                                                         </a>
+                                                                    </li>
+                                                                    …
+                                                            </ul>
+                                                            …
+                                                        </div>
+                                                    </div>
+                                                    <aside class="sub-nav_media">
+                                                        [Featured Menu Content]
+                                                    </aside>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </li>
+                                </ul>
+                                [Global Eyebrow]
                             </div>
                         </div>
-                    </li>
-                </ul>
-                [Global Eyebrow]
-            </nav>
-        </div>
+                    </div>
+                </div>
+            </div>
+        </nav>
       codenotes:
         - |
           Structural cheat sheet:
           -----------------------
-          .o-mega-menu
+          nav.o-mega-menu
             .o-mega-menu_trigger
             .o-mega-menu_content
-                ul.o-mega-menu_content-list
-                    li.o-mega-menu_content-item
-                        .m-global-header-cta.m-global-header-cta__list
-                    li.o-mega-menu_content-item
-                        a.o-mega-menu_content-link
-                    li.o-mega-menu_content-item
-                        a.o-mega-menu_content-link
-                        .o-mega-menu_subcontent
-                            .o-mega-menu_subcontent-wrapper
-                                .wrapper
-                                    button.o-mega-menu_subcontent-btn__back
-                                    .o-mega-menu_subcontent-grid
-                                        .o-mega-menu_subcontent-title
-                                            a.o-mega-menu_subcontent-link
-                                        .o-mega-menu_subcontent-lists
-                                            ul.o-mega-menu_subcontent-list
-                                                li.o-mega-menu_subcontent-item
-                                            ul.o-mega-menu_subcontent-list
-                                                li.o-mega-menu_subcontent-item
-                                    aside.sub-nav_media
+                .o-mega-menu_content-wrapper
+                    .wrapper
+                        .o-mega-menu-content-grid
+                            .o-mega-menu_content-title
+                                a.o-mega-menu_content-link
+                            .o-mega-menu_content-lists
+                                ul.o-mega-menu_content-list
+                                    li.o-mega-menu_content-item
+                                        .m-global-header-cta.m-global-header-cta__list
+                                    li.o-mega-menu_content-item
+                                        a.o-mega-menu_content-link
+                                    li.o-mega-menu_content-item
+                                        a.o-mega-menu_content-link
+                                        .o-mega-menu_content
+                                            .o-mega-menu_content-wrapper
+                                                .wrapper
+                                                    button.o-mega-menu_content-alt-trigger
+                                                    .o-mega-menu_content-grid
+                                                        .o-mega-menu_content-title
+                                                            a.o-mega-menu_content-link
+                                                        .o-mega-menu_content-lists
+                                                            ul.o-mega-menu_content-list
+                                                                li.o-mega-menu_content-item
+                                                            ul.o-mega-menu_content-list
+                                                                li.o-mega-menu_content-item
+                                                    aside.sub-nav_media
+      notes:
+        - "Not shown, but each content level adds a depth-specific class,
+           such as o-mega-menu_content-1, o-mega-menu_content-2, etc."
   tags:
     - cfgov-organisms
 */
 
 .o-mega-menu {
 
-    &_content-item,
-    &_subcontent-item {
+    &_content-item {
         // Override margin added by CF to list items.
         margin-bottom: 0;
     }
 
-    &_content {
+    // 1st-level menu.
+    &_content-1 {
         &-link {
             // Colors for :link, :visited, :hover, :focus, :active.
             .u-link__colors( @black );
@@ -138,19 +141,23 @@
         }
     }
 
-    &_subcontent {
-        &-title {
+    // 2nd and 3rd-level menus.
+    &_content-2,
+    &_content-3 {
+        &-overview {
             display: block;
             border-bottom: 1px solid @gray-50;
         }
 
-        &-link {
+        &-link,
+        &-overview-link {
             // Colors for :link, :visited, :hover, :focus, :active.
             .u-link__colors( @pacific, @black );
 
             display: block;
         }
     }
+
 
     // Tablet/mobile sizes.
     .respond-to-max( @bp-sm-max, {
@@ -195,14 +202,14 @@
         }
 
         // Menu flyout.
+        // All menus - Tablet/Mobile.
         &_content {
             box-sizing: border-box;
             width: 100%;
 
             position: absolute;
             left: 0;
-            // Offset for height of trigger button.
-            top: 60px;
+            top: -1px;
             z-index: 10;
 
             background-color: @gray-5;
@@ -221,61 +228,7 @@
                 transform: translateX( 0 );
             }
 
-            // Adjust padding and margin on unordered list menu items
-            // above the global eyebrow.
-            &-list {
-                padding-left: unit( @grid_gutter-width / 2 / @base-font-size-px, em );
-                padding-right: unit( @grid_gutter-width / 2 / @base-font-size-px, em );
-                margin-bottom: 0;
-            }
-
-            &-item:not(:last-child) {
-                border-bottom: 1px solid @gray-50;
-            }
-
-            &-link {
-                // Colors for :link, :visited, :hover, :focus, :active.
-                .u-link__colors( @pacific, @pacific, @pacific-60, @pacific, @dark-navy );
-
-                padding-top: @grid_gutter-width / 2;
-                padding-bottom: @grid_gutter-width / 2;
-
-                position: relative;
-
-                &:after {
-                    .cf-icon();
-
-                    position: absolute;
-                    right: 0;
-                    top: 50%;
-                    transform: translateY(-50%);
-
-                    content: @cf-icon-right;
-                }
-
-                &:not(.u-link__disabled):after {
-                    color: @green;
-                }
-            }
-        }
-
-        // Submenu flyout.
-        &_subcontent {
-            background-color: @gray-5;
-            width: 100%;
-            position: absolute;
-            z-index: 10;
-            top: 0;
-            right: 100%;
-            transition: transform 0.25s ease-out;
-
-            .u-drop-shadow-after();
-
-            &[aria-expanded="true"] {
-                transform: translateX( 100% );
-            }
-
-            &-btn__back {
+            &-alt-trigger {
                 .webfont-medium();
 
                 padding: unit( @grid_gutter-width / 2 / @base-font-size-px, em );
@@ -303,17 +256,20 @@
                 }
             }
 
-            &-title {
-                margin-left: unit( @grid_gutter-width / 2 / 18px, em );
-                margin-right: unit( @grid_gutter-width / 2 / 18px, em );
+            &-overview {
+                display: block;
+                border-bottom: 1px solid @gray-50;
             }
 
-            &-lists {
-                padding-left: unit( @grid_gutter-width / 18px, em );
-                padding-right: unit( @grid_gutter-width / 2 / 18px, em );
+            &-grid {
+                padding-left: unit( @grid_gutter-width / 2 / 18px, em );
+                padding-right: unit( @grid_gutter-width / 2 / @base-font-size-px, em );
             }
 
+            // Adjust padding and margin on unordered list menu items
+            // above the global eyebrow.
             &-list {
+                padding-left: unit( @grid_gutter-width / 2 / @base-font-size-px, em );
                 margin-bottom: 0;
             }
 
@@ -321,13 +277,83 @@
                 border-bottom: 1px solid @gray-50;
             }
 
-            &-list:last-child .o-mega-menu_subcontent-item:last-child {
-                border-bottom: none;
-            }
+            &-link,
+            &-overview-link {
+                position: relative;
+                // Colors for :link, :visited, :hover, :focus, :active.
+                .u-link__colors( @pacific, @pacific, @pacific-60, @pacific, @dark-navy );
 
-            &-link {
                 padding-top: @grid_gutter-width / 2;
                 padding-bottom: @grid_gutter-width / 2;
+
+                &__has-children:after {
+                    .cf-icon();
+
+                    position: absolute;
+                    right: 0;
+                    top: 50%;
+                    transform: translateY( -50% );
+
+                    color: @green;
+                    content: @cf-icon-right;
+                }
+
+                &__current,
+                &:hover {
+                    cursor: pointer;
+                }
+            }
+
+            // TODO: Remove when transitions for 3rd-level are in.
+            //       This is temporary to hide the 3rd-level menu on mobile
+            //       till transitions to show the 3rd-level are in.
+            & & & {
+                &-link {
+                    &__has-children:after {
+                        display: none;
+                    }
+                }
+            }
+            & & & {
+                display: none;
+            }
+        }
+
+        // 1st-level menu - Tablet/Mobile.
+        &_content-1 {
+            // Offset for height of trigger button.
+            top: 60px;
+
+            &-list {
+                padding-right: unit( @grid_gutter-width / 2 / @base-font-size-px, em );
+            }
+
+            // Remove final border line of last list item.
+            &-list:last-child {
+                .o-mega-menu_content-1-item:last-child {
+                    border-bottom: none;
+                }
+            }
+        }
+
+        // 2nd-level menu - Tablet/Mobile.
+        &_content-2 {
+
+            // Make current page menu link non-clickable.
+            &-link,
+            &-overview-link {
+                &__current,
+                &__current:hover {
+                    color: @black;
+                    cursor: default;
+                }
+            }
+
+            // Remove final border line of last list item.
+            &-list:last-child {
+                .o-mega-menu_content-2-item:last-child {
+                    border-bottom: none;
+                }
             }
         }
     } );
@@ -341,19 +367,20 @@
             display: none;
         }
 
-        &_content {
+        // 1st-level menu - Desktop.
+        &_content-1 {
+            &[aria-expanded="true"] {
+                .o-mega-menu_content-1-wrapper {
+                    display: block;
+                    transform: translateY( 0 );
+                }
+            }
             &-list {
-                padding-left: unit( @grid_gutter-width / 2 / @base-font-size-px, em );
                 margin-bottom: 0;
             }
 
             &-item {
-                margin-right: 0.25em;
                 display: inline-block;
-
-                &:first-child {
-                    display: none;
-                }
             }
 
             &-link {
@@ -367,17 +394,20 @@
                     margin-left: 0;
                 }
 
-                // TODO: Show menu on hover and remove :hover selector.
+                // -6px padding offset is to account for the border height.
                 &[aria-expanded="true"],
                 &__current,
+                // TODO: Show menu on hover and remove :hover selector.
                 &:hover {
                     padding-bottom: @grid_gutter-width - 6px;
                     border-bottom: 6px solid @black;
+                    cursor: pointer;
                 }
             }
         }
 
-        &_subcontent {
+        // 2nd-level menu - Desktop.
+        &_content-2 {
             overflow: hidden;
             position: absolute;
             left: 0;
@@ -389,6 +419,15 @@
             min-height: 600px;
             pointer-events: none;
 
+            &[aria-expanded="true"] {
+
+                .o-mega-menu_content-2-wrapper {
+                    display: block;
+
+                    transform: translateY( 0 );
+                }
+            }
+
             &-wrapper {
                 pointer-events: auto;
                 background-color: @gray-5;
@@ -399,6 +438,9 @@
 
                 .u-drop-shadow-after();
 
+                // Adjustments to CF-wrapper.
+                // TODO: Investigate applying adjustment to CF directly,
+                //       or copying values here.
                 .wrapper {
                     padding: unit( @grid_gutter-width / @base-font-size-px, em );
                     padding-left: unit( @grid_gutter-width / 2 / @base-font-size-px, em );
@@ -406,19 +448,11 @@
                 }
             }
 
-            &[aria-expanded="true"] {
-
-                .o-mega-menu_subcontent-wrapper {
-                    display: block;
-                    transform: translateY( 0 );
-                }
-            }
-
-            &-btn__back {
+            &-alt-trigger {
                 display: none;
             }
 
-            &-title {
+            &-overview {
                 padding-bottom: @grid_gutter-width / 2;
                 margin-bottom: unit( @grid_gutter-width / 2 / 18px, em );
 
@@ -433,27 +467,33 @@
                 .grid_column(4);
             }
 
-            .list_link {
+            &-link {
                 padding-top: unit( 10px / 18px, em );
                 padding-bottom: unit( 10px / 18px, em );
                 padding-left: unit( 15px / 18px, em );
 
                 border-left: 5px solid transparent;
                 font-size: unit( 18px / @base-font-size-px, em );
+            }
 
+            &-link,
+            &-overview-link {
                 &:hover,
-                &__current {
+                &__current,
+                &__current:visited {
+                    color: @black;
                     border-left-color: @green;
-                }
-
-                &__current {
-                    cursor: default;
                 }
             }
         }
 
-        // Hide global header CTA and eyebrow at desktop size.
-        .m-global-header-cta,
+        // 3rd-level menu - Desktop.
+        &_content-3 {
+            display: none;
+        }
+
+        // Hide global header CTA container and eyebrow at desktop size.
+        &_content-1-item:first-child,
         .m-global-eyebrow {
             display: none;
         }
@@ -461,11 +501,14 @@
 
     // Large desktop size.
     .respond-to-min( @bp-lg-min, {
-        &_subcontent-grid {
-            .grid_column( 8 );
-            // TODO: Check if .grid_nested-col-group()
-            //       can be used here when implementing Featured Menu Content.
-            border-left: 0;
+        // 2nd-level menu - Large desktop.
+         &_content-2 {
+            &-grid {
+                .grid_column( 8 );
+                // TODO: Check if .grid_nested-col-group()
+                //       can be used here when implementing Featured Menu Content.
+                border-left: 0;
+            }
         }
     } );
 

--- a/cfgov/unprocessed/js/modules/util/data-hook.js
+++ b/cfgov/unprocessed/js/modules/util/data-hook.js
@@ -1,0 +1,61 @@
+'use strict';
+
+// Required modules.
+var standardType = require( './standard-type' );
+
+/**
+ * @param {HTMLNode} element - DOM element.
+ * @param {string} attr
+ *   Attribute to add to the JS data-* hook value.
+ * @throws {Error} If supplied value contains a space,
+ *   which would mean it would be two values, which is likely a typo.
+ * @returns {string} The value that was added.
+ */
+function add( element, attr ) {
+  if ( attr.indexOf( ' ' ) !== -1 ) {
+    var msg = standardType.JS_HOOK + 'values cannot contain spaces!';
+    throw new Error( msg );
+  }
+  var values = element.getAttribute( standardType.JS_HOOK );
+  element.setAttribute( standardType.JS_HOOK, values + ' ' + attr );
+
+  return attr;
+}
+
+/**
+ * @param {HTMLNode} element - DOM element.
+ * @param {string} attr
+ *   Attribute to remove from the JS data-* hook value.
+ * @returns {boolean} True if value was removed, false otherwise.
+ */
+function remove( element, attr ) {
+  var values = element.getAttribute( standardType.JS_HOOK );
+  var index = values.indexOf( attr );
+  var attrs = values.split( ' ' );
+  if ( index > -1 ) {
+    attrs.splice( index, 1 );
+    element.setAttribute( standardType.JS_HOOK, attrs.join( ' ' ) );
+    return true;
+  }
+  return false;
+}
+
+/**
+ * @param {HTMLNode} element - DOM element.
+ * @param {string} attr
+ *   Attribute to check as existing as a JS data-* hook value.
+ * @returns {boolean} True if the data-* hook value exists, false otherwise.
+ */
+function contains( element, attr ) {
+  var values = element.getAttribute( standardType.JS_HOOK );
+  // TODO: This will match variations on the class name,
+  //       like 'flyout-menu-var', which would not be correct.
+  //       IndexOf should be updated to use a regex instead.
+  return values.indexOf( attr ) > -1 ? true : false;
+}
+
+module.exports = {
+  add:      add,
+  contains: contains,
+  remove:   remove
+};

--- a/cfgov/unprocessed/js/modules/util/standard-type.js
+++ b/cfgov/unprocessed/js/modules/util/standard-type.js
@@ -1,5 +1,9 @@
 'use strict';
 
+// Constant for the name of the JS hook used
+// for attaching JS behavior to HTML DOM elements.
+var JS_HOOK = 'data-js-hook';
+
 /**
  * Empty function that will do nothing.
  * A usecase is when an object has empty functions used for callbacks,
@@ -14,5 +18,6 @@ function noopFunct() {
 }
 
 module.exports = {
+  JS_HOOK:   JS_HOOK,
   noopFunct: noopFunct
 };

--- a/cfgov/unprocessed/js/molecules/GlobalSearch.js
+++ b/cfgov/unprocessed/js/molecules/GlobalSearch.js
@@ -25,8 +25,7 @@ function GlobalSearch( element ) { // eslint-disable-line max-statements, no-inl
     atomicCheckers.validateDomElement( element, BASE_CLASS, 'GlobalSearch' );
   var _triggerSel = '.' + BASE_CLASS + '_trigger';
   var _triggerDom = _dom.querySelector( _triggerSel );
-  var _flyoutMenu =
-    new FlyoutMenu( _dom, _triggerSel, '.' + BASE_CLASS + '_content' ).init();
+  var _flyoutMenu = new FlyoutMenu( _dom ).init();
   var _contentDom = _dom.querySelector( '.' + BASE_CLASS + '_content' );
   var _searchInputDom;
   var _searchBtnDom;

--- a/cfgov/unprocessed/js/organisms/MegaMenu.js
+++ b/cfgov/unprocessed/js/organisms/MegaMenu.js
@@ -21,9 +21,7 @@ function MegaMenu( element ) {
 
   var _dom =
     atomicCheckers.validateDomElement( element, BASE_CLASS, 'MegaMenu' );
-  var _flyoutMenu = new FlyoutMenu( _dom,
-                                    '.' + BASE_CLASS + '_trigger',
-                                    '.' + BASE_CLASS + '_content' ).init();
+  var _flyoutMenu = new FlyoutMenu( _dom ).init();
   var _activeMenu = _flyoutMenu;
   var _activeMenuDom = _flyoutMenu.getDom().content;
   var _menuItems = _dom.querySelectorAll( '.' + BASE_CLASS + '_content-item' );
@@ -41,13 +39,13 @@ function MegaMenu( element ) {
     var initEventsBinded = _initEvents.bind( this );
     var menuItem;
     var submenu;
+    var childSel = '.' + BASE_CLASS + '_content-link__has-children';
     for ( var i = 1, len = _menuItems.length; i < len; i++ ) {
       menuItem = _menuItems[i];
-      if ( menuItem.querySelector( '.u-link__disabled' ) === null ) {
+      if ( menuItem.querySelector( '.u-link__disabled' ) === null &&
+           menuItem.querySelector( childSel ) !== null ) {
         submenu =
-          new FlyoutMenu( menuItem, '.' + BASE_CLASS + '_content-link',
-                          '.' + BASE_CLASS + '_subcontent',
-                          '.' + BASE_CLASS + '_subcontent-btn__back' ).init();
+          new FlyoutMenu( menuItem ).init();
         _subMenus[menuItem] = submenu;
         initEventsBinded( submenu );
       }
@@ -143,6 +141,7 @@ function MegaMenu( element ) {
    * @returns {Object} A MegaMenu instance.
    */
   function collapse() {
+    _flyoutMenu.collapse();
     _activeMenu.collapse();
 
     return this;


### PR DESCRIPTION
Major structural update to the mega menu to accommodate the 3rd-level menu. 

## Additions
- Added `data-hook.js` JS utility class for working with `data-*` attributes on DOM.

## Changes

- Flyoutmenu behavior is added through a JS hook on the dom, so that it can do it's own lookups for the flyout menu trigger and content.
- Menu is made to be recursive, so that the content and underlying data structure of the first-level menu matches the second and third level.
- Featured Menu Content data is moved to its own variable so that an empty string wouldn't need to be delivered for the vast majority of menu items.
- Renamed the menu title, "overview" instead to follow how we talk about it.
- When the user is on a particular page, they will find that the associated link in the menu is not clickable.
- Weight change on the main menu items. They shouldn't be so bold.

## Testing

- `gulp build`, menu should function the same as on refresh (with the addition of the overlay).

## Review

- @jimmynotjim 
- @sebworks 
- @KimberlyMunoz 

## Screenshots
In blog section:
<img width="559" alt="screen shot 2016-02-25 at 2 57 56 pm" src="https://cloud.githubusercontent.com/assets/704760/13333947/6543b53e-dbd7-11e5-8246-e5fd1844e32d.png">

In About Us Overview section:
<img width="1025" alt="screen shot 2016-02-25 at 4 09 45 pm" src="https://cloud.githubusercontent.com/assets/704760/13334518/404ec072-dbda-11e5-8dab-6ba4b41a6180.png">

In Careers section:
<img width="1026" alt="screen shot 2016-02-25 at 4 09 52 pm" src="https://cloud.githubusercontent.com/assets/704760/13334519/40536d34-dbda-11e5-95ac-b839db81484a.png">


## Notes

- In the CSS I had a very difficult time targeting the first menu items without bleeding into the second and third level menus. It would be nice to target these by scoping them to level, but I did not find the selectors clear or practical. I ended up writing out level-specific classes for each class member within `o-mega-menu_content`, this creates a lot of markup, but gives a lot of flexibility in targeting as well, which I'm finding helps with the complexity of the mega menu. But sorry for substantial increase in markup :( When the third level transitions are in we may want to revisit this and selectively remove some nesting that isn't necessary on the first level menu.

## Todos

- Noted as `TODO` in the code. The next step is to update the mobile mega menu transitions to slide between each level, up to three.
