### PR TITLE
Consistent ordering of current job openings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 
 ### Changed
 - Updated ESLint to `2.13.1` from `2.7.0`.
+- Fixed job ordering on Careers home page to be consistent with Current Openings page.
 
 ### Removed
 

--- a/cfgov/jinja2/v1/about-us/careers/index.html
+++ b/cfgov/jinja2/v1/about-us/careers/index.html
@@ -59,7 +59,7 @@
                           block
                           block__flush-top"
                    data-qa-hook="openings-section">
-                <h2 class="h3">Newest openings</h2>
+                <h2 class="h3">Current openings</h2>
                 <ul class="list list__unstyled">
                     {% for career in newest_careers %}
                     <li class="list_item">

--- a/cfgov/jobmanager/tests/test_views.py
+++ b/cfgov/jobmanager/tests/test_views.py
@@ -1,0 +1,54 @@
+import django
+
+from django.test import RequestFactory
+from mock import patch
+from model_mommy import mommy
+from unittest import TestCase
+
+from jobmanager.models import Job
+from jobmanager.views import CurrentOpeningsView, IndexView, JobListView
+
+
+django.setup()
+
+
+class JobListViewTestCaseMixin(object):
+    def setUp(self):
+        self.view = self.view_cls()
+
+    def request(self):
+        request = RequestFactory().get('')
+        return self.view_cls.as_view()(request)
+
+    def mock_jobs(self, count):
+        jobs = mommy.prepare(Job, _quantity=count) if count else []
+
+        patched = patch(
+            'jobmanager.views.JobListView.get_queryset',
+            return_value=jobs
+        )
+        patched.start()
+        self.addCleanup(patched.stop)
+
+        return jobs
+
+    def test_get(self):
+        self.mock_jobs(100)
+        self.assertEquals(self.request().status_code, 200)
+
+    def test_get_no_jobs(self):
+        self.mock_jobs(0)
+        self.assertEquals(self.request().status_code, 200)
+
+
+class IndexViewTestCase(JobListViewTestCaseMixin, TestCase):
+    view_cls = IndexView
+
+    def test_get_queryset_limits_max_results(self):
+        limit = self.view.jobs_to_show
+        jobs = self.mock_jobs(limit * 2)
+        self.assertEqual(self.view.get_queryset(), jobs[:limit])
+
+
+class CurrentOpeningsViewTestCase(JobListViewTestCaseMixin, TestCase):
+    view_cls = CurrentOpeningsView

--- a/cfgov/jobmanager/urls.py
+++ b/cfgov/jobmanager/urls.py
@@ -4,11 +4,14 @@ from django.core.context_processors import csrf
 from django.conf import settings
 from django.views.generic import TemplateView, RedirectView
 
+from jobmanager.views import CurrentOpeningsView, IndexView
+
+
 urlpatterns = patterns(
     'jobmanager.views',
-    url(r'^$', 'index', name='jobs'),
-    url(r'^current-openings/$', 'current_openings', name='current_openings'),
-
+    url(r'^$', IndexView.as_view(), name='jobs'),
+    url(r'^current-openings/$', CurrentOpeningsView.as_view(),
+        name='current_openings'),
     url(r'application-process',
         TemplateView.as_view(template_name='about-us/careers/application-process/index.html')),
     url(r'working-at-cfpb/$',

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,3 +1,4 @@
 -r base.txt
 mock==1.3.0
 tox==2.1.1
+model_mommy==1.2.6


### PR DESCRIPTION
Makes job listing ordering on [/careers/](http://www.consumerfinance.gov/about-us/careers/) consistent with the ordering on [/careers/current-openings/](http://www.consumerfinance.gov/about-us/careers/current-openings/) (ordered first by soonest to close and then alphabetically). Changes text on /careers/ from "Newest Openings" to "Current Openings".

## Changes

- Converted the careers index view and the current openings view to Django class-based views.
- Modified index view to use an ordering of `('close_date', 'title')` to be consistent with the jobs listing page.
- Changed text on `jinja2/v1/about-us/careers/index.html` from "Newest Openings" to "Current Openings".
- Updated `CHANGELOG.md` to include this update.

## Testing

- Added new unit tests for the above views. Created new `jobmanager/tests` module to hold these.
- Added new dependency (only to `requirements/test.txt`) on the useful [model_mommy](https://pypi.python.org/pypi/model_mommy) package for easily mocking Django models.

## Review

- @kurtw @rosskarchner @richaagarwal 

## Screenshots

Careers page:
![image](https://cloud.githubusercontent.com/assets/654645/16501426/5d814b0a-3ed7-11e6-9350-d6ee495d9999.png)

## Todos

- These pages don't gracefully handle the case when there are no job openings.

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
