### PR TITLE
Fix Django system checks when using test settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Refactoring email signup to remove validate.js.
 - Frontend: update `browser-sync` to version `2.17.5` from `2.11.2`.
 - Frontend: update `mkdirp` to version `0.5.1` from `0.3.0`.
+- Fixed broken `manage.py check` command when using `cfgov.settings.test`.
 
 
 ### Removed

--- a/cfgov/cfgov/settings/test.py
+++ b/cfgov/cfgov/settings/test.py
@@ -18,3 +18,12 @@ LOGGING = {}
 INSTALLED_APPS += (
     'wagtail.tests.testapp',
 )
+
+WAGTAILADMIN_RICH_TEXT_EDITORS = {
+    'default': {
+        'WIDGET': 'wagtail.wagtailadmin.rich_text.HalloRichTextArea',
+    },
+    'custom': {
+        'WIDGET': 'wagtail.tests.testapp.rich_text.CustomRichTextArea',
+    },
+}


### PR DESCRIPTION
The introduction of the `wagtail.tests.testapp` app for testing in #2481 broke the ability to run the [Django system checks](https://docs.djangoproject.com/en/1.8/ref/checks/) when using test settings (`cfgov.settings.test`).

Previously, running

```
$ DJANGO_SETTINGS_MODULE=cfgov.settings.test python cfgov/manage.py check
```

would produce this error:

```
  File "/Users/user/.virtualenvs/cfgov-refresh/lib/python2.7/site-packages/wagtail/wagtailadmin/rich_text.py", line 56, in get_rich_text_editor_widget
    editor = editor_settings[name]
KeyError: u'custom'
```

This PR copies [settings logic in Wagtail](https://github.com/torchbox/wagtail/blob/v1.6.3/wagtail/tests/settings.py#L188) that sets up an appropriate custom rich text editor for the test app, thus allowing all checks to pass.

## Changes

- `cfgov.settings.test` now explicitly sets `WAGTAILADMIN_RICH_TEXT_EDITORS` to allow system checks to pass when including `wagtail.tests.testapp` as an installed app.

## Testing

- Run the following command and observe that it passes with no errors:

 ```
$ DJANGO_SETTINGS_MODULE=cfgov.settings.test python cfgov/manage.py check
System check identified no issues (0 silenced).
```

## Review

- @willbarton 

## Checklist

* [X] Changes are limited to a single goal (no scope creep)
* [X] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [X] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [X] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)

