### PR TITLE
DFJR-1220: Fix constrained mega-menu bg on older projects

### DIFF
--- a/cfgov/unprocessed/css/organisms/header.less
+++ b/cfgov/unprocessed/css/organisms/header.less
@@ -87,7 +87,7 @@
         position: relative;
 
         > .wrapper {
-            // Fix for projects using older Capital Framework dependencies.
+            // TODO: remove when Capital Framework is updated to 3.x.x. on outdated consumerfinance.gov projects.
             position: initial;
           
             > .m-global-search {

--- a/cfgov/unprocessed/css/organisms/header.less
+++ b/cfgov/unprocessed/css/organisms/header.less
@@ -87,6 +87,9 @@
         position: relative;
 
         > .wrapper {
+            // Fix for projects using older Capital Framework dependencies.
+            position: initial;
+          
             > .m-global-search {
                 float: right;
             }


### PR DESCRIPTION
The mega-menu background was being constrained on some older projects, such as Owning a Home and Everyone Has a Story. This fixes that by overriding those projects' `position` declaration on the first `.wrapper` inside the header to set it back to its initial value.

## Additions

- `position: initial;` on `.o-header_content > wrapper`

## Testing

- Pull
- Build
- Serve
- Visit `owning-a-home/` or `everyone-has-a-story/` and test

## Review

- @jimmynotjim 
- @anselmbradford 
- @KimberlyMunoz 
- @sebworks 

## Notes
- This line could be removed if these older projects' dependencies are ever brought up to modern standards.

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)

