### PR TITLE
Page specific js

### DIFF
--- a/cfgov/unprocessed/js/routes/on-demand/secondary-navigation.js
+++ b/cfgov/unprocessed/js/routes/on-demand/secondary-navigation.js
@@ -1,0 +1,9 @@
+/* ==========================================================================
+   Scripts for Secondary Navigation Organism
+   ========================================================================== */
+
+'use strict';
+
+// List of organisms used.
+var SecondaryNavigation = require( '../../organisms/SecondaryNavigation' );
+var secondaryNavigation = new SecondaryNavigation( document.querySelector( '.content_sidebar .o-secondary-navigation' ) ).init();

--- a/cfgov/v1/models/base.py
+++ b/cfgov/v1/models/base.py
@@ -1,7 +1,6 @@
 import os
 from itertools import chain
 import json
-from sets import Set
 
 from django.db import models
 from django.db.models import Q
@@ -267,7 +266,7 @@ class CFGOVPage(Page):
 
     # To be overriden if page type requires JS files every time
     def get_page_js(self):
-        return ()
+        return []
 
     # Retrieves the stream values on a page from it's Streamfield
     def _get_streamfield_blocks(self):
@@ -279,7 +278,7 @@ class CFGOVPage(Page):
     def _get_block_js(self):
         from v1 import models
 
-        js = ()
+        js = []
 
         for child in self._get_streamfield_blocks():
             class_ = type(child.block)
@@ -294,12 +293,12 @@ class CFGOVPage(Page):
             except:
                 pass
 
-        return Set(js)
+        return set(js)
 
     # Returns all the JS files specific to this page and it's current Streamfield's blocks
     @property
     def media(self):
-        return Set(chain(self.get_page_js(), self._get_block_js()))
+        return set(chain(self.get_page_js(), self._get_block_js()))
 
 
 class CFGOVPageCategory(Orderable):

--- a/cfgov/v1/models/base.py
+++ b/cfgov/v1/models/base.py
@@ -265,17 +265,26 @@ class CFGOVPage(Page):
         parent = self.get_ancestors(inclusive=False).reverse()[0].specific
         return parent
 
-    def elements(self):
+    # To be overriden if page type requires JS files every time
+    def get_page_js(self):
+        return ()
+
+    # Retrieves the stream values on a page from it's Streamfield
+    def _get_streamfield_blocks(self):
         lst = [value for key, value in vars(self).iteritems()
                if type(value) is StreamValue]
         return list(chain(*lst))
 
-    def _media(self):
+    # Gets the JS from the Streamfield data
+    def _get_block_js(self):
         from v1 import models
 
         js = ()
 
-        for child in self.elements():
+        for child in self._get_streamfield_blocks():
+            class_ = type(child.block)
+            instance = class_()
+
             try:
                 class_ = type(child.block)
                 instance = class_()
@@ -287,7 +296,10 @@ class CFGOVPage(Page):
 
         return Set(js)
 
-    media = property(_media)
+    # Returns all the JS files specific to this page and it's current Streamfield's blocks
+    @property
+    def media(self):
+        return Set(chain(self.get_page_js(), self._get_block_js()))
 
 
 class CFGOVPageCategory(Orderable):

--- a/cfgov/v1/models/browse_filterable_page.py
+++ b/cfgov/v1/models/browse_filterable_page.py
@@ -47,6 +47,9 @@ class BrowseFilterablePage(base.CFGOVPage):
 
     template = 'browse-filterable/index.html'
 
+    def get_page_js(self):
+        return ('SecondaryNavigation.js',)
+
     def get_context(self, request, *args, **kwargs):
         context = super(BrowseFilterablePage, self).get_context(request, *args, **kwargs)
         return filterable_context.get_context(self, request, context)

--- a/cfgov/v1/models/browse_filterable_page.py
+++ b/cfgov/v1/models/browse_filterable_page.py
@@ -48,7 +48,7 @@ class BrowseFilterablePage(base.CFGOVPage):
     template = 'browse-filterable/index.html'
 
     def get_page_js(self):
-        return ('SecondaryNavigation.js',)
+        return super(BrowseFilterablePage, self).get_page_js() + ['secondary-navigation.js']
 
     def get_context(self, request, *args, **kwargs):
         context = super(BrowseFilterablePage, self).get_context(request, *args, **kwargs)

--- a/cfgov/v1/models/browse_page.py
+++ b/cfgov/v1/models/browse_page.py
@@ -52,6 +52,9 @@ class BrowsePage(CFGOVPage):
 
     template = 'browse-basic/index.html'
 
+    def get_page_js(self):
+        return ('SecondaryNavigation.js',)
+
     def full_width_serif(self):
         return true
 

--- a/cfgov/v1/models/browse_page.py
+++ b/cfgov/v1/models/browse_page.py
@@ -53,7 +53,7 @@ class BrowsePage(CFGOVPage):
     template = 'browse-basic/index.html'
 
     def get_page_js(self):
-        return ('SecondaryNavigation.js',)
+        return super(BrowsePage, self).get_page_js() + ['secondary-navigation.js']
 
     def full_width_serif(self):
         return true


### PR DESCRIPTION
This adds the ability for us to instantiate page type specific js scripts just by overriding the `get_page_js()` method.

## Additions

- `get_page_js()` method
- `secondary-nagivation.js` script to Browse/BrowseFilterablePage types

## Removals

- `from sets import Set` because it's deprecated and replaced with the built-in `set/frozenset` type

## Changes

- js file names are returned and stored in memory as lists instead of tuples because the intention of this is to update the names of files at will and tuples are supposedly immutable.

## Testing

- `gulp build`
- Go to [`localhost:8000/about-us/events/`](localhost:8000/about-us/events/) and shrink window to tablet/mobile site. You should see the :heavy_plus_sign: button on the navigation and it should drop down a list of the sidenav.
- same goes for [`localhost:8000/plain-writing/`](localhost:8000/plain-writing/)

## Review

- @richaagarwal 
- @kave 
- @anselmbradford 

## Screenshots
![screen shot 2016-03-24 at 11 17 40 am](https://cloud.githubusercontent.com/assets/1412978/14021485/17d5f690-f1b2-11e5-9b8d-627cb05f2eb6.png)
![screen shot 2016-03-24 at 11 17 50 am](https://cloud.githubusercontent.com/assets/1412978/14021486/18ddd4d6-f1b2-11e5-950a-0f3e3be93b00.png)

## TODO

- Create tests for new on-demand file

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [x] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)