### PR TITLE
On demand JS files should be served in order of largest to smallest s…

### DIFF
--- a/cfgov/jinja2/v1/_layouts/base.html
+++ b/cfgov/jinja2/v1/_layouts/base.html
@@ -186,8 +186,10 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     {# TODO: Remove Else conditional when this is fully moved to wagtail. #}
     {# Check and include page-level JavaScript. #}
     {% if page and page.media %}
-        {% for js in page.media %}
-            {% include '/js/routes/on-demand/' + js ignore missing %}
+        {% for type, jsfiles in page.media.iteritems() %}
+            {% for js in jsfiles %}
+                {% include '/js/routes/on-demand/' + js ignore missing %}
+            {% endfor %}
         {% endfor %}
     {% else %}
         {% include '/js/routes/' + request.path[1:] + 'index.js' ignore missing %}

--- a/cfgov/v1/models/browse_filterable_page.py
+++ b/cfgov/v1/models/browse_filterable_page.py
@@ -47,13 +47,13 @@ class BrowseFilterablePage(base.CFGOVPage):
 
     template = 'browse-filterable/index.html'
 
-    def get_page_js(self):
-        return super(BrowseFilterablePage, self).get_page_js() + ['secondary-navigation.js']
+    def add_page_js(self, js):
+        super(BrowseFilterablePage, self).add_page_js(js)
+        js['template'] += ['secondary-navigation.js']
 
     def get_context(self, request, *args, **kwargs):
         context = super(BrowseFilterablePage, self).get_context(request, *args, **kwargs)
         return filterable_context.get_context(self, request, context)
-
 
     def get_form_class(self):
         return filterable_context.get_form_class()

--- a/cfgov/v1/models/browse_page.py
+++ b/cfgov/v1/models/browse_page.py
@@ -52,8 +52,9 @@ class BrowsePage(CFGOVPage):
 
     template = 'browse-basic/index.html'
 
-    def get_page_js(self):
-        return super(BrowsePage, self).get_page_js() + ['secondary-navigation.js']
+    def add_page_js(self, js):
+        super(BrowsePage, self).add_page_js(js)
+        js['template'] += ['secondary-navigation.js']
 
     def full_width_serif(self):
         return true

--- a/cfgov/v1/models/molecules.py
+++ b/cfgov/v1/models/molecules.py
@@ -225,7 +225,7 @@ class BaseExpandable(blocks.StructBlock):
         label = 'Expandable'
 
     class Media:
-        js = ("expandable.js",)
+        js = ["expandable.js"]
 
 
 class Expandable(BaseExpandable):

--- a/cfgov/v1/models/organisms.py
+++ b/cfgov/v1/models/organisms.py
@@ -155,7 +155,7 @@ class ExpandableGroup(blocks.StructBlock):
         template = '_includes/organisms/expandable-group.html'
 
     class Media:
-        js = ("expandable-group.js",)
+        js = ["expandable-group.js"]
 
 
 class ItemIntroduction(blocks.StructBlock):
@@ -198,4 +198,4 @@ class FilterControls(molecules.BaseExpandable):
         icon = 'form'
 
     class Media:
-        js = ('notification.js', 'expandable.js', 'filterable-list-controls.js',)
+        js = ['notification.js', 'expandable.js', 'filterable-list-controls.js']


### PR DESCRIPTION
Each of the JS files are included in the order of `template`, `organism`, `molecule`, `atom`.

## Changes

- The structure containing the names of the scripts to be run is now an ordered dictionary with previously stated order.

## Testing

- Go to a Browse or BrowseFilterable Page on the site. 
- Inspect the page and scroll down to the bottom of the document to find the loaded scripts. The `template` scripts should have been loaded first, followed by any organism scripts, and so on.

## Review

- @anselmbradford 
- @kave 
- @richaagarwal 
- @rosskarchner 

## Notes

- Should fix homepage 500

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)

…cope