### PR TITLE
Rich text Internal links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Add text intro and featured content to SublandingFilterablePage
 - Add a script `move_reports.py` to move all reports under a given SublandingFilterablePage
 - Add a 'careers_preview' query to limit the results to 5
+- Added CFGovLinkHandler to convert richtext internal links to relative links
 
 ### Changed
 - Converted the project to Capital Framework v3

--- a/cfgov/v1/wagtail_hooks.py
+++ b/cfgov/v1/wagtail_hooks.py
@@ -66,7 +66,6 @@ def register_share_permissions():
     return Permission.objects.filter(codename='share_page')
 
 
-
 class CFGovLinkHandler(object):
     """
     CFGovLinkHandler will be invoked whenever we encounter an <a> element in HTML content
@@ -93,8 +92,6 @@ class CFGovLinkHandler(object):
                 editor_attrs = 'data-linktype="page" data-id="%d" ' % page.id
             else:
                 editor_attrs = ''
-
-            # TODO Add check for External Links to include icon css class
 
             return '<a %shref="%s">' % (editor_attrs, escape(urlsplit(page.url).path))
         except Page.DoesNotExist:

--- a/cfgov/v1/wagtail_hooks.py
+++ b/cfgov/v1/wagtail_hooks.py
@@ -1,9 +1,12 @@
 import os
 import json
+from urlparse import urlsplit
 
 from django.http import Http404
 from django.contrib.auth.models import Permission
+from django.utils.html import escape
 
+from wagtail.wagtailcore.models import Page
 from wagtail.wagtailcore import hooks
 
 from v1.models import CFGOVPage
@@ -49,6 +52,7 @@ def share_the_page(request, page):
     if is_publishing:
         latest.publish()
 
+
 @hooks.register('before_serve_page')
 def check_request_site(page, request, serve_args, serve_kwargs):
     if request.site.hostname == os.environ.get('STAGING_HOSTNAME'):
@@ -60,3 +64,43 @@ def check_request_site(page, request, serve_args, serve_kwargs):
 @hooks.register('register_permissions')
 def register_share_permissions():
     return Permission.objects.filter(codename='share_page')
+
+
+
+class CFGovLinkHandler(object):
+    """
+    CFGovLinkHandler will be invoked whenever we encounter an <a> element in HTML content
+    with an attribute of data-linktype="page". The resulting element in the database
+    representation will be:
+    <a linktype="page" id="42">hello world</a>
+    """
+
+    @staticmethod
+    def get_db_attributes(tag):
+        """
+        Given an <a> tag that we've identified as a page link embed (because it has a
+        data-linktype="page" attribute), return a dict of the attributes we should
+        have on the resulting <a linktype="page"> element.
+        """
+        return {'id': tag['data-id']}
+
+    @staticmethod
+    def expand_db_attributes(attrs, for_editor):
+        try:
+            page = Page.objects.get(id=attrs['id'])
+
+            if for_editor:
+                editor_attrs = 'data-linktype="page" data-id="%d" ' % page.id
+            else:
+                editor_attrs = ''
+
+            # TODO Add check for External Links to include icon css class
+
+            return '<a %shref="%s">' % (editor_attrs, escape(urlsplit(page.url).path))
+        except Page.DoesNotExist:
+            return "<a>"
+
+
+@hooks.register('register_rich_text_link_handler')
+def register_cfgov_link_handler():
+    return ('page', CFGovLinkHandler)


### PR DESCRIPTION
## Additions

- registered cfgov link handler for rich text fields.
 - This strips the hostname from internal links allowing them to be relative.

## Changes
- refactored atomic element templates to not use `.source` attribute of rich text fields as this renders links & embedded data incorrectly and therefore doesn't allow full use of editor features.

## Testing

- Create a `DemoPage` and create a text introduction.
- In the `Intro` field create an internal link and share it. Visit shared page and verify link has `content.localhost` associated with it
- Publish created page. Visit published page url and verify link has `localhost` associated with it

## Review

- @kurtw 
- @richaagarwal 

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
