### PR TITLE
Mega Menu: DFJR-817 - Added behaviors for third level at mobile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Add a script `move_reports.py` to move all reports under a given SublandingFilterablePage
 - Add a 'careers_preview' query to limit the results to 5
 - Added CFGovLinkHandler to convert richtext internal links to relative links
+- Frontend: added `u-hidden-overflow` utility class.
 
 ### Changed
 - Converted the project to Capital Framework v3
@@ -80,6 +81,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Frontend: Added all launch-state mega menu links.
 - Frontend: Added hover-to-show behavior in desktop mega menu.
 - Use the added `careers_preview.json` in the careers sublanding page instead of `careers.json`
+- Frontend: Added behaviors for third level mobile mega menu.
 
 ### Removed
 - Removed normalize and normalize-legacy from main less file because CF already includes it.

--- a/cfgov/jinja2/v1/_includes/organisms/mega-menu.html
+++ b/cfgov/jinja2/v1/_includes/organisms/mega-menu.html
@@ -60,11 +60,11 @@
     <li class="list_item
                {{ _classes( nav_depth, '-item' ) }}"
         {{ 'data-js-hook=flyout-menu' if nav_children | count > 0 else '' }}>
-        {# TODO: Remove nav_depth < 2 check on has-children class when 3rd level transitions are in. #}
+        {# TODO: Disable link (or overview link) of page user is currently on (on mobile). #}
         <a class="{{ _classes( nav_depth, '-link' ) }}
-                  {{ _classes( nav_depth, '-link__has-children' ) if nav_children | count > 0 and nav_depth < 2 else '' }}
+                  {{ _classes( nav_depth, '-link__has-children' ) if nav_children | count > 0 else '' }}
                   {{ _classes( nav_depth, '-link__current' ) if nav_url == request.path else '' }}"
-           {{ '' if nav_url == '' or nav_url == request.path else 'href=' + nav_url | e }}
+           {{ '' if nav_url == '' else 'href=' + nav_url | e }}
            {{ 'data-js-hook=flyout-menu_trigger' if nav_children | count > 0 else '' }}>
             {{ nav_caption }}
         </a>
@@ -100,7 +100,8 @@
    ========================================================================== #}
 
 {% macro _nav( nav_depth, nav_items, nav_overview, nav_overview_url, media_items ) %}
-<div class="{{ _classes( nav_depth ) }}"
+<div class="{{ _classes( nav_depth ) }}
+            u-hidden-overflow"
      aria-expanded="false"
      data-js-hook="flyout-menu_content">
 

--- a/cfgov/unprocessed/css/cf-enhancements.less
+++ b/cfgov/unprocessed/css/cf-enhancements.less
@@ -1386,6 +1386,27 @@ textarea {
 
 
 /* topdoc
+  name: Hidden Overflow
+  family: cf-core
+  patterns:
+    - name: Utility class
+      markup: |
+        <div class="u-hidden-overflow"></div>
+      codenotes:
+        - .u-hidden-overflow;
+      notes:
+        - "Use this class to hide content outside the bounds of an element.
+           Used for cropping views in multi-level menus."
+  tags:
+    - cf-core
+*/
+
+.u-hidden-overflow {
+    overflow: hidden;
+}
+
+
+/* topdoc
   name: Invisible
   family: cf-core
   patterns:

--- a/cfgov/unprocessed/css/organisms/header.less
+++ b/cfgov/unprocessed/css/organisms/header.less
@@ -23,32 +23,37 @@
     - name: Default example
       markup: |
         <div class="o-header">
-            <div class="m-global-header-cta"></div>
-            <div class="m-global-search"></div>
-            <a class="o-header_logo" href="/">
-                <img class="header_logo u-js-only"
-                     src="/static/img/logo_sm-exec.svg"
-                     onerror="this.onerror=null;this.src='/static/img/logo_sm-exec.png';"
-                     alt="Consumer Financial Protection Bureau"
-                     width="237"
-                     height="50">
-                <noscript>
-                    <img class="header_logo logo__no-js"
-                         src="/static/img/logo_sm-exec.png"
+            <div class="wrapper">
+                <div class="m-global-header-cta"></div>
+                <div class="m-global-search"></div>
+                <a class="o-header_logo" href="/">
+                    <img class="header_logo u-js-only"
+                         src="/static/img/logo_sm-exec.svg"
+                         onerror="this.onerror=null;this.src='/static/img/logo_sm-exec.png';"
                          alt="Consumer Financial Protection Bureau"
                          width="237"
                          height="50">
-                </noscript>
-            </a>
+                    <noscript>
+                        <img class="header_logo logo__no-js"
+                             src="/static/img/logo_sm-exec.png"
+                             alt="Consumer Financial Protection Bureau"
+                             width="237"
+                             height="50">
+                    </noscript>
+                </a>
+            </div>
+            [o-mega-menu]
         </div>
       codenotes:
         - |
           Structural cheat sheet:
           -----------------------
           .o-header
-            .m-global-header-cta
-            .m-global-search
-            .o-header_logo
+            .wrapper
+              .m-global-header-cta
+              .m-global-search
+              .o-header_logo
+            .o-mega-menu
       notes:
         - "The `onerror` attribute allows for the usage of an SVG logo for
            browsers that support SVG, with a fallback to PNG for browsers that
@@ -82,6 +87,7 @@
             }
         }
 
+        // Desktop size.
         .respond-to-min( @bp-med-min, {
             padding-top: unit( @grid_gutter-width / 2 / @base-font-size-px, em );
 

--- a/cfgov/unprocessed/css/organisms/mega-menu.less
+++ b/cfgov/unprocessed/css/organisms/mega-menu.less
@@ -300,20 +300,6 @@
                     cursor: pointer;
                 }
             }
-
-            // TODO: Remove when transitions for 3rd-level are in.
-            //       This is temporary to hide the 3rd-level menu on mobile
-            //       till transitions to show the 3rd-level are in.
-            & & & {
-                &-link {
-                    &__has-children:after {
-                        display: none;
-                    }
-                }
-            }
-            & & & {
-                display: none;
-            }
         }
 
         // 1st-level menu - Tablet/Mobile.
@@ -336,15 +322,20 @@
         // 2nd-level menu - Tablet/Mobile.
         &_content-2 {
 
+            // TODO: Enable or delete when non-clickable
+            //       current page link is in.
+            //       The problem is sections with a 3rd
+            //       level need to remain links and the
+            //       overview link is what needs to be disabled.
             // Make current page menu link non-clickable.
-            &-link,
-            &-overview-link {
-                &__current,
-                &__current:hover {
-                    color: @black;
-                    cursor: default;
-                }
-            }
+            // &-link,
+            // &-overview-link {
+            //    &__current,
+            //    &__current:hover {
+            //        color: @black;
+            //        cursor: default;
+            //    }
+            // }
 
             // Remove final border line of last list item.
             &-list:last-child {
@@ -369,10 +360,10 @@
 
         // Submenus - Tablet/Mobile.
         // TODO: Enable when third-level behaviors are in.
-        //&_content-2,
-        //&_content-3 {
-        //    .u-move-right();
-        //}
+        &_content-2,
+        &_content-3 {
+            .u-move-right();
+        }
     } );
 
     // Desktop sizes.

--- a/cfgov/unprocessed/js/modules/FlyoutMenu.js
+++ b/cfgov/unprocessed/js/modules/FlyoutMenu.js
@@ -54,7 +54,9 @@ function FlyoutMenu( element ) { // eslint-disable-line max-statements, no-inlin
   var _expandTransition;
   var _collapseTransition;
   var _expandTransitionMethod;
+  var _expandTransitionMethodArgs = [];
   var _collapseTransitionMethod;
+  var _collapseTransitionMethodArgs = [];
 
   // Binded events.
   var _collapseBinded = collapse.bind( this );
@@ -142,8 +144,8 @@ function FlyoutMenu( element ) { // eslint-disable-line max-statements, no-inlin
       this.dispatchEvent( 'expandBegin',
                           { target: this, type: 'expandBegin' } );
       if ( _expandTransitionMethod ) {
-        // The following method is defined in the transition, not this file.
-        _expandTransitionMethod();
+        _expandTransitionMethod
+          .apply( _expandTransition, _expandTransitionMethodArgs );
         if ( _expandTransition && _collapseTransition.isAnimated() ) {
           _expandTransition
             .addEventListener( 'transitionEnd', _expandEndBinded );
@@ -173,8 +175,8 @@ function FlyoutMenu( element ) { // eslint-disable-line max-statements, no-inlin
       _isExpanded = false;
       _isAnimating = true;
       if ( _collapseTransitionMethod ) {
-        // The following method is defined in the transition, not this file.
-        _collapseTransitionMethod();
+        _collapseTransitionMethod
+          .apply( _collapseTransition, _collapseTransitionMethodArgs );
         if ( _collapseTransition && _collapseTransition.isAnimated() ) {
           _collapseTransition
             .addEventListener( 'transitionEnd', _collapseEndBinded );
@@ -231,10 +233,13 @@ function FlyoutMenu( element ) { // eslint-disable-line max-statements, no-inlin
    *   A transition instance to watch for events on.
    * @param {Function} method
    *   The transition method to call on expand.
+   * @param {Array} args
+   *   (Optional) list of arguments to apply to collapse method.
    */
-  function setExpandTransition( transition, method ) {
+  function setExpandTransition( transition, method, args ) {
     _expandTransition = transition;
     _expandTransitionMethod = method;
+    _expandTransitionMethodArgs = args;
   }
 
   /**
@@ -242,10 +247,13 @@ function FlyoutMenu( element ) { // eslint-disable-line max-statements, no-inlin
    *   A transition instance to watch for events on.
    * @param {Function} method
    *   The transition method to call on collapse.
+   * @param {Array} args
+   *   (Optional) list of arguments to apply to collapse method.
    */
-  function setCollapseTransition( transition, method ) {
+  function setCollapseTransition( transition, method, args ) {
     _collapseTransition = transition;
     _collapseTransitionMethod = method;
+    _collapseTransitionMethodArgs = args;
   }
 
   /**
@@ -326,10 +334,17 @@ function FlyoutMenu( element ) { // eslint-disable-line max-statements, no-inlin
   }
 
   /**
-   * @returns {boolean} True if menu is expanded, false otherwise.
+   * @returns {boolean} True if menu is animating, false otherwise.
    */
   function isAnimating() {
     return _isAnimating;
+  }
+
+  /**
+   * @returns {boolean} True if menu is expanded, false otherwise.
+   */
+  function isExpanded() {
+    return _isExpanded;
   }
 
   // Attach public events.
@@ -347,6 +362,7 @@ function FlyoutMenu( element ) { // eslint-disable-line max-statements, no-inlin
   this.getTransition = getTransition;
   this.getDom = getDom;
   this.isAnimating = isAnimating;
+  this.isExpanded = isExpanded;
   this.resume = resume;
   this.setData = setData;
   this.suspend = suspend;

--- a/cfgov/unprocessed/js/modules/Tree.js
+++ b/cfgov/unprocessed/js/modules/Tree.js
@@ -102,7 +102,7 @@ function Tree() {
  * @classdesc A node in a tree data structure.
  *
  * @param {Tree} tree - The data structure this node is a member of.
- * @param {Object} data - The data data.
+ * @param {Object} data - The data payload.
  * @param {TreeNode} parent - The parent node in the root,
  *   null if this is the root node.
  * @param {Arrray} children - List of children nodes.

--- a/cfgov/unprocessed/js/organisms/MegaMenu.js
+++ b/cfgov/unprocessed/js/organisms/MegaMenu.js
@@ -60,6 +60,7 @@ function MegaMenu( element ) {
 
     // Populate tree model with menus.
     var rootNode = _menus.init( rootMenu ).getRoot();
+    rootMenu.setData( rootNode );
     _populateTreeFromDom( rootMenuDom, rootNode, _addMenu );
 
     // Initialize screen-size specific behaviors.


### PR DESCRIPTION
## Additions

- Adds `u-hidden-overflow` utility class.

## Changes

- Adds behaviors for third-level mega menu.

## Testing

- `gulp build` and then these are the possible states:
 - **First-level:**
   - Expand menu > Collapse menu with (x).
    - Expand menu > Collapse menu by clicking body overlay.
    - Expand menu > Collapse menu by clicking search button.
 - **Second-level:**
   - Expand menu > Click about us > Collapse menu by clicking (x).
    - Expand menu > Click about us > Collapse menu by clicking body overlay.
    - Expand menu > Click about us > Collapse menu by clicking search button.
    - Expand menu > Click about us > Return to first-level by clicking back button.
    - Repeat first-level steps.
 - **Third-level:**
   - Expand menu > Click about us > Click careers > Collapse menu by clicking (x).
    - Expand menu > Click about us > Click careers > Collapse menu by clicking body overlay.
    - Expand menu > Click about us > Click careers > Collapse menu by clicking search button.
    - Expand menu > Click about us > Click careers > Return to second-level by clicking back button.
    - Repeat second and first-level steps.
 - Repeat all steps, but resize and interact with desktop menu between steps and then resize back to mobile size.
 - Load mobile menu first, resize window to desktop, interact with menu.
 - Load desktop menu first, resize window to mobile, interact with menu.

## Review

- @KimberlyMunoz 
- @sebworks 
- @jimmynotjim 

## Screenshots

![thirdlevel](https://cloud.githubusercontent.com/assets/704760/13883037/30426e24-ecfe-11e5-8fdd-cd6512dfc6a2.gif)


## Todos

- Keyboard navigation needs to be added.
- IE/Opera Mini needs to be handled.
- Lots of refactoring potential marked as `TODO`s in the code, but this PR appears to be a working state.
- It likely needs acceptance tests before major refactoring.