### PR TITLE
Switch to using Django's date filter instead of sheerlike

### DIFF
--- a/cfgov/jinja2/v1/_includes/macros/util/format/datetime.html
+++ b/cfgov/jinja2/v1/_includes/macros/util/format/datetime.html
@@ -19,11 +19,7 @@
    ========================================================================== #}
 
 {% macro format_time(datetime, timezone=none) %}
-    {% if timezone %}
-        {{- datetime | date('%I:%M %p %Z', timezone) -}}
-    {% else %}
-        {{- datetime | date('%I:%M %p') -}}
-    {% endif %}
+    {{- datetime | date('%I:%M %p %Z') -}}
 {% endmacro %}
 
 

--- a/cfgov/v1/__init__.py
+++ b/cfgov/v1/__init__.py
@@ -4,18 +4,23 @@ import os
 import re
 from urlparse import urlparse, parse_qs
 
-from django.contrib.staticfiles.storage import staticfiles_storage
-from django.template.defaultfilters import pluralize, slugify, linebreaksbr
-from django.utils.module_loading import import_string
-from django.contrib import messages
 from django.conf import settings
+from django.contrib import messages
+from django.contrib.staticfiles.storage import staticfiles_storage
 from django.core.urlresolvers import reverse
+from django.template.defaultfilters import (
+    date,
+    linebreaksbr,
+    pluralize,
+    slugify,
+)
+from django.utils.module_loading import import_string
 
 from jinja2 import contextfunction, Markup
 from sheerlike import environment as sheerlike_environment
 from compressor.contrib.jinja2ext import CompressorExtension
 from flags.template_functions import flag_enabled, flag_disabled
-from .util.util import get_unique_id
+from v1.util.util import get_unique_id
 
 from wagtail.wagtailcore.rich_text import expand_db_html, RichText
 from bs4 import BeautifulSoup, NavigableString


### PR DESCRIPTION
A side effect [our recent effort to remove the custom sharing code](https://github.com/cfpb/cfgov-refresh/pull/2827/commits/26e53bdd4ad786436e4457d54243323099263d85#diff-8e8a3e28d46ee12516bea4f5b50bf5a4L220) is that event starting times were showing up in UTC:

![image](https://cloud.githubusercontent.com/assets/10562538/24878498/5d9924a0-1e01-11e7-8ee2-b0138bb48c9e.png)

This is because the `get_appropriate_page_version()` method that was removed hide a quirk of timezone handling: By always getting the latest page revision from JSON and then converting it to a Wagtail Page, it was converting the UTC datetime to the configured `settings.TIME_ZONE`. When that was removed, we're left with UTC. 

Additionally, our `date` filter in Jinja2 templates was not Django's `date` filter, but our own [custom date filter from sheerlike](https://github.com/cfpb/cfgov-refresh/blob/master/cfgov/sheerlike/templates.py#L19). The sheerlike `get_date_string()` doesn't do any special timezone handling, and doesn't check `settings.TIME_ZONE` but relies on a timezone being passed in.

This PR replaces the sheerlike `date` in the Jinja2 environment with Django's `date`. Because of this, the `timezone` parameter will be ignored.

This is a quick fix for the upcoming live event. We *must* go back and revisit our date/timezone handling in templates more generally.

With this change we have the desired outcome on the event:

![image](https://cloud.githubusercontent.com/assets/10562538/24878632/eb09482e-1e01-11e7-843a-7c1bdf4f744b.png)


## Changes

- Replace sheerlike's `date` filter with Django's `date` filter.

## Checklist

* [ ] PR has an informative and human-readable title
* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated
* [ ] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
