### PR TITLE
Created non-responsive on-demand styles for non-v1 sections of the site.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,19 +16,21 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 ## Unreleased
 
 ## Added
-- Ability to use Social Media molecule as a Wagtail module in the Sidefoot
+- Ability to use Social Media molecule as a Wagtail module in the Sidefoot.
 - Frontend: Added task for generating JavaScript code docs with `gulp docs`.
 
 ### Changes
-- Use bare value of RichText field if value type is not RichText
-- Check against Activity Log topics when generating View More link
-- Breadcrumb and sidenav link generation gets most appropriate version of page
-- Made Text Introduction's `has_rule` option have an effect
-- Tidied up some of the template logic around using `render_block`
-- Changed class of FCM category slug to remove extra spacing
+- Use bare value of RichText field if value type is not RichText.
+- Check against Activity Log topics when generating View More link.
+- Breadcrumb and sidenav link generation gets most appropriate version of page.
+- Made Text Introduction's `has_rule` option have an effect.
+- Tidied up some of the template logic around using `render_block`.
+- Changed class of FCM category slug to remove extra spacing.
+- Updated gulp task to write both responsive and non-responsive styles for ondemand needs.
+- Updated the test fixture for ondemand includes to allow for the nonresponsive stylesheet to be loaded for visual testing.
 
 ### Removed
-- Event RSVP email link button
+- Event RSVP email link button.
 - `atomicName` parameter from `checkDom` atomic helper.
 
 ### Fixed

--- a/cfgov/jinja2/v1/test-fixture/index.html
+++ b/cfgov/jinja2/v1/test-fixture/index.html
@@ -8,6 +8,9 @@
 {# Set to the Header organism by default. #}
 {% set atomic_type = 'header' if atomic_type == None else atomic_type %}
 
+{% set suffix = request.GET.get( 'suffix' ) %}
+{% set suffix = '' if suffix == None else '.' + suffix %}
+
 <!DOCTYPE html>
 
 <!--[if IE 8]>         <html lang="en" class="no-js lt-ie10 lt-ie9"> <![endif]-->
@@ -41,7 +44,7 @@
     ============
     The atomic CSS file. This includes legacy IE-specific prefixing.
 #}
-<link rel="stylesheet" href="{{ static('css/' + atomic_type + '.css') }}">
+<link rel="stylesheet" href="{{ static('css/' + atomic_type + suffix + '.css') }}">
 
 {#
     ================

--- a/gulp/tasks/styles.js
+++ b/gulp/tasks/styles.js
@@ -77,6 +77,16 @@ function stylesOnDemand() {
     } ) )
     .pipe( plugins.header( configBanner, { pkg: configPkg } ) )
     .pipe( gulp.dest( configStyles.dest ) )
+    .pipe( mqr( {
+      width: '75em'
+    } ) )
+    // mqr expands the minified file
+    .pipe( plugins.cssmin() )
+    .pipe( plugins.rename( {
+      suffix:  '.nonresponsive',
+      extname: '.css'
+    } ) )
+    .pipe( gulp.dest( configStyles.dest ) )
     .pipe( browserSync.reload( {
       stream: true
     } ) );


### PR DESCRIPTION
As part of #2156, we need a stylesheet without the small screen styles for limited sections of the site that aren't yet updated. Updated the ondemand gulp task to write a separate nonresponsive stylesheet.

## Changes

- Updated gulp task to write both responsive and non-responsive styles for ondemand needs.
- Updated the test fixture for ondemand includes to allow for the nonresponsive stylesheet to be loaded for visual testing.

## Testing

- `gulp styles:ondemand` and navigate to `http://localhost:8000/test-fixture/?atomic=header&suffix=nonresponsive`. Header should keep the large screen styles (though the menu will still go offscreen due to JS, upcoming fix for that).

## Review

- @KimberlyMunoz 
- @rosskarchner 
- @richaagarwal 

## Screenshots

<img width="1139" alt="screen shot 2016-06-01 at 12 12 10 pm" src="https://cloud.githubusercontent.com/assets/1280430/15718651/1936e762-27f2-11e6-8369-62f88ac4b7bc.png">

## Notes

- It's looking like we'll need to separate out the small screen vs large screen menus to make this simpler. Getting the JS to work with both, but only show the large screen behaviors on these older pages is proving to be extremely complicated. If anyone has objections or other ideas, please chime in cc @anselmbradford 

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)