### PR TITLE
Fix filterable list page set retrieval

### DIFF
--- a/cfgov/v1/models/learn_page.py
+++ b/cfgov/v1/models/learn_page.py
@@ -75,6 +75,8 @@ class AbstractFilterPage(CFGOVPage):
     # This page class cannot be created.
     is_creatable = False
 
+    objects = CFGOVPageManager()
+
     def related_metadata_tags(self, get_request):
         # Set the tags to correct data format
         tags = {'links': []}

--- a/cfgov/v1/util/filterable_context.py
+++ b/cfgov/v1/util/filterable_context.py
@@ -78,8 +78,8 @@ def get_page_set(page, form, hostname):
                 blog_cats = [c[0] for c in ref.categories[1][1]]
                 blog_q = Q('categories__name__in', blog_cats)
 
-    results = base.CFGOVPage.objects.live_shared(hostname).descendant_of(
-        page).filter(form.generate_query() | blog_q).specific()
+    results = AbstractFilterPage.objects.live_shared(hostname).descendant_of(
+        page).filter(form.generate_query() | blog_q)
 
     if isinstance(page, EventArchivePage):
         filter_pages = [page for page in results if isinstance(page, AbstractFilterPage)]


### PR DESCRIPTION
A new manager for the pages was necessary to get the `date_published` from the queryset. For whatever reason, even though the objects within the queryset had `date_published` the queryset itself was not filterable on that field. Go figure. 

@richaagarwal 
@kave 