### PR TITLE
Removes inline CSS when running sheer_index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 ### Added
 
 - Adds a max-selections checker to the Multiselect.
+- Remove inline CSS when running sheer_index
 
 ### Changed
 

--- a/cfgov/v1/__init__.py
+++ b/cfgov/v1/__init__.py
@@ -56,6 +56,9 @@ def parse_links(soup):
     icon_pattern = re.compile(settings.EXTERNAL_ICON_PATTERN)
     a_class = os.environ.get('EXTERNAL_A_CSS', 'icon-link icon-link__external-link')
     span_class = os.environ.get('EXTERNAL_SPAN_CSS', 'icon-link_text')
+    for tag in soup:
+        if hasattr(tag, 'style'):
+            del tag['style']
     for a in soup.find_all('a', href=True):
         # Sets the link to an external one if you're leaving .gov 
         if link_pattern.match(a['href']):


### PR DESCRIPTION
Removes the inline CSS from the sheer_indexed content.

## Addition

- Parsing data now removes inline CSS

## Testing

- Go [here](http://localhost:8000/about-us/blog/take-a-tour-of-money-as-you-grow-our-new-resource-to-help-parents-and-caregivers-give-children-a-strong-financial-start/) and inspect the aside tag. (screenshot below)
- Run `./cfgov/manage.py sheer_index` 
- Go back to the page and see that inline CSS is gone

## Review

- @richaagarwal 
- @kave 
- @rosskarchner 

