### PR TITLE
PDFReactor scheme should always be http

### DIFF
--- a/cfgov/legacy/views.py
+++ b/cfgov/legacy/views.py
@@ -35,7 +35,7 @@ class HousingCounselorPDFView(PDFGeneratorView):
 
         zip = self.form.cleaned_data['zip']
         api_url = 'hud-api-replace/%s.html/' % zip
-        url = '%s://%s/%s' % (request.scheme, 'localhost', api_url)
+        url = '%s://%s/%s' % ('http', 'localhost', api_url)
         return url
 
     def get(self, request):

--- a/cfgov/legacy/views.py
+++ b/cfgov/legacy/views.py
@@ -31,8 +31,6 @@ class InvalidZipException(Exception):
 
 class HousingCounselorPDFView(PDFGeneratorView):
     def get_render_url(self):
-        request = self.request
-
         zip = self.form.cleaned_data['zip']
         api_url = 'hud-api-replace/%s.html/' % zip
         url = '%s://%s/%s' % ('http', 'localhost', api_url)


### PR DESCRIPTION
## Changes

- When PDFReactor reaches back to the web server to get the HTML to render, it shouldn't depend on request.scheme


## Checklist

* [ ] PR has an informative and human-readable title
* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated
* [ ] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
