### PR TITLE
Modifying video player for live event to allow using youtube

### DIFF
--- a/cfgov/jinja2/v1/_includes/macros/video-player.html
+++ b/cfgov/jinja2/v1/_includes/macros/video-player.html
@@ -27,8 +27,7 @@
 
 {% macro render(options={}) -%}
     {% set video_url    = options.video.url | default('/') %}
-    {% set video_player = options.video.player or
-                          ( video_url.find( 'youtube.com') > -1 and 'youtube' ) or
+    {% set video_player = ( video_url.find( 'youtube.com') > -1 and 'youtube' ) or
                           ( video_url.find( 'ustream.tv') and 'ustream' ) %}
     {% set image_url = static('img/cfpb_video_cover_card_1380x776.png') %}
     {% set video_id = options.video.id | default('') %}

--- a/cfgov/v1/migrations/0062_modifying_video_player.py
+++ b/cfgov/v1/migrations/0062_modifying_video_player.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import django.core.validators
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('v1', '0061_make_info_unit_headings_linkable'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='eventpage',
+            name='live_stream_url',
+            field=models.URLField(blank=True, help_text=b'Format: https://www.ustream.tv/embed/video_id or https://www.youtube.com/embed/video_id.', verbose_name=b'URL', validators=[django.core.validators.RegexValidator(regex=b'^https?:\\/\\/www\\.(ustream\\.tv|youtube\\.com)\\/embed\\/.*$')]),
+        ),
+    ]

--- a/cfgov/v1/models/learn_page.py
+++ b/cfgov/v1/models/learn_page.py
@@ -181,7 +181,9 @@ class EventPage(AbstractFilterPage):
     youtube_url = models.URLField(
         "Youtube URL",
         blank=True,
-        help_text="Format: https://www.youtube.com/embed/video_id. It can be obtained by clicking on Share > Embed on Youtube.",
+        help_text="Format: https://www.youtube.com/embed/video_id. "
+                  "It can be obtained by clicking on Share > "
+                  "Embed on Youtube.",
         validators=[
             RegexValidator(regex='^https?:\/\/www\.youtube\.com\/embed\/.*$')
         ]
@@ -195,9 +197,12 @@ class EventPage(AbstractFilterPage):
     live_stream_url = models.URLField(
         "URL",
         blank=True,
-        help_text="Format: https://www.ustream.tv/embed/video_id or https://www.youtube.com/embed/video_id.",
+        help_text="Format: https://www.ustream.tv/embed/video_id "
+                  "or https://www.youtube.com/embed/video_id.",
         validators=[
-            RegexValidator(regex='^https?:\/\/www\.(ustream\.tv|youtube\.com)\/embed\/.*$')
+            RegexValidator(
+                regex='^https?:\/\/www\.(ustream\.tv|youtube\.com)\/embed\/.*$'
+            )
         ]
     )
     live_stream_date = models.DateTimeField(

--- a/cfgov/v1/models/learn_page.py
+++ b/cfgov/v1/models/learn_page.py
@@ -195,9 +195,9 @@ class EventPage(AbstractFilterPage):
     live_stream_url = models.URLField(
         "URL",
         blank=True,
-        help_text="Format: https://www.ustream.tv/embed/video_id.  It can be obtained by following the instructions listed here: https://support.ustream.tv/hc/en-us/articles/207851917-How-to-embed-a-stream-or-video-on-your-site",  # noqa: E501
+        help_text="Format: https://www.ustream.tv/embed/video_id or https://www.youtube.com/embed/video_id.",
         validators=[
-            RegexValidator(regex='^https?:\/\/www\.ustream\.tv\/embed\/.*$')
+            RegexValidator(regex='^https?:\/\/www\.(ustream\.tv|youtube\.com)\/embed\/.*$')
         ]
     )
     live_stream_date = models.DateTimeField(

--- a/cfgov/v1/models/learn_page.py
+++ b/cfgov/v1/models/learn_page.py
@@ -181,7 +181,7 @@ class EventPage(AbstractFilterPage):
     youtube_url = models.URLField(
         "Youtube URL",
         blank=True,
-        help_text="Format: https://www.youtube.com/embed/video_id. It can be obtained by clicking on Share > Embed on Youtube.",  # noqa: E501
+        help_text="Format: https://www.youtube.com/embed/video_id. It can be obtained by clicking on Share > Embed on Youtube.",
         validators=[
             RegexValidator(regex='^https?:\/\/www\.youtube\.com\/embed\/.*$')
         ]


### PR DESCRIPTION
Modifying video player for live event to allow using youtube

## Changes

- Modifed `cfgov/jinja2/v1/_includes/macros/video-player.html` to determine video type solely based on the URL. 

- Modified `cfgov/v1/models/learn_page.py` validation regex and help text to acommodate allowing youtube.

## Testing

- Create an event page.
- Modify the event date / times to create an live event.
- Enter in a youtube live event url (https://www.youtube.com/embed/TY8bZHo6iRg).
- Preview.
- Play the event and verify it plays, stops, and restarts correctly. Check the console for errors.
- Edit the event again in Wagtail.
- Enter in a Ustream event (https://www.ustream.tv/embed/6540154?html5ui). 
- Preview.
- Play the event, you should be redirected to Ustream to view the event. 
- Visit `http://localhost:8000/about-us/events/archive-past-events/` and verify the archived events play.

## Screenshots

- 
<img width="953" alt="screen shot 2017-04-18 at 6 23 47 am" src="https://cloud.githubusercontent.com/assets/1696212/25127050/6f192638-2402-11e7-93bc-51f149527510.png">

## Notes

-


## Checklist

* [ ] PR has an informative and human-readable title
* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated
* [ ] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
