### PR TITLE
Add "social sharing image" image chooser to settings panel

### DIFF
--- a/cfgov/jinja2/v1/_layouts/base.html
+++ b/cfgov/jinja2/v1/_layouts/base.html
@@ -67,9 +67,13 @@
     {% if page and page.meta_image %}
         <meta property="og:image"
               content="{{ request.scheme }}://{{ request.get_host() }}{{ image(page.meta_image, 'original').url }}">
+        <meta property="twitter:image"
+              content="{{ request.scheme }}://{{ request.get_host() }}{{ image(page.meta_image, 'original').url }}">
     {% else %}
         <meta property="og:image"
               content="{{ request.scheme }}://{{ request.get_host() }}{{ static('img/logo_open-graph_facebook.png') }}">
+        <meta property="twitter:image"
+              content="{{ request.scheme }}://{{ request.get_host() }}{{ static('img/logo_open-graph_twitter.png') }}">
     {% endif %}
         <!--  Optional -->
         <meta property="og:description"
@@ -84,21 +88,6 @@
         <!-- Facebook -->
         <meta property="fb:app_id" content="210516218981921">
         {% block og_article_author %}{% endblock %}
-        <!-- Twitter -->
-    {% if page and page.meta_image %}
-        {%- set twitter_image = image(page.meta_image, 'original') %}
-        <meta property="twitter:image"
-              content="{{ request.scheme }}://{{ request.get_host() }}{{ twitter_image.url }}">
-        {#- Display a large twitter card if it's a large image and
-            its height-to-width ratio is approximately 1/2 #}
-        {%- if twitter_image.width >= 1000 and
-            0.4 <= twitter_image.height / twitter_image.width <= 0.6 %}
-        <meta name="twitter:card" content="summary_large_image">
-        {% endif %}
-    {% else %}
-        <meta property="twitter:image"
-              content="{{ request.scheme }}://{{ request.get_host() }}{{ static('img/logo_open-graph_twitter.png') }}">
-    {% endif %}
     <!-- End of Open Graph properties -->
 
     <link rel="shortcut icon" type="image/x-icon" href="{{ static('assets/favicon.ico') }}">

--- a/cfgov/jinja2/v1/_layouts/base.html
+++ b/cfgov/jinja2/v1/_layouts/base.html
@@ -64,10 +64,9 @@
         <meta property="og:title" content="{% block og_title %}{{ self.title() }}{% endblock %}">
         <meta property="og:type" content="{% block og_type %}website{% endblock %}">
         <meta property="og:url" content="{{ request.url }}">
-    {% if page and page.preview_image %}
-        {%- set preview_image = image(page.preview_image, 'original') %}
+    {% if page.meta_image %}
         <meta property="og:image"
-              content="{{ preview_image.url }}">
+              content="{{ request.scheme }}://{{ request.get_host() }}{{ image(page.meta_image, 'original').url }}">
     {% else %}
         <meta property="og:image"
               content="{{ request.scheme }}://{{ request.get_host() }}{{ static('img/logo_open-graph_facebook.png') }}">
@@ -86,10 +85,16 @@
         <meta property="fb:app_id" content="210516218981921">
         {% block og_article_author %}{% endblock %}
         <!-- Twitter -->
-    {% if page and page.preview_image %}
-        {%- set preview_image = image(page.preview_image, 'original') %}
+    {% if page.meta_image %}
+        {%- set twitter_image = image(page.meta_image, 'original') %}
         <meta property="twitter:image"
-              content="{{ preview_image.url }}">
+              content="{{ request.scheme }}://{{ request.get_host() }}{{ twitter_image.url }}">
+        {#- Display a large twitter card if it's a large image and
+            its height-to-width ratio is approximately 1/2 #}
+        {%- if twitter_image.width >= 1000 and
+            0.4 <= twitter_image.height / twitter_image.width <= 0.6 %}
+        <meta name="twitter:card" content="summary_large_image">
+        {% endif %}
     {% else %}
         <meta property="twitter:image"
               content="{{ request.scheme }}://{{ request.get_host() }}{{ static('img/logo_open-graph_twitter.png') }}">

--- a/cfgov/jinja2/v1/_layouts/base.html
+++ b/cfgov/jinja2/v1/_layouts/base.html
@@ -64,7 +64,7 @@
         <meta property="og:title" content="{% block og_title %}{{ self.title() }}{% endblock %}">
         <meta property="og:type" content="{% block og_type %}website{% endblock %}">
         <meta property="og:url" content="{{ request.url }}">
-    {% if page.meta_image %}
+    {% if page and page.meta_image %}
         <meta property="og:image"
               content="{{ request.scheme }}://{{ request.get_host() }}{{ image(page.meta_image, 'original').url }}">
     {% else %}
@@ -85,7 +85,7 @@
         <meta property="fb:app_id" content="210516218981921">
         {% block og_article_author %}{% endblock %}
         <!-- Twitter -->
-    {% if page.meta_image %}
+    {% if page and page.meta_image %}
         {%- set twitter_image = image(page.meta_image, 'original') %}
         <meta property="twitter:image"
               content="{{ request.scheme }}://{{ request.get_host() }}{{ twitter_image.url }}">

--- a/cfgov/v1/migrations/0069_add_social_sharing_image.py
+++ b/cfgov/v1/migrations/0069_add_social_sharing_image.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('v1', '0068_remove_cfgovrendition_filter'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='cfgovpage',
+            name='social_sharing_image',
+            field=models.ForeignKey(related_name='+', on_delete=django.db.models.deletion.SET_NULL, blank=True, to='v1.CFGOVImage', help_text=b'Optionally select a custom image to appear when users share this page on social media websites.', null=True),
+        ),
+    ]

--- a/cfgov/v1/models/base.py
+++ b/cfgov/v1/models/base.py
@@ -23,6 +23,7 @@ from wagtail.wagtailcore.blocks.stream_block import StreamValue
 from wagtail.wagtailcore.fields import StreamField
 from wagtail.wagtailcore.models import (Orderable, Page, PageManager,
                                         PageQuerySet)
+from wagtail.wagtailimages.edit_handlers import ImageChooserPanel
 
 from v1 import get_protected_url
 from v1.atomic_elements import molecules, organisms
@@ -66,6 +67,17 @@ class CFGOVPage(Page):
     language = models.CharField(
         choices=ref.supported_languagues, default='en', max_length=2
     )
+    social_sharing_image = models.ForeignKey(
+        'v1.CFGOVImage',
+        null=True,
+        blank=True,
+        on_delete=models.SET_NULL,
+        related_name='+',
+        help_text=(
+            'Optionally select a custom image to appear when users share this '
+            'page on social media websites.'
+        )
+    )
 
     # This is used solely for subclassing pages we want to make at the CFPB.
     is_creatable = False
@@ -87,12 +99,16 @@ class CFGOVPage(Page):
     ], blank=True)
 
     # Panels
+    promote_panels = Page.promote_panels + [
+        ImageChooserPanel('social_sharing_image'),
+    ]
+
     sidefoot_panels = [
         StreamFieldPanel('sidefoot'),
     ]
 
     settings_panels = [
-        MultiFieldPanel(Page.promote_panels, 'Settings'),
+        MultiFieldPanel(promote_panels, 'Settings'),
         InlinePanel('categories', label="Categories", max_num=2),
         FieldPanel('tags', 'Tags'),
         FieldPanel('authors', 'Authors'),
@@ -336,6 +352,10 @@ class CFGOVPage(Page):
             js[key] = OrderedDict.fromkeys(js_files).keys()
         return js
 
+    # Returns an image for the page's meta Open Graph tag
+    @property
+    def meta_image(self):
+        return self.social_sharing_image
 
 class CFGOVPageCategory(Orderable):
     page = ParentalKey(CFGOVPage, related_name='categories')

--- a/cfgov/v1/models/base.py
+++ b/cfgov/v1/models/base.py
@@ -357,6 +357,7 @@ class CFGOVPage(Page):
     def meta_image(self):
         return self.social_sharing_image
 
+
 class CFGOVPageCategory(Orderable):
     page = ParentalKey(CFGOVPage, related_name='categories')
     name = models.CharField(max_length=255, choices=ref.categories)

--- a/cfgov/v1/models/learn_page.py
+++ b/cfgov/v1/models/learn_page.py
@@ -51,7 +51,7 @@ class AbstractFilterPage(CFGOVPage):
 
     # Configuration tab panels
     settings_panels = [
-        MultiFieldPanel(Page.promote_panels, 'Settings'),
+        MultiFieldPanel(CFGOVPage.promote_panels, 'Settings'),
         InlinePanel('categories', label="Categories", max_num=2),
         FieldPanel('tags', 'Tags'),
         MultiFieldPanel([
@@ -88,6 +88,12 @@ class AbstractFilterPage(CFGOVPage):
             ObjectList(CFGOVPage.sidefoot_panels, heading='Sidebar'),
             ObjectList(self.settings_panels, heading='Configuration'),
         ])
+
+    # Returns an image for the page's meta Open Graph tag
+    @property
+    def meta_image(self):
+        parent_meta = super(AbstractFilterPage, self).meta_image
+        return parent_meta or self.preview_image
 
 
 class LearnPage(AbstractFilterPage):

--- a/cfgov/v1/tests/models/test_base.py
+++ b/cfgov/v1/tests/models/test_base.py
@@ -3,9 +3,11 @@ import datetime
 import mock
 from django.test import TestCase
 from django.test.client import RequestFactory
+from model_mommy import mommy
 from wagtail.wagtailcore.models import Site
 
 from v1.models.base import CFGOVPage, Feedback
+from v1.models.images import CFGOVImage
 from v1.tests.wagtail_pages.helpers import publish_page, save_new_page
 
 
@@ -258,3 +260,21 @@ class TestFeedbackModel(TestCase):
                      "tester@example.com",
                      "{}".format(self.test_feedback.submitted_on.date())]:
             self.assertIn(term, test_csv)
+
+class TestMetaImage(TestCase):
+    def setUp(self):
+        self.social_sharing_image = mommy.prepare(CFGOVImage)
+
+    def test_meta_image_no_images(self):
+        page = mommy.prepare(
+            CFGOVPage,
+            social_sharing_image=None
+        )
+        self.assertIsNone(page.meta_image)
+
+    def test_meta_image(self):
+        page = mommy.prepare(
+            CFGOVPage,
+            social_sharing_image=self.social_sharing_image
+        )
+        self.assertEqual(page.meta_image, page.social_sharing_image)

--- a/cfgov/v1/tests/models/test_learn_page.py
+++ b/cfgov/v1/tests/models/test_learn_page.py
@@ -1,0 +1,42 @@
+from django.test import TestCase
+from model_mommy import mommy
+
+from v1.models import AbstractFilterPage, CFGOVImage
+
+
+class TestMetaImage(TestCase):
+    def setUp(self):
+        self.preview_image = mommy.prepare(CFGOVImage)
+        self.social_sharing_image = mommy.prepare(CFGOVImage)
+
+    def test_meta_image_no_images(self):
+        page = mommy.prepare(
+            AbstractFilterPage,
+            social_sharing_image=None,
+            preview_image=None
+        )
+        self.assertIsNone(page.meta_image)
+
+    def test_meta_image_only_social_sharing(self):
+        page = mommy.prepare(
+            AbstractFilterPage,
+            social_sharing_image=self.social_sharing_image,
+            preview_image=None
+        )
+        self.assertEqual(page.meta_image, page.social_sharing_image)
+
+    def test_meta_image_only_preview(self):
+        page = mommy.prepare(
+            AbstractFilterPage,
+            social_sharing_image=None,
+            preview_image=self.preview_image
+        )
+        self.assertEqual(page.meta_image, page.preview_image)
+
+    def test_meta_image_both(self):
+        page = mommy.prepare(
+            AbstractFilterPage,
+            social_sharing_image=self.social_sharing_image,
+            preview_image=self.preview_image
+        )
+        self.assertEqual(page.meta_image, page.social_sharing_image)


### PR DESCRIPTION
This adds a new image chooser field that populates the HTML Open Graph meta tags (which is what Facebook and Twitter use when you share a page).

The logic in our base template has been changed to:

```
IF page.social_image USE page.social_image
OTHERWISE IF page.preview_image USE page.preview_image
OTHERWISE USE default_cfpb_logo
```

I also added some logic to instruct Twitter to use large cards if the supplied social sharing image is large enough.

## Additions

- Social image chooser in the settings panel of page's admin screen
- Large twitter card option

## Changes

- `meta` image tag logic

## Screenshots

### New social sharing image field in the settings panel:

![screen shot 2017-05-30 at 5 46 25 pm](https://cloud.githubusercontent.com/assets/1060248/26606850/a7fba0cc-4561-11e7-8e69-07860a9363a7.png)

### Current normal size Twitter cards:

![screen shot 2017-05-30 at 12 49 56 pm](https://cloud.githubusercontent.com/assets/1060248/26607017/58cbb9c8-4562-11e7-822e-4e4836ae0cf3.png)

### New large Twitter cards:

![screen shot 2017-05-30 at 12 56 06 pm](https://cloud.githubusercontent.com/assets/1060248/26607026/65a7c7d6-4562-11e7-8667-452243cda526.png)

## Notes

- I added the field to the `CFGOVPage` class which means almost every page on the website will have it available. @ielerol @schaferjh Let me know if you think we should instead restrict it to certain page types (blog post, askcfpb pages, etc.).

## Checklist

* [ ] PR has an informative and human-readable title
* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated
* [ ] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
