### PR TITLE
Add accessibility acceptance tests

### DIFF
--- a/TEST.md
+++ b/TEST.md
@@ -154,7 +154,11 @@ run `gulp test:unit:server` from the command-line in the project root.
 
 # Accessibility Testing
 
-To audit a page's WCAG and Section 508 accessibility:
+Whenever `gulp test:acceptance` is run, every webpage is checked for WCAG and
+Section 508 compliancy using Protractor's
+[accessibility plugin](https://github.com/angular/protractor-accessibility-plugin).
+
+If you'd like to audit a specific page, use `gulp test:a11y`:
   1. Enable the environment variable `ACHECKER_ID` in your `.env` file.
      Get a free [AChecker API ID](http://achecker.ca/register.php) for the value.
   2. Reload your `.env` with `. ./.env` while in the project root directory.

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "mocha": "2.4.5",
     "mocha-jsdom": "1.1.0",
     "protractor": "3.2.1",
+    "protractor-accessibility-plugin": "github:cfpb/protractor-accessibility-plugin#on-page-load",
     "sinon": "1.17.3",
     "sinon-chai": "2.8.0",
     "wcag": "0.2.2"

--- a/test/browser_tests/conf.js
+++ b/test/browser_tests/conf.js
@@ -159,7 +159,10 @@ var config = {
   jasmineNodeOpts: {
     defaultTimeoutInterval: 60000
   },
-
+  plugins: [{
+    axe: true,
+    package: 'protractor-accessibility-plugin'
+  }],
   getMultiCapabilities: function() {
     var params = this.params;
 


### PR DESCRIPTION
Protractor accessibility plugin that runs [aXe](https://github.com/dequelabs/axe-core) against every page during browser tests.

## Additions

- `plugins` array in protractor config file.

## Testing

- `npm install`
- `gulp test:acceptance:full`

## Review

- @sebworks 
- @virginiacc 

## Screenshots

<img width="782" alt="screen shot 2016-07-26 at 8 21 04 pm" src="https://cloud.githubusercontent.com/assets/1060248/17159850/899b98ac-536e-11e6-81c8-2dc52b0da279.png">

## Notes

- It's reporting lots of accessibility errors. 😓 
- `package.json` is pointing to our fork because our changes haven't reached [upstream](https://github.com/angular/protractor-accessibility-plugin/pull/6) yet.