### PR TITLE
Ensure files uploaded as .PDFs get a download icon as well

### DIFF
--- a/cfgov/unprocessed/css/misc.less
+++ b/cfgov/unprocessed/css/misc.less
@@ -737,7 +737,7 @@
     - cfgov-misc
 */
 
-
+a[href$='.PDF']:after,
 a[href$='.pdf']:after,
 a[href$='.doc']:after,
 a[href$='.docx']:after,


### PR DESCRIPTION
This takes care of the issue on http://www.consumerfinance.gov/policy-compliance/guidance/implementation-guidance/title-xiv-mortgage-rules/ where there are a couple pdfs with a .PDF (rather than .pdf) extension.  

This is a quick fix - Longer-term we probably want to lowercase these as part of the upload process.

To test locally, get the latest refresh dump, run `gulp build`, and ensure all the download icons are in place here: [http://localhost:8000/policy-compliance/guidance/implementation-guidance/title-xiv-mortgage-rules/](http://localhost:8000/policy-compliance/guidance/implementation-guidance/title-xiv-mortgage-rules/)

@kave 
@kurtw 
@rosskarchner 