### PR TITLE
refactored form to use USZipCodeField() inorder to not strip leading zeros

### DIFF
--- a/cfgov/legacy/forms.py
+++ b/cfgov/legacy/forms.py
@@ -1,5 +1,6 @@
 from django import forms
+from localflavor.us.forms import USZipCodeField
 
 
 class HousingCounselorForm(forms.Form):
-    zip = forms.IntegerField(label='Zipcode', max_value=99999)
+    zip = USZipCodeField()


### PR DESCRIPTION
@rosskarchner @kurtw 

This resolves issues with people entering correct zipcodes with leading `0`'s but pdfreactor was stripping them on the backend.
