### PR TITLE
Hotfix: Changes overlay click behavior for iOS/BB

### DIFF
--- a/cfgov/unprocessed/css/atoms/overlay.less
+++ b/cfgov/unprocessed/css/atoms/overlay.less
@@ -26,6 +26,10 @@
 
         background: @black;
         opacity: 0.6;
+
+        // Cursor needs to be set for iOS to capture clicks of the overlay
+        // and bubble them up to the body.
+        cursor: pointer;
     } );
 }
 

--- a/cfgov/unprocessed/js/organisms/MegaMenuMobile.js
+++ b/cfgov/unprocessed/js/organisms/MegaMenuMobile.js
@@ -56,7 +56,7 @@ function MegaMenuMobile( menus ) {
   /**
    * Event handler for when there's a click on the page's body.
    * Used to close the global search, if needed.
-   * @param {MouseEvent} event The event object for the mousedown event.
+   * @param {MouseEvent} event The event object for the click event.
    */
   function _handleBodyClick( event ) {
     var target = event.target;
@@ -163,7 +163,7 @@ function MegaMenuMobile( menus ) {
     _handleToggle( menu );
     if ( menu === _rootMenu ) {
       this.dispatchEvent( 'rootExpandBegin', { target: this } );
-      _bodyDom.addEventListener( 'mousedown', _handleBodyClick );
+      _bodyDom.addEventListener( 'click', _handleBodyClick );
     }
 
     // TODO: Enable or remove when keyboard navigation is in.
@@ -186,7 +186,7 @@ function MegaMenuMobile( menus ) {
     var menu = event.target;
     _handleToggle( menu );
     if ( menu === _rootMenu ) {
-      _bodyDom.removeEventListener( 'mousedown', _handleBodyClick );
+      _bodyDom.removeEventListener( 'click', _handleBodyClick );
     }
   }
 
@@ -274,7 +274,7 @@ function MegaMenuMobile( menus ) {
       // TODO: Investigate updating this to close the menus directly
       //       so `_handleCollapseEnd` is fired.
       this.dispatchEvent( 'rootCollapseEnd', { target: this } );
-      _bodyDom.removeEventListener( 'mousedown', _handleBodyClick );
+      _bodyDom.removeEventListener( 'click', _handleBodyClick );
     }
 
     return _suspended;


### PR DESCRIPTION
iOS was not dismissing the menu on click of the mega menu semi-opaque overlay.
BB was dismissing it too soon.

## Changes

- Adds `cursor: pointer` to the styles for the overlay so that iOS bubbles the click event up to the body, which dismisses the menu in the mega menu script.
- Changes the event type to `click` instead of `mousedown`, so that a `mouseup` event is required to the dismiss the menu (hopefully this fixes the issue on BB).

## Testing

- `gulp build`
- Load in iOS simulator (try iPhone 5)
- Click hamburger menu, scroll down till the menu isn't visible, and click the overlay. Menu should close

## Review

- @jimmynotjim 
- @sebworks 
- @KimberlyMunoz 
