### PR TITLE
Fix for table block link icons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 
 
 ### Changed
-
+- Fixed issue surrounding table link download / external icons not appearing.
 
 ### Removed
 - `tax-time-saving` reference in `base.py` (it moved to Wagtail)

--- a/cfgov/jinja2/v1/_includes/organisms/table.html
+++ b/cfgov/jinja2/v1/_includes/organisms/table.html
@@ -26,7 +26,7 @@
 {% if value.data  %}
 
 {% macro _render_cell(cell) %}
-    {{ cell if cell is not none else '&nbsp;' | trim | safe | linebreaksbr }}
+    {{ (cell or '&nbsp;') | safe | trim | linebreaksbr }}
 {% endmacro %}
 
 <table class="o-table
@@ -77,7 +77,7 @@
                     %}
                 {% endif %}
                 <{{ tag | safe }}{{ attributes | safe }}>
-                    {{ _render_cell(parse_links(cell)) }}
+                    {{ _render_cell(parse_links(cell or '&nbsp;')) }}
                 </{{ tag | safe }}>
             {% endfor %}
         </tr>

--- a/cfgov/jinja2/v1/_includes/organisms/table.html
+++ b/cfgov/jinja2/v1/_includes/organisms/table.html
@@ -77,7 +77,7 @@
                     %}
                 {% endif %}
                 <{{ tag | safe }}{{ attributes | safe }}>
-                    {{ _render_cell(cell) }}
+                    {{ _render_cell(parse_links(cell)) }}
                 </{{ tag | safe }}>
             {% endfor %}
         </tr>

--- a/cfgov/jobmanager/models/blocks.py
+++ b/cfgov/jobmanager/models/blocks.py
@@ -4,7 +4,6 @@ from django.template.loader import render_to_string
 from django.utils import timezone
 from v1.atomic_elements import organisms
 from wagtail.wagtailcore import blocks
-from jinja2 import Markup
 
 
 class OpenJobListingsMixin(object):
@@ -68,10 +67,10 @@ class JobListingTable(OpenJobListingsMixin, organisms.ModelTable):
     field_headers = ['TITLE', 'GRADE', 'POSTING CLOSES', 'REGION']
 
     def make_title_value(self, instance, value):
-        return Markup('<a href="{}">{}</a>'.format(
+        return '<a href="{}">{}</a>'.format(
             instance.relative_url(instance.get_site()),
             value
-        ))
+        )
 
     def make_grades_value(self, instance, value):
         return ', '.join(sorted(g.grade.grade for g in value.all()))

--- a/cfgov/jobmanager/tests/models/test_blocks.py
+++ b/cfgov/jobmanager/tests/models/test_blocks.py
@@ -189,13 +189,13 @@ class JobListingTableTestCase(HtmlMixin, TestCase):
 
         self.assertHtmlRegexpMatches(html, (
             '<tr>'
-            '<td data-label="TITLE"><a href=".*">Assistant</a></td>'
+            '<td data-label="TITLE"><a class="" href=".*">Assistant</a></td>'
             '<td data-label="GRADE">12</td>'
             '<td data-label="POSTING CLOSES">APR 21, 2099</td>'
             '<td data-label="REGION">Silicon Valley</td>'
             '</tr>'
             '<tr>'
-            '<td data-label="TITLE"><a href=".*">Manager</a></td>'
+            '<td data-label="TITLE"><a class="" href=".*">Manager</a></td>'
             '<td data-label="GRADE">1, 2, 3</td>'
             '<td data-label="POSTING CLOSES">AUG 05, 2099</td>'
             '<td data-label="REGION">DC, NY</td>'
@@ -213,7 +213,7 @@ class JobListingTableTestCase(HtmlMixin, TestCase):
 
         self.assertHtmlRegexpMatches(html, (
             '<tr>'
-            '<td data-label="TITLE"><a href=".*">CEO</a></td>'
+            '<td data-label="TITLE"><a class="" href=".*">CEO</a></td>'
             '<td data-label="GRADE"></td>'
             '<td data-label="POSTING CLOSES">DEC 01, 2099</td>'
             '<td data-label="REGION"></td>'


### PR DESCRIPTION
Hotfix to resolve issue of external-link / download link icons not displaying on tables.

## Changes

- Modified `cfgov/jinja2/v1/_includes/organisms/table.html` to add `parse_links` context function.

## Testing

- Add a Table block via Wagtail.
- Add a document link, via the editor, to the the table.
- Preview
- Verify that the table contains the external link.

## Review

- @schaferjh 
- @richaagarwal 
- @chosak 

## Screenshots

<img width="227" alt="screen shot 2016-10-14 at 11 25 47 am" src="https://cloud.githubusercontent.com/assets/1696212/19393036/189b6eee-9201-11e6-8141-84afa8d25784.png">

- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
- [ ] Passes all existing automated tests
- [ ] New functions include new tests
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged
- [ ] Visually tested in supported browsers and devices
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
