### PR TITLE
Fixes an issue in the Menu Search Input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,8 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Fixed archive_events script to run in production.
 - Fixed issue where form validation clashed with filterable list controls.
 - Post preview title now links to page link.
+- Fixed a bug where the search input and button in the header were misaligned.
+
 
 ## 3.0.0-3.0.0 - 2016-02-11
 

--- a/cfgov/unprocessed/css/cf-enhancements.less
+++ b/cfgov/unprocessed/css/cf-enhancements.less
@@ -1709,6 +1709,49 @@ select[multiple] {
 }
 
 /* topdoc
+  name: Set form elements to base webfont
+  family: cf-core
+  tags:
+    - cf-core
+*/
+
+input[type="text"],
+input[type="search"],
+input[type="email"],
+input[type="url"],
+input[type="tel"],
+input[type="number"],
+textarea,
+select[multiple] {
+    .webfont-regular();
+}
+
+/* topdoc
+  name: Match the input to button
+  family: cf-form
+  notes: "Matches the font-size and padding of the input in
+          .input-with-btn to the button"
+  tags:
+    - cf-form
+*/
+
+input {
+    .input-with-btn & {
+        // Match button 8px padding minus border width
+        padding-top: 7px;
+        padding-bottom: 7px;
+
+        // Match button font-size
+        font-size: unit( 14px / @base-font-size-px, em );
+
+        &:focus {
+            box-shadow: 0 0 0 1px @pacific inset;
+            outline: none;
+        }
+    }
+}
+
+/* topdoc
     name: EOF
     eof: true
 */


### PR DESCRIPTION
Fixes an issue in the Menu Search Input

## Changes

- Matches the input font-size and padding to the button
- Updates inputs to use the webfont

## Testing

- `gulp build` and click the "Search" link in the nav. The input and button should be the same height and align.

## Review

- @anselmbradford 
- @sebworks 
- @KimberlyMunoz 

## Screenshots

![screen shot 2016-03-07 at 2 15 33 pm](https://cloud.githubusercontent.com/assets/1280430/13580170/155c5602-e46f-11e5-9f0a-a3c7eed0ce04.png)

![screen shot 2016-03-07 at 2 14 54 pm](https://cloud.githubusercontent.com/assets/1280430/13580152/fea56a34-e46e-11e5-801e-f02f57cc212d.png)

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)