### PR TITLE
Adding back line between mobile eyebrow and items

### DIFF
--- a/cfgov/unprocessed/css/molecules/global-eyebrow.less
+++ b/cfgov/unprocessed/css/molecules/global-eyebrow.less
@@ -110,6 +110,7 @@
         padding-right: unit( ( @grid_gutter-width / 4 ) * 3 / @base-font-size-px, em );
         padding-top: unit( @grid_gutter-width / 2 / @base-font-size-px, em );
         padding-bottom: unit( @grid_gutter-width / @base-font-size-px, em );
+        border-top: 1px solid @gray-40;
 
         .m-global-eyebrow_tagline {
             background-position-y: unit( @grid_gutter-width / 2 / @base-font-size-px, em );


### PR DESCRIPTION
Quick fix to the global eyebrow on mobile. There's a line between the items and the eyebrow that was removed in #1586, this adds it back.

## Testing

- `gulp build` and check on mobile. Compare it to Flapjack.

## Review

- @anselmbradford 

## Screenshots

![image](https://cloud.githubusercontent.com/assets/1860176/13858031/15e3c48e-ec53-11e5-92f5-cb125eaa7844.png)