### PR TITLE
Fix for Related Links inset within full-text-width organsim

### DIFF
--- a/cfgov/jinja2/v1/_includes/organisms/full-width-text.html
+++ b/cfgov/jinja2/v1/_includes/organisms/full-width-text.html
@@ -31,7 +31,7 @@
                      src="{{ media.url }}"
                      alt="{{ block.value.alt or media.alt }}">
             </div>
-        {% elif block.block_type in ['quote', 'cta', 'related-links'] %}
+        {% elif block.block_type in ['quote', 'cta', 'related_links'] %}
             <div class="m-inset">
                 {{ block | safe }}
             </div>

--- a/cfgov/unprocessed/css/organisms/full-width-text-group.less
+++ b/cfgov/unprocessed/css/organisms/full-width-text-group.less
@@ -34,11 +34,6 @@
           } );
       }
 
-      .m-related-links {
-          max-width: 41.875rem;
-          margin: unit( @grid_gutter-width / @base-font-size-px, em ) 0;
-      }
-
       .respond-to-min( @bp-sm-min, {
           .m-inset {
               margin-left: unit( @grid_gutter-width / @base-font-size-px, em );


### PR DESCRIPTION
Fix for Related Links inset within full-text-width organism

## Changes

- Modified code to fix copy / paste error. 

## Screenshots
- 
<img width="451" alt="screen shot 2017-03-20 at 8 27 00 am" src="https://cloud.githubusercontent.com/assets/1696212/24099686/08428e62-0d47-11e7-8f26-42ab57140cd7.png">


## Checklist

* [ ] PR has an informative and human-readable title
* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated
* [ ] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
