### PR TITLE
Fix focus on multiselect in IE

### DIFF
--- a/cfgov/unprocessed/css/atoms/multi-select.less
+++ b/cfgov/unprocessed/css/atoms/multi-select.less
@@ -26,7 +26,7 @@
 
         // Styles
         box-sizing: border-box;
-        overflow: scroll;
+        overflow-y: scroll;
         position: absolute;
         z-index: 10;
 

--- a/cfgov/unprocessed/js/molecules/Multiselect.js
+++ b/cfgov/unprocessed/js/molecules/Multiselect.js
@@ -418,6 +418,12 @@ function Multiselect( element ) { // eslint-disable-line max-statements, inline-
       }
     } );
 
+    _bind( _container, {
+      mousedown: function() {
+        _isBlurSkipped = true;
+      }
+    } );
+
     for ( var i = 0, len = inputs.length; i < len; i++ ) {
       _bind( inputs[i], {
         change: _changeHandler


### PR DESCRIPTION
Previously, people who scrolled by clicking on the scrollbar would close
the multiselect search box. The blur event is a little more aggressive in IE. This
uses the blurskipped event to catch clicks on the container.

## Additions

- Fix for IE Scrollbar #1712
- Fix for scrolling on IE with the multiselect.

## Testing

- Visit /blog/ on Windows IE 11. Scroll to select a topic near the bottom and click anywhere on the page to dismiss the box.

## Review

- @jimmynotjim 
- @anselmbradford 
- @sebworks 


## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
