### PR TITLE
Bump eregs/ip version from 1.0.2 to 1.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Disable logging below CRITICAL when running Python unit tests.
 - Fixed empty `heading` value in link blobs
 - Picard upgraded to version 1.5.2.
+- Eregs/ip updated to version 1.0.3.
 
 ### Removed
 - `tax-time-saving` reference in `base.py` (it moved to Wagtail)

--- a/requirements/optional-private.txt
+++ b/requirements/optional-private.txt
@@ -7,4 +7,4 @@ git+https://private.repo/CFPB/cfgov-selfregistration.git@v1.2#egg=selfregistrati
 git+https://private.repo/CFPB/django-college-cost-comparison.git@v1.2.7#egg=comparisontool
 git+https://private.repo/CFPB/knowledgebase.git@v2.1.4#egg=knowledgebase
 git+https://private.repo/CFPB/Picard.git@1.5.2#egg=picard
-git+https://private.repo/eregs/ip.git@1.0.2#egg=eregsip
+git+https://private.repo/eregs/ip.git@1.0.3#egg=eregsip


### PR DESCRIPTION
This PR bumps the version of the optional private eregs/ip repository from 1.0.2 to 1.03, the version tagged and created today.

## Changes

- Eregs/ip updated to version 1.0.3.

## Review

- @cfpb/cfgov-backends 

## Checklist

* [X] Changes are limited to a single goal (no scope creep)
* [X] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [X] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)

