### PR TITLE
Update knowledgebase to 2.2.4

### DIFF
--- a/requirements/optional-private.txt
+++ b/requirements/optional-private.txt
@@ -5,6 +5,6 @@
 git+https://private.repo/CFPB/agreement_database.git@v2.2.4#egg=agreement-database
 git+https://private.repo/CFPB/cfgov-selfregistration.git@v1.2#egg=selfregistration
 git+https://private.repo/CFPB/django-college-cost-comparison.git@v1.2.9#egg=comparisontool
-git+https://private.repo/CFPB/knowledgebase.git@v2.2.3#egg=knowledgebase
+git+https://private.repo/CFPB/knowledgebase.git@v2.2.4#egg=knowledgebase
 git+https://private.repo/CFPB/Picard.git@1.5.5#egg=picard
 git+https://private.repo/eregs/ip.git@1.0.3#egg=eregsip

--- a/requirements/optional-private.txt
+++ b/requirements/optional-private.txt
@@ -5,6 +5,6 @@
 git+https://private.repo/CFPB/agreement_database.git@v2.2.4#egg=agreement-database
 git+https://private.repo/CFPB/cfgov-selfregistration.git@v1.2#egg=selfregistration
 git+https://private.repo/CFPB/django-college-cost-comparison.git@v1.2.9#egg=comparisontool
-git+https://private.repo/CFPB/knowledgebase.git@v2.2.2#egg=knowledgebase
+git+https://private.repo/CFPB/knowledgebase.git@v2.2.3#egg=knowledgebase
 git+https://private.repo/CFPB/Picard.git@1.5.5#egg=picard
 git+https://private.repo/eregs/ip.git@1.0.3#egg=eregsip


### PR DESCRIPTION
## Fixes

- A CSS bug on AskCFPB (demonstrated below)
- For questions that exist in the database, attempts to retrieve a non-existent english or spanish answer will result in 404's, not 500's.

Here's an example URL that includes a valid Question ID, but there is no longer an associated english answer: http://www.consumerfinance.gov/askcfpb/145/what-happens-after-i-apply-for-a-loan.html

The CSS fix turns this:
<img width="792" alt="screen shot 2017-01-05 at 11 03 50 am" src="https://cloud.githubusercontent.com/assets/235397/21687394/201cec2a-d337-11e6-9113-eb02e4c60f08.png">

Into this:
<img width="732" alt="screen shot 2017-01-05 at 11 03 43 am" src="https://cloud.githubusercontent.com/assets/235397/21687391/1dc2b4be-d337-11e6-90ae-86d0d8db23c0.png">
