### PR TITLE
Fixing missing event suite field on template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Conference Registration Form configurable error and success messages.
 - Fixed broken static assets on Technology and Innovation Fellowship page.
 - Updated the analytics code to send events on form submission.
+- Fixed issue surrounding event venue not displaying on event page.
 
 ### Removed
 - `tax-time-saving` reference in `base.py` (it moved to Wagtail)

--- a/cfgov/jinja2/v1/events/_macros.html
+++ b/cfgov/jinja2/v1/events/_macros.html
@@ -72,6 +72,7 @@
     {%- set city   =  event.venue_city   | default('', true) -%}
     {%- set state  =  event.venue_state  | default('', true) -%}
     {%- set street =  event.venue_street | default('', true) -%}
+    {%- set suite  =  event.venue_suite  | default('', true) -%}
     {%- set name   =  event.venue_name   | default('', true) -%}
     {%- set zip    =  event.venue_zip    | default('', true) -%}
     <p class="event-meta_address h-adr">
@@ -87,6 +88,10 @@
             <span class="event-meta_street p-street-address">{{ street }}</span>
         {% endmacro -%}
 
+        {%- macro _suite() %}
+            <span class="event-meta_suite p-extended-address">{{ suite }}</span>
+        {% endmacro -%}
+
         {% macro _venue() %}
             <span class="event-meta_venue p-extended-address">{{ name }}</span>
         {% endmacro %}
@@ -100,6 +105,7 @@
                 'city'   : _city()   | trim,
                 'street' : _street() | trim,
                 'state'  : _state()  | trim,
+                'suite'  : _suite()  | trim,
                 'venue'  : _venue()  | trim,
                 'zip'    : _zip()    | trim
             }) | safe
@@ -145,7 +151,8 @@
             <div class="content-l">
                 <div class="event-meta content-l_col content-l_col-1-2">
                     {{ event_meta_address(event,
-                        address_format ='{venue} {street} {city}' ~ state_prefix ~ '{state} {zip}'
+                        address_format ='{venue} {street} {suite}
+                        {city}' ~ state_prefix ~ '{state} {zip}'
                     ) }}
                 </div>
                 <div class="content-l_col content-l_col-1-2 event-calendar_container">

--- a/cfgov/unprocessed/css/pages/event.less
+++ b/cfgov/unprocessed/css/pages/event.less
@@ -146,7 +146,8 @@
     text-transform: capitalize;
     display: inline-block;
 
-    .event-meta_street:not(:empty):after {
+    .event-meta_street:not(:empty):after,
+    .event-meta_suite:not(:empty):after {
         // Adding a linebreak after the street if it's contents
         // aren't empty.
         content: '\A';


### PR DESCRIPTION
Fixing missing event suite field on template.

## Changes

- Fixing missing event suite field on template

## Testing

- Create an Event page.
- Fill in all venue fields and preview.
- Verify that the `venue suite` field is being displayed.

## Review

- @chosak 

## Screenshots

<img width="318" alt="screen shot 2016-11-15 at 11 10 17 am" src="https://cloud.githubusercontent.com/assets/1696212/20313889/54372c0c-ab26-11e6-8d6c-d5c88790554d.png">


## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)

