### PR TITLE
Adds no fear link to footer test

### DIFF
--- a/test/browser_tests/spec_suites/organisms/footer.js
+++ b/test/browser_tests/spec_suites/organisms/footer.js
@@ -10,6 +10,8 @@ describe( 'Footer', function() {
       'accessibility',
     '/office-civil-rights/':
       'office of civil rights',
+    '/office-civil-rights/no-fear-act/':
+      'no fear act data',
     '/about-us/careers/':
       'careers',
     '/foia-requests/':


### PR DESCRIPTION
Oops, forgot to include this in my No FEAR Act PR.

## Additions

- Adds no fear link to footer test.

## Testing

- `gulp test:acceptance --sauce=false` should not have a footer test failure.

## Review

- @sebworks 
- @jimmynotjim 
