### PR TITLE
Updates the global search for no-js and IE 8-10 fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Included Password Complexity rules for admin user creation/editing flow
 - Enabled email backend for Production settings
 - Frontend: Added utility classes for translation and opacity CSS transitions.
-- Added SublandingFilterablePage class 
+- Added SublandingFilterablePage class
 - Script to semi-automate importing refresh data
 - Provided option to exclude sibling pages in secondary navigation
 - Added tests for `external-site-redirect.js`
@@ -72,6 +72,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Changes to job listing pages.
 - included backend support for Video in FCM
 - Changed `external-site-redirect.js` to remove jQuery and fix Regex.
+- Updated the global search for no-js and IE 8-10 fixes.
 
 ### Removed
 - Removed normalize and normalize-legacy from main less file because CF already includes it.

--- a/cfgov/unprocessed/css/misc.less
+++ b/cfgov/unprocessed/css/misc.less
@@ -645,12 +645,14 @@
         height: 5px;
         width: 100%;
 
-        position: relative;
-        top: 5px;
+        position: absolute;
+        // Offset for thickness of shadow.
+        bottom: -5px;
+        left: 0;
 
         background: @gray;
         // Whitespace in content so element can have dimensions set.
-        content: '\a0';
+        content: '';
         opacity: 0.2;
     }
 }

--- a/cfgov/unprocessed/css/molecules/global-search.less
+++ b/cfgov/unprocessed/css/molecules/global-search.less
@@ -92,23 +92,22 @@
     - cfgov-molecules
 */
 
-.js .m-global-search {
+.m-global-search {
+    // Hide search unless we have JS or it's a desktop-ish size
+    display: none;
+
+    .js & {
+        display: block;
+    }
 
     &_trigger {
-        height: unit( 45px / 18px, em );
-        min-width: unit( 45px / 18px, em );
-        padding-left: unit( @grid_gutter-width / 2 / 18px, em );
-        padding-right: unit( @grid_gutter-width / 2 / 18px, em );
-
-        // TODO: Check that float doesn't spill outside molecule.
-        float: right;
-        position: relative;
-
-        background: @white;
+        // Resets
+        background-color: transparent;
         border: none;
-        color: @black;
-        font-size: unit( 18px / @base-font-size-px, em );
-        pointer-events: auto;
+        display: none;
+
+        box-sizing: border-box;
+        border-left: 1px solid transparent;
 
         &:focus {
             outline: 1px dotted @black;
@@ -116,15 +115,45 @@
 
         &:before {
             .cf-icon();
+
             content: @cf-icon-search;
-            font-size: unit( 20px / 18px, em );
+        }
+
+        // Only show trigger if we have JS
+        .js & {
+            display: block;
         }
     }
 
     &_content {
-        padding-top: unit( @grid_gutter-width / 4 / @base-font-size-px, em );
         position: absolute;
+        left: 0;
 
+        &-form {
+            width: 100%;
+        }
+
+        // Only add transforms if we have JS
+        .js & {
+            &.u-invisible {
+                overflow-x: hidden;
+            }
+
+            &-form {
+                position: absolute;
+
+                transform: translateX( 100% );
+                transition: transform 0.25s ease-out;
+            }
+        }
+
+        .js &[aria-expanded="true"] &-form {
+            display: block;
+
+            transform: translateX( 0 );
+        }
+
+        // Hide suggestions outside of tablet sizes
         &-suggestions {
             display: none;
 
@@ -135,80 +164,71 @@
         }
     }
 
-    // Tablet size and below.
+    // Up to desktops
     .respond-to-max( @bp-sm-max, {
-        // Absolute position when there is a flyout at mobile/tablet sizes.
-        // Make the height large so that the overflowing flyout can be hidden,
-        // but not get cropped when it's visible.
-        height: 500px;
-        width: 100%;
-        position: absolute;
-        top: 0;
-        overflow-x: hidden;
-        // TODO: This will be ignored in IE8-10,
-        //       leading to the overflow preventing clicks on the links.
-        pointer-events: none;
+        &_trigger{
+            padding-top: unit( @grid_gutter-width / 2 / 16px, em );
+            padding-bottom: unit( @grid_gutter-width / 2 / 16px, em );
+            height: unit( 60px / @base-font-size-px, em );
+            min-width: unit( 60px / @base-font-size-px, em );
 
-        &_trigger {
-            height: unit( 60px / 18px, em );
-            min-width: unit( 60px / 18px, em );
-            padding-top: unit( @grid_gutter-width / 2 / 18px, em );
-            padding-bottom: unit( @grid_gutter-width / 2 / 18px, em );
-            display: block;
+            &:before {
+                font-size: unit( 20px / 16px, em );
+            }
 
             &[aria-expanded="true"] {
                 background: @gray-10;
                 border-left: 1px solid @gray-40;
-                color: @black;
 
+                // Show "X" icon when flyout is open
                 &:before {
-                    .cf-icon();
                     content: @cf-icon-delete;
                 }
             }
         }
 
-        &_content {
-            box-sizing: border-box;
+         &_content {
             width: 100%;
 
-            position: absolute;
-            left: 0;
-            // Offset for height of trigger button.
-            top: 60px;
-            z-index: 10;
-
-            background-color: @gray-5;
-            border-top: 1px solid @gray-40;
-            border-bottom: 1px solid @gray-40;
-            pointer-events: auto;
-
             &-form {
-                padding-top: @margin__em;
-                padding-left: @margin_half__em;
-                padding-right: @margin_half__em;
-                padding-bottom: @margin_half__em;
-            }
+                .u-drop-shadow-after();
 
-            .u-drop-shadow-after();
+                box-sizing: border-box;
+                width: 100%;
+                padding: @margin__em
+                         @margin_half__em
+                         @margin_half__em;
+
+                left: 0;
+                z-index: 10;
+
+                background-color: @gray-5;
+                border-top: 1px solid @gray-40;
+                border-bottom: 1px solid @gray-40;
+            }
         }
     } );
 
-    // Tablet size and above.
-    .respond-to-min( @bp-sm-min {
-        &_trigger {
-            // Show "Search" text in trigger at tablet sizes.
-            &-label:before {
-                .webfont-medium();
-                content: 'Search';
-            }
+    // Tablet and above.
+    .respond-to-min( @bp-sm-min, {
+        // Add "Search" text in trigger
+        &_trigger-label:before {
+            .webfont-medium();
+
+            content: 'Search';
         }
     } );
 
     // Tablet size only.
-    .respond-to-range( @bp-sm-min, @bp-med-min, {
-        // Show "Close" text in trigger at tablet sizes.
+    .respond-to-range( @bp-sm-min, @bp-sm-max, {
         &_trigger {
+            // Min-width sets open/close states to same size
+            min-width: 110px;
+
+            padding-left: unit( @grid_gutter-width / 2 / 18px, em );
+            padding-right: unit( @grid_gutter-width / 2 / 18px, em );
+
+            // Show "Close" text when flyout is open
             &[aria-expanded="true"] {
                 .m-global-search_trigger-label:before {
                     content: 'Close';
@@ -222,44 +242,39 @@
         }
     } );
 
-    // Desktop size.
-    .respond-to-min( @bp-med-min {
-      overflow: hidden;
+    // Desktop and above
+    .respond-to-min( @bp-med-min, {
+        // Always show on desktop, even without JS
+        display: block;
+        // Center on the call to action (CTA) divider to right of search
+        padding-top: 6px;
+        padding-bottom: 6px;
+        // Match CTA offset from divider
+        padding-right: @margin_half__em;
 
-      // Match height of Search button at desktop size.
-      // Used to make overflow cover one line only.
-      // 1px offset is to expand overflow area by 1px
-      // so that the focus outline is not cropped.
-      max-height: 47px;
-      position: relative;
-      left: -1px;
-      top: -1px;
+        overflow: hidden;
 
-      &_trigger,
-      &_trigger:focus,
-       {
-        position: relative;
-        top: 1px;
-      }
-      &_content {
-        position: relative;
-        left: 1px;
-      }
+        &_trigger {
+            // Match height of input with button
+            padding: 7px 0;
+        }
 
+        .js & {
+            position: relative;
 
-      &_trigger {
-          &[aria-expanded="true"] {
-              display: none;
-          }
-      }
+            &_trigger {
+                float: right;
+            }
 
-      &_content {
-          padding-right: @margin_half__em;
-      }
-
+            &_content {
+                right: @margin_half__em;
+                width: auto;
+            }
+        }
     } );
 
     // TODO: Move these styles to cf-enhancements/cf-forms.
+    // Look into removing grid styles altogether
     // Mobile size.
     .respond-to-min( 480px, {
         &_content-form {
@@ -278,26 +293,13 @@
             }
         }
     } );
-}
 
-.m-global-search {
     // Tab trigger is used to capture press of the tab key so that
     // global search can be collapsed when it hits this element.
     &_tab-trigger {
         position: absolute;
         top: -9999px;
         left: -9999px;
-    }
-}
-
-.no-js .m-global-search {
-    &_trigger {
-        display: none;
-    }
-
-    // JS isn't available to remove u-hidden class, so override it.
-    &_content.u-hidden {
-        display: block;
     }
 }
 

--- a/cfgov/unprocessed/css/organisms/header.less
+++ b/cfgov/unprocessed/css/organisms/header.less
@@ -76,11 +76,14 @@
 
     &_content {
 
+        > .m-global-search {
+          float: right;
+        }
+
         .respond-to-min( @bp-med-min, {
             padding-top: unit( @grid_gutter-width / 2 / @base-font-size-px, em );
 
-            & > .m-global-header-cta,
-            & > .m-global-search {
+            > .m-global-header-cta {
                 float: right;
             }
 
@@ -91,11 +94,11 @@
 
         // Hide Global Header Call to Action at tablet/mobile sizes.
         .respond-to-max( @bp-sm-max, {
-            & > .m-global-header-cta {
+            > .m-global-header-cta {
                 display: none;
             }
 
-            & > .o-mega-menu {
+            > .o-mega-menu {
                 float: left;
             }
         } );


### PR DESCRIPTION
Updates the global search for no-js and IE 8-10 fixes (Part 1 of Jira issue 816)

## Removals

- Removes need for pointer events

## Changes

- Sets up JS only styles instead of search styles globally scoped to js
- Reduces search styles for simplicity
- Updates drop-shadow after utility for simplified search styles

## Testing

- `gulp build` and test the search at multiple browser styles, with JS on and off, it should look and function the same as before.

## Review

- @anselmbradford 
- @KimberlyMunoz 
- @sebworks 

## Notes

- I'm hiding the search altogether if JS is off for smaller screens because it's unusable otherwise

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)