### PR TITLE
Bugfix: added js init scripts for old pages.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Signal receiver function to unpublish all revisions for a page when a page is unpublished
 - Backend: HomePage Model
 - David Silberman's assets
+- Frontend: Added JS init scripts for /offices/, /sub-pages/, and /budget/.
 
 ### Changed
 - Converted the project to Capital Framework v3

--- a/cfgov/unprocessed/js/routes/budget/single.js
+++ b/cfgov/unprocessed/js/routes/budget/single.js
@@ -1,0 +1,9 @@
+/* ==========================================================================
+   Scripts for `/budget/*`.
+   ========================================================================== */
+
+'use strict';
+
+var SecondaryNavigation = require( '../../organisms/SecondaryNavigation' );
+var sidebarDom = document.querySelector( '.content_sidebar' );
+var secondaryNavigation = new SecondaryNavigation( sidebarDom ).init();

--- a/cfgov/unprocessed/js/routes/offices/single.js
+++ b/cfgov/unprocessed/js/routes/offices/single.js
@@ -1,0 +1,9 @@
+/* ==========================================================================
+   Scripts for `/offices/*`.
+   ========================================================================== */
+
+'use strict';
+
+var SecondaryNavigation = require( '../../organisms/SecondaryNavigation' );
+var sidebarDom = document.querySelector( '.content_sidebar' );
+var secondaryNavigation = new SecondaryNavigation( sidebarDom ).init();

--- a/cfgov/unprocessed/js/routes/sub-pages/single.js
+++ b/cfgov/unprocessed/js/routes/sub-pages/single.js
@@ -1,0 +1,9 @@
+/* ==========================================================================
+   Scripts for `/sub-pages/*`.
+   ========================================================================== */
+
+'use strict';
+
+var SecondaryNavigation = require( '../../organisms/SecondaryNavigation' );
+var sidebarDom = document.querySelector( '.content_sidebar' );
+var secondaryNavigation = new SecondaryNavigation( sidebarDom ).init();


### PR DESCRIPTION
The secondary nav was not being initialized on some non-wagtail pages. This adds initialization scripts for those routes.

## Additions

- Added js init scripts for non-wagtail pages at `/offices/`, `/sub-pages/`, and `/budget/` routes.

## Testing

- `gulp build`
- visit `/offices/`, `/sub-pages/`, and `/budget/` URLs
- resize to mobile
- navigate section using the "In This Section" secondary nav.

## Review

- @sebworks 
- @KimberlyMunoz 
- @jimmynotjim 
- @kurtw 
- @schaferjh 

## Screenshots

<img width="508" alt="screen shot 2016-02-29 at 4 00 08 pm" src="https://cloud.githubusercontent.com/assets/704760/13408771/8d18e4de-defd-11e5-91c4-4522c9c66a8b.png">

