### PR TITLE
Add rossify script

### DIFF
--- a/cfgov/scripts/rossify_pages.py
+++ b/cfgov/scripts/rossify_pages.py
@@ -1,0 +1,13 @@
+from django.contrib.auth import User
+from wagtail.wagtailcore.models import Page, PageRevision
+
+def run():
+    ross = User.objects.get(username='rosskarchner')
+    for page in Page.objects.all():
+        page.owner = ross
+        page.save()
+    for revision in PageRevision.objects.all():
+        revision.user = ross
+        revision.save()
+
+    print 'All your pages belong to Ross now muwhuahuahaha'


### PR DESCRIPTION
# Please verify data integrity with extreme scrutiny

I'm going to tack on the part of the script that adds the current Wagtail user data later.

## Test

- grab the `content` dump of auth tables (check group chat)
- grab the `refresh` dump from jenkins.
 - make duplicate incase you have to start over
- modify the refresh dump file and remove the auth table creation sql and migrations
- then import `content` file into a fresh v1 database then:
 - `cfgov/manage.py migrate auth --fake`
 - `cfgov/manage.py migrate`
- Import the modified `refresh` dump into the v1 database then run:
 - `cfgov/manage.py runscript rossify_pages`
- Check/Verify the users and groups tables to see `content` dump data is there (should have legacy users):
 - look around, make users, assign permissions, etc
- you'll notice that the `Can share pages` permission is set for each auth group
- you'll also notice that none of the groups have permissions to edit pages (we can just set this later)
 
## Todo's

We'll need to recreate all of our Wagtail users, but that shouldn't be too much of a haul.

## Review

@kave @richaagarwal @rosskarchner 