### PR TITLE
Adding Fix for email address on Press Resource page

### DIFF
--- a/cfgov/jinja2/v1/newsroom/press-resources/index.html
+++ b/cfgov/jinja2/v1/newsroom/press-resources/index.html
@@ -36,7 +36,7 @@
 
         <ul class="press-contacts_main-contact-list list list__links list__icons">
             <li class="list_item">
-                <a class="list_link" href="mailto:inquiries@consumerfinance.gov">
+                <a class="list_link" href="mailto:press@consumerfinance.gov">
                     <span class="cf-icon cf-icon-email list_icon"></span>
                     <span class="list_text">press@consumerfinance.gov</span>
                 </a>

--- a/test/browser_tests/spec_suites/newsroom-press-resources.js
+++ b/test/browser_tests/spec_suites/newsroom-press-resources.js
@@ -32,7 +32,7 @@ describe( 'The Newsroom Press Resources Page', function() {
     expect( page.contactListEmail.getText() )
     .toBe( 'press@consumerfinance.gov' );
     expect( page.contactListEmail.getAttribute( 'href' ) )
-    .toBe( 'mailto:inquiries@consumerfinance.gov' );
+    .toBe( 'mailto:press@consumerfinance.gov' );
   } );
 
   it( 'should include a Press contact list phone number', function() {


### PR DESCRIPTION
Adding Fix for email address on Press Resource page

## Changes

- Changed the email address on the Press Resource page. 

## Testing

- Visit `http://localhost:8000/about-us/newsroom/press-resources/` and click on the `press@consumerfinance.gov`. It should a mail client with the address set to `press@consumerfinance.gov`.

## Review

- @anselmbradford 
- @KimberlyMunoz 



## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)

