### PR TITLE
Fixes for Ustream invalid certificate and Event copy changes

### DIFF
--- a/cfgov/jinja2/v1/events/_event-detail.html
+++ b/cfgov/jinja2/v1/events/_event-detail.html
@@ -35,7 +35,7 @@
                 <div class="event-status_livestream">
                   <p>
                       <span class="cf-icon cf-icon-livestream"></span>
-                      <strong>Available on Live stream.</strong>
+                      <strong>Available on live stream</strong>
                   </p>
                   <p class="event-meta">
                       <span class="event-meta_description event-meta_description__block">
@@ -63,7 +63,7 @@
                         Use the link below to troubleshoot the live video stream if it isn't playing properly.
                     </p>
                     <p>
-                        <a href="https://help.livestream.com/hc/en-us/sections/201923657-Watch">
+                        <a href="https://support.ustream.tv/hc/en-us/articles/207851767-Viewing-troubleshooting-steps">
                             Livestream video help FAQ
                         </a>
                     </p>

--- a/cfgov/unprocessed/css/video-player.less
+++ b/cfgov/unprocessed/css/video-player.less
@@ -99,6 +99,19 @@
     margin: auto;
 }
 
+.respond-to-min( @fcm-bp-min, {
+    .video-player_video-actions-container {
+        position: absolute;
+        top: 0;
+        left: @video-width__px;
+    }
+
+    .video-player .m-social-media,
+    .video-player_video-actions {
+        margin-bottom: @grid_gutter-width;
+    }
+} );
+
 .video-player_video-container__flexible {
     .video-player_iframe-container {
         width: auto;
@@ -193,22 +206,6 @@
     }
 } );
 
-.respond-to-min( @fcm-bp-min, {
-    .video-player_video-actions-container {
-        position: absolute;
-        top: 0;
-        left: @video-width__px;
-    }
-
-    .video-player .m-social-media,
-    .video-player_video-actions {
-        margin-bottom: @grid_gutter-width;
-    }
-
-    .video-player .m-social-media {
-        text-align: left;
-    }
-} );
 
 .respond-to-min( @bp-xl-min, {
     .video-player_iframe-container {

--- a/cfgov/unprocessed/js/modules/UStreamPlayer.js
+++ b/cfgov/unprocessed/js/modules/UStreamPlayer.js
@@ -10,7 +10,7 @@ var CLASSES = Object.freeze( {
 
 var API = {
 
-  SCRIPT_API: 'https://developers.ustream.tv/js/ustream-embedapi.min.js',
+  SCRIPT_API: '/static/js/ustream-embedapi.min.js',
 
   constructor: UStreamPlayer,
 

--- a/gulp/config.js
+++ b/gulp/config.js
@@ -98,7 +98,8 @@ module.exports = {
     },
     vendorJs: {
       src: [
-        paths.modules + '/jquery/dist/jquery.min.js'
+        paths.modules + '/jquery/dist/jquery.min.js',
+        paths.modules + '/ustream-embedapi/dist/ustream-embedapi.min.js'
       ],
       dest: paths.processed + '/js/'
     }

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -6159,6 +6159,11 @@
       "from": "user-home@>=1.1.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz"
     },
+    "ustream-embedapi": {
+      "version": "1.0.0",
+      "from": "ustream-embedapi@1.0.0",
+      "resolved": "https://registry.npmjs.org/ustream-embedapi/-/ustream-embedapi-1.0.0.tgz"
+    },
     "util": {
       "version": "0.10.3",
       "from": "util@>=0.10.3 <0.11.0",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -277,9 +277,9 @@
       "resolved": "https://registry.npmjs.org/atob/-/atob-1.1.3.tgz"
     },
     "autoprefixer": {
-      "version": "6.7.2",
+      "version": "6.7.5",
       "from": "autoprefixer@>=6.0.0 <7.0.0",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-6.7.2.tgz"
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-6.7.5.tgz"
     },
     "aws-sign2": {
       "version": "0.6.0",
@@ -512,9 +512,9 @@
       "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz"
     },
     "browserslist": {
-      "version": "1.7.2",
-      "from": "browserslist@>=1.7.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.7.2.tgz"
+      "version": "1.7.5",
+      "from": "browserslist@>=1.7.5 <2.0.0",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.7.5.tgz"
     },
     "bs-recipes": {
       "version": "1.3.4",
@@ -616,9 +616,9 @@
       }
     },
     "caniuse-db": {
-      "version": "1.0.30000623",
-      "from": "caniuse-db@>=1.0.30000618 <2.0.0",
-      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000623.tgz"
+      "version": "1.0.30000624",
+      "from": "caniuse-db@>=1.0.30000624 <2.0.0",
+      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000624.tgz"
     },
     "capital-framework": {
       "version": "3.6.1",
@@ -693,9 +693,9 @@
       "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.1.tgz"
     },
     "clean-css": {
-      "version": "4.0.7",
+      "version": "4.0.8",
       "from": "clean-css@>=4.0.4 <5.0.0",
-      "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.0.7.tgz",
+      "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.0.8.tgz",
       "dependencies": {
         "source-map": {
           "version": "0.5.6",
@@ -899,9 +899,9 @@
       "resolved": "https://registry.npmjs.org/coveralls/-/coveralls-2.11.16.tgz",
       "dependencies": {
         "qs": {
-          "version": "6.3.0",
+          "version": "6.3.1",
           "from": "qs@>=6.3.0 <6.4.0",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.3.0.tgz"
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.3.1.tgz"
         },
         "request": {
           "version": "2.79.0",
@@ -1568,9 +1568,9 @@
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz"
     },
     "electron-to-chromium": {
-      "version": "1.2.2",
-      "from": "electron-to-chromium@>=1.2.2 <2.0.0",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.2.2.tgz"
+      "version": "1.2.3",
+      "from": "electron-to-chromium@>=1.2.3 <2.0.0",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.2.3.tgz"
     },
     "emitter-steward": {
       "version": "1.0.0",
@@ -1746,9 +1746,9 @@
       "resolved": "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz"
     },
     "eslint": {
-      "version": "3.15.0",
+      "version": "3.16.1",
       "from": "eslint@>=3.0.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-3.15.0.tgz",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-3.16.1.tgz",
       "dependencies": {
         "lodash": {
           "version": "4.17.4",
@@ -1807,9 +1807,9 @@
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
     },
     "etag": {
-      "version": "1.7.0",
+      "version": "1.8.0",
       "from": "etag@>=1.7.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/etag/-/etag-1.7.0.tgz"
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.0.tgz"
     },
     "event-emitter": {
       "version": "0.3.4",
@@ -2217,9 +2217,9 @@
       "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-0.1.5.tgz"
     },
     "globals": {
-      "version": "9.15.0",
+      "version": "9.16.0",
       "from": "globals@>=9.14.0 <10.0.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-9.15.0.tgz"
+      "resolved": "https://registry.npmjs.org/globals/-/globals-9.16.0.tgz"
     },
     "globby": {
       "version": "5.0.0",
@@ -2288,9 +2288,9 @@
           "dev": true,
           "dependencies": {
             "async": {
-              "version": "2.1.4",
+              "version": "2.1.5",
               "from": "async@>=2.0.1 <3.0.0",
-              "resolved": "https://registry.npmjs.org/async/-/async-2.1.4.tgz",
+              "resolved": "https://registry.npmjs.org/async/-/async-2.1.5.tgz",
               "dev": true
             }
           }
@@ -2346,9 +2346,9 @@
           "dev": true,
           "dependencies": {
             "async": {
-              "version": "2.1.4",
+              "version": "2.1.5",
               "from": "async@>=2.0.1 <3.0.0",
-              "resolved": "https://registry.npmjs.org/async/-/async-2.1.4.tgz",
+              "resolved": "https://registry.npmjs.org/async/-/async-2.1.5.tgz",
               "dev": true
             }
           }
@@ -2366,9 +2366,9 @@
           "dev": true
         },
         "qs": {
-          "version": "6.1.0",
+          "version": "6.1.1",
           "from": "qs@>=6.1.0 <6.2.0",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.1.1.tgz",
           "dev": true
         },
         "readable-stream": {
@@ -3043,9 +3043,9 @@
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.8.tgz"
     },
     "ignore": {
-      "version": "3.2.2",
+      "version": "3.2.4",
       "from": "ignore@>=3.2.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.2.2.tgz"
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.2.4.tgz"
     },
     "imagemin": {
       "version": "5.2.2",
@@ -3597,9 +3597,9 @@
           "dev": true
         },
         "qs": {
-          "version": "6.3.0",
+          "version": "6.3.1",
           "from": "qs@>=6.3.0 <6.4.0",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.3.1.tgz",
           "dev": true
         },
         "request": {
@@ -3749,9 +3749,9 @@
       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz"
     },
     "loader-utils": {
-      "version": "0.2.16",
+      "version": "0.2.17",
       "from": "loader-utils@>=0.2.11 <0.3.0",
-      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.16.tgz"
+      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz"
     },
     "localtunnel": {
       "version": "1.8.2",
@@ -4696,9 +4696,9 @@
       "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-1.2.1.tgz"
     },
     "port-numbers": {
-      "version": "1.1.55",
+      "version": "1.1.56",
       "from": "port-numbers@>=1.1.53 <2.0.0",
-      "resolved": "https://registry.npmjs.org/port-numbers/-/port-numbers-1.1.55.tgz"
+      "resolved": "https://registry.npmjs.org/port-numbers/-/port-numbers-1.1.56.tgz"
     },
     "portscanner": {
       "version": "2.1.1",
@@ -4706,9 +4706,9 @@
       "resolved": "https://registry.npmjs.org/portscanner/-/portscanner-2.1.1.tgz"
     },
     "postcss": {
-      "version": "5.2.13",
+      "version": "5.2.15",
       "from": "postcss@>=5.0.4 <6.0.0",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.13.tgz",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.15.tgz",
       "dependencies": {
         "source-map": {
           "version": "0.5.6",
@@ -4893,18 +4893,10 @@
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz"
     },
     "rc": {
-      "version": "1.1.6",
+      "version": "1.1.7",
       "from": "rc@>=1.1.2 <2.0.0",
-      "resolved": "https://registry.npmjs.org/rc/-/rc-1.1.6.tgz",
-      "dev": true,
-      "dependencies": {
-        "strip-json-comments": {
-          "version": "1.0.4",
-          "from": "strip-json-comments@>=1.0.4 <1.1.0",
-          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
-          "dev": true
-        }
-      }
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.1.7.tgz",
+      "dev": true
     },
     "read-all-stream": {
       "version": "3.1.0",
@@ -4923,9 +4915,9 @@
       "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz"
     },
     "readable-stream": {
-      "version": "2.2.2",
+      "version": "2.2.3",
       "from": "readable-stream@>=2.0.2 <3.0.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz"
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.3.tgz"
     },
     "readdirp": {
       "version": "2.1.0",
@@ -5017,9 +5009,9 @@
       "resolved": "https://registry.npmjs.org/request/-/request-2.78.0.tgz",
       "dependencies": {
         "qs": {
-          "version": "6.3.0",
+          "version": "6.3.1",
           "from": "qs@>=6.3.0 <6.4.0",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.3.0.tgz"
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.3.1.tgz"
         }
       }
     },
@@ -5103,9 +5095,9 @@
       "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz"
     },
     "rimraf": {
-      "version": "2.5.4",
+      "version": "2.6.0",
       "from": "rimraf@>=2.2.8 <3.0.0",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.4.tgz"
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.0.tgz"
     },
     "ripemd160": {
       "version": "0.2.0",
@@ -5217,6 +5209,11 @@
       "from": "send@0.14.1",
       "resolved": "https://registry.npmjs.org/send/-/send-0.14.1.tgz",
       "dependencies": {
+        "etag": {
+          "version": "1.7.0",
+          "from": "etag@>=1.7.0 <1.8.0",
+          "resolved": "https://registry.npmjs.org/etag/-/etag-1.7.0.tgz"
+        },
         "mime": {
           "version": "1.3.4",
           "from": "mime@1.3.4",
@@ -6148,9 +6145,9 @@
       }
     },
     "url-parse": {
-      "version": "1.1.7",
+      "version": "1.1.8",
       "from": "url-parse@>=1.1.7 <2.0.0",
-      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.1.7.tgz"
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.1.8.tgz"
     },
     "url-parse-lax": {
       "version": "1.0.0",
@@ -6507,15 +6504,15 @@
       "dev": true
     },
     "whatwg-url": {
-      "version": "4.3.0",
+      "version": "4.5.0",
       "from": "whatwg-url@>=4.3.0 <5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-4.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-4.5.0.tgz",
       "dev": true
     },
     "when": {
-      "version": "3.7.7",
+      "version": "3.7.8",
       "from": "when@>=3.7.7 <4.0.0",
-      "resolved": "https://registry.npmjs.org/when/-/when-3.7.7.tgz"
+      "resolved": "https://registry.npmjs.org/when/-/when-3.7.8.tgz"
     },
     "which": {
       "version": "1.2.12",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,8 @@
     "gulp-mocha": "3.0.1",
     "is-reachable": "2.3.2",
     "gulp-util": "3.0.8",
-    "jquery": "1.11.3"
+    "jquery": "1.11.3",
+    "ustream-embedapi": "1.0.0"
   },
   "devDependencies": {
     "chai": "3.5.0",
@@ -70,8 +71,7 @@
   },
   "browser": {
     "es5-sham": "./node_modules/es5-shim/es5-sham.min.js",
-    "jquery": "./node_modules/jquery/dist/jquery.js",
-    "ustream-embedapi": "./node_modules/ustream-embedapi/dist/ustream-embedapi.min.js"
+    "jquery": "./node_modules/jquery/dist/jquery.js"
   },
   "scripts": {
     "test": "snyk test"

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "require-dir": "0.3.1",
     "webpack": "1.13.2",
     "webpack-stream": "3.2.0",
-
     "browser-sync": "2.18.7",
     "glob-all": "3.1.0",
     "gulp-imagemin": "3.1.1",
@@ -71,7 +70,8 @@
   },
   "browser": {
     "es5-sham": "./node_modules/es5-shim/es5-sham.min.js",
-    "jquery": "./node_modules/jquery/dist/jquery.js"
+    "jquery": "./node_modules/jquery/dist/jquery.js",
+    "ustream-embedapi": "./node_modules/ustream-embedapi/dist/ustream-embedapi.min.js"
   },
   "scripts": {
     "test": "snyk test"


### PR DESCRIPTION
Fixes for Ustream invalid certificate and Event copy changes


## Changes

- Modified `cfgov/jinja2/v1/events/_event-detail.html` to fix copy changes. 
- Modified `package.json` to add ustream embed module. 
- Modified `cfgov/unprocessed/css/video-player.less`  to fix hierarchy bug.
- Modified `gulp/config.js` to add reference to static file. Static ustream file will be hot loaded when needed.

## Testing

- run `npm install`
- run gulp build
- Modify the date on a future event to make it a live event.
- Enter `https://www.ustream.tv/embed/10414700?html5ui` as the live stream URL.
- Visit the `http://localhost:8000/about-us/events/`
- Select the event that should be live.
- Hit play and watch the event without any errors.



## Screenshots

<img width="299" alt="screen shot 2017-02-22 at 6 49 48 pm" src="https://cloud.githubusercontent.com/assets/1696212/23238403/c92fef2e-f92f-11e6-8d50-07b2e58c0601.png">

<img width="775" alt="screen shot 2017-02-22 at 6 51 27 pm" src="https://cloud.githubusercontent.com/assets/1696212/23238438/f327aa88-f92f-11e6-859f-ef683ca9048e.png">


## Notes

-

## Todos

-

## Checklist

* [ ] PR has an informative and human-readable title
* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated
* [ ] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
