### PR TITLE
Enforce unique user emails when creating/editing users in Wagtail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Author names are now displayed in alphabetical order by last name, falls back on first name if necessary
 - Ability to output sharing links within an Image and Text 50/50 Group module
 - Google Optimize code on `find-a-housing-counselor` page
+- Wagtail User editor now enforces unique email addresses when creating/editing users.
 
 ### Changed
 - Special characters no longer break the multiselect in the filter form

--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -215,6 +215,7 @@ WAGTAILIMAGES_IMAGE_MODEL = 'v1.CFGOVImage'
 TAGGIT_CASE_INSENSITIVE = True
 
 WAGTAIL_USER_CREATION_FORM = 'v1.auth_forms.UserCreationForm'
+WAGTAIL_USER_EDIT_FORM = 'v1.auth_forms.UserEditForm'
 
 SHEER_ELASTICSEARCH_SERVER = os.environ.get('ES_HOST', 'localhost') + ':' + os.environ.get('ES_PORT', '9200')
 SHEER_ELASTICSEARCH_INDEX = os.environ.get('SHEER_ELASTICSEARCH_INDEX', 'content')

--- a/cfgov/v1/tests/test_auth_forms.py
+++ b/cfgov/v1/tests/test_auth_forms.py
@@ -1,8 +1,8 @@
 from django.contrib.auth.models import User
+from django.test import TestCase
 from mock import patch
-from unittest import TestCase
 
-from v1.auth_forms import UserCreationForm
+from v1.auth_forms import UserCreationForm, UserEditForm
 
 
 @patch('v1.auth_forms.send_password_reset_email')
@@ -34,3 +34,79 @@ class UserCreationFormTestCase(TestCase):
         self.assertTrue(form.is_valid())
         form.save(commit=False)
         send_email.assert_not_called()
+
+    def test_duplicate_email_fails_validation(self, send_email):
+        User.objects.create(username='foo', email=self.email)
+        form = UserCreationForm(self.userdata)
+        self.assertFalse(form.is_valid())
+        self.assertTrue(form.errors['email'])
+
+
+class UserEditFormTestCase(TestCase):
+    def test_no_edits_valid(self):
+        data = {
+            'username': 'george',
+            'email': 'george@washington.com',
+            'first_name': 'george',
+            'last_name': 'washington',
+        }
+
+        user = User.objects.create(**data)
+        form = UserEditForm(data=data, instance=user)
+        self.assertTrue(form.is_valid())
+
+    def test_edit_first_name(self):
+        data = {
+            'username': 'george',
+            'email': 'george@washington.com',
+            'first_name': 'george',
+            'last_name': 'washington',
+        }
+
+        user = User.objects.create(**data)
+
+        data['first_name'] = 'joe'
+        form = UserEditForm(data=data, instance=user)
+        self.assertTrue(form.is_valid())
+
+        user = form.save()
+        self.assertEqual(user.first_name, 'joe')
+        self.assertEqual(user.username, 'george')
+
+    def test_duplicate_email_fails_validation(self):
+        data = {
+            'username': 'george',
+            'email': 'george@washington.com',
+            'first_name': 'george',
+            'last_name': 'washington',
+        }
+
+        User.objects.create(**data)
+
+        data2 = dict(data)
+        data['username'] = 'patrick'
+        form = UserEditForm(data=data2)
+
+        self.assertFalse(form.is_valid())
+        self.assertTrue(form.errors['email'])
+
+    def test_duplicate_emails_allowed_on_user_model(self):
+        data = {
+            'username': 'george',
+            'email': 'george@washington.com',
+            'first_name': 'george',
+            'last_name': 'washington',
+        }
+
+        User.objects.create(**data)
+
+        data2 = dict(data)
+        data2['username'] = 'patrick'
+
+        try:
+            User.objects.create(**data2)
+        except Exception:
+            self.fail(
+                'users with duplicate emails are allowed, '
+                'just not when creating or editing via for '
+            )


### PR DESCRIPTION
We want to avoid having users share the same email address. This PR prevents Wagtail editors from creating users with an email that's already in use. It also prevents them from modifying a user's email to one that's already in use by somebody else.

This PR does not prevent use of the Django shell to set duplicate emails, nor does it create a DB constraint that would prevent this (there might be reasonable dev use cases to support something like this, for example easy local testing). It also doesn't do anything to modify any pre-existing users that may already share the same email.

## Additions

- New custom `v1.auth_forms.UserEditForm` that has custom email validation to prevent duplicates.

## Changes

- Our custom `v1.auth_forms.UserCreationForm` now has custom email validation to prevent duplicates.

## Testing

- Run `tox` or `tox -e fast` to run all unit tests. New tests for this are in `v1.tests.test_auth_forms`.
- Testing with a local database:
 - Go to [the Wagtail User editor](http://localhost:8000/admin/users/) and select "Add a user".
 - Fill out all of the information, including a unique email address. Select "Roles" and then "Add user" to save.
 - Try repeating the process with a second user using the same email address but other unique information. Validation should fail and prevent you from saving the second user.
 - Try repeating the process with a second unique email (this should work), and then go back and edit this new second user by clicking on its username in the user list.
 - Try changing the second user email to the first unique email address you used. Validation should fail and prevent you from updating the second user.

## Review

- @grapesmoker 

## Screenshots

Can't add a user with a duplicate email address:

![image](https://cloud.githubusercontent.com/assets/654645/18356884/aaf0629c-75bc-11e6-96eb-3307d8323473.png)

Can't edit a user to set a duplicate email address:

![image](https://cloud.githubusercontent.com/assets/654645/18356900/be7258b6-75bc-11e6-9d46-fedec69f76a6.png)

## Checklist

* [X] Changes are limited to a single goal (no scope creep)
* [X] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [X] Passes all existing automated tests
* [X] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [X] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)