### PR TITLE
Related Posts now use category to filter out related content

### DIFF
--- a/cfgov/v1/models/base.py
+++ b/cfgov/v1/models/base.py
@@ -143,6 +143,9 @@ class CFGOVPage(Page):
     def related_posts(self, block, hostname):
         related = {}
         query = models.Q(('tags__name__in', self.tags.names()))
+        if block.value['specific_categories']:
+            categories = ref.related_posts_category_lookup(block.value['specific_categories'])
+            query &= Q(('categories__name__in', categories))
         # TODO: Add other search types as they are implemented in Django
         # Import classes that use this class here to maintain proper import
         # order.

--- a/cfgov/v1/util/ref.py
+++ b/cfgov/v1/util/ref.py
@@ -121,6 +121,22 @@ supported_languagues = [
 ]
 
 
+def related_posts_category_lookup(related_categories):
+    related = []
+    for category in related_categories:
+        for name, related_posts_cats in related_posts_categories:
+            for cat in related_posts_cats:
+                if category == cat[0]:
+                    related.append(cat[1])
+    results = []
+    for r in related:
+        for name, cats in categories:
+            for c in cats:
+                if r == c[1]:
+                    related.append(c[0])
+    return related
+
+
 def page_type_choices():
     new_choices = [
         ('Activity Log', (
@@ -180,6 +196,7 @@ def is_blog(page):
                 return True
     if 'Blog' in page.specific_class.__name__:
         return True
+
 
 def is_report(page):
     for category in page.categories.all():


### PR DESCRIPTION
Creates a lookup function in ref.py and then uses it to create the related posts query in base.py.

@kave @rosskarchner 