### PR TITLE
Bugfix for selected options in multiselect on form submission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,6 +123,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Fixed a bug in the multi-select script where value was set before input type.
 - Fixed positioning bug in global search.
 - Fixed issue where categories without a set icon were showing the speach icon.
+- Fixed issue where a filtered page wasn’t showing the selected options in the multiselect.
 
 ## 3.0.0-3.0.0 - 2016-02-11
 

--- a/cfgov/unprocessed/js/molecules/Multiselect.js
+++ b/cfgov/unprocessed/js/molecules/Multiselect.js
@@ -59,6 +59,12 @@ function Multiselect( element ) { // eslint-disable-line max-statements, inline-
     _placeholder = _dom.getAttribute( 'placeholder' );
     _filtered = _optionData = _sanitizeList( _options );
 
+    for ( var i = 0, l = _filtered.length; i < l; i++ ) {
+      if ( _filtered[i].checked ) {
+        _selections.push( _filtered[i] );
+      }
+    }
+
     if ( _optionData.length > 0 ) {
       _populateMarkup();
       _bindEvents();
@@ -102,10 +108,10 @@ function Multiselect( element ) { // eslint-disable-line max-statements, inline-
 
     for ( var i = 0, len = list.length; i < len; i++ ) {
       item = list[i];
-
       cleaned.push( {
-        value: item.value,
-        text:  item.text
+        value:   item.value,
+        text:    item.text,
+        checked: item.defaultSelected
       } );
     }
 
@@ -126,6 +132,21 @@ function Multiselect( element ) { // eslint-disable-line max-statements, inline-
     _choices = _create( 'ul', {
       className: 'list__unstyled cf-multi-select_choices',
       inside:    _container
+    } );
+
+    _selections.forEach( function( option ) {
+      var li = _create( 'li', {
+        'data-option': option.value
+      } );
+
+      _create( 'label', {
+        'for':         option.value,
+        'textContent': option.text,
+        'className':   'cf-multi-select_label',
+        'inside':      li
+      } );
+
+      _choices.appendChild( li );
     } );
 
     _header = _create( 'header', {
@@ -155,15 +176,19 @@ function Multiselect( element ) { // eslint-disable-line max-statements, inline-
         'data-option': option.value
       } );
 
-      _create( 'input', {
+      var inputData = {
         'id':        option.value,
         // Type must come before value or IE fails
-        'type':      'checkbox',
-        'value':     option.value,
-        'name':      _name,
-        'class':     'cf-input cf-multi-select_checkbox',
-        'inside':    li
-      } );
+        'type':    'checkbox',
+        'value':   option.value,
+        'name':    _name,
+        'class':   'cf-input cf-multi-select_checkbox',
+        'inside':  li
+      }
+      if ( option.checked ) {
+        inputData.checked = true;
+      }
+      _create( 'input', inputData );
 
       _create( 'label', {
         'for':         option.value,


### PR DESCRIPTION
After submitting the form, the page would load with the selected options, but the multiselect didn't display those options

## Additions

- Added a 'defaultSelected' lookup to set the 'checked' state of inputs
- Added a 'checked' state lookup when creating the `_selected` array
- Added the items to the choices list that exist in the `_selected` array

## Testing

- Use the multiselect on `/blog` on the demo server and make a selection in the multiselect. Notice that the selected options aren't persistent on form submission, but the params are correctly set in the url query. 
- Pull the branch locally and `gulp build`. Visit `/blog` and again make a selection in the multiselect. Choices should be persistent after form submission. Should also work on `/policy-compliance/amicus/briefs/` if you have CMS data locally.

## Review

- @KimberlyMunoz 
- @sebworks 
- @anselmbradford 

## Todo

- Tests, hopefully this next sprint

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [x] Passes all existing automated tests
* [ ] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)