### PR TITLE
Bumping Retirement version to 0.5.5

### DIFF
--- a/requirements/optional-public.txt
+++ b/requirements/optional-public.txt
@@ -4,4 +4,4 @@ git+https://github.com/cfpb/django-hud.git@1.2#egg=django-hud
 git+https://github.com/cfpb/owning-a-home-api.git@0.9.94#egg=owning-a-home-api
 git+https://github.com/cfpb/regulations-core.git@1.2.3#egg=regcore
 git+https://github.com/cfpb/regulations-site.git@2.1.5#egg=regulations
-git+https://github.com/cfpb/retirement.git@0.5.4#egg=retirement
+git+https://github.com/cfpb/retirement.git@0.5.5#egg=retirement


### PR DESCRIPTION
Bumping Retirement version to 0.5.5


## Changes

- Modified `requirements/optional-public.txt` to bump the version to 0.5.5.

## Testing

- Install pip optional dependencies.
- Visit `https://www.consumerfinance.gov/retirement/before-you-claim/`.
- Verify that the site works as expected.


## Checklist

* [ ] PR has an informative and human-readable title
* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated
* [ ] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
