### PR TITLE
Adds cordray filter to calendar link

### DIFF
--- a/cfgov/jinja2/v1/about-us/the-bureau/about-director/index.html
+++ b/cfgov/jinja2/v1/about-us/the-bureau/about-director/index.html
@@ -177,7 +177,7 @@
                         See how the director spends his time working for consumers.
                     </p>
                     <a class="jump-link jump-link__underline"
-                       href="{{ vars.path + 'leadership-calendar/' }}">
+                       href="{{ vars.path + 'leadership-calendar/?filter_calendar=Richard+Cordray' }}">
                         View the director’s public calendar
                     </a>
                 </div>


### PR DESCRIPTION
Clicking "View the director’s public calendar” was showing all calendar results (which happened to be mostly Cordray). This updates it to filter out only Rich's results.

## Changes

- Adds cordray filter to calendar link on About the Director page.

## Testing

- Visit `/about-us/the-bureau/about-director/` and click "View the director’s public calendar”
The filter should be pre-checked with Richard Cordray.

## Review

- @KimberlyMunoz 
- @sebworks 
- @jimmynotjim 

