### PR TITLE
Minor linter build file cleanup

### DIFF
--- a/cfgov/unprocessed/js/modules/util/assign.js
+++ b/cfgov/unprocessed/js/modules/util/assign.js
@@ -11,10 +11,9 @@
 
 
 /**
-* @param {object} JavaScript object.
+* @param {Object} object - JavaScript object.
 * @returns {boolean} True if object is plain Javascript object.
 */
-
 function _isPlainObject( object ) {
   return Object.prototype.toString.call( object ) === '[object Object]';
 }
@@ -24,10 +23,9 @@ function _isPlainObject( object ) {
 * existing properties. When assigning from multiple sources, fields of every
 * next source will override same named fields of previous sources.
 *
-* @param {object} destination object.
-* @returns {object} assigned destination object.
+* @param {Object} destination object.
+* @returns {Object} assigned destination object.
 */
-
 function assign( destination ) {
   destination = destination || {};
 

--- a/cfgov/unprocessed/js/modules/util/breakpoint-state.js
+++ b/cfgov/unprocessed/js/modules/util/breakpoint-state.js
@@ -8,6 +8,11 @@ var _breakpointsConfig = require( '../../config/breakpoints-config' );
 var _getViewportDimensions = require( './get-viewport-dimensions' )
                              .getViewportDimensions;
 
+/**
+ * @param {Object} breakpointRange - Object containing breakpoint constants.
+ * @param {integer} width - Current window width.
+ * @returns {boolean} Whether the passed width is within a breakpoint range.
+ */
 function _inBreakpointRange( breakpointRange, width ) {
   var min = breakpointRange.min || 0;
   var max = breakpointRange.max || Number.POSITIVE_INFINITY;
@@ -16,9 +21,9 @@ function _inBreakpointRange( breakpointRange, width ) {
 }
 
 /**
- * @returns {object} An object literal with Boolean
+ * @param {integer} width - Current window width.
+ * @returns {Object} An object literal with Boolean
  * isBpXS, isBpSM, isBpMED, isBpLG, isBpXL properties.
- * @param {integer} width Current window width.
  */
 function get( width ) {
   var breakpointState = {};

--- a/gulp/config.js
+++ b/gulp/config.js
@@ -51,10 +51,10 @@ module.exports = {
     src:      '/main.less',
     dest:     paths.processed + '/css',
     settings: {
-      paths:  globAll.sync([
+      paths:  globAll.sync( [
         paths.modules + '/capital-framework/**',
         paths.lib
-      ]),
+      ] ),
       compress: true
     }
   },

--- a/gulp/tasks/scripts.js
+++ b/gulp/tasks/scripts.js
@@ -39,10 +39,11 @@ gulp.task( 'scripts:modern', function() {
 gulp.task( 'scripts:ie', function() {
   return gulp.src( paths.unprocessed + '/js/ie/common.ie.js' )
     .pipe( webpackStream( {
-        entry: paths.unprocessed + '/js/ie/common.ie.js' ,
-        output: {
-          filename: 'common.ie.js',
-    } } ) )
+      entry: paths.unprocessed + '/js/ie/common.ie.js',
+      output: {
+        filename: 'common.ie.js'
+      }
+    } ) )
     .on( 'error', handleErrors )
     .pipe( gulpUglify() )
     .pipe( gulp.dest( paths.processed + '/js/ie/' ) )


### PR DESCRIPTION
## Changes

- Fixes errors in `gulp lint:build`

## Testing

- `gulp lint:build` should show 0 errors and 2 TODO warnings.

## Review

- @KimberlyMunoz 
- @sebworks 
- @jimmynotjim 