### PR TITLE
Pin govdelivery to 1.0

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -22,7 +22,7 @@ edgegrid-python==1.0.10
 elasticsearch==1.6.0
 feedparser==5.2.1
 geocoder==1.12.0
-git+https://github.com/rosskarchner/govdelivery.git#egg=govdelivery
+govdelivery==1.0
 html5lib==0.9999999
 icalendar==3.9.0
 Jinja2==2.7.3


### PR DESCRIPTION
This PR uses the PyPI version of govdelivery and pins it to 1.0.

## Changes

- Use the PyPI 1.0 release of govdelivery

## Checklist

* [x] PR has an informative and human-readable title
* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated
* [x] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
