### PR TITLE
Updating mobile tests and adding mega menu tests

### DIFF
--- a/test/browser_tests/spec_suites/activity-log.js
+++ b/test/browser_tests/spec_suites/activity-log.js
@@ -4,6 +4,10 @@ var ActivityLog = require(
     '../page_objects/page_activity-log.js'
   );
 
+var BASE_JS_PATH = '../../../cfgov/unprocessed/js/';
+
+var breakpointsConfig = require( BASE_JS_PATH + 'config/breakpoints-config' );
+
 describe( 'The Activity Log Page', function() {
   var page;
 
@@ -14,10 +18,6 @@ describe( 'The Activity Log Page', function() {
 
   it( 'should properly load in a browser', function() {
     expect( page.pageTitle() ).toContain( 'Activity Log' );
-  } );
-
-  xit( 'should include a main title', function() {
-    expect( page.mainTitle.getText() ).toBe( 'Activity Log' );
   } );
 
   it( 'should include a main summary', function() {
@@ -39,9 +39,16 @@ describe( 'The Activity Log Page', function() {
   it( 'should include a visible Show button',
     function() {
       expect( page.searchFilterShowBtn.isDisplayed() ).toBe( true );
-      expect( page.searchFilterShowBtn.getText() ).toBe( 'Show' );
     }
   );
+
+  if ( browser.params.windowWidth > breakpointsConfig.bpMED.min ) {
+    it( 'should say "Show" on medium/large screens',
+      function() {
+        expect( page.searchFilterShowBtn.getText() ).toBe( 'Show' );
+      }
+    );
+  }
 
   it( 'should include a hidden Hide button',
     function() {

--- a/test/browser_tests/spec_suites/blog.js
+++ b/test/browser_tests/spec_suites/blog.js
@@ -4,6 +4,10 @@ var Blog = require(
     '../page_objects/page_blog.js'
   );
 
+var BASE_JS_PATH = '../../../cfgov/unprocessed/js/';
+
+var breakpointsConfig = require( BASE_JS_PATH + 'config/breakpoints-config' );
+
 describe( 'The Blog Page', function() {
   var page;
 
@@ -95,8 +99,15 @@ describe( 'The Blog Page', function() {
 
   it( 'should include a visible Show button', function() {
     expect( page.searchFilterShowBtn.isDisplayed() ).toBe( true );
-    expect( page.searchFilterShowBtn.getText() ).toBe( 'Show' );
   } );
+
+  if ( browser.params.windowWidth > breakpointsConfig.bpMED.min ) {
+    it( 'should say "Show" on medium/large screens',
+      function() {
+        expect( page.searchFilterShowBtn.getText() ).toBe( 'Show' );
+      }
+    );
+  }
 
   it( 'should include a hidden Hide button', function() {
     expect( page.searchFilterHideBtn.isDisplayed() ).toBe( false );

--- a/test/browser_tests/spec_suites/leadership-calendar.js
+++ b/test/browser_tests/spec_suites/leadership-calendar.js
@@ -3,6 +3,10 @@
 var TheLeadershipCalendarPage =
 require( '../page_objects/page_leadership-calendar.js' );
 
+var BASE_JS_PATH = '../../../cfgov/unprocessed/js/';
+
+var breakpointsConfig = require( BASE_JS_PATH + 'config/breakpoints-config' );
+
 describe( 'The Leadership Calendar Page', function() {
   var page;
 
@@ -48,8 +52,15 @@ describe( 'The Leadership Calendar Page', function() {
 
     it( 'should include a visible Show button', function() {
       expect( page.searchFilterShowBtn.isDisplayed() ).toBe( true );
-      expect( page.searchFilterShowBtn.getText() ).toBe( 'Show' );
     } );
+
+    if ( browser.params.windowWidth > breakpointsConfig.bpMED.min ) {
+      it( 'should say "Show" on medium/large screens',
+        function() {
+          expect( page.searchFilterShowBtn.getText() ).toBe( 'Show' );
+        }
+      );
+    }
 
     it( 'should include a visible Hide button when clicked', function() {
       var expectedConditions = protractor.ExpectedConditions;
@@ -86,7 +97,6 @@ describe( 'The Leadership Calendar Page', function() {
 
     it( 'should include a visible Show button', function() {
       expect( page.downloadFilterShowBtn.isDisplayed() ).toBe( true );
-      expect( page.downloadFilterShowBtn.getText() ).toBe( 'Show' );
     } );
 
     it( 'should include a visible Hide button when clicked', function() {

--- a/test/browser_tests/spec_suites/newsroom.js
+++ b/test/browser_tests/spec_suites/newsroom.js
@@ -4,6 +4,10 @@ var Newsroom = require(
     '../page_objects/page_newsroom.js'
   );
 
+var BASE_JS_PATH = '../../../cfgov/unprocessed/js/';
+
+var breakpointsConfig = require( BASE_JS_PATH + 'config/breakpoints-config' );
+
 describe( 'The Newsroom Page', function() {
   var page;
 
@@ -85,8 +89,15 @@ describe( 'The Newsroom Page', function() {
 
   it( 'should include a visible Show button', function() {
     expect( page.searchFilterShowBtn.isDisplayed() ).toBe( true );
-    expect( page.searchFilterShowBtn.getText() ).toBe( 'Show' );
   } );
+
+  if ( browser.params.windowWidth > breakpointsConfig.bpMED.min ) {
+    it( 'should say "Show" on medium/large screens',
+      function() {
+        expect( page.searchFilterShowBtn.getText() ).toBe( 'Show' );
+      }
+    );
+  }
 
   it( 'should include a hidden Hide button', function() {
     expect( page.searchFilterHideBtn.isDisplayed() ).toBe( false );

--- a/test/browser_tests/spec_suites/organisms/mega-menu.js
+++ b/test/browser_tests/spec_suites/organisms/mega-menu.js
@@ -6,27 +6,33 @@ var breakpointsConfig = require( BASE_JS_PATH + 'config/breakpoints-config' );
 
 describe( 'MegaMenu', function() {
   var BASE_SEL = '.o-mega-menu';
+  var TRIGGER_BTN = '.o-mega-menu_trigger';
+  var CONTENT_WRAPPER = '.o-mega-menu_content';
+  var EYEBROW = '.m-global-eyebrow_tagline';
   var TRIGGER_1_SEL = BASE_SEL + '_content-1-link';
   var CONTENT_2_SEL = BASE_SEL + '_content-2';
 
   var _dom;
 
+  beforeAll( function() {
+    _dom = {
+      triggerBtn:     element( by.css( TRIGGER_BTN ) ),
+      contentWrapper: element( by.css( CONTENT_WRAPPER ) ),
+      eyebrow:        element( by.css( EYEBROW ) ),
+      triggerPolyCom: element.all( by.css( TRIGGER_1_SEL ) ).get( 3 ),
+      triggerAboutUs: element.all( by.css( TRIGGER_1_SEL ) ).get( 4 ),
+      contentPolyCom: element.all( by.css( CONTENT_2_SEL ) ).get( 3 ),
+      contentAboutUs: element.all( by.css( CONTENT_2_SEL ) ).get( 4 )
+    };
+  } );
+
+  beforeEach( function() {
+    browser.get( '/' );
+  } );
+
   // Check large size.
   if ( browser.params.windowWidth > breakpointsConfig.bpLG.min ) {
     describe( 'large size', function() {
-
-      beforeAll( function() {
-        _dom = {
-          triggerPolyCom: element.all( by.css( TRIGGER_1_SEL ) ).get( 3 ),
-          triggerAboutUs: element.all( by.css( TRIGGER_1_SEL ) ).get( 4 ),
-          contentPolyCom: element.all( by.css( CONTENT_2_SEL ) ).get( 3 ),
-          contentAboutUs: element.all( by.css( CONTENT_2_SEL ) ).get( 4 )
-        };
-      } );
-
-      beforeEach( function() {
-        browser.get( '/' );
-      } );
 
       describe( 'at page load', function() {
         it( 'should NOT show content', function() {
@@ -80,11 +86,37 @@ describe( 'MegaMenu', function() {
             } );
         } );
       } );
+    } );
+  } else if ( browser.params.windowWidth < breakpointsConfig.bpSM.max ) {
 
-      // TODO: Add test for:
-      //       - Moving over and off the menu.
-      //       - Clicking the menu link.
-      //       - Tabbing over the menu.
+    describe( 'mobile size', function() {
+      it( 'should show menu when clicked', function() {
+        browser.driver.actions().click( _dom.triggerBtn ).perform()
+          .then( function() {
+            expect( _dom.contentWrapper.isDisplayed() ).toBe( true );
+          } );
+      } );
+
+      it( 'should show the PolyCom menu when clicked', function() {
+        browser.driver.actions().click( _dom.triggerBtn ).perform();
+        browser.sleep( 500 );
+        browser.driver.actions().click( _dom.triggerPolyCom ).perform()
+          .then( function() {
+            expect( _dom.contentPolyCom.isDisplayed() ).toBe( true );
+            expect( _dom.contentAboutUs.isDisplayed() ).toBe( false );
+          } );
+      } );
+
+      // This test is failing right now, but should pass
+      // when we fix keyboard tabbing on mobile
+      xit( 'should not shift menus when tabbing', function() {
+        browser.driver.actions().click( _dom.triggerBtn ).perform();
+        browser.driver.actions().sendKeys( protractor.Key.TAB ).perform();
+        browser.driver.actions().sendKeys( protractor.Key.TAB ).perform();
+        browser.driver.actions().sendKeys( protractor.Key.TAB ).perform();
+        browser.driver.actions().sendKeys( protractor.Key.TAB ).perform();
+        expect( _dom.eyebrow.isDisplayed() ).toBe( true );
+      } );
     } );
   }
 } );


### PR DESCRIPTION
This updates failing tests at the small breakpoint for filters and adds
tests for the mega menu at small breakpoints. 

Finishes up with a failing test for keyboard tabbing on mobile. Ideally,
tabbing should trap focus on a menu until something is selected.

## Testing 

`gulp test:acceptance --sauce=false --windowSize=400,610`


## Review

- @jimmynotjim 


## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
