### PR TITLE
Capping input width within the email signup organism

### DIFF
--- a/cfgov/unprocessed/css/enhancements/layout.less
+++ b/cfgov/unprocessed/css/enhancements/layout.less
@@ -210,6 +210,13 @@
 .content__2-1 .content_main .o-email-signup {
     width: 100%;
     max-width: 41.875rem;
+
+    .respond-to-min( @bp-sm-min, {
+
+        .m-form-field-with-button_field {
+            max-width: unit( 370px / @base-font-size-px, rem );
+        }
+    } )
 }
 
 /* topdoc


### PR DESCRIPTION
Capping input width within the email signup organism

## Changes

- Modified `cfgov/unprocessed/css/enhancements/layout.less` to limit the width of the email signup organism. 

## Testing

- Add an email signup organism to the blog
- Resize your browser ensure the width is limited to `670px` until `601px`.


## Screenshots

<img width="815" alt="screen shot 2017-03-28 at 8 54 31 am" src="https://cloud.githubusercontent.com/assets/1696212/24405817/33381efe-1394-11e7-80d7-549ccdc5d61b.png">


## Checklist

* [ ] PR has an informative and human-readable title
* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated
* [ ] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
