### PR TITLE
Updating Capital Framework to 3.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Updated the placeholders in wagtail filterable list controls.
 - Updated footer to atomic footer.
 - Pinned our NPM dependencies.
+- Updated Capital Framework to 3.3.0
 
 ### Removed
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "banner-footer-webpack-plugin": "git://github.com/dtothefp/banner-footer-webpack-plugin.git",
     "browser-sync": "2.11.2",
-    "capital-framework": "3.2.1",
+    "capital-framework": "3.3.0",
     "del": "2.2.0",
     "gulp": "3.9.1",
     "gulp-autoprefixer": "3.1.0",


### PR DESCRIPTION
Updating Capital Framework to 3.3.0

## Changes

- Bumped CF to 3.3.0

## Testing

- `gulp build`
- `gulp test:unit`
- `gulp test:acceptance --sauce=false`

## Review

- @KimberlyMunoz 
- @sebworks 
- @anselmbradford 

## Notes

- When updatinga a dep, run `npm install [dep name]@[version] --save[-dev]`.
- After install build the project and run tests to make sure nothing breaks.
- Check package.json, mostly likely npm has added `^` when saving the new version, make sure to remove it.

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)