### PR TITLE
Removing custom grid variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 
 ### Changed
 - Add image inset.
+- Modifield `@grid_wrapper-width` to match Capital Framework.
 
 ### Removed
 

--- a/cfgov/legacy/static/nemo/_/c/v1-nonresponsive-footer.css
+++ b/cfgov/legacy/static/nemo/_/c/v1-nonresponsive-footer.css
@@ -25,7 +25,7 @@
 .wrapper__match-content, .content_wrapper__match-content {
     padding-left: 30px;
     padding-right: 30px;
-    max-width: 1170px;
+    max-width: 1200px;
 }
 
 .o-footer_pre {

--- a/cfgov/unprocessed/css/cf-theme-overrides.less
+++ b/cfgov/unprocessed/css/cf-theme-overrides.less
@@ -144,7 +144,10 @@
    ========================================================================== */
 
 @grid_box-sizing-polyfill-path: '../js';
-
+-@grid_wrapper-width:            1230px;
+-@grid_gutter-width:             30px;
+-@grid_total-columns:            12;
+-@grid_debug:                    false;
 
 /* cf-icons
    ========================================================================== */

--- a/cfgov/unprocessed/css/cf-theme-overrides.less
+++ b/cfgov/unprocessed/css/cf-theme-overrides.less
@@ -144,10 +144,10 @@
    ========================================================================== */
 
 @grid_box-sizing-polyfill-path: '../js';
--@grid_wrapper-width:            1230px;
--@grid_gutter-width:             30px;
--@grid_total-columns:            12;
--@grid_debug:                    false;
+@grid_wrapper-width:            1230px;
+@grid_gutter-width:             30px;
+@grid_total-columns:            12;
+@grid_debug:                    false;
 
 /* cf-icons
    ========================================================================== */

--- a/cfgov/unprocessed/css/cf-theme-overrides.less
+++ b/cfgov/unprocessed/css/cf-theme-overrides.less
@@ -144,10 +144,6 @@
    ========================================================================== */
 
 @grid_box-sizing-polyfill-path: '../js';
-@grid_wrapper-width:            1200px;
-@grid_gutter-width:             30px;
-@grid_total-columns:            12;
-@grid_debug:                    false;
 
 
 /* cf-icons


### PR DESCRIPTION
Removing custom grid variables. We should be using the grid variables which are defined in Capital framework. 

## Changes

- Modified `cfgov/unprocessed/css/cf-theme-overrides.less` to remove custom grid variables.


## Testing

- Run `gulp styles`.
- Browse the site at various breakpoints. 

## Screenshots


## Notes

- PRs will need to be created for the sites that require the on-demand footer / header. 


## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
* [ ] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
