### PR TITLE
Fix scheduled publishing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Updated ESLint to `2.13.1` from `2.7.0`.
 - Fixed job ordering on Careers home page to be consistent with Current Openings page.
 
+### Removed
+
+### Fixed
+- Fix scheduled publishing
 
 
 ## 3.0.0-3.3.22 – 2016-06-22

--- a/cfgov/v1/models/base.py
+++ b/cfgov/v1/models/base.py
@@ -217,7 +217,11 @@ class CFGOVPage(Page):
     @property
     def status_string(self):
         page = CFGOVPage.objects.get(id=self.id)
-        if page.live and page.shared:
+        if page.expired:
+            return _("expired")
+        elif page.approved_schedule:
+            return _("scheduled")
+        elif page.live and page.shared:
             if page.has_unpublished_changes:
                 if page.has_unshared_changes:
                     for revision in page.revisions.order_by('-created_at', '-id'):
@@ -236,10 +240,6 @@ class CFGOVPage(Page):
                 return _("shared + draft")
             else:
                 return _("shared")
-        elif page.expired:
-            return _("expired")
-        elif page.approved_schedule:
-            return _("scheduled")
         else:
             return _("draft")
 

--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,10 @@ setenv =
     ES_HOST=localhost
     SHEER_ELASTICSEARCH_INDEX=content
     STAGING_HOSTNAME=content.localhost
+    AKAMAI_USER=test@mail.com
+    AKAMAI_PASSWORD=password
+    AKAMAI_NOTIFY_EMAIL=test@mail.com
+    AKAMAI_HOST=localhost
 deps =
     -r{toxinidir}/requirements/test.txt
 changedir = {toxinidir}/cfgov


### PR DESCRIPTION
**This should probably go in after the timezone PR is merged #2189**

Scheduled publishing was broken because we changed the `route` function to point to the latest revision when publishing instead of the page itself. When running the management command `publish_scheduled_pages`, it would publish the revisions that were appropriate to publish but it wouldn't hit our logic to update the revision to `live=True` so the changes are never seen. This fixes that by making it hit our logic when calling `publish` on a revision anywhere using signal passing.

## Additions

- Signal to call our revision logic to update the revision appropriately.
- New function to flush akamai

## Removals

- [Here](https://github.com/cfpb/cfgov-refresh/pull/2189/files#diff-44507cc860654b805baac659b58d2c53L64) I removed the `publish()` call from this function since it doesn't provide any value and caused infinite loops when introducing the signal handler.

## Changes

- Every time a revision of a page is published, its revision is updated instead of only when a page is created or edited.
- Akamai is flushed for every page publish call

## Testing

- Make sure the regular workflow of saving, sharing, and publishing a page works.
- Publish a page
- Make an edit and set the Go Live At datetime to be just after the current time
- Publish it
- Note the status of SCHEDULED
- Go to the page and note that the edits have not been published
- once the Go Live At datetime that you set is now or greater, run `cfgov/manage.py publish_scheduled_pages`
- Visit the page again and see the changes. The admin should also now say that the page's status is LIVE

## Review

- @kave 
- @rosskarchner 
- @richaagarwal 

## Todos

- At some point we really need to rethink how we're handling our Shared vs Live logic since it doesn't fall in line with Wagtail's method of serving appropriate versions of pages.

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [x] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)

