### PR TITLE
Fixed spacing issues in the pre-footer

### DIFF
--- a/cfgov/jinja2/v1/_includes/molecules/contact-address.html
+++ b/cfgov/jinja2/v1/_includes/molecules/contact-address.html
@@ -25,7 +25,7 @@
 
    ========================================================================== #}
 
-<div class="m-contact-address" data-qa-hook="contact-address">
+<div class="m-contact m-contact-address" data-qa-hook="contact-address">
     <span class="cf-icon cf-icon-mail"></span>
     <span class="h5">{{ value.label }}</span>
 

--- a/cfgov/jinja2/v1/_includes/molecules/contact-email.html
+++ b/cfgov/jinja2/v1/_includes/molecules/contact-email.html
@@ -15,7 +15,7 @@
 
    ========================================================================== #}
 
-<div class="m-contact-email" data-qa-hook="contact-email">
+<div class="m-contact m-contact-email" data-qa-hook="contact-email">
     <span class="cf-icon cf-icon-email"></span>
     <span class="h5">Email</span>
     <p>

--- a/cfgov/jinja2/v1/_includes/molecules/contact-phone.html
+++ b/cfgov/jinja2/v1/_includes/molecules/contact-phone.html
@@ -24,7 +24,7 @@
    ========================================================================== #}
 
 {% from 'macros/util/format/contact.html' import format_phone as format_phone %}
-<div class="m-contact-phone" data-qa-hook="contact-phone">
+<div class="m-contact m-contact-phone" data-qa-hook="contact-phone">
     {# TODO: Update fax param name to is_fax to make clear it's a boolean. #}
     {% if value.fax == true %}
         {% set icon = 'cf-icon-fax' %}

--- a/cfgov/jinja2/v1/_includes/molecules/related-posts.html
+++ b/cfgov/jinja2/v1/_includes/molecules/related-posts.html
@@ -78,7 +78,8 @@
     {% import 'macros/time.html' as time %}
     {% set limit = limit | int if posts | length >= limit | int else posts | length %}
     <ul class="m-related-posts_list
-               list list__unstyled
+               list
+               list__unstyled
                list__spaced">
         {% for i in range(limit) %}
             {% set post_url = slugurl(posts[i].slug) or '' %}

--- a/cfgov/jinja2/v1/_includes/organisms/sidebar-contact-info.html
+++ b/cfgov/jinja2/v1/_includes/organisms/sidebar-contact-info.html
@@ -45,7 +45,7 @@
         </h2>
     </div>
 
-    <div class="o-sidebar-contact-info_column">
+    <div class="o-sidebar-contact-info_content">
         {% if value.header %}
             <h3>{{ value.header }}</h3>
         {% endif %}
@@ -53,7 +53,7 @@
         {{ parse_links(value.contact.body) |safe }}
     </div>
 
-    <div class="o-sidebar-contact-info_column">
+    <div class="o-sidebar-contact-info_contacts">
         {% if value.contact.contact_info %}
             {% for block in value.contact.contact_info %}
                 {{ render_stream_child(block) }}

--- a/cfgov/jinja2/v1/_includes/templates/streamfield-sidefoot.html
+++ b/cfgov/jinja2/v1/_includes/templates/streamfield-sidefoot.html
@@ -8,7 +8,7 @@
         {% if 'related_posts' in block.block_type %}
             {% set posts = page.related_posts(block, request.site.hostname) %}
             {% if posts %}
-                <div class="block {{- 'block__flush-top' if loop.index == 1 else '' -}}">
+                <div class="block {{ 'block__flush-top' if loop.index == 1 else '' -}}">
                     {{ related_posts.render(posts, block, half_width) }}
                 </div>
             {% else %}
@@ -17,11 +17,11 @@
                 {% break %}
             {% endif %}
         {% elif 'related_metadata' in block.block_type %}
-            <div class="block {{- 'block__flush-top' if loop.index == 1 else '' -}}">
+            <div class="block {{ 'block__flush-top' if loop.index == 1 else '' -}}">
                 {{ related_metadata.render(block.value) }}
             </div>
         {% elif 'social_media' in block.block_type %}
-            <div class="block {{- 'block__flush-top' if loop.index == 1 else '' -}}">
+            <div class="block {{ 'block__flush-top' if loop.index == 1 else '' -}}">
                 {{ social_media.render(block.value) }}
             </div>
         {% else %}

--- a/cfgov/unprocessed/css/molecules/related-posts.less
+++ b/cfgov/unprocessed/css/molecules/related-posts.less
@@ -47,6 +47,8 @@
 
 @list_half-width: {
 
+    .grid_nested-col-group();
+
     .list_item {
         .grid_column(6);
     }
@@ -65,13 +67,6 @@
         }
     }
 };
-
-.m-related-posts {
-
-    .respond-to-range(@bp-sm-min, @bp-sm-max, {
-        .grid_column(12);
-    });
-}
 
 .m-related-posts__half-width {
     .m-related-posts_list {

--- a/cfgov/unprocessed/css/organisms/sidebar-contact-info.less
+++ b/cfgov/unprocessed/css/organisms/sidebar-contact-info.less
@@ -37,16 +37,13 @@
 
 .o-sidebar-contact-info {
 
-    &_heading {
-        .respond-to-range( @bp-sm-min, @bp-sm-max {
-            .grid_column(12);
-        } );
+    &_content {
+        margin-bottom: unit( @grid_gutter-width / @base-font-size-px, em );
     }
 
-    &_column {
-        .respond-to-range( @bp-sm-min, @bp-sm-max {
-            .grid_column(6);
-        } );
+    .m-contact + .m-contact {
+        // Adds margin top to info contacts that follow another
+        margin-top: unit( @grid_gutter-width / @base-font-size-px, em );
     }
 }
 


### PR DESCRIPTION
There were multiple spacing issues in the pre-footer that had gone unnoticed until the recent changes to the last paragraph spacing. Updated the contact info to remove extra left/right spacing and added spacing between components where necessary.

## Added

- Added generic contact molecule to fix spacing when multiple exist together

## Changes

- Fixed missing space between `block` and `block__flush-top` modifier
- Updated grid

## Removed

- Removed grid wrappers where they weren't necessary

## Testing

- `gulp build` and check http://localhost:8000/accessibility/ and http://localhost:8000/about-us/advisory-groups/ and compare them to Jess's screenshots at https://github.com/cfpb/cfgov-refresh/pull/2186#issuecomment-225941037

## Review

- @KimberlyMunoz 
- @Scotchester 
- @schaferjh 

## Screenshots

![screen shot 2016-06-17 at 9 28 35 am](https://cloud.githubusercontent.com/assets/1280430/16154621/44757eee-3471-11e6-84e6-2017d311e030.png)

![screen shot 2016-06-17 at 9 53 43 am](https://cloud.githubusercontent.com/assets/1280430/16154659/70ae407c-3471-11e6-812d-7e668577947b.png)

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)