### PR TITLE
Always use localhost when rendering HUD PDFs

### DIFF
--- a/cfgov/legacy/views/housing_counselor.py
+++ b/cfgov/legacy/views/housing_counselor.py
@@ -69,9 +69,7 @@ class HousingCounselorPDFView(View):
 
     def get_render_url(self, zipcode):
         html_path = reverse('housing-counselor')
-        return self.request.build_absolute_uri(
-            html_path + '?zipcode={}&pdf'.format(zipcode)
-        )
+        return 'http://localhost{}?zipcode={}&pdf'.format(html_path, zipcode)
 
     def generate_pdf_from_url(self, url, filename):
         result = self.pdfreactor.renderDocumentFromURL(url)


### PR DESCRIPTION
Followup to https://github.com/cfpb/cfgov-refresh/pull/2935 -- `request.build_absolute_uri` doesn't work properly on deployed infrastructure so we have to use `localhost` as a workaround.

This unfortunately breaks local rendering of PDFs.

## Checklist

* [X] PR has an informative and human-readable title
* [X] Changes are limited to a single goal (no scope creep)
* [X] Code can be automatically merged (no conflicts)
* [X] Passes all existing automated tests
* [X] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
