### PR TITLE
switch to html.parser to avoid jenkins dependency

### DIFF
--- a/cfgov/scripts/static_asset_smoke_test.py
+++ b/cfgov/scripts/static_asset_smoke_test.py
@@ -37,7 +37,7 @@ def check_static(url):
 
     count = 0
     failures = []
-    soup = bs(requests.get(url).content, 'lxml')
+    soup = bs(requests.get(url).content, 'html.parser')
     static_js = [
         link.get('src') for link in soup.findAll('script') if
         link.get('src') and 'static' in link.get('src')


### PR DESCRIPTION
bs4 needs a parser, and `html.parser` is fine for this test's purposes.

## Changes

- switch from `lxml` to `html.parser`

## Testing

- Try running `python cfgov/scripts/static_asset_smoke_test.py -v` with the changed parser.

## Note
Smoketests have been fixed manually in Jenkins for now, so this is mop-up.

## Review
@rosskarchner @richaagarwal 

## changelog
I think this is below the changelog threshold.
