### PR TITLE
Delays hover state on menu

### DIFF
--- a/cfgov/unprocessed/css/organisms/mega-menu.less
+++ b/cfgov/unprocessed/css/organisms/mega-menu.less
@@ -425,6 +425,7 @@
             }
 
             &-list {
+                display: inline-block;
                 margin-bottom: 0;
             }
 
@@ -436,6 +437,10 @@
                     .o-mega-menu_content-2 {
                         display: block;
                     }
+                }
+
+                &:last-child {
+                    margin-right: 0;
                 }
             }
 

--- a/cfgov/unprocessed/js/organisms/MegaMenu.js
+++ b/cfgov/unprocessed/js/organisms/MegaMenu.js
@@ -138,8 +138,9 @@ function MegaMenu( element ) {
    * @param {FlyoutMenu} menu - a menu on which to attach events.
    */
   function _addEvents( menu ) {
-    menu.addEventListener( 'triggerOver', _handleEvent );
     menu.addEventListener( 'triggerClick', _handleEvent );
+    menu.addEventListener( 'triggerOver', _handleEvent );
+    menu.addEventListener( 'triggerOut', _handleEvent );
     menu.addEventListener( 'expandBegin', _handleEvent );
     menu.addEventListener( 'expandEnd', _handleEvent );
     menu.addEventListener( 'collapseBegin', _handleEvent );

--- a/cfgov/unprocessed/js/organisms/MegaMenuDesktop.js
+++ b/cfgov/unprocessed/js/organisms/MegaMenuDesktop.js
@@ -19,10 +19,12 @@ function MegaMenuDesktop( menus ) {
 
   // DOM references.
   var _bodyDom = document.body;
+  var _firstLevelDom;
 
   // Binded functions.
   var _handleTriggerClickBinded = fnBind( _handleTriggerClick, this );
   var _handleTriggerOverBinded = fnBind( _handleTriggerOver, this );
+  var _handleTriggerOutBinded = fnBind( _handleTriggerOut, this );
   var _handleExpandBeginBinded = fnBind( _handleExpandBegin, this );
   var _handleCollapseEndBinded = fnBind( _handleCollapseEnd, this );
 
@@ -35,10 +37,18 @@ function MegaMenuDesktop( menus ) {
   // Whether this instance's behaviors are suspended or not.
   var _suspended = true;
 
+  // Timeout for delayed events.
+  var _showDelay;
+
   /**
    * @returns {MegaMenuDesktop} An instance.
    */
   function init() {
+    // Get the immediate parent of the 1st level menu links.
+    // We'll use this later to check if we're still over the links,
+    // on mouse move.
+    var firstLevelMenus = _menus.getAllAtLevel( 1 );
+    _firstLevelDom = firstLevelMenus[0].data.getDom().container.parentNode;
 
     return this;
   }
@@ -48,16 +58,58 @@ function MegaMenuDesktop( menus ) {
    * @param {Event} event - A FlyoutMenu event.
    */
   function handleEvent( event ) {
-    if ( _suspended ) return;
+    if ( _suspended ) { return; }
     var eventMap = {
       triggerClick: _handleTriggerClickBinded,
       triggerOver:  _handleTriggerOverBinded,
+      triggerOut:   _handleTriggerOutBinded,
       expandBegin:  _handleExpandBeginBinded,
       collapseEnd:  _handleCollapseEndBinded
     };
 
     var currHandler = eventMap[event.type];
-    if ( currHandler ) currHandler( event );
+    if ( currHandler ) {
+      var delay = _calcEventDelay( event.type );
+      if ( delay > 0 ) {
+        _delayedEvent( currHandler, event, delay );
+      } else {
+        currHandler( event );
+      }
+    }
+  }
+
+  /**
+   * @param {string} type - The type of event to check.
+   * @returns {number} The amount to delay in milliseconds,
+   *   length is determined based on the event type and
+   *   whether the menu is active or not.
+   */
+  function _calcEventDelay( type ) {
+    var delay = 0;
+    if ( type === 'triggerClick' ) {
+      window.clearTimeout( _showDelay );
+    } else if ( type === 'triggerOver' ) {
+      if ( _activeMenu === null ) {
+        delay = 150;
+      } else {
+        delay = 50;
+      }
+    }
+
+    return delay;
+  }
+
+  /**
+   * Delay the broadcasting of an event by supplied delay.
+   * @param {Function} currHandler - Event handler.
+   * @param {Event} event - A FlyoutMenu event.
+   * @param {number} delay - Delay in milliseconds.
+   */
+  function _delayedEvent( currHandler, event, delay ) {
+    window.clearTimeout( _showDelay );
+    _showDelay = window.setTimeout( function() {
+      currHandler( event );
+    }, delay );
   }
 
   /**
@@ -67,29 +119,26 @@ function MegaMenuDesktop( menus ) {
   function _handleTriggerClick( event ) {
     this.dispatchEvent( 'triggerClick', { target: this } );
     var menu = event.target;
-    if ( !menu.isAnimating() ) {
-      if ( _activeMenu === null ) {
-        // A menu is opened.
-        _activeMenu = menu;
-        _activeMenu.getTransition().animateOn();
-        // TODO: Investigate whether mouseout event may be able to be used
-        //       instead of mousemove.
-        _bodyDom.addEventListener( 'mousemove', _handleMove );
-        _bodyDom.addEventListener( 'mouseleave', _handleMove );
-      } else if ( _activeMenu === menu ) {
-        // A menu is closed.
-        _activeMenu.getTransition().animateOn();
-        _activeMenu = null;
-        _bodyDom.removeEventListener( 'mousemove', _handleMove );
-        _bodyDom.removeEventListener( 'mouseleave', _handleMove );
-      } else {
-        // An open menu has switched to another menu.
-        _activeMenu.getTransition().animateOff();
-        _activeMenu.collapse();
-        _activeMenu = event.target;
-        _activeMenu.getTransition().animateOff();
-      }
-    }
+    if ( menu.isAnimating() ) { return; }
+    _updateMenuState( menu, event.type );
+  }
+
+  /**
+   * Event handler for when FlyoutMenu trigger is hovered over.
+   * @param {Event} event - A FlyoutMenu event.
+   */
+  function _handleTriggerOver( event ) {
+    this.dispatchEvent( 'triggerOver', { target: this } );
+    _updateMenuState( event.target, event.type );
+  }
+
+  /**
+   * Event handler for when FlyoutMenu trigger is hovered out.
+   */
+  function _handleTriggerOut() {
+    this.dispatchEvent( 'triggerOut', { target: this } );
+    // Clear any queued events to show the menu.
+    window.clearTimeout( _showDelay );
   }
 
   /**
@@ -118,30 +167,49 @@ function MegaMenuDesktop( menus ) {
   }
 
   /**
-   * Event handler for when FlyoutMenu trigger is hovered over.
-   * @param {Event} event - A FlyoutMenu event.
-   */
-  function _handleTriggerOver( event ) {
-    this.dispatchEvent( 'triggerOver', { target: this } );
-    var menu = event.target;
-    var level = menu.getData().level;
-
-    // Only trigger a click when rolling over the level one
-    // menu items when in the desktop view.
-    if ( level === 1 && _activeMenu !== menu ) {
-      menu.getDom().trigger.click();
-    }
-  }
-
-  /**
    * Event handler for when mouse is hovering.
    * @param {MouseEvent} event - The hovering event.
    */
   function _handleMove( event ) {
-    var menu = event.target;
+    // If we've left the parent container of the current menu, close it.
+    if ( !_firstLevelDom.contains( event.target ) ) {
+      _updateMenuState( null, event.type );
+    }
+  }
 
-    if ( !_activeMenu.getDom().container.parentNode.contains( menu ) ) {
-      _activeMenu.getDom().trigger.click();
+  /**
+   * Cleanup state and set the currently active menu.
+   * @param {FlyoutMenu} menu - The menu currently being activated.
+   * @param {string} type - The event type that is calling this method.
+   */
+  function _updateMenuState( menu, type ) {
+    if ( menu === null || _activeMenu === menu ) {
+      // A menu is closed.
+      window.clearTimeout( _showDelay );
+      _activeMenu.getTransition().animateOn();
+      _activeMenu.collapse();
+      _activeMenu = null;
+      _bodyDom.removeEventListener( 'mousemove', _handleMove );
+      _bodyDom.removeEventListener( 'mouseleave', _handleMove );
+    } else if ( _activeMenu === null ) {
+      // A menu is opened.
+      _activeMenu = menu;
+      _activeMenu.getTransition().animateOn();
+      // Mousemove needed in addition to mouseout of the trigger
+      // in order to check if user has moved off the menu <ul> and not
+      // just the <li> list items.
+      _bodyDom.addEventListener( 'mousemove', _handleMove );
+      _bodyDom.addEventListener( 'mouseleave', _handleMove );
+      _activeMenu.expand();
+    } else {
+      // An open menu has switched to another menu.
+      _activeMenu.getTransition().animateOff();
+      _activeMenu.collapse();
+      _activeMenu = menu;
+      if ( type === 'triggerOver' ) {
+        _activeMenu.getTransition().animateOff();
+        _activeMenu.expand();
+      }
     }
   }
 


### PR DESCRIPTION
## Changes

- Delays hover state on header.

## Testing

- `gulp build`
- if quickly moving over the menu it should not open.
- When over the menu item it should open after a short 150ms delay.
- Check in iPad simulator

## Review

- @sebworks 
- @jimmynotjim 
- @KimberlyMunoz 

## Todos

- iPad simulator (Apple) has a slide down transition the first time each menu is opened, after which it works as expected where when switching between menus there is no slide down transition.
