### PR TITLE
enable USE_X_FORWARDED_HOST

### DIFF
--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -18,6 +18,7 @@ SECRET_KEY = os.environ.get('SECRET_KEY', os.urandom(32))
 # signal that tells us that this is a proxied HTTPS request
 # effects how request.is_secure() responds
 SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
+USE_X_FORWARDED_HOST = True
 
 # Use the django default password hashing
 PASSWORD_HASHERS = global_settings.PASSWORD_HASHERS


### PR DESCRIPTION
This is basically an extension of #2747

On beta, I've got the X-Forwarded-Proto header working correctly, *mostly*. The (small) problem is that URL's include the port, which seems is kind of sloppy.

For example, the og:url on a blog post looks like:

https://beta.consumerfinance.gov:443/about-us/blog/cfpb-ombudsmans-office-2016-annual-report/

This is because (for whatever reason) when the CDN requests documents from the origin, the Host: header contains the port number, like beta.consumerfinance.gov:443

By enabling USE_X_FORWARDED_HOST, we can configure the CDN to send a X-Forwarded-Host header with our chose value (which will just be beta.consumerfinance.gov and www.consumerfinance.gov), and Django will respect that when generating URL's

The relevant Django logic is here:

https://github.com/django/django/blob/1.8.15/django/http/request.py#L76


## Additions

- Set settings.USE_X_FORWARDED_HOST to True


## Checklist

* [ ] PR has an informative and human-readable title

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated
* [ ] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
