### PR TITLE
Added correct spacing to Home Hero Content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,8 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 
 ### Fixed
 
-- Fixed layout bug in Latest Updates on Home Page
+- Fixed layout bug in Latest Updates on Home Page.
+- Fixed spacing of Home Hero content.
 
 
 ## 3.0.0-3.3.21-hotfix – 2016-06-10

--- a/cfgov/unprocessed/css/molecules/home-hero.less
+++ b/cfgov/unprocessed/css/molecules/home-hero.less
@@ -85,6 +85,10 @@
     } );
 
     &_content {
+        .respond-to-max( @bp-xs-max, {
+            margin-bottom: unit( @grid_gutter-width / @base-font-size-px, em );
+        } );
+
         .respond-to-min( @bp-sm-min, {
             .grid_column( 1, 1 );
         } );


### PR DESCRIPTION
The home hero lost it's spacing below the content after the global last paragraph margin change. Updated the content wrapper to add the necessary margin back in.

## Additions

- Added margin to hero content wrapper.

## Testing

- `gulp build` and navigate to the home page. The margin should match the image below at small device sizes.

## Review

- @KimberlyMunoz 
- @Scotchester 
- @schaferjh 

## Screenshots

![screen shot 2016-06-14 at 11 28 35 am](https://cloud.githubusercontent.com/assets/1280430/16050923/2786ca40-3223-11e6-8c65-2a96cba70266.png)

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)