### PR TITLE
Adding Fix for GTM on subnav items

### DIFF
--- a/cfgov/jinja2/v1/_includes/organisms/mega-menu.html
+++ b/cfgov/jinja2/v1/_includes/organisms/mega-menu.html
@@ -66,7 +66,8 @@
                   {{ _classes( nav_depth, '-link__has-children' ) if nav_children | count > 0 else '' }}
                   {{ _classes( nav_depth, '-link__current' ) if nav_url == request.path else '' }}"
            {{ '' if nav_url == '' else 'href=' + nav_url | e }}
-           {{ 'data-js-hook=flyout-menu_trigger' if nav_children | count > 0 else '' }}>
+           {{ 'data-js-hook=flyout-menu_trigger' if nav_children | count > 0 else '' }}
+           data-gtm_ignore="true">
             {{ nav_caption }}
         </a>
         {% if nav_children | count > 0 %}


### PR DESCRIPTION
Adds GTM ignore attribute to subnavs items in Jinja 

## Review

- @Scotchester 

## Notes

We currently add the ignore attribute via JS but unsure why.

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)

