### PR TITLE
Bump optional knowledgebase requirement to v2.2.9

### DIFF
--- a/requirements/optional-private.txt
+++ b/requirements/optional-private.txt
@@ -5,6 +5,6 @@
 git+https://private.repo/CFPB/agreement_database.git@v2.2.6#egg=agreement-database
 git+https://private.repo/CFPB/cfgov-selfregistration.git@v1.2#egg=selfregistration
 git+https://private.repo/CFPB/django-college-cost-comparison.git@v1.2.9#egg=comparisontool
-git+https://private.repo/CFPB/knowledgebase.git@2.2.8#egg=knowledgebase
+git+https://private.repo/CFPB/knowledgebase.git@2.2.9#egg=knowledgebase
 git+https://private.repo/CFPB/Picard.git@1.5.5#egg=picard
 git+https://private.repo/eregs/ip.git@1.0.3#egg=eregsip


### PR DESCRIPTION
This PR increases the optional knowledgebase requirement from version 2.2.8 to 2.2.9. This improves handling of improper POSTs to question rating forms.

## Changes

- Bump knowledgebase version in `requirements/optional-private.txt`.

## Testing

```sh
(cfgov-refresh) $ pip install git+https://private.repo/CFPB/knowledgebase.git@2.2.9#egg=knowledgebase
(cfgov-refresh) $ PYTHONPATH=. DJANGO_SETTINGS_MODULE=cfgov.settings.test_nomigrations python cfgov/manage.py test knowledgebase
Creating test database for alias 'default'...
applying migration wagtail.wagtailcore.migrations.0002_initial_data
applying migration wagtail.wagtailcore.migrations.0025_collection_initial_data
.................................................
----------------------------------------------------------------------
Ran 49 tests in 2.721s

OK
Destroying test database for alias 'default'...
```

## Checklist

* [X] PR has an informative and human-readable title
* [X] Changes are limited to a single goal (no scope creep)
* [X] Code can be automatically merged (no conflicts)
* [X] Passes all existing automated tests
* [X] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
