### PR TITLE
Fix for no max res image

### DIFF
--- a/cfgov/jinja2/v1/_includes/macros/video-player.html
+++ b/cfgov/jinja2/v1/_includes/macros/video-player.html
@@ -34,10 +34,12 @@
     {% set video_player = options.video.player or
                           ( video_url.find( 'youtube.com') > -1 and 'youtube' ) or
                           ( video_url.find( 'ustream.tv') and 'ustream' ) %}
+    {% set image_url = '/static/img/cfpb_video_cover_card_1380x776.png' %}
+    {% set video_id = options.video.id | default('') %}
+
     {# TODO: Replace with django method for getting video id if youtube and urlparams #}
     {% if video_player == 'youtube' -%}
-        {% set video_id = options.video.id or ( video_url.split('?')[0].split('/') | last ) %}
-        {% set image_url = options.image.url or ( 'https://img.youtube.com/vi/' + video_id + '/maxresdefault.jpg' ) %}
+        {% set video_id =  video_url.split('?')[0].split('/') | last %}
         {% if video_url.find( '?' ) == -1 -%}
             {% set video_url = video_url ~ '?'  %}
         {% endif %}
@@ -50,17 +52,13 @@
         {% if video_url.find( 'origin=' ) == -1 -%}
             {% set video_url = _buildParam( video_url, 'origin=http://' ~ request.META['HTTP_HOST'] )  %}
         {% endif %}
-    {% else %}
-        {% set video_id = '' %}
-        {% set image_url = '/static/img/cfpb_video_cover_card_1380x776.png' %}
     {% endif %}
-
     {% set button_pos   = options.button_pos or 'center' %}
     {% set is_flexible  = ( options.video.width or options.video.height ) is not defined %}
     <div class="video-player
                 video-player__{{ video_player }}
-                {{ 'featured-content-module_visual' if is_flexible == false }}"
-         {{ "data-id="~video_id | trim if video_id else '' }}
+                {{ 'featured-content-module_visual' if is_flexible == false else '' }}"
+         {{ "data-id=" ~ video_id  if video_id else '' }}
          data-src="{{ video_url }}"
          data-width="{{ options.video.width if options.video.width else '' }}"
          data-height="{{ options.video.height if options.video.height else '' }}">

--- a/cfgov/unprocessed/css/video-player.less
+++ b/cfgov/unprocessed/css/video-player.less
@@ -48,13 +48,23 @@
     }
 }
 
-// Video image container related styles
+// Video image related styles
 
 .video-player_image-container {
     position: relative;
     // @black not used because it's not totally black.
     background-color: #000;
     text-align: center;
+}
+
+.video-player_image {
+    opacity: 0;
+    transition: opacity .25s;
+
+    .no-js &,
+    &-loaded {
+        opacity: 1;
+    }
 }
 
 .video-player_play-btn {

--- a/cfgov/unprocessed/js/modules/VideoPlayer.js
+++ b/cfgov/unprocessed/js/modules/VideoPlayer.js
@@ -14,14 +14,14 @@ var DOM_INVALID = require( '../config/error-messages-config' ).DOM.INVALID;
 var CLASSES = Object.freeze( {
   VIDEO_PLAYER_SELECTOR:     '.video-player',
   VIDEO_PLAYING_STATE:       'video-playing',
+  IMAGE_SELECTOR:            '.video-player_image',
   IFRAME_CLASS_NAME:         'video-player_iframe',
   IFRAME_CONTAINER_SELECTOR: '.video-player_iframe-container',
   PLAY_BTN_SELECTOR:         '.video-player_play-btn',
   CLOSE_BTN_SELECTOR:        '.video-player_close-btn'
 } );
 
-
-// PRIVATE properties.
+// Private properties.
 var _isIframeLoaded;
 var _isIframeLoading;
 var _isVideoPlaying;
@@ -40,8 +40,6 @@ function VideoPlayer( element, options ) {
   _this = this;
   options = options || {};
   this.baseElement = _ensureElement( element, options.createIFrame );
-
-  // TODO: Add utility function for dataset. Oh dear IE, how I love you.
   this.iFrameProperties = _assign( _dataSet( this.baseElement ) ||
     {}, this.iFrameProperties );
 
@@ -207,6 +205,7 @@ var API = {
   baseElement: null,
 
   childElements: {
+    image:           CLASSES.IMAGE_SELECTOR,
     iFrame:          CLASSES.IFRAME_SELECTOR,
     iFrameContainer: CLASSES.IFRAME_CONTAINER_SELECTOR,
     playBtn:         CLASSES.PLAY_BTN_SELECTOR,
@@ -227,6 +226,7 @@ var API = {
   * @param {function} callback - function called when script is loaded.
   */
   embedScript: function embedScript( script, callback ) {
+
     /**
     * Function called when script is loaded.
     */

--- a/cfgov/unprocessed/js/modules/util/data-set.js
+++ b/cfgov/unprocessed/js/modules/util/data-set.js
@@ -1,5 +1,7 @@
 'use strict';
 
+var _assign = require( './assign' ).assign;
+
 /**
  * Converts a string from selector-case to camelCase.
  * @param {string} str - The string in selector-case form.
@@ -19,7 +21,9 @@ function _toCamelCase( str ) {
  * @returns {Object} The data set.
  */
 function dataSet( element ) {
-  if ( document.documentElement.dataset ) return element.dataset;
+  if ( document.documentElement.dataset ) {
+    return _assign({}, element.dataset );
+  }
 
   var dataset = {};
   var regex = /^data-(.+)/;


### PR DESCRIPTION
Certain youtube videos don't have a max res image. This fixes that by using Javascript to check for the image and using a default if not present.

## Changes

- Made changes to the JS to create the image.

## Testing

- Visit `http://localhost:8000/about-us/the-bureau/` and turn JS on and off.

## Review

- @anselmbradford 
- @KimberlyMunoz 

## Screenshots

-  
<img width="1019" alt="screen shot 2016-04-01 at 10 51 28 am" src="https://cloud.githubusercontent.com/assets/1696212/14210609/bcd69096-f7f7-11e5-87cd-93fc4c927600.png">
<img width="1017" alt="screen shot 2016-04-01 at 10 51 21 am" src="https://cloud.githubusercontent.com/assets/1696212/14210608/bccad058-f7f7-11e5-9f6d-316e81c0c140.png">

## Notes
- This also fixes an error in the Jinja template due to no `else` condition.

## Todos

- I will eventually replace this method with a call to the Youtube data API, which should return a list of available images. This method will however be slower, more complex, and require a API key.

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
