### PR TITLE
Run subdirectory test suites

### DIFF
--- a/cfgov/jinja2/v1/blog/_single.html
+++ b/cfgov/jinja2/v1/blog/_single.html
@@ -3,7 +3,7 @@
 {% set breadcrumb_items = vars.breadcrumb_items %}
 
 {% block title -%}
-    {{ post.title }} | Consumer Financial Protection Bureau
+    {{ post.title | safe}} | Consumer Financial Protection Bureau
 {%- endblock %}
 
 {% block desc -%}

--- a/gulp/tasks/test.js
+++ b/gulp/tasks/test.js
@@ -9,7 +9,11 @@ var config = require( '../config' ).test;
 var fsHelper = require( '../utils/fsHelper' );
 var minimist = require( 'minimist' );
 
-gulp.task( 'test:unit:scripts', function( cb ) {
+/**
+ * Run Mocha JavaScript unit tests.
+ * @param {Function} cb - Callback function to call on completion.
+ */
+function testUnitScripts( cb ) {
   gulp.src( config.src )
     .pipe( $.istanbul( {
       includeUntested: true
@@ -32,29 +36,33 @@ gulp.task( 'test:unit:scripts', function( cb ) {
 
         .on( 'end', cb );
     } );
-} );
+}
 
-gulp.task( 'test:unit:macro', function() {
+/**
+ * Run jinja macro unit tests.
+ */
+function testUnitMacro() {
   spawn(
     'python',
     [ config.tests + '/macro_tests/test_macros.py' ],
     { stdio: 'inherit' }
-  )
-    .once( 'close', function() {
-      $.util.log( 'Macro unit tests done!' );
-    } );
-} );
+  ).once( 'close', function() {
+    $.util.log( 'Macro unit tests done!' );
+  } );
+}
 
-gulp.task( 'test:unit:server', function() {
+/**
+ * Run tox unit tests.
+ */
+function testUnitServer() {
   spawn(
     'tox',
     [ 'cfgov/core/tests' ],
     { stdio: 'inherit' }
-  )
-    .once( 'close', function() {
-      $.util.log( 'Tox tests done!' );
-    } );
-} );
+  ).once( 'close', function() {
+    $.util.log( 'Tox tests done!' );
+  } );
+}
 
 /**
  * Add a command-line flag to a list of Protractor parameters, if present.
@@ -75,10 +83,9 @@ function _addCommandLineFlag( protractorParams, commandLineParams, value ) {
 
 /**
  * Format and return parameters for Protractor binary.
- * @param {boolean} isWagtailSpec flag determining if these params are specific to the wagtail browser spec
  * @returns {Array} List of Protractor binary parameters as strings.
  */
-function _getProtractorParams(isWagtailSpec) {
+function _getProtractorParams() {
 
   // Set default configuration command-line parameter.
   var params = [ 'test/browser_tests/conf.js' ];
@@ -89,9 +96,6 @@ function _getProtractorParams(isWagtailSpec) {
 
   // If --specs=path/to/js flag is added on the command-line,
   // pass the value to protractor to override the default specs to run.
-  if ( isWagtailSpec ) {
-    commandLineParams.specs = 'wagtail/*';
-  }
   params = _addCommandLineFlag( params, commandLineParams, 'specs' );
 
   // If --windowSize=w,h flag is added on the command-line.
@@ -150,35 +154,6 @@ gulp.task( 'test:perf', sitespeedio( {
   }
 } ) );
 
-gulp.task( 'test:acceptance:browser', function() {
-  spawn(
-    fsHelper.getBinary( 'protractor' ),
-    _getProtractorParams(),
-    { stdio: 'inherit' }
-  )
-    .once( 'close', function() {
-      $.util.log( 'Protractor tests done!' );
-    } );
-} );
-
-gulp.task('test:acceptance:wagtail', function () {
-  spawn(
-    './initial-test-data.sh', [], {stdio: 'inherit'}
-  ).once('close', function () {
-    spawn(
-        fsHelper.getBinary('protractor'),
-        _getProtractorParams(true),
-        {stdio: 'inherit'}
-      )
-  });
-});
-
-gulp.task( 'test:acceptance',
-  [
-    'test:acceptance:browser'
-  ]
-);
-
 /**
  * Processes command-line and environment variables
  * for passing to the wcag executable.
@@ -212,35 +187,84 @@ function _parsePath( urlPath ) {
   return urlPath;
 }
 
-gulp.task( 'test:a11y', function() {
+/**
+ * Run WCAG accessibility tests.
+ */
+function testA11y() {
   spawn(
     fsHelper.getBinary( 'wcag', '.bin' ),
     _getWCAGParams(),
     { stdio: 'inherit' }
-  )
-    .once( 'close', function() {
-      $.util.log( 'WCAG tests done!' );
-    } );
-} );
+  ).once( 'close', function() {
+    $.util.log( 'WCAG tests done!' );
+  } );
+}
 
-// This task will only run on Travis
-gulp.task( 'test:coveralls', function() {
+/**
+ * Run the protractor browser acceptance tests.
+ */
+function testAcceptanceBrowser() {
+  spawn(
+    fsHelper.getBinary( 'protractor' ),
+    _getProtractorParams(),
+    { stdio: 'inherit' }
+  ).once( 'close', function() {
+    $.util.log( 'Protractor tests done!' );
+  } );
+}
+
+/**
+ * Initialize the test database
+ * and call the protractor browser acceptance tests.
+ */
+function testAcceptanceWagtail() {
+  spawn(
+    './initial-test-data.sh', [], { stdio: 'inherit' }
+  ).once( 'close', function() {
+    $.util.log( 'Loaded Wagtail database data!' );
+    // TODO: narrow the scope to only --specs=wagtail/*
+    testAcceptanceBrowser();
+  } );
+}
+
+/**
+ * Run coveralls reports on Travis.
+ */
+function testCoveralls() {
   gulp.src( config.tests + '/unit_test_coverage/lcov.info' )
     .pipe( $.coveralls() );
-} );
+}
 
-gulp.task( 'test',
+// This task will only run on Travis
+gulp.task( 'test:coveralls', testCoveralls );
+
+gulp.task( 'test:a11y', testA11y );
+
+gulp.task( 'test:acceptance:browser', testAcceptanceBrowser );
+gulp.task( 'test:acceptance:wagtail', testAcceptanceWagtail );
+gulp.task( 'test:acceptance',
   [
-    'lint',
-    'test:unit',
-    'test:acceptance'
+    'test:acceptance:browser',
+    'test:acceptance:wagtail'
   ]
 );
+
+gulp.task( 'test:unit:scripts', testUnitScripts );
+gulp.task( 'test:unit:macro', testUnitMacro );
+gulp.task( 'test:unit:server', testUnitServer );
 
 gulp.task( 'test:unit',
   [
     'test:unit:scripts',
     'test:unit:macro',
     'test:unit:server'
+  ]
+);
+
+gulp.task( 'test',
+  [
+    'lint',
+    'test:unit',
+    'test:acceptance'
   ]
 );

--- a/initial-test-data.sh
+++ b/initial-test-data.sh
@@ -13,9 +13,9 @@ set -e
 import_data(){
     echo 'Creating DB Tables...'
     ./create-mysql-db.sh
-    ./cfgov/manage.py migrate --settings='cfgov.settings.test'
+    ./cfgov/manage.py migrate
     echo 'Loading Initial Data...'
-    ./cfgov/manage.py runscript initial_test_data --settings='cfgov.settings.test'
+    ./cfgov/manage.py runscript initial_test_data
 }
 
 import_data

--- a/test/browser_tests/environment.js
+++ b/test/browser_tests/environment.js
@@ -20,7 +20,7 @@ module.exports = {
           ':' + ( process.env.HTTP_PORT || webServerDefaultPort ),
 
   // The base path where the spec suites are located.
-  specsBasePath: 'spec_suites/',
+  specsBasePath: 'spec_suites/**/*',
 
   // The default window width and height.
   // Can be overridden with the --windowSize=w,h command-line flag.

--- a/test/browser_tests/jenkins_conf.js
+++ b/test/browser_tests/jenkins_conf.js
@@ -3,10 +3,11 @@
 var JasmineReporters = require( 'jasmine-reporters' );
 var JasmineSpecReporter = require( 'jasmine-spec-reporter' );
 var mkdirp = require( 'mkdirp' );
+var environment = require( './environment.js' );
 
 exports.config = {
   framework:    'jasmine2',
-  specs:        [ 'spec_suites/*.js' ],
+  specs:        [ environment.specsBasePath + '.js' ],
   capabilities: {
     'browserName':       'chrome',
     'name':              'flapjack-browser-tests ' + process.env.SITE_DESC,

--- a/test/browser_tests/spec_suites/blog.js
+++ b/test/browser_tests/spec_suites/blog.js
@@ -24,12 +24,6 @@ describe( 'The Blog Page', function() {
     expect( page.contentSidebar.isPresent() ).toBe( true );
   } );
 
-  it( 'might include Popular Stories in the sidebar', function() {
-    if ( page.popularStories ) {
-      expect( page.popularStoriesTitle.getText() ).toBe( 'POPULAR STORIES' );
-    }
-  } );
-
   it( 'should include a Stay Informed section in the sidebar', function() {
     expect( page.stayInformedSection.isPresent() ).toBe( true );
   } );


### PR DESCRIPTION
## Changes

- Minor config change needed to run test suites in subdirectories in `/test/browser_tests/spec_suites/` by default.
- Updated jenkins to use environment config for path.
- Updated functions in test gulp script to be named functions.

## Removed

- Deprecated blog test.

## Testing

- `gulp test:acceptance --sauce=false` should pass.

## Review

- @KimberlyMunoz 
- @jimmynotjim 
- @sebworks 
