### PR TITLE
Make page statuses more descriptive

### DIFF
--- a/cfgov/templates/wagtailadmin/shared/page_status_tag.html
+++ b/cfgov/templates/wagtailadmin/shared/page_status_tag.html
@@ -1,10 +1,12 @@
 {% load share %}
 
 {% if page.live %}
-    <a href="{{ page.url }}" target="_blank" class="status-tag primary">{{ page.status_string }}</a>
-{% elif page.specific.shared %}
-    {% get_page_state_url page as shared_url %}
-    <a href="{{ shared_url }}" target="_blank" class="status-tag primary">{{ page.specific.status_string }}</a>
+    <a href="{{ page.url }}" target="_blank" class="status-tag primary">{{ page.specific.status_string }}</a>
 {% else %}
-    <span class="status-tag">{{ page.status_string }}</span>
+    {% get_page_state_url page as shared_url %}
+    {% if shared_url %}
+        <a href="{{ shared_url }}" target="_blank" class="status-tag primary">{{ page.specific.status_string }}</a>
+    {% else %}
+        <span class="status-tag">{{ page.status_string }}</span>
+    {% endif %}
 {% endif %}

--- a/cfgov/v1/migrations/0091_cfgovpage_has_unshared_changes.py
+++ b/cfgov/v1/migrations/0091_cfgovpage_has_unshared_changes.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+import json
+from django.db import migrations, models
+
+
+def update_page_statuses(apps, schema_editor):
+    CFGOVPage = apps.get_model('v1.CFGOVPage')
+    PageRevision = apps.get_model('wagtailcore.PageRevision')
+
+    for page in CFGOVPage.objects.all():
+        revisions = PageRevision.objects.filter(page=page.id).order_by('-created_at', '-id')
+        latest_revision = revisions.first()
+        latest_content = json.loads(latest_revision.content_json)
+        if not latest_content['shared']:
+            page.has_unshared_changes = True
+        for revision in revisions:
+            content = json.loads(revision.content_json)
+            if content['live']:
+                page.live = True
+            if content['shared']:
+                page.shared = True
+        page.save()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('v1', '0089_auto_20160607_1826'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='cfgovpage',
+            name='has_unshared_changes',
+            field=models.BooleanField(default=False),
+        ),
+        migrations.RunPython(update_page_statuses)
+    ]

--- a/cfgov/v1/templatetags/share.py
+++ b/cfgov/v1/templatetags/share.py
@@ -21,12 +21,15 @@ def is_shared(page):
 
 @register.assignment_tag(takes_context=True)
 def get_page_state_url(context, page):
+    page = Page.objects.get(id=page.id).specific
+    if not page.live and not page.shared:
+        return None
     url = page.url
     if url is None:  # If page is not aligned to a site root return None
         return None
     page_hostname = urlparse(url).hostname
     staging_hostname = os.environ.get('STAGING_HOSTNAME')
-    if not page.live and page.specific.shared and staging_hostname not in page_hostname:
+    if not page.live and page.shared and staging_hostname != page_hostname:
         url = url.replace(page_hostname, staging_hostname)
     return url
 

--- a/cfgov/v1/tests/test_filterable_list.py
+++ b/cfgov/v1/tests/test_filterable_list.py
@@ -311,16 +311,3 @@ class TestFilterableListMixin(TestCase):
         forms = self.mixin.get_forms(mock_request)
         assert type(forms) is list
         assert mock_form.called
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/cfgov/v1/tests/test_wagtail_hooks.py
+++ b/cfgov/v1/tests/test_wagtail_hooks.py
@@ -23,46 +23,58 @@ class TestShareThePage(TestCase):
         for key in self.mock_request.keys():
             self.mock_request[key].user = mock.Mock()
 
+
+    @mock.patch('v1.wagtail_hooks.Page')
     @mock.patch('v1.wagtail_hooks.check_permissions')
     @mock.patch('v1.wagtail_hooks.share')
     @mock.patch('v1.wagtail_hooks.configure_page_revision')
-    def test_save_draft(self, mock_configure_page_revision, mock_share, mock_check_permissions):
+    def test_save_draft(self, mock_configure_page_revision, mock_share, mock_check_permissions, mock_page):
         """
             Make sure 'Save Draft' request sets correct values for
             is_publishing and is_sharing.
         """
+        mock_page.objects.get.return_value = self.page
         share_the_page(self.mock_request['saving'], self.page)
         mock_share.assert_called_once_with(self.page.specific, False, False)
 
+
+    @mock.patch('v1.wagtail_hooks.Page')
     @mock.patch('v1.wagtail_hooks.check_permissions')
     @mock.patch('v1.wagtail_hooks.share')
     @mock.patch('v1.wagtail_hooks.configure_page_revision')
-    def test_share_on_content(self, mock_configure_page_revision, mock_share, mock_check_permissions):
+    def test_share_on_content(self, mock_configure_page_revision, mock_share, mock_check_permissions, mock_page):
         """
             Make sure 'Share on Content' request sets correct values for
             is_publishing and is_sharing.
         """
+        mock_page.objects.get.return_value = self.page
         share_the_page(self.mock_request['sharing'], self.page)
         mock_share.assert_called_once_with(self.page.specific, True, False)
 
+
+    @mock.patch('v1.wagtail_hooks.Page')
     @mock.patch('v1.wagtail_hooks.check_permissions')
     @mock.patch('v1.wagtail_hooks.share')
     @mock.patch('v1.wagtail_hooks.configure_page_revision')
-    def test_publish_to_www(self, mock_configure_page_revision, mock_share, mock_check_permissions):
+    def test_publish_to_www(self, mock_configure_page_revision, mock_share, mock_check_permissions, mock_page):
         """
             Make sure 'Publish to WWW' request sets correct values for
             is_publishing and is_sharing.
         """
+        mock_page.objects.get.return_value = self.page
         share_the_page(self.mock_request['publishing'], self.page)
         mock_share.assert_called_once_with(self.page.specific, False, True)
 
+
+    @mock.patch('v1.wagtail_hooks.Page')
     @mock.patch('v1.wagtail_hooks.check_permissions')
     @mock.patch('v1.wagtail_hooks.share')
     @mock.patch('v1.wagtail_hooks.configure_page_revision')
-    def test_function_calls(self, mock_configure_page_revision, mock_share, mock_check_permissions):
+    def test_function_calls(self, mock_configure_page_revision, mock_share, mock_check_permissions, mock_page):
         """
             Make sure all functions are called once.
         """
+        mock_page.objects.get.return_value = self.page
         share_the_page(self.mock_request['publishing'], self.page)
         assert mock_configure_page_revision.call_count == 1
         assert mock_share.call_count == 1


### PR DESCRIPTION
This is going to be a pain to review. Sorry in advance. Page statuses haven't been as complex as they've needed to be with our introduction of the `SHARED` status. This fixes that by adding new statuses so that content editors can easily tell what the state of the page is. The page states are as follows:

1. The page is just started, it is neither SHARED nor LIVE. — DRAFT
2. The page moves from draft to share on content but is not LIVE — SHARED
3. The page is SHARED and has unshared updates — SHARED + DRAFT
4. The page is published to www (and shared on content) -- LIVE
5. The page is LIVE and has unpublished updates -- LIVE + DRAFT
6. The page is LIVE and has shared updates -- LIVE + SHARED
7. The page is LIVE and has shared updates and has unpublished updates - LIVE + (SHARED+DRAFT)

## Additions

- `has_unshared_changes` field to CFGOVPage

## Changes

- Our hook function `share_the_page()` sets state of `has_unshared_changes` appropriately.

## Fixes

- Fixes bug that changed a shared page's "state" to DRAFT even though it was still accessible on staging.

## Testing
Testing this PR is going to be tedious but is important

- **Before pulling down the branch**
 - Create 7 pages:
  - Title page 1 `Draft` and just save the page as draft.
  - Title page 2 `Shared` and share the page.
  - Title page 3 `Live` and publish the page.
  - Title page 4 `Shared Draft`, share the page, then hit save as draft.
  - Title page 5 `Live Draft`, publish the page, then hit save as draft.
  - Title page 6 `Live Shared`, publish the page, then share the page.
  - Title page 7 `Live Shared Draft`, publish the page, share the page, then hit save as draft.
- **Pull down branch**
 - Run `./cfgov/manage.py migrate`
 - Look at all the pages for their new statuses mapped by the following:
  - Page 1: `DRAFT`
  - Page 2: `SHARED`
  - Page 3: `LIVE`
  - Page 4: `SHARED + DRAFT`
  - Page 5: `LIVE + DRAFT`
  - Page 6: `LIVE + SHARED`
  - Page 7: `LIVE + (SHARED + DRAFT)`
- Run sanity check on drafted content vs shared content vs published content so there's no leakage.

## Review

- @kave 
- @richaagarwal 
- @rosskarchner 

## Todos

- Document this in Flapjack Wagtail docs (currently underway)

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)