### PR TITLE
Acceptance tests for Wagtail publish/unpublish

### DIFF
--- a/test/browser_tests/cucumber/features/suites/wagtail-admin/publish-unpublish.feature
+++ b/test/browser_tests/cucumber/features/suites/wagtail-admin/publish-unpublish.feature
@@ -19,7 +19,7 @@ Feature:
   Scenario: Page published then unpublished
     When I create a draft Browse Page with title "Publish Unpublish 3"
     And I publish the page
-    And I edit the page
+    And I navigate back to the edit page
     And I unpublish the page
     And I visit URL "/publish-unpublish-3"
     Then I should see page title "404 error: not found"

--- a/test/browser_tests/cucumber/features/suites/wagtail-admin/publish-unpublish.feature
+++ b/test/browser_tests/cucumber/features/suites/wagtail-admin/publish-unpublish.feature
@@ -21,5 +21,5 @@ Feature:
     And I publish the page
     And I edit the page
     And I unpublish the page
-    And I visit URL "/publish-unpublish"
+    And I visit URL "/publish-unpublish-3"
     Then I should see page title "404 error: not found"

--- a/test/browser_tests/cucumber/features/suites/wagtail-admin/publish-unpublish.feature
+++ b/test/browser_tests/cucumber/features/suites/wagtail-admin/publish-unpublish.feature
@@ -1,0 +1,25 @@
+Feature:
+  As a user of Wagtail
+  I should be able to trust that only published pages are live  
+
+  Background:
+    Given I am logged into Wagtail as an admin
+
+  Scenario: Page never published
+    When I create a draft Browse Page with title "Publish Unpublish 1"
+    And I visit URL "/publish-unpublish-1"
+    Then I should see page title "404 error: not found"
+
+  Scenario: Page published
+    When I create a draft Browse Page with title "Publish Unpublish 2"
+    And I publish the page
+    And I visit URL "/publish-unpublish-2"
+    Then I should see page title "Publish Unpublish 2 | Consumer Financial Protection Bureau"
+
+  Scenario: Page published then unpublished
+    When I create a draft Browse Page with title "Publish Unpublish 3"
+    And I publish the page
+    And I edit the page
+    And I unpublish the page
+    And I visit URL "/publish-unpublish"
+    Then I should see page title "404 error: not found"

--- a/test/browser_tests/cucumber/step_definitions/publish-unpublish.js
+++ b/test/browser_tests/cucumber/step_definitions/publish-unpublish.js
@@ -1,0 +1,21 @@
+'use strict';
+
+const BasePage = require('../../page_objects/base-page.js');
+const basePage = new BasePage();
+
+const { defineSupportCode } = require( 'cucumber' );
+const { expect } = require( 'chai' );
+
+defineSupportCode( function( { Then, When } ) {
+
+  When( /I visit URL "(.*)"/, function( url ) {
+    return basePage.gotoURL( url );
+  } );
+
+  Then( /I should see page title "(.*)"/, function( pageTitle ) {
+    return browser.getTitle().then( function(title) {
+      expect( title ).to.equal( pageTitle );
+    } );
+  } );
+
+} );

--- a/test/browser_tests/cucumber/step_definitions/publish-unpublish.js
+++ b/test/browser_tests/cucumber/step_definitions/publish-unpublish.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const BasePage = require('../../page_objects/base-page.js');
+const BasePage = require( '../../page_objects/base-page.js' );
 const basePage = new BasePage();
 
 const { defineSupportCode } = require( 'cucumber' );
@@ -17,7 +17,7 @@ defineSupportCode( function( { Then, When } ) {
   } );
 
   Then( /I should see page title "(.*)"/, function( pageTitle ) {
-    return browser.getTitle().then( function(title) {
+    return browser.getTitle().then( function( title ) {
       expect( title ).to.equal( pageTitle );
     } );
   } );

--- a/test/browser_tests/cucumber/step_definitions/publish-unpublish.js
+++ b/test/browser_tests/cucumber/step_definitions/publish-unpublish.js
@@ -12,6 +12,10 @@ defineSupportCode( function( { Then, When } ) {
     return basePage.gotoURL( url );
   } );
 
+  When( 'I navigate back to the edit page', function( ) {
+    return browser.navigate().back();
+  } );
+
   Then( /I should see page title "(.*)"/, function( pageTitle ) {
     return browser.getTitle().then( function(title) {
       expect( title ).to.equal( pageTitle );

--- a/test/browser_tests/cucumber/step_definitions/wagtail-admin-login.js
+++ b/test/browser_tests/cucumber/step_definitions/wagtail-admin-login.js
@@ -1,6 +1,8 @@
 'use strict';
 
-const WagtailLogin = require( '../../page_objects/wagtail-admin-login-page.js' );
+const WagtailLogin = require(
+  '../../page_objects/wagtail-admin-login-page.js'
+);
 const wagtailLoginPage = new WagtailLogin();
 const { defineSupportCode } = require( 'cucumber' );
 const { expect } = require( 'chai' );

--- a/test/browser_tests/cucumber/step_definitions/wagtail-admin-pages.js
+++ b/test/browser_tests/cucumber/step_definitions/wagtail-admin-pages.js
@@ -14,6 +14,15 @@ defineSupportCode( function( { Then, When } ) {
     return wagtailAdminPagesPage.createPage( pageType );
   } );
 
+  When( /I create a draft (.*) Page with title "(.*)"/, function(
+    pageType, pageTitle
+  ) {
+
+    wagtailAdminPagesPage.createPage( pageType );
+    wagtailAdminPagesPage.setPageTitle( pageTitle );
+    return wagtailAdminPagesPage.save( );
+  } );
+
   Then( /I open the (.*) menu/, function( menuType ) {
 
     return wagtailAdminPagesPage.openMenu( menuType );
@@ -25,5 +34,14 @@ defineSupportCode( function( { Then, When } ) {
       return wagtailAdminPagesPage.selectMenuItem( component );
     }
   );
+
+  When( /I publish the page/, function( ) {
+    return wagtailAdminPagesPage.publish();
+  } );
+
+  When( /I unpublish the page/, function( ) {
+    return wagtailAdminPagesPage.unpublish();
+  } );
+
 
 } );

--- a/test/browser_tests/cucumber/step_definitions/wagtail-admin-pages.js
+++ b/test/browser_tests/cucumber/step_definitions/wagtail-admin-pages.js
@@ -5,7 +5,6 @@ const WagtailAdminPagesPage = require(
 );
 const wagtailAdminPagesPage = new WagtailAdminPagesPage();
 const { defineSupportCode } = require( 'cucumber' );
-const { expect } = require( 'chai' );
 
 defineSupportCode( function( { Then, When } ) {
 

--- a/test/browser_tests/cucumber/step_definitions/wagtail-admin-rich-text-editor.js
+++ b/test/browser_tests/cucumber/step_definitions/wagtail-admin-rich-text-editor.js
@@ -9,18 +9,19 @@ const linkChooser = require(
 const { defineSupportCode } = require( 'cucumber' );
 const { expect } = require( 'chai' );
 
-const { capture } = require( '../../util/screenshot.js' );
-
 defineSupportCode( function( { Then, When, After, setDefaultTimeout } ) {
 
   setDefaultTimeout( 10800 );
 
   After( function() {
 
+    /*
     browser.manage().logs().get( 'browser' )
     .then( function( browserLog ) {
-      // console.log( browserLog );
+      console.log( browserLog );
     } );
+    */
+
   } );
 
   When( /I click the (.*) button in the rich text editor/,

--- a/test/browser_tests/page_objects/wagtail-admin-pages-page.js
+++ b/test/browser_tests/page_objects/wagtail-admin-pages-page.js
@@ -27,17 +27,13 @@ const MENUS = {
   content: contentMenu
 };
 
-const titleFieldSelector = '#id_title';
-const titleField = element( by.css( titleFieldSelector ) );
 
-const saveButtonSelector = '.button.action-save';
-const saveButton = element( by.css( saveButtonSelector ) );
-
-const dropdownToggleSelector = '.dropdown-toggle';
-const dropdownToggle = element( by.css( dropdownToggleSelector ) );
-
-const publishButtonSelector = 'button[name="action-publish"]';
-const publishButton = element( by.css( publishButtonSelector ) );
+const titleField = element( by.css( '#id_title' ) );
+const saveButton = element( by.css( '.button.action-save' ) );
+const dropdownToggle = element( by.css( '.dropdown-toggle' ) );
+const publishButton = element( by.css( 'button[name="action-publish"]' ) );
+const unpublishButton = element( by.css( 'a[href$="/unpublish/"]' ) );
+const confirmUnpublishButton = element( by.css( 'input[value="Yes, unpublish it"]' ) );
 
 class WagtailAdminPages extends BasePage {
 
@@ -114,7 +110,17 @@ class WagtailAdminPages extends BasePage {
       } );
   }
 
-  unpublish(  ) {
+  unpublish( ) {
+    return browser.wait( EC.elementToBeClickable( dropdownToggle ) )
+      .then( function() {
+        return dropdownToggle.click().then( function() {
+          return browser.wait( EC.elementToBeClickable( unpublishButton ) )
+            .then( function() {
+              unpublishButton.click();
+              return confirmUnpublishButton.click();
+            } );
+        } );
+      } );
   }
 
 }

--- a/test/browser_tests/page_objects/wagtail-admin-pages-page.js
+++ b/test/browser_tests/page_objects/wagtail-admin-pages-page.js
@@ -1,7 +1,9 @@
 'use strict';
 
 const BasePage = require( './base-page.js' );
-const contentMenu = require( '../shared_objects/wagtail-admin-content-menu.js' );
+const contentMenu = require(
+  '../shared_objects/wagtail-admin-content-menu.js'
+);
 const EC = protractor.ExpectedConditions;
 
 const PAGE_TYPES = {
@@ -15,7 +17,7 @@ const PAGE_TYPES = {
   JOB_LISTING:            'joblistingpage',
   LANDING:                'landingpage',
   LEARN:                  'learnpage',
-  LEGACY_BlOG:            'legacyblogpage',
+  LEGACY_BLOG:            'legacyblogpage',
   LEGACY_NEWSROOM:        'legacynewsroompage',
   NEWSROOM_LANDING:       'newsroomlandingpage',
   NEWSROOM:               'newsroompage',
@@ -33,7 +35,9 @@ const saveButton = element( by.css( '.button.action-save' ) );
 const dropdownToggle = element( by.css( '.dropdown-toggle' ) );
 const publishButton = element( by.css( 'button[name="action-publish"]' ) );
 const unpublishButton = element( by.css( 'a[href$="/unpublish/"]' ) );
-const confirmUnpublishButton = element( by.css( 'input[value="Yes, unpublish it"]' ) );
+const confirmUnpublishButton = element( by.css(
+  'input[value="Yes, unpublish it"]'
+) );
 
 class WagtailAdminPages extends BasePage {
 
@@ -85,16 +89,16 @@ class WagtailAdminPages extends BasePage {
   }
 
   setPageTitle( title ) {
-    return browser.wait( EC.elementToBeClickable( titleField ) ) 
+    return browser.wait( EC.elementToBeClickable( titleField ) )
       .then( function() {
         return titleField.sendKeys( title );
       } );
   }
 
   save( ) {
-    return browser.wait( EC.elementToBeClickable( saveButton ) ) 
+    return browser.wait( EC.elementToBeClickable( saveButton ) )
       .then( function() {
-        return saveButton.click(); 
+        return saveButton.click();
       } );
   }
 
@@ -104,7 +108,7 @@ class WagtailAdminPages extends BasePage {
         return dropdownToggle.click().then( function() {
           return browser.wait( EC.elementToBeClickable( publishButton ) )
             .then( function() {
-              return publishButton.click(); 
+              return publishButton.click();
             } );
         } );
       } );

--- a/test/browser_tests/page_objects/wagtail-admin-pages-page.js
+++ b/test/browser_tests/page_objects/wagtail-admin-pages-page.js
@@ -2,6 +2,7 @@
 
 const BasePage = require( './base-page.js' );
 const contentMenu = require( '../shared_objects/wagtail-admin-content-menu.js' );
+const EC = protractor.ExpectedConditions;
 
 const PAGE_TYPES = {
   ACTIVITY_LOG:           'activitylogpage',
@@ -26,14 +27,22 @@ const MENUS = {
   content: contentMenu
 };
 
+const titleFieldSelector = '#id_title';
+const titleField = element( by.css( titleFieldSelector ) );
+
+const saveButtonSelector = '.button.action-save';
+const saveButton = element( by.css( saveButtonSelector ) );
+
+const dropdownToggleSelector = '.dropdown-toggle';
+const dropdownToggle = element( by.css( dropdownToggleSelector ) );
+
+const publishButtonSelector = 'button[name="action-publish"]';
+const publishButton = element( by.css( publishButtonSelector ) );
+
 class WagtailAdminPages extends BasePage {
 
   constructor() {
     super();
-
-    this.addChildPageBtn = element(
-      by.css( 'btn[href="/admin/pages/1/add_subpage/"]' )
-    );
 
     this.URL = '/admin/pages/';
   }
@@ -43,7 +52,10 @@ class WagtailAdminPages extends BasePage {
                              .toUpperCase()
                              .replace( /\s/g, '_' );
     const pageType = PAGE_TYPES[normalizedPageName];
-    const pageUrl = `add/v1/${ pageType }/1`;
+
+    // Add the new page as a child of page ID 3 (the site root).
+    const pageUrl = `add/v1/${ pageType }/3`;
+
     const url = this.URL + pageUrl;
 
     return this.gotoURL( url );
@@ -74,6 +86,35 @@ class WagtailAdminPages extends BasePage {
   selectMenuItem( menuItem ) {
 
     return this.menu.selectItem( menuItem );
+  }
+
+  setPageTitle( title ) {
+    return browser.wait( EC.elementToBeClickable( titleField ) ) 
+      .then( function() {
+        return titleField.sendKeys( title );
+      } );
+  }
+
+  save( ) {
+    return browser.wait( EC.elementToBeClickable( saveButton ) ) 
+      .then( function() {
+        return saveButton.click(); 
+      } );
+  }
+
+  publish( ) {
+    return browser.wait( EC.elementToBeClickable( dropdownToggle ) )
+      .then( function() {
+        return dropdownToggle.click().then( function() {
+          return browser.wait( EC.elementToBeClickable( publishButton ) )
+            .then( function() {
+              return publishButton.click(); 
+            } );
+        } );
+      } );
+  }
+
+  unpublish(  ) {
   }
 
 }


### PR DESCRIPTION
This commit adds a few new acceptance tests for the following scenarios:

- A draft page isn't reachable at its slug-based URL
- A published page is reachable at its slug-based URL
- A published and then unpublished page isn't reachable at its slug-based URL

## Additions

- New acceptance tests and related support classes.

## Testing

1. `tox -e acceptance-fast specs=publish-unpublish.feature`

## Checklist

* [X] PR has an informative and human-readable title
* [X] Changes are limited to a single goal (no scope creep)
* [X] Code can be automatically merged (no conflicts)
* [X] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [X] Passes all existing automated tests
* [X] New functions include new tests
* [X] Visually tested in supported browsers and devices
* [X] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
