### PR TITLE
Fix for alt tag text for the full width media molecule

### DIFF
--- a/cfgov/jinja2/v1/_includes/organisms/full-width-text.html
+++ b/cfgov/jinja2/v1/_includes/organisms/full-width-text.html
@@ -27,7 +27,9 @@
         {% elif 'media' in block.block_type %}
             <div class="m-full-width-media">
                 {% set media = image(block.value, 'original') %}
-                <img class="m-full-width-media_image" src="{{ media.url }}" alt="{{ media.alt }}">
+                <img class="m-full-width-media_image"
+                     src="{{ media.url }}"
+                     alt="{{ block.value.alt or media.alt }}">
             </div>
         {% elif block.block_type in ['quote', 'cta', 'related-links'] %}
             <div class="m-inset">


### PR DESCRIPTION
Fix for alt tag text for the full width media molecule


## Changes

- Modified `cfgov/jinja2/v1/_includes/organisms/full-width-text.html` to fix issue with using the image title instead of the image alt tag.

## Testing

- Create a browse page.
- Add a `full width text organism` to the page.
- Add the `media` module to the page.
- Add an image.
- Insert `Image title` as the title.
- Preview and inspect the image in your browsers console.
- The image alt tag should be `Image title`.
- Edit the page in Wagtail.
- Edit the image you inserted earlier.
- Enter `Image alt` in the alt field.
- Preview and inspect the image in your browsers console.
- The image alt tag should be `Image alt`.

## Notes

- I'll feature flag this if necessary.


## Todos

-

## Checklist

* [ ] PR has an informative and human-readable title
* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated
* [ ] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
