### PR TITLE
Incorporate sheer pages into a Wagtail served related posts organism

### DIFF
--- a/cfgov/jinja2/v1/_includes/macros/category-icon.html
+++ b/cfgov/jinja2/v1/_includes/macros/category-icon.html
@@ -18,27 +18,26 @@
 
 {% macro render(category, additional_classes) %}
     {% set icons = {
-        'info for consumers': 'cf-icon-information',
         'at the cfpb': 'cf-icon-bullhorn',
-        'data, research & reports': 'cf-icon-chart',
-        'policy & compliance': 'cf-icon-bank-account',
-        'speech': 'cf-icon-microphone',
-        'press release': 'cf-icon-bullhorn',
-        'op-ed': 'cf-icon-contract',
-        'testimony': 'cf-icon-double-quote',
         'blog': 'cf-icon-speech-bubble',
-        'newsroom': 'cf-icon-newspaper',
+        'data, research & reports': 'cf-icon-chart',
+        'events': 'cf-icon-date',
         'featured event': 'cf-icon-date',
         'featured blog': 'cf-icon-speech-bubble',
         'featured video': 'cf-icon-play-round',
         'featured tool': 'cf-icon-settings',
         'featured news': 'cf-icon-newspaper',
-        'featured': 'cf-icon-favorite'
+        'featured': 'cf-icon-favorite',
+        'info for consumers': 'cf-icon-information',
+        'newsroom': 'cf-icon-newspaper',
+        'op-ed': 'cf-icon-contract',
+        'policy & compliance': 'cf-icon-bank-account',
+        'press release': 'cf-icon-bullhorn',
+        'speech': 'cf-icon-microphone',
+        'testimony': 'cf-icon-double-quote',
       }
     %}
-    {% set category = category | lower %}
-    {%- if icons[category] -%}
-    <span class="cf-icon {{ icons[category] }}
-                 {{ additional_classes or '' }}"></span>
-    {%- endif -%}
+    {% set icon = icons[category | lower] or icons['blog'] %}
+    <span class="cf-icon {{ icon }}
+                 {{- additional_classes or '' -}}"></span>
 {% endmacro %}

--- a/cfgov/jinja2/v1/_includes/molecules/related-posts.html
+++ b/cfgov/jinja2/v1/_includes/molecules/related-posts.html
@@ -17,39 +17,39 @@
    ========================================================================== #}
 
 {% macro render(block, is_half_width=false, hide_header_slug=false) %}
-{% import 'macros/category-icon.html' as category_icon %}
-{% set title_icon_lookup = {
-    "newsroom" : ("Newsroom","newspaper"),
-    "posts"    : ("Blog", "speech-bubble"),
-    "events"   : ("Events", "speech-bubble")
-  }
-%}
-{% set related_post_types = page.related_posts(block) %}
-{% if related_post_types %}
-<div class="m-related-posts
-            {{'m-related-posts__half-width'
-              if is_half_width else ''}}">
-    {% if not hide_header_slug %}
-    <h2 class="header-slug">
-        <span class="header-slug_inner">
-            Related Posts
-        </span>
-    </h2>
+    {% import 'macros/category-icon.html' as category_icon %}
+    {% set title_icon_lookup = {
+        "newsroom" : ("Newsroom","newspaper"),
+        "posts"    : ("Blog", "speech-bubble"),
+        "events"   : ("Events", "speech-bubble")
+      }
+    %}
+    {% set related_post_types = page.related_posts(block, request.site.hostname) %}
+    {% if related_post_types %}
+        <div class="m-related-posts
+                    {{'m-related-posts__half-width'
+                      if is_half_width else ''}}">
+            {% if not hide_header_slug %}
+                <h2 class="header-slug">
+                    <span class="header-slug_inner">
+                        Related Posts
+                    </span>
+                </h2>
+            {% endif %}
+            {% for post_type, post_type_list in related_post_types.iteritems() %}
+                {% set title, icon = title_icon_lookup[post_type] or ("Blog", "speech-bubble") %}
+                <div class="m-related-posts_list-container">
+                    {% if block.value.show_heading %}
+                        <h3 class="h4">
+                             <span class="cf-icon cf-icon-{{icon}}"></span>
+                            {{ title }}
+                        </h3>
+                    {% endif %}
+                    {{ _related_posts_list(post_type_list, block.value.limit) }}
+                </div>
+            {% endfor %}
+        </div>
     {% endif %}
-    {% for post_type, post_type_list in related_post_types.iteritems() %}
-    {% set title, icon = title_icon_lookup[post_type] or ("Blog", "speech-bubble") %}
-    <div class="m-related-posts_list-container">
-    {% if block.value.show_heading %}
-        <h3 class="h4">
-             <span class="cf-icon cf-icon-{{icon}}"></span>
-            {{ title }}
-        </h3>
-    {% endif %}
-        {{ _related_posts_list(post_type_list) }}
-    </div>
-    {% endfor %}
-</div>
-{% endif %}
 {% endmacro %}
 
 
@@ -67,39 +67,41 @@
 
    ========================================================================== #}
 
-{% macro _related_posts_list(posts) %}
-{% import 'macros/time.html' as time %}
-<ul class="m-related-posts_list
-           list list__unstyled
-           list__spaced">
-    {% for post in posts %}
-    {% set post_url = slugurl(post.slug) or '' %}
-    <li class="list_item">
-        <h3 class="h4 u-mb5">
-            <a class="list_link"
-               href="{{ post_url if post_url else post.permalink }}">
-                {{ post.title | safe }}
-            </a>
-        </h3>
-        {% if post.text %}
-        <p>
-            {{ post.text | safe }}
-        </p>
-        {% endif %}
-        <p class="date">
-            {{ time.render(post.latest_revision_created_at, {'date':true}) }}
-        </p>
-    </li>
-    {% endfor %}
-</ul>
+{% macro _related_posts_list(posts, limit) %}
+    {% import 'macros/time.html' as time %}
+    {% set limit = limit|int if posts|length >= limit|int else posts|length %}
+    <ul class="m-related-posts_list
+               list list__unstyled
+               list__spaced">
+        {% for i in range(limit) %}
+            {% set post_url = slugurl(posts[i].slug) or '' %}
+            <li class="list_item">
+                <h3 class="h4 u-mb5">
+                    <a class="list_link"
+                       href="{{ post_url or posts[i].permalink }}">
+                        {{ posts[i].title | safe }}
+                    </a>
+                </h3>
+                {% if posts[i].text %}
+                <p>
+                    {{ posts[i].text | safe }}
+                </p>
+                {% endif %}
+                <p class="date">
+                    {% set date = posts[i].latest_revision_created_at or  posts[i].date %}
+                    {{ time.render(date, {'date':true}) }}
+                </p>
+            </li>
+        {% endfor %}
+    </ul>
 
-{% for block in page.sidefoot %}
-  {% if 'related_posts' in block.block_type %}
-    {% if block.value.view_more %}
-        {{ _view_more(block) }}
-    {% endif %}
-  {% endif %}
-{% endfor %}
+    {% for block in page.sidefoot %}
+        {% if 'related_posts' in block.block_type %}
+            {% if block.value.view_more %}
+                {{ _view_more(block) }}
+            {% endif %}
+        {% endif %}
+    {% endfor %}
 {% endmacro %}
 
 {# ==========================================================================

--- a/cfgov/jinja2/v1/_includes/molecules/related-posts.html
+++ b/cfgov/jinja2/v1/_includes/molecules/related-posts.html
@@ -18,12 +18,6 @@
 
 {% macro render(block, is_half_width=false, hide_header_slug=false) %}
     {% import 'macros/category-icon.html' as category_icon %}
-    {% set title_icon_lookup = {
-        "newsroom" : ("Newsroom","newspaper"),
-        "posts"    : ("Blog", "speech-bubble"),
-        "events"   : ("Events", "speech-bubble")
-      }
-    %}
     {% set related_post_types = page.related_posts(block, request.site.hostname) %}
     {% if related_post_types %}
         <div class="m-related-posts
@@ -37,12 +31,11 @@
                 </h2>
             {% endif %}
             {% for post_type, post_type_list in related_post_types.iteritems() %}
-                {% set title, icon = title_icon_lookup[post_type] or ("Blog", "speech-bubble") %}
+                {% set title, icon = (post_type, category_icon.render(post_type)) or ("Blog", "cf-icon-speech-bubble") %}
                 <div class="m-related-posts_list-container">
                     {% if block.value.show_heading %}
                         <h3 class="h4">
-                             <span class="cf-icon cf-icon-{{icon}}"></span>
-                            {{ title }}
+                            {{ icon }} {{ title }}
                         </h3>
                     {% endif %}
                     {{ _related_posts_list(post_type_list, block.value.limit) }}

--- a/cfgov/sheerlike/query.py
+++ b/cfgov/sheerlike/query.py
@@ -175,6 +175,16 @@ class QueryResults(object):
                 query_hit = QueryHit(hit, self.query.es, self.query.es_index)
                 yield query_hit
 
+    def __getitem__(self, index):
+        if 'hits' in self.result_dict and 'hits' in self.result_dict['hits']:
+            for i, hit in enumerate(self.result_dict['hits']['hits']):
+                if i == index:
+                    return QueryHit(hit, self.query.es, self.query.es_index)
+
+    def __len__(self):
+        if 'hits' in self.result_dict and 'hits' in self.result_dict['hits']:
+            return len(self.result_dict['hits']['hits'])
+
     def aggregations(self, fieldname):
         if "aggregations" in self.result_dict and \
                 fieldname in self.result_dict['aggregations']:

--- a/cfgov/sheerlike/templates.py
+++ b/cfgov/sheerlike/templates.py
@@ -4,15 +4,18 @@ from pytz import timezone
 
 
 def date_filter(value, format="%Y-%m-%d", tz='America/New_York'):
-    if type(value) not in [datetime.datetime, datetime.date]:
-        date = parser.parse(value,
-                            default=datetime.datetime.today().replace(day=1))
-        naive = date.replace(tzinfo=None)
-        dt = timezone(tz).localize(naive)
-    else:
-        dt = value
+    if value:
+        if type(value) not in [datetime.datetime, datetime.date]:
+            date = parser.parse(value,
+                                default=datetime.datetime.today().replace(day=1))
+            naive = date.replace(tzinfo=None)
+            dt = timezone(tz).localize(naive)
+        else:
+            dt = value
 
-    return dt.strftime(format)
+        return dt.strftime(format)
+    else:
+        return ''
 
 
 def date_formatter(value, format='%d/%m/%Y', tz='America/New_York'):

--- a/cfgov/v1/models/base.py
+++ b/cfgov/v1/models/base.py
@@ -133,22 +133,22 @@ class CFGOVPage(Page):
         # order.
         from . import EventPage
         search_types = [
-            ('events', EventPage),
+            ('events', EventPage, 'Events'),
         ]
-        for search_type, search_class in search_types:
+        for search_type, search_class, search_type_name in search_types:
             if 'relate_%s' % search_type in block.value \
                     and block.value['relate_%s' % search_type]:
-                related[search_type] = \
+                related[search_type_name] = \
                     search_class.objects.filter(query).order_by(
                         '-latest_revision_created_at').exclude(
                         slug=self.slug).live_shared(hostname)[:block.value['limit']]
         # TODO: Remove each search_type as it is implemented into Django
         queries = QueryFinder()
-        for search_type in ['newsroom', 'posts']:
+        for search_type, search_type_name in [('newsroom', 'Newsroom'), ('posts', 'Blog')]:
             if 'relate_%s' % search_type in block.value \
                     and block.value['relate_%s' % search_type]:
                 sheer_query = getattr(queries, search_type)
-                related[search_type] = sheer_query.search(filter_tags=self.tags.names())
+                related[search_type_name] = sheer_query.search(filter_tags=self.tags.names())
 
         # Return a dictionary of lists of each type when there's at least one
         # hit for that type.

--- a/cfgov/v1/models/base.py
+++ b/cfgov/v1/models/base.py
@@ -1,6 +1,7 @@
 import os
 from itertools import chain
 import json
+from sets import Set
 
 from django.db import models
 from django.db.models import Q
@@ -25,7 +26,7 @@ from taggit.models import TaggedItemBase
 from modelcluster.fields import ParentalKey
 from modelcluster.tags import ClusterTaggableManager
 
-from sets import Set
+from sheerlike.query import QueryFinder
 
 from . import ref
 from . import molecules
@@ -124,25 +125,30 @@ class CFGOVPage(Page):
         ObjectList(settings_panels, heading='Configuration'),
     ])
 
-    def related_posts(self, block):
+    def related_posts(self, block, hostname):
         related = {}
         query = models.Q(('tags__name__in', self.tags.names()))
-        # TODO: Replace this in a more global scope when Filterable List gets
-        # implemented in the backend.
+        # TODO: Add other search types as they are implemented in Django
         # Import classes that use this class here to maintain proper import
         # order.
         from . import EventPage
-        search_types = {
-            'events': EventPage,
-        }
-        # End TODO
-        for search_type, page_class in search_types.items():
+        search_types = [
+            ('events', EventPage),
+        ]
+        for search_type, search_class in search_types:
             if 'relate_%s' % search_type in block.value \
                     and block.value['relate_%s' % search_type]:
                 related[search_type] = \
-                    page_class.objects.filter(query).order_by(
+                    search_class.objects.filter(query).order_by(
                         '-latest_revision_created_at').exclude(
-                        slug=self.slug)[:block.value['limit']]
+                        slug=self.slug).live_shared(hostname)[:block.value['limit']]
+        # TODO: Remove each search_type as it is implemented into Django
+        queries = QueryFinder()
+        for search_type in ['newsroom', 'posts']:
+            if 'relate_%s' % search_type in block.value \
+                    and block.value['relate_%s' % search_type]:
+                sheer_query = getattr(queries, search_type)
+                related[search_type] = sheer_query.search(filter_tags=self.tags.names())
 
         # Return a dictionary of lists of each type when there's at least one
         # hit for that type.

--- a/cfgov/v1/models/learn_page.py
+++ b/cfgov/v1/models/learn_page.py
@@ -12,7 +12,7 @@ from wagtail.wagtailimages.edit_handlers import ImageChooserPanel
 
 from . import molecules
 from . import organisms
-from .base import CFGOVPage
+from .base import CFGOVPage, CFGOVPageManager
 from ..templatetags.share import get_page_state_url
 from ..util import util
 
@@ -180,6 +180,8 @@ class EventPage(AbstractFilterPage):
     venue_state = USStateField(blank=True)
     venue_zip = models.IntegerField(blank=True, null=True)
     agenda_items = StreamField([('item', AgendaItemBlock())], blank=True)
+
+    objects = CFGOVPageManager()
 
     # General content tab
     content_panels = CFGOVPage.content_panels + [


### PR DESCRIPTION
The related posts molecule retrieves Events, Blog posts, and Newsroom items. The last two of which are in the elasticsearch index. This incorporates their retrieval into the set of pages that are retrieved for the molecule.

## Additions

- Custom manager for EventPage
- Logic to retrieve elasticsearch data for related-posts

## Changes

- sheerlike query now has __getitem__ and __len__ methods
- molecule/related-posts.html is changed up a bit in response to this sheer data incorporation

## Testing

- Go to/make a page with tags and a related post organism in the sidebar/footer
- Save/share/publish then visit the page to see if the related posts show

## Review

- @kave 
- @richaagarwal 

## Screenshots
![screen shot 2016-03-10 at 4 37 08 pm](https://cloud.githubusercontent.com/assets/1412978/13685422/5ef79b34-e6de-11e5-928c-f5b9935601ee.png)

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)

