### PR TITLE
Organize/cleanup style/scripts tasks

### DIFF
--- a/config/webpack-config.js
+++ b/config/webpack-config.js
@@ -14,7 +14,7 @@ var webpack = require( 'webpack' );
 var JS_ROUTES_PATH = '/js/routes';
 var COMMON_BUNDLE_NAME = 'common.js';
 
-module.exports = {
+var modernConf = {
   // jQuery is exported in the global space in the head.
   externals: { jquery: 'jQuery' },
   context:   path.join( __dirname, '/../', paths.unprocessed, JS_ROUTES_PATH ),
@@ -35,4 +35,21 @@ module.exports = {
     // Wrap JS in raw Jinja tags so included JS won't get parsed by Jinja.
     new BannerFooterPlugin( '{% raw %}', '{% endraw %}', { raw: true } )
   ]
+};
+
+var ieConf = {
+  entry: paths.unprocessed + '/js/ie/common.ie.js',
+  output: {
+    filename: 'common.ie.js'
+  },
+  plugins: [
+    new webpack.optimize.UglifyJsPlugin( {
+      compress: { warnings: false }
+    } )
+  ]
+};
+
+module.exports = {
+  modernConf:  modernConf,
+  ieConf:      ieConf
 };

--- a/gulp/tasks/scripts.js
+++ b/gulp/tasks/scripts.js
@@ -17,7 +17,12 @@ var paths = require( '../../config/environment' ).paths;
 var webpackConfig = require( '../../config/webpack-config.js' );
 var webpackStream = require( 'webpack-stream' );
 
-gulp.task( 'scripts:modern', function() {
+
+/**
+ * Generate modernizr polyfill bundle.
+ * @returns {PassThrough} A source stream.
+ */
+function scriptsPolyfill() {
   return gulp.src( paths.unprocessed + '/js/routes/common.js' )
     .pipe( gulpModernizr( {
       tests:   [ 'csspointerevents', 'classlist' ],
@@ -27,32 +32,48 @@ gulp.task( 'scripts:modern', function() {
     } ) )
     .pipe( gulpUglify() )
     .pipe( gulpRename( 'modernizr.min.js' ) )
+    .on( 'error', handleErrors )
     .pipe( gulp.dest( paths.processed + '/js/' ) )
-    .pipe( webpackStream( webpackConfig ) )
+    .pipe( browserSync.reload( {
+      stream: true
+    } ) );
+}
+
+/**
+ * Bundle scripts in unprocessed/js/routes/
+ * and factor out common modules into common.js.
+ * @returns {PassThrough} A source stream.
+ */
+function scriptsModern() {
+  return gulp.src( paths.unprocessed + '/js/routes/common.js' )
+    .pipe( webpackStream( webpackConfig.modernConf ) )
     .on( 'error', handleErrors )
     .pipe( gulp.dest( paths.processed + '/js/routes/' ) )
     .pipe( browserSync.reload( {
       stream: true
     } ) );
-} );
+}
 
-gulp.task( 'scripts:ie', function() {
+/**
+ * Bundle IE9-specific script.
+ * @returns {PassThrough} A source stream.
+ */
+function scriptsIe() {
   return gulp.src( paths.unprocessed + '/js/ie/common.ie.js' )
-    .pipe( webpackStream( {
-      entry: paths.unprocessed + '/js/ie/common.ie.js',
-      output: {
-        filename: 'common.ie.js'
-      }
-    } ) )
+    .pipe( webpackStream( webpackConfig.ieConf ) )
     .on( 'error', handleErrors )
-    .pipe( gulpUglify() )
     .pipe( gulp.dest( paths.processed + '/js/ie/' ) )
     .pipe( browserSync.reload( {
       stream: true
     } ) );
-} );
+}
+
+gulp.task( 'scripts:polyfill', scriptsPolyfill );
+gulp.task( 'scripts:modern', scriptsModern );
+gulp.task( 'scripts:ie', scriptsIe );
 
 gulp.task( 'scripts', [
+  'scripts:polyfill',
   'scripts:modern',
   'scripts:ie'
 ] );

--- a/gulp/tasks/styles.js
+++ b/gulp/tasks/styles.js
@@ -9,19 +9,15 @@ var config = require( '../config' ).styles;
 var handleErrors = require( '../utils/handleErrors' );
 var browserSync = require( 'browser-sync' );
 
-gulp.task( 'styles:modern', function() {
+/**
+ * Process modern CSS.
+ * @returns {PassThrough} A source stream.
+ */
+function stylesModern() {
   return gulp.src( config.cwd + config.src )
     .pipe( $.sourcemaps.init() )
     .pipe( $.less( config.settings ) )
     .on( 'error', handleErrors )
-    .pipe( $.replace(
-      /url\('chosen-sprite.png'\)/ig,
-      'url("/img/chosen-sprite.png")'
-    ) )
-    .pipe( $.replace(
-      /url\('chosen-sprite@2x.png'\)/ig,
-      'url("/img/chosen-sprite@2x.png")'
-    ) )
     .pipe( $.autoprefixer( {
       browsers: [ 'last 2 version',
                   'not ie <= 8',
@@ -35,20 +31,16 @@ gulp.task( 'styles:modern', function() {
     .pipe( browserSync.reload( {
       stream: true
     } ) );
-} );
+}
 
-gulp.task( 'styles:ie', function() {
+/**
+ * Process legacy CSS for IE7 and 8 only.
+ * @returns {PassThrough} A source stream.
+ */
+function stylesIe() {
   return gulp.src( config.cwd + config.src )
     .pipe( $.less( config.settings ) )
     .on( 'error', handleErrors )
-    .pipe( $.replace(
-      /url\('chosen-sprite.png'\)/ig,
-      'url("/img/chosen-sprite.png")'
-    ) )
-    .pipe( $.replace(
-      /url\('chosen-sprite@2x.png'\)/ig,
-      'url("/img/chosen-sprite@2x.png")'
-    ) )
     .pipe( $.autoprefixer( {
       browsers: [ 'ie 7-8' ]
     } ) )
@@ -65,7 +57,10 @@ gulp.task( 'styles:ie', function() {
     .pipe( browserSync.reload( {
       stream: true
     } ) );
-} );
+}
+
+gulp.task( 'styles:modern', stylesModern );
+gulp.task( 'styles:ie', stylesIe );
 
 gulp.task( 'styles', [
   'styles:modern',


### PR DESCRIPTION
## Changes

- Creates separate webpack config objects for modern and IE.
- Moves IE script uglifying to webpack Uglifier plugin instead of gulp.
- Moves modernizr generation to its own task `gulp scripts:polyfill`. (@jimmynotjim – you're right, this makes sense.)
- Moves task functions to named functions.
- Remove `replace` for chosen-sprite, since chosen has been removed in https://github.com/cfpb/cfgov-refresh/pull/1576

## Testing

- `gulp build` site should work on modern browsers and IE9 as before.

## Review

- @sebworks 
- @KimberlyMunoz 
- @jimmynotjim 
