### PR TITLE
Pass empty password to mysql import command

### DIFF
--- a/refresh-data.sh
+++ b/refresh-data.sh
@@ -23,7 +23,7 @@ refresh_data(){
 	echo 'Creating db'
 	./create-mysql-db.sh
 	echo 'Importing refresh db'
-	mysql v1 -u root -p < $refresh_dump_name
+	mysql v1 --user='root' --password='' < $refresh_dump_name
 	echo 'Setting up initial data'
 	./cfgov/manage.py runscript initial_data
 }


### PR DESCRIPTION
This is to prevent the `refresh-data` script's password prompt. The shorthand `-p` option doesn't work with blank passwords so I used the longer version.

## Checklist

* [x] PR has an informative and human-readable title
* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices
* [x] Project documentation has been updated
* [x] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
