### PR TITLE
Modify richtext fields to have a max-width of 1000px

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 ## Unreleased
 
 ### Added
+- Keep richtext fields within the desktop viewport at all times
 
 ### Changed
 

--- a/cfgov/templates/wagtailadmin/css/richtext.css
+++ b/cfgov/templates/wagtailadmin/css/richtext.css
@@ -1,3 +1,7 @@
+/*
+ * Keep richtext fields within the desktop viewport, even if long or wide
+ * blocks of information are entered in them.
+ */
 .richtext {
     max-width: 1000px;
 }

--- a/cfgov/templates/wagtailadmin/css/richtext.css
+++ b/cfgov/templates/wagtailadmin/css/richtext.css
@@ -1,0 +1,3 @@
+.richtext {
+  max-width: 1000px
+}

--- a/cfgov/templates/wagtailadmin/css/richtext.css
+++ b/cfgov/templates/wagtailadmin/css/richtext.css
@@ -1,3 +1,3 @@
 .richtext {
-  max-width: 1000px
+    max-width: 1000px;
 }

--- a/cfgov/v1/wagtail_hooks.py
+++ b/cfgov/v1/wagtail_hooks.py
@@ -102,6 +102,7 @@ def editor_js():
 def editor_css():
     css_files = [
         'css/table-block.css',
+        'css/richtext.css',
         'css/bureau-structure.css'
     ]
     css_includes = format_html_join(


### PR DESCRIPTION
When entering large blocks of information into Full Width Text Blocks, the fields become massively wide. Neither IE nor Chrome provides a horizontal scroll bar to help in navigating the field. This becomes problematic if you need to insert a new field under one that you just created and populated, as the (+) button to add a new field is far off-screen. In order to see that add button, you would have to use the keyboard to move character by character until the button was visible.

This PR places a maximum width of 1000 pixels on richtext fields.

## Additions

- CSS file for richtext fields that sets a maximum width

## Testing

- Before loading this branch, log into the Wagtail admin as it exists now on `master` and open the page with the ID of 4529 for editing. In the "Lending levels" area, observe how the buttons to add new fields around the existing Full Width Text Block fields are far off screen.
- Load this branch, and view the same page. Observe that the buttons are now within the desktop viewport.

## Notes

Much thanks to @Scotchester for his prompting to dig into this when I wasn't sure that I could, and for his assistance in testing it!

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
* [x] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
