### PR TITLE
	Fixed the spacing around info-units groups and breadcrumbs 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 ### Fixed
 
 - Fixed an issue where the header only had 15px of spacing instead of 30.
-
+- Fixed the spacing around info-units groups and breadcrumbs.
 
 ## 3.0.0-3.3.12 - 2016-05-05
 

--- a/cfgov/jinja2/v1/_includes/organisms/half-width-link-blob-group.html
+++ b/cfgov/jinja2/v1/_includes/organisms/half-width-link-blob-group.html
@@ -1,5 +1,8 @@
+
 <div class="o-info-unit-group" data-qa-hook="half-width-link-blob">
+    {% if value.heading %}
     <h2>{{ value.heading }}</h2>
+    {% endif %}
 
     <div class="content-l">
         {% for block in value.link_blobs %}

--- a/cfgov/jinja2/v1/_includes/organisms/image-text-25-75-group.html
+++ b/cfgov/jinja2/v1/_includes/organisms/image-text-25-75-group.html
@@ -1,5 +1,7 @@
 <div class="o-info-unit-group" data-qa-hook="image-text-25-75">
+    {% if value.heading %}
     <h2>{{ value.heading }}</h2>
+    {% endif %}
 
     <div class="content-l">
       {% for block in value.image_texts %}

--- a/cfgov/jinja2/v1/_includes/organisms/image-text-50-50-group.html
+++ b/cfgov/jinja2/v1/_includes/organisms/image-text-50-50-group.html
@@ -1,5 +1,8 @@
 <div class="o-info-unit-group" data-qa-hook="image-text-50-50">
+    {% if value.heading %}
     <h2>{{ value.heading }}</h2>
+    {% endif %}
+
     <div class="content-l">
       {% for block in value.image_texts %}
         <div class="content-l_col

--- a/cfgov/unprocessed/css/breadcrumbs.less
+++ b/cfgov/unprocessed/css/breadcrumbs.less
@@ -1,8 +1,8 @@
 .breadcrumbs {
-    .grid_column(1,1);
+    .grid_column( 1, 1 );
 
-    padding-top: unit(@grid_gutter-width / 14px, em);
-    font-size: unit(14px / @base-font-size-px, em);
+    padding-top: unit( @grid_gutter-width / 14px, em );
+    font-size: unit( 14px / @base-font-size-px, em );
     overflow-x: auto;
     white-space: nowrap;
 
@@ -12,28 +12,18 @@
       font-family: 'CFPB Minicons';
     }
 
-    .respond-to-max(@bp-sm-max, {
-        padding-top: unit(@grid_gutter-width / 2 / 14px, em);
-        padding-bottom: unit(@grid_gutter-width / 2 / 14px, em);
-    });
+    .respond-to-max( @bp-sm-max, {
+        padding-top: unit( @grid_gutter-width / 2 / 14px, em );
+        padding-bottom: unit( @grid_gutter-width / 2 / 14px, em );
+    } );
 
     &_link {
         padding-left: 4px;
 
-        &:not(:last-child):after {
+        &:not( :last-child ):after {
             padding-left: 4px;
             color: @text;
             content: ' /';
         }
     }
-}
-
-.breadcrumbs__main-first {
-    margin-bottom: unit(@grid_gutter-width / 2 / 14px, em);
-}
-
-.breadcrumbs__sidebar-first {
-    .respond-to-min(@bp-med-min, {
-        margin-bottom: unit(@grid_gutter-width / 2 / 14px, em);
-    });
 }


### PR DESCRIPTION
The info-unit groups were including headings even if no heading was provided and breadcrumbs had an extra margin above them that wasn't necessary. Wrapped the heading in a conditional so that it's skipped if the value doesn't exist and removed the extra margin on the breadcrumb.

## Changes

- Removed headings when there's no value for it
- Removed the extra margin on breadcrumbs

## Testing

- `gulp build` and check out http://localhost:8000/policy-compliance/rulemaking/final-rules/ for breadcrumb changes and http://localhost:8000/policy-compliance/ for 25/75 fixes

## Review

- @duelj 
- @sebworks 
- @anselmbradford 

## Screenshots

__Breadcrumbs__

<img width="1183" alt="screen shot 2016-05-03 at 5 39 55 pm" src="https://cloud.githubusercontent.com/assets/1280430/15021871/b9aeefb0-11ee-11e6-8e78-2b8a2b791c80.png">

__25/75__

<img width="1204" alt="screen shot 2016-05-03 at 5 39 34 pm" src="https://cloud.githubusercontent.com/assets/1280430/15021856/a63db632-11ee-11e6-83df-a40a195a8fb0.png">

## Notes

- This PR goes with https://github.com/cfpb/capital-framework/pull/306 for the 45px change.

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
