### PR TITLE
Fix sidebar breakout template rendering

### DIFF
--- a/cfgov/jinja2/v1/_includes/organisms/sidebar-breakout.html
+++ b/cfgov/jinja2/v1/_includes/organisms/sidebar-breakout.html
@@ -82,7 +82,7 @@
                                 {% endif %}
                                 {% if blocks.body.value %}
                                     <p class="o-sidebar-breakout_text-body">
-                                        {{ blocks.body.render() }}
+                                        {{ parse_links(blocks.body.render()) | safe }}
                                     </p>
                                 {% endif %}
                                 </div>
@@ -99,10 +99,16 @@
                             {{ loop(blocks[loop.index:]) }}
                             {% break %}
                         {% endif %}
-                    {% elif 'related_metadata' in block.block_type %}
-                        <div class="block {{- 'block__flush-top' if loop.index == 1 else '' -}}">
-                            {{ related_metadata.render(block.value) }}
-                        </div>
+                    {% elif 'slug' in block.block_type %}
+                        <h2 class="header-slug">
+                            <span class="header-slug_inner">
+                                {{ block.value }}
+                            </span>
+                        </h2>
+                    {% elif 'paragraph' in block.block_type %}
+                        <p class="o-sidebar-breakout_text-body">
+                            {{ parse_links(block.value) | safe }}
+                        </p>
                     {% else %}
                         {% import 'templates/render_block.html' as render_block with context %}
                         {{ render_block.render(block, loop.index) }}


### PR DESCRIPTION
Sidebar breakout organism still had atoms in its selections that needed markup added to them.

## Additions

- Markup handling for atoms in sidebar breakout

## Testing

- Go to [refresh]/policy-compliance/rulemaking/ and compare to http://localhost:8000/policy-compliance/rulemaking/

## Review

- @kave 
- @richaagarwal 
- @rosskarchner 

## Screenshots
before
![screen shot 2016-04-21 at 8 47 30 am](https://cloud.githubusercontent.com/assets/1412978/14709254/b8bf1e3c-079d-11e6-9638-409204916f16.png)

after
![screen shot 2016-04-21 at 8 44 40 am](https://cloud.githubusercontent.com/assets/1412978/14709262/bdad8c62-079d-11e6-8ea9-33fdd56f987e.png)
