### PR TITLE
Removes the RSVP button on Event pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Check against Activity Log topics when generating View More link
 
 ### Removed
+- Event RSVP email link button
 
 ### Fixed
 - get_browsefilterable_posts() call to get_page_set

--- a/cfgov/jinja2/v1/events/_event-detail.html
+++ b/cfgov/jinja2/v1/events/_event-detail.html
@@ -28,23 +28,10 @@
         {{ event_venue( page, event_state ) }}
     </header>
     <div class="post_body">
-        {% if ( event_state == 'future' ) %}
+        {% if event_state == 'future' and page.live_stream_availability %}
         <aside class="post_inset post_inset__right line-container event-status">
             <div class="line-container_body">
-                <h1 class="u-visually-hidden">Event reservation and viewing details</h1>
-                <div class="event-status_rsvp">
-                  <p>
-                      <strong>This event requires an RSVP.</strong>
-                  </p>
-                  <p>
-                      <a href="mailto:reserve@cfpb.gov?subject=Event RSVP&body=To RSVP, please fill in your first and last name below and send this email.%0D%0A%0D%0AFirst name:%0D%0ALast name:"
-                         class="btn">
-                          <span class="btn_icon__left cf-icon cf-icon-email-social"></span>
-                           reserve@cfpb.gov
-                      </a>
-                  </p>
-                </div>
-                {% if page.live_stream_availability %}
+                <h1 class="u-visually-hidden">Event viewing details</h1>
                 <div class="event-status_livestream">
                   <p>
                       <span class="cf-icon cf-icon-livestream"></span>
@@ -60,7 +47,6 @@
                       ) }}
                   </p>
                 </div>
-                {% endif %}
             </div>
         </aside>
         {% elif ( event_state == 'present' and page.live_stream_availability ) %}


### PR DESCRIPTION
@sarahsimpson09 said that the email reservations for the Events is deprecated and will be replaced by a form unique to the event in the future.

## Removals

- RSVP button

## Testing

- Visit a future event page and witness the page without the button.

## Review

- @kave 
- @sebworks 

## Screenshots
### Before
![screen shot 2016-05-25 at 2 09 08 pm](https://cloud.githubusercontent.com/assets/1412978/15551135/95f08d28-2282-11e6-9573-cfb446cc92fa.png)
### After
![screen shot 2016-05-25 at 2 11 02 pm](https://cloud.githubusercontent.com/assets/1412978/15551145/a09e7d7a-2282-11e6-9025-b632b9673f42.png)

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices
* [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)

