### PR TITLE
removes style tags and all in-line style attributes

### DIFF
--- a/cfgov/v1/__init__.py
+++ b/cfgov/v1/__init__.py
@@ -1,5 +1,5 @@
 from __future__ import absolute_import
-import os, re,HTMLParser
+import os, re, HTMLParser
 from urlparse import urlparse
 
 from django.contrib.staticfiles.storage import staticfiles_storage
@@ -59,9 +59,19 @@ def parse_links(soup):
     files_pattern = re.compile(settings.FILES_LINK_PATTERN)
     a_class = os.environ.get('EXTERNAL_A_CSS', 'icon-link icon-link__external-link')
     span_class = os.environ.get('EXTERNAL_SPAN_CSS', 'icon-link_text')
-    for tag in soup:
-        if hasattr(tag, 'style'):
+
+    # This removes style tags <style>
+    for s in soup('style'):
+        s.decompose()
+
+    # This removes all inline style attr's
+    for tag in soup.recursiveChildGenerator():
+        try:
             del tag['style']
+        except:
+            # 'NavigableString' object has does not have attr's
+            pass
+
     for a in soup.find_all('a', href=True):
         # Sets the link to an external one if you're leaving .gov 
         if extlink_pattern.match(a['href']):
@@ -69,7 +79,7 @@ def parse_links(soup):
         # Sets the icon to indicate you're leaving consumerfinance.gov
         if noncfpb_pattern.match(a['href']):
             a.attrs.update({'class': a_class})
-            a.append(' ') # We want an extra space before the icon
+            a.append(' ')  # We want an extra space before the icon
             a.append(soup.new_tag('span', attrs='class="%s"' % span_class))
         elif not files_pattern.match(a['href']):
             fix_link(a)
@@ -104,6 +114,7 @@ def render_stream_child(context, stream_child):
     # Return the rendered template as safe html
     return Markup(unescaped)
 
+
 @contextfunction
 def get_protected_url(context, page):
     request_hostname = urlparse(context['request'].url).hostname
@@ -119,6 +130,7 @@ def get_protected_url(context, page):
             return url.replace(page_hostname, staging_hostname)
         else:
             return '#'
+
 
 @contextfunction
 def related_metadata_tags(context, page):


### PR DESCRIPTION
@kurtw @richaagarwal @jimmynotjim @sebworks @KimberlyMunoz @anselmbradford 

### Testing
- view this [page](http://localhost:8000/about-us/blog/mortgage-moves-where-will-you-start/)
<img width="779" alt="screen shot 2016-04-10 at 10 31 47 pm" src="https://cloud.githubusercontent.com/assets/254877/14415344/0eacdad0-ff6c-11e5-87f4-7ea5127eafad.png">

- Then run `./cfgov/manage.py sheer_index -r -p posts` 
should now look like this with all style tags and inline styles stripped:
<img width="627" alt="screen shot 2016-04-10 at 10 27 49 pm" src="https://cloud.githubusercontent.com/assets/254877/14415351/21c13fee-ff6c-11e5-837c-5cc1a7358ed9.png">
 