### PR TITLE
Handle govdelivery job subscriptions via a Django form

### DIFF
--- a/cfgov/jobmanager/static/jobmanager/js/supervision.js
+++ b/cfgov/jobmanager/static/jobmanager/js/supervision.js
@@ -39,7 +39,7 @@ $(document).ready(function(){
         
         $.ajax({
             type: "POST", 
-            url: "/jobs/submit-govdelivery/",
+            url: "/subscriptions/new/",
             data: form.serialize(),
             complete: function(req, status_msg) {
                 if(status_msg == 'success')

--- a/cfgov/jobmanager/urls.py
+++ b/cfgov/jobmanager/urls.py
@@ -9,7 +9,6 @@ urlpatterns = patterns(
     url(r'^$', 'index', name='jobs'),
     url(r'^current-openings/$', 'current_openings', name='current_openings'),
 
-    url(r'^submit-govdelivery/$', 'submit_govdelivery', name='jobs_submit-govdelivery'),
     url(r'application-process',
         TemplateView.as_view(template_name='about-us/careers/application-process/index.html')),
     url(r'working-at-cfpb/$',


### PR DESCRIPTION
Lamin pointed out that we need to clean the parameters passed to the govdelivery subscription urls.

## Changes

- govdelivery jobs subscription view now require post requests
- reuse the core/views.py subscribe view

## Testing

- cd into django-cfgov-common and pull down [GHE]/CFPB/django-cfgov-common/pull/81
- cd back into cfgov-refresh and pull this PR down
- Go to `http://localhost:8000/jobs/supervision/` and enter an email and subscribe. Success message is expected!

## Review

- @rosskarchner 
- @richaagarwal 
- @kave 
