### PR TITLE
Adds overflow:hidden to body at mobile + iPad fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 
 ### Changed
 
+- Hid overflow-x at mobile sizes on document body.
+- Added `halt()` and `clearTransitions()` methods to transition behaviors.
+
 
 ### Removed
 

--- a/cfgov/unprocessed/css/enhancements/base.less
+++ b/cfgov/unprocessed/css/enhancements/base.less
@@ -7,7 +7,8 @@
   name: Body Font
   family: cf-core
   notes:
-    - "Set the body to Avenir Regular"
+    - "Set the body to Avenir Regular."
+    - "Hides overflow on mobile sizes."
   patterns:
     - name: Body
       codenotes:
@@ -18,7 +19,11 @@
 */
 
 body {
-  .webfont-regular();
+    .webfont-regular();
+
+    .respond-to-max( @bp-sm-max, {
+        overflow-x: hidden;
+    } );
 }
 
 /* topdoc

--- a/cfgov/unprocessed/js/modules/FlyoutMenu.js
+++ b/cfgov/unprocessed/js/modules/FlyoutMenu.js
@@ -53,11 +53,12 @@ function FlyoutMenu( element ) { // eslint-disable-line max-statements, no-inlin
   var _isExpanded = false;
   var _isAnimating = false;
 
-  var _expandTransition;
-  var _collapseTransition;
-  var _expandTransitionMethod;
+  var _expandTransition = null;
+  var _expandTransitionMethod = null;
   var _expandTransitionMethodArgs = [];
-  var _collapseTransitionMethod;
+
+  var _collapseTransition = null;
+  var _collapseTransitionMethod = null;
   var _collapseTransitionMethodArgs = [];
 
   // Binded events.
@@ -303,6 +304,24 @@ function FlyoutMenu( element ) { // eslint-disable-line max-statements, no-inlin
   }
 
   /**
+   * Clear the transitions attached to this FlyoutMenu instance.
+   */
+  function clearTransitions() {
+    var transition = getTransition( FlyoutMenu.EXPAND_TYPE );
+    if ( transition ) { transition.remove(); }
+    transition = getTransition( FlyoutMenu.COLLAPSE_TYPE );
+    if ( transition ) { transition.remove(); }
+
+    _expandTransition = null;
+    _expandTransitionMethod = null;
+    _expandTransitionMethodArgs = [];
+
+    _collapseTransition = null;
+    _collapseTransitionMethod = null;
+    _collapseTransitionMethodArgs = [];
+  }
+
+  /**
    * @param {string} type
    *   (Optional) The type of transition to return.
    *   Accepts 'expand' or 'collapse'.
@@ -310,7 +329,7 @@ function FlyoutMenu( element ) { // eslint-disable-line max-statements, no-inlin
    *   as type-safe constants passed into this method.
    *   If neither or something else is supplied, expand type is returned.
    * @returns {MoveTransition|AlphaTransition}
-   *   A transition instance set on this instance, or undefined if none is set.
+   *   A transition instance set on this instance, or null if none is set.
    */
   function getTransition( type ) {
     if ( type === FlyoutMenu.COLLAPSE_TYPE ) {
@@ -404,6 +423,7 @@ function FlyoutMenu( element ) { // eslint-disable-line max-statements, no-inlin
   this.collapse = collapse;
   this.setExpandTransition = setExpandTransition;
   this.setCollapseTransition = setCollapseTransition;
+  this.clearTransitions = clearTransitions;
   this.getData = getData;
   this.getTransition = getTransition;
   this.getDom = getDom;

--- a/cfgov/unprocessed/js/modules/transition/AlphaTransition.js
+++ b/cfgov/unprocessed/js/modules/transition/AlphaTransition.js
@@ -72,6 +72,7 @@ function AlphaTransition( element ) {
 
   this.animateOff = _baseTransition.animateOff;
   this.animateOn = _baseTransition.animateOn;
+  this.halt = _baseTransition.halt;
   this.isAnimated = _baseTransition.isAnimated;
   this.remove = _baseTransition.remove;
   this.setElement = _baseTransition.setElement;

--- a/cfgov/unprocessed/js/modules/transition/BaseTransition.js
+++ b/cfgov/unprocessed/js/modules/transition/BaseTransition.js
@@ -26,6 +26,7 @@ function BaseTransition( element, classes ) { // eslint-disable-line max-stateme
   var _transitionEndEvent;
   var _transitionCompleteBinded;
   var _addEventListenerBinded;
+  var _isAnimating = false;
   var _isFlushed = false;
 
   /**
@@ -87,10 +88,29 @@ function BaseTransition( element, classes ) { // eslint-disable-line max-stateme
   }
 
   /**
+   * Halt an in-progress animation and call the complete event immediately.
+   */
+  function halt() {
+    if ( !_isAnimating ) { return; }
+    _dom.style.webkitTransitionDuration = '0';
+    _dom.style.mozTransitionDuration = '0';
+    _dom.style.oTransitionDuration = '0';
+    _dom.style.transitionDuration = '0';
+    _dom.removeEventListener( _transitionEndEvent,
+                              _transitionCompleteBinded );
+    _transitionCompleteBinded();
+    _dom.style.webkitTransitionDuration = '';
+    _dom.style.mozTransitionDuration = '';
+    _dom.style.oTransitionDuration = '';
+    _dom.style.transitionDuration = '';
+  }
+
+  /**
    * Add an event listener to the transition, or call the transition
    * complete handler immediately if transition not supported.
    */
   function _addEventListener() {
+    _isAnimating = true;
     // If transition is not supported, call handler directly (IE9/OperaMini).
     if ( _transitionEndEvent ) {
       _dom.addEventListener( _transitionEndEvent,
@@ -115,6 +135,7 @@ function BaseTransition( element, classes ) { // eslint-disable-line max-stateme
   function _transitionComplete() {
     _removeEventListener();
     this.dispatchEvent( BaseTransition.END_EVENT, { target: this } );
+    _isAnimating = false;
   }
 
   /**
@@ -138,6 +159,7 @@ function BaseTransition( element, classes ) { // eslint-disable-line max-stateme
    */
   function remove() {
     if ( _dom ) {
+      halt();
       _dom.classList.remove( _classes.BASE_CLASS );
       _flush();
       return true;
@@ -211,6 +233,7 @@ function BaseTransition( element, classes ) { // eslint-disable-line max-stateme
   this.animateOff = animateOff;
   this.animateOn = animateOn;
   this.applyClass = applyClass;
+  this.halt = halt;
   this.init = init;
   this.isAnimated = isAnimated;
   this.remove = remove;

--- a/cfgov/unprocessed/js/modules/transition/MoveTransition.js
+++ b/cfgov/unprocessed/js/modules/transition/MoveTransition.js
@@ -109,6 +109,7 @@ function MoveTransition( element ) { // eslint-disable-line max-statements, no-i
 
   this.animateOff = _baseTransition.animateOff;
   this.animateOn = _baseTransition.animateOn;
+  this.halt = _baseTransition.halt;
   this.isAnimated = _baseTransition.isAnimated;
   this.setElement = _baseTransition.setElement;
   this.remove = _baseTransition.remove;

--- a/cfgov/unprocessed/js/organisms/MegaMenu.js
+++ b/cfgov/unprocessed/js/organisms/MegaMenu.js
@@ -67,12 +67,12 @@ function MegaMenu( element ) {
     _desktopNav = new MegaMenuDesktop( _menus ).init();
     _mobileNav = new MegaMenuMobile( _menus ).init();
     _mobileNav.addEventListener( 'rootExpandBegin',
-                                 fnBind (_handleRootExpandBegin, this ) );
+                                 fnBind( _handleRootExpandBegin, this ) );
     _mobileNav.addEventListener( 'rootCollapseEnd',
                                  fnBind( _handleRootCollapseEnd, this ) );
 
     window.addEventListener( 'resize', _resizeHandler );
-    // Funnel window resize handler into orientation change on devices that support it.
+    // Pipe window resize handler into orientation change on supported devices.
     if ( 'onorientationchange' in window ) {
       window.addEventListener( 'orientationchange', _resizeHandler );
     }

--- a/cfgov/unprocessed/js/organisms/MegaMenuDesktop.js
+++ b/cfgov/unprocessed/js/organisms/MegaMenuDesktop.js
@@ -165,6 +165,12 @@ function MegaMenuDesktop( menus ) {
   function suspend() {
     if ( !_suspended ) {
       treeTraversal.bfs( _menus.getRoot(), _handleSuspendTraversal );
+
+      // Ensure body events were removed.
+      _bodyDom.removeEventListener( 'mousemove', _handleMove );
+      _bodyDom.removeEventListener( 'mouseleave', _handleMove );
+      // Clear active menu.
+      _activeMenu = null;
       _suspended = true;
     }
 
@@ -185,7 +191,7 @@ function MegaMenuDesktop( menus ) {
       var wrapperDom = contentDom.querySelector( wrapperSel );
       var transition = menu.getTransition();
 
-      // This checks if the transition has been removed by MegaMenuMobile.
+      // This ensures the transition has been removed by MegaMenuMobile.
       transition = _setTransitionElement( wrapperDom, transition );
       transition.moveUp();
 
@@ -224,8 +230,7 @@ function MegaMenuDesktop( menus ) {
     var menu = node.data;
 
     if ( nLevel === 1 ) {
-      var transition = menu.getTransition();
-      transition.remove();
+      menu.clearTransitions();
       menu.getDom().content.classList.remove( 'u-invisible' );
 
       if ( menu.isExpanded() ) {

--- a/test/unit_tests/modules/FlyoutMenu-spec.js
+++ b/test/unit_tests/modules/FlyoutMenu-spec.js
@@ -75,7 +75,7 @@ describe( 'FlyoutMenu', function() {
       // TODO: check aria-expanded state as well.
       expect( flyoutMenu.isAnimating() ).to.be.false;
       expect( flyoutMenu.isExpanded() ).to.be.false;
-      expect( flyoutMenu.getTransition() ).to.be.undefined;
+      expect( flyoutMenu.getTransition() ).to.be.null;
       expect( flyoutMenu.getData() ).to.be.undefined;
     } );
 
@@ -261,13 +261,29 @@ describe( 'FlyoutMenu', function() {
   describe( '.getTransition()', function() {
     it( 'should return a transition instance', function() {
       flyoutMenu.init();
-      expect( flyoutMenu.getTransition() ).to.be.undefined;
+      expect( flyoutMenu.getTransition() ).to.be.null;
       var transition = new MoveTransition( contentDom ).init();
       flyoutMenu.setExpandTransition( transition, transition.moveLeft );
       flyoutMenu.setCollapseTransition( transition, transition.moveToOrigin );
       expect( flyoutMenu.getTransition() ).to.equal( transition );
       expect( flyoutMenu.getTransition( FlyoutMenu.COLLAPSE_TYPE ) )
         .to.equal( transition );
+    } );
+  } );
+
+  describe( '.clearTransitions()', function() {
+    it( 'should remove all transitions', function() {
+      flyoutMenu.init();
+      var transition = new MoveTransition( contentDom ).init();
+      flyoutMenu.setExpandTransition( transition, transition.moveLeft );
+      flyoutMenu.setCollapseTransition( transition, transition.moveToOrigin );
+      var hasClass = contentDom.classList.contains( 'u-move-transition' );
+      expect( hasClass ).to.be.true;
+      flyoutMenu.clearTransitions();
+      expect( flyoutMenu.getTransition() ).to.be.null;
+      hasClass = contentDom.classList.contains( 'u-move-transition' );
+      console.log( contentDom.classList );
+      expect( hasClass ).to.be.false;
     } );
   } );
 

--- a/test/unit_tests/modules/transition/BaseTransition-spec.js
+++ b/test/unit_tests/modules/transition/BaseTransition-spec.js
@@ -61,6 +61,14 @@ describe( 'BaseTransition', function() {
     } );
   } );
 
+  describe( '.halt()', function() {
+    xit( 'should immediately fire transition end event', function() {
+      // TODO: To test halt() the transition needs to be started and
+      //       then halt() needs to be called before the transition
+      //       duration has completed.
+    } );
+  } );
+
   describe( '.remove()', function() {
     it( 'should remove transition classes from element', function() {
       transition.init();


### PR DESCRIPTION
## Changes

- Hides overflow at mobile sizes.
- Adds halt and clearTransitions methods for halting in-progress transitions and clearing transitions, respectively.
- Added brackets to single-line if statements, because CodeClimate prefers that.
- Cleanup on mobile mega menu suspend method.

## Testing

- Open iPad Retina simulator portrait orientation.
- Navigate to `flapjack.demo.cfpb.gov`
- Open menu.
- Rotate to landscape.
- Click any menu link.
- Rotate to portrait.
- It should look like:

![screen shot 2016-04-20 at 1 28 30 pm](https://cloud.githubusercontent.com/assets/704760/14684162/87b464a6-06fc-11e6-9895-390fb25be140.png)

Now, `gulp build` and navigate to `localhost:8000` and repeat the steps above. Off-screen content should not be visible.

![screen shot 2016-04-20 at 1 34 41 pm](https://cloud.githubusercontent.com/assets/704760/14684183/a84896f6-06fc-11e6-9eea-d3a87f6ca1a4.png)

## Review

- @sebworks 
- @jimmynotjim 
- @KimberlyMunoz 

## Todo

- There's a weird double-closure of the menu on iPad at mobile sizes, but is *kinda* looks like an intentional effect, so I think it'll be okay for launch. I think it's due to the deferred collapse function that was added for multiple clicks on the global search flyout menu. 