### PR TITLE
Fixed the missing logo on IE 8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,10 +38,10 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 
 ### Fixed
 
-- Fixed paths to templates that were moved in to /about-us
-- Update biographies for director bios
+- Fixed paths to templates that were moved in to /about-us.
+- Update biographies for director bios.
 - Fixed issue with bad values in the multiselect.
-
+- Fixed the missing logon on IE 8.
 
 ## 3.0.0-3.2.1 - 2016-03-21
 

--- a/cfgov/jinja2/v1/_includes/organisms/header.html
+++ b/cfgov/jinja2/v1/_includes/organisms/header.html
@@ -66,6 +66,14 @@
             {% include 'molecules/global-search.html' with context %}
 
             <a class="o-header_logo" href="/">
+                <!--[if lt IE 9]>
+                    <img class="o-header_logo-img"
+                         src="/static/img/logo_sm-exec.png"
+                         alt="Consumer Financial Protection Bureau"
+                         width="237"
+                         height="50">
+                <![endif]-->
+                <!--[if gt IE 8]><!-->
                 <img class="o-header_logo-img u-js-only"
                      src="/static/img/logo_sm-exec.svg"
                      onerror="this.onerror=null;this.src='/static/img/logo_sm-exec.png';"
@@ -79,6 +87,7 @@
                          width="237"
                          height="50">
                 </noscript>
+                <!--<![endif]-->
             </a>
 
             {% block primary_nav %}


### PR DESCRIPTION
Fixed the missing logo on IE 8

## Additions

- Added conditional IE 8 logo

## Testing

- `gulp build` and check the homepage in a modern browser with and without JS, and IE 8 with and without JS. A single logo should be displayed in all.

## Review

- @sebworks 
- @anselmbradford 
- @KimberlyMunoz 

## Screenshots

__IE 8__

<img width="995" alt="screen shot 2016-04-06 at 10 48 38 am" src="https://cloud.githubusercontent.com/assets/1280430/14323188/2699c494-fbe5-11e5-86a4-bd581b1be1de.png">


## Notes

- We are forcing no-js on IE 8, but the logo swaps to a backup with `noscript`, issue was that logo isn't loaded in IE 8 because the JS is actually still available

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)