### PR TITLE
Add AB_TESTING flag for Optimize code snippets

### DIFF
--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -606,4 +606,9 @@ FLAGS = {
     'WAGTAIL_ASK_CFPB': {
         'boolean': True if DEPLOY_ENVIRONMENT in ['build'] else False
     },
+
+    # Google Optimize code snippets for A/B testing
+    # When enabled this flag will add various Google Optimize code snippets.
+    # Intended for use with path conditions.
+    'AB_TESTING': {},
 }

--- a/cfgov/jinja2/v1/_layouts/base.html
+++ b/cfgov/jinja2/v1/_layouts/base.html
@@ -130,6 +130,7 @@
              (Ideally, also, we will move away from jQuery entirely.) #}
     <script src="{{ static('js/jquery.min.js') }}"></script>
 
+    {% if flag_enabled('AB_TESTING', request) %}
     <!-- Google Optimize page-hiding snippet -->
     <style>
         .optimize-loading {
@@ -158,6 +159,7 @@
         // the Google Tag Manager tag (code included below).
     </script>
     <!-- end Google Analytics/Optimize snippet -->
+    {% endif %}
 
     <!-- Google Tag Manager -->
     <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':

--- a/docs/feature-flags.md
+++ b/docs/feature-flags.md
@@ -166,7 +166,7 @@ This lambda takes the request and calls the [Wagtail-Sharing](https://github.com
 
 ## Enabling a flag
 
-Feature flags are enabled based on a set of conditions that are given either in the Django settings files (in `cfgov/cfgov/settings/`) or in the Django or Wagtail admin. Multiple conditions can be given, both in settings and in the admin, and all conditions must be satisfied before a flag is enabled.
+Feature flags are enabled based on a set of conditions that are given either in the Django settings files (in `cfgov/cfgov/settings/`) or in the Django or Wagtail admin. Multiple conditions can be given, both in settings and in the admin, and if any condition is satisfied a flag is enabled.
 
 [A list of available conditions and how to use them is available in the Wagtail-Flags documentation](https://github.com/cfpb/wagtail-flags/blob/master/README.md#built-in-conditions).
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -43,6 +43,6 @@ tinys3==0.1.11
 unipath>=1.1,<=2.0
 vobject==0.9.1
 wagtail==1.8.1
-wagtail-flags==2.0.2
+wagtail-flags==2.0.3
 wagtail-sharing==0.5
 Wand==0.4.2


### PR DESCRIPTION
Adds a feature flag for A/B testing around the Google Optimize code in `base.html`.

After this PR, to conduct an A/B test we will have to add a "path" condition for the `AB_TESTING` flag in the Wagtail Admin before the optimize code snippets are available on the page being tested.

![image](https://cloud.githubusercontent.com/assets/10562538/26272581/cb0994b4-3ce9-11e7-8220-801812dd1129.png)

This PR depends on https://github.com/cfpb/wagtail-flags/pull/12

## Changes

- Wrap the Optimize code in a feature flag.

## Testing

Install that Wagtail-Flags PR from its branch:

```
pip install git+https://github.com/cfpb/wagtail-flags.git@any-instead-of-all
```

Run the server:

```
./runserver.sh
```

Then go to http://localhost:8000/admin/flags/ and add a "path" condition for `AB_TESTING` with a path served from Wagtail, visit that path and verify that the Google Optimize code is in the header.

## Notes

Travis will fail on this PR until Wagtail-Flags 2.0.3 is released.

## Checklist

* [ ] PR has an informative and human-readable title
* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated
* [ ] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
