### PR TITLE
Fix bug report link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,9 +58,7 @@ mkdocs serve
 Use the [issue tracker](https://github.com/cfpb/cfgov-refresh/issues) to follow the
 development conversation.
 If you find a bug not listed in the issue tracker,
-please [file a bug report](https://github.com/cfpb/cfgov-refresh/issues/new?body=
-%23%23%20URL%0D%0D%0D%23%23%20Actual%20Behavior%0D%0D%0D%23%23%20Expected%20Behavior
-%0D%0D%0D%23%23%20Steps%20to%20Reproduce%0D%0D%0D%23%23%20Screenshot&labels=bug).
+please [file a bug report](https://github.com/cfpb/cfgov-refresh/issues/new).
 
 
 ## Getting involved


### PR DESCRIPTION
This PR fixes the project README to properly link to where contributors [can file a new bug report](https://github.com/cfpb/cfgov-refresh/issues/new).

## Changes

- Fix bug report link in README.

## Testing

- Click the link in the README.

## Notes

- Thanks to @willbarton for noticing this!

## Checklist

* [X] PR has an informative and human-readable title
* [X] Changes are limited to a single goal (no scope creep)
* [X] Code can be automatically merged (no conflicts)
* [X] Passes all existing automated tests
* [X] Project documentation has been updated
* [X] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
