### PR TITLE
Log INFO for v1 to /var/log/django.log

### DIFF
--- a/cfgov/cfgov/settings/production.py
+++ b/cfgov/cfgov/settings/production.py
@@ -32,6 +32,11 @@ LOGGING = {
         'django': {
             'level': 'ERROR',
             'propagate': False,
+        },
+        'v1': {
+            'handlers': ['disk'],
+            'level': 'INFO',
+            'propagate': True,
         }
     }
 }

--- a/cfgov/cfgov/settings/production.py
+++ b/cfgov/cfgov/settings/production.py
@@ -14,7 +14,14 @@ LOGGING = {
         'console': {
             'level': 'DEBUG',
             'class': 'logging.StreamHandler',
-        }
+        },
+        'disk': {
+            'level': 'INFO',
+            'class': 'logging.handlers.RotatingFileHandler',
+            'filename': '/var/log/django.log',
+            'maxBytes': 1024*1024*10,  # max 10 MB per file
+            'backupCount': 5,  # keep 5 files around
+        },
     },
     'loggers': {
         'django.request': {


### PR DESCRIPTION
This PR adds a rotating file log handler to our production logging that will log `INFO` to `/var/logs/django.log` with a 10MB limit and 5 file backup (this is all @chosak — I just added it and tested locally).

See GHE/CFGOV/platform/issues/182 for more context.

## Additions

- Log handler to log INFO to disk for the v1 app

## Checklist

* [ ] PR has an informative and human-readable title
* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated
* [ ] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
