### PR TITLE
Update owning-a-home-api dependency to v0.9.93

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 - Keep richtext fields within the desktop viewport at all times
 
 ### Changed
+- Updated owning-a-home-api requirement to v0.9.93.
 
 ### Removed
 - `header` and `body` fields from `MainContactInfo`

--- a/requirements/optional-public.txt
+++ b/requirements/optional-public.txt
@@ -1,7 +1,7 @@
 git+https://github.com/cfpb/college-costs.git@2.3.2#egg=college-costs
 git+https://github.com/cfpb/complaint.git@v1.2.8#egg=complaintdatabase
 git+https://github.com/cfpb/django-hud.git@1.2#egg=django-hud
-git+https://github.com/cfpb/owning-a-home-api.git@v0.9.92#egg=owning-a-home-api
+git+https://github.com/cfpb/owning-a-home-api.git@v0.9.93#egg=owning-a-home-api
 git+https://github.com/cfpb/regulations-core.git@1.2.3#egg=regcore
 git+https://github.com/cfpb/regulations-site.git@2.1.5#egg=regulations
 git+https://github.com/cfpb/retirement.git@0.5.3#egg=retirement


### PR DESCRIPTION
Bump version of optional [owning-a-home-api](https://github.com/cfpb/owning-a-home-api) requirement to [v0.9.93](https://github.com/cfpb/owning-a-home-api/releases/tag/v0.9.93).

## Changes

- Increase owning-a-home-api requirement to v0.9.93.

## Checklist

* [X] Changes are limited to a single goal (no scope creep)
* [X] Code can be automatically merged (no conflicts)
* [X] Passes all existing automated tests
* [X] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
* [X] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
