### PR TITLE
Bump owning-a-home-api to version 0.9.96

### DIFF
--- a/requirements/optional-public.txt
+++ b/requirements/optional-public.txt
@@ -1,7 +1,7 @@
 git+https://github.com/cfpb/college-costs.git@2.3.3#egg=college-costs
 git+https://github.com/cfpb/complaint.git@1.3.1#egg=complaintdatabase
 git+https://github.com/cfpb/django-hud.git@1.2#egg=django-hud
-git+https://github.com/cfpb/owning-a-home-api.git@0.9.95#egg=owning-a-home-api
+git+https://github.com/cfpb/owning-a-home-api.git@0.9.96#egg=owning-a-home-api
 git+https://github.com/cfpb/regulations-core.git@1.2.3#egg=regcore
 git+https://github.com/cfpb/regulations-site.git@2.1.8#egg=regulations
 git+https://github.com/cfpb/retirement.git@0.5.5#egg=retirement


### PR DESCRIPTION
This PR bumps the version of [owning-a-home-api](https://github.com/cfpb/owning-a-home-api) from 0.9.95 to [0.9.96](https://github.com/cfpb/owning-a-home-api/releases/tag/0.9.96).

## Changes

- Bump owning-a-home-api dependency from version 0.9.95 to 0.9.96.

## Testing

- See release notes for owning-a-home-api PRs [115](https://github.com/cfpb/owning-a-home-api/pull/115) and [116](https://github.com/cfpb/owning-a-home-api/pull/116).

## Checklist

* [X] PR has an informative and human-readable title
* [X] Changes are limited to a single goal (no scope creep)
* [X] Code can be automatically merged (no conflicts)
* [X] Passes all existing automated tests
* [X] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
