### PR TITLE
bump picard to 1.7.0, and small fix to AkamaiBackend

### DIFF
--- a/cfgov/v1/models/akamai_backend.py
+++ b/cfgov/v1/models/akamai_backend.py
@@ -11,9 +11,9 @@ logger = logging.getLogger(__name__)
 
 class AkamaiBackend(BaseBackend):
     def __init__(self, params):
-        self.client_token = params.pop('CLIENT_TOKEN')
-        self.client_secret = params.pop('CLIENT_SECRET')
-        self.access_token = params.pop('ACCESS_TOKEN')
+        self.client_token = params.get('CLIENT_TOKEN')
+        self.client_secret = params.get('CLIENT_SECRET')
+        self.access_token = params.get('ACCESS_TOKEN')
         if not all((
             self.client_token,
             self.client_secret,

--- a/requirements/optional-private.txt
+++ b/requirements/optional-private.txt
@@ -6,5 +6,5 @@ git+https://private.repo/CFPB/agreement_database.git@2.2.7#egg=agreement-databas
 selfregistration==@1.3.1
 git+https://private.repo/CFPB/django-college-cost-comparison.git@v1.2.9#egg=comparisontool
 git+https://private.repo/CFPB/knowledgebase.git@2.3.1#egg=knowledgebase
-git+https://private.repo/CFPB/Picard.git@1.5.5#egg=picard
+git+https://private.repo/CFPB/Picard.git@1.7.0#egg=picard
 git+https://private.repo/eregs/ip.git@1.0.3#egg=eregsip


### PR DESCRIPTION
## Changes

- Picard is updated to 1.7.0
- AkamaiBackend no longer removes the values from the `params` dictionary during instantiation. That behavior proved problematic when `params` is a reference to a settings variable, and  AkamaiBackend is instantiated more than once in a python process

## Testing

Try out /tasks/ in your local install. Depending on If you have all of the necessary Akamai settings configured, you might observe "purge request submitted" or "Akamai is not configured on this server" when you try to flush Akamai.


## Checklist

* [ ] PR has an informative and human-readable title
* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated
* [ ] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
