### PR TITLE
Adding validation to require option selection on the Leadership calendar

### DIFF
--- a/cfgov/jinja2/v1/_includes/macros/filters.html
+++ b/cfgov/jinja2/v1/_includes/macros/filters.html
@@ -391,6 +391,7 @@
            {%- if is_filter_selected(field, value) %}
            checked
            {%- endif -%}
+           data-required="1"
            >
     <label class="form-group_item" for="{{ id }}">
         {{ label | safe if label else value | safe }}

--- a/cfgov/jinja2/v1/about-us/the-bureau/leadership-calendar/index.html
+++ b/cfgov/jinja2/v1/about-us/the-bureau/leadership-calendar/index.html
@@ -98,7 +98,6 @@
                     'show_current_filters': false,
                     'action'              : 'pdf/',
                     'submit_label'        : 'Download PDF',
-                    'additional_classes'  : 'js-validate_require-date',
                     'form_method'         : 'get',
                     'show_errors'         :  True
                 }


### PR DESCRIPTION
Adding validation to the leadership calendar to force users to select at least one option.  The primary goal is to reduce the pdf download size.

## Changes

- Remove class name the we no longer use and adds selection requirement.

## Testing

- Visit `http://localhost:8000/about-us/the-bureau/leadership-calendar/` and click the `Download PDF` button. It should display an error notification.

## Review

- @richaagarwal 

## Screenshots
<img width="940" alt="screen shot 2016-07-07 at 11 47 06 am" src="https://cloud.githubusercontent.com/assets/1696212/16659597/d639d5d8-4438-11e6-9f5a-e386225f245f.png">

## Notes

- The `macros/filters` jinja macro should be removed as it's only being used on the Leadership Calendar page. It may require refactoring the `filterable-list-control` macro to be modular.


## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)

…ndar