### PR TITLE
Fix for secondary nav showing at 600-900px when the nav doesnt contai…

### DIFF
--- a/cfgov/jinja2/v1/_includes/organisms/secondary-navigation.html
+++ b/cfgov/jinja2/v1/_includes/organisms/secondary-navigation.html
@@ -38,10 +38,8 @@
 {% endmacro %}
 
 {% set nav_items, has_children = get_secondary_nav_items(page, request.site.hostname) %}
-
-{# TODO: This should be hidden on tablets as well. #}
 <nav class="o-secondary-navigation
-            {{ 'u-hide-on-mobile' if not has_children else '' }}"
+            {{ '' if has_children else 'o-secondary-navigation__no-children' }}"
      aria-label="Section navigation">
     {% set sec_nav_settings = {
         'label': 'In this section',

--- a/cfgov/unprocessed/css/organisms/secondary-navigation.less
+++ b/cfgov/unprocessed/css/organisms/secondary-navigation.less
@@ -90,6 +90,12 @@
 .o-secondary-navigation {
     .webfont-regular();
 
+    &__no-children {
+      .respond-to-max( @bp-sm-max, {
+          display: none;
+      } );
+    }
+
     .m-expandable_target {
         .webfont-demi();
 


### PR DESCRIPTION
Fixes issue of secondary nav disappearing and reappearing when nav doesn't contain children at 600 - 900px.


## Changes

- Modified jinja and less files to remove utility class and use regular css class to hide secondary nav.

## Testing

- Visit `http://beta.consumerfinance.gov/policy-compliance/guidance/supervisory-highlights/` and resize down to mobile. The secondary nav should disappear below 900px.

## Review

- @jimmynotjim 
- @KimberlyMunoz 
- @anselmbradford 

## Notes

- It might make sense to have utility classes to `hide/show` at all the various breakpoints.

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)

…n children