### PR TITLE
Limited the old form validation to email signups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,7 +82,8 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Fixed Contacts import-data script to set phone numbers correctly
 - Fixed an issue where heros were not displaying on new Wagtail pages.
 - Fixed an error where the secondary nav script was trying to initialize on pages it wasn't used.
-- Fixed archive_events script to run in production
+- Fixed archive_events script to run in production.
+- Fixed issue where form validation clashed with filterable list controls.
 
 ## 3.0.0-3.0.0 - 2016-02-11
 

--- a/cfgov/unprocessed/js/modules/form-validation.js
+++ b/cfgov/unprocessed/js/modules/form-validation.js
@@ -71,7 +71,7 @@ function _sendSubscriptionRequest( elem ) {
 }
 
 function init() {
-  $( 'form' )
+  $( '#email-subscribe-form' )
     .cf_notifier()
     .cf_formValidator( 'init', {
       onFailure: function( event, fields ) {


### PR DESCRIPTION
Limited the old form validation to email signups to avoid clashing with the filterable list controls

## Changes

- Targets `#email-subscribe-form` instead of all forms

## Testing

- `gulp build` and test email signups in both sidebars and pre-footers throughout the project

## Review

- @KimberlyMunoz 
- @sebworks 
- @anselmbradford 

## Todos

- This should be combined w/ the validation in filterable controls post launch.

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices
* [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)