### PR TITLE
Updates environment configuration filename

### DIFF
--- a/test/browser_tests/conf.js
+++ b/test/browser_tests/conf.js
@@ -1,13 +1,13 @@
 'use strict';
 
-var environment = require( './environment.js' );
-var envvars = require( '../../config/environment' ).envvars;
-var defaultSuites = require( './default-suites.js' );
+const environmentTest = require( './environment-test' );
+const envvars = require( '../../config/environment' ).envvars;
+const defaultSuites = require( './default-suites.js' );
 
 /**
  * Check whether a parameter value is set.
  * @param {string} param The value of a parameter.
- * @returns {Boolean} Whether a parameter value is undefined or not,
+ * @returns {boolean} Whether a parameter value is undefined or not,
  *   meaining whether it has been set on the command-line or not.
  */
 function _paramIsSet( param ) {
@@ -16,18 +16,18 @@ function _paramIsSet( param ) {
 
 /**
  * Choose the suite based on what command-line flags are passed.
- * @param {object} params Set of parameters from the command-line.
+ * @param {Object} params Set of parameters from the command-line.
  * @returns {Array} List of multiCapabilities objects.
  */
 function _chooseSuite( params ) {
 
-  var paramsAreNotSet = !_paramIsSet( params.browserName ) &&
-                        !_paramIsSet( params.version ) &&
-                        !_paramIsSet( params.platform );
+  const paramsAreNotSet = !_paramIsSet( params.browserName ) &&
+                          !_paramIsSet( params.version ) &&
+                          !_paramIsSet( params.platform );
 
-  var useSauceCredentials = ( !_paramIsSet( params.sauce ) ||
-                              params.sauce === 'true' ) &&
-                            _isSauceCredentialSet();
+  const useSauceCredentials = ( !_paramIsSet( params.sauce ) ||
+                                params.sauce === 'true' ) &&
+                                _isSauceCredentialSet();
 
   // Set the capabilities to use the essential suite,
   // unless Sauce Labs credentials are set and
@@ -47,13 +47,13 @@ function _chooseSuite( params ) {
 
 /**
  * Check that Sauce Labs credentials are set in the .env file.
- * @returns {Boolean} True if all the Sauce credentials
+ * @returns {boolean} True if all the Sauce credentials
  *   are not undefined or an empty string, false otherwise.
  */
 function _isSauceCredentialSet() {
-  var sauceSeleniumUrl = envvars.SAUCE_SELENIUM_URL;
-  var sauceUsername = envvars.SAUCE_USERNAME;
-  var sauceAccessKey = envvars.SAUCE_ACCESS_KEY;
+  const sauceSeleniumUrl = envvars.SAUCE_SELENIUM_URL;
+  const sauceUsername = envvars.SAUCE_USERNAME;
+  const sauceAccessKey = envvars.SAUCE_ACCESS_KEY;
 
   return typeof sauceSeleniumUrl !== 'undefined' &&
          sauceSeleniumUrl !== '' &&
@@ -65,32 +65,32 @@ function _isSauceCredentialSet() {
 
 /**
  * Choose test specs based on passed parameters.
- * @param {object} params Set of parameters from the command-line.
+ * @param {Object} params Set of parameters from the command-line.
  * @returns {Array} List of specs or spec patterns to execute.
  */
 function _chooseProtractorSpecs( params ) {
-  var i;
-  var len;
-  var specs = [];
+  let i;
+  let len;
+  let specs = [];
 
   // If one or more suites are specified, use their specs.
   if ( _paramIsSet( params.suite ) ) {
-    var suiteNames = params.suite.split( ',' );
+    const suiteNames = params.suite.split( ',' );
     for ( i = 0, len = suiteNames.length; i < len; i++ ) {
-      var suiteSpecs = environment.suites[suiteNames[i]];
+      const suiteSpecs = environmentTest.suites[suiteNames[i]];
       if ( suiteSpecs ) {
         specs = specs.concat( suiteSpecs );
       }
     }
   // Otherwise if specs are specified, use them.
   } else if ( _paramIsSet( params.specs ) ) {
-    var specPatterns = params.specs.split( ',' );
+    const specPatterns = params.specs.split( ',' );
     for ( i = 0, len = specPatterns.length; i < len; i++ ) {
-      specs = specs.concat( environment.specsBasePath + specPatterns[i] );
+      specs = specs.concat( environmentTest.specsBasePath + specPatterns[i] );
     }
   // If neither a suite or specs are specified, use the default suite.
   } else {
-    specs = specs.concat( environment.suites.default );
+    specs = specs.concat( environmentTest.suites.default );
   }
 
   return specs;
@@ -98,12 +98,12 @@ function _chooseProtractorSpecs( params ) {
 
 /**
  * Params that need to be passed to protractor config.
- * @param {object} params Set of parameters from the command-line.
- * @returns {object} Parsed parameters from the command-line,
+ * @param {Object} params Set of parameters from the command-line.
+ * @returns {Object} Parsed parameters from the command-line,
  *   which are only applicable to protractor.
  */
 function _retrieveProtractorParams( params ) { // eslint-disable-line complexity, no-inline-comments, max-len
-  var parsedParams = {};
+  const parsedParams = {};
 
   parsedParams.specs = _chooseProtractorSpecs( params );
 
@@ -124,24 +124,24 @@ function _retrieveProtractorParams( params ) { // eslint-disable-line complexity
 
 /**
  * Copy parameters into multiCapabilities array.
- * @param {object} params Set of parameters from the command-line.
+ * @param {Object} params Set of parameters from the command-line.
  * @param {Array} capabilities List of multiCapabilities objects.
  * @returns {Array} List of multiCapabilities objects
  *   with injected params from the command-line and a test name field.
  */
 function _copyParameters( params, capabilities ) { // eslint-disable-line complexity, no-inline-comments, max-len
-  var newCapabilities = [];
-  var injectParams = _retrieveProtractorParams( params );
-  var capability;
+  let newCapabilities = [];
+  const injectParams = _retrieveProtractorParams( params );
+  let capability;
 
-  for ( var i = 0, len = capabilities.length; i < len; i++ ) {
+  for ( let i = 0, len = capabilities.length; i < len; i++ ) {
     capability = capabilities[i];
     for ( var p in injectParams ) {
       if ( injectParams.hasOwnProperty( p ) ) {
         capability[p] = injectParams[p];
       }
     }
-    capability.name = environment.testName +
+    capability.name = environmentTest.testName +
                       ' ' + capability.specs +
                       ', running ' +
                       capability.browserName +
@@ -151,77 +151,88 @@ function _copyParameters( params, capabilities ) { // eslint-disable-line comple
                       ' at ' +
                       ( params.windowSize ?
                         params.windowSize :
-                        environment.windowWidthPx + ',' +
-                        environment.windowHeightPx ) + 'px';
+                        environmentTest.windowWidthPx + ',' +
+                        environmentTest.windowHeightPx ) + 'px';
     newCapabilities.push( capability );
   }
 
   return newCapabilities;
 }
 
-var config = {
-  baseUrl:       environment.baseUrl,
-  cucumberOpts: {
-    'require':   'cucumber/step_definitions/*.js',
-    'tags':      false,
-    'format':    'pretty',
-    'profile':   false,
-    'no-source': true
-  },
-  directConnect: true,
-  framework:     'custom',
-  frameworkPath: require.resolve( 'protractor-cucumber-framework' ),
-  getMultiCapabilities: function() {
-    var params = this.params;
+/**
+ * The getMultiCapabilities method for Protractor's workflow.
+ * See https://github.com/angular/protractor/blob/master/lib/config.ts#L336
+ */
+function _getMultiCapabilities() {
+  const params = this.params;
 
-    // If Sauce Labs credentials or --sauce flag is not set or is not true,
-    // delete Sauce credentials on the config object.
-    if ( !_isSauceCredentialSet() || params.sauce === 'false' ) {
-      delete config.sauceSeleniumAddress;
-      delete config.sauceUser;
-      delete config.sauceKey;
-    }
-
-    var suite = _chooseSuite( params );
-    var capabilities = _copyParameters( params, suite );
-    return capabilities;
-  },
-
-  onPrepare: function() {
-    // Ignore Selenium allowances for non-angular sites.
-    browser.ignoreSynchronization = true;
-
-    // If --windowSize=w,h flag was passed, set window dimensions.
-    // Otherwise, use default values from the test settings.
-    var windowSize = browser.params.windowSize;
-    var windowWidthPx;
-    var windowHeightPx;
-    if ( typeof windowSize === 'undefined' ) {
-      windowWidthPx = environment.windowWidthPx;
-      windowHeightPx = environment.windowHeightPx;
-    } else {
-      var windowSizeArray = windowSize.split( ',' );
-      windowWidthPx = Number( windowSizeArray[0] );
-      windowHeightPx = Number( windowSizeArray[1] );
-    }
-
-    // Calling setSize with headless chromeDriver doesn't work properly if
-    // the requested size is larger than the available screen size.
-    if ( !envvars.HEADLESS_CHROME_BINARY ) {
-      browser.driver.manage().window().setSize(
-        windowWidthPx,
-        windowHeightPx
-      );
-
-      // Set default windowSize parameter equal to the value in settings.js.
-      browser.params.windowWidth = windowWidthPx;
-      browser.params.windowHeight = windowHeightPx;
-      browser.params.windowSize = String( windowWidthPx ) +
-                                  ',' + String( windowHeightPx );
-    }
-
-    return;
+  // If Sauce Labs credentials or --sauce flag is not set or is not true,
+  // delete Sauce credentials on the config object.
+  if ( !_isSauceCredentialSet() || params.sauce === 'false' ) {
+    delete config.sauceSeleniumAddress;
+    delete config.sauceUser;
+    delete config.sauceKey;
   }
+
+  const suite = _chooseSuite( params );
+  const capabilities = _copyParameters( params, suite );
+  return capabilities;
+}
+
+/**
+ * The onPrepare method for Protractor's workflow.
+ * See https://github.com/angular/protractor/blob/master/docs/system-setup.md
+ */
+function _onPrepare() {
+  // Ignore Selenium allowances for non-angular sites.
+  browser.ignoreSynchronization = true;
+
+  // If --windowSize=w,h flag was passed, set window dimensions.
+  // Otherwise, use default values from the test settings.
+  const windowSize = browser.params.windowSize;
+  let windowWidthPx;
+  let windowHeightPx;
+  if ( typeof windowSize === 'undefined' ) {
+    windowWidthPx = environmentTest.windowWidthPx;
+    windowHeightPx = environmentTest.windowHeightPx;
+  } else {
+    const windowSizeArray = windowSize.split( ',' );
+    windowWidthPx = Number( windowSizeArray[0] );
+    windowHeightPx = Number( windowSizeArray[1] );
+  }
+
+  // Calling setSize with headless chromeDriver doesn't work properly if
+  // the requested size is larger than the available screen size.
+  if ( !envvars.HEADLESS_CHROME_BINARY ) {
+    browser.driver.manage().window().setSize(
+      windowWidthPx,
+      windowHeightPx
+    );
+
+    // Set default windowSize parameter equal to the value in settings.js.
+    browser.params.windowWidth = windowWidthPx;
+    browser.params.windowHeight = windowHeightPx;
+    browser.params.windowSize = String( windowWidthPx ) +
+                                ',' + String( windowHeightPx );
+  }
+
+  return;
+}
+
+const config = {
+  baseUrl:              environmentTest.baseUrl,
+  cucumberOpts:         {
+                          'require':   'cucumber/step_definitions/*.js',
+                          'tags':      false,
+                          'format':    'pretty',
+                          'profile':   false,
+                          'no-source': true
+                        },
+  directConnect:        true,
+  framework:            'custom',
+  frameworkPath:        require.resolve( 'protractor-cucumber-framework' ),
+  getMultiCapabilities: _getMultiCapabilities,
+  onPrepare:            _onPrepare
 };
 
 // Set Sauce Labs credientials from .env file.

--- a/test/browser_tests/environment-test.js
+++ b/test/browser_tests/environment-test.js
@@ -1,7 +1,7 @@
 'use strict';
 
-var envvars = require( '../../config/environment' ).envvars;
-var specsRoot = 'cucumber/features/';
+const envvars = require( '../../config/environment' ).envvars;
+const specsRoot = 'cucumber/features/';
 
 module.exports = {
   // A base URL for your application under test.

--- a/test/browser_tests/jenkins_conf.js
+++ b/test/browser_tests/jenkins_conf.js
@@ -1,14 +1,14 @@
 'use strict';
 
-var environment = require( './environment.js' );
-var envvars = require( '../../config/environment' ).envvars;
-var JasmineReporters = require( 'jasmine-reporters' );
-var JasmineSpecReporter = require( 'jasmine-spec-reporter' );
-var mkdirp = require( 'mkdirp' );
+const environmentTest = require( './environmentTest' );
+const envvars = require( '../../config/environment' ).envvars;
+const JasmineReporters = require( 'jasmine-reporters' );
+const JasmineSpecReporter = require( 'jasmine-spec-reporter' );
+const mkdirp = require( 'mkdirp' );
 
 exports.config = {
   framework:    'jasmine2',
-  specs:        [ environment.specsBasePath + '.js' ],
+  specs:        [ environmentTest.specsBasePath + '.js' ],
   capabilities: {
     'browserName':       'chrome',
     'name':              'flapjack-browser-tests ' + envvars.SITE_DESC,


### PR DESCRIPTION
## Changes

- Updates `test/browser_tests/environment.js` to `test/browser_tests/environment-test.js` so that there aren't vaguely confusing imports like:

```
var environment = require( './environment.js' );
var envvars = require( '../../config/environment' ).envvars;
```
- Moves nested functions for `onPrepare` and `getMultiCapabilities` into top-level private functions and adds jsdocs.
- Updates variable syntax to use ES6 declarations.
- Fixes trivial jsdoc errors.

## Testing

1. `gulp test:acceptance` should run no probs.
