### PR TITLE
Fix menu on no-js base_nonresponsive/base_update pages

### DIFF
--- a/cfgov/legacy/static/nemo/_/c/styles.css
+++ b/cfgov/legacy/static/nemo/_/c/styles.css
@@ -3354,3 +3354,8 @@ Not in CF docs yet..
 	color: black;
 	letter-spacing: 0;
 }
+
+/* Mega menu link hover state */
+.o-mega-menu a:hover {
+	background-color: transparent;
+}

--- a/cfgov/legacy/templates/front/base_nonresponsive.html
+++ b/cfgov/legacy/templates/front/base_nonresponsive.html
@@ -26,7 +26,8 @@ please send an email with your full name to tech@cfpb.gov.
 <!--[if IE 7]>    <html class="no-js lt-ie9 lt-ie8" dir="ltr" lang="{% trans "en-US" %}"> <![endif]-->
 <!--[if IE 8]>    <html class="no-js lt-ie9" dir="ltr" lang="{% trans "en-US" %}"> <![endif]-->
 <!-- Consider adding a manifest.appcache: h5bp.com/d/Offline -->
-<!--[if gt IE 8]><!--> <html dir="ltr" lang="{% trans "en-US" %}"> <!--<![endif]-->
+<!--[if gt IE 8]><!--> <html dir="ltr" lang="{% trans "en-US" %}" class="no-js"> <!--<![endif]-->
+
 
 <head prefix="og: http://ogp.me/ns# fb: http://ogp.me/ns/fb#">
     <meta charset="utf-8">
@@ -123,6 +124,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <!-- End Google Tag Manager -->
 {% endblock %}
 <script src="{% static 'js/modernizr.min.js'  %}"></script>
+
 
 
 <!--[if lt IE 9]>

--- a/cfgov/legacy/templates/front/base_update.html
+++ b/cfgov/legacy/templates/front/base_update.html
@@ -24,7 +24,7 @@ please send an email with your full name to tech@cfpb.gov.
 <!--[if IE 7]>    <html class="no-js lt-ie9 lt-ie8" dir="ltr" lang="{% trans "en-US" %}"> <![endif]-->
 <!--[if IE 8]>    <html class="no-js lt-ie9" dir="ltr" lang="{% trans "en-US" %}"> <![endif]-->
 <!-- Consider adding a manifest.appcache: h5bp.com/d/Offline -->
-<!--[if gt IE 8]><!--> <html dir="ltr" lang="{% trans "en-US" %}"> <!--<![endif]-->
+<!--[if gt IE 8]><!--> <html dir="ltr" lang="{% trans "en-US" %}" class="no-js"> <!--<![endif]-->
 
 <head prefix="og: http://ogp.me/ns# fb: http://ogp.me/ns/fb#">
 


### PR DESCRIPTION
When Javascript is turned off on pages that use the `base_nonresponsive.html` template (like `find-a-housing-counselor`) or `base_update.html`  template (like `askcfpb`), the menu loads open and won't close

## Additions

- Add `no-js` class to `<html>` in `base_nonresponsive.html` template
- Add `no-js` class to `<html>` in `base_update.html` template
- Override hover state background color for menu links in legacy `styles.less`

## Testing

- Check out branch
- Turn off js in browser
- Navigate to [http://localhost:8000/find-a-housing-counselor](http://localhost:8000/find-a-housing-counselor) and [http://localhost:8000/askcfpb](http://localhost:8000/askcfpb) and verify that: 
  - menu is not open on load & behaves as expected
  - menu links don't have background color on hover

## Review

- @cfpb/cfgov-frontends 

## Screenshots

Before:

<img width="1286" alt="screen shot 2016-09-15 at 3 34 51 pm" src="https://cloud.githubusercontent.com/assets/778171/18570027/8d3e6dda-7b5b-11e6-9e06-1242f76943b0.png">

After: 

On load:

<img width="1280" alt="screen shot 2016-09-15 at 3 33 36 pm" src="https://cloud.githubusercontent.com/assets/778171/18570065/e1314f98-7b5b-11e6-9558-def75f3d9dce.png">

On hover:

<img width="1277" alt="screen shot 2016-09-15 at 3 33 44 pm" src="https://cloud.githubusercontent.com/assets/778171/18570064/dc50477c-7b5b-11e6-8c7a-d5d0a21d628c.png">



## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)

so menu will work when js is turned off, and remove menu link hover
state background color on nonresponsive pages.