### PR TITLE
Breadcrumb and sidenav generation gets most appropriate page version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 ### Changes
 - Use bare value of RichText field if value type is not RichText
 - Check against Activity Log topics when generating View More link
+- Breadcrumb and sidenav link generation gets most appropriate version of page
 
 ### Removed
 

--- a/cfgov/jinja2/v1/_includes/organisms/secondary-navigation.html
+++ b/cfgov/jinja2/v1/_includes/organisms/secondary-navigation.html
@@ -33,7 +33,7 @@
    ========================================================================== #}
 {% macro _render_secondary_navigation() %}
 {% if nav_items is not defined and has_children is not defined %}
-    {% set nav_items, has_children = get_secondary_nav_items(page, request.site.hostname) %}
+    {% set nav_items, has_children = get_secondary_nav_items(request, page) %}
 {% endif %}
 <nav class="o-secondary-navigation
             {{ '' if has_children else 'o-secondary-navigation__no-children' }}"

--- a/cfgov/jinja2/v1/_layouts/content-base-sidebar-first.html
+++ b/cfgov/jinja2/v1/_layouts/content-base-sidebar-first.html
@@ -3,7 +3,7 @@
 {% block pre_content scoped -%}
     {# TODO: Remove non-wagtail logic once old pages have been converted #}
     {% if page %}
-        {% set breadcrumb_items = page.get_breadcrumbs(request.site) %}
+        {% set breadcrumb_items = page.get_breadcrumbs(request) %}
         {% if breadcrumb_items | length > 0 %}
             <div class="content_wrapper">
                 {%- import 'molecules/breadcrumbs.html' as breadcrumbs with context -%}

--- a/cfgov/v1/__init__.py
+++ b/cfgov/v1/__init__.py
@@ -12,7 +12,7 @@ from jinja2 import Environment, contextfunction, Markup
 from sheerlike import environment as sheerlike_environment
 from compressor.contrib.jinja2ext import CompressorExtension
 from flags.template_functions import flag_enabled, flag_disabled
-from .util.util import get_unique_id
+from .util.util import get_unique_id, get_secondary_nav_items
 
 from wagtail.wagtailcore.rich_text import expand_db_html, RichText
 from bs4 import BeautifulSoup

--- a/cfgov/v1/models/base.py
+++ b/cfgov/v1/models/base.py
@@ -193,12 +193,12 @@ class CFGOVPage(Page):
         return {search_type: queryset for search_type, queryset in
                 related.items() if queryset}
 
-    def get_breadcrumbs(self, site):
+    def get_breadcrumbs(self, request):
         ancestors = self.get_ancestors()
-        home_page_children = site.root_page.get_children()
+        home_page_children = request.site.root_page.get_children()
         for i, ancestor in enumerate(ancestors):
             if ancestor in home_page_children:
-                return ancestors[i+1:]
+                return [util.get_appropriate_page_version(request, ancestor) for ancestor in ancestors[i+1:]]
         return []
 
     def get_appropriate_descendants(self, hostname, inclusive=True):
@@ -269,19 +269,9 @@ class CFGOVPage(Page):
 
         else:
             # Request is for this very page.
-            # If we're on the production site, make sure the version of the page
-            # displayed is the latest version that has `live` set to True for
-            # the live site or `shared` set to True for the staging site.
-            staging_hostname = os.environ.get('STAGING_HOSTNAME')
-            revisions = self.revisions.all().order_by('-created_at')
-            for revision in revisions:
-                page_version = json.loads(revision.content_json)
-                if request.site.hostname != staging_hostname:
-                    if page_version['live']:
-                        return RouteResult(revision.as_page_object())
-                else:
-                    if page_version['shared']:
-                        return RouteResult(revision.as_page_object())
+            page = util.get_appropriate_page_version(request, self)
+            if page:
+                return RouteResult(page)
             raise Http404
 
     def permissions_for_user(self, user):

--- a/cfgov/v1/tests/test_util.py
+++ b/cfgov/v1/tests/test_util.py
@@ -1,0 +1,55 @@
+import mock
+
+from django.test import TestCase
+from django.test.client import RequestFactory
+
+from ..util import util
+
+
+class TestUtilFunctions(TestCase):
+
+    def setUp(self):
+        self.page = mock.Mock()
+        self.request = mock.Mock()
+        self.page_versions = [
+            mock.Mock(**{'content_json': {'live': False, 'shared': False}}), # draft
+            mock.Mock(**{'content_json': {'live': False, 'shared': True}}), # shared
+            mock.Mock(**{'content_json': {'live': True, 'shared': False}}), # live
+            mock.Mock(**{'content_json': {'live': True, 'shared': True}}), # live and shared
+        ]
+        self.page.revisions.all().order_by.return_value = self.page_versions
+
+    @mock.patch('json.loads')
+    def test_production_returns_first_live_page(self, mock_json_loads):
+        self.request.site.hostname = 'localhost'
+        mock_json_loads.side_effect = [page.content_json for page in self.page_versions]
+        util.get_appropriate_page_version(self.request, self.page)
+        assert not self.page_versions[0].as_page_object.called
+        assert not self.page_versions[1].as_page_object.called
+        assert self.page_versions[2].as_page_object.called
+        assert not self.page_versions[3].as_page_object.called
+
+    @mock.patch('json.loads')
+    def test_shared_returns_first_shared_page(self, mock_json_loads):
+        self.request.site.hostname = 'content.localhost'
+        mock_json_loads.side_effect = [page.content_json for page in self.page_versions]
+        util.get_appropriate_page_version(self.request, self.page)
+        assert not self.page_versions[0].as_page_object.called
+        assert self.page_versions[1].as_page_object.called
+        assert not self.page_versions[2].as_page_object.called
+        assert not self.page_versions[3].as_page_object.called
+
+    @mock.patch('json.loads')
+    def test_shared_returns_None_for_only_draft_versions(self, mock_json_loads):
+        self.page_versions = [
+            mock.Mock(**{'content_json': {'live': False, 'shared': False}}),
+            mock.Mock(**{'content_json': {'live': False, 'shared': False}}),
+            mock.Mock(**{'content_json': {'live': False, 'shared': False}}),
+            mock.Mock(**{'content_json': {'live': False, 'shared': False}}),
+        ]
+        mock_json_loads.side_effect = [page.content_json for page in self.page_versions]
+        util.get_appropriate_page_version(self.request, self.page)
+        assert not self.page_versions[0].as_page_object.called
+        assert not self.page_versions[1].as_page_object.called
+        assert not self.page_versions[2].as_page_object.called
+        assert not self.page_versions[3].as_page_object.called

--- a/cfgov/v1/tests/test_util.py
+++ b/cfgov/v1/tests/test_util.py
@@ -53,3 +53,20 @@ class TestUtilFunctions(TestCase):
         assert not self.page_versions[1].as_page_object.called
         assert not self.page_versions[2].as_page_object.called
         assert not self.page_versions[3].as_page_object.called
+
+
+    @mock.patch('json.loads')
+    def test_shared_returns_None_if_page_not_live_when_on_production(self, mock_json_loads):
+        self.request.site.hostname = 'localhost'
+        self.page_versions = [
+            mock.Mock(**{'content_json': {'live': False, 'shared': True}}),
+            mock.Mock(**{'content_json': {'live': False, 'shared': True}}),
+            mock.Mock(**{'content_json': {'live': False, 'shared': True}}),
+            mock.Mock(**{'content_json': {'live': False, 'shared': True}}),
+        ]
+        mock_json_loads.side_effect = [page.content_json for page in self.page_versions]
+        util.get_appropriate_page_version(self.request, self.page)
+        assert not self.page_versions[0].as_page_object.called
+        assert not self.page_versions[1].as_page_object.called
+        assert not self.page_versions[2].as_page_object.called
+        assert not self.page_versions[3].as_page_object.called

--- a/cfgov/v1/util/util.py
+++ b/cfgov/v1/util/util.py
@@ -1,6 +1,4 @@
-import collections
-import re
-import os
+import collections, json, os, re
 from itertools import chain
 from time import time
 from django.conf import settings
@@ -70,12 +68,15 @@ def instanceOfBrowseOrFilterablePages(page):
 # For use by Browse type pages to get the secondary navigation items
 # TODO: Move into BrowsePage class once BrowseFilterablePage has been merged
 # into BrowsePage
-def get_secondary_nav_items(current, hostname):
+def get_secondary_nav_items(request, current_page):
     from ..templatetags.share import get_page_state_url
-    on_staging = os.environ.get('STAGING_HOSTNAME') == hostname
+    on_staging = os.environ.get('STAGING_HOSTNAME') == request.site.hostname
     nav_items = []
-    parent = current.get_parent().specific
-    page = parent if instanceOfBrowseOrFilterablePages(parent) else current
+    parent = current_page.get_parent().specific
+    if instanceOfBrowseOrFilterablePages(parent):
+        page = get_appropriate_page_version(request, parent)
+    else:
+        page = get_appropriate_page_version(request, current_page)
 
     # TODO: Remove this ASAP once Press Resources gets its own Wagtail page
     if page.slug == 'newsroom':
@@ -95,12 +96,15 @@ def get_secondary_nav_items(current, hostname):
         ], True
     # END TODO
 
-    pages = [page] if page.secondary_nav_exclude_sibling_pages else page.get_appropriate_siblings(hostname)
+    pages = [page] if page.secondary_nav_exclude_sibling_pages else page.get_appropriate_siblings(request.site.hostname)
 
     for sibling in pages:
         # Only if it's a Browse(Filterable) type page
         if instanceOfBrowseOrFilterablePages(sibling.specific):
-            sibling = page if page.id == sibling.id else sibling
+            if page.id == sibling.id:
+                sibling = get_appropriate_page_version(request, page)
+            else:
+                sibling = get_appropriate_page_version(request, sibling)
             item = {
                 'title': sibling.title,
                 'slug': sibling.slug,
@@ -121,3 +125,19 @@ def get_secondary_nav_items(current, hostname):
         if get_page_state_url({}, page) == item['url'] and item['children']:
             return nav_items, True
     return nav_items, False
+
+
+def get_appropriate_page_version(request, page):
+    # If we're on the production site, make sure the version of the page
+    # displayed is the latest version that has `live` set to True for
+    # the live site or `shared` set to True for the staging site.
+    staging_hostname = os.environ.get('STAGING_HOSTNAME')
+    revisions = page.revisions.all().order_by('-created_at')
+    for revision in revisions:
+        page_version = json.loads(revision.content_json)
+        if request.site.hostname != staging_hostname:
+            if page_version['live']:
+                return revision.as_page_object()
+        else:
+            if page_version['shared']:
+                return revision.as_page_object()

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ envlist = py27,py34
 skipsdist = True
 
 [testenv]
-recreate = False
+recreate = True
 setenv =
     GOVDELIVERY_ACCOUNT_CODE = fake_account_code
     DJANGO_SETTINGS_MODULE = cfgov.settings.test

--- a/tox.ini
+++ b/tox.ini
@@ -3,13 +3,14 @@ envlist = py27,py34
 skipsdist = True
 
 [testenv]
-recreate = True
+recreate = False
 setenv =
     GOVDELIVERY_ACCOUNT_CODE = fake_account_code
     DJANGO_SETTINGS_MODULE = cfgov.settings.test
     ES_PORT=9200
     ES_HOST=localhost
     SHEER_ELASTICSEARCH_INDEX=content
+    STAGING_HOSTNAME=content.localhost
 deps =
     -r{toxinidir}/requirements/test.txt
 changedir = {toxinidir}/cfgov


### PR DESCRIPTION
This PR fixes two bugs brought up by @Scotchester. 
- Breadcrumb and sidenav generation used to get the page titles from the Page table in the database, leaking saved edits to `title` that were not shared or published.
- Breadcrumb and sidenav items that were previously shared but then had edits saved would return `None` as their URL. 

## Additions

- `get_appropriate_page_version` function in utils.py that grabs the page version based on revision history and request hostname.

## Changes

- `get_breadcrumbs` method on CFGOVPage and `get_secondary_nav_items` function in utils.py now use `get_appropriate_page_version`.

## Testing

- Get the latest from prod database OR share a Sublanding page with a Browse page as a child. The breadcrumb should be in the top left under the mega menu.
- **BEFORE PULLING DOWN**
 - Edit the title of this page `http://localhost:8000/admin/pages/3085/edit/` and hit `SAVE AS DRAFT`
 - Go to `http://content.localhost:8000/consumer-tools/auto-loans/plan-to-shop-for-your-auto-loan/`
 - Notice your change in the breadcrumb and that the URL ends with `None`
- Pull down the branch
 - Run `tox -- v1.tests.test_util`
 - Go back to `http://content.localhost:8000/consumer-tools/auto-loans/plan-to-shop-for-your-auto-loan/`
 - Notice your edit is not visible and the link is correct

## Review

- @rosskarchner 
- @richaagarwal 
- @kave 
- @Scotchester 


## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices
* [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)