### PR TITLE
Dfjr 930 non v1 header - PROTOTYPE

### DIFF
--- a/cfgov/cfgov/urls.py
+++ b/cfgov/cfgov/urls.py
@@ -250,6 +250,7 @@ if 'selfregistration' in settings.INSTALLED_APPS:
     urlpatterns.append(pattern)
 
 if settings.DEBUG :
+    urlpatterns.append(url(r'^test-fixture/$', SheerTemplateView.as_view(template_name='test-fixture/index.html'), name='test-fixture'))
     urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
 
 # Catch remaining URL patterns that did not match a route thus far.

--- a/cfgov/jinja2/v1/_includes/organisms/header.html
+++ b/cfgov/jinja2/v1/_includes/organisms/header.html
@@ -1,7 +1,25 @@
+{# ==========================================================================
+
+   header.render()
+
+   ==========================================================================
+
+   Description:
+
+   Creates markup for Header organism.
+
+   show_banner: Whether the global banner molecule is included.
+                Default is true.
+
+   ========================================================================== #}
+
+{# TODO: Remove global page reference when moving to Wagtail. #}
+{% macro render( show_banner=false ) %}
+
 <header class="o-header"
         role="banner">
 
-    {% if flag_enabled('BETA_NOTICE') %}
+    {% if flag_enabled('BETA_NOTICE') and show_banner %}
     <div class="m-global-banner">
         <div class="wrapper
                     wrapper__match-content
@@ -70,3 +88,5 @@
 
     </div>
 </header>
+
+{% endmacro %}

--- a/cfgov/jinja2/v1/_layouts/base.html
+++ b/cfgov/jinja2/v1/_layouts/base.html
@@ -143,7 +143,8 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <a href="#main" id="skip-nav">Skip to main content</a>
 
 {% block header %}
-    {% include 'organisms/header.html' %}
+    {% import 'organisms/header.html' as o_header with context %}
+    {{ o_header.render( show_banner=true ) }}
 {% endblock header %}
 
 {# WAGTAILUSERBAR IN-PAGE VIEW CONTROLS #}

--- a/cfgov/jinja2/v1/templatetags/global_include.py
+++ b/cfgov/jinja2/v1/templatetags/global_include.py
@@ -1,0 +1,10 @@
+from django import template
+
+import sheerlike
+
+register = template.Library()
+
+
+@register.simple_tag
+def global_include(name):
+    return sheerlike.global_render_template(name)

--- a/cfgov/jinja2/v1/test-fixture/index.html
+++ b/cfgov/jinja2/v1/test-fixture/index.html
@@ -1,0 +1,124 @@
+{# ==========================================================================
+
+   Minimal template for rendering out an atomic component in sudo isolation.
+
+   ========================================================================== #}
+
+{% set atomic_type = request.GET.get( 'atomic' ) %}
+{# Set to the Header organism by default. #}
+{% set atomic_type = 'header' if atomic_type == None else atomic_type %}
+
+<!DOCTYPE html>
+
+<!--[if IE 8]>         <html lang="en" class="no-js lt-ie10 lt-ie9"> <![endif]-->
+<!--[if IE 9]>         <html lang="en" class="no-js lt-ie10"> <![endif]-->
+<!--[if gt IE 8]><!--> <html lang="en" class="no-js"> <!--<![endif]-->
+
+<head prefix="og: http://ogp.me/ns# fb: http://ogp.me/ns/fb# {% block og_article_prefix %}{% endblock %}">
+
+<!--
+    ===========
+    GLOBAL META
+    ===========
+-->
+
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta charset="utf-8">
+    {% block meta_viewport %}
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    {% endblock meta_viewport %}
+
+<!--
+    ==================
+    PAGE-SPECIFIC META
+    ==================
+-->
+
+    <title>{% block title %}MISSING TITLE{% endblock title %}</title>
+    <meta name="description"
+          content="{% block desc %}Prototyping for the consumerfinance.gov refresh{% endblock %}">
+
+    <!-- Open Graph properties -->
+        <!--   Required  -->
+        <meta property="og:title" content="{% block og_title %}{{ self.title() }}{% endblock %}">
+        <meta property="og:type" content="{% block og_type %}website{% endblock %}">
+        <meta property="og:url" content="{{ request.url }}">
+        <meta property="og:image"
+              content="http://www.consumerfinance.gov/wp-content/themes/cfpb_nemo/_/img/logo.svg">
+        <!--   Optional -->
+        <meta property="og:description" content="{% block og_desc %}{{ self.desc() }}{% endblock %}">
+        <meta property="og:site_name" content="Consumer Financial Protection Bureau">
+        <!--   Facebook -->
+        <meta property="fb:app_id" content="210516218981921">
+        {% block og_article_author %}{% endblock %}
+    <!-- End of Open Graph properties -->
+
+    {# TODO: Explicit favicon link needed for testing. Remove for production. #}
+    <link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+{#
+    ============
+    ONDEMAND CSS
+    ============
+    The atomic CSS file. This includes legacy IE-specific prefixing.
+#}
+<link rel="stylesheet" href="{{ static('css/' + atomic_type + '.css') }}">
+
+{#
+    ================
+    POLYFILL SCRIPTS
+    ================
+    The following scripts must be included in the <head>
+    and are used to polyfill missing functionality in legacy browsers.
+#}
+    {# Customized Modernizr build that includes html5shiv.
+       Built via gulp-modernizer in `scripts.js` task. #}
+    <script src="{{ static('js/modernizr.min.js') }}"></script>
+
+    <!--[if lt IE 9]>
+    <script>
+        // If in IE8 reverse no-js/js class change made by modernizr.
+        var docElement = document.documentElement;
+        docElement.className = docElement.className.replace( /(^|\s)js(\s|$)/, '$1no-js$2' );
+    </script>
+    <![endif]-->
+
+    <!--[if IE 9]><script src="{{ static('js/ie/common.ie.js') }}"></script><![endif]-->
+{#
+    ====================
+    END POLYFILL SCRIPTS
+    ====================
+#}
+</head>
+
+<body>
+
+{#
+    =================
+    ONDEMAND TEMPLATE
+    =================
+    The jinja template and associate HTML to include for an atomic component.
+#}
+{% if atomic_type == 'header' %}
+
+    {# Overlay for the page. Used for the mobile mega menu. #}
+    <div class="a-overlay u-hidden"></div>
+
+    {% import 'organisms/header.html' as o_header with context %}
+    {{ o_header.render() }}
+
+{% endif %}
+
+{#
+    ===============
+    ONDEMAND SCRIPT
+    ===============
+    The atomic JS file. This needs to be delivered either:
+    (a) At the bottom of the <body> (as shown).
+    (b) In the <head> with the `defer` and `async` attributes
+        set on the <script> tag.
+#}
+<script type="text/javascript" src="{{ static('js/atomic/' + atomic_type + '.js') }}"></script>
+
+</body>
+
+</html>

--- a/cfgov/sheerlike/__init__.py
+++ b/cfgov/sheerlike/__init__.py
@@ -8,6 +8,8 @@ import warnings
 from django.contrib.staticfiles.storage import staticfiles_storage
 from django.core.urlresolvers import reverse
 from django.conf import settings
+from django.template import loader, RequestContext
+from django.utils.html import mark_safe
 
 from jinja2 import Environment
 import jinja2.runtime
@@ -28,6 +30,13 @@ default_app_config = 'sheerlike.apps.SheerlikeConfig'
 
 def register_permalink(sheer_type, url_pattern_name):
     PERMALINK_REGISTRY[sheer_type] = url_pattern_name
+
+
+def global_render_template(name, **kwargs):
+    request = get_request()
+    context = RequestContext(request, kwargs or None)
+    template = loader.get_template(name, using='wagtail-env')
+    return mark_safe(template.render(context.flatten()))
 
 
 def url_for(app, filename, site_slug=None):

--- a/cfgov/unprocessed/css/enhancements/base.less
+++ b/cfgov/unprocessed/css/enhancements/base.less
@@ -21,4 +21,7 @@ body {
   .webfont-regular();
 }
 
-
+/* topdoc
+  name: EOF
+  eof: true
+*/

--- a/cfgov/unprocessed/css/enhancements/buttons.less
+++ b/cfgov/unprocessed/css/enhancements/buttons.less
@@ -23,3 +23,8 @@
         }
     });
 }
+
+/* topdoc
+  name: EOF
+  eof: true
+*/

--- a/cfgov/unprocessed/css/enhancements/code.less
+++ b/cfgov/unprocessed/css/enhancements/code.less
@@ -17,3 +17,8 @@
     color: @black;
     font-size: unit(14px / @base-font-size-px, em);
 }
+
+/* topdoc
+  name: EOF
+  eof: true
+*/

--- a/cfgov/unprocessed/css/enhancements/expandables.less
+++ b/cfgov/unprocessed/css/enhancements/expandables.less
@@ -103,3 +103,8 @@
 .expandable-group_items .expandable:first-child {
     border-top: 1px solid @expandable-group-divider;
 }
+
+/* topdoc
+  name: EOF
+  eof: true
+*/

--- a/cfgov/unprocessed/css/enhancements/forms.less
+++ b/cfgov/unprocessed/css/enhancements/forms.less
@@ -281,3 +281,8 @@ input {
         }
     }
 }
+
+/* topdoc
+  name: EOF
+  eof: true
+*/

--- a/cfgov/unprocessed/css/enhancements/grid.less
+++ b/cfgov/unprocessed/css/enhancements/grid.less
@@ -62,3 +62,8 @@
         content: '';
     }
 }
+
+/* topdoc
+  name: EOF
+  eof: true
+*/

--- a/cfgov/unprocessed/css/enhancements/icons.less
+++ b/cfgov/unprocessed/css/enhancements/icons.less
@@ -1,5 +1,3 @@
-
-
 /* topdoc
   name: Icon list modifier
   family: cfgov-cf-enhancements
@@ -39,7 +37,6 @@
         .list__icons .list_icon__left();
     }
 }
-
 
 /* topdoc
   name: List icon left modifier
@@ -138,3 +135,8 @@
         text-align: right;
     }
 }
+
+/* topdoc
+  name: EOF
+  eof: true
+*/

--- a/cfgov/unprocessed/css/enhancements/layout.less
+++ b/cfgov/unprocessed/css/enhancements/layout.less
@@ -1,5 +1,3 @@
-
-
 /* topdoc
   name: Block
   family: cf-layout
@@ -36,7 +34,6 @@
     }
 });
 
-
 /* topdoc
   name: Half top padding
   family: cf-layout
@@ -61,7 +58,6 @@
     });
 }
 
-
 /* topdoc
   name: Flush sides on small devices
   family: cf-layout
@@ -83,7 +79,6 @@
         border-width: 0;
     });
 }
-
 
 /* topdoc
   name: Code styles
@@ -201,7 +196,11 @@
 
 }
 
-
 .featured-content-module_visual.video-playing {
     left: 0;
 }
+
+/* topdoc
+  name: EOF
+  eof: true
+*/

--- a/cfgov/unprocessed/css/enhancements/media-queries.less
+++ b/cfgov/unprocessed/css/enhancements/media-queries.less
@@ -81,3 +81,8 @@
         @rules();
     }
 }
+
+/* topdoc
+  name: EOF
+  eof: true
+*/

--- a/cfgov/unprocessed/css/enhancements/print.less
+++ b/cfgov/unprocessed/css/enhancements/print.less
@@ -18,3 +18,8 @@
         color: @green;
     });
 }
+
+/* topdoc
+  name: EOF
+  eof: true
+*/

--- a/cfgov/unprocessed/css/enhancements/tables.less
+++ b/cfgov/unprocessed/css/enhancements/tables.less
@@ -1,4 +1,3 @@
-
 /* topdoc
   name: Tables
   family: cf-tables
@@ -13,7 +12,6 @@
         width: 100%;
     }
 });
-
 
 /* topdoc
   name: Simple Table
@@ -147,3 +145,8 @@
         }
     });
 }
+
+/* topdoc
+  name: EOF
+  eof: true
+*/

--- a/cfgov/unprocessed/css/enhancements/typography.less
+++ b/cfgov/unprocessed/css/enhancements/typography.less
@@ -1,4 +1,3 @@
-
 /* topdoc
   name: Download links list
   family: cfgov-cf-enhancements
@@ -428,3 +427,8 @@ ul:last-child,
         margin-bottom: unit(10px / @base-font-size-px, em);
     }
 }
+
+/* topdoc
+  name: EOF
+  eof: true
+*/

--- a/cfgov/unprocessed/css/enhancements/utilities.less
+++ b/cfgov/unprocessed/css/enhancements/utilities.less
@@ -44,7 +44,6 @@
 .u-w15pct  { width: 15%; }
 .u-w5pct   { width:  5%; }
 
-
 /* topdoc
   name: Centered on mobile utility
   family: cfgov-cf-enhancements
@@ -115,7 +114,6 @@
     }
 }
 
-
 /* topdoc
   name: Hidden
   family: cf-core
@@ -137,7 +135,6 @@
     display: none;
 }
 
-
 /* topdoc
   name: Hidden Overflow
   family: cf-core
@@ -157,7 +154,6 @@
 .u-hidden-overflow {
     overflow: hidden;
 }
-
 
 /* topdoc
   name: Invisible
@@ -180,7 +176,6 @@
 .u-invisible {
     visibility: hidden;
 }
-
 
 /* topdoc
   name: Disabled link
@@ -211,3 +206,7 @@
     }
 }
 
+/* topdoc
+  name: EOF
+  eof: true
+*/

--- a/cfgov/unprocessed/css/enhancements/vars.less
+++ b/cfgov/unprocessed/css/enhancements/vars.less
@@ -14,3 +14,8 @@
 */
 
 @horizontal-rule: @gray-40;
+
+/* topdoc
+  name: EOF
+  eof: true
+*/

--- a/cfgov/unprocessed/css/on-demand/header.less
+++ b/cfgov/unprocessed/css/on-demand/header.less
@@ -1,0 +1,65 @@
+/* ==========================================================================
+   cfgov-refresh
+   Master Less File.
+   ========================================================================== */
+
+
+/* Base styles
+   @import combined CF components Less file and make any overrides.
+   ========================================================================== */
+
+// Import required CF components.
+// Combined CF components.
+@import (less) 'cf-core/src/cf-core.less';
+@import (less) 'cf-icons/src/cf-icons.less';
+@import (less) 'cf-buttons/src/cf-buttons.less';
+@import (less) 'cf-forms/src/cf-forms.less';
+
+.o-header {
+    @import (less) 'cf-buttons/src/cf-buttons.less';
+    @import (less) 'cf-layout/src/cf-layout.less';
+    @import (less) 'cf-typography/src/cf-typography.less';
+}
+
+// The Capital Framework (CF) brand color palette.
+@import (less) "../brand-palette.less";
+
+// Override the CF theme variables with colors from the brand color palette.
+@import (less) "../cf-theme-overrides.less";
+
+// Enhancements that are on a migration path to being added to CF.
+// CF Core
+@import (less) "../enhancements/vars.less";
+@import (less) "../enhancements/media-queries.less";
+@import (less) "../enhancements/utilities.less";
+@import (less) "../enhancements/base.less";
+
+.o-header {
+    // CF Forms
+    @import (less) "../enhancements/forms.less";
+}
+
+/* Base patterns
+   ========================================================================== */
+@import (less) "../misc.less";
+
+/* Atom pieces
+   ========================================================================== */
+
+@import (less) "../atoms/rule-break.less";
+@import (less) "../atoms/overlay.less";
+
+/* Molecule pieces
+   ========================================================================== */
+
+@import (less) "../molecules/featured-menu-content.less";
+@import (less) "../molecules/global-banner.less";
+@import (less) "../molecules/global-eyebrow.less";
+@import (less) "../molecules/global-header-cta.less";
+@import (less) "../molecules/global-search.less";
+
+/* Organism pieces
+   ========================================================================== */
+
+@import (less) "../organisms/header.less";
+@import (less) "../organisms/mega-menu.less";

--- a/cfgov/unprocessed/js/routes/on-demand/header.js
+++ b/cfgov/unprocessed/js/routes/on-demand/header.js
@@ -1,0 +1,12 @@
+/* ==========================================================================
+   Scripts for Expandable Group organism.
+   ========================================================================== */
+
+'use strict';
+
+// GLOBAL ATOMIC ELEMENTS.
+// Organisms.
+var Header = require( '../../organisms/Header.js' );
+var header = new Header( document.body );
+// Initialize header by passing it reference to global overlay atom.
+header.init( document.body.querySelector( '.a-overlay' ) );

--- a/config/webpack-config.js
+++ b/config/webpack-config.js
@@ -49,7 +49,25 @@ var ieConf = {
   ]
 };
 
+var onDemandConf = {
+  context: path.join( __dirname, '/../', paths.unprocessed,
+                      JS_ROUTES_PATH + '/on-demand' ),
+  entry:   scriptsManifest.getDirectoryMap( paths.unprocessed +
+                                            JS_ROUTES_PATH + '/on-demand' ),
+  output: {
+    path:     path.join( __dirname, 'js' ),
+    filename: '[name]'
+  },
+  plugins: [
+    // Change warnings flag to true to view linter-style warnings at runtime.
+    new webpack.optimize.UglifyJsPlugin( {
+      compress: { warnings: false }
+    } )
+  ]
+};
+
 module.exports = {
-  modernConf:  modernConf,
-  ieConf:      ieConf
+  onDemandConf: onDemandConf,
+  ieConf:       ieConf,
+  modernConf:   modernConf
 };

--- a/gulp/tasks/scripts.js
+++ b/gulp/tasks/scripts.js
@@ -58,7 +58,7 @@ function scriptsModern() {
  * Bundle IE9-specific script.
  * @returns {PassThrough} A source stream.
  */
-function scriptsIe() {
+function scriptsIE() {
   return gulp.src( paths.unprocessed + '/js/ie/common.ie.js' )
     .pipe( webpackStream( webpackConfig.ieConf ) )
     .on( 'error', handleErrors )
@@ -68,9 +68,26 @@ function scriptsIe() {
     } ) );
 }
 
+/**
+ * Bundle atomic component scripts.
+ * Provides a means to bundle JS for specific atomic components,
+ * which then can be carried over to other projects.
+ * @returns {PassThrough} A source stream.
+ */
+function scriptsOnDemand() {
+  return gulp.src( paths.unprocessed + '/js/routes/on-demand/*.js' )
+    .pipe( webpackStream( webpackConfig.onDemandConf ) )
+    .on( 'error', handleErrors )
+    .pipe( gulp.dest( paths.processed + '/js/atomic/' ) )
+    .pipe( browserSync.reload( {
+      stream: true
+    } ) );
+}
+
 gulp.task( 'scripts:polyfill', scriptsPolyfill );
 gulp.task( 'scripts:modern', scriptsModern );
-gulp.task( 'scripts:ie', scriptsIe );
+gulp.task( 'scripts:ie', scriptsIE );
+gulp.task( 'scripts:ondemand', scriptsOnDemand );
 
 gulp.task( 'scripts', [
   'scripts:polyfill',

--- a/gulp/tasks/styles.js
+++ b/gulp/tasks/styles.js
@@ -59,8 +59,31 @@ function stylesIe() {
     } ) );
 }
 
+/**
+ * Process stand-alone atomic component CSS.
+ * @returns {PassThrough} A source stream.
+ */
+function stylesOnDemand() {
+  return gulp.src( config.cwd + '/on-demand/*.less' )
+    .pipe( $.less( config.settings ) )
+    .on( 'error', handleErrors )
+    .pipe( $.autoprefixer( {
+      browsers: [ 'last 2 version',
+                  'ie 7-8',
+                  'android 4',
+                  'BlackBerry 7',
+                  'BlackBerry 10' ]
+    } ) )
+    .pipe( $.header( banner, { pkg: pkg } ) )
+    .pipe( gulp.dest( config.dest ) )
+    .pipe( browserSync.reload( {
+      stream: true
+    } ) );
+}
+
 gulp.task( 'styles:modern', stylesModern );
 gulp.task( 'styles:ie', stylesIe );
+gulp.task( 'styles:ondemand', stylesOnDemand );
 
 gulp.task( 'styles', [
   'styles:modern',


### PR DESCRIPTION
Adds a method for packaging and viewing an atomic component in (relative) isolation, for moving to other projects.

## Changes

- Contains https://github.com/cfpb/cfgov-refresh/pull/1749 and https://github.com/cfpb/cfgov-refresh/pull/1795
- Adds header initialization script to /on-demand/ routes folder.
- Wraps header organism in a macro and allow passing in of option to hide banner (in addition to flag set in CMS).
- Adds /on-demand/ directory in unprocessed css directory for creating a custom stylesheet for a specific component.
- Adds a private `/test-fixture/` route for viewing a component in a stripped down webpage template.

## Testing

- Run `gulp scripts:atomic && gulp styles:atomic`
- Visit `localhost:8000/test-fixture/?atomic=header`
There should be a functional header without any other content.

## Review

- @jimmynotjim 
- @sebworks 
- @KimberlyMunoz 
- @schaferjh 
- @rosskarchner 
- @Scotchester 

## Screenshots

![screen shot 2016-04-02 at 1 21 52 pm](https://cloud.githubusercontent.com/assets/704760/14227942/ed3cc51e-f8d5-11e5-828f-65f11cb99fef.png)

![screen shot 2016-04-02 at 1 22 02 pm](https://cloud.githubusercontent.com/assets/704760/14227943/f0e31aa6-f8d5-11e5-8a64-b5e396094080.png)

## Notes

- The idea of this PR is to have some encapsulated HTML/JS/CSS that could be copied over to responsive non-V1 pages, in a reproducible fashion, so that updates can be carried over easily in the future. However, some of our styles have the expectation of being global. I've wrapped the ones I could in an `.o-header` scope, but the others will need extra attention to see they don't break the existing sites. See `/unprocessed/css/on-demand/header.less` for which ones are not wrapped in a scope (all atomic components will have atomic prefix scope, so will not collide on pages that don't have atomic components).