### PR TITLE
Bugfix adds proper spacing between two inline info-units at all sizes

### DIFF
--- a/cfgov/unprocessed/css/organisms/info-unit-group.less
+++ b/cfgov/unprocessed/css/organisms/info-unit-group.less
@@ -44,15 +44,15 @@
     - cfgov-organisms
 */
 .o-info-unit-group {
+    .content-l_col-1 + .content-l_col-1 {
+        // Adds margin top to info units that follow another
+        margin-top: unit( @grid_gutter-width / @base-font-size-px, em ) !important;
+    }
+
     .respond-to-min(@bp-sm-min, {
         .content-l_col-1-2:nth-of-type(n+3) {
             // Adds margin top to info units that are 3rd and up in a group
             margin-top: unit(@grid_gutter-width / @base-font-size-px, em);
-        }
-
-        .content-l_col-1 + .content-l_col-1 {
-            // Adds margin top to info units that follow another
-            margin-top: unit( @grid_gutter-width / @base-font-size-px, em ) !important;
         }
     } );
 }


### PR DESCRIPTION
Bugfix adds proper spacing between two inline info-units at all sizes

## Changes

- Removes the media query wrapping the defined top margin

## Testing

- `gulp build` and if you have local data visit `/policy-compliance/`, otherwise build a page w/ multiple 25/75 molecules

## Review

- @anselmbradford 
- @sebworks 

## Screenshots

__Before__
![screen shot 2016-02-26 at 5 52 26 pm](https://cloud.githubusercontent.com/assets/1280430/13367608/b94d9728-dcb1-11e5-93c6-6e9bb65e0941.png)

__After__
![screen shot 2016-02-26 at 5 48 02 pm](https://cloud.githubusercontent.com/assets/1280430/13367612/bd89cb2c-dcb1-11e5-8f5e-59243b4ae769.png)

## Notes

- Still uses the !important that I'd like to remove, but that's outside the scope

## Todos

- Still uses the !important that I'd like to remove, but that's outside the scope

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)

- Removes the media query wrapping the defined top margin
- Still uses the !important that I'd like to remove, but that's outside the scope