### PR TITLE
Remove list alignment rule

### DIFF
--- a/cfgov/unprocessed/css/enhancements/base.less
+++ b/cfgov/unprocessed/css/enhancements/base.less
@@ -22,10 +22,6 @@ body {
     .webfont-regular(); // Moved to CF, delete freely when migrating to CF4
 }
 
-ul, ol {
-    padding-left: unit( 18px / @base-font-size-px, em );
-}
-
 /* topdoc
   name: EOF
   eof: true


### PR DESCRIPTION
Remove base list padding rule which was added for Ask landing page lists but is causing alignment issues in `full-width-text-group`.

## Removals

- List padding rule

## Todos

- Add a `list__flush-left` modifier for Ask landing page lists

