### PR TITLE
Fix for breadcrumb on Newsroom page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 
 ### Fixed
 - Fix filter categories on the `enforcement/actions/` page.
+- Fix for missing breadcrumb on Press Resources `about-us/newsroom/press-resources/` page.
+
 
 ## 4.5.1
 
@@ -75,6 +77,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Fixed handling of invalid date query string parameters for filterable list forms.
 - Added missing `block` class from a block on the about the director page.
 - Fixed issue with erroneously removed bureau stylesheet.
+
 
 ## 4.3.2
 

--- a/cfgov/jinja2/v1/newsroom/_vars-newsroom.html
+++ b/cfgov/jinja2/v1/newsroom/_vars-newsroom.html
@@ -6,3 +6,5 @@
       (path + 'press-resources/', 'press-resources', 'Press Resources')
     ])
 ] %}
+
+{% set breadcrumb_items = [(path, path, 'Newsroom')] %}


### PR DESCRIPTION
Fix for breadcrumb on Newsroom page. Closes issue #2635.

## Additional

- Adds back Breadcrumb which was removed during cleanup way back in the day.

## Testing

- Visit http://web.archive.org/web/20160430162311/http://www.consumerfinance.gov/about-us/newsroom/press-resources/ and verify that there is a breadcrumb.

- Visit http://www.consumerfinance.gov/about-us/newsroom/press-resources/ and verify that there is no breadcrumb. 

-  Visit http://localhost:8000/about-us/newsroom/press-resources/ and verify that its back. 


## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
* [ ] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
