### PR TITLE
Simplify publish logic to always flush Akamai cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Disable logging below CRITICAL when running Python unit tests.
 - Fixed empty `heading` value in link blobs
 - Picard upgraded to version 1.5.2.
+- Simplified Akamai cache flushing logic to always flush on publish.
 
 ### Removed
 - `tax-time-saving` reference in `base.py` (it moved to Wagtail)


### PR DESCRIPTION
This PR simplifies the Akamai cache flushing logic so that a cache flush is always called on every Wagtail page publish. Previously, flushes would only be triggered by pages that were first published over a minute ago. This prevents scheduled publishing events from triggering Akamai cache flushes, which meant that publishing a child page on a schedule (like a job posting) would not force an update of its parent page (for example a list of current open jobs).

## Changes

- Simplified Akamai cache flushes to always flush on page publish.

## Testing

- This is difficult to test in practice. See the unit tests in `v1.tests.wagtail_hooks` (I added a few new ones to make sure that my flake8 cleanups to the credentials method didn't break anything).
- In production, schedule a new page to publish, wait for the publish event to occur, and verify that referring pages also get invalidated.

## Review

- @richaagarwal @rosskarchner @willbarton 

## Notes

- This change has at least these negative side effects:
 - Flushes are caused when new pages are published, even if those new pages aren't referred to anywhere.
 - Multiple flushes are triggered if multiple pages are published at the same time.

## Checklist

* [X] Changes are limited to a single goal (no scope creep)
* [X] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [X] Passes all existing automated tests
* [X] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [X] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
