### PR TITLE
Fix ordering of related posts to be date descending

### DIFF
--- a/cfgov/sheerlike/query.py
+++ b/cfgov/sheerlike/query.py
@@ -237,7 +237,8 @@ class Query(object):
     def get_tag_related_documents(self, tags, size=0):
         query_file = json.loads(file(self.filename).read())
         doc_type = query_file['query']['doc_type']
-        query_dict = {'query': {'bool': {'should': []}}}
+        query_dict = {'sort': [{'date': {'order': 'desc'}}],
+                      'query': {'bool': {'should': []}}}
         if size:
             query_dict['size'] = size
         for tag in tags:


### PR DESCRIPTION
The data retrieved from elasticsearch was not ordered by date so this fixes that by making the most recent related post first.

## Additions

- Add `sort` list to the `Query.get_tag_related_documents` in sheerlike

## Testing

- go to http://beta.consumerfinance.gov/about-us/operations/ and not that the orderiing is wonky
- go to http://content.localhost:8000/about-us/operations/ and note the ordering is date desc

## Review

- @richaagarwal 
- @rosskarchner 

## Screenshots
![screen shot 2016-03-25 at 12 02 13 pm](https://cloud.githubusercontent.com/assets/1412978/14047952/7357007a-f281-11e5-9865-7d7a6e6c74ae.png)