### PR TITLE
Automate content updates from Wagtail

### DIFF
--- a/.env_SAMPLE
+++ b/.env_SAMPLE
@@ -29,7 +29,7 @@ export ALLOW_ADMIN_URL=True
 #export ENABLE_AKAMAI_CACHE_PURGE=<boolean_enable_purging_akamai_cache>
 #export AKAMAI_USER=<akamai_username>
 #export AKAMAI_PASSWORD=<akamai_password>
-#export AKAMAI_NOTIFY=<akamai_notify_email>
+#export AKAMAI_NOTIFY_EMAIL=<akamai_notify_email>
 #export AKAMAI_HOST=<akamai_hostname>
 
 ############################

--- a/.env_SAMPLE
+++ b/.env_SAMPLE
@@ -26,6 +26,11 @@ export STAGING_HOSTNAME='content.localhost'
 #export DEMO_PAGE=<boolean_enable_demo_page_use>
 #export EXTERNAL_LINK_CSS=<external_links_css_class_name>
 export ALLOW_ADMIN_URL=True
+#export ENABLE_AKAMAI_CACHE_PURGE=<boolean_enable_purging_akamai_cache>
+#export AKAMAI_USER=<akamai_username>
+#export AKAMAI_PASSWORD=<akamai_password>
+#export AKAMAI_NOTIFY=<akamai_notify_email>
+#export AKAMAI_HOST=<akamai_hostname>
 
 ############################
 # Mysql Database Server.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Add unit tests for filterable list functions
 - Added browser tests for the multiselect.
 - Fix category filtering
+- Ability to refresh akamai cache on page publish
 
 ### Changes
 - filterable_context.py -> filterable_list.py

--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -78,6 +78,7 @@ OPTIONAL_APPS=[
     {'import':'eregsip','apps':('eregsip',)},
     {'import':'regulations','apps':('regulations',)},
     {'import':'picard','apps':('picard',)},
+    {'import':'publish-eccu','apps':('publish-eccu',)},
 ]
 
 MIDDLEWARE_CLASSES = (
@@ -497,3 +498,6 @@ ACCOUNT_CODE = os.environ.get('GOVDELIVERY_ACCOUNT_CODE')
 # Regulations.gov environment variables
 REGSGOV_BASE_URL = os.environ.get('REGSGOV_BASE_URL')
 REGSGOV_API_KEY = os.environ.get('REGSGOV_API_KEY')
+
+# Akamai
+ENABLE_AKAMAI_CACHE_PURGE = os.environ.get('ENABLE_AKAMAI_CACHE_PURGE', False)

--- a/cfgov/v1/wagtail_hooks.py
+++ b/cfgov/v1/wagtail_hooks.py
@@ -67,9 +67,11 @@ def configure_page_revision(page, is_publishing):
 
             url_paths = [page.url_path.replace('cfgov/', '')]
             if url_paths[0] == '/':
-                akamai_cache_reset(url_paths, invalidate_root=True, user_email=latest.user.email)
+                is_home_page = True
             else:
-                akamai_cache_reset(url_paths, user_email=latest.user.email)
+                is_home_page = False
+
+            akamai_cache_reset(url_paths, invalidate_root=is_home_page, user_email=latest.user.email)
 
 
 @hooks.register('before_serve_page')

--- a/cfgov/v1/wagtail_hooks.py
+++ b/cfgov/v1/wagtail_hooks.py
@@ -2,6 +2,7 @@ import os
 import json
 from urlparse import urlsplit
 
+from django.conf import settings
 from django.http import Http404
 from django.contrib.auth.models import Permission
 from django.utils.html import escape
@@ -61,6 +62,14 @@ def configure_page_revision(page, is_publishing):
     latest.save()
     if is_publishing:
         latest.publish()
+        if settings.ENABLE_AKAMAI_CACHE_PURGE:
+            from publish_eccu.publish import publish as akamai_cache_reset
+
+            url_paths = [page.url_path.replace('cfgov/', '')]
+            if url_paths[0] == '/':
+                akamai_cache_reset(url_paths, invalidate_root=True, user_email=latest.user.email)
+            else:
+                akamai_cache_reset(url_paths, user_email=latest.user.email)
 
 
 @hooks.register('before_serve_page')

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -22,3 +22,4 @@ django-overextends==0.4.1
 django-reversion==1.10.1
 django-tinymce==2.2.0
 Wand==0.4.2
+git+https://github.com/cfpb/publish_eccu.git#egg=publish_eccu


### PR DESCRIPTION
There was a need to purge the akamai cache when a page was published, this integrates the work done here https://github.com/cfpb/publish_eccu to purge the cache by url.
It will then either send an email to the publishing user to alert them of a successful cache flush or IT rep email set.

## Additions

- Ability to refresh akamai cache on page publish

## Testing

- Keep in mind this style of flushing can take upto 20-40mins to resolve vs the entire cache flush of < 10mins
- Reach out to me for environmental variables for beta site
```
#export ENABLE_AKAMAI_CACHE_PURGE=<boolean_enable_purging_akamai_cache>
#export AKAMAI_USER=<akamai_username>
#export AKAMAI_PASSWORD=<akamai_password>
#export AKAMAI_NOTIFY=<akamai_notify_email>
#export AKAMAI_HOST=<akamai_hostname>
   ```
- Import Refresh db dump
- login into beta wagtail page using the **ip address** vs the hostname (**IMPORTANT**)
 - Edit page and publish
- Edit the same page locally and publish. This will send the request for beta
 - wait for email and verify page

## Review

- @kurtw 
- @richaagarwal 
- @rosskarchner 