### PR TITLE
Fix link text

### DIFF
--- a/cfgov/jinja2/v1/_includes/organisms/_vars-mega-menu.html
+++ b/cfgov/jinja2/v1/_includes/organisms/_vars-mega-menu.html
@@ -58,7 +58,7 @@
         ('Tell Your Story', '/your-story/', []),
         ('Information for Students', '/students/', []),
         ('Information for Older Americans', '/older-americans/', []),
-        ('Information for Servicemembers', '/servicemembers/', [])
+        ('Information for Servicemembers & Veterans', '/servicemembers/', [])
     ),(
         ('Paying for College', '/paying-for-college/', []),
         ('Owning a Home', '/owning-a-home/', []),


### PR DESCRIPTION
## Changes

- Updates menu text to `Information for Servicemembers & Veterans` from `Information for Servicemembers` 

## Testing

- Link text should be updated in the menu.

## Review

- @schaferjh 
- @jimmynotjim 
- @KimberlyMunoz 
- @sebworks 

## Screenshots

![screen shot 2016-03-28 at 3 13 16 pm](https://cloud.githubusercontent.com/assets/704760/14087993/ef5aebac-f4fa-11e5-9208-b455a5cb911d.png)