### PR TITLE
Fix pagination bug

### DIFF
--- a/cfgov/jinja2/v1/_includes/leadership-calendar-table.html
+++ b/cfgov/jinja2/v1/_includes/leadership-calendar-table.html
@@ -1,4 +1,4 @@
-{% macro render(posts, user_options) %}
+{% macro render(user_options={}) %}
 
 {% import 'macros/time.html' as time %}
 
@@ -9,44 +9,49 @@
 } %}
 {% set _ignore = options.update(user_options) %}
 
-{% for days in posts|groupby('day')|reverse %}
+{# Page the events by the earliest and latest dates in the range. #}
+{% set range = day_range or page_days %}
+{% set from = range[-1] %}
+{% set to = range[0] %}
+{% set paged_events = events.filter(dtstart__gte=from).filter(dtstart__lte=to).order_by('-dtstart') %}
+
+{% for day in page_days %}
 <table class="u-w100pct block block__flush-top">
     <thead>
         <tr>
             <th colspan="3">
-                {{ time.render(days.grouper, {'date':true}) }}
+                {{ time.render(day, {'date':true}) }}
             </th>
         </tr>
     </thead>
     <tbody>
-    {% for event in days.list|sort(attribute='dtstart') %}
-        <tr>
-            <td class="{{ options.time_col_classes }}">
-            {%- if event.all_day %}
-                All day
-            {%- else %}
-                {{ time.render(event.dtstart, {'time':true}) }}
-                &ndash;
-                {{ time.render(event.dtend, {'time':true}) }}
-            {%- endif %}
-            </td>
-            <td class="{{ options.name_col_classes }}">
-                <span class="h4">
-                    {{ event.calendar }}
-                </span>
-            </td>
-            <td class="{{ options.desc_col_classes }}">
-                {{ event.summary }}
-            {% if event.location %}
-                <br>
-                <span class="u-small-text">{{ event.location }}</span>
-            {% endif %}
-            {% if event.description %}
-                <br>
-                <small><i>{{ event.description }}</i></small>
-            {% endif %}
-            </td>
-        </tr>
+    {% for event in paged_events|sort(attribute='dtstart') %}
+        {% set start = event.dtstart | dateobj %}
+        {% if start.date() == day.date() %}
+            <tr>
+                <td class="{{ options.time_col_classes }}">
+                {%- if event.all_day %}
+                    All day
+                {%- else %}
+                    {{ time.render(event.dtstart, {'time':true}) }}
+                    &ndash;
+                    {{ time.render(event.dtend, {'time':true}) }}
+                {%- endif %}
+                </td>
+                <td class="{{ options.name_col_classes }}">
+                    <span class="h4">
+                        {{ event.calendar }}
+                    </span>
+                </td>
+                <td class="{{ options.desc_col_classes }}">
+                    {{ event.summary }}
+                {% if event.description %}
+                    <br>
+                    <small><i>{{ event.description }}</i></small>
+                {% endif %}
+                </td>
+            </tr>
+        {% endif %}
     {% endfor %}
     </tbody>
 </table>

--- a/cfgov/jinja2/v1/_includes/macros/active-filters.html
+++ b/cfgov/jinja2/v1/_includes/macros/active-filters.html
@@ -68,11 +68,7 @@
     {%- if options.show_filters_label -%}
         <li class="list_item filtered-by_header">
         {%- if posts | list | length > 0 -%}
-          {% if posts.paginator -%}
-            {{ posts.paginator.count }} filtered result{{ 's' if posts.paginator.count > 1 }} for
-          {% else -%}
-            {{ posts.total }} filtered result{{ 's' if posts.total > 1 }} for
-          {% endif -%}
+            {{ posts | list | length }} filtered result{{ 's' if posts | list | length > 1 }} for
         {%- else -%}
             No results for
         {%- endif -%}
@@ -98,11 +94,7 @@
     {% if options.show_unfiltered_count and options.show_filters_label %}
         <li class="list_item">
             <span class="filtered-by_header">
-              {% if posts.paginator -%}
-                {{ posts.paginator.count }} result{{ 's' if posts.paginator.count > 1 }}
-              {% else -%}
-                {{ posts.total }} result{{ 's' if posts.total > 1 }}
-              {% endif -%}
+              {{ posts | list | length }} filtered result{{ 's' if posts | list | length > 1 }} for
             </span>
         </li>
     {% endif %}
@@ -115,15 +107,9 @@
    ========================================================================== #}
 {% macro _active_filters_notification(posts, has_active_filters=false) %}
 {%- if posts | list | length > 0 -%}
-    {% if posts.paginator is defined and posts.paginator -%}
-      {% set text = posts.paginator.count | string
-                    + ' filtered result'
-                    + ('s' if posts.paginator.count > 1 else '') %}
-    {% else -%}
-      {% set text = posts.total | string
-                    + ' filtered result'
-                    + ('s' if posts.total > 1 else '') %}
-    {% endif -%}
+    {% set text = posts | list | length | string
+                  + ' filtered result'
+                  + ('s' if posts | list | length > 1 else '') %}
     {% set type = 'success' %}
     {% set is_visible = has_active_filters %}
 {%- else -%}

--- a/cfgov/jinja2/v1/about-us/the-bureau/leadership-calendar/index.html
+++ b/cfgov/jinja2/v1/about-us/the-bureau/leadership-calendar/index.html
@@ -20,7 +20,7 @@
 
 {% block content_main %}
 
-    {% import 'leadership-calendar-table.html' as calendar %}
+    {% import 'leadership-calendar-table.html' as calendar with context %}
     {% import 'molecules/social-media.html' as social_media %}
     {% from 'post-macros.html' import pagination as pagination with context %}
 
@@ -55,7 +55,7 @@
 
             {# Set the filters #}
 
-		{% set filter_by = {
+    		{% set filter_by = {
                 'calendar':   true,
                 'range_date': true
             } %}
@@ -65,11 +65,15 @@
                 paginator,
                 events,
                 'calendar_event',
-                { 'expand_label': 'Filter calendars' }
+                { 'expand_label': 'Filter calendars', 'show_errors': true }
             ) }}
-            {{ calendar.render(events) }}
+            {% if events is defined and page_days is defined %}
+                {{ calendar.render() }}
+            {% endif %}
 
-            {{ pagination(paginator, ['calendar', 'range_date_gte', 'range_date_lte']) }}
+            {% if paginator is defined %}
+                {{ pagination(paginator, ['calendar', 'range_date_gte', 'range_date_lte']) }}
+            {% endif %}
         </div>
     </div>
 

--- a/cfgov/jinja2/v1/about-us/the-bureau/leadership-calendar/print/index.html
+++ b/cfgov/jinja2/v1/about-us/the-bureau/leadership-calendar/print/index.html
@@ -27,10 +27,10 @@
 
                     <h1 class="superheader">Leadership Calendar</h1>
                     {% if form.cleaned_data['filter_calendar']%}
-                    {{events|length}} events for {{ form.cleaned_data['filter_calendar']|join(', ') }}
+                    {{ events | length }} events for {{ form.cleaned_data['filter_calendar']|join(', ') }}
                     {% endif %}
-                    from {{ range_start|date("%B %d, %Y") }}
-                    to {{ range_end|date("%B %d, %Y") }}
+                    from {{ range_start | date("%B %d, %Y") }}
+                    to {{ range_end | date("%B %d, %Y") }}
 
 
                 </div>

--- a/cfgov/sheerlike/__init__.py
+++ b/cfgov/sheerlike/__init__.py
@@ -19,7 +19,7 @@ from unipath import Path
 
 from .query import QueryFinder, more_like_this, get_document, when
 from .filters import selected_filters_for_field, is_filter_selected
-from .templates import get_date_string
+from .templates import get_date_string, get_date_obj
 from .middleware import get_request
 
 
@@ -112,6 +112,7 @@ def environment(**options):
         'global_include': global_render_template,
     })
     env.filters.update({
-        'date': get_date_string
+        'date': get_date_string,
+        'dateobj': get_date_obj
     })
     return env


### PR DESCRIPTION
There is a bug in the [Leadership Calendar](http://www.consumerfinance.gov/about-us/the-bureau/leadership-calendar) where a day's events that split across multiple pages output out of order and/or missing. Also, events that have a start date within the hour threshold of being saved in UTC as the next day are showing up in UTC day's table instead of it's actual day's table. Additionally, there was a `pdb` statement left in there from the last PR that needed to be removed because [invalid form submission results in server errors](http://www.consumerfinance.gov/about-us/the-bureau/leadership-calendar/?filter_range_date_gte=01).

## Changes
The reason for the pagination bug is somewhat simple but took some maneuvering to overcome. We served events to the page in most recent to least then grouped events by the day and reversed the order within that day. This caused the strange behavior seen when days were split between pages.

- In order to subvert this, I changed the the display of each page to show events in **iterations of 5 days**. 
- I also refactored the view function and fixed the template for the new logic to display events.

## Testing

- `gulp test`
- go to leadership calendar page
- click on pagination button to see each page have 5 days of events that _do not_ bleed events for a single day across pages
- filter the events for a date range
 - filter across 6 days to see 2 pages with one that has 1 day. There's some logic that handles that specifically that should be tested.
- filter by calendar
- test that the PDF works

## Review

- @rosskarchner 
- @richaagarwal 
- @willbarton 
- @schaferjh re: **"5 days per page"** (I thought this flowed better since some days were very short)
- anyone else i should've tagged

## Screenshots
### Before
#### Page 1
![screen shot 2016-07-14 at 1 21 08 pm](https://cloud.githubusercontent.com/assets/1412978/16848883/e2e819d8-49c5-11e6-85e7-12af92da65a4.png)

#### Page 2
![screen shot 2016-07-14 at 1 20 57 pm](https://cloud.githubusercontent.com/assets/1412978/16848887/e6f52548-49c5-11e6-955a-157ad0490228.png)

### After
#### Page 1
![screen shot 2016-07-14 at 1 35 04 pm](https://cloud.githubusercontent.com/assets/1412978/16849312/de65ee56-49c7-11e6-8241-2e0725cc1361.png)

#### Page 2
![screen shot 2016-07-14 at 1 35 12 pm](https://cloud.githubusercontent.com/assets/1412978/16849314/e0b39f32-49c7-11e6-88a9-d616216edb1f.png)

## Notes

- There are a few more things that I noticed that the Platform team should be aware of:
 - Invalid date input gets passed into the backend and invalidates the form. I've programmed it to return nothing but **there's no error message shown, only a warn notification stating there's no results.** Additionally, on the JS date validator, the date formats that are invalid but not caught send that request to the server and then get fixed in the form after page load which is confusing because the user submits something invalid and then sees a valid date with no results. This is better than before, where it would just throw a 500 error, but definitely isn't desired. I felt that this was out of scope for the pagination fix.
- To the same point, there are certain date formats that are caught by the JS validator and some that are not. The validator should probably be smarter.
- There are two places where leadership calendar PDF handling is located. [Here](https://github.com/cfpb/cfgov-refresh/blob/f3f5dd156dd121c1db8ae62b484d83ebee7c9b37/cfgov/cal/views.py#L125) and [here](https://github.com/cfpb/cfgov-refresh/blob/flapjack/cfgov/core/services.py#L30). This should be refactored. Again, out of scope for this PR.

## Todos

- Add tests
- Add a CHANGELOG entry

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
* [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)

