### PR TITLE
WIP: Desktop print styles

### DIFF
--- a/cfgov/jinja2/v1/index.html
+++ b/cfgov/jinja2/v1/index.html
@@ -11,7 +11,7 @@
 
 {% block content %}
 
-    <main class="content" id="main" role="main">
+    <main class="content p-home" id="main" role="main">
 
         {% from 'molecules/home-hero.html' import home_hero with context %}
         {{ home_hero( {

--- a/cfgov/jinja2/v1/sublanding-page/index.html
+++ b/cfgov/jinja2/v1/sublanding-page/index.html
@@ -21,6 +21,10 @@
     {% endif %}
 {% endblock %}
 
+{% block content_main_modifiers -%}
+    {{ super() }} p-sublanding
+{%- endblock %}
+
 {% block content_main %}
     {% for block in page.content -%}
         {% if 'featured_content' in block.block_type %}

--- a/cfgov/unprocessed/css/main.less
+++ b/cfgov/unprocessed/css/main.less
@@ -12,14 +12,6 @@
 // Combined CF components.
 
 @import (less) 'cf-core/src/cf-core.less';
-
-/* override respond-to-min to add print */
-.respond-to-min(@bp, @rules) {
-    @ems: unit((@bp / @base-font-size-px), em);
-    @media only all and (min-width: @ems), only print {
-        @rules();
-    }
-}
 @import (less) 'cf-icons/src/cf-icons.less';
 @import (less) 'cf-buttons/src/cf-buttons.less';
 @import (less) 'cf-forms/src/cf-forms.less';

--- a/cfgov/unprocessed/css/main.less
+++ b/cfgov/unprocessed/css/main.less
@@ -12,6 +12,14 @@
 // Combined CF components.
 
 @import (less) 'cf-core/src/cf-core.less';
+
+/* override respond-to-min to add print */
+.respond-to-min(@bp, @rules) {
+    @ems: unit((@bp / @base-font-size-px), em);
+    @media only all and (min-width: @ems), only print {
+        @rules();
+    }
+}
 @import (less) 'cf-icons/src/cf-icons.less';
 @import (less) 'cf-buttons/src/cf-buttons.less';
 @import (less) 'cf-forms/src/cf-forms.less';

--- a/cfgov/unprocessed/css/misc.less
+++ b/cfgov/unprocessed/css/misc.less
@@ -166,6 +166,13 @@
     }
 }
 
+.float-media, .media_image {
+    .respond-to-print( {
+        width: 0;
+        max-width: 0;
+        display: none;
+    } );
+}
 
 /* topdoc
   name: Responsive cropping
@@ -173,7 +180,7 @@
   notes:
     - "A simple cropping pattern. We may need more advanced ones in the future."
     - "How it works: At smaller screens .rwd-crop is cropped to 75% of its
-       original height and flexibily scales 100% of its parents width. At larger
+       original height and flexib`ily scales 100% of its parents width. At larger
        screens it is no longer flexible and uses its default width. For images
        the default width can be set using the width attribute."
   patterns:

--- a/cfgov/unprocessed/css/pages/bureau.less
+++ b/cfgov/unprocessed/css/pages/bureau.less
@@ -39,3 +39,17 @@
     }
 
 }
+
+// Print styles.
+.featured-content-module {
+    .respond-to-print( {
+        width: 0;
+        display: none;
+    } );
+}
+
+.the-bureau .media_body {
+    .respond-to-print( {
+        text-align: left !important;
+    } );
+}

--- a/cfgov/unprocessed/css/pages/home.less
+++ b/cfgov/unprocessed/css/pages/home.less
@@ -15,3 +15,55 @@
         .u-info-unit-base__inline( @m-info-unit_img__lg );
     } );
 }
+
+@supports (-webkit-appearance:none) {
+    .p-home {
+        .content-l_col {
+            padding: 5px;
+            display: table-cell !important;
+        }
+
+        .content-l {
+            display: table !important;
+        }
+
+        .content_main__home .content-l_col-1-2 {
+            width: 50% !important;
+        }
+    }
+}
+
+@-moz-document url-prefix() {
+    .p-home {
+        /* home page tweaks */
+        .content-l_col + .content-l_col {
+            margin-top: 0 !important;
+        }
+
+        .content-l_col-1-2__on-lg {
+            width: 100% !important;
+            .m-card {
+                width: 100%;
+                box-sizing: border-box;
+            }
+        }
+
+        .content-l_col-1-3__on-lg +
+        .content-l_col-1-3__on-lg:before {
+            display: none;
+        }
+
+        .content-l_col-1-3__on-lg {
+            margin-top: 0 !important;
+
+            .m-info-unit {
+                display: block !important;
+            }
+
+            .m-info-unit_content {
+                width: 100%;
+                margin-left: 0 !important;
+            }
+        }
+    }
+}

--- a/cfgov/unprocessed/css/pages/sublanding.less
+++ b/cfgov/unprocessed/css/pages/sublanding.less
@@ -1,0 +1,19 @@
+/* ==========================================================================
+   cfgov-refresh
+   Sublanding page.
+   ========================================================================== */
+
+// Mozilla only hacks
+@media only print {
+    .p-sublanding {
+        @-moz-document url-prefix() {
+            .content_sidebar .list_item,
+            .content_sidebar  .block,
+            .content_sidebar .o-email-signup,
+            .content_sidebar  p {
+                /* for Firefox; prevents sidebar items from displaying inline */
+                width: 100% !important;
+           }
+        }
+    }
+}

--- a/cfgov/unprocessed/css/print.less
+++ b/cfgov/unprocessed/css/print.less
@@ -45,72 +45,60 @@
     - cfgov-print
 */
 
+
 .print-header {
     margin-bottom: unit(30px / @base-font-size-px, em);
     padding-bottom: unit(30px / @base-font-size-px, em);
     border-bottom: 5px solid @black;
 }
 
+@media only print {
+    html,
+    body {
+        margin: 1mm;
+        /* may need to adjust so print isn't too small w/ 1000px width */
+        font-size: 17px;
+    }
 
-@media only print  {
-   @page { 
-      margin: 10mm;  
-      width: 1000px !important;
-   } 
+    // Webkit only hacks
+    @supports (-webkit-appearance: none) {
+        .content {
+            display: table !important;
+        }
 
-   html, body {
-      /* Firefox needs width, Chrome doesn't, but less than 1000px seems too narrow on Chrome */
-      width: 1000px; 
-      font-size: 17px; /* may need to adjust so print isn't too small w/ 1000px width */
-   }
-   .content_wrapper {
-      /* for Firefox, which only prints first page of inline-block elements */
-      display: table !important; 
-   }
+        .content__2-1 {
+            .content_main {
+                margin: 0;
+                width: 66%;
+                display: table-cell !important;
+            }
 
-   .content_main,
-   .content_sidebar {
-      /* for Firefox, which only prints first page of inline-block elements */
-      display: table-cell !important;
-   }
+            .content_sidebar {
+                width: 33%;
+                display: table-cell !important;
+            }
+        }
+    }
 
-   .content_sidebar .list_item, 
-   .content_sidebar  .block,
-   .content_sidebar .o-email-signup,
-   .content_sidebar  p {
-      /* for Firefox; prevents sidebar items from displaying inline */
-      width: 100% !important; 
-   }
+    // Mozilla only hacks
+    @-moz-document url-prefix() {
+        html,
+        body {
+            margin: 0;
+            padding: 0;
+        }
 
-   /* home page tweaks */
-   .content-l_col + .content-l_col {
-      margin-top: 0 !important;
-   }
+        .content__2-1 {
+            .content_main {
+                margin: 0;
+                width: 66%;
+                display: table-cell !important;
+            }
 
-   .content-l_col-1-2__on-lg  {
-      width: 100% !important;
-      .m-card {
-      width: 100%;
-      box-sizing: border-box;
-      }
-   }
-
-   .content-l_col-1-3__on-lg + .content-l_col-1-3__on-lg:before {
-      display: none;
-   }
-
-   .content-l_col-1-3__on-lg {
-      margin-top: 0 !important;
-
-      .m-info-unit  {
-         display: block !important;
-      }
-      
-
-      .m-info-unit_content {
-         width: 100%;
-         margin-left: 0 !important;
-      }
-   }
-
+            .content_sidebar {
+                width: 33%;
+                display: table-cell !important;
+            }
+        }
+    }
 }

--- a/cfgov/unprocessed/css/print.less
+++ b/cfgov/unprocessed/css/print.less
@@ -50,3 +50,67 @@
     padding-bottom: unit(30px / @base-font-size-px, em);
     border-bottom: 5px solid @black;
 }
+
+
+@media only print  {
+   @page { 
+      margin: 10mm;  
+      width: 1000px !important;
+   } 
+
+   html, body {
+      /* Firefox needs width, Chrome doesn't, but less than 1000px seems too narrow on Chrome */
+      width: 1000px; 
+      font-size: 17px; /* may need to adjust so print isn't too small w/ 1000px width */
+   }
+   .content_wrapper {
+      /* for Firefox, which only prints first page of inline-block elements */
+      display: table !important; 
+   }
+
+   .content_main,
+   .content_sidebar {
+      /* for Firefox, which only prints first page of inline-block elements */
+      display: table-cell !important;
+   }
+
+   .content_sidebar .list_item, 
+   .content_sidebar  .block,
+   .content_sidebar .o-email-signup,
+   .content_sidebar  p {
+      /* for Firefox; prevents sidebar items from displaying inline */
+      width: 100% !important; 
+   }
+
+   /* home page tweaks */
+   .content-l_col + .content-l_col {
+      margin-top: 0 !important;
+   }
+
+   .content-l_col-1-2__on-lg  {
+      width: 100% !important;
+      .m-card {
+      width: 100%;
+      box-sizing: border-box;
+      }
+   }
+
+   .content-l_col-1-3__on-lg + .content-l_col-1-3__on-lg:before {
+      display: none;
+   }
+
+   .content-l_col-1-3__on-lg {
+      margin-top: 0 !important;
+
+      .m-info-unit  {
+         display: block !important;
+      }
+      
+
+      .m-info-unit_content {
+         width: 100%;
+         margin-left: 0 !important;
+      }
+   }
+
+}


### PR DESCRIPTION
- Some browsers (Chrome, Firefox, etc) use tablet styles when printing responsive layouts. This PR is an initial effort to apply desktop styles to printed output across browsers. 
- Firefox apparently only prints the first page of `inline-block` elements, which is an issue because we use `inline-block` to create two column layouts. This PR substitutes `display:table-cell` in a print media query so that Firefox will print the full text of pages with long `inline-block` elements.

## Additions

- Override `respond-to-min` mixin in `main.less` to add `print` to the media query it generates. This will cause the desktop styles to be used in printing across browsers.
- Adds more styles needed for printing desktop layout in Firefox: page widths, font size bump, etc
- Use `display:table-cell` instead of `inline-block` for columns in print media query
- Add print style tweaks for homepage

## Testing

- Check out branch & run gulp styles
- Check that pages print in desktop layout across browsers
- Navigate to a blog page and verify that the full text prints in Firefox

## Review

- @Scotchester 
- @jimmynotjim 

## Screenshots
Before, print preview of blog page in Chrome:
<img width="513" alt="screen shot 2016-11-09 at 9 51 34 pm" src="https://cloud.githubusercontent.com/assets/778171/20166032/e7b36c34-a6c6-11e6-8bbf-359096b708c7.png">


After, print preview of blog page in Chrome:

<img width="507" alt="screen shot 2016-11-09 at 9 51 48 pm" src="https://cloud.githubusercontent.com/assets/778171/20166038/ee87dc0c-a6c6-11e6-9f64-6a009af28724.png">


## Notes

- This is a work in progress/not ready to be merged. The basic print desktop layout seems to work across browsers, but there are tweaks & possibly design input needed for the different page types 
- Overriding the `respond-to-min` mixin seemed like the simplest approach to applying desktop styles to print, but cherry-picking the styles into a print media query is another option

## Todos

- On IE9, overriding `respond-to-min` seems to be breaking the header & footer. Need to figure out why this is happening

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
