### PR TITLE
WIP: Adding stored procedure to find components

### DIFF
--- a/FindComponent.psql
+++ b/FindComponent.psql
@@ -1,0 +1,51 @@
+DELIMITER $$
+
+DROP PROCEDURE IF EXISTS FindAtomicComponents;
+
+CREATE PROCEDURE FindAtomicComponents(
+	in component_name varchar(100))
+BEGIN
+	DECLARE _table_name varchar(255);
+
+	DECLARE no_more_rows BOOLEAN DEFAULT FALSE;
+
+	DECLARE table_name_cursor CURSOR FOR SELECT table_name FROM
+	information_schema.tables WHERE table_name LIKE "v1%_%page";
+
+	DECLARE CONTINUE HANDLER FOR NOT FOUND SET no_more_rows = TRUE;
+
+	OPEN table_name_cursor;
+
+	get_components: LOOP
+		FETCH table_name_cursor INTO _table_name;
+
+		IF no_more_rows THEN
+       		CLOSE table_name_cursor;
+        	LEAVE get_components;
+    	END IF;
+
+		SELECT COLUMN_NAME FROM INFORMATION_SCHEMA.COLUMNS
+		WHERE table_name = _table_name
+		AND COLUMN_KEY = 'PRI' into @primary_key;
+
+		IF EXISTS ( SELECT COLUMN_NAME FROM INFORMATION_SCHEMA.COLUMNS
+		WHERE table_name = _table_name
+		AND COLUMN_NAME = 'content' ) THEN
+			SET @SQL = CONCAT( "select CASE WHEN INSTR( url_path, '/cfgov/')",
+						   " THEN replace(url_path, '/cfgov/', 'localhost:8000/')"
+						   " ELSE url_path END FROM ",
+			               _table_name,
+			               ", wagtailcore_page as wagtailpage where ",
+			               _table_name,
+			               ".",
+			               @primary_key,
+			               "= wagtailpage.id and content like '%\"type\": \"",
+			               component_name, "\"%' " );
+
+			PREPARE sql_statement FROM @SQL;
+	        EXECUTE sql_statement;
+	        DEALLOCATE PREPARE sql_statement;
+        END IF;
+
+  	END LOOP get_components;
+END$$


### PR DESCRIPTION
WIP: Adding stored procedure to find components

## Additions

- Adding stored procedure to find components based on component parameter.

## Testing

- Run `mysql -u root -D v1 <  FindComponent.psql`
- Run `mysql -u root -D v1  -e "call FindAtomicComponents('text_introduction')" > FindComponents.txt`
- Open `FindComponents.txt` and browse the links.

## Notes

- It's probably easier to just use Django models or Q
- Need a way to integrate it into Wagtail search.

## Checklist

* [ ] PR has an informative and human-readable title
* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated
* [ ] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
