### PR TITLE
Be less "clever" when setting BaseURL

### DIFF
--- a/cfgov/cal/views.py
+++ b/cfgov/cal/views.py
@@ -146,7 +146,7 @@ def pdf_response(request, context):
     stylesheet_url = '/static/css/pdfreactor-fonts.css'
     pdf_reactor = PDFreactor()
 
-    pdf_reactor.setBaseURL("%s://%s/" % (request.scheme, request.get_host()))
+    pdf_reactor.setBaseURL("http://localhost/")
     pdf_reactor.setLogLevel(PDFreactor.LOG_LEVEL_WARN)
     pdf_reactor.setLicenseKey(str(license))
     pdf_reactor.setAuthor('CFPB')


### PR DESCRIPTION
The 'master' version of this fix should probably use environment variables (but default to localhost if the variable is unset)