### PR TITLE
Hotfix: Adding Prepaid Cards to the mega menu behind a feature flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 ## 3.10.4
 
 ### Added
-- Added Prepaid Cards to mega menu.
+- Added Prepaid Cards to mega menu. (Requires feature flag for now.)
 
 
 ## 3.10.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,18 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 
 ---------------------------------------
 
+## 3.10.4
+
+### Added
+- Added Prepaid Cards to mega menu.
+
+
+## 3.10.3
+
+### Removed
+- This removes the current version number from built assets, like main.css
+
+
 ## 3.10.2
 
 ### Changed
@@ -24,6 +36,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 ### Changed
 - retirement app updated 0.5.1
 - restored css file 'cr-003-theme.css'
+
 
 ## 3.10.0
 
@@ -69,7 +82,6 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Removed duplicate caching configuration
 - Icon for old Table from admin panel (this field will need to be removed in a future release)
 
-
 ### Fixed
 - Corrected Spanish-language label for sharing module
 
@@ -85,7 +97,6 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Wagtail User editor now enforces unique email addresses when creating/editing users.
 - Default button text color and spacing overrides to `.m-global-search_trigger` in nemo stylesheet so that search button will be visible on pages that use `base_nonresponsive` template
 - New `@flag_required` decorator for Django views
-
 
 ### Changed
 - Special characters no longer break the multiselect in the filter form
@@ -106,13 +117,10 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Updated admin page sidefoot 'Related links' label and icon to read 'Related content'
 - Feature flag methods now take an explicit `request` object to determine what site to check the flag against
 
-
-
 ### Removed
 - Unused functions `author_name` and `item_author_name` from `v1/feeds.py`
 - Unused npm module map-stream.
 - Custom method `most_common` since python lib offers similar function
-
 
 ### Fixed
 - Post preview organism template used tag/author names instead of slugs that

--- a/cfgov/flags/migrations/0008_add_prepaid_release_flag.py
+++ b/cfgov/flags/migrations/0008_add_prepaid_release_flag.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+def add_prepaid_release_flag(apps, schema_editor):
+    Flag = apps.get_model('flags', 'flag')
+    prepaid_release = Flag(key='PREPAID_RELEASE', enabled_by_default=False)
+    prepaid_release.save()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('flags', '0007_unique_flag_site'),
+    ]
+
+    operations = [
+        migrations.RunPython(add_prepaid_release_flag)
+    ]

--- a/cfgov/jinja2/v1/_includes/organisms/_vars-mega-menu.html
+++ b/cfgov/jinja2/v1/_includes/organisms/_vars-mega-menu.html
@@ -69,7 +69,12 @@
         ('Paying for College', '/paying-for-college/', []),
         ('Owning a Home', '/owning-a-home/', []),
         ('Planning for Retirement', '/retirement/', []),
-        ('Sending Money Abroad', '/sending-money/', [])
+        ('Sending Money Abroad', '/sending-money/', []),
+        ('Prepaid Cards', '/consumer-tools/prepaid-cards/', [(
+            ('Choose the Right Card for Your Situation', '/consumer-tools/prepaid-cards/choose-the-right-card/', []),
+            ('Know Your Rights', '/consumer-tools/prepaid-cards/know-your-rights/', []),
+            ('Understand the Fees You Will Pay', '/consumer-tools/prepaid-cards/understand-fees/', [])
+        )])
     ),(
         ('Know Before You Owe Mortgages', '/know-before-you-owe/', []),
         ('Trouble Paying Your Mortgage?', '/mortgagehelp/', []),

--- a/cfgov/jinja2/v1/_includes/organisms/_vars-mega-menu.html
+++ b/cfgov/jinja2/v1/_includes/organisms/_vars-mega-menu.html
@@ -59,7 +59,7 @@
         ('Information for Students', '/students/', []),
         ('Information for Older Americans', '/older-americans/', []),
         ('Information for Servicemembers & Veterans', '/servicemembers/', [])
-    ),(
+    ),[
         ('Getting an Auto Loan', '/consumer-tools/auto-loans/', [(
             ('Plan to Shop for Your Auto Loan', '/consumer-tools/auto-loans/plan-to-shop-for-your-auto-loan/', []),
             ('Learn to Explore Loan Choices', '/consumer-tools/auto-loans/learn-to-explore-loan-choices/', []),
@@ -69,13 +69,8 @@
         ('Paying for College', '/paying-for-college/', []),
         ('Owning a Home', '/owning-a-home/', []),
         ('Planning for Retirement', '/retirement/', []),
-        ('Sending Money Abroad', '/sending-money/', []),
-        ('Prepaid Cards', '/consumer-tools/prepaid-cards/', [(
-            ('Choose the Right Card for Your Situation', '/consumer-tools/prepaid-cards/choose-the-right-card/', []),
-            ('Know Your Rights', '/consumer-tools/prepaid-cards/know-your-rights/', []),
-            ('Understand the Fees You Will Pay', '/consumer-tools/prepaid-cards/understand-fees/', [])
-        )])
-    ),(
+        ('Sending Money Abroad', '/sending-money/', [])
+    ],(
         ('Know Before You Owe Mortgages', '/know-before-you-owe/', []),
         ('Trouble Paying Your Mortgage?', '/mortgagehelp/', []),
         ('Protections Against Discrimination', '/fair-lending/', [])
@@ -155,3 +150,11 @@
         ('Contact Us', '/about-us/contact-us/', [])
     )])
 )] -%}
+
+{% if flag_enabled(request, 'PREPAID_RELEASE') %}
+    {{ nav_items[0][0][2][1].append( ('Prepaid Cards', '/consumer-tools/prepaid-cards/', [(
+        ('Choose the Right Card for Your Situation', '/consumer-tools/prepaid-cards/choose-the-right-card/', []),
+        ('Know Your Rights', '/consumer-tools/prepaid-cards/know-your-rights/', []),
+        ('Understand the Fees You Will Pay', '/consumer-tools/prepaid-cards/understand-fees/', [])
+    )]) ) }}
+{% endif %}


### PR DESCRIPTION
Short description explaining the high-level reason for the pull request

## Additions

- Added Prepaid Cards to mega menu.

## Testing

1. Pull branch
2. Migrate
3. Runserver
4. Flip `PREPAID_RELEASE` flag on in Wagtail Admin
5. Visit site and see it in the Consumer Tools menu

## Review

- @willbarton 
- @chosak 
- @rosskarchner 

## Todos

- Remove flag in 3.11 release.

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices
* [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
