### PR TITLE
Refactor datetime formatting to use Django's localtime

### DIFF
--- a/cfgov/jinja2/v1/_includes/macros/time.html
+++ b/cfgov/jinja2/v1/_includes/macros/time.html
@@ -20,8 +20,7 @@
    ========================================================================== #}
 
 {% macro render(datetime,
-                show_value_for={'date':true, 'time':true, 'timezone':true},
-                timezone=none) %}
+                show_value_for={'date':true, 'time':true, 'timezone':true}) %}
 <span class="datetime">
     {% if show_value_for.date == true  %}
     <time class="datetime_date" datetime="{{ dt.format_datetime(datetime) }}">
@@ -36,7 +35,7 @@
     {% if show_value_for.time == true %}
     <time class="datetime_time" datetime="{{ dt.format_datetime(datetime) }}">
         {% if show_value_for.timezone == true %}
-        {{ dt.format_time(datetime, timezone) }}
+        {{ dt.format_time(localtime(datetime), show_timezone=true) }}
         {% else %}
         {{ dt.format_time(datetime) }}
         {% endif %}

--- a/cfgov/jinja2/v1/_includes/macros/util/format/datetime.html
+++ b/cfgov/jinja2/v1/_includes/macros/util/format/datetime.html
@@ -18,8 +18,8 @@
 
    ========================================================================== #}
 
-{% macro format_time(datetime, timezone=none) %}
-    {% if timezone %}
+{% macro format_time(datetime, show_timezone=false) %}
+    {% if show_timezone %}
         {{- datetime | date('%I:%M %p %Z', timezone) -}}
     {% else %}
         {{- datetime | date('%I:%M %p') -}}

--- a/cfgov/jinja2/v1/events/_event-detail.html
+++ b/cfgov/jinja2/v1/events/_event-detail.html
@@ -41,10 +41,7 @@
                       <span class="event-meta_description event-meta_description__block">
                           Video link available:
                       </span>
-                      {{ time.render(
-                          page.live_stream_date,
-                          timezone=page.live_stream_date.tzinfo | string
-                      ) }}
+                      {{ time.render(page.live_stream_date) }}
                   </p>
                 </div>
             </div>

--- a/cfgov/jinja2/v1/events/_macros.html
+++ b/cfgov/jinja2/v1/events/_macros.html
@@ -110,10 +110,7 @@
                 {% else %}
                     {% import 'macros/time.html' as time %}
                     {% if event.start_dt %}
-                        {{ time.render(
-                            event.start_dt,
-                            timezone=event.start_dt.tzinfo | string
-                        ) }}
+                        {{ time.render(event.start_dt) }}
                     {% endif %}
                 {% endif %}
                 </div>

--- a/cfgov/v1/__init__.py
+++ b/cfgov/v1/__init__.py
@@ -4,18 +4,23 @@ import os
 import re
 from urlparse import urlparse, parse_qs
 
-from django.contrib.staticfiles.storage import staticfiles_storage
-from django.template.defaultfilters import pluralize, slugify, linebreaksbr
-from django.utils.module_loading import import_string
-from django.contrib import messages
 from django.conf import settings
+from django.contrib import messages
+from django.contrib.staticfiles.storage import staticfiles_storage
 from django.core.urlresolvers import reverse
+from django.template.defaultfilters import (
+    linebreaksbr,
+    pluralize,
+    slugify,
+)
+from django.utils.module_loading import import_string
+from django.utils.timezone import template_localtime
 
 from jinja2 import contextfunction, Markup
 from sheerlike import environment as sheerlike_environment
 from compressor.contrib.jinja2ext import CompressorExtension
 from flags.template_functions import flag_enabled, flag_disabled
-from .util.util import get_unique_id
+from v1.util.util import get_unique_id
 
 from wagtail.wagtailcore.rich_text import expand_db_html, RichText
 from bs4 import BeautifulSoup, NavigableString
@@ -58,10 +63,12 @@ def environment(**options):
         'get_protected_url': get_protected_url,
         'get_latest_activities': get_latest_activities,
         'get_snippets': get_snippets,
+        'localtime': template_localtime,
     })
 
     env.filters.update({
         'linebreaksbr': linebreaksbr,
+        'localtime': template_localtime,
         'pluralize': pluralize,
         'slugify': slugify,
     })


### PR DESCRIPTION
TLDR: This PR replaces adds Django's `localtime` template tag/filter to our Jinja2 environment and then refactors the `time.render()` and `datetime.format_time()` macros to use `localtime` for timezone handling and changes everywhere that `time.render()` was called with a separate timezone. This should maintain the existing expectations of rendering.

Longer:

A side effect [our recent effort to remove the custom sharing code](https://github.com/cfpb/cfgov-refresh/pull/2827/commits/26e53bdd4ad786436e4457d54243323099263d85#diff-8e8a3e28d46ee12516bea4f5b50bf5a4L220) is that event starting times were showing up in UTC:

![image](https://cloud.githubusercontent.com/assets/10562538/24878498/5d9924a0-1e01-11e7-8ee2-b0138bb48c9e.png)

This is because the `get_appropriate_page_version()` method that was removed hide a quirk of timezone handling: By always getting the latest page revision from JSON and then converting it to a Wagtail Page, it was converting the UTC datetime to the configured `settings.TIME_ZONE`. When that was removed, we're left with UTC. 

Additionally, our `date` filter in Jinja2 templates was not Django's `date` filter, but our own [custom date filter from sheerlike](https://github.com/cfpb/cfgov-refresh/blob/master/cfgov/sheerlike/templates.py#L19). The sheerlike `get_date_string()` doesn't do any special timezone handling, and doesn't check `settings.TIME_ZONE` but relies on a timezone being passed in.

With this change we have the desired outcome on the event:

![image](https://cloud.githubusercontent.com/assets/10562538/24878632/eb09482e-1e01-11e7-843a-7c1bdf4f744b.png)

## Changes

- Replace sheerlike's `date` filter with Django's `date` filter.

## Checklist

* [ ] PR has an informative and human-readable title
* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated
* [ ] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
