### PR TITLE
Hotfix published pages

### DIFF
--- a/cfgov/v1/migrations/0092_auto_20160623_1335.py
+++ b/cfgov/v1/migrations/0092_auto_20160623_1335.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+from v1.models import CFGOVPage
+
+
+def save_live_pages(apps, schema_editor):
+    for page in CFGOVPage.objects.live():
+        if not page.has_unpublished_changes:
+            revision = page.get_latest_revision()
+            revision.publish()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('v1', '0091_auto_20160609_1603'),
+    ]
+
+    operations = [
+        migrations.RunPython(save_live_pages),
+    ]


### PR DESCRIPTION
All the datetimes were updated in #2188 but pages that were LIVE at the time they were migrated have these changes saved on the page revision but not the page object. This is causing the content to be different in the admin. Thankfully, this does not affect the page's content that is served to the public.

## Additions

- migration that publishes all the revisions for pages that are in a LIVE status, which saves the page that the revision is associated with the content of the revision.

## Testing

- check http://localhost:8000/admin/pages/262/edit/ and note that it has empty agenda item start and end times
- `cfgov/manage.py migrate`
- go back to the page and see the times appear

## Review

- @richaagarwal 
- @rosskarchner 

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)

