### PR TITLE
bump college-costs to 2.3.7 for bug fix

### DIFF
--- a/requirements/optional-public.txt
+++ b/requirements/optional-public.txt
@@ -1,4 +1,4 @@
-git+https://github.com/cfpb/college-costs.git@2.3.6#egg=college-costs
+git+https://github.com/cfpb/college-costs.git@2.3.7#egg=college-costs
 git+https://github.com/cfpb/complaint.git@1.3.3#egg=complaintdatabase
 git+https://github.com/cfpb/django-hud.git@1.2#egg=django-hud
 git+https://github.com/cfpb/owning-a-home-api.git@0.9.96#egg=owning-a-home-api


### PR DESCRIPTION
Push college-costs to 2.3.7 for a bug fix.

This is not critical and can ride to production any time.