### PR TITLE
Converting simple table to table organism for Careers Page

### DIFF
--- a/cfgov/jinja2/v1/_includes/organisms/table.html
+++ b/cfgov/jinja2/v1/_includes/organisms/table.html
@@ -12,7 +12,10 @@
 
    ========================================================================== #}
 
-<table class="table__stack-on-small table__entry-header-on-small">
+<table class="o-table
+              {{ 'o-table__row-links' if value.row_links else '' }}
+              table__stack-on-small
+              table__entry-header-on-small">
     <thead>
         <tr>
             {% for thead in value.headers %}

--- a/cfgov/jinja2/v1/about-us/careers/_macro-table-current-openings.html
+++ b/cfgov/jinja2/v1/about-us/careers/_macro-table-current-openings.html
@@ -15,11 +15,11 @@
 {% macro render(careers) %}
 {% import 'macros/time.html' as time %}
 
-<table class="u-w100pct
+<table class="o-table
+              o-table__row-links
+              u-w100pct
               block
-              block__flush-top
-              simple-table
-              simple-table__row-links">
+              block__flush-top">
     <thead>
         <tr>
             <th>

--- a/cfgov/jinja2/v1/events/_macros.html
+++ b/cfgov/jinja2/v1/events/_macros.html
@@ -226,33 +226,29 @@
    ========================================================================== #}
 
 {% macro event_agenda(event) %}
-  {% set options = {
-      'time_col_classes': 'u-w25pct',
-      'agenda_col_classes': 'u-w25pct',
-      'location_col_classes': 'u-w25pct',
-      'speaker_col_classes': 'u-w25pct',
-  } %}
   <div class="block
               block__padded-top
               block__border-top">
     <h2>Agenda</h2>
-    <table class="u-w100pct
+    <table class="o-table
+                  event-agenda_table
+                  table__stack-on-small
+                  u-w100pct
                   block
-                  block__flush-top
-                  simple-table">
+                  block__flush-top">
         <thead>
             <tr>
-                <th class="{{ options.time_col_classes }}">Time</th>
-                <th class="{{ options.desc_col_classes }}">Agenda</th>
-                <th class="{{ options.location_col_classes }}">Location</th>
-                <th class="{{ options.speaker_col_classes }}">Speakers</th>
+                <th>Time</th>
+                <th>Agenda</th>
+                <th>Location</th>
+                <th>Speakers</th>
             </tr>
         </thead>
         <tbody>
         {% for block in event.agenda_items %}
           {% set bound = block.value.bound_blocks %}
             <tr>
-                <td class="{{ options.time_col_classes }}">
+                <td>
                     {% import 'macros/time.html' as time %}
                     {{ time.render(
                         bound.start_time.render(),
@@ -261,15 +257,15 @@
                     &ndash;
                     {{ time.render(bound.end_time.render(), {'time':true, 'timezone':true}) }}
                 </td>
-                <td class="{{ options.agenda_col_classes }} simple-table_row-heading">
+                <td data-label="Agenda">
                     {{ bound.description.render() }}
                 </td>
-                <td class="{{ options.location_col_classes }}" data-label="Location">
+                <td data-label="Location">
                   {% if bound.location.render() %}
                     {{ bound.location.render() }}
                   {% endif %}
                 </td>
-                <td class='{{ options.speaker_col_classes }}' data-label="Speakers">
+                <td data-label="Speakers">
                 {% for speaker in bound.speakers.value %}
                     {%- if speaker.bound_blocks.url.render() -%}
                     <a href="{{ speaker.bound_blocks.url.render() }}">

--- a/cfgov/unprocessed/css/enhancements/tables.less
+++ b/cfgov/unprocessed/css/enhancements/tables.less
@@ -14,7 +14,7 @@
 });
 
 /* topdoc
-  name: Simple Table
+  name: Table Organism
   family: cfgov-cf-enhancements
   notes:
     - Extends the above stacked tables for sm devices
@@ -27,7 +27,7 @@
   patterns:
     - name: Collapsable Table
       markup: |
-        <table class="simple-table">
+        <table class="o-table">
             <thead>
                 <tr>
                     <th>Column 1</th>
@@ -39,27 +39,27 @@
             <tbody>
                 <tr>
                     <td>Lorem ipsum dolor.</td>
-                    <td class="simple-table_row-heading">Lorem ipsum dolor.</td>
+                    <td class="o-table_row-heading">Lorem ipsum dolor.</td>
                     <td data-label="Lorem">Lorem ipsum dolor.</td>
                     <td data-label="Ipsum">Lorem ipsum dolor.</td>
                 </tr>
                 <tr>
                     <td>Lorem ipsum dolor.</td>
-                    <td class="simple-table_row-heading">Lorem ipsum dolor.</td>
+                    <td class="o-table_row-heading">Lorem ipsum dolor.</td>
                     <td data-label="Lorem">Lorem ipsum dolor.</td>
                     <td data-label="Ipsum">Lorem ipsum dolor.</td>
                 </tr>
                 <tr>
                     <td>Lorem ipsum dolor.</td>
-                    <td class="simple-table_row-heading">Lorem ipsum dolor.</td>
+                    <td class="o-table_row-heading">Lorem ipsum dolor.</td>
                     <td data-label="Lorem">Lorem ipsum dolor.</td>
                     <td data-label="Ipsum">Lorem ipsum dolor.</td>
                 </tr>
             </tbody>
         </table>
-    - name: simple-table__row-links (modifier)
+    - name: o-table__row-links (modifier)
       markup: |
-        <table class="simple-table simple-table__row-links">
+        <table class="o-table o-table__row-links">
             <thead>
                 <tr>
                     <th>Column 1</th>
@@ -69,20 +69,20 @@
             <tbody>
                 <tr>
                     <td><a href="#">Lorem ipsum dolor.</a></td>
-                    <td class="simple-table_row-heading">Lorem ipsum dolor.</td>
+                    <td class="o-table_row-heading">Lorem ipsum dolor.</td>
                 </tr>
                 <tr>
                     <td><a href="#">Lorem ipsum dolor.</a></td>
-                    <td class="simple-table_row-heading">Lorem ipsum dolor.</td>
+                    <td class="o-table_row-heading">Lorem ipsum dolor.</td>
                 </tr>
             </tbody>
         </table>
       codenotes:
         - |
-          .simple-table.simple-table__row-links
+          .o-table.o-table__row-links
       notes:
         - "Modifier that makes rows appear to be hoverable links.
-           Used in coordination with simple-table-row-links.js."
+           Used in coordination with o-table-row-links.js."
     tags:
   tags:
     - cfgov-cf-enhancements
@@ -90,7 +90,9 @@
 @td-bg-mobile: @gray-5;
 @tr-link-color: @white;
 @tr-link-bg-hover: @pacific-80;
-.simple-table {
+
+
+.o-table {
 
     &__row-links {
       .respond-to-min(961px, {
@@ -145,6 +147,7 @@
         }
     });
 }
+
 
 /* topdoc
   name: EOF

--- a/cfgov/unprocessed/css/pages/event.less
+++ b/cfgov/unprocessed/css/pages/event.less
@@ -15,6 +15,23 @@
     }
 }
 
+/* Event-Agenda Table
+   ========================================================================== */
+.event-agenda_table {
+    h2 + & td[data-label]:before {
+        margin-top: 0;
+    }
+
+    th, td {
+        font-size: 16px;
+    }
+
+    .respond-to-min(@bp-med-min, {
+        th {
+            width: 25%;
+        }
+    } );
+}
 
 /* Event-Post
    ========================================================================== */

--- a/cfgov/unprocessed/js/modules/o-table-row-links.js
+++ b/cfgov/unprocessed/js/modules/o-table-row-links.js
@@ -5,7 +5,7 @@
  * for the entire table row.
  */
 function init() {
-  var tables = document.querySelectorAll( '.simple-table__row-links' );
+  var tables = document.querySelectorAll( '.o-table__row-links' );
 
   for ( var i = tables.length - 1; i >= 0; i-- ) {
     tables[i].addEventListener( 'click', _tableClicked, false );

--- a/cfgov/unprocessed/js/routes/about-us/careers/current-openings/index.js
+++ b/cfgov/unprocessed/js/routes/about-us/careers/current-openings/index.js
@@ -4,4 +4,4 @@
 
 'use strict';
 
-require( '../../../../modules/simple-table-row-links' ).init();
+require( '../../../../modules/o-table-row-links' ).init();

--- a/test/browser_tests/page_objects/page_dbwu-small-businesses.js
+++ b/test/browser_tests/page_objects/page_dbwu-small-businesses.js
@@ -26,7 +26,7 @@ function SmallBusinessess() {
 
   this.smallBusinessLinks = this.smallBusinessInfo.all( by.css( 'a' ) );
 
-  this.awardsTable = element( by.css( '.content_main .simple-table' ) );
+  this.awardsTable = element( by.css( '.content_main table' ) );
 
   this.moreInfoSection = _getQAElement( 'more-info', true );
 

--- a/test/browser_tests/page_objects/page_dbwu-upcoming-procurement-needs.js
+++ b/test/browser_tests/page_objects/page_dbwu-upcoming-procurement-needs.js
@@ -21,7 +21,7 @@ function UpcomingProcurementNeeds() {
   element( by.css( '[data-qa-hook="main-summary"] + p a' ) );
 
   this.procurementNeedsTable =
-  element( by.css( '.content_main .simple-table' ) );
+  element( by.css( '.content_main table' ) );
 
   this.moreInfoSection = _getQAElement( 'more-info', true );
 

--- a/test/unit_tests/modules/o-table-row-links-spec.js
+++ b/test/unit_tests/modules/o-table-row-links-spec.js
@@ -2,7 +2,7 @@
 
 var BASE_JS_PATH = '../../../cfgov/unprocessed/js/';
 var simpleTableRowLinks =
-  require( BASE_JS_PATH + 'modules/simple-table-row-links' );
+  require( BASE_JS_PATH + 'modules/o-table-row-links' );
 
 var chai = require( 'chai' );
 var expect = chai.expect;
@@ -15,7 +15,7 @@ var linkRowCellDom;
 var nonLinkRowCellDom;
 
 var HTML_SNIPPET =
-  '<table class="simple-table__row-links">' +
+  '<table class="o-table__row-links">' +
   '<tbody>' +
     '<tr>' +
       '<th>cell1</th>' +
@@ -39,14 +39,14 @@ function triggerClickEvent( target ) {
 }
 
 
-describe( 'simple-table-row-links', function() {
+describe( 'o-table-row-links', function() {
   jsdom();
   beforeEach( function() {
     var windowLocation;
     sandbox = sinon.sandbox.create();
 
     document.body.innerHTML = HTML_SNIPPET;
-    tableDom = document.querySelector( '.simple-table__row-links' );
+    tableDom = document.querySelector( '.o-table__row-links' );
     linkDom = tableDom.querySelector( 'a' );
     linkRowCellDom = tableDom.querySelector( '.linkRowCell' );
     nonLinkRowCellDom = tableDom.querySelector( '.nonLinkRowCell' );


### PR DESCRIPTION
Converting simple table to table organism for Careers Page

## Changes

- Modified CSS, Javascript, spec files in conjunction with converting simple table to a table organism.

## Testing

- Visit the `http://localhost:8000/.gov/about-us/careers/current-openings/` and observe that the table highlighting still works via mouseover.

## Review

- @anselmbradford 
- @virginiacc 
- @contolini 

## Notes

Wasn't sure if the table highlighting should just be a behavior.

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)

