### PR TITLE
Removes global protractor logic

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -75,8 +75,8 @@ brew info autoenv
 
 !!! note
     If you use Zsh you’ll need to use
-	[zsh-autoenv](https://github.com/Tarrasch/zsh-autoenv),
-	but we can’t provide support for issues that may arise.
+    [zsh-autoenv](https://github.com/Tarrasch/zsh-autoenv),
+    but we can’t provide support for issues that may arise.
 
 #### MySQL
 
@@ -133,7 +133,7 @@ The cfgov-refresh front end currently uses the following frameworks / tools:
 
 !!! note
     If you’re new to Capital Framework, we encourage you to
-	[start here](https://cfpb.github.io/capital-framework/getting-started).
+    [start here](https://cfpb.github.io/capital-framework/getting-started).
 
 1. Install [Node.js](http://nodejs.org) however you’d like.
    We recommend using [nvm](https://github.com/creationix/nvm), though.
@@ -145,7 +145,7 @@ npm install -g gulp
 ```
 
 !!! note
-	This project requires Node.js v5.5 or higher, and npm v3 or higher.
+    This project requires Node.js v5.5 or higher, and npm v3 or higher.
 
 
 #### Set up your environment
@@ -248,7 +248,7 @@ vagrant up
 ```
 
 !!! note
-	Please be patient the first time you run this step.
+    Please be patient the first time you run this step.
 
 ### 4. Front-end Tools
 
@@ -304,16 +304,6 @@ To apply any unapplied migrations to a database created from a dump, run:
 python cfgov/manage.py migrate
 ```
 
-### Install Protractor locally
-
-Protractor (for the test suites) can be installed globally
-to avoid downloading Chromedriver repeatedly.
-To do so, run:
-
-```bash
-npm install -g protractor && webdriver-manager update
-```
-
 ### Install dependencies for working with the GovDelivery API
 
 Install the following GovDelivery dependencies into your virtual environment:
@@ -326,9 +316,9 @@ pip install git+git://github.com/rosskarchner/govdelivery
 Uncomment and set the GovDelivery environment variables in your `.env` file.
 
 !!! note
-	GovDelivery is a third-party web service that powers our emails.
-	The API is used by subscribe forms on our website.
-	Users may decide to swap this tool out for another third-party service.
+    GovDelivery is a third-party web service that powers our emails.
+    The API is used by subscribe forms on our website.
+    Users may decide to swap this tool out for another third-party service.
 
 
 ## Curious about what the setup scripts are doing?

--- a/frontend.sh
+++ b/frontend.sh
@@ -43,33 +43,15 @@ install() {
   if [ "$cli_flag" = "development" ] ||
      [ "$cli_flag" = "test" ]; then
 
-    # Before installing dependencies,
-    # create variables for globally-installed ones.
-    local is_installed_protractor=$(is_installed protractor)
-
     npm install -d --loglevel warn
 
-    # Copy globally-installed packages.
     # Protractor = JavaScript acceptance testing framework.
-    if [ $is_installed_protractor = 0 ]; then
-      echo 'Installing Protractor dependencies locally…'
-      # We skip Gecko here (--gecko false) because webdriver pulls its release
-      # directly from a GitHub.com URL which enforces rate-limiting. This can
-      # cause installation failures when running automated testing. Currently
-      # we don't rely on Gecko for testing.
-      ./$NODE_DIR/protractor/bin/webdriver-manager update --gecko false
-    else
-      echo 'Global Protractor installed. Copying global install locally…'
-      protractor_symlink=$(command -v protractor)
-      protractor_binary=$(readlink $protractor_symlink)
-      protractor_full_path=$(dirname $protractor_symlink)/$(dirname $protractor_binary)/../../protractor
-      if [ ! -d $protractor_full_path/node_modules/webdriver-manager/selenium ]; then
-        echo 'ERROR: Please run `webdriver-manager update` and try again!'
-        exit
-      fi
-      mkdir -p ./$NODE_DIR/protractor
-      cp -r $protractor_full_path ./$NODE_DIR/
-    fi
+    echo 'Installing Protractor dependencies locally…'
+    # We skip Gecko here (--gecko false) because webdriver pulls its release
+    # directly from a GitHub.com URL which enforces rate-limiting. This can
+    # cause installation failures when running automated testing. Currently
+    # we don't rely on Gecko for testing.
+    ./$NODE_DIR/protractor/bin/webdriver-manager update --gecko false
 
   else
     npm install --production --loglevel warn --no-optional
@@ -118,18 +100,6 @@ shrinkwrap() {
   echo 'Shrinkwrapping…'
   npm shrinkwrap
   checksum
-}
-
-# Returns 1 if a global command-line program installed, else 0.
-# For example, echo "node: $(is_installed node)".
-is_installed() {
-  # Set to 1 initially.
-  local return_=1
-
-  # Set to 0 if program is not found.
-  type $1 >/dev/null 2>&1 || { local return_=0; }
-
-  echo "$return_"
 }
 
 # Execute requested (or all) functions.


### PR DESCRIPTION
[The node_modules checksum](https://github.com/cfpb/cfgov-refresh/blob/master/frontend.sh#L84) in `frontend.sh` makes repeatedly downloading chromedriver less of an issue, so this PR removes the logic around installing protractor globally, as it may not be worth the complexity it introduces and the possibility global protractor make be outdated and break independent of changes in the codebase.

## Removals

- Removes global protractor installation logic from `frontend.sh`

## Changes

- Updates installation docs to reflect removal of global protractor option.
- Replaces mix of tabs and spaces with spaces.

## Testing

1. Remove `node_modules`
2. Run `./frontend.sh`
3. Profit
