### PR TITLE
Fix bug in page.media code

### DIFF
--- a/cfgov/v1/models/base.py
+++ b/cfgov/v1/models/base.py
@@ -298,8 +298,7 @@ class CFGOVPage(Page):
             for child in block.child_blocks.values():
                 self._add_block_js(child, js)
         elif issubclass(type(block), blocks.ListBlock):
-            for child in block.child_block.child_blocks.values():
-                self._add_block_js(child, js)
+            self._add_block_js(block.child_block, js)
 
     # Assign the Media js to the dictionary appropriately
     def _assign_js(self, obj, js):


### PR DESCRIPTION
Expandables were not showing up correctly

## Changes

- List block type blocks are now accessed correctly in page.media code

## Testing

- Go [here](http://content.localhost:8000/cfpb-ombudsman/ombudsman-faqs/) and verify that expandables work right.

## Review

- @kave 
- @richaagarwal 

## Screenshots
![screen shot 2016-03-31 at 10 49 55 am](https://cloud.githubusercontent.com/assets/1412978/14179765/5bfeae26-f72e-11e5-941c-e53317eb66a5.png)

