### PR TITLE
Datetimes are now saved in UTC with the eastern timezone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 ### Added
 
 ### Changed
+- Datetimes are now saved in UTC and rendered in Eastern timezone when displayed in templates
+- Django timezone setting changed to America/New_York
 
 ### Removed
 

--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -160,7 +160,7 @@ DATABASES = {
 
 LANGUAGE_CODE = 'en-us'
 
-TIME_ZONE = 'UTC'
+TIME_ZONE = 'America/New_York'
 
 USE_I18N = True
 

--- a/cfgov/jinja2/v1/events/_event-detail.html
+++ b/cfgov/jinja2/v1/events/_event-detail.html
@@ -43,7 +43,7 @@
                       </span>
                       {{ time.render(
                           page.live_stream_date,
-                          timezone='America/New_York'
+                          timezone=page.live_stream_date.tzinfo | string
                       ) }}
                   </p>
                 </div>

--- a/cfgov/jinja2/v1/events/_macros.html
+++ b/cfgov/jinja2/v1/events/_macros.html
@@ -156,7 +156,7 @@
                     {% if event.start_dt %}
                         {{ time.render(
                             event.start_dt,
-                            timezone='America/New_York'
+                            timezone=event.start_dt.tzinfo | string
                         ) }}
                     {% endif %}
                 {% endif %}
@@ -255,11 +255,11 @@
                 <td class="{{ options.time_col_classes }}">
                     {% import 'macros/time.html' as time %}
                     {{ time.render(
-                        bound.start_dt.render(),
+                        bound.start_time.render(),
                         {'date':false,'time':true,'timezone':false}
                     ) }}
                     &ndash;
-                    {{ time.render(bound.end_dt.render(), {'time':true, 'timezone':true}) }}
+                    {{ time.render(bound.end_time.render(), {'time':true, 'timezone':true}) }}
                 </td>
                 <td class="{{ options.agenda_col_classes }} simple-table_row-heading">
                     {{ bound.description.render() }}

--- a/cfgov/sheerlike/templates.py
+++ b/cfgov/sheerlike/templates.py
@@ -7,6 +7,9 @@ def _convert_date(date, tz):
     if date and isinstance(date, basestring):
         date = parser.parse(date,
                             default=datetime.datetime.today().replace(day=1))
+    if isinstance(date, datetime.datetime) and tz:
+        this_tz = timezone(tz)
+        return date.astimezone(this_tz)
     return date
 
 

--- a/cfgov/sheerlike/templates.py
+++ b/cfgov/sheerlike/templates.py
@@ -4,18 +4,9 @@ from pytz import timezone
 
 
 def _convert_date(date, tz):
-    if date:
-        if isinstance(date, basestring):
-            date = parser.parse(date,
-                                default=datetime.datetime.today().replace(day=1))
-        # TODO: Event times are currently stored as UTC in the database, but they're actually ET times. 
-        # We will need to fix this once Wagtail fixes its handling of TIME_ZONE. 
-        if type(date) in [datetime.datetime, datetime.date]:
-            if isinstance(date, datetime.datetime):
-                pytzone = timezone(tz)
-                if date.tzinfo:
-                    date = date.replace(tzinfo=None)
-                date = pytzone.localize(date)
+    if date and isinstance(date, basestring):
+        date = parser.parse(date,
+                            default=datetime.datetime.today().replace(day=1))
     return date
 
 

--- a/cfgov/sheerlike/templates.py
+++ b/cfgov/sheerlike/templates.py
@@ -9,6 +9,8 @@ def _convert_date(date, tz):
                             default=datetime.datetime.today().replace(day=1))
     if isinstance(date, datetime.datetime) and tz:
         this_tz = timezone(tz)
+        if date.tzinfo == None:
+            return this_tz.localize(date)
         return date.astimezone(this_tz)
     return date
 

--- a/cfgov/sheerlike/test_templates.py
+++ b/cfgov/sheerlike/test_templates.py
@@ -8,13 +8,13 @@ class TestTemplates(TestCase):
     def test_get_date_obj(self):
         date_string = '2012-02'
         result = get_date_string(date_string)
-        assert(result == '2012-02-01')
+        self.assertEqual(result, '2012-02-01')
 
     def test_different_date_format(self):
         date_string = '2015-02-01T22:00:00'
         date_format = '%-I:%M%p %B %-d, %Y'
         result = get_date_string(date_string, date_format)
-        assert(result == '10:00PM February 1, 2015')
+        self.assertEqual(result, '10:00PM February 1, 2015')
 
     def test_default_timezone_is_eastern(self):
         date_string = '2015-02-01T22:00:00'
@@ -27,4 +27,4 @@ class TestTemplates(TestCase):
         date_format = '%Y-%m-%d %Z'
         tz = 'America/Chicago'
         result = get_date_string(date_string, date_format, tz)
-        assert(result == '2015-02-01 CST')
+        self.assertEqual(result, '2015-02-01 CST')

--- a/cfgov/v1/atomic_elements/organisms.py
+++ b/cfgov/v1/atomic_elements/organisms.py
@@ -195,7 +195,7 @@ class ItemIntroduction(blocks.StructBlock):
     heading = blocks.CharBlock(required=False)
     paragraph = blocks.RichTextBlock(required=False)
 
-    date = blocks.DateTimeBlock(required=False)
+    date = blocks.DateBlock(required=False)
     has_social = blocks.BooleanBlock(required=False, help_text="Whether to show the share icons or not.")
 
     class Meta:

--- a/cfgov/v1/migrations/0090_auto_20160609_1603.py
+++ b/cfgov/v1/migrations/0090_auto_20160609_1603.py
@@ -1,0 +1,151 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+import json
+import pytz
+import datetime
+from dateutil import parser
+
+from django.conf import settings
+from django.contrib.contenttypes.models import ContentType
+from django.db import migrations, models
+import wagtail.wagtailcore.fields
+import wagtail.wagtailcore.blocks
+
+
+def convert_datetimes(apps, schema_editor):
+    HomePage = apps.get_model('v1.HomePage')
+    DemoPage = apps.get_model('v1.DemoPage')
+    Page = apps.get_model('wagtailcore.Page')
+    PageRevision = apps.get_model('wagtailcore.PageRevision')
+
+    def specific(page):
+        content_type = ContentType.objects.get_for_id(page.content_type_id)
+        model_class = content_type.model_class()
+        if model_class is None:
+            return page
+        elif isinstance(page, model_class):
+            return page
+        else:
+            return content_type.get_object_for_this_type(id=page.id)
+
+    local = pytz.timezone('America/New_York')
+    def timezone_conversion(dt):
+        if isinstance(dt, basestring):
+            dt = parser.parse(dt)
+        naive = dt.replace(tzinfo=None)
+        localized_dt = local.localize(naive)
+        return localized_dt.astimezone(pytz.utc)
+
+    home = HomePage.objects.filter(slug='cfgov').first()
+    if home:
+        for update in home.latest_updates:
+            if update.block_type == 'posts':
+                for post in update.value:
+                    post['date'] = timezone_conversion(post['date'])
+        home.save()
+        revision = PageRevision.objects.filter(page=home).order_by('-id').first()
+        content = json.loads(revision.content_json)
+        if 'latest_updates' in content:
+            latest_updates = json.loads(content['latest_updates'])
+            for i, update in enumerate(latest_updates):
+                for j, value in enumerate(update['value']):
+                    if value['date']:
+                        latest_updates[i]['value'][j]['date'] = timezone_conversion(value['date']).isoformat()
+            content['latest_updates'] = json.dumps(latest_updates)
+            revision.content_json = json.dumps(content)
+        revision.save()
+
+    if settings.DEBUG:
+        for demo in DemoPage.objects.all():
+            for block in demo.organisms:
+                if block.block_type == 'item_intro':
+                    datetime = block.value['date']
+                    if datetime:
+                        block.value['date'] = datetime.date()
+            demo.save()
+
+    for page in Page.objects.all():
+        if page.go_live_at:
+            page.go_live_at = timezone_conversion(page.go_live_at)
+            for revision in PageRevision.objects.filter(page=page).order_by('-id'):
+                revision.approved_go_live_at = page.go_live_at
+                revision.save()
+        if page.expire_at:
+            page.expire_at = timezone_conversion(page.expire_at)
+        page.save()
+        specific_page = specific(page)
+        if 'learn_page' in str(type(specific_page)):
+            for block in specific_page.header:
+                if block.block_type == 'item_introduction':
+                    datetime = block.value['date']
+                    if datetime:
+                        block.value['date'] = datetime.date()
+            specific_page.save()
+            revision = PageRevision.objects.filter(page=page).order_by('-id').first()
+            content = json.loads(revision.content_json)
+            if 'header' in content:
+                header = json.loads(content['header'])
+                for i, block in enumerate(header):
+                    if block['type'] == 'item_introduction':
+                        if block['value']['date']:
+                            header[i]['value']['date'] = timezone_conversion(block['value']['date']).date().isoformat()
+                content['header'] = json.dumps(header)
+                revision.content_json = json.dumps(content)
+            revision.save()
+        if 'EventPage' in str(type(specific_page)):
+            if specific_page.start_dt:
+                specific_page.start_dt = timezone_conversion(specific_page.start_dt)
+            if specific_page.end_dt:
+                specific_page.end_dt = timezone_conversion(specific_page.end_dt)
+            if specific_page.live_stream_date:
+                specific_page.live_stream_date = timezone_conversion(specific_page.live_stream_date)
+            for item in specific_page.agenda_items:
+                if item.block_type == 'item':
+                    for old, new in {'start_dt': 'start_time', 'end_dt': 'end_time'}.iteritems():
+                        if old in item.value and item.value[old]:
+                            item.value[new] = item.value[old].time()
+                            del item.value[old]
+            specific_page.save()
+            revision = PageRevision.objects.filter(page=page).order_by('-id').first()
+            content = json.loads(revision.content_json)
+            for time in ['start_dt', 'end_dt', 'live_stream_date']:
+                if time in content and content[time]:
+                    content[time] = timezone_conversion(content[time]).isoformat()
+            if 'agenda_items' in content:
+                agenda_items = json.loads(content['agenda_items'])
+                for i, item in enumerate(agenda_items):
+                    if item['type'] == 'item':
+                        for old, new in {'start_dt': 'start_time', 'end_dt': 'end_time'}.iteritems():
+                            if old in item['value'] and item['value'][old]:
+                                agenda_items[i]['value'][new] = parser.parse(item['value'][old]).time().isoformat()
+                                del agenda_items[i]['value'][old]
+                content['agenda_items'] = json.dumps(agenda_items)
+            revision.content_json = json.dumps(content)
+            revision.save()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('v1', '0089_auto_20160607_1826'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='abstractfilterpage',
+            name='header',
+            field=wagtail.wagtailcore.fields.StreamField([(b'article_subheader', wagtail.wagtailcore.blocks.RichTextBlock(icon=b'form')), (b'text_introduction', wagtail.wagtailcore.blocks.StructBlock([(b'heading', wagtail.wagtailcore.blocks.CharBlock(required=False)), (b'intro', wagtail.wagtailcore.blocks.RichTextBlock(required=False)), (b'body', wagtail.wagtailcore.blocks.RichTextBlock(required=False)), (b'links', wagtail.wagtailcore.blocks.ListBlock(wagtail.wagtailcore.blocks.StructBlock([(b'text', wagtail.wagtailcore.blocks.CharBlock(required=False)), (b'url', wagtail.wagtailcore.blocks.CharBlock(default=b'/', required=False))]), required=False)), (b'has_rule', wagtail.wagtailcore.blocks.BooleanBlock(required=False))])), (b'item_introduction', wagtail.wagtailcore.blocks.StructBlock([(b'category', wagtail.wagtailcore.blocks.ChoiceBlock(required=False, choices=[(b'Amicus Brief', ((b'us-supreme-court', b'U.S. Supreme Court'), (b'fed-circuit-court', b'Federal Circuit Court'), (b'fed-district-court', b'Federal District Court'), (b'state-court', b'State Court'))), (b'Blog', ((b'at-the-cfpb', b'At the CFPB'), (b'policy_compliance', b'Policy & Compliance'), (b'data-research-reports', b'Data, research & reports'), (b'info-for-consumers', b'Info for consumers'))), (b'Enforcement action', ((b'fed-district-case', b'Federal District Court Case'), (b'admin-filing', b'Administrative Filing'))), (b'Final Rule', ((b'interim-final-rule', b'Interim Final Rule'), (b'final-rule', b'Final Rule'))), (b'FOIA Frequently Requested Record', ((b'report', b'Report'), (b'log', b'Log'), (b'record', b'Record'))), (b'Implementation Resource', ((b'compliance-aid', b'Compliance aid'), (b'official-guidance', b'Official guidance'))), (b'Newsroom', ((b'op-ed', b'Op-Ed'), (b'press-release', b'Press Release'), (b'speech', b'Speech'), (b'testimony', b'Testimony'))), (b'Notice and Opportunity for Comment', ((b'notice-proposed-rule', b'Advanced Notice of Proposed Rulemaking'), (b'proposed-rule', b'Proposed Rule'), (b'interim-final-rule-2', b'Interim Final Rule'), (b'request-comment-info', b'Request for Comment or Information'), (b'proposed-policy', b'Proposed Policy'), (b'intent-preempt-determ', b'Intent to make Preemption Determination'), (b'info-collect-activity', b'Information Collection Activities'), (b'notice-privacy-act', b'Notice related to Privacy Act'))), (b'Research Report', ((b'consumer-complaint', b'Consumer Complaint'), (b'super-highlight', b'Supervisory Highlights'), (b'data-point', b'Data Point'), (b'industry-markets', b'Industry and markets'), (b'consumer-edu-empower', b'Consumer education and empowerment'), (b'to-congress', b'To Congress'))), (b'Rule under development', ((b'notice-proposed-rule-2', b'Advanced Notice of Proposed Rulemaking'), (b'proposed-rule-2', b'Proposed Rule')))])), (b'heading', wagtail.wagtailcore.blocks.CharBlock(required=False)), (b'paragraph', wagtail.wagtailcore.blocks.RichTextBlock(required=False)), (b'date', wagtail.wagtailcore.blocks.DateBlock(required=False)), (b'has_social', wagtail.wagtailcore.blocks.BooleanBlock(help_text=b'Whether to show the share icons or not.', required=False))]))], blank=True),
+        ),
+        migrations.AlterField(
+            model_name='demopage',
+            name='organisms',
+            field=wagtail.wagtailcore.fields.StreamField([(b'well', wagtail.wagtailcore.blocks.StructBlock([(b'content', wagtail.wagtailcore.blocks.RichTextBlock(required=False, label=b'Well'))])), (b'full_width_text', wagtail.wagtailcore.blocks.StreamBlock([(b'content', wagtail.wagtailcore.blocks.RichTextBlock(icon=b'edit')), (b'media', wagtail.wagtailimages.blocks.ImageChooserBlock(icon=b'image')), (b'quote', wagtail.wagtailcore.blocks.StructBlock([(b'body', wagtail.wagtailcore.blocks.TextBlock()), (b'citation', wagtail.wagtailcore.blocks.TextBlock())])), (b'cta', wagtail.wagtailcore.blocks.StructBlock([(b'slug_text', wagtail.wagtailcore.blocks.CharBlock(required=False)), (b'paragraph_text', wagtail.wagtailcore.blocks.RichTextBlock(required=False)), (b'button', wagtail.wagtailcore.blocks.StructBlock([(b'text', wagtail.wagtailcore.blocks.CharBlock(required=False)), (b'url', wagtail.wagtailcore.blocks.CharBlock(default=b'/', required=False))]))])), (b'related_links', wagtail.wagtailcore.blocks.StructBlock([(b'heading', wagtail.wagtailcore.blocks.CharBlock(required=False)), (b'paragraph', wagtail.wagtailcore.blocks.RichTextBlock(required=False)), (b'links', wagtail.wagtailcore.blocks.ListBlock(wagtail.wagtailcore.blocks.StructBlock([(b'text', wagtail.wagtailcore.blocks.CharBlock(required=False)), (b'url', wagtail.wagtailcore.blocks.CharBlock(default=b'/', required=False))])))])), (b'table', wagtail.wagtailcore.blocks.StructBlock([(b'headers', wagtail.wagtailcore.blocks.ListBlock(wagtail.wagtailcore.blocks.CharBlock())), (b'rows', wagtail.wagtailcore.blocks.ListBlock(wagtail.wagtailcore.blocks.StreamBlock([(b'hyperlink', wagtail.wagtailcore.blocks.StructBlock([(b'text', wagtail.wagtailcore.blocks.CharBlock(required=False)), (b'url', wagtail.wagtailcore.blocks.CharBlock(default=b'/', required=False))])), (b'text', wagtail.wagtailcore.blocks.CharBlock()), (b'text_blob', wagtail.wagtailcore.blocks.TextBlock()), (b'rich_text_blob', wagtail.wagtailcore.blocks.RichTextBlock())])))]))])), (b'expandable_group', wagtail.wagtailcore.blocks.StructBlock([(b'heading', wagtail.wagtailcore.blocks.CharBlock(required=False)), (b'body', wagtail.wagtailcore.blocks.RichTextBlock(required=False)), (b'is_accordion', wagtail.wagtailcore.blocks.BooleanBlock(required=False)), (b'has_rule', wagtail.wagtailcore.blocks.BooleanBlock(required=False)), (b'expandables', wagtail.wagtailcore.blocks.ListBlock(wagtail.wagtailcore.blocks.StructBlock([(b'label', wagtail.wagtailcore.blocks.CharBlock(required=False)), (b'is_bordered', wagtail.wagtailcore.blocks.BooleanBlock(required=False)), (b'is_midtone', wagtail.wagtailcore.blocks.BooleanBlock(required=False)), (b'is_expanded', wagtail.wagtailcore.blocks.BooleanBlock(required=False)), (b'content', wagtail.wagtailcore.blocks.StreamBlock([(b'paragraph', wagtail.wagtailcore.blocks.RichTextBlock(required=False)), (b'well', wagtail.wagtailcore.blocks.StructBlock([(b'content', wagtail.wagtailcore.blocks.RichTextBlock(required=False, label=b'Well'))])), (b'links', wagtail.wagtailcore.blocks.StructBlock([(b'text', wagtail.wagtailcore.blocks.CharBlock(required=False)), (b'url', wagtail.wagtailcore.blocks.CharBlock(default=b'/', required=False))])), (b'email', wagtail.wagtailcore.blocks.StructBlock([(b'emails', wagtail.wagtailcore.blocks.ListBlock(wagtail.wagtailcore.blocks.StructBlock([(b'text', wagtail.wagtailcore.blocks.CharBlock(required=False)), (b'url', wagtail.wagtailcore.blocks.CharBlock(default=b'/', required=False))])))])), (b'phone', wagtail.wagtailcore.blocks.StructBlock([(b'fax', wagtail.wagtailcore.blocks.BooleanBlock(default=False, required=False, label=b'Is this number a fax?')), (b'phones', wagtail.wagtailcore.blocks.ListBlock(wagtail.wagtailcore.blocks.StructBlock([(b'number', wagtail.wagtailcore.blocks.CharBlock(max_length=15)), (b'vanity', wagtail.wagtailcore.blocks.CharBlock(max_length=15, required=False)), (b'tty', wagtail.wagtailcore.blocks.CharBlock(max_length=15, required=False))])))])), (b'address', wagtail.wagtailcore.blocks.StructBlock([(b'label', wagtail.wagtailcore.blocks.CharBlock(required=False)), (b'title', wagtail.wagtailcore.blocks.CharBlock(required=False)), (b'street', wagtail.wagtailcore.blocks.CharBlock(required=False)), (b'city', wagtail.wagtailcore.blocks.CharBlock(max_length=50, required=False)), (b'state', wagtail.wagtailcore.blocks.CharBlock(max_length=25, required=False)), (b'zip_code', wagtail.wagtailcore.blocks.CharBlock(max_length=15, required=False))]))], blank=True))])))])), (b'item_intro', wagtail.wagtailcore.blocks.StructBlock([(b'category', wagtail.wagtailcore.blocks.ChoiceBlock(required=False, choices=[(b'Amicus Brief', ((b'us-supreme-court', b'U.S. Supreme Court'), (b'fed-circuit-court', b'Federal Circuit Court'), (b'fed-district-court', b'Federal District Court'), (b'state-court', b'State Court'))), (b'Blog', ((b'at-the-cfpb', b'At the CFPB'), (b'policy_compliance', b'Policy & Compliance'), (b'data-research-reports', b'Data, research & reports'), (b'info-for-consumers', b'Info for consumers'))), (b'Enforcement action', ((b'fed-district-case', b'Federal District Court Case'), (b'admin-filing', b'Administrative Filing'))), (b'Final Rule', ((b'interim-final-rule', b'Interim Final Rule'), (b'final-rule', b'Final Rule'))), (b'FOIA Frequently Requested Record', ((b'report', b'Report'), (b'log', b'Log'), (b'record', b'Record'))), (b'Implementation Resource', ((b'compliance-aid', b'Compliance aid'), (b'official-guidance', b'Official guidance'))), (b'Newsroom', ((b'op-ed', b'Op-Ed'), (b'press-release', b'Press Release'), (b'speech', b'Speech'), (b'testimony', b'Testimony'))), (b'Notice and Opportunity for Comment', ((b'notice-proposed-rule', b'Advanced Notice of Proposed Rulemaking'), (b'proposed-rule', b'Proposed Rule'), (b'interim-final-rule-2', b'Interim Final Rule'), (b'request-comment-info', b'Request for Comment or Information'), (b'proposed-policy', b'Proposed Policy'), (b'intent-preempt-determ', b'Intent to make Preemption Determination'), (b'info-collect-activity', b'Information Collection Activities'), (b'notice-privacy-act', b'Notice related to Privacy Act'))), (b'Research Report', ((b'consumer-complaint', b'Consumer Complaint'), (b'super-highlight', b'Supervisory Highlights'), (b'data-point', b'Data Point'), (b'industry-markets', b'Industry and markets'), (b'consumer-edu-empower', b'Consumer education and empowerment'), (b'to-congress', b'To Congress'))), (b'Rule under development', ((b'notice-proposed-rule-2', b'Advanced Notice of Proposed Rulemaking'), (b'proposed-rule-2', b'Proposed Rule')))])), (b'heading', wagtail.wagtailcore.blocks.CharBlock(required=False)), (b'paragraph', wagtail.wagtailcore.blocks.RichTextBlock(required=False)), (b'date', wagtail.wagtailcore.blocks.DateBlock(required=False)), (b'has_social', wagtail.wagtailcore.blocks.BooleanBlock(help_text=b'Whether to show the share icons or not.', required=False))]))], blank=True),
+        ),
+        migrations.RunPython(convert_datetimes),
+        migrations.AlterField(
+            model_name='eventpage',
+            name='agenda_items',
+            field=wagtail.wagtailcore.fields.StreamField([(b'item', wagtail.wagtailcore.blocks.StructBlock([(b'start_time', wagtail.wagtailcore.blocks.TimeBlock(required=False, label=b'Start')), (b'end_time', wagtail.wagtailcore.blocks.TimeBlock(required=False, label=b'End')), (b'description', wagtail.wagtailcore.blocks.CharBlock(max_length=100, required=False)), (b'location', wagtail.wagtailcore.blocks.CharBlock(max_length=100, required=False)), (b'speakers', wagtail.wagtailcore.blocks.ListBlock(wagtail.wagtailcore.blocks.StructBlock([(b'name', wagtail.wagtailcore.blocks.CharBlock(required=False)), (b'url', wagtail.wagtailcore.blocks.URLBlock(required=False))], required=False, icon=b'user')))]))], blank=True),
+        ),
+    ]

--- a/cfgov/v1/models/learn_page.py
+++ b/cfgov/v1/models/learn_page.py
@@ -107,8 +107,8 @@ class DocumentDetailPage(AbstractFilterPage):
 
 
 class AgendaItemBlock(blocks.StructBlock):
-    start_dt = blocks.DateTimeBlock(label="Start", required=False)
-    end_dt = blocks.DateTimeBlock(label="End", required=False)
+    start_time = blocks.TimeBlock(label="Start", required=False)
+    end_time = blocks.TimeBlock(label="End", required=False)
     description = blocks.CharBlock(max_length=100, required=False)
     location = blocks.CharBlock(max_length=100, required=False)
     speakers = blocks.ListBlock(blocks.StructBlock([


### PR DESCRIPTION
Timezones were saved in UTC but being treated in code as eastern. Now, they are saved as UTC with their hour difference applied as is best practice. For example, before this change 4:00am was saved as 04:00:00 UTC and now 12:00am is saved as 08:00:00 UTC and Django will apply the eastern timezone when appropriate. [See this for more details on the settings.](https://docs.djangoproject.com/en/1.9/ref/settings/#std:setting-TIME_ZONE)

This also changes the block types that are used in EventPage AgendaItemBlock's and ItemIntroduction blocks. Before, they were unnecessarily using DateTimeBlock's and now they use their appropriate block types.

## Additions

- A new migration that changes the block types and migrates the datetimes on the pages to the appropriate values.

## Changes

- The timezone is now `America/New_York` and dates displayed in templates and input into forms will be treated as such.

## Testing

- Preferably start with a fresh database dump
- **Before pulling down**
 - Go to the homepage and see dates in latest updates
 - Go to http://localhost:8000/about-us/events/archive-past-events/fall-community-bank-advisory-council-meeting-in-washington-dc/
 - see the start date and agenda times
- **After pulling down** 
 - run `cfgov/manage.py migrate`
  - Go to the homepage and see dates in latest updates unchanged
  - Go to http://localhost:8000/about-us/events/archive-past-events/fall-community-bank-advisory-council-meeting-in-washington-dc/
  - witness that they haven't been affected on the frontend
  - open a shell
  - run:
```
page = EventPage.objects.get(slug='fall-community-bank-advisory-council-meeting-in-washington-dc')
print page.start_dt
```
  - witness `page.start_dt` is saved as UTC with hour difference applied.
  - create a new EventPage with a future start time and agenda items with times
  - publish and see all the times are correct


## Review

- @kave 
- @richaagarwal 
- @rosskarchner 

## TODO

- Later add the timezone selection for events and logic to handle different timezones

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices
* [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)

