### PR TITLE
refactored get_form_id into the filterable mixin class

### DIFF
--- a/cfgov/v1/__init__.py
+++ b/cfgov/v1/__init__.py
@@ -195,5 +195,5 @@ def get_filter_data(page):
     for ancestor in page.get_ancestors().reverse().specific():
         if ancestor.specific_class.__name__ in ['BrowseFilterablePage', 'SublandingFilterablePage',
                                                 'EventArchivePage', 'NewsroomLandingPage']:
-            return util.get_form_id(ancestor), ancestor
+            return ancestor.form_id(), ancestor
     return None, None

--- a/cfgov/v1/models/base.py
+++ b/cfgov/v1/models/base.py
@@ -150,7 +150,7 @@ class CFGOVPage(Page):
         form = FilterableListForm(parent=activity_log, hostname=request.site.hostname)
         available_tags = [tag[0] for name, tags in form.fields['topics'].choices for tag in tags]
         tags = []
-        index = util.get_form_id(activity_log)
+        index = activity_log.form_id()
         for tag in self.tags.slugs():
             if tag in available_tags:
                 tags.append('filter%s_topics=' % index + urllib.quote_plus(tag))

--- a/cfgov/v1/models/sublanding_page.py
+++ b/cfgov/v1/models/sublanding_page.py
@@ -77,7 +77,7 @@ class SublandingPage(CFGOVPage):
                         and 'archive' not in p.title.lower()]
         posts_tuple_list = []
         for page in filter_pages:
-            form_id = str(util.get_form_id(page))
+            form_id = str(page.form_id())
             form = FilterableListForm(parent=page, hostname=request.site.hostname)
             for post in form.get_page_set():
                 posts_tuple_list.append((form_id, post))

--- a/cfgov/v1/util/filterable_list.py
+++ b/cfgov/v1/util/filterable_list.py
@@ -93,3 +93,10 @@ class FilterableListMixin(object):
 
     def per_page_limit(self):
         return 10
+
+    def form_id(self):
+        form_ids = self.get_filter_ids()
+        if form_ids:
+            return form_ids[0]
+        else:
+            return 0

--- a/cfgov/v1/util/util.py
+++ b/cfgov/v1/util/util.py
@@ -26,14 +26,6 @@ ERROR_MESSAGES = {
     }
 }
 
-def get_form_id(page):
-    form_ids = page.get_filter_ids()
-    if form_ids:
-        return form_ids[0]
-    else:
-        return 0
-
-
 def instanceOfBrowseOrFilterablePages(page):
     from ..models import BrowsePage, BrowseFilterablePage
     return isinstance(page, (BrowsePage, BrowseFilterablePage))


### PR DESCRIPTION
This PR refactors the function get_form_id into the FilterableMixin class, which it needs to be called on anyway in order to produce the correct result.

## Additions

- adds form_id to the FilterableMixin class

## Changes

- change calls to util.get_form_id(page) into calls to page.form_id()

## Testing

- no new tests required; all current tests should pass

## Review

@chosak @richaagarwal @willbarton 

## Todos

The plan is to eventually replace all the weird get_whatever functions that take pages as arguments with class instance methods. These functions result in a great deal of confusing spaghetti code and logical fragmentation of the codebase.

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)

