### PR TITLE
Wrapping es-5 script in conditional statement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - college-costs app updated to: 2.2.6
 - Moved careers page creation from Django data migrations to standalone Python scripts.
 - Use HTTPS when linking to search.consumerfinance.gov.
+- Update base.html to conditionally include es5 script.
 
 ### Removed
 

--- a/cfgov/jinja2/v1/_layouts/base.html
+++ b/cfgov/jinja2/v1/_layouts/base.html
@@ -103,7 +103,7 @@
     {# Customized Modernizr build that includes html5shiv.
        Built via gulp-modernizer in `scripts.js` task. #}
     <script src="{{ static('js/modernizr.min.js') }}"></script>
-    <script type='text/javascript'>
+    <script>
     //<![CDATA[
         if ( window.Modernizr && window.Modernizr.es5 === false ) {
             var script = document.createElement( 'script' );

--- a/cfgov/jinja2/v1/_layouts/base.html
+++ b/cfgov/jinja2/v1/_layouts/base.html
@@ -103,7 +103,16 @@
     {# Customized Modernizr build that includes html5shiv.
        Built via gulp-modernizer in `scripts.js` task. #}
     <script src="{{ static('js/modernizr.min.js') }}"></script>
-    <script src="{{ static('js/es5-shim.js') }}"></script>
+    <script type='text/javascript'>
+    //<![CDATA[
+        if ( window.Modernizr && window.Modernizr.es5 === false ) {
+            var script = document.createElement( 'script' );
+            script.type = 'text/javascript';
+            script.src = '{{ static('js/es5-shim.js') }}';
+            document.getElementsByTagName( 'head' )[0].appendChild( script );
+        }
+    //]]>
+    </script>
 
     <!--[if lt IE 9]>
     <script>


### PR DESCRIPTION
We currently write the `es-5` script to all browsers. This PR adds code which conditionally adds the script using Modernizr feature detection.

## Additions

- Modified `base.html` to wrap the es-5 script in a conditional statement.


## Testing

- Use Saucelabs to browse the site on a Android 4.1 device. Verify that the navigation and site work as expected.

## Review

- @contolini 
- @Scotchester 

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)

