### PR TITLE
Fail gulp test when spawned processes fail

### DIFF
--- a/gulp/tasks/test.js
+++ b/gulp/tasks/test.js
@@ -43,7 +43,11 @@ function testUnitServer() {
   spawn(
     'tox',
     { stdio: 'inherit' }
-  ).once( 'close', function() {
+  ).once( 'close', function( code ) {
+    if ( code ) {
+      plugins.util.log( 'Tox tests exited with code ' + code );
+      process.exit( 1 );
+    }
     plugins.util.log( 'Tox tests done!' );
   } );
 }
@@ -144,7 +148,11 @@ function testA11y() {
     fsHelper.getBinary( 'wcag', 'wcag', '../.bin' ),
     _getWCAGParams(),
     { stdio: 'inherit' }
-  ).once( 'close', function() {
+  ).once( 'close', function( code ) {
+    if ( code ) {
+      plugins.util.log( 'WCAG tests exited with code ' + code );
+      process.exit( 1 );
+    }
     plugins.util.log( 'WCAG tests done!' );
   } );
 }
@@ -160,7 +168,11 @@ function _spawnProtractor( suite ) {
     fsHelper.getBinary( 'protractor', 'protractor', '../bin/' ),
     params,
     { stdio: 'inherit' }
-  ).once( 'close', function() {
+  ).once( 'close', function( code ) {
+    if ( code ) {
+      plugins.util.log( 'Protractor tests exited with code ' + code );
+      process.exit( 1 );
+    }
     plugins.util.log( 'Protractor tests done!' );
   } );
 }
@@ -172,7 +184,11 @@ function _spawnProtractor( suite ) {
 function testAcceptanceBrowser( suite ) {
   spawn(
     './initial-test-data.sh', [], { stdio: 'inherit' }
-  ).once( 'close', function() {
+  ).once( 'close', function( code ) {
+    if ( code ) {
+      plugins.util.log( 'Initial test data script exited with code ' + code );
+      process.exit( 1 );
+    }
     plugins.util.log( 'Loaded Wagtail database data!' );
     _spawnProtractor( suite );
   } );


### PR DESCRIPTION
The `gulp test` task currently spawns various processes to test different things: `tox` for Python unit tests, `wcag` for accessibility tests, `protractor` for browser tests, and `initial-test-data.sh` to load initial test data. If one or any of these processes return with a non-zero error code (for example if the Python unit tests fail), they should cause the gulp task to fail.

## Changes

- `spawn()` calls in `gulp/tasks/test.js` now check the returned status code and call `process.exit` if it is non-zero.

## Testing

- Run `gulp test` with a broken Python unit test (or temporarily remove or rename one of the dependent executables) and notice that the failure causes `gulp` to fail:

```sh
$ gulp test:unit
...
----------------------------------------------------------------------
Ran 131 tests in 0.973s

FAILED (errors=3)
...
ERROR:   py27: commands failed
[09:51:15] Tox tests exited with code 1
$ echo $?
1
```

## Review

- @anselmbradford @sebworks 

## Notes

- Is `process.exit(1)` a reasonable way to fail `gulp` when this happens?

## Checklist

* [X] Changes are limited to a single goal (no scope creep)
* [X] Code can be automatically merged (no conflicts)
* [X] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [X] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)

