### PR TITLE
Fixes formatting issue in installation docs note

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -86,9 +86,9 @@ You can optionally install a different version with Homebrew.
 
 #### Elasticsearch
 
-!!! note
-  __These instructions are deprecated since Elasticsearch 1.7
-  is no longer supported by `brew`__
+!!! warning
+    __These instructions are deprecated since Elasticsearch 1.7
+    is no longer supported by `brew`.__
 
 [Install Elasticsearch 1.7](https://www.elastic.co/guide/en/elasticsearch/reference/1.7/setup.html)
 however you’d like. We use [Homebrew](http://brew.sh) for developing on OS X):


### PR DESCRIPTION
Installation docs note contents were not included in their associated
note because their indent was not far enough in. Also, changes the note
to a warning because that’s what it is.

## Changes

- Indents note contents in the installation doc so that they appear inside their associated note.
- Updates note type to warning, because that's what it is.

## Testing

- To preview docs locally, first `pip install -r requirements/manual.txt`
- `mkdocs serve`
- go to http://127.0.0.1:8000/installation/ and scroll down to ES 1.7 warning.

## Screenshots

Before:

<img width="894" alt="screen shot 2017-05-26 at 5 08 57 pm" src="https://cloud.githubusercontent.com/assets/704760/26512934/d337cf82-4236-11e7-877a-74d98ae68436.png">

After:

<img width="834" alt="screen shot 2017-05-26 at 5 15 05 pm" src="https://cloud.githubusercontent.com/assets/704760/26512939/e281675a-4236-11e7-9edc-388dabee2e5f.png">
