### PR TITLE
Added no-js and js classes to the on-demand header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 ### Added
 
 - Added unit test specs for all files to test (excluding config, polyfills and jQuery plugins).
+- Added no-js and js classes to the on-demand header.
 
 ### Changed
 

--- a/cfgov/jinja2/v1/_includes/on-demand/header.html
+++ b/cfgov/jinja2/v1/_includes/on-demand/header.html
@@ -13,6 +13,14 @@
    remove this and empty after-header div #}
 <a href="#after-nav" id="skip-nav">Skip to main content</a>
 
+<div class="header-dom no-js">
 {% import 'organisms/header.html' as header with context %}
 {{ header.render( show_banner=false ) }}
+</div>
 <div id="after-nav"></div>
+
+<script>
+  // Limiting .no-js and .js to the header to avoid collisions elsewhere
+  var headerDom = document.querySelector( '.header-dom' );
+  headerDom.className = headerDom.className.replace('no-js','js');
+</script>


### PR DESCRIPTION
Some of the django projects don't have their own no-js and js solution causing issues with the classes and scripts in the header. To fix this issue while avoiding creating new issues elsewhere, I’ve scopped the classes to just the on-demand header.

## Additions

- Added no-js class wrapper to the on-demand header.
- Added script to swap the no-js class to js on load.

## Testing

1. Clone django-cfgov-common from GHE as a sibling to cfgov-refresh
2. Clone django-college-cost-comparison from GHE as a sibling to cfgov-refresh
3. In the cfgov-refresh repo root run `pip install -e ../django-cfgov-common && pip install -e ../django-college-cost-comparison`
4. Restart the cfgov-refresh server.
5. Navigate to http://localhost:8000/paying-for-college/.
6. Click where the search button should be (it's there, but the text is white on white, so it's not visible. PR to fix forthcoming to cfpb_nemo).
7. Get excited about moving all of this into Wagtail and cfgov-refresh this summer.

## Review

- @KimberlyMunoz 
- @anselmbradford 
- @sebworks 

## Screenshots

![screen shot 2016-04-19 at 1 36 45 pm](https://cloud.githubusercontent.com/assets/1280430/14651033/c746107a-0633-11e6-8ac9-44a43c007704.png)


## Notes

- The text color of the initial state is white on a white background. The fix will happen in cfpb_nemo theme.

## Todos

- Move all of this to Wagtail and forget we ever needed these workarounds.

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)