### PR TITLE
Switch migration order because of django migration bug

### DIFF
--- a/cfgov/v1/migrations/0090_cfgovpage_has_unshared_changes.py
+++ b/cfgov/v1/migrations/0090_cfgovpage_has_unshared_changes.py
@@ -27,7 +27,7 @@ def update_page_statuses(apps, schema_editor):
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('v1', '0090_auto_20160609_1603'),
+        ('v1', '0089_auto_20160607_1826'),
     ]
 
     operations = [

--- a/cfgov/v1/migrations/0091_auto_20160609_1603.py
+++ b/cfgov/v1/migrations/0091_auto_20160609_1603.py
@@ -128,7 +128,7 @@ def convert_datetimes(apps, schema_editor):
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('v1', '0089_auto_20160607_1826'),
+        ('v1', '0090_cfgovpage_has_unshared_changes'),
     ]
 
     operations = [


### PR DESCRIPTION
According to [this issue](https://code.djangoproject.com/ticket/24573) there was a bug in the django migrations module that cause it to look for fields that are not available when retrieving a model through `apps`. Apparently, this was only fixed in the case described in the issue and does not fix our specific situation. I'm opening up an issue soon because this keeps cropping up when we do data migrations. 

This fixes the migrations so that the field is available on model retrieval.

@rosskarchner 