### PR TITLE
Downgrade djangorestframework

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -20,7 +20,7 @@ django-taggit==0.18.3
 django-tinymce==2.2.0
 django-treebeard==3.0
 django>=1.8,<=1.8.99
-djangorestframework==3.3.3
+djangorestframework==2.4.8
 elasticsearch==1.6.0
 git+https://github.com/cfpb/publish_eccu.git#egg=publish_eccu
 git+https://github.com/rosskarchner/govdelivery.git#egg=govdelivery


### PR DESCRIPTION
I think this upgrade was erroneous (but understandable, the way our requirements have been split among multiple repo's), but I want to make sure @grapesmoker didn't have a specific reason for upgrading it.


## Changes

- change base.txt to reference djangorestframework==2.4.8

## Review

- @cfpb/cfgov-backends 

