### PR TITLE
Fix for IOS Expandable resize bug

### DIFF
--- a/cfgov/unprocessed/js/molecules/Expandable.js
+++ b/cfgov/unprocessed/js/molecules/Expandable.js
@@ -233,11 +233,15 @@ function Expandable( element ) { // eslint-disable-line max-statements, inline-c
 
   /**
    * Handle a resize of the window.
+   * TODO: Throttle this call per
+   * https://developer.mozilla.org/en-US/docs/Web/Events/resize.
    */
   function _resizeHandler() {
-    _refreshHeight();
-    if ( _isInMobile() ) {
-      _collapseBinded();
+    if( _contentAnimated.offsetHeight !== _contentHeight ) {
+      _refreshHeight();
+      if ( _isInMobile() ) {
+        _collapseBinded();
+      }
     }
   }
 


### PR DESCRIPTION
Fix for IOS Expandable resize bug

## Changes

- Added some code to the expandable to check the contentHeight before resizing.

## Testing

- Visit the blog on the IOS simulator (`http:127.0.0.1:8000/about-us/blog`) and click/scroll on the expandable. It shouldn't close. Rotate the simulator 360 degrees; it should close.

## Review

- @anselmbradford 
- @jimmynotjim 
- @KimberlyMunoz 

## Todos

- Throttle the window.resize method.

## Checklist

## Notes
- Calling `offsetHeight` will cause a reflow so we need to address that at some point.

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
