### PR TITLE
bringing /find-a-housing-counselor/ to django + mapbox

### DIFF
--- a/cfgov/cfgov/urls.py
+++ b/cfgov/cfgov/urls.py
@@ -245,6 +245,7 @@ urlpatterns = [
     url(r'^eregs-api/', include_if_app_enabled('regcore', 'regcore.urls')),
     url(r'^eregulations/', include_if_app_enabled('regulations','regulations.urls')),
 
+    url(r'^find-a-housing-counselor/$', TemplateView.as_view(template_name='find_a_housing_counselor.html')),
     # Report redirects
     url(r'^reports/(?P<path>.*)$', RedirectView.as_view(url='/data-research/research-reports/%(path)s', permanent=True)),
 ]

--- a/cfgov/cfgov/urls.py
+++ b/cfgov/cfgov/urls.py
@@ -5,6 +5,7 @@ from django.conf import settings
 from django.conf.urls.static import static
 from django.conf.urls import include, url
 from django.views.generic.base import TemplateView, RedirectView
+from legacy.views import HousingCounselorPDFView
 from sheerlike.views.generic import SheerTemplateView
 from sheerlike.feeds import SheerlikeFeed
 from sheerlike.sites import SheerSite
@@ -246,6 +247,7 @@ urlpatterns = [
     url(r'^eregulations/', include_if_app_enabled('regulations','regulations.urls')),
 
     url(r'^find-a-housing-counselor/$', TemplateView.as_view(template_name='find_a_housing_counselor.html')),
+    url(r'^save-hud-counselors-list/$', HousingCounselorPDFView.as_view()),
     # Report redirects
     url(r'^reports/(?P<path>.*)$', RedirectView.as_view(url='/data-research/research-reports/%(path)s', permanent=True)),
 ]

--- a/cfgov/core/services.py
+++ b/cfgov/core/services.py
@@ -14,6 +14,7 @@ from v1.forms import CalenderPDFFilterForm
 from django.core.urlresolvers import reverse
 from django.contrib import messages
 from django.http import HttpResponseRedirect
+from django.conf import settings
 
 class PDFReactorNotConfigured(Exception):
     pass
@@ -24,7 +25,7 @@ if six.PY2:
         sys.path.append(os.environ.get('PDFREACTOR_LIB'))
         from PDFreactor import *
     except:
-        pass
+       PDFReactor = None
 
 class PDFGeneratorView(View):
     render_url = None

--- a/cfgov/legacy/views.py
+++ b/cfgov/legacy/views.py
@@ -1,0 +1,53 @@
+from core.services import PDFGeneratorView, PDFReactor
+from django.conf import settings
+from django.http import HttpResponse
+
+
+class HousingCounselorPDFView(PDFGeneratorView):
+    def get_render_url(self):
+        request = self.request
+        api_url = 'hud-api-replace/%s.html/' % request.GET['zip']
+        url = '%s://%s/%s' % (request.scheme, request.get_host(), api_url)
+        return url
+
+    def get(self, request):
+
+        self.request = request
+        if settings.DEBUG and PDFReactor is None:
+            return HttpResponse("PDF Reactor is not configured, can not render %s" % self.get_render_url())
+
+        return self.generate_pdf()
+
+    def get_filename(self):
+        return '%s.zip' % self.request.GET['zip']
+
+    def generate_pdf(self):
+        url = self.get_render_url()
+
+        if self.license is None:
+            raise Exception("PDFGeneratorView requires a license")
+
+        try:
+            pdf_reactor = PDFreactor()
+        except:
+            raise PDFReactorNotConfigured('PDFreactor python library path needs to be configured.')
+
+        pdf_reactor.setLogLevel(PDFreactor.LOG_LEVEL_WARN)
+        pdf_reactor.setLicenseKey(str(self.license))
+        pdf_reactor.setAuthor('CFPB')
+        pdf_reactor.setAddTags(True)
+        pdf_reactor.setAddBookmarks(True)
+
+        result = pdf_reactor.renderDocumentFromURL(url)
+
+        # Check if successful
+        if result is None:
+            # Not successful, return 500
+            raise Exception('Error while rendering PDF: {}'.format(
+                pdf_reactor.getError()))
+        else:
+            # Set the correct header for PDF output
+            response = HttpResponse(result, content_type='application/pdf')
+            response['Content-Disposition'] = 'attachment; filename={0}'.format(
+                self.get_filename())
+            return response

--- a/cfgov/templates/find_a_housing_counselor.html
+++ b/cfgov/templates/find_a_housing_counselor.html
@@ -1,6 +1,10 @@
 {% extends "front/base_nonresponsive.html" %}
 {% load static %}
 
+{% block title %}
+Find a housing counselor
+{% endblock %}
+
 {% block content %}
 <section>
 			  <ul class="bread meta">

--- a/cfgov/templates/find_a_housing_counselor.html
+++ b/cfgov/templates/find_a_housing_counselor.html
@@ -49,7 +49,9 @@
 		</div><!-- end .cfpb_hud_hca_api_more_info -->
 	</div><!-- end .hud_hca_api_form_container -->
 
-	<div id="hud_hca_api_map_container" class="hud_hca_api_map col"></div><!-- end .hud_hca_api_map -->
+	<div id="hud_hca_api_map_container" class="hud_hca_api_map col">
+    <div id="hud_hca_api_map_canvas" ></div>
+  </div><!-- end .hud_hca_api_map -->
 </div><!-- end .hud_hca_api_grid_twothird -->
 
 <div id="hud_hca_api_results_container" class="hud_hca_api_results">
@@ -145,7 +147,14 @@
 
 {% endblock content %}
 
+
+{% block app_css %}
+<link href='https://api.mapbox.com/mapbox.js/v2.4.0/mapbox.css' rel='stylesheet' />
+<link href='{% static 'hud_api/css/hud_api.css' %}' rel='stylesheet' ></link>
+{% endblock %}
+
 {% block app_js %}
-<script type='text/javascript' src='{% static 'hud_api/hud_api.js' %}'></script>
+<script type='text/javascript' src='https://api.mapbox.com/mapbox.js/v2.4.0/mapbox.js'></script>
+<script type='text/javascript' src='{% static 'hud_api/js/hud_api.js' %}'></script>
 
 {% endblock %}

--- a/cfgov/templates/find_a_housing_counselor.html
+++ b/cfgov/templates/find_a_housing_counselor.html
@@ -145,6 +145,6 @@
 {% endblock content %}
 
 {% block app_js %}
-<script type='text/javascript' src=''></script>
+<script type='text/javascript' src='{% static 'hud_api/hud_api.js' %}'></script>
 
 {% endblock %}

--- a/cfgov/templates/find_a_housing_counselor.html
+++ b/cfgov/templates/find_a_housing_counselor.html
@@ -1,0 +1,150 @@
+{% extends "front/base_nonresponsive.html" %}
+
+{% block content %}
+<section>
+			  <ul class="bread meta">
+  	<li><a href="/">Home</a></li>
+        <li>Find a housing counselor</li>
+  </ul>         
+		<div class="share mini">	<a href="http://www.facebook.com/sharer.php?u=http://beta.consumerfinance.gov/find-a-housing-counselor/&amp;t=Find a housing counselor" class="share-facebook noStyles"><img src="http://beta.consumerfinance.gov/wp-content/themes/cfpb_nemo/_/img/icon_small_facebook.png" alt="Share on Facebook"></a>
+	<a href="http://twitter.com/intent/tweet/?url=http://beta.consumerfinance.gov/find-a-housing-counselor/&amp;via=CFPB" class="share-twitter noStyles"><img src="http://beta.consumerfinance.gov/wp-content/themes/cfpb_nemo/_/img/icon_small_twitter.png" alt="Share on Twitter"></a>
+	<a href="http://api.addthis.com/oexchange/0.8/forward/email/offer?url=http://beta.consumerfinance.gov/find-a-housing-counselor/&amp;title=Find a housing counselor&amp;pubid=ra-4da354ee346886d2" class="share-email noStyles"><img src="http://beta.consumerfinance.gov/wp-content/themes/cfpb_nemo/_/img/icon_small_email.png" alt="Share via email"></a>
+</div>		<article class="page">
+			
+				<div class="hud_hca_api_print-header">
+				<!-- Show different content on print -->
+					<img class="hud_hca_api_print_logo hud_hca_api_print_show cfpb_hide" src="/wp-content/themes/cfpb_nemo/_/img/logo.png" alt="Consumer Financial Protection Bureau">
+												<header class="pagetitle hud_hca_api_print_show cfpb_hide"><h1>Housing counselors near you</h1></header>
+											<div class="hud_hca_api_the_results hud_hca_api_print_show cfpb_hide">10 closest results to ZIP code <span class="hud_hca_api_search_zip"></span></div>
+				</div><!-- end .hud_hca_api_print-header -->
+				<header class="pagetitle hud_hca_api_print_hide"><h1>Find a housing counselor</h1></header>
+
+				<div class="hud_hca_api_print_hide">
+				<!-- Regular content hidden on print -->
+					<p>Housing counselors throughout the country can provide advice on buying a home, renting, defaults, foreclosures, and credit issues. Using the search box below, you can find one near you. The counseling agencies on this list are approved by the U.S. Department of Housing and Urban Development (HUD) and they can offer independent advice about whether a particular set of mortgage loan terms is a good fit based on your objectives and circumstances, often at little or no cost to you. This list will show you several approved agencies in your area. There is also a&nbsp;<a href="http://portal.hud.gov/hudportal/HUD?src=/ohc_nint">list of nationwide HUD-approved counseling intermediaries</a>.</p>
+				</div><!-- end .hud_hca_api_print_hide -->
+				
+				<div id="cfpb_hud_hca_api_print_text_container" class="cfpb_hud_hca_api_print_text hud_hca_api_print_show cfpb_hide">
+				<!-- Show different content on print -->
+					<p>The counseling agencies on this list are approved by the U.S. Department of Housing and Urban Development (HUD), and they can offer independent advice about whether a particular set of mortgage loan terms is a good fit based on your objectives and circumstances, often at little or no cost to you.  This list shows you several approved agencies in your area.  You can find other approved counseling agencies at the Consumer Financial Protection Bureau’s (CFPB) website: consumerfinance.gov/mortgagehelp or by calling 1-855-411-CFPB (2372).  You can also access a list of nationwide HUD-approved counseling intermediaries at http://portal.hud.gov/hudportal/HUD?src=/ohc_nint</p>				</div><!-- end .cfpb_hud_hca_api_print_text -->
+
+				<div class="hud_hca_api_print border">
+					<div class="hud_hca_api_print_full">
+						<div id="hud_hca_api_interactions_container" class="hud_hca_api_interactions">
+							<div class="hud_hca_api_grid_twothird clearfix hud_hca_api_print_hide">
+	<div id="hud_hca_api_form_container" class="hud_hca_api_form_container col">
+		<div id="hud_hca_api_form" class="hud_hca_api_form">
+			<form action="#" method="get">
+				 <label for="hud_hca_api_query">Search by ZIP code:</label>
+				 <input type="text" name="hud_hca_api_query" id="hud_hca_api_query" value="" placeholder="Please enter a 5-digit ZIP code">
+				 <button class="hud_hca_api_form_button">Find a counselor</button>
+			</form>
+			<a class="cfpb_visually_hide" href="#hud_hca_api_results_meta_container">Skip to results</a>
+		</div>
+		<div id="hud_hca_api_more_info_container" class="hud_hca_api_more_info">
+			<p>This tool is open sourced on <a href="https://github.com/cfpb/django-hud">GitHub</a> and powered by <a href="http://data.hud.gov/housing_counseling.html">HUD's</a> official list of housing counselors. We encourage you to leverage it in your own applications.</p>
+
+<p>If you notice errors in the housing counselor data, contact <a href="mailto: housing.counseling@hud.gov ">housing.counseling@hud.gov .</a></p>
+		</div><!-- end .cfpb_hud_hca_api_more_info -->
+	</div><!-- end .hud_hca_api_form_container -->
+
+	<div id="hud_hca_api_map_container" class="hud_hca_api_map col"></div><!-- end .hud_hca_api_map -->
+</div><!-- end .hud_hca_api_grid_twothird -->
+
+<div id="hud_hca_api_results_container" class="hud_hca_api_results">
+	<div id="hud_hca_api_message" role="alert" class="hud_hca_api_message" style="display: none;">
+		<p></p>
+	</div>
+    <div id="hud_hca_api_results_meta_container" class="hud_hca_api_results_meta clearfix">
+        <div id="hud_hca_api_results_info" class="hud_hca_api_results_info hud_hca_api_print_hide clearfix" style="display: none;">
+            <div class="hud_hca_api_results_total">
+                <p>Displaying the 10 locations closest to ZIP code <span class="hud_hca_api_search_zip"></span></p>
+            </div><!-- end .hud_hca_api_results_total -->
+            <div class="hud_hca_api_results_actions">
+                <p>
+                    <span class="icon-print"></span>
+                    <span class="hud_hca_api_results_print"><a class="hud-hca-api-print" href="#print">Print list</a></span>
+                    <span class="icon-save"></span>
+                    <span class="hud_hca_api_results_save"><a id="generate-pdf-link" href="/save-hud-counselors-list/" target="_blank">Save list as PDF</a></span>
+                </p>
+            </div><!-- end .hud_hca_api_results_actions -->
+        </div><!-- end .hud_hca_api_results_info -->
+        <div id="hud_hca_api_results_list_container" class="hud_hca_api_results_list">
+        	<div id="hud_hca_api_the_results" class="hud_hca_api_the_results_list_container">
+        		<table id="hud_hca_api_results_table" class="hud_hca_api_results_listing hud_hca_api_print" style="display: none;">				
+					<thead class="hud_hca_api_print_hide">
+						<tr>
+							<th scope="col" class="hud_hca_api_titles hud_hca_api_titles_left">Agency</th>
+							<th scope="col" class="hud_hca_api_titles hud_hca_api_titles_middle">Services</th>
+							<th scope="col" class="hud_hca_api_titles hud_hca_api_titles_right">Distance</th>
+						</tr>
+					</thead>
+					<tbody>
+					</tbody>
+					<tfoot id="hud_hca_api_row_template" style="display:none;">
+						<tr class="hud_hca_api_result">
+							<td class="hud_hca_api_result hud_hca_api_counselors_td">
+								<div class="hud_hca_api_num"></div>
+								<div class="hud_hca_api_counselor_info_container">								
+									<div class="hud_hca_api_counselor">
+									</div>
+									<div class="hud_hca_api_counselor_address">
+										<span class="hud_hca_api_adr">
+										</span>
+										<span class="hud_hca_api_region">
+										</span>
+									</div>
+									<div class="hud_hca_api_counselor_meta">
+										<span class="hud_hca_api_results_listing_title">Website: <span class="hud_hca_api_site"></span></span>
+										<span class="hud_hca_api_results_listing_title">Phone: <span class="hud_hca_api_tel"></span></span>
+										<span class="hud_hca_api_results_listing_title">Email Address: <span class="hud_hca_api_email">
+										</span></span>
+										<span class="hud_hca_api_results_listing_title">Languages: <span class="hud_hca_api_lang"></span></span>
+									</div>
+								</div>
+							</td>
+							<td class="hud_hca_api_result hud_hca_api_services_td">
+								<div class="hud_hca_api_services">
+									<span class="hud_hca_api_results_listing_title cfpb_hide hud_hca_api_print_show">Services: </span><span class="hud_hca_api_serv"></span>
+								</div>
+							</td>
+							<td class="hud_hca_api_result hud_hca_api_distances_td">
+								<div class="hud_hca_api_distance">
+									<span class="hud_hca_api_results_listing_title cfpb_hide hud_hca_api_print_show">Distance</span>
+									<span class="hud_hca_api_the_distance"><span class="hud_hca_api_miles"></span> miles</span>
+								</div>
+							</td>
+						</tr>
+					</tfoot>              
+				</table><!-- end .hud_hca_api_results_listing -->
+        	</div>
+        	<div class="show-hide default-hidden hud_hca_api_print_hide hud_hca_api_pras">
+			<span class="show-hide-icon icon-plus-alt"></span>
+				<a href="javascript:void(0)" class="show-hide-link" data-texthide="Hide" data-textshow="View">
+					<span class="show-hide-name">View</span>
+					Paperwork Reduction Act statement				</a>
+			<div class="show-hide-content" style="display: none;">
+				<p>According to the Paperwork Reduction Act of 1995, an agency may not conduct or sponsor, and a person is not required to respond to a collection of information unless it displays a valid OMB control number.  The OMB control number for this collection is <a href="http://www.reginfo.gov/public/do/PRAOMBHistory?ombControlNumber=3170-0025">3170-0025</a>. It expires on 04/30/2016.  Using this tool to generate a list of HUD-Approved Housing Counseling Agencies is voluntary however, if you are an entity subject to 12 CFR § 1024 (78 FR 6856 (Jan. 31, 2013)), you are required to provide this list as specified in the regulation. Comments regarding this collection of information, including suggestions for improving the usefulness of the information, or suggestions for reducing the burden to respond to this collection should be submitted to Bureau at the Consumer Financial Protection Bureau (Attention:  PRA Office), 1700 G Street NW, Washington, DC 20552, or by email to <a href="mailto:PRA@cfpb.gov">PRA@cfpb.gov</a>.</p>
+			</div>
+		</div><!-- end .show-hide-mod default-hidden hud_hca_api_print_hide -->
+        </div><!-- end .hud_hca_api_results_list -->
+    </div><!-- end .hud_hca_api_results_meta -->
+</div><!-- end .hud_hca_api_results -->						</div><!-- end .hud_hca_api_interactions -->
+					</div><!-- end .hud_hca_api_print_full -->
+				</div><!-- end .hud_hca_api_print border -->
+
+
+		</article>
+		
+
+	
+
+	</section>
+
+
+{% endblock content %}
+
+{% block app_js %}
+<script type='text/javascript' src=''></script>
+
+{% endblock %}

--- a/cfgov/templates/find_a_housing_counselor.html
+++ b/cfgov/templates/find_a_housing_counselor.html
@@ -1,4 +1,5 @@
 {% extends "front/base_nonresponsive.html" %}
+{% load static %}
 
 {% block content %}
 <section>

--- a/cfgov/templates/hud_list.html
+++ b/cfgov/templates/hud_list.html
@@ -1,0 +1,113 @@
+
+	 
+<!--[if lt IE 7]> <html class="no-js lt-ie9 lt-ie8 lt-ie7" lang="en-US"> <![endif]-->
+<!--[if IE 7]>    <html class="no-js lt-ie9 lt-ie8" lang="en-US"> <![endif]-->
+<!--[if IE 8]>    <html class="no-js lt-ie9" lang="en-US"> <![endif]-->
+<!--[if gt IE 8]><!--> <html lang="en-US"> <!--<![endif]-->
+<head>
+	
+	<meta charset="UTF-8">
+	<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1"><script type="text/javascript">window.NREUM||(NREUM={}),__nr_require=function(e,t,n){function r(n){if(!t[n]){var o=t[n]={exports:{}};e[n][0].call(o.exports,function(t){var o=e[n][1][t];return r(o||t)},o,o.exports)}return t[n].exports}if("function"==typeof __nr_require)return __nr_require;for(var o=0;o<n.length;o++)r(n[o]);return r}({1:[function(e,t,n){function r(e,t){return function(){o(e,[(new Date).getTime()].concat(a(arguments)),null,t)}}var o=e("handle"),i=e(2),a=e(3);"undefined"==typeof window.newrelic&&(newrelic=NREUM);var u=["setPageViewName","addPageAction","setCustomAttribute","finished","addToTrace","inlineHit"],c=["addPageAction"],f="api-";i(u,function(e,t){newrelic[t]=r(f+t,"api")}),i(c,function(e,t){newrelic[t]=r(f+t)}),t.exports=newrelic,newrelic.noticeError=function(e){"string"==typeof e&&(e=new Error(e)),o("err",[e,(new Date).getTime()])}},{}],2:[function(e,t,n){function r(e,t){var n=[],r="",i=0;for(r in e)o.call(e,r)&&(n[i]=t(r,e[r]),i+=1);return n}var o=Object.prototype.hasOwnProperty;t.exports=r},{}],3:[function(e,t,n){function r(e,t,n){t||(t=0),"undefined"==typeof n&&(n=e?e.length:0);for(var r=-1,o=n-t||0,i=Array(0>o?0:o);++r<o;)i[r]=e[t+r];return i}t.exports=r},{}],ee:[function(e,t,n){function r(){}function o(e){function t(e){return e&&e instanceof r?e:e?u(e,a,i):i()}function n(n,r,o){e&&e(n,r,o);for(var i=t(o),a=l(n),u=a.length,c=0;u>c;c++)a[c].apply(i,r);var s=f[g[n]];return s&&s.push([m,n,r,i]),i}function p(e,t){w[e]=l(e).concat(t)}function l(e){return w[e]||[]}function d(e){return s[e]=s[e]||o(n)}function v(e,t){c(e,function(e,n){t=t||"feature",g[n]=t,t in f||(f[t]=[])})}var w={},g={},m={on:p,emit:n,get:d,listeners:l,context:t,buffer:v};return m}function i(){return new r}var a="nr@context",u=e("gos"),c=e(2),f={},s={},p=t.exports=o();p.backlog=f},{}],gos:[function(e,t,n){function r(e,t,n){if(o.call(e,t))return e[t];var r=n();if(Object.defineProperty&&Object.keys)try{return Object.defineProperty(e,t,{value:r,writable:!0,enumerable:!1}),r}catch(i){}return e[t]=r,r}var o=Object.prototype.hasOwnProperty;t.exports=r},{}],handle:[function(e,t,n){function r(e,t,n,r){o.buffer([e],r),o.emit(e,t,n)}var o=e("ee").get("handle");t.exports=r,r.ee=o},{}],id:[function(e,t,n){function r(e){var t=typeof e;return!e||"object"!==t&&"function"!==t?-1:e===window?0:a(e,i,function(){return o++})}var o=1,i="nr@id",a=e("gos");t.exports=r},{}],loader:[function(e,t,n){function r(){if(!w++){var e=v.info=NREUM.info,t=s.getElementsByTagName("script")[0];if(e&&e.licenseKey&&e.applicationID&&t){c(l,function(t,n){e[t]||(e[t]=n)});var n="https"===p.split(":")[0]||e.sslForHttp;v.proto=n?"https://":"http://",u("mark",["onload",a()],null,"api");var r=s.createElement("script");r.src=v.proto+e.agent,t.parentNode.insertBefore(r,t)}}}function o(){"complete"===s.readyState&&i()}function i(){u("mark",["domContent",a()],null,"api")}function a(){return(new Date).getTime()}var u=e("handle"),c=e(2),f=window,s=f.document;NREUM.o={ST:setTimeout,CT:clearTimeout,XHR:f.XMLHttpRequest,REQ:f.Request,EV:f.Event,PR:f.Promise,MO:f.MutationObserver},e(1);var p=""+location,l={beacon:"bam.nr-data.net",errorBeacon:"bam.nr-data.net",agent:"js-agent.newrelic.com/nr-918.min.js"},d=window.XMLHttpRequest&&XMLHttpRequest.prototype&&XMLHttpRequest.prototype.addEventListener&&!/CriOS/.test(navigator.userAgent),v=t.exports={offset:a(),origin:p,features:{},xhrWrappable:d};s.addEventListener?(s.addEventListener("DOMContentLoaded",i,!1),f.addEventListener("load",r,!1)):(s.attachEvent("onreadystatechange",o),f.attachEvent("onload",r)),u("mark",["firstbyte",a()],null,"api");var w=0},{}]},{},["loader"]);</script>
+	
+	
+	<title>Housing counselors near you > Consumer Financial Protection Bureau</title>
+	
+	<meta name="title" content="Housing counselors near you >Consumer Financial Protection Bureau">
+	<meta name="Copyright" content="Public domain">
+	<link rel='stylesheet' id='nemo_pdf_style_css-css'  href='/wp-content/themes/cfpb_nemo/_/c/hud-hca-api-pdf-style.css' type='text/css' media='all' />	
+</head>
+
+<body class="page page-id-43619 page-template page-template-page-hud-generate-pdf-php logged-in admin-bar no-customize-support page">
+
+	<div id="wrapper">
+		<section id="maincontent">
+						<article class="page">
+
+					<img class="hud_hca_api_print_logo hud_hca_api_print_show cfpb_hide" src="/wp-content/themes/cfpb_nemo/_/img/logo.png" alt="Consumer Financial Protection Bureau">
+					<header class="pagetitle"><h1>Housing counselors near you</h1></header>
+					<p class="hud_hca_api_the_results hud_hca_api_print_show cfpb_hide">10 closest results to ZIP code <span class="hud_hca_api_search_zip">{{zip.zipcode}}</span></p>
+					<p class="cfpb_hud_hca_api_print_text">The counseling agencies on this list are approved by the U.S. Department of Housing and Urban Development (HUD), and they can offer independent advice about whether a particular set of mortgage loan terms is a good fit based on your objectives and circumstances, often at little or no cost to you.  This list shows you several approved agencies in your area.  You can find other approved counseling agencies at the Consumer Financial Protection Bureau’s (CFPB) website: consumerfinance.gov/mortgagehelp or by calling 1-855-411-CFPB (2372).  You can also access a list of nationwide HUD-approved counseling intermediaries at http://portal.hud.gov/hudportal/HUD?src=/ohc_nint</p>
+				
+					<div id="hud_hca_api_results_container" class="hud_hca_api_results">
+						<div id="hud_hca_api_results_meta_container" class="hud_hca_api_results_meta clearfix">
+							<div id="hud_hca_api_results_info" class="hud_hca_api_results_info two-col hud_hca_api_print_hide">
+								<div class="hud_hca_api_results_total col">
+                                    <p>10 closest results to ZIP code <span class="hud_hca_api_search_zip">{{zip.zipcode}}</span></p>
+								</div><!-- end .hud_hca_api_results_total -->
+								<div class="hud_hca_api_results_actions col">
+									<p>
+										<span class="hud_hca_api_results_print"><span class="hud_hca_api_no_js_print_text">Print with Browser</span></span>
+										<span class="hud_hca_api_results_save"><a href="/save-hud-counselors-list" target="_blank">Save list as PDF</a></span>
+									</p>
+								</div><!-- end .hud_hca_api_results_actions -->
+								<div class="hud_hca_api_grid_three hud_hca_api_titles">
+									<div class="col">
+										<h2>Agency</h2>
+									</div>
+									<div class="col">
+										<h2>Services</h2>
+									</div>
+									<div class="col last">
+										<h2>Distance</h2>
+									</div>
+								</div>
+							</div><!-- end .hud_hca_api_results_info -->
+							<div id="hud_hca_api_results_list_container" class="hud_hca_api_results_list">
+								<ol class="hud_hca_api_results_listing hud_hca_api_print">
+										{% for counselor in counseling_agencies %}
+										<li class="hud_hca_api_result hud_hca_api_grid_three">
+										<div class="col">
+											<h2 class="cfpb_visually_hide">Agency</h2>
+											<div class="hud_hca_api_counselor">
+												{{ counselor.nme }}											</div>
+											<div class="hud_hca_api_counselor_address">
+												<span class="hud_hca_api_adr">
+												{{ counselor.adr1 }}
+												{% if counselor.adr2 %}
+  													</br> {{ counselor.adr2 }}
+												{% endif %}
+												<span class="hud_hca_api_region">
+                                                    {{ counselor.city }}
+											</div>
+											<div class="hud_hca_api_counselor_meta">
+												<span class="hud_hca_api_results_listing_title">Website: <span class="hud_hca_api_site">
+													<a href="{{counselor.weburl}}">{{ counselor.weburl }}</a>												</span></span>
+												<span class="hud_hca_api_results_listing_title">Phone: <span class="hud_hca_api_tel">{{ counselor.phone1}}</span></span>
+												<span class="hud_hca_api_results_listing_title">Email Address: <span class="hud_hca_api_email">
+													<a href="mailto:{{counselor.email}}">{{counselor.email}}</a>												</span></span>
+												<div class="show-hide-mod default-hidden">
+													<span class="show-hide-icon hud_hca_api_print_hide"></span>
+														<a href="javascript:void(0)" class="show-hide-link hud_hca_api_print_hide" data-texthide="Hide" data-textshow="View">
+															<span class="show-hide-name">View</span>
+															languages offered at this location														</a>
+													<div class="show-hide-content hud_hca_api_print_show">
+														<span class="hud_hca_api_results_listing_title">Languages:</span> <span class="hud_hca_api_lang">{{ counselor.languages }}</span>
+													</div>
+												</div>
+											</div>
+										</div>
+										<div class="col">
+											<h2 class="cfpb_visually_hide">Services</h2>
+											<div class="hud_hca_api_services">
+												<span class="hud_hca_api_results_listing_title cfpb_hide hud_hca_api_print_show">Services: </span>
+												<span class="hud_hca_api_serv">
+													<span class="hud_hca_api_serv_item">{{ counselor.services }}</span><span class="hud_hca_api_serv_item">Resolving/Preventing Mortgage Delinquency Workshop</span>												</span>
+											</div>                      
+										</div>            
+										<div class="col last">
+											<h2 class="cfpb_visually_hide">Distance</h2>
+											<div class="hud_hca_api_distance">
+												<span class="hud_hca_api_the_distance"><span class="hud_hca_api_results_listing_title cfpb_hide hud_hca_api_print_show">Distance</span><span class="hud_hca_api_miles">{{ counselor.distance }}</span> miles</span>
+											</div>
+										</div>
+									</li>
+{% endfor %}
+</ol>
+					</div>
+
+			</article>
+				</section><!--/main_content-->
+	</div><!-- /wrapper -->
+<script type='text/javascript' src='/static/nemo/_/js/jquery-1.9.1.min.js?ver=1.9.1'></script>
+<script type='text/javascript' src='/static/nemo/_/js/functions.js?ver=3.6.1'></script>
+</html>


### PR DESCRIPTION
## Additions

- This brings the "find a housing counselor" tool to Django, and which now uses Mapbox instead of Google Maps. Thank you @wpears!


## Testing

- install the private repo 'django-cfgov-common' if you haven't already, and make sure you have a recent checkout of cfpb_nemo (also private) checked out as a sibling to cfgov-refresh
- check out https://github.com/cfpb/django-hud and `pip install -e ../django-hud` (or wherever you put it)
- you may need to `cfgov/manage.py migrate`
- get the mapbox API key, either from me from 'build.json' in the private 'website' repo.
- `export MAPBOX_ACCESS_TOKEN=[ the token ]`
- `cfgov/manage.py load_hud_data` to load the housing counselor data
- `cfgov/manage.py runserver` and go to http://localhost:8000/find-a-housing-counselor/ to give it a try.
- note that PDF generation will only work if you have PDFReactor configured.

## Review

- @kave @kurtw 

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [x] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
