### PR TITLE
Removing cf-expandable and jquery easing

### DIFF
--- a/TERMS.md
+++ b/TERMS.md
@@ -53,8 +53,6 @@ author or the affirmer.
   et al., is licensed under MIT/GPL2.
 - [jQuery](http://jquery.com/) by The jQuery Foundation is licensed under the
   MIT License.
-- [jQuery Easing](http://gsgd.co.uk/sandbox/jquery/easing/) by George McGinley
-  Smith is licensed under the BSD License.
 - [Modernizr](https://github.com/Modernizr/Modernizr) by Faruk Ateş, et al.,
   is licensed under MIT License.
 - [Normalize](http://necolas.github.io/normalize.css/) by Nicolas Gallagher,

--- a/cfgov/unprocessed/js/routes/common.js
+++ b/cfgov/unprocessed/js/routes/common.js
@@ -6,8 +6,6 @@
 
 // Vendor libraries.
 require( 'jquery' );
-require( 'jquery-easing' );
-require( 'cf-expandables' );
 
 // Global modules.
 require( '../modules/focus-target' ).init();

--- a/package.json
+++ b/package.json
@@ -68,8 +68,6 @@
     "es5-sham": "./node_modules/es5-shim/es5-sham.min.js",
     "handlebars": "./node_modules/handlebars/dist/handlebars.min.js",
     "jquery": "./node_modules/jquery/dist/jquery.js",
-    "jquery-easing": "./node_modules/capital-framework/node_modules/jquery.easing/jquery.easing.js",
-    "cf-expandables": "./node_modules/capital-framework/src/cf-expandables/src/cf-expandables.js",
     "slick": "./vendor/slick-carousel/slick/slick.js",
     "validate": "./node_modules/validate.js/validate.js"
   },


### PR DESCRIPTION
We no longer use `cf-expandable` or `JQuery easing` so I'm removing them. This is a move toward elimination of all external JS libraries and frameworks. 

## Testing

- Run `npm install && bower install && gulp build`. Visit the site and browse; shouldn't see any errors in the console.

## Review

- @anselmbradford 
- @Scotchester 

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
