### PR TITLE
Root-relative flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Updated footer to atomic footer.
 - Pinned our NPM dependencies.
 - Updated Capital Framework to 3.3.0
+- Changed U.S. flag image paths to be root-relative
 
 ### Removed
 

--- a/cfgov/unprocessed/css/molecules/global-eyebrow.less
+++ b/cfgov/unprocessed/css/molecules/global-eyebrow.less
@@ -53,10 +53,10 @@
 
     &_tagline {
         padding-left: 37px; //22px flag + 15px spacing
-        background: url('../img/us-flag_22x13.png') no-repeat 0 0;
+        background: url('/static/img/us-flag_22x13.png') no-repeat 0 0;
 
         .respond-to-dpi(2, {
-            background-image: url('../img/us-flag_44x26.png');
+            background-image: url('/static/img/us-flag_44x26.png');
             background-size: 22px;
         });
 

--- a/cfgov/unprocessed/css/organisms/footer.less
+++ b/cfgov/unprocessed/css/organisms/footer.less
@@ -195,7 +195,7 @@
         .o-footer_official-website {
             .short-desc();
             padding-left: 37px; //22px flag + 15px spacing
-            background: url( '../img/us-flag_22x13.png' ) no-repeat 0 4px;
+            background: url( '/static/img/us-flag_22x13.png' ) no-repeat 0 4px;
 
             // This media query is to keep 'United States Government'
             // on one line.
@@ -204,7 +204,7 @@
             } );
 
             .respond-to-dpi( 2, {
-                background-image: url( '../img/us-flag_44x26.png' );
+                background-image: url( '/static/img/us-flag_44x26.png' );
                 background-size: 22px;
             } );
         }


### PR DESCRIPTION
As discussed with @anselmbradford, this PR sets the paths of the U.S. flag images to be root-relative. This allows sites that are relying on the on-demand versions of this CSS (such as my Sheer projects) to find those flag images in their canonical cfgov-refresh location, rather than having to add them to their static files, as well.

## Changes

- Changed `us-flag` image paths to be root-relative.

## Testing

1. Pull down this fork
2. Rebuild the CSS
3. Serve the site
4. Observe that the flag images still load

## Review

- @anselmbradford 
- @KimberlyMunoz 
- @sebworks  
- @jimmynotjim 


## Notes

- This would allow me to revert the last commit in cfpb/cfgov-sheer-templates#8, which would be great.

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
