### PR TITLE
Standardize spacing on molecule macros

### DIFF
--- a/cfgov/jinja2/v1/_includes/molecules/breadcrumbs.html
+++ b/cfgov/jinja2/v1/_includes/molecules/breadcrumbs.html
@@ -17,10 +17,10 @@
    ========================================================================== #}
 
 {# TODO: Remove additional_classes parameter from macros. #}
-{% macro render(breadcrumbs, additional_classes) %}
+{% macro render( breadcrumbs, additional_classes ) %}
     <nav class="breadcrumbs {{ additional_classes }}" aria-label="Breadcrumbs">
         {% for crumb in breadcrumbs %}
-        <a class="breadcrumbs_link" href="{{ get_page_state_url({}, crumb) }}">
+        <a class="breadcrumbs_link" href="{{ get_page_state_url( {}, crumb ) }}">
             {{ crumb.title | e }}
         </a>
         {% endfor %}

--- a/cfgov/jinja2/v1/_includes/molecules/call-to-action.html
+++ b/cfgov/jinja2/v1/_includes/molecules/call-to-action.html
@@ -35,7 +35,6 @@
             {{ parse_links(value.paragraph_text) |safe }}
         </p>
     {% endif %}
-
     {% if value.button %}
         <a class="btn btn__full"
            href="{{ value.button.url or '/' }}">

--- a/cfgov/jinja2/v1/_includes/molecules/card.html
+++ b/cfgov/jinja2/v1/_includes/molecules/card.html
@@ -1,4 +1,4 @@
 <div class="m-card">
-  <h3 class="h1 m-card_heading">Card Heading</h3>
-  <p class="m-card_body">Card text</p>
+    <h3 class="h1 m-card_heading">Card Heading</h3>
+    <p class="m-card_body">Card text</p>
 </div>

--- a/cfgov/jinja2/v1/_includes/molecules/contact-address.html
+++ b/cfgov/jinja2/v1/_includes/molecules/contact-address.html
@@ -22,7 +22,6 @@
 <div class="m-contact-address">
     <span class="cf-icon cf-icon-mail"></span>
     <span class="h5">{{ value.label }}</span>
-
     <p>
         {% if value.title %}
             <span>{{ value.title }}</span><br>

--- a/cfgov/jinja2/v1/_includes/molecules/contact-phone.html
+++ b/cfgov/jinja2/v1/_includes/molecules/contact-phone.html
@@ -32,14 +32,14 @@
     <span class="cf-icon {{ icon }}"></span>
     <span class="h5">{{ label }}</span>
     {% for phone in value.phones %}
-    <p>
-        <b>{{ format_phone(phone.number) }}</b>
-        {% if phone.vanity %}
-        <span>{{ format_phone(phone.vanity) }}</span>
-        {% endif %}
-        {% if phone.tty %}
-        <span>TTY/TDD: {{ format_phone(phone.tty) }}<span>
-        {% endif %}
-    </p>
+        <p>
+            <b>{{ format_phone( phone.number ) }}</b>
+            {% if phone.vanity %}
+                <span>{{ format_phone( phone.vanity ) }}</span>
+            {% endif %}
+            {% if phone.tty %}
+                <span>TTY/TDD: {{ format_phone( phone.tty ) }}<span>
+            {% endif %}
+        </p>
     {% endfor %}
 </div>

--- a/cfgov/jinja2/v1/_includes/molecules/expandable.html
+++ b/cfgov/jinja2/v1/_includes/molecules/expandable.html
@@ -26,14 +26,12 @@
 
    ========================================================================== #}
 
-{% macro expandable(value) %}
-
+{% macro expandable( value ) %}
 <div class="m-expandable
             m-expandable__expanded
             {{ 'm-expandable__borders' if value.is_bordered else '' }}
             {{ 'm-expandable__midtone' if value.is_midtone else '' }}"
             {{ 'data-state=expanded' if value.is_expanded else '' }}>
-
     <button class="m-expandable_target">
         <div class="m-expandable_header">
             <span class="m-expandable_header-left
@@ -64,9 +62,9 @@
             {% else %}
                 {% for block in value.content %}
                     {% if 'paragraph' in block.block_type %}
-                        {{ parse_links(block.value) |safe}}
+                        {{ parse_links( block.value ) | safe }}
                     {% else %}
-                        {{ render_stream_child(block) }}
+                        {{ render_stream_child( block ) }}
                     {% endif %}
                 {% endfor %}
             {% endif %}
@@ -76,5 +74,5 @@
 {% endmacro %}
 
 {% if value %}
-    {{ expandable(value) }}
+    {{ expandable( value ) }}
 {% endif %}

--- a/cfgov/jinja2/v1/_includes/molecules/featured-content.html
+++ b/cfgov/jinja2/v1/_includes/molecules/featured-content.html
@@ -43,35 +43,35 @@
 
    ========================================================================== #}
 
-{% macro render(value) %}
+{% macro render( value ) %}
 {% import 'macros/category-icon.html' as category_icon %}
 
 <section class="featured-content-module">
     <div class="featured-content-module_text">
         <p class="h4">
-            {{ category_icon.render( fcm_label(value.category) ) | safe }}
+            {{ category_icon.render( fcm_label( value.category ) ) | safe }}
             {{ fcm_label( value.category ) }}
         </p>
         <h2>
             {{ value.heading }}
         </h2>
         <p>
-            {{ parse_links(value.body) |safe }}
+            {{ parse_links( value.body ) |safe }}
         </p>
         <ul class="list list__links">
             {% if value.show_post_link and value.post %}
                 <li class="list_item">
-                  <a class="list_link" href="{{ value.post.url_path }}">
-                    {{ value.post_link_text }}
-                  </a>
+                    <a class="list_link" href="{{ value.post.url_path }}">
+                        {{ value.post_link_text }}
+                    </a>
                 </li>
             {% endif %}
             {% if value.macro_link %}
-              <li class="list_item">
-                  <a class="list_link" href="{{ value.macro_link.url }}">
-                      {{ value.macro_link.text }}
-                  </a>
-              </li>
+                <li class="list_item">
+                    <a class="list_link" href="{{ value.macro_link.url }}">
+                        {{ value.macro_link.text }}
+                    </a>
+                </li>
             {% endif %}
             {% for link in value.links %}
                 <li class="list_item">
@@ -85,7 +85,7 @@
     {% if value.video.url and value.video.id %}
         <div class="featured-content-module_visual">
             {% import 'macros/video-player.html' as video_player %}
-            {{ video_player.render(value) }}
+            {{ video_player.render( value ) }}
         </div>
     {% elif value.image %}
         <div class="featured-content-module_visual">

--- a/cfgov/jinja2/v1/_includes/molecules/global-search.html
+++ b/cfgov/jinja2/v1/_includes/molecules/global-search.html
@@ -55,7 +55,6 @@
                     <button class="btn" type="submit">Search</button>
                 </div>
             </div>
-
             <div class="m-global-search_content-suggestions">
                 <p class="h5">Suggested search terms:</p>
                 <ul class="list list__horizontal">

--- a/cfgov/jinja2/v1/_includes/molecules/hero.html
+++ b/cfgov/jinja2/v1/_includes/molecules/hero.html
@@ -40,8 +40,8 @@
              if value.background_color else '' }}>
     <div class="wrapper hero_wrapper">
         <div class="hero_text">
-            <h1 class="hero_heading">{{ value.heading | safe}}</h1>
-            <div class="hero_subhead">{{ parse_links(value.body) | safe }}</div>
+            <h1 class="hero_heading">{{ value.heading | safe }}</h1>
+            <div class="hero_subhead">{{ parse_links( value.body ) | safe }}</div>
             {% for link in value.links %}
                 <a href="{{ link.url }}"
                    class="hero_cta
@@ -50,9 +50,8 @@
                 </a>
             {% endfor %}
         </div>
-
         {% if value.image.upload %}
-            {% set photo=image(value.image.upload, 'original') %}
+            {% set photo=image( value.image.upload, 'original' ) %}
             <div class="hero_image"
                  style="background-image: url( {{ photo.url }} );"></div>
         {% endif %}

--- a/cfgov/jinja2/v1/_includes/molecules/info-unit.html
+++ b/cfgov/jinja2/v1/_includes/molecules/info-unit.html
@@ -35,29 +35,25 @@
 
    ========================================================================== #}
 
-{% macro info_unit(value) %}
+{% macro info_unit( value ) %}
 <div class="m-info-unit
             {{ 'm-info-unit__' ~ value.modifier if value.modifier else '' }}">
-
     {% if value.image %}
         {% if value.image.is_decorative %}
-        <div class="m-info-unit_image
-                    {{ 'm-info-unit_image__square' if value.image.is_square else '' }}"
-             style="background-image: url( {{ value.image.url }} );">
-        </div>
+            <div class="m-info-unit_image
+                        {{ 'm-info-unit_image__square' if value.image.is_square else '' }}"
+                 style="background-image: url( {{ value.image.url }} );">
+            </div>
         {% else %}
-        <img src="{{ value.image.url }}"
-             alt="{{ value.image.alt if value.image.alt else '' }}"
-             class="m-info-unit_image
-                    {{ 'm-info-unit_image__square' if value.image.is_square else '' }}">
+            <img src="{{ value.image.url }}"
+                 alt="{{ value.image.alt if value.image.alt else '' }}"
+                 class="m-info-unit_image
+                        {{ 'm-info-unit_image__square' if value.image.is_square else '' }}">
         {% endif %}
     {% endif %}
-
     <div class="m-info-unit_content">
         {{ value.heading | safe if value.heading else '' }}
-
         {{ value.body | safe }}
-
         {% if value.links %}
             <ul class="list list__links">
             {% for link in value.links %}
@@ -74,6 +70,5 @@
             </ul>
         {% endif %}
     </div>
-
 </div>
 {% endmacro %}

--- a/cfgov/jinja2/v1/_includes/molecules/nav-link.html
+++ b/cfgov/jinja2/v1/_includes/molecules/nav-link.html
@@ -19,7 +19,7 @@
             Defaults to false.
 
    ========================================================================= #}
-{% macro nav_link(text, href, parent=true, current=false) %}
+{% macro nav_link( text, href, parent=true, current=false ) %}
 <a class="m-nav-link
           {{ 'm-nav-link__parent' if parent else '' }}
           {{ 'm-nav-link__current' if current else '' }}"

--- a/cfgov/jinja2/v1/_includes/molecules/notification.html
+++ b/cfgov/jinja2/v1/_includes/molecules/notification.html
@@ -23,28 +23,26 @@
 
    ========================================================================== #}
 
-{% macro render(type, is_visible, message, explanation=none) %}
+{% macro render( type, is_visible, message, explanation=none ) %}
 
-  {% set type_lookup  = {
+    {% set type_lookup  = {
         'success' : 'approved',
         'warning' : 'error',
         'error'   : 'delete',
       }
-  %}
-  {% set icon = type_lookup[type]  %}
-  {% set type = ('m-notification__' + type | string) if type else '' %}
+    %}
+    {% set icon = type_lookup[type] %}
+    {% set type = ('m-notification__' + type | string) if type else '' %}
 
-  <div class="m-notification
+    <div class="m-notification
               {{ type }}
               {{ 'm-notification__visible' if is_visible else '' }}">
-      <span class="m-notification_icon
-                   cf-icon"></span>
-      <div class="m-notification_content">
-          <p class="h4 m-notification_message">{{ message }}</p>
-          {% if explanation %}
-              <p class="h4 m-notification_explanation">{{ explanation }}</p>
-          {% endif %}
-      </div>
-  </div>
-
+        <span class="m-notification_icon cf-icon"></span>
+        <div class="m-notification_content">
+            <p class="h4 m-notification_message">{{ message }}</p>
+            {% if explanation %}
+                <p class="h4 m-notification_explanation">{{ explanation }}</p>
+            {% endif %}
+        </div>
+    </div>
 {% endmacro %}

--- a/cfgov/jinja2/v1/_includes/molecules/related-links.html
+++ b/cfgov/jinja2/v1/_includes/molecules/related-links.html
@@ -31,11 +31,11 @@
 
     {% if value.links %}
         <ul class="list list__unstyled list__links">
-        {% for link in value.links %}
-            <li class="list_item">
-                <a href="{{ link.url }}" class="list_link">{{ link.text }}</a>
-            </li>
-        {% endfor %}
+            {% for link in value.links %}
+                <li class="list_item">
+                    <a href="{{ link.url }}" class="list_link">{{ link.text }}</a>
+                </li>
+            {% endfor %}
         </ul>
     {% endif %}
 </div>

--- a/cfgov/jinja2/v1/_includes/molecules/related-metadata.html
+++ b/cfgov/jinja2/v1/_includes/molecules/related-metadata.html
@@ -15,7 +15,7 @@
 
    ========================================================================== #}
 
-{% macro render(value) %}
+{% macro render( value ) %}
 {% set types_lookup = {
     'date':   _date,
     'list':   _list,
@@ -39,7 +39,7 @@
             <h3 class="h4">
                 {{ block.value.heading }}
             </h3>
-            {{ types_lookup[block.block_type](block.value) }}
+            {{ types_lookup[block.block_type]( block.value ) }}
         </div>
     {% endfor %}
 </div>
@@ -62,17 +62,17 @@
 
    ========================================================================== #}
 
-{% macro _list(list, is_related_topics=false) %}
+{% macro _list( list, is_related_topics=false ) %}
 <ul class="list
            list__unstyled
            list__links
            {{ 'm-related-metadata_topics' if is_related_topics else '' }} ">
     {% for link in list.links %}
-    <li class="list_item">
-        <a href="{{ link.url }}" class="list_link">
-            {{ link.text }}
-        </a>
-    </li>
+        <li class="list_item">
+            <a href="{{ link.url }}" class="list_link">
+                {{ link.text }}
+            </a>
+        </li>
     {% endfor %}
 </ul>
 {% endmacro %}
@@ -94,7 +94,7 @@
 {% macro _date(date) %}
 {% import 'macros/time.html' as time %}
 <p class="date u-mb0">
-    {{ time.render(date.date, {'date':true}) }}
+    {{ time.render( date.date, {'date':true} ) }}
 </p>
 {% endmacro %}
 
@@ -112,8 +112,7 @@
 
    ========================================================================== #}
 
-{% macro _text(text) %}
-
+{% macro _text( text ) %}
 <p class="u-mb0">
     {{ parse_links(text.blob) | safe }}
 </p>
@@ -133,6 +132,6 @@
 
    ========================================================================== #}
 
-{% macro _topics(list) %}
-    {{ _list( page.related_metadata_tags(request.GET), true ) }}
+{% macro _topics( list ) %}
+    {{ _list( page.related_metadata_tags( request.GET ), true ) }}
 {% endmacro %}

--- a/cfgov/jinja2/v1/_includes/molecules/related-posts.html
+++ b/cfgov/jinja2/v1/_includes/molecules/related-posts.html
@@ -16,9 +16,9 @@
 
    ========================================================================== #}
 
-{% macro render(block, is_half_width=false, hide_header_slug=false) %}
+{% macro render( block, is_half_width=false, hide_header_slug=false ) %}
     {% import 'macros/category-icon.html' as category_icon %}
-    {% set related_post_types = page.related_posts(block, request.site.hostname) %}
+    {% set related_post_types = page.related_posts( block, request.site.hostname ) %}
     {% if related_post_types %}
         <div class="m-related-posts
                     {{'m-related-posts__half-width'
@@ -31,14 +31,14 @@
                 </h2>
             {% endif %}
             {% for post_type, post_type_list in related_post_types.iteritems() %}
-                {% set title, icon = (post_type, category_icon.render(post_type)) or ("Blog", "cf-icon-speech-bubble") %}
+                {% set title, icon = ( post_type, category_icon.render( post_type ) ) or ( "Blog", "cf-icon-speech-bubble" ) %}
                 <div class="m-related-posts_list-container">
                     {% if block.value.show_heading %}
                         <h3 class="h4">
                             {{ icon }} {{ title }}
                         </h3>
                     {% endif %}
-                    {{ _related_posts_list(post_type_list, block.value.limit) }}
+                    {{ _related_posts_list( post_type_list, block.value.limit ) }}
                 </div>
             {% endfor %}
         </div>

--- a/cfgov/jinja2/v1/_includes/molecules/related-topics.html
+++ b/cfgov/jinja2/v1/_includes/molecules/related-topics.html
@@ -22,12 +22,12 @@
         </span>
     </h2>
     <ul class="list list__unstyled list__links">
-    {% for topic in value.topics %}
-    <li class="list_item">
-        <a href="{{ topic.url }}" class="list_link">
-            {{ topic.text }}
-        </a>
-    </li>
-    {% endfor %}
+        {% for topic in value.topics %}
+            <li class="list_item">
+                <a href="{{ topic.url }}" class="list_link">
+                    {{ topic.text }}
+                </a>
+            </li>
+        {% endfor %}
     </ul>
 </div>

--- a/cfgov/jinja2/v1/_includes/molecules/text-introduction.html
+++ b/cfgov/jinja2/v1/_includes/molecules/text-introduction.html
@@ -25,8 +25,10 @@
    ========================================================================== #}
 
 <h1>{{ value.heading }}</h1>
-<div class="lead-paragraph">{{ parse_links(value.intro) | safe }}</div>
-{{ parse_links(value.body) | safe }}
+<div class="lead-paragraph">
+    {{ parse_links( value.intro ) | safe }}
+</div>
+{{ parse_links( value.body ) | safe }}
 <ul class="list list__links">
     {% for link in value.links %}
         <li class="list_item">


### PR DESCRIPTION
Went through spacing for macros in the molecule folder to standardize our spacing norms.

## Review

- @anselmbradford 
- @jimmynotjim 
- @sebworks 

## Notes

- I didn't update spacing after we define a macro. I think keep it inline like this, similar to how we treat body tags to avoid extra unnecessary spacing.

```
{% macro render( post ) %}
<div class="post">
    {{ post }}
</div>
{% endmacro %}
```

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
