### PR TITLE
Add browser tests for various page states

### DIFF
--- a/cfgov/scripts/initial_test_data.py
+++ b/cfgov/scripts/initial_test_data.py
@@ -120,6 +120,14 @@ def run():
         site_root.add_child(instance=shared)
         shared.save_revision(user=admin_user)
 
+    if not DemoPage.objects.filter(slug='shared-draft-page'):
+        shared = DemoPage(title='Shared Page', slug='shared-draft-page', owner=admin_user, live=False, shared=True)
+        site_root.add_child(instance=shared)
+        shared.save_revision(user=admin_user)
+        shared.title = 'Shared Draft Page'
+        shared.save()
+        shared.save_revision(user=admin_user)
+
     if not DemoPage.objects.filter(slug='live-page'):
         live = DemoPage(title='Live Page', slug='live-page', owner=admin_user, live=True, shared=True)
         publish_page(live)

--- a/cfgov/scripts/initial_test_data.py
+++ b/cfgov/scripts/initial_test_data.py
@@ -109,3 +109,25 @@ def run():
         dp.sidefoot = StreamValue(dp.sidefoot.stream_block, [{'type': 'related_links', 'value': {'links': [{'url': '/url', 'text': 'this is a related link'}]}}], True)
         publish_page(dp)
 
+    # Create and configure pages for testing page states
+    if not DemoPage.objects.filter(slug='draft-page'):
+        draft = DemoPage(title='Draft Page', slug='draft-page', owner=admin_user, live=False, shared=False)
+        site_root.add_child(instance=draft)
+        draft.save_revision(user=admin_user)
+
+    if not DemoPage.objects.filter(slug='shared-page'):
+        shared = DemoPage(title='Shared Page', slug='shared-page', owner=admin_user, live=False, shared=True)
+        site_root.add_child(instance=shared)
+        shared.save_revision(user=admin_user)
+
+    if not DemoPage.objects.filter(slug='live-page'):
+        live = DemoPage(title='Live Page', slug='live-page', owner=admin_user, live=True, shared=True)
+        publish_page(live)
+
+    if not DemoPage.objects.filter(slug='live-draft-page'):
+        livedraft = DemoPage(title='Live Draft Page', slug='live-draft-page', owner=admin_user, live=True, shared=True)
+        publish_page(livedraft)
+        livedraft.live = False
+        livedraft.shared = False
+        livedraft.title = 'Live Page'
+        livedraft.save_revision(user=admin_user)

--- a/test/browser_tests/page_objects/page_wagtail_states_pages.js
+++ b/test/browser_tests/page_objects/page_wagtail_states_pages.js
@@ -1,0 +1,68 @@
+'use strict';
+
+function DraftPage() {
+
+  this.get = function() {
+    var baseUrl = '/draft-page/';
+    browser.get( baseUrl );
+  };
+
+  this.pageTitle = function() { return browser.getTitle(); };
+
+}
+
+function SharedPage() {
+
+  this.get = function() {
+    var baseUrl = '/shared-page/';
+    browser.get( baseUrl );
+  };
+
+  this.getStaging = function() {
+    var baseUrl = 'content.' + process.env.HTTP_HOST + ':' + process.env.HTTP_PORT + '/shared-page/';
+    browser.get( baseUrl );
+  };
+
+  this.pageTitle = function() { return browser.getTitle(); };
+
+}
+
+function SharedDraftPage() {
+
+  this.get = function() {
+    var baseUrl = '/shared-draft-page/';
+    browser.get( baseUrl );
+  };
+
+  this.pageTitle = function() { return browser.getTitle(); };
+
+}
+
+function LivePage() {
+
+  this.get = function() {
+    var baseUrl = '/live-page/';
+    browser.get( baseUrl );
+  };
+
+  this.pageTitle = function() { return browser.getTitle(); };
+
+}
+
+function LiveDraftPage() {
+
+  this.get = function() {
+    var baseUrl = '/live-draft-page/';
+    browser.get( baseUrl );
+  };
+
+  this.pageTitle = function() { return browser.getTitle(); };
+
+}
+
+module.exports = {
+  draftpage: DraftPage,
+  sharedpage: SharedPage,
+  livepage: LivePage,
+  livedraftpage: LiveDraftPage,
+};

--- a/test/browser_tests/page_objects/page_wagtail_states_pages.js
+++ b/test/browser_tests/page_objects/page_wagtail_states_pages.js
@@ -19,7 +19,8 @@ function SharedPage() {
   };
 
   this.getStaging = function() {
-    var baseUrl = 'content.' + process.env.HTTP_HOST + ':' + process.env.HTTP_PORT + '/shared-page/';
+    var baseUrl = 'content.' + process.env.HTTP_HOST + ':' + 
+      process.env.HTTP_PORT + '/shared-page/';
     browser.get( baseUrl );
   };
 
@@ -61,8 +62,8 @@ function LiveDraftPage() {
 }
 
 module.exports = {
-  draftpage: DraftPage,
-  sharedpage: SharedPage,
-  livepage: LivePage,
-  livedraftpage: LiveDraftPage,
+  draftpage:     DraftPage,
+  sharedpage:    SharedPage,
+  livepage:      LivePage,
+  livedraftpage: LiveDraftPage
 };

--- a/test/browser_tests/page_objects/page_wagtail_states_pages.js
+++ b/test/browser_tests/page_objects/page_wagtail_states_pages.js
@@ -1,16 +1,5 @@
 'use strict';
 
-function DraftPage() {
-
-  this.get = function() {
-    var baseUrl = '/draft-page/';
-    browser.get( baseUrl );
-  };
-
-  this.pageTitle = function() { return browser.getTitle(); };
-
-}
-
 function SharedPage() {
 
   this.get = function() {
@@ -19,7 +8,7 @@ function SharedPage() {
   };
 
   this.getStaging = function() {
-    var baseUrl = 'content.' + process.env.HTTP_HOST + ':' + 
+    var baseUrl = process.env.STAGING_HOSTNAME + ':' + 
       process.env.HTTP_PORT + '/shared-page/';
     browser.get( baseUrl );
   };
@@ -35,25 +24,9 @@ function SharedDraftPage() {
     browser.get( baseUrl );
   };
 
-  this.pageTitle = function() { return browser.getTitle(); };
-
-}
-
-function LivePage() {
-
-  this.get = function() {
-    var baseUrl = '/live-page/';
-    browser.get( baseUrl );
-  };
-
-  this.pageTitle = function() { return browser.getTitle(); };
-
-}
-
-function LiveDraftPage() {
-
-  this.get = function() {
-    var baseUrl = '/live-draft-page/';
+  this.getStaging = function() {
+    var baseUrl = process.env.STAGING_HOSTNAME + ':' + 
+      process.env.HTTP_PORT + '/shared-draft-page/';
     browser.get( baseUrl );
   };
 
@@ -62,8 +35,6 @@ function LiveDraftPage() {
 }
 
 module.exports = {
-  draftpage:     DraftPage,
   sharedpage:    SharedPage,
-  livepage:      LivePage,
-  livedraftpage: LiveDraftPage
+  shareddraftpage:    SharedDraftPage,
 };

--- a/test/browser_tests/spec_suites/wagtail/wagtail-page-states-pages.js
+++ b/test/browser_tests/spec_suites/wagtail/wagtail-page-states-pages.js
@@ -1,77 +1,84 @@
 'use strict';
 
-var DraftPage = require( '../../page_objects/page_wagtail_states_pages.js' ).draftpage;
-var SharedPage = require( '../../page_objects/page_wagtail_states_pages.js' ).sharedpage;
-var LivePage = require( '../../page_objects/page_wagtail_states_pages.js' ).livepage;
-var LiveDraftPage = require( '../../page_objects/page_wagtail_states_pages.js' ).livedraftpage;
+var DraftPage = require(
+  '../../page_objects/page_wagtail_states_pages.js' ).draftpage;
+var SharedPage = require(
+  '../../page_objects/page_wagtail_states_pages.js' ).sharedpage;
+var LivePage = require(
+  '../../page_objects/page_wagtail_states_pages.js' ).livepage;
+var LiveDraftPage = require(
+  '../../page_objects/page_wagtail_states_pages.js' ).livedraftpage;
 
-describe( 'Wagtail Draft Page', function () {
+describe( 'Wagtail Draft Page', function() {
   var page;
 
-  beforeAll(function () {
+  beforeAll( function() {
     page = new DraftPage();
     page.get();
-  });
+  } );
 
   it( 'should not load in a browser',
-    function () {
-      expect(404);
+    function() {
+      expect( 404 );
     }
   );
 
-});
+} );
 
-describe( 'Wagtail Shared Page', function () {
+describe( 'Wagtail Shared Page', function() {
   var page;
 
-  beforeAll(function () {
+  beforeAll( function() {
     page = new SharedPage();
-  });
+  } );
 
   it( 'should not load in a browser',
-    function () {
+    function() {
       page.get();
-      expect(404);
+      expect( 404 );
     }
   );
 
   it( 'should properly load in a browser',
-    function () {
+    function() {
       page.getStaging();
-      expect(page.pageTitle()).toContain( 'Shared Page | Consumer Financial Protection Bureau' );
+      expect( page.pageTitle() ).toContain(
+        'Shared Page | Consumer Financial Protection Bureau' );
     }
   );
 
-});
+} );
 
-describe( 'Wagtail Live Page', function () {
+describe( 'Wagtail Live Page', function() {
   var page;
 
-  beforeAll(function () {
+  beforeAll( function() {
     page = new LivePage();
     page.get();
-  });
+  } );
 
   it( 'should properly load in a browser',
-    function () {
-      expect(page.pageTitle()).toContain( 'Live Page | Consumer Financial Protection Bureau' );
+    function() {
+      expect( page.pageTitle() ).toContain(
+        'Live Page | Consumer Financial Protection Bureau' );
     }
   );
 
-});
+} );
 
-describe( 'Wagtail Live Draft Page', function () {
+describe( 'Wagtail Live Draft Page', function() {
   var page;
 
-  beforeAll(function () {
+  beforeAll( function() {
     page = new LiveDraftPage();
     page.get();
-  });
+  } );
 
   it( 'should properly load in a browser',
-    function () {
-      expect(page.pageTitle()).toContain( 'Live Draft Page | Consumer Financial Protection Bureau' );
+    function() {
+      expect( page.pageTitle() ).toContain(
+        'Live Draft Page | Consumer Financial Protection Bureau' );
     }
   );
 
-});
+} );

--- a/test/browser_tests/spec_suites/wagtail/wagtail-page-states-pages.js
+++ b/test/browser_tests/spec_suites/wagtail/wagtail-page-states-pages.js
@@ -19,7 +19,7 @@ describe( 'Wagtail Draft Page', function() {
 
   it( 'should not load in a browser',
     function() {
-      expect( 404 );
+      expect( !page );
     }
   );
 
@@ -35,7 +35,7 @@ describe( 'Wagtail Shared Page', function() {
   it( 'should not load in a browser',
     function() {
       page.get();
-      expect( 404 );
+      expect( !page );
     }
   );
 

--- a/test/browser_tests/spec_suites/wagtail/wagtail-page-states-pages.js
+++ b/test/browser_tests/spec_suites/wagtail/wagtail-page-states-pages.js
@@ -1,0 +1,77 @@
+'use strict';
+
+var DraftPage = require( '../../page_objects/page_wagtail_states_pages.js' ).draftpage;
+var SharedPage = require( '../../page_objects/page_wagtail_states_pages.js' ).sharedpage;
+var LivePage = require( '../../page_objects/page_wagtail_states_pages.js' ).livepage;
+var LiveDraftPage = require( '../../page_objects/page_wagtail_states_pages.js' ).livedraftpage;
+
+describe( 'Wagtail Draft Page', function () {
+  var page;
+
+  beforeAll(function () {
+    page = new DraftPage();
+    page.get();
+  });
+
+  it( 'should not load in a browser',
+    function () {
+      expect(404);
+    }
+  );
+
+});
+
+describe( 'Wagtail Shared Page', function () {
+  var page;
+
+  beforeAll(function () {
+    page = new SharedPage();
+  });
+
+  it( 'should not load in a browser',
+    function () {
+      page.get();
+      expect(404);
+    }
+  );
+
+  it( 'should properly load in a browser',
+    function () {
+      page.getStaging();
+      expect(page.pageTitle()).toContain( 'Shared Page | Consumer Financial Protection Bureau' );
+    }
+  );
+
+});
+
+describe( 'Wagtail Live Page', function () {
+  var page;
+
+  beforeAll(function () {
+    page = new LivePage();
+    page.get();
+  });
+
+  it( 'should properly load in a browser',
+    function () {
+      expect(page.pageTitle()).toContain( 'Live Page | Consumer Financial Protection Bureau' );
+    }
+  );
+
+});
+
+describe( 'Wagtail Live Draft Page', function () {
+  var page;
+
+  beforeAll(function () {
+    page = new LiveDraftPage();
+    page.get();
+  });
+
+  it( 'should properly load in a browser',
+    function () {
+      expect(page.pageTitle()).toContain( 'Live Draft Page | Consumer Financial Protection Bureau' );
+    }
+  );
+
+});

--- a/test/browser_tests/spec_suites/wagtail/wagtail-page-states-pages.js
+++ b/test/browser_tests/spec_suites/wagtail/wagtail-page-states-pages.js
@@ -1,20 +1,18 @@
 'use strict';
 
-var DraftPage = require(
-  '../../page_objects/page_wagtail_states_pages.js' ).draftpage;
-var SharedPage = require(
-  '../../page_objects/page_wagtail_states_pages.js' ).sharedpage;
-var LivePage = require(
-  '../../page_objects/page_wagtail_states_pages.js' ).livepage;
-var LiveDraftPage = require(
-  '../../page_objects/page_wagtail_states_pages.js' ).livedraftpage;
+var state_pages = require(
+  '../../page_objects/page_wagtail_states_pages.js' )
+var SharedPage = state_pages.sharedpage
+var SharedDraftPage = state_pages.shareddraftpage
+
+var TITLE_TAGLINE = ' | Consumer Financial Protection Bureau';
+
 
 describe( 'Wagtail Draft Page', function() {
   var page;
 
   beforeAll( function() {
-    page = new DraftPage();
-    page.get();
+    page = browser.get('/draft-page/');
   } );
 
   it( 'should not load in a browser',
@@ -42,8 +40,38 @@ describe( 'Wagtail Shared Page', function() {
   it( 'should properly load in a browser',
     function() {
       page.getStaging();
-      expect( page.pageTitle() ).toContain(
-        'Shared Page | Consumer Financial Protection Bureau' );
+      expect( page.pageTitle() ).toEqual( 'Shared Page' + TITLE_TAGLINE );
+    }
+  );
+
+} );
+
+describe( 'Wagtail Shared Draft Page', function() {
+  var page;
+
+  beforeAll( function() {
+    page = new SharedDraftPage();
+  } );
+
+  it( 'should not load in a browser',
+    function() {
+      page.get();
+      expect( !page );
+    }
+  );
+
+  it( 'should properly load in a browser',
+    function() {
+      page.getStaging();
+      expect( page.pageTitle() ).toEqual( 'Shared Page' + TITLE_TAGLINE );
+    }
+  );
+
+  it( 'should not display unshared content',
+    function() {
+      page.getStaging();
+      expect( page.pageTitle() ).not.toEqual(
+        'Shared Draft Page' + TITLE_TAGLINE );
     }
   );
 
@@ -53,14 +81,12 @@ describe( 'Wagtail Live Page', function() {
   var page;
 
   beforeAll( function() {
-    page = new LivePage();
-    page.get();
+    page = browser.get('/live-page/');
   } );
 
   it( 'should properly load in a browser',
     function() {
-      expect( page.pageTitle() ).toContain(
-        'Live Page | Consumer Financial Protection Bureau' );
+      expect( browser.getTitle() ).toEqual( 'Live Page' + TITLE_TAGLINE );
     }
   );
 
@@ -70,14 +96,13 @@ describe( 'Wagtail Live Draft Page', function() {
   var page;
 
   beforeAll( function() {
-    page = new LiveDraftPage();
-    page.get();
+    page = browser.get('/live-draft-page/');
   } );
 
   it( 'should properly load in a browser',
     function() {
-      expect( page.pageTitle() ).toContain(
-        'Live Draft Page | Consumer Financial Protection Bureau' );
+      expect( browser.getTitle() ).toEqual(
+        'Live Draft Page' + TITLE_TAGLINE );
     }
   );
 


### PR DESCRIPTION
This is the beginning of testing Wagtail page states.

### Testing

- Run `gulp test:acceptance:wagtail --specs=wagtail/wagtail-page-states-pages.js --sauce=false --windowSize=610,700`

### Review

- @kave 
- @richaagarwal 
- @jimmynotjim 
- @anselmbradford 