### PR TITLE
Remove meta stuff from private test-fixture path

### DIFF
--- a/cfgov/jinja2/v1/test-fixture/index.html
+++ b/cfgov/jinja2/v1/test-fixture/index.html
@@ -35,26 +35,6 @@
 -->
 
     <title>{% block title %}MISSING TITLE{% endblock title %}</title>
-    <meta name="description"
-          content="{% block desc %}Prototyping for the consumerfinance.gov refresh{% endblock %}">
-
-    <!-- Open Graph properties -->
-        <!--   Required  -->
-        <meta property="og:title" content="{% block og_title %}{{ self.title() }}{% endblock %}">
-        <meta property="og:type" content="{% block og_type %}website{% endblock %}">
-        <meta property="og:url" content="{{ request.url }}">
-        <meta property="og:image"
-              content="http://www.consumerfinance.gov/wp-content/themes/cfpb_nemo/_/img/logo.svg">
-        <!--   Optional -->
-        <meta property="og:description" content="{% block og_desc %}{{ self.desc() }}{% endblock %}">
-        <meta property="og:site_name" content="Consumer Financial Protection Bureau">
-        <!--   Facebook -->
-        <meta property="fb:app_id" content="210516218981921">
-        {% block og_article_author %}{% endblock %}
-    <!-- End of Open Graph properties -->
-
-    {# TODO: Explicit favicon link needed for testing. Remove for production. #}
-    <link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
 {#
     ============
     ONDEMAND CSS


### PR DESCRIPTION
Remove meta stuff from private test-fixture path.
meta elements for open graph and favicon aren't needed on private path for on-demand components.

## Removals

- open graph meta.
- description meta.
- favicon.

## Review

- @jimmynotjim 
- @sebworks 

