### PR TITLE
Makes pagination a macro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,8 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Ignored `console.log` in tests and enforced `no-process`.
 - Updated `STAGING_HOSTNAME` to `DJANGO_STAGING_HOSTNAME` environment var.
 - Allows passing of port to `runserver.sh`.
+- Updated browse-filterable test suite to properly nest pagination tests.
+- Updated pagination to support multiple pagination molecules on a single page.
 
 ### Removed
 - Unused `SELENIUM_URL` environment variable.
@@ -55,8 +57,8 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - `initial_test_data.py` as the tests create the data they need now.
 
 ### Fixed
-
 - Added misnamed and unreferenced environment variables to .env.
+- Moved pagination tests from /organisms/ to /molecules/ where they belong.
 
 
 ## 3.4.0 2016-07-12

--- a/cfgov/jinja2/v1/_includes/molecules/pagination.html
+++ b/cfgov/jinja2/v1/_includes/molecules/pagination.html
@@ -1,7 +1,7 @@
 
 {# ==========================================================================
 
-   Pagination
+   pagination.render()
 
    ==========================================================================
 
@@ -9,55 +9,71 @@
 
    Builds pagination markup when given:
 
-   posts:                        TODO: fill in data type and description.
+   total_pages: Total number of pages.
 
-   posts.paginator:              TODO: fill in data type and description.
+   current_page:   Currently selected page (out of the total).
 
-   posts.paginator.num_pages:    Number of total pages.
+   fragment_id: The fragment identifier attached
+                to the prev/next pagination buttons.
+                Default is empty string.
 
-   posts.number:                 TODO: fill in data type and description.
-
-   posts.previous_page_number(): Method to return previous page number.
-
-   posts.page:                   Current page number of the iterable list.
+   index:       A unique number given to render the form and its fields with.
+                Default is 0.
 
    ========================================================================== #}
 
-{% if posts and posts.paginator.num_pages > 1 %}
+{% macro render(total_pages, current_page, fragment_id='', index=0) %}
+{% if total_pages > 1 and current_page <= total_pages %}
 {% from 'macros/util/url_parameters.html' import url_parameters %}
+
+{% set fragment_id = '#' + fragment_id if fragment_id else '' %}
 
     <nav class="m-pagination"
          role="navigation"
          aria-label="Pagination">
-        {%- if posts.number > 1 %}
-        <a class="btn btn__super m-pagination_btn-prev"
-           href="?page={{ posts.previous_page_number()
-                          ~ url_parameters(request.GET)
-                          ~ '#o-filterable-list-controls' }}">
+        {%- if current_page > 1 %}
+        <a class="btn
+                  btn__super
+                  m-pagination_btn-prev"
+           href="?page={{ (current_page - 1) ~
+                          url_parameters(request.GET) ~
+                          fragment_id }}">
         {%- else %}
-        <a class="btn btn__super
+        <a class="btn
+                  btn__super
                   btn__disabled
                   m-pagination_btn-prev">
         {% endif %}
-            <span class="btn_icon__left cf-icon cf-icon-left"></span>
+            <span class="btn_icon__left
+                         cf-icon
+                         cf-icon-left"></span>
             Newer
         </a>
-        {%- if posts.number < posts.paginator.num_pages %}
-        <a class="btn btn__super m-pagination_btn-next"
-           href="?page={{ posts.next_page_number()
-                          ~ url_parameters(request.GET)
-                          ~ '#o-filterable-list-controls' }}">
+        {%- if current_page < total_pages %}
+        <a class="btn
+                  btn__super
+                  m-pagination_btn-next"
+           href="?page={{ (current_page + 1) ~
+                          url_parameters(request.GET) ~
+                          fragment_id }}">
         {%- else %}
-        <a class="btn btn__super btn__disabled m-pagination_btn-next">
+        <a class="btn
+                  btn__super
+                  btn__disabled
+                  m-pagination_btn-next">
         {% endif -%}
             Older
-            <span class="btn_icon__right cf-icon cf-icon-right"></span>
+            <span class="btn_icon__right
+                         cf-icon
+                         cf-icon-right"></span>
         </a>
-        <form action="#o-filterable-list-controls">
-            <label for="m-pagination_current-page">
-                Page
+        <form action="{{ fragment_id }}">
+            <label for="m-pagination_current-page-{{ index | string }}">
+                <span class="m-pagination_label">
+                    Page
+                </span>
                 <span class="u-visually-hidden">
-                    number out of {{ posts.paginator.num_pages }} total pages
+                    {{ current_page }} out of {{ total_pages }} total pages
                 </span>
             </label>
             {% for (key, value) in request.GET.items() %}
@@ -67,22 +83,25 @@
                            value="{{ value }}">
                 {% endif %}
             {% endfor %}
-            <input id="m-pagination_current-page"
+            <input id="m-pagination_current-page-{{ index | string }}"
+                   class="m-pagination_current-page"
                    name="page"
                    type="number"
                    min="1"
-                   max="{{ posts.paginator.num_pages }}"
+                   max="{{ total_pages }}"
                    pattern="[0-9]*"
                    inputmode="numeric"
-                   value="{{ posts.number }}">
+                   value="{{ current_page }}">
             <span class="m-pagination_label">
-                of {{ posts.paginator.num_pages }}
+                of {{ total_pages }}
             </span>
-            <button class="btn btn__link"
-                    id="m-pagination_submit-btn"
+            <button class="btn
+                           btn__link
+                           m-pagination_submit-btn"
                     type="submit">
                 Go
             </button>
         </form>
     </nav>
 {% endif %}
+{% endmacro %}

--- a/cfgov/jinja2/v1/_includes/organisms/filterable-list-controls.html
+++ b/cfgov/jinja2/v1/_includes/organisms/filterable-list-controls.html
@@ -181,7 +181,7 @@
 
 {% macro render(controls, index) %}
     <div class="o-filterable-list-controls"
-         id="o-filterable-list-controls">
+         id="o-filterable-list-controls-{{ index | string }}">
         {% set form = filter_data.forms.pop(0) %}
         {% set posts = filter_data.page_sets.pop(0) %}
         {% set has_active_filters = page.has_active_filters(request, index) %}
@@ -223,6 +223,8 @@
                 {{ post_preview(post, controls, form_id=index) }}
             {% endfor %}
         {% endif %}
-        {% include 'molecules/pagination.html' %}
+        {% import 'molecules/pagination.html' as pagination with context %}
+        {% set fragment_id = 'o-filterable-list-controls-' + index | string %}
+        {{ pagination.render( posts.paginator.num_pages, posts.number, fragment_id, index ) }}
     </div>
 {% endmacro %}

--- a/cfgov/unprocessed/css/molecules/pagination.less
+++ b/cfgov/unprocessed/css/molecules/pagination.less
@@ -108,7 +108,7 @@
         .webfont-medium();
 
         &.btn__disabled {
-          background-color: @pagination-bg-color;
+            background-color: @pagination-bg-color;
         }
     }
 
@@ -118,14 +118,14 @@
         right: 0;
     }
 
-    .respond-to-max(@bp-xs-max, {
+    .respond-to-max( @bp-xs-max, {
         &_btn-prev,
         &_btn-next {
             margin-bottom: @pagination-font-size__em / 2;
         }
-    });
+    } );
 
-    .respond-to-min(@bp-sm-min, {
+    .respond-to-min( @bp-sm-min, {
         &_btn-prev {
             position: absolute;
             top: 0;
@@ -143,11 +143,11 @@
             &,
             &:link,
             &:visited {
-                  border-top-left-radius: 0;
-                  border-bottom-left-radius: 0;
-              }
+                border-top-left-radius: 0;
+                border-bottom-left-radius: 0;
+            }
         }
-    });
+    } );
 }
 
 /* topdoc

--- a/test/browser_tests/shared_objects/pagination.js
+++ b/test/browser_tests/shared_objects/pagination.js
@@ -16,10 +16,10 @@ var pagination = {
     paginationContent.element( by.css( '.m-pagination_btn-next' ) ),
 
   paginationPageInput:
-    paginationContent.element( by.css( '#m-pagination_current-page' ) ),
+    paginationContent.element( by.css( '.m-pagination_current-page' ) ),
 
   paginationPageBtn:
-    paginationContent.element( by.css( '#m-pagination_submit-btn' ) )
+    paginationContent.element( by.css( '.m-pagination_submit-btn' ) )
 
 };
 

--- a/test/browser_tests/spec_suites/integration/browse-filterable.js
+++ b/test/browser_tests/spec_suites/integration/browse-filterable.js
@@ -1,60 +1,91 @@
 'use strict';
 
-var Blog = require(
-    '../../page_objects/page_blog.js'
-  );
+var Blog = require( '../../page_objects/page_blog.js' );
 
-describe( 'Pagination', function() {
-  var page;
+describe( 'Browse filterable', function() {
 
-  beforeEach( function() {
-    page = new Blog();
-    page.get();
-  } );
+  describe( 'pagination', function() {
+    var page;
 
-  it( 'should navigate to the first page of filtered results', function() {
-    page.searchFilterBtn.click();
-    browser.sleep( 1000 );
+    beforeEach( function() {
+      page = new Blog();
+      page.get();
+    } );
 
-    page.searchCategoryLabel.click();
-    page.searchFilterSubmitBtn.click();
-    browser.sleep( 1000 );
+    it( 'should navigate to the first page of filtered results', function() {
+      page.searchFilterBtn.click();
+      browser.wait( page.searchCategoryLabel.isEnabled() ).then( function() {
+        page.searchCategoryLabel.click();
+        browser.wait( page.searchFilterSubmitBtn.isEnabled() ).then( function() {
+          page.searchFilterSubmitBtn.click().then( function() {
+            expect( browser.getCurrentUrl() ).not.toContain( 'page=' );
+            expect( browser.getCurrentUrl() ).toContain( 'at-the-cfpb' );
+          } );
+        } );
+      } );
+    } );
 
-    expect( browser.getCurrentUrl() ).not.toContain( 'page=' );
-    expect( browser.getCurrentUrl() ).toContain( 'at-the-cfpb' );
-  } );
+    it( 'should navigate to the second filtered page', function() {
+      page.searchFilterBtn.click();
+      browser.wait( page.searchCategoryLabel.isEnabled() ).then( function() {
+        page.searchCategoryLabel.click();
+        browser.wait( page.searchFilterSubmitBtn.isEnabled() ).then( function() {
+          page.searchFilterSubmitBtn.click();
+          browser.wait( page.paginationNextBtn.isEnabled() ).then( function() {
 
-  it( 'should navigate to the second filtered page', function() {
-    page.searchFilterBtn.click();
-    browser.sleep( 1000 );
+            // Save current URL, perform action, then wait for URL to change.
+            var currentUrl;
+            browser.getCurrentUrl().then( function( url ) {
+              currentUrl = url;
+              // Do action that changes the URL.
+              page.paginationNextBtn.click();
+            } ).then( function() {
+              browser.wait( function() {
+                // The URL has changed.
+                return browser.getCurrentUrl().then( function( url ) {
+                  return url !== currentUrl;
+                } );
+              } );
+            } ).then( function() {
+              // Perform tests on changed URL.
+              expect( browser.getCurrentUrl() ).toContain( 'page=2' );
+              expect( browser.getCurrentUrl() ).toContain( 'at-the-cfpb' );
+            } );
+          } );
+        } );
+      } );
+    } );
 
-    page.searchCategoryLabel.click();
-    page.searchFilterSubmitBtn.click();
-    browser.sleep( 1000 );
+    it( 'should navigate to the fifth filtered page', function() {
+      page.searchFilterBtn.click();
+      browser.wait( page.searchCategoryLabel.isEnabled() ).then( function() {
+        page.searchCategoryLabel.click();
+        browser.wait( page.searchFilterSubmitBtn.isEnabled() ).then( function() {
+          page.searchFilterSubmitBtn.click();
+          browser.wait( page.paginationPageBtn.isDisplayed() ).then( function() {
 
-    page.paginationNextBtn.click();
-    browser.sleep( 1000 );
-
-    expect( browser.getCurrentUrl() ).toContain( 'page=2' );
-    expect( browser.getCurrentUrl() ).toContain( 'at-the-cfpb' );
-  } );
-
-  it( 'should navigate to the fifth filtered page', function() {
-    page.searchFilterBtn.click();
-    browser.sleep( 1000 );
-
-    page.searchCategoryLabel.click();
-    page.searchFilterSubmitBtn.click();
-    browser.sleep( 1000 );
-
-    var input = browser.element( by.css( '#m-pagination_current-page' ) );
-    var btn = browser.element( by.css( '#m-pagination_submit-btn' ) );
-
-    input.clear().sendKeys( '5' );
-    btn.click();
-    browser.sleep( 1000 );
-
-    expect( browser.getCurrentUrl() ).toContain( 'page=5' );
-    expect( browser.getCurrentUrl() ).toContain( 'at-the-cfpb' );
+            // Save current URL, perform action, then wait for URL to change.
+            var currentUrl;
+            browser.getCurrentUrl().then( function( url ) {
+              currentUrl = url;
+              // Do action that changes the URL.
+              page.paginationPageInput.clear().sendKeys( '5' );
+              page.paginationPageBtn.click();
+            } ).then( function() {
+              browser.wait( function() {
+                // The URL has changed.
+                return browser.getCurrentUrl().then( function( url ) {
+                  return url !== currentUrl;
+                } );
+              } );
+            } ).then( function() {
+              // Perform tests on changed URL.
+              expect( browser.getCurrentUrl() ).toContain( 'page=5' );
+              expect( browser.getCurrentUrl() ).toContain( 'at-the-cfpb' );
+            } );
+          } );
+        } );
+      } );
+    } );
   } );
 } );


### PR DESCRIPTION
Pulls the pagination updates out of https://github.com/cfpb/cfgov-refresh/pull/2201 without including the stepper.

## Changes

- Updated browse-filterable test suite to properly nest pagination tests.
- Updated pagination to support multiple pagination molecules on a single page.
- Moved pagination tests from /organisms/ to /molecules/ where they belong.

## Testing

- `gulp test:acceptance --specs=integration/browse-filterable.js --sauce=false`
- `gulp test:acceptance --specs=molecules/pagination.js --sauce=false`
- visit /blog/ and check that the pagination with and without a filter work correctly.

## Review

- @sebworks 
- @contolini
- @virginiacc  
- @chosak 

## Screenshots
<img width="270" alt="screen shot 2016-06-17 at 2 45 10 pm" src="https://cloud.githubusercontent.com/assets/704760/16200300/c070cec0-36da-11e6-8be2-96f32d0db54f.png">

<img width="855" alt="screen shot 2016-06-17 at 2 45 34 pm" src="https://cloud.githubusercontent.com/assets/704760/16200302/c07428c2-36da-11e6-99e1-a5072eb853a5.png">

## Notes
- My local dev setup data isn't working to display /blog/ so hopefully that's not broken!