### PR TITLE
Mega Menu: DFJR-821 Adds full menu/desktop hover state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,8 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - included backend support for Video in FCM
 - Changed `external-site-redirect.js` to remove jQuery and fix Regex.
 - Updated the global search for no-js and IE 8-10 fixes.
+- Frontend: Added all launch-state mega menu links.
+- Frontend: Added hover-to-show behavior in desktop mega menu.
 
 ### Removed
 - Removed normalize and normalize-legacy from main less file because CF already includes it.

--- a/cfgov/jinja2/v1/_includes/organisms/_vars-mega-menu.html
+++ b/cfgov/jinja2/v1/_includes/organisms/_vars-mega-menu.html
@@ -1,4 +1,3 @@
-
 {#
   Navigation and Sub-Navigation menu items,
   used to populate the contents of the site's navigation menus (Mega Menu).
@@ -22,40 +21,100 @@
 {# TODO: Update file path for Featured Menu Content module when that is added. #}
 {% import 'templates/nav/about-us-media.html' as about_us_media %}
 
+{# Featured Menu Content. #}
 {% set media_items = [
   ('/about-us/', about_us_media)
 ] %}
+
 {% set nav_items = [(
-    ('Consumer Tools', '', []),
-    ('Educational Resources', '', []),
-    ('Data & Research', '', []),
-    ('Policy & Compliance', '', []),
-    ('About Us', '/about-us/', [
-        (
-            ('The Bureau', '/the-bureau/', []),
-            ('Budget and Strategy', '/budget/', []),
-            ('Payments to Harmed Consumers',
-             '/offices/payments-to-harmed-consumers/', [])
-        ),
-        (
-            ('Blog','/blog/', []),
-            ('Newsroom', '/newsroom/', []),
-            ('Events', '/events/', []),
-            ('Activity Log', '/activity-log/', [])
-        ),
-        (
-            ('Careers', '/careers/', [
-                (
-                    ('Working at the CFPB', '/careers/working-at-cfpb/', []),
-                    ('Job Application Process', '/careers/application-process/', []),
-                    ('Students & Recent Graduates', '/careers/students-and-graduates/', []),
-                    ('Current Openings', '/careers/current-openings/', [])
-                )
-            ]),
-            ('Doing Business With Us', '/doing-business-with-us/', []),
-            ('Advisory Groups', '/offices/advisory-groups/', []),
-            ('Project Catalyst', '/offices/project-catalyst/', []),
-            ('Contact Us', '/contact-us/', [])
-        )
-    ])
+    ('Consumer Tools', '', [(
+        ('Submit a Complaint', '/complaint/', []),
+        ('Ask CFPB', '/askcfpb/', []),
+        ('Tell Your Story', '/your-story/', []),
+        ('Information for Students', '/students/', []),
+        ('Information for Older Americans', '/older-americans/', []),
+        ('Information for Servicemembers', '/servicemembers/', [])
+    ),(
+        ('Paying for College', '/paying-for-college/', []),
+        ('Owning a Home', '/owning-a-home/', []),
+        ('Planning for Retirement', '/retirement/', []),
+        ('Sending Money Abroad', '/sending-money/', [])
+    ),(
+        ('Know Before You Owe Mortgages', '/know-before-you-owe/', []),
+        ('Trouble Paying Your Mortgage?', '/mortgagehelp/', []),
+        ('Protections Against Discrimination', '/fair-lending/', [])
+    )]),
+    ('Educational Resources', '', [(
+        ('Your Money, Your Goals', '/your-money-your-goals/', []),
+        ('Adult Financial Education', '/adult-financial-education/', []),
+        ('Youth Financial Education', '/youth-financial-education/', [])
+    ),(
+        ('Resources for Libraries', '/library-resources/', []),
+        ('Resources for Tax Preparers', '/tax-preparer-resources/', []),
+        ('Resources for Parents', '/parents/', [])
+    ),(
+        ('Information for Economically Vulnerable Consumers', '/empowerment/', []),
+        ('Managing Someone Else’s Money', '/managing-someone-elses-money/', []),
+        ('Free Brochures', 'http://promotions.usa.gov/cfpbpubs.html', [])
+    )]),
+    ('Data & Research', '/data-research/', [(
+        ('Research & Reports', '/data-research/research-reports/', []),
+    ),(
+        ('Consumer Complaint Database', '/complaintdatabase/', []),
+        ('Mortgage Database (HMDA)', '/hmda/', [])
+    ),(
+        ('Credit Card Surveys & Agreements', '/data-research/credit-card-data/', []),
+    )]),
+    ('Policy & Compliance', '/policy-and-compliance/', [(
+        ('Rulemaking', '/policy-compliance/rulemaking/', [(
+            ('Final Rules', '/policy-compliance/rulemaking/final-rules/', []),
+            ('Rules Under Development', '/policy-compliance/rulemaking/rules-under-development/', []),
+            ('Regulatory Agenda', '/policy-compliance/rulemaking/regulatory-agenda/', []),
+            ('Small Business Review Panels', '/policy-compliance/rulemaking/small-business-review-panels/', []),
+        )]),
+    ),(
+        ('Compliance & Guidance', '/policy-compliance/guidance/', [(
+            ('Implementation & Guidance', '/policy-compliance/guidance/implementation-guidance/', []),
+            ('Supervision & Examinations', '/policy-compliance/guidance/supervision-and-examinations/', []),
+            ('Supervisory Highlights', '/policy-compliance/guidance/supervisory-highlights/', [])
+        )]),
+        ('Enforcement', '/policy-compliance/enforcement/', [(
+            ('Enforcement Actions', '/policy-compliance/enforcement/actions/', []),
+            ('Petitions to Modify or Set Aside', '/policy-compliance/enforcement/petitions/', []),
+            ('Warning Letters', '/policy-compliance/enforcement/warning-letters/', [])
+        )])
+    ),(
+        ('Notices & Opportunities to Comment', '/policy-compliance/notice-opportunities-comment/', [(
+            ('Open Notices', '/policy-compliance/notice-opportunities-comment/open-notices/', []),
+            ('Archive of Closed Notices', '/policy-compliance/notice-opportunities-comment/archive-closed/', [])
+        )]),
+        ('Amicus Program', '/policy-compliance/amicus/', [(
+            ('Filed Briefs', '/policy-compliance/amicus/briefs/', []),
+            ('Suggest a Case', '/policy-compliance/amicus/suggest/', [])
+        )])
+    )]),
+    ('About Us', '/about-us/', [(
+        ('The Bureau', '/the-bureau/', []),
+        ('Budget and Strategy', '/budget/', []),
+        ('Payments to Harmed Consumers',
+         '/about-us/payments-harmed-consumers/', [])
+    ),(
+        ('Blog','/blog/', []),
+        ('Newsroom', '/newsroom/', []),
+        ('Events', '/about-us/events/', []),
+        ('Recent Postings', '/activity-log/', [])
+    ),(
+        ('Careers', '/careers/', [
+            (
+                ('Working @ CFPB', '/careers/working-at-cfpb/', []),
+                ('Job Application Process', '/careers/application-process/', []),
+                ('Students & Recent Graduates', '/careers/students-and-graduates/', []),
+                ('All Current Openings', '/careers/current-openings/', [])
+            )
+        ]),
+        ('Doing Business With Us', '/doing-business-with-us/', []),
+        ('Advisory Groups', '/about-us/advisory-groups/', []),
+        ('Project Catalyst', '/about-us/project-catalyst/', []),
+        ('Contact Us', '/about-us/contact-us/', [])
+    )])
 )] -%}

--- a/cfgov/jinja2/v1/_includes/organisms/header.html
+++ b/cfgov/jinja2/v1/_includes/organisms/header.html
@@ -3,29 +3,30 @@
     {% import 'molecules/global-eyebrow.html' as global_eyebrow with context %}
     {{ global_eyebrow.render( true ) }}
 
-    <div class="o-header_content
-                wrapper">
+    <div class="o-header_content">
 
-        {% import 'molecules/global-header-cta.html' as global_header_cta with context %}
-        {{ global_header_cta.render( true ) }}
+        <div class="wrapper">
+            {% import 'molecules/global-header-cta.html' as global_header_cta with context %}
+            {{ global_header_cta.render( true ) }}
 
-        {% include 'molecules/global-search.html' with context %}
+            {% include 'molecules/global-search.html' with context %}
 
-        <a class="o-header_logo" href="/">
-            <img class="o-header_logo-img u-js-only"
-                 src="/static/img/logo_sm-exec.svg"
-                 onerror="this.onerror=null;this.src='/static/img/logo_sm-exec.png';"
-                 alt="Consumer Financial Protection Bureau"
-                 width="237"
-                 height="50">
-            <noscript>
-                <img class="o-header_logo-img"
-                     src="/static/img/logo_sm-exec.png"
+            <a class="o-header_logo" href="/">
+                <img class="o-header_logo-img u-js-only"
+                     src="/static/img/logo_sm-exec.svg"
+                     onerror="this.onerror=null;this.src='/static/img/logo_sm-exec.png';"
                      alt="Consumer Financial Protection Bureau"
                      width="237"
                      height="50">
-            </noscript>
-        </a>
+                <noscript>
+                    <img class="o-header_logo-img"
+                         src="/static/img/logo_sm-exec.png"
+                         alt="Consumer Financial Protection Bureau"
+                         width="237"
+                         height="50">
+                </noscript>
+            </a>
+        </div>
 
         {% block primary_nav %}
             {% include 'organisms/mega-menu.html' with context %}

--- a/cfgov/jinja2/v1/_includes/organisms/mega-menu.html
+++ b/cfgov/jinja2/v1/_includes/organisms/mega-menu.html
@@ -61,8 +61,7 @@
                {{ _classes( nav_depth, '-item' ) }}"
         {{ 'data-js-hook=flyout-menu' if nav_children | count > 0 else '' }}>
         {# TODO: Remove nav_depth < 2 check on has-children class when 3rd level transitions are in. #}
-        <a class="{{ 'u-link__disabled' if nav_url == '' else '' }}
-                  {{ _classes( nav_depth, '-link' ) }}
+        <a class="{{ _classes( nav_depth, '-link' ) }}
                   {{ _classes( nav_depth, '-link__has-children' ) if nav_children | count > 0 and nav_depth < 2 else '' }}
                   {{ _classes( nav_depth, '-link__current' ) if nav_url == request.path else '' }}"
            {{ '' if nav_url == '' or nav_url == request.path else 'href=' + nav_url | e }}
@@ -116,11 +115,13 @@
             <div class="{{ _classes( nav_depth, '-grid' ) }}">
                 {% if nav_depth > 1 %}
                 <span class="{{ _classes( nav_depth, '-overview' ) }}">
+                    {% if nav_overview_url %}
                     <a class="{{ _classes( nav_depth, '-overview-link' ) }}
                               {{ _classes( nav_depth, '-overview-link__current' ) if nav_overview_url == request.path else '' }}"
-                       {{ '' if nav_overview_url == '' or nav_overview_url == request.path else 'href=' + nav_overview_url | e }}>
+                       {{ '' if nav_overview_url == request.path else 'href=' + nav_overview_url | e }}>
                         {{ nav_overview }}
                     </a>
+                    {% endif %}
                 </span>
                 {% endif %}
                 <div class="{{ _classes( nav_depth, '-lists' ) }}">
@@ -156,7 +157,8 @@
    Creates a mega menu primary navigation menu.
 
    ========================================================================== #}
-<nav class="{{ base_class }}"
+<nav class="{{ base_class }}
+            u-hidden"
      data-js-hook="flyout-menu"
      aria-label="main navigation"
      role="navigation">

--- a/cfgov/unprocessed/css/organisms/header.less
+++ b/cfgov/unprocessed/css/organisms/header.less
@@ -67,44 +67,63 @@
     z-index: 10;
     background-color: @white;
 
-    > .m-global-eyebrow {
-
-        .respond-to-max( @bp-sm-max, {
+    // Desktop size
+    .respond-to-max( @bp-sm-max, {
+        > .m-global-eyebrow {
             display: none;
-        } );
-    }
+        }
+    } );
 
     &_content {
 
-        > .m-global-search {
-          float: right;
+        > .wrapper {
+            > .m-global-search {
+                float: right;
+            }
         }
 
         .respond-to-min( @bp-med-min, {
             padding-top: unit( @grid_gutter-width / 2 / @base-font-size-px, em );
 
-            > .m-global-header-cta {
-                float: right;
-            }
+            > .wrapper {
+                > .m-global-header-cta {
+                    float: right;
+                }
 
-            > .m-global-search {
-                min-width: 340px;
+                > .m-global-search {
+                    min-width: 340px;
+                }
             }
         } );
 
-        // Hide Global Header Call to Action at tablet/mobile sizes.
+        // Tablet/mobile sizes.
+        // Hide Global Header Call to Action.
         .respond-to-max( @bp-sm-max, {
-            > .m-global-header-cta {
-                display: none;
+            > .wrapper {
+                > .m-global-header-cta {
+                    display: none;
+                }
             }
 
+            // Set the mobile hamburger mega menu next to the logo.
+            // Remove pointer-events so the menu doesn't cover up the search.
             > .o-mega-menu {
-                float: left;
+                top: 0;
+                left: 0;
+                position: absolute;
+                pointer-events: none;
             }
         } );
     }
 
     &_logo {
+
+        // Tablet/mobile sizes.
+        .respond-to-max( @bp-sm-max, {
+            // Offset logo by width of mega menu trigger: 60px + 10px gap.
+            margin-left: 70px;
+        } );
+
         &-img {
             height: 40px;
             width: 190px;
@@ -112,11 +131,12 @@
             // Removes typical inline vertical whitespace.
             vertical-align: middle;
 
-            .respond-to-min(@bp-med-min, {
+            // Desktop size.
+            .respond-to-min( @bp-med-min, {
                 margin: 0 0 unit(20px / @base-font-size-px, em) 0;
                 height: 50px;
                 width: 237px;
-            });
+            } );
         }
 
         noscript .o-header_logo-img {

--- a/cfgov/unprocessed/css/organisms/mega-menu.less
+++ b/cfgov/unprocessed/css/organisms/mega-menu.less
@@ -125,6 +125,8 @@
 */
 
 .o-mega-menu {
+    position: relative;
+    width: 100%;
 
     &_content-item {
         // Override margin added by CF to list items.
@@ -217,15 +219,10 @@
             border-bottom: 1px solid @gray-50;
             pointer-events: auto;
 
-            transform: translateX( -100% );
-            transition: transform 0.25s ease-out;
-
             .u-drop-shadow-after();
 
             &[aria-expanded="true"] {
                 display: block;
-
-                transform: translateX( 0 );
             }
 
             &-alt-trigger {
@@ -356,12 +353,30 @@
                 }
             }
         }
+
+        // 3rd-level menu - Tablet/Mobile.
+        &_content-3 {
+
+            // TODO: There is similar code set on all three menus.
+            //       Investigate if it can be combined.
+            // Remove final border line of last list item.
+            &-list:last-child {
+                .o-mega-menu_content-3-item:last-child {
+                    border-bottom: none;
+                }
+            }
+        }
+
+        // Submenus - Tablet/Mobile.
+        // TODO: Enable when third-level behaviors are in.
+        //&_content-2,
+        //&_content-3 {
+        //    .u-move-right();
+        //}
     } );
 
     // Desktop sizes.
     .respond-to-min( @bp-med-min, {
-        margin-right: -@grid_gutter-width / 2;
-        margin-left: -@grid_gutter-width / 2;
 
         &_trigger {
             display: none;
@@ -381,11 +396,11 @@
 
             &-item {
                 display: inline-block;
+                margin-right: @grid_gutter-width / 2;
             }
 
             &-link {
                 padding-bottom: @grid_gutter-width;
-                margin-right: @grid_gutter-width / 2;
                 margin-left: @grid_gutter-width / 2;
 
                 font-size: unit( 18px / @base-font-size-px, em );
@@ -396,11 +411,15 @@
 
                 // -6px padding offset is to account for the border height.
                 &[aria-expanded="true"],
-                &__current,
-                // TODO: Show menu on hover and remove :hover selector.
-                &:hover {
+                &__current {
                     padding-bottom: @grid_gutter-width - 6px;
                     border-bottom: 6px solid @black;
+                    cursor: pointer;
+                }
+
+                &:hover {
+                    padding-bottom: @grid_gutter-width - 6px;
+                    border-bottom: 6px solid @gray-50;
                     cursor: pointer;
                 }
             }
@@ -423,8 +442,6 @@
 
                 .o-mega-menu_content-2-wrapper {
                     display: block;
-
-                    transform: translateY( 0 );
                 }
             }
 
@@ -433,8 +450,6 @@
                 background-color: @gray-5;
                 border-top: 1px solid @gray-50;
                 border-bottom: 1px solid @gray-50;
-                transform: translateY( -100% );
-                transition: transform 0.25s ease-out;
 
                 .u-drop-shadow-after();
 
@@ -542,6 +557,13 @@
         position: absolute;
         top: -9999px;
         left: -9999px;
+    }
+}
+
+.no-js .o-mega-menu {
+    // JS isn't available to remove u-hidden class, so override it.
+    &.u-hidden {
+      display: block;
     }
 }
 

--- a/cfgov/unprocessed/js/modules/Tree.js
+++ b/cfgov/unprocessed/js/modules/Tree.js
@@ -5,7 +5,7 @@
  * @class
  *
  * @classdesc A tree data structure.
- * Tree's have one root node, and child nodes that branch.
+ * Trees have one root node, and child nodes that branch.
  * Like:
  *
  *        R
@@ -69,6 +69,7 @@ function Tree() {
    *      A   B
    *    / | \
    *   C  D  E
+   *
    * Level 0 nodes would return (R).
    * Level 1 nodes would return (A) and (B).
    * Level 2 nodes would return (C), (D), and (E).

--- a/cfgov/unprocessed/js/modules/transition/AlphaTransition.js
+++ b/cfgov/unprocessed/js/modules/transition/AlphaTransition.js
@@ -43,10 +43,10 @@ function AlphaTransition( element ) {
   }
 
   /**
-   * Clear transition classes from the transition target.
+   * Remove all transition classes.
    */
-  function flush() {
-    _baseTransition.flush();
+  function remove() {
+    _baseTransition.remove();
   }
 
   /**
@@ -107,10 +107,10 @@ function AlphaTransition( element ) {
   this.animateOn = animateOn;
   this.fadeTo100 = fadeTo100;
   this.fadeTo0 = fadeTo0;
-  this.flush = flush;
   this.init = init;
   this.isAnimated = isAnimated;
   this.setElement = setElement;
+  this.remove = remove;
 
   return this;
 }

--- a/cfgov/unprocessed/js/modules/transition/BaseTransition.js
+++ b/cfgov/unprocessed/js/modules/transition/BaseTransition.js
@@ -45,8 +45,7 @@ function BaseTransition( element, classes ) { // eslint-disable-line max-stateme
     // If the element has already been set,
     // clear the transition classes from the old element.
     if ( _dom ) {
-      _dom.classList.remove( _classes.BASE_CLASS );
-      flush();
+      remove();
       animateOn();
     }
     _dom = elem;
@@ -111,10 +110,8 @@ function BaseTransition( element, classes ) { // eslint-disable-line max-stateme
   /**
    * Search for and remove initial BaseTransition classes that have
    * already been applied to this BaseTransition's target element.
-   * Will only be run once internally, but can be run additional
-   * times externally.
    */
-  function flush() {
+  function _flush() {
     for ( var prop in _classes ) {
       if ( _classes.hasOwnProperty( prop ) &&
            _classes[prop] !== _classes.BASE_CLASS &&
@@ -125,13 +122,21 @@ function BaseTransition( element, classes ) { // eslint-disable-line max-stateme
   }
 
   /**
+   * Remove all transition classes.
+   */
+  function remove() {
+    _dom.classList.remove( _classes.BASE_CLASS );
+    _flush();
+  }
+
+  /**
    * @param {string} className - A CSS class.
    * @returns {boolean} False if the class is already applied,
    *   otherwise true if the class was applied.
    */
   function applyClass( className ) {
     if ( !_isFlushed ) {
-      flush();
+      _flush();
       _isFlushed = true;
     }
 
@@ -187,9 +192,9 @@ function BaseTransition( element, classes ) { // eslint-disable-line max-stateme
   this.animateOff = animateOff;
   this.animateOn = animateOn;
   this.applyClass = applyClass;
-  this.flush = flush;
   this.init = init;
   this.isAnimated = isAnimated;
+  this.remove = remove;
   this.setElement = setElement;
 
   // Public static constants.

--- a/cfgov/unprocessed/js/modules/transition/MoveTransition.js
+++ b/cfgov/unprocessed/js/modules/transition/MoveTransition.js
@@ -47,10 +47,10 @@ function MoveTransition( element ) { // eslint-disable-line max-statements, no-i
   }
 
   /**
-   * Clear transition classes from the transition target.
+   * Remove all transition classes.
    */
-  function flush() {
-    _baseTransition.flush();
+  function remove() {
+    _baseTransition.remove();
   }
 
   /**
@@ -142,7 +142,6 @@ function MoveTransition( element ) { // eslint-disable-line max-statements, no-i
 
   this.animateOff = animateOff;
   this.animateOn = animateOn;
-  this.flush = flush;
   this.init = init;
   this.isAnimated = isAnimated;
   this.moveToOrigin = moveToOrigin;
@@ -150,6 +149,7 @@ function MoveTransition( element ) { // eslint-disable-line max-statements, no-i
   this.moveRight = moveRight;
   this.moveUp = moveUp;
   this.setElement = setElement;
+  this.remove = remove;
 
   return this;
 }

--- a/cfgov/unprocessed/js/organisms/MegaMenu.js
+++ b/cfgov/unprocessed/js/organisms/MegaMenu.js
@@ -3,8 +3,13 @@
 // Required modules.
 var atomicHelpers = require( '../modules/util/atomic-helpers' );
 var breakpointState = require( '../modules/util/breakpoint-state' );
+var dataHook = require( '../modules/util/data-hook' );
 var EventObserver = require( '../modules/util/EventObserver' );
 var FlyoutMenu = require( '../modules/FlyoutMenu' );
+var MegaMenuDesktop = require( '../organisms/MegaMenuDesktop' );
+var MegaMenuMobile = require( '../organisms/MegaMenuMobile' );
+var MoveTransition = require( '../modules/transition/MoveTransition' );
+var Tree = require( '../modules/Tree' );
 
 /**
  * MegaMenu
@@ -14,17 +19,19 @@ var FlyoutMenu = require( '../modules/FlyoutMenu' );
  *
  * @param {HTMLNode} element
  *   The DOM element within which to search for the organism.
- * @returns {Object} An MegaMenu instance.
+ * @returns {MegaMenu} An instance.
  */
 function MegaMenu( element ) {
   var BASE_CLASS = 'o-mega-menu';
 
   var _dom = atomicHelpers.checkDom( element, BASE_CLASS, 'MegaMenu' );
-  var _flyoutMenu = new FlyoutMenu( _dom ).init();
-  var _activeMenu = _flyoutMenu;
-  var _activeMenuDom = _flyoutMenu.getDom().content;
-  var _menuItems = _dom.querySelectorAll( '.' + BASE_CLASS + '_content-item' );
-  var _subMenus = {};
+
+  // Tree data model.
+  var _menus;
+
+  // Screen-size specific behaviors.
+  var _desktopNav;
+  var _mobileNav;
 
   // TODO: Move tab trigger to its own class.
   var _tabTriggerDom = _dom.querySelector( '.' + BASE_CLASS + '_tab-trigger' );
@@ -32,54 +39,127 @@ function MegaMenu( element ) {
   var KEY_TAB = 9;
 
   /**
-   * @returns {Object} The MegaMenu instance.
+   * @returns {MegaMenu} An instance.
    */
   function init() {
-    var initEventsBinded = _initEvents.bind( this );
-    var menuItem;
-    var submenu;
-    var childSel = '.' + BASE_CLASS + '_content-link__has-children';
-    for ( var i = 1, len = _menuItems.length; i < len; i++ ) {
-      menuItem = _menuItems[i];
-      if ( menuItem.querySelector( '.u-link__disabled' ) === null &&
-           menuItem.querySelector( childSel ) !== null ) {
-        submenu =
-          new FlyoutMenu( menuItem ).init();
-        _subMenus[menuItem] = submenu;
-        initEventsBinded( submenu );
-      }
+    // DOM selectors.
+    var rootMenuDom = _dom;
+    var rootContentDom = rootMenuDom.querySelector( FlyoutMenu.CONTENT_SEL );
+    var submenusDom = _dom.querySelectorAll( FlyoutMenu.BASE_SEL );
+
+    // Create model.
+    _menus = new Tree();
+
+    // Create root menu.
+    var transition = new MoveTransition( rootContentDom ).init();
+    var rootMenu = new FlyoutMenu( rootMenuDom ).init();
+    // Set initial position.
+    rootMenu.setExpandTransition( transition, transition.moveToOrigin );
+    rootMenu.setCollapseTransition( transition, transition.moveLeft );
+    _addEvents( rootMenu );
+
+    // Populate tree model with menus.
+    var rootNode = _menus.init( rootMenu ).getRoot();
+    _populateTreeFromDom( rootMenuDom, rootNode, _addMenu );
+
+    // Initialize screen-size specific behaviors.
+    _desktopNav = new MegaMenuDesktop( _menus ).init();
+    _mobileNav = new MegaMenuMobile( _menus ).init();
+    _mobileNav.addEventListener( 'rootExpandBegin', _handleRootExpandBegin.bind( this ) );
+    _mobileNav.addEventListener( 'rootCollapseEnd', _handleRootCollapseEnd.bind( this ) );
+
+    window.addEventListener( 'resize', _resizeHandler );
+
+    if ( _isInDesktop() ) {
+      _desktopNav.resume();
+    } else {
+      _mobileNav.resume();
     }
 
-    initEventsBinded( _flyoutMenu );
+    _dom.classList.remove( 'u-hidden' );
+
     _tabTriggerDom.addEventListener( 'keyup', _handleTabPress );
 
     return this;
   }
 
   /**
-   * @param {FlyoutMenu} menu - The FlyoutMenu to add event listeners to.
+   * Perform a recursive depth-first search of the DOM
+   * and call a function for each node.
+   * @param {HTMLNode} dom - A DOM element to search from.
+   * @param {TreeNode} parentNode
+   *   Node in a tree from which to attach new nodes.
+   * @param {Function} callback - Function to call on each node.
+   *   Must return a TreeNode.
    */
-  function _initEvents( menu ) {
-    menu.addEventListener( 'expandBegin', _handleExpandBegin.bind( this ) );
-    menu.addEventListener( 'collapseBegin', _handleCollapseBegin );
-    menu.addEventListener( 'collapseEnd', _handleCollapseEnd.bind( this ) );
+  function _populateTreeFromDom( dom, parentNode, callback ) {
+    var children = dom.children;
+    var child;
+    for ( var i = 0, len = children.length; i < len; i++ ) {
+      var newParentNode = parentNode;
+      child = children[i];
+      newParentNode = callback.call( this, child, newParentNode );
+      _populateTreeFromDom( child, newParentNode, callback );
+    }
   }
 
   /**
-   * Event handler for when there's a click on the page's body.
-   * Used to close the global search, if needed.
-   * @param {MouseEvent} event The event object for the mousedown event.
+   * Create a new FlyoutMenu and attach it to a new tree node.
+   * @param {HTMLNode} dom
+   *   A DOM element to check for a js data-* attribute hook.
+   * @param {TreeNode} parentNode
+   *   The parent node in a tree on which to attach a new menu.
+   * @returns {TreeNode} Return the processed tree node.
    */
-  function _handleBodyClick( event ) {
-    var target = event.target;
-    if ( _activeMenu.getDom().trigger === target ) {
-      return;
+  function _addMenu( dom, parentNode ) {
+    var newParentNode = parentNode;
+    var transition;
+    if ( dataHook.contains( dom, FlyoutMenu.BASE_CLASS ) ) {
+      var menu = new FlyoutMenu( dom ).init();
+      transition = new MoveTransition( menu.getDom().content ).init();
+      menu.setExpandTransition( transition, transition.moveToOrigin );
+      menu.setCollapseTransition( transition, transition.moveLeft );
+      _addEvents( menu );
+      newParentNode = newParentNode.tree.add( menu, newParentNode );
+      menu.setData( newParentNode );
     }
 
-    var isInDesktop = _isInDesktop();
-    if ( isInDesktop && !_isDesktopTarget( target ) ||
-         !isInDesktop && !_isMobileTarget( target ) ) {
-      collapse();
+    return newParentNode;
+  }
+
+  /**
+   * @param {FlyoutMenu} menu - a menu on which to attach events.
+   */
+  function _addEvents( menu ) {
+    menu.addEventListener( 'triggerOver', _handleEvent );
+    menu.addEventListener( 'triggerClick', _handleEvent );
+    menu.addEventListener( 'expandBegin', _handleEvent );
+    menu.addEventListener( 'expandEnd', _handleEvent );
+    menu.addEventListener( 'collapseBegin', _handleEvent );
+    menu.addEventListener( 'collapseEnd', _handleEvent );
+  }
+
+  /**
+   * Handle events coming from menu,
+   * and pass it to the desktop or mobile behaviors.
+   * @param {Object} event - A FlyoutMenu event object.
+   */
+  function _handleEvent( event ) {
+    var activeNav = _isInDesktop() ? _desktopNav : _mobileNav;
+    activeNav.handleEvent( event );
+  }
+
+  /**
+   * Handle resizing of the window,
+   * suspends or resumes the mobile or desktop menu behaviors.
+   */
+  function _resizeHandler() {
+    if ( _isInDesktop() ) {
+      _mobileNav.suspend();
+      _desktopNav.resume();
+    } else {
+      _desktopNav.suspend();
+      _mobileNav.resume();
     }
   }
 
@@ -100,24 +180,6 @@ function MegaMenu( element ) {
   }
 
   /**
-   * Whether a target is one of the ones that appear in the desktop view.
-   * @param {HTMLNode} target - The target of a mouse event (most likely).
-   * @returns {boolean} True if the passed target is in the desktop view.
-   */
-  function _isDesktopTarget( target ) {
-    return _activeMenuDom.contains( target );
-  }
-
-  /**
-   * Whether a target is one of the ones that appear in the mobile view.
-   * @param {HTMLNode} target - The target of a mouse event (most likely).
-   * @returns {boolean} True if the passed target is in the mobile view.
-   */
-  function _isMobileTarget( target ) {
-    return _dom.contains( target );
-  }
-
-  /**
    * Event handler for when the tab key is pressed.
    * @param {KeyboardEvent} event
    *   The event object for the keyboard key press.
@@ -129,83 +191,31 @@ function MegaMenu( element ) {
   }
 
   /**
-   * Open the mega menu.
-   * @returns {Object} A MegaMenu instance.
-   */
-  function expand() {
-    _activeMenu.expand();
-
-    return this;
-  }
-
-  /**
    * Close the mega menu.
-   * @returns {Object} A MegaMenu instance.
+   * @returns {MegaMenu} An instance.
    */
   function collapse() {
-    _flyoutMenu.collapse();
-    _activeMenu.collapse();
+    if ( !_isInDesktop() ) {
+      _mobileNav.collapse();
+    }
 
     return this;
   }
 
   /**
-   * Event handler for when the search input flyout is toggled,
-   * which opens/closes the search input.
-   * @param {FlyoutMenu} target - menu that is expanding or collapsing.
+   * Event handler for when root menu expand transition begins.
+   * @param {Object} event - A MegaMenuMobile event.
    */
-  function _handleToggle( target ) {
-    if ( target === _flyoutMenu &&
-         _activeMenu !== target ) {
-      _activeMenu.collapse();
-    }
-    _activeMenu = target;
-    _activeMenuDom = _activeMenu.getDom().content;
+  function _handleRootExpandBegin( event ) {
+    this.dispatchEvent( 'rootExpandBegin', { target: this } );
   }
 
   /**
-   * Event handler for when FlyoutMenu expand transition begins.
-   * Use this to perform post-expandBegin actions.
-   * @param {Event} event - A FlyoutMenu event.
+   * Event handler for when root menu collapse transition ends.
+   * @param {Object} event - A MegaMenuMobile event.
    */
-  function _handleExpandBegin( event ) {
-    var target = event.target;
-    _handleToggle( target );
-    if ( target === _flyoutMenu ) {
-      this.dispatchEvent( 'rootExpandBegin', { target: this } );
-    }
-    // If on a submenu, focus the back button, otherwise focus the first link.
-    var firstMenuLink;
-    if ( _activeMenu === _flyoutMenu ) {
-      firstMenuLink = _activeMenuDom.querySelector( 'a' );
-    } else {
-      firstMenuLink = _activeMenuDom.querySelector( 'button' );
-    }
-
-    firstMenuLink.focus();
-    document.body.addEventListener( 'mousedown', _handleBodyClick );
-  }
-
-  /**
-   * Event handler for when FlyoutMenu collapse transition begins.
-   * Use this to perform post-collapseBegin actions.
-   * @param {Event} event - A FlyoutMenu event.
-   */
-  function _handleCollapseBegin( event ) {
-    _handleToggle( event.target );
-    document.body.removeEventListener( 'mousedown', _handleBodyClick );
-  }
-
-  /**
-   * Event handler for when FlyoutMenu collapse transition ends.
-   * Use this to perform post-collapseEnd actions.
-   * @param {Event} event - A FlyoutMenu event.
-   */
-  function _handleCollapseEnd( event ) {
-    if ( event.target === _flyoutMenu ) {
-      this.dispatchEvent( 'rootCollapseEnd', { target: this } );
-    }
-    document.body.removeEventListener( 'mousedown', _handleBodyClick );
+  function _handleRootCollapseEnd( event ) {
+    this.dispatchEvent( 'rootCollapseEnd', { target: this } );
   }
 
   // Attach public events.
@@ -215,7 +225,6 @@ function MegaMenu( element ) {
   this.dispatchEvent = eventObserver.dispatchEvent;
 
   this.init = init;
-  this.expand = expand;
   this.collapse = collapse;
 
   return this;

--- a/cfgov/unprocessed/js/organisms/MegaMenuDesktop.js
+++ b/cfgov/unprocessed/js/organisms/MegaMenuDesktop.js
@@ -1,0 +1,219 @@
+'use strict';
+
+// Required modules.
+var EventObserver = require( '../modules/util/EventObserver' );
+
+/**
+ * MegaMenuDesktop
+ * @class
+ *
+ * @classdesc Behavior for the mega menu at desktop sizes.
+ *
+ * @param {Tree} menus - Tree of FlyoutMenus.
+ * @returns {MegaMenuDesktop} An instance.
+ */
+function MegaMenuDesktop( menus ) {
+
+  // DOM references.
+  var _bodyDom = document.body;
+
+  // Binded functions.
+  var _handleTriggerClickBinded = _handleTriggerClick.bind( this );
+  var _handleTriggerOverBinded = _handleTriggerOver.bind( this );
+  var _handleExpandBeginBinded = _handleExpandBegin.bind( this );
+  var _handleCollapseEndBinded = _handleCollapseEnd.bind( this );
+
+  // Tree model.
+  var _menus = menus;
+
+  //  Currently showing menu picked from the tree.
+  var _activeMenu = null;
+
+  // Whether this instance's behaviors are suspended or not.
+  var _suspended = true;
+
+  /**
+   * @returns {MegaMenuDesktop} An instance.
+   */
+  function init() {
+
+    return this;
+  }
+
+  /**
+   * Pass an event bubbled up from the menus to the appropriate handler.
+   * @param {Event} event - A FlyoutMenu event.
+   */
+  function handleEvent( event ) {
+    if ( !_suspended ) {
+      if ( event.type === 'triggerClick' ) {
+        _handleTriggerClickBinded( event );
+      } else if ( event.type === 'triggerOver' ) {
+        _handleTriggerOverBinded( event );
+      } else if ( event.type === 'expandBegin' ) {
+        _handleExpandBeginBinded( event );
+      } else if ( event.type === 'collapseEnd' ) {
+        _handleCollapseEndBinded( event );
+      }
+    }
+  }
+
+  /**
+   * Event handler for when FlyoutMenu trigger is clicked.
+   * @param {Event} event - A FlyoutMenu event.
+   */
+  function _handleTriggerClick( event ) {
+    this.dispatchEvent( 'triggerClick', { target: this } );
+    var menu = event.target;
+    if ( !menu.isAnimating() ) {
+      if ( _activeMenu === null ) {
+        // A menu is opened.
+        _activeMenu = menu;
+        _activeMenu.getTransition().animateOn();
+        // TODO: Investigate whether mouseout event may be able to be used
+        //       instead of mousemove.
+        _bodyDom.addEventListener( 'mousemove', _handleMove );
+        _bodyDom.addEventListener( 'mouseleave', _handleMove );
+      } else if ( _activeMenu === menu ) {
+        // A menu is closed.
+        _activeMenu.getTransition().animateOn();
+        _activeMenu = null;
+        _bodyDom.removeEventListener( 'mousemove', _handleMove );
+        _bodyDom.removeEventListener( 'mouseleave', _handleMove );
+      } else {
+        // An open menu has switched to another menu.
+        _activeMenu.getTransition().animateOff();
+        _activeMenu.collapse();
+        _activeMenu = event.target;
+        _activeMenu.getTransition().animateOff();
+      }
+    }
+  }
+
+  /**
+   * Event handler for when FlyoutMenu expand transition begins.
+   * Use this to perform post-expandBegin actions.
+   */
+  function _handleExpandBegin() {
+    this.dispatchEvent( 'expandBegin', { target: this } );
+
+    // Set keyboard focus on first menu item link.
+    var activeMenuDom = _activeMenu.getDom().content;
+    activeMenuDom.classList.remove( 'u-invisible' );
+    // TODO: Remove or uncomment when keyboard navigation is in.
+    // var firstMenuLink = activeMenuDom.querySelector( 'a' );
+    // firstMenuLink.focus();
+  }
+
+  /**
+   * Event handler for when FlyoutMenu collapse transition has ended.
+   * Use this to perform post-collapseEnd actions.
+   * @param {Event} event - A FlyoutMenu event.
+   */
+  function _handleCollapseEnd( event ) {
+    this.dispatchEvent( 'collapseEnd', { target: this } );
+    event.target.getDom().content.classList.add( 'u-invisible' );
+  }
+
+  /**
+   * Event handler for when FlyoutMenu trigger is hovered over.
+   * @param {Event} event - A FlyoutMenu event.
+   */
+  function _handleTriggerOver( event ) {
+    this.dispatchEvent( 'triggerOver', { target: this } );
+    var menu = event.target;
+    var level = menu.getData().level;
+
+    // Only trigger a click when rolling over the level one
+    // menu items when in the desktop view.
+    if ( level === 1 && _activeMenu !== menu ) {
+      menu.getDom().trigger.click();
+    }
+  }
+
+  /**
+   * Event handler for when mouse is hovering.
+   * @param {MouseEvent} event - The hovering event.
+   */
+  function _handleMove( event ) {
+    var menu = event.target;
+
+    if ( !_activeMenu.getDom().container.parentNode.contains( menu ) ) {
+      _activeMenu.getDom().trigger.click();
+    }
+  }
+
+  /**
+   * Add events necessary for the desktop menu behaviors.
+   * @returns {boolean} Whether it has successfully been resumed or not.
+   */
+  function resume() {
+    if ( _suspended ) {
+      var level2 = _menus.getAllAtLevel( 1 );
+      var menu;
+      var contentDom;
+      var wrapperDom;
+      var transition;
+      var wrapperSel = '.o-mega-menu_content-2-wrapper';
+      for ( var i = 0, len = level2.length; i < len; i++ ) {
+        menu = level2[i].data;
+        contentDom = menu.getDom().content;
+        wrapperDom = contentDom.querySelector( wrapperSel );
+        transition = menu.getTransition();
+        transition.setElement( wrapperDom );
+        transition.moveUp();
+        // TODO: The only reason hiding is necessary is that the
+        //       drop-shadow of the menu extends below it border,
+        //       so it's still visible when the menu slides -100% out of view.
+        //       Investigate whether it would be better to have a u-move-up-1_1x
+        //       or similar class to move up -110%. Or whether the drop-shadow
+        //       could be included within the bounds of the menu.
+        menu.getDom().content.classList.add( 'u-invisible' );
+        menu.setExpandTransition( transition, transition.moveToOrigin );
+        menu.setCollapseTransition( transition, transition.moveUp );
+        menu.collapse();
+      }
+
+      _suspended = false;
+    }
+
+    return !_suspended;
+  }
+
+  /**
+   * Remove events necessary for the desktop menu behaviors.
+   * @returns {boolean} Whether it has successfully been suspended or not.
+   */
+  function suspend() {
+    if ( !_suspended ) {
+      var level2 = _menus.getAllAtLevel( 1 );
+      var menu;
+      var transition;
+      for ( var i = 0, len = level2.length; i < len; i++ ) {
+        menu = level2[i].data;
+        transition = menu.getTransition();
+        transition.remove();
+        menu.getDom().content.classList.remove( 'u-invisible' );
+      }
+
+      _suspended = true;
+    }
+
+    return _suspended;
+  }
+
+  // Attach public events.
+  var eventObserver = new EventObserver();
+  this.addEventListener = eventObserver.addEventListener;
+  this.removeEventListener = eventObserver.removeEventListener;
+  this.dispatchEvent = eventObserver.dispatchEvent;
+
+  this.handleEvent = handleEvent;
+  this.init = init;
+  this.resume = resume;
+  this.suspend = suspend;
+
+  return this;
+}
+
+module.exports = MegaMenuDesktop;

--- a/cfgov/unprocessed/js/organisms/MegaMenuMobile.js
+++ b/cfgov/unprocessed/js/organisms/MegaMenuMobile.js
@@ -1,0 +1,215 @@
+'use strict';
+
+// Required modules.
+var EventObserver = require( '../modules/util/EventObserver' );
+var MoveTransition = require( '../modules/transition/MoveTransition' );
+var treeTraversal = require( '../modules/util/tree-traversal' );
+
+/**
+ * MegaMenuMobile
+ * @class
+ *
+ * @classdesc Behavior for the mega menu at desktop sizes.
+ *
+ * @param {Tree} menus - Tree of FlyoutMenus.
+ * @returns {MegaMenuMobile} An instance.
+ */
+function MegaMenuMobile( menus ) {
+
+  // DOM references.
+  var _bodyDom = document.body;
+
+  // Binded functions.
+  var _handleExpandBeginBinded = _handleExpandBegin.bind( this );
+  var _handleCollapseBeginBinded = _handleCollapseBegin.bind( this );
+  var _handleCollapseEndBinded = _handleCollapseEnd.bind( this );
+
+  // Tree model.
+  var _menus = menus;
+
+  var _rootMenu;
+
+  //  Currently showing menu picked from the tree.
+  var _activeMenu = null;
+  var _activeMenuDom;
+
+  // Whether this instance's behaviors are suspended or not.
+  var _suspended = true;
+
+  /**
+   * @returns {MegaMenuMobile} An instance.
+   */
+  function init() {
+
+    var rootNode = _menus.getRoot();
+    _rootMenu = rootNode.data;
+    _activeMenu = _rootMenu;
+    _activeMenuDom = _rootMenu.getDom().content;
+
+    return this;
+  }
+
+  function _setTransition( node ) {
+    var menu = node.data;
+    var transition = new MoveTransition( menu.getDom().content ).init();
+    menu.setExpandTransition( transition, transition.moveToOrigin );
+    menu.setCollapseTransition( transition, transition.moveLeft );
+    menu.collapse();
+    transition.moveLeft();
+  }
+
+  /**
+   * Event handler for when there's a click on the page's body.
+   * Used to close the global search, if needed.
+   * @param {MouseEvent} event The event object for the mousedown event.
+   */
+  function _handleBodyClick( event ) {
+    var target = event.target;
+    if ( _activeMenu.getDom().trigger === target ) {
+      return;
+    }
+
+    if ( !_rootMenu.getDom().container.contains( target ) ) {
+      _rootMenu.collapse();
+      _activeMenu.collapse();
+    }
+  }
+
+  /**
+   * Pass an event bubbled up from the menus to the appropriate handler.
+   * @param {Event} event - A FlyoutMenu event.
+   */
+  function handleEvent( event ) {
+    if ( !_suspended ) {
+      if ( event.type === 'expandBegin' ) {
+        _handleExpandBeginBinded( event );
+      } else if ( event.type === 'collapseBegin' ) {
+        _handleCollapseBeginBinded( event );
+      } else if ( event.type === 'collapseEnd' ) {
+        _handleCollapseEndBinded( event );
+      }
+    }
+  }
+
+  /**
+   * Event handler for when the search input flyout is toggled,
+   * which opens/closes the search input.
+   * @param {FlyoutMenu} target - menu that is expanding or collapsing.
+   */
+  function _handleToggle( target ) {
+    if ( target === _rootMenu &&
+         _activeMenu !== target ) {
+      _activeMenu.collapse();
+    }
+    _activeMenu = target;
+    _activeMenuDom = _activeMenu.getDom().content;
+  }
+
+  /**
+   * Event handler for when FlyoutMenu expand transition begins.
+   * Use this to perform post-expandBegin actions.
+   * @param {Event} event - A FlyoutMenu event.
+   */
+  function _handleExpandBegin( event ) {
+    var menu = event.target;
+    _handleToggle( menu );
+    if ( menu === _rootMenu ) {
+      this.dispatchEvent( 'rootExpandBegin', { target: this } );
+    }
+    // If on a submenu, focus the back button, otherwise focus the first link.
+    var firstMenuLink;
+    if ( _activeMenu === _rootMenu ) {
+      firstMenuLink = _activeMenuDom.querySelector( 'a' );
+    } else {
+      firstMenuLink = _activeMenuDom.querySelector( 'button' );
+    }
+
+    firstMenuLink.focus();
+    document.body.addEventListener( 'mousedown', _handleBodyClick );
+  }
+
+  /**
+   * Event handler for when FlyoutMenu collapse transition has begun.
+   * Use this to perform post-collapseBegin actions.
+   * @param {Event} event - A FlyoutMenu event.
+   */
+  function _handleCollapseBegin( event ) {
+    _handleToggle( event.target );
+    document.body.removeEventListener( 'mousedown', _handleBodyClick );
+  }
+
+  /**
+   * Event handler for when FlyoutMenu collapse transition has ended.
+   * Use this to perform post-collapseEnd actions.
+   * @param {Event} event - A FlyoutMenu event.
+   */
+  function _handleCollapseEnd( event ) {
+    if ( event.target === _rootMenu ) {
+      this.dispatchEvent( 'rootCollapseEnd', { target: this } );
+    }
+    document.body.removeEventListener( 'mousedown', _handleBodyClick );
+  }
+
+  /**
+   * Close the mega menu.
+   * @returns {MegaMenuMobile} A instance.
+   */
+  function collapse() {
+
+    // TODO: Combine with `resume` implementation.
+    treeTraversal.bfs( _menus.getRoot(), function( node ) {
+      var menu = node.data;
+      menu.collapse();
+    } );
+
+    return this;
+  }
+
+  /**
+   * Add events necessary for the desktop menu behaviors.
+   * @returns {boolean} Whether it has successfully been resumed or not.
+   */
+  function resume() {
+    if ( _suspended ) {
+      treeTraversal.bfs( _menus.getRoot(), _setTransition );
+      _suspended = false;
+    }
+
+    return !_suspended;
+  }
+
+  /**
+   * Remove events necessary for the desktop menu behaviors.
+   * @returns {boolean} Whether it has successfully been suspended or not.
+   */
+  function suspend() {
+    if ( !_suspended ) {
+      _menus.getRoot().data.getTransition().remove();
+
+      // TODO: Update this to close the menus directly
+      //       so `_handleCollapseEnd` is fired.
+      this.dispatchEvent( 'rootCollapseEnd', { target: this } );
+      document.body.removeEventListener( 'mousedown', _handleBodyClick );
+
+      _suspended = true;
+    }
+
+    return _suspended;
+  }
+
+  // Attach public events.
+  var eventObserver = new EventObserver();
+  this.addEventListener = eventObserver.addEventListener;
+  this.removeEventListener = eventObserver.removeEventListener;
+  this.dispatchEvent = eventObserver.dispatchEvent;
+
+  this.collapse = collapse;
+  this.handleEvent = handleEvent;
+  this.init = init;
+  this.resume = resume;
+  this.suspend = suspend;
+
+  return this;
+}
+
+module.exports = MegaMenuMobile;


### PR DESCRIPTION
## Additions

- Added Tree and tree traversal algorithms (includes https://github.com/cfpb/cfgov-refresh/pull/1542, with code review revisions.)

## Changes

- Added all launch-state mega menu links.
- Added hover-to-show behavior in desktop mega menu. Fixes DFJR 821.
- Renames transition `flush` method to `remove` and makes it so it removes all transition classes (including the base transition class).
- Adds mouseover the trigger event to the flyout menu.
- Adds `isAnimating` method to the flyout menu.

## Testing

- `gulp build`
- Hovery hover and clickety click on the mege menu items at desktop sizes.
- Resize to mobile, repeat.
- Resize to desktop, repeat.
- Clickety click the search too.

## Review

- @KimberlyMunoz 
- @sebworks 
- @jimmynotjim 

## Screenshots

![mobilemegamenu](https://cloud.githubusercontent.com/assets/704760/13690044/54f06e3c-e6fb-11e5-86d3-1d7592cab251.gif)

![desktopmegamenu](https://cloud.githubusercontent.com/assets/704760/13690045/54f273da-e6fb-11e5-9dde-00c99b1817e8.gif)

## Notes

- Includes https://github.com/cfpb/cfgov-refresh/pull/1542, with code review revisions.

## Todos

- Keyboard navigation will be done last, so don't expect it to work.
- The selected state of the menu items at desktop size needs to be worked out. It should be a solid black bar when in a section, but a grey bar when hovering in a section.