### PR TITLE
Fixed the mobile menu for on-demand django pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 
 - Fixed an issue where the multiselect couldn't be closed.
 - Fixed the browser tests for the recent change to wagtail pages.
+- Fixed the mobile menu for on-demand django pages.
 
 
 ## 3.0.0-3.3.2 - 2016-04-11

--- a/cfgov/jinja2/v1/_includes/on-demand/header.html
+++ b/cfgov/jinja2/v1/_includes/on-demand/header.html
@@ -13,14 +13,6 @@
    remove this and empty after-header div #}
 <a href="#after-nav" id="skip-nav">Skip to main content</a>
 
-<div class="header-dom no-js">
 {% import 'organisms/header.html' as header with context %}
 {{ header.render( show_banner=false ) }}
-</div>
 <div id="after-nav"></div>
-
-<script>
-  // Limiting .no-js and .js to the header to avoid collisions elsewhere
-  var headerDom = document.querySelector( '.header-dom' );
-  headerDom.className = headerDom.className.replace('no-js','js');
-</script>

--- a/cfgov/jinja2/v1/_includes/organisms/header.html
+++ b/cfgov/jinja2/v1/_includes/organisms/header.html
@@ -56,7 +56,7 @@
     {% import 'molecules/global-eyebrow.html' as global_eyebrow with context %}
     {{ global_eyebrow.render( true ) }}
 
-    <div class="o-header_content">
+    <div class="o-header_content no-js">
 
         <div class="wrapper">
             {% import 'molecules/global-header-cta.html' as global_header_cta with context %}
@@ -95,6 +95,11 @@
         </div>
 
     </div>
+    <script>
+      /* TODO: scope no-js to individual molecules/organisms. This is a hack to fix no-js on the on-demand header, while also allowing the menu to be scoped to o-header for on-demand pages. */
+      var headerDom = document.querySelector( '.o-header_content' );
+      headerDom.className = headerDom.className.replace('no-js','js');
+    </script>
 </header>
 
 {% endmacro %}

--- a/cfgov/unprocessed/css/on-demand/header.less
+++ b/cfgov/unprocessed/css/on-demand/header.less
@@ -62,7 +62,11 @@
    ========================================================================== */
 
 @import (less) "../organisms/header.less";
-@import (less) "../organisms/mega-menu.less";
+
+.o-header {
+  // menu needs to be scoped or the cascade pushes the other scoped styles up
+  @import (less) "../organisms/mega-menu.less";
+}
 
 /* Template pieces
    ========================================================================== */


### PR DESCRIPTION
Due to the `.o-header` scoping, some base styles were overwriting our mega-menu styles. By scoping the mega-menu to the header organism I was able to match the specificity and set the cascade properly.

## Changes

- Wrapped the mega-menu import in the header organism to match the scoping.

## Testing

- `gulp styles:ondemand` and open http://localhost:8000/test-fixture/?atomic=header in a smaller browser window. The left side of the nav should have the proper gutter instead of being pushed up agains the window as we're currently seeing on `/complaint`

## Review

- @anselmbradford 
- @sebworks 

## Screenshots

__Before__

<img width="402" alt="screen shot 2016-04-20 at 7 22 26 pm" src="https://cloud.githubusercontent.com/assets/1280430/14694358/40811e86-072d-11e6-9c3c-018cda6ff39f.png">

__After__

<img width="400" alt="screen shot 2016-04-20 at 7 22 21 pm" src="https://cloud.githubusercontent.com/assets/1280430/14694361/43ea5f60-072d-11e6-96ea-b875f2791077.png">

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)