### PR TITLE
Fix for boolean equality check - DFJR-933

### DIFF
--- a/cfgov/jinja2/v1/_includes/organisms/sidebar-breakout.html
+++ b/cfgov/jinja2/v1/_includes/organisms/sidebar-breakout.html
@@ -59,8 +59,8 @@
                         {% if blocks.image is defined %}
                             {% set photo = image(blocks.image.value, 'original') %}
                             <div class="o-sidebar-breakout_img-container
-                                        {{ 'o-sidebar-breakout_img-container__round'
-                                        if blocks.is_round.render() else '' }}
+                                        {{ 'o-sidebar-breakout_img-container__round' 
+                                           if blocks.is_round | string == 'True' else '' }}
                                         u-centered-on-mobile">
                               <div class="o-sidebar-breakout_img
                                           u-centered-on-mobile"


### PR DESCRIPTION
Weird happenings when `is_round` returns a boolean and the Jinja equality check fails. This fixes that by coercing to a string. 

## Changes

- Modified `cfgov/jinja2/v1/_includes/organisms/sidebar-breakout.html` to fix boolean comparison issue. 

## Testing
- Add a `sidebar breakbout` and toggle the `round` property. Preview. Check the width of the breakout image.

## Review

- @jimmynotjim 
- @anselmbradford 
- @KimberlyMunoz 
- @kave 

## Screenshots
<img width="560" alt="screen shot 2016-03-02 at 1 37 48 pm" src="https://cloud.githubusercontent.com/assets/1696212/13470932/5c7d33c2-e07c-11e5-9c78-fbb809c07383.png">


## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)