### PR TITLE
Fix: handle SecurityError around window.sessionStorage

### DIFF
--- a/test/unit_tests/modules/util/web-storage-proxy-spec.js
+++ b/test/unit_tests/modules/util/web-storage-proxy-spec.js
@@ -56,7 +56,7 @@ describe( 'web-storage-proxy', function() {
     sandbox.restore();
   } );
 
-  describe( 'setItem', function() {
+  describe( '.setItem()', function() {
     it( 'should set an item of "bar" for the key "foo" in sessionStorage',
       function() {
         setItem( 'foo', 'bar', window.sessionStorage );
@@ -99,7 +99,7 @@ describe( 'web-storage-proxy', function() {
   } );
 
 
-  describe( 'getItem', function() {
+  describe( '.getItem()', function() {
     beforeEach( function() {
       window.sessionStorage.setItem( 'foo', 'bar' );
       window.localStorage.setItem( 'foo', 'baz' );
@@ -141,7 +141,7 @@ describe( 'web-storage-proxy', function() {
     );
   } );
 
-  describe( 'removeItem', function() {
+  describe( '.removeItem()', function() {
     beforeEach( function() {
       window.sessionStorage.setItem( 'foo', 'bar' );
       window.localStorage.setItem( 'foo', 'baz' );
@@ -191,7 +191,7 @@ describe( 'web-storage-proxy', function() {
     );
   } );
 
-  describe( 'setStorage', function() {
+  describe( '.setStorage()', function() {
     beforeEach( function() {
       setStorage( window.localStorage );
     } );
@@ -259,6 +259,13 @@ describe( 'web-storage-proxy', function() {
         expect( storageError, Error ).to.throw( Error );
       }
     );
-  } );
 
+    xit( 'should set storage to an object if sessionStorage throws an error',
+      function() {
+        // TODO: If cookies are disabled, window.sessionStorage
+        //       will throw a SecurityError and the internal storage will be
+        //       an object literal.
+      }
+    );
+  } );
 } );


### PR DESCRIPTION
## Changes

- Updates web-storage-proxy to fallback to an object literal for storage if cookies aren't available.

## Testing

- Go to Preferences > Show Advanced Settings > Privacy > Content settings... > Cookies and disable them:
![screen shot 2016-03-24 at 9 32 17 pm](https://cloud.githubusercontent.com/assets/704760/14035757/389ae9a2-f208-11e5-86a7-f3e5b638ce23.png)
- Go to beta.consumerfinance.gov and open the console. Note SecurityError with web storage and beta banner does not work.
- Go to this PR and open localhost.
- Note that beta banner works, but on reload does not remember its state.

## Review

- @sebworks 
- @KimberlyMunoz 
- @jimmynotjim 
