### PR TITLE
Setting db to django mysql backend.

### DIFF
--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -19,11 +19,7 @@ PASSWORD_HASHERS = global_settings.PASSWORD_HASHERS
 # see https://docs.djangoproject.com/en/1.8/ref/settings/#std:setting-USE_ETAGS
 USE_ETAGS = True
 
-try:
-    import mysql
-    MYSQL_ENGINE = 'mysql.connector.django'
-except ImportError:
-    MYSQL_ENGINE = 'django.db.backends.mysql'
+MYSQL_ENGINE = 'django.db.backends.mysql'
 
 # Application definition
 


### PR DESCRIPTION
Sets database to use django mysql backend explicitly.  Removes try...catch block.

## Additions

-

## Removals

-

## Changes

-  Uses django mysql database backend

## Testing

-

## Review

- @rosskarchner @chosak @willbarton @vccabral @m3brown

## Screenshots


## Notes

-

## Todos

-

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)

