### PR TITLE
Avoid a collision with Wagtail's initial home page slug

### DIFF
--- a/cfgov/scripts/initial_data.py
+++ b/cfgov/scripts/initial_data.py
@@ -28,7 +28,7 @@ def run():
         site_root = HomePage.objects.filter(title='CFGOV')
         if not site_root:
             root = Page.objects.first()
-            site_root = HomePage(title='CFGOV', slug='home', depth=2, owner=admin_user)
+            site_root = HomePage(title='CFGOV', slug='home-page', depth=2, owner=admin_user)
             site_root.live = True
             root.add_child(instance=site_root)
             latest = site_root.save_revision(user=admin_user, submitted_for_moderation=False)


### PR DESCRIPTION
This PR matches the change in 17239da0459dbf4bc9098cb3909731097d5846c8 to initial_test_data.py. Wagtail's migrations create an initial page with the slug "home". When running `./setup.sh` (or `./backend.sh` or `./initial-data.sh`) this will cause an error because the slug "home" already exists at the time when `./cfgov/scripts/initial_data.py` is run.

## Changes

- Change the initial home page slug to "home-page" from "home"

## Testing

- Run `./initial-data.sh` on a clean database.

## Review

- @cfpb/cfgov-backends

## Notes

To ensure that our setup scripts aren’t regularly broken, I will also set up a periodic Jenkins job that runs them and reports any failures.

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [x] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)

