### PR TITLE
enable USE_ETAGS

### DIFF
--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -16,6 +16,8 @@ SECRET_KEY = os.environ.get('SECRET_KEY', os.urandom(32))
 # Use the django default password hashing
 PASSWORD_HASHERS = global_settings.PASSWORD_HASHERS
 
+# see https://docs.djangoproject.com/en/1.8/ref/settings/#std:setting-USE_ETAGS
+USE_ETAGS = True
 
 try:
     import mysql


### PR DESCRIPTION
An "etag" is a token that represents the content at a URL at a particular point in time. The idea is, that if a web browser holds on to these etag values, and if a URL is requested again (using the [If-None-Match](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/If-None-Match) request header, the browser can make a *conditional* request-- "send me the content at this URL, unless the etag is still XYZ". If the etag is unchanged, instead of responding with "200 OK" and the content, it'll respond with "304 Not Modified" and *not* transmit the content.

Our Akamai configuration is currently not set to validate etags, but I am working to get that fixed shortly.

You can accomplish similar things with the Last Modified date, but that's a little tricker with dynamic content (and Django doesn't provide a similar USE_LASTMODIFIED setting)

## What's next?

One interesting angle with this setting: it does not save any *processing* on the Django side of things, all of the database queries, logic, and rendering must still happen BEFORE the etag comparison is made (otherwise, what would it compare the incoming etag to?). It only saves bandwidth, not computing cycles.

I think we could get some mileage out of caching etags (and maybe even generating last-modified dates while we're at it), so long as we flush this cache at the same time, or do it intelligently when pages change. I'll open up a discussion of this idea in our internal issue tracker.

The Django docs have [some good information on other ways to support conditional processing](https://docs.djangoproject.com/en/1.8/topics/conditional-view-processing/)-- there's a danger in tying etags or modified dates to the underlying page model, though, in that it could create blind spot (like template changes, or parts of a page that are dynamic)

## Additions

- adds the USE_ETAGS configuration value.


## Testing

Use curl to verify that this is working:

```
curl -I http://localhost:8000/ 
HTTP/1.0 200 OK
Date: Tue, 11 Oct 2016 18:36:21 GMT
Server: WSGIServer/0.1 Python/2.7.11
Vary: Cookie
X-Frame-Options: SAMEORIGIN
ETag: "bdc03a6c1c6aba24a39f22738fbfd302"
Content-Type: text/html; charset=utf-8

$ curl -I http://localhost:8000/ --header 'If-None-Match: "bdc03a6c1c6aba24a39f22738fbfd302"'                                     
HTTP/1.0 304 NOT MODIFIED
Date: Tue, 11 Oct 2016 18:36:46 GMT
Server: WSGIServer/0.1 Python/2.7.11
Content-Length: 0
Vary: Cookie
```
The actual value of etag/If-None-Match will probably be different for you.

## Review

- @cfpb/cfgov-backends 

## Screenshots


## Notes

-

## Todos

-

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)

https://docs.djangoproject.com/en/1.10/ref/settings/#std:setting-USE_ETAGS