### PR TITLE
Fix blog and newsroom RSS feed links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,18 +18,19 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 ## Added
 - New AWS_S3_ROOT setting to specify root S3 path.
 - New PlaceholderFieldBlock and PlaceholderCharBlock to set block placeholder text.
+- Add RSS subscription button to newsroom posts.
 
 ## Changed
 - external-site redirector now requires URLs to either be whitelisted or signed
 - Move logic for activity snippets out of template
 - Update privacy policy URL
 - Upgrade npm shrinkwrap endpoints to HTTPS
-- Upgrade to Wagtail 1.7 
+- Upgrade to Wagtail 1.7
 
 ## Removed
 - Removed deprecated Django careers-related models, views, and templates.
 - Removed layout.less enhancements that have been moved to Capital Framework.
-- Wagtail pages from the Django admin 
+- Wagtail pages from the Django admin
 - Delete option from Wagtail templates
 - Removed deprecated fellowship view/model.
 - Removed deprecated fellowship notification sign up form.
@@ -41,6 +42,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Added missing uniqueness constraint on CFGOVRendition.
 - Fix for YouTube API failures
 - Now correctly allows for hyphens in the video ID of a Video Player's `video_url` field.
+- Fix blog post RSS subscription links
 
 
 ## 4.3.2

--- a/cfgov/jinja2/v1/blog/blog_page.html
+++ b/cfgov/jinja2/v1/blog/blog_page.html
@@ -27,6 +27,6 @@
     {{ streamfield_sidefoot.render(page.sidefoot) }}
     <div class="block block__sub" data-qa-hook="rss-subscribe-section">
         {% import 'rss.html' as rss %}
-        {{ rss.render('feed/') }}
+        {{ rss.render('/about-us/blog/feed/') }}
     </div>
 {% endblock %}

--- a/cfgov/jinja2/v1/newsroom/newsroom-page.html
+++ b/cfgov/jinja2/v1/newsroom/newsroom-page.html
@@ -33,4 +33,8 @@
 
 {% block content_sidebar %}
     {{ streamfield_sidefoot.render(page.sidefoot) }}
+    <div class="block block__sub" data-qa-hook="rss-subscribe-section">
+        {% import 'rss.html' as rss %}
+        {{ rss.render('/about-us/newsroom/feed/') }}
+    </div>
 {% endblock %}


### PR DESCRIPTION
Per GHE 457:

> The "Subscribe to RSS" buttons on the sidebar of individual newsroom or blog post pages are broken - they link to "[this-post-URL]/feed" -- see example at http://www.consumerfinance.gov/about-us/blog/be-your-familys-financial-action-hero-during-emergency and then click "Subscribe to RSS" in the sidebar.

## Additions

- Add RSS subscription button to newsroom posts

## Changes

- Fix blog post RSS subscription links

## Notes

- Making the links absolute URLs feels a little weird but I'm unsure of an alternative. It was a relative URL hardcoded to `feed/` before so I guess this isn't that much different.
