### PR TITLE
Fix unit test so it doesn't try to make request to Akamai

### DIFF
--- a/cfgov/v1/tests/test_wagtail_hooks.py
+++ b/cfgov/v1/tests/test_wagtail_hooks.py
@@ -290,15 +290,13 @@ class TestFlushAkamai(TestCase):
         with self.settings(ENABLE_AKAMAI_CACHE_PURGE=True):
             assert should_flush(self.page)
 
-    @mock.patch('v1.wagtail_hooks.should_flush')
-    def test_should_flush_gets_called_when_trying_to_flush(self, mock_should_flush):
-        with self.settings(
-            AKAMAI_OBJECT_ID='some-arbitrary-id',
-            AKAMAI_USER='some-arbitrary-user',
-            AKAMAI_PASSWORD='some-arbitrary-pw'
-        ):
-            flush_akamai(self.page)
-        assert mock_should_flush.called
+    def test_should_flush_gets_called_when_trying_to_flush(self):
+        with mock.patch(
+            'v1.wagtail_hooks.should_flush',
+            return_value=False
+        ) as should_flush:
+            self.assertFalse(flush_akamai(self.page))
+            should_flush.assert_called_once_with(self.page)
 
 
 class TestGetAkamaiCredentials(TestCase):


### PR DESCRIPTION
The unit test `v1.tests.wagtail_hooks.TestFlushAkamai. test_should_flush_gets_called_when_trying_to_flush` actually tries to make an HTTP request to the server defined in environment variable `AKAMAI_PURGE_URL`, which is set by default to [the actual Akamai URL](https://github.com/cfpb/cfgov-refresh/blob/master/cfgov/cfgov/settings/base.py#L513). This doesn't actually purge Akamai (because the other settings aren't defined), but does try to make a request. This fails the test when that URL isn't accessible, and is causing some other PR Travis tests to fail.

This PR modifies that test to skip the actual call to Akamai and only test that `should_flush` gets called appropriately.

## Changes

- Fix to unit test to avoid making HTTP request to Akamai server.

## Testing

- All unit tests should pass.

## Checklist

* [X] Changes are limited to a single goal (no scope creep)
* [X] Code can be automatically merged (no conflicts)
* [X] Passes all existing automated tests
* [X] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
