### PR TITLE
we don't use eccu anymore

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -36,7 +36,7 @@ pytz
 requests==2.7.0
 requests_toolbelt==0.6.0
 simplejson==3.8.2
-six==1.9.0
+six==1.10.0
 suds==0.4
 tinys3==0.1.11
 unipath>=1.1,<=2.0

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -21,7 +21,6 @@ django-treebeard==3.0
 elasticsearch==1.6.0
 feedparser==5.2.1
 geocoder==1.12.0
-git+https://github.com/cfpb/publish_eccu.git#egg=publish_eccu
 git+https://github.com/rosskarchner/govdelivery.git#egg=govdelivery
 html5lib==0.9999999
 icalendar==3.9.0


### PR DESCRIPTION
## Removals

- remove publish_eccu from requirements

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
* [ ] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
