### PR TITLE
lxml, perhaps not

### DIFF
--- a/cfgov/processors/processors_common.py
+++ b/cfgov/processors/processors_common.py
@@ -15,7 +15,7 @@ def update_path(path):
     return path
 
 def fix_links(html):
-    soup = BeautifulSoup(html, 'lxml')
+    soup = BeautifulSoup(html, 'html.parser')
     for link in soup.findAll('a'):
         try:
             urldata = urlsplit(link['href'])
@@ -27,5 +27,4 @@ def fix_links(html):
             # this means there's no href-- perhaps an <a name="foo"> link
             continue
 
-    return unicode(soup)
-
+    return soup.encode(formatter="html")

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -17,4 +17,3 @@ boto==2.38.0
 django-storages==1.1.8
 django-haystack==2.4.1
 beautifulsoup4==4.4.1
-lxml==3.6.0


### PR DESCRIPTION
lxml resolved the problem it was introduced to solve (see #1777), but installation is error-prone and


## Removals

- lxml is removed

## Changes

- process_common.fix_links altered to use html.parser and explicitly use BeautifulSoup's html output formatter.

## Testing

- Run `cfgov/manage.py sheer_index` and observe that the issue from #1777 hasn't regressed

## Review

- @kurtw @kave  @richaagarwal 


## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
