### PR TITLE
restore jobs URL's

### DIFF
--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -317,7 +317,7 @@ PDFREACTOR_LIB = os.environ.get('PDFREACTOR_LIB', '/opt/PDFreactor/wrappers/pyth
 #LEGACY APPS
 
 STATIC_VERSION = ''
-LEGACY_APP_URLS={'jobmanager': False,
+LEGACY_APP_URLS={'jobmanager': True,
                  'cal':False,
                  'comparisontool':True,
                  'agreements':True,

--- a/cfgov/cfgov/urls.py
+++ b/cfgov/cfgov/urls.py
@@ -230,6 +230,7 @@ urlpatterns = [
             name='how-to-apply-for-a-federal-job-with-the-cfpb'),
     ],
         namespace='transcripts')),
+    url(r'^jobs/', include_if_app_enabled('jobmanager','jobmanager.urls')),
     url(r'^paying-for-college/', include_if_app_enabled('comparisontool','comparisontool.urls')),
     url(r'^credit-cards/agreements/', include_if_app_enabled('agreements','agreements.urls')),
     url(r'^(?i)askcfpb/', include_if_app_enabled('knowledgebase','knowledgebase.urls')),


### PR DESCRIPTION
Mistakenly thought we didn't need the jobs app-- this puts those URL's back