### PR TITLE
Integrate 4.1.x releases into changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,11 +16,69 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 ## Unreleased
 
 ### Added
-- DownStreamCacheControl middleware, which sets the `Edge-Control: no-store` header pages use csrf_token.
 - Forms and other bits for two new Owning a Home feedback modules
 - django.middleware.locale.LocaleMiddleware, which controls translation in a current thread context. 
 - `conference_export` management command added to export conference registrations.
-- django.middleware.locale.LocaleMiddleware, which controls translation in a current thread context.
+
+### Changed
+- Eregs/ip updated to version 1.0.3.
+- Simplified Akamai cache flushing logic to always flush on publish.
+- Conference Registration Form display element improvements.
+- Conference Registration Form submission success message replaced.
+- Improved job listings view in Wagtail admin.
+- college-costs updated to version 2.2.8 for new URL field
+- Updated the analytics code to send events on form submission.
+- Fixed issue surrounding event venue not displaying on event page.
+
+### Removed
+
+
+## 4.1.8
+
+### Changed
+- roll complaints back to 1.2.6
+
+## 4.1.7
+
+### Changed
+- moved data_research into the db_router.py whitelist
+
+## 4.1.6
+
+### Changed
+- Fixed broken static assets on Technology and Innovation Fellowship page.
+- Conference Registration Form configurable error and success messages.
+
+## 4.1.5
+
+### Changed
+- update complaints to 1.2.7
+
+## 4.1.4
+
+### Fixed
+- an improved fix for the newsroom issue (see 4.1.2 and 4.1.3)
+
+## 4.1.3
+
+### Fixed
+- backed-out 4.1.2's newsroom fix
+
+## 4.1.2
+
+### Fixed
+- exclude reports from newsroom
+
+### Changed
+- Conference Registration Form display element improvements.
+- Conference Registration Form submission success message replaced.
+
+
+## 4.1.0
+
+### Added
+- DownStreamCacheControl middleware, which sets the `Edge-Control: no-store` header pages use csrf_token.
+- django.middleware.locale.LocaleMiddleware, which controls translation in a current thread context. 
 
 ### Changed
 - Fixed issue surrounding table link download / external icons not appearing.
@@ -34,20 +92,11 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Disable logging below CRITICAL when running Python unit tests.
 - Fixed empty `heading` value in link blobs
 - Picard upgraded to version 1.5.2.
-- Eregs/ip updated to version 1.0.3.
-- Simplified Akamai cache flushing logic to always flush on publish.
-- Conference Registration Form display element improvements.
-- Conference Registration Form submission success message replaced.
-- Improved job listings view in Wagtail admin.
-- college-costs updated to version 2.2.8 for new URL field
-- Conference Registration Form configurable error and success messages.
-- Fixed broken static assets on Technology and Innovation Fellowship page.
-- Updated the analytics code to send events on form submission.
-- Fixed issue surrounding event venue not displaying on event page.
 
 ### Removed
 - `tax-time-saving` reference in `base.py` (it moved to Wagtail)
 - all references to `django-htmlmin`
+
 
 
 ## 4.0.0


### PR DESCRIPTION
Get the changelog back up to date before the 4.2 tagging