### PR TITLE
Remove p tag wrapping rich text field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 ### Removed
 
 ### Fixed
+- Removed wrapping `<p>` tag on a form field's description field output,
+  since it's a rich text field that provides its own markup.
 
 
 ## 3.0.0-3.3.15 - 2016-05-16

--- a/cfgov/jinja2/v1/_includes/molecules/form-field-with-button.html
+++ b/cfgov/jinja2/v1/_includes/molecules/form-field-with-button.html
@@ -42,6 +42,6 @@
                class="m-form-field-with-button_field"
                {{ 'required' if value.required else '' }}>
     </div>
-    <p>{{ parse_links(value.info) | safe }}</p>
+    {{ parse_links(value.info) | safe }}
     <input class="btn btn__full" type="submit" value="{{ value.btn_text }}">
 </div>


### PR DESCRIPTION
## Fixes
- Removed wrapping `<p>` tag on a form field's description field output, since it's a rich text field that provides its own markup.

## Testing

1. Pull down branch
2. Go to any page with an Email Signup organism
3. View source on the info below the field and verify that you're no longer seeing stuff like this:

   ```html
   <p><p>
       The information you provide will permit the Consumer Financial Protection Bureau
       to process your request or inquiry.
       <a href="http://beta.consumerfinance.gov/privacy/privacy-policy/">See More</a>.
   </p></p>
   ```

## Review

- @KimberlyMunoz 
- @sebworks 
- @anselmbradford 
- @jimmynotjim 

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)

