### PR TITLE
Updates the mega-menu for no-js and IE8-10 fixes **SEE NOTES**

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,8 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Wrap prefooter section in Browse pages in a conditional to prevent empty prefooter
 - Frontend: Added behaviors for third level mobile mega menu.
 - Frontend: Made Expandables collapse under 600px window size.
+- Updated the Mega Menu layout to avoid pointer events for older IE.
+- Updated the Mega Menu for devices without JS.
 
 ### Removed
 - Removed normalize and normalize-legacy from main less file because CF already includes it.

--- a/cfgov/jinja2/v1/_includes/organisms/header.html
+++ b/cfgov/jinja2/v1/_includes/organisms/header.html
@@ -26,11 +26,11 @@
                          height="50">
                 </noscript>
             </a>
-        </div>
 
-        {% block primary_nav %}
-            {% include 'organisms/mega-menu.html' with context %}
-        {% endblock primary_nav %}
+            {% block primary_nav %}
+                {% include 'organisms/mega-menu.html' with context %}
+            {% endblock primary_nav %}
+        </div>
 
     </div>
 </header>

--- a/cfgov/jinja2/v1/_includes/organisms/mega-menu.html
+++ b/cfgov/jinja2/v1/_includes/organisms/mega-menu.html
@@ -107,7 +107,8 @@
      data-js-hook="flyout-menu_content">
 
     <div class="{{ _classes( nav_depth, '-wrapper' ) }}">
-        <div class="wrapper">
+        {{ '<div class="wrapper">' | safe if nav_depth > 1 else '' }}
+            {# Open wrapper if needed #}
             {% if nav_depth > 1 %}
             <button class="{{ _classes( nav_depth, '-alt-trigger' ) }}"
                     data-js-hook="flyout-menu_alt-trigger">
@@ -140,7 +141,8 @@
             </aside>
             {% endif %}
             {% endfor %}
-        </div>
+        {# Close Wrapper if needed #}
+        {{ '</div>' | safe if nav_depth > 1 else '' }}
     </div>
 
     {% if nav_depth == 1 %}

--- a/cfgov/unprocessed/css/organisms/header.less
+++ b/cfgov/unprocessed/css/organisms/header.less
@@ -112,12 +112,12 @@
             }
 
             // Set the mobile hamburger mega menu next to the logo.
-            // Remove pointer-events so the menu doesn't cover up the search.
             > .o-mega-menu {
-                top: 0;
-                left: 0;
-                position: absolute;
-                pointer-events: none;
+                .js & {
+                    top: 0;
+                    left: 0;
+                    position: absolute;
+                }
             }
         } );
     }
@@ -126,8 +126,10 @@
 
         // Tablet/mobile sizes.
         .respond-to-max( @bp-sm-max, {
-            // Offset logo by width of mega menu trigger: 60px + 10px gap.
-            margin-left: 70px;
+            .js & {
+                // Offset logo by width of mega menu trigger: 60px + 10px gap.
+                margin-left: 70px;
+            }
         } );
 
         &-img {

--- a/cfgov/unprocessed/css/organisms/mega-menu.less
+++ b/cfgov/unprocessed/css/organisms/mega-menu.less
@@ -125,9 +125,6 @@
 */
 
 .o-mega-menu {
-    position: relative;
-    width: 100%;
-
     &_content-item {
         // Override margin added by CF to list items.
         margin-bottom: 0;
@@ -164,21 +161,24 @@
     // Tablet/mobile sizes.
     .respond-to-max( @bp-sm-max, {
         &_trigger {
+            display: none;
             height: unit( 60px / 18px, em );
             min-width: unit( 60px / 18px, em );
             padding-top: unit( @grid_gutter-width / 2 / 18px, em );
             padding-bottom: unit( @grid_gutter-width / 2 / 18px, em );
 
-            // TODO: Check that float doesn't spill outside organism.
-            float: left;
-            position: relative;
+            position: absolute;
+            top: 0;
             z-index: 20;
 
             background: @white;
             border: none;
             color: @black;
             font-size: unit( 18px / @base-font-size-px, em );
-            pointer-events: auto;
+
+            .js & {
+                display: block;
+            }
 
             &:focus {
                 outline: 1px dotted @black;
@@ -206,18 +206,29 @@
         // Menu flyout.
         // All menus - Tablet/Mobile.
         &_content {
+            display: none;
             box-sizing: border-box;
             width: 100%;
 
-            position: absolute;
-            left: 0;
-            top: -1px;
-            z-index: 10;
+            .js & {
+                display: block;
+                position: absolute;
+                left: 0;
+                top: -1px;
+                z-index: 10;
+            }
+
+            &-2,
+            &-3 {
+                position: absolute;
+                left: 0;
+                top: -1px;
+                z-index: 10;
+            }
 
             background-color: @gray-5;
             border-top: 1px solid @gray-50;
             border-bottom: 1px solid @gray-50;
-            pointer-events: auto;
 
             .u-drop-shadow-after();
 
@@ -283,16 +294,18 @@
                 padding-top: @grid_gutter-width / 2;
                 padding-bottom: @grid_gutter-width / 2;
 
-                &__has-children:after {
-                    .cf-icon();
+                .js & {
+                    &__has-children:after {
+                        .cf-icon();
 
-                    position: absolute;
-                    right: 0;
-                    top: 50%;
-                    transform: translateY( -50% );
+                        position: absolute;
+                        right: 0;
+                        top: 50%;
+                        transform: translateY( -50% );
 
-                    color: @green;
-                    content: @cf-icon-right;
+                        color: @green;
+                        content: @cf-icon-right;
+                    }
                 }
 
                 &__current,
@@ -304,8 +317,11 @@
 
         // 1st-level menu - Tablet/Mobile.
         &_content-1 {
-            // Offset for height of trigger button.
-            top: 60px;
+            .js & {
+                // Offset for height of trigger button.
+                top: 60px;
+            }
+            display: block;
 
             &-list {
                 padding-right: unit( @grid_gutter-width / 2 / @base-font-size-px, em );
@@ -392,6 +408,7 @@
                     transform: translateY( 0 );
                 }
             }
+
             &-list {
                 margin-bottom: 0;
             }
@@ -399,6 +416,12 @@
             &-item {
                 display: inline-block;
                 margin-right: @grid_gutter-width / 2;
+
+                .no-js &:hover {
+                    .o-mega-menu_content-2 {
+                        display: block;
+                    }
+                }
             }
 
             &-link {
@@ -448,10 +471,9 @@
             z-index: 10;
             width: 100%;
 
-            // Set an arbtrary min-height to create a "window" into which
-            // the menu will slide into view.
-            min-height: 600px;
-            pointer-events: none;
+            .no-js & {
+                display: none;
+            }
 
             &[aria-expanded="true"] {
 
@@ -461,7 +483,6 @@
             }
 
             &-wrapper {
-                pointer-events: auto;
                 background-color: @gray-5;
                 border-top: 1px solid @gray-50;
                 border-bottom: 1px solid @gray-50;


### PR DESCRIPTION
Updates the mega-menu for no-js and IE 8-10 fixes (Part 2 of Jira issue 816)

## Removals

- Removes need for pointer events

## Changes

- Sets up JS only styles instead of menu styles globally scoped to js

## Testing

- `gulp build` and test the menu at multiple browser styles, with JS on and off, it should look and function the same as before.

## Review

- @anselmbradford 
- @KimberlyMunoz 
- @sebworks 

## Notes

- We've decided to show the top level items as links by default on small screens when JS fails to deliver.
- ~~There are script errors from the BaseTransitions files in IE9. I'm having trouble debugging them, but we should discuss if transitions should even be supported in such an old browser. Progressively enhancing a simple toggle of show/hide is probably more appropriate than trying to add complicated scripting that the browser doesn't seem to like.~~ This was fixed in #1641 

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)