### PR TITLE
Disable GTM on menu links that don't go anywhere

### DIFF
--- a/cfgov/unprocessed/js/modules/FlyoutMenu.js
+++ b/cfgov/unprocessed/js/modules/FlyoutMenu.js
@@ -83,6 +83,12 @@ function FlyoutMenu( element ) { // eslint-disable-line max-statements, no-inlin
    * @returns {FlyoutMenu} An instance.
    */
   function init() {
+    // Ignore Google Analytics on the trigger if it is a link,
+    // since we're preventing the default link behavior.
+    if ( _triggerDom.tagName === 'A' ) {
+      _triggerDom.setAttribute( 'data-gtm_ignore', 'true' );
+    }
+
     var triggerClickedBinded = _triggerClicked.bind( this );
     var triggerOverBinded = _triggerOver.bind( this );
     _triggerDom.addEventListener( 'click', triggerClickedBinded );
@@ -97,6 +103,13 @@ function FlyoutMenu( element ) { // eslint-disable-line max-statements, no-inlin
       if ( subMenu && subMenu.contains( _altTriggerDom ) ) {
         _altTriggerDom = null;
       } else {
+        // TODO: Investigate just having multiple triggers,
+        //       instead of a primary and alternative.
+        // Ignore Google Analytics on the trigger if it is a link,
+        // since we're preventing the default link behavior.
+        if ( _altTriggerDom.tagName === 'A' ) {
+          _altTriggerDom.setAttribute( 'data-gtm_ignore', 'true' );
+        }
         _altTriggerDom.addEventListener( 'click', triggerClickedBinded );
       }
     }


### PR DESCRIPTION
## Changes

- Adds a `data-gtm_ignore="true"` to menu links that have their default behavior disabled so they don't actually work like links.

## Testing

- `gulp build` and view the source for the desktop menu. The main links should have `data-gtm_ignore="true"` attributes set.

## Review

- @sebworks 
- @jimmynotjim 
- @KimberlyMunoz 
