### PR TITLE
Docs spellcheck: front-end-build.md

### DIFF
--- a/docs/front-end-build.md
+++ b/docs/front-end-build.md
@@ -45,12 +45,12 @@ We usually use [Grunt](http://gruntjs.com/) to automate the compilation of JavaS
 
 Here are some helpful plugins for Grunt:
 
-- [grunt-contrib-uglify](https://github.com/gruntjs/grunt-contrib-uglify) for concatinating and minifying JS
+- [grunt-contrib-uglify](https://github.com/gruntjs/grunt-contrib-uglify) for concatenating and minifying JS
 - [grunt-contrib-less](https://github.com/gruntjs/grunt-contrib-less) for compiling Less and CSS files
 - [grunt-contrib-cssmin](https://github.com/gruntjs/grunt-contrib-cssmin) for minifying CSS
 - [grunt-contrib-clean](https://github.com/gruntjs/grunt-contrib-clean) for cleaning folders
 - [grunt-contrib-watch](https://github.com/gruntjs/grunt-contrib-watch) for watching and compiling assets on the fly
-- [grunt-browserify](https://github.com/jmreidy/grunt-browserify) for using Node style CommonJS modules clientside
+- [grunt-browserify](https://github.com/jmreidy/grunt-browserify) for using Node style CommonJS modules client-side
 
 ## Capital Framework Generator
 


### PR DESCRIPTION
Another documentation spellcheck, this time for docs/front-end-build.md.

## Changes

- Couple of spelling mistakes amended.

concatinating -> concatenating
clientside -> client-side

No functional changes to software.

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)

