### PR TITLE
app version bumps for cfgov-setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,8 +22,11 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 
 ### Changed
 - Improved the help text in the Featured Content module in Wagtail.
-
 - JS form validation messages and Conference module validation messages
+- complaints app updated to 1.2.5
+- retirement app updated to 0.5.3
+- knowledgebase app updated to: v2.1.3
+- college-costs app updated to: 2.2.6
 
 ### Removed
 

--- a/requirements/optional-private.txt
+++ b/requirements/optional-private.txt
@@ -5,6 +5,6 @@
 git+https://private.repo/CFPB/agreement_database.git@v2.2.3#egg=agreements
 git+https://private.repo/CFPB/cfgov-selfregistration.git@v1.2#egg=selfregistration
 git+https://private.repo/CFPB/django-college-cost-comparison.git@v1.2.4#egg=comparisontool
-git+https://private.repo/CFPB/knowledgebase.git@v2.1.2#egg=knowledgebase
+git+https://private.repo/CFPB/knowledgebase.git@v2.1.3#egg=knowledgebase
 git+https://private.repo/CFPB/Picard.git@v1.3#egg=picard
 git+https://private.repo/eregs/ip.git@1.0.2#egg=eregsip

--- a/requirements/optional-public.txt
+++ b/requirements/optional-public.txt
@@ -1,7 +1,7 @@
-git+https://github.com/cfpb/college-costs.git@2.2.5#egg=college-costs
-git+https://github.com/cfpb/complaint.git@v1.2.4#egg=complaintdatabase
+git+https://github.com/cfpb/college-costs.git@2.2.6#egg=college-costs
+git+https://github.com/cfpb/complaint.git@v1.2.5#egg=complaintdatabase
 git+https://github.com/cfpb/django-hud.git@1.2#egg=django-hud
 git+https://github.com/cfpb/owning-a-home-api.git@v0.9.7#egg=owning-a-home-api
 git+https://github.com/cfpb/regulations-core.git@1.2.3#egg=regcore
 git+https://github.com/cfpb/regulations-site.git@2.1.3#egg=regulations
-git+https://github.com/cfpb/retirement.git@0.5.1#egg=retirement
+git+https://github.com/cfpb/retirement.git@0.5.3#egg=retirement


### PR DESCRIPTION
These updates all add [cfgov-django-setup](https://github.com/cfpb/cfgov-django-setup), which centralizes all of our "build front-end assets when building the python app" code, and implements a key improvement: the python build will now fail if the underlying front-end build script fails. 

[These changes are still pending in regulations-site](https://github.com/cfpb/regulations-site/pull/817)


## Changes

- complaints app updated to 1.2.5
- retiremen app updated to 0.5.3
- knowledgebase app updated to: v2.1.3
- college-costs app updated to: 2.2.6


## Review

- @cfpb/back-end-team-admin 



* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
