### PR TITLE
Restore Prepaid menu update for 3.11

### DIFF
--- a/cfgov/jinja2/v1/_includes/organisms/_vars-mega-menu.html
+++ b/cfgov/jinja2/v1/_includes/organisms/_vars-mega-menu.html
@@ -59,7 +59,7 @@
         ('Information for Students', '/students/', []),
         ('Information for Older Americans', '/older-americans/', []),
         ('Information for Servicemembers & Veterans', '/servicemembers/', [])
-    ),(
+    ),[
         ('Getting an Auto Loan', '/consumer-tools/auto-loans/', [(
             ('Plan to Shop for Your Auto Loan', '/consumer-tools/auto-loans/plan-to-shop-for-your-auto-loan/', []),
             ('Learn to Explore Loan Choices', '/consumer-tools/auto-loans/learn-to-explore-loan-choices/', []),
@@ -70,7 +70,7 @@
         ('Owning a Home', '/owning-a-home/', []),
         ('Planning for Retirement', '/retirement/', []),
         ('Sending Money Abroad', '/sending-money/', [])
-    ),(
+    ],(
         ('Know Before You Owe Mortgages', '/know-before-you-owe/', []),
         ('Trouble Paying Your Mortgage?', '/mortgagehelp/', []),
         ('Protections Against Discrimination', '/fair-lending/', [])
@@ -150,3 +150,11 @@
         ('Contact Us', '/about-us/contact-us/', [])
     )])
 )] -%}
+
+{% if flag_enabled(request, 'PREPAID_RELEASE') %}
+    {{ nav_items[0][0][2][1].append( ('Prepaid Cards', '/consumer-tools/prepaid-cards/', [(
+        ('Choose the Right Card for Your Situation', '/consumer-tools/prepaid-cards/choose-the-right-card/', []),
+        ('Know Your Rights', '/consumer-tools/prepaid-cards/know-your-rights/', []),
+        ('Understand the Fees You Will Pay', '/consumer-tools/prepaid-cards/understand-fees/', [])
+    )]) ) }}
+{% endif %}


### PR DESCRIPTION
This PR restores the Prepaid menu item for the 3.11 release branch.

## Additions

- Restore Prepaid links in mega-menu

