### PR TITLE
Update spacing in item introduction

### DIFF
--- a/cfgov/jinja2/v1/_includes/article.html
+++ b/cfgov/jinja2/v1/_includes/article.html
@@ -39,7 +39,7 @@
 
         {% for block in page.header -%}
             {% if block.block_type == 'article_subheader' %}
-                {% do data.update({paragraph: block.value}) %}
+                {% do data.update({'paragraph': block.value}) %}
             {% endif %}
         {% endfor %}
 

--- a/cfgov/jinja2/v1/_includes/article.html
+++ b/cfgov/jinja2/v1/_includes/article.html
@@ -24,58 +24,28 @@
 
    ========================================================================== #}
 
-{%- import 'macros/category-slug.html' as category_slug -%}
-{%- import 'macros/time.html' as time -%}
-{%- import 'molecules/social-media.html' as social_media with context -%}
+{% import 'organisms/item-introduction.html' as item_introduction with context %}
 {%- import 'templates/render_block.html' as render_block with context -%}
 {%- import 'tags.html' as tags -%}
 
 <article class="post">
-    <header class="post_header">
-        {% set index, ancestor = get_filter_data(page) %}
-        {% for category in page.categories.all() %}
-            {{ '|' if loop.index > 1 else '' }}
-            {{ category_slug.render(category.name, get_protected_url(ancestor), 'post_slug', index=index) }}
-        {% endfor %}
-        <h1 class="post_heading">
-            {{ page.title|safe }}
-        </h1>
+    <header>
+        {% set data = {
+            'category': page.categories.all(),
+            'heading': page.title,
+            'date': page.date_published,
+            'has_social': True
+        } %}
+
         {% for block in page.header -%}
-            {% if block.block_type == 'item_introduction' %}
-                {% import 'organisms/item-introduction.html' as item_introduction with context %}
-                {{ item_introduction.render(block.value) }}
-            {% elif block.block_type == 'article_subheader' %}
-                <div class="post_dek">
-                  {{ parse_links(block.value) | safe }}
-                </div>
-            {% else %}
-                <div class="block
-                            block__flush-top">
-                    {{ render_stream_child(block) }}
-                </div>
+            {% if block.block_type == 'article_subheader' %}
+                {% do data.update({paragraph: block.value}) %}
             {% endif %}
         {% endfor %}
-        <div class="post_meta">
-        {% set num_authors = page.authors.all()|length %}
-        {% if num_authors %}
 
-            <span class="post_byline">
-            {%- for author in page.authors.names() -%}
-                {{- 'By ' if loop.index == 1 else ' and ' }}
-                <a href="{{ get_protected_url(ancestor) }}?filter{{ index }}_authors={{ author }}">
-                    {{ author }}
-                </a>
-            {%- endfor -%}
-                &ndash;
-            </span>
-
-        {% endif %}
-        <span class="date">
-            {{ time.render(page.date_published, {'date':true}) }}
-        </span>
-        </div>
-        {{ social_media.render({'title': page.title}) }}
+        {{ item_introduction.render(data) }}
     </header>
+
     <div class="post_body">
         {% for block in page.content %}
             {% if block.block_type == 'content' %}

--- a/cfgov/jinja2/v1/_includes/article.html
+++ b/cfgov/jinja2/v1/_includes/article.html
@@ -31,11 +31,11 @@
 {%- import 'tags.html' as tags -%}
 
 <article class="post">
-    <header>
+    <header class="post_header">
         {% set index, ancestor = get_filter_data(page) %}
         {% for category in page.categories.all() %}
             {{ '|' if loop.index > 1 else '' }}
-            {{ category_slug.render(category.name, get_protected_url(ancestor), 'post_slug meta-header_left', index=index) }}
+            {{ category_slug.render(category.name, get_protected_url(ancestor), 'post_slug', index=index) }}
         {% endfor %}
         <h1 class="post_heading">
             {{ page.title|safe }}
@@ -58,31 +58,33 @@
         <div class="post_meta">
         {% set num_authors = page.authors.all()|length %}
         {% if num_authors %}
+
             <span class="post_byline">
             {%- for author in page.authors.names() -%}
-                {{- 'By ' if loop.index == 1 else ', ' if num_authors > 2 and not loop.index == num_authors else ' ' }}
+                {{- 'By ' if loop.index == 1 else ' and ' }}
                 <a href="{{ get_protected_url(ancestor) }}?filter{{ index }}_authors={{ author }}">
                     {{ author }}
                 </a>
             {%- endfor -%}
                 &ndash;
             </span>
+
         {% endif %}
         <span class="date">
             {{ time.render(page.date_published, {'date':true}) }}
         </span>
         </div>
         {{ social_media.render({'title': page.title}) }}
-        <div class="post_body">
-            {% for block in page.content %}
-                {% if block.block_type == 'content' %}
-                    {{ parse_links(block.value) | safe }}
-                {% else %}
-                    {{ render_block.render(block, loop.index) }}
-                {% endif %}
-            {% endfor %}
-        </div>
     </header>
+    <div class="post_body">
+        {% for block in page.content %}
+            {% if block.block_type == 'content' %}
+                {{ parse_links(block.value) | safe }}
+            {% else %}
+                {{ render_block.render(block, loop.index) }}
+            {% endif %}
+        {% endfor %}
+    </div>
     {% if page.tags.all() | length %}
         <footer>
             {{ tags.render( related_metadata_tags(page), '', is_wagtail=True) }}

--- a/cfgov/jinja2/v1/_includes/macros/category-slug.html
+++ b/cfgov/jinja2/v1/_includes/macros/category-slug.html
@@ -52,7 +52,7 @@
 {% macro _category_link(href, classes) %}
     {% if href %}
         <a href="{{ href }}"
-           class="category-slug {{ classes if classes }}">
+           class="category-slug {{ classes if classes else '' }}">
     {% endif %}
        {{ caller() }}
     {% if href %}

--- a/cfgov/jinja2/v1/_includes/organisms/item-introduction.html
+++ b/cfgov/jinja2/v1/_includes/organisms/item-introduction.html
@@ -32,38 +32,35 @@
 {% set page_url = get_protected_url(ancestor) %}
 
 <div class="o-item-introduction">
-    <div class="h4">
-        {{ category_slug.render(value.category, page_url, index=form_id) }}
-    </div>
+    {{ category_slug.render(value.category, page_url, index=form_id) }}
     <h1>{{ value.heading }}</h1>
 
     {% if value.paragraph %}
         <div class="lead-paragraph">{{ parse_links(value.paragraph) | safe }}</div>
     {% endif %}
+
     {% if value.date or page.authors.all() %}
-        <p>
+        <div class="meta">
     {% endif %}
-    {% for author in page.authors.names() %}
-        {% if loop.index == 1  %}
-            By <a href="{{ page_url }}?filter{{ form_id }}_authors={{ author }}">
-                {{ author }}
+    {% set num_authors = page.authors.all()|length %}
+        {% if num_authors %}
+            <span class="byline">
+            {%- for author in page.authors.names() -%}
+                {{- 'By ' if loop.index == 1 else ' and ' }}
+                <a href="{{ page_url }}?filter{{ form_id }}_authors={{ author }}">
+                    {{ author }}
                 </a>
-        {% elif loop.last == true %}
-            and <a href="{{ page_url }}?filter{{ form_id }}_authors={{ author }}">
-                {{ author }}
-                </a>
-        {% else %}
-            , <a href="{{ page_url }}?filter{{ form_id }}_authors={{ author }}">
-                {{ author }}
-                </a>
+            {%- endfor -%}
+                &ndash;
+            </span>
         {% endif %}
-    {% endfor %}
-    {% if value.date %}
-        {{ time.render(value.date, {'date':true}) }}
-    {% endif %}
+        <span class="date">
+            {{ time.render(value.date, {'date':true}) }}
+        </span>
     {% if value.date or page.authors.all() %}
-        </p>
+        </div>
     {% endif %}
+
     {% if value.has_social %}
         {{ social_media.render() }}
     {% endif %}

--- a/cfgov/jinja2/v1/_includes/organisms/item-introduction.html
+++ b/cfgov/jinja2/v1/_includes/organisms/item-introduction.html
@@ -32,8 +32,15 @@
 {% set page_url = get_protected_url(ancestor) %}
 
 <div class="o-item-introduction">
-    {{ category_slug.render(value.category, page_url, index=form_id) }}
-    <h1>{{ value.heading }}</h1>
+    {% if value.category is string %}
+        {{ category_slug.render(value.category, page_url, index=form_id) }}
+    {% else %}
+        {% for category in page.categories.all() %}
+            {{ '|' if loop.index > 1 else '' }}
+            {{ category_slug.render(category.name, get_protected_url(ancestor), 'post_slug', index=index) }}
+        {% endfor %}
+    {% endif %}
+    <h1>{{ value.heading | safe }}</h1>
 
     {% if value.paragraph %}
         <div class="lead-paragraph">{{ parse_links(value.paragraph) | safe }}</div>

--- a/cfgov/jinja2/v1/_includes/organisms/item-introduction.html
+++ b/cfgov/jinja2/v1/_includes/organisms/item-introduction.html
@@ -30,6 +30,9 @@
 
 {% set form_id, ancestor = get_filter_data(page) %}
 {% set page_url = get_protected_url(ancestor) %}
+{% set published_date = value.date %}
+{% set page_authors = page.authors.all() %}
+{% set has_authors = page_authors|length > 0 %}
 
 <div class="o-item-introduction">
     {% if value.category is string %}
@@ -46,13 +49,12 @@
         <div class="lead-paragraph">{{ parse_links(value.paragraph) | safe }}</div>
     {% endif %}
 
-    {% if value.date or page.authors.all() %}
+    {% if published_date or has_authors %}
         <div class="meta">
     {% endif %}
-    {% set num_authors = page.authors.all()|length %}
-        {% if num_authors %}
+        {% if has_authors %}
             <span class="byline">
-            {%- for author in page.authors.names() -%}
+            {%- for author in page_authors -%}
                 {{- 'By ' if loop.index == 1 else ' and ' }}
                 <a href="{{ page_url }}?filter{{ form_id }}_authors={{ author }}">
                     {{ author }}
@@ -62,9 +64,9 @@
             </span>
         {% endif %}
         <span class="date">
-            {{ time.render(value.date, {'date':true}) }}
+            {{ time.render(published_date, {'date':true}) }}
         </span>
-    {% if value.date or page.authors.all() %}
+    {% if published_date or has_authors %}
         </div>
     {% endif %}
 

--- a/cfgov/unprocessed/css/organisms/item-introduction.less
+++ b/cfgov/unprocessed/css/organisms/item-introduction.less
@@ -35,11 +35,10 @@
 */
 
 .o-item-introduction {
-    // visually approximates 60px
-    margin-bottom: unit( 55px / @base-font-size-px, em);
+    margin-bottom: unit(@grid_gutter-width * 2 / @base-font-size-px, em);
 
     .short-desc {
-        padding-bottom: unit( (@grid_gutter-width / 2) / @base-font-size-px, em);
+        padding-bottom: unit(@grid_gutter-width / 2 / @base-font-size-px, em);
     }
 
     .lead-paragraph {
@@ -47,8 +46,7 @@
     }
 
     .meta {
-      // visually approximates 30px
-      margin-bottom: unit(20px / @base-font-size-px, em);
+      margin-bottom: unit(@grid_gutter-width / @base-font-size-px, em);
 
         .byline {
           .heading-4();

--- a/cfgov/unprocessed/css/organisms/item-introduction.less
+++ b/cfgov/unprocessed/css/organisms/item-introduction.less
@@ -35,10 +35,27 @@
 */
 
 .o-item-introduction {
+    // visually approximates 60px
+    margin-bottom: unit( 55px / @base-font-size-px, em);
+
     .short-desc {
-        padding-bottom: unit( @grid_gutter-width / 2 / @base-font-size-px, em)
+        padding-bottom: unit( (@grid_gutter-width / 2) / @base-font-size-px, em);
+    }
+
+    .lead-paragraph {
+        margin-top: 0;
+    }
+
+    .meta {
+        .byline {
+          .heading-4();
+        }
+
+        // visually approximates 30px
+        margin-bottom: unit(20px / @base-font-size-px, em);
     }
 }
+
 
 /* topdoc
     name: EOF

--- a/cfgov/unprocessed/css/organisms/item-introduction.less
+++ b/cfgov/unprocessed/css/organisms/item-introduction.less
@@ -52,7 +52,6 @@
         }
 
         // visually approximates 30px
-        margin-bottom: unit(20px / @base-font-size-px, em);
     }
 }
 

--- a/cfgov/unprocessed/css/organisms/item-introduction.less
+++ b/cfgov/unprocessed/css/organisms/item-introduction.less
@@ -47,11 +47,12 @@
     }
 
     .meta {
+      // visually approximates 30px
+      margin-bottom: unit(20px / @base-font-size-px, em);
+
         .byline {
           .heading-4();
         }
-
-        // visually approximates 30px
     }
 }
 

--- a/cfgov/unprocessed/css/post.less
+++ b/cfgov/unprocessed/css/post.less
@@ -373,14 +373,15 @@
     - cfgov-post
 */
 
+.post_header {
+    // Eyeballed to 60px.
+    margin-bottom: unit( 55px / @base-font-size-px, em);
+}
+
 .post_heading {
     .h2();
-    // Eyeballed to 24px.
-    margin-bottom: unit(13px / @font-size, em);
     .respond-to-min(@bp-sm-min, {
         .h1();
-        // Eyeballed to 24px.
-        margin-bottom: unit(10px / @font-size, em);
     });
 }
 
@@ -391,7 +392,8 @@
 }
 
 .post_meta {
-    margin-bottom: unit(18px / @base-font-size-px, em);
+    // Eyeballed to 30px.
+    margin-bottom: unit(22px / @base-font-size-px, em);
 }
 
 .post_byline {
@@ -412,7 +414,6 @@
 
 .post_body {
     .u-clearfix();
-    margin-top: unit( @grid_gutter-width / @base-font-size-px, em );
     color: @dark-gray;
 
     // Spacing has been eyeballed to be 30px.

--- a/cfgov/unprocessed/css/post.less
+++ b/cfgov/unprocessed/css/post.less
@@ -373,33 +373,6 @@
     - cfgov-post
 */
 
-.post_header {
-    // Eyeballed to 60px.
-    margin-bottom: unit( 55px / @base-font-size-px, em);
-}
-
-.post_heading {
-    .h2();
-    .respond-to-min(@bp-sm-min, {
-        .h1();
-    });
-}
-
-.post_dek {
-    .h4();
-    // Eyeballed to 30px.
-    margin-bottom: unit(20px / @font-size, em);
-}
-
-.post_meta {
-    // Eyeballed to 30px.
-    margin-bottom: unit(22px / @base-font-size-px, em);
-}
-
-.post_byline {
-    .h4();
-}
-
 .post_featured-img {
     display: block;
     margin: unit(16px / @base-font-size-px, em) 0;

--- a/cfgov/unprocessed/css/post.less
+++ b/cfgov/unprocessed/css/post.less
@@ -373,6 +373,31 @@
     - cfgov-post
 */
 
+.post_heading {
+    .h2();
+    // Eyeballed to 24px.
+    margin-bottom: unit(13px / @font-size, em);
+    .respond-to-min(@bp-sm-min, {
+        .h1();
+        // Eyeballed to 24px.
+        margin-bottom: unit(10px / @font-size, em);
+    });
+}
+
+.post_dek {
+    .h4();
+    // Eyeballed to 30px.
+    margin-bottom: unit(20px / @font-size, em);
+}
+
+.post_meta {
+    margin-bottom: unit(18px / @base-font-size-px, em);
+}
+
+.post_byline {
+    .h4();
+}
+
 .post_featured-img {
     display: block;
     margin: unit(16px / @base-font-size-px, em) 0;
@@ -387,6 +412,7 @@
 
 .post_body {
     .u-clearfix();
+    margin-top: unit( @grid_gutter-width / @base-font-size-px, em );
     color: @dark-gray;
 
     // Spacing has been eyeballed to be 30px.

--- a/test/browser_tests/page_objects/page_blog-single.js
+++ b/test/browser_tests/page_objects/page_blog-single.js
@@ -13,13 +13,13 @@ function BlogSingle() {
 
   this.pageTitle = function() { return browser.getTitle(); };
 
-  this.postTitle = element( by.css( 'header .post_heading' ) );
+  this.postTitle = element( by.css( 'header h1' ) );
 
-  this.postByLine = element( by.css( 'header .post_byline' ) );
+  this.postByLine = element( by.css( 'header .byline' ) );
 
   this.postBody = element( by.css( '.post .post_body' ) );
 
-  this.share = element( by.css( 'header .share' ) );
+  this.share = element( by.css( 'header .m-social-media__share' ) );
 
   this.breadcrumbs = element( by.css( '.breadcrumbs' ) );
 


### PR DESCRIPTION
Update spacing between header elements in item introduction and use item introduction template for blog/newsroom header

## Additions
- add 'and' between author names in item introduction byline
- add an else condition in category-slug class output

## Changes
- update spacing between elements in item introduction 
- use item introduction for article header

## Testing

- Navigate to a [blog post](http://localhost:8000/about-us/blog/older-americans-are-not-alone-in-the-fight-to-stop-financial-abuse/) and a [page with item introduction](http://localhost:8000/data-research/research-reports/2014-consumer-response-annual-report/). Check that:
  - Header element spacing matches specs in bug report (issue 10)
  - Multiple author names are joined by 'and'

## Review

- @contolini 
- @sebworks 
- @Scotchester 

## Screenshots
<img width="785" alt="screen shot 2016-07-13 at 7 13 03 am" src="https://cloud.githubusercontent.com/assets/778171/16809192/31b77b0a-48d4-11e6-9b4e-bb6720c3be1f.png">

<img width="712" alt="screen shot 2016-07-13 at 7 13 32 am" src="https://cloud.githubusercontent.com/assets/778171/16809203/3bb0a56e-48d4-11e6-842f-02419e5ee6d3.png">


## Notes

- Lead paragraph is output in item introduction even when it has no content, causing slight spacing discrepancies
- Article template still needs to be converted to use item introduction template if possible
- If article template can't use item introduction template, consider moving byline generation from both templates into its own macro

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)

