### PR TITLE
Set up logging locally

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 ## Unreleased Changes
 
 ### Added
+- Logging configuration to `local.py`
 - Author names are now displayed in alphabetical order by last name, falls back on first name if necessary
 - Ability to output sharing links within an Image and Text 50/50 Group module
 - Google Optimize code on `find-a-housing-counselor` page

--- a/cfgov/cfgov/settings/local.py
+++ b/cfgov/cfgov/settings/local.py
@@ -42,3 +42,22 @@ else:
 STATIC_ROOT = REPOSITORY_ROOT.child('collectstatic')
 
 ALLOW_ADMIN_URL = DEBUG or os.environ.get('ALLOW_ADMIN_URL', False)
+
+
+LOGGING = {
+    'version': 1,
+    'disable_existing_loggers': False,
+    'handlers': {
+        'console': {
+            'level': 'INFO',
+            'class': 'logging.StreamHandler',
+        }
+    },
+    'loggers': {
+        '': {
+            'handlers': ['console'],
+            'level': 'INFO',
+            'propagate': True,
+        }
+    }
+}

--- a/cfgov/scripts/archive_events.py
+++ b/cfgov/scripts/archive_events.py
@@ -1,17 +1,14 @@
-import os
-from django.utils import timezone
-
-from django.conf import settings
-from django.contrib.auth.hashers import make_password
-from django.contrib.auth.models import User
-
 from v1.models.learn_page import EventPage
 from v1.models.browse_filterable_page import BrowseFilterablePage, EventArchivePage
-from wagtail.wagtailcore.models import Page
-from modelcluster.models import get_all_child_relations
+
+from django.utils import timezone
+from django.conf import settings
+import logging
+logger = logging.getLogger(__name__)
 
 
 def run():
+    logger.info('Searching for events to archive...')
     event_page_exists = BrowseFilterablePage.objects.filter(title='Events').exists()
     archive_event_page_exists = EventArchivePage.objects.filter(title__icontains='Archive').exists()
 
@@ -27,12 +24,12 @@ def run():
                         if event.end_dt < timezone.now():
                             if event.can_move_to(archived_events):
                                 event.move(archived_events, pos='last-child')
-                                print event.title + ' Event .....archived'
+                                loggger.info(event.title + ' Event .....archived')
         else:
-            print 'No events to archive found....'
+            logger.info('No events to archive found....')
     elif not event_page_exists:
-        print 'Events browse filterable page has not been created....'
+        logger.info('Events browse filterable page has not been created....')
     elif not archive_event_page_exists:
-        print 'No Archived events Browse filterable page named \'Archive\' exist....'
+        logger.info('No Archived events Browse filterable page named \'Archive\' exist....')
     else:
-        print 'No events exist in the database...'
+        logger.info('No events exist in the database...')


### PR DESCRIPTION
So that we don't have to use print statements.  I updated `archive_events` as an example, although I don't actually think we use it anymore. 

Run `python cfgov/manage.py runscript archive_events` to see the logging in action.

@cfpb/cfgov-backends 