### PR TITLE
Change search script include from HTTP to HTTPS

### DIFF
--- a/cfgov/legacy/templates/front/base_nonresponsive.html
+++ b/cfgov/legacy/templates/front/base_nonresponsive.html
@@ -177,7 +177,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     var aid = "cfpb";
     var script = document.createElement('script');
     script.type = "text/javascript";
-    script.src = "http://search.usa.gov/javascripts/stats.js";
+    script.src = "https://search.usa.gov/javascripts/stats.js";
     document.getElementsByTagName("head")[0].appendChild(script);
   //]]>
 </script>

--- a/cfgov/legacy/templates/front/base_update.html
+++ b/cfgov/legacy/templates/front/base_update.html
@@ -203,7 +203,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     var aid = 'cfpb';
     var script = document.createElement( 'script' );
     script.type = 'text/javascript';
-    script.src = 'http://search.usa.gov/javascripts/stats.js';
+    script.src = 'https://search.usa.gov/javascripts/stats.js';
     document.getElementsByTagName( 'head' )[0].appendChild( script );
   //]]>
 </script>


### PR DESCRIPTION
This PR changes some script includes in legacy templates from HTTP to HTTPS.

This is a followup to #2455.

## Changes

- Changed references from http://search.usa.gov to https://search.usa.gov.

## Testing

- Passes all unit tests.
- Run an HTTPS localhost (`./runserver ssl`) and then navigate to [https://localhost:8000/paying-for-college/](https://localhost:8000/paying-for-college/) (requires the `college-costs` app). Note there are no mixed-content warnings.

## Review

- @sebworks @cfpb/cfgov-frontends 

## Notes

- This will prevent mixed-content warnings when cf.gov moves to HTTPS itself.

## Checklist

* [X] Changes are limited to a single goal (no scope creep)
* [X] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [X] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)

