### PR TITLE
Hotfix field sort

### DIFF
--- a/cfgov/jinja2/v1/_queries/calendar_event.json
+++ b/cfgov/jinja2/v1/_queries/calendar_event.json
@@ -3,6 +3,6 @@
   "query": {
     "doc_type": "calendar_event",
     "size": 20,
-    "sort": "dtstart:desc"
+    "sort": "day:desc"
   }
 }


### PR DESCRIPTION
Change the query's sort field so we actually get calendar events by day.

@kave @rosskarchner @richaagarwal @sebworks @anselmbradford @jimmynotjim @KimberlyMunoz 