### PR TITLE
Pin version of html5lib because of breaking change in latest release

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -12,6 +12,7 @@ git+https://github.com/rosskarchner/govdelivery.git#egg=govdelivery
 icalendar==3.9.0
 django-localflavor==1.1
 wagtail==1.3
+html5lib==0.999999
 MySQL-python==1.2.5
 django-extensions==1.5.5
 boto==2.38.0


### PR DESCRIPTION
- [Bug on BS4](https://bugs.launchpad.net/beautifulsoup/+bug/1603299)
- [Current Wagtail version susceptible](https://github.com/torchbox/wagtail/blob/v1.3/setup.py#L32)
- [Wagtail version upgrade still susceptible](https://github.com/torchbox/wagtail/blob/v1.5.2/setup.py#L31)
- [Wagtail commit to solve issue that's not released yet](https://github.com/torchbox/wagtail/blob/master/setup.py#L31)

## Additions

- html5lib version _after_ wagtail in `requirements/base.txt`

## Testing

- `pip install -r requirements/local.txt`
- `tox`

## Review

- @richaagarwal 
- @rosskarchner 
- @willbarton 


## Todos

- CHANGELOG

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)

