### PR TITLE
Legacy template overrides + sheerlike config for know-before-you-owe

### DIFF
--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -412,5 +412,8 @@ SHEER_SITES = {
             Path(REPOSITORY_ROOT, '../owning-a-home/dist')),
         'fin-ed-resources':
             Path(os.environ.get('FIN_ED_SHEER_PATH') or
-            Path(REPOSITORY_ROOT, '../fin-ed-resources/dist'))
+            Path(REPOSITORY_ROOT, '../fin-ed-resources/dist')),
+        'know-before-you-owe':
+            Path(os.environ.get('KBYO_SHEER_PATH') or
+            Path(REPOSITORY_ROOT, '../know-before-you-owe/dist'))
 }

--- a/cfgov/cfgov/urls.py
+++ b/cfgov/cfgov/urls.py
@@ -23,6 +23,8 @@ from wagtail.wagtailadmin.forms import PasswordResetForm
 from wagtail.wagtailadmin.views import account
 
 fin_ed = SheerSite('fin-ed-resources')
+know_before_you_owe = SheerSite('know-before-you-owe')
+owning_a_home = SheerSite('owning-a-home')
 
 urlpatterns = [
     url(r'^django-admin/login', cfpb_login, name='wagtailadmin_login'),
@@ -50,7 +52,14 @@ urlpatterns = [
 
     url(r'^home/(?P<path>.*)$', RedirectView.as_view(url='/%(path)s', permanent=True)),
 
-    url(r'^owning-a-home/', include(SheerSite('owning-a-home').urls)),
+    url(r'^owning-a-home/', include(owning_a_home.urls)),
+
+    # this is unforunate, but these paths are coded in javascript or JSON
+    # and thus don't get picked up in the middleware
+    url(r'know-before-you-owe/static/(?P<path>.*)$',
+        RedirectView.as_view(url='/static/know-before-you-owe/static/%(path)s', permanent=True)),
+
+    url(r'^know-before-you-owe/', include(know_before_you_owe.urls)),
 
     url(r'^adult-financial-education/', include(fin_ed.urls_for_prefix('adult-financial-education'))),
     url(r'^youth-financial-education/', include(fin_ed.urls_for_prefix('youth-financial-education'))),

--- a/cfgov/jinja2/sheer_override/common/nemo_header.html
+++ b/cfgov/jinja2/sheer_override/common/nemo_header.html
@@ -1,0 +1,58 @@
+<a class="u-visually-hidden" href="#primary-content" id="skip-link">Skip to content</a>
+
+ <!-- top banner -->
+ <!-- this header is coming from cfgov-refresh! -->
+<div class="nemo">
+    <div class="wrapper-banner">
+        <div class="wrapper-container">
+            <div class="split">
+                <span class="official-website">An official website of the United States Government</span>
+                <div class="split-right language-banner">
+                  <a href="/es/" hreflang="es" class="espanol-link">Español</a>
+                  <a href="/lang/#zh" hreflang="zh">中文</a>
+                  <a href="/lang/#vi" hreflang="vi">Tiếng Việt</a>
+                  <a href="/lang/#ko" hreflang="ko">한국의</a>
+                  <a href="/lang/#tl" hreflang="tl">Tagalog</a>
+                  <a href="/lang/#ru" hreflang="ru">Pусский</a>
+                  <a href="/lang/#ar" hreflang="ar">العربية</a>
+                  <a href="/lang/#ht" hreflang="ht">Kreyòl Ayisyen</a>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- header and nav -->
+    <header id="header">
+      <div role="banner">
+         <a class="toggle-menu" href="#"><i class="cf-icon cf-icon-menu"></i><span class="u-visually-hidden">Menu</span></a>
+        <h1>
+          <a href="/" class="noStyles">
+            <img id="logo" class="logo__js" src="http://www.consumerfinance.gov/wp-content/themes/cfpb_nemo/_/img/logo.svg" onerror="this.src='http://www.consumerfinance.gov/wp-content/themes/cfpb_nemo/_/img/logo.png';" alt="Consumer Financial Protection Bureau" width="262" height="66">
+            <noscript>
+              <img id="logo" class="logo__no-js" src="http://www.consumerfinance.gov/wp-content/themes/cfpb_nemo/_/img/logo.png" alt="Consumer Financial Protection Bureau" width="262" height="66">
+            </noscript>
+          </a>
+        </h1>
+        <p class="lang"><span class="tel"><a href="tel:+18554112372">Contact us&nbsp;&nbsp;<strong>(855) 411-2372</strong></a></span></p>
+        <form accept-charset="UTF-8" action="http://search.consumerfinance.gov/search" class="single" id="search_form" method="get">
+          <input name="utf8" type="hidden" value="✓">
+          <input id="affiliate" name="affiliate" type="hidden" value="cfpb">
+          <div class="inf">
+            <label for="query" id="search-placeholder">Search</label>
+            <input id="query" name="query" type="text">
+          </div>
+          <button>Go</button>
+        </form>
+      </div>
+      <nav class="main" role="navigation">
+        <ul>
+          <li><a href="/">Home</a></li>
+          <li><a href="#inside">Inside the CFPB</a></li>
+          <li><a href="#assistance">Get assistance</a></li>
+          <li><a href="#participate">Participate</a></li>
+          <li><a href="#regulation">Law &amp; Regulation</a></li>
+          <li><a href="#alert" class="complaint">Submit a complaint</a></li>
+        </ul>
+      </nav>
+    </header>
+</div>

--- a/cfgov/sheerlike/apps.py
+++ b/cfgov/sheerlike/apps.py
@@ -2,6 +2,9 @@ from django.apps import AppConfig
 from django.conf import settings
 
 
+sheer_override_dir = settings.PROJECT_ROOT.child('jinja2', 'sheer_override')
+common_overrides = sheer_override_dir.child('common')
+
 class SheerlikeConfig(AppConfig):
     name = 'sheerlike'
     verbose_name = 'Sheerlike'
@@ -9,8 +12,11 @@ class SheerlikeConfig(AppConfig):
     def ready(self):
         for app, directory in settings.SHEER_SITES.items():
             if directory.exists():
+                app_overrides =sheer_override_dir.child('app')
                 engine_config = {
                     'NAME': app, 'BACKEND': 'django.template.backends.jinja2.Jinja2', 'DIRS': [
+                        str(app_overrides),
+                        str(common_overrides),
                         str(directory), str(
                             directory.child('_includes')), str(
                             directory.child('_layouts'))], 'OPTIONS': {


### PR DESCRIPTION
With this PR, all work needed to apply the new headers to Sheer and django apps can be done within this repo. Sheer templates can be overridden globally by putting a replacement in:

cfgov-refresh/cfgov/jinja2/sheer_overrides/common

or, on a project-by-project basis:

cfgov-refresh/cfgov/jinja2/sheer_overrides/know-before-you-owe


## Additions

- a few new directories are added to the template search path for sheerlike sites, cfgov/jinja2/sheer_overrides/common and cfgov/jinja2/sheer_overrides/(site-name), which is the dictionary key from settings.SHEER_SITES
- I snuck in the settings and url configuration to support the know-before-you-owe sheer app


## Testing

- check out this PR
- check out know-before-you-owe as a sibling directory of cfgov-refresh, and build it (`npm install && grunt build`)
- `cfgov/manage.py runserver`
- observe that http://localhost:8000/know-before-you-owe/  works.
- view source, and observe the comment `<!-- this header is coming from cfgov-refresh! -->`. this file is at cfgov/jinja2/sheer_overrides/common/nemo_header.html
- If you followed along with the testing instructions for #1798 you can view http://localhost:8000/company-signup/ and view source to find the comment `<!-- this code is coming from cfgov-refresh! --!>` . That code is coming from the django template at cfgov/legacy_common/templates/front/base_update.html.

## Review

- @anselmbradford @KimberlyMunoz @richaagarwal @kave @kurtw @Scotchester 


## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [x] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
