### PR TITLE
Fixed issue where missing images were breaking the layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 
 ### Fixed
 
+- Fixed issue where missing images were breaking the hero layout
+
 ## 3.0.0-3.3.0 - 2016-04-08
 
 ### Added

--- a/cfgov/jinja2/v1/_includes/molecules/hero.html
+++ b/cfgov/jinja2/v1/_includes/molecules/hero.html
@@ -64,10 +64,13 @@
             {% endfor %}
         </div>
 
+
+        <div class="hero_image"
         {% if value.image.upload %}
             {% set photo=image(value.image.upload, 'original') %}
-            <div class="hero_image"
-                 style="background-image: url( {{ photo.url }} );"></div>
+             style="background-image:
+                    url( {{- photo.url -}} );"
         {% endif %}
+          ></div>
     </div>
 </section>


### PR DESCRIPTION
Table cells will fill the container even if a width is set if there are no other table cells. Even if there's no image, we need the div to keep the layout the same

## Changes

- Moved the image div out of the condition

## Testing

- `gulp build` and visit `/policy-compliance`. The text shouldn't be the entire width due to the CMS not having an image to use.

## Review

- @KimberlyMunoz 
- @anselmbradford 
- @sebworks 

## Screenshots

__Before__

![screen shot 2016-04-04 at 4 02 48 pm](https://cloud.githubusercontent.com/assets/1280430/14263163/b2870fce-fa7e-11e5-9253-f22d4a79852b.png)

__After__

![screen shot 2016-04-04 at 4 02 34 pm](https://cloud.githubusercontent.com/assets/1280430/14263171/b7e54210-fa7e-11e5-93ed-949895379852.png)

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)