### PR TITLE
Filter tag slugs

### DIFF
--- a/cfgov/jinja2/v1/_includes/organisms/post-preview.html
+++ b/cfgov/jinja2/v1/_includes/organisms/post-preview.html
@@ -164,9 +164,9 @@
                     </span>
                 {% endfor %}
 
-                {% if post.tags.names() | length %}
+                {% if post.tags.all() | length %}
                     {%- import 'tags.html' as tags %}
-                    {{ tags.render(post.tags.names(), page_url, true, false, form_id) }}
+                    {{ tags.render(post.tags.all(), page_url, true, false, form_id) }}
                 {% endif %}
             </div>
             {% if post.secondary_link_url and post.secondary_link_text %}

--- a/cfgov/jinja2/v1/_includes/tags.html
+++ b/cfgov/jinja2/v1/_includes/tags.html
@@ -35,11 +35,17 @@
     <ul class="tags_list">
     {% for tag in tags %}
         <li class="tags_tag">
-          {% set url_arg = 'filter_tags=' if is_sheer else 'filter' ~ index|string ~ '_topics=' %}
-            <a class="tags_link" href="{{ path }}?{{ url_arg }}{{ tag }}">
-                <span class="tags_bullet" aria-hidden="true">&bull;</span>
-                {{ tag }}
-            </a>
+          {% if is_sheer %}
+              <a class="tags_link" href="{{ path }}?filter_tags={{ tag }}">
+                  <span class="tags_bullet" aria-hidden="true">&bull;</span>
+                  {{ tag }}
+              </a>
+          {% else %}
+              <a class="tags_link" href="{{ path }}?filter{{ index }}_topics={{ tag.slug }}">
+                  <span class="tags_bullet" aria-hidden="true">&bull;</span>
+                  {{ tag.name }}
+              </a>
+          {% endif %}
         </li>
     {% endfor %}
     </ul>

--- a/cfgov/jinja2/v1/events/_event-detail.html
+++ b/cfgov/jinja2/v1/events/_event-detail.html
@@ -93,10 +93,10 @@
         {% endif %}
         {{ page.body | safe }}
     </div>
-    {% if page.tags.names() | length %}
+    {% if page.tags.all() | length %}
     <footer>
         {%- import 'tags.html' as tags %}
-        {{ tags.render(page.tags.names(), path) }}
+        {{ tags.render(page.tags.all(), path) }}
     </footer>
     {% endif %}
 </article>

--- a/cfgov/jinja2/v1/events/_list-preview.html
+++ b/cfgov/jinja2/v1/events/_list-preview.html
@@ -48,11 +48,11 @@
                     <div class="tags tags__hide-heading">
                         <span class="tags_heading u-visually-hidden">Topics:</span>
                         <ul class="tags_list">
-                        {% for tag in event.tags.names() %}
+                        {% for tag in event.tags.all() %}
                             <li class="tags_tag">
-                                <a class="tags_link" href="{{ request.path }}?topics={{ tag }}">
+                                <a class="tags_link" href="{{ request.path }}?topics={{ tag.slug }}">
                                     <span class="tags_bullet" aria-hidden="true">&bull;</span>
-                                    {{ tag }}
+                                    {{ tag.name }}
                                 </a>
                             </li>
                         {% endfor %}

--- a/cfgov/v1/models/learn_page.py
+++ b/cfgov/v1/models/learn_page.py
@@ -85,10 +85,10 @@ class AbstractFilterPage(CFGOVPage):
         # have the first id on the page. For more, see v1/models/browse_filterable_page.py line 105.
         parent = self.parent()
         id = util.get_form_id(parent, get_request)
-        for tag in self.tags.names():
-            tag_link = {'text': tag, 'url': ''}
+        for tag in self.tags.all():
+            tag_link = {'text': tag.name, 'url': ''}
             if id is not None:
-                param = '?filter' + str(id) + '_topics=' + tag
+                param = '?filter' + str(id) + '_topics=' + tag.slug
                 tag_link['url'] = get_page_state_url({'request': get_request}, parent) + param
             tags['links'].append(tag_link)
 

--- a/cfgov/v1/util/util.py
+++ b/cfgov/v1/util/util.py
@@ -50,7 +50,7 @@ def most_common(lst):
         # Gets the most common element in the list.
         most = max(set(lst), key=lst.count)
         # Creates a new list without that element.
-        new_list = [e for e in lst if most not in e]
+        new_list = [e for e in lst if most != e]
         # Recursively returns a list with the most common elements ordered
         # most to least. Ties go to the lowest index in the given list.
         return [most] + most_common(new_list)


### PR DESCRIPTION
The tag/author names can cause JS errors, breaking filterable list functions. This makes the filter use slugs instead.

## Changes

- data retrieval for tags and authors gets both slug and name instead of just name
- related-metadata links back to the tag's slug

## Review

- Go to http://localhost:8000/data-research/research-reports/ and make sure filtering still works.
- Go to a report and click one of the topic links and make sure that it applies the topic filter correctly.

## Testing

- @kave 
- @richaagarwal 
