### PR TITLE
Update privacy link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - external-site redirector now requires URLs to either be whitelisted or signed
 - Move logic for activity snippets out of template
 - Move `get_page_state_url` out of templatetags to avoid circular dependencies
+- Update privacy policy URL
 
 ### Fixed
 - Fixed bug stopping videos in HTTPS pages.

--- a/cfgov/jinja2/v1/_includes/organisms/footer.html
+++ b/cfgov/jinja2/v1/_includes/organisms/footer.html
@@ -79,7 +79,7 @@
                     </li>
                     <li class="list_item">
                         <a class="list_link"
-                           href="/privacy/digital-privacy-policy/">
+                           href="/privacy/website-privacy-policy/">
                             Website Privacy Policy & Legal Notices
                         </a>
                     </li>

--- a/test/browser_tests/spec_suites/integration/footer.js
+++ b/test/browser_tests/spec_suites/integration/footer.js
@@ -28,8 +28,8 @@ describe( 'Footer', function() {
       'plain writing',
     '/privacy/':
       'privacy, policy & legal notices',
-    '/privacy/digital-privacy-policy/':
-      'digital privacy policy',
+    '/privacy/website-privacy-policy/':
+      'website privacy policy',
     '/tribal/':
       'tribal',
     'http://usa.gov/':


### PR DESCRIPTION
The slug for the privacy policy changed recently. This PR updates the link in the footer to the new URL.

## Changes

- Update the privacy policy link in the footer

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [x] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices
* [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
* [x] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
