### PR TITLE
Wrap parse_links for every RichTextField/Block instance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 ## Unreleased
 
 ### Added
+- `parse_links` calls on rich text fields on the rest of the fields
 
 ### Changes
 

--- a/cfgov/jinja2/v1/_includes/molecules/half-width-link-blob.html
+++ b/cfgov/jinja2/v1/_includes/molecules/half-width-link-blob.html
@@ -27,6 +27,6 @@
 
 {{ info_unit( {
     'heading': '<h3>' ~ value.heading ~ '</h3>' if value.heading else '',
-    'body':    value.body,
+    'body':    parse_links(value.body) | safe,
     'links':   value.links
 } ) }}

--- a/cfgov/jinja2/v1/_includes/molecules/image-text-25-75.html
+++ b/cfgov/jinja2/v1/_includes/molecules/image-text-25-75.html
@@ -45,6 +45,6 @@
         'is_decorative': value.image.alt == ''
     },
     'heading': '<h3>' ~ value.heading ~ '</h3>',
-    'body': value.body,
+    'body': parse_links(value.body) | safe,
     'links': value.links
 } ) }}

--- a/cfgov/jinja2/v1/_includes/molecules/image-text-50-50.html
+++ b/cfgov/jinja2/v1/_includes/molecules/image-text-50-50.html
@@ -50,7 +50,7 @@
         'is_decorative': value.image.alt == ''
     },
     'heading': '<h3>' ~ value.heading ~ '</h3>',
-    'body': value.body,
+    'body': parse_links(value.body) | safe,
     'is_button': value.is_button,
     'links': value.links
 } ) }}

--- a/cfgov/jinja2/v1/_includes/organisms/post-preview.html
+++ b/cfgov/jinja2/v1/_includes/organisms/post-preview.html
@@ -142,7 +142,7 @@
             {% endif %}
             {% if post.preview_description %}
                 <div class="o-post-preview_description">
-                    {{ post.preview_description | safe }}
+                    {{ parse_links(post.preview_description) | safe }}
                 </div>
             {% endif %}
             <div class="post_meta">

--- a/cfgov/jinja2/v1/_includes/organisms/table.html
+++ b/cfgov/jinja2/v1/_includes/organisms/table.html
@@ -26,9 +26,15 @@
             {% set colcount = loop.index %}
             {% for thead in value.headers %}
                 {% if colcount == loop.index %}
-                    <td data-label="{{ thead }}">
-                        {{ cell | safe }}
-                    </td>
+                    {% if 'rich_text_blob' in cell.block_type %}
+                        <td data-label="{{ thead }}">
+                            {{ parse_links(cell) | safe }}
+                        </td>
+                    {% else %}
+                        <td data-label="{{ thead }}">
+                            {{ cell | safe }}
+                        </td>
+                    {% endif %}
                 {% endif %}
             {% endfor %}
         {% endfor %}

--- a/cfgov/jinja2/v1/events/_event-detail.html
+++ b/cfgov/jinja2/v1/events/_event-detail.html
@@ -7,11 +7,11 @@
         </h1>
         <p class="post_dek">
         {% if (event_state == 'past') %}
-            {{ page.archive_body | striptags }}
+            {{ parse_links(page.archive_body) | safe }}
         {% elif (event_state == 'present') %}
-            {{ page.live_body | striptags }}
+            {{ parse_links(page.live_body) | safe }}
         {% elif (event_state == 'future') %}
-            {{ page.future_body | striptags }}
+            {{ parse_links(page.future_body) | safe }}
         {% endif %}
         </p>
         <div class="t-event_details">
@@ -91,7 +91,7 @@
             </div>
         </aside>
         {% endif %}
-        {{ page.body | safe }}
+        {{ parse_links(page.body) | safe }}
     </div>
     {% if page.tags.names() | length %}
     <footer>


### PR DESCRIPTION
Rich text fields can have links that need to be dealt with. This also removes that annoying `div class="rich-text"`.

## Additions

- `parse_links` calls

## Testing

- Go to each changed module and verify they render safely
 - cfgov/jinja2/v1/_includes/molecules/half-width-link-blob.html
 - cfgov/jinja2/v1/_includes/molecules/image-text-25-75.html
 - cfgov/jinja2/v1/_includes/organisms/post-preview.html
 - cfgov/jinja2/v1/_includes/organisms/table.html
 - cfgov/jinja2/v1/events/_event-detail.html

## Review

- @kave 
- @richaagarwal 
- @jimmynotjim 
- @anselmbradford 

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)

