### PR TITLE
Shrinking expandables target area + updating date

### DIFF
--- a/cfgov/jinja2/v1/about-us/the-bureau/bureau-structure/_macro-node.html
+++ b/cfgov/jinja2/v1/about-us/the-bureau/bureau-structure/_macro-node.html
@@ -22,9 +22,9 @@
            m-expandable__expanded'
           if has_children else '' }}">
     {% if has_children %}
+    {{ role.render(org) }}
     <button class="m-expandable_target">
         <div class="m-expandable_header">
-            {{ role.render(org) }}
             <div class="org-chart_node_expander">
                 <span class="m-expandable_header-left
                              m-expandable_label

--- a/cfgov/jinja2/v1/about-us/the-bureau/bureau-structure/index.html
+++ b/cfgov/jinja2/v1/about-us/the-bureau/bureau-structure/index.html
@@ -8,7 +8,7 @@
 
 {% set active_nav_id = 'bureau-structure' %}
 {% set breadcrumb_items = vars.breadcrumb_items %}
-{% set categories = [{ 
+{% set categories = [{
                         'title': 'Divisions',
                         'sub_title': 'Offices in this division',
                         'data': division_data.data
@@ -16,7 +16,7 @@
                         'title':'Office of the Director',
                         'sub_title': 'Offices under this position',
                         'data': office_data.data
-                     }] 
+                     }]
 %}
 
 {% block title -%}
@@ -46,7 +46,7 @@
 
 {% block content_main %}
     <h1>Bureau Structure</h1>
-    <p>Org chart last updated: January 11, 2016</p>
+    <p>Org chart last updated: April 4, 2016</p>
     <div class="org-chart">
         <div class="org-chart_node org-chart_node__root">
             {{ role.render({

--- a/cfgov/unprocessed/css/pages/bureau-structure.less
+++ b/cfgov/unprocessed/css/pages/bureau-structure.less
@@ -308,7 +308,6 @@
     padding: @margin / 2 0;
     border-top: 1px solid @node-border-color;
     border-bottom: 1px solid @node-border-color;
-    margin-top: @margin;
 }
 
 .org-chart_node_more-info {
@@ -330,6 +329,10 @@
 
     &_name {
         .webfont-medium();
+    }
+
+    + .m-expandable_target {
+        margin-top: @margin;
     }
 }
 


### PR DESCRIPTION
Two changes:

-  This shrinks the expandable target area on the bureau-structure page to make it easier to scroll without hitting a target area unintentionally. I talked through it with @schaferjh to make sure this reflects the intended UX behavior of having the expandable header section be the target.
- Updated the date to reflect the changes made in #1553 

## Testing

- Visit http://localhost:8000/about-us/the-bureau/bureau-structure/ on mobile and note the target area
- Visit the same page on iOS simulator and try scrolling. @schaferjh noticed some strange behavior where it would close during scrolling. I assumed it was because of accidentally tapping the large target area, but please let me know if you see anything suspicious.

## Review

- @jimmynotjim 
- @sebworks 
- @anselmbradford 


## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)