### PR TITLE
Add screenshot.capture() test utility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,6 +96,7 @@ collectstatic/*
 test/macro_tests/src/
 test/unit_test_coverage/
 test/perf_test_results/
+test/screenshot.png
 htmlcov/
 .tox/
 .coverage

--- a/test/browser_tests/util/screenshot.js
+++ b/test/browser_tests/util/screenshot.js
@@ -1,0 +1,39 @@
+/* ==========================================================================
+   Utility to capture a screenshot of the current browser window.
+   ========================================================================== */
+
+'use strict';
+
+var fs = require( 'fs' );
+
+var _screenShotDirectory = 'test/';
+
+/**
+ * Write a screenshot string to a file.
+ * @param {string} filename - The filename of the file to create.
+ * @param {string} data - A base64-encoded string to write to a file.
+ */
+function _writeScreenShot( filename, data ) {
+  var stream = fs.createWriteStream( _screenShotDirectory + filename );
+
+  stream.write( new Buffer( data, 'base64' ) );
+  stream.end();
+}
+
+/**
+ * Process a screenshot generated from a browser.takeScreenshot() promise.
+ * @param {string} png - A base64-encoded string to write to a file.
+ */
+function _processScreenshot( png ) {
+  _writeScreenShot( 'screenshot.png', png );
+}
+
+/**
+ * Capture a screenshot of the current browser window.
+ */
+function capture() {
+  browser.takeScreenshot().then( _processScreenshot );
+}
+
+// Expose public methods.
+module.exports = { capture: capture };


### PR DESCRIPTION
Using this to check a test suite I'm building, so spinning it off here.

## Additions

- Adds screenshot.js test utility for capturing a screenshot in a running test.

## Testing

- In a test (such as `blog.js`) add `var screenshot = require( '../util/screenshot' );` (or whatever path is needed) and add `screenshot.capture()` to a test to observe, such as:

```js
  it( 'should properly load in a browser', function() {
    expect( page.pageTitle() ).toContain( 'Blog' );
    screenshot.capture();
  } );

```

- Find screenshot in `test/screenshot.png`

## Review

- @KimberlyMunoz 
- @sebworks 
- @jimmynotjim 
