### PR TITLE
proof-of-concept: alterative approach for making in-progress work visible on content server

### DIFF
--- a/cfgov/cfgov/urls.py
+++ b/cfgov/cfgov/urls.py
@@ -9,18 +9,17 @@ from sheerlike.views.generic import SheerTemplateView
 from sheerlike.feeds import SheerlikeFeed
 from sheerlike.sites import SheerSite
 
+from core.views import preview_if_content_server
+
 from v1.views import LeadershipCalendarPDFView, unshare, renderDirectoryPDF, \
     change_password, password_reset_confirm, cfpb_login, create_user, edit_user
 
 from wagtail.wagtailadmin import urls as wagtailadmin_urls
 from wagtail.wagtaildocs import urls as wagtaildocs_urls
 from wagtail.wagtailcore import urls as wagtail_urls
-from django.views.generic import RedirectView
 
 from transition_utilities.conditional_urls import include_if_app_enabled
 
-from wagtail.wagtailadmin.forms import PasswordResetForm
-from wagtail.wagtailadmin.views import account
 
 fin_ed = SheerSite('fin-ed-resources')
 
@@ -251,7 +250,10 @@ if settings.DEBUG :
 
 # Catch remaining URL patterns that did not match a route thus far.
 
-urlpatterns.append(url(r'', include(wagtail_urls)))
+if 'STAGING_HOSTNAME' in os.environ:
+    urlpatterns.append(url(r'^((?:[\w\-]+/)*)$', preview_if_content_server, name='wagtail_serve'))
+else:
+    urlpatterns.append(url(r'', include(wagtail_urls)))
 
 from sheerlike import register_permalink
 


### PR DESCRIPTION
This can _probably_ wait until post-launch. 

Basically, this makes it so that on the "Staging" site (like content.refresh) , all drafts are visible, without needing to be "shared". It _doesn't_ make brand new, un-published content show up on lists (like on the events page). I'm not yet sure if this is a big problem or not, or how big the effort would be to make that work.

In this world 'publishing' is publishing to production, and nothing special needs to be done to make drafts visible to stakeholders.
## Additions
- If the STAGING_HOSTNAME environment variable is defined, instead of the default wagtail catch-all URL pattern, it adds one that points to [this function](https://github.com/rosskarchner/cfgov-refresh/blob/alternate-sharing-idea/cfgov/core/views.py#L19), which, if the current hostname matches STAGING_HOSTNAME, will serve the latest draft of any content.
## Removals
- Fully implemented, this would involve removing most/all of our "sharing" logic. That hasn't been done on this branch _yet_
## Testing
- check out this PR
- In wagtail, go into 'sites' and make sure the secondary site has a hostname of 'content.localhost' and port 8000 (this may not be the case if you've recently imported another database, like refresh)
  ![screen shot 2016-04-01 at 8 42 50 am](https://cloud.githubusercontent.com/assets/235397/14207102/dd0ee14a-f7e5-11e5-9708-65b2daf09c34.png)
- edit any wagtail page (like Amicus) to add a bit of your own flavor, and SAVE (not publish or share) it. confirm that the change is NOT visible on plain old localhost:

![screen shot 2016-04-01 at 8 30 23 am](https://cloud.githubusercontent.com/assets/235397/14207019/56562bcc-f7e5-11e5-8b62-ff26f146e791.png)

![screen shot 2016-04-01 at 8 30 41 am](https://cloud.githubusercontent.com/assets/235397/14207120/feaf6ce8-f7e5-11e5-805f-22319670d576.png)
- confirm that your change IS visible on content.localhost:

![screen shot 2016-04-01 at 8 31 10 am](https://cloud.githubusercontent.com/assets/235397/14207157/3d355554-f7e6-11e5-9cc9-77137faf97c7.png)
## Review
- @richaagarwal @kave @kurtw @tnferrell  @sarahsimpson09 @Schlachtmeyer @schaferjh
## Todos
- [ ] remove (or at least disable) sharing code
## Checklist
- [x] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
- [ ] Passes all existing automated tests
- [ ] New functions include new tests
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged
- [ ] Visually tested in supported browsers and devices
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
