### PR TITLE
Fix coveralls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,45 +5,26 @@ python:
 
 cache: pip
 
-sudo: false
-
-services:
-  - elasticsearch
-
 install:
   # Project configuration requirements.
-  - pip install virtualenv virtualenvwrapper
-  - pip install autoenv
-  - pip install coveralls
   - export CXX=clang++
   - curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.31.0/install.sh | bash
   - nvm install 5.5.0
   - nvm use 5.5.0
   - npm install -g gulp
-  - chmod +x ./setup.sh
-  - ./setup.sh test
 
   # Project initialization.
+  - pip install -r requirements/travis.txt
+  - chmod +x ./frontend.sh
+  - ./frontend.sh test
 
 env:
-  - TOXENV=py27 DJANGO_SETTINGS_MODULE=cfgov.settings.test WORDPRESS=http://www.consumerfinance.gov DJANGO_STAGING_HOSTNAME=content.localhost
-  # COVERALLS_PARALLEL=true
-  # - GULP_TEST="lint"
-  # - GULP_TEST="test:unit"
-  # - GULP_TEST="test:coveralls"
-
-before_script:
-  - python cfgov/manage.py sheer_index
-  - python cfgov/manage.py migrate
+  - TOXENV=py27 DJANGO_SETTINGS_MODULE=cfgov.settings.test DJANGO_STAGING_HOSTNAME=content.localhost
 
 script:
   - gulp lint
   - gulp test:unit
-  - gulp test:coveralls
+  - tox -e travis
 
 after_success:
-  - coverage combine
   - coveralls
-
-# notifications:
-#   webhooks: https://coveralls.io/webhook?repo_token=COVERALLS_REPO_TOKEN

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,8 +29,8 @@ env:
 script:
   - ./run_travis.sh
 
-after_success:
-  - coveralls
+# after_success:
+#   - coveralls
 
 notifications:
   webhooks: https://coveralls.io/webhook?repo_token=COVERALLS_REPO_TOKEN

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,25 +6,31 @@ python:
 cache: pip
 
 install:
-  # Project configuration requirements.
+  - pip install -r requirements/travis.txt
   - export CXX=clang++
   - curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.31.0/install.sh | bash
   - nvm install 5.5.0
   - nvm use 5.5.0
   - npm install -g gulp
-
-  # Project initialization.
-  - pip install -r requirements/travis.txt
   - chmod +x ./frontend.sh
   - ./frontend.sh test
 
 env:
-  - TOXENV=py27 DJANGO_SETTINGS_MODULE=cfgov.settings.test DJANGO_STAGING_HOSTNAME=content.localhost
+  global:
+    - TOXENV=py27
+    - DJANGO_SETTINGS_MODULE=cfgov.settings.test
+    - DJANGO_STAGING_HOSTNAME=content.localhost
+    - COVERALLS_PARALLEL=true
+  matrix:
+    - RUNTEST=frontend
+    - RUNTEST=backend
 
 script:
-  - gulp lint
-  - gulp test:unit
-  - tox -e travis
+  - ./run_travis.sh
 
 after_success:
   - coveralls
+
+notifications:
+  webhooks: https://coveralls.io/webhook?repo_token=COVERALLS_REPO_TOKEN
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,9 +29,6 @@ env:
 script:
   - ./run_travis.sh
 
-# after_success:
-#   - coveralls
-
 notifications:
   webhooks: https://coveralls.io/webhook?repo_token=COVERALLS_REPO_TOKEN
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 ### Added
 - Created new `WAGTAIL_CAREERS` feature flag to toggle from Django to Wagtail careers pages.
 - Production settings now use ManifestStaticFilesStorage
+- Added a 'run_travis.sh' script to enable separate JS and Python test coverage reporting 
 
 ### Changed
 - Refactored heroes to support the new "bleeding" format.

--- a/gulp/tasks/test.js
+++ b/gulp/tasks/test.js
@@ -277,8 +277,7 @@ gulp.task( 'test:unit:server', testUnitServer );
 
 gulp.task( 'test:unit',
   [
-    'test:unit:scripts',
-    'test:unit:server'
+    'test:unit:scripts'
   ]
 );
 

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -1,0 +1,3 @@
+tox==2.3.1
+coveralls==1.1
+coverage==4.2

--- a/run_travis.sh
+++ b/run_travis.sh
@@ -1,4 +1,4 @@
-echo "running $RUNTEST"
+echo "running $RUNTEST tests"
 if [ "$RUNTEST" == "frontend" ]; then
     gulp "test:unit"
     gulp "test:coveralls"

--- a/run_travis.sh
+++ b/run_travis.sh
@@ -1,0 +1,8 @@
+echo "running $RUNTEST"
+if [ "$RUNTEST" == "frontend" ]; then
+    gulp lint
+    gulp "test:unit"
+    gulp "test:coveralls"
+elif [ "$RUNTEST" == "backend" ]; then
+    tox -e travis
+fi

--- a/run_travis.sh
+++ b/run_travis.sh
@@ -1,6 +1,5 @@
 echo "running $RUNTEST"
 if [ "$RUNTEST" == "frontend" ]; then
-    gulp lint
     gulp "test:unit"
     gulp "test:coveralls"
 elif [ "$RUNTEST" == "backend" ]; then

--- a/run_travis.sh
+++ b/run_travis.sh
@@ -5,4 +5,5 @@ if [ "$RUNTEST" == "frontend" ]; then
     gulp "test:coveralls"
 elif [ "$RUNTEST" == "backend" ]; then
     tox -e travis
+    coveralls
 fi

--- a/tox.ini
+++ b/tox.ini
@@ -29,3 +29,8 @@ recreate = False
 setenv =
     {[testenv]setenv}
     DJANGO_SETTINGS_MODULE=cfgov.settings.test_nomigrations
+
+[testenv:travis]
+passenv = TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH
+commands =
+    coverage run --source='.' manage.py test


### PR DESCRIPTION
Add a run_travis script and travis matrix vars

This produces separate parallel builds for front and back ends and should
fix our blank coverage badge. ~~but the coverage report for js still doesn't pick up data~~

## Additions

- run_travis.sh to launch separate builds

## Removals

- the `coverage combine` command, which wasn't doing the job

## Review

- @chosak @contolini 

## Testing

Check out the jobs at https://coveralls.io/builds/8022169

![selfie-0](https://i.imgur.com/vcKBuAW.gif)
[_GitHub Selfies_](https://github.com/thieman/github-selfies/)

## Todos
- ~~I could use some front-end pairing to work on js reporting~~ -- done


## Checklist

* [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
