### PR TITLE
Updates meta descriptions

### DIFF
--- a/cfgov/jinja2/v1/about-us/careers/application-process/index.html
+++ b/cfgov/jinja2/v1/about-us/careers/application-process/index.html
@@ -9,7 +9,7 @@
 {%- endblock %}
 
 {% block desc -%}
-    {# TODO: Add page meta description. #}
+    Information on careers at the CFPB.
 {%- endblock %}
 
 {% block content_modifiers -%}

--- a/cfgov/jinja2/v1/about-us/careers/index.html
+++ b/cfgov/jinja2/v1/about-us/careers/index.html
@@ -7,7 +7,7 @@
 {%- endblock %}
 
 {% block desc -%}
-    {# TODO: Add page meta description. #}
+    Information on careers at the CFPB.
 {%- endblock %}
 
 {% block content_main_modifiers -%}

--- a/cfgov/jinja2/v1/about-us/careers/students-and-graduates/index.html
+++ b/cfgov/jinja2/v1/about-us/careers/students-and-graduates/index.html
@@ -8,7 +8,7 @@
 {%- endblock %}
 
 {% block desc -%}
-    {# TODO: Add page meta description. #}
+    Information on careers at the CFPB.
 {%- endblock %}
 
 {% block content_modifiers -%}

--- a/cfgov/jinja2/v1/about-us/the-bureau/index.html
+++ b/cfgov/jinja2/v1/about-us/the-bureau/index.html
@@ -7,7 +7,7 @@
 {%- endblock %}
 
 {% block desc -%}
-    Information on the leadership, structure, and history of the CFPB
+    Information on the leadership, structure, and history of the CFPB.
 {%- endblock %}
 
 {% block content_modifiers -%}


### PR DESCRIPTION
Careers meta descriptions had TODOs for some pages. This makes them all have the same description (text taking from an existing description). 

## Changes

- Adds meta description for careers pages that were missing it.
- ~~Fixes issue where homepage meta description would have a large gap of spaces after a comma.~~

## Testing

- View `<head>` source on homepage and on careers pages.

## Review

- @Scotchester 
- @schaferjh 
- @jimmynotjim 
- @sebworks 

## Notes

- @schaferjh We had this careers meta description already in some of the careers pages, but I'm not sure if the content needs approval? It could show up in search engine results I think.
