### PR TITLE
Fix email sharing

### DIFF
--- a/cfgov/jinja2/v1/external-site/index.html
+++ b/cfgov/jinja2/v1/external-site/index.html
@@ -2,8 +2,12 @@
 {% set request_host = 'http://' + request.META.HTTP_HOST %}
 {% set request_referrer = request.META.HTTP_REFERER or request_host %}
 
-{% set request_url_param = request.GET.get('ext_url', '') %}
-{% set external_url = request_url_param or request_host %}
+{% set request_url = request.GET.get('ext_url', '') %}
+{% set request_body = request.GET.get('body') %}
+{% if request_body %}
+  {% set request_url = request_url + "&body=" + request_body %}
+{% endif %}
+{% set external_url = request_url or request_host %}
 
 {% block title -%}
     External Site | Consumer Financial Protection Bureau


### PR DESCRIPTION
Fixes e-mail share to pass in body as well.

## Testing

- If you go to [http://refresh.demo.cfpb.gov/about-us/the-bureau/about-director/](http://refresh.demo.cfpb.gov/about-us/the-bureau/about-director/), and click on the email button, you'll notice it doesn't populate the e-mail with the body parameter.
- Go to [http://localhost:8000/about-us/the-bureau/about-director/](http://localhost:8000/about-us/the-bureau/about-director/), click on the email button, and verify it populates the e-mail with the body parameter. (The subject line is currently empty, but if someone sets that, it should work).
- Click on other external links to verify those still work as before.

## Review

- @kave @rosskarchner @kurtw 

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [x] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)

