### PR TITLE
READY: Fixed an issue where the header only had 15px of spacing instead of 30

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 
 ### Fixed
 
+- Fixed an issue where the header only had 15px of spacing instead of 30.
+
 
 ## 3.0.0-3.3.12 - 2016-05-05
 

--- a/cfgov/jinja2/v1/_includes/molecules/global-eyebrow.html
+++ b/cfgov/jinja2/v1/_includes/molecules/global-eyebrow.html
@@ -16,49 +16,52 @@
     <div class="m-global-eyebrow
                 m-global-eyebrow__{{ 'horizontal' if is_horizontal
                                       else 'list' }}">
-        <div class="wrapper">
+        <div class="wrapper
+                    {{ 'wrapper__match-content' if is_horizontal else '' }}">
             <div class="m-global-eyebrow_tagline">
                 An official website of the
                 <span class="m-global-eyebrow_tagline-usa">United States Government</span>
             </div>
             <div class="m-global-eyebrow_actions">
-                <ul class="m-global-eyebrow_languages">
-                    <li>
+                <ul class="list__unstyled
+                           list__horizontal
+                           m-global-eyebrow_languages">
+                    <li class="list_item">
                         <a href="/es/" hreflang="es" lang="es">
                             Español
                         </a>
                     </li>
-                    <li>
+                    <li class="list_item">
                         <a href="/language/zh/" hreflang="zh" lang="zh">
                             中文
                         </a>
                     </li>
-                    <li>
+                    <li class="list_item">
                         <a href="/language/vi/" hreflang="vi" lang="vi">
                             Tiếng Việt
                         </a>
                     </li>
-                    <li>
+                    <li class="list_item">
                         <a href="/language/ko/" hreflang="ko" lang="ko">
                             한국어
                         </a>
                     </li>
-                    <li>
+                    <li class="list_item">
                         <a href="/language/tl/" hreflang="tl" lang="tl">
                             Tagalog
                         </a>
                     </li>
-                    <li>
+                    <li class="list_item">
                         <a href="/language/ru/" hreflang="ru" lang="ru">
                             Pусский
                         </a>
                     </li>
-                    <li>
+                    <li class="list_item">
                         <a href="/language/ar/" hreflang="ar" lang="ar">
                             العربية
                         </a>
                     </li>
-                    <li>
+                    <li class="list_item">
                         <a href="/language/ht/" hreflang="ht" lang="ht">
                             Kreyòl Ayisyen
                         </a>

--- a/cfgov/jinja2/v1/_includes/organisms/header.html
+++ b/cfgov/jinja2/v1/_includes/organisms/header.html
@@ -58,7 +58,7 @@
 
     <div class="o-header_content no-js">
 
-        <div class="wrapper">
+        <div class="wrapper wrapper__match-content">
             {% import 'molecules/global-header-cta.html' as global_header_cta with context %}
             {{ global_header_cta.render( true ) }}
 

--- a/cfgov/unprocessed/css/enhancements/layout.less
+++ b/cfgov/unprocessed/css/enhancements/layout.less
@@ -1,3 +1,9 @@
+.wrapper__match-content {
+    .respond-to-min(@bp-sm-min, {
+        max-width: @grid_wrapper-width - ( @grid_gutter-width * 2 );
+    });
+}
+
 /* topdoc
   name: Block
   family: cf-layout

--- a/cfgov/unprocessed/css/molecules/global-eyebrow.less
+++ b/cfgov/unprocessed/css/molecules/global-eyebrow.less
@@ -52,7 +52,7 @@
     font-size: unit( 12px / @base-font-size-px, em);
 
     &_tagline {
-        padding-left: 37px; //22px flag + 15px spacing
+        padding-left: 32px; //22px flag + 10px spacing
         background: url('/static/img/us-flag_22x13.png') no-repeat 0 0;
 
         .respond-to-dpi(2, {
@@ -71,16 +71,14 @@
 
     &_languages {
         display: inline;
-        list-style-type: none;
 
-        li {
-            display: inline-block;
-            margin-right: unit( @grid_gutter-width / 2 / @base-font-size-px, em );
+        .list_item:not(:last-child) {
+            margin-right: unit( 7px / 12px, em );
             margin-bottom: 0;
 
-            &:last-child {
-                margin-right: 0;
-            }
+            .respond-to-min( @bp-lg-min, {
+                margin-right: unit( 10px / 12px, em );
+            } );
         }
 
         a {
@@ -93,41 +91,38 @@
     }
 
     &__horizontal {
-        padding: unit( @grid_gutter-width / 3 / @base-font-size-px, em );
+        padding-top: unit( @grid_gutter-width / 3 / @base-font-size-px, em );
+        padding-bottom: unit( @grid_gutter-width / 3 / @base-font-size-px, em );
         background: @gray-5;
         border-bottom: 1px solid @gray-40;
 
         .m-global-eyebrow_tagline {
             float: left;
         }
+
         .m-global-eyebrow_languages {
             text-align: right;
         }
     }
 
     &__list {
-        padding-left: unit( ( @grid_gutter-width / 4 ) * 3 / @base-font-size-px, em );
-        padding-right: unit( ( @grid_gutter-width / 4 ) * 3 / @base-font-size-px, em );
-        padding-top: unit( @grid_gutter-width / 2 / @base-font-size-px, em );
-        padding-bottom: unit( @grid_gutter-width / @base-font-size-px, em );
+        padding: unit( @grid_gutter-width / 2 / 12px, em )
+                 unit( @grid_gutter-width / 2 / 12px, em )
+                 unit( @grid_gutter-width / 12px, em );
         border-top: 1px solid @gray-40;
-
-        .m-global-eyebrow_tagline {
-            background-position-y: unit( @grid_gutter-width / 2 / @base-font-size-px, em );
-            padding-top: unit( @grid_gutter-width / 2 / @base-font-size-px, em );
-            padding-bottom: unit( @grid_gutter-width / 2 / @base-font-size-px, em );
-        }
 
         .m-global-eyebrow_actions {
             padding-top: unit( @grid_gutter-width / 2 / @base-font-size-px, em );
             border-top: 1px solid @gray-40;
+            margin-top: unit( @grid_gutter-width / 2 / @base-font-size-px, em );
+
             text-align: left;
         }
 
         .m-global-eyebrow_phone,
         .m-global-eyebrow_languages {
-          display: block;
-          padding-left: 37px; //22px flag + 15px spacing
+            display: block;
+            padding-left: 32px; //22px flag + 15px spacing
         }
     }
 }

--- a/cfgov/unprocessed/css/organisms/header.less
+++ b/cfgov/unprocessed/css/organisms/header.less
@@ -89,9 +89,19 @@
         > .wrapper {
             // TODO: remove when Capital Framework is updated to 3.x.x. on outdated consumerfinance.gov projects.
             position: initial;
-          
+
             > .m-global-search {
                 float: right;
+
+                // Mobile size.
+                .respond-to-max( @bp-xs-max, {
+                    margin-right: -15px;
+                } );
+
+                // Tablet size.
+                .respond-to-range( @bp-sm-min, @bp-sm-max {
+                    margin-right: -30px;
+                } );
             }
         }
 

--- a/cfgov/unprocessed/css/organisms/mega-menu.less
+++ b/cfgov/unprocessed/css/organisms/mega-menu.less
@@ -176,6 +176,19 @@
         }
     }
 
+    // Mobile sizes.
+    .respond-to-max( @bp-xs-max, {
+        &_trigger {
+            margin-left: -15px;
+        }
+    } );
+
+    // Tablet sizes.
+    .respond-to-range( @bp-sm-min, @bp-sm-max, {
+        &_trigger {
+            margin-left: -30px;
+        }
+    } );
 
     // Tablet/mobile sizes.
     .respond-to-max( @bp-sm-max, {
@@ -431,7 +444,7 @@
 
             &-item {
                 display: inline-block;
-                margin-right: @grid_gutter-width;
+                margin-right: unit( 25px / @base-font-size-px, em );
 
                 .no-js &:hover {
                     .o-mega-menu_content-2 {


### PR DESCRIPTION
Fixed an issue where the header only had 15px of spacing instead of 30

## Changes

- Added `__match-content` modifier to header `wrapper`s
- Utilized existing list modifiers to reduce styles for the language list
- Reduced spacing between language and nav items at 901px

## Testing

- `gulp build` and check out the header

## Review

- @duelj 
- @ajbush 
- @schaferjh 
- @KimberlyMunoz 
- @sebworks 
- @anselmbradford 

## Screenshots

__Before__
![screen shot 2016-04-07 at 5 19 06 pm](https://cloud.githubusercontent.com/assets/1280430/14369084/cf037a64-fce7-11e5-9228-bf8a8fe8bef0.png)

__After__
![screen shot 2016-04-07 at 5 17 49 pm](https://cloud.githubusercontent.com/assets/1280430/14369096/d7c3fb56-fce7-11e5-84ac-03f1d5b67593.png)

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices
* [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)