### PR TITLE
Remove `atomicName` parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 
 ### Removed
 - Event RSVP email link button
+- `atomicName` parameter from `checkDom` atomic helper.
 
 ### Fixed
 - get_browsefilterable_posts() call to get_page_set

--- a/cfgov/unprocessed/js/modules/ClearableInput.js
+++ b/cfgov/unprocessed/js/modules/ClearableInput.js
@@ -16,7 +16,7 @@ var atomicHelpers = require( '../modules/util/atomic-helpers' );
 function ClearableInput( element ) {
   var BASE_CLASS = 'input-contains-label';
 
-  var _dom = atomicHelpers.checkDom( element, BASE_CLASS, 'ClearableInput' );
+  var _dom = atomicHelpers.checkDom( element, BASE_CLASS );
   var _inputDom = _dom.querySelector( 'input' );
   var _clearBtnDom = _dom.querySelector( '.' + BASE_CLASS + '_after__clear' );
 

--- a/cfgov/unprocessed/js/modules/ExternalSite.js
+++ b/cfgov/unprocessed/js/modules/ExternalSite.js
@@ -21,7 +21,7 @@ function ExternalSite( element ) {
   var TOTAL_DURATION = 5;
   var INTERVAL = 1000;
 
-  var _dom = atomicHelpers.checkDom( element, BASE_CLASS, 'ExternalSite' );
+  var _dom = atomicHelpers.checkDom( element, BASE_CLASS );
   var _durationEl = _dom.querySelector( '.external-site_reload-container' );
   var _directEl = _dom.querySelector( '.external-site_proceed-btn' );
   var _duration = TOTAL_DURATION;

--- a/cfgov/unprocessed/js/modules/util/atomic-helpers.js
+++ b/cfgov/unprocessed/js/modules/util/atomic-helpers.js
@@ -14,14 +14,12 @@ var INIT_FLAG = standardType.STATE_PREFIX + 'atomic_init';
 /**
  * @param {HTMLNode} element
  *   The DOM element within which to search for the atomic element class.
- * @param {string} baseClass The CSS class name for the atomic element.
- * @param {string} atomicName
- *   The name of the atomic element in CapitalizedCamelCase.
+ * @param {string} baseClass - The CSS class name for the atomic element.
  * @returns {HTMLNode} The DOM element for the atomic element.
  * @throws {Error} If DOM element passed into the atomic element is not valid.
  */
-function checkDom( element, baseClass, atomicName ) {
-  _verifyElementExists( element, atomicName );
+function checkDom( element, baseClass ) {
+  _verifyElementExists( element, baseClass);
   var dom = _verifyClassExists( element, baseClass );
 
   return dom;
@@ -30,15 +28,15 @@ function checkDom( element, baseClass, atomicName ) {
 /**
  * @param {HTMLNode} element
  *   The DOM element within which to search for the atomic element class.
- * @param {string} atomicName
- *   The name of the atomic element in CapitalizedCamelCase.
+ * @param {string} baseClass - The CSS class name for the atomic element.
  * @returns {HTMLNode} The DOM element for the atomic element.
  * @throws {Error} If DOM element passed into the atomic element is not valid.
  */
-function _verifyElementExists( element, atomicName ) {
+function _verifyElementExists( element, baseClass ) {
   if ( !element || !element.classList ) {
-    var msg = element + ' passed to ' + atomicName + '.js is not valid. ' +
-              'Check that element is a valid DOM node';
+    var msg = element + ' is not valid. ' +
+              'Check that element is a DOM node with class "' +
+              baseClass + '"';
     throw new Error( msg );
   }
 

--- a/cfgov/unprocessed/js/molecules/Expandable.js
+++ b/cfgov/unprocessed/js/molecules/Expandable.js
@@ -29,7 +29,7 @@ function Expandable( element ) { // eslint-disable-line max-statements, inline-c
 
   // The Expandable element will directly be the Expandable
   // when used in an ExpandableGroup, otherwise it can be the parent container.
-  var _dom = atomicHelpers.checkDom( element, BASE_CLASS, 'Expandable' );
+  var _dom = atomicHelpers.checkDom( element, BASE_CLASS );
   var _target = _dom.querySelector( '.' + BASE_CLASS + '_target' );
   var _content = _dom.querySelector( '.' + BASE_CLASS + '_content' );
   var _contentAnimated =

--- a/cfgov/unprocessed/js/molecules/GlobalBanner.js
+++ b/cfgov/unprocessed/js/molecules/GlobalBanner.js
@@ -26,7 +26,7 @@ function GlobalBanner( element ) {
   var BASE_CLASS = 'm-global-banner';
   var EXPANDED_STATE = 'globalBannerIsExpanded';
 
-  var _dom = atomicHelpers.checkDom( element, BASE_CLASS, 'GlobalBanner' );
+  var _dom = atomicHelpers.checkDom( element, BASE_CLASS );
   var _expandable;
 
   /**

--- a/cfgov/unprocessed/js/molecules/GlobalSearch.js
+++ b/cfgov/unprocessed/js/molecules/GlobalSearch.js
@@ -23,7 +23,7 @@ var standardType = require( '../modules/util/standard-type' );
 function GlobalSearch( element ) { // eslint-disable-line max-statements, no-inline-comments, max-len
 
   var BASE_CLASS = 'm-global-search';
-  var _dom = atomicHelpers.checkDom( element, BASE_CLASS, 'GlobalSearch' );
+  var _dom = atomicHelpers.checkDom( element, BASE_CLASS );
   var _contentDom = _dom.querySelector( '.' + BASE_CLASS + '_content' );
   var _flyoutMenu = new FlyoutMenu( _dom );
   var _searchInputDom;

--- a/cfgov/unprocessed/js/molecules/Notification.js
+++ b/cfgov/unprocessed/js/molecules/Notification.js
@@ -26,7 +26,7 @@ function Notification( element ) { // eslint-disable-line max-statements, inline
   // Constants for the Notification modifiers.
   var MODIFIER_VISIBLE = BASE_CLASS + '__visible';
 
-  var _dom = atomicHelpers.checkDom( element, BASE_CLASS, 'Notification' );
+  var _dom = atomicHelpers.checkDom( element, BASE_CLASS );
   var _contentDom = _dom.querySelector( '.' + BASE_CLASS + '_content' );
 
   var _currentType;

--- a/cfgov/unprocessed/js/organisms/ExpandableGroup.js
+++ b/cfgov/unprocessed/js/organisms/ExpandableGroup.js
@@ -19,7 +19,7 @@ function ExpandableGroup( element ) {
 
   var BASE_CLASS = 'o-expandable-group';
 
-  var _dom = atomicHelpers.checkDom( element, BASE_CLASS, 'ExpandableGroup' );
+  var _dom = atomicHelpers.checkDom( element, BASE_CLASS );
   var _domChildren = _dom.querySelectorAll( '.m-expandable' );
   var _lastOpenChild;
   var _isAccordion;

--- a/cfgov/unprocessed/js/organisms/FilterableListControls.js
+++ b/cfgov/unprocessed/js/organisms/FilterableListControls.js
@@ -22,8 +22,7 @@ var validators = require( '../modules/util/validators' );
  */
 function FilterableListControls( element ) {
   var BASE_CLASS = 'o-filterable-list-controls';
-  var _dom = atomicHelpers.checkDom(
-    element, BASE_CLASS, 'FilterableListControls' );
+  var _dom = atomicHelpers.checkDom( element, BASE_CLASS );
   var _form = _dom.querySelector( 'form' );
   var _notification;
   var _fieldGroups;

--- a/cfgov/unprocessed/js/organisms/Footer.js
+++ b/cfgov/unprocessed/js/organisms/Footer.js
@@ -19,7 +19,7 @@ function Footer( element ) {
 
   var BASE_CLASS = 'o-footer';
 
-  var _dom = atomicHelpers.checkDom( element, BASE_CLASS, 'Footer' );
+  var _dom = atomicHelpers.checkDom( element, BASE_CLASS );
 
   /**
    * @returns {Footer|undefined} An instance,

--- a/cfgov/unprocessed/js/organisms/Header.js
+++ b/cfgov/unprocessed/js/organisms/Header.js
@@ -21,7 +21,7 @@ function Header( element ) {
 
   var BASE_CLASS = 'o-header';
 
-  var _dom = atomicHelpers.checkDom( element, BASE_CLASS, 'Header' );
+  var _dom = atomicHelpers.checkDom( element, BASE_CLASS );
 
   var _globalbanner;
   var _globalSearch;

--- a/cfgov/unprocessed/js/organisms/MegaMenu.js
+++ b/cfgov/unprocessed/js/organisms/MegaMenu.js
@@ -26,7 +26,7 @@ var standardType = require( '../modules/util/standard-type' );
 function MegaMenu( element ) {
   var BASE_CLASS = 'o-mega-menu';
 
-  var _dom = atomicHelpers.checkDom( element, BASE_CLASS, 'MegaMenu' );
+  var _dom = atomicHelpers.checkDom( element, BASE_CLASS );
 
   // Tree data model.
   var _menus;

--- a/cfgov/unprocessed/js/organisms/SecondaryNavigation.js
+++ b/cfgov/unprocessed/js/organisms/SecondaryNavigation.js
@@ -17,8 +17,7 @@ var standardType = require( '../modules/util/standard-type' );
 function SecondaryNavigation( element ) {
   var BASE_CLASS = 'o-secondary-navigation';
 
-  var _dom =
-    atomicHelpers.checkDom( element, BASE_CLASS, 'SecondaryNavigation' );
+  var _dom = atomicHelpers.checkDom( element, BASE_CLASS );
 
   /**
    * @returns {SecondaryNavigation|undefined} An instance,

--- a/test/unit_tests/modules/util/atomic-helpers-spec.js
+++ b/test/unit_tests/modules/util/atomic-helpers-spec.js
@@ -25,10 +25,10 @@ describe( 'atomic-helpers', function() {
 
   describe( '.checkDom()', function() {
     it( 'should throw an error if element DOM not found', function() {
-      var errMsg = 'null passed to Expandable.js is not valid. ' +
-                   'Check that element is a valid DOM node';
+      var errMsg = 'null is not valid. ' +
+                   'Check that element is a DOM node with class ".m-expandable"';
       function errFunc() {
-        atomicHelpers.checkDom( null, '.m-expandable', 'Expandable' );
+        atomicHelpers.checkDom( null, '.m-expandable' );
       }
       expect( errFunc ).to.throw( Error, errMsg );
     } );
@@ -36,7 +36,7 @@ describe( 'atomic-helpers', function() {
     it( 'should throw an error if element class not found', function() {
       var errMsg = 'mock-class not found on or in passed DOM node.';
       function errFunc() {
-        atomicHelpers.checkDom( expandableDom, 'mock-class', 'Expandable' );
+        atomicHelpers.checkDom( expandableDom, 'mock-class' );
       }
       expect( errFunc ).to.throw( Error, errMsg );
     } );
@@ -44,14 +44,14 @@ describe( 'atomic-helpers', function() {
     it( 'should return the correct HTMLElement ' +
         'when direct element is searched', function() {
       var dom =
-        atomicHelpers.checkDom( expandableDom, 'm-expandable', 'Expandable' );
+        atomicHelpers.checkDom( expandableDom, 'm-expandable' );
       expect( dom ).to.be.equal( expandableDom );
     } );
 
     it( 'should return the correct HTMLElement ' +
         'when parent element is searched', function() {
       var dom =
-        atomicHelpers.checkDom( containerDom, 'm-expandable', 'Expandable' );
+        atomicHelpers.checkDom( containerDom, 'm-expandable' );
       expect( dom ).to.be.equal( expandableDom );
     } );
   } );


### PR DESCRIPTION
`atomicName` parameter was passed around purely to provide a more descriptive error message. However, the class name can be used instead, since—if the atomic naming is correct—the class name will include the atomic name. This simplifies the atomic helper utilities.

## Removals

- `atomicName` parameter from `atomicHelpers.checkDom`.

## Changes

- Updates associated calling code and tests.

## Testing

- `gulp test:unit:scripts` should pass. `gulp build` and no change in site functionality.

## Review

- @sebworks 
- @jimmynotjim 
