### PR TITLE
Fix Post Preview Snapshot list to get most recent pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -807,6 +807,8 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 
 ### Added
 
+- Add reverse flag back into post preview snapshot for most recent pages
+
 ### Changed
 
 ### Removed

--- a/cfgov/v1/models/sublanding_page.py
+++ b/cfgov/v1/models/sublanding_page.py
@@ -64,7 +64,7 @@ class SublandingPage(CFGOVPage):
 
     def get_browsefilterable_posts(self, request, limit):
         filter_pages = [p.specific for p in self.get_appropriate_descendants(request.site.hostname)
-                        if 'BrowseFilterablePage' in p.specific_class.__name__]
+                        if 'FilterablePage' in p.specific_class.__name__]
         filtered_controls = {}
         for page in filter_pages:
             id = str(util.get_form_id(page, request.GET))
@@ -74,5 +74,5 @@ class SublandingPage(CFGOVPage):
             filtered_controls[id] = filterable_context.get_page_set(
                 page, form_class(parent=page, hostname=request.site.hostname), request.site.hostname)
         posts_tuple_list = [(id, post) for id, posts in filtered_controls.iteritems() for post in posts]
-        posts = sorted(posts_tuple_list, key=lambda p: p[1].date_published)[:limit]
+        posts = sorted(posts_tuple_list, key=lambda p: p[1].date_published, reverse=True)[:limit]
         return posts


### PR DESCRIPTION
The Post Preview Snapshot page order is oldest to newest. This should be reversed.

## Additions

- Add reverse flag to Post Preview Snapshot list to get most recent pages

## Changed

- List search includes any page class ending with `FilterablePage` not just `BrowseFilterablePage`

## Testing

- These pages should have the most recent pages
 - Go [here](http://localhost:8000/policy-compliance/amicus/)
 - And [here](http://localhost:8000/policy-compliance/amicus/)
- You can check their refresh/beta counterparts to view it in reverse

## Review

- @richaagarwal 
- @kave 

## Screenshots

![screen shot 2016-04-04 at 10 22 33 am](https://cloud.githubusercontent.com/assets/1412978/14251071/2ffa334e-fa4f-11e5-9728-cb3cb9a06150.png)
