### PR TITLE
Tests Refactoring and minor cleanup

### DIFF
--- a/test/browser_tests/cucumber/features/suites/wagtail-admin/wagtail-admin-publish-unpublish.feature
+++ b/test/browser_tests/cucumber/features/suites/wagtail-admin/wagtail-admin-publish-unpublish.feature
@@ -1,19 +1,19 @@
 Feature:
   As a user of Wagtail
-  I should be able to trust that only published pages are live  
+  I should be able to trust that only published pages are live
 
   Background:
     Given I am logged into Wagtail as an admin
 
   Scenario: Page never published
     When I create a draft Browse Page with title "Publish Unpublish 1"
-    And I visit URL "/publish-unpublish-1"
+    And I goto URL "/publish-unpublish-1"
     Then I should see page title "404 error: not found"
 
   Scenario: Page published
     When I create a draft Browse Page with title "Publish Unpublish 2"
     And I publish the page
-    And I visit URL "/publish-unpublish-2"
+    And I goto URL "/publish-unpublish-2"
     Then I should see page title "Publish Unpublish 2 | Consumer Financial Protection Bureau"
 
   Scenario: Page published then unpublished
@@ -21,5 +21,5 @@ Feature:
     And I publish the page
     And I navigate back to the edit page
     And I unpublish the page
-    And I visit URL "/publish-unpublish-3"
+    And I goto URL "/publish-unpublish-3"
     Then I should see page title "404 error: not found"

--- a/test/browser_tests/cucumber/step_definitions/application.js
+++ b/test/browser_tests/cucumber/step_definitions/application.js
@@ -8,17 +8,20 @@ const { expect } = require( 'chai' );
 
 defineSupportCode( function( { Then, When } ) {
 
-  When( /I visit URL "(.*)"/, function( url ) {
+  When( /I goto URL "(.*)"/, function( url ) {
     return basePage.gotoURL( url );
   } );
 
-  When( 'I navigate back to the edit page', function( ) {
+  When( /I navigate back*/, function( ) {
+
     return browser.navigate().back();
   } );
 
   Then( /I should see page title "(.*)"/, function( pageTitle ) {
+
     return browser.getTitle().then( function( title ) {
-      expect( title ).to.equal( pageTitle );
+
+      return expect( title ).to.equal( pageTitle );
     } );
   } );
 

--- a/test/browser_tests/cucumber/step_definitions/filterable-list-control.js
+++ b/test/browser_tests/cucumber/step_definitions/filterable-list-control.js
@@ -3,9 +3,8 @@
 
 var filterableListControl = require( '../../shared_objects/filterable-list-control.js' );
 var { defineSupportCode } = require( 'cucumber' );
-var { expect } = require( 'chai' );
 
-defineSupportCode( function( { Then, When } ) {
+defineSupportCode( function( { When } ) {
   When( /I (.*) the filterable list control/, function( action ) {
 
     return filterableListControl[action]();

--- a/test/browser_tests/cucumber/step_definitions/multi-select.js
+++ b/test/browser_tests/cucumber/step_definitions/multi-select.js
@@ -3,10 +3,9 @@
 
 var multiSelect = require( '../../shared_objects/multi-select.js' );
 var { defineSupportCode } = require( 'cucumber' );
-var { expect } = require( 'chai' );
 
 
-defineSupportCode( function( { Then, When } ) {
+defineSupportCode( function( { When } ) {
   When( 'interacting with search input', function( ) {
 
     return multiSelect.multiSelectSearch.click();

--- a/test/browser_tests/cucumber/step_definitions/wagtail-admin-pages.js
+++ b/test/browser_tests/cucumber/step_definitions/wagtail-admin-pages.js
@@ -13,13 +13,24 @@ defineSupportCode( function( { Then, When } ) {
     return wagtailAdminPagesPage.createPage( pageType );
   } );
 
-  When( /I create a draft (.*) Page with title "(.*)"/, function(
-    pageType, pageTitle
-  ) {
+  When( /I create a draft (.*) Page with title "(.*)"/,
+    function( pageType, pageTitle ) {
 
-    wagtailAdminPagesPage.createPage( pageType );
-    wagtailAdminPagesPage.setPageTitle( pageTitle );
-    return wagtailAdminPagesPage.save( );
+      wagtailAdminPagesPage.createPage( pageType );
+      wagtailAdminPagesPage.setPageTitle( pageTitle );
+
+      return wagtailAdminPagesPage.save( );
+    }
+  );
+
+  When( /I publish the page/, function( ) {
+
+    return wagtailAdminPagesPage.publish();
+  } );
+
+  When( /I unpublish the page/, function( ) {
+
+    return wagtailAdminPagesPage.unpublish();
   } );
 
   Then( /I open the (.*) menu/, function( menuType ) {
@@ -33,14 +44,5 @@ defineSupportCode( function( { Then, When } ) {
       return wagtailAdminPagesPage.selectMenuItem( component );
     }
   );
-
-  When( /I publish the page/, function( ) {
-    return wagtailAdminPagesPage.publish();
-  } );
-
-  When( /I unpublish the page/, function( ) {
-    return wagtailAdminPagesPage.unpublish();
-  } );
-
 
 } );

--- a/test/browser_tests/page_objects/wagtail-admin-pages-page.js
+++ b/test/browser_tests/page_objects/wagtail-admin-pages-page.js
@@ -4,6 +4,9 @@ const BasePage = require( './base-page.js' );
 const contentMenu = require(
   '../shared_objects/wagtail-admin-content-menu.js'
 );
+const clickWhenReady = require(
+  '../util/click-when-ready.js'
+);
 const EC = protractor.ExpectedConditions;
 
 const PAGE_TYPES = {
@@ -89,42 +92,29 @@ class WagtailAdminPages extends BasePage {
   }
 
   setPageTitle( title ) {
-    return browser.wait( EC.elementToBeClickable( titleField ) )
+
+    return browser.wait( EC.visibilityOf( titleField ) )
       .then( function() {
+
         return titleField.sendKeys( title );
       } );
   }
 
   save( ) {
-    return browser.wait( EC.elementToBeClickable( saveButton ) )
-      .then( function() {
-        return saveButton.click();
-      } );
+
+    return clickWhenReady( saveButton );
   }
 
   publish( ) {
-    return browser.wait( EC.elementToBeClickable( dropdownToggle ) )
-      .then( function() {
-        return dropdownToggle.click().then( function() {
-          return browser.wait( EC.elementToBeClickable( publishButton ) )
-            .then( function() {
-              return publishButton.click();
-            } );
-        } );
-      } );
+
+    return clickWhenReady( [ dropdownToggle, publishButton ] );
   }
 
   unpublish( ) {
-    return browser.wait( EC.elementToBeClickable( dropdownToggle ) )
-      .then( function() {
-        return dropdownToggle.click().then( function() {
-          return browser.wait( EC.elementToBeClickable( unpublishButton ) )
-            .then( function() {
-              unpublishButton.click();
-              return confirmUnpublishButton.click();
-            } );
-        } );
-      } );
+
+    return clickWhenReady(
+      [ dropdownToggle, unpublishButton, confirmUnpublishButton ]
+    );
   }
 
 }

--- a/test/browser_tests/util/click-when-ready.js
+++ b/test/browser_tests/util/click-when-ready.js
@@ -1,0 +1,30 @@
+'use strict';
+
+const EC = protractor.ExpectedConditions;
+
+function _clickElement( element ) {
+
+  return browser
+         .wait( EC.elementToBeClickable( element ) )
+         .then( element.click );
+}
+
+function clickWhenReady( elements ) {
+
+  if ( elements instanceof protractor.ElementFinder ) {
+    elements = [ elements ];
+  }
+
+  if ( Array.isArray( elements ) === false ) {
+    return Promise.resolve( );
+  }
+
+  return elements.reduce( ( promise, element ) =>
+
+    promise.then( _clickElement.bind( null, element ) )
+
+  , Promise.resolve( ) );
+
+}
+
+module.exports = clickWhenReady;

--- a/test/browser_tests/util/screenshot.js
+++ b/test/browser_tests/util/screenshot.js
@@ -34,8 +34,8 @@ function _processScreenshot( screenShotName = 'screenshot', png ) {
  * @param {string} screenShotName - Name of the screenshot.
  */
 function capture( screenShotName ) {
-  browser.takeScreenshot().then( function( bufferData ) {
-    _processScreenshot( screenShotName, bufferData );
+  browser.takeScreenshot().then( function( png ) {
+    _processScreenshot( screenShotName, png );
   } );
 }
 


### PR DESCRIPTION
Tests Refactoring and minor cleanup

## Additions

- Added `click-when-ready.js` utility to create a convenient method for click flows.

## Changes

- Modified and renamed  `publish-unpublish.js` to make the steps more reusable. 

## Testing

- Run `tox -e acceptance-fast specs=wagtail-admin-publish-unpublish.feature`.

## Checklist

* [ ] PR has an informative and human-readable title
* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated
* [ ] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
