### PR TITLE
Normalize calendar event dates to fix date filtering

### DIFF
--- a/cfgov/es_mappings/calendar_event.json
+++ b/cfgov/es_mappings/calendar_event.json
@@ -6,7 +6,7 @@
         },
         "dtstart": {
             "type": "date",
-            "format": "Y-M-D H:m"
+            "format": "dateOptionalTime"
         },
         "description": {
             "type": "string"
@@ -36,11 +36,11 @@
         },
         "date": {
             "type": "date",
-            "format": "Y-M-D H:m"
+            "format": "dateOptionalTime"
         },
         "dtend": {
             "type": "date",
-            "format": "Y-M-D H:m"
+            "format": "dateOptionalTime"
         },
         "summary": {
             "type": "string"

--- a/cfgov/processors/django_calendar_event.py
+++ b/cfgov/processors/django_calendar_event.py
@@ -42,12 +42,12 @@ def process_event(event):
     # when Wagtail fixes https://github.com/torchbox/wagtail/issues/2406
     # along with https://github.com/cfpb/cfgov-refresh/pull/1661
     dt_start = dt_start.astimezone(timezone('America/New_York'))
-    event['date'] = dt_start.strftime('%Y-%m-%d %H:%M')
+    event['date'] = dt_start.isoformat()
     event['dtstart'] = event['date']
 
     dt_end = dateutil.parser.parse(event['dtend'])
     dt_end = dt_end.astimezone(timezone('America/New_York'))
-    event['dtend'] = dt_end.strftime('%Y-%m-%d %H:%M')
+    event['dtend'] = dt_end.isoformat()
 
     event['day'] = datetime.date(dt_start.year, dt_start.month, dt_start.day)
     if event['description']:


### PR DESCRIPTION
_Some_ of the dates were a different format than what was expected.


## Test
- `./cfgov/manage.py sheer_index -r -p calendar_event`
- Go to [the event calendar](http://localhost:8000/about-us/the-bureau/leadership-calendar/)
- Filter by date and verify the results are accurate

@kave 
@jimmynotjim 