### PR TITLE
Don't always delete $NODE_DIR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 
 ### Changed
 - Updated owning-a-home-api requirement to v0.9.93.
+- Checksum package.json to avoid reinstalling dependencies that haven't changed
 
 ### Removed
 - `header` and `body` fields from `MainContactInfo`

--- a/frontend.sh
+++ b/frontend.sh
@@ -20,7 +20,7 @@ init() {
   echo "npm components directory: $NODE_DIR"
 }
 
-# Clean project dependencies if needed
+# Clean project dependencies if needed.
 clean() {
   # If the node directory exists, $NODE_DIR/CHECKSUM exists, and
   # the contents DO NOT match the checksum of package.json, clear

--- a/frontend.sh
+++ b/frontend.sh
@@ -109,13 +109,11 @@ is_installed() {
 }
 
 # Execute requested (or all) functions.
-if [ "$1" == "init" ] || [ "$1" == "build" ]; then
-  if [ "$1" == "init" ]; then
-    init ""
-    clean_and_install
-  else
-    build
-  fi
+if [ "$1" == "init" ]; then
+  init ""
+  clean_and_install
+elif [ "$1" == "build" ]; then
+  build
 else
   init "$1"
   clean_and_install

--- a/frontend.sh
+++ b/frontend.sh
@@ -15,6 +15,7 @@ init() {
   source cli-flag.sh 'Front end' $1
 
   NODE_DIR=node_modules
+  DEP_CHECKSUM=`cat npm-shrinkwrap.json package.json | shasum -a 256`
 
   echo "npm components directory: $NODE_DIR"
 }
@@ -26,7 +27,10 @@ clean() {
   # $NODE_DIR so we know we're working with a clean slate of the
   # dependencies listed in package.json.
   if [ -d $NODE_DIR ]; then
-    if [ ! -f $NODE_DIR/CHECKSUM ] || [ "`shasum package.json`" != "`cat $NODE_DIR/CHECKSUM`" ]; then
+    echo $DEP_CHECKSUM
+    echo `cat $NODE_DIR/CHECKSUM`
+    if [ ! -f $NODE_DIR/CHECKSUM ] || 
+       [ "$DEP_CHECKSUM" != "`cat $NODE_DIR/CHECKSUM`" ]; then
       echo 'Removing project dependency directories…'
       rm -rf $NODE_DIR
       echo 'Project dependencies have been removed.'
@@ -73,7 +77,7 @@ install() {
 
   # Add a checksum file
   if  [ ! -f $NODE_DIR/CHECKSUM ]; then
-    shasum package.json > $NODE_DIR/CHECKSUM
+    echo -n $DEP_CHECKSUM > $NODE_DIR/CHECKSUM
   fi
 }
 

--- a/frontend.sh
+++ b/frontend.sh
@@ -31,18 +31,18 @@ clean() {
     echo `cat $NODE_DIR/CHECKSUM`
     if [ ! -f $NODE_DIR/CHECKSUM ] || 
        [ "$DEP_CHECKSUM" != "`cat $NODE_DIR/CHECKSUM`" ]; then
-      echo 'Removing project dependency directories…'
+      echo 'Removing project dependency directories...'
       rm -rf $NODE_DIR
       echo 'Project dependencies have been removed.'
     else
-      echo 'Project dependencies checksum matches package.json…'
+      echo 'Project dependencies checksum matches package.json...'
     fi
   fi
 }
 
 # Install project dependencies.
 install() {
-  echo 'Installing front-end dependencies…'
+  echo 'Installing front-end dependencies...'
 
   if [ "$cli_flag" = "development" ] ||
      [ "$cli_flag" = "test" ]; then
@@ -56,10 +56,10 @@ install() {
     # Copy globally-installed packages.
     # Protractor = JavaScript acceptance testing framework.
     if [ $is_installed_protractor = 0 ]; then
-      echo 'Installing Protractor dependencies locally…'
+      echo 'Installing Protractor dependencies locally...'
       ./$NODE_DIR/protractor/bin/webdriver-manager update
     else
-      echo 'Global Protractor installed. Copying global install locally…'
+      echo 'Global Protractor installed. Copying global install locally...'
       protractor_symlink=$(command -v protractor)
       protractor_binary=$(readlink $protractor_symlink)
       protractor_full_path=$(dirname $protractor_symlink)/$(dirname $protractor_binary)/../../protractor
@@ -83,7 +83,7 @@ install() {
 
 # Run tasks to build the project for distribution.
 build() {
-  echo 'Building project…'
+  echo 'Building project...'
   gulp clean
   gulp build
 

--- a/frontend.sh
+++ b/frontend.sh
@@ -31,18 +31,18 @@ clean() {
     echo `cat $NODE_DIR/CHECKSUM`
     if [ ! -f $NODE_DIR/CHECKSUM ] || 
        [ "$DEP_CHECKSUM" != "`cat $NODE_DIR/CHECKSUM`" ]; then
-      echo 'Removing project dependency directories...'
+      echo 'Removing project dependency directories…'
       rm -rf $NODE_DIR
       echo 'Project dependencies have been removed.'
     else
-      echo 'Project dependencies checksum matches package.json...'
+      echo 'Project dependencies checksum matches package.json…'
     fi
   fi
 }
 
 # Install project dependencies.
 install() {
-  echo 'Installing front-end dependencies...'
+  echo 'Installing front-end dependencies…'
 
   if [ "$cli_flag" = "development" ] ||
      [ "$cli_flag" = "test" ]; then
@@ -56,10 +56,10 @@ install() {
     # Copy globally-installed packages.
     # Protractor = JavaScript acceptance testing framework.
     if [ $is_installed_protractor = 0 ]; then
-      echo 'Installing Protractor dependencies locally...'
+      echo 'Installing Protractor dependencies locally…'
       ./$NODE_DIR/protractor/bin/webdriver-manager update
     else
-      echo 'Global Protractor installed. Copying global install locally...'
+      echo 'Global Protractor installed. Copying global install locally…'
       protractor_symlink=$(command -v protractor)
       protractor_binary=$(readlink $protractor_symlink)
       protractor_full_path=$(dirname $protractor_symlink)/$(dirname $protractor_binary)/../../protractor
@@ -83,7 +83,7 @@ install() {
 
 # Run tasks to build the project for distribution.
 build() {
-  echo 'Building project...'
+  echo 'Building project…'
   gulp clean
   gulp build
 


### PR DESCRIPTION
This PR addresses #2654 and implements @rosskarchner's suggestion in GHE#563 to checksum `package.json`, store the checksum in `$NODE_DIR/CHECKSUM`, and then only delete $NODE_DIR if the checksums don't match. This should improve the efficiency of our `frontend.sh` script.

Some quick and dirty metrics on my local machine:

Full install of all dependencies (checksum doesn't exist or doesn't match):

```
./frontend.sh  110.17s user 30.05s system 66% cpu 3:29.80 total
```

When no dependencies have changed (checksum exists and matches):

```
./frontend.sh  55.34s user 2.62s system 155% cpu 37.200 total
```

So, this cuts down the time spent installing frontend dependencies by half unless `package.json` has changed.

## Changes

- Checksum package.json to avoid reinstalling dependencies that haven't changed

## Testing

- Run `frontend.sh` once to generate the checksum file, then run it again and observe the message:

  `Project dependencies checksum matches package.json…`
  
  And that node dependencies aren't reinstalled.

## Notes

I want to get this in front of Travis to make sure I'm not making assumptions about the availability of `shasum`. 

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
* [ ] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
