### PR TITLE
Add Tabbing to Consumer Resources + Education Navs

### DIFF
--- a/cfgov/jinja2/v1/_includes/organisms/_vars-mega-menu.html
+++ b/cfgov/jinja2/v1/_includes/organisms/_vars-mega-menu.html
@@ -27,7 +27,7 @@
 ] %}
 
 {% set nav_items = [(
-    ('Consumer Tools', '', [(
+    ('Consumer Tools', '#', [(
         ('Submit a Complaint', '/complaint/', []),
         ('Ask CFPB', '/askcfpb/', []),
         ('Tell Your Story', '/your-story/', []),
@@ -44,7 +44,7 @@
         ('Trouble Paying Your Mortgage?', '/mortgagehelp/', []),
         ('Protections Against Discrimination', '/fair-lending/', [])
     )]),
-    ('Educational Resources', '', [(
+    ('Educational Resources', '#', [(
         ('Your Money, Your Goals', '/your-money-your-goals/', []),
         ('Adult Financial Education', '/adult-financial-education/', []),
         ('Youth Financial Education', '/youth-financial-education/', [])

--- a/cfgov/jinja2/v1/_includes/organisms/mega-menu.html
+++ b/cfgov/jinja2/v1/_includes/organisms/mega-menu.html
@@ -115,7 +115,10 @@
             <div class="{{ _classes( nav_depth, '-grid' ) }}">
                 {% if nav_depth > 1 %}
                 <span class="{{ _classes( nav_depth, '-overview' ) }}">
-                    {% if nav_overview_url %}
+                    {# TODO: Remove the check for '#' when real overview pages
+                             are added for the Consumer Resources and Education
+                             pages. #}
+                    {% if nav_overview_url and nav_overview_url != '#' %}
                     <a class="{{ _classes( nav_depth, '-overview-link' ) }}
                               {{ _classes( nav_depth, '-overview-link__current' ) if nav_overview_url == request.path else '' }}"
                        {{ '' if nav_overview_url == request.path else 'href=' + nav_overview_url | e }}>


### PR DESCRIPTION
This PR adds a "#" link as a way to remove the blank href on the first
two subnav items. Anchor links without a href are not keyboard
navigable.

This is the method being used by 18F
https://github.com/18F/web-design-standards/issues/743

## Additions

- Adds "#" and a check to make sure links to "#" don't link to non-existent overview pages.

## Testing

- Using your keyboard, navigate to the first an item in the Consumer Resources section. [Quick guide here.](https://github.com/cfpb/front-end/blob/master/accessibility.md#keyboard-testing)


## Review

- @anselmbradford 
- @sebworks 
- @jimmynotjim 


## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)

