### PR TITLE
Post preview title now links to page link.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Renamed atomic-checkers `validateDomElement` to atomic-helpers `checkDom`.
 - Add two categories to the Implementation Resource group.
 - Updated the homepage based on user feedback.
+- Renamed preview_link_url/text => secondary_link_url/text
 
 ### Removed
 - Removed normalize and normalize-legacy from main less file because CF already includes it.
@@ -84,6 +85,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Fixed an error where the secondary nav script was trying to initialize on pages it wasn't used.
 - Fixed archive_events script to run in production.
 - Fixed issue where form validation clashed with filterable list controls.
+- Post preview title now links to page link.
 
 ## 3.0.0-3.0.0 - 2016-02-11
 

--- a/cfgov/jinja2/v1/_includes/organisms/post-preview.html
+++ b/cfgov/jinja2/v1/_includes/organisms/post-preview.html
@@ -108,7 +108,7 @@
         <div class="o-post-preview_content">
 
             <h3 class="o-post-preview_title">
-                <a href="{{ get_page_state_url({'request':request}, page) }}">
+                <a href="{{ get_page_state_url({'request':request}, post) }}">
                     {{ post.preview_title | safe if post.preview_title else post.title }}
                 </a>
             </h3>

--- a/cfgov/v1/forms.py
+++ b/cfgov/v1/forms.py
@@ -221,7 +221,7 @@ class FilterableListForm(forms.Form):
     # Populate Authors' choices
     def set_authors(self, parent, hostname):
         all_authors = [author for authors in [page.authors.names() for page in
-                       AbstractFilterPage.objects.live_shared().descendant_of(
+                       AbstractFilterPage.objects.live_shared(hostname).descendant_of(
                        parent)] for author in authors]
         # Orders by most to least common authors
         self.fields['authors'].choices = [(author, author) for author in

--- a/cfgov/v1/migrations/0056_auto_20160304_1651.py
+++ b/cfgov/v1/migrations/0056_auto_20160304_1651.py
@@ -3,6 +3,19 @@ from __future__ import unicode_literals
 
 from django.db import migrations, models
 from v1.models.learn_page import DocumentDetailPage
+from itertools import chain
+
+
+def save_revisions(apps, schema_editor):
+    from v1.models.learn_page import DocumentDetailPage, EventPage, LearnPage
+
+    pages = list(chain(DocumentDetailPage.objects.all(),
+                       EventPage.objects.all(),
+                       LearnPage.objects.all()))
+
+    for page in pages:
+        page.save_revision()
+
 
 class Migration(migrations.Migration):
     dependencies = [
@@ -20,4 +33,5 @@ class Migration(migrations.Migration):
             old_name='preview_link_url',
             new_name='secondary_link_url',
         ),
+        migrations.RunPython(save_revisions),
     ]

--- a/cfgov/v1/migrations/0056_auto_20160304_1651.py
+++ b/cfgov/v1/migrations/0056_auto_20160304_1651.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+from v1.models.learn_page import DocumentDetailPage
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('v1', '0055_auto_20160224_2201'),
+    ]
+
+    operations = [
+        migrations.RenameField(
+            model_name='abstractfilterpage',
+            old_name='preview_link_text',
+            new_name='secondary_link_text',
+        ),
+        migrations.RenameField(
+            model_name='abstractfilterpage',
+            old_name='preview_link_url',
+            new_name='secondary_link_url',
+        ),
+    ]

--- a/cfgov/v1/models/learn_page.py
+++ b/cfgov/v1/models/learn_page.py
@@ -25,8 +25,8 @@ class AbstractFilterPage(CFGOVPage):
     preview_title = models.CharField(max_length=255, null=True, blank=True)
     preview_subheading = models.CharField(max_length=255, null=True, blank=True)
     preview_description = RichTextField(null=True, blank=True)
-    preview_link_url = models.CharField(max_length=500, null=True, blank=True)
-    preview_link_text = models.CharField(max_length=255, null=True, blank=True)
+    secondary_link_url = models.CharField(max_length=500, null=True, blank=True)
+    secondary_link_text = models.CharField(max_length=255, null=True, blank=True)
     preview_image = models.ForeignKey(
         'v1.CFGOVImage',
         null=True,

--- a/cfgov/v1/models/learn_page.py
+++ b/cfgov/v1/models/learn_page.py
@@ -51,8 +51,8 @@ class AbstractFilterPage(CFGOVPage):
             FieldPanel('preview_title', classname="full"),
             FieldPanel('preview_subheading', classname="full"),
             FieldPanel('preview_description', classname="full"),
-            FieldPanel('preview_link_url', classname="full"),
-            FieldPanel('preview_link_text', classname="full"),
+            FieldPanel('secondary_link_url', classname="full"),
+            FieldPanel('secondary_link_text', classname="full"),
             ImageChooserPanel('preview_image'),
         ], heading='Page Preview Fields', classname='collapsible collapsed'),
         MultiFieldPanel([


### PR DESCRIPTION
## Changes

- Renamed preview_link_url/text => secondary_link_url/text

## Testing

- Load refresh data locally and navigate to `http://content.localhost:8000/policy-compliance/amicus/briefs`
- Verify clicking a post title reroutes to their home page
- *Note* Don't forget to edit you wagtail sites to relate to your localhost

## Review

- @kurtw 
- @richaagarwal 

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices
* [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
