### PR TITLE
Removes console.log statement

### DIFF
--- a/test/unit_tests/modules/ClearableInput-spec.js
+++ b/test/unit_tests/modules/ClearableInput-spec.js
@@ -84,7 +84,6 @@ describe( 'ClearableInput', function() {
 
       // Event code 65 is the `a` character.
       triggerEvent( inputDom, 'keyup', 65 );
-      console.log( inputDom.value, 'value')
       expect( clearBtnDom.classList.contains( 'u-hidden' ) ).to.equal( false );
     } );
 


### PR DESCRIPTION
Oops, noticed a console.log slipped through and is logging "value" in the unit test output.

## Removals

- Removes console.log statement from unit test.

## Testing

- `gulp lint:tests` should have no errors.

## Review

- @sebworks 
- @jimmynotjim 
