### PR TITLE
Updates reference to glob-all from glob

### DIFF
--- a/gulp/tasks/docs.js
+++ b/gulp/tasks/docs.js
@@ -2,7 +2,7 @@
 
 var configScripts = require( '../config' ).scripts;
 var fsHelper = require( '../utils/fs-helper' );
-var glob = require( 'glob' );
+var globAll = require( 'glob-all' );
 var gulp = require( 'gulp' );
 var plugins = require( 'gulp-load-plugins' )();
 var spawn = require( 'child_process' ).spawn;
@@ -12,7 +12,7 @@ var spawn = require( 'child_process' ).spawn;
  * Generate scripts documentation.
  */
 function docsScripts() {
-  glob( configScripts.src, function( er, files ) {
+  globAll( configScripts.src, function( er, files ) {
     var options = [ 'build' ].concat( files ).concat(
                   [ '--github',
                     '--output=docs/scripts',


### PR DESCRIPTION
`glob` was being required while it was not imported in `package.json` so that reference should be updated to the imported `glob-all` module.

## Changes

- Updates reference to glob-all from glob
