### PR TITLE
Android fix - Remove global search invisibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 
 - Hid overflow-x at mobile sizes on document body.
 - Added `halt()` and `clearTransitions()` methods to transition behaviors.
-
+- Updated position of global search content to remove need for invisibility.
 
 ### Removed
 

--- a/cfgov/unprocessed/css/molecules/global-search.less
+++ b/cfgov/unprocessed/css/molecules/global-search.less
@@ -131,8 +131,18 @@
         position: absolute;
         left: 0;
 
+        // Offset to move the global search content over so it's not visible
+        // in the gap between the "search" button and the edge of
+        // global search overflow area.
+        padding-left: 16px;
+
         &-form {
             width: 100%;
+        }
+
+        // Resets the offset for moving the global search content out of view.
+        &[aria-expanded="true"] {
+          padding-left: 0;
         }
 
         // Only add transforms if we have JS.

--- a/cfgov/unprocessed/js/molecules/GlobalSearch.js
+++ b/cfgov/unprocessed/js/molecules/GlobalSearch.js
@@ -66,12 +66,8 @@ function GlobalSearch( element ) { // eslint-disable-line max-statements, no-inl
     var handleExpandBeginBinded = fnBind( _handleExpandBegin, this );
     _flyoutMenu.addEventListener( 'expandBegin', handleExpandBeginBinded );
     _flyoutMenu.addEventListener( 'collapseBegin', _handleCollapseBegin );
-    _flyoutMenu.addEventListener( 'collapseEnd', _handleCollapseEnd );
 
     _tabTriggerDom.addEventListener( 'keyup', _handleTabPress );
-
-    // Set initial collapse state.
-    _handleCollapseEnd();
 
     return this;
   }
@@ -146,7 +142,6 @@ function GlobalSearch( element ) { // eslint-disable-line max-statements, no-inl
     this.dispatchEvent( 'expandBegin', { target: this } );
     // If it's the desktop view, hide the "Search" button.
     if ( _isInDesktop() ) { _triggerDom.classList.add( 'u-invisible' ); }
-    _contentDom.classList.remove( 'u-invisible' );
     _searchInputDom.select();
 
     document.body.addEventListener( 'mousedown', _handleBodyClick );
@@ -157,20 +152,8 @@ function GlobalSearch( element ) { // eslint-disable-line max-statements, no-inl
    * Use this to perform post-collapseBegin actions.
    */
   function _handleCollapseBegin() {
-    _triggerDom.classList.remove( 'u-invisible' );
+    if ( _isInDesktop() ) { _triggerDom.classList.remove( 'u-invisible' ); }
     document.body.removeEventListener( 'mousedown', _handleBodyClick );
-  }
-
-  /**
-   * Event handler for when FlyoutMenu collapse transition ends.
-   * Use this to perform post-collapseEnd actions.
-   */
-  function _handleCollapseEnd() {
-    // TODO: When tabbing is used to collapse the search flyout
-    //       it will not animate with the below line.
-    //       Investigate why this is the case for tab key
-    //       but not with mouse clicks.
-    _contentDom.classList.add( 'u-invisible' );
   }
 
   /**


### PR DESCRIPTION
Remove global search invisibility to make search work on Android 4.

## Changes

- Moves global search content out of view when aria-expanded is false.
- Removes logic for setting/removing invisibility on global search content.

## Testing

- `gulp build` and check on Android 4 in Sauce. Search should be clickable.

## Review

- @sebworks 
- @jimmynotjim 

## Screenshots

![screen shot 2016-04-21 at 10 59 07 am](https://cloud.githubusercontent.com/assets/704760/14713696/1c24bdf8-07b0-11e6-9d33-c9e4fe35ca49.png)
