### PR TITLE
Fix Spanish label for sharing module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,8 +25,11 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - In CSS/Less, references to other assets are now relative
 
 ### Removed
-- `max-height` styling on info unit images 
+- `max-height` styling on info unit images
+
 ### Fixed
+- Corrected Spanish-language label for sharing module
+
 
 ## 3.9.0
 
@@ -34,7 +37,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Logging configuration to `local.py`
 - Author names are now displayed in alphabetical order by last name, falls back on first name if necessary
 - Ability to output sharing links within an Image and Text 50/50 Group module
-- Added a test for get_browsefilterable_posts function of the sublanding page 
+- Added a test for get_browsefilterable_posts function of the sublanding page
 - Data migration sets up site root and careers pages
 - Wagtail User editor now enforces unique email addresses when creating/editing users.
 - Default button text color and spacing overrides to `.m-global-search_trigger` in nemo stylesheet so that search button will be visible on pages that use `base_nonresponsive` template

--- a/cfgov/jinja2/v1/_includes/molecules/social-media.html
+++ b/cfgov/jinja2/v1/_includes/molecules/social-media.html
@@ -44,7 +44,7 @@
             m-social-media__{{ 'share' if is_share_view else 'follow' }}">
     {% if is_share_view %}
         <div class="h5 m-social-media_heading">Share this</div>
-        <div class="h5 m-social-media_heading m-social-media_heading__es">Compartir este</div>
+        <div class="h5 m-social-media_heading m-social-media_heading__es">Compartir</div>
     {% endif %}
 
     <ul class="list


### PR DESCRIPTION
Our stakeholder for Money as You Grow Spanish informed us that the label for the sharing module in Spanish should simply read "Compartir", not "Compartir este"

## Changes

- Corrected Spanish-language label for sharing module

## Review

- @cfpb/cfgov-frontends 

## Screenshots

![screen shot 2016-09-21 at 15 55 47](https://cloud.githubusercontent.com/assets/1044670/18726767/e634d412-8013-11e6-81c9-498f91fb5974.png)

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices
* [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)

