### PR TITLE
Fix related posts

### DIFF
--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -282,6 +282,10 @@ SHEER_ELASTICSEARCH_SETTINGS = \
                 "analyzer": {
                     "my_edge_ngram_analyzer": {
                         "tokenizer": "my_edge_ngram_tokenizer"
+                    },
+                    "tag_analyzer": {
+                       "tokenizer": "keyword",
+                       "filter": "lowercase"
                     }
                 },
                 "tokenizer": {

--- a/cfgov/es_mappings/newsroom.json
+++ b/cfgov/es_mappings/newsroom.json
@@ -50,7 +50,13 @@
         },
         "tags": {
             "index": "not_analyzed",
-            "type": "string"
+            "type": "string",
+            "fields": {
+                "lower": {
+                    "type": "string",
+                    "analyzer": "tag_analyzer"
+                }
+            }
         },
         "taxonomy_cfpb_newsroom_cat_taxonomy": {
             "properties": {

--- a/cfgov/es_mappings/posts.json
+++ b/cfgov/es_mappings/posts.json
@@ -91,7 +91,13 @@
         },
         "tags": {
             "index": "not_analyzed",
-            "type": "string"
+            "type": "string",
+            "fields": {
+                "lower": {
+                    "type": "string",
+                    "analyzer": "tag_analyzer"
+                }
+            }
         },
         "comment_count": {
             "type": "long"

--- a/cfgov/jinja2/v1/_includes/templates/streamfield-sidefoot.html
+++ b/cfgov/jinja2/v1/_includes/templates/streamfield-sidefoot.html
@@ -1,0 +1,21 @@
+{% import 'molecules/related-posts.html' as related_posts with context %}
+{% import 'molecules/related-metadata.html' as related_metadata with context %}
+
+
+{% macro render(streamfield, half_width=false) %}
+    {% for block in streamfield %}
+        {% if 'related_posts' in block.block_type %}
+            <div class="block
+                        {{ 'block__flush-top' if loop.index == 1 else '' }}">
+                {{ related_posts.render(block, half_width) }}
+            </div>
+        {% elif 'related_metadata' in block.block_type %}
+            <div class="block
+                        {{ 'block__flush-top' if loop.index == 1 else '' }}">
+                {{ related_metadata.render(block.value) }}
+            </div>
+        {% else %}
+            {% include 'templates/render_block.html' with context %}
+        {% endif %}
+    {% endfor %}
+{% endmacro %}

--- a/cfgov/jinja2/v1/_queries/careers.json
+++ b/cfgov/jinja2/v1/_queries/careers.json
@@ -9,7 +9,7 @@
     {
     "range" : {
         "close_date" : {
-          "gte": "now"
+          "gte": "now/d"
         }
       }
     }

--- a/cfgov/jinja2/v1/_queries/just_newsroom.json
+++ b/cfgov/jinja2/v1/_queries/just_newsroom.json
@@ -1,0 +1,34 @@
+{
+  "name": "CFPB Newsroom",
+  "query": {
+    "size": 10,
+    "sort": "date:desc",
+    "doc_type": "newsroom"
+  },
+  "filters": [
+    {
+      "or": [
+        {
+          "term": {
+            "display_in_newsroom": "on"
+          }
+        },
+        {
+          "type": {
+            "value": "newsroom"
+          }
+        }
+      ]
+    }
+  ],
+  "feed": {
+    "feed_title": "CFPB Newsroom",
+    "feed_url": "/newsroom/",
+    "entry_title": "$$title$$",
+    "entry_author": "$$author$$",
+    "entry_content": "$$content$$",
+    "entry_summary": "$$excerpt$$",
+    "entry_url": "$$url$$",
+    "entry_updated": "$$modified$$"
+  }
+}

--- a/cfgov/jinja2/v1/browse-basic/index.html
+++ b/cfgov/jinja2/v1/browse-basic/index.html
@@ -1,9 +1,7 @@
 {% extends 'layout-side-nav.html' %}
 
-{% import 'molecules/related-posts.html' as related_posts with context %}
 {% import 'molecules/featured-content.html' as featured_content %}
-
-{% set parent = page.parent() %}
+{% import 'templates/streamfield-sidefoot.html' as streamfield_sidefoot with context %}
 
 {% block title -%}
     {{ page.seo_title }}
@@ -37,20 +35,7 @@
     {%- endfor %}
 
     <aside class="prefooter">
-        {% for block in page.sidefoot %}
-            {% if 'related_posts' or 'call_to_action' or 'email_signup' in block.block_type %}
-                {% if loop.index == 1 %}
-                    <div class="block
-                                block__flush-top">
-                        {{ render_stream_child(block) }}
-                    </div>
-                {% else %}
-                    <div class="block">
-                        {{ render_stream_child(block) }}
-                    </div>
-                {% endif %}
-            {% endif %}
-        {% endfor %}
+        {{ streamfield_sidefoot.render(page.sidefoot, half_width=true) }}
     </aside>
 {% endblock %}
 

--- a/cfgov/jinja2/v1/browse-filterable/index.html
+++ b/cfgov/jinja2/v1/browse-filterable/index.html
@@ -1,7 +1,7 @@
 {% extends 'layout-side-nav.html' %}
 
-{% import 'molecules/related-posts.html' as related_posts with context %}
 {% import 'molecules/featured-content.html' as featured_content %}
+{% import 'templates/streamfield-sidefoot.html' as streamfield_sidefoot with context %}
 
 {% block title -%}
     {{ page.seo_title if page.seo_title else page.title }}
@@ -10,8 +10,6 @@
 {% block content_main_modifiers -%}
     {{ super() }} content__flush-bottom
 {%- endblock %}
-
-{% set parent = page.parent() %}
 
 {% block content_main %}
     {% for block in page.header %}
@@ -41,14 +39,6 @@
         {% endif %}
     {% endfor %}
     <aside class="prefooter">
-        {% for block in page.sidefoot %}
-            <div class="block block__flush-top">
-                {% if 'related_posts' in block.block_type %}
-                    {{ related_posts.render(block) }}
-                {% else %}
-                    {{ render_stream_child(block) }}
-                {% endif %}
-            </div>
-        {% endfor %}
+        {{ streamfield_sidefoot.render(page.sidefoot, half_width=true) }}
     </aside>
 {% endblock %}

--- a/cfgov/jinja2/v1/document-detail/index.html
+++ b/cfgov/jinja2/v1/document-detail/index.html
@@ -1,9 +1,6 @@
 {% extends 'layout-2-1-bleedbar.html' %}
 
-{% import 'molecules/related-posts.html' as related_posts with context %}
-{% import 'molecules/related-metadata.html' as related_metadata with context %}
-
-{% set parent = page.parent() %}
+{% import 'templates/streamfield-sidefoot.html' as streamfield_sidefoot with context %}
 
 {% block title -%}
     {{ page.seo_title }}
@@ -31,15 +28,5 @@
 {%- endblock %}
 
 {% block content_sidebar scoped -%}
-    {% for block in page.sidefoot %}
-        <div class="block block__flush-top">
-            {% if 'related_posts' in block.block_type %}
-                {{ related_posts.render(block) }}
-            {% elif 'related_metadata' in block.block_type %}
-                {{ related_metadata.render(block.value) }}
-            {% else %}
-                {{ render_stream_child(block) }}
-            {% endif %}
-        </div>
-    {% endfor %}
+    {{ streamfield_sidefoot.render(page.sidefoot) }}
 {%- endblock %}

--- a/cfgov/jinja2/v1/landing-page/index.html
+++ b/cfgov/jinja2/v1/landing-page/index.html
@@ -1,6 +1,6 @@
 {% extends 'layout-2-1-bleedbar.html' %}
 
-{% import 'molecules/related-posts.html' as related_posts with context %}
+{% import 'templates/streamfield-sidefoot.html' as streamfield_sidefoot with context %}
 
 {% block title -%}
     {{ page.seo_title }}
@@ -41,17 +41,5 @@
 {%- endblock %}
 
 {% block content_sidebar scoped -%}
-    {% for block in page.sidefoot %}
-        <div class="block block__flush-top">
-            {% if 'related_posts' in block.block_type %}
-                {{ related_posts.render(block) }}
-            {% elif 'heading' in block.block_type %}
-                <h3 class="o-sidebar-breakout_heading">
-                    {{ render_stream_child(block) }}
-                </h3>
-            {% else %}
-                {{ render_stream_child(block) }}
-            {% endif %}
-        </div>
-    {% endfor %}
+    {{ streamfield_sidefoot.render(page.sidefoot) }}
 {%- endblock %}

--- a/cfgov/jinja2/v1/learn-page/index.html
+++ b/cfgov/jinja2/v1/learn-page/index.html
@@ -1,9 +1,6 @@
 {% extends 'layout-2-1-bleedbar.html' %}
 
-{% import 'molecules/related-posts.html' as related_posts with context %}
-{% import 'molecules/related-metadata.html' as related_metadata with context %}
-
-{% set parent = page.parent() %}
+{% import 'templates/streamfield-sidefoot.html' as streamfield_sidefoot with context %}
 
 {% block title -%}
     {{ page.seo_title }}
@@ -31,15 +28,5 @@
 {%- endblock %}
 
 {% block content_sidebar scoped -%}
-    {% for block in page.sidefoot %}
-        <div class="block block__flush-top">
-            {% if 'related_posts' in block.block_type %}
-                {{ related_posts.render(block) }}
-            {% elif 'related_metadata' in block.block_type %}
-                {{ related_metadata.render(block.value) }}
-            {% else %}
-                {{ render_stream_child(block) }}
-            {% endif %}
-        </div>
-    {% endfor %}
+    {{ streamfield_sidefoot.render(page.sidefoot) }}
 {%- endblock %}

--- a/cfgov/jinja2/v1/sublanding-page/index.html
+++ b/cfgov/jinja2/v1/sublanding-page/index.html
@@ -1,9 +1,8 @@
 {% extends 'layout-2-1-bleedbar.html' %}
 
-{% import 'molecules/related-posts.html' as related_posts with context %}
 {% import 'molecules/featured-content.html' as featured_content %}
-{% import 'molecules/related-posts.html' as related_posts with context %}
 {% import 'organisms/post-preview.html' as post_preview with context %}
+{% import 'templates/streamfield-sidefoot.html' as streamfield_sidefoot with context %}
 
 {% block title -%}
     {{ page.seo_title }}
@@ -60,17 +59,5 @@
 {%- endblock %}
 
 {% block content_sidebar scoped -%}
-    {% for block in page.sidefoot %}
-        <div class="block block__flush-top">
-            {% if 'related_posts' in block.block_type %}
-                {{ related_posts.render(block) }}
-            {% elif 'heading' in block.block_type %}
-                <h3 class="o-sidebar-breakout_heading">
-                    {{ render_stream_child(block) }}
-                </h3>
-            {% else %}
-                {{ render_stream_child(block) }}
-            {% endif %}
-        </div>
-    {%- endfor %}
+    {{ streamfield_sidefoot.render(page.sidefoot) }}
 {%- endblock %}

--- a/cfgov/scripts/update_es_settings.py
+++ b/cfgov/scripts/update_es_settings.py
@@ -1,0 +1,21 @@
+from elasticsearch import Elasticsearch
+from elasticsearch.client import IndicesClient
+
+from django.conf import settings
+
+
+# This is run so the Elasticsearch index settings actually get updated with the
+# new settings when they're changed. We're going to just put this as part of our
+# deployment so it gets run before a sheer_index to prevent failed deployments.
+def run():
+    es = Elasticsearch(settings.SHEER_ELASTICSEARCH_SERVER)
+    index_name = settings.SHEER_ELASTICSEARCH_INDEX
+
+    if not es.indices.exists(index_name):
+        print 'Index %s does not exist' % index_name
+        return
+
+    es_settings = settings.SHEER_ELASTICSEARCH_SETTINGS
+    es.indices.close(index_name)
+    es.indices.put_settings(es_settings, index_name)
+    es.indices.open(index_name)

--- a/cfgov/sheerlike/query.py
+++ b/cfgov/sheerlike/query.py
@@ -234,6 +234,18 @@ class Query(object):
         self.__results = None
         self.json_safe = json_safe
 
+    def get_tag_related_documents(self, tags, size=0):
+        query_file = json.loads(file(self.filename).read())
+        doc_type = query_file['query']['doc_type']
+        query_dict = {'query': {'bool': {'should': []}}}
+        if size:
+            query_dict['size'] = size
+        for tag in tags:
+            query_dict['query']['bool']['should'].append({'match': {'tags.lower': tag}})
+        response = self.es.search(index=self.es_index, doc_type=doc_type,
+                                  body=query_dict, analyzer='tag_analyzer')
+        return QueryResults(self, response)
+
     def search(
             self,
             aggregations=None,

--- a/cfgov/v1/models/base.py
+++ b/cfgov/v1/models/base.py
@@ -147,8 +147,12 @@ class CFGOVPage(Page):
         for search_type, search_type_name in [('newsroom', 'Newsroom'), ('posts', 'Blog')]:
             if 'relate_%s' % search_type in block.value \
                     and block.value['relate_%s' % search_type]:
+                if search_type == 'newsroom':
+                    search_type = 'just_newsroom'
                 sheer_query = getattr(queries, search_type)
-                related[search_type_name] = sheer_query.search(filter_tags=self.tags.names())
+                related[search_type_name] = \
+                    sheer_query.get_tag_related_documents(tags=self.tags.names(),
+                                                          size=block.value['limit'])
 
         # Return a dictionary of lists of each type when there's at least one
         # hit for that type.


### PR DESCRIPTION
Phew. This one was a bit of a doozy. This does a few things but is all related to getting this related posts mechanism working once and for all. Basically, it's adding a script to update the ES index with new settings (something we didn't have) then updating the tags field in the mapping so we can perform lowercase searches for content while still maintain the original case in places like the filters, then it adds a new search method on the Query class in sheerlike to actually get the posts by the lowercase tag.

Then another commit updates the templates to actually render things properly, adding a generic streamfield template.

## Additions

- New script to update es settings
- New method to find documents based on tags
- New newsroom query
- New analyzer for tags
- Template for generic rendering of sidefoot streamfield

## Changes

- All page templates now use this generic sidefoot streamfield template

## Testing

- First, run `./cfgov/manage.py runscript update_es_settings`
- Then, run `./cfgov/manage.py sheer_index -r`
- Go [here](http://content.localhost:8000/about-us/payments-harmed-consumers/civil-penalty-fund/consumer-education-financial-literacy/). If you can see related posts, then hallelujah.
- Check /blogs/ and /newsroom/ to make sure those still work

## Review

- @richaagarwal 
- @kave 
- @rosskarchner 
