### PR TITLE
Set a max-width for full-text molecules

### DIFF
--- a/cfgov/unprocessed/css/molecules/full-width-text.less
+++ b/cfgov/unprocessed/css/molecules/full-width-text.less
@@ -35,6 +35,9 @@
 */
 
 .m-full-width-text {
+    // This makes for line lengths between 85-95 characters
+    max-width: 41.8em;
+
     &__serif {
       font-family: Georgia, 'Times New Roman', serif;
     }


### PR DESCRIPTION
## Changes

- Set a max-width for full-text molecules

## Testing

-  Visit `/privacy/digital-privacy-policy/` if you have the DB or just create a page with a full-width-text blob.

## Review

- @anselmbradford 
- @sebworks 
- @jimmynotjim 

## Screenshots

![image](https://cloud.githubusercontent.com/assets/1860176/14049981/1dc31cda-f28f-11e5-9e2d-59fe8ffed140.png)

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
