### PR TITLE
Reverts cfpb-chart-builder to v1.1.4

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -842,8 +842,8 @@
       "resolved": "https://registry.npmjs.org/cf-typography/-/cf-typography-4.1.0.tgz"
     },
     "cfpb-chart-builder": {
-      "version": "1.1.5",
-      "from": "cfpb-chart-builder@1.1.5"
+      "version": "1.1.4",
+      "from": "cfpb-chart-builder@1.1.4"
     },
     "chalk": {
       "version": "1.1.3",
@@ -1171,9 +1171,9 @@
       "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-2.0.0.tgz"
     },
     "debug": {
-      "version": "2.6.1",
+      "version": "2.6.2",
       "from": "debug@>=2.1.1 <3.0.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.1.tgz"
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.2.tgz"
     },
     "debug-fabulous": {
       "version": "0.0.4",
@@ -3760,6 +3760,11 @@
       "from": "pako@>=0.2.0 <0.3.0",
       "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz"
     },
+    "papaparse": {
+      "version": "4.1.2",
+      "from": "papaparse@4.1.2",
+      "resolved": "https://registry.npmjs.org/papaparse/-/papaparse-4.1.2.tgz"
+    },
     "parse-asn1": {
       "version": "5.0.0",
       "from": "parse-asn1@>=5.0.0 <6.0.0",
@@ -4717,9 +4722,9 @@
       "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.12.tgz"
     },
     "uglify-js": {
-      "version": "2.8.10",
+      "version": "2.8.11",
       "from": "uglify-js@>=2.7.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.10.tgz",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.11.tgz",
       "dependencies": {
         "cliui": {
           "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "banner-footer-webpack-plugin": "git://github.com/dtothefp/banner-footer-webpack-plugin.git",
     "browser-sync": "2.18.7",
     "capital-framework": "3.6.1",
-    "cfpb-chart-builder": "1.1.5",
+    "cfpb-chart-builder": "1.1.4",
     "del": "2.2.2",
     "es5-shim": "4.5.9",
     "glob-all": "3.1.0",


### PR DESCRIPTION
This commit reverts `cfpb-chart-builder` to version 1.1.4 and npm shrinkwraps it.

We aren't quite ready to go ahead with the data changes that go with version 1.1.5, so we're reverting it for now.

## Changes
- Reverts `cfpb-chart-builder` back to version 1.1.4

## Checklist

* [ ] PR has an informative and human-readable title
* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated
* [ ] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
