### PR TITLE
mysql connector

### DIFF
--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -16,6 +16,11 @@ SECRET_KEY = os.environ.get('SECRET_KEY', os.urandom(32))
 # Use the django default password hashing
 PASSWORD_HASHERS = global_settings.PASSWORD_HASHERS
 
+try:
+    import mysql
+    MYSQL_ENGINE = 'django.db.backends.mysql'
+except ImportError:
+    MYSQL_ENGINE = 'django.db.backends.mysql'
 
 # Application definition
 
@@ -130,7 +135,7 @@ WSGI_APPLICATION = 'cfgov.wsgi.application'
 
 DATABASES = {
     'default': {
-        'ENGINE': 'django.db.backends.mysql',
+        'ENGINE': MYSQL_ENGINE,
         'NAME': os.environ.get('MYSQL_NAME', 'v1'),
         'USER': os.environ.get('MYSQL_USER', 'root'),
         'PASSWORD': os.environ.get('MYSQL_PW', ''),

--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -18,7 +18,7 @@ PASSWORD_HASHERS = global_settings.PASSWORD_HASHERS
 
 try:
     import mysql
-    MYSQL_ENGINE = 'django.db.backends.mysql'
+    MYSQL_ENGINE = 'mysql.connector.django'
 except ImportError:
     MYSQL_ENGINE = 'django.db.backends.mysql'
 

--- a/cfgov/cfgov/settings/local.py
+++ b/cfgov/cfgov/settings/local.py
@@ -5,7 +5,7 @@ INSTALLED_APPS += ('wagtail.contrib.wagtailstyleguide',)
 
 DATABASES = {
     'default': {
-        'ENGINE': 'django.db.backends.mysql',
+        'ENGINE': MYSQL_ENGINE,
         'NAME': os.environ.get('MYSQL_NAME'),
         'USER': os.environ.get('MYSQL_USER'),
         'PASSWORD': os.environ.get('MYSQL_PW', ''),


### PR DESCRIPTION
This will allow usage of Oracle's pure-python mysql connector. If it's not installed, we still attempt to use MySQL-Python.

This has the potential to ease development setup, and some deployment scenarios.


## Changes

- adds a switch to settings that checks if 'mysql' can be imported, and if so, sets the mysql engine to 'mysql.connectors.django'

## Testing

- download the platform-independent zip from [here](http://dev.mysql.com/downloads/connector/python/), and `pip install file.zip`, and verify that wagtail-backed pages continue to work.

## Review

- @kurtw @kave 


## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
