### PR TITLE
Jobs fixes

### DIFF
--- a/cfgov/jinja2/v1/about-us/careers/_macro-table-current-openings.html
+++ b/cfgov/jinja2/v1/about-us/careers/_macro-table-current-openings.html
@@ -43,7 +43,7 @@
                 {{ time.render(career.close_date, {'date':true}) }}
             </td>
             <td data-label="Location">
-                {{ career.locations.all()|join(', ') }}
+                {{ career.location_names|join(', ') }}
             </td>
         </tr>
     {% endfor %}

--- a/cfgov/jinja2/v1/about-us/careers/_macro-table-current-openings.html
+++ b/cfgov/jinja2/v1/about-us/careers/_macro-table-current-openings.html
@@ -37,7 +37,7 @@
     {% for career in careers %}
         <tr>
             <td>
-                <a href="{{url('careers:detail',args=[career.pk])}}">{{ career.title }}</a>
+                <a href="{{url('careers:detail',args=[career.slug])}}">{{ career.title }}</a>
             </td>
             <td data-label="Posting Closes">
                 {{ time.render(career.close_date, {'date':true}) }}

--- a/cfgov/jinja2/v1/about-us/careers/_single.html
+++ b/cfgov/jinja2/v1/about-us/careers/_single.html
@@ -28,7 +28,7 @@
                     block__sub">
         <h1>{{ career.title }}</h1>
         <dl>
-            <dt>Office: </dt>
+            <dt>Division/Office: </dt>
             <dd> {{career.category}}</dd>
             <dt>Expiration Date:</dt>
             <dd>
@@ -66,15 +66,15 @@
         <h2>Job Description</h2>
         {{ career.description | safe }}
 
-        <div class="content-l">
-            <p> <br/>   <em>
+    </section>
+
+        <section class="block">
+            <em>
         The Consumer Financial Protection Bureau (CFPB) is an equal opportunity
         employer and seeks to create and maintain a vibrant and diverse
         workforce. Women, minorities, veterans, and people with disabilities
-        are encouraged to apply.</em></p>
-    </div>
+        are encouraged to apply.</em>
     </section>
-
     <section class="block
                     block__padded-top
                     block__border-top">

--- a/cfgov/jinja2/v1/about-us/careers/_single.html
+++ b/cfgov/jinja2/v1/about-us/careers/_single.html
@@ -28,6 +28,8 @@
                     block__sub">
         <h1>{{ career.title }}</h1>
         <dl>
+            <dt>Office: </dt>
+            <dd> {{career.category}}</dd>
             <dt>Expiration Date:</dt>
             <dd>
                 {% import 'macros/time.html' as time %}
@@ -64,19 +66,13 @@
         <h2>Job Description</h2>
         {{ career.description | safe }}
 
-        {# TODO: Discuss how to break duties and departments out of
-                 the description.
-        <h2>Duties</h2>
-        <h3>As a test opening, you will:</h3>
-        <ul class="list__branded">
-            <li>Lorem ipsum...place first duty here</li>
-            <li>Lorem ipsum..place second duty here</li>
-            <li>Etc, etc, etc</li>
-        </ul>
-
-        <h2>Departments</h2>
-        <p>Multiple offices</p>
-        #}
+        <div class="content-l">
+            <p> <br/>   <em>
+        The Consumer Financial Protection Bureau (CFPB) is an equal opportunity
+        employer and seeks to create and maintain a vibrant and diverse
+        workforce. Women, minorities, veterans, and people with disabilities
+        are encouraged to apply.</em></p>
+    </div>
     </section>
 
     <section class="block

--- a/cfgov/jobmanager/models.py
+++ b/cfgov/jobmanager/models.py
@@ -98,7 +98,7 @@ class Job(models.Model):
         ordering = ['close_date', 'title']
 
     def get_absolute_url(self):
-        return reverse('careers:detail', kwargs={'job_id': self.id})
+        return reverse('careers:detail', kwargs={'slug': self.slug})
 
     def save(self):
         if self.date_created == None:

--- a/cfgov/jobmanager/models.py
+++ b/cfgov/jobmanager/models.py
@@ -149,6 +149,10 @@ class Job(models.Model):
 
         return strip_tags(text)
 
+    @property
+    def location_names(self):
+        return [l.region_long for l in self.locations.all()]
+
 
 class JobApplicantType(models.Model):
     application_type = models.ForeignKey(ApplicantType)

--- a/cfgov/jobmanager/urls.py
+++ b/cfgov/jobmanager/urls.py
@@ -19,5 +19,6 @@ urlpatterns = patterns(
     # Deprecated /jobs/design-technology-fellows/. Will keep it to keep the external links functioning
     url(r'^fellowship_form_submit/$', 'fellowship_form_submit', name='fellowship_form_submit'),
 
-    url(r'^(?P<job_id>(.+?))/$', 'detail', name='detail'),
+    url(r'^(?P<pk>\d+)/$', 'detail', name='detail-id-redirect'),
+    url(r'^(?P<slug>.+?)/$', 'detail', name='detail'),
 )

--- a/cfgov/jobmanager/views.py
+++ b/cfgov/jobmanager/views.py
@@ -1,5 +1,5 @@
 from django.http import HttpResponseNotFound, HttpResponse
-from django.shortcuts import render, get_object_or_404
+from django.shortcuts import render, get_object_or_404, redirect
 from django.template import RequestContext
 from django.http import HttpRequest
 from django.http import Http404
@@ -39,13 +39,18 @@ def index(request):
     return render(request, "about-us/careers/index.html", context)
 
 
-def detail(request,job_id):
+def detail(request, pk=None, slug=None):
     today = timezone.now().date()
-    job_pk = int(job_id)
-    job = Job.objects.filter(pk=job_id, open_date__lte=today,
-            close_date__gte=today,active=True).get()
 
+    qs = Job.objects.filter(open_date__lte=today,
+                close_date__gte=today,active=True)
+    if pk:
+        job = get_object_or_404(qs, pk=pk)
 
+        return redirect(job.get_absolute_url())
+
+    if slug:
+        job = get_object_or_404(qs, slug=slug)
     salary_min = int(job.salary_min or min([g.salary_min 
         for g in job.grades.all()]))
     salary_max = int(job.salary_max or max([g.salary_max


### PR DESCRIPTION
**I'm going to be gone next week, someone else will probably need to merge it, or make changes if needed**

- use the long region description on the 'current openings' page
- add "office" to the information at the top of job listing, and EEO notice at the bottom
- Restore the usage of URL slugs instead of numeric ID's
- fixes a logic flaw that was causing missing or expired jobs to generate errors (instead of 404's)

Addresses: DFJR-1420, DFJR-1404, most of DFJR-1416, 

@schaferjh this does not fix the spacing issues in 1416

## Testing

- load this SQL: [jobs.sql.zip](https://github.com/cfpb/cfgov-refresh/files/263953/jobs.sql.zip)
- observe that http://localhost:8000/about-us/careers/current-openings/ shows "Washington, DC" instead of "HQ".
- Click a job, and observe that the 'Office' is listed, and the Equal Opportunity text is near the bottom

## Review

- @richaagarwal @kave @kurtw  @schaferjh 

## Screenshots

![image](https://cloud.githubusercontent.com/assets/235397/15260148/2df9c1de-1923-11e6-9509-91c4dc6af947.png)


## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)