### PR TITLE
Store rich text table cells like rich text fields

### DIFF
--- a/cfgov/jinja2/v1/_includes/organisms/table.html
+++ b/cfgov/jinja2/v1/_includes/organisms/table.html
@@ -39,7 +39,7 @@
 
 {% if value.has_data is not defined or value.has_data %}
 {% macro _render_cell(cell) %}
-    {{ (cell or '&nbsp;') | safe | trim | linebreaksbr }}
+    {{ parse_links(cell or '&nbsp;') | safe | trim | linebreaksbr }}
 {% endmacro %}
 
 <table class="o-table
@@ -98,7 +98,7 @@
                     %}
                 {% endif %}
                 <{{ tag | safe }}{{ attributes | safe }}>
-                    {{ _render_cell(parse_links(cell or '&nbsp;')) }}
+                    {{ _render_cell(cell) }}
                 </{{ tag | safe }}>
             {% endfor %}
         </tr>

--- a/cfgov/templates/wagtailadmin/js/table-block.js
+++ b/cfgov/templates/wagtailadmin/js/table-block.js
@@ -11,7 +11,7 @@
  */
 ( function( win ) {
 
-    function initAtomicTable( id, options ) {
+    function initRichTextTable( id, options ) {
         id = '#' + id;
 
         var utilities = {
@@ -558,6 +558,6 @@
         } );
     } );
 
-    win.initAtomicTable = initAtomicTable;
+    win.initRichTextTable = initRichTextTable;
 
 } ) ( window );

--- a/cfgov/v1/tests/atomic_elements/organisms/test_tables.py
+++ b/cfgov/v1/tests/atomic_elements/organisms/test_tables.py
@@ -1,0 +1,66 @@
+import json
+
+from django.test import TestCase
+from wagtail.wagtailcore.models import Site
+from wagtail.tests.testapp.models import SimplePage
+
+from v1.atomic_elements.organisms import AtomicTableBlock, RichTextTableInput
+
+
+class TestRichTextTableInput(TestCase):
+    def test_json_dict_apply_none(self):
+        self.assertEqual(
+            RichTextTableInput.json_dict_apply('null', lambda x: x),
+            'null'
+        )
+
+    def test_json_dict_apply_modifies_each_cell(self):
+        value = {
+            'foo': 'bar',
+            'data': [
+                ['a', 'b', None],
+                [],
+                ['d', 'e', ''],
+            ]
+        }
+
+        applied_value = RichTextTableInput.json_dict_apply(
+            json.dumps(value),
+            lambda x: 2 * x
+        )
+
+        self.assertEqual(
+            json.loads(applied_value),
+            {
+                'foo': 'bar',
+                'data': [
+                    ['aa', 'bb', None],
+                    [],
+                    ['dd', 'ee', ''],
+                ]
+            }
+        )
+
+
+class TestAtomicTableBlock(TestCase):
+    def test_render_with_data(self):
+        value = {
+            'data': [['Header 1', 'Header 2'], ['1', '2']]
+        }
+        block = AtomicTableBlock()
+        result = block.render(value)
+        self.assertIn('<table', result)
+
+    def test_render_rich_text_page_links_expanded(self):
+        page = SimplePage(title='title', slug='slug', content='content')
+        default_site = Site.objects.get(is_default_site=True)
+        default_site.root_page.add_child(instance=page)
+
+        value = {
+            'data': [[
+                '<a linktype="page" id="{}">'.format(page.pk)
+            ]],
+        }
+        block = AtomicTableBlock()
+        result = block.render(value)
+        self.assertIn('href="/slug/"', result)


### PR DESCRIPTION
The `v1.atomic_elements.organisms.AtomicTableBlock` block provides a rich text editor in the Wagtail admin, but doesn't currently store its content in the database in the same way that the built-in
`RichTextBlock` block type does. This causes some inconsistency, for example in how internal links are rendered.

This change modifies the way that table content is stored in the database, making sure that it is first cleaned using `DbWhitelister` and then restored using `expand_db_html`, consistently with how Wagtail does it for `RichTextBlock` content. See `wagtail.wagtailcore.richtext` for reference.

This change also renames and slightly refactors the `AtomicTableInput` to `RichTextTableInput` to be more explicit about how it is intended to work. The JavaScript `initAtomicTable` method is similarly renamed to `initRichTextTable`. I did not rename `AtomicTableBlock` to `RichTextTableBlock` as that would have required additional migrations.

## Changes

- Refactoring of `AtomicTableBlock` to store and retrieve database data in the same way that `RichTextBlock` does, for more consistent rendering of cell content.

## Testing

- I've added a few unit tests but unfortunately because this change is mainly only visible through JS interaction in the editor, some manual testing is required. To demonstrate this change, create a `BrowsePage`, add a `TableBlock`, and then insert (for example) a link to an internal Wagtail page. You'll see that in the Wagtail editor this table cell's HTML looks like this:

```html
<a data-linktype="page" data-id="319" data-parent-id="1" href="/">CFGov</a>
```

but when the page is rendered, it looks properly like this:

```html
<a class="" href="/">CFGov</a>
```

This is in contrast to the current behavior where the rendered HTLM also contains those various `data-` fields which should be limited to just the editor.

## Checklist

* [X] PR has an informative and human-readable title
* [X] Changes are limited to a single goal (no scope creep)
* [X] Code can be automatically merged (no conflicts)
* [X] Passes all existing automated tests
* [X] New functions include new tests
* [X] New functions are documented (with a description, list of inputs, and expected output)
* [X] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
