### PR TITLE
Disable htmlmin 4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
   to the level of a MAJOR or MINOR update.
 
 ---------------------------------------
+## 4.0.2
+
+### Removals
+- django-htmlmin removed from middleware and dependencies.
+
 ## 4.0.1
 
 ### Changed

--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -100,8 +100,6 @@ MIDDLEWARE_CLASSES = (
     'wagtail.wagtailredirects.middleware.RedirectMiddleware',
     'transition_utilities.middleware.RewriteNemoURLsMiddleware',
     'v1.middleware.StagingMiddleware',
-    'htmlmin.middleware.HtmlMinifyMiddleware',
-    'htmlmin.middleware.MarkRequestMiddleware',
 )
 
 ROOT_URLCONF = 'cfgov.urls'

--- a/cfgov/cfgov/settings/test.py
+++ b/cfgov/cfgov/settings/test.py
@@ -1,7 +1,5 @@
 from .local import *
 
-HTML_MINIFY = False
-
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.sqlite3',

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -41,4 +41,3 @@ unipath>=1.1,<=2.0
 vobject==0.9.1
 wagtail==1.6.3
 Wand==0.4.2
-django-htmlmin==0.10.0


### PR DESCRIPTION
### Removals
- django-htmlmin removed from middleware and dependencies.