### PR TITLE
Adds on demand templates

### DIFF
--- a/cfgov/jinja2/v1/_includes/on-demand/footer.html
+++ b/cfgov/jinja2/v1/_includes/on-demand/footer.html
@@ -1,0 +1,8 @@
+{# ==========================================================================
+
+   Render a footer for use in the global_include used in non-V1 projects.
+
+   ========================================================================== #}
+
+{% import 'macros/footer-global.html' as footer_global with context %}
+{{ footer_global.render() }}

--- a/cfgov/jinja2/v1/_includes/on-demand/header.html
+++ b/cfgov/jinja2/v1/_includes/on-demand/header.html
@@ -1,0 +1,9 @@
+{# ==========================================================================
+
+   Render a header without the banner, for use in the global_include used
+   in non-V1 projects.
+
+   ========================================================================== #}
+
+{% import 'organisms/header.html' as o_header with context %}
+{{ o_header.render( show_banner=false ) }}

--- a/cfgov/jinja2/v1/test-fixture/index.html
+++ b/cfgov/jinja2/v1/test-fixture/index.html
@@ -99,13 +99,9 @@
     The jinja template and associate HTML to include for an atomic component.
 #}
 {% if atomic_type == 'header' %}
-
-    {# Overlay for the page. Used for the mobile mega menu. #}
-    <div class="a-overlay u-hidden"></div>
-
-    {% import 'organisms/header.html' as o_header with context %}
-    {{ o_header.render() }}
-
+    {% include 'on-demand/header.html' %}
+{% elif atomic_type == 'footer' %}
+    {% include 'on-demand/footer.html' %}
 {% endif %}
 
 {#


### PR DESCRIPTION
## Additions

- Adds on-demand templates for global include. 

## Changes

- Updates test-fixture path to pull in on-demand templates.

## Testing

- `/test-fixture/?atomic=header` should spit out the header.
- `/test-fixture/?atomic=footer` should spit out the footer (CSS will be broken because it's not atomic).

## Review

- @Scotchester 
- @rosskarchner 
- @jimmynotjim 
- @sebworks 
- @KimberlyMunoz 

## Todos

- footer.css needs to be generated with `styles:ondemand` task.
