### PR TITLE
Fix report slugs

### DIFF
--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -268,6 +268,11 @@ SHEER_PROCESSORS = \
             "url": "$WORDPRESS/api/get_posts/?post_type=faq",
             "processor": "processors.wordpress_faq",
             "mappings": MAPPINGS.child("faq.json")
+        },
+        "report": {
+            "url": "$WORDPRESS/api/get_posts/?post_type=cfpb_report",
+            "processor": "processors.wordpress_cfpb_report",
+            "mappings": MAPPINGS.child("report.json")
         }
     }
 

--- a/cfgov/cfgov/urls.py
+++ b/cfgov/cfgov/urls.py
@@ -4,7 +4,7 @@ from django.contrib import admin
 from django.conf import settings
 from django.conf.urls.static import static
 from django.conf.urls import include, url
-from django.views.generic.base import TemplateView
+from django.views.generic.base import TemplateView, RedirectView
 from sheerlike.views.generic import SheerTemplateView
 from sheerlike.feeds import SheerlikeFeed
 from sheerlike.sites import SheerSite
@@ -252,6 +252,8 @@ urlpatterns = [
     url(r'^oah-api/rates/', include_if_app_enabled('ratechecker', 'ratechecker.urls')),
     url(r'^oah-api/county/', include_if_app_enabled('countylimits','countylimits.urls')),
 
+    # Report redirects
+    url(r'^reports/(?P<path>.*)$', RedirectView.as_view(url='/data-research/research-reports/%(path)s')),
 ]
 if 'cfpb_common' in settings.INSTALLED_APPS:
     pattern=url(r'^token-provider/', 'cfpb_common.views.token_provider')

--- a/cfgov/es_mappings/report.json
+++ b/cfgov/es_mappings/report.json
@@ -1,0 +1,10 @@
+{
+    "properties": {
+        "title": {
+            "type": "string"
+        },
+        "slug": {
+            "type": "string"
+        }
+    }
+}

--- a/cfgov/jinja2/v1/_queries/reports.json
+++ b/cfgov/jinja2/v1/_queries/reports.json
@@ -1,0 +1,7 @@
+{
+  "name": "Reports",
+  "query": {
+    "doc_type": "report",
+    "size": 10000
+  }
+}

--- a/cfgov/processors/wordpress_cfpb_report.py
+++ b/cfgov/processors/wordpress_cfpb_report.py
@@ -1,0 +1,36 @@
+import sys
+import json
+import os.path
+import requests
+
+
+def posts_at_url(url):
+
+    current_page = 1
+    max_page = sys.maxint
+
+    while current_page <= max_page:
+        url = os.path.expandvars(url)
+        resp = requests.get(url, params={'page': current_page, 'count': '-1'})
+        results = json.loads(resp.content)
+        current_page += 1
+        max_page = results['pages']
+
+        for p in results['posts']:
+            yield p
+
+
+def documents(name='', url='', **kwargs):
+
+    for post in posts_at_url(url):
+        yield process_post(post)
+
+
+def process_post(page):
+
+    del page['comments']
+    page['_id'] = page['id']
+
+    return {'_type': 'report',
+            '_id': page['id'],
+            '_source': page}

--- a/cfgov/scripts/report_slugs.py
+++ b/cfgov/scripts/report_slugs.py
@@ -1,0 +1,41 @@
+import json
+from wagtail.wagtailcore.models import Page, PageRevision
+from sheerlike.query import QueryFinder
+
+
+def run():
+    qf = QueryFinder()
+    es_reports = qf.reports.search(use_url_arguments=False)
+    results = {'successful': [], 'errors': {}, 'multiple_hits': {}}
+    for es_report in es_reports:
+        try:
+            reports = Page.objects.filter(title=es_report.title)
+            if len(reports) > 1:
+                results['multiple_hits'][str(len(reports))] = es_report.title
+                continue
+            elif not reports:
+                continue
+            report = reports.first()
+            if report.slug == es_report.slug:
+                continue
+            old_slug = report.slug
+            report.slug = es_report.slug
+            report.save()
+            revisions = PageRevision.objects.filter(page=report).order_by('id')
+            for revision in revisions:
+                page_content = json.loads(revision.content_json)
+                page_content['slug'] = es_report.slug
+                content = json.dumps(page_content)
+                revision.content_json = content
+                revision.save()
+            results['successful'].append(old_slug + ' -- changed to --> ' + report.slug)
+        except Exception as e:
+            results['errors'][es_report.title] = e
+    for key, values in results.iteritems():
+        print key
+        if type(values) is dict:
+            for k, v in values.iteritems():
+                print k, ':', v
+        else:
+            for v in values:
+                print v


### PR DESCRIPTION
There are pages created in wagtail that have wordpress counterparts. Many of these pages have slightly different slugs and all of them are located under a different root path. This adds a django script to change the slugs on the wagtail pages to their counterparts' and adds a rule to redirect from the original path to the new one.

## Additions

- Redirect path
- Script to change report slugs
- report mapping for elasticsearch
- sheer processor for report

## Changes

- Change the sheerlike.query module to only use the get request when specifically told to do so.

## Testing

- use a refresh db dump
- run `./cfgov/manage.py sheer_index`
- go to `http://content.localhost:8000/data-research/research-reports/using-publicly-available-information-proxy-unidentified-race-and-ethnicity/` and check the slug
 - this slug should be `using-publicly-available-information-to-proxy-for-unidentified-race-and-ethnicity`
 - ` run ./cfgov/manage.py runscript report_slugs`
- check the page to see if the slug has been changed correctly
- go back to the page
- attempt to go to `http://content.localhost:8000/reports/using-publicly-available-information-to-proxy-for-unidentified-race-and-ethnicity/`
 - this should redirect to the `/data-research/research-reports/using-publicly-available-information-to-proxy-for-unidentified-race-and-ethnicity`

## Review

- @kave 
- @richaagarwal 
- @rosskarchner 

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Passes all existing automated tests
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
