### PR TITLE
Updating CSS for the related links molecule with the full width organism

### DIFF
--- a/cfgov/jinja2/v1/_includes/molecules/related-content.html
+++ b/cfgov/jinja2/v1/_includes/molecules/related-content.html
@@ -24,9 +24,7 @@
 
    ========================================================================== #}
 
-<div class="m-related-links
-            {{ ' m-related-links__half-width-test'
-               if flag_enabled(request, 'RELATED-LINKS-TEST') else '' }}">
+<div class="m-related-links">
     {% if value.heading %}
         <h2 class="header-slug">
             <span class="header-slug_inner">

--- a/cfgov/unprocessed/css/organisms/full-width-text-group.less
+++ b/cfgov/unprocessed/css/organisms/full-width-text-group.less
@@ -24,6 +24,7 @@
 .o-full-width-text-group {
     overflow: auto;
 
+
       .m-inset {
           margin-top: unit( @grid_gutter-width / @base-font-size-px, em );
           margin-bottom: unit( @grid_gutter-width / @base-font-size-px, em );
@@ -31,6 +32,11 @@
           .respond-to-min( @bp-lg-min, {
               margin-right: unit( @grid_gutter-width / @base-font-size-px, em );
           } );
+      }
+
+      .m-related-links {
+          max-width: 41.875rem;
+          margin: unit( @grid_gutter-width / @base-font-size-px, em ) 0;
       }
 
       .respond-to-min( @bp-sm-min, {
@@ -57,10 +63,6 @@
           .m-inset__image +
           .m-full-width-text {
               margin-top: unit( @grid_gutter-width / 2 / @base-font-size-px, em );
-          }
-
-          .m-related-links__half-width-test {
-              width: 50%;
           }
       } );
 


### PR DESCRIPTION
Updating CSS for the related links molecule with the full width organism

Short description explaining the high-level reason for the pull request

## Additions

-

## Removals

-

## Changes

- Modified `cfgov/jinja2/v1/_includes/molecules/related-content.html` to remove the feature flag code.
- Modified `cfgov/unprocessed/css/organisms/full-width-text-group.less` to add margin to the related links molecule and cap the width;


## Testing

- Visit `http://localhost:8000/about-us/blog/buying-home-first-step-check-your-credit/` and observe the width.

## Screenshots
- <img width="828" alt="screen shot 2017-03-10 at 6 56 36 pm" src="https://cloud.githubusercontent.com/assets/1696212/23817722/52318f22-05c3-11e7-9033-5711feb3c62a.png">


## Notes

-

## Todos

-

## Checklist

* [ ] PR has an informative and human-readable title
* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated
* [ ] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
