### PR TITLE
Fix for validation on Leadership Calendar download

### DIFF
--- a/cfgov/jinja2/v1/_includes/macros/filters.html
+++ b/cfgov/jinja2/v1/_includes/macros/filters.html
@@ -311,8 +311,7 @@
                         <label for="{{ options.id_range_date_gte }}" class="form-label-header">
                             From <span class="date-range_label">mm/dd/yyyy</span>:
                         </label>
-                        <input class="js-filter_range-date js-filter_range-date__gte"
-                               id="{{ options.id_range_date_gte }}"
+                        <input id="{{ options.id_range_date_gte }}"
                                name="{{ options.id_range_date_gte }}"
                                type="text"
                                value="{{ from_date_formatted if from_date_formatted else '' }}"
@@ -330,8 +329,7 @@
                         <label for="{{ options.id_range_date_lte }}" class="form-label-header">
                             To <span class="date-range_label">mm/dd/yyyy</span>:
                         </label>
-                        <input class="js-filter_range-date js-filter_range-date__lte"
-                               id="{{ options.id_range_date_lte }}"
+                        <input id="{{ options.id_range_date_lte }}"
                                name="{{ options.id_range_date_lte }}"
                                type="text"
                                value="{{ to_date_formatted if to_date_formatted else '' }}"

--- a/cfgov/jinja2/v1/about-us/the-bureau/leadership-calendar/index.html
+++ b/cfgov/jinja2/v1/about-us/the-bureau/leadership-calendar/index.html
@@ -84,23 +84,26 @@
             only available for months when someone was serving in Bureau leadership. We’ll
             generate a PDF of the results for you. Very large requests may take a while.
         </p>
-
-        {{ filters.render(
-            filter_by,
-            query,
-            posts,
-            'calendar_event',
-            {
-                'id_prefix'           : 'download',
-                'expand_label'        : 'Download options',
-                'show_current_filters': false,
-                'action'              : 'pdf/',
-                'submit_label'        : 'Download PDF',
-                'additional_classes'  : 'js-validate_form-not-empty, js-validate_require-date',
-                'form_method'         : 'post',
-                'show_errors'         :  True
-            }
-        ) }}
+        <div class="o-filterable-list-controls">
+            {{ filters.render(
+                filter_by,
+                query,
+                posts,
+                'calendar_event',
+                {
+                    'id_prefix'           : 'download',
+                    'expand_label'        : 'Download options',
+                    'show_current_filters': false,
+                    'action'              : 'pdf/',
+                    'submit_label'        : 'Download PDF',
+                    'additional_classes'  : 'js-validate_require-date',
+                    'form_method'         : 'post',
+                    'show_errors'         :  True
+                }
+            ) }}
+            {% import 'molecules/notification.html' as notification %}
+            {{ notification.render(type='warning', is_visible=false, message='') }}
+        </div>
     </section>
 
     <aside class="prefooter">

--- a/cfgov/unprocessed/js/organisms/FilterableListControls.js
+++ b/cfgov/unprocessed/js/organisms/FilterableListControls.js
@@ -214,7 +214,7 @@ function FilterableListControls( element ) {
 
     if ( isInGroup ) {
       var groupName = field.getAttribute( 'data-group' ) ||
-                field.getAttribute( 'name' );
+                      field.getAttribute( 'name' );
       var groupSelector = '[name=' + groupName + ']:checked,' +
                           '[data-group=' + groupName + ']:checked';
       fieldset = _form.querySelectorAll( groupSelector ) || [];

--- a/cfgov/unprocessed/js/routes/sheer.js
+++ b/cfgov/unprocessed/js/routes/sheer.js
@@ -13,7 +13,7 @@ var filterableListDom = document.querySelectorAll( '.o-filterable-list-controls'
 var filterableListControls;
 if ( filterableListDom ) {
   for ( var i = 0, len = filterableListDom.length; i < len; i++ ) {
-    filterableListControls = new FilterableListControls( document.body )
+    filterableListControls = new FilterableListControls( filterableListDom[i] );
     filterableListControls.init();
   }
 }


### PR DESCRIPTION
Fix for validation on Leadership Calendar download

## Changes

- Changed `cfgov/unprocessed/js/routes/sheer.js` to fix issue passing in the correct dom element.
- Changed `cfgov/jinja2/v1/about-us/the-bureau/leadership-calendar/index.html` to wrap the filter in a dom element.
- Removed unused classes.

## Testing

- Visit `http://localhost:8000/about-us/the-bureau/leadership-calendar/` and expand the `Download options` filter. Enter in an invalid date. You should see the warning notification. 

## Review

- @anselmbradford 
- @jimmynotjim 
- @KimberlyMunoz 


## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
