### PR TITLE
Bump agreement_database from v2.2.5 to v2.2.6

### DIFF
--- a/requirements/optional-private.txt
+++ b/requirements/optional-private.txt
@@ -2,7 +2,7 @@
 # configure git with:
 # git config --global url.https://<private hostname>/.insteadOf https://private.repo/
 
-git+https://private.repo/CFPB/agreement_database.git@v2.2.5#egg=agreement-database
+git+https://private.repo/CFPB/agreement_database.git@v2.2.6#egg=agreement-database
 git+https://private.repo/CFPB/cfgov-selfregistration.git@v1.2#egg=selfregistration
 git+https://private.repo/CFPB/django-college-cost-comparison.git@v1.2.9#egg=comparisontool
 git+https://private.repo/CFPB/knowledgebase.git@2.2.8#egg=knowledgebase


### PR DESCRIPTION
This PR updates the version of the optional private repository agreement_database from v2.2.5 to v2.2.6.

## Changes

- Bump agreement_database from v2.2.5 to v2.2.6.

## Testing

- Run unit tests in cfgov-refresh with:

 ```sh
$ pip install git+https://private.repo/CFPB/agreement_database.git@v2.2.6#egg=agreement-database
$ PYTHONPATH=cfgov DJANGO_SETTINGS_MODULE=cfgov.settings.test python cfgov/manage.py test agreements
```

- Test locally with a production data dump and visit http://localhost:8000/credit-cards/agreements/.

## Checklist

* [X] PR has an informative and human-readable title
* [X] Changes are limited to a single goal (no scope creep)
* [X] Code can be automatically merged (no conflicts)
* [X] Passes all existing automated tests
* [X] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
