### PR TITLE
Squash gulp lint:build warnings/errors

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -207,7 +207,7 @@ rules:
   dot-notation:
     - 2
     -
-      allowKeywords: false
+      allowKeywords: true
       allowPattern: ''
 
   # Enforces use of === and !== over == and !=.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,9 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Migrated previous Table data to new TableBlocks
 - Updated documentation npm module to version `4.0.0-beta5` from `4.0.0-beta2`.
 - Updated gulp-uglify npm module to version `2.0.0` from `1.5.3`.
+- Updated eslintrc dot-notation rule to support `catch` block in a Promise.
+- Updated `gulp test:perf` task to use a Promise.
+- Added `.eslintrc` override for gulp tasks to allow process.exit and console logging.
 
 ### Removed
 - Unused `sinon-chai` npm package.

--- a/gulp/.eslintrc
+++ b/gulp/.eslintrc
@@ -1,0 +1,3 @@
+rules:
+  no-console: 0
+  no-process-exit: 0


### PR DESCRIPTION
## Changes

- Updated ESLint dot-notation rule to support `catch` block in a Promise.
- Updated `gulp test:perf` task to use a Promise.
- Added `.eslintrc` override for gulp tasks to allow process.exit and console logging.

## Testing

- `gulp lint:build` should only warn about TODOs.
- `gulp test:perf` should work as expected (@contolini plz see that I didn't break anything)

## Review

- @contolini 
- @sebworks 
- @virginiacc 

