### PR TITLE
Fixed missing semicolon in fellows.js

### DIFF
--- a/cfgov/jobmanager/static/jobmanager/js/fellows.js
+++ b/cfgov/jobmanager/static/jobmanager/js/fellows.js
@@ -3,7 +3,7 @@ $(function(){
 	$(".fellows-signup-form").submit(function(){
 		$("#signup_btn").prop('disabled', true).val("Please wait...");
 		$.post(fellowship_form_submit_url, $(this).serialize(), function(){
-			$(".fellows-signup-form").html("<h3>Thank you!</h3> <p>We have your information and will be in touch with updates.</p>")
+			$(".fellows-signup-form").html("<h3>Thank you!</h3> <p>We have your information and will be in touch with updates.</p>");
 		});
 		return false;
 	});


### PR DESCRIPTION
After getting familiar with the JavaScript files in main repository, I spotted a missing semicolon in fellows signup form jQuery. I decided to fix it as missing semicolon might actually have an adverse effect in submitting the form or printing out the submission message.

File: ```cfgov/jobmanager/static/jobmanager/js/fellows.js```

## Changes
Added missing semicolon in fellows signup form jQuery.

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)

