### PR TITLE
Remove unused jobmanager view function for gov delivery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 ### Removed
 - Event RSVP email link button
 - `atomicName` parameter from `checkDom` atomic helper.
+- Unused gov delivery view function in jobmanager
 
 ### Fixed
 - get_browsefilterable_posts() call to get_page_set

--- a/cfgov/jobmanager/views.py
+++ b/cfgov/jobmanager/views.py
@@ -71,18 +71,3 @@ def current_openings(request):
     
     return render(request, "about-us/careers/current-openings/index.html",
         {'careers':jobs})
-
-
-# This function is used to submit to Gov-Delivery
-@csrf_exempt
-def submit_govdelivery(request):
-    code = request.POST.get('code')
-    email = request.POST.get('email')
-    import urllib
-    try:
-        res = urllib.urlopen('https://public.govdelivery.com/service/process_ss.xml?code=%s&email=%s' % (code, email))
-    except:
-        # todo: log error
-        res = '<response code="500" message="Unknown Server Error"/>'
-
-    return HttpResponse(res, content_type="application/xhtml+xml")


### PR DESCRIPTION
Nothing is using it.

## Removals

- Jobmanager view function 


## Review

- @rosskarchner 
- @kave 
- @richaagarwal 

