### PR TITLE
Fix mobile text intro

### DIFF
--- a/cfgov/jinja2/v1/_includes/molecules/text-introduction.html
+++ b/cfgov/jinja2/v1/_includes/molecules/text-introduction.html
@@ -27,14 +27,14 @@
 <h1>{{ value.heading }}</h1>
 <div class="lead-paragraph">{{ parse_links(value.intro) | safe }}</div>
 {{ parse_links(value.body) | safe }}
-{% if value.links.url %}
-  <ul class="list list__links">
-      {% for link in value.links %}
-          <li class="list_item">
-              <a class="list_link" href="{{ link.url }}">
-                  {{ link.text }}
-              </a>
-          </li>
-      {% endfor %}
-  </ul>
-{% endif %}
+{% for link in value.links %}
+    {% if link.text %}
+        {% if loop.first %}<ul class="list list__links">{% endif %}
+            <li class="list_item">
+                <a class="list_link" href="{{ link.url }}">
+                    {{ link.text }}
+                </a>
+            </li>
+        {% if loop.last %}</ul>{% endif %}
+    {% endif %}
+{% endfor %}

--- a/cfgov/jinja2/v1/_includes/molecules/text-introduction.html
+++ b/cfgov/jinja2/v1/_includes/molecules/text-introduction.html
@@ -27,12 +27,14 @@
 <h1>{{ value.heading }}</h1>
 <div class="lead-paragraph">{{ parse_links(value.intro) | safe }}</div>
 {{ parse_links(value.body) | safe }}
-<ul class="list list__links">
-    {% for link in value.links %}
-        <li class="list_item">
-            <a class="list_link" href="{{ link.url }}">
-                {{ link.text }}
-            </a>
-        </li>
-    {% endfor %}
-</ul>
+{% if value.links.url %}
+  <ul class="list list__links">
+      {% for link in value.links %}
+          <li class="list_item">
+              <a class="list_link" href="{{ link.url }}">
+                  {{ link.text }}
+              </a>
+          </li>
+      {% endfor %}
+  </ul>
+{% endif %}

--- a/cfgov/jinja2/v1/_includes/organisms/item-introduction.html
+++ b/cfgov/jinja2/v1/_includes/organisms/item-introduction.html
@@ -38,16 +38,21 @@
     {% if value.date or value.authors.text %}
         <p>
     {% endif %}
-    {% if value.authors.text %}
-        By
-        {% for link in value.authors %}
-            {% if loop.first == false %}
-            and
-            {% endif %}
-            <a href="{{ link.url }}">{{ link.text }}</a>
-        {% endfor %}
-        {{ '-' if value.date else ''}}
-    {% endif %}
+    {% for link in value.authors %}
+        {%- if link.text -%}
+          {%- if loop.first -%}
+              By
+          {%- elif loop.last -%}
+              &nbsp;and
+          {%- else -%}
+              ,
+          {%- endif -%}
+              &nbsp;<a href="{{ link.url }}">{{ link.text }}</a>
+          {%- if loop.last -%}
+              &nbsp;{{ '-' if value.date else ''}}
+          {%- endif -%}
+        {%- endif -%}
+    {% endfor %}
     {% if value.date %}
         {{ time.render(value.date, {'date':true}) }}
     {% endif %}


### PR DESCRIPTION
Added a check to avoid blank link lists on mobile.

## Testing

- Visit http://localhost:8000/about-us/events/ on mobile

## Review

- @anselmbradford 
- @sebworks 
- @jimmynotjim 

## Screenshots

It should _not_ look like this

![image](https://cloud.githubusercontent.com/assets/1860176/14428489/5b1250ac-ffc7-11e5-962a-c0a028411b59.png)

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
