### PR TITLE
Fix download links from becoming relative

### DIFF
--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -188,6 +188,7 @@ ALLOWED_HOSTS = ['*']
 
 EXTERNAL_LINK_PATTERN = r'https?:\/\/(?:www\.)?(?![^\?]+gov)(?!(content\.)?localhost).*'
 NONCFPB_LINK_PATTERN = r'(https?:\/\/(?:www\.)?(?![^\?]*(cfpb|consumerfinance).gov)(?!(content\.)?localhost).*)'
+FILES_LINK_PATTERN = r'https?:\/\/files\.consumerfinance.gov\/f\/\S+\.[a-z]+'
 
 # Wagtail settings
 

--- a/cfgov/v1/__init__.py
+++ b/cfgov/v1/__init__.py
@@ -56,6 +56,7 @@ def environment(**options):
 def parse_links(soup):
     extlink_pattern = re.compile(settings.EXTERNAL_LINK_PATTERN)
     noncfpb_pattern = re.compile(settings.NONCFPB_LINK_PATTERN)
+    files_pattern = re.compile(settings.FILES_LINK_PATTERN)
     a_class = os.environ.get('EXTERNAL_A_CSS', 'icon-link icon-link__external-link')
     span_class = os.environ.get('EXTERNAL_SPAN_CSS', 'icon-link_text')
     for tag in soup:
@@ -70,7 +71,7 @@ def parse_links(soup):
             a.attrs.update({'class': a_class})
             a.append(' ') # We want an extra space before the icon
             a.append(soup.new_tag('span', attrs='class="%s"' % span_class))
-        else:
+        elif not files_pattern.match(a['href']):
             fix_link(a)
     return soup
 


### PR DESCRIPTION
Download links were being set to relative links so `files.consumerfinance.gov` wouldn't have ever been hit. This prevents this from happening.

@rosskarchner @kave @richaagarwal 