### PR TITLE
Use HTTPS for search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - knowledgebase app updated to: v2.1.3
 - college-costs app updated to: 2.2.6
 - Moved careers page creation from Django data migrations to standalone Python scripts.
+- Use HTTPS when linking to search.consumerfinance.gov.
 
 ### Removed
 

--- a/cfgov/jinja2/v1/_includes/molecules/global-search.html
+++ b/cfgov/jinja2/v1/_includes/molecules/global-search.html
@@ -23,7 +23,7 @@
          data-js-hook="behavior_flyout-menu_content"
          aria-expanded="false">
         <form class="m-global-search_content-form"
-              action="http://search.consumerfinance.gov/search"
+              action="https://search.consumerfinance.gov/search"
               method="get">
             {# The following inputs are required by the CFPB search portal. #}
             <input type="hidden"
@@ -60,22 +60,22 @@
                 <p class="h5">Suggested search terms:</p>
                 <ul class="list list__horizontal">
                     <li class="list_item">
-                        <a class="list_link" href="http://search.consumerfinance.gov/search?utf8=%E2%9C%93&affiliate=cfpb&query=regulations">
+                        <a class="list_link" href="https://search.consumerfinance.gov/search?utf8=%E2%9C%93&affiliate=cfpb&query=regulations">
                             Regulations
                         </a>
                     </li>
                     <li class="list_item">
-                        <a class="list_link" href="http://search.consumerfinance.gov/search?utf8=%E2%9C%93&affiliate=cfpb&query=compliance+guides">
+                        <a class="list_link" href="https://search.consumerfinance.gov/search?utf8=%E2%9C%93&affiliate=cfpb&query=compliance+guides">
                             Compliance guides
                         </a>
                     </li>
                     <li class="list_item">
-                        <a class="list_link" href="http://search.consumerfinance.gov/search?utf8=%E2%9C%93&affiliate=cfpb&query=mortgage">
+                        <a class="list_link" href="https://search.consumerfinance.gov/search?utf8=%E2%9C%93&affiliate=cfpb&query=mortgage">
                             Mortgage
                         </a>
                     </li>
                     <li class="list_item">
-                        <a class="list_link" href="http://search.consumerfinance.gov/search?utf8=%E2%9C%93&affiliate=cfpb&query=college+loans">
+                        <a class="list_link" href="https://search.consumerfinance.gov/search?utf8=%E2%9C%93&affiliate=cfpb&query=college+loans">
                             College loans
                         </a>
                     </li>

--- a/test/browser_tests/spec_suites/integration/global-search.js
+++ b/test/browser_tests/spec_suites/integration/global-search.js
@@ -101,7 +101,7 @@ describe( 'GlobalSearch', function() {
           } )
           .then( function() {
             _dom.searchBtn.click();
-            var portalUrl = 'http://search.consumerfinance.gov/' +
+            var portalUrl = 'https://search.consumerfinance.gov/' +
                             'search?utf8=%E2%9C%93&affiliate=cfpb&query=test';
             expect( browser.getCurrentUrl() ).toBe( portalUrl );
           } );


### PR DESCRIPTION
Links and searches to search.consumerfinance.gov should use HTTPS, not HTTP.

## Changes

- Changed references from http://search.consumerfinance.gov to https://search.consumerfinance.gov.

## Testing

- Run a local server, and type a search into the search box. Note that it links to https://search.consumerfinance.gov.

## Review

- @cfpb/cfgov-backends 

## Notes

- This will prevent mixed-content warnings when cf.gov moves to HTTPS itself.

## Checklist

* [X] Changes are limited to a single goal (no scope creep)
* [X] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [X] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [X] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)

