### PR TITLE
Fix for spacing issue on image inset

### DIFF
--- a/cfgov/jinja2/v1/_includes/molecules/image-inset.html
+++ b/cfgov/jinja2/v1/_includes/molecules/image-inset.html
@@ -38,8 +38,7 @@
 
 {# Image sizes are doubled for retina displays. Images created via Wagtail
    are never stretched or upscaled and maintain their aspect ratio. #}
-{% set image_inset = image(value.image.upload, 'width-'
-                     ~ value.image_width * 2) %}
+{% set image_inset = image(value.image.upload, 'original') %}
 {% set image_mobile = image(value.image.upload, 'width-1200') %}
 <div class="m-inset
             m-inset__image

--- a/cfgov/unprocessed/css/organisms/full-width-text-group.less
+++ b/cfgov/unprocessed/css/organisms/full-width-text-group.less
@@ -52,8 +52,8 @@
               margin-left: 0;
           }
 
-          .m-full-width-text + .m-inset__image {
-              margin-top: unit( @grid_gutter-width / @base-font-size-px, em );
+          .m-full-width-text + .m-inset__image + .m-full-width-text {
+              margin-top: unit( @grid_gutter-width / 2 / @base-font-size-px, em );
           }
 
           .m-related-links__half-width-test {


### PR DESCRIPTION
Fix for spacing issue on image inset

## Changes

- Modified `cfgov/jinja2/v1/_includes/molecules/image-inset.html` to remove code that wasn't doing anything. 

- Modified `cfgov/unprocessed/css/organisms/full-width-text-group.less` to fix issue with margin spacing.


## Testing

- Add an `image-inset` molecule to the full-text width organism.
- Add `content` molecule above the image inset.
- Add a some some paragraphs to the `content` molecule just added.
- Add `content` molecule below the image inset.
- Add a some some paragraphs to the `content` molecule just added.
- Publish and verify the spacing is correct above the paragraph adjacent to the image.

## Screenshots

- 
<img width="918" alt="screen shot 2017-03-02 at 2 16 44 pm" src="https://cloud.githubusercontent.com/assets/1696212/23522957/e826fdc2-ff52-11e6-98aa-31a86e2da2d8.png">

## Checklist

* [ ] PR has an informative and human-readable title
* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated
* [ ] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
