### PR TITLE
Only run accessibility tests when requested by the user

### DIFF
--- a/TEST.md
+++ b/TEST.md
@@ -154,8 +154,8 @@ run `gulp test:unit:server` from the command-line in the project root.
 
 # Accessibility Testing
 
-Whenever `gulp test:acceptance` is run, every webpage is checked for WCAG and
-Section 508 compliancy using Protractor's
+Run the acceptance tests with an `--a11y` flag (i.e. `gulp test:acceptance --a11y`)
+to check every webpage for WCAG and Section 508 compliancy using Protractor's
 [accessibility plugin](https://github.com/angular/protractor-accessibility-plugin).
 
 If you'd like to audit a specific page, use `gulp test:a11y`:

--- a/gulp/config.js
+++ b/gulp/config.js
@@ -38,7 +38,8 @@ module.exports = {
   },
   test: {
     src:   paths.unprocessed + '/js/**/*.js',
-    tests: paths.test
+    tests: paths.test,
+    reporter: process.env.CONTINUOUS_INTEGRATION // eslint-disable-line no-process-env
   },
   clean: {
     dest: paths.processed

--- a/gulp/tasks/test.js
+++ b/gulp/tasks/test.js
@@ -21,7 +21,7 @@ function testUnitScripts( cb ) {
     .on( 'finish', function() {
       gulp.src( configTest.tests + '/unit_tests/**/*.js' )
         .pipe( plugins.mocha( {
-          reporter: process.env.CONTINUOUS_INTEGRATION ? 'spec' : 'nyan'
+          reporter: configTest.reporter ? 'spec' : 'nyan'
         } ) )
         .pipe( plugins.istanbul.writeReports( {
           dir: configTest.tests + '/unit_test_coverage'
@@ -79,7 +79,7 @@ function _getProtractorParams( suite ) {
 
   var commandLineParams = minimist( process.argv.slice( 2 ) );
 
-  var configFile = commandLineParams['a11y'] ? 'test/browser_tests/a11y_conf.js' : 'test/browser_tests/conf.js';
+  var configFile = commandLineParams.a11y ? 'test/browser_tests/a11y_conf.js' : 'test/browser_tests/conf.js';
 
   // Set default configuration command-line parameter.
   var params = [ configFile ];

--- a/gulp/tasks/test.js
+++ b/gulp/tasks/test.js
@@ -77,9 +77,12 @@ function _addCommandLineFlag( protractorParams, commandLineParams, value ) {
  */
 function _getProtractorParams( suite ) {
 
-  // Set default configuration command-line parameter.
-  var params = [ 'test/browser_tests/conf.js' ];
   var commandLineParams = minimist( process.argv.slice( 2 ) );
+
+  var configFile = commandLineParams['a11y'] ? 'test/browser_tests/a11y_conf.js' : 'test/browser_tests/conf.js';
+
+  // Set default configuration command-line parameter.
+  var params = [ configFile ];
 
   // If --sauce=false flag is added on the command-line.
   params = _addCommandLineFlag( params, commandLineParams, 'sauce' );

--- a/test/browser_tests/a11y_conf.js
+++ b/test/browser_tests/a11y_conf.js
@@ -1,0 +1,10 @@
+'use strict';
+
+var config = require('./conf').config;
+
+config.plugins = [{
+  axe: true,
+  package: 'protractor-accessibility-plugin'
+}];
+
+exports.config = config;

--- a/test/browser_tests/conf.js
+++ b/test/browser_tests/conf.js
@@ -162,10 +162,6 @@ var config = {
   jasmineNodeOpts: {
     defaultTimeoutInterval: 60000
   },
-  plugins: [{
-    axe: true,
-    package: 'protractor-accessibility-plugin'
-  }],
   getMultiCapabilities: function() {
     var params = this.params;
 


### PR DESCRIPTION
## Before

Running `gulp test` ran lots of tests including our new accessibility tests. This is annoying because it reports a lot of accessibility problems that we won't have time to address anytime soon.

## After

Running `gulp test` doesn't include the accessibility tests. Run `gulp test --a11y` to include them.

## Review

- @chosak 
- @richaagarwal 

## Notes

- It kills me to create a second config file (a11y_conf.js) but it was the only way I could figure out how to modify the `plugins` property via a command line option. Only the [onPrepare](https://github.com/angular/protractor/blob/a74175d4b37fed0b86ca9646b749585a5ff1ba52/docs/referenceConf.js#L195-L209) method seems to have access to the protractor globals and by then it's too late to add a plugin.