### PR TITLE
4.6.2: Update owning-a-home-api to v0.9.93

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 ### Added
 
 ### Changed
+- Updated owning-a-home-api requirement to v0.9.93.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,11 +18,16 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 ### Added
 
 ### Changed
-- Updated owning-a-home-api requirement to v0.9.93.
 
 ### Removed
 
 ### Fixed
+
+
+## 4.6.2
+
+### Changed
+- Updated owning-a-home-api requirement to v0.9.93.
 
 
 ## 4.6.1 

--- a/requirements/optional-public.txt
+++ b/requirements/optional-public.txt
@@ -1,7 +1,7 @@
 git+https://github.com/cfpb/college-costs.git@2.3.2#egg=college-costs
 git+https://github.com/cfpb/complaint.git@v1.2.8#egg=complaintdatabase
 git+https://github.com/cfpb/django-hud.git@1.2#egg=django-hud
-git+https://github.com/cfpb/owning-a-home-api.git@v0.9.92#egg=owning-a-home-api
+git+https://github.com/cfpb/owning-a-home-api.git@v0.9.93#egg=owning-a-home-api
 git+https://github.com/cfpb/regulations-core.git@1.2.3#egg=regcore
 git+https://github.com/cfpb/regulations-site.git@2.1.5#egg=regulations
 git+https://github.com/cfpb/retirement.git@0.5.3#egg=retirement


### PR DESCRIPTION
4.6.2 hotfix: update owning-a-home-api to v0.9.93. See #2701.