### PR TITLE
Scroll back to top on menu clicks

### DIFF
--- a/cfgov/unprocessed/js/organisms/MegaMenuDesktop.js
+++ b/cfgov/unprocessed/js/organisms/MegaMenuDesktop.js
@@ -47,17 +47,16 @@ function MegaMenuDesktop( menus ) {
    * @param {Event} event - A FlyoutMenu event.
    */
   function handleEvent( event ) {
-    if ( !_suspended ) {
-      var eventMap = {
-        triggerClick: _handleTriggerClickBinded,
-        triggerOver:  _handleTriggerOverBinded,
-        expandBegin:  _handleExpandBeginBinded,
-        collapseEnd:  _handleCollapseEndBinded
-      };
+    if ( _suspended ) return;
+    var eventMap = {
+      triggerClick: _handleTriggerClickBinded,
+      triggerOver:  _handleTriggerOverBinded,
+      expandBegin:  _handleExpandBeginBinded,
+      collapseEnd:  _handleCollapseEndBinded
+    };
 
-      var currHandler = eventMap[event.type];
-      if ( currHandler ) currHandler( event );
-    }
+    var currHandler = eventMap[event.type];
+    if ( currHandler ) currHandler( event );
   }
 
   /**

--- a/cfgov/unprocessed/js/organisms/MegaMenuMobile.js
+++ b/cfgov/unprocessed/js/organisms/MegaMenuMobile.js
@@ -74,17 +74,16 @@ function MegaMenuMobile( menus ) {
    * @param {Event} event - A FlyoutMenu event.
    */
   function handleEvent( event ) {
-    if ( !_suspended ) {
-      if ( event.type === 'triggerClick' ) {
-        _handleTriggerClickBinded( event );
-      } else if ( event.type === 'expandBegin' ) {
-        _handleExpandBeginBinded( event );
-      } else if ( event.type === 'collapseBegin' ) {
-        _handleCollapseBeginBinded( event );
-      } else if ( event.type === 'collapseEnd' ) {
-        _handleCollapseEndBinded( event );
-      }
-    }
+    if ( _suspended ) return;
+    var eventMap = {
+      triggerClick:  _handleTriggerClickBinded,
+      expandBegin:   _handleExpandBeginBinded,
+      collapseBegin: _handleCollapseBeginBinded,
+      collapseEnd:   _handleCollapseEndBinded
+    };
+
+    var currHandler = eventMap[event.type];
+    if ( currHandler ) currHandler( event );
   }
 
   /**
@@ -159,6 +158,7 @@ function MegaMenuMobile( menus ) {
    * @param {Event} event - A FlyoutMenu event.
    */
   function _handleExpandBegin( event ) {
+    window.scrollTo( 0, 0 );
     var menu = event.target;
     _handleToggle( menu );
     if ( menu === _rootMenu ) {


### PR DESCRIPTION
Always go to the top of the page as navigating between menus.

## Changes

- Scroll back to top on menu changes.
- Turn suspended checks into guard clauses.

## Testing

- `gulp build`
- Open in mobile view.
- Go to About Us, scroll down till Careers button is at the top of the screen.
- Click Careers entries. 
Should scroll to top and slide careers menu into view.

## Review

- @jimmynotjim 
- @KimberlyMunoz 
- @sebworks 