### PR TITLE
Upgrade Wagtail to v1.10.1

### DIFF
--- a/cfgov/v1/atomic_elements/organisms.py
+++ b/cfgov/v1/atomic_elements/organisms.py
@@ -5,6 +5,7 @@ from django import forms
 from django.apps import apps
 from django.template.loader import render_to_string
 from django.utils.encoding import smart_text
+from django.utils.safestring import mark_safe
 from django.utils.functional import cached_property
 from functools import partial
 from jinja2 import Markup
@@ -709,7 +710,7 @@ class HTMLBlock(blocks.StructBlock):
     def render(self, value, context=None):
         resp = requests.get(value['html_url'], timeout=5)
         resp.raise_for_status()
-        return self.render_basic(resp.content, context=context)
+        return mark_safe(resp.content)
 
     class Meta:
         label = 'HTML Block'

--- a/cfgov/v1/migrations/0068_remove_cfgovrendition_filter.py
+++ b/cfgov/v1/migrations/0068_remove_cfgovrendition_filter.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('v1', '0067_auto_20170517_1344'),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name='cfgovrendition',
+            name='filter',
+        ),
+    ]

--- a/cfgov/v1/models/images.py
+++ b/cfgov/v1/models/images.py
@@ -1,6 +1,4 @@
 from django.db import models
-from django.db.models.signals import pre_delete
-from django.dispatch import receiver
 from django.utils.six import string_types
 from wagtail.wagtailimages.image_operations import (DoNothingOperation,
                                                     MinMaxOperation,
@@ -101,15 +99,3 @@ class CFGOVRendition(AbstractRendition):
         unique_together = (
             ('image', 'filter_spec', 'focal_point_key'),
         )
-
-
-# Delete the source image file when an image is deleted
-@receiver(pre_delete, sender=CFGOVImage)
-def image_delete(sender, instance, **kwargs):
-    instance.file.delete(False)
-
-
-# Delete the rendition image file when a rendition is deleted
-@receiver(pre_delete, sender=CFGOVRendition)
-def rendition_delete(sender, instance, **kwargs):
-    instance.file.delete(False)

--- a/cfgov/v1/tests/models/test_images.py
+++ b/cfgov/v1/tests/models/test_images.py
@@ -101,11 +101,11 @@ class CFGOVRenditionTest(TestCase):
             file=get_test_image_file()
         )
 
-        filt = Filter.objects.create(spec='original')
+        filt = Filter(spec='original')
 
         def create_rendition(image, filt):
             return CFGOVRendition.objects.create(
-                filter=filt,
+                filter_spec=filt.spec,
                 image=image,
                 file=image.file,
                 width=100,

--- a/cfgov/v1/tests/test_s3utils.py
+++ b/cfgov/v1/tests/test_s3utils.py
@@ -5,10 +5,8 @@ from django.core.files.base import ContentFile
 from django.core.files.storage import get_storage_class
 from django.test import TestCase, override_settings
 from wagtail.wagtailimages.tests.utils import get_test_image_file
-from wagtail.wagtailimages.models import get_image_model
-from wagtail.wagtailimages.tests.utils import get_test_image_file
+from wagtail.wagtailimages import get_image_model
 
-from moto import mock_s3
 from v1.s3utils import (MediaRootS3BotoStorage, http_s3_url_prefix,
                         https_s3_url_prefix)
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -41,7 +41,7 @@ suds==0.4
 tinys3==0.1.11
 unipath>=1.1,<=2.0
 vobject==0.9.1
-wagtail==1.10
+wagtail==1.10.1
 wagtail-flags==2.0.3
 wagtail-sharing==0.5
 Wand==0.4.2

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -43,5 +43,6 @@ unipath>=1.1,<=2.0
 vobject==0.9.1
 wagtail==1.8.1
 wagtail-flags==2.0.3
+wagtail==1.10
 wagtail-sharing==0.5
 Wand==0.4.2

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -41,8 +41,7 @@ suds==0.4
 tinys3==0.1.11
 unipath>=1.1,<=2.0
 vobject==0.9.1
-wagtail==1.8.1
-wagtail-flags==2.0.3
 wagtail==1.10
+wagtail-flags==2.0.3
 wagtail-sharing==0.5
 Wand==0.4.2


### PR DESCRIPTION
This PR upgrades Wagtail from v1.8.1 to v1.10rc1 (1.10 release is expected in the next week or so, marking this PR as **hold** until that time).

See release notes for these versions:

http://docs.wagtail.io/en/latest/releases/1.8.2.html
http://docs.wagtail.io/en/latest/releases/1.9.html
http://docs.wagtail.io/en/latest/releases/1.9.1.html
http://docs.wagtail.io/en/latest/releases/1.10.html

Notable changes include:

- Support for Django 1.11 and Python 3.6!
- New ability to [compare revisions](http://docs.wagtail.io/en/latest/releases/1.9.html#revision-comparisons) (see screenshot below).
- New ability to set up [many-to-many relations for pages](http://docs.wagtail.io/en/latest/releases/1.9.html#many-to-many-relations-on-page-models). I haven't looked into this much but the docs suggest this might allow for a new/better way to do page categories @richaagarwal @Scotchester.
- Speaking of categories/tags, it looks like [tags now support spaces in them by default](http://docs.wagtail.io/en/latest/releases/1.10.html#other-features).
- Adding users through the Wagtail admin [no longer sets `is_staff`](http://docs.wagtail.io/en/latest/releases/1.10.html#adding-editing-users-through-wagtail-admin-no-longer-sets-is-staff-flag) @rosskarchner.

Includes these changes required to make our tests pass:

- Removal of custom image rendition signals which are no longer needed as of 1.10.
- Change in use of `wagtailimages.models.Filter` to support change from Django model to regular Python class in 1.9.
- Change in location of `wagtailimages.get_image_model` in 1.9.
- Change in how `HTMLBlock` is rendered due to change in block `get_context` usage in 1.10. Included HTML is always rendered verbatim and so should not need context passed in.

## Changes

- Bump of Wagtail version from `1.8.1` to `1.10rc1`.

## Testing

- Please read the release notes above to see the numerous changes involved in this upgrade. This version bump requires a good amount of testing with real data, so the best way to do that is to use a production dump:

 ```sh
 (cfgov-refresh) $ pip install -r requirements/local.txt
 (cfgov-refresh) $ ./drop-db.sh
 (cfgov-refresh) $ ./create-mysql-db.sh
 (cfgov-refresh) $ ./refresh-data.sh /path/to/dump.sql
 (cfgov-refresh) $ python cfgov/manage.py migrate --fake-initial --noinput
 (cfgov-refresh) $ ./runserver.sh
 ```

## Screenshots

New ability to compare revisions:

![image](https://cloud.githubusercontent.com/assets/654645/25487384/0c673f02-2b32-11e7-94e0-56b25b2966af.png)

Example revision comparison:

![image](https://cloud.githubusercontent.com/assets/654645/25487424/32481a0c-2b32-11e7-8cd2-fc11fe154733.png)

## Checklist

* [X] PR has an informative and human-readable title
* [X] Changes are limited to a single goal (no scope creep)
* [X] Code can be automatically merged (no conflicts)
* [X] Passes all existing automated tests
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated
* [X] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
