### PR TITLE
Make sure smoke tests that fail exit with an appropriate status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 ### Fixed
 - Correctly show "live + draft" page status for unshared pages.
 - Fix for Washington, DC Google map image on `/archive-past-events/` page.
+- Failing/timing out smoke tests return 1 not 0
 
 ## 4.6.3
 

--- a/cfgov/scripts/http_smoke_test.py
+++ b/cfgov/scripts/http_smoke_test.py
@@ -207,16 +207,19 @@ def check_urls(base, full=False):
             len(timeouts)
         )
     )
+
     if failures:
         logger.error("These URLs failed: {}".format(failures))
     if timeouts:
         logger.error("These URLs timed out after {} seconds: "
                      "{}".format(TIMEOUT, timeouts))
+
     if failures or timeouts:
         logger.error("FAIL")
-        sys.exit(1)
-    else:
-        logger.info("\x1B[32mAll URLs return 200. No smoke!\x1B[0m")
+        return False
+
+    logger.info("\x1B[32mAll URLs return 200. No smoke!\x1B[0m")
+    return True
 
 if __name__ == '__main__':
     args = parser.parse_args()
@@ -226,4 +229,5 @@ if __name__ == '__main__':
         BASE = args.base
     if args.full:
         FULL = True
-    check_urls(BASE, full=FULL)
+    if not check_urls(BASE, full=FULL):
+        sys.exit(1)

--- a/cfgov/scripts/http_smoke_test.py
+++ b/cfgov/scripts/http_smoke_test.py
@@ -214,6 +214,7 @@ def check_urls(base, full=False):
                      "{}".format(TIMEOUT, timeouts))
     if failures or timeouts:
         logger.error("FAIL")
+        sys.exit(1)
     else:
         logger.info("\x1B[32mAll URLs return 200. No smoke!\x1B[0m")
 


### PR DESCRIPTION
Out smoke test script always exits with 0, even with failures. This fixes that.
 
## Changes

- Failing/timing out smoke tests return 1 not 0

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
* [ ] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
