### PR TITLE
Secondary navigation refactoring

### DIFF
--- a/cfgov/jinja2/v1/_includes/organisms/secondary-navigation.html
+++ b/cfgov/jinja2/v1/_includes/organisms/secondary-navigation.html
@@ -8,7 +8,7 @@
 
    Creates markup for Header organism.
 
-   TODO: `active_nav_id` and `vars` parameters can be removed when
+   TODO: `active_nav_id` and `nav_items` parameters can be removed when
          `_render_secondary_navigation_deprecated` is removed.
 
    active_nav_id: Name of active navigation item.
@@ -47,36 +47,30 @@
 
     {% from 'molecules/expandable.html' import expandable with context %}
     {% call() expandable(sec_nav_settings) %}
-        {{ _secondary_navigation(nav_items, active_nav_id) | safe }}
+        {% import 'molecules/nav-link.html' as nav_link %}
+        <ul class="o-secondary-navigation_list
+                   o-secondary-navigation_list__parents">
+        {%- for item in nav_items %}
+            <li data-nav-is-active="{{ request.url.startswith(item.url) }}">
+                {{ nav_link.render(item.title, item.url, true, item.url == request.url) }}
+            {%- if item.children -%}
+                <ul class="o-secondary-navigation_list
+                           o-secondary-navigation_list__children">
+                {%- for child in item.children -%}
+                    <li>
+                        {{ nav_link.render(child.title, child.url, false, child.url == request.url) }}
+                    </li>
+                {%- endfor %}
+                </ul>
+            {%- endif -%}
+            </li>
+
+        {%- endfor %}
+        </ul>
     {% endcall %}
 </nav>
 {% endmacro %}
 
-{# ==========================================================================
-
-   _secondary_navigation()
-
-   ========================================================================== #}
-{% macro _secondary_navigation(items, active_item_id) %}
-{% import 'molecules/nav-link.html' as nav_link %}
-    <ul class="o-secondary-navigation_list
-               o-secondary-navigation_list__parents">
-        {%- for item in items %}
-            <li data-nav-is-active="{{ request.url.startswith(item.url) }}">
-                {{ nav_link.render(item.title, item.url, true, item.url == request.url) }}
-                {%- for child in item.children -%}
-                    <ul class="o-secondary-navigation_list
-                               o-secondary-navigation_list__children">
-                        <li>
-                            {{ nav_link.render(child.title, child.url, false, child.url == request.url) }}
-                        </li>
-                    </ul>
-                {%- endfor %}
-            </li>
-
-        {%- endfor %}
-    </ul>
-{% endmacro %}
 
 {# TODO: Remove `_render_secondary_navigation_deprecated` and
          `_secondary_navigation_deprecated` when non-wagtail pages
@@ -98,38 +92,29 @@
 
     {% from 'molecules/expandable.html' import expandable with context %}
     {% call() expandable(sec_nav_settings) %}
-        {{ _secondary_navigation_deprecated(nav_items, active_nav_id) | safe }}
-    {% endcall %}
-</nav>
-{% endmacro %}
-
-{# ==========================================================================
-
-   _secondary_navigation_deprecated()
-
-   ========================================================================== #}
-{% macro _secondary_navigation_deprecated(items, active_item_id) %}
-{% import 'molecules/nav-link.html' as nav_link %}
-<ul class="o-secondary-navigation_list
-           o-secondary-navigation_list__parents">
-    {%- for item in items %}
-        {%- set href, id, caption, children = item[0], item[1], item[2], item[3:] %}
-
-    <li>
-        {{ nav_link.render(caption, href, true, id == active_item_id) }}
-    {%- if children -%}
-        {% set children = children[0] %}
+        {% import 'molecules/nav-link.html' as nav_link %}
         <ul class="o-secondary-navigation_list
-                   o-secondary-navigation_list__children">
-        {%- for href, id, caption in children %}
+                   o-secondary-navigation_list__parents">
+        {%- for item in nav_items %}
+            {%- set href, id, caption, children = item[0], item[1], item[2], item[3:] %}
+
             <li>
-                {{ nav_link.render(caption, href, false, id == active_item_id) }}
+                {{ nav_link.render(caption, href, true, id == active_nav_id) }}
+            {%- if children -%}
+                {% set children = children[0] %}
+                <ul class="o-secondary-navigation_list
+                           o-secondary-navigation_list__children">
+                {%- for href, id, caption in children %}
+                    <li>
+                        {{ nav_link.render(caption, href, false, id == active_nav_id) }}
+                    </li>
+                {%- endfor %}
+                </ul>
+            {%- endif %}
             </li>
+
         {%- endfor %}
         </ul>
-    {%- endif %}
-    </li>
-
-    {%- endfor %}
-</ul>
+    {% endcall %}
+</nav>
 {% endmacro %}

--- a/cfgov/unprocessed/css/on-demand/secondary-navigation.less
+++ b/cfgov/unprocessed/css/on-demand/secondary-navigation.less
@@ -45,6 +45,4 @@
 /* Organism pieces
    ========================================================================== */
 
-.o-secondary-navigation {
-  @import (less) "../organisms/secondary-navigation.less";
-}
+@import (less) "../organisms/secondary-navigation.less";

--- a/cfgov/unprocessed/css/organisms/secondary-navigation.less
+++ b/cfgov/unprocessed/css/organisms/secondary-navigation.less
@@ -32,29 +32,29 @@
             .o-secondary-navigation_list.o-secondary-navigation_list__parents
               li
                 m-nav-link
-    - name: Secondary nav mixed with cf-expandable
+    - name: Secondary nav mixed with atomic expandable
       markup: |
-        <nav class="expandable
+        <nav class="m-expandable
                     o-secondary-navigation">
-            <div class="expandable_header">
-                <button class="expandable_target
+            <div class="m-expandable_header">
+                <button class="m-expandable_target
                                o-secondary-navigation_button">
-                    <span class="expandable_header-left">
+                    <span class="m-expandable_header-left">
                         Nav Button
                     </span>
-                    <span class="expandable_header-right">
-                        <span class="expandable_cue-open">
+                    <span class="m-expandable_header-right">
+                        <span class="m-expandable_cue-open">
                             <span class="cf-icon
                                          cf-icon-down"></span>
                         </span>
-                        <span class="expandable_cue-close">
+                        <span class="m-expandable_cue-close">
                             <span class="cf-icon
                                          cf-icon-up"></span>
                         </span>
                     </span>
                 </button>
             </div>
-            <div class="expandable_content">
+            <div class="m-expandable_content">
                 <ul class="o-secondary-navigation_list
                            o-secondary-navigation_list__parents">
                     li
@@ -70,16 +70,16 @@
         - |
           Structural cheat sheet:
           -----------------------
-          .expandable.o-secondary-navigation
-            .expandable_header
-              .expandable_target.o-secondary-navigation_button
-                .expandable_header-left
-                .expandable_header-right
-                  .expandable_cue-open
+          .m-expandable.o-secondary-navigation
+            .m-expandable_header
+              .m-expandable_target.o-secondary-navigation_button
+                .m-expandable_header-left
+                .m-expandable_header-right
+                  .m-expandable_cue-open
                     .cf-icon.cf-icon-down
-                  .expandable_cue-close
+                  .m-expandable_cue-close
                     .cf-icon.cf-icon-up
-            .expandable_content
+            .m-expandable_content
               .o-secondary-navigation_list.o-secondary-navigation_list__parents
                 li
                   m-nav-link
@@ -96,6 +96,11 @@
       } );
     }
 
+    // TODO: If secondary navigation is overriding m-expandables appearance,
+    //       they aren't atomic expandables anymore per the design spec.
+    //       Secondary navigation should use FlyoutMenu for expandable-like
+    //       behavior and handle its own styling
+    //       (possibly shared with expandables).
     .m-expandable_target {
         .webfont-demi();
 


### PR DESCRIPTION
## Changes

- Simplifies secondary navigation internal macros to reduce from four to two per @Scotchester suggestion in https://github.com/cfpb/cfgov-sheer-templates/pull/16#issuecomment-218890307
- Fixes issue in on-demand secondary navigation where it was always mobile (thanks to @jimmynotjim for pointing that out).
- Updates documentation.

## Testing

- `gulp build && gulp scripts:ondemand && gulp styles:ondemand`
Secondary navigation should work in the following contexts:
  - wagtail: `/policy-compliance/rulemaking/final-rules/?page=6#o-pagination-content_list`
  - non-wagtail: `/about-us/careers/application-process/`
  - on-demand: `/test-fixture/?atomic=secondary-navigation`

## Review

- @jimmynotjim 
- @Scotchester 
- @sebworks 
- @KimberlyMunoz 