### PR TITLE
Fixes the Sublanding pages Text Introduction rendering bug

### DIFF
--- a/cfgov/jinja2/v1/_includes/organisms/sidebar-breakout.html
+++ b/cfgov/jinja2/v1/_includes/organisms/sidebar-breakout.html
@@ -29,20 +29,23 @@
 
    ========================================================================== #}
 
+{% macro render() %}
 <div class="o-sidebar-breakout
             content__flush-bottom
             wrapper">
     <div class="content_intro">
         <div class="content-l">
-            <section class="o-sidebar-breakout_col
-                            content-l_col
-                            content-l_col-2-3">
-                {% for block in page.header %}
-                    {% if 'text_introduction' in block.block_type -%}
-                        {{ render_stream_child(block) }}
+            {% if caller is defined %}
+                {% for block in page.content %}
+                    {% if 'text_introduction' in block.block_type %}
+                        <section class="o-sidebar-breakout_col
+                                        content-l_col
+                                        content-l_col-2-3">
+                            {{ caller(block) }}
+                        </section>
                     {% endif %}
                 {% endfor %}
-            </section>
+            {% endif %}
             <aside class="o-sidebar-breakout_col
                           content-l_col
                           content-l_col-1-3
@@ -103,3 +106,4 @@
     </div>
 </div>
 <div class="content_line"></div>
+{% endmacro %}

--- a/cfgov/jinja2/v1/sublanding-page/index.html
+++ b/cfgov/jinja2/v1/sublanding-page/index.html
@@ -2,6 +2,8 @@
 
 {% import 'molecules/related-posts.html' as related_posts with context %}
 {% import 'molecules/featured-content.html' as featured_content %}
+{% import 'molecules/related-posts.html' as related_posts with context %}
+{% import 'organisms/post-preview.html' as post_preview with context %}
 
 {% block title -%}
     {{ page.seo_title }}
@@ -9,18 +11,18 @@
 
 {% block hero -%}
     {% for block in page.header -%}
-        {% if 'hero' in block.block_type -%}
-            {{ render_stream_child(block) }}
-        {%- endif %}
+        {% include 'templates/render_block.html' with context %}
     {%- endfor %}
 {% endblock %}
 
 {% block pre_content %}
     {% if page.sidebar_breakout %}
-        {% include 'organisms/sidebar-breakout.html' %}
+        {% import 'organisms/sidebar-breakout.html' as sidebar_breakout with context %}
+        {% call(block) sidebar_breakout.render() %}
+            {{ render_stream_child(block) }}
+        {% endcall %}
     {% endif %}
 {% endblock %}
-
 
 {% block content_main %}
     {% for block in page.content -%}
@@ -29,22 +31,20 @@
                         block__flush-sides">
                 {{ featured_content.render(block.value) }}
             </div>
-        {% elif loop.index == 1 %}
-            <div class="block
-                        block__flush-top">
-                {% if 'post_preview_snapshot' in block.block_type %}
-                    {% set posts = page.get_browsefilterable_posts(request) %}
-                    {% set limit = block.value.limit | int %}
-                    {% set num_posts = limit if limit <= posts | length else posts | length %}
-                    {% for i in range(num_posts) %}
-                        {{ post_preview.render(posts[i], '', 0, pageurl(posts[i].parent())) }}
-                    {% endfor %}
-                {% else %}
-                    {{ render_stream_child(block) }}
-                {% endif %}
+        {% elif 'post_preview_snapshot' in block.block_type %}
+            <div class="block 
+                        {{ block.block.meta.classname if block.block.meta.classname else '' }}">
+                {% set posts = page.get_browsefilterable_posts(request) %}
+                {% set limit = block.value.limit | int %}
+                {% set num_posts = limit if limit <= posts | length else posts | length %}
+                {% for i in range(num_posts) %}
+                    {{ post_preview.render(posts[i], '', 0, pageurl(posts[i].parent())) }}
+                {% endfor %}
              </div>
-        {% else %}
-             {% include 'templates/render_block.html' with context %}
+        {% elif 'text_introduction' not in block.block_type %}
+            {% include 'templates/render_block.html' with context %}
+        {% elif not page.sidebar_breakout %}
+            {% include 'templates/render_block.html' with context %}
         {% endif %}
     {%- endfor %}
 {% endblock %}

--- a/cfgov/v1/migrations/0055_auto_20160224_2201.py
+++ b/cfgov/v1/migrations/0055_auto_20160224_2201.py
@@ -1,0 +1,64 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+import json
+
+from django.db import migrations, models
+import wagtail.wagtailcore.fields
+import wagtail.wagtailcore.blocks
+import wagtail.wagtailimages.blocks
+
+
+def migrate_text_intro_blocks(apps, schema_editor):
+    SublandingPage = apps.get_model('v1.SublandingPage')
+    PageRevision = apps.get_model('wagtailcore.PageRevision')
+
+    for page in SublandingPage.objects.all():
+        for i, child in enumerate(page.header.stream_data):
+            if child['type'] == 'text_introduction':
+                page.content.stream_data = [child] + page.content.stream_data
+                del page.header.stream_data[i]
+                page.save()
+        revisions = PageRevision.objects.filter(page=page).order_by('-id')
+        latest_revision = revisions.first()
+        revisions_to_update = {'shared': None, 'live': None}
+        for attr in revisions_to_update.keys():
+            for revision in revisions:
+                content = json.loads(revision.content_json)
+                if content[attr]:
+                    revisions_to_update[attr] = revision
+        revisions_to_update.update({'latest': latest_revision})
+        page_content = json.loads(latest_revision.content_json)
+        header = json.loads(page_content['header'])
+        content = json.loads(page_content['content'])
+        for i, child in enumerate(header):
+            if child['type'] == 'text_introduction':
+                content += [child]
+                del header[i]
+        page_content['header'] = json.dumps(header)
+        page_content['content'] = json.dumps(content)
+        content = json.dumps(page_content)
+        for revision in revisions_to_update.values():
+            if revision:
+                revision.content_json = content
+                revision.save()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('v1', '0054_auto_20160229_2044'),
+    ]
+
+    operations = [
+        migrations.RunPython(migrate_text_intro_blocks),
+        migrations.AlterField(
+            model_name='sublandingpage',
+            name='header',
+            field=wagtail.wagtailcore.fields.StreamField([(b'hero', wagtail.wagtailcore.blocks.StructBlock([(b'heading', wagtail.wagtailcore.blocks.CharBlock(required=False)), (b'body', wagtail.wagtailcore.blocks.RichTextBlock(required=False)), (b'image', wagtail.wagtailcore.blocks.StructBlock([(b'upload', wagtail.wagtailimages.blocks.ImageChooserBlock(required=False)), (b'alt', wagtail.wagtailcore.blocks.CharBlock(required=False))])), (b'background_color', wagtail.wagtailcore.blocks.CharBlock(help_text=b'Use Hexcode colors e.g #F0F8FF', required=False)), (b'links', wagtail.wagtailcore.blocks.ListBlock(wagtail.wagtailcore.blocks.StructBlock([(b'text', wagtail.wagtailcore.blocks.CharBlock(required=False)), (b'url', wagtail.wagtailcore.blocks.CharBlock(default=b'/', required=False))]))), (b'is_button', wagtail.wagtailcore.blocks.BooleanBlock(required=False))]))], blank=True),
+        ),
+        migrations.AlterField(
+            model_name='sublandingpage',
+            name='sidebar_breakout',
+            field=wagtail.wagtailcore.fields.StreamField([(b'slug', wagtail.wagtailcore.blocks.CharBlock(icon=b'title')), (b'heading', wagtail.wagtailcore.blocks.CharBlock(icon=b'title')), (b'paragraph', wagtail.wagtailcore.blocks.RichTextBlock(icon=b'edit')), (b'breakout_image', wagtail.wagtailcore.blocks.StructBlock([(b'image', wagtail.wagtailimages.blocks.ImageChooserBlock()), (b'is_round', wagtail.wagtailcore.blocks.BooleanBlock(default=True, required=False, label=b'Round?')), (b'icon', wagtail.wagtailcore.blocks.CharBlock(help_text=b'Enter icon class name.')), (b'heading', wagtail.wagtailcore.blocks.CharBlock(required=False, label=b'Introduction Heading')), (b'body', wagtail.wagtailcore.blocks.TextBlock(required=False, label=b'Introduction Body'))], heading=b'Breakout Image', icon=b'image')), (b'related_posts', wagtail.wagtailcore.blocks.StructBlock([(b'limit', wagtail.wagtailcore.blocks.CharBlock(default=b'3', label=b'Limit')), (b'show_heading', wagtail.wagtailcore.blocks.BooleanBlock(help_text=b'This toggles the heading and icon for the related types.', default=True, required=False, label=b'Show Heading and Icon?')), (b'relate_posts', wagtail.wagtailcore.blocks.BooleanBlock(default=True, required=False, editable=False, label=b'Blog Posts')), (b'relate_newsroom', wagtail.wagtailcore.blocks.BooleanBlock(default=True, required=False, editable=False, label=b'Newsroom')), (b'relate_events', wagtail.wagtailcore.blocks.BooleanBlock(default=True, required=False, label=b'Events')), (b'view_more', wagtail.wagtailcore.blocks.StructBlock([(b'text', wagtail.wagtailcore.blocks.CharBlock(required=False)), (b'url', wagtail.wagtailcore.blocks.CharBlock(default=b'/', required=False))]))]))], blank=True),
+        ),
+    ]

--- a/cfgov/v1/models/sublanding_page.py
+++ b/cfgov/v1/models/sublanding_page.py
@@ -14,7 +14,6 @@ from . import organisms
 class SublandingPage(CFGOVPage):
     header = StreamField([
         ('hero', molecules.Hero()),
-        ('text_introduction', molecules.TextIntroduction()),
     ], blank=True)
     content = StreamField([
         ('text_introduction', molecules.TextIntroduction()),
@@ -38,8 +37,8 @@ class SublandingPage(CFGOVPage):
             ('is_round', blocks.BooleanBlock(required=False, default=True,
                                              label='Round?')),
             ('icon', blocks.CharBlock(help_text='Enter icon class name.')),
-            ('heading', blocks.CharBlock(label='Introduction Heading')),
-            ('body', blocks.TextBlock(label='Introduction Body')),
+            ('heading', blocks.CharBlock(required=False, label='Introduction Heading')),
+            ('body', blocks.TextBlock(required=False, label='Introduction Body')),
         ], heading='Breakout Image', icon='image')),
         ('related_posts', organisms.RelatedPosts()),
     ], blank=True)


### PR DESCRIPTION
The text intro block was never being accessed in the template. Also, the sidebar-breakout organism template needs the context supplied to it. This fixes the issue by changing up the template quite a bit and moving the text introduction to only be located in the content streamfield. It does a data migration so nothing is lost.

## Additions

- supplies context to call to sidebar-breakout

## Removals

- conditional wrapping the blocks of a header
- text introduction from header streamfield on sublanding page

## Testing
### Before pulling down
- Make or go to a sublanding page and create a text introduction in the header streamfield

### Pull down
- run `./cfgov/manage.py migrate`
- Return to the sublanding page and see if the text intro has moved to the content streamfield and that text intro has been removed from the header streamfield
- Go to the page and verify that the text intro renders properly
- Go back to the sublanding page and create a sidebar breakout.
 - verify the the text intro renders with the breakout
- Remove the Breakout and add a Hero to the page in the header streamfield and verify that renders properly as well

## Review

- @kave 
- @richaagarwal 

## Screenshots
Text intro with Sidebar Breakout
![screen shot 2016-02-25 at 11 04 42 am](https://cloud.githubusercontent.com/assets/1412978/13325403/a8fec106-dbaf-11e5-909a-b86b4d85339c.png)
Text intro Without Sidebar Breakout
![screen shot 2016-02-25 at 11 05 08 am](https://cloud.githubusercontent.com/assets/1412978/13325405/ac0529ee-dbaf-11e5-94aa-c1d069e3d6f4.png)
