### PR TITLE
Script to move reports to a given page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Added tests for `external-site-redirect.js`
 - Frontend: Added JS Tree data structure and traversal algorithms.
 - Add text intro and featured content to SublandingFilterablePage
+- Add a script `move_reports.py` to move all reports under a given SublandingFilterablePage
 
 ### Changed
 - Converted the project to Capital Framework v3

--- a/cfgov/scripts/move_reports.py
+++ b/cfgov/scripts/move_reports.py
@@ -1,0 +1,25 @@
+import sys
+from v1.models.browse_filterable_page import BrowseFilterablePage
+from v1.models.sublanding_filterable_page import SublandingFilterablePage
+
+def run(page_title):
+    reports_page_exists = BrowseFilterablePage.objects.filter(title='Research and reports').exists()
+    sublanding_filterable_page_exists = SublandingFilterablePage.objects.filter(title=page_title).exists()
+
+    if sublanding_filterable_page_exists and reports_page_exists:
+        reports = BrowseFilterablePage.objects.get(title='Research and reports')
+        sublanding_pages = SublandingFilterablePage.objects.get(title=page_title)
+
+        if len(reports.get_children()) >= 1:
+            for child in reports.get_children():
+                report = child.specific
+                if report.can_move_to(sublanding_pages):
+                    report.move(sublanding_pages, pos='last-child')
+                    print report.title + ' Report .....archived'
+        else:
+            print 'No report to archive found....'
+    elif not sublanding_filterable_page_exists:
+        print 'Sublanding filterable page named \'%s\' has not been created....' %(page_title)
+    elif not reports_page_exists:
+        print 'No Browse filterable page named \'Research and reports\' exists....'
+


### PR DESCRIPTION
Move all the reports under the browse filterable page `Research and reports` (http://localhost:8000/admin/pages/159/edit/) to the new sublanding filterable page they will be creating.

## Additions

- Add a script `move_reports.py` to move all reports under a given SublandingFilterablePage


## Testing

- Create a SublandingFilterablePage locally, name it whatever you want. e.g. Placeholder
- python cfgov/manage.py runscript move_reports --script-args=Placeholder
- (Replace Placeholder above with whatever you named it, if you didn't name it Placeholder :) )

## Review

- @kave @kurtw 

## Notes

- Jira task mentioned several implementation details, one of which was "Creation of a script to take a list of id's as a parameter and move them to a destination id." That seems a bit burdensome in this case for the user, so I'm not going to do that, but if that's important for some other tasks, let's log those separately. 

## Todos

- Possibly anything that comes out of the Notes above

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [x] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)