### PR TITLE
Removed Silberman and Fuchs from Leadership calendar filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,9 +18,12 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 ### Added
 
 ### Changes
+
 - Updated Capital Framework to latest.
 
 ### Removed
+
+- Removed acting Dept Directors from Leadership calendar filter
 
 ### Fixed
 

--- a/cfgov/jinja2/v1/_includes/macros/filters.html
+++ b/cfgov/jinja2/v1/_includes/macros/filters.html
@@ -213,8 +213,6 @@
         {% if filters.calendar %}
         {% set directors_list = [
             'Richard Cordray',
-            'David Silberman',
-            'Meredith Fuchs',
             'Steve Antonakes',
             'Raj Date',
             'Elizabeth Warren'


### PR DESCRIPTION
Acting officers shouldn't be listed in the leadership calendar. Removed them from the list of directors in the calendar filters.

## Removals

- Silberman and Fuchs from leadership calendar

## Testing

- Navigate to http://localhost:8000/about-us/the-bureau/leadership-calendar/ and make sure the two acting deputy directors are no longer listed as options. There were no results for them to begin with.

## Review

- @anselmbradford 
- @sebworks 
- @KimberlyMunoz 
- @schaferjh 

## Screenshots

![screen shot 2016-05-13 at 3 53 07 pm](https://cloud.githubusercontent.com/assets/1280430/15261534/ccd9cff2-1922-11e6-9196-0cffaab19f37.png)

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)