### PR TITLE
Return redirect when retrieving Downloads from S3

### DIFF
--- a/cfgov/cfgov/test.py
+++ b/cfgov/cfgov/test.py
@@ -5,43 +5,32 @@ import re
 
 from django.apps import apps
 from django.test.runner import DiscoverRunner
-from wagtail.wagtailcore.models import Page
-
-from scripts import initial_data
 
 
 class TestDataTestRunner(DiscoverRunner):
     def setup_databases(self, **kwargs):
         dbs = super(TestDataTestRunner, self).setup_databases(**kwargs)
 
-        if not self.check_for_wagtail_root():
-            self.setup_wagtail_root()
+        migration_methods = (
+            (
+                'wagtail.wagtailcore.migrations.0002_initial_data',
+                'initial_data'
+            ),
+            (
+                'wagtail.wagtailcore.migrations.0025_collection_initial_data',
+                'initial_data'
+            ),
+            (
+                'v1.migrations.0009_site_root_data',
+                'create_site_root'
+            ),
+        )
 
-        if not self.check_for_cfgov_root():
-            self.setup_cfgov_root()
+        for migration, method in migration_methods:
+            module = importlib.import_module(migration)
+            getattr(module, method)(apps, None)
 
-        initial_data.run()
         return dbs
-
-    def check_for_wagtail_root(self):
-        return Page.objects.filter(slug='root').exists()
-
-    def setup_wagtail_root(self):
-        migration = 'wagtail.wagtailcore.migrations.0002_initial_data'
-        print('Running migration {} to setup Wagtail root'.format(migration))
-
-        module = importlib.import_module(migration)
-        module.initial_data(apps, None)
-
-    def check_for_cfgov_root(self):
-        return Page.objects.filter(slug='cfgov').exists()
-
-    def setup_cfgov_root(self):
-        migration = 'v1.migrations.0009_site_root_data'
-        print('Running migration {} to setup CFGOV root'.format(migration))
-
-        module = importlib.import_module(migration)
-        module.create_site_root(apps, None)
 
 
 class HtmlMixin(object):

--- a/cfgov/cfgov/urls.py
+++ b/cfgov/cfgov/urls.py
@@ -1,7 +1,5 @@
 import os
 
-from functools import partial
-
 from django.contrib import admin
 from django.contrib.auth import views as auth_views
 from django.conf import settings
@@ -9,24 +7,23 @@ from django.conf.urls.static import static
 from django.conf.urls import include, url
 from django.views.generic.base import TemplateView, RedirectView
 from django.http import HttpResponse
-
-from legacy.views import HousingCounselorPDFView, dbrouter_shortcut, token_provider
-from sheerlike.views.generic import SheerTemplateView
-from sheerlike.sites import SheerSite
-from sheerlike.middleware import GlobalRequestMiddleware
-
-from v1.views import unshare, change_password, \
-                     password_reset_confirm, login_with_lockout,\
-                     check_permissions, welcome
-from v1.views.documents import DocumentServeView
-from v1.auth_forms import CFGOVPasswordChangeForm
-
-
+from functools import partial
 from wagtail.wagtailadmin import urls as wagtailadmin_urls
-from wagtail.wagtaildocs import urls as wagtaildocs_urls
 from wagtail.wagtailcore import urls as wagtail_urls
 
+from legacy.views import (
+    HousingCounselorPDFView, dbrouter_shortcut, token_provider
+)
+from sheerlike.views.generic import SheerTemplateView
+from sheerlike.sites import SheerSite
 from transition_utilities.conditional_urls import include_if_app_enabled
+from v1.auth_forms import CFGOVPasswordChangeForm
+from v1.views import (
+    change_password, check_permissions, login_with_lockout,
+    password_reset_confirm, unshare, welcome
+)
+from v1.views.documents import DocumentServeView
+
 
 fin_ed = SheerSite('fin-ed-resources')
 
@@ -34,7 +31,7 @@ urlpatterns = [
 
     url(r'^documents/(?P<document_id>\d+)/(?P<document_filename>.*)$',
         DocumentServeView.as_view(),
-        name='document_serve'),
+        name='wagtaildocs_serve'),
 
     # TODO: Enable search route when search is available.
     # url(r'^search/$', 'search.views.search', name='search'),

--- a/cfgov/cfgov/urls.py
+++ b/cfgov/cfgov/urls.py
@@ -18,6 +18,7 @@ from sheerlike.middleware import GlobalRequestMiddleware
 from v1.views import unshare, change_password, \
                      password_reset_confirm, login_with_lockout,\
                      check_permissions, welcome
+from v1.views.documents import DocumentServeView
 from v1.auth_forms import CFGOVPasswordChangeForm
 
 
@@ -31,7 +32,10 @@ fin_ed = SheerSite('fin-ed-resources')
 
 urlpatterns = [
 
-    url(r'^documents/', include(wagtaildocs_urls)),
+    url(r'^documents/(?P<document_id>\d+)/(?P<document_filename>.*)$',
+        DocumentServeView.as_view(),
+        name='document_serve'),
+
     # TODO: Enable search route when search is available.
     # url(r'^search/$', 'search.views.search', name='search'),
 

--- a/cfgov/v1/tests/views/test_documents.py
+++ b/cfgov/v1/tests/views/test_documents.py
@@ -1,0 +1,54 @@
+from mock import Mock, patch
+
+from django.core.files.base import ContentFile
+from django.http import Http404
+from django.test import TestCase, override_settings
+from wagtail.wagtaildocs.models import get_document_model
+
+from v1.views.documents import DocumentServeView
+
+
+class ServeViewTestCase(TestCase):
+    def setUp(self):
+        self.view = DocumentServeView()
+        self.request = Mock()
+
+    def create_document(self, filename):
+        Document = get_document_model()
+        document = Document(title='Test document')
+        document.file.save(filename, ContentFile('Some content'))
+        return document
+
+    def test_local_document_uses_wagtail_serve(self):
+        filename = 'test.txt'
+        doc = self.create_document(filename)
+
+        with patch('v1.views.documents.wagtail_serve') as p:
+            self.view.get(self.request, doc.pk, filename)
+            p.assert_called_once_with(self.request, doc.pk, filename)
+
+    @override_settings(
+        AWS_QUERYSTRING_AUTH=False,
+        AWS_STORAGE_BUCKET_NAME='test_s3_bucket',
+        AWS_S3_CALLING_FORMAT='boto.s3.connection.OrdinaryCallingFormat',
+        AWS_S3_SECURE_URLS=False,
+        DEFAULT_FILE_STORAGE='v1.s3utils.MediaRootS3BotoStorage',
+        MEDIA_URL='https://test.s3.amazonaws.com/f/',
+        AWS_S3_ACCESS_KEY_ID='test-access-key',
+        AWS_S3_SECRET_ACCESS_KEY='test-secret-access-key'
+    )
+    def test_document_serve_view_s3(self):
+        filename = 'test.txt'
+        with patch('v1.s3utils.S3BotoStorage._save', return_value=filename):
+            doc = self.create_document(filename)
+
+        response = self.view.get(self.request, doc.pk, filename)
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(
+            response['Location'],
+            'http://s3.amazonaws.com/test_s3_bucket/f/test.txt'
+        )
+
+    def test_missing_document_returns_404(self):
+        with self.assertRaises(Http404):
+            self.view.get(self.request, 9999, 'missing.txt')

--- a/cfgov/v1/tests/views/test_documents.py
+++ b/cfgov/v1/tests/views/test_documents.py
@@ -1,6 +1,7 @@
 from mock import Mock, patch
 
 from django.core.files.base import ContentFile
+from django.core.urlresolvers import resolve, reverse
 from django.http import Http404
 from django.test import TestCase, override_settings
 from wagtail.wagtaildocs.models import get_document_model
@@ -8,20 +9,21 @@ from wagtail.wagtaildocs.models import get_document_model
 from v1.views.documents import DocumentServeView
 
 
+def create_document(filename):
+    Document = get_document_model()
+    document = Document(title='Test document')
+    document.file.save(filename, ContentFile('Some content'))
+    return document
+
+
 class ServeViewTestCase(TestCase):
     def setUp(self):
         self.view = DocumentServeView()
         self.request = Mock()
 
-    def create_document(self, filename):
-        Document = get_document_model()
-        document = Document(title='Test document')
-        document.file.save(filename, ContentFile('Some content'))
-        return document
-
     def test_local_document_uses_wagtail_serve(self):
         filename = 'test.txt'
-        doc = self.create_document(filename)
+        doc = create_document(filename)
 
         with patch('v1.views.documents.wagtail_serve') as p:
             self.view.get(self.request, doc.pk, filename)
@@ -40,7 +42,7 @@ class ServeViewTestCase(TestCase):
     def test_document_serve_view_s3(self):
         filename = 'test.txt'
         with patch('v1.s3utils.S3BotoStorage._save', return_value=filename):
-            doc = self.create_document(filename)
+            doc = create_document(filename)
 
         response = self.view.get(self.request, doc.pk, filename)
         self.assertEqual(response.status_code, 302)
@@ -52,3 +54,15 @@ class ServeViewTestCase(TestCase):
     def test_missing_document_returns_404(self):
         with self.assertRaises(Http404):
             self.view.get(self.request, 9999, 'missing.txt')
+
+
+class ServeUrlTestCase(TestCase):
+    def test_url_reverse(self):
+        self.assertEqual(
+            reverse('document_serve', args=('123', 'example.doc')),
+            '/documents/123/example.doc'
+        )
+
+    def test_url_resolve(self):
+        view = resolve('/documents/123/example.doc')
+        self.assertEqual(view.func.func_name, 'DocumentServeView')

--- a/cfgov/v1/tests/views/test_documents.py
+++ b/cfgov/v1/tests/views/test_documents.py
@@ -59,7 +59,7 @@ class ServeViewTestCase(TestCase):
 class ServeUrlTestCase(TestCase):
     def test_url_reverse(self):
         self.assertEqual(
-            reverse('document_serve', args=('123', 'example.doc')),
+            reverse('wagtaildocs_serve', args=('123', 'example.doc')),
             '/documents/123/example.doc'
         )
 

--- a/cfgov/v1/views/__init__.py
+++ b/cfgov/v1/views/__init__.py
@@ -29,11 +29,13 @@ from wagtail.wagtailadmin.views import account
 from wagtail.wagtailusers.views.users import add_user_perm, change_user_perm
 from wagtail.wagtailadmin.utils import permission_required
 
-from .auth_forms import CFGOVSetPasswordForm, CFGOVPasswordChangeForm, LoginForm
-
-from .util.util import valid_destination_for_request,\
-                       all_valid_destinations_for_request
-from .signals import page_unshared
+from v1.auth_forms import (
+    CFGOVPasswordChangeForm, CFGOVSetPasswordForm, LoginForm
+)
+from v1.signals import page_unshared
+from v1.util.util import (
+    all_valid_destinations_for_request, valid_destination_for_request
+)
 
 
 class EventICSView(ICSView):
@@ -249,7 +251,7 @@ def custom_password_reset_confirm(request, uidb64=None, token=None,
 def welcome(request):
     valid_destinations = all_valid_destinations_for_request(request)
 
-    
+
     if len(valid_destinations) == 1:
         redirect_to = valid_destinations[0][1]
         return HttpResponseRedirect(redirect_to)

--- a/cfgov/v1/views/documents.py
+++ b/cfgov/v1/views/documents.py
@@ -1,0 +1,40 @@
+from django.http import HttpResponseRedirect
+from django.shortcuts import get_object_or_404
+from django.views.generic import View
+from urlparse import urlparse
+from wagtail.wagtaildocs.views.serve import serve as wagtail_serve
+from wagtail.wagtaildocs.models import get_document_model
+
+
+class DocumentServeView(View):
+    """Serve a non-local document by returning a redirect to its URL.
+
+    Local files are served using the standard Wagtail document serve view.
+    URL query string parameters are removed before the redirect is returned.
+    """
+    def get(self, request, document_id, document_filename):
+        document = self.get_document_or_404(document_id)
+
+        if self.is_local_file(document):
+            return wagtail_serve(request, document_id, document_filename)
+        else:
+            return self.redirect_to_file_url(request, document)
+
+    def get_document_or_404(self, document_id):
+        Document = get_document_model()
+        return get_object_or_404(Document, id=document_id)
+
+    def is_local_file(self, document):
+        try:
+            return document.file.path
+        except NotImplementedError:
+            pass
+
+    def redirect_to_file_url(self, request, document):
+        url = self.remove_url_query_string(document.file.url)
+        return HttpResponseRedirect(url)
+
+    @staticmethod
+    def remove_url_query_string(url):
+        parts = urlparse(url)
+        return parts.scheme + '://' + parts.netloc + parts.path

--- a/cfgov/v1/views/documents.py
+++ b/cfgov/v1/views/documents.py
@@ -1,5 +1,4 @@
-from django.http import HttpResponseRedirect
-from django.shortcuts import get_object_or_404
+from django.shortcuts import get_object_or_404, redirect
 from django.views.generic import View
 from urlparse import urlparse
 from wagtail.wagtaildocs.views.serve import serve as wagtail_serve
@@ -32,7 +31,7 @@ class DocumentServeView(View):
 
     def redirect_to_file_url(self, request, document):
         url = self.remove_url_query_string(document.file.url)
-        return HttpResponseRedirect(url)
+        return redirect(url, permanent=False)
 
     @staticmethod
     def remove_url_query_string(url):


### PR DESCRIPTION
Current Wagtail behavior for downloads from a remote file storage (e.g. S3) is to load the file contents and serve them as a Django `StreamingHttpResponse`. This can be inefficient and also breaks the file content-type, preventing browsers from e.g. displaying PDFs naturally.

This PR modifies file download behavior so that requests to download a remote file (e.g. `/downloads/pk/filename`) return a (temporary) redirect to the S3 location, e.g. `http://s3.amazonaws.com/bucketname/f/documents/filename`.

Local file serving behavior is not modified when running in debug mode.

## Additions

- New `v1.views.documents.DocumentServeView` view class that handles non-local file downloads by returning a redirect, and passes local file downloads off to the built-in `wagtail.wagtaildocs.views.serve` method.

## Changes

- I cleaned up our `cgfov.test.TestDataTestRunner` class a bit to be more clear about why it is running certain data migrations. I also added `wagtailcore_0025` to this list because testing the `Download` class requires at least one `Collection`. 

## Testing

- With a new local database:
 - Go to [the CFGOV root](http://localhost:8000/admin/pages/3/).
 - Select "Add child page".
 - Choose "Document Detail Page".
 - Give the page a title, and then edit the "Full width text" in the Content section.
 - Edit the "Content" element.
 - Click on the little page icon (third from left in the second row) to open the "Choose a Document" dialog.
 - Go to "Upload" and seelct some local PDF to use for testing.
 - Preview the page and note that the link should appear something like `http://localhost:8000/documents/3/filename.pdf`.
 - Now curl that link, and notice that it returns the file contents directly (using the built-in Wagtail handling).
  ```sh
$ curl -I http://localhost:8000/documents/3/filename.pdf
HTTP/1.0 200 OK
Date: Tue, 20 Sep 2016 14:59:17 GMT
Server: WSGIServer/0.1 Python/2.7.11
Last-Modified: Tue, 20 Sep 2016 14:57:53 GMT
Content-length: 161263
Content-Type: application/pdf
X-Frame-Options: SAMEORIGIN
Content-Disposition: attachment; filename="filename.pdf"
```
- With a current production database:
 - Run your local server with the following settings in your environment:

   ```sh
export S3_ENABLED=True
export AWS_S3_ACCESS_KEY_ID=<s3 access key id>
export AWS_S3_SECRET_ACCESS_KEY=<s3 secret access key>
export AWS_STORAGE_BUCKET_NAME=files.consumerfinance.gov
export AWS_S3_URL=https://files.consumerfinance.gov.s3.amazonaws.com
   ```
 - Open this page in your browser: [http://localhost:8000/policy-compliance/enforcement/actions/intercept-corporation-db-intercepteft-bryan-smith-and-craig-dresser/](http://localhost:8000/policy-compliance/enforcement/actions/intercept-corporation-db-intercepteft-bryan-smith-and-craig-dresser/)
 - Note the download link under "Related Documents" appears something like [http://localhost:8000/documents/433/3_16_cv_00144_ars_CFPB_v_Intercept.pdf](http://localhost:8000/documents/433/3_16_cv_00144_ars_CFPB_v_Intercept.pdf).
 - Curl that link and notice that it returns a redirect to the location on S3:

   ```sh
curl -I http://localhost:8000/documents/433/3_16_cv_00144_ars_CFPB_v_Intercept.pdf
HTTP/1.0 302 FOUND
Date: Tue, 20 Sep 2016 15:10:04 GMT
Server: WSGIServer/0.1 Python/2.7.11
X-Frame-Options: SAMEORIGIN
Content-Type: text/html; charset=utf-8
Location: http://s3.amazonaws.com/files.consumerfinance.gov/f/documents/3_16_cv_00144_ars_CFPB_v_Intercept.pdf
```

## Review

- @rosskarchner @cfpb/cfgov-backends 

## Notes

- I explicitly remove all query string parameters from the remote file's URL when returning it in the redirect. Even though [we disable](https://github.com/cfpb/cfgov-refresh/blob/master/cfgov/cfgov/settings/base.py#L344) `AWS_QUERYSTRING_AUTH`, there is [an open issue](https://github.com/boto/boto/issues/1477) in boto that still adds a (not required) `x-amz-security-token` to the string.

## Checklist

* [X] Changes are limited to a single goal (no scope creep)
* [X] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [X] Passes all existing automated tests
* [X] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
