### PR TITLE
Fix for erroneously removed bureau.less file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Fixed use of `moto.mock_s3` in unit tests.
 - Fixed handling of invalid date query string parameters for filterable list forms.
 - Added missing `block` class from a block on the about the director page.
+- Fixed issue with erroneously removed bureau stylesheet.
 
 ## 4.3.2
 

--- a/cfgov/unprocessed/css/main.less
+++ b/cfgov/unprocessed/css/main.less
@@ -158,6 +158,7 @@
 /* Page-specific styles
    ========================================================================== */
 
+@import (less) "pages/bureau.less";
 @import (less) "pages/business.less";
 @import (less) "pages/event.less";
 @import (less) "pages/external-site.less";


### PR DESCRIPTION
Fix for erroneously removed bureau.less file. Closes issue #2644 


## Changes

- Changed `cfgov/unprocessed/css/main.less` to add in `bureau.less`.


## Testing

-  Run `gulp styles`.
- Visit `http://localhost:8000/about-us/the-bureau/` and observe that the `Our work includes:` list should be stacked.

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
* [ ] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
