### PR TITLE
Adding Jobs List Molecule

### DIFF
--- a/cfgov/jinja2/v1/_includes/molecules/jobs-list.html
+++ b/cfgov/jinja2/v1/_includes/molecules/jobs-list.html
@@ -1,0 +1,65 @@
+{# ==========================================================================
+
+   jobs_list.render(value)
+
+   ==========================================================================
+
+   Description:
+
+   Creates jobs list when given:
+
+   value:                Object defined from a StreamField block.
+
+   value.close_date:     A string representing the closing date for the job.
+
+   value.heading:        The heading of the jobs list.
+                         Default is "Career Openings".
+
+   value.more_jobs_url:  A string for the URL of the more jobs url.
+
+   value.more_jobs_text: A string for the text of the more jobs link.
+
+   value.jobs:           A list of jobs with the link first
+                         followed by the text of link.
+
+   value.jobs[i].url:    A string for the URL of the link.
+
+   value.jobs[i].text:   A string for the text of the link.
+
+
+   ========================================================================== #}
+
+{% macro render(value) %}
+<aside class="m-jobs-list"
+       data-qa-hook="openings-section">
+    <h3>
+        {{ value.heading or 'Career Openings' }}
+    </h3>
+    {% if value.jobs is defined and value.jobs | length > 0 %}
+    {% import 'macros/time.html' as time %}
+    <ul class="list list__unstyled">
+        {% for job in value.jobs %}
+        <li class="list_item">
+            <a class="list_link"
+               href="{{ job.url }}">{{ job.text }}</a>
+            <p class="date">
+                CLOSING
+                {% if job.close_date is defined %}
+                    {{ time.render(job.close_date, {'date':true}) }}
+                {% endif %}
+            </p>
+        </li>
+        {% endfor %}
+    </ul>
+    <a class="jump-link
+              jump-link__underline"
+       href="{{ value.more_jobs_url }}">
+        <span class="jump-link_text">
+          {{ value.more_jobs_text or 'View all job openings' }}
+        </span>
+    </a>
+    {% else %}
+    <p class='short-desc'>There are no current openings at this time.</p>
+    {% endif %}
+</aside>
+{% endmacro %}


### PR DESCRIPTION
 We currently don't have a molecule which matches the current Career page requirements, so I've created a jobs list molecule. This molecule will be used on `/about-us/careers/` page, within the `Sidebar-Breakout` organism.  

## Additions

- Adding Jobs List Molecule

## Testing

- N/A

## Review

- @chosak 
- @richaagarwal 
- @virginiacc 
- @ajbush 

## Screenshots

<img width="506" alt="screen shot 2016-08-04 at 9 37 59 am" src="https://cloud.githubusercontent.com/assets/1696212/17404061/7716b9da-5a28-11e6-99e3-ec5da3dd7820.png">


## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)

