### PR TITLE
Data-hook fixes + Minor cleanup

### DIFF
--- a/cfgov/unprocessed/js/modules/util/data-hook.js
+++ b/cfgov/unprocessed/js/modules/util/data-hook.js
@@ -5,53 +5,59 @@ var standardType = require( './standard-type' );
 
 /**
  * @param {HTMLNode} element - DOM element.
- * @param {string} attr
- *   Attribute to add to the JS data-* hook value.
+ * @param {string} value
+ *   Value to add to the element's JS data-* hook.
  * @throws {Error} If supplied value contains a space,
  *   which would mean it would be two values, which is likely a typo.
  * @returns {string} The value that was added.
  */
-function add( element, attr ) {
-  if ( attr.indexOf( ' ' ) !== -1 ) {
+function add( element, value ) {
+  if ( value.indexOf( ' ' ) !== -1 ) {
     var msg = standardType.JS_HOOK + 'values cannot contain spaces!';
     throw new Error( msg );
   }
-  var values = element.getAttribute( standardType.JS_HOOK );
-  element.setAttribute( standardType.JS_HOOK, values + ' ' + attr );
 
-  return attr;
+  var values = element.getAttribute( standardType.JS_HOOK );
+  if ( values !== null ) {
+    value = values + ' ' + value;
+  }
+  element.setAttribute( standardType.JS_HOOK, value );
+
+  return value;
 }
 
 /**
  * @param {HTMLNode} element - DOM element.
- * @param {string} attr
- *   Attribute to remove from the JS data-* hook value.
+ * @param {string} value
+ *   Value to remove from the JS data-* hook value.
  * @returns {boolean} True if value was removed, false otherwise.
  */
-function remove( element, attr ) {
+function remove( element, value ) {
   var values = element.getAttribute( standardType.JS_HOOK );
-  var index = values.indexOf( attr );
-  var attrs = values.split( ' ' );
+  var index = values.indexOf( value );
+  var values = values.split( ' ' );
   if ( index > -1 ) {
-    attrs.splice( index, 1 );
-    element.setAttribute( standardType.JS_HOOK, attrs.join( ' ' ) );
+    values.splice( index, 1 );
+    element.setAttribute( standardType.JS_HOOK, values.join( ' ' ) );
     return true;
   }
+
   return false;
 }
 
 /**
  * @param {HTMLNode} element - DOM element.
- * @param {string} attr
- *   Attribute to check as existing as a JS data-* hook value.
+ * @param {string} value
+ *   Value to check as existing as a JS data-* hook value.
  * @returns {boolean} True if the data-* hook value exists, false otherwise.
  */
-function contains( element, attr ) {
+function contains( element, value ) {
   var values = element.getAttribute( standardType.JS_HOOK );
-  // TODO: This will match variations on the class name,
-  //       like 'flyout-menu-var', which would not be correct.
-  //       IndexOf should be updated to use a regex instead.
-  return values.indexOf( attr ) > -1 ? true : false;
+  // If JS data-* hook is not set return immediately.
+  if ( !values ) { return false; }
+  values = values.split( ' ' );
+
+  return values.indexOf( value ) > -1 ? true : false;
 }
 
 module.exports = {

--- a/cfgov/unprocessed/js/modules/util/dom-traverse.js
+++ b/cfgov/unprocessed/js/modules/util/dom-traverse.js
@@ -1,7 +1,5 @@
 'use strict';
 
-if ( window.Modernizr && !window.Modernizr.classlist ) { require( '../polyfill/class-list' ); } // eslint-disable-line no-undef, global-require, no-inline-comments, max-len
-
 /**
  * Get the sibling nodes of a dom node.
  *

--- a/cfgov/unprocessed/js/routes/common.js
+++ b/cfgov/unprocessed/js/routes/common.js
@@ -25,6 +25,6 @@ require( '../modules/external-site-redirect.js' ).init();
 // GLOBAL ATOMIC ELEMENTS.
 // Organisms.
 var Header = require( '../organisms/Header.js' );
-// Initialize header by passing it reference to global overlay atom.
 var header = new Header( document.body );
+// Initialize header by passing it reference to global overlay atom.
 header.init( document.body.querySelector( '.a-overlay' ) );


### PR DESCRIPTION
## Removals

- Removes unneeded classlist polyfill that is covered by the IE9 polyfill.

## Changes

- Moves code comment above correct line it refers to in common.js
- Updates `attr` variables to `value` to more accurately reflect what it represents.
- Fixes TODO in data-hook.js `contains` method.
- Fixes issue in data-hook.js where if an element didn't already have a `data-js-hook` value, it would get one with a value of `null`.

## Testing

- You can try this on any element and check the page source, such as the overlay in Header.js:
```
var dataHook = require( '../modules/util/data-hook.js' );
dataHook.add( _overlay, 'test' );
dataHook.remove( _overlay, 'test' );
console.log( dataHook.contains( _overlay, 'test' ) );
```

## Review

- @jimmynotjim 
- @sebworks 
- @KimberlyMunoz 

## Notes

- When removing all the values from  `data-js-hook`, the attribute itself still remains on the element (but without any value). I think the overhead of checking whether all values have been removed and then removing the attribute probably isn't worth it.