### PR TITLE
Adds icon to download icons

### DIFF
--- a/cfgov/unprocessed/css/misc.less
+++ b/cfgov/unprocessed/css/misc.less
@@ -726,6 +726,29 @@
     opacity: 0;
 }
 
+/* topdoc
+  name: Download icons
+  family: cfgov-misc
+  notes:
+    - "Adds download icons to certain links"
+  tags:
+    - cfgov-misc
+*/
+
+
+a[href$='.pdf']:after,
+a[href$='.doc']:after,
+a[href$='.docx']:after,
+a[href$='.xls']:after,
+a[href$='.xlsx']:after,
+a[href$='.csv']:after,
+a[href$='.zip']:after {
+    .cf-icon();
+    display: inline-block;
+    content: @cf-icon-download;
+    width: 1em;
+    text-align: right;
+}
 
 /* topdoc
   name: EOF

--- a/cfgov/unprocessed/css/pages/sub-pages.less
+++ b/cfgov/unprocessed/css/pages/sub-pages.less
@@ -3,17 +3,6 @@
    Sub-Pages pages at /sub-pages/*.
    ========================================================================== */
 
-.sub-page {
-    a[href $='.pdf']:after {
-        .cf-icon();
-        .u-inline-block();
-        width: 1em;
-        content: @cf-icon-download;
-        color: @pacific;
-        text-align: right;
-    }
-}
-
 .sub-page__grandchild,
 .sub-page__grandchild + .content_sidebar {
     padding-top: @grid_gutter-width;
@@ -24,14 +13,5 @@
 .sub-page_privacy-impact-assessments-pias {
     a {
         .jump-link();
-
-        &:after {
-            .cf-icon();
-            .u-inline-block();
-            width: 1em;
-            content: @cf-icon-download;
-            color: @pacific;
-            text-align: right;
-        }
     }
 }


### PR DESCRIPTION
Any link with pdf, doc, docx, xls, xlsx, or zip will get the icon. Fixes #1390 

## Additions

- Adds a download icon to certain links

## Testing

- http://localhost:8000/blog/struggling-to-keep-up-with-student-loan-repayment-2/
- http://localhost:8000/sub-pages/privacy-impact-assessments-pias/

## Review

- @anselmbradford 
- @sebworks 
- @jimmynotjim 

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)