### PR TITLE
fixed leadership calendar filtering for pdf downloads

### DIFF
--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -206,6 +206,7 @@ TAGGIT_CASE_INSENSITIVE = True
 
 SHEER_ELASTICSEARCH_SERVER = os.environ.get('ES_HOST', 'localhost') + ':' + os.environ.get('ES_PORT', '9200')
 SHEER_ELASTICSEARCH_INDEX = os.environ.get('SHEER_ELASTICSEARCH_INDEX', 'content')
+ELASTICSEARCH_BIGINT = 50000
 
 MAPPINGS = PROJECT_ROOT.child('es_mappings')
 SHEER_PROCESSORS = \

--- a/cfgov/jinja2/v1/_includes/macros/active-filters.html
+++ b/cfgov/jinja2/v1/_includes/macros/active-filters.html
@@ -68,7 +68,7 @@
     {%- if options.show_filters_label -%}
         <li class="list_item filtered-by_header">
         {%- if posts | list | length > 0 -%}
-          {% if posts.paginator is defined -%}
+          {% if posts.paginator -%}
             {{ posts.paginator.count }} filtered result{{ 's' if posts.paginator.count > 1 }} for
           {% else -%}
             {{ posts.total }} filtered result{{ 's' if posts.total > 1 }} for
@@ -81,16 +81,16 @@
     {%- for filter in active_filters %}
         <li class="list_item filtered-by_filter">
             {{ 'Blog' if filter == 'post' else filter }}
-        {%- if not loop.last or active_date_filters | length > 0 -%}
+        {% if not loop.last or active_date_filters | length > 0 %}
             ,
-        {%- endif %}
+        {% endif %}
         </li>
     {% endfor %}
     {%- if active_date_filters | length > 0 -%}
         <li class="list_item filtered-by_filter">
         {%- for filter in active_date_filters %}
             {{ filter | date("%B %Y") }}
-            {{ '&ndash;' | safe if not loop.last }}
+            {{ '&ndash;' | safe if not loop.last else '' }}
         {%- endfor -%}
         </li>
     {%- endif %}
@@ -98,7 +98,7 @@
     {% if options.show_unfiltered_count and options.show_filters_label %}
         <li class="list_item">
             <span class="filtered-by_header">
-              {% if posts.paginator is defined -%}
+              {% if posts.paginator -%}
                 {{ posts.paginator.count }} result{{ 's' if posts.paginator.count > 1 }}
               {% else -%}
                 {{ posts.total }} result{{ 's' if posts.total > 1 }}

--- a/cfgov/jinja2/v1/about-us/the-bureau/leadership-calendar/print/index.html
+++ b/cfgov/jinja2/v1/about-us/the-bureau/leadership-calendar/print/index.html
@@ -18,19 +18,19 @@
 {% endblock %}
 
 {% block body %}
-
-    {% import 'macros/active-filters.html' as active_filters with context %}
     {% import 'leadership-calendar-table.html' as calendar %}
 
     <main class="content print" id="main" role="main">
         <div class="content_wrapper">
             <div class="content_main">
                 <div class="print-header">
-                    {% set query = queries.calendar_event -%}
-                    {%- set posts = query.search() -%}
+                    {% set query = queries.calendar_event %}
+                    {% set posts = query.search(pdf_print=True) %}
+
+                    {% import 'macros/active-filters.html' as active_filters with context %}
                     <h1 class="superheader">Leadership Calendar</h1>
                     {{ active_filters.render(posts, ['calendar', 'range_date'], {
-                        'show_filters_label': false,
+                        'show_filters_label': true,
                         'show_unfiltered_count': true,
                         'use_list': true
                     }) }}

--- a/cfgov/sheerlike/query.py
+++ b/cfgov/sheerlike/query.py
@@ -267,10 +267,13 @@ class Query(object):
             aggregations=None,
             use_url_arguments=True,
             size=10,
+            pdf_print=False,
             **kwargs):
         query_file = json.loads(file(self.filename).read())
         query_dict = query_file['query']
 
+        if pdf_print:
+            query_dict['size'] = settings.ELASTICSEARCH_BIGINT
         '''
         These dict constructors split the kwargs from the template into filter
         arguments and arguments that can be placed directly into the query body.

--- a/cfgov/v1/views.py
+++ b/cfgov/v1/views.py
@@ -40,7 +40,7 @@ from .signals import page_unshared
 LoginForm = login_form()
 
 class LeadershipCalendarPDFView(PDFGeneratorView):
-    render_url = 'http://localhost/the-bureau/leadership-calendar/print/'
+    render_url = 'http://localhost/about-us/the-bureau/leadership-calendar/print/'
     stylesheet_url = 'http://localhost/static/css/pdfreactor-fonts.css'
     filename = 'cfpb_leadership-calendar.pdf'
 


### PR DESCRIPTION
The redirect was tossing the `GET` request params, so i updated the url path created by the service.

Also created a ELASTICSEARCH_BIGINT variable as es doesn't currently have a way to return all documents without pagination of some sort which won't work for a pdf creation.

@kurtw @richaagarwal @rosskarchner 

## Testing
- Testing this locally will be a pain for you, wait to test on flapjack after merging.