### PR TITLE
Fix broken T&I Fellowship page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Simplified Akamai cache flushing logic to always flush on publish.
 - Conference Registration Form display element improvements.
 - Conference Registration Form submission success message replaced.
+- Fixed broken static assets on Technology and Innovation Fellowship page.
 
 ### Removed
 - `tax-time-saving` reference in `base.py` (it moved to Wagtail)

--- a/cfgov/templates/jobmanager/technology-innovation-fellows.html
+++ b/cfgov/templates/jobmanager/technology-innovation-fellows.html
@@ -1,4 +1,5 @@
 {% extends "front/base_nonresponsive.html" %}
+{% load static %}
 
 {% block page_meta %}
 <meta charset="UTF-8" />
@@ -13,11 +14,11 @@
 {% block breadcrumbs %}{% endblock %}
 
 {% block page_css %}
-    <link rel="stylesheet" type="text/css" href="{{ STATIC_PREFIX }}jobmanager/css/fellows.css" />
+<link rel="stylesheet" type="text/css" href="{% static 'jobmanager/css/fellows.css' %}" />
 {% endblock %}
 
 {% block page_js %}
-    <script src="{{ STATIC_PREFIX }}jobmanager/js/fellows.js"></script>
+    <script src="{% static 'jobmanager/js/fellows.js' %}"></script>
 {% endblock %}
 
 {% block content %}
@@ -34,7 +35,7 @@ fellowship_form_submit_url = "{% url 'fellowship_form_submit' %}";
                         <h3>Our mission demands smart, usable, and reliable technology. Come serve consumers by helping us design and build it.</h3>
                     </div>
                     <div class="span5 offset1">
-                        <img alt="Technology and Innovation Fellowship Hero Image" id="hero-image" src="{{ STATIC_PREFIX }}jobmanager/img/fellowship_hero.png" />
+                        <img alt="Technology and Innovation Fellowship Hero Image" id="hero-image" src="{% static 'jobmanager/img/fellowship_hero.png' %}" />
                     </div>
                 </div> <!-- END .row-fluid -->
             </div><!-- END .wrapper -->
@@ -151,24 +152,24 @@ fellowship_form_submit_url = "{% url 'fellowship_form_submit' %}";
                 </div>
                 <div class="row-fluid current-fellows">
                     <div class="span3">
-                        <img alt="Photo of Stephanie" src="{{ STATIC_PREFIX }}jobmanager/img/stephanie.png" />
+                        <img alt="Photo of Stephanie" src="{% static 'jobmanager/img/stephanie.png' %}" />
                         <h3 class="fellow-name">Stephanie</h3>
                         <h5 class="fellow-title">Graphic Designer</h5>
                         <p>"I've had the opportunity to do so much more than I was expecting. I've designed web tools to aid consumers shopping for mortgages, user-friendly <a href="http://www.consumerfinance.gov/complaint/#debt-collection">forms for submitting complaints</a>, and <a href="http://www.consumerfinance.gov/strategic-plan/">reports to Congress</a>."</p>
                     </div>
                     <div class="span3">
-                        <img alt="Photo of Mehgan" src="{{ STATIC_PREFIX }}jobmanager/img/mehgan.png" />
+                        <img alt="Photo of Mehgan" src="{% static 'jobmanager/img/mehgan.png' %}" />
                         <h3 class="fellow-name">Mehgan</h3>
                         <h5 class="fellow-title">Graphic Designer</h5>
                         <p>"I've always had an interest in socially responsible design. Through improved digital experiences, there is a unique opportunity for the government to reach consumers and bring about positive change in people's lives."</p> </div>
                     <div class="span3">
-                        <img alt="Photo of Eduardo" src="{{ STATIC_PREFIX }}jobmanager/img/eduardo.png" />
+                        <img alt="Photo of Eduardo" src="{% static 'jobmanager/img/eduardo.png' %}" />
                         <h3 class="fellow-name">Eduardo</h3>
                         <h5 class="fellow-title">UX Designer</h5>
                         <p>"I work on <a href="https://github.com/cfpb/owning-a-home">Owning a Home</a>, an upcoming online tool that will provide consumers with tools to better understand the process necessary for homeownership. As a veteran, working at CFPB has allowed me to serve my country in a different way."</p>
                     </div>
                     <div class="span3">
-                        <img alt="Photo of Shashank" src="{{ STATIC_PREFIX }}jobmanager/img/shashank_photo.png" />
+                        <img alt="Photo of Shashank" src="{% static 'jobmanager/img/shashank_photo.png' %}" />
                         <h3 class="fellow-name">Shashank</h3>
                         <h5 class="fellow-title">Back-end Developer</h5>
                         <p>"I work on <a href="http://www.consumerfinance.gov/eregulations/about">eRegulations</a>. I helped develop the <a href="https://github.com/cfpb/regulations-parser">parser</a>, the <a href="https://github.com/cfpb/regulations-parser/blob/master/regparser/notice/compiler.py">compiler</a>, and the regulation <a href="https://github.com/eregs/regulations-site">viewer</a> that displays regulatory information that's easy to read, access, and understand."</p> </div>

--- a/cfgov/templates/jobmanager/technology-innovation-fellows.html
+++ b/cfgov/templates/jobmanager/technology-innovation-fellows.html
@@ -14,7 +14,7 @@
 {% block breadcrumbs %}{% endblock %}
 
 {% block page_css %}
-<link rel="stylesheet" type="text/css" href="{% static 'jobmanager/css/fellows.css' %}" />
+    <link rel="stylesheet" type="text/css" href="{% static 'jobmanager/css/fellows.css' %}" />
 {% endblock %}
 
 {% block page_js %}


### PR DESCRIPTION
As reported in #2546 (thanks @KimberlyMunoz), styles on [the Technology & Innovation Fellowship page](http://www.consumerfinance.gov/jobs/technology-innovation-fellows/) are broken.

This is due to some legacy `STATIC_ROOT` references that didn't properly get converted over to the `static` tag.

## Changes

- Replace use of `STATIC_ROOT` with `static` tag instead.

## Testing

- Run a local server and navigate to [http://localhost:8000/jobs/technology-innovation-fellows/](http://localhost:8000/jobs/technology-innovation-fellows/) (after running `gulp scripts:ondemand` to generate ondemand assets). Notice that all static assets load properly.

## Review

- @cfpb/cfgov-backends @cfpb/cfgov-frontends 

## Screenshots

![image](https://cloud.githubusercontent.com/assets/654645/20460063/6b356888-aea5-11e6-81cb-9641d1f88fd7.png)

## Checklist

* [X] Changes are limited to a single goal (no scope creep)
* [X] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [X] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [X] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
