### PR TITLE
Minor linter fixes

### DIFF
--- a/cfgov/unprocessed/js/modules/focus-target.js
+++ b/cfgov/unprocessed/js/modules/focus-target.js
@@ -11,6 +11,7 @@
 'use strict';
 
 var attachBehavior = require( './util/behavior' ).attach;
+
 /**
  * Parse links to handle webkit bug with keyboard focus.
  */

--- a/cfgov/unprocessed/js/modules/util/behavior.js
+++ b/cfgov/unprocessed/js/modules/util/behavior.js
@@ -77,7 +77,7 @@ function attach( behaviorElement, event, eventHandler, baseElement ) {
     behaviorElements = _findElements( behaviorElement, baseElement );
   }
 
-  for( var i = 0, len = behaviorElements.length; i < len; i++ ) {
+  for ( var i = 0, len = behaviorElements.length; i < len; i++ ) {
     behaviorElements[i].addEventListener( event, eventHandler, false );
   }
 

--- a/cfgov/unprocessed/js/organisms/Header.js
+++ b/cfgov/unprocessed/js/organisms/Header.js
@@ -45,7 +45,7 @@ function Header( element ) {
     try {
       _globalbanner = new GlobalBanner( _dom );
       _globalbanner.init();
-    } catch( err ) {
+    } catch ( err ) {
       // No Banner to initialize.
     }
 

--- a/cfgov/unprocessed/js/shims/es5-shim.js
+++ b/cfgov/unprocessed/js/shims/es5-shim.js
@@ -4,7 +4,7 @@
 
 'use strict';
 
-if( window.Modernizr && window.Modernizr.es5 === false ) {
+if ( window.Modernizr && window.Modernizr.es5 === false ) {
   // Global modules.
   require( 'es5-shim' ); // eslint-disable-line global-require
   require( 'es5-sham' ); // eslint-disable-line global-require

--- a/test/browser_tests/conf.js
+++ b/test/browser_tests/conf.js
@@ -66,12 +66,14 @@ function _isSauceCredentialSet() {
  * @returns {Array} List of specs or spec patterns to execute.
  */
 function _chooseProtractorSpecs( params ) {
-  var i, len, specs = [];
+  var i;
+  var len;
+  var specs = [];
 
   // If one or more suites are specified, use their specs.
   if ( _paramIsSet( params.suite ) ) {
     var suiteNames = params.suite.split( ',' );
-    for ( i = 0, len = suiteNames.length; i < len; i++) {
+    for ( i = 0, len = suiteNames.length; i < len; i++ ) {
       var suiteSpecs = environment.suites[suiteNames[i]];
       if ( suiteSpecs ) {
         specs = specs.concat( suiteSpecs );

--- a/test/unit_tests/modules/util/atomic-helpers-spec.js
+++ b/test/unit_tests/modules/util/atomic-helpers-spec.js
@@ -26,7 +26,8 @@ describe( 'atomic-helpers', function() {
   describe( '.checkDom()', function() {
     it( 'should throw an error if element DOM not found', function() {
       var errMsg = 'null is not valid. ' +
-                   'Check that element is a DOM node with class ".o-expandable"';
+                   'Check that element is a DOM node with ' +
+                   'class ".o-expandable"';
       function errFunc() {
         atomicHelpers.checkDom( null, '.o-expandable' );
       }

--- a/test/unit_tests/organisms/FilterableListControls-spec.js
+++ b/test/unit_tests/organisms/FilterableListControls-spec.js
@@ -3,7 +3,8 @@ var BASE_JS_PATH = '../../../cfgov/unprocessed/js/';
 
 var chai = require( 'chai' );
 var expect = chai.expect;
-var FilterableListControls = require( BASE_JS_PATH + 'organisms/FilterableListControls' );
+var FilterableListControls =
+  require( BASE_JS_PATH + 'organisms/FilterableListControls' );
 
 describe( 'FilterableListControls', function() {
   // TODO: Implement tests.


### PR DESCRIPTION
## Changes

- Minor linter fixes from autofixing errors with `--fix` flag and reformatting to remove some `max-len` warnings.

## Testing

- `gulp lint` should show no errors (but will show warnings).

## Review

- @sebworks 
- @chosak 
- @contolini 
