### PR TITLE
Removing Leadership Calendar code

### DIFF
--- a/cfgov/v1/util/util.py
+++ b/cfgov/v1/util/util.py
@@ -64,39 +64,6 @@ def get_secondary_nav_items(request, current_page):
         ], True
     # END TODO
 
-    # TODO: Remove this ASAP once the-bureau gets migrated to Wagtail
-    if page.slug == 'leadership-calendar':
-        BASE_URL = '/about-us/the-bureau'
-        return [{
-            'title': 'The Bureau',
-            'slug': 'the-bureau',
-            'url': '/the-bureau/',
-            'children': [
-                {
-                    'title': 'The Director',
-                    'url': BASE_URL + '/about-director/',
-                    'slug': 'about-director',
-                },
-                {
-                    'title': 'The Deputy Director',
-                    'url': BASE_URL + '/about-deputy-director/',
-                    'slug': 'about-deputy-director',
-                },
-                {
-                    'title': 'Bureau Structure',
-                    'url': BASE_URL + '/bureau-structure/',
-                    'slug': 'bureau-structure',
-                },
-                {
-                    'title': page.title,
-                    'url': get_page_state_url({}, page).replace(
-                        '/about-us', BASE_URL),
-                    'slug': page.slug,
-                }
-            ]
-        }], True
-    # END TODO
-
     pages = ([page] if page.secondary_nav_exclude_sibling_pages
              else page.get_appropriate_siblings(request.site.hostname))
 


### PR DESCRIPTION
Removing unneeded Leadership Calendar code


## Testing

- Restart your server
- Visit `http://localhost:8000/about-us/the-bureau/leadership-calendar/` and verify that the navigation items work.


## Checklist

* [ ] PR has an informative and human-readable title
* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated
* [ ] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
