### PR TITLE
Adding Unit Test for Js Loader

### DIFF
--- a/test/unit_tests/modules/util/js-loader-spec.js
+++ b/test/unit_tests/modules/util/js-loader-spec.js
@@ -1,11 +1,34 @@
 'use strict';
 
 var BASE_JS_PATH = '../../../../cfgov/unprocessed/js/';
-
 var chai = require( 'chai' );
 var expect = chai.expect;
+var jsdom = require( 'mocha-jsdom' );
 var jsLoader = require( BASE_JS_PATH + 'modules/util/js-loader' );
 
-describe( 'js-loader', function() {
-  // TODO: Implement tests.
+describe( 'loadScript method', function() {
+  jsdom( {
+    features: {
+      FetchExternalResources:   [ 'script' ],
+      ProcessExternalResources: [ 'script' ],
+      MutationEvents:           '2.0'
+    }
+  } );
+
+  it( 'should invoke the callback method when the script loads',
+    function() {
+      var loaderPromise = new Promise( function( resolve, reject ) {
+        var scriptLocation = 'http://code.jquery.com/jquery-1.5.min.js';
+        jsLoader.loadScript( scriptLocation, function() {
+          resolve( 'Callback called' );
+        } );
+      } );
+
+      return loaderPromise.then( function( result ) {
+        expect( result ).to.equal( 'Callback called' );
+      } );
+    }
+  );
+
+  // TODO: Add Test for script.onreadystatechange
 } );


### PR DESCRIPTION
Adding Unit Test for Js Loader
## Additions

- Adding Unit Test for Js Loader
## Testing

- Run `gulp test:unit`.

## Review

- @anselmbradford 
- @jimmynotjim

## Notes

- I've not added tests for `script.readyState`. I'm not sure how to test for those branches as it's not implemented by jsDom (https://github.com/tmpvar/jsdom/issues/1436 ). If anyone has ideals then please let me know.

## Todos

-

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
