### PR TITLE
Fix post-preview.html to use tag/author slugs in links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,10 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Unused npm module map-stream.
 - Custom method `most_common` since python lib offers similar function
 
+### Fixed
+- Post preview organism template used tag/author names instead of slugs that
+caused bad link formation
+
 ## 3.7.2
 
 ### Changed

--- a/cfgov/jinja2/v1/_includes/organisms/item-introduction.html
+++ b/cfgov/jinja2/v1/_includes/organisms/item-introduction.html
@@ -31,8 +31,7 @@
 {% set form_id, ancestor = get_filter_data(page) %}
 {% set page_url = get_protected_url(ancestor) %}
 {% set published_date = value.date %}
-{% set page_authors = page.get_authors() %}
-{% set has_authors = page_authors|length > 0 %}
+{% set has_authors = page.authors.exists() %}
 
 <div class="o-item-introduction">
     {% if value.category is string %}
@@ -54,10 +53,10 @@
     {% endif %}
         {% if has_authors %}
             <span class="byline">
-            {%- for author in page_authors -%}
+            {%- for author in page.get_authors() -%}
                 {{- 'By ' if loop.index == 1 else ' and ' }}
-                <a href="{{ page_url }}?filter{{ form_id }}_authors={{ author }}">
-                    {{ author }}
+                <a href="{{ page_url }}?filter{{ form_id }}_authors={{ author.slug }}">
+                    {{ author.name }}
                 </a>
             {%- endfor -%}
                 &ndash;

--- a/cfgov/jinja2/v1/_includes/organisms/post-preview.html
+++ b/cfgov/jinja2/v1/_includes/organisms/post-preview.html
@@ -151,19 +151,19 @@
                 </div>
             {% endif %}
             <div class="post_meta">
-                {% for author in post.get_authors() %}
+                {% for author in post.authors.all() %}
                     <span class="o-post-preview_byline">
                         {% if loop.index == 1  %}
-                            By <a href="{{ page_url }}?filter{{ form_id }}_authors={{ author }}">
-                                {{ author }}
+                            By <a href="{{ page_url }}?filter{{ form_id }}_authors={{ author.slug }}">
+                                {{ author.name }}
                                 </a>
                         {% elif loop.last == true %}
-                            and <a href="{{ page_url }}?filter{{ form_id }}_authors={{ author }}">
-                                {{ author }}
+                            and <a href="{{ page_url }}?filter{{ form_id }}_authors={{ author.slug }}">
+                                {{ author.name }}
                                 </a>
                         {% else %}
-                            ,<a href="{{ page_url }}?filter{{ form_id }}_authors={{ author }}">
-                                {{ author }}
+                            ,<a href="{{ page_url }}?filter{{ form_id }}_authors={{ author.slug }}">
+                                {{ author.name }}
                                 </a>
                         {% endif %}
                     </span>
@@ -171,7 +171,7 @@
 
                 {% if post.tags.names() | length %}
                     {%- import 'tags.html' as tags %}
-                    {{ tags.render(post.tags.names(), page_url, true, false, form_id) }}
+                    {{ tags.render(related_metadata_tags(post), page_url, true, false, form_id, is_wagtail=True) }}
                 {% endif %}
             </div>
             {% if post.secondary_link_url and post.secondary_link_text %}

--- a/cfgov/jinja2/v1/_includes/organisms/post-preview.html
+++ b/cfgov/jinja2/v1/_includes/organisms/post-preview.html
@@ -151,7 +151,7 @@
                 </div>
             {% endif %}
             <div class="post_meta">
-                {% for author in post.authors.all() %}
+                {% for author in post.get_authors() %}
                     <span class="o-post-preview_byline">
                         {% if loop.index == 1  %}
                             By <a href="{{ page_url }}?filter{{ form_id }}_authors={{ author.slug }}">
@@ -169,7 +169,7 @@
                     </span>
                 {% endfor %}
 
-                {% if post.tags.names() | length %}
+                {% if post.tags.exists() %}
                     {%- import 'tags.html' as tags %}
                     {{ tags.render(related_metadata_tags(post), page_url, true, false, form_id, is_wagtail=True) }}
                 {% endif %}

--- a/cfgov/v1/models/base.py
+++ b/cfgov/v1/models/base.py
@@ -138,9 +138,9 @@ class CFGOVPage(Page):
     def alphabetize_authors(self):
         """ Alphabetize authors of this page by last name, then first name if needed """
         # First sort by first name
-        author_names = sorted(self.authors.names())
+        author_names = self.authors.order_by('name')
         # Then sort by last name
-        return sorted(author_names, key=lambda x: x.split()[-1])
+        return sorted(author_names, key=lambda x: x.name.split()[-1])
 
     def generate_view_more_url(self, request):
         from ..forms import ActivityLogFilterForm

--- a/cfgov/v1/tests/models/test_author_names.py
+++ b/cfgov/v1/tests/models/test_author_names.py
@@ -11,9 +11,10 @@ class TestAuthorNames(TestCase):
 
     def test_alphabetize_authors_by_last_name(self):
         page = CFGOVPage()
-        page.authors.add('Ross Karchner','Richa Agarwal', 'Andy Chosak', 'Will Barton')
+        page.authors.add('Ross Karchner', 'Richa Agarwal', 'Andy Chosak', 'Will Barton')
         expected_result = ['Richa Agarwal', 'Will Barton', 'Andy Chosak', 'Ross Karchner']
-        self.assertEquals(page.alphabetize_authors(), expected_result)
+        author_names = [a.name for a in page.alphabetize_authors()]
+        self.assertEquals(author_names, expected_result)
     
     def test_no_authors(self):
         page = CFGOVPage()
@@ -23,13 +24,15 @@ class TestAuthorNames(TestCase):
         page = CFGOVPage()
         page.authors.add('Jess Schafer', 'Richa Something Agarwal', 'Sarah Simpson')
         expected_result = ['Richa Something Agarwal', 'Jess Schafer', 'Sarah Simpson']
-        self.assertEquals(page.alphabetize_authors(), expected_result)
+        author_names = [a.name for a in page.alphabetize_authors()]
+        self.assertEquals(author_names, expected_result)
 
     def test_same_last_names(self):
         page = CFGOVPage()
         page.authors.add('Mary Smith', 'Vic Kumar', 'John Smith')
         expected_result = ['Vic Kumar', 'John Smith', 'Mary Smith']
-        self.assertEquals(page.alphabetize_authors(), expected_result)
+        author_names = [a.name for a in page.alphabetize_authors()]
+        self.assertEquals(author_names, expected_result)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Filtering breaks if a user clicks a link from an author's name or a tag on the post preview.

## Changes

- post-preview.html tag/author rendering uses slugs to create links now so filtering doesn't break

## Testing

- Run `tox`
- Go to any filterable list page and click an author or tag link to make sure you receive results and no errors

## Review

- @chosak 
- @Scotchester 
- @richaagarwal 

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [x] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices
* [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)

