### PR TITLE
Menu CSS cleanup / spec feedback

### DIFF
--- a/cfgov/unprocessed/css/organisms/mega-menu.less
+++ b/cfgov/unprocessed/css/organisms/mega-menu.less
@@ -218,14 +218,6 @@
                 z-index: 10;
             }
 
-            &-2,
-            &-3 {
-                position: absolute;
-                left: 0;
-                top: -1px;
-                z-index: 10;
-            }
-
             background-color: @gray-5;
             border-top: 1px solid @gray-50;
             border-bottom: 1px solid @gray-50;
@@ -269,11 +261,6 @@
                 border-bottom: 1px solid @gray-50;
             }
 
-            &-grid {
-                padding-left: unit( @grid_gutter-width / 2 / 18px, em );
-                padding-right: unit( @grid_gutter-width / 2 / @base-font-size-px, em );
-            }
-
             // Adjust padding and margin on unordered list menu items
             // above the global eyebrow.
             &-list {
@@ -292,6 +279,7 @@
                 .u-link__colors( @pacific, @pacific, @pacific-60, @pacific, @dark-navy );
 
                 padding-top: @grid_gutter-width / 2;
+                padding-right: @grid_gutter-width / 2;
                 padding-bottom: @grid_gutter-width / 2;
 
                 .js & {
@@ -374,7 +362,6 @@
 
         // 3rd-level menu - Tablet/Mobile.
         &_content-3 {
-
             // TODO: There is similar code set on all three menus.
             //       Investigate if it can be combined.
             // Remove final border line of last list item.
@@ -386,10 +373,18 @@
         }
 
         // Submenus - Tablet/Mobile.
-        // TODO: Enable when third-level behaviors are in.
         &_content-2,
         &_content-3 {
             .u-move-right();
+            position: absolute;
+            left: 0;
+            top: -1px;
+            z-index: 10;
+
+            &-grid {
+                padding-left: unit( @grid_gutter-width / 2 / 18px, em );
+                padding-right: unit( @grid_gutter-width / 2 / @base-font-size-px, em );
+            }
         }
     } );
 


### PR DESCRIPTION
## Changes

- Add padding-right to menu items so that they wrap before colliding with the green arrow.
- Consolidates -content-2, -content-3 styles.
- Fixes padding issues on -grid styles where the menus where getting different padding at different levels.

## Testing

- `gulp build` 'n' check the mobile menu.
- Desktop should be unaffected.

## Review

- @jimmynotjim 
- @KimberlyMunoz 
- @sebworks 
- @duelj @ajbush 

## Screenshots

1st level
![screen shot 2016-04-07 at 4 54 46 pm](https://cloud.githubusercontent.com/assets/704760/14366668/f12f3b42-fce1-11e5-8b42-04d4a781b05f.png)

2nd level
![screen shot 2016-04-07 at 4 54 55 pm](https://cloud.githubusercontent.com/assets/704760/14366680/fa9e55a0-fce1-11e5-85d6-09f5c9bc1faf.png)

3rd level
![screen shot 2016-04-07 at 4 59 49 pm](https://cloud.githubusercontent.com/assets/704760/14366707/2c019698-fce2-11e5-8339-7be764a44bbb.png)

