### PR TITLE
Removing padding and width from CTA

### DIFF
--- a/cfgov/unprocessed/css/molecules/call-to-action.less
+++ b/cfgov/unprocessed/css/molecules/call-to-action.less
@@ -23,11 +23,6 @@
 */
 
 .m-call-to-action {
-    padding-bottom: unit( @grid_gutter-width / @base-font-size-px, em ) * 2;
-
-    .respond-to-range(@bp-sm-min, @bp-sm-max, {
-        .grid_column( 6 );
-    });
 
     .btn {
         text-align: center;


### PR DESCRIPTION
Removing padding and width from CTA


## Changes

- Modified `cfgov/unprocessed/css/molecules/call-to-action.less` to remove padding and width from the Call to Action molecule. This brings it back inline with our Atomic philosophy. 

## Testing

- Add a Call To Action to a Sub-landing page
- Preview and verify that it has no top / bottom margin or padding.

## Screenshots
- 
<img width="820" alt="screen shot 2017-04-20 at 2 39 57 pm" src="https://cloud.githubusercontent.com/assets/1696212/25247030/9b436710-25d7-11e7-833b-0a7cddf639e8.png">


## Notes

- There is essentially no margin on the CTA within the Full Width Text organism.  You will have to control spacing using the Rich Text Editor.
- Wrapping everything in a block is a mistake, if you aren't going to allow editors to control spacing for the block from Wagtail. 

## Todos

-

## Checklist

* [ ] PR has an informative and human-readable title
* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated
* [ ] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
