### PR TITLE
Fix the header tests

### DIFF
--- a/test/browser_tests/shared_objects/header.js
+++ b/test/browser_tests/shared_objects/header.js
@@ -7,9 +7,9 @@ function Header( url ) {
 
   this.header = element( by.css( '.o-header' ) );
   this.logo = element( by.css( '.o-header_logo-img' ) );
-  this.navList = element( by.css( '.o-mega-menu_content-list' ) );
-  this.primaryLinks = this.navList.all( by.css( '.o-mega-menu_content-item' ) );
-  this.subLinks = element.all( by.css( '.o-mega-menu_subcontent-link' ) );
+  this.navList = element( by.css( '.o-mega-menu_content-1-lists' ) );
+  this.primaryLinks = this.navList.all( by.css( '.o-mega-menu_content-1-item' ) );
+  this.subLinks = element.all( by.css( '.o-mega-menu_content-2-link' ) );
 }
 
 module.exports = Header;

--- a/test/browser_tests/spec_suites/header.js
+++ b/test/browser_tests/spec_suites/header.js
@@ -58,7 +58,7 @@ describe( 'The Header Component', function() {
     expect( _sharedObject.navList.isPresent() ).toBe( true );
   } );
 
-  it( 'should include four Primary Nav Links', function() {
+  it( 'should include six Primary Nav Links', function() {
     expect( _sharedObject.primaryLinks.count() ).toEqual( 6 );
   } );
 


### PR DESCRIPTION
This fixes the browser tests for the header. Nothing was broken, but the refactoring made our selectors out of date.


## Testing

- run `gulp test:acceptance --sauce=false`

## Review

- @anselmbradford 
- @sebworks 
- @jimmynotjim 

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices
* [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)

A few of the selectors were out of date with recent refactoring. This
makes our test suite nice and green again. How sweet.