### PR TITLE
Removes redundant script includes

### DIFF
--- a/cfgov/unprocessed/js/organisms/FilterableListControls.js
+++ b/cfgov/unprocessed/js/organisms/FilterableListControls.js
@@ -3,6 +3,7 @@
 // Required modules.
 var atomicHelpers = require( '../modules/util/atomic-helpers' );
 var ERROR_MESSAGES = require( '../config/error-messages-config' );
+var Expandable = require( '../molecules/Expandable' );
 var getClosestElement = require( '../modules/util/dom-traverse' ).closest;
 var Multiselect = require( '../molecules/Multiselect' );
 var Notification = require( '../molecules/Notification' );
@@ -43,6 +44,12 @@ function FilterableListControls( element ) {
    * Initialize FilterableListControls instance.
    */
   function init( ) {
+
+    // TODO: FilterableListControls should use expandable
+    //       behavior (FlyoutMenu), not an expandable directly.
+    var expandable = new Expandable( _dom );
+    expandable.init();
+
     _notification = new Notification( _dom );
     _notification.init();
 

--- a/cfgov/v1/atomic_elements/organisms.py
+++ b/cfgov/v1/atomic_elements/organisms.py
@@ -195,6 +195,9 @@ class ItemIntroduction(blocks.StructBlock):
         classname = 'block__flush-top'
 
 
+# TODO: FilterControls/Filterable List should be updated to use same
+#       atomic name used on the frontend of FilterableListControls,
+#       or vice versa.
 class FilterControls(molecules.BaseExpandable):
     form_type = blocks.ChoiceBlock(choices=[
         ('filterable-list', 'Filterable List'),
@@ -221,4 +224,4 @@ class FilterControls(molecules.BaseExpandable):
         icon = 'form'
 
     class Media:
-        js = ['notification.js', 'expandable.js', 'filterable-list-controls.js']
+        js = ['filterable-list-controls.js']


### PR DESCRIPTION
## Changes

- Updates FilterableListControls to instantiate its internal expandable.
- Removes redundant script includes in the wagtail ondemand script include.

## Testing

- `gulp build` and `/blog/` should still work.

## Review

- @kurtw 
- @jimmynotjim 
- @KimberlyMunoz 

## Notes

- Organisms should instantiate their own molecules. `expandable.js` should only ever need to be included when there is a standalone expandable on the page.