### PR TITLE
Ask CFPB deploy config

### DIFF
--- a/cfgov/ask_cfpb/models/django.py
+++ b/cfgov/ask_cfpb/models/django.py
@@ -420,10 +420,11 @@ class Answer(models.Model):
             get_feedback_stream_value(_page),
             is_lazy=True)
         _page.save_revision(user=self.last_user)
-        base_page.refresh_from_db()
-        base_page.has_unpublished_changes = True
-        base_page.save()
-        return base_page
+        # _page.save()
+        # base_page.refresh_from_db()
+        # base_page.has_unpublished_changes = True
+        # base_page.save()
+        return _page
 
     def create_or_update_pages(self):
         counter = 0

--- a/cfgov/ask_cfpb/scripts/migrate_knowledgebase.py
+++ b/cfgov/ask_cfpb/scripts/migrate_knowledgebase.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
+import datetime
+import pytz
 import re
 import sys
 import time
@@ -22,6 +24,10 @@ from ask_cfpb.models import (
 from ask_cfpb.models import Audience as ASK_audience
 from v1.util.migrations import get_or_create_page
 
+TZ = pytz.timezone('US/Eastern')
+
+# Go live is 11 a.m. Wednesday, June 14, 2017
+GO_LIVE_AT = datetime.datetime(2017, 6, 14, 11, 0, tzinfo=TZ)
 
 logging.basicConfig(level=logging.WARNING)
 logging.disable(logging.INFO)
@@ -144,6 +150,17 @@ def fix_tips(answer_text):
     return clean2
 
 
+# PAGE CREATION
+
+def prep_page(page):
+    """Set the go-live date, create a revision, save page, publish revision"""
+    page.has_unpublished_changes = True
+    page.go_live_at = GO_LIVE_AT
+    revision = page.save_revision()
+    page.save()
+    revision.publish()
+
+
 def get_or_create_landing_pages():
     """
     Create Spanish and English landing pages.
@@ -183,16 +200,13 @@ def get_or_create_landing_pages():
             _map['slug'],
             _map['parent'],
             language=language)
-        landing_page.has_unpublished_changes = True
         if _map['hero']:
             stream_block = landing_page.header.stream_block
             landing_page.header = StreamValue(
                 stream_block,
                 _map['hero'],
                 is_lazy=True)
-        revision = landing_page.save_revision()
-        landing_page.save()
-        revision.publish()
+        prep_page(landing_page)
         time.sleep(1)
         counter += 1
 
@@ -232,10 +246,7 @@ def get_or_create_search_results_pages():
             _map['parent'])
         if _map['language']:
             results_page.language = _map['language']
-        results_page.has_unpublished_changes = True
-        revision = results_page.save_revision()
-        results_page.save()
-        revision.publish()
+        prep_page(results_page)
         time.sleep(1)
         counter += 1
     print("Created {} search results pages".format(counter))
@@ -266,10 +277,7 @@ def get_or_create_category_pages():
                 parent,
                 language=language,
                 ask_category=cat)
-            cat_page.has_unpublished_changes = True
-            revision = cat_page.save_revision()
-            cat_page.save()
-            revision.publish()
+            prep_page(cat_page)
             time.sleep(1)
             counter += 1
     print("Created {} category pages".format(counter))
@@ -289,10 +297,7 @@ def get_or_create_audience_pages():
             parent,
             language='en',
             ask_audience=audience)
-        audience_page.has_unpublished_changes = True
-        revision = audience_page.save_revision()
-        audience_page.save()
-        revision.publish()
+        prep_page(audience_page)
         time.sleep(1)
         counter += 1
     print("Created {} audience pages".format(counter))
@@ -323,7 +328,9 @@ def create_answer_pages(queryset):
                         count_es += 1
                         sys.stdout.write('+')
                         sys.stdout.flush()
-                    revision = _page.get_latest_revision()
+                    _page.go_live_at = GO_LIVE_AT
+                    revision = _page.save_revision(
+                        approved_go_live_at=GO_LIVE_AT)
                     revision.publish()
     else:
         print("No Answer objects found in queryset.")
@@ -336,6 +343,8 @@ def create_pages():
     print("Creating Answer pages: . = English, + = Spanish")
     create_answer_pages(Answer.objects.all())
 
+
+# ANSWER AND METADATA CREATION
 
 def migrate_categories():
     """Move parent QuestionCategories into the new Category model"""

--- a/cfgov/ask_cfpb/scripts/migrate_knowledgebase.py
+++ b/cfgov/ask_cfpb/scripts/migrate_knowledgebase.py
@@ -152,10 +152,11 @@ def fix_tips(answer_text):
 
 # PAGE CREATION
 
-def prep_page(page):
+def prep_page(page, go_live_date=False):
     """Set the go-live date, create a revision, save page, publish revision"""
     page.has_unpublished_changes = True
-    page.go_live_at = GO_LIVE_AT
+    if go_live_date:
+        page.go_live_at = GO_LIVE_AT
     revision = page.save_revision()
     page.save()
     revision.publish()
@@ -469,8 +470,10 @@ def migrate_audiences():
                 ASK_audience.objects.get(id=audience.id))
             audience_relation_count += 1
     print("Migrated {} Audience objects\n"
+          "Found {} already created\n"
           "Created {} Audience links".format(
               audiences_created,
+              Audience.objects.count(),
               audience_relation_count))
 
 

--- a/cfgov/ask_cfpb/scripts/publish_ask_pages.py
+++ b/cfgov/ask_cfpb/scripts/publish_ask_pages.py
@@ -1,0 +1,46 @@
+from __future__ import unicode_literals
+import datetime
+import logging
+import pytz
+import sys
+
+from django.utils import timezone
+
+from ask_cfpb.models import (
+    AnswerPage,
+    AnswerAudiencePage,
+    AnswerCategoryPage,
+    AnswerLandingPage,
+    AnswerResultsPage,
+    TagResultsPage)
+
+logger = logging.getLogger('wagtail.core')
+logger.setLevel(logging.ERROR)
+TZ = pytz.timezone('US/Eastern')
+AWARE_NOW = timezone.now().astimezone(TZ)
+YESTERDAY = AWARE_NOW - datetime.timedelta(days=1)
+
+
+def publish_ask_pages():
+    print("Setting page go_live_at dates to yesterady")
+    count = 0
+    for cls in [AnswerPage,
+                AnswerAudiencePage,
+                AnswerCategoryPage,
+                AnswerLandingPage,
+                AnswerResultsPage,
+                TagResultsPage]:
+        for page in cls.objects.all():
+            count += 1
+            page.go_live_at = YESTERDAY
+            revision = page.save_revision(approved_go_live_at=YESTERDAY)
+            revision.publish()
+            sys.stdout.write('.')
+            sys.stdout.flush()
+
+    print('\nBackdated go_live_at dates '
+          'and published {} pages\n'.format(count))
+
+
+def run():
+    publish_ask_pages()

--- a/cfgov/ask_cfpb/views.py
+++ b/cfgov/ask_cfpb/views.py
@@ -1,5 +1,6 @@
 from __future__ import unicode_literals
 import json
+import re
 from urlparse import urljoin
 
 from bs4 import BeautifulSoup as bs
@@ -132,3 +133,23 @@ def ask_autocomplete(request, language='en'):
                 'url': result.url}
                for result in sqs[:20]]
     return JsonResponse(results, safe=False)
+
+
+def redirect_ask_search(request):
+    # Get selected facets
+    selected_facets = request.GET.get('selected_facets')
+    if selected_facets is None:
+        raise Http404
+
+    # Get the category
+    category_match = re.match(r'category_exact:(?P<category>[^&]+)',
+                              selected_facets)
+    if category_match is None:
+        raise Http404
+
+    category = category_match.groupdict().get('category')
+    if category is None:
+        raise Http404
+
+    return redirect('/ask-cfpb/category-{category}'.format(
+                    category=category), permanent=True)

--- a/cfgov/ask_cfpb/views.py
+++ b/cfgov/ask_cfpb/views.py
@@ -3,11 +3,12 @@ import json
 from urlparse import urljoin
 
 from bs4 import BeautifulSoup as bs
-from django.shortcuts import get_object_or_404, redirect, render
-from django.http import HttpResponse, Http404, JsonResponse
 from haystack.query import SearchQuerySet
 from haystack.inputs import Clean
 from wagtail.wagtailcore.models import Site
+
+from django.http import HttpResponse, Http404, JsonResponse
+from django.shortcuts import get_object_or_404, redirect, render
 
 from ask_cfpb.models import (
     Answer,

--- a/cfgov/ask_cfpb/wagtail_hooks.py
+++ b/cfgov/ask_cfpb/wagtail_hooks.py
@@ -125,8 +125,7 @@ def whitelister_element_rules():
         'aside': attribute_rule({'class': True}),
     }
 
-if settings.DEPLOY_ENVIRONMENT == 'build':
-    hooks.register('insert_editor_js', editor_js)
-    hooks.register('insert_editor_css', editor_css)
-    hooks.register(
-        'construct_whitelister_element_rules', whitelister_element_rules)
+hooks.register('insert_editor_js', editor_js)
+hooks.register('insert_editor_css', editor_css)
+hooks.register(
+    'construct_whitelister_element_rules', whitelister_element_rules)

--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -66,6 +66,7 @@ INSTALLED_APPS = (
     'django.contrib.staticfiles',
     'django.contrib.humanize',
     'storages',
+    'ask_cfpb',
     'data_research',
     'v1',
     'core',
@@ -77,9 +78,6 @@ INSTALLED_APPS = (
     'jobmanager',
     'ccdb5'
 )
-
-if DEPLOY_ENVIRONMENT == 'build':
-    INSTALLED_APPS += ('ask_cfpb',)
 
 OPTIONAL_APPS = [
     {'import': 'noticeandcomment', 'apps': ('noticeandcomment',)},
@@ -592,7 +590,7 @@ FLAGS = {
     # Migration of Ask CFPB to Wagtail
     # When enabled, Ask CFPB is served from Wagtail
     'WAGTAIL_ASK_CFPB': {
-        'boolean': True if DEPLOY_ENVIRONMENT in ['build'] else False
+        'boolean': True if DEPLOY_ENVIRONMENT in ['build', 'beta'] else False
     },
 
     # The next version of the public consumer complaint database

--- a/cfgov/cfgov/urls.py
+++ b/cfgov/cfgov/urls.py
@@ -413,7 +413,7 @@ if settings.DEBUG:
     except ImportError:
         pass
 
-if settings.DEPLOY_ENVIRONMENT != 'build':
+if settings.DEPLOY_ENVIRONMENT not in ['build', 'beta']:
     kb_patterns = [
         url(r'^(?i)askcfpb/',
             include_if_app_enabled(
@@ -425,7 +425,7 @@ if settings.DEPLOY_ENVIRONMENT != 'build':
     urlpatterns += kb_patterns
 
 
-if settings.DEPLOY_ENVIRONMENT == 'build':
+if settings.DEPLOY_ENVIRONMENT in ['build', 'beta']:
     ask_patterns = [
         url(r'^(?i)ask-cfpb/([-\w]{1,244})-(en)-(\d{1,6})/?$',
             view_answer,

--- a/cfgov/cfgov/urls.py
+++ b/cfgov/cfgov/urls.py
@@ -301,16 +301,8 @@ urlpatterns = [
         name='cckbyo'),
     # Form csrf token provider for JS form submission
     url(r'^token-provider/', token_provider),
-    flagged_url('WAGTAIL_ASK_CFPB',
-                r'^data-research/consumer-complaints/',
-                include_if_app_enabled(
-                    'complaintdatabase', 'complaintdatabase.urls'
-                ),
-                state=False,
-                fallback=TemplateView.as_view(
-                    template_name='ccdb5_landing_page.html'
-                ))
 ]
+
 
 with flagged_urls('CCDB5_RELEASE') as _url:
     apiBase = '^data-research/consumer-complaints/api/v1'
@@ -394,6 +386,7 @@ if 'selfregistration' in settings.INSTALLED_APPS:
     pattern = url(r'^company-signup/', CompanySignup.as_view())
     urlpatterns.append(pattern)
 
+
 if settings.DEBUG:
     urlpatterns.append(
         url(r'^test-fixture/$',
@@ -421,6 +414,7 @@ if settings.DEBUG:
         urlpatterns.append(url(r'^__debug__/', include(debug_toolbar.urls)))
     except ImportError:
         pass
+
 
 if settings.DEPLOY_ENVIRONMENT not in ['build', 'beta']:
     kb_patterns = [
@@ -480,10 +474,9 @@ with flagged_urls('WAGTAIL_ASK_CFPB') as _url:
     ]
     urlpatterns += ask_patterns
 
-# Catch remaining URL patterns that did not match a route thus far.
 
+# Catch remaining URL patterns that did not match a route thus far.
 urlpatterns.append(url(r'', include(wagtailsharing_urls)))
-# urlpatterns.append(url(r'', include(wagtailsharing_urls)))
 
 
 def handle_error(code, request):

--- a/cfgov/cfgov/urls.py
+++ b/cfgov/cfgov/urls.py
@@ -19,7 +19,8 @@ from ask_cfpb.views import (
     ask_search,
     ask_autocomplete,
     print_answer,
-    view_answer
+    view_answer,
+    redirect_ask_search
 )
 import ccdb5.views as CCDB5
 from core.views import ExternalURLNoticeView
@@ -462,10 +463,7 @@ ask_cfpb_english_redirects = [
         RedirectView.as_view(
             url='/ask-cfpb/slug-en-%(ask_id)s',
             permanent=True)),
-    url(r'^search/\?selected_facets=category_exact:(?P<category>[^&]+)',  # noqa: E501
-        RedirectView.as_view(
-            url='/ask-cfpb/category-%(category)s',
-            permanent=True)),
+    url(r'^search$', redirect_ask_search),
 ]
 
 # Flagged includes for either old knowledgebase Ask CFPB URLs or new ask_cfpb

--- a/cfgov/cfgov/urls.py
+++ b/cfgov/cfgov/urls.py
@@ -301,6 +301,15 @@ urlpatterns = [
         name='cckbyo'),
     # Form csrf token provider for JS form submission
     url(r'^token-provider/', token_provider),
+    flagged_url('WAGTAIL_ASK_CFPB',
+                r'^data-research/consumer-complaints/',
+                include_if_app_enabled(
+                    'complaintdatabase', 'complaintdatabase.urls'
+                ),
+                state=False,
+                fallback=TemplateView.as_view(
+                    template_name='ccdb5_landing_page.html'
+                ))
 ]
 
 with flagged_urls('CCDB5_RELEASE') as _url:
@@ -425,36 +434,51 @@ if settings.DEPLOY_ENVIRONMENT not in ['build', 'beta']:
     urlpatterns += kb_patterns
 
 
-if settings.DEPLOY_ENVIRONMENT in ['build', 'beta']:
+with flagged_urls('WAGTAIL_ASK_CFPB') as _url:
     ask_patterns = [
-        url(r'^(?i)ask-cfpb/([-\w]{1,244})-(en)-(\d{1,6})/?$',
+        _url(r'^askcfpb/$',
+             RedirectView.as_view(
+                 url='/ask-cfpb/',
+                 permanent=True)),
+        _url(r'^askcfpb/(?P<ask_id>\d+)/(.*)$',
+             RedirectView.as_view(
+                 url='/ask-cfpb/slug-en-%(ask_id)s',
+                 permanent=True)),
+        _url(r'^es/obtener-respuestas/c/(.+)/(?P<ask_id>\d+)/(.+)\.html$',
+             RedirectView.as_view(
+                 url='/es/obtener-respuestas/slug-es-%(ask_id)s',
+                 permanent=True)),
+        _url(r'^askcfpb/search/\?selected_facets=category_exact:(?P<category>[^&]+)',  # noqa: E501
+             RedirectView.as_view(
+                 url='/ask-cfpb/category-%(category)s',
+                 permanent=True)),
+        _url(r'^(?i)ask-cfpb/([-\w]{1,244})-(en)-(\d{1,6})/?$',
             view_answer,
             name='ask-english-answer'),
-        url(r'^es/obtener-respuestas/([-\w]{1,244})-(es)-(\d{1,6})/?$',
+        _url(r'^es/obtener-respuestas/([-\w]{1,244})-(es)-(\d{1,6})/?$',
             view_answer,
             name='ask-spanish-answer'),
-        url(r'^es/obtener-respuestas/([-\w]{1,244})-(es)-(\d{1,6})/imprimir/?$',  # noqa: E501
+        _url(r'^es/obtener-respuestas/([-\w]{1,244})-(es)-(\d{1,6})/imprimir/?$',  # noqa: E501
             print_answer,
             name='ask-spanish-print-answer'),
-        url(r'^(?i)ask-cfpb/search/$',
+        _url(r'^(?i)ask-cfpb/search/$',
             ask_search,
             name='ask-search-en'),
-        url(r'^(?i)ask-cfpb/search/(?P<as_json>json)/$',
+        _url(r'^(?i)ask-cfpb/search/(?P<as_json>json)/$',
             ask_search,
             name='ask-search-en-json'),
-        url(r'^(?P<language>es)/obtener-respuestas/buscar/$',
+        _url(r'^(?P<language>es)/obtener-respuestas/buscar/$',
             ask_search,
             name='ask-search-es'),
-        url(r'^(?P<language>es)/obtener-respuestas/buscar/(?P<as_json>json)/$',
+        _url(r'^(?P<language>es)/obtener-respuestas/buscar/(?P<as_json>json)/$',  # noqa: E501
             ask_search,
             name='ask-search-es-json'),
-        url(r'^(?i)ask-cfpb/api/autocomplete/$',
+        _url(r'^(?i)ask-cfpb/api/autocomplete/$',
             ask_autocomplete, name='ask-autocomplete-en'),
-        url(r'^(?P<language>es)/obtener-respuestas/api/autocomplete/$',
+        _url(r'^(?P<language>es)/obtener-respuestas/api/autocomplete/$',
             ask_autocomplete, name='ask-autocomplete-es'),
     ]
     urlpatterns += ask_patterns
-
 
 # Catch remaining URL patterns that did not match a route thus far.
 

--- a/cfgov/jinja2/v1/_includes/organisms/_vars-mega-menu.html
+++ b/cfgov/jinja2/v1/_includes/organisms/_vars-mega-menu.html
@@ -66,10 +66,21 @@
   ( 'Consumer Tools', featured_menu_content.render( consumer_tools_content ) )
 ] %}
 
+
+                                    {% if flag_enabled('WAGTAIL_ASK_CFPB', request) %}
+                                    'text': 'Find answers to common questions',
+                                    'url':  '/ask-cfpb/'
+                                    {% else %}
+                                    'text': 'Find answers to common questions',
+                                    'url':  '/askcfpb/'
+                                    {% endif %}
+
+
+
 {% set nav_items = [(
     ('Consumer Tools', '#', [(
         ('Submit a Complaint', '/complaint/', []),
-        ('Ask CFPB', '/askcfpb/', []),
+        ('Ask CFPB', {% if flag_enabled('WAGTAIL_ASK_CFPB', request) %}'/ask-cfpb/'{% else %}/askcfpb/'{% endif %}, []),
         ('Tell Your Story', '/your-story/', []),
         ('Information for Students', '/students/', []),
         ('Information for Servicemembers & Veterans', '/servicemembers/', [])

--- a/cfgov/jinja2/v1/_includes/organisms/_vars-mega-menu.html
+++ b/cfgov/jinja2/v1/_includes/organisms/_vars-mega-menu.html
@@ -66,10 +66,6 @@
   ( 'Consumer Tools', featured_menu_content.render( consumer_tools_content ) )
 ] %}
 
-
-                                    'text': 'Find answers to common questions',
-                                    'url':  '/askcfpb/'
-
 {% set nav_items = [(
     ('Consumer Tools', '#', [(
         ('Submit a Complaint', '/complaint/', []),

--- a/cfgov/jinja2/v1/_includes/organisms/_vars-mega-menu.html
+++ b/cfgov/jinja2/v1/_includes/organisms/_vars-mega-menu.html
@@ -73,7 +73,7 @@
 {% set nav_items = [(
     ('Consumer Tools', '#', [(
         ('Submit a Complaint', '/complaint/', []),
-        ('Ask CFPB', '/ask-cfpb/', []),
+        ('Ask CFPB', '/ask-cfpb/' if flag_enabled('WAGTAIL_ASK_CFPB', request) else '/askcfpb/', []),
         ('Tell Your Story', '/your-story/', []),
         ('Information for Students', '/students/', []),
         ('Information for Servicemembers & Veterans', '/servicemembers/', [])
@@ -177,3 +177,4 @@
         ('Contact Us', '/about-us/contact-us/', [])
     )])
 )] -%}
+

--- a/cfgov/jinja2/v1/_includes/organisms/_vars-mega-menu.html
+++ b/cfgov/jinja2/v1/_includes/organisms/_vars-mega-menu.html
@@ -67,20 +67,13 @@
 ] %}
 
 
-                                    {% if flag_enabled('WAGTAIL_ASK_CFPB', request) %}
-                                    'text': 'Find answers to common questions',
-                                    'url':  '/ask-cfpb/'
-                                    {% else %}
                                     'text': 'Find answers to common questions',
                                     'url':  '/askcfpb/'
-                                    {% endif %}
-
-
 
 {% set nav_items = [(
     ('Consumer Tools', '#', [(
         ('Submit a Complaint', '/complaint/', []),
-        ('Ask CFPB', {% if flag_enabled('WAGTAIL_ASK_CFPB', request) %}'/ask-cfpb/'{% else %}/askcfpb/'{% endif %}, []),
+        ('Ask CFPB', '/ask-cfpb/', []),
         ('Tell Your Story', '/your-story/', []),
         ('Information for Students', '/students/', []),
         ('Information for Servicemembers & Veterans', '/servicemembers/', [])

--- a/cfgov/jinja2/v1/index.html
+++ b/cfgov/jinja2/v1/index.html
@@ -79,8 +79,13 @@
                             'body': '<p>Financial matters can be complicated. Get the facts you need to make choices about money, credit scores, mortgages, and more.</p>',
                             'links': [
                                 {
+                                    {% if flag_enabled('WAGTAIL_ASK_CFPB', request) %}
+                                    'text': 'Find answers to common questions',
+                                    'url':  '/ask-cfpb/'
+                                    {% else %}
                                     'text': 'Find answers to common questions',
                                     'url':  '/askcfpb/'
+                                    {% endif %}
                                 }
                             ]
                         } ) }}

--- a/cfgov/jinja2/v1/index.html
+++ b/cfgov/jinja2/v1/index.html
@@ -79,13 +79,8 @@
                             'body': '<p>Financial matters can be complicated. Get the facts you need to make choices about money, credit scores, mortgages, and more.</p>',
                             'links': [
                                 {
-                                    {% if flag_enabled('WAGTAIL_ASK_CFPB', request) %}
                                     'text': 'Find answers to common questions',
-                                    'url':  '/ask-cfpb/'
-                                    {% else %}
-                                    'text': 'Find answers to common questions',
-                                    'url':  '/askcfpb/'
-                                    {% endif %}
+                                    'url':  '/ask-cfpb/' if flag_enabled('WAGTAIL_ASK_CFPB', request) else '/askcfpb/'
                                 }
                             ]
                         } ) }}

--- a/cfgov/v1/db_router.py
+++ b/cfgov/v1/db_router.py
@@ -5,6 +5,7 @@ cfgov_apps = [
     'sessions',
     'admin',
     'contenttypes',
+    'ask_cfpb',
     'v1',
     'flags',
     'taggit',
@@ -14,7 +15,6 @@ cfgov_apps = [
 optional_apps = [
     'countylimits',
     'ratechecker',
-    'ask_cfpb',
 ]
 
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -42,6 +42,6 @@ tinys3==0.1.11
 unipath>=1.1,<=2.0
 vobject==0.9.1
 wagtail==1.10.1
-wagtail-flags==2.0.3
+wagtail-flags==2.0.4
 wagtail-sharing==0.5
 Wand==0.4.2

--- a/tox.ini
+++ b/tox.ini
@@ -16,6 +16,7 @@ setenv=
     GOVDELIVERY_ACCOUNT_CODE=fake_account_code
     DJANGO_SETTINGS_MODULE=cfgov.settings.test
     DJANGO_STAGING_HOSTNAME=content.localhost
+    DEPLOY_ENVIRONMENT=build
     LANG=en_US.UTF-8
     LC_ALL=en_US.UTF-8
 

--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,6 @@ setenv=
     GOVDELIVERY_ACCOUNT_CODE=fake_account_code
     DJANGO_SETTINGS_MODULE=cfgov.settings.test
     DJANGO_STAGING_HOSTNAME=content.localhost
-    DEPLOY_ENVIRONMENT=build
     LANG=en_US.UTF-8
     LC_ALL=en_US.UTF-8
 


### PR DESCRIPTION
Prep for ask_cfpb deployment
See GHE/ConsumerExperience/information-architecture/issues/308

Preps code and a flag for final deployment. 
We're ready to install the app everywhere, but pages won't show up yet.

To do: add flag code to megamenu template to handle the change to an  `/ask-cfpb/` link. 
