### PR TITLE
Bugfix for bad values in selects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,13 +34,14 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 
 - Removed `gulp beep` task for optional alerting when the build process
   has completed.
-
 - Remove Disqus comments from blog pages
 
 ### Fixed
 
 - Fixed paths to templates that were moved in to /about-us
 - Update biographies for director bios
+- Fixed issue with bad values in the multiselect.
+
 
 ## 3.0.0-3.2.1 - 2016-03-21
 

--- a/cfgov/unprocessed/js/modules/util/strings.js
+++ b/cfgov/unprocessed/js/modules/util/strings.js
@@ -1,6 +1,5 @@
 'use strict';
 
-
 /**
  * Escapes a string.
  * @param   {string} s The string to escape.
@@ -11,10 +10,19 @@ function stringEscape( s ) {
 }
 
 /**
- * Tests whether a string matches another.
- * @param   {string}  x  The control string.
- * @param   {string}  y  The comparison string.
- * @returns {boolean}    Returns the boolean result of the test.
+ * Tests whether a string is valid
+ * @param  {string}  s The string to test
+ * @return {boolean}   Returns the boolean result of the test
+ */
+function stringValid( s ) {
+  return !/[~`!#$%\^&*+=\[\]\\';,/{}|\\":<>\?]/g.test( s );
+}
+
+/**
+ * Tests whether a string matches another
+ * @param   {string}  x The control string
+ * @param   {string}  y The comparison string
+ * @returns {boolean}   Returns the boolean result of the test
  */
 function stringMatch( x, y ) {
   return RegExp( stringEscape( y.trim() ), 'i' ).test( x );
@@ -22,5 +30,6 @@ function stringMatch( x, y ) {
 
 module.exports = {
   stringEscape: stringEscape,
+  stringValid: stringValid,
   stringMatch: stringMatch
 };

--- a/cfgov/unprocessed/js/molecules/Multiselect.js
+++ b/cfgov/unprocessed/js/molecules/Multiselect.js
@@ -5,7 +5,7 @@ var arrayHelpers = require( '../modules/util/array-helpers' );
 var typeCheckers = require( '../modules/util/type-checkers' );
 var domTraverse = require( '../modules/util/dom-traverse' );
 var domCreate = require( '../modules/util/dom-manipulators' ).create;
-var stringMatch = require( '../modules/util/strings' ).stringMatch;
+var strings = require( '../modules/util/strings' );
 
 /**
  * Multiselect
@@ -111,6 +111,14 @@ function Multiselect( element ) { // eslint-disable-line max-statements, inline-
 
     for ( var i = 0, len = list.length; i < len; i++ ) {
       item = list[i];
+
+      // If the value isn't valid kill the script and propt the developer
+      if ( !strings.stringValid( item.value ) ) {
+        console.log( '\'' + item.value + '\' is not a valid value' );
+
+        return false;
+      }
+
       cleaned.push( {
         value:   item.value,
         text:    item.text,
@@ -301,7 +309,7 @@ function Multiselect( element ) { // eslint-disable-line max-statements, inline-
       _index = -1;
 
       _filtered = _optionData.filter( function( item ) {
-        return stringMatch( item.text, value );
+        return strings.stringMatch( item.text, value );
       } );
 
       _filterResults();

--- a/test/unit_tests/modules/util/strings-spec.js
+++ b/test/unit_tests/modules/util/strings-spec.js
@@ -30,6 +30,50 @@ describe( 'Strings stringEscape()', function() {
   } );
 } );
 
+describe( 'Strings stringValid()', function() {
+  it( 'should return true when testing a standard string', function() {
+    string = 'Test String';
+
+    expect( strings.stringValid( string ) ).to.be.true;
+  } );
+
+  it( 'should return true when testing a hyphenated string', function() {
+    string = 'Test-String';
+
+    expect( strings.stringValid( string ) ).to.be.true;
+  } );
+
+  it( 'should return true when testing an underscored string', function() {
+    string = 'Test_String';
+
+    expect( strings.stringValid( string ) ).to.be.true;
+  } );
+
+  it( 'should return false when testing a string containing a single tick',
+    function() {
+      string = 'Person\'s Name';
+
+      expect( strings.stringValid( string) ).to.be.false;
+    }
+  );
+
+  it( 'should return false when testing a string containing a colon',
+    function() {
+      string = 'Person: Name';
+
+      expect( strings.stringValid( string) ).to.be.false;
+    }
+  );
+
+  it( 'should return false when testing a string containing a gt or lt',
+    function() {
+      string = '<body>';
+
+      expect( strings.stringValid( string) ).to.be.false;
+    }
+  );
+} );
+
 describe( 'Strings stringMatch()', function() {
   it( 'should return true when testing matching strings', function() {
     string = 'Test String';


### PR DESCRIPTION
If the select contains an invalid value (an issue we've been seeing often), the scripts will terminate early and log the issue as a tip for developers.

## Additions

- Adds stringValid function and tests
- Adds stringValid checker when sanitizing the list of options

## Testing

- `gulp test:unit:scripts`
- `gulp build` and publish Data & Research's child page Research Reports as well as it's child page Data point: Checking account overdraft then open the page. The error should be logged, but it shouldn't be an error which blocks the rest of the scripts on the page.

## Review

- @anselmbradford 
- @KimberlyMunoz 
- @sebworks 
- @kurtw 

## Notes

- Kurt and I have dealt with bad values more than once, this should help us avoid tearing out our hair if it happens again.

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)