### PR TITLE
Updates ESLint to `2.13.1` from `2.7.0`

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -95,11 +95,11 @@ rules:
   # Disallow a duplicate case label.
   no-duplicate-case: 2
 
-  # Disallow the use of empty character classes in regular expressions.
-  no-empty-character-class: 2
-
   # Disallows empty statements.
   no-empty: 2
+
+  # Disallow the use of empty character classes in regular expressions.
+  no-empty-character-class: 2
 
   # Disallows assigning to the exception in a catch block.
   no-ex-assign: 2
@@ -135,6 +135,9 @@ rules:
   # Disallows use of the global Math and JSON objects as functions.
   no-obj-calls: 2
 
+  # Disallow use of Object.prototypes builtins directly.
+  no-prototype-builtins: 0
+
   # Disallows multiple spaces in a regular expression literal.
   no-regex-spaces: 2
 
@@ -142,8 +145,14 @@ rules:
   # Array values should be explicitly defined.
   no-sparse-arrays: 2
 
+  # Avoid code that looks like two expressions but is actually one.
+  no-unexpected-multiline: 2
+
   # Disallows unreachable statements after a return, throw, continue, or break.
   no-unreachable: 2
+
+  # Disallow control flow statements in finally blocks.
+  no-unsafe-finally: 2
 
   # Disallows comparisons with the value NaN.
   use-isnan: 2
@@ -161,9 +170,6 @@ rules:
 
   # Enforces that the results of typeof are compared against a valid string.
   valid-typeof: 2
-
-  # Avoid code that looks like two expressions but is actually one.
-  no-unexpected-multiline: 2
 
 
   # Rules for encouraging BEST PRACTICES.
@@ -197,6 +203,11 @@ rules:
   # Enforces default case in switch statements.
   default-case: 2
 
+  # Enforces consistent newlines before or after dots.
+  dot-location:
+    - 2
+    - property
+
   # Enforces use of dot notation whenever possible.
   # `allowKeywords` = false follows ECMAScript version 3 compatible style.
   dot-notation:
@@ -204,11 +215,6 @@ rules:
     -
       allowKeywords: false
       allowPattern: ''
-
-  # Enforces consistent newlines before or after dots.
-  dot-location:
-    - 2
-    - property
 
   # Enforces use of === and !== over == and !=.
   eqeqeq:
@@ -294,6 +300,8 @@ rules:
     - 0
     -
       ignoreArrayIndexes: true
+      enforceConst: true
+      detectObjects: true
 
   # Disallows use of multiple spaces.
   no-multi-spaces:
@@ -310,30 +318,26 @@ rules:
   # Disallows reassignments of native objects.
   no-native-reassign: 2
 
+  # Disallows use of new operator when not part of the assignment or comparison.
+  no-new: 1
+
   # Disallows use of new operator for Function object.
   no-new-func: 2
 
   # Disallows creating new instances of String, Number, and Boolean.
   no-new-wrappers: 2
 
-  # Disallows use of new operator when not part of the assignment or comparison.
-  no-new: 1
+  # Disallows use of octal literals.
+  no-octal: 2
 
   # Disallows use of octal escape sequences in string literals, e.g. "\251".
   no-octal-escape: 2
-
-  # Disallows use of octal literals.
-  no-octal: 2
 
   # Disallow reassignment of function parameters.
   no-param-reassign:
     - 0
     -
       props: false
-
-  # Disallows use of process.env.
-  # Only applicable to Node.js.
-  no-process-env: 2
 
   # Disallows usage of __proto__ property.
   no-proto: 2
@@ -373,11 +377,14 @@ rules:
   # Disallow unnecessary .call() and .apply().
   no-useless-call: 2
 
-  # Disallows use of void operator.
-  no-void: 2
-
   # Disallow unnecessary concatenation of literals or template literals.
   no-useless-concat: 2
+
+  # Disallow unnecessary escape characters.
+  no-useless-escape: 1
+
+  # Disallows use of void operator.
+  no-void: 2
 
   # Disallows use of configurable warning terms in comments, e. g. TODO.
   no-warning-comments:
@@ -426,6 +433,9 @@ rules:
 
   # Rules for VARIABLES.
 
+  # Require or disallow initialization in var declarations.
+  init-declarations: 0
+
   # Disallows the catch clause parameter name being the same as a variable
   # in the outer scope.
   # This rule is needed for IE8- support.
@@ -437,14 +447,17 @@ rules:
   # Disallows labels that share a name with a variable.
   no-label-var: 2
 
-  # Disallows shadowing of names such as arguments.
-  no-shadow-restricted-names: 2
+  # Disallow specified global variables.
+  no-restricted-globals: 2
 
   # Disallows declaring variables already declared in the outer scope.
   no-shadow:
     - 1
     -
       hoist: functions
+
+  # Disallows shadowing of names such as arguments.
+  no-shadow-restricted-names: 2
 
   # Disallows use of undeclared vars unless mentioned in a /*global */ block.
   no-undef:
@@ -462,7 +475,11 @@ rules:
     - 1
     -
       vars: all
+      varsIgnorePattern: ''
       args: after-used
+      argsIgnorePattern: ''
+      caughtErrors: 'none'
+      caughtErrorsIgnorePattern: ''
 
   # Disallows use of variables before they are defined.
   no-use-before-define:
@@ -472,7 +489,7 @@ rules:
       classes: true
 
 
-  # Rules for NODE.JS.
+  # Rules for Node.js and CommonJS.
 
   # Enforce return after a callback.
   # callback, cb, and next are possible callback function names.
@@ -506,11 +523,12 @@ rules:
   # Disallows string concatenation with __dirname and __filename.
   no-path-concat: 2
 
+  # Disallows use of process.env.
+  # Only applicable to Node.js.
+  no-process-env: 2
+
   # Disallows use of process.exit().
   no-process-exit: 1
-
-  # Restrict usage of specified node imports.
-  no-restricted-imports: 0
 
   # Restrict usage of specific node modules.
   no-restricted-modules: 0
@@ -600,6 +618,13 @@ rules:
       exceptions:
         - i
 
+  # Require identifiers to match the provided regular expression.
+  id-match:
+    - 0
+    - '^[a-z]+([A-Z][a-z]+)*$'
+    -
+      properties: false
+
   # Set a specific tab width for your code.
   indent:
     - 2
@@ -624,6 +649,17 @@ rules:
       afterColon: true
       mode: minimum
 
+  # Enforce consistent spacing among keys/values in object literal properties.
+  keyword-spacing:
+    - 1
+    -
+      before: true
+
+  # Disallow mixed 'LF' and 'CRLF' as linebreaks.
+  linebreak-style:
+    - 2
+    - unix
+
   # Enforces empty lines around comments.
   lines-around-comment:
     - 1
@@ -635,15 +671,50 @@ rules:
       allowBlockStart: false
       allowBlockEnd: false
 
-  # Disallow mixed 'LF' and 'CRLF' as linebreaks.
-  linebreak-style:
-    - 2
-    - unix
+  # Specifies maximum depth that blocks can be nested.
+  max-depth:
+    - 1
+    - 5
+
+  # Specifies maximum length of a line in your program.
+  max-len:
+    - 1
+    -
+      code: 80
+      tabWidth: 4
+      comments: 80
+      ignorePattern: ''
+      ignoreTrailingComments: true
+      ignoreUrls: true
+
+  # Enforce a maximum file length.
+  max-lines:
+    - 0
+    -
+      max: 300
+      skipBlankLines: true
+      skipComments: true
 
   # Specify the maximum depth callbacks can be nested.
   max-nested-callbacks:
     - 2
     - 3
+
+  # Limits number of parameters that can be used in the function declaration.
+  max-params:
+    - 1
+    - 5
+
+  # Specifies maximum number of statement allowed in a function.
+  max-statements:
+    - 1
+    - 25
+
+  # Enforce a maximum number of statements allowed per line.
+  max-statements-per-line:
+    - 1
+    -
+      max: 2
 
   # Require a capital letter for constructors.
   new-cap:
@@ -662,8 +733,21 @@ rules:
     - 0
     - always
 
+  # Require or disallow an empty line after var declarations.
+  newline-before-return:
+    - 0
+
+  # Require a newline after each call in a method chain.
+  newline-per-chained-call:
+    - 0
+    -
+      ignoreChainWithDepth: 2
+
   # Disallows use of the Array constructor.
   no-array-constructor: 2
+
+  # Disallows use of bitwise operators.
+  no-bitwise: 0
 
   # Disallow use of the continue statement.
   no-continue: 1
@@ -673,6 +757,9 @@ rules:
 
   # Disallows if as the only statement in an else block.
   no-lonely-if: 2
+
+  # Disallow mixes of different operators.
+  no-mixed-operators: 1
 
   # Disallows mixed spaces and tabs for indentation.
   # Include "smart-tabs" option to suppresses warnings tabs used for alignment.
@@ -694,6 +781,9 @@ rules:
 
   # Disallows use of the Object constructor.
   no-new-object: 2
+
+  # Disallows use of unary operators, ++ and --.
+  no-plusplus: 0
 
   # Disallow use of certain syntax in code.
   no-restricted-syntax:
@@ -720,6 +810,13 @@ rules:
   # Disallow whitespace before properties.
   no-whitespace-before-property: 2
 
+  # Enforce consistent line breaks inside braces.
+  object-curly-newline:
+    - 0
+    -
+      multiline: true
+      minProperties: 3
+
   # Require or disallow padding inside curly braces.
   object-curly-spacing:
     - 1
@@ -727,6 +824,12 @@ rules:
     -
       objectsInObjects: false
       arraysInObjects: false
+
+  # Enforce placing object properties on separate lines.
+  object-property-newline:
+    - 1
+    -
+      allowMultiplePropertiesPerLine: true
 
   # Disallows multiple var statements per function.
   one-var:
@@ -772,13 +875,6 @@ rules:
   require-jsdoc:
     - 1
 
-  # Require identifiers to match the provided regular expression.
-  id-match:
-    - 0
-    - '^[a-z]+([A-Z][a-z]+)*$'
-    -
-      properties: false
-
   # Requires or disallows use of semicolons instead of ASI.
   semi:
     - 2
@@ -790,18 +886,6 @@ rules:
     -
       before: false
       after: true
-
-  # Sort import declarations within module.
-  sort-imports:
-    - 1
-    -
-      ignoreCase: false
-      ignoreMemberSort: false
-      memberSyntaxSortOrder:
-        - none
-        - all
-        - multiple
-        - single
 
   # Enforces sorting variables within the same declaration block.
   sort-vars: 0
@@ -850,6 +934,11 @@ rules:
       markers:
         - /
 
+  # Require or disallow the Unicode BOM.
+  unicode-bom:
+    - 2
+    - never
+
   # Requires regex literals to be wrapped in parentheses.
   wrap-regex: 2
 
@@ -888,7 +977,10 @@ rules:
   no-class-assign: 2
 
   # Disallow arrow functions where they could be confused with comparisons.
-  no-confusing-arrow: 1
+  no-confusing-arrow:
+    - 1
+    -
+      allowParens: true
 
   # Disallow modifying variables that are declared using const.
   no-const-assign: 2
@@ -896,15 +988,35 @@ rules:
   # Disallow duplicate name in class members.
   no-dupe-class-members: 2
 
+  # Disallow duplicate module imports.
+  no-duplicate-imports:
+    - 2
+    -
+      includeExports: true
+
   # Disallow use of the new operator with the Symbol object.
   # This rule should not be used in ES3/5 environments.
   no-new-symbol: 0
 
+  # Restrict usage of specified node imports.
+  no-restricted-imports: 0
+
   # Disallow to use this/super before super() calling in constructors.
   no-this-before-super: 2
 
+  # Disallow unnecessary computed property keys in object literals.
+  no-useless-computed-key: 2
+
   # Disallow unnecessary constructor.
   no-useless-constructor: 2
+
+  # Disallow renaming import/export/destructured assignments to the same name.
+  no-useless-rename:
+    - 2
+    -
+      ignoreImport: false
+      ignoreExport: false
+      ignoreDestructuring: false
 
   # Requires using let or const instead of var.
   # This should be turned on when browser support is better.
@@ -922,10 +1034,6 @@ rules:
   # Suggest using of const declaration for variables that are never modified.
   prefer-const: 1
 
-  # Suggest using the spread operator instead of .apply().
-  # Should not be enabled in ES3/5 environments.
-  prefer-spread: 0
-
   # Suggest using Reflect methods where applicable.
   # Should not be enabled in ES3/5 environments.
   prefer-reflect: 0
@@ -934,12 +1042,33 @@ rules:
   # Should not be enabled in ES3/5 environments.
   prefer-rest-params: 0
 
+  # Suggest using the spread operator instead of .apply().
+  # Should not be enabled in ES3/5 environments.
+  prefer-spread: 0
+
   # Suggest using template literals instead of strings concatenation.
   # Should not be enabled in ES3/5 environments.
   prefer-template: 0
 
   # Disallow generator functions that do not have yield.
   require-yield: 1
+
+  # Enforce spacing between rest and spread operators and their expressions.
+  rest-spread-spacing:
+    - 2
+    - never
+
+  # Sort import declarations within module.
+  sort-imports:
+    - 1
+    -
+      ignoreCase: false
+      ignoreMemberSort: false
+      memberSyntaxSortOrder:
+        - none
+        - all
+        - multiple
+        - single
 
   # Enforce spacing around embedded expressions of template strings.
   template-curly-spacing:
@@ -952,35 +1081,3 @@ rules:
     -
       before: true
       after: false
-
-
-
-  # Rules for LEGACY SUPPORT.
-  # These rules provide compatibility with JSHint/JSLint rules.
-
-  # Specifies maximum depth that blocks can be nested.
-  max-depth:
-    - 1
-    - 5
-
-  # Specifies maximum length of a line in your program.
-  max-len:
-    - 1
-    - 80
-    - 4
-
-  # Limits number of parameters that can be used in the function declaration.
-  max-params:
-    - 1
-    - 5
-
-  # Specifies maximum number of statement allowed in a function.
-  max-statements:
-    - 1
-    - 25
-
-  # Disallows use of bitwise operators.
-  no-bitwise: 0
-
-  # Disallows use of unary operators, ++ and --.
-  no-plusplus: 0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 ### Added
 
 ### Changed
+- Updated ESLint to `2.13.1` from `2.7.0`.
 
 ### Removed
 

--- a/cfgov/unprocessed/js/modules/UStreamPlayer.js
+++ b/cfgov/unprocessed/js/modules/UStreamPlayer.js
@@ -27,7 +27,7 @@ var API = {
       this.player = new UstreamPlayer( this.iFrameProperties.id );
       this.initPlayerEvents();
       this.state.isPlayerInitialized = true;
-    } else if( this.state.isScriptLoading === false ) {
+    } else if ( this.state.isScriptLoading === false ) {
       this.embedScript( this.SCRIPT_API, this.initPlayer.bind( this ) );
     }
   },

--- a/cfgov/unprocessed/js/modules/VideoPlayer.js
+++ b/cfgov/unprocessed/js/modules/VideoPlayer.js
@@ -113,7 +113,7 @@ function _attachIFrame() {
     iFrameElement.onload =
       function oniFrameLoad() { _this.state.setIsIframeLoaded( true ); };
     iFrameContainerElement.appendChild( iFrameElement );
-  } else if( _this.childElements.iframeContainer === null ) {
+  } else if ( _this.childElements.iframeContainer === null ) {
     throw new Error( 'No iframe container element found.' );
   }
 
@@ -147,7 +147,7 @@ function _createElement( tagName, properties ) {
 * @returns {HTMLNode} A dom element.
 */
 function _ensureElement( domElement, msg ) {
-  if( domElement instanceof HTMLElement === false ) {
+  if ( domElement instanceof HTMLElement === false ) {
     msg = msg || DOM_INVALID;
     throw new Error( msg );
   }
@@ -275,7 +275,7 @@ var API = {
   * Function used to play the video player.
   */
   play: function play( ) {
-    if( _isIframeLoaded === false ) {
+    if ( _isIframeLoaded === false ) {
       _attachIFrame();
     }
     this.baseElement.classList.add( CLASSES.VIDEO_PLAYING_STATE );

--- a/cfgov/unprocessed/js/modules/behavior/FlyoutMenu.js
+++ b/cfgov/unprocessed/js/modules/behavior/FlyoutMenu.js
@@ -3,7 +3,6 @@
 // Required modules.
 var BaseTransition = require( '../../modules/transition/BaseTransition' );
 var behavior = require( '../../modules/util/behavior' );
-var dataHook = require( '../../modules/util/data-hook' );
 var EventObserver = require( '../../modules/util/EventObserver' );
 var fnBind = require( '../../modules/util/fn-bind' ).fnBind;
 var standardType = require( '../../modules/util/standard-type' );

--- a/cfgov/unprocessed/js/modules/form-validation.js
+++ b/cfgov/unprocessed/js/modules/form-validation.js
@@ -33,7 +33,8 @@ function _sendError( elem, field ) {
   var type;
 
   for ( var key in field.status ) {
-    if ( field.status.hasOwnProperty( key ) && field.status[key] === false ) {
+    if ( field.status.hasOwnProperty( key ) &&
+         field.status[key] === false ) {
       type = key;
     }
   }

--- a/cfgov/unprocessed/js/modules/util/atomic-helpers.js
+++ b/cfgov/unprocessed/js/modules/util/atomic-helpers.js
@@ -35,7 +35,7 @@ var INIT_FLAG = standardType.STATE_PREFIX + 'atomic_init';
  * @throws {Error} If DOM element passed into the atomic element is not valid.
  */
 function checkDom( element, baseClass ) {
-  _verifyElementExists( element, baseClass);
+  _verifyElementExists( element, baseClass );
   var dom = _verifyClassExists( element, baseClass );
 
   return dom;

--- a/cfgov/unprocessed/js/modules/util/tree-traversal.js
+++ b/cfgov/unprocessed/js/modules/util/tree-traversal.js
@@ -44,7 +44,7 @@ function bfs( node, callback ) {
   var queue = [ node ];
   var currNode;
   var children;
-  while( queue.length > 0 ) {
+  while ( queue.length > 0 ) {
     currNode = queue.shift();
     children = currNode.children;
     if ( children.length > 0 ) {

--- a/cfgov/unprocessed/js/modules/util/web-storage-proxy.js
+++ b/cfgov/unprocessed/js/modules/util/web-storage-proxy.js
@@ -104,7 +104,7 @@ function _getStorageType( storage ) {
     if ( typeof _storage === 'undefined' ) {
       try {
         storage = window.sessionStorage;
-      } catch( err ) {
+      } catch ( err ) {
         // SecurityError was thrown if cookies are off.
         storage = {};
       }

--- a/cfgov/unprocessed/js/organisms/Expandable.js
+++ b/cfgov/unprocessed/js/organisms/Expandable.js
@@ -276,7 +276,7 @@ function Expandable( element ) { // eslint-disable-line max-statements, inline-c
    * https://developer.mozilla.org/en-US/docs/Web/Events/resize.
    */
   function _resizeHandler() {
-    if( _contentAnimated.offsetHeight !== _contentHeight ) {
+    if ( _contentAnimated.offsetHeight !== _contentHeight ) {
       _refreshHeight();
       if ( _isInMobile() ) {
         _collapseBinded();

--- a/gulp/tasks/scripts.js
+++ b/gulp/tasks/scripts.js
@@ -18,7 +18,7 @@ var handleErrors = require( '../utils/handle-errors' );
 var paths = require( '../../config/environment' ).paths;
 var webpackConfig = require( '../../config/webpack-config.js' );
 var webpackStream = require( 'webpack-stream' );
-var configLegacy = require( '../config.js').legacy;
+var configLegacy = require( '../config.js' ).legacy;
 
 /**
  * Standardize webpack workflow for handling script

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "cfgov-refresh",
-  "version": "3.0.0-3.3.12",
+  "version": "3.0.0-3.3.21-hotfix1",
   "dependencies": {
     "abab": {
       "version": "1.0.3",
@@ -30,9 +30,9 @@
       }
     },
     "acorn": {
-      "version": "3.0.4",
-      "from": "acorn@>=3.0.4 <4.0.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.0.4.tgz"
+      "version": "3.2.0",
+      "from": "acorn@>=3.2.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.2.0.tgz"
     },
     "acorn-globals": {
       "version": "1.0.9",
@@ -47,16 +47,9 @@
       }
     },
     "acorn-jsx": {
-      "version": "2.0.1",
-      "from": "acorn-jsx@>=2.0.1 <3.0.0",
-      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-2.0.1.tgz",
-      "dependencies": {
-        "acorn": {
-          "version": "2.7.0",
-          "from": "acorn@>=2.0.1 <3.0.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-2.7.0.tgz"
-        }
-      }
+      "version": "3.0.1",
+      "from": "acorn-jsx@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz"
     },
     "after": {
       "version": "0.8.1",
@@ -77,6 +70,11 @@
       "version": "1.3.0",
       "from": "ansi-escapes@>=1.1.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.3.0.tgz"
+    },
+    "ansi-html": {
+      "version": "0.0.5",
+      "from": "ansi-html@0.0.5",
+      "resolved": "https://registry.npmjs.org/ansi-html/-/ansi-html-0.0.5.tgz"
     },
     "ansi-regex": {
       "version": "2.0.0",
@@ -203,6 +201,11 @@
       "from": "async-each-series@>=0.1.1 <0.2.0",
       "resolved": "https://registry.npmjs.org/async-each-series/-/async-each-series-0.1.1.tgz"
     },
+    "attach-ware": {
+      "version": "1.1.1",
+      "from": "attach-ware@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/attach-ware/-/attach-ware-1.1.1.tgz"
+    },
     "autoprefixer": {
       "version": "6.3.6",
       "from": "autoprefixer@>=6.0.0 <7.0.0",
@@ -213,10 +216,539 @@
       "from": "aws-sign2@>=0.6.0 <0.7.0",
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz"
     },
+    "babel-code-frame": {
+      "version": "6.8.0",
+      "from": "babel-code-frame@>=6.8.0 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.8.0.tgz",
+      "dependencies": {
+        "esutils": {
+          "version": "2.0.2",
+          "from": "esutils@>=2.0.2 <3.0.0",
+          "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+        }
+      }
+    },
+    "babel-core": {
+      "version": "6.9.1",
+      "from": "babel-core@>=6.5.2 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.9.1.tgz",
+      "dependencies": {
+        "lodash": {
+          "version": "4.13.1",
+          "from": "lodash@>=4.2.0 <5.0.0",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.13.1.tgz"
+        },
+        "path-exists": {
+          "version": "1.0.0",
+          "from": "path-exists@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-1.0.0.tgz"
+        },
+        "source-map": {
+          "version": "0.5.6",
+          "from": "source-map@>=0.5.0 <0.6.0",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
+        }
+      }
+    },
+    "babel-generator": {
+      "version": "6.10.0",
+      "from": "babel-generator@>=6.9.0 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.10.0.tgz",
+      "dependencies": {
+        "lodash": {
+          "version": "4.13.1",
+          "from": "lodash@^4.2.0",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.13.1.tgz"
+        },
+        "source-map": {
+          "version": "0.5.6",
+          "from": "source-map@^0.5.0",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
+        }
+      }
+    },
+    "babel-helper-bindify-decorators": {
+      "version": "6.8.0",
+      "from": "babel-helper-bindify-decorators@>=6.8.0 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-bindify-decorators/-/babel-helper-bindify-decorators-6.8.0.tgz"
+    },
+    "babel-helper-builder-binary-assignment-operator-visitor": {
+      "version": "6.8.0",
+      "from": "babel-helper-builder-binary-assignment-operator-visitor@>=6.8.0 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-6.8.0.tgz"
+    },
+    "babel-helper-builder-react-jsx": {
+      "version": "6.9.0",
+      "from": "babel-helper-builder-react-jsx@>=6.8.0 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-builder-react-jsx/-/babel-helper-builder-react-jsx-6.9.0.tgz",
+      "dependencies": {
+        "esutils": {
+          "version": "2.0.2",
+          "from": "esutils@^2.0.0",
+          "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+        },
+        "lodash": {
+          "version": "4.13.1",
+          "from": "lodash@^4.2.0",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.13.1.tgz"
+        }
+      }
+    },
+    "babel-helper-call-delegate": {
+      "version": "6.8.0",
+      "from": "babel-helper-call-delegate@>=6.8.0 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.8.0.tgz"
+    },
+    "babel-helper-define-map": {
+      "version": "6.9.0",
+      "from": "babel-helper-define-map@>=6.9.0 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.9.0.tgz",
+      "dependencies": {
+        "lodash": {
+          "version": "4.13.1",
+          "from": "lodash@^4.2.0",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.13.1.tgz"
+        }
+      }
+    },
+    "babel-helper-explode-assignable-expression": {
+      "version": "6.8.0",
+      "from": "babel-helper-explode-assignable-expression@>=6.8.0 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.8.0.tgz"
+    },
+    "babel-helper-explode-class": {
+      "version": "6.8.0",
+      "from": "babel-helper-explode-class@>=6.8.0 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-explode-class/-/babel-helper-explode-class-6.8.0.tgz"
+    },
+    "babel-helper-function-name": {
+      "version": "6.8.0",
+      "from": "babel-helper-function-name@>=6.8.0 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.8.0.tgz"
+    },
+    "babel-helper-get-function-arity": {
+      "version": "6.8.0",
+      "from": "babel-helper-get-function-arity@>=6.8.0 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.8.0.tgz"
+    },
+    "babel-helper-hoist-variables": {
+      "version": "6.8.0",
+      "from": "babel-helper-hoist-variables@>=6.8.0 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.8.0.tgz"
+    },
+    "babel-helper-optimise-call-expression": {
+      "version": "6.8.0",
+      "from": "babel-helper-optimise-call-expression@>=6.8.0 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.8.0.tgz"
+    },
+    "babel-helper-regex": {
+      "version": "6.9.0",
+      "from": "babel-helper-regex@>=6.8.0 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.9.0.tgz",
+      "dependencies": {
+        "lodash": {
+          "version": "4.13.1",
+          "from": "lodash@^4.2.0",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.13.1.tgz"
+        }
+      }
+    },
+    "babel-helper-remap-async-to-generator": {
+      "version": "6.8.0",
+      "from": "babel-helper-remap-async-to-generator@>=6.8.0 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.8.0.tgz"
+    },
+    "babel-helper-replace-supers": {
+      "version": "6.8.0",
+      "from": "babel-helper-replace-supers@>=6.8.0 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.8.0.tgz"
+    },
+    "babel-helpers": {
+      "version": "6.8.0",
+      "from": "babel-helpers@>=6.8.0 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.8.0.tgz"
+    },
+    "babel-messages": {
+      "version": "6.8.0",
+      "from": "babel-messages@>=6.8.0 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.8.0.tgz"
+    },
+    "babel-plugin-check-es2015-constants": {
+      "version": "6.8.0",
+      "from": "babel-plugin-check-es2015-constants@>=6.3.13 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.8.0.tgz"
+    },
+    "babel-plugin-syntax-async-functions": {
+      "version": "6.8.0",
+      "from": "babel-plugin-syntax-async-functions@>=6.8.0 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.8.0.tgz"
+    },
+    "babel-plugin-syntax-class-constructor-call": {
+      "version": "6.8.0",
+      "from": "babel-plugin-syntax-class-constructor-call@>=6.8.0 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-class-constructor-call/-/babel-plugin-syntax-class-constructor-call-6.8.0.tgz"
+    },
+    "babel-plugin-syntax-class-properties": {
+      "version": "6.8.0",
+      "from": "babel-plugin-syntax-class-properties@>=6.8.0 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-class-properties/-/babel-plugin-syntax-class-properties-6.8.0.tgz"
+    },
+    "babel-plugin-syntax-decorators": {
+      "version": "6.8.0",
+      "from": "babel-plugin-syntax-decorators@>=6.8.0 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-decorators/-/babel-plugin-syntax-decorators-6.8.0.tgz"
+    },
+    "babel-plugin-syntax-do-expressions": {
+      "version": "6.8.0",
+      "from": "babel-plugin-syntax-do-expressions@>=6.8.0 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-do-expressions/-/babel-plugin-syntax-do-expressions-6.8.0.tgz"
+    },
+    "babel-plugin-syntax-exponentiation-operator": {
+      "version": "6.8.0",
+      "from": "babel-plugin-syntax-exponentiation-operator@>=6.8.0 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.8.0.tgz"
+    },
+    "babel-plugin-syntax-export-extensions": {
+      "version": "6.8.0",
+      "from": "babel-plugin-syntax-export-extensions@>=6.8.0 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-export-extensions/-/babel-plugin-syntax-export-extensions-6.8.0.tgz"
+    },
+    "babel-plugin-syntax-flow": {
+      "version": "6.8.0",
+      "from": "babel-plugin-syntax-flow@>=6.3.13 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-flow/-/babel-plugin-syntax-flow-6.8.0.tgz"
+    },
+    "babel-plugin-syntax-function-bind": {
+      "version": "6.8.0",
+      "from": "babel-plugin-syntax-function-bind@>=6.8.0 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-function-bind/-/babel-plugin-syntax-function-bind-6.8.0.tgz"
+    },
+    "babel-plugin-syntax-jsx": {
+      "version": "6.8.0",
+      "from": "babel-plugin-syntax-jsx@>=6.3.13 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.8.0.tgz"
+    },
+    "babel-plugin-syntax-object-rest-spread": {
+      "version": "6.8.0",
+      "from": "babel-plugin-syntax-object-rest-spread@>=6.8.0 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.8.0.tgz"
+    },
+    "babel-plugin-syntax-trailing-function-commas": {
+      "version": "6.8.0",
+      "from": "babel-plugin-syntax-trailing-function-commas@>=6.3.13 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.8.0.tgz"
+    },
+    "babel-plugin-transform-async-to-generator": {
+      "version": "6.8.0",
+      "from": "babel-plugin-transform-async-to-generator@>=6.3.13 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.8.0.tgz"
+    },
+    "babel-plugin-transform-class-constructor-call": {
+      "version": "6.8.0",
+      "from": "babel-plugin-transform-class-constructor-call@>=6.3.13 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-class-constructor-call/-/babel-plugin-transform-class-constructor-call-6.8.0.tgz"
+    },
+    "babel-plugin-transform-class-properties": {
+      "version": "6.9.1",
+      "from": "babel-plugin-transform-class-properties@>=6.3.13 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-class-properties/-/babel-plugin-transform-class-properties-6.9.1.tgz"
+    },
+    "babel-plugin-transform-decorators": {
+      "version": "6.8.0",
+      "from": "babel-plugin-transform-decorators@>=6.3.13 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-decorators/-/babel-plugin-transform-decorators-6.8.0.tgz"
+    },
+    "babel-plugin-transform-do-expressions": {
+      "version": "6.8.0",
+      "from": "babel-plugin-transform-do-expressions@>=6.3.13 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-do-expressions/-/babel-plugin-transform-do-expressions-6.8.0.tgz"
+    },
+    "babel-plugin-transform-es2015-arrow-functions": {
+      "version": "6.8.0",
+      "from": "babel-plugin-transform-es2015-arrow-functions@>=6.3.13 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.8.0.tgz"
+    },
+    "babel-plugin-transform-es2015-block-scoped-functions": {
+      "version": "6.8.0",
+      "from": "babel-plugin-transform-es2015-block-scoped-functions@>=6.3.13 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.8.0.tgz"
+    },
+    "babel-plugin-transform-es2015-block-scoping": {
+      "version": "6.10.1",
+      "from": "babel-plugin-transform-es2015-block-scoping@>=6.9.0 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.10.1.tgz",
+      "dependencies": {
+        "lodash": {
+          "version": "4.13.1",
+          "from": "lodash@^4.2.0",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.13.1.tgz"
+        }
+      }
+    },
+    "babel-plugin-transform-es2015-classes": {
+      "version": "6.9.0",
+      "from": "babel-plugin-transform-es2015-classes@>=6.9.0 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.9.0.tgz"
+    },
+    "babel-plugin-transform-es2015-computed-properties": {
+      "version": "6.8.0",
+      "from": "babel-plugin-transform-es2015-computed-properties@>=6.3.13 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.8.0.tgz"
+    },
+    "babel-plugin-transform-es2015-destructuring": {
+      "version": "6.9.0",
+      "from": "babel-plugin-transform-es2015-destructuring@>=6.9.0 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.9.0.tgz"
+    },
+    "babel-plugin-transform-es2015-duplicate-keys": {
+      "version": "6.8.0",
+      "from": "babel-plugin-transform-es2015-duplicate-keys@>=6.6.0 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.8.0.tgz"
+    },
+    "babel-plugin-transform-es2015-for-of": {
+      "version": "6.8.0",
+      "from": "babel-plugin-transform-es2015-for-of@>=6.6.0 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.8.0.tgz"
+    },
+    "babel-plugin-transform-es2015-function-name": {
+      "version": "6.9.0",
+      "from": "babel-plugin-transform-es2015-function-name@>=6.9.0 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.9.0.tgz"
+    },
+    "babel-plugin-transform-es2015-literals": {
+      "version": "6.8.0",
+      "from": "babel-plugin-transform-es2015-literals@>=6.3.13 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.8.0.tgz"
+    },
+    "babel-plugin-transform-es2015-modules-commonjs": {
+      "version": "6.8.0",
+      "from": "babel-plugin-transform-es2015-modules-commonjs@>=6.6.0 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.8.0.tgz"
+    },
+    "babel-plugin-transform-es2015-object-super": {
+      "version": "6.8.0",
+      "from": "babel-plugin-transform-es2015-object-super@>=6.3.13 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.8.0.tgz"
+    },
+    "babel-plugin-transform-es2015-parameters": {
+      "version": "6.9.0",
+      "from": "babel-plugin-transform-es2015-parameters@>=6.9.0 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.9.0.tgz"
+    },
+    "babel-plugin-transform-es2015-shorthand-properties": {
+      "version": "6.8.0",
+      "from": "babel-plugin-transform-es2015-shorthand-properties@>=6.3.13 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.8.0.tgz"
+    },
+    "babel-plugin-transform-es2015-spread": {
+      "version": "6.8.0",
+      "from": "babel-plugin-transform-es2015-spread@>=6.3.13 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.8.0.tgz"
+    },
+    "babel-plugin-transform-es2015-sticky-regex": {
+      "version": "6.8.0",
+      "from": "babel-plugin-transform-es2015-sticky-regex@>=6.3.13 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.8.0.tgz"
+    },
+    "babel-plugin-transform-es2015-template-literals": {
+      "version": "6.8.0",
+      "from": "babel-plugin-transform-es2015-template-literals@>=6.6.0 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.8.0.tgz"
+    },
+    "babel-plugin-transform-es2015-typeof-symbol": {
+      "version": "6.8.0",
+      "from": "babel-plugin-transform-es2015-typeof-symbol@>=6.6.0 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.8.0.tgz"
+    },
+    "babel-plugin-transform-es2015-unicode-regex": {
+      "version": "6.8.0",
+      "from": "babel-plugin-transform-es2015-unicode-regex@>=6.3.13 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.8.0.tgz"
+    },
+    "babel-plugin-transform-exponentiation-operator": {
+      "version": "6.8.0",
+      "from": "babel-plugin-transform-exponentiation-operator@>=6.3.13 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-6.8.0.tgz"
+    },
+    "babel-plugin-transform-export-extensions": {
+      "version": "6.8.0",
+      "from": "babel-plugin-transform-export-extensions@>=6.3.13 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-export-extensions/-/babel-plugin-transform-export-extensions-6.8.0.tgz"
+    },
+    "babel-plugin-transform-flow-strip-types": {
+      "version": "6.8.0",
+      "from": "babel-plugin-transform-flow-strip-types@>=6.3.13 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-flow-strip-types/-/babel-plugin-transform-flow-strip-types-6.8.0.tgz"
+    },
+    "babel-plugin-transform-function-bind": {
+      "version": "6.8.0",
+      "from": "babel-plugin-transform-function-bind@>=6.3.13 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-function-bind/-/babel-plugin-transform-function-bind-6.8.0.tgz"
+    },
+    "babel-plugin-transform-object-rest-spread": {
+      "version": "6.8.0",
+      "from": "babel-plugin-transform-object-rest-spread@>=6.3.13 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.8.0.tgz"
+    },
+    "babel-plugin-transform-react-display-name": {
+      "version": "6.8.0",
+      "from": "babel-plugin-transform-react-display-name@>=6.3.13 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-display-name/-/babel-plugin-transform-react-display-name-6.8.0.tgz"
+    },
+    "babel-plugin-transform-react-jsx": {
+      "version": "6.8.0",
+      "from": "babel-plugin-transform-react-jsx@>=6.3.13 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx/-/babel-plugin-transform-react-jsx-6.8.0.tgz"
+    },
+    "babel-plugin-transform-react-jsx-source": {
+      "version": "6.9.0",
+      "from": "babel-plugin-transform-react-jsx-source@>=6.3.13 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx-source/-/babel-plugin-transform-react-jsx-source-6.9.0.tgz"
+    },
+    "babel-plugin-transform-regenerator": {
+      "version": "6.9.0",
+      "from": "babel-plugin-transform-regenerator@>=6.9.0 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.9.0.tgz"
+    },
+    "babel-plugin-transform-strict-mode": {
+      "version": "6.8.0",
+      "from": "babel-plugin-transform-strict-mode@>=6.8.0 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.8.0.tgz"
+    },
+    "babel-preset-es2015": {
+      "version": "6.9.0",
+      "from": "babel-preset-es2015@>=6.5.0 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-preset-es2015/-/babel-preset-es2015-6.9.0.tgz"
+    },
+    "babel-preset-react": {
+      "version": "6.5.0",
+      "from": "babel-preset-react@>=6.5.0 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-preset-react/-/babel-preset-react-6.5.0.tgz"
+    },
+    "babel-preset-stage-0": {
+      "version": "6.5.0",
+      "from": "babel-preset-stage-0@>=6.5.0 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-preset-stage-0/-/babel-preset-stage-0-6.5.0.tgz"
+    },
+    "babel-preset-stage-1": {
+      "version": "6.5.0",
+      "from": "babel-preset-stage-1@>=6.3.13 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-preset-stage-1/-/babel-preset-stage-1-6.5.0.tgz"
+    },
+    "babel-preset-stage-2": {
+      "version": "6.5.0",
+      "from": "babel-preset-stage-2@>=6.3.13 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-preset-stage-2/-/babel-preset-stage-2-6.5.0.tgz"
+    },
+    "babel-preset-stage-3": {
+      "version": "6.5.0",
+      "from": "babel-preset-stage-3@>=6.3.13 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-preset-stage-3/-/babel-preset-stage-3-6.5.0.tgz"
+    },
+    "babel-register": {
+      "version": "6.9.0",
+      "from": "babel-register@>=6.9.0 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.9.0.tgz",
+      "dependencies": {
+        "lodash": {
+          "version": "4.13.1",
+          "from": "lodash@^4.2.0",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.13.1.tgz"
+        },
+        "minimist": {
+          "version": "0.0.8",
+          "from": "minimist@0.0.8",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "from": "mkdirp@>=0.5.1 <0.6.0",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz"
+        },
+        "path-exists": {
+          "version": "1.0.0",
+          "from": "path-exists@^1.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-1.0.0.tgz"
+        }
+      }
+    },
+    "babel-runtime": {
+      "version": "6.9.2",
+      "from": "babel-runtime@>=6.9.1 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.9.2.tgz"
+    },
+    "babel-template": {
+      "version": "6.9.0",
+      "from": "babel-template@>=6.9.0 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.9.0.tgz",
+      "dependencies": {
+        "lodash": {
+          "version": "4.13.1",
+          "from": "lodash@^4.2.0",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.13.1.tgz"
+        }
+      }
+    },
+    "babel-traverse": {
+      "version": "6.9.0",
+      "from": "babel-traverse@>=6.5.0 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.9.0.tgz",
+      "dependencies": {
+        "globals": {
+          "version": "8.18.0",
+          "from": "globals@>=8.3.0 <9.0.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-8.18.0.tgz"
+        },
+        "lodash": {
+          "version": "4.13.1",
+          "from": "lodash@^4.2.0",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.13.1.tgz"
+        }
+      }
+    },
+    "babel-types": {
+      "version": "6.10.0",
+      "from": "babel-types@>=6.7.2 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.10.0.tgz",
+      "dependencies": {
+        "esutils": {
+          "version": "2.0.2",
+          "from": "esutils@^2.0.2",
+          "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+        },
+        "lodash": {
+          "version": "4.13.1",
+          "from": "lodash@^4.2.0",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.13.1.tgz"
+        }
+      }
+    },
+    "babelify": {
+      "version": "7.3.0",
+      "from": "babelify@>=7.2.0 <8.0.0",
+      "resolved": "https://registry.npmjs.org/babelify/-/babelify-7.3.0.tgz",
+      "dependencies": {
+        "object-assign": {
+          "version": "4.1.0",
+          "from": "object-assign@>=4.0.0 <5.0.0",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz"
+        }
+      }
+    },
+    "babylon": {
+      "version": "6.8.1",
+      "from": "babylon@>=6.5.2 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.8.1.tgz"
+    },
     "backo2": {
       "version": "1.0.2",
       "from": "backo2@1.0.2",
       "resolved": "https://registry.npmjs.org/backo2/-/backo2-1.0.2.tgz"
+    },
+    "bail": {
+      "version": "1.0.0",
+      "from": "bail@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/bail/-/bail-1.0.0.tgz"
     },
     "balanced-match": {
       "version": "0.3.0",
@@ -331,9 +863,21 @@
       "resolved": "https://registry.npmjs.org/blob/-/blob-0.0.4.tgz"
     },
     "bluebird": {
-      "version": "3.3.4",
+      "version": "3.4.1",
       "from": "bluebird@>=3.1.1 <4.0.0",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.3.4.tgz"
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.1.tgz"
+    },
+    "body-parser": {
+      "version": "1.14.2",
+      "from": "body-parser@>=1.14.0 <1.15.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.14.2.tgz",
+      "dependencies": {
+        "qs": {
+          "version": "5.2.0",
+          "from": "qs@5.2.0",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-5.2.0.tgz"
+        }
+      }
     },
     "boom": {
       "version": "2.10.1",
@@ -366,6 +910,11 @@
       "version": "1.8.3",
       "from": "braces@>=1.8.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.3.tgz"
+    },
+    "browser-resolve": {
+      "version": "1.11.2",
+      "from": "browser-resolve@>=1.7.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.2.tgz"
     },
     "browser-sync": {
       "version": "2.11.2",
@@ -409,6 +958,11 @@
         }
       }
     },
+    "buffer-shims": {
+      "version": "1.0.0",
+      "from": "buffer-shims@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz"
+    },
     "buffer-to-vinyl": {
       "version": "1.1.0",
       "from": "buffer-to-vinyl@>=1.0.0 <2.0.0",
@@ -440,6 +994,11 @@
       "version": "0.0.7",
       "from": "builtins@0.0.7",
       "resolved": "https://registry.npmjs.org/builtins/-/builtins-0.0.7.tgz"
+    },
+    "bytes": {
+      "version": "2.2.0",
+      "from": "bytes@2.2.0",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.2.0.tgz"
     },
     "caller-path": {
       "version": "0.1.0",
@@ -501,6 +1060,11 @@
       "from": "caw@>=1.0.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/caw/-/caw-1.2.0.tgz"
     },
+    "ccount": {
+      "version": "1.0.0",
+      "from": "ccount@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-1.0.0.tgz"
+    },
     "center-align": {
       "version": "0.1.3",
       "from": "center-align@>=0.1.1 <0.2.0",
@@ -517,6 +1081,26 @@
       "version": "1.1.3",
       "from": "chalk@>=1.1.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz"
+    },
+    "character-entities": {
+      "version": "1.0.0",
+      "from": "character-entities@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-1.0.0.tgz"
+    },
+    "character-entities-html4": {
+      "version": "1.0.0",
+      "from": "character-entities-html4@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-1.0.0.tgz"
+    },
+    "character-entities-legacy": {
+      "version": "1.0.0",
+      "from": "character-entities-legacy@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-1.0.0.tgz"
+    },
+    "character-reference-invalid": {
+      "version": "1.0.0",
+      "from": "character-reference-invalid@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-1.0.0.tgz"
     },
     "chokidar": {
       "version": "1.4.1",
@@ -683,6 +1267,11 @@
       "from": "code-point-at@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.0.0.tgz"
     },
+    "collapse-white-space": {
+      "version": "1.0.0",
+      "from": "collapse-white-space@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/collapse-white-space/-/collapse-white-space-1.0.0.tgz"
+    },
     "colors": {
       "version": "1.1.2",
       "from": "colors@>=1.1.2 <1.2.0",
@@ -787,10 +1376,20 @@
       "from": "constants-browserify@0.0.1",
       "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-0.0.1.tgz"
     },
+    "content-type": {
+      "version": "1.0.2",
+      "from": "content-type@>=1.0.1 <1.1.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.2.tgz"
+    },
     "convert-source-map": {
       "version": "1.2.0",
       "from": "convert-source-map@>=1.1.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.2.0.tgz"
+    },
+    "core-js": {
+      "version": "2.4.0",
+      "from": "core-js@>=2.4.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.4.0.tgz"
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -974,6 +1573,18 @@
       "version": "1.0.0",
       "from": "deap@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/deap/-/deap-1.0.0.tgz"
+    },
+    "debounce": {
+      "version": "1.0.0",
+      "from": "debounce@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/debounce/-/debounce-1.0.0.tgz",
+      "dependencies": {
+        "date-now": {
+          "version": "1.0.1",
+          "from": "date-now@1.0.1",
+          "resolved": "https://registry.npmjs.org/date-now/-/date-now-1.0.1.tgz"
+        }
+      }
     },
     "debug": {
       "version": "2.2.0",
@@ -1199,6 +1810,23 @@
       "from": "defaults@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz"
     },
+    "define-properties": {
+      "version": "1.1.2",
+      "from": "define-properties@>=1.1.2 <2.0.0",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
+      "dependencies": {
+        "object-keys": {
+          "version": "1.0.9",
+          "from": "object-keys@^1.0.8",
+          "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.9.tgz"
+        }
+      }
+    },
+    "defined": {
+      "version": "1.0.0",
+      "from": "defined@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz"
+    },
     "del": {
       "version": "2.2.0",
       "from": "del@2.2.0",
@@ -1231,6 +1859,28 @@
       "from": "destroy@>=1.0.4 <1.1.0",
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz"
     },
+    "detab": {
+      "version": "1.0.2",
+      "from": "detab@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/detab/-/detab-1.0.2.tgz"
+    },
+    "detect-indent": {
+      "version": "3.0.1",
+      "from": "detect-indent@>=3.0.1 <4.0.0",
+      "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-3.0.1.tgz"
+    },
+    "detective": {
+      "version": "4.3.1",
+      "from": "detective@>=4.0.0 <5.0.0",
+      "resolved": "https://registry.npmjs.org/detective/-/detective-4.3.1.tgz",
+      "dependencies": {
+        "acorn": {
+          "version": "1.2.2",
+          "from": "acorn@>=1.0.3 <2.0.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz"
+        }
+      }
+    },
     "dev-ip": {
       "version": "1.0.1",
       "from": "dev-ip@>=1.0.1 <2.0.0",
@@ -1241,10 +1891,163 @@
       "from": "diff@1.4.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-1.4.0.tgz"
     },
+    "disparity": {
+      "version": "2.0.0",
+      "from": "disparity@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/disparity/-/disparity-2.0.0.tgz"
+    },
     "doctrine": {
       "version": "1.1.0",
       "from": "doctrine@1.1.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.1.0.tgz"
+    },
+    "documentation-theme-default": {
+      "version": "3.0.0-beta",
+      "from": "documentation-theme-default@3.0.0-beta",
+      "resolved": "https://registry.npmjs.org/documentation-theme-default/-/documentation-theme-default-3.0.0-beta.tgz",
+      "dependencies": {
+        "async": {
+          "version": "0.2.10",
+          "from": "async@>=0.2.6 <0.3.0",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
+        },
+        "camelcase": {
+          "version": "2.1.1",
+          "from": "camelcase@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz"
+        },
+        "doctrine": {
+          "version": "0.7.2",
+          "from": "doctrine@>=0.7.2 <0.8.0",
+          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-0.7.2.tgz"
+        },
+        "documentation-theme-utils": {
+          "version": "1.3.1",
+          "from": "documentation-theme-utils@>=1.2.1 <2.0.0",
+          "resolved": "https://registry.npmjs.org/documentation-theme-utils/-/documentation-theme-utils-1.3.1.tgz"
+        },
+        "glob": {
+          "version": "6.0.4",
+          "from": "glob@>=6.0.1 <7.0.0",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz"
+        },
+        "glob-stream": {
+          "version": "5.3.2",
+          "from": "glob-stream@>=5.3.2 <6.0.0",
+          "resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-5.3.2.tgz",
+          "dependencies": {
+            "glob": {
+              "version": "5.0.15",
+              "from": "glob@>=5.0.3 <6.0.0",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz"
+            },
+            "readable-stream": {
+              "version": "1.0.34",
+              "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz"
+            },
+            "through2": {
+              "version": "0.6.5",
+              "from": "through2@>=0.6.0 <0.7.0",
+              "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz"
+            }
+          }
+        },
+        "handlebars": {
+          "version": "3.0.3",
+          "from": "handlebars@>=3.0.3 <4.0.0",
+          "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-3.0.3.tgz"
+        },
+        "micromatch": {
+          "version": "2.3.8",
+          "from": "micromatch@>=2.3.7 <3.0.0",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.8.tgz"
+        },
+        "minimatch": {
+          "version": "3.0.0",
+          "from": "minimatch@>=3.0.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz"
+        },
+        "minimist": {
+          "version": "0.0.8",
+          "from": "minimist@0.0.8",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "from": "mkdirp@^0.5.0",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz"
+        },
+        "object-assign": {
+          "version": "4.1.0",
+          "from": "object-assign@^4.0.0",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz"
+        },
+        "ordered-read-streams": {
+          "version": "0.3.0",
+          "from": "ordered-read-streams@>=0.3.0 <0.4.0",
+          "resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.3.0.tgz"
+        },
+        "remark": {
+          "version": "3.2.3",
+          "from": "remark@>=3.0.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/remark/-/remark-3.2.3.tgz"
+        },
+        "strip-bom": {
+          "version": "2.0.0",
+          "from": "strip-bom@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz"
+        },
+        "uglify-js": {
+          "version": "2.3.6",
+          "from": "uglify-js@>=2.3.0 <2.4.0",
+          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.3.6.tgz",
+          "dependencies": {
+            "optimist": {
+              "version": "0.3.7",
+              "from": "optimist@>=0.3.5 <0.4.0",
+              "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz"
+            }
+          }
+        },
+        "unique-stream": {
+          "version": "2.2.1",
+          "from": "unique-stream@>=2.0.2 <3.0.0",
+          "resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-2.2.1.tgz"
+        },
+        "user-home": {
+          "version": "2.0.0",
+          "from": "user-home@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz"
+        },
+        "vinyl": {
+          "version": "1.1.1",
+          "from": "vinyl@^1.0.0",
+          "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.1.1.tgz"
+        },
+        "vinyl-fs": {
+          "version": "2.4.3",
+          "from": "vinyl-fs@^2.0.0",
+          "resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-2.4.3.tgz"
+        }
+      }
+    },
+    "documentation-theme-utils": {
+      "version": "2.0.2",
+      "from": "documentation-theme-utils@>=2.0.2 <3.0.0",
+      "resolved": "https://registry.npmjs.org/documentation-theme-utils/-/documentation-theme-utils-2.0.2.tgz",
+      "dependencies": {
+        "doctrine": {
+          "version": "1.2.2",
+          "from": "doctrine@>=1.2.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.2.2.tgz"
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "from": "isarray@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+        }
+      }
     },
     "domain-browser": {
       "version": "1.1.7",
@@ -1384,10 +2187,20 @@
       "from": "ee-first@1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz"
     },
+    "elegant-spinner": {
+      "version": "1.0.1",
+      "from": "elegant-spinner@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/elegant-spinner/-/elegant-spinner-1.0.1.tgz"
+    },
     "emitter-steward": {
       "version": "1.0.0",
       "from": "emitter-steward@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/emitter-steward/-/emitter-steward-1.0.0.tgz"
+    },
+    "emoji-regex": {
+      "version": "6.0.0",
+      "from": "emoji-regex@>=6.0.0 <7.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-6.0.0.tgz"
     },
     "end-of-stream": {
       "version": "0.1.5",
@@ -1471,9 +2284,16 @@
       "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.0.tgz"
     },
     "es6-map": {
-      "version": "0.1.3",
+      "version": "0.1.4",
       "from": "es6-map@>=0.1.3 <0.2.0",
-      "resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.3.tgz"
+      "resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.4.tgz",
+      "dependencies": {
+        "es6-symbol": {
+          "version": "3.1.0",
+          "from": "es6-symbol@>=3.1.0 <3.2.0",
+          "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.0.tgz"
+        }
+      }
     },
     "es6-promise": {
       "version": "3.1.2",
@@ -1533,9 +2353,9 @@
       "resolved": "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz"
     },
     "eslint": {
-      "version": "2.7.0",
+      "version": "2.13.1",
       "from": "eslint@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-2.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-2.13.1.tgz",
       "dependencies": {
         "cli-width": {
           "version": "2.1.0",
@@ -1543,9 +2363,9 @@
           "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.1.0.tgz"
         },
         "doctrine": {
-          "version": "1.2.1",
-          "from": "doctrine@>=1.2.1 <2.0.0",
-          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.2.1.tgz",
+          "version": "1.2.2",
+          "from": "doctrine@>=1.2.2 <2.0.0",
+          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.2.2.tgz",
           "dependencies": {
             "esutils": {
               "version": "1.1.6",
@@ -1570,9 +2390,9 @@
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
         },
         "lodash": {
-          "version": "4.8.2",
+          "version": "4.13.1",
           "from": "lodash@>=4.0.0 <5.0.0",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.8.2.tgz"
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.13.1.tgz"
         },
         "minimist": {
           "version": "0.0.8",
@@ -1592,9 +2412,9 @@
       }
     },
     "espree": {
-      "version": "3.1.3",
-      "from": "espree@3.1.3",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-3.1.3.tgz"
+      "version": "3.1.6",
+      "from": "espree@>=3.1.6 <4.0.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-3.1.6.tgz"
     },
     "esprima": {
       "version": "2.7.2",
@@ -1612,9 +2432,9 @@
           "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.1.1.tgz"
         },
         "object-assign": {
-          "version": "4.0.1",
-          "from": "object-assign@>=4.0.1 <5.0.0",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz"
+          "version": "4.1.0",
+          "from": "object-assign@^4.0.1",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz"
         }
       }
     },
@@ -1719,6 +2539,11 @@
       "from": "extend-shallow@>=2.0.1 <3.0.0",
       "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz"
     },
+    "extend.js": {
+      "version": "0.0.2",
+      "from": "extend.js@0.0.2",
+      "resolved": "https://registry.npmjs.org/extend.js/-/extend.js-0.0.2.tgz"
+    },
     "extglob": {
       "version": "0.3.2",
       "from": "extglob@>=0.3.1 <0.4.0",
@@ -1738,6 +2563,11 @@
       "version": "1.1.3",
       "from": "fast-levenshtein@>=1.1.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.1.3.tgz"
+    },
+    "faye-websocket": {
+      "version": "0.10.0",
+      "from": "faye-websocket@>=0.10.0 <0.11.0",
+      "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.10.0.tgz"
     },
     "fd-slicer": {
       "version": "1.0.1",
@@ -1760,9 +2590,9 @@
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-1.2.4.tgz",
       "dependencies": {
         "object-assign": {
-          "version": "4.0.1",
-          "from": "object-assign@>=4.0.1 <5.0.0",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz"
+          "version": "4.1.0",
+          "from": "object-assign@^4.0.1",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz"
         }
       }
     },
@@ -1935,6 +2765,11 @@
       "version": "0.1.4",
       "from": "for-own@>=0.1.3 <0.2.0",
       "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.4.tgz"
+    },
+    "foreach": {
+      "version": "2.0.5",
+      "from": "foreach@>=2.0.5 <3.0.0",
+      "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz"
     },
     "forever-agent": {
       "version": "0.6.1",
@@ -2605,6 +3440,11 @@
         }
       }
     },
+    "function-bind": {
+      "version": "1.1.0",
+      "from": "function-bind@>=1.0.2 <2.0.0",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.0.tgz"
+    },
     "gaze": {
       "version": "0.5.2",
       "from": "gaze@>=0.5.1 <0.6.0",
@@ -2620,6 +3460,11 @@
       "from": "generate-object-property@>=1.1.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz"
     },
+    "get-comments": {
+      "version": "1.0.1",
+      "from": "get-comments@>=1.0.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/get-comments/-/get-comments-1.0.1.tgz"
+    },
     "get-proxy": {
       "version": "1.1.0",
       "from": "get-proxy@>=1.0.1 <2.0.0",
@@ -2634,6 +3479,21 @@
       "version": "3.0.3",
       "from": "gifsicle@>=3.0.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/gifsicle/-/gifsicle-3.0.3.tgz"
+    },
+    "git-up": {
+      "version": "2.0.2",
+      "from": "git-up@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/git-up/-/git-up-2.0.2.tgz"
+    },
+    "git-url-parse": {
+      "version": "6.0.3",
+      "from": "git-url-parse@>=6.0.1 <7.0.0",
+      "resolved": "https://registry.npmjs.org/git-url-parse/-/git-url-parse-6.0.3.tgz"
+    },
+    "github-slugger": {
+      "version": "1.1.1",
+      "from": "github-slugger@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/github-slugger/-/github-slugger-1.1.1.tgz"
     },
     "glob": {
       "version": "7.0.3",
@@ -2683,9 +3543,14 @@
       "resolved": "https://registry.npmjs.org/glob2base/-/glob2base-0.0.12.tgz"
     },
     "globals": {
-      "version": "9.4.0",
+      "version": "9.8.0",
       "from": "globals@>=9.2.0 <10.0.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-9.4.0.tgz"
+      "resolved": "https://registry.npmjs.org/globals/-/globals-9.8.0.tgz"
+    },
+    "globals-docs": {
+      "version": "2.2.0",
+      "from": "globals-docs@>=2.1.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/globals-docs/-/globals-docs-2.2.0.tgz"
     },
     "globby": {
       "version": "4.0.0",
@@ -2928,6 +3793,18 @@
       "version": "1.2.0",
       "from": "gulp-decompress@>=1.2.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/gulp-decompress/-/gulp-decompress-1.2.0.tgz"
+    },
+    "gulp-eslint": {
+      "version": "2.0.0",
+      "from": "gulp-eslint@2.0.0",
+      "resolved": "https://registry.npmjs.org/gulp-eslint/-/gulp-eslint-2.0.0.tgz",
+      "dependencies": {
+        "object-assign": {
+          "version": "4.1.0",
+          "from": "object-assign@^4.0.1",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz"
+        }
+      }
     },
     "gulp-header": {
       "version": "1.7.1",
@@ -3284,10 +4161,25 @@
       "from": "hawk@>=3.1.0 <3.2.0",
       "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz"
     },
+    "he": {
+      "version": "0.5.0",
+      "from": "he@>=0.5.0 <0.6.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-0.5.0.tgz"
+    },
+    "highlight.js": {
+      "version": "9.4.0",
+      "from": "highlight.js@>=9.1.0 <10.0.0",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.4.0.tgz"
+    },
     "hoek": {
       "version": "2.16.3",
       "from": "hoek@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
+    },
+    "home-or-tmp": {
+      "version": "1.0.0",
+      "from": "home-or-tmp@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-1.0.0.tgz"
     },
     "hooker": {
       "version": "0.2.3",
@@ -3334,15 +4226,20 @@
       "from": "https-browserify@0.0.0",
       "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-0.0.0.tgz"
     },
+    "iconv-lite": {
+      "version": "0.4.13",
+      "from": "iconv-lite@0.4.13",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz"
+    },
     "ieee754": {
       "version": "1.1.6",
       "from": "ieee754@>=1.1.4 <2.0.0",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.6.tgz"
     },
     "ignore": {
-      "version": "3.0.14",
-      "from": "ignore@>=3.0.10 <4.0.0",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.0.14.tgz"
+      "version": "3.1.3",
+      "from": "ignore@>=3.1.2 <4.0.0",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.1.3.tgz"
     },
     "image-size": {
       "version": "0.4.0",
@@ -3526,6 +4423,11 @@
       "version": "1.0.0",
       "from": "interpret@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.0.0.tgz"
+    },
+    "invariant": {
+      "version": "2.2.1",
+      "from": "invariant@>=2.2.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.1.tgz"
     },
     "invert-kv": {
       "version": "1.0.0",
@@ -3712,6 +4614,11 @@
       "from": "is-retry-allowed@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.0.0.tgz"
     },
+    "is-ssh": {
+      "version": "1.3.0",
+      "from": "is-ssh@>=1.3.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/is-ssh/-/is-ssh-1.3.0.tgz"
+    },
     "is-stream": {
       "version": "1.0.1",
       "from": "is-stream@>=1.0.1 <2.0.0",
@@ -3732,6 +4639,11 @@
       "from": "is-typedarray@>=1.0.0 <1.1.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz"
     },
+    "is-unc-path": {
+      "version": "0.1.1",
+      "from": "is-unc-path@>=0.1.1 <0.2.0",
+      "resolved": "https://registry.npmjs.org/is-unc-path/-/is-unc-path-0.1.1.tgz"
+    },
     "is-url": {
       "version": "1.2.1",
       "from": "is-url@>=1.2.0 <2.0.0",
@@ -3746,6 +4658,11 @@
       "version": "0.3.0",
       "from": "is-valid-glob@>=0.3.0 <0.4.0",
       "resolved": "https://registry.npmjs.org/is-valid-glob/-/is-valid-glob-0.3.0.tgz"
+    },
+    "is-windows": {
+      "version": "0.1.1",
+      "from": "is-windows@>=0.1.1 <0.2.0",
+      "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-0.1.1.tgz"
     },
     "is-zip": {
       "version": "1.0.0",
@@ -3922,6 +4839,11 @@
       "from": "js-base64@>=2.1.9 <3.0.0",
       "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz"
     },
+    "js-tokens": {
+      "version": "1.0.3",
+      "from": "js-tokens@>=1.0.2 <2.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.3.tgz"
+    },
     "js-yaml": {
       "version": "3.5.5",
       "from": "js-yaml@>=3.5.5 <3.6.0",
@@ -3931,6 +4853,16 @@
       "version": "0.1.0",
       "from": "jsbn@>=0.1.0 <0.2.0",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz"
+    },
+    "jsdoc-inline-lex": {
+      "version": "1.0.1",
+      "from": "jsdoc-inline-lex@>=1.0.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/jsdoc-inline-lex/-/jsdoc-inline-lex-1.0.1.tgz"
+    },
+    "jsesc": {
+      "version": "0.5.0",
+      "from": "jsesc@>=0.5.0 <0.6.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz"
     },
     "json-schema": {
       "version": "0.2.2",
@@ -3967,10 +4899,20 @@
       "from": "jsonify@>=0.0.0 <0.1.0",
       "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz"
     },
+    "jsonparse": {
+      "version": "1.2.0",
+      "from": "jsonparse@>=1.1.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.2.0.tgz"
+    },
     "jsonpointer": {
       "version": "2.0.0",
       "from": "jsonpointer@2.0.0",
       "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz"
+    },
+    "JSONStream": {
+      "version": "1.1.2",
+      "from": "JSONStream@>=1.0.3 <2.0.0",
+      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.1.2.tgz"
     },
     "jsprim": {
       "version": "1.2.2",
@@ -4065,6 +5007,11 @@
       "version": "1.1.0",
       "from": "limiter@>=1.0.5 <2.0.0",
       "resolved": "https://registry.npmjs.org/limiter/-/limiter-1.1.0.tgz"
+    },
+    "livereload-js": {
+      "version": "2.2.2",
+      "from": "livereload-js@>=2.2.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/livereload-js/-/livereload-js-2.2.2.tgz"
     },
     "load-json-file": {
       "version": "1.1.0",
@@ -4404,6 +5351,11 @@
       "from": "log-symbols@>=1.0.2 <2.0.0",
       "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz"
     },
+    "log-update": {
+      "version": "1.0.2",
+      "from": "log-update@>=1.0.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/log-update/-/log-update-1.0.2.tgz"
+    },
     "logalot": {
       "version": "2.1.0",
       "from": "logalot@>=2.0.0 <3.0.0",
@@ -4418,6 +5370,16 @@
       "version": "1.0.1",
       "from": "longest@>=1.0.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
+    },
+    "longest-streak": {
+      "version": "1.0.0",
+      "from": "longest-streak@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-1.0.0.tgz"
+    },
+    "loose-envify": {
+      "version": "1.2.0",
+      "from": "loose-envify@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.2.0.tgz"
     },
     "loud-rejection": {
       "version": "1.3.0",
@@ -4444,6 +5406,11 @@
       "from": "lru-cache@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz"
     },
+    "map-cache": {
+      "version": "0.2.2",
+      "from": "map-cache@>=0.2.0 <0.3.0",
+      "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz"
+    },
     "map-obj": {
       "version": "1.0.1",
       "from": "map-obj@>=1.0.0 <2.0.0",
@@ -4454,6 +5421,11 @@
       "from": "map-stream@0.0.4",
       "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.0.4.tgz"
     },
+    "markdown-table": {
+      "version": "0.4.0",
+      "from": "markdown-table@>=0.4.0 <0.5.0",
+      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-0.4.0.tgz"
+    },
     "marked": {
       "version": "0.3.5",
       "from": "marked@0.3.5",
@@ -4463,6 +5435,21 @@
       "version": "1.6.1",
       "from": "marked-terminal@>=1.6.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/marked-terminal/-/marked-terminal-1.6.1.tgz"
+    },
+    "mdast-util-inject": {
+      "version": "1.1.0",
+      "from": "mdast-util-inject@>=1.1.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-inject/-/mdast-util-inject-1.1.0.tgz"
+    },
+    "mdast-util-to-string": {
+      "version": "1.0.2",
+      "from": "mdast-util-to-string@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-1.0.2.tgz"
+    },
+    "media-typer": {
+      "version": "0.3.0",
+      "from": "media-typer@0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz"
     },
     "memory-fs": {
       "version": "0.3.0",
@@ -4590,6 +5577,18 @@
           "version": "3.31.0",
           "from": "yargs@3.31.0",
           "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.31.0.tgz"
+        }
+      }
+    },
+    "module-deps": {
+      "version": "4.0.7",
+      "from": "module-deps@>=4.0.2 <5.0.0",
+      "resolved": "https://registry.npmjs.org/module-deps/-/module-deps-4.0.7.tgz",
+      "dependencies": {
+        "duplexer2": {
+          "version": "0.1.4",
+          "from": "duplexer2@>=0.1.2 <0.2.0",
+          "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz"
         }
       }
     },
@@ -4728,6 +5727,11 @@
       "version": "0.1.2",
       "from": "normalize-range@>=0.1.2 <0.2.0",
       "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz"
+    },
+    "normalize-uri": {
+      "version": "1.0.0",
+      "from": "normalize-uri@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-uri/-/normalize-uri-1.0.0.tgz"
     },
     "npm": {
       "version": "2.15.5",
@@ -5501,7 +6505,7 @@
               "dependencies": {
                 "async": {
                   "version": "1.5.2",
-                  "from": "async@>=1.4.0 <2.0.0",
+                  "from": "async@>=1.5.2 <2.0.0",
                   "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
                 }
               }
@@ -5600,7 +6604,7 @@
             },
             "hawk": {
               "version": "3.1.3",
-              "from": "hawk@>=3.1.0 <3.2.0",
+              "from": "hawk@>=3.1.3 <3.2.0",
               "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
               "dependencies": {
                 "boom": {
@@ -5679,7 +6683,7 @@
                     },
                     "ecc-jsbn": {
                       "version": "0.1.1",
-                      "from": "ecc-jsbn@>=0.0.1 <1.0.0",
+                      "from": "ecc-jsbn@>=0.1.1 <0.2.0",
                       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz"
                     },
                     "getpass": {
@@ -5699,7 +6703,7 @@
                     },
                     "tweetnacl": {
                       "version": "0.13.3",
-                      "from": "tweetnacl@>=0.13.0 <1.0.0",
+                      "from": "tweetnacl@>=0.13.0 <0.14.0",
                       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.13.3.tgz"
                     }
                   }
@@ -5940,6 +6944,11 @@
         }
       }
     },
+    "npm-prefix": {
+      "version": "1.2.0",
+      "from": "npm-prefix@>=1.0.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/npm-prefix/-/npm-prefix-1.2.0.tgz"
+    },
     "npmi": {
       "version": "1.0.1",
       "from": "npmi@>=1.0.1 <2.0.0",
@@ -5984,6 +6993,18 @@
       "version": "0.9.2",
       "from": "object-path@>=0.9.0 <0.10.0",
       "resolved": "https://registry.npmjs.org/object-path/-/object-path-0.9.2.tgz"
+    },
+    "object.assign": {
+      "version": "4.0.3",
+      "from": "object.assign@>=4.0.1 <5.0.0",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.0.3.tgz",
+      "dependencies": {
+        "object-keys": {
+          "version": "1.0.9",
+          "from": "object-keys@>=1.0.9 <2.0.0",
+          "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.9.tgz"
+        }
+      }
     },
     "object.omit": {
       "version": "2.0.0",
@@ -6138,6 +7159,38 @@
       "from": "pako@>=0.2.0 <0.3.0",
       "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.8.tgz"
     },
+    "parents": {
+      "version": "1.0.1",
+      "from": "parents@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/parents/-/parents-1.0.1.tgz"
+    },
+    "parse-entities": {
+      "version": "1.0.2",
+      "from": "parse-entities@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-1.0.2.tgz"
+    },
+    "parse-filepath": {
+      "version": "0.6.3",
+      "from": "parse-filepath@>=0.6.3 <0.7.0",
+      "resolved": "https://registry.npmjs.org/parse-filepath/-/parse-filepath-0.6.3.tgz",
+      "dependencies": {
+        "is-absolute": {
+          "version": "0.2.5",
+          "from": "is-absolute@>=0.2.2 <0.3.0",
+          "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.2.5.tgz"
+        },
+        "is-relative": {
+          "version": "0.2.1",
+          "from": "is-relative@>=0.2.1 <0.3.0",
+          "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-0.2.1.tgz"
+        }
+      }
+    },
+    "parse-git-config": {
+      "version": "0.2.0",
+      "from": "parse-git-config@>=0.2.0 <0.3.0",
+      "resolved": "https://registry.npmjs.org/parse-git-config/-/parse-git-config-0.2.0.tgz"
+    },
     "parse-glob": {
       "version": "3.0.4",
       "from": "parse-glob@>=3.0.4 <4.0.0",
@@ -6147,6 +7200,11 @@
       "version": "2.2.0",
       "from": "parse-json@>=2.1.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz"
+    },
+    "parse-url": {
+      "version": "1.3.3",
+      "from": "parse-url@>=1.3.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/parse-url/-/parse-url-1.3.3.tgz"
     },
     "parse5": {
       "version": "1.5.1",
@@ -6192,6 +7250,11 @@
       "version": "1.0.1",
       "from": "path-is-inside@>=1.0.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.1.tgz"
+    },
+    "path-platform": {
+      "version": "0.11.15",
+      "from": "path-platform@>=0.11.15 <0.12.0",
+      "resolved": "https://registry.npmjs.org/path-platform/-/path-platform-0.11.15.tgz"
     },
     "path-type": {
       "version": "1.1.0",
@@ -6304,6 +7367,11 @@
       "from": "pretty-hrtime@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.2.tgz"
     },
+    "private": {
+      "version": "0.1.6",
+      "from": "private@>=0.1.6 <0.2.0",
+      "resolved": "https://registry.npmjs.org/private/-/private-0.1.6.tgz"
+    },
     "process": {
       "version": "0.11.2",
       "from": "process@>=0.11.0 <0.12.0",
@@ -6334,9 +7402,14 @@
       "from": "protocolify@>=1.0.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/protocolify/-/protocolify-1.0.2.tgz"
     },
+    "protocols": {
+      "version": "1.4.1",
+      "from": "protocols@>=1.1.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/protocols/-/protocols-1.4.1.tgz"
+    },
     "protractor": {
       "version": "3.2.1",
-      "from": "protractor@latest",
+      "from": "protractor@3.2.1",
       "resolved": "https://registry.npmjs.org/protractor/-/protractor-3.2.1.tgz",
       "dependencies": {
         "adm-zip": {
@@ -6411,7 +7484,7 @@
         },
         "chalk": {
           "version": "1.1.1",
-          "from": "chalk@>=1.1.1 <2.0.0",
+          "from": "chalk@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz"
         },
         "color-convert": {
@@ -6421,12 +7494,12 @@
         },
         "combined-stream": {
           "version": "1.0.5",
-          "from": "combined-stream@>=1.0.5 <1.1.0",
+          "from": "combined-stream@>=1.0.1 <1.1.0",
           "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz"
         },
         "commander": {
           "version": "2.9.0",
-          "from": "commander@>=2.9.0 <3.0.0",
+          "from": "commander@>=2.8.1 <3.0.0",
           "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz"
         },
         "concat-map": {
@@ -6483,7 +7556,7 @@
         },
         "extend": {
           "version": "3.0.0",
-          "from": "extend@>=3.0.0 <3.1.0",
+          "from": "extend@>=3.0.0 <4.0.0",
           "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
         },
         "extsprintf": {
@@ -6493,7 +7566,7 @@
         },
         "forever-agent": {
           "version": "0.6.1",
-          "from": "forever-agent@>=0.6.1 <0.7.0",
+          "from": "forever-agent@>=0.6.0 <0.7.0",
           "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
         },
         "form-data": {
@@ -6583,7 +7656,7 @@
         },
         "isstream": {
           "version": "0.1.2",
-          "from": "isstream@>=0.1.2 <0.2.0",
+          "from": "isstream@>=0.1.1 <0.2.0",
           "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
         },
         "jasmine": {
@@ -6630,7 +7703,7 @@
         },
         "json-stringify-safe": {
           "version": "5.0.1",
-          "from": "json-stringify-safe@>=5.0.1 <5.1.0",
+          "from": "json-stringify-safe@>=5.0.0 <5.1.0",
           "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
         },
         "jsonpointer": {
@@ -6680,7 +7753,7 @@
         },
         "node-uuid": {
           "version": "1.4.7",
-          "from": "node-uuid@>=1.4.7 <1.5.0",
+          "from": "node-uuid@>=1.4.0 <1.5.0",
           "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
         },
         "oauth-sign": {
@@ -6839,7 +7912,7 @@
         },
         "tunnel-agent": {
           "version": "0.4.2",
-          "from": "tunnel-agent@>=0.4.1 <0.5.0",
+          "from": "tunnel-agent@>=0.4.0 <0.5.0",
           "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.2.tgz"
         },
         "tweetnacl": {
@@ -6944,6 +8017,18 @@
       "from": "range-parser@>=1.0.3 <1.1.0",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.0.3.tgz"
     },
+    "raw-body": {
+      "version": "2.1.6",
+      "from": "raw-body@>=2.1.5 <2.2.0",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.1.6.tgz",
+      "dependencies": {
+        "bytes": {
+          "version": "2.3.0",
+          "from": "bytes@2.3.0",
+          "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.3.0.tgz"
+        }
+      }
+    },
     "rc": {
       "version": "1.1.6",
       "from": "rc@>=1.1.2 <2.0.0",
@@ -7037,15 +8122,99 @@
         }
       }
     },
+    "regenerate": {
+      "version": "1.3.1",
+      "from": "regenerate@>=1.2.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.1.tgz"
+    },
+    "regenerator-runtime": {
+      "version": "0.9.5",
+      "from": "regenerator-runtime@>=0.9.5 <0.10.0",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.9.5.tgz"
+    },
     "regex-cache": {
       "version": "0.4.3",
       "from": "regex-cache@>=0.4.2 <0.5.0",
       "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.3.tgz"
     },
+    "regexpu-core": {
+      "version": "1.0.0",
+      "from": "regexpu-core@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-1.0.0.tgz"
+    },
     "registry-url": {
       "version": "3.1.0",
       "from": "registry-url@>=3.0.3 <4.0.0",
       "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz"
+    },
+    "regjsgen": {
+      "version": "0.2.0",
+      "from": "regjsgen@>=0.2.0 <0.3.0",
+      "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz"
+    },
+    "regjsparser": {
+      "version": "0.1.5",
+      "from": "regjsparser@>=0.1.4 <0.2.0",
+      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz"
+    },
+    "remark": {
+      "version": "4.2.2",
+      "from": "remark@>=4.1.2 <5.0.0",
+      "resolved": "https://registry.npmjs.org/remark/-/remark-4.2.2.tgz",
+      "dependencies": {
+        "attach-ware": {
+          "version": "2.0.0",
+          "from": "attach-ware@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/attach-ware/-/attach-ware-2.0.0.tgz"
+        },
+        "camelcase": {
+          "version": "2.1.1",
+          "from": "camelcase@^2.0.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz"
+        },
+        "minimatch": {
+          "version": "3.0.0",
+          "from": "minimatch@^3.0.0",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz"
+        },
+        "unified": {
+          "version": "3.0.0",
+          "from": "unified@>=3.0.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/unified/-/unified-3.0.0.tgz"
+        },
+        "user-home": {
+          "version": "2.0.0",
+          "from": "user-home@^2.0.0",
+          "resolved": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz"
+        }
+      }
+    },
+    "remark-html": {
+      "version": "2.0.2",
+      "from": "remark-html@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/remark-html/-/remark-html-2.0.2.tgz",
+      "dependencies": {
+        "object-assign": {
+          "version": "4.1.0",
+          "from": "object-assign@^4.0.1",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz"
+        }
+      }
+    },
+    "remark-slug": {
+      "version": "4.1.1",
+      "from": "remark-slug@>=4.0.0 <5.0.0",
+      "resolved": "https://registry.npmjs.org/remark-slug/-/remark-slug-4.1.1.tgz"
+    },
+    "remark-toc": {
+      "version": "3.0.1",
+      "from": "remark-toc@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/remark-toc/-/remark-toc-3.0.1.tgz"
+    },
+    "remote-origin-url": {
+      "version": "0.4.0",
+      "from": "remote-origin-url@0.4.0",
+      "resolved": "https://registry.npmjs.org/remote-origin-url/-/remote-origin-url-0.4.0.tgz"
     },
     "repeat-element": {
       "version": "1.1.2",
@@ -7237,6 +8406,11 @@
       "from": "serve-static@>=1.10.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.10.2.tgz"
     },
+    "set-blocking": {
+      "version": "1.0.0",
+      "from": "set-blocking@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-1.0.0.tgz"
+    },
     "set-immediate-shim": {
       "version": "1.0.1",
       "from": "set-immediate-shim@>=1.0.0 <2.0.0",
@@ -7247,10 +8421,20 @@
       "from": "sha.js@2.2.6",
       "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.2.6.tgz"
     },
+    "shebang-regex": {
+      "version": "1.0.0",
+      "from": "shebang-regex@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz"
+    },
     "shelljs": {
       "version": "0.6.0",
       "from": "shelljs@>=0.6.0 <0.7.0",
       "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.6.0.tgz"
+    },
+    "shellsubstitute": {
+      "version": "1.1.0",
+      "from": "shellsubstitute@>=1.1.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/shellsubstitute/-/shellsubstitute-1.1.0.tgz"
     },
     "shellwords": {
       "version": "0.1.0",
@@ -7267,6 +8451,11 @@
       "from": "signal-exit@>=2.1.2 <3.0.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-2.1.2.tgz"
     },
+    "slash": {
+      "version": "1.0.0",
+      "from": "slash@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz"
+    },
     "slice-ansi": {
       "version": "0.0.4",
       "from": "slice-ansi@0.0.4",
@@ -7276,6 +8465,11 @@
       "version": "1.1.6",
       "from": "slide@>=1.1.5 <2.0.0",
       "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz"
+    },
+    "slugg": {
+      "version": "1.0.0",
+      "from": "slugg@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/slugg/-/slugg-1.0.0.tgz"
     },
     "sntp": {
       "version": "1.0.9",
@@ -7433,6 +8627,18 @@
       "from": "source-map@>=0.1.38 <0.2.0",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz"
     },
+    "source-map-support": {
+      "version": "0.2.10",
+      "from": "source-map-support@>=0.2.10 <0.3.0",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.2.10.tgz",
+      "dependencies": {
+        "source-map": {
+          "version": "0.1.32",
+          "from": "source-map@0.1.32",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz"
+        }
+      }
+    },
     "sparkles": {
       "version": "1.0.0",
       "from": "sparkles@>=1.0.0 <2.0.0",
@@ -7495,6 +8701,23 @@
       "from": "statuses@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.2.1.tgz"
     },
+    "stream-array": {
+      "version": "1.1.2",
+      "from": "stream-array@>=1.1.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/stream-array/-/stream-array-1.1.2.tgz",
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "from": "isarray@~1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+        },
+        "readable-stream": {
+          "version": "2.1.4",
+          "from": "readable-stream@>=2.1.0 <2.2.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.4.tgz"
+        }
+      }
+    },
     "stream-browserify": {
       "version": "1.0.0",
       "from": "stream-browserify@>=1.0.0 <2.0.0",
@@ -7549,6 +8772,11 @@
       "from": "string-width@>=1.0.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.1.tgz"
     },
+    "stringify-entities": {
+      "version": "1.0.1",
+      "from": "stringify-entities@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-1.0.1.tgz"
+    },
     "stringstream": {
       "version": "0.0.5",
       "from": "stringstream@>=0.0.4 <0.1.0",
@@ -7596,6 +8824,11 @@
       "from": "strip-outer@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/strip-outer/-/strip-outer-1.0.0.tgz"
     },
+    "subarg": {
+      "version": "1.0.0",
+      "from": "subarg@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/subarg/-/subarg-1.0.0.tgz"
+    },
     "sum-up": {
       "version": "1.0.3",
       "from": "sum-up@>=1.0.1 <2.0.0",
@@ -7639,9 +8872,9 @@
       "resolved": "https://registry.npmjs.org/table/-/table-3.7.8.tgz",
       "dependencies": {
         "lodash": {
-          "version": "4.8.2",
-          "from": "lodash@>=4.0.0 <5.0.0",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.8.2.tgz"
+          "version": "4.13.1",
+          "from": "lodash@^4.0.0",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.13.1.tgz"
         }
       }
     },
@@ -7751,6 +8984,18 @@
       "from": "timers-browserify@>=1.0.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.4.2.tgz"
     },
+    "tiny-lr": {
+      "version": "0.2.1",
+      "from": "tiny-lr@>=0.2.1 <0.3.0",
+      "resolved": "https://registry.npmjs.org/tiny-lr/-/tiny-lr-0.2.1.tgz",
+      "dependencies": {
+        "qs": {
+          "version": "5.1.0",
+          "from": "qs@>=5.1.0 <5.2.0",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-5.1.0.tgz"
+        }
+      }
+    },
     "to-absolute-glob": {
       "version": "0.1.1",
       "from": "to-absolute-glob@>=0.1.1 <0.2.0",
@@ -7760,6 +9005,16 @@
       "version": "0.1.4",
       "from": "to-array@0.1.4",
       "resolved": "https://registry.npmjs.org/to-array/-/to-array-0.1.4.tgz"
+    },
+    "to-fast-properties": {
+      "version": "1.0.2",
+      "from": "to-fast-properties@>=1.0.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.2.tgz"
+    },
+    "to-vfile": {
+      "version": "1.0.0",
+      "from": "to-vfile@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/to-vfile/-/to-vfile-1.0.0.tgz"
     },
     "tough-cookie": {
       "version": "2.2.2",
@@ -7771,6 +9026,16 @@
       "from": "tr46@>=0.0.3 <0.1.0",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz"
     },
+    "trim": {
+      "version": "0.0.1",
+      "from": "trim@>=0.0.1 <0.0.2",
+      "resolved": "https://registry.npmjs.org/trim/-/trim-0.0.1.tgz"
+    },
+    "trim-lines": {
+      "version": "1.0.0",
+      "from": "trim-lines@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-1.0.0.tgz"
+    },
     "trim-newlines": {
       "version": "1.0.0",
       "from": "trim-newlines@>=1.0.0 <2.0.0",
@@ -7780,6 +9045,11 @@
       "version": "1.0.0",
       "from": "trim-repeated@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/trim-repeated/-/trim-repeated-1.0.0.tgz"
+    },
+    "trim-trailing-lines": {
+      "version": "1.0.0",
+      "from": "trim-trailing-lines@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/trim-trailing-lines/-/trim-trailing-lines-1.0.0.tgz"
     },
     "tryit": {
       "version": "1.0.2",
@@ -7815,6 +9085,23 @@
       "version": "1.0.0",
       "from": "type-detect@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-1.0.0.tgz"
+    },
+    "type-is": {
+      "version": "1.6.13",
+      "from": "type-is@>=1.6.10 <1.7.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.13.tgz",
+      "dependencies": {
+        "mime-db": {
+          "version": "1.23.0",
+          "from": "mime-db@>=1.23.0 <1.24.0",
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.23.0.tgz"
+        },
+        "mime-types": {
+          "version": "2.1.11",
+          "from": "mime-types@>=2.1.11 <2.2.0",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.11.tgz"
+        }
+      }
     },
     "typedarray": {
       "version": "0.0.6",
@@ -7878,6 +9165,11 @@
       "from": "ultron@>=1.0.0 <1.1.0",
       "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.0.2.tgz"
     },
+    "unc-path-regex": {
+      "version": "0.1.2",
+      "from": "unc-path-regex@>=0.1.0 <0.2.0",
+      "resolved": "https://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz"
+    },
     "undefsafe": {
       "version": "0.0.3",
       "from": "undefsafe@0.0.3",
@@ -7893,15 +9185,45 @@
       "from": "underscore.string@>=2.3.3 <2.4.0",
       "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz"
     },
+    "unherit": {
+      "version": "1.0.4",
+      "from": "unherit@>=1.0.4 <2.0.0",
+      "resolved": "https://registry.npmjs.org/unherit/-/unherit-1.0.4.tgz"
+    },
+    "unified": {
+      "version": "2.1.4",
+      "from": "unified@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-2.1.4.tgz"
+    },
     "unique-stream": {
       "version": "1.0.0",
       "from": "unique-stream@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-1.0.0.tgz"
     },
+    "unist-builder": {
+      "version": "1.0.1",
+      "from": "unist-builder@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/unist-builder/-/unist-builder-1.0.1.tgz"
+    },
+    "unist-util-remove-position": {
+      "version": "1.0.0",
+      "from": "unist-util-remove-position@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-remove-position/-/unist-util-remove-position-1.0.0.tgz"
+    },
+    "unist-util-visit": {
+      "version": "1.1.0",
+      "from": "unist-util-visit@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-1.1.0.tgz"
+    },
     "unpipe": {
       "version": "1.0.0",
       "from": "unpipe@>=1.0.0 <1.1.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz"
+    },
+    "untildify": {
+      "version": "2.1.0",
+      "from": "untildify@>=2.1.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/untildify/-/untildify-2.1.0.tgz"
     },
     "unzip-response": {
       "version": "1.0.0",
@@ -8036,6 +9358,36 @@
       "version": "1.3.6",
       "from": "verror@1.3.6",
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz"
+    },
+    "vfile": {
+      "version": "1.4.0",
+      "from": "vfile@>=1.1.2 <2.0.0",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-1.4.0.tgz"
+    },
+    "vfile-find-down": {
+      "version": "1.0.0",
+      "from": "vfile-find-down@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/vfile-find-down/-/vfile-find-down-1.0.0.tgz"
+    },
+    "vfile-find-up": {
+      "version": "1.0.0",
+      "from": "vfile-find-up@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/vfile-find-up/-/vfile-find-up-1.0.0.tgz"
+    },
+    "vfile-location": {
+      "version": "2.0.0",
+      "from": "vfile-location@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-2.0.0.tgz"
+    },
+    "vfile-reporter": {
+      "version": "1.5.0",
+      "from": "vfile-reporter@>=1.4.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/vfile-reporter/-/vfile-reporter-1.5.0.tgz"
+    },
+    "vfile-sort": {
+      "version": "1.0.0",
+      "from": "vfile-sort@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/vfile-sort/-/vfile-sort-1.0.0.tgz"
     },
     "vinyl": {
       "version": "0.5.3",
@@ -8189,6 +9541,16 @@
         }
       }
     },
+    "websocket-driver": {
+      "version": "0.6.5",
+      "from": "websocket-driver@>=0.5.1",
+      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.6.5.tgz"
+    },
+    "websocket-extensions": {
+      "version": "0.1.1",
+      "from": "websocket-extensions@>=0.1.1",
+      "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.1.tgz"
+    },
     "weinre": {
       "version": "2.0.0-pre-I0Z7U9OV",
       "from": "weinre@>=2.0.0-pre-I0Z7U9OV <3.0.0",
@@ -8298,15 +9660,32 @@
       "from": "xml-name-validator@>=2.0.1 <3.0.0",
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-2.0.1.tgz"
     },
+    "xml2js": {
+      "version": "0.4.16",
+      "from": "xml2js@>=0.4.12 <0.5.0",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.16.tgz"
+    },
+    "xmlbuilder": {
+      "version": "4.2.1",
+      "from": "xmlbuilder@>=4.1.0 <5.0.0",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-4.2.1.tgz",
+      "dependencies": {
+        "lodash": {
+          "version": "4.13.1",
+          "from": "lodash@^4.0.0",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.13.1.tgz"
+        }
+      }
+    },
     "xmlhttprequest-ssl": {
       "version": "1.5.1",
       "from": "xmlhttprequest-ssl@1.5.1",
       "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.1.tgz"
     },
     "xregexp": {
-      "version": "3.1.0",
+      "version": "3.1.1",
       "from": "xregexp@>=3.0.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/xregexp/-/xregexp-3.1.0.tgz"
+      "resolved": "https://registry.npmjs.org/xregexp/-/xregexp-3.1.1.tgz"
     },
     "xtend": {
       "version": "4.0.1",

--- a/test/browser_tests/spec_suites/careers-application-process.js
+++ b/test/browser_tests/spec_suites/careers-application-process.js
@@ -68,7 +68,7 @@ describe( 'The Application Process Page', function() {
       beforeEach( function() {
         page.videoPlayerPlayButton.isDisplayed().then(
         function( playButtonIsVisible ) {
-          if( playButtonIsVisible === false ) {
+          if ( playButtonIsVisible === false ) {
             page.videoPlayerCloseButton.click();
           }
           page.videoPlayerPlayButton.click();
@@ -89,7 +89,7 @@ describe( 'The Application Process Page', function() {
       beforeEach( function() {
         page.videoPlayerCloseButton.isDisplayed().then(
         function( closeButtonIsVisible ) {
-          if( closeButtonIsVisible === false ) {
+          if ( closeButtonIsVisible === false ) {
             page.videoPlayerPlayButton.click();
           }
           page.videoPlayerCloseButton.click();

--- a/test/browser_tests/spec_suites/organisms/header.js
+++ b/test/browser_tests/spec_suites/organisms/header.js
@@ -43,7 +43,8 @@ describe( 'Header', function() {
 
   beforeEach( function() {
     browser.get( '/' );
-    browser.executeScript('document.body.className = "u-move-transition__disabled";');
+    var script = 'document.body.className = "u-move-transition__disabled";';
+    browser.executeScript( script );
   } );
 
   if ( browser.params.windowWidth > breakpointsConfig.bpLG.min ) {
@@ -150,7 +151,7 @@ describe( 'Header', function() {
             .perform();
           // Since the code doesn't work when .u-move-transition__disabled is
           // set to 0ms, we still need a quick sleep.
-          browser.sleep(2);
+          browser.sleep( 2 );
           expect( _dom.megaMenuContent.getAttribute( 'aria-expanded' ) )
             .toBe( 'true' );
           expect( _dom.globalSearchContent.getAttribute( 'aria-expanded' ) )

--- a/test/browser_tests/spec_suites/the-bureau.js
+++ b/test/browser_tests/spec_suites/the-bureau.js
@@ -44,7 +44,7 @@ describe( 'The Bureau Page', function() {
       beforeEach( function() {
         page.videoPlayerPlayButton.isDisplayed().then(
         function( playButtonIsVisible ) {
-          if( playButtonIsVisible === false ) {
+          if ( playButtonIsVisible === false ) {
             page.videoPlayerCloseButton.click();
           }
           page.videoPlayerPlayButton.click();
@@ -65,7 +65,7 @@ describe( 'The Bureau Page', function() {
       beforeEach( function() {
         page.videoPlayerCloseButton.isDisplayed().then(
         function( closeButtonIsVisible ) {
-          if( closeButtonIsVisible === false ) {
+          if ( closeButtonIsVisible === false ) {
             page.videoPlayerPlayButton.click();
           }
           page.videoPlayerCloseButton.click();

--- a/test/unit_tests/modules/ClearableInput-spec.js
+++ b/test/unit_tests/modules/ClearableInput-spec.js
@@ -25,7 +25,7 @@ var HTML_SNIPPET =
 
 function triggerEvent( target, eventType, eventOption ) {
   var event = document.createEvent( 'Event' );
-  if( eventType === 'keyup' ) {
+  if ( eventType === 'keyup' ) {
     event.keyCode = eventOption || '';
   }
   event.initEvent( eventType, true, true );

--- a/test/unit_tests/modules/FlyoutMenu-spec.js
+++ b/test/unit_tests/modules/FlyoutMenu-spec.js
@@ -237,7 +237,7 @@ describe( 'FlyoutMenu', function() {
           var hasClass = contentDom.classList.contains( 'u-move-transition' );
           expect( hasClass ).to.be.true;
           done();
-        } catch( err ) {
+        } catch ( err ) {
           done( err );
         }
       } );
@@ -256,7 +256,7 @@ describe( 'FlyoutMenu', function() {
           var hasClass = contentDom.classList.contains( 'u-move-transition' );
           expect( hasClass ).to.be.true;
           done();
-        } catch( err ) {
+        } catch ( err ) {
           done( err );
         }
       } );
@@ -368,7 +368,7 @@ describe( 'FlyoutMenu', function() {
         try {
           expect( flyoutMenu.isAnimating() ).to.be.true;
           done();
-        } catch( err ) {
+        } catch ( err ) {
           done( err );
         }
       } );
@@ -381,7 +381,7 @@ describe( 'FlyoutMenu', function() {
         try {
           expect( flyoutMenu.isAnimating() ).to.be.false;
           done();
-        } catch( err ) {
+        } catch ( err ) {
           done( err );
         }
       } );
@@ -394,7 +394,7 @@ describe( 'FlyoutMenu', function() {
         try {
           expect( flyoutMenu.isAnimating() ).to.be.true;
           done();
-        } catch( err ) {
+        } catch ( err ) {
           done( err );
         }
       } );
@@ -408,7 +408,7 @@ describe( 'FlyoutMenu', function() {
         try {
           expect( flyoutMenu.isAnimating() ).to.be.false;
           done();
-        } catch( err ) {
+        } catch ( err ) {
           done( err );
         }
       } );
@@ -424,7 +424,7 @@ describe( 'FlyoutMenu', function() {
         try {
           expect( flyoutMenu.isExpanded() ).to.be.false;
           done();
-        } catch( err ) {
+        } catch ( err ) {
           done( err );
         }
       } );
@@ -437,7 +437,7 @@ describe( 'FlyoutMenu', function() {
         try {
           expect( flyoutMenu.isExpanded() ).to.be.true;
           done();
-        } catch( err ) {
+        } catch ( err ) {
           done( err );
         }
       } );
@@ -451,7 +451,7 @@ describe( 'FlyoutMenu', function() {
         try {
           expect( flyoutMenu.isExpanded() ).to.be.true;
           done();
-        } catch( err ) {
+        } catch ( err ) {
           done( err );
         }
       } );
@@ -464,7 +464,7 @@ describe( 'FlyoutMenu', function() {
         try {
           expect( flyoutMenu.isExpanded() ).to.be.false;
           done();
-        } catch( err ) {
+        } catch ( err ) {
           done( err );
         }
       } );


### PR DESCRIPTION
## Changes

- Updates ESLint to `2.13.1` from `2.7.0`
- Adds `init-declarations`, `max-lines`, `object-curly-newline`, `newline-before-return`, and `newline-per-chained-call` rules, but does not enforce them.
- Enforces `no-prototype-builtins`, `no-unsafe-finally`, `no-duplicate-imports`, `unicode-bom`, `no-useless-computed-key`, `no-useless-rename`, `rest-spread-spacing`, and `no-restricted-globals` rules.
- Warns on `no-useless-escape`, `keyword-spacing`, `max-statements-per-line`, `no-mixed-operators`, `object-property-newline`
- Adds options to `no-confusing-arrow`, `no-magic-numbers`, and `no-unused-vars`. Only `no-confusing-arrow` option has an effect and relaxes the rule.
- Minor code cleanup to fix linter warnings.

## Testing

- `./setup.sh`
- `gulp lint` should have no errors.

## Review

- @jimmynotjim 
- @sebworks 
- @KimberlyMunoz 
