### PR TITLE
Removes gulp-load-plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 
 ### Removed
 - Removed Handlebars from `package.json` and `cf_notifier.js`.
+- Removed `gulp-load-plugins` from `package.json`.
 
 ## 3.11.1
 

--- a/gulp/tasks/clean.js
+++ b/gulp/tasks/clean.js
@@ -1,8 +1,8 @@
 'use strict';
 
-var gulp = require( 'gulp' );
-var del = require( 'del' );
 var configClean = require( '../config' ).clean;
+var del = require( 'del' );
+var gulp = require( 'gulp' );
 
 gulp.task( 'clean', function() {
   del( configClean.dest + '/**/*' );

--- a/gulp/tasks/copy.js
+++ b/gulp/tasks/copy.js
@@ -1,7 +1,8 @@
 'use strict';
 
 var gulp = require( 'gulp' );
-var plugins = require( 'gulp-load-plugins' )();
+var gulpChanged = require( 'gulp-changed' );
+var gulpReplace = require( 'gulp-replace' );
 var configCopy = require( '../config' ).copy;
 var handleErrors = require( '../utils/handle-errors' );
 var browserSync = require( 'browser-sync' );
@@ -14,7 +15,7 @@ var browserSync = require( 'browser-sync' );
  */
 function _genericCopy( src, dest ) {
   return gulp.src( src )
-    .pipe( plugins.changed( dest ) )
+    .pipe( gulpChanged( dest ) )
     .on( 'error', handleErrors )
     .pipe( gulp.dest( dest ) )
     .pipe( browserSync.reload( {
@@ -35,9 +36,9 @@ gulp.task( 'copy:vendorfonts', function() {
 gulp.task( 'copy:vendorcss', function() {
   var vendorCss = configCopy.vendorCss;
   return gulp.src( vendorCss.src )
-    .pipe( plugins.changed( vendorCss.dest ) )
+    .pipe( gulpChanged( vendorCss.dest ) )
     .on( 'error', handleErrors )
-    .pipe( plugins.replace(
+    .pipe( gulpReplace(
       /url\(".\/ajax-loader.gif"\)/ig,
       'url("/img/ajax-loader.gif")'
     ) )

--- a/gulp/tasks/docs.js
+++ b/gulp/tasks/docs.js
@@ -4,7 +4,7 @@ var configScripts = require( '../config' ).scripts;
 var fsHelper = require( '../utils/fs-helper' );
 var globAll = require( 'glob-all' );
 var gulp = require( 'gulp' );
-var plugins = require( 'gulp-load-plugins' )();
+var gulpUtil = require( 'gulp-util' );
 var spawn = require( 'child_process' ).spawn;
 
 // TODO: Update this to support grouping methods by class in the generated docs.
@@ -21,7 +21,7 @@ function docsScripts() {
     fsHelper.getBinary( 'documentation', 'documentation.js' ),
       options, { stdio: 'inherit' }
     ).once( 'close', function() {
-      plugins.util.log( 'Scripts documentation generated!' );
+      gulpUtil.log( 'Scripts documentation generated!' );
     } );
   } );
 }

--- a/gulp/tasks/images.js
+++ b/gulp/tasks/images.js
@@ -1,15 +1,16 @@
 'use strict';
 
-var gulp = require( 'gulp' );
-var plugins = require( 'gulp-load-plugins' )();
-var configImages = require( '../config' ).images;
-var handleErrors = require( '../utils/handle-errors' );
 var browserSync = require( 'browser-sync' );
+var configImages = require( '../config' ).images;
+var gulp = require( 'gulp' );
+var gulpChanged = require( 'gulp-changed' );
+var gulpImagemin = require( 'gulp-imagemin' );
+var handleErrors = require( '../utils/handle-errors' );
 
 gulp.task( 'images', function() {
   return gulp.src( configImages.src )
-    .pipe( plugins.changed( configImages.dest ) )
-    .pipe( plugins.imagemin() )
+    .pipe( gulpChanged( configImages.dest ) )
+    .pipe( gulpImagemin() )
     .on( 'error', handleErrors )
     .pipe( gulp.dest( configImages.dest ) )
     .pipe( browserSync.reload( {

--- a/gulp/tasks/lint.js
+++ b/gulp/tasks/lint.js
@@ -1,8 +1,8 @@
 'use strict';
 
-var gulp = require( 'gulp' );
-var plugins = require( 'gulp-load-plugins' )();
 var configLint = require( '../config' ).lint;
+var gulp = require( 'gulp' );
+var gulpEslint = require( 'gulp-eslint' );
 var handleErrors = require( '../utils/handle-errors' );
 var minimist = require( 'minimist' );
 
@@ -16,8 +16,8 @@ function _genericLint( src ) {
   var commandLineParams = minimist( process.argv.slice( 2 ) );
   var willFix = commandLineParams.fix || false;
   return gulp.src( src, { base: './' } )
-    .pipe( plugins.eslint( { fix: willFix } ) )
-    .pipe( plugins.eslint.format() )
+    .pipe( gulpEslint( { fix: willFix } ) )
+    .pipe( gulpEslint.format() )
     .pipe( gulp.dest( './' ) )
     .on( 'error', handleErrors );
 }

--- a/gulp/tasks/styles.js
+++ b/gulp/tasks/styles.js
@@ -1,16 +1,20 @@
 'use strict';
 
-var gulp = require( 'gulp' );
-var plugins = require( 'gulp-load-plugins' )();
-var mqr = require( 'gulp-mq-remove' );
+var browserSync = require( 'browser-sync' );
 var cleanCSS = require('gulp-clean-css');
 var config = require( '../config' );
 var configPkg = config.pkg;
 var configBanner = config.banner;
 var configStyles = config.styles;
 var configLegacy = config.legacy;
+var gulp = require( 'gulp' );
+var gulpAutoprefixer = require( 'gulp-autoprefixer' );
+var gulpHeader = require( 'gulp-header' );
+var gulpLess = require( 'gulp-less' );
+var gulpRename = require( 'gulp-rename' );
+var gulpSourcemaps = require( 'gulp-sourcemaps' );
 var handleErrors = require( '../utils/handle-errors' );
-var browserSync = require( 'browser-sync' );
+var mqr = require( 'gulp-mq-remove' );
 
 /**
  * Process modern CSS.
@@ -18,18 +22,18 @@ var browserSync = require( 'browser-sync' );
  */
 function stylesModern() {
   return gulp.src( configStyles.cwd + configStyles.src )
-    .pipe( plugins.sourcemaps.init() )
-    .pipe( plugins.less( configStyles.settings ) )
+    .pipe( gulpSourcemaps.init() )
+    .pipe( gulpLess( configStyles.settings ) )
     .on( 'error', handleErrors )
-    .pipe( plugins.autoprefixer( {
+    .pipe( gulpAutoprefixer( {
       browsers: [ 'last 2 version',
                   'not ie <= 8',
                   'android 4',
                   'BlackBerry 7',
                   'BlackBerry 10' ]
     } ) )
-    .pipe( plugins.header( configBanner, { pkg: configPkg } ) )
-    .pipe( plugins.sourcemaps.write( '.' ) )
+    .pipe( gulpHeader( configBanner, { pkg: configPkg } ) )
+    .pipe( gulpSourcemaps.write( '.' ) )
     .pipe( gulp.dest( configStyles.dest ) )
     .pipe( browserSync.reload( {
       stream: true
@@ -42,9 +46,9 @@ function stylesModern() {
  */
 function stylesIe() {
   return gulp.src( configStyles.cwd + configStyles.src )
-    .pipe( plugins.less( configStyles.settings ) )
+    .pipe( gulpLess( configStyles.settings ) )
     .on( 'error', handleErrors )
-    .pipe( plugins.autoprefixer( {
+    .pipe( gulpAutoprefixer( {
       browsers: [ 'ie 7-8' ]
     } ) )
     .pipe( mqr( {
@@ -52,7 +56,7 @@ function stylesIe() {
     } ) )
     // mqr expands the minified file
     .pipe( cleanCSS( {compatibility: 'ie8'} ) )
-    .pipe( plugins.rename( {
+    .pipe( gulpRename( {
       suffix:  '.ie',
       extname: '.css'
     } ) )
@@ -68,23 +72,23 @@ function stylesIe() {
  */
 function stylesOnDemand() {
   return gulp.src( configStyles.cwd + '/on-demand/*.less' )
-    .pipe( plugins.less( configStyles.settings ) )
+    .pipe( gulpLess( configStyles.settings ) )
     .on( 'error', handleErrors )
-    .pipe( plugins.autoprefixer( {
+    .pipe( gulpAutoprefixer( {
       browsers: [ 'last 2 version',
                   'ie 7-8',
                   'android 4',
                   'BlackBerry 7',
                   'BlackBerry 10' ]
     } ) )
-    .pipe( plugins.header( configBanner, { pkg: configPkg } ) )
+    .pipe( gulpHeader( configBanner, { pkg: configPkg } ) )
     .pipe( gulp.dest( configStyles.dest ) )
     .pipe( mqr( {
       width: '75em'
     } ) )
     // mqr expands the minified file
     .pipe( cleanCSS( {compatibility: 'ie8'} ) )
-    .pipe( plugins.rename( {
+    .pipe( gulpRename( {
       suffix:  '.nonresponsive',
       extname: '.css'
     } ) )
@@ -100,9 +104,9 @@ function stylesOnDemand() {
  */
 function stylesFeatureFlags() {
   return gulp.src( configStyles.cwd + '/feature-flags/*.less' )
-    .pipe( plugins.less( configStyles.settings ) )
+    .pipe( gulpLess( configStyles.settings ) )
     .on( 'error', handleErrors )
-    .pipe( plugins.autoprefixer( {
+    .pipe( gulpAutoprefixer( {
       browsers: [ 'last 2 version',
                   'ie 7-8',
                   'android 4',
@@ -121,17 +125,17 @@ function stylesFeatureFlags() {
  */
 function stylesNemoProd() {
   return gulp.src( configLegacy.cwd + '/nemo/_/c/less/es-styles.less' )
-    .pipe( plugins.less( { compress: true } ) )
+    .pipe( gulpLess( { compress: true } ) )
     .on( 'error', handleErrors )
-    .pipe( plugins.autoprefixer( {
+    .pipe( gulpAutoprefixer( {
       browsers: [ 'last 2 version',
                   'not ie <= 8',
                   'android 4',
                   'BlackBerry 7',
                   'BlackBerry 10' ]
     } ) )
-    .pipe( plugins.header( configBanner, { pkg: configPkg } ) )
-    .pipe( plugins.rename( 'es-styles.min.css' ) )
+    .pipe( gulpHeader( configBanner, { pkg: configPkg } ) )
+    .pipe( gulpRename( 'es-styles.min.css' ) )
     .pipe( gulp.dest( configLegacy.dest + '/nemo/_/c/' ) )
     .pipe( browserSync.reload( {
       stream: true
@@ -144,17 +148,17 @@ function stylesNemoProd() {
  */
 function stylesNemoIE() {
   return gulp.src( configLegacy.cwd + '/nemo/_/c/less/es-styles-ie.less' )
-    .pipe( plugins.less( { compress: true } ) )
+    .pipe( gulpLess( { compress: true } ) )
     .on( 'error', handleErrors )
-    .pipe( plugins.autoprefixer( {
+    .pipe( gulpAutoprefixer( {
       browsers: [ 'last 2 version',
                   'not ie <= 8',
                   'android 4',
                   'BlackBerry 7',
                   'BlackBerry 10' ]
     } ) )
-    .pipe( plugins.header( configBanner, { pkg: configPkg } ) )
-    .pipe( plugins.rename( 'es-styles-ie.min.css' ) )
+    .pipe( gulpHeader( configBanner, { pkg: configPkg } ) )
+    .pipe( gulpRename( 'es-styles-ie.min.css' ) )
     .pipe( gulp.dest( configLegacy.dest + '/nemo/_/c/' ) )
     .pipe( browserSync.reload( {
       stream: true

--- a/gulp/tasks/test.js
+++ b/gulp/tasks/test.js
@@ -1,15 +1,17 @@
 'use strict';
 
-var envvars = require( '../../config/environment' ).envvars;
-var gulp = require( 'gulp' );
-var gulpMocha = require( 'gulp-mocha' );
-var plugins = require( 'gulp-load-plugins' )();
-var spawn = require( 'child_process' ).spawn;
 var configTest = require( '../config' ).test;
+var envvars = require( '../../config/environment' ).envvars;
 var fsHelper = require( '../utils/fs-helper' );
-var minimist = require( 'minimist' );
-var localtunnel = require( 'localtunnel' );
+var gulp = require( 'gulp' );
+var gulpCoveralls = require( 'gulp-coveralls' );
+var gulpIstanbul = require( 'gulp-istanbul' );
+var gulpMocha = require( 'gulp-mocha' );
+var gulpUtil = require( 'gulp-util' );
 var isReachable = require( 'is-reachable' );
+var localtunnel = require( 'localtunnel' );
+var minimist = require( 'minimist' );
+var spawn = require( 'child_process' ).spawn;
 
 /**
  * Run Mocha JavaScript unit tests.
@@ -17,21 +19,21 @@ var isReachable = require( 'is-reachable' );
  */
 function testUnitScripts( cb ) {
   gulp.src( configTest.src )
-    .pipe( plugins.istanbul( {
+    .pipe( gulpIstanbul( {
       includeUntested: false
     } ) )
-    .pipe( plugins.istanbul.hookRequire() )
+    .pipe( gulpIstanbul.hookRequire() )
     .on( 'finish', function() {
       gulp.src( configTest.tests + '/unit_tests/**/*.js' )
         .pipe( gulpMocha( {
           reporter: configTest.reporter ? 'spec' : 'nyan'
         } ) )
-        .pipe( plugins.istanbul.writeReports( {
+        .pipe( gulpIstanbul.writeReports( {
           dir: configTest.tests + '/unit_test_coverage'
         } ) )
 
         /* TODO: we want this but it breaks because we don't have good coverage
-        .pipe( plugins.istanbul.enforceThresholds( {
+        .pipe( gulpIstanbul.enforceThresholds( {
           thresholds: { global: 90 }
         } ) )
         */
@@ -49,10 +51,10 @@ function testUnitServer() {
     { stdio: 'inherit' }
   ).once( 'close', function( code ) {
     if ( code ) {
-      plugins.util.log( 'Tox tests exited with code ' + code );
+      gulpUtil.log( 'Tox tests exited with code ' + code );
       process.exit( 1 );
     }
-    plugins.util.log( 'Tox tests done!' );
+    gulpUtil.log( 'Tox tests done!' );
   } );
 }
 
@@ -131,7 +133,7 @@ function _getWCAGParams() {
   var checkerId = envvars.ACHECKER_ID;
   var urlPath = _parsePath( commandLineParams.u );
   var url = host + ':' + port + urlPath;
-  plugins.util.log( 'WCAG tests checking URL: http://' + url );
+  gulpUtil.log( 'WCAG tests checking URL: http://' + url );
 
   return [ '--u=' + url, '--id=' + checkerId ];
 }
@@ -202,10 +204,10 @@ function testA11y() {
     { stdio: 'inherit' }
   ).once( 'close', function( code ) {
     if ( code ) {
-      plugins.util.log( 'WCAG tests exited with code ' + code );
+      gulpUtil.log( 'WCAG tests exited with code ' + code );
       process.exit( 1 );
     }
-    plugins.util.log( 'WCAG tests done!' );
+    gulpUtil.log( 'WCAG tests done!' );
   } );
 }
 
@@ -214,17 +216,17 @@ function testA11y() {
  */
 function testPerf() {
   _createPSITunnel().then( function( params ) {
-    plugins.util.log( 'PSI tests checking URL: http://' + params.url.split( ' ' ) );
+    gulpUtil.log( 'PSI tests checking URL: http://' + params.url.split( ' ' ) );
     spawn(
       fsHelper.getBinary( 'psi', 'psi', '../.bin' ),
       params.url,
       { stdio: 'inherit' }
     ).once( 'close', function() {
-      plugins.util.log( 'PSI tests done!' );
+      gulpUtil.log( 'PSI tests done!' );
       params.tunnel.close();
     } );
   } ).catch( function( err ) {
-    plugins.util.log( err );
+    gulpUtil.log( err );
     process.exit( 1 );
   } );
 }
@@ -235,17 +237,17 @@ function testPerf() {
  */
 function _spawnProtractor( suite ) {
   var params = _getProtractorParams( suite );
-  plugins.util.log( 'Running Protractor with params: ' + params );
+  gulpUtil.log( 'Running Protractor with params: ' + params );
   spawn(
     fsHelper.getBinary( 'protractor', 'protractor', '../bin/' ),
     params,
     { stdio: 'inherit' }
   ).once( 'close', function( code ) {
     if ( code ) {
-      plugins.util.log( 'Protractor tests exited with code ' + code );
+      gulpUtil.log( 'Protractor tests exited with code ' + code );
       process.exit( 1 );
     }
-    plugins.util.log( 'Protractor tests done!' );
+    gulpUtil.log( 'Protractor tests done!' );
   } );
 }
 
@@ -262,7 +264,7 @@ function testAcceptanceBrowser( suite ) {
  */
 function testCoveralls() {
   gulp.src( configTest.tests + '/unit_test_coverage/lcov.info' )
-    .pipe( plugins.coveralls() );
+    .pipe( gulpCoveralls() );
 }
 
 // This task will only run on Travis

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "gulp-header": "1.8.8",
     "gulp-imagemin": "3.0.3",
     "gulp-less": "3.1.0",
-    "gulp-load-plugins": "1.2.4",
     "gulp-modernizr": "1.0.0-alpha",
     "gulp-mq-remove": "0.0.2",
     "gulp-notify": "2.2.0",


### PR DESCRIPTION
`gulp-load-plugins` makes it more difficult to use search to find where a particular npm module is used, since the require statement for the modules is omitted and they come through via the `plugins` variable. 
Some tasks were already not using it, so by removing it completely, there's almost the equivalent amount of code and the modules can now be found in the requires section at the top of the gulp tasks.

## Removals

- Removes `gulp-load-plugins`

## Changes

- Alphabetizes require statements in gulp tasks.

## Testing

- `./frontend.sh` should pass.

## Review

- @cfpb/cfgov-frontends 
- @chosak 
