### PR TITLE
Updates the categories for the item introduction and the page categor…

### DIFF
--- a/cfgov/scripts/update_header_cats.py
+++ b/cfgov/scripts/update_header_cats.py
@@ -1,0 +1,35 @@
+import json
+from v1.models import DocumentDetailPage
+from wagtail.wagtailcore.models import PageRevision
+
+def run():
+    for page in DocumentDetailPage.objects.all():
+        for i, child in enumerate(page.header.stream_data):
+            if child['type'] == 'item_introduction':
+                if 'admin-adj-process' in child['value']['category']:
+                    page.header.stream_data[i]['value']['category'] = 'admin-filing'
+                    page.save()
+        revisions = PageRevision.objects.filter(page=page).order_by('-id')
+        latest_revision = revisions.first()
+        revisions_to_update = {'shared': None, 'live': None}
+        for attr in revisions_to_update.keys():
+            for revision in revisions:
+                content = json.loads(revision.content_json)
+                if content[attr]:
+                    revisions_to_update[attr] = revision
+        revisions_to_update.update({'latest': latest_revision})
+        page_content = json.loads(latest_revision.content_json)
+        header = json.loads(page_content['header'])
+        for i, child in enumerate(header):
+            if child['type'] == 'item_introduction':
+                if 'admin-adj-process' in child['value']['category']:
+                    header[i]['value']['category'] = 'admin-filing'
+        page_content['header'] = json.dumps(header)
+        for i, category in enumerate(page_content['categories']):
+            if 'admin-adj-process' in category['name']:
+                page_content['categories'][i]['name']  = 'admin-filing'
+        content = json.dumps(page_content)
+        for revision in revisions_to_update.values():
+            if revision:
+                revision.content_json = content
+                revision.save()


### PR DESCRIPTION
Categories have been updated on the pages themselves, but not on the item introductions of the header stream field on DocumentDetailPages and their revisions. I tried to make it a migrations but got a weird error about a field that didn't exist for no reason so I gave up with that.

### Testing
- Pull down the latest dump from refresh
- Run `./cfgov/manage.py runscript update_header_cats`
- Go to the Security National Automotive Acceptance Company (SNAAC) 2 page http://content.localhost:8000/admin/pages/670/edit/ and check the category in the Item Introduction and on the page itself in the Configuration tab.

@kave 
@richaagarwal 
@rosskarchner 