### PR TITLE
Conditioned off the category icons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,6 +122,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Fixed failing browser tests due to atomic naming updates.
 - Fixed a bug in the multi-select script where value was set before input type.
 - Fixed positioning bug in global search.
+- Fixed issue where categories without a set icon were showing the speach icon.
 
 ## 3.0.0-3.0.0 - 2016-02-11
 

--- a/cfgov/jinja2/v1/_includes/macros/category-icon.html
+++ b/cfgov/jinja2/v1/_includes/macros/category-icon.html
@@ -37,7 +37,9 @@
         'testimony': 'cf-icon-double-quote',
       }
     %}
-    {% set icon = icons[category | lower] or icons['blog'] %}
+    {% set icon = icons[category | lower] %}
+    {% if icon %}
     <span class="cf-icon {{ icon }}
                  {{ additional_classes or '' }}"></span>
+    {% endif %}
 {% endmacro %}


### PR DESCRIPTION
Categories without a set icon should not show any icon

## Changes

- Added a condition to the category icon macro to avoid including any icon or the markup with the category doesn't have a matching icon

## Testing

- If you have CMS data, navigate to `/policy-compliance/amicus/briefs/` and ensure the categories aren't showing the speech bubble icon

## Review

- @KimberlyMunoz 
- @anselmbradford 
- @sebworks 

## Screenshots

<img width="869" alt="screen shot 2016-03-20 at 9 25 46 pm" src="https://cloud.githubusercontent.com/assets/1280430/13909486/53d71f16-eee2-11e5-8af2-c3b1992a8310.png">

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
