### PR TITLE
Fix for hiding sibliing nav items on the mobile/tablet

### DIFF
--- a/cfgov/jinja2/v1/_includes/organisms/secondary-navigation.html
+++ b/cfgov/jinja2/v1/_includes/organisms/secondary-navigation.html
@@ -21,7 +21,7 @@
     <ul class="o-secondary-navigation_list
                o-secondary-navigation_list__parents">
         {%- for item in items %}
-            <li>
+            <li data-nav-is-active="{{ request.url.startswith(item.url) }}">
                 {{ nav_link(item.title, item.url, true, item.url == request.url) }}
                 {%- for child in item.children -%}
                     <ul class="o-secondary-navigation_list

--- a/cfgov/unprocessed/css/organisms/secondary-navigation.less
+++ b/cfgov/unprocessed/css/organisms/secondary-navigation.less
@@ -123,6 +123,10 @@
                 margin-right: unit( (@grid_gutter-width / 2) / @base-font-size-px, em);
 
                 border-top: 1px solid @gray-40;
+
+                li[data-nav-is-active="False"]{
+                    display: none;
+                }
             });
         }
 


### PR DESCRIPTION
Fix for hiding sibling nav items on the mobile/tablet

## Changes

- Modified Jinja and Less to hide sibling nav items on mobile/tablet

## Additions

- Added context function to determine if current or children nav items are active. 


## Testing

- Run `gulp styles`. Visit `http://localhost:8000/policy-compliance/guidance/supervision-examinations/` and resize down to mobile. Sibling nav items should disappear below 900px.

## Review

- @KimberlyMunoz 
- @anselmbradford 
- @jimmynotjim 
- @kave 
- @kurtw 


## Screenshots

- 
<img width="409" alt="screen shot 2016-04-20 at 11 36 42 am" src="https://cloud.githubusercontent.com/assets/1696212/14680717/3842eaec-06ec-11e6-954b-c3117cc08b1d.png">



* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
