### PR TITLE
Always use relative internal links in rich text fields

### DIFF
--- a/cfgov/v1/tests/test_wagtail_hooks.py
+++ b/cfgov/v1/tests/test_wagtail_hooks.py
@@ -1,13 +1,12 @@
-import json
-
 import mock
+
 from django.test import TestCase
-from django.test.client import RequestFactory
+from wagtail.wagtailcore.models import Site
+from wagtail.tests.testapp.models import SimplePage
 
-from akamai.edgegrid import EdgeGridAuth
-
-from v1.models.browse_page import BrowsePage
-from v1.wagtail_hooks import check_permissions, form_module_handlers
+from v1.wagtail_hooks import (
+    RelativePageLinkHandler, check_permissions, form_module_handlers
+)
 
 
 class TestCheckPermissions(TestCase):
@@ -118,3 +117,49 @@ class TestFormModuleHandlers(TestCase):
         form_module_handlers(self.page, self.request, self.context)
         child.block.is_submitted.assert_called_with(self.request, 'name', 0)
 
+
+class TestRelativePageLinkHandler(TestCase):
+    def setUp(self):
+        self.default_site = Site.objects.get(is_default_site=True)
+
+    def test_nonexisting_page_returns_empty_link(self):
+        self.assertEqual(
+            RelativePageLinkHandler.expand_db_attributes(
+                attrs={'id': 0},
+                for_editor=False
+            ),
+            '<a>',
+        )
+
+    def test_page_not_in_site_root_returns_none_link(self):
+        self.assertEqual(
+            RelativePageLinkHandler.expand_db_attributes(
+                attrs={'id': 1},
+                for_editor=False
+            ),
+            '<a href="None">',
+        )
+
+    def check_page_renders_as_relative_link(self):
+        page = SimplePage(title='title', slug='slug', content='content')
+        self.default_site.root_page.add_child(instance=page)
+
+        self.assertEqual(
+            RelativePageLinkHandler.expand_db_attributes(
+                attrs={'id': page.pk},
+                for_editor=False
+            ),
+            '<a href="/slug/">',
+        )
+
+    def test_single_site_returns_relative_link(self):
+        self.assertEqual(Site.objects.count(), 1)
+        self.check_page_renders_as_relative_link()
+
+    def test_multiple_sites_still_returns_relative_link(self):
+        Site.objects.create(
+            hostname='other',
+            root_page=self.default_site.root_page,
+            is_default_site=False
+        )
+        self.check_page_renders_as_relative_link()

--- a/cfgov/v1/wagtail_hooks.py
+++ b/cfgov/v1/wagtail_hooks.py
@@ -4,7 +4,9 @@ from django.core.exceptions import PermissionDenied
 from django.conf import settings
 from django.core.urlresolvers import reverse
 from django.utils.html import escape, format_html_join
+
 from urlparse import urlsplit
+
 from wagtail.wagtailadmin.menu import MenuItem
 from wagtail.wagtailcore import hooks
 from wagtail.wagtailcore.models import Page
@@ -120,18 +122,26 @@ class RelativePageLinkHandler(PageLinkHandler):
     Rich text link handler that forces all page links to be relative.
 
     This special page link handler makes it so that any internal Wagtail page
-    links inserted into rich text fields, for example:
+    links inserted into rich text fields are rendered as relative links.
+
+    Standard Wagtail behavior stores rich text link content in the database in
+    a psuedo-HTML format like this, including only a page's ID:
 
         <a linktype="page" id="123">foo</a>
 
-    always get replaced with a relative URL to that page, never an absolute
-    one, like this:
+    When this content is rendered for preview or viewing, it's replaced with
+    valid HTML including the page's URL. This custom handler ensures that page
+    URLs are always rendered as relative, like this:
 
         <a href="/path/to/page">foo</a>
 
-    In standard Wagtail behavior, this may be an absolute URL if an
-    installation has multiple Wagtail Sites. In our current custom usage we
-    have multiple Wagtail Sites (one for production, one for staging) that
+    Pages rendered with this handler should never be rendered like this:
+
+        <a href="http://my.domain/path/to/page">foo</a>
+
+    In standard Wagtail behavior, pages will be rendered with an absolute URL
+    if an installation has multiple Wagtail Sites. In our current custom usage
+    we have multiple Wagtail Sites (one for production, one for staging) that
     share the same root page. So forcing the use of relative URLs would work
     fine and allow for easier navigation within a single domain.
 
@@ -139,7 +149,6 @@ class RelativePageLinkHandler(PageLinkHandler):
     additional site that doesn't share the same root page.
 
     This code is modified from `wagtail.wagtailcore.rich_text.PageLinkHandler`.
-
     """
     @staticmethod
     def expand_db_attributes(attrs, for_editor):

--- a/cfgov/v1/wagtail_hooks.py
+++ b/cfgov/v1/wagtail_hooks.py
@@ -3,9 +3,12 @@ import logging
 from django.core.exceptions import PermissionDenied
 from django.conf import settings
 from django.core.urlresolvers import reverse
-from django.utils.html import format_html_join
+from django.utils.html import escape, format_html_join
+from urlparse import urlsplit
 from wagtail.wagtailadmin.menu import MenuItem
 from wagtail.wagtailcore import hooks
+from wagtail.wagtailcore.models import Page
+from wagtail.wagtailcore.rich_text import PageLinkHandler
 
 from v1.util import util
 
@@ -110,3 +113,57 @@ def register_django_admin_menu_item():
         classnames='icon icon-redirect',
         order=99999
     )
+
+
+class RelativePageLinkHandler(PageLinkHandler):
+    """
+    Rich text link handler that forces all page links to be relative.
+
+    This special page link handler makes it so that any internal Wagtail page
+    links inserted into rich text fields, for example:
+
+        <a linktype="page" id="123">foo</a>
+
+    always get replaced with a relative URL to that page, never an absolute
+    one, like this:
+
+        <a href="/path/to/page">foo</a>
+
+    In standard Wagtail behavior, this may be an absolute URL if an
+    installation has multiple Wagtail Sites. In our current custom usage we
+    have multiple Wagtail Sites (one for production, one for staging) that
+    share the same root page. So forcing the use of relative URLs would work
+    fine and allow for easier navigation within a single domain.
+
+    This will explicitly break things if users ever wanted to host some
+    additional site that doesn't share the same root page.
+
+    This code is modified from `wagtail.wagtailcore.rich_text.PageLinkHandler`.
+
+    """
+    @staticmethod
+    def expand_db_attributes(attrs, for_editor):
+        try:
+            page = Page.objects.get(id=attrs['id'])
+
+            if for_editor:
+                editor_attrs = 'data-linktype="page" data-id="%d" ' % page.id
+                parent_page = page.get_parent()
+                if parent_page:
+                    editor_attrs += 'data-parent-id="%d" ' % parent_page.id
+            else:
+                editor_attrs = ''
+
+            page_url = page.specific.url
+
+            if page_url:
+                page_url = urlsplit(page_url).path
+
+            return '<a %shref="%s">' % (editor_attrs, escape(page_url))
+        except Page.DoesNotExist:
+            return "<a>"
+
+
+@hooks.register('register_rich_text_link_handler')
+def register_cfgov_link_handler():
+    return ('page', RelativePageLinkHandler)


### PR DESCRIPTION
This commit restores behavior that was removed in #2872.

When we insert internal Wagtail page links into rich text fields, we need them to always render as relative (not absolute) so as to maintain expected behavior across sharing/production sites. This new handler makes sure all internal Wagtail page links are always rendered as relative.

See [comments in `v1.wagtail_hooks.RelativePageLinkHandler`](https://github.com/cfpb/cfgov-refresh/compare/better-link-handler?expand=1#diff-44507cc860654b805baac659b58d2c53R118) for more details.

## Additions

- New `v1.wagtail_hooks.RelativePageLinkHandler` that forces relative internal links in Wagtail rich text fields.

## Testing

- New unit tests cover the new handler class; to manually test locally, [create a `BrowsePage`](http://localhost:8000/admin/pages/add/v1/browsepage/3/), add a `FullWidthText` organism, insert a "Content" `RichTextBlock`, then insert an internal link to another Wagtail page. You'll see that links render as relative when previewing or viewing the page even if multiple Wagtail `Site`s are defined.

## Notes

- As always, [I should have listened better](https://github.com/cfpb/cfgov-refresh/pull/2872#issuecomment-297458526) to @Scotchester.

## Checklist

* [X] PR has an informative and human-readable title
* [X] Changes are limited to a single goal (no scope creep)
* [X] Code can be automatically merged (no conflicts)
* [X] Passes all existing automated tests
* [X] New functions include new tests
* [X] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Project documentation has been updated
* [X] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
