### PR TITLE
Add credit reporting item to megamenu

### DIFF
--- a/cfgov/jinja2/v1/_includes/organisms/_vars-mega-menu.html
+++ b/cfgov/jinja2/v1/_includes/organisms/_vars-mega-menu.html
@@ -83,17 +83,18 @@
         ('Paying for College', '/paying-for-college/', []),
         ('Owning a Home', '/owning-a-home/', []),
         ('Planning for Retirement', '/retirement/', []),
-        ('Sending Money Abroad', '/sending-money/', []),
+        ('Credit Reports & Scores', '/consumer-tools/credit-reports-and-scores/', []),
+        ('Debt Collection', '/consumer-tools/debt-collection/', []),
         ('Prepaid Cards', '/consumer-tools/prepaid-cards/', [(
             ('Choose the Right Card for Your Situation', '/consumer-tools/prepaid-cards/choose-the-right-card/', []),
             ('Know Your Rights', '/consumer-tools/prepaid-cards/know-your-rights/', []),
             ('Understand the Fees You Will Pay', '/consumer-tools/prepaid-cards/understand-fees/', [])
-        )]),
-        ('Debt Collection', '/consumer-tools/debt-collection/', [])
+        )])
     ],(
         ('Know Before You Owe Mortgages', '/know-before-you-owe/', []),
         ('Trouble Paying Your Mortgage?', '/mortgagehelp/', []),
-        ('Protections Against Discrimination', '/fair-lending/', [])
+        ('Protections Against Discrimination', '/fair-lending/', []),
+        ('Sending Money Abroad', '/sending-money/', [])
     )]),
     ('Educational Resources', '#', [(
         ('Your Money, Your Goals', '/your-money-your-goals/', []),


### PR DESCRIPTION
Adds `Credit Reports & Scores` item to megamenu
## Additions

- Adds `Credit Reports & Scores` item to megamenu

## Changes

- Alphabetize `Credit Reports & Scores`, `Debt Collection`, and `Prepaid Cards` items in second column under `Consumer Tools`
- Move `Sending Money Abroad` item to next column to balance column heights

## Testing

- Check out branch
- Verify that `Credit Reports & Scores`, `Debt Collection`, `Prepaid Cards`,  and `Sending Money Abroad` items all appear under Consumer Tools and work as expected

## Screenshots
<img width="1198" alt="screen shot 2017-03-15 at 1 25 04 pm" src="https://cloud.githubusercontent.com/assets/778171/23969286/21a4f34e-0983-11e7-89ff-6ffb2bb0c99a.png">


## Checklist

* [ ] PR has an informative and human-readable title
* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated
* [ ] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
