### PR TITLE
Bump regulations-site from 2.1.5 to 2.1.6

### DIFF
--- a/requirements/optional-public.txt
+++ b/requirements/optional-public.txt
@@ -3,5 +3,5 @@ git+https://github.com/cfpb/complaint.git@v1.2.8#egg=complaintdatabase
 git+https://github.com/cfpb/django-hud.git@1.2#egg=django-hud
 git+https://github.com/cfpb/owning-a-home-api.git@0.9.94#egg=owning-a-home-api
 git+https://github.com/cfpb/regulations-core.git@1.2.3#egg=regcore
-git+https://github.com/cfpb/regulations-site.git@2.1.5#egg=regulations
+git+https://github.com/cfpb/regulations-site.git@2.1.6#egg=regulations
 git+https://github.com/cfpb/retirement.git@0.5.4#egg=retirement


### PR DESCRIPTION
This PR bumps the optional [regulations-site](https://github.com/cfpb/regulations-site) requirement from release 2.1.5 to [2.1.6](https://github.com/cfpb/regulations-site/releases/tag/2.1.6).

## Changes

- Increases regulations-site version from 2.1.5 to 2.1.6.

## Testing

- Run 

 ```sh
$ pip install git+https://github.com/cfpb/regulations-site.git@2.1.6#egg=regulations
```

 from command-line without a local snyk setup and verify that install succeeds.

## Checklist

* [X] PR has an informative and human-readable title
* [X] Changes are limited to a single goal (no scope creep)
* [X] Code can be automatically merged (no conflicts)
* [X] Passes all existing automated tests
* [X] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
