### PR TITLE
tying wagtail tests into gulp tests flow

### DIFF
--- a/gulp/tasks/test.js
+++ b/gulp/tasks/test.js
@@ -102,6 +102,37 @@ function _getProtractorParams() {
   // If --version=number flag is added on the command-line.
   params = _addCommandLineFlag( params, commandLineParams, 'version' );
 
+  console.log(params);
+  return params;
+}
+
+function _getProtractorWagtailParams() {
+
+  // Set default configuration command-line parameter.
+  var params = [ 'test/browser_tests/conf.js' ];
+  var commandLineParams = minimist( process.argv.slice( 2 ) );
+
+  // If --sauce=false flag is added on the command-line.
+  params = _addCommandLineFlag( params, commandLineParams, 'sauce' );
+
+  // If --specs=path/to/js flag is added on the command-line,
+  // pass the value to protractor to override the default specs to run.
+  commandLineParams['specs']  = 'wagtail/*';
+  params = _addCommandLineFlag( params, commandLineParams, 'specs' );
+
+  // If --windowSize=w,h flag is added on the command-line.
+  params = _addCommandLineFlag( params, commandLineParams, 'windowSize' );
+
+  // If --browserName=browser flag is added on the command-line.
+  params = _addCommandLineFlag( params, commandLineParams, 'browserName' );
+
+  // If --platform=os flag is added on the command-line.
+  params = _addCommandLineFlag( params, commandLineParams, 'platform' );
+
+  // If --version=number flag is added on the command-line.
+  params = _addCommandLineFlag( params, commandLineParams, 'version' );
+
+  console.log(params);
   return params;
 }
 
@@ -156,6 +187,26 @@ gulp.task( 'test:acceptance:browser', function() {
       $.util.log( 'Protractor tests done!' );
     } );
 } );
+
+gulp.task('test:acceptance:wagtail', function () {
+  spawn(
+      './initial-test-data.sh', [], {stdio: 'inherit'}
+  ).once('close', function () {
+        spawn(
+            fsHelper.getBinary('protractor'),
+            _getProtractorWagtailParams(),
+            {stdio: 'inherit'}
+        )
+            .once('close', function () {
+              $.util.log('Wagtail Protractor tests done!');
+              spawn(
+                  './drop-db.sh', ['testdb'], {stdio: 'inherit'}
+              ).once('close', function () {
+                  });
+
+            });
+      });
+});
 
 gulp.task( 'test:acceptance',
   [

--- a/gulp/tasks/test.js
+++ b/gulp/tasks/test.js
@@ -75,6 +75,7 @@ function _addCommandLineFlag( protractorParams, commandLineParams, value ) {
 
 /**
  * Format and return parameters for Protractor binary.
+ * @param {boolean} isWagtailSpec flag determining if these params are specific to the wagtail browser spec
  * @returns {Array} List of Protractor binary parameters as strings.
  */
 function _getProtractorParams(isWagtailSpec) {
@@ -88,8 +89,8 @@ function _getProtractorParams(isWagtailSpec) {
 
   // If --specs=path/to/js flag is added on the command-line,
   // pass the value to protractor to override the default specs to run.
-  if (isWagtailSpec){
-    commandLineParams['specs']  = 'wagtail/*';
+  if ( isWagtailSpec ) {
+    commandLineParams.specs = 'wagtail/*';
   }
   params = _addCommandLineFlag( params, commandLineParams, 'specs' );
 
@@ -162,22 +163,20 @@ gulp.task( 'test:acceptance:browser', function() {
 
 gulp.task('test:acceptance:wagtail', function () {
   spawn(
-      './initial-test-data.sh', [], {stdio: 'inherit'}
+    './initial-test-data.sh', [], {stdio: 'inherit'}
   ).once('close', function () {
-        spawn(
-            fsHelper.getBinary('protractor'),
-            _getProtractorParams(true),
-            {stdio: 'inherit'}
-        )
-            .once('close', function () {
-              $.util.log('Wagtail Protractor tests done!');
-              spawn(
-                  './drop-db.sh', ['testdb'], {stdio: 'inherit'}
-              ).once('close', function () {
-                  });
-
-            });
-      });
+    spawn(
+        fsHelper.getBinary('protractor'),
+        _getProtractorParams(true),
+        {stdio: 'inherit'}
+      )
+        .once('close', function () {
+          $.util.log('Wagtail Protractor tests done!');
+          spawn(
+            './drop-db.sh', ['testdb'], {stdio: 'inherit'}
+          );
+        });
+  });
 });
 
 gulp.task( 'test:acceptance',

--- a/gulp/tasks/test.js
+++ b/gulp/tasks/test.js
@@ -77,7 +77,7 @@ function _addCommandLineFlag( protractorParams, commandLineParams, value ) {
  * Format and return parameters for Protractor binary.
  * @returns {Array} List of Protractor binary parameters as strings.
  */
-function _getProtractorParams() {
+function _getProtractorParams(isWagtailSpec) {
 
   // Set default configuration command-line parameter.
   var params = [ 'test/browser_tests/conf.js' ];
@@ -88,6 +88,9 @@ function _getProtractorParams() {
 
   // If --specs=path/to/js flag is added on the command-line,
   // pass the value to protractor to override the default specs to run.
+  if (isWagtailSpec){
+    commandLineParams['specs']  = 'wagtail/*';
+  }
   params = _addCommandLineFlag( params, commandLineParams, 'specs' );
 
   // If --windowSize=w,h flag is added on the command-line.
@@ -102,37 +105,6 @@ function _getProtractorParams() {
   // If --version=number flag is added on the command-line.
   params = _addCommandLineFlag( params, commandLineParams, 'version' );
 
-  console.log(params);
-  return params;
-}
-
-function _getProtractorWagtailParams() {
-
-  // Set default configuration command-line parameter.
-  var params = [ 'test/browser_tests/conf.js' ];
-  var commandLineParams = minimist( process.argv.slice( 2 ) );
-
-  // If --sauce=false flag is added on the command-line.
-  params = _addCommandLineFlag( params, commandLineParams, 'sauce' );
-
-  // If --specs=path/to/js flag is added on the command-line,
-  // pass the value to protractor to override the default specs to run.
-  commandLineParams['specs']  = 'wagtail/*';
-  params = _addCommandLineFlag( params, commandLineParams, 'specs' );
-
-  // If --windowSize=w,h flag is added on the command-line.
-  params = _addCommandLineFlag( params, commandLineParams, 'windowSize' );
-
-  // If --browserName=browser flag is added on the command-line.
-  params = _addCommandLineFlag( params, commandLineParams, 'browserName' );
-
-  // If --platform=os flag is added on the command-line.
-  params = _addCommandLineFlag( params, commandLineParams, 'platform' );
-
-  // If --version=number flag is added on the command-line.
-  params = _addCommandLineFlag( params, commandLineParams, 'version' );
-
-  console.log(params);
   return params;
 }
 
@@ -194,7 +166,7 @@ gulp.task('test:acceptance:wagtail', function () {
   ).once('close', function () {
         spawn(
             fsHelper.getBinary('protractor'),
-            _getProtractorWagtailParams(),
+            _getProtractorParams(true),
             {stdio: 'inherit'}
         )
             .once('close', function () {

--- a/test/browser_tests/spec_suites/wagtail/wagtail-page-templates.js
+++ b/test/browser_tests/spec_suites/wagtail/wagtail-page-templates.js
@@ -1,14 +1,14 @@
 'use strict';
 
-var LandingPage = require( '../page_objects/page_wagtail_templates.js' ).landing;
-var SubLandingPage = require( '../page_objects/page_wagtail_templates.js' ).sublanding;
-var BrowsePage = require( '../page_objects/page_wagtail_templates.js' ).browse;
-var BrowseFilterablePage = require( '../page_objects/page_wagtail_templates.js' ).browse_filterable;
-var SublandingFilterablePage = require( '../page_objects/page_wagtail_templates.js' ).sublanding_filterable;
-var EventArchivePage = require( '../page_objects/page_wagtail_templates.js' ).event_archive;
-var LearnPage = require( '../page_objects/page_wagtail_templates.js' ).learn;
-var EventPage = require( '../page_objects/page_wagtail_templates.js' ).event;
-var DocumentDetailPage = require( '../page_objects/page_wagtail_templates.js' ).docdetail;
+var LandingPage = require( '../../page_objects/page_wagtail_templates.js' ).landing;
+var SubLandingPage = require( '../../page_objects/page_wagtail_templates.js' ).sublanding;
+var BrowsePage = require( '../../page_objects/page_wagtail_templates.js' ).browse;
+var BrowseFilterablePage = require( '../../page_objects/page_wagtail_templates.js' ).browse_filterable;
+var SublandingFilterablePage = require( '../../page_objects/page_wagtail_templates.js' ).sublanding_filterable;
+var EventArchivePage = require( '../../page_objects/page_wagtail_templates.js' ).event_archive;
+var LearnPage = require( '../../page_objects/page_wagtail_templates.js' ).learn;
+var EventPage = require( '../../page_objects/page_wagtail_templates.js' ).event;
+var DocumentDetailPage = require( '../../page_objects/page_wagtail_templates.js' ).docdetail;
 
 describe('Wagtail Landing Page', function () {
     var page;

--- a/test/browser_tests/spec_suites/wagtail/wagtail-page-templates.js
+++ b/test/browser_tests/spec_suites/wagtail/wagtail-page-templates.js
@@ -1,155 +1,155 @@
 'use strict';
 
-var LandingPage = require( '../../page_objects/page_wagtail_templates.js' ).landing;
-var SubLandingPage = require( '../../page_objects/page_wagtail_templates.js' ).sublanding;
-var BrowsePage = require( '../../page_objects/page_wagtail_templates.js' ).browse;
-var BrowseFilterablePage = require( '../../page_objects/page_wagtail_templates.js' ).browse_filterable;
-var SublandingFilterablePage = require( '../../page_objects/page_wagtail_templates.js' ).sublanding_filterable;
-var EventArchivePage = require( '../../page_objects/page_wagtail_templates.js' ).event_archive;
-var LearnPage = require( '../../page_objects/page_wagtail_templates.js' ).learn;
-var EventPage = require( '../../page_objects/page_wagtail_templates.js' ).event;
-var DocumentDetailPage = require( '../../page_objects/page_wagtail_templates.js' ).docdetail;
+var LandingPage = require('../../page_objects/page_wagtail_templates.js').landing;
+var SubLandingPage = require('../../page_objects/page_wagtail_templates.js').sublanding;
+var BrowsePage = require('../../page_objects/page_wagtail_templates.js').browse;
+var BrowseFilterablePage = require('../../page_objects/page_wagtail_templates.js').browse_filterable;
+var SublandingFilterablePage = require('../../page_objects/page_wagtail_templates.js').sublanding_filterable;
+var EventArchivePage = require('../../page_objects/page_wagtail_templates.js').event_archive;
+var LearnPage = require('../../page_objects/page_wagtail_templates.js').learn;
+var EventPage = require('../../page_objects/page_wagtail_templates.js').event;
+var DocumentDetailPage = require('../../page_objects/page_wagtail_templates.js').docdetail;
 
 describe('Wagtail Landing Page', function () {
-    var page;
+  var page;
 
-    beforeAll(function () {
-        page = new LandingPage();
-        page.get();
-    });
+  beforeAll(function () {
+    page = new LandingPage();
+    page.get();
+  });
 
-    it('should properly load in a browser',
-        function () {
-            expect(page.pageTitle()).toContain('Landing Page | Consumer Financial Protection Bureau');
-        }
-    );
+  it('should properly load in a browser',
+    function () {
+      expect(page.pageTitle()).toContain('Landing Page | Consumer Financial Protection Bureau');
+    }
+  );
 
 });
 
 describe('Wagtail SubLanding Page', function () {
-    var page;
+  var page;
 
-    beforeAll(function () {
-        page = new SubLandingPage();
-        page.get();
-    });
+  beforeAll(function () {
+    page = new SubLandingPage();
+    page.get();
+  });
 
-    it('should properly load in a browser',
-        function () {
-            expect(page.pageTitle()).toContain('Sublanding Page | Consumer Financial Protection Bureau');
-        }
-    );
+  it('should properly load in a browser',
+    function () {
+      expect(page.pageTitle()).toContain('Sublanding Page | Consumer Financial Protection Bureau');
+    }
+  );
 
 });
 
 describe('Wagtail Browse Page', function () {
-    var page;
+  var page;
 
-    beforeAll(function () {
-        page = new BrowsePage();
-        page.get();
-    });
+  beforeAll(function () {
+    page = new BrowsePage();
+    page.get();
+  });
 
-    it('should properly load in a browser',
-        function () {
-            expect(page.pageTitle()).toContain('Browse Page | Consumer Financial Protection Bureau');
-        }
-    );
+  it('should properly load in a browser',
+    function () {
+      expect(page.pageTitle()).toContain('Browse Page | Consumer Financial Protection Bureau');
+    }
+  );
 
 });
 
 describe('Wagtail Browse Filterable Page', function () {
-    var page;
+  var page;
 
-    beforeAll(function () {
-        page = new BrowseFilterablePage();
-        page.get();
-    });
+  beforeAll(function () {
+    page = new BrowseFilterablePage();
+    page.get();
+  });
 
-    it('should properly load in a browser',
-        function () {
-            expect(page.pageTitle()).toContain('Browse Filterable Page | Consumer Financial Protection Bureau');
-        }
-    );
+  it('should properly load in a browser',
+    function () {
+      expect(page.pageTitle()).toContain('Browse Filterable Page | Consumer Financial Protection Bureau');
+    }
+  );
 
 });
 
 describe('Wagtail Sublanding Filterable Page', function () {
-    var page;
+  var page;
 
-    beforeAll(function () {
-        page = new SublandingFilterablePage();
-        page.get();
-    });
+  beforeAll(function () {
+    page = new SublandingFilterablePage();
+    page.get();
+  });
 
-    it('should properly load in a browser',
-        function () {
-            expect(page.pageTitle()).toContain('Sublanding Filterable Page | Consumer Financial Protection Bureau');
-        }
-    );
+  it('should properly load in a browser',
+    function () {
+      expect(page.pageTitle()).toContain('Sublanding Filterable Page | Consumer Financial Protection Bureau');
+    }
+  );
 
 });
 
 describe('Wagtail Event Archive Page', function () {
-    var page;
+  var page;
 
-    beforeAll(function () {
-        page = new EventArchivePage();
-        page.get();
-    });
+  beforeAll(function () {
+    page = new EventArchivePage();
+    page.get();
+  });
 
-    it('should properly load in a browser',
-        function () {
-            expect(page.pageTitle()).toContain('Event Archive Page | Consumer Financial Protection Bureau');
-        }
-    );
+  it('should properly load in a browser',
+    function () {
+      expect(page.pageTitle()).toContain('Event Archive Page | Consumer Financial Protection Bureau');
+    }
+  );
 
 });
 
 describe('Wagtail Learn Page', function () {
-    var page;
+  var page;
 
-    beforeAll(function () {
-        page = new LearnPage();
-        page.get();
-    });
+  beforeAll(function () {
+    page = new LearnPage();
+    page.get();
+  });
 
-    it('should properly load in a browser',
-        function () {
-            expect(page.pageTitle()).toContain('Learn Page | Consumer Financial Protection Bureau');
-        }
-    );
+  it('should properly load in a browser',
+    function () {
+      expect(page.pageTitle()).toContain('Learn Page | Consumer Financial Protection Bureau');
+    }
+  );
 
 });
 
 describe('Wagtail Event Page', function () {
-    var page;
+  var page;
 
-    beforeAll(function () {
-        page = new EventPage();
-        page.get();
-    });
+  beforeAll(function () {
+    page = new EventPage();
+    page.get();
+  });
 
-    it('should properly load in a browser',
-        function () {
-            expect(page.pageTitle()).toContain('Event Page | Consumer Financial Protection Bureau');
-        }
-    );
+  it('should properly load in a browser',
+    function () {
+      expect(page.pageTitle()).toContain('Event Page | Consumer Financial Protection Bureau');
+    }
+  );
 
 });
 
 describe('Wagtail Document Detail Page', function () {
-    var page;
+  var page;
 
-    beforeAll(function () {
-        page = new DocumentDetailPage();
-        page.get();
-    });
+  beforeAll(function () {
+    page = new DocumentDetailPage();
+    page.get();
+  });
 
-    it('should properly load in a browser',
-        function () {
-            expect(page.pageTitle()).toContain('Document Detail Page | Consumer Financial Protection Bureau');
-        }
-    );
+  it('should properly load in a browser',
+    function () {
+      expect(page.pageTitle()).toContain('Document Detail Page | Consumer Financial Protection Bureau');
+    }
+  );
 
 });


### PR DESCRIPTION
## Additions

- Wagtail browser tests into gulp 

## Testing

- Ensure your server is running in test mode
 - `./cfgov/manage.py runserver --settings='cfgov.settings.test'`
- `gulp test:acceptance:wagtail --sauce=false`

## Review
- @KimberlyMunoz 
- @anselmbradford 
- @kurtw 
- @richaagarwal 
