### PR TITLE
Fix filter controls and sublanding page

### DIFF
--- a/cfgov/jinja2/v1/_includes/organisms/post-preview.html
+++ b/cfgov/jinja2/v1/_includes/organisms/post-preview.html
@@ -45,15 +45,18 @@
 
 {% macro render(post, controls, form_id=0, url='') %}
     {% set type = controls.page_type or '' %}
+    {% set date_desc = controls.post_date_description or 'Published' %}
+    {% set cat_controls = controls.categories %}
+    {% set show_categories = cat_controls.show_preview_categories if cat_controls is defined else true %}
     {% set page_url = url or get_protected_url(page) %}
     {% set post_url = get_protected_url(post) %}
     <article class="o-post-preview">
         <div class="meta-header">
             <span class="date meta-header_right">
-                {{ controls.post_date_description if controls.post_date_description else 'Published'}} {{ time.render(post.date_published, {'date':true}) }}
+                {{ date_desc }} {{ time.render(post.date_published, {'date':true}) }}
             </span>
             {# Newsroom Blog category logic #}
-            {% if controls.show_preview_categories %}
+            {% if show_categories %}
                 {% if 'newsroom' in type %}
                     {% if is_blog(post) %}
                         {{ category_slug.render('blog',

--- a/cfgov/jinja2/v1/sublanding-page/index.html
+++ b/cfgov/jinja2/v1/sublanding-page/index.html
@@ -29,11 +29,10 @@
         {% elif 'post_preview_snapshot' in block.block_type %}
             <div class="block 
                         {{ block.block.meta.classname if block.block.meta.classname else '' }}">
-                {% set posts = page.get_browsefilterable_posts(request) %}
                 {% set limit = block.value.limit | int %}
-                {% set num_posts = limit if limit <= posts | length else posts | length %}
-                {% for i in range(num_posts) %}
-                    {{ post_preview.render(posts[i], '', 0, get_protected_url(posts[i].parent())) }}
+                {% set posts = page.get_browsefilterable_posts(request, limit) %}
+                {% for post in posts %}
+                    {{ post_preview.render(post=post[1], controls=none, form_id=post[0], url=get_protected_url(post[1].parent())) }}
                 {% endfor %}
              </div>
         {% elif 'filter_controls' in block.block_type %}

--- a/cfgov/v1/util/util.py
+++ b/cfgov/v1/util/util.py
@@ -80,7 +80,7 @@ def get_form_id(page, get_request):
     if form_ids:
         return form_ids[0]
     else:
-        return None
+        return 0
 
 
 def instanceOfBrowseOrFilterablePages(page):


### PR DESCRIPTION
Updated FilterControls organism's `show_preview_categories` flag was broken on the front end. In fixing this, it unearthed another bug which is solved in here as well. Basically, the posts in the Post Preview Snapshot organism's tags and categories links would be broken because the form_id was never gotten from the pages that the posts existed on.

## Changes

- The `get_browsefilterable_posts` now returns a tuple that is the id of the form where the post came from and the post.

## Testing

- Go [here](http://content.localhost:8000/data-research/research-reports/) and see categories displayed on the post previews. Some don't have them because they don't have categories.
- Go [here](http://content.localhost:8000/policy-compliance/amicus/) and make sure that the posts have categories and that the categories and tags have links that work to link back to the filterable page with the appropriate parameters.

## Review

- @kave 
- @richaagarwal 
