### PR TITLE
Mega Menu: Fixes DFJR-1045 - disables links for non-functional areas of menu

### DIFF
--- a/cfgov/jinja2/v1/_includes/organisms/_vars-mega-menu.html
+++ b/cfgov/jinja2/v1/_includes/organisms/_vars-mega-menu.html
@@ -28,34 +28,34 @@
 
 {% set nav_items = [(
     ('Consumer Tools', '#', [(
-        ('Submit a Complaint', '/complaint/', []),
-        ('Ask CFPB', '/askcfpb/', []),
-        ('Tell Your Story', '/your-story/', []),
-        ('Information for Students', '/students/', []),
-        ('Information for Older Americans', '/older-americans/', []),
-        ('Information for Servicemembers', '/servicemembers/', [])
+        ('Submit a Complaint', '', []),
+        ('Ask CFPB', '', []),
+        ('Tell Your Story', '', []),
+        ('Information for Students', '', []),
+        ('Information for Older Americans', '', []),
+        ('Information for Servicemembers', '', [])
     ),(
-        ('Paying for College', '/paying-for-college/', []),
-        ('Owning a Home', '/owning-a-home/', []),
-        ('Planning for Retirement', '/retirement/', []),
-        ('Sending Money Abroad', '/sending-money/', [])
+        ('Paying for College', '', []),
+        ('Owning a Home', '', []),
+        ('Planning for Retirement', '', []),
+        ('Sending Money Abroad', '', [])
     ),(
-        ('Know Before You Owe Mortgages', '/know-before-you-owe/', []),
-        ('Trouble Paying Your Mortgage?', '/mortgagehelp/', []),
-        ('Protections Against Discrimination', '/fair-lending/', [])
+        ('Know Before You Owe Mortgages', '', []),
+        ('Trouble Paying Your Mortgage?', '', []),
+        ('Protections Against Discrimination', '', [])
     )]),
     ('Educational Resources', '#', [(
-        ('Your Money, Your Goals', '/your-money-your-goals/', []),
-        ('Adult Financial Education', '/adult-financial-education/', []),
-        ('Youth Financial Education', '/youth-financial-education/', [])
+        ('Your Money, Your Goals', '', []),
+        ('Adult Financial Education', '', []),
+        ('Youth Financial Education', '', [])
     ),(
-        ('Resources for Libraries', '/library-resources/', []),
-        ('Resources for Tax Preparers', '/tax-preparer-resources/', []),
-        ('Resources for Parents', '/parents/', [])
+        ('Resources for Libraries', '', []),
+        ('Resources for Tax Preparers', '', []),
+        ('Resources for Parents', '', [])
     ),(
-        ('Information for Economically Vulnerable Consumers', '/empowerment/', []),
-        ('Managing Someone Else’s Money', '/managing-someone-elses-money/', []),
-        ('Free Brochures', 'http://promotions.usa.gov/cfpbpubs.html', [])
+        ('Information for Economically Vulnerable Consumers', '', []),
+        ('Managing Someone Else’s Money', '', []),
+        ('Free Brochures', '', [])
     )]),
     ('Data & Research', '/data-research/', [(
         ('Research & Reports', '/data-research/research-reports/', []),

--- a/cfgov/jinja2/v1/_includes/organisms/mega-menu.html
+++ b/cfgov/jinja2/v1/_includes/organisms/mega-menu.html
@@ -61,7 +61,8 @@
                {{ _classes( nav_depth, '-item' ) }}"
         {{ 'data-js-hook=flyout-menu' if nav_children | count > 0 else '' }}>
         {# TODO: Disable link (or overview link) of page user is currently on (on mobile). #}
-        <a class="{{ _classes( nav_depth, '-link' ) }}
+        <a class="{{ 'u-link__disabled' if nav_url == '' else '' }}
+                  {{ _classes( nav_depth, '-link' ) }}
                   {{ _classes( nav_depth, '-link__has-children' ) if nav_children | count > 0 else '' }}
                   {{ _classes( nav_depth, '-link__current' ) if nav_url == request.path else '' }}"
            {{ '' if nav_url == '' else 'href=' + nav_url | e }}

--- a/cfgov/unprocessed/css/organisms/mega-menu.less
+++ b/cfgov/unprocessed/css/organisms/mega-menu.less
@@ -317,6 +317,17 @@
                     border-bottom: none;
                 }
             }
+
+            // TODO: Remove when Consumer Tools and Ed Resources links are in.
+            // Overrides disabled link styles.
+            &-link.u-link__disabled {
+                color: @pacific !important;
+
+                &:hover {
+                    color: @pacific-60 !important;
+                    cursor: pointer !important;
+                }
+            }
         }
 
         // 2nd-level menu - Tablet/Mobile.
@@ -414,6 +425,19 @@
                     cursor: pointer;
                 }
             }
+
+            // TODO: Remove when Consumer Tools and Ed Resources links are in.
+            // Overrides disabled link styles.
+            &-link.u-link__disabled {
+                color: @black !important;
+
+                &:hover {
+                    padding-bottom: @grid_gutter-width - 6px !important;
+                    border-bottom: 6px solid @gray-50 !important;
+                    cursor: pointer !important;
+                }
+            }
+
         }
 
         // 2nd-level menu - Desktop.


### PR DESCRIPTION
## Changes

- Temporarily removes and disables links in Consumer Tools and Educational Resources.

## Testing

- `gulp build`
- Check menu at desktop and mobile. Consumer Tools and Educational Resources links should all be disabled styled.

## Review

- @jimmynotjim
- @sebworks
-@kimberlymunoz

## Screenshots

<img width="508" alt="screen shot 2016-03-18 at 1 50 08 pm" src="https://cloud.githubusercontent.com/assets/704760/13887392/db39104a-ed11-11e5-8a42-f51f76cc3c20.png">

<img width="957" alt="screen shot 2016-03-18 at 1 49 13 pm" src="https://cloud.githubusercontent.com/assets/704760/13887393/dbfbdefe-ed11-11e5-8abf-233b69b4c491.png">



