### PR TITLE
Add missing uniqueness constraint to CFGOVRendition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 ### Fixed
 - Fixed bug stopping videos in HTTPS pages.
 - bug that wasn't signing links already coded to /external-site
+- Added missing uniqueness constraint on CFGOVRendition.
 
 
 ## 4.3.1

--- a/cfgov/v1/migrations/0036_cfgovrendition_uniqueness.py
+++ b/cfgov/v1/migrations/0036_cfgovrendition_uniqueness.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('v1', '0035_add_5050_output_to_flc'),
+    ]
+
+    operations = [
+        migrations.AlterUniqueTogether(
+            name='cfgovrendition',
+            unique_together=set([('image', 'filter', 'focal_point_key')]),
+        ),
+    ]

--- a/cfgov/v1/models/images.py
+++ b/cfgov/v1/models/images.py
@@ -89,6 +89,11 @@ class CFGOVImage(AbstractImage):
 class CFGOVRendition(AbstractRendition):
     image = models.ForeignKey(CFGOVImage, related_name='renditions')
 
+    class Meta:
+        unique_together = (
+            ('image', 'filter', 'focal_point_key'),
+        )
+
 
 # Delete the source image file when an image is deleted
 @receiver(pre_delete, sender=CFGOVImage)

--- a/cfgov/v1/tests/models/test_images.py
+++ b/cfgov/v1/tests/models/test_images.py
@@ -1,6 +1,4 @@
-from unittest import skipIf
-
-from django.db import IntegrityError, connection
+from django.db import IntegrityError
 from django.test import TestCase
 from mock import Mock, patch
 from wagtail.wagtailimages.models import Filter

--- a/cfgov/v1/tests/models/test_images.py
+++ b/cfgov/v1/tests/models/test_images.py
@@ -1,6 +1,10 @@
+from unittest import skipIf
+
+from django.db import IntegrityError, connection
 from django.test import TestCase
 from mock import Mock, patch
 from wagtail.wagtailimages.models import Filter
+from wagtail.wagtailimages.tests.utils import get_test_image_file
 
 from v1.models.images import CFGOVImage, CFGOVRendition
 
@@ -90,3 +94,27 @@ class CFGOVImageTest(TestCase):
             rendition.img_tag(),
             '<img alt="" height="150" src="https://url" width="250">'
         )
+
+
+class CFGOVRenditionTest(TestCase):
+    def test_uniqueness_constraint(self):
+        image = CFGOVImage.objects.create(
+            title='test',
+            file=get_test_image_file()
+        )
+
+        filt = Filter.objects.create(spec='original')
+
+        def create_rendition(image, filt):
+            return CFGOVRendition.objects.create(
+                filter=filt,
+                image=image,
+                file=image.file,
+                width=100,
+                height=100,
+                focal_point_key=filt.get_cache_key(image)
+            )
+
+        create_rendition(image=image, filt=filt)
+        with self.assertRaises(IntegrityError):
+            create_rendition(image=image, filt=filt)


### PR DESCRIPTION
Our use of a custom image rendition class `v1.models.images.CFGOVRendition` neglected to include the uniqueness constraint present on the reference rendition model [here](https://github.com/wagtail/wagtail/blob/v1.6.3/wagtail/wagtailimages/models.py#L516) and in the documentation [here](http://docs.wagtail.io/en/v1.7/advanced_topics/images/custom_image_model.html?highlight=unique_together#custom-image-models):

```py
class Meta:
    unique_together = (
        ('image', 'filter', 'focal_point_key'),
    )
```

This lack of constraint may have enabled the creation of duplicate rendition objects which caused some 500 errors when browsing images today: the rendition creation code [uses](https://github.com/wagtail/wagtail/blob/v1.6.3/wagtail/wagtailimages/models.py#L291) Django `get_or_create`, about which [the docs say](https://docs.djangoproject.com/en/1.8/ref/models/querysets/#django.db.models.query.QuerySet.get_or_create):

> This method is atomic assuming correct usage, correct database configuration, and correct behavior of the underlying database. However, if uniqueness is not enforced at the database level for the kwargs used in a get_or_create call (see unique or unique_together), this method is prone to a race-condition which can result in multiple rows with the same parameters being inserted simultaneously.

Without that `unique_together` constraint, we may have been hitting that race condition.

## Additions

- New `unique_together` constraint on `CFGOVRendition`, as recommended by documentation.

## Testing

- This is a little bit difficult to test interactively, but to isolate a new unit test that checks this logic you can run:
 ```sh
$ tox -e fast v1.tests.models.test_images.CFGOVRenditionTest
```

## Checklist

* [X] Changes are limited to a single goal (no scope creep)
* [X] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [X] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [X] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
* [X] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:

