### PR TITLE
Mega Menu/Search: Remove toggle / defer collapse

### DIFF
--- a/cfgov/unprocessed/js/molecules/GlobalSearch.js
+++ b/cfgov/unprocessed/js/molecules/GlobalSearch.js
@@ -59,9 +59,8 @@ function GlobalSearch( element ) { // eslint-disable-line max-statements, no-inl
     var clearableInput = new ClearableInput( inputContainsLabel );
     clearableInput.init();
 
-    _flyoutMenu.addEventListener( 'toggle',
-                                  _handleToggle.bind( this ) );
-    _flyoutMenu.addEventListener( 'expandBegin', _handleExpandBegin );
+    var handleExpandBeginBinded = _handleExpandBegin.bind( this );
+    _flyoutMenu.addEventListener( 'expandBegin', handleExpandBeginBinded );
     _flyoutMenu.addEventListener( 'collapseBegin', _handleCollapseBegin );
     _flyoutMenu.addEventListener( 'collapseEnd', _handleCollapseEnd );
 
@@ -136,18 +135,11 @@ function GlobalSearch( element ) { // eslint-disable-line max-statements, no-inl
   }
 
   /**
-   * Event handler for when the search input flyout is toggled,
-   * which opens/closes the search input.
-   */
-  function _handleToggle() {
-    this.dispatchEvent( 'toggle', { target: this } );
-  }
-
-  /**
    * Event handler for when FlyoutMenu expand transition begins.
    * Use this to perform post-expandBegin actions.
    */
   function _handleExpandBegin() {
+    this.dispatchEvent( 'expandBegin', { target: this } );
     if ( _isInDesktop() ) { _triggerDom.classList.add( 'u-hidden' ); }
     _contentDom.classList.remove( 'u-invisible' );
     _searchInputDom.select();

--- a/cfgov/unprocessed/js/organisms/Header.js
+++ b/cfgov/unprocessed/js/organisms/Header.js
@@ -33,7 +33,7 @@ function Header( element ) {
   function init( overlay ) {
     _overlay = overlay;
     _globalSearch = new GlobalSearch( _dom );
-    _globalSearch.addEventListener( 'toggle', _searchClicked );
+    _globalSearch.addEventListener( 'expandBegin', _searchExpandBegin );
     _globalSearch.init();
 
     _megaMenu = new MegaMenu( _dom );
@@ -47,7 +47,7 @@ function Header( element ) {
   /**
    * Handler for opening the search.
    */
-  function _searchClicked() {
+  function _searchExpandBegin() {
     _megaMenu.collapse();
   }
 

--- a/cfgov/unprocessed/js/organisms/MegaMenu.js
+++ b/cfgov/unprocessed/js/organisms/MegaMenu.js
@@ -17,7 +17,6 @@ var FlyoutMenu = require( '../modules/FlyoutMenu' );
  * @returns {Object} An MegaMenu instance.
  */
 function MegaMenu( element ) {
-
   var BASE_CLASS = 'o-mega-menu';
 
   var _dom =
@@ -64,7 +63,6 @@ function MegaMenu( element ) {
    * @param {FlyoutMenu} menu - The FlyoutMenu to add event listeners to.
    */
   function _initEvents( menu ) {
-    menu.addEventListener( 'toggle', _handleToggle.bind( this ) );
     menu.addEventListener( 'expandBegin', _handleExpandBegin.bind( this ) );
     menu.addEventListener( 'collapseBegin', _handleCollapseBegin );
     menu.addEventListener( 'collapseEnd', _handleCollapseEnd.bind( this ) );
@@ -153,17 +151,15 @@ function MegaMenu( element ) {
   /**
    * Event handler for when the search input flyout is toggled,
    * which opens/closes the search input.
-   * @param {Event} event - Event dispatched by the FlyoutMenu instance.
+   * @param {FlyoutMenu} target - menu that is expanding or collapsing.
    */
-  function _handleToggle( event ) {
-    var target = event.target;
+  function _handleToggle( target ) {
     if ( target === _flyoutMenu &&
          _activeMenu !== target ) {
       _activeMenu.collapse();
     }
     _activeMenu = target;
     _activeMenuDom = _activeMenu.getDom().content;
-    this.dispatchEvent( 'toggle', { target: this } );
   }
 
   /**
@@ -172,7 +168,9 @@ function MegaMenu( element ) {
    * @param {Event} event - A FlyoutMenu event.
    */
   function _handleExpandBegin( event ) {
-    if ( event.target === _flyoutMenu ) {
+    var target = event.target;
+    _handleToggle( target );
+    if ( target === _flyoutMenu ) {
       this.dispatchEvent( 'rootExpandBegin', { target: this } );
     }
     // If on a submenu, focus the back button, otherwise focus the first link.
@@ -190,8 +188,10 @@ function MegaMenu( element ) {
   /**
    * Event handler for when FlyoutMenu collapse transition begins.
    * Use this to perform post-collapseBegin actions.
+   * @param {Event} event - A FlyoutMenu event.
    */
-  function _handleCollapseBegin() {
+  function _handleCollapseBegin( event ) {
+    _handleToggle( event.target );
     document.body.removeEventListener( 'mousedown', _handleBodyClick );
   }
 


### PR DESCRIPTION
## Removals

- Removes `toggle` event from FlyoutMenu.

## Changes

- Adds collapse queue to FlyoutMenu so that if `collapse()` is called while expand is animating, it'll call collapse after the animation has completed.

## Testing

- On refresh.demo, click Search and immediately click Mega Menu. It's possible to have both expanded at the same time, which shouldn't happen:
![screen shot 2016-02-26 at 2 46 36 pm](https://cloud.githubusercontent.com/assets/704760/13363503/c0e4be54-dc97-11e5-837f-4a56b596703b.png)
- Now do the same thing with this PR. It should not be possible to show both the mega menu and search expanded.

## Review

- @sebworks 
- @jimmynotjim 
