### PR TITLE
Add jobmanager app to CFGOVRouter

### DIFF
--- a/cfgov/v1/db_router.py
+++ b/cfgov/v1/db_router.py
@@ -6,7 +6,7 @@ cfgov_apps = [
     'v1',
     'flags',
     'taggit',
-    'jobmanager',
+    'jobmanager'
 ]
 
 

--- a/cfgov/v1/db_router.py
+++ b/cfgov/v1/db_router.py
@@ -6,6 +6,7 @@ cfgov_apps = [
     'v1',
     'flags',
     'taggit',
+    'jobmanager',
 ]
 
 

--- a/cfgov/v1/tests/test_db_router.py
+++ b/cfgov/v1/tests/test_db_router.py
@@ -1,0 +1,28 @@
+from django.apps import apps
+from django.test import TestCase
+
+from v1.db_router import CFGOVRouter, cfgov_apps
+
+
+class CFGOVRouterTestCase(TestCase):
+    def check_app_router(self, app, method_name, expected_db):
+        router = CFGOVRouter()
+        method = getattr(router, method_name)
+
+        models = apps.get_app_config(app).get_models()
+        for model in models:
+            self.assertEqual(method(model), expected_db)
+
+    def test_cfgov_apps_read_from_default_db(self):
+        for app in cfgov_apps:
+            self.check_app_router(app, 'db_for_read', 'default')
+
+    def test_cfgov_apps_write_to_default_db(self):
+        for app in cfgov_apps:
+            self.check_app_router(app, 'db_for_write', 'default')
+
+    def test_other_app_reads_are_not_routed(self):
+        self.check_app_router('messages', 'db_for_read', None)
+
+    def test_other_app_writes_are_not_routed(self):
+        self.check_app_router('messages', 'db_for_write', None)


### PR DESCRIPTION
Models for the `jobmanager` app should go to/from the `default` database on the content server, so that they can be edited and shared/published properly in the Wagtail editor.

## Additions

- New unit tests for the `CFGOVRouter` database router.

## Changes

- Adds the `jobmanager` app to the list of apps covered by `CFGOVRouter`.

## Testing

- Testing this properly locally is difficult because we don't have a way to reproduce the multi-database setup. There are new unit tests (`tox`) that test the router itself. This change mirrors the existing structure which works for other apps.

## Review

- @rosskarchner @willbarton 

## Checklist

* [X] Changes are limited to a single goal (no scope creep)
* [X] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [X] Passes all existing automated tests
* [X] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)

