### PR TITLE
Adding Validation for Youtube URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Added specific Blog/Newsroom Categories to Related Post options
 - base.html now checks for page (seo) title if exists
 - Added a space before the external icon
+- Added validation for Youtube URLs.
 
 ### Changed
 

--- a/cfgov/v1/migrations/0073_auto_20160331_1100.py
+++ b/cfgov/v1/migrations/0073_auto_20160331_1100.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import django.core.validators
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('v1', '0072_auto_20160331_0209'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='eventpage',
+            name='youtube_url',
+            field=models.URLField(blank=True, help_text=b'Format: https://www.youtube.com/embed/video_id. It can be obtained by clicking on Share > Embed on Youtube.', verbose_name=b'Youtube URL', validators=[django.core.validators.RegexValidator(regex=b'^https?:\\/\\/www\\.youtube\\.com\\/embed\\/.*$')]),
+        ),
+    ]

--- a/cfgov/v1/models/learn_page.py
+++ b/cfgov/v1/models/learn_page.py
@@ -2,6 +2,7 @@ from datetime import datetime
 from localflavor.us.models import USStateField
 
 from django.db import models
+from django.core.validators import RegexValidator
 from wagtail.wagtailcore import blocks
 from wagtail.wagtailcore.models import Page
 from wagtail.wagtaildocs.edit_handlers import DocumentChooserPanel
@@ -169,7 +170,10 @@ class EventPage(AbstractFilterPage):
         related_name='+'
     )
     flickr_url = models.URLField("Flickr URL", blank=True)
-    youtube_url = models.URLField("Youtube URL", blank=True)
+    youtube_url = models.URLField("Youtube URL", blank=True,
+    help_text="Format: https://www.youtube.com/embed/video_id. It can be obtained by clicking on Share > Embed on Youtube.",
+    validators=[ RegexValidator(regex='^https?:\/\/www\.youtube\.com\/embed\/.*$')])
+
     live_stream_availability = models.BooleanField("Streaming?", default=False,
                                                    blank=True)
     live_stream_url = models.URLField("URL", blank=True)


### PR DESCRIPTION
Adding Validation for Youtube URLs on the Event Page.

## Changes

- Modified the `EventPage` class to add validation for Youtube URLs. 

## Testing

- Visit the Wagtail Admin and create an `Event Page`.  Enter `https://youtube.com/embed/zOV4R08i7b8` for the `Youtube URL`. Click `Save Draft`. You should get a validation error because `www` was ommited.


## Screenshot

- 
<img width="1048" alt="screen shot 2016-03-31 at 6 52 41 am" src="https://cloud.githubusercontent.com/assets/1696212/14174060/016c68c2-f710-11e5-9dc8-e55c080985ec.png">


## Review

- @anselmbradford 
- @kave 
- @kurtw 
- @tnferrell 


## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
