### PR TITLE
Fix category links on Blog posts and Newsroom items

### DIFF
--- a/cfgov/jinja2/v1/_includes/article.html
+++ b/cfgov/jinja2/v1/_includes/article.html
@@ -40,7 +40,8 @@
                 {{ category_slug.render(icon,
                         path,
                         'post_slug meta-header_left',
-                        use_blog_category) }}
+                        use_blog_category,
+                        sheerpage=True) }}
             {% endfor %}
         {% elif post.category.0 %}
             {% for icon in post.category %}
@@ -49,7 +50,8 @@
                 {% endif %}
                 {{ category_slug.render(icon,
                         path,
-                        'post_slug meta-header_left') }}
+                        'post_slug meta-header_left',
+                        sheerpage=True) }}
             {% endfor %}
         {% endif %}
         <h1 class="post_heading">


### PR DESCRIPTION
The links on the Category on the Newsroom item page or a Blog Post page are broken. This fixes that.

## Additions

- Add the sheerpage argument to the call from the `article.html` file.

## Testing

- go [here](http://localhost:8000/about-us/newsroom/cfpb-monthly-complaint-snapshot-examines-debt-collection-complaints/) and click the category link 

## Review

- @kave 
- @richaagarwal 

