### PR TITLE
Fixes init flag issue in cloned nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,10 +18,17 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 ### Added
 
 ### Changes
+- Frontend: Added `destroyInitFlag()` method to `atomic-helpers.js`.
+- Frontend: Added `destroy()` method to `Expandables.js` to allow
+  reversing calls to `init()`.
+- Frontend: Added extra small tests to bureau structure page.
 
 ### Removed
 
 ### Fixed
+- Frontend: Fixed issue where cloned expandables were not initializing
+  on the bureau structure page.
+- Frontend: Removed `self` references in ContentSlider.
 
 
 ## 3.0.0-3.3.17 - 2016-05-20

--- a/cfgov/unprocessed/js/modules/util/atomic-helpers.js
+++ b/cfgov/unprocessed/js/modules/util/atomic-helpers.js
@@ -67,8 +67,8 @@ function _verifyClassExists( element, baseClass ) {
  * Set a flag on an atomic component when it is initialized.
  * Use the returned boolean to handle cases where an atomic component
  * is initializing when it has already been initialized elsewhere.
- * @param {HTMLNode} element
- *   The DOM element within which to search for the atomic element class.
+ * @param {HTMLNode} element - The DOM element for the atomic component.
+ * @param {null} destroy - Pass in true to .
  * @returns {boolean} True if the init data-js-* hook attribute was set,
  *   false otherwise.
  */
@@ -78,6 +78,23 @@ function setInitFlag( element ) {
   }
 
   dataHook.add( element, INIT_FLAG );
+
+  return true;
+}
+
+/**
+ * Remove the initialization flag on an atomic component.
+ * This might be used if the DOM of an atomic element is cloned.
+ * @param {HTMLNode} element - The DOM element for the atomic component.
+ * @returns {boolean} True if the init data-js-* hook attribute was destroyed,
+ *   otherwise false if it didn't exist.
+ */
+function destroyInitFlag( element ) {
+  if ( !dataHook.contains( element, INIT_FLAG ) ) {
+    return false;
+  }
+
+  dataHook.remove( element, INIT_FLAG );
 
   return true;
 }
@@ -101,7 +118,8 @@ function instantiateAll( selector, Constructor ) {
 
 // Expose public methods.
 module.exports = {
-  checkDom:       checkDom,
-  instantiateAll: instantiateAll,
-  setInitFlag:    setInitFlag
+  checkDom:        checkDom,
+  destroyInitFlag: destroyInitFlag,
+  instantiateAll:  instantiateAll,
+  setInitFlag:     setInitFlag
 };

--- a/cfgov/unprocessed/js/organisms/ExpandableGroup.js
+++ b/cfgov/unprocessed/js/organisms/ExpandableGroup.js
@@ -40,7 +40,7 @@ function ExpandableGroup( element ) {
 
     for ( var i = 0; i < len; i++ ) {
       child = new Expandable( _domChildren[i] ).init();
-      child.addEventListener( 'beginExpand', _childBeginExpand );
+      child.addEventListener( 'expandBegin', _childBeginExpand );
     }
 
     return this;

--- a/cfgov/unprocessed/js/routes/about-us/the-bureau/bureau-structure/index.js
+++ b/cfgov/unprocessed/js/routes/about-us/the-bureau/bureau-structure/index.js
@@ -13,8 +13,11 @@ require( 'slick' );
 var ContentSlider = require( '../../../../modules/ContentSlider' );
 var BreakpointHandler = require( '../../../../modules/BreakpointHandler' );
 var Expandable = require( '../../../../molecules/Expandable' );
+var dataHook = require( '../../../../modules/util/data-hook' );
+var standardType = require( '../../../../modules/util/standard-type' );
 
 var _slider;
+var $legend;
 
 function init() {
 
@@ -28,57 +31,67 @@ function init() {
   new BreakpointHandler( bpSettings ); // eslint-disable-line no-new, no-inline-comments, max-len
 }
 
-function initExpandables() {
+var _expandables = [];
+function _initExpandables() {
   // Initialize the Expandable.
   var selector = '.m-expandable';
-  var expandables = document.querySelectorAll( selector );
+  var expandablesDom = document.querySelectorAll( selector );
   var expandable;
-  for ( var i = 0, len = expandables.length; i < len; i++ ) {
-    expandable = new Expandable( expandables[i] );
+  for ( var i = 0, len = expandablesDom.length; i < len; i++ ) {
+    expandable = new Expandable( expandablesDom[i] );
+    // Ensure Expandable isn't coming from cloned DOM nodes.
+    expandable.destroy();
+    expandable.addEventListener( 'expandEnd', _updateHeight );
+    expandable.addEventListener( 'collapseEnd', _updateHeight );
     expandable.init();
+    _expandables.push( expandable );
   }
 }
 
+function _updateHeight() {
+  _slider.setHeightToAuto();
+}
+
 function _createSlider() {
-  var $legend = $( '.org-chart_legend' ).parent().clone();
-  var $contentSlider = $( '#content-slider' );
+  $legend = $( '.org-chart_legend' ).parent().clone();
   // Hide org chart branches.
   $( '.org-chart_branches' ).hide();
   // Show content slider & mobile nav links.
   $( '#content-slider, .content-hide' ).show();
   // Initialize slider.
-  _slider = new ContentSlider( $contentSlider, 1 );
+  var sliderElem = document.querySelector( '#content-slider' );
+  _slider = new ContentSlider( sliderElem ).init( 1 );
+  _slider.addEventListener( 'afterChange', _sliderAfterChangeHandler )
+}
 
-  // Overwrite the default method to set height
-  // There are performance implications of doing so
-  // as noted here https://github.com/kenwheeler/slick/issues/83.
-  // ( Although wildly exaggerated. )
-  _slider.slickObj.setHeight = function setHeight() {
-      this.$list.css( 'height', 'auto' );
-  };
+function _sliderAfterChangeHandler( event ) {
+  var currInd = event.currInd;
 
-  _slider.slickObj.options.onAfterChange =
-    function onAfterChange( slider, currInd, targetInd ) {
-      // Add legend to the nodes list if doesn't exist.
-      var add_legend = currInd > 0 &&
-                       $( '.slick-active .org-chart_legend' ).length === 0;
-      if ( add_legend ) {
-        $( '.slick-active > .org-chart_nodes' ).append( $legend );
-      }
-      $contentSlider.height( 'auto' );
-      // Init the Expandable after the nodes have been cloned.
-      initExpandables();
-    };
+  // Add legend to the nodes list if doesn't exist.
+  var add_legend = currInd > 0 &&
+                 $( '.slick-active .org-chart_legend' ).length === 0;
+  if ( add_legend ) {
+    $( '.slick-active > .org-chart_nodes' ).append( $legend );
+  }
+
+  _updateHeight();
+  _initExpandables();
 }
 
 function _destroySlider() {
   // Destroy slider.
-  if ( _slider ) _slider.destroy();
+  if ( _slider ) { _slider.destroy(); }
   _slider = null;
   // Hide content slider & mobile nav links.
   $( '#content-slider, .content-hide' ).hide();
   // Show org chart branches.
   $( '.org-chart_branches' ).show();
+
+  for ( var i = 0, len = _expandables.length; i < len; i++ ) {
+    _expandables[i].removeEventListener( 'expandEnd', _updateHeight );
+    _expandables[i].removeEventListener( 'collapseEnd', _updateHeight );
+    _expandables[i].destroy();
+  }
 }
 
 init();

--- a/test/browser_tests/page_objects/page_bureau-structure.js
+++ b/test/browser_tests/page_objects/page_bureau-structure.js
@@ -8,24 +8,47 @@ function TheBureauStructurePage() {
 
   this.pageTitle = function() { return browser.getTitle(); };
 
-  this.sideNav = element( by.css( '.o-secondary-navigation' ) );
+  this.secondaryNavigation = element( by.css( '.o-secondary-navigation' ) );
 
-  this.orgChartRoot = element( by.css( '.org-chart_root' ) );
+  this.orgChartRoot = element( by.css( '.org-chart_node__root' ) );
+
+  this.orgChartCategoryLinks =
+    element.all( by.css( '.org-chart_categories .link_item' ) );
 
   this.orgChartBranches = element.all( by.css( '.org-chart_branch' ) );
 
   this.orgChartParentNodes =
-  this.orgChartBranches.all( by.css( '.org-chart_nodes > .org-chart_node' ) );
+    this.orgChartBranches.all(
+      by.css( '.org-chart_nodes > .org-chart_node' )
+    );
 
   this.orgChartChildNodes =
-  this.orgChartParentNodes.all( by.css( '.org-chart_node' ) );
+    this.orgChartParentNodes.all( by.css( '.org-chart_node' ) );
 
   this.downloadInfo =
-  element( by.css( '[data-qa-hook="org-chart-download-info"]' ) );
+    element( by.css( '[data-qa-hook="org-chart-download-info"]' ) );
 
   this.downloadBtn =
-  this.downloadInfo.element( by.css( 'a.btn' ) );
+    this.downloadInfo.element( by.css( 'a.btn' ) );
 
+  this.getExpandableOffice = function() {
+    return element( by.css( '.slick-slider .m-expandable' ) );
+  };
+
+  this.getExpandableTarget = function() {
+    var expandable = this.getExpandableOffice();
+    return expandable.element( by.css( '.m-expandable_target' ) );
+  };
+
+  this.getExpandableShowBtn = function() {
+    var expandable = this.getExpandableOffice();
+    return expandable.element( by.css( '.m-expandable_cue-open' ) );
+  };
+
+  this.getExpandableHideBtn = function() {
+    var expandable = this.getExpandableOffice();
+    return expandable.element( by.css( '.m-expandable_cue-close' ) );
+  };
 }
 
 module.exports = TheBureauStructurePage;

--- a/test/browser_tests/spec_suites/bureau-structure.js
+++ b/test/browser_tests/spec_suites/bureau-structure.js
@@ -1,64 +1,135 @@
 'use strict';
 
+var BASE_JS_PATH = '../../../cfgov/unprocessed/js/';
+
+var breakpointsConfig = require( BASE_JS_PATH + 'config/breakpoints-config' );
+
 var TheBureauStructurePage =
-require( '../page_objects/page_bureau-structure.js' );
+  require( '../page_objects/page_bureau-structure.js' );
 
 describe( 'The Bureau Structure Page', function() {
   var page;
+  var _expectedConditions = protractor.ExpectedConditions;
+  var _expandable;
 
   beforeAll( function() {
     page = new TheBureauStructurePage();
     page.get();
-
-    browser.getCapabilities().then( function( cap ) {
-      browser.name = cap.get( 'browserName' );
-      browser.version = cap.get( 'version' );
-    } );
   } );
 
+  // Check large size.
+  if ( browser.params.windowWidth > breakpointsConfig.bpLG.min ) {
+    describe( 'large size', function() {
 
-  it( 'should properly load in a browser',
-    function() {
-      expect( page.pageTitle() ).toContain( 'Bureau Structure' );
-    }
-  );
+      it( 'should properly load in a browser',
+        function() {
+          expect( page.pageTitle() ).toContain( 'Bureau Structure' );
+        }
+      );
 
-  it( 'should have a side nav',
-    function() {
-      expect( page.sideNav.isPresent() ).toBe( true );
-    }
-  );
+      it( 'should have a secondary navigation',
+        function() {
+          expect( page.secondaryNavigation.isPresent() ).toBe( true );
+        }
+      );
 
-  it( 'should include two org chart branches',
-    function() {
-      expect( page.orgChartBranches.count() ).toEqual( 2 );
-    }
-  );
+      it( 'should include two org chart branches',
+        function() {
+          expect( page.orgChartBranches.count() ).toEqual( 2 );
+        }
+      );
 
-  it( 'should include org chart parent nodes',
-    function() {
-      expect( page.orgChartParentNodes.count() ).toBeGreaterThan( 0 );
-    }
-  );
+      it( 'should include org chart parent nodes',
+        function() {
+          expect( page.orgChartParentNodes.count() ).toBeGreaterThan( 0 );
+        }
+      );
 
-  it( 'should show org chart child nodes and they should be hidden',
-    function() {
-      expect( page.orgChartChildNodes.count() ).toBeGreaterThan( 0 );
+      it( 'should show org chart child nodes and they should be hidden',
+        function() {
+          expect( page.orgChartChildNodes.count() ).toBeGreaterThan( 0 );
 
-      var ie8 = browser.name === 'internet explorer' && browser.version === '8';
+          browser.getCapabilities().then( function( cap ) {
+            browser.name = cap.get( 'browserName' );
+            browser.version = cap.get( 'version' );
+          } );
+          var ie8 = browser.name === 'internet explorer' && browser.version === '8';
 
-      if ( !ie8 ) {
-        page.orgChartChildNodes.each( function( childNode ) {
-          expect( childNode.isDisplayed() ).toBe( false );
+          if ( !ie8 ) {
+            page.orgChartChildNodes.each( function( childNode ) {
+              expect( childNode.isDisplayed() ).toBe( false );
+            } );
+          }
+        }
+      );
+
+      it( 'should include the download button',
+        function() {
+          expect( page.downloadBtn.isPresent() ).toBe( true );
+        }
+      );
+    } );
+  } else if ( browser.params.windowWidth < breakpointsConfig.bpXS.max ) {
+    describe( 'extra small size', function() {
+
+      describe( 'on page load', function() {
+        it( 'should NOT display org chart children', function() {
+          expect( page.orgChartChildNodes.first().isDisplayed() ).toBe( false );
         } );
-      }
-    }
-  );
+      } );
 
-  it( 'should include the download button',
-    function() {
-      expect( page.downloadBtn.isPresent() ).toBe( true );
-    }
-  );
+      describe( 'when clicking chart node', function() {
+        beforeEach( function() {
+          page.get();
+          page.orgChartCategoryLinks.last().click();
+          _expandable = page.getExpandableOffice();
+        } );
 
+        it( 'should display org chart children', function() {
+          browser.driver.wait(
+            _expectedConditions.elementToBeClickable( _expandable )
+          ).then( function() {
+            expect( _expandable.isDisplayed() ).toBe( true );
+          } );
+        } );
+
+        it( 'should display expandable show button', function() {
+          browser.driver.wait(
+            _expectedConditions.elementToBeClickable( _expandable )
+          ).then( function() {
+            // Caveat.. if for some reason the expandable is programmatically
+            // clicked when opening the org chart, this likely won't catch it
+            // as the assertions will happen before the hide button shows
+            // at the end of the expandable animation.
+            expect( page.getExpandableHideBtn().isDisplayed() ).toBe( false );
+            expect( page.getExpandableShowBtn().isDisplayed() ).toBe( true );
+          } );
+        } );
+      } );
+
+      describe( 'when clicking chart node expandable', function() {
+        // TODO: Implement test.
+        /* beforeEach( function() {
+          page.get();
+          page.orgChartCategoryLinks.last().click();
+          _expandable = page.getExpandableOffice();
+          browser.driver.wait(
+            _expectedConditions.elementToBeClickable( _expandable )
+          ).then( function() {
+            page.getExpandableTarget().click();
+          } );
+        } ); */
+
+        xit( 'should display expandable hide button', function() {
+          // TODO: Implement test.
+          //       Sadly, this is a difficult one, as the expandable
+          //       can be clicked before it's initialized since
+          //       the ContentSlider clones the expandable nodes,
+          //       so it looks like it's initialized from a markup
+          //       perspective before it is.
+        } );
+      } );
+
+    } );
+  }
 } );

--- a/test/unit_tests/modules/util/atomic-helpers-spec.js
+++ b/test/unit_tests/modules/util/atomic-helpers-spec.js
@@ -72,4 +72,21 @@ describe( 'atomic-helpers', function() {
       expect( atomicHelpers.setInitFlag( expandableDom ) ).to.be.false;
     } );
   } );
+
+  describe( '.destroyInitFlag()', function() {
+
+    beforeEach( function() {
+      atomicHelpers.setInitFlag( expandableDom );
+    } );
+
+    it( 'should return true when init flag is removed', function() {
+      expect( atomicHelpers.destroyInitFlag( expandableDom ) ).to.be.true;
+    } );
+
+    it( 'should return false when init ' +
+        'flag has already been removed', function() {
+      atomicHelpers.destroyInitFlag( expandableDom );
+      expect( atomicHelpers.destroyInitFlag( expandableDom ) ).to.be.false;
+    } );
+  } );
 } );


### PR DESCRIPTION
## Changes

- Adds `destroyInitFlag()` method to `atomic-helpers.js`.
- Adds `destroy()` method to `Expandables.js` to allow reversing calls to `init()`.
- Fixed issue where cloned expandables were not initializing on the bureau structure page.
- Removed `self` references in ContentSlider. (Part of https://github.com/cfpb/cfgov-refresh/issues/571)
- Adds extra small tests to bureau structure page.
 
## Testing

- `gulp test:acceptance --sauce=false --specs=bureau-structure.js --windowSize=480,900` should pass.
- http://localhost:8000/about-us/the-bureau/bureau-structure/ at mobile and desktop should work as expected (nodes and expandables expand).

## Review

- @sebworks 
- @KimberlyMunoz 