### PR TITLE
Improve Wagtail page statuses to be more descriptive

### DIFF
--- a/cfgov/templates/wagtailadmin/shared/page_status_tag.html
+++ b/cfgov/templates/wagtailadmin/shared/page_status_tag.html
@@ -1,7 +1,7 @@
 {% load share %}
 
 {% if page.live %}
-    <a href="{{ page.url }}" target="_blank" class="status-tag primary">{{ page.status_string }}</a>
+    <a href="{{ page.url }}" target="_blank" class="status-tag primary">{{ page.specific.status_string }}</a>
 {% elif page.specific.shared %}
     {% get_page_state_url page as shared_url %}
     <a href="{{ shared_url }}" target="_blank" class="status-tag primary">{{ page.specific.status_string }}</a>

--- a/cfgov/v1/migrations/0057_auto_20160304_1651.py
+++ b/cfgov/v1/migrations/0057_auto_20160304_1651.py
@@ -7,8 +7,10 @@ from itertools import chain
 
 
 def save_revisions(apps, schema_editor):
-    from v1.models.learn_page import DocumentDetailPage, EventPage, LearnPage
-
+    DocumentDetailPage = apps.get_model('v1', 'DocumentDetailPage')
+    EventPage = apps.get_model('v1', 'EventPage')
+    LearnPage = apps.get_model('v1', 'LearnPage')
+    
     pages = list(chain(DocumentDetailPage.objects.all(),
                        EventPage.objects.all(),
                        LearnPage.objects.all()))

--- a/cfgov/v1/migrations/0070_cfgovpage_has_unshared_changes.py
+++ b/cfgov/v1/migrations/0070_cfgovpage_has_unshared_changes.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('v1', '0069_auto_20160318_2108'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='cfgovpage',
+            name='has_unshared_changes',
+            field=models.BooleanField(default=False),
+        ),
+    ]

--- a/cfgov/v1/models/base.py
+++ b/cfgov/v1/models/base.py
@@ -84,7 +84,7 @@ class CFGOVPage(Page):
     tags = ClusterTaggableManager(through=CFGOVTaggedPages, blank=True,
                                   related_name='tagged_pages')
     shared = models.BooleanField(default=False)
-
+    has_unshared_changes = models.BooleanField(default=False)
     language = models.CharField(choices=ref.supported_languagues, default='en', max_length=2)
 
     # This is used solely for subclassing pages we want to make at the CFPB.
@@ -181,20 +181,33 @@ class CFGOVPage(Page):
 
     @property
     def status_string(self):
-        if not self.live:
-            if self.expired:
-                return _("expired")
-            elif self.approved_schedule:
-                return _("scheduled")
-            elif self.shared:
-                return _("shared")
-            else:
-                return _("draft")
-        else:
+        if self.live and self.shared:
             if self.has_unpublished_changes:
-                return _("live + draft")
+                if self.has_unshared_changes:
+                    # Get the second to last revision to reference what the page's
+                    # state was in order to determine whether this page has shared
+                    # updates or if all the page's content was live.
+                    second_r = self.revisions.order_by('-created_at', '-id')[1]
+                    second_content = json.loads(second_r.content_json)
+                    if second_content['live'] and second_content['shared']:
+                        return _('live + draft')
+                    else:
+                        return _('live + (shared + draft)')
+                else:
+                    return _("live + shared")
             else:
                 return _("live")
+        elif self.shared:
+            if self.has_unshared_changes:
+                return _("shared + draft")
+            else:
+                return _("shared")
+        elif self.expired:
+            return _("expired")
+        elif self.approved_schedule:
+            return _("scheduled")
+        else:
+            return _("draft")
 
     def sharable_pages(self):
         """
@@ -246,7 +259,7 @@ class CFGOVPage(Page):
                     if page_version['live']:
                         return RouteResult(revision.as_page_object())
                 else:
-                    if page_version['shared']:
+                    if page_version['shared'] and not page_version['has_unshared_changes']:
                         return RouteResult(revision.as_page_object())
             raise Http404
 

--- a/cfgov/v1/wagtail_hooks.py
+++ b/cfgov/v1/wagtail_hooks.py
@@ -30,8 +30,9 @@ def share_the_page(request, page):
     # and save the page.
     if is_sharing or is_publishing:
         page.shared = True
-    else:
-        page.shared = False
+        page.has_unshared_changes = False
+    if not is_sharing and not is_publishing:
+        page.has_unshared_changes = True
     page.save()
 
     # If the page isn't being published but the page is live and the editor
@@ -42,11 +43,11 @@ def share_the_page(request, page):
     # True and we're never commiting the change. As seen in CFGOVPage's route
     # method, `route()` will select the latest revision of the page where `live`
     # is set to True and return that revision as a page object to serve the request with.
-    if not is_publishing:
-        page.live = False
     latest = page.get_latest_revision()
     content_json = json.loads(latest.content_json)
-    content_json['live'], content_json['shared'] = page.live, page.shared
+    content_json['live'] = is_publishing
+    content_json['shared'] = page.shared
+    content_json['has_unshared_changes'] = page.has_unshared_changes
     latest.content_json = json.dumps(content_json)
     latest.save()
     if is_publishing:


### PR DESCRIPTION
This is going to be a pain to review. Sorry in advance. It should make you feel a bit less worried about our shared vs live vs draft state handling. Anyway, with the addition of `sharing` pages in Wagtail, we've complicated the statuses. There are certain odd states of the pages that required more descriptive statuses so this fixes that. More in the notes.

## Additions

- `has_unshared_changes` field to CFGOVPage

## Changes

- `CFGOVPage.serve()` now checks the status of the page's `has_unshared_changes` field before serving the page.
- Our hook function `share_the_page()` sets state of `has_unshared_changes` appropriately.

## Testing

- Run `./cfgov/manage.py migrate`
- Take a page all the way down to the `DRAFT` state.
 - Check that the status is `DRAFT`
- `SHARE` it.
 - Check that the status of the page is `SHARED`
 - Check that it exists as it's supposed to.
 - Check that it doesn't exist on the live site.
- Make an edit. The hit `SAVE AS DRAFT`.
 - Check that the status of the page is `SHARED + DRAFT`
 - Check that the edit didn't show on the shared site.
 - Check that the page still doesn't exist on the live site.
- Publish the page.
 - Check that the status of the page is `LIVE`
 - Check that the page exists on both sites.
- Make edits and save a draft
 - Check that the status of the page is `LIVE + DRAFT`
 - Make sure edits don't end up on either site
- Share the page.
 - Check that the status of the page is `LIVE + SHARED`
 - Verify the edits now show on the shared site but not production.
- Save a draft.
 - Check that the status of the page is `LIVE + (SHARED + DRAFT)`
- Unpublish
 - Check that the status of the page is `SHARED + DRAFT`
 - Verify the production site page is not longer accessible.
- Unshare
 - Check that the status of the page is `DRAFT`
 - Verify the shared site page is no longer accessible

## Review

- @kave 
- @richaagarwal 
- @rosskarchner 

## Notes

**New page status reference**
1. The page is just started, it is neither SHARED nor LIVE. — DRAFT
2. The page moves from draft to share on content but is not LIVE — SHARED
3. The page is SHARED and has unshared updates — SHARED + DRAFT
4. The page is published to www (and shared on content) -- LIVE
5. The page is LIVE and has unpublished updates -- LIVE + DRAFT
6. The page is LIVE and has shared updates -- LIVE + SHARED
7. The page is LIVE and has shared updates and has unpublished updates - LIVE + (SHARED+DRAFT)

## Todos

- Document this later on before we're training folks on Wagtail

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [x] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
