### PR TITLE
Remove output formatting to get back what was put in

### DIFF
--- a/cfgov/sheerlike/external_links.py
+++ b/cfgov/sheerlike/external_links.py
@@ -14,7 +14,7 @@ def process_external_links(doc):
 def _process_data(field):
     if isinstance(field, basestring):
         soup = BeautifulSoup(field, 'html.parser')
-        field = parse_links(soup).encode(formatter="html")
+        field = parse_links(soup).encode(formatter=None)
     elif isinstance(field, list):
         for i, value in enumerate(field):
             field[i] = _process_data(value)


### PR DESCRIPTION


Looks like the `html` formatter from before caused some weird output for `>`-like symbols. This jsut removes formatting entirely so we're just getting back what was put in to begin with. Safe enough, though the docs say that it might output invalid html, but that seems to be the case if the html was invalid to begin with.

`cfgov/manage.py sheer_index`

http://localhost:8000/about-us/blog/mortgage-moves-what-kind-of-mortgage-will-you-get/ check for correct output of apostrophes

http://localhost:8000/about-us/the-bureau/leadership-calendar/ check descriptions for correct output of `>`'s
<img width="816" alt="screen shot 2016-04-08 at 11 32 37 am" src="https://cloud.githubusercontent.com/assets/254877/14388767/a0b848a6-fd7d-11e5-8f6b-fde3b1301512.png">
@rosskarchner @kave @richaagarwal 