### PR TITLE
3.11 wagtail jobs fixes

### DIFF
--- a/cfgov/flags/decorators.py
+++ b/cfgov/flags/decorators.py
@@ -12,7 +12,7 @@ def flag_required(flag_name, fallback_view=None, pass_if_set=True):
             if (enabled and pass_if_set) or (not enabled and not pass_if_set):
                 return func(request, *args, **kwargs)
             elif fallback_view is not None:
-                return fallback_view(request, *args, **kwargs)
+                return fallback_view(request)
             else:
                 raise Http404
 

--- a/cfgov/jinja2/v1/_includes/organisms/job-listing-list.html
+++ b/cfgov/jinja2/v1/_includes/organisms/job-listing-list.html
@@ -30,7 +30,7 @@
         {% for job in careers %}
         <li class="list_item">
             <a class="list_link"
-               href="{{ job.url }}">{{ job.title }}</a>
+               href="{{ get_protected_url(job) }}">{{ job.title }}</a>
             <p class="date">
                 CLOSING
                 {{ time.render(job.close_date, {'date': true}) }}
@@ -40,7 +40,7 @@
     </ul>
     <a class="jump-link
               jump-link__underline"
-       href="{{ more_jobs_page.url }}">
+       href="{{ get_protected_url(more_jobs_page) }}">
         <span class="jump-link_text">
           {{ more_jobs_text or 'View all job openings' }}
         </span>

--- a/cfgov/jinja2/v1/_includes/organisms/job-listing-list.html
+++ b/cfgov/jinja2/v1/_includes/organisms/job-listing-list.html
@@ -30,7 +30,7 @@
         {% for job in careers %}
         <li class="list_item">
             <a class="list_link"
-               href="{{ get_protected_url(job) }}">{{ job.title }}</a>
+               href="{{ job.relative_url(job.get_site()) }}">{{ job.title }}</a>
             <p class="date">
                 CLOSING
                 {{ time.render(job.close_date, {'date': true}) }}
@@ -40,7 +40,7 @@
     </ul>
     <a class="jump-link
               jump-link__underline"
-       href="{{ get_protected_url(more_jobs_page) }}">
+       href="{{ more_jobs_page.relative_url(more_jobs_page.get_site()) }}">
         <span class="jump-link_text">
           {{ more_jobs_text or 'View all job openings' }}
         </span>

--- a/cfgov/jobmanager/models/blocks.py
+++ b/cfgov/jobmanager/models/blocks.py
@@ -45,8 +45,6 @@ class JobListingList(OpenJobListingsMixin, organisms.ModelList):
 
     def render(self, value):
         value['careers'] = self.get_queryset(value)
-        value.update(context or {})
-
         template = '_includes/organisms/job-listing-list.html'
         return render_to_string(template, value)
 

--- a/cfgov/jobmanager/models/blocks.py
+++ b/cfgov/jobmanager/models/blocks.py
@@ -45,6 +45,8 @@ class JobListingList(OpenJobListingsMixin, organisms.ModelList):
 
     def render(self, value):
         value['careers'] = self.get_queryset(value)
+        value.update(context or {})
+
         template = '_includes/organisms/job-listing-list.html'
         return render_to_string(template, value)
 
@@ -66,7 +68,10 @@ class JobListingTable(OpenJobListingsMixin, organisms.ModelTable):
     field_headers = ['TITLE', 'GRADE', 'POSTING CLOSES', 'REGION']
 
     def make_title_value(self, instance, value):
-        return Markup('<a href="{}">{}</a>'.format(instance.url, value))
+        return Markup('<a href="{}">{}</a>'.format(
+            instance.relative_url(instance.get_site()),
+            value
+        ))
 
     def make_grades_value(self, instance, value):
         return ', '.join(sorted(g.grade.grade for g in value.all()))

--- a/cfgov/jobmanager/tests/models/test_blocks.py
+++ b/cfgov/jobmanager/tests/models/test_blocks.py
@@ -44,8 +44,9 @@ def make_job_listing_page(title, close_date=None, grades=[], regions=[],
 
 class JobListingListTestCase(HtmlMixin, TestCase):
     def setUp(self):
-        self.request = Mock(site=Site.objects.get(is_default_site=True))
-        self.more_jobs_page = Page.objects.first()
+        site = Site.objects.get(is_default_site=True)
+        self.request = Mock(site=site)
+        self.more_jobs_page = site.root_page
 
     def test_html_has_aside(self):
         block = JobListingList()

--- a/cfgov/jobmanager/tests/models/test_blocks.py
+++ b/cfgov/jobmanager/tests/models/test_blocks.py
@@ -45,10 +45,13 @@ def make_job_listing_page(title, close_date=None, grades=[], regions=[],
 class JobListingListTestCase(HtmlMixin, TestCase):
     def setUp(self):
         self.request = Mock(site=Site.objects.get(is_default_site=True))
+        self.more_jobs_page = Page.objects.first()
 
     def test_html_has_aside(self):
         block = JobListingList()
-        html = block.render(block.to_python({}))
+        html = block.render(block.to_python({
+            'more_jobs_page': self.more_jobs_page.pk,
+        }))
 
         self.assertHtmlRegexpMatches(html, (
             '^<aside class="m-jobs-list" data-qa-hook="openings-section">'
@@ -65,10 +68,9 @@ class JobListingListTestCase(HtmlMixin, TestCase):
         )
 
         block = JobListingList()
-        html = block.render(
-            block.to_python({}),
-            context={'request': self.request}
-        )
+        html = block.render(block.to_python({
+            'more_jobs_page': self.more_jobs_page.pk,
+        }))
 
         self.assertHtmlRegexpMatches(html, (
             '<ul class="list list__unstyled">.*</ul>'
@@ -89,10 +91,9 @@ class JobListingListTestCase(HtmlMixin, TestCase):
         )
 
         block = JobListingList()
-        html = block.render(
-            block.to_python({}),
-            context={'request': self.request}
-        )
+        html = block.render(block.to_python({
+            'more_jobs_page': self.more_jobs_page.pk,
+        }))
 
         self.assertHtmlRegexpMatches(html, (
             '<li class="list_item">'

--- a/cfgov/jobmanager/tests/models/test_blocks.py
+++ b/cfgov/jobmanager/tests/models/test_blocks.py
@@ -1,8 +1,9 @@
 from datetime import date
 from django.test import TestCase
 from django.utils import timezone
+from mock import Mock
 from model_mommy import mommy
-from wagtail.wagtailcore.models import Page
+from wagtail.wagtailcore.models import Page, Site
 
 from cfgov.test import HtmlMixin
 from jobmanager.models.blocks import JobListingList, JobListingTable
@@ -42,6 +43,9 @@ def make_job_listing_page(title, close_date=None, grades=[], regions=[],
 
 
 class JobListingListTestCase(HtmlMixin, TestCase):
+    def setUp(self):
+        self.request = Mock(site=Site.objects.get(is_default_site=True))
+
     def test_html_has_aside(self):
         block = JobListingList()
         html = block.render(block.to_python({}))
@@ -61,7 +65,10 @@ class JobListingListTestCase(HtmlMixin, TestCase):
         )
 
         block = JobListingList()
-        html = block.render(block.to_python({}))
+        html = block.render(
+            block.to_python({}),
+            context={'request': self.request}
+        )
 
         self.assertHtmlRegexpMatches(html, (
             '<ul class="list list__unstyled">.*</ul>'
@@ -82,7 +89,10 @@ class JobListingListTestCase(HtmlMixin, TestCase):
         )
 
         block = JobListingList()
-        html = block.render(block.to_python({}))
+        html = block.render(
+            block.to_python({}),
+            context={'request': self.request}
+        )
 
         self.assertHtmlRegexpMatches(html, (
             '<li class="list_item">'


### PR DESCRIPTION
This PR fixes several issues related to Careers pages in Wagtail:

- Job listing page view was being passed invalid request arguments.
- Links in job listing table were hardcoded to www on content.
- Links in job listing list were hardcoded to www on content.

## Changes

- Feature flag fallback view doesn't take original request parameters.
- Use relative URLs in job listing list and table.

## Testing

- Load a production database.
- Set the `WAGTAIL_CAREERS` flag on both content and localhost.
- Publish all careers pages under "About".
- Run `python cfgov/manage.py runscript migrate_job_pages` to migrate job listing pages over.
- Add a `JobListingTable` to the "Current Openings" page.
- Add a `JobListingList` to the "Careers" page.
- Load those two pages; you should see no jobs because none have been published.
- Publish one of the job pages.
- Load those two pages; links should be relative and work properly.

## Review

- @willbarton @rosskarchner @higs4281 

## Checklist

* [X] Changes are limited to a single goal (no scope creep)
* [X] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [X] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
