### PR TITLE
final missing admin bits

### DIFF
--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -75,6 +75,7 @@ OPTIONAL_APPS=[
     {'import':'regcore','apps':('regcore','regcore_read', 'regcore_write')},
     {'import':'eregsip','apps':('eregsip',)},
     {'import':'regulations','apps':('regulations',)},
+    {'import':'picard','apps':('picard',)},
 ]
 
 MIDDLEWARE_CLASSES = (
@@ -418,6 +419,7 @@ LOGIN_FAIL_TIME_PERIOD = os.environ.get('LOGIN_FAIL_TIME_PERIOD', 120 * 60)
 # number of failed attempts
 LOGIN_FAILS_ALLOWED = os.environ.get('LOGIN_FAILS_ALLOWED', 5)
 LOGIN_REDIRECT_URL='/admin/'
+LOGIN_URL = "/admin/login/"
 
 
 SHEER_SITES = {
@@ -510,3 +512,5 @@ CACHES = {
         },
     }
 }
+
+PICARD_SCRIPTS_DIRECTORY = os.environ.get('PICARD_SCRIPTS_DIRECTORY',REPOSITORY_ROOT.child('picard_scripts'))

--- a/cfgov/cfgov/settings/local.py
+++ b/cfgov/cfgov/settings/local.py
@@ -11,6 +11,7 @@ DATABASES = {
         'PASSWORD': os.environ.get('MYSQL_PW', ''),
         'HOST': os.environ.get('MYSQL_HOST', ''),  # empty string == localhost
         'PORT': os.environ.get('MYSQL_PORT', ''),  # empty string == default
+        'OPTIONS': {'init_command': 'SET storage_engine=MYISAM', },
     },
 }
 

--- a/cfgov/cfgov/urls.py
+++ b/cfgov/cfgov/urls.py
@@ -217,6 +217,8 @@ urlpatterns = [
 
 if settings.ALLOW_ADMIN_URL:
     patterns = [
+        url(r'^d/admin/(?P<path>.*)$', RedirectView.as_view(url='/django-admin/%(path)s',permanent=True)),
+        url(r'^picard/(?P<path>.*)$', RedirectView.as_view(url='/tasks/%(path)s',permanent=True)),
         url(r'^django-admin/login', cfpb_login, name='django_admin_login'),
         url(r'^django-admin/auth/user/add/', create_user, name='django_admin_create_user'),
         url(r'^django-admin/password_change', change_password, name='django_admin_account_change_password'),
@@ -238,6 +240,11 @@ if settings.ALLOW_ADMIN_URL:
 
         url(r'^admin/', include(wagtailadmin_urls)),
     ]
+    if 'picard' in settings.INSTALLED_APPS:
+        patterns.append(url(r'^tasks/', include('picard.urls')))
+
+    if 'selfregistration' in settings.INSTALLED_APPS:
+        patterns.append(url(r'^selfregs/', include('selfregistration.urls')))
 
     urlpatterns = patterns + urlpatterns
 

--- a/cfgov/templates/admin/base.html
+++ b/cfgov/templates/admin/base.html
@@ -16,5 +16,6 @@
         <a href="{% url 'admin:password_change' %}">{% trans 'Change password' %}</a> /
     {% endif %}
     <a href="/admin/">{% trans 'Wagtail login' %}</a> /
+    <a href="/tasks/">{% trans 'Task launcher' %}</a> /
     <a href="{% url 'admin:logout' %}">{% trans 'Log out' %}</a>
 {% endblock %}

--- a/picard_scripts/akamai_flush.sh
+++ b/picard_scripts/akamai_flush.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+echo "this script only exists to prove that Picard is working"
+

--- a/picard_scripts/picard_data_export.sh
+++ b/picard_scripts/picard_data_export.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+echo "this script only exists to prove that Picard is working"
+

--- a/picard_scripts/picard_synonyms_export.sh
+++ b/picard_scripts/picard_synonyms_export.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+echo "this script only exists to prove that Picard is working"
+


### PR DESCRIPTION
Adds some final missing admin bits: picard, and the export tool that comes the selfregistration app.

## Additions

- URL patterns, redirects, and OPTIONAL_APPS config for picard and selfregistration
- some sample scripts for picard
- adds 'task Launcher' (aka Picard) to django admin nav

## Testing

-  check out CFPB/django-cfpb-common and `pip install -e <path>` it
-  check out CFPB/Picard and `pip install -e <path>` it
-  check out CFPB/cfgov-selfregistration and `pip install -e <path>` it
- `pip install django-braces==1.0.0`
- `cfgov/manage.py migrate`
- `cfgov/manage.py runserver`
- Observe that http://localhost:8000/picard/ redirects to localhost:8000/tasks/ (will require login if you aren't already logged in), and that running any tasks produce the expected output "this script only exists to prove that Picard is working"
- fill out this form: http://localhost:8000/company-signup/
- go to http://localhost:8000/selfregs/export/ and click 'export all'
- dig that sweet CSV file.

## Review

- @kave @kurtw @richaagarwal 


## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)

add Task Launcher to the django admin navigation