### PR TITLE
Fix .gov external links

### DIFF
--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -187,7 +187,7 @@ if NEMO_PATH.exists():
 ALLOWED_HOSTS = ['*']
 
 EXTERNAL_LINK_PATTERN = r'https?:\/\/(?:www\.)?(?![^\?]+gov)(?!(content\.)?localhost).*'
-EXTERNAL_ICON_PATTERN = r'(https?:\/\/(?:www\.)?(?![^\?]*(cfpb|consumerfinance).gov)(?!(content\.)?localhost).*)'
+NONCFPB_LINK_PATTERN = r'(https?:\/\/(?:www\.)?(?![^\?]*(cfpb|consumerfinance).gov)(?!(content\.)?localhost).*)'
 
 # Wagtail settings
 

--- a/cfgov/processors/processors_common.py
+++ b/cfgov/processors/processors_common.py
@@ -1,5 +1,7 @@
+import re
 from bs4 import BeautifulSoup
 from urlparse import urlsplit, urlunsplit
+from django.conf import settings
 
 replacements = (('/blog/', '/about-us/blog/'),
                 ('/pressrelease/','/about-us/newsroom/'),
@@ -14,17 +16,9 @@ def update_path(path):
             return new_path
     return path
 
-def fix_links(html):
-    soup = BeautifulSoup(html, 'html.parser')
-    for link in soup.findAll('a'):
-        try:
-            urldata = urlsplit(link['href'])
-            new_path = update_path(urldata.path)
-            new_href = urlunsplit((None, None, urldata.path, urldata.query,
-                                  urldata.fragment))
-            link['href'] = new_href
-        except KeyError:
-            # this means there's no href-- perhaps an <a name="foo"> link
-            continue
-
-    return soup.encode(formatter="html")
+def fix_link(link):
+    urldata = urlsplit(link['href'])
+    new_path = update_path(urldata.path)
+    new_href = urlunsplit((None, None, urldata.path, urldata.query,
+                          urldata.fragment))
+    link['href'] = new_href

--- a/cfgov/processors/wordpress_newsroom.py
+++ b/cfgov/processors/wordpress_newsroom.py
@@ -3,7 +3,6 @@ import json
 import os.path
 import requests
 from sheerlike.external_links import process_external_links
-from .processors_common import fix_links
 
 
 def posts_at_url(url):
@@ -57,7 +56,6 @@ def process_post(post):
     del post['custom_fields']
 
     post = process_external_links(post)
-    post['content'] = fix_links(post['content'])
 
     return {'_type': 'newsroom',
             '_id': post['slug'],

--- a/cfgov/processors/wordpress_post.py
+++ b/cfgov/processors/wordpress_post.py
@@ -3,7 +3,6 @@ import json
 import os.path
 import requests
 from sheerlike.external_links import process_external_links
-from .processors_common import fix_links
 
 
 def posts_at_url(url):
@@ -73,7 +72,6 @@ def process_post(post):
     del post['custom_fields']
 
     post = process_external_links(post)
-    post['content'] = fix_links(post['content'])
 
     return {'_type': 'posts',
             '_id': post['slug'],

--- a/cfgov/sheerlike/external_links.py
+++ b/cfgov/sheerlike/external_links.py
@@ -13,7 +13,8 @@ def process_external_links(doc):
 
 def _process_data(field):
     if isinstance(field, basestring):
-        field = str(parse_links(BeautifulSoup(field, 'html.parser')))
+        soup = BeautifulSoup(field, 'html.parser')
+        field = parse_links(soup).encode(formatter="html")
     elif isinstance(field, list):
         for i, value in enumerate(field):
             field[i] = _process_data(value)

--- a/cfgov/v1/__init__.py
+++ b/cfgov/v1/__init__.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 import os, re,HTMLParser
 from urlparse import urlparse
 
@@ -11,11 +12,12 @@ from jinja2 import Environment, contextfunction, Markup
 from sheerlike import environment as sheerlike_environment
 from compressor.contrib.jinja2ext import CompressorExtension
 from flags.template_functions import flag_enabled, flag_disabled
-from util.util import get_unique_id
+from .util.util import get_unique_id
 
 from wagtail.wagtailcore.rich_text import expand_db_html, RichText
 from bs4 import BeautifulSoup
 from django.conf import settings
+from processors.processors_common import fix_link
 
 default_app_config = 'v1.apps.V1AppConfig'
 
@@ -52,8 +54,8 @@ def environment(**options):
 
 
 def parse_links(soup):
-    link_pattern = re.compile(settings.EXTERNAL_LINK_PATTERN)
-    icon_pattern = re.compile(settings.EXTERNAL_ICON_PATTERN)
+    extlink_pattern = re.compile(settings.EXTERNAL_LINK_PATTERN)
+    noncfpb_pattern = re.compile(settings.NONCFPB_LINK_PATTERN)
     a_class = os.environ.get('EXTERNAL_A_CSS', 'icon-link icon-link__external-link')
     span_class = os.environ.get('EXTERNAL_SPAN_CSS', 'icon-link_text')
     for tag in soup:
@@ -61,13 +63,15 @@ def parse_links(soup):
             del tag['style']
     for a in soup.find_all('a', href=True):
         # Sets the link to an external one if you're leaving .gov 
-        if link_pattern.match(a['href']):
+        if extlink_pattern.match(a['href']):
             a['href'] = '/external-site/?ext_url=' + a['href']
         # Sets the icon to indicate you're leaving consumerfinance.gov
-        if icon_pattern.match(a['href']):
+        if noncfpb_pattern.match(a['href']):
             a.attrs.update({'class': a_class})
             a.append(' ') # We want an extra space before the icon
             a.append(soup.new_tag('span', attrs='class="%s"' % span_class))
+        else:
+            fix_link(a)
     return soup
 
 


### PR DESCRIPTION
.gov links should not be stripped of its hostname

## Changes

- names of external link/icon pattern names
- processors_common now checks against a link pattern before stripping hostnames from links

## Testing

- run `cfgov/manage.py sheer_index`
- go [here](http://localhost:8000/about-us/blog/3-tips-to-help-you-make-the-most-of-your-tax-refund/) and go to irs links. they should go straight to the irs.gov page

## Review

- @kave 
- @richaagarwal 
- @rosskarchner 

