### PR TITLE
Tox environment cleanup

### DIFF
--- a/run_travis.sh
+++ b/run_travis.sh
@@ -8,7 +8,7 @@ if [ "$RUNTEST" == "frontend" ]; then
     gulp "test:unit"
     gulp "test:coveralls"
 elif [ "$RUNTEST" == "backend" ]; then
-    tox -e travis
+    tox
     flake8
     coveralls
 fi

--- a/tox.ini
+++ b/tox.ini
@@ -1,69 +1,67 @@
 [tox]
-envlist = py27,py34
-skipsdist = True
+envlist=py27
+skipsdist=True
 
 [testenv]
-recreate = True
-# TODO: Pull in environment variables from .env instead of re-defining them.
-setenv =
-    GOVDELIVERY_ACCOUNT_CODE = fake_account_code
-    DJANGO_SETTINGS_MODULE = cfgov.settings.test
-    ES_PORT=9200
-    ES_HOST=localhost
-    SHEER_ELASTICSEARCH_INDEX=content
-    DJANGO_STAGING_HOSTNAME=content.localhost
-    DJANGO_HTTP_PORT=8000
-    AKAMAI_NOTIFY_EMAIL=test@mail.com
-    AKAMAI_HOST=localhost
-    DEPLOY_ENVIRONMENT=build
-deps =
-    -r{toxinidir}/requirements/test.txt
-changedir = {toxinidir}/cfgov
-commands =
+# Invoke with: tox
+changedir={toxinidir}/cfgov
+commands=
     coverage erase
     coverage run --source='.' manage.py test {posargs}
+deps=-r{toxinidir}/requirements/test.txt
+envdir={toxworkdir}/py27
+passenv=TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH
+recreate=True
+setenv=
+    GOVDELIVERY_ACCOUNT_CODE=fake_account_code
+    DJANGO_SETTINGS_MODULE=cfgov.settings.test
+    DJANGO_STAGING_HOSTNAME=content.localhost
+    DEPLOY_ENVIRONMENT=build
+    LANG=en_US.UTF-8
+    LC_ALL=en_US.UTF-8
 
 [testenv:fast]
-recreate = False
-setenv =
+# Invoke with: tox -e fast
+# Don't recreate virtualenv, skip Django migrations.
+envdir={[testenv]envdir}
+recreate=False
+setenv=
     {[testenv]setenv}
     DJANGO_SETTINGS_MODULE=cfgov.settings.test_nomigrations
 
 [testenv:acceptance]
-recreate = False
-commands =
-     coverage run --source='.' manage.py test {posargs}
-passenv =
-    USER
-setenv =
+# Invoke with: tox -e acceptance
+# Run acceptance tests using same virtualenv as backend tests.
+# Always skips unnecessary Django migrations.
+envdir={[testenv]envdir}
+passenv=USER
+setenv=
     {[testenv]setenv}
-    LANG=en_US.UTF-8
-    LC_ALL=en_US.UTF-8
     DJANGO_LIVE_TEST_SERVER_ADDRESS=localhost:9000-9010
     DJANGO_SETTINGS_MODULE=cfgov.settings.test_acceptance
 
-[testenv:optional-public]
-deps=
-    -r{toxinidir}/requirements/optional-public.txt
-    {[testenv]deps}
-
-[testenv:optional-private]
-deps=
-    -r{toxinidir}/requirements/optional-private.txt
-    {[testenv]deps}
+[testenv:acceptance-fast]
+# Invoke with: tox -e acceptance-fast
+# Run acceptance tests without recreating virtualenv.
+envdir={[testenv:acceptance]envdir}
+passenv={[testenv:acceptance]passenv}
+recreate=False
+setenv={[testenv:acceptance]setenv}
 
 [testenv:optional]
+# Invoke with: tox -e optional
+# Also run tests against public optional Django apps.
+# Uses alternate virtualenv with -optional suffix.
 deps=
     -r{toxinidir}/requirements/optional-public.txt
-    -r{toxinidir}/requirements/optional-private.txt
     {[testenv]deps}
+envdir={[testenv]envdir}-optional
 
-[testenv:fast-optional]
+[testenv:optional-fast]
+# Invoke with: tox -e optional-fast
+# Include optional public apps but don't recreate virtualenv each time.
+# Also skips unnecessary Django migrations.
+deps={[testenv:optional]deps}
+envdir={[testenv:optional]envdir}
 recreate={[testenv:fast]recreate}
 setenv={[testenv:fast]setenv}
-deps={[testenv:optional]deps}
-
-[testenv:travis]
-passenv = TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH
-commands =
-    coverage run --source='.' manage.py test


### PR DESCRIPTION
This commit cleans up and simplifies the list of available tox environments in `tox.ini`. There's now a single supported main environment (`py27`) which is run with `tox` whether or not you have the `TOXENV` environment variable set.

Documentation in the `tox.ini` file now describes the following available commands:

- `tox -e fast`: run all project unit tests, use the same virtual environment as standard `tox`, don't recreate the virtualenv each time. Also uses special Django settings that skip unneeded migrations.
- `tox -e acceptance`: use the same virtualenv but run browser tests instead of Python unit tests. Also skips unneeded migrations.
- `tox -e acceptance-fast`: same as `acceptance`, but don't recreate the virtual environment each time.
- `tox -e optional`: using a separate virtual environment (named, e.g. `py27-optional`) install optional public Django apps and run their unit tests as well.
- `tox -e optional-fast`: using the same virtualenv as `optional`, run all unit tests but skip unneeded Django migrations.

This change also moves some Travis environment variables into the testing environment for simplification, to avoid needing a separate Travis environment.

In theory this reorganization should make it easier in future to add support for Python3 while maintaining all of these various environments.

## Changes

- `tox.ini` cleanup.

## Testing

- Try running any of the `tox` commands described above. Note that, for example, after you run `tox` once, you can run any of the `-fast` environments without needing to recreate it.

## Checklist

* [X] PR has an informative and human-readable title
* [X] Changes are limited to a single goal (no scope creep)
* [X] Code can be automatically merged (no conflicts)
* [X] Passes all existing automated tests
* [X] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Project documentation has been updated
* [X] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
