### PR TITLE
Content Edits and spacing from EA

### DIFF
--- a/cfgov/jinja2/v1/about-us/careers/students-and-graduates/index.html
+++ b/cfgov/jinja2/v1/about-us/careers/students-and-graduates/index.html
@@ -43,7 +43,7 @@
                  src="/static/img/gavel-round-300x300.png">
         </div>
         <div class="media_body">
-            <h2>Brandeis Honor Attorney Program</h2>
+            <h2>Brandeis Honors Attorney Program</h2>
             <h3 class="h5">Look for applications here starting Summer 2016</h3>
             <p>
                 A two-year fellowship that provides law students

--- a/cfgov/jinja2/v1/about-us/index.html
+++ b/cfgov/jinja2/v1/about-us/index.html
@@ -56,7 +56,7 @@
                         <h3 class="bureau-bio_name">Richard Cordray</h3>
                         <a class="jump-link jump-link__underline"
                            href="/about-us/the-bureau/about-director/">
-                            Cordray’s bio
+                            Biography
                         </a>
                     </div>
                 </div>
@@ -74,7 +74,7 @@
                         <h3 class="bureau-bio_name">David Silberman</h3>
                         <a class="jump-link jump-link__underline"
                            href="/about-us/the-bureau/about-deputy-director/">
-                            Silberman’s bio
+                            Biography
                         </a>
                     </div>
                 </div>
@@ -153,7 +153,7 @@
                             block__padded-top">
                 <h2>Careers</h2>
                 <p>
-                    We are always looking for talented individuals
+                    We are always looking to hire talented individuals
                     who want to do meaningful work for consumers.
                     And we strive to create a workplace
                     that supports and develops them.

--- a/cfgov/jinja2/v1/about-us/the-bureau/leadership-calendar/index.html
+++ b/cfgov/jinja2/v1/about-us/the-bureau/leadership-calendar/index.html
@@ -27,7 +27,7 @@
     <div class="block
                 block__flush-top"
          data-qa-hook="leadership-calendar-intro">
-        <h1>Leadership Calendar</h1>
+        <h1>Leadership calendar</h1>
         <p class="lead-paragraph"
            data-qa-hook="leadership-calendar-summary">
             At the Consumer Financial Protection Bureau, we are committed to letting you

--- a/cfgov/jinja2/v1/newsroom/press-resources/index.html
+++ b/cfgov/jinja2/v1/newsroom/press-resources/index.html
@@ -29,7 +29,7 @@
         </p>
 
         <p>
-            To report an issue you’re having with a financial company, please call 
+            To report an issue you’re having with a financial company, please call
             <a href="tel:8554112372">(855) 411-CFPB (2372)</a>.
             News media should use the information below to reach our Office of Communications.
         </p>
@@ -52,7 +52,7 @@
         <div class="press-contacts_people content-l content-l__main">
 
             <section class="contact-person content-l_col-1-2">
-                <h3 class="contact-person_name">Jen Howard</h3>
+                <h3 class="h4">Jen Howard</h3>
                 <div class="contact-person_title">Communications Director</div>
                 <ul class="contact-person_methods list list__unstyled">
                     <li class="list_item">
@@ -67,7 +67,7 @@
             </section>
 
             <section class="contact-person content-l_col-1-2">
-                <h3 class="contact-person_name">Walter Suskind</h3>
+                <h3 class="h4">Walter Suskind</h3>
                 <div class="contact-person_title">Regional Spokesperson</div>
                 <ul class="contact-person_methods list list__unstyled">
                     <li class="list_item">
@@ -82,7 +82,7 @@
             </section>
 
             <section class="contact-person content-l_col-1-2">
-                <h3 class="contact-person_name">Laura Van Dyke</h3>
+                <h3 class="h4">Laura Van Dyke</h3>
                 <div class="contact-person_title">Press Assistant</div>
                 <ul class="contact-person_methods list list__unstyled">
                     <li class="list_item">
@@ -97,7 +97,7 @@
             </section>
 
             <section class="contact-person content-l_col-1-2">
-                <h3 class="contact-person_name">Moira Vahey</h3>
+                <h3 class="h4">Moira Vahey</h3>
                 <div class="contact-person_title">Spokesperson</div>
                 <ul class="contact-person_methods list list__unstyled">
                     <li class="list_item">
@@ -112,7 +112,7 @@
             </section>
 
             <section class="contact-person content-l_col-1-2">
-                <h3 class="contact-person_name">Sam Gilford</h3>
+                <h3 class="h4">Sam Gilford</h3>
                 <div class="contact-person_title">Spokesperson</div>
                 <ul class="contact-person_methods list list__unstyled">
                     <li class="list_item">
@@ -127,7 +127,7 @@
             </section>
 
             <section class="contact-person content-l_col-1-2">
-                <h3 class="contact-person_name">David Mayorga</h3>
+                <h3 class="h4">David Mayorga</h3>
                 <div class="contact-person_title">Spokesperson</div>
                 <ul class="contact-person_methods list list__unstyled">
                     <li class="list_item">

--- a/cfgov/unprocessed/css/pages/press-resources.less
+++ b/cfgov/unprocessed/css/pages/press-resources.less
@@ -20,13 +20,8 @@
 
 .contact-person {
     margin-bottom: unit(30px / @base-font-size-px, em);
-    .respond-to-min(@bp-sm-min, {
-        margin-bottom: unit(10px / @base-font-size-px, em);
-    });
 }
-.contact-person_name {
-    .h4();
-}
+
 .contact-person__director {
     margin-top: unit(30px / @base-font-size-px, em);
 


### PR DESCRIPTION
A few minor changes to wording requested by external affairs before the
www switchover.

A few changes on press-resources to bring them more in line with current
standards.

## Testing

- `gulp build` and visit affected pages

## Review

- @anselmbradford 
- @sebworks 
- @jimmynotjim 

## Screenshots

![image](https://cloud.githubusercontent.com/assets/1860176/14656852/eb5f0984-0657-11e6-967d-310141f40933.png)


## Notes

- I talked with @ajbush and @duelj about the spacing between rows. I think EA thought there was no spacing and asked us to change it from 10px to 15px. I double-checked with Design and they said 30px was the correct spacing.  I also removed some unnecessary hardcoding of the titles while I was in there. @schaferjh 
