### PR TITLE
Positioning fixes for search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,7 +87,8 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Fixed issue where form validation clashed with filterable list controls.
 - Post preview title now links to page link.
 - Fixed a bug where the search input and button in the header were misaligned.
-- Fixed urls document type for career pages
+- Fixed urls document type for career pages.
+- Fixed stacking bug in header search.
 
 ## 3.0.0-3.0.0 - 2016-02-11
 

--- a/cfgov/unprocessed/css/molecules/global-search.less
+++ b/cfgov/unprocessed/css/molecules/global-search.less
@@ -103,7 +103,6 @@
         // TODO: Check that float doesn't spill outside molecule.
         float: right;
         position: relative;
-        z-index: 20;
 
         background: @white;
         border: none;
@@ -124,6 +123,7 @@
 
     &_content {
         padding-top: unit( @grid_gutter-width / 4 / @base-font-size-px, em );
+        position: absolute;
 
         transform: translateX( 100% );
         transition: transform 0.25s ease-out;

--- a/cfgov/unprocessed/css/organisms/header.less
+++ b/cfgov/unprocessed/css/organisms/header.less
@@ -83,6 +83,10 @@
             & > .m-global-search {
                 float: right;
             }
+
+            > .m-global-search {
+                min-width: 340px;
+            }
         } );
 
         // Hide Global Header Call to Action at tablet/mobile sizes.


### PR DESCRIPTION
Positioning fixes to stop Search trigger and form from stacking while transitioning

## Changes

- Adds absolute positioning to search form and a set width in the organism

## Removals

- Removes z-index from search button (form should sit on top of the button).

## Testing

- `gulp build` and test the menu in the header

## Review

- @anselmbradford 
- @KimberlyMunoz 
- @sebworks 

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)