### PR TITLE
Fixed issue with page jump form.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 ### Added
 - Added print styles to hide major site features that aren't print applicable.
 - Added base pagination browser tests.
-- Image Text 50 50 Organism to Blog Page 
+- Image Text 50 50 Organism to Blog Page
 
 ### Changed
 
@@ -31,6 +31,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Fixed an issue where the header only had 15px of spacing instead of 30.
 - Fixed the spacing around info-units groups and breadcrumbs.
 - Fixed duplicate Protractor tests.
+- Fixed issue with page jump form.
 
 ## 3.0.0-3.3.12 - 2016-05-05
 

--- a/cfgov/jinja2/v1/_includes/molecules/pagination.html
+++ b/cfgov/jinja2/v1/_includes/molecules/pagination.html
@@ -33,7 +33,7 @@
         <a class="btn btn__super m-pagination_btn-prev"
            href="?page={{ posts.previous_page_number()
                           ~ url_parameters(request.GET)
-                          ~ '#o-pagination-content_list' }}">
+                          ~ '#o-filterable-list-controls' }}">
         {%- else %}
         <a class="btn btn__super
                   btn__disabled
@@ -46,20 +46,27 @@
         <a class="btn btn__super m-pagination_btn-next"
            href="?page={{ posts.next_page_number()
                           ~ url_parameters(request.GET)
-                          ~ '#o-pagination-content_list' }}">
+                          ~ '#o-filterable-list-controls' }}">
         {%- else %}
         <a class="btn btn__super btn__disabled m-pagination_btn-next">
         {% endif -%}
             Older
             <span class="btn_icon__right cf-icon cf-icon-right"></span>
         </a>
-        <form data-js-hook="validate_pagination" action="#o-pagination-content_list">
+        <form action="#o-filterable-list-controls">
             <label for="m-pagination_current-page">
                 Page
                 <span class="u-visually-hidden">
                     number out of {{ posts.paginator.num_pages }} total pages
                 </span>
             </label>
+            {% for (key, value) in request.GET.items() %}
+                {% if value != '' %}
+                    <input type="hidden"
+                           name="{{ key }}"
+                           value="{{ value }}">
+                {% endif %}
+            {% endfor %}
             <input id="m-pagination_current-page"
                    name="page"
                    type="number"

--- a/cfgov/jinja2/v1/_includes/organisms/filterable-list-controls.html
+++ b/cfgov/jinja2/v1/_includes/organisms/filterable-list-controls.html
@@ -180,7 +180,8 @@
 {% from 'organisms/post-preview.html' import render as post_preview with context %}
 
 {% macro render(controls, form, index) %}
-    <div class="o-filterable-list-controls">
+    <div class="o-filterable-list-controls"
+         id="o-filterable-list-controls">
         {% set has_active_filters = has_active_filters(page, request, index) %}
         {% if has_active_filters %}
             {% do controls.update({'is_expanded':true}) %}

--- a/cfgov/jinja2/v1/_includes/post-macros.html
+++ b/cfgov/jinja2/v1/_includes/post-macros.html
@@ -89,7 +89,7 @@
             Older
             <span class="btn_icon__right cf-icon cf-icon-right"></span>
         </a>
-        <form class="pagination_form js-validate_pagination" action="#pagination_content">
+        <form class="pagination_form" action="#pagination_content">
             <label class="pagination_label" for="pagination_current-page">
                 Page
                 <span class="u-visually-hidden">

--- a/cfgov/jinja2/v1/events/_paginated.html
+++ b/cfgov/jinja2/v1/events/_paginated.html
@@ -23,7 +23,7 @@
             Older
             <span class="btn_icon__right cf-icon cf-icon-right"></span>
         </a>
-        <form class="pagination_form js-validate_pagination" action="#pagination_content">
+        <form class="pagination_form" action="#pagination_content">
             <label class="pagination_label" for="pagination_current-page">
                 Page
                 <span class="u-visually-hidden">

--- a/cfgov/unprocessed/css/molecules/pagination.less
+++ b/cfgov/unprocessed/css/molecules/pagination.less
@@ -13,7 +13,7 @@
                   Next
                   <span class="btn_icon__right cf-icon cf-icon-right"></span>
               </a>
-              <form data-js-hook="validate_pagination" action="#o-pagination-content_list">
+              <form action="#o-pagination-content_list">
                   <label for="m-pagination_current-page">
                       Page
                       <span class="u-visually-hidden">

--- a/test/browser_tests/spec_suites/templates/browse-filterable.js
+++ b/test/browser_tests/spec_suites/templates/browse-filterable.js
@@ -39,8 +39,7 @@ describe( 'Pagination', function() {
     expect( browser.getCurrentUrl() ).toContain( 'at-the-cfpb' );
   } );
 
-  xit( 'should navigate to the fifth filtered page', function() {
-    // TODO: Fix the input pagination to include existing filters
+  it( 'should navigate to the fifth filtered page', function() {
     page.searchFilterBtn.click();
     browser.sleep( 1000 );
 
@@ -51,7 +50,7 @@ describe( 'Pagination', function() {
     var input = browser.element( by.css( '#m-pagination_current-page' ) );
     var btn = browser.element( by.css( '#m-pagination_submit-btn' ) );
 
-    input.sendKeys( '5' );
+    input.clear().sendKeys( '5' );
     btn.click();
     browser.sleep( 1000 );
 


### PR DESCRIPTION
All other filters are being cleared when entering a page number to the page jump form within the pagination. Added hidden inputs for each existing filter param to submit the form with the appropriate filters. Un-silenced the corresponding test and fixed the input interaction.

## Changes

- Updated the pagination form to loop through any set url params as hidden inputs.
- Un-silenced and updated the corresponding browser test.

## Testing

- `gulp test:acceptance --sauce=false --specs=templates/browse-filterable.js` should pass

## Review

- @sebworks 
- @anselmbradford 
- @KimberlyMunoz 

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)