### PR TITLE
Hack for sub navigation mobile items being hidden

### DIFF
--- a/cfgov/unprocessed/css/organisms/secondary-navigation.less
+++ b/cfgov/unprocessed/css/organisms/secondary-navigation.less
@@ -134,10 +134,6 @@
                 margin-right: unit( @grid_gutter-width / 2 / @base-font-size-px, em);
 
                 border-top: 1px solid @gray-40;
-
-                li[data-nav-is-active="False"]{
-                    display: none;
-                }
             } );
         }
 


### PR DESCRIPTION
Removing code so the mobile sub navigations items show on mobile. This is a temporary fix that shouldn't ever be necessary.  This will also break existing logic surrounding which sub nav items show based on the requested URL / item slug.


## Screenshots
- 
<img width="393" alt="screen shot 2017-03-14 at 10 47 47 am" src="https://cloud.githubusercontent.com/assets/1696212/23906226/b9fd4cb2-08a3-11e7-8872-e63c434a4609.png">

 

## Notes

-

## Todos

-

## Checklist

* [ ] PR has an informative and human-readable title
* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated
* [ ] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
