### PR TITLE
Fixing browser tests

### DIFF
--- a/test/browser_tests/page_objects/page_careers-application-process.js
+++ b/test/browser_tests/page_objects/page_careers-application-process.js
@@ -9,7 +9,7 @@ function ApplicationProcess() {
   Object.assign( this, relatedLinksSection );
 
   this.get = function() {
-    browser.get( '/careers/application-process/' );
+    browser.get( '/about-us/careers/application-process/' );
   };
 
   this.pageTitle = function() { return browser.getTitle(); };

--- a/test/browser_tests/page_objects/page_careers-current-openings.js
+++ b/test/browser_tests/page_objects/page_careers-current-openings.js
@@ -9,7 +9,7 @@ function CurrentOpenings() {
   Object.assign( this, relatedLinksSection );
 
   this.get = function() {
-    browser.get( '/careers/current-openings/' );
+    browser.get( '/about-us/careers/current-openings/' );
   };
 
   this.pageTitle = function() { return browser.getTitle(); };

--- a/test/browser_tests/page_objects/page_careers-students-and-graduates.js
+++ b/test/browser_tests/page_objects/page_careers-students-and-graduates.js
@@ -2,12 +2,12 @@
 
 function StudentsAndGraduates() {
   this.get = function() {
-    browser.get( '/careers/students-and-graduates/' );
+    browser.get( '/about-us/careers/students-and-graduates/' );
   };
 
   this.pageTitle = function() { return browser.getTitle(); };
   this.opportunities = element.all(
-    by.css( '.careers-students-and-graduates .content_main .media h2' )
+    by.css( '.t-careers_students-and-graduates .content_main .media h2' )
   );
 }
 

--- a/test/browser_tests/page_objects/page_careers-working-at-cfpb.js
+++ b/test/browser_tests/page_objects/page_careers-working-at-cfpb.js
@@ -9,7 +9,7 @@ function WorkingAtCFPB() {
   Object.assign( this, relatedLinksSection );
 
   this.get = function() {
-    browser.get( '/careers/working-at-cfpb/' );
+    browser.get( '/about-us/careers/working-at-cfpb/' );
   };
 
   this.pageTitle = function() { return browser.getTitle(); };

--- a/test/browser_tests/page_objects/page_careers.js
+++ b/test/browser_tests/page_objects/page_careers.js
@@ -5,7 +5,7 @@ var _getQAelement = require( '../util/qa-element' ).get;
 function Careers() {
 
   this.get = function() {
-    browser.get( '/careers/' );
+    browser.get( '/about-us/careers/' );
   };
 
   this.pageTitle = function() { return browser.getTitle(); };

--- a/test/browser_tests/page_objects/page_dbwu-past-awards.js
+++ b/test/browser_tests/page_objects/page_dbwu-past-awards.js
@@ -5,7 +5,7 @@ var _getQAElement = require( '../util/qa-element' ).get;
 function PastAwards() {
 
   this.get = function() {
-    browser.get( 'doing-business-with-us/past-awards/' );
+    browser.get( '/about-us/doing-business-with-us/past-awards/' );
   };
 
   this.pageTitle = function() { return browser.getTitle(); };

--- a/test/browser_tests/page_objects/page_dbwu-small-businesses.js
+++ b/test/browser_tests/page_objects/page_dbwu-small-businesses.js
@@ -5,7 +5,7 @@ var _getQAElement = require( '../util/qa-element' ).get;
 function SmallBusinessess() {
 
   this.get = function() {
-    browser.get( 'doing-business-with-us/small-businesses/' );
+    browser.get( '/about-us/doing-business-with-us/small-businesses/' );
   };
 
   this.pageTitle = function() { return browser.getTitle(); };

--- a/test/browser_tests/page_objects/page_dbwu-upcoming-procurement-needs.js
+++ b/test/browser_tests/page_objects/page_dbwu-upcoming-procurement-needs.js
@@ -5,7 +5,7 @@ var _getQAElement = require( '../util/qa-element' ).get;
 function UpcomingProcurementNeeds() {
 
   this.get = function() {
-    browser.get( 'doing-business-with-us/upcoming-procurement-needs/' );
+    browser.get( '/about-us/doing-business-with-us/upcoming-procurement-needs/' );
   };
 
   this.pageTitle = function() { return browser.getTitle(); };

--- a/test/browser_tests/page_objects/page_doing-business-with-us.js
+++ b/test/browser_tests/page_objects/page_doing-business-with-us.js
@@ -5,7 +5,7 @@ var _getQAElement = require( '../util/qa-element' ).get;
 function DoingBusinessWithUs() {
 
   this.get = function() {
-    browser.get( 'doing-business-with-us/' );
+    browser.get( '/about-us/doing-business-with-us/' );
   };
 
   this.pageTitle = function() { return browser.getTitle(); };

--- a/test/browser_tests/spec_suites/careers-application-process.js
+++ b/test/browser_tests/spec_suites/careers-application-process.js
@@ -37,8 +37,9 @@ describe( 'The Application Process Page', function() {
     [ 'Current Openings', 'Working at the CFPB',
     'Students & Recent Graduates' ];
     var infoSectionLinks =
-    [ '/careers/current-openings/', '/careers/working-at-cfpb/',
-    '/careers/students-and-graduates/' ];
+    [ '/about-us/careers/current-openings/',
+      '/about-us/careers/working-at-cfpb/',
+      '/about-us/careers/students-and-graduates/' ];
 
     expect( page.infoSectionTitles.getText() )
     .toEqual( infoSectionTitles );

--- a/test/browser_tests/spec_suites/careers-current-openings.js
+++ b/test/browser_tests/spec_suites/careers-current-openings.js
@@ -28,7 +28,8 @@ describe( 'The Current Openings Page', function() {
     var infoSectionTitles =
     [ 'Job Application Process', 'Working at the CFPB' ];
     var infoSectionLinks =
-    [ '/careers/application-process/', '/careers/working-at-cfpb/' ];
+    [ '/about-us/careers/application-process/',
+      '/about-us/careers/working-at-cfpb/' ];
 
     expect( page.infoSectionTitles.getText() )
     .toEqual( infoSectionTitles );

--- a/test/browser_tests/spec_suites/careers-working-at-cfpb.js
+++ b/test/browser_tests/spec_suites/careers-working-at-cfpb.js
@@ -37,8 +37,9 @@ describe( 'The Working At CFPB Page', function() {
     [ 'Current Openings', 'Job Application Process',
     'Students & Recent Graduates' ];
     var infoSectionLinks =
-    [ '/careers/current-openings/', '/careers/application-process/',
-    '/careers/students-and-graduates/' ];
+    [ '/about-us/careers/current-openings/',
+      '/about-us/careers/application-process/',
+      '/about-us/careers/students-and-graduates/' ];
 
     expect( page.infoSectionTitles.getText() )
     .toEqual( infoSectionTitles );

--- a/test/browser_tests/spec_suites/careers.js
+++ b/test/browser_tests/spec_suites/careers.js
@@ -31,21 +31,9 @@ describe( 'The Careers Page', function() {
   it( 'should have a career info section', function() {
     var infoSectionTitles = [ 'Job Application Process',
     'Students and Recent Graduates' ];
-    var infoSectionLinks = [ '/careers/application-process/',
-    '/careers/students-and-graduates/' ];
-
-    expect( page.infoSectionTitles.getText() )
-    .toEqual( infoSectionTitles );
-    expect( page.infoSectionDescriptions.count() ).toEqual( 2 );
-    expect( page.infoSectionLinks.getAttribute( 'href' ) )
-    .toEqualUrl( infoSectionLinks );
-  } );
-
-  it( 'should have a career info section', function() {
-    var infoSectionTitles = [ 'Job Application Process',
-    'Students and Recent Graduates' ];
-    var infoSectionLinks = [ '/careers/application-process/',
-    '/careers/students-and-graduates/' ];
+    var infoSectionLinks = [
+      '/about-us/careers/application-process/',
+      '/about-us/careers/students-and-graduates/' ];
 
     expect( page.infoSectionTitles.getText() )
     .toEqual( infoSectionTitles );

--- a/test/browser_tests/spec_suites/dbwu-past-awards.js
+++ b/test/browser_tests/spec_suites/dbwu-past-awards.js
@@ -46,7 +46,7 @@ describe( 'The Past Awards Page', function() {
     [ 'How to do business with us',
       'Small and disadvantaged businesses' ];
     var moreInfoSectionLinks = [ 'https://www.sam.gov/',
-    '/doing-business-with-us/small-businesses/' ];
+    '/about-us/doing-business-with-us/small-businesses/' ];
 
     expect( page.moreInfoSectionTitles.getText() )
     .toEqual( moreInfoSectionTitles );

--- a/test/browser_tests/spec_suites/dbwu-small-businesses.js
+++ b/test/browser_tests/spec_suites/dbwu-small-businesses.js
@@ -61,7 +61,7 @@ describe( 'The Small Businesses Page', function() {
     [ 'How to do business with us',
       'Expected procurement requests' ];
     var moreInfoSectionLinks = [ 'https://www.sam.gov/',
-    '/doing-business-with-us/upcoming-procurement-needs/' ];
+    '/about-us/doing-business-with-us/upcoming-procurement-needs/' ];
 
     expect( page.moreInfoSectionTitles.getText() )
     .toEqual( moreInfoSectionTitles );

--- a/test/browser_tests/spec_suites/dbwu-upcoming-procurement-needs.js
+++ b/test/browser_tests/spec_suites/dbwu-upcoming-procurement-needs.js
@@ -48,7 +48,7 @@ describe( 'The Upcoming Procurement Needs Page', function() {
     [ 'How to do business with us',
       'Small and disadvantaged businesses' ];
     var moreInfoSectionLinks = [ 'https://www.sam.gov/',
-    '/doing-business-with-us/small-businesses/' ];
+    '/about-us/doing-business-with-us/small-businesses/' ];
 
     expect( page.moreInfoSectionTitles.getText() )
     .toEqual( moreInfoSectionTitles );

--- a/test/browser_tests/spec_suites/doing-business-with-us.js
+++ b/test/browser_tests/spec_suites/doing-business-with-us.js
@@ -47,7 +47,7 @@ describe( 'The Doing Business with Us Page', function() {
     [ 'https://www.sam.gov/',
       'https://www.fbo.gov/?s=agency&mode=form&tab=notices&' +
       'id=e4a0c57cfb98ca60165469a7f9a778a0',
-      '/doing-business-with-us/upcoming-procurement-needs/' ];
+      '/about-us/doing-business-with-us/upcoming-procurement-needs/' ];
 
     expect( page.businessStepTitles.getText() )
     .toEqual( businessStepTitles );
@@ -59,8 +59,8 @@ describe( 'The Doing Business with Us Page', function() {
   it( 'should have two More Info sections', function() {
     var moreInfoSectionTitles = [ 'Existing and past service contracts',
       'Small, women-owned, and minority-owned businesses' ];
-    var moreInfoSectionLinks = [ '/doing-business-with-us/past-awards/',
-    '/doing-business-with-us/small-businesses/' ];
+    var moreInfoSectionLinks = [ '/about-us/doing-business-with-us/past-awards/',
+    '/about-us/doing-business-with-us/small-businesses/' ];
 
     expect( page.moreInfoSectionTitles.getText() )
     .toEqual( moreInfoSectionTitles );

--- a/test/browser_tests/spec_suites/footer.js
+++ b/test/browser_tests/spec_suites/footer.js
@@ -10,7 +10,7 @@ describe( 'The Footer Component', function() {
       'accessibility',
     '/office-civil-rights/':
       'office of civil rights',
-    '/careers/':
+    '/about-us/careers/':
       'careers',
     '/foia-requests/':
       'foia',


### PR DESCRIPTION
A lot of tests broke when career pages and Doing Business With Us moved. This fixes all those broken tests.

## Testing
- Run `gulp test:acceptance --sauce=false`

## Review
- @anselmbradford 
- @sebworks 
- @jimmynotjim 
- @richaagarwal 