### PR TITLE
Adds print styles for major site features that aren't print applicable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 ## Unreleased
 
 ### Added
+- Frontend: Added print styles to hide major site features that aren't
+  print applicable.
 
 ### Changed
 

--- a/cfgov/unprocessed/css/breadcrumbs.less
+++ b/cfgov/unprocessed/css/breadcrumbs.less
@@ -27,3 +27,10 @@
         }
     }
 }
+
+// Hide on print.
+.respond-to-print( {
+    .breadcrumbs {
+        display: none;
+    }
+} );

--- a/cfgov/unprocessed/css/molecules/call-to-action.less
+++ b/cfgov/unprocessed/css/molecules/call-to-action.less
@@ -33,7 +33,6 @@
     }
 }
 
-
 /* topdoc
     name: EOF
     eof: true

--- a/cfgov/unprocessed/css/molecules/featured-menu-content.less
+++ b/cfgov/unprocessed/css/molecules/featured-menu-content.less
@@ -77,7 +77,6 @@
     } );
 }
 
-
 /* topdoc
     name: EOF
     eof: true

--- a/cfgov/unprocessed/css/molecules/global-banner.less
+++ b/cfgov/unprocessed/css/molecules/global-banner.less
@@ -98,3 +98,15 @@
         display: none;
     }
 }
+
+// Hide button on print.
+.respond-to-print( {
+    .m-global-banner_btn {
+        display: none;
+    }
+} );
+
+/* topdoc
+    name: EOF
+    eof: true
+*/

--- a/cfgov/unprocessed/css/molecules/global-eyebrow.less
+++ b/cfgov/unprocessed/css/molecules/global-eyebrow.less
@@ -126,3 +126,8 @@
         }
     }
 }
+
+/* topdoc
+    name: EOF
+    eof: true
+*/

--- a/cfgov/unprocessed/css/molecules/global-header-cta.less
+++ b/cfgov/unprocessed/css/molecules/global-header-cta.less
@@ -62,3 +62,8 @@
         padding-bottom: unit( @grid_gutter-width / 2 / @base-font-size-px, em );
     }
 }
+
+/* topdoc
+    name: EOF
+    eof: true
+*/

--- a/cfgov/unprocessed/css/molecules/global-search.less
+++ b/cfgov/unprocessed/css/molecules/global-search.less
@@ -302,6 +302,14 @@
         top: -9999px;
         left: -9999px;
     }
+
+    // Hide on print.
+    .respond-to-print( {
+        & {
+            // Important needed to override JS display settings.
+            display: none !important;
+        }
+    } );
 }
 
 /* topdoc

--- a/cfgov/unprocessed/css/molecules/home-hero.less
+++ b/cfgov/unprocessed/css/molecules/home-hero.less
@@ -131,4 +131,16 @@
             display: none;
         } );
     }
+
+    // Hide image on print.
+    .respond-to-print( {
+        &_sm-img {
+            display: none;
+        }
+    } );
 }
+
+/* topdoc
+    name: EOF
+    eof: true
+*/

--- a/cfgov/unprocessed/css/molecules/info-unit.less
+++ b/cfgov/unprocessed/css/molecules/info-unit.less
@@ -161,7 +161,16 @@
             .u-info-unit-base__inline( @m-info-unit_img__lg );
         } );
     }
+
+    // Hide image on print.
+    .respond-to-print( {
+        &_image {
+            display: none;
+        }
+    } );
 }
 
-
-
+/* topdoc
+    name: EOF
+    eof: true
+*/

--- a/cfgov/unprocessed/css/molecules/inset.less
+++ b/cfgov/unprocessed/css/molecules/inset.less
@@ -61,3 +61,8 @@
         margin-bottom: unit( ( @grid_gutter-width / 2 ) / @base-font-size-px, em );
     }
 }
+
+/* topdoc
+    name: EOF
+    eof: true
+*/

--- a/cfgov/unprocessed/css/molecules/nav-link.less
+++ b/cfgov/unprocessed/css/molecules/nav-link.less
@@ -78,3 +78,8 @@
         margin-bottom: inherit;
     }
 }
+
+/* topdoc
+    name: EOF
+    eof: true
+*/

--- a/cfgov/unprocessed/css/molecules/pagination.less
+++ b/cfgov/unprocessed/css/molecules/pagination.less
@@ -150,7 +150,6 @@
     });
 }
 
-
 /* topdoc
     name: EOF
     eof: true

--- a/cfgov/unprocessed/css/molecules/social-media.less
+++ b/cfgov/unprocessed/css/molecules/social-media.less
@@ -65,4 +65,16 @@
         .u-link__colors( @dark-gray, @pacific-80 );
         .u-link__no-border();
     }
+
+    // Hide on print.
+    .respond-to-print( {
+        & {
+            display: none;
+        }
+    } );
 }
+
+/* topdoc
+    name: EOF
+    eof: true
+*/

--- a/cfgov/unprocessed/css/organisms/footer.less
+++ b/cfgov/unprocessed/css/organisms/footer.less
@@ -208,6 +208,13 @@
             } );
         }
     }
+
+    // Hide return to top button on print.
+    .respond-to-print( {
+        &_top-button {
+            display: none !important;
+        }
+    } );
 }
 
 /* topdoc

--- a/cfgov/unprocessed/css/organisms/header.less
+++ b/cfgov/unprocessed/css/organisms/header.less
@@ -87,7 +87,8 @@
         position: relative;
 
         > .wrapper {
-            // TODO: remove when Capital Framework is updated to 3.x.x. on outdated consumerfinance.gov projects.
+            // TODO: Remove when Capital Framework is updated to 3.x.x.
+            //       on outdated consumerfinance.gov projects.
             position: initial;
 
             > .m-global-search {
@@ -187,6 +188,14 @@
         padding-left: 10px;
     } );
 }
+
+// Move logo on print.
+.respond-to-print( {
+    .o-header_logo {
+        // Mega menu is hidden, so we need to remove logo offset.
+        margin-left: 15px !important;
+    }
+} );
 
 /* topdoc
     name: EOF

--- a/cfgov/unprocessed/css/organisms/mega-menu.less
+++ b/cfgov/unprocessed/css/organisms/mega-menu.less
@@ -640,6 +640,13 @@
     }
 }
 
+// Hide on print.
+.respond-to-print( {
+    .o-mega-menu {
+        display: none;
+    }
+} );
+
 /* topdoc
     name: EOF
     eof: true

--- a/cfgov/unprocessed/css/organisms/secondary-navigation.less
+++ b/cfgov/unprocessed/css/organisms/secondary-navigation.less
@@ -145,6 +145,13 @@
             });
         }
     }
+
+    // Hide on print.
+    .respond-to-print( {
+        & {
+            display: none;
+        }
+    } );
 }
 
 /* topdoc

--- a/cfgov/unprocessed/css/print.less
+++ b/cfgov/unprocessed/css/print.less
@@ -33,6 +33,7 @@
   name: Print header
   notes:
     - "Separates print header stuff from the rest of the page content."
+    - "Used on /about-us/the-bureau/leadership-calendar/print/"
   family: cfgov-print
   patterns:
     - name: .print-header


### PR DESCRIPTION
## Additions

- Adds print styles for major site features that aren't print applicable.
- Moves the logo on print so it is aligned correctly.
- Adds missing topdoc EOF comments.

## Testing

- `gulp build` visit the homepage and go to File > Print and look at the preview. Should not include the mega menu, search, hero, social media icons, banner and footer buttons, or gaps for images that are background images.
- Check /about-us/careers/application-process/ for the hidden breadcrumbs and secondary nav too.

## Review

- @jimmynotjim 
- @sebworks 
- @schaferjh 

## Screenshots

![screen shot 2016-05-05 at 12 48 32 pm](https://cloud.githubusercontent.com/assets/704760/15050160/09285f5a-12c0-11e6-8b27-53217d9094a3.png)

## Todos

- Heros in CF need print styles added to hide areas where background images appear.
