### PR TITLE
Removed Event download & reserve buttons

### DIFF
--- a/cfgov/jinja2/v1/events/event.html
+++ b/cfgov/jinja2/v1/events/event.html
@@ -39,17 +39,18 @@
                      reserve@cfpb.gov</a>
             </p>
         {% endif %}
-        <div class="content-l">
-            <section class="content-l_col content-l_col-1-2 event-footer_col">
-                <h3 class="h4 u-mb5">Downloads</h3>
-                <!-- TDOD: Replace with real download link -->
-                <a href="#" class="event-footer_link">Download event PDF <span class="cf-icon cf-icon-pdf"></span></a>
-            </section>
-            <section class="content-l_col content-l_col-1-2 event-footer_col">
-                <h3 class="h4 u-mb5">Do you have event questions?</h3>
-                <a href="mailto:reserve@cfpb.gov?subject=Event Question&body=Please include your question and fill in your first and last name below and send this email.%0D%0A%0D%0AQuestion:%0D%0AFirst name:%0D%0ALast name:" class="event-footer_link"><span class="cf-icon cf-icon-email-social"></span> reserve@cfpb.gov</a>
-            </section>
-        </div>
+        {# TODO resolve download button and verify reservation email at a future date #}
+{#        <div class="content-l">#}
+{#            <section class="content-l_col content-l_col-1-2 event-footer_col">#}
+{#                <h3 class="h4 u-mb5">Downloads</h3>#}
+{#                <!-- TDOD: Replace with real download link -->#}
+{#                <a href="#" class="event-footer_link">Download event PDF <span class="cf-icon cf-icon-pdf"></span></a>#}
+{#            </section>#}
+{#            <section class="content-l_col content-l_col-1-2 event-footer_col">#}
+{#                <h3 class="h4 u-mb5">Do you have event questions?</h3>#}
+{#                <a href="mailto:reserve@cfpb.gov?subject=Event Question&body=Please include your question and fill in your first and last name below and send this email.%0D%0A%0D%0AQuestion:%0D%0AFirst name:%0D%0ALast name:" class="event-footer_link"><span class="cf-icon cf-icon-email-social"></span> reserve@cfpb.gov</a>#}
+{#            </section>#}
+{#        </div>#}
     </div>
 {% endblock %}
 

--- a/cfgov/jinja2/v1/events/event.html
+++ b/cfgov/jinja2/v1/events/event.html
@@ -31,15 +31,17 @@
         {{ event_agenda(page) }}
     {% endif %}
     <div class="event-footer">
-        {% if event_state and event_state != 'past' %}
-            <p class="event-footer_banner">
-                <span class="event-footer_banner-message h4">This event requires an RSVP. Reserve your spot here: </span>
-                <a href="mailto:reserve@cfpb.gov?subject=Event RSVP&body=To RSVP, please fill in your first and last name below and send this email.%0D%0A%0D%0AFirst name:%0D%0ALast name:" class="btn">
-                    <span class="btn_icon__left cf-icon cf-icon-email-social"></span>
-                     reserve@cfpb.gov</a>
-            </p>
-        {% endif %}
-        {# TODO resolve download button and verify reservation email at a future date #}
+     {# TODO resolve download button and verify reservation email at a future date #}
+
+{#        {% if event_state and event_state != 'past' %}#}
+{#            <p class="event-footer_banner">#}
+{#                <span class="event-footer_banner-message h4">This event requires an RSVP. Reserve your spot here: </span>#}
+{#                <a href="mailto:reserve@cfpb.gov?subject=Event RSVP&body=To RSVP, please fill in your first and last name below and send this email.%0D%0A%0D%0AFirst name:%0D%0ALast name:" class="btn">#}
+{#                    <span class="btn_icon__left cf-icon cf-icon-email-social"></span>#}
+{#                     reserve@cfpb.gov</a>#}
+{#            </p>#}
+{#        {% endif %}#}
+
 {#        <div class="content-l">#}
 {#            <section class="content-l_col content-l_col-1-2 event-footer_col">#}
 {#                <h3 class="h4 u-mb5">Downloads</h3>#}


### PR DESCRIPTION
## Removals

- removed erroneous Event buttons and added todo to resolve download button and verify reservation email at a future date

## Testing

- Load Refresh Db
-  visit [here](http://content.localhost:8000/about-us/events/spring-2016-credit-union-advisory-council-meeting-washington-dc/) to verify download and reservation buttons do not render

## Review

- @kurtw 
- @richaagarwal 

## Screenshots
before:
![screen shot 2016-03-21 at 9 56 49 am](https://cloud.githubusercontent.com/assets/254877/13920858/76172166-ef4b-11e5-9b9d-0fa01b7f63e0.png)

after:
![screen shot 2016-03-21 at 9 56 37 am](https://cloud.githubusercontent.com/assets/254877/13920860/78e1a678-ef4b-11e5-86b1-a6d263c44e7d.png)

