### PR TITLE
Updating the Bureau Structure

### DIFF
--- a/cfgov/jinja2/v1/the-bureau/bureau-structure/_footer.html
+++ b/cfgov/jinja2/v1/the-bureau/bureau-structure/_footer.html
@@ -1,0 +1,34 @@
+<aside class="block
+              block__padded-top
+              block__border-top
+              org-chart_footer">
+    <div class="content-l content-l__main">
+        <div class="content-l_col content-l_col-1-2"
+             data-qa-hook="org-chart-download-info">
+            <h2 class="h3">Download a copy</h2>
+            <p>
+                Download a printable, PDF copy of this organizational chart. This version
+                is expanded to show all offices.
+            </p>
+            {# Add PDF download URL when it's available. #}
+            <a class="btn btn__secondary u-link__disabled">
+                <span class="btn_icon__left cf-icon cf-icon-save"></span>
+                Download PDF
+            </a>
+        </div>
+        <div class="content-l_col content-l_col-1-2"
+             data-qa-hook="org-chart-speaking-info">
+            <h2 class="h3">Request speaking info</h2>
+            <p>
+                Ask a CFPB employee to be involved in a forum, publication, discussion, or
+                other event; or to inquire about any CFPB events.
+            </p>
+            <span class="cf-icon cf-icon-email list_icon"></span>
+            <span class="list_text">
+                <a class="list_link" href="mailto:cfpb.events@cfpb.gov">
+                    cfpb.events@cfpb.gov
+                </a>
+            </span>
+        </div>
+    </div>
+</aside>

--- a/cfgov/jinja2/v1/the-bureau/bureau-structure/_legend.html
+++ b/cfgov/jinja2/v1/the-bureau/bureau-structure/_legend.html
@@ -1,0 +1,24 @@
+<section class="org-chart_legend">
+    <h4>Chart Legend</h4>
+    <ul class="list
+               list__unstyled
+               list__spaced">
+        <li class="list_item">
+            <span class="org-chart_legend_symbol">*</span>
+            <span class="org-chart_legend_definition">
+                Position currently filled on an acting basis
+            </span>
+        </li>
+        <li class="list_item">
+            <span class="org-chart_legend_symbol">**</span>
+            <span class="org-chart_legend_definition">
+                Position has direct reporting responsibilities to the director
+            </span>
+        </li>
+        <li class="list_item">
+            <span class="org-chart_legend_symbol">***</span>
+            <span class="org-chart_legend_definition">
+                Position is not part of the CFPB director’s office
+            </span>
+        </li>
+</section>

--- a/cfgov/jinja2/v1/the-bureau/bureau-structure/_macro-branches.html
+++ b/cfgov/jinja2/v1/the-bureau/bureau-structure/_macro-branches.html
@@ -1,0 +1,48 @@
+{# ==========================================================================
+
+   branches.render()
+
+   ==========================================================================
+
+   Description:
+
+   Renders an org chart branch when given:
+
+   categories: An Array of categories.
+
+   ========================================================================== #}
+{% macro render(categories) -%}
+{% import '_macro-node.html' as node with context %}
+<ul class="org-chart_branches
+           list
+           list__unstyled">
+    {% for category in categories %}
+    {% set category_index = loop.index %}
+    <li class="org-chart_branch">
+        <h4 class="org-chart_branch_name">{{ category.title }}</h4>
+        <ul class="org-chart_nodes
+                   nodes{{ category_index }}
+                   list
+                   list__unstyled">
+            <li class="org-chart_branch_name">
+                <button class="content-hide
+                               link_text
+                               jump-link
+                               jump-link__before
+                               jump-link__left">
+                    {{ category.title }}
+                </button>
+            </li>
+            {% for org in category.data %}
+            {{ node.render('li', org, category.sub_title) }}
+            {% endfor %}
+            {% if loop.last %}
+            <li>
+                {% include '_legend.html' %}
+            </li>
+            {% endif %}
+        </ul>
+    </li>
+    {% endfor %}
+</ul>
+{%- endmacro %}

--- a/cfgov/jinja2/v1/the-bureau/bureau-structure/_macro-content-slider.html
+++ b/cfgov/jinja2/v1/the-bureau/bureau-structure/_macro-content-slider.html
@@ -1,0 +1,33 @@
+{# ==========================================================================
+
+   content-slider.render()
+
+   ==========================================================================
+
+   Description:
+
+   Renders a content slider when given:
+
+   categories: An Array of categories.
+
+   ========================================================================== #}
+{% macro render(categories) -%}
+<div id="content-slider">
+    <div class="org-chart_categories">
+        <ul class="list__links">
+            {% for category in categories %}
+            <li class="link_item">
+                <button class="link_text
+                               jump-link
+                               jump-link__right
+                               jump-link__bg
+                               content-show"
+                        data-content=".nodes{{ loop.index }}">
+                    {{ category.title }}
+                </button>
+            </li>
+            {% endfor %}
+        </ul>
+    </div>
+</div>
+{%- endmacro %}

--- a/cfgov/jinja2/v1/the-bureau/bureau-structure/_macro-node.html
+++ b/cfgov/jinja2/v1/the-bureau/bureau-structure/_macro-node.html
@@ -1,0 +1,71 @@
+{# ==========================================================================
+
+   node.render()
+
+   ==========================================================================
+
+   Description:
+
+   Renders an org chart node when given:
+
+   tagName:   A string representing the encompassing element tag name.
+
+   org:       A dictionary object representing an organization.
+
+   sub_title: A string representing a sub title for an organization.
+
+   ========================================================================== #}
+{% macro render(tagName="div", org, sub_title="text") -%}
+{% set has_children = org.children | list | length %}
+<{{ tagName }} class="org-chart_node
+       {{ 'm-expandable
+           m-expandable__expanded'
+          if has_children else '' }}">
+    {% if has_children %}
+    <button class="m-expandable_target">
+        <div class="m-expandable_header">
+            {{ role.render(org) }}
+            <div class="org-chart_node_expander">
+                <span class="m-expandable_header-left
+                             m-expandable_label
+                             org-chart_node_label">
+                    {{ sub_title }}
+                </span>
+                <span class="m-expandable_header-right
+                             m-expandable_link">
+                    <span class="m-expandable_cue
+                                 m-expandable_cue-open">
+                        <span class="m-expandable_cue-label">Show</span>
+                        <span class="cf-icon cf-icon-plus-round"></span>
+                    </span>
+                    <span class="m-expandable_cue
+                                 m-expandable_cue-close">
+                        <span class="m-expandable_cue-label">Hide</span>
+                        <span class="cf-icon cf-icon-minus-round"></span>
+                    </span>
+                </span>
+            </div>
+        </div>
+    </button>
+    <div class="org-chart_nodes
+                m-expandable_content">
+        <ul class="m-expandable_content-animated
+                   list list__unstyled
+                   list__spaced">
+            {% for child_org in org.children %}
+            <li class="org-chart_node">
+                {{ role.render(child_org) }}
+                {% if loop.last and org.relative_url %}
+                <a href="{{ org.relative_url }}" class="org-chart_node_more-info">
+                    More information about these offices
+                </a>
+                {% endif %}
+            </li>
+            {% endfor %}
+        </ul>
+    </div>
+    {% else %}
+    {{ role.render(org) }}
+    {% endif %}
+</{{ tagName }} >
+{%- endmacro %}

--- a/cfgov/jinja2/v1/the-bureau/bureau-structure/_macro-role.html
+++ b/cfgov/jinja2/v1/the-bureau/bureau-structure/_macro-role.html
@@ -1,0 +1,29 @@
+{# ==========================================================================
+
+   role.render()
+
+   ==========================================================================
+
+   Description:
+
+   Renders a person's role within the bureau structure when given:
+
+   role: An object containing a title (office title), name (person's name),
+         and titles (list of titles the person holds in particular office).
+
+   ========================================================================== #}
+{% macro render(role) -%}
+<div class="org-chart_role">
+    <h6 class="org-chart_role_office">
+        {{ role.title | safe }}
+    </h6>
+    <span class="org-chart_role_name">
+        {{ role.name | safe }}
+    </span>
+    {% for title in role.titles %}
+    <span class="org-chart_role_title">
+        {{ title | safe }}
+    </span>
+    {% endfor %}
+</div>
+{%- endmacro %}

--- a/cfgov/jinja2/v1/the-bureau/bureau-structure/_vars-division-data.html
+++ b/cfgov/jinja2/v1/the-bureau/bureau-structure/_vars-division-data.html
@@ -1,0 +1,202 @@
+{% set data = [{
+    'relative_url': '/about-us/operations/',
+    'titles': ['Chief Operating Officer (COO)', 'Associate Director'],
+    'slug':   'operations',
+    'name':   'Sartaj Alag',
+    'title':  'Operations',
+    'children': [{
+        'titles': ['Chief Administrative Officer (CAO)', 'Assistant Director'],
+        'slug':   'administrative-operations',
+        'name':   'Suzanne Tosini',
+        'title':  'Administrative Operations'
+        }, {
+        'titles': ['Assistant Director'],
+        'slug':   'chief-financial-office-cfo',
+        'name':   'Stephen Agostini',
+        'title':  'Chief Financial Officer (CFO)'
+        }, {
+        'titles': ['Chief Human Capital Officer (CHCO)', 'Assistant Director'],
+        'slug':   'human-capital-chief-human-capital-officer-chco',
+        'name':   'Jeffrey Sumberg',
+        'title':  'Human Capital'
+        }, {
+        'titles': ['Chief Information Officer (COO)', 'Assistant Director'],
+        'slug':   'technology-and-innovation',
+        'name':   'Ashwin Vasan',
+        'title':  'Technology and Innovation'
+        }, {
+        'titles': ['Assistant Director<sup>*</sup>'],
+        'slug':   'office-of-consumer-response',
+        'name':   'Christopher Johnson',
+        'title':  'Office of Consumer Response'
+        }, {
+        'titles': ['Assistant Director'],
+        'slug':   'chief-procurement-officer-cpo',
+        'name':   'David Gragan',
+        'title':  'Chief Procurement Officer (CPO)'
+    }]
+}, {
+    'relative_url': '/about-us/cee/',
+    'titles': ['Associate Director'],
+    'slug':   'consumer-education-engagement',
+    'name':   'Gail Hillebrand',
+    'title':  'Consumer Education &#038; Engagement',
+    'children': [{
+        'titles': ['Assistant Director'],
+        'slug':   'consumer-engagement',
+        'name':   'Gene Koo',
+        'title':  'Consumer Engagement'
+    }, {
+        'titles': ['Assistant Director'],
+        'slug':   'financial-education',
+        'name':   'Janneke Ratcliffe',
+        'title':  'Financial Education'
+    }, {
+        'titles': ['Assistant Director'],
+        'slug':   'financial-empowerment',
+        'name':   'Daniel Dodd-Ramirez',
+        'title':  'Financial Empowerment'
+    }, {
+        'titles': ['Assistant Director'],
+        'slug':   'older-americans',
+        'name':   'Nora Dodd Eisenhower',
+        'title':  'Older Americans'
+    }, {
+        'titles': ['Assistant Director'],
+        'slug':   'servicemember-affairs',
+        'name':   'Hollister Petraeus',
+        'title':  'Servicemember Affairs'
+    }, {
+        'titles': ['Assistant Director'],
+        'slug':   'students',
+        'name':   'Seth Frotman',
+        'title':  'Students'
+    }]
+}, {
+    'relative_url': '/about-us/supervision-enforcement-fair-lending/',
+    'titles': ['Associate Director<sup>*</sup>'],
+    'slug':   'supervision-enforcement-and-fair-lending',
+    'name':   'David Bleicken',
+    'title':  'Supervision, Enforcement, &#038; Fair Lending',
+    'children': [{
+        'titles': ['Assistant Director'],
+        'slug':   'enforcement',
+        'name':   'Anthony Alexis',
+        'title':  'Enforcement'
+        }, {
+        'titles': ['Assistant Director'],
+        'slug':   'fair-lending-and-equal-opportunity',
+        'name':   'Patrice Ficklin',
+        'title':  'Fair Lending and Equal Opportunity'
+        }, {
+        'titles': ['Assistant Director'],
+        'slug':   'office-of-supervision-examinations',
+        'name':   'Paul Sanford',
+        'title':  'Office of Supervision Examinations'
+        }, {
+        'titles': ['Assistant Director'],
+        'slug':   'office-of-supervision-policy',
+        'name':   'Peggy Twohig',
+        'title':  'Office of Supervision Policy'
+        }]
+}, {
+    'relative_url': '/about-us/rmr/',
+    'titles': ['Associate Director'],
+    'name':   'David Silberman',
+    'slug':   'research-markets-regulations/',
+    'title':  'Research, Markets &#038; Regulations',
+    'children':[{
+        'titles': ['Assistant Director'],
+        'slug':   'card-markets',
+        'name':   'William Wade-Gery',
+        'title':  'Card Markets'
+    }, {
+        'titles': ['Assistant Director'],
+        'slug':   'credit-information-collections-and-deposits-markets',
+        'name':   'Bayard Stone Jr.',
+        'title':  'Credit Information, Collections, and Deposits Markets'
+    }, {
+        'titles': ['Assistant Director'],
+        'slug':   'installment-and-liquidity-lending-markets',
+        'name':   'Jeffrey Langer',
+        'title':  'Installment and Liquidity Lending Markets'
+    }, {
+        'titles': ['Assistant Director'],
+        'slug':   'mortgage-markets',
+        'name':   'Patricia McClung',
+        'title':  'Mortgage Markets'
+    }, {
+        'titles': ['Assistant Director'],
+        'slug':   'regulations',
+        'name':   'Kelly Cochran',
+        'title':  'Regulations'
+    }, {
+        'titles': ['Assistant Director'],
+        'slug':   'research',
+        'name':   'Christopher Carroll',
+        'title':  'Research'
+    }]
+}, {
+    'relative_url': '/about-us/external-affairs/',
+    'titles': ['Associate Director'],
+    'slug':   'external-affairs',
+    'name':   'Zixta Martinez',
+    'title':  'External Affairs',
+    'children':[{
+        'titles': ['Assistant Director'],
+        'slug':   'communications',
+        'name':   'Jennifer Howard',
+        'title':  'Communications'
+    }, {
+        'titles': ['Assistant Director'],
+        'slug':   'community-affairs',
+        'name':   'Chris Vaeth',
+        'title':  'Community Affairs'
+    }, {
+        'titles': ['Assistant Director'],
+        'slug':   'office-of-financial-institutions',
+        'name':   'Daniel Smith',
+        'title':  'Office of Financial Institutions'
+    }, {
+        'titles': ['Staff Director'],
+        'slug':   'consumer-advisory-board-councils',
+        'name':   'Delicia Hand',
+        'title':  'Consumer Advisory Board &#038; Councils'
+    }, {
+        'titles': ['Assistant Director'],
+        'slug':   'intergovernmental-affairs',
+        'name':   'Cheryl Parker Rose',
+        'title':  'Intergovernmental Affairs'
+    }, {
+        'titles': ['Assistant Director'],
+        'slug':   'legislative-affairs',
+        'name':   'Catherine Galicia',
+        'title':  'Legislative Affairs'
+    }]
+}, {
+    'relative_url': '/about-us/legal/',
+    'titles': ['Acting Associate Director<sup>*</sup>'],
+    'name':   'Stephen Van Meter',
+    'title':  'Legal, General Counsel',
+    'children': [{
+        'titles': ['Deputy Associate Director'],
+        'slug':   'principal-deputy-general-counsel',
+        'name':   'Vacant',
+        'title':  'Principal Deputy General Counsel'
+    }, {
+        'titles': ['Assistant Director'],
+        'slug':   'general-law-ethics-deputy-general-counsel',
+        'name':   'Richard Lepley',
+        'title':  'General Law &#038; Ethics, Deputy General Counsel'
+    }, {
+        'titles': ['Assistant Director'],
+        'slug':   'oversight-litigation-enforcement-support-deputy-general-counsel',
+        'name':   'To-Quyen Truong',
+        'title':  'Oversight, Litigation, &#038; Enforcement Support, Deputy General Counsel'
+    }, {
+        'titles': ['Assistant Director'],
+        'slug':   'law-policy-deputy-general-counsel',
+        'name':   'Stephen Van Meter',
+        'title':  'Law &#038; Policy, Deputy General Counsel'
+    }]
+}] %}

--- a/cfgov/jinja2/v1/the-bureau/bureau-structure/_vars-office-data.html
+++ b/cfgov/jinja2/v1/the-bureau/bureau-structure/_vars-office-data.html
@@ -1,0 +1,38 @@
+{% set data = {
+    'titles': '',
+    'slug':   'deputy-director',
+    'name':   'David Silberman',
+    'title':  'Deputy Director<sup>*</sup>',
+    'children': [{
+	    'titles': '',
+	    'slug':   'ombudsman',
+	    'name':   'Wendy Kamenshine',
+	    'title':  'Ombudsman<sup>***</sup>'
+	}]
+}, {
+    'titles': '',
+    'slug':   'chief-of-staff',
+    'name':   'Christopher D\'Angelo',
+    'title':  'Chief of Staff'
+}, {
+    'titles': ['Assistant Director'],
+    'slug':   'office-of-equal-opportunity-fairness',
+    'name':   'Stuart Ishimaru',
+    'title':  'Office of Equal Opportunity &#038; Fairness',
+    'children': [{
+	    'titles': ['Assistant Director<sup>**</sup>'],
+	    'slug':   'office-of-civil-rights',
+	    'name':   'M. Stacey Bach',
+	    'title':  'Office of Civil Rights'
+	},{
+	    'titles': ['Assistant Director'],
+	    'slug':   'office-of-minority-women-inclusion-omwi',
+	    'name':   'Stuart Ishimaru',
+	    'title':  'Office of Minority &#038; Women Inclusion (OMWI)'
+	}]
+}, {
+    'titles': '',
+    'slug':   'administrative-law-judge',
+    'name':   'Vacant',
+    'title':  'Administrative Law Judge<sup>***</sup>'
+} %}

--- a/cfgov/jinja2/v1/the-bureau/bureau-structure/index.html
+++ b/cfgov/jinja2/v1/the-bureau/bureau-structure/index.html
@@ -1,7 +1,23 @@
 {% extends 'layout-side-nav.html' %}
 {% import '_vars-the-bureau.html' as vars with context %}
+{% import '_vars-office-data.html' as office_data %}
+{% import '_vars-division-data.html' as division_data %}
+{% import '_macro-role.html' as role with context %}
+{% import '_macro-content-slider.html' as content_slider with context %}
+{% import '_macro-branches.html' as branches with context %}
+
 {% set active_nav_id = 'bureau-structure' %}
 {% set breadcrumb_items = vars.breadcrumb_items %}
+{% set categories = [{ 
+                        'title': 'Divisions',
+                        'sub_title': 'Offices in this division',
+                        'data': division_data.data
+                     },{
+                        'title':'Office of the Director',
+                        'sub_title': 'Offices under this position',
+                        'data': office_data.data
+                     }] 
+%}
 
 {% block title -%}
     Bureau Structure
@@ -29,142 +45,18 @@
 {%- endblock %}
 
 {% block content_main %}
-
-    {% import '_macro-role.html' as role with context %}
-    <h1 class="u-visually-hidden">Bureau Structure</h1>
+    <h1>Bureau Structure</h1>
+    <p>Org chart last updated: January 11, 2016</p>
     <div class="org-chart">
-
-        <div class="media org-chart_root">
-            <img class="media_image media_image__150" src="/static/img/director-cordray-round-300x300.jpg">
-            <p class="h2 u-mb0">Richard Cordray</p>
-            <h2 class="h4">Director</h2>
+        <div class="org-chart_node org-chart_node__root">
+            {{ role.render({
+                "name"  : "<a href='/the-bureau/about-director/'>Richard Cordray</a>",
+                "title" : "Director",
+                "titles": []
+            }) }}
         </div>
-
-        <div id="content-slider-container">
-            <div id="content-slider">
-                <div>
-                    <ul class="list__links">
-                    {% for category in ['Divisions', 'Office of the Director'] %}
-                        <li>
-                            <button class="link-text
-                                           jump-link
-                                           jump-link__right
-                                           jump-link__bg
-                                           content-show"
-                                    data-content=".nodes{{ loop.index }}">
-                                {{ category }}
-                            </button>
-                        </li>
-                    {% endfor %}
-                    </ul>
-                </div>
-            </div>
-        </div>
-
-        <ul class="org-chart_branches">
-        {% for category in ['Divisions', 'Office of the Director'] %}
-            {% set cat_loop = loop %}
-            <li class="org-chart_branch {% if loop.last %} last-child {% endif %}">
-                <h3 class="org-chart_branch_name">{{ category }}</h3>
-                <ul class="org-chart_nodes
-                           content-panel
-                           nodes{{ cat_loop.index }}">
-                    <li>
-                        <button class="content-hide
-                                       link-text
-                                       jump-link
-                                       jump-link__before
-                                       jump-link__left">
-                            {{ category }}
-                        </button>
-                    </li>
-                {% set parents = queries.orgmember.search(
-                   filter_has_parent='false', filter_category=category) %}
-                {% for parent in parents %}
-                    {% set par_loop = loop %}
-                    <li class="org-chart_node expandable">
-                        {% set children = queries.orgmember.search(
-                           filter_parent=parent.id) %}
-                    {% if children | list | length %}
-                        <button class="org-chart_role expandable_target expandable_header content-show"
-                                data-content=".nodes{{ cat_loop.index }}_{{ par_loop.index }}">
-                            <span class="node_expander">
-                                <span class="expandable_link u-hide-on-mobile">
-                                    <span class="expandable_cue-open">
-                                        <span class="cf-icon cf-icon-down"></span>
-                                    </span>
-                                    <span class="expandable_cue-close">
-                                        <span class="cf-icon cf-icon-up"></span>
-                                    </span>
-                                </span>
-                                <span class="expandable_link u-show-on-mobile">
-                                    <span class="cf-icon cf-icon-right"></span>
-                                </span>
-                            </span>
-                            {{ role.render(parent) }}
-                        </button>
-                        <ul class="org-chart_nodes
-                                   expandable_content
-                                   content-panel
-                                   nodes{{ cat_loop.index }}_{{ par_loop.index }}">
-                            <li>
-                                <button class="jump-link jump-link__before jump-link__left content-hide">
-                                    {{ role.render(parent) }}
-                                </button>
-                            </li>
-                        {% for child in children %}
-                            <li class="org-chart_node">
-                                <div class="org-chart_role">
-                                    {{ role.render(child) }}
-                                </div>
-                            </li>
-                        {% endfor %}
-                        </ul>
-                    {% else %}
-                        <div class="org-chart_role">
-                            {{ role.render(parent) }}
-                        </div>
-                    {% endif %}
-                    </li>
-                {% endfor %}
-                </ul>
-            </li>
-        {% endfor %}
-        </ul>
-
+        {{ content_slider.render(categories) }}
+        {{ branches.render(categories) }}
     </div>
-
-    <aside class="block
-                  block__padded-top
-                  block__border-top">
-        <div class="content-l content-l__main">
-            <div class="content-l_col content-l_col-1-2"
-                 data-qa-hook="org-chart-download-info">
-                <h2 class="h3">Download a copy</h2>
-                <p>
-                    Download a printable, PDF copy of this organizational chart. This version
-                    is expanded to show all offices.
-                </p>
-                {# Add PDF download URL when it's available. #}
-                <a class="btn btn__secondary u-link__disabled">
-                    <span class="btn_icon__left cf-icon cf-icon-save"></span>
-                    Download PDF
-                </a>
-            </div>
-            <div class="content-l_col content-l_col-1-2"
-                 data-qa-hook="org-chart-speaking-info">
-                <h2 class="h3">Request speaking info</h2>
-                <p>
-                    Ask a CFPB employee to be involved in a forum, publication, discussion, or
-                    other event; or to inquire about any CFPB events.
-                </p>
-                <span class="cf-icon cf-icon-email list_icon"></span>
-                <span class="list_text">
-                    <a class="list_link" href="mailto:cfpb.events@cfpb.gov">
-                        cfpb.events@cfpb.gov
-                    </a>
-                </span>
-            </div>
-        </div>
-    </aside>
+    {% include '_footer.html' %}
 {% endblock %}

--- a/cfgov/unprocessed/css/pages/bureau-structure.less
+++ b/cfgov/unprocessed/css/pages/bureau-structure.less
@@ -3,151 +3,31 @@
    Bureau structure page at /the-bureau/bureau-structure/.
    ========================================================================== */
 
+@margin: unit(@grid_gutter-width / @base-font-size-px, em);
+@spine-width: 5px;
+@spine-color: @gray-40;
+@node-width__desktop: 405px;
+@node-width__tablet: 300px;
+@node-width__mobile: none;
+@node-border-width: 3px;
+@node-border-color: @gray-20;
+
 .org-chart {
+    margin-top: @margin;
+    background: @gray-10;
+    border-top:1px solid @node-border-color;
 
-    .respond-to-min(@bp-sm-min, {
-        width: 90%;
-        margin: 0 auto;
-    });
+    .respond-to-min( @bp-sm-min, {
+        padding: @margin;
+        border: 1px solid @node-border-color;
+        margin-left: -@margin;
+        margin-right: -@margin;
+    } );
 
-    &_root {
-        margin-left: auto;
-        margin-right: auto;
-        text-align: center;
-    }
-
-    &_branches,
-    &_nodes {
-        list-style-type: none;
-        margin: 0;
-        padding: 0;
-    }
-
-    /* On larger screen sizes, the lines of the org chart are drawn with before & after
-       pseudo elements applied to .org-chart_branches & .org-chart_branch.
-     */
-    &_branches {
-        padding-top: @grid_gutter-width;
-
-        /* :before pseudo element's left border draws a centered vertical line
-           down from .org-chart_root to .org-chart_branches.*/
-        .respond-to-min(@bp-sm-min, {
-            position: relative;
-
-            &:before{
-                content: '';
-                position: absolute;
-                top: 0;
-                left: 50%;
-                border-left: 1px solid @gray-40;
-                width: 0;
-                height: @grid_gutter-width;
-            }
-        });
-    }
-
-    &_branch {
-        /* Borders on .org-chart_branch pseudo elements (:after on first branch, :before on last)
-           draw lines connecting the branch headers to the line from .org-chart_root. */
-        .respond-to-min(@bp-sm-min, {
-            .grid_column(6);
-            position: relative;
-            padding-top: 45px;
-            border-width: 0;
-
-            &:before,
-            &:after {
-                content: '';
-                position: absolute;
-                top: 0;
-                width: 50%;
-                height: @grid_gutter-width;
-                border-color: @gray-40;
-                border-style: solid;
-                border-width: 0;
-            }
-
-            &:first-child {
-                padding-right: @grid_gutter-width / 2;
-
-                &:after {
-                    left: 50%;
-                    border-width: 1px 0 0 1px;
-                }
-            }
-
-            &.last-child {
-                padding-left: @grid_gutter-width / 2;
-
-                &:before{
-                    right: 50%;
-                    border-width: 1px 1px 0 0;
-                }
-            }
-
-        });
-
-        &_name {
-            .respond-to-min(@bp-sm-min, {
-                .h4();
-                margin-bottom: unit(15px / @font-size, em);
-                text-align: center;
-            });
-        }
-    }
-
-    &_role {
-        padding: @grid_gutter-width / 2;
-        padding-right: @grid_gutter-width;
-        position: relative;
-        background: @gray-10;
-        border-color: @gray-20;
-        border-style: solid;
-        border-width: 1px 0 1px 0;
-
-        .respond-to-min(@bp-sm-min, {
-            border-width: 1px 0 0 0;
-        });
-    }
-
-    &_node {
-        width: 100%;
-        margin-bottom: -1px;
-
-        .respond-to-min(@bp-sm-min, {
-            position: relative;
-            margin-bottom: @grid_gutter-width / 2;
-        });
-
-        // nested .org-chart_node blocks have different background color & borders.
-        .org-chart_nodes {
-            border-top: 5px solid @pacific-60;
-
-            .org-chart_node {
-                .respond-to-min(@bp-sm-min, {
-                    margin-bottom: 0px;
-                });
-            }
-
-            .org-chart_role {
-                border-width: 1px 0 1px 0;
-
-                .respond-to-min(@bp-sm-min, {
-                    background: @pacific-20;
-                    border-color: #E5F1FA;
-                    border-width: 0 0 1px 0;
-                });
-            }
-        }
-    }
-
-    #content-slider-container {
+    #content-slider {
+        display: none;
         position: relative;
         margin-left: -10px;
-
-        #content-slider {
-            display: none;
-        }
 
         .slick-slide {
             margin-left: 10px;
@@ -156,18 +36,31 @@
         .slick-slider {
             margin-bottom: 0;
         }
+
+        .link_text {
+            background: none;
+            color: @pacific;
+
+            &:hover {
+                color: @pacific-60;
+            }
+
+            &:active {
+                color: @navy;
+            }
+        }
     }
 
     .content-hide {
         display: none;
+        margin-bottom: @margin;
         background-color: inherit;
-        margin-bottom: 20px;
     }
 
     .content-show,
     .content-hide {
 
-        .respond-to-max(@bp-xs-max, {
+        .respond-to-max( @bp-xs-max, {
             .cf-icon,
             &:before,
             &:after {
@@ -198,52 +91,277 @@
                     color: @navy;
                 }
             }
-        });
+        } );
+    }
+
+    // Expandable Overrides
+    // TODO: Remove these when base expandable is created.
+    .m-expandable_target {
+        padding: 0;
+        border: none;
+    }
+
+    .m-expandable_content-animated {
+        padding: 0;
+    }
+
+    .m-expandable_cue-label {
+        display: inline-block;
+    }
+
+    .m-expandable_header-left {
+        width: 73%;
+    }
+
+    .m-expandable_header-right {
+        width: 27%;
     }
 }
 
-.node_expander {
-    position: absolute;
-    right: 10px;
-    top: 20px;
+.org-chart_branch {
+    /* Borders on .org-chart_branch pseudo elements (:after on first branch, :before on last)
+       draw lines connecting the branch headers to the line from .org-chart_root.
+    */
+    .respond-to-min( @bp-sm-min, {
+        .grid_column( 6 );
+        position: relative;
+        padding-top: @margin;
+        border-width: 0;
 
-    .respond-to-max(@bp-xs-max, {
-        height: 30px;
-        top: 50%;
-        margin-top: -@base-font-size-px/2;
-    });
+        &:before,
+        &:after {
+            content: '';
+            position: absolute;
+            top: 0;
+            width: 50%;
+            height: @margin;
+            border: 0 solid @spine-color;
+        }
 
-    .expandable_link {
-        font-size: @base-font-size-px;
+        &:first-child {
+            padding-right: @margin / 2;
+
+            &:after {
+                left: 50%;
+                border-width: @spine-width 0 0 @spine-width;
+            }
+        }
+
+        &:last-child {
+            padding-left: @margin / 2;
+
+            &:before{
+                right: 50%;
+                border-width: @spine-width @spine-width 0 0;
+            }
+
+            .org-chart_node:nth-last-child(2):after {
+                border: none;
+            }
+        }
+    } );
+
+    &_name {
+        position: relative;
+
+        .respond-to-min( @bp-sm-min, {
+            margin: @margin / 2 0;
+            text-align: center;
+        } );
+
+        .respond-to-max( @bp-xs-max, {
+            margin-bottom: @margin;
+            background: @white;
+
+            &:after {
+                content: '';
+                position: absolute;
+                left: 50%;
+                width: 0;
+                height: @margin;
+                border-left: @spine-width solid @spine-color;
+            }
+        } );
     }
 }
 
-.role {
+/* Lines of the org chart are drawn with before & after
+   pseudo elements applied to .org-chart_branches & .org-chart_branch.
+*/
+.org-chart_branches {
+    padding-top: @margin;
+
+    /* :before pseudo element's left border draws a centered vertical line
+       down from .org-chart_root to .org-chart_branches.
+    */
+    .respond-to-min( @bp-sm-min, {
+        position: relative;
+
+        &:before {
+            content: '';
+            position: absolute;
+            top: 0;
+            left: 50%;
+            width: 0;
+            height: @margin;
+            border-left: @spine-width solid @spine-color;
+        }
+    } );
+}
+
+.org-chart_categories {
+    .link_item {
+        margin-bottom: 0;
+        border-top: 1px solid @node-border-color;
+        background: @gray-5;
+
+        &:last-child {
+            border-bottom: 1px solid @node-border-color;
+        }
+    }
+
+    .link_text {
+       border: none;
+    }
+}
+
+.org-chart_node {
+    .webfont-regular();
+    position:relative;
+    box-sizing: border-box;
+    padding: @margin @margin / 2;
+    border-bottom: @node-border-width solid @node-border-color;
+    margin: 0 auto @margin / 2;
+    background: @white;
+
+    // nested .org-chart_node blocks have different borders.
+    .org-chart_nodes {
+        border: none;
+
+        .org-chart_node {
+            padding-top: @margin / 2;
+            border-width: 1px;
+            margin-bottom: 0;
+
+            &:after {
+                border: none;
+            }
+
+            &:last-child {
+                border: none;
+            }
+
+            .respond-to-max( @bp-xs-max, {
+                margin: 0;
+            } );
+        }
+    }
+
+    &:not(:last-child):after {
+        content: '';
+        position: absolute;
+        left: 50%;
+        bottom: -(@grid_gutter-width / 2 + @node-border-width);
+        width: 0;
+        height: @grid_gutter-width / 2;
+        border-left: @spine-width solid @spine-color;
+    }
+
+    .respond-to-max( @bp-xs-max, {
+        &:not(:first-child) {
+            margin: @margin / 2;
+        }
+
+        &:nth-last-child(2):after {
+            border: none;
+        }
+    } );
+}
+
+.org-chart_node__root {
+    margin-bottom: 0;
+    max-width: @node-width__desktop;
+
+    .respond-to-max( @bp-xs-max, {
+        max-width: @node-width__mobile;
+        padding-top: @margin;
+        padding-bottom: @margin;
+        border: none;
+        margin: 0;
+
+        .org-chart_role {
+            text-align: center;
+        }
+
+        &:after {
+            border: none;
+        }
+    } );
+
+    .respond-to-range( @bp-sm-min, @bp-lg-max, {
+        max-width: @node-width__tablet;
+    } );
+}
+
+.org-chart_node_expander {
+    overflow: auto;
+    padding: @margin / 2 0;
+    border-top: 1px solid @node-border-color;
+    border-bottom: 1px solid @node-border-color;
+    margin-top: @margin;
+}
+
+.org-chart_node_more-info {
+    .u-link__colors(@pacific, @pacific, @pacific-60, @pacific, @navy);
+    .u-link__no-border();
+
     display: block;
+    margin-top: @margin;
+}
 
-    &_office {
+.org-chart_role {
+    text-align: left;
+
+    &_name,
+    &_title {
+        .webfont-regular();
         display: block;
-        .h6();
     }
 
     &_name {
-        display: block;
         .webfont-medium();
-    }
-
-    &_title {
-        display: block;
     }
 }
 
-.link-text {
-    color: @pacific;
+.org-chart_legend {
+    padding: @margin;
+    border-top: @node-border-width solid @green;
+    margin-top:  @margin;
+    background: @white;
 
-    &:hover {
-        color: @pacific-60;
+    &_symbol {
+        display: block;
+        width: @margin;
+        float: left;
     }
 
-    &:active{
-        color: @navy;
+    &_definition {
+        display: block;
+        margin-left: @margin;
     }
+
+    .respond-to-max( @bp-xs-max, {
+        margin: @margin / 2;
+    } );
+}
+
+.org-chart_footer {
+    border-color: @node-border-color;
+    margin-top: @margin * 2;
+
+    .respond-to-min( @bp-sm-min, {
+        padding-top: 0;
+        margin-top: @margin;
+        border: none;
+    } );
 }

--- a/cfgov/unprocessed/css/pages/business.less
+++ b/cfgov/unprocessed/css/pages/business.less
@@ -22,20 +22,6 @@
     });
 }
 
-.nav__small-business {
-    .expandable_header {
-        position: relative;
-    }
-
-    .expandable_header-right {
-        .node_expander();
-        .respond-to-max(@bp-xs-max, {
-            margin-top: -@base-font-size-px;
-        });
-        top: @base-font-size-px;
-    }
-}
-
 .business_page-content {
     .list__download();
 }

--- a/cfgov/unprocessed/js/modules/MobileCarousel.js
+++ b/cfgov/unprocessed/js/modules/MobileCarousel.js
@@ -35,10 +35,6 @@ function MobileCarousel( breakpointPx ) {
   * @returns {Object} A reference to the instance.
   */
   function enableOn( selector ) {
-    if ( $( 'html' ).hasClass( 'lt-ie9' ) ) {
-      return this;
-    }
-
     _targetDom = $( selector );
     if ( !selector || !_targetDom ) {
       throw new Error( 'MobileCarousel.enableOn requires a valid selector!' );

--- a/cfgov/unprocessed/js/routes/the-bureau/bureau-structure/index.js
+++ b/cfgov/unprocessed/js/routes/the-bureau/bureau-structure/index.js
@@ -1,6 +1,8 @@
 /* ==========================================================================
    Bureau structure.
    Scripts for `/the-bureau/bureau-structure/`.
+
+   TODO: Remove jQuery, burn slick.js, and refactor ContentSlider.js.
    ========================================================================== */
 
 'use strict';
@@ -10,14 +12,11 @@ require( 'slick' );
 
 var ContentSlider = require( '../../../modules/ContentSlider' );
 var BreakpointHandler = require( '../../../modules/BreakpointHandler' );
+var Expandable = require( '../../../molecules/Expandable' );
 
 var _slider;
 
 function init() {
-  // If not in IE.
-  if ( $( 'html' ).hasClass( 'lt-ie9' ) ) {
-    return;
-  }
 
   var bpSettings = {
     breakpoint: 600,
@@ -27,18 +26,51 @@ function init() {
   };
 
   new BreakpointHandler( bpSettings ); // eslint-disable-line no-new, no-inline-comments, max-len
+
+  initExpandables();
+}
+
+function initExpandables() {
+  // Initialize the Expandable.
+  var selector = '.m-expandable';
+  var expandables = document.querySelectorAll( selector );
+  var expandable;
+  for ( var i = 0, len = expandables.length; i < len; i++ ) {
+    expandable = new Expandable( expandables[i] );
+    expandable.init();
+  }
 }
 
 function _createSlider() {
-  // Close any open expandables.
-  $( '.org-chart' )
-    .find( '.expandable__expanded .expandable_target' ).click();
+  var $legend = $( '.org-chart_legend' ).parent().clone();
+  var $contentSlider = $( '#content-slider' );
   // Hide org chart branches.
   $( '.org-chart_branches' ).hide();
   // Show content slider & mobile nav links.
   $( '#content-slider, .content-hide' ).show();
   // Initialize slider.
-  _slider = new ContentSlider( '#content-slider', 1 );
+  _slider = new ContentSlider( $contentSlider, 1 );
+
+  // Overwrite the default method to set height
+  // There are performance implications of doing so
+  // as noted here https://github.com/kenwheeler/slick/issues/83.
+  // ( Although wildly exaggerated. )
+  _slider.slickObj.setHeight = function setHeight() {
+      this.$list.css( 'height', 'auto' );
+  };
+
+  _slider.slickObj.options.onAfterChange =
+    function onAfterChange( slider, currInd, targetInd ) {
+      // Add legend to the nodes list if doesn't exist.
+      var add_legend = currInd > 0 &&
+                       $( '.slick-active .org-chart_legend' ).length === 0;
+      if ( add_legend ) {
+        $( '.slick-active > .org-chart_nodes' ).append( $legend );
+      }
+      $contentSlider.height( 'auto' );
+      // Init the Expandable after the nodes have been cloned.
+      initExpandables();
+    };
 }
 
 function _destroySlider() {


### PR DESCRIPTION
Updating the Bureau Structure to match the new design

## Additions

- Added Jinja, CSS, and JS to update the Bureau Structure to match the new design.

## Removals

- Removed some legacy code related to IE8


## Testing

- Visit `http://localhost:8000/the-bureau/bureau-structure/`.

## Review

- @KimberlyMunoz 
- @anselmbradford 
- @jimmynotjim 

## Screenshots

- 
<img width="393" alt="screen shot 2016-03-09 at 8 52 44 am" src="https://cloud.githubusercontent.com/assets/1696212/13637271/7424eb52-e5d4-11e5-95ed-f1c19af7d193.png">
<img width="829" alt="screen shot 2016-03-09 at 8 52 27 am" src="https://cloud.githubusercontent.com/assets/1696212/13637273/742d6b2e-e5d4-11e5-9d6c-6dade0ba1f6b.png">
<img width="1014" alt="screen shot 2016-03-09 at 8 52 08 am" src="https://cloud.githubusercontent.com/assets/1696212/13637272/7428c6f0-e5d4-11e5-9b6f-54a5947b54d1.png">




## Notes

- There is a lot of css which hopefully can be reduced. 

## Todos

- Ask for Gods forgiveness for writing jQuery.

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
