### PR TITLE
Modifying acceptance tests scripts to pass all the necessary arguments

### DIFF
--- a/cfgov/cfgov/test.py
+++ b/cfgov/cfgov/test.py
@@ -128,11 +128,11 @@ class TestDataTestRunner(OptionalAppsMixin, PlaceholderJSMixin,
 class AcceptanceTestRunner(TestDataTestRunner):
     def run_suite(self, **kwargs):
         gulp_command = ['gulp', 'test:acceptance:protractor']
-        SPECS_KEY = 'specs'
-        specs = ''.join(sys.argv[2:])
+        protractor_args = sys.argv[2:]
 
-        if (SPECS_KEY in specs):
-            gulp_command.append('--' + ''.join(specs))
+        if ( protractor_args ):
+            for arg in protractor_args:
+                gulp_command.append('--' + arg)
         try:
             subprocess.check_call(gulp_command)
         except subprocess.CalledProcessError:

--- a/cfgov/cfgov/test.py
+++ b/cfgov/cfgov/test.py
@@ -130,7 +130,7 @@ class AcceptanceTestRunner(TestDataTestRunner):
         gulp_command = ['gulp', 'test:acceptance:protractor']
         protractor_args = sys.argv[2:]
 
-        if ( protractor_args ):
+        if (protractor_args):
             for arg in protractor_args:
                 gulp_command.append('--' + arg)
         try:

--- a/cfgov/cfgov/test.py
+++ b/cfgov/cfgov/test.py
@@ -130,9 +130,10 @@ class AcceptanceTestRunner(TestDataTestRunner):
         gulp_command = ['gulp', 'test:acceptance:protractor']
         protractor_args = sys.argv[2:]
 
-        if (protractor_args):
+        if protractor_args:
             for arg in protractor_args:
                 gulp_command.append('--' + arg)
+
         try:
             subprocess.check_call(gulp_command)
         except subprocess.CalledProcessError:

--- a/gulp/tasks/test.js
+++ b/gulp/tasks/test.js
@@ -48,16 +48,20 @@ function testUnitScripts( cb ) {
  * Run tox Acceptance tests.
  */
 function testAcceptanceBrowser() {
-  const params = minimist( process.argv.slice( 3 ) );
-  let toxParams = [ '-e', 'acceptance' ];
+  const params = minimist( process.argv.slice( 3 ) ) || {};
+  let toxParams = [ '-e' ];
 
-  if ( params ) {
-    Object.keys( params ).forEach( ( key, value ) => {
-      if ( key !== '_' ) {
-        toxParams.push( key + '=' + params[key] );
-      }
-    } );
+  if( params[ 'fast' ] ) {
+    toxParams.push( 'acceptance-fast' );
+  } else {
+    toxParams.push( 'acceptance' );
   }
+
+  Object.keys( params ).forEach( ( key, value ) => {
+    if ( key !== '_' ) {
+      toxParams.push( key + '=' + params[key] );
+    }
+  } );
 
   spawn( 'tox', toxParams, { stdio: 'inherit' } )
   .once( 'close', function( code ) {

--- a/gulp/tasks/test.js
+++ b/gulp/tasks/test.js
@@ -48,13 +48,15 @@ function testUnitScripts( cb ) {
  * Run tox Acceptance tests.
  */
 function testAcceptanceBrowser() {
-  const params = minimist( process.argv.slice( 2 ) );
-  const SPECS_KEY = 'specs';
+  const params = minimist( process.argv.slice( 3 ) );
   let toxParams = [ '-e', 'acceptance' ];
 
-  // Set `specs=true` for tox if `--specs` is a command-line argument.
-  if ( params && params[SPECS_KEY] ) {
-    toxParams.push( SPECS_KEY + '=' + params[SPECS_KEY] );
+  if ( params ) {
+    Object.keys( params ).forEach( ( key, value ) => {
+      if ( key !== '_' ) {
+        toxParams.push( key + '=' + params[key] );
+      }
+    } );
   }
 
   spawn( 'tox', toxParams, { stdio: 'inherit' } )
@@ -269,16 +271,15 @@ function testPerf() {
 
 /**
  * Spawn the appropriate acceptance tests.
- * @param {string} suite Name of specific suite or suites to run, if any.
+ * @param {string} args Selenium arguments.
  */
-function spawnProtractor( suite ) {
+function spawnProtractor( args ) {
   let UNDEFINED;
 
-  if ( typeof suite === 'function' ) {
-    suite = UNDEFINED;
+  if ( typeof args === 'function' ) {
+    args = UNDEFINED;
   }
-
-  const params = _getProtractorParams( suite );
+  const params = _getProtractorParams( args );
 
   gulpUtil.log( 'Running Protractor with params: ' + params );
   spawn(

--- a/gulp/tasks/test.js
+++ b/gulp/tasks/test.js
@@ -51,7 +51,7 @@ function testAcceptanceBrowser() {
   const params = minimist( process.argv.slice( 3 ) ) || {};
   let toxParams = [ '-e' ];
 
-  if( params[ 'fast' ] ) {
+  if( params.fast ) {
     toxParams.push( 'acceptance-fast' );
   } else {
     toxParams.push( 'acceptance' );
@@ -85,6 +85,13 @@ function _addCommandLineFlag( protractorParams, commandLineParams, value ) {
   if ( typeof commandLineParams[value] === 'undefined' ) {
     return protractorParams;
   }
+
+  if ( value === 'tags' ) {
+    return protractorParams.concat( [ '--cucumberOpts.tags' +
+                                      '=' +
+                                      commandLineParams[value] ] );
+  }
+
   return protractorParams.concat( [ '--params.' +
                                     value + '=' +
                                     commandLineParams[value] ] );
@@ -122,6 +129,9 @@ function _getProtractorParams( suite ) {
 
   // If --version=number flag is added on the command-line.
   params = _addCommandLineFlag( params, commandLineParams, 'version' );
+
+  // If --tags=@tagName flag is added on the command-line.
+  params = _addCommandLineFlag( params, commandLineParams, 'tags' );
 
   // If the --suite=suite1,suite2 flag is added on the command-line
   // or, if not, if a suite is passed as part of the gulp task definition.

--- a/test/browser_tests/conf.js
+++ b/test/browser_tests/conf.js
@@ -230,6 +230,7 @@ const config = {
     'profile':   false,
     'no-source': true
   },
+  unknownFlags_:        ['cucumberOpts'],
   directConnect:        true,
   framework:            'custom',
   frameworkPath:        require.resolve( 'protractor-cucumber-framework' ),


### PR DESCRIPTION
Modifying scripts associated with acceptance testing to pass arguments to Protractor appropriately.  It's still a dance, but I like dancing.

## Changes

- Modified `cfgov/cfgov/test.py` to pass the necessary arguments to the gulp process.
- Modifed `gulp/tasks/test.js` to pass the the necessary arguments to the tox process.

## Testing

1. Run `gulp test:acceptance --specs=multi-select.feature,filterable-page.feature` and verify that it works as expected.
2. Run `gulp test:acceptance --a11y`  and verify that it works as expected.
3. Run `tox -e acceptance-fast a11y` and verify that it works as expected.
3. Run any other protractor command line argument and verify that it gets passed as expected.

## Screenshots
- 
![giphy](https://user-images.githubusercontent.com/1696212/26885186-e77572c8-4b6f-11e7-802d-6b030f609823.gif)


## Notes

- The tox / gulp dance is obviously a bit sub-optimal but minimal.

## Todos

-

## Checklist

* [ ] PR has an informative and human-readable title
* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated
* [ ] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
