### PR TITLE
Remove the OAH homepage from urls.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,8 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - `max-height` styling on info unit images
 - Reference to publish_eccu repo
 - `tax-time-saving` rules from `urls.py`
+- Removed Owning a Home homepage from urls being pulled from sheersites.
+
 
 ### Fixed
 - Corrected Spanish-language label for sharing module

--- a/cfgov/cfgov/urls.py
+++ b/cfgov/cfgov/urls.py
@@ -26,6 +26,7 @@ from v1.views.documents import DocumentServeView
 
 
 fin_ed = SheerSite('fin-ed-resources')
+oah = SheerSite('owning-a-home')
 
 urlpatterns = [
 
@@ -40,7 +41,26 @@ urlpatterns = [
 
     url(r'^owning-a-home/static/(?P<path>.*)$', RedirectView.as_view(url='/static/owning-a-home/static/%(path)s', permanent=True)),
     url(r'^owning-a-home/resources/(?P<path>.*)$', RedirectView.as_view(url='/static/owning-a-home/resources/%(path)s', permanent=True)),
-    url(r'^owning-a-home/', include(SheerSite('owning-a-home').urls)),
+
+    url(r'^owning-a-home/closing-disclosure/', include(oah.urls_for_prefix('closing-disclosure'))),
+    url(r'^owning-a-home/explore-rates/', include(oah.urls_for_prefix('explore-rates'))),
+    url(r'^owning-a-home/loan-estimate/', include(oah.urls_for_prefix('loan-estimate'))),
+
+    url(r'^owning-a-home/loan-options/', include(oah.urls_for_prefix('loan-options'))),
+    url(r'^owning-a-home/loan-options/FHA-loans/', include(oah.urls_for_prefix('loan-options/FHA-loans/'))),
+    url(r'^owning-a-home/loan-options/conventional-loans/', include(oah.urls_for_prefix('loan-options/conventional-loans/'))),
+    url(r'^owning-a-home/loan-options/special-loan-programs/', include(oah.urls_for_prefix('loan-options/special-loan-programs/'))),
+
+    url(r'^owning-a-home/mortgage-closing/', include(oah.urls_for_prefix('mortgage-closing'))),
+    url(r'^owning-a-home/mortgage-estimate/', include(oah.urls_for_prefix('mortgage-estimate'))),
+
+    url(r'^owning-a-home/process/prepare/', include(oah.urls_for_prefix('process/prepare/'))),
+    url(r'^owning-a-home/process/explore/', include(oah.urls_for_prefix('process/explore/'))),
+    url(r'^owning-a-home/process/compare/', include(oah.urls_for_prefix('process/compare/'))),
+    url(r'^owning-a-home/process/close/', include(oah.urls_for_prefix('process/close/'))),
+    url(r'^owning-a-home/process/sources/', include(oah.urls_for_prefix('process/sources/'))),
+    
+    # url('')
 
     # the redirect is an unfortunate workaround, could be resolved by
     # using static('path/to/asset') in the source template

--- a/cfgov/cfgov/urls.py
+++ b/cfgov/cfgov/urls.py
@@ -54,12 +54,13 @@ urlpatterns = [
     url(r'^owning-a-home/mortgage-closing/', include(oah.urls_for_prefix('mortgage-closing'))),
     url(r'^owning-a-home/mortgage-estimate/', include(oah.urls_for_prefix('mortgage-estimate'))),
 
+    url(r'^owning-a-home/process/', include(oah.urls_for_prefix('process/prepare/'))),
     url(r'^owning-a-home/process/prepare/', include(oah.urls_for_prefix('process/prepare/'))),
     url(r'^owning-a-home/process/explore/', include(oah.urls_for_prefix('process/explore/'))),
     url(r'^owning-a-home/process/compare/', include(oah.urls_for_prefix('process/compare/'))),
     url(r'^owning-a-home/process/close/', include(oah.urls_for_prefix('process/close/'))),
     url(r'^owning-a-home/process/sources/', include(oah.urls_for_prefix('process/sources/'))),
-    
+
     # url('')
 
     # the redirect is an unfortunate workaround, could be resolved by


### PR DESCRIPTION
The Owning a Home team would like to start using wagtail for their homepage to be able to use wagtail features and change content in wagtail. This PR removes the Owning a Home home page from urls.py and explicitly lists the other OaH pages in its place.

## Testing

- All of the urls listed in the urls.py should work, but the OaH homepage should 404 locally. On build it will grab the new OaH wagtail page.

## Review

- @rosskarchner 
- @virginiacc 

## Notes

- Like all back-end changes, please let me know if something seems even slightly off, since this is my first time doing this. Thanks!