### PR TITLE
Adding redirect for Ustream Live event

### DIFF
--- a/cfgov/unprocessed/js/modules/UStreamPlayer.js
+++ b/cfgov/unprocessed/js/modules/UStreamPlayer.js
@@ -48,18 +48,12 @@ var API = {
 
   /**
    * Action function used to play the Ustream video.
+   * @returns {UStreamPlayer} An instance.
    */
   play: function( ) {
     // TODO: Remove this code when the Ustream https issue is resolved.
     window.location = 'https://www.ustream.tv/channel/cfpblive';
     return this;
-
-    this._super.play.call( this );
-    if ( this.state.isPlayerInitialized ) {
-      this.player.callMethod( 'play' );
-    } else {
-      this.initPlayer();
-    }
   },
 
   /**

--- a/cfgov/unprocessed/js/modules/UStreamPlayer.js
+++ b/cfgov/unprocessed/js/modules/UStreamPlayer.js
@@ -50,6 +50,10 @@ var API = {
    * Action function used to play the Ustream video.
    */
   play: function( ) {
+    // TODO: Remove this code when the Ustream https issue is resolved.
+    window.location = 'https://www.ustream.tv/channel/cfpblive';
+    return this;
+
     this._super.play.call( this );
     if ( this.state.isPlayerInitialized ) {
       this.player.callMethod( 'play' );


### PR DESCRIPTION
Adding redirect for Ustream Live event


## Changes

- Modify `cfgov/unprocessed/js/modules/UStreamPlayer.js` to add redirect to Ustream for live events.

## Testing

- Create a live event via Wagtail.
- View the live event on the site.
- Click the play button; you should be redirected to Ustream.

## Screenshots


## Notes

- This redirect will be in place until we have a permanent https solution for the live events.

## Checklist

* [ ] PR has an informative and human-readable title
* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated
* [ ] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
