### PR TITLE
Updating Akamai invalidation

### DIFF
--- a/.env_SAMPLE
+++ b/.env_SAMPLE
@@ -36,9 +36,10 @@ export DJANGO_HTTP_PORT=8000
 #export EXTERNAL_LINK_CSS=<external_links_css_class_name>
 export ALLOW_ADMIN_URL=True
 #export ENABLE_AKAMAI_CACHE_PURGE=<set_to_enable_purging_akamai_cache>
-#export AKAMAI_USER=<akamai_username>
-#export AKAMAI_PASSWORD=<akamai_password>
-#export AKAMAI_OBJECT_ID=<akamai_object_id>
+#export AKAMAI_CLIENT_TOKEN=<akamai_client_token>
+#export AKAMAI_CLIENT_SECRET=<akamai_client_secret>
+#export AKAMAI_ACCESS_TOKEN=<akamai_access_token>
+#export AKAMAI_FAST_PURGE_URL=<akamai_fast_purge_url>
 #export AKAMAI_NOTIFY_EMAIL=<akamai_notify_email>
 #export AKAMAI_HOST=<akamai_hostname>
 

--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -483,11 +483,11 @@ REGSGOV_API_KEY = os.environ.get('REGSGOV_API_KEY')
 
 # Akamai
 ENABLE_AKAMAI_CACHE_PURGE = os.environ.get('ENABLE_AKAMAI_CACHE_PURGE', False)
-AKAMAI_PURGE_URL = 'https://api.ccu.akamai.com/ccu/v2/queues/default'
 if ENABLE_AKAMAI_CACHE_PURGE:
-    AKAMAI_USER = os.environ.get('AKAMAI_USER')
-    AKAMAI_PASSWORD = os.environ.get('AKAMAI_PASSWORD')
-    AKAMAI_OBJECT_ID = os.environ.get('AKAMAI_OBJECT_ID')
+    AKAMAI_CLIENT_TOKEN = os.environ.get('AKAMAI_CLIENT_TOKEN')
+    AKAMAI_CLIENT_SECRET = os.environ.get('AKAMAI_CLIENT_SECRET')
+    AKAMAI_ACCESS_TOKEN = os.environ.get('AKAMAI_ACCESS_TOKEN')
+    AKAMAI_FAST_PURGE_URL = os.environ.get('AKAMAI_FAST_PURGE_URL')
 
 # Staging site
 STAGING_HOSTNAME = os.environ.get('DJANGO_STAGING_HOSTNAME')

--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -39,6 +39,7 @@ INSTALLED_APPS = (
     'wagtail.wagtailusers',
     'wagtail.wagtailimages',
     'wagtail.wagtailembeds',
+    'wagtail.contrib.wagtailfrontendcache',
 #    'wagtail.wagtailsearch', # TODO: conflicts with haystack, will need to revisit.
     'wagtail.wagtailredirects',
     'wagtail.wagtailforms',
@@ -484,10 +485,16 @@ REGSGOV_API_KEY = os.environ.get('REGSGOV_API_KEY')
 # Akamai
 ENABLE_AKAMAI_CACHE_PURGE = os.environ.get('ENABLE_AKAMAI_CACHE_PURGE', False)
 if ENABLE_AKAMAI_CACHE_PURGE:
-    AKAMAI_CLIENT_TOKEN = os.environ.get('AKAMAI_CLIENT_TOKEN')
-    AKAMAI_CLIENT_SECRET = os.environ.get('AKAMAI_CLIENT_SECRET')
-    AKAMAI_ACCESS_TOKEN = os.environ.get('AKAMAI_ACCESS_TOKEN')
-    AKAMAI_FAST_PURGE_URL = os.environ.get('AKAMAI_FAST_PURGE_URL')
+    WAGTAILFRONTENDCACHE = {
+        'akamai': {
+            'BACKEND': 'v1.models.akamai_backend.AkamaiBackend',
+            'CLIENT_TOKEN': os.environ.get('AKAMAI_CLIENT_TOKEN'),
+            'CLIENT_SECRET': os.environ.get('AKAMAI_CLIENT_SECRET'),
+            'ACCESS_TOKEN': os.environ.get('AKAMAI_ACCESS_TOKEN'),
+            'FAST_PURGE_URL': os.environ.get('AKAMAI_FAST_PURGE_URL')
+        },
+}
+
 
 # Staging site
 STAGING_HOSTNAME = os.environ.get('DJANGO_STAGING_HOSTNAME')
@@ -549,3 +556,4 @@ CSP_CONNECT_SRC = ("'self'",
                    '*.tiles.mapbox.com',
                    'bam.nr-data.net',
                    'api.iperceptions.com')
+

--- a/cfgov/v1/management/commands/delete_page.py
+++ b/cfgov/v1/management/commands/delete_page.py
@@ -2,7 +2,6 @@ from django.core.exceptions import MultipleObjectsReturned
 from django.core.management.base import BaseCommand, CommandError
 
 from v1.models import CFGOVPage
-from v1.wagtail_hooks import flush_akamai
 
 
 class Command(BaseCommand):
@@ -36,7 +35,6 @@ class Command(BaseCommand):
             raise CommandError('Must supply a slug or an id')
         try:
             page_to_delete.delete()
-            flush_akamai()
 
         except Exception as e:
             self.stderr.write(str(e))

--- a/cfgov/v1/models/akamai_backend.py
+++ b/cfgov/v1/models/akamai_backend.py
@@ -1,0 +1,53 @@
+import json
+import logging
+import requests
+
+from akamai.edgegrid import EdgeGridAuth
+from wagtail.contrib.wagtailfrontendcache.backends import BaseBackend
+
+logger = logging.getLogger(__name__)
+
+
+class AkamaiBackend(BaseBackend):
+    def __init__(self, params):
+        self.client_token = params.pop('CLIENT_TOKEN')
+        self.client_secret = params.pop('CLIENT_SECRET')
+        self.access_token = params.pop('ACCESS_TOKEN')
+        self.fast_purge_url = params.pop('FAST_PURGE_URL')
+        if not all((
+            self.client_token,
+            self.client_secret,
+            self.access_token,
+            self.fast_purge_url
+        )):
+            raise ValueError(
+                'AKAMAI_CLIENT_TOKEN, AKAMAI_CLIENT_SECRET, '
+                'AKAMAI_ACCESS_TOKEN, AKAMAI_FAST_PURGE_URL '
+                'must be configured.'
+            )
+
+    def purge(self, url):
+        auth = EdgeGridAuth(
+            client_token=self.client_token,
+            client_secret=self.client_secret,
+            access_token=self.access_token
+        )
+        headers = {'content-type': 'application/json'}
+        payload = {
+            'action': 'invalidate',
+            'objects': [url]
+        }
+        resp = requests.post(
+            self.fast_purge_url,
+            headers=headers,
+            data=json.dumps(payload),
+            auth=auth
+        )
+        logger.info(
+            u'Attempted to invalidate page {url}, '
+            'got back response {message}'.format(
+                url=url,
+                message=resp.text
+            )
+        )
+        resp.raise_for_status()

--- a/cfgov/v1/models/base.py
+++ b/cfgov/v1/models/base.py
@@ -1,5 +1,8 @@
 import csv
 import json
+import logging
+import requests
+
 from collections import OrderedDict
 from cStringIO import StringIO
 from itertools import chain
@@ -33,6 +36,9 @@ from v1 import get_protected_url
 from v1.atomic_elements import molecules, organisms
 from v1.models.snippets import ReusableText, ReusableTextChooserBlock
 from v1.util import ref
+from v1.wagtail_hooks import get_akamai_credentials
+
+logger = logging.getLogger(__name__)
 
 
 class CFGOVAuthoredPages(TaggedItemBase):
@@ -216,6 +222,41 @@ class CFGOVPage(Page):
         # hit for that type.
         return {search_type: queryset for search_type, queryset in
                 related.items() if queryset}
+
+    def flush(self):
+        if not settings.ENABLE_AKAMAI_CACHE_PURGE:
+            logger.info(
+                'Page {slug} (id = {id}) was not invalidated because '
+                'ENABLE_AKAMAI_CACHE_PURGE is not set'.format(
+                    slug=self.slug,
+                    id=self.id
+                )
+            )
+            return
+        auth, fast_purge_url = get_akamai_credentials()
+        headers = {'content-type': 'application/json'}
+        payload = {
+            'action': 'invalidate',
+            'hostname': settings.WAGTAIL_SITE_NAME,
+            'objects': [
+                self.relative_url(self.get_site())
+            ]
+        }
+        resp = requests.post(
+            fast_purge_url,
+            headers=headers,
+            data=json.dumps(payload),
+            auth=auth
+        )
+        logger.info(
+            'Attempted to invalidate page {slug} (id = {id}), '
+            'got back response {message}'.format(
+                slug=self.slug,
+                id=self.id,
+                message=resp.text
+            )
+        )
+        resp.raise_for_status()
 
     def get_appropriate_page_version(self, request):
         # If we're on the production site, make sure the version of the page

--- a/cfgov/v1/signals.py
+++ b/cfgov/v1/signals.py
@@ -1,12 +1,10 @@
 import json
 from datetime import timedelta
-import logging
 
 from django.dispatch import Signal
 from django.utils import timezone
 from wagtail.wagtailcore.signals import page_published, page_unpublished
 
-logger = logging.getLogger(__name__)
 page_unshared = Signal(providing_args=['instance'])
 
 
@@ -70,14 +68,6 @@ def configure_page_and_revision(sender, **kwargs):
         page=page, is_sharing=False, is_live=True)
 
 
-def flush_page(sender, **kwargs):
-    flush = getattr(kwargs['instance'], 'flush', None)
-    if flush and callable(flush):
-        flush()
-
-
 page_unshared.connect(unshare_all_revisions)
 page_unpublished.connect(unpublish_all_revisions)
-page_unpublished.connect(flush_page)
 page_published.connect(configure_page_and_revision)
-page_published.connect(flush_page)

--- a/cfgov/v1/tests/models/test_akamai_backend.py
+++ b/cfgov/v1/tests/models/test_akamai_backend.py
@@ -1,0 +1,37 @@
+from django.test import TestCase
+
+from v1.models.akamai_backend import AkamaiBackend
+
+class TestAkamaiBackend(TestCase):
+    def test_no_credentials_raises(self):
+        credentials = {
+                'CLIENT_TOKEN': None,
+                'CLIENT_SECRET': None,
+                'ACCESS_TOKEN': None,
+                'FAST_PURGE_URL': None,
+        }
+        with self.assertRaises(ValueError):
+            AkamaiBackend(credentials)
+
+    def test_some_credentials_raises(self):
+        credentials = {
+                'CLIENT_TOKEN': 'some-arbitrary-token',
+                'CLIENT_SECRET': None,
+                'ACCESS_TOKEN': None,
+                'FAST_PURGE_URL': None,
+        }
+        with self.assertRaises(ValueError):
+            AkamaiBackend(credentials)
+
+    def test_all_credentials_get_set(self):
+        credentials = {
+                'CLIENT_TOKEN': 'token',
+                'CLIENT_SECRET': 'secret',
+                'ACCESS_TOKEN': 'access token',
+                'FAST_PURGE_URL': 'fast purge url',
+        }
+        akamai_backend = AkamaiBackend(credentials)
+        self.assertEquals(akamai_backend.client_token, 'token')
+        self.assertEquals(akamai_backend.client_secret, 'secret')
+        self.assertEquals(akamai_backend.access_token, 'access token')
+        self.assertEquals(akamai_backend.fast_purge_url, 'fast purge url')

--- a/cfgov/v1/tests/test_wagtail_hooks.py
+++ b/cfgov/v1/tests/test_wagtail_hooks.py
@@ -8,8 +8,7 @@ from akamai.edgegrid import EdgeGridAuth
 
 from v1.models.browse_page import BrowsePage
 from v1.wagtail_hooks import (check_permissions, configure_page_revision,
-                              form_module_handlers,
-                              get_akamai_credentials, share, share_the_page)
+                              form_module_handlers, share, share_the_page)
 
 
 class TestShareThePage(TestCase):
@@ -265,33 +264,3 @@ class TestFormModuleHandlers(TestCase):
         form_module_handlers(self.page, self.request, self.context)
         child.block.is_submitted.assert_called_with(self.request, 'name', 0)
 
-
-class TestGetAkamaiCredentials(TestCase):
-    def test_no_credentials_raises(self):
-        with self.settings(
-            AKAMAI_CLIENT_TOKEN=None,
-            AKAMAI_CLIENT_SECRET=None,
-            AKAMAI_ACCESS_TOKEN=None,
-            AKAMAI_FAST_PURGE_URL=None
-        ):
-            self.assertRaises(ValueError, get_akamai_credentials)
-
-    def test_some_credentials_raises(self):
-        with self.settings(
-            AKAMAI_CLIENT_TOKEN='some-arbitrary-token',
-            AKAMAI_CLIENT_SECRET=None,
-            AKAMAI_ACCESS_TOKEN=None,
-            AKAMAI_FAST_PURGE_URL=None
-        ):
-            self.assertRaises(ValueError, get_akamai_credentials)
-
-    def test_all_credentials_returns(self):
-        with self.settings(
-            AKAMAI_CLIENT_TOKEN='token',
-            AKAMAI_CLIENT_SECRET='secret',
-            AKAMAI_ACCESS_TOKEN='access token',
-            AKAMAI_FAST_PURGE_URL='fast purge url'
-        ):
-            auth, fast_purge_url = get_akamai_credentials()
-            self.assertEqual(fast_purge_url, 'fast purge url')
-            self.assertIsInstance(auth, EdgeGridAuth)

--- a/cfgov/v1/wagtail_hooks.py
+++ b/cfgov/v1/wagtail_hooks.py
@@ -17,8 +17,6 @@ from urlparse import urlsplit
 from v1.templatetags.share import v1page_permissions
 from v1.util import util
 
-from akamai.edgegrid import EdgeGridAuth
-
 
 logger = logging.getLogger(__name__)
 
@@ -124,24 +122,6 @@ def configure_page_revision(page, is_sharing, is_live):
     content_json['has_unshared_changes'] = not is_sharing and not is_live
     latest.content_json = json.dumps(content_json)
     latest.save()
-
-
-def get_akamai_credentials():
-    client_token = getattr(settings, 'AKAMAI_CLIENT_TOKEN', None)
-    client_secret = getattr(settings, 'AKAMAI_CLIENT_SECRET', None)
-    access_token = getattr(settings, 'AKAMAI_ACCESS_TOKEN', None)
-    fast_purge_url = getattr(settings, 'AKAMAI_FAST_PURGE_URL', None)
-    if not all((client_token, client_secret, access_token, fast_purge_url)):
-        raise ValueError(
-            'AKAMAI_CLIENT_TOKEN, AKAMAI_CLIENT_SECRET, AKAMAI_ACCESS_TOKEN,'
-            ' AKAMAI_FAST_PURGE_URL must be configured.'
-        )
-    auth = EdgeGridAuth(
-        client_token=client_token,
-        client_secret=client_secret,
-        access_token=access_token
-    )
-    return auth, fast_purge_url
 
 
 @hooks.register('register_permissions')

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -18,6 +18,7 @@ django-reversion==1.10.1
 django-storages==1.1.8
 django-tinymce==2.2.0
 django-treebeard==3.0
+edgegrid-python==1.0.10
 elasticsearch==1.6.0
 feedparser==5.2.1
 geocoder==1.12.0


### PR DESCRIPTION
### Overview
- Entire site will no longer be flushed when publishing/unpublishing, but the specific page will be
- Related: https://github.com/cfpb/cfgov-refresh/pull/2798
### Changes
- Uses Akamai's Fast Purge option (takes less than a minute!)
- Only invalidates the page being modified
- `flush` function now lives on Page model instead of in `wagtail_hooks.py`
- Removed the flush call from `unshare_all_revisions` and `unpublish_all_revisions` since we will be removing that code soon anyway (yay!), as well as `configure_page_and_revision` and instead hooked it up directly to the `page_published` and `page_unpublished` signals for clarity.
- Removed `should_flush` as this used to encapsulate more complex logic, and is now (and has been) a simple settings check

### TODO
- Immediate:
  - [ ] We'll need to ensure we make the appropriate changes to the variables in `ansible-consumer-finance/provisioning/group_vars`, and to the `ansible-consumer-finance-frontend/templates/configs/environment.json.j2` template file. (thanks @willbarton )
  - [ ] Test this on beta 
- Longer-term
  - [ ] Don't call `flush` on pages that are being published for the first time (Wagtail's frontendcache module doesn't take care of this)
  - [ ] `get_akamai_credentials` should probably not live in `wagtail_hooks.py` either, need to find a home for it 
  - [ ] Hook this into Wagtail's [frontendcache module](http://docs.wagtail.io/en/v1.9/reference/contrib/frontendcache.html) 