### PR TITLE
Fixing the missing spacing below full-width images

### DIFF
--- a/cfgov/jinja2/v1/_includes/organisms/full-width-text.html
+++ b/cfgov/jinja2/v1/_includes/organisms/full-width-text.html
@@ -25,7 +25,7 @@
         {% elif 'media' in block.block_type %}
             <div class="m-full-width-media">
                 {% set media = image(block.value, 'original') %}
-                <img class="m-full-width-media" src="{{ media.url }}" alt="{{ media.alt }}">
+                <img class="m-full-width-media_image" src="{{ media.url }}" alt="{{ media.alt }}">
             </div>
         {% else %}
             <div class="m-inset">


### PR DESCRIPTION
Classname was just incorrectly set.

## Changes

- Fixed the `full-width-media_image` classname

## Testing

- gulp build and create a blog post with images (or trust the screenshot)

## Review

- @KimberlyMunoz 
- @sebworks 
- @anselmbradford 

## Screenshots

__Before__

![screen shot 2016-04-21 at 12 48 03 pm](https://cloud.githubusercontent.com/assets/1280430/14718996/56266a10-07bf-11e6-8719-f6150dc81f00.png)

__After__

![screen shot 2016-04-21 at 12 47 53 pm](https://cloud.githubusercontent.com/assets/1280430/14718999/5966139c-07bf-11e6-934e-399c4b380b0e.png)

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
