### PR TITLE
Modify default Wagtail page settings panel order

### DIFF
--- a/cfgov/v1/models/base.py
+++ b/cfgov/v1/models/base.py
@@ -117,11 +117,11 @@ class CFGOVPage(Page):
 
     settings_panels = [
         MultiFieldPanel(Page.promote_panels, 'Settings'),
+        InlinePanel('categories', label="Categories", max_num=2),
         FieldPanel('tags', 'Tags'),
         FieldPanel('authors', 'Authors'),
-        FieldPanel('language', 'language'),
-        InlinePanel('categories', label="Categories", max_num=2),
         MultiFieldPanel(Page.settings_panels, 'Scheduled Publishing'),
+        FieldPanel('language', 'language'),
     ]
 
     # Tab handler interface guide because it must be repeated for each subclass

--- a/cfgov/v1/models/learn_page.py
+++ b/cfgov/v1/models/learn_page.py
@@ -43,6 +43,8 @@ class AbstractFilterPage(CFGOVPage):
     # Configuration tab panels
     settings_panels = [
         MultiFieldPanel(Page.promote_panels, 'Settings'),
+        InlinePanel('categories', label="Categories", max_num=2),
+        FieldPanel('tags', 'Tags'),
         MultiFieldPanel([
             FieldPanel('preview_title', classname="full"),
             FieldPanel('preview_subheading', classname="full"),
@@ -50,15 +52,13 @@ class AbstractFilterPage(CFGOVPage):
             FieldPanel('secondary_link_url', classname="full"),
             FieldPanel('secondary_link_text', classname="full"),
             ImageChooserPanel('preview_image'),
-        ], heading='Page Preview Fields', classname='collapsible collapsed'),
+        ], heading='Page Preview Fields', classname='collapsible'),
+        FieldPanel('authors', 'Authors'),
         MultiFieldPanel([
             FieldPanel('date_published'),
             FieldPanel('date_filed'),
             FieldPanel('comments_close_by'),
         ], 'Relevant Dates', classname='collapsible'),
-        FieldPanel('tags', 'Tags'),
-        FieldPanel('authors', 'Authors'),
-        InlinePanel('categories', label="Categories", max_num=2),
         MultiFieldPanel(Page.settings_panels, 'Scheduled Publishing'),
     ]
 

--- a/cfgov/v1/tests/models/test_page_settings.py
+++ b/cfgov/v1/tests/models/test_page_settings.py
@@ -1,0 +1,58 @@
+from django.apps import apps
+from django.test import TestCase
+
+from v1.models.base import CFGOVPage
+
+
+class PageSettingsOrderTestCaseMeta(type):
+    def __new__(cls, name, parent, dct):
+        for app in apps.get_app_configs():
+            for model in app.get_models():
+                if issubclass(model, CFGOVPage):
+                    cls.add_test(dct, model)
+
+        return super(PageSettingsOrderTestCaseMeta, cls).__new__(
+            cls, name, parent, dct
+        )
+
+    @classmethod
+    def add_test(cls, dct, page_cls):
+        def fn(self):
+            self.check_correct_page_settings_order(page_cls)
+
+        cls_name = page_cls.__name__.lower()
+        test_name = 'test_correct_page_settings_order_{}'.format(cls_name)
+        fn.__name__ = test_name
+        dct[test_name] = fn
+
+
+class PageSettingsOrderTestCase(TestCase):
+    __metaclass__ = PageSettingsOrderTestCaseMeta
+
+    expected_panel_order = (
+        'settings',
+        'categories',
+        'tags',
+        'page preview fields',
+        'authors',
+        'relevant dates',
+        'scheduled publishing',
+        'language',
+    )
+
+    def check_correct_page_settings_order(self, page_cls):
+        settings_panels = getattr(page_cls, 'settings_panels', [])
+        panel_names = [self.get_panel_name(p).lower() for p in settings_panels]
+        expected_order = [
+            p for p in self.expected_panel_order if p in panel_names
+        ]
+
+        self.assertSequenceEqual(panel_names, expected_order)
+
+    def get_panel_name(self, panel):
+        name_keys = ('heading', 'field_name', 'relation_name')
+        for name_key in name_keys:
+            name = getattr(panel, name_key, None)
+
+            if name:
+                return name


### PR DESCRIPTION
To make editing Wagtail pages easier for content managers, this PR reorders items in the page configuration tab to match the following specified order:

 * Settings, 
 * Categories, 
 * Tags, 
 * Page preview fields (expanded by default)
 * Authors, 
 * Relevant dates, 
 * Scheduled publishing
 * Language

## Additions

- New tests to enforce that all pages that inherit from `CFGOVPage` comply with this order.

## Changes

- Modified order of fields on `CFGOVPage` and `AbstractFilterPage` to comply with new order.

## Testing

- Create a new `DocumentDetailPage` or edit an existing one in the Wagtail editor and notice that the field order has changed, and that page preview fields should be expanded by default.

## Review

- @cfpb/cfgov-backends @schaferjh 

## Checklist

* [X] Changes are limited to a single goal (no scope creep)
* [X] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [X] Passes all existing automated tests
* [X] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
