### PR TITLE
Ensures IE prefixed styles aren't double-generated

### DIFF
--- a/gulp/tasks/styles.js
+++ b/gulp/tasks/styles.js
@@ -24,9 +24,10 @@ gulp.task( 'styles:modern', function() {
     ) )
     .pipe( $.autoprefixer( {
       browsers: [ 'last 2 version',
+                  'not ie <= 8',
                   'android 4',
                   'BlackBerry 7',
-                  'BlackBerry 10']
+                  'BlackBerry 10' ]
     } ) )
     .pipe( $.header( banner, { pkg: pkg } ) )
     .pipe( $.sourcemaps.write( '.' ) )
@@ -49,7 +50,7 @@ gulp.task( 'styles:ie', function() {
       'url("/img/chosen-sprite@2x.png")'
     ) )
     .pipe( $.autoprefixer( {
-      browsers: [ 'IE 7', 'IE 8' ]
+      browsers: [ 'ie 7-8' ]
     } ) )
     .pipe( mqr( {
       width: '75em'

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "capital-framework": "^3.1.1",
     "del": "^2.0.0",
     "gulp": "^3.9.0",
-    "gulp-autoprefixer": "^3.0.2",
+    "gulp-autoprefixer": "^3.1.0",
     "gulp-changed": "^1.2.1",
     "gulp-cssmin": "^0.1.7",
     "gulp-header": "^1.2.2",


### PR DESCRIPTION
## Changes

- Updates autoprefixer version.
- Removes possibility of IE7-8 prefixing from non-ie stylesheet.

## Testing

- `gulp build` should pass. If it doesn't you'll need to run `./frontend.sh`
- Site should still look fine on IE8.

## Review

- @sebworks 
- @KimberlyMunoz 
