### PR TITLE
[WIP] resolves issue of global header exceptions related to missing request…

### DIFF
--- a/cfgov/flags/template_functions.py
+++ b/cfgov/flags/template_functions.py
@@ -8,6 +8,8 @@ from .models import Flag
 
 def flag_enabled(key):
     request = get_request()
+    if not request:
+        return False
     site = Site.find_for_request(request)
     state_for_site = site.flagstate_set.filter(flag_id=key, \
             ).first()

--- a/cfgov/sheerlike/middleware.py
+++ b/cfgov/sheerlike/middleware.py
@@ -6,7 +6,10 @@ _active = local()
 
 
 def get_request():
-    return _active.request
+    try:
+        return _active.request
+    except AttributeError:
+        return None
 
 
 class FlaskyHeaderGetter(object):


### PR DESCRIPTION
### Fixes
- resolves issue of global header exceptions related to missing request object in the active thread

i noticed this exception that we see alot in the server logs usually originates from the global header, this should resolve it. I still need to run through some tests (hence the WIP)
```
  File "/Users/apaue/workspace/f5/cfgov-refresh/cfgov/v1/templatetags/global_include.py", line 10, in global_include
    return sheerlike.global_render_template(name)
  File "/Users/apaue/workspace/f5/cfgov-refresh/cfgov/sheerlike/__init__.py", line 37, in global_render_template
    request = get_request()
  File "/Users/apaue/workspace/f5/cfgov-refresh/cfgov/sheerlike/middleware.py", line 9, in get_request
    return _active.request
AttributeError: 'thread._local' object has no attribute 'request'
```