### PR TITLE
Removing feature flag code from Multi-select

### DIFF
--- a/cfgov/jinja2/v1/_includes/organisms/filterable-list-controls.html
+++ b/cfgov/jinja2/v1/_includes/organisms/filterable-list-controls.html
@@ -180,10 +180,7 @@
 {% from 'organisms/post-preview.html' import render as post_preview with context %}
 
 {% macro render(controls, index) %}
-    <div class="o-filterable-list-controls
-        {{ 'o-filterable-list-controls__mulit-select-test'
-           if flag_enabled(request, 'MULTI-SELECT-TEST')
-           else '' }}"
+    <div class="o-filterable-list-controls"
          id="o-filterable-list-controls-{{ index | string }}">
         {% set form = filter_data.forms.pop(0) %}
         {% set posts = filter_data.page_sets.pop(0) %}

--- a/cfgov/unprocessed/css/organisms/filterable-list-controls.less
+++ b/cfgov/unprocessed/css/organisms/filterable-list-controls.less
@@ -40,7 +40,7 @@
         margin-bottom: unit( @grid_gutter-width / @base-font-size-px, em );
     }
 
-    &.o-filterable-list-controls__mulit-select-test {
+    &.o-filterable-list-controls {
         .cf-multi-select_fieldset {
             position: relative;
         }

--- a/cfgov/unprocessed/js/organisms/FilterableListControls.js
+++ b/cfgov/unprocessed/js/organisms/FilterableListControls.js
@@ -64,7 +64,7 @@ function FilterableListControls( element ) {
     _expandable = new Expandable( _dom );
     _expandable.init();
 
-    if ( _dom.classList.contains( 'o-filterable-list-controls__mulit-select-test' ) ) {
+    if ( _dom.classList.contains( 'o-filterable-list-controls' ) ) {
       multiSelects.forEach( function( multiSelect ) {
         multiSelect.addEventListener( 'expandBegin', function refresh() {
           window.setTimeout( _expandable.refreshHeight, 250 );


### PR DESCRIPTION

Removing feature flag code from Multi-select


## Changes

- Modified files to remove feature flag.


## Testing

- Run `gulp build`
- Goto `http://localhost:8000/about-us/blog/` 
- Enter in some topics
- Observe the Filterable List Control expands to the correct height.

## Screenshots

- 
<img width="831" alt="screen shot 2017-04-25 at 1 42 02 pm" src="https://cloud.githubusercontent.com/assets/1696212/25399295/fbbaaa0c-29bc-11e7-8104-cdf734e4d720.png">


## Notes

- The flags need to be deleted from Wagtail.

## Todos

-

## Checklist

* [ ] PR has an informative and human-readable title
* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated
* [ ] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
