### PR TITLE
Looser coupling between HUD API and code in cfgov/legacy/views/

### DIFF
--- a/.env_SAMPLE
+++ b/.env_SAMPLE
@@ -91,6 +91,12 @@ export VENV_NAME=cfgov-refresh
 export WORDPRESS=http://www.consumerfinance.gov
 
 ##############################################################
+# HUD API
+##############################################################
+
+export HUD_API_ENDPOINT=http://localhost:8000/hud-api-replace/
+
+##############################################################
 # GOVDELIVERY (optional) - for running the subscription forms.
 ##############################################################
 

--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -321,9 +321,7 @@ LEGACY_APP_URLS={'comparisontool':True,
                  'noticeandcomment':True}
 
 # DJANGO HUD API
-GOOGLE_MAPS_API_PRIVATE_KEY = os.environ.get('GOOGLE_MAPS_API_PRIVATE_KEY')
-GOOGLE_MAPS_API_CLIENT_ID = os.environ.get('GOOGLE_MAPS_API_CLIENT_ID')
-DJANGO_HUD_NOTIFY_EMAILS = os.environ.get('DJANGO_HUD_NOTIFY_EMAILS')
+DJANGO_HUD_API_ENDPOINT= os.environ.get('HUD_API_ENDPOINT', 'http://localhost/hud-api-replace/')
 # in seconds, 2592000 == 30 days. Google allows no more than a month of caching
 DJANGO_HUD_GEODATA_EXPIRATION_INTERVAL = 2592000
 MAPBOX_ACCESS_TOKEN = os.environ.get('MAPBOX_ACCESS_TOKEN')

--- a/cfgov/legacy/views/housing_counselor.py
+++ b/cfgov/legacy/views/housing_counselor.py
@@ -2,6 +2,7 @@ import os
 import re
 import requests
 import sys
+from urlparse import urljoin
 
 from django.conf import settings
 from django.core.urlresolvers import reverse
@@ -42,12 +43,8 @@ class HousingCounselorView(TemplateView):
 
         Queries a locally running django-hud API.
         """
-        api_path = reverse(
-            'hud_api_replace:index',
-            kwargs={'zipcode': zipcode}
-        )
+        api_url = urljoin(settings.DJANGO_HUD_API_ENDPOINT,zipcode)
 
-        api_url = 'http://localhost' + api_path
         response = requests.get(api_url)
         response.raise_for_status()
 

--- a/cfgov/legacy/views/housing_counselor.py
+++ b/cfgov/legacy/views/housing_counselor.py
@@ -43,7 +43,7 @@ class HousingCounselorView(TemplateView):
 
         Queries a local or remote django-hud API
         """
-        api_url = urljoin(settings.DJANGO_HUD_API_ENDPOINT,zipcode)
+        api_url = urljoin(settings.DJANGO_HUD_API_ENDPOINT, zipcode)
 
         response = requests.get(api_url)
         response.raise_for_status()

--- a/cfgov/legacy/views/housing_counselor.py
+++ b/cfgov/legacy/views/housing_counselor.py
@@ -41,7 +41,7 @@ class HousingCounselorView(TemplateView):
     def get_counselors(request, zipcode):
         """Return list of housing counselors closest to a given zipcode.
 
-        Queries a locally running django-hud API.
+        Queries a local or remote django-hud API
         """
         api_url = urljoin(settings.DJANGO_HUD_API_ENDPOINT,zipcode)
 


### PR DESCRIPTION
## Additions

- DJANGO_HUD_API_ENDPOINT setting, which can be populated from the
environment. The default matches what we use in production.
- a useful initial value for development is added to .env_SAMPLE

## Changes

- the new setting is used to connect to the HUD API. The previous code had hardcoded "http://localhost" which doesn't work when developing on localhost, and depended on Django's URL reversing, which wouldn't work in a hypothetical future where the HUD API was running as a standalone service.

## Testing

- After adding something like `export HUD_API_ENDPOINT=http://localhost:8000/hud-api-replace/` to your own .env file, (and re-sourcing it), you should be able to successfully search for zip codes at /find-a-housing-counselor/


## Checklist

* [x] PR has an informative and human-readable title
* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [x] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated
* [x] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
