### PR TITLE
Remove obsolete custom link handler

### DIFF
--- a/cfgov/v1/wagtail_hooks.py
+++ b/cfgov/v1/wagtail_hooks.py
@@ -3,11 +3,9 @@ import logging
 from django.core.exceptions import PermissionDenied
 from django.conf import settings
 from django.core.urlresolvers import reverse
-from django.utils.html import escape, format_html_join
+from django.utils.html import format_html_join
 from wagtail.wagtailadmin.menu import MenuItem
 from wagtail.wagtailcore import hooks
-from wagtail.wagtailcore.models import Page
-from urlparse import urlsplit
 
 from v1.util import util
 
@@ -70,46 +68,6 @@ def editor_css():
     )
 
     return css_includes
-
-
-class CFGovLinkHandler(object):
-    """
-    CFGovLinkHandler will be invoked whenever we encounter an <a> element in
-    HTML content with an attribute of data-linktype="page". The resulting
-    element in the database representation will be:
-    <a linktype="page" id="42">hello world</a>
-    """
-
-    @staticmethod
-    def get_db_attributes(tag):
-        """
-        Given an <a> tag that we've identified as a page link embed (because it
-        has a data-linktype="page" attribute), return a dict of the attributes
-        we should have on the resulting <a linktype="page"> element.
-        """
-        return {'id': tag['data-id']}
-
-    @staticmethod
-    def expand_db_attributes(attrs, for_editor):
-        try:
-            page = Page.objects.get(id=attrs['id'])
-
-            if for_editor:
-                editor_attrs = 'data-linktype="page" data-id="%d" ' % page.id
-            else:
-                editor_attrs = ''
-
-            return '<a %shref="%s">' % (
-                editor_attrs,
-                escape(urlsplit(page.url).path)
-            )
-        except Page.DoesNotExist:
-            return "<a>"
-
-
-@hooks.register('register_rich_text_link_handler')
-def register_cfgov_link_handler():
-    return ('page', CFGovLinkHandler)
 
 
 @hooks.register('cfgovpage_context_handlers')


### PR DESCRIPTION
This commit removes a custom rich text link handler (registered against the `register_rich_text_link_handler` hook) that is obsolete after the move to [wagtail-sharing](https://github.com/cfpb/wagtail-sharing).

Compare the code being removed against [the core Wagtail `wagtail.wagtailcore.rich_text.PageLinkHander` class](https://github.com/wagtail/wagtail/blob/v1.8.1/wagtail/wagtailcore/rich_text.py#L21); removing this should have no impact on how rich text links are rendered.

Our custom code was doing a `urlsplit(page.url)` which will fail if the page URL is relative or `None`. These cases would never happen pre-wagtail-sharing because there were always multiple Wagtail Sites defined, but now (and in standard Wagtail usage) this cannot be assumed to be the case.

This restores the default Wagtail behavior of inserting `<a href="None">` for links that are not part of any Site root.

## Removals

- Removed custom `v1.wagtail_hooks.CFGovLinkHandler` link handler class.

## Testing

- This defaults to the standard Wagtail behavior, so I didn't think it would be appropriate to add custom unit tests for this behavior here. To test manually, you can create a page with a link to a page not under a site root (e.g. under "Trash").

## Screenshots

![image](https://cloud.githubusercontent.com/assets/654645/25440127/7cf1d316-2a6c-11e7-860d-c9fc75eadb0d.png)

## Checklist

* [X] PR has an informative and human-readable title
* [X] Changes are limited to a single goal (no scope creep)
* [X] Code can be automatically merged (no conflicts)
* [X] Passes all existing automated tests
* [X] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
