### PR TITLE
There's no v in the Picard 1.5 tag

### DIFF
--- a/requirements/optional-private.txt
+++ b/requirements/optional-private.txt
@@ -6,5 +6,5 @@ git+https://private.repo/CFPB/agreement_database.git@v2.2.3#egg=agreements
 git+https://private.repo/CFPB/cfgov-selfregistration.git@v1.2#egg=selfregistration
 git+https://private.repo/CFPB/django-college-cost-comparison.git@v1.2.7#egg=comparisontool
 git+https://private.repo/CFPB/knowledgebase.git@v2.1.3#egg=knowledgebase
-git+https://private.repo/CFPB/Picard.git@v1.5#egg=picard
+git+https://private.repo/CFPB/Picard.git@1.5#egg=picard
 git+https://private.repo/eregs/ip.git@1.0.2#egg=eregsip


### PR DESCRIPTION
The 1.5 release of Picard doesn't have a v in the tag name.

## Changes

- Remove the v in the Picard 1.5 tag.
