### PR TITLE
Add Wand for animated gif handling

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -21,3 +21,4 @@ beautifulsoup4==4.4.1
 django-overextends==0.4.1
 django-reversion==1.10.1
 django-tinymce==2.2.0
+Wand==0.4.2


### PR DESCRIPTION
Animated gifs are supported for use in Wagtail, but you must follow Wand's [installation instructions](http://docs.wand-py.org/en/0.4.2/guide/install.html) to get it working.

## Additions

- Wand

## Testing

- go through the installation instructions to install ImageMagick
- `pip install -r requirements/base.txt`
- find a gif and upload it. add it to a page to see it in action

## Review

- @richaagarwal 
- @kave 
- @rosskarchner 

## Todos

- the servers need to install `ImageMagick` before this can work
