### PR TITLE
Remove MOSAIC_CCDB flag and update complaint to 1.3.3

### DIFF
--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -599,15 +599,12 @@ FLAGS = {
     # When enabled, the "Submit a complaint" page is served from Wagtail
     'MOSAIC_COMPLAINTS': {},
 
-    # Transition of CCDB landing page to Mosaic version
-    # When enabled, the CCDB landing page is the Mosaic version
-    'MOSAIC_CCDB': {},
-
     # Migration of Ask CFPB to Wagtail
     # When enabled, Ask CFPB is served from Wagtail
     'WAGTAIL_ASK_CFPB': {
         'boolean': True if DEPLOY_ENVIRONMENT in ['build'] else False
     },
+
     # The next version of the public consumer complaint database
     'CCDB5_RELEASE': {},
 

--- a/requirements/optional-public.txt
+++ b/requirements/optional-public.txt
@@ -1,5 +1,5 @@
 git+https://github.com/cfpb/college-costs.git@2.3.4#egg=college-costs
-git+https://github.com/cfpb/complaint.git@1.3.2#egg=complaintdatabase
+git+https://github.com/cfpb/complaint.git@1.3.3#egg=complaintdatabase
 git+https://github.com/cfpb/django-hud.git@1.2#egg=django-hud
 git+https://github.com/cfpb/owning-a-home-api.git@0.9.96#egg=owning-a-home-api
 git+https://github.com/cfpb/regulations-core.git@1.2.3#egg=regcore


### PR DESCRIPTION
This PR removes the MOSAIC_CCDB feature flag from configuration and updates the complaint app to 1.3.3.

## Removals

- `MOSAIC_CCDB` feature flag

## Changes

- complaint to 1.3.3

## Checklist

* [ ] PR has an informative and human-readable title
* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated
* [ ] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
