### PR TITLE
Adds global search acceptance tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 ### Added
 
 ### Changed
+- Updated Global Search to set search trigger to invisible,
+  since hidden is overridden.
 
 ### Removed
 

--- a/cfgov/unprocessed/css/molecules/global-search.less
+++ b/cfgov/unprocessed/css/molecules/global-search.less
@@ -93,7 +93,7 @@
 */
 
 .m-global-search {
-    // Hide search unless we have JS or it's a desktop-ish size
+    // Hide search unless we have JS or it's a desktop-ish size.
     display: none;
 
     .js & {
@@ -101,7 +101,7 @@
     }
 
     &_trigger {
-        // Resets
+        // Resets for default button styles.
         background-color: transparent;
         border: none;
         display: none;
@@ -119,7 +119,7 @@
             content: @cf-icon-search;
         }
 
-        // Only show trigger if we have JS
+        // Only show trigger if we have JS.
         .js & {
             display: block;
         }
@@ -133,7 +133,7 @@
             width: 100%;
         }
 
-        // Only add transforms if we have JS
+        // Only add transforms if we have JS.
         .js & {
             &.u-invisible {
                 overflow-x: hidden;
@@ -148,7 +148,7 @@
             display: block;
         }
 
-        // Hide suggestions outside of tablet sizes
+        // Hide suggestions outside of tablet sizes.
         &-suggestions {
             display: none;
 
@@ -159,7 +159,7 @@
         }
     }
 
-    // Up to desktops
+    // Up to desktops.
     .respond-to-max( @bp-sm-max, {
         &_trigger{
             padding-top: unit( @grid_gutter-width / 2 / 16px, em );
@@ -175,7 +175,7 @@
                 background: @gray-10;
                 border-left: 1px solid @gray-40;
 
-                // Show "X" icon when flyout is open
+                // Show "X" icon when flyout is open.
                 &:before {
                     content: @cf-icon-delete;
                 }
@@ -206,7 +206,7 @@
 
     // Tablet and above.
     .respond-to-min( @bp-sm-min, {
-        // Add "Search" text in trigger
+        // Add "Search" text in trigger.
         &_trigger-label:before {
             .webfont-medium();
 
@@ -217,13 +217,13 @@
     // Tablet size only.
     .respond-to-range( @bp-sm-min, @bp-sm-max, {
         &_trigger {
-            // Min-width sets open/close states to same size
+            // Min-width sets open/close states to same size.
             min-width: 110px;
 
             padding-left: unit( @grid_gutter-width / 2 / 18px, em );
             padding-right: unit( @grid_gutter-width / 2 / 18px, em );
 
-            // Show "Close" text when flyout is open
+            // Show "Close" text when flyout is open.
             &[aria-expanded="true"] {
                 .m-global-search_trigger-label:before {
                     content: 'Close';
@@ -239,18 +239,18 @@
 
     // Desktop and above
     .respond-to-min( @bp-med-min, {
-        // Always show on desktop, even without JS
+        // Always show on desktop, even without JS.
         display: block;
-        // Center on the call to action (CTA) divider to right of search
+        // Center on the call to action (CTA) divider to right of search.
         padding-top: 6px;
         padding-bottom: 6px;
-        // Match CTA offset from divider
+        // Match CTA offset from divider.
         padding-right: @margin_half__em;
 
         overflow: hidden;
 
         &_trigger {
-            // Match height of input with button
+            // Match height of input with button.
             padding: 7px 0;
         }
 
@@ -269,7 +269,7 @@
     } );
 
     // TODO: Move these styles to cf-enhancements/cf-forms.
-    // Look into removing grid styles altogether
+    //       Look into removing grid styles altogether.
     // Mobile size.
     .respond-to-min( 480px, {
         &_content-form {

--- a/cfgov/unprocessed/js/molecules/GlobalSearch.js
+++ b/cfgov/unprocessed/js/molecules/GlobalSearch.js
@@ -146,7 +146,7 @@ function GlobalSearch( element ) { // eslint-disable-line max-statements, no-inl
   function _handleExpandBegin() {
     this.dispatchEvent( 'expandBegin', { target: this } );
     // If it's the desktop view, hide the "Search" button.
-    if ( _isInDesktop() ) { _triggerDom.classList.add( 'u-hidden' ); }
+    if ( _isInDesktop() ) { _triggerDom.classList.add( 'u-invisible' ); }
     _contentDom.classList.remove( 'u-invisible' );
     _searchInputDom.select();
 
@@ -158,7 +158,7 @@ function GlobalSearch( element ) { // eslint-disable-line max-statements, no-inl
    * Use this to perform post-collapseBegin actions.
    */
   function _handleCollapseBegin() {
-    _triggerDom.classList.remove( 'u-hidden' );
+    _triggerDom.classList.remove( 'u-invisible' );
     document.body.removeEventListener( 'mousedown', _handleBodyClick );
   }
 

--- a/test/browser_tests/spec_suites/organisms/global-search.js
+++ b/test/browser_tests/spec_suites/organisms/global-search.js
@@ -1,0 +1,159 @@
+'use strict';
+
+var BASE_JS_PATH = '../../../../cfgov/unprocessed/js/';
+
+var breakpointsConfig = require( BASE_JS_PATH + 'config/breakpoints-config' );
+
+describe( 'GlobalSearch', function() {
+  var BASE_SEL = '.m-global-search';
+  var TRIGGER_SEL = BASE_SEL + ' [data-js-hook="flyout-menu_trigger"]';
+  var CONTENT_SEL = BASE_SEL + ' [data-js-hook="flyout-menu_content"]';
+  var INPUT_SEL = BASE_SEL + ' input#query';
+  var SEARCH_SEL = BASE_SEL + ' [data-js-hook="flyout-menu_content"] .btn';
+  var CLEAR_SEL = BASE_SEL + ' .input-contains-label_after';
+  var SUGGEST_SEL = BASE_SEL + ' .m-global-search_content-suggestions';
+
+  var _dom;
+  var _nonLinkDom;
+
+  beforeAll( function() {
+    _nonLinkDom = element( by.css( '.footer_official-website' ) );
+    _dom = {
+      trigger:   element( by.css( TRIGGER_SEL ) ),
+      content:   element( by.css( CONTENT_SEL ) ),
+      input:     element( by.css( INPUT_SEL ) ),
+      searchBtn: element( by.css( SEARCH_SEL ) ),
+      clearBtn:  element( by.css( CLEAR_SEL ) ),
+      suggest:   element( by.css( SUGGEST_SEL ) )
+    };
+  } );
+
+  beforeEach( function() {
+    browser.get( '/' );
+  } );
+
+  if ( browser.params.windowWidth > breakpointsConfig.bpLG.min ) {
+    describe( 'large size', function() {
+
+      describe( 'at page load', function() {
+        it( 'should have a search trigger', function() {
+          expect( _dom.trigger.isDisplayed() ).toBe( true );
+        } );
+
+        it( 'should NOT have search input content', function() {
+          expect( _dom.content.isDisplayed() ).toBe( false );
+        } );
+
+        it( 'should NOT have suggested search terms', function() {
+          expect( _dom.suggest.isDisplayed() ).toBe( false );
+        } );
+      } );
+
+      describe( 'after clicking search', function() {
+        beforeEach( function() {
+          _dom.trigger.click();
+        } );
+
+        it( 'should NOT have a search trigger', function() {
+          expect( _dom.trigger.isDisplayed() ).toBe( false );
+        } );
+
+        it( 'should have search input content', function() {
+          expect( _dom.content.isDisplayed() ).toBe( true );
+        } );
+
+        it( 'should focus the search input field', function() {
+          var activeElement = browser.driver.switchTo().activeElement();
+          expect( _dom.input.getAttribute( 'id' ) )
+            .toEqual( activeElement.getAttribute( 'id' ) );
+        } );
+
+        it( 'should NOT have a clear button label', function() {
+          expect( _dom.clearBtn.isDisplayed() ).toBe( false );
+        } );
+      } );
+
+      describe( 'after entering text', function() {
+        beforeEach( function() {
+          _dom.trigger.click();
+          _dom.input.sendKeys( 'test' );
+        } );
+
+        it( 'should have a clear button label', function() {
+          browser.wait( _dom.input.isEnabled() )
+            .then( function() {
+              expect( _dom.clearBtn.isDisplayed() ).toBe( true );
+            } );
+        } );
+
+        it( 'should navigate to search portal', function() {
+
+          // Wait for search button to show after expanding search.
+          browser.wait( function() {
+            return _dom.searchBtn.isDisplayed();
+          } )
+          .then( function() {
+            _dom.searchBtn.click();
+            var portalUrl = 'http://search.consumerfinance.gov/' +
+                            'search?utf8=%E2%9C%93&affiliate=cfpb&query=test';
+            expect( browser.getCurrentUrl() ).toBe( portalUrl );
+          } );
+        } );
+      } );
+
+      describe( 'after clicking off search', function() {
+        beforeEach( function() {
+          _dom.trigger.click();
+          _nonLinkDom.click();
+        } );
+
+        it( 'should NOT have search input content', function() {
+          // TODO: Investigate reusing _dom.content in place of elem.
+          //       Redundant lookup is needed for elementIsNotVisible(),
+          //       since it's in the Selenium API, not protractor.
+          var elem = browser.driver.findElement( by.css( CONTENT_SEL ) );
+          // Wait for search button to disappear after collapsing search.
+          browser.wait(
+            protractor.until.elementIsNotVisible( elem )
+          ).then( function() {
+            expect( _dom.content.isDisplayed() ).toBe( false );
+          } );
+        } );
+      } );
+
+      describe( 'after the tab key is pressed', function() {
+        beforeEach( function() {
+          _dom.trigger.sendKeys( protractor.Key.SPACE );
+        } );
+
+        it( 'should NOT have search input content', function() {
+          var activeElement = browser.driver.switchTo().activeElement();
+          activeElement.sendKeys( protractor.Key.TAB );
+          activeElement = browser.driver.switchTo().activeElement();
+          activeElement.sendKeys( protractor.Key.TAB );
+          // TODO: Investigate reusing _dom.content in place of elem.
+          //       Redundant lookup is needed for elementIsNotVisible(),
+          //       since it's in the Selenium API, not protractor.
+          var elem = browser.driver.findElement( by.css( CONTENT_SEL ) );
+          // Wait for search button to disappear after collapsing search.
+          browser.wait(
+            protractor.until.elementIsNotVisible( elem )
+          ).then( function() {
+            expect( _dom.content.isDisplayed() ).toBe( false );
+          } );
+        } );
+      } );
+    } );
+  } else if ( browser.params.windowWidth > breakpointsConfig.bpSM.min &&
+              browser.params.windowWidth < breakpointsConfig.bpSM.max ) {
+    describe( 'small size', function() {
+      beforeEach( function() {
+        _dom.trigger.click();
+      } );
+
+      it( 'should have suggested search terms', function() {
+        expect( _dom.suggest.isDisplayed() ).toBe( true );
+      } );
+    } );
+  }
+} );


### PR DESCRIPTION
## Additions

- Adds acceptance tests for the global search organism.

## Testing

Tests will run 
- `gulp build`
- `gulp test:acceptance --specs=organisms/global-search.js --sauce=false`
- `gulp test:acceptance --specs=organisms/global-search.js --sauce=false --windowSize=610,700`

## Review

- @sebworks 
- @KimberlyMunoz 
- @kurtw 

## Todos

- This tests things at two window sizes, which need to be manually passed in. We'll want a mechanism to run the tests and have them run through the different sizes automatically *unless* `windowSize` is set.
