### PR TITLE
Remove order field and let wagtail handle the ordering of pages

### DIFF
--- a/cfgov/jinja2/v1/_includes/organisms/secondary-navigation.html
+++ b/cfgov/jinja2/v1/_includes/organisms/secondary-navigation.html
@@ -37,7 +37,7 @@
     </ul>
 {% endmacro %}
 
-{% set nav_items, has_children = get_secondary_nav_items(page) %}
+{% set nav_items, has_children = get_secondary_nav_items(page, request.site.hostname) %}
 
 {# TODO: This should be hidden on tablets as well. #}
 <nav class="o-secondary-navigation

--- a/cfgov/v1/forms.py
+++ b/cfgov/v1/forms.py
@@ -15,7 +15,7 @@ from django.forms import widgets
 
 from sheerlike.templates import date_formatter
 from .models import ref
-from .models.learn_page import AbstractFilterPage
+from .models.base import CFGOVPage
 from .util.util import most_common
 
 
@@ -208,7 +208,7 @@ class FilterableListForm(forms.Form):
     def set_topics(self, parent, hostname):
         tags = [tag for tags in
                      [page.tags.names() for page in
-                      AbstractFilterPage.objects.live_shared(hostname).descendant_of(parent)]
+                      CFGOVPage.objects.live_shared(hostname).descendant_of(parent)]
                      for tag in tags]
         # Orders by most to least common tags
         options = most_common(tags)
@@ -221,7 +221,7 @@ class FilterableListForm(forms.Form):
     # Populate Authors' choices
     def set_authors(self, parent, hostname):
         all_authors = [author for authors in [page.authors.names() for page in
-                       AbstractFilterPage.objects.live_shared(hostname).descendant_of(
+                       CFGOVPage.objects.live_shared(hostname).descendant_of(
                        parent)] for author in authors]
         # Orders by most to least common authors
         self.fields['authors'].choices = [(author, author) for author in

--- a/cfgov/v1/migrations/0058_auto_20160309_1813.py
+++ b/cfgov/v1/migrations/0058_auto_20160309_1813.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('v1', '0057_auto_20160304_1651'),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name='browsefilterablepage',
+            name='secondary_nav_order',
+        ),
+        migrations.RemoveField(
+            model_name='browsepage',
+            name='secondary_nav_order',
+        ),
+    ]

--- a/cfgov/v1/models/base.py
+++ b/cfgov/v1/models/base.py
@@ -157,6 +157,15 @@ class CFGOVPage(Page):
                 return ancestors[i+1:]
         return []
 
+    def get_appropriate_siblings(self, hostname, inclusive=True):
+        return CFGOVPage.objects.live_shared(hostname).sibling_of(self, inclusive)
+
+    def get_next_appropriate_siblings(self, hostname, inclusive=False):
+        return self.get_appropriate_siblings(hostname=hostname, inclusive=inclusive).filter(path__gte=self.path).order_by('path')
+
+    def get_prev_appropriate_siblings(self, hostname, inclusive=False):
+        return self.get_appropriate_siblings(hostname=hostname, inclusive=inclusive).filter(path__lte=self.path).order_by('-path')
+
     @property
     def status_string(self):
         if not self.live:

--- a/cfgov/v1/models/browse_filterable_page.py
+++ b/cfgov/v1/models/browse_filterable_page.py
@@ -24,7 +24,6 @@ class BrowseFilterablePage(base.CFGOVPage):
         ('full_width_text', organisms.FullWidthText()),
         ('filter_controls', organisms.FilterControls()),
     ])
-    secondary_nav_order = models.IntegerField()
 
     # General content tab
     content_panels = base.CFGOVPage.content_panels + [
@@ -32,15 +31,11 @@ class BrowseFilterablePage(base.CFGOVPage):
         StreamFieldPanel('content'),
     ]
 
-    settings_panels = base.CFGOVPage.settings_panels + [
-        FieldPanel('secondary_nav_order'),
-    ]
-
     # Tab handler interface
     edit_handler = TabbedInterface([
         ObjectList(content_panels, heading='General Content'),
         ObjectList(base.CFGOVPage.sidefoot_panels, heading='Footer'),
-        ObjectList(settings_panels, heading='Configuration'),
+        ObjectList(base.CFGOVPage.settings_panels, heading='Configuration'),
     ])
 
     template = 'browse-filterable/index.html'
@@ -115,8 +110,9 @@ class BrowseFilterablePage(base.CFGOVPage):
                 if not categories or 'blog' in categories:
                     blog_cats = [c[0] for c in ref.categories[1][1]]
                     blog_q = Q('categories__name__in', blog_cats)
-        return AbstractFilterPage.objects.live_shared(hostname).descendant_of(
-            self).filter(form.generate_query() | blog_q)
+        results = base.CFGOVPage.objects.live_shared(hostname).descendant_of(
+            self).filter(form.generate_query() | blog_q).specific()
+        return [page for page in results if isinstance(page, AbstractFilterPage)]
 
 
 class EventArchivePage(BrowseFilterablePage):

--- a/cfgov/v1/models/browse_page.py
+++ b/cfgov/v1/models/browse_page.py
@@ -13,6 +13,7 @@ from . import molecules
 from . import organisms
 from ..util.util import get_secondary_nav_items
 
+
 class BrowsePage(CFGOVPage):
     header = StreamField([
         ('text_introduction', molecules.TextIntroduction()),
@@ -29,7 +30,6 @@ class BrowsePage(CFGOVPage):
         ('expandable_group', organisms.ExpandableGroup()),
         ('table', organisms.Table()),
     ], blank=True)
-    secondary_nav_order = models.IntegerField(default=1)
 
     # General content tab
     content_panels = CFGOVPage.content_panels + [
@@ -37,15 +37,11 @@ class BrowsePage(CFGOVPage):
         StreamFieldPanel('content'),
     ]
 
-    settings_panels = CFGOVPage.settings_panels + [
-        FieldPanel('secondary_nav_order'),
-    ]
-
     # Tab handler interface
     edit_handler = TabbedInterface([
         ObjectList(content_panels, heading='General Content'),
         ObjectList(CFGOVPage.sidefoot_panels, heading='Sidebar'),
-        ObjectList(settings_panels, heading='Configuration'),
+        ObjectList(CFGOVPage.settings_panels, heading='Configuration'),
     ])
 
     template = 'browse-basic/index.html'

--- a/cfgov/v1/models/learn_page.py
+++ b/cfgov/v1/models/learn_page.py
@@ -75,8 +75,6 @@ class AbstractFilterPage(CFGOVPage):
     # This page class cannot be created.
     is_creatable = False
 
-    objects = CFGOVPage.objects
-
     class Meta:
         ordering = ('date_published',)
 

--- a/cfgov/v1/util/util.py
+++ b/cfgov/v1/util/util.py
@@ -1,5 +1,6 @@
 import collections
 import re
+import os
 from itertools import chain
 from time import time
 from django.conf import settings
@@ -66,36 +67,35 @@ def get_form_id(page, get_request):
 
 
 # For use by Browse type pages to get the secondary navigation items
-def get_secondary_nav_items(current):
+def get_secondary_nav_items(current, hostname):
     from ..templatetags.share import get_page_state_url
+    on_staging = os.environ.get('STAGING_HOSTNAME') == hostname
     nav_items = []
-    parent = current.get_parent()
+    parent = current.get_parent().specific
     page = parent if 'Browse' in parent.specific_class.__name__ else current
     # Use chain to add the page object in from the function call since the page
     # argument passed could be different than the one in the database, as is
     # the case with "previewing".
-    for sibling in list(chain([page], page.get_siblings(inclusive=False))):
+    for sibling in page.get_appropriate_siblings(hostname):
         # Only if it's a Browse type page
         if 'Browse' in sibling.specific_class.__name__:
+            sibling = page if page.id == sibling.id else sibling
             item = {
                 'title': sibling.title,
                 'slug': sibling.slug,
                 'url': get_page_state_url({}, sibling),
-                'order': sibling.specific.secondary_nav_order,
                 'children': [],
             }
-            for child in sibling.get_children():
+            children = sibling.get_children().specific()
+            for child in [c for c in children if (on_staging and c.shared) or c.live]:
                 if 'Browse' in child.specific_class.__name__:
                     item['children'].append({
                         'title': child.title,
                         'slug': child.slug,
                         'url': get_page_state_url({}, child),
-                        'order': child.specific.secondary_nav_order,
                     })
-            item['children'] = sorted(item['children'], key=lambda x: x['order'])
             nav_items.append(item)
     # Return a boolean about whether or not the current page has Browse children
-    nav_items = sorted(nav_items, key=lambda x: x['order'])
     for item in nav_items:
         if get_page_state_url({}, page) == item['url'] and item['children']:
             return nav_items, True


### PR DESCRIPTION
The order field was unnecessary because Wagtail handles ordering itself!

## Additions

- functions to retrieve appropriate siblings/children

## Removals

- nav order field on browse type pages

## Testing

- click the button to use the Wagtail ordering (pic below)
- order them hold you want by drag/drop
- look at a browse type page's secondary nav to see the appropriate order

## Review

- @kave 
- @richaagarwal 

## Screenshots
![screen shot 2016-03-09 at 3 39 41 pm](https://cloud.githubusercontent.com/assets/1412978/13649750/2f8eb660-e60d-11e5-86e4-f55bc0480bce.png)
