### PR TITLE
Pull feedback stuff into partial

### DIFF
--- a/cfgov/jinja2/v1/_includes/article.html
+++ b/cfgov/jinja2/v1/_includes/article.html
@@ -51,10 +51,7 @@
             {% if block.block_type == 'content' %}
                 {{ parse_links(block.value) | safe }}
             {% elif block.block_type == 'feedback' %}
-                {% import block.block.meta.template as feedback with context %}
-                {% set form_id = 'form-content-' ~ loop.index0 %}
-                {% set settings = form_modules.content[loop.index0] %}
-                {{ feedback.render(block.value, settings, form_id) }}
+                {% include 'setup-feedback-and-render.html' %}
             {% else %}
                 {{ render_block.render(block, loop.index) }}
             {% endif %}

--- a/cfgov/jinja2/v1/_includes/setup-feedback-and-render.html
+++ b/cfgov/jinja2/v1/_includes/setup-feedback-and-render.html
@@ -1,0 +1,4 @@
+{% import block.block.meta.template as feedback with context %}
+{% set form_id = 'form-content-' ~ loop.index0 %}
+{% set settings = form_modules.content[loop.index0] %}
+{{ feedback.render(block.value, settings, form_id) }}

--- a/cfgov/jinja2/v1/browse-basic/index.html
+++ b/cfgov/jinja2/v1/browse-basic/index.html
@@ -22,10 +22,7 @@
 
     {% for block in page.content -%}
         {% if block.block_type == 'feedback' %}
-            {% import block.block.meta.template as feedback with context %}
-            {% set form_id = 'form-content-' ~ loop.index0 %}
-            {% set settings = form_modules.content[loop.index0] %}
-            {{ feedback.render(block.value, settings, form_id) }}
+            {% include 'setup-feedback-and-render.html' %}
         {% else %}
             {{ render_block.render(block, loop.index) }}
         {% endif %}

--- a/cfgov/jinja2/v1/browse-filterable/index.html
+++ b/cfgov/jinja2/v1/browse-filterable/index.html
@@ -27,10 +27,7 @@
                 {{ flc.render(block.value, loop.index0) }}
             </div>
         {% elif block.block_type == 'feedback' %}
-            {% import block.block.meta.template as feedback with context %}
-            {% set form_id = 'form-content-' ~ loop.index0 %}
-            {% set settings = form_modules.content[loop.index0] %}
-            {{ feedback.render(block.value, settings, form_id) }}
+            {% include 'setup-feedback-and-render.html' %}
         {% else %}
             {{ render_block.render(block, loop.index) }}
         {% endif %}

--- a/cfgov/jinja2/v1/document-detail/index.html
+++ b/cfgov/jinja2/v1/document-detail/index.html
@@ -22,10 +22,7 @@
 
     {% for block in page.content -%}
         {% if block.block_type == 'feedback' %}
-            {% import block.block.meta.template as feedback with context %}
-            {% set form_id = 'form-content-' ~ loop.index0 %}
-            {% set settings = form_modules.content[loop.index0] %}
-            {{ feedback.render(block.value, settings, form_id) }}
+            {% include 'setup-feedback-and-render.html' %}
         {% else %}
             {{ render_block.render(block, loop.index) }}
         {% endif %}

--- a/cfgov/jinja2/v1/landing-page/index.html
+++ b/cfgov/jinja2/v1/landing-page/index.html
@@ -23,10 +23,7 @@
     {%- endfor %}
     {% for block in page.content -%}
         {% if block.block_type == 'feedback' %}
-            {% import block.block.meta.template as feedback with context %}
-            {% set form_id = 'form-content-' ~ loop.index0 %}
-            {% set settings = form_modules.content[loop.index0] %}
-            {{ feedback.render(block.value, settings, form_id) }}
+            {% include 'setup-feedback-and-render.html' %}
         {% else %}
             {{ render_block.render(block, loop.index) }}
         {% endif %}

--- a/cfgov/jinja2/v1/learn-page/index.html
+++ b/cfgov/jinja2/v1/learn-page/index.html
@@ -19,10 +19,7 @@
 
     {% for block in page.content -%}
         {% if block.block_type == 'feedback' %}
-            {% import block.block.meta.template as feedback with context %}
-            {% set form_id = 'form-content-' ~ loop.index0 %}
-            {% set settings = form_modules.content[loop.index0] %}
-            {{ feedback.render(block.value, settings, form_id) }}
+            {% include 'setup-feedback-and-render.html' %}
         {% else %}
             {{ render_block.render(block, loop.index) }}
         {% endif %}

--- a/cfgov/jinja2/v1/sublanding-page/index.html
+++ b/cfgov/jinja2/v1/sublanding-page/index.html
@@ -28,12 +28,9 @@
                 {{ featured_content.render(block.value) }}
             </div>
         {% elif block.block_type == 'feedback' %}
-            {% import block.block.meta.template as feedback with context %}
-            {% set form_id = 'form-content-' ~ loop.index0 %}
-            {% set settings = form_modules.content[loop.index0] %}
-            {{ feedback.render(block.value, settings, form_id) }}
+            {% include 'setup-feedback-and-render.html' %}
         {% elif 'post_preview_snapshot' in block.block_type %}
-            <div class="block 
+            <div class="block
                         {{ block.block.meta.classname if block.block.meta.classname else '' }}">
                 {% set limit = block.value.limit | int %}
                 {% set posts = page.get_browsefilterable_posts(request, limit) %}

--- a/cfgov/jinja2/v1/wagtail/demo/index.html
+++ b/cfgov/jinja2/v1/wagtail/demo/index.html
@@ -23,14 +23,11 @@
 
     {% for block in page.blocks %}
         {% if block.block_type == 'feedback' %}
-            {% import block.block.meta.template as feedback with context %}
-            {% set form_id = 'form-content-' ~ loop.index0 %}
-            {% set settings = form_modules.content[loop.index0] %}
-            {{ feedback.render(block.value, settings, form_id) }}
+            {% include 'setup-feedback-and-render.html' %}
         {% else %}
             {{ render_block.render(block, loop.index) }}
         {% endif %}
-
+    {% endfor %}
     </div>
 {% endblock content_main %}
 


### PR DESCRIPTION
Addresses [comments](https://github.com/cfpb/cfgov-refresh/pull/2418/files#r80704024) by @chosak and @richaagarwal about DRYing up the template pieces.

It's probably not a full and complete solution, but I think it's a decent step forward. PRing this to that branch in case folks think there's a better path.

Also fixes that one [missing `endfor`](https://github.com/cfpb/cfgov-refresh/pull/2418/files#r81018476)

## Review

- @kurtrwall 
- @chosak 
- @richaagarwal 


## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices
* [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)

