### PR TITLE
Include Password Complexity to Admin Creation Flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Frontend: Added data-* attribute JS utility class.
 - New manager to query for the most appropriate pages (shared and/or live)
 - Enabled Demo Page in flapjack
+- Included Password Complexity rules for admin user creation/editing flow
 
 ### Changed
 - Converted the project to Capital Framework v3

--- a/cfgov/cfgov/urls.py
+++ b/cfgov/cfgov/urls.py
@@ -10,7 +10,7 @@ from sheerlike.feeds import SheerlikeFeed
 from sheerlike.sites import SheerSite
 
 from v1.views import LeadershipCalendarPDFView, unshare, renderDirectoryPDF, \
-    change_password, password_reset_confirm, cfpb_login
+    change_password, password_reset_confirm, cfpb_login, create_user, edit_user
 
 from wagtail.wagtailadmin import urls as wagtailadmin_urls
 from wagtail.wagtaildocs import urls as wagtaildocs_urls
@@ -37,6 +37,8 @@ urlpatterns = [
         )
     ])),
     url(r'^admin/account/change_password/$', change_password, name='wagtailadmin_account_change_password'),
+    url(r'^admin/users/add/$', create_user, name='create_user'),
+    url(r'^admin/users/([^\/]+)/$', edit_user, name='edit_user'),
     # ----------------x-------------------- #
 
     url(r'^admin/', include(wagtailadmin_urls)),

--- a/cfgov/v1/util/password_policy.py
+++ b/cfgov/v1/util/password_policy.py
@@ -22,15 +22,16 @@ def _check_passwords(pass1, pass2, user):
     if len(data)==0: # only check this stuff if there are no failures above
         from ..models import PasswordHistoryItem
         try:
-            current_password_data = user.passwordhistoryitem_set.latest()
+            if user:
+                current_password_data = user.passwordhistoryitem_set.latest()
 
-            if not current_password_data.can_change_password():
-                data += "You can not change passwords more than once" \
-                              " in 24 hours"
+                if not current_password_data.can_change_password():
+                    data += "You can not change passwords more than once" \
+                                  " in 24 hours"
         except ObjectDoesNotExist:
             pass
 
-    if len(data)==0:
+    if len(data)==0 and user:
         queryset = user.passwordhistoryitem_set.order_by('-created')[:10]
 
         checker =functools.partial(hashers.check_password, pass1)

--- a/cfgov/v1/views.py
+++ b/cfgov/v1/views.py
@@ -247,3 +247,67 @@ def custom_password_reset_confirm(request, uidb64=None, token=None,
 
 
 password_reset_confirm = account._wrap_password_reset_view(custom_password_reset_confirm)
+
+## User Creation
+from wagtail.wagtailusers.views.users import add_user_perm, change_user_perm
+from wagtail.wagtailusers.forms import UserCreationForm, UserEditForm
+from wagtail.wagtailadmin.utils import permission_required
+
+@permission_required(add_user_perm)
+def create_user(request):
+    if request.POST:
+        form = UserCreationForm(request.POST)
+        if form.is_valid():
+            password1 = form.cleaned_data.get('password1', '')
+            password2 = form.cleaned_data.get('password2', '')
+            errors = password_policy._check_passwords(password1, password2, None)
+
+            if len(errors) == 0:
+                user = form.save()
+                wagtail_messages.success(request, _("User '{0}' created.").format(user), buttons=[
+                    wagtail_messages.button(reverse('wagtailusers_users:edit', args=(user.id,)), _('Edit'))
+                ])
+                return redirect('wagtailusers_users:index')
+            else:
+                messages.error(request, errors)
+        else:
+            wagtail_messages.error(request, _("The user could not be created due to errors."))
+    else:
+        form = UserCreationForm()
+
+    return render(request, 'wagtailusers/users/create.html', {
+        'form': form,
+    })
+
+@permission_required(change_user_perm)
+def edit_user(request, user_id):
+    user = get_object_or_404(get_user_model(), id=user_id)
+    if request.POST:
+        form = UserEditForm(request.POST, instance=user)
+        if form.is_valid():
+            errors = []
+            password1 = form.cleaned_data.get('password1', '')
+            password2 = form.cleaned_data.get('password2', '')
+
+            if password1 and password2:
+                errors = password_policy._check_passwords(password1, password2, None)
+                password_check = True
+
+            if len(errors) == 0 or not password_check:
+                user = form.save()
+                wagtail_messages.success(request, _("User '{0}' updated.").format(user), buttons=[
+                    wagtail_messages.button(reverse('wagtailusers_users:edit', args=(user.id,)), _('Edit'))
+                ])
+                return redirect('wagtailusers_users:index')
+            else:
+                messages.error(request, errors)
+        else:
+            wagtail_messages.error(request, _("The user could not be saved due to errors."))
+    else:
+        form = UserEditForm(instance=user)
+
+    return render(request, 'wagtailusers/users/edit.html', {
+        'user': user,
+        'form': form,
+    })
+


### PR DESCRIPTION
## Additions

- Include Password Complexity to Admin Creation Flow

## Testing

- Login as an admin user and navigate to the `Users` menu
<img width="360" alt="screen shot 2016-03-01 at 3 54 29 pm" src="https://cloud.githubusercontent.com/assets/254877/13441667/720126d8-dfc6-11e5-9808-c75e76441713.png">
- Create a new User
- Edit an old User and change their password


## Review

- @kurtw 
- @richaagarwal 
- @rosskarchner 

## Screenshots

<img width="1018" alt="screen shot 2016-03-01 at 3 53 10 pm" src="https://cloud.githubusercontent.com/assets/254877/13441639/4e357402-dfc6-11e5-9578-0a0c10078f31.png">

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices
* [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)