### PR TITLE
Refactoring footer-button and removing jQuery

### DIFF
--- a/cfgov/jinja2/v1/_includes/organisms/footer.html
+++ b/cfgov/jinja2/v1/_includes/organisms/footer.html
@@ -21,9 +21,10 @@
 
             <a class="btn
                       btn__secondary
-                      js-return-to-top
                       o-footer_top-button"
-               href="#">
+                data-gtm_ignore="true"
+                data-js-hook="behavior_return-to-top"
+                href="#">
                 Back to top <span class="cf-icon cf-icon-arrow-up"></span>
             </a>
 

--- a/cfgov/unprocessed/js/modules/focus-target.js
+++ b/cfgov/unprocessed/js/modules/focus-target.js
@@ -17,7 +17,7 @@ var attachBehavior = require( './util/behavior' ).attach;
  */
 function init() {
 
-  attachBehavior( 'a[href^="#"]', 'click', function behavior() {
+  attachBehavior( 'a[href^="#"]:not([href="#"])', 'click', function behavior() {
     var anchorSelector = this.getAttribute( 'href' );
     var anchorElement = document.querySelector( anchorSelector );
     if ( anchorElement ) {

--- a/cfgov/unprocessed/js/modules/footer-button.js
+++ b/cfgov/unprocessed/js/modules/footer-button.js
@@ -1,26 +1,59 @@
 /* ==========================================================================
    Footer Button: Scroll to Top
+
+   Code copied from the following with minimal modifications :
+
+   - http://stackoverflow.com/questions/21474678/
+     scrolltop-animation-without-jquery
    ========================================================================== */
+
 'use strict';
 
-var $ = require( 'jquery' );
+// Required modules.
+var behavior = require( './util/behavior' );
 
-// TODO: Refactor this file to remove jquery dependency.
-//       http://stackoverflow.com/questions/21474678/
-//       scrolltop-animation-without-jquery
 /**
  * Set up event handler for button to scroll to top of page.
  */
 function init() {
-  var duration = 300;
+  if ( 'requestAnimationFrame' in window === false ) {
+    return;
+  }
 
-  // Disable Google Tag Manager tracking on this link.
-  $( '.js-return-to-top' ).attr( 'data-gtm_ignore', 'true' );
-
-  $( '.js-return-to-top' ).click( function( event ) {
+  behavior.attach( 'return-to-top', 'click', function( event ) {
     event.preventDefault();
-    $( 'html, body' ).animate( { scrollTop: 0 }, duration );
+    _scrollToTop();
   } );
+}
+
+/**
+ *  Duration of the scroll to top of the page.
+ */
+function _scrollToTop() {
+  var SCROLL_DURATION = 300;
+  var SCROLL_STEP_DURATION = 10;
+  var scrollHeight = window.scrollY;
+  var scrollStep = Math.PI / ( SCROLL_DURATION / SCROLL_STEP_DURATION );
+  var cosParameter = scrollHeight / 2;
+  var scrollCount = 0;
+  var scrollMargin;
+
+  window.requestAnimationFrame( _step );
+
+  /**
+   * Decrement scroll Y position.
+   */
+  function _step() {
+    window.setTimeout( function() {
+      if ( window.scrollY !== 0 ) {
+        window.requestAnimationFrame( _step );
+        scrollCount += 1;
+        scrollMargin = cosParameter - ( cosParameter *
+                       Math.cos( scrollCount * scrollStep ) );
+        window.scrollTo( 0, scrollHeight - scrollMargin );
+      }
+    }, SCROLL_STEP_DURATION );
+  }
 }
 
 module.exports = { init: init };

--- a/test/unit_tests/organisms/Footer-spec.js
+++ b/test/unit_tests/organisms/Footer-spec.js
@@ -1,10 +1,83 @@
 'use strict';
-var BASE_JS_PATH = '../../../cfgov/unprocessed/js/';
 
 var chai = require( 'chai' );
 var expect = chai.expect;
-var Footer = require( BASE_JS_PATH + 'organisms/Footer' );
+var jsdom = require( 'mocha-jsdom' );
+var sinon = require( 'sinon' );
+
+var BASE_JS_PATH = '../../../cfgov/unprocessed/js/';
+var FooterButton = require( BASE_JS_PATH + 'modules/footer-button.js' );
+
+var footerBtnDom;
+var bodyDom;
+var sandbox;
+var lastTime = 0;
+
+var HTML_SNIPPET =
+    '<a class="btn btn__secondary o-footer_top-button" ' +
+        'data-gtm_ignore="true" data-js-hook="behavior_return-to-top" ' +
+        'href="#">' +
+        'Back to top <span class="cf-icon cf-icon-arrow-up"></span>' +
+    '</a>';
+
+function triggerClick( target ) {
+  var clickEvent = new MouseEvent( 'click', {
+    bubbles: true,
+    cancelable: true,
+    view: window
+  } );
+
+  target.dispatchEvent( clickEvent );
+}
+
+function scrollTo( xCoord, yCoord ) {
+  window.scrollX = xCoord;
+  window.scrollY = yCoord;
+}
+
+function requestAnimationFrame( callback ) {
+  var currTime = new Date().getTime();
+  var timeToCall = Math.max( 0, 16 - ( currTime - lastTime ) );
+  var id = window.setTimeout(
+    function() {
+      callback( currTime + timeToCall );
+    }, timeToCall
+  );
+
+  lastTime = currTime + timeToCall;
+
+  return id;
+}
 
 describe( 'Footer', function() {
-  // TODO: Implement tests.
+  jsdom();
+
+  before( function() {
+    sandbox = sinon.sandbox.create();
+  } );
+
+  beforeEach( function( ) {
+    bodyDom = document.body;
+    bodyDom.innerHTML = HTML_SNIPPET;
+    footerBtnDom = document.querySelector( '.o-footer_top-button' );
+
+    window.requestAnimationFrame = requestAnimationFrame;
+    window.scrollTo = scrollTo;
+  } );
+
+  afterEach( function() {
+    sandbox.restore();
+  } );
+
+  it( 'button should initiate scroll to page top when clicked',
+    function( done ) {
+      window.scrollY = 10;
+      FooterButton.init();
+      triggerClick( footerBtnDom );
+      this.timeout( 3000 );
+      window.setTimeout( function( ) {
+        expect( window.scrollY ).to.equal( 0 );
+        done();
+      }, 2000 );
+    } );
 } );


### PR DESCRIPTION
Refactoring footer-button and removing jQuery

## Changes

- Refactored `footer-button.js` to remove jQuery and use requestAnimationFrame for smooth scrolling to the top of page. 

## Testing

- Visit `localhost:8000` on mobile an click the `Back to Top` button. It should smoothly scroll you back to the top of the page.
- Run 'gulp test:unit:scripts`

## Review

- @KimberlyMunoz 
- @anselmbradford 


## Todos

- Need to write further acceptance and unit tests.

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)

