### PR TITLE
Add DB dump download feature to refresh script

### DIFF
--- a/refresh-data.sh
+++ b/refresh-data.sh
@@ -42,7 +42,7 @@ if [[ -z "$refresh_dump_name" ]]; then
 
 Or you can define the location of a dump and this script will download it for you:
 
-	export CFGOV_PROD_DB_LOCATION=http://bucket-name.s3.amazonaws.com/db_dumps/production_django.sql.gz
+	export CFGOV_PROD_DB_LOCATION=http://some-bucket.s3.amazonaws.com/wherever/production_django.sql.gz
 	./refresh-data.sh
 	'
 else

--- a/refresh-data.sh
+++ b/refresh-data.sh
@@ -10,6 +10,13 @@
 set -e
 refresh_dump_name=$1
 
+download_data() {
+	echo 'Downloading fresh production Django database dump...'
+	prod_archive="$refresh_dump_name".gz
+	curl -o $prod_archive $CFGOV_PROD_DB_LOCATION
+	gunzip -f $prod_archive
+}
+
 refresh_data(){
 	echo 'Dropping db'
 	./drop-db.sh
@@ -17,8 +24,27 @@ refresh_data(){
 	./create-mysql-db.sh
 	echo 'Importing refresh db'
 	mysql v1 -u root -p < $refresh_dump_name
-    echo 'Setting up initial data'
-    ./cfgov/manage.py runscript initial_data
+	echo 'Setting up initial data'
+	./cfgov/manage.py runscript initial_data
 }
 
-refresh_data
+# If no argument was passed to the script and the db dump env variable is set
+if [[ -z "$1" && ! -z "$CFGOV_PROD_DB_LOCATION" ]]; then
+	refresh_dump_name='production_django.sql'
+	download_data
+fi
+
+# Only attempt to load data if a db dump file is provided
+if [[ -z "$refresh_dump_name" ]]; then
+	echo 'Please download a recent database dump before running this script:
+
+	./refresh-data.sh production_django.sql
+
+Or you can define the location of a dump and this script will download it for you:
+
+	export CFGOV_PROD_DB_LOCATION=http://bucket-name.s3.amazonaws.com/db_dumps/production_django.sql.gz
+	./refresh-data.sh
+	'
+else
+	refresh_data
+fi


### PR DESCRIPTION
With this commit, invoking the refresh-data script without any arguments will download the latest DB dump for you (if CFGOV_PROD_DB_LOCATION is defined).

## Testing

```sh
export CFGOV_PROD_DB_LOCATION=http://<our-secret-location-check-ghe>/production_django.sql.gz
./refresh-data.sh
```

It should download `production_django.sql.gz` and then do the normal MySQL import process.

Running `./refresh-data.sh` without any arguments and without CFGOV_PROD_DB_LOCATION defined will show some help text.

## Checklist

* [ ] PR has an informative and human-readable title
* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated
* [ ] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
