### PR TITLE
update latest data month from november to december

### DIFF
--- a/cfgov/jinja2/v1/_includes/organisms/chart.html
+++ b/cfgov/jinja2/v1/_includes/organisms/chart.html
@@ -36,7 +36,7 @@
       <strong>Date published:</strong> January 2017<br>
 
       {% if value.note %}
-      <strong>Note:</strong> {{ value.note }} The most recent data available in each visualization is for November 2016.
+      <strong>Note:</strong> {{ value.note }} The most recent data available in each visualization is for December 2016.
       {% endif %}
     </p>
 </div>

--- a/cfgov/jinja2/v1/_includes/organisms/chart.html
+++ b/cfgov/jinja2/v1/_includes/organisms/chart.html
@@ -33,7 +33,7 @@
       <strong>Source:</strong> <a class="icon-link icon-link__download" href="https://s3.amazonaws.com/files.consumerfinance.gov/data/{{ value.data_source }}"> <span class="icon-link_text">Download CSV file</span> </a><br>
       {% endif %}
 
-      <strong>Date published:</strong> January 2017<br>
+      <strong>Date published:</strong> February 2017<br>
 
       {% if value.note %}
       <strong>Note:</strong> {{ value.note }} The most recent data available in each visualization is for December 2016.


### PR DESCRIPTION
Updates hard-coded date for the CCT monthly data sets. The footnote for each graph should say "December 2016" once the latest date goes live (slated for Tuesday 2/21).