### PR TITLE
social media sharing fixes

### DIFF
--- a/cfgov/jinja2/v1/_includes/article.html
+++ b/cfgov/jinja2/v1/_includes/article.html
@@ -81,15 +81,12 @@
                 {{ time.render(post.date, {'date':true}) }}
             </span>
         </div>
-        {{ social_media.render({
-            'title': post.title,
-            'twitter_options': {
-                'text':     post.twtr_text,
-                'related':  post.twtr_rel,
-                'language': post.twtr_lang,
-                'hashtags': post.twtr_hash
-            }
-        }) }}
+        {{ social_media.render( {
+            'title':            post.title,
+            'twitter_related':  post.twtr_rel,
+            'twitter_lang':     post.twtr_lang,
+            'twitter_hashtags': post.twtr_hash
+        } ) }}
     {% if post.thumbnail.images %}
         <img class="post_featured-img"
              src="{{ post.thumbnail.images.full.url }}"
@@ -97,12 +94,12 @@
     {% endif %}
     </header>
     <div class="post_body">
-        {{ post.content|safe }}
+        {{ post.content | safe }}
     </div>
-{% if post.tags|length %}
+{% if post.tags | length %}
     <footer>
         {%- import 'tags.html' as tags %}
-        {{ tags.render(post.tags, path, is_sheer=True) }}
+        {{ tags.render( post.tags, path, is_sheer=True ) }}
     </footer>
 {% endif %}
 </article>

--- a/cfgov/jinja2/v1/_includes/macros/footer-global.html
+++ b/cfgov/jinja2/v1/_includes/macros/footer-global.html
@@ -53,7 +53,7 @@
                         block__flush-top
                         block__flush-bottom
                         block__padded-top">
-                {{ social_media.render( is_share_view=false ) }}
+                {{ social_media.render( { 'is_share_view': false } ) }}
             </div>
         </div><!-- END .footer-pre -->
 

--- a/cfgov/jinja2/v1/_includes/molecules/social-media.html
+++ b/cfgov/jinja2/v1/_includes/molecules/social-media.html
@@ -8,10 +8,10 @@
 
    Creates markup for Social Media molecule.
 
-   is_share_view: Whether the "Share this" heading is shown.
-                  Default is true.
-
    options:       Object of optional parameters.
+
+   options.is_share_view:    Whether the "Share this" heading is shown.
+                             Default is true.
 
    options.title:            Sets the title in email subject line
                              and in the LinkedIn share post.
@@ -21,20 +21,23 @@
                              to be appended to default Tweet text.
                              https://dev.twitter.com/web/tweet-button/parameters
 
-   options.twitter_related: A comma-separated list of accounts
-                            related to the content of the shared URI.
-                            https://dev.twitter.com/web/tweet-button/parameters
+   options.twitter_related:  A comma-separated list of accounts
+                             related to the content of the shared URI.
+                             https://dev.twitter.com/web/tweet-button/parameters
+                             Default is `cfpb`.
 
-   options.twitter_lang:    Loads text components in the specified language.
-                            https://dev.twitter.com/web/tweet-button/parameters
+   options.twitter_lang:     Loads text components in the specified language,
+                             if other than English.
+                             https://dev.twitter.com/web/tweet-button/parameters
 
    ========================================================================== #}
 
 {# TODO: Remove global page reference when moving to Wagtail. #}
-{% macro render(is_share_view=true, options={}) %}
+{% macro render( options={} ) %}
 {% set title = options.title | urlencode or ( page or {} ).seo_title | urlencode  %}
 {% set parsed_url = request.url | urlencode %}
 {% set external_redirect_url = '/external-site/?ext_url=' %}
+{% set is_share_view = options.is_share_view | default( true ) %}
 <div class="m-social-media
             m-social-media__{{ 'share' if is_share_view else 'follow' }}">
     {% if is_share_view %}
@@ -107,7 +110,7 @@
             {% if is_share_view %}
                 <li class="list_item">
                     <a class="m-social-media_icon"
-                       href="{{ external_redirect_url ~ link.share_url }}"
+                       href="{{ external_redirect_url ~ link.share_url | trim }}"
                        {{ 'target=_blank' if link.name != 'email' else '' }}>
                         <span class="cf-icon {{ link.class }}"></span>
                         <span class="u-visually-hidden">Share on {{ link.name }}</span>
@@ -116,7 +119,7 @@
             {% else %}
                 <li class="list_item">
                     <a class="m-social-media_icon"
-                       href="{{ external_redirect_url ~ link.homepage }}">
+                       href="{{ external_redirect_url ~ link.homepage | trim }}">
                         <span class="cf-icon {{ link.class }}"></span>
                         <span class="u-visually-hidden">Visit us on {{ link.name }}</span>
                     </a>
@@ -139,6 +142,8 @@
     {% endif -%}
     {%- if options.twitter_related %}
         {% set _share_twitter_url = _share_twitter_url + '&related=' + options.twitter_related %}
+    {%- else %}
+        {% set _share_twitter_url = _share_twitter_url + '&related=cfpb' %}
     {% endif -%}
     {%- if options.twitter_lang %}
         {% set _share_twitter_url = _share_twitter_url + '&lang=' + options.twitter_lang %}

--- a/cfgov/jinja2/v1/about-us/careers/_single.html
+++ b/cfgov/jinja2/v1/about-us/careers/_single.html
@@ -52,14 +52,10 @@
             <div class="t-careers_social
                         content-l_col
                         content-l_col-1-2">
-                {{ social_media.render({
-                    'title': career.title,
-                    'twitter_options': {
-                        'text':     career.title,
-                        'related':  '@cfpb',
-                        'hashtags': '#usajobs'
-                    }
-                }) }}
+                {{ social_media.render( {
+                    'title':            career.title,
+                    'twitter_hashtags': 'usajobs'
+                } ) }}
             </div>
         </div>
     </section>
@@ -98,14 +94,10 @@
                 {# TODO: Fix vertical alignment.
                          Social Media icons are slightly high
                          relative to Interested in Applying heading. #}
-                {{ social_media.render({
-                    'title': career.title,
-                    'twitter_options': {
-                        'text':     career.title,
-                        'related':  '@cfpb',
-                        'hashtags': '#usajobs'
-                    }
-                }) }}
+                {{ social_media.render( {
+                    'title':            career.title,
+                    'twitter_hashtags': 'usajobs'
+                } ) }}
             </div>
         </div>
         <div class="block">

--- a/cfgov/jinja2/v1/events/_event-detail.html
+++ b/cfgov/jinja2/v1/events/_event-detail.html
@@ -19,15 +19,12 @@
                 {{ time.render(page.latest_revision_created_at, {'date':true}) }}
             </div>
             {% import 'molecules/social-media.html' as social_media with context %}
-            {{ social_media.render({
-                'title': page.title,
-                'twitter_options': {
-                    'text':     page.twtr_text,
-                    'related':  page.twtr_rel,
-                    'language': page.twtr_lang,
-                    'hashtags': page.twtr_hash
-                }
-            }) }}
+            {{ social_media.render( {
+                'title':            page.twtr_text,
+                'twitter_related':  page.twtr_rel,
+                'twitter_lang':     page.twtr_lang,
+                'twitter_hashtags': page.twtr_hash
+            } ) }}
         </div>
         {% from 'events/_macros.html' import event_venue as event_venue %}
         {{ event_venue( page, event_state ) }}
@@ -95,7 +92,7 @@
     {% if page.tags.names() | length %}
     <footer>
         {%- import 'tags.html' as tags %}
-        {{ tags.render(page.tags.names(), path) }}
+        {{ tags.render( page.tags.names(), path ) }}
     </footer>
     {% endif %}
 </article>


### PR DESCRIPTION
## Changes

- social media molecule updates:
  - Includes `is_share_view` in `options`.
  - Makes related account `@CFPB` by default
  - Trims URL so it's not padded with whitespace when handed to /external-site/.

## Testing

- Share icons in the footer should not have "Share this"
- Share icons in careers, events, the bureau, and blog should have "Share this"
- Twitter share button URLs should have `&related=cfpb` in them (**note: /external-site/ seems to be stripping these**)

## Review

- @kave 
- @kurtw 
- @richaagarwal 
- @sebworks 
- @KimberlyMunoz 

## Todos

- The default title seems broken for tweets. Tagging bewds below...
