### PR TITLE
Fix expired password message and reset password button styling

### DIFF
--- a/cfgov/templates/wagtailadmin/account/password_reset/confirm.html
+++ b/cfgov/templates/wagtailadmin/account/password_reset/confirm.html
@@ -40,7 +40,7 @@
                     </li>
                 {% endfor %}
                 <li class="submit">
-                    <input type="submit" value="{% trans 'Reset password' %}"/>
+                    <button type="submit" class="button button-longrunning" tabindex="3" data-clicked-text="Working..."><span class="icon icon-spinner"></span><em>{% trans 'Reset password' %}</em></button>
                 </li>
             </ul>
         </form>

--- a/cfgov/v1/auth_forms.py
+++ b/cfgov/v1/auth_forms.py
@@ -97,7 +97,7 @@ class LoginForm(AuthenticationForm):
                         'This account is temporarily locked; '
                         'please try later or <a href="/admin/password_reset/" '
                         'style="color:white;font-weight:bold">'
-                        'reset your password</a>'
+                        'reset your password</a>.'
                     )
                 else:
                     fa.save()
@@ -117,11 +117,10 @@ class LoginForm(AuthenticationForm):
 
                     if dt_now > current_password_data.expires_at:
                         raise ValidationError(
-                            'This account is temporarily locked; '
-                            'please try later or '
+                            'Your password has expired. Please '
                             '<a href="/admin/password_reset/" '
                             'style="color:white;font-weight:bold">'
-                            'reset your password</a>'
+                            'reset your password</a>.'
                         )
 
                 except ObjectDoesNotExist:
@@ -140,7 +139,7 @@ class LoginForm(AuthenticationForm):
                 'This account is temporarily locked; '
                 'please try later or <a href="/admin/password_reset/" '
                 'style="color:white;font-weight:bold">'
-                'reset your password</a>'
+                'reset your password</a>.'
             )
 
 


### PR DESCRIPTION
I got tired of the message for an expired password not telling you that your password has expired and implying that simply waiting might fix it.

This also updates the button on the password reset confirmation form to be in line with standard Wagtail auth flow button styling.

## Changes

- Reworded expired password error message to be helpful
- Updated password reset confirmation form button styling

## Testing

I'm not sure how to fake an expired password, but here's how to see the new button styling:

1. Pull this branch
2. `./runserver.sh` if not already running
3. Go to https://localhost:8000/admin/
4. Log out if already logged in
5. Click "Forgotten it?" on the login form
6. Enter your email address and submit the form
7. View the console to see the email it _would_ be sending you
8. Copy the password reset link from the console and paste it into the browser
9. See the updated button at the bottom of the form
 
## Screenshots

![screen shot 2017-05-25 at 15 42 56](https://cloud.githubusercontent.com/assets/1044670/26467650/922112d6-4161-11e7-847f-092d9b689a9f.png)

## Notes

- I noted when testing this that if you try to visit a password reset link that you've already used, there is no error message. Just a page with no fields:

  ![screen shot 2017-05-25 at 15 49 32](https://cloud.githubusercontent.com/assets/1044670/26467706/cb5f867c-4161-11e7-9675-4d352d7a50bc.png)

  I wasn't sure how to fix this properly.

## Checklist

* [x] PR has an informative and human-readable title
* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices
* [x] Project documentation has been updated
* [x] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
