### PR TITLE
Add icon to back into external links that leave .gov

### DIFF
--- a/cfgov/v1/__init__.py
+++ b/cfgov/v1/__init__.py
@@ -73,11 +73,11 @@ def parse_links(soup):
             pass
 
     for a in soup.find_all('a', href=True):
-        # Sets the link to an external one if you're leaving .gov 
-        if extlink_pattern.match(a['href']):
-            a['href'] = '/external-site/?ext_url=' + a['href']
         # Sets the icon to indicate you're leaving consumerfinance.gov
         if noncfpb_pattern.match(a['href']):
+            # Sets the link to an external one if you're leaving .gov 
+            if extlink_pattern.match(a['href']):
+                a['href'] = '/external-site/?ext_url=' + a['href']
             a.attrs.update({'class': a_class})
             a.append(' ')  # We want an extra space before the icon
             a.append(soup.new_tag('span', attrs='class="%s"' % span_class))


### PR DESCRIPTION
## Changes

- Makes sure external link icon gets into any external link

## Testing

- go to these pages and then go to localhost and compare the links. See [JIRA]/browse/DFJR-1229 for details on the links.
 - http://beta.consumerfinance.gov/policy-compliance/guidance/implementation-guidance/tila-respa-disclosure-rule/
 - http://beta.consumerfinance.gov/open-government/our-open-government-activities/
 - http://beta.consumerfinance.gov/policy-compliance/guidance/implementation-guidance/tila-respa-disclosure-rule/
- http://beta.consumerfinance.gov/policy-compliance/notice-opportunities-comment/archive-closed/30-day-pra-loan-originator-compensation-amendment-regulation-z/

- run `./cfgov/manage.py sheer_index` and go to http://localhost:8000/about-us/blog/5-things-to-consider-before-you-collect-your-social-security-benefits/ and see that the `seven in ten countries` link has an icon. also check that the `30 percent reduction` link has it too.

## Review

- @kave 
- @richaagarwal 
