### PR TITLE
About us page content fixes & browser test fixes

### DIFF
--- a/cfgov/jinja2/v1/about-us/index.html
+++ b/cfgov/jinja2/v1/about-us/index.html
@@ -28,7 +28,7 @@
                 Find resources and tools for consumers in the Consumer Tools section
             </li>
             <li class="list_item">
-                <a href="/offices/payments-to-harmed-consumers/"
+                <a href="/about-us/payments-harmed-consumers/"
                    class="list_link">
                     Find out about our work to protect consumers
                 </a>
@@ -70,7 +70,7 @@
                              alt="David Silberman">
                     </div>
                     <div class="media_body">
-                        <span class="h6">Deputy Director</span>
+                        <span class="h6">Acting Deputy Director</span>
                         <h3 class="bureau-bio_name">David Silberman</h3>
                         <a class="jump-link jump-link__underline"
                            href="/the-bureau/about-deputy-director/">
@@ -98,17 +98,20 @@
                 </p>
                 <ul class="list list__links">
                     <li class="list_item">
-                        <a href="/budget/strategic-plan/" class="list_link">
+                        <a href="/about-us/budget-strategy/strategic-plan/"
+                           class="list_link">
                             Our strategic plan
                         </a>
                     </li>
                     <li class="list_item">
-                        <a href="/budget/financial-report/" class="list_link">
+                        <a href="/about-us/budget-strategy/financial-reports/"
+                           class="list_link">
                             Financial reports and updates
                         </a>
                     </li>
                     <li class="list_item">
-                        <a href="/budget/" class="list_link">
+                        <a href="/about-us/budget-strategy/"
+                           class="list_link">
                             Learn more about our strategy and budget
                         </a>
                     </li>

--- a/cfgov/jinja2/v1/about-us/index.html
+++ b/cfgov/jinja2/v1/about-us/index.html
@@ -1,7 +1,7 @@
 {% extends 'layout-2-1-bleedbar.html' %}
 
 {% block title -%}
-    About Us
+    About us
 {%- endblock %}
 
 {% block content_main %}
@@ -9,7 +9,7 @@
                 block__flush-top
                 block__flush-bottom
                 block__padded-bottom">
-        <h1>About Us</h1>
+        <h1>About us</h1>
         <p class="h3">
             The Consumer Financial Protection Bureau (CFPB)
             is a 21<sup>st</sup> century agency that helps consumer finance markets work
@@ -43,7 +43,7 @@
                             block__padded-top
                             block__padded-bottom
                             block__flush-bottom">
-                <h2>CFPB Leadership</h2>
+                <h2>CFPB leadership</h2>
                 <div class="media bureau-bio u-mb30">
                     <div class="media_image-container">
                         <img class="media_image
@@ -90,7 +90,7 @@
                             block__padded-top
                             block__padded-bottom
                             block__flush-bottom">
-                <h2>Strategy & Budget</h2>
+                <h2>Strategy and budget</h2>
                 <p>
                     We work for the American public.
                     We publish our strategy and budget
@@ -121,7 +121,7 @@
             <section class="block
                             block__border-top
                             block__padded-top">
-                <h2>Engage in our Work</h2>
+                <h2>Engage in our work</h2>
                 <p>
                     We actively seek opportunities to collaborate
                     with subject matter experts, third-party vendors,
@@ -132,7 +132,7 @@
                 </p>
                 <ul class="list list__links">
                     <li class="list_item">
-                        <a href="/offices/advisory-groups/" class="list_link">
+                        <a href="/about-us/advisory-groups/" class="list_link">
                             Advisory groups
                         </a>
                     </li>

--- a/test/browser_tests/spec_suites/about-us.js
+++ b/test/browser_tests/spec_suites/about-us.js
@@ -13,7 +13,7 @@ describe( 'About Landing Page', function() {
   } );
 
   it( 'should properly load in a browser', function() {
-    expect( page.pageTitle() ).toContain( 'About Us' );
+    expect( page.pageTitle() ).toContain( 'About us' );
   } );
 
   it( 'should load the activity block in the sidebar', function() {

--- a/test/browser_tests/spec_suites/footer.js
+++ b/test/browser_tests/spec_suites/footer.js
@@ -26,6 +26,8 @@ describe( 'The Footer Component', function() {
       'plain writing',
     '/privacy/':
       'privacy, policy & legal notices',
+    '/privacy/digital-privacy-policy/':
+      'digital privacy policy',
     '/tribal/':
       'tribal',
     'http://usa.gov/':
@@ -76,7 +78,7 @@ describe( 'The Footer Component', function() {
 
       element.getText().then( function( textValue ) {
         _linkText = textValue.toLowerCase();
-        expect( _footerLinkLookup[_linkHref] ).toEqual( _linkText );
+        expect( _footerLinkLookup[_linkHref] ).toContain( _linkText );
       } );
 
     } );


### PR DESCRIPTION
A bunch of fixes to the content of the about us page. Mostly changing things to sentence case.

While I was fixing a browser test, I also fixed a few broken ones in the footer.

## Testing

- Visit /about-us/, half blob titles should be in sentence case now

## Review

- @jimmynotjim 
- @sebworks 
- @anselmbradford 

## Screenshots

![Uploading image.png…]()


## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
