### PR TITLE
Support orientation change

### DIFF
--- a/cfgov/unprocessed/js/organisms/MegaMenu.js
+++ b/cfgov/unprocessed/js/organisms/MegaMenu.js
@@ -71,6 +71,10 @@ function MegaMenu( element ) {
                                  _handleRootCollapseEnd.bind( this ) );
 
     window.addEventListener( 'resize', _resizeHandler );
+    // Funnel window resize handler into orientation change on devices that support it.
+    if ( 'onorientationchange' in window ) {
+      window.addEventListener( 'orientationchange', _resizeHandler );
+    }
 
     if ( _isInDesktop() ) {
       _desktopNav.resume();


### PR DESCRIPTION
## Changes

- Add listening for switch between mobile and desktop on orientation change.

## Testing

- `gulp build`
- View in iPad simulator. 
- Use menu in landscape.
- Swap to portrait.
- Use menu in portrait. It should still work.

**Note: The simulator may show a flyout menu to the right. This may be a simulator bug and not occur on a device, but not sure till we push to beta and test on a device.**
<img width="577" alt="screen shot 2016-04-12 at 10 31 44 am" src="https://cloud.githubusercontent.com/assets/704760/14469143/3c51539e-00b1-11e6-96f3-1bc60d270823.png">


## Review

- @sebworks 
- @jimmynotjim 
- @KimberlyMunoz 

## Notes

- In some cases the `_resizeHandler` will fire twice on devices that support both orientation change and resize events. This shouldn't be a problem, because in the case of resize events they are firing continuously while resizing anyway. We could limit it to one or the other, but I think there will be cases where the page could be resized and have an orientation change as separate events.
