### PR TITLE
Removes potentially misleading instructions from backend.sh

### DIFF
--- a/backend.sh
+++ b/backend.sh
@@ -16,8 +16,7 @@ init() {
 
   # Ensure that we're in a virtualenv
   python -c 'import sys; sys.real_prefix' 2>/dev/null || (
-    echo 'Please activate your virtualenv before running this script:' \
-         '$ workon cfgov-refresh' &&
+    echo 'Please activate your virtualenv before running this script.' &&
     exit 1
   )
 }


### PR DESCRIPTION
## Changes

- Remove `backend.sh` message about activating virtual environment.

## Testing

- Open a new tab and cd to the project directory.
- Run `deactivate` if a virtual environment was activated.
- Run `./backend.sh` and see that the message output does not include the virtualenv.

## Review

- @richaagarwal 
- @chosak 
- @kurtrwall 
