### PR TITLE
Consolidates environment variable references

### DIFF
--- a/.env_SAMPLE
+++ b/.env_SAMPLE
@@ -3,26 +3,13 @@
 # The file may be manually initialized with . ./.env from the project root.
 # --------------------------------------------------------------------------
 
-###################################################################
-# DO NOT EDIT VALUES. Project configuration - clear variable state.
-###################################################################
-
-unset DJANGO_STAGING_HOSTNAME
-unset DJANGO_HTTP_PORT
-unset TEST_HTTP_HOST
-unset TEST_HTTP_PORT
-unset SAUCE_USERNAME
-unset SAUCE_ACCESS_KEY
-unset SAUCE_SELENIUM_URL
-unset ACHECKER_ID
-
 ############################
 # Django Application Server.
 ############################
 
-#export DJANGO_STAGING_HOSTNAME=<staging_hostname>
+export DJANGO_STAGING_HOSTNAME='content.localhost'
 #export DJANGO_STATIC_ROOT=<path_to_static_files>
-#export DJANGO_HTTP_PORT=8000
+export DJANGO_HTTP_PORT=8000
 
 #############################################
 # V1 - application feature related variables.
@@ -122,9 +109,9 @@ export WORDPRESS=http://www.consumerfinance.gov
 # TESTING (optional) - for handling testing of the site.
 ########################################################
 
-#export SITE_DESC=cfgov
-#export TEST_HTTP_HOST=localhost
-#export TEST_HTTP_PORT=8000
+export SITE_DESC=cfgov
+export TEST_HTTP_HOST=localhost
+export TEST_HTTP_PORT=8000
 
 # Web service ID for accessibility testing via http://achecker.ca site.
 #export ACHECKER_ID=<web_service_id>
@@ -140,20 +127,6 @@ export TOXENV=py27
 #export SAUCE_ACCESS_KEY=<sauce_access_key>
 #export SAUCE_SELENIUM_URL=localhost:4445/wd/hub
 #export SAUCE_TUNNEL=<sauce_tunnel_id>
-
-#######################################################################
-# DO NOT EDIT VALUES. Project configuration - export variable defaults.
-#######################################################################
-
-export DJANGO_STAGING_HOSTNAME=${DJANGO_STAGING_HOSTNAME:-'content.localhost'}
-export DJANGO_HTTP_PORT=${DJANGO_HTTP_PORT:-8000}
-export SITE_DESC=${SITE_DESC:-cfgov}
-export TEST_HTTP_HOST=${TEST_HTTP_HOST:-localhost}
-export TEST_HTTP_PORT=${TEST_HTTP_PORT:-${DJANGO_HTTP_PORT}}
-export SAUCE_USERNAME=${SAUCE_USERNAME:-''}
-export SAUCE_ACCESS_KEY=${SAUCE_ACCESS_KEY:-''}
-export SAUCE_SELENIUM_URL=${SAUCE_SELENIUM_URL:-localhost:4445/wd/hub}
-export ACHECKER_ID=${ACHECKER_ID:-''}
 
 ###############################################
 # Project configuration - set up working state.

--- a/.env_SAMPLE
+++ b/.env_SAMPLE
@@ -3,12 +3,26 @@
 # The file may be manually initialized with . ./.env from the project root.
 # --------------------------------------------------------------------------
 
+###################################################################
+# DO NOT EDIT VALUES. Project configuration - clear variable state.
+###################################################################
+
+unset DJANGO_STAGING_HOSTNAME
+unset DJANGO_HTTP_PORT
+unset TEST_HTTP_HOST
+unset TEST_HTTP_PORT
+unset SAUCE_USERNAME
+unset SAUCE_ACCESS_KEY
+unset SAUCE_SELENIUM_URL
+unset ACHECKER_ID
+
 ############################
 # Django Application Server.
 ############################
 
-export STAGING_HOSTNAME='content.localhost'
+#export DJANGO_STAGING_HOSTNAME=<staging_hostname>
 #export DJANGO_STATIC_ROOT=<path_to_static_files>
+#export DJANGO_HTTP_PORT=8000
 
 #############################################
 # V1 - application feature related variables.
@@ -108,9 +122,9 @@ export WORDPRESS=http://www.consumerfinance.gov
 # TESTING (optional) - for handling testing of the site.
 ########################################################
 
-#export HTTP_HOST=localhost
-#export HTTP_PORT=8000
-#export SELENIUM_URL=http://localhost:4444/wd/hub
+#export SITE_DESC=cfgov
+#export TEST_HTTP_HOST=localhost
+#export TEST_HTTP_PORT=8000
 
 # Web service ID for accessibility testing via http://achecker.ca site.
 #export ACHECKER_ID=<web_service_id>
@@ -125,6 +139,21 @@ export TOXENV=py27
 #export SAUCE_USERNAME=<sauce_username>
 #export SAUCE_ACCESS_KEY=<sauce_access_key>
 #export SAUCE_SELENIUM_URL=localhost:4445/wd/hub
+#export SAUCE_TUNNEL=<sauce_tunnel_id>
+
+#######################################################################
+# DO NOT EDIT VALUES. Project configuration - export variable defaults.
+#######################################################################
+
+export DJANGO_STAGING_HOSTNAME=${DJANGO_STAGING_HOSTNAME:-'content.localhost'}
+export DJANGO_HTTP_PORT=${DJANGO_HTTP_PORT:-8000}
+export SITE_DESC=${SITE_DESC:-cfgov}
+export TEST_HTTP_HOST=${TEST_HTTP_HOST:-localhost}
+export TEST_HTTP_PORT=${TEST_HTTP_PORT:-${DJANGO_HTTP_PORT}}
+export SAUCE_USERNAME=${SAUCE_USERNAME:-''}
+export SAUCE_ACCESS_KEY=${SAUCE_ACCESS_KEY:-''}
+export SAUCE_SELENIUM_URL=${SAUCE_SELENIUM_URL:-localhost:4445/wd/hub}
+export ACHECKER_ID=${ACHECKER_ID:-''}
 
 ###############################################
 # Project configuration - set up working state.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,20 +15,27 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 ## UNRELEASED
 
 ### Added
-- Page revision management: http://docs.wagtail.io/en/v1.4.1/releases/1.4.html#page-revision-management,available at e.g. http://127.0.0.1:8000/admin/pages/64/revisions/ 
+- Page revision management: http://docs.wagtail.io/en/v1.4.1/releases/1.4.html#page-revision-management,available at e.g. http://127.0.0.1:8000/admin/pages/64/revisions/
 - Redesigned userbar: http://docs.wagtail.io/en/v1.4.1/releases/1.4.html#redesigned-userbar
-- Multiple document uploader: http://docs.wagtail.io/en/v1.4.1/releases/1.4.html#multiple-document-uploader 
+- Multiple document uploader: http://docs.wagtail.io/en/v1.4.1/releases/1.4.html#multiple-document-uploader
 - Improved link handling: http://docs.wagtail.io/en/v1.5/releases/1.5.html#improved-link-handling-in-rich-text
 
 ### Changed
 - `content_panels` are no longer defined in `AbstractFilterPage`; defined in its subclasses instead
 - Upgraded Wagtail from 1.3 to 1.5.2
+- Consolidated all environment variables in config/environment.js.
+- Ignored `console.log` in tests and enforced `no-process`.
+- Updated `STAGING_HOSTNAME` to `DJANGO_STAGING_HOSTNAME` environment var.
+- Allows passing of port to `runserver.sh`.
 
 ### Removed
+- Unused `SELENIUM_URL` environment variable.
 - Removed unused `interactiveTestPort` test variable.
 - Squashed all migrations
 
 ### Fixed
+
+- Added misnamed and unreferenced environment variables to .env.
 
 
 ## 3.4.0 2016-07-12
@@ -46,7 +53,6 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 
 ### Fixed
 - Fix scheduled publishing
-
 
 ## 3.0.0-3.3.22 – 2016-06-22
 

--- a/cfgov/v1/__init__.py
+++ b/cfgov/v1/__init__.py
@@ -166,7 +166,7 @@ def get_protected_url(context, page):
     if url is None:  # If page is not aligned to a site root return None
         return None
     page_hostname = urlparse(url).hostname
-    staging_hostname = os.environ.get('STAGING_HOSTNAME')
+    staging_hostname = os.environ.get('DJANGO_STAGING_HOSTNAME')
     if page.live:
         return url
     elif page.specific.shared:

--- a/cfgov/v1/models/base.py
+++ b/cfgov/v1/models/base.py
@@ -65,7 +65,7 @@ class CFGOVPageQuerySet(PageQuerySet):
         return self.live_q() | self.shared_q()
 
     def live_shared(self, hostname):
-        staging_hostname = os.environ.get('STAGING_HOSTNAME')
+        staging_hostname = os.environ.get('DJANGO_STAGING_HOSTNAME')
         if staging_hostname in hostname:
             return self.filter(self.live_shared_q())
         else:

--- a/cfgov/v1/templatetags/share.py
+++ b/cfgov/v1/templatetags/share.py
@@ -28,7 +28,7 @@ def get_page_state_url(context, page):
     if url is None:  # If page is not aligned to a site root return None
         return None
     page_hostname = urlparse(url).hostname
-    staging_hostname = os.environ.get('STAGING_HOSTNAME')
+    staging_hostname = os.environ.get('DJANGO_STAGING_HOSTNAME')
     if not page.live and page.shared and staging_hostname != page_hostname:
         url = url.replace(page_hostname, staging_hostname)
     return url

--- a/cfgov/v1/util/util.py
+++ b/cfgov/v1/util/util.py
@@ -60,7 +60,7 @@ def instanceOfBrowseOrFilterablePages(page):
 # into BrowsePage
 def get_secondary_nav_items(request, current_page):
     from ..templatetags.share import get_page_state_url
-    on_staging = os.environ.get('STAGING_HOSTNAME') == request.site.hostname
+    on_staging = os.environ.get('DJANGO_STAGING_HOSTNAME') == request.site.hostname
     nav_items = []
     parent = current_page.get_parent().specific
     if instanceOfBrowseOrFilterablePages(parent):
@@ -121,7 +121,7 @@ def get_appropriate_page_version(request, page):
     # If we're on the production site, make sure the version of the page
     # displayed is the latest version that has `live` set to True for
     # the live site or `shared` set to True for the staging site.
-    staging_hostname = os.environ.get('STAGING_HOSTNAME')
+    staging_hostname = os.environ.get('DJANGO_STAGING_HOSTNAME')
     revisions = page.revisions.all().order_by('-created_at')
     for revision in revisions:
         page_version = json.loads(revision.content_json)

--- a/cfgov/v1/wagtail_hooks.py
+++ b/cfgov/v1/wagtail_hooks.py
@@ -80,7 +80,7 @@ def flush_akamai(page, is_live):
 
 @hooks.register('before_serve_page')
 def check_request_site(page, request, serve_args, serve_kwargs):
-    if request.site.hostname == os.environ.get('STAGING_HOSTNAME'):
+    if request.site.hostname == os.environ.get('DJANGO_STAGING_HOSTNAME'):
         if isinstance(page, CFGOVPage):
             if not page.shared:
                 raise Http404

--- a/config/environment.js
+++ b/config/environment.js
@@ -1,18 +1,32 @@
 /* ==========================================================================
-   Settings for project environment. Used by JavaScript gulp build process.
+   Settings for project environment.
+   Used by JavaScript gulp build process and JavaScript test configuration.
    ========================================================================== */
 
 'use strict';
 
+var envvars = {
+  /* eslint-disable no-process-env */
+  DJANGO_STAGING_HOSTNAME: process.env.DJANGO_STAGING_HOSTNAME,
+  TEST_HTTP_HOST:          process.env.TEST_HTTP_HOST,
+  TEST_HTTP_PORT:          process.env.TEST_HTTP_PORT,
+  SAUCE_SELENIUM_URL:      process.env.SAUCE_SELENIUM_URL,
+  SAUCE_USERNAME:          process.env.SAUCE_USERNAME,
+  SAUCE_ACCESS_KEY:        process.env.SAUCE_ACCESS_KEY,
+  ACHECKER_ID:             process.env.ACHECKER_ID
+  /* eslint-enable no-process-env */
+};
+
 var paths = {
   unprocessed: './cfgov/unprocessed',
   processed:   './cfgov/static_built',
-  legacy: 	   './cfgov/legacy/static',
+  legacy:      './cfgov/legacy/static',
   lib:         './vendor',
   modules:     './node_modules',
   test:        './test'
 };
 
 module.exports = {
+  envvars: envvars,
   paths: paths
 };

--- a/gulp/tasks/browser-sync.js
+++ b/gulp/tasks/browser-sync.js
@@ -1,12 +1,13 @@
 'use strict';
 
-var gulp = require( 'gulp' );
-var util = require( 'gulp-util' );
 var browserSync = require( 'browser-sync' );
+var envvars = require( '../../config/environment' ).envvars;
+var gulp = require( 'gulp' );
 
 gulp.task( 'browsersync', function() {
-  var port = util.env.port || process.env.HTTP_PORT || '8000'; // eslint-disable-line no-process-env, no-inline-comments, max-len
+  var host = envvars.TEST_HTTP_HOST;
+  var port = envvars.TEST_HTTP_PORT;
   browserSync.init( {
-    proxy: 'localhost:' + port
+    proxy: host + ':' + port
   } );
 } );

--- a/gulp/tasks/test.js
+++ b/gulp/tasks/test.js
@@ -1,5 +1,6 @@
 'use strict';
 
+var envvars = require( '../../config/environment' ).envvars;
 var gulp = require( 'gulp' );
 var plugins = require( 'gulp-load-plugins' )();
 var spawn = require( 'child_process' ).spawn;
@@ -113,12 +114,13 @@ function _getProtractorParams( suite ) {
  */
 function _getWCAGParams() {
   var commandLineParams = minimist( process.argv.slice( 2 ) );
-  var host = process.env.HTTP_HOST || 'localhost'; // eslint-disable-line no-process-env, no-inline-comments, max-len
-  var port = process.env.HTTP_PORT || '8000'; // eslint-disable-line no-process-env, no-inline-comments, max-len
-  var checkerId = process.env.ACHECKER_ID || ''; // eslint-disable-line no-process-env, no-inline-comments, max-len
+  var host = envvars.TEST_HTTP_HOST;
+  var port = envvars.TEST_HTTP_PORT;
+  var checkerId = envvars.ACHECKER_ID;
   var urlPath = _parsePath( commandLineParams.u );
   var url = host + ':' + port + urlPath;
   plugins.util.log( 'WCAG tests checking URL: http://' + url );
+
   return [ '--u=' + url, '--id=' + checkerId ];
 }
 
@@ -133,6 +135,7 @@ function _parsePath( urlPath ) {
   if ( urlPath.charAt( 0 ) !== '/' ) {
     urlPath = '/' + urlPath;
   }
+
   return urlPath;
 }
 

--- a/runserver.sh
+++ b/runserver.sh
@@ -17,8 +17,8 @@ mysql(){
 
 # Run tasks to build the project for distribution.
 server(){
-  echo 'Starting the Server...'
-  python cfgov/manage.py runserver
+  echo '\033[0;32mStarting the Django server on port' $DJANGO_HTTP_PORT '...'
+  python cfgov/manage.py runserver $DJANGO_HTTP_PORT
 }
 
 mysql

--- a/test/browser_tests/.eslintrc
+++ b/test/browser_tests/.eslintrc
@@ -7,7 +7,7 @@ globals:
   browser: true
   element: true
 rules:
-  no-process-env: 0
+  no-console: 0
   no-unused-expressions: 0
   max-nested-callbacks: 0
   require-jsdoc: 0

--- a/test/browser_tests/conf.js
+++ b/test/browser_tests/conf.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var environment = require( './environment.js' );
+var envvars = require( '../../config/environment' ).envvars;
 var defaultSuites = require( './default-suites.js' );
 
 /**
@@ -48,9 +49,9 @@ function _chooseSuite( params ) {
  *   are not undefined or an empty string, false otherwise.
  */
 function _isSauceCredentialSet() {
-  var sauceSeleniumUrl = process.env.SAUCE_SELENIUM_URL;
-  var sauceUsername = process.env.SAUCE_USERNAME;
-  var sauceAccessKey = process.env.SAUCE_ACCESS_KEY;
+  var sauceSeleniumUrl = envvars.SAUCE_SELENIUM_URL;
+  var sauceUsername = envvars.SAUCE_USERNAME;
+  var sauceAccessKey = envvars.SAUCE_ACCESS_KEY;
 
   return typeof sauceSeleniumUrl !== 'undefined' &&
          sauceSeleniumUrl !== '' &&
@@ -210,7 +211,7 @@ var config = {
                                 ',' + String( windowHeightPx );
 
     browser.getProcessedConfig().then( function( cf ) {
-      console.log( 'Executing...', cf.capabilities.name ); // eslint-disable-line no-console, no-inline-comments, max-len
+      console.log( 'Executing...', cf.capabilities.name );
     } );
     return;
   }
@@ -218,9 +219,9 @@ var config = {
 
 // Set Sauce Labs credientials from .env file.
 if ( _isSauceCredentialSet() ) {
-  config.sauceSeleniumAddress = process.env.SAUCE_SELENIUM_URL;
-  config.sauceUser = process.env.SAUCE_USERNAME;
-  config.sauceKey = process.env.SAUCE_ACCESS_KEY;
+  config.sauceSeleniumAddress = envvars.SAUCE_SELENIUM_URL;
+  config.sauceUser = envvars.SAUCE_USERNAME;
+  config.sauceKey = envvars.SAUCE_ACCESS_KEY;
 }
 
 exports.config = config;

--- a/test/browser_tests/environment.js
+++ b/test/browser_tests/environment.js
@@ -1,22 +1,11 @@
 'use strict';
 
-// Common configuration files with defaults plus overrides from environment vars
-var webServerDefaultPort = 8000;
-
+var envvars = require( '../../config/environment' ).envvars;
 var specsRoot = 'spec_suites/';
 
 module.exports = {
-  // The address of a running selenium server.
-  seleniumAddress:
-    process.env.SELENIUM_URL || 'http://localhost:4444/wd/hub',
-
-  // Default http port to host the web server
-  webServerDefaultPort: webServerDefaultPort,
-
   // A base URL for your application under test.
-  baseUrl:
-    'http://' + ( process.env.HTTP_HOST || 'localhost' ) +
-          ':' + ( process.env.HTTP_PORT || webServerDefaultPort ),
+  baseUrl: 'http://' + envvars.TEST_HTTP_HOST + ':' + envvars.TEST_HTTP_PORT,
 
   // The base path where the spec suites are located.
   specsBasePath: specsRoot + '**/*',

--- a/test/browser_tests/jenkins_conf.js
+++ b/test/browser_tests/jenkins_conf.js
@@ -1,21 +1,22 @@
 'use strict';
 
+var environment = require( './environment.js' );
+var envvars = require( '../../config/environment' ).envvars;
 var JasmineReporters = require( 'jasmine-reporters' );
 var JasmineSpecReporter = require( 'jasmine-spec-reporter' );
 var mkdirp = require( 'mkdirp' );
-var environment = require( './environment.js' );
 
 exports.config = {
   framework:    'jasmine2',
   specs:        [ environment.specsBasePath + '.js' ],
   capabilities: {
     'browserName':       'chrome',
-    'name':              'flapjack-browser-tests ' + process.env.SITE_DESC,
-    'tunnel-identifier': process.env.SAUCE_TUNNEL
+    'name':              'flapjack-browser-tests ' + envvars.SITE_DESC,
+    'tunnel-identifier': envvars.SAUCE_TUNNEL
   },
 
-  sauceUser: process.env.SAUCE_USER,
-  sauceKey:  process.env.SAUCE_KEY,
+  sauceUser: envvars.SAUCE_USERNAME,
+  sauceKey:  envvars.SAUCE_ACCESS_KEY,
 
   onPrepare: function() {
     browser.ignoreSynchronization = true;
@@ -29,7 +30,7 @@ exports.config = {
 
     mkdirp( newFolder, function( err ) {
       if ( err ) {
-        console.error( err ); // eslint-disable-line no-console, no-inline-comments, max-len
+        console.error( err );
       } else {
         var jUnitXmlReporter = new JasmineReporters.JUnitXmlReporter( {
           consolidateAll: true,

--- a/test/browser_tests/page_objects/page_wagtail_states_pages.js
+++ b/test/browser_tests/page_objects/page_wagtail_states_pages.js
@@ -1,5 +1,7 @@
 'use strict';
 
+var envvars = require( '../../../config/environment' ).envvars;
+
 function SharedPage() {
 
   this.get = function() {
@@ -8,8 +10,8 @@ function SharedPage() {
   };
 
   this.getStaging = function() {
-    var baseUrl = process.env.STAGING_HOSTNAME + ':' +
-                  process.env.HTTP_PORT + '/shared-page/';
+    var baseUrl = envvars.DJANGO_STAGING_HOSTNAME + ':' +
+                  envvars.TEST_HTTP_PORT + '/shared-page/';
     browser.get( baseUrl );
   };
 
@@ -25,8 +27,8 @@ function SharedDraftPage() {
   };
 
   this.getStaging = function() {
-    var baseUrl = process.env.STAGING_HOSTNAME + ':' +
-                  process.env.HTTP_PORT + '/shared-draft-page/';
+    var baseUrl = envvars.DJANGO_STAGING_HOSTNAME + ':' +
+                  envvars.TEST_HTTP_PORT + '/shared-draft-page/';
     browser.get( baseUrl );
   };
 

--- a/test/unit_tests/modules/BreakpointHandler-spec.js
+++ b/test/unit_tests/modules/BreakpointHandler-spec.js
@@ -23,7 +23,7 @@ describe( 'BreakpointHandler', function() {
   jsdom( {
     created: function( error, win ) {
       if ( error ) {
-        console.log( error ); // eslint-disable-line no-console, no-inline-comments, max-len
+        console.log( error );
       }
 
       var resizeEvent = win.document.createEvent( 'Event' );

--- a/tox.ini
+++ b/tox.ini
@@ -4,13 +4,14 @@ skipsdist = True
 
 [testenv]
 recreate = True
+# TODO: Pull in environment variables from .env instead of re-defining them.
 setenv =
     GOVDELIVERY_ACCOUNT_CODE = fake_account_code
     DJANGO_SETTINGS_MODULE = cfgov.settings.test
     ES_PORT=9200
     ES_HOST=localhost
     SHEER_ELASTICSEARCH_INDEX=content
-    STAGING_HOSTNAME=content.localhost
+    DJANGO_STAGING_HOSTNAME=content.localhost
     AKAMAI_USER=test@mail.com
     AKAMAI_PASSWORD=password
     AKAMAI_NOTIFY_EMAIL=test@mail.com
@@ -20,7 +21,7 @@ deps =
 changedir = {toxinidir}/cfgov
 commands=
     python manage.py test {posargs}
-    
+
 [testenv:fast]
 recreate = False
 setenv =


### PR DESCRIPTION
## Changes
- Consolidated all environment variables in `config/environment.js`.
- Ignored `console.log` in tests and enforced `no-process`.
- Updated `STAGING_HOSTNAME` to `DJANGO_STAGING_HOSTNAME` environment var.
- Updated `HTTP_HOST` to `TEST_HTTP_HOST` environment var.
- Updated `HTTP_PORT` to `TEST_HTTP_PORT` environment var.
- Allows passing of port to `runserver.sh`.
- Added misnamed and unreferenced environment variables to .env.

## Removed
- Removed unused `SELENIUM_URL` environment variable.

## Testing

- Grab `clear variable state` and `export variable defaults` sections from `.env_SAMPLE` and add to your local `.env`.
- Update values in your local `.env` for:
  - `STAGING_HOSTNAME` > `DJANGO_STAGING_HOSTNAME`
  - `HTTP_HOST` > `TEST_HTTP_HOST`
  - `HTTP_PORT` > `TEST_HTTP_PORT`
  - add `SITE_DESC`
  - add `DJANGO_HTTP_PORT`
  - remove `SELENIUM_URL`
- Reload your environment with `source ./.env` while in the root directory.
- Stop the server and re-start with `./runserver.sh`
- Edit `DJANGO_HTTP_PORT` in django settings section to change port (e.g. `8001`).
- Reload settings with `source ./.env`.
- Stop the server and start again with `./runserver.sh` and note port change from before.
- All other test tasks, etc. should run as before:
  - `gulp test:a11y`
  - `gulp test --sauce=false`
  - `gulp test` (on sauce).

## Review

- @chosak 
- @rosskarchner
- @richaagarwal
- @vickumar1981
- @vccabral

## Screenshots

![screen shot 2016-07-26 at 4 24 14 pm](https://cloud.githubusercontent.com/assets/704760/17156547/6a7ff6cc-5358-11e6-8bde-71b989ae4daa.png)


## Notes

- All settings that have defaults should probably be unset to begin with and then set to their defaults in `.env` and then the individual settings should be commented out by default so that they are only enabled in order to override the default.
