### PR TITLE
Condition the snippet ID

### DIFF
--- a/cfgov/jinja2/v1/_includes/organisms/snippet-list.html
+++ b/cfgov/jinja2/v1/_includes/organisms/snippet-list.html
@@ -37,7 +37,7 @@
 
 {% from 'molecules/info-unit.html' import info_unit with context %}
 
-<div class="o-snippet-list" id="{{ value.heading|slugify }}">
+<div class="o-snippet-list"{{ ' id="' ~ value.heading|slugify ~ '"' if value.heading else '' }}>
     {% set img = image(value.image.upload, 'original')
        if value.image.upload
        else '/' %}


### PR DESCRIPTION
When a heading isn't included the template prints an empty ID. Emtpy IDs are invalid and should be avoided.

## Changes

- Conditioned the snippet ID to only print if the heading exists.


## Notes

- Fixes https://github.com/cfpb/cfgov-refresh/pull/2898#issuecomment-299468182

## Checklist

* [x] PR has an informative and human-readable title
* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices
* [x] Project documentation has been updated
* [x] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
