### PR TITLE
Added a checker for max selections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 
 ### Added
 
+- Adds a max-selections checker to the Multiselect.
+
 ### Changed
 
 ### Removed

--- a/cfgov/unprocessed/css/atoms/multi-select.less
+++ b/cfgov/unprocessed/css/atoms/multi-select.less
@@ -60,16 +60,23 @@
             display: none;
         }
 
-        &.no-results {
+        &.no-results,
+        &.max-selections {
             li {
                 display: none;
             }
 
             &:after {
                 display: list-item;
-
-                content: 'No results found';
             }
+        }
+
+        &.no-results:after {
+            content: 'No results found';
+        }
+
+        &.max-selections:after {
+            content: 'Reached maximum of five selections';
         }
     }
 

--- a/cfgov/unprocessed/js/molecules/Multiselect.js
+++ b/cfgov/unprocessed/js/molecules/Multiselect.js
@@ -252,6 +252,10 @@ function Multiselect( element ) { // eslint-disable-line max-statements, inline-
       if ( selectionIndex > -1 ) {
         _selections.splice( selectionIndex, 1 );
 
+        if ( _list.classList.contains( 'max-selections' ) ) {
+          _list.classList.remove( 'max-selections' );
+        }
+
         li = _choices.querySelector( 'li[data-option="' + option.value + '"]' );
 
         if ( li ) {
@@ -270,6 +274,10 @@ function Multiselect( element ) { // eslint-disable-line max-statements, inline-
 
         _choices.appendChild( li );
         _selections.push( option );
+
+        if ( _selections.length > 4 ) {
+          _list.classList.add( 'max-selections' );
+        }
       }
     }
 


### PR DESCRIPTION
Added a checker to the Multiselect for max selections

## Changes

- Adds a max-selections class when user reaches five selections
- Removes the class once the user removes the fifth selection

## Testing

- `gulp build` and navigate to `/blog` and make five selections in the Multiselect

## Review

- @schaferjh 
- @KimberlyMunoz 
- @sebworks 
- @anselmbradford 

## Screenshots

![screen shot 2016-03-29 at 10 15 53 am](https://cloud.githubusercontent.com/assets/1280430/14113135/40974d16-f597-11e5-9f93-08f65c117f71.png)

## Todos

- Add tests (slowly working on this in other PRs)

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)