### PR TITLE
resolved merge conflict override

### DIFF
--- a/cfgov/v1/models/browse_filterable_page.py
+++ b/cfgov/v1/models/browse_filterable_page.py
@@ -110,8 +110,13 @@ class BrowseFilterablePage(base.CFGOVPage):
                 if not categories or 'blog' in categories:
                     blog_cats = [c[0] for c in ref.categories[1][1]]
                     blog_q = Q('categories__name__in', blog_cats)
-        return AbstractFilterPage.objects.live_shared(hostname).descendant_of(self).filter(
-            form.generate_query() | blog_q).order_by('-date_published')
+
+        results = base.CFGOVPage.objects.live_shared(hostname).descendant_of(
+            self).filter(form.generate_query() | blog_q).specific()
+
+        filter_pages = [page for page in results if isinstance(page, AbstractFilterPage)]
+        filter_pages.sort(key=lambda x: x.date_published, reverse=True)
+        return filter_pages
 
 
 class EventArchivePage(BrowseFilterablePage):


### PR DESCRIPTION
@kurtw 

Accidentally deleted  your changes to the browse filterable `get_page_set` function. 
I've reverted and included changes to maintain the order by published date functionality now that `CFGOVPage` pages are used to get the status appropriate set.