### PR TITLE
Setup initial test data when running Python unit tests

### DIFF
--- a/cfgov/cfgov/settings/test.py
+++ b/cfgov/cfgov/settings/test.py
@@ -5,4 +5,6 @@ DATABASES = {
         'ENGINE': 'django.db.backends.sqlite3',
         'NAME': os.path.join(REPOSITORY_ROOT, 'db.sqlite3'),
     }
-} 
+}
+
+TEST_RUNNER = 'cfgov.test.TestDataTestRunner'

--- a/cfgov/cfgov/test.py
+++ b/cfgov/cfgov/test.py
@@ -1,0 +1,32 @@
+from __future__ import print_function
+
+import importlib
+
+from django.apps import apps
+from django.test.runner import DiscoverRunner
+from wagtail.wagtailcore.models import Page
+
+from scripts import initial_data, initial_test_data
+
+
+class TestDataTestRunner(DiscoverRunner):
+    def setup_databases(self, **kwargs):
+        dbs = super(TestDataTestRunner, self).setup_databases(**kwargs)
+
+        if not self.check_for_wagtail_root():
+            self.setup_wagtail_root()
+
+        initial_data.run()
+        initial_test_data.run()
+        return dbs
+
+    def check_for_wagtail_root(self):
+        return Page.objects.filter(slug='root').exists()
+
+    def setup_wagtail_root(self):
+        migration = 'wagtail.wagtailcore.migrations.0002_initial_data'
+        print('Running migration {} to setup Wagtail root'.format(migration))
+
+        module = importlib.import_module(migration)
+        module.initial_data(apps, None)
+

--- a/cfgov/cfgov/test.py
+++ b/cfgov/cfgov/test.py
@@ -29,4 +29,3 @@ class TestDataTestRunner(DiscoverRunner):
 
         module = importlib.import_module(migration)
         module.initial_data(apps, None)
-

--- a/cfgov/scripts/initial_data.py
+++ b/cfgov/scripts/initial_data.py
@@ -9,66 +9,65 @@ from v1.models import HomePage, BrowseFilterablePage
 
 
 def run():
-    if settings.DEBUG:
-        print 'Running script \'scripts.initial_data\' ...'
-        admin_user = None
-        site_root = None
-        events = None
+    print 'Running script \'scripts.initial_data\' ...'
+    admin_user = None
+    site_root = None
+    events = None
 
-        admin_user = User.objects.filter(username='admin')
-        if not admin_user:
-            admin_user = User(username='admin',
-                              password=make_password(os.environ.get('WAGTAIL_ADMIN_PW')),
-                              is_superuser=True, is_active=True, is_staff=True)
-            admin_user.save()
-        else:
-            admin_user = admin_user[0]
+    admin_user = User.objects.filter(username='admin')
+    if not admin_user:
+        admin_user = User(username='admin',
+                            password=make_password(os.environ.get('WAGTAIL_ADMIN_PW')),
+                            is_superuser=True, is_active=True, is_staff=True)
+        admin_user.save()
+    else:
+        admin_user = admin_user[0]
 
-        # Creates a new site root `CFGov`
-        site_root = HomePage.objects.filter(title='CFGOV')
-        if not site_root:
-            root = Page.objects.first()
-            site_root = HomePage(title='CFGOV', slug='home-page', depth=2, owner=admin_user)
-            site_root.live = True
-            root.add_child(instance=site_root)
-            latest = site_root.save_revision(user=admin_user, submitted_for_moderation=False)
-            latest.save()
-        else:
-            site_root = site_root[0]
+    # Creates a new site root `CFGov`
+    site_root = HomePage.objects.filter(title='CFGOV')
+    if not site_root:
+        root = Page.objects.first()
+        site_root = HomePage(title='CFGOV', slug='home-page', depth=2, owner=admin_user)
+        site_root.live = True
+        root.add_child(instance=site_root)
+        latest = site_root.save_revision(user=admin_user, submitted_for_moderation=False)
+        latest.save()
+    else:
+        site_root = site_root[0]
 
-        # Setting new site root
-        if not Site.objects.filter(hostname='content.localhost').exists():
-            site = Site.objects.first()
-            site.port = 8000
-            site.root_page_id = site_root.id
-            site.save()
-            content_site = Site(hostname='content.localhost', port=8000, root_page_id=site_root.id)
-            content_site.save()
+    # Setting new site root
+    if not Site.objects.filter(hostname='content.localhost').exists():
+        site = Site.objects.first()
+        site.port = 8000
+        site.root_page_id = site_root.id
+        site.save()
+        content_site = Site(hostname='content.localhost', port=8000, root_page_id=site_root.id)
+        content_site.save()
 
-            # Clean Up
-            old_site_root = Page.objects.filter(id=2)[0]
-            if old_site_root:
-                old_site_root.delete()
+        # Clean Up
+        old_site_root = Page.objects.filter(id=2)[0]
+        if old_site_root:
+            old_site_root.delete()
 
-        # Events Browse Page required for event `import-data` command
-        if not BrowseFilterablePage.objects.filter(title='Events').exists():
-            events = BrowseFilterablePage(title='Events', slug='events', owner=admin_user)
-            site_root.add_child(instance=events)
-            revision = events.save_revision(
-                user=admin_user,
-                submitted_for_moderation=False,
-            )
-            revision.publish()
+    # Events Browse Page required for event `import-data` command
+    if not BrowseFilterablePage.objects.filter(title='Events').exists():
+        events = BrowseFilterablePage(title='Events', slug='events', owner=admin_user)
+        site_root.add_child(instance=events)
+        revision = events.save_revision(
+            user=admin_user,
+            submitted_for_moderation=False,
+        )
+        revision.publish()
 
-        # Archived Events Browse Filterable Page
-        if not BrowseFilterablePage.objects.filter(title='Archive').exists():
-            archived_events = BrowseFilterablePage(title='Archive', slug='archive', owner=admin_user)
-            if not events:
-                events = BrowseFilterablePage.objects.get(title='Events')
+    # Archived Events Browse Filterable Page
+    if not BrowseFilterablePage.objects.filter(title='Archive').exists():
+        archived_events = BrowseFilterablePage(title='Archive', slug='archive', owner=admin_user)
+        if not events:
+            events = BrowseFilterablePage.objects.get(title='Events')
 
-            events.add_child(instance=archived_events)
-            revision = archived_events.save_revision(
-                user=admin_user,
-                submitted_for_moderation=False,
-            )
-            revision.publish()
+        events.add_child(instance=archived_events)
+        revision = archived_events.save_revision(
+            user=admin_user,
+            submitted_for_moderation=False,
+        )
+        revision.publish()

--- a/cfgov/scripts/initial_data.py
+++ b/cfgov/scripts/initial_data.py
@@ -1,4 +1,7 @@
-import os, json
+from __future__ import print_function
+
+import json
+import os
 
 from django.conf import settings
 from django.contrib.auth.hashers import make_password
@@ -9,7 +12,7 @@ from v1.models import HomePage, BrowseFilterablePage
 
 
 def run():
-    print 'Running script \'scripts.initial_data\' ...'
+    print('Running script \'scripts.initial_data\' ...')
     admin_user = None
     site_root = None
     events = None


### PR DESCRIPTION
This PR tries to setup required initial test data before running the Python unit tests, by implementing a custom Django TestRunner class.

## Additions

- Added new `cfgov/cfgov/test.py` file that contains a `cfgov.test.TestDataTestRunner` class.

## Removals

- Removed check against `settings.DEBUG` in `cfgov/scripts/initial_data.py` as this seemed like an unnecessary check vs. just not running the script. Is there anywhere this script is ever run in production?

## Changes

- Python testing using `manage.py test` now uses the custom test runner, which does these steps before running the tests:
 1. Checks to see if the Wagtail [initial_data](https://github.com/torchbox/wagtail/blob/v1.5.3/wagtail/wagtailcore/migrations/0002_initial_data.py) migration has been run (it normally is when running `tox` or `manage.py test`, but not when running `tox -e fast` which skips all migrations), and, if not, runs it to create the Wagtail root page and related models.
 1. Runs our `cfgov/scripts/initial_data.py` to setup initial pages like home, Events, and Archive.
 1. Runs our `cfgov/scripts/initial_test_data.py` to setup specific testing data.

## Testing

- Run `tox` and `tox -e fast` and notice that the initial test data scripts are run before the tests are.

## Review

- @cfpb/cfgov-backends 

## Todos

- If this approach makes sense, we could consider having the Django unit test runner also kick off the Protractor browser tests, so that those can run against the test database.

## Checklist

* [X] Changes are limited to a single goal (no scope creep)
* [X] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [X] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
