### PR TITLE
Header: Adds transition utilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Enabled Demo Page in flapjack
 - Included Password Complexity rules for admin user creation/editing flow
 - Enabled email backend for Production settings
+- Frontend: Added utility classes for translation and opacity CSS transitions.
 
 ### Changed
 - Converted the project to Capital Framework v3

--- a/cfgov/jinja2/v1/_includes/molecules/global-search.html
+++ b/cfgov/jinja2/v1/_includes/molecules/global-search.html
@@ -18,7 +18,8 @@
             <span class="u-visually-hidden">Search</span>
         </span>
     </button>
-    <div class="m-global-search_content"
+    <div class="m-global-search_content
+                u-hidden"
          data-js-hook="flyout-menu_content"
          aria-expanded="false">
         <form class="m-global-search_content-form"

--- a/cfgov/unprocessed/css/misc.less
+++ b/cfgov/unprocessed/css/misc.less
@@ -655,6 +655,78 @@
     }
 }
 
+
+/* topdoc
+  name: Transition utility classes.
+  family: cfgov-misc
+  notes:
+    - "Adds transitions utilty classes for transform, opacity,
+       and for the removing the transition duration."
+  tags:
+    - cfgov-misc
+*/
+.u-move-transition {
+    transition: transform 0.25s ease-out;
+}
+
+.u-alpha-transition {
+    transition: opacity 0.25s ease-out;
+}
+
+.u-no-animation {
+    transition-duration: 0s;
+}
+
+/* topdoc
+  name: Move utility classes.
+  family: cfgov-misc
+  notes:
+    - "Utility classes for moving an element using transform translate values."
+  tags:
+    - cfgov-misc
+*/
+.u-move-to-origin {
+    transform: translateX( 0 );
+}
+
+.u-move-left {
+    transform: translateX( -100% );
+}
+
+// TODO: Look into adding a mixin for movement multiples.
+.u-move-left-2x {
+    transform: translateX( -200% );
+}
+
+.u-move-left-3x {
+    transform: translateX( -300% );
+}
+
+.u-move-right {
+    transform: translateX( 100% );
+}
+
+.u-move-up {
+    transform: translateY( -100% );
+}
+
+/* topdoc
+  name: Alpha utility classes.
+  family: cfgov-misc
+  notes:
+    - "Utility classes for setting an element's opacity."
+  tags:
+    - cfgov-misc
+*/
+.u-alpha-100 {
+    opacity: 1;
+}
+
+.u-alpha-0 {
+    opacity: 0;
+}
+
+
 /* topdoc
   name: EOF
   eof: true

--- a/cfgov/unprocessed/css/molecules/global-search.less
+++ b/cfgov/unprocessed/css/molecules/global-search.less
@@ -125,15 +125,6 @@
         padding-top: unit( @grid_gutter-width / 4 / @base-font-size-px, em );
         position: absolute;
 
-        transform: translateX( 100% );
-        transition: transform 0.25s ease-out;
-
-        &[aria-expanded="true"] {
-            display: block;
-
-            transform: translateX( 0 );
-        }
-
         &-suggestions {
             display: none;
 
@@ -302,6 +293,11 @@
 .no-js .m-global-search {
     &_trigger {
         display: none;
+    }
+
+    // JS isn't available to remove u-hidden class, so override it.
+    &_content.u-hidden {
+        display: block;
     }
 }
 

--- a/cfgov/unprocessed/js/modules/transition/AlphaTransition.js
+++ b/cfgov/unprocessed/js/modules/transition/AlphaTransition.js
@@ -1,0 +1,121 @@
+'use strict';
+
+// Required modules.
+var EventObserver = require( '../../modules/util/EventObserver' );
+var BaseTransition = require( './BaseTransition' );
+
+// Exported constants.
+var CLASSES = Object.seal( {
+  BASE_CLASS: 'u-alpha-transition',
+  ALPHA_100:  'u-alpha-100',
+  ALPHA_0:    'u-alpha-0'
+} );
+
+/**
+ * AlphaTransition
+ * @class
+ *
+ * @classdesc Initializes new AlphaTransition behavior.
+ *
+ * @param {HTMLNode} element
+ *   DOM element to apply opacity transition to.
+ * @returns {AlphaTransition} An instance.
+ */
+function AlphaTransition( element ) {
+
+  var _baseTransition = new BaseTransition( element, CLASSES ).init();
+  var _transitionCompleteBinded = _transitionComplete.bind( this );
+  _baseTransition.addEventListener( BaseTransition.END_EVENT,
+                                    _transitionCompleteBinded );
+
+  /**
+   * @returns {AlphaTransition} An instance.
+   */
+  function init() {
+    return this;
+  }
+
+  /**
+   * @param {HTMLNode} elem - Set HTML element target of the transition.
+   */
+  function setElement( elem ) {
+    _baseTransition.setElement( elem );
+  }
+
+  /**
+   * Clear transition classes from the transition target.
+   */
+  function flush() {
+    _baseTransition.flush();
+  }
+
+  /**
+   * Add a "transition-duration: 0" utility CSS class.
+   */
+  function animateOn() {
+    _baseTransition.animateOn();
+  }
+
+  /**
+   * Remove a "transition-duration: 0" utility CSS class.
+   */
+  function animateOff() {
+    _baseTransition.animateOff();
+  }
+
+  /**
+   * @returns {boolean} Whether the transition has a duration or not.
+   */
+  function isAnimated() {
+    return _baseTransition.isAnimated();
+  }
+
+  /**
+   * Handle the end of a transition.
+   */
+  function _transitionComplete() {
+    this.dispatchEvent( BaseTransition.END_EVENT, { target: this } );
+  }
+
+  /**
+   * Fade to 100% by applying a utility alpha class.
+   * @returns {AlphaTransition} An instance.
+   */
+  function fadeTo100() {
+    _baseTransition.applyClass( CLASSES.ALPHA_100 );
+
+    return this;
+  }
+
+  /**
+   * Fade to nothing by applying a utility alpha class.
+   * @returns {AlphaTransition} An instance.
+   */
+  function fadeTo0() {
+    _baseTransition.applyClass( CLASSES.ALPHA_0 );
+
+    return this;
+  }
+
+  // Attach public events.
+  var eventObserver = new EventObserver();
+  this.addEventListener = eventObserver.addEventListener;
+  this.dispatchEvent = eventObserver.dispatchEvent;
+  this.removeEventListener = eventObserver.removeEventListener;
+
+  this.animateOff = animateOff;
+  this.animateOn = animateOn;
+  this.fadeTo100 = fadeTo100;
+  this.fadeTo0 = fadeTo0;
+  this.flush = flush;
+  this.init = init;
+  this.isAnimated = isAnimated;
+  this.setElement = setElement;
+
+  return this;
+}
+
+// Public static properties.
+AlphaTransition.CLASSES = CLASSES;
+
+module.exports = AlphaTransition;

--- a/cfgov/unprocessed/js/modules/transition/BaseTransition.js
+++ b/cfgov/unprocessed/js/modules/transition/BaseTransition.js
@@ -1,0 +1,203 @@
+'use strict';
+
+// Required modules.
+var EventObserver = require( '../../modules/util/EventObserver' );
+
+/**
+ * BaseTransition
+ * @class
+ *
+ * @classdesc Initializes new BaseTransition behavior.
+ *   This shouldn't be used directly, but instead should be
+ *   the base class used through composition by a specific transition.
+ *
+ * @param {HTMLNode} element
+ *   DOM element to apply transition to.
+ * @param {Object} classes
+ *   The classes to apply to this transition.
+ * @returns {BaseTransition} An instance.
+ */
+function BaseTransition( element, classes ) { // eslint-disable-line max-statements, no-inline-comments, max-len
+  var _classes = classes;
+  var _dom;
+
+  var _lastClass;
+  var _transitionEndEvent;
+  var _transitionCompleteBinded = _transitionComplete.bind( this );
+  var _addEventListenerBinded = _addEventListener.bind( this );
+  var _isFlushed = false;
+
+  /**
+   * @returns {BaseTransition} An instance.
+   */
+  function init() {
+    setElement( element );
+
+    return this;
+  }
+
+  /**
+   * Add an event listener to the transition, or call the transition
+   * complete handler immediately if transition not supported.
+   * @param {HTMLNode} elem - Set the HTML element target of this transition.
+   */
+  function setElement( elem ) {
+    // If the element has already been set,
+    // clear the transition classes from the old element.
+    if ( _dom ) {
+      _dom.classList.remove( _classes.BASE_CLASS );
+      flush();
+      animateOn();
+    }
+    _dom = elem;
+    _dom.classList.add( _classes.BASE_CLASS );
+    _transitionEndEvent = _getTransitionEndEvent( _dom );
+  }
+
+  /**
+   * Add a "transition-duration: 0s" utility CSS class.
+   */
+  function animateOn() {
+    _dom.classList.remove( BaseTransition.NO_ANIMATION_CLASS );
+  }
+
+  /**
+   * Remove a "transition-duration: 0s" utility CSS class.
+   */
+  function animateOff() {
+    _dom.classList.add( BaseTransition.NO_ANIMATION_CLASS );
+  }
+
+  /**
+   * @returns {boolean} Whether the transition has a duration or not.
+   */
+  function isAnimated() {
+    return !_dom.classList.contains( BaseTransition.NO_ANIMATION_CLASS );
+  }
+
+  /**
+   * Add an event listener to the transition, or call the transition
+   * complete handler immediately if transition not supported.
+   */
+  function _addEventListener() {
+    // If transition is not supported, call handler directly (IE9/OperaMini).
+    if ( _transitionEndEvent ) {
+      _dom.addEventListener( _transitionEndEvent,
+                                        _transitionCompleteBinded );
+      this.dispatchEvent( BaseTransition.BEGIN_EVENT, { target: this } );
+    } else {
+      this.dispatchEvent( BaseTransition.BEGIN_EVENT, { target: this } );
+      _transitionComplete();
+      this.dispatchEvent( BaseTransition.END_EVENT, { target: this } );
+    }
+  }
+
+  /**
+   * Remove an event listener to the transition.
+   */
+  function _removeEventListener() {
+    _dom.removeEventListener( _transitionEndEvent,
+                                         _transitionCompleteBinded );
+  }
+
+  /**
+   * Handle the end of a transition.
+   */
+  function _transitionComplete() {
+    _removeEventListener();
+    this.dispatchEvent( BaseTransition.END_EVENT, { target: this } );
+  }
+
+  /**
+   * Search for and remove initial BaseTransition classes that have
+   * already been applied to this BaseTransition's target element.
+   * Will only be run once internally, but can be run additional
+   * times externally.
+   */
+  function flush() {
+    for ( var prop in _classes ) {
+      if ( _classes.hasOwnProperty( prop ) &&
+           _classes[prop] !== _classes.BASE_CLASS &&
+           _dom.classList.contains( _classes[prop] ) ) {
+        _dom.classList.remove( _classes[prop] );
+      }
+    }
+  }
+
+  /**
+   * @param {string} className - A CSS class.
+   * @returns {boolean} False if the class is already applied,
+   *   otherwise true if the class was applied.
+   */
+  function applyClass( className ) {
+    if ( !_isFlushed ) {
+      flush();
+      _isFlushed = true;
+    }
+
+    if ( _dom.classList.contains( className ) ) {
+      return false;
+    }
+
+    _removeEventListener();
+    _dom.classList.remove( _lastClass );
+    _lastClass = className;
+    _addEventListenerBinded();
+    _dom.classList.add( _lastClass );
+
+    return true;
+  }
+
+  // TODO: Update Expandables to use a transition.
+  /**
+   * @param {HTMLNode} elem
+   *   The element to check for support of transition end event.
+   * @returns {string} The browser-prefixed transition end event.
+   */
+  function _getTransitionEndEvent( elem ) {
+    if ( !elem ) {
+      var msg = 'Element does not have TransitionEnd event. It may be null!';
+      throw new Error( msg );
+    }
+
+    var transition;
+    var transitions = {
+      WebkitTransition: 'webkitTransitionEnd',
+      MozTransition:    'transitionend',
+      OTransition:      'oTransitionEnd otransitionend',
+      transition:       'transitionend'
+    };
+
+    for ( var t in transitions ) {
+      if ( transitions.hasOwnProperty( t ) &&
+           typeof elem.style[t] !== 'undefined' ) {
+        transition = transitions[t];
+        break;
+      }
+    }
+    return transition;
+  }
+
+  // Attach public events.
+  var eventObserver = new EventObserver();
+  this.addEventListener = eventObserver.addEventListener;
+  this.dispatchEvent = eventObserver.dispatchEvent;
+  this.removeEventListener = eventObserver.removeEventListener;
+
+  this.animateOff = animateOff;
+  this.animateOn = animateOn;
+  this.applyClass = applyClass;
+  this.flush = flush;
+  this.init = init;
+  this.isAnimated = isAnimated;
+  this.setElement = setElement;
+
+  // Public static constants.
+  BaseTransition.BEGIN_EVENT = 'transitionBegin';
+  BaseTransition.END_EVENT = 'transitionEnd';
+  BaseTransition.NO_ANIMATION_CLASS = 'u-no-animation';
+
+  return this;
+}
+
+module.exports = BaseTransition;

--- a/cfgov/unprocessed/js/modules/transition/MoveTransition.js
+++ b/cfgov/unprocessed/js/modules/transition/MoveTransition.js
@@ -1,0 +1,160 @@
+'use strict';
+
+// Required modules.
+var EventObserver = require( '../../modules/util/EventObserver' );
+var BaseTransition = require( './BaseTransition' );
+
+// Exported constants.
+var CLASSES = Object.seal( {
+  BASE_CLASS:     'u-move-transition',
+  MOVE_TO_ORIGIN: 'u-move-to-origin',
+  MOVE_LEFT:      'u-move-left',
+  MOVE_LEFT_2X:   'u-move-left-2x',
+  MOVE_LEFT_3X:   'u-move-left-3x',
+  MOVE_RIGHT:     'u-move-right',
+  MOVE_UP:        'u-move-up'
+} );
+
+/**
+ * MoveTransition
+ * @class
+ *
+ * @classdesc Initializes new MoveTransition behavior.
+ *
+ * @param {HTMLNode} element
+ *   DOM element to apply move transition to.
+ * @returns {MoveTransition} An instance.
+ */
+function MoveTransition( element ) { // eslint-disable-line max-statements, no-inline-comments, max-len
+
+  var _baseTransition = new BaseTransition( element, CLASSES ).init();
+  var _transitionCompleteBinded = _transitionComplete.bind( this );
+  _baseTransition.addEventListener( BaseTransition.END_EVENT,
+                                    _transitionCompleteBinded );
+
+  /**
+   * @returns {MoveTransition} An instance.
+   */
+  function init() {
+    return this;
+  }
+
+  /**
+   * @param {HTMLNode} elem - Set HTML element target of the transition.
+   */
+  function setElement( elem ) {
+    _baseTransition.setElement( elem );
+  }
+
+  /**
+   * Clear transition classes from the transition target.
+   */
+  function flush() {
+    _baseTransition.flush();
+  }
+
+  /**
+   * Add a "transition-duration: 0" utility CSS class.
+   */
+  function animateOn() {
+    _baseTransition.animateOn();
+  }
+
+  /**
+   * Remove a "transition-duration: 0" utility CSS class.
+   */
+  function animateOff() {
+    _baseTransition.animateOff();
+  }
+
+  /**
+   * @returns {boolean} Whether the transition has a duration or not.
+   */
+  function isAnimated() {
+    return _baseTransition.isAnimated();
+  }
+
+  /**
+   * Handle the end of a transition.
+   */
+  function _transitionComplete() {
+    this.dispatchEvent( BaseTransition.END_EVENT, { target: this } );
+  }
+
+  /**
+   * Move to the element's original coordinates.
+   * @returns {MoveTransition} An instance.
+   */
+  function moveToOrigin() {
+    _baseTransition.applyClass( CLASSES.MOVE_TO_ORIGIN );
+
+    return this;
+  }
+
+  /**
+   * Move to the left by applying a utility move class.
+   * @param {Number} count
+   *   How many times to move left as a multiplication of the element's width.
+   * @returns {MoveTransition} An instance.
+   */
+  function moveLeft( count ) {
+    count = count || 1;
+    var moveClasses = [
+      CLASSES.MOVE_LEFT,
+      CLASSES.MOVE_LEFT_2X,
+      CLASSES.MOVE_LEFT_3X
+    ];
+
+    if ( count < 1 || count > moveClasses.length ) {
+      throw new Error( 'MoveTransition: moveLeft count is out of range!' );
+    }
+
+    _baseTransition.applyClass( moveClasses[count - 1] );
+
+    return this;
+  }
+
+  /**
+   * Move to the right by applying a utility move class.
+   * @returns {MoveTransition} An instance.
+   */
+  function moveRight() {
+    _baseTransition.applyClass( CLASSES.MOVE_RIGHT );
+
+    return this;
+  }
+
+  /**
+   * Move up by applying a utility move class.
+   * @returns {MoveTransition} An instance.
+   */
+  function moveUp() {
+    _baseTransition.applyClass( CLASSES.MOVE_UP );
+
+    return this;
+  }
+
+  // Attach public events.
+  var eventObserver = new EventObserver();
+  this.addEventListener = eventObserver.addEventListener;
+  this.dispatchEvent = eventObserver.dispatchEvent;
+  this.removeEventListener = eventObserver.removeEventListener;
+
+  this.animateOff = animateOff;
+  this.animateOn = animateOn;
+  this.flush = flush;
+  this.init = init;
+  this.isAnimated = isAnimated;
+  this.moveToOrigin = moveToOrigin;
+  this.moveLeft = moveLeft;
+  this.moveRight = moveRight;
+  this.moveUp = moveUp;
+  this.setElement = setElement;
+
+  return this;
+}
+
+// Public static properties.
+MoveTransition.CLASSES = CLASSES;
+
+module.exports = MoveTransition;

--- a/cfgov/unprocessed/js/molecules/GlobalSearch.js
+++ b/cfgov/unprocessed/js/molecules/GlobalSearch.js
@@ -6,6 +6,7 @@ var breakpointState = require( '../modules/util/breakpoint-state' );
 var ClearableInput = require( '../modules/ClearableInput' );
 var EventObserver = require( '../modules/util/EventObserver' );
 var FlyoutMenu = require( '../modules/FlyoutMenu' );
+var MoveTransition = require( '../modules/transition/MoveTransition' );
 
 /**
  * GlobalSearch
@@ -24,8 +25,8 @@ function GlobalSearch( element ) { // eslint-disable-line max-statements, no-inl
   var _dom = atomicHelpers.checkDom( element, BASE_CLASS, 'GlobalSearch' );
   var _triggerSel = '.' + BASE_CLASS + '_trigger';
   var _triggerDom = _dom.querySelector( _triggerSel );
-  var _flyoutMenu = new FlyoutMenu( _dom ).init();
   var _contentDom = _dom.querySelector( '.' + BASE_CLASS + '_content' );
+  var _flyoutMenu = new FlyoutMenu( _dom );
   var _searchInputDom;
   var _searchBtnDom;
   var _clearBtnDom;
@@ -40,6 +41,15 @@ function GlobalSearch( element ) { // eslint-disable-line max-statements, no-inl
    * @returns {Object} The GlobalSearch instance.
    */
   function init() {
+    // Set initial appearance.
+    var transition = new MoveTransition( _contentDom ).init();
+    transition.moveRight();
+    _flyoutMenu.setExpandTransition( transition, transition.moveToOrigin );
+    _flyoutMenu.setCollapseTransition( transition, transition.moveRight );
+    _flyoutMenu.init();
+
+    _contentDom.classList.remove( 'u-hidden' );
+
     var clearBtnSel = '.' + BASE_CLASS + ' .input-contains-label_after__clear';
     var inputContainsLabelSel =
       '.' + BASE_CLASS + '_content-form .input-contains-label';
@@ -135,6 +145,7 @@ function GlobalSearch( element ) { // eslint-disable-line max-statements, no-inl
    */
   function _handleExpandBegin() {
     this.dispatchEvent( 'expandBegin', { target: this } );
+    // If it's the desktop view, hide the "Search" button.
     if ( _isInDesktop() ) { _triggerDom.classList.add( 'u-hidden' ); }
     _contentDom.classList.remove( 'u-invisible' );
     _searchInputDom.select();

--- a/cfgov/unprocessed/js/organisms/MegaMenu.js
+++ b/cfgov/unprocessed/js/organisms/MegaMenu.js
@@ -72,6 +72,9 @@ function MegaMenu( element ) {
    */
   function _handleBodyClick( event ) {
     var target = event.target;
+    if ( _activeMenu.getDom().trigger === target ) {
+      return;
+    }
 
     var isInDesktop = _isInDesktop();
     if ( isInDesktop && !_isDesktopTarget( target ) ||


### PR DESCRIPTION
Updates Global Search animation to use separate transition module, which eventually the mega menu will use also.

## Additions

- Added utility classes for translation and opacity CSS transitions.

## Changes

- Updates flyout menu to support transition utilities.

## Testing

- Global search and mega menu should work the same as on refresh.demo.

## Review

- @jimmynotjim 
- @KimberlyMunoz 
- @sebworks 

## Notes

- The flyout menu can either use no transition, in which case `expandBegin` and `expandEnd` are called subsequent to each other, or a transition can be added, in which case `expandEnd` is called after the `transitionEnd` event fires. The same architecture is present for the collapse methods. A different transition instance can be used for the expand and collapse, if, for example, a menu should move into view when opened, but fade out of view when closed.

## Todos

- This is prep for the transitions used in the mega menu hamburger menu.
