### PR TITLE
Fix printing of error for sidebar-contact-info.html

### DIFF
--- a/cfgov/jinja2/v1/_includes/organisms/sidebar-contact-info.html
+++ b/cfgov/jinja2/v1/_includes/organisms/sidebar-contact-info.html
@@ -54,18 +54,10 @@
     </div>
 
     <div class="o-sidebar-contact-info_column">
-        {% set blockLookup = {
-          email: '',
-          phone: '',
-          address: '',
-        } %}
         {% if value.contact.contact_info %}
             {% for block in value.contact.contact_info %}
-                {% do blockLookup.update({ block.block_type: block } ) %}
+                {{ render_stream_child(block) }}
             {% endfor %}
-            {{ blockLookup.email }}
-            {{ blockLookup.phone }}
-            {{ blockLookup.address }}
         {% endif %}
     </div>
 </div>


### PR DESCRIPTION
I noticed that there was an error printing out on the contact info section of a sidebar/footer.

@richaagarwal 
@sebworks 