### PR TITLE
URL's and settings to support eregs, tax-time-savings, and know-before-you-owe

### DIFF
--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -66,6 +66,9 @@ OPTIONAL_APPS=[
     {'import':'complaint','apps':('complaint','complaintdatabase','complaint_common',)},
     {'import':'ratechecker','apps':('ratechecker','rest_framework')},
     {'import':'countylimits','apps':('countylimits','rest_framework')},
+    {'import':'regcore','apps':('regcore','regcore_read', 'regcore_write')},
+    {'import':'eregsip','apps':('eregsip',)},
+    {'import':'regulations','apps':('regulations',)},
 ]
 
 MIDDLEWARE_CLASSES = (
@@ -314,8 +317,8 @@ PDFREACTOR_LIB = os.environ.get('PDFREACTOR_LIB', '/opt/PDFreactor/wrappers/pyth
 #LEGACY APPS
 
 STATIC_VERSION = ''
-LEGACY_APP_URLS={'jobmanager': True,
-                 'cal':True,
+LEGACY_APP_URLS={'jobmanager': False,
+                 'cal':False,
                  'comparisontool':True,
                  'agreements':True,
                  'knowledgebase':True,
@@ -325,6 +328,8 @@ LEGACY_APP_URLS={'jobmanager': True,
                  'complaint':True,
                  'complaintdatabase':True,
                  'ratechecker':True,
+                 'regcore':True,
+                 'regulations':True,
                  'countylimits':True,
                  'noticeandcomment':True}
 
@@ -413,5 +418,55 @@ SHEER_SITES = {
             Path(REPOSITORY_ROOT, '../owning-a-home/dist')),
         'fin-ed-resources':
             Path(os.environ.get('FIN_ED_SHEER_PATH') or
-            Path(REPOSITORY_ROOT, '../fin-ed-resources/dist'))
+            Path(REPOSITORY_ROOT, '../fin-ed-resources/dist')),
+        'know-before-you-owe':
+            Path(os.environ.get('KBYO_SHEER_PATH') or
+            Path(REPOSITORY_ROOT, '../know-before-you-owe/dist')),
+        'tax-time-saving':
+            Path(os.environ.get('TAX_TIME_SHEER_PATH') or
+            Path(REPOSITORY_ROOT, '../tax-time-saving/dist')),
 }
+
+CACHES = {
+    'default' : {
+        'BACKEND': 'django.core.cache.backends.filebased.FileBasedCache',
+        'LOCATION': '/tmp/eregs_cache',
+    },
+    'eregs_longterm_cache': {
+        'BACKEND': 'django.core.cache.backends.filebased.FileBasedCache',
+        'LOCATION': '/tmp/eregs_longterm_cache',
+        'TIMEOUT': 60*60*24*15,     # 15 days
+        'OPTIONS': {
+            'MAX_ENTRIES': 10000,
+        },
+    },
+    'api_cache':{
+        'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
+        'LOCATION': 'api_cache_memory',
+        'TIMEOUT': 3600,
+        'OPTIONS': {
+            'MAX_ENTRIES': 1000,
+        },
+    }
+}
+
+CACHE_MIDDLEWARE_ALIAS = 'default'
+CACHE_MIDDLEWARE_KEY_PREFIX = 'eregs'
+CACHE_MIDDLEWARE_SECONDS = 600
+
+if 'EREGS_REGULATIONS_DIR' in os.environ:
+    #The base URL for the API that we use to access layers and the regulation.
+    API_BASE = os.environ['EREGS_API_BASE']
+
+    #When we generate an full HTML version of the regulation, we want to
+    #write it out somewhere. This is where.
+    OFFLINE_OUTPUT_DIR = ''
+
+    DATE_FORMAT = 'n/j/Y'
+
+    GOOGLE_ANALYTICS_ID = ''
+    GOOGLE_ANALYTICS_SITE = ''
+
+    CACHE_MIDDLEWARE_ALIAS = 'default'
+    CACHE_MIDDLEWARE_KEY_PREFIX = 'eregs'
+    CACHE_MIDDLEWARE_SECONDS = 1800

--- a/cfgov/cfgov/urls.py
+++ b/cfgov/cfgov/urls.py
@@ -52,6 +52,14 @@ urlpatterns = [
 
     url(r'^owning-a-home/', include(SheerSite('owning-a-home').urls)),
 
+    # the two redirects are an unfortunate workaround, could be resolved by
+    # using static('path/to/asset') in the source template
+
+    url(r'^tax-time-saving/static/(?P<path>.*)$', RedirectView.as_view(url='/static/tax-time-saving/static/%(path)s')),
+    url(r'^tax-time-saving/', include(SheerSite('tax-time-saving').urls)),
+    url(r'^know-before-you-owe/static/(?P<path>.*)$', RedirectView.as_view(url='/static/know-before-you-owe/static/%(path)s')),
+    url(r'^know-before-you-owe/', include(SheerSite('know-before-you-owe').urls)),
+
     url(r'^adult-financial-education/', include(fin_ed.urls_for_prefix('adult-financial-education'))),
     url(r'^youth-financial-education/', include(fin_ed.urls_for_prefix('youth-financial-education'))),
     url(r'^library-resources/', include(fin_ed.urls_for_prefix('library-resources'))),
@@ -222,9 +230,6 @@ urlpatterns = [
             name='how-to-apply-for-a-federal-job-with-the-cfpb'),
     ],
         namespace='transcripts')),
-    url(r'^jobs/', include_if_app_enabled('jobmanager','jobmanager.urls')),
-    url(r'^notice-and-comment/', include_if_app_enabled('noticeandcomment','noticeandcomment.urls')),
-    url(r'^leadership-calendar/', include_if_app_enabled('cal','cal.urls')),
     url(r'^paying-for-college/', include_if_app_enabled('comparisontool','comparisontool.urls')),
     url(r'^credit-cards/agreements/', include_if_app_enabled('agreements','agreements.urls')),
     url(r'^(?i)askcfpb/', include_if_app_enabled('knowledgebase','knowledgebase.urls')),
@@ -236,6 +241,8 @@ urlpatterns = [
     url(r'^data-research/consumer-complaints/', include_if_app_enabled('complaintdatabase','complaintdatabase.urls')),
     url(r'^oah-api/rates/', include_if_app_enabled('ratechecker', 'ratechecker.urls')),
     url(r'^oah-api/county/', include_if_app_enabled('countylimits','countylimits.urls')),
+    url(r'^eregs-api/', include_if_app_enabled('regcore','regcore.urls')),
+    url(r'^eregulations/', include_if_app_enabled('regulations','regulations.urls')),
 
     # Report redirects
     url(r'^reports/(?P<path>.*)$', RedirectView.as_view(url='/data-research/research-reports/%(path)s', permanent=True)),


### PR DESCRIPTION
These are URL configurations and settings to allow eregs, tax-time-savings, and know-before-you-owe to run within cfgov-refresh


## Additions

- urls, SHEER_SITES, and some extra settings that eregs expects


- @kave @kurtw @richaagarwal @anselmbradford 

## Testing

- clone [tax-time-saving](https://github.com/cfpb/tax-time-saving) and know-before-you-owe (internal) as siblings of cfgov-refresh
- follow the instructions to build both
- `cfgov/manage.py runserver`
- observe that you can reach http://localhost:8000/know-before-you-owe/ and http://localhost:8000/tax-time-saving/

The eregs stuff is complicated to get running, so for now, please just trust me. You can observe substantially the same settings in cfpb_django, and see the similarity to other "optional" apps in our settings and URL configs.


## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)

…-you-owe