### PR TITLE
Hotfix: Fix for Youtube Player on Desktop IE/Safari

### DIFF
--- a/cfgov/unprocessed/js/modules/YoutubePlayer.js
+++ b/cfgov/unprocessed/js/modules/YoutubePlayer.js
@@ -23,6 +23,10 @@ var API = {
 
   IMAGE_URL: 'https://img.youtube.com/vi/%video_id%/maxresdefault.jpg',
 
+  YOUTUBE_API_CONFIG: {
+    'host': 'https://www.youtube.com'
+  },
+
   iFrameProperties: {
     id: CLASSES.IFRAME_CLASS_NAME
   },
@@ -59,11 +63,12 @@ var API = {
     var YouTubePlayer = window.YT;
     var player;
     if ( YouTubePlayer && YouTubePlayer.Player ) {
+      YouTubePlayer.setConfig( this.YOUTUBE_API_CONFIG );
       player = new YouTubePlayer.Player( this.iFrameProperties.id
         , this.playerOptions );
       this.state.isPlayerInitialized = true;
     } else if( this.state.isScriptLoading === false ) {
-      window.onYouTubeIframeAPIReady = this.initPlayer;
+      window.onYouTubeIframeAPIReady = this.initPlayer.bind( this );
       this.embedScript();
     }
   },


### PR DESCRIPTION
Fix for Youtube Player on Desktop IE9/Safari. This sets the Youtube host to use https which resolves an issue allowing control of the Iframe on IE9 and Safari ( what a weird combo ). 

## Testing

- Visit `http://localhost:8000/about-us/the-bureau/` on Safari or IE9. Click the play button.  Click the close button.  The video should start from the beginning. 

## Review

- @anselmbradford 
- @KimberlyMunoz 
- @jimmynotjim 

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
