### PR TITLE
Moves behavior dom check to utility

### DIFF
--- a/cfgov/unprocessed/js/modules/behavior/FlyoutMenu.js
+++ b/cfgov/unprocessed/js/modules/behavior/FlyoutMenu.js
@@ -2,6 +2,7 @@
 
 // Required modules.
 var BaseTransition = require( '../../modules/transition/BaseTransition' );
+var behavior = require( '../../modules/util/behavior' );
 var dataHook = require( '../../modules/util/data-hook' );
 var EventObserver = require( '../../modules/util/EventObserver' );
 var fnBind = require( '../../modules/util/fn-bind' ).fnBind;
@@ -12,13 +13,16 @@ var standardType = require( '../../modules/util/standard-type' );
  * @class
  *
  * @classdesc Initializes new FlyoutMenu behavior.
+ * Behaviors are functionality that can be shared between different pieces
+ * of markup. They are not strictly atomic, though they likely are used
+ * on atomic components.
  * As added JS behavior, this is added through HTML data-js-hook attributes.
  *
  * Structure is:
- * flyout-menu
- *   flyout-menu_trigger
- *   flyout-menu_content
- *     flyout-menu_alt-trigger
+ * behavior_flyout-menu
+ *   behavior_flyout-menu_trigger
+ *   behavior_flyout-menu_content
+ *     behavior_flyout-menu_alt-trigger
  *
  * The alt-trigger is for a back button, which may obscure the first trigger.
  * The flyout can be triggered three ways: through a click of the trigger or
@@ -31,24 +35,14 @@ function FlyoutMenu( element ) { // eslint-disable-line max-statements, no-inlin
 
   var BASE_CLASS = standardType.BEHAVIOR_PREFIX + 'flyout-menu';
   var SEL_PREFIX = '[' + standardType.JS_HOOK + '=' + BASE_CLASS;
-
   var BASE_SEL = SEL_PREFIX + ']';
-  var ALT_TRIGGER_SEL = SEL_PREFIX + '_alt-trigger]';
-  var CONTENT_SEL = SEL_PREFIX + '_content]';
-  var TRIGGER_SEL = SEL_PREFIX + '_trigger]';
 
-  // TODO: Update atomic-helpers to support CSS selectors for validity check.
-  var _dom = dataHook.contains( element, BASE_CLASS ) ? element : null;
-  if ( !_dom ) { _dom = element.parentNode.querySelector( BASE_SEL ); }
-  if ( !_dom ) { throw new Error( 'Selector not found on passed node!' ); }
+  // Verify that the expected dom attributes are present.
+  var _dom = behavior.checkBehaviorDom( element, BASE_CLASS );
+  var _triggerDom = behavior.checkBehaviorDom( element, BASE_CLASS + '_trigger' );
+  var _contentDom = behavior.checkBehaviorDom( element, BASE_CLASS + '_content' );
 
-  var _triggerDom = _dom.querySelector( TRIGGER_SEL );
-  var _contentDom = _dom.querySelector( CONTENT_SEL );
-
-  if ( !_triggerDom ) { throw new Error( TRIGGER_SEL + ' is missing!' ); }
-  if ( !_contentDom ) { throw new Error( CONTENT_SEL + ' is missing!' ); }
-
-  var _altTriggerDom = _dom.querySelector( ALT_TRIGGER_SEL );
+  var _altTriggerDom = _dom.querySelector( SEL_PREFIX + '_alt-trigger]' );
 
   var _isExpanded = false;
   var _isAnimating = false;
@@ -475,10 +469,6 @@ function FlyoutMenu( element ) { // eslint-disable-line max-statements, no-inlin
   FlyoutMenu.EXPAND_TYPE = 'expand';
   FlyoutMenu.COLLAPSE_TYPE = 'collapse';
   FlyoutMenu.BASE_CLASS = BASE_CLASS;
-  FlyoutMenu.BASE_SEL = BASE_SEL;
-  FlyoutMenu.ALT_TRIGGER_SEL = ALT_TRIGGER_SEL;
-  FlyoutMenu.CONTENT_SEL = CONTENT_SEL;
-  FlyoutMenu.TRIGGER_SEL = TRIGGER_SEL;
 
   return this;
 }

--- a/cfgov/unprocessed/js/modules/util/atomic-helpers.js
+++ b/cfgov/unprocessed/js/modules/util/atomic-helpers.js
@@ -1,6 +1,12 @@
 /* ==========================================================================
    Atomic Helpers.
    Utilities for helping validate atomic design element architecture.
+   In descending order of scope, atomic components are:
+   - Page
+   - Template
+   - Organism
+   - Molecule
+   - Atom
    ========================================================================= */
 
 'use strict';
@@ -8,10 +14,20 @@
 var dataHook = require( './data-hook' );
 var standardType = require( './standard-type' );
 
+/**
+ * @constant
+ * @type {string}
+ * Flag that gets set on an atomic component after its .init()
+ * method has been called. This is used so that an atomic
+ * component won't get initialized a second time after it
+ * has already been initialized.
+ */
 var INIT_FLAG = standardType.STATE_PREFIX + 'atomic_init';
 
-// TODO: Update baseClass to baseSel to handle CSS selector instead of a class.
 /**
+ * Check that a particular element passed into the constructor of
+ * an atomic component exists and that the correct atomic class
+ * is present on the element.
  * @param {HTMLNode} element
  *   The DOM element within which to search for the atomic element class.
  * @param {string} baseClass The CSS class name for the atomic element.

--- a/cfgov/unprocessed/js/modules/util/behavior.js
+++ b/cfgov/unprocessed/js/modules/util/behavior.js
@@ -1,0 +1,70 @@
+/* ==========================================================================
+   Dom Behaviors
+
+   Behaviors are functionality that can be shared between different pieces
+   of markup. They are not strictly atomic, though they likely are used
+   on atomic components. An example of shared behavior may be a menu that
+   expands and collapses and sets the aria-expanded attribute on the HTML.
+   Or an input field that can be cleared by clicking an (x) button in the
+   input. These are both behaviors that may appear in different parts of
+   the codebase, but could share the same functionality.
+   Behaviors are added through the `data-js-hook` attribute on the HTML
+   and have a prefix of `behavior_`
+   (both those designators are set in modules/util/standard-type.js).
+
+   For example, `modules/behaviors/FlyoutMenu.js` defines the behavior of
+   expanding and collapsing an expandable menu. At a minimum, three things
+   need to be defined: (A) The containing scope of the menu, (B) the trigger
+   to activate the menu, and (C) the content to show/hide when the trigger
+   is clicked. So the markup looks something like:
+
+   <div data-js-hook="behavior_flyout-menu">
+     <button data-js-hook="behavior_flyout-menu_trigger">
+     <div data-js-hook="behavior_flyout-menu_content">
+
+   ========================================================================== */
+
+'use strict';
+
+// Required modules.
+var standardType = require( './standard-type' );
+var dataHook = require( '../../modules/util/data-hook' );
+
+/**
+ * @param {HTMLNode} element
+ *   The DOM element within which to search for the behavior
+ *   in the data-js-hook attribute.
+ * @param {string} behaviorDataAttr
+ *   The value in the data-js-hook. This is the name of the behavior.
+ *   E.g. `behavior_flyout-menu`, `behavior_flyout-menu_content`.
+ * @returns {HTMLNode} The DOM element that has an attached behavior.
+ * @throws {Error} If data-js-hook attribute value was not found on DOM element.
+ */
+function checkBehaviorDom( element, behaviorDataAttr ) {
+  // Check that the behavior is found on the passed DOM node.
+  var dom;
+
+  if ( dataHook.contains( element, behaviorDataAttr ) ) {
+    dom = element;
+    return dom;
+  }
+
+  // If the passed DOM node isn't null,
+  // query the node to see if it's in the children.
+  if ( element ) {
+    var selector = '[' + standardType.JS_HOOK + '=' + behaviorDataAttr + ']';
+    dom = element.querySelector( selector );
+  }
+
+  if ( !dom ) {
+    var msg = behaviorDataAttr + ' behavior not found on passed DOM node!';
+    throw new Error( msg );
+  }
+
+  return dom;
+}
+
+// Expose public methods.
+module.exports = {
+  checkBehaviorDom: checkBehaviorDom
+};

--- a/cfgov/unprocessed/js/modules/util/data-hook.js
+++ b/cfgov/unprocessed/js/modules/util/data-hook.js
@@ -52,6 +52,7 @@ function remove( element, value ) {
  * @returns {boolean} True if the data-* hook value exists, false otherwise.
  */
 function contains( element, value ) {
+  if ( !element ) { return false; }
   var values = element.getAttribute( standardType.JS_HOOK );
   // If JS data-* hook is not set return immediately.
   if ( !values ) { return false; }

--- a/cfgov/unprocessed/js/organisms/MegaMenu.js
+++ b/cfgov/unprocessed/js/organisms/MegaMenu.js
@@ -51,7 +51,7 @@ function MegaMenu( element ) {
 
     // DOM selectors.
     var rootMenuDom = _dom;
-    var rootContentDom = rootMenuDom.querySelector( FlyoutMenu.CONTENT_SEL );
+    var rootContentDom = rootMenuDom.querySelector( '.' + BASE_CLASS + '_content' );
 
     // Create model.
     _menus = new Tree();

--- a/test/unit_tests/modules/FlyoutMenu-spec.js
+++ b/test/unit_tests/modules/FlyoutMenu-spec.js
@@ -66,14 +66,6 @@ describe( 'FlyoutMenu', function() {
       expect( FlyoutMenu.EXPAND_TYPE ).to.equal( 'expand' );
       expect( FlyoutMenu.COLLAPSE_TYPE ).to.equal( 'collapse' );
       expect( FlyoutMenu.BASE_CLASS ).to.equal( 'behavior_flyout-menu' );
-      expect( FlyoutMenu.BASE_SEL )
-        .to.equal( '[data-js-hook=behavior_flyout-menu]' );
-      expect( FlyoutMenu.ALT_TRIGGER_SEL )
-        .to.equal( '[data-js-hook=behavior_flyout-menu_alt-trigger]' );
-      expect( FlyoutMenu.CONTENT_SEL )
-        .to.equal( '[data-js-hook=behavior_flyout-menu_content]' );
-      expect( FlyoutMenu.TRIGGER_SEL )
-        .to.equal( '[data-js-hook=behavior_flyout-menu_trigger]' );
     } );
 
     it( 'should have correct state before initializing', function() {

--- a/test/unit_tests/modules/util/behavior-spec.js
+++ b/test/unit_tests/modules/util/behavior-spec.js
@@ -1,0 +1,60 @@
+'use strict';
+
+var BASE_JS_PATH = '../../../../cfgov/unprocessed/js/';
+
+var chai = require( 'chai' );
+var expect = chai.expect;
+var jsdom = require( 'jsdom' );
+
+var behavior = require( BASE_JS_PATH + 'modules/util/behavior' );
+
+describe( 'behavior', function() {
+
+  var HTML_SNIPPET = '<div data-js-hook="behavior_flyout-menu">' +
+                     '<div data-js-hook="behavior_flyout-menu_content">' +
+                     '</div></div>';
+  var initdom = jsdom.jsdom( HTML_SNIPPET );
+  var document = initdom.defaultView.document;
+
+  var containerDom;
+  var behaviorElmDom;
+  var selector = 'data-js-hook=behavior_flyout-menu';
+
+  before( function() {
+    containerDom = document.querySelector( '[' + selector + ']' );
+    behaviorElmDom = document.querySelector( '[' + selector + '_content]' );
+  } );
+
+  describe( '.checkBehaviorDom()', function() {
+    it( 'should throw an error if element DOM not found', function() {
+      var errMsg = 'behavior_flyout-menu ' +
+                   'behavior not found on passed DOM node!';
+      function errFunc() {
+        behavior.checkBehaviorDom( null, 'behavior_flyout-menu' );
+      }
+      expect( errFunc ).to.throw( Error, errMsg );
+    } );
+
+    it( 'should throw an error if behavior attribute not found', function() {
+      var errMsg = 'mock-attr behavior not found on passed DOM node!';
+      function errFunc() {
+        behavior.checkBehaviorDom( containerDom, 'mock-attr' );
+      }
+      expect( errFunc ).to.throw( Error, errMsg );
+    } );
+
+    it( 'should return the correct HTMLElement ' +
+        'when direct element is searched', function() {
+      var dom = behavior.checkBehaviorDom( containerDom,
+                                           'behavior_flyout-menu' );
+      expect( dom ).to.be.equal( containerDom );
+    } );
+
+    it( 'should return the correct HTMLElement ' +
+        'when child element is searched', function() {
+      var dom = behavior.checkBehaviorDom( behaviorElmDom,
+                                           'behavior_flyout-menu_content' );
+      expect( dom ).to.be.equal( behaviorElmDom );
+    } );
+  } );
+} );


### PR DESCRIPTION
## Changes

- Removes unneeded constant exports from FlyoutMenu.
- Moves behavior DOM check to utility method.
- Removes TODO for atomic-helper, as behavior shouldn't use that for clarity.

## Testing

- `gulp build && gulp test:unit && gulp test:acceptance --sauce=false`

## Review

- @sebworks 
- @jimmynotjim 

## Notes

- Adds to `/util/behavior.js` created in https://github.com/cfpb/cfgov-refresh/pull/2118