### PR TITLE
Abstracted the string utils from the Multiselect for easier reuse and testing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Updated the home hero to it’s own molecule.
 - Updated the layout for the level 1 menu items to distribute them more evenly
   across the header.
+- Abstracted the string utils from the Multiselect.
 
 ### Removed
 

--- a/cfgov/unprocessed/js/modules/util/strings.js
+++ b/cfgov/unprocessed/js/modules/util/strings.js
@@ -1,0 +1,26 @@
+'use strict';
+
+
+/**
+ * Escapes a string
+ * @param   {string} s The string to escape
+ * @returns {string}   The escaped string
+ */
+function stringEscape( s ) {
+  return s.replace( /[-\\^$*+?.()|[\]{}]/g, '\\$&' );
+}
+
+/**
+ * Tests whether a string matches another
+ * @param   {string}  x  The control string
+ * @param   {string}  y  The comparison string
+ * @returns {boolean}    Returns the boolean result of the test
+ */
+function stringMatch( x, y ) {
+  return RegExp( stringEscape( y.trim() ), 'i' ).test( x );
+}
+
+module.exports = {
+  stringEscape: stringEscape,
+  stringMatch: stringMatch
+}

--- a/cfgov/unprocessed/js/molecules/Multiselect.js
+++ b/cfgov/unprocessed/js/molecules/Multiselect.js
@@ -5,6 +5,7 @@ var arrayHelpers = require( '../modules/util/array-helpers' );
 var typeCheckers = require( '../modules/util/type-checkers' );
 var domTraverse = require( '../modules/util/dom-traverse' );
 var domCreate = require( '../modules/util/dom-manipulators' ).create;
+var stringMatch = require( '../modules/util/strings' ).stringMatch;
 
 /**
  * Multiselect
@@ -292,7 +293,7 @@ function Multiselect( element ) { // eslint-disable-line max-statements, inline-
       _index = -1;
 
       _filtered = _optionData.filter( function( item ) {
-        return _filterContains( item.text, value );
+        return stringMatch( item.text, value );
       } );
 
       _filterResults();
@@ -441,16 +442,6 @@ function Multiselect( element ) { // eslint-disable-line max-statements, inline-
   }
 
   /**
-   * Tests if the user's query matches the text input
-   * @param   {string} text  The text to test against
-   * @param   {string} value The value the user has entered
-   * @returns {boolean}      Returns the boolean result of the test
-   */
-  function _filterContains( text, value ) {
-    return RegExp( _regExpEscape( value.trim() ), 'i' ).test( text );
-  }
-
-  /**
    * Shortcut for binding event listeners to elements
    * @param  {HTMLNode} elem The element to attach the event listener to
    * @param  {object} options   The options for the event listener
@@ -497,15 +488,6 @@ function Multiselect( element ) { // eslint-disable-line max-statements, inline-
     }
 
     target.dispatchEvent( evt );
-  }
-
-  /**
-   * Escapes a string
-   * @param   {string} s The string to escape
-   * @returns {string}   The escaped string
-   */
-  function _regExpEscape( s ) {
-    return s.replace( /[-\\^$*+?.()|[\]{}]/g, '\\$&' );
   }
 
   // Attach public events.

--- a/test/unit_tests/modules/util/strings-spec.js
+++ b/test/unit_tests/modules/util/strings-spec.js
@@ -1,0 +1,60 @@
+'use strict';
+var chai = require( 'chai' );
+var expect = chai.expect;
+var BASE_JS_PATH = '../../../../cfgov/unprocessed/js/';
+var ERROR_MESSAGES = require( BASE_JS_PATH + 'config/error-messages-config' );
+var strings = require( BASE_JS_PATH + 'modules/util/strings' );
+var string;
+var control;
+
+describe( 'Strings stringEscape()', function() {
+
+  it( 'should escape a url', function() {
+    string = 'http://google.com';
+
+    expect( strings.stringEscape( string ) )
+      .to.equal( 'http://google\\.com' );
+  } );
+
+  it( 'should escape a hyphenated name', function() {
+    string = 'Miller-Webster';
+
+    expect( strings.stringEscape( string ) )
+      .to.equal( 'Miller\\-Webster' );
+  } );
+
+  it( 'should escape a comma', function() {
+    string = 'Students, Parents, and Teachers';
+
+    expect( strings.stringEscape( string ) )
+      .to.equal( 'Students\, Parents\, and Teachers' );
+  } );
+} );
+
+describe( 'Strings stringMatch()', function() {
+  it( 'should return true when testing matching strings', function() {
+    string = 'Test String';
+    control = 'Test String';
+
+    expect( strings.stringMatch( control, string ) )
+      .to.be.true;
+  } );
+
+  it( 'should return true when testing matching strings with differing casing',
+    function() {
+      string = 'test string';
+      control = 'Test String';
+
+      expect( strings.stringMatch( control, string ) )
+        .to.be.true;
+    }
+  );
+
+  it( 'should return false when testing differing strings', function() {
+    string = 'Test String';
+    control = 'Result String';
+
+    expect( strings.stringMatch( control, string ) )
+      .to.be.false;
+  } );
+} );


### PR DESCRIPTION
Abstracted the string utils from the Multiselect for easier reuse and testing

## Changes

- Renamed _regExpEscape to stringEscape and added tests
- Renamed _filterContains to stringMatch and added tests

## Testing

- `gulp test:unit:scripts`
- `gulp build` and navigate to `/blog` and use the filters (~~the expandable is broken, @sebworks is working on a fix, you'll need to inspect and force it open~~ it's fixed)

## Review

- @anselmbradford 
- @sebworks 
- @KimberlyMunoz 

## Notes

__Before__

```
=============================== Coverage summary ===============================
Statements   : 29.04% ( 778/2679 )
Branches     : 24.25% ( 210/866 )
Functions    : 22.43% ( 96/428 )
Lines        : 29.19% ( 775/2655 )
================================================================================
```

__After__

```
=============================== Coverage summary ===============================
Statements   : 29.13% ( 781/2681 )
Branches     : 24.25% ( 210/866 )
Functions    : 22.9% ( 98/428 )
Lines        : 29.28% ( 778/2657 )
================================================================================
```

`/utils` are now at 79% coverage, this is huge for us!

<img width="1259" alt="screen shot 2016-03-25 at 9 50 23 am" src="https://cloud.githubusercontent.com/assets/1280430/14046362/087a8932-f26f-11e5-99e1-2a89280f732b.png">

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)