### PR TITLE
Half and third width link blob group headings fix

### DIFF
--- a/cfgov/unprocessed/css/organisms/info-unit-group.less
+++ b/cfgov/unprocessed/css/organisms/info-unit-group.less
@@ -50,7 +50,7 @@
     // 30px between headings and 15px between headings and paragraphs.
     // See https://[GHE]/CFGOV/platform/issues/860
     h2 {
-      margin-bottom: 0;
+      .u-mb0;
       + .content-l {
         h3 {
           margin-top: unit( @grid_gutter-width / @size-iii, em );

--- a/cfgov/unprocessed/css/organisms/info-unit-group.less
+++ b/cfgov/unprocessed/css/organisms/info-unit-group.less
@@ -44,6 +44,26 @@
     - cfgov-organisms
 */
 .o-info-unit-group {
+
+    // This is hacky but we need to target a variable number of
+    // nested info unit headings. h2, h3 and h4 are all optional. We want
+    // 30px between headings and 15px between headings and paragraphs.
+    // See https://[GHE]/CFGOV/platform/issues/860
+    h2 {
+      margin-bottom: 0;
+      + .content-l {
+        h3 {
+          margin-top: unit( @grid_gutter-width / @size-iii, em );
+        }
+        h4 {
+          margin-top: unit( @grid_gutter-width / @size-iv, em );
+        }
+        p {
+          margin-top: unit( @grid_gutter-width / @base-font-size-px / 2, em );
+        }
+      }
+    }
+
     .content-l_col-1 + .content-l_col-1 {
         // Adds margin top to info units that follow another
         margin-top: unit( @grid_gutter-width / @base-font-size-px, em ) !important;


### PR DESCRIPTION
This is an attempt to fix https://[GHE]/CFGOV/platform/issues/860.

We want 30px between headings in link blob groups and 15px between headings and paragraph text. The tricky part is that headings are optional so there's no guarantee that a h2, h3 or h4 will be present. This PR removes h2's bottom padding, adds 30px to the top of h3s and h4s, and adds 15px to the top of paragraphs.

## Screenshots

<img width="859" alt="screen shot 2017-05-22 at 9 53 57 pm" src="https://cloud.githubusercontent.com/assets/1060248/26335710/d222b858-3f3b-11e7-8130-2cfc7efb214a.png">

<img width="853" alt="screen shot 2017-05-22 at 9 57 53 pm" src="https://cloud.githubusercontent.com/assets/1060248/26335713/d461e576-3f3b-11e7-8a79-ddc398dabf7b.png">

## Checklist

* [ ] PR has an informative and human-readable title
* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated
* [ ] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
