### PR TITLE
Fixed an issue w/ the spacing on the hero

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Update biographies for director bios.
 - Fixed issue with bad values in the multiselect.
 - Fixed the missing logon on IE 8.
+- Fixed an issue w/ the spacing on the hero.
 
 ## 3.0.0-3.2.1 - 2016-03-21
 

--- a/cfgov/v1/models/molecules.py
+++ b/cfgov/v1/models/molecules.py
@@ -78,7 +78,7 @@ class Hero(blocks.StructBlock):
     class Meta:
         icon = 'image'
         template = '_includes/molecules/hero.html'
-        classname = 'block__flush'
+        classname = 'block__flush-top block__flush-bottom'
 
 
 class FormFieldWithButton(blocks.StructBlock):


### PR DESCRIPTION
Fixed an issue w/ the spacing on the hero

## Changes

- Changed the modifier on heros to `flush-top` and `flush-bottom`

## Testing

- Open a page with a hero, ex `data-research/credit-card-data/` under 1000px there should be some gutter space on either side. The text shouldn't be flush against the browser edge.

## Review

- @KimberlyMunoz 
- @sebworks 
- @duelj 
- @schaferjh 

## Screenshots

__Before__
![screen shot 2016-04-07 at 4 58 21 pm](https://cloud.githubusercontent.com/assets/1280430/14368201/fb63a9cc-fce1-11e5-9f4e-21f221c4b76f.png)

__After__
![screen shot 2016-04-07 at 4 58 07 pm](https://cloud.githubusercontent.com/assets/1280430/14368204/ff028d0a-fce1-11e5-82ef-d7ab742db54e.png)


## Notes

- The flush sides modifier on `block` was forcing a -30px margin on both sides
- This molecule doesn’t actually need a block wrapper at all, investigate removing it in the future


## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)