### PR TITLE
Update django-hud requirement to 1.3

### DIFF
--- a/requirements/optional-public.txt
+++ b/requirements/optional-public.txt
@@ -1,6 +1,6 @@
 git+https://github.com/cfpb/college-costs.git@2.3.7#egg=college-costs
 git+https://github.com/cfpb/complaint.git@1.3.3#egg=complaintdatabase
-git+https://github.com/cfpb/django-hud.git@1.2#egg=django-hud
+git+https://github.com/cfpb/django-hud.git@1.3#egg=django-hud
 git+https://github.com/cfpb/owning-a-home-api.git@0.9.96#egg=owning-a-home-api
 git+https://github.com/cfpb/regulations-core.git@1.2.3#egg=regcore
 git+https://github.com/cfpb/regulations-site.git@2.1.8#egg=regulations


### PR DESCRIPTION
This commit updates the external [django-hud](https://github.com/cfpb/django-hud) requirement from release 1.2 to release 1.3. See release details at:

https://github.com/cfpb/django-hud/releases/tag/1.3

## Changes

- External django-hud release upgrade from 1.2 to 1.3.
 
## Testing

1. All unit tests pass, see also unit tests at django-hud.

## Checklist

* [X] PR has an informative and human-readable title
* [X] Changes are limited to a single goal (no scope creep)
* [X] Code can be automatically merged (no conflicts)
* [X] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [X] Passes all existing automated tests
* [X] New functions include new tests
* [X] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
