### PR TITLE
Remove pdb breakpoint

### DIFF
--- a/cfgov/v1/forms.py
+++ b/cfgov/v1/forms.py
@@ -28,7 +28,6 @@ class FilterDateField(forms.DateField):
 
 class PDFFilterDateField(forms.DateField):
     def clean(self, value):
-        import pdb; pdb.set_trace();
         if value:
             try:
                 value = get_date_string(value)


### PR DESCRIPTION
[This commit](https://github.com/cfpb/cfgov-refresh/commit/12379803d316a6e7321a8f439b8806e499ea3964) accidentally introduced a `pdb` breakpoint into the calendar forms code. This PR removes that breakpoint.

## Removals

- Removes `import pdb; pdb.set_trace()` statement.

## Review

- @cfpb/cfgov-backends 

## Notes

- Assuming this was checked in erroneously @richaagarwal.

## Checklist

* [X] Changes are limited to a single goal (no scope creep)
* [X] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [X] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)

