### PR TITLE
Better use of moto.mock_s3 in unit tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Fix for Wagtail admin page status string when live but not shared.
 - Fixed legacy supervision jobs page.
 - Fix for External Redirect proceed button and jQuery reference.
+- Fixed use of `moto.mock_s3` in unit tests.
 
 
 ## 4.3.2

--- a/cfgov/v1/tests/test_s3utils.py
+++ b/cfgov/v1/tests/test_s3utils.py
@@ -1,9 +1,9 @@
 import boto
+import moto
 
 from django.core.files.base import ContentFile
 from django.core.files.storage import get_storage_class
 from django.test import TestCase, override_settings
-from moto import mock_s3
 from wagtail.wagtailimages.tests.utils import get_test_image_file
 from wagtail.wagtailimages.models import get_image_model
 
@@ -12,7 +12,6 @@ from v1.s3utils import (
 )
 
 
-@mock_s3
 @override_settings(
     AWS_QUERYSTRING_AUTH=False,
     AWS_S3_ACCESS_KEY_ID='test',
@@ -25,6 +24,10 @@ from v1.s3utils import (
 )
 class S3UtilsTestCase(TestCase):
     def setUp(self):
+        mock_s3 = moto.mock_s3()
+        mock_s3.start()
+        self.addCleanup(mock_s3.stop)
+
         self.s3 = boto.connect_s3()
         self.s3.create_bucket('test_s3_bucket')
 


### PR DESCRIPTION
The use of `@moto.mock_s3` as a test case decorator was causing some problems when writing other unit tests that access the network. This PR moves the mock s3 setup from the test case decorator to the unit test `setUp` method.

See also https://github.com/spulec/moto/issues/363 for related explanation.

Short description explaining the high-level reason for the pull request

## Changes

- Modify use of `moto.mock_s3` in unit tests.

## Testing

- Run unit tests.

## Checklist

* [X] Changes are limited to a single goal (no scope creep)
* [X] Code can be automatically merged (no conflicts)
* [X] Passes all existing automated tests
* [X] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
* [X] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
