### PR TITLE
Optionally enable Django Debug Toolbar for local development

### DIFF
--- a/cfgov/cfgov/settings/local.py
+++ b/cfgov/cfgov/settings/local.py
@@ -68,7 +68,7 @@ LOGGING = {
 }
 
 # Django Debug Toolbar
-if not os.environ.get('DISABLE_DEBUG_TOOLBAR'):
+if os.environ.get('ENABLE_DEBUG_TOOLBAR'):
     INSTALLED_APPS += ('debug_toolbar',)
 
     INTERNAL_IPS = ('127.0.0.1',)

--- a/cfgov/cfgov/settings/local.py
+++ b/cfgov/cfgov/settings/local.py
@@ -67,6 +67,17 @@ LOGGING = {
     }
 }
 
+# Django Debug Toolbar
+if not os.environ.get('DISABLE_DEBUG_TOOLBAR'):
+    INSTALLED_APPS += ('debug_toolbar',)
+
+    INTERNAL_IPS = ('127.0.0.1',)
+    MIDDLEWARE_CLASSES += ('debug_toolbar.middleware.DebugToolbarMiddleware',)
+
+    DEBUG_TOOLBAR_CONFIG = {
+        'SHOW_COLLAPSED': True,
+    }
+
 
 MIDDLEWARE_CLASSES += CSP_MIDDLEWARE_CLASSES
 CSP_REPORT_ONLY = True

--- a/cfgov/cfgov/urls.py
+++ b/cfgov/cfgov/urls.py
@@ -372,6 +372,12 @@ if settings.DEBUG:
             name='404')
     )
 
+    try:
+        import debug_toolbar
+        urlpatterns.append(url(r'^__debug__/', include(debug_toolbar.urls)))
+    except ImportError:
+        pass
+
 
 # Catch remaining URL patterns that did not match a route thus far.
 

--- a/docs/development-tips.md
+++ b/docs/development-tips.md
@@ -251,6 +251,20 @@ This will return documents that have the tag Students OR Finance, AND have an au
 If you need more control over your filter than that,
 enter it manually in the `cfgov/jinja2/v1/_queries/[filtername].json` file.
 
+### TIP: Debugging site performance
+
+When running locally it is possible to enable the
+[Django Debug Toolbar](https://django-debug-toolbar.readthedocs.io/en/stable/)
+by defining the `ENABLE_DEBUG_TOOLBAR` environment variable:
+
+```sh
+$ ENABLE_DEBUG_TOOLBAR=1 ./runserver.sh
+```
+
+This tool exposes various useful pieces of information about things like HTTP headers,
+Django settings, SQL queries, and template variables. Note that running with the toolbar on
+may have an impact on local server performance.
+
 ### TIP: Updating the documentation
 
 Our documentation is written as Markdown files and served in GitHub pages 

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -1,5 +1,6 @@
 -r base.txt
 
+django-debug-toolbar==1.7
 django-livereload==1.2
 django-sslserver==0.19
 tox==2.3.1


### PR DESCRIPTION
This PR adds the ability to enable [Django Debug Toolbar](https://django-debug-toolbar.readthedocs.io/en/stable/) for local development, which makes it easier to debug things like SQL queries, settings, template variables, and HTTP headers.

The toolbar is only supported when running locally using `cfgov.settings.local`, and only when the environment variable `ENABLE_DEBUG_TOOLBAR` is defined, e.g.

```sh
$ ENABLE_DEBUG_TOOLBAR=1 ./runserver.sh
```

~~Note that before using this for the first time on a new or restored database you will have to set up the required DB tables~~

## Additions

- Added settings for Django Debug Toolbar to `settings.cfgov.local`.
- Added documentation for Django Debug Toolbar to development manual.

## Screenshots

Homepage:

![image](https://cloud.githubusercontent.com/assets/654645/23809247/f5553268-059a-11e7-9d06-a26c7451a94c.png)

New documentation:

![image](https://cloud.githubusercontent.com/assets/654645/23809453/c354e32a-059b-11e7-9224-c50ce6575832.png)

## Checklist

* [X] PR has an informative and human-readable title
* [X] Changes are limited to a single goal (no scope creep)
* [X] Code can be automatically merged (no conflicts)
* [X] Passes all existing automated tests
* [X] Project documentation has been updated
* [X] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
