### PR TITLE
Fix for empty h3 tag on home page

### DIFF
--- a/cfgov/jinja2/v1/_includes/molecules/half-width-link-blob.html
+++ b/cfgov/jinja2/v1/_includes/molecules/half-width-link-blob.html
@@ -25,7 +25,7 @@
 {% from 'molecules/info-unit.html' import info_unit with context %}
 
 {{ info_unit( {
-    'heading': '<h3>' ~ value.heading ~ '</h3>',
+    'heading': '<h3>' ~ value.heading ~ '</h3>' if value.heading else '',
     'body':    value.body,
     'links':   value.links
 } ) }}


### PR DESCRIPTION
Fix for empty `h3` tag on home page

## Changes

- Added conditional statement to pass in empty string when `value.heading` is empty.

## Testing

- Add a `Half Width Blob` to the homepage via admin ( leave the heading field blank ).
- Visit `http://localhost:8000/` and view source.  Find `m-info-unit_content` and observe it doesn't contain an empty `h3` tag. 

## Review

- @Scotchester 
- @rosskarchner 

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)