### PR TITLE
Fix for filter categories on the Enforcement actions page. 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 
 
 ### Fixed
-
+- Fix filter categories on the `enforcement/actions/` page.
 
 ## 4.5.1
 

--- a/cfgov/v1/migrations/0044_changing_case_on_enforcement_action_category.py
+++ b/cfgov/v1/migrations/0044_changing_case_on_enforcement_action_category.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('v1', '0043_create_chart_block'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='cfgovpagecategory',
+            name='name',
+            field=models.CharField(max_length=255, choices=[(b'Amicus Brief', ((b'us-supreme-court', b'U.S. Supreme Court'), (b'fed-circuit-court', b'Federal Circuit Court'), (b'fed-district-court', b'Federal District Court'), (b'state-court', b'State Court'))), (b'Blog', ((b'at-the-cfpb', b'At the CFPB'), (b'policy_compliance', b'Policy & Compliance'), (b'data-research-reports', b'Data, research & reports'), (b'info-for-consumers', b'Info for consumers'))), (b'Enforcement Action', ((b'fed-district-case', b'Federal District Court Case'), (b'admin-filing', b'Administrative Filing'))), (b'Final Rule', ((b'interim-final-rule', b'Interim Final Rule'), (b'final-rule', b'Final Rule'))), (b'FOIA Frequently Requested Record', ((b'report', b'Report'), (b'log', b'Log'), (b'record', b'Record'))), (b'Implementation Resource', ((b'compliance-aid', b'Compliance aid'), (b'official-guidance', b'Official guidance'))), (b'Newsroom', ((b'op-ed', b'Op-Ed'), (b'press-release', b'Press Release'), (b'speech', b'Speech'), (b'testimony', b'Testimony'))), (b'Notice and Opportunity for Comment', ((b'notice-proposed-rule', b'Advanced Notice of Proposed Rulemaking'), (b'proposed-rule', b'Proposed Rule'), (b'interim-final-rule-2', b'Interim Final Rule'), (b'request-comment-info', b'Request for Comment or Information'), (b'proposed-policy', b'Proposed Policy'), (b'intent-preempt-determ', b'Intent to make Preemption Determination'), (b'info-collect-activity', b'Information Collection Activities'), (b'notice-privacy-act', b'Notice related to Privacy Act'))), (b'Research Report', ((b'consumer-complaint', b'Consumer Complaint'), (b'super-highlight', b'Supervisory Highlights'), (b'data-point', b'Data Point'), (b'industry-markets', b'Industry and markets'), (b'consumer-edu-empower', b'Consumer education and empowerment'), (b'to-congress', b'To Congress'))), (b'Rule under development', ((b'notice-proposed-rule-2', b'Advanced Notice of Proposed Rulemaking'), (b'proposed-rule-2', b'Proposed Rule'))), (b'Story', ((b'auto-loans', b'Auto loans'), (b'credit-cards', b'Credit cards'), (b'credit-reporting', b'Credit reporting'), (b'debt-collection', b'Debt collection'), (b'mortgages', b'Mortgages'), (b'student-loans', b'Student loans')))]),
+        ),
+    ]

--- a/cfgov/v1/util/ref.py
+++ b/cfgov/v1/util/ref.py
@@ -62,7 +62,7 @@ categories = [
         ('data-research-reports', 'Data, research & reports'),
         ('info-for-consumers', 'Info for consumers'),
     )),
-    ('Enforcement action', (
+    ('Enforcement Action', (
         ('fed-district-case', 'Federal District Court Case'),
         ('admin-filing', 'Administrative Filing'),
     )),


### PR DESCRIPTION
Fix for filter categories on the Enforcement Actions page. 


## Changes

- Modified `cfgov/v1/util/ref.py` to fix case issue.

## Testing

- Visit `http://localhost:8000/policy-compliance/enforcement/actions/` and expand the filter.
- Verify that the categories exist.

## Screenshots

<img width="876" alt="screen shot 2017-01-10 at 11 02 51 pm" src="https://cloud.githubusercontent.com/assets/1696212/21835168/f2d6bccc-d788-11e6-81b1-abf9e0fd4c47.png">


## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
* [ ] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
