### PR TITLE
Correctly show 'live + draft' status for unshared pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 ### Removed
 
 ### Fixed
+- Correctly show "live + draft" page status for unshared pages.
 
 
 ## 4.6.2

--- a/cfgov/v1/models/base.py
+++ b/cfgov/v1/models/base.py
@@ -310,14 +310,15 @@ class CFGOVPage(Page):
 
     @property
     def status_string(self):
-        if self.expired:
+        page = CFGOVPage.objects.get(id=self.id)
+        if page.expired:
             return _("expired")
-        elif self.approved_schedule:
+        elif page.approved_schedule:
             return _("scheduled")
-        elif self.live and self.shared:
-            if self.has_unpublished_changes:
-                if self.has_unshared_changes:
-                    for revision in self.revisions.order_by(
+        elif page.live and page.shared:
+            if page.has_unpublished_changes:
+                if page.has_unshared_changes:
+                    for revision in page.revisions.order_by(
                             '-created_at', '-id'):
                         content = json.loads(revision.content_json)
                         if content['shared']:
@@ -329,13 +330,13 @@ class CFGOVPage(Page):
                     return _("live + shared")
             else:
                 return _("live")
-        elif self.live:
-            if self.has_unpublished_changes:
+        elif page.live:
+            if page.has_unpublished_changes:
                 return _('live + draft')
             else:
                 return _('live')
-        elif self.shared:
-            if self.has_unshared_changes:
+        elif page.shared:
+            if page.has_unshared_changes:
                 return _("shared + draft")
             else:
                 return _("shared")

--- a/cfgov/v1/models/base.py
+++ b/cfgov/v1/models/base.py
@@ -330,7 +330,10 @@ class CFGOVPage(Page):
             else:
                 return _("live")
         elif self.live:
-            return _("live")
+            if self.has_unpublished_changes:
+                return _('live + draft')
+            else:
+                return _('live')
         elif self.shared:
             if self.has_unshared_changes:
                 return _("shared + draft")

--- a/cfgov/v1/tests/models/test_base.py
+++ b/cfgov/v1/tests/models/test_base.py
@@ -302,3 +302,11 @@ class CFGOVPageStatusStringTest(TestCase):
                 has_unpublished_changes=True
             )
             self.assertEqual(page.status_string, 'live + shared')
+
+        def test_live_and_draft(self):
+            page = CFGOVPage(
+                live=True,
+                shared=False,
+                has_unpublished_changes=True
+            )
+            self.assertEqual(page.status_string, 'live + draft')

--- a/cfgov/v1/tests/models/test_base.py
+++ b/cfgov/v1/tests/models/test_base.py
@@ -280,33 +280,43 @@ class TestFeedbackModel(TestCase):
 
 class CFGOVPageStatusStringTest(TestCase):
         def test_expired(self):
-            page = CFGOVPage(expired=True)
+            page = CFGOVPage(expired=True, slug='foo', title='foo')
+            save_new_page(page)
             self.assertEqual(page.status_string, 'expired')
 
         def test_live(self):
-            page = CFGOVPage(live=True)
+            page = CFGOVPage(live=True, slug='foo', title='foo')
+            publish_page(page)
             self.assertEqual(page.status_string, 'live')
 
         def test_draft(self):
-            page = CFGOVPage(live=False, shared=False)
+            page = CFGOVPage(live=False, shared=False, slug='foo', title='foo')
+            save_new_page(page)
             self.assertEqual(page.status_string, 'draft')
 
         def test_shared(self):
-            page = CFGOVPage(live=False, shared=True)
+            page = CFGOVPage(live=False, shared=True, slug='foo', title='foo')
+            save_new_page(page)
             self.assertEqual(page.status_string, 'shared')
 
         def test_live_and_shared(self):
             page = CFGOVPage(
                 live=True,
                 shared=True,
-                has_unpublished_changes=True
+                has_unpublished_changes=True,
+                slug='foo',
+                title='foo'
             )
+            save_new_page(page)
             self.assertEqual(page.status_string, 'live + shared')
 
         def test_live_and_draft(self):
             page = CFGOVPage(
                 live=True,
                 shared=False,
-                has_unpublished_changes=True
+                has_unpublished_changes=True,
+                slug='foo',
+                title='foo'
             )
+            save_new_page(page)
             self.assertEqual(page.status_string, 'live + draft')


### PR DESCRIPTION
If a page has been published but not shared, its status in the Wagtail browser should say "live + draft".

## Changes

- Change to status string logic to properly support live + draft (but not shared) state.

## Testing

- Create a new page in the Wagtail editor and publish it. Then manually go back into the editor view and unshare it. You should see it in the browser with 'live + draft' status.

## Screenshots

![image](https://cloud.githubusercontent.com/assets/654645/22305779/ce0b7ad0-e30a-11e6-8643-b92ce92aa288.png)

## Checklist

* [X] Changes are limited to a single goal (no scope creep)
* [X] Code can be automatically merged (no conflicts)
* [X] Passes all existing automated tests
* [X] New functions include new tests
* [X] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
* [X] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
