### PR TITLE
Missing token provider for forms submitted by JS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 
 ### Added
 
+- Missing token provider for forms submitted by JS
+
 ### Changes
 
 ### Removed

--- a/cfgov/cfgov/urls.py
+++ b/cfgov/cfgov/urls.py
@@ -263,7 +263,6 @@ if settings.ALLOW_ADMIN_URL:
 
     if 'selfregistration' in settings.INSTALLED_APPS:
         patterns.append(url(r'^selfregs/', include('selfregistration.urls')))
-        url(r'^token-provider/', 'cfpb_common.views.token_provider')
 
     urlpatterns = patterns + urlpatterns
 

--- a/cfgov/cfgov/urls.py
+++ b/cfgov/cfgov/urls.py
@@ -5,7 +5,7 @@ from django.conf import settings
 from django.conf.urls.static import static
 from django.conf.urls import include, url
 from django.views.generic.base import TemplateView, RedirectView
-from legacy.views import HousingCounselorPDFView, dbrouter_shortcut
+from legacy.views import HousingCounselorPDFView, dbrouter_shortcut, token_provider
 from sheerlike.views.generic import SheerTemplateView
 from sheerlike.sites import SheerSite
 
@@ -224,6 +224,9 @@ urlpatterns = [
         TemplateView.as_view(template_name='jobmanager/technology-innovation-fellows.html'),
         name='technology_innovation_fellows'),
     url(r'^jobs/fellowship_form_submit/$', 'jobmanager.views.fellowship_form_submit', name='fellowship_form_submit'),
+
+    # Form crsf token provider for JS form submission
+    url(r'^token-provider/', token_provider)
 ]
 
 if settings.ALLOW_ADMIN_URL:
@@ -260,6 +263,7 @@ if settings.ALLOW_ADMIN_URL:
 
     if 'selfregistration' in settings.INSTALLED_APPS:
         patterns.append(url(r'^selfregs/', include('selfregistration.urls')))
+        url(r'^token-provider/', 'cfpb_common.views.token_provider')
 
     urlpatterns = patterns + urlpatterns
 

--- a/cfgov/legacy/views.py
+++ b/cfgov/legacy/views.py
@@ -1,13 +1,16 @@
 import six, sys, os
 
 from django.conf import settings
-from django.http import HttpResponse
+from django.http import HttpResponse, HttpResponseRedirect, HttpResponseNotFound
 from django import http
 from django.apps import apps
 from django.contrib.contenttypes.models import ContentType
 from django.contrib.sites.requests import RequestSite
 from django.core.exceptions import ObjectDoesNotExist
 from django.utils.translation import ugettext as _
+from django.views.decorators.csrf import csrf_exempt
+from django.shortcuts import render_to_response
+from django.template import RequestContext
 
 from core.services import PDFGeneratorView
 from v1.db_router import cfgov_apps
@@ -20,8 +23,10 @@ if six.PY2:
     except:
         PDFreactor = None
 
+
 class InvalidZipException(Exception):
     pass
+
 
 class HousingCounselorPDFView(PDFGeneratorView):
     def get_render_url(self):
@@ -111,3 +116,12 @@ def dbrouter_shortcut(request, content_type_id, object_id):
                            {'ct_name': content_type.name})
 
     return http.HttpResponseRedirect(get_absolute_url())
+
+
+@csrf_exempt
+def token_provider(request):
+    request.session.modified = True
+    if request.method == 'POST':
+        context = RequestContext(request)
+        return render_to_response('common/csrf.html', context)
+    return HttpResponse()


### PR DESCRIPTION
## Additions

- Missing token provider for forms submitted by JS

## Testing

- Ensure self-registration is installed
 - clone private repo as a sibling CFPB/cfgov-selfregistration
 - `pip install -e ../cfgov-selfregistration`
- visit this [page](http://localhost:8000/company-signup/)
- submit information

## Review

- @richaagarwal 