### PR TITLE
initial robots.txt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - New unit test checks for missing migrations that need to be generated using `makemigrations`.
 - Ability to run using HTTP locally with `./runserver.sh ssl`.
 - Load DigitalGov Search JS using HTTPS.
+- an initial robots.txt file
 
 ### Changed
 - Improved the help text in the Featured Content module in Wagtail.

--- a/cfgov/core/static/robots.txt
+++ b/cfgov/core/static/robots.txt
@@ -1,0 +1,6 @@
+User-agent: *
+Disallow: /save-hud-counselors-list
+Disallow: /about-us/the-bureau/leadership-calendar/pdf
+Disallow: /es/obtener-respuestas/*.imprimir.html
+
+sitemap: http://www.consumerfinance.gov/activity-log/feed/

--- a/cfgov/core/static/robots.txt
+++ b/cfgov/core/static/robots.txt
@@ -2,5 +2,6 @@ User-agent: *
 Disallow: /save-hud-counselors-list
 Disallow: /about-us/the-bureau/leadership-calendar/pdf
 Disallow: /es/obtener-respuestas/*.imprimir.html
+Disallow: /external-site
 
 sitemap: http://www.consumerfinance.gov/activity-log/feed/


### PR DESCRIPTION
It's a robots.txt file!

We will almost certainly iterate on this, but I think this is an OK start. I've only chosen to disallow URL's that produce PDF's, and the "print" versions of Spanish AskCFPB pages (the english versions were removed in the recent redesign).

I've also used the 'sitemap' declaration to point to the activity log RSS feed, since [the sitemap protocol allows it](http://www.sitemaps.org/protocol.html#otherformats). We should still look into a "real" sitemap, but this should allow search engines to pick up new content faster (at least, content that's reflected in the activity feed)

Once merged (and deployed), we'll need to create an alias from /robots.txt to  (site location on server/static/robots.txt

## Additions

- a robots.txt files

## Review

- @willbarton 
- @sarahsimpson09 
- @schaferjh 

## Screenshots


## Notes

-

## Todos

-

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)

