### PR TITLE
Fixes up the related posts again to correctly include category based …

### DIFF
--- a/cfgov/v1/util/ref.py
+++ b/cfgov/v1/util/ref.py
@@ -174,7 +174,7 @@ def choices_for_page_type(page_type):
             for cat_slug, cat_tuples in page_type_choices():
                 if name == cat_slug:
                     return list(cat_tuples)
-
+    return []
 
 def category_label(category):
     for parent, children in page_type_choices():

--- a/cfgov/v1/util/ref.py
+++ b/cfgov/v1/util/ref.py
@@ -133,8 +133,8 @@ def related_posts_category_lookup(related_categories):
         for name, cats in categories:
             for c in cats:
                 if r == c[1]:
-                    related.append(c[0])
-    return related
+                    results.append(c[0])
+    return results
 
 
 def page_type_choices():


### PR DESCRIPTION
This should fix it up well now. It applies a descendant_of query for each parent of the types of data we want to pull in, as well handles filtering the categories that are selected for each query as well.

## Changes

- Refactored related_posts query for category handling...again

## Testing

- Go to http://localhost:8000/data-research/research-reports/issue-brief-social-security-claiming-age-and-retirement-security/ and see that related posts pull in Data, research & reports related content. If you change the category selection, the results change with it.


## Review

- @kave 
- @richaagarwal 
- @rosskarchner 

## Notes

- also fixes the return value of a ref.py function