### PR TITLE
Adds aria-pressed to primary flyout menu trigger

### DIFF
--- a/cfgov/jinja2/v1/_includes/organisms/mega-menu.html
+++ b/cfgov/jinja2/v1/_includes/organisms/mega-menu.html
@@ -66,7 +66,8 @@
                   {{ _classes( nav_depth, '-link__has-children' ) if nav_children | count > 0 else '' }}
                   {{ _classes( nav_depth, '-link__current' ) if nav_url == request.path else '' }}"
            {{ '' if nav_url == '' else 'href=' + nav_url | e }}
-           {{ 'data-js-hook=flyout-menu_trigger' if nav_children | count > 0 else '' }}>
+           {{ 'data-js-hook=flyout-menu_trigger' if nav_children | count > 0 else '' }}
+           {{ 'aria-pressed=false' if nav_children | count > 0 else '' }}>
             {{ nav_caption }}
         </a>
         {% if nav_children | count > 0 %}
@@ -168,7 +169,9 @@
      data-js-hook="flyout-menu"
      aria-label="main navigation"
      role="navigation">
-    <button class="{{ base_class ~ '_trigger' }}" data-js-hook="flyout-menu_trigger">
+    <button class="{{ base_class ~ '_trigger' }}"
+            data-js-hook="flyout-menu_trigger"
+            aria-pressed="false">
         <span class="u-visually-hidden">Menu</span>
     </button>
     {# Create a root menu at depth one.

--- a/cfgov/unprocessed/js/modules/FlyoutMenu.js
+++ b/cfgov/unprocessed/js/modules/FlyoutMenu.js
@@ -101,8 +101,9 @@ function FlyoutMenu( element ) { // eslint-disable-line max-statements, no-inlin
     var handleTriggerOverBinded = fnBind( _handleTriggerOver, this );
     var handleTriggerOutBinded = fnBind( _handleTriggerOut, this );
 
-    // Set initial `aria-expanded="false"` attribute.
-    _setAriaExpandedAttr( _triggerDom, 'false' );
+    // Set initial aria attributes to false.
+    _setAriaAttr( 'expanded', _triggerDom, 'false' );
+    _setAriaAttr( 'pressed', _triggerDom, 'false' );
 
     _triggerDom.addEventListener( 'click', handleTriggerClickedBinded );
     _triggerDom.addEventListener( 'touchstart', _handleTouchStart );
@@ -126,8 +127,8 @@ function FlyoutMenu( element ) { // eslint-disable-line max-statements, no-inlin
           _altTriggerDom.setAttribute( 'data-gtm_ignore', 'true' );
         }
 
-        // Set initial `aria-expanded="false"` attribute.
-        _setAriaExpandedAttr( _altTriggerDom, 'false' );
+        // Set initial aria attributes to false.
+        _setAriaAttr( 'expanded', _altTriggerDom, 'false' );
 
         // TODO: alt trigger should probably listen
         //       for a mouseover/mouseout event too.
@@ -141,15 +142,17 @@ function FlyoutMenu( element ) { // eslint-disable-line max-statements, no-inlin
   }
 
   /**
-   * Event handler for when the trigger is hovered over.
+   * Set an aria attribute on an HTML element.
+   * @param {string} type - The aria attribute to set
+   *   (without the aria- prefix).
    * @param {HTMLNode} elem - The element to set.
    * @param {boolean} value - The value to set on `aria-expanded`,
    *   casts to a string.
    * @returns {string} The cast value.
    */
-  function _setAriaExpandedAttr( elem, value ) {
+  function _setAriaAttr( type, elem, value ) {
     var strValue = String( value );
-    elem.setAttribute( 'aria-expanded', strValue );
+    elem.setAttribute( 'aria-' + type, strValue );
     return strValue;
   }
 
@@ -209,6 +212,7 @@ function FlyoutMenu( element ) { // eslint-disable-line max-statements, no-inlin
       _deferFunct = standardType.noopFunct;
       this.dispatchEvent( 'expandBegin',
                           { target: this, type: 'expandBegin' } );
+      _setAriaAttr( 'pressed', _triggerDom, true );
       if ( _expandTransitionMethod ) {
         var hasTransition = _expandTransition &&
                             _expandTransition.isAnimated();
@@ -258,9 +262,12 @@ function FlyoutMenu( element ) { // eslint-disable-line max-statements, no-inlin
       } else {
         _collapseEndBinded();
       }
-      if ( _altTriggerDom ) _setAriaExpandedAttr( _altTriggerDom, false );
-      _setAriaExpandedAttr( _triggerDom, false );
-      _setAriaExpandedAttr( _contentDom, false );
+      if ( _altTriggerDom ) {
+        _setAriaAttr( 'expanded', _altTriggerDom, false )
+      };
+      _setAriaAttr( 'expanded', _triggerDom, false );
+      _setAriaAttr( 'pressed', _triggerDom, false );
+      _setAriaAttr( 'expanded', _contentDom, false );
       // TODO: Remove or uncomment when keyboard navigation is in.
       // _triggerDom.focus();
     } else {
@@ -283,9 +290,11 @@ function FlyoutMenu( element ) { // eslint-disable-line max-statements, no-inlin
         .removeEventListener( BaseTransition.END_EVENT, _expandEndBinded );
     }
     this.dispatchEvent( 'expandEnd', { target: this, type: 'expandEnd' } );
-    if ( _altTriggerDom ) _setAriaExpandedAttr( _altTriggerDom, true );
-    _setAriaExpandedAttr( _triggerDom, true );
-    _setAriaExpandedAttr( _contentDom, true );
+    if ( _altTriggerDom ) {
+      _setAriaAttr( 'expanded', _altTriggerDom, true );
+    }
+    _setAriaAttr( 'expanded', _triggerDom, true );
+    _setAriaAttr( 'expanded', _contentDom, true );
     // Call collapse, if it was called while expand was animating.
     _deferFunct();
   }

--- a/test/unit_tests/modules/FlyoutMenu-spec.js
+++ b/test/unit_tests/modules/FlyoutMenu-spec.js
@@ -29,9 +29,12 @@ describe( 'FlyoutMenu', function() {
   var document;
   var HTML_SNIPPET =
     '<div data-js-hook="flyout-menu">' +
-      '<button data-js-hook="flyout-menu_trigger"></button>' +
-      '<div data-js-hook="flyout-menu_content">' +
-        '<button data-js-hook="flyout-menu_alt-trigger"></button>' +
+      '<button data-js-hook="flyout-menu_trigger" ' +
+              'aria-pressed="false" ' +
+              'aria-expanded="false"></button>' +
+      '<div data-js-hook="flyout-menu_content" aria-expanded="false">' +
+        '<button data-js-hook="flyout-menu_alt-trigger" ' +
+                'aria-expanded="false"></button>' +
       '</div>' +
     '</div>';
 
@@ -72,7 +75,12 @@ describe( 'FlyoutMenu', function() {
     } );
 
     it( 'should have correct state before initializing', function() {
-      // TODO: check aria-expanded state as well.
+      expect( triggerDom.getAttribute( 'aria-pressed' ) ).to.equal( 'false' );
+      expect( triggerDom.getAttribute( 'aria-expanded' ) ).to.equal( 'false' );
+      expect( contentDom.getAttribute( 'aria-expanded' ) ).to.equal( 'false' );
+      expect( altTriggerDom.getAttribute( 'aria-pressed' ) ).to.be.null;
+      expect( altTriggerDom.getAttribute( 'aria-expanded' ) ).to.equal( 'false' );
+
       expect( flyoutMenu.isAnimating() ).to.be.false;
       expect( flyoutMenu.isExpanded() ).to.be.false;
       expect( flyoutMenu.getTransition() ).to.be.undefined;
@@ -151,24 +159,26 @@ describe( 'FlyoutMenu', function() {
       expect( args.target ).to.equal( flyoutMenu );
       expect( args.type ).to.equal( 'expandEnd' );
 
-      // Check expected aria-expanded state.
+      // Check expected aria attributes state.
+      expect( triggerDom.getAttribute( 'aria-pressed' ) ).to.equal( 'true' );
       expect( triggerDom.getAttribute( 'aria-expanded' ) ).to.equal( 'true' );
       expect( contentDom.getAttribute( 'aria-expanded' ) ).to.equal( 'true' );
+      expect( altTriggerDom.getAttribute( 'aria-pressed' ) ).to.be.null;
       expect( altTriggerDom.getAttribute( 'aria-expanded' ) )
         .to.equal( 'true' );
     } );
 
-    it( 'should dispatch events and set aria-expanded, ' +
+    it( 'should dispatch events and set aria attributes, ' +
         'when called by trigger click', function() {
       triggerDom.click();
     } );
 
-    it( 'should dispatch events and set aria-expanded, ' +
+    it( 'should dispatch events and set aria attributes, ' +
         'when called by alt trigger click', function() {
       altTriggerDom.click();
     } );
 
-    it( 'should dispatch events and set aria-expanded, ' +
+    it( 'should dispatch events and set aria attributes, ' +
         'when called directly', function() {
       flyoutMenu.expand();
     } );
@@ -198,24 +208,26 @@ describe( 'FlyoutMenu', function() {
       expect( args.target ).to.equal( flyoutMenu );
       expect( args.type ).to.equal( 'collapseEnd' );
 
-      // Check expected aria-expanded state.
+      // Check expected aria attribute states.
+      expect( triggerDom.getAttribute( 'aria-pressed' ) ).to.equal( 'false' );
       expect( triggerDom.getAttribute( 'aria-expanded' ) ).to.equal( 'false' );
       expect( contentDom.getAttribute( 'aria-expanded' ) ).to.equal( 'false' );
+      expect( altTriggerDom.getAttribute( 'aria-pressed' ) ).to.be.null;
       expect( altTriggerDom.getAttribute( 'aria-expanded' ) )
         .to.equal( 'false' );
     } );
 
-    it( 'should dispatch events and set aria-expanded, ' +
+    it( 'should dispatch events and set aria attributes, ' +
         'when called by trigger click', function() {
       triggerDom.click();
     } );
 
-    it( 'should dispatch events and set aria-expanded, ' +
+    it( 'should dispatch events and set aria attributes, ' +
         'when called by alt trigger click', function() {
       altTriggerDom.click();
     } );
 
-    it( 'should dispatch events and set aria-expanded, ' +
+    it( 'should dispatch events and set aria attributes, ' +
         'when called directly', function() {
       flyoutMenu.collapse();
     } );


### PR DESCRIPTION
## Changes

- Adds aria-pressed to primary flyout menu trigger to prepare expandables to share transition code.

## Testing

- `gulp test:unit` should pass.
- When inspecting mega menu hamburger menu at mobile, the trigger to show/hide the menu should toggle `aria-pressed` from false to true. The submenu links should as well. The back button _should not_, but maybe it should also? It's not clearly a toggle, but neither are the submenu links.

## Review

- @jimmynotjim 
- @sebworks 
