### PR TITLE
Fix bugs on leadership calendar

### DIFF
--- a/cfgov/cal/test_views.py
+++ b/cfgov/cal/test_views.py
@@ -1,0 +1,161 @@
+import mock
+import json
+import urllib2
+
+from django.db.models import Q
+from django.http import HttpResponse
+from django.test import TestCase
+from django.test.client import RequestFactory
+
+from .views import display, set_cal_events_context, set_pagination_context, \
+    get_calendar_events_query, pdf_response
+
+
+class TestCalendarEvents(TestCase):
+    def setUp(self):
+        self.request = mock.Mock()
+
+    @mock.patch('cal.views.render')
+    @mock.patch('cal.views.CalendarFilterForm')
+    def test_display_calls_form_is_valid(self, mock_form_class, mock_render):
+        mock_form = mock.Mock()
+        mock_form.is_valid.return_value = False
+        mock_form_class.return_value = mock_form
+        display(self.request)
+        assert mock_form.is_valid.called
+
+    @mock.patch('cal.views.render')
+    @mock.patch('cal.views.CalendarFilterForm')
+    @mock.patch('cal.views.pdf_response')
+    @mock.patch('cal.views.set_cal_events_context')
+    @mock.patch('cal.views.PDFreactor')
+    def test_display_calls_pdf_response(self, mock_PDFreactor,
+            mock_set_cal_events_context, mock_pdf_response, mock_form_class,
+            mock_render):
+        mock_form = mock.Mock()
+        mock_form.is_valid.return_value = True
+        mock_form_class.return_value = mock_form
+        display(self.request, pdf=True)
+        assert mock_set_cal_events_context.called
+        assert mock_pdf_response.called
+
+    @mock.patch('cal.views.render')
+    @mock.patch('cal.views.CalendarFilterForm')
+    @mock.patch('cal.views.pdf_response')
+    @mock.patch('cal.views.set_cal_events_context')
+    def test_display_calls_render_for_print(self, mock_set_cal_events_context,
+            mock_pdf_response, mock_form_class, mock_render):
+        mock_form = mock.Mock()
+        mock_form.is_valid.return_value = True
+        mock_form_class.return_value = mock_form
+        template_name = 'about-us/the-bureau/leadership-calendar/print/index.html'
+        display(self.request, pdf=True)
+        mock_render.assert_called_with(self.request, template_name, {'form': mock_form})
+
+    @mock.patch('cal.views.render')
+    @mock.patch('cal.views.CalendarFilterForm')
+    @mock.patch('cal.views.set_pagination_context')
+    @mock.patch('cal.views.set_cal_events_context')
+    def test_display_calls_set_pagination_context(self,
+            mock_set_cal_events_context, mock_set_pagination_context,
+            mock_form_class, mock_render):
+        mock_form = mock.Mock()
+        mock_form.is_valid.return_value = True
+        mock_form_class.return_value = mock_form
+        display(self.request)
+        assert mock_set_pagination_context.called
+
+    @mock.patch('cal.views.render')
+    @mock.patch('cal.views.CalendarFilterForm')
+    @mock.patch('cal.views.set_pagination_context')
+    @mock.patch('cal.views.set_cal_events_context')
+    def test_display_calls_render_for_regular_view(self,
+            mock_set_cal_events_context, mock_set_pagination_context,
+            mock_form_class, mock_render):
+        mock_form = mock.Mock()
+        mock_form.is_valid.return_value = True
+        mock_form_class.return_value = mock_form
+        template_name = 'about-us/the-bureau/leadership-calendar/index.html'
+        display(self.request)
+        assert mock_render.called
+        mock_render.assert_called_with(self.request, template_name, {'form': mock_form})
+
+
+class TestSetCalendarEventsContext(TestCase):
+    @mock.patch('cal.views.PaginatorForSheerTemplates')
+    def setUp(self, mock_paginator):
+        self.form = mock.Mock()
+        self.context = {'form': self.form}
+
+    @mock.patch('cal.views.CFPBCalendarEvent')
+    @mock.patch('cal.views.get_calendar_events_query')
+    def test_calls_get_calendar_query(self, mock_query_fn, mock_event_class):
+        set_cal_events_context(self.context)
+        assert mock_query_fn.called
+
+    @mock.patch('cal.views.CFPBCalendarEvent')
+    @mock.patch('cal.views.get_calendar_events_query')
+    def test_updates_context(self, mock_query_fn, mock_event_class):
+        set_cal_events_context(self.context)
+        for key in ['events', 'range_start', 'range_end', 'form']:
+            assert key in self.context.keys()
+
+
+class TestCalendarEventsQuery(TestCase):
+    def setUp(self):
+        self.form = mock.MagicMock()
+
+    def test_returns_query(self):
+        result = get_calendar_events_query(self.form)
+        assert type(result) is Q
+
+
+class TestSetPaginationContext(TestCase):
+    def setUp(self):
+        self.request = mock.Mock()
+        self.request.GET.get.return_value = 1
+        self.context = {'events': mock.Mock()}
+
+    @mock.patch('cal.views.PaginatorForSheerTemplates')
+    @mock.patch('cal.views.configure_page_days')
+    def test_calls_configure_page_days(self, mock_configure_page_days,
+            mock_paginator):
+        set_pagination_context(self.request, self.context)
+        assert mock_configure_page_days.called
+
+    @mock.patch('cal.views.PaginatorForSheerTemplates')
+    @mock.patch('cal.views.configure_page_days')
+    def test_sets_context(self, mock_configure_page_days, mock_paginator):
+        set_pagination_context(self.request, self.context)
+        assert 'paginator' in self.context
+        assert 'page_days' in self.context
+
+
+class TestPDFResponse(TestCase):
+    def setUp(self):
+        self.request = mock.Mock()
+        self.context = mock.Mock()
+
+    @mock.patch('cal.views.render')
+    @mock.patch('cal.views.get_template')
+    @mock.patch('cal.views.PDFreactor')
+    def test_returns_http_response(self, mock_pdf_reactor, mock_get_template,
+            mock_render):
+        pdf_reactor = mock.MagicMock()
+        result = pdf_response(self.request, self.context)
+        assert type(result) is HttpResponse
+
+    @mock.patch('cal.views.render')
+    @mock.patch('cal.views.HttpResponse')
+    @mock.patch('cal.views.get_template')
+    @mock.patch('cal.views.PDFreactor')
+    def test_calls_render(self, mock_pdf_reactor, mock_get_template,
+            mock_HttpResponse, mock_render):
+        mock_HttpResponse.side_effect = urllib2.URLError(1)
+        pdf_response(self.request, self.context)
+        assert mock_render.called
+
+
+
+
+

--- a/cfgov/cal/views.py
+++ b/cfgov/cal/views.py
@@ -110,7 +110,7 @@ def display(request, pdf=False):
             day_range = [object_list[0] + timedelta(hours=23, minutes=59, seconds=59),
                          object_list[0]]
             context.update({'day_range': day_range})
-        else:
+        elif object_list:
             object_list[0] += timedelta(hours=23, minutes=59, seconds=59)
             page_days.object_list = object_list
 
@@ -150,4 +150,4 @@ def pdf_response(request, context):
         response['Content-Disposition'] = 'attachment; filename=cfpb-leadership.pdf'
         return response
     except (urllib2.HTTPError, urllib2.URLError, BadStatusLine):
-        pass
+        return render(request, template_name, context)

--- a/cfgov/cal/views.py
+++ b/cfgov/cal/views.py
@@ -32,11 +32,14 @@ if six.PY2:
 
 
 class CalendarFilterForm(forms.Form):
-    filter_calendar = forms.MultipleChoiceField(
-            choices = [(c.title, c.title) for c in CFPBCalendar.objects.all()],
-            required=False)
+    filter_calendar = forms.MultipleChoiceField(choices=[], required=False)
     filter_range_date_gte = forms.DateField(required=False)
     filter_range_date_lte = forms.DateField(required=False)
+
+    def __init__(self, *args, **kwargs):
+        super(CalendarFilterForm, self).__init__(*args, **kwargs)
+        self.fields['filter_calendar'].choices = [(c.title, c.title) for c in
+                                                  CFPBCalendar.objects.all()]
 
     def clean_filter_calendar(self):
         calendar_names = self.cleaned_data['filter_calendar']
@@ -68,66 +71,86 @@ def display(request, pdf=False):
     context = {'form': form}
 
     if form.is_valid():
-        cal_q = Q(('active', True))
-        if form.cleaned_data.get('filter_calendar', None):
-            calendars = form.cleaned_data['filter_calendar']
-            cal_q &= Q(('calendar__in', calendars))
-
-        if form.cleaned_data.get('filter_range_date_gte'):
-            gte = form.cleaned_data['filter_range_date_gte']
-            cal_q &= Q(('dtstart__gte', gte))
-
-        if form.cleaned_data.get('filter_range_date_lte'):
-            # adding timedelta(days=1) makes the end of the range inclusive
-            lte = form.cleaned_data['filter_range_date_lte']+ timedelta(days=1)
-            cal_q &= Q(('dtend__lte', lte))
-
-
-        events = CFPBCalendarEvent.objects.filter(cal_q).order_by('-dtstart')
-        datetimes = events.datetimes('dtstart', 'day', order='DESC')
-        paginator = PaginatorForSheerTemplates(request, datetimes, 5)
-        page_num = int(request.GET.get('page', 1))
-
-        try:
-            page_days = paginator.page(page_num)
-            paginator.current_page = page_num
-        except PageNotAnInteger:
-            # If page is not an integer, deliver first page.
-            page_days = paginator.page(1)
-            paginator.current_page = 1
-        except EmptyPage:
-            # If page is out of range (e.g. 9999), deliver last page of results.
-            page_days = paginator.page(paginator.num_pages)
-            paginator.current_page = paginator.num_pages
-
-        stats = events.aggregate(Min('dtstart'), Max('dtend'))
-        range_start = form.cleaned_data.get('filter_range_date_gte') or stats['dtstart__min']
-        range_end = form.cleaned_data.get('filter_range_date_lte') or stats['dtend__max']
-
-        # The first date in the list needs to include all the events for that day
-        object_list = list(page_days.object_list)
-        if len(object_list) == 1:
-            day_range = [object_list[0] + timedelta(hours=23, minutes=59, seconds=59),
-                         object_list[0]]
-            context.update({'day_range': day_range})
-        elif object_list:
-            object_list[0] += timedelta(hours=23, minutes=59, seconds=59)
-            page_days.object_list = object_list
-
-        context.update({
-            'paginator': paginator,
-            'events': events,
-            'page_days': page_days,
-            'range_start': range_start,
-            'range_end':range_end,
-        })
+        set_cal_events_context(context)
 
         if pdf:
             template_name = 'about-us/the-bureau/leadership-calendar/print/index.html'
             if PDFreactor:
                 return pdf_response(request, context)
+            else:
+                return render(request, template_name, context)
+
+        set_pagination_context(request, context)
 
     return render(request, template_name, context)
+
+
+def set_cal_events_context(context):
+    cal_q = get_calendar_events_query(context['form'])
+    events = CFPBCalendarEvent.objects.filter(cal_q).order_by('-dtstart')
+    stats = events.aggregate(Min('dtstart'), Max('dtend'))
+    range_start = context['form'].cleaned_data.get('filter_range_date_gte') or stats['dtstart__min']
+    range_end = context['form'].cleaned_data.get('filter_range_date_lte') or stats['dtend__max']
+
+    context.update({
+        'events': events,
+        'range_start': range_start,
+        'range_end':range_end,
+    })
+
+
+def get_calendar_events_query(form):
+    cal_q = Q(('active', True))
+    if form.cleaned_data.get('filter_calendar', None):
+        calendars = form.cleaned_data['filter_calendar']
+        cal_q &= Q(('calendar__in', calendars))
+
+    if form.cleaned_data.get('filter_range_date_gte'):
+        gte = form.cleaned_data['filter_range_date_gte']
+        cal_q &= Q(('dtstart__gte', gte))
+
+    if form.cleaned_data.get('filter_range_date_lte'):
+        # adding timedelta(days=1) makes the end of the range inclusive
+        lte = form.cleaned_data['filter_range_date_lte'] + timedelta(days=1)
+        cal_q &= Q(('dtend__lte', lte))
+
+    return cal_q
+
+def set_pagination_context(request, context):
+    datetimes = context['events'].datetimes('dtstart', 'day', order='DESC')
+    paginator = PaginatorForSheerTemplates(request, datetimes, 5)
+    page_num = int(request.GET.get('page', 1))
+
+    try:
+        page_days = paginator.page(page_num)
+        paginator.current_page = page_num
+    except PageNotAnInteger:
+        # If page is not an integer, deliver first page.
+        page_days = paginator.page(1)
+        paginator.current_page = 1
+    except EmptyPage:
+        # If page is out of range (e.g. 9999), deliver last page of results.
+        page_days = paginator.page(paginator.num_pages)
+        paginator.current_page = paginator.num_pages
+
+    configure_page_days(page_days)
+
+    context.update({
+        'paginator': paginator,
+        'page_days': page_days,
+    })
+
+
+def configure_page_days(page_days):
+    # The first date in the list needs to include all the events for that day
+    days = list(page_days.object_list)
+    if days:
+        if len(days) == 1:
+            # If there's only one day of events then duplicate it
+            days = [days[0], days[0]]
+        days[0] += timedelta(hours=23, minutes=59, seconds=59)
+        page_days.object_list = days
+
 
 def pdf_response(request, context):
     template_name = 'about-us/the-bureau/leadership-calendar/print/index.html'

--- a/cfgov/cal/views.py
+++ b/cfgov/cal/views.py
@@ -122,8 +122,10 @@ def display(request, pdf=False):
             'range_end':range_end,
         })
 
-        if pdf and PDFreactor:
-            return pdf_response(request, context)
+        if pdf:
+            template_name = 'about-us/the-bureau/leadership-calendar/print/index.html'
+            if PDFreactor:
+                return pdf_response(request, context)
 
     return render(request, template_name, context)
 

--- a/cfgov/jinja2/v1/_includes/leadership-calendar-table.html
+++ b/cfgov/jinja2/v1/_includes/leadership-calendar-table.html
@@ -19,24 +19,24 @@
 {% endif %}
 
 {% if is_pdf %}
-    {% for days_of_events in events|groupby('day')|reverse %}
-        {{ render_table(days_of_events, is_pdf, options) }}
+    {% for day_of_events in events|groupby('day')|reverse %}
+        {{ render_table(day_of_events, is_pdf, options) }}
     {% endfor %}
 {% else %}
-    {% for days in page_days %}
-        {{ render_table(days, is_pdf, options) }}
+    {% for day in page_days %}
+        {{ render_table(day, is_pdf, options) }}
     {% endfor %}
 {% endif %}
 
 {% endmacro %}
 
-{% macro render_table(days, is_pdf, options) %}
+{% macro render_table(day_of_events, is_pdf, options) %}
     <table class="u-w100pct block block__flush-top">
         <thead>
             <tr>
                 <th colspan="3">
-                    {% set day = days.grouper if is_pdf else days %}
-                    {# {% import 'macros/time.html' as time %} #}
+                    {% set day = day_of_events.grouper if is_pdf else day_of_events %}
+                    {% set events = day_of_events.list if is_pdf else events %}
                     {{ time.render(day, {'date':true}) }}
                 </th>
             </tr>
@@ -52,7 +52,7 @@
         {% set day = day.date() %}
     {% endif %}
     {% for event in calendar_events|sort(attribute='dtstart') %}
-        {% set start = event.dtstart | dateobj %}
+        {% set start = event.dtstart %}
         {% if start.date() == day %}
             <tr>
                 <td class="{{ options.time_col_classes }}">

--- a/cfgov/jinja2/v1/_includes/leadership-calendar-table.html
+++ b/cfgov/jinja2/v1/_includes/leadership-calendar-table.html
@@ -1,6 +1,6 @@
-{% macro render(user_options={}) %}
-
 {% import 'macros/time.html' as time %}
+
+{% macro render(user_options={}, is_pdf=false) %}
 
 {% set options = {
     'time_col_classes': 'u-w25pct',
@@ -8,26 +8,52 @@
     'desc_col_classes': 'u-w50pct'
 } %}
 {% set _ignore = options.update(user_options) %}
+{% set paged_events = none %}
 
-{# Page the events by the earliest and latest dates in the range. #}
-{% set range = day_range or page_days %}
-{% set from = range[-1] %}
-{% set to = range[0] %}
-{% set paged_events = events.filter(dtstart__gte=from).filter(dtstart__lte=to).order_by('-dtstart') %}
+{% if not is_pdf %}
+    {# Page the events by the earliest and latest dates in the range. #}
+    {% set range = day_range or page_days %}
+    {% set from = range[-1] %}
+    {% set to = range[0] %}
+    {% set paged_events = events.filter(dtstart__gte=from).filter(dtstart__lte=to).order_by('-dtstart') %}
+{% endif %}
 
-{% for day in page_days %}
-<table class="u-w100pct block block__flush-top">
-    <thead>
-        <tr>
-            <th colspan="3">
-                {{ time.render(day, {'date':true}) }}
-            </th>
-        </tr>
-    </thead>
-    <tbody>
-    {% for event in paged_events|sort(attribute='dtstart') %}
+{% if is_pdf %}
+    {% for days_of_events in events|groupby('day')|reverse %}
+        {{ render_table(days_of_events, is_pdf, options) }}
+    {% endfor %}
+{% else %}
+    {% for days in page_days %}
+        {{ render_table(days, is_pdf, options) }}
+    {% endfor %}
+{% endif %}
+
+{% endmacro %}
+
+{% macro render_table(days, is_pdf, options) %}
+    <table class="u-w100pct block block__flush-top">
+        <thead>
+            <tr>
+                <th colspan="3">
+                    {% set day = days.grouper if is_pdf else days %}
+                    {# {% import 'macros/time.html' as time %} #}
+                    {{ time.render(day, {'date':true}) }}
+                </th>
+            </tr>
+        </thead>
+        <tbody>
+            {{ render_events(events, day, options) }}
+        </tbody>
+    </table>
+{% endmacro %}
+
+{% macro render_events(calendar_events, day, options) %}
+    {% if day.date is defined %}
+        {% set day = day.date() %}
+    {% endif %}
+    {% for event in calendar_events|sort(attribute='dtstart') %}
         {% set start = event.dtstart | dateobj %}
-        {% if start.date() == day.date() %}
+        {% if start.date() == day %}
             <tr>
                 <td class="{{ options.time_col_classes }}">
                 {%- if event.all_day %}
@@ -54,7 +80,4 @@
         {% endif %}
     {% endfor %}
     </tbody>
-</table>
-{% endfor %}
-
 {% endmacro %}

--- a/cfgov/jinja2/v1/_includes/macros/filters.html
+++ b/cfgov/jinja2/v1/_includes/macros/filters.html
@@ -390,7 +390,7 @@
            id="{{ id }}"
            {%- if is_filter_selected(field, value) %}
            checked
-           {%- endif -%}
+           {% endif -%}
            data-required="1"
            >
     <label class="form-group_item" for="{{ id }}">

--- a/cfgov/jinja2/v1/about-us/the-bureau/leadership-calendar/index.html
+++ b/cfgov/jinja2/v1/about-us/the-bureau/leadership-calendar/index.html
@@ -67,7 +67,7 @@
                 'calendar_event',
                 { 'expand_label': 'Filter calendars', 'show_errors': true }
             ) }}
-            {% if events is defined and page_days is defined %}
+            {% if events and page_days %}
                 {{ calendar.render() }}
             {% endif %}
 

--- a/cfgov/jinja2/v1/about-us/the-bureau/leadership-calendar/print/index.html
+++ b/cfgov/jinja2/v1/about-us/the-bureau/leadership-calendar/print/index.html
@@ -34,7 +34,7 @@
 
 
                 </div>
-                {% if events and page_days %}
+                {% if events %}
                     {{ calendar.render({
                         'time_col_classes': 'u-w30pct',
                         'name_col_classes': 'u-w30pct',

--- a/cfgov/jinja2/v1/about-us/the-bureau/leadership-calendar/print/index.html
+++ b/cfgov/jinja2/v1/about-us/the-bureau/leadership-calendar/print/index.html
@@ -18,7 +18,7 @@
 {% endblock %}
 
 {% block body %}
-    {% import 'leadership-calendar-table.html' as calendar %}
+    {% import 'leadership-calendar-table.html' as calendar with context %}
 
     <main class="content print" id="main" role="main">
         <div class="content_wrapper">
@@ -34,11 +34,13 @@
 
 
                 </div>
-                {{ calendar.render(events, {
-                    'time_col_classes': 'u-w30pct',
-                    'name_col_classes': 'u-w30pct',
-                    'desc_col_classes': 'u-w40pct'
-                }) }}
+                {% if events and page_days %}
+                    {{ calendar.render({
+                        'time_col_classes': 'u-w30pct',
+                        'name_col_classes': 'u-w30pct',
+                        'desc_col_classes': 'u-w40pct'
+                    }, is_pdf=True) }}
+                {% endif %}
             </div>
         </div><!-- END .wrapper -->
     </main><!-- END .content -->


### PR DESCRIPTION
Related to [GHE]/CFGOV/platform/issues/131

There are template errors and mishandled PDF logic that is fixed with this.

## Additions

- Macros in the leadership-calendar-table.html template for modularity and clarity.

## Changes

- Failed PDFreactor calls return the print template rendered instead of just passing.
- Fixed print template macro call
- Refactored templates and view logic
- Fixed markup for "checked" calendars

## Testing

- Go to leadership calendar
- Filter on a calendar
- Filter on dates
- Click Download PDF button on the bottom controls form
- If PDFreactor is set up then it should return a pdf. Otherwise, it should direct you to the print page with all the events.

## Review

- @rosskarchner 
- @willbarton 
- @Scotchester 
- @chosak 
- @virginiacc 
- @contolini 

## Todos

- Tests

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)

