### PR TITLE
Stop footer link underlines from going under icon

### DIFF
--- a/cfgov/jinja2/v1/_includes/organisms/footer.html
+++ b/cfgov/jinja2/v1/_includes/organisms/footer.html
@@ -117,7 +117,7 @@
                                   icon-link
                                   icon-link__external-link"
                            href="http://usa.gov/">
-                            USA.gov
+                            <span class="icon-link_text">USA.gov</span>
                         </a>
                     </li>
                     <li class="list_item">
@@ -125,7 +125,7 @@
                                   icon-link
                                   icon-link__external-link"
                            href="http://www.federalreserve.gov/oig/default.htm">
-                            Office of Inspector General
+                            <span class="icon-link_text">Office of Inspector General</span>
                         </a>
                     </li>
                 </ul>

--- a/cfgov/unprocessed/css/organisms/footer.less
+++ b/cfgov/unprocessed/css/organisms/footer.less
@@ -73,7 +73,6 @@
 
         .list_link {
             .u-link__colors( @dark-gray );
-            border-bottom: 1px dotted;
         }
     }
 


### PR DESCRIPTION
## Changes

- Adds `span.icon-link_text` into external links in footer to prevent their underlines from going under the icon.

## Review

- @jimmynotjim 
- @KimberlyMunoz 
- @sebworks 
- @anselmbradford 

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)

