### PR TITLE
Tweak reg comment form disclaimer styling

### DIFF
--- a/cfgov/jinja2/v1/_includes/organisms/reg-comment.html
+++ b/cfgov/jinja2/v1/_includes/organisms/reg-comment.html
@@ -67,9 +67,11 @@
         <input type="email" id="email" name="email"
                placeholder="example@mail.com">
 
-        <p>
-            <strong>Sensitive personal information, such as account numbers or
-            Social Security numbers, should not be included.</strong>
+        <p class="o-reg-comment_disclaimer">
+            <span class="o-reg-comment_disclaimer-em">
+                Sensitive personal information, such as account numbers or
+                Social Security numbers, should not be included.
+            </span>
             Your comments will become part of the public record and posted to
             <a class="icon-link icon-link__external-link"
                href="https://www.regulations.gov/">

--- a/cfgov/unprocessed/css/organisms/reg-comment.less
+++ b/cfgov/unprocessed/css/organisms/reg-comment.less
@@ -31,8 +31,13 @@
         margin-bottom: @margin__em / 2;
     }
 
+    &_disclaimer,
     input[type="submit"] {
         display: block;
         margin-bottom: @margin__em;
+    }
+
+    &_disclaimer-em {
+        .webfont-medium();
     }
 }


### PR DESCRIPTION
Should have included this in the previous PR, but here it is now.

## Additions

- Some classes and Less to control the styling of the disclaimer text a little bit more, as requested by @nataliafitzgerald.
  - Bolded text is now Medium.
  - Space between disclaimer and button is now 30px.

## Review

- @jimmynotjim 
- @sebworks 
- @anselmbradford 
- @KimberlyMunoz 
- @nataliafitzgerald

## Screenshots

![screen shot 2016-05-05 at 11 01 26](https://cloud.githubusercontent.com/assets/1044670/15047047/f3627430-12b0-11e6-92d3-ef9684e70ce1.png)

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)

