### PR TITLE
Revert "Remove page from WordPress indexing"

### DIFF
--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -249,6 +249,11 @@ SHEER_PROCESSORS = \
             "processor": "processors.wordpress_orgmember",
             "mappings": MAPPINGS.child("orgmember.json")
         },
+        "pages": {
+            "url": "$WORDPRESS/api/get_posts/?post_type=page",
+            "processor": "processors.wordpress_page",
+            "mappings": MAPPINGS.child("pages.json")
+        },
         "posts": {
             "url": "$WORDPRESS/api/get_posts/",
             "processor": "processors.wordpress_post",

--- a/cfgov/es_mappings/pages.json
+++ b/cfgov/es_mappings/pages.json
@@ -1,0 +1,272 @@
+{
+    "properties": {
+        "status": {
+            "type": "string"
+        },
+        "title_plain": {
+            "type": "string"
+        },
+        "attachments": {
+            "properties": {
+                "parent": {
+                    "type": "long"
+                },
+                "title": {
+                    "type": "string"
+                },
+                "url": {
+                    "type": "string"
+                },
+                "slug": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "long"
+                },
+                "mime_type": {
+                    "type": "string"
+                }
+            }
+        },
+        "parent": {
+            "type": "long"
+        },
+        "author": {
+            "properties": {
+                "first_name": {
+                    "type": "string"
+                },
+                "last_name": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "url": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "long"
+                },
+                "nickname": {
+                    "type": "string"
+                },
+                "slug": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                }
+            }
+        },
+        "url": {
+            "type": "string"
+        },
+        "relative_url": {
+            "type": "string"
+        },
+        "title": {
+            "type": "string"
+        },
+        "excerpt": {
+            "type": "string"
+        },
+        "modified": {
+            "type": "date",
+            "format": "dateOptionalTime"
+        },
+        "order": {
+            "type": "long"
+        },
+        "content": {
+            "type": "string"
+        },
+        "thumbnail": {
+            "properties": {
+                "images": {
+                    "properties": {
+                        "full": {
+                            "properties": {
+                                "url": {
+                                    "type": "string"
+                                },
+                                "width": {
+                                    "type": "long"
+                                },
+                                "height": {
+                                    "type": "long"
+                                }
+                            }
+                        },
+                        "post_thumbnail": {
+                            "properties": {
+                                "url": {
+                                    "type": "string"
+                                },
+                                "width": {
+                                    "type": "long"
+                                },
+                                "height": {
+                                    "type": "long"
+                                }
+                            }
+                        },
+                        "post_image_2x": {
+                            "properties": {
+                                "url": {
+                                    "type": "string"
+                                },
+                                "width": {
+                                    "type": "long"
+                                },
+                                "height": {
+                                    "type": "long"
+                                }
+                            }
+                        },
+                        "post_thumbnail_2x": {
+                            "properties": {
+                                "url": {
+                                    "type": "string"
+                                },
+                                "width": {
+                                    "type": "long"
+                                },
+                                "height": {
+                                    "type": "long"
+                                }
+                            }
+                        },
+                        "large": {
+                            "properties": {
+                                "url": {
+                                    "type": "string"
+                                },
+                                "width": {
+                                    "type": "long"
+                                },
+                                "height": {
+                                    "type": "long"
+                                }
+                            }
+                        },
+                        "post_image": {
+                            "properties": {
+                                "url": {
+                                    "type": "string"
+                                },
+                                "width": {
+                                    "type": "long"
+                                },
+                                "height": {
+                                    "type": "long"
+                                }
+                            }
+                        }
+                    }
+                },
+                "alt_text": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "size": {
+                    "type": "string"
+                }
+            }
+        },
+        "comment_count": {
+            "type": "long"
+        },
+        "dek": {
+            "type": "string"
+        },
+        "id": {
+            "type": "long"
+        },
+        "custom_fields": {
+            "properties": {
+                "og_image": {
+                    "type": "string"
+                },
+                "popular_posts": {
+                    "type": "string"
+                },
+                "utm_content": {
+                    "type": "string"
+                },
+                "cfpb-hud-hca-api-print-title": {
+                    "type": "string"
+                },
+                "og_desc": {
+                    "type": "string"
+                },
+                "custom_title": {
+                    "type": "string"
+                },
+                "related_hero": {
+                    "type": "string"
+                },
+                "og_title": {
+                    "type": "string"
+                },
+                "utm_campaign": {
+                    "type": "string"
+                },
+                "twtr_text": {
+                    "type": "string"
+                },
+                "cfpb-hud-hca-api-print-desc": {
+                    "type": "string"
+                },
+                "cfpb-hud-hca-api-more-info": {
+                    "type": "string"
+                },
+                "twtr_lang": {
+                    "type": "string"
+                },
+                "hero": {
+                    "type": "string"
+                },
+                "twtr_rel": {
+                    "type": "string"
+                },
+                "utm_term": {
+                    "type": "string"
+                },
+                "video_response": {
+                    "type": "string"
+                },
+                "link": {
+                    "type": "string"
+                },
+                "dsq_thread_id": {
+                    "type": "string"
+                },
+                "alt_title": {
+                    "type": "string"
+                },
+                "dbt_filename": {
+                    "type": "string"
+                },
+                "twtr_hash": {
+                    "type": "string"
+                }
+            }
+        },
+        "date": {
+            "type": "date",
+            "format": "dateOptionalTime"
+        },
+        "type": {
+            "type": "string"
+        },
+        "slug": {
+            "type": "string"
+        },
+        "comment_status": {
+            "type": "string"
+        }
+    }
+}

--- a/cfgov/processors/wordpress_page.py
+++ b/cfgov/processors/wordpress_page.py
@@ -7,18 +7,13 @@ from sheerlike.external_links import process_external_links
 
 def posts_at_url(url):
 
-    current_page = 1
-    max_page = sys.maxint
+    results = {'posts':[]}
+    for post_id in ['36603', '36605', '36601']:
+        resp = requests.get('http://www.consumerfinance.gov/api/get_post/', params={'post_type': 'page', 'post_id': post_id})
+        results['posts'].append(json.loads(resp.content)['post'])
 
-    while current_page <= max_page:
-        url = os.path.expandvars(url)
-        resp = requests.get(url, params={'page': current_page, 'count': '-1'})
-        results = json.loads(resp.content)
-        current_page += 1
-        max_page = results['pages']
-
-        for p in results['posts']:
-            yield p
+    for p in results['posts']:
+        yield p
 
 
 def documents(name, url, **kwargs):

--- a/cfgov/processors/wordpress_page.py
+++ b/cfgov/processors/wordpress_page.py
@@ -1,0 +1,39 @@
+import sys
+import json
+import os.path
+import requests
+from sheerlike.external_links import process_external_links
+
+
+def posts_at_url(url):
+
+    current_page = 1
+    max_page = sys.maxint
+
+    while current_page <= max_page:
+        url = os.path.expandvars(url)
+        resp = requests.get(url, params={'page': current_page, 'count': '-1'})
+        results = json.loads(resp.content)
+        current_page += 1
+        max_page = results['pages']
+
+        for p in results['posts']:
+            yield p
+
+
+def documents(name, url, **kwargs):
+
+    for post in posts_at_url(url):
+        yield process_post(post)
+
+
+def process_post(page):
+
+    del page['comments']
+    page['_id'] = page['id']
+
+    page = process_external_links(page)
+
+    return {'_type': 'pages',
+            '_id': page['id'],
+            '_source': page}


### PR DESCRIPTION
Reverts cfpb/cfgov-refresh#1938

Changes the `page` processor to only get pages we need.

@rosskarchner @kave 