### PR TITLE
Fixed spacing with category icon classes

### DIFF
--- a/cfgov/jinja2/v1/_includes/macros/category-icon.html
+++ b/cfgov/jinja2/v1/_includes/macros/category-icon.html
@@ -39,5 +39,5 @@
     %}
     {% set icon = icons[category | lower] or icons['blog'] %}
     <span class="cf-icon {{ icon }}
-                 {{- additional_classes or '' -}}"></span>
+                 {{ additional_classes or '' }}"></span>
 {% endmacro %}

--- a/cfgov/jinja2/v1/_includes/macros/category-slug.html
+++ b/cfgov/jinja2/v1/_includes/macros/category-slug.html
@@ -52,7 +52,7 @@
 {% macro _category_link(href, classes) %}
     {% if href %}
         <a href="{{ href }}"
-           class="category-slug{{ ' ' + classes if classes }}">
+           class="category-slug {{ classes if classes }}">
     {% endif %}
        {{ caller() }}
     {% if href %}


### PR DESCRIPTION
A couple of spacing issues were causing icons to not appear.

## Testing

- Visit `/blog/` and `/newsroom/` and marvel at how the icons.

## Review

- @anselmbradford 
- @jimmynotjim 
- @sebworks 

## Screenshots

![image](https://cloud.githubusercontent.com/assets/1860176/13861226/8474167e-ec62-11e5-8b4c-e32a3d1a3c18.png)