### PR TITLE
Password policy testing

### DIFF
--- a/cfgov/v1/auth_forms.py
+++ b/cfgov/v1/auth_forms.py
@@ -1,0 +1,132 @@
+import time
+from datetime import timedelta
+
+from django.contrib.auth.forms import (PasswordChangeForm, PasswordResetForm,
+                                       SetPasswordForm)
+
+from django.contrib.auth import authenticate
+from django.contrib.auth import get_user_model
+from django.utils import timezone
+from django.conf import settings
+from django.core.exceptions import ValidationError, ObjectDoesNotExist
+
+from wagtail.wagtailadmin import forms as wagtail_adminforms
+from wagtail.wagtailusers.forms import UserCreationForm, UserEditForm
+
+from .models import base
+from .util import password_policy
+
+
+class PasswordValidationMixin(object):
+    password_key = 'new_password'
+    user_attribute = 'user'
+
+    def clean(self):
+        cleaned_data = super(PasswordValidationMixin, self).clean()
+        user = getattr(self, self.user_attribute)
+        key1, key2 = (self.password_key + '1', self.password_key + '2')
+        if key1 in cleaned_data and key2 in cleaned_data:
+            password = cleaned_data[key1]
+
+            password_policy._check_passwords(password, user, password_field = key1)
+        return cleaned_data
+
+class UserEditValidationMixin(PasswordValidationMixin):
+    password_key = 'password'
+    user_attribute = 'instance'
+
+
+class CFGOVUserCreationForm(UserEditValidationMixin, UserCreationForm):
+    pass
+
+
+class CFGOVUserEditForm(UserEditValidationMixin, UserEditForm):
+    pass
+
+
+class CFGOVPasswordChangeForm(PasswordValidationMixin, PasswordChangeForm):
+    pass
+
+
+class CFGOVPasswordResetForm(PasswordValidationMixin, PasswordResetForm):
+    pass
+
+
+class CFGOVSetPasswordForm(PasswordValidationMixin, SetPasswordForm):
+    pass
+
+
+class LoginForm(wagtail_adminforms.LoginForm):
+
+    def clean(self):
+        username = self.cleaned_data.get('username')
+        password = self.cleaned_data.get('password')
+
+        if username and password:
+            self.user_cache = authenticate(username=username,
+                                           password=password)
+
+            if (self.user_cache is None and username is not None):
+                UserModel = get_user_model()
+
+                try:
+                    user = UserModel._default_manager.get(
+                            username=username)
+                except ObjectDoesNotExist:
+                    raise ValidationError(
+                        self.error_messages['invalid_login'],
+                        code='invalid_login',
+                        params={'username':
+                                self.username_field.verbose_name
+                                },
+                    )
+
+                # fail fast if user is already blocked for some other
+                # reason
+                self.confirm_login_allowed(user)
+
+                fa, created = base.FailedLoginAttempt.objects.\
+                    get_or_create(user=user)
+                now = time.time()
+                fa.failed(now)
+                # Defaults to a 2 hour lockout for a user
+                time_period = now - int(settings.LOGIN_FAIL_TIME_PERIOD)
+                attempts_allowed = int(settings.LOGIN_FAILS_ALLOWED)
+                attempts_used = len(fa.failed_attempts.split(','))
+
+                if fa.too_many_attempts(attempts_allowed, time_period):
+                    dt_now = timezone.now()
+                    lockout_expires = dt_now + timedelta(seconds=settings.LOGIN_FAIL_TIME_PERIOD)
+                    lockout = user.temporarylockout_set.create(expires_at=lockout_expires)
+                    lockout.save()
+                    raise ValidationError("This account is temporarily locked; please try later or <a href='/admin/password_reset/' style='color:white;font-weight:bold'>reset your password</a>")
+                else:
+                    fa.save()
+                    raise ValidationError('Login failed. %s more attempts until your account will be temporarily locked.' % (attempts_allowed-attempts_used))
+
+            else:
+                self.confirm_login_allowed(self.user_cache)
+
+                dt_now = timezone.now()
+                try:
+                    current_password_data = self.user_cache.passwordhistoryitem_set.latest()
+
+                    if dt_now > current_password_data.expires_at:
+                        raise ValidationError("This account is temporarily locked; please try later or <a href='/admin/password_reset/' style='color:white;font-weight:bold'>reset your password</a>")
+
+                except ObjectDoesNotExist:
+                    pass
+
+                return self.cleaned_data
+
+    def confirm_login_allowed(self, user):
+        super(LoginForm, self).confirm_login_allowed(user)
+        now = timezone.now()
+
+        lockout_query = user.temporarylockout_set.filter(expires_at__gt=now)
+
+        if lockout_query.count() > 0 :
+            raise ValidationError("This account is temporarily locked; please try later or <a href='/admin/password_reset/' style='color:white;font-weight:bold'>reset your password</a>")
+
+
+

--- a/cfgov/v1/forms.py
+++ b/cfgov/v1/forms.py
@@ -6,11 +6,6 @@ from util import ERROR_MESSAGES
 from django import forms
 from django.db.models import Q
 from django.forms.utils import ErrorList
-from django.contrib.auth import get_user_model
-from django.utils import timezone
-from django.core.exceptions import ValidationError, ObjectDoesNotExist
-from django.contrib.auth import authenticate
-from django.conf import settings
 from django.forms import widgets
 from taggit.models import Tag
 
@@ -18,89 +13,6 @@ from .util import ref
 from .models.base import CFGOVPage
 from .util.util import most_common
 
-
-# importing wagtail.wagtailadmin.forms at module load time seems to have
-# caused some trouble with the translation subsystem being invoked before
-# it's ready-- so I've wrapped it in a function
-def login_form():
-    from wagtail.wagtailadmin import forms as wagtail_adminforms
-
-    from .models import base
-
-    class LoginForm(wagtail_adminforms.LoginForm):
-
-        def clean(self):
-            username = self.cleaned_data.get('username')
-            password = self.cleaned_data.get('password')
-
-            if username and password:
-                self.user_cache = authenticate(username=username,
-                                               password=password)
-
-                if (self.user_cache is None and username is not None):
-                    UserModel = get_user_model()
-
-                    try:
-                        user = UserModel._default_manager.get(
-                                username=username)
-                    except ObjectDoesNotExist:
-                        raise forms.ValidationError(
-                            self.error_messages['invalid_login'],
-                            code='invalid_login',
-                            params={'username':
-                                    self.username_field.verbose_name
-                                    },
-                        )
-
-                    # fail fast if user is already blocked for some other
-                    # reason
-                    self.confirm_login_allowed(user)
-
-                    fa, created = base.FailedLoginAttempt.objects.\
-                        get_or_create(user=user)
-                    now = time.time()
-                    fa.failed(now)
-                    # Defaults to a 2 hour lockout for a user
-                    time_period = now - int(settings.LOGIN_FAIL_TIME_PERIOD)
-                    attempts_allowed = int(settings.LOGIN_FAILS_ALLOWED)
-                    attempts_used = len(fa.failed_attempts.split(','))
-
-                    if fa.too_many_attempts(attempts_allowed, time_period):
-                        dt_now = timezone.now()
-                        lockout_expires = dt_now + timedelta(seconds=settings.LOGIN_FAIL_TIME_PERIOD)
-                        lockout = user.temporarylockout_set.create(expires_at=lockout_expires)
-                        lockout.save()
-                        raise ValidationError("This account is temporarily locked; please try later or <a href='/admin/password_reset/' style='color:white;font-weight:bold'>reset your password</a>")
-                    else:
-                        fa.save()
-                        raise ValidationError('Login failed. %s more attempts until your account will be temporarily locked.' % (attempts_allowed-attempts_used))
-
-                else:
-                    self.confirm_login_allowed(self.user_cache)
-
-                    dt_now = timezone.now()
-                    try:
-                        current_password_data = self.user_cache.passwordhistoryitem_set.latest()
-
-                        if dt_now > current_password_data.expires_at:
-                            raise ValidationError("This account is temporarily locked; please try later or <a href='/admin/password_reset/' style='color:white;font-weight:bold'>reset your password</a>")
-
-                    except ObjectDoesNotExist:
-                        pass
-
-                    return self.cleaned_data
-
-        def confirm_login_allowed(self, user):
-            super(LoginForm, self).confirm_login_allowed(user)
-            now = timezone.now()
-
-            lockout_query = user.temporarylockout_set.filter(expires_at__gt=now)
-
-            if lockout_query.count() > 0 :
-                raise ValidationError("This account is temporarily locked; please try later or <a href='/admin/password_reset/' style='color:white;font-weight:bold'>reset your password</a>")
-
-
-    return LoginForm
 
 class FilterErrorList(ErrorList):
     def __str__(self):

--- a/cfgov/v1/tests/test_password_policy.py
+++ b/cfgov/v1/tests/test_password_policy.py
@@ -1,0 +1,25 @@
+from django.test import TestCase
+from django.core.exceptions import ValidationError
+
+from mock import patch
+
+from .util import password_policy
+
+PASSWORD_RULES = [
+    [r'.{12,}', 'Minimum allowed length is 12 characters'],
+    [r'[A-Z]', 'must include at least one capital letter'],
+    [r'[a-z]', 'must include at least one lowercase letter'],
+    [r'[0-9]', 'must include at least one digit'],
+    [r'[@#$%&!]', 'must include at least one special character (@#$%&!)'],
+]
+
+POLICY_SETTING = 'django.conf.settings.CFPB_COMMON_PASSWORD_RULES'
+
+
+class TestPasswordPolicy(TestCase):
+
+    @patch(POLICY_SETTING, PASSWORD_RULES)
+    def test_rules_engine(self):
+        with self.assertRaises(ValidationError):
+                password_policy.validate_password_all_rules('invalid')
+

--- a/cfgov/v1/tests/test_password_policy.py
+++ b/cfgov/v1/tests/test_password_policy.py
@@ -1,9 +1,12 @@
 from django.test import TestCase
 from django.core.exceptions import ValidationError
+from django.utils import timezone
+from django.contrib.auth.models import User
+from django.contrib.auth.hashers import make_password
 
 from mock import patch
 
-from .util import password_policy
+from ..util import password_policy
 
 PASSWORD_RULES = [
     [r'.{12,}', 'Minimum allowed length is 12 characters'],
@@ -16,10 +19,61 @@ PASSWORD_RULES = [
 POLICY_SETTING = 'django.conf.settings.CFPB_COMMON_PASSWORD_RULES'
 
 
-class TestPasswordPolicy(TestCase):
+class TestPasswordValidation(TestCase):
 
     @patch(POLICY_SETTING, PASSWORD_RULES)
-    def test_rules_engine(self):
-        with self.assertRaises(ValidationError):
-                password_policy.validate_password_all_rules('invalid')
+    def test_bad_passwords(self):
+        for password in ['T00Short!', 'no_c@pital_l3tters',
+                         'NO_LOWERCASE_L3TTERS!', '#Everything_but_digits!',
+                         'No8Special7Characters8675309', 'Tr0ub4dor&3',
+                         'correct_horse_battery_staple']:
+            with self.assertRaises(ValidationError):
+                    password_policy.validate_password_all_rules(password, 'key')
 
+    def test_good_passwords(self):
+        for password in ['1976IndyD3claration!', 'XkCd936HasAGoodPoint!']:
+            # confession: I spent a good few minutes looking for something like
+            # assertDoesNotRaise.
+            password_policy.validate_password_all_rules(password, 'key')
+
+
+class TestWithUser(TestCase):
+    def setUp(self):
+        user = User(username='testuser', password=make_password('password')) 
+        user.save()
+
+    def tearDown(self):
+        User.objects.get(username='testuser').delete()
+
+    def get_user(self):
+        return User.objects.get(username='testuser')
+
+
+class TestMinimumPasswordAge(TestWithUser):
+
+    def test_too_soon(self):
+        user = self.get_user()
+        with self.assertRaises(ValidationError):
+            password_policy.validate_password_age(user)
+
+    def test_old_enough_to_change(self):
+        user = self.get_user()
+        history_item = user.passwordhistoryitem_set.get()
+
+        current_lock_expires = history_item.locked_until
+        new_expiration = current_lock_expires.replace(year=2013)
+        history_item.locked_until = new_expiration
+        history_item.save()
+
+        password_policy.validate_password_age(user)
+
+
+class TestPasswordReusePolicy(TestWithUser):
+    def test_reuse_password(self):
+        user = self.get_user()
+        with self.assertRaises(ValidationError):
+            password_policy.validate_password_history(user, 'password')
+
+    def test_new_password(self):
+        user = self.get_user()
+        password_policy.validate_password_history(user, 'new_password')

--- a/cfgov/v1/util/password_policy.py
+++ b/cfgov/v1/util/password_policy.py
@@ -2,41 +2,40 @@ import functools
 import re
 
 from django.conf import settings
-from django.utils import timezone
 from django.contrib.auth import hashers
-from django.core.exceptions import ObjectDoesNotExist
+from django.core.exceptions import ObjectDoesNotExist, ValidationError
+from django.contrib.auth import get_user_model
+from django.utils import timezone
+from django.core.exceptions import ValidationError, ObjectDoesNotExist
+from django.conf import settings
+
+def validate_password_rule(regex, password,
+                           password_field, failure_message='invalid password'):
+    if not re.search(regex, password):
+        raise ValidationError({password_field:failure_message})
 
 
-def _check_passwords(pass1, pass2, user):
-    """ Run passwords through a set of rules """
-    data = ''
-    if pass1 != pass2:
-        data += "Passwords don't match</br>"
-    if pass1 == '':
-        data += "Blank passwords are not too secure</br>"
-    for rule in settings.CFPB_COMMON_PASSWORD_RULES:
-        if not re.search(rule[0], pass1):
-            data += (str(rule[1])+"</br>")
+def validate_password_all_rules(password, password_field):
+    for regex, rule_name in settings.CFPB_COMMON_PASSWORD_RULES:
+        validate_password_rule(regex, password, password_field, rule_name)
 
 
-    if len(data)==0: # only check this stuff if there are no failures above
-        from ..models import PasswordHistoryItem
-        try:
-            if user:
-                current_password_data = user.passwordhistoryitem_set.latest()
+def _check_passwords(password, user, password_field):
+    validate_password_all_rules(password, password_field)
+    try:
+        if user:
+            current_password_data = user.passwordhistoryitem_set.latest()
 
-                if not current_password_data.can_change_password():
-                    data += "You can not change passwords more than once" \
-                                  " in 24 hours"
-        except ObjectDoesNotExist:
-            pass
+            if not current_password_data.can_change_password():
+                raise ValidationError("You can not change passwords more"
+                                      "than once in 24 hours")
+    except ObjectDoesNotExist:
+        pass
 
-    if len(data)==0 and user:
+    if user:
         queryset = user.passwordhistoryitem_set.order_by('-created')[:10]
 
-        checker =functools.partial(hashers.check_password, pass1)
+        checker =functools.partial(hashers.check_password, password)
 
         if any([checker(pass_hist.encrypted_password) for pass_hist in queryset]):
-            data += "You may not re-use any of your last 10 passwords"
-
-    return data
+            raise ValidationError("You may not re-use any of your last 10 passwords")

--- a/cfgov/v1/util/password_policy.py
+++ b/cfgov/v1/util/password_policy.py
@@ -4,15 +4,12 @@ import re
 from django.conf import settings
 from django.contrib.auth import hashers
 from django.core.exceptions import ObjectDoesNotExist, ValidationError
-from django.contrib.auth import get_user_model
-from django.utils import timezone
-from django.core.exceptions import ValidationError, ObjectDoesNotExist
-from django.conf import settings
+
 
 def validate_password_rule(regex, password,
                            password_field, failure_message='invalid password'):
     if not re.search(regex, password):
-        raise ValidationError({password_field:failure_message})
+        raise ValidationError({password_field: failure_message})
 
 
 def validate_password_all_rules(password, password_field):
@@ -20,22 +17,30 @@ def validate_password_all_rules(password, password_field):
         validate_password_rule(regex, password, password_field, rule_name)
 
 
-def _check_passwords(password, user, password_field):
-    validate_password_all_rules(password, password_field)
+def validate_password_age(user):
     try:
-        if user:
-            current_password_data = user.passwordhistoryitem_set.latest()
+        current_password_data = user.passwordhistoryitem_set.latest()
 
-            if not current_password_data.can_change_password():
-                raise ValidationError("You can not change passwords more"
-                                      "than once in 24 hours")
+        if not current_password_data.can_change_password():
+            raise ValidationError("You can not change passwords more"
+                                  " than once in 24 hours")
     except ObjectDoesNotExist:
         pass
 
-    if user:
+
+def validate_password_history(user, password):
         queryset = user.passwordhistoryitem_set.order_by('-created')[:10]
 
-        checker =functools.partial(hashers.check_password, password)
+        checker = functools.partial(hashers.check_password, password)
 
-        if any([checker(pass_hist.encrypted_password) for pass_hist in queryset]):
-            raise ValidationError("You may not re-use any of your last 10 passwords")
+        if any([checker(pass_hist.encrypted_password)
+                for pass_hist in queryset]):
+            raise ValidationError("You may not re-use any of your last 10"
+                                  " passwords")
+
+
+def _check_passwords(password, user, password_field):
+    if user:
+        validate_password_age(user)
+        validate_password_history(user, password)
+    validate_password_all_rules(password, password_field)

--- a/tox.ini
+++ b/tox.ini
@@ -14,4 +14,5 @@ deps =
     -r{toxinidir}/requirements/test.txt
 changedir = {toxinidir}/cfgov
 commands=
-    python manage.py test
+    python manage.py test {posargs}
+    


### PR DESCRIPTION
Good: refactored the password policy code and wrote tests, and I think it is well-covered now.
Bad: created a new module, that still needs some testing.

@richaagarwal you might be interested in this little bonus: I've included a tox configuration change that allows you to invoke tox with extra arguments, that are passed on to django's test runner. For example, you can now do:

`tox -- v1.tests` to only run the tests in v1.tests 

## Testing

- `tox` or `cfgov/manage.py test` ought to do it.

## Review

- @kurtw @richaagarwal @kave 

## Screenshots


## Notes

-

## Todos

-

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
