### PR TITLE
Side Navigation now pulling in Archive Event Page correctly

### DIFF
--- a/cfgov/scripts/archive_events.py
+++ b/cfgov/scripts/archive_events.py
@@ -6,19 +6,18 @@ from django.contrib.auth.hashers import make_password
 from django.contrib.auth.models import User
 
 from v1.models.learn_page import EventPage
-from v1.models.browse_page import BrowsePage
-from v1.models.browse_filterable_page import EventArchivePage
+from v1.models.browse_filterable_page import BrowseFilterablePage, EventArchivePage
 from wagtail.wagtailcore.models import Page
 from modelcluster.models import get_all_child_relations
 
 
 def run():
-    event_page_exists = BrowsePage.objects.filter(title='Events').exists()
-    archive_event_page_exists = EventArchivePage.objects.filter(title='Archive').exists()
+    event_page_exists = BrowseFilterablePage.objects.filter(title='Events').exists()
+    archive_event_page_exists = EventArchivePage.objects.filter(title__icontains='Archive').exists()
 
     if event_page_exists and archive_event_page_exists:
-        events = BrowsePage.objects.get(title='Events')
-        archived_events = EventArchivePage.objects.get(title='Archive')
+        events = BrowseFilterablePage.objects.get(title='Events')
+        archived_events = EventArchivePage.objects.get(title__icontains='Archive')
 
         if len(events.get_children()) > 1:
             for child in events.get_children():
@@ -32,8 +31,8 @@ def run():
         else:
             print 'No events to archive found....'
     elif not event_page_exists:
-        print 'Events browse page has not been created....'
+        print 'Events browse filterable page has not been created....'
     elif not archive_event_page_exists:
-        print 'No Archived events Browse page named \'Archive\' exist....'
+        print 'No Archived events Browse filterable page named \'Archive\' exist....'
     else:
         print 'No events exist in the database...'

--- a/cfgov/v1/models/browse_filterable_page.py
+++ b/cfgov/v1/models/browse_filterable_page.py
@@ -53,7 +53,7 @@ class BrowseFilterablePage(base.CFGOVPage):
 
 
     def get_form_class(self):
-        return filterable_context.get_form_class(self)
+        return filterable_context.get_form_class()
 
     def get_page_set(self, form, hostname):
         return filterable_context.get_page_set(self, form, hostname)

--- a/cfgov/v1/models/sublanding_filterable_page.py
+++ b/cfgov/v1/models/sublanding_filterable_page.py
@@ -49,7 +49,7 @@ class SublandingFilterablePage(base.CFGOVPage):
         return filterable_context.get_context(self, request, context)
 
     def get_form_class(self):
-        return filterable_context.get_form_class(self)
+        return filterable_context.get_form_class()
 
     def get_page_set(self, form, hostname):
         return filterable_context.get_page_set(self, form, hostname)

--- a/cfgov/v1/util/filterable_context.py
+++ b/cfgov/v1/util/filterable_context.py
@@ -66,7 +66,7 @@ def get_form_specific_filter_data(page, form_class, request_dict):
 
 # Returns a queryset of AbstractFilterPages
 def get_page_set(page, form, hostname):
-    from ..models.browse_filterable_page import EventArchivePage, BrowseFilterablePage
+    from ..models.browse_filterable_page import EventArchivePage
     # If this is the Newsroom, then we need to go get the blog
     # from a different part of the site.
     blog_q = Q()

--- a/cfgov/v1/util/filterable_context.py
+++ b/cfgov/v1/util/filterable_context.py
@@ -33,8 +33,10 @@ def get_context(page, request, context):
         context['forms'].append(form)
     return context
 
+
 def get_form_class():
     return forms.FilterableListForm
+
 
 # Transform each GET parameter key from unique ID for the form in the
 # request and assign it to a dictionary under the form ID from where it
@@ -61,8 +63,10 @@ def get_form_specific_filter_data(page, form_class, request_dict):
                     request_dict.get(request_field_name, '')
     return filters_data
 
+
 # Returns a queryset of AbstractFilterPages
 def get_page_set(page, form, hostname):
+    from ..models.browse_filterable_page import EventArchivePage, BrowseFilterablePage
     # If this is the Newsroom, then we need to go get the blog
     # from a different part of the site.
     blog_q = Q()
@@ -77,7 +81,12 @@ def get_page_set(page, form, hostname):
     results = base.CFGOVPage.objects.live_shared(hostname).descendant_of(
         page).filter(form.generate_query() | blog_q).specific()
 
-    filter_pages = [page for page in results if isinstance(page, AbstractFilterPage)]
+    if isinstance(page, EventArchivePage):
+        filter_pages = [page for page in results if isinstance(page, AbstractFilterPage)]
+    else:
+        filter_pages = [page for page in results if
+                        isinstance(page, AbstractFilterPage) and not isinstance(page.get_parent().specific,
+                                                                                EventArchivePage)]
+
     filter_pages.sort(key=lambda x: x.date_published, reverse=True)
     return filter_pages
-

--- a/cfgov/v1/util/util.py
+++ b/cfgov/v1/util/util.py
@@ -68,13 +68,18 @@ def get_form_id(page, get_request):
         return None
 
 
+def instanceOfBrowseOrFilterablePages(page):
+    from ..models import BrowsePage, BrowseFilterablePage
+    return isinstance(page, BrowsePage) or isinstance(page, BrowseFilterablePage)
+
+
 # For use by Browse type pages to get the secondary navigation items
 def get_secondary_nav_items(current, hostname, exclude_siblings=False):
     from ..templatetags.share import get_page_state_url
     on_staging = os.environ.get('STAGING_HOSTNAME') == hostname
     nav_items = []
     parent = current.get_parent().specific
-    page = parent if 'Browse' in parent.specific_class.__name__ else current
+    page = parent if instanceOfBrowseOrFilterablePages(parent) else current
 
     pages = [page] if page.secondary_nav_exclude_sibling_pages else page.get_appropriate_siblings(hostname)
 
@@ -90,7 +95,7 @@ def get_secondary_nav_items(current, hostname, exclude_siblings=False):
             }
             children = sibling.get_children().specific()
             for child in [c for c in children if (on_staging and c.shared) or c.live]:
-                if 'Browse' in child.specific_class.__name__:
+                if instanceOfBrowseOrFilterablePages(child):
                     item['children'].append({
                         'title': child.title,
                         'slug': child.slug,


### PR DESCRIPTION
## Changes

- Checking for class instances of Browse & BrowseFilterable Pages for Side Navigation
- Fixed events pages so it only renders non-archived events

## Testing

- load latest refresh DB
- visit `http://content.localhost:8000/about-us/events2/`

## Review

- @kurtw 
- @richaagarwal 

## Screenshots

<img width="280" alt="screen shot 2016-03-15 at 8 48 42 am" src="https://cloud.githubusercontent.com/assets/254877/13778191/bf3a8588-ea8a-11e5-88e4-9fe00f8ae8d1.png">



## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)

