### PR TITLE
`has_active_filters` needs to be accessible from all filterable type …

### DIFF
--- a/cfgov/jinja2/v1/_includes/organisms/filterable-list-controls.html
+++ b/cfgov/jinja2/v1/_includes/organisms/filterable-list-controls.html
@@ -181,7 +181,7 @@
 
 {% macro render(controls, form, index) %}
     <div class="o-filterable-list-controls">
-        {% set has_active_filters = page.has_active_filters(request) %}
+        {% set has_active_filters = has_active_filters(page, request, index) %}
         {% if has_active_filters %}
             {% do controls.update({'is_expanded':true}) %}
         {% endif %}

--- a/cfgov/v1/models/browse_filterable_page.py
+++ b/cfgov/v1/models/browse_filterable_page.py
@@ -58,17 +58,6 @@ class BrowseFilterablePage(base.CFGOVPage):
     def get_page_set(self, form, hostname):
         return filterable_context.get_page_set(self, form, hostname)
 
-    def has_active_filters(self, request):
-        active_filters = False;
-        form_class = filterable_context.get_form_class()
-        filters = filterable_context.get_form_specific_filter_data(self, form_class, request.GET)
-        if filters:
-            for value in filters[0].itervalues():
-                if value:
-                    active_filters = True
-
-        return active_filters
-
 
 class EventArchivePage(BrowseFilterablePage):
     def get_form_class(self):

--- a/cfgov/v1/util/filterable_context.py
+++ b/cfgov/v1/util/filterable_context.py
@@ -8,6 +8,7 @@ from ..models.learn_page import AbstractFilterPage
 
 def get_context(page, request, context):
     context.update({'get_secondary_nav_items': get_secondary_nav_items})
+    context.update({'has_active_filters': has_active_filters})
 
     context['forms'] = []
     form_class = get_form_class()
@@ -90,3 +91,16 @@ def get_page_set(page, form, hostname):
 
     filter_pages.sort(key=lambda x: x.date_published, reverse=True)
     return filter_pages
+
+
+def has_active_filters(page, request, index):
+    active_filters = False;
+    form_class = get_form_class()
+    forms_data = get_form_specific_filter_data(page, form_class, request.GET)
+    if forms_data:
+        for filters in forms_data[index].values():
+            for value in filters:
+                if value:
+                    active_filters = True
+
+    return active_filters


### PR DESCRIPTION
SublandingFilterablePage's are breaking because `has_active_filters` needs to be accessible from all filterable type pages so it's moved into the fitlerable_context.py in the utils module in v1 to accomplish that.

## Changes

- moved `has_active_filters` to a larger scope

## Testing

- go to a sublanding and browse fitlerable page and test out the filter controls, making sure that the notifications show up appropriately.

## Review

- @richaagarwal 
- @sebworks 
