### PR TITLE
Allow init_command to be set by env

### DIFF
--- a/cfgov/cfgov/settings/local.py
+++ b/cfgov/cfgov/settings/local.py
@@ -11,7 +11,7 @@ DATABASES = {
         'PASSWORD': os.environ.get('MYSQL_PW', ''),
         'HOST': os.environ.get('MYSQL_HOST', ''),  # empty string == localhost
         'PORT': os.environ.get('MYSQL_PORT', ''),  # empty string == default
-        'OPTIONS': {'init_command': 'SET storage_engine=MYISAM', },
+        'OPTIONS': {'init_command': os.environ.get('STORAGE_ENGINE', 'SET storage_engine=MYISAM') },
     },
 }
 


### PR DESCRIPTION
I need `default_storage_engine` in my setup, and maybe others do too? 

If you need `storage_engine`, it's set to that by default, but double-check `STORAGE_ENGINE` is not being set to anything else in your `.env`

Testing:  Make sure you can still run the app

@kave 
@kurtw 
@rosskarchner 