### PR TITLE
Fix for link blob heading spacing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Frontend: update `mkdirp` to version `0.5.1` from `0.3.0`.
 - Fixed broken `manage.py check` command when using `cfgov.settings.test`.
 - Update `snyk` to version `1.19.1` from `1.13.2`.
+- Fixed empty `heading` value in link blobs
 
 ### Removed
 - `tax-time-saving` reference in `base.py` (it moved to Wagtail)

--- a/cfgov/jinja2/v1/_includes/molecules/link-blob.html
+++ b/cfgov/jinja2/v1/_includes/molecules/link-blob.html
@@ -43,7 +43,7 @@
 {% endif %}
 
 {{ info_unit( {
-    'heading':     '<h3>' ~ value.heading ~ '</h3>',
+    'heading':     '<h3>' ~ value.heading ~ '</h3>' if value.heading else '',
     'sub_heading': sub_heading,
     'body':        parse_links(value.body) | safe,
     'links':       value.links


### PR DESCRIPTION
The link blob is including an `h3` even if the `value.heading` doesn't exist causing a spacing error from our `h3+h4` rules. Updated the `heading` value to  conditionally set the `h3` only if the `value.heading` exists.

## Changes

- Added a conditional statement to the link blob `heading` value

## Testing

- 

## Review

- @sebworks 

## Notes

- Are there tests for these link blobs I can update?

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [x] Passes all existing automated tests
* [ ] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices
* [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)