### PR TITLE
Removing unused breadcrumb classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 
 ### Fixed
 - Fix for missing breadcrumb on Press Resources `about-us/newsroom/press-resources/` page.
-
+- Fix for unused breadcrumb css styles.
 
 ## 4.5.2
 
@@ -88,7 +88,6 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Fixed handling of invalid date query string parameters for filterable list forms.
 - Added missing `block` class from a block on the about the director page.
 - Fixed issue with erroneously removed bureau stylesheet.
-- Fix for unused breadcrumb styles.
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,8 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Fixed handling of invalid date query string parameters for filterable list forms.
 - Added missing `block` class from a block on the about the director page.
 - Fixed issue with erroneously removed bureau stylesheet.
+- Fix for unused breadcrumb styles.
+
 
 
 ## 4.3.2

--- a/cfgov/jinja2/v1/_includes/breadcrumbs.html
+++ b/cfgov/jinja2/v1/_includes/breadcrumbs.html
@@ -11,13 +11,10 @@
    items:              An array of tuples used to display nav items.
                        format: (href, id, caption)
 
-   additional_classes: Extra classes you wish to add to the nav,
-                       space separated.
-
    ========================================================================== #}
 
-{% macro render(items, additional_classes='') %}
-<nav class="breadcrumbs {{ additional_classes  }}" aria-label="Breadcrumbs">
+{% macro render(items) %}
+<nav class="breadcrumbs" aria-label="Breadcrumbs">
     {% for href, id, caption in items %}
     <a class="breadcrumbs_link" href="{{ href }}">
         {{ caption | e }}

--- a/cfgov/jinja2/v1/_includes/breadcrumbs.html
+++ b/cfgov/jinja2/v1/_includes/breadcrumbs.html
@@ -16,8 +16,8 @@
 
    ========================================================================== #}
 
-{% macro render(items, additional_classes) %}
-<nav class="breadcrumbs {{ additional_classes }}" aria-label="Breadcrumbs">
+{% macro render(items, additional_classes='') %}
+<nav class="breadcrumbs {{ additional_classes  }}" aria-label="Breadcrumbs">
     {% for href, id, caption in items %}
     <a class="breadcrumbs_link" href="{{ href }}">
         {{ caption | e }}

--- a/cfgov/jinja2/v1/_includes/molecules/breadcrumbs.html
+++ b/cfgov/jinja2/v1/_includes/molecules/breadcrumbs.html
@@ -11,14 +11,10 @@
    items:              An array of tuples used to display nav items.
                        format: (href, id, caption)
 
-   additional_classes: Extra classes you wish to add to the nav,
-                       space separated.
-
    ========================================================================== #}
 
-{# TODO: Remove additional_classes parameter from macros. #}
-{% macro render(breadcrumbs, additional_classes='') %}
-    <nav class="breadcrumbs {{ additional_classes }}" aria-label="Breadcrumbs">
+{% macro render(breadcrumbs) %}
+    <nav class="breadcrumbs" aria-label="Breadcrumbs">
         {% for crumb in breadcrumbs %}
         <a class="breadcrumbs_link" href="{{ get_protected_url(crumb) }}">
             {{ crumb.title | e }}

--- a/cfgov/jinja2/v1/_includes/molecules/breadcrumbs.html
+++ b/cfgov/jinja2/v1/_includes/molecules/breadcrumbs.html
@@ -17,7 +17,7 @@
    ========================================================================== #}
 
 {# TODO: Remove additional_classes parameter from macros. #}
-{% macro render(breadcrumbs, additional_classes) %}
+{% macro render(breadcrumbs, additional_classes='') %}
     <nav class="breadcrumbs {{ additional_classes }}" aria-label="Breadcrumbs">
         {% for crumb in breadcrumbs %}
         <a class="breadcrumbs_link" href="{{ get_protected_url(crumb) }}">

--- a/cfgov/jinja2/v1/_layouts/content-base-main-first.html
+++ b/cfgov/jinja2/v1/_layouts/content-base-main-first.html
@@ -7,7 +7,7 @@
         {% if breadcrumb_items | length > 0 %}
             <div class="content_wrapper">
                 {%- import 'molecules/breadcrumbs.html' as breadcrumbs with context -%}
-                {{ breadcrumbs.render(breadcrumb_items, 'breadcrumbs__main-first') }}
+                {{ breadcrumbs.render(breadcrumb_items) }}
             </div>
         {% endif %}
     {% else %}

--- a/cfgov/jinja2/v1/_layouts/content-base-sidebar-first.html
+++ b/cfgov/jinja2/v1/_layouts/content-base-sidebar-first.html
@@ -7,14 +7,14 @@
         {% if breadcrumb_items | length > 0 %}
             <div class="content_wrapper">
                 {%- import 'molecules/breadcrumbs.html' as breadcrumbs with context -%}
-                {{ breadcrumbs.render(breadcrumb_items, 'breadcrumbs__main-first') }}
+                {{ breadcrumbs.render(breadcrumb_items) }}
             </div>
         {% endif %}
     {% else %}
         {% if breadcrumb_items | length > 0 %}
             <div class="wrapper">
                 {%- import 'breadcrumbs.html' as breadcrumbs -%}
-                {{ breadcrumbs.render(breadcrumb_items, 'breadcrumbs__sidebar-first') }}
+                {{ breadcrumbs.render(breadcrumb_items) }}
             </div>
         {% endif %}
     {% endif %}


### PR DESCRIPTION
Removing unused breadcrumb classes. Closes issue #2639.

## Removals

- Removed unused classes from the breadcrumb macros and provided sensible defaults.

## Testing

1. Visit http://localhost:8000/about-us/the-bureau/about-deputy-director/.
2. Inspect the breadcrumb and note  `breadcrumb__sidebar-first` shouldn't be present.  


## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
* [ ] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
