### PR TITLE
Fix broken supervision jobs page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Now correctly allows for hyphens in the video ID of a Video Player's `video_url` field.
 - Fix blog post RSS subscription links
 - Fix for Wagtail admin page status string when live but not shared.
+- Fixed legacy supervision jobs page.
 
 
 ## 4.3.2

--- a/cfgov/templates/jobmanager/supervision.html
+++ b/cfgov/templates/jobmanager/supervision.html
@@ -1,4 +1,5 @@
 {% extends "front/base_nonresponsive.html" %}
+{% load static from staticfiles %}
 
 {% block page_meta %}
 <meta charset="UTF-8" />
@@ -11,16 +12,16 @@
 
 {% block breadcrumbs %}
 	<li><a href="/" class="internal-link">Home</a></li>
-	<li><a href="{% url 'careers:jobs' %}" class="internal-link">Jobs</a></li>
+  <li><a href="/about-us/careers/" class="internal-link">Jobs</a></li>
     <li>Supervision</li>
 {% endblock %}
 
 {% block page_css %}
-    <link rel="stylesheet" type="text/css" href="{{ STATIC_PREFIX }}jobmanager/css/jobs2.css" />
+<link rel="stylesheet" type="text/css" href="{% static 'jobmanager/css/jobs2.css' %}" />
 {% endblock %}
 
 {% block page_js %}
-    <script src="{{ STATIC_PREFIX }}jobmanager/js/supervision.js"></script>
+    <script src="{% static 'jobmanager/js/supervision.js' %}"></script>
 {% endblock %}
 
 {% block content %}
@@ -157,7 +158,7 @@
         </li>
         <li>
             <h3>Other Current Job Opportunities</h3>
-            <p>Please go to <a href='{% url "careers:jobs" %}' class="internal-link">our jobs sections</a> to view other job opportunities</p>
+            <p>Please go to <a href='/about-us/careers/' class="internal-link">our jobs sections</a> to view other job opportunities</p>
         </li>
     </ul>
 </section>

--- a/cfgov/v1/tests/test_legacy_pages.py
+++ b/cfgov/v1/tests/test_legacy_pages.py
@@ -1,0 +1,17 @@
+from django.core.urlresolvers import reverse
+from django.test import Client, TestCase
+
+
+class TestLegacyPagesRender(TestCase):
+    def setUp(self):
+        self.client = Client()
+
+    def check_named_url(self, name):
+        response = self.client.get(reverse(name))
+        self.assertEqual(response.status_code, 200)
+
+    def test_fellowship_page(self):
+        self.check_named_url('technology_innovation_fellows')
+
+    def test_supervision_page(self):
+        self.check_named_url('jobs_supervision')


### PR DESCRIPTION
[The legacy supervision jobs page](http://www.consumerfinance.gov/jobs/supervision/) is throwing 500 errors because of some careers cleanup in #2612.

This PR fixes use of a now-deprecated URL pattern (by hardcoding links to `/about-us/careers/`, unfortunately the best way right now to link from non-Wagtail to Wagtail pages) and also fixes static asset references.

## Changes

- Replaced some outdated usage of `STATIC_ROOT` with the `{% static %}` tag.
- Replaced outdated usage of `{% url 'careers:jobs' %}` with `/about-us/careers/`.

## Testing

- Run a local server and visit [http://localhost:8000/jobs/supervision/](http://localhost:8000/jobs/supervision/). Note the two links to `/about-us/careers/` and that static assets appear properly.

## Checklist

* [X] Changes are limited to a single goal (no scope creep)
* [X] Code can be automatically merged (no conflicts)
* [X] Passes all existing automated tests
* [X] New functions include new tests
* [X] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
* [X] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
