### PR TITLE
DFJR-994 Adds initialization flag for atomic components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 
 ### Changed
 - Updated event times to show EDT.
+- Frontend: Added init flag when initializing atomic components.
 
 
 ## 3.0.0-3.3.11 - 2016-05-03

--- a/cfgov/jinja2/v1/_includes/molecules/global-search.html
+++ b/cfgov/jinja2/v1/_includes/molecules/global-search.html
@@ -11,16 +11,16 @@
    ========================================================================== #}
 
 <div class="m-global-search"
-     data-js-hook="flyout-menu">
+     data-js-hook="behavior_flyout-menu">
     <button class="m-global-search_trigger"
-            data-js-hook="flyout-menu_trigger">
+            data-js-hook="behavior_flyout-menu_trigger">
         <span class="m-global-search_trigger-label">
             <span class="u-visually-hidden">Search</span>
         </span>
     </button>
     <div class="m-global-search_content
                 u-hidden"
-         data-js-hook="flyout-menu_content"
+         data-js-hook="behavior_flyout-menu_content"
          aria-expanded="false">
         <form class="m-global-search_content-form"
               action="http://search.consumerfinance.gov/search"

--- a/cfgov/jinja2/v1/_includes/organisms/mega-menu.html
+++ b/cfgov/jinja2/v1/_includes/organisms/mega-menu.html
@@ -59,14 +59,14 @@
             nav_children in nav_group %}
     <li class="list_item
                {{ _classes( nav_depth, '-item' ) }}"
-        {{ 'data-js-hook=flyout-menu' if nav_children | count > 0 else '' }}>
+        {{ 'data-js-hook=behavior_flyout-menu' if nav_children | count > 0 else '' }}>
         {# TODO: Disable link (or overview link) of page user is currently on (on mobile). #}
         <a class="{{ 'u-link__disabled' if nav_url == '' else '' }}
                   {{ _classes( nav_depth, '-link' ) }}
                   {{ _classes( nav_depth, '-link__has-children' ) if nav_children | count > 0 else '' }}
                   {{ _classes( nav_depth, '-link__current' ) if nav_url == request.path else '' }}"
            {{ '' if nav_url == '' else 'href=' + nav_url | e }}
-           {{ 'data-js-hook=flyout-menu_trigger' if nav_children | count > 0 else '' }}
+           {{ 'data-js-hook=behavior_flyout-menu_trigger' if nav_children | count > 0 else '' }}
            {{ 'aria-pressed=false' if nav_children | count > 0 else '' }}>
             {{ nav_caption }}
         </a>
@@ -105,14 +105,14 @@
 <div class="{{ _classes( nav_depth ) }}
             u-hidden-overflow"
      aria-expanded="false"
-     data-js-hook="flyout-menu_content">
+     data-js-hook="behavior_flyout-menu_content">
 
     <div class="{{ _classes( nav_depth, '-wrapper' ) }}">
         {{ '<div class="wrapper">' | safe if nav_depth > 1 else '' }}
             {# Open wrapper if needed #}
             {% if nav_depth > 1 %}
             <button class="{{ _classes( nav_depth, '-alt-trigger' ) }}"
-                    data-js-hook="flyout-menu_alt-trigger">
+                    data-js-hook="behavior_flyout-menu_alt-trigger">
                 Back
             </button>
             {% endif %}
@@ -166,11 +166,11 @@
    ========================================================================== #}
 <nav class="{{ base_class }}
             u-hidden"
-     data-js-hook="flyout-menu"
+     data-js-hook="behavior_flyout-menu"
      aria-label="main navigation"
      role="navigation">
     <button class="{{ base_class ~ '_trigger' }}"
-            data-js-hook="flyout-menu_trigger"
+            data-js-hook="behavior_flyout-menu_trigger"
             aria-pressed="false">
         <span class="u-visually-hidden">Menu</span>
     </button>

--- a/cfgov/unprocessed/js/modules/behavior/FlyoutMenu.js
+++ b/cfgov/unprocessed/js/modules/behavior/FlyoutMenu.js
@@ -1,11 +1,11 @@
 'use strict';
 
 // Required modules.
-var BaseTransition = require( '../modules/transition/BaseTransition' );
-var dataHook = require( '../modules/util/data-hook' );
-var EventObserver = require( '../modules/util/EventObserver' );
-var fnBind = require( '../modules/util/fn-bind' ).fnBind;
-var standardType = require( '../modules/util/standard-type' );
+var BaseTransition = require( '../../modules/transition/BaseTransition' );
+var dataHook = require( '../../modules/util/data-hook' );
+var EventObserver = require( '../../modules/util/EventObserver' );
+var fnBind = require( '../../modules/util/fn-bind' ).fnBind;
+var standardType = require( '../../modules/util/standard-type' );
 
 /**
  * FlyoutMenu
@@ -29,7 +29,7 @@ var standardType = require( '../modules/util/standard-type' );
  */
 function FlyoutMenu( element ) { // eslint-disable-line max-statements, no-inline-comments, max-len
 
-  var BASE_CLASS = 'flyout-menu';
+  var BASE_CLASS = standardType.BEHAVIOR_PREFIX + 'flyout-menu';
   var SEL_PREFIX = '[' + standardType.JS_HOOK + '=' + BASE_CLASS;
 
   var BASE_SEL = SEL_PREFIX + ']';

--- a/cfgov/unprocessed/js/modules/util/atomic-helpers.js
+++ b/cfgov/unprocessed/js/modules/util/atomic-helpers.js
@@ -6,6 +6,9 @@
 'use strict';
 
 var dataHook = require( './data-hook' );
+var standardType = require( './standard-type' );
+
+var INIT_FLAG = standardType.STATE_PREFIX + 'atomic_init';
 
 // TODO: Update baseClass to baseSel to handle CSS selector instead of a class.
 /**
@@ -70,11 +73,11 @@ function _verifyClassExists( element, baseClass ) {
  *   false otherwise.
  */
 function setInitFlag( element ) {
-  if ( dataHook.contains( element, 'init' ) ) {
+  if ( dataHook.contains( element, INIT_FLAG ) ) {
     return false;
   }
 
-  dataHook.add( element, 'init' );
+  dataHook.add( element, INIT_FLAG );
 
   return true;
 }
@@ -98,7 +101,7 @@ function instantiateAll( selector, Constructor ) {
 
 // Expose public methods.
 module.exports = {
-  checkDom: checkDom,
+  checkDom:       checkDom,
   instantiateAll: instantiateAll,
-  setInitFlag: setInitFlag
+  setInitFlag:    setInitFlag
 };

--- a/cfgov/unprocessed/js/modules/util/standard-type.js
+++ b/cfgov/unprocessed/js/modules/util/standard-type.js
@@ -1,8 +1,44 @@
 'use strict';
 
-// Constant for the name of the JS hook used
-// for attaching JS behavior to HTML DOM elements.
+/**
+ * @constant
+ * @type {string}
+ * Constant for the name of the data-* attribute set on
+ * HTML DOM elements for access by JavaScript.
+ */
 var JS_HOOK = 'data-js-hook';
+
+/**
+ * @constant
+ * @type {string}
+ * Flag prefix for settings that describe what JavaScript
+ * behaviors should be attached to a component.
+ * This would be set in the markup and initialized when
+ * the JavaScript loads.
+ *
+ * @example
+ * A component may flag that it has certain JavaScript behaviors attached,
+ * such as:
+ * `data-js-hook="behavior_flyout-menu behavior_clearable-input"`,
+ * which defines that two scripts (FlyoutMenu) and (ClearableInput)
+ * should access this DOM element and initialize its behaviors.
+ */
+var BEHAVIOR_PREFIX = 'behavior_';
+
+/**
+ * @constant
+ * @type {string}
+ * Flag prefix for settings related to changes in a components
+ * state set in the data-* JavaScript hook.
+ *
+ * @example
+ * A component may flag that it has been initialized by setting
+ * `data-js-hook="state_atomic_init"` after page load.
+ * Which specifies that the init method of a atomic constructor
+ * has been called, such as
+ * `var globalSearch = new GlobalSearch( 'm-global-search' ).init()`.
+ */
+var STATE_PREFIX = 'state_';
 
 /**
  * Empty function that will do nothing.
@@ -10,7 +46,7 @@ var JS_HOOK = 'data-js-hook';
  * which are meant to be overridden with functionality, but if not,
  * noopFunct will fire and do nothing instead.
  *
- * e.g.
+ * @example
  * callback.onComplete = standardType.noopFunct;
  */
 function noopFunct() {
@@ -20,7 +56,9 @@ function noopFunct() {
 var UNDEFINED;
 
 module.exports = {
-  JS_HOOK:   JS_HOOK,
-  noopFunct: noopFunct,
-  UNDEFINED: UNDEFINED
+  BEHAVIOR_PREFIX: BEHAVIOR_PREFIX,
+  JS_HOOK:         JS_HOOK,
+  noopFunct:       noopFunct,
+  STATE_PREFIX:    STATE_PREFIX,
+  UNDEFINED:       UNDEFINED
 };

--- a/cfgov/unprocessed/js/molecules/Expandable.js
+++ b/cfgov/unprocessed/js/molecules/Expandable.js
@@ -5,6 +5,7 @@ var atomicHelpers = require( '../modules/util/atomic-helpers' );
 var breakpointState = require( '../modules/util/breakpoint-state' );
 var EventObserver = require( '../modules/util/EventObserver' );
 var fnBind = require( '../modules/util/fn-bind' ).fnBind;
+var standardType = require( '../modules/util/standard-type' );
 
 /**
  * Expandable
@@ -52,7 +53,9 @@ function Expandable( element ) { // eslint-disable-line max-statements, inline-c
    *   or undefined if it was already initialized.
    */
   function init( state ) {
-    if ( !atomicHelpers.setInitFlag( _dom ) ) { var inst; return inst; }
+    if ( !atomicHelpers.setInitFlag( _dom ) ) {
+      return standardType.UNDEFINED;
+    }
 
     _calcHeight();
     // Even if expanded is set, don't expand if in mobile window size.

--- a/cfgov/unprocessed/js/molecules/GlobalBanner.js
+++ b/cfgov/unprocessed/js/molecules/GlobalBanner.js
@@ -9,6 +9,7 @@
 var atomicHelpers = require( '../modules/util/atomic-helpers' );
 var Expandable = require( '../molecules/Expandable' );
 var webStorageProxy = require( '../modules/util/web-storage-proxy' );
+var standardType = require( '../modules/util/standard-type' );
 
 /**
  * GlobalBanner
@@ -30,14 +31,22 @@ function GlobalBanner( element ) {
 
   /**
    * Set up DOM references and event handlers.
+   * @returns {GlobalBanner|undefined} An instance,
+   *   or undefined if it was already initialized.
    */
   function init() {
+    if ( !atomicHelpers.setInitFlag( _dom ) ) {
+      return standardType.UNDEFINED;
+    }
+
     // Init Expandable.
     var isExpanded = webStorageProxy.getItem( EXPANDED_STATE ) !== 'false';
     _expandable = new Expandable( _dom.querySelector( '.m-expandable' ) );
     _expandable.init( isExpanded && _expandable.EXPANDED );
 
     _initEvents();
+
+    return this;
   }
 
   /**

--- a/cfgov/unprocessed/js/molecules/GlobalSearch.js
+++ b/cfgov/unprocessed/js/molecules/GlobalSearch.js
@@ -5,9 +5,10 @@ var atomicHelpers = require( '../modules/util/atomic-helpers' );
 var breakpointState = require( '../modules/util/breakpoint-state' );
 var ClearableInput = require( '../modules/ClearableInput' );
 var EventObserver = require( '../modules/util/EventObserver' );
-var FlyoutMenu = require( '../modules/FlyoutMenu' );
+var FlyoutMenu = require( '../modules/behavior/FlyoutMenu' );
 var fnBind = require( '../modules/util/fn-bind' ).fnBind;
 var MoveTransition = require( '../modules/transition/MoveTransition' );
+var standardType = require( '../modules/util/standard-type' );
 
 /**
  * GlobalSearch
@@ -36,9 +37,14 @@ function GlobalSearch( element ) { // eslint-disable-line max-statements, no-inl
   var KEY_TAB = 9;
 
   /**
-   * @returns {Object} The GlobalSearch instance.
+   * @returns {GlobalSearch|undefined} An instance,
+   *   or undefined if it was already initialized.
    */
   function init() {
+    if ( !atomicHelpers.setInitFlag( _dom ) ) {
+      return standardType.UNDEFINED;
+    }
+
     // Set initial appearance.
     var transition = new MoveTransition( _contentDom ).init();
     transition.moveRight();

--- a/cfgov/unprocessed/js/molecules/Multiselect.js
+++ b/cfgov/unprocessed/js/molecules/Multiselect.js
@@ -2,10 +2,12 @@
 
 // Required modules.
 var arrayHelpers = require( '../modules/util/array-helpers' );
-var queryOne = require( '../modules/util/dom-traverse' ).queryOne;
-var domCreate = require( '../modules/util/dom-manipulators' ).create;
-var strings = require( '../modules/util/strings' );
+var atomicHelpers = require( '../modules/util/atomic-helpers' );
 var bindEvent = require( '../modules/util/dom-events' ).bindEvent;
+var domCreate = require( '../modules/util/dom-manipulators' ).create;
+var queryOne = require( '../modules/util/dom-traverse' ).queryOne;
+var standardType = require( '../modules/util/standard-type' );
+var strings = require( '../modules/util/strings' );
 
 /**
  * Multiselect
@@ -15,7 +17,7 @@ var bindEvent = require( '../modules/util/dom-events' ).bindEvent;
  *
  * @param {HTMLNode} element
  *   The DOM element within which to search for the molecule.
- * @returns {Object} A Multiselect instance.
+ * @returns {Multiselect} An instance.
  */
 function Multiselect( element ) { // eslint-disable-line max-statements, inline-comments, max-len
 
@@ -55,9 +57,14 @@ function Multiselect( element ) { // eslint-disable-line max-statements, inline-
 
   /**
    * Set up and create the multi-select.
-   * @returns {object} The Multiselect instance.
+   * @returns {Multiselect|undefined} An instance,
+   *   or undefined if it was already initialized.
    */
   function init() {
+    if ( !atomicHelpers.setInitFlag( _dom ) ) {
+      return standardType.UNDEFINED;
+    }
+
     _name = _dom.name;
     _options = _dom.options || [];
     _placeholder = _dom.getAttribute( 'placeholder' );
@@ -74,7 +81,7 @@ function Multiselect( element ) { // eslint-disable-line max-statements, inline-
 
   /**
    * Expand the multi-select drop down.
-   * @returns {object} The Multiselect instance.
+   * @returns {Multiselect} An instance.
    */
   function expand() {
     _containerDom.classList.add( 'active' );
@@ -85,7 +92,7 @@ function Multiselect( element ) { // eslint-disable-line max-statements, inline-
 
   /**
    * Collapse the multi-select drop down.
-   * @returns {object} The Multiselect instance.
+   * @returns {Multiselect} An instance.
    */
   function collapse() {
     _containerDom.classList.remove( 'active' );
@@ -96,9 +103,9 @@ function Multiselect( element ) { // eslint-disable-line max-statements, inline-
   }
 
   /**
-   * Cleans up a list of options for saving to memory
-   * @param   {array} list The options from the parent select elem
-   * @returns {array}      An array of option objects
+   * Cleans up a list of options for saving to memory.
+   * @param   {Array} list The options from the parent select elem.
+   * @returns {Array}      An array of option objects.
    */
   function _sanitizeOptions( list ) {
     var item;
@@ -125,7 +132,7 @@ function Multiselect( element ) { // eslint-disable-line max-statements, inline-
   }
 
   /**
-   * Populates and injects the markup for the custom multi-select
+   * Populates and injects the markup for the custom multi-select.
    */
   function _populateMarkup() {
     // Add a container for our markup
@@ -212,7 +219,7 @@ function Multiselect( element ) { // eslint-disable-line max-statements, inline-
   /**
    * Highlights an option in the list
    * @param   {string} direction Direction to highlight compared to the
-   *                             current focus
+   *                             current focus.
    */
   function _highlight( direction ) {
     var count = _filteredData.length;
@@ -237,8 +244,8 @@ function Multiselect( element ) { // eslint-disable-line max-statements, inline-
   }
 
   /**
-   * Tracks a user's selections and updates the list in the dom
-   * @param   {string} value The value of the option the user has chosen
+   * Tracks a user's selections and updates the list in the dom.
+   * @param   {string} value The value of the option the user has chosen.
    */
   function _updateSelections( value ) {
     var optionIndex =
@@ -293,8 +300,8 @@ function Multiselect( element ) { // eslint-disable-line max-statements, inline-
 
   /**
    * Evaluates the list of options based on the user's query in the
-   * search input
-   * @param  {string} value Text the user has entered in the search query
+   * search input.
+   * @param  {string} value Text the user has entered in the search query.
    */
   function _evaluate( value ) {
     _resetFilter();
@@ -311,7 +318,7 @@ function Multiselect( element ) { // eslint-disable-line max-statements, inline-
   }
 
   /**
-   * Resets the search input and filtering
+   * Resets the search input and filtering.
    */
   function _resetSearch() {
     _searchDom.value = '';
@@ -319,7 +326,7 @@ function Multiselect( element ) { // eslint-disable-line max-statements, inline-
   }
 
   /**
-   * Resets the filtered option list
+   * Resets the filtered option list.
    */
   function _resetFilter() {
     _optionsDom.classList.remove( 'filtered', 'no-results' );
@@ -332,7 +339,7 @@ function Multiselect( element ) { // eslint-disable-line max-statements, inline-
   }
 
   /**
-   * Filters the list of options based on the results of the evaluate function
+   * Filters the list of options based on the results of the evaluate function.
    */
   function _filterResults() {
     _optionsDom.classList.add( 'filtered' );
@@ -351,7 +358,8 @@ function Multiselect( element ) { // eslint-disable-line max-statements, inline-
   }
 
   /**
-   * Updates the list of options to show the user there are no matching results
+   * Updates the list of options to show the user there
+   * are no matching results.
    */
   function _noResults() {
     _optionsDom.classList.add( 'no-results' );
@@ -359,7 +367,7 @@ function Multiselect( element ) { // eslint-disable-line max-statements, inline-
   }
 
   /**
-   * Binds events to the search input, option list, and checkboxes
+   * Binds events to the search input, option list, and checkboxes.
    */
   function _bindEvents() {
     var inputs = _optionsDom.querySelectorAll( 'input' );
@@ -444,8 +452,8 @@ function Multiselect( element ) { // eslint-disable-line max-statements, inline-
   }
 
   /**
-   * Handles the functions to trigger on the checkbox change
-   * @param   {object} event The checkbox change event
+   * Handles the functions to trigger on the checkbox change.
+   * @param   {Event} event The checkbox change event.
    */
   function _changeHandler( event ) {
     _updateSelections( event.target.value );

--- a/cfgov/unprocessed/js/molecules/Notification.js
+++ b/cfgov/unprocessed/js/molecules/Notification.js
@@ -2,6 +2,7 @@
 
 // Required modules.
 var atomicHelpers = require( '../modules/util/atomic-helpers' );
+var standardType = require( '../modules/util/standard-type' );
 
 /**
  * Notification
@@ -11,7 +12,7 @@ var atomicHelpers = require( '../modules/util/atomic-helpers' );
  *
  * @param {HTMLNode} element
  *   The DOM element within which to search for the molecule.
- * @returns {Object} An Notification instance.
+ * @returns {Notification} An instance.
  */
 function Notification( element ) { // eslint-disable-line max-statements, inline-comments, max-len
 
@@ -31,9 +32,14 @@ function Notification( element ) { // eslint-disable-line max-statements, inline
   var _currentType;
 
   /**
-   * @returns {Object} The Notification instance.
+   * @returns {Notification|undefined} An instance,
+   *   or undefined if it was already initialized.
    */
   function init() {
+    if ( !atomicHelpers.setInitFlag( _dom ) ) {
+      return standardType.UNDEFINED;
+    }
+
     // Check and set default type of notification.
     var classList = _dom.classList;
     if ( classList.contains( BASE_CLASS + '__' + SUCCESS ) ) {
@@ -52,7 +58,7 @@ function Notification( element ) { // eslint-disable-line max-statements, inline
    * @param {string} messageText The content of the notifiation message.
    * @param {string|HTMLNode} explanationText
    *   The content of the notifiation explanation.
-   * @returns {Object} The Notification instance.
+   * @returns {Notification} An instance.
    */
   function setTypeAndContent( type, messageText, explanationText ) {
     _setType( type );
@@ -65,7 +71,7 @@ function Notification( element ) { // eslint-disable-line max-statements, inline
    * @param {string} messageText The content of the notifiation message.
    * @param {string|HTMLNode} explanationText
    *   The content of the notifiation explanation.
-   * @returns {Object} The Notification instance.
+   * @returns {Notification} An instance.
    */
   function setContent( messageText, explanationText ) {
     var content = '<p class="h4">' +
@@ -83,7 +89,7 @@ function Notification( element ) { // eslint-disable-line max-statements, inline
 
   /**
    * @param {number} type The notifiation type.
-   * @returns {Object} The Notification instance.
+   * @returns {Notification} An instance.
    */
   function _setType( type ) {
     // If type hasn't changed, return.
@@ -107,7 +113,7 @@ function Notification( element ) { // eslint-disable-line max-statements, inline
   }
 
   /**
-   * @returns {Object} The Notification instance.
+   * @returns {Notification} An instance.
    */
   function show() {
     if ( _currentType === ERROR || _currentType === WARNING ) {
@@ -120,7 +126,7 @@ function Notification( element ) { // eslint-disable-line max-statements, inline
   }
 
   /**
-   * @returns {Object} The Notification instance.
+   * @returns {Notification} An instance.
    */
   function hide() {
     _dom.classList.remove( MODIFIER_VISIBLE );

--- a/cfgov/unprocessed/js/organisms/ExpandableGroup.js
+++ b/cfgov/unprocessed/js/organisms/ExpandableGroup.js
@@ -1,8 +1,9 @@
 'use strict';
 
 // Required modules.
-var Expandable = require( '../molecules/Expandable' );
 var atomicHelpers = require( '../modules/util/atomic-helpers' );
+var Expandable = require( '../molecules/Expandable' );
+var standardType = require( '../modules/util/standard-type' );
 
 /**
  * ExpandableGroup
@@ -24,9 +25,14 @@ function ExpandableGroup( element ) {
   var _isAccordion;
 
   /**
-   * @returns {Object} The ExpandableGroup instance.
+   * @returns {ExpandableGroup|undefined} An instance,
+   *   or undefined if it was already initialized.
    */
   function init() {
+    if ( !atomicHelpers.setInitFlag( _dom ) ) {
+      return standardType.UNDEFINED;
+    }
+
     _isAccordion = _dom.classList.contains( BASE_CLASS + '__accordion' );
 
     var child;

--- a/cfgov/unprocessed/js/organisms/FilterableListControls.js
+++ b/cfgov/unprocessed/js/organisms/FilterableListControls.js
@@ -7,6 +7,7 @@ var Expandable = require( '../molecules/Expandable' );
 var getClosestElement = require( '../modules/util/dom-traverse' ).closest;
 var Multiselect = require( '../molecules/Multiselect' );
 var Notification = require( '../molecules/Notification' );
+var standardType = require( '../modules/util/standard-type' );
 var validators = require( '../modules/util/validators' );
 
 /**
@@ -17,6 +18,7 @@ var validators = require( '../modules/util/validators' );
  *
  * @param {HTMLNode} element
  *   The DOM element within which to search for the organism.
+ * @returns {FilterableListControls} An instance.
  */
 function FilterableListControls( element ) {
   var BASE_CLASS = 'o-filterable-list-controls';
@@ -41,9 +43,13 @@ function FilterableListControls( element ) {
   };
 
   /**
-   * Initialize FilterableListControls instance.
+   * @returns {FilterableListControls|undefined} An instance,
+   *   or undefined if it was already initialized.
    */
-  function init( ) {
+  function init() {
+    if ( !atomicHelpers.setInitFlag( _dom ) ) {
+      return standardType.UNDEFINED;
+    }
 
     // TODO: FilterableListControls should use expandable
     //       behavior (FlyoutMenu), not an expandable directly.
@@ -56,6 +62,8 @@ function FilterableListControls( element ) {
     atomicHelpers.instantiateAll( 'select[multiple]', Multiselect );
 
     _initEvents();
+
+    return this;
   }
 
   /**
@@ -130,7 +138,7 @@ function FilterableListControls( element ) {
    * @param {string} type The type of notification to display.
    * @param {string} msg The message to display in the notification.
    * @param {string} methodName The method to use to control visibility
-                                of the notification.
+   *                            of the notification.
    */
   function _setNotification( type, msg, methodName ) {
     methodName = methodName || 'show';
@@ -143,7 +151,7 @@ function FilterableListControls( element ) {
    * @param {HTMLNode} field A form field.
    * @param {string} type The type of field.
    * @param {boolean} isInGroup A boolean that determines if field in a group.
-   * @returns {boolean} Value indicating whether to validate a field.
+   * @returns {boolean} True if the field should be validated, false otherwise.
    */
   function shouldValidateField( field, type, isInGroup ) {
     var isDisabled = field.getAttribute( 'disabled' ) !== null;

--- a/cfgov/unprocessed/js/organisms/Footer.js
+++ b/cfgov/unprocessed/js/organisms/Footer.js
@@ -3,7 +3,7 @@
 // Required modules.
 var atomicHelpers = require( '../modules/util/atomic-helpers' );
 var footerButton = require( '../modules/footer-button' );
-
+var standardType = require( '../modules/util/standard-type' );
 
 /**
  * Footer
@@ -22,9 +22,14 @@ function Footer( element ) {
   var _dom = atomicHelpers.checkDom( element, BASE_CLASS, 'Footer' );
 
   /**
-   * @returns {Footer} The instance.
+   * @returns {Footer|undefined} An instance,
+   *   or undefined if it was already initialized.
    */
   function init() {
+    if ( !atomicHelpers.setInitFlag( _dom ) ) {
+      return standardType.UNDEFINED;
+    }
+
     footerButton.init();
 
     return this;

--- a/cfgov/unprocessed/js/organisms/Header.js
+++ b/cfgov/unprocessed/js/organisms/Header.js
@@ -5,6 +5,7 @@ var atomicHelpers = require( '../modules/util/atomic-helpers' );
 var GlobalBanner = require( '../molecules/GlobalBanner.js' );
 var GlobalSearch = require( '../molecules/GlobalSearch.js' );
 var MegaMenu = require( '../organisms/MegaMenu.js' );
+var standardType = require( '../modules/util/standard-type' );
 
 /**
  * Header
@@ -30,9 +31,14 @@ function Header( element ) {
   /**
    * @param {HTMLNode} overlay
    *   Overlay to show/hide when mobile mega menu is shown.
-   * @returns {Object} The Header instance.
+   * @returns {Header|undefined} An instance,
+   *   or undefined if it was already initialized.
    */
   function init( overlay ) {
+    if ( !atomicHelpers.setInitFlag( _dom ) ) {
+      return standardType.UNDEFINED;
+    }
+
     // TODO: Investigate a better method of handling optional elements.
     //       Banner is optional, so we don't want to throw a nice error
     //       when its DOM isn't found.

--- a/cfgov/unprocessed/js/organisms/MegaMenu.js
+++ b/cfgov/unprocessed/js/organisms/MegaMenu.js
@@ -5,12 +5,13 @@ var atomicHelpers = require( '../modules/util/atomic-helpers' );
 var breakpointState = require( '../modules/util/breakpoint-state' );
 var dataHook = require( '../modules/util/data-hook' );
 var EventObserver = require( '../modules/util/EventObserver' );
-var FlyoutMenu = require( '../modules/FlyoutMenu' );
+var FlyoutMenu = require( '../modules/behavior/FlyoutMenu' );
 var fnBind = require( '../modules/util/fn-bind' ).fnBind;
 var MegaMenuDesktop = require( '../organisms/MegaMenuDesktop' );
 var MegaMenuMobile = require( '../organisms/MegaMenuMobile' );
 var MoveTransition = require( '../modules/transition/MoveTransition' );
 var Tree = require( '../modules/Tree' );
+var standardType = require( '../modules/util/standard-type' );
 
 /**
  * MegaMenu
@@ -40,9 +41,14 @@ function MegaMenu( element ) {
   var KEY_TAB = 9;
 
   /**
-   * @returns {MegaMenu} An instance.
+   * @returns {MegaMenu|undefined} An instance,
+   *   or undefined if it was already initialized.
    */
   function init() {
+    if ( !atomicHelpers.setInitFlag( _dom ) ) {
+      return standardType.UNDEFINED;
+    }
+
     // DOM selectors.
     var rootMenuDom = _dom;
     var rootContentDom = rootMenuDom.querySelector( FlyoutMenu.CONTENT_SEL );

--- a/cfgov/unprocessed/js/organisms/SecondaryNavigation.js
+++ b/cfgov/unprocessed/js/organisms/SecondaryNavigation.js
@@ -3,6 +3,7 @@
 // Required modules.
 var atomicHelpers = require( '../modules/util/atomic-helpers' );
 var Expandable = require( '../molecules/Expandable' );
+var standardType = require( '../modules/util/standard-type' );
 
 /**
  * SecondaryNavigation
@@ -24,7 +25,9 @@ function SecondaryNavigation( element ) {
    *   or undefined if it was already initialized.
    */
   function init() {
-    if ( !atomicHelpers.setInitFlag( _dom ) ) { var inst; return inst; }
+    if ( !atomicHelpers.setInitFlag( _dom ) ) {
+      return standardType.UNDEFINED;
+    }
 
     var expandable = new Expandable( _dom );
     expandable.init();

--- a/test/browser_tests/spec_suites/organisms/global-search.js
+++ b/test/browser_tests/spec_suites/organisms/global-search.js
@@ -6,10 +6,10 @@ var breakpointsConfig = require( BASE_JS_PATH + 'config/breakpoints-config' );
 
 describe( 'GlobalSearch', function() {
   var BASE_SEL = '.m-global-search';
-  var TRIGGER_SEL = BASE_SEL + ' [data-js-hook="flyout-menu_trigger"]';
-  var CONTENT_SEL = BASE_SEL + ' [data-js-hook="flyout-menu_content"]';
+  var TRIGGER_SEL = BASE_SEL + ' [data-js-hook="behavior_flyout-menu_trigger"]';
+  var CONTENT_SEL = BASE_SEL + ' [data-js-hook="behavior_flyout-menu_content"]';
   var INPUT_SEL = BASE_SEL + ' input#query';
-  var SEARCH_SEL = BASE_SEL + ' [data-js-hook="flyout-menu_content"] .btn';
+  var SEARCH_SEL = BASE_SEL + ' [data-js-hook="behavior_flyout-menu_content"] .btn';
   var CLEAR_SEL = BASE_SEL + ' .input-contains-label_after';
   var SUGGEST_SEL = BASE_SEL + ' .m-global-search_content-suggestions';
 

--- a/test/unit_tests/modules/FlyoutMenu-spec.js
+++ b/test/unit_tests/modules/FlyoutMenu-spec.js
@@ -7,7 +7,7 @@ var expect = chai.expect;
 var jsdom = require( 'jsdom' );
 var sinon = require( 'sinon' );
 
-var FlyoutMenu = require( BASE_JS_PATH + 'modules/FlyoutMenu' );
+var FlyoutMenu = require( BASE_JS_PATH + 'modules/behavior/FlyoutMenu' );
 var MoveTransition =
   require( BASE_JS_PATH + 'modules/transition/MoveTransition' );
 
@@ -28,15 +28,16 @@ describe( 'FlyoutMenu', function() {
   var window;
   var document;
   var HTML_SNIPPET =
-    '<div data-js-hook="flyout-menu">' +
-      '<button data-js-hook="flyout-menu_trigger" ' +
+    '<div data-js-hook="behavior_flyout-menu">' +
+      '<button data-js-hook="behavior_flyout-menu_trigger" ' +
               'aria-pressed="false" ' +
               'aria-expanded="false"></button>' +
-      '<div data-js-hook="flyout-menu_content" aria-expanded="false">' +
-        '<button data-js-hook="flyout-menu_alt-trigger" ' +
+      '<div data-js-hook="behavior_flyout-menu_content" aria-expanded="false">' +
+        '<button data-js-hook="behavior_flyout-menu_alt-trigger" ' +
                 'aria-expanded="false"></button>' +
       '</div>' +
     '</div>';
+  var SEL_PREFIX = '[data-js-hook=behavior_flyout-menu';
 
   var containerDom;
   var triggerDom;
@@ -48,14 +49,14 @@ describe( 'FlyoutMenu', function() {
     window = initdom.defaultView;
     document = window.document;
 
-    containerDom = document.querySelector( '[data-js-hook=flyout-menu]' );
+    containerDom = document.querySelector( SEL_PREFIX + ']' );
     triggerDom =
-      document.querySelector( '[data-js-hook=flyout-menu_trigger]' );
+      document.querySelector( SEL_PREFIX + '_trigger]' );
     contentDom =
-      document.querySelector( '[data-js-hook=flyout-menu_content]' );
+      document.querySelector( SEL_PREFIX + '_content]' );
     // TODO: check for cases where alt trigger is absent.
     altTriggerDom =
-      document.querySelector( '[data-js-hook=flyout-menu_alt-trigger]' );
+      document.querySelector( SEL_PREFIX + '_alt-trigger]' );
 
     flyoutMenu = new FlyoutMenu( containerDom );
   } );
@@ -64,14 +65,15 @@ describe( 'FlyoutMenu', function() {
     it( 'should have public static methods', function() {
       expect( FlyoutMenu.EXPAND_TYPE ).to.equal( 'expand' );
       expect( FlyoutMenu.COLLAPSE_TYPE ).to.equal( 'collapse' );
-      expect( FlyoutMenu.BASE_CLASS ).to.equal( 'flyout-menu' );
-      expect( FlyoutMenu.BASE_SEL ).to.equal( '[data-js-hook=flyout-menu]' );
+      expect( FlyoutMenu.BASE_CLASS ).to.equal( 'behavior_flyout-menu' );
+      expect( FlyoutMenu.BASE_SEL )
+        .to.equal( '[data-js-hook=behavior_flyout-menu]' );
       expect( FlyoutMenu.ALT_TRIGGER_SEL )
-        .to.equal( '[data-js-hook=flyout-menu_alt-trigger]' );
+        .to.equal( '[data-js-hook=behavior_flyout-menu_alt-trigger]' );
       expect( FlyoutMenu.CONTENT_SEL )
-        .to.equal( '[data-js-hook=flyout-menu_content]' );
+        .to.equal( '[data-js-hook=behavior_flyout-menu_content]' );
       expect( FlyoutMenu.TRIGGER_SEL )
-        .to.equal( '[data-js-hook=flyout-menu_trigger]' );
+        .to.equal( '[data-js-hook=behavior_flyout-menu_trigger]' );
     } );
 
     it( 'should have correct state before initializing', function() {

--- a/test/unit_tests/modules/util/atomic-helpers-spec.js
+++ b/test/unit_tests/modules/util/atomic-helpers-spec.js
@@ -63,12 +63,13 @@ describe( 'atomic-helpers', function() {
   } );
 
   describe( '.setInitFlag()', function() {
-    xit( 'should return true when init flag is set', function() {
-      // TODO: Implement test.
+    it( 'should return true when init flag is set', function() {
+      expect( atomicHelpers.setInitFlag( expandableDom ) ).to.be.true;
     } );
 
-    xit( 'should return false when init flag is already set', function() {
-      // TODO: Implement test.
+    it( 'should return false when init flag is already set', function() {
+      atomicHelpers.setInitFlag( expandableDom );
+      expect( atomicHelpers.setInitFlag( expandableDom ) ).to.be.false;
     } );
   } );
 } );


### PR DESCRIPTION
## Changes

- Adds initialization flag for atomic components so that they bail out of their `init` function if it has already been called.

## Testing

- `gulp build` and inspect the page. Any atomic component should have `data-js-hook="[atomic base class] init"` attributes.
- In Wagtail, it should be possible to add an expandable and an expandable group to a page, or expandable and secondary navigation, and they will both still work.

## Review

- @kave
- @kurtw 
- @jimmynotjim 
- @sebworks 
