### PR TITLE
[HOLD] Updates jsdom to 9.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Author names are now displayed in alphabetical order by last name, falls back on first name if necessary
 
 ### Changed
+- Updated gulp-istanbul npm module to version `1.1.1` from `0.10.3`.
+- Updated jsdom npm module to version `9.4.2` from `8.3.0`.
 
 ### Removed
 - Unused functions `author_name` and `item_author_name` from `v1/feeds.py`

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1681,7 +1681,7 @@
     },
     "cssstyle": {
       "version": "0.2.37",
-      "from": "cssstyle@>=0.2.34 <0.3.0",
+      "from": "cssstyle@>=0.2.36 <0.3.0",
       "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-0.2.37.tgz"
     },
     "ctype": {
@@ -5473,14 +5473,19 @@
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz"
     },
     "jsdom": {
-      "version": "8.3.0",
-      "from": "jsdom@8.3.0",
-      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-8.3.0.tgz",
+      "version": "9.4.2",
+      "from": "jsdom@9.4.2",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-9.4.2.tgz",
       "dependencies": {
         "acorn": {
           "version": "2.7.0",
           "from": "acorn@>=2.4.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/acorn/-/acorn-2.7.0.tgz"
+        },
+        "tough-cookie": {
+          "version": "2.3.1",
+          "from": "tough-cookie@>=2.3.1 <3.0.0",
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.1.tgz"
         }
       }
     },
@@ -8777,9 +8782,9 @@
       "resolved": "https://registry.npmjs.org/weinre/-/weinre-2.0.0-pre-I0Z7U9OV.tgz"
     },
     "whatwg-url": {
-      "version": "1.0.1",
-      "from": "whatwg-url@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-1.0.1.tgz"
+      "version": "3.0.0",
+      "from": "whatwg-url@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-3.0.0.tgz"
     },
     "when": {
       "version": "3.7.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cfgov-refresh",
-  "version": "3.6.0",
+  "version": "3.7.2",
   "description": "The consumerfinance.gov website.",
   "homepage": "http://www.consumerfinance.gov/",
   "author": {
@@ -62,7 +62,7 @@
     "jasmine-reporters": "2.1.1",
     "jasmine-spec-reporter": "2.4.0",
     "jquery": "1.11.3",
-    "jsdom": "8.3.0",
+    "jsdom": "9.4.2",
     "localtunnel": "1.8.1",
     "map-stream": "0.0.4",
     "minimist": "1.2.0",


### PR DESCRIPTION
## Changes

- Updates jsdom to 9.4.2 `9.4.2` from `8.3.0`.
- Bumps package.json version to match release version.
- Re-generates shrinkwrap.

## Testing

- `./frontend.sh && gulp test:unit:scripts`

## Review

- @contolini 
- @virginiacc 
- @sebworks 
