### PR TITLE
Fix sharing bug that would prevent the display of tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Fixed a bug where the search input and button in the header were misaligned.
 - Fixed urls document type for career pages.
 - Fixed stacking bug in header search.
+- Fixed page saving bug that would prevent the display of a page's tags
 
 ## 3.0.0-3.0.0 - 2016-02-11
 

--- a/cfgov/v1/wagtail_hooks.py
+++ b/cfgov/v1/wagtail_hooks.py
@@ -1,4 +1,5 @@
 import os
+import json
 
 from django.http import Http404
 from django.contrib.auth.models import Permission
@@ -41,13 +42,12 @@ def share_the_page(request, page):
     if not is_publishing:
         page.live = False
     latest = page.get_latest_revision()
-    latest.delete()
-    revision = page.save_revision()
-
-    # If the page is being published, the publish the newly created revision.
+    content_json = json.loads(latest.content_json)
+    content_json['live'], content_json['shared'] = page.live, page.shared
+    latest.content_json = json.dumps(content_json)
+    latest.save()
     if is_publishing:
-        revision.publish()
-
+        latest.publish()
 
 @hooks.register('before_serve_page')
 def check_request_site(page, request, serve_args, serve_kwargs):


### PR DESCRIPTION
The wagtail_hooks.py file deletes the latest revision and creates a new one. It's not known why a new revision would lose the tag references, but modifying the latest instead of deleting it and creating a new one seems like a better choice anyway.

## Changes

- sharing a page now modifies the wagtail created revision instead of deleting it and creating a new one

## Testing

- Create, save, share, publish a page with tags.
 - Verify that the tags are saved at each step.

## Review

- @kave 

