### PR TITLE
Fix for BB on non V1 pages

### DIFF
--- a/cfgov/unprocessed/js/modules/FlyoutMenu.js
+++ b/cfgov/unprocessed/js/modules/FlyoutMenu.js
@@ -4,6 +4,7 @@
 var BaseTransition = require( '../modules/transition/BaseTransition' );
 var dataHook = require( '../modules/util/data-hook' );
 var EventObserver = require( '../modules/util/EventObserver' );
+var fnBind = require( '../modules/util/fn-bind' ).fnBind;
 var standardType = require( '../modules/util/standard-type' );
 
 /**
@@ -60,10 +61,10 @@ function FlyoutMenu( element ) { // eslint-disable-line max-statements, no-inlin
   var _collapseTransitionMethodArgs = [];
 
   // Binded events.
-  var _collapseBinded = collapse.bind( this );
+  var _collapseBinded = fnBind( collapse, this );
   // Needed to add and remove events to transitions.
-  var _collapseEndBinded = _collapseEnd.bind( this );
-  var _expandEndBinded = _expandEnd.bind( this );
+  var _collapseEndBinded = fnBind( _collapseEnd, this );
+  var _expandEndBinded = fnBind( _expandEnd, this );
 
   // If this menu appears in a data source,
   // this can be used to store the source.
@@ -90,8 +91,8 @@ function FlyoutMenu( element ) { // eslint-disable-line max-statements, no-inlin
       _triggerDom.setAttribute( 'data-gtm_ignore', 'true' );
     }
 
-    var triggerClickedBinded = _triggerClicked.bind( this );
-    var triggerOverBinded = _triggerOver.bind( this );
+    var triggerClickedBinded = fnBind( _triggerClicked, this );
+    var triggerOverBinded = fnBind( _triggerOver, this );
 
     // Set initial `aria-expanded="false"` attribute.
     _setAriaExpandedAttr( _triggerDom, 'false' );

--- a/cfgov/unprocessed/js/modules/transition/AlphaTransition.js
+++ b/cfgov/unprocessed/js/modules/transition/AlphaTransition.js
@@ -3,7 +3,7 @@
 // Required modules.
 var EventObserver = require( '../../modules/util/EventObserver' );
 var BaseTransition = require( './BaseTransition' );
-// TODO: import Function.bind polyfill.
+var fnBind = require( '../../modules/util/fn-bind' ).fnBind;
 
 // Exported constants.
 var CLASSES = {
@@ -31,7 +31,7 @@ function AlphaTransition( element ) {
    */
   function init() {
     _baseTransition.init();
-    var _transitionCompleteBinded = _transitionComplete.bind( this );
+    var _transitionCompleteBinded = fnBind( _transitionComplete, this );
     _baseTransition.addEventListener( BaseTransition.END_EVENT,
                                       _transitionCompleteBinded );
     return this;

--- a/cfgov/unprocessed/js/modules/transition/BaseTransition.js
+++ b/cfgov/unprocessed/js/modules/transition/BaseTransition.js
@@ -2,7 +2,7 @@
 
 // Required modules.
 var EventObserver = require( '../../modules/util/EventObserver' );
-// TODO: import Function.bind polyfill.
+var fnBind = require( '../../modules/util/fn-bind' ).fnBind;
 
 /**
  * BaseTransition
@@ -32,8 +32,8 @@ function BaseTransition( element, classes ) { // eslint-disable-line max-stateme
    * @returns {BaseTransition} An instance.
    */
   function init() {
-    _transitionCompleteBinded = _transitionComplete.bind( this );
-    _addEventListenerBinded = _addEventListener.bind( this );
+    _transitionCompleteBinded = fnBind( _transitionComplete, this );
+    _addEventListenerBinded = fnBind( _addEventListener, this );
     setElement( element );
 
     return this;

--- a/cfgov/unprocessed/js/modules/transition/MoveTransition.js
+++ b/cfgov/unprocessed/js/modules/transition/MoveTransition.js
@@ -3,7 +3,7 @@
 // Required modules.
 var EventObserver = require( '../../modules/util/EventObserver' );
 var BaseTransition = require( './BaseTransition' );
-// TODO: import Function.bind polyfill.
+var fnBind = require( '../../modules/util/fn-bind' ).fnBind;
 
 // Exported constants.
 var CLASSES = {
@@ -35,7 +35,7 @@ function MoveTransition( element ) { // eslint-disable-line max-statements, no-i
    */
   function init() {
     _baseTransition.init();
-    var _transitionCompleteBinded = _transitionComplete.bind( this );
+    var _transitionCompleteBinded = fnBind( _transitionComplete, this );
     _baseTransition.addEventListener( BaseTransition.END_EVENT,
                                       _transitionCompleteBinded );
     return this;

--- a/cfgov/unprocessed/js/modules/util/assign.js
+++ b/cfgov/unprocessed/js/modules/util/assign.js
@@ -9,10 +9,10 @@
 
 'use strict';
 
-var fnBind = require( './fnBind' ).fnBind;
+var fnBind = require( './fn-bind' ).fnBind;
 
 /**
-* @param {Object} object - JavaScript object.
+* @param {object} object - JavaScript object.
 * @returns {boolean} True if object is plain Javascript object.
 */
 function _isPlainObject( object ) {

--- a/cfgov/unprocessed/js/modules/util/fn-bind.js
+++ b/cfgov/unprocessed/js/modules/util/fn-bind.js
@@ -16,7 +16,7 @@
 * @access private
 * @function fnBind
 * @param {function} fn - a function you want to change `this` reference to
-* @param {object} context - the `this` you want to call the function with
+* @param {Object} context - the `this` you want to call the function with
 * @returns {function} The wrapped version of the supplied function
 */
 function fnBind( fn, context ) {

--- a/cfgov/unprocessed/js/molecules/Expandable.js
+++ b/cfgov/unprocessed/js/molecules/Expandable.js
@@ -4,6 +4,7 @@
 var atomicHelpers = require( '../modules/util/atomic-helpers' );
 var breakpointState = require( '../modules/util/breakpoint-state' );
 var EventObserver = require( '../modules/util/EventObserver' );
+var fnBind = require( '../modules/util/fn-bind' ).fnBind;
 
 /**
  * Expandable
@@ -41,8 +42,8 @@ function Expandable( element ) { // eslint-disable-line max-statements, inline-c
 
   // TODO: Replace function of _that with Function.prototype.bind.
   var _that = this;
-  var _collapseBinded = collapse.bind( this );
-  var _expandBinded = expand.bind( this );
+  var _collapseBinded = fnBind( collapse, this );
+  var _expandBinded = fnBind( expand, this );
 
   /**
    * @param {number} state

--- a/cfgov/unprocessed/js/molecules/GlobalSearch.js
+++ b/cfgov/unprocessed/js/molecules/GlobalSearch.js
@@ -6,6 +6,7 @@ var breakpointState = require( '../modules/util/breakpoint-state' );
 var ClearableInput = require( '../modules/ClearableInput' );
 var EventObserver = require( '../modules/util/EventObserver' );
 var FlyoutMenu = require( '../modules/FlyoutMenu' );
+var fnBind = require( '../modules/util/fn-bind' ).fnBind;
 var MoveTransition = require( '../modules/transition/MoveTransition' );
 
 /**
@@ -21,7 +22,6 @@ var MoveTransition = require( '../modules/transition/MoveTransition' );
 function GlobalSearch( element ) { // eslint-disable-line max-statements, no-inline-comments, max-len
 
   var BASE_CLASS = 'm-global-search';
-
   var _dom = atomicHelpers.checkDom( element, BASE_CLASS, 'GlobalSearch' );
   var _triggerSel = '.' + BASE_CLASS + '_trigger';
   var _triggerDom = _dom.querySelector( _triggerSel );
@@ -63,8 +63,7 @@ function GlobalSearch( element ) { // eslint-disable-line max-statements, no-inl
     // Initialize new clearable input behavior on the input-contains-label.
     var clearableInput = new ClearableInput( inputContainsLabel );
     clearableInput.init();
-
-    var handleExpandBeginBinded = _handleExpandBegin.bind( this );
+    var handleExpandBeginBinded = fnBind( _handleExpandBegin, this );
     _flyoutMenu.addEventListener( 'expandBegin', handleExpandBeginBinded );
     _flyoutMenu.addEventListener( 'collapseBegin', _handleCollapseBegin );
     _flyoutMenu.addEventListener( 'collapseEnd', _handleCollapseEnd );

--- a/cfgov/unprocessed/js/organisms/MegaMenu.js
+++ b/cfgov/unprocessed/js/organisms/MegaMenu.js
@@ -6,6 +6,7 @@ var breakpointState = require( '../modules/util/breakpoint-state' );
 var dataHook = require( '../modules/util/data-hook' );
 var EventObserver = require( '../modules/util/EventObserver' );
 var FlyoutMenu = require( '../modules/FlyoutMenu' );
+var fnBind = require( '../modules/util/fn-bind' ).fnBind;
 var MegaMenuDesktop = require( '../organisms/MegaMenuDesktop' );
 var MegaMenuMobile = require( '../organisms/MegaMenuMobile' );
 var MoveTransition = require( '../modules/transition/MoveTransition' );
@@ -66,9 +67,9 @@ function MegaMenu( element ) {
     _desktopNav = new MegaMenuDesktop( _menus ).init();
     _mobileNav = new MegaMenuMobile( _menus ).init();
     _mobileNav.addEventListener( 'rootExpandBegin',
-                                 _handleRootExpandBegin.bind( this ) );
+                                 fnBind (_handleRootExpandBegin, this ) );
     _mobileNav.addEventListener( 'rootCollapseEnd',
-                                 _handleRootCollapseEnd.bind( this ) );
+                                 fnBind( _handleRootCollapseEnd, this ) );
 
     window.addEventListener( 'resize', _resizeHandler );
     // Funnel window resize handler into orientation change on devices that support it.

--- a/cfgov/unprocessed/js/organisms/MegaMenuDesktop.js
+++ b/cfgov/unprocessed/js/organisms/MegaMenuDesktop.js
@@ -2,6 +2,7 @@
 
 // Required modules.
 var EventObserver = require( '../modules/util/EventObserver' );
+var fnBind = require( '../modules/util/fn-bind' ).fnBind;
 var MoveTransition = require( '../modules/transition/MoveTransition' );
 var treeTraversal = require( '../modules/util/tree-traversal' );
 
@@ -20,10 +21,10 @@ function MegaMenuDesktop( menus ) {
   var _bodyDom = document.body;
 
   // Binded functions.
-  var _handleTriggerClickBinded = _handleTriggerClick.bind( this );
-  var _handleTriggerOverBinded = _handleTriggerOver.bind( this );
-  var _handleExpandBeginBinded = _handleExpandBegin.bind( this );
-  var _handleCollapseEndBinded = _handleCollapseEnd.bind( this );
+  var _handleTriggerClickBinded = fnBind( _handleTriggerClick, this );
+  var _handleTriggerOverBinded = fnBind( _handleTriggerOver, this );
+  var _handleExpandBeginBinded = fnBind( _handleExpandBegin, this );
+  var _handleCollapseEndBinded = fnBind( _handleCollapseEnd, this );
 
   // Tree model.
   var _menus = menus;

--- a/cfgov/unprocessed/js/organisms/MegaMenuMobile.js
+++ b/cfgov/unprocessed/js/organisms/MegaMenuMobile.js
@@ -1,7 +1,9 @@
 'use strict';
 
+
 // Required modules.
 var EventObserver = require( '../modules/util/EventObserver' );
+var fnBind = require( '../modules/util/fn-bind' ).fnBind;
 var MoveTransition = require( '../modules/transition/MoveTransition' );
 var treeTraversal = require( '../modules/util/tree-traversal' );
 
@@ -20,11 +22,11 @@ function MegaMenuMobile( menus ) {
   var _bodyDom = document.body;
 
   // Binded functions.
-  var _handleTriggerClickBinded = _handleTriggerClick.bind( this );
-  var _handleExpandBeginBinded = _handleExpandBegin.bind( this );
-  var _handleCollapseBeginBinded = _handleCollapseBegin.bind( this );
-  var _handleCollapseEndBinded = _handleCollapseEnd.bind( this );
-  var _suspendBinded = suspend.bind( this );
+  var _handleTriggerClickBinded = fnBind( _handleTriggerClick, this );
+  var _handleExpandBeginBinded = fnBind( _handleExpandBegin, this );
+  var _handleCollapseBeginBinded = fnBind( _handleCollapseBegin, this );
+  var _handleCollapseEndBinded = fnBind( _handleCollapseEnd, this );
+  var _suspendBinded = fnBind( suspend, this );
 
   // Tree model.
   var _menus = menus;


### PR DESCRIPTION
Fix for BB on non V1 pages. We have opted not to include a polyfill or shim for various reasons. Instead, we have chosen to use an internal function to augment `Function.prototype.bind`. I think this approach is the least invasive when including the header/footer modules on other sites. It's not a complete approach as we are using `.bind` instead of `fnBind` in other modules.

This fix doesn't work on the emulator but does on a real device. What a fun time that was discovering this fact. 


## Changes

- Changed `Function.prototype.bind` instances to use internal function.

## Removals

- Removed instances of `Object.seal` to avoid shimming/shamming/polyfill augmenting. We will address immutable constants at a later date.

## Testing

- Browse the site paying close attention to the nav at various breakpoints. Visit `http://localhost:8000/test-fixture/?atomic=header` and do the same. 


## Review

- @KimberlyMunoz 
- @anselmbradford 
- @jimmynotjim 


## Notes



## Todos

-

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
