### PR TITLE
Adds No Fear Act link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 ### Added
 
 ### Changed
+- Frontend: Added No Fear Act link to footer.
 
 ### Removed
 

--- a/cfgov/jinja2/v1/_includes/organisms/footer.html
+++ b/cfgov/jinja2/v1/_includes/organisms/footer.html
@@ -82,6 +82,11 @@
                             Digital Privacy Policy
                         </a>
                     </li>
+                    <li class="list_item">
+                        <a class="list_link" href="/open-government/">
+                            Open Government
+                        </a>
+                    </li>
                 </ul>
             </div>
             <div class="o-footer_col">
@@ -97,8 +102,8 @@
                         </a>
                     </li>
                     <li class="list_item">
-                        <a class="list_link" href="/open-government/">
-                            Open Government
+                        <a class="list_link" href="/office-civil-rights/no-fear-act/">
+                            No FEAR Act Data
                         </a>
                     </li>
                     <li class="list_item">


### PR DESCRIPTION
## Changes

- Adds No Fear link to footer.

## Testing

- Visit any page and it should have No Fear Act link in the footer links. @Scotchester / @rosskarchner - this should update it across the site through the global_include, is that right?

## Review

- @sebworks 
- @schaferjh 

## Screenshots

![screen shot 2016-04-29 at 12 58 10 pm](https://cloud.githubusercontent.com/assets/704760/14923238/108b8dd6-0e0a-11e6-80ed-1e9638a04bc6.png)
