### PR TITLE
Adding Fix for Active Filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 
 ### Fixed
 
+ - Fixed active filter notification on Browse Filterable pages.
+
 ## 3.0.0-3.1.1 - 2016-03-21
 
 ### Added

--- a/cfgov/jinja2/v1/_includes/organisms/filterable-list-controls.html
+++ b/cfgov/jinja2/v1/_includes/organisms/filterable-list-controls.html
@@ -181,7 +181,8 @@
 
 {% macro render(controls, form, index) %}
     <div class="o-filterable-list-controls">
-        {% if request.GET %}
+        {% set has_active_filters = page.has_active_filters(request) %}
+        {% if has_active_filters %}
             {% do controls.update({'is_expanded':true}) %}
         {% endif %}
         {% set form_markup = _filters_form(controls, form, index) %}
@@ -201,7 +202,7 @@
             {% endfor %}
         {% endif %}
         {% if 'filterable-list' in controls.form_type and posts is defined %}
-            {% if not request.GET %}
+            {% if has_active_filters == false %}
                 {{ notification('success', false, posts.paginator.count ~ ' filtered results') }}
             {% elif posts.paginator.count == 0 %}
                 {{ notification('warning', true,

--- a/cfgov/v1/models/browse_filterable_page.py
+++ b/cfgov/v1/models/browse_filterable_page.py
@@ -57,7 +57,18 @@ class BrowseFilterablePage(base.CFGOVPage):
 
     def get_page_set(self, form, hostname):
         return filterable_context.get_page_set(self, form, hostname)
-     
+
+    def has_active_filters(self, request):
+        active_filters = False;
+        form_class = filterable_context.get_form_class()
+        filters = filterable_context.get_form_specific_filter_data(self, form_class, request.GET)
+        if filters:
+            for value in filters[0].itervalues():
+                if value:
+                    active_filters = True
+
+        return active_filters
+
 
 class EventArchivePage(BrowseFilterablePage):
     def get_form_class(self):


### PR DESCRIPTION
Adding a fix for determining when active the filters are active. This replaces using `request.GET` which will be populated with values during pagination.

## Additions

- Added a method to `browse_filterable_page.py` which can be called from Jinja to determine if the filters are active.

## Testing

- Visit a browse filterable page; click the next button. You shouldn't see any notification.

- Manually steps for creating a Browse Filterable Page:
 - Add a Browse Filterable Page via Wagtail
 - Add a `Filterable Control` to the page.
 - Select `Amicus Brief` for the page type under `Categories`
 - Select `Publish the page to WWW`
 - Click `Add Child Page` when mousing over the page you just created.
 - Click `Learn Page` and add some `General Content`. 
 - Click on the `Configuration` tab and add `tags`, `authors` of your choosing.
 - Select `US Supreme Court` under `Amicus Brief` 
 - Select `Publish the page to WWW` 

## Review

- @kave 
- @kurtw 
- @richaagarwal 
- @anselmbradford 

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
