### PR TITLE
Removed interactiveTestPort variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,17 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
   to the level of a MAJOR or MINOR update.
 
 ---------------------------------------
+## UNRELEASED
+
+### Added
+
+### Changed
+
+### Removed
+- Removed unused `interactiveTestPort` test variable.
+
+### Fixed
+
 
 ## 3.4.0 2016-07-12
 

--- a/test/browser_tests/environment.js
+++ b/test/browser_tests/environment.js
@@ -13,9 +13,6 @@ module.exports = {
   // Default http port to host the web server
   webServerDefaultPort: webServerDefaultPort,
 
-  // Protractor interactive tests
-  interactiveTestPort: 6969,
-
   // A base URL for your application under test.
   baseUrl:
     'http://' + ( process.env.HTTP_HOST || 'localhost' ) +


### PR DESCRIPTION
I couldn't find anywhere that this was used. Seems safe to remove... or?

## Removals

- Removed `interactiveTestPort` test variable.

## Review

- @jimmynotjim 
- @imuchnik 
- @sebworks 
- @KimberlyMunoz 