### PR TITLE
Fixed file type link icons within info-units

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 ### Added
 - DownStreamCacheControl middleware, which sets the `Edge-Control: no-store` header pages use csrf_token.
 - Forms and other bits for two new Owning a Home feedback modules
-- django.middleware.locale.LocaleMiddleware, which controls translation in a current thread context. 
+- django.middleware.locale.LocaleMiddleware, which controls translation in a current thread context.
 - `conference_export` management command added to export conference registrations.
 - django.middleware.locale.LocaleMiddleware, which controls translation in a current thread context.
 
@@ -48,6 +48,9 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 ### Removed
 - `tax-time-saving` reference in `base.py` (it moved to Wagtail)
 - all references to `django-htmlmin`
+
+### Fixed
+- Fixed file type link icons within info-units
 
 
 ## 4.0.0

--- a/cfgov/jinja2/v1/_includes/molecules/info-unit.html
+++ b/cfgov/jinja2/v1/_includes/molecules/info-unit.html
@@ -81,13 +81,13 @@
                         {% endif %}
                         {% include 'contact-email.html' with context %}
                     {% else %}
-                    <a class="{{ 'btn m-info-unit_btn' if value.is_button
-                                  else 'list_link' }}"
-                       href="{{ link.url }}">
-                        {# TODO: check for link.url otherwise show disabled
-                                 after testing is completed #}
-                        {{ link.text if link.text else 'Learn More' }}
-                    </a>
+                        {% set link_class = 'btn m-info-unit_btn' if
+                            value.is_button else 'list_link' %}
+                        {% set link_text = link.text if link.text
+                            else 'Learn More' %}
+                        {% set link = '<a class="' ~ link_class ~ '" href="' ~
+                            link.url ~ '">' ~ link_text ~ '</a>' %}
+                        {{ parse_links( link ) | safe }}
                     {% endif %}
                 </li>
             {% endfor %}


### PR DESCRIPTION
Icons for file types were missing from links within info-units. Updated the macro to parse the link before priting it to the page.

## Changed

- Updated the info-unit to set the link to a variable and then run that variable through the `parse_link` function.

## Testing

- In Wagtail create a 25/75, 50/50, and half-width link blob. Include links with `.pdf` file extensions (they don't have to be real, just add the extension to any url).

## Review

- @Scotchester 

## Screenshots

<img width="289" alt="screen shot 2016-11-28 at 2 15 51 pm" src="https://cloud.githubusercontent.com/assets/1280430/20684366/308a4088-b575-11e6-9e09-05f1bd1bf63a.png">

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices
* [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)