### PR TITLE
Install wagtail-sharing from PyPI

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -43,5 +43,5 @@ unipath>=1.1,<=2.0
 vobject==0.9.1
 wagtail==1.8.1
 wagtail-flags==1.0.0
-git+https://github.com/cfpb/wagtail-sharing.git@0.2#egg=wagtail-sharing
+wagtail-sharing==0.3
 Wand==0.4.2


### PR DESCRIPTION
[wagtail-sharing](https://pypi.python.org/pypi/wagtail-sharing/0.3) is on PyPI! (with an ugly README, sadly...) We should install it from there instead of from a GitHub URL.

## Changes

- `requirements/base.txt` now includes `wagtail-sharing==0.3`.

## Todos

- Fix the README on PyPI.

## Checklist

* [X] PR has an informative and human-readable title
* [X] Changes are limited to a single goal (no scope creep)
* [X] Code can be automatically merged (no conflicts)
* [X] Passes all existing automated tests
* [X] Project documentation has been updated
* [X] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
