### PR TITLE
Sheer served pages now sort related posts by date descending

### DIFF
--- a/cfgov/jinja2/v1/_includes/related-posts.html
+++ b/cfgov/jinja2/v1/_includes/related-posts.html
@@ -10,7 +10,7 @@
         </span>
     </h2>
     <ul class="list list__unstyled list__spaced">
-    {% for similar in more_like_this(post, search_types=doc_types, search_size=quantity) %}
+    {% for similar in more_like_this(post, search_types=doc_types, search_size=quantity, body={'sort': [{'date': {'order': 'desc'}}]}) %}
         <li class="list_item">
             <h3 class="h4 u-mb5">
                 <a class="list_link"

--- a/cfgov/v1/models/base.py
+++ b/cfgov/v1/models/base.py
@@ -140,7 +140,7 @@ class CFGOVPage(Page):
                     and block.value['relate_%s' % search_type]:
                 related[search_type_name] = \
                     search_class.objects.filter(query).order_by(
-                        'latest_revision_created_at').exclude(
+                        '-date_published').exclude(
                         slug=self.slug).live_shared(hostname)[:block.value['limit']]
         # TODO: Remove each search_type as it is implemented into Django
         queries = QueryFinder()


### PR DESCRIPTION
Related Posts for blog posts and newsroom items need to be sorted by date descending, and events need to be sorted by date_published descending on all pages that have a relation to them.

@kave 
@richaagarwal 