### PR TITLE
Removes unused fnBind

### DIFF
--- a/cfgov/unprocessed/js/modules/util/fn-bind.js
+++ b/cfgov/unprocessed/js/modules/util/fn-bind.js
@@ -5,19 +5,25 @@
 
    - https://raw.githubusercontent.com/Modernizr/Modernizr/
      74655c45ad2cd05c002e4802cdd74cba70310f08/src/fnBind.js
+
+   Polyfill for BlackBerry 7. IE8- gets a simplified no-js page.
+   To test whether the polyfill is needed by a particular browser,
+   the following code can temporarily be placed in the document <head>:
+
+   alert( typeof Function.prototype.bind == 'function' );
    ========================================================================== */
 
 'use strict';
 
 
 /**
-* Function.Bind polyfill.
+* Function.prototype.bind polyfill.
 *
 * @access private
 * @function fnBind
-* @param {function} fn - a function you want to change `this` reference to
-* @param {Object} context - the `this` you want to call the function with
-* @returns {function} The wrapped version of the supplied function
+* @param {Function} fn - A function you want to change `this` reference to.
+* @param {Object} context - The `this` you want to call the function with.
+* @returns {Function} The wrapped version of the supplied function.
 */
 function fnBind( fn, context ) {
   return function() {

--- a/gulp/tasks/scripts.js
+++ b/gulp/tasks/scripts.js
@@ -26,9 +26,7 @@ function scriptsPolyfill() {
   return gulp.src( paths.unprocessed + '/js/routes/common.js' )
     .pipe( gulpModernizr( {
       tests:   [ 'csspointerevents', 'classlist', 'es5' ],
-      options: [ 'setClasses',
-                 'html5printshiv',
-                 'fnBind' ]
+      options: [ 'setClasses', 'html5printshiv' ]
     } ) )
     .pipe( gulpUglify() )
     .pipe( gulpRename( 'modernizr.min.js' ) )


### PR DESCRIPTION
## Changes

- Removes unsupported fnBind (see https://github.com/Modernizr/Modernizr/pull/1278) from Modernizr.

## Review

- @sebworks 
- @jimmynotjim 