### PR TITLE
Removing validation from the video player

### DIFF
--- a/cfgov/v1/migrations/0063_remove_validation_from_video_player.py
+++ b/cfgov/v1/migrations/0063_remove_validation_from_video_player.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('v1', '0062_modifying_video_player'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='eventpage',
+            name='live_stream_url',
+            field=models.URLField(help_text=b'Format: https://www.ustream.tv/embed/video_id or https://www.youtube.com/embed/video_id.', verbose_name=b'URL', blank=True),
+        ),
+    ]

--- a/cfgov/v1/models/learn_page.py
+++ b/cfgov/v1/models/learn_page.py
@@ -198,12 +198,7 @@ class EventPage(AbstractFilterPage):
         "URL",
         blank=True,
         help_text="Format: https://www.ustream.tv/embed/video_id "
-                  "or https://www.youtube.com/embed/video_id.",
-        validators=[
-            RegexValidator(
-                regex='^https?:\/\/www\.(ustream\.tv|youtube\.com)\/embed\/.*$'
-            )
-        ]
+                  "or https://www.youtube.com/embed/video_id."
     )
     live_stream_date = models.DateTimeField(
         "Go Live Date",


### PR DESCRIPTION
Removing validation from the video player


## Changes

- Due to the link format we will need to removed the validation from video player. It can be added back at a later time.

## Testing

- Create an event page.
- Modify the event date / times to create an live event.
- Enter in a youtube live event url (https://www.youtube.com/embed/TY8bZHo6iRg).
- Preview.
- Play the event and verify it plays, stops, and restarts correctly. Check the console for errors.
- Edit the event again in Wagtail.
- Enter in a Ustream event (https://www.ustream.tv/embed/6540154?html5ui). 
- Preview.
- Play the event, you should be redirected to Ustream to view the event. 
- Visit `http://localhost:8000/about-us/events/archive-past-events/` and verify the archived events play.


## Screenshots

- 
<img width="792" alt="screen shot 2017-04-19 at 2 57 46 pm" src="https://cloud.githubusercontent.com/assets/1696212/25197051/98666c1c-2510-11e7-84bc-0ac9f6092b1e.png">


## Notes

-

## Todos

-

## Checklist

* [ ] PR has an informative and human-readable title
* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated
* [ ] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
