### PR TITLE
tweak admin for feedback entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Limit Activity Log posts to appropriate page categories.
 - Flush Akamai when unpublishing or unsharing a page so those changes propagate immediately
 - Removed feedback-form default text and clarified help_text
+- Ajusted Django admin page for v1_feedback objects
 
 ### Removed
 

--- a/cfgov/v1/admin.py
+++ b/cfgov/v1/admin.py
@@ -33,7 +33,7 @@ def feedback_page_title(feedback):
     if feedback.page:
         return feedback.page.title
 
-feedback_page_title.short_description = 'Page title'
+feedback_page_title.short_description = 'Page'
 
 
 @admin.register(Feedback)

--- a/cfgov/v1/admin.py
+++ b/cfgov/v1/admin.py
@@ -29,21 +29,21 @@ class UserAdmin(UserAdmin):
     send_password_reset_email.short_description = 'Send password reset email'
 
 
-def feedback_page_url(feedback):
+def feedback_page_title(feedback):
     if feedback.page:
-        return feedback.page.url
+        return feedback.page.title
 
-feedback_page_url.short_description = 'Page URL'
+feedback_page_title.short_description = 'Page title'
 
 
 @admin.register(Feedback)
 class FeedbackAdmin(admin.ModelAdmin):
-    list_filter = ('submitted_on', 'page__title',)
+    list_filter = ('submitted_on',)
     list_display = (
-        'referrer',
-        'comment',
-        feedback_page_url,
         'submitted_on',
-        'is_helpful'
+        feedback_page_title,
+        'referrer',
+        'is_helpful',
+        'comment'
     )
-    search_fields = ['referrer', 'comment']
+    search_fields = ['referrer', 'comment', 'page__title']


### PR DESCRIPTION
Product owner needs better filtering/searching capability for
v1_feedback objects in the admin.


## Changes

- adjusts the v1_feedback admin for usability.

## Checklist

* [x] Visually tested and reviewed by stakeholders
* [x] Updated the "Unreleased" section of the CHANGELOG
* [x] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:

