### PR TITLE
Specify parser for BeautifulSoup

### DIFF
--- a/cfgov/v1/__init__.py
+++ b/cfgov/v1/__init__.py
@@ -127,7 +127,7 @@ def add_link_markup(tags):
         if added_icon:
             # Wraps the link text in a span that provides the underline
             contents = tag.contents
-            span = BeautifulSoup('').new_tag('span')
+            span = BeautifulSoup('', 'html.parser').new_tag('span')
             span['class'] = EXTERNAL_SPAN_CSS
             span.contents = contents
             tag.contents = [span, NavigableString(' ')]


### PR DESCRIPTION
As of BeautifulSoup library version 4.4 (release blog post [here](https://www.crummy.com/2015/06/29/0)), a warning is generated if the library is initialized without [specifying a parser](https://www.crummy.com/software/BeautifulSoup/bs4/doc/#installing-a-parser). This PR fixes a place in the code where this wasn't being done.

## Changes

- Specify use of the `html.parser` parser with BeautifulSoup.

## Testing

- Run `tox -e fast v1.tests.test_links` and note that no warnings are generated.

## Review

- @cfpb/cfgov-backends 

## Notes

- The warning being generated was:

 ```sh
/cfgov-refresh/.tox/fast/lib/python2.7/site-packages/bs4/__init__.py:166: UserWarning: No parser was explicitly specified, so I'm using the best available HTML parser for this sys
tem ("lxml"). This usually isn't a problem, but if you run this code on another system, or in a different virtual environment, it may use a different parser and behave differently.

To get rid of this warning, change this:

 BeautifulSoup([your markup])
to this:
 BeautifulSoup([your markup], "lxml")

  markup_type=markup_type))
```

## Checklist

* [X] Changes are limited to a single goal (no scope creep)
* [X] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [X] Passes all existing automated tests
* [X] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)