### PR TITLE
Make further reading and list filter results distinct

### DIFF
--- a/cfgov/v1/models/base.py
+++ b/cfgov/v1/models/base.py
@@ -153,7 +153,7 @@ class CFGOVPage(Page):
         for parent_slug, search_type, search_type_name, search_query in search_types:
             try:
                 parent = Page.objects.get(slug=parent_slug)
-                search_query &= Page.objects.descendant_of_q(parent)
+                search_query &= Page.objects.child_of_q(parent)
                 if 'specific_categories' in block.value:
                     specific_categories = ref.related_posts_category_lookup(block.value['specific_categories'])
                     choices = [c[0] for c in ref.choices_for_page_type(parent_slug)]
@@ -164,7 +164,7 @@ class CFGOVPage(Page):
                     try:
                         parent_slug = 'archive-past-events'
                         parent = Page.objects.get(slug=parent_slug)
-                        q = (Page.objects.descendant_of_q(parent) & query)
+                        q = (Page.objects.child_of_q(parent) & query)
                         if 'specific_categories' in block.value:
                             specific_categories = ref.related_posts_category_lookup(block.value['specific_categories'])
                             choices = [c[0] for c in ref.choices_for_page_type(parent_slug)]
@@ -182,7 +182,7 @@ class CFGOVPage(Page):
                     and block.value['relate_%s' % search_type]:
                 related[search_type_name] = \
                     AbstractFilterPage.objects.live_shared(hostname).filter(
-                        queries[search_type_name]).order_by('-date_published')[:block.value['limit']]
+                        queries[search_type_name]).distinct().order_by('-date_published')[:block.value['limit']]
 
         # Return a dictionary of lists of each type when there's at least one
         # hit for that type.

--- a/cfgov/v1/models/base.py
+++ b/cfgov/v1/models/base.py
@@ -182,7 +182,8 @@ class CFGOVPage(Page):
                     and block.value['relate_%s' % search_type]:
                 related[search_type_name] = \
                     AbstractFilterPage.objects.live_shared(hostname).filter(
-                        queries[search_type_name]).distinct().order_by('-date_published')[:block.value['limit']]
+                        queries[search_type_name]).distinct().exclude(
+                        id=self.id).order_by('-date_published')[:block.value['limit']]
 
         # Return a dictionary of lists of each type when there's at least one
         # hit for that type.

--- a/cfgov/v1/models/browse_filterable_page.py
+++ b/cfgov/v1/models/browse_filterable_page.py
@@ -97,7 +97,7 @@ class NewsroomLandingPage(BrowseFilterablePage):
             except base.CFGOVPage.DoesNotExist:
                 print 'Blog does not exist'
 
-        return AbstractFilterPage.objects.live_shared(hostname).filter(newsroom_q | blog_q).order_by('-date_published')
+        return AbstractFilterPage.objects.live_shared(hostname).filter(newsroom_q | blog_q).distinct().order_by('-date_published')
 
 
     def get_form_class(self):

--- a/cfgov/v1/models/sublanding_filterable_page.py
+++ b/cfgov/v1/models/sublanding_filterable_page.py
@@ -97,7 +97,7 @@ class ActivityLogPage(SublandingFilterablePage):
         # AND all selected queries together
         final_q = reduce(lambda x,y: x|y, queries.values())
 
-        return AbstractFilterPage.objects.live_shared(hostname).filter(final_q).order_by('-date_published')
+        return AbstractFilterPage.objects.live_shared(hostname).filter(final_q).distinct().order_by('-date_published')
 
 
     def get_form_class(self):

--- a/cfgov/v1/util/filterable_context.py
+++ b/cfgov/v1/util/filterable_context.py
@@ -68,7 +68,7 @@ def get_form_specific_filter_data(page, form_class, request_dict):
 # Returns a queryset of AbstractFilterPages
 def get_page_set(page, form, hostname):
     return AbstractFilterPage.objects.live_shared(hostname).child_of(
-        page).filter(form.generate_query()).order_by('-date_published')
+        page).filter(form.generate_query()).distinct().order_by('-date_published')
 
 
 def has_active_filters(page, request, index):


### PR DESCRIPTION
Duplicate results are showing up in the Further Reading sections of pages. The same type of queries are happening on the filterable lists, so it's possible that it's happening there (though not observed yet).

Also, `descendant_of_q` is changed to `child_of_q`to prevent undesired results.

## Additions

- `.distinct()` to queries to return unique rows in the results

## Testing

#### Before checking out the branch

- Go into wagtail to make a new page
- Add a Related Posts molecule to the Sidefoot with specified categories `Data, research, & reports` and `Press release`
- Add the tags to the page: `Academic research council`, `Research`, and `Payday loans`
- Publish and go to the page
- View repeated results

#### After checking out the branch

- Go to your page and see unique results

## Review

- @richaagarwal 
- @rosskarchner 
- @kave 

