### PR TITLE
Fixed archive_events script & Created DemoPage availability flag

### DIFF
--- a/.env_SAMPLE
+++ b/.env_SAMPLE
@@ -22,6 +22,7 @@ export STAGING_HOSTNAME='content.localhost'
 #export WAGTAILADMIN_NOTIFICATION_FROM_EMAIL=<wagtail_notification_from_email>
 #export LOGIN_FAIL_TIME_PERIOD=<time_between_failed_attempts>
 #export LOGIN_FAILS_ALLOWED=<number_of_fails_allowed_before_lockout>
+#export DEMO_PAGE=<boolean_enable_demo_page_use>
 
 ############################
 # Mysql Database Server.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Frontend: Added JS init scripts for /offices/, /sub-pages/, and /budget/.
 - Frontend: Added data-* attribute JS utility class.
 - New manager to query for the most appropriate pages (shared and/or live)
+- Enabled Demo Page in flapjack
 
 ### Changed
 - Converted the project to Capital Framework v3
@@ -78,6 +79,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Fixed Contacts import-data script to set phone numbers correctly
 - Fixed an issue where heros were not displaying on new Wagtail pages.
 - Fixed an error where the secondary nav script was trying to initialize on pages it wasn't used.
+- Fixed archive_events script to run in production
 
 ## 3.0.0-3.0.0 - 2016-02-11
 

--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -42,6 +42,7 @@ INSTALLED_APPS = (
     'v1',
     'core',
     'sheerlike',
+    'django_extensions',
 )
 
 OPTIONAL_APPS=[

--- a/cfgov/cfgov/settings/local.py
+++ b/cfgov/cfgov/settings/local.py
@@ -1,7 +1,7 @@
 from .base import *
 
 DEBUG = True
-INSTALLED_APPS += ('django_extensions', 'wagtail.contrib.wagtailstyleguide')
+INSTALLED_APPS += ('wagtail.contrib.wagtailstyleguide',)
 
 DATABASES = {
     'default': {

--- a/cfgov/scripts/archive_events.py
+++ b/cfgov/scripts/archive_events.py
@@ -32,8 +32,8 @@ def run():
         else:
             print 'No events to archive found....'
     elif not event_page_exists:
-        print 'Events browse page has not create....'
+        print 'Events browse page has not been created....'
     elif not archive_event_page_exists:
-        print 'No archived events browse page not created....'
+        print 'No Archived events Browse page named \'Archive\' exist....'
     else:
         print 'No events exist in the database...'

--- a/cfgov/v1/models/__init__.py
+++ b/cfgov/v1/models/__init__.py
@@ -12,6 +12,7 @@ from .browse_filterable_page import *
 from .learn_page import *
 from .home_page import *
 
+import os
 from django.conf import settings
-if settings.DEBUG:
+if settings.DEBUG or os.environ.get('DEMO_PAGE'):
     from .demo import *


### PR DESCRIPTION
## Additions

- enabled demo_page use in flapjack

## Fixed

- Fixed archive_events script to run in production

## Testing

- Set `Debug=False` and verify you cannot create the `DemoPage`
 - *Note* run server in insecure mode after a `collectstatic`
 - `./cfgov/manage.py runserver --insecure`
- Set environment variable `export DEMO_PAGE=True` and verify you can create the `DemoPage`

## Review

- @kurtw 
- @richaagarwal 
- @rosskarchner 

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)

…emo_page in flapjack