### PR TITLE
READY: Updated the nav for the upcoming conference page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 ## UNRELEASED
 
 ### Added
+- Added new conference url in the nav
 
 ### Changed
 - Updated Protractor to version `4.0.2` from `3.2.1`.

--- a/cfgov/jinja2/v1/_includes/organisms/_vars-mega-menu.html
+++ b/cfgov/jinja2/v1/_includes/organisms/_vars-mega-menu.html
@@ -90,6 +90,7 @@
     )]),
     ('Data & Research', '/data-research/', [(
         ('Research & Reports', '/data-research/research-reports/', []),
+        ('CFPB Research Conference', '/data-research/cfpb-research-conference/', [])
     ),(
         ('Consumer Complaint Database', '/data-research/consumer-complaints/', []),
         ('Mortgage Database (HMDA)', '/data-research/mortgage-data-hmda/', [])


### PR DESCRIPTION
Data & Research will be publishing a new page for the Research Conference (whooo!). Adding the link to the nav so that it will be discoverable.

## Additions

- Added new conference url in the nav

## Testing

- checkout the branch and make sure the link is in the nav

## Review

- @KimberlyMunoz 
- @cfarm 
- @schaferjh 

## Screenshots

![screen shot 2016-08-12 at 2 09 04 pm](https://cloud.githubusercontent.com/assets/1280430/17634073/635ce738-6096-11e6-853c-186a8a2b97d4.png)

## Notes

- It doesn't go anywhere yet, but when the page is published next tue/wed this should get merged shortly so it can go out with the following release.

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices
* [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)