### PR TITLE
Use the base_query to for FilterableListForm page_ids

### DIFF
--- a/cfgov/v1/forms.py
+++ b/cfgov/v1/forms.py
@@ -7,8 +7,7 @@ from django.forms.utils import ErrorList
 from django.forms import widgets
 from taggit.models import Tag
 
-from .models.base import CFGOVPage, Feedback
-from .models.learn_page import AbstractFilterPage
+from .models.base import Feedback
 from v1.util.categories import clean_categories
 from v1.util import ref
 
@@ -131,15 +130,6 @@ class FilterableListForm(forms.Form):
         clean_categories(selected_categories=self.data.get('categories'))
         self.set_topics(page_ids)
         self.set_authors(page_ids)
-
-
-    def base_query(self):
-        base_query = AbstractFilterPage.objects.live_shared(hostname=self.hostname)
-        if self.parent:
-            base_query = base_query.filter(CFGOVPage.objects.child_of_q(self.parent))
-            logger.info('Filtering by parent {}'.format(self.parent))
-        return base_query
-
 
     def get_page_set(self):
         query = self.generate_query()

--- a/cfgov/v1/forms.py
+++ b/cfgov/v1/forms.py
@@ -10,7 +10,7 @@ from taggit.models import Tag
 from .models.base import CFGOVPage, Feedback
 from .models.learn_page import AbstractFilterPage
 from v1.util.categories import clean_categories
-from v1.util import ref 
+from v1.util import ref
 
 
 import logging
@@ -126,7 +126,7 @@ class FilterableListForm(forms.Form):
         self.hostname = kwargs.pop('hostname')
         self.base_query = kwargs.pop('base_query')
         super(FilterableListForm, self).__init__(*args, **kwargs)
-        page_ids = CFGOVPage.objects.live_shared(self.hostname).values_list('id', flat=True)
+        page_ids = self.base_query.live_shared(self.hostname).values_list('id', flat=True)
 
         clean_categories(selected_categories=self.data.get('categories'))
         self.set_topics(page_ids)


### PR DESCRIPTION
This PR fixes a problem with filterable list forms where the topics would include all possible topics, not just the topics that apply to the pages being filtered.

We may want to hotfix 4.3 with this once it's merged.

## Changes

- Change the filterable list `page_ids` to come from the constructed `base_query` rather than all `CFGovPage` objects.

## Testing

- Visit a BrowseFilterablePage and attempt to search for a topic that doesn't belong to any of the subpages and notice topics that have no results appear. Apply this fix and attempt the same and notice that topics with no results no longer appear.

## Screenshots

Before, on http://www.consumerfinance.gov/policy-compliance/enforcement/actions/:
![image](https://cloud.githubusercontent.com/assets/10562538/21358718/8ee3a2bc-c6a7-11e6-8de5-cfcbfc9495b0.png)

After:
![image](https://cloud.githubusercontent.com/assets/10562538/21358707/84d93b60-c6a7-11e6-9387-482e66d90b76.png)

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [x] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
* [x] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
