### PR TITLE
Run acceptance tests on Travis w/headless browser

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,14 @@
 language: python
 sudo: false
+dist: trusty
 
 python:
   - "2.7"
+
+addons:
+  apt:
+    packages:
+      - google-chrome-beta
 
 cache: pip
 
@@ -26,6 +32,7 @@ env:
   matrix:
     - RUNTEST=frontend
     - RUNTEST=backend
+    - RUNTEST=acceptance
 
 script:
   - ./run_travis.sh

--- a/config/environment.js
+++ b/config/environment.js
@@ -17,7 +17,8 @@ var envvars = {
   SAUCE_SELENIUM_URL:      process.env.SAUCE_SELENIUM_URL,
   SAUCE_USERNAME:          process.env.SAUCE_USERNAME,
   SAUCE_ACCESS_KEY:        process.env.SAUCE_ACCESS_KEY,
-  ACHECKER_ID:             process.env.ACHECKER_ID
+  ACHECKER_ID:             process.env.ACHECKER_ID,
+  HEADLESS_CHROME_BINARY:  process.env.HEADLESS_CHROME_BINARY
 
   /* eslint-enable no-process-env */
 };

--- a/gulp/tasks/test.js
+++ b/gulp/tasks/test.js
@@ -44,22 +44,6 @@ function testUnitScripts( cb ) {
 }
 
 /**
- * Run tox unit tests.
- */
-function testUnitServer() {
-  spawn(
-    'tox',
-    { stdio: 'inherit' }
-  ).once( 'close', function( code ) {
-    if ( code ) {
-      gulpUtil.log( 'Tox tests exited with code ' + code );
-      process.exit( 1 );
-    }
-    gulpUtil.log( 'Tox tests done!' );
-  } );
-}
-
-/**
  * Run tox Acceptance tests.
  */
 function testAcceptanceBrowser() {
@@ -299,7 +283,3 @@ gulp.task( 'test:coveralls', testCoveralls );
 gulp.task( 'test:perf', testPerf );
 gulp.task( 'test:unit', [ 'test:unit:scripts' ] );
 gulp.task( 'test:unit:scripts', testUnitScripts );
-
-// This task will only run on Travis
-gulp.task( 'test:unit:server', testUnitServer );
-

--- a/run_travis.sh
+++ b/run_travis.sh
@@ -11,4 +11,11 @@ elif [ "$RUNTEST" == "backend" ]; then
     tox
     flake8
     coveralls
+elif [ "$RUNTEST" == "acceptance" ]; then
+    export DISPLAY=:99.0
+    sh -e /etc/init.d/xvfb start &
+    sleep 3
+
+    export HEADLESS_CHROME_BINARY=/usr/bin/google-chrome-beta
+    gulp test:acceptance
 fi

--- a/test/browser_tests/conf.js
+++ b/test/browser_tests/conf.js
@@ -21,7 +21,6 @@ function _paramIsSet( param ) {
  */
 function _chooseSuite( params ) {
 
-
   var paramsAreNotSet = !_paramIsSet( params.browserName ) &&
                         !_paramIsSet( params.version ) &&
                         !_paramIsSet( params.platform );
@@ -36,7 +35,10 @@ function _chooseSuite( params ) {
   // This will make it so that setting the browser/platform flags
   // won't launch several identical browsers performing the same tests.
   var capabilities = defaultSuites.essential;
-  if ( paramsAreNotSet && useSauceCredentials ) {
+
+  if ( envvars.HEADLESS_CHROME_BINARY ) {
+    capabilities = defaultSuites.headless;
+  } else if ( paramsAreNotSet && useSauceCredentials ) {
     capabilities = defaultSuites.full;
   }
 
@@ -159,7 +161,7 @@ function _copyParameters( params, capabilities ) { // eslint-disable-line comple
 
 var config = {
   baseUrl:       environment.baseUrl,
-   cucumberOpts: {
+  cucumberOpts: {
     require:     'cucumber/step_definitions/*.js',
     tags:        false,
     format:      'pretty',
@@ -203,17 +205,20 @@ var config = {
       windowHeightPx = Number( windowSizeArray[1] );
     }
 
-    browser.driver.manage().window().setSize(
-      windowWidthPx,
-      windowHeightPx
-    );
+    // Calling setSize with headless chromeDriver doesn't work properly if
+    // the requested size is larger than the available screen size.
+    if ( !envvars.HEADLESS_CHROME_BINARY ) {
+      browser.driver.manage().window().setSize(
+        windowWidthPx,
+        windowHeightPx
+      );
 
-    // Set default windowSize parameter equal to the value in settings.js.
-    browser.params.windowWidth = windowWidthPx;
-    browser.params.windowHeight = windowHeightPx;
-    browser.params.windowSize = String( windowWidthPx ) +
-                                ',' + String( windowHeightPx );
-
+      // Set default windowSize parameter equal to the value in settings.js.
+      browser.params.windowWidth = windowWidthPx;
+      browser.params.windowHeight = windowHeightPx;
+      browser.params.windowSize = String( windowWidthPx ) +
+                                  ',' + String( windowHeightPx );
+    }
 
     return;
   }

--- a/test/browser_tests/default-suites.js
+++ b/test/browser_tests/default-suites.js
@@ -1,5 +1,7 @@
 'use strict';
 
+var envvars = require( '../../config/environment' ).envvars;
+
 var defaultSuites = {
   // Set default browser suites to test.
   // These values are passed to the `multiCapabilities` property
@@ -40,6 +42,17 @@ var defaultSuites = {
       version:     '',
       platform:    'Windows 10',
       maxDuration: 10800
+    }
+  ],
+
+  // Headless browser to run on Travis.
+  headless: [
+    {
+      browserName: 'chrome',
+      chromeOptions: {
+        args: [ '--headless', '--disable-gpu' ],
+        binary: envvars.HEADLESS_CHROME_BINARY
+      }
     }
   ]
 };

--- a/tox.ini
+++ b/tox.ini
@@ -39,6 +39,7 @@ setenv=
     {[testenv]setenv}
     DJANGO_LIVE_TEST_SERVER_ADDRESS=localhost:9000-9010
     DJANGO_SETTINGS_MODULE=cfgov.settings.test_acceptance
+commands=./manage.py test
 
 [testenv:acceptance-fast]
 # Invoke with: tox -e acceptance-fast
@@ -47,6 +48,7 @@ envdir={[testenv:acceptance]envdir}
 passenv={[testenv:acceptance]passenv}
 recreate=False
 setenv={[testenv:acceptance]setenv}
+commands={[testenv:acceptance]commands}
 
 [testenv:optional]
 # Invoke with: tox -e optional

--- a/tox.ini
+++ b/tox.ini
@@ -34,7 +34,7 @@ setenv=
 # Run acceptance tests using same virtualenv as backend tests.
 # Always skips unnecessary Django migrations.
 envdir={[testenv]envdir}
-passenv=USER
+passenv=USER HEADLESS_CHROME_BINARY DISPLAY
 setenv=
     {[testenv]setenv}
     DJANGO_LIVE_TEST_SERVER_ADDRESS=localhost:9000-9010


### PR DESCRIPTION
This commit adds the running of browser tests to our TravisCI integration, using the headless mode of Google Chrome. Currently this requires a custom installation of `google-chrome-beta` (version 59)
although this functionality should be coming to the stable release soon.

The various Protractor-related files have been modified to look for a `GOOGLE_CHROME_BINARY` environment variable; if this is set, running the browser tests (using `tox -e acceptance` or `gulp test:acceptance`) will try to invoke that path in headless mode.

Note: this is a suboptimal way to configure that headless mode is desired, but I've punted on a better way pending some ongoing discussions with @sebworks about a larger refactor of Protractor config.

To test locally on MacOS, download the beta version of Google Chrome:

https://www.google.com/chrome/browser/beta.html

Then set the environment variable like:

```
GOOGLE_CHROME_BINARY=/path/to/Google\ Chrome\ Beta\ App.app/Contents/MacOS/Google\ Chrome
```

## Additions

- New acceptance testing matrix entry for Travis, and support for running Protractor with a headless browser.

## Removals

- Removed `gulp test:unit:server` to standardize on use of `tox` for running Python unit tests.

## Testing

- Look at the Travis logs! Follow steps above to reproduce with a local headless browser.

## Notes

- Unfortunately there seems to be an issue with calling `setSize` to set the browser size when using the headless mode with chromeDriver; I think this might be because of the need for `Xvfb` which is due to [this open issue](https://bugs.chromium.org/p/chromedriver/issues/detail?id=1772). See also [this open issue to Travis](https://github.com/travis-ci/travis-ci/issues/7650#issuecomment-302467188).

## Checklist

* [X] PR has an informative and human-readable title
* [X] Changes are limited to a single goal (no scope creep)
* [X] Code can be automatically merged (no conflicts)
* [X] Passes all existing automated tests
* [X] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
