### PR TITLE
Updating newsroom page to remove Laura Van Dyke

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Removed Handlebars from `package.json` and `cf_notifier.js`.
 - `NewsroomFilterForm` and `ActivityLogFilterForm` and related tests
 - Removed `gulp-load-plugins` from `package.json`.
+- Removed  Laura Van Dyke from the press resources page.
 
 ## 3.11.1
 

--- a/cfgov/jinja2/v1/newsroom/press-resources/index.html
+++ b/cfgov/jinja2/v1/newsroom/press-resources/index.html
@@ -82,21 +82,6 @@
             </section>
 
             <section class="contact-person content-l_col-1-2">
-                <h3 class="h4">Laura Van Dyke</h3>
-                <div class="contact-person_title">Press Assistant</div>
-                <ul class="contact-person_methods list list__unstyled">
-                    <li class="list_item">
-                        <a href="mailto:laura.vandyke@cfpb.gov">
-                            laura.vandyke@cfpb.gov
-                        </a>
-                    </li>
-                    <li class="list_item">
-                        <a href="tel:2024359019">(202) 435-9019</a>
-                    </li>
-                </ul>
-            </section>
-
-            <section class="contact-person content-l_col-1-2">
                 <h3 class="h4">Moira Vahey</h3>
                 <div class="contact-person_title">Spokesperson</div>
                 <ul class="contact-person_methods list list__unstyled">


### PR DESCRIPTION
Updating newsroom page to remove Laura Van Dyke

## Removals

-  Removed  Laura Van Dyke from the press resources page.


## Testing

- Visit `http://localhost:8000/about-us/newsroom/press-resources/` and verify the resources are correct.

## Review

- @willbarton 
- @sarahsimpson09 

## Screenshots

<img width="1016" alt="screen shot 2016-11-04 at 12 00 34 pm" src="https://cloud.githubusercontent.com/assets/1696212/20012620/5d9b433a-a286-11e6-9dd2-0423dc49f1bb.png">

## Notes

-

## Todos

-

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
