### PR TITLE
Job template page changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,7 +64,11 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Add two categories to the Implementation Resource group.
 - Updated the homepage based on user feedback.
 - Renamed preview_link_url/text => secondary_link_url/text
+<<<<<<< HEAD
 - Updated Categories for Research & Reports
+=======
+- Changes to job listing pages
+>>>>>>> Fixing the template for the individual job posting
 
 ### Removed
 - Removed normalize and normalize-legacy from main less file because CF already includes it.

--- a/cfgov/jinja2/v1/careers/_single.html
+++ b/cfgov/jinja2/v1/careers/_single.html
@@ -1,4 +1,4 @@
-{% extends 'layout-side-nav.html' %}
+{% extends 'layout-2-1-bleedbar.html' %}
 {% import '_vars-careers.html' as vars with context %}
 {% set breadcrumb_items = [(vars.path, vars.path, 'Careers'),
                             (vars.path + 'current-openings/',
@@ -12,7 +12,6 @@
 {% block desc -%}
     {# TODO: Update admin to include excerpt. #}
     {{ career.excerpt | striptags }}
-    }
 {%- endblock %}
 
 {% block content_main_modifiers -%}
@@ -112,15 +111,11 @@
                 }) }}
             </div>
         </div>
-        <div class="block
-                    block__bg
-                    block__border
-                    block__sub">
+        <div class="block">
             <h3>Before you apply</h3>
             <p>
                 {# TODO: Replace with real content. #}
             </p>
-
             <ul class="list list__links">
                 <li class="list_item">
                     <a class="jump-link"
@@ -136,24 +131,74 @@
                 </li>
             </ul>
         </div>
-        <div class="block block__flush-top">
-            {% set applicant_type = career.applicant_types[0] %}
+        {% for applicant_type in career.applicant_types %}
+        <div class="block block__bg block__border">
             <h4>{{ applicant_type.application_type.name }}</h4>
             <p>{{ applicant_type.application_type.description | striptags }}</p>
-            <div class="content-l">
-                <div class="content-l_col content-l_col-1-4">
-                    <a class="btn" href="{{ applicant_type.usajobs_url }}">Apply now</a>
-                </div>
-                <div class="content-l_col content-l_col-3-4">
-                    <h4 class="u-mb0">
-                        You are about to leave consumerfinance.gov.
-                    </h4>
-                    <p>
-                        To finish the application, you must go to USAJobs.gov.
-                    </p>
-                </div>
-            </div>
+
+            <p><a class="btn" href="{{ applicant_type.usajobs_url }}">Apply now</a></p>
+
+            <p>
+                You are about to leave consumerfinance.gov. To submit the application, you must go to USAJobs.gov.
+            </p>
         </div>
+        {% endfor %}
     </section>
+
+{% endblock %}
+
+{% block content_sidebar scoped  %}
+
+<div class="block block__flush-top">
+    <h2 class="header-slug">
+        <span class="header-slug_inner">
+            Before you apply
+        </span>
+    </h2>
+    <p>
+        Consider exploring our information about working at the CFPB
+        and our application process.
+    </p>
+    <ul class="list list__links u-mb0">
+        <li class="list_item">
+            <a href="/careers/working-at-cfpb" class="list_link">
+                Working at the CFPB
+            </a>
+        </li>
+        <li class="list_item">
+            <a href="/careers/application-process" class="list_link">
+                Learn how the application process works
+            </a>
+        </li>
+    </ul>
+</div>
+
+<div class="block block__flush-top">
+    {%- import 'related-links.html' as related_links -%}
+    {{- related_links.render([
+      [ '/blog/',
+        'CFPB Blog' ],
+      [ '/newsroom/',
+        'Newsroom' ],
+      [ '/offices/office-of-civil-rights/',
+        'Office of Civil Rights' ]
+    ]) -}}
+</div>
+
+<h2 class="header-slug">
+    <span class="header-slug_inner">
+        Follow us on LinkedIn
+    </span>
+</h2>
+<p data-qa-hook="info-section-desc">
+    The CFPB is one of the most searched for agencies
+    in the federal government.
+    Connect with us to stay updated on the work
+    we do and new opportunities to be a part of it.
+</p>
+<a href="https://www.linkedin.com/company/consumer-financial-protection-bureau"
+   class="jump-link jump-link__external-link jump-link__underline">
+    Follow us on LinkedIn
+</a>
 
 {% endblock %}

--- a/cfgov/unprocessed/css/cf-theme-overrides.less
+++ b/cfgov/unprocessed/css/cf-theme-overrides.less
@@ -175,7 +175,7 @@
 @content_main-border:           @gray-40;
 
 // .content_sidebar
-@content_sidebar-bg:            @gray-10;
+@content_sidebar-bg:            @gray-5;
 @content_sidebar-border:        @gray-40;
 
 // .content_bar


### PR DESCRIPTION
Changes to the job template page to make them match the wireframes at [ghe]/flapjack/careers/issues/5#issuecomment-70755

## Changes

- Changed the page to one similar to the landing page
- Added sidebar widgets similar to the ones in the prefooter of other career pages
- Changed the blocks at the end to border each application process.

## Testing

- Visit any of the job pages. "Reporting Analyst" is a good example of one with two ways to apply.
## Review

- @anselmbradford 
- @sebworks 
- @jimmynotjim 

## Screenshots

![image](https://cloud.githubusercontent.com/assets/1860176/13654112/002fa41c-e624-11e5-8619-720214a224a8.png)

![image](https://cloud.githubusercontent.com/assets/1860176/13654119/08ece862-e624-11e5-8ca4-cdceca6d2abe.png)


## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
