### PR TITLE
LESS fix for stacked tables on small screens

### DIFF
--- a/cfgov/unprocessed/css/enhancements/tables.less
+++ b/cfgov/unprocessed/css/enhancements/tables.less
@@ -131,7 +131,6 @@
         [data-display-table="row"],
         [data-display-table="cell"] {
             display: block;
-            width: 100%;
         }
 
         tr,
@@ -145,6 +144,7 @@
         [data-display-table="cell"] {
             padding-right: 0;
             padding-left: 0;
+            width: 100%;
         }
 
         & > thead,

--- a/cfgov/unprocessed/css/enhancements/tables.less
+++ b/cfgov/unprocessed/css/enhancements/tables.less
@@ -2,24 +2,6 @@
   name: Tables
   family: cf-tables
   notes:
-    - A fix that makes stacking cells 100% width when stacked
-  tags:
-    - cfgov-cf-tables
-*/
-
-.respond-to-max(@bp-xs-max, {
-    .o-table__stack-on-small {
-        thead tr th,
-        tbody tr td {
-            width: 100%;
-        }
-    }
-});
-
-/* topdoc
-  name: Tables
-  family: cf-tables
-  notes:
     - Adjustments for cf-tables to allow them to be full-width
   tags:
     - cfgov-cf-tables
@@ -149,6 +131,7 @@
         [data-display-table="row"],
         [data-display-table="cell"] {
             display: block;
+            width: 100%;
         }
 
         tr,

--- a/cfgov/unprocessed/css/enhancements/tables.less
+++ b/cfgov/unprocessed/css/enhancements/tables.less
@@ -2,6 +2,24 @@
   name: Tables
   family: cf-tables
   notes:
+    - A fix that makes stacking cells 100% width when stacked
+  tags:
+    - cfgov-cf-tables
+*/
+
+.respond-to-max(@bp-xs-max, {
+    .o-table__stack-on-small {
+        thead tr th,
+        tbody tr td {
+            width: 100%;
+        }
+    }
+});
+
+/* topdoc
+  name: Tables
+  family: cf-tables
+  notes:
     - Adjustments for cf-tables to allow them to be full-width
   tags:
     - cfgov-cf-tables


### PR DESCRIPTION
This code fixes an issue with stacking tables in small screens, forcing cells in these stacked tables to be 100% width.

## Additions
- LESS code which forces cells to be 100% width when stacked on small screens. (Currently, when the cells are set to a specific width using existing CF classes, those widths naturally carry over to stacked tables on small screens. However, it's intended that stacked cells should always be 100% width.)

## Screenshots
### Before:
<img width="285" alt="screen shot 2017-04-11 at 2 03 21 pm" src="https://cloud.githubusercontent.com/assets/1490703/25146716/f2e64fdc-2442-11e7-8460-a6b3b44fa823.png">

### After fix:
<img width="409" alt="screen shot 2017-04-18 at 2 25 22 pm" src="https://cloud.githubusercontent.com/assets/1490703/25146731/fd5725c2-2442-11e7-81ce-1d82f2c2e284.png">

## Checklist

* [x] PR has an informative and human-readable title
* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated
* [x] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
