### PR TITLE
intitial test suite for page templates

### DIFF
--- a/cfgov/jinja2/v1/events/_macros.html
+++ b/cfgov/jinja2/v1/events/_macros.html
@@ -154,7 +154,9 @@
                     Video Replay will be<br> available shortly
                 {% else %}
                     {% import 'macros/time.html' as time %}
-                    {{ time.render(event.start_dt) }}
+                    {% if event.start_dt%}
+                        {{ time.render(event.start_dt) }}
+                    {% endif %}
                 {% endif %}
                 </div>
           </div>

--- a/test/browser_tests/page_objects/page_wagtail_templates.js
+++ b/test/browser_tests/page_objects/page_wagtail_templates.js
@@ -1,7 +1,5 @@
 'use strict';
 
-var _getQAElement = require( '../util/qa-element' ).get;
-
 function LandingPage() {
 
   this.get = function() {
@@ -121,4 +119,4 @@ module.exports = {
   docdetail: DocumentDetailPage,
   learn: LearnPage,
   event: EventPage
-}
+};

--- a/test/browser_tests/page_objects/page_wagtail_templates.js
+++ b/test/browser_tests/page_objects/page_wagtail_templates.js
@@ -1,0 +1,112 @@
+'use strict';
+
+var _getQAElement = require( '../util/qa-element' ).get;
+
+function LandingPage() {
+
+  this.get = function() {
+    var baseUrl = '/landing-page/';
+    browser.get( baseUrl );
+  };
+
+  this.pageTitle = function() { return browser.getTitle(); };
+
+}
+
+function SubLandingPage() {
+
+  this.get = function() {
+    var baseUrl = '/sublanding-page/';
+    browser.get( baseUrl );
+  };
+
+  this.pageTitle = function() { return browser.getTitle(); };
+
+}
+
+function BrowsePage() {
+
+  this.get = function() {
+    var baseUrl = '/browse-page/';
+    browser.get( baseUrl );
+  };
+
+  this.pageTitle = function() { return browser.getTitle(); };
+
+}
+
+function BrowseFilterablePage() {
+
+  this.get = function() {
+    var baseUrl = '/browse-filterable-page/';
+    browser.get( baseUrl );
+  };
+
+  this.pageTitle = function() { return browser.getTitle(); };
+
+}
+
+function SublandingFilterablePage() {
+
+  this.get = function() {
+    var baseUrl = '/sublanding-filterable-page/';
+    browser.get( baseUrl );
+  };
+
+  this.pageTitle = function() { return browser.getTitle(); };
+
+}
+
+function EventArchivePage() {
+
+  this.get = function() {
+    var baseUrl = '/event-archive-page/';
+    browser.get( baseUrl );
+  };
+
+  this.pageTitle = function() { return browser.getTitle(); };
+
+}
+
+function DocumentDetailPage() {
+
+  this.get = function() {
+    var baseUrl = '/browse-filterable-page/document-detail';
+    browser.get( baseUrl );
+  };
+
+  this.pageTitle = function() { return browser.getTitle(); };
+
+}
+
+function LearnPage() {
+
+  this.get = function() {
+    var baseUrl = '/browse-filterable-page/learn';
+    browser.get( baseUrl );
+  };
+
+  this.pageTitle = function() { return browser.getTitle(); };
+
+}
+
+function EventPage() {
+
+  this.get = function() {
+    var baseUrl = '/browse-filterable-page/event';
+    browser.get( baseUrl );
+  };
+
+  this.pageTitle = function() { return browser.getTitle(); };
+
+}
+
+module.exports.landing = LandingPage;
+module.exports.sublanding = SubLandingPage;
+module.exports.browse = BrowsePage;
+module.exports.browse_filterable = BrowseFilterablePage;
+module.exports.sublanding_filterable = SublandingFilterablePage;
+module.exports.event_archive = EventArchivePage;
+module.exports.docdetail = DocumentDetailPage;
+module.exports.learn = LearnPage;
+module.exports.event = EventPage;

--- a/test/browser_tests/page_objects/page_wagtail_templates.js
+++ b/test/browser_tests/page_objects/page_wagtail_templates.js
@@ -71,7 +71,7 @@ function EventArchivePage() {
 function DocumentDetailPage() {
 
   this.get = function() {
-    var baseUrl = '/browse-filterable-page/document-detail';
+    var baseUrl = '/browse-filterable-page/document-detail-page/';
     browser.get( baseUrl );
   };
 
@@ -82,7 +82,7 @@ function DocumentDetailPage() {
 function LearnPage() {
 
   this.get = function() {
-    var baseUrl = '/browse-filterable-page/learn';
+    var baseUrl = '/browse-filterable-page/learn-page';
     browser.get( baseUrl );
   };
 
@@ -93,7 +93,7 @@ function LearnPage() {
 function EventPage() {
 
   this.get = function() {
-    var baseUrl = '/browse-filterable-page/event';
+    var baseUrl = '/browse-filterable-page/event-page';
     browser.get( baseUrl );
   };
 
@@ -110,3 +110,15 @@ module.exports.event_archive = EventArchivePage;
 module.exports.docdetail = DocumentDetailPage;
 module.exports.learn = LearnPage;
 module.exports.event = EventPage;
+
+module.exports = {
+  landing:    LandingPage,
+  sublanding: SubLandingPage,
+  browse: BrowsePage,
+  browse_filterable: BrowseFilterablePage,
+  sublanding_filterable: SublandingFilterablePage,
+  event_archive: EventArchivePage,
+  docdetail: DocumentDetailPage,
+  learn: LearnPage,
+  event: EventPage
+}

--- a/test/browser_tests/spec_suites/wagtail-page-templates.js
+++ b/test/browser_tests/spec_suites/wagtail-page-templates.js
@@ -4,6 +4,11 @@ var LandingPage = require('../page_objects/page_wagtail_templates.js').landing;
 var SubLandingPage = require('../page_objects/page_wagtail_templates.js').sublanding;
 var BrowsePage = require('../page_objects/page_wagtail_templates.js').browse;
 var BrowseFilterablePage = require('../page_objects/page_wagtail_templates.js').browse_filterable;
+var SublandingFilterablePage = require('../page_objects/page_wagtail_templates.js').sublanding_filterable;
+var EventArchivePage = require('../page_objects/page_wagtail_templates.js').event_archive;
+var LearnPage = require('../page_objects/page_wagtail_templates.js').LearnPage;
+var EventPage = require('../page_objects/page_wagtail_templates.js').EventPage;
+var DocumentDetailPage = require('../page_objects/page_wagtail_templates.js').docdetail;
 
 xdescribe('Wagtail Landing Page', function () {
     var page;
@@ -64,6 +69,86 @@ xdescribe('Wagtail Browse Filterable Page', function () {
     it('should properly load in a browser',
         function () {
             expect(page.pageTitle()).toContain('Browse Filterable Page | Consumer Financial Protection Bureau');
+        }
+    );
+
+});
+
+xdescribe('Wagtail Sublanding Filterable Page', function () {
+    var page;
+
+    beforeAll(function () {
+        page = new SublandingFilterablePage();
+        page.get();
+    });
+
+    it('should properly load in a browser',
+        function () {
+            expect(page.pageTitle()).toContain('Sublanding Filterable Page | Consumer Financial Protection Bureau');
+        }
+    );
+
+});
+
+xdescribe('Wagtail Event Archive Page', function () {
+    var page;
+
+    beforeAll(function () {
+        page = new EventArchivePage();
+        page.get();
+    });
+
+    it('should properly load in a browser',
+        function () {
+            expect(page.pageTitle()).toContain('Event Archive Page | Consumer Financial Protection Bureau');
+        }
+    );
+
+});
+
+xdescribe('Wagtail Learn Page', function () {
+    var page;
+
+    beforeAll(function () {
+        page = new LearnPage();
+        page.get();
+    });
+
+    it('should properly load in a browser',
+        function () {
+            expect(page.pageTitle()).toContain('Learn Page | Consumer Financial Protection Bureau');
+        }
+    );
+
+});
+
+xdescribe('Wagtail Event Page', function () {
+    var page;
+
+    beforeAll(function () {
+        page = new EventPage();
+        page.get();
+    });
+
+    it('should properly load in a browser',
+        function () {
+            expect(page.pageTitle()).toContain('Event Page | Consumer Financial Protection Bureau');
+        }
+    );
+
+});
+
+xdescribe('Wagtail Document Detail Page', function () {
+    var page;
+
+    beforeAll(function () {
+        page = new DocumentDetailPage();
+        page.get();
+    });
+
+    it('should properly load in a browser',
+        function () {
+            expect(page.pageTitle()).toContain('Document Detail Page | Consumer Financial Protection Bureau');
         }
     );
 

--- a/test/browser_tests/spec_suites/wagtail-page-templates.js
+++ b/test/browser_tests/spec_suites/wagtail-page-templates.js
@@ -1,0 +1,70 @@
+'use strict';
+
+var LandingPage = require('../page_objects/page_wagtail_templates.js').landing;
+var SubLandingPage = require('../page_objects/page_wagtail_templates.js').sublanding;
+var BrowsePage = require('../page_objects/page_wagtail_templates.js').browse;
+var BrowseFilterablePage = require('../page_objects/page_wagtail_templates.js').browse_filterable;
+
+xdescribe('Wagtail Landing Page', function () {
+    var page;
+
+    beforeAll(function () {
+        page = new LandingPage();
+        page.get();
+    });
+
+    it('should properly load in a browser',
+        function () {
+            expect(page.pageTitle()).toContain('Landing Page | Consumer Financial Protection Bureau');
+        }
+    );
+
+});
+
+xdescribe('Wagtail SubLanding Page', function () {
+    var page;
+
+    beforeAll(function () {
+        page = new SubLandingPage();
+        page.get();
+    });
+
+    it('should properly load in a browser',
+        function () {
+            expect(page.pageTitle()).toContain('Sublanding Page | Consumer Financial Protection Bureau');
+        }
+    );
+
+});
+
+xdescribe('Wagtail Browse Page', function () {
+    var page;
+
+    beforeAll(function () {
+        page = new BrowsePage();
+        page.get();
+    });
+
+    it('should properly load in a browser',
+        function () {
+            expect(page.pageTitle()).toContain('Browse Page | Consumer Financial Protection Bureau');
+        }
+    );
+
+});
+
+xdescribe('Wagtail Browse Filterable Page', function () {
+    var page;
+
+    beforeAll(function () {
+        page = new BrowseFilterablePage();
+        page.get();
+    });
+
+    it('should properly load in a browser',
+        function () {
+            expect(page.pageTitle()).toContain('Browse Filterable Page | Consumer Financial Protection Bureau');
+        }
+    );
+
+});

--- a/test/browser_tests/spec_suites/wagtail-page-templates.js
+++ b/test/browser_tests/spec_suites/wagtail-page-templates.js
@@ -1,16 +1,16 @@
 'use strict';
 
-var LandingPage = require('../page_objects/page_wagtail_templates.js').landing;
-var SubLandingPage = require('../page_objects/page_wagtail_templates.js').sublanding;
-var BrowsePage = require('../page_objects/page_wagtail_templates.js').browse;
-var BrowseFilterablePage = require('../page_objects/page_wagtail_templates.js').browse_filterable;
-var SublandingFilterablePage = require('../page_objects/page_wagtail_templates.js').sublanding_filterable;
-var EventArchivePage = require('../page_objects/page_wagtail_templates.js').event_archive;
-var LearnPage = require('../page_objects/page_wagtail_templates.js').LearnPage;
-var EventPage = require('../page_objects/page_wagtail_templates.js').EventPage;
-var DocumentDetailPage = require('../page_objects/page_wagtail_templates.js').docdetail;
+var LandingPage = require( '../page_objects/page_wagtail_templates.js' ).landing;
+var SubLandingPage = require( '../page_objects/page_wagtail_templates.js' ).sublanding;
+var BrowsePage = require( '../page_objects/page_wagtail_templates.js' ).browse;
+var BrowseFilterablePage = require( '../page_objects/page_wagtail_templates.js' ).browse_filterable;
+var SublandingFilterablePage = require( '../page_objects/page_wagtail_templates.js' ).sublanding_filterable;
+var EventArchivePage = require( '../page_objects/page_wagtail_templates.js' ).event_archive;
+var LearnPage = require( '../page_objects/page_wagtail_templates.js' ).learn;
+var EventPage = require( '../page_objects/page_wagtail_templates.js' ).event;
+var DocumentDetailPage = require( '../page_objects/page_wagtail_templates.js' ).docdetail;
 
-xdescribe('Wagtail Landing Page', function () {
+describe('Wagtail Landing Page', function () {
     var page;
 
     beforeAll(function () {
@@ -26,7 +26,7 @@ xdescribe('Wagtail Landing Page', function () {
 
 });
 
-xdescribe('Wagtail SubLanding Page', function () {
+describe('Wagtail SubLanding Page', function () {
     var page;
 
     beforeAll(function () {
@@ -42,7 +42,7 @@ xdescribe('Wagtail SubLanding Page', function () {
 
 });
 
-xdescribe('Wagtail Browse Page', function () {
+describe('Wagtail Browse Page', function () {
     var page;
 
     beforeAll(function () {
@@ -58,7 +58,7 @@ xdescribe('Wagtail Browse Page', function () {
 
 });
 
-xdescribe('Wagtail Browse Filterable Page', function () {
+describe('Wagtail Browse Filterable Page', function () {
     var page;
 
     beforeAll(function () {
@@ -74,7 +74,7 @@ xdescribe('Wagtail Browse Filterable Page', function () {
 
 });
 
-xdescribe('Wagtail Sublanding Filterable Page', function () {
+describe('Wagtail Sublanding Filterable Page', function () {
     var page;
 
     beforeAll(function () {
@@ -90,7 +90,7 @@ xdescribe('Wagtail Sublanding Filterable Page', function () {
 
 });
 
-xdescribe('Wagtail Event Archive Page', function () {
+describe('Wagtail Event Archive Page', function () {
     var page;
 
     beforeAll(function () {
@@ -106,7 +106,7 @@ xdescribe('Wagtail Event Archive Page', function () {
 
 });
 
-xdescribe('Wagtail Learn Page', function () {
+describe('Wagtail Learn Page', function () {
     var page;
 
     beforeAll(function () {
@@ -122,7 +122,7 @@ xdescribe('Wagtail Learn Page', function () {
 
 });
 
-xdescribe('Wagtail Event Page', function () {
+describe('Wagtail Event Page', function () {
     var page;
 
     beforeAll(function () {
@@ -138,7 +138,7 @@ xdescribe('Wagtail Event Page', function () {
 
 });
 
-xdescribe('Wagtail Document Detail Page', function () {
+describe('Wagtail Document Detail Page', function () {
     var page;
 
     beforeAll(function () {


### PR DESCRIPTION
Initially i want us to start basic with just testing page templates render with no elements. Then we can break up tasks by page and populate the individual pages with elements and test them.

## Additions

- initial wagtail page template browser tests

## Testing
- run server `./cfgov/manage.py runserver --settings='cfgov.settings.test'`
- initialize database with `./initial-test-data.sh`
- run `gulp test:acceptance --specs=wagtail-page-templates.js --sauce=false --windowSize=610,700`
- dropdb with `./drop-db.sh testdb`

## Review

- @kurtw 
- @richaagarwal 

