### PR TITLE
Fix disappearing submit button in filter expandable on blog page

### DIFF
--- a/cfgov/unprocessed/js/organisms/FilterableListControls.js
+++ b/cfgov/unprocessed/js/organisms/FilterableListControls.js
@@ -50,6 +50,11 @@ function FilterableListControls( element ) {
       return standardType.UNDEFINED;
     }
 
+    // instantiate multiselects before their containing expandable
+    // so height of any 'selected choice' buttons is included when
+    // expandable height is calculated initially
+    atomicHelpers.instantiateAll( 'select[multiple]', Multiselect );
+
     // TODO: FilterableListControls should use expandable
     //       behavior (FlyoutMenu), not an expandable directly.
     var expandable = new Expandable( _dom );
@@ -57,8 +62,6 @@ function FilterableListControls( element ) {
 
     _notification = new Notification( _dom );
     _notification.init();
-
-    atomicHelpers.instantiateAll( 'select[multiple]', Multiselect );
 
     _initEvents();
 

--- a/test/browser_tests/conf.js
+++ b/test/browser_tests/conf.js
@@ -66,7 +66,9 @@ function _isSauceCredentialSet() {
  * @returns {Array} List of specs or spec patterns to execute.
  */
 function _chooseProtractorSpecs( params ) {
-  var i, len, specs = [];
+  var i;
+  var len;
+  var specs = [];
 
   // If one or more suites are specified, use their specs.
   if ( _paramIsSet( params.suite ) ) {

--- a/test/browser_tests/spec_suites/content/blog.js
+++ b/test/browser_tests/spec_suites/content/blog.js
@@ -134,4 +134,35 @@ describe( 'The Blog Page', function() {
   it( 'should include a page input with value set to 1', function() {
     expect( page.paginationPageInput.getAttribute( 'value' ) === 1 );
   } );
+
+  it( 'should set an initial height on filter expandable that does not cut off submit button when page loads with 5 filter options selected', function() {
+    // open filter and select 5 options
+    page.searchFilterShowBtn.click();
+    browser.sleep( 1000 );
+
+    page.multiSelectSearch.click();
+    browser.sleep( 1000 );
+
+    var options = browser.element.all( by.css( '.cf-multi-select_label' ) );
+    for ( var i = 0; i < 5; i++ ) {
+     options.get(i).click();
+    }
+
+    // 5 choices should appear
+    var choices = browser.element.all( by.css( '.cf-multi-select_choices label' ) );
+    expect( choices.count() ).toBe( 5 );
+
+    // submit choices
+    browser.executeScript( "arguments[0].scrollIntoView();", page.searchFilterSubmitBtn.getWebElement() );
+    page.searchFilterSubmitBtn.click()
+    browser.sleep( 1000 );
+
+    // submit button should be visible in open filter expandable
+    // after page is reloaded 
+    browser.getCurrentUrl().then(function(newUrl) {
+      browser.get( newUrl );
+      browser.sleep( 1000 );
+      expect( page.searchFilterSubmitBtn.isDisplayed() ).toBe( true );
+    } );
+  } );
 } );

--- a/test/browser_tests/spec_suites/content/blog.js
+++ b/test/browser_tests/spec_suites/content/blog.js
@@ -145,7 +145,7 @@ describe( 'The Blog Page', function() {
 
     var options = browser.element.all( by.css( '.cf-multi-select_label' ) );
     for ( var i = 0; i < 5; i++ ) {
-     options.get(i).click();
+      options.get(i).click();
     }
 
     // 5 choices should appear
@@ -153,12 +153,12 @@ describe( 'The Blog Page', function() {
     expect( choices.count() ).toBe( 5 );
 
     // submit choices
-    browser.executeScript( "arguments[0].scrollIntoView();", page.searchFilterSubmitBtn.getWebElement() );
-    page.searchFilterSubmitBtn.click()
+    browser.executeScript( 'arguments[0].scrollIntoView();', page.searchFilterSubmitBtn.getWebElement() );
+    page.searchFilterSubmitBtn.click();
     browser.sleep( 1000 );
 
     // submit button should be visible in open filter expandable
-    // after page is reloaded 
+    // after page is reloaded
     browser.getCurrentUrl().then(function(newUrl) {
       browser.get( newUrl );
       browser.sleep( 1000 );

--- a/test/browser_tests/spec_suites/content/blog.js
+++ b/test/browser_tests/spec_suites/content/blog.js
@@ -137,32 +137,33 @@ describe( 'The Blog Page', function() {
 
   it( 'should set an initial height on filter expandable that does not cut off submit button when page loads with 5 filter options selected', function() {
     // open filter and select 5 options
-    page.searchFilterShowBtn.click();
-    browser.sleep( 1000 );
+    page.searchFilterShowBtn.click().then(function () {
+      page.multiSelectSearch.isDisplayed().then(function () {
+        page.multiSelectSearch.click().then(function () {
+          var options = browser.element.all( by.css( '.cf-multi-select_label' ) );
+          for ( var i = 0; i < 5; i++ ) {
+            options.get(i).click();
+          }
 
-    page.multiSelectSearch.click();
-    browser.sleep( 1000 );
+          // 5 choices should appear
+          var choices = browser.element.all( by.css( '.cf-multi-select_choices label' ) );
+          expect( choices.count() ).toBe( 5 );
 
-    var options = browser.element.all( by.css( '.cf-multi-select_label' ) );
-    for ( var i = 0; i < 5; i++ ) {
-      options.get(i).click();
-    }
+          // submit choices
+          browser.executeScript( 'arguments[0].scrollIntoView();', page.searchFilterSubmitBtn.getWebElement() );
+          page.searchFilterSubmitBtn.click().then(function () {
+            // submit button should be visible in open filter expandable
+            // after page is reloaded
+            browser.getCurrentUrl().then(function(newUrl) {
+              browser.get( newUrl );
+              browser.sleep( 1000 );
+              expect( page.searchFilterSubmitBtn.isDisplayed() ).toBe( true );
+            } );
+          } );
 
-    // 5 choices should appear
-    var choices = browser.element.all( by.css( '.cf-multi-select_choices label' ) );
-    expect( choices.count() ).toBe( 5 );
-
-    // submit choices
-    browser.executeScript( 'arguments[0].scrollIntoView();', page.searchFilterSubmitBtn.getWebElement() );
-    page.searchFilterSubmitBtn.click();
-    browser.sleep( 1000 );
-
-    // submit button should be visible in open filter expandable
-    // after page is reloaded
-    browser.getCurrentUrl().then(function(newUrl) {
-      browser.get( newUrl );
-      browser.sleep( 1000 );
-      expect( page.searchFilterSubmitBtn.isDisplayed() ).toBe( true );
+        } );
+      } );
     } );
   } );
+
 } );


### PR DESCRIPTION
Filter section submit button is cut off when blog page is loaded with more than 3 filter options selected

## Additions

- Test for disappearing filter button

## Changes

- Init multiselect before expandable in `FilterableListControls` so initial height set on expandable is calculated after filter choices are added to DOM

## Testing

- Navigate to [blog page with 3+ filter options selected](http://localhost:8000/about-us/blog/?form-id=1&filter1_title=&filter1_topics=Mortgages&filter1_topics=Students&filter1_topics=Financial+education&filter1_topics=Student+loans&filter1_from_date=&filter1_to_date=) and check that submit button is displayed in filter expandable

## Review

- @cfpb/cfgov-frontends 

## Screenshots

Before

<img width="789" alt="screen shot 2016-07-29 at 8 42 19 am" src="https://cloud.githubusercontent.com/assets/778171/17254157/6c845a50-5568-11e6-98cd-fe6e549964b7.png">


After

<img width="795" alt="screen shot 2016-07-29 at 8 42 29 am" src="https://cloud.githubusercontent.com/assets/778171/17254164/71ba98ea-5568-11e6-855e-722327972e1e.png">


## Notes

-

## Todos

-

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
