### PR TITLE
Add CFPB Researchers link to megamenu

### DIFF
--- a/cfgov/jinja2/v1/_includes/organisms/_vars-mega-menu.html
+++ b/cfgov/jinja2/v1/_includes/organisms/_vars-mega-menu.html
@@ -110,14 +110,14 @@
     )]),
     ('Data & Research', '/data-research/', [(
         ('Research & Reports', '/data-research/research-reports/', []),
-        ('CFPB Research Conference', '/data-research/cfpb-research-conference/', []),
-        ('CFPB Researchers', '/data-research/cfpb-researchers/', [])
+        ('CFPB Research Conference', '/data-research/cfpb-research-conference/', [])
     ),(
         ('Consumer Complaint Database', '/data-research/consumer-complaints/', []),
         ('Mortgage Database (HMDA)', '/data-research/mortgage-data-hmda/', [])
     ),[
         ('Consumer Credit Trends', '/data-research/consumer-credit-trends/', []),
         ('Credit Card Surveys & Agreements', '/data-research/credit-card-data/', []),
+        ('CFPB Researchers', '/data-research/cfpb-researchers/', []),
     ]]),
     ('Policy & Compliance', '/policy-compliance/', [(
         ('Rulemaking', '/policy-compliance/rulemaking/', [(

--- a/cfgov/jinja2/v1/_includes/organisms/_vars-mega-menu.html
+++ b/cfgov/jinja2/v1/_includes/organisms/_vars-mega-menu.html
@@ -110,7 +110,8 @@
     )]),
     ('Data & Research', '/data-research/', [(
         ('Research & Reports', '/data-research/research-reports/', []),
-        ('CFPB Research Conference', '/data-research/cfpb-research-conference/', [])
+        ('CFPB Research Conference', '/data-research/cfpb-research-conference/', []),
+        ('CFPB Researchers', '/data-research/cfpb-researchers/', [])
     ),(
         ('Consumer Complaint Database', '/data-research/consumer-complaints/', []),
         ('Mortgage Database (HMDA)', '/data-research/mortgage-data-hmda/', [])


### PR DESCRIPTION
The PR adds a link to the megamenu for the CFPB Researchers filterable page.

Note: **the pages are not live yet.** Please hold on merging this PR until they are.

## Additions

- Link to CFPB Researchers in the Data & Research menu

## Testing

- Pull down this branch.
- Run the server.
- Open the megamenu, and look under the Data & Research vertical.

## Screenshots

![screen shot 2017-03-14 at 1 45 46 pm](https://cloud.githubusercontent.com/assets/1183435/23914535/9b0363e6-08bc-11e7-86e5-bde758149a8d.png)

## Checklist

* [x] PR has an informative and human-readable title
* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices
* [x] Project documentation has been updated
* [x] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
