### PR TITLE
Add/Correct IE8/9 fallback code for base and on-demand templates

### DIFF
--- a/cfgov/jinja2/v1/_includes/organisms/header.html
+++ b/cfgov/jinja2/v1/_includes/organisms/header.html
@@ -97,11 +97,13 @@
         </div>
 
     </div>
+    <!--[if gt IE 8]><!-->
     <script>
       /* TODO: scope no-js to individual molecules/organisms. This is a hack to fix no-js on the on-demand header, while also allowing the menu to be scoped to o-header for on-demand pages. */
       var headerDom = document.querySelector( '.o-header_content' );
-      headerDom.className = headerDom.className.replace('no-js','js');
+      headerDom.className = headerDom.className.replace( 'no-js', 'js' );
     </script>
+    <!--<![endif]-->
 </header>
 
 {% endmacro %}

--- a/cfgov/jinja2/v1/test-fixture/index.html
+++ b/cfgov/jinja2/v1/test-fixture/index.html
@@ -44,7 +44,14 @@
     ============
     The atomic CSS file. This includes legacy IE-specific prefixing.
 #}
+
+<!--[if lt IE 9]>
+<link rel="stylesheet" href="{{ static('css/' + atomic_type + suffix + '.nonresponsive.css') }}">
+<![endif]-->
+
+<!--[if gt IE 8]><!-->
 <link rel="stylesheet" href="{{ static('css/' + atomic_type + suffix + '.css') }}">
+<!--<![endif]-->
 
 {#
     ================

--- a/cfgov/legacy/templates/front/base_update.html
+++ b/cfgov/legacy/templates/front/base_update.html
@@ -76,7 +76,7 @@ please send an email with your full name to tech@cfpb.gov.
     <link rel="stylesheet" href="/static/nemo/_/c/eot.css">
     <![endif]-->
     <link rel="stylesheet" href="/static/nemo/_/c/styles.css{{ STATIC_VERSION }}">
-   
+
     {% endblock %}
 
     {% block app_css %}
@@ -85,8 +85,17 @@ please send an email with your full name to tech@cfpb.gov.
     {% block page_css %}
     {% endblock %}
 
+    <!--[if lt IE 9]>
+    <link rel="stylesheet" href="{% static 'css/header.nonresponsive.css' %}"/>
+    <link rel="stylesheet" href="{% static 'css/footer.nonresponsive.css' %}"/>
+    <![endif]-->
+
+    <!--[if gt IE 8]><!-->
     <link rel="stylesheet" href="{% static 'css/header.css' %}"/>
     <link rel="stylesheet" href="{% static 'css/footer.css' %}"/>
+    <!--<![endif]-->
+
+
     <!-- Feeds -->
     <link rel="alternate" type="application/rss+xml" title="Consumer Financial Protection Bureau &raquo; Feed" href="/feed/" />
     <link rel="alternate" type="application/rss+xml" title="Consumer Financial Protection Bureau &raquo; Comments Feed" href="/comments/feed/" />
@@ -123,18 +132,19 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 })(window,document,'script','dataLayer','GTM-KMMLRS');</script>
 <!-- End Google Tag Manager -->
 {% endblock %}
+
+<script src="{% static 'js/modernizr.min.js' %}"></script>
+
+<!--[if lt IE 9]>
 <script>
-  if(document.getElementsByTagName("body")) {
-    var bodyTag = document.getElementsByTagName("body")[0];
-    bodyTag.className += " js";
-  }
-  if (document.getElementsByTagName("html")) {
-    var htmlTag = document.getElementsByTagName("html")[0];
-    var classes = htmlTag.className;
-    htmlTag.className = classes.replace("no-js", "");
-  }
+    // If in IE8 reverse no-js/js class change made by modernizr.
+    var docElement = document.documentElement;
+    docElement.className = docElement.className.replace( /(^|\s)js(\s|$)/, '$1no-js$2' );
 </script>
-        {% global_include "on-demand/header.html" %}
+<![endif]-->
+
+<!--[if IE 9]><script src="{% static 'js/ie/common.ie.js'  %}"></script><![endif]-->
+    {% global_include "on-demand/header.html" %}
     <div id="page">
         {% block app_notification %}
         {% endblock %}
@@ -154,7 +164,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 
 
     </div><!-- /#page -->
-        {% global_include "on-demand/footer.html" %}    
+    {% global_include "on-demand/footer.html" %}
 
     {% block app_modal %}
     {% endblock %}
@@ -163,7 +173,6 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <script src="/static/nemo/_/js/functions.js{{ STATIC_VERSION }}"></script>
 <script type="text/javascript" src="/static/agreements/js/chosen.jquery.js{{ STATIC_VERSION }}"></script>
 {% endblock %}
-
 
 {% block app_js %}
 {% endblock %}
@@ -174,11 +183,11 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <!-- for search.usa.gov indexing -->
 <script type="text/javascript">
   //<![CDATA[
-    var aid = "cfpb";
-    var script = document.createElement('script');
-    script.type = "text/javascript";
-    script.src = "http://search.usa.gov/javascripts/stats.js";
-    document.getElementsByTagName("head")[0].appendChild(script);
+    var aid = 'cfpb';
+    var script = document.createElement( 'script' );
+    script.type = 'text/javascript';
+    script.src = 'http://search.usa.gov/javascripts/stats.js';
+    document.getElementsByTagName( 'head' )[0].appendChild( script );
   //]]>
 </script>
 
@@ -186,13 +195,15 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     // If there are no breadcrumbs on this page, remove the ul tag so that screen
     // readers don't read it (since the ul has nothing in it).
     $(function(){
-        var numBreadCrumbs = $("ul.bread").children("li").length;
-        if(numBreadCrumbs == 0){
-            $("ul.bread").remove();
+        var numBreadCrumbs = $( 'ul.bread' ).children( 'li' ).length;
+        if( numBreadCrumbs === 0 ) {
+           $( 'ul.bread' ).remove();
         }
     });
 </script>
+<!--[if gt IE 8]><!-->
 <script type="text/javascript" src="{% static "js/atomic/header.js" %}"></script>
 <script type="text/javascript" src="{% static "js/atomic/footer.js" %}"></script>
+<!--<![endif]-->
 </body>
 </html>


### PR DESCRIPTION
base_update.html does not include IE8 fallback script to set IE visitors to the no-js state, very likely leading to JS errors on the pages that use that template.

Fixes https://github.com/cfpb/cfgov-refresh/issues/2264
The on-demand header was not including the nonresponsive CSS when it was in IE8. This PR includes the correct CSS where needed.

## Additions

- Adds conditional code blocks for IE8/9.
- Adds non-responsive CSS for IE8.

## Changes

- General code style cleanup of inline JS in template.

## Removes

- Inline JS for adding js/no-js flags that should be set in modernizr.

## Testing

- No sure how to test this. @rosskarchner do you know how to test changes to the `base_update.html` template?
- For the on-demand bits: 
 1. Run `gulp scripts:ondemand && gulp styles:ondemand`
  2. Open `/test-fixture/` in sauce labs (won't work in local VM unless localhost routing is set up).
  3. Menu should be visible and interactive and there shouldn't be any JS errors in the dev console.

## Review

- @rosskarchner 
- @sebworks 
- @virginiacc 
- @jimmynotjim 

## Notes

- All site pages should include `common.ie.js`. If you visit consumerfinance.gov/askcfpb/ and search the source code you will see it is missing `common.ie.js`.
