### PR TITLE
Removed the ICS download option from the front-end

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 ### Removed
 
 - Removed Georgia usage for the time being.
+- Removed ICS download placeholder from events.
 
 ### Fixed
 

--- a/cfgov/jinja2/v1/events/_macros.html
+++ b/cfgov/jinja2/v1/events/_macros.html
@@ -155,16 +155,6 @@
                 {% else %}
                     {% import 'macros/time.html' as time %}
                     {{ time.render(event.start_dt) }}
-
-                    {# TODO: Replace with real download link #}
-                    {% if event_state == 'future' %}
-                    <a class="event-calendar_download
-                              jump-link
-                              jump-link__download
-                              u-link__disabled">
-                        <span class="jump_link_text">Download .ics</span>
-                    </a>
-                    {% endif %}
                 {% endif %}
                 </div>
           </div>


### PR DESCRIPTION
Removed the ics download from the front-end

## Testing

- Create an event in the future. Under the date, there should be no download option.

## Review

- @sebworks 
- @anselmbradford 

## Screenshots

![image](https://cloud.githubusercontent.com/assets/1860176/14186925/bec8e344-f74e-11e5-9bf6-7b39973a7257.png)

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices
* [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)

