### PR TITLE
Updating changelog to show 4.2 hotfixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,6 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 
 
 ## 4.1.9
-- Bumping version of College Comparision Tool.
 - Bumping version of College Comparision Tool to 1.2.9
 
 ## 4.1.8


### PR DESCRIPTION
Okay it turns out @richaagarwal's hotfix *is* already in master. So the changelog is in fact all that needs to be updated.

@Scotchester @higs4281 