### PR TITLE
Add a default of file logging handler filename

### DIFF
--- a/cfgov/cfgov/settings/production.py
+++ b/cfgov/cfgov/settings/production.py
@@ -18,7 +18,7 @@ LOGGING = {
         'disk': {
             'level': 'INFO',
             'class': 'logging.handlers.RotatingFileHandler',
-            'filename': os.getenv('CFGOV_DJANGO_LOG'),
+            'filename': os.getenv('CFGOV_DJANGO_LOG', '/dev/null'),
             'maxBytes': 1024*1024*10,  # max 10 MB per file
             'backupCount': 5,  # keep 5 files around
         },


### PR DESCRIPTION
## Changes

- Default to `/dev/null` for file-based logging if the env var doesn't exist.

## Checklist

* [ ] PR has an informative and human-readable title
* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated
* [ ] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
