### PR TITLE
Removing Email field which was added to test Filterable Control List. 

### DIFF
--- a/cfgov/jinja2/v1/_includes/organisms/filterable-list-controls.html
+++ b/cfgov/jinja2/v1/_includes/organisms/filterable-list-controls.html
@@ -40,16 +40,6 @@
 {% endmacro %}
 
 {% macro _render_filter_fields(controls, form, index) -%}
-     <div class="form-l_col
-                    form-l_col-1">
-            <div class="form-group">
-                <label class="form-label-header" for="email">
-                    Email:
-                </label>
-                 <input data-type='email' id='email' type="text" />
-            </div>
-        </div>
-   
     {% if controls.title %}
         <div class="form-l_col
                     form-l_col-1">


### PR DESCRIPTION
Removing Email field which was added to test Filterable Control List. 


## Testing

- Add a Filterable Control to a page. You should not see the email form field on the filter.

## Review

- @kave 

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)

