### PR TITLE
Conference registration form display fixes (4.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Disable logging below CRITICAL when running Python unit tests.
 - Fixed empty `heading` value in link blobs
 - Picard upgraded to version 1.5.2.
+- Conference Registration Form display element improvements.
+- Conference Registration Form submission success message replaced.
 
 ### Removed
 - `tax-time-saving` reference in `base.py` (it moved to Wagtail)

--- a/cfgov/data_research/handlers.py
+++ b/cfgov/data_research/handlers.py
@@ -90,16 +90,17 @@ class ConferenceRegistrationHandler(Handler):
         else:
             messages.success(self.request,
                 'Thank you for registering for '
-                'the CFPB research conference on December 15-16, 2016. '
+                'the 2016 CFPB Research Conference on December 15-16, 2016. '
                 'We are looking forward to seeing you there!<br><br>'
                 '<span style="font-weight: normal; '
                 'font-family:AvenirNextLTW01-Regular,Arial,sans-serif">'
                 'Let us know if your plans change, and you can\'t make '
-                'the days you registered to attend. Also, let us know '
+                'the sessions you registered to attend. Also, let us know '
                 'if you have any questions about the event and how to '
                 'attend. Feel free to email us at '
                 '<a href="mailto:CFPB_ResearchConference@cfpb.gov">'
-                'CFPB_ResearchConference@cfpb.gov</a>.</span>')
+                'CFPB_ResearchConference@cfpb.gov</a>.</span>',
+                extra_tags='safe')
             return HttpResponseRedirect(self.page.url)
 
     def fail(self, form):

--- a/cfgov/data_research/handlers.py
+++ b/cfgov/data_research/handlers.py
@@ -89,7 +89,17 @@ class ConferenceRegistrationHandler(Handler):
             return JsonResponse({'result': 'pass'})
         else:
             messages.success(self.request,
-                             'Your submission was successfully received.')
+                'Thank you for registering for '
+                'the CFPB research conference on December 15-16, 2016. '
+                'We are looking forward to seeing you there!<br><br>'
+                '<span style="font-weight: normal; '
+                'font-family:AvenirNextLTW01-Regular,Arial,sans-serif">'
+                'Let us know if your plans change, and you can\'t make '
+                'the days you registered to attend. Also, let us know '
+                'if you have any questions about the event and how to '
+                'attend. Feel free to email us at '
+                '<a href="mailto:CFPB_ResearchConference@cfpb.gov">'
+                'CFPB_ResearchConference@cfpb.gov</a>.</span>')
             return HttpResponseRedirect(self.page.url)
 
     def fail(self, form):

--- a/cfgov/data_research/handlers.py
+++ b/cfgov/data_research/handlers.py
@@ -99,8 +99,7 @@ class ConferenceRegistrationHandler(Handler):
                 'if you have any questions about the event and how to '
                 'attend. Feel free to email us at '
                 '<a href="mailto:CFPB_ResearchConference@cfpb.gov">'
-                'CFPB_ResearchConference@cfpb.gov</a>.</span>',
-                extra_tags='safe')
+                'CFPB_ResearchConference@cfpb.gov</a>.</span>')
             return HttpResponseRedirect(self.page.url)
 
     def fail(self, form):

--- a/cfgov/jinja2/v1/_includes/conference-registration-form.html
+++ b/cfgov/jinja2/v1/_includes/conference-registration-form.html
@@ -27,7 +27,7 @@
 
             {# JS-disabled result handling #}
             {%- for message in get_messages(request) -%}
-                {{- notification.render(message.level_tag, true, message.message) -}}
+                {{- notification.render(message.level_tag, true, message.message | safe) -}}
             {%- endfor -%}
 
             <section class="o-form-section">

--- a/cfgov/jinja2/v1/_includes/conference-registration-form.html
+++ b/cfgov/jinja2/v1/_includes/conference-registration-form.html
@@ -31,11 +31,14 @@
             {%- endfor -%}
 
             <section class="o-form-section">
+                <div class="form-l_col form-l_col-1">
+                    <p><strong>*</strong> Indicates a required field.</p>
+                </div>
 
                 {# Name #}
                 {{- input.render({
                     'id':       'name',
-                    'label':    'Name',
+                    'label':    'Name *',
                     'type':     'text',
                     'value':    form.name.value() | default('', true),
                     'size':     '1',
@@ -57,7 +60,7 @@
                 {# Email #}
                 {{- input.render({
                     'id': 'email',
-                    'label':   'Email',
+                    'label':   'Email *',
                     'type':    'email',
                     'value':    form.email.value() | default('', true),
                     'size':    '1',
@@ -72,7 +75,7 @@
                 {% endfor %}
 
                 {{ big_checkbox.render({
-                    "legend": 'Which sessions will you be attending?',
+                    "legend": 'Which sessions will you be attending? ',
                     "fields": checkbox_fields,
                     'value':  request.POST.getlist('form_sessions', []),
                     "size" :  '1'

--- a/cfgov/jinja2/v1/_includes/molecules/notification.html
+++ b/cfgov/jinja2/v1/_includes/molecules/notification.html
@@ -40,12 +40,7 @@
       <span class="m-notification_icon
                    cf-icon"></span>
       <div class="m-notification_content">
-          <p class="h4 m-notification_message">
-            {% if 'safe' in message.tags %}
-                {{ message | safe }} 
-            {% else %}
-                {{ message }}
-            {% endif %}</p>
+          <p class="h4 m-notification_message">{{ message }}</p>
           {% if explanation %}
               <p class="h4 m-notification_explanation">{{ explanation }}</p>
           {% endif %}

--- a/cfgov/jinja2/v1/_includes/molecules/notification.html
+++ b/cfgov/jinja2/v1/_includes/molecules/notification.html
@@ -40,7 +40,12 @@
       <span class="m-notification_icon
                    cf-icon"></span>
       <div class="m-notification_content">
-          <p class="h4 m-notification_message">{{ message }}</p>
+          <p class="h4 m-notification_message">
+            {% if 'safe' in message.tags %}
+                {{ message | safe }} 
+            {% else %}
+                {{ message }}
+            {% endif %}</p>
           {% if explanation %}
               <p class="h4 m-notification_explanation">{{ explanation }}</p>
           {% endif %}


### PR DESCRIPTION
4.1 branch version of #2534 Form Display Fixes by @hillaryj.

## Changes

- Slight changes to form display in conference registration form.
- Updated (HTML) success message when conference registration form is submitted.

## Testing

- This requires a properly configured GovDelivery environment, and a valid GovDelivery code in the form configuration. Submitting the form will properly display the success message below.

## Review

- @rosskarchner 

## Screenshots

New success message:

![image](https://cloud.githubusercontent.com/assets/654645/20326883/b1052696-ab58-11e6-81cf-7e769376a24d.png)

## Checklist

* [X] Changes are limited to a single goal (no scope creep)
* [X] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [X] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [X] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
