### PR TITLE
Update mega menu links for older adults

### DIFF
--- a/cfgov/jinja2/v1/_includes/organisms/_vars-mega-menu.html
+++ b/cfgov/jinja2/v1/_includes/organisms/_vars-mega-menu.html
@@ -72,7 +72,6 @@
         ('Ask CFPB', '/askcfpb/', []),
         ('Tell Your Story', '/your-story/', []),
         ('Information for Students', '/students/', []),
-        ('Information for Older Americans', '/older-americans/', []),
         ('Information for Servicemembers & Veterans', '/servicemembers/', [])
     ),[
         ('Getting an Auto Loan', '/consumer-tools/auto-loans/', [(
@@ -99,14 +98,14 @@
     ('Educational Resources', '#', [(
         ('Your Money, Your Goals', '/your-money-your-goals/', []),
         ('Adult Financial Education', '/adult-financial-education/', []),
-        ('Youth Financial Education', '/youth-financial-education/', [])
+        ('Youth Financial Education', '/educational-resources/youth-financial-education/', [])
     ),(
         ('Resources for Libraries', '/library-resources/', []),
         ('Resources for Tax Preparers', '/tax-preparer-resources/', []),
-        ('Resources for Parents', '/money-as-you-grow/', [])
+        ('Resources for Parents', '/educational-resources/money-as-you-grow/', [])
     ),(
         ('Information for Economically Vulnerable Consumers', '/empowerment/', []),
-        ('Managing Someone Else’s Money', '/managing-someone-elses-money/', []),
+        ('Resources for Older Adults and Their Families', '/educational-resources/resources-for-older-adults/', []),
         ('Free Brochures', 'http://pueblo.gpo.gov/CFPBPubs/CFPBPubs.php', [])
     )]),
     ('Data & Research', '/data-research/', [(


### PR DESCRIPTION
Resources for Older Adults and Their Families (Educational Resources), which just launched, replaces both Information for Older Americans (Consumer Tools) and Managing Someone Else's Money (Educational Resources).

Overdue updates to the canonical URLs for Youth Financial Education and Resources for Parents (Money as You Grow) are coming along for the ride.

## Removals

- Link to Information for Older Americans in the Consumer Tools menu.

## Changes

- Link to Managing Someone Else's Money in the Educational Resources menu becomes Resources for Older Adults and Their Families

## Testing

- Pull, run server, open menu.

## Screenshots

![screen shot 2017-03-13 at 18 27 15](https://cloud.githubusercontent.com/assets/1044670/23877869/d3e4a668-081a-11e7-9380-9db5ac8fd5e4.png)

## Checklist

* [x] PR has an informative and human-readable title
* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices
* [x] Project documentation has been updated
* [x] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
