### PR TITLE
Fix call to get_form_id method

### DIFF
--- a/cfgov/jinja2/v1/_includes/molecules/related-metadata.html
+++ b/cfgov/jinja2/v1/_includes/molecules/related-metadata.html
@@ -69,9 +69,13 @@
            {{ 'm-related-metadata_topics' if is_related_topics else '' }} ">
     {% for link in list.links %}
     <li class="list_item">
-        <a href="{{ link.url }}" class="list_link">
-            {{ link.text }}
-        </a>
+        {% if link.url %}
+            <a href="{{ link.url }}" class="list_link">
+                {{ link.text }}
+            </a>
+        {% else %}
+            <span class="list_link">{{ link.text }}</span>
+        {% endif %}
     </li>
     {% endfor %}
 </ul>
@@ -134,5 +138,5 @@
    ========================================================================== #}
 
 {% macro _topics(list) %}
-    {{ _list( page.related_metadata_tags(request.GET), true ) }}
+    {{ _list( related_metadata_tags(page), true ) }}
 {% endmacro %}

--- a/cfgov/v1/models/browse_filterable_page.py
+++ b/cfgov/v1/models/browse_filterable_page.py
@@ -9,10 +9,9 @@ from wagtail.wagtailadmin.edit_handlers import StreamFieldPanel, FieldPanel
 from wagtail.wagtailcore.fields import StreamField
 from wagtail.wagtailadmin.edit_handlers import TabbedInterface, ObjectList
 
-from . import base, molecules, organisms
+from . import base, molecules, organisms, ref
 from .learn_page import AbstractFilterPage
 from .. import forms
-from ..util.util import get_secondary_nav_items
 from ..util import filterable_context
 
 

--- a/cfgov/v1/models/learn_page.py
+++ b/cfgov/v1/models/learn_page.py
@@ -13,8 +13,6 @@ from wagtail.wagtailimages.edit_handlers import ImageChooserPanel
 from . import molecules
 from . import organisms
 from .base import CFGOVPage, CFGOVPageManager
-from ..templatetags.share import get_page_state_url
-from ..util import util
 
 
 class AbstractFilterPage(CFGOVPage):
@@ -76,23 +74,6 @@ class AbstractFilterPage(CFGOVPage):
     is_creatable = False
 
     objects = CFGOVPageManager()
-
-    def related_metadata_tags(self, get_request):
-        # Set the tags to correct data format
-        tags = {'links': []}
-        # From the parent, get the form ids from the BrowseFilterablePage helper method
-        # then use the first id since the filterable list on the page will probably
-        # have the first id on the page. For more, see v1/models/browse_filterable_page.py line 105.
-        parent = self.parent()
-        id = util.get_form_id(parent, get_request)
-        for tag in self.tags.names():
-            tag_link = {'text': tag, 'url': ''}
-            if id is not None:
-                param = '?filter' + str(id) + '_topics=' + tag
-                tag_link['url'] = get_page_state_url({'request': get_request}, parent) + param
-            tags['links'].append(tag_link)
-
-        return tags
 
 
 class LearnPage(AbstractFilterPage):

--- a/cfgov/v1/models/sublanding_filterable_page.py
+++ b/cfgov/v1/models/sublanding_filterable_page.py
@@ -11,10 +11,9 @@ from wagtail.wagtailadmin.edit_handlers import TabbedInterface, ObjectList
 from wagtail.wagtailcore import blocks
 from wagtail.wagtailimages.blocks import ImageChooserBlock
 
-from . import base, molecules, organisms
+from . import base, molecules, organisms, ref
 from .learn_page import AbstractFilterPage
 from .. import forms
-from ..util.util import get_secondary_nav_items
 from ..util import filterable_context
 
 from .base import CFGOVPage


### PR DESCRIPTION
For AbstractFilterPage types, the code to get the links for the related metadata topics doesn't account for parents of the pages that are not BrowseFilterablePage or SublandingFilterablePage. This fixes that call.

## Additions

- Logic to look through the ancestors of the current page for a filterable type to call the method on.

## Changes

- The tag will not have a tag if none of the ancestors of the page that is in on are BrowseFilterablePage or SublandingFilterablePage.

## Testing

-

## Review

- @richaagarwal 
- @kave 
- @rosskarchner 