### PR TITLE
Move get_page_state_url back to v1.templatetags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,6 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 ## Changed
 - external-site redirector now requires URLs to either be whitelisted or signed
 - Move logic for activity snippets out of template
-- Move `get_page_state_url` out of templatetags to avoid circular dependencies
 
 ### Fixed
 - Fixed bug stopping videos in HTTPS pages.

--- a/cfgov/v1/__init__.py
+++ b/cfgov/v1/__init__.py
@@ -20,7 +20,8 @@ from wagtail.wagtailcore.rich_text import expand_db_html, RichText
 from bs4 import BeautifulSoup, NavigableString
 from processors.processors_common import fix_link
 from core.utils import signed_redirect, unsigned_redirect, sign_url
-from v1.routing import get_page_state_url, get_protected_url, get_page_relative_url
+from v1.routing import get_protected_url, get_page_relative_url
+from v1.templatetags.share import get_page_state_url
 
 
 default_app_config = 'v1.apps.V1AppConfig'

--- a/cfgov/v1/routing.py
+++ b/cfgov/v1/routing.py
@@ -1,14 +1,7 @@
 from django.core.urlresolvers import reverse
-from django.conf import settings
 
 from wagtail.wagtailcore.utils import WAGTAIL_APPEND_SLASH
 from jinja2 import contextfunction
-from django import template
-from wagtail.wagtailcore.models import Page
-from urlparse import urlparse
-import os
-
-register = template.Library()
 
 
 def get_url_parts_for_site(page, site):
@@ -55,21 +48,6 @@ def get_page_relative_url(page, site):
         return page_path
     else:
         return root_url + page_path
-
-
-@register.assignment_tag(takes_context=True)
-def get_page_state_url(context, page):
-    page = Page.objects.get(id=page.id).specific
-    if not page.live and not page.shared:
-        return None
-    url = page.url
-    if url is None:  # If page is not aligned to a site root return None
-        return None
-    page_hostname = urlparse(url).hostname
-    staging_hostname = settings.STAGING_HOSTNAME
-    if not page.live and page.shared and staging_hostname != page_hostname:
-        url = url.replace(page_hostname, staging_hostname)
-    return url
 
 
 @contextfunction

--- a/cfgov/v1/templatetags/share.py
+++ b/cfgov/v1/templatetags/share.py
@@ -1,9 +1,25 @@
 from django import template
-
-from v1.models import CFGOVUserPagePermissionsProxy
+from django.conf import settings
+from urlparse import urlparse
 from wagtail.wagtailcore.models import Page
 
+
 register = template.Library()
+
+
+@register.assignment_tag(takes_context=True)
+def get_page_state_url(context, page):
+    page = Page.objects.get(id=page.id).specific
+    if not page.live and not page.shared:
+        return None
+    url = page.url
+    if url is None:  # If page is not aligned to a site root return None
+        return None
+    page_hostname = urlparse(url).hostname
+    staging_hostname = settings.STAGING_HOSTNAME
+    if not page.live and page.shared and staging_hostname != page_hostname:
+        url = url.replace(page_hostname, staging_hostname)
+    return url
 
 
 @register.filter
@@ -20,6 +36,9 @@ def is_shared(page):
 def v1page_permissions(context, page):
     page = page.specific
     if 'user_page_permissions' not in context:
-        context['user_page_permissions'] = CFGOVUserPagePermissionsProxy(context['request'].user)
+        from v1.models import CFGOVUserPagePermissionsProxy
+        context['user_page_permissions'] = CFGOVUserPagePermissionsProxy(
+            context['request'].user
+        )
 
     return context['user_page_permissions'].for_page(page)

--- a/cfgov/v1/tests/templatetags/test_share.py
+++ b/cfgov/v1/tests/templatetags/test_share.py
@@ -1,11 +1,13 @@
 import mock
 
 from unittest import TestCase
-from v1.templatetags import share
-from v1.routing import get_page_state_url
-from v1.tests.wagtail_pages import helpers
-from v1.models.base import CFGOVPage, CFGOVPagePermissionTester, CFGOVUserPagePermissionsProxy, User
 from wagtail.wagtailcore.models import Site
+
+from v1.templatetags import share
+from v1.tests.wagtail_pages import helpers
+from v1.models.base import (
+    CFGOVPage, CFGOVPagePermissionTester, CFGOVUserPagePermissionsProxy, User
+)
 
 
 class TemplatetagsShareTestCase(TestCase):
@@ -85,7 +87,7 @@ class TemplatetagsShareTestCase(TestCase):
         self.page.shared = False
         self.page.save()
 
-        result = get_page_state_url(None, self.page)
+        result = share.get_page_state_url(None, self.page)
         self.assertIsNone(result)
 
     def test_get_page_state_url_staged(self):
@@ -100,7 +102,7 @@ class TemplatetagsShareTestCase(TestCase):
         self.page.shared = True
         self.page.save()
 
-        result = get_page_state_url(None, self.page)
+        result = share.get_page_state_url(None, self.page)
         self.assertEqual(result, self.page.url.replace('http://localhost',
                                                        'http://content.localhost'))
 
@@ -113,7 +115,7 @@ class TemplatetagsShareTestCase(TestCase):
         self.page.shared = False
         self.page.save()
 
-        result = get_page_state_url(None, self.page)
+        result = share.get_page_state_url(None, self.page)
         self.assertEqual(result, self.page.url)
 
     def test_v1page_permissions_no_permissions_in_context(self):
@@ -158,7 +160,7 @@ class TemplatetagsShareTestCase(TestCase):
         for site in site_objects:
             site.delete()
 
-        result = get_page_state_url(None, self.page)
+        result = share.get_page_state_url(None, self.page)
 
         for site in site_objects:
             site.save()

--- a/cfgov/v1/tests/templatetags/test_share.py
+++ b/cfgov/v1/tests/templatetags/test_share.py
@@ -1,5 +1,6 @@
 import mock
 
+from django.template import Context, Template
 from unittest import TestCase
 from wagtail.wagtailcore.models import Site
 
@@ -166,3 +167,19 @@ class TemplatetagsShareTestCase(TestCase):
             site.save()
 
         self.assertIsNone(result)
+
+
+class TemplateRenderingTest(TestCase):
+    def test_template_renders_with_get_page_state_url(self):
+        site = Site.objects.get(is_default_site=True)
+        page = site.root_page
+
+        template = (
+            '{% load share %}'
+            '{% get_page_state_url page as url %}'
+            '{{ url }}'
+        )
+
+        t = Template(template)
+        c = Context({'page': page})
+        self.assertEquals(t.render(c), page.url)

--- a/cfgov/v1/util/util.py
+++ b/cfgov/v1/util/util.py
@@ -35,7 +35,7 @@ def instanceOfBrowseOrFilterablePages(page):
 # TODO: Move into BrowsePage class once BrowseFilterablePage has been merged
 # into BrowsePage
 def get_secondary_nav_items(request, current_page):
-    from v1.routing import get_page_state_url
+    from v1.templatetags.share import get_page_state_url
     on_staging = os.environ.get('DJANGO_STAGING_HOSTNAME') == request.site.hostname
     nav_items = []
     parent = current_page.get_parent().specific


### PR DESCRIPTION
#2523 [moved](https://github.com/cfpb/cfgov-refresh/pull/2523/files#diff-4ac32a78649ca5bdd8e0ba38b7006a1eR20) `get_page_state_url` from `v1.templatetags.share` into `v1.routing`. This avoided a circular dependency but had the unfortunate side effect of breaking use of `{% get_page_state_url %}` in non-Jinja templates (e.g. the Wagtail admin). This causes 500 errors when viewing the root Wagtail admin page with the latest production database dump:

> TemplateSyntaxError at /admin/
Invalid block tag: 'get_page_state_url', expected 'endif'

This PR moves that `get_page_state_url` method back into `v1.templatetags.share`, and resolves the circular dependency by moving a `v1.models` import into a function.

## Changes

- `get_page_state_url` moved back to `v1.templatetags.share`.

## Testing

- Browse local admin with a recent production data dump and note that recent edits show up properly on the [admin home page](http://localhost:8000/admin/).
- New unit test in `v1.tests.templatetags.test_share` that isolates use of this function in a Django (non-Jinja) template.

## Checklist

* [X] Changes are limited to a single goal (no scope creep)
* [X] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [X] Passes all existing automated tests
* [X] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [X] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
* [X] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
