### PR TITLE
Bump regulations-site version to 2.1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Updated `gulp-clean-css` from `2.0.6` to `2.3.2`.
 - Updated `gulp-imagemin` from `3.0.3` to `3.1.1`.
 - Updated `gulp-less` from `3.1.0` to `3.3.0`.
+- Updated regulations-site requirement to version `2.1.5`.
 
 ## Removed
 - Removed layout.less enhancements that have been moved to Capital Framework.

--- a/requirements/optional-public.txt
+++ b/requirements/optional-public.txt
@@ -3,5 +3,5 @@ git+https://github.com/cfpb/complaint.git@v1.2.8#egg=complaintdatabase
 git+https://github.com/cfpb/django-hud.git@1.2#egg=django-hud
 git+https://github.com/cfpb/owning-a-home-api.git@v0.9.92#egg=owning-a-home-api
 git+https://github.com/cfpb/regulations-core.git@1.2.3#egg=regcore
-git+https://github.com/cfpb/regulations-site.git@2.1.4#egg=regulations
+git+https://github.com/cfpb/regulations-site.git@2.1.5#egg=regulations
 git+https://github.com/cfpb/retirement.git@0.5.3#egg=retirement


### PR DESCRIPTION
This PR increases the version of the [regulations-site](https://github.com/cfpb/regulations-site) requirement to [the 2.1.5 release](https://github.com/cfpb/regulations-site/releases/tag/2.1.5), to address some [errors that can occur on invalid date redirects](https://github.com/cfpb/regulations-site/pull/821).

## Changes

- `regulations-site` version bumped to 2.1.5.

## Checklist

* [X] Changes are limited to a single goal (no scope creep)
* [X] Code can be automatically merged (no conflicts)
* [X] Passes all existing automated tests
* [X] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
* [X] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
