### PR TITLE
Removing jQuery CDN from base.html

### DIFF
--- a/cfgov/jinja2/v1/_layouts/base.html
+++ b/cfgov/jinja2/v1/_layouts/base.html
@@ -156,10 +156,7 @@
              Ideally GTM would handle its own dependency management
              and initializing jQuery could be moved to the footer. #}
 
-    <script src="//ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
-    <script>if (!window.jQuery) { document.write('<script src="{{ static('js/jquery.min.js') }}"><\/script>'); }
-    </script>
-
+    <script src="{{ static('js/jquery.min.js') }}" ></script>
 </head>
 
 <body>


### PR DESCRIPTION
Removing jQuery CDN from base.html


## Changes

- Removing jQuery CDN from `base.html`.

## Testing

- Visit `http://localhost:8000/`
- View the page source.
- Click on the link script and verify that it loaded correctly.


## Checklist

* [ ] PR has an informative and human-readable title
* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated
* [ ] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
