### PR TITLE
Add a link to event page

### DIFF
--- a/cfgov/jinja2/v1/_includes/templates/upcoming-events.html
+++ b/cfgov/jinja2/v1/_includes/templates/upcoming-events.html
@@ -4,7 +4,6 @@
             Upcoming events
         </span>
     </h2>
-    <div class="demo-placeholder">
-        placeholder
-    </div>
+    <p>Check out our upcoming events.</p>
+    <a class="btn" href="/events/">Find out more</a>
 </div>


### PR DESCRIPTION
Rather than including a feed of the events, we're just including a button per @schaferjh's instructions.

## Testing

- Visit localhost:8000/newsroom/press-resources/

## Review

- @anselmbradford 
- @sebworks 
- @jimmynotjim 

## Screenshots

![image](https://cloud.githubusercontent.com/assets/1860176/13586323/266f14ce-e48e-11e5-8013-25c87633775f.png)
