### PR TITLE
Mega Menu: Suspend 3rd level menu at desktop

### DIFF
--- a/cfgov/jinja2/v1/_includes/organisms/_vars-mega-menu.html
+++ b/cfgov/jinja2/v1/_includes/organisms/_vars-mega-menu.html
@@ -65,7 +65,7 @@
     ),(
         ('Credit Card Surveys & Agreements', '/data-research/credit-card-data/', []),
     )]),
-    ('Policy & Compliance', '/policy-and-compliance/', [(
+    ('Policy & Compliance', '/policy-compliance/', [(
         ('Rulemaking', '/policy-compliance/rulemaking/', [(
             ('Final Rules', '/policy-compliance/rulemaking/final-rules/', []),
             ('Rules Under Development', '/policy-compliance/rulemaking/rules-under-development/', []),
@@ -95,7 +95,7 @@
     )]),
     ('About Us', '/about-us/', [(
         ('The Bureau', '/the-bureau/', []),
-        ('Budget and Strategy', '/about-us/budget-strategy/', []),
+        ('Budget & Strategy', '/about-us/budget-strategy/', []),
         ('Payments to Harmed Consumers',
          '/about-us/payments-harmed-consumers/', [])
     ),(

--- a/cfgov/unprocessed/js/organisms/MegaMenuDesktop.js
+++ b/cfgov/unprocessed/js/organisms/MegaMenuDesktop.js
@@ -174,6 +174,13 @@ function MegaMenuDesktop( menus ) {
         menu.collapse();
       }
 
+      // TODO: Combine this loop with the above
+      //       into a Breadth-First Search iteration.
+      var level3 = _menus.getAllAtLevel( 2 );
+      for ( var i2 = 0, len2 = level3.length; i2 < len2; i2++ ) {
+        level3[i2].data.suspend();
+      }
+
       _suspended = false;
     }
 


### PR DESCRIPTION
## Changes

- Updates incorrect URL and replaces `and` with `&` in menu item text.
- Adds method to suspend/resume trigger events on a flyout menu.
- Suspends trigger events on the 3rd-level trigger at the desktop menu size so that the triggers (e.g. About Us > Careers) won't prevent the default link behavior.

## Testing

- On refresh clicking About Us > Careers just closes the mega menu. Run `gulp build` and see that going from About Us > Careers goes to the careers overview page.

## Review

- @jimmynotjim 
- @KimberlyMunoz 
- @sebworks 
