### PR TITLE
Django templates: use staticfiles instead of plain old 'static'

### DIFF
--- a/cfgov/legacy/templates/front/base_nonresponsive.html
+++ b/cfgov/legacy/templates/front/base_nonresponsive.html
@@ -1,4 +1,4 @@
-{% load static %}
+{% load static from staticfiles %}
 {% load global_include %}
 {% get_static_prefix as STATIC_PREFIX %}
 {% get_media_prefix as MEDIA_PREFIX %}

--- a/cfgov/legacy/templates/front/base_print.html
+++ b/cfgov/legacy/templates/front/base_print.html
@@ -1,4 +1,4 @@
- {% load static %}
+ {% load static from staticfiles %}
 <!DOCTYPE html>
 
 <!-- paulirish.com/2008/conditional-stylesheets-vs-css-hacks-answer-neither/ -->

--- a/cfgov/legacy/templates/front/base_update.html
+++ b/cfgov/legacy/templates/front/base_update.html
@@ -1,4 +1,4 @@
-{% load static %}
+{% load static from staticfiles %}
 {% load global_include %}
 {% load i18n %}
 {% load staticversions %}

--- a/cfgov/legacy/templates/front/share_links.html
+++ b/cfgov/legacy/templates/front/share_links.html
@@ -1,4 +1,4 @@
-{% load static %}
+{% load static from staticfiles %}
 <a href="http://www.facebook.com/sharer.php?u={% firstof share_uri request.build_absolute_uri|urlencode %}{% if utm_campaign %}%3Futm_campaign={{ utm_campaign }}{% endif %}" class="share-facebook"><img src="{% static 'nemo/_/img/icon_small_facebook.png' %}" alt="Share on Facebook"></a>
 <a href="http://twitter.com/share?url={% firstof share_uri request.build_absolute_uri|urlencode %}{% if utm_campaign %}%3Futm_campaign={{ utm_campaign }}{% endif %}&text={% firstof tweet_text pagetitle "CFPB" %}&via=CFPB&lang=en" class="share-twitter"><img src="{% static 'nemo/_/img/icon_small_twitter.png' %}" alt="Share on Twitter"></a>
 <a class="addthis_button_email share-email" href="http://api.addthis.com/oexchange/0.8/forward/email/offer?url={% firstof share_uri request.build_absolute_uri|urlencode %}{% if utm_campaign %}%3Futm_campaign={{ utm_campaign }}{% endif %}&title={% firstof email_title "CFPB" %}&pubid=ra-4da354ee346886d2"><img src="{% static 'nemo/_/img/icon_small_email.png' %}" alt="Share via email"></a>

--- a/cfgov/templates/find_a_housing_counselor.html
+++ b/cfgov/templates/find_a_housing_counselor.html
@@ -1,5 +1,5 @@
 {% extends "front/base_nonresponsive.html" %}
-{% load static %}
+{% load static from staticfiles %}
 
 {% block title %}
 Find a housing counselor


### PR DESCRIPTION
The static tag that you get from `{% load static %}` doesn't respect the value of STATICFILES_STORAGES, which means it can't take advantage of the changes made in #2407.

`{% load static from staticfiles %}` is a drop-in replacement that DOES respect those your configured static storage mechanism.

https://docs.djangoproject.com/en/1.8/ref/contrib/staticfiles/#std:templatetag-staticfiles-static


## Changes

- described above!

## Testing

- check a legacy django page (like /find-a-housing-counselor/ ) before and after the change, and you should notice no changes.

## Review

- @cfpb/back-end-team-admin 


## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [x] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)

