### PR TITLE
Added the Digital Gov search script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,8 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Added unit test specs for all files to test (excluding config, polyfills and jQuery plugins).
 - Added no-js and js classes to the on-demand header.
 - Added link to Livestream FAQ.
-- Flag for database routing for content.consumerfinance.gov
+- Flag for database routing for content.consumerfinance.gov.
+- Added the Digital Gov search script.
 
 ### Changed
 

--- a/cfgov/jinja2/v1/_includes/on-demand/footer.html
+++ b/cfgov/jinja2/v1/_includes/on-demand/footer.html
@@ -6,3 +6,14 @@
 
 {% import 'organisms/footer.html' as footer with context %}
 {{ footer.render() }}
+
+<script type='text/javascript'>
+//<![CDATA[
+    var usasearch_config = { siteHandle: 'cfpb' };
+
+    var script = document.createElement( 'script' );
+    script.type = 'text/javascript';
+    script.src = 'http://search.usa.gov/javascripts/remote.loader.js';
+    document.getElementsByTagName( 'head' )[0].appendChild( script );
+//]]>
+</script>

--- a/cfgov/jinja2/v1/_layouts/base.html
+++ b/cfgov/jinja2/v1/_layouts/base.html
@@ -210,6 +210,17 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 </script>
 {% endif %}
 <!--<![endif]-->
+
+<script type='text/javascript'>
+//<![CDATA[
+    var usasearch_config = { siteHandle: 'cfpb' };
+
+    var script = document.createElement( 'script' );
+    script.type = 'text/javascript';
+    script.src = 'http://search.usa.gov/javascripts/remote.loader.js';
+    document.getElementsByTagName( 'head' )[0].appendChild( script );
+//]]>
+</script>
 {% endblock javascript %}
 
 </body>


### PR DESCRIPTION
Including this script allows Digital Gov to generate our global site search results. Do not edit, this script comes straight from Digital Gov - http://search.digitalgov.gov/manual/code.html

## Additions

- Digital Gov search loader script

## Testing

- navigate to any new page and inspect the `head`. Just after the IE conditional and jQuery loader should be two search.usa.gov scripts injected by this loader script in the footer.

## Review

- @rosskarchner 
- @sebworks 
- @anselmbradford 

## Screenshots

![screen shot 2016-04-21 at 8 28 23 am](https://cloud.githubusercontent.com/assets/1280430/14710435/078ccc9c-079b-11e6-98ef-50d47837e6e7.png)

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
