### PR TITLE
Clean list of optional apps

### DIFF
--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -60,12 +60,12 @@ INSTALLED_APPS = (
     'legacy',
     'django_extensions',
     'reversion',
-    'tinymce'
+    'tinymce',
+    'jobmanager',
 )
 
 OPTIONAL_APPS = [
     {'import': 'noticeandcomment', 'apps': ('noticeandcomment',)},
-    {'import': 'jobmanager', 'apps': ('jobmanager', 'reversion', 'tinymce')},
     {'import': 'comparisontool', 'apps': ('comparisontool', 'haystack',)},
     {'import': 'paying_for_college',
      'apps': ('paying_for_college', 'haystack',)},

--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -82,7 +82,6 @@ OPTIONAL_APPS = [
     {'import': 'eregsip', 'apps': ('eregsip',)},
     {'import': 'regulations', 'apps': ('regulations',)},
     {'import': 'picard', 'apps': ('picard',)},
-    {'import': 'publish-eccu', 'apps': ('publish-eccu',)},
 ]
 
 MIDDLEWARE_CLASSES = (


### PR DESCRIPTION
This PR makes two minor cleanup changes to `settings.OPTIONAL_APPS`.

## Changes

- Removes reference to `publish-eccu`, which is no longer used as of #2417.
- Moves `jobmanager` from `OPTIONAL_APPS` to `INSTALLED_APPS` as this app is now part of the main `cfgov-refresh` repository.

## Testing

- All unit tests pass, including `jobmanager` ones.

## Review

- @cfpb/cfgov-backends 

## Notes

- I didn't update the CHANGELOG as it seems like a fairly minor thing to mention.

## Checklist

* [X] Changes are limited to a single goal (no scope creep)
* [X] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [X] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
