### PR TITLE
Add tests for external/internal link handling

### DIFF
--- a/cfgov/v1/tests.py
+++ b/cfgov/v1/tests.py
@@ -1,3 +1,0 @@
-from django.test import TestCase
-
-# Create your tests here.

--- a/cfgov/v1/tests/test_links.py
+++ b/cfgov/v1/tests/test_links.py
@@ -1,0 +1,27 @@
+from django.test import TestCase
+from v1 import parse_links
+from bs4 import BeautifulSoup
+
+class ImportDataTest(TestCase):
+    def test_external_link(self):
+        soup = BeautifulSoup('<a href="https://wwww.google.com">external link/a>', 'html.parser')
+        output = str(parse_links(soup))
+        self.assertIn('external-site', output)
+        self.assertIn('class="icon-link_text"', output)
+
+    def test_cfpb_link(self):
+        soup = BeautifulSoup('<a href="http://www.consumerfinance.gov/foo">cfpb link</a>', 'html.parser')
+        output = str(parse_links(soup))
+        self.assertNotIn('external-site', output)
+        self.assertNotIn('class="icon-link_text"', output)
+
+    def test_gov_link(self):
+        soup = BeautifulSoup('<a href="http://www.fdic.gov/bar">gov link</a>', 'html.parser')
+        output = str(parse_links(soup))
+        self.assertNotIn('external-site', output)
+        self.assertIn('class="icon-link_text"', output)
+
+
+if __name__ == '__main__':
+    unittest.main()
+


### PR DESCRIPTION
This adds unit tests for the way we handle external and non CFPB links, functionality for which can be found in `cfgov/v1/__init__.py`.  

I removed `cfgov/v1/tests.py` since it was not being used and does not match the structure we're using elsewhere for unit tests.

To test, run `tox` (I don't know of a way that runs the test individually (that actually works), but if you know of a way, please comment!)

@rosskarchner 
@kave 
@kurtw 