### PR TITLE
Fixed issue with single careers layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,8 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 ## Unreleased
 
 ### Added
-- `parse_links` calls on rich text fields on the rest of the fields
 
+- `parse_links` calls on rich text fields on the rest of the fields
 - Added browser tests for the multiselect.
 
 ### Changes
@@ -25,9 +25,10 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 ### Removed
 
 ### Fixed
+
 - Removed wrapping `<p>` tag on a form field's description field output,
   since it's a rich text field that provides its own markup.
-
+- Fixed issue with single careers layout.
 
 ## 3.0.0-3.3.15 - 2016-05-16
 

--- a/cfgov/jinja2/v1/about-us/careers/_single.html
+++ b/cfgov/jinja2/v1/about-us/careers/_single.html
@@ -80,7 +80,7 @@
                     block__border-top">
         <div class="content-l">
             <div class="content-l_col content-l_col-1-2">
-                <h2 class="u-mb0" id="interested">Interested in Applying?</h2>
+                <h2 id="interested">Interested in Applying?</h2>
             </div>
             <div class="t-careers_social
                         content-l_col
@@ -94,39 +94,38 @@
                 } ) }}
             </div>
         </div>
-        <div class="block">
-            <h3>Before you apply</h3>
-            <p>
-                {# TODO: Replace with real content. #}
-            </p>
-            <ul class="list list__links">
-                <li class="list_item">
-                    <a class="jump-link"
-                       href="/about-us/careers/working-at-cfpb/">
-                        Learn about working @ CFPB
-                    </a>
-                </li>
-                <li class="list_item">
-                    <a class="jump-link"
-                       href="/about-us/careers/application-process/">
-                        Learn about the application process
-                    </a>
-                </li>
-            </ul>
-        </div>
-        {% for job_applicant_type in career.jobapplicanttype_set.all() %}
-        <div class="block block__bg block__border">
-            <h4>{{ job_applicant_type.application_type.applicant_type }}</h4>
-            <p>{{ job_applicant_type.application_type.description | striptags }}</p>
+        <h3>Before you apply</h3>
+        {# TODO: Replace with real content. #}
+        {#<p>
 
-            <p><a class="btn" href="{{ job_applicant_type.usajobs_url }}">Apply now</a></p>
-
-            <p>
-                You are about to leave consumerfinance.gov. To submit the application, you must go to USAJobs.gov.
-            </p>
-        </div>
-        {% endfor %}
+        </p>#}
+        <ul class="list list__links">
+            <li class="list_item">
+                <a class="jump-link"
+                   href="/about-us/careers/working-at-cfpb/">
+                    Learn about working @ CFPB
+                </a>
+            </li>
+            <li class="list_item">
+                <a class="jump-link"
+                   href="/about-us/careers/application-process/">
+                    Learn about the application process
+                </a>
+            </li>
+        </ul>
     </section>
+    {% for job_applicant_type in career.jobapplicanttype_set.all() %}
+    <div class="block block__bg block__border">
+        <h4>{{ job_applicant_type.application_type.applicant_type }}</h4>
+        <p>{{ job_applicant_type.application_type.description | striptags }}</p>
+
+        <p><a class="btn" href="{{ job_applicant_type.usajobs_url }}">Apply now</a></p>
+
+        <p>
+            You are about to leave consumerfinance.gov. To submit the application, you must go to USAJobs.gov.
+        </p>
+    </div>
+    {% endfor %}
 
 {% endblock %}
 


### PR DESCRIPTION
There is extra spacing at the bottom of individual careers between the "Interested in Applying" text and the content that followed. Removed the extra blocks so that the content follows the proper flow.

## Changes

- Updated markup to remove excess block div.

## Testing

- ¯\_(ツ)_/¯ I can't seem to get the individual careers locally, but this worked when making the same modifications in the console on www. See screenshot below.

## Review

- @schaferjh 
- @KimberlyMunoz 
- @anselmbradford 

## Screenshots

![screen shot 2016-05-16 at 11 16 48 am](https://cloud.githubusercontent.com/assets/1280430/15295772/b3ce8688-1b57-11e6-895e-74740e746a85.png)

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)

