### PR TITLE
Fixes issue related to Android search element on legacy devices

### DIFF
--- a/cfgov/unprocessed/js/molecules/GlobalSearch.js
+++ b/cfgov/unprocessed/js/molecules/GlobalSearch.js
@@ -146,7 +146,15 @@ function GlobalSearch( element ) { // eslint-disable-line max-statements, no-inl
     this.dispatchEvent( 'expandBegin', { target: this } );
     // If it's the desktop view, hide the "Search" button.
     if ( _isInDesktop() ) { _triggerDom.classList.add( 'u-invisible' ); }
+
+    // TODO: Remove when Android 4.0-4.4 support is dropped.
+    // Hack to fix reflow issues on legacy Android devices.
+    _contentDom.style.display='none';
+    _contentDom.offsetHeight;
+    _contentDom.style.display='';
+
     _contentDom.classList.remove( 'u-invisible' );
+
     _searchInputDom.select();
 
     document.body.addEventListener( 'mousedown', _handleBodyClick );


### PR DESCRIPTION
Fixes issue related to Android search element on legacy devices

## Changes

- Modified `cfgov/unprocessed/js/molecules/GlobalSearch.js` to force a reflow when the search is beginning to expand. 

## Testing

- Visit the site via sauce labs on a legacy Android device. Click on the `Search` icon. The search should expand/collapse as you click on the icon. 

## Review

- @anselmbradford 
- @jimmynotjim 
- @KimberlyMunoz 


## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)