### PR TITLE
Add AbstractFormBlock for handling forms in Wagtail pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Created new `WAGTAIL_CAREERS` feature flag to toggle from Django to Wagtail careers pages.
 - Production settings now use ManifestStaticFilesStorage
 - Added a 'run_travis.sh' script to enable separate JS and Python test coverage reporting 
+- AbstractFormBlock
 
 ### Changed
 - Refactored heroes to support the new "bleeding" format.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Optimized Travis build by removing unnecessary steps.
 - Refactored heroes to support the new "bleeding" format.
 - `CFGOVPage.get_context()` now uses wagtail hooks to call functions registered with the hook name `cfgovpage_context_handlers`
-- `CFGOVPage.serve()` calls `CFGOVPage.serve_ajax()` to handle AJAX requests
+- `CFGOVPage.serve()` calls `CFGOVPage.serve_post()` to handle POST requests
 
 ### Removed
 - `max-height` styling on info unit images

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,13 +19,17 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Created new `WAGTAIL_CAREERS` feature flag to toggle from Django to Wagtail careers pages.
 - Production settings now use ManifestStaticFilesStorage
 - Added a 'run_travis.sh' script to enable separate JS and Python test coverage reporting 
-- AbstractFormBlock
+- AbstractFormBlock to be used as a base class for modules requiring Django Forms
+- wagtail_hooks.py function `form_module_handlers` used by `CFGOVPage.get_context()`
 
 ### Changed
 - Refactored heroes to support the new "bleeding" format.
 - In templates, ALL static file references now use Django's `static` tag/function
 - In CSS/Less, references to other assets are now relative
 - Optimized Travis build by removing unnecessary steps.
+- Refactored heroes to support the new "bleeding" format.
+- `CFGOVPage.get_context()` now uses wagtail hooks to call functions registered with the hook name `cfgovpage_context_handlers`
+- `CFGOVPage.serve()` calls `CFGOVPage.serve_ajax()` to handle AJAX requests
 
 ### Removed
 - `max-height` styling on info unit images

--- a/cfgov/v1/blocks.py
+++ b/cfgov/v1/blocks.py
@@ -1,5 +1,5 @@
 from wagtail.wagtailcore import blocks
-from v1.util import util
+from django.utils.module_loading import import_string
 
 
 class AbstractFormBlock(blocks.StructBlock):
@@ -16,7 +16,7 @@ class AbstractFormBlock(blocks.StructBlock):
         if not handler_path:
             raise AttributeError(
                 'You must set a handler attribute on the Meta class.')
-        return util.load_class(handler_path)
+        return import_string(handler_path)
 
     def is_submitted(self, request, sfname, index):
         form_id = 'form-%s-%d' % (sfname, index)

--- a/cfgov/v1/blocks.py
+++ b/cfgov/v1/blocks.py
@@ -1,0 +1,32 @@
+from wagtail.wagtailcore import blocks
+from v1.util import util
+
+
+class AbstractFormBlock(blocks.StructBlock):
+    """
+    Block class to be subclassed for blocks that involve form handling.
+    """
+    def get_result(self, page, request, value, is_submitted):
+        handler_class = self.get_handler_class()
+        handler = handler_class(page, request, block_value=value)
+        return handler.process(is_submitted)
+
+    def get_handler_class(self):
+        handler_path = self.meta.handler
+        if not handler_path:
+            raise AttributeError(
+                'You must set a handler attribute on the Meta class.')
+        return util.load_class(handler_path)
+
+    def is_submitted(self, request, sfname, index):
+        form_id = 'form-%s-%d' % (sfname, index)
+        if request.method.lower() == self.meta.method.lower():
+            query_dict = getattr(request, self.meta.method.upper())
+            return form_id in query_dict.get('form_id', '')
+        return False
+
+    class Meta:
+        # This should be a dotted path to the handler class for the block.
+        handler = None
+        method = 'POST'
+        icon = 'form'

--- a/cfgov/v1/models/base.py
+++ b/cfgov/v1/models/base.py
@@ -7,7 +7,7 @@ from django.core.urlresolvers import reverse
 from django.db import models
 from django.db.models import Q
 from django.db.models.signals import pre_delete
-from django.http import Http404
+from django.http import Http404, JsonResponse
 from django.utils.translation import ugettext_lazy as _
 from django.utils import timezone
 from django.dispatch import receiver
@@ -15,7 +15,7 @@ from django.contrib.auth.models import User
 
 from wagtail.wagtailimages.models import Image, AbstractImage, AbstractRendition
 from wagtail.wagtailadmin.edit_handlers import StreamFieldPanel
-from wagtail.wagtailcore import blocks
+from wagtail.wagtailcore import blocks, hooks
 from wagtail.wagtailcore.blocks.stream_block import StreamValue
 from wagtail.wagtailcore.fields import StreamField
 from wagtail.wagtailcore.templatetags.wagtailcore_tags import slugurl
@@ -229,6 +229,43 @@ class CFGOVPage(Page):
 
     def get_prev_appropriate_siblings(self, hostname, inclusive=False):
         return self.get_appropriate_siblings(hostname=hostname, inclusive=inclusive).filter(path__lte=self.path).order_by('-path')
+
+    def get_context(self, request, *args, **kwargs):
+        context = super(CFGOVPage, self).get_context(request, *args, **kwargs)
+        for hook in hooks.get_hooks('cfgovpage_context_handlers'):
+            hook(self, request, context, *args, **kwargs)
+        return context
+
+    def serve(self, request, *args, **kwargs):
+        """
+        If request is ajax, then return the ajax request handler response, else
+        return the super.
+        """
+        if request.is_ajax():
+            return self.serve_ajax(request)
+
+        return super(CFGOVPage, self).serve(request, *args, **kwargs)
+
+    def serve_ajax(self, request):
+        """
+        Attempts to retreive form_id from the POST request and returns a JSON
+        response.
+
+        If form_id is found, it returns the response from the block method
+        retrieval.
+
+        If form_id is not found it returns an error response.
+        """
+        form_id = request.POST.get('form_id', None)
+        if not form_id:
+            return JsonResponse({'result': 'error'})
+
+        sfname, index = form_id.split('-')[1:]
+
+        streamfield = getattr(self, sfname)
+        module = streamfield[int(index)]
+
+        return module.block.get_result(self, request, module.value, True)
 
     @property
     def status_string(self):

--- a/cfgov/v1/models/base.py
+++ b/cfgov/v1/models/base.py
@@ -258,7 +258,7 @@ class CFGOVPage(Page):
         """
         form_id = request.POST.get('form_id', None)
         if not form_id:
-            return JsonResponse({'result': 'error'})
+            return JsonResponse({'result': 'error'}, status=400)
 
         sfname, index = form_id.split('-')[1:]
 

--- a/cfgov/v1/tests/models/test_base.py
+++ b/cfgov/v1/tests/models/test_base.py
@@ -47,36 +47,56 @@ class TestCFGOVPage(TestCase):
         mock_super().serve.assert_called_with(self.request)
 
     @mock.patch('__builtin__.super')
-    @mock.patch('v1.models.base.CFGOVPage.serve_ajax')
-    def test_serve_calls_serve_ajax_on_ajax_request(self, mock_serve_ajax, mock_super):
-        self.request = self.factory.post('/', HTTP_X_REQUESTED_WITH='XMLHttpRequest')
+    @mock.patch('v1.models.base.CFGOVPage.serve_post')
+    def test_serve_calls_serve_post_on_post_request(self, mock_serve_post, mock_super):
+        self.request = self.factory.post('/')
         self.page.serve(self.request)
-        mock_serve_ajax.assert_called_with(self.request)
+        mock_serve_post.assert_called_with(self.request)
 
-    def test_serve_ajax_returns_failed_JSON_response_for_no_form_id(self):
-        response = self.page.serve_ajax(self.request)
+    def test_serve_post_returns_failed_JSON_response_for_no_form_id(self):
+        self.request = self.factory.post('/', HTTP_X_REQUESTED_WITH='XMLHttpRequest')
+        response = self.page.serve_post(self.request)
         self.assertEqual(response.content, '{"result": "error"}')
         self.assertEqual(response.status_code, 400)
 
+    @mock.patch('v1.models.base.HttpResponseBadRequest')
+    def test_serve_post_calls_messages_and_bad_request_for_no_form_id(self, mock_bad_request):
+        self.request = self.factory.post('/')
+        self.page.serve_post(self.request)
+        mock_bad_request.assert_called_with(self.page.url)
+
+    @mock.patch('v1.models.base.HttpResponseBadRequest')
+    def test_serve_post_returns_bad_request_for_no_form_id(self, mock_bad_request):
+        self.request = self.factory.post('/')
+        result = self.page.serve_post(self.request)
+        self.assertTrue(mock_bad_request.called)
+
+    @mock.patch('v1.models.base.TemplateResponse')
+    @mock.patch('v1.models.base.CFGOVPage.get_template')
+    @mock.patch('v1.models.base.CFGOVPage.get_context')
     @mock.patch('v1.models.base.getattr')
-    def test_serve_ajax_gets_streamfield_from_page_using_form_id(self, mock_getattr):
+    def test_serve_post_gets_streamfield_from_page_using_form_id(self, mock_getattr, mock_get_context, mock_get_template, mock_response):
         mock_getattr.return_value = mock.MagicMock()
+        mock_get_context.return_value = mock.MagicMock()
         self.request = self.factory.post(
             '/',
             {'form_id': 'form-content-0'},
             HTTP_X_REQUESTED_WITH='XMLHttpRequest'
         )
-        self.page.serve_ajax(self.request)
+        result = self.page.serve_post(self.request)
         mock_getattr.assert_called_with(self.page, 'content')
 
+    @mock.patch('v1.models.base.TemplateResponse')
+    @mock.patch('v1.models.base.CFGOVPage.get_template')
+    @mock.patch('v1.models.base.CFGOVPage.get_context')
     @mock.patch('v1.models.base.getattr')
-    def test_serve_ajax_calls_module_get_result(self, mock_getattr):
+    def test_serve_post_calls_module_get_result(self, mock_getattr, mock_get_context, mock_get_template, mock_response):
         self.request = self.factory.post(
             '/',
             {'form_id': 'form-content-0'},
             HTTP_X_REQUESTED_WITH='XMLHttpRequest'
         )
-        result = self.page.serve_ajax(self.request)
+        result = self.page.serve_post(self.request)
         module = mock_getattr()[0]
         module.block.get_result.assert_called_with(
             self.page,
@@ -84,15 +104,69 @@ class TestCFGOVPage(TestCase):
             module.value,
             True
         )
-        self.assertEqual(result, module.block.get_result())
 
+    @mock.patch('v1.models.base.isinstance')
+    @mock.patch('v1.models.base.TemplateResponse')
+    @mock.patch('v1.models.base.CFGOVPage.get_template')
+    @mock.patch('v1.models.base.CFGOVPage.get_context')
     @mock.patch('v1.models.base.getattr')
-    def test_serve_ajax_returns_value_from_get_result(self, mock_getattr):
+    def test_serve_post_returns_result_if_response(self, mock_getattr, mock_get_context, mock_get_template, mock_response, mock_isinstance):
+        mock_getattr.return_value = mock.MagicMock()
+        mock_get_context.return_value = mock.MagicMock()
         self.request = self.factory.post(
             '/',
             {'form_id': 'form-content-0'},
             HTTP_X_REQUESTED_WITH='XMLHttpRequest'
         )
-        result = self.page.serve_ajax(self.request)
+        result = self.page.serve_post(self.request)
         module = mock_getattr()[0]
         self.assertEqual(result, module.block.get_result())
+
+    @mock.patch('v1.models.base.TemplateResponse')
+    @mock.patch('v1.models.base.CFGOVPage.get_template')
+    @mock.patch('v1.models.base.CFGOVPage.get_context')
+    @mock.patch('v1.models.base.getattr')
+    def test_serve_post_calls_get_context(self, mock_getattr, mock_get_context, mock_get_template, mock_response):
+        mock_getattr.return_value = mock.MagicMock()
+        mock_get_context.return_value = mock.MagicMock()
+        self.request = self.factory.post(
+            '/',
+            {'form_id': 'form-content-0'},
+            HTTP_X_REQUESTED_WITH='XMLHttpRequest'
+        )
+        result = self.page.serve_post(self.request)
+        self.assertTrue(mock_get_context.called)
+
+    @mock.patch('v1.models.base.TemplateResponse')
+    @mock.patch('v1.models.base.CFGOVPage.get_template')
+    @mock.patch('v1.models.base.CFGOVPage.get_context')
+    @mock.patch('v1.models.base.getattr')
+    def test_serve_post_sets_context(self, mock_getattr, mock_get_context, mock_get_template, mock_response):
+        context = {'form_modules': {'content': {}}}
+        mock_getattr.return_value = mock.MagicMock()
+        mock_get_context.return_value = context
+        self.request = self.factory.post(
+            '/',
+            {'form_id': 'form-content-0'},
+            HTTP_X_REQUESTED_WITH='XMLHttpRequest'
+        )
+        result = self.page.serve_post(self.request)
+        module = mock_getattr()[0]
+        self.assertIn(0, context['form_modules']['content'])
+        self.assertEqual(module.block.get_result(), context['form_modules']['content'][0])
+
+    @mock.patch('v1.models.base.TemplateResponse')
+    @mock.patch('v1.models.base.CFGOVPage.get_template')
+    @mock.patch('v1.models.base.CFGOVPage.get_context')
+    @mock.patch('v1.models.base.getattr')
+    def test_serve_post_returns_template_response_if_result_not_response(self, mock_getattr, mock_get_context, mock_get_template, mock_response):
+        mock_getattr.return_value = mock.MagicMock()
+        mock_get_context.return_value = mock.MagicMock()
+        self.request = self.factory.post(
+            '/',
+            {'form_id': 'form-content-0'},
+            HTTP_X_REQUESTED_WITH='XMLHttpRequest'
+        )
+        result = self.page.serve_post(self.request)
+        mock_response.assert_called_with(self.request, mock_get_template(), mock_get_context())
+        self.assertEqual(result, mock_response())

--- a/cfgov/v1/tests/models/test_base.py
+++ b/cfgov/v1/tests/models/test_base.py
@@ -1,0 +1,97 @@
+import mock
+
+from django.http import JsonResponse
+from django.test import TestCase
+from django.test.client import RequestFactory
+
+from ...models.base import CFGOVPage
+
+
+class TestCFGOVPage(TestCase):
+    def setUp(self):
+        self.page = CFGOVPage(title='Test', slug='test')
+        self.factory = RequestFactory()
+        self.request = self.factory.get('/')
+
+    @mock.patch('__builtin__.super')
+    @mock.patch('v1.models.base.hooks')
+    def test_get_context_calls_get_hooks(self, mock_hooks, mock_super):
+        self.page.get_context(self.request)
+        mock_super.assert_called_with(CFGOVPage, self.page)
+        mock_super().get_context.assert_called_with(self.request, [], {})
+
+    @mock.patch('__builtin__.super')
+    @mock.patch('v1.models.base.hooks')
+    def test_get_context_calls_get_hooks(self, mock_hooks, mock_super):
+        self.page.get_context(self.request)
+        mock_hooks.get_hooks.assert_called_with('cfgovpage_context_handlers')
+
+    @mock.patch('__builtin__.super')
+    @mock.patch('v1.models.base.hooks')
+    def test_get_context_calls_hook_functions(self, mock_hooks, mock_super):
+        fn = mock.Mock()
+        mock_hooks.get_hooks.return_value = [fn]
+        self.page.get_context(self.request)
+        fn.assert_called_with(self.page, self.request, mock_super().get_context())
+
+    @mock.patch('__builtin__.super')
+    @mock.patch('v1.models.base.hooks')
+    def test_get_context_returns_context(self, mock_hooks, mock_super):
+        result = self.page.get_context(self.request)
+        self.assertEqual(result, mock_super().get_context())
+
+    @mock.patch('__builtin__.super')
+    def test_serve_calls_super_on_non_ajax_request(self, mock_super):
+        self.page.serve(self.request)
+        mock_super.assert_called_with(CFGOVPage, self.page)
+        mock_super().serve.assert_called_with(self.request)
+
+    @mock.patch('__builtin__.super')
+    @mock.patch('v1.models.base.CFGOVPage.serve_ajax')
+    def test_serve_calls_serve_ajax_on_ajax_request(self, mock_serve_ajax, mock_super):
+        self.request = self.factory.post('/', HTTP_X_REQUESTED_WITH='XMLHttpRequest')
+        self.page.serve(self.request)
+        mock_serve_ajax.assert_called_with(self.request)
+
+    def test_serve_ajax_returns_failed_JSON_response_for_no_form_id(self):
+        response = self.page.serve_ajax(self.request)
+        self.assertEqual(response.content, '{"result": "error"}')
+
+    @mock.patch('v1.models.base.getattr')
+    def test_serve_ajax_gets_streamfield_from_page_using_form_id(self, mock_getattr):
+        mock_getattr.return_value = mock.MagicMock()
+        self.request = self.factory.post(
+            '/',
+            {'form_id': 'form-content-0'},
+            HTTP_X_REQUESTED_WITH='XMLHttpRequest'
+        )
+        self.page.serve_ajax(self.request)
+        mock_getattr.assert_called_with(self.page, 'content')
+
+    @mock.patch('v1.models.base.getattr')
+    def test_serve_ajax_calls_module_get_result(self, mock_getattr):
+        self.request = self.factory.post(
+            '/',
+            {'form_id': 'form-content-0'},
+            HTTP_X_REQUESTED_WITH='XMLHttpRequest'
+        )
+        result = self.page.serve_ajax(self.request)
+        module = mock_getattr()[0]
+        module.block.get_result.assert_called_with(
+            self.page,
+            self.request,
+            module.value,
+            True
+        )
+        self.assertEqual(result, module.block.get_result())
+
+    @mock.patch('v1.models.base.getattr')
+    def test_serve_ajax_returns_value_from_get_result(self, mock_getattr):
+        self.request = self.factory.post(
+            '/',
+            {'form_id': 'form-content-0'},
+            HTTP_X_REQUESTED_WITH='XMLHttpRequest'
+        )
+        result = self.page.serve_ajax(self.request)
+        module = mock_getattr()[0]
+        self.assertEqual(result, module.block.get_result())

--- a/cfgov/v1/tests/models/test_base.py
+++ b/cfgov/v1/tests/models/test_base.py
@@ -4,7 +4,7 @@ from django.http import JsonResponse
 from django.test import TestCase
 from django.test.client import RequestFactory
 
-from ...models.base import CFGOVPage
+from v1.models.base import CFGOVPage
 
 
 class TestCFGOVPage(TestCase):
@@ -56,6 +56,7 @@ class TestCFGOVPage(TestCase):
     def test_serve_ajax_returns_failed_JSON_response_for_no_form_id(self):
         response = self.page.serve_ajax(self.request)
         self.assertEqual(response.content, '{"result": "error"}')
+        self.assertEqual(response.status_code, 400)
 
     @mock.patch('v1.models.base.getattr')
     def test_serve_ajax_gets_streamfield_from_page_using_form_id(self, mock_getattr):

--- a/cfgov/v1/tests/test_blocks.py
+++ b/cfgov/v1/tests/test_blocks.py
@@ -1,0 +1,54 @@
+import mock
+
+from django.test import TestCase
+from django.test.client import RequestFactory
+
+from ..blocks import AbstractFormBlock
+
+
+class TestAbstractFormBlock(TestCase):
+    def setUp(self):
+        self.page = mock.Mock()
+        self.factory = RequestFactory()
+        self.request = self.factory.get('/')
+        self.block_value = mock.Mock()
+        self.block = AbstractFormBlock()
+
+    @mock.patch('v1.blocks.AbstractFormBlock.get_handler_class')
+    def test_get_result_calls_get_handler_class(self, mock_getclass):
+        self.block.get_result(self.page, self.request, self.block_value, True)
+        self.assertTrue(mock_getclass.called)
+
+    @mock.patch('v1.blocks.AbstractFormBlock.get_handler_class')
+    def test_get_result_instantiates_class(self, mock_getclass):
+        self.block.get_result(self.page, self.request, self.block_value, True)
+        mock_getclass().assert_called_with(self.page, self.request, block_value=self.block_value)
+
+    @mock.patch('v1.blocks.AbstractFormBlock.get_handler_class')
+    def test_get_result_instantiates_class(self, mock_getclass):
+        self.block.get_result(self.page, self.request, self.block_value, True)
+        mock_getclass()().process.assert_called_with(True)
+
+    def test_get_handler_class_raises_AttributeError_for_unset_handler_meta(self):
+        with self.assertRaises(AttributeError) as e:
+            self.block.get_handler_class()
+
+    @mock.patch('v1.blocks.util')
+    def test_get_handler_class_returns_load_class_with_handler_path(self, mock_util):
+        self.block.meta.handler = 'handler.dot.path'
+        self.block.get_handler_class()
+        mock_util.load_class.assert_called_with(self.block.meta.handler)
+
+    def test_is_submitted_returns_False_for_wrong_method(self):
+        result = self.block.is_submitted(self.request, 'name', 0)
+        self.assertFalse(result)
+
+    def test_is_submitted_returns_False_if_form_id_doesnt_match(self):
+        self.request = self.factory.post('/', {'form_id': 'notamatch-0'})
+        result = self.block.is_submitted(self.request, 'withthis', 0)
+        self.assertFalse(result)
+
+    def test_is_submitted_returns_True_for_matching_form_id(self):
+        self.request = self.factory.post('/', {'form_id': 'form-match-0'})
+        result = self.block.is_submitted(self.request, 'match', 0)
+        self.assertTrue(result)

--- a/cfgov/v1/tests/test_blocks.py
+++ b/cfgov/v1/tests/test_blocks.py
@@ -33,11 +33,11 @@ class TestAbstractFormBlock(TestCase):
         with self.assertRaises(AttributeError) as e:
             self.block.get_handler_class()
 
-    @mock.patch('v1.blocks.util')
-    def test_get_handler_class_returns_load_class_with_handler_path(self, mock_util):
+    @mock.patch('v1.blocks.import_string')
+    def test_get_handler_class_returns_load_class_with_handler_path(self, mock_import):
         self.block.meta.handler = 'handler.dot.path'
         self.block.get_handler_class()
-        mock_util.load_class.assert_called_with(self.block.meta.handler)
+        mock_import.assert_called_with(self.block.meta.handler)
 
     def test_is_submitted_returns_False_for_wrong_method(self):
         result = self.block.is_submitted(self.request, 'name', 0)

--- a/cfgov/v1/tests/test_util.py
+++ b/cfgov/v1/tests/test_util.py
@@ -70,3 +70,29 @@ class TestUtilFunctions(TestCase):
         assert not self.page_versions[1].as_page_object.called
         assert not self.page_versions[2].as_page_object.called
         assert not self.page_versions[3].as_page_object.called
+
+    @mock.patch('v1.util.util.importlib')
+    def test_load_class_calls_import_module_with_split_path_string(self, mock_import):
+        module = mock.Mock()
+        module.module_class = object
+        mock_import.import_module.return_value = module
+        util.load_class('dotted.path.to.module.module_class')
+        mock_import.import_module.assert_called_with('dotted.path.to.module')
+
+    @mock.patch('v1.util.util.importlib')
+    def test_load_class_returns_imported_module_class(self, mock_import):
+        module = mock.Mock()
+        module.module_class = object
+        mock_import.import_module.return_value = module
+        result = util.load_class('dotted.path.to.module.module_class')
+        assert result is object
+
+    @mock.patch('__builtin__.isinstance')
+    @mock.patch('__builtin__.vars')
+    @mock.patch('v1.util.util.StreamValue')
+    def get_streamfields_returns_dict_of_streamfields(self, mock_streamvalueclass, mock_vars, mock_isinstance):
+        page = mock.Mock()
+        mock_vars.items.return_value = {'key': 'value'}
+        mock_isinstance.return_value = True
+        result = util.get_streamfields(page)
+        self.assertEqual(result, {'key': 'value'})

--- a/cfgov/v1/tests/test_util.py
+++ b/cfgov/v1/tests/test_util.py
@@ -71,22 +71,6 @@ class TestUtilFunctions(TestCase):
         assert not self.page_versions[2].as_page_object.called
         assert not self.page_versions[3].as_page_object.called
 
-    @mock.patch('v1.util.util.importlib')
-    def test_load_class_calls_import_module_with_split_path_string(self, mock_import):
-        module = mock.Mock()
-        module.module_class = object
-        mock_import.import_module.return_value = module
-        util.load_class('dotted.path.to.module.module_class')
-        mock_import.import_module.assert_called_with('dotted.path.to.module')
-
-    @mock.patch('v1.util.util.importlib')
-    def test_load_class_returns_imported_module_class(self, mock_import):
-        module = mock.Mock()
-        module.module_class = object
-        mock_import.import_module.return_value = module
-        result = util.load_class('dotted.path.to.module.module_class')
-        assert result is object
-
     @mock.patch('__builtin__.isinstance')
     @mock.patch('__builtin__.vars')
     @mock.patch('v1.util.util.StreamValue')

--- a/cfgov/v1/tests/test_wagtail_hooks.py
+++ b/cfgov/v1/tests/test_wagtail_hooks.py
@@ -232,13 +232,13 @@ class TestFormModuleHandlers(TestCase):
     def test_sets_context(self, mock_getstreamfields, mock_hasattr):
         mock_hasattr.return_value = True
         child = mock.Mock()
-        mock_getstreamfields.items.return_value = [('name', [child])]
+        mock_getstreamfields().items.return_value = [('name', [child])]
         form_module_handlers(self.page, self.request, self.context)
         assert 'form_modules' in self.context
 
     @mock.patch('v1.wagtail_hooks.util.get_streamfields')
-    def test_sets_context(self, mock_getstreamfields):
-        mock_getstreamfields.items.return_value = []
+    def test_does_not_set_context(self, mock_getstreamfields):
+        mock_getstreamfields().items.return_value = []
         form_module_handlers(self.page, self.request, self.context)
         assert 'form_modules' not in self.context
 

--- a/cfgov/v1/tests/test_wagtail_hooks.py
+++ b/cfgov/v1/tests/test_wagtail_hooks.py
@@ -265,7 +265,7 @@ class TestFormModuleHandlers(TestCase):
         mock_hasattr.return_value = True        
         form_module_handlers(self.page, self.request, self.context)
         assert 'name' in self.context['form_modules']
-        self.assertIsInstance(self.context['form_modules']['name'], list)
+        self.assertIsInstance(self.context['form_modules']['name'], dict)
 
     @mock.patch('__builtin__.hasattr')
     @mock.patch('v1.wagtail_hooks.util.get_streamfields')

--- a/cfgov/v1/util/util.py
+++ b/cfgov/v1/util/util.py
@@ -1,3 +1,4 @@
+import importlib
 import collections, json, os, re
 from itertools import chain
 from time import time
@@ -143,3 +144,32 @@ def all_valid_destinations_for_request(request):
                             valid_destination_for_request(request, pair[1])]
 
     return valid_destinations
+
+
+def load_class(full_class_string):
+    """
+    Credit to @tsileo
+
+    Returns a class from a dotted class string.
+    """
+
+    class_data = full_class_string.split('.')
+    module_path = '.'.join(class_data[:-1])
+    class_str = class_data[-1]
+
+    try:
+        module = importlib.import_module(module_path)
+    except ImportError as e:
+        raise e('Handler class path from block Meta does not exist.')
+
+    return getattr(module, class_str)
+
+def get_streamfields(page):
+    """
+    Retrieves the stream values on a page from it's Streamfield
+    """
+    blocks_dict = {}
+    for key, value in vars(page).items():
+        if isinstance(value, StreamValue):
+            blocks_dict.update({key: value})
+    return blocks_dict

--- a/cfgov/v1/util/util.py
+++ b/cfgov/v1/util/util.py
@@ -146,24 +146,6 @@ def all_valid_destinations_for_request(request):
     return valid_destinations
 
 
-def load_class(full_class_string):
-    """
-    Credit to @tsileo
-
-    Returns a class from a dotted class string.
-    """
-
-    class_data = full_class_string.split('.')
-    module_path = '.'.join(class_data[:-1])
-    class_str = class_data[-1]
-
-    try:
-        module = importlib.import_module(module_path)
-    except ImportError as e:
-        raise e('Handler class path from block Meta does not exist.')
-
-    return getattr(module, class_str)
-
 def get_streamfields(page):
     """
     Retrieves the stream values on a page from it's Streamfield

--- a/cfgov/v1/util/util.py
+++ b/cfgov/v1/util/util.py
@@ -1,4 +1,3 @@
-import importlib
 import collections, json, os, re
 from itertools import chain
 from time import time
@@ -148,7 +147,7 @@ def all_valid_destinations_for_request(request):
 
 def get_streamfields(page):
     """
-    Retrieves the stream values on a page from it's Streamfield
+    Retrieves the stream values on a page from its Streamfield
     """
     blocks_dict = {}
     for key, value in vars(page).items():

--- a/cfgov/v1/wagtail_hooks.py
+++ b/cfgov/v1/wagtail_hooks.py
@@ -141,19 +141,21 @@ def form_module_handlers(page, request, context, *args, **kwargs):
         for index, child in enumerate(blocks):
             if hasattr(child.block, 'get_result'):
                 if fieldname not in form_modules:
-                    form_modules[fieldname] = []
-                is_submitted = child.block.is_submitted(
-                    request,
-                    fieldname,
-                    index
-                )
-                module_context = child.block.get_result(
-                    page,
-                    request,
-                    child.value,
-                    is_submitted
-                )
-                form_modules[fieldname].append(module_context)
+                    form_modules[fieldname] = {}
+
+                if not request.method == 'POST':
+                    is_submitted = child.block.is_submitted(
+                        request,
+                        fieldname,
+                        index
+                    )
+                    module_context = child.block.get_result(
+                        page,
+                        request,
+                        child.value,
+                        is_submitted
+                    )
+                    form_modules[fieldname].update({index: module_context})
 
     if form_modules:
         context['form_modules'] = form_modules

--- a/cfgov/v1/wagtail_hooks.py
+++ b/cfgov/v1/wagtail_hooks.py
@@ -4,7 +4,7 @@ from urlparse import urlsplit
 from django.utils import timezone
 
 from django.conf import settings
-from django.http import Http404, JsonResponse
+from django.http import Http404
 from django.contrib.auth.models import Permission
 from django.utils.html import escape
 

--- a/docs/forms-in-wagtail.md
+++ b/docs/forms-in-wagtail.md
@@ -1,10 +1,6 @@
 # Including forms into Wagtail page context
 
-Wagtail has a FormBuilder module that they want you to use for forms on their pages. The problem with this module is that it's restrictive. There are ways of subclassing its normal behavior, but the real restriction lays in that it subclasses the same class CFGOVPage does: Page. This makes using it nearly impossible for us at the moment.
-
-To get a form in the Wagtail page context, a developer has a few options. All of which are quite onerous and require an intimate knowledge of the Wagtail page backend and request handling flow to implement correctly.
-
-For our purposes there is `AbstractFormBlock`, a subclass of StructBlock that implements methods to process a request. If a developer wishes to add a module that includes a form, they only need to follow a few steps in order to get it handled properly:
+Wagtail provides a FormBuilder module, but it cannot be used with subclasses of Page, like our CFGOVPage. For our purposes there is `AbstractFormBlock`, a subclass of StructBlock that implements methods to process a request. If a developer wishes to add a module that includes a form, they only need to follow a few steps in order to get it handled properly:
 
 1. Create the form.
 2. Create handler class that implements a method named `process`.

--- a/docs/forms-in-wagtail.md
+++ b/docs/forms-in-wagtail.md
@@ -1,0 +1,44 @@
+# Including forms into Wagtail page context
+
+Wagtail has a FormBuilder module that they want you to use for forms on their pages. The problem with this module is that it's restrictive. There are ways of subclassing its normal behavior, but the real restriction lays in that it subclasses the same class CFGOVPage does: Page. This makes using it nearly impossible for us at the moment.
+
+To get a form in the Wagtail page context, a developer has a few options. All of which are quite onerous and require an intimate knowledge of the Wagtail page backend and request handling flow to implement correctly.
+
+For our purposes there is `AbstractFormBlock`, a subclass of StructBlock that implements methods to process a request. If a developer wishes to add a module that includes a form, they only need to follow a few steps in order to get it handled properly:
+
+1. Create the form.
+2. Create handler class that implements a method named `process`.
+ a. The process method should take in a boolean parameter named `is_submitted` that flags whether or not that particular module has been the source of the request.
+ b. The process method should return a dictionary that will be included in the context of the page and a JSONResponse for ajax requests. If a context is returned, this is where the form would go.
+3. Create a subclass of `AbstractFormBlock` with any other blocks that are required.
+ a. Add the path to the handler class to the block class' Meta handler attribute.
+4. Create a template in which to render the form.
+
+Here's an example of a form's block class:
+```python
+...
+
+class FormBlock(AbstractFormBlock):
+    heading = blocks.CharBlock()
+
+    class Meta:
+        handler = 'app_name.handlers.handler_class'
+        # defaults
+        method = 'POST'
+        icon = 'form'
+```
+
+And an example of a handler class:
+```python
+...
+class ConferenceRegistrationHandler(Handler):
+    def process(self, is_submitted):
+        if is_submitted:
+            form = Form(self.request.POST)
+            if form.is_valid():
+                return success
+            else:
+                return fail
+
+        return {'form': Form()}
+```

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ envlist = py27,py34
 skipsdist = True
 
 [testenv]
-recreate = True
+recreate = False
 # TODO: Pull in environment variables from .env instead of re-defining them.
 setenv =
     GOVDELIVERY_ACCOUNT_CODE = fake_account_code

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ envlist = py27,py34
 skipsdist = True
 
 [testenv]
-recreate = False
+recreate = True
 # TODO: Pull in environment variables from .env instead of re-defining them.
 setenv =
     GOVDELIVERY_ACCOUNT_CODE = fake_account_code


### PR DESCRIPTION
This adds a block class to be used for modules that have a form. The class automatically handles getting the form into the context of the page. Developers should only have to follow steps from the docs to get the form in the page context.

## Additions

- AbstractFormBlock
- `CFGOVPage.serve_ajax()` to handle ajax requests.
- util module
 - `load_class` that takes in a path to a class and returns the class
 - `get_streamfields` returns a dictionary of a page's streamfield names and values
- `form_module_handlers` function to add form module's context to the page's context

## Changes

- `CFGOVPage.serve` overridden to call `serve_ajax` for ajax requests.
- `CFGOVPage.get_context` overridden to call registered `cfgovpage-context-handlers` functions

## Testing

- `tox`

## Review

- @cfpb/cfgov-backends 
- @hillaryj 

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)

