### PR TITLE
Make TextIntroduction's has_rule functional

### DIFF
--- a/cfgov/jinja2/v1/_includes/molecules/text-introduction.html
+++ b/cfgov/jinja2/v1/_includes/molecules/text-introduction.html
@@ -25,6 +25,9 @@
 
    value.links[i].url:  A string for the URL of the link.
 
+   value.has_rule:      Whether or not to render a rule line (border-bottom)
+                        at the bottom of the molecule.
+
    ========================================================================== #}
 
 {% if value.heading %}

--- a/cfgov/jinja2/v1/_includes/templates/render_block.html
+++ b/cfgov/jinja2/v1/_includes/templates/render_block.html
@@ -1,6 +1,8 @@
-
 {% macro render(block, index) %}
-    <div class="block {{ 'block__flush-top' if index == 1 else '' }} {{ block.block.meta.classname if block.block.meta.classname else '' -}}">
+    <div class="block
+                {{ 'block__flush-top' if index == 1 else '' }}
+                {{ 'block__padded-bottom block__border-bottom' if block.value.has_rule else '' }}
+                {{ block.block.meta.classname if block.block.meta.classname else '' -}}">
         {{ render_stream_child(block) }}
     </div>
 {% endmacro %}

--- a/cfgov/jinja2/v1/browse-basic/index.html
+++ b/cfgov/jinja2/v1/browse-basic/index.html
@@ -1,6 +1,7 @@
 {% extends 'layout-side-nav.html' %}
 
 {% import 'molecules/featured-content.html' as featured_content %}
+{% import 'templates/render_block.html' as render_block with context %}
 {% import 'templates/streamfield-sidefoot.html' as streamfield_sidefoot with context %}
 
 {% block content_main_modifiers -%}
@@ -14,20 +15,12 @@
                         block__flush-sides">
                 {{ featured_content.render(block.value) }}
             </div>
-        {% elif loop.index == 1 %}
-            <div class="block
-                        block__flush-top">
-                {{ render_stream_child(block) }}
-            </div>
         {% else %}
-            <div class="block">
-                {{ render_stream_child(block) }}
-            </div>
+            {{ render_block.render(block, loop.index) }}
         {% endif %}
     {%- endfor %}
 
     {% for block in page.content -%}
-        {% import 'templates/render_block.html' as render_block with context %}
         {{ render_block.render(block, loop.index) }}
     {%- endfor %}
 
@@ -37,4 +30,3 @@
         </aside>
     {% endif %}
 {% endblock %}
-

--- a/cfgov/jinja2/v1/browse-filterable/index.html
+++ b/cfgov/jinja2/v1/browse-filterable/index.html
@@ -1,6 +1,8 @@
 {% extends 'layout-side-nav.html' %}
 
 {% import 'molecules/featured-content.html' as featured_content %}
+{% import 'organisms/filterable-list-controls.html' as flc with context %}
+{% import 'templates/render_block.html' as render_block with context %}
 {% import 'templates/streamfield-sidefoot.html' as streamfield_sidefoot with context %}
 
 {% block content_main_modifiers -%}
@@ -14,22 +16,17 @@
                         block__flush-sides">
                 {{ featured_content.render(block.value) }}
             </div>
-        {% elif loop.index == 1 %}
-        <div class="block
-                    block__flush-top">
-            {{ render_stream_child(block) }}
-        </div>
+        {% else %}
+            {{ render_block.render(block, loop.index) }}
         {% endif %}
     {% endfor %}
     {% for block in page.content %}
         {% if 'filter_controls' in block.block_type %}
             <div class="block
-                    block__flush-top">
-                {% import 'organisms/filterable-list-controls.html' as flc with context %}
+                        block__flush-top">
                 {{ flc.render(block.value, loop.index0) }}
             </div>
         {% else %}
-            {% import 'templates/render_block.html' as render_block with context %}
             {{ render_block.render(block, loop.index) }}
         {% endif %}
     {% endfor %}

--- a/cfgov/jinja2/v1/landing-page/index.html
+++ b/cfgov/jinja2/v1/landing-page/index.html
@@ -1,5 +1,6 @@
 {% extends 'layout-2-1-bleedbar.html' %}
 
+{% import 'templates/render_block.html' as render_block with context %}
 {% import 'templates/streamfield-sidefoot.html' as streamfield_sidefoot with context %}
 
 {% block content_main_modifiers -%}
@@ -17,20 +18,11 @@
 {% block content_main %}
     {% for block in page.header -%}
         {% if block.block_type != 'hero' %}
-            {% import 'templates/render_block.html' as render_block with context %}
             {{ render_block.render(block, loop.index) }}
         {% endif %}
     {%- endfor %}
     {% for block in page.content -%}
-        {% if loop.index == 1 %}
-            <div class="block
-                        block__flush-top">
-                {{ render_stream_child(block) }}
-            </div>
-        {% else %}
-             {% import 'templates/render_block.html' as render_block with context %}
-            {{ render_block.render(block, loop.index) }}
-        {% endif %}
+        {{ render_block.render(block, loop.index) }}
     {%- endfor %}
 {% endblock %}
 

--- a/cfgov/jinja2/v1/learn-page/index.html
+++ b/cfgov/jinja2/v1/learn-page/index.html
@@ -1,5 +1,7 @@
 {% extends 'layout-2-1-bleedbar.html' %}
 
+{% import 'organisms/item-introduction.html' as item_introduction with context %}
+{% import 'templates/render_block.html' as render_block with context %}
 {% import 'templates/streamfield-sidefoot.html' as streamfield_sidefoot with context %}
 
 {% block content_main_modifiers -%}
@@ -9,18 +11,13 @@
 {% block content_main %}
     {% for block in page.header -%}
         {% if block.block_type == 'item_introduction' %}
-            {% import 'organisms/item-introduction.html' as item_introduction with context %}
             {{ item_introduction.render(block.value) }}
         {% else %}
-            <div class="block
-                        block__flush-top">
-                {{ render_stream_child(block) }}
-            </div>
+            {{ render_block.render(block, loop.index) }}
         {% endif %}
     {%- endfor %}
 
     {% for block in page.content -%}
-        {% import 'templates/render_block.html' as render_block with context %}
         {{ render_block.render(block, loop.index) }}
     {%- endfor %}
 {% endblock %}


### PR DESCRIPTION
The "Has rule" option in the Text Introduction module wasn't actually doing anything. This PR fixes that.

## Additions

- Documentation of `has_rule` option to Text Introduction template

## Changes

- Updates the `render_block` macro to add `.block__padded-bottom.block__border-bottom` to the `div` if it finds a truthy `has_rule` option in the block it's rendering.
- Updates several template files to use `render_block` in all cases where they should be.
- Standardizes `import` rules at the top of the file. _(Let me know if this was a bad idea.)_

## Testing

Verifying bug:
1. Check the "Has rule" option in a Text Introduction module in any Wagtail page.
2. Preview the page and see that no rule is added below the module.

Verifying fix:
1. Pull branch.
2. In your local Wagtail, 
3. Publish the page and view the result. It now has a rule at the bottom!
4. For extra credit, create each one of the page types modified in this PR (browse basic, browse filterable, landing, learn) with Text Introduction modules and test all of them.

## Review

- @kurtw 
- @sebworks 
- @jimmynotjim 
- @KimberlyMunoz 
- @anselmbradford 

## Todos

- Out of scope of this PR, but @kurtw mentioned that the other module-related logic in these page templates could maybe be further simplified?

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)