### PR TITLE
Downcase gulp tasks

### DIFF
--- a/gulp/tasks/browser-sync.js
+++ b/gulp/tasks/browser-sync.js
@@ -4,7 +4,7 @@ var gulp = require( 'gulp' );
 var util = require( 'gulp-util' );
 var browserSync = require( 'browser-sync' );
 
-gulp.task( 'browserSync', function() {
+gulp.task( 'browsersync', function() {
   var port = util.env.port || process.env.HTTP_PORT || '8000'; // eslint-disable-line no-process-env, no-inline-comments, max-len
   browserSync.init( {
     proxy: 'localhost:' + port

--- a/gulp/tasks/watch.js
+++ b/gulp/tasks/watch.js
@@ -7,7 +7,7 @@
 var gulp = require( 'gulp' );
 var config = require( '../config' );
 
-gulp.task( 'watch', [ 'browserSync' ], function() {
+gulp.task( 'watch', [ 'browsersync' ], function() {
   gulp.watch( config.scripts.src, [ 'scripts' ] );
   gulp.watch( config.styles.cwd + '/**/*.less', [ 'styles' ] );
   gulp.watch( config.images.src, [ 'images' ] );


### PR DESCRIPTION
All our gulp tasks are lowercase, except for `gulp watch:browserSync` ... seems like when we're talking about typing in the command line, keeping everything lowercase will be easier.

## Changes

- downcases `gulp watch:browserSync` to `gulp watch:browsersync`

## Testing

- `gulp --tasks` are all lowercase.

## Review

- @jimmynotjim 
- @sebworks 
