### PR TITLE
Unit test that checks for missing migrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 
 ### Added
 
+- New unit test checks for missing migrations that need to be generated using `makemigrations`.
+
 ### Changed
 
 ### Removed

--- a/cfgov/core/tests/test_missing_migrations.py
+++ b/cfgov/core/tests/test_missing_migrations.py
@@ -1,0 +1,29 @@
+from django import VERSION
+from django.core.management import call_command
+from django.test import TestCase
+
+
+class MissingMigrationsTestCase(TestCase):
+    def test_check_for_missing_migrations(self):
+        major, minor = VERSION[0:2]
+        if 1 == major and 10 <= minor:
+            self.fail(
+                'makemigrations --exit deprecated in Django 1.10: '
+                'https://docs.djangoproject.com/en/1.10/ref/django-admin/'
+                '#cmdoption-makemigrations--exit'
+            )
+
+        try:
+            call_command(
+                'makemigrations',
+                exit=True,
+                dry_run=True,
+                verbosity=0
+            )
+        except SystemExit:
+            # makemigrations calls sys.exit if there are no migrations to be
+            # made. We want to detect the inverse, and fail if there are any
+            # migrations that need to be generated.
+            pass
+        else:
+            self.fail('missing migrations, run manage.py makemigrations')

--- a/cfgov/v1/atomic_elements/organisms.py
+++ b/cfgov/v1/atomic_elements/organisms.py
@@ -36,7 +36,7 @@ class ImageText5050Group(blocks.StructBlock):
         ('shareable', blocks.BooleanBlock(label='Include sharing links?',
                                           help_text='If checked, share links '
                                                     'will be included below '
-                                                    'the items.',
+                                                    'the items---TEST',
                                           required=False)),
         ('share_blurb', blocks.CharBlock(help_text='Sets the tweet text, '
                                                    'email subject line, and '

--- a/cfgov/v1/atomic_elements/organisms.py
+++ b/cfgov/v1/atomic_elements/organisms.py
@@ -81,7 +81,7 @@ class HalfWidthLinkBlobGroup(LinkBlobGroup):
 
 class PostPreviewSnapshot(blocks.StructBlock):
     limit = blocks.CharBlock(default='3', label='Limit',
-                             help_text='How many posts do you want to show?')
+                             help_text='How many posts do you want to show? TESTING')
 
     post_date_description = blocks.CharBlock(default='Published')
 

--- a/cfgov/v1/atomic_elements/organisms.py
+++ b/cfgov/v1/atomic_elements/organisms.py
@@ -81,7 +81,7 @@ class HalfWidthLinkBlobGroup(LinkBlobGroup):
 
 class PostPreviewSnapshot(blocks.StructBlock):
     limit = blocks.CharBlock(default='3', label='Limit',
-                             help_text='How many posts do you want to show? TESTING')
+                             help_text='How many posts do you want to show?')
 
     post_date_description = blocks.CharBlock(default='Published')
 

--- a/cfgov/v1/atomic_elements/organisms.py
+++ b/cfgov/v1/atomic_elements/organisms.py
@@ -36,7 +36,7 @@ class ImageText5050Group(blocks.StructBlock):
         ('shareable', blocks.BooleanBlock(label='Include sharing links?',
                                           help_text='If checked, share links '
                                                     'will be included below '
-                                                    'the items---TEST',
+                                                    'the items.',
                                           required=False)),
         ('share_blurb', blocks.CharBlock(help_text='Sets the tweet text, '
                                                    'email subject line, and '

--- a/run_travis.sh
+++ b/run_travis.sh
@@ -1,3 +1,8 @@
+#!/usr/bin/env bash
+
+# Fail if any command fails.
+set -e
+
 echo "running $RUNTEST tests"
 if [ "$RUNTEST" == "frontend" ]; then
     gulp "test:unit"


### PR DESCRIPTION
Subtle changes to Wagtail atomic elements can require unexpected Django migrations, and there have been a few times where PRs have failed to include them. This PR adds a new unit test that fails if there are any unapplied migrations, as determined by using the Django [makemigrations](https://docs.djangoproject.com/en/1.8/ref/django-admin/#makemigrations-app-label) command.

## Additions

- New `core.tests.test_missing_migrations.py` unit test.

## Testing

- Run `tox core.tests.test_missing_migrations`. It should pass. Make a minor change to a Wagtail atomic element (say, [this](https://github.com/cfpb/cfgov-refresh/blob/master/cfgov/v1/atomic_elements/organisms.py#L83) help text). Run the `tox` command again. It should fail.

## Review

- @cfpb/cfgov-backends 

## Notes

- Note that this test will not fail if there are unapplied migrations but you test with the `tox -e fast` testing environment, because that environment skips all migrations and seems to block the ability to detect unapplied ones.

## Checklist

* [X] Changes are limited to a single goal (no scope creep)
* [X] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [X] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [X] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)

