### PR TITLE
Optimize queries for filter lists for fast page loads

### DIFF
--- a/cfgov/v1/forms.py
+++ b/cfgov/v1/forms.py
@@ -12,6 +12,7 @@ from django.core.exceptions import ValidationError, ObjectDoesNotExist
 from django.contrib.auth import authenticate
 from django.conf import settings
 from django.forms import widgets
+from taggit.models import Tag
 
 from .util import ref
 from .models.base import CFGOVPage
@@ -213,17 +214,16 @@ class FilterableListForm(forms.Form):
         parent = kwargs.pop('parent')
         hostname = kwargs.pop('hostname')
         super(FilterableListForm, self).__init__(*args, **kwargs)
-        self.set_topics(parent, hostname)
-        self.set_authors(parent, hostname)
+        page_ids = CFGOVPage.objects.live_shared(hostname).descendant_of(parent).values_list('id', flat=True)
+        self.set_topics(parent, page_ids, hostname)
+        self.set_authors(parent, page_ids, hostname)
 
     # Populate Topics' choices
-    def set_topics(self, parent, hostname):
-        tags = [tag for tags in
-                     [page.tags.names() for page in
-                      CFGOVPage.objects.live_shared(hostname).descendant_of(parent)]
-                     for tag in tags]
+    def set_topics(self, parent, page_ids, hostname):
+        tags = Tag.objects.filter(v1_cfgovtaggedpages_items__content_object__id__in=page_ids).values_list('name', flat=True)
+
         # Orders by most to least common tags
-        options = most_common(tags)
+        options = most_common(list(tags))
         most = [(option, option) for option in options[:3]]
         other = [(option, option) for option in options[3:]]
         self.fields['topics'].choices = \
@@ -231,13 +231,12 @@ class FilterableListForm(forms.Form):
              ('All other topics', tuple(other)))
 
     # Populate Authors' choices
-    def set_authors(self, parent, hostname):
-        all_authors = [author for authors in [page.authors.names() for page in
-                       CFGOVPage.objects.live_shared(hostname).descendant_of(
-                       parent)] for author in authors]
+    def set_authors(self, parent, page_ids, hostname):
+        authors = Tag.objects.filter(v1_cfgovauthoredpages_items__content_object__id__in=page_ids).values_list('name', flat=True)
+
         # Orders by most to least common authors
         self.fields['authors'].choices = [(author, author) for author in
-                                          most_common(all_authors)]
+                                          most_common(list(authors))]
 
     def clean(self):
         cleaned_data = super(FilterableListForm, self).clean()
@@ -320,50 +319,36 @@ class EventArchiveFilterForm(FilterableListForm):
 
 
 class NewsroomFilterForm(FilterableListForm):
-
-    def get_pages(self, parent, hostname):
-        pages = CFGOVPage.objects.live_shared(hostname).descendant_of(parent)
-        blogs = []
+    def __init__(self, *args, **kwargs):
+        parent = kwargs.pop('parent')
+        hostname = kwargs.pop('hostname')
+        super(FilterableListForm, self).__init__(*args, **kwargs)
         try:
             blog = CFGOVPage.objects.get(slug='blog')
-            blogs = CFGOVPage.objects.live_shared(hostname).descendant_of(blog)
         except CFGOVPage.DoesNotExist:
             print 'A blog landing page needs to be made'
-        if blogs:
-            pages = list(chain(pages, blogs))
-        return pages
-
-    # Populate Topics' choices
-    def set_topics(self, parent, hostname):
-        tags = [tag for tags in [page.tags.names() for page in self.get_pages(parent, hostname)] for tag in tags]
-        # Orders by most to least common tags
-        options = most_common(tags)
-        most = [(option, option) for option in options[:3]]
-        other = [(option, option) for option in options[3:]]
-        self.fields['topics'].choices = \
-            (('Most frequent', tuple(most)),
-             ('All other topics', tuple(other)))
-
-    # Populate Authors' choices
-    def set_authors(self, parent, hostname):
-        all_authors = [author for authors in
-                       [page.authors.names() for page in self.get_pages(parent, hostname)]
-                       for author in authors]
-        # Orders by most to least common authors
-        self.fields['authors'].choices = [(author, author) for author in
-                                          most_common(all_authors)]
+        query = CFGOVPage.objects.child_of_q(parent)
+        query |= CFGOVPage.objects.child_of_q(blog)
+        page_ids = CFGOVPage.objects.live_shared(hostname).filter(query).values_list('id', flat=True)
+        self.set_topics(parent, page_ids, hostname)
+        self.set_authors(parent, page_ids, hostname)
 
 
 class ActivityLogFilterForm(NewsroomFilterForm):
-    def per_page_limit(self):
-        return 100
-
-    def get_pages(self, parent, hostname):
-        pages = {'blog': None, 'newsroom': None, 'research-reports': None}
-        for slug in pages.keys():
+    def __init__(self, *args, **kwargs):
+        parent = kwargs.pop('parent')
+        hostname = kwargs.pop('hostname')
+        super(FilterableListForm, self).__init__(*args, **kwargs)
+        query = CFGOVPage.objects.child_of_q(parent)
+        for slug in ['blog', 'newsroom', 'research-reports']:
             try:
-                page = CFGOVPage.objects.get(slug=slug)
-                pages[slug] = CFGOVPage.objects.live_shared(hostname).descendant_of(page)
+                parent = CFGOVPage.objects.get(slug=slug)
+                query |= CFGOVPage.objects.child_of_q(parent)
             except CFGOVPage.DoesNotExist:
                 print slug, 'does not exist'
-        return list(chain(*[qs for qs in pages.values() if qs]))
+        page_ids = CFGOVPage.objects.live_shared(hostname).filter(query).values_list('id', flat=True)
+        self.set_topics(parent, page_ids, hostname)
+        self.set_authors(parent, page_ids, hostname)
+
+    def per_page_limit(self):
+        return 100

--- a/cfgov/v1/models/browse_filterable_page.py
+++ b/cfgov/v1/models/browse_filterable_page.py
@@ -86,21 +86,18 @@ class NewsroomLandingPage(BrowseFilterablePage):
                         categories_cache = list(categories)
 
         blog_q = Q()
-        newsroom_q = AbstractFilterPage.objects.descendant_of_q(self)
+        newsroom_q = AbstractFilterPage.objects.child_of_q(self)
         newsroom_q &= form.generate_query()
         if get_blog:
             try:
                 del form.cleaned_data['categories']
                 blog = base.CFGOVPage.objects.get(slug='blog')
-                blog_q = AbstractFilterPage.objects.descendant_of_q(blog)
+                blog_q = AbstractFilterPage.objects.child_of_q(blog)
                 blog_q &= form.generate_query()
             except base.CFGOVPage.DoesNotExist:
                 print 'Blog does not exist'
 
-        if not categories_cache and get_blog:
-            return AbstractFilterPage.objects.live_shared(hostname).filter(blog_q).order_by('-date_published')
-        else:
-            return AbstractFilterPage.objects.live_shared(hostname).filter(newsroom_q | blog_q).order_by('-date_published')
+        return AbstractFilterPage.objects.live_shared(hostname).filter(newsroom_q | blog_q).order_by('-date_published')
 
 
     def get_form_class(self):

--- a/cfgov/v1/models/sublanding_filterable_page.py
+++ b/cfgov/v1/models/sublanding_filterable_page.py
@@ -63,6 +63,7 @@ class ActivityLogPage(SublandingFilterablePage):
     def get_page_set(page, form, hostname):
         queries = {}
         selections = {}
+        categories_cache = list(form.cleaned_data.get('categories', []))
 
         # Get filter selections for Blog and Report
         for f in page.content:
@@ -76,10 +77,10 @@ class ActivityLogPage(SublandingFilterablePage):
                             del categories[categories.index(category)]
 
         # Get Newsroom pages
-        if not categories or map(lambda x: x in [c[0] for c in ref.choices_for_page_type('newsroom')], categories):
+        if not categories_cache or map(lambda x: x in [c[0] for c in ref.choices_for_page_type('newsroom')], categories):
             try:
                 parent = CFGOVPage.objects.get(slug='newsroom')
-                queries['newsroom'] = AbstractFilterPage.objects.descendant_of_q(parent) & form.generate_query()
+                queries['newsroom'] = AbstractFilterPage.objects.child_of_q(parent) & form.generate_query()
             except CFGOVPage.DoesNotExist:
                 print 'Newsroom does not exist'
 
@@ -89,7 +90,7 @@ class ActivityLogPage(SublandingFilterablePage):
             if is_selected:
                 try:
                     parent = CFGOVPage.objects.get(slug=slug)
-                    queries.update({slug: AbstractFilterPage.objects.descendant_of_q(parent) & form.generate_query()})
+                    queries.update({slug: AbstractFilterPage.objects.child_of_q(parent) & form.generate_query()})
                 except CFGOVPage.DoesNotExist:
                     print slug, 'does not exist'
 

--- a/cfgov/v1/util/filterable_context.py
+++ b/cfgov/v1/util/filterable_context.py
@@ -67,7 +67,7 @@ def get_form_specific_filter_data(page, form_class, request_dict):
 
 # Returns a queryset of AbstractFilterPages
 def get_page_set(page, form, hostname):
-    return AbstractFilterPage.objects.live_shared(hostname).descendant_of(
+    return AbstractFilterPage.objects.live_shared(hostname).child_of(
         page).filter(form.generate_query()).order_by('-date_published')
 
 

--- a/cfgov/v1/util/filterable_context.py
+++ b/cfgov/v1/util/filterable_context.py
@@ -67,14 +67,8 @@ def get_form_specific_filter_data(page, form_class, request_dict):
 
 # Returns a queryset of AbstractFilterPages
 def get_page_set(page, form, hostname):
-    pages = AbstractFilterPage.objects.live_shared(hostname).descendant_of(
+    return AbstractFilterPage.objects.live_shared(hostname).descendant_of(
         page).filter(form.generate_query()).order_by('-date_published')
-
-    if 'archive' not in page.title.lower():
-        pages = [p for p in pages if 'archive' not in p.parent().title.lower()]
-    else:
-        pages = [p for p in pages if 'archive' in p.parent().title.lower()]
-    return pages
 
 
 def has_active_filters(page, request, index):


### PR DESCRIPTION
This should speed up the lists tremendously.

## Changes

- `get_page_set` for each method has changed. I've made use of the Q object throughout and for regular filterable pages, I've simplified the method to a single line.
- getting the list of tags and authors was a HUGE slowdown in page loads. This uses a different query to get the data that cuts execution time by many orders of magnitude.

## Testing

- Go to all the filterable list type pages and test out the filtering at each one:
 - Newsroom, Blog, Activity log, Research Reports, and Enforcement actions

## Review

- @kave 
- @richaagarwal 
- @rosskarchner 

## Todos

- Tests

