### PR TITLE
Fix for Ustream redirect on winter-2017-consumer-advisory-board-meeting-washington-dc/

### DIFF
--- a/cfgov/jinja2/v1/_includes/macros/video-player.html
+++ b/cfgov/jinja2/v1/_includes/macros/video-player.html
@@ -59,9 +59,6 @@
     {% endif %}
     {% set button_pos   = options.button_pos or 'center' %}
     {% set is_flexible  = ( options.video.width or options.video.height ) is not defined %}
-    {% if request.url and 'winter-2017-consumer-advisory-board-meeting-washington-dc' in request.url %}
-        {% set video_url = 'https://www.ustream.tv/channel/cfpblive' %}
-    {% endif %}
     <div class="video-player
                 video-player__{{ video_player }}
                 {{ 'featured-content-module_visual' if is_flexible == false else '' }}"

--- a/cfgov/jinja2/v1/_includes/macros/video-player.html
+++ b/cfgov/jinja2/v1/_includes/macros/video-player.html
@@ -59,6 +59,9 @@
     {% endif %}
     {% set button_pos   = options.button_pos or 'center' %}
     {% set is_flexible  = ( options.video.width or options.video.height ) is not defined %}
+    {% if request.url and 'winter-2017-consumer-advisory-board-meeting-washington-dc' in request.url %}
+        {% set video_url = 'https://www.ustream.tv/channel/cfpblive' %}
+    {% endif %}
     <div class="video-player
                 video-player__{{ video_player }}
                 {{ 'featured-content-module_visual' if is_flexible == false else '' }}"
@@ -105,7 +108,6 @@
                  src="{{ image_url }}">
         </div>
     </div>
-
 {%- endmacro %}
 
 {% macro _buildParam( previousParam , param='') -%}

--- a/cfgov/unprocessed/js/modules/UStreamPlayer.js
+++ b/cfgov/unprocessed/js/modules/UStreamPlayer.js
@@ -50,7 +50,7 @@ var API = {
    * Action function used to play the Ustream video.
    */
   play: function( ) {
-    var winterIsComing = 'winter-2017-consumer-advisory-board-meeting-washington-dc';
+    var winterIsComing = '/events/winter-2017-consumer-advisory-board-meeting-washington-dc';
     if ( window.location.pathname.indexOf( winterIsComing > -1 ) ) {
       window.location = 'https://www.ustream.tv/channel/cfpblive ';
       return this;

--- a/cfgov/unprocessed/js/modules/UStreamPlayer.js
+++ b/cfgov/unprocessed/js/modules/UStreamPlayer.js
@@ -50,6 +50,12 @@ var API = {
    * Action function used to play the Ustream video.
    */
   play: function( ) {
+    var winterIsComing = 'winter-2017-consumer-advisory-board-meeting-washington-dc';
+    if ( window.location.pathname.indexOf( winterIsComing > -1 ) ) {
+      window.location = 'http://www.ustream.tv/channel/cfpblive ';
+      return this;
+    };
+
     this._super.play.call( this );
     if ( this.state.isPlayerInitialized ) {
       this.player.callMethod( 'play' );

--- a/cfgov/unprocessed/js/modules/UStreamPlayer.js
+++ b/cfgov/unprocessed/js/modules/UStreamPlayer.js
@@ -52,7 +52,7 @@ var API = {
   play: function( ) {
     var winterIsComing = 'winter-2017-consumer-advisory-board-meeting-washington-dc';
     if ( window.location.pathname.indexOf( winterIsComing > -1 ) ) {
-      window.location = 'http://www.ustream.tv/channel/cfpblive ';
+      window.location = 'https://www.ustream.tv/channel/cfpblive ';
       return this;
     };
 

--- a/cfgov/unprocessed/js/modules/util/email-popup-helpers.js
+++ b/cfgov/unprocessed/js/modules/util/email-popup-helpers.js
@@ -13,7 +13,7 @@ var FOREVER = 10000;
 
 function getFutureDate( days ) {
   var date = new Date();
-  return date.setTime( date.getTime() + ( days * 24 * 60 * 60 * 1000 ) )
+  return date.setTime( date.getTime() + ( days * 24 * 60 * 60 * 1000 ) );
 }
 
 function recordEmailPopupView() {


### PR DESCRIPTION
Due to https issues we need to write some code to redirect users to the Ustream page. 

## Changes

- Modified `cfgov/jinja2/v1/_includes/macros/video-player.html` and `cfgov/unprocessed/js/modules/UStreamPlayer.js` to redirect users to Ustream when the play button is clicked.

- Modified `cfgov/unprocessed/js/modules/util/email-popup-helpers.js` to fix linting error.


## Testing

- Visit `http://localhost:8000/about-us/events/winter-2017-consumer-advisory-board-meeting-washington-dc/`
- Click the play button
- You should be redirected to the CFPB Ustream channel.


## Notes

-

## Todos

-

## Checklist

* [ ] PR has an informative and human-readable title
* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated
* [ ] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
