### PR TITLE
Fix for form reset button

### DIFF
--- a/cfgov/jinja2/v1/_includes/macros/filters.html
+++ b/cfgov/jinja2/v1/_includes/macros/filters.html
@@ -357,9 +357,10 @@
             <input class="btn form-actions_item"
                    type="submit"
                    value="{{ options.submit_label }}">
-            <input class="btn btn__warning btn__link form-actions_item js-form_clear"
-                   type="button"
-                   value="Reset filters">
+            <a class="btn btn__warning btn__link"
+                   href="{{ request.path }}">
+                    Reset filters
+            </a>
         </div>
     </div>
 

--- a/cfgov/jinja2/v1/_includes/organisms/filterable-list-controls.html
+++ b/cfgov/jinja2/v1/_includes/organisms/filterable-list-controls.html
@@ -167,10 +167,10 @@
                 <input class="btn form-actions_item"
                        type="submit"
                        value="Apply Filters">
-                <input class="btn btn__warning btn__link form-actions_item js-form_clear"
-                       type="button"
-                       value="Clear filters"
-                       data-js-hook="form-clear">
+                <a class="btn btn__warning btn__link"
+                   href="{{ request.path }}">
+                    Clear filters
+                </a>
             </div>
         </div>
     </form>


### PR DESCRIPTION
Fix for form reset button not submitting form field values.

## Changes

- Changed the form reset button to be a link

## Testing

- Visit the blog page and enter some criteria in the filter. Click on the apply filters link. After the page loads click on the reset link.

- Create a Filterable Control List and repeat the steps as above.

## Review

- @richaagarwal 
- @KimberlyMunoz 
- @jimmynotjim 
- @anselmbradford 

## Screenshots

<img width="1008" alt="screen shot 2016-03-21 at 12 36 13 am" src="https://cloud.githubusercontent.com/assets/1696212/13910789/c7ab7a0c-eefd-11e5-8090-f10eb90611fa.png">
