### PR TITLE
Adds task to generate JS docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,8 +75,9 @@ vendor/
 ############
 .floo*
 
-# Topdoc #
+# Documentation #
 ##########
+docs/scripts
 docs/*/slick.html
 docs/*/pdfreactor-fonts.html
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 
 ## Added
 
+- Frontend: Added task for generating JavaScript code docs with `gulp docs`.
+
 ### Changes
 - Check against Activity Log topics when generating View More link
 

--- a/README.md
+++ b/README.md
@@ -185,6 +185,7 @@ The important ones are listed below:
 gulp build           # Concatenate, optimize, and copy source files to the production /dist/ directory.
 gulp clean           # Remove the contents of the production /dist/ directory.
 gulp lint            # Lint the scripts and build files.
+gulp docs            # Generate JSDocs from the scripts.
 gulp test            # Run linting, unit and acceptance tests (see below).
 gulp test:unit       # Run only unit tests on source code.
 gulp test:acceptance # Run only acceptance (in-browser) tests on production code.

--- a/gulp/tasks/docs.js
+++ b/gulp/tasks/docs.js
@@ -1,0 +1,35 @@
+'use strict';
+
+var configScripts = require( '../config' ).scripts;
+var fsHelper = require( '../utils/fs-helper' );
+var glob = require( 'glob' );
+var gulp = require( 'gulp' );
+var plugins = require( 'gulp-load-plugins' )();
+var spawn = require( 'child_process' ).spawn;
+
+// TODO: Update this to support grouping methods by class in the generated docs.
+/**
+ * Generate scripts documentation.
+ */
+function docsScripts() {
+  glob( configScripts.src, function( er, files ) {
+    var options = [ 'build' ].concat( files ).concat(
+                  [ '--github',
+                    '--output=docs/scripts',
+                    '--format=html' ] );
+    spawn(
+    fsHelper.getBinary( 'documentation', 'documentation.js' ),
+      options, { stdio: 'inherit' }
+    ).once( 'close', function() {
+      plugins.util.log( 'Scripts documentation generated!' );
+    } );
+  } );
+}
+
+gulp.task( 'docs:scripts', docsScripts );
+
+gulp.task( 'docs',
+  [
+    'docs:scripts'
+  ]
+);

--- a/gulp/tasks/test.js
+++ b/gulp/tasks/test.js
@@ -149,7 +149,7 @@ function _parsePath( urlPath ) {
  */
 function testA11y() {
   spawn(
-    fsHelper.getBinary( 'wcag', '.bin' ),
+    fsHelper.getBinary( 'wcag', 'wcag', '../.bin' ),
     _getWCAGParams(),
     { stdio: 'inherit' }
   ).once( 'close', function() {
@@ -178,7 +178,7 @@ function _shouldInstallInitialData() {
  */
 function _spawnProtractor() {
   spawn(
-    fsHelper.getBinary( 'protractor' ),
+    fsHelper.getBinary( 'protractor', 'protractor', '../bin/' ),
     _getProtractorParams(),
     { stdio: 'inherit' }
   ).once( 'close', function() {

--- a/gulp/utils/fs-helper.js
+++ b/gulp/utils/fs-helper.js
@@ -4,19 +4,21 @@ var path = require( 'path' );
 
 /**
  * Retrieve a reference path to a binary.
- * @param {string} binaryName The name of the binary to retrieve.
- * @param {string} binaryDir The name of the binary directory to use.
+ * @param {string} packageName - The name of the software package.
+ * @param {string} [binaryName] - The name of the binary to retrieve.
+ *   Same as the package name by default.
+ * @param {string} [binaryDir] - The name of the binary directory to use.
  *   `bin` by default.
  * @returns {string} Path to the binary to run.
  */
-function getBinary( binaryName, binaryDir ) {
+function getBinary( packageName, binaryName, binaryDir ) {
+  binaryName = binaryName || packageName;
   binaryDir = binaryDir || 'bin';
-  var winExt = ( /^win/ ).test( process.platform ) ? '.cmd' : '';
-  var pkgPath = require.resolve( binaryName );
+  var pkgPath = require.resolve( packageName );
   binaryDir = path.resolve(
-    path.join( path.dirname( pkgPath ), '..', binaryDir )
+    path.join( path.dirname( pkgPath ), binaryDir, '/' + binaryName )
   );
-  return path.join( binaryDir, '/' + binaryName + winExt );
+  return binaryDir;
 }
 
 module.exports = {

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "browser-sync": "2.11.2",
     "cf-component-demo": "git://github.com/cfpb/cf-component-demo.git#0.8.2",
     "chai": "3.5.0",
+    "documentation": "4.0.0-beta2",
     "es5-shim": "4.5.7",
     "glob-all": "3.0.1",
     "gulp-concat": "2.6.0",


### PR DESCRIPTION
Put together while traveling. Adds initial ability to generate docs from code jsdocs.

## Additions

- Adds `gulp docs` task to generate code docs for JavaScript.

## Testing

- `./frontend.sh`
- `gulp docs`
- open html page in `docs/scripts/index.html`

## Review

- @sebworks 
- @Scotchester 

## Screenshots

![screen shot 2016-04-28 at 10 28 53 am](https://cloud.githubusercontent.com/assets/704760/14889288/3bbaad22-0d2c-11e6-946a-20c98f2e7112.png)