### PR TITLE
Bug fix: filter links not working on English ask

### DIFF
--- a/requirements/optional-private.txt
+++ b/requirements/optional-private.txt
@@ -5,6 +5,6 @@
 git+https://private.repo/CFPB/agreement_database.git@v2.2.4#egg=agreement-database
 git+https://private.repo/CFPB/cfgov-selfregistration.git@v1.2#egg=selfregistration
 git+https://private.repo/CFPB/django-college-cost-comparison.git@v1.2.9#egg=comparisontool
-git+https://private.repo/CFPB/knowledgebase.git@v2.2.0#egg=knowledgebase
+git+https://private.repo/CFPB/knowledgebase.git@v2.2.1#egg=knowledgebase
 git+https://private.repo/CFPB/Picard.git@1.5.5#egg=picard
 git+https://private.repo/eregs/ip.git@1.0.3#egg=eregsip


### PR DESCRIPTION
Updates knowledgebase to 2.2.1

You can observe the issue on www, on a page like:

http://www.consumerfinance.gov/askcfpb/search/?selected_facets=category_exact:debt-collection

Clicking the checkboxes does not change the filter results. This is resolved in knowledgebase 2.2.1