### PR TITLE
Add feature flag check for WAGTAIL_THE_BUREAU

### DIFF
--- a/cfgov/cfgov/urls.py
+++ b/cfgov/cfgov/urls.py
@@ -14,6 +14,7 @@ from wagtail.wagtailcore import urls as wagtail_urls
 from wagtail.wagtailcore import views
 
 from core.views import ExternalURLNoticeView
+from flags.decorators import flag_required
 from legacy.views import (HousingCounselorPDFView, dbrouter_shortcut,
                           token_provider)
 from sheerlike.sites import SheerSite
@@ -118,22 +119,44 @@ urlpatterns = [
             template_name='newsroom/press-resources/index.html'),
         name='press-resources'),
 
-    url(r'^the-bureau/(?P<path>.*)$', RedirectView.as_view(
-        url='/about-us/the-bureau/%(path)s', permanent=True)),
+
+    url(r'^the-bureau/(?P<path>.*)$',
+            RedirectView.as_view(url='/about-us/the-bureau/%(path)s',
+                                 permanent=True)
+    ),
     url(r'^about-us/leadership-calendar/(?P<path>.*)$', RedirectView.as_view(
         url='/about-us/the-bureau/leadership-calendar/%(path)s',
         permanent=True)),
+
+    # For our move of 'The Bureau' to Wagtail, we need a complicated mess of
+    # feature flags here. Once the move is complete, this url should be
+    # entirely removable.
     url(r'^about-us/the-bureau/', include([
         url(r'^$',
-            SheerTemplateView.as_view(
-                template_name='about-us/the-bureau/index.html'),
+            flag_required('WAGTAIL_THE_BUREAU',
+                          fallback_view=lambda request: views.serve(
+                              request, request.path),
+                          pass_if_set=False)(
+                SheerTemplateView.as_view(
+                    template_name='about-us/the-bureau/index.html')
+            ),
             name='index'),
         url(r'^leadership-calendar/',
-            lambda request: views.serve(request,
-                                        'about-us/leadership-calendar'),
+            flag_required('WAGTAIL_THE_BUREAU',
+                          fallback_view=lambda request: views.serve(
+                              request, request.path),
+                          pass_if_set=False)(
+                lambda request: views.serve(request,
+                                            'about-us/leadership-calendar')
+            ),
             name='leadership-calendar'),
         url(r'^(?P<page_slug>[\w-]+)/$',
-            SheerTemplateView.as_view(),
+            flag_required('WAGTAIL_THE_BUREAU',
+                          fallback_view=lambda request: views.serve(
+                              request, request.path),
+                          pass_if_set=False)(
+                SheerTemplateView.as_view()
+            ),
             name='page'),
         ],
         namespace='the-bureau')),


### PR DESCRIPTION
We're moving "The Bureau" section to Wagtail. This PR adds a check in `urls.py` for the feature flag `WAGTAIL_THE_BUREAU`, and if it **is not enabled** the hard-coded templates will be used for all urls under "The Bureau" except for the leadership calendar. 

The leadership calendar will need to be copied into about-us/the-bureau in Wagtail before the page will work once the `WAGTAIL_THE_BUREAU` flag is set. After this, about-us/leadership-calendar can be deleted in Wagtail.

## Additions

- Checks for `WAGTAIL_THE_BUREAU` in `cfgov/urls.py` for all "The Bureau" urls.

## Testing

- Use a recent database dump that has the Wagtail work on "The Bureau" pages.
- Visit the following URLs to confirm they work *without the feature flag set*:
  - http://localhost:8000/about-us/the-bureau/
  - http://localhost:8000/about-us/the-bureau/the-director/
  - http://localhost:8000/about-us/the-bureau/deputy-director/
  - http://localhost:8000/about-us/the-bureau/bureau-structure/
  - http://localhost:8000/about-us/the-bureau/leadership-calendar/
- Go to the feature flag admin and add `WAGTAIL_THE_BUREAU` to your flags for `localhost:8000`
- Enable the feature flag
- Publish the pages under "CFGov/About Us/The Bureau" in Wagtail
- Copy the page "CFGov/About Us/Leadership Calendar" to "CFGov/About Us/The Bureau"
- Visit the following URLs to confirm they work *with the feature flag set*:
  - http://localhost:8000/about-us/the-bureau/
  - http://localhost:8000/about-us/the-bureau/the-director/
  - http://localhost:8000/about-us/the-bureau/deputy-director/
  - http://localhost:8000/about-us/the-bureau/bureau-structure/
  - http://localhost:8000/about-us/the-bureau/leadership-calendar/
- At present the bio pages **will not** have the image inset.

## Notes

Handling feature flags in urls.py makes for some messy code. It might be nice to have a url constructor, something like `flagged_url()` in place of `url()` that cleans that up a bit.

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
* [ ] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
