### PR TITLE
Add handlers.py to v1/models to refactor JS filename handling

### DIFF
--- a/cfgov/jinja2/v1/_layouts/base.html
+++ b/cfgov/jinja2/v1/_layouts/base.html
@@ -199,8 +199,8 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 
     {# TODO: Remove Else conditional when this is fully moved to wagtail. #}
     {# Check and include page-level JavaScript. #}
-    {% if page and page.media %}
-        {% for type, jsfiles in page.media.iteritems() %}
+    {% if page and media %}
+        {% for type, jsfiles in media.iteritems() %}
             {% for js in jsfiles %}
                 {% include '/js/routes/on-demand/' + js ignore missing %}
             {% endfor %}

--- a/cfgov/v1/atomic_elements/__init__.py
+++ b/cfgov/v1/atomic_elements/__init__.py
@@ -1,0 +1,9 @@
+from .atoms import JS_ATOMS
+from .molecules import JS_MOLECULES
+from .organisms import JS_ORGANISMS
+
+ATOMIC_JS = {
+    'atoms': JS_ATOMS,
+    'molecules': JS_MOLECULES,
+    'organisms': JS_ORGANISMS
+}

--- a/cfgov/v1/atomic_elements/atoms.py
+++ b/cfgov/v1/atomic_elements/atoms.py
@@ -4,6 +4,8 @@ from django.core.exceptions import ValidationError
 from wagtail.wagtailcore import blocks
 from wagtail.wagtailimages.blocks import ImageChooserBlock
 
+JS_ATOMS = []
+
 
 def number_validator(value, search=re.compile(r'[^0-9]').search):
     if value:

--- a/cfgov/v1/atomic_elements/molecules.py
+++ b/cfgov/v1/atomic_elements/molecules.py
@@ -6,6 +6,7 @@ from wagtail.wagtailimages.blocks import ImageChooserBlock
 from . import atoms
 from ..util import util, ref
 
+JS_MOLECULES = []
 
 def isRequired(field_name):
     return [str(field_name) + ' is required.']

--- a/cfgov/v1/atomic_elements/organisms.py
+++ b/cfgov/v1/atomic_elements/organisms.py
@@ -6,6 +6,13 @@ from . import atoms, molecules
 from ..util import ref
 from ..models.snippets import Contact as ContactSnippetClass
 
+JS_ORGANISMS = [
+    'BaseExpandable',
+    'Expandable',
+    'ExpandableGroup',
+    'FilterControls'
+]
+
 
 class Well(blocks.StructBlock):
     content = blocks.RichTextBlock(required=False, label='Well')

--- a/cfgov/v1/models/base.py
+++ b/cfgov/v1/models/base.py
@@ -31,6 +31,7 @@ from modelcluster.tags import ClusterTaggableManager
 
 from sheerlike.query import QueryFinder
 
+from .handlers import JSHandler
 from .. import get_protected_url
 from ..atomic_elements import molecules, organisms
 from ..util import util, ref
@@ -307,50 +308,11 @@ class CFGOVPage(Page):
     def add_page_js(self, js):
         js['template'] = []
 
-    # Retrieves the stream values on a page from it's Streamfield
-    def _get_streamfield_blocks(self):
-        lst = [value for key, value in vars(self).iteritems()
-               if type(value) is StreamValue]
-        return list(chain(*lst))
-
-    # Gets the JS from the Streamfield data
-    def _add_streamfield_js(self, js):
-        # Create a dictionary with keys ordered organisms, molecules, then atoms
-        for child in self._get_streamfield_blocks():
-            self._add_block_js(child.block, js)
-
-    # Recursively search the blocks and classes for declared Media.js
-    def _add_block_js(self, block, js):
-        self._assign_js(block, js)
-        if issubclass(type(block), blocks.StructBlock):
-            for child in block.child_blocks.values():
-                self._add_block_js(child, js)
-        elif issubclass(type(block), blocks.ListBlock):
-            self._add_block_js(block.child_block, js)
-
-    # Assign the Media js to the dictionary appropriately
-    def _assign_js(self, obj, js):
-        try:
-            if hasattr(obj.Media, 'js'):
-                for key in js.keys():
-                    if obj.__module__.endswith(key):
-                        js[key] += obj.Media.js
-                if not [key for key in js.keys() if obj.__module__.endswith(key)]:
-                    js.update({'other': obj.Media.js})
-        except:
-            pass
-
     # Returns all the JS files specific to this page and it's current Streamfield's blocks
     @property
     def media(self):
-        js = OrderedDict()
-        for key in ['template', 'organisms', 'molecules', 'atoms']:
-            js.update({key: []})
-        self.add_page_js(js)
-        self._add_streamfield_js(js)
-        for key, js_files in js.iteritems():
-            js[key] = OrderedDict.fromkeys(js_files).keys()
-        return js
+        js_handler = JSHandler(self)
+        return js_handler.get_js_dict()
 
 
 class CFGOVPageCategory(Orderable):

--- a/cfgov/v1/models/handlers.py
+++ b/cfgov/v1/models/handlers.py
@@ -17,7 +17,7 @@ class Handler(object):
 
 class JSHandler(Handler):
     """
-        Gathers all the JS files specific to this page and it's current
+        Gathers all the JS files specific to this page and its current
         Streamfield's blocks and puts them in the template context.
     """
     def __init__(self, page, request):

--- a/cfgov/v1/models/handlers.py
+++ b/cfgov/v1/models/handlers.py
@@ -1,0 +1,56 @@
+from collections import OrderedDict
+from itertools import chain
+from wagtail.wagtailcore import blocks
+from wagtail.wagtailcore.blocks.stream_block import StreamValue
+
+
+class JSHandler:
+    def __init__(self, page):
+        self.page = page
+        self.js_dict = OrderedDict()
+        self.generate_js_dict()
+
+    def generate_js_dict(self):
+        for key in ['template', 'organisms', 'molecules', 'atoms']:
+            self.js_dict.update({key: []})
+        self.page.add_page_js(self.js_dict)
+        self.add_streamfield_js()
+        for key, js_files in self.js_dict.iteritems():
+            self.js_dict[key] = OrderedDict.fromkeys(js_files).keys()
+
+    def get_js_dict(self):
+        return self.js_dict
+
+    # Gets the JS from the Streamfield data
+    def add_streamfield_js(self):
+        # Create a dictionary with keys ordered organisms, molecules, then atoms
+        for child in self.get_streamfield_blocks():
+            self.add_block_js(child.block)
+
+    # Retrieves the stream values on a page from it's Streamfield
+    def get_streamfield_blocks(self):
+        lst = [value for key, value in vars(self.page).iteritems()
+               if type(value) is StreamValue]
+        return list(chain(*lst))
+
+    # Recursively search the blocks and classes for declared Media.js
+    def add_block_js(self, block):
+        self.assign_js(block)
+        if issubclass(type(block), blocks.StructBlock):
+            for child in block.child_blocks.values():
+                self.add_block_js(child)
+        elif issubclass(type(block), blocks.ListBlock):
+            self.add_block_js(block.child_block)
+
+    # Assign the Media js to the dictionary appropriately
+    def assign_js(self, obj):
+        try:
+            if hasattr(obj.Media, 'js'):
+                for key in self.js_dict.keys():
+                    if obj.__module__.endswith(key):
+                        self.js_dict[key] += obj.Media.js
+                if not [key for key in self.js_dict.keys()
+                        if obj.__module__.endswith(key)]:
+                    self.js_dict.update({'other': obj.Media.js})
+        except:
+            pass

--- a/cfgov/v1/models/handlers.py
+++ b/cfgov/v1/models/handlers.py
@@ -14,6 +14,12 @@ class Handler(object):
     def process(self, context):
         raise NotImplementedError
 
+    # Retrieves the stream values on a page from it's Streamfield
+    def get_streamfield_blocks(self):
+        lst = [value for key, value in vars(self.page).iteritems()
+               if type(value) is StreamValue]
+        return list(chain(*lst))
+
 
 class JSHandler(Handler):
     """
@@ -41,12 +47,6 @@ class JSHandler(Handler):
         # Create a dictionary with keys ordered organisms, molecules, then atoms
         for child in self.get_streamfield_blocks():
             self.add_block_js(child.block)
-
-    # Retrieves the stream values on a page from it's Streamfield
-    def get_streamfield_blocks(self):
-        lst = [value for key, value in vars(self.page).iteritems()
-               if type(value) is StreamValue]
-        return list(chain(*lst))
 
     # Recursively search the blocks and classes for declared Media.js
     def add_block_js(self, block):

--- a/cfgov/v1/models/handlers.py
+++ b/cfgov/v1/models/handlers.py
@@ -6,11 +6,27 @@ from wagtail.wagtailcore.blocks.stream_block import StreamValue
 from ..atomic_elements import ATOMIC_JS
 
 
-class JSHandler:
-    def __init__(self, page):
+class Handler(object):
+    def __init__(self, page, request):
         self.page = page
+        self.request = request
+
+    def process(self, context):
+        raise NotImplementedError
+
+
+class JSHandler(Handler):
+    """
+        Gathers all the JS files specific to this page and it's current
+        Streamfield's blocks and puts them in the template context.
+    """
+    def __init__(self, page, request):
+        super(JSHandler, self).__init__(page, request)
         self.js_dict = OrderedDict()
+
+    def process(self, context):
         self.generate_js_dict()
+        context['media'] = self.js_dict
 
     def generate_js_dict(self):
         for key in ['template', 'organisms', 'molecules', 'atoms', 'other']:
@@ -19,9 +35,6 @@ class JSHandler:
         self.add_streamfield_js()
         for key, js_files in self.js_dict.iteritems():
             self.js_dict[key] = OrderedDict.fromkeys(js_files).keys()
-
-    def get_js_dict(self):
-        return self.js_dict
 
     # Gets the JS from the Streamfield data
     def add_streamfield_js(self):

--- a/cfgov/v1/tests/models/test_handlers.py
+++ b/cfgov/v1/tests/models/test_handlers.py
@@ -1,0 +1,54 @@
+import mock
+from collections import OrderedDict
+from unittest import TestCase
+from ...models.handlers import JSHandler
+
+
+class TestJSHandler(TestCase):
+    def setUp(self):
+        self.page = mock.Mock()
+        self.js_handler = JSHandler(self.page)
+
+    @mock.patch('v1.models.handlers.JSHandler.generate_js_dict')
+    def test_generate_js_dict_returns_OrderedDict(self, mock_generate_js_dict):
+        js_handler = JSHandler(self.page)
+        assert mock_generate_js_dict.called
+
+    @mock.patch('v1.models.handlers.JSHandler.add_streamfield_js')
+    def test_generate_js_dict_returns_OrderedDict(self, mock_add_sf_js):
+        assert type(self.js_handler.js_dict) is OrderedDict
+
+    @mock.patch('v1.models.handlers.JSHandler.add_streamfield_js')
+    def test_generate_js_dict_calls_page_add_page_js(self, mock_add_sf_js):
+        self.js_handler.generate_js_dict()
+        assert self.page.add_page_js.called
+
+    @mock.patch('v1.models.handlers.JSHandler.add_streamfield_js')
+    def test_generate_js_dict_calls_add_streamfield_js(self, mock_add_sf_js):
+        js_dict = self.js_handler.generate_js_dict()
+        assert mock_add_sf_js.called
+
+    def test_get_js_dict_returns_OrderedDict(self):
+        self.js_handler.js_dict = OrderedDict()
+        assert type(self.js_handler.get_js_dict()) is OrderedDict
+
+    @mock.patch('v1.models.handlers.JSHandler.get_streamfield_blocks')
+    @mock.patch('v1.models.handlers.JSHandler.add_block_js')
+    def test_add_streamfield_js_calls_get_streamfield_blocks(self, mock_add_js, mock_get_blocks):
+        self.js_handler.add_streamfield_js()
+        assert mock_get_blocks.called
+
+    @mock.patch('v1.models.handlers.JSHandler.get_streamfield_blocks')
+    @mock.patch('v1.models.handlers.JSHandler.add_block_js')
+    def test_add_streamfield_js_calls_add_block_js(self, mock_add_js, mock_get_blocks):
+        mock_get_blocks.return_value = [mock.Mock()]
+        self.js_handler.add_streamfield_js()
+        assert mock_add_js.called
+
+    @mock.patch('v1.models.handlers.JSHandler.assign_js')
+    def test_add_block_js_calls_assign_js(self, mock_assign_js):
+        block = mock.Mock()
+        js_dict = OrderedDict()
+        self.js_handler.add_block_js(block)
+        assert mock_assign_js.called
+        mock_assign_js.assert_called_with(block)

--- a/cfgov/v1/tests/models/test_handlers.py
+++ b/cfgov/v1/tests/models/test_handlers.py
@@ -1,18 +1,40 @@
 import mock
 from collections import OrderedDict
 from unittest import TestCase
-from ...models.handlers import JSHandler
+from ...models.handlers import Handler, JSHandler
+
+
+class TestHandler(TestCase):
+    def setUp(self):
+        self.page = mock.Mock()
+        self.request = mock.Mock()
+        self.handler = Handler(self.page, self.request)
+
+    def test_process_raises_NotImplementedError(self):
+        with self.assertRaises(NotImplementedError) as nie:
+            self.handler.process({})
+
+    def test_get_streamfield_blocks_returns_list(self):
+        assert type(self.handler.get_streamfield_blocks()) is list
 
 
 class TestJSHandler(TestCase):
     def setUp(self):
         self.page = mock.Mock()
-        self.js_handler = JSHandler(self.page)
+        self.request = mock.Mock()
+        self.js_handler = JSHandler(self.page, self.request)
 
     @mock.patch('v1.models.handlers.JSHandler.generate_js_dict')
-    def test_generate_js_dict_returns_OrderedDict(self, mock_generate_js_dict):
-        js_handler = JSHandler(self.page)
+    def test_process_calls_generate_js_dict(self, mock_generate_js_dict):
+        self.js_handler.process({})
         assert mock_generate_js_dict.called
+
+    @mock.patch('v1.models.handlers.JSHandler.generate_js_dict')
+    def test_process_sets_context_media_od(self, mock_generate_js_dict):
+        context = {}
+        self.js_handler.process(context)
+        assert 'media' in context
+        assert type(context['media']) is OrderedDict
 
     @mock.patch('v1.models.handlers.JSHandler.add_streamfield_js')
     def test_generate_js_dict_returns_OrderedDict(self, mock_add_sf_js):
@@ -27,10 +49,6 @@ class TestJSHandler(TestCase):
     def test_generate_js_dict_calls_add_streamfield_js(self, mock_add_sf_js):
         js_dict = self.js_handler.generate_js_dict()
         assert mock_add_sf_js.called
-
-    def test_get_js_dict_returns_OrderedDict(self):
-        self.js_handler.js_dict = OrderedDict()
-        assert type(self.js_handler.get_js_dict()) is OrderedDict
 
     @mock.patch('v1.models.handlers.JSHandler.get_streamfield_blocks')
     @mock.patch('v1.models.handlers.JSHandler.add_block_js')


### PR DESCRIPTION
**This is the start of a series of PR's that deal with refactoring the CFGOVPage class to set up work to be done with filterable pages.**

This abstracts the JS filename handling for a page into it's own class for a more OO approach.

## Additions

- v1/models/handlers.py to hold the handler classes (so far just JSHandler)
- JSHandler: a class to handle the JS filename collection

## Removals

- JS handling code from CFGOVPage

## Changes

- JS filename handling now resides in handlers.py in the JSHandler class

## Testing

- run `tox -- v1.tests.models.test_handlers`
- Run a shell and grab a page that has expandables, expandable group, or filterable list in it's content
 - execute `page.media` and observe an OrderedDict returned with the appropriate filenames

## Review

- @Scotchester 
- @cfpb/cfgov-backends 

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)

