### PR TITLE
Fix for nav not functioning on Android 4 devices

### DIFF
--- a/gulp/tasks/styles.js
+++ b/gulp/tasks/styles.js
@@ -23,7 +23,7 @@ gulp.task( 'styles:modern', function() {
       'url("/img/chosen-sprite@2x.png")'
     ) )
     .pipe( $.autoprefixer( {
-      browsers: [ 'last 2 version' ]
+      browsers: [ 'last 2 version', 'android 4']
     } ) )
     .pipe( $.header( banner, { pkg: pkg } ) )
     .pipe( $.sourcemaps.write( '.' ) )


### PR DESCRIPTION
Fix for Android 4 `WebkitTransitionEnd` not firing due to lack of prefix.


## Changes

- Added `Android 4` to the autoprefixer.

## Testing

-  Run `gulp build` and inspect the dom. You should see that `o-mega-menu_content-1` is prefixed with `-webkit-transition`

## Review

- @KimberlyMunoz 
- @anselmbradford 
- @jimmynotjim 

## Screenshots
<img width="487" alt="screen shot 2016-03-30 at 10 29 44 am" src="https://cloud.githubusercontent.com/assets/1696212/14145833/51dc37e0-f663-11e5-8ed9-ae1579811652.png">


## Notes

-

## Todos

-

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
