### PR TITLE
Fix job grade ordering (4.0 branch)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Frontend: upgrade `gulp-sourcemaps` from `1.6.0` to `2.1.1`.
 - Modified org structure to change the Assistant Director to `Stacy Canan`.
 - Updated "Standing up for you" stats on the homepage.
+- Fixed grade ordering on job listing posts.
 
 ### Removed
 - Removed Handlebars from `package.json` and `cf_notifier.js`.

--- a/cfgov/jinja2/v1/job-description-page/index.html
+++ b/cfgov/jinja2/v1/job-description-page/index.html
@@ -29,7 +29,7 @@
             <dt>Grade{{ page.grades.all() | pluralize() }}:</dt>
             <dd>
                 {% if page.grades.exists() %}
-                <strong>({{ page.grades.all() | join(', ') }})</strong>
+                <strong>({{ page.ordered_grades | join(', ') }})</strong>
                 {% endif %}
                 ${{ '{:,.0f}'.format( page.salary_min ) }}–${{ '{:,.0f}'.format( page.salary_max ) }}
             </dd>

--- a/cfgov/jobmanager/models/pages.py
+++ b/cfgov/jobmanager/models/pages.py
@@ -56,3 +56,9 @@ class JobListingPage(CFGOVPage):
     template = 'job-description-page/index.html'
 
     objects = PageManager()
+
+    @property
+    def ordered_grades(self):
+        """Return a list of job grades in numerical order."""
+        grades = set(g.grade.grade for g in self.grades.all())
+        return sorted(map(int, grades))

--- a/cfgov/jobmanager/models/pages.py
+++ b/cfgov/jobmanager/models/pages.py
@@ -59,6 +59,9 @@ class JobListingPage(CFGOVPage):
 
     @property
     def ordered_grades(self):
-        """Return a list of job grades in numerical order."""
+        """Return a list of job grades in numerical order.
+
+        Non-numeric grades are sorted alphabetically after numeric grades.
+        """
         grades = set(g.grade.grade for g in self.grades.all())
-        return sorted(map(int, grades))
+        return sorted(grades, key=lambda g: int(g) if g.isdigit() else g)

--- a/cfgov/jobmanager/tests/models/test_pages.py
+++ b/cfgov/jobmanager/tests/models/test_pages.py
@@ -73,13 +73,22 @@ class JobListingPageTestCase(TestCase):
         return page
 
     def test_ordered_grades(self):
-        page = self.make_page_with_grades(3, 2, 1)
-        self.assertEqual(page.ordered_grades, [1, 2, 3])
+        page = self.make_page_with_grades('3', '2', '1')
+        self.assertEqual(page.ordered_grades, ['1', '2', '3'])
 
     def test_ordered_grades_removes_duplicates(self):
-        page = self.make_page_with_grades(3, 2, 2, 2, 1, 1)
-        self.assertEqual(page.ordered_grades, [1, 2, 3])
+        page = self.make_page_with_grades('3', '2', '2', '2', '1', '1')
+        self.assertEqual(page.ordered_grades, ['1', '2', '3'])
 
     def test_ordered_grades_sorts_numerically(self):
-        page = self.make_page_with_grades(100, 10, 11, 1, 2, 3)
-        self.assertEqual(page.ordered_grades, [1, 2, 3, 10, 11, 100])
+        page = self.make_page_with_grades('100', '10', '11', '1')
+        self.assertEqual(page.ordered_grades, ['1', '10', '11', '100'])
+
+    def test_ordered_grades_non_numeric_after_numeric(self):
+        page = self.make_page_with_grades('2', '1', 'b', 'B', 'a', 'A')
+        self.assertEqual(page.ordered_grades, ['1', '2', 'A', 'B', 'a', 'b'])
+
+    def test_ordered_grades_returns_strings(self):
+        page = self.make_page_with_grades('3', '2', '1')
+        for grade in page.ordered_grades:
+            self.assertIsInstance(grade, basestring)


### PR DESCRIPTION
Implementation of #2500 (Fix job grade ordering) for the 4.0 branch.

## Changes

- Job grades are displayed using a sorting function.

## Testing

- See #2500 for testing instructions.

## Review

- @cfpb/cfgov-backends 

## Checklist

* [X] Changes are limited to a single goal (no scope creep)
* [X] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [X] Passes all existing automated tests
* [X] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [X] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
