### PR TITLE
fixed incorrect variables and added default to post_date_description …

### DIFF
--- a/cfgov/jinja2/v1/_includes/organisms/post-preview.html
+++ b/cfgov/jinja2/v1/_includes/organisms/post-preview.html
@@ -50,10 +50,10 @@
     <article class="o-post-preview">
         <div class="meta-header">
             <span class="date meta-header_right">
-                {{ controls.post_date_description }} {{ time.render(post.date_published, {'date':true}) }}
+                {{ controls.post_date_description if controls.post_date_description else 'Published'}} {{ time.render(post.date_published, {'date':true}) }}
             </span>
             {# Newsroom Blog category logic #}
-            {% if controls.categories.show_preview_categories %}
+            {% if controls.show_preview_categories %}
                 {% if 'newsroom' in type %}
                     {% if is_blog(post) %}
                         {{ category_slug.render('blog',


### PR DESCRIPTION
fixed incorrect variables and added default to post_date_description to account for post preview snapshot organism

### Testing 
- Load Refresh db
- visit http://localhost:8000/policy-compliance/amicus/
 -  should render correctly and post previews should have `Published` as default text next to date since it wasn't available from the backend
 - <img width="207" alt="screen shot 2016-03-30 at 11 24 04 pm" src="https://cloud.githubusercontent.com/assets/254877/14164566/9967c8ac-f6ce-11e5-8ee5-7be82443fda0.png">


@kurtw @richaagarwal 