### PR TITLE
Hotfix: Spanish molecule translations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,17 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 
 ---------------------------------------
 
+## Unreleased
+
+### Added
+
+### Changed
+- Added support for Spanish-language cue labels to the Expandables organism.
+- Added support for Spanish-language heading to the Social Media molecule.
+
+### Removed
+
+
 ## 3.7.0
 
 ### Added

--- a/cfgov/jinja2/v1/_includes/molecules/social-media.html
+++ b/cfgov/jinja2/v1/_includes/molecules/social-media.html
@@ -44,6 +44,7 @@
             m-social-media__{{ 'share' if is_share_view else 'follow' }}">
     {% if is_share_view %}
         <div class="h5 m-social-media_heading">Share this</div>
+        <div class="h5 m-social-media_heading m-social-media_heading__es">Compartir este</div>
     {% endif %}
 
     <ul class="list

--- a/cfgov/jinja2/v1/_includes/organisms/expandable.html
+++ b/cfgov/jinja2/v1/_includes/organisms/expandable.html
@@ -48,11 +48,13 @@
                 <span class="o-expandable_cue
                              o-expandable_cue-open">
                     <span class="o-expandable_cue-label">Show</span>
+                    <span class="o-expandable_cue-label o-expandable_cue-label__es">Mostrar</span>
                     <span class="cf-icon cf-icon-plus-round"></span>
                 </span>
                 <span class="o-expandable_cue
                              o-expandable_cue-close">
                     <span class="o-expandable_cue-label">Hide</span>
+                    <span class="o-expandable_cue-label o-expandable_cue-label__es">Ocultar</span>
                     <span class="cf-icon cf-icon-minus-round"></span>
                 </span>
             </span>

--- a/cfgov/unprocessed/css/molecules/social-media.less
+++ b/cfgov/unprocessed/css/molecules/social-media.less
@@ -47,6 +47,18 @@
         padding-right: unit( @grid_gutter-width / @font-size - 0.25em, em );
         margin-bottom: 0;
         vertical-align: middle;
+
+        &__es {
+            display: none;
+        }
+
+        [lang="es"] & {
+            display: none;
+        }
+
+        [lang="es"] &__es {
+            display: inline-block;
+        }
     }
 
     .list {

--- a/cfgov/unprocessed/css/organisms/expandable.less
+++ b/cfgov/unprocessed/css/organisms/expandable.less
@@ -165,6 +165,20 @@
     }
 }
 
+// Alternate language show/hide cues
+.o-expandable_cue-label__es {
+    display: none;
+}
+
+[lang="es"] {
+    .o-expandable_cue-label {
+        display: none;
+    }
+    .o-expandable_cue-label__es {
+        display: inline;
+    }
+}
+
 // Setting height to prevent flash on load.
 .o-expandable_content:not([aria-expanded='true']) {
     height: 0;


### PR DESCRIPTION
We're launching Money as You Grow in Spanish on September 1st. The pages (unlike the existing English pages, which live in the fin-ed-resources repo) will be built in Wagtail. Consequently, they need the microcopy on a few choice modules to be in Spanish.

This needs to be a hotfix because the next regularly-scheduled release is Tuesday, September 6th.

## Additions

- Added support for Spanish-language cue labels to the Expandables organism.
- Added support for Spanish-language heading to the Social Media molecule.

## Testing

1. Pull branch
2. `gulp styles`
3. `runserver`
4. Create a new Browse page in your local Wagtail instance.
5. Add an Expandable to the main content area, and a Social Media module (in sharing mode) to the sidefoot.
6. Preview it.
7. Observe the cue labels on the Expandable and the heading on the Social Media module _en español_.

## Review

- @cfpb/cfgov-frontends 

## Screenshots

![screen shot 2016-08-23 at 14 54 30](https://cloud.githubusercontent.com/assets/1044670/17905587/87d59a48-6941-11e6-858a-acf5b75bfc7d.png)

## Notes

- This is a quick-and-dirty, won't-scale-for-more-languages implementation. If someone is willing to help me figure out how to actually test for the language of the page in the template for an atomic module and output the text appropriately there, that would probably be the better route to go.

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
