### PR TITLE
Update knowledgebase requirement to 2.2.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,11 +20,17 @@ Given the `MAJOR.MINOR.PATCH` pattern, here is how we decide to increment:
 ### Changed
 - Bumped the version of Node used by Travis to v6
 - Checksum package.json to avoid reinstalling dependencies that haven't changed
-- Updated knowledgebase requirement to 2.2.6.
+- Updated knowledgebase requirement to 2.2.7.
 
 ### Removed
 
 ### Fixed
+
+
+## 4.6.5
+
+### Changed
+- Updated knowledgebase requirement to 2.2.6.
 
 
 ## 4.6.4

--- a/requirements/optional-private.txt
+++ b/requirements/optional-private.txt
@@ -5,6 +5,6 @@
 git+https://private.repo/CFPB/agreement_database.git@v2.2.5#egg=agreement-database
 git+https://private.repo/CFPB/cfgov-selfregistration.git@v1.2#egg=selfregistration
 git+https://private.repo/CFPB/django-college-cost-comparison.git@v1.2.9#egg=comparisontool
-git+https://private.repo/CFPB/knowledgebase.git@2.2.6#egg=knowledgebase
+git+https://private.repo/CFPB/knowledgebase.git@2.2.7#egg=knowledgebase
 git+https://private.repo/CFPB/Picard.git@1.5.5#egg=picard
 git+https://private.repo/eregs/ip.git@1.0.3#egg=eregsip


### PR DESCRIPTION
This PR updates the optional (private) knowledgebase version from 2.2.6 to 2.2.7.

It also updates the CHANGELOG with missing release notes from version 4.6.5.

## Additions

- Release notes for 4.6.5.

## Changes

- Knowledgebase dependency bumped to 2.2.7

## Checklist

* [X] Changes are limited to a single goal (no scope creep)
* [X] Code can be automatically merged (no conflicts)
* [X] Passes all existing automated tests
* [X] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
* [X] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
