### PR TITLE
Adds delay to search test to allow transition to complete

### DIFF
--- a/test/browser_tests/spec_suites/organisms/global-search.js
+++ b/test/browser_tests/spec_suites/organisms/global-search.js
@@ -55,6 +55,11 @@ describe( 'GlobalSearch', function() {
         } );
 
         it( 'should NOT have a search trigger', function() {
+          // Pause to allow the transition to complete animating.
+          // Update to use `protractor.until.elementIsNotVisible`
+          // if this causes random failures due to differences in
+          // execution time of the transition.
+          browser.sleep( 500 );
           expect( _dom.trigger.isDisplayed() ).toBe( false );
         } );
 


### PR DESCRIPTION
## Changes

- Adds delay to search test to allow transition to complete

## Testing

- `gulp build && gulp test:acceptance --sauce=false --specs=organisms/global-search.js` should pass

## Review

- @richaagarwal 
- @jimmynotjim 
- @sebworks 
