### PR TITLE
Fix breadcrumbs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 ---------------------------------------
 
 ## Unreleased
+- Fixed breadcrumb rendering for wagtail subpages
 
 ### Added
 - DownStreamCacheControl middleware, which sets the `Edge-Control: no-store` header pages use csrf_token.

--- a/cfgov/cfgov/test.py
+++ b/cfgov/cfgov/test.py
@@ -5,6 +5,7 @@ import itertools
 import logging
 import re
 
+from wagtail.wagtailcore.models import Site
 from django.apps import apps
 from django.conf import settings
 from django.db import connection
@@ -99,6 +100,7 @@ class HtmlMixin(object):
 
     def assertPageIncludesHtml(self, page, s):
         request = RequestFactory().get('/')
+        request.site = Site.objects.get(is_default_site=True)
         request.user = Mock()
 
         rendered_html = page.serve(request).render()

--- a/cfgov/jinja2/v1/_layouts/content-base-main-first.html
+++ b/cfgov/jinja2/v1/_layouts/content-base-main-first.html
@@ -6,8 +6,8 @@
         {% set breadcrumb_items = page.get_breadcrumbs(request) %}
         {% if breadcrumb_items | length > 0 %}
             <div class="content_wrapper">
-                {%- import 'molecules/breadcrumbs.html' as breadcrumbs with context -%}
-                {{ breadcrumbs.render(breadcrumb_items, 'breadcrumbs__main-first') }}
+                {%- import 'breadcrumbs.html' as breadcrumbs -%}
+                {{ breadcrumbs.render(breadcrumb_items) }}
             </div>
         {% endif %}
     {% else %}

--- a/cfgov/jinja2/v1/_layouts/content-base-main-first.html
+++ b/cfgov/jinja2/v1/_layouts/content-base-main-first.html
@@ -7,7 +7,7 @@
         {% if breadcrumb_items | length > 0 %}
             <div class="content_wrapper">
                 {%- import 'breadcrumbs.html' as breadcrumbs -%}
-                {{ breadcrumbs.render(breadcrumb_items) }}
+                {{ breadcrumbs.render(breadcrumb_items, 'breadcrumbs__main-first') }}
             </div>
         {% endif %}
     {% else %}

--- a/cfgov/jinja2/v1/_layouts/content-base.html
+++ b/cfgov/jinja2/v1/_layouts/content-base.html
@@ -3,6 +3,7 @@
 {% block content scoped %}
     <main class="content {% block content_modifiers -%}{%- endblock %}" id="main" role="main">
         {% block hero -%}{%- endblock %}
+        {% block pre_content scoped -%}
         {% if page %}
             {% set breadcrumb_items = page.get_breadcrumbs(request) %}
             {% if breadcrumb_items | length > 0 %}
@@ -12,6 +13,7 @@
                 </div>
             {% endif %}
         {% endif %}
+        {%- endblock %}
         {% block body_content scoped -%}{%- endblock %}
         {% block post_content scoped -%}{%- endblock %}
     </main>

--- a/cfgov/jinja2/v1/_layouts/content-base.html
+++ b/cfgov/jinja2/v1/_layouts/content-base.html
@@ -3,15 +3,19 @@
 {% block content scoped %}
     <main class="content {% block content_modifiers -%}{%- endblock %}" id="main" role="main">
         {% block hero -%}{%- endblock %}
-        {% block pre_content scoped -%}
+        {% if page %}
+            {% set breadcrumb_items = page.get_breadcrumbs(request) %}
             {% if breadcrumb_items | length > 0 %}
                 <div class="wrapper">
                 {%- import 'breadcrumbs.html' as breadcrumbs -%}
                 {{ breadcrumbs.render(breadcrumb_items) }}
                 </div>
             {% endif %}
-        {%- endblock %}
+        {% endif %}
         {% block body_content scoped -%}{%- endblock %}
         {% block post_content scoped -%}{%- endblock %}
     </main>
 {% endblock %}
+
+
+

--- a/cfgov/jinja2/v1/sublanding-page/index.html
+++ b/cfgov/jinja2/v1/sublanding-page/index.html
@@ -13,6 +13,7 @@
 {% endblock %}
 
 {% block pre_content %}
+    {{ super() }}
     {% if page.sidebar_breakout %}
         {% import 'organisms/sidebar-breakout.html' as sidebar_breakout with context %}
         {% call(block) sidebar_breakout.render() %}

--- a/cfgov/jobmanager/tests/models/test_blocks.py
+++ b/cfgov/jobmanager/tests/models/test_blocks.py
@@ -4,7 +4,6 @@ from django.utils import timezone
 from mock import Mock
 from model_mommy import mommy
 from wagtail.wagtailcore.models import Page, Site
-from django.test import RequestFactory
 
 from cfgov.test import HtmlMixin
 from jobmanager.models.blocks import JobListingList, JobListingTable
@@ -137,10 +136,6 @@ class JobListingListTestCase(HtmlMixin, TestCase):
         page = SublandingPage(title='title', slug='slug')
         save_new_page(page)
         set_stream_data(page, 'sidebar_breakout', [job_listing_list])
-        request = RequestFactory().get('/')
-        request.site = Site.objects.get(is_default_site=True)
-        request.user = Mock()
-        print("Page content is {}".format(page.serve(request).render()))
 
         self.assertPageIncludesHtml(page, (
             '><aside class="m-jobs-list" data-qa-hook="openings-section">'

--- a/cfgov/jobmanager/tests/models/test_blocks.py
+++ b/cfgov/jobmanager/tests/models/test_blocks.py
@@ -4,6 +4,7 @@ from django.utils import timezone
 from mock import Mock
 from model_mommy import mommy
 from wagtail.wagtailcore.models import Page, Site
+from django.test import RequestFactory
 
 from cfgov.test import HtmlMixin
 from jobmanager.models.blocks import JobListingList, JobListingTable
@@ -136,6 +137,10 @@ class JobListingListTestCase(HtmlMixin, TestCase):
         page = SublandingPage(title='title', slug='slug')
         save_new_page(page)
         set_stream_data(page, 'sidebar_breakout', [job_listing_list])
+        request = RequestFactory().get('/')
+        request.site = Site.objects.get(is_default_site=True)
+        request.user = Mock()
+        print("Page content is {}".format(page.serve(request).render()))
 
         self.assertPageIncludesHtml(page, (
             '><aside class="m-jobs-list" data-qa-hook="openings-section">'

--- a/cfgov/v1/models/base.py
+++ b/cfgov/v1/models/base.py
@@ -227,11 +227,22 @@ class CFGOVPage(Page):
                     return revision.as_page_object()
 
     def get_breadcrumbs(self, request):
+        """
+        Delivers 3-tuple (href, id, caption) for each ancestor page,
+        to be processed by jinja2 breadcrumbs.html macro
+        """
         ancestors = self.get_ancestors()
         home_page_children = request.site.root_page.get_children()
         for i, ancestor in enumerate(ancestors):
             if ancestor in home_page_children:
-                return [ancestor.specific.get_appropriate_page_version(request) for ancestor in ancestors[i+1:]]
+                crumb_pages = [
+                    ancestor.specific.get_appropriate_page_version(request)
+                    for ancestor in ancestors[i:]]
+                return [(
+                    page.url_path.replace('/cfgov', ''),
+                    page.id,
+                    page.title
+                    ) for page in crumb_pages]
         return []
 
     def get_appropriate_descendants(self, hostname, inclusive=True):


### PR DESCRIPTION
Breadcrumbs aren't rendering for wagtail sub-pages.

A number of things seem to contribute:
- the get_breadcrumbs page function was slicing in a way that guaranteed no results
- the breadcrumbs macro expected a list of 3-value tuples, but the function delivered a list of pages
- the sublandingpage was overriding the pre_content block instead of appending to it (learn pages did not do this)

## Testing

- compare a local learn page, such as `http://localhost:8000/owning-a-home/privacy-act-statement/` against www
- compare a local sublanding page, such as `http://localhost:8000/owning-a-home/your-down-payment-decision/ agsint www`

## Review

- @cfpb/back-end-team-admin @cfpb/cfgov-frontends 

* [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
