### PR TITLE
Hotfix for key access on datatable when table is empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 ### Removed
 
 ### Fixed
+- Fixed issue with key access on datatable when table is empty.
 
 
 ## 4.6.0

--- a/cfgov/jinja2/v1/_includes/organisms/table.html
+++ b/cfgov/jinja2/v1/_includes/organisms/table.html
@@ -27,7 +27,8 @@
 
    ========================================================================== #}
 
-{% if value.has_data %}
+
+{% if value.has_data is not defined or value.has_data %}
 {% macro _render_cell(cell) %}
     {{ (cell or '&nbsp;') | safe | trim | linebreaksbr }}
 {% endmacro %}

--- a/cfgov/v1/atomic_elements/organisms.py
+++ b/cfgov/v1/atomic_elements/organisms.py
@@ -300,9 +300,11 @@ class AtomicTableBlock(TableBlock):
 
     def get_has_data(self, value):
         has_data = False
-        if value and value['data']:
-            first_row_index = 1 if value['first_row_is_table_header'] else 0
-            first_col_index = 1 if value['first_col_is_header'] else 0
+        if value and 'data' in value:
+            first_row_index = 1 if value.get('first_row_is_table_header',
+                                             None) else 0
+            first_col_index = 1 if value.get('first_col_is_header',
+                                             None) else 0
 
             for row in value['data'][first_row_index:]:
                 for cell in row[first_col_index:]:

--- a/cfgov/v1/tests/atomic_elements/organisms/test_organisms.py
+++ b/cfgov/v1/tests/atomic_elements/organisms/test_organisms.py
@@ -187,7 +187,6 @@ class OrganismsTestCase(TestCase):
 
     def test_tableblock_missing_attributes(self):
         """Table correctly displays when value dictionary is missing attributes"""
-        table_context = atomic.table_block.copy
         value = atomic.table_block.get( 'value', None )
         del value['first_row_is_table_header']
         del value['first_col_is_header']

--- a/cfgov/v1/tests/atomic_elements/organisms/test_organisms.py
+++ b/cfgov/v1/tests/atomic_elements/organisms/test_organisms.py
@@ -187,7 +187,8 @@ class OrganismsTestCase(TestCase):
 
     def test_tableblock_missing_attributes(self):
         """Table correctly displays when value dictionary is missing attributes"""
-        value = atomic.table_block.get( 'value', None )
+        table_context = dict(atomic.table_block)
+        value = table_context.get('value')
         del value['first_row_is_table_header']
         del value['first_col_is_header']
         table = TableBlock()
@@ -197,8 +198,8 @@ class OrganismsTestCase(TestCase):
         self.assertRegexpMatches(html, 'Row 1-1')
         self.assertRegexpMatches(html, 'Row 2-1')
 
-        self.assertEqual(value.get('first_row_is_table_header', None) , None)
-        self.assertEqual(value.get('first_col_is_header', None), None)
+        self.assertIsNone(value.get('first_row_is_table_header'), None)
+        self.assertIsNone(value.get('first_col_is_header'), None)
 
         with self.assertRaises(KeyError):
             value['first_row_is_table_header']

--- a/cfgov/v1/tests/atomic_elements/organisms/test_organisms.py
+++ b/cfgov/v1/tests/atomic_elements/organisms/test_organisms.py
@@ -2,6 +2,7 @@ from django.test import Client, TestCase
 from wagtail.wagtailcore.blocks import StreamValue
 
 from scripts import _atomic_helpers as atomic
+from v1.atomic_elements.organisms import TableBlock
 from v1.models.browse_page import BrowsePage
 from v1.models.landing_page import LandingPage
 from v1.models.learn_page import LearnPage
@@ -183,7 +184,28 @@ class OrganismsTestCase(TestCase):
         self.assertContains(response, 'Header One')
         self.assertContains(response, 'Row 1-1')
         self.assertContains(response, 'Row 2-1')
-        
+
+    def test_tableblock_missing_attributes(self):
+        """Table correctly displays when value dictionary is missing attributes"""
+        table_context = atomic.table_block.copy
+        value = atomic.table_block.get( 'value', None )
+        del value['first_row_is_table_header']
+        del value['first_col_is_header']
+        table = TableBlock()
+        html = str(table.render(table.to_python(value)))
+
+        self.assertRegexpMatches(html, 'Header One')
+        self.assertRegexpMatches(html, 'Row 1-1')
+        self.assertRegexpMatches(html, 'Row 2-1')
+
+        self.assertEqual(value.get('first_row_is_table_header', None) , None)
+        self.assertEqual(value.get('first_col_is_header', None), None)
+
+        with self.assertRaises(KeyError):
+            value['first_row_is_table_header']
+        with self.assertRaises(KeyError):
+            value['first_col_is_header']
+
     def test_expandable_group(self):
         """Expandable group correctly displays on a Browse Page"""
         browse_page = BrowsePage(


### PR DESCRIPTION
Hotfix for key access on datatable when table is empty. Introduced in PR #2662.


## Changes

- Modified `cfgov/jinja2/v1/_includes/organisms/table.html` to fix issue rendering tables when previewing. The  `to_python` method is not called when previewing, so the `has_data` property doesn't exist.

- Modified `cfgov/v1/atomic_elements/organisms.py` to add safer method for accessing dictionary keys. 

## Testing

- Visit `http://beta.consumerfinance.gov/policy-compliance/rulemaking/small-business-review-panels/` and observe the error.
- Visit `http://localhost:8000/policy-compliance/rulemaking/small-business-review-panels/` and observe the table renders as expected.


## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
* [ ] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
