### PR TITLE
Fixes macro unit tests

### DIFF
--- a/cfgov/v1/forms.py
+++ b/cfgov/v1/forms.py
@@ -13,7 +13,6 @@ from django.contrib.auth import authenticate
 from django.conf import settings
 from django.forms import widgets
 
-from sheerlike.templates import get_date_obj
 from .util import ref
 from .models.base import CFGOVPage
 from .util.util import most_common
@@ -109,6 +108,7 @@ class FilterErrorList(ErrorList):
 
 class FilterDateField(forms.DateField):
     def clean(self, value):
+        from sheerlike.templates import get_date_obj
         if value:
             try:
                 value = get_date_obj(value)

--- a/gulp/tasks/test.js
+++ b/gulp/tasks/test.js
@@ -4,7 +4,6 @@ var gulp = require( 'gulp' );
 var $ = require( 'gulp-load-plugins' )();
 var sitespeedio = require( 'gulp-sitespeedio' );
 var childProcess = require( 'child_process' );
-var exec = childProcess.exec;
 var spawn = childProcess.spawn;
 var config = require( '../config' ).test;
 var fsHelper = require( '../utils/fsHelper' );
@@ -36,13 +35,14 @@ gulp.task( 'test:unit:scripts', function( cb ) {
 } );
 
 gulp.task( 'test:unit:macro', function( cb ) {
-  exec( 'python ' + config.tests + '/macro_tests/test_macros.py',
-    function( err, stdout, stderr ) {
-      $.util.log( stdout );
-      $.util.log( stderr );
-      cb( err );
-    }
-  );
+  spawn(
+    'python',
+    [ config.tests + '/macro_tests/test_macros.py' ],
+    { stdio: 'inherit' }
+  )
+    .once( 'close', function() {
+      $.util.log( 'Macro unit tests done!' );
+    } );
 } );
 
 gulp.task( 'test:unit:server', function() {


### PR DESCRIPTION
## Changes

- Fixes https://github.com/cfpb/cfgov-refresh/issues/1760 with feedback from @rosskarchner 
- Exchanges running of macro unit tests via `exec` with `spawn` in hopes of making the macro unit tests more stable.

## Testing

- `gulp test:unit:macro` should pass.
- `gulp test --sauce=false` (or `gulp test` shouldn't stall)

## Review

- @KimberlyMunoz 
- @sebworks 
- @rosskarchner 
