### PR TITLE
Leadership Calendar breadcrumb fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Fixed handling of invalid date query string parameters for filterable list forms.
 - Added missing `block` class from a block on the about the director page.
 - Fixed issue with erroneously removed bureau stylesheet.
+- Fixed issue with breadcrumb on Leadership Calendar page.
 
 ## 4.3.2
 

--- a/cfgov/jinja2/v1/_layouts/content-base-sidebar-first.html
+++ b/cfgov/jinja2/v1/_layouts/content-base-sidebar-first.html
@@ -9,6 +9,13 @@
                 {%- import 'molecules/breadcrumbs.html' as breadcrumbs with context -%}
                 {{ breadcrumbs.render(breadcrumb_items, 'breadcrumbs__main-first') }}
             </div>
+        {# TODO: Remove this ASAP once the-bureau gets migrated to Wagtail #}
+        {% elif page.slug == 'leadership-calendar' %}
+            <div class="content_wrapper">
+                {%- import 'breadcrumbs.html' as breadcrumbs -%}
+                {% set breadcrumb_items = [('/about-us/the-bureau/', 'None', 'The Bureau')] %}
+                {{ breadcrumbs.render(breadcrumb_items, 'breadcrumbs__main-first') }}
+            </div>
         {% endif %}
     {% else %}
         {% if breadcrumb_items | length > 0 %}


### PR DESCRIPTION
Adding breadcrumb to the Leadership Calendar page.  This isn't scalable code but we don't have a way of handling `vars` files from `get_breadcrumbs`. It might make sense to migrate the `vars` breadcrumbs code to Django.  Closes issue #2634.

## Changes

- Modified `cfgov/jinja2/v1/_layouts/content-base-sidebar-first.html` to add hack to get breadcrumbs on the Leadership Calendar page.

## Testing

- Visit http://localhost:8000/about-us/the-bureau/leadership-calendar/ and verify the breadcrumb is present. 

## Screenshots


## Notes

- We will have to do the same thing for the Bureau Structure page.

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
* [ ] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
