### PR TITLE
Fix unstoppable videos when playing in HTTPS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 ---------------------------------------
 
 
+## Unreleased
+
+### Fixed
+- Fixed bug stopping videos in HTTPS pages.
+
+
 ## 4.3.0
 
 ### Added

--- a/cfgov/jinja2/v1/_includes/macros/video-player.html
+++ b/cfgov/jinja2/v1/_includes/macros/video-player.html
@@ -50,7 +50,10 @@
             {% set video_url = _buildParam( video_url, 'enablejsapi=1' )  %}
         {% endif -%}
         {% if video_url.find( 'origin=' ) == -1 -%}
-            {% set video_url = _buildParam( video_url, 'origin=http://' ~ request.META['HTTP_HOST'] )  %}
+            {% set video_url = _buildParam(
+                 video_url,
+                 'origin=' ~ request.scheme ~ '://' ~ request.META['HTTP_HOST']
+            ) %}
         {% endif %}
     {% elif video_player == 'ustream' %}
         {% if video_url.find( 'html5ui' ) == -1 -%}


### PR DESCRIPTION
This PR fixes a bug where videos played from a page accessed with HTTPS would continue playing even when the video module was closed.

## Changes

- Use the proper (current) request scheme when including the `origin` parameter in YouTube URLs.

## Testing

- Run your local server as HTTP using `./runserver.sh`.
- Create an `EventPage`. Give it a title, a start and end date (both in the past), and a YouTube embed URL (for example https://www.youtube.com/embed/cx7-2El9NxA).
- Access the page in your browser. Click the play button, let the video start playing, then hit the Close button. Observe that the video disappears and that audio stops playing.
- Restart your local server as HTTPS using `./runserver.sh ssl`.
- Access the same page (via https://localhost:8000/slug instead of http://localhost:8000/slug), and repeat the above behavior.

## Checklist

* [X] Changes are limited to a single goal (no scope creep)
* [X] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [X] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [X] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
* [X] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
