### PR TITLE
Remove the negative margin on the FCM

### DIFF
--- a/cfgov/unprocessed/css/organisms/featured-content-module.less
+++ b/cfgov/unprocessed/css/organisms/featured-content-module.less
@@ -13,9 +13,6 @@
   position: relative;
 
   min-height: 320px;
-  // Fix the doubled border issue
-  margin-right: -1px;
-  margin-left: -1px;
 
   background-color: @fcm-bg;
 


### PR DESCRIPTION
The negative margin was causing the FCM to be pulled beyond the block container, which in turn caused the left hand border to be clipped on right sidebar templates. Removing the negative margin fixes this, but causes a slightly different issue of a double border on right sidebar templates. This turns out to be a rounding error, and is not something worth diving into at this exact moment due to discussion to remove the FCM to sidebar abutment. 

## Removals

- Negative margin within the Featured Content Module

## Testing

1. Run `./runserver.sh`
1. Run `gulp build`
1. Navigate to `http://localhost:8000/about-us/the-bureau/`
1. Navigate to `http://localhost:8000/educational-resources/your-money-your-goals/`

## Screenshots

<img width="1009" alt="screen shot 2017-06-08 at 8 45 13 am" src="https://user-images.githubusercontent.com/1280430/26931907-a1eddda4-4c27-11e7-8189-80b63e44cac0.png">

<img width="888" alt="screen shot 2017-06-08 at 8 45 27 am" src="https://user-images.githubusercontent.com/1280430/26931911-a3f48530-4c27-11e7-822a-63bbee433994.png">

## Checklist

* [x] PR has an informative and human-readable title
* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices
* [x] Project documentation has been updated
* [x] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
