### PR TITLE
Removing the google optimize code from the Find a housing counselor page

### DIFF
--- a/cfgov/templates/find_a_housing_counselor.html
+++ b/cfgov/templates/find_a_housing_counselor.html
@@ -6,12 +6,7 @@ Find a housing counselor
 {% endblock %}
 
 {% block analytics_js %}
-<!-- Google Optimize --> 
-<noscript><iframe src="https://www.google-analytics.com/gtm/ns?id=GTM-KHB8MB" style="display:none;visibility:hidden" height="0" width="0"></iframe> </noscript>
-<script>(function(p,a,l,i,n,d,r,o,m,e){r={id:'GTM-KHB8MB',l:'dataLayer',m:'sync'}; if(!r.gac){o=/;((__utma=)|([^;=]+=GAX?\d+\.))[^;]*/g;m=l.cookie.replace( /^|(; +)/g,';').match(o);if(m)r.gac=m.sort().join('').substring(1)};e= 'https://www.google-analytics.com/gtm/js?';r.m=='sync'||(p['event']='gtm.js'); for(d in r)if(r.hasOwnProperty(d))e+=n(d)+'='+n(r[d])+'&';a[r.l]=a[r.l]||[]; a[r.l].push(p);if(r.m=='sync'){l.write('<'+i+' src="'+e+'"><\/'+i+'>');}else{ j=l.createElement(i);j.async=!0;j.src=e;f=l.getElementsByTagName(i)[0]; f.parentNode.insertBefore(j,f);}})({'gtm.start':1*new Date()},window,document, 'script',encodeURIComponent);</script>
-<!-- End Google Optimize -->
 {{block.super}}
-
 {% endblock %}
 
 {% block content %}
@@ -19,12 +14,12 @@ Find a housing counselor
   <ul class="bread meta">
   	<li><a href="/">Home</a></li>
         <li>Find a housing counselor</li>
-  </ul>         
+  </ul>
   <div class="share mini">	<a href="http://www.facebook.com/sharer.php?u=http://www.consumerfinance.gov/find-a-housing-counselor/&amp;t=Find a housing counselor" class="share-facebook noStyles"><img src="{% static 'nemo/_/img/icon_small_facebook.png' %}" alt="Share on Facebook"></a>
             <a href="http://twitter.com/intent/tweet/?url=http://www.consumerfinance.gov/find-a-housing-counselor/&amp;via=CFPB" class="share-twitter noStyles"><img src="{% static 'nemo/_/img/icon_small_twitter.png' %}" alt="Share on Twitter"></a>
             <a href="http://api.addthis.com/oexchange/0.8/forward/email/offer?url=http://www.consumerfinance.gov/find-a-housing-counselor/&amp;title=Find a housing counselor&amp;pubid=ra-4da354ee346886d2" class="share-email noStyles"><img src="{% static 'nemo/_/img/icon_small_email.png' %}" alt="Share via email"></a>
 </div>		<article class="page">
-			
+
 				<div class="hud_hca_api_print-header">
 				<!-- Show different content on print -->
                 <img class="hud_hca_api_print_logo hud_hca_api_print_show cfpb_hide" src="{% static 'nemo/_/img/logo.png' %}" alt="Consumer Financial Protection Bureau">
@@ -37,7 +32,7 @@ Find a housing counselor
 				<!-- Regular content hidden on print -->
 					<p>Housing counselors throughout the country can provide advice on buying a home, renting, defaults, foreclosures, and credit issues. Using the search box below, you can find one near you. The counseling agencies on this list are approved by the U.S. Department of Housing and Urban Development (HUD) and they can offer independent advice about whether a particular set of mortgage loan terms is a good fit based on your objectives and circumstances, often at little or no cost to you. This list will show you several approved agencies in your area. There is also a&nbsp;<a href="http://portal.hud.gov/hudportal/HUD?src=/ohc_nint">list of nationwide HUD-approved counseling intermediaries</a>.</p>
 				</div><!-- end .hud_hca_api_print_hide -->
-				
+
 				<div id="cfpb_hud_hca_api_print_text_container" class="cfpb_hud_hca_api_print_text hud_hca_api_print_show cfpb_hide">
 				<!-- Show different content on print -->
 					<p>The counseling agencies on this list are approved by the U.S. Department of Housing and Urban Development (HUD), and they can offer independent advice about whether a particular set of mortgage loan terms is a good fit based on your objectives and circumstances, often at little or no cost to you.  This list shows you several approved agencies in your area.  You can find other approved counseling agencies at the Consumer Financial Protection Bureau’s (CFPB) website: consumerfinance.gov/mortgagehelp or by calling 1-855-411-CFPB (2372).  You can also access a list of nationwide HUD-approved counseling intermediaries at http://portal.hud.gov/hudportal/HUD?src=/ohc_nint</p>				</div><!-- end .cfpb_hud_hca_api_print_text -->
@@ -87,7 +82,7 @@ Find a housing counselor
         </div><!-- end .hud_hca_api_results_info -->
         <div id="hud_hca_api_results_list_container" class="hud_hca_api_results_list">
         	<div id="hud_hca_api_the_results" class="hud_hca_api_the_results_list_container">
-        		<table id="hud_hca_api_results_table" class="hud_hca_api_results_listing hud_hca_api_print" style="display: none;">				
+        		<table id="hud_hca_api_results_table" class="hud_hca_api_results_listing hud_hca_api_print" style="display: none;">
 					<thead class="hud_hca_api_print_hide">
 						<tr>
 							<th scope="col" class="hud_hca_api_titles hud_hca_api_titles_left">Agency</th>
@@ -101,7 +96,7 @@ Find a housing counselor
 						<tr class="hud_hca_api_result">
 							<td class="hud_hca_api_result hud_hca_api_counselors_td">
 								<div class="hud_hca_api_num"></div>
-								<div class="hud_hca_api_counselor_info_container">								
+								<div class="hud_hca_api_counselor_info_container">
 									<div class="hud_hca_api_counselor">
 									</div>
 									<div class="hud_hca_api_counselor_address">
@@ -131,7 +126,7 @@ Find a housing counselor
 								</div>
 							</td>
 						</tr>
-					</tfoot>              
+					</tfoot>
 				</table><!-- end .hud_hca_api_results_listing -->
         	</div>
         	<div class="show-hide default-hidden hud_hca_api_print_hide hud_hca_api_pras">
@@ -151,9 +146,9 @@ Find a housing counselor
 
 
 		</article>
-		
 
-	
+
+
 
 	</section>
 


### PR DESCRIPTION
Removing the google optimize code

## Notes

- I'm not sure if this is the correct one or if it's the nemo one. 


## Checklist

* [ ] PR has an informative and human-readable title
* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated
* [ ] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
