### PR TITLE
add lxml (fix apostrophe issue)

### DIFF
--- a/cfgov/processors/processors_common.py
+++ b/cfgov/processors/processors_common.py
@@ -15,7 +15,7 @@ def update_path(path):
     return path
 
 def fix_links(html):
-    soup = BeautifulSoup(html)
+    soup = BeautifulSoup(html, 'lxml')
     for link in soup.findAll('a'):
         try:
             urldata = urlsplit(link['href'])

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -17,4 +17,4 @@ boto==2.38.0
 django-storages==1.1.8
 django-haystack==2.4.1
 beautifulsoup4==4.4.1
-
+lxml==3.6.0


### PR DESCRIPTION
adds lxml to requirements/base.txt, and ask for it when invoking beautifulsoup during sheer_index

## Additions

- adds lxml to requirements

## Removals

-

## Changes

- explicitly invoke lxml when parsing blog/newsroom HTML

## Testing

 run sheer index under the current flapjack, and you'll notice some ugliness on blog and newsroom pages, for example on http://flapjack.demo.cfpb.gov/about-us/newsroom/cfpb-monthly-complaint-snapshot-examines-debt-collection-complaints/

![screen shot 2016-03-31 at 4 30 52 pm](https://cloud.githubusercontent.com/assets/235397/14189937/066d7020-f75e-11e5-871e-ac555d20e4e6.png)

checkout this code, do a `pip install -r requirements/base.txt`, and re-run sheer_index, and see the problem resolved:

![screen shot 2016-03-31 at 4 32 35 pm](https://cloud.githubusercontent.com/assets/235397/14189976/40dc457e-f75e-11e5-935e-d2b24bba30c3.png)



## Review

- @kurtw @richaagarwal @kave @schaferjh 


## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)

… for links

to fix