### PR TITLE
Adds BASE_CLASS and dom validity check to multiselect.

### DIFF
--- a/cfgov/unprocessed/js/molecules/Multiselect.js
+++ b/cfgov/unprocessed/js/molecules/Multiselect.js
@@ -21,6 +21,14 @@ var strings = require( '../modules/util/strings' );
  */
 function Multiselect( element ) { // eslint-disable-line max-statements, inline-comments, max-len
 
+  var BASE_CLASS = 'cf-multi-select';
+
+  // TODO: As the multiselect is developed further
+  //       explore whether it should use an updated
+  //       class name or data-* attribute in the
+  //       markup so that it doesn't apply globally by default.
+  element.classList.add( BASE_CLASS );
+
   // Constants for direction.
   var DIR_PREV = 'prev';
   var DIR_NEXT = 'next';
@@ -37,7 +45,7 @@ function Multiselect( element ) { // eslint-disable-line max-statements, inline-
   var MAX_SELECTIONS = 5;
 
   // Internal vars.
-  var _dom = element;
+  var _dom = atomicHelpers.checkDom( element, BASE_CLASS );
   var _index = -1;
   var _isBlurSkipped = false;
   var _selectionsCount = 0;
@@ -71,9 +79,17 @@ function Multiselect( element ) { // eslint-disable-line max-statements, inline-
     _filteredData = _optionsData = _sanitizeOptions( _options );
 
     if ( _optionsData.length > 0 ) {
-      _populateMarkup();
-      _bindEvents();
+      var newDom = _populateMarkup();
+
+      // Removes <select> element,
+      // and re-assign DOM reference.
       _dom.parentNode.removeChild( _dom );
+      _dom = newDom;
+      // We need to set init flag again since we've created a new <div>
+      // to replace the <select> element.
+      atomicHelpers.setInitFlag( _dom );
+
+      _bindEvents();
     }
 
     return this;
@@ -116,7 +132,10 @@ function Multiselect( element ) { // eslint-disable-line max-statements, inline-
 
       // If the value isn't valid kill the script and prompt the developer.
       if ( !strings.stringValid( item.value ) ) {
+        // TODO: Update to throw an error and handle the error vs logging.
         console.log( '\'' + item.value + '\' is not a valid value' );
+        // TODO: Remove this line if the class is added via markup.
+        element.classList.remove( BASE_CLASS );
 
         return false;
       }
@@ -133,26 +152,27 @@ function Multiselect( element ) { // eslint-disable-line max-statements, inline-
 
   /**
    * Populates and injects the markup for the custom multi-select.
+   * @returns {HTMLNode} Newly created <div> element to hold the multiselect.
    */
   function _populateMarkup() {
     // Add a container for our markup
     _containerDom = domCreate( 'div', {
-      className: 'cf-multi-select',
+      className: BASE_CLASS,
       around:    _dom
     } );
 
     // Create all our markup but wait to manipulate the DOM just once
     _selectionsDom = domCreate( 'ul', {
-      className: 'list__unstyled cf-multi-select_choices',
+      className: 'list__unstyled ' + BASE_CLASS + '_choices',
       inside:    _containerDom
     } );
 
     _headerDom = domCreate( 'header', {
-      className: 'cf-multi-select_header'
+      className: BASE_CLASS + '_header'
     } );
 
     _searchDom = domCreate( 'input', {
-      className:   'cf-multi-select_search',
+      className:   BASE_CLASS + '_search',
       type:        'text',
       placeholder: _placeholder || 'Choose up to five',
       inside:      _headerDom,
@@ -160,12 +180,12 @@ function Multiselect( element ) { // eslint-disable-line max-statements, inline-
     } );
 
     _fieldsetDom = domCreate( 'fieldset', {
-      'className':   'cf-multi-select_fieldset u-invisible',
+      'className':   BASE_CLASS + '_fieldset u-invisible',
       'aria-hidden': 'true'
     } );
 
     _optionsDom = domCreate( 'ul', {
-      className: 'list__unstyled cf-multi-select_options',
+      className: 'list__unstyled ' + BASE_CLASS + '_options',
       inside:    _fieldsetDom
     } );
 
@@ -180,7 +200,7 @@ function Multiselect( element ) { // eslint-disable-line max-statements, inline-
         'type':    'checkbox',
         'value':   option.value,
         'name':    _name,
-        'class':   'cf-input cf-multi-select_checkbox',
+        'class':   'cf-input ' + BASE_CLASS + '_checkbox',
         'inside':  _optionsItemDom,
         'checked': option.checked
       } );
@@ -188,7 +208,7 @@ function Multiselect( element ) { // eslint-disable-line max-statements, inline-
       domCreate( 'label', {
         'for':         option.value,
         'textContent': option.text,
-        'className':   'cf-multi-select_label',
+        'className':   BASE_CLASS + '_label',
         'inside':      _optionsItemDom
       } );
 
@@ -202,7 +222,7 @@ function Multiselect( element ) { // eslint-disable-line max-statements, inline-
         domCreate( 'label', {
           'for':         option.value,
           'textContent': option.text,
-          'className':   'cf-multi-select_label',
+          'className':   BASE_CLASS + '_label',
           'inside':      selectionsItemDom
         } );
 
@@ -211,15 +231,17 @@ function Multiselect( element ) { // eslint-disable-line max-statements, inline-
       }
     } );
 
-    // Write our new markup to the DOM
+    // Write our new markup to the DOM.
     _containerDom.appendChild( _headerDom );
     _containerDom.appendChild( _fieldsetDom );
+
+    return _containerDom;
   }
 
   /**
-   * Highlights an option in the list
-   * @param   {string} direction Direction to highlight compared to the
-   *                             current focus.
+   * Highlights an option in the list.
+   * @param {string} direction Direction to highlight compared to the
+   *                           current focus.
    */
   function _highlight( direction ) {
     var count = _filteredData.length;

--- a/test/unit_tests/molecules/Multiselect-spec.js
+++ b/test/unit_tests/molecules/Multiselect-spec.js
@@ -32,7 +32,6 @@ describe( 'Multiselect', function() {
 
   beforeEach( function() {
     sandbox = sinon.sandbox.create();
-    sandbox.stub( window.console, 'log' );
 
     document.body.innerHTML = HTML_SNIPPET;
 
@@ -59,7 +58,8 @@ describe( 'Multiselect', function() {
         var option = document.querySelector( 'option' );
         option.defaultSelected = true;
         multiselect.init();
-        var choices = document.querySelectorAll( '.cf-multi-select_choices li' );
+        var choices =
+          document.querySelectorAll( '.cf-multi-select_choices li' );
 
         expect( choices.length ).to.equal( 1 );
         expect( choices[0].innerHTML ).to.contain( 'Debt collection' );
@@ -67,6 +67,10 @@ describe( 'Multiselect', function() {
     );
 
     it( 'should log a helpful tip if passed a bad option value', function() {
+      // TODO: Remove console.log in favor of throwing an error.
+      //       sandbox.stub console.log will prevent regular `console.log(…)`
+      //       calls in this suite.
+      sandbox.stub( window.console, 'log' );
       var option = document.querySelector( 'option' );
       option.value = 'Foo\'';
       multiselect.init();
@@ -87,7 +91,8 @@ describe( 'Multiselect', function() {
       multiselect.init();
       multiselect.expand();
       multiselectDom = document.querySelector( '.cf-multi-select' );
-      var fieldset = multiselectDom.querySelector( '.cf-multi-select_fieldset' );
+      var fieldset =
+        multiselectDom.querySelector( '.cf-multi-select_fieldset' );
 
       expect( multiselectDom.className ).to.equal( 'cf-multi-select active' );
       expect( fieldset.getAttribute( 'aria-hidden' ) ).to.equal( 'false' );
@@ -98,7 +103,8 @@ describe( 'Multiselect', function() {
       multiselect.expand();
       multiselect.collapse();
       multiselectDom = document.querySelector( '.cf-multi-select' );
-      var fieldset = multiselectDom.querySelector( '.cf-multi-select_fieldset' );
+      var fieldset =
+        multiselectDom.querySelector( '.cf-multi-select_fieldset' );
 
       expect( multiselectDom.className ).to.equal( 'cf-multi-select' );
       expect( fieldset.getAttribute( 'aria-hidden' ) ).to.equal( 'true' );
@@ -109,7 +115,8 @@ describe( 'Multiselect', function() {
     xit( 'should open when the search input is clicked', function() {
       multiselect.init();
       multiselectDom = document.querySelector( '.cf-multi-select' );
-      var fieldset = multiselectDom.querySelector( '.cf-multi-select_fieldset' );
+      var fieldset =
+        multiselectDom.querySelector( '.cf-multi-select_fieldset' );
       var search = document.querySelector( '#test-select' );
       search.click();
 
@@ -131,7 +138,8 @@ describe( 'Multiselect', function() {
       multiselect.init();
       multiselect.expand();
       multiselectDom = document.querySelector( '.cf-multi-select' );
-      var fieldset = multiselectDom.querySelector( '.cf-multi-select_fieldset' );
+      var fieldset =
+        multiselectDom.querySelector( '.cf-multi-select_fieldset' );
       document.click();
 
       expect( multiselectDom.className ).to.equal( 'cf-multi-select' );


### PR DESCRIPTION
## Changes

- Adds `BASE_CLASS` and dom validity check to multiselect to align it with the other atomic components lifecycle.
- Fixes some minor linter warnings.

## Testing

- `gulp test:unit:scripts && gulp test:acceptance --sauce=false` should pass (expect for the 2 acceptance test errors we're getting from wagtail on all PRs).

## Review

- @jimmynotjim 
- @sebworks 

## Todos

- Added a todo to scope the multiselect to markup that has the base class. If global behavior is needed, a separate script like this can be added to common.js or similar:
```
var mselects = document.querySelector( 'select[multiple]' );
for ( var i, len = mselects.length; i < len; i++ ) {
  mselects.classList.add( 'cf-multi-select' );
}
```
