### PR TITLE
Created initial full-width-media molecule

### DIFF
--- a/cfgov/jinja2/v1/_includes/organisms/full-width-text.html
+++ b/cfgov/jinja2/v1/_includes/organisms/full-width-text.html
@@ -22,6 +22,10 @@
             <div class="m-full-width-text">
                 {{ render_stream_child(block) | safe}}
             </div>
+        {% elif 'media' in block.block_type %}
+            <div class="m-full-width-media">
+                {# render media here #}
+            </div>
         {% else %}
             <div class="m-inset">
                 {{ block | safe }}

--- a/cfgov/unprocessed/css/main.less
+++ b/cfgov/unprocessed/css/main.less
@@ -104,6 +104,7 @@
 @import (less) "molecules/expandable.less";
 @import (less) "molecules/featured-menu-content.less";
 @import (less) "molecules/form-field-with-button.less";
+@import (less) "molecules/full-width-media.less";
 @import (less) "molecules/full-width-text.less";
 @import (less) "molecules/global-banner.less";
 @import (less) "molecules/global-eyebrow.less";

--- a/cfgov/unprocessed/css/molecules/full-width-media.less
+++ b/cfgov/unprocessed/css/molecules/full-width-media.less
@@ -1,0 +1,37 @@
+/* topdoc
+  name: Full width media
+  family: cfgov-molecules
+  patterns:
+    - name: Default example
+      markup: |
+        <div class="o-full-width-text-group">
+            <div class="m-full-width-media">
+                <img class="m-full-width-media_image" />
+            </div>
+        </div>
+      codenotes:
+        - |
+          Structural cheat sheet:
+          -----------------------
+          .o-full-width-text
+            .m-full-width-media
+              .m-full-width-media_image
+  tags:
+    - cfgov-molecules
+  notes:
+    - These are held in a full-width-text-group container to be held with
+      various insets and tables as needed.
+*/
+
+.m-full-width-media {
+
+    &_image {
+        display: block;
+        margin-bottom: unit( @grid_gutter-width / @base-font-size-px, em );
+    }
+}
+
+/* topdoc
+    name: EOF
+    eof: true
+*/


### PR DESCRIPTION
Blog posts need to have the ability to include full width images, figures, and block quotes. This is only a start, but it accounts for the full width images content editors need at this momemnt. Figures and block quotes should be addressed post-launch.

## Additions

- Added simple default styles for images within a full-width-media molecule 

## Changes

- Added initial media markup to the full-width-text-group

## Testing

- Add this between L:29 and L:30 in  `organisms/full-width-text.html`:
  ```
      <div class="m-full-width-media">
            <img class="m-full-width-media_image"
                 alt="Mortgage Moves: What kind of mortgage will you get? graphic"
                 src="http://files.consumerfinance.gov/f/201604_cfpb_what-kind-of-mortgage-will-you-get-blog.png">
      </div>
```

  and open a doc detail page like http://localhost:8000/data-research/research-reports/2015-office-minority-and-women-inclusion-annual-report-congress/

## Review

- @kurtw 
- @KimberlyMunoz 
- @sebworks 
- @anselmbradford 

## Screenshots

![screen shot 2016-04-20 at 3 01 53 pm](https://cloud.githubusercontent.com/assets/1280430/14688560/d4a19dcc-0708-11e6-9ac6-35e1f5ff0961.png)

## Notes

- This is a terrible example, but until wagtail blog posts are completed, it's the best I was able to cobble together.

## Todos

- Build the backend doc detail blog posts.

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)