### PR TITLE
Fix empty prefooter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Frontend: Added all launch-state mega menu links.
 - Frontend: Added hover-to-show behavior in desktop mega menu.
 - Use the added `careers_preview.json` in the careers sublanding page instead of `careers.json`
+- Wrap prefooter section in Browse pages in a conditional to prevent empty prefooter
 
 ### Removed
 - Removed normalize and normalize-legacy from main less file because CF already includes it.

--- a/cfgov/jinja2/v1/browse-basic/index.html
+++ b/cfgov/jinja2/v1/browse-basic/index.html
@@ -34,8 +34,10 @@
         {% include 'templates/render_block.html' with context %}
     {%- endfor %}
 
-    <aside class="prefooter">
-        {{ streamfield_sidefoot.render(page.sidefoot, half_width=true) }}
-    </aside>
+    {% if page.sidefoot %}
+        <aside class="prefooter">
+            {{ streamfield_sidefoot.render(page.sidefoot, half_width=true) }}
+        </aside>
+    {% endif %}
 {% endblock %}
 

--- a/cfgov/jinja2/v1/browse-filterable/index.html
+++ b/cfgov/jinja2/v1/browse-filterable/index.html
@@ -38,7 +38,9 @@
             {% include 'templates/render_block.html' with context %}
         {% endif %}
     {% endfor %}
-    <aside class="prefooter">
-        {{ streamfield_sidefoot.render(page.sidefoot, half_width=true) }}
-    </aside>
+    {% if page.sidefoot %}
+        <aside class="prefooter">
+            {{ streamfield_sidefoot.render(page.sidefoot, half_width=true) }}
+        </aside>
+    {% if page.sidefoot %}
 {% endblock %}

--- a/cfgov/jinja2/v1/wagtail/demo/index.html
+++ b/cfgov/jinja2/v1/wagtail/demo/index.html
@@ -27,12 +27,6 @@
 
 {% block content_sidebar scoped -%}
 <aside>
-    {% for block in page.sidefoot %}
-        {% if 'related_posts' in block.block_type %}
-            {{ related_posts.render() }}
-        {% else %}
-            {% include 'templates/render_block.html' with context %}
-        {% endif %}
-    {% endfor %}
+    {{ streamfield_sidefoot.render(page.sidefoot) }}
 </aside>
 {%- endblock %}


### PR DESCRIPTION
From Jira: "When there's no content entered in the sidefoot area in Wagtail on a browse or browse filterable template, a small empty pre-footer well shows on page."

## Additions

- Wrap the code that renders the prefooter in a conditional so it only displays if there is content in the sidefoot.

## Removals

- 

## Changes

- Replaced redundant code with a call to macro in `demo/index.html`

## Testing

- Create or go to a Browse / Browse filterable page and remove the sidefoot content. Ensure there's no empty prefooter. 

## Review

- @kave @kurtw 

## Screenshots

Before fix:

<img width="1234" alt="screen shot 2016-03-17 at 5 16 01 pm" src="https://cloud.githubusercontent.com/assets/354591/13889432/c93016fe-ed03-11e5-9598-486379898bb3.png">


After fix:

<img width="1165" alt="screen shot 2016-03-18 at 12 21 37 pm" src="https://cloud.githubusercontent.com/assets/354591/13889484/02e1da18-ed04-11e5-8689-5eea16fb0d8a.png">

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [x] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
