### PR TITLE
Adds ability to auto-fix linter errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,9 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 
 ### Added
 - leadership calendar Django app
-- 
+- Frontend: Added ability to auto-fix linter error with the `--fix`
+  flag on the linter task.
+
 ### Changed
 - Updated ESLint to `2.13.1` from `2.7.0`.
 - Fixed job ordering on Careers home page to be consistent with Current Openings page.

--- a/TEST.md
+++ b/TEST.md
@@ -162,3 +162,19 @@ To audit a page's WCAG and Section 508 accessibility:
   4. To test a page aside from the homepage, add the `--u=<path_to_test>` flag.
      For example, `gulp test:a11y --u=contact-us`
      or `gulp test:a11y --u=the-bureau/bureau-structure/`.
+
+# Source code linting
+
+The default test task includes linting of the JavaScript source, build,
+and test files.
+Use the `gulp lint` command from the command-line to run the ESLint linter,
+which checks the JavaScript against the rules configured in `.eslintrc`.
+[See the ESLint docs](http://eslint.org/docs/rules/)
+for detailed rule descriptions.
+
+There are a number of options to the command:
+ - Use `gulp lint:build` to only lint the build scripts.
+ - Use `gulp lint:test` to only lint the test scripts.
+ - Use `gulp lint:scripts` to only lint the project source scripts.
+ - Add the `--fix` flag (like `gulp lint --fix`) to auto-fix
+   some errors, where ESLint has support to do so.

--- a/gulp/tasks/lint.js
+++ b/gulp/tasks/lint.js
@@ -4,6 +4,7 @@ var gulp = require( 'gulp' );
 var plugins = require( 'gulp-load-plugins' )();
 var configLint = require( '../config' ).lint;
 var handleErrors = require( '../utils/handle-errors' );
+var minimist = require( 'minimist' );
 
 /**
  * Generic lint a script source.
@@ -11,9 +12,13 @@ var handleErrors = require( '../utils/handle-errors' );
  * @returns {Object} An output stream from gulp.
  */
 function _genericLint( src ) {
-  return gulp.src( src )
-    .pipe( plugins.eslint() )
+  // Grab the --fix flag from the command-line, if available.
+  var commandLineParams = minimist( process.argv.slice( 2 ) );
+  var willFix = commandLineParams.fix || false;
+  return gulp.src( src, { base: './' } )
+    .pipe( plugins.eslint( { fix: willFix } ) )
     .pipe( plugins.eslint.format() )
+    .pipe( gulp.dest( './' ) )
     .on( 'error', handleErrors );
 }
 


### PR DESCRIPTION
## Additions

- Adds ability to auto-fix linter errors with a command-line `--fix` flag on the linter task.

## Testing

- Run `gulp lint --fix` and look at your changed files in git. See that `Header.js` and `es5-shim.js` have spacing issues that are automatically fixed.

## Review

- @sebworks 
- @contolini 
- @chosak 
- @jimmynotjim 
- @virginiacc
- @KimberlyMunoz 