### PR TITLE
Fix sheerlike date functions bug for timezones

### DIFF
--- a/cfgov/jinja2/v1/_includes/macros/time.html
+++ b/cfgov/jinja2/v1/_includes/macros/time.html
@@ -21,7 +21,7 @@
 
 {% macro render(datetime,
                 show_only={'date':true, 'time':true, 'timezone':true},
-                timezone='America/New_York') %}
+                timezone=none) %}
 <span class="datetime">
     {% if show_only.date == true  %}
     <time class="datetime_date" datetime="{{ dt.format_datetime(datetime) }}">

--- a/cfgov/jinja2/v1/_includes/macros/util/format/datetime.html
+++ b/cfgov/jinja2/v1/_includes/macros/util/format/datetime.html
@@ -20,13 +20,11 @@
 
    ========================================================================== #}
 
-{% macro format_time(datetime, timezone) %}
-    {% set parse_timezone = 'America/New_York'
-                            if timezone == '' else timezone %}
-    {% if parse_timezone is defined %}
-    {{- datetime | date('%I:%M %p %Z', parse_timezone) -}}
+{% macro format_time(datetime, timezone=none) %}
+    {% if timezone %}
+        {{- datetime | date('%I:%M %p %Z', timezone) -}}
     {% else %}
-    {{- datetime | date('%I:%M %p') -}}
+        {{- datetime | date('%I:%M %p') -}}
     {% endif %}
 {% endmacro %}
 

--- a/cfgov/sheerlike/__init__.py
+++ b/cfgov/sheerlike/__init__.py
@@ -17,7 +17,7 @@ from unipath import Path
 
 from .query import QueryFinder, more_like_this, get_document, when
 from .filters import selected_filters_for_field, is_filter_selected
-from .templates import date_filter
+from .templates import get_date_string
 from .middleware import get_request
 
 from flags.template_functions import flag_enabled, flag_disabled
@@ -101,6 +101,6 @@ def environment(**options):
         'flag_disabled': flag_disabled,
     })
     env.filters.update({
-        'date': date_filter
+        'date': get_date_string
     })
     return env

--- a/cfgov/sheerlike/templates.py
+++ b/cfgov/sheerlike/templates.py
@@ -3,27 +3,26 @@ from dateutil import parser
 from pytz import timezone
 
 
-def date_filter(value, format="%Y-%m-%d", tz='America/New_York'):
-    if value:
-        if type(value) not in [datetime.datetime, datetime.date]:
-            date = parser.parse(value,
+def _convert_date(date, tz):
+    if date:
+        if isinstance(date, basestring):
+            date = parser.parse(date,
                                 default=datetime.datetime.today().replace(day=1))
-            naive = date.replace(tzinfo=None)
-            dt = timezone(tz).localize(naive)
-        else:
-            dt = value
+        if type(date) in [datetime.datetime, datetime.date]:
+            if isinstance(date, datetime.datetime):
+                pytzone = timezone(tz)
+                if not date.tzinfo:
+                    date = pytzone.localize(date)
+                else:
+                    date = date.astimezone(pytzone)
+    return date
 
-        return dt.strftime(format)
-    else:
-        return ''
+
+def get_date_string(date, format="%Y-%m-%d", tz='America/New_York'):
+    dt = _convert_date(date, tz)
+    return dt.strftime(format)
 
 
-def date_formatter(value, format='%d/%m/%Y', tz='America/New_York'):
-    if type(value) not in [datetime.datetime, datetime.date]:
-        date = parser.parse(value,
-                            default=datetime.datetime.today().replace(day=1))
-        naive = date.replace(tzinfo=None)
-        dt = timezone(tz).localize(naive)
-    else:
-        dt = value
+def get_date_obj(date, tz='America/New_York'):
+    dt = _convert_date(date, tz)
     return dt

--- a/cfgov/sheerlike/test_templates.py
+++ b/cfgov/sheerlike/test_templates.py
@@ -1,28 +1,31 @@
-from .templates import date_formatter
+from django.test import TestCase
+
+from .templates import get_date_string
 
 
-class TestTemplates(object):
+class TestTemplates(TestCase):
 
-    def test_date_formatter(self):
+    def test_get_date_obj(self):
         date_string = '2012-02'
-        result = date_formatter(date_string)
+        result = get_date_string(date_string)
         assert(result == '2012-02-01')
 
     def test_different_date_format(self):
         date_string = '2015-02-01T22:00:00'
         date_format = '%-I:%M%p %B %-d, %Y'
-        result = date_formatter(date_string, date_format)
+        result = get_date_string(date_string, date_format)
         assert(result == '10:00PM February 1, 2015')
 
     def test_default_timezone_is_eastern(self):
         date_string = '2015-02-01T22:00:00'
         date_format = '%Y-%m-%d %Z'
-        result = date_formatter(date_string, date_format)
-        assert(result == '2015-02-01 EST')
+        result = get_date_string(date_string, date_format)
+        assert(result == '2015-02-01 EST' or result == '2015-02-01 EDT')
 
     def test_use_different_timezone(self):
         date_string = '2015-02-01T22:00:00'
         date_format = '%Y-%m-%d %Z'
         tz = 'America/Chicago'
-        result = date_formatter(date_string, date_format, tz)
+        result = get_date_string(date_string, date_format, tz)
+        print result
         assert(result == '2015-02-01 CST')

--- a/cfgov/v1/forms.py
+++ b/cfgov/v1/forms.py
@@ -13,7 +13,7 @@ from django.contrib.auth import authenticate
 from django.conf import settings
 from django.forms import widgets
 
-from sheerlike.templates import date_formatter
+from sheerlike.templates import get_date_obj
 from .models import ref
 from .models.base import CFGOVPage
 from .util.util import most_common
@@ -111,7 +111,7 @@ class FilterDateField(forms.DateField):
     def clean(self, value):
         if value:
             try:
-                value = date_formatter(value)
+                value = get_date_obj(value)
             except Exception as e:
                 pass
         return value


### PR DESCRIPTION
Dates were being output with the UTC timezone instead of the appropriate timezone (mainly Eastern). This fixes the functions that are used to convert the given timestamps into the correct timezones.

## Additions

- helper function for DRYness

## Changes

- The functions now use the same logic but return different types and their names reflect that (str vs date obj)

## Fixes

- Sheerlike tests for the templates are now being run 

## Testing

- Run `tox`
- Check out a list page with dates. Really any date being outputted on the site.
- Check out a browsefilterablepage and filter using dates. That should also work.

## Review

- @kave 
- @richaagarwal 

## Screenshots
![screen shot 2016-03-16 at 2 31 59 pm](https://cloud.githubusercontent.com/assets/1412978/13824315/e17e7164-eb83-11e5-8410-0d163a468e1b.png)


## Notes

- The other sheerlike tests need to be updated too, but that's out of scope for this PR
- Maybe more tests. See if we have time later or post launch

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Passes all existing automated tests
* [x] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)

