### PR TITLE
Update knowledgebase requirement to 2.2.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 ### Changed
 - Bumped the version of Node used by Travis to v6
 - Checksum package.json to avoid reinstalling dependencies that haven't changed
+- Updated knowledgebase requirement to 2.2.5.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 ### Changed
 - Bumped the version of Node used by Travis to v6
 - Checksum package.json to avoid reinstalling dependencies that haven't changed
-- Updated knowledgebase requirement to 2.2.5.
+- Updated knowledgebase requirement to 2.2.6.
 
 ### Removed
 

--- a/requirements/optional-private.txt
+++ b/requirements/optional-private.txt
@@ -5,6 +5,6 @@
 git+https://private.repo/CFPB/agreement_database.git@v2.2.5#egg=agreement-database
 git+https://private.repo/CFPB/cfgov-selfregistration.git@v1.2#egg=selfregistration
 git+https://private.repo/CFPB/django-college-cost-comparison.git@v1.2.9#egg=comparisontool
-git+https://private.repo/CFPB/knowledgebase.git@v2.2.4#egg=knowledgebase
+git+https://private.repo/CFPB/knowledgebase.git@2.2.5#egg=knowledgebase
 git+https://private.repo/CFPB/Picard.git@1.5.5#egg=picard
 git+https://private.repo/eregs/ip.git@1.0.3#egg=eregsip

--- a/requirements/optional-private.txt
+++ b/requirements/optional-private.txt
@@ -5,6 +5,6 @@
 git+https://private.repo/CFPB/agreement_database.git@v2.2.5#egg=agreement-database
 git+https://private.repo/CFPB/cfgov-selfregistration.git@v1.2#egg=selfregistration
 git+https://private.repo/CFPB/django-college-cost-comparison.git@v1.2.9#egg=comparisontool
-git+https://private.repo/CFPB/knowledgebase.git@2.2.5#egg=knowledgebase
+git+https://private.repo/CFPB/knowledgebase.git@2.2.6#egg=knowledgebase
 git+https://private.repo/CFPB/Picard.git@1.5.5#egg=picard
 git+https://private.repo/eregs/ip.git@1.0.3#egg=eregsip


### PR DESCRIPTION
This PR bumps the version of the internal knowledgebase repository to version ~2.2.5~ 2.2.6 (note: purposefully no 'v').

## Changes

- Bump knowledgebase from v2.2.4 to ~2.2.5~ 2.2.6.

## Testing

- Unit tests: `tox -e optional-private knowledgebase`.
 
## Checklist

* [X] Changes are limited to a single goal (no scope creep)
* [X] Code can be automatically merged (no conflicts)
* [X] Passes all existing automated tests
* [X] New functions include new tests
* [X] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
* [X] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
