### PR TITLE
Speedup Python unit tests by removing DB dependence

### DIFF
--- a/cfgov/cfgov/urls.py
+++ b/cfgov/cfgov/urls.py
@@ -37,16 +37,16 @@ urlpatterns = [
 
     url(r'^home/(?P<path>.*)$', RedirectView.as_view(url='/%(path)s', permanent=True)),
 
-    url(r'^owning-a-home/static/(?P<path>.*)$', RedirectView.as_view(url='/static/owning-a-home/static/%(path)s')),
-    url(r'^owning-a-home/resources/(?P<path>.*)$', RedirectView.as_view(url='/static/owning-a-home/resources/%(path)s')),
+    url(r'^owning-a-home/static/(?P<path>.*)$', RedirectView.as_view(url='/static/owning-a-home/static/%(path)s', permanent=True)),
+    url(r'^owning-a-home/resources/(?P<path>.*)$', RedirectView.as_view(url='/static/owning-a-home/resources/%(path)s', permanent=True)),
     url(r'^owning-a-home/', include(SheerSite('owning-a-home').urls)),
 
     # the two redirects are an unfortunate workaround, could be resolved by
     # using static('path/to/asset') in the source template
 
-    url(r'^tax-time-saving/static/(?P<path>.*)$', RedirectView.as_view(url='/static/tax-time-saving/static/%(path)s')),
+    url(r'^tax-time-saving/static/(?P<path>.*)$', RedirectView.as_view(url='/static/tax-time-saving/static/%(path)s', permanent=True)),
     url(r'^tax-time-saving/', include(SheerSite('tax-time-saving').urls)),
-    url(r'^know-before-you-owe/static/(?P<path>.*)$', RedirectView.as_view(url='/static/know-before-you-owe/static/%(path)s')),
+    url(r'^know-before-you-owe/static/(?P<path>.*)$', RedirectView.as_view(url='/static/know-before-you-owe/static/%(path)s', permanent=True)),
     url(r'^know-before-you-owe/', include(SheerSite('know-before-you-owe').urls)),
 
     url(r'^adult-financial-education/', include(fin_ed.urls_for_prefix('adult-financial-education'))),
@@ -186,10 +186,10 @@ urlpatterns = [
             template_name='regulation-comment/reg-comment-form-test.html'),
         name='reg-comment-form-test'),
 
-    url(r'^feed/$', RedirectView.as_view(url='/about-us/blog/feed/')),
-    url(r'^feed/blog/$', RedirectView.as_view(url='/about-us/blog/feed/')),
-    url(r'^feed/newsroom/$', RedirectView.as_view(url='/about-us/newsroom/feed/')),
-    url(r'^newsroom-feed/$', RedirectView.as_view(url='/about-us/newsroom/feed/')),
+    url(r'^feed/$', RedirectView.as_view(url='/about-us/blog/feed/', permanent=True)),
+    url(r'^feed/blog/$', RedirectView.as_view(url='/about-us/blog/feed/', permanent=True)),
+    url(r'^feed/newsroom/$', RedirectView.as_view(url='/about-us/newsroom/feed/', permanent=True)),
+    url(r'^newsroom-feed/$', RedirectView.as_view(url='/about-us/newsroom/feed/', permanent=True)),
 
     url(r'^about-us/$', SheerTemplateView.as_view(template_name='about-us/index.html'), name='about-us'),
 

--- a/cfgov/sheerlike/loaders.py
+++ b/cfgov/sheerlike/loaders.py
@@ -1,5 +1,4 @@
 from jinja2.loaders import FileSystemLoader
-import fslib
 
 
 class FslibLoader(FileSystemLoader):

--- a/cfgov/v1/models/browse_filterable_page.py
+++ b/cfgov/v1/models/browse_filterable_page.py
@@ -12,7 +12,6 @@ from wagtail.wagtailadmin.edit_handlers import TabbedInterface, ObjectList
 
 from .base import CFGOVPage
 from .learn_page import AbstractFilterPage
-from .. import forms
 from ..atomic_elements import molecules, organisms
 from ..feeds import FilterableFeedPageMixin
 from ..util.filterable_list import FilterableListMixin
@@ -57,14 +56,18 @@ class BrowseFilterablePage(FilterableFeedPageMixin, FilterableListMixin, CFGOVPa
 class EventArchivePage(BrowseFilterablePage):
     template = 'browse-filterable/index.html'
 
-    def get_form_class(self):
+    @staticmethod
+    def get_form_class():
+        from .. import forms
         return forms.EventArchiveFilterForm
 
 
 class NewsroomLandingPage(BrowseFilterablePage):
     template = 'newsroom/index.html'
 
-    def get_form_class(self):
+    @staticmethod
+    def get_form_class():
+        from .. import forms
         return forms.NewsroomFilterForm
 
     def get_page_set(self, form, hostname):

--- a/cfgov/v1/models/sublanding_filterable_page.py
+++ b/cfgov/v1/models/sublanding_filterable_page.py
@@ -14,7 +14,6 @@ from wagtail.wagtailimages.blocks import ImageChooserBlock
 
 from .base import CFGOVPage
 from .learn_page import AbstractFilterPage
-from .. import forms
 from ..atomic_elements import molecules, organisms
 from ..feeds import FilterableFeedPageMixin
 from ..util.ref import choices_for_page_type
@@ -52,7 +51,9 @@ class ActivityLogPage(SublandingFilterablePage):
     template = 'activity-log/index.html'
 
 
-    def get_form_class(self):
+    @staticmethod
+    def get_form_class():
+        from .. import forms
         return forms.ActivityLogFilterForm
 
 

--- a/cfgov/v1/tests/models/test_browse_filterable_page.py
+++ b/cfgov/v1/tests/models/test_browse_filterable_page.py
@@ -1,0 +1,22 @@
+from unittest import TestCase
+
+from v1.forms import EventArchiveFilterForm, NewsroomFilterForm
+from v1.models.browse_filterable_page import (
+    EventArchivePage, NewsroomLandingPage
+)
+
+
+class EventArchivePageTestCase(TestCase):
+    def test_get_form_class(self):
+        self.assertEqual(
+            EventArchivePage.get_form_class(),
+            EventArchiveFilterForm
+        )
+
+
+class NewroomLandingPageTestCase(TestCase):
+    def test_get_form_class(self):
+        self.assertEqual(
+            NewsroomLandingPage.get_form_class(),
+            NewsroomFilterForm
+        )

--- a/cfgov/v1/tests/models/test_sublanding_filterable_page.py
+++ b/cfgov/v1/tests/models/test_sublanding_filterable_page.py
@@ -1,0 +1,12 @@
+from unittest import TestCase
+
+from v1.forms import ActivityLogFilterForm
+from v1.models.sublanding_filterable_page import ActivityLogPage
+
+
+class ActivityLogPageTestCase(TestCase):
+    def test_get_form_class(self):
+        self.assertEqual(
+            ActivityLogPage.get_form_class(),
+            ActivityLogFilterForm
+        )

--- a/cfgov/v1/tests/test_password_policy.py
+++ b/cfgov/v1/tests/test_password_policy.py
@@ -81,12 +81,12 @@ class TestMinimumPasswordAge(TestWithUser):
 
 class TestPasswordReusePolicy(TestWithUser):
     def test_can_set_new_password(self):
-        user = self.get_user('password1')
+        user = self.get_user(last_password='password1')
         password_policy.validate_password_history(user, 'password2')
 
     def test_cant_reuse_password(self):
         password = 'password'
-        user = self.get_user(password)
+        user = self.get_user(last_password=password)
         self.assertRaises(
             ValidationError,
             password_policy.validate_password_history,

--- a/cfgov/v1/util/filterable_list.py
+++ b/cfgov/v1/util/filterable_list.py
@@ -1,6 +1,5 @@
 from django.core.paginator import Paginator, EmptyPage, PageNotAnInteger
 
-from .. import forms
 from ..models.learn_page import AbstractFilterPage
 from ..util.util import get_secondary_nav_items
 
@@ -13,6 +12,7 @@ class FilterableListMixin(object):
 
     # Returns a form class to use for the filterable list
     def get_form_class(self):
+        from .. import forms
         return forms.FilterableListForm
 
 

--- a/gulp/tasks/test.js
+++ b/gulp/tasks/test.js
@@ -42,7 +42,6 @@ function testUnitScripts( cb ) {
 function testUnitServer() {
   spawn(
     'tox',
-    [ 'cfgov/core/tests' ],
     { stdio: 'inherit' }
   ).once( 'close', function() {
     plugins.util.log( 'Tox tests done!' );

--- a/tox.ini
+++ b/tox.ini
@@ -17,3 +17,7 @@ changedir = {toxinidir}/cfgov
 commands=
     python manage.py test {posargs}
     
+[testenv:fast]
+recreate = False
+commands =
+    python -m unittest discover


### PR DESCRIPTION
Speedup Python unit tests by removing their dependence on the database. This speeds up the current Python unit tests from roughly two minutes to roughly two seconds:

```sh
$ time tox -e fast
...
Ran 129 tests in 0.506s
...
real    0m1.783s
user    0m1.381s
sys     0m0.313s
```

## Additions

- This PR introduces an alternate tox environment named `fast` that runs without recreating the virtualenv each time, invoked using `tox -e fast`. It also invokes tests using `python -m unittest discover` instead of `./manage. py test`, removing any dependence on the Django database. The standard tox environment (that recreates the DB and uses it each time) is still run if you just invoke `tox`.

## Changes

- There were several dozen tests that had some dependence on the database. Many of these were  using the built-in [test client](https://docs.djangoproject.com/en/1.9/topics/testing/tools/#the-test-client) which seems to check the `Site` table. Instead I use the [RequestFactory](https://docs.djangoproject.com/en/1.9/topics/testing/advanced/#django.test.RequestFactory) which lets you create requests and test views against them without going through the urlconf.
- Some of the existing unit tests had some painful mocking going on; I've tried to make things less painful but there are still some refactors that it would be good to have others review. See additional PR comments for some detail.
- This modifies the current `gulp test` command to run all backend unit tests; before it was only running the ones in `core.test` for some reason.

## Testing

- From the command line you can now do:

```sh
$ tox -e fast
```

Alternatively to run a subset of tests you can do something like:

```sh
~/Projects/cfgov-refresh/cfgov $ source .tox/fast/bin/activate
(fast) ~/Projects/cfgov-refresh/cfgov $ DJANGO_SETTINGS_MODULE=cfgov.settings.test python -m unittest core.tests.test_views
```

## Review

- @richaagarwal 
- @grapesmoker 
- @rosskarchner 
- @willbarton 

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
