### PR TITLE
Fix for the Bureau page on Android 4.1

### DIFF
--- a/cfgov/unprocessed/js/modules/util/assign.js
+++ b/cfgov/unprocessed/js/modules/util/assign.js
@@ -9,6 +9,7 @@
 
 'use strict';
 
+var fnBind = require( './fnBind' ).fnBind;
 
 /**
 * @param {Object} object - JavaScript object.
@@ -31,7 +32,7 @@ function assign( destination ) {
   var hasOwnProp;
   for ( var i = 1; i < arguments.length; i++ ) {
     var source = arguments[i] || {};
-    hasOwnProp = Object.hasOwnProperty.bind( source );
+    hasOwnProp = fnBind( Object.hasOwnProperty, source );
     for ( var key in source ) {
       if ( hasOwnProp( key ) ) {
         var value = source[key];

--- a/cfgov/unprocessed/js/modules/util/assign.js
+++ b/cfgov/unprocessed/js/modules/util/assign.js
@@ -28,11 +28,12 @@ function _isPlainObject( object ) {
 */
 function assign( destination ) {
   destination = destination || {};
-
+  var hasOwnProp;
   for ( var i = 1; i < arguments.length; i++ ) {
     var source = arguments[i] || {};
+    hasOwnProp = Object.hasOwnProperty.bind( source );
     for ( var key in source ) {
-      if ( source.hasOwnProperty( key ) ) {
+      if ( hasOwnProp( key ) ) {
         var value = source[key];
         if ( _isPlainObject( value ) ) {
           assign( destination[key] = {}, value );

--- a/cfgov/unprocessed/js/modules/util/fnBind.js
+++ b/cfgov/unprocessed/js/modules/util/fnBind.js
@@ -19,10 +19,9 @@
 * @param {object} context - the `this` you want to call the function with
 * @returns {function} The wrapped version of the supplied function
 */
-
-function fnBind(fn, context) {
+function fnBind( fn, context ) {
   return function() {
-    return fn.apply(context, arguments);
+    return fn.apply( context, arguments );
   };
 }
 

--- a/cfgov/unprocessed/js/modules/util/fnBind.js
+++ b/cfgov/unprocessed/js/modules/util/fnBind.js
@@ -1,0 +1,22 @@
+'use strict';
+
+
+/**
+* Function.Bind polyfill.
+*
+* @access private
+* @function fnBind
+* @param {function} fn - a function you want to change `this` reference to
+* @param {object} context - the `this` you want to call the function with
+* @returns {function} The wrapped version of the supplied function
+*/
+
+function fnBind(fn, context) {
+  return function() {
+    return fn.apply(context, arguments);
+  };
+}
+
+
+// Expose public methods.
+module.exports = { fnBind: fnBind };

--- a/cfgov/unprocessed/js/modules/util/fnBind.js
+++ b/cfgov/unprocessed/js/modules/util/fnBind.js
@@ -1,3 +1,12 @@
+/* ==========================================================================
+   fnBind
+
+   Code copied from the following with minimal modifications :
+
+   - https://raw.githubusercontent.com/Modernizr/Modernizr/
+     74655c45ad2cd05c002e4802cdd74cba70310f08/src/fnBind.js
+   ========================================================================== */
+
 'use strict';
 
 


### PR DESCRIPTION
Fix for the Bureau page on Android 4.1. The Mega Menu is currently breaking because of a null handling error in the assign utility function on `the-bureau` page. 

## Testing

- Visit `http://localhost:8000/about-us/the-bureau/` on an Android device via Sauce Labs. (I'm still mad that Sauce labs doesn't have Blackberry).

## Review

- @KimberlyMunoz 
- @anselmbradford 
- @jimmynotjim 


## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)

