### PR TITLE
Hotfix: stop trying to process invalid URL's with PDFReactor

### DIFF
--- a/cfgov/cfgov/urls.py
+++ b/cfgov/cfgov/urls.py
@@ -316,17 +316,18 @@ from django.shortcuts import render
 
 def handle_error(code, request):
     try:
-        return render(request, '%s.html' % code, context={'request': request})
+        return render(request, '%s.html' % code, context={'request': request},
+                      status=code)
     except AttributeError:
         # for certain URL's, it seems like our middleware doesn't run
         # Thankfully, these are probably not errors real users see -- usually
         # the results of a security scan, or a malformed static file reference.
 
         return HttpResponse("This request could not be processed, "
-                            "HTTP Error %s." % code)
+                            "HTTP Error %s." % str(code), status=code)
 
-handler404 = partial(handle_error, '404')
-handler500 = partial(handle_error, '500')
+handler404 = partial(handle_error, 404)
+handler500 = partial(handle_error, 500)
 
 
 register_permalink('posts', 'blog:detail')

--- a/cfgov/legacy/forms.py
+++ b/cfgov/legacy/forms.py
@@ -3,4 +3,4 @@ from localflavor.us.forms import USZipCodeField
 
 
 class HousingCounselorForm(forms.Form):
-    zip = USZipCodeField()
+    zip = USZipCodeField(max_length=5)

--- a/cfgov/v1/migrations/0057_auto_20160304_1651.py
+++ b/cfgov/v1/migrations/0057_auto_20160304_1651.py
@@ -23,15 +23,17 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.RenameField(
-            model_name='abstractfilterpage',
-            old_name='preview_link_text',
-            new_name='secondary_link_text',
-        ),
-        migrations.RenameField(
-            model_name='abstractfilterpage',
-            old_name='preview_link_url',
-            new_name='secondary_link_url',
-        ),
-        migrations.RunPython(save_revisions),
+        # THIS IS NO LONGER NEEDED
+        #
+        # migrations.RenameField(
+        #     model_name='abstractfilterpage',
+        #     old_name='preview_link_text',
+        #     new_name='secondary_link_text',
+        # ),
+        # migrations.RenameField(
+        #     model_name='abstractfilterpage',
+        #     old_name='preview_link_url',
+        #     new_name='secondary_link_url',
+        # ),
+        # migrations.RunPython(save_revisions),
     ]

--- a/cfgov/v1/migrations/0057_auto_20160304_1651.py
+++ b/cfgov/v1/migrations/0057_auto_20160304_1651.py
@@ -2,19 +2,6 @@
 from __future__ import unicode_literals
 
 from django.db import migrations, models
-from v1.models.learn_page import DocumentDetailPage
-from itertools import chain
-
-
-def save_revisions(apps, schema_editor):
-    from v1.models.learn_page import DocumentDetailPage, EventPage, LearnPage
-
-    pages = list(chain(DocumentDetailPage.objects.all(),
-                       EventPage.objects.all(),
-                       LearnPage.objects.all()))
-
-    for page in pages:
-        page.save_revision()
 
 
 class Migration(migrations.Migration):
@@ -23,17 +10,14 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        # THIS IS NO LONGER NEEDED
-        #
-        # migrations.RenameField(
-        #     model_name='abstractfilterpage',
-        #     old_name='preview_link_text',
-        #     new_name='secondary_link_text',
-        # ),
-        # migrations.RenameField(
-        #     model_name='abstractfilterpage',
-        #     old_name='preview_link_url',
-        #     new_name='secondary_link_url',
-        # ),
-        # migrations.RunPython(save_revisions),
+        migrations.RenameField(
+            model_name='abstractfilterpage',
+            old_name='preview_link_text',
+            new_name='secondary_link_text',
+        ),
+        migrations.RenameField(
+            model_name='abstractfilterpage',
+            old_name='preview_link_url',
+            new_name='secondary_link_url',
+        ),
     ]


### PR DESCRIPTION
This is a hotfix that should stop *some* of the bleeding with PDFReactor and our web servers.

We now reject zip+4 codes, because the backend API doesn't support them. PDFReactor doesn't seem to deal well with parsing our error pages.

This also fixes a bug where we were sending error responses with HTTP status 200 that may have been aggravating things.