### PR TITLE
Updates gulp-autoprefixer from 3.1.1. to 4.0.0.

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -240,9 +240,9 @@
       "resolved": "https://registry.npmjs.org/autolinker/-/autolinker-0.15.3.tgz"
     },
     "autoprefixer": {
-      "version": "6.7.7",
-      "from": "autoprefixer@>=6.0.0 <7.0.0",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-6.7.7.tgz"
+      "version": "7.1.1",
+      "from": "autoprefixer@>=7.0.0 <8.0.0",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-7.1.1.tgz"
     },
     "aws-sign2": {
       "version": "0.6.0",
@@ -791,9 +791,9 @@
       "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz"
     },
     "browserslist": {
-      "version": "1.7.7",
-      "from": "browserslist@>=1.7.6 <2.0.0",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.7.7.tgz"
+      "version": "2.1.4",
+      "from": "browserslist@>=2.1.3 <3.0.0",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-2.1.4.tgz"
     },
     "bs-recipes": {
       "version": "1.3.4",
@@ -901,10 +901,10 @@
         }
       }
     },
-    "caniuse-db": {
-      "version": "1.0.30000676",
-      "from": "caniuse-db@>=1.0.30000634 <2.0.0",
-      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000676.tgz"
+    "caniuse-lite": {
+      "version": "1.0.30000679",
+      "from": "caniuse-lite@>=1.0.30000670 <2.0.0",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000679.tgz"
     },
     "capital-framework": {
       "version": "3.6.1",
@@ -944,9 +944,9 @@
       "resolved": "https://registry.npmjs.org/cf-core/-/cf-core-4.2.0.tgz"
     },
     "cf-grid": {
-      "version": "4.1.0",
+      "version": "4.1.1",
       "from": "cf-grid@>=4.0.1 <5.0.0",
-      "resolved": "https://registry.npmjs.org/cf-grid/-/cf-grid-4.1.0.tgz"
+      "resolved": "https://registry.npmjs.org/cf-grid/-/cf-grid-4.1.1.tgz"
     },
     "cf-icons": {
       "version": "4.1.0",
@@ -1220,9 +1220,9 @@
       "resolved": "https://registry.npmjs.org/cross-spawn-async/-/cross-spawn-async-2.2.5.tgz",
       "dependencies": {
         "lru-cache": {
-          "version": "4.0.2",
+          "version": "4.1.0",
           "from": "lru-cache@>=4.0.0 <5.0.0",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.0.2.tgz"
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.0.tgz"
         }
       }
     },
@@ -1850,7 +1850,7 @@
     },
     "electron-to-chromium": {
       "version": "1.3.13",
-      "from": "electron-to-chromium@>=1.2.7 <2.0.0",
+      "from": "electron-to-chromium@>=1.3.11 <2.0.0",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.13.tgz"
     },
     "elliptic": {
@@ -1957,9 +1957,9 @@
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz"
     },
     "es5-ext": {
-      "version": "0.10.22",
+      "version": "0.10.23",
       "from": "es5-ext@>=0.10.14 <0.11.0",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.22.tgz"
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.23.tgz"
     },
     "es5-shim": {
       "version": "4.5.9",
@@ -2202,9 +2202,9 @@
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz"
     },
     "file-type": {
-      "version": "4.3.0",
+      "version": "4.4.0",
       "from": "file-type@>=4.1.0 <5.0.0",
-      "resolved": "https://registry.npmjs.org/file-type/-/file-type-4.3.0.tgz"
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-4.4.0.tgz"
     },
     "filename-regex": {
       "version": "2.0.1",
@@ -2504,9 +2504,9 @@
       "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-0.1.5.tgz"
     },
     "globals": {
-      "version": "9.17.0",
+      "version": "9.18.0",
       "from": "globals@>=9.0.0 <10.0.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-9.17.0.tgz"
+      "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz"
     },
     "globby": {
       "version": "5.0.0",
@@ -2651,9 +2651,9 @@
       }
     },
     "gulp-autoprefixer": {
-      "version": "3.1.1",
-      "from": "gulp-autoprefixer@3.1.1",
-      "resolved": "https://registry.npmjs.org/gulp-autoprefixer/-/gulp-autoprefixer-3.1.1.tgz"
+      "version": "4.0.0",
+      "from": "gulp-autoprefixer@4.0.0",
+      "resolved": "https://registry.npmjs.org/gulp-autoprefixer/-/gulp-autoprefixer-4.0.0.tgz"
     },
     "gulp-bless": {
       "version": "3.2.1",
@@ -3293,6 +3293,11 @@
       "from": "immutable@3.8.1",
       "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.8.1.tgz"
     },
+    "import-lazy": {
+      "version": "2.1.0",
+      "from": "import-lazy@>=2.1.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-2.1.0.tgz"
+    },
     "imurmurhash": {
       "version": "0.1.4",
       "from": "imurmurhash@>=0.1.4 <0.2.0",
@@ -3711,11 +3716,6 @@
       "from": "jquery.easing@>=1.3.0 <1.4.0",
       "resolved": "https://registry.npmjs.org/jquery.easing/-/jquery.easing-1.3.2.tgz"
     },
-    "js-base64": {
-      "version": "2.1.9",
-      "from": "js-base64@>=2.1.9 <3.0.0",
-      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz"
-    },
     "js-tokens": {
       "version": "3.0.1",
       "from": "js-tokens@>=3.0.0 <4.0.0",
@@ -3822,11 +3822,6 @@
       "version": "0.0.1",
       "from": "lazy-debug-legacy@>=0.0.0 <0.1.0",
       "resolved": "https://registry.npmjs.org/lazy-debug-legacy/-/lazy-debug-legacy-0.0.1.tgz"
-    },
-    "lazy-req": {
-      "version": "2.0.0",
-      "from": "lazy-req@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/lazy-req/-/lazy-req-2.0.0.tgz"
     },
     "lazystream": {
       "version": "1.0.0",
@@ -4750,9 +4745,9 @@
       "resolved": "https://registry.npmjs.org/portscanner/-/portscanner-2.1.1.tgz"
     },
     "postcss": {
-      "version": "5.2.17",
-      "from": "postcss@>=5.0.4 <6.0.0",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
+      "version": "6.0.1",
+      "from": "postcss@>=6.0.1 <7.0.0",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.1.tgz",
       "dependencies": {
         "supports-color": {
           "version": "3.2.3",
@@ -4909,9 +4904,9 @@
       "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz"
     },
     "readable-stream": {
-      "version": "2.2.10",
+      "version": "2.2.11",
       "from": "readable-stream@>=2.0.2 <3.0.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.10.tgz"
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.11.tgz"
     },
     "readdirp": {
       "version": "2.1.0",
@@ -5003,9 +4998,9 @@
       }
     },
     "remove-trailing-separator": {
-      "version": "1.0.1",
+      "version": "1.0.2",
       "from": "remove-trailing-separator@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.0.1.tgz"
+      "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.0.2.tgz"
     },
     "repeat-element": {
       "version": "1.1.2",
@@ -5158,7 +5153,7 @@
     },
     "safe-buffer": {
       "version": "5.0.1",
-      "from": "safe-buffer@>=5.0.1 <6.0.0",
+      "from": "safe-buffer@>=5.0.1 <5.1.0",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz"
     },
     "seek-bzip": {
@@ -5268,9 +5263,9 @@
       "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.8.tgz"
     },
     "shelljs": {
-      "version": "0.7.7",
+      "version": "0.7.8",
       "from": "shelljs@>=0.7.5 <0.8.0",
-      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.7.7.tgz"
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.7.8.tgz"
     },
     "shellwords": {
       "version": "0.1.0",
@@ -5515,9 +5510,9 @@
       "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz"
     },
     "string_decoder": {
-      "version": "1.0.1",
+      "version": "1.0.2",
       "from": "string_decoder@>=1.0.0 <1.1.0",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.1.tgz"
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.2.tgz"
     },
     "string-template": {
       "version": "1.0.0",
@@ -5793,9 +5788,9 @@
       "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.12.tgz"
     },
     "uglify-js": {
-      "version": "2.8.27",
+      "version": "2.8.28",
       "from": "uglify-js@>=2.7.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.27.tgz",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.28.tgz",
       "dependencies": {
         "cliui": {
           "version": "2.1.0",
@@ -5870,9 +5865,9 @@
       "resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-2.0.1.tgz"
     },
     "update-notifier": {
-      "version": "2.1.0",
+      "version": "2.2.0",
       "from": "update-notifier@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-2.1.0.tgz"
+      "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-2.2.0.tgz"
     },
     "urix": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "es5-shim": "4.5.9",
     "glob-all": "3.1.0",
     "gulp": "3.9.1",
-    "gulp-autoprefixer": "3.1.1",
+    "gulp-autoprefixer": "4.0.0",
     "gulp-bless": "3.2.1",
     "gulp-changed": "1.3.2",
     "gulp-clean-css": "3.0.4",


### PR DESCRIPTION
## Changes

- Updates `gulp-autoprefixer` from `3.1.1.` to `4.0.0.`

## Testing

1. Throw out `node_modules` and run `./frontend.sh`
2. `gulp build` should pass.

## Notes

- It appears that some outside dependencies were out-of-date in npm-shrinkwrap, so that seems to include updates not related to this PR.
