### PR TITLE
Disables GTM in return to top link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -121,6 +121,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Frontend: Made Expandables collapse under 600px window size.
 - Updated the Mega Menu layout to avoid pointer events for older IE.
 - Updated the Mega Menu for devices without JS.
+- Disabled GTM tracking for links in menu and return to top link.
 
 ### Removed
 - Removed normalize and normalize-legacy from main less file because CF

--- a/cfgov/unprocessed/js/modules/footer-button.js
+++ b/cfgov/unprocessed/js/modules/footer-button.js
@@ -6,11 +6,17 @@
 
 var $ = require( 'jquery' );
 
+// TODO: Refactor this file to remove jquery dependency.
+//       http://stackoverflow.com/questions/21474678/
+//       scrolltop-animation-without-jquery
 /**
  * Set up event handler for button to scroll to top of page.
  */
 function init() {
   var duration = 300;
+
+  // Disable Google Tag Manager tracking on this link.
+  $( '.js-return-to-top' ).attr( 'data-gtm_ignore', 'true' );
 
   $( '.js-return-to-top' ).click( function( event ) {
     event.preventDefault();


### PR DESCRIPTION
## Changes

- Addendum to https://github.com/cfpb/cfgov-refresh/pull/1729

## Testing

- `gulp build`, resize to mobile, click back to top should still work.

## Review

- @sebworks 
- @jimmynotjim 
- @KimberlyMunoz 

## TODO

- Footer code could remove jquery dependency. Dom lookups aren't needed and the animation can be covered in a function or two.