### PR TITLE
global_include in all supported template environments

### DIFF
--- a/cfgov/sheerlike/__init__.py
+++ b/cfgov/sheerlike/__init__.py
@@ -22,6 +22,7 @@ from .filters import selected_filters_for_field, is_filter_selected
 from .templates import get_date_string
 from .middleware import get_request
 
+
 from flags.template_functions import flag_enabled, flag_disabled
 
 PERMALINK_REGISTRY = {}
@@ -108,6 +109,7 @@ def environment(**options):
         'when': when,
         'flag_enabled': flag_enabled,
         'flag_disabled': flag_disabled,
+        'global_include': global_render_template,
     })
     env.filters.update({
         'date': get_date_string

--- a/cfgov/v1/templatetags/global_include.py
+++ b/cfgov/v1/templatetags/global_include.py
@@ -1,0 +1,10 @@
+from django import template
+
+import sheerlike
+
+register = template.Library()
+
+
+@register.simple_tag
+def global_include(name):
+    return sheerlike.global_render_template(name)


### PR DESCRIPTION
Sheerlike sites need to run in their own isolated template environments, to avoid collisions with v1 and other sheer sites (for example, they all have their own 'index.html')

Similarly, legacy django apps exist in another silo, in that they can't reference v1's Jinja2 templates.

With this, we provide a way of breaking out of those silos, and pulling in (rendered) templates from v1. This will primarily be useful for applying a single header/footer to all of these pages.


## Additions

- a global_include function is made available across all Jinja2 pages (including Sheer sites)
- a similar django template tag is created

## Testing

- clone django-cfgov-common, cfgov-selfregistration, and fin-ed-resources as siblings to your checkout of cfgov-refresh.
- build fin-ed-resources per it's instructions
- for the other two repos, be sure to check out their 'django18' branch
- `pip install -e ../django-cfgov-common`
- `pip install -e ../cfgov-selfregistration`
- `cfgov/manage.py migrate`
- `cfgov/manage.py sheer_index`
- in fin-ed-resources/dist/_includes/nemo_header.html, try changing the whole file to:
```
 <div class="nemo">                                                               
      {{ global_include('organisms/header.html') }}                                
  </div> {# END .nemo #} 
```
- take a look at http://localhost:8000/tax-preparer-resources/ and see our header (minus css) displayed on that page
- in django-cfgov-common/cfpb_common/templates/front/base_update.html, add this to the top (after `{% load static %}`
```
{% load global_include %}
```
and, try deleteing the `<div class=nemo>` with just:
```
{% global_include "organisms/header.html" %} 
```
... and see as similarly busted version of the navigation.

(this test is just to demonstrate the functionality-- the work of applying the header globally certainly won't involve editing 'dist' files-- though django-cfgov-common will be important for legacy django apps, and may be the only place you need to apply the change)

## Review

- @anselmbradford @kave @richaagarwal @kurtw 


## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [x] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
