### PR TITLE
Fix date-dependent unit test that could break on occasion

### DIFF
--- a/cfgov/v1/tests/test_filterable_list_form.py
+++ b/cfgov/v1/tests/test_filterable_list_form.py
@@ -48,10 +48,10 @@ class TestFilterableListForm(TestCase):
         publish_page(page2)
         publish_page(page3)
         form = self.setUpFilterableForm(data={'topics': ['foo', 'bar']})
-        page_set = form.get_page_set()
-        self.assertEquals(len(page_set), 2)
-        self.assertEquals(page_set[1].specific, page1)
-        self.assertEquals(page_set[0].specific, page2)
+        page_set_pks = form.get_page_set().values_list('pk', flat=True)
+        self.assertEquals(len(page_set_pks), 2)
+        self.assertIn(page1.pk, page_set_pks)
+        self.assertIn(page2.pk, page_set_pks)
 
     def test_filter_doesnt_return_drafts(self):
         page1 = BlogPage(title='test page 1')


### PR DESCRIPTION
The unit test [`v1.tests.test_filterable_list_form.TestFilterableListForm.test_filter_by_tags`](https://github.com/cfpb/cfgov-refresh/blob/master/cfgov/v1/tests/test_filterable_list_form.py#L40) (introduced in #2448) was relying on [`FilterableListForm.get_page_set`](https://github.com/cfpb/cfgov-refresh/blob/master/cfgov/v1/forms.py#L102) returning pages in a
particular order. That method returns pages ordered by `date_published` [which is a Django `DateField`](https://github.com/cfpb/cfgov-refresh/blob/master/cfgov/v1/models/learn_page.py#L48).

Two pages that are published on the same day won't necessarily always return in the same order. This commit changes this test so that it doesn't rely on any particular order.

## Changes

- Refactor of unit test to avoid dependence on publishing order.

## Testing

1. Unit tests continue to pass.

## Checklist

* [X] PR has an informative and human-readable title
* [X] Changes are limited to a single goal (no scope creep)
* [X] Code can be automatically merged (no conflicts)
* [X] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [X] Passes all existing automated tests
* [X] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
