### PR TITLE
Correct improper use of unicode PDFReactor license key

### DIFF
--- a/cfgov/legacy/views/housing_counselor.py
+++ b/cfgov/legacy/views/housing_counselor.py
@@ -94,7 +94,11 @@ class HousingCounselorPDFView(View):
         reactor = PDFreactor()
 
         reactor.setLogLevel(PDFreactor.LOG_LEVEL_FATAL)
-        reactor.setLicenseKey(os.environ['PDFREACTOR_LICENSE'])
+
+        # License key needs to be cast to str here because PDFReactor
+        # doesn't play well with unicode.
+        reactor.setLicenseKey(str(os.environ['PDFREACTOR_LICENSE']))
+
         reactor.setAuthor('CFPB')
         reactor.setAddTags(True)
         reactor.setAddBookmarks(True)


### PR DESCRIPTION
PDFReactor doesn't play well with unicode values for the license key.

This fixes the removal of [this line](https://github.com/cfpb/cfgov-refresh/commit/64f89b07cd6cceae3d4c53bbb0a9910008523271#diff-ce8b16726af60f2157fbb75fb8b61a7cL111) in #2924. When we pass the license key to PDFReactor, we need to make sure it's of type `str`.

## Changes

- Cast PDFReactor license key to `str`.

## Checklist

* [X] PR has an informative and human-readable title
* [X] Changes are limited to a single goal (no scope creep)
* [X] Code can be automatically merged (no conflicts)
* [X] Passes all existing automated tests
* [X] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
