### PR TITLE
Added base pagination test before working on pagination bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,8 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 ## Unreleased
 
 ### Added
-- Frontend: Added print styles to hide major site features that aren't
-  print applicable.
+- Added print styles to hide major site features that aren't print applicable.
+- Added base pagination browser tests.
 
 ### Changed
 

--- a/test/browser_tests/shared_objects/filter.js
+++ b/test/browser_tests/shared_objects/filter.js
@@ -16,8 +16,11 @@ var filter = {
 
   searchFilterHideBtn: _getFilterElement( '.m-expandable_cue-close' ),
 
-  searchFilterSubmitBtn: _getFilterElement( 'btn[type="submit"]' )
+  searchCategoryLabel: _getFilterElement(
+    'label[for="filter1_categories_at-the-cfpb"]'
+  ),
 
+  searchFilterSubmitBtn: _getFilterElement( 'input[type="submit"]' )
 };
 
 module.exports = filter;

--- a/test/browser_tests/shared_objects/pagination.js
+++ b/test/browser_tests/shared_objects/pagination.js
@@ -16,7 +16,10 @@ var pagination = {
     paginationContent.element( by.css( '.m-pagination_btn-next' ) ),
 
   paginationPageInput:
-    paginationContent.element( by.css( '#m-pagination_current-page' ) )
+    paginationContent.element( by.css( '#m-pagination_current-page' ) ),
+
+  paginationPageBtn:
+    paginationContent.element( by.css( '#m-pagination_submit-btn' ) )
 
 };
 

--- a/test/browser_tests/spec_suites/blog.js
+++ b/test/browser_tests/spec_suites/blog.js
@@ -123,5 +123,4 @@ describe( 'The Blog Page', function() {
   it( 'should include a page input with value set to 1', function() {
     expect( page.paginationPageInput.getAttribute( 'value' ) === 1 );
   } );
-
 } );

--- a/test/browser_tests/spec_suites/organisms/pagination.js
+++ b/test/browser_tests/spec_suites/organisms/pagination.js
@@ -1,0 +1,39 @@
+'use strict';
+
+var Blog = require(
+    '../../page_objects/page_blog.js'
+  );
+
+describe( 'Pagination', function() {
+  var page;
+
+  beforeEach( function() {
+    page = new Blog();
+    page.get();
+  } );
+
+  it( 'should navigate to the second page', function() {
+    page.paginationNextBtn.click()
+    browser.sleep( 1000 );
+
+    expect( browser.getCurrentUrl() ).toContain( 'page=2' );
+  } );
+
+  it( 'should navigate to the first page', function() {
+    page.paginationNextBtn.click()
+    browser.sleep( 1000 );
+
+    page.paginationPrevBtn.click()
+    browser.sleep( 1000 );
+
+    expect( browser.getCurrentUrl() ).toContain( 'page=1' );
+  } );
+
+  it( 'should navigate to the fifth page', function() {
+    page.paginationPageInput.sendKeys( '5' );
+    page.paginationPageBtn.click();
+    browser.sleep( 1000 );
+
+    expect( browser.getCurrentUrl() ).toContain( 'page=5' );
+  } );
+} );

--- a/test/browser_tests/spec_suites/templates/browse-filterable.js
+++ b/test/browser_tests/spec_suites/templates/browse-filterable.js
@@ -1,0 +1,61 @@
+'use strict';
+
+var Blog = require(
+    '../../page_objects/page_blog.js'
+  );
+
+describe( 'Pagination', function() {
+  var page;
+
+  beforeEach( function() {
+    page = new Blog();
+    page.get();
+  } );
+
+  it( 'should navigate to the first page of filtered results', function() {
+    page.searchFilterBtn.click();
+    browser.sleep( 1000 );
+
+    page.searchCategoryLabel.click();
+    page.searchFilterSubmitBtn.click();
+    browser.sleep( 1000 );
+
+    expect( browser.getCurrentUrl() ).not.toContain( 'page=' );
+    expect( browser.getCurrentUrl() ).toContain( 'at-the-cfpb' );
+  } );
+
+  it( 'should navigate to the second filtered page', function() {
+    page.searchFilterBtn.click();
+    browser.sleep( 1000 );
+
+    page.searchCategoryLabel.click();
+    page.searchFilterSubmitBtn.click();
+    browser.sleep( 1000 );
+
+    page.paginationNextBtn.click()
+    browser.sleep( 1000 );
+
+    expect( browser.getCurrentUrl() ).toContain( 'page=2' );
+    expect( browser.getCurrentUrl() ).toContain( 'at-the-cfpb' );
+  } );
+
+  xit( 'should navigate to the fifth filtered page', function() {
+    // TODO: Fix the input pagination to include existing filters
+    page.searchFilterBtn.click();
+    browser.sleep( 1000 );
+
+    page.searchCategoryLabel.click();
+    page.searchFilterSubmitBtn.click();
+    browser.sleep( 1000 );
+
+    var input = browser.element( by.css( '#m-pagination_current-page' ) );
+    var btn = browser.element( by.css( '#m-pagination_submit-btn' ) );
+
+    input.sendKeys( '5' );
+    btn.click();
+    browser.sleep( 1000 );
+
+    expect( browser.getCurrentUrl() ).toContain( 'page=5' );
+    expect( browser.getCurrentUrl() ).toContain( 'at-the-cfpb' );
+  } );
+} );


### PR DESCRIPTION
There are no tests for pagination interaction. Before taking on fixing the existing filter/pagination combo bug, I'm adding some baseline tests of the functionality.

## Additions

- pagination organism tests
- filtering/pagination template tests

## Testing

- `gulp test:acceptance --sauce=false --specs=blog.js,organisms/pagination.js,templates/browse-filterable.js`

## Review

- @anselmbradford 
- @sebworks 
- @KimberlyMunoz 

## Notes

- The last test is the reported bug, fix forthcoming.

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)

