### PR TITLE
Reduce mobile header height + add styles per spec feedback

### DIFF
--- a/cfgov/unprocessed/css/molecules/global-search.less
+++ b/cfgov/unprocessed/css/molecules/global-search.less
@@ -1,5 +1,5 @@
 
-// TODO: Move the theme variables to cf-enhancements.
+// TODO: Move the theme variables to /enhancements/ for CF.
 /* topdoc
   name: Theme variables
   family: cf-core
@@ -12,12 +12,14 @@
         - |
           @margin__em
           @margin_half__em
+          @mobile_trigger_ht__px
   tags:
     - cf-core
 */
 
 @margin__em: unit( @grid_gutter-width / @base-font-size-px, em );
 @margin_half__em: unit( @grid_gutter-width / 2 / @base-font-size-px, em );
+@mobile_trigger_ht__px: 54px;
 
 /* topdoc
   name: Global Search molecule
@@ -164,8 +166,8 @@
         &_trigger{
             padding-top: unit( @grid_gutter-width / 2 / 16px, em );
             padding-bottom: unit( @grid_gutter-width / 2 / 16px, em );
-            height: unit( 60px / @base-font-size-px, em );
-            min-width: unit( 60px / @base-font-size-px, em );
+            height: unit( @mobile_trigger_ht__px / @base-font-size-px, em );
+            min-width: unit( @mobile_trigger_ht__px / @base-font-size-px, em );
 
             &:before {
                 font-size: unit( 20px / 16px, em );

--- a/cfgov/unprocessed/css/organisms/header.less
+++ b/cfgov/unprocessed/css/organisms/header.less
@@ -10,11 +10,15 @@
       codenotes:
         - |
           @margin_half__em
+          @mobile_trigger_ht__px
+          @min_app_width__px
   tags:
     - cf-core
 */
 
 @margin_half__em: unit( @grid_gutter-width / 2 / @base-font-size-px, em );
+@mobile_trigger_ht__px: 54px;
+@min_app_width__px: 320px;
 
 /* topdoc
   name: Header
@@ -66,7 +70,7 @@
 */
 
 .o-header {
-    min-width: 320px;
+    min-width: @min_app_width__px;
     border-bottom: 5px solid @green;
     position: relative;
     z-index: 10;
@@ -128,21 +132,24 @@
         // Tablet/mobile sizes.
         .respond-to-max( @bp-sm-max, {
             .js & {
-                // Offset logo by width of mega menu trigger: 60px + 10px gap.
-                margin-left: 70px;
+                // Offset logo by width of mega menu trigger + 10px gap.
+                margin-left: @mobile_trigger_ht__px + ( @grid_gutter-width / 2 );
             }
         } );
 
         &-img {
-            height: 40px;
-            width: 190px;
-            margin: 10px;
+            // Size is to fit 320px minimum width for older iPhones, etc.
+            height: @mobile_trigger_ht__px - 20px;
+            width: auto;
+            // Margin is to bring height to menu trigger's 60px (40 + 10 + 10).
+            margin-top: 10px;
+            margin-bottom: 10px;
             // Removes typical inline vertical whitespace.
             vertical-align: middle;
 
             // Desktop size.
             .respond-to-min( @bp-med-min, {
-                margin: 0 0 unit(20px / @base-font-size-px, em) 0;
+                margin: 0 0 unit( 20px / @base-font-size-px, em ) 0;
                 height: 50px;
                 width: 237px;
             } );

--- a/cfgov/unprocessed/css/organisms/mega-menu.less
+++ b/cfgov/unprocessed/css/organisms/mega-menu.less
@@ -1,3 +1,22 @@
+
+// TODO: Move the theme variables to /enhancements/ for CF.
+/* topdoc
+  name: Theme variables
+  family: cf-core
+  notes:
+    - "The following color and sizing variables are exposed, allowing you to
+       easily override them before compiling."
+  patterns:
+    - name: Sizing
+      codenotes:
+        - |
+          @mobile_trigger_ht__px
+  tags:
+    - cf-core
+*/
+
+@mobile_trigger_ht__px: 54px;
+
 /* topdoc
   name: Mega Menu
   family: cfgov-organisms
@@ -162,8 +181,8 @@
     .respond-to-max( @bp-sm-max, {
         &_trigger {
             display: none;
-            height: unit( 60px / 18px, em );
-            min-width: unit( 60px / 18px, em );
+            height: unit( @mobile_trigger_ht__px / 18px, em );
+            min-width: unit( @mobile_trigger_ht__px / 18px, em );
             padding-top: unit( @grid_gutter-width / 2 / 18px, em );
             padding-bottom: unit( @grid_gutter-width / 2 / 18px, em );
 
@@ -173,6 +192,7 @@
 
             background: @white;
             border: none;
+            border-right: 1px solid @gray-40;
             color: @black;
             font-size: unit( 18px / @base-font-size-px, em );
 
@@ -319,7 +339,7 @@
         &_content-1 {
             .js & {
                 // Offset for height of trigger button.
-                top: 60px;
+                top: @mobile_trigger_ht__px;
             }
             display: block;
 


### PR DESCRIPTION
## Changes

- Reduces height of mega menu and global search triggers.
- Creates `@mobile_trigger_ht__px` to track header height.
- Adds right-side border to mega-menu hamburger menu.

## Testing

- `gulp build`
- Boot up the iOS simulator for an iPhone 5.
- C-c-check it out and click the menu and search buttons.

## Review

- @sebworks 
- @jimmynotjim 
- @KimberlyMunoz 
- @ajbush @duelj 

## Screenshots

![screen shot 2016-04-07 at 2 47 55 pm](https://cloud.githubusercontent.com/assets/704760/14363061/5ce54bea-fcd0-11e5-8ce3-99cb92782c9f.png)
