### PR TITLE
Fixed Activity Feed to properly limit posts

### DIFF
--- a/cfgov/jinja2/v1/_includes/macros/activity-snippets.html
+++ b/cfgov/jinja2/v1/_includes/macros/activity-snippets.html
@@ -33,7 +33,7 @@
     {% from 'macros/util/text.html' import string_length as string_length %}
     <div class="content-l content-l__large-gutters">
     {% for activity_type in activity_types %}
-        {% set activity = _activity_snippet(activity_type, tag, 2, include_date_flag) %}
+        {% set activity = _activity_snippet(activity_type, tag, 5, include_date_flag) %}
         {% if string_length(activity)|int > 0 %}
             <div class="content-l_col {{ 'content-l_col-1' ~ ('-' ~ number_columns if number_columns > 1 else '') }}">
                 {{ activity }}
@@ -126,6 +126,9 @@
         <h3 class="h4">{{ icon }} {{ header }}</h3>
         <ul class="list list__unstyled list__spaced list__links">
         {% for item in feed %}
+            {% if loop.index > quantity %}
+                {% break %}
+            {% endif %}
             <li class="list_item">
                 <a class="list_link"
                    href="{{ item.permalink }}">


### PR DESCRIPTION
Something happened to the limiting on Activity Feed. This fixes it with a break in the loop.

## Testing

- Visit `/about-us/` or `/careers/` and make sure it's only showing 5 posts

## Review

- @jimmynotjim 
- @anselmbradford 
- @sebworks 

## Screenshots

![image](https://cloud.githubusercontent.com/assets/1860176/13609656/e23e1940-e527-11e5-9b81-1939432a4adb.png)

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)

