### PR TITLE
Remove unicode characters from Python source

### DIFF
--- a/cfgov/scripts/archive_events.py
+++ b/cfgov/scripts/archive_events.py
@@ -29,13 +29,13 @@ def run():
                         if event.end_dt < timezone.now():
                             if event.can_move_to(archived_events):
                                 event.move(archived_events, pos='last-child')
-                                logger.info(event.title + ' Event …archived')
+                                logger.info(event.title + ' archived')
         else:
-            logger.info('No events to archive found…')
+            logger.info('No events to archive found...')
     elif not event_page_exists:
-        logger.info('Events browse filterable page has not been created…')
+        logger.info('Events browse filterable page has not been created...')
     elif not archive_event_page_exists:
         logger.info('No Archived events Browse filterable page named '
-                    '\'Archive\' exist…')
+                    '\'Archive\' exist...')
     else:
-        logger.info('No events exist in the database…')
+        logger.info('No events exist in the database...')


### PR DESCRIPTION
Our recent effort to `flake8` everything introduced unicode `...` characters into the source file for `cfgov/scripts/archive_events.py`, which causes that script to fail when run using `manage.py runscript`.

This PR replaces those characters with regular `...` strings.

## Changes

- Convert unicode `...` characters to regular `...` strings.

## Testing

- `python cfgov/manage.py runscript archive_events`.

## Checklist

* [X] PR has an informative and human-readable title
* [X] Changes are limited to a single goal (no scope creep)
* [X] Code can be automatically merged (no conflicts)
* [X] Passes all existing automated tests
* [X] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
