### PR TITLE
Change validation for Event live stream URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 
 ### Changes
 - Check against Activity Log topics when generating View More link
+- Validation for Event live stream URLs does not check for the word "embed"
 
 ### Removed
 

--- a/cfgov/v1/models/learn_page.py
+++ b/cfgov/v1/models/learn_page.py
@@ -160,7 +160,7 @@ class EventPage(AbstractFilterPage):
     live_stream_url = models.URLField("URL", blank=True,
     help_text="Format: https://www.ustream.tv/embed/video_id.  It can be obtained by following the instructions listed here: " \
     "https://support.ustream.tv/hc/en-us/articles/207851917-How-to-embed-a-stream-or-video-on-your-site",
-    validators=[ RegexValidator(regex='^https?:\/\/www\.ustream\.tv\/embed\/.*$')])
+    validators=[ RegexValidator(regex='^https?:\/\/www\.ustream\.tv\/.*$')])
     live_stream_date = models.DateTimeField("Go Live Date", blank=True, null=True)
     # Venue content fields
     venue_name = models.CharField(max_length=100, blank=True)


### PR DESCRIPTION
Some of the URLs from ustream don't contain `embed` which invalidates the URL. This removes that constraint.

## Testing

- Try to save `https://www.ustream.tv/video` as a URL in the Live Stream URL field on an Event page.

## Review

- @kave

