### PR TITLE
Fixed a bug in IE where value wasn't being correctly set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,6 +119,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Fixes the values for author and tag options to remove special characters.
 - Fixes layout issues with filters on sheer pages.
 - Fixed failing browser tests due to atomic naming updates.
+- Fixed a bug in the multi-select script where value was set before input type.
 
 ## 3.0.0-3.0.0 - 2016-02-11
 

--- a/cfgov/unprocessed/js/molecules/Multiselect.js
+++ b/cfgov/unprocessed/js/molecules/Multiselect.js
@@ -158,8 +158,9 @@ function Multiselect( element ) { // eslint-disable-line max-statements, inline-
 
       _create( 'input', {
         'id':        option.value,
-        'value':     option.value,
+        // Type must come before value or IE fails
         'type':      'checkbox',
+        'value':     option.value,
         'name':      _name,
         'class':     'cf-input cf-multi-select_checkbox',
         'inside':    li


### PR DESCRIPTION
Fixed a bug in IE where value wasn't being correctly set

## Changes

- Updated the order of options when creating an `input` to set the `type` before the `value`

## Testing

- `gulp build` and check out `/blog` in an IE VM

## Review

- @KimberlyMunoz 
- @sebworks 
- @anselmbradford 

## Notes

- When creating input elements, the type must be set before a value can be set. This issue exists in all versions of IE

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
