### PR TITLE
Remove version number from css banner and package.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,12 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 
 ### Removed
 
+## 3.10.3
+
+### Removals
+
+- This removes the current version number from built assets, like main.css
+
 ## 3.10.2
 
 ### Changed

--- a/gulp/config.js
+++ b/gulp/config.js
@@ -20,7 +20,7 @@ module.exports = {
       ' *                     $$\n' +
       ' *                     $$\n' +
       ' *\n' +
-      ' *  <%= pkg.name %> - v<%= pkg.version %>\n' +
+      ' *  <%= pkg.name %>\n' +
       ' *  <%= pkg.homepage %>\n' +
       ' *  A public domain work of the Consumer Financial Protection Bureau\n' +
       ' */\n',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,5 @@
 {
   "name": "cfgov-refresh",
-  "version": "3.8.2",
   "description": "The consumerfinance.gov website.",
   "homepage": "http://www.consumerfinance.gov/",
   "author": {


### PR DESCRIPTION
Including the version number in built output will lead to files being marked as "changed", even if there aren't actual changes to the code-- busting the cache on every release, instead of just when there are real changes.

This PR stops that from happening. Thank you for the consultation, @sebworks and @contolini!

## Removals

- no more version number in package.json
- no more version number in the 'banner' gulp template.

## Review

- @cfpb/cfgov-frontends 


## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)