### PR TITLE
Testing half-width related content within Full text width organism

### DIFF
--- a/cfgov/jinja2/v1/_includes/molecules/related-content.html
+++ b/cfgov/jinja2/v1/_includes/molecules/related-content.html
@@ -24,7 +24,9 @@
 
    ========================================================================== #}
 
-<div class="m-related-links">
+<div class="m-related-links
+            {{ ' m-related-links__half-width-test'
+               if flag_enabled(request, 'RELATED-LINKS-TEST') else '' }}">
     {% if value.heading %}
         <h2 class="header-slug">
             <span class="header-slug_inner">

--- a/cfgov/unprocessed/css/organisms/full-width-text-group.less
+++ b/cfgov/unprocessed/css/organisms/full-width-text-group.less
@@ -57,7 +57,7 @@
           }
 
           .m-related-links__half-width-test {
-              .grid_column(6);
+              width: 50%;
           }
       } );
 

--- a/cfgov/unprocessed/css/organisms/full-width-text-group.less
+++ b/cfgov/unprocessed/css/organisms/full-width-text-group.less
@@ -55,6 +55,10 @@
           .m-full-width-text + .m-inset__image {
               margin-top: unit( @grid_gutter-width / @base-font-size-px, em );
           }
+
+          .m-related-links__half-width-test {
+              .grid_column(6);
+          }
       } );
 
       .respond-to-max( @bp-xs-max, {


### PR DESCRIPTION
Testing half-width related content within Full text width organism

## Changes

- Modified `cfgov/jinja2/v1/_includes/molecules/related-content.html` to test `related link` molecule at half-width.
- Modified `cfgov/unprocessed/css/organisms/full-width-text-group.less` to add flag.

## Testing

- Enable the `RELATED-LINKS-TEST` flag.
- Edit an existing blog page.
- Add the full-width text organism to the page.
- Add the `related-content` molecule to the page. 
- Enter the necessary fields.
- Publish and visit the page. 
- Verify the `related-content` molecule is at half width.

## Screenshots
<img width="619" alt="screen shot 2017-03-01 at 11 28 44 am" src="https://cloud.githubusercontent.com/assets/1696212/23469682/40129e74-fe72-11e6-96c2-a02761992dcb.png">


## Notes

-

## Todos

-

## Checklist

* [ ] PR has an informative and human-readable title
* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated
* [ ] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
