### PR TITLE
Refactor Activity Snippets and sort by latest 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,10 +16,13 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 
 ## Changed
 - external-site redirector now requires URLs to either be whitelisted or signed
+- Move logic for activity snippets out of template
+- Move `get_page_state_url` out of templatetags to avoid circular dependencies
 
 ### Fixed
 - Fixed bug stopping videos in HTTPS pages.
 - bug that wasn't signing links already coded to /external-site
+- Sort activity snippets by latest date
 
 
 ## 4.3.1

--- a/cfgov/jinja2/v1/_includes/macros/activity-snippets.html
+++ b/cfgov/jinja2/v1/_includes/macros/activity-snippets.html
@@ -25,7 +25,7 @@
    ========================================================================== #}
 
 {% macro render(tag,
-                activity_types=['posts', 'op-ed', 'newsroom', 'press release', 'speech', 'testimony'],
+                activity_types=['blog', 'op-ed', 'newsroom', 'press release', 'speech', 'testimony'],
                 include_date_flag=false,
                 number_columns=1
                )
@@ -72,67 +72,29 @@
 
 {% macro _activity_snippet(activity_type, tags, quantity, include_date_flag=false) %}
     {% import 'macros/category-icon.html' as category_icon %}
-    {% if activity_type|lower == 'posts' %}
-        {% set icon = category_icon.render('blog') %}
-        {% set header = 'Blog' %}
-        {% set categories = ['at-the-cfpb', 'policy_compliance', 'data-research-reports', 'info-for-consumers'] %}
-        {% set feed = cfgovpage_objects.live_shared(request.site.hostname).filter(categories__name__in=categories)[:quantity] %}
-    {% elif activity_type|lower == 'op-ed' %}
-        {% set icon = category_icon.render(activity_type) %}
-        {% set header = 'Op-Ed' %}
-        {% set categories = ['op-ed'] %}
-        {% set feed = cfgovpage_objects.live_shared(request.site.hostname).filter(categories__name__in=categories)[:quantity] %}
-    {% elif activity_type|lower == 'newsroom' %}
-        {% set icon = category_icon.render(activity_type) %}
-        {% set header = 'Newsroom' %}
-        {% set categories = ['op-ed', 'press-release', 'speech', 'testimony'] %}
-        {% set feed = cfgovpage_objects.live_shared(request.site.hostname).filter(categories__name__in=categories)[:quantity] %}
-    {% elif activity_type|lower == 'press release' %}
-        {% set icon = category_icon.render(activity_type) %}
-        {% set header = 'Press Release' %}
-        {% set categories = ['press-release'] %}
-        {% set feed = cfgovpage_objects.live_shared(request.site.hostname).filter(categories__name__in=categories)[:quantity] %}
-    {% elif activity_type|lower == 'speech' %}
-        {% set icon = category_icon.render(activity_type) %}
-        {% set header = 'Speech' %}
-        {% set categories = ['speech'] %}
-        {% set feed = cfgovpage_objects.live_shared(request.site.hostname).filter(categories__name__in=categories)[:quantity] %}
-    {% elif activity_type|lower == 'testimony' %}
-        {% set icon = category_icon.render(activity_type) %}
-        {% set header = 'Testimony' %}
-        {% set categories = ['testimony'] %}
-        {% set feed = cfgovpage_objects.live_shared(request.site.hostname).filter(categories__name__in=categories)[:quantity] %}
-    {% elif activity_type|lower == 'cfpb_report' %}
-        {% set icon = category_icon.render(activity_type) %}
-        {% set header = 'Reports' %}
-        {% set categories = ['consumer-complaint', 'super-highlight', 'data-point', 'industry-markets', 'consumer-edu-empower', 'to-congress'] %}
-        {% set feed = cfgovpage_objects.live_shared(request.site.hostname).filter(categories__name__in=categories)[:quantity] %}
-    {% else %}
-        {% set icon = category_icon.render('blog') %}
-        {% set header = 'Feed' %}
-        {% set categories = ['at-the-cfpb', 'policy_compliance', 'data-research-reports', 'info-for-consumers'] %}
-        {% set feed = cfgovpage_objects.live_shared(request.site.hostname).filter(categories__name__in=categories)[:quantity] %}
-    {% endif %}
+    {% set feed = get_latest_activities(activity_type, request.site.hostname) %}
     {% if feed %}
-    <div class="activity">
-        <h3 class="h4">{{ icon }} {{ header }}</h3>
-        <ul class="list list__unstyled list__spaced list__links">
-        {% for item in feed %}
-            <li class="list_item">
-                <a class="list_link"
-                   href="{{ get_protected_url(item) }}">
-                    {{ item.preview_title | safe if item.preview_title else item.title | safe  }}
-                    {%- if include_date_flag and item.specific.date_published -%}
-                        <span class="date">
-                            &ndash;
-                            {% import 'macros/time.html' as time %}
-                            {{ time.render(item.specific.date_published, {'date':true}) }}
-                        </span>
-                    {%- endif -%}
-                </a>
-            </li>
-        {% endfor %}
-        </ul>
-    </div>
+      {% set header = activity_type.title() %}
+      {% set icon = category_icon.render(activity_type) %}
+      <div class="activity">
+          <h3 class="h4">{{ icon }} {{ header }}</h3>
+          <ul class="list list__unstyled list__spaced list__links">
+          {% for item in feed %}
+              <li class="list_item">
+                  <a class="list_link"
+                     href="{{ get_protected_url(item) }}">
+                      {{ item.preview_title | safe if item.preview_title else item.title | safe  }}
+                      {%- if include_date_flag and item.specific.date_published -%}
+                          <span class="date">
+                              &ndash;
+                              {% import 'macros/time.html' as time %}
+                              {{ time.render(item.specific.date_published, {'date':true}) }}
+                          </span>
+                      {%- endif -%}
+                  </a>
+              </li>
+          {% endfor %}
+          </ul>
+      </div>
     {% endif %}
 {% endmacro %}

--- a/cfgov/jinja2/v1/about-us/index.html
+++ b/cfgov/jinja2/v1/about-us/index.html
@@ -180,7 +180,7 @@
         {# TODO Add Events to the Activity Snippets #}
 
         {% import 'macros/activity-snippets.html' as activity_snippets with context %}
-        {% set activities_feed = activity_snippets.render(tags, ['posts', 'newsroom'], include_date_flag=true) %}
+        {% set activities_feed = activity_snippets.render(tags, ['blog', 'newsroom'], include_date_flag=true) %}
         {% include 'templates/activities-feed.html' %}
         <a class="jump-link jump-link__underline"
            href="/activity-log/">

--- a/cfgov/v1/__init__.py
+++ b/cfgov/v1/__init__.py
@@ -19,8 +19,8 @@ from .util.util import get_unique_id, get_secondary_nav_items
 from wagtail.wagtailcore.rich_text import expand_db_html, RichText
 from bs4 import BeautifulSoup, NavigableString
 from processors.processors_common import fix_link
-from v1.routing import get_page_relative_url
 from core.utils import signed_redirect, unsigned_redirect, sign_url
+from v1.routing import get_page_state_url, get_protected_url, get_page_relative_url
 
 
 default_app_config = 'v1.apps.V1AppConfig'
@@ -32,7 +32,7 @@ def environment(**options):
     env = sheerlike_environment(**options)
     env.autoescape = True
     from v1.models import CFGOVPage
-    from v1.templatetags import share
+    from v1.templatetags.activity_feed import get_latest_activities
     from v1.util import ref
     env.globals.update({
         'static': staticfiles_storage.url,
@@ -48,20 +48,21 @@ def environment(**options):
         'choices_for_page_type': ref.choices_for_page_type,
         'is_blog': ref.is_blog,
         'is_report': ref.is_report,
-        'get_page_state_url': share.get_page_state_url,
+        'get_page_state_url': get_page_state_url,
         'parse_links': parse_links,
-        'get_protected_url': get_protected_url,
         'related_metadata_tags': related_metadata_tags,
         'get_filter_data': get_filter_data,
         'cfgovpage_objects': CFGOVPage.objects,
         'signed_redirect': signed_redirect,
         'unsigned_redirect': unsigned_redirect,
+        'get_protected_url': get_protected_url,
+        'get_latest_activities': get_latest_activities,
     })
 
     env.filters.update({
         'linebreaksbr': linebreaksbr,
         'pluralize': pluralize,
-        'slugify': slugify
+        'slugify': slugify,
     })
     return env
 
@@ -172,20 +173,6 @@ def render_stream_child(context, stream_child):
     unescaped = HTMLParser.HTMLParser().unescape(html)
     # Return the rendered template as safe html
     return Markup(unescaped)
-
-
-@contextfunction
-def get_protected_url(context, page):
-    if page:
-        request = context['request']
-
-        if page.live or page.shared and request.is_staging:
-            url = get_page_relative_url(page, request.site)
-
-            if url:
-                return url
-
-    return '#'
 
 
 @contextfunction

--- a/cfgov/v1/models/base.py
+++ b/cfgov/v1/models/base.py
@@ -35,6 +35,7 @@ from wagtail.wagtailcore.url_routing import RouteResult
 
 from taggit.models import TaggedItemBase
 
+
 from v1 import get_protected_url
 from v1.atomic_elements import molecules, organisms
 from v1.util import ref

--- a/cfgov/v1/routing.py
+++ b/cfgov/v1/routing.py
@@ -1,4 +1,6 @@
 from django.core.urlresolvers import reverse
+from django.conf import settings
+
 from wagtail.wagtailcore.utils import WAGTAIL_APPEND_SLASH
 from jinja2 import contextfunction
 from django import template
@@ -64,7 +66,7 @@ def get_page_state_url(context, page):
     if url is None:  # If page is not aligned to a site root return None
         return None
     page_hostname = urlparse(url).hostname
-    staging_hostname = os.environ.get('DJANGO_STAGING_HOSTNAME')
+    staging_hostname = settings.STAGING_HOSTNAME
     if not page.live and page.shared and staging_hostname != page_hostname:
         url = url.replace(page_hostname, staging_hostname)
     return url

--- a/cfgov/v1/routing.py
+++ b/cfgov/v1/routing.py
@@ -1,5 +1,12 @@
 from django.core.urlresolvers import reverse
 from wagtail.wagtailcore.utils import WAGTAIL_APPEND_SLASH
+from jinja2 import contextfunction
+from django import template
+from wagtail.wagtailcore.models import Page
+from urlparse import urlparse
+import os
+
+register = template.Library()
 
 
 def get_url_parts_for_site(page, site):
@@ -46,3 +53,32 @@ def get_page_relative_url(page, site):
         return page_path
     else:
         return root_url + page_path
+
+
+@register.assignment_tag(takes_context=True)
+def get_page_state_url(context, page):
+    page = Page.objects.get(id=page.id).specific
+    if not page.live and not page.shared:
+        return None
+    url = page.url
+    if url is None:  # If page is not aligned to a site root return None
+        return None
+    page_hostname = urlparse(url).hostname
+    staging_hostname = os.environ.get('DJANGO_STAGING_HOSTNAME')
+    if not page.live and page.shared and staging_hostname != page_hostname:
+        url = url.replace(page_hostname, staging_hostname)
+    return url
+
+
+@contextfunction
+def get_protected_url(context, page):
+    if page:
+        request = context['request']
+
+        if page.live or page.shared and request.is_staging:
+            url = get_page_relative_url(page, request.site)
+
+            if url:
+                return url
+
+    return '#'

--- a/cfgov/v1/templatetags/activity_feed.py
+++ b/cfgov/v1/templatetags/activity_feed.py
@@ -1,0 +1,6 @@
+from v1.util.categories import clean_categories
+from v1.models.learn_page import AbstractFilterPage
+
+def get_latest_activities(activity_type, hostname, quantity=5):
+	categories = clean_categories([activity_type])
+	return AbstractFilterPage.objects.live_shared(hostname).filter(categories__name__in=categories).order_by('-date_published')[:quantity]

--- a/cfgov/v1/templatetags/share.py
+++ b/cfgov/v1/templatetags/share.py
@@ -1,10 +1,7 @@
-import os
-from urlparse import urlparse
-
 from django import template
-from wagtail.wagtailcore.models import Page
 
 from v1.models import CFGOVUserPagePermissionsProxy
+from wagtail.wagtailcore.models import Page
 
 register = template.Library()
 
@@ -17,21 +14,6 @@ def is_shared(page):
             return True
         else:
             return False
-
-
-@register.assignment_tag(takes_context=True)
-def get_page_state_url(context, page):
-    page = Page.objects.get(id=page.id).specific
-    if not page.live and not page.shared:
-        return None
-    url = page.url
-    if url is None:  # If page is not aligned to a site root return None
-        return None
-    page_hostname = urlparse(url).hostname
-    staging_hostname = os.environ.get('DJANGO_STAGING_HOSTNAME')
-    if not page.live and page.shared and staging_hostname != page_hostname:
-        url = url.replace(page_hostname, staging_hostname)
-    return url
 
 
 @register.assignment_tag(takes_context=True)

--- a/cfgov/v1/tests/templatetags/test_activity_feed.py
+++ b/cfgov/v1/tests/templatetags/test_activity_feed.py
@@ -1,0 +1,54 @@
+import datetime
+
+from unittest import TestCase
+
+from wagtail.wagtailcore.models import Site
+
+from v1.models import BlogPage
+from v1.models.base import CFGOVPageCategory
+from v1.templatetags import activity_feed
+from v1.tests.wagtail_pages.helpers import publish_page
+
+class TestActivityFeed(TestCase):
+
+
+    def test_get_latest_activities_returns_relevant_activities(self):
+        hostname = Site.objects.get(is_default_site=True).hostname
+        page1 = BlogPage(title='test page')
+        # Give it a blog subcategory
+        page1.categories.add(CFGOVPageCategory(name='at-the-cfpb'))
+        publish_page(page1)
+
+        page2 = BlogPage(title='another test page')
+        # Don't give it a blog subcategory
+        publish_page(page2)
+
+        activities = activity_feed.get_latest_activities(activity_type='blog', hostname=hostname) 
+        self.assertEquals(len(activities), 1)
+        self.assertEquals(activities[0].specific, page1)
+
+
+    def test_get_latest_activities_returns_activities_sorted(self):
+        hostname = Site.objects.get(is_default_site=True).hostname
+        page1 = BlogPage(title='oldest page', date_published=datetime.date(2015, 9, 3))
+        # Give it a newsroom subcategory
+        page1.categories.add(CFGOVPageCategory(name='press-release'))
+        publish_page(page1)
+
+        page2 = BlogPage(title='second page', date_published=datetime.date(2016, 5, 3))
+        # Give it a newsroom subcategory
+        page2.categories.add(CFGOVPageCategory(name='speech'))
+        publish_page(page2)
+
+        page3 = BlogPage(title='most recent page')
+        # Give it a newsroom subcategory
+        page3.categories.add(CFGOVPageCategory(name='testimony'))
+        publish_page(page3)
+
+        activities = activity_feed.get_latest_activities(activity_type='newsroom', hostname=hostname) 
+        self.assertEquals(len(activities), 3)
+        self.assertEquals(activities[0].specific, page3)
+        self.assertEquals(activities[1].specific, page2)
+        self.assertEquals(activities[2].specific, page1)
+
+

--- a/cfgov/v1/tests/templatetags/test_share.py
+++ b/cfgov/v1/tests/templatetags/test_share.py
@@ -2,6 +2,7 @@ import mock
 
 from unittest import TestCase
 from v1.templatetags import share
+from v1.routing import get_page_state_url
 from v1.tests.wagtail_pages import helpers
 from v1.models.base import CFGOVPage, CFGOVPagePermissionTester, CFGOVUserPagePermissionsProxy, User
 from wagtail.wagtailcore.models import Site
@@ -84,7 +85,7 @@ class TemplatetagsShareTestCase(TestCase):
         self.page.shared = False
         self.page.save()
 
-        result = share.get_page_state_url(None, self.page)
+        result = get_page_state_url(None, self.page)
         self.assertIsNone(result)
 
     def test_get_page_state_url_staged(self):
@@ -99,7 +100,7 @@ class TemplatetagsShareTestCase(TestCase):
         self.page.shared = True
         self.page.save()
 
-        result = share.get_page_state_url(None, self.page)
+        result = get_page_state_url(None, self.page)
         self.assertEqual(result, self.page.url.replace('http://localhost',
                                                        'http://content.localhost'))
 
@@ -112,7 +113,7 @@ class TemplatetagsShareTestCase(TestCase):
         self.page.shared = False
         self.page.save()
 
-        result = share.get_page_state_url(None, self.page)
+        result = get_page_state_url(None, self.page)
         self.assertEqual(result, self.page.url)
 
     def test_v1page_permissions_no_permissions_in_context(self):
@@ -157,7 +158,7 @@ class TemplatetagsShareTestCase(TestCase):
         for site in site_objects:
             site.delete()
 
-        result = share.get_page_state_url(None, self.page)
+        result = get_page_state_url(None, self.page)
 
         for site in site_objects:
             site.save()

--- a/cfgov/v1/tests/test_filterable_list_form.py
+++ b/cfgov/v1/tests/test_filterable_list_form.py
@@ -1,12 +1,13 @@
 from django.test import TestCase
-from ..models import BlogPage
-from ..models.learn_page import EventPage
-from v1.forms import FilterableListForm
-from v1.models.base import CFGOVPageCategory
-from v1.tests.wagtail_pages.helpers import publish_page
-from wagtail.wagtailcore.models import Site
-from v1.models.learn_page import AbstractFilterPage
 
+from wagtail.wagtailcore.models import Site
+
+from v1.forms import FilterableListForm
+from v1.models import BlogPage
+from v1.models.base import CFGOVPageCategory
+from v1.models.learn_page import AbstractFilterPage, EventPage
+from v1.tests.wagtail_pages.helpers import publish_page
+from v1.util.categories import clean_categories
 
 class TestFilterableListForm(TestCase):
 
@@ -89,11 +90,11 @@ class TestFilterableListForm(TestCase):
     def test_clean_categories_converts_blog_subcategories_correctly(self):
         form = self.setUpFilterableForm()
         form.data = {'categories': ['blog']}
-        form.clean_categories()
+        clean_categories(selected_categories=form.data.get('categories'))
         self.assertEquals(form.data['categories'], ['blog', 'at-the-cfpb', 'policy_compliance', 'data-research-reports', 'info-for-consumers'])
 
     def test_clean_categories_converts_reports_subcategories_correctly(self):
         form = self.setUpFilterableForm()
         form.data = {'categories': ['research-reports']}
-        form.clean_categories()
+        clean_categories(selected_categories=form.data.get('categories'))
         self.assertEquals(form.data['categories'], ['research-reports', 'consumer-complaint', 'super-highlight', 'data-point', 'industry-markets', 'consumer-edu-empower', 'to-congress'])

--- a/cfgov/v1/util/categories.py
+++ b/cfgov/v1/util/categories.py
@@ -1,0 +1,25 @@
+from v1.util import ref 
+
+import logging
+logger = logging.getLogger(__name__)
+
+def clean_categories(selected_categories):
+    """ This is a (hopefully) temporary solution for dealing w/ the fact
+    that we show Blog and Reports as options for filtering, but
+    aren't categories themselves. Rather, they consist of sub-categories,
+    but since we aren't showing those sub-categories to the end user,
+    selecting the parent category is equivalent to all of them
+    getting checked. The mapping of Blog and Reports to their
+    respective categories exists in cfgov/v1/util/ref.py
+    """
+    if not selected_categories:
+        return None
+    subcategories_dict = dict(ref.categories)
+    for unicorn in ['blog', 'newsroom', 'research-reports']:
+        if unicorn in selected_categories:
+            if unicorn == 'research-reports':
+                unicorn = 'Research Report'
+            for category in subcategories_dict[unicorn.title()]:
+                selected_categories.append(category[0].lower())
+    logger.info('Filtering by categories {}'.format(selected_categories))
+    return selected_categories

--- a/cfgov/v1/util/util.py
+++ b/cfgov/v1/util/util.py
@@ -35,7 +35,7 @@ def instanceOfBrowseOrFilterablePages(page):
 # TODO: Move into BrowsePage class once BrowseFilterablePage has been merged
 # into BrowsePage
 def get_secondary_nav_items(request, current_page):
-    from ..templatetags.share import get_page_state_url
+    from v1.routing import get_page_state_url
     on_staging = os.environ.get('DJANGO_STAGING_HOSTNAME') == request.site.hostname
     nav_items = []
     parent = current_page.get_parent().specific


### PR DESCRIPTION
## Overview
Per GHE 458: 
Currently we show "Latest Activities" on the About Us page, and they're in no particular order -- http://www.consumerfinance.gov/about-us/
We should sort them by latest date.

Because much of this logic existed in a template, I decided to do some heavy refactoring as part of this fix. There's a lot here so please take your time reviewing and ask questions if anything looks questionable.

## Test
To test, notice this behavior locally before pulling down the branch, and after, at [http://localhost:8000/about-us/](http://localhost:8000/about-us/
)

