### PR TITLE
Check against Activity Log topics when generating View More link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 ## Added
 
 ### Changes
+- Check against Activity Log topics when generating View More link
 
 ### Removed
 

--- a/cfgov/v1/models/base.py
+++ b/cfgov/v1/models/base.py
@@ -131,11 +131,15 @@ class CFGOVPage(Page):
     ])
 
     def generate_view_more_url(self, request):
-        tags = []
+        from ..forms import ActivityLogFilterForm
         activity_log = CFGOVPage.objects.get(slug='activity-log').specific
+        form = ActivityLogFilterForm(parent=activity_log, hostname=request.site.hostname)
+        available_tags = [tag[0] for name, tags in form.fields['topics'].choices for tag in tags]
+        tags = []
         index = util.get_form_id(activity_log)
         for tag in self.tags.names():
-            tags.append('filter%s_topics=' % index + urllib.quote_plus(tag))
+            if tag in available_tags:
+                tags.append('filter%s_topics=' % index + urllib.quote_plus(tag))
         tags = '&'.join(tags)
         return get_protected_url({'request': request}, activity_log) + '?' + tags
 


### PR DESCRIPTION
View more link to Activity log from a page with tags that are not in the Activity log causes filter to give error.

## Additions

- Generates the list of tags to check against when forming the link

## Testing

-Visit http://www.consumerfinance.gov/policy-compliance/rulemaking/final-rules/fair-credit-reporting-act-disclosures/
http://www.consumerfinance.gov/policy-compliance/ , go to the View more link, notice the error
- go to them locally and visit the link without problems on the activity log

## Review

- @kave 
- @richaagarwal 
- @rosskarchner 

