### PR TITLE
enable the leadership calendar API

### DIFF
--- a/cfgov/cfgov/urls.py
+++ b/cfgov/cfgov/urls.py
@@ -247,6 +247,12 @@ if 'cfpb_common' in settings.INSTALLED_APPS:
                ]
     urlpatterns += patterns
 
+if 'cal' in settings.INSTALLED_APPS:
+    from cal.views import CalendarJSONList
+    patterns= [url(r'^leadership-calendar/cfpb-leadership.json$', CalendarJSONList.as_view()),
+               ]
+    urlpatterns += patterns
+
 if 'selfregistration' in settings.INSTALLED_APPS:
     from selfregistration.views import CompanySignup
     pattern = url(r'^company-signup/', CompanySignup.as_view())


### PR DESCRIPTION
So that 'sheer_index' keeps working when cfgov-refresh is powering the whole site

## Additions

- if the 'cal' app  is installed, a URL route is created for /leadership-calendar/cfpb-leadership.json


## Testing

- Trust me? No. OK. download this and hang on to your hat: [calendar.sql.zip](https://github.com/cfpb/cfgov-refresh/files/228024/calendar.sql.zip)
- `pip install djangorestframework==2.4.8`
- `pip install vobject==0.9.1`
- clone private repo CFPB/leadership-calendar
- clone private repo CFPB/django-cfgov-common
- `pip install -e ../leadership-calendar && pip install -e ../django-cfgov-common`
- unzip calendar.sql.zip
- `cfgov/manage.py dbshell < ~/Documents/calendar.sql`
- `cfgov/manage.py runserver`
- observe the beautiful json at http://localhost:8000/leadership-calendar/cfpb-leadership.json



## Review

- @richaagarwal @kave @kurtw 


* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
