### PR TITLE
Fix broken Learn Page browser tests 

### DIFF
--- a/cfgov/jinja2/v1/_includes/organisms/item-introduction.html
+++ b/cfgov/jinja2/v1/_includes/organisms/item-introduction.html
@@ -63,9 +63,11 @@
                 &ndash;
             </span>
         {% endif %}
-        <span class="date">
-            {{ time.render(published_date, {'date':true}) }}
-        </span>
+        {% if published_date %}
+            <span class="date">
+                {{ time.render(published_date, {'date':true}) }}
+            </span>
+        {% endif %}
     {% if published_date or has_authors %}
         </div>
     {% endif %}


### PR DESCRIPTION
The combination of #2234 and #2226 broke the browser tests related to the "Learn Page" test page at `/browse-filterable-page/learn-page/`. This page [uses](https://github.com/cfpb/cfgov-refresh/blob/flapjack/cfgov/scripts/initial_test_data.py#L195) an Item Introduction but doesn't fill in the date field. The [`item-introduction`](https://github.com/cfpb/cfgov-refresh/blob/flapjack/cfgov/jinja2/v1/_includes/organisms/item-introduction.html#L65) template should check to make sure this field isn't null before trying to render it.

## Changes

- Modify the `item-introduction.html` template to check for null `published_date` before rendering it.

## Testing

- Run `gulp test` or `gulp test:acceptance` to see all 48 functional browser tests pass.

## Review

- @virginiacc 

## Checklist

* [X] Changes are limited to a single goal (no scope creep)
* [X] Code can be automatically merged (no conflicts)
* [X] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [X] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)

