### PR TITLE
[vagrant] made the mysql version less specific

### DIFF
--- a/ansible/vars/db.yml
+++ b/ansible/vars/db.yml
@@ -14,7 +14,7 @@ mysql_users:
     priv: "{{ mysql_database }}.*:ALL"
 
 mysql_packages:
-  - mysql-5.1.73-5.el6_6
+  - mysql
   - mysql-server
   - mysql-libs
   - MySQL-python


### PR DESCRIPTION
This lets ansible get further than it was-- though it's still not quite working.

Once this is merged, then you should get up to an error like:

```
TASK: [Migrate django db to match application state] ************************** 
fatal: [default] => failed to transfer file to /home/vagrant/.ansible/tmp/ansible-tmp-1464870516.27-55513630887318/command:
Received message too long 1449751156
```

@vickumar1981 @vccabral any idea what to try next?

## Review

- @richaagarwal @kave @kurtw 

## Testing

- `vagrant up` will fail at an error like the one above (instead of complaining about MySQL versions)

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)