### PR TITLE
Disable page deletion via POST request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Updated custom Wagtail admin templates to 1.7 version.
 
 ### Removed
+- Can no longer delete via `/delete` in Wagtail
 
 
 ### Fixed

--- a/cfgov/v1/wagtail_hooks.py
+++ b/cfgov/v1/wagtail_hooks.py
@@ -3,6 +3,7 @@ import logging
 import os
 import requests
 
+from django.core.exceptions import PermissionDenied
 from django.conf import settings
 from django.contrib.auth.models import Permission
 from django.core.urlresolvers import reverse
@@ -22,6 +23,11 @@ from v1.util import util
 
 
 logger = logging.getLogger(__name__)
+
+
+@hooks.register('before_delete_page')
+def raise_delete_error(request, page):
+    raise PermissionDenied('Deletion via POST is disabled')
 
 
 @hooks.register('after_create_page')


### PR DESCRIPTION
## Overview
- GHE 505
- Disables page deletion via `/delete` POST endpoint in Wagtail admin 
- Can still delete via command line as introduced in this PR -- https://github.com/cfpb/cfgov-refresh/pull/2663

## Screenshots
- What you see when you try to delete a page 
<img width="1252" alt="screen shot 2017-01-12 at 4 41 17 pm" src="https://cloud.githubusercontent.com/assets/354591/21914131/fa7719f0-d8e5-11e6-9b78-87941efe9317.png">

## Testing
- Go to a page in the Wagtail admin, and add `/delete` to the path
- Confirm you see the exception
- Go back to the page and confirm it's still there
