### PR TITLE
Updates gulp-istanbul to `1.1.1`

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1002,9 +1002,9 @@
       "resolved": "https://registry.npmjs.org/blob/-/blob-0.0.4.tgz"
     },
     "bluebird": {
-      "version": "3.4.3",
+      "version": "3.4.4",
       "from": "bluebird@>=3.1.1 <4.0.0",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.3.tgz"
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.4.tgz"
     },
     "body-parser": {
       "version": "1.14.2",
@@ -3014,9 +3014,9 @@
       "resolved": "https://registry.npmjs.org/fobject/-/fobject-0.0.3.tgz",
       "dependencies": {
         "graceful-fs": {
-          "version": "3.0.10",
+          "version": "3.0.11",
           "from": "graceful-fs@>=3.0.2 <4.0.0",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.10.tgz"
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.11.tgz"
         }
       }
     },
@@ -3935,9 +3935,9 @@
           "resolved": "http://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
         },
         "bluebird": {
-          "version": "2.10.2",
+          "version": "2.11.0",
           "from": "bluebird@>=2.9.30 <3.0.0",
-          "resolved": "http://registry.npmjs.org/bluebird/-/bluebird-2.10.2.tgz"
+          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz"
         },
         "har-validator": {
           "version": "1.8.0",
@@ -6273,9 +6273,9 @@
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.4.0.tgz"
     },
     "natives": {
-      "version": "1.0.2",
-      "from": "natives@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/natives/-/natives-1.0.2.tgz"
+      "version": "1.1.0",
+      "from": "natives@>=1.1.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/natives/-/natives-1.1.0.tgz"
     },
     "natural-compare": {
       "version": "1.4.0",
@@ -8556,9 +8556,9 @@
           "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz"
         },
         "graceful-fs": {
-          "version": "3.0.10",
+          "version": "3.0.11",
           "from": "graceful-fs@>=3.0.0 <4.0.0",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.10.tgz"
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.11.tgz"
         },
         "isarray": {
           "version": "0.0.1",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -4308,9 +4308,16 @@
       "resolved": "https://registry.npmjs.org/gulp-imagemin/-/gulp-imagemin-3.0.2.tgz"
     },
     "gulp-istanbul": {
-      "version": "0.10.3",
-      "from": "gulp-istanbul@0.10.3",
-      "resolved": "http://registry.npmjs.org/gulp-istanbul/-/gulp-istanbul-0.10.3.tgz"
+      "version": "1.1.1",
+      "from": "gulp-istanbul@1.1.1",
+      "resolved": "https://registry.npmjs.org/gulp-istanbul/-/gulp-istanbul-1.1.1.tgz",
+      "dependencies": {
+        "lodash": {
+          "version": "4.15.0",
+          "from": "lodash@>=4.0.0 <5.0.0",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.15.0.tgz"
+        }
+      }
     },
     "gulp-less": {
       "version": "3.0.5",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "gulp-concat": "2.6.0",
     "gulp-coveralls": "0.1.4",
     "gulp-eslint": "3.0.1",
-    "gulp-istanbul": "0.10.3",
+    "gulp-istanbul": "1.1.1",
     "gulp-mocha": "3.0.1",
     "gulp-plumber": "1.1.0",
     "gulp-rename": "1.1.0",


### PR DESCRIPTION
## Changes

- Updates gulp-istanbul to `1.1.1` from `0.10.3`.

## Testing

- `./frontend.sh && gulp test:unit:scripts` should pass.

## Review

- @sebworks 
- @virginiacc 
- @contolini 

