### PR TITLE
bump comparisontool to v1.2.6

### DIFF
--- a/requirements/optional-private.txt
+++ b/requirements/optional-private.txt
@@ -4,7 +4,7 @@
 
 git+https://private.repo/CFPB/agreement_database.git@v2.2.3#egg=agreements
 git+https://private.repo/CFPB/cfgov-selfregistration.git@v1.2#egg=selfregistration
-git+https://private.repo/CFPB/django-college-cost-comparison.git@v1.2.4#egg=comparisontool
+git+https://private.repo/CFPB/django-college-cost-comparison.git@v1.2.6#egg=comparisontool
 git+https://private.repo/CFPB/knowledgebase.git@v2.1.3#egg=knowledgebase
 git+https://private.repo/CFPB/Picard.git@v1.3#egg=picard
 git+https://private.repo/eregs/ip.git@1.0.2#egg=eregsip


### PR DESCRIPTION
Includes @virginiacc's formatting fixes, and fixes a broken `{% static %}` tag