### PR TITLE
move the static() calls out of the info-unit module

### DIFF
--- a/cfgov/jinja2/v1/_includes/molecules/info-unit.html
+++ b/cfgov/jinja2/v1/_includes/molecules/info-unit.html
@@ -54,10 +54,10 @@
         {% if value.image.is_decorative %}
         <div class="m-info-unit_image
                     {{ 'm-info-unit_image__square' if value.image.is_square else '' }}"
-             style="background-image: url( {{ static(value.image.url) }} );">
+             style="background-image: url( {{ value.image.url }} );">
         </div>
         {% else %}
-        <img src="{{ static(value.image.url) }}"
+        <img src="{{ value.image.url }}"
              alt="{{ value.image.alt if value.image.alt else '' }}"
              class="m-info-unit_image
                     {{ 'm-info-unit_image__square' if value.image.is_square else '' }}">

--- a/cfgov/jinja2/v1/index.html
+++ b/cfgov/jinja2/v1/index.html
@@ -48,7 +48,7 @@
                         {{ info_unit( {
                             'modifier': 'home',
                             'image': {
-                                'url': 'img/home-complaint_150.png',
+                                'url': static('img/home-complaint_150.png'),
                                 'is_square': true,
                                 'is_decorative': true
                             },
@@ -71,7 +71,7 @@
                         {{ info_unit( {
                             'modifier': 'home',
                             'image': {
-                                'url': 'img/home-answers_150.png',
+                                'url': static('img/home-answers_150.png'),
                                 'is_square': true,
                                 'is_decorative': true
                             },
@@ -90,7 +90,7 @@
                         {{ info_unit( {
                             'modifier': 'home',
                             'image': {
-                                'url': 'img/home-goals_150.png',
+                                'url': static('img/home-goals_150.png'),
                                 'is_square': true,
                                 'is_decorative': true
                             },


### PR DESCRIPTION
That was a poorly considered change, and broke info-unit's on wagtail pages that included uploaded pictures. 


## Testing

- the info-unit's on the home page should still render correctly


- @chosak 


## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)

must do that now