### PR TITLE
setup sites for ec2 instances

### DIFF
--- a/cfgov/scripts/setup_sites_prod.py
+++ b/cfgov/scripts/setup_sites_prod.py
@@ -1,0 +1,22 @@
+from wagtail.wagtailcore.models import Site
+from django.conf import settings
+
+
+def run(hostname):
+    # Set up sites
+    live = 'localhost'
+    shared = 'content.' + live
+    port = 8000
+    if hostname:
+        live = str(hostname)
+        shared = 'content.' + live
+        port = 80
+
+    site1 = Site.objects.first()
+    site1.hostname = live
+    site1.port = port
+    site1.save()
+    site2 = Site.objects.last()
+    site2.hostname = shared
+    site2.port = port
+    site2.save()


### PR DESCRIPTION
@kurtw 

@richaagarwal 

@rosskarchner 

## Test
- `./cfgov/manage.py runscript setup_sites_prod --script-args='flapjack.demo.gov'`
- verify wagtail sites have been updated to match param