### PR TITLE
Databases routes for cfgov-refresh vs legacy apps

### DIFF
--- a/.env_SAMPLE
+++ b/.env_SAMPLE
@@ -37,6 +37,13 @@ export MYSQL_USER=root
 #export MYSQL_HOST=<hostname>
 #export MYSQL_PORT=<portnumber>
 
+#export DATABASE_ROUTING=<boolean_database_routing>
+#export LEGACY_MYSQL_NAME=<legacy_db_name>
+#export LEGACY_MYSQL_USER=<legacy_db_user>
+#export LEGACY_MYSQL_PW=<legacy_db_password>
+#export LEGACY_MYSQL_HOST=<legacy_db_hostname>
+#export LEGACY_MYSQL_PORT=<legacy_db_portnumber>
+
 #############################################
 # AWS S3
 #############################################

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Added unit test specs for all files to test (excluding config, polyfills and jQuery plugins).
 - Added no-js and js classes to the on-demand header.
 - Added link to Livestream FAQ.
+- Flag for database routing for content.consumerfinance.gov
 
 ### Changed
 

--- a/cfgov/cfgov/settings/production.py
+++ b/cfgov/cfgov/settings/production.py
@@ -28,3 +28,25 @@ LOGGING = {
 
 EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
 EMAIL_HOST = os.getenv('EMAIL_HOST')
+
+if os.environ.get('DATABASE_ROUTING', False):
+    DATABASE_ROUTERS = ['v1.db_router.CFGOVRouter', 'v1.db_router.LegacyRouter']
+
+    DATABASES = {
+        'default': {
+            'ENGINE': MYSQL_ENGINE,
+            'NAME': os.environ.get('MYSQL_NAME', ''),
+            'USER': os.environ.get('MYSQL_USER', ''),
+            'PASSWORD': os.environ.get('MYSQL_PW', ''),
+            'HOST': os.environ.get('MYSQL_HOST', ''),
+            'PORT': os.environ.get('MYSQL_PORT', ''),
+        },
+        'legacy': {
+            'ENGINE': MYSQL_ENGINE,
+            'NAME': os.environ.get('LEGACY_MYSQL_NAME', ''),
+            'USER': os.environ.get('LEGACY_MYSQL_USER', ''),
+            'PASSWORD': os.environ.get('LEGACY_MYSQL_PW', ''),
+            'HOST': os.environ.get('LEGACY_MYSQL_HOST', ''),
+            'PORT': os.environ.get('LEGACY_MYSQL_PORT', ''),
+        },
+    }

--- a/cfgov/v1/db_router.py
+++ b/cfgov/v1/db_router.py
@@ -1,0 +1,79 @@
+cfgov_apps = [
+    'auth',
+    'sessions',
+    'admin',
+    'contenttypes',
+    'v1',
+    'flags',
+    'taggit',
+]
+
+
+class CFGOVRouter(object):
+    """
+    A router to control all database operations on models in
+    wagtail and auth application.
+    """
+
+    def db_for_read(self, model, **hints):
+        """
+        Attempts to read cfgov-refresh models go to default.
+        """
+        if model._meta.app_label in cfgov_apps or model._meta.app_label.find('wagtail') != -1:
+            return 'default'
+        return None
+
+    def db_for_write(self, model, **hints):
+        """
+        Attempts to write cfgov-refresh models go to default.
+        """
+        if model._meta.app_label in cfgov_apps or model._meta.app_label.find('wagtail') != -1:
+            return 'default'
+        return None
+
+    def allow_relation(self, obj1, obj2, **hints):
+        """
+        Allow relations if a model in the cfgov-refresh app is involved.
+        """
+        if obj1._meta.app_label in cfgov_apps or obj2._meta.app_label in cfgov_apps or \
+                        obj1._meta.app_label.find('wagtail') != -1 or obj2._meta.app_label.find('wagtail') != -1:
+            return True
+        return None
+
+    def allow_migrate(self, db, app_label, model_name=None, **hints):
+        """
+        Make sure the cfgov-refresh app only appears in the 'default'
+        database.
+        """
+        if app_label in cfgov_apps or app_label.find('wagtail') != -1:
+            return db == 'default'
+        return None
+
+
+class LegacyRouter(object):
+    def db_for_read(self, model, **hints):
+        """
+        All non cfgov-refresh Reads go to legacy Db.
+        """
+        return 'legacy'
+
+    def db_for_write(self, model, **hints):
+        """
+        All non cfgov-refresh Writes always go to legacy Db.
+        """
+        return 'legacy'
+
+    def allow_relation(self, obj1, obj2, **hints):
+        """
+        Relations between objects are allowed if both objects are
+        in the legacy db.
+        """
+        if obj1._state.db in 'legacy' and obj2._state.db in 'legacy':
+            return True
+        return None
+
+    def allow_migrate(self, db, app_label, model_name=None, **hints):
+        """
+        All non cfgov-refresh models end up in this pool.
+        """
+        return db == 'legacy'


### PR DESCRIPTION

@kurtw @richaagarwal @rosskarchner 

### Testing
- you will need some legacy apps installed. You can use `CFPB/agreement_database` from the internal github
 - then `pip install -e ../agreement_database` from inside the cfgov-refresh repo
- Copy `production.py` database & routing settings into your `local.py`
- Create an extra database named whatever i used `legacy`, and drop and recreate `v1`
- run:
 - `./cfgov/manage.py migrate`
 - `./cfgov/manage.py migrate --database=legacy` (its always legacy regardless of your db name)
- Observe only cfgov-refresh tables are in `v1` and legacy apps are in your new db `legacy`
![screen shot 2016-04-20 at 11 57 26 am](https://cloud.githubusercontent.com/assets/254877/14683245/b5de4c3e-06f7-11e6-8041-594039a2b84e.png)
