### PR TITLE
Integrate with CCDB5-API - very basic skeleton query

### DIFF
--- a/.env_SAMPLE
+++ b/.env_SAMPLE
@@ -79,6 +79,12 @@ export ES_PORT=9200
 export ES_HOST=localhost
 export SHEER_ELASTICSEARCH_INDEX=content
 
+##########################################
+# Complaint Search ES Indexes Information
+#########################################
+# export COMPLAINT_ES_INDEX=<Complaint_index>
+# export COMPLAINT_DOC_TYPE=<Complaint_doctype>
+
 ########################################################
 # Sheer - for loading data into Elastic-Search instance.
 ########################################################

--- a/cfgov/ccdb5/views.py
+++ b/cfgov/ccdb5/views.py
@@ -1,20 +1,24 @@
 from django.http import JsonResponse
 import datetime
+import complaint_search
 
 
 def search(request):
     now = datetime.datetime.now()
     results = {'search': {'timestamp': '%s' % now}}
+    results = complaint_search.search()
     return JsonResponse(results)
 
 
 def suggest(request):
     now = datetime.datetime.now()
     results = {'suggest': {'timestamp': '%s' % now}}
+    results = complaint_search.suggest()
     return JsonResponse(results)
 
 
 def document(request, id):
     now = datetime.datetime.now()
     results = {'document': {'timestamp': '%s' % now, 'id': id}}
+    results = complaint_search.document(id)
     return JsonResponse(results)

--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -99,6 +99,7 @@ OPTIONAL_APPS = [
     {'import': 'eregsip', 'apps': ('eregsip',)},
     {'import': 'regulations', 'apps': ('regulations',)},
     {'import': 'picard', 'apps': ('picard',)},
+    {'import': 'complaint_search', 'apps': ('complaint_search', 'rest_framework')},
 ]
 
 MIDDLEWARE_CLASSES = (

--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -319,7 +319,8 @@ LEGACY_APP_URLS={'comparisontool':True,
                  'regcore':True,
                  'regulations':True,
                  'countylimits':True,
-                 'noticeandcomment':True}
+                 'noticeandcomment':True,
+                 'complaint_search':True}
 
 # DJANGO HUD API
 DJANGO_HUD_API_ENDPOINT= os.environ.get('HUD_API_ENDPOINT', 'http://localhost/hud-api-replace/')

--- a/cfgov/cfgov/urls.py
+++ b/cfgov/cfgov/urls.py
@@ -13,7 +13,7 @@ from wagtail.wagtailadmin import urls as wagtailadmin_urls
 from wagtailsharing import urls as wagtailsharing_urls
 from wagtailsharing.views import ServeView
 
-from flags.urls import flagged_url, flagged_urls
+from flags.urls import flagged_url
 
 from ask_cfpb.views import (
     ask_search,

--- a/cfgov/cfgov/urls.py
+++ b/cfgov/cfgov/urls.py
@@ -21,7 +21,7 @@ from ask_cfpb.views import (
     print_answer,
     view_answer
 )
-import ccdb5.views as CCDB5
+# import ccdb5.views as CCDB5
 from core.views import ExternalURLNoticeView
 from legacy.views import dbrouter_shortcut, token_provider
 from legacy.views.housing_counselor import (
@@ -301,16 +301,23 @@ urlpatterns = [
         name='cckbyo'),
     # Form csrf token provider for JS form submission
     url(r'^token-provider/', token_provider),
+
+    # CCDB5-API
+    url(r'^data-research/consumer-complaints/api/v1',
+        include_if_app_enabled('complaint_search', 'complaint_search.urls')),
 ]
 
-with flagged_urls('CCDB5_RELEASE') as _url:
-    apiBase = '^data-research/consumer-complaints/api/v1'
-    ccdb5_patterns = [
-        _url(apiBase + '/_suggest', CCDB5.suggest),
-        _url(apiBase + '/(?P<id>[0-9]+)$', CCDB5.document),
-        _url(apiBase, CCDB5.search)
-    ]
-urlpatterns += ccdb5_patterns
+
+# with flagged_urls('CCDB5_RELEASE') as _url:
+#     apiBase = '^data-research/consumer-complaints/api/v1'
+
+#     include_if_app_enabled('ccdb5_api')
+#     ccdb5_patterns = [
+#         _url(apiBase + '/_suggest', CCDB5.suggest),
+#         _url(apiBase + '/(?P<id>[0-9]+)$', CCDB5.document),
+#         _url(apiBase, CCDB5.search)
+#     ]
+# urlpatterns += ccdb5_patterns
 
 
 if settings.ALLOW_ADMIN_URL:

--- a/cfgov/cfgov/urls.py
+++ b/cfgov/cfgov/urls.py
@@ -255,6 +255,18 @@ urlpatterns = [
                 fallback=lambda req: ServeView.as_view()(req, req.path),
                 state=False),
 
+    # If 'CCDB5_RELEASE' is false, include CCDB4 urls.
+    # Otherwise use CCDB5.
+    flagged_url('CCDB5_RELEASE',
+                r'^data-research/consumer-complaints/',
+                include_if_app_enabled(
+                    'complaintdatabase', 'complaintdatabase.urls'
+                ),
+                state=False,
+                fallback=TemplateView.as_view(
+                    template_name='ccdb5_landing_page.html'
+                )),
+
     url(r'^oah-api/rates/',
         include_if_app_enabled('ratechecker', 'ratechecker.urls')),
     url(r'^oah-api/county/',
@@ -291,20 +303,8 @@ urlpatterns = [
     url(r'^token-provider/', token_provider),
 
     # CCDB5-API
-    url(r'^data-research/consumer-complaints/api/v1',
+    url(r'^data-research/consumer-complaints/api/v1/',
         include_if_app_enabled('complaint_search', 'complaint_search.urls')),
-
-    # If 'CCDB5_RELEASE' is false, include CCDB4 urls.
-    # Otherwise use CCDB5.
-    flagged_url('CCDB5_RELEASE',
-                r'^data-research/consumer-complaints/',
-                include_if_app_enabled(
-                    'complaintdatabase', 'complaintdatabase.urls'
-                ),
-                state=False,
-                fallback=TemplateView.as_view(
-                    template_name='ccdb5_landing_page.html'
-                )),
 ]
 
 

--- a/cfgov/cfgov/urls.py
+++ b/cfgov/cfgov/urls.py
@@ -255,18 +255,6 @@ urlpatterns = [
                 fallback=lambda req: ServeView.as_view()(req, req.path),
                 state=False),
 
-    # If 'CCDB5_RELEASE' is false, include CCDB4 urls.
-    # Otherwise use CCDB5.
-    flagged_url('CCDB5_RELEASE',
-                r'^data-research/consumer-complaints/',
-                include_if_app_enabled(
-                    'complaintdatabase', 'complaintdatabase.urls'
-                ),
-                state=False,
-                fallback=TemplateView.as_view(
-                    template_name='ccdb5_landing_page.html'
-                )),
-
     url(r'^oah-api/rates/',
         include_if_app_enabled('ratechecker', 'ratechecker.urls')),
     url(r'^oah-api/county/',
@@ -305,6 +293,18 @@ urlpatterns = [
     # CCDB5-API
     url(r'^data-research/consumer-complaints/api/v1',
         include_if_app_enabled('complaint_search', 'complaint_search.urls')),
+
+    # If 'CCDB5_RELEASE' is false, include CCDB4 urls.
+    # Otherwise use CCDB5.
+    flagged_url('CCDB5_RELEASE',
+                r'^data-research/consumer-complaints/',
+                include_if_app_enabled(
+                    'complaintdatabase', 'complaintdatabase.urls'
+                ),
+                state=False,
+                fallback=TemplateView.as_view(
+                    template_name='ccdb5_landing_page.html'
+                )),
 ]
 
 

--- a/cfgov/cfgov/urls.py
+++ b/cfgov/cfgov/urls.py
@@ -21,7 +21,6 @@ from ask_cfpb.views import (
     print_answer,
     view_answer
 )
-# import ccdb5.views as CCDB5
 from core.views import ExternalURLNoticeView
 from legacy.views import dbrouter_shortcut, token_provider
 from legacy.views.housing_counselor import (
@@ -306,19 +305,6 @@ urlpatterns = [
     url(r'^data-research/consumer-complaints/api/v1/',
         include_if_app_enabled('complaint_search', 'complaint_search.urls')),
 ]
-
-
-# with flagged_urls('CCDB5_RELEASE') as _url:
-#     apiBase = '^data-research/consumer-complaints/api/v1'
-
-#     include_if_app_enabled('ccdb5_api')
-#     ccdb5_patterns = [
-#         _url(apiBase + '/_suggest', CCDB5.suggest),
-#         _url(apiBase + '/(?P<id>[0-9]+)$', CCDB5.document),
-#         _url(apiBase, CCDB5.search)
-#     ]
-# urlpatterns += ccdb5_patterns
-
 
 if settings.ALLOW_ADMIN_URL:
     patterns = [

--- a/requirements/optional-public.txt
+++ b/requirements/optional-public.txt
@@ -5,4 +5,4 @@ git+https://github.com/cfpb/owning-a-home-api.git@0.9.96#egg=owning-a-home-api
 git+https://github.com/cfpb/regulations-core.git@1.2.3#egg=regcore
 git+https://github.com/cfpb/regulations-site.git@2.1.8#egg=regulations
 git+https://github.com/cfpb/retirement.git@0.5.5#egg=retirement
--e git+https://github.com/cfpb/ccdb5-api.git@master#egg=ccdb5-api
+git+https://github.com/cfpb/ccdb5-api.git@v0.0.2#egg=ccdb5-api

--- a/requirements/optional-public.txt
+++ b/requirements/optional-public.txt
@@ -5,3 +5,4 @@ git+https://github.com/cfpb/owning-a-home-api.git@0.9.96#egg=owning-a-home-api
 git+https://github.com/cfpb/regulations-core.git@1.2.3#egg=regcore
 git+https://github.com/cfpb/regulations-site.git@2.1.8#egg=regulations
 git+https://github.com/cfpb/retirement.git@0.5.5#egg=retirement
+-e git+https://github.com/cfpb/ccdb5-api.git@master#egg=ccdb5-api


### PR DESCRIPTION
This is to first integration with the [CCDB5-API](https://github.com/cfpb/ccdb5-api/) so we have access to the complaint data.

## Additions

- Added index/doc_type environment variable template 
- Added basic calls from CCDB5-API
- Added repository to requirements

## Removals

-

## Changes

-

## Testing

1. This will work after https://github.com/cfpb/ccdb5-api/pull/2 is merged
1. This assumes that you have accessed to the complaint data at this point through elasticsearch
1. Pip install `requirements/optional-public.txt` or just pip install ccdb5-api
1. Update the `COMPLAINT_ES_INDEX` and `COMPLAINT_DOC_TYPE` to the correct index and doctype

## Screenshots


## Notes

-

## Todos

- 

## Reviews
@JeffreyMFarley @rosskarchner @willbarton @adamzarger 
cc @sephcoster 

## Checklist

* [ ] PR has an informative and human-readable title
* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated
* [ ] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
