### PR TITLE
Add Ombudsman as its own node in /bureau-structure/

### DIFF
--- a/cfgov/jinja2/v1/the-bureau/bureau-structure/_vars-office-data.html
+++ b/cfgov/jinja2/v1/the-bureau/bureau-structure/_vars-office-data.html
@@ -2,13 +2,7 @@
     'titles': '',
     'slug':   'deputy-director',
     'name':   'David Silberman',
-    'title':  'Deputy Director<sup>*</sup>',
-    'children': [{
-	    'titles': '',
-	    'slug':   'ombudsman',
-	    'name':   'Wendy Kamenshine',
-	    'title':  'Ombudsman<sup>***</sup>'
-	}]
+    'title':  'Deputy Director<sup>*</sup>'
 }, {
     'titles': '',
     'slug':   'chief-of-staff',
@@ -35,4 +29,9 @@
     'slug':   'administrative-law-judge',
     'name':   'Vacant',
     'title':  'Administrative Law Judge<sup>***</sup>'
+}, {
+    'titles': '',
+    'slug':   'ombudsman',
+    'name':   'Wendy Kamenshine',
+    'title':  'Ombudsman<sup>***</sup>'
 } %}


### PR DESCRIPTION
> Move Ombudsman out from under Deputy Director, to below the Administrative Law Judge. Deputy Director box will no longer have an expandable. Ombudsman box should look similar to Administrative law judge. 

## Changes

- Breaks out ombudsman into its own node.

## Testing

- Visit http://localhost:8000/the-bureau/bureau-structure/

## Review

- @sebworks 
- @jimmynotjim 
- @anselmbradford 


## Screenshots

![image](https://cloud.githubusercontent.com/assets/1860176/13861855/026d1708-ec66-11e5-9b33-347c67039438.png)


## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)

