### PR TITLE
Exclude reports from showing up on the Newsroom Landing Page

### DIFF
--- a/cfgov/v1/forms.py
+++ b/cfgov/v1/forms.py
@@ -7,9 +7,8 @@ from django.forms.utils import ErrorList
 from django.forms import widgets
 from taggit.models import Tag
 
-from .util import ref
-from .models.base import CFGOVPage, Feedback
-from .models.learn_page import AbstractFilterPage
+from v1.util import ref
+from v1.models.base import CFGOVPage, Feedback
 
 import logging
 logger = logging.getLogger(__name__)
@@ -116,8 +115,8 @@ class FilterableListForm(forms.Form):
     authors = forms.MultipleChoiceField(required=False, choices=[], widget=widgets.SelectMultiple(attrs=authors_select_attrs))
 
     def __init__(self, *args, **kwargs):
-        self.parent = kwargs.pop('parent')
         self.hostname = kwargs.pop('hostname')
+        self.base_query = kwargs.pop('base_query')
         super(FilterableListForm, self).__init__(*args, **kwargs)
         page_ids = CFGOVPage.objects.live_shared(self.hostname).values_list('id', flat=True)
 
@@ -148,21 +147,9 @@ class FilterableListForm(forms.Form):
         logger.info('Filtering by categories {}'.format(categories))
         return categories
 
-    def base_query(self):
-        base_query = AbstractFilterPage.objects.live_shared(
-            hostname=self.hostname
-        )
-        if self.parent:
-            base_query = base_query.filter(
-                CFGOVPage.objects.child_of_q(self.parent)
-            )
-            logger.info('Filtering by parent {}'.format(self.parent))
-        return base_query
-
     def get_page_set(self):
-        base_query = self.base_query()
         query = self.generate_query()
-        return base_query.filter(query).distinct().order_by('-date_published')
+        return self.base_query.filter(query).distinct().order_by('-date_published')
 
     def prepare_options(self, arr):
         """ Returns an ordered list of tuples of the format ('tag-slug-name', 'Tag Display Name') """

--- a/cfgov/v1/forms.py
+++ b/cfgov/v1/forms.py
@@ -83,6 +83,9 @@ class CalenderPDFFilterForm(forms.Form):
             )
         return cleaned_data
 
+class MultipleChoiceFieldNoValidation(forms.MultipleChoiceField):
+    def validate(self, value):
+        pass
 
 class FilterableListForm(forms.Form):
     title_attrs = {
@@ -111,7 +114,7 @@ class FilterableListForm(forms.Form):
     from_date = FilterDateField(required=False, input_formats=['%m/%d/%Y'], widget=widgets.DateInput(attrs=from_select_attrs))
     to_date = FilterDateField(required=False, input_formats=['%m/%d/%Y'], widget=widgets.DateInput(attrs=to_select_attrs))
     categories = forms.MultipleChoiceField(required=False, choices=ref.page_type_choices, widget=widgets.CheckboxSelectMultiple())
-    topics = forms.MultipleChoiceField(required=False, choices=[], widget=widgets.SelectMultiple(attrs=topics_select_attrs))
+    topics = MultipleChoiceFieldNoValidation(required=False, choices=[], widget=widgets.SelectMultiple(attrs=topics_select_attrs))
     authors = forms.MultipleChoiceField(required=False, choices=[], widget=widgets.SelectMultiple(attrs=authors_select_attrs))
 
     def __init__(self, *args, **kwargs):

--- a/cfgov/v1/models/base.py
+++ b/cfgov/v1/models/base.py
@@ -161,20 +161,16 @@ class CFGOVPage(Page):
         return sorted(author_names, key=lambda x: x.name.split()[-1])
 
     def generate_view_more_url(self, request):
-        from ..forms import FilterableListForm
         activity_log = CFGOVPage.objects.get(slug='activity-log').specific
-        form = FilterableListForm(parent=activity_log, hostname=request.site.hostname)
-        available_tags = [tag[0] for name, tags in form.fields['topics'].choices for tag in tags]
         tags = []
         index = activity_log.form_id()
         for tag in self.tags.slugs():
-            if tag in available_tags:
-                tags.append('filter%s_topics=' % index + urllib.quote_plus(tag))
+            tags.append('filter%s_topics=' % index + urllib.quote_plus(tag))
         tags = '&'.join(tags)
         return get_protected_url({'request': request}, activity_log) + '?' + tags
 
     def related_posts(self, block, hostname):
-        from . import AbstractFilterPage
+        from v1.models.learn_page import AbstractFilterPage
         related = {}
         query = models.Q(('tags__name__in', self.tags.names()))
         search_types = [

--- a/cfgov/v1/models/base.py
+++ b/cfgov/v1/models/base.py
@@ -499,7 +499,6 @@ def rendition_delete(sender, instance, **kwargs):
     instance.file.delete(False)
 
 
-<<<<<<< 891c51e596fe6ee61f11aac5e81092b875df1c99
 # keep encrypted passwords around to ensure that user does not re-use
 # any of the previous 10
 class PasswordHistoryItem(models.Model):
@@ -507,15 +506,6 @@ class PasswordHistoryItem(models.Model):
     created = models.DateTimeField(auto_now_add=True)
     expires_at = models.DateTimeField()  # password becomes invalid at...
     locked_until = models.DateTimeField()  # password cannot be changed until
-=======
-# keep encrypted passwords around to ensure that user does not re-use any of the
-# previous 10
-class PasswordHistoryItem(models.Model):
-    user = models.ForeignKey(User)
-    created = models.DateTimeField(auto_now_add=True)
-    expires_at = models.DateTimeField()   # password becomes invalid at...
-    locked_until = models.DateTimeField()  # password can not be changed until...
->>>>>>> flake8 updates and use urlencode instead
     encrypted_password = models.CharField(_('password'), max_length=128)
 
     class Meta:

--- a/cfgov/v1/models/base.py
+++ b/cfgov/v1/models/base.py
@@ -1,54 +1,43 @@
-import os
-import json
-import urllib
-from itertools import chain
 from collections import OrderedDict
+from itertools import chain
+import json
+import os
+from urllib import urlencode
 
+from django.contrib.auth.models import User
 from django.db import models
 from django.db.models import Q
 from django.db.models.signals import pre_delete
+from django.dispatch import receiver
 from django.http import (
     Http404,
     JsonResponse,
     HttpResponseBadRequest,
     HttpResponse
 )
-from django.template.response import TemplateResponse
-from django.utils.translation import ugettext_lazy as _
-from django.utils import timezone
-from django.dispatch import receiver
-from django.contrib.auth.models import User
 
-from wagtail.wagtailimages.models import (
-    Image, AbstractImage, AbstractRendition
-)
-from wagtail.wagtailadmin.edit_handlers import StreamFieldPanel
-from wagtail.wagtailcore import blocks, hooks
-from wagtail.wagtailcore.blocks.stream_block import StreamValue
-from wagtail.wagtailcore.fields import StreamField
-from wagtail.wagtailcore.models import (
-    Orderable,
-    Page,
-    PageManager,
-    PagePermissionTester,
-    PageQuerySet,
-    UserPagePermissionsProxy
-)
-from wagtail.wagtailcore.url_routing import RouteResult
-from wagtail.wagtailadmin.edit_handlers import (
-    FieldPanel,
-    InlinePanel,
-    MultiFieldPanel,
-    ObjectList,
-    TabbedInterface
-)
-from taggit.models import TaggedItemBase
+from django.template.response import TemplateResponse
+from django.utils import timezone
+from django.utils.translation import ugettext_lazy as _
+
 from modelcluster.fields import ParentalKey
 from modelcluster.tags import ClusterTaggableManager
 
-from .. import get_protected_url
-from ..atomic_elements import molecules, organisms
-from ..util import ref
+from wagtail.wagtailadmin.edit_handlers import StreamFieldPanel, FieldPanel, InlinePanel, \
+    MultiFieldPanel, TabbedInterface, ObjectList
+from wagtail.wagtailcore import blocks, hooks
+from wagtail.wagtailcore.blocks.stream_block import StreamValue
+from wagtail.wagtailcore.fields import StreamField
+from wagtail.wagtailcore.models import Orderable, Page, PageManager, PagePermissionTester, \
+    PageQuerySet, UserPagePermissionsProxy
+from wagtail.wagtailimages.models import AbstractImage, AbstractRendition, Image
+from wagtail.wagtailcore.url_routing import RouteResult
+
+from taggit.models import TaggedItemBase
+
+from v1 import get_protected_url
+from v1.atomic_elements import molecules, organisms
+from v1.util import ref
 
 
 class CFGOVAuthoredPages(TaggedItemBase):
@@ -164,9 +153,7 @@ class CFGOVPage(Page):
         activity_log = CFGOVPage.objects.get(slug='activity-log').specific
         tags = []
         index = activity_log.form_id()
-        for tag in self.tags.slugs():
-            tags.append('filter%s_topics=' % index + urllib.quote_plus(tag))
-        tags = '&'.join(tags)
+        tags = urlencode([('filter%s_topics' % index, tag) for tag in self.tags.slugs()])
         return get_protected_url({'request': request}, activity_log) + '?' + tags
 
     def related_posts(self, block, hostname):
@@ -512,6 +499,7 @@ def rendition_delete(sender, instance, **kwargs):
     instance.file.delete(False)
 
 
+<<<<<<< 891c51e596fe6ee61f11aac5e81092b875df1c99
 # keep encrypted passwords around to ensure that user does not re-use
 # any of the previous 10
 class PasswordHistoryItem(models.Model):
@@ -519,6 +507,15 @@ class PasswordHistoryItem(models.Model):
     created = models.DateTimeField(auto_now_add=True)
     expires_at = models.DateTimeField()  # password becomes invalid at...
     locked_until = models.DateTimeField()  # password cannot be changed until
+=======
+# keep encrypted passwords around to ensure that user does not re-use any of the
+# previous 10
+class PasswordHistoryItem(models.Model):
+    user = models.ForeignKey(User)
+    created = models.DateTimeField(auto_now_add=True)
+    expires_at = models.DateTimeField()   # password becomes invalid at...
+    locked_until = models.DateTimeField()  # password can not be changed until...
+>>>>>>> flake8 updates and use urlencode instead
     encrypted_password = models.CharField(_('password'), max_length=128)
 
     class Meta:

--- a/cfgov/v1/models/browse_filterable_page.py
+++ b/cfgov/v1/models/browse_filterable_page.py
@@ -5,11 +5,13 @@ from wagtail.wagtailcore.fields import StreamField
 from wagtail.wagtailcore.models import PageManager
 from wagtail.wagtailadmin.edit_handlers import TabbedInterface, ObjectList
 
-from .base import CFGOVPage
-from ..atomic_elements import molecules, organisms
-from ..feeds import FilterableFeedPageMixin
-from ..util.filterable_list import FilterableListMixin
-from .. import blocks as v1_blocks
+from v1.models.base import CFGOVPage
+from v1.atomic_elements import molecules, organisms
+from v1.feeds import FilterableFeedPageMixin
+from v1.util.filterable_list import FilterableListMixin
+from v1 import blocks as v1_blocks
+from v1.util import ref
+from v1.models.learn_page import AbstractFilterPage
 
 
 class BrowseFilterablePage(FilterableFeedPageMixin, FilterableListMixin, CFGOVPage):
@@ -67,6 +69,7 @@ class NewsroomLandingPage(BrowseFilterablePage):
 
     objects = PageManager()
 
-    def get_filter_parent(self):
-        """ The Newsroom never filters results by a parent page """
-        return None
+    def base_query(self, hostname):
+        """ Modify the base query for Newsroom to exclude research reports """
+        reports = [x[0] for x in dict(ref.categories)['Research Report']]
+        return AbstractFilterPage.objects.live_shared(hostname).exclude(categories__name__in=reports)

--- a/cfgov/v1/models/browse_filterable_page.py
+++ b/cfgov/v1/models/browse_filterable_page.py
@@ -1,17 +1,16 @@
 from django.db import models
 
-from wagtail.wagtailadmin.edit_handlers import StreamFieldPanel, FieldPanel
+from wagtail.wagtailadmin.edit_handlers import StreamFieldPanel, FieldPanel, TabbedInterface, ObjectList
 from wagtail.wagtailcore.fields import StreamField
 from wagtail.wagtailcore.models import PageManager
-from wagtail.wagtailadmin.edit_handlers import TabbedInterface, ObjectList
 
-from v1.models.base import CFGOVPage
+from v1 import blocks as v1_blocks
 from v1.atomic_elements import molecules, organisms
 from v1.feeds import FilterableFeedPageMixin
-from v1.util.filterable_list import FilterableListMixin
-from v1 import blocks as v1_blocks
-from v1.util import ref
+from v1.models.base import CFGOVPage
 from v1.models.learn_page import AbstractFilterPage
+from v1.util import ref
+from v1.util.filterable_list import FilterableListMixin
 
 
 class BrowseFilterablePage(FilterableFeedPageMixin, FilterableListMixin, CFGOVPage):

--- a/cfgov/v1/models/sublanding_filterable_page.py
+++ b/cfgov/v1/models/sublanding_filterable_page.py
@@ -3,11 +3,12 @@ from wagtail.wagtailcore.fields import StreamField
 from wagtail.wagtailadmin.edit_handlers import TabbedInterface, ObjectList
 from wagtail.wagtailcore.models import PageManager
 
-from .base import CFGOVPage
-from .. import blocks as v1_blocks
-from ..atomic_elements import molecules, organisms
+from v1.models.base import CFGOVPage
+from v1.models.learn_page import AbstractFilterPage
+from v1 import blocks as v1_blocks
+from v1.atomic_elements import molecules, organisms
 from ..feeds import FilterableFeedPageMixin
-from ..util.filterable_list import FilterableListMixin
+from v1.util.filterable_list import FilterableListMixin
 
 
 class SublandingFilterablePage(FilterableFeedPageMixin, FilterableListMixin, CFGOVPage):
@@ -45,9 +46,8 @@ class ActivityLogPage(SublandingFilterablePage):
 
     objects = PageManager()
 
+    def base_query(self, hostname):
+        return AbstractFilterPage.objects.live_shared(hostname)
+
     def per_page_limit(self):
         return 100
-
-    def get_filter_parent(self):
-        """ The Activity Log never filters results by a parent page """
-        return None

--- a/cfgov/v1/models/sublanding_page.py
+++ b/cfgov/v1/models/sublanding_page.py
@@ -5,12 +5,17 @@ from wagtail.wagtailcore import blocks
 from wagtail.wagtailcore.models import PageManager
 from wagtail.wagtailimages.blocks import ImageChooserBlock
 
-from .base import CFGOVPage
-from .. import blocks as v1_blocks
-from ..atomic_elements import molecules, organisms
-# from ..util import util
+from v1.models.base import CFGOVPage
+from v1.models.learn_page import AbstractFilterPage
+
+from v1 import blocks as v1_blocks
+from v1.atomic_elements import molecules, organisms
+
 from jobmanager.models import JobListingList
 from v1.forms import FilterableListForm
+
+import logging
+logger = logging.getLogger(__name__)
 
 
 class SublandingPage(CFGOVPage):
@@ -72,13 +77,16 @@ class SublandingPage(CFGOVPage):
     objects = PageManager()
 
     def get_browsefilterable_posts(self, request, limit):
-        filter_pages = [p.specific for p in self.get_appropriate_descendants(request.site.hostname)
+        hostname = request.site.hostname
+        filter_pages = [p.specific for p in self.get_appropriate_descendants(hostname)
                         if 'FilterablePage' in p.specific_class.__name__
                         and 'archive' not in p.title.lower()]
         posts_tuple_list = []
         for page in filter_pages:
+            base_query = AbstractFilterPage.objects.live_shared(hostname).filter(CFGOVPage.objects.child_of_q(page))
+            logger.info('Filtering by parent {}'.format(page))
             form_id = str(page.form_id())
-            form = FilterableListForm(parent=page, hostname=request.site.hostname)
+            form = FilterableListForm(hostname=hostname, base_query=base_query)
             for post in form.get_page_set():
                 posts_tuple_list.append((form_id, post))
         return sorted(posts_tuple_list, key=lambda p: p[1].date_published, reverse=True)[:limit]

--- a/cfgov/v1/tests/test_filterable_list.py
+++ b/cfgov/v1/tests/test_filterable_list.py
@@ -11,11 +11,6 @@ class TestFilterableListMixin(TestCase):
     def setUp(self):
         self.mixin = FilterableListMixin()
         self.factory = RequestFactory()
-
-    @mock.patch('v1.models.learn_page.AbstractFilterPage.objects')
-    def test_base_query_calls_live_shared(self, mock_cfgovmanager):
-        FilterableListForm(parent=None, hostname='hostname').base_query()
-        assert mock_cfgovmanager.live_shared.called
     
     # FilterableListMixin.per_page_limit tests
     def test_per_page_limit_returns_integer(self):

--- a/cfgov/v1/tests/test_filterable_list_form.py
+++ b/cfgov/v1/tests/test_filterable_list_form.py
@@ -5,13 +5,15 @@ from v1.forms import FilterableListForm
 from v1.models.base import CFGOVPageCategory
 from v1.tests.wagtail_pages.helpers import publish_page
 from wagtail.wagtailcore.models import Site
+from v1.models.learn_page import AbstractFilterPage
 
 
 class TestFilterableListForm(TestCase):
 
     def setUpFilterableForm(self, data=None):
-        site = Site.objects.get(is_default_site=True)
-        form = FilterableListForm(parent=None, hostname=site.hostname)
+        hostname = Site.objects.get(is_default_site=True).hostname
+        base_query = AbstractFilterPage.objects.live_shared(hostname)
+        form = FilterableListForm(hostname=hostname, base_query=base_query)
         form.is_bound = True
         form.cleaned_data = data
         return form


### PR DESCRIPTION
## Overview

This is needed because my previous Filterable refactoring (https://github.com/cfpb/cfgov-refresh/pull/2448) unintentionally** removed this functionality.

- **We need to have some way of documenting or capturing more clearly in the code the very custom functionality of the Activity Log and Newsroom pages.  The fact that the Newsroom should not include in its results anything from research reports is not obvious, and I only found this out by @schaferjh pointing it out. I tried to make it clearer in the code I'm adding here, but there are other things specific to these pages (e.g. only include results from AbstractFilterPages) that isn't immediately obvious to someone looking at the page or looking at the code.  @chosak and I have discussed that it might be better to configure this functionality in the Wagtail editor itself, which would require further refactoring.  I think that's probably the way to go, but we might need to have a BEWD discussion about the best approach.

## Other notes
- Instead of passing around `filter_parent` as I did in my earlier refactor, I opted for passing around `base_query` as that allows us to pass from the `NewsroomLandingPage` definition directly the fact that it needs to exclude research reports' subcategories.  It looks slightly messier in the `get_browsefilterable_posts` function because the logic for filtering by parent page is now redundant (defined there as well as in `FilterableListMixin`) but I think that redundancy is a vestige of the fact that `get_browse_filterable_posts` is defined in the wrong class.
- Not updating the `CHANGELOG` since together with the filterable refactor, this does not change functionality
- I included some minor flake8 clean-up as well as updated relative imports to absolute imports where I saw fit
- Removed validation on topic tags specifically, so that we can pass in whatever in the "View More" URL and not worry about it breaking things

## Testing
- Confirm that no reports show up on Newsroom, [http://localhost:8000/about-us/newsroom/](http://localhost:8000/about-us/newsroom/), but that they do show up on the Activity Log [http://localhost:8000/activity-log/](http://localhost:8000/activity-log/)

## Review
@cfpb/cfgov-backends 

## TODO
- Add a test for `generate_view_more_url` given that I updated it and it does not have any tests (and actually broke it without realizing it earlier - thanks @rosskarchner for catching that before deploying)