### PR TITLE
Convert pre-footer to atomic structure

### DIFF
--- a/cfgov/jinja2/v1/browse-basic/index.html
+++ b/cfgov/jinja2/v1/browse-basic/index.html
@@ -30,7 +30,7 @@
     {%- endfor %}
 
     {% if page.sidefoot %}
-        <aside class="prefooter">
+        <aside class="o-prefooter">
             {{ streamfield_sidefoot.render(page.sidefoot, half_width=true) }}
         </aside>
     {% endif %}

--- a/cfgov/jinja2/v1/events/index.html
+++ b/cfgov/jinja2/v1/events/index.html
@@ -30,7 +30,7 @@
     </section>
 
     <aside>
-        <div class="prefooter">
+        <div class="o-prefooter">
             <div class="content-l content-l__main">
                 <section class="u-mb20 content-l_col content-l_col-1-2">
                     <div class="u-mb30">

--- a/cfgov/jinja2/v1/newsroom/index.html
+++ b/cfgov/jinja2/v1/newsroom/index.html
@@ -34,7 +34,7 @@
             {{ render_block.render(block, loop.index) }}
         {% endif %}
     {% endfor %}
-    <aside class="prefooter">
+    <aside class="o-prefooter">
         {% if page.sidefoot %}
             {{ streamfield_sidefoot.render(page.sidefoot, half_width=true) }}
         {% endif %}

--- a/cfgov/jinja2/v1/newsroom/press-resources/index.html
+++ b/cfgov/jinja2/v1/newsroom/press-resources/index.html
@@ -196,7 +196,7 @@
 
     </section><!-- END .press-section.press-photos-bios -->
 
-    <aside class="prefooter">
+    <aside class="o-prefooter">
         <div class="content-l content-l__main">
             <section class="content-l_col content-l_col-1-2"
                      data-qa-hook="stay-informed-section">

--- a/cfgov/unprocessed/css/organisms/prefooter.less
+++ b/cfgov/unprocessed/css/organisms/prefooter.less
@@ -1,12 +1,14 @@
 // TODO: Investigate where this fits in the organisms wiki.
-//       Also, investigating prefixing classes as o-prefooter.
+//       Remove margin from this file as it doesn't fit within
+//       our atomic rules.
+
 /* topdoc
-  name: Pre-footer
+  name: Pre-footer organism
   family: cfgov-organisms
   patterns:
     - name: Default example
       markup: |
-        <div class="prefooter">
+        <div class="o-prefooter">
             <div class="block block__flush">
               <div class="m-related-posts"></div>
             </div>
@@ -18,14 +20,14 @@
         - |
           Structural cheat sheet:
           -----------------------
-          .prefooter
+          .o-prefooter
             .block.block__flush
             .block
   tags:
     - cfgov-organisms
 */
 
-.prefooter {
+.o-prefooter {
     .block();
 
     margin-right: unit( @grid_gutter-width / -2 / @base-font-size-px, em );
@@ -52,4 +54,3 @@
         padding-right: unit( @grid_gutter-width / @base-font-size-px, em);
     });
 }
-


### PR DESCRIPTION
Convert pre-footer to atomic structure

## Changes

- Modified files to convert them to the proper atomic structure. The pre footer currently sets it's own margin but I'll fix that at a later date.

## Testing
- Run `gulp styles`
- Visit `http://localhost:8000/about-us/payments-harmed-consumers/` and verify the pre-footer works as expected.

## Checklist

* [ ] PR has an informative and human-readable title
* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated
* [ ] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
