### PR TITLE
Adding unit tests for data-set utility

### DIFF
--- a/test/unit_tests/modules/util/data-set-spec.js
+++ b/test/unit_tests/modules/util/data-set-spec.js
@@ -1,11 +1,52 @@
 'use strict';
 
 var BASE_JS_PATH = '../../../../cfgov/unprocessed/js/';
+var dataSet = require( BASE_JS_PATH + 'modules/util/data-set' ).dataSet;
 
 var chai = require( 'chai' );
 var expect = chai.expect;
-var dataSet = require( BASE_JS_PATH + 'modules/util/data-set' );
+var jsdom = require( 'mocha-jsdom' );
+var sinon = require( 'sinon' );
+var sandbox;
+var baseDom;
+
+var HTML_SNIPPET =
+  '<div data-test-value-a="testValueA"' +
+        'data-test-value-B="testValueB"' +
+        'data-testValue-C="testValueC"' +
+        'data-test-ValuE-D="testValueD"' +
+        'data-TEST-value-E="testValueE" >' +
+    'testValue' +
+  '</div>';
+
+// JSdom hasn't implmented Element.dataset so I used Chrome to determine
+// the correct values : http://jsfiddle.net/0j9u66h0/13/.
+var datasetLookup =
+  { testValueA: 'testValueA',
+    testValueB: 'testValueB',
+    testvalueC: 'testValueC',
+    testValueD: 'testValueD',
+    testValueE: 'testValueE'
+  };
 
 describe( 'data-set', function() {
-  // TODO: Implement tests.
+  jsdom();
+
+  beforeEach( function() {
+    sandbox = sinon.sandbox.create();
+    document.body.innerHTML = HTML_SNIPPET;
+    baseDom = document.querySelector( 'div' );
+  } );
+
+  afterEach( function() {
+    sandbox.restore();
+  } );
+
+  it( 'should have the correct keys and values when using utility',
+    function() {
+      var dataset = dataSet( baseDom );
+      expect( JSON.stringify( dataset ) ===
+        JSON.stringify( datasetLookup ) ).to.equal( true );
+    }
+  );
 } );


### PR DESCRIPTION
Adding unit tests for data-set utility

## Additions

- Adding unit tests for data-set utility

## Testing

- Run `test:unit:scripts`

## Review

- @anselmbradford 
- @jimmynotjim 


## Todos

- This unit test doesn't include referencing the native dataset property, as it's not supported by jsdom. I don't have a great way to test that yet.

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
