### PR TITLE
Amended missing semicolon

### DIFF
--- a/cfgov/jobmanager/static/jobmanager/js/supervision.js
+++ b/cfgov/jobmanager/static/jobmanager/js/supervision.js
@@ -13,7 +13,7 @@ function smooth_scroll(id){
 $(document).ready(function(){
     $('.goto-jobs').click(function(){
         smooth_scroll('featured_positions');
-    })
+    });
 
 
     $('#email_collection_form #email').focus(function(){


### PR DESCRIPTION
Hello. While familiarizing myself with the JavaScript source code, I spotted another missing semicolon in the .js files. This time, the bug was in was in file:

cfgov/jobmanager/static/jobmanager/js/supervision.js. 

This has now been amended. The change should mitigate the bug risk.

Thank you. 

## Changes

- Amended missing semicolon in ```goto-jobs``` jQuery function.

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)

