### PR TITLE
Updated event times to show EDT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,11 +16,14 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 ## Unreleased
 
 ### Added
+
 - RegComment organism: New option to use a generic link for commenting at
   Regulations.gov or going directly to the specified document's comment form.
 
 ### Changed
+
 - Frontend: Added No Fear Act link to footer.
+- Updated event times to show EDT.
 
 ### Removed
 

--- a/cfgov/jinja2/v1/_includes/macros/time.html
+++ b/cfgov/jinja2/v1/_includes/macros/time.html
@@ -10,12 +10,12 @@
 
    Renders a time element with a standard datetime format when given:
 
-   datetime:             A date timestamp to format.
+   datetime:  A date timestamp to format.
 
-   show_only (optional): Object of fields to show.
+   show_only: (Optional) Object of fields to show.
                          Default is true for 'date', 'time', and 'timezone'.
 
-   timezone (optional):  Timezone string value. Default is 'America/New_York'.
+   timezone:  (Optional) Timezone string value. Default is none.
 
    ========================================================================== #}
 

--- a/cfgov/jinja2/v1/_includes/macros/util/format/datetime.html
+++ b/cfgov/jinja2/v1/_includes/macros/util/format/datetime.html
@@ -14,9 +14,7 @@
 
    datetime: A datetime object.
 
-   timezone (optional): Whether to include the timezone or not.
-                        Provide '' to default to 'America/New_York',
-                        otherwise provide actual timezone.
+   timezone: (Optional) Timezone string value. Default is none.
 
    ========================================================================== #}
 

--- a/cfgov/jinja2/v1/events/_event-detail.html
+++ b/cfgov/jinja2/v1/events/_event-detail.html
@@ -1,3 +1,5 @@
+{% import 'macros/time.html' as time %}
+
 <article class="post post__event">
     <header>
         <h1 class="post_heading">
@@ -15,8 +17,10 @@
         <div class="t-event_details">
             <div class="modification-date date">
                 <span>Updated</span>
-                {% import 'macros/time.html' as time %}
-                {{ time.render(page.latest_revision_created_at, {'date':true}) }}
+                {{ time.render(
+                    page.latest_revision_created_at,
+                    {'date': true}
+                ) }}
             </div>
             {% import 'molecules/social-media.html' as social_media with context %}
             {{ social_media.render( {
@@ -56,9 +60,10 @@
                       <span class="event-meta_description event-meta_description__block">
                           Video link available:
                       </span>
-                      {% import 'macros/time.html' as time %}
-                      {{ time.render(page.live_stream_date,
-                                     {'date':true, 'time':true, 'timezone':true}) }}
+                      {{ time.render(
+                          page.live_stream_date,
+                          timezone='America/New_York'
+                      ) }}
                   </p>
                 </div>
                 {% endif %}

--- a/cfgov/jinja2/v1/events/_macros.html
+++ b/cfgov/jinja2/v1/events/_macros.html
@@ -153,8 +153,11 @@
                     Video Replay will be<br> available shortly
                 {% else %}
                     {% import 'macros/time.html' as time %}
-                    {% if event.start_dt%}
-                        {{ time.render(event.start_dt) }}
+                    {% if event.start_dt %}
+                        {{ time.render(
+                            event.start_dt,
+                            timezone='America/New_York'
+                        ) }}
                     {% endif %}
                 {% endif %}
                 </div>
@@ -251,7 +254,10 @@
             <tr>
                 <td class="{{ options.time_col_classes }}">
                     {% import 'macros/time.html' as time %}
-                    {{ time.render(bound.start_dt.render(), {'time':true, 'timezone':true}) }}
+                    {{ time.render(
+                        bound.start_dt.render(),
+                        {'date':false,'time':true,'timezone':false}
+                    ) }}
                     &ndash;
                     {{ time.render(bound.end_dt.render(), {'time':true, 'timezone':true}) }}
                 </td>


### PR DESCRIPTION
Timezones...for now we're going to show all event timezones as EDT to reduce confusion until we can add localized timezone support.

## Changes

- Updated event times to show EDT
- Updated code comments to correctly show `none` as the timezone default

## Testing

- navigate to http://localhost:8000/about-us/events/field-hearing-arbitration-albuquerque-nm/ and the time in the event venue details to show EDT.

## Review

- @sarahsimpson09 
- @anselmbradford 
- @sebworks 

## Screenshots

<img width="642" alt="screen shot 2016-05-04 at 4 31 32 pm" src="https://cloud.githubusercontent.com/assets/1280430/15029989/ae16ebea-1215-11e6-9cfa-82a26236ea66.png">

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices
* [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)