### PR TITLE
fixed category filtering on sheer pages

### DIFF
--- a/cfgov/jinja2/v1/_includes/macros/category-slug.html
+++ b/cfgov/jinja2/v1/_includes/macros/category-slug.html
@@ -27,13 +27,15 @@
 
    ========================================================================== #}
 
-{% macro render(category, href, classes, use_blog_category=false, index=0) %}
+{% macro render(category, href, classes, use_blog_category=false, index=0, sheerpage=false) %}
     {% import 'macros/category-icon.html' as category_icon %}
 
     {% if href %}
         {# TODO: Remove use_blog_category parameter when this element becomes atomic. #}
         {% if use_blog_category %}
             {% set href = href + '?filter_blog_category=' + category | urlencode | replace('%20', '+') %}
+        {% elif sheerpage %}
+            {% set href = href + '?filter_category=' + category | urlencode | replace('%20', '+') %}
         {% else %}
             {% set href = href + '?filter' + index | string + '_categories=' + category | urlencode | replace('%20', '+') %}
         {% endif %}

--- a/cfgov/jinja2/v1/_includes/organisms/post-preview.html
+++ b/cfgov/jinja2/v1/_includes/organisms/post-preview.html
@@ -44,7 +44,8 @@
 {% from 'macros/util/format/url.html' import location_image_url as location_image_url %}
 
 {% macro render(post, type='', form_id=0, url='') %}
-    {% set url = url or get_page_state_url({'request':request}, post) %}
+    {% set page_url = url or get_page_state_url({'request':request}, page) %}
+    {% set post_url = get_page_state_url({'request':request}, post) %}
     <article class="o-post-preview">
         <div class="meta-header">
             <span class="date meta-header_right">
@@ -54,7 +55,7 @@
             {% if 'newsroom' in type %}
                 {% if is_blog(post) %}
                     {{ category_slug.render('blog',
-                            url,
+                            page_url,
                             'post_slug meta-header_left',
                             false, form_id) }}
                 {% endif %}
@@ -64,7 +65,7 @@
                         |
                     {% endif %}
                     {{ category_slug.render(cat.name,
-                            url,
+                            page_url,
                             'post_slug meta-header_left',
                             false, form_id) }}
                 {% endfor %}
@@ -108,7 +109,7 @@
         <div class="o-post-preview_content">
 
             <h3 class="o-post-preview_title">
-                <a href="{{ get_page_state_url({'request':request}, post) }}">
+                <a href="{{ post_url }}">
                     {{ post.preview_title | safe if post.preview_title else post.title }}
                 </a>
             </h3>
@@ -140,15 +141,15 @@
                 {% for author in post.authors.names() %}
                     <span class="o-post-preview_byline">
                         {% if loop.index == 1  %}
-                            By <a href="{{ url }}?filter{{ form_id }}_authors={{ author }}">
+                            By <a href="{{ page_url }}?filter{{ form_id }}_authors={{ author }}">
                                 {{ author }}
                                 </a>
                         {% elif loop.last == true %}
-                            and <a href="{{ url }}?filter{{ form_id }}_authors={{ author }}">
+                            and <a href="{{ page_url }}?filter{{ form_id }}_authors={{ author }}">
                                 {{ author }}
                                 </a>
                         {% else %}
-                            ,<a href="{{ url }}?filter{{ form_id }}_authors={{ author }}">
+                            ,<a href="{{ page_url }}?filter{{ form_id }}_authors={{ author }}">
                                 {{ author }}
                                 </a>
                         {% endif %}
@@ -157,7 +158,7 @@
 
                 {% if post.tags.names() | length %}
                     {%- import 'tags.html' as tags %}
-                    {{ tags.render(post.tags.names(), url, true, false, form_id) }}
+                    {{ tags.render(post.tags.names(), page_url, true, false, form_id) }}
                 {% endif %}
             </div>
             {% if post.preview_link_url and post.preview_link_text %}

--- a/cfgov/jinja2/v1/_includes/posts-paginated.html
+++ b/cfgov/jinja2/v1/_includes/posts-paginated.html
@@ -15,7 +15,7 @@
         {% set use_blog_category = true %}
     {% elif post.category %}
         {% set category = post.category %}
-        {% set use_blog_category = false %}
+        {% set sheer_page = true %}
     {% endif -%}
     {%- import 'macros/category-slug.html' as category_slug %}
 
@@ -35,7 +35,7 @@
                     {% set slug = category_slug.render(cat,
                                                        vars.path,
                                                        'meta-header_left',
-                                                       use_blog_category) %}
+                                                       use_blog_category, 0, sheer_page) %}
                     {{ slug }}
                 {% endfor %}
             {% endif %}


### PR DESCRIPTION
## Changes

- Included a new flag to handle category slug creation for sheer page filtering
- Fixed links in Post Preview elements so they filter on the page correctly

## Testing
- Import refresh db
- visit `http://localhost:8000/newsroom/` and click on a category
- visit `http://content.localhost:8000/policy-compliance/enforcement/actions/` and click on categories or tags to see page filter correctly:
<img width="904" alt="screen shot 2016-03-16 at 3 53 49 pm" src="https://cloud.githubusercontent.com/assets/254877/13826722/4e0216e6-eb8f-11e5-8031-32479c92cd2b.png">


## Review

- @kurtw 
- @richaagarwal 

## Screenshots

<img width="913" alt="screen shot 2016-03-16 at 3 36 24 pm" src="https://cloud.githubusercontent.com/assets/254877/13826248/e674facc-eb8c-11e5-97f1-c20dbc5c2407.png">

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [x] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)

