### PR TITLE
remove old get_static_prefix and friends

### DIFF
--- a/cfgov/legacy/templates/front/base_nonresponsive.html
+++ b/cfgov/legacy/templates/front/base_nonresponsive.html
@@ -1,10 +1,8 @@
 {% load static from staticfiles %}
 {% load global_include %}
-{% get_static_prefix as STATIC_PREFIX %}
-{% get_media_prefix as MEDIA_PREFIX %}
+
 {% load i18n %}
 {% load staticversions %}
-{% get_static_version as STATIC_VERSION %}
 {% load remit_var %}
 {% is_remit as IS_REMIT %}
 


### PR DESCRIPTION
These tags should have been removed when the static tag was changed.

## Additions

-

## Removals

-

## Changes

-

## Testing

-

## Review

- @user

## Screenshots


## Notes

-

## Todos

-

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)

