### PR TITLE
Add missing {% load staticfiles %}

### DIFF
--- a/cfgov/templates/hud_list.html
+++ b/cfgov/templates/hud_list.html
@@ -1,4 +1,4 @@
-
+{% load staticfiles %}
 	 
 <!--[if lt IE 7]> <html class="no-js lt-ie9 lt-ie8 lt-ie7" lang="en-US"> <![endif]-->
 <!--[if IE 7]>    <html class="no-js lt-ie9 lt-ie8" lang="en-US"> <![endif]-->


### PR DESCRIPTION
This is the template used when generating PDF's from the find-a-housing-counselor tool

## Additions

- `{% load staticfiles %}` in hud_list.html


## Review

- @willbarton 


* [x] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)

