### PR TITLE
Login Page Reduction Act

### DIFF
--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -16,6 +16,7 @@ SECRET_KEY = os.environ.get('SECRET_KEY', os.urandom(32))
 # Use the django default password hashing
 PASSWORD_HASHERS = global_settings.PASSWORD_HASHERS
 
+
 try:
     import mysql
     MYSQL_ENGINE = 'mysql.connector.django'
@@ -399,8 +400,8 @@ CFPB_COMMON_PASSWORD_RULES = [
 LOGIN_FAIL_TIME_PERIOD = os.environ.get('LOGIN_FAIL_TIME_PERIOD', 120 * 60)
 # number of failed attempts
 LOGIN_FAILS_ALLOWED = os.environ.get('LOGIN_FAILS_ALLOWED', 5)
-LOGIN_REDIRECT_URL='/admin/'
-LOGIN_URL = "/admin/login/"
+LOGIN_REDIRECT_URL='/login/welcome/'
+LOGIN_URL = "/login/"
 
 
 SHEER_SITES = {

--- a/cfgov/cfgov/urls.py
+++ b/cfgov/cfgov/urls.py
@@ -10,8 +10,11 @@ from legacy.views import HousingCounselorPDFView, dbrouter_shortcut, token_provi
 from sheerlike.views.generic import SheerTemplateView
 from sheerlike.sites import SheerSite
 
-from v1.views import LeadershipCalendarPDFView, unshare, change_password, cfpb_login, password_reset_confirm
-from v1.auth_forms import CFGOVSetPasswordForm, CFGOVPasswordChangeForm
+from v1.views import LeadershipCalendarPDFView, unshare, change_password, \
+                     password_reset_confirm, login_with_lockout,\
+                     check_permissions, welcome
+from v1.auth_forms import CFGOVPasswordChangeForm
+
 from wagtail.wagtailadmin import urls as wagtailadmin_urls
 from wagtail.wagtaildocs import urls as wagtaildocs_urls
 from wagtail.wagtailcore import urls as wagtail_urls
@@ -232,8 +235,18 @@ urlpatterns = [
 
 if settings.ALLOW_ADMIN_URL:
     patterns = [
+        url(r'^login/$', login_with_lockout, name='cfpb_login'),
+        url(r'^login/check_permissions/$', check_permissions, name='check_permissions'),
+        url(r'^login/welcome/$', welcome, name='welcome'),
+        url('admin/login/$', RedirectView.as_view(url='/login/', permanent=True, query_string=True)),
+        url('django-admin/login/$', RedirectView.as_view(url='/login/', permanent=True, query_string=True)),
+
         url(r'^d/admin/(?P<path>.*)$', RedirectView.as_view(url='/django-admin/%(path)s',permanent=True)),
         url(r'^picard/(?P<path>.*)$', RedirectView.as_view(url='/tasks/%(path)s',permanent=True)),
+        url(r'^django-admin/password_change', change_password, name='django_admin_account_change_password'),
+        url(r'^django-admin/', include(admin.site.urls)),
+        url(r'^admin/pages/(\d+)/unshare/$', unshare, name='unshare'),
+
         # - Override Django and Wagtail password views with our password policy - #
         url(r'^admin/password_reset/', include([
             url(
@@ -247,8 +260,6 @@ if settings.ALLOW_ADMIN_URL:
             auth_views.password_change_done,
             name='password_change_done'),
         url(r'^admin/account/change_password/$', change_password, name='wagtailadmin_account_change_password'),
-        url(r'^django-admin/login', cfpb_login, name='django_admin_login'),
-        url(r'^admin/login/$', cfpb_login, name='wagtailadmin_login'),
         url(r'^django-admin/', include(admin.site.urls)),
         url(r'^admin/', include(wagtailadmin_urls)),
         url(r'^admin/pages/(\d+)/unshare/$', unshare, name='unshare'),

--- a/cfgov/cfgov/urls.py
+++ b/cfgov/cfgov/urls.py
@@ -238,6 +238,7 @@ if settings.ALLOW_ADMIN_URL:
         url(r'^login/$', login_with_lockout, name='cfpb_login'),
         url(r'^login/check_permissions/$', check_permissions, name='check_permissions'),
         url(r'^login/welcome/$', welcome, name='welcome'),
+        url(r'^logout/$', auth_views.logout),
         url('admin/login/$', RedirectView.as_view(url='/login/', permanent=True, query_string=True)),
         url('django-admin/login/$', RedirectView.as_view(url='/login/', permanent=True, query_string=True)),
 

--- a/cfgov/templates/registration/logged_out.html
+++ b/cfgov/templates/registration/logged_out.html
@@ -1,0 +1,10 @@
+{% overextends "wagtailadmin/login.html" %}
+{% load i18n admin_static %}
+
+{% block furniture %}
+    <div class="content-wrapper">
+        <h1>You've logged out of the consumerfinance.gov editorial tools.	
+        </h1>
+        <h2><a href="/login/">log back in</a></h2>
+    </div>
+{% endblock %}

--- a/cfgov/templates/wagtailadmin/login.html
+++ b/cfgov/templates/wagtailadmin/login.html
@@ -3,14 +3,6 @@
 
 {% block furniture %}
     <div class="content-wrapper">
-        <div style="float:right">
-        {% if '/django-admin/' in request.path %}
-            <h2><a href="/admin/">Log into Wagtail Admin</a></h2>
-        {% else %}
-            <h2><a href="/django-admin/">Log into Django Admin</a></h2>
-        {% endif %}
-        </div>
-
         {% if messages  or form.non_field_errors %}
             <div class="messages">
                 <ul>
@@ -24,21 +16,13 @@
             </div>
         {% endif %}
 
-        <form action="{% url 'wagtailadmin_login' %}" method="post" autocomplete="off">
+        <h1>Log in to consumerfinance.gov</h1>
+        <form action="{% url 'cfpb_login' %}" method="post" autocomplete="off">
             {% csrf_token %}
 
-            {% url 'wagtailadmin_home' as home_url %}
+            {% url 'user_welcome' as home_url %}
             <input type="hidden" name="next" value="{{ next|default:home_url }}" />
 
-            {% block branding_login %}
-            <h1>
-            {% if '/django-admin/' in request.path %}
-                {% trans "Sign in to consumerfinance.gov" %}
-            {% else %}
-                <img class="wagtail-logo" src="{% static 'wagtailadmin/images/wagtail-logo.svg' %}" alt="Wagtail" width="30" /> {% trans "Sign in to consumerfinance.gov" %}
-            {% endif %}
-            </h1>
-            {% endblock %}
 
             <ul class="fields">
                 <li class="full">

--- a/cfgov/templates/welcome.html
+++ b/cfgov/templates/welcome.html
@@ -1,13 +1,12 @@
 {% overextends "wagtailadmin/login.html" %}
 {% load i18n admin_static %}
 
-
 {% block furniture %}
     <div class="content-wrapper">
-        <h1>{% trans 'Sorry!' %} <br/>
-        	{% trans 'You do not have permission to access this page.' %}
+        <h1>{% trans 'Welcome' %} <br/>
+        You've logged in to the consumerfinance.gov editorial tools.	
         </h1>
-        <h2>Perhaps you could try:</h2>
+        <h2>Continue on to...</h2>
         <ul>
         {% for name, url in destinations %}
             <li><a href="{{url}}"> {{name}}</a></li>

--- a/cfgov/templates/welcome.html
+++ b/cfgov/templates/welcome.html
@@ -12,6 +12,5 @@
             <li><a href="{{url}}"> {{name}}</a></li>
         {% endfor %}
         </ul>
-        <p>{% trans 'Otherwise, you may want to' %} <a href="/logout/">{% trans 'LOG OUT ' %}</a></p>
     </div>
 {% endblock %}

--- a/cfgov/v1/auth_forms.py
+++ b/cfgov/v1/auth_forms.py
@@ -9,6 +9,7 @@ from django.contrib.auth import get_user_model
 from django.utils import timezone
 from django.conf import settings
 from django.core.exceptions import ValidationError, ObjectDoesNotExist
+from django.contrib.auth.forms import AuthenticationForm
 
 from wagtail.wagtailadmin import forms as wagtail_adminforms
 from wagtail.wagtailusers.forms import UserCreationForm, UserEditForm
@@ -48,7 +49,7 @@ class CFGOVSetPasswordForm(PasswordValidationMixin, SetPasswordForm):
     pass
 
 
-class LoginForm(wagtail_adminforms.LoginForm):
+class LoginForm(AuthenticationForm):
 
     def clean(self):
         username = self.cleaned_data.get('username')

--- a/cfgov/v1/util/util.py
+++ b/cfgov/v1/util/util.py
@@ -2,6 +2,9 @@ import collections, json, os, re
 from itertools import chain
 from time import time
 from django.conf import settings
+from django.http import Http404, HttpResponseRedirect
+from django.contrib.auth import REDIRECT_FIELD_NAME
+from django.core.urlresolvers import resolve
 from wagtail.wagtailcore.blocks.stream_block import StreamValue
 from wagtail.wagtailcore.blocks.struct_block import StructValue
 from ref import related_posts_categories
@@ -128,3 +131,28 @@ def get_appropriate_page_version(request, page):
         else:
             if page_version['shared']:
                 return revision.as_page_object()
+
+def valid_destination_for_request(request, url):
+
+    view, args, kwargs = resolve(url)
+    kwargs['request'] = request
+    try:
+        response = view(*args, **kwargs)
+    except (Http404, TypeError):
+        return False
+
+    if isinstance(response, HttpResponseRedirect):
+        # this indicates a permissions problem
+        # (there may be a better way)
+        if REDIRECT_FIELD_NAME + '=' in response.url:
+            return False
+
+    return True
+
+
+def all_valid_destinations_for_request(request):
+    possible_destinations = (('Wagtail','/admin/'), ('Django admin', '/django-admin/'))
+    valid_destinations = [pair for pair in possible_destinations if 
+                            valid_destination_for_request(request, pair[1])]
+
+    return valid_destinations 

--- a/cfgov/v1/views.py
+++ b/cfgov/v1/views.py
@@ -6,7 +6,7 @@ from wagtail.wagtailadmin import messages as wagtail_messages
 from django.utils.translation import ugettext as _
 from django.core.urlresolvers import reverse
 from django.conf import settings
-from django.http import HttpResponse
+from django.http import HttpResponse, Http404
 
 from django.contrib.auth import get_user_model
 from django.contrib import messages
@@ -23,6 +23,7 @@ from django.views.decorators.debug import sensitive_post_parameters
 from django.utils.encoding import force_text
 from django.utils.http import is_safe_url, urlsafe_base64_decode
 from django.template.response import TemplateResponse
+from django.core.urlresolvers import resolve
 
 from wagtail.wagtailadmin.views import account
 from wagtail.wagtailusers.views.users import add_user_perm, change_user_perm
@@ -30,6 +31,8 @@ from wagtail.wagtailadmin.utils import permission_required
 
 from .auth_forms import CFGOVSetPasswordForm, CFGOVPasswordChangeForm, LoginForm
 
+from .util.util import valid_destination_for_request,\
+                       all_valid_destinations_for_request
 from .signals import page_unshared
 
 class LeadershipCalendarPDFView(PDFGeneratorView):
@@ -122,18 +125,6 @@ def change_password(request):
     })
 
 
-@sensitive_post_parameters()
-@never_cache
-def cfpb_login(request):
-    if request.user.is_authenticated():
-        if request.user.has_perm('wagtailadmin.access_admin'):
-            return redirect('wagtailadmin_home')
-        else:
-            return render(request, "wagtailadmin/access_denied.html")
-
-    else:
-        return login_with_lockout(request)
-
 
 @sensitive_post_parameters()
 @csrf_protect
@@ -166,8 +157,10 @@ def login_with_lockout(request, template_name='wagtailadmin/login.html'):
 
             login(request, form.get_user())
 
-            return HttpResponseRedirect(redirect_to)
+            return HttpResponseRedirect('/login/check_permissions/?next=' + redirect_to)
     else:
+	if request.user.is_authenticated():
+            return HttpResponseRedirect('/login/check_permissions/?next=' + redirect_to)
         form = LoginForm(request)
 
     current_site = get_current_site(request)
@@ -184,6 +177,31 @@ def login_with_lockout(request, template_name='wagtailadmin/login.html'):
 
     return TemplateResponse(request, template_name, context)
 
+
+@never_cache
+def check_permissions(request):
+    redirect_to = request.POST.get(REDIRECT_FIELD_NAME,
+                                   request.GET.get(REDIRECT_FIELD_NAME, ''))
+
+    if not request.user.is_authenticated():
+       return HttpResponseRedirect("%s?%s=%s" % (settings.LOGIN_URL,
+          REDIRECT_FIELD_NAME, redirect_to))
+    view, args, kwargs = resolve(redirect_to)
+    kwargs['request'] = request
+    try:
+        response = view(*args, **kwargs)
+    except (Http404, TypeError):
+        return HttpResponseRedirect(settings.LOGIN_REDIRECT_URL)
+
+    if isinstance(response, HttpResponseRedirect):
+        # this indicates a permissions problem
+        # (there may be a better way)
+        if REDIRECT_FIELD_NAME + '=' in response.url:
+            return render(request, "wagtailadmin/access_denied.html",
+            context= {'attempted_to_reach': redirect_to,
+                      'destinations': all_valid_destinations_for_request(request)})
+
+    return HttpResponseRedirect(redirect_to)
 
 
 @sensitive_post_parameters()
@@ -231,6 +249,18 @@ def custom_password_reset_confirm(request, uidb64=None, token=None,
 
     return TemplateResponse(request, template_name, context)
 
+@never_cache
+@login_required
+def welcome(request):
+    valid_destinations = all_valid_destinations_for_request(request)
+
+    
+    if len(valid_destinations) == 1:
+        redirect_to = valid_destinations[0][1]
+        return HttpResponseRedirect(redirect_to)
+
+    else:
+        return render(request, 'welcome.html', {'destinations': valid_destinations})
 
 password_reset_confirm = account._wrap_password_reset_view(custom_password_reset_confirm)
 


### PR DESCRIPTION
This gives us a single page for all logins, removing the need for us (and users!) to keep /admin/login and /django-admin/login straight.

Also:
- provides an intermediary view that sniffs the permissions of the page
you are trying to reach. If you don't have appropriate permissions, then you can
navigate to a page you DO have permissions for (Django admin or wagtail)
- If you log in without requesting a specific page, and you have access to
both Django admin and wagtail, you're presented with a page providing both options
- If you log in without requesting a specific page, and you have access to
ONLY ONE of django admin or wagtail, you're redirected to the one you can
access.

## Testing

- Create a user with ONLY wagtail access (active, NOT staff, and a member of moderator and/or editor group)
 - log in via http://localhost:8000/login/ . You should be sent to the wagtail admin page
 - try to reach /django-admin/ , you should see a page explaining that you don't have access to that, with a link back to wagtail
- Create a user with ONLY django admin access (active, staff, and NOT a member of moderator and/or editor groups)
 - log in via http://localhost:8000/login/ . You should be sent to the django-admin admin page
 - try to reach /admin/ , you should see a page explaining that you don't have access to that, with a link back to django-admin
- Create a user with BOTH django-admin and wagtail access (active, staff, and a member of moderator and/or editor group)
 - log in via http://localhost:8000/login/ . You should see a welcome page offering links to both Wagtail and django admin
- Go ahead and do a password reset, just to confirm that it's not broken

## Review

- @richaagarwal @kurtw @kave @Scotchester 

## Screenshots

<img width="1436" alt="screen shot 2016-06-08 at 11 26 24 pm" src="https://cloud.githubusercontent.com/assets/235397/15918154/dc5e4c6e-2dd1-11e6-9869-c4a0e0000d90.png">

<img width="1266" alt="screen shot 2016-06-08 at 11 37 19 pm" src="https://cloud.githubusercontent.com/assets/235397/15918162/fd19a610-2dd1-11e6-93d4-42e1e8b1fdb0.png">

## Todos

- It'd be nice if the new templates had appropriate HTML titles (they all say wagtail login)
- now that most of our validation logic is encapsulated in forms, I wonder if we can use the [built in authentication views](https://docs.djangoproject.com/en/1.9/topics/auth/default/#all-authentication-views)


## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
