### PR TITLE
Run Python unit tests quickly by skipping test database migrations

### DIFF
--- a/cfgov/cfgov/settings/test_nomigrations.py
+++ b/cfgov/cfgov/settings/test_nomigrations.py
@@ -1,0 +1,12 @@
+from .test import *
+
+
+class NoMigrations(object):
+    def __contains__(self, item):
+        return True
+
+    def __getitem__(self, item):
+        return 'nomigrations'
+
+MIGRATION_MODULES = NoMigrations()
+

--- a/cfgov/cfgov/settings/test_nomigrations.py
+++ b/cfgov/cfgov/settings/test_nomigrations.py
@@ -9,4 +9,3 @@ class NoMigrations(object):
         return 'nomigrations'
 
 MIGRATION_MODULES = NoMigrations()
-

--- a/tox.ini
+++ b/tox.ini
@@ -20,5 +20,5 @@ commands=
 [testenv:fast]
 recreate = False
 setenv =
+    {[testenv]setenv}
     DJANGO_SETTINGS_MODULE=cfgov.settings.test_nomigrations
-    STAGING_HOSTNAME=content.localhost

--- a/tox.ini
+++ b/tox.ini
@@ -19,5 +19,6 @@ commands=
     
 [testenv:fast]
 recreate = False
-commands =
-    python -m unittest discover
+setenv =
+    DJANGO_SETTINGS_MODULE=cfgov.settings.test_nomigrations
+    STAGING_HOSTNAME=content.localhost


### PR DESCRIPTION
When Python unit tests create a new test database, they start with the initial migration and then apply all subsequent migrations. This can be quite slow, even though we really only care about the final database schema as defined in various `models.py` files.

This PR modifies the `tox -e fast` faster unit test approach introduced in #2227 by restoring the use of a Django test database (using `manage.py test`) but modifying how it applies migrations.

## Additions

- A new `cfgov.settings.test_nomigrations` inherits all from `cfgov.settings.test` but modifies the [`MIGRATION_MODULES`](https://docs.djangoproject.com/en/1.8/ref/settings/#std:setting-MIGRATION_MODULES) setting so that all migrations are skipped for all apps.

## Changes

- Modifies the `tox -e fast` implementation introduced in #2227 so that unit tests can now run in a fast way against a test database.

## Testing

- Run `tox -e fast` and notice how much faster the tests run than if you just do `tox` (especially after the first time when setting up a new environment).

## Review

- @rosskarchner @richaagarwal @vickumar1981 @vccabral and any other Django testing fans. This PR doesn't really affect much of importance but I'm interested to get feedback on this approach and if people think it might be more broadly useful as a trick to speed up Python unit tests.

## Notes

- Inspired by [this](https://gist.github.com/NotSqrt/5f3c76cd15e40ef62d09) gist.
- Are there cases to consider where it's important to run through migrations before running unit tests? For example, see [this](https://gist.github.com/NotSqrt/5f3c76cd15e40ef62d09#gistcomment-1707544) comment on the gist.

## Checklist

* [X] Changes are limited to a single goal (no scope creep)
* [X] Code can be automatically merged (no conflicts)
* [X] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [X] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)

