### PR TITLE
Recognize requests proxied from HTTPS

### DIFF
--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -15,6 +15,10 @@ V1_TEMPLATE_ROOT = PROJECT_ROOT.child('jinja2', 'v1')
 
 SECRET_KEY = os.environ.get('SECRET_KEY', os.urandom(32))
 
+# signal that tells us that this is a proxied HTTPS request
+# effects how request.is_secure() responds
+SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
+
 # Use the django default password hashing
 PASSWORD_HASHERS = global_settings.PASSWORD_HASHERS
 


### PR DESCRIPTION
Right now, even though www.consumerfinance.gov is served via HTTPS, automatically generated URL's still use plain old HTTP. This is because the final leg of the request is not encrypted. We need to send Django a hint about the true protocol of the request.

<img width="550" alt="screen shot 2017-02-14 at 3 19 13 pm" src="https://cloud.githubusercontent.com/assets/235397/22947472/230e7c1c-f2c9-11e6-93d0-84e87a367561.png">

Django let's us send that hint using the SECURE_PROXY_SSL_HEADER setting. By configuring with a header name and expected value, we can tell Django that generated URL's should include https.

https://docs.djangoproject.com/en/1.8/ref/settings/#secure-proxy-ssl-header

We've gone with the example provided in the Django docs:
` SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')`

We will need to configure the CDN to include the X-FORWARDED-PROTO header.

## Additions

- added SECURE_PROXY_SSL_HEADER to cfgov/settings/base.py


## Testing

 start the django server. In another terminal tab:

`curl  -s http://localhost:8000 | grep og:url`

The output will look like:
`        <meta property="og:url" content="http://localhost:8000/">`

Not the protocol on that URL is 'http'.  Now send the X-Forwarded-Proto header with:

`curl  --header "X-FORWARDED-PROTO: https" -s http://localhost:8000 | grep og:url`

and note that the og:url value now has https:

`<meta property="og:url" content="https://localhost:8000/">`

## Checklist

* [x] PR has an informative and human-readable title
* [x] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated
* [ ] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
