### PR TITLE
Added browser tests for the multiselect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 
 ### Added
 
+- Added browser tests for the multiselect.
+
 ### Changes
 
 ### Removed

--- a/test/browser_tests/page_objects/page_blog.js
+++ b/test/browser_tests/page_objects/page_blog.js
@@ -3,6 +3,7 @@
 var filter = require( '../shared_objects/filter.js' );
 var filterableListControl =
 require( '../shared_objects/filterable-list-control.js' );
+var multiSelect = require( '../shared_objects/multiselect' );
 var pagination = require( '../shared_objects/pagination' );
 var stayInformedSection = require( '../shared_objects/stay-informed-section' );
 var rssSection = require( '../shared_objects/rss-section' );
@@ -10,7 +11,7 @@ var _getQAelement = require( '../util/qa-element' ).get;
 
 function Blog() {
 
-  Object.assign( this, filter, filterableListControl,
+  Object.assign( this, filter, filterableListControl, multiSelect,
     pagination, stayInformedSection, rssSection );
 
   this.get = function() {

--- a/test/browser_tests/shared_objects/multiselect.js
+++ b/test/browser_tests/shared_objects/multiselect.js
@@ -1,0 +1,24 @@
+'use strict';
+
+var _multiSelect =
+  element.all( by.css( '.cf-multi-select' ) ).first();
+
+function _getMultiSelectElement( selector ) {
+  return _multiSelect.element( by.css( selector ) );
+}
+
+var multiSelect = {
+  multiSelect: _multiSelect,
+
+  multiSelectChoices: _getMultiSelectElement( '.cf-multi-select_choices' ),
+
+  multiSelectHeader: _getMultiSelectElement( '.cf-multi-select_header' ),
+
+  multiSelectSearch: _getMultiSelectElement( '.cf-multi-select_search' ),
+
+  multiSelectFieldset: _getMultiSelectElement( '.cf-multi-select_fieldset' ),
+
+  multiSelectOptions: _getMultiSelectElement( '.cf-multi-select_options' )
+};
+
+module.exports = multiSelect;

--- a/test/browser_tests/spec_suites/molecules/multiselect.js
+++ b/test/browser_tests/spec_suites/molecules/multiselect.js
@@ -1,0 +1,208 @@
+'use strict';
+
+var Blog = require(
+    '../../page_objects/page_blog.js'
+  );
+
+describe( 'Multiselect', function() {
+  var page;
+
+  beforeEach( function() {
+    page = new Blog();
+    page.get();
+
+    page.searchFilterBtn.click();
+    browser.sleep( 1000 );
+  } );
+
+  describe( 'on page load', function() {
+    it( 'should create the multiselect', function() {
+      expect( page.multiSelect.isDisplayed() ).toBe( true );
+    } );
+
+    it( 'should not show the dropdown', function() {
+      expect( page.multiSelectFieldset.isDisplayed() ).toBe( false );
+    } );
+  } );
+
+  describe( 'when interacting with search input', function() {
+    it( 'should show the dropdown on click', function() {
+      page.multiSelectSearch.click();
+      browser.sleep( 1000 );
+
+      expect( page.multiSelectFieldset.isDisplayed() ).toBe( true );
+    } );
+
+    xit( 'should show the dropdown on focus', function() {
+      // Couldn't get this to tab over, not sure why
+      var prevInput = browser.element(
+        by.css( 'label[for="filter1_categories_info-for-consumers"]' )
+      );
+      prevInput.click();
+      browser.sleep( 1000 );
+      prevInput.sendKeys( protractor.Key.TAB );
+      browser.sleep( 1000 );
+
+      expect( page.multiSelectFieldset.isDisplayed() ).toBe( true );
+    } );
+
+    it( 'should hide the dropdown when losing focus', function() {
+      page.multiSelectSearch.click();
+      browser.sleep( 1000 );
+      page.multiSelectSearch.sendKeys( protractor.Key.TAB );
+      browser.sleep( 1000 );
+
+      expect( page.multiSelectFieldset.isDisplayed() ).toBe( false );
+    } );
+  } );
+
+  describe( 'when typing in search input', function() {
+    it( 'should return the matched results', function() {
+      page.multiSelectSearch.sendKeys( 'students' );
+      browser.sleep( 1000 );
+
+      var results = browser.element
+        .all( by.css( '.cf-multi-select .filter-match' ) );
+
+      expect( results.count() ).toBe( 1 );
+      expect( results.first().getAttribute( 'data-option' ) )
+        .toContain( 'Students' );
+      expect( page.multiSelectOptions.getAttribute( 'class' ) )
+        .toContain( 'filtered' );
+    } );
+
+    it( 'should not return the unmatched results', function() {
+      page.multiSelectSearch.sendKeys( 'students' );
+      browser.sleep( 1000 );
+
+      var results = browser.element
+        .all( by.css( '.cf-multi-select .filter-match' ) );
+
+      expect( results.first().getAttribute( 'data-option' ) )
+        .not.toContain( 'Mortgages' );
+    } );
+
+    it( 'should clear the input and close the results', function() {
+      page.multiSelectSearch.sendKeys( 'students' );
+      browser.sleep( 1000 );
+      page.multiSelectSearch.sendKeys( protractor.Key.ESCAPE );
+
+      var results = browser.element
+        .all( by.css( '.cf-multi-select .filter-match' ) );
+
+      expect( results.count() ).toBe( 0 );
+      expect( page.multiSelectOptions.getAttribute( 'class' ) )
+        .not.toContain( 'filtered' );
+      expect( page.multiSelectFieldset.isDisplayed() ).toBe( false );
+    } );
+
+    it( 'should highlight the first item', function() {
+      page.multiSelectSearch.click();
+      browser.sleep( 1000 );
+      page.multiSelectSearch.sendKeys( protractor.Key.ARROW_DOWN );
+
+      var results = browser.element
+        .all( by.css( '.cf-multi-select_options li input' ) );
+
+      expect( results.first().getInnerHtml() )
+        .toBe( browser.driver.switchTo().activeElement().getInnerHtml() );
+    } );
+  } );
+
+  describe( 'when interacting with options list', function() {
+    var options = browser.element
+        .all( by.css( '.cf-multi-select_label' ) );
+    var choices;
+
+    it( 'should add an option to choices list when clicked', function() {
+      page.multiSelectSearch.click();
+      browser.sleep( 1000 );
+
+      options.first().click();
+      browser.sleep( 1000 );
+
+      choices = browser.element
+        .all( by.css( '.cf-multi-select_choices label' ) );
+
+      expect( choices.count() ).toBe( 1 );
+      expect( choices.first().getInnerHtml() ).toContain( 'Mortgages' );
+    } );
+
+    it( 'should remove an option from choices when clicked', function() {
+      page.multiSelectSearch.click();
+      browser.sleep( 1000 );
+
+      options.first().click();
+      browser.sleep( 500 );
+      options.first().click();
+      browser.sleep( 1000 );
+
+      choices = browser.element
+        .all( by.css( '.cf-multi-select_choices label' ) );
+
+      expect( choices.count() ).toBe( 0 );
+    } );
+
+    xit( 'should add an option with RETURN key', function() {
+      // Current bug, needs to be fixed. Checks item but doesn't
+      // add it to the choices list
+      page.multiSelectSearch.click();
+      browser.sleep( 1000 );
+      page.multiSelectSearch.sendKeys( protractor.Key.ARROW_DOWN );
+
+      browser.driver.switchTo().activeElement()
+        .sendKeys( protractor.Key.RETURN );
+      browser.sleep( 1000 );
+
+      choices = browser.element
+        .all( by.css( '.cf-multi-select_choices label' ) );
+
+      expect( choices.count() ).toBe( 1 );
+      expect( choices.first().getInnerHtml() ).toContain( 'Mortgages' );
+    } );
+
+    xit( 'should remove an option with RETURN key', function() {
+       // Current bug, needs to be fixed. Checks item but doesn't
+      // add it to the choices list
+      page.multiSelectSearch.click();
+      browser.sleep( 1000 );
+      page.multiSelectSearch.sendKeys( protractor.Key.ARROW_DOWN );
+
+      browser.driver.switchTo().activeElement()
+        .sendKeys( protractor.Key.RETURN );
+      browser.sleep( 1000 );
+      browser.driver.switchTo().activeElement()
+        .sendKeys( protractor.Key.RETURN );
+
+      choices = browser.element
+        .all( by.css( '.cf-multi-select_choices label' ) );
+
+      expect( choices.count() ).toBe( 0 );
+    } );
+  } );
+
+  describe( 'when interacting with choices list', function() {
+    var options = browser.element
+        .all( by.css( '.cf-multi-select_label' ) );
+    var choices;
+
+    it( 'should remove option from choices when clicked', function() {
+      page.multiSelectSearch.click();
+      browser.sleep( 1000 );
+
+      options.first().click();
+      browser.sleep( 1000 );
+
+      choices = browser.element
+        .all( by.css( '.cf-multi-select_choices label' ) );
+
+      choices.first().click();
+      browser.sleep( 1000 );
+
+      choices = browser.element
+        .all( by.css( '.cf-multi-select_choices label' ) );
+
+      expect( choices.count() ).toBe( 0 );
+    } );
+  } );
+} );


### PR DESCRIPTION
There were no tests, fixing that with some baseline tests of: initialization, default results, filtering, clearing results, and keyboard highlighting.

## Additions

- Multiselect objects for testing
- Tests of basic behaviors

## Testing

- `gulp test:acceptance --sauce=false --specs=molecules/multiselect.js`

## Review

- @KimberlyMunoz 
- @anselmbradford 
- @sebworks 

## Notes

- Hit me with other behaviors you think we should test! These seemed like the most important to start with.

## Todos

- Add even more tests (but don't get so out of hand it becomes brittle).

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
