### PR TITLE
Adding Acceptance tests for the Video Player

### DIFF
--- a/test/browser_tests/page_objects/page_careers-application-process.js
+++ b/test/browser_tests/page_objects/page_careers-application-process.js
@@ -2,11 +2,12 @@
 
 var _getQAelement = require( '../util/qa-element' ).get;
 var relatedLinksSection = require( '../shared_objects/related-links-section' );
+var videoPlayer = require( '../shared_objects/video-player' );
 
 
 function ApplicationProcess() {
 
-  Object.assign( this, relatedLinksSection );
+  Object.assign( this, relatedLinksSection, videoPlayer );
 
   this.get = function() {
     browser.get( '/about-us/careers/application-process/' );

--- a/test/browser_tests/page_objects/page_the-bureau.js
+++ b/test/browser_tests/page_objects/page_the-bureau.js
@@ -1,9 +1,10 @@
 'use strict';
 
 var secondaryNav = require( '../shared_objects/secondary-navigation' );
+var videoPlayer = require( '../shared_objects/video-player' );
 
 function TheBureauPage() {
-  Object.assign( this, secondaryNav );
+  Object.assign( this, secondaryNav, videoPlayer );
 
   this.get = function() {
     browser.get( '/about-us/the-bureau/' );

--- a/test/browser_tests/shared_objects/video-player.js
+++ b/test/browser_tests/shared_objects/video-player.js
@@ -1,0 +1,32 @@
+'use strict';
+
+var videoPlayer = element( by.css( '.video-player' ) );
+
+function _videoPlayerElement( selector ) {
+  return videoPlayer.element( by.css( selector ) );
+}
+
+var VideoPlayer = {
+
+  videoPlayerCloseButton: _videoPlayerElement( '.video-player_close-btn' ),
+
+  videoPlayerVideoContainer:
+    _videoPlayerElement( '.video-player_video-container' ),
+
+  videoPlayerIframeContainer:
+    _videoPlayerElement( '.video-player_iframe-container' ),
+
+  getVideoPlayerIframe: function getVideoPlayerIframe( ) {
+    return _videoPlayerElement( '.video-player_iframe' );
+  },
+
+  videoPlayerImageContainer:
+    _videoPlayerElement( '.video-player_image-container' ),
+
+  videoPlayerPlayButton: _videoPlayerElement( '.video-player_play-btn' ),
+
+  videoPlayer: videoPlayer
+
+};
+
+module.exports = VideoPlayer;

--- a/test/browser_tests/spec_suites/careers-application-process.js
+++ b/test/browser_tests/spec_suites/careers-application-process.js
@@ -12,7 +12,6 @@ describe( 'The Application Process Page', function() {
   beforeAll( function() {
     page = new ApplicationProcess();
     page.get();
-
     jasmine.addMatchers( Urlmatcher );
   } );
 
@@ -52,4 +51,56 @@ describe( 'The Application Process Page', function() {
     expect( page.relatedLinksSection.isPresent() ).toBe( true );
   } );
 
+  describe( '(Video Player)', function() {
+
+    describe( 'on page load', function() {
+      it( 'should be present', function() {
+        expect( page.videoPlayer.isPresent() ).toBe( true );
+      } );
+
+      it( 'should show the image and not the video', function() {
+        expect( page.videoPlayerImageContainer.isDisplayed() ).toBe( true );
+        expect( page.videoPlayerVideoContainer.isDisplayed() ).toBe( false );
+      } );
+    } );
+
+    describe( 'on play button click', function() {
+      beforeEach( function() {
+        page.videoPlayerPlayButton.isDisplayed().then(
+        function( playButtonIsVisible ) {
+          if( playButtonIsVisible === false ) {
+            page.videoPlayerCloseButton.click();
+          }
+          page.videoPlayerPlayButton.click();
+        } );
+      } );
+
+      it( 'should show the video and not the image', function() {
+        expect( page.videoPlayerVideoContainer.isDisplayed() ).toBe( true );
+        expect( page.videoPlayerImageContainer.isDisplayed() ).toBe( false );
+      } );
+
+      it( 'should attach an iframe', function() {
+        expect( page.getVideoPlayerIframe().isPresent() ).toBe( true );
+      } );
+    } );
+
+    describe( 'on close button click', function() {
+      beforeEach( function() {
+        page.videoPlayerCloseButton.isDisplayed().then(
+        function( closeButtonIsVisible ) {
+          if( closeButtonIsVisible === false ) {
+            page.videoPlayerPlayButton.click();
+          }
+          page.videoPlayerCloseButton.click();
+        } );
+      } );
+
+      it( 'should hide the video and show the image', function() {
+        expect( page.videoPlayerImageContainer.isDisplayed() ).toBe( true );
+        expect( page.videoPlayerVideoContainer.isDisplayed() ).toBe( false );
+      } );
+    } );
+
+  } );
 } );

--- a/test/browser_tests/spec_suites/the-bureau.js
+++ b/test/browser_tests/spec_suites/the-bureau.js
@@ -27,6 +27,59 @@ describe( 'The Bureau Page', function() {
     }
   );
 
+  describe( '(Video Player)', function() {
+
+    describe( 'on page load', function() {
+      it( 'should be present', function() {
+        expect( page.videoPlayer.isPresent() ).toBe( true );
+      } );
+
+      it( 'should show the image and not the video', function() {
+        expect( page.videoPlayerImageContainer.isDisplayed() ).toBe( true );
+        expect( page.videoPlayerVideoContainer.isDisplayed() ).toBe( false );
+      } );
+    } );
+
+    describe( 'on play button click', function() {
+      beforeEach( function() {
+        page.videoPlayerPlayButton.isDisplayed().then(
+        function( playButtonIsVisible ) {
+          if( playButtonIsVisible === false ) {
+            page.videoPlayerCloseButton.click();
+          }
+          page.videoPlayerPlayButton.click();
+        } );
+      } );
+
+      it( 'should show the video and not the image', function() {
+        expect( page.videoPlayerVideoContainer.isDisplayed() ).toBe( true );
+        expect( page.videoPlayerImageContainer.isDisplayed() ).toBe( false );
+      } );
+
+      it( 'should attach an iframe', function() {
+        expect( page.getVideoPlayerIframe().isPresent() ).toBe( true );
+      } );
+    } );
+
+    describe( 'on close button click', function() {
+      beforeEach( function() {
+        page.videoPlayerCloseButton.isDisplayed().then(
+        function( closeButtonIsVisible ) {
+          if( closeButtonIsVisible === false ) {
+            page.videoPlayerPlayButton.click();
+          }
+          page.videoPlayerCloseButton.click();
+        } );
+      } );
+
+      it( 'should hide the video and show the image', function() {
+        expect( page.videoPlayerImageContainer.isDisplayed() ).toBe( true );
+        expect( page.videoPlayerVideoContainer.isDisplayed() ).toBe( false );
+      } );
+    } );
+
+  } );
+
   if ( browser.params.windowWidth > breakpointsConfig.bpSM.min &&
        browser.params.windowWidth < breakpointsConfig.bpSM.max ) {
     describe( '(mobile)', function() {


### PR DESCRIPTION
Adding Acceptance tests for the Video Player

## Additions

- Added `test/browser_tests/shared_objects/video-player.js` to allow pages that have video player functionality to easily add the video-player element references. 

- Added basic interaction tests for the video player to `test/browser_tests/shared_objects/video-player.js`, and `test/browser_tests/spec_suites/the-bureau.js`.

## Review

- @anselmbradford 
- @KimberlyMunoz 
- @kave 

## Notes

- Not sure how to test the video player on Wagtail pages ( Events ). Maybe you can help me with that @kave?

## Todos

- Add video player tests to the Archive/Live Events page.

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
