### PR TITLE
Removed potential link to consumer guides section

### DIFF
--- a/cfgov/jinja2/v1/about-us/index.html
+++ b/cfgov/jinja2/v1/about-us/index.html
@@ -25,10 +25,7 @@
                 </a>
             </li>
             <li class="list_item">
-                {# TODO: Add link to Consumer Guides #}
-                <a class="list_link u-link__disabled">
-                    Find resources and tools for consumers
-                </a>
+                Find resources and tools for consumers in the Consumer Tools section
             </li>
             <li class="list_item">
                 <a href="/offices/payments-to-harmed-consumers/"


### PR DESCRIPTION
Since we don't have the Consumer Guides section, this just removes the link

## Testing

- Visit http://localhost:8000/about-us/

## Review

- @schaferjh 

## Screenshots

![image](https://cloud.githubusercontent.com/assets/1860176/13717364/f7a47e80-e7ae-11e5-8734-731295cb6271.png)

