### PR TITLE
Fix hashed files pattern

### DIFF
--- a/cfgov/v1/apps.py
+++ b/cfgov/v1/apps.py
@@ -19,10 +19,9 @@ class V1AppConfig(AppConfig):
         # yet, url(null) trips up the ManifestStaticFilesStorage, so we
         # monkeypatch the regex so that url(null) is ignored
 
-        storage.HashedFilesMixin.patterns = ((
-            "*.css",
-            (
+        storage.HashedFilesMixin.patterns = (
+            ("*.css", (
                 r"""(url\((?!null)['"]{0,1}\s*(.*?)["']{0,1}\))""",
                 (r"""(@import\s*["']\s*(.*?)["'])""", """@import url("%s")"""),
-            )
-        ))
+            )),
+        )


### PR DESCRIPTION
This PR fixes a bug introduced in the HashedFilesMixin patterns.

## Changes

- Added trailing comma
- Slight reformatting to better imply the expected structure

## Testing

```
>>> from django.core.files.storage import get_storage_class
>>> get_storage_class('django.contrib.staticfiles.storage.ManifestStaticFilesStorage')()
<django.contrib.staticfiles.storage.ManifestStaticFilesStorage object at 0x10798fe50>
```

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
* [x] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
