### PR TITLE
Add page models to implement category-based pages

### DIFF
--- a/cfgov/ask_cfpb/migrations/0005_add_category_pages.py
+++ b/cfgov/ask_cfpb/migrations/0005_add_category_pages.py
@@ -1,0 +1,79 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import wagtail.wagtailcore.fields
+import django.db.models.deletion
+import v1.util.ref
+import v1.feeds
+import wagtail.wagtailcore.blocks
+import v1.util.filterable_list
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('v1', '0060_feedback_language'),
+        ('ask_cfpb', '0004_answerpage_content'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='AnswerCategoryPage',
+            fields=[
+                ('cfgovpage_ptr', models.OneToOneField(parent_link=True, auto_created=True, primary_key=True, serialize=False, to='v1.CFGOVPage')),
+                ('content', wagtail.wagtailcore.fields.StreamField([('filter_controls', wagtail.wagtailcore.blocks.StructBlock([(b'label', wagtail.wagtailcore.blocks.CharBlock(required=False)), (b'is_bordered', wagtail.wagtailcore.blocks.BooleanBlock(required=False)), (b'is_midtone', wagtail.wagtailcore.blocks.BooleanBlock(required=False)), (b'is_expanded', wagtail.wagtailcore.blocks.BooleanBlock(required=False)), (b'form_type', wagtail.wagtailcore.blocks.ChoiceBlock(default=b'filterable-list', choices=[(b'filterable-list', b'Filterable List'), (b'pdf-generator', b'PDF Generator')])), (b'title', wagtail.wagtailcore.blocks.BooleanBlock(default=True, required=False, label=b'Filter Title')), (b'post_date_description', wagtail.wagtailcore.blocks.CharBlock(default=b'Published')), (b'categories', wagtail.wagtailcore.blocks.StructBlock([(b'filter_category', wagtail.wagtailcore.blocks.BooleanBlock(default=True, required=False)), (b'show_preview_categories', wagtail.wagtailcore.blocks.BooleanBlock(default=True, required=False)), (b'page_type', wagtail.wagtailcore.blocks.ChoiceBlock(required=False, choices=v1.util.ref.filterable_list_page_types))])), (b'topics', wagtail.wagtailcore.blocks.BooleanBlock(default=True, required=False, label=b'Filter Topics')), (b'authors', wagtail.wagtailcore.blocks.BooleanBlock(default=True, required=False, label=b'Filter Authors')), (b'date_range', wagtail.wagtailcore.blocks.BooleanBlock(default=True, required=False, label=b'Filter Date Range')), (b'output_5050', wagtail.wagtailcore.blocks.BooleanBlock(default=False, required=False, label=b'Render preview items as 50-50s')), (b'should_link_image', wagtail.wagtailcore.blocks.BooleanBlock(help_text=b'Add links to post preview images in filterable list results', default=False, required=False))]))], null=True)),
+            ],
+            options={
+                'abstract': False,
+            },
+            bases=(v1.feeds.FilterableFeedPageMixin, v1.util.filterable_list.FilterableListMixin, 'v1.cfgovpage'),
+        ),
+        migrations.CreateModel(
+            name='AnswerLandingPage',
+            fields=[
+                ('landingpage_ptr', models.OneToOneField(parent_link=True, auto_created=True, primary_key=True, serialize=False, to='v1.LandingPage')),
+            ],
+            options={
+                'abstract': False,
+            },
+            bases=('v1.landingpage',),
+        ),
+        migrations.AlterModelOptions(
+            name='subcategory',
+            options={'ordering': ['weight'], 'verbose_name_plural': 'Subcategories'},
+        ),
+        migrations.RenameField(
+            model_name='answer',
+            old_name='tagging',
+            new_name='search_tags',
+        ),
+        migrations.RemoveField(
+            model_name='category',
+            name='featured_questions',
+        ),
+        migrations.RemoveField(
+            model_name='subcategory',
+            name='featured',
+        ),
+        migrations.AddField(
+            model_name='answer',
+            name='featured',
+            field=models.BooleanField(default=False, help_text='Makes the answer available to cards on the landing page'),
+        ),
+        migrations.AddField(
+            model_name='answer',
+            name='featured_rank',
+            field=models.IntegerField(null=True, blank=True),
+        ),
+        migrations.AlterField(
+            model_name='subcategory',
+            name='parent',
+            field=models.ForeignKey(related_name='subcategories', default=None, blank=True, to='ask_cfpb.Category', null=True),
+        ),
+        migrations.AddField(
+            model_name='answercategorypage',
+            name='ask_category',
+            field=models.ForeignKey(related_name='category_page', on_delete=django.db.models.deletion.PROTECT, blank=True, to='ask_cfpb.Category', null=True),
+        ),
+    ]

--- a/cfgov/ask_cfpb/models/django.py
+++ b/cfgov/ask_cfpb/models/django.py
@@ -163,13 +163,6 @@ class Answer(models.Model):
     def spanish_page(self):
         return self.answer_pages.filter(language='es').first()
 
-    @property
-    def available_subcategories(self):
-        subcats = []
-        for parent in self.category.all():
-            subcats += list(parent.subcategories.all())
-        return subcats
-
     panels = [
         MultiFieldPanel([
             FieldRowPanel([

--- a/cfgov/ask_cfpb/models/pages.py
+++ b/cfgov/ask_cfpb/models/pages.py
@@ -1,5 +1,4 @@
 from __future__ import absolute_import, unicode_literals
-# import collections
 
 from django.utils import timezone
 from django.db import models
@@ -17,7 +16,68 @@ from wagtail.wagtailsearch import index
 from wagtail.wagtailcore.fields import StreamField
 
 from v1 import blocks as v1_blocks
-from v1.models import CFGOVPage
+from v1.atomic_elements.organisms import FilterControls
+from v1.feeds import FilterableFeedPageMixin
+from v1.models import CFGOVPage, LandingPage
+from v1.util.filterable_list import FilterableListMixin
+
+
+class AnswerLandingPage(LandingPage):
+    """
+    Page type for Ask CFPB's landing page.
+    """
+    content_panels = [
+        StreamFieldPanel('header'),
+        StreamFieldPanel('content'),
+    ]
+    edit_handler = TabbedInterface([
+        ObjectList(content_panels, heading='Content'),
+        ObjectList(LandingPage.settings_panels, heading='Configuration'),
+    ])
+    objects = PageManager()
+    template = 'ask-cfpb/landing-page.html'
+
+
+class AnswerCategoryPage(
+        FilterableFeedPageMixin, FilterableListMixin, CFGOVPage):
+    """
+    Page type for Ask CFPB parent-category pages.
+    """
+    from .django import Category
+
+    objects = PageManager()
+    content = StreamField([
+        ('filter_controls', FilterControls()),
+    ], null=True)
+    ask_category = models.ForeignKey(
+        Category,
+        blank=True,
+        null=True,
+        on_delete=models.PROTECT,
+        related_name='category_page')
+    content_panels = CFGOVPage.content_panels + [
+        FieldPanel('ask_category', Category),
+        StreamFieldPanel('content'),
+    ]
+    edit_handler = TabbedInterface([
+        ObjectList(content_panels, heading='Content'),
+        ObjectList(CFGOVPage.settings_panels, heading='Configuration'),
+    ])
+    template = 'ask-cfpb/category-page.html'
+
+    def add_page_js(self, js):
+        super(AnswerCategoryPage, self).add_page_js(js)
+        js['template'] += ['secondary-navigation.js']
+
+    def get_context(self, request, *args, **kwargs):
+        context = super(
+            AnswerCategoryPage, self).get_context(request, *args, **kwargs)
+        context.update({
+            'choices':
+            self.ask_category.subcategories.all().values_list(
+                'slug', 'name')
+        })
+        return context
 
 
 class AnswerPage(CFGOVPage):
@@ -66,7 +126,7 @@ class AnswerPage(CFGOVPage):
         ObjectList(CFGOVPage.settings_panels, heading='Configuration'),
     ])
 
-    template = 'ask-answer-page/index.html'
+    template = 'ask-cfpb/answer-page.html'
     objects = PageManager()
 
     def __str__(self):

--- a/cfgov/ask_cfpb/tests/models/test_pages.py
+++ b/cfgov/ask_cfpb/tests/models/test_pages.py
@@ -8,7 +8,7 @@ from model_mommy import mommy
 from django.utils import timezone
 from django.apps import apps
 from django.core.urlresolvers import reverse
-from django.http import HttpResponse
+from django.http import HttpRequest, HttpResponse
 from django.test import TestCase
 from django.test import Client
 from django.utils import html
@@ -17,7 +17,7 @@ from v1.util.migrations import get_or_create_page, get_free_path
 from ask_cfpb.models.django import (
     Answer, Category, SubCategory, Audience,
     NextStep, ENGLISH_PARENT_SLUG, SPANISH_PARENT_SLUG)
-from ask_cfpb.models.pages import AnswerPage
+from ask_cfpb.models.pages import AnswerPage, AnswerCategoryPage
 
 html_parser = HTMLParser.HTMLParser()
 client = Client()
@@ -41,6 +41,16 @@ class AnswerModelTestCase(TestCase):
         page.save()
         return page
 
+    def create_category_page(self, **kwargs):
+        kwargs.setdefault(
+            'path', get_free_path(apps, self.english_parent_page))
+        kwargs.setdefault('depth', self.english_parent_page.depth + 1)
+        kwargs.setdefault('slug', 'category-mortgages')
+        kwargs.setdefault('title', 'Mortgages')
+        page = mommy.prepare(AnswerCategoryPage, **kwargs)
+        page.save()
+        return page
+
     def setUp(self):
         from v1.models import HomePage
         ROOT_PAGE = HomePage.objects.get(slug='cfgov')
@@ -48,6 +58,8 @@ class AnswerModelTestCase(TestCase):
         self.category = mommy.make(Category, name='stub_cat', name_es='que')
         self.subcategories = mommy.make(
             SubCategory, name='stub_subcat', _quantity=3)
+        self.category.subcategories.add(self.subcategories[0])
+        self.category.save()
         self.next_step = mommy.make(NextStep, title='stub_step')
         page_clean = patch('ask_cfpb.models.pages.CFGOVPage.clean')
         page_clean.start()
@@ -131,6 +143,13 @@ class AnswerModelTestCase(TestCase):
         answer.save()
         with self.assertRaises(ValueError):
             answer.create_or_update_page(language='zz')
+
+    def test_answer_available_subcategory_qs(self):
+        answer = self.prepare_answer()
+        answer.save()
+        answer.category.add(self.category)
+        answer.subcategory.add(self.subcategories[0])
+        self.assertIn(self.subcategories[0], answer.available_subcategory_qs)
 
     def test_create_or_update_pages_english_only(self):
         answer = self.prepare_answer()
@@ -242,9 +261,9 @@ class AnswerModelTestCase(TestCase):
         answer.save()
         self.assertIn(audience.name, answer.audience_strings())
 
-    def test_tagging(self):
+    def test_search_tags(self):
         """Test the generator produced by answer.tags()"""
-        answer = self.prepare_answer(tagging='Chutes, Ladders')
+        answer = self.prepare_answer(search_tags='Chutes, Ladders')
         answer.save()
         taglist = [tag for tag in answer.tags()]
         for name in ['Chutes', 'Ladders']:
@@ -299,6 +318,14 @@ class AnswerModelTestCase(TestCase):
         category = self.category
         self.assertEqual(category.__str__(), category.name)
 
+    def test_category_featured_answers(self):
+        category = self.category
+        mock_answer = self.answer1234
+        mock_answer.featured = True
+        mock_answer.category.add(category)
+        mock_answer.save()
+        self.assertIn(mock_answer, category.featured_answers())
+
     def test_subcategory_str(self):
         subcategory = self.subcategories[0]
         self.assertEqual(subcategory.__str__(), subcategory.name)
@@ -333,3 +360,24 @@ class AnswerModelTestCase(TestCase):
         from haystack.query import SearchQuerySet
         subcat = SubCategory.objects.first()
         self.assertTrue(isinstance(subcat.search_query(), SearchQuerySet))
+
+    def test_category_page_context(self):
+        mock_site = mock.Mock()
+        mock_site.hostname = 'localhost'
+        mock_request = HttpRequest()
+        mock_request.site = mock_site
+        cat_page = self.create_category_page(ask_category=self.category)
+        test_context = cat_page.get_context(mock_request)
+        self.assertEqual(test_context['choices'][0][1], 'stub_subcat')
+
+    def test_category_page_add_js_function(self):
+        cat_page = self.create_category_page(ask_category=self.category)
+        js = {}
+        cat_page.add_page_js(js)
+        self.assertEqual(js, {'template': [u'secondary-navigation.js']})
+
+    def test_answer_language_page_true(self):
+        self.assertEqual(self.answer5678.english_page, self.page2)
+
+    def test_answer_language_page_false(self):
+        self.assertEqual(self.answer5678.spanish_page, None)

--- a/cfgov/ask_cfpb/tests/models/test_pages.py
+++ b/cfgov/ask_cfpb/tests/models/test_pages.py
@@ -144,13 +144,6 @@ class AnswerModelTestCase(TestCase):
         with self.assertRaises(ValueError):
             answer.create_or_update_page(language='zz')
 
-    def test_answer_available_subcategory_qs(self):
-        answer = self.prepare_answer()
-        answer.save()
-        answer.category.add(self.category)
-        answer.subcategory.add(self.subcategories[0])
-        self.assertIn(self.subcategories[0], answer.available_subcategory_qs)
-
     def test_create_or_update_pages_english_only(self):
         answer = self.prepare_answer()
         answer.save()
@@ -228,7 +221,7 @@ class AnswerModelTestCase(TestCase):
         _revision.publish()
         self.assertEqual(answer.has_live_page(), True)
 
-    def test_available_subcategories(self):
+    def test_available_subcategories_qs(self):
         parent_category = self.category
         for sc in self.subcategories:
             sc.parent = parent_category
@@ -237,7 +230,8 @@ class AnswerModelTestCase(TestCase):
         answer.save()
         answer.category.add(parent_category)
         answer.save()
-        self.assertEqual(answer.available_subcategories, self.subcategories)
+        for subcat in self.subcategories:
+            self.assertIn(subcat, answer.available_subcategory_qs)
 
     def test_bass_string_no_base(self):  # sic
         test_page = self.create_answer_page()

--- a/cfgov/ask_cfpb/tests/test_hooks.py
+++ b/cfgov/ask_cfpb/tests/test_hooks.py
@@ -1,11 +1,16 @@
 from __future__ import unicode_literals
 
-from unittest import TestCase
+import mock
+
+from django.contrib.auth.models import User
+from django.http import HttpRequest
+from django.test import TestCase
 
 from ask_cfpb.wagtail_hooks import (
     Answer,
     AnswerModelAdmin,
     Audience,
+    AnswerModelAdminSaveUserEditView,
     AudienceModelAdmin,
     NextStep,
     NextStepModelAdmin,
@@ -32,3 +37,20 @@ class TestAskHooks(TestCase):
         self.assertIn("registerHalloPlugin('editHtmlButton')", editor_js())
         self.assertIn("css/question_tips.css", editor_css())
         self.assertEqual(whitelister_element_rules().keys(), ['aside'])
+
+    def test_AnswerModelAdminSaveUserEditView(self):
+        mock_admin = mock.Mock()
+        mock_admin.is_page = True
+        mock_admin.model = Answer
+        mock_answer = Answer()
+        mock_answer.save()
+        mock_user = User(username='Goliath')
+        mock_user.save()
+        mock_request = HttpRequest()
+        mock_request.user = mock_user
+        mock_request.method = "GET"
+        mock_edit_view = AnswerModelAdminSaveUserEditView(mock_admin, '1')
+        mock_edit_view.request = mock_request
+        mock_edit_view.instance = mock_answer
+        mock_edit_view.dispatch(mock_request)
+        self.assertEqual(mock_answer.last_user.username, 'Goliath')

--- a/cfgov/ask_cfpb/wagtail_hooks.py
+++ b/cfgov/ask_cfpb/wagtail_hooks.py
@@ -36,10 +36,14 @@ class AnswerModelAdmin(ModelAdmin):
     menu_label = 'Answers'
     menu_icon = 'list-ul'
     list_display = (
-        'id', 'question', 'last_edited', 'question_es', 'last_edited_es')
+        'id',
+        'question',
+        'last_edited',
+        'question_es',
+        'last_edited_es')
     search_fields = (
         'id', 'question', 'question_es', 'answer', 'answer_es')
-    list_filter = ('category',)
+    list_filter = ('category', 'featured')
     edit_view_class = AnswerModelAdminSaveUserEditView
 
 

--- a/cfgov/jinja2/v1/ask-cfpb/answer-page.html
+++ b/cfgov/jinja2/v1/ask-cfpb/answer-page.html
@@ -1,5 +1,4 @@
 {% extends 'layout-2-1-bleedbar.html' %}
-{% import 'macros/time.html' as time %}
 {% import 'form_block.html' as form_block with context %}
 
 {% block content_main_modifiers -%}
@@ -30,6 +29,7 @@
 
     </section>
 
+{# This brings in the feedback module #}
 {% for block in page.content %}
 {{- form_block.render(block, 'content', loop.index0) -}}
 {% endfor %}

--- a/cfgov/jinja2/v1/ask-cfpb/category-page.html
+++ b/cfgov/jinja2/v1/ask-cfpb/category-page.html
@@ -1,0 +1,39 @@
+{% extends 'layout-side-nav.html' %}
+{% import 'organisms/filterable-list-controls.html' as flc with context %}
+
+{% import 'macros/time.html' as time %}
+
+
+{% block content_main_modifiers -%}
+    {{ super() }} content__flush-bottom
+{%- endblock %}
+
+{% block content_main %}
+    <section class="block
+                    block__flush-top
+                    block__sub">
+        <h1>{{ page.ask_category.name }}</h1>
+        <div class="lead-paragraph">
+            <p>{{ page.ask_category.intro|safe }}</p>
+        </div>
+        <h3>What is your question about?</h3>
+        <ul>
+        {%- for subcat in page.ask_category.subcategories.all() -%}
+            <li>{{ subcat.name }}</li>
+        {% endfor %}
+        </ul>
+    </section>
+    <section class="search-results"></section>
+
+    {% for block in page.content %}
+        {% if 'filter_controls' in block.block_type %}
+            <div class="block
+                        block__flush-top">
+                {% import 'organisms/filterable-list-controls.html' as flc with context %}
+                {{ flc.render(block.value, loop.index0) }}
+            </div>
+        {% endif %}
+    {% endfor %}
+{% endblock %}
+
+

--- a/cfgov/jinja2/v1/ask-cfpb/landing-page.html
+++ b/cfgov/jinja2/v1/ask-cfpb/landing-page.html
@@ -1,0 +1,43 @@
+{% extends 'layout-2-1-bleedbar.html' %}
+
+{% import 'form_block.html' as form_block with context %}
+{% import 'templates/render_block.html' as render_block with context %}
+{% import 'templates/streamfield-sidefoot.html' as streamfield_sidefoot with context %}
+
+{% block content_main_modifiers -%}
+    {{ super() }} content__flush-bottom
+{%- endblock %}
+
+{% block hero -%}
+    {% for block in page.header -%}
+        {% if 'hero' in block.block_type %}
+            {{ render_stream_child(block) }}
+        {% endif %}
+    {%- endfor %}
+{% endblock %}
+
+{% block content_main %}
+    {% for block in page.header -%}
+        {% if block.block_type != 'hero' %}
+            {{ render_block.render(block, loop.index) }}
+        {% endif %}
+    {%- endfor %}
+    {% for block in page.cards -%}
+            {{ render_block.render(block, loop.index) }}
+    {%- endfor %}
+    {% for block in page.content -%}
+        {% if block.block_type == 'feedback' %}
+            {{- form_block.render(block, 'content', loop.index0) -}}
+        {% else %}
+            {{ render_block.render(block, loop.index) }}
+        {% endif %}
+    {%- endfor %}
+{% endblock %}
+
+{% block content_sidebar_modifiers -%}
+    o-sidebar-content
+{%- endblock %}
+
+{% block content_sidebar scoped -%}
+    {{ streamfield_sidefoot.render(page.sidefoot) }}
+{%- endblock %}

--- a/cfgov/v1/atomic_elements/organisms.py
+++ b/cfgov/v1/atomic_elements/organisms.py
@@ -1,4 +1,3 @@
-
 import json
 import requests
 
@@ -20,6 +19,7 @@ from v1.atomic_elements import atoms, molecules
 from v1.models.snippets import Contact as ContactSnippetClass
 from v1.models.snippets import ReusableText, ReusableTextChooserBlock
 from v1.util import ref
+import ask_cfpb
 
 
 class Well(blocks.StructBlock):
@@ -763,3 +763,13 @@ class SnippetList(blocks.StructBlock):
     class Meta:
         icon = 'table'
         template = '_includes/organisms/snippet-list.html'
+
+
+class AskCategoryCard(ModelList):
+
+    def render(self, value, context=None):
+        value['category'] = ask_cfpb.models.Category.objects.first()
+        value.update(context or {})
+
+        template = '_includes/organisms/ask-cfpb-card.html'
+        return render_to_string(template, value)

--- a/cfgov/v1/util/ref.py
+++ b/cfgov/v1/util/ref.py
@@ -39,6 +39,7 @@ page_types = [
     ('research-reports', 'Research Report'),
     ('rule-under-dev', 'Rule Under Development'),
     ('story', 'Story'),
+    ('ask', 'Ask CFPB'),
 ]
 
 fcm_types = [

--- a/cfgov/v1/util/util.py
+++ b/cfgov/v1/util/util.py
@@ -25,7 +25,8 @@ ERROR_MESSAGES = {
 
 def instanceOfBrowseOrFilterablePages(page):
     from ..models import BrowsePage, BrowseFilterablePage
-    return isinstance(page, (BrowsePage, BrowseFilterablePage))
+    from ask_cfpb.models import AnswerCategoryPage
+    return isinstance(page, (BrowsePage, BrowseFilterablePage, AnswerCategoryPage))
 
 
 # For use by Browse type pages to get the secondary navigation items
@@ -67,6 +68,16 @@ def get_secondary_nav_items(request, current_page):
             }
         ], True
     # END TODO
+    
+    if page.slug.startswith("category"):
+        from ask_cfpb.models import Category
+        return [
+            {
+                'title': cat.name, 
+                'url': '/ask-cfpb/category-' + cat.slug, 
+                'active': cat.name == page.ask_category.name
+            } for cat in Category.objects.all()
+        ], True
 
     if page.secondary_nav_exclude_sibling_pages:
         pages = [page]

--- a/cfgov/v1/util/util.py
+++ b/cfgov/v1/util/util.py
@@ -26,7 +26,8 @@ ERROR_MESSAGES = {
 def instanceOfBrowseOrFilterablePages(page):
     from ..models import BrowsePage, BrowseFilterablePage
     from ask_cfpb.models import AnswerCategoryPage
-    return isinstance(page, (BrowsePage, BrowseFilterablePage, AnswerCategoryPage))
+    return isinstance(
+        page, (BrowsePage, BrowseFilterablePage, AnswerCategoryPage))
 
 
 # For use by Browse type pages to get the secondary navigation items
@@ -68,13 +69,13 @@ def get_secondary_nav_items(request, current_page):
             }
         ], True
     # END TODO
-    
+
     if page.slug.startswith("category"):
         from ask_cfpb.models import Category
         return [
             {
-                'title': cat.name, 
-                'url': '/ask-cfpb/category-' + cat.slug, 
+                'title': cat.name,
+                'url': '/ask-cfpb/category-' + cat.slug,
                 'active': cat.name == page.ask_category.name
             } for cat in Category.objects.all()
         ], True


### PR DESCRIPTION
To replicate the Ask CFPB landing page and category-driven sub-pages, we
add the following:
- A page type for the landing page that allows full-width presentation
- A page type for category pages
- A `featured` field on the Answer model so editors can check which
  answers to feature in landing-page cards
- A `featured` filter for answers in the admin

This is prep work for front-end surgeons who will recreate knowledgebase pages as living Wagtail pages.

## Testing

To see this locally, you need to do the migration dance

```
./drop-db.sh
./create-mysql-db.sh
mysql -uroot v1 < ~/Downloads/production_django.sql
python cfgov/manage.py migrate
python cfgov/manage.py runscript migrate_knowledgebase
```

The new category pages are just stubs, but they're starting to look like the real thing:

<img width="1028" alt="category_page" src="https://cloud.githubusercontent.com/assets/515885/25019354/443dbce2-2058-11e7-878d-aba7a85bdef8.png">

This code will only appear on build.