### PR TITLE
add urls for legacy 'knowbeforeyouowe' pages

### DIFF
--- a/cfgov/cfgov/urls.py
+++ b/cfgov/cfgov/urls.py
@@ -262,8 +262,12 @@ if settings.ALLOW_ADMIN_URL:
     urlpatterns = patterns + urlpatterns
 
 if 'cfpb_common' in settings.INSTALLED_APPS:
-    pattern=url(r'^token-provider/', 'cfpb_common.views.token_provider')
-    urlpatterns.append(pattern)
+    patterns= [url(r'^token-provider/', 'cfpb_common.views.token_provider'),
+               url(r'^students/knowbeforeyouowe/$', TemplateView.as_view(template_name='knowbeforeyouowe/studentloans/tool.html')),
+               url(r'^students/knowbeforeyouowe/about/$', TemplateView.as_view(template_name='knowbeforeyouowe/studentloans/about.html')),
+               url(r'^credit-cards/knowbeforeyouowe/$', TemplateView.as_view(template_name='knowbeforeyouowe/creditcards/tool.html'), name='cckbyo'),
+               ]
+    urlpatterns += patterns
 
 if 'selfregistration' in settings.INSTALLED_APPS:
     from selfregistration.views import CompanySignup

--- a/cfgov/cfgov/urls.py
+++ b/cfgov/cfgov/urls.py
@@ -263,8 +263,6 @@ if settings.ALLOW_ADMIN_URL:
 
 if 'cfpb_common' in settings.INSTALLED_APPS:
     patterns= [url(r'^token-provider/', 'cfpb_common.views.token_provider'),
-               url(r'^students/knowbeforeyouowe/$', TemplateView.as_view(template_name='knowbeforeyouowe/studentloans/tool.html')),
-               url(r'^students/knowbeforeyouowe/about/$', TemplateView.as_view(template_name='knowbeforeyouowe/studentloans/about.html')),
                url(r'^credit-cards/knowbeforeyouowe/$', TemplateView.as_view(template_name='knowbeforeyouowe/creditcards/tool.html'), name='cckbyo'),
                ]
     urlpatterns += patterns


### PR DESCRIPTION
Adds a URL ruls for the Django page at /credit-cards/knowbeforeyouowe 

## Additions

- a url rule (pointing to a templateview)


## Testing

- clone  django-cfgov-common (or update your existing checkout) and make sure that you're on master
- clone CFPB/agreement_database (or update your existing checkout) and make sure that you're on master
- `pip install -r path/to/django-cfgov-common`
- `pip install -r path/to/agreement_database`
- observe that http://localhost:8000/credit-cards/knowbeforeyouowe works

## Review

- @kurtw @kave @richaagarwal 

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)

