### PR TITLE
Include hero in migration of Ask landing page

### DIFF
--- a/cfgov/ask_cfpb/scripts/migrate_knowledgebase.py
+++ b/cfgov/ask_cfpb/scripts/migrate_knowledgebase.py
@@ -150,6 +150,7 @@ def get_or_create_landing_pages():
          'value': {
              'heading': 'Ask CFPB',
              'links': [],
+             'background_color': '#ffffff',
              'body': ('We offer clear, impartial answers to hundreds '
                       'of financial questions. Find the information you need '
                       'to make more informed choices about your money.')}}]

--- a/cfgov/ask_cfpb/tests/models/test_pages.py
+++ b/cfgov/ask_cfpb/tests/models/test_pages.py
@@ -20,7 +20,8 @@ from v1.util.migrations import get_or_create_page, get_free_path
 from ask_cfpb.models.django import (
     Answer, Category, SubCategory, Audience,
     NextStep, ENGLISH_PARENT_SLUG, SPANISH_PARENT_SLUG)
-from ask_cfpb.models.pages import AnswerPage, AnswerCategoryPage
+from ask_cfpb.models.pages import (
+    AnswerPage, AnswerCategoryPage)
 
 html_parser = HTMLParser.HTMLParser()
 client = Client()
@@ -69,19 +70,21 @@ class AnswerModelTestCase(TestCase):
         self.addCleanup(page_clean.stop)
         self.english_parent_page = get_or_create_page(
             apps,
-            'v1',
-            'LandingPage',
+            'ask_cfpb',
+            'AnswerLandingPage',
             'Ask CFPB',
             ENGLISH_PARENT_SLUG,
             ROOT_PAGE,
+            language='en',
             live=True)
         self.spanish_parent_page = get_or_create_page(
             apps,
-            'v1',
-            'LandingPage',
+            'ask_cfpb',
+            'AnswerLandingPage',
             'Obtener respuestas',
             SPANISH_PARENT_SLUG,
             ROOT_PAGE,
+            language='es',
             live=True)
         self.answer1234 = self.prepare_answer(
             id=1234,
@@ -379,6 +382,42 @@ class AnswerModelTestCase(TestCase):
         cat_page = self.create_category_page(ask_category=self.category)
         test_context = cat_page.get_context(mock_request)
         self.assertEqual(test_context['choices'][0][1], 'stub_subcat')
+
+    def test_landing_page_context(self):
+        mock_site = mock.Mock()
+        mock_site.hostname = 'localhost'
+        mock_request = HttpRequest()
+        mock_request.site = mock_site
+        landing_page = self.english_parent_page
+        test_context = landing_page.get_context(mock_request)
+        self.assertEqual(
+            test_context['categories'].count(),
+            Category.objects.count())
+        self.assertEqual(
+            test_context['audiences'].count(),
+            Audience.objects.count())
+
+    def test_landing_page_get_english_template(self):
+        mock_site = mock.Mock()
+        mock_site.hostname = 'localhost'
+        mock_request = HttpRequest()
+        mock_request.site = mock_site
+        landing_page = self.english_parent_page
+        test_get_template = landing_page.get_template(mock_request)
+        self.assertEqual(
+            test_get_template,
+            'ask-cfpb/landing-page.html')
+
+    def test_landing_page_get_spanish_template(self):
+        mock_site = mock.Mock()
+        mock_site.hostname = 'localhost'
+        mock_request = HttpRequest()
+        mock_request.site = mock_site
+        landing_page = self.spanish_parent_page
+        test_get_template = landing_page.get_template(mock_request)
+        self.assertEqual(
+            test_get_template,
+            'ask-cfpb/landing-page-spanish.html')
 
     def test_category_page_add_js_function(self):
         cat_page = self.create_category_page(ask_category=self.category)


### PR DESCRIPTION
This adds a hero streamfield to the migration of the  English Ask
landing page, so that editors don't have to set this up
in every environment we deploy to. The hero image is left blank for now.

Also adds tests for the AskLandingPage `get_context` and `get_template` methods.

## Testing
do the migration dance and check the English landing page:
http://localhost:8000/ask-cfpb/

It won't have a hero image.

