### PR TITLE
Added tests for the public methods in the Multiselect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 
 ### Added
 
+- Added tests for the public methods in the Multiselect
+
 ### Changed
 
 ### Removed

--- a/cfgov/unprocessed/js/molecules/Multiselect.js
+++ b/cfgov/unprocessed/js/molecules/Multiselect.js
@@ -457,25 +457,6 @@ function Multiselect( element ) { // eslint-disable-line max-statements, inline-
     _resetSearch();
   }
 
-  /**
-   * Tests if the user's query matches the text input
-   * @param   {string} text  The text to test against
-   * @param   {string} value The value the user has entered
-   * @returns {boolean}      Returns the boolean result of the test
-   */
-  function _filterContains( text, value ) {
-    return RegExp( _regExpEscape( value.trim() ), 'i' ).test( text );
-  }
-
-  /**
-   * Escapes a string
-   * @param   {string} s The string to escape
-   * @returns {string}   The escaped string
-   */
-  function _regExpEscape( s ) {
-    return s.replace( /[-\\^$*+?.()|[\]{}]/g, '\\$&' );
-  }
-
   // Attach public events.
   this.init = init;
   this.expand = expand;

--- a/test/unit_tests/molecules/Multiselect-spec.js
+++ b/test/unit_tests/molecules/Multiselect-spec.js
@@ -3,12 +3,14 @@
 var chai = require( 'chai' );
 var expect = chai.expect;
 var jsdom = require( 'mocha-jsdom' );
+var sinon = require( 'sinon' );
 
 var BASE_JS_PATH = '../../../cfgov/unprocessed/js/';
 var Multiselect = require( BASE_JS_PATH + 'molecules/Multiselect' );
 var multiselect;
 var selectDom;
 var multiselectDom;
+var sandbox;
 var HTML_SNIPPET =
     '<select name="test-select" id="test-select" multiple>' +
       '<option value="Debt collection">Debt collection</option>' +
@@ -17,15 +19,29 @@ var HTML_SNIPPET =
       '<optgroup label="All other topics">' +
     '</select>';
 
+function keyPress( target, key ) {
+  var event = target.createEvent( 'Event' );
+  event.keyCode = key;
+  event.initEvent( 'keydown' );
+  target.dispatchEvent( event );
+}
+
 describe( 'Multiselect', function() {
+
   jsdom();
 
   beforeEach( function() {
+    sandbox = sinon.sandbox.create();
+    sandbox.stub(window.console, "log");
+
     document.body.innerHTML = HTML_SNIPPET;
 
     selectDom = document.querySelector( 'select[multiple]' );
-    multiselect =
-      new Multiselect( selectDom );
+    multiselect = new Multiselect( selectDom );
+  } );
+
+  afterEach( function() {
+    sandbox.restore();
   } );
 
   describe( 'init', function() {
@@ -37,17 +53,89 @@ describe( 'Multiselect', function() {
       expect( selectDom.length ).to.equal( 0 );
       expect( multiselectDom.length ).to.equal( 1 );
     } );
+
+    it( 'should autocheck any selected options (form submitted pages)',
+      function() {
+        var option = document.querySelector( 'option' );
+        option.defaultSelected = true;
+        multiselect.init();
+        var choices = document.querySelectorAll( '.cf-multi-select_choices li' );
+
+        expect( choices.length ).to.equal( 1 );
+        expect( choices[0].innerHTML ).to.contain( 'Debt collection' );
+      }
+    );
+
+    it( 'should log a helpful tip if passed a bad option value', function() {
+      var option = document.querySelector( 'option' );
+      option.value = 'Foo\'';
+      multiselect.init();
+      selectDom = document.querySelectorAll( 'select[multiple]' );
+      multiselectDom = document.querySelectorAll( '.cf-multi-select' );
+
+      expect( selectDom.length ).to.equal( 1 );
+      expect( multiselectDom.length ).to.equal( 0 );
+      sinon.assert.calledOnce( console.log );
+      sinon.assert.calledWithExactly(
+        console.log, '\'Foo\'\' is not a valid value'
+      );
+    } );
   } );
 
-  describe( 'dom creation', function() {
-    xit( 'should autocheck any selected options ' +
-         '(form submitted pages)', function() {
-      var options = selectDom.querySelectorAll( 'option' );
-      options[0].selected = 'selected';
+  describe( 'public methods', function() {
+    it( 'should open when the expand method is called', function() {
       multiselect.init();
-      var choices = document.querySelectorAll( '.cf-multi-select_choices li' );
+      multiselect.expand();
+      multiselectDom = document.querySelector( '.cf-multi-select' );
+      var fieldset = multiselectDom.querySelector( '.cf-multi-select_fieldset' );
 
-      expect( choices.length ).to.equal( 1 );
+      expect( multiselectDom.className ).to.equal( 'cf-multi-select active' );
+      expect( fieldset.getAttribute( 'aria-hidden' ) ).to.equal( 'false' );
+    } );
+
+    it( 'should close when the collapse method is called', function() {
+      multiselect.init();
+      multiselect.expand();
+      multiselect.collapse();
+      multiselectDom = document.querySelector( '.cf-multi-select' );
+      var fieldset = multiselectDom.querySelector( '.cf-multi-select_fieldset' );
+
+      expect( multiselectDom.className ).to.equal( 'cf-multi-select' );
+      expect( fieldset.getAttribute( 'aria-hidden' ) ).to.equal( 'true' );
+    } );
+  } );
+
+  describe( 'interactions', function() {
+    xit( 'should open when the search input is clicked', function() {
+      multiselect.init();
+      multiselectDom = document.querySelector( '.cf-multi-select' );
+      var fieldset = multiselectDom.querySelector( '.cf-multi-select_fieldset' );
+      var search = document.querySelector( '#test-select' );
+      search.click();
+
+      expect( document.activeElement.id ).to.equal( 'test-select' );
+      expect( multiselectDom.className ).to.equal( 'cf-multi-select active' );
+      expect( fieldset.getAttribute( 'aria-hidden' ) ).to.equal( 'false' );
+    } );
+
+    xit( 'should highlight the first item when keying down', function() {
+      multiselect.init();
+      var search = document.querySelector( '#test-select' );
+      search.click();
+      keyPress( search, 40 );
+
+      expect( document.activeElement.id ).to.equal( 'Debt collection' );
+    } );
+
+    xit( 'should close when the body is clicked', function() {
+      multiselect.init();
+      multiselect.expand();
+      multiselectDom = document.querySelector( '.cf-multi-select' );
+      var fieldset = multiselectDom.querySelector( '.cf-multi-select_fieldset' );
+      document.click();
+
+      expect( multiselectDom.className ).to.equal( 'cf-multi-select' );
+      expect( fieldset.getAttribute( 'aria-hidden' ) ).to.equal( 'true' );
     } );
   } );
 } );


### PR DESCRIPTION
Slowly increasing code coverage and preparing to do some cleaning in the Multiselect. The expand/collapse functionality will need to be tweaked to be testable, due to the aspects of jsdom, it's difficult to test for changes triggered by focus.

## Additions

- Added tests!

## Removals

- Removed unnecessary functions that were previously replaced by string utilities

## Testing

- `gulp test:unit:scripts`

## Review

- @anselmbradford 
- @sebworks 

## Todos

- Rewrite the expand/collapse functionality to remove the dependency on `focus`

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)