### PR TITLE
Fixing TestMinimumPasswordAge.test_too_soon

### DIFF
--- a/cfgov/v1/tests/test_password_policy.py
+++ b/cfgov/v1/tests/test_password_policy.py
@@ -1,3 +1,5 @@
+import datetime
+
 from django.test import TestCase
 from django.core.exceptions import ValidationError
 from django.utils import timezone
@@ -53,6 +55,11 @@ class TestMinimumPasswordAge(TestWithUser):
 
     def test_too_soon(self):
         user = self.get_user()
+        history_item = user.passwordhistoryitem_set.latest()
+        current_locked_until = history_item.locked_until
+        new_locked_until = current_locked_until.replace(year=datetime.MAXYEAR)
+        history_item.locked_until = new_locked_until
+        history_item.save()
         with self.assertRaises(ValidationError):
             password_policy.validate_password_age(user)
 


### PR DESCRIPTION
TestMinimumPasswordAge.test_too_soon assumed that new users were created with a password that can't be changed until 24 hours later. That assumption is no longer valid, so I've altered the test to make certain that the user is not allowed to change their password.    