### PR TITLE
Update CHANGELOG for 4.5 (inclusive of 4.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,13 +15,27 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 
 ## Unreleased
 
-## Added
+### Added
+
+
+### Changed
+
+
+### Removed
+
+
+### Fixed
+
+
+## 4.4.0 - 4.5.0
+
+### Added
 - Add RSS subscription button to newsroom posts.
 - New `validate_page_html` command for checking/fixing HTTP image links in legacy pages.
 - New block `HTMLBlock` that allows rendering of arbitrary HTML. Enabled on browse pages.
 - OAH-api upgraded to v0.9.92
 
-## Changed
+### Changed
 - Upgrade to Wagtail 1.7
 - Added redirect for `Leadership Calendar` Wagtail Page.
 - Moved CSS npm dev modules to devDependencies in `package.json`.
@@ -29,7 +43,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Updated `gulp-imagemin` from `3.0.3` to `3.1.1`.
 - Updated `gulp-less` from `3.1.0` to `3.3.0`.
 
-## Removed
+### Removed
 - Removed layout.less enhancements that have been moved to Capital Framework.
 - Wagtail pages from the Django admin
 - Delete option from Wagtail templates


### PR DESCRIPTION
This PR updates the CHANGELOG in master for 4.5.0. Rather than untangling the 4.4/4.5 mess right now, I made the entry inclusive of 4.4.

## Additions

- A new unreleased section

## Changes

- Unreleased to 4.5.0
