### PR TITLE
Fix Blog posts that have no category

### DIFF
--- a/cfgov/v1/util/ref.py
+++ b/cfgov/v1/util/ref.py
@@ -178,6 +178,8 @@ def is_blog(page):
         for choice in choices_for_page_type('blog'):
             if category.name == choice[0]:
                 return True
+    if 'Blog' in page.specific_class.__name__:
+        return True
 
 def is_report(page):
     for category in page.categories.all():


### PR DESCRIPTION
Short description explaining the high-level reason for the pull request

## Additions

- Logic to `is_blog` that checks to see if the page is of blog type.

## Testing

- Go to activity log and find Mortgage Moves: What kind of Mortgage Will You Get?
- http://localhost:8000/about-us/blog/mortgage-moves-what-kind-of-mortgage-will-you-get/ should have no category above the title

## Review

- @kave 

