### PR TITLE
Abstracted dom events for easier reuse throughout the project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,8 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 ### Added
 
 - Adds a max-selections checker to the Multiselect.
-- Remove inline CSS when running sheer_index
+- Remove inline CSS when running sheer_index.
+- Abstracted dom events for easier reuse throughout the project.
 
 ### Changed
 

--- a/cfgov/unprocessed/js/modules/util/dom-events.js
+++ b/cfgov/unprocessed/js/modules/util/dom-events.js
@@ -1,0 +1,21 @@
+'use strict';
+
+/**
+ * Shortcut for binding event listeners to elements
+ * @param  {HTMLNode} elem   The element to attach the event listener to
+ * @param  {Object}   events The list of events to attach to the element
+ */
+function bindEvent( elem, events ) {
+  var callback;
+
+  for ( var event in events ) {
+    if ( events.hasOwnProperty( event ) ) {
+      callback = events[event];
+      elem.addEventListener( event, callback );
+    }
+  }
+}
+
+module.exports = {
+  bindEvent: bindEvent
+}

--- a/cfgov/unprocessed/js/molecules/Multiselect.js
+++ b/cfgov/unprocessed/js/molecules/Multiselect.js
@@ -3,9 +3,10 @@
 // Required modules.
 var arrayHelpers = require( '../modules/util/array-helpers' );
 var typeCheckers = require( '../modules/util/type-checkers' );
-var domTraverse = require( '../modules/util/dom-traverse' );
+var queryOne = require( '../modules/util/dom-traverse' ).queryOne;
 var domCreate = require( '../modules/util/dom-manipulators' ).create;
 var strings = require( '../modules/util/strings' );
+var bindEvent = require( '../modules/util/dom-events' ).bindEvent;
 
 /**
  * Multiselect
@@ -369,7 +370,7 @@ function Multiselect( element ) { // eslint-disable-line max-statements, inline-
   function _bindEvents() {
     var inputs = _list.querySelectorAll( 'input' );
 
-    _bind( _search, {
+    bindEvent( _search, {
       input: function() {
         _evaluate( this.value );
       },
@@ -411,7 +412,7 @@ function Multiselect( element ) { // eslint-disable-line max-statements, inline-
       }
     } );
 
-    _bind( _list, {
+    bindEvent( _list, {
       mousedown: function() {
         _isBlurSkipped = true;
       },
@@ -423,7 +424,7 @@ function Multiselect( element ) { // eslint-disable-line max-statements, inline-
           event.preventDefault();
           event.target.checked = !checked;
 
-          _fire( domTraverse.queryOne( event.target ), 'change', {} );
+          queryOne( event.target ).dispatchEvent( 'change' );
         } else if ( key === KEY_ESCAPE ) {
           _search.focus();
           collapse();
@@ -435,14 +436,14 @@ function Multiselect( element ) { // eslint-disable-line max-statements, inline-
       }
     } );
 
-    _bind( _container, {
+    bindEvent( _container, {
       mousedown: function() {
         _isBlurSkipped = true;
       }
     } );
 
     for ( var i = 0, len = inputs.length; i < len; i++ ) {
-      _bind( inputs[i], {
+      bindEvent( inputs[i], {
         change: _changeHandler
       } );
     }
@@ -458,52 +459,22 @@ function Multiselect( element ) { // eslint-disable-line max-statements, inline-
   }
 
   /**
-   * Shortcut for binding event listeners to elements
-   * @param  {HTMLNode} elem The element to attach the event listener to
-   * @param  {object} options   The options for the event listener
+   * Tests if the user's query matches the text input
+   * @param   {string} text  The text to test against
+   * @param   {string} value The value the user has entered
+   * @returns {boolean}      Returns the boolean result of the test
    */
-  function _bind( elem, options ) {
-    var callback;
-    for ( var evt in options ) {
-      if ( options.hasOwnProperty( evt ) ) {
-        callback = options[evt];
-        _parseEvent( evt, elem, callback );
-      }
-    }
+  function _filterContains( text, value ) {
+    return RegExp( _regExpEscape( value.trim() ), 'i' ).test( text );
   }
 
   /**
-   * Parses the event passed byt the _bind shortcut to create the event listener
-   * @param   {string}   evt      The type of event to watch for
-   * @param   {HTMLNode} elem     The element to watch for the passed event
-   * @param   {Function} callback The function to trigger on the event
+   * Escapes a string
+   * @param   {string} s The string to escape
+   * @returns {string}   The escaped string
    */
-  function _parseEvent( evt, elem, callback ) {
-    evt.split( /\s+/ ).forEach(
-      function( event ) {
-        elem.addEventListener( event, callback );
-      }
-    );
-  }
-
-  /**
-   * Shortcut for triggering events on elements
-   * @param  {HTMLNode} target   The element to fire events on
-   * @param  {string} type       The event type to create
-   * @param  {object} properties The options for the event
-   */
-  function _fire( target, type, properties ) {
-    var evt = document.createEvent( 'HTMLEvents' );
-
-    evt.initEvent( type, true, true );
-
-    for ( var j in properties ) {
-      if ( properties.hasOwnProperty( j ) ) {
-        evt[j] = properties[j];
-      }
-    }
-
-    target.dispatchEvent( evt );
+  function _regExpEscape( s ) {
+    return s.replace( /[-\\^$*+?.()|[\]{}]/g, '\\$&' );
   }
 
   // Attach public events.

--- a/test/unit_tests/modules/util/dom-events-spec.js
+++ b/test/unit_tests/modules/util/dom-events-spec.js
@@ -1,0 +1,55 @@
+'use strict';
+var chai = require( 'chai' );
+var expect = chai.expect;
+var sinon = require( 'sinon' );
+var jsdom = require( 'mocha-jsdom' );
+var BASE_JS_PATH = '../../../../cfgov/unprocessed/js/';
+var ERROR_MESSAGES = require( BASE_JS_PATH + 'config/error-messages-config' );
+var domEvents = require( BASE_JS_PATH + 'modules/util/dom-events' );
+var input;
+var clicked;
+var message;
+
+describe( 'Dom Events bindEvent', function() {
+  jsdom();
+
+  beforeEach( function() {
+    input = document.createElement( 'input' );
+    input.type = 'checkbox';
+    input.value = 'test-bind-event';
+    clicked = false;
+  } );
+
+  it( 'should not update the var until event is triggered', function() {
+    domEvents.bindEvent( input, {
+        click: function() {
+          clicked = true;
+        }
+      } );
+      expect( clicked ).to.be.false;
+  } );
+
+  it( 'should not update the var if another event is triggered',
+    function() {
+      domEvents.bindEvent( input, {
+        click: function() {
+          clicked = true;
+        }
+      } );
+      input.focus();
+      expect( clicked ).to.be.false;
+    }
+  );
+
+  it( 'should update the var when the event is triggered',
+    function() {
+      domEvents.bindEvent( input, {
+        click: function() {
+          clicked = true;
+        }
+      } );
+      input.click();
+      expect( clicked ).to.be.true;
+    }
+  );
+} );


### PR DESCRIPTION
Abstracted dom events for easier reuse throughout the project

## Additions

- Creates public bind and fire events
- Creates private parse event helper for bind
- Adds tests for public bind events

## Testing

- `gulp test:unit:scripts`
- `gulp build` and test the Multiselect on `/blog`. It should function exactly the same

## Review

- @anselmbradford 
- @sebworks 
- @KimberlyMunoz 

## Notes

- Not a lot to gain in coverage, but it'll make testing the multiselect and anything else that uses events easier to test in the long run.

__Before__

```
=============================== Coverage summary ===============================
Statements   : 27.28% ( 731/2680 )
Branches     : 23.34% ( 204/874 )
Functions    : 20.05% ( 86/429 )
Lines        : 27.38% ( 727/2655 )
================================================================================
```

__After__

```
=============================== Coverage summary ===============================
Statements   : 27.78% ( 745/2682 )
Branches     : 23.57% ( 206/874 )
Functions    : 20.98% ( 90/429 )
Lines        : 27.89% ( 741/2657 )
================================================================================
```

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)

