### PR TITLE
Make category pages routable to subcategories

### DIFF
--- a/cfgov/ask_cfpb/migrations/0003_add_answercategorypage.py
+++ b/cfgov/ask_cfpb/migrations/0003_add_answercategorypage.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('ask_cfpb', '0002_answeraudiencepage'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='answercategorypage',
+            name='ask_subcategory',
+            field=models.ForeignKey(related_name='subcategory_page', on_delete=django.db.models.deletion.PROTECT, blank=True, to='ask_cfpb.SubCategory', null=True),
+        ),
+    ]

--- a/cfgov/ask_cfpb/models/pages.py
+++ b/cfgov/ask_cfpb/models/pages.py
@@ -123,7 +123,6 @@ class AnswerCategoryPage(RoutablePageMixin, CFGOVPage):
         related_name='subcategory_page')
     content_panels = CFGOVPage.content_panels + [
         FieldPanel('ask_category', Category),
-        FieldPanel('ask_subcategory', SubCategory),
         StreamFieldPanel('content'),
     ]
 

--- a/cfgov/ask_cfpb/models/pages.py
+++ b/cfgov/ask_cfpb/models/pages.py
@@ -102,13 +102,12 @@ class AnswerLandingPage(LandingPage):
 
 class AnswerCategoryPage(RoutablePageMixin, CFGOVPage):
     """
-    Page type for Ask CFPB category pages and their subcategories.
+    A routable page type for Ask CFPB category pages and their subcategories.
     """
     from ask_cfpb.models import Answer, Audience, Category, SubCategory
 
     objects = CFGOVPageManager()
     content = StreamField([], null=True)
-    page_type = 'category'
     ask_category = models.ForeignKey(
         Category,
         blank=True,
@@ -204,7 +203,6 @@ class AnswerCategoryPage(RoutablePageMixin, CFGOVPage):
 
     @route(r'^(?P<subcat>[^/]+)/$')
     def subcategory_page(self, request, **kwargs):
-        self.page_type = 'subcategory'
         self.ask_subcategory = self.SubCategory.objects.get(
             slug=kwargs.get('subcat'))
         # self.slug = self.ask_subcategory.slug

--- a/cfgov/ask_cfpb/tests/models/test_pages.py
+++ b/cfgov/ask_cfpb/tests/models/test_pages.py
@@ -202,18 +202,31 @@ class AnswerModelTestCase(TestCase):
         test_list = get_valid_spanish_tags()
         self.assertIn('hipotecas', test_list)
 
-    def test_routable_page_template(self):
+    def test_routable_category_page_view(self):
+        cat_page = self.create_category_page(
+            ask_category=self.category)
+        response = cat_page.category_page(HttpRequest())
+        self.assertEqual(response.status_code, 200)
+
+    def test_routable_subcategory_page_view(self):
+        cat_page = self.create_category_page(
+            ask_category=self.category)
+        response = cat_page.subcategory_page(
+            HttpRequest(), subcat=self.subcategories[0].slug)
+        self.assertEqual(response.status_code, 200)
+
+    def test_routable_tag_page_template(self):
         self.assertEqual(
             self.tag_results_page.get_template(HttpRequest()),
             'ask-cfpb/answer-tag-spanish-results.html')
 
-    def test_routable_page_base_returns_404(self):
+    def test_routable_tag_page_base_returns_404(self):
         response = self.client.get(
             self.tag_results_page.url +
             self.tag_results_page.reverse_subpage('spanish_tag_base'))
         self.assertEqual(response.status_code, 404)
 
-    def test_routable_page_subpage_bad_tag_returns_404(self):
+    def test_routable_tag_page_subpage_bad_tag_returns_404(self):
         page = self.tag_results_page
         response = self.client.get(
             page.url + page.reverse_subpage(
@@ -221,7 +234,7 @@ class AnswerModelTestCase(TestCase):
                 kwargs={'tag': 'hippopotamus'}))
         self.assertEqual(response.status_code, 404)
 
-    def test_routable_page_subpage_valid_tag_returns_200(self):
+    def test_routable_tag_page_subpage_valid_tag_returns_200(self):
         page = self.tag_results_page
         response = self.client.get(
             page.url + page.reverse_subpage(
@@ -229,7 +242,7 @@ class AnswerModelTestCase(TestCase):
                 kwargs={'tag': 'hipotecas'}))
         self.assertEqual(response.status_code, 200)
 
-    def test_routable_page_returns_url_suffix(self):
+    def test_routable_tag_page_returns_url_suffix(self):
         response = self.tag_results_page.reverse_subpage(
             'buscar_por_etiqueta', kwargs={'tag': 'hipotecas'})
         self.assertEqual(response, 'hipotecas/')

--- a/cfgov/jinja2/v1/ask-cfpb/category-page.html
+++ b/cfgov/jinja2/v1/ask-cfpb/category-page.html
@@ -43,6 +43,44 @@
         </div>
     </section>
 
+    <section class="ask-categories">
+
+        {% if choices|length > 0 or audiences|length > 0 %}
+        <div class="block block__bg 
+                     block__flush-sides 
+                     block__flush-bottom 
+                     block__bg-extend-right">
+            <h3>What is your question about?</h3>
+            <div class="subcategory-nav u-mb30">
+                {% for subcategory in choices %}
+                {% if loop.index == 1 %}
+                <ul class="content-l_col content-l_col-1-2 facets_list list list__unstyled list__spaced">
+                {% endif %}
+                {% set count = choices|length %}
+                {% if loop.index == ( count // 2 ) + ( 2 if count % 2 else 1) %}
+                </ul>
+                <ul class="content-l_col content-l_col-1-2 facets_list list__unstyled list__spaced">
+                {% endif %}
+                    <li class="list_item">
+                        <a href="/ask-cfpb/category-{{ page.ask_category.slug }}/{{ subcategory.slug }}">   
+                            {{ subcategory.name }}
+                        </a>
+                    </li>
+                {% if loop.index == count %}
+                </ul>
+                {% endif %}
+                {% endfor %}
+            </div>
+            {% if audiences %}
+            <div class="topics topics__askcfpb 
+                        topics__category-filter">
+                
+            </div>
+            {% endif %}
+        </div>
+        {% endif %}
+    </section>
+
     <section class="search-results block
                     block__flush-top">
         <div class="message">

--- a/cfgov/jinja2/v1/ask-cfpb/category-page.html
+++ b/cfgov/jinja2/v1/ask-cfpb/category-page.html
@@ -35,7 +35,11 @@
         </h1>
 
         <div class="lead-paragraph">
+            {% if page.ask_subcategory %}
+            <p>{{ page.ask_subcategory.name }}</p>
+            {% else %}
             <p>{{ page.ask_category.intro|safe }}</p>
+            {% endif %}
         </div>
     </section>
 


### PR DESCRIPTION
This allows category pages to serve as the routable parent page of all
of its subcategories, allowing links to related subcategories and
eliminating the need to facet subcategories. In this way, audiences,
subcategories and categories all have their own pages to link to.

The category page template can serve both categories and subcategories, with the subcategory name taking the place of the category intro.

The subcategory slug is just appended to the category page's URL.

## Testing
If you've migrated knowledgebase, you don't need to do that again. You just need to run a table migration with `python cfgov/manage.py migrate`

This sample subcategory page:  
 http://localhost:8000/ask-cfpb/category-student-loans/understanding-student-loans/  
should look like this:

<img width="943" alt="understanding-student-loans" src="https://cloud.githubusercontent.com/assets/515885/26813384/b79a59ee-4a4b-11e7-8d3a-815d460ae177.png">
