### PR TITLE
Flyout Menu: Adds aria-expanded on alt trigger

### DIFF
--- a/cfgov/unprocessed/js/modules/FlyoutMenu.js
+++ b/cfgov/unprocessed/js/modules/FlyoutMenu.js
@@ -108,6 +108,19 @@ function FlyoutMenu( element ) { // eslint-disable-line max-statements, no-inlin
 
   /**
    * Event handler for when the search input trigger is hovered over.
+   * @param {HTMLNode} elem - The element to set.
+   * @param {boolean} value - The value to set on `aria-expanded`,
+   *   casts to a string.
+   * @param {string} The cast value.
+   */
+  function _setAriaExpandedAttr( elem, value ) {
+    var strValue = String( value );
+    elem.setAttribute( 'aria-expanded', strValue );
+    return strValue;
+  }
+
+  /**
+   * Event handler for when the search input trigger is hovered over.
    */
   function _triggerOver() {
     if ( !_suspended ) {
@@ -193,8 +206,9 @@ function FlyoutMenu( element ) { // eslint-disable-line max-statements, no-inlin
       } else {
         _collapseEndBinded();
       }
-      _triggerDom.setAttribute( 'aria-expanded', 'false' );
-      _contentDom.setAttribute( 'aria-expanded', 'false' );
+      if ( _altTriggerDom ) _setAriaExpandedAttr( _altTriggerDom, false );
+      _setAriaExpandedAttr( _triggerDom, false );
+      _setAriaExpandedAttr( _contentDom, false );
       // TODO: Remove or uncomment when keyboard navigation is in.
       // _triggerDom.focus();
     } else {
@@ -217,8 +231,9 @@ function FlyoutMenu( element ) { // eslint-disable-line max-statements, no-inlin
         .removeEventListener( BaseTransition.END_EVENT, _expandEndBinded );
     }
     this.dispatchEvent( 'expandEnd', { target: this, type: 'expandEnd' } );
-    _triggerDom.setAttribute( 'aria-expanded', 'true' );
-    _contentDom.setAttribute( 'aria-expanded', 'true' );
+    if ( _altTriggerDom ) _setAriaExpandedAttr( _altTriggerDom, true );
+    _setAriaExpandedAttr( _triggerDom, true );
+    _setAriaExpandedAttr( _contentDom, true );
     // Call collapse, if it was called while expand was animating.
     _deferFunct();
   }


### PR DESCRIPTION
## Changes

- I'm unclear on what should have aria-expanded when the triggers to show/hide some content are outside or inside the content to be shown. 
[This](https://www.w3.org/WAI/GL/wiki/Using_the_WAI-ARIA_aria-expanded_state_to_mark_expandable_and_collapsible_regions#Example_2:_Collapsing_and_expanding_subtrees_of_a_tree) makes it seem like it should only be on the content, while [this](http://v4-alpha.getbootstrap.com/components/collapse/#example) makes it seem like it should be on the content and the triggers.
We have this structure for flyout menus (in pseudocode):

```
.trigger
.content
   .alt-trigger
```

So `.trigger` and `.content` are siblings and `.alt-trigger` is a child of `.content`.
Clicking either of the triggers toggles content.

This PR updates the FlyoutMenu to set `aria-expanded` on the alt-trigger, as it was only being applied to the trigger and content before, but is this correct?

## Testing

- `gulp build`
- Menu and search should work as before, but at mobile sizes the "Back" button should get an `aria-expanded` attribute.

## Review

- @KimberlyMunoz 
- @sebworks 
- @jimmynotjim 

