### PR TITLE
Creates nonresponsive header script for non-v1 sections of the site

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 
 ### Added
 
+- Added nonresponsive header script for non-v1 sections of the site
+
 ### Changed
 
 ### Removed

--- a/cfgov/jinja2/v1/test-fixture/index.html
+++ b/cfgov/jinja2/v1/test-fixture/index.html
@@ -118,7 +118,7 @@
     (b) In the <head> with the `defer` and `async` attributes
         set on the <script> tag.
 #}
-<script type="text/javascript" src="{{ static('js/atomic/' + atomic_type + '.js') }}"></script>
+<script type="text/javascript" src="{{ static('js/atomic/' + atomic_type + suffix + '.js') }}"></script>
 
 </body>
 

--- a/cfgov/unprocessed/css/organisms/header.less
+++ b/cfgov/unprocessed/css/organisms/header.less
@@ -76,11 +76,15 @@
     z-index: 10;
     background-color: @white;
 
-    // Desktop size
+    // Tablet/mobile sizes.
     .respond-to-max( @bp-sm-max, {
         > .m-global-eyebrow {
             display: none;
         }
+    } );
+
+    .respond-to-min( @bp-lg-min, {
+        min-width: @bp-lg-min;
     } );
 
     &_content {

--- a/cfgov/unprocessed/js/modules/util/breakpoint-state.js
+++ b/cfgov/unprocessed/js/modules/util/breakpoint-state.js
@@ -40,5 +40,23 @@ function get( width ) {
   return breakpointState;
 }
 
+/**
+ * Whether currently in the desktop view.
+ * @returns {boolean} True if in the desktop view, otherwise false.
+ */
+function isInDesktop() {
+  var response = false;
+  var currentBreakpoint = get();
+  if ( currentBreakpoint.isBpMED ||
+       currentBreakpoint.isBpLG ||
+       currentBreakpoint.isBpXL ) {
+    response = true;
+  }
+  return response;
+}
+
 // Expose public methods.
-module.exports = { get: get };
+module.exports = {
+  get: get,
+  isInDesktop: isInDesktop
+};

--- a/cfgov/unprocessed/js/molecules/GlobalSearch.js
+++ b/cfgov/unprocessed/js/molecules/GlobalSearch.js
@@ -88,27 +88,11 @@ function GlobalSearch( element ) { // eslint-disable-line max-statements, no-inl
   function _handleBodyClick( event ) {
     var target = event.target;
 
-    var isInDesktop = _isInDesktop();
+    var isInDesktop = breakpointState.isInDesktop();
     if ( isInDesktop && !_isDesktopTarget( target ) ||
          !isInDesktop && !_isMobileTarget( target ) ) {
       collapse();
     }
-  }
-
-  // TODO: Move this to breakpoint-state.js.
-  /**
-   * Whether currently in the desktop view.
-   * @returns {boolean} True if in the desktop view, otherwise false.
-   */
-  function _isInDesktop() {
-    var isInDesktop = false;
-    var currentBreakpoint = breakpointState.get();
-    if ( currentBreakpoint.isBpMED ||
-         currentBreakpoint.isBpLG ||
-         currentBreakpoint.isBpXL ) {
-      isInDesktop = true;
-    }
-    return isInDesktop;
   }
 
   /**

--- a/cfgov/unprocessed/js/organisms/MegaMenu.js
+++ b/cfgov/unprocessed/js/organisms/MegaMenu.js
@@ -83,7 +83,7 @@ function MegaMenu( element ) {
       window.addEventListener( 'orientationchange', _resizeHandler );
     }
 
-    if ( _isInDesktop() ) {
+    if ( breakpointState.isInDesktop() ) {
       _desktopNav.resume();
     } else {
       _mobileNav.resume();
@@ -159,7 +159,7 @@ function MegaMenu( element ) {
    * @param {Object} event - A FlyoutMenu event object.
    */
   function _handleEvent( event ) {
-    var activeNav = _isInDesktop() ? _desktopNav : _mobileNav;
+    var activeNav = breakpointState.isInDesktop() ? _desktopNav : _mobileNav;
     activeNav.handleEvent( event );
   }
 
@@ -168,29 +168,13 @@ function MegaMenu( element ) {
    * suspends or resumes the mobile or desktop menu behaviors.
    */
   function _resizeHandler() {
-    if ( _isInDesktop() ) {
+    if ( breakpointState.isInDesktop() ) {
       _mobileNav.suspend();
       _desktopNav.resume();
     } else {
       _desktopNav.suspend();
       _mobileNav.resume();
     }
-  }
-
-  // TODO: Move this to breakpoint-state.js.
-  /**
-   * Whether currently in the desktop view.
-   * @returns {boolean} True if in the desktop view, otherwise false.
-   */
-  function _isInDesktop() {
-    var isInDesktop = false;
-    var currentBreakpoint = breakpointState.get();
-    if ( currentBreakpoint.isBpMED ||
-         currentBreakpoint.isBpLG ||
-         currentBreakpoint.isBpXL ) {
-      isInDesktop = true;
-    }
-    return isInDesktop;
   }
 
   /**
@@ -209,7 +193,7 @@ function MegaMenu( element ) {
    * @returns {MegaMenu} An instance.
    */
   function collapse() {
-    if ( !_isInDesktop() ) {
+    if ( !breakpointState.isInDesktop() ) {
       _mobileNav.collapse();
     }
 

--- a/config/webpack-config.js
+++ b/config/webpack-config.js
@@ -66,8 +66,19 @@ var onDemandConf = {
   ]
 };
 
+var onDemandHeaderRawConf = {
+  context: path.join( __dirname, '/../', paths.unprocessed,
+                      JS_ROUTES_PATH + '/on-demand' ),
+  entry:   './header.js',
+  output: {
+    path:     path.join( __dirname, 'js' ),
+    filename: '[name]'
+  }
+};
+
 module.exports = {
-  onDemandConf: onDemandConf,
-  ieConf:       ieConf,
-  modernConf:   modernConf
+  onDemandHeaderRawConf: onDemandHeaderRawConf,
+  onDemandConf:          onDemandConf,
+  ieConf:                ieConf,
+  modernConf:            modernConf
 };

--- a/gulp/tasks/scripts.js
+++ b/gulp/tasks/scripts.js
@@ -11,6 +11,7 @@ var browserSync = require( 'browser-sync' );
 var gulp = require( 'gulp' );
 var gulpModernizr = require( 'gulp-modernizr' );
 var gulpRename = require( 'gulp-rename' );
+var gulpReplace = require( 'gulp-replace' );
 var gulpUglify = require( 'gulp-uglify' );
 var handleErrors = require( '../utils/handle-errors' );
 var paths = require( '../../config/environment' ).paths;
@@ -85,6 +86,25 @@ function scriptsOnDemand() {
 }
 
 /**
+ * Bundle atomic component scripts for non-responsive pages.
+ * Provides a means to bundle JS for specific atomic components,
+ * which then can be carried over to other projects.
+ * @returns {PassThrough} A source stream.
+ */
+function scriptsNonResponsive() {
+  return gulp.src( paths.unprocessed + '/js/routes/on-demand/header.js' )
+    .pipe( webpackStream( webpackConfig.onDemandHeaderRawConf ) )
+    .on( 'error', handleErrors )
+    .pipe( gulpRename( 'header.nonresponsive.js' ) )
+    .pipe( gulpReplace( 'breakpointState.isInDesktop()', 'true' ) )
+    .pipe( gulpUglify() )
+    .pipe( gulp.dest( paths.processed + '/js/atomic/' ) )
+    .pipe( browserSync.reload( {
+      stream: true
+    } ) );
+}
+
+/**
  * Bundle Es5 shim scripts.
  * @returns {PassThrough} A source stream.
  */
@@ -107,7 +127,12 @@ function scriptsEs5Shim() {
 gulp.task( 'scripts:polyfill', scriptsPolyfill );
 gulp.task( 'scripts:modern', scriptsModern );
 gulp.task( 'scripts:ie', scriptsIE );
-gulp.task( 'scripts:ondemand', scriptsOnDemand );
+gulp.task( 'scripts:ondemand:base', scriptsOnDemand );
+gulp.task( 'scripts:ondemand:nonresponsive', scriptsNonResponsive );
+gulp.task( 'scripts:ondemand', [
+  'scripts:ondemand:base',
+  'scripts:ondemand:nonresponsive'
+] );
 gulp.task( 'scripts:es5-shim', scriptsEs5Shim );
 
 gulp.task( 'scripts', [


### PR DESCRIPTION
PR #2160 only addressed non-responsive styles, leading to incorrect behavior at smaller screens on the non-responsive test fixture. Added a gulp task to create a nonresponsive script that rewrites `isInDesktop` to always return true.

## Additions

- Added gulp task for nonresponsive scripts
- Added webpack config for nonresponsive gulp task

## Changes

- Moved `isInDesktop` to breakpoint state file to resolve TODOs

## Testing

- `gulp scripts:ondemand && gulp styles:ondemand`
- navigate to `http://localhost:8000/test-fixture/?atomic=header&suffix=nonresponsive` 

## Review

- @KimberlyMunoz 
- @anselmbradford 
- @rosskarchner 

## Screenshots

<img width="736" alt="screen shot 2016-06-07 at 8 49 22 am" src="https://cloud.githubusercontent.com/assets/1280430/15859947/c16f5dee-2c8c-11e6-89ac-4f781660d6b6.png">

# Notes

- We should wait for #2164 & #2166 to be merged to make sure this PR doesn't break the existing functionality

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)