### PR TITLE
Fixed an issue where the multiselect couldn't be closed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,16 +17,18 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 
 ### Added
 
-- Added unit test specs for all files to test (excluding config, polyfills and jQuery plugins)
+- Added unit test specs for all files to test (excluding config, polyfills and jQuery plugins).
 
 ### Changed
 
 
 ### Removed
 
-- Removed resolved TODOs and old macros replaced by atomic components
+- Removed resolved TODOs and old macros replaced by atomic components.
 
 ### Fixed
+
+- Fixed an issue where the multiselect couldn't be closed.
 
 
 

--- a/cfgov/unprocessed/js/molecules/Multiselect.js
+++ b/cfgov/unprocessed/js/molecules/Multiselect.js
@@ -435,7 +435,7 @@ function Multiselect( element ) { // eslint-disable-line max-statements, inline-
       }
     } );
 
-    bindEvent( _container, {
+    bindEvent( _fieldset, {
       mousedown: function() {
         _isBlurSkipped = true;
       }


### PR DESCRIPTION
When clicking outside the multiselect, it should close but wasn't. A click event necessary to allow scrollbar clicking on IE was the cause, limiting it to the fieldset allows IE users to click the scrollbar while also allowing the multiselect to close when clicking outside of it.

## Changes

- Limited the click event to the fieldset to allow users to click off of the multiselect.

## Testing

- `gulp build` and navigate to `/blog/` both in Chrome and IE 10 (SauceLabs is easiest).

## Review

- @KimberlyMunoz 
- @anselmbradford 
- @sebworks 

## Todo

- Write browser tests to ensure click events are properly scoped. 

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)