### PR TITLE
Setup fixes

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -69,7 +69,18 @@ cfgov start django
 
 ## Stand-alone installation
 
-### 1. Back-end setup
+### 1. Environment variables setup
+
+The project uses a number of environment variables.
+The `setup.sh` script will create a `.env` file for you
+from the `.env_SAMPLE` file found in the repository,
+if you don't already have one:
+
+```sh
+./setup.sh
+```
+
+### 2. Back-end setup
 
 #### Virtualenv & Virtualenvwrapper Python modules
 
@@ -196,7 +207,7 @@ pip install git+git://github.com/rosskarchner/govdelivery
   in the [Project Configuration](https://github.com/cfpb/cfgov-refresh/blob/flapjack/INSTALL.md#4-project-configuration).
 
 
-## 2. Front-end setup
+## 3. Front-end setup
 
 The cfgov-refresh front-end currently uses the following frameworks / tools:
 
@@ -217,7 +228,7 @@ The cfgov-refresh front-end currently uses the following frameworks / tools:
 npm install -g gulp bower
 ```
 
-## 3. Install dependencies
+## 4. Install dependencies
 
 > **NOTE:**
   Protractor (for the test suite)
@@ -240,7 +251,7 @@ Next, install dependencies with:
   [updating all the project dependencies](README.md#updating-all-dependencies).
 
 
-## 4. Project configuration
+## 5. Project configuration
 
 The project uses a number of environment variables.
 The `setup.sh` script will create a `.env` file for you
@@ -268,6 +279,6 @@ by directly setting its value from the command-line with:
 export [CONSTANTNAME]=[CONSTANTVALUE]
 ```
 
-### 5. Usage
+### 6. Usage
 
 Continue following the [Usage instructions](README.md#usage) in the README.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -238,13 +238,6 @@ npm install -g gulp bower
   npm install -g protractor && webdriver-manager update
   ```
 
-
-Next, install dependencies with:
-
-```bash
-./setup.sh
-```
-
 > **NOTE:**
   To re-install and rebuild all the site’s assets run `./setup.sh` again.
   See the usage section

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -221,7 +221,7 @@ The cfgov-refresh front-end currently uses the following frameworks / tools:
 > **NOTE:** If you’re new to Capital Framework, we encourage you to
   [start here](https://cfpb.github.io/capital-framework/getting-started).
 
-1. Install [Node.js](http://nodejs.org) however you’d like.
+1. Install [Node.js](http://nodejs.org) however you’d like. This project requires version 5.5.0 and up.
 2. Install [Gulp](http://gulpjs.com) and [Bower](http://bower.io):
 
 ```bash

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -11,7 +11,11 @@ There are two ways to install:
 The project uses a number of environment variables.
 The `setup.sh` script will create a `.env` file for you
 from the `.env_SAMPLE` file found in the repository,
-if you don't already have one.
+if you don't already have one:
+
+```sh
+./setup.sh
+```
 
 Inside the `.env` file you can customize the project environment configuration.
 

--- a/backend.sh
+++ b/backend.sh
@@ -28,11 +28,11 @@ init(){
 
   # Notify of environment that user is in.
   if [ "$cli_flag" = "development" ]; then
-    echo 'Frontend:\033[33;33m development environment\033[0m.'
+    echo 'Backend:\033[33;33m development environment\033[0m.'
   elif [ "$cli_flag" = "test" ]; then
-    echo 'Frontend:\033[33;1m test environment\033[0m.'
+    echo 'Backend:\033[33;1m test environment\033[0m.'
   elif [ "$cli_flag" = "production" ]; then
-    echo 'Frontend:\033[32;1m production environment\033[0m.'
+    echo 'Backend:\033[32;1m production environment\033[0m.'
   fi
 
   ENVVAR_SAMPLE=.env_SAMPLE

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "webpack-stream": "3.1.0"
   },
   "devDependencies": {
-    "browser-sync": "2.11.2",
     "cf-component-demo": "git://github.com/cfpb/cf-component-demo.git#0.8.2",
     "chai": "3.5.0",
     "documentation": "4.0.0-beta2",


### PR DESCRIPTION
Fixes for issues found during project setup, following standalone instructions in INSTALL.md

## Additions

- add command for running `setup.sh` - it was unclear from the written instructions that you *need* to run this as step 1 of the install in both vagrant + standalone scenarios. I found this out for standalone, because the MySQL script fails until you run `setup.sh` first.

## Removals

- duplicate browser-sync dependency. During setup.sh got this warning message:

  ```
  npm WARN package.json Dependency 'browser-sync' exists in both dependencies and devDependencies, using 'browser-sync@2.11.2' from dependencies`
 ```
- setup.sh step in front end section is redundant since i added it in step 1. I kept the note about re-installing, though.

## Changes

- change 'frontend' references in `backend.sh` script to say 'backend'

## Testing

-

## Review

- @user

## Screenshots


## Notes

-

## Todos

-

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
