### PR TITLE
Sheer filters Acceptance Tests

### DIFF
--- a/test/browser_tests/page_objects/page_leadership-calendar.js
+++ b/test/browser_tests/page_objects/page_leadership-calendar.js
@@ -11,27 +11,27 @@ function TheLeadershipCalendarPage() {
   this.sideNav = element( by.css( '.o-secondary-navigation' ) );
 
   this.intro =
-  element( by.css( '[data-qa-hook="leadership-calendar-intro"]' ) );
+    element( by.css( '[data-qa-hook="leadership-calendar-intro"]' ) );
 
   this.introSummary =
-  this.intro.element(
-    by.css( '[data-qa-hook="leadership-calendar-summary"]' )
-  );
+    this.intro.element(
+      by.css( '[data-qa-hook="leadership-calendar-summary"]' )
+    );
 
   this.searchFilter =
-  element.all( by.css( '[data-qa-hook="filter"]' ) ).get( 0 );
+    element.all( by.css( '[data-qa-hook="filter"]' ) ).get( 0 );
 
-  this.searchFilterBtn =
-  this.searchFilter.all( by.css( '.m-expandable_target' ) ).first();
+  this.searchFilterShowBtn =
+    element.all( by.css( '.m-expandable_cue-open' ) ).get( 0 );
 
   this.downloadFilter =
-  element.all( by.css( '[data-qa-hook="filter"]' ) ).get( 1 );
+    element.all( by.css( '[data-qa-hook="filter"]' ) ).get( 1 );
 
   this.downloadFilterBtn =
-  this.downloadFilter.all( by.css( '.m-expandable_target' ) ).first();
+    this.downloadFilter.all( by.css( '.m-expandable_target' ) ).first();
 
   this.searchFilterResults =
-  element.all( by.css( '[data-qa-hook="leadership-calendar-filter"] tbody' ) );
+    element.all( by.css( '[data-qa-hook="leadership-calendar-filter"] tbody' ) );
 
   this.paginationForm = element( by.css( '.pagination_form' ) );
 

--- a/test/browser_tests/page_objects/page_leadership-calendar.js
+++ b/test/browser_tests/page_objects/page_leadership-calendar.js
@@ -21,14 +21,38 @@ function TheLeadershipCalendarPage() {
   this.searchFilter =
     element.all( by.css( '[data-qa-hook="filter"]' ) ).get( 0 );
 
+  this.searchFilterBtn =
+    this.searchFilter.element(
+      by.css( '.o-filterable-list-controls .m-expandable_target' )
+    );
+
   this.searchFilterShowBtn =
-    element.all( by.css( '.m-expandable_cue-open' ) ).get( 0 );
+    this.searchFilter.element(
+      by.css( '.o-filterable-list-controls .m-expandable_cue-open' )
+    );
+
+  this.searchFilterHideBtn =
+    this.searchFilter.element(
+      by.css( '.o-filterable-list-controls .m-expandable_cue-close' )
+    );
 
   this.downloadFilter =
     element.all( by.css( '[data-qa-hook="filter"]' ) ).get( 1 );
 
   this.downloadFilterBtn =
-    this.downloadFilter.all( by.css( '.m-expandable_target' ) ).first();
+    this.downloadFilter.element(
+      by.css( '.o-filterable-list-controls .m-expandable_target' )
+    );
+
+  this.downloadFilterShowBtn =
+    this.downloadFilter.element(
+      by.css( '.o-filterable-list-controls .m-expandable_cue-open' )
+    );
+
+  this.downloadFilterHideBtn =
+    this.downloadFilter.element(
+      by.css( '.o-filterable-list-controls .m-expandable_cue-close' )
+    );
 
   this.searchFilterResults =
     element.all( by.css( '[data-qa-hook="leadership-calendar-filter"] tbody' ) );

--- a/test/browser_tests/spec_suites/leadership-calendar.js
+++ b/test/browser_tests/spec_suites/leadership-calendar.js
@@ -52,9 +52,13 @@ describe( 'The Leadership Calendar Page', function() {
     } );
 
     it( 'should include a visible Hide button when clicked', function() {
+      var expectedConditions = protractor.ExpectedConditions;
       page.searchFilterBtn.click();
-      browser.sleep(1000);
-      expect( page.searchFilterHideBtn.isDisplayed() ).toBe( true );
+      browser.driver.wait(
+        expectedConditions.elementToBeClickable( page.searchFilterHideBtn )
+      ).then( function() {
+        expect( page.searchFilterHideBtn.isDisplayed() ).toBe( true );
+      } );
     } );
 
     it( 'should include a search filter search filter results',
@@ -86,9 +90,13 @@ describe( 'The Leadership Calendar Page', function() {
     } );
 
     it( 'should include a visible Hide button when clicked', function() {
+      var expectedConditions = protractor.ExpectedConditions;
       page.downloadFilterBtn.click();
-      browser.sleep(1000);
-      expect( page.downloadFilterHideBtn.isDisplayed() ).toBe( true );
+      browser.driver.wait(
+        expectedConditions.elementToBeClickable( page.downloadFilterHideBtn )
+      ).then( function() {
+        expect( page.downloadFilterHideBtn.isDisplayed() ).toBe( true );
+      } );
     } );
 
   } );

--- a/test/browser_tests/spec_suites/leadership-calendar.js
+++ b/test/browser_tests/spec_suites/leadership-calendar.js
@@ -30,50 +30,67 @@ describe( 'The Leadership Calendar Page', function() {
     }
   );
 
-  it( 'should include a search filter',
-    function() {
-      expect( page.searchFilter.isPresent() ).toBe( true );
-    }
-  );
+  describe( 'Search Filter', function() {
 
-  it( 'should include a search filter button',
-    function() {
-      var searchFilterBtn = page.searchFilterBtn;
-      expect( searchFilterBtn.isPresent() ).toBe( true );
-      expect( searchFilterBtn.getText() ).toContain( 'Filter calendars' );
-      expect( searchFilterBtn.getText() ).toContain( 'Show' );
-    }
-  );
+    it( 'should be included',
+      function() {
+        expect( page.searchFilter.isPresent() ).toBe( true );
+      }
+    );
 
-  it( 'should include a search filter search filter results',
-    function() {
-      expect( page.searchFilterResults.count() ).toBeGreaterThan( 0 );
-    }
-  );
+    it( 'should include Filter Calendars label',
+      function() {
+        var searchFilterBtn = page.searchFilterBtn;
+        expect( searchFilterBtn.isPresent() ).toBe( true );
+        expect( searchFilterBtn.getText() ).toContain( 'Filter calendars' );
+      }
+    );
 
-  it( 'should include a download filter',
-    function() {
-      expect( page.paginationForm.isPresent() ).toBe( true );
-    }
-  );
+    it( 'should include a visible Show button', function() {
+      expect( page.searchFilterShowBtn.isDisplayed() ).toBe( true );
+      expect( page.searchFilterShowBtn.getText() ).toBe( 'Show' );
+    } );
 
-  it( 'should include a download filter button',
-    function() {
-      var downloadFilterBtn = page.downloadFilterBtn;
-      expect( downloadFilterBtn.isPresent() ).toBe( true );
-      expect( downloadFilterBtn.getText() ).toContain( 'Download options' );
-      expect( downloadFilterBtn.getText() ).toContain( 'Show' );
-    }
-  );
+    it( 'should include a visible Hide button when clicked', function() {
+      page.searchFilterBtn.click();
+      browser.sleep(1000);
+      expect( page.searchFilterHideBtn.isDisplayed() ).toBe( true );
+    } );
 
-  it( 'should include a visible Show button', function() {
-    browser.pause();
-    expect( page.searchFilterShowBtn.isDisplayed() ).toBe( true );
-    expect( page.searchFilterShowBtn.getText() ).toBe( 'Show' );
+    it( 'should include a search filter search filter results',
+      function() {
+        expect( page.searchFilterResults.count() ).toBeGreaterThan( 0 );
+      }
+    );
   } );
 
-  xit( 'should include a hidden Hide button', function() {
-    expect( page.searchFilterHideBtn.isDisplayed() ).toBe( false );
+  describe( 'Download Filter', function() {
+
+    it( 'should be included',
+      function() {
+        expect( page.paginationForm.isPresent() ).toBe( true );
+      }
+    );
+
+    it( 'should include text to download options',
+      function() {
+        var downloadFilterBtn = page.downloadFilterBtn;
+        expect( downloadFilterBtn.isPresent() ).toBe( true );
+        expect( downloadFilterBtn.getText() ).toContain( 'Download options' );
+      }
+    );
+
+    it( 'should include a visible Show button', function() {
+      expect( page.downloadFilterShowBtn.isDisplayed() ).toBe( true );
+      expect( page.downloadFilterShowBtn.getText() ).toBe( 'Show' );
+    } );
+
+    it( 'should include a visible Hide button when clicked', function() {
+      page.downloadFilterBtn.click();
+      browser.sleep(1000);
+      expect( page.downloadFilterHideBtn.isDisplayed() ).toBe( true );
+    } );
+
   } );
 
   it( 'should include pagination form',

--- a/test/browser_tests/spec_suites/leadership-calendar.js
+++ b/test/browser_tests/spec_suites/leadership-calendar.js
@@ -66,6 +66,16 @@ describe( 'The Leadership Calendar Page', function() {
     }
   );
 
+  it( 'should include a visible Show button', function() {
+    browser.pause();
+    expect( page.searchFilterShowBtn.isDisplayed() ).toBe( true );
+    expect( page.searchFilterShowBtn.getText() ).toBe( 'Show' );
+  } );
+
+  xit( 'should include a hidden Hide button', function() {
+    expect( page.searchFilterHideBtn.isDisplayed() ).toBe( false );
+  } );
+
   it( 'should include pagination form',
     function() {
       expect( page.paginationForm.isPresent() ).toBe( true );


### PR DESCRIPTION
More browser tests for filters on sheer pages. (Which are only on the leadership calendar page as far as I know.)

## Testing

- `gulp test:acceptance --sauce=false --specs=leadership-calendar.js`

## Review

- @jimmynotjim 
- @anselmbradford 
- @sebworks 

## Notes

- I'd ideally like to test the filters themselves, but I ran into a roadblock testing the page when the page changes and decided against adding a potentially fragile test.

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
