### PR TITLE
Remove unused sinon-chai

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,18 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
   to the level of a MAJOR or MINOR update.
 
 ---------------------------------------
+## UNRELEASED
+
+### Added
+
+### Changed
+
+### Removed
+- Unused `sinon-chai` npm package.
+
+### Fixed
+
+
 ## 3.6.0
 
 ### Added

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -8698,11 +8698,6 @@
       "from": "sinon@1.17.3",
       "resolved": "http://registry.npmjs.org/sinon/-/sinon-1.17.3.tgz"
     },
-    "sinon-chai": {
-      "version": "2.8.0",
-      "from": "sinon-chai@2.8.0",
-      "resolved": "http://registry.npmjs.org/sinon-chai/-/sinon-chai-2.8.0.tgz"
-    },
     "slash": {
       "version": "1.0.0",
       "from": "slash@>=1.0.0 <2.0.0",

--- a/package.json
+++ b/package.json
@@ -70,7 +70,6 @@
     "protractor": "3.2.1",
     "protractor-accessibility-plugin": "github:cfpb/protractor-accessibility-plugin#on-page-load",
     "sinon": "1.17.3",
-    "sinon-chai": "2.8.0",
     "wcag": "0.2.2"
   },
   "browser": {


### PR DESCRIPTION
`sinon-chai` does not appear to be used.

## Removals

- Removes `sinon-chai` npm package.

## Testing

- `gulp test:acceptance --sauce=false` should pass.

## Review

- @contolini 
- @virginiacc 
- @sebworks 
