### PR TITLE
Fixes issue with spacing after the last item in a full-width component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 ### Fixed
 
 - Fixed a validation bug in the Multiselect.
+- Fixed issue with spacing after the last-child.
 
 
 ## 3.0.0-3.3.14 - 2016-05-11

--- a/cfgov/unprocessed/css/enhancements/typography.less
+++ b/cfgov/unprocessed/css/enhancements/typography.less
@@ -383,6 +383,7 @@ dd {
     - cf-core
 */
 
+p:last-child,
 ul:last-child,
 .list__links .list_item:last-child {
     margin-bottom: 0;

--- a/cfgov/unprocessed/css/molecules/full-width-text.less
+++ b/cfgov/unprocessed/css/molecules/full-width-text.less
@@ -39,7 +39,7 @@
     max-width: 41.8em;
 
     &__serif {
-      font-family: Georgia, 'Times New Roman', serif;
+        font-family: Georgia, 'Times New Roman', serif;
     }
 }
 


### PR DESCRIPTION
The full-width text molecule always lives within a block, which has 60px of bottom spacing. The addition of bottom spacing to the last child of the full-width text molecule was being stacked with the block’s 60px increasing the space more than spec’d. Removing the bottom margin from the last child of the full-width text molecule fixes this issue.

## Changes

- Forced the last child of a full-width text molecule to remove any set padding.

## Testing

- `gulp build` and check out http://localhost:8000/about-us/project-catalyst/. The paragraph wrapping `Get the data` should have 0 bottom margin.

## Review

- @Scotchester 
- @KimberlyMunoz 
- @sebworks 
- @anselmbradford 

## Screenshots

![screen shot 2016-05-12 at 2 04 45 pm](https://cloud.githubusercontent.com/assets/1280430/15226933/80a2ec96-184a-11e6-8afc-6efa4518d330.png)

## Notes

- Thanks to @Scotchester for reporting this bug

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)

