### PR TITLE
Fix link icons

### DIFF
--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -203,6 +203,7 @@ ALLOWED_HOSTS = ['*']
 EXTERNAL_LINK_PATTERN = r'https?:\/\/(?:www\.)?(?![^\?]+gov)(?!(content\.)?localhost).*'
 NONCFPB_LINK_PATTERN = r'(https?:\/\/(?:www\.)?(?![^\?]*(cfpb|consumerfinance).gov)(?!(content\.)?localhost).*)'
 FILES_LINK_PATTERN = r'https?:\/\/files\.consumerfinance.gov\/f\/\S+\.[a-z]+'
+DOWNLOAD_LINK_PATTERN = r'(\.pdf|\.doc|\.docx|\.xls|\.xlsx|\.csv|\.zip)$'
 
 # Wagtail settings
 

--- a/cfgov/sheerlike/external_links.py
+++ b/cfgov/sheerlike/external_links.py
@@ -13,8 +13,7 @@ def process_external_links(doc):
 
 def _process_data(field):
     if isinstance(field, basestring):
-        soup = BeautifulSoup(field, 'html.parser')
-        field = parse_links(soup).encode(formatter=None)
+        field = parse_links(field).encode(formatter=None)
     elif isinstance(field, list):
         for i, value in enumerate(field):
             field[i] = _process_data(value)

--- a/cfgov/unprocessed/css/misc.less
+++ b/cfgov/unprocessed/css/misc.less
@@ -746,21 +746,6 @@
     - cfgov-misc
 */
 
-a[href$='.PDF']:after,
-a[href$='.pdf']:after,
-a[href$='.doc']:after,
-a[href$='.docx']:after,
-a[href$='.xls']:after,
-a[href$='.xlsx']:after,
-a[href$='.csv']:after,
-a[href$='.zip']:after {
-    .cf-icon();
-    display: inline-block;
-    content: @cf-icon-download;
-    width: 1em;
-    text-align: right;
-}
-
 .date-range {
     &_label {
         display: none;

--- a/cfgov/v1/__init__.py
+++ b/cfgov/v1/__init__.py
@@ -85,15 +85,23 @@ def parse_links(soup):
                 needs_icon = False
                 break
         if needs_icon:
+            add_download_icon = False
+            add_external_icon = False
             if not a.attrs.get('class', None):
                 a.attrs.update({'class': []})
-            if download_pattern.match(a['href']):
-                a.attrs['class'].append(download_a_class)
-            if noncfpb_pattern.match(a['href']): # Sets the icon to indicate you're leaving consumerfinance.gov
+            if noncfpb_pattern.match(a['href']):
+                # Sets the icon to indicate you're leaving consumerfinance.gov
                 a.attrs['class'].append(external_a_class)
-                if extlink_pattern.match(a['href']): # Sets the link to an external one if you're leaving .gov
+                if extlink_pattern.match(a['href']):
+                    # Sets the link to an external one if you're leaving .gov
                     a['href'] = '/external-site/?ext_url=' + a['href']
-            if download_pattern.match(a['href']) or noncfpb_pattern.match(a['href']):
+                    add_external_icon = True
+            elif download_pattern.search(a['href']):
+                # Sets the icon to indicate you're downloading a file
+                a.attrs['class'].append(download_a_class)
+                add_download_icon = True
+            if add_download_icon or add_external_icon:
+                # Wraps the link text in a span that provides the underline
                 contents = a.contents
                 span = soup.new_tag('span')
                 span['class'] = span_class

--- a/cfgov/v1/__init__.py
+++ b/cfgov/v1/__init__.py
@@ -86,11 +86,11 @@ def parse_links(soup):
                 break
         if needs_icon:
             if not a.attrs.get('class', None):
-                a.attrs.update({'class': ''})
+                a.attrs.update({'class': []})
             if download_pattern.match(a['href']):
-                a.attrs['class'] = ' '.join([download_a_class, a.attrs['class']])
+                a.attrs['class'].append(download_a_class)
             if noncfpb_pattern.match(a['href']): # Sets the icon to indicate you're leaving consumerfinance.gov
-                a.attrs['class'] = ' '.join([external_a_class, a.attrs['class']])
+                a.attrs['class'].append(external_a_class)
                 if extlink_pattern.match(a['href']): # Sets the link to an external one if you're leaving .gov
                     a['href'] = '/external-site/?ext_url=' + a['href']
             if download_pattern.match(a['href']) or noncfpb_pattern.match(a['href']):

--- a/cfgov/v1/__init__.py
+++ b/cfgov/v1/__init__.py
@@ -95,7 +95,7 @@ def parse_links(soup):
                 if extlink_pattern.match(a['href']):
                     # Sets the link to an external one if you're leaving .gov
                     a['href'] = '/external-site/?ext_url=' + a['href']
-                    add_external_icon = True
+                add_external_icon = True
             elif download_pattern.search(a['href']):
                 # Sets the icon to indicate you're downloading a file
                 a.attrs['class'].append(download_a_class)

--- a/cfgov/v1/__init__.py
+++ b/cfgov/v1/__init__.py
@@ -45,7 +45,7 @@ def environment(**options):
         'is_blog': ref.is_blog,
         'is_report': ref.is_report,
         'get_page_state_url': share.get_page_state_url,
-        'parse_links': external_links_filter,
+        'parse_links': parse_links,
         'get_protected_url': get_protected_url,
         'related_metadata_tags': related_metadata_tags,
         'get_filter_data': get_filter_data,
@@ -57,14 +57,11 @@ def environment(**options):
     return env
 
 
-def parse_links(soup):
-    extlink_pattern = re.compile(settings.EXTERNAL_LINK_PATTERN)
-    noncfpb_pattern = re.compile(settings.NONCFPB_LINK_PATTERN)
-    files_pattern = re.compile(settings.FILES_LINK_PATTERN)
-    download_pattern = re.compile(settings.DOWNLOAD_LINK_PATTERN)
-    external_a_class = os.environ.get('EXTERNAL_A_CSS', 'icon-link icon-link__external-link')
-    download_a_class = os.environ.get('DOWNLOAD_A_CSS', 'icon-link icon-link__download')
-    span_class = os.environ.get('EXTERNAL_SPAN_CSS', 'icon-link_text')
+def parse_links(value):
+    if isinstance(value, RichText):
+        soup = BeautifulSoup(expand_db_html(value.source), 'html.parser')
+    else:
+        soup = BeautifulSoup(expand_db_html(value), 'html.parser')
 
     # This removes style tags <style>
     for s in soup('style'):
@@ -78,44 +75,62 @@ def parse_links(soup):
             # 'NavigableString' object has does not have attr's
             pass
 
-    for a in soup.find_all('a', href=True):
-        needs_icon = True
-        for child in a.children:
-            if child.name in ['img', 'svg']:
-                needs_icon = False
-                break
-        if needs_icon:
-            added_icon = False
-            if not a.attrs.get('class', None):
-                a.attrs.update({'class': []})
-            if noncfpb_pattern.match(a['href']):
-                # Sets the icon to indicate you're leaving consumerfinance.gov
-                a.attrs['class'].append(external_a_class)
-                if extlink_pattern.match(a['href']):
-                    # Sets the link to an external one if you're leaving .gov
-                    a['href'] = '/external-site/?ext_url=' + a['href']
-                added_icon = True
-            elif download_pattern.search(a['href']):
-                # Sets the icon to indicate you're downloading a file
-                a.attrs['class'].append(download_a_class)
-                added_icon = True
-            if added_icon:
-                # Wraps the link text in a span that provides the underline
-                contents = a.contents
-                span = soup.new_tag('span')
-                span['class'] = span_class
-                span.contents = contents
-                a.contents = [span, NavigableString(' ')]
-            elif not files_pattern.match(a['href']):
-                fix_link(a)
+    # This adds the link markup
+    link_tags = get_link_tags(soup)
+    add_link_markup(link_tags)
+
     return soup
 
 
-def external_links_filter(value):
-    if isinstance(value, RichText):
-        return parse_links(BeautifulSoup(expand_db_html(value.source), 'html.parser'))
-    else:
-        return parse_links(BeautifulSoup(expand_db_html(value), 'html.parser'))
+def get_link_tags(soup):
+    tags = []
+    for a in soup.find_all('a', href=True):
+        if not is_image_tag(a):
+            tags.append(a)
+    return tags
+
+
+def is_image_tag(tag):
+    for child in tag.children:
+        if child.name in ['img', 'svg']:
+            return True
+    return False
+
+
+EXTERNAL_LINK_PATTERN = re.compile(settings.EXTERNAL_LINK_PATTERN)
+NONCFPB_LINK_PATTERN = re.compile(settings.NONCFPB_LINK_PATTERN)
+FILES_LINK_PATTERN = re.compile(settings.FILES_LINK_PATTERN)
+DOWNLOAD_LINK_PATTERN = re.compile(settings.DOWNLOAD_LINK_PATTERN)
+EXTERNAL_A_CSS = os.environ.get('EXTERNAL_A_CSS', 'icon-link icon-link__external-link')
+DOWNLOAD_A_CSS = os.environ.get('DOWNLOAD_A_CSS', 'icon-link icon-link__download')
+EXTERNAL_SPAN_CSS = os.environ.get('EXTERNAL_SPAN_CSS', 'icon-link_text')
+
+
+def add_link_markup(tags):
+    for tag in tags:
+        added_icon = False
+        if not tag.attrs.get('class', None):
+            tag.attrs.update({'class': []})
+        if NONCFPB_LINK_PATTERN.match(tag['href']):
+            # Sets the icon to indicate you're leaving consumerfinance.gov
+            tag.attrs['class'].append(EXTERNAL_A_CSS)
+            if EXTERNAL_LINK_PATTERN.match(tag['href']):
+                # Sets the link to an external one if you're leaving .gov
+                tag['href'] = '/external-site/?ext_url=' + tag['href']
+            added_icon = True
+        elif DOWNLOAD_LINK_PATTERN.search(tag['href']):
+            # Sets the icon to indicate you're downloading a file
+            tag.attrs['class'].append(DOWNLOAD_A_CSS)
+            added_icon = True
+        if added_icon:
+            # Wraps the link text in a span that provides the underline
+            contents = tag.contents
+            span = BeautifulSoup('').new_tag('span')
+            span['class'] = EXTERNAL_SPAN_CSS
+            span.contents = contents
+            tag.contents = [span, NavigableString(' ')]
+        elif not FILES_LINK_PATTERN.match(tag['href']):
+            fix_link(tag)
 
 
 @contextfunction

--- a/cfgov/v1/__init__.py
+++ b/cfgov/v1/__init__.py
@@ -85,8 +85,7 @@ def parse_links(soup):
                 needs_icon = False
                 break
         if needs_icon:
-            add_download_icon = False
-            add_external_icon = False
+            added_icon = False
             if not a.attrs.get('class', None):
                 a.attrs.update({'class': []})
             if noncfpb_pattern.match(a['href']):
@@ -95,12 +94,12 @@ def parse_links(soup):
                 if extlink_pattern.match(a['href']):
                     # Sets the link to an external one if you're leaving .gov
                     a['href'] = '/external-site/?ext_url=' + a['href']
-                add_external_icon = True
+                added_icon = True
             elif download_pattern.search(a['href']):
                 # Sets the icon to indicate you're downloading a file
                 a.attrs['class'].append(download_a_class)
-                add_download_icon = True
-            if add_download_icon or add_external_icon:
+                added_icon = True
+            if added_icon:
                 # Wraps the link text in a span that provides the underline
                 contents = a.contents
                 span = soup.new_tag('span')


### PR DESCRIPTION
The logic handling links doesn't insert the correct markup.

## Additions

- Added download link regex pattern and logic to parse_link function for rich text.

## Removals

- CSS to add icon classes for files

## Changes

- Markup is inserted and manipulated differently for affected links matching the patterns.

## Testing

- Add cfpb link
- Add .gov link
- Add external link
- add file link
- make sure markup is correct for each one


## Review

- @Scotchester 
- @willbarton 
- @richaagarwal 
- @virginiacc 
- @contolini 

## Notes

-

## Todos

- Change where logic is located for efficiency
- Possible refactor for readability
- Write tests

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
