### PR TITLE
Fixes for External Redirect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Fix blog post RSS subscription links
 - Fix for Wagtail admin page status string when live but not shared.
 - Fixed legacy supervision jobs page.
+- Fix for External Redirect proceed button and jQuery reference.
 
 
 ## 4.3.2

--- a/cfgov/unprocessed/js/modules/ExternalSite.js
+++ b/cfgov/unprocessed/js/modules/ExternalSite.js
@@ -16,7 +16,6 @@ var atomicHelpers = require( '../modules/util/atomic-helpers' );
  * @param {HTMLElement} element DOM Element.
  */
 function ExternalSite( element ) {
-
   var BASE_CLASS = 'external-site_container';
   var TOTAL_DURATION = 5;
   var INTERVAL = 1000;
@@ -24,7 +23,6 @@ function ExternalSite( element ) {
   var _dom = atomicHelpers.checkDom( element, BASE_CLASS );
   var _durationEl = _dom.querySelector( '.external-site_reload-container' );
   var _directEl = _dom.querySelector( '.external-site_proceed-btn' );
-  var _form = _dom.querySelector( 'form#proceed' );
   var _duration = TOTAL_DURATION;
   var _intervalId;
 
@@ -50,8 +48,9 @@ function ExternalSite( element ) {
    * Go to the redirect URL.
    */
   function _gotoUrl() {
+    var _formEl = _dom.querySelector( 'form#proceed' );
     clearInterval( _intervalId );
-    _form.submit();
+    _formEl.submit();
   }
 
   /**

--- a/cfgov/unprocessed/js/modules/ExternalSite.js
+++ b/cfgov/unprocessed/js/modules/ExternalSite.js
@@ -24,6 +24,7 @@ function ExternalSite( element ) {
   var _dom = atomicHelpers.checkDom( element, BASE_CLASS );
   var _durationEl = _dom.querySelector( '.external-site_reload-container' );
   var _directEl = _dom.querySelector( '.external-site_proceed-btn' );
+  var _form = _dom.querySelector( 'form#proceed' );
   var _duration = TOTAL_DURATION;
   var _intervalId;
 
@@ -32,6 +33,7 @@ function ExternalSite( element ) {
    */
   function init() {
     _intervalId = setInterval( _tick, INTERVAL );
+    _directEl.addEventListener( 'click', _proceedClicked );
   }
 
   /**
@@ -49,7 +51,7 @@ function ExternalSite( element ) {
    */
   function _gotoUrl() {
     clearInterval( _intervalId );
-    $('#proceed').submit();
+    _form.submit();
   }
 
   /**


### PR DESCRIPTION
The external redirect button isn't working and there is a jQuery reference.

## Changes

- Added fix for missing button event listener and removed jQuery.

## Testing

- Visit the homepage ( http://localhost:8000/ ).
- Click on the `Proceed to external site` button.


## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
* [ ] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
