### PR TITLE
Fixed a validation bug in the Multiselect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,9 +23,11 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 
 ### Removed
 
-- Removed acting Dept Directors from Leadership calendar filter
+- Removed acting Dept Directors from Leadership calendar filter.
 
 ### Fixed
+
+- Fixed a validation bug in the Multiselect.
 
 
 ## 3.0.0-3.3.14 - 2016-05-11

--- a/cfgov/unprocessed/js/modules/util/strings.js
+++ b/cfgov/unprocessed/js/modules/util/strings.js
@@ -16,7 +16,7 @@ function stringEscape( s ) {
  *   True if string `s` contains special characters, false otherwise.
  */
 function stringValid( s ) {
-  return !( /[~`!#$%\^&*+=\[\]\\';,/{}|\\":<>\?]/g ).test( s );
+  return !( /[~`!.#$%\^&*+=\[\]\\';,/{}|\\":<>\?]/g ).test( s );
 }
 
 /**

--- a/test/unit_tests/modules/util/strings-spec.js
+++ b/test/unit_tests/modules/util/strings-spec.js
@@ -57,6 +57,14 @@ describe( 'Strings stringValid()', function() {
     }
   );
 
+  it( 'should return false when testing a string containing a period',
+    function() {
+      string = 'Some P. Name';
+
+      expect( strings.stringValid( string ) ).to.be.false;
+    }
+  );
+
   it( 'should return false when testing a string containing a colon',
     function() {
       string = 'Person: Name';


### PR DESCRIPTION
When an author (or any string) contains a period, it is not a valid value. Updated the string validator to check strings for periods. Now the Multiselect will skip initialization and log a helper message if the value contains a period.

## Changes

- Added period to string validation regex.
- Added a test for the string validation using a period in the test string.

## Testing

- `gulp test:unit:scripts`

## Review

- @anselmbradford 
- @KimberlyMunoz 
- @kurtw 

## Notes

We really should get these values fixed in the DB to properly stringified values

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)