### PR TITLE
make the link-fixing code ignore mailto (and other non-http schemes)

### DIFF
--- a/cfgov/processors/processors_common.py
+++ b/cfgov/processors/processors_common.py
@@ -18,7 +18,11 @@ def update_path(path):
 
 def fix_link(link):
     urldata = urlsplit(link['href'])
-    new_path = update_path(urldata.path)
-    new_href = urlunsplit((None, None, urldata.path, urldata.query,
-                          urldata.fragment))
-    link['href'] = new_href
+    if urldata.scheme in ('http','https',''):
+        # the empty string captures URL's without a scheme, like '/about-us'
+        new_path = update_path(urldata.path)
+        new_href = urlunsplit((None, None, urldata.path, urldata.query,
+                              urldata.fragment))
+        link['href'] = new_href
+    else:
+        return link


### PR DESCRIPTION
Fixes a bug that was leaving mailto: links unusable


## Changes

- the function that fixes relative links (for example, changing /blog/foo to /about-us/blog/foo when it appears in blog or newsroom content) now skips over non-http links (like mailto), leaving them un-mangled.

## Testing

- observe on the current branch, on a page like http://beta.consumerfinance.gov/about-us/project-catalyst/run-trial-disclosure/ that the "tell us about it link" leads to a 404.
- with this PR, run `cfgov/manage.py sheer_index`
- reload that page and observe that mailto links still work



## Review

- @kurtw @richaagarwal @kave 


## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)

