### PR TITLE
Updates ESLint to v3

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -63,12 +63,6 @@ rules:
 
   # Rules for flagging POSSIBLE ERRORS.
 
-  # Consistent use of trailing commas in object and array literals.
-  # This rule is needed for IE8- support.
-  comma-dangle:
-    - 2
-    - never
-
   # Disallows assignment in conditional expressions.
   no-cond-assign:
     - 2
@@ -95,11 +89,11 @@ rules:
   # Disallow a duplicate case label.
   no-duplicate-case: 2
 
-  # Disallows empty statements.
-  no-empty: 2
-
   # Disallow the use of empty character classes in regular expressions.
   no-empty-character-class: 2
+
+  # Disallows empty statements.
+  no-empty: 2
 
   # Disallows assigning to the exception in a catch block.
   no-ex-assign: 2
@@ -145,7 +139,7 @@ rules:
   # Array values should be explicitly defined.
   no-sparse-arrays: 2
 
-  # Avoid code that looks like two expressions but is actually one.
+  # Disallow confusing multiline expressions.
   no-unexpected-multiline: 2
 
   # Disallows unreachable statements after a return, throw, continue, or break.
@@ -318,20 +312,20 @@ rules:
   # Disallows reassignments of native objects.
   no-native-reassign: 2
 
-  # Disallows use of new operator when not part of the assignment or comparison.
-  no-new: 1
-
   # Disallows use of new operator for Function object.
   no-new-func: 2
 
   # Disallows creating new instances of String, Number, and Boolean.
   no-new-wrappers: 2
 
-  # Disallows use of octal literals.
-  no-octal: 2
+  # Disallows use of new operator when not part of the assignment or comparison.
+  no-new: 1
 
   # Disallows use of octal escape sequences in string literals, e.g. "\251".
   no-octal-escape: 2
+
+  # Disallows use of octal literals.
+  no-octal: 2
 
   # Disallow reassignment of function parameters.
   no-param-reassign:
@@ -450,22 +444,22 @@ rules:
   # Disallow specified global variables.
   no-restricted-globals: 2
 
+  # Disallows shadowing of names such as arguments.
+  no-shadow-restricted-names: 2
+
   # Disallows declaring variables already declared in the outer scope.
   no-shadow:
     - 1
     -
       hoist: functions
 
-  # Disallows shadowing of names such as arguments.
-  no-shadow-restricted-names: 2
+  # Disallows use of undefined when initializing variables.
+  no-undef-init: 2
 
   # Disallows use of undeclared vars unless mentioned in a /*global */ block.
   no-undef:
     - 2
     - typeof: true
-
-  # Disallows use of undefined when initializing variables.
-  no-undef-init: 2
 
   # Disallows use of undefined variable.
   no-undefined: 2
@@ -562,6 +556,12 @@ rules:
     - 1
     -
       properties: always
+
+  # Consistent use of trailing commas in object and array literals.
+  # This rule is needed for IE8- support.
+  comma-dangle:
+    - 2
+    - never
 
   # Enforce spacing before and after comma.
   comma-spacing:
@@ -834,15 +834,15 @@ rules:
     -
       allowMultiplePropertiesPerLine: true
 
-  # Disallows multiple var statements per function.
-  one-var:
-    - 0
-    - always
-
   # Require or disallow an newline around variable declarations.
   one-var-declaration-per-line:
     - 2
     - initializations
+
+  # Disallows multiple var statements per function.
+  one-var:
+    - 0
+    - always
 
   # Requires assignment operator shorthand or prohibit it entirely.
   operator-assignment:
@@ -878,17 +878,17 @@ rules:
   require-jsdoc:
     - 1
 
-  # Requires or disallows use of semicolons instead of ASI.
-  semi:
-    - 2
-    - always
-
   # Disallows space before semicolon.
   semi-spacing:
     - 2
     -
       before: false
       after: true
+
+  # Requires or disallows use of semicolons instead of ASI.
+  semi:
+    - 2
+    - always
 
   # Enforces sorting variables within the same declaration block.
   sort-vars: 0

--- a/.eslintrc
+++ b/.eslintrc
@@ -705,16 +705,19 @@ rules:
     - 1
     - 5
 
-  # Specifies maximum number of statement allowed in a function.
-  max-statements:
-    - 1
-    - 25
-
   # Enforce a maximum number of statements allowed per line.
   max-statements-per-line:
     - 1
     -
       max: 2
+
+  # Specifies maximum number of statement allowed in a function.
+  max-statements:
+    - 1
+    - 25
+
+  # Enforce newlines between operands of ternary expressions.
+  multiline-ternary: 0
 
   # Require a capital letter for constructors.
   new-cap:
@@ -928,11 +931,18 @@ rules:
     - 2
     - always
     -
-      exceptions:
-        - '-'
-        - +
-      markers:
-        - /
+      line:
+        markers:
+          - '/'
+        exceptions:
+          - '-'
+          - '+'
+      block:
+        markers:
+          - '!'
+        exceptions:
+          - '*'
+        balanced: true
 
   # Require or disallow the Unicode BOM.
   unicode-bom:

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -981,9 +981,9 @@
       }
     },
     "bufferstreams": {
-      "version": "1.1.0",
-      "from": "bufferstreams@>=1.1.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/bufferstreams/-/bufferstreams-1.1.0.tgz"
+      "version": "1.1.1",
+      "from": "bufferstreams@>=1.1.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/bufferstreams/-/bufferstreams-1.1.1.tgz"
     },
     "builtin-modules": {
       "version": "1.1.1",
@@ -1076,6 +1076,16 @@
           "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.3.tgz"
         }
       }
+    },
+    "cf-component-demo": {
+      "version": "0.8.2",
+      "from": "git://github.com/cfpb/cf-component-demo.git#d654f01b58b4ee980ba9bc575392c6c8a9ff4279",
+      "resolved": "git://github.com/cfpb/cf-component-demo.git#d654f01b58b4ee980ba9bc575392c6c8a9ff4279"
+    },
+    "chai": {
+      "version": "3.5.0",
+      "from": "chai@3.5.0",
+      "resolved": "http://registry.npmjs.org/chai/-/chai-3.5.0.tgz"
     },
     "chalk": {
       "version": "1.1.3",
@@ -1901,6 +1911,130 @@
       "from": "doctrine@1.1.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.1.0.tgz"
     },
+    "documentation": {
+      "version": "4.0.0-beta2",
+      "from": "documentation@4.0.0-beta2",
+      "resolved": "https://registry.npmjs.org/documentation/-/documentation-4.0.0-beta2.tgz",
+      "dependencies": {
+        "camelcase": {
+          "version": "3.0.0",
+          "from": "camelcase@>=3.0.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz"
+        },
+        "cliui": {
+          "version": "3.2.0",
+          "from": "cliui@>=3.2.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz"
+        },
+        "glob": {
+          "version": "5.0.15",
+          "from": "glob@>=5.0.3 <6.0.0",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz"
+        },
+        "glob-stream": {
+          "version": "5.3.2",
+          "from": "glob-stream@>=5.3.2 <6.0.0",
+          "resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-5.3.2.tgz",
+          "dependencies": {
+            "micromatch": {
+              "version": "2.3.11",
+              "from": "micromatch@>=2.3.7 <3.0.0",
+              "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz"
+            },
+            "readable-stream": {
+              "version": "1.0.34",
+              "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz"
+            },
+            "through2": {
+              "version": "0.6.5",
+              "from": "through2@>=0.6.0 <0.7.0",
+              "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz"
+            }
+          }
+        },
+        "lodash.assign": {
+          "version": "4.0.9",
+          "from": "lodash.assign@>=4.0.3 <5.0.0",
+          "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.0.9.tgz"
+        },
+        "lodash.keys": {
+          "version": "4.0.7",
+          "from": "lodash.keys@>=4.0.0 <5.0.0",
+          "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-4.0.7.tgz"
+        },
+        "mime": {
+          "version": "1.3.4",
+          "from": "mime@>=1.3.4 <2.0.0",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz"
+        },
+        "minimist": {
+          "version": "0.0.8",
+          "from": "minimist@0.0.8",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "from": "mkdirp@>=0.5.0 <0.6.0",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz"
+        },
+        "object-assign": {
+          "version": "4.1.0",
+          "from": "object-assign@>=4.0.0 <5.0.0",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz"
+        },
+        "ordered-read-streams": {
+          "version": "0.3.0",
+          "from": "ordered-read-streams@>=0.3.0 <0.4.0",
+          "resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.3.0.tgz"
+        },
+        "set-blocking": {
+          "version": "2.0.0",
+          "from": "set-blocking@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz"
+        },
+        "strip-bom": {
+          "version": "2.0.0",
+          "from": "strip-bom@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz"
+        },
+        "strip-json-comments": {
+          "version": "2.0.1",
+          "from": "strip-json-comments@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz"
+        },
+        "unique-stream": {
+          "version": "2.2.1",
+          "from": "unique-stream@>=2.0.2 <3.0.0",
+          "resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-2.2.1.tgz"
+        },
+        "vinyl": {
+          "version": "1.1.1",
+          "from": "vinyl@>=1.1.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.1.1.tgz"
+        },
+        "vinyl-fs": {
+          "version": "2.4.3",
+          "from": "vinyl-fs@>=2.3.1 <3.0.0",
+          "resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-2.4.3.tgz"
+        },
+        "window-size": {
+          "version": "0.2.0",
+          "from": "window-size@>=0.2.0 <0.3.0",
+          "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.2.0.tgz"
+        },
+        "yargs": {
+          "version": "4.8.1",
+          "from": "yargs@>=4.3.1 <5.0.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-4.8.1.tgz"
+        },
+        "yargs-parser": {
+          "version": "2.4.1",
+          "from": "yargs-parser@>=2.4.1 <3.0.0",
+          "resolved": "https://registry.npmjs.com/yargs-parser/-/yargs-parser-2.4.1.tgz"
+        }
+      }
+    },
     "documentation-theme-default": {
       "version": "3.0.0-beta",
       "from": "documentation-theme-default@3.0.0-beta",
@@ -2278,6 +2412,11 @@
       "from": "es5-ext@>=0.10.8 <0.11.0",
       "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.11.tgz"
     },
+    "es5-shim": {
+      "version": "4.5.7",
+      "from": "es5-shim@4.5.7",
+      "resolved": "https://registry.npmjs.org/es5-shim/-/es5-shim-4.5.7.tgz"
+    },
     "es6-iterator": {
       "version": "2.0.0",
       "from": "es6-iterator@>=2.0.0 <3.0.0",
@@ -2358,7 +2497,7 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-3.1.1.tgz",
       "dependencies": {
         "cli-width": {
-          "version": "3.1.1",
+          "version": "2.1.0",
           "from": "cli-width@>=3.0.0 <4.0.0",
           "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.1.0.tgz"
         },
@@ -2403,6 +2542,11 @@
           "version": "0.5.1",
           "from": "mkdirp@>=0.5.0 <0.6.0",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz"
+        },
+        "strip-bom": {
+          "version": "3.0.0",
+          "from": "strip-bom@>=3.0.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz"
         },
         "user-home": {
           "version": "2.0.0",
@@ -3460,6 +3604,11 @@
       "from": "generate-object-property@>=1.1.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz"
     },
+    "get-caller-file": {
+      "version": "1.0.1",
+      "from": "get-caller-file@>=1.0.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.1.tgz"
+    },
     "get-comments": {
       "version": "1.0.1",
       "from": "get-comments@>=1.0.1 <2.0.0",
@@ -3499,6 +3648,18 @@
       "version": "7.0.3",
       "from": "glob@>=7.0.0 <8.0.0",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.3.tgz"
+    },
+    "glob-all": {
+      "version": "3.0.1",
+      "from": "glob-all@3.0.1",
+      "resolved": "https://registry.npmjs.org/glob-all/-/glob-all-3.0.1.tgz",
+      "dependencies": {
+        "glob": {
+          "version": "4.5.3",
+          "from": "glob@>=4.0.6 <5.0.0",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz"
+        }
+      }
     },
     "glob-base": {
       "version": "0.3.0",
@@ -3692,6 +3853,40 @@
       "from": "gulp-changed@1.3.0",
       "resolved": "https://registry.npmjs.org/gulp-changed/-/gulp-changed-1.3.0.tgz"
     },
+    "gulp-concat": {
+      "version": "2.6.0",
+      "from": "gulp-concat@2.6.0",
+      "resolved": "http://registry.npmjs.org/gulp-concat/-/gulp-concat-2.6.0.tgz",
+      "dependencies": {
+        "readable-stream": {
+          "version": "1.0.34",
+          "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz"
+        },
+        "through2": {
+          "version": "0.6.5",
+          "from": "through2@^0.6.3",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz"
+        }
+      }
+    },
+    "gulp-coveralls": {
+      "version": "0.1.4",
+      "from": "gulp-coveralls@0.1.4",
+      "resolved": "http://registry.npmjs.org/gulp-coveralls/-/gulp-coveralls-0.1.4.tgz",
+      "dependencies": {
+        "readable-stream": {
+          "version": "1.1.14",
+          "from": "readable-stream@>=1.1.13-1 <1.2.0-0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz"
+        },
+        "through2": {
+          "version": "1.1.1",
+          "from": "through2@>=1.1.1 <2.0.0",
+          "resolved": "http://registry.npmjs.org/through2/-/through2-1.1.1.tgz"
+        }
+      }
+    },
     "gulp-cssmin": {
       "version": "0.1.7",
       "from": "gulp-cssmin@0.1.7",
@@ -3795,16 +3990,9 @@
       "resolved": "https://registry.npmjs.org/gulp-decompress/-/gulp-decompress-1.2.0.tgz"
     },
     "gulp-eslint": {
-      "version": "2.0.0",
-      "from": "gulp-eslint@2.0.0",
-      "resolved": "https://registry.npmjs.org/gulp-eslint/-/gulp-eslint-2.0.0.tgz",
-      "dependencies": {
-        "object-assign": {
-          "version": "4.1.0",
-          "from": "object-assign@^4.0.1",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz"
-        }
-      }
+      "version": "3.0.1",
+      "from": "gulp-eslint@3.0.1",
+      "resolved": "https://registry.npmjs.org/gulp-eslint/-/gulp-eslint-3.0.1.tgz"
     },
     "gulp-header": {
       "version": "1.7.1",
@@ -3822,6 +4010,11 @@
           "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz"
         }
       }
+    },
+    "gulp-istanbul": {
+      "version": "0.10.3",
+      "from": "gulp-istanbul@0.10.3",
+      "resolved": "http://registry.npmjs.org/gulp-istanbul/-/gulp-istanbul-0.10.3.tgz"
     },
     "gulp-less": {
       "version": "3.0.5",
@@ -3851,6 +4044,11 @@
           "resolved": "https://registry.npmjs.org/glob/-/glob-4.3.5.tgz"
         }
       }
+    },
+    "gulp-mocha": {
+      "version": "2.2.0",
+      "from": "gulp-mocha@2.2.0",
+      "resolved": "http://registry.npmjs.org/gulp-mocha/-/gulp-mocha-2.2.0.tgz"
     },
     "gulp-modernizr": {
       "version": "1.0.0-alpha",
@@ -4066,6 +4264,11 @@
           "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz"
         }
       }
+    },
+    "gulp-plumber": {
+      "version": "1.1.0",
+      "from": "gulp-plumber@1.1.0",
+      "resolved": "http://registry.npmjs.org/gulp-plumber/-/gulp-plumber-1.1.0.tgz"
     },
     "gulp-rename": {
       "version": "1.1.0",
@@ -4824,6 +5027,23 @@
         }
       }
     },
+    "jasmine-reporters": {
+      "version": "2.1.1",
+      "from": "jasmine-reporters@2.1.1",
+      "resolved": "http://registry.npmjs.org/jasmine-reporters/-/jasmine-reporters-2.1.1.tgz",
+      "dependencies": {
+        "mkdirp": {
+          "version": "0.3.5",
+          "from": "mkdirp@>=0.3.5 <0.4.0",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz"
+        }
+      }
+    },
+    "jasmine-spec-reporter": {
+      "version": "2.4.0",
+      "from": "jasmine-spec-reporter@2.4.0",
+      "resolved": "http://registry.npmjs.org/jasmine-spec-reporter/-/jasmine-spec-reporter-2.4.0.tgz"
+    },
     "jodid25519": {
       "version": "1.0.2",
       "from": "jodid25519@>=1.0.0 <2.0.0",
@@ -4833,6 +5053,11 @@
       "version": "3.0.6",
       "from": "jpegtran-bin@>=3.0.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/jpegtran-bin/-/jpegtran-bin-3.0.6.tgz"
+    },
+    "jquery": {
+      "version": "1.11.3",
+      "from": "jquery@1.11.3",
+      "resolved": "http://registry.npmjs.org/jquery/-/jquery-1.11.3.tgz"
     },
     "js-base64": {
       "version": "2.1.9",
@@ -4858,6 +5083,18 @@
       "version": "1.0.1",
       "from": "jsdoc-inline-lex@>=1.0.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/jsdoc-inline-lex/-/jsdoc-inline-lex-1.0.1.tgz"
+    },
+    "jsdom": {
+      "version": "8.3.0",
+      "from": "jsdom@8.3.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-8.3.0.tgz",
+      "dependencies": {
+        "acorn": {
+          "version": "2.7.0",
+          "from": "acorn@>=2.4.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-2.7.0.tgz"
+        }
+      }
     },
     "jsesc": {
       "version": "0.5.0",
@@ -5547,6 +5784,11 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.2.0.tgz"
         }
       }
+    },
+    "mocha-jsdom": {
+      "version": "1.1.0",
+      "from": "mocha-jsdom@1.1.0",
+      "resolved": "https://registry.npmjs.org/mocha-jsdom/-/mocha-jsdom-1.1.0.tgz"
     },
     "modernizr": {
       "version": "3.3.1",
@@ -8258,6 +8500,11 @@
       "from": "require-dir@0.3.0",
       "resolved": "https://registry.npmjs.org/require-dir/-/require-dir-0.3.0.tgz"
     },
+    "require-directory": {
+      "version": "2.1.1",
+      "from": "require-directory@>=2.1.1 <3.0.0",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz"
+    },
     "require-main-filename": {
       "version": "1.0.1",
       "from": "require-main-filename@>=1.0.1 <2.0.0",
@@ -8406,11 +8653,6 @@
       "from": "serve-static@>=1.10.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.10.2.tgz"
     },
-    "set-blocking": {
-      "version": "1.0.0",
-      "from": "set-blocking@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-1.0.0.tgz"
-    },
     "set-immediate-shim": {
       "version": "1.0.1",
       "from": "set-immediate-shim@>=1.0.0 <2.0.0",
@@ -8450,6 +8692,16 @@
       "version": "2.1.2",
       "from": "signal-exit@>=2.1.2 <3.0.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-2.1.2.tgz"
+    },
+    "sinon": {
+      "version": "1.17.3",
+      "from": "sinon@1.17.3",
+      "resolved": "http://registry.npmjs.org/sinon/-/sinon-1.17.3.tgz"
+    },
+    "sinon-chai": {
+      "version": "2.8.0",
+      "from": "sinon-chai@2.8.0",
+      "resolved": "http://registry.npmjs.org/sinon-chai/-/sinon-chai-2.8.0.tgz"
     },
     "slash": {
       "version": "1.0.0",
@@ -9482,6 +9734,23 @@
         }
       }
     },
+    "wcag": {
+      "version": "0.2.2",
+      "from": "wcag@0.2.2",
+      "resolved": "http://registry.npmjs.org/wcag/-/wcag-0.2.2.tgz",
+      "dependencies": {
+        "indent-string": {
+          "version": "2.1.0",
+          "from": "indent-string@>=2.1.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz"
+        },
+        "repeating": {
+          "version": "2.0.1",
+          "from": "repeating@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz"
+        }
+      }
+    },
     "webidl-conversions": {
       "version": "3.0.1",
       "from": "webidl-conversions@>=3.0.1 <4.0.0",
@@ -9575,6 +9844,11 @@
       "version": "1.2.4",
       "from": "which@>=1.0.5 <2.0.0",
       "resolved": "https://registry.npmjs.org/which/-/which-1.2.4.tgz"
+    },
+    "which-module": {
+      "version": "1.0.0",
+      "from": "which-module@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz"
     },
     "widest-line": {
       "version": "1.0.0",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -2353,13 +2353,13 @@
       "resolved": "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz"
     },
     "eslint": {
-      "version": "2.13.1",
-      "from": "eslint@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-2.13.1.tgz",
+      "version": "3.1.1",
+      "from": "eslint@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-3.1.1.tgz",
       "dependencies": {
         "cli-width": {
-          "version": "2.1.0",
-          "from": "cli-width@>=2.0.0 <3.0.0",
+          "version": "3.1.1",
+          "from": "cli-width@>=3.0.0 <4.0.0",
           "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.1.0.tgz"
         },
         "doctrine": {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "glob-all": "3.0.1",
     "gulp-concat": "2.6.0",
     "gulp-coveralls": "0.1.4",
-    "gulp-eslint": "2.0.0",
+    "gulp-eslint": "3.0.1",
     "gulp-istanbul": "0.10.3",
     "gulp-mocha": "2.2.0",
     "gulp-plumber": "1.1.0",


### PR DESCRIPTION
## Changes

- Updates ESLint to v3 (latest).
- Minor linter file updates:
  - Adds new `line` and `block` sections to `spaced-comment` rule.
  - Adds (but doesn't enforce) the `multiline-ternary` rule.
  - Matches order of rules to ESLint docs.

## Testing

- `gulp lint` should have no errors.

## Review

- @sebworks 
- @jimmynotjim 
- @KimberlyMunoz 
- @contolini 
- @virginiacc 
