### PR TITLE
Fix related posts section of a blog post page to use sheerlike method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Changed Wagtail pages extending from `layout-side-nav.html` to use new side navigation handling
 - Changed FilterableListControls.js to add validation for email, date, and checkbox fields.
 - Converted references and asset urls from Fuchs to Silberman.
+- Fix blog post template to use sheerlike related posts method.
 
 ### Removed
 - Removed normalize and normalize-legacy from main less file because CF already includes it.

--- a/cfgov/jinja2/v1/blog/_single.html
+++ b/cfgov/jinja2/v1/blog/_single.html
@@ -30,10 +30,9 @@
 
 {% block content_sidebar %}
     <section class="block block__flush-top">
-        {% if page %}
-            {% import 'related-posts.html' as related_posts with context %}
-            {{ related_posts.render() }}
-        {% endif %}
+        {# TODO: When moving blogs to Wagtail, change to "molecules/related-posts.html". #}
+        {% import 'related-posts.html' as related_posts with context %}
+        {{ related_posts.render(post) }}
     </section>
     <section class="block" data-qa-hook="stay-informed-section">
         <h2 class="header-slug">


### PR DESCRIPTION
## Changes

- Blog posts now use sheerlike template to generate the related posts.

## Testing

- `./cfgov/manage.py sheer_index`
- go to `localhost:8000/blog/` and then select any blog post
- verify that the related posts section is populated

## Review

- @jimmynotjim 
- @richaagarwal 
- @kave 

## Screenshots
![screen shot 2016-02-29 at 10 34 31 am](https://cloud.githubusercontent.com/assets/1412978/13399199/0f05eccc-ded0-11e5-965d-5d5d698dcb97.png)

