### PR TITLE
Adding tests for dom-traverse functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Added Featured Menu Content Molecule.
 - Added Global Banner Molecule.
 - Added Digital Privacy Policy to the footer.
+- Added tests for dom-traverse functions
 
 ### Changed
 

--- a/cfgov/unprocessed/js/modules/util/dom-traverse.js
+++ b/cfgov/unprocessed/js/modules/util/dom-traverse.js
@@ -49,9 +49,11 @@ function getSiblings( elem, selector ) {
 function not( elems, exclude ) {
   var elemsArr = Array.prototype.slice.call( elems );
   var index = elemsArr.indexOf( exclude );
+
   if ( index > -1 ) {
-    return elemsArr.splice( index, 1 );
+    elemsArr.splice( index, 1 );
   }
+
   return elemsArr;
 }
 

--- a/test/unit_tests/modules/util/dom-traverse-spec.js
+++ b/test/unit_tests/modules/util/dom-traverse-spec.js
@@ -7,12 +7,12 @@ var expect = chai.expect;
 var jsdom = require( 'mocha-jsdom' );
 var domTraverse = require( BASE_JS_PATH + 'modules/util/dom-traverse' );
 
-describe( 'Dom Traverse queryOne', function() {
+describe( 'Dom Traverse queryOne()', function() {
   jsdom();
 
   before( function() {
     document.body.innerHTML =
-      '<div class="div-1"></div><div class="query-2"></div>';
+      '<div class="div-1"></div><div class="div-2"></div>';
   } );
 
   it( 'should return the first elem if the expr is a string', function() {
@@ -34,4 +34,90 @@ describe( 'Dom Traverse queryOne', function() {
 
     expect( query ).to.equal( null );
   } );
+} );
+
+describe( 'Dom Traverse getSiblings()', function() {
+  jsdom();
+
+  before( function() {
+    document.body.innerHTML =
+      '<div class="div-1"></div><div class="div-2"></div>';
+  } );
+
+  it( 'should return an array with a single sibling',
+    function() {
+      var elem = document.querySelector( '.div-1' );
+      var siblings = domTraverse.getSiblings( elem, 'div' );
+
+      expect( siblings.length ).to.equal( 1 );
+      expect( siblings[0].className ).to.equal( 'div-2' );
+    }
+  );
+} );
+
+describe( 'Dom Traverse not()', function() {
+  jsdom();
+
+  before( function() {
+    document.body.innerHTML =
+      '<div class="div-1"></div><div class="div-2"></div>';
+  } );
+
+  it( 'should return an array with the item that wasn’t excluded',
+    function() {
+      var items = document.querySelectorAll( 'div' );
+      var exclude = document.querySelector( '.div-2' );
+
+      items = domTraverse.not( items, exclude );
+
+      expect( items.length ).to.equal( 1 );
+      expect( items[0].className ).to.equal( 'div-1' );
+    }
+  );
+} );
+
+describe( 'Dom Traverse closest()', function() {
+  jsdom();
+
+  before( function() {
+    document.body.innerHTML =
+      '<div class="grandparent"><div class="parent"><div class="child">' +
+      '</div></div></div>';
+  } );
+
+  it( 'should return the immediate parent HTMLNode with a passed selector',
+    function() {
+      var child = document.querySelector( '.child' );
+      var parent = domTraverse.closest( child, 'div' );
+
+      expect( parent.className ).to.equal( 'parent' );
+    }
+  );
+
+  it( 'should return the grandparent HTMLNode with a passed selector',
+    function() {
+      var child = document.querySelector( '.child' );
+      var parent = domTraverse.closest( child, '.grandparent' );
+
+      expect( parent.className ).to.equal( 'grandparent' );
+    }
+  );
+
+  it( 'should return null without a passed selector',
+    function() {
+      var child = document.querySelector( '.child' );
+      var parent = domTraverse.closest( child );
+
+      expect( parent ).to.equal( null );
+    }
+  );
+
+  it( 'should return the parent HTMLNode even if the selector wasn’t found',
+    function() {
+      var child = document.querySelector( '.child' );
+      var parent = domTraverse.closest( child, 'greatgrandparent' );
+
+      expect( parent ).to.equal( null );
+    }
+  );
 } );


### PR DESCRIPTION
Adding tests for dom-traverse functions

## Additions

- Added tests for all the functions

## Testing

- `gulp test:unit:scripts`

## Review

- @anselmbradford 
- @sebworks 
- @KimberlyMunoz 

## Notes

- `not()` is failing unexpectedly. This needs a second set of eyes to see what I'm missing.

__Before__

```
=============================== Coverage summary ===============================
Statements   : 27.17% ( 724/2665 )
Branches     : 22.92% ( 198/864 )
Functions    : 20.14% ( 86/427 )
Lines        : 27.33% ( 722/2642 )
================================================================================
```

__After__

```
=============================== Coverage summary ===============================
Statements   : 27.88% ( 743/2665 )
Branches     : 23.96% ( 207/864 )
Functions    : 20.61% ( 88/427 )
Lines        : 28.01% ( 740/2642 )
================================================================================
```

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
