### PR TITLE
Bump picard to 1.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 ### Changed
 - Update base.html to conditionally include es5 script.
 - Wagtail upgraded to version 1.6.3.
-- Picard upgraded to version 1.5.
+- Picard upgraded to version 1.5.1.
 - Moved site root setup from Django data migration into 'initial_data' script.
 - Graduated line lengths feature flag to main stylesheet.
 - Unit tests run via tox now include optional app tests, if optional apps are present.

--- a/requirements/optional-private.txt
+++ b/requirements/optional-private.txt
@@ -6,5 +6,5 @@ git+https://private.repo/CFPB/agreement_database.git@v2.2.3#egg=agreements
 git+https://private.repo/CFPB/cfgov-selfregistration.git@v1.2#egg=selfregistration
 git+https://private.repo/CFPB/django-college-cost-comparison.git@v1.2.7#egg=comparisontool
 git+https://private.repo/CFPB/knowledgebase.git@v2.1.3#egg=knowledgebase
-git+https://private.repo/CFPB/Picard.git@1.5#egg=picard
+git+https://private.repo/CFPB/Picard.git@1.5.1#egg=picard
 git+https://private.repo/eregs/ip.git@1.0.2#egg=eregsip


### PR DESCRIPTION
Update to picard 1.5.1, which is a bugfix release addressing missing files in the package.

## Additions

-

## Removals

-

## Changes

-

## Testing

-

## Review

- @willbarton

## Screenshots


## Notes

-

## Todos

-

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)

