### PR TITLE
Design fix for Email Signup on Blog

### DIFF
--- a/cfgov/unprocessed/css/enhancements/layout.less
+++ b/cfgov/unprocessed/css/enhancements/layout.less
@@ -207,6 +207,11 @@
     }
 }
 
+.content__2-1 .content_main .o-email-signup {
+    width: 100%;
+    max-width: 41.875rem;
+}
+
 /* topdoc
   name: EOF
   eof: true


### PR DESCRIPTION
Design fix for Email Signup on Blog

## Additions

## Changes
- Modified `cfgov/unprocessed/css/enhancements/layout.less`

## Testing

- Edit an existing blog page in Wagtail.
- Add an email signup organism to the blog. 
- Verify that the sign-up width doesn't exceed the 670px.

## Screenshots

<img width="817" alt="screen shot 2017-03-08 at 11 40 10 am" src="https://cloud.githubusercontent.com/assets/1696212/23713485/08c780d8-03f4-11e7-92f3-1b5614b2450d.png">

## Notes


## Todos

-

## Checklist

* [ ] PR has an informative and human-readable title
* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated
* [ ] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
