### PR TITLE
Set pdfreactor log level to 'fatal'

### DIFF
--- a/cfgov/cal/views.py
+++ b/cfgov/cal/views.py
@@ -147,7 +147,7 @@ def pdf_response(request, context):
     pdf_reactor = PDFreactor()
 
     pdf_reactor.setBaseURL("http://localhost/")
-    pdf_reactor.setLogLevel(PDFreactor.LOG_LEVEL_WARN)
+    pdf_reactor.setLogLevel(PDFreactor.LOG_LEVEL_FATAL)
     pdf_reactor.setLicenseKey(str(license))
     pdf_reactor.setAuthor('CFPB')
     pdf_reactor.setAddTags(True)

--- a/cfgov/legacy/views.py
+++ b/cfgov/legacy/views.py
@@ -63,7 +63,7 @@ class HousingCounselorPDFView(PDFGeneratorView):
         except:
             raise PDFReactorNotConfigured('PDFreactor python library path needs to be configured.')
 
-        pdf_reactor.setLogLevel(PDFreactor.LOG_LEVEL_WARN)
+        pdf_reactor.setLogLevel(PDFreactor.LOG_LEVEL_FATAL)
         pdf_reactor.setLicenseKey(str(self.license))
         pdf_reactor.setAuthor('CFPB')
         pdf_reactor.setAddTags(True)


### PR DESCRIPTION
This should reduce the noise and weight of PDF reactor logs.


## Changes

- in the places where we set the log level, use `PDFreactor.LOG_LEVEL_FATAL` instead of  `PDFreactor.LOG_LEVEL_WARN`

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
* [ ] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
