### PR TITLE
Re-enables consumer tools and ed resources

### DIFF
--- a/cfgov/jinja2/v1/_includes/organisms/_vars-mega-menu.html
+++ b/cfgov/jinja2/v1/_includes/organisms/_vars-mega-menu.html
@@ -53,34 +53,34 @@
 
 {% set nav_items = [(
     ('Consumer Tools', '#', [(
-        ('Submit a Complaint', '', []),
-        ('Ask CFPB', '', []),
-        ('Tell Your Story', '', []),
-        ('Information for Students', '', []),
-        ('Information for Older Americans', '', []),
-        ('Information for Servicemembers', '', [])
+        ('Submit a Complaint', '/complaint/', []),
+        ('Ask CFPB', '/askcfpb/', []),
+        ('Tell Your Story', '/your-story/', []),
+        ('Information for Students', '/students/', []),
+        ('Information for Older Americans', '/older-americans/', []),
+        ('Information for Servicemembers', '/servicemembers/', [])
     ),(
-        ('Paying for College', '', []),
-        ('Owning a Home', '', []),
-        ('Planning for Retirement', '', []),
-        ('Sending Money Abroad', '', [])
+        ('Paying for College', '/paying-for-college/', []),
+        ('Owning a Home', '/owning-a-home/', []),
+        ('Planning for Retirement', '/retirement/', []),
+        ('Sending Money Abroad', '/sending-money/', [])
     ),(
-        ('Know Before You Owe Mortgages', '', []),
-        ('Trouble Paying Your Mortgage?', '', []),
-        ('Protections Against Discrimination', '', [])
+        ('Know Before You Owe Mortgages', '/know-before-you-owe/', []),
+        ('Trouble Paying Your Mortgage?', '/mortgagehelp/', []),
+        ('Protections Against Discrimination', '/fair-lending/', [])
     )]),
     ('Educational Resources', '#', [(
-        ('Your Money, Your Goals', '', []),
-        ('Adult Financial Education', '', []),
-        ('Youth Financial Education', '', [])
+        ('Your Money, Your Goals', '/your-money-your-goals/', []),
+        ('Adult Financial Education', '/adult-financial-education/', []),
+        ('Youth Financial Education', '/youth-financial-education/', [])
     ),(
-        ('Resources for Libraries', '', []),
-        ('Resources for Tax Preparers', '', []),
-        ('Resources for Parents', '', [])
+        ('Resources for Libraries', '/library-resources/', []),
+        ('Resources for Tax Preparers', '/tax-preparer-resources/', []),
+        ('Resources for Parents', '/money-as-you-grow/', [])
     ),(
-        ('Information for Economically Vulnerable Consumers', '', []),
-        ('Managing Someone Else’s Money', '', []),
-        ('Free Brochures', '', [])
+        ('Information for Economically Vulnerable Consumers', '/empowerment/', []),
+        ('Managing Someone Else’s Money', '/managing-someone-elses-money/', []),
+        ('Free Brochures', 'http://promotions.usa.gov/cfpbpubs.html', [])
     )]),
     ('Data & Research', '/data-research/', [(
         ('Research & Reports', '/data-research/research-reports/', []),

--- a/cfgov/jinja2/v1/_includes/organisms/mega-menu.html
+++ b/cfgov/jinja2/v1/_includes/organisms/mega-menu.html
@@ -121,10 +121,11 @@
                     {# TODO: Remove the check for '#' when real overview pages
                              are added for the Consumer Resources and Education
                              pages. #}
-                    {% if nav_overview_url and nav_overview_url != '#' %}
-                    <a class="{{ _classes( nav_depth, '-overview-link' ) }}
+                    {% if nav_overview_url %}
+                    <a class="{{ 'u-link__disabled' if nav_overview_url == '#' else '' }}
+                              {{ _classes( nav_depth, '-overview-link' ) }}
                               {{ _classes( nav_depth, '-overview-link__current' ) if nav_overview_url == request.path else '' }}"
-                       {{ '' if nav_overview_url == request.path else 'href=' + nav_overview_url | e }}>
+                       {{ '' if nav_overview_url == request.path or nav_overview_url == '#' else 'href=' + nav_overview_url | e }}>
                         {{ nav_overview }}
                     </a>
                     {% endif %}

--- a/cfgov/unprocessed/css/organisms/mega-menu.less
+++ b/cfgov/unprocessed/css/organisms/mega-menu.less
@@ -508,6 +508,16 @@
                 margin-bottom: unit( @grid_gutter-width / 2 / 18px, em );
 
                 font-size: 1em;
+
+                // ------------------------------------------------------------
+                // TODO: Remove when Consumer Tools and Education Resources
+                //       have overview pages post-launch.
+                //       This is temporary code to hide the overview links
+                //       at desktop sizes.
+                .u-link__disabled {
+                    visibility: hidden;
+                }
+                // ------------------------------------------------------------
             }
 
             &-lists {


### PR DESCRIPTION
## Changes

- Re-enables Consumer Tools and Education Resources links in the mega menu.
- Temporarily hides the overview links at desktop sizes for those two sections. (**Note:** they are still there—but disabled—at mobile.)

## Testing

- `gulp build` and check the first two menu items.

## Review

- @jimmynotjim 
- @KimberlyMunoz 
- @sebworks 
- @schaferjh (please double-check link URLs in _vars-mega-menu.html below)

## Screenshots

<img width="982" alt="screen shot 2016-03-25 at 10 52 07 am" src="https://cloud.githubusercontent.com/assets/704760/14046473/2a7a942e-f278-11e5-8b37-0608e9750406.png">

<img width="530" alt="screen shot 2016-03-25 at 10 52 49 am" src="https://cloud.githubusercontent.com/assets/704760/14046471/2a78455c-f278-11e5-857d-349608884bc1.png">

<img width="532" alt="screen shot 2016-03-25 at 10 52 56 am" src="https://cloud.githubusercontent.com/assets/704760/14046472/2a78888c-f278-11e5-8ccb-ee74a479271b.png">

<img width="870" alt="screen shot 2016-03-25 at 10 52 20 am" src="https://cloud.githubusercontent.com/assets/704760/14046474/2a7cbcd6-f278-11e5-9301-071f9ab10a83.png">


## Todos

- The disabling link feature for the overview links needs to be updated because the fallback menu still only has a `#` URL for the top-level links that have disabled overview pages.