### PR TITLE
Add EMAIL_SUBJECT_PREFIX to the inactive user email

### DIFF
--- a/cfgov/core/management/commands/inactive_users.py
+++ b/cfgov/core/management/commands/inactive_users.py
@@ -2,6 +2,7 @@ from __future__ import unicode_literals
 
 from datetime import timedelta
 
+from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.core.management.base import BaseCommand
 from django.core import mail
@@ -67,7 +68,8 @@ class Command(BaseCommand):
 
     def send_email(self, emails, period, inactive_users):
         now = date_format(timezone.now(), "SHORT_DATETIME_FORMAT")
-        subject = 'Inactive users as of {}'.format(now)
+        subject = '{prefix}Inactive users as of {now}'.format(
+            prefix=settings.EMAIL_SUBJECT_PREFIX, now=now)
         msg = ('The following active users have not logged in for '
                '{period}+ days:\n'.format(period=period))
         msg += self.format_inactive_users(inactive_users)

--- a/cfgov/core/tests/test_management_inactive_users.py
+++ b/cfgov/core/tests/test_management_inactive_users.py
@@ -7,7 +7,7 @@ from datetime import timedelta
 from django.contrib.auth import get_user_model
 from django.core import mail
 from django.core.management import call_command
-from django.test import TestCase
+from django.test import TestCase, override_settings
 from django.utils import timezone
 from django.utils.formats import date_format
 
@@ -92,6 +92,7 @@ class InactiveUsersTestCase(TestCase):
         self.assertNotIn("user_4", self.get_stdout())
         self.assertNotIn("user_5", self.get_stdout())
 
+    @override_settings(EMAIL_SUBJECT_PREFIX='[Prefix]')
     def test_sends_email(self):
         """ Test that mail.EmailMessage is called with the appropriate
         list of users """
@@ -103,6 +104,7 @@ class InactiveUsersTestCase(TestCase):
         email = mail.outbox[0]
         self.assertEqual(email.to, ['test@example.com'])
         self.assertEqual(email.from_email, 'webmaster@localhost')
+        self.assertIn('[Prefix]', email.subject)
         self.assertIn('Inactive users as of', email.subject)
 
         message = email.message().as_string()


### PR DESCRIPTION
This PR simply adds the Django `EMAIL_SUBJECT_PREFIX` setting to the `inactive_users` management command's email subject.

## Additions

- `settings.EMAIL_SUBJECT_PREFIX` to the `inactive_users` management command's email subject

## Checklist

* [x] PR has an informative and human-readable title
* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated
* [x] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
