### PR TITLE
Try parallel testing and caching

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: python
 
+cache: pip
+
 python:
   - "2.7"
 
@@ -12,12 +14,12 @@ install:
   # Project configuration requirements.
   - pip install virtualenv virtualenvwrapper
   - pip install autoenv
+  - pip install coveralls
   - export CXX=clang++
   - curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.31.0/install.sh | bash
   - nvm install 5.5.0
   - nvm use 5.5.0
   - npm install -g gulp
-  - pip install coveralls
 
   # Project initialization.
   - chmod +x ./setup.sh
@@ -26,11 +28,8 @@ install:
   - python cfgov/manage.py migrate
 
 env:
-  - TOXENV=py27
-  - DJANGO_SETTINGS_MODULE=cfgov.settings.test
-  - WORDPRESS=http://www.consumerfinance.gov
-  - DJANGO_STAGING_HOSTNAME=content.localhost
-  - COVERALLS_PARALLEL=true
+  - TOXENV=py27 DJANGO_SETTINGS_MODULE=cfgov.settings.test WORDPRESS=http://www.consumerfinance.gov DJANGO_STAGING_HOSTNAME=content.localhost
+COVERALLS_PARALLEL=true
   - GULP_TEST="lint"
   - GULP_TEST="test:unit"
   - GULP_TEST="test:coveralls"

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,8 +28,7 @@ install:
   - python cfgov/manage.py migrate
 
 env:
-  - TOXENV=py27 DJANGO_SETTINGS_MODULE=cfgov.settings.test WORDPRESS=http://www.consumerfinance.gov DJANGO_STAGING_HOSTNAME=content.localhost
-COVERALLS_PARALLEL=true
+  - TOXENV=py27 DJANGO_SETTINGS_MODULE=cfgov.settings.test WORDPRESS=http://www.consumerfinance.gov DJANGO_STAGING_HOSTNAME=content.localhost COVERALLS_PARALLEL=true
   - GULP_TEST="lint"
   - GULP_TEST="test:unit"
   - GULP_TEST="test:coveralls"

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,12 +25,22 @@ install:
   - python cfgov/manage.py sheer_index
   - python cfgov/manage.py migrate
 
-script:
-  - gulp lint
-  - gulp test:unit
-  - gulp test:coveralls
-
 env:
-    - TOXENV=py27 DJANGO_SETTINGS_MODULE=cfgov.settings.test WORDPRESS=http://www.consumerfinance.gov DJANGO_STAGING_HOSTNAME=content.localhost COVERALLS_PARALLEL=true
+  - TOXENV=py27
+  - DJANGO_SETTINGS_MODULE=cfgov.settings.test
+  - WORDPRESS=http://www.consumerfinance.gov
+  - DJANGO_STAGING_HOSTNAME=content.localhost
+  - COVERALLS_PARALLEL=true
+  - GULP_TEST="lint"
+  - GULP_TEST="test:unit"
+  - GULP_TEST="test:coveralls"
+
+script:
+  - gulp $GULP_TEST
+
 after_success:
+  - coverage combine
   - coveralls
+
+notifications:
+  webhooks: https://coveralls.io/webhook?repo_token=COVERALLS_REPO_TOKEN

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,8 @@ install:
   # Project initialization.
 
 env:
-  - TOXENV=py27 DJANGO_SETTINGS_MODULE=cfgov.settings.test WORDPRESS=http://www.consumerfinance.gov DJANGO_STAGING_HOSTNAME=content.localhost COVERALLS_PARALLEL=true
+  - TOXENV=py27 DJANGO_SETTINGS_MODULE=cfgov.settings.test WORDPRESS=http://www.consumerfinance.gov DJANGO_STAGING_HOSTNAME=content.localhost
+  # COVERALLS_PARALLEL=true
   - GULP_TEST="lint"
   - GULP_TEST="test:unit"
   - GULP_TEST="test:coveralls"
@@ -42,5 +43,5 @@ after_success:
   - coverage combine
   - coveralls
 
-notifications:
-  webhooks: https://coveralls.io/webhook?repo_token=COVERALLS_REPO_TOKEN
+# notifications:
+#   webhooks: https://coveralls.io/webhook?repo_token=COVERALLS_REPO_TOKEN

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,16 +28,18 @@ install:
 env:
   - TOXENV=py27 DJANGO_SETTINGS_MODULE=cfgov.settings.test WORDPRESS=http://www.consumerfinance.gov DJANGO_STAGING_HOSTNAME=content.localhost
   # COVERALLS_PARALLEL=true
-  - GULP_TEST="lint"
-  - GULP_TEST="test:unit"
-  - GULP_TEST="test:coveralls"
+  # - GULP_TEST="lint"
+  # - GULP_TEST="test:unit"
+  # - GULP_TEST="test:coveralls"
 
 before_script:
   - python cfgov/manage.py sheer_index
   - python cfgov/manage.py migrate
 
 script:
-  - gulp $GULP_TEST
+  - gulp lint
+  - gulp test:unit
+  - gulp test:coveralls
 
 after_success:
   - coverage combine

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: python
 
-cache: pip
-
 python:
   - "2.7"
+
+cache: pip
 
 sudo: false
 
@@ -20,18 +20,20 @@ install:
   - nvm install 5.5.0
   - nvm use 5.5.0
   - npm install -g gulp
-
-  # Project initialization.
   - chmod +x ./setup.sh
   - ./setup.sh test
-  - python cfgov/manage.py sheer_index
-  - python cfgov/manage.py migrate
+
+  # Project initialization.
 
 env:
   - TOXENV=py27 DJANGO_SETTINGS_MODULE=cfgov.settings.test WORDPRESS=http://www.consumerfinance.gov DJANGO_STAGING_HOSTNAME=content.localhost COVERALLS_PARALLEL=true
   - GULP_TEST="lint"
   - GULP_TEST="test:unit"
   - GULP_TEST="test:coveralls"
+
+before_script:
+  - python cfgov/manage.py sheer_index
+  - python cfgov/manage.py migrate
 
 script:
   - gulp $GULP_TEST

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # cfgov-refresh
 
-[![Build Status](https://travis-ci.org/cfpb/cfgov-refresh.png?branch=flapjack)](https://travis-ci.org/cfpb/cfgov-refresh?branch=flapjack)
-[![Code Climate](https://codeclimate.com/github/cfpb/cfgov-refresh.png?branch=flapjack)](https://codeclimate.com/github/cfpb/cfgov-refresh?branch=flapjack)
+[![Build Status](https://travis-ci.org/cfpb/cfgov-refresh.png?branch=master)](https://travis-ci.org/cfpb/cfgov-refresh?branch=master)
+[![Code Climate](https://codeclimate.com/github/cfpb/cfgov-refresh.png?branch=master)](https://codeclimate.com/github/cfpb/cfgov-refresh?branch=master)
 [![Coverage Status](https://coveralls.io/repos/github/cfpb/cfgov-refresh/badge.svg?branch=master)](https://coveralls.io/github/cfpb/cfgov-refresh?branch=master)
 
 The redesign of the [www.consumerfinance.gov](http://www.consumerfinance.gov) website.


### PR DESCRIPTION
In hopes of speeding up test runs, this takes a shot at running parallel
tests, caching pip installs between runs and combining the coverage
reports. If this doesn't help, we could try caching specific directories.

This also fixes branch specifiers for the build and code climate badges, 
which were still pointed at the  flapjack branch.

## Changes

- New travis configs
- README badges

- @chosak @sebworks 
