### PR TITLE
Update to correct envvars

### DIFF
--- a/gulp/tasks/test.js
+++ b/gulp/tasks/test.js
@@ -144,8 +144,8 @@ function _getWCAGParams() {
  */
 function _createPSITunnel( callback ) {
   var commandLineParams = minimist( process.argv.slice( 2 ) );
-  var host = process.env.HTTP_HOST || 'localhost'; // eslint-disable-line no-process-env, no-inline-comments, max-len
-  var port = process.env.HTTP_PORT || '8000'; // eslint-disable-line no-process-env, no-inline-comments, max-len
+  var host = process.env.TEST_HTTP_HOST || 'localhost'; // eslint-disable-line no-process-env, no-inline-comments, max-len
+  var port = process.env.TEST_HTTP_PORT || '8000'; // eslint-disable-line no-process-env, no-inline-comments, max-len
   var path = _parsePath( commandLineParams.u );
   var url = host + ':' + port + path;
   var strategy = commandLineParams.s || 'mobile';


### PR DESCRIPTION
## Changes

- Script was referencing `HTTP_PORT` and `HTTP_HOST`, which should be prefixed with [`TEST_`](https://github.com/cfpb/cfgov-refresh/blob/master/.env_SAMPLE#L121-L122)

## Testing

- Set a different port number for `TEST_HTTP_PORT` in `.env`, restart the server, and run `gulp test:perf` and it shouldn't fall over looking for port `8000`.

## Review

- @virginiacc 
- @sebworks 
- @contolini 

## Notes

- I really think the ` || 'localhost'` and ` || '8000'` defaults should be removed and the envvar should be enforced in `.env`, otherwise errors like this get hidden till you need to switch to a non-standard port because you're running two projects at the same time. @chosak sorry to beat a dead horse, but was it decided to enforce `TEST_HTTP_PORT` as a value in `.env`?