### PR TITLE
Add a management command for deleting Wagtail pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 ### Added
 
 - New block 'ChartBlock' to support rendering of charts for Consumer Credit Trends
+- Django management command to delete Wagtail pages by their slug or ID
 
 ### Changed
 

--- a/cfgov/v1/management/commands/delete_page.py
+++ b/cfgov/v1/management/commands/delete_page.py
@@ -12,13 +12,29 @@ class Command(BaseCommand):
             nargs='+',
             help='The slug for the page you wish to delete'
         )
+        parser.add_argument(
+            '--id',
+            nargs='+',
+            help='The ID for the page you wish to delete'
+        )
 
     def handle(self, *args, **options):
-        slug = options['slug'][0]
+        page_to_delete = None
+        if options['slug']:
+            slug = options['slug'][0]
+            try:
+                page_to_delete = CFGOVPage.objects.get(slug=slug)
+            except Exception as e:
+                self.stderr.write(str(e))
+                raise CommandError('Slug `{}` did not work'.format(slug))
+        elif options['id']:
+            page_id = options['id'][0]
+            page_to_delete = CFGOVPage.objects.get(id=page_id)
+        else:
+            raise CommandError('Must supply a --slug or an --id')
         try:
-            page_to_delete = CFGOVPage.objects.get(slug=slug)
             page_to_delete.unpublish()
             page_to_delete.delete()
         except Exception as e:
             self.stderr.write(str(e))
-            raise CommandError('failed to delete page {}'.format(slug))
+            raise CommandError('Failed to delete page {}'.format(page_to_delete))

--- a/cfgov/v1/management/commands/delete_page.py
+++ b/cfgov/v1/management/commands/delete_page.py
@@ -1,0 +1,24 @@
+from django.core.management.base import BaseCommand, CommandError
+
+from v1.models import CFGOVPage
+
+
+class Command(BaseCommand):
+    help = 'Deletes a page by its slug name'
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--slug',
+            nargs='+',
+            help='The slug for the page you wish to delete'
+        )
+
+    def handle(self, *args, **options):
+        slug = options['slug'][0]
+        try:
+            page_to_delete = CFGOVPage.objects.get(slug=slug)
+            page_to_delete.unpublish()
+            page_to_delete.delete()
+        except Exception as e:
+            self.stderr.write(str(e))
+            raise CommandError('failed to delete page {}'.format(slug))

--- a/cfgov/v1/signals.py
+++ b/cfgov/v1/signals.py
@@ -55,13 +55,13 @@ def update_all_revisions(instance, attr):
 def unshare_all_revisions(sender, **kwargs):
     from v1.wagtail_hooks import flush_akamai
     update_all_revisions(kwargs['instance'], 'shared')
-    flush_akamai(page=kwargs['instance'])
+    flush_akamai()
 
 
 def unpublish_all_revisions(sender, **kwargs):
     from v1.wagtail_hooks import flush_akamai
     update_all_revisions(kwargs['instance'], 'live')
-    flush_akamai(page=kwargs['instance'])
+    flush_akamai()
 
 
 def configure_page_and_revision(sender, **kwargs):
@@ -69,7 +69,7 @@ def configure_page_and_revision(sender, **kwargs):
     share(page=kwargs['instance'], is_sharing=False, is_live=True)
     configure_page_revision(
         page=kwargs['instance'], is_sharing=False, is_live=True)
-    flush_akamai(page=kwargs['instance'])
+    flush_akamai()
 
 
 page_unshared.connect(unshare_all_revisions)

--- a/cfgov/v1/tests/test_wagtail_hooks.py
+++ b/cfgov/v1/tests/test_wagtail_hooks.py
@@ -283,19 +283,19 @@ class TestFlushAkamai(TestCase):
 
     def test_should_not_flush_if_not_enabled(self):
         with self.settings(ENABLE_AKAMAI_CACHE_PURGE=None):
-            assert not should_flush(self.page)
+            assert not should_flush()
 
     def test_should_flush_if_enabled(self):
         with self.settings(ENABLE_AKAMAI_CACHE_PURGE=True):
-            assert should_flush(self.page)
+            assert should_flush()
 
     def test_should_flush_gets_called_when_trying_to_flush(self):
         with mock.patch(
             'v1.wagtail_hooks.should_flush',
             return_value=False
         ) as should_flush:
-            self.assertFalse(flush_akamai(self.page))
-            should_flush.assert_called_once_with(self.page)
+            self.assertFalse(flush_akamai())
+            should_flush.assert_called_once_with()
 
 
 class TestGetAkamaiCredentials(TestCase):

--- a/cfgov/v1/wagtail_hooks.py
+++ b/cfgov/v1/wagtail_hooks.py
@@ -38,7 +38,7 @@ def share_the_page(request, page):
     share(page, is_sharing, is_live)
     configure_page_revision(page, is_sharing, is_live)
     if is_live:
-        flush_akamai(page)
+        flush_akamai()
 
 
 @hooks.register('after_delete_page')
@@ -129,13 +129,13 @@ def get_akamai_credentials():
     return object_id, (user, password)
 
 
-def should_flush(page):
+def should_flush():
     """Only initiate an Akamai flush if it is enabled in settings."""
     return settings.ENABLE_AKAMAI_CACHE_PURGE
 
 
-def flush_akamai(page):
-    if should_flush(page):
+def flush_akamai():
+    if should_flush():
         object_id, auth = get_akamai_credentials()
         headers = {'content-type': 'application/json'}
         payload = {


### PR DESCRIPTION
## Overview
- GHE 506
- Unpublishes & deletes a page given its slug name

## Usage
- `python cfgov/manage.py delete_page --slug page-slug` 

## Testing
- Grab a page's slug locally and type in the above, replacing `page-slug` as appropriate 