### PR TITLE
update 98% to 97% of consumers

### DIFF
--- a/cfgov/jinja2/v1/index.html
+++ b/cfgov/jinja2/v1/index.html
@@ -153,7 +153,7 @@
                         </div>
                         <div class="content-l_col content-l_col-1-2__on-lg">
                             <div class="m-card">
-                                <h3 class="h1 m-card_heading">98% of consumers</h3>
+                                <h3 class="h1 m-card_heading">97% of consumers</h3>
                                 <p class="m-card_body">get timely replies when we send their complaints to companies</p>
                             </div>
                         </div>


### PR DESCRIPTION
Fixes outdated 98% number on homepage to match the current number on the [CCDB landing page](http://www.consumerfinance.gov/data-research/consumer-complaints/): 97%.

## Changes

- change static text from 98% to 97% to match CCDB landing

## Review

- @jimmynotjim 

## Todos

- this is a short-term fix in the static content. the permanent fix would update the homepage to reuse the same code that gets this number from the database in the CCDB landing.

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
