### PR TITLE
HOLD - Updating mailto message for error pages

### DIFF
--- a/cfgov/jinja2/v1/_layouts/404.html
+++ b/cfgov/jinja2/v1/_layouts/404.html
@@ -32,7 +32,8 @@
                     <p>
                         If you’re sure this is the right place, let us know.
                     </p>
-                    <a class="jump-link" href="mailto:CFPB_website@consumerfinance.gov?subject=404%20Error">
+                    {% set subject = "subject=404%20error%20occurred%20at%20{0}".format(request.url) %}
+                    <a class="jump-link" href="mailto:CFPB_website@consumerfinance.gov?{{ subject }}">
                         Contact us
                     </a>
                 </div>

--- a/cfgov/jinja2/v1/_layouts/500.html
+++ b/cfgov/jinja2/v1/_layouts/500.html
@@ -33,7 +33,8 @@
                     <p>
                         If the problem persists please let us know.
                     </p>
-                    <a class="jump-link" href="mailto:CFPB_website@consumerfinance.gov?subject=500%20Error">
+                     {% set subject = "subject=500%20error%20occurred%20at%20{0}".format(request.url) %}
+                    <a class="jump-link" href="mailto:CFPB_website@consumerfinance.gov?{{ subject }}">
                         Contact us
                     </a>
                 </div>


### PR DESCRIPTION
Updating mailto message for error pages. This is the first portion of 400 / 500 error page related work.


## Changes

- Updating mailto message for error pages to add the `request.path`

## Testing

- Change the debug value to `False`  in your `local.py` file. 
- Goto `http://localhost:8000/testing/`. You should see an unstyled 400 error page. 
- Fear not, this is expected. Scan the page for the `Contact Us` link. Click the link and verify the subject of the mail message should be `404 error occurred at http://localhost:8000/testing/`

## Review

- @rosskarchner 
- @schaferjh 

## Screenshots

<img width="771" alt="screen shot 2016-08-18 at 6 35 15 pm" src="https://cloud.githubusercontent.com/assets/1696212/17793043/95058f02-6572-11e6-99be-9fadad832a42.png">
<img width="759" alt="screen shot 2016-08-18 at 6 37 10 pm" src="https://cloud.githubusercontent.com/assets/1696212/17793087/cfe17eec-6572-11e6-85ff-6e205f08da40.png">


## Notes

-

## Todos

- Modify templates to add telephone contact information.

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)

