### PR TITLE
DFJR 971 - Collapses expandable on mobile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Use the added `careers_preview.json` in the careers sublanding page instead of `careers.json`
 - Wrap prefooter section in Browse pages in a conditional to prevent empty prefooter
 - Frontend: Added behaviors for third level mobile mega menu.
+- Frontend: Made Expandables collapse under 600px window size.
 
 ### Removed
 - Removed normalize and normalize-legacy from main less file because CF already includes it.

--- a/cfgov/jinja2/v1/_includes/organisms/email-signup.html
+++ b/cfgov/jinja2/v1/_includes/organisms/email-signup.html
@@ -8,13 +8,13 @@
 
    Creates an email sign up form when given:
 
-   value:      An object used to customize the markup.
+   value:         An object used to customize the markup.
 
-   value.heading: A string with the title for the header slug
+   value.heading: A string with the title for the header slug.
 
-   value.text: The text used within the description markup.
+   value.text:    The text used within the description markup.
 
-   value.gd_code:       A GovDelivery code for a specified mailing list.
+   value.gd_code: A GovDelivery code for a specified mailing list.
 
    ========================================================================== #}
 

--- a/cfgov/jinja2/v1/_includes/organisms/filterable-list-controls.html
+++ b/cfgov/jinja2/v1/_includes/organisms/filterable-list-controls.html
@@ -8,12 +8,12 @@
 
    Create an expandable of filters when given:
 
-   controls     Collection of field controls and other settings to determine
-                    what's rendered.
+   controls: Collection of field controls and other settings to determine
+             what's rendered.
 
-   form         Django form that carries the fields that are to be rendered
+   form:     Django form that carries the fields that are to be rendered.
 
-   index        A unique number given to render the form and its fields with
+   index:    A unique number given to render the form and its fields with.
 
    ========================================================================== #}
 {% from 'molecules/expandable.html' import expandable with context %}

--- a/cfgov/jinja2/v1/browse-filterable/index.html
+++ b/cfgov/jinja2/v1/browse-filterable/index.html
@@ -31,8 +31,8 @@
                     block__flush-top">
 
                 {% set f = forms.pop(0) %}
-                {% from 'organisms/filterable-list-controls.html' import render as flc with context %}
-                {{ flc(block.value, f, loop.index0) }}
+                {% import 'organisms/filterable-list-controls.html' as flc with context %}
+                {{ flc.render(block.value, f, loop.index0) }}
             </div>
         {% else %}
             {% include 'templates/render_block.html' with context %}

--- a/cfgov/unprocessed/js/modules/util/breakpoint-state.js
+++ b/cfgov/unprocessed/js/modules/util/breakpoint-state.js
@@ -22,8 +22,8 @@ function _inBreakpointRange( breakpointRange, width ) {
 
 /**
  * @param {integer} width - Current window width.
- * @returns {Object} An object literal with Boolean
- * isBpXS, isBpSM, isBpMED, isBpLG, isBpXL properties.
+ * @returns {Object} An object literal with boolean
+ *   isBpXS, isBpSM, isBpMED, isBpLG, isBpXL properties.
  */
 function get( width ) {
   var breakpointState = {};
@@ -34,7 +34,7 @@ function get( width ) {
     breakpointKey = 'is' + rangeKey.charAt( 0 ).toUpperCase() +
                     rangeKey.slice( 1 );
     breakpointState[breakpointKey] =
-    _inBreakpointRange( _breakpointsConfig[rangeKey], width );
+      _inBreakpointRange( _breakpointsConfig[rangeKey], width );
   }
 
   return breakpointState;


### PR DESCRIPTION
Expandables will collapse when page is loaded under 600px width, or if it is resized below 600px. If resized and collapsed, it won't remember that it was expanded at desktop sizes and won't expand when resizing back to desktop.

## Changes

- Makes Expandables collapse under 600px window size.
- General code comment cleanup.
- Removes `addEventListener` check since IE8 is no-js state now.

## Testing

- `gulp build`
- Create a browse filterable page in wagtail and add a filter.
- Check "Is Expanded" in wagtail admin.
- Load the page preview in a small window, note filter is collapsed.
- Load the page preview in a large window, note filter is expanded.
- Resize the page to a small size and note filter collapses.

## Review

- @kurtw 
- @sebworks 
- @jimmynotjim 
- @KimberlyMunoz 

## Todos

- @kurtw Can we add a note next to the "Is Expanded" checkbox in wagtail that says it won't apply under 600px wide?
- If filters have any user entered data, they need `is_expanded=true` passed to `block.value` in https://github.com/cfpb/cfgov-refresh/blob/flapjack/cfgov/jinja2/v1/browse-filterable/index.html#L34