### PR TITLE
Update frontend.sh to create npm-shrinkwrap.json

### DIFF
--- a/frontend.sh
+++ b/frontend.sh
@@ -15,7 +15,11 @@ init() {
   source cli-flag.sh 'Front end' $1
 
   NODE_DIR=node_modules
-  DEP_CHECKSUM=$(cat npm-shrinkwrap.json package.json | shasum -a 256)
+  if [ -f "npm-shrinkwrap.json" ]; then
+    DEP_CHECKSUM=$(cat npm-shrinkwrap.json package.json | shasum -a 256)
+  else
+    DEP_CHECKSUM=$(cat package.json | shasum -a 256)
+  fi
 
   echo "npm components directory: $NODE_DIR"
 }
@@ -74,7 +78,7 @@ install() {
 # $NODE_DIR so we know we're working with a clean slate of the
 # dependencies listed in package.json.
 clean_and_install() {
-  if [ ! -f $NODE_DIR/CHECKSUM ] || 
+  if [ ! -f $NODE_DIR/CHECKSUM ] ||
      [ "$DEP_CHECKSUM" != "$(cat $NODE_DIR/CHECKSUM)" ]; then
     clean
     install
@@ -96,6 +100,16 @@ build() {
   fi
 }
 
+shrinkwrap() {
+  if [ -f "npm-shrinkwrap.json" ]; then
+    echo 'Removing npm-shrinkwrap.json…'
+    rm npm-shrinkwrap.json
+  fi
+  clean_and_install
+  echo 'Shrinkwrapping…'
+  npm shrinkwrap
+}
+
 # Returns 1 if a global command-line program installed, else 0.
 # For example, echo "node: $(is_installed node)".
 is_installed() {
@@ -112,6 +126,9 @@ is_installed() {
 if [ "$1" == "init" ]; then
   init ""
   clean_and_install
+elif [ "$1" == "shrinkwrap" ]; then
+  init "production"
+  shrinkwrap
 elif [ "$1" == "build" ]; then
   build
 else

--- a/frontend.sh
+++ b/frontend.sh
@@ -70,7 +70,7 @@ install() {
   else
     npm install --production --loglevel warn --no-optional
   fi
-
+  npm prune
 }
 
 # Add a checksum file

--- a/frontend.sh
+++ b/frontend.sh
@@ -73,6 +73,11 @@ install() {
 
 }
 
+# Add a checksum file
+checksum() {
+  echo -n "$DEP_CHECKSUM" > $NODE_DIR/CHECKSUM
+}
+
 # If the node directory exists, $NODE_DIR/CHECKSUM exists, and
 # the contents DO NOT match the checksum of package.json, clear
 # $NODE_DIR so we know we're working with a clean slate of the
@@ -82,8 +87,7 @@ clean_and_install() {
      [ "$DEP_CHECKSUM" != "$(cat $NODE_DIR/CHECKSUM)" ]; then
     clean
     install
-    # Add a checksum file
-    echo -n "$DEP_CHECKSUM" > $NODE_DIR/CHECKSUM
+    checksum
   else
     echo 'Dependencies are up to date.'
   fi
@@ -105,9 +109,11 @@ shrinkwrap() {
     echo 'Removing npm-shrinkwrap.json…'
     rm npm-shrinkwrap.json
   fi
-  clean_and_install
+  clean
+  install
   echo 'Shrinkwrapping…'
   npm shrinkwrap
+  checksum
 }
 
 # Returns 1 if a global command-line program installed, else 0.


### PR DESCRIPTION
We have a list of steps we have to go through to update npm-shrinkwrap.json when we update a frontend dependency. This moves those steps to the frontend.sh script. The new process is:

1. Update the version in package.json
2. Run `./frontend.sh shrinkwrap`.

The second step will:

1. Clean up the existing shrinkwrap and node_modules
2. Run `npm install --production`
3. Run `npm shrinkwrap`
4. Add our dependency checksum file 

## Additions

- Add `frontend.sh shrinkwrap`

## Test this 

- Edit a depedency version number in package.json - downgrade `cfpb-chart-builder` to 1.1.4, for example
- Run `./frontend.sh shrinkwrap`

## Checklist

* [x] PR has an informative and human-readable title
* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated
* [ ] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
