### PR TITLE
Remove CF component demo dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
   },
   "devDependencies": {
     "browser-sync": "2.11.2",
-    "cf-component-demo": "git://github.com/cfpb/cf-component-demo.git#0.8.2",
     "chai": "3.5.0",
     "documentation": "4.0.0-beta2",
     "es5-shim": "4.5.7",


### PR DESCRIPTION
AFAIK this is cruft (and jenkins doesn't like it).

## Removals

- `cf-component-demo` dependency

## Review

- @virginiacc 
- @sebworks 
- @anselmbradford 