### PR TITLE
add some URL redirects for owning-a-home static assets

### DIFF
--- a/cfgov/cfgov/urls.py
+++ b/cfgov/cfgov/urls.py
@@ -51,6 +51,8 @@ urlpatterns = [
 
     url(r'^home/(?P<path>.*)$', RedirectView.as_view(url='/%(path)s', permanent=True)),
 
+    url(r'^owning-a-home/static/(?P<path>.*)$', RedirectView.as_view(url='/static/owning-a-home/static/%(path)s')),
+    url(r'^owning-a-home/resources/(?P<path>.*)$', RedirectView.as_view(url='/static/owning-a-home/resources/%(path)s')),
     url(r'^owning-a-home/', include(SheerSite('owning-a-home').urls)),
 
     # the two redirects are an unfortunate workaround, could be resolved by


### PR DESCRIPTION
These redirects resolve issues with certain static assets in the owning-a-home project

## Additions

- two URL redirection rules, that grab /owning-a-home/static and owning-a-home/resources and redirect to /static/owning-a-home/[static or resources/]


- @kave @richaagarwal @kurtw 

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)

