### PR TITLE
Datetimes now render with their entered times with the desired timezone

### DIFF
--- a/cfgov/sheerlike/templates.py
+++ b/cfgov/sheerlike/templates.py
@@ -11,10 +11,9 @@ def _convert_date(date, tz):
         if type(date) in [datetime.datetime, datetime.date]:
             if isinstance(date, datetime.datetime):
                 pytzone = timezone(tz)
-                if not date.tzinfo:
-                    date = pytzone.localize(date)
-                else:
-                    date = date.astimezone(pytzone)
+                if date.tzinfo:
+                    date = date.replace(tzinfo=None)
+                date = pytzone.localize(date)
     return date
 
 


### PR DESCRIPTION
Basically, timezones are saved as UTC which is usually the best idea but when converting to EST is a problem because data entry is in EST not UTC. This strips the UTC and replaces it with the desired timezone (usually EST) instead of converting from UTC.

@richaagarwal 
@kave 