### PR TITLE
Fix broken parse_links unit tests

### DIFF
--- a/cfgov/v1/tests/test_links.py
+++ b/cfgov/v1/tests/test_links.py
@@ -4,20 +4,20 @@ from bs4 import BeautifulSoup
 
 class ImportDataTest(TestCase):
     def test_external_link(self):
-        soup = BeautifulSoup('<a href="https://wwww.google.com">external link/a>', 'html.parser')
-        output = str(parse_links(soup))
+        link = '<a href="https://wwww.google.com">external link/a>'
+        output = str(parse_links(link))
         self.assertIn('external-site', output)
         self.assertIn('class="icon-link_text"', output)
 
     def test_cfpb_link(self):
-        soup = BeautifulSoup('<a href="http://www.consumerfinance.gov/foo">cfpb link</a>', 'html.parser')
-        output = str(parse_links(soup))
+        link = '<a href="http://www.consumerfinance.gov/foo">cfpb link</a>'
+        output = str(parse_links(link))
         self.assertNotIn('external-site', output)
         self.assertNotIn('class="icon-link_text"', output)
 
     def test_gov_link(self):
-        soup = BeautifulSoup('<a href="http://www.fdic.gov/bar">gov link</a>', 'html.parser')
-        output = str(parse_links(soup))
+        link = '<a href="http://www.fdic.gov/bar">gov link</a>'
+        output = str(parse_links(link))
         self.assertNotIn('external-site', output)
         self.assertIn('class="icon-link_text"', output)
 


### PR DESCRIPTION
PR #2236 broke three unit tests by changing the expected type of the `parse_links` method. Previously it took a `BeautifulSoup` object but after that change expected a raw string or a `RichText` object. This PR fixes the unit tests in `v1.tests.test_links` to use that new behavior.

## Changes

- Fixes to `v1.tests.test_links` in how `parse_links` is called.

## Testing

- Run `tox` to verify that all unit tests pass.

## Review

- @kurtw @richaagarwal @Scotchester 

## Checklist

* [X] Changes are limited to a single goal (no scope creep)
* [X] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [X] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)

