### PR TITLE
Use the latest version of Node v6 in Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,8 @@ install:
   - pip install -r requirements/travis.txt
   - export CXX=clang++
   - curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.31.0/install.sh | bash
-  - nvm install 5.5.0
-  - nvm use 5.5.0
+  - nvm install 6
+  - nvm use 6
   - npm install -g gulp
   - chmod +x ./frontend.sh
   - ./frontend.sh test
@@ -31,4 +31,3 @@ script:
 
 notifications:
   webhooks: https://coveralls.io/webhook?repo_token=COVERALLS_REPO_TOKEN
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 
 ### Changed
 - Updated owning-a-home-api requirement to v0.9.93.
+- Bumped the version of Node used by Travis to v6
 
 ### Removed
 - `header` and `body` fields from `MainContactInfo`
@@ -28,7 +29,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 ### Fixed
 
 
-## 4.6.1 
+## 4.6.1
 
 ### Changed
 -  Bumped college-costs to 2.3.2
@@ -36,7 +37,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 
 ### Fixed
 - Fixed issue with key access on datatable when table is empty.
-- `sidebar-contact-info.html` to display heading from snippet 
+- `sidebar-contact-info.html` to display heading from snippet
 
 ## 4.6.0
 


### PR DESCRIPTION
This updates the version of Node used in Travis builds to v6. Odd numbered versions of Node are "progress" versions and do not have a long-term support plan, while even numbered versions are considered stable.

#### More info about Node versioning

- https://github.com/nodejs/LTS
- https://nodejs.org/en/blog/community/v5-to-v7/