### PR TITLE
Fixes package.json fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
   to the level of a MAJOR or MINOR update.
 
 ---------------------------------------
-## 3.6
+## 3.6.0
 
 ### Added
 - Page revision management: http://docs.wagtail.io/en/v1.4.1/releases/1.4.html#page-revision-management,available at e.g. http://127.0.0.1:8000/admin/pages/64/revisions/

--- a/package.json
+++ b/package.json
@@ -1,6 +1,13 @@
 {
   "name": "cfgov-refresh",
-  "version": "3.6",
+  "version": "3.6.0",
+  "description": "The consumerfinance.gov website.",
+  "homepage": "http://www.consumerfinance.gov/",
+  "author": {
+    "name": "Consumer Financial Protection Bureau",
+    "email": "tech@cfpb.gov",
+    "url": "https://cfpb.github.io/"
+  },
   "repository": {
     "type": "git",
     "url": "http://github.com/cfpb/cfgov-refresh.git"


### PR DESCRIPTION
Version has to be three digits long to avoid npm warnings.

## Changes

- Updates changelog and package.json version to `3.6.0` from `3.6`.
- Adds additional `description`, `homepage`, and `author` fields to `package.json`.

## Testing

- `npm uninstall sinon-chai` should show no npm warnings in the console.

## Review

- @Scotchester 
- @sebworks 
- @virginiacc 
- @contolini 
- @rosskarchner 
