### PR TITLE
Run HTTPS locally

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,27 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 ## Unreleased
 
 ### Added
+
+- Ability to run using HTTP locally with `./runserver.sh ssl`.
+
+### Changed
+
+### Removed
+
+## 3.10.2
+
+### Changed
+- fixed typo in mission statement
+
+## 3.10.1
+
+### Changed
+- retirement app updated 0.5.1
+- restored css file 'cr-003-theme.css'
+
+## 3.10.0
+
+### Added
 - Created new `WAGTAIL_CAREERS` feature flag to toggle from Django to Wagtail careers pages.
 - Production settings now use ManifestStaticFilesStorage
 - New environment variable to store the Akamai object ID

--- a/cfgov/cfgov/settings/local.py
+++ b/cfgov/cfgov/settings/local.py
@@ -1,7 +1,10 @@
 from .base import *
 
 DEBUG = True
-INSTALLED_APPS += ('wagtail.contrib.wagtailstyleguide',)
+INSTALLED_APPS += (
+    'sslserver',
+    'wagtail.contrib.wagtailstyleguide',
+)
 
 if os.environ.get('DATABASE_ROUTING', False):
     DATABASE_ROUTERS = ['v1.db_router.CFGOVRouter', 'v1.db_router.LegacyRouter']

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -8,10 +8,10 @@ If not using the Vagrant box, you will generally have four tabs
     such as `git checkout master`.
  2. **Elasticsearch**.
     Run an Elasticsearch (ES) instance.
-    See instructions [below](https://github.com/cfpb/cfgov-refresh#2-run-elasticsearch).
+    See instructions [below](#2-run-elasticsearch).
  3. **Django server**. Start and stop the web server.
     Server is started with `./runserver.sh`,
-    but see more details [below](https://github.com/cfpb/cfgov-refresh#3-load-indexes--launch-site).
+    but see more details [below](#3-load-indexes--launch-site).
  4. **Gulp watch**.
     Run the Gulp watch (`gulp watch`) task to automatically re-run the gulp
     asset compilation tasks when their source files are changed.
@@ -103,13 +103,22 @@ python cfgov/manage.py createsuperuser
 
 To view the site browse to: <http://localhost:8000>
 
+!!! note "Using a different port"
+	If you want to run the server at a port other than 8000 use
+
+    `python cfgov/manage.py runserver <port number>`
+
+    Specify an alternate port number, e.g. `8001`.
+
 To view the Wagtail admin login,
 browse to: <http://localhost:8000/admin/login/>
 
-!!! note
-	Using a different port.**
-	If you want to run the server at a port other than 8000
-	use `python cfgov/manage.py runserver <port number>`, e.g. `8001`.
+!!! note "Using HTTPS locally"
+    To access a local server using HTTPS use
+
+    `./runserver.sh ssl`
+
+    You'll need to ignore any browser certificate errors.
 
 ### 4. Launch the Gulp watch task
 

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -2,5 +2,5 @@
 
 django-livereload==1.2
 django-sslserver==0.19
-tox==2.1.1
+tox==2.3.1
 Werkzeug==0.10.4

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -1,5 +1,6 @@
 -r base.txt
 
 django-livereload==1.2
+django-sslserver==0.19
 tox==2.1.1
 Werkzeug==0.10.4

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,4 +1,6 @@
 -r base.txt
+
+django-sslserver==0.19
 mock==1.3.0
 model_mommy==1.2.6
 tox==2.3.1

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,7 +1,5 @@
--r base.txt
+-r local.txt
 
-django-sslserver==0.19
 mock==1.3.0
 model_mommy==1.2.6
-tox==2.3.1
 coverage==4.2

--- a/runserver.sh
+++ b/runserver.sh
@@ -17,11 +17,16 @@ mysql(){
 
 # Run tasks to build the project for distribution.
 server(){
-  echo '\033[0;32mStarting the Django server on port' $DJANGO_HTTP_PORT '...'
-  python cfgov/manage.py runserver $DJANGO_HTTP_PORT
+  if [ "$1" == "ssl" ]; then
+    echo '\033[0;32mStarting SSL Django server on port' $DJANGO_HTTP_PORT '...'
+    python cfgov/manage.py runsslserver $DJANGO_HTT_PORT
+  else
+    echo '\033[0;32mStarting the Django server on port' $DJANGO_HTTP_PORT '...'
+    python cfgov/manage.py runserver $DJANGO_HTTP_PORT
+  fi
 }
 
 mysql
-server
+server "$1"
 
 


### PR DESCRIPTION
This PR lets you run a local server using HTTPS, which is useful for debugging mixed-content warnings and other SSL-related issues.

Run the local server using `./runserver.sh ssl`:

```sh
$ ./runserver.sh ssl
 SUCCESS! MySQL running (2221)
Starting SSL Django server on port 8000 ...
Validating models...

System check identified no issues (0 silenced).
October 03, 2016 - 15:19:19
Django version 1.8.14, using settings 'cfgov.settings.local'
Starting development server at https://127.0.0.1:8000/
Using SSL certificate: /Users/user/.virtualenvs/cfgov-refresh/lib/python2.7/site-packages/sslserver/certs/development.crt
Using SSL key: /Users/user/.virtualenvs/cfgov-refresh/lib/python2.7/site-packages/sslserver/certs/development.key
Quit the server with CONTROL-C.
```

The local server is now available at [https://localhost:8000](https://localhost:8000):

```sh
$ curl -Ik https://localhost:8000
HTTP/1.0 200 OK
Date: Mon, 03 Oct 2016 19:20:29 GMT
Server: WSGIServer/0.1 Python/2.7.11
Vary: Cookie
X-Frame-Options: SAMEORIGIN
Content-Type: text/html; charset=utf-8
```

## Additions

- Added [django-sslserver](https://pypi.python.org/pypi/django-sslserver) to local requirements and to local Django apps in `cfgov.settings.local`.

## Changes

- Modified `runserver.sh` to add support for an `ssl` parameter.
- Updated `CHANGELOG.md` and docs.

## Testing

- Run `./manage.py runserver ssl` and hit [https://localhost:8000](https://localhost:8000) in your browser.

## Review

- @rosskarchner @cfpb/cfgov-backends 

## Screenshots

Modified section of docs:

![image](https://cloud.githubusercontent.com/assets/654645/19051065/5e2db23a-897f-11e6-84cf-9c0833dbd984.png)

Accessing the local server over HTTPS:

![image](https://cloud.githubusercontent.com/assets/654645/19051088/7cacefe6-897f-11e6-9070-81c906df83b0.png)

## Notes

- Because this uses a self-signed certificate (docs [here](https://github.com/teddziuba/django-sslserver#browser-certificate-errors)), you'll get warnings that your browser doesn't trust the local site when you access it with HTTPS.

## Checklist

* [X] Changes are limited to a single goal (no scope creep)
* [X] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [X] Passes all existing automated tests
* [ ] New functions include new tests
* [X] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [X] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
