### PR TITLE
Fixes a bug with the global search positioning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,6 +120,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Fixes layout issues with filters on sheer pages.
 - Fixed failing browser tests due to atomic naming updates.
 - Fixed a bug in the multi-select script where value was set before input type.
+- Fixed positioning bug in global search.
 
 ## 3.0.0-3.0.0 - 2016-02-11
 

--- a/cfgov/unprocessed/css/molecules/global-search.less
+++ b/cfgov/unprocessed/css/molecules/global-search.less
@@ -141,16 +141,11 @@
 
             &-form {
                 position: absolute;
-
-                transform: translateX( 100% );
-                transition: transform 0.25s ease-out;
             }
         }
 
         .js &[aria-expanded="true"] &-form {
             display: block;
-
-            transform: translateX( 0 );
         }
 
         // Hide suggestions outside of tablet sizes


### PR DESCRIPTION
Fixes a bug where the global search was bing transformed twice delaying the animation

## Removals

- Removed duplicate transform in the styles.

## Testing

- `gulp build` and click the search icon on a small screen. It shouldn't delay like it is on the demo server.

## Review

- @anselmbradford 
- @sebworks 
- @KimberlyMunoz 

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)