### PR TITLE
updated tags to account for events

### DIFF
--- a/cfgov/jinja2/v1/_includes/tags.html
+++ b/cfgov/jinja2/v1/_includes/tags.html
@@ -29,19 +29,34 @@
 
    ========================================================================== #}
 
-{% macro render(tags, path, hide_heading=false, display_block=false, index=0, is_sheer=False) %}
+{% macro render(tags, path, hide_heading=false, display_block=false, index=0, is_sheer=False, is_wagtail=False) %}
 <div class="tags {{'tags__hide-heading' if hide_heading else ''}} {{'tags__block-list' if display_block else '' }}">
     <span class="{{'u-visually-hidden' if hide_heading else 'tags_heading' }}">Topics:</span>
     <ul class="tags_list">
-    {% for tag in tags %}
-        <li class="tags_tag">
-          {% set url_arg = 'filter_tags=' if is_sheer else 'filter' ~ index|string ~ '_topics=' %}
-            <a class="tags_link" href="{{ path }}?{{ url_arg }}{{ tag }}">
-                <span class="tags_bullet" aria-hidden="true">&bull;</span>
-                {{ tag }}
-            </a>
-        </li>
-    {% endfor %}
+        {% if is_wagtail %}
+            {% for tag in tags.links %}
+            <li class="tags_tag">
+                {% if tag.url %}
+                    <a href="{{ tag.url }}" class="tags_link">
+                        <span class="tags_bullet" aria-hidden="true">&bull;</span>
+                        {{ tag.text }}
+                    </a>
+                {% else %}
+                    <span class="tags_bullet">{{ tag.text }}</span>
+                {% endif %}
+            </li>
+            {% endfor %}
+        {% else %}
+            {% for tag in tags %}
+                <li class="tags_tag">
+                    {% set url_arg = 'filter_tags=' if is_sheer else 'filter' ~ index|string ~ '_topics=' %}
+                    <a class="tags_link" href="{{ path }}?{{ url_arg }}{{ tag }}">
+                        <span class="tags_bullet" aria-hidden="true">&bull;</span>
+                        {{ tag }}
+                    </a>
+                </li>
+            {% endfor %}
+        {% endif %}
     </ul>
 </div>
 {% endmacro %}

--- a/cfgov/jinja2/v1/events/_event-detail.html
+++ b/cfgov/jinja2/v1/events/_event-detail.html
@@ -92,7 +92,7 @@
     {% if page.tags.names() | length %}
     <footer>
         {%- import 'tags.html' as tags %}
-        {{ tags.render( page.tags.names(), path ) }}
+        {{ tags.render( related_metadata_tags(page), '', is_wagtail=True) }}
     </footer>
     {% endif %}
 </article>

--- a/cfgov/v1/__init__.py
+++ b/cfgov/v1/__init__.py
@@ -130,7 +130,7 @@ def related_metadata_tags(context, page):
     id = None
     filter_page = None
     for ancestor in page.get_ancestors().reverse().specific():
-        if ancestor.specific_class.__name__ in ['BrowseFilterablePage', 'SublandingFilterablePage']:
+        if ancestor.specific_class.__name__ in ['EventArchivePage', 'FilterablePage']:
             filter_page = ancestor
             id = util.get_form_id(ancestor, request.GET)
             break


### PR DESCRIPTION
This event pages tags were not routing to the correct url. that has been fixed

e.g [here](http://localhost:8000/about-us/events/spring-2016-community-bank-advisory-council-meeting-washington-dc/)


@kurtw @richaagarwal 