### PR TITLE
Fixed duplicate Protractor tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 
 - Fixed an issue where the header only had 15px of spacing instead of 30.
 - Fixed the spacing around info-units groups and breadcrumbs.
+- Fixed duplicate Protractor tests.
 
 ## 3.0.0-3.3.12 - 2016-05-05
 

--- a/test/browser_tests/spec_suites/organisms/pagination.js
+++ b/test/browser_tests/spec_suites/organisms/pagination.js
@@ -13,17 +13,17 @@ describe( 'Pagination', function() {
   } );
 
   it( 'should navigate to the second page', function() {
-    page.paginationNextBtn.click()
+    page.paginationNextBtn.click();
     browser.sleep( 1000 );
 
     expect( browser.getCurrentUrl() ).toContain( 'page=2' );
   } );
 
   it( 'should navigate to the first page', function() {
-    page.paginationNextBtn.click()
+    page.paginationNextBtn.click();
     browser.sleep( 1000 );
 
-    page.paginationPrevBtn.click()
+    page.paginationPrevBtn.click();
     browser.sleep( 1000 );
 
     expect( browser.getCurrentUrl() ).toContain( 'page=1' );

--- a/test/browser_tests/spec_suites/templates/browse-filterable.js
+++ b/test/browser_tests/spec_suites/templates/browse-filterable.js
@@ -32,7 +32,7 @@ describe( 'Pagination', function() {
     page.searchFilterSubmitBtn.click();
     browser.sleep( 1000 );
 
-    page.paginationNextBtn.click()
+    page.paginationNextBtn.click();
     browser.sleep( 1000 );
 
     expect( browser.getCurrentUrl() ).toContain( 'page=2' );


### PR DESCRIPTION
The acceptance test task was running duplicate sets of tests due to the Wagtail tests triggering the browser tests after installing the intial data DB. All Protractor acceptance tests are now combined and the intial data is conditionally loaded based on the passed spec params. Tests should run far faster making testing and development easier.

## Additions

- Added `_shouldInstallInitialData` function to test whether specs were passed and if so if they contain a wagtail spec

## Removals

- Removed the duplicate acceptance test trigger `testAcceptanceWagtail`

## Changes

- Updated the `testAcceptanceBrowser` to conditionally load the initial data originally in `testAcceptanceWagtail` before triggering the tests

## Testing

- `gulp test:acceptance --sauce=false` should install the data
- `gulp test:acceptance --sauce=false --specs=organisms/pagination.js,wagtail/molecules.js` should install the data
- `gulp test:acceptance --sauce=false --specs=organisms/pagination.js` should not install the data

## Review

- @anselmbradford 
- @KimberlyMunoz 
- @sebworks 
- @richaagarwal 
- @kurtw 
- @kave 

## Screenshots

<img width="931" alt="screen shot 2016-05-09 at 12 13 55 pm" src="https://cloud.githubusercontent.com/assets/1280430/15121294/8a49cb10-15df-11e6-88b1-c6b863adfd01.png">

vs 

<img width="868" alt="screen shot 2016-05-09 at 12 14 40 pm" src="https://cloud.githubusercontent.com/assets/1280430/15121313/a298c8d8-15df-11e6-978e-feaed6a93682.png">

## Notes

- Thanks to @anselmbradford for helping me think this one through, much simpler solution than where I started.

## Todos

- Fix failing tests. These are outside the scope of this PR.

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)