### PR TITLE
Modify CONTRIBUTING guidelines based in-person discussions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,8 +33,9 @@ All new code should have associated unit tests and/or functional tests that
 validate implemented features and the presence or lack of defects. The
 overall test coverage of the code-base should not decrease.
 
-Python code is expected to follow PEP8 and 
+Python code is expected to follow 
+[PEP8](https://www.python.org/dev/peps/pep-0008/) and 
 [not commit atrocities](https://www.youtube.com/watch?v=wf-BqAjZb8M). 
-JavaScript should follow our 
-[JavaScript style guide](https://github.com/cfpb/front-end/blob/master/javascript.md). 
+JavaScript, CSS/Less, and markup should follow our 
+[front-end standards](https://github.com/cfpb/front-end). 
 When in doubt, mimic the styles and patterns in the existing code-base.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@
 
 There are two primary ways to help: 
  - Using the issue tracker, and 
- - Changing the code-base.
+ - Changing the codebase.
 
 
 ## Using the issue tracker
@@ -18,11 +18,11 @@ This is also a great way to connect with the developers of the project as well
 as others who are interested in this solution.  
 
 Use the issue tracker to find ways to contribute. Find a bug or a feature, mention in
-the issue that you will take on that effort, then follow the _Changing the code-base_ 
+the issue that you will take on that effort, then follow the _Changing the codebase_ 
 guidance below.
 
 
-## Changing the code-base
+## Changing the codebase
 
 Generally speaking, you should fork this repository, make changes in your
 own fork, and then submit a pull-request. For timely code reviews,
@@ -31,11 +31,11 @@ for your changes.
 
 All new code should have associated unit tests and/or functional tests that 
 validate implemented features and the presence or lack of defects. The
-overall test coverage of the code-base should not decrease.
+overall test coverage of the codebase should not decrease.
 
 Python code is expected to follow 
 [PEP8](https://www.python.org/dev/peps/pep-0008/) and 
 [not commit atrocities](https://www.youtube.com/watch?v=wf-BqAjZb8M). 
 JavaScript, CSS/Less, and markup should follow our 
 [front-end standards](https://github.com/cfpb/front-end). 
-When in doubt, mimic the styles and patterns in the existing code-base.
+When in doubt, mimic the styles and patterns in the existing codebase.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,8 +25,16 @@ guidance below.
 ## Changing the code-base
 
 Generally speaking, you should fork this repository, make changes in your
-own fork, and then submit a pull-request. All new code should have associated unit
-tests that validate implemented features and the presence or lack of defects. 
-Additionally, the code should follow any stylistic and architectural guidelines 
-prescribed by the project. In the absence of such guidelines, mimic the styles
-and patterns in the existing code-base.
+own fork, and then submit a pull-request. For timely code reviews,
+please tag @cfpb/cfgov-backends and @cfpb/cfgov-frontends as appropriate
+for your changes.
+
+All new code should have associated unit tests and/or functional tests that 
+validate implemented features and the presence or lack of defects. The
+overall test coverage of the code-base should not decrease.
+
+Python code is expected to follow PEP8 and 
+[not commit atrocities](https://www.youtube.com/watch?v=wf-BqAjZb8M). 
+JavaScript should follow our 
+[JavaScript style guide](https://github.com/cfpb/front-end/blob/master/javascript.md). 
+When in doubt, mimic the styles and patterns in the existing code-base.


### PR DESCRIPTION
Modifies the CONTRIBUTING.md file slightly to align with the front-end standards, back-end discussions, our team discussion in-person last week, and our "Building and Deploying" working document.

## Additions

- Adds some additional text about contributing to this repository.

## Review

@cfpb/cfgov-platform 

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)