### PR TITLE
Spelling amendment: deployment.md

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -4,7 +4,7 @@ Everything that is part of cfgov-refresh and its dependencies are deployed as pa
 
 Projects that are independent of cfgov-refresh will need to provide their own deployment process, and all jobs they require. They will not be automatically included in the cf.gov deployment process, and will not be on the cf.gov release cadence. 
 
-All new deployment jobs, jobs that run in addition to the cf.gov depoyment jobs, as well as independent jobs, must be implemented with [Jenkins-as-code](https://github.com/cfpb/jenkins-automation).
+All new deployment jobs, jobs that run in addition to the cf.gov deployment jobs, as well as independent jobs, must be implemented with [Jenkins-as-code](https://github.com/cfpb/jenkins-automation).
 
 ## Deployment QA
 


### PR DESCRIPTION
Hi. I spotted a spelling mistake in the documentation file docs/deployment.md. This has been now amended.

## Changes

- Documentation spelling amendment.

depoyment -> deployment

No functional changes to software itself.

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
