### PR TITLE
Fix extra scroll bar on IE

### DIFF
--- a/cfgov/unprocessed/css/atoms/multi-select.less
+++ b/cfgov/unprocessed/css/atoms/multi-select.less
@@ -26,7 +26,7 @@
 
         // Styles
         box-sizing: border-box;
-        overflow: scroll;
+        overflow-y: scroll;
         position: absolute;
         z-index: 10;
 


### PR DESCRIPTION
Fixes the extra scrollbar on the x-axis with a CSS fix.

## Testing

- Visit localhost/blog on IE either with a VM or Sauce Labs

## Review

- @jimmynotjim 
- @sebworks 
- @anselmbradford 

## Screenshots

![image](https://cloud.githubusercontent.com/assets/1860176/14051868/54d41d3e-f29c-11e5-84fb-b2add5996588.png)


## Notes

- The `blur` binding on IE is way more aggressive than it is on Chrome. When you grab the scrollbar to scroll, it runs the `collapse()` method. This doesn't affect people who use a scrollmouse or keyboard. I'll play with it some more, but does anyone have any ideas.
