### PR TITLE
Always connect to the django-hud API using localhost

### DIFF
--- a/cfgov/legacy/views/housing_counselor.py
+++ b/cfgov/legacy/views/housing_counselor.py
@@ -47,7 +47,7 @@ class HousingCounselorView(TemplateView):
             kwargs={'zipcode': zipcode}
         )
 
-        api_url = request.build_absolute_uri(api_path)
+        api_url = 'http://localhost' + api_path
         response = requests.get(api_url)
         response.raise_for_status()
 


### PR DESCRIPTION
This PR fixes an issue with accessing a local django-hud API using the request's hostname and port.

In theory using `request.build_absolute_uri` should work but it can fail if, for example, DNS resolution doesn't work as expected. This breaks behavior when running with the Django development server.

## Changes

- Always connect using `localhost`.

## Checklist

* [X] PR has an informative and human-readable title
* [X] Changes are limited to a single goal (no scope creep)
* [X] Code can be automatically merged (no conflicts)
* [X] Passes all existing automated tests
* [X] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
