### PR TITLE
Fix for margin-top when using the text inset

### DIFF
--- a/cfgov/jinja2/v1/_includes/organisms/full-width-text.html
+++ b/cfgov/jinja2/v1/_includes/organisms/full-width-text.html
@@ -32,7 +32,9 @@
                      alt="{{ block.value.alt or media.alt }}">
             </div>
         {% elif block.block_type in ['quote', 'cta', 'related_links'] %}
-            <div class="m-inset">
+            <div class="m-inset
+                    {{ 'm-inset__test'
+                       if flag_enabled(request, 'INSET_TEST') else '' }}">
                 {{ block | safe }}
             </div>
         {% else %}

--- a/cfgov/unprocessed/css/organisms/full-width-text-group.less
+++ b/cfgov/unprocessed/css/organisms/full-width-text-group.less
@@ -24,7 +24,6 @@
 .o-full-width-text-group {
     overflow: auto;
 
-
       .m-inset {
           margin-top: unit( @grid_gutter-width / @base-font-size-px, em );
           margin-bottom: unit( @grid_gutter-width / @base-font-size-px, em );
@@ -55,7 +54,14 @@
 
           .m-full-width-text + .m-inset__image,
           .m-full-width-text +
-          .m-inset +
+          .m-inset__image +
+          .m-full-width-text {
+              margin-top: unit( @grid_gutter-width / 2 / @base-font-size-px, em );
+          }
+
+          .m-full-width-text + .m-inset__test,
+          .m-full-width-text +
+          .m-inset__test +
           .m-full-width-text {
               margin-top: unit( @grid_gutter-width / 2 / @base-font-size-px, em );
           }

--- a/cfgov/unprocessed/css/organisms/full-width-text-group.less
+++ b/cfgov/unprocessed/css/organisms/full-width-text-group.less
@@ -55,7 +55,7 @@
 
           .m-full-width-text + .m-inset__image,
           .m-full-width-text +
-          .m-inset__image +
+          .m-inset +
           .m-full-width-text {
               margin-top: unit( @grid_gutter-width / 2 / @base-font-size-px, em );
           }


### PR DESCRIPTION
Fix for margin-top when using the text inset

## Changes

- Modified `cfgov/unprocessed/css/organisms/full-width-text-group.less` to fix spacing issue with the inset.

## Testing

- Run `gulp styles`
- Add feature flag named `INSET_TEST`
- Visit `http://localhost:8000/about-us/blog/buying-home-first-step-check-your-credit/`

## Screenshots

<img width="823" alt="screen shot 2017-03-21 at 1 30 27 pm" src="https://cloud.githubusercontent.com/assets/1696212/24161368/97148250-0e3a-11e7-8aae-9fc6a116f0c9.png">


## Checklist

* [ ] PR has an informative and human-readable title
* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated
* [ ] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
