### PR TITLE
Adding exitProcess flag to the gulp error handler

### DIFF
--- a/cfgov/unprocessed/css/molecules/related-posts.less
+++ b/cfgov/unprocessed/css/molecules/related-posts.less
@@ -45,7 +45,7 @@
 
 @margin_half__em: unit(15px / @base-font-size-px, em);
 
-@list_half-width: {
+@list_half-width:
 
     .grid_nested-col-group();
 

--- a/cfgov/unprocessed/css/molecules/related-posts.less
+++ b/cfgov/unprocessed/css/molecules/related-posts.less
@@ -45,7 +45,7 @@
 
 @margin_half__em: unit(15px / @base-font-size-px, em);
 
-@list_half-width:
+@list_half-width: {
 
     .grid_nested-col-group();
 

--- a/gulp/tasks/styles.js
+++ b/gulp/tasks/styles.js
@@ -25,7 +25,7 @@ function stylesModern() {
   return gulp.src( configStyles.cwd + configStyles.src )
     .pipe( gulpSourcemaps.init() )
     .pipe( gulpLess( configStyles.settings ) )
-    .on( 'error', handleErrors )
+    .on( 'error', handleErrors.bind( this, true ) )
     .pipe( gulpAutoprefixer( { browsers: [
       'last 2 version',
       'not ie <= 8',

--- a/gulp/tasks/styles.js
+++ b/gulp/tasks/styles.js
@@ -25,7 +25,7 @@ function stylesModern() {
   return gulp.src( configStyles.cwd + configStyles.src )
     .pipe( gulpSourcemaps.init() )
     .pipe( gulpLess( configStyles.settings ) )
-    .on( 'error', handleErrors.bind( this, true ) )
+    .on( 'error', handleErrors.bind( this, { exitProcess: true } ) )
     .pipe( gulpAutoprefixer( { browsers: [
       'last 2 version',
       'not ie <= 8',

--- a/gulp/utils/handle-errors.js
+++ b/gulp/utils/handle-errors.js
@@ -2,20 +2,26 @@
 
 var notify = require( 'gulp-notify' );
 
-module.exports = function( err, exitProcess = false ) {
+module.exports = function( ) {
   var args = Array.prototype.slice.call( arguments );
+  var exitProcessParam = false;
+  var errorParam = args[0] || {};
+
+  if( errorParam.hasOwnProperty( 'exitProcess' ) ) {
+    exitProcessParam = errorParam.exitProcess;
+    errorParam = args[1];
+  }
 
   // Send error to notification center with gulp-notify
   notify.onError( {
     title:   'Compile Error',
     message: '<%= error %>'
-  } ).apply( this, args );
+  } ).call( this, errorParam );
 
   // Keep gulp from hanging on this task
   this.emit( 'end' );
 
-  console.log( exitProcess.error, 'err' )
-  if ( exitProcess === true ) {
+  if ( exitProcessParam === true ) {
     process.exit( 1 );
   }
 };

--- a/gulp/utils/handle-errors.js
+++ b/gulp/utils/handle-errors.js
@@ -2,7 +2,7 @@
 
 var notify = require( 'gulp-notify' );
 
-module.exports = function() {
+module.exports = function( err, exitProcess = false ) {
   var args = Array.prototype.slice.call( arguments );
 
   // Send error to notification center with gulp-notify
@@ -13,4 +13,9 @@ module.exports = function() {
 
   // Keep gulp from hanging on this task
   this.emit( 'end' );
+
+  console.log( exitProcess.error, 'err' )
+  if ( exitProcess === true ) {
+    process.exit( 1 );
+  }
 };


### PR DESCRIPTION
Adding exitProcess flag to the gulp error handler

## Changes

- Modified `gulp/utils/handle-errors.js` to add an error handler.

## Testing

- Run `gulp styles` and notice that the process exits as expected.
- Verify that the gulp error is causing the Travis builds to fail.

## Screenshots
- 
<img width="1167" alt="screen shot 2017-05-31 at 5 57 36 pm" src="https://cloud.githubusercontent.com/assets/1696212/26656028/61338a4a-462b-11e7-8735-7e7cb0232047.png">


## Notes

-  :skull_and_crossbones:  **This PR has an intentional less error in order to test on Travis** :skull_and_crossbones:

## Todos

-

## Checklist

* [ ] PR has an informative and human-readable title
* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated
* [ ] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
