### PR TITLE
Fixes/Test for External Site Redirect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Frontend: Added utility classes for translation and opacity CSS transitions.
 - Script to semi-automate importing refresh data
 - Provided option to exclude sibling pages in secondary navigation
+- Added tests for `external-site-redirect.js`
 
 ### Changed
 - Converted the project to Capital Framework v3
@@ -68,6 +69,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Updated Categories for Research & Reports.
 - Changes to job listing pages.
 - included backend support for Video in FCM
+- Changed `external-site-redirect.js` to remove jQuery and fix Regex.
 
 ### Removed
 - Removed normalize and normalize-legacy from main less file because CF already includes it.

--- a/cfgov/unprocessed/js/modules/external-site-redirect.js
+++ b/cfgov/unprocessed/js/modules/external-site-redirect.js
@@ -6,29 +6,39 @@
    ========================================================================== */
 
 'use strict';
-var $ = require( 'jquery' );
 
 /**
  * Set up event handler for links and determine if link is external or not.
  */
 function init() {
-  $( '#main, footer' ).on( 'click', 'a', function( event ) {
+  var elements = document.querySelectorAll( '#main, body > footer' );
 
-    var url = this.href;
-    // Regex to determine if link URL is external.
-    // Futher explanation can be viewed
-    // at https://regex101.com/r/xT7sL5/2.
-    var externalURLArray =
-        ( /(https?:\/\/(?:www\.)?(?!.*gov)(?!(content\.)?localhost).*)/g )
-        .exec( url );
+  for ( var i = 0; i < elements.length; ++i ) {
+    elements[i].addEventListener( 'click', _handleClick, false );
+  }
+}
 
-    if ( $.isArray( externalURLArray ) ) {
-      event.preventDefault();
-      window.location = '/external-site/?ext_url=' +
-                        encodeURIComponent( externalURLArray[1] );
-    }
+/**
+ * Handle the element click event.
+ * @param {MouseEvent} event A click event.
+ */
+function _handleClick( event ) {
+  var element = event.target;
+  if ( element && element.tagName !== 'A' ) element = element.parentNode;
+  if ( element === null || element.tagName !== 'A' ) return;
 
-  } );
+  // Regex to determine if link URL is external.
+  // Futher explanation can be viewed
+  // at https://regex101.com/r/xT7sL5/6.
+  var externalURLArray =
+    ( /(https?:\/\/(?:www\.)?(?![^\?]+gov)(?!(content\.)?localhost).*)/g )
+    .exec( element.href );
+
+  if ( Array.isArray( externalURLArray ) ) {
+    event.preventDefault();
+    window.location.href = '/external-site/?ext_url=' +
+     encodeURIComponent( externalURLArray[1] );
+  }
 }
 
 // Expose public methods.

--- a/test/unit_tests/modules/external-site-redirect-spec.js
+++ b/test/unit_tests/modules/external-site-redirect-spec.js
@@ -1,0 +1,105 @@
+'use strict';
+
+var chai = require( 'chai' );
+var expect = chai.expect;
+var jsdom = require( 'mocha-jsdom' );
+
+var clickEvent;
+var link;
+var span;
+var shouldRedirectURLArray = [
+  'http://www.consumerfinance.net/',
+  'http://www.google.com/',
+  'https://www.facebook.com/dialog/share?app_id=210516218981921' +
+  '&display=page&href=http%3A//test.demo.gov/' +
+  'the-bureau/about-deputy-director/&redirect_uri=http%3A//test.' +
+  'demo.gov/the-bureau/about-deputy-director/',
+  'https://www.linkedin.com/company/consumer-financial-protection-bureau'
+];
+var shouldNotRedirectURLArray = [
+  'http://localhost:8000/blog/',
+  'http://beta.consumerfinance.gov/careers/working-at-cfpb/',
+  'https://test.demo.gov/',
+  'http://www.federalreserve.gov/oig/default.html',
+  'http://beta.consumerfinance.gov/offices/open-government/'
+];
+
+var EXTERNAL_SITE_PATH = '/external-site/?ext_url=';
+var SITE_URL = 'www.example.com';
+
+describe( 'External Site', function() {
+
+  jsdom( {
+    created: function( error, window ) {
+      if ( error ) console.log( error );
+      var _href;
+
+      delete window.location;
+      window.location = {};
+
+      Object.defineProperty( window.location, 'href', {
+        get: function() {
+          return _href;
+        },
+        set: function( url ) {
+          _href = url;
+        },
+        enumerable: true,
+        configurable: true
+      } );
+    }
+  } );
+
+  beforeEach( function() {
+    span = document.createElement( 'span' );
+    span.textContent = 'let slip the dogs of war';
+    link = document.createElement( 'a' );
+    link.appendChild( span );
+
+    document.body.id = 'main';
+    document.body.appendChild( link );
+
+    clickEvent = document.createEvent( 'Event' );
+    clickEvent.initEvent( 'click', true, true );
+    window.location.href = SITE_URL;
+
+    require( '../../../cfgov/unprocessed/js/modules/external-site-redirect.js' )
+      .init();
+  } );
+
+  describe( 'Redirect', function() {
+
+    it( 'should redirect external links', function() {
+      shouldRedirectURLArray.forEach( function( url ) {
+        link.href = url;
+        link.dispatchEvent( clickEvent );
+        expect( window.location.href ).to
+          .equal( EXTERNAL_SITE_PATH + encodeURIComponent( url ) );
+      } );
+    } );
+
+    it( 'should not redirect internal links', function() {
+      shouldNotRedirectURLArray.forEach( function( url ) {
+        link.href = url;
+        link.dispatchEvent( clickEvent );
+        expect( window.location.href ).to.equal( SITE_URL );
+      } );
+    } );
+
+    it( 'should handle click events when anchor links have spans', function() {
+      shouldNotRedirectURLArray.forEach( function( url ) {
+        link.href = url;
+        span.dispatchEvent( clickEvent );
+        expect( window.location.href ).to.equal( SITE_URL );
+      } );
+    } );
+
+    it( 'should do nothing when a click event is fired on non-anchor elements',
+    function() {
+      document.body.dispatchEvent( clickEvent );
+      expect( window.location.href ).to.equal( SITE_URL );
+    } );
+
+  } );
+
+} );


### PR DESCRIPTION
Fixes/Test for External Site Redirect

## Additions

- Added Unit test for External Site Redirect.

## Removals

- Removed the need for jQuery.

## Changes

- Changed the regex to fix an issue where it wasn't catching query-string params. 

## Testing

- `Visit http://localhost:8000/` and click links in the footer. All non gov links should be redirected.

## Review

- @jimmynotjim 
- @KimberlyMunoz 
- @anselmbradford 

## Notes

- This assumes there is only one level nested spans within an anchor element. 
- The redirect test is very expensive to run on every click. In a beautiful world this wouldn't exist.

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)

