### PR TITLE
Fix for failing Youtube API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 ### Fixed
 - Fixed bug stopping videos in HTTPS pages.
 - bug that wasn't signing links already coded to /external-site
-
+- Fix for Youtube API failures.
 
 ## 4.3.1
 

--- a/cfgov/unprocessed/js/modules/UStreamPlayer.js
+++ b/cfgov/unprocessed/js/modules/UStreamPlayer.js
@@ -10,7 +10,7 @@ var CLASSES = Object.freeze( {
 
 var API = {
 
-  SCRIPT_API: 'http://developers.ustream.tv/js/ustream-embedapi.min.js',
+  SCRIPT_API: 'https://developers.ustream.tv/js/ustream-embedapi.min.js',
 
   constructor: UStreamPlayer,
 

--- a/cfgov/unprocessed/js/modules/YoutubePlayer.js
+++ b/cfgov/unprocessed/js/modules/YoutubePlayer.js
@@ -19,7 +19,7 @@ var API = {
 
   constructor: YoutubePlayer,
 
-  SCRIPT_API: 'http://www.youtube.com/iframe_api',
+  SCRIPT_API: 'https://www.youtube.com/iframe_api',
 
   IMAGE_URL: 'https://img.youtube.com/vi/%video_id%/maxresdefault.jpg',
 
@@ -135,7 +135,7 @@ var API = {
    */
   play: function( ) {
     this._super.play.call( this );
-    if ( this.state.isPlayerInitialized ) {
+    if ( this.state.isPlayerInitialized && this.player ) {
       this.player.seekTo( 0 );
       this.player.playVideo();
     } else {
@@ -148,8 +148,13 @@ var API = {
    */
   stop: function( ) {
     this._super.stop.call( this );
-    if ( this.state.isPlayerInitialized ) {
-      this.player.stopVideo();
+    if ( this.state.isPlayerInitialized && this.player ) {
+        this.player.stopVideo();
+    } else {
+      this.childElements.iFrameContainer.removeChild(
+        this.childElements.iFrameContainer.firstChild;
+      )
+       this.state.setIsIframeLoaded( false );
     }
   }
 };

--- a/cfgov/unprocessed/js/modules/YoutubePlayer.js
+++ b/cfgov/unprocessed/js/modules/YoutubePlayer.js
@@ -152,9 +152,9 @@ var API = {
         this.player.stopVideo();
     } else {
       this.childElements.iFrameContainer.removeChild(
-        this.childElements.iFrameContainer.firstChild;
-      )
-       this.state.setIsIframeLoaded( false );
+        this.childElements.iFrameContainer.firstChild
+      );
+      this.state.setIsIframeLoaded( false );
     }
   }
 };


### PR DESCRIPTION
The Youtube API sometimes fails to load which causes problems when accessing its video player API. This is a workaround for that issue which removes and reattaches the iframe when stopping / playing.
I also changed hardcoded `http` references to `https`. 

## Changes

-  Modified `cfgov/unprocessed/js/modules/UStreamPlayer.js` to switch `http` to `https`.
-  Modifeid c`fgov/unprocessed/js/modules/YoutubePlayer.js` to attach / reattach the iframe when stopping / playing.

## Testing

- Modify the `origin` property in `video-player.html`
- Visit `http://localhost:8000/about-us/the-bureau/`.
- You should be able to play and stop the video without error.
- Check the console to verify that there are no errors.


## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
* [ ] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:

