### PR TITLE
Hotfix: Add value default back

### DIFF
--- a/cfgov/jinja2/v1/_includes/molecules/social-media.html
+++ b/cfgov/jinja2/v1/_includes/molecules/social-media.html
@@ -32,7 +32,7 @@
 
    ========================================================================== #}
 
-{% macro render( value ) %}
+{% macro render( value={} ) %}
 
 {% set blurb = (value.blurb or (page.seo_title if page) or value.title or
                 'Look what I found on the CFPB’s site!') | urlencode %}


### PR DESCRIPTION
## Changes

- Add default value for `value` back in from https://github.com/cfpb/cfgov-refresh/pull/2117, otherwise non-wagtail pages that use the social media molecule fail (e.g. /about-us/the-bureau/about-director/)

## Testing

- `gulp test:acceptance --sauce=false`

## Review

- @Scotchester 
- @kave 
- @kurtw 

## Notes

- Not sure if there's a better way to provide the default, but this seems to work inside and out of wagtail.

