### PR TITLE
Fix a layout issue in the FCM when a video plays at small screen

### DIFF
--- a/cfgov/unprocessed/css/organisms/featured-content-module.less
+++ b/cfgov/unprocessed/css/organisms/featured-content-module.less
@@ -53,17 +53,17 @@
         left: 360px; // widht of 5 of 12 cols at lg size + grid gutters
         bottom: 0;
       }
-    } );
 
-    // This bit is not in CF becuase the video player code is not a part of CF
-    // Possibly move to the video.less file when this file is removed.
-    &.video-playing {
-      position: absolute;
-      top: 0;
-      right: 0;
-      bottom: 0;
-      left: 0;
-    }
+      // This bit is not in CF becuase the video player code is not a part of CF
+      // Possibly move to the video.less file when this file is removed.
+      &.video-playing {
+        position: absolute;
+        top: 0;
+        right: 0;
+        bottom: 0;
+        left: 0;
+      }
+    } );
   }
 
   &_img {


### PR DESCRIPTION
When a video was playing on smaller screens, the share buttons were being cut off. Limited the absolute positioning to only larger screens where the FCM visual is to the right of the text instead of below it.

## Changes

- Limited the FCM video absolute positioning to larger screens

## Testing

1. Build the assets, navigate to `about-us/the-bureau/` with the browser closed down a bit and play the video.
2. Navigate to `/consumer-tools/everyone-has-a-story/danieshia-threatened-with-jail/` with the browser closed down a bit and play the video.

## Screenshots

Before:

<img width="396" alt="screen shot 2017-06-01 at 5 33 52 am" src="https://cloud.githubusercontent.com/assets/1280430/26689143/569e6cdc-46ba-11e7-877d-0c86db25f652.png">

After:

![screen shot 2017-06-01 at 10 56 45 am](https://cloud.githubusercontent.com/assets/1280430/26689117/41ba975a-46ba-11e7-8f69-2944afb13152.png)

## Notes

- I'd really like to rebuild the video player side of things, but that's far outside the scope right now.

## Checklist

* [x] PR has an informative and human-readable title
* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices
* [x] Project documentation has been updated
* [x] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
