### PR TITLE
Change page.media to use OrderedDict

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Updated the test fixture for ondemand includes to allow for the nonresponsive stylesheet to be loaded for visual testing.
 - Promotes Expandables from molecule to organism
 - Changes global banner expandable Less to resolve cascade issue
+- Maintain order and uniqueness in JS file lists by using `OrderedDict` instead of `set`
 
 ### Removed
 - Event RSVP email link button.

--- a/cfgov/v1/models/base.py
+++ b/cfgov/v1/models/base.py
@@ -337,7 +337,7 @@ class CFGOVPage(Page):
         self.add_page_js(js)
         self._add_streamfield_js(js)
         for key, js_files in js.iteritems():
-            js[key] = list(set(js_files))
+            js[key] = OrderedDict.fromkeys(js_files).keys()
         return js
 
 


### PR DESCRIPTION
`set` makes the JS files list from the unique but since it is unordered it can interfere with the JS instantiation. This uses OrderedDict (since python has no built-in implementation of something like OrderedSet) to get both order and uniqueness.

## Changes

- OrderedDict replaces set in use of maintaining uniqueness and order.

## Testing

- Add ExpandableGroup to a page and test its functionality.

## Review

- @Scotchester 

