### PR TITLE
Make Resource snippets orderable and update Snippet Lists to sort by order, then title

### DIFF
--- a/cfgov/jinja2/v1/_includes/organisms/snippet-list.html
+++ b/cfgov/jinja2/v1/_includes/organisms/snippet-list.html
@@ -55,7 +55,7 @@
     } ) }}
 
     {% set snippets = get_snippets(value.snippet_type) %}
-    {% set filtered_snippets = snippets.objects.filter_by_tags(value.tags).order_by('order', 'title') %}
+    {% set filtered_snippets = snippets.objects.filter_by_tags(value.tags) if snippets.objects.filter_by_tags else snippets.objects.all() %}
     {% if filtered_snippets.exists() %}
         <div class="o-table__stack-on-small o-snippet-list_list" data-display-table="table">
             <header data-display-table="thead">
@@ -66,7 +66,7 @@
             {% for snippet in filtered_snippets %}
                 <li data-display-table="row">
                     <div data-display-table="cell">
-                        <div class="o-snippet-list_list-item-title">{{ snippet.title }}</div>
+                        <div class="o-snippet-list_list-item-title">{{ snippet }}</div>
                         {{ snippet.desc if snippet.desc else '' }}
                     </div>
                     <div data-display-table="cell">

--- a/cfgov/jinja2/v1/_includes/organisms/snippet-list.html
+++ b/cfgov/jinja2/v1/_includes/organisms/snippet-list.html
@@ -55,7 +55,7 @@
     } ) }}
 
     {% set snippets = get_snippets(value.snippet_type) %}
-    {% set filtered_snippets = snippets.objects.filter_by_tags(value.tags) %}
+    {% set filtered_snippets = snippets.objects.filter_by_tags(value.tags).order_by('order', 'title') %}
     {% if filtered_snippets.exists() %}
         <div class="o-table__stack-on-small o-snippet-list_list" data-display-table="table">
             <header data-display-table="thead">

--- a/cfgov/jinja2/v1/_includes/organisms/snippet-list.html
+++ b/cfgov/jinja2/v1/_includes/organisms/snippet-list.html
@@ -38,15 +38,21 @@
 {% from 'molecules/info-unit.html' import info_unit with context %}
 
 <div class="o-snippet-list">
-    {% set img = image(value.image.upload, 'original') if value.image.upload else '/' %}
+    {% set img = image(value.image.upload, 'original')
+       if value.image.upload
+       else '/' %}
     {% set image = {
-        'url': img.url,
-        'alt': value.image.alt,
-        'is_square': true,
-        'is_decorative': value.image.alt == ''
-    } if value.image.upload else null %}
+         'url': img.url,
+         'alt': value.image.alt,
+         'is_square': true,
+         'is_decorative': value.image.alt == ''
+       }
+       if value.image.upload
+       else null %}
     {% set modifier = 'inline' if value.image.upload else '' %}
-    {% set heading = '<h3>' ~ value.heading ~ '</h3>' if value.heading else '' %}
+    {% set heading = '<h3>' ~ value.heading ~ '</h3>'
+       if value.heading
+       else '' %}
     {{ info_unit( {
         'modifier': modifier,
         'image': image,
@@ -55,7 +61,9 @@
     } ) }}
 
     {% set snippets = get_snippets(value.snippet_type) %}
-    {% set filtered_snippets = snippets.objects.filter_by_tags(value.tags) if snippets.objects.filter_by_tags else snippets.objects.all() %}
+    {% set filtered_snippets = snippets.objects.filter_by_tags(value.tags)
+       if snippets.objects.filter_by_tags
+       else snippets.objects.all() %}
     {% if filtered_snippets.exists() %}
         <div class="o-table__stack-on-small o-snippet-list_list" data-display-table="table">
             <header data-display-table="thead">

--- a/cfgov/v1/migrations/0053_orderable_resource_snippets.py
+++ b/cfgov/v1/migrations/0053_orderable_resource_snippets.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import taggit.managers
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('v1', '0052_add_image_inset'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='resource',
+            name='order',
+            field=models.PositiveSmallIntegerField(help_text=b'Snippets will be listed alphabetically by title in a Snippet List module, unless any in the list have a number in this field; those with an order value will appear at the bottom of the list, in ascending order.', null=True, blank=True),
+        ),
+        migrations.AlterField(
+            model_name='resource',
+            name='tags',
+            field=taggit.managers.TaggableManager(to='taggit.Tag', through='v1.ResourceTag', blank=True, help_text=b'Tags can be used to filter snippets in a Snippet List.', verbose_name='Tags'),
+        ),
+    ]

--- a/cfgov/v1/migrations/0055_orderable_resource_snippets.py
+++ b/cfgov/v1/migrations/0055_orderable_resource_snippets.py
@@ -8,10 +8,14 @@ import taggit.managers
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('v1', '0052_add_image_inset'),
+        ('v1', '0054_new_categories'),
     ]
 
     operations = [
+        migrations.AlterModelOptions(
+            name='resource',
+            options={'ordering': ('order', 'title')},
+        ),
         migrations.AddField(
             model_name='resource',
             name='order',

--- a/cfgov/v1/models/snippets.py
+++ b/cfgov/v1/models/snippets.py
@@ -134,3 +134,6 @@ class Resource(ClusterableModel):
 
     def __str__(self):
         return self.title
+
+    class Meta:
+        ordering = ('order', 'title')

--- a/cfgov/v1/models/snippets.py
+++ b/cfgov/v1/models/snippets.py
@@ -95,7 +95,20 @@ class Resource(ClusterableModel):
         validators=[URLValidator]
     )
 
-    tags = TaggableManager(through=ResourceTag, blank=True)
+    order = models.PositiveSmallIntegerField(
+        null=True,
+        blank=True,
+        help_text='Snippets will be listed alphabetically by title in a '
+        'Snippet List module, unless any in the list have a number in this '
+        'field; those with an order value will appear at the bottom of the '
+        'list, in ascending order.'
+    )
+
+    tags = TaggableManager(
+        through=ResourceTag,
+        blank=True,
+        help_text='Tags can be used to filter snippets in a Snippet List.'
+    )
 
     objects = TaggableSnippetManager()
 
@@ -107,6 +120,7 @@ class Resource(ClusterableModel):
         DocumentChooserPanel('alternate_file'),
         FieldPanel('link'),
         FieldPanel('alternate_link'),
+        FieldPanel('order'),
         FieldPanel('tags'),
     ]
 

--- a/cfgov/v1/tests/models/test_snippets.py
+++ b/cfgov/v1/tests/models/test_snippets.py
@@ -42,6 +42,52 @@ class TestFilterByTags(TestCase):
         )
 
 
+class TestOrderedResources(TestCase):
+    def setUp(self):
+        self.snippetBBC = Resource.objects.create(title='BBC')
+        self.snippetZebra = Resource.objects.create(title='Zebra')
+        self.snippetAbc = Resource.objects.create(title='Abc')
+
+    def test_default_alphabetical_ordering(self):
+        self.assertSequenceEqual(
+            Resource.objects.all(),
+            [self.snippetAbc, self.snippetBBC, self.snippetZebra]
+        )
+
+    def test_partial_explicit_ordering(self):
+        self.snippetBBC.order = 1
+        self.snippetBBC.save()
+
+        self.assertSequenceEqual(
+            Resource.objects.all(),
+            [self.snippetAbc, self.snippetZebra, self.snippetBBC]
+        )
+
+    def test_total_explicit_ordering(self):
+        self.snippetAbc.order = 23
+        self.snippetAbc.save()
+        self.snippetBBC.order = 1
+        self.snippetBBC.save()
+        self.snippetZebra.order = 32000
+        self.snippetZebra.save()
+
+        self.assertSequenceEqual(
+            Resource.objects.all(),
+            [self.snippetBBC, self.snippetAbc, self.snippetZebra]
+        )
+
+    def test_order_tiebreaking(self):
+        self.snippetAbc.order = 1
+        self.snippetAbc.save()
+        self.snippetBBC.order = 1
+        self.snippetBBC.save()
+
+        self.assertSequenceEqual(
+            Resource.objects.all(),
+            [self.snippetZebra, self.snippetAbc, self.snippetBBC]
+        )
+
+
 class TestUnicodeCompatibility(TestCase):
     def test_unicode_contact_heading_str(self):
         contact = Contact(heading=u'Unicod\xeb')


### PR DESCRIPTION
Snippet list output has previously been in a random order. This sets the default order to alphabetical by title, and enables the ability to order them manually by using the Resource snippet's `order` field.

## Additions

- Adds `order` field to Resource snippet model

## Changes

- Uses the `order` field to sort the output of a Snippet List module, defaulting to (and breaking ties with) alphabetical by title.
- Updates `help_text` for Resource's `tags` field.

## Testing

1. Pull fork
1. Create some Resource snippets with various titles, if you don't have any yet. Don't give them an order value, but do give them a tag you can use in the Snippet List.
1. Create a Snippet List on a browse page using the name of the tag you gave to the snippets in the above step.
1. View the page and confirm that they are sorting alphabetically by title.
1. Go back and edit some of the snippets to give them a numeric order value.
1. Refresh the page and confirm that the ones you gave an order to appear below the ones with no order, and they appear in numeric order.

## To do

- As I write this, it occurs to me that I should test this with a Snippet List set to use Contacts, to ensure it doesn't break because Contacts don't have an order field.

## Checklist

* [x] PR has an informative and human-readable title
* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices
* [x] Project documentation has been updated
* [x] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
