### PR TITLE
Updated urls.py for new location of about-us sub-directories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 
 ### Fixed
 
-- 
+- Fixed paths to templates that were moved in to /about-us
 
 ## 3.0.0-3.2.1 - 2016-03-21
 

--- a/cfgov/cfgov/urls.py
+++ b/cfgov/cfgov/urls.py
@@ -151,7 +151,7 @@ urlpatterns = [
             LeadershipCalendarPDFView.as_view(),
             name='leadership-calendar-pdf'),
         url(r'^leadership-calendar/print/$',
-            SheerTemplateView.as_view(template_name='the-bureau/leadership-calendar/print/index.html'),
+            SheerTemplateView.as_view(template_name='about-us/the-bureau/leadership-calendar/print/index.html'),
             name='leadership-calendar-print')],
         namespace='the-bureau')),
 
@@ -203,14 +203,14 @@ urlpatterns = [
         url(r'^(?P<doc_id>[\w-]+)/$',
             SheerTemplateView.as_view(doc_type='career',
                                       local_name='career',
-                                      default_template='careers/_single.html'), name='career'),
+                                      default_template='about-us/careers/_single.html'), name='career'),
 
-        url(r'^current-openings/$', SheerTemplateView.as_view(template_name='current-openings/index.html'),
+        url(r'^current-openings/$', SheerTemplateView.as_view(template_name='about-us/current-openings/index.html'),
             name='current-openings'),
-        url(r'^students-and-graduates/$', SheerTemplateView.as_view(template_name='students-and-graduates/index.html'),
+        url(r'^students-and-graduates/$', SheerTemplateView.as_view(template_name='about-us/students-and-graduates/index.html'),
             name='students-and-graduates'),
 
-        url(r'^working-at-cfpb/$', SheerTemplateView.as_view(template_name='working-at-cfpb/index.html'),
+        url(r'^working-at-cfpb/$', SheerTemplateView.as_view(template_name='about-us/working-at-cfpb/index.html'),
             name='working-at-cfpb'),
 
     ],


### PR DESCRIPTION
Updated urls.py for new location of about-us sub-directories to fix a few issues with `/about-us` urls

## Changes

- Updated careers, doing-business-with-us, and the-bureau in urls.py to fix a few issues with `/about-us` urls

## Testing

- navigate to the pages that have been updated, they shouldn't 404

## Review

- @KimberlyMunoz 
- @rosskarchner 
- @richaagarwal 
- @kave 
- @kurtw 

## Notes

- I'm wondering if /blog and /newsroom should be moved as well

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)