### PR TITLE
Fix feeds

### DIFF
--- a/cfgov/v1/feeds.py
+++ b/cfgov/v1/feeds.py
@@ -24,7 +24,8 @@ class FilterableFeed(Feed):
         return "%s | Consumer Financial Protection Bureau" % self.page.title
 
     def items(self):
-        return self.context['posts']
+        posts = self.context['filter_data']['page_sets'].pop(0)
+        return posts
 
     def item_link(self, item):
         return item.full_url


### PR DESCRIPTION
The changes in 28cd667cf70578134af8d4b6b9330b2c0f7d2270 alter the way the contents of a filterable are exposed to the template. feeds.py wasn't updated to account for the change, thus feeds are broken

## Changes

- updates feeds.py to use the new method for getting at the filtered list of content

## Testing

-  Make sure http://localhost:8000/about-us/blog/feed returns the content (as opposed to a 500 error)

## Review

- @kurtw @richaagarwal @kave 

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)

