### PR TITLE
Update install instructions to specify Elasticsearch 1.7

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -117,18 +117,16 @@ $ brew install homebrew/versions/elasticsearch17
 ```
 
 Just as with autoenv, Homebrew will output similar instructions after installation:
+
 ```bash
-To have launchd start elasticsearch at login:
-    ln -sfv /Users/[YOUR MAC OSX USERNAME]/homebrew/opt/elasticsearch/*.plist ~/Library/LaunchAgents
-Then to load elasticsearch now:
-    launchctl load ~/Library/LaunchAgents/homebrew.mxcl.elasticsearch.plist
-Or, if you don’t want/need launchctl, you can just run:
-    elasticsearch --config=/Users/[YOUR MAC OSX USERNAME]/homebrew/opt/elasticsearch/config/elasticsearch.yml
+To have launchd start homebrew/versions/elasticsearch17 now and restart at login:
+  brew services start homebrew/versions/elasticsearch17
+Or, if you don't want/need a background service you can just run:
+  elasticsearch --config=/Users/[YOUR MAC OSX USERNAME]/homebrew/opt/elasticsearch17/config/elasticsearch.yml
 ```
 
 Any time you work on the project, you’ll need to open a new tab and run that last line.
-If you’ll be working on the project consistently, we suggest using the first option
-utilizing `launchd`.
+If you’ll be working on the project consistently, we suggest using the first option. Note that some older versions of Homebrew may suggest using `launchctl` instead of `brew services`.
 
 If you need to find this info again later, you can run:
 ```bash

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -111,9 +111,9 @@ brew info autoenv
 [Install Elasticsearch 1.7](https://www.elastic.co/guide/en/elasticsearch/reference/1.7/setup.html)
 however you’d like. (We use [Homebrew](http://brew.sh)):
 ```bash
-$ brew tap homebrew/versions
-$ brew search elasticsearch
-$ brew install homebrew/versions/elasticsearch17
+brew tap homebrew/versions
+brew search elasticsearch
+brew install homebrew/versions/elasticsearch17
 ```
 
 Just as with autoenv, Homebrew will output similar instructions after installation:
@@ -130,7 +130,7 @@ If you’ll be working on the project consistently, we suggest using the first o
 
 If you need to find this info again later, you can run:
 ```bash
-$ brew info elasticsearch17
+brew info elasticsearch17
 ```
 
 ### MYSQL Database

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -108,10 +108,12 @@ brew info autoenv
 
 #### Elasticsearch
 
-[Install Elasticsearch](http://www.elastic.co/guide/en/elasticsearch/reference/current/setup.html)
+[Install Elasticsearch 1.7](https://www.elastic.co/guide/en/elasticsearch/reference/1.7/setup.html)
 however you’d like. (We use [Homebrew](http://brew.sh)):
 ```bash
-brew install elasticsearch
+$ brew tap homebrew/versions
+$ brew search elasticsearch
+$ brew install homebrew/versions/elasticsearch17
 ```
 
 Just as with autoenv, Homebrew will output similar instructions after installation:
@@ -130,7 +132,7 @@ utilizing `launchd`.
 
 If you need to find this info again later, you can run:
 ```bash
-brew info elasticsearch
+$ brew info elasticsearch17
 ```
 
 ### MYSQL Database


### PR DESCRIPTION
The current install instructions recommend using `brew install elasticsearch` to install ES, but this installs a version (2.2) which is later than what seems to be the required version (1.7). Specifically, trying to run `sheer_index` fails on ES 2.x. This PR modifies the install instructions to be more specific about what version to install.

## Additions

-

## Removals

-

## Changes

- Update `INSTALL.md` to specify use of Elasticsearch 1.7 now that `brew install elasticsearch` defaults to ES 2.x.

## Testing

- Try following install instructions after clean checkout. The command `python cfgov/manage.py sheer_index -r` in `README.md` will fail if you don't have the right ES version.

## Review

- @richaagarwal

## Screenshots


## Notes

-

## Todos

-

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)

