### PR TITLE
Fix for Expandables on Blog

### DIFF
--- a/cfgov/unprocessed/js/routes/sheer.js
+++ b/cfgov/unprocessed/js/routes/sheer.js
@@ -17,3 +17,12 @@ if ( filterableListDom ) {
     filterableListControls.init();
   }
 }
+
+var expandableDom = document.querySelectorAll( '.content_main .m-expandable' );
+var expandable;
+if ( expandableDom ) {
+  for ( var i = 0, len = expandableDom.length; i < len; i++ ) {
+    expandable = new Expandable( expandableDom[i] );
+    expandable.init();
+  }
+}


### PR DESCRIPTION
Fixes issue with initializing the atomic Expandable on the Blog

## Changes

- Adds code to scope the initializing of the Expandable


## Review

- @anselmbradford 
- @jimmynotjim 
- @KimberlyMunoz 


## Testing

- Run `bulp build` and visit the `/blog`. Click on the filter; it should expand.

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)

