### PR TITLE
Certify CF changes for enhancements/base

### DIFF
--- a/cfgov/unprocessed/css/enhancements/base.less
+++ b/cfgov/unprocessed/css/enhancements/base.less
@@ -19,7 +19,7 @@
 */
 
 body {
-    .webfont-regular(); // Moved to CF
+    .webfont-regular(); // Moved to CF, delete freely when migrating to CF4
 }
 
 /* topdoc

--- a/cfgov/unprocessed/css/enhancements/base.less
+++ b/cfgov/unprocessed/css/enhancements/base.less
@@ -19,11 +19,7 @@
 */
 
 body {
-    .webfont-regular();
-
-    .respond-to-max( @bp-sm-max, {
-        overflow-x: hidden;
-    } );
+    .webfont-regular(); // Moved to CF
 }
 
 /* topdoc

--- a/cfgov/unprocessed/css/organisms/mega-menu.less
+++ b/cfgov/unprocessed/css/organisms/mega-menu.less
@@ -18,6 +18,22 @@
 @mobile_trigger_ht__px: 54px;
 
 /* topdoc
+  name: Body Overflow
+  notes:
+    - "Hides menu overflow on mobile sizes."
+  patterns:
+    - name: Body
+      codenotes:
+        - |
+          body
+*/
+body {
+    .respond-to-max( @bp-sm-max, {
+        overflow-x: hidden;
+    } );
+}
+
+/* topdoc
   name: Mega Menu
   family: cfgov-organisms
   patterns:

--- a/cfgov/unprocessed/css/organisms/mega-menu.less
+++ b/cfgov/unprocessed/css/organisms/mega-menu.less
@@ -27,6 +27,8 @@
         - |
           body
 */
+// TODO: Reduce global scope and reign it in to the menu only if possible.
+
 body {
     .respond-to-max( @bp-sm-max, {
         overflow-x: hidden;


### PR DESCRIPTION
The body font is now in CFv4 and the overflow is related to the menu, and won't be moved to CF.

Looking for feedback on how to properly note what is and isn't in Capital Framework and whether the menu organism really is the best place for that overflow rule.

## Changes

- Moved the menu related overflow rule to the menu file
- Noted the code already in CF

## Checklist

* [x] PR has an informative and human-readable title
* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices
* [x] Project documentation has been updated
* [x] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
