### PR TITLE
Removing Multiselect from common.js

### DIFF
--- a/cfgov/unprocessed/js/organisms/FilterableListControls.js
+++ b/cfgov/unprocessed/js/organisms/FilterableListControls.js
@@ -4,6 +4,7 @@
 var atomicHelpers = require( '../modules/util/atomic-helpers' );
 var ERROR_MESSAGES = require( '../config/error-messages-config' );
 var getClosestElement = require( '../modules/util/dom-traverse' ).closest;
+var Multiselect = require( '../molecules/Multiselect' );
 var Notification = require( '../molecules/Notification' );
 var validators = require( '../modules/util/validators' );
 
@@ -44,6 +45,8 @@ function FilterableListControls( element ) {
   function init( ) {
     _notification = new Notification( _dom );
     _notification.init();
+
+    atomicHelpers.instantiateAll( 'select[multiple]', Multiselect );
 
     _initEvents();
   }

--- a/cfgov/unprocessed/js/routes/common.js
+++ b/cfgov/unprocessed/js/routes/common.js
@@ -22,14 +22,3 @@ header.init( document.body.querySelector( '.a-overlay' ) );
 
 var Footer = require( '../organisms/Footer.js' );
 var footer = new Footer( document.body ).init();
-
-// Multi-select.
-// TODO: Move to browse-filterable route after old WP pages are removed
-var Multiselect = require( '../molecules/Multiselect' );
-var selects = document.querySelectorAll( 'select[multiple]' );
-
-var multiselect;
-for ( var i = 0, len = selects.length; i < len; i++ ) {
-  multiselect = new Multiselect( selects[i] );
-  multiselect.init();
-}


### PR DESCRIPTION
All sheer pages should be using the `FilterableListControl` so I'm moving the `Multiselect` out of `common.js`. 

## Changes

- Moved code from `common.js` to `FilterableListControl.js`.

## Testing

- Run gulp build and visit the blog. Expand the filter and use the Multiselect. It should function without error

## Review

- @anselmbradford 

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)

