### PR TITLE
fixed a mistake in get_browserfilterable_posts and wrote a test for it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Author names are now displayed in alphabetical order by last name, falls back on first name if necessary
 - Ability to output sharing links within an Image and Text 50/50 Group module
 - Google Optimize code on `find-a-housing-counselor` page
+- Added a test for get_browsefilterable_posts function of the sublanding page 
 
 ### Changed
 - Special characters no longer break the multiselect in the filter form

--- a/cfgov/scripts/_atomic_helpers.py
+++ b/cfgov/scripts/_atomic_helpers.py
@@ -116,6 +116,14 @@ well = {
         'content': "this is well content"
     }
 }
+filter_controls = {
+    'type': 'filter_controls',
+    'value': [
+        {
+            'title': 'this is a filter'
+        }
+    ]
+}
 full_width_text = {
     'type': 'full_width_text',
     'value': [

--- a/cfgov/v1/models/sublanding_page.py
+++ b/cfgov/v1/models/sublanding_page.py
@@ -65,13 +65,15 @@ class SublandingPage(CFGOVPage):
 
     def get_browsefilterable_posts(self, request, limit):
         filter_pages = [p.specific for p in self.get_appropriate_descendants(request.site.hostname)
-                        if 'FilterablePage' in p.specific_class.__name__ and 'archive' not in p.title.lower()]
+                        if 'FilterablePage' in p.specific_class.__name__
+                        and 'archive' not in p.title.lower()]
 
         posts_tuple_list = [(str(util.get_form_id(page)), post)
                             for page in filter_pages
-                            for post in page.get_page_set(page.get_form_class()(parent=page,
-                                                                                hostname=request.site.hostname),
-                                                          request.site.hostname)]
+                            for post in page.get_page_set(
+                                page.get_form_class()(parent=page,
+                                                      hostname=request.site.hostname),
+                                request.site.hostname)]
 
         posts = sorted(posts_tuple_list, key=lambda p: p[1].date_published, reverse=True)[:limit]
         return posts

--- a/cfgov/v1/models/sublanding_page.py
+++ b/cfgov/v1/models/sublanding_page.py
@@ -1,6 +1,3 @@
-from itertools import chain
-from collections import defaultdict
-
 from wagtail.wagtailcore.fields import StreamField
 from wagtail.wagtailadmin.edit_handlers import TabbedInterface, ObjectList, \
     StreamFieldPanel

--- a/cfgov/v1/models/sublanding_page.py
+++ b/cfgov/v1/models/sublanding_page.py
@@ -75,10 +75,8 @@ class SublandingPage(CFGOVPage):
                 filtered_controls.update({id: []})
             form_class = page.get_form_class()
             posts = page.get_page_set(form_class(parent=page, hostname=request.site.hostname), request.site.hostname)
-            if filtered_controls[id]:
-                filtered_controls[id] += posts
-            else:
-                filtered_controls[id] = posts
-        posts_tuple_list = [(id, post) for id, posts in filtered_controls.iteritems() for post in posts]
+            filtered_controls[id].append(posts)
+
+        posts_tuple_list = [(id, post) for id, posts in filtered_controls.iteritems() for post in chain(*posts)]
         posts = sorted(posts_tuple_list, key=lambda p: p[1].date_published, reverse=True)[:limit]
         return posts

--- a/cfgov/v1/tests/models/test_sublanding_page.py
+++ b/cfgov/v1/tests/models/test_sublanding_page.py
@@ -12,8 +12,8 @@ import datetime as dt
 
 class SublandingPageTestCase(TestCase):
     """
-    This test case checks that the browse-filterable posts of a sublanding page are
-    properly retrieved.
+    This test case checks that the browse-filterable posts of a sublanding
+    page are properly retrieved.
     """
     def setUp(self):
         self.request = mock.MagicMock()
@@ -24,9 +24,11 @@ class SublandingPageTestCase(TestCase):
         helpers.publish_page(child=self.sublanding_page)
         self.post1 = BrowseFilterablePage(title='post 1')
         self.post2 = BrowseFilterablePage(title='post 2')
-        # the content of this post has both a full_width_text and a filter_controls
+        # the content of this post has both a full_width_text
+        # and a filter_controls
         self.post1.content = StreamValue(self.post1.content.stream_block,
-                                         [atomic.full_width_text, atomic.filter_controls], True)
+                                         [atomic.full_width_text, atomic.filter_controls],
+                                         True)
         # this one only has a filter_controls
         self.post2.content = StreamValue(self.post1.content.stream_block,
                                          [atomic.filter_controls], True)
@@ -38,9 +40,12 @@ class SublandingPageTestCase(TestCase):
         # order of retrieval in test situations, otherwise the `date_published`
         # can vary due to commit order
 
-        self.child1_of_post1 = AbstractFilterPage(title='child 1 of post 1', date_published=dt.date(2016, 9, 1))
-        self.child2_of_post1 = AbstractFilterPage(title='child 2 of post 1', date_published=dt.date(2016, 9, 2))
-        self.child1_of_post2 = AbstractFilterPage(title='child 1 of post 2', date_published=dt.date(2016, 9, 3))
+        self.child1_of_post1 = AbstractFilterPage(title='child 1 of post 1',
+                                                  date_published=dt.date(2016, 9, 1))
+        self.child2_of_post1 = AbstractFilterPage(title='child 2 of post 1',
+                                                  date_published=dt.date(2016, 9, 2))
+        self.child1_of_post2 = AbstractFilterPage(title='child 1 of post 2',
+                                                  date_published=dt.date(2016, 9, 3))
         helpers.save_new_page(self.child1_of_post1, self.post1)
         helpers.save_new_page(self.child2_of_post1, self.post1)
         helpers.save_new_page(self.child1_of_post2, self.post2)
@@ -51,9 +56,9 @@ class SublandingPageTestCase(TestCase):
 
     def test_get_appropriate_descendants(self):
         """
-        Check to make sure the descendants of the sublanding page are the correct
-        children that we saved during setup. The order of the retrieval should be
-        consistent with the order in which they were saved.
+        Check to make sure the descendants of the sublanding page are the
+        correct children that we saved during setup. The order of the
+        retrieval should be consistent with the order in which they were saved.
         """
 
         descendants = self.sublanding_page.get_appropriate_descendants(self.request.site.hostname)
@@ -66,22 +71,23 @@ class SublandingPageTestCase(TestCase):
     def test_get_browsefilterable_posts(self):
         """
         Test to make sure the browsefilterable posts are retrieved correctly.
-        The posts should be retrieved in reverse chronological order, and if the
-        limit exceeds the total number of posts, all should be retrieved.
+        The posts should be retrieved in reverse chronological order, and if
+        the limit exceeds the total number of posts, all should be retrieved.
         """
         browsefilterable_posts = self.sublanding_page.get_browsefilterable_posts(self.request, self.limit)
         self.assertEqual(len(browsefilterable_posts), 3)
-        # the first number in the tuple represents the order of the filter_controls form
-        # in the post's content field, so we test situations in which that order varies
+        # the first number in the tuple represents the order of the
+        # filter_controls form in the post's content field, so we test
+        # situations in which that order varies
         self.assertEqual(('1', self.child1_of_post1), browsefilterable_posts[2])
         self.assertEqual(('1', self.child2_of_post1), browsefilterable_posts[1])
         self.assertEqual(('0', self.child1_of_post2), browsefilterable_posts[0])
 
     def test_get_browsefilterable_posts_with_limit(self):
         """
-        Same as the above test but imposes a limit that is smaller than the total number
-        of posts. Check to make sure we only retrieve the specified number of posts,
-        and that the most recent post comes first.
+        Same as the above test but imposes a limit that is smaller than the
+        total number of posts. Check to make sure we only retrieve the
+        specified number of posts, and that the most recent post comes first.
         """
         self.limit = 1
         browsefilterable_posts = self.sublanding_page.get_browsefilterable_posts(self.request, self.limit)

--- a/cfgov/v1/tests/models/test_sublanding_page.py
+++ b/cfgov/v1/tests/models/test_sublanding_page.py
@@ -38,9 +38,9 @@ class SublandingPageTestCase(TestCase):
         # order of retrieval in test situations, otherwise the `date_published`
         # can vary due to commit order
 
-        self.child1_of_post1 = AbstractFilterPage(title='child 1 of post 1', date_published=dt.datetime(2016, 9, 1))
-        self.child2_of_post1 = AbstractFilterPage(title='child 2 of post 1', date_published=dt.datetime(2016, 9, 2))
-        self.child1_of_post2 = AbstractFilterPage(title='child 1 of post 2', date_published=dt.datetime(2016, 9, 3))
+        self.child1_of_post1 = AbstractFilterPage(title='child 1 of post 1', date_published=dt.date(2016, 9, 1))
+        self.child2_of_post1 = AbstractFilterPage(title='child 2 of post 1', date_published=dt.date(2016, 9, 2))
+        self.child1_of_post2 = AbstractFilterPage(title='child 1 of post 2', date_published=dt.date(2016, 9, 3))
         helpers.save_new_page(self.child1_of_post1, self.post1)
         helpers.save_new_page(self.child2_of_post1, self.post1)
         helpers.save_new_page(self.child1_of_post2, self.post2)

--- a/cfgov/v1/tests/models/test_sublanding_page.py
+++ b/cfgov/v1/tests/models/test_sublanding_page.py
@@ -1,0 +1,89 @@
+import mock
+
+from unittest import TestCase
+from v1.models import SublandingPage, BrowseFilterablePage, AbstractFilterPage
+from wagtail.wagtailcore.blocks import StreamValue
+
+import scripts._atomic_helpers as atomic
+from v1.tests.wagtail_pages import helpers
+
+import datetime as dt
+
+
+class SublandingPageTestCase(TestCase):
+    """
+    This test case checks that the browse-filterable posts of a sublanding page are
+    properly retrieved.
+    """
+    def setUp(self):
+        self.request = mock.MagicMock()
+        self.request.site.hostname = 'localhost:8000'
+        self.limit = 10
+        self.sublanding_page = SublandingPage(title='title')
+
+        helpers.publish_page(child=self.sublanding_page)
+        self.post1 = BrowseFilterablePage(title='post 1')
+        self.post2 = BrowseFilterablePage(title='post 2')
+        # the content of this post has both a full_width_text and a filter_controls
+        self.post1.content = StreamValue(self.post1.content.stream_block,
+                                         [atomic.full_width_text, atomic.filter_controls], True)
+        # this one only has a filter_controls
+        self.post2.content = StreamValue(self.post1.content.stream_block,
+                                         [atomic.filter_controls], True)
+
+        helpers.save_new_page(self.post1, self.sublanding_page)
+        helpers.save_new_page(self.post2, self.sublanding_page)
+
+        # manually set the publication date of the posts to ensure consistent
+        # order of retrieval in test situations, otherwise the `date_published`
+        # can vary due to commit order
+
+        self.child1_of_post1 = AbstractFilterPage(title='child 1 of post 1', date_published=dt.datetime(2016, 9, 1))
+        self.child2_of_post1 = AbstractFilterPage(title='child 2 of post 1', date_published=dt.datetime(2016, 9, 2))
+        self.child1_of_post2 = AbstractFilterPage(title='child 1 of post 2', date_published=dt.datetime(2016, 9, 3))
+        helpers.save_new_page(self.child1_of_post1, self.post1)
+        helpers.save_new_page(self.child2_of_post1, self.post1)
+        helpers.save_new_page(self.child1_of_post2, self.post2)
+
+    def tearDown(self):
+
+        pass
+
+    def test_get_appropriate_descendants(self):
+        """
+        Check to make sure the descendants of the sublanding page are the correct
+        children that we saved during setup. The order of the retrieval should be
+        consistent with the order in which they were saved.
+        """
+
+        descendants = self.sublanding_page.get_appropriate_descendants(self.request.site.hostname)
+        self.assertEqual(descendants[0].title, self.sublanding_page.title)
+        self.assertEqual(descendants[1].title, self.post1.title)
+        self.assertEqual(descendants[2].title, self.child1_of_post1.title)
+        self.assertEqual(descendants[3].title, self.child2_of_post1.title)
+        self.assertEqual(descendants[4].title, self.post2.title)
+
+    def test_get_browsefilterable_posts(self):
+        """
+        Test to make sure the browsefilterable posts are retrieved correctly.
+        The posts should be retrieved in reverse chronological order, and if the
+        limit exceeds the total number of posts, all should be retrieved.
+        """
+        browsefilterable_posts = self.sublanding_page.get_browsefilterable_posts(self.request, self.limit)
+        self.assertEqual(len(browsefilterable_posts), 3)
+        # the first number in the tuple represents the order of the filter_controls form
+        # in the post's content field, so we test situations in which that order varies
+        self.assertEqual(('1', self.child1_of_post1), browsefilterable_posts[2])
+        self.assertEqual(('1', self.child2_of_post1), browsefilterable_posts[1])
+        self.assertEqual(('0', self.child1_of_post2), browsefilterable_posts[0])
+
+    def test_get_browsefilterable_posts_with_limit(self):
+        """
+        Same as the above test but imposes a limit that is smaller than the total number
+        of posts. Check to make sure we only retrieve the specified number of posts,
+        and that the most recent post comes first.
+        """
+        self.limit = 1
+        browsefilterable_posts = self.sublanding_page.get_browsefilterable_posts(self.request, self.limit)
+        self.assertEqual(1, len(browsefilterable_posts))
+        self.assertEqual(('0', self.child1_of_post2), browsefilterable_posts[0])


### PR DESCRIPTION
The get_browsefilterable_posts function had a mistake in it that would cause an uncaught exception if one of the intermediate calls to get_page_set returned None. That was fixed. Also, tests were written for get_browsefilterable_posts and get_appropriate_descendants functions.

## Additions

* test for get_appropriate_descendants
* test for get_browsefilterable_posts

## Changes

* in get_browsefilterable_posts, the filtered_controls dict accumulates the results of get_page_set via append so that it doesn't throw an error if that result is None.

## Testing

* two tests written as above

## Review

@richaagarwal @chosak @willbarton

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)

