### PR TITLE
Go back to Wagtail 1.10

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -41,7 +41,7 @@ suds==0.4
 tinys3==0.1.11
 unipath>=1.1,<=2.0
 vobject==0.9.1
-wagtail==1.10.1
+wagtail==1.10
 wagtail-flags==2.0.3
 wagtail-sharing==0.5
 Wand==0.4.2


### PR DESCRIPTION
For some reason we get this error when trying to deploy on build:
`No matching distribution found for wagtail==1.10.1 (from -r cfgov/requirements/base.txt (line 44))`
which doesn't make sense since the package is on pypi.  I'm retrying with 1.10. If that fails too, I'll revert my PR. 