### PR TITLE
Fix the way the fcm video expands

### DIFF
--- a/cfgov/jinja2/v1/_includes/macros/video-player.html
+++ b/cfgov/jinja2/v1/_includes/macros/video-player.html
@@ -55,7 +55,8 @@
     {% set button_pos   = options.button_pos or 'center' %}
     {% set is_flexible  = ( options.video.width or options.video.height ) is not defined %}
     <div class="video-player
-                video-player__{{ video_player }}"
+                video-player__{{ video_player }}
+                {{ 'featured-content-module_visual' if is_flexible == false }}"
          {{ "data-id="~video_id | trim if video_id else '' }}
          data-src="{{ video_url }}"
          data-width="{{ options.video.width if options.video.width else '' }}"

--- a/cfgov/jinja2/v1/_includes/molecules/featured-content.html
+++ b/cfgov/jinja2/v1/_includes/molecules/featured-content.html
@@ -83,10 +83,8 @@
         </ul>
     </div>
     {% if value.video.url and value.video.id %}
-        <div class="featured-content-module_visual">
-            {% import 'macros/video-player.html' as video_player %}
-            {{ video_player.render(value) }}
-        </div>
+        {% import 'macros/video-player.html' as video_player %}
+        {{ video_player.render(value) }}
     {% elif value.image %}
         <div class="featured-content-module_visual">
             {% set photo = image(value.image.upload, 'original') %}


### PR DESCRIPTION
Fix so close and share buttons don't hover over the video.

## Changes

- Add the `featured-content-module_visual` class to the video player instead of around it so that the `left` attribute can be overwritten when the video is playing

## Testing

- Visit http://localhost:8000/the-bureau/

## Review

- @sebworks 
- @anselmbradford 
- @jimmynotjim 

## Screenshots

![image](https://cloud.githubusercontent.com/assets/1860176/13969476/87fc1030-f059-11e5-965b-2ad2b6c9e4ea.png)


## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)

