### PR TITLE
Bump wagtail-flags version to 1.0.1

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -42,6 +42,6 @@ tinys3==0.1.11
 unipath>=1.1,<=2.0
 vobject==0.9.1
 wagtail==1.8.1
-wagtail-flags==1.0.0
+wagtail-flags==1.0.1
 wagtail-sharing==0.3
 Wand==0.4.2


### PR DESCRIPTION
wagtail-flags 1.0.1 includes a fix for admin template inclusion. Bumping the version will fix our problems with our flags admin.
 
## Changes

- wagtail-flags to 1.0.1

## Checklist

* [ ] PR has an informative and human-readable title
* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated
* [ ] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
