### PR TITLE
Adding Fixes for Event Detail display.

### DIFF
--- a/cfgov/jinja2/v1/events/_macros.html
+++ b/cfgov/jinja2/v1/events/_macros.html
@@ -36,7 +36,6 @@
 
 {% macro event_location_image(options={}) %}
     {% from 'macros/util/format/url.html' import location_image_url as location_image_url %}
-
     <img class="{{ options.additional_classes if options.additional_classes else '' }}"
          src="{{ location_image_url({
                         'location': options.location
@@ -70,12 +69,11 @@
    ========================================================================== #}
 
 {% macro event_meta_address(event, address_format='{city}, {state}') %}
-    {%- set city   =  event.venue_city     | default('Washington', true) -%}
-    {%- set state  =  event.venue_state    | default('DC', true) -%}
-    {%- set street =  event.venue_street   | default('1275 First St NE', true) -%}
-    {%- set name   =  event.venue_name     | default('CFPB', true) -%}
-    {%- set zip    =  event.venue_zip_code | default('20002', true) -%}
-
+    {%- set city   =  event.venue_city   | default('', true) -%}
+    {%- set state  =  event.venue_state  | default('', true) -%}
+    {%- set street =  event.venue_street | default('', true) -%}
+    {%- set name   =  event.venue_name   | default('', true) -%}
+    {%- set zip    =  event.venue_zip    | default('', true) -%}
     <p class="event-meta_address h-adr">
         {%- macro _city() %}
             <span class="event-meta_city p-locality">{{ city }}</span>
@@ -128,7 +126,8 @@
    ========================================================================== #}
 
 {% macro event_venue(event, event_state) %}
-    {%- set city =  event.venue_city + ', ' + event.venue_state | default('Washington, DC') -%}
+    {% set state_prefix = ', ' if event.venue_city and event.venue_state else '' %}
+    {% set city_prefix_state = event.venue_city ~ state_prefix ~ event.venue_state %}
     <section class="event-venue">
         <div class="event-venue_details">
             <header class="event-venue_header">
@@ -140,13 +139,13 @@
                 </button>
                 {% endif %}
                 <h2 class="event-venue_heading">
-                    {{ city }}
+                    {{ city_prefix_state }}
                 </h2>
             </header>
             <div class="content-l">
                 <div class="event-meta content-l_col content-l_col-1-2">
                     {{ event_meta_address(event,
-                        address_format ='{venue} {street} {city}, {state} {zip}'
+                        address_format ='{venue} {street} {city}' ~ state_prefix ~ '{state} {zip}'
                     ) }}
                 </div>
                 <div class="content-l_col content-l_col-1-2 event-calendar_container">
@@ -197,7 +196,7 @@
                 }) }}
             {% else %}
                 {{ event_location_image({
-                    'location': city,
+                    'location': city_prefix_state,
                     'zoom':     '12',
                     'scale':    '2',
                     'size':     '640x320'

--- a/cfgov/unprocessed/css/pages/event.less
+++ b/cfgov/unprocessed/css/pages/event.less
@@ -128,6 +128,13 @@
 .event-meta_address {
     text-transform: capitalize;
     display: inline-block;
+
+    .event-meta_street:not(:empty):after {
+        // Adding a linebreak after the street if it's contents
+        // aren't empty.
+        content: '\A';
+        white-space: pre;
+    }
 }
 
 .event-calendar_container .datetime {


### PR DESCRIPTION
Removing default data from the event venue template. We are still defaulting the Google Map image to Washington DC when no venue info is present. This also fixes a 'comma' bug in the template which caused the map to display a weird location when no venue info was present.

## Additions

- Added CSS to add a line break after the state if it wasn't empty.

## Changes

- Modified the template to fix issues with default data, commas, and a line break on the street address.

## Testing

-  Visit `http://localhost:8000/about-us/events/archive-past-events/summer-consumer-advisory-board-meeting-in-reno-nv/` and observe the address.

## Review

- @anselmbradford 
- @KimberlyMunoz 
- @jimmynotjim 

## Screenshots
<img width="676" alt="screen shot 2016-04-06 at 3 13 01 pm" src="https://cloud.githubusercontent.com/assets/1696212/14329591/15246c94-fc0a-11e5-896c-08e7949ec265.png">


## Notes

- This doesn't address the issue of Wagtail stripping leading zeroes from zip codes. @kave, can you take a look at that?



## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
