### PR TITLE
Bump complaints to 1.2.6

### DIFF
--- a/requirements/optional-public.txt
+++ b/requirements/optional-public.txt
@@ -1,5 +1,5 @@
 git+https://github.com/cfpb/college-costs.git@2.2.6#egg=college-costs
-git+https://github.com/cfpb/complaint.git@v1.2.5#egg=complaintdatabase
+git+https://github.com/cfpb/complaint.git@v1.2.6#egg=complaintdatabase
 git+https://github.com/cfpb/django-hud.git@1.2#egg=django-hud
 git+https://github.com/cfpb/owning-a-home-api.git@v0.9.7#egg=owning-a-home-api
 git+https://github.com/cfpb/regulations-core.git@1.2.3#egg=regcore


### PR DESCRIPTION
This PR bumps the version number of the `complaints` app to 1.2.6.

## Changes

- Pin the `complaints` requirement to 1.2.6

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)

