### PR TITLE
Remove tax-time-saving from SHEER_SITES

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 
 
 ### Removed
-
+- `tax-time-saving` reference in `base.py` (it moved to Wagtail)
 
 
 ## 4.0.0

--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -426,9 +426,6 @@ SHEER_SITES = {
         'know-before-you-owe':
             Path(os.environ.get('KBYO_SHEER_PATH') or
             Path(REPOSITORY_ROOT, '../know-before-you-owe/dist')),
-        'tax-time-saving':
-            Path(os.environ.get('TAX_TIME_SHEER_PATH') or
-            Path(REPOSITORY_ROOT, '../tax-time-saving/dist')),
 }
 
 #The base URL for the API that we use to access layers and the regulation.

--- a/docs/development-tips.md
+++ b/docs/development-tips.md
@@ -26,9 +26,8 @@ and then indexed within this cfgov-refresh project.
 The non-v1 apps are the following:
 
  - [Owning a Home](https://github.com/cfpb/owning-a-home).
- - [Tax time savings](https://github.com/cfpb/tax-time-saving).
- - fin-ed-resources (not public) - for the Education Resources section.
- - know-before-you-owe (not public) - for the Consumer Tools > Know before you owe section.
+ - fin-ed-resources (ghe/CFGOV/fin-ed-resources) - for the Education Resources section.
+ - know-before-you-owe (ghe/CFGOV/know-before-you-owe) - for the Consumer Tools > Know before you owe section.
 
 After installing these projects as sibling directories to the `cfgov-refresh` repository,
 build the third-party projects per their directions,


### PR DESCRIPTION
Tax Time Saving has been moved to a Wagtail page, so let's stop handling it as a Sheer site.

## Removals

- `tax-time-saving` removed from `SHEER_SITES` setting in `base.py`

## Review

- @rosskarchner 
- @cfpb/cfgov-backends 

## Todos

- Deprecate the [cfpb/tax-time-saving repo](https://github.com/cfpb/tax-time-saving)

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)