### PR TITLE
Protect URLs from potentially leaking unpublished pages

### DIFF
--- a/cfgov/jinja2/v1/_includes/molecules/breadcrumbs.html
+++ b/cfgov/jinja2/v1/_includes/molecules/breadcrumbs.html
@@ -20,7 +20,7 @@
 {% macro render(breadcrumbs, additional_classes) %}
     <nav class="breadcrumbs {{ additional_classes }}" aria-label="Breadcrumbs">
         {% for crumb in breadcrumbs %}
-        <a class="breadcrumbs_link" href="{{ get_page_state_url({}, crumb) }}">
+        <a class="breadcrumbs_link" href="{{ get_protected_url(crumb) }}">
             {{ crumb.title | e }}
         </a>
         {% endfor %}

--- a/cfgov/jinja2/v1/_includes/molecules/featured-content.html
+++ b/cfgov/jinja2/v1/_includes/molecules/featured-content.html
@@ -61,7 +61,7 @@
         <ul class="list list__links">
             {% if value.show_post_link and value.post %}
                 <li class="list_item">
-                  <a class="list_link" href="{{ value.post.url_path }}">
+                  <a class="list_link" href="{{ get_protected_url(value.post) }}">
                     {{ value.post_link_text }}
                   </a>
                 </li>

--- a/cfgov/jinja2/v1/_includes/organisms/post-preview.html
+++ b/cfgov/jinja2/v1/_includes/organisms/post-preview.html
@@ -44,8 +44,8 @@
 {% from 'macros/util/format/url.html' import location_image_url as location_image_url %}
 
 {% macro render(post, type='', form_id=0, url='') %}
-    {% set page_url = url or get_page_state_url({'request':request}, page) %}
-    {% set post_url = get_page_state_url({'request':request}, post) %}
+    {% set page_url = url or get_protected_url(page) %}
+    {% set post_url = get_protected_url(post) %}
     <article class="o-post-preview">
         <div class="meta-header">
             <span class="date meta-header_right">

--- a/cfgov/jinja2/v1/sublanding-page/index.html
+++ b/cfgov/jinja2/v1/sublanding-page/index.html
@@ -37,7 +37,7 @@
                 {% set limit = block.value.limit | int %}
                 {% set num_posts = limit if limit <= posts | length else posts | length %}
                 {% for i in range(num_posts) %}
-                    {{ post_preview.render(posts[i], '', 0, get_page_state_url({'request':request}, posts[i].parent())) }}
+                    {{ post_preview.render(posts[i], '', 0, get_protected_url(posts[i].parent())) }}
                 {% endfor %}
              </div>
         {% elif 'filter_controls' in block.block_type %}


### PR DESCRIPTION
Live pages have the possibility of linking to pages that are not yet live, which is fine. However, what's not fine is the information that's leaked from that link. This protects that information by replacing non-live page links on the live site with `#`. It also fixes the 404 issue for Featured Content modules.

## Additions

- context function that returns the protected URL

## Changes

- page links should use `get_protected_url` instead of `get_page_state_url`

## Testing

- Go to http://localhost:8000/data-research/research-reports/ and click on the See Full Report link on the featured content component to make sure that link is okay.
- Go to that full report's edit page and unpublish it. 
- go back to http://localhost:8000/data-research/research-reports/ and verify that the link to the full report has been replaced with a `#`

## Review

- @richaagarwal 
- @rosskarchner 
- @kave 
