### PR TITLE
Disable logging below CRITICAL during acceptance tests

### DIFF
--- a/cfgov/cfgov/settings/test.py
+++ b/cfgov/cfgov/settings/test.py
@@ -11,8 +11,6 @@ EMAIL_BACKEND = 'django.core.mail.backends.locmem.EmailBackend'
 
 TEST_RUNNER = 'cfgov.test.TestDataTestRunner'
 
-LOGGING = {}
-
 INSTALLED_APPS += (
     'wagtail.contrib.settings',
     'wagtail.tests.testapp',

--- a/cfgov/cfgov/test.py
+++ b/cfgov/cfgov/test.py
@@ -93,7 +93,6 @@ class TestDataTestRunner(OptionalAppsMixin, DiscoverRunner):
 
 
 class AcceptanceTestRunner(TestDataTestRunner):
-
     def run_suite(self, **kwargs):
         gulp_command = ['gulp', 'test:acceptance:protractor']
         SPECS_KEY = 'specs'
@@ -116,7 +115,6 @@ class AcceptanceTestRunner(TestDataTestRunner):
     def setup_databases(self, **kwargs):
         dbs = super(AcceptanceTestRunner, self).setup_databases(**kwargs)
         test_data.run()
-
         return dbs
 
     def teardown(self):
@@ -125,6 +123,9 @@ class AcceptanceTestRunner(TestDataTestRunner):
         StaticLiveServerTestCase.tearDownClass()
 
     def run_tests(self, test_labels, extra_tests=None, **kwargs):
+        # Disable logging below CRITICAL during tests.
+        logging.disable(logging.CRITICAL)
+
         self.setup_test_environment()
         self.dbs = self.setup_databases()
 


### PR DESCRIPTION
The current test settings (`cfgov.settings.test` and related modules) override `settings.LOGGING` with an empty dict. This causes warning statements from the logging system if any logging statements are called.

This change was introduced in 59a9e5500d71ca25b69a6d2349d22c69cd0ce6a6. At a later date, in 5a80a5aface1852f1d5838d4db1ddb47cb51be79, the unit test runner (which is now also used by acceptance tests) was also changed to disable non-critical logging via `logging.disable(logging.CRITICAL)`.

This commit alters the acceptance test runner so that is also uses this method to disable non-critical logging, rather than just removing all logs. This prevents logging messages in the test output while still
avoiding warnings if loggers are invoked.

## Changes

- `cfgov.settings.test` no longer removes all loggers in `settings.LOGGING`.

## Testing

- Run `tox -e fast` and `tox -e acceptance-fast` and verify that no logging messages are dumped during tests.

## Checklist

* [X] PR has an informative and human-readable title
* [X] Changes are limited to a single goal (no scope creep)
* [X] Code can be automatically merged (no conflicts)
* [X] Passes all existing automated tests
* [X] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
