### PR TITLE
Refactoring focus target to remove jQuery

### DIFF
--- a/cfgov/unprocessed/js/modules/focus-target.js
+++ b/cfgov/unprocessed/js/modules/focus-target.js
@@ -10,15 +10,19 @@
 
 'use strict';
 
-var $ = require( 'jquery' );
-
+var attachBehavior = require( './util/behavior' ).attach;
 /**
  * Parse links to handle webkit bug with keyboard focus.
  */
 function init() {
-  $( 'a[href^="#"]' ).click( function() {
-    var anchor = $( this ).attr( 'href' );
-    $( anchor ).attr( 'tabindex', -1 ).focus();
+
+  attachBehavior( 'a[href^="#"]', 'click', function behavior() {
+    var anchorSelector = this.getAttribute( 'href' );
+    var anchorElement = document.querySelector( anchorSelector );
+    if ( anchorElement ) {
+      anchorElement.setAttribute( 'tabindex', -1 );
+      anchorElement.focus();
+    }
   } );
 }
 

--- a/cfgov/unprocessed/js/modules/util/behavior.js
+++ b/cfgov/unprocessed/js/modules/util/behavior.js
@@ -30,6 +30,60 @@
 var standardType = require( './standard-type' );
 var dataHook = require( '../../modules/util/data-hook' );
 
+
+/**
+ * @param {string} behaviorSelector
+ *  Behavior type used to find the element within the dom.
+ * @param {HTMLNode} baseElement Containing element for the behavior element.
+ * @returns {HTMLNodeList} behaviorElements if it exists in the dom,
+ *                         null otherwise.
+ */
+function _findElements( behaviorSelector, baseElement ) {
+  baseElement = baseElement || document;
+  var behaviorElements = [];
+
+  try {
+    behaviorElements = baseElement.querySelectorAll( behaviorSelector );
+  } catch ( error ) {
+    var msg = behaviorSelector + ' not found in DOM!';
+    throw new Error( msg );
+  }
+
+  if ( behaviorElements.length === 0 &&
+       behaviorSelector.indexOf( standardType.BEHAVIOR_PREFIX ) === -1 ) {
+    behaviorElements = find( behaviorSelector, baseElement );
+  }
+
+  return behaviorElements;
+}
+
+
+/**
+ * @param {( string|HTMLNode|HTMLNodeList )} behaviorElement
+ *  Used to query dom for elements.
+ * @param {string} event Event type to add to element.
+ * @param {Function} eventHandler Callback for event.
+ * @param {HTMLNode} baseElement Containing element for the behavior element.
+ * @returns {HTMLNodeList} if it exists in the dom, null otherwise.
+ */
+function attach( behaviorElement, event, eventHandler, baseElement ) {
+  var behaviorElements = [];
+
+  if ( behaviorElement instanceof NodeList === true ) {
+    behaviorElements = behaviorElement;
+  } else if ( behaviorElement instanceof Node === true ) {
+    behaviorElements = [ behaviorElement ];
+  } else if ( typeof behaviorElement === 'string' ) {
+    behaviorElements = _findElements( behaviorElement, baseElement );
+  }
+
+  for( var i = 0, len = behaviorElements.length; i < len; i++ ) {
+    behaviorElements[i].addEventListener( event, eventHandler, false );
+  }
+
+  return behaviorElements;
+}
+
 /**
  * @param {HTMLNode} element
  *   The DOM element within which to search for the behavior
@@ -64,7 +118,33 @@ function checkBehaviorDom( element, behaviorDataAttr ) {
   return dom;
 }
 
+/**
+ * @param {string} behaviorSelector
+ *  Behavior type used to find the element within the dom.
+ * @param {HTMLNode} baseElement Containing element for the behavior element.
+ * @returns {HTMLNodeList} if it exists in the dom, null otherwise.
+ */
+function find( behaviorSelector, baseElement ) {
+  behaviorSelector =
+  standardType.JS_HOOK + '*=' + standardType.BEHAVIOR_PREFIX + behaviorSelector;
+  behaviorSelector = '[' + behaviorSelector + ']';
+
+  return _findElements( behaviorSelector, baseElement );
+}
+
+/**
+ * @param {HTMLNode} behaviorElement Element in which to remove the event.
+ * @param {string} event Event type to remove from the element.
+ * @param {Function} eventHandler Callback for event.
+ */
+function remove( behaviorElement, event, eventHandler ) {
+  behaviorElement.removeEventListener( event, eventHandler );
+}
+
 // Expose public methods.
 module.exports = {
-  checkBehaviorDom: checkBehaviorDom
+  attach: attach,
+  checkBehaviorDom: checkBehaviorDom,
+  find: find,
+  remove: remove
 };

--- a/test/unit_tests/modules/util/behavior-spec.js
+++ b/test/unit_tests/modules/util/behavior-spec.js
@@ -1,31 +1,93 @@
 'use strict';
-
 var BASE_JS_PATH = '../../../../cfgov/unprocessed/js/';
-
 var chai = require( 'chai' );
 var expect = chai.expect;
-var jsdom = require( 'jsdom' );
+var jsdom = require( 'mocha-jsdom' );
+var sinon = require( 'sinon' );
+var sandbox;
 
 var behavior = require( BASE_JS_PATH + 'modules/util/behavior' );
 
-describe( 'behavior', function() {
+function triggerEvent( target, eventType, eventOption ) {
+  var event = document.createEvent( 'Event' );
+  if ( eventType === 'keyup' ) {
+    event.keyCode = eventOption || '';
+  }
+  event.initEvent( eventType, true, true );
+  target.dispatchEvent( event );
+}
 
-  var HTML_SNIPPET = '<div data-js-hook="behavior_flyout-menu">' +
-                     '<div data-js-hook="behavior_flyout-menu_content">' +
-                     '</div></div>';
-  var initdom = jsdom.jsdom( HTML_SNIPPET );
-  var document = initdom.defaultView.document;
+describe( 'behavior', function() {
+  jsdom();
+
+  var HTML_SNIPPET =
+  '<a href="#main" id="skip-nav">Skip to main content</a>' +
+  '<a class="o-mega-menu_content-link o-mega-menu_content-1-link"' +
+      'data-js-hook="behavior_flyout-menu_trigger">' +
+        'Consumer Tools' +
+  '</a>' +
+  '<a class="o-mega-menu_content-link o-mega-menu_content-1-link"' +
+      'data-js-hook="behavior_flyout-menu_trigger">' +
+        'Educational Resources' +
+  '</a>' +
+  '<div data-js-hook="behavior_flyout-menu">' +
+      '<div data-js-hook="behavior_flyout-menu_content"></div>' +
+  '</div>';
 
   var containerDom;
   var behaviorElmDom;
   var selector = 'data-js-hook=behavior_flyout-menu';
 
-  before( function() {
+  beforeEach( function() {
+    sandbox = sinon.sandbox.create();
+    document.body.innerHTML = HTML_SNIPPET;
     containerDom = document.querySelector( '[' + selector + ']' );
     behaviorElmDom = document.querySelector( '[' + selector + '_content]' );
   } );
 
-  describe( '.checkBehaviorDom()', function() {
+  afterEach( function() {
+    sandbox.restore();
+  } );
+
+  describe( 'attach function', function() {
+    it( 'should register an event callback when passed a Node',
+    function() {
+      var spy = sinon.spy();
+      var linkDom = document.querySelector( 'a[href^="#"]' );
+      behavior.attach( linkDom, 'click', spy );
+      triggerEvent( linkDom, 'click' );
+      expect( spy.called ).to.equal( true );
+    } );
+
+    it( 'should register an event callback when passed a NodeList',
+    function() {
+      var spy = sinon.spy();
+      var behaviorDom = behavior.find( 'flyout-menu_trigger' );
+      behavior.attach( behaviorDom, 'mouseover', spy );
+      triggerEvent( behaviorDom[0], 'mouseover' );
+      expect( spy.called ).to.equal( true );
+    } );
+
+    it( 'should register an event callback when passed a behavior selector',
+    function() {
+      var spy = sinon.spy();
+      var behaviorDom = behavior.find( 'flyout-menu_trigger' );
+      behavior.attach( 'flyout-menu_trigger', 'mouseover', spy );
+      triggerEvent( behaviorDom[0], 'mouseover' );
+      expect( spy.called ).to.equal( true );
+    } );
+
+    it( 'should register an event callback when passed a dom selector',
+    function() {
+      var spy = sinon.spy();
+      var linkDom = document.querySelector( 'a[href^="#"]' );
+      behavior.attach( 'a[href^="#"]', 'click', spy );
+      triggerEvent( linkDom, 'click' );
+      expect( spy.called ).to.equal( true );
+    } );
+  } );
+
+  describe( 'checkBehaviorDom function ', function() {
     it( 'should throw an error if element DOM not found', function() {
       var errMsg = 'behavior_flyout-menu ' +
                    'behavior not found on passed DOM node!';
@@ -55,6 +117,40 @@ describe( 'behavior', function() {
       var dom = behavior.checkBehaviorDom( behaviorElmDom,
                                            'behavior_flyout-menu_content' );
       expect( dom ).to.be.equal( behaviorElmDom );
+    } );
+  } );
+
+  describe( 'find function', function() {
+    it( 'should find all elements with the specific behavior hook',
+    function() {
+      var behaviorDom = behavior.find( 'flyout-menu_trigger' );
+      expect( behaviorDom.length === 2 ).to.equal( true );
+      behaviorDom = behavior.find( 'flyout-menu_content' );
+      expect( behaviorDom.length === 1 ).to.equal( true );
+    } );
+
+    it( 'should throw an error when passed an invalid behavior selector',
+    function() {
+      var behaviorSelector = 'a[href^="#"]';
+      var errorMsg =
+        '[data-js-hook*=behavior_' + behaviorSelector + '] not found in DOM!';
+      var findFunction = behavior.find.bind( this, behaviorSelector );
+      expect( findFunction ).to.throw( Error, errorMsg );
+    } );
+  } );
+
+  describe( 'remove function', function() {
+    it( 'should remove the event callback for the specific behavior hook',
+    function() {
+      var spy = sinon.spy();
+      var linkDom = document.querySelector( 'a[href^="#"]' );
+      behavior.attach( linkDom, 'click', spy );
+      triggerEvent( linkDom, 'click' );
+      expect( spy.called ).to.equal( true );
+      spy.reset();
+      behavior.remove( linkDom, 'click', spy );
+      triggerEvent( linkDom, 'click' );
+      expect( spy.called ).to.equal( false );
     } );
   } );
 } );


### PR DESCRIPTION
Refactoring focus target to remove jQuery

## Additions

- Added `cfgov/unprocessed/js/modules/util/Behavior.js` to provide easy mechanism for adding behaviors.

## Changes

- Modified `cfgov/unprocessed/js/modules/focus-target.js` to remove jQuery and uitilize Behavior utility.

## Testing

- Visit `http://localhost:8000/` and tab once. Click on the `Skip to main content` button in the upper left-hand corner. Observe that the `#main` element should have its `tab-index` attribute set to `-1`.

## Review

- @anselmbradford 
- @KimberlyMunoz 

## Notes

-

## Todos

-

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
