### PR TITLE
Removes unused gulp-bless

### DIFF
--- a/gulp/tasks/styles.js
+++ b/gulp/tasks/styles.js
@@ -15,7 +15,6 @@ var gulpRename = require( 'gulp-rename' );
 var gulpSourcemaps = require( 'gulp-sourcemaps' );
 var handleErrors = require( '../utils/handle-errors' );
 var mqr = require( 'gulp-mq-remove' );
-var gulpBless = require( 'gulp-bless' );
 
 /**
  * Process modern CSS.

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -2643,38 +2643,6 @@
       "from": "gulp-autoprefixer@3.1.1",
       "resolved": "https://registry.npmjs.org/gulp-autoprefixer/-/gulp-autoprefixer-3.1.1.tgz"
     },
-    "gulp-bless": {
-      "version": "3.2.1",
-      "from": "gulp-bless@3.2.1",
-      "resolved": "https://registry.npmjs.org/gulp-bless/-/gulp-bless-3.2.1.tgz",
-      "dependencies": {
-        "isarray": {
-          "version": "0.0.1",
-          "from": "isarray@0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-        },
-        "readable-stream": {
-          "version": "1.0.34",
-          "from": "readable-stream@>=1.0.17 <1.1.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz"
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "from": "string_decoder@>=0.10.0 <0.11.0",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-        },
-        "through2": {
-          "version": "0.5.1",
-          "from": "through2@>=0.5.1 <0.6.0",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz"
-        },
-        "xtend": {
-          "version": "3.0.0",
-          "from": "xtend@>=3.0.0 <3.1.0",
-          "resolved": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz"
-        }
-      }
-    },
     "gulp-changed": {
       "version": "1.3.2",
       "from": "gulp-changed@1.3.2",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "glob-all": "3.1.0",
     "gulp": "3.9.1",
     "gulp-autoprefixer": "3.1.1",
-    "gulp-bless": "3.2.1",
     "gulp-changed": "1.3.2",
     "gulp-clean-css": "3.0.4",
     "gulp-concat": "2.6.1",


### PR DESCRIPTION
`gulp-bless` appears to be unused in the project. This removes references to it.

## Removals

- Removes `gulp-bless`.

## Testing

1. `./setup.sh && gulp styles` should work.