### PR TITLE
Adding mobile tests for the header

### DIFF
--- a/cfgov/unprocessed/css/misc.less
+++ b/cfgov/unprocessed/css/misc.less
@@ -665,7 +665,7 @@
     - "Adds transitions utilty classes for transform, opacity,
        and for the removing the transition duration."
     - "`.u-move-transition__disabled` is used for disabling tests
-        in protractor tess"
+        in protractor tests"
   tags:
     - cfgov-misc
 */
@@ -681,8 +681,11 @@
     transition-duration: 0s;
 }
 
-.u-move-transition__disabled * {
-  transition: none !important;
+// The mega-menu code doesn't work with a transition of 0ms
+.u-move-transition__disabled {
+  .u-move-transition {
+    transition: transform 1ms ease;
+  }
 }
 
 /* topdoc

--- a/cfgov/unprocessed/css/misc.less
+++ b/cfgov/unprocessed/css/misc.less
@@ -664,6 +664,8 @@
   notes:
     - "Adds transitions utilty classes for transform, opacity,
        and for the removing the transition duration."
+    - "`.u-move-transition__disabled` is used for disabling tests
+        in protractor tess"
   tags:
     - cfgov-misc
 */
@@ -677,6 +679,10 @@
 
 .u-no-animation {
     transition-duration: 0s;
+}
+
+.u-move-transition__disabled * {
+  transition: none !important;
 }
 
 /* topdoc

--- a/test/browser_tests/spec_suites/organisms/header.js
+++ b/test/browser_tests/spec_suites/organisms/header.js
@@ -136,7 +136,7 @@ describe( 'Header', function() {
         } );
 
         describe( 'then click search', function() {
-          it( 'should show the search and hide menu', function() {
+          it( 'should show the search and hide megamenu', function() {
             browser.driver.actions().click( _dom.megaMenuTrigger ).perform();
             browser.driver.actions().click( _dom.globalSearchTrigger ).perform();
             browser.driver.wait( _dom.globalSearchContent.getAttribute( 'aria-expanded' ) )
@@ -157,12 +157,8 @@ describe( 'Header', function() {
                 expect( _dom.globalSearchContent.getAttribute( 'aria-expanded' ) ).toBe( 'false' );
                 return isTrue == 'true'
               } );
-
         } );
       } );
-
     } );
   }
 } );
-
-//expect( _dom.globalSearch.getAttribute('aria-expanded') ).toBe( true );

--- a/test/browser_tests/spec_suites/organisms/header.js
+++ b/test/browser_tests/spec_suites/organisms/header.js
@@ -43,6 +43,7 @@ describe( 'Header', function() {
 
   beforeEach( function() {
     browser.get( '/' );
+    browser.executeScript('document.body.className = "u-move-transition__disabled";');
   } );
 
   if ( browser.params.windowWidth > breakpointsConfig.bpLG.min ) {
@@ -139,11 +140,7 @@ describe( 'Header', function() {
           it( 'should show the search and hide megamenu', function() {
             browser.driver.actions().click( _dom.megaMenuTrigger ).perform();
             browser.driver.actions().click( _dom.globalSearchTrigger ).perform();
-            browser.driver.wait( _dom.globalSearchContent.getAttribute( 'aria-expanded' ) )
-              .then( function( isTrue ) {
-                expect( _dom.megaMenuContent.getAttribute( 'aria-expanded' ) ).toBe( 'false' );
-                return isTrue == 'true'
-              } );
+            expect( _dom.megaMenuContent.getAttribute( 'aria-expanded' ) ).toBe( 'false' );
           } );
         } );
       } );
@@ -152,11 +149,7 @@ describe( 'Header', function() {
         it( 'should show the megamenu and hide search', function() {
           browser.driver.actions().click( _dom.globalSearchTrigger ).perform();
           browser.driver.actions().click( _dom.megaMenuTrigger ).perform()
-          browser.driver.wait( _dom.megaMenuContent.getAttribute( 'aria-expanded' ) )
-              .then( function( isTrue ) {
-                expect( _dom.globalSearchContent.getAttribute( 'aria-expanded' ) ).toBe( 'false' );
-                return isTrue == 'true'
-              } );
+          expect( _dom.globalSearchContent.getAttribute( 'aria-expanded' ) ).toBe( 'false' );
         } );
       } );
     } );

--- a/test/browser_tests/spec_suites/organisms/header.js
+++ b/test/browser_tests/spec_suites/organisms/header.js
@@ -81,8 +81,7 @@ describe( 'Header', function() {
         } );
       } );
     } );
-  } else if ( browser.params.windowWidth > breakpointsConfig.bpSM.min &&
-              browser.params.windowWidth < breakpointsConfig.bpSM.max ) {
+  } else if ( browser.params.windowWidth < breakpointsConfig.bpSM.max ) {
     describe( 'small size', function() {
       describe( 'at page load', function() {
         it( 'should display Header', function() {
@@ -135,11 +134,31 @@ describe( 'Header', function() {
               expect( _dom.overlay.isDisplayed() ).toBe( true );
             } );
         } );
+
+        describe( 'then click search', function() {
+          it( 'should show the search and hide menu', function() {
+            browser.driver.actions().click( _dom.megaMenuTrigger ).perform();
+            browser.driver.wait( _dom.megaMenuContent.isDisplayed() );
+            browser.driver.actions().click( _dom.globalSearchTrigger ).perform()
+              .then( function() {
+                expect( _dom.globalSearch.isDisplayed() ).toBe( true );
+
+              } );
+          } );
+        } );
       } );
 
-      // TODO: Add tests for clicking between menu and search.
-      // describe( 'click search when mega menu is showing', function() {} );
-      // describe( 'click mega menu when search is showing', function() {} );
+      describe( 'click search, then click mega menu', function() {
+        it( 'should show the megamenu and hide search', function() {
+          browser.driver.actions().click( _dom.globalSearchTrigger ).perform();
+          browser.driver.wait( _dom.megaMenuContent.isDisplayed() );
+          browser.driver.actions().click( _dom.megaMenuTrigger ).perform()
+            .then( function() {
+              expect( _dom.megaMenuContent.isDisplayed() ).toBe( true );
+            } );
+        } );
+      } );
+
     } );
   }
 } );

--- a/test/browser_tests/spec_suites/organisms/header.js
+++ b/test/browser_tests/spec_suites/organisms/header.js
@@ -138,11 +138,11 @@ describe( 'Header', function() {
         describe( 'then click search', function() {
           it( 'should show the search and hide menu', function() {
             browser.driver.actions().click( _dom.megaMenuTrigger ).perform();
-            browser.driver.wait( _dom.megaMenuContent.isDisplayed() );
-            browser.driver.actions().click( _dom.globalSearchTrigger ).perform()
-              .then( function() {
-                expect( _dom.globalSearch.isDisplayed() ).toBe( true );
-
+            browser.driver.actions().click( _dom.globalSearchTrigger ).perform();
+            browser.driver.wait( _dom.globalSearchContent.getAttribute( 'aria-expanded' ) )
+              .then( function( isTrue ) {
+                expect( _dom.megaMenuContent.getAttribute( 'aria-expanded' ) ).toBe( 'false' );
+                return isTrue == 'true'
               } );
           } );
         } );
@@ -151,14 +151,18 @@ describe( 'Header', function() {
       describe( 'click search, then click mega menu', function() {
         it( 'should show the megamenu and hide search', function() {
           browser.driver.actions().click( _dom.globalSearchTrigger ).perform();
-          browser.driver.wait( _dom.megaMenuContent.isDisplayed() );
           browser.driver.actions().click( _dom.megaMenuTrigger ).perform()
-            .then( function() {
-              expect( _dom.megaMenuContent.isDisplayed() ).toBe( true );
-            } );
+          browser.driver.wait( _dom.megaMenuContent.getAttribute( 'aria-expanded' ) )
+              .then( function( isTrue ) {
+                expect( _dom.globalSearchContent.getAttribute( 'aria-expanded' ) ).toBe( 'false' );
+                return isTrue == 'true'
+              } );
+
         } );
       } );
 
     } );
   }
 } );
+
+//expect( _dom.globalSearch.getAttribute('aria-expanded') ).toBe( true );

--- a/test/browser_tests/spec_suites/organisms/header.js
+++ b/test/browser_tests/spec_suites/organisms/header.js
@@ -47,7 +47,7 @@ describe( 'Header', function() {
   } );
 
   if ( browser.params.windowWidth > breakpointsConfig.bpLG.min ) {
-    describe( 'large size', function() {
+    describe( '(desktop)', function() {
       describe( 'at page load', function() {
         it( 'should display Header', function() {
           expect( _dom.header.isDisplayed() ).toBe( true );
@@ -83,7 +83,7 @@ describe( 'Header', function() {
       } );
     } );
   } else if ( browser.params.windowWidth < breakpointsConfig.bpSM.max ) {
-    describe( 'small size', function() {
+    describe( '(mobile):', function() {
       describe( 'at page load', function() {
         it( 'should display Header', function() {
           expect( _dom.header.isDisplayed() ).toBe( true );
@@ -110,10 +110,8 @@ describe( 'Header', function() {
         } );
 
         it( 'should display small Global Header CTA', function() {
-          browser.driver.actions().click( _dom.megaMenuTrigger ).perform()
-            .then( function() {
-              expect( _dom.globalHeaderCtaSM.isDisplayed() ).toBe( true );
-            } );
+          browser.driver.actions().click( _dom.megaMenuTrigger ).perform();
+          expect( _dom.globalHeaderCtaSM.isDisplayed() ).toBe( true );
         } );
 
         it( 'should NOT display large Global Eyebrow', function() {
@@ -121,35 +119,42 @@ describe( 'Header', function() {
         } );
 
         it( 'should display small Global Eyebrow', function() {
-          browser.driver.actions().click( _dom.megaMenuTrigger ).perform()
-            .then( function() {
-              expect( _dom.globalEyebrowSM.isDisplayed() ).toBe( true );
-            } );
+          browser.driver.actions().click( _dom.megaMenuTrigger ).perform();
+          expect( _dom.globalEyebrowSM.isDisplayed() ).toBe( true );
         } );
       } );
 
-      describe( 'click mega menu', function() {
-        it( 'should show the global overlay', function() {
-          browser.driver.actions().click( _dom.megaMenuTrigger ).perform()
-            .then( function() {
-              expect( _dom.overlay.isDisplayed() ).toBe( true );
-            } );
+      describe( 'if you click mega menu', function() {
+        it( 'it should show the global overlay', function() {
+          browser.driver.actions().click( _dom.megaMenuTrigger ).perform();
+          expect( _dom.overlay.isDisplayed() ).toBe( true );
         } );
 
         describe( 'then click search', function() {
-          it( 'should show the search and hide megamenu', function() {
-            browser.driver.actions().click( _dom.megaMenuTrigger ).perform();
-            browser.driver.actions().click( _dom.globalSearchTrigger ).perform();
-            expect( _dom.megaMenuContent.getAttribute( 'aria-expanded' ) ).toBe( 'false' );
+          it( 'it should show the search and hide megamenu', function() {
+            browser.driver.actions().click( _dom.megaMenuTrigger )
+              .click( _dom.globalSearchTrigger )
+              .perform();
+            expect( _dom.globalSearchContent.getAttribute( 'aria-expanded' ) )
+              .toBe( 'true' );
+            expect( _dom.megaMenuContent.getAttribute( 'aria-expanded' ) )
+              .toBe( 'false' );
           } );
         } );
       } );
 
-      describe( 'click search, then click mega menu', function() {
-        it( 'should show the megamenu and hide search', function() {
-          browser.driver.actions().click( _dom.globalSearchTrigger ).perform();
-          browser.driver.actions().click( _dom.megaMenuTrigger ).perform()
-          expect( _dom.globalSearchContent.getAttribute( 'aria-expanded' ) ).toBe( 'false' );
+      describe( 'if you click search, then click mega menu', function() {
+        it( 'it should show the mega menu and hide search', function() {
+          browser.driver.actions().click( _dom.globalSearchTrigger )
+            .click( _dom.megaMenuTrigger )
+            .perform();
+          // Since the code doesn't work when .u-move-transition__disabled is
+          // set to 0ms, we still need a quick sleep.
+          browser.sleep(2);
+          expect( _dom.megaMenuContent.getAttribute( 'aria-expanded' ) )
+            .toBe( 'true' );
+          expect( _dom.globalSearchContent.getAttribute( 'aria-expanded' ) )
+            .toBe( 'false' );
         } );
       } );
     } );


### PR DESCRIPTION
Adding some missing tests to the header to test switching between the search and mega menu.

## Testing

- `gulp test:acceptance --sauce=false --windowSize=400,610 --specs=header.js` 

## Review

- @jimmynotjim 

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)

These tests look at switching between the mega menu and search.