### PR TITLE
Bad zips should return 400 error

### DIFF
--- a/cfgov/legacy/views.py
+++ b/cfgov/legacy/views.py
@@ -34,7 +34,7 @@ class HousingCounselorPDFView(PDFGeneratorView):
             url = '%s://%s/%s' % (request.scheme, 'localhost', api_url)
             return url
         else:
-            raise InvalidZipException(form.errors)
+            raise InvalidZipException(form.errors['zip'].as_text())
 
     def get(self, request):
 
@@ -44,9 +44,9 @@ class HousingCounselorPDFView(PDFGeneratorView):
 
         try:
             return self.generate_pdf()
-        except InvalidZipException:
+        except InvalidZipException as error:
             if not settings.DEBUG:
-                return HttpResponse(status=500)
+                return HttpResponse("That does not appear to be a valid zip code", status=400)
             raise
 
     def get_filename(self):

--- a/cfgov/legacy/views.py
+++ b/cfgov/legacy/views.py
@@ -20,6 +20,8 @@ if six.PY2:
     except:
         PDFreactor = None
 
+class InvalidZipException(Exception):
+    pass
 
 class HousingCounselorPDFView(PDFGeneratorView):
     def get_render_url(self):
@@ -32,7 +34,7 @@ class HousingCounselorPDFView(PDFGeneratorView):
             url = '%s://%s/%s' % (request.scheme, 'localhost', api_url)
             return url
         else:
-            raise Exception(form.errors)
+            raise InvalidZipException(form.errors)
 
     def get(self, request):
 
@@ -40,7 +42,12 @@ class HousingCounselorPDFView(PDFGeneratorView):
         if settings.DEBUG and PDFreactor is None:
             return HttpResponse("PDF Reactor is not configured, can not render %s" % self.get_render_url())
 
-        return self.generate_pdf()
+        try:
+            return self.generate_pdf()
+        except InvalidZipException:
+            if not settings.DEBUG:
+                return HttpResponse(status=500)
+            raise
 
     def get_filename(self):
         return '%s.pdf' % self.request.GET['zip']


### PR DESCRIPTION
This one is pretty subtle.

The old behavior was, we were raising an Exception, and letting Django sort out the rest. This meant, in production, a 500 error. My main concern is that this was polluting the 'Error' rate in New Relic.

Also, I did some reading, and it seems like HTTP 400 is a more appropriate response.

So, when DEBUG is False, we now return a simple failure message with HTTP status 400. We may wish to create a full-fledged error template for 400, like we do 404 and 500-- but users of the /find-a-housing-counselor/ tool will never get this far, so I'm confident the error will mostly be seen by bots.

## Testing

- Hit /save-hud-counselors-list/?zip=9021 and note the exception message you get
- temporarily set DEBUG to False in cfgov/settings/local.py
- Hit /save-hud-counselors-list/?zip=9021 and note the new error message
- If you want to get really fancy, use curl and see the HTTP status:

`curl -I http://localhost:8000/save-hud-counselors-list/?zip=9021`

should look something like this:

```
HTTP/1.0 400 BAD REQUEST
Date: Thu, 05 May 2016 16:50:36 GMT
Server: WSGIServer/0.1 Python/2.7.11
X-Frame-Options: SAMEORIGIN
Content-Type: text/html; charset=utf-8
```

## Review

- @kurtw @kave @richaagarwal 


## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
