### PR TITLE
Fixes disappearing search close button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,8 +29,6 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Added `halt()` and `clearTransitions()` methods to transition behaviors.
 - Updated the content on doing-business-with-us and doing-business-with-us/upcoming-procurement-needs based on EA feedback.
 
-
-
 ### Removed
 
 - Removed resolved TODOs and old macros replaced by atomic components.
@@ -40,6 +38,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Fixed an issue where the multiselect couldn't be closed.
 - Fixed the browser tests for the recent change to wagtail pages.
 - Fixed the mobile menu for on-demand django pages.
+- Fixed disappearing search close button when swapping device orientation.
 
 
 ## 3.0.0-3.3.2 - 2016-04-11

--- a/cfgov/unprocessed/css/molecules/global-search.less
+++ b/cfgov/unprocessed/css/molecules/global-search.less
@@ -254,6 +254,10 @@
         &_trigger {
             // Match height of input with button.
             padding: 7px 0;
+
+            &[aria-expanded="true"] {
+                .u-invisible();
+            }
         }
 
         .js & {

--- a/cfgov/unprocessed/js/molecules/GlobalSearch.js
+++ b/cfgov/unprocessed/js/molecules/GlobalSearch.js
@@ -144,14 +144,12 @@ function GlobalSearch( element ) { // eslint-disable-line max-statements, no-inl
    */
   function _handleExpandBegin() {
     this.dispatchEvent( 'expandBegin', { target: this } );
-    // If it's the desktop view, hide the "Search" button.
-    if ( _isInDesktop() ) { _triggerDom.classList.add( 'u-invisible' ); }
 
     // TODO: Remove when Android 4.0-4.4 support is dropped.
     // Hack to fix reflow issues on legacy Android devices.
-    _contentDom.style.display='none';
+    _contentDom.style.display = 'none';
     _contentDom.offsetHeight;
-    _contentDom.style.display='';
+    _contentDom.style.display = '';
 
     _contentDom.classList.remove( 'u-invisible' );
 
@@ -165,7 +163,6 @@ function GlobalSearch( element ) { // eslint-disable-line max-statements, no-inl
    * Use this to perform post-collapseBegin actions.
    */
   function _handleCollapseBegin() {
-    _triggerDom.classList.remove( 'u-invisible' );
     document.body.removeEventListener( 'mousedown', _handleBodyClick );
   }
 


### PR DESCRIPTION
Fixed disappearing search close button when swapping device orientation.

## Changes

- Makes trigger invisible when `aria-expanded` is `true` at desktop sizes (via CSS instead of JS).

## Testing

- `gulp build`
- open in iPad simulator.
- in landscape, open search.
- rotate to portrait. Search close button should be visible.

## Review

- @jimmynotjim 
- @sebworks 
- @KimberlyMunoz 
