### PR TITLE
Hotfix: Decouple leadership calendar PDF template from base.html

### DIFF
--- a/cfgov/jinja2/v1/about-us/the-bureau/leadership-calendar/print/index.html
+++ b/cfgov/jinja2/v1/about-us/the-bureau/leadership-calendar/print/index.html
@@ -1,23 +1,198 @@
-{% extends 'base.html' %}
+<html>
+<head>
+<title> Leadership calendar </title>
 
-{% block title -%}
-    Leadership calendar
-{%- endblock %}
 
-{% block desc -%}
-    Leadership calendar | Consumer Financial Protection Bureau
-{%- endblock %}
+<style type="text/css">
+@media print {
 
-{% block css %}
-    {{ super() }}
-    {% import 'pdfreactor-footer.html' as pdfreactor_footer %}
-    {{ pdfreactor_footer.render('consumerfinance.gov/about-us/the-bureau/leadership-calendar') }}
-{% endblock %}
+    @page {
+        size: letter;
+        padding: 0;
+        margin: 0.35in 0.35in 1.25in;
+        /*border: 1px solid red;*/
+        counter-increment: page;
+    }
 
-{% block javascript %}
-{% endblock %}
+    @page {
+        @bottom-center {
+            content: xhtml('<div class="pdfreactor-footer" role="contentinfo">    <span class="pdfreactor-footer_info">consumerfinance.gov/about-us/the-bureau/leadership-calendar</span>    <span class="pdfreactor-footer_page-num"></span></div>');
+        }
+    }
 
-{% block body %}
+    .content_wrapper,
+    .content_main {
+        padding: 0;
+    }
+
+    .pdfreactor-footer {
+        float: left;
+        width: 100%;
+        padding-top: 1.25em; /* -20px / 16px = 1.25em */
+        text-align: right;
+    }
+    .pdfreactor-footer_logo {
+        float: left;
+        width: 200px;
+        margin-top: -1.25em; /* -20px / 16px = 1.25em */
+    }
+    .pdfreactor-footer_info {
+        font-size: 0.875em; /* 14px / 16px = 0.875em */
+        font-family: "AvenirNextLTW01-Demi", Arial, sans-serif;
+        font-style: normal;
+        font-weight: bold;
+    }
+    .pdfreactor-footer_page-num {
+        margin-left: 2em;
+        font-family: "AvenirNextLTW01-Demi", Arial, sans-serif;
+        font-style: normal;
+        font-weight: bold;
+    }
+    .pdfreactor-footer_page-num:after {
+        content: counter(page) ' of ' counter(pages);
+    }
+
+}
+</style>
+<style>
+
+@font-face {
+    font-family: "AvenirNextLTW01-Regular";
+    src: url("/static/fonts/pdfreactor/46cf1067-688d-4aab-b0f7-bd942af6efd8.ttf");
+    font-style: normal;
+    font-weight: normal;
+}
+
+@font-face {
+    font-family: "AvenirNextLTW01-Italic";
+    src: url("/static/fonts/pdfreactor/18839597-afa8-4f0b-9abb-4a30262d0da8.ttf");
+    font-style: italic;
+    font-weight: normal;
+}
+
+@font-face {
+    font-family: "AvenirNextLTW01-Regular";
+    src: url("/static/fonts/pdfreactor/46cf1067-688d-4aab-b0f7-bd942af6efd8.ttf");
+}
+
+@font-face{
+    font-family: "AvenirNextLTW01-Medium";
+    src: url("/static/fonts/pdfreactor/63a74598-733c-4d0c-bd91-b01bffcd6e69.ttf");
+    font-style: normal;
+    font-weight: 500;
+}
+
+@font-face{
+    font-family: "AvenirNextLTW01-Demi";
+    src: url("/static/fonts/pdfreactor/a0f4c2f9-8a42-4786-ad00-fce42b57b148.ttf");
+    font-style: normal;
+    font-weight: 700;
+}
+.superheading,
+.superheader {
+    font-family: 'AvenirNextLTW01-Regular', Arial, sans-serif;
+    font-style: normal;
+    font-weight: normal;
+    margin-bottom: .41666667em;
+    font-size: 3em;
+    line-height: 1.25;
+}
+.print .superheader {
+    color: #20aa3f;
+}
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+    margin-top: 0;
+}
+h1 {
+    margin: .67em 0;
+}
+.print-header {
+    margin-bottom: 1.875em;
+    padding-bottom: 1.875em;
+    border-bottom: 5px solid #101820;
+}
+div {
+    display: block;
+}
+body {
+    font-family: 'AvenirNextLTW01-Regular', Arial, sans-serif;
+    font-style: normal;
+    font-weight: normal;
+    color: #101820;
+    font-size: 100%;
+    line-height: 1.375;
+}
+.block__flush-top {
+    margin-top: 0 !important;
+}
+.block {
+    margin-top: 3.75em;
+    margin-bottom: 3.75em;
+}
+.u-w100pct {
+    width: 100%;
+}
+table {
+    font-family: 'AvenirNextLTW01-Regular', Arial, sans-serif;
+    font-style: normal;
+    font-weight: normal;
+}
+p,
+ul,
+ol,
+dl,
+figure,
+table,
+blockquote {
+    margin-top: 0;
+    margin-bottom: .9375em;
+}
+table {
+    border-collapse: collapse;
+    border-spacing: 0;
+}
+thead,
+tbody tr {
+    border-bottom: 1px solid #5a5d61;
+}
+thead {
+    display: table-header-group;
+    vertical-align: middle;
+    border-color: inherit;
+}
+thead th,
+thead td {
+    padding: .71428571em;
+    color: #101820;
+    background: #f1f1f1;
+    font-family: 'AvenirNextLTW01-Demi', Arial, sans-serif;
+    font-style: normal;
+    font-weight: bold;
+    margin-bottom: 1.07142857em;
+    font-size: .875em;
+    letter-spacing: 1px;
+    line-height: 1.25;
+    text-transform: uppercase;
+}
+th {
+    font-family: 'AvenirNextLTW01-Demi', Arial, sans-serif;
+    font-style: normal;
+    font-weight: bold;
+    text-align: left;
+}
+th,
+td {
+    padding: .625em;
+}
+</style>
+
+</head>
+<body>
     {% import 'leadership-calendar-table.html' as calendar with context %}
 
     <main class="content print" id="main" role="main">
@@ -44,5 +219,5 @@
             </div>
         </div><!-- END .wrapper -->
     </main><!-- END .content -->
+</body>
 
-{% endblock body %}


### PR DESCRIPTION
While further troubleshooting PDF's, I discovered that PDFReactor was really choking on main.css. Removing it made the difference between **painfully slow** (takes multiple minutes, sometimes times out) to reasonably zippy.

What I've done here, is take the template and remove it from the "base.html" inheritance chain. I've added the necessary CSS directly to the template. This isn't front-end code that we'll be proud of, but with this change, this feature is now usable.



## Testing

- Review this PDF generated with this code:  [cfpb-leadership (22).pdf](https://github.com/cfpb/cfgov-refresh/files/435530/cfpb-leadership.22.pdf)

- If you have a working PDF reactor, give it a try

(note that this PDF exposes a logic flaw in the application itself-- that event from March 14th should not appear there. This is not PDF-specific though)


## Review

- @cfpb/cfgov-backends 

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)

