### PR TITLE
Use bare value of RichText field if value type is not RichText

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 ## Added
 
 ### Changes
+- Use bare value of RichText field if value type is not RichText
 - Check against Activity Log topics when generating View More link
 
 ### Removed

--- a/cfgov/v1/__init__.py
+++ b/cfgov/v1/__init__.py
@@ -93,7 +93,8 @@ def parse_links(soup):
 def external_links_filter(value):
     if isinstance(value, RichText):
         return parse_links(BeautifulSoup(expand_db_html(value.source), 'html.parser'))
-    return value
+    else:
+        return parse_links(BeautifulSoup(expand_db_html(value), 'html.parser'))
 
 
 @contextfunction


### PR DESCRIPTION
This should fix the issue along with the other fields that we haven't been catching either.

## Changes

- Use bare value of RichText field if value type is not RichText

## Testing

- Add link to a Contact's body field and view it in a sidebar on a page. Make sure the link is valid.

## Review

- @richaagarwal 

