### PR TITLE
Fixed layout bug in Latest Updates on Home Page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 
 ### Fixed
 
+- Fixed layout bug in Latest Updates on Home Page
+
 
 ## 3.0.0-3.3.21-hotfix – 2016-06-10
 

--- a/cfgov/jinja2/v1/index.html
+++ b/cfgov/jinja2/v1/index.html
@@ -173,7 +173,7 @@
                         <section class="content-l_col
                                         content-l_col-1-3">
                             {% for block in sections.value %}
-                                <div>
+                                <div class="m-related-posts_list-container">
                                     <h3 class="h4">
                                          <span class="cf-icon cf-icon-{{ block.categories }}"></span>
                                         {{ page.get_category_name(block.categories) }}
@@ -192,7 +192,7 @@
                                 </div>
                             {% endfor %}
                         {% if loop.last %}
-                            <div>
+                            <div class="m-related-posts_list-container">
                                 <a class="jump-link
                                           jump-link__underline"
                                    href="/activity-log/">


### PR DESCRIPTION
The individual posts in "Latest Updates" were missing spacing between each other. The `m-related-posts_list-container` class had been removed at some point in the past, it is now restored fixing the spacing.

## Additions

- Added `m-related-posts_list-container` where necessary.

## Testing

- `gulp build` and check the homepage matches the screenshot

## Review

- @KimberlyMunoz 
- @schaferjh 
- @schaferjh 
- @sarahsimpson09 

## Screenshots

![screen shot 2016-06-14 at 11 57 36 am](https://cloud.githubusercontent.com/assets/1280430/16051868/379cf856-3227-11e6-85ed-467663f3ff15.png)

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices
* [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)