### PR TITLE
Refactor page JS inclusion via Wagtail hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 
 ### Changed
 - Improved the help text in the Featured Content module in Wagtail.
+- `CFGOVPage.media` property is now a variable in the jinja2 context named `media`
+- `CFGOVPage.media` property methods are now in JSHandler
 
 ### Removed
 

--- a/cfgov/jinja2/v1/_layouts/base.html
+++ b/cfgov/jinja2/v1/_layouts/base.html
@@ -199,8 +199,8 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 
     {# TODO: Remove Else conditional when this is fully moved to wagtail. #}
     {# Check and include page-level JavaScript. #}
-    {% if page and page.media %}
-        {% for type, jsfiles in page.media.iteritems() %}
+    {% if page and media %}
+        {% for type, jsfiles in media.iteritems() %}
             {% for js in jsfiles %}
                 {% include '/js/routes/on-demand/' + js ignore missing %}
             {% endfor %}

--- a/cfgov/v1/handlers/js.py
+++ b/cfgov/v1/handlers/js.py
@@ -1,0 +1,88 @@
+from collections import OrderedDict
+from itertools import chain
+from wagtail.wagtailcore import blocks
+
+from ..handlers import Handler
+from v1.util import util
+
+
+class JSEnum:
+    atoms     = []
+    blocks    = []
+    molecules = []
+    organisms = [
+        'BaseExpandable',
+        'Expandable',
+        'ExpandableGroup',
+        'FilterControls',
+    ]
+
+
+class JSHandler(Handler):
+    """
+        Gathers all the JS files specific to this page and its current
+        Streamfields' blocks and sets them in the template context.
+    """
+    def __init__(self, page, request, context):
+        super(JSHandler, self).__init__(page, request, context)
+        atomic_types = ['template', 'organisms', 'molecules', 'atoms']
+        self.js_dict = OrderedDict([(at, []) for at in atomic_types])
+
+    def process(self):
+        """
+        Sets media in context to the configured js_dict.
+        """
+        self.set_js_dict()
+
+        if 'media' not in self.context:
+            self.context['media'] = self.js_dict
+
+        elif isinstance(self.context['media'], OrderedDict):
+            self.context['media'].update(self.js_dict)
+
+    def set_js_dict(self):
+        """
+        Sets the js_dict's keys to valid files.
+        """
+        self.js_dict['template'] = self.page.get_page_js()
+
+        blocks_dict = util.get_streamfields(self.page)
+        for child in chain(*blocks_dict.values()):
+            self.set_block_js(child.block)
+
+    def set_block_js(self, block):
+        """
+        Recursively search the blocks and classes for declared Media.js.
+        """
+        self.assign_js(block)
+
+        if issubclass(type(block), blocks.StructBlock):
+            for child in block.child_blocks.values():
+                self.set_block_js(child)
+
+        elif issubclass(type(block), blocks.ListBlock):
+            self.set_block_js(block.child_block)
+
+    def assign_js(self, obj):
+        """
+        Assign the obj.Media.js to the dictionary.
+        """
+        key = self.is_valid(obj)
+        if key:
+            self.js_dict[key] += [
+                name for name in obj.Media.js if name not in self.js_dict[key]
+            ]
+
+    def is_valid(self, obj):
+        """
+        Checks against the enum for the validity of the object's JS and returns
+        the key if it is.
+        """
+        if hasattr(obj, 'Media') and hasattr(obj.Media, 'js'):
+            class_name = obj.__class__.__name__
+
+            for key in self.js_dict:
+                approved_files = getattr(JSEnum, key, None)
+                if approved_files and class_name in approved_files:
+                    return key
+        return False

--- a/cfgov/v1/models/base.py
+++ b/cfgov/v1/models/base.py
@@ -365,62 +365,17 @@ class CFGOVPage(Page):
         user_perms = CFGOVUserPagePermissionsProxy(user)
         return user_perms.for_page(self)
 
-    class Meta:
-        app_label = 'v1'
-
     def parent(self):
         parent = self.get_ancestors(inclusive=False).reverse()[0].specific
         return parent
 
     # To be overriden if page type requires JS files every time
     # 'template' is used as the key for front-end consistency
-    def add_page_js(self, js):
-        js['template'] = []
+    def get_page_js(self):
+        return []
 
-    # Retrieves the stream values on a page from it's Streamfield
-    def _get_streamfield_blocks(self):
-        lst = [value for key, value in vars(self).iteritems()
-               if type(value) is StreamValue]
-        return list(chain(*lst))
-
-    # Gets the JS from the Streamfield data
-    def _add_streamfield_js(self, js):
-        # Create a dictionary with keys ordered organisms, molecules, then atoms
-        for child in self._get_streamfield_blocks():
-            self._add_block_js(child.block, js)
-
-    # Recursively search the blocks and classes for declared Media.js
-    def _add_block_js(self, block, js):
-        self._assign_js(block, js)
-        if issubclass(type(block), blocks.StructBlock):
-            for child in block.child_blocks.values():
-                self._add_block_js(child, js)
-        elif issubclass(type(block), blocks.ListBlock):
-            self._add_block_js(block.child_block, js)
-
-    # Assign the Media js to the dictionary appropriately
-    def _assign_js(self, obj, js):
-        try:
-            if hasattr(obj.Media, 'js'):
-                for key in js.keys():
-                    if obj.__module__.endswith(key):
-                        js[key] += obj.Media.js
-                if not [key for key in js.keys() if obj.__module__.endswith(key)]:
-                    js.update({'other': obj.Media.js})
-        except:
-            pass
-
-    # Returns all the JS files specific to this page and it's current Streamfield's blocks
-    @property
-    def media(self):
-        js = OrderedDict()
-        for key in ['template', 'organisms', 'molecules', 'atoms']:
-            js.update({key: []})
-        self.add_page_js(js)
-        self._add_streamfield_js(js)
-        for key, js_files in js.iteritems():
-            js[key] = OrderedDict.fromkeys(js_files).keys()
-        return js
+    class Meta:
+        app_label = 'v1'
 
 
 class CFGOVPageCategory(Orderable):

--- a/cfgov/v1/models/browse_filterable_page.py
+++ b/cfgov/v1/models/browse_filterable_page.py
@@ -50,9 +50,9 @@ class BrowseFilterablePage(FilterableFeedPageMixin, FilterableListMixin, CFGOVPa
 
     template = 'browse-filterable/index.html'
 
-    def add_page_js(self, js):
-        super(BrowseFilterablePage, self).add_page_js(js)
-        js['template'] += ['secondary-navigation.js']
+    def get_page_js(self):
+        files = super(BrowseFilterablePage, self).get_page_js()
+        return files + ['secondary-navigation.js']
 
 
 class EventArchivePage(BrowseFilterablePage):

--- a/cfgov/v1/models/browse_page.py
+++ b/cfgov/v1/models/browse_page.py
@@ -60,9 +60,9 @@ class BrowsePage(CFGOVPage):
 
     template = 'browse-basic/index.html'
 
-    def add_page_js(self, js):
-        super(BrowsePage, self).add_page_js(js)
-        js['template'] += ['secondary-navigation.js']
+    def get_page_js(self):
+        files = super(BrowsePage, self).get_page_js()
+        return files + ['secondary-navigation.js']
 
     def full_width_serif(self):
         return true

--- a/cfgov/v1/tests/handlers/test_handler.py
+++ b/cfgov/v1/tests/handlers/test_handler.py
@@ -1,6 +1,6 @@
 import mock
 from unittest import TestCase
-from ...handlers import Handler
+from v1.handlers import Handler
 
 
 class TestHandler(TestCase):

--- a/cfgov/v1/tests/handlers/test_js.py
+++ b/cfgov/v1/tests/handlers/test_js.py
@@ -1,0 +1,111 @@
+import mock
+from collections import OrderedDict
+from unittest import TestCase
+from v1.handlers.js import JSHandler
+
+
+class TestJSHandler(TestCase):
+    def setUp(self):
+        self.page = mock.Mock()
+        self.request = mock.Mock()
+        self.context = {}
+        self.handler = JSHandler(self.page, self.request, self.context)
+
+    @mock.patch('v1.handlers.js.JSHandler.set_js_dict')
+    def test_process_calls_set_js_dict(self, mock_set_js_dict):
+        self.handler.process()
+        self.assertTrue(mock_set_js_dict.called)
+
+    @mock.patch('v1.handlers.js.JSHandler.set_js_dict')
+    def test_process_sets_context_media_to_OrderedDict(self, mock_set_js_dict):
+        self.handler.process()
+        self.assertIn('media', self.context)
+        self.assertIsInstance(self.context['media'], OrderedDict)
+
+    @mock.patch('v1.handlers.js.util')
+    def test_set_js_dict_sets_context_to_get_page_js(self, mock_util):
+        self.handler.set_js_dict()
+        self.assertIn('template', self.handler.js_dict)
+        self.assertEqual(self.handler.page.get_page_js(), self.handler.js_dict['template'])
+
+    @mock.patch('v1.handlers.js.util')
+    def test_set_js_dict_calls_util_get_streamfields(self, mock_util):
+        js_dict = self.handler.set_js_dict()
+        self.assertTrue(mock_util.get_streamfields.called)
+
+    @mock.patch('v1.handlers.js.chain')
+    @mock.patch('v1.handlers.js.util')
+    @mock.patch('v1.handlers.js.JSHandler.set_block_js')
+    def test_set_js_dict_calls_set_block_js_on_each_block(self, mock_set_block_js, mock_util, mock_chain):
+        child = mock.Mock()
+        mock_chain.return_value = [child] * 5
+        self.handler.set_js_dict()
+        mock_set_block_js.assert_called_with(child.block)
+        self.assertEqual(mock_set_block_js.call_count, 5)
+
+    # TODO: Test recursive method JSHandler.set_block_js
+
+    # @mock.patch('__builtin__.issubclass')
+    # @mock.patch('v1.handlers.js.JSHandler.assign_js')
+    # def test_set_block_js_calls_assign_js(self, mock_assign_js, mock_issubclass):
+    #     mock_issubclass.return_value = False
+    #     block = mock.Mock()
+    #     self.handler.set_block_js(block)
+    #     mock_assign_js.assert_called_with(block)
+
+    # @mock.patch('__builtin__.issubclass')
+    # @mock.patch('v1.handlers.js.JSHandler.assign_js')
+    # def test_set_block_js_calls_set_block_js_for_each_child(self, mock_assign_js, mock_issubclass):
+    #     import pdb; pdb.set_trace()
+    #     block = mock.Mock()
+    #     child_block = mock.Mock()
+    #     block.child_blocks.values.return_value = [child_block] * 5
+    #     copy_sbj = JSHandler.set_block_js
+    #     self.handler.set_block_js = mock.Mock()
+    #     copy_sbj(self.handler, block)
+    #     mock_set_block_js.assert_called_with(child_block)
+    #     self.assertEqual(self.handler.set_block_js.call_count, 5)
+
+    @mock.patch('v1.handlers.js.JSHandler.is_valid')
+    def test_assign_js_calls_is_valid(self, mock_is_valid):
+        obj = mock.Mock()
+        mock_is_valid.return_value = False
+        self.handler.assign_js(obj)
+        mock_is_valid.assert_called_with(obj)
+
+    @mock.patch('v1.handlers.js.JSHandler.is_valid')
+    def test_assign_js_adds_objMediajs_uniquely(self, mock_is_valid):
+        obj = mock.Mock()
+        obj.Media.js = ['one', 'two', 'three']
+        mock_is_valid.return_value = 'atoms'
+        self.handler.js_dict['atoms'] = ['one']
+        self.handler.assign_js(obj)
+        mock_is_valid.assert_called_with(obj)
+        self.assertEqual(self.handler.js_dict['atoms'], ['one', 'two', 'three'])
+
+    def test_is_valid_returns_False_if_object_doesnt_have_Media(self):
+        obj = mock.Mock()
+        result = self.handler.is_valid(obj)
+        self.assertFalse(result)
+
+    def test_is_valid_returns_False_if_objectMedia_doesnt_have_js(self):
+        obj = mock.Mock()
+        obj.Media = '1'
+        result = self.handler.is_valid(obj)
+        self.assertFalse(result)
+
+    def test_is_valid_returns_False_if_obj_classname_not_in_JSEnum_key(self):
+        obj = mock.Mock()
+        obj.Media.js = ['file.js']
+        obj.__class__.__name__ = 'classname'
+        result = self.handler.is_valid(obj)
+        self.assertFalse(result)
+
+    @mock.patch('v1.handlers.js.JSEnum')
+    def test_is_valid_returns_True_if_obj_classname_in_JSEnum_key(self, mock_enum):
+        mock_enum.atoms = ['classname']
+        obj = mock.Mock()
+        obj.Media.js = ['file.js']
+        obj.__class__.__name__ = 'classname'
+        result = self.handler.is_valid(obj)
+        self.assertTrue(result)

--- a/cfgov/v1/wagtail_hooks.py
+++ b/cfgov/v1/wagtail_hooks.py
@@ -19,6 +19,7 @@ from wagtail.wagtailcore.models import Page
 
 from .models import CFGOVPage
 from .util import util
+from v1.handlers.js import JSHandler
 
 logger = logging.getLogger(__name__)
 
@@ -222,3 +223,8 @@ def form_module_handlers(page, request, context, *args, **kwargs):
 
     if form_modules:
         context['form_modules'] = form_modules
+
+
+@hooks.register('cfgovpage_context_handlers')
+def register_js_handler(page, request, context, *args, **kwargs):
+    JSHandler(page, request, context).process()


### PR DESCRIPTION
This changes the inclusion of page/streamfield media object into the jinja2 context. It just pulls the code from the CFGOVPage and puts it into a handler class for cleaner code.

## Additions

- Handler and JSHandler classes

## Changes

- Move JS handling logic into JSHandler class from CFGOVPage

## Testing

- `tox`

## Review

- @chosak 
- @Scotchester 
- @cfpb/cfgov-backends 

## TODO 

- Add tests for JSHandler.set_block_js method.
#
## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)

