### PR TITLE
Fix tag url for blogs and newsrooms

### DIFF
--- a/cfgov/jinja2/v1/_includes/article.html
+++ b/cfgov/jinja2/v1/_includes/article.html
@@ -88,7 +88,7 @@
 {% if post.tags|length %}
     <footer>
         {%- import 'tags.html' as tags %}
-        {{ tags.render(post.tags, path) }}
+        {{ tags.render(post.tags, path, is_sheer=True) }}
     </footer>
 {% endif %}
 </article>

--- a/cfgov/jinja2/v1/_includes/tags.html
+++ b/cfgov/jinja2/v1/_includes/tags.html
@@ -29,13 +29,14 @@
 
    ========================================================================== #}
 
-{% macro render(tags, path, hide_heading=false, display_block=false, index=0) %}
+{% macro render(tags, path, hide_heading=false, display_block=false, index=0, is_sheer=False) %}
 <div class="tags {{'tags__hide-heading' if hide_heading else ''}} {{'tags__block-list' if display_block else '' }}">
     <span class="{{'u-visually-hidden' if hide_heading else 'tags_heading' }}">Topics:</span>
     <ul class="tags_list">
     {% for tag in tags %}
         <li class="tags_tag">
-            <a class="tags_link" href="{{ path }}?filter{{ index }}_topics={{ tag }}">
+          {% set url_arg = 'filter_tags=' if is_sheer else 'filter' ~ index|string ~ '_topics=' %}
+            <a class="tags_link" href="{{ path }}?{{ url_arg }}{{ tag }}">
                 <span class="tags_bullet" aria-hidden="true">&bull;</span>
                 {{ tag }}
             </a>


### PR DESCRIPTION
The topic tag urls were using url parameters that are Wagtail page specific for every type of page. This changes up the tags.html code so that the topic tags will work for pages that are in sheer.

## Additions

- New tags.html render() parameter to tell whether or not the page is a sheer page.

## Testing

- Go to a blog post or a newsroom item and click on the topic tag that should now link back to the newsroom or blog landing page with a working url parameter to filter based on the tag selected.

## Review

- @kave 
- @richaagarwal 

