### PR TITLE
Abstracted create and queryOne out of the multiselect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 
 ### Changed
 
+- Abstracted create and queryOneout of the multiselect
+
 ### Removed
 
 ### Fixed

--- a/cfgov/unprocessed/js/modules/util/dom-manipulators.js
+++ b/cfgov/unprocessed/js/modules/util/dom-manipulators.js
@@ -1,0 +1,37 @@
+'use strict';
+
+var queryOne = require( './dom-traverse' ).queryOne;
+
+/**
+ * Shortcut for creating new dom elements
+ * @param   {string} tag     The html elem to create
+ * @param   {Object} options The options for building the elem
+ * @returns {HTMLNode}       The created elem
+ */
+function create( tag, options ) {
+  var elem = document.createElement( tag );
+
+  for ( var i in options ) {
+    if ( options.hasOwnProperty( i ) ) {
+      var val = options[i];
+      var ref = queryOne( val );
+
+      if ( i === 'inside' ) {
+        ref.appendChild( elem );
+      } else if ( i === 'around' ) {
+        ref.parentNode.insertBefore( elem, ref );
+        elem.appendChild( ref );
+      } else if ( i in elem ) {
+        elem[i] = val;
+      } else {
+        elem.setAttribute( i, val );
+      }
+    }
+  }
+
+  return elem;
+}
+
+module.exports = {
+  create: create
+};

--- a/cfgov/unprocessed/js/modules/util/dom-traverse.js
+++ b/cfgov/unprocessed/js/modules/util/dom-traverse.js
@@ -1,5 +1,19 @@
 'use strict';
 
+var typeCheckers = require( './type-checkers' );
+
+/**
+ * Queries for the first match unless an HTMLNode is passed
+ * @param   {(HTMLNode|string)} expr HTMLNode or string to query for
+ * @param   {Object}          con  The document location to query
+ * @returns {HTMLNode}             The elem
+ */
+function queryOne( expr, con ) {
+  return typeCheckers.isString( expr ) ?
+    ( con || document ).querySelector( expr ) :
+    expr || null;
+}
+
 /**
  * Get the sibling nodes of a dom node.
  *
@@ -71,6 +85,7 @@ function closest( elem, selector ) {
 }
 
 module.exports = {
+  queryOne:    queryOne,
   closest:     closest,
   getSiblings: getSiblings,
   not:         not

--- a/cfgov/unprocessed/js/molecules/Multiselect.js
+++ b/cfgov/unprocessed/js/molecules/Multiselect.js
@@ -3,6 +3,8 @@
 // Required modules.
 var arrayHelpers = require( '../modules/util/array-helpers' );
 var typeCheckers = require( '../modules/util/type-checkers' );
+var domTraverse = require( '../modules/util/dom-traverse' );
+var domCreate = require( '../modules/util/dom-manipulators' ).create;
 
 /**
  * Multiselect
@@ -123,23 +125,23 @@ function Multiselect( element ) { // eslint-disable-line max-statements, inline-
    */
   function _populateMarkup() {
     // Add a container for our markup and hide the default select elem
-    _container = _create( 'div', {
+    _container = domCreate( 'div', {
       className: 'cf-multi-select',
       around:    _dom
     } );
 
     // Create all our markup but wait to manipulate the DOM just once
-    _choices = _create( 'ul', {
+    _choices = domCreate( 'ul', {
       className: 'list__unstyled cf-multi-select_choices',
       inside:    _container
     } );
 
     _selections.forEach( function( option ) {
-      var li = _create( 'li', {
+      var li = domCreate( 'li', {
         'data-option': option.value
       } );
 
-      _create( 'label', {
+      domCreate( 'label', {
         'for':         option.value,
         'textContent': option.text,
         'className':   'cf-multi-select_label',
@@ -149,11 +151,11 @@ function Multiselect( element ) { // eslint-disable-line max-statements, inline-
       _choices.appendChild( li );
     } );
 
-    _header = _create( 'header', {
+    _header = domCreate( 'header', {
       className: 'cf-multi-select_header'
     } );
 
-    _search = _create( 'input', {
+    _search = domCreate( 'input', {
       className:   'cf-multi-select_search',
       type:        'text',
       placeholder: _placeholder || 'Choose up to five',
@@ -161,18 +163,18 @@ function Multiselect( element ) { // eslint-disable-line max-statements, inline-
       id:          _name
     } );
 
-    _fieldset = _create( 'fieldset', {
-      'className':   'cf-multi-select_fieldset u-invisible',
+    _fieldset = domCreate( 'fieldset', {
+      className:     'cf-multi-select_fieldset u-invisible',
       'aria-hidden': 'true'
     } );
 
-    _list = _create( 'ul', {
+    _list = domCreate( 'ul', {
       className: 'list__unstyled cf-multi-select_options',
       inside:    _fieldset
     } );
 
     _optionData.forEach( function( option ) {
-      var li = _create( 'li', {
+      var li = domCreate( 'li', {
         'data-option': option.value
       } );
 
@@ -190,9 +192,9 @@ function Multiselect( element ) { // eslint-disable-line max-statements, inline-
         inputData.checked = true;
       }
 
-      _create( 'input', inputData );
+      domCreate( 'input', inputData );
 
-      _create( 'label', {
+      domCreate( 'label', {
         'for':         option.value,
         'textContent': option.text,
         'className':   'cf-multi-select_label',
@@ -255,11 +257,11 @@ function Multiselect( element ) { // eslint-disable-line max-statements, inline-
           _choices.removeChild( li );
         }
       } else {
-        li = _create( 'li', {
+        li = domCreate( 'li', {
           'data-option': option.value
         } );
 
-        _create( 'label', {
+        domCreate( 'label', {
           'for': option.value,
           'innerHTML': option.text,
           'inside': li
@@ -404,7 +406,7 @@ function Multiselect( element ) { // eslint-disable-line max-statements, inline-
           event.preventDefault();
           event.target.checked = !checked;
 
-          _fire( _queryOne( event.target ), 'change', {} );
+          _fire( domTraverse.queryOne( event.target ), 'change', {} );
         } else if ( key === KEY_ESCAPE ) {
           _search.focus();
           collapse();
@@ -440,48 +442,6 @@ function Multiselect( element ) { // eslint-disable-line max-statements, inline-
    */
   function _filterContains( text, value ) {
     return RegExp( _regExpEscape( value.trim() ), 'i' ).test( text );
-  }
-
-  /**
-   * Queries the doc for the first match of the elem
-   * @param   {object|string} expr HTMLNode or string to query for
-   * @param   {object} con         The document location to query
-   * @returns {HTMLNode}           The elem
-   */
-  function _queryOne( expr, con ) {
-    return typeCheckers.isString( expr ) ?
-      ( con || document ).querySelector( expr ) :
-      expr || null;
-  }
-
-  /**
-   * Shortcut for creating new dom elements
-   * @param   {string} tag     The html elem to create
-   * @param   {object} options The options for building the elem
-   * @returns {HTMLNode}       The created elem
-   */
-  function _create( tag, options ) {
-    var elem = document.createElement( tag );
-
-    for ( var i in options ) {
-      if ( options.hasOwnProperty( i ) ) {
-        var val = options[i];
-        var ref = _queryOne( val );
-
-        if ( i === 'inside' ) {
-          ref.appendChild( elem );
-        } else if ( i === 'around' ) {
-          ref.parentNode.insertBefore( elem, ref );
-          elem.appendChild( ref );
-        } else if ( i in elem ) {
-          elem[i] = val;
-        } else {
-          elem.setAttribute( i, val );
-        }
-      }
-    }
-
-    return elem;
   }
 
   /**

--- a/test/unit_tests/modules/util/dom-manipulators-spec.js
+++ b/test/unit_tests/modules/util/dom-manipulators-spec.js
@@ -1,0 +1,70 @@
+'use strict';
+var chai = require( 'chai' );
+var expect = chai.expect;
+var sinon = require( 'sinon' );
+var jsdom = require( 'mocha-jsdom' );
+var BASE_JS_PATH = '../../../../cfgov/unprocessed/js/';
+var ERROR_MESSAGES = require( BASE_JS_PATH + 'config/error-messages-config' );
+var domManipulators = require( BASE_JS_PATH + 'modules/util/dom-manipulators' );
+var heading;
+var span;
+var div;
+
+describe( 'Dom Manipulators create', function() {
+  jsdom();
+
+  before( function() {
+    heading = domManipulators.create( 'h1', {
+      'textContent': 'Create Heading Text',
+      'id':          'create-heading-id',
+      'className':   'create-heading-class',
+      'data-name':   'create-heading-data'
+    } );
+
+    span = domManipulators.create( 'span', {
+      'textContent': 'Heading Span',
+      'id':          'create-span-id',
+      'className':   'create-span-class',
+      'data-name':   'create-span-data',
+      'inside':      heading
+    } );
+
+    document.body.appendChild( heading );
+
+    div = domManipulators.create( 'div', {
+      'id':        'create-div-id',
+      'className': 'create-div-class',
+      'data-name': 'create-div-data',
+      'around':    heading
+    } );
+  } );
+
+
+  it( 'should create a single elem', function() {
+    var query = document.querySelector( 'h1' );
+
+    expect( query.id ).to.equal( 'create-heading-id' );
+    expect( query.className ).to.equal( 'create-heading-class' );
+    expect( query.getAttribute( 'data-name' ) )
+      .to.equal( 'create-heading-data' );
+  } );
+
+  it( 'should create an elem inside another', function() {
+    var query = document.querySelector( 'span' );
+
+    expect( query.textContent ).to.equal( 'Heading Span' );
+    expect( query.id ).to.equal( 'create-span-id' );
+    expect( query.className ).to.equal( 'create-span-class' );
+    expect( query.getAttribute( 'data-name' ) )
+      .to.equal( 'create-span-data' );
+  } );
+
+  it( 'should create an elem around another', function() {
+    var query = document.querySelector( 'div' );
+
+    expect( query.id ).to.equal( 'create-div-id' );
+    expect( query.className ).to.equal( 'create-div-class' );
+    expect( query.getAttribute( 'data-name' ) )
+      .to.equal( 'create-div-data' );
+  } );
+} );

--- a/test/unit_tests/modules/util/dom-traverse-spec.js
+++ b/test/unit_tests/modules/util/dom-traverse-spec.js
@@ -1,0 +1,37 @@
+'use strict';
+var chai = require( 'chai' );
+var expect = chai.expect;
+var sinon = require( 'sinon' );
+var jsdom = require( 'mocha-jsdom' );
+var BASE_JS_PATH = '../../../../cfgov/unprocessed/js/';
+var ERROR_MESSAGES = require( BASE_JS_PATH + 'config/error-messages-config' );
+var domTraverse = require( BASE_JS_PATH + 'modules/util/dom-traverse' );
+
+describe( 'Dom Traverse queryOne', function() {
+  jsdom();
+
+  before( function() {
+    document.body.innerHTML =
+      '<div class="div-1"></div><div class="query-2"></div>';
+  } );
+
+  it( 'should return the first elem if the expr is a string', function() {
+    var query = domTraverse.queryOne( 'div' );
+
+    expect( query.className ).to.equal( 'div-1' );
+  } );
+
+  it( 'should return the passed expr if it’s an object', function() {
+    var obj = document.createElement( 'div' );
+    obj.className = 'div-3';
+    var query = domTraverse.queryOne( obj );
+
+    expect( query.className ).to.equal( 'div-3' );
+  } );
+
+  it( 'should return null if the elem doesn’t exist', function() {
+    var query = document.querySelector( '.div-4' );
+
+    expect( query ).to.equal( null );
+  } );
+} );


### PR DESCRIPTION
Abstracted create and queryOne out of the multiselect

## Additions

- Creates elem creation helper for standardizing elem creation
  - Adds option for creating an elem inside another (including in memory, reducing dom changes)
  - Adds option for creating an elem around another
- Creates elem query helper for standardizing elem search (necessary for appending elems to others in memory)
- Adds tests for both of these

## Changes

- Updated the multiselect to use the abstracted helpers

## Testing

- `gulp build` and test the multiselect, shouldn't be any changes
- `gulp test:unit:scripts` and open `./test/unit_test_coverage/lcov-report/modules/util/index.html` to view the stats on both of these specs

## Review

- @KimberlyMunoz 
- @sebworks 
- @anselmbradford 

## Screenshots


## Notes

__Before__

```
=============================== Coverage summary ===============================
Statements   : 26.64% ( 712/2673 )
Branches     : 21.97% ( 192/874 )
Functions    : 19.58% ( 84/429 )
Lines        : 26.74% ( 708/2648 )
================================================================================
```

__After__

```
=============================== Coverage summary ===============================
Statements   : 27.3% ( 731/2678 )
Branches     : 23.34% ( 204/874 )
Functions    : 20.05% ( 86/429 )
Lines        : 27.4% ( 727/2653 )
================================================================================
```

## Todos

- Abstract and test the rest of the multiselect, I didn't want to make this PR too large.

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)