### PR TITLE
Removed Georgia usage for the time being

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 
 ### Removed
 
+- Removed Georgia usage for the time being.
+
 ### Fixed
 
  - Fixed active filter notification on Browse Filterable pages.

--- a/cfgov/jinja2/v1/_includes/organisms/full-width-text.html
+++ b/cfgov/jinja2/v1/_includes/organisms/full-width-text.html
@@ -15,15 +15,11 @@
 <div class="o-full-width-text-group">
     {% for block in value %}
         {% if 'content' in block.block_type %}
-            <div class="m-full-width-text
-                        {{ 'm-full-width-text__serif' if
-                         page.full_width_serif else '' }}">
+            <div class="m-full-width-text">
                 {{ parse_links(block.value) | safe }}
             </div>
         {% elif 'table' in block.block_type %}
-            <div class="m-full-width-text
-                        {{ 'm-full-width-text__serif' if
-                        page.full_width_serif else '' }}">
+            <div class="m-full-width-text">
                 {{ render_stream_child(block) | safe}}
             </div>
         {% else %}


### PR DESCRIPTION
Removed Georgia usage for the time being

## Removals

- Removed Georgia modifier from the full-width-text molecule macro.

## Testing

- `gulp build` and navigate to `/plain-writing/plain-writing-act/`. It should not be Georgia.

## Review

- @schaferjh 
- @ajbush 
- @duelj 
- @KimberlyMunoz 
- @anselmbradford 
- @sebworks 

## Screenshots

![screen shot 2016-03-25 at 3 01 19 pm](https://cloud.githubusercontent.com/assets/1280430/14052744/7349863e-f29a-11e5-84cf-ddeafe87b424.png)

## Notes

- AJ and Justin will re-evaluate Georgia usage on the web after launch.

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)

