### PR TITLE
Remove max-height from info unit images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 ### Added
 - Created new `WAGTAIL_CAREERS` feature flag to toggle from Django to Wagtail careers pages.
 
+### Removed
+- `max-height` styling on info unit images
+
 
 ## 3.8.2
 
@@ -38,7 +41,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Author names are now displayed in alphabetical order by last name, falls back on first name if necessary
 - Ability to output sharing links within an Image and Text 50/50 Group module
 - Google Optimize code on `find-a-housing-counselor` page
-- Added a test for get_browsefilterable_posts function of the sublanding page 
+- Added a test for get_browsefilterable_posts function of the sublanding page
 - Data migration sets up site root and careers pages
 - Wagtail User editor now enforces unique email addresses when creating/editing users.
 - Default button text color and spacing overrides to `.m-global-search_trigger` in nemo stylesheet so that search button will be visible on pages that use `base_nonresponsive` template

--- a/cfgov/unprocessed/css/molecules/info-unit.less
+++ b/cfgov/unprocessed/css/molecules/info-unit.less
@@ -98,15 +98,10 @@
  */
 .u-info-unit-base() {
     &_image {
-        max-height: unit( @m-info-unit_img__sm / @base-font-size-px, em );
         margin-right: auto;
         margin-bottom: unit( ( @grid_gutter-width / 2 ) / @base-font-size-px, em );
         margin-left: auto;
         display: block;
-
-        .respond-to-min( @bp-med-min, {
-            max-height: unit( @m-info-unit_img__lg / @base-font-size-px, em );
-        } );
 
         &__square {
             width: unit( @m-info-unit_img__sm / @base-font-size-px, em );


### PR DESCRIPTION
The declaration was unnecessary, as there is an explicit `height` declared on the `__square` variant, and it was unintentionally restricting the size of 16:9 info unit images, which are necessarily taller than 150px when [spanning the full column width](http://cfpb.github.io/design-manual/page-components/50-50.html).

## Removals

- Removed `max-height` from the styling of info unit images.

## Testing

1. Run the server.
1. Create a page with a 50/50 Image and Text module, adding an info unit with an image in a 16:9 aspect ratio and selecting the "Use 16:9 image" option.
1. Preview the page and observe the image not spanning the full width of the column.
1. Pull this branch.
1. `gulp styles`
1. Reload the test page and observe the image spanning the full width of the column.

## Review

- @cfpb/cfgov-frontends 

## Screenshots

### Before
![screen shot 2016-09-20 at 17 08 17](https://cloud.githubusercontent.com/assets/1044670/18689034/1a13751e-7f55-11e6-9a7b-69876ccf2385.png)

### After
![screen shot 2016-09-20 at 17 08 42](https://cloud.githubusercontent.com/assets/1044670/18689047/21991c9e-7f55-11e6-8e13-a408af210e73.png)

## Notes

- I see that that `CHANGELOG.md` on `master` doesn't have the 3.9.0 details in it. Did we miss a step at release time, @rosskarchner?

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices
* [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)

