### PR TITLE
Added missed block class to a block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Fix for External Redirect proceed button and jQuery reference.
 - Fixed use of `moto.mock_s3` in unit tests.
 - Fixed handling of invalid date query string parameters for filterable list forms.
+- Added missing `block` class from a block on the about the director page.
 
 ## 4.3.2
 

--- a/cfgov/jinja2/v1/about-us/the-bureau/index.html
+++ b/cfgov/jinja2/v1/about-us/the-bureau/index.html
@@ -103,7 +103,7 @@
                 Today, it’s our primary focus.
             </p>
 
-            <section class="bureau-functions block__padded-top">
+            <section class="bureau-functions block block__flush-bottom block__padded-top">
                 <h3 class="h4">Our work includes:</h3>
                 <ul class="list list__branded bureau-functions_list u-mb0">
                     <li>


### PR DESCRIPTION
## Changes

- Added missed `block` class to a block on the about the director's page.

## Testing

- `Our core functions` well on http://www.consumerfinance.gov/about-us/the-bureau/ should look unchanged.

## Screenshots

![screen shot 2017-01-03 at 5 34 33 pm](https://cloud.githubusercontent.com/assets/704760/21625732/0a0e5b74-d1db-11e6-9c7e-161a5c9a2684.png)
