### PR TITLE
Add management commands for Akamai flushes

### DIFF
--- a/.env_SAMPLE
+++ b/.env_SAMPLE
@@ -40,6 +40,7 @@ export ALLOW_ADMIN_URL=True
 #export AKAMAI_CLIENT_SECRET=<akamai_client_secret>
 #export AKAMAI_ACCESS_TOKEN=<akamai_access_token>
 #export AKAMAI_FAST_PURGE_URL=<akamai_fast_purge_url>
+#export AKAMAI_PURGE_ALL_URL=<akamai_purge_all_url>
 #export AKAMAI_NOTIFY_EMAIL=<akamai_notify_email>
 #export AKAMAI_HOST=<akamai_hostname>
 

--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -492,8 +492,7 @@ if ENABLE_AKAMAI_CACHE_PURGE:
             'BACKEND': 'v1.models.akamai_backend.AkamaiBackend',
             'CLIENT_TOKEN': os.environ.get('AKAMAI_CLIENT_TOKEN'),
             'CLIENT_SECRET': os.environ.get('AKAMAI_CLIENT_SECRET'),
-            'ACCESS_TOKEN': os.environ.get('AKAMAI_ACCESS_TOKEN'),
-            'FAST_PURGE_URL': os.environ.get('AKAMAI_FAST_PURGE_URL')
+            'ACCESS_TOKEN': os.environ.get('AKAMAI_ACCESS_TOKEN')
         },
     }
 

--- a/cfgov/v1/management/commands/invalidate_all_pages.py
+++ b/cfgov/v1/management/commands/invalidate_all_pages.py
@@ -1,38 +1,11 @@
-import json
-import logging
-import os
-import requests
-
-from akamai.edgegrid import EdgeGridAuth
-
+from django.conf import settings
 from django.core.management.base import BaseCommand
 
-logger = logging.getLogger(__name__)
+from v1.models.akamai_backend import AkamaiBackend
 
 
 class Command(BaseCommand):
+    help = 'Invalidates entire cfgov site'
+
     def handle(self, *args, **options):
-        auth = EdgeGridAuth(
-            client_token=os.environ.get('AKAMAI_CLIENT_TOKEN'),
-            client_secret=os.environ.get('AKAMAI_CLIENT_SECRET'),
-            access_token=os.environ.get('AKAMAI_ACCESS_TOKEN')
-        )
-        headers = {'content-type': 'application/json'}
-        payload = {
-            'action': 'invalidate',
-            'type': 'cpcode',
-            'domain': 'production',
-            'objects': [os.environ.get('AKAMAI_OBJECT_ID')]
-        }
-        resp = requests.post(
-            os.environ.get('AKAMAI_PURGE_ALL_URL'),
-            headers=headers,
-            data=json.dumps(payload),
-            auth=auth
-        )
-        logger.info(
-            'Initiated Akamai flush with response {text}'.format(
-                text=resp.text
-            )
-        )
-        resp.raise_for_status()
+        AkamaiBackend(settings.WAGTAILFRONTENDCACHE['akamai']).purge_all()

--- a/cfgov/v1/management/commands/invalidate_all_pages.py
+++ b/cfgov/v1/management/commands/invalidate_all_pages.py
@@ -1,0 +1,38 @@
+import json
+import logging
+import os
+import requests
+
+from akamai.edgegrid import EdgeGridAuth
+
+from django.core.management.base import BaseCommand
+
+logger = logging.getLogger(__name__)
+
+
+class Command(BaseCommand):
+    def handle(self, *args, **options):
+        auth = EdgeGridAuth(
+            client_token=os.environ.get('AKAMAI_CLIENT_TOKEN'),
+            client_secret=os.environ.get('AKAMAI_CLIENT_SECRET'),
+            access_token=os.environ.get('AKAMAI_ACCESS_TOKEN')
+        )
+        headers = {'content-type': 'application/json'}
+        payload = {
+            'action': 'invalidate',
+            'type': 'cpcode',
+            'domain': 'production',
+            'objects': [os.environ.get('AKAMAI_OBJECT_ID')]
+        }
+        resp = requests.post(
+            os.environ.get('AKAMAI_PURGE_ALL_URL'),
+            headers=headers,
+            data=json.dumps(payload),
+            auth=auth
+        )
+        logger.info(
+            'Initiated Akamai flush with response {text}'.format(
+                text=resp.text
+            )
+        )
+        resp.raise_for_status()

--- a/cfgov/v1/management/commands/invalidate_page.py
+++ b/cfgov/v1/management/commands/invalidate_page.py
@@ -1,4 +1,4 @@
-from django.core.management.base import BaseCommand, CommandError
+from django.core.management.base import BaseCommand
 
 from wagtail.contrib.wagtailfrontendcache.utils import purge_url_from_cache
 

--- a/cfgov/v1/management/commands/invalidate_single_page.py
+++ b/cfgov/v1/management/commands/invalidate_single_page.py
@@ -9,15 +9,10 @@ class Command(BaseCommand):
     def add_arguments(self, parser):
         parser.add_argument(
             '--url',
-            nargs='?',
+            required=True,
             help='The full URL for the page you wish to invalidate'
         )
 
     def handle(self, *args, **options):
         page_url = options['url']
-        if page_url:
-            purge_url_from_cache(page_url)
-        else:
-            raise CommandError('Must supply a page URL')
-
         purge_url_from_cache(page_url)

--- a/cfgov/v1/management/commands/invalidate_single_page.py
+++ b/cfgov/v1/management/commands/invalidate_single_page.py
@@ -1,0 +1,23 @@
+from django.core.management.base import BaseCommand, CommandError
+
+from wagtail.contrib.wagtailfrontendcache.utils import purge_url_from_cache
+
+
+class Command(BaseCommand):
+    help = 'Invalidates a page by its full URL'
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--url',
+            nargs='?',
+            help='The full URL for the page you wish to invalidate'
+        )
+
+    def handle(self, *args, **options):
+        page_url = options['url']
+        if page_url:
+            purge_url_from_cache(page_url)
+        else:
+            raise CommandError('Must supply a page URL')
+
+        purge_url_from_cache(page_url)

--- a/cfgov/v1/tests/models/test_akamai_backend.py
+++ b/cfgov/v1/tests/models/test_akamai_backend.py
@@ -8,7 +8,6 @@ class TestAkamaiBackend(TestCase):
                 'CLIENT_TOKEN': None,
                 'CLIENT_SECRET': None,
                 'ACCESS_TOKEN': None,
-                'FAST_PURGE_URL': None,
         }
         with self.assertRaises(ValueError):
             AkamaiBackend(credentials)
@@ -18,7 +17,6 @@ class TestAkamaiBackend(TestCase):
                 'CLIENT_TOKEN': 'some-arbitrary-token',
                 'CLIENT_SECRET': None,
                 'ACCESS_TOKEN': None,
-                'FAST_PURGE_URL': None,
         }
         with self.assertRaises(ValueError):
             AkamaiBackend(credentials)
@@ -28,10 +26,8 @@ class TestAkamaiBackend(TestCase):
                 'CLIENT_TOKEN': 'token',
                 'CLIENT_SECRET': 'secret',
                 'ACCESS_TOKEN': 'access token',
-                'FAST_PURGE_URL': 'fast purge url',
         }
         akamai_backend = AkamaiBackend(credentials)
         self.assertEquals(akamai_backend.client_token, 'token')
         self.assertEquals(akamai_backend.client_secret, 'secret')
         self.assertEquals(akamai_backend.access_token, 'access token')
-        self.assertEquals(akamai_backend.fast_purge_url, 'fast purge url')


### PR DESCRIPTION
## Overview
- We want to be able to invoke flushes to Akamai (both fast purge, and entire site) via Jenkins; it makes sense to have these be management commands rather than defined in the Jenkins job itself 
- We want to use token-based credentials (rather than Ross's credentials) for purging the entire site, so this adds a new env var for that endpoint. Ansible PRs are up. 
- GHE 586