### PR TITLE
Remove nyan cat unit test reporter 😿

### DIFF
--- a/gulp/tasks/test.js
+++ b/gulp/tasks/test.js
@@ -20,9 +20,7 @@ function testUnitScripts( cb ) {
     .pipe( plugins.istanbul.hookRequire() )
     .on( 'finish', function() {
       gulp.src( configTest.tests + '/unit_tests/**/*.js' )
-        .pipe( plugins.mocha( {
-          reporter: 'nyan'
-        } ) )
+        .pipe( plugins.mocha() )
         .pipe( plugins.istanbul.writeReports( {
           dir: configTest.tests + '/unit_test_coverage'
         } ) )

--- a/gulp/tasks/test.js
+++ b/gulp/tasks/test.js
@@ -20,7 +20,9 @@ function testUnitScripts( cb ) {
     .pipe( plugins.istanbul.hookRequire() )
     .on( 'finish', function() {
       gulp.src( configTest.tests + '/unit_tests/**/*.js' )
-        .pipe( plugins.mocha() )
+        .pipe( plugins.mocha( {
+          reporter: process.env.CONTINUOUS_INTEGRATION ? 'spec' : 'nyan'
+        } ) )
         .pipe( plugins.istanbul.writeReports( {
           dir: configTest.tests + '/unit_test_coverage'
         } ) )


### PR DESCRIPTION
As an ASCII art connoisseur it pains me to remove this but I think it's time. Its output makes Travis reports nearly unusable.

## Removals

![nyan cat](http://cdn.nyanit.com/nyan2.gif)

## Review

- @chosak 

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices
* [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)

