### PR TITLE
Adding email address to info-unit molecule

### DIFF
--- a/cfgov/jinja2/v1/_includes/molecules/contact-email.html
+++ b/cfgov/jinja2/v1/_includes/molecules/contact-email.html
@@ -21,7 +21,7 @@
     <p>
         {% for email in value.emails %}
             <a href="mailto:{{ email.url }}">
-                {{ email.text or email.url }}
+                {{ email.url }}
             </a><br>
         {% endfor %}
     </p>

--- a/cfgov/jinja2/v1/_includes/molecules/contact-email.html
+++ b/cfgov/jinja2/v1/_includes/molecules/contact-email.html
@@ -21,7 +21,7 @@
     <p>
         {% for email in value.emails %}
             <a href="mailto:{{ email.url }}">
-                {{ email.url }}
+                {{ email.text or email.url }}
             </a><br>
         {% endfor %}
     </p>

--- a/cfgov/jinja2/v1/_includes/molecules/info-unit.html
+++ b/cfgov/jinja2/v1/_includes/molecules/info-unit.html
@@ -71,6 +71,12 @@
             <ul class="list list__links">
             {% for link in value.links %}
                 <li class="list_item">
+                    {% if link.text is defined and link.text.find('@') > -1 %}
+                        {% if not value.emails is defined %}
+                            {% do value.update({'emails': [link]}) %}
+                        {% endif %}
+                        {% include 'contact-email.html' with context %}
+                    {% else %}
                     <a class="{{ 'btn m-info-unit_btn' if value.is_button
                                   else 'list_link' }}"
                        href="{{ link.url }}">
@@ -78,6 +84,7 @@
                                  after testing is completed #}
                         {{ link.text if link.text else 'Learn More' }}
                     </a>
+                    {% endif %}
                 </li>
             {% endfor %}
             </ul>

--- a/cfgov/jinja2/v1/_includes/molecules/info-unit.html
+++ b/cfgov/jinja2/v1/_includes/molecules/info-unit.html
@@ -73,7 +73,7 @@
                 <li class="list_item">
                     {% if link.text is defined and link.text.find('@') > -1 %}
                         {% if not value.emails is defined %}
-                            {% do value.update({'emails': [link]}) %}
+                            {% do value.update({'emails':[{'url':link.text}]}) %}
                         {% endif %}
                         {% include 'contact-email.html' with context %}
                     {% else %}


### PR DESCRIPTION
Adding email address to info-unit molecule

## Changes

- Modified  `cfgov/jinja2/v1/_includes/molecules/contact-email.html` to use `email.text` before `email.url`.

- Modified  `cfgov/jinja2/v1/_includes/molecules/info-unit.html` to use display email address if `link.text` contains and email address.

## Testing

- Create a `Sublanding` page via Wagtail. 
- Add a `Half Width Link Blob Group` molecule. 
- Enter `email@example.com` in the link text field. Preview.
- Notice that the link has the email formatting. 

## Review

- @richaagarwal 
- @chosak 
- @virginiacc 

## Screenshots

<img width="410" alt="screen shot 2016-08-05 at 9 15 14 am" src="https://cloud.githubusercontent.com/assets/1696212/17437703/4bdf69cc-5aed-11e6-8871-f1fcbf3f5e18.png">


## Todos

-

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)

