### PR TITLE
Wagtail requires a richtext filter for richtext fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 ## Added
 
 ### Changes
+- Use bare value of RichText field if value type is not RichText
 - Check against Activity Log topics when generating View More link
 
 ### Removed

--- a/cfgov/v1/__init__.py
+++ b/cfgov/v1/__init__.py
@@ -93,7 +93,8 @@ def parse_links(soup):
 def external_links_filter(value):
     if isinstance(value, RichText):
         return parse_links(BeautifulSoup(expand_db_html(value.source), 'html.parser'))
-    return value
+    else:
+        return parse_links(BeautifulSoup(expand_db_html(value), 'html.parser'))
 
 
 @contextfunction


### PR DESCRIPTION
This fixes the viewing of internal links in contact snippets.

Note: you will need to make sure the below page is published locally if it isn't already.
On flapjack, if you navigate to [http://localhost:8000/policy-compliance/guidance/interstate-land-sales-registration/](http://localhost:8000/policy-compliance/guidance/interstate-land-sales-registration/), you'll notice that the "FOIA office" link under Contact Information is broken.

On this branch, navigate to it and the link should work.

@kave @kurtw 

