### PR TITLE
Fix for black bar on video player

### DIFF
--- a/cfgov/unprocessed/css/video-player.less
+++ b/cfgov/unprocessed/css/video-player.less
@@ -100,6 +100,11 @@
 }
 
 .respond-to-min( @fcm-bp-min, {
+
+    .video-player {
+        left: 360px;
+    }
+
     .video-player_video-actions-container {
         position: absolute;
         top: 0;

--- a/cfgov/unprocessed/css/video-player.less
+++ b/cfgov/unprocessed/css/video-player.less
@@ -101,7 +101,7 @@
 
 .respond-to-min( @fcm-bp-min, {
 
-    .video-player {
+    .video-player.featured-content-module_visual {
         left: 360px;
     }
 


### PR DESCRIPTION
Fix for black bar on video player


## Testing

- Run `gulp build`
- Visit `http://localhost:8000/about-us/the-bureau/` and verify that there is no black bar.

## Screenshots

before:
- 
<img width="969" alt="screen shot 2017-05-03 at 12 39 24 pm" src="https://cloud.githubusercontent.com/assets/1696212/25671332/98c34e1c-2ffd-11e7-8213-63ec9f3bf77c.png">

After:
-
<img width="997" alt="screen shot 2017-05-03 at 12 40 51 pm" src="https://cloud.githubusercontent.com/assets/1696212/25671372/c38b05c2-2ffd-11e7-8f14-516d67e6220a.png">


## Checklist

* [ ] PR has an informative and human-readable title
* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated
* [ ] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
