### PR TITLE
change URL pattern for complaint database

### DIFF
--- a/cfgov/cfgov/urls.py
+++ b/cfgov/cfgov/urls.py
@@ -223,7 +223,7 @@ urlpatterns = [
     url(r'^hud-api-replace/', include_if_app_enabled('hud_api_replace','hud_api_replace.urls')),
     url(r'^retirement/', include_if_app_enabled('retirement_api','retirement_api.urls')),
     url(r'^complaint/', include_if_app_enabled('complaint','complaint.urls')),
-    url(r'^complaintdatabase/', include_if_app_enabled('complaintdatabase','complaintdatabase.urls')),
+    url(r'^data-research/consumer-complaints/', include_if_app_enabled('complaintdatabase','complaintdatabase.urls')),
     url(r'^oah-api/rates/', include_if_app_enabled('ratechecker', 'ratechecker.urls')),
     url(r'^oah-api/county/', include_if_app_enabled('countylimits','countylimits.urls')),
 

--- a/cfgov/jinja2/v1/_includes/organisms/_vars-mega-menu.html
+++ b/cfgov/jinja2/v1/_includes/organisms/_vars-mega-menu.html
@@ -60,7 +60,7 @@
     ('Data & Research', '/data-research/', [(
         ('Research & Reports', '/data-research/research-reports/', []),
     ),(
-        ('Consumer Complaint Database', '/complaintdatabase/', []),
+        ('Consumer Complaint Database', '/data-research/consumer-complaints/', []),
         ('Mortgage Database (HMDA)', '/hmda/', [])
     ),(
         ('Credit Card Surveys & Agreements', '/data-research/credit-card-data/', []),


### PR DESCRIPTION
Per most recent URL tracker document from @schaferjh, complaint database will be at /data-research/consumer-complaints/

This moves it there.


## Changes

- only edits urls.py

## Testing

- install the CCDB4/CCDB-content app, start cfgov/manage.py runserver
- browse to /data-research/consumer-complaints/ and admire
- brose to /complaintdatabase and admire the 404

## Review

- @richaagarwal @kave @kurtw @schaferjh 

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [x] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)