### PR TITLE
Run unit tests for optional apps, if they exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Update base.html to conditionally include es5 script.
 - Wagtail upgraded to version 1.6.3.
 - Moved site root setup from Django data migration into 'initial_data' script.
+- Unit tests run via tox now include optional app tests, if optional apps are present.
 
 ### Removed
 - Removed Handlebars from `package.json` and `cf_notifier.js`.

--- a/cfgov/cfgov/test.py
+++ b/cfgov/cfgov/test.py
@@ -1,19 +1,40 @@
 from __future__ import print_function
 
 import importlib
+import itertools
 import re
 
 from django.apps import apps
+from django.conf import settings
 from django.db import connection
 from django.db.migrations.loader import MigrationLoader
 from django.test import RequestFactory
-from django.test.runner import DiscoverRunner
+from django.test.runner import DiscoverRunner, is_discoverable
 from mock import Mock
 
 from scripts import initial_data
 
 
-class TestDataTestRunner(DiscoverRunner):
+class OptionalAppsMixin(object):
+    def build_suite(self, test_labels=None, extra_tests=None, **kwargs):
+        if not test_labels:
+            app_names = set(itertools.chain(*(
+                optional_app['apps']
+                for optional_app in settings.OPTIONAL_APPS
+            )))
+
+            discoverable_app_names = filter(is_discoverable, app_names)
+
+            test_labels = list(discoverable_app_names) + ['.']
+
+        return super(OptionalAppsMixin, self).build_suite(
+            test_labels=test_labels,
+            extra_tests=extra_tests,
+            **kwargs
+        )
+
+
+class TestDataTestRunner(OptionalAppsMixin, DiscoverRunner):
     def setup_databases(self, **kwargs):
         dbs = super(TestDataTestRunner, self).setup_databases(**kwargs)
 

--- a/tox.ini
+++ b/tox.ini
@@ -54,4 +54,3 @@ deps={[testenv:optional]deps}
 passenv = TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH
 commands =
     coverage run --source='.' manage.py test
-deps={[testenv:optional-public]deps}

--- a/tox.ini
+++ b/tox.ini
@@ -30,7 +30,18 @@ setenv =
     {[testenv]setenv}
     DJANGO_SETTINGS_MODULE=cfgov.settings.test_nomigrations
 
+[testenv:optional]
+deps =
+    {[testenv]deps}
+    -r{toxinidir}/requirements/optional-public.txt
+
+[testenv:fast-optional]
+recreate={[testenv:fast]recreate}
+setenv={[testenv:fast]setenv}
+deps={[testenv:optional]deps}
+
 [testenv:travis]
 passenv = TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH
 commands =
     coverage run --source='.' manage.py test
+deps={[testenv:optional]deps}

--- a/tox.ini
+++ b/tox.ini
@@ -42,8 +42,9 @@ deps=
 
 [testenv:optional]
 deps=
-    {[testenv:optional-public]deps}
-    {[testenv:optional-private]deps}
+    -r{toxinidir}/requirements/optional-public.txt
+    -r{toxinidir}/requirements/optional-private.txt
+    {[testenv]deps}
 
 [testenv:fast-optional]
 recreate={[testenv:fast]recreate}

--- a/tox.ini
+++ b/tox.ini
@@ -30,10 +30,20 @@ setenv =
     {[testenv]setenv}
     DJANGO_SETTINGS_MODULE=cfgov.settings.test_nomigrations
 
-[testenv:optional]
-deps =
-    {[testenv]deps}
+[testenv:optional-public]
+deps=
     -r{toxinidir}/requirements/optional-public.txt
+    {[testenv]deps}
+
+[testenv:optional-private]
+deps=
+    -r{toxinidir}/requirements/optional-private.txt
+    {[testenv]deps}
+
+[testenv:optional]
+deps=
+    {[testenv:optional-public]deps}
+    {[testenv:optional-private]deps}
 
 [testenv:fast-optional]
 recreate={[testenv:fast]recreate}
@@ -44,4 +54,4 @@ deps={[testenv:optional]deps}
 passenv = TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH
 commands =
     coverage run --source='.' manage.py test
-deps={[testenv:optional]deps}
+deps={[testenv:optional-public]deps}


### PR DESCRIPTION
This PR modifies the unit test runner so that it runs unit tests for satellite apps, if they are present.

~~It modifies the default Travis config to install public satellite apps (from `requirements/optional-public.txt`) and run unit tests against them.~~

## Changes

- Default test runner in `cfgov.test.TestDataTestRunner` now adds optional app unit tests, if those apps are present locally (both public and private).
- ~~Travis default configuration now installs public optional apps as part of its testing.~~

## Testing

- Install optional apps (`pip install -r requirements/optional-public.txt`) then run `tox -e optional` or `tox -e fast-optional` and verify that extra tests are being run.
- Confirm that default testing still works properly, e.g. `tox -e fast v1`.

## Review

- @cfpb/cfgov-backends

## Notes

- Adding optional app testing increases the number of unit tests from 513 (`cfgov-refresh` only) to 769 (with optional apps). I see 18 failures locally when I run with all optional apps.

## Todos

- Fix optional apps so that their tests all pass!

## Checklist

* [X] Changes are limited to a single goal (no scope creep)
* [X] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [X] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [X] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)

