### PR TITLE
Set a shorter TTL on filterable list pages

### DIFF
--- a/cfgov/v1/util/filterable_list.py
+++ b/cfgov/v1/util/filterable_list.py
@@ -5,8 +5,7 @@ from django.core.paginator import EmptyPage, PageNotAnInteger, Paginator
 from v1.forms import FilterableListForm
 from v1.models.base import CFGOVPage
 from v1.models.learn_page import AbstractFilterPage
-
-from ..util.util import get_secondary_nav_items
+from v1.util.util import get_secondary_nav_items
 
 logger = logging.getLogger(__name__)
 
@@ -116,3 +115,9 @@ class FilterableListMixin(object):
             return form_ids[0]
         else:
             return 0
+
+    def serve(self, request, *args, **kwargs):
+        """ Modify response header to set a shorter TTL in Akamai """
+        response = super(FilterableListMixin, self).serve(request)
+        response['Edge-Control'] = 'cache-maxage=10m'
+        return response


### PR DESCRIPTION
## Overview
- Currently we flush the entire site because we don't have a way to easily flush filterable pages on changes to one of their objects. Rather than invalidating the entire cache every time we publish or unpublish, it'd be great to simply lower the TTL to something reasonable (I propose 10 minutes in this PR) for pages for which we regularly need to refresh. 
- I think this allows us to move away from flushing the entire site upon publish/unpublish (PR here -- https://github.com/cfpb/cfgov-refresh/pull/2801), bearing in mind that there are other dynamic pages that might still require a manual trigger to flush the entire site (e.g. pages that live outside Wagtail, job listing pages and snippets, though for some of these we can also automate it)
## Related GHE issues
- GHE 704
- GHE 634
- GHE 550