### PR TITLE
Fix for empty agenda times on event page.

### DIFF
--- a/cfgov/jinja2/v1/events/_macros.html
+++ b/cfgov/jinja2/v1/events/_macros.html
@@ -202,13 +202,13 @@
             <tr>
                 <td>
                     {% import 'macros/time.html' as time %}
-                    {% if bound.start_time | string != 'None' %}
+                    {% if bound.start_time.value is not none %}
                       {{ time.render(
                           bound.start_time.render(),
                           {'date':false,'time':true,'timezone':false}
                       ) }}
                     {% endif %}
-                    {% if bound.end_time | string != 'None' %}
+                    {% if bound.end_time.value is not none %}
                       &ndash;
                       {{ time.render(bound.end_time.render(), {'time':true, 'timezone':true}) }}
                     {% endif %}

--- a/cfgov/jinja2/v1/events/_macros.html
+++ b/cfgov/jinja2/v1/events/_macros.html
@@ -202,12 +202,16 @@
             <tr>
                 <td>
                     {% import 'macros/time.html' as time %}
-                    {{ time.render(
-                        bound.start_time.render(),
-                        {'date':false,'time':true,'timezone':false}
-                    ) }}
-                    &ndash;
-                    {{ time.render(bound.end_time.render(), {'time':true, 'timezone':true}) }}
+                    {% if bound.start_time | string != 'None' %}
+                      {{ time.render(
+                          bound.start_time.render(),
+                          {'date':false,'time':true,'timezone':false}
+                      ) }}
+                    {% endif %}
+                    {% if bound.end_time | string != 'None' %}
+                      &ndash;
+                      {{ time.render(bound.end_time.render(), {'time':true, 'timezone':true}) }}
+                    {% endif %}
                 </td>
                 <td data-label="Agenda">
                     {{ bound.description.render() }}


### PR DESCRIPTION
Fix for agenda times on event page.

## Changes

- Modified `cfgov/jinja2/v1/events/_macros.html` to allow for empty start / end times on event agenda page. 


## Testing

- Visit `http://localhost:8000/admin/pages/3759/edit/` and remove an end date for any agenda item.
- Preview and be amazed.

## Screenshots

<img width="877" alt="screen shot 2017-02-10 at 12 04 52 pm" src="https://cloud.githubusercontent.com/assets/1696212/22836207/70351692-ef89-11e6-8eb7-83c8e082154c.png">

## Notes

- `{% if bound.start_time is not none % }` doesn't work. I had to cast to string.


## Checklist

* [ ] PR has an informative and human-readable title
* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated
* [ ] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
