### PR TITLE
Careers Pages now render correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,7 +87,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Fixed issue where form validation clashed with filterable list controls.
 - Post preview title now links to page link.
 - Fixed a bug where the search input and button in the header were misaligned.
-
+- Fixed urls document type for career pages
 
 ## 3.0.0-3.0.0 - 2016-02-11
 

--- a/cfgov/cfgov/urls.py
+++ b/cfgov/cfgov/urls.py
@@ -217,8 +217,8 @@ urlpatterns = [
             name='careers'),
 
         url(r'^(?P<doc_id>[\w-]+)/$',
-            SheerTemplateView.as_view(doc_type='careers',
-                                      local_name='careers',
+            SheerTemplateView.as_view(doc_type='career',
+                                      local_name='career',
                                       default_template='careers/_single.html'), name='career'),
 
         url(r'^current-openings/$', SheerTemplateView.as_view(template_name='current-openings/index.html'),

--- a/cfgov/jinja2/v1/careers/_single.html
+++ b/cfgov/jinja2/v1/careers/_single.html
@@ -56,7 +56,11 @@
                 'heading': 'Share this job',
                 'hide_heading': false,
                 'show_linkedin': true,
-                'show_twitter': false,
+                'twitter_options': {
+                    'text':     career.title,
+                    'related':  '@cfpb',
+                    'hashtags': '#usajobs'
+                },
                 'additional_classes':
                     'share__horizontal share__align-right'
             }) }}
@@ -98,7 +102,11 @@
                     'heading': 'Share this job',
                     'hide_heading': false,
                     'show_linkedin': true,
-                    'show_twitter': false,
+                    'twitter_options': {
+                        'text':     career.title,
+                        'related':  '@cfpb',
+                        'hashtags': '#usajobs'
+                    },
                     'additional_classes':
                         'share__horizontal share__align-right'
                 }) }}

--- a/cfgov/jinja2/v1/careers/_single.html
+++ b/cfgov/jinja2/v1/careers/_single.html
@@ -56,6 +56,7 @@
                 'heading': 'Share this job',
                 'hide_heading': false,
                 'show_linkedin': true,
+                'show_twitter': false,
                 'additional_classes':
                     'share__horizontal share__align-right'
             }) }}
@@ -67,7 +68,7 @@
                     block__padded-top
                     block__border-top">
         <h2>Job Description</h2>
-        {{ career.description }}
+        {{ career.description | safe}}
 
         {# TODO: Discuss how to break duties and departments out of
                  the description.
@@ -97,6 +98,7 @@
                     'heading': 'Share this job',
                     'hide_heading': false,
                     'show_linkedin': true,
+                    'show_twitter': false,
                     'additional_classes':
                         'share__horizontal share__align-right'
                 }) }}


### PR DESCRIPTION
## Changes

- Fixed urls document type for career pages

## Testing
- run `./cfgov/manage.py sheer_index`
- navigate to  `/careers/` url
- Click on an career link on the `Newest Openings` sections.

## Review

- @kurtw 
- @richaagarwal 

## Screenshots
<img width="1383" alt="screen shot 2016-03-07 at 11 40 31 am" src="https://cloud.githubusercontent.com/assets/254877/13575990/6da0b88c-e459-11e5-96c5-f577c067fbf3.png">

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)