### PR TITLE
Converting old acceptance tests to use new Cucumber framework

### DIFF
--- a/cfgov/scripts/test_data.py
+++ b/cfgov/scripts/test_data.py
@@ -34,7 +34,7 @@ def add_filterable_page(slug, cls):
     publish_page(filterable_page)
     add_children(
         parent=filterable_page,
-        num=10,
+        num=11,
         slug=slug,
     )
 

--- a/gulp/tasks/test.js
+++ b/gulp/tasks/test.js
@@ -38,13 +38,11 @@ function testUnitScripts( cb ) {
           thresholds: { global: 90 }
         } ) )
         */
-
         .on( 'end', cb );
     } );
 }
 
 /**
-
  * Run tox Acceptance tests.
  */
 function testAcceptanceBrowser() {

--- a/gulp/utils/handle-errors.js
+++ b/gulp/utils/handle-errors.js
@@ -10,8 +10,6 @@ module.exports = function() {
                    && this.tasks.browsersync
                    && this.tasks.browsersync.done === false;
 
-  console.log( 'isWatching', isWatching );
-
   if ( errorParam.exitProcess ) {
     exitProcessParam = errorParam.exitProcess;
     errorParam = args[1];

--- a/gulp/utils/handle-errors.js
+++ b/gulp/utils/handle-errors.js
@@ -10,6 +10,8 @@ module.exports = function() {
                    && this.tasks.browsersync
                    && this.tasks.browsersync.done === false;
 
+  console.log( 'isWatching', isWatching );
+
   if ( errorParam.exitProcess ) {
     exitProcessParam = errorParam.exitProcess;
     errorParam = args[1];

--- a/test/browser_tests/conf.js
+++ b/test/browser_tests/conf.js
@@ -225,7 +225,7 @@ const config = {
   baseUrl:              environmentTest.baseUrl,
   cucumberOpts: {
     'require':   'cucumber/step_definitions/*.js',
-    'tags':      false,
+    'tags':      [ '~@mobile', '~@skip' ],
     'format':    'pretty',
     'profile':   false,
     'no-source': true

--- a/test/browser_tests/conf.js
+++ b/test/browser_tests/conf.js
@@ -35,10 +35,22 @@ function _chooseSuite( params ) {
   // no browser/platform flags are passed, in which case use the full suite.
   // This will make it so that setting the browser/platform flags
   // won't launch several identical browsers performing the same tests.
-  var capabilities = defaultSuites.essential;
+  let capabilities = defaultSuites.essential;
 
   if ( envvars.HEADLESS_CHROME_BINARY ) {
     capabilities = defaultSuites.headless;
+    const cucumberOpts = minimist( process.argv.slice( 2 ) )
+                         .cucumberOpts || {};
+    const WINDOW_SIZES = environmentTest.WINDOW_SIZES;
+    let windowWidthPx = WINDOW_SIZES.DESKTOP.WIDTH;
+    let windowHeightPx = WINDOW_SIZES.DESKTOP.HEIGHT;
+
+    if ( cucumberOpts.tags === '@mobile' ) {
+      windowWidthPx = WINDOW_SIZES.MOBILE.WIDTH;
+      windowHeightPx = WINDOW_SIZES.MOBILE.HEIGHT;
+    }
+    let windowSize = `--window-size=${windowWidthPx}x${windowHeightPx}`;
+    capabilities[0].chromeOptions.args.push( windowSize );
   } else if ( paramsAreNotSet && useSauceCredentials ) {
     capabilities = defaultSuites.full;
   }
@@ -211,7 +223,6 @@ function _onPrepare() {
   // Calling setSize with headless chromeDriver doesn't work properly if
   // the requested size is larger than the available screen size.
   if ( !envvars.HEADLESS_CHROME_BINARY ) {
-    console.log(  browser.driver )
     browser.driver.manage().window().setSize(
       windowWidthPx,
       windowHeightPx

--- a/test/browser_tests/conf.js
+++ b/test/browser_tests/conf.js
@@ -3,6 +3,7 @@
 const environmentTest = require( './environment-test' );
 const envvars = require( '../../config/environment' ).envvars;
 const defaultSuites = require( './default-suites.js' );
+const minimist = require( 'minimist' );
 
 /**
  * Check whether a parameter value is set.
@@ -192,20 +193,25 @@ function _onPrepare() {
   // If --windowSize=w,h flag was passed, set window dimensions.
   // Otherwise, use default values from the test settings.
   const windowSize = browser.params.windowSize;
-  let windowWidthPx;
-  let windowHeightPx;
-  if ( typeof windowSize === 'undefined' ) {
-    windowWidthPx = environmentTest.windowWidthPx;
-    windowHeightPx = environmentTest.windowHeightPx;
-  } else {
+  const WINDOW_SIZES = environmentTest.WINDOW_SIZES;
+  const cucumberOpts = minimist( process.argv.slice( 2 ) ).cucumberOpts || {};
+
+  let windowWidthPx = WINDOW_SIZES.DESKTOP.WIDTH;
+  let windowHeightPx = WINDOW_SIZES.DESKTOP.HEIGHT;
+
+  if ( windowSize ) {
     const windowSizeArray = windowSize.split( ',' );
     windowWidthPx = Number( windowSizeArray[0] );
     windowHeightPx = Number( windowSizeArray[1] );
+  } else if ( cucumberOpts.tags === '@mobile' ) {
+    windowWidthPx = WINDOW_SIZES.MOBILE.WIDTH;
+    windowHeightPx = WINDOW_SIZES.MOBILE.HEIGHT;
   }
 
   // Calling setSize with headless chromeDriver doesn't work properly if
   // the requested size is larger than the available screen size.
   if ( !envvars.HEADLESS_CHROME_BINARY ) {
+    console.log(  browser.driver )
     browser.driver.manage().window().setSize(
       windowWidthPx,
       windowHeightPx
@@ -230,7 +236,7 @@ const config = {
     'profile':   false,
     'no-source': true
   },
-  unknownFlags_:        ['cucumberOpts'],
+  unknownFlags_:        [ 'cucumberOpts' ],
   directConnect:        true,
   framework:            'custom',
   frameworkPath:        require.resolve( 'protractor-cucumber-framework' ),

--- a/test/browser_tests/cucumber/features/suites/default/global-search.feature
+++ b/test/browser_tests/cucumber/features/suites/default/global-search.feature
@@ -1,0 +1,40 @@
+
+Feature: Global Search
+  As a user of cf.gov
+  I should be able to use the global search molecule
+  to search for content on the site
+
+  Background:
+    Given I goto URL "/"
+
+  Scenario: Large Size, on page Load
+    Then the search molecule should have a search trigger
+    And it shouldn't have search input content
+    And it shouldn't have suggested search terms
+
+  Scenario: Large Size, after clicking search
+    When I click on the search molecule
+    Then the search molecule shouldn't have a search trigger
+    And it should have search input content
+    And it should focus the search input field
+    And it shouldn't have a clear button label
+
+  Scenario: Large Size, after entering Text
+    When I enter "test" in the search molecule
+    Then it should have a clear button label
+
+  Scenario: Large Size, should navigate to search portal
+    When I enter "test" in the search molecule
+    Then I should navigate to search portal
+
+  Scenario: Large Size, after clicking off search
+    And I click off the search molecule
+    Then it shouldn't have search input content
+
+  Scenario: Large Size, after the tab key is pressed
+    When I focus on the search molecule trigger
+    And I perform tab actions on the search molecule
+    Then it shouldn't have search input content
+
+  Scenario: Mobile, should have suggested search terms
+    When I click on the search molecule

--- a/test/browser_tests/cucumber/features/suites/default/header.feature
+++ b/test/browser_tests/cucumber/features/suites/default/header.feature
@@ -1,0 +1,43 @@
+
+Feature: Header
+  As a user of cf.gov
+  I should be able to use the Header
+
+  Background:
+    Given I goto a browse filterable page
+
+  Scenario: Desktop, at page load
+    Then the header organism should display the header
+    And the header organism should display the logo
+    And the header organism should display the mega menu
+    And the header organism should display the global search
+    And the header organism should display the global eyebrow LG
+    And the header organism should display the global header Cta LG
+    And the header organism shouldn't display the global header Cta SM
+    And the header organism shouldn't display the global eyebrow SM
+
+  @mobile
+  Scenario: Mobile, at page load
+    Then the header organism should display the header
+    And the header organism should display the logo
+    And the header organism should display the mega menu
+    And the header organism shouldn't display the overlay
+    And the header organism should display the global search
+    And the header organism shouldn't display the global header Cta LG
+    And the header organism should display the global header Cta SM
+    And the header organism shouldn't display the global eyebrow LG
+    And the header organism should display the global eyebrow SM
+
+  @mobile
+  Scenario: Mobile, if you click mega menu
+    When I click on the mega-menu
+    Then the header organism should display the overlay
+    And I click on search
+    Then it should show the search and hide the mega-menu
+
+  @mobile
+  Scenario: Mobile, if you click search, then click mega menu
+    When I click on the mega-menu search
+    And click the mega-menu
+    Then it should show the mega menu and hide search
+

--- a/test/browser_tests/cucumber/features/suites/default/header.feature
+++ b/test/browser_tests/cucumber/features/suites/default/header.feature
@@ -24,13 +24,17 @@ Feature: Header
     And the header organism shouldn't display the overlay
     And the header organism should display the global search
     And the header organism shouldn't display the global header Cta LG
-    And the header organism should display the global header Cta SM
-    And the header organism shouldn't display the global eyebrow LG
-    And the header organism should display the global eyebrow SM
+
+  @mobile
+  Scenario: Mobile, if you click the mega menu trigger
+    When I click the the mega-menu trigger
+    Then the header organism should display the global header Cta SM
+    Then the header organism shouldn't display the global eyebrow LG
+    Then the header organism should display the global eyebrow SM
 
   @mobile
   Scenario: Mobile, if you click mega menu
-    When I click on the mega-menu
+    When I click on the mega-menu trigger
     Then the header organism should display the overlay
     And I click on search
     Then it should show the search and hide the mega-menu

--- a/test/browser_tests/cucumber/features/suites/default/header.feature
+++ b/test/browser_tests/cucumber/features/suites/default/header.feature
@@ -27,21 +27,17 @@ Feature: Header
 
   @mobile
   Scenario: Mobile, if you click the mega menu trigger
-    When I click the the mega-menu trigger
+    When I click on the mega-menu trigger
     Then the header organism should display the global header Cta SM
     Then the header organism shouldn't display the global eyebrow LG
     Then the header organism should display the global eyebrow SM
 
   @mobile
-  Scenario: Mobile, if you click mega menu
+  Scenario: Mobile, if you click mega menu, if you click search
     When I click on the mega-menu trigger
     Then the header organism should display the overlay
-    And I click on search
-    Then it should show the search and hide the mega-menu
+    When I click on the mega-menu search trigger
+    Then the mega-menu search form should be displayed
+    And the mega-menu shouldn't be displayed
 
-  @mobile
-  Scenario: Mobile, if you click search, then click mega menu
-    When I click on the mega-menu search
-    And click the mega-menu
-    Then it should show the mega menu and hide search
 

--- a/test/browser_tests/cucumber/features/suites/default/mega-menu.feature
+++ b/test/browser_tests/cucumber/features/suites/default/mega-menu.feature
@@ -1,0 +1,33 @@
+
+Feature: Mega Menu
+  As a user of cf.gov
+  I should be able to use the mega menu organism
+  to navigate the site
+
+  Background:
+    Given I goto URL "/"
+
+  Scenario: Large Size, on page Load
+    Then the mega-menu organism shouldn't show content
+
+  Scenario: Large Size, when mouse is over link
+    Then the mega-menu organism shouldn't show the first link immediately
+
+  Scenario: Large Size, when mouse is over link
+    Then the mega-menu organism should show the first link after a delay
+
+  Scenario: Large Size, mouse moves between menu items
+    When mouse moves from one link to another after a delay
+    Then should only show second link content
+
+  @mobile
+  Scenario: Mobile Size, mouse moves between menu items
+    Then the mega-menu organism should show menu when clicked
+
+  @mobile
+  Scenario: Mobile Size, mouse moves between menu items
+    Then the mega-menu organism should show the PolyCom menu when clicked
+
+  @mobile
+  Scenario: Mobile Size, mouse moves between menu items
+    Then the mega-menu organism should not shift menus when tabbing

--- a/test/browser_tests/cucumber/features/suites/default/multi-select.feature
+++ b/test/browser_tests/cucumber/features/suites/default/multi-select.feature
@@ -3,6 +3,77 @@ Feature: MultiSelect Tags
   As a user of cf.gov
   I should be able to select using the multi-select
 
-  Scenario: Selecting topic tags on the Filterable List Control
-  	Given I goto a browse filterable page
+  Background:
+    Given I goto a browse filterable page
   	And I open the filterable list control
+
+  Scenario: State on page load
+    Then the multi-select should be rendered
+  	But no tags should be selected
+  	And the multi-select dropdown shouldn't be visible
+
+  Scenario: Search input click
+    When I click on the multi-select search input
+    Then the multi-select dropdown should be visible
+
+  Scenario: Search input focus
+    When I focus on the multi-select search input
+    Then the multi-select dropdown should be visible
+
+  Scenario: Search input blur
+    When I focus on the multi-select search input
+   	And I click away from the search input
+   	Then the multi-select dropdown shouldn't be visible
+   	And the multi-select dropdown length should be 0
+
+  Scenario: Typing in search input, returning matched results
+    When I enter "tag0" in the search input
+    Then the multi-select dropdown should display "tag0"
+    And the multi-select dropdown length should be 1
+
+  Scenario: Typing in search input, not returning unmatched results
+    When I enter "tag0" in the search input
+    Then the multi-select dropdown shouldn't display "tag2"
+    And the multi-select dropdown length should be 1
+
+  Scenario: Typing in search input, clearing the input and closing results
+    When I enter "tag0" in the search input
+    And I hit the escape button on the search input
+    Then the multi-select dropdown shouldn't be visible
+    And the multi-select dropdown length should be 0
+    And the options field shouldn't contain the class "filtered"
+
+  Scenario: Typing in search input, highlighting the first item
+    When I click on the multi-select search input
+    And I hit the down arrow on the multi-select
+    Then the first option should be highlighted
+
+  Scenario: Interacting with options list, adding option to choices
+    When I click on the multi-select search input
+    And I click on the first option in the dropdown
+    Then the choices element should contain the first option
+
+  Scenario: Interacting with options list, removing option from choices
+    When I click on the multi-select search input
+    And I click on the first option in the dropdown
+    And I click on the first option in the dropdown again
+    Then the choices length should be 0
+
+  @skip
+  Scenario: XIT - Interacting with options list, add an option with RETURN key
+    When I click on the multi-select search input
+    And I hit the down arrow on the multi-select
+    And I switch to the active element
+
+  @skip
+  Scenario: XIT - Interacting with options list, remove an option with RETURN key
+    When I click on the multi-select search input
+    And I hit the down arrow on the multi-select
+    And I switch to the active element
+
+  Scenario: Interacting with choices list, remove an option from choices
+    When I click on the multi-select search input
+    And I click on the first option in the dropdown
+    And I click on the first choices element
+    Then the choices length should be 0
+

--- a/test/browser_tests/cucumber/features/suites/default/multi-select.feature
+++ b/test/browser_tests/cucumber/features/suites/default/multi-select.feature
@@ -5,12 +5,12 @@ Feature: MultiSelect Tags
 
   Background:
     Given I goto a browse filterable page
-  	And I open the filterable list control
+    And I open the filterable list control
 
   Scenario: State on page load
     Then the multi-select should be rendered
-  	But no tags should be selected
-  	And the multi-select dropdown shouldn't be visible
+    But no tags should be selected
+    And the multi-select dropdown shouldn't be visible
 
   Scenario: Search input click
     When I click on the multi-select search input
@@ -22,9 +22,9 @@ Feature: MultiSelect Tags
 
   Scenario: Search input blur
     When I focus on the multi-select search input
-   	And I click away from the search input
-   	Then the multi-select dropdown shouldn't be visible
-   	And the multi-select dropdown length should be 0
+    And I click away from the search input
+    Then the multi-select dropdown shouldn't be visible
+    And the multi-select dropdown length should be 0
 
   Scenario: Typing in search input, returning matched results
     When I enter "tag0" in the search input
@@ -76,4 +76,3 @@ Feature: MultiSelect Tags
     And I click on the first option in the dropdown
     And I click on the first choices element
     Then the choices length should be 0
-

--- a/test/browser_tests/cucumber/features/suites/default/pagination.feature
+++ b/test/browser_tests/cucumber/features/suites/default/pagination.feature
@@ -1,0 +1,22 @@
+
+Feature: Pagination
+  As a user of cf.gov
+  I should be able to use the pagination molecule
+  to navigate on the filterable pages
+
+  Background:
+    Given I goto a browse filterable page
+
+  Scenario: Navigate to the next page
+    When I click on the next button
+  	Then the page url should contain "page=2"
+
+  Scenario: Navigate to the previous page
+    When I click on the next button
+    And I click on the previous button again
+  	Then the page url should contain "page=1"
+
+   Scenario: Navigate to nth Page
+    When I enter "2" in the page input field
+    And I click on the next button again
+  	Then the page url should contain "page=2"

--- a/test/browser_tests/cucumber/features/suites/default/pagination.feature
+++ b/test/browser_tests/cucumber/features/suites/default/pagination.feature
@@ -9,14 +9,14 @@ Feature: Pagination
 
   Scenario: Navigate to the next page
     When I click on the next button
-  	Then the page url should contain "page=2"
+    Then the page url should contain "page=2"
 
   Scenario: Navigate to the previous page
     When I click on the next button
     And I click on the previous button again
-  	Then the page url should contain "page=1"
+    Then the page url should contain "page=1"
 
    Scenario: Navigate to nth Page
     When I enter "2" in the page input field
     And I click on the next button again
-  	Then the page url should contain "page=2"
+    Then the page url should contain "page=2"

--- a/test/browser_tests/cucumber/step_definitions/application.js
+++ b/test/browser_tests/cucumber/step_definitions/application.js
@@ -17,6 +17,11 @@ defineSupportCode( function( { Then, When } ) {
     return browser.navigate().back();
   } );
 
+  When( /I click away*/, function( ) {
+
+    return element( by.css( 'body' ) ).click( );
+  } );
+
   Then( /I should see page title "(.*)"/, function( pageTitle ) {
 
     return browser.getTitle().then( function( title ) {

--- a/test/browser_tests/cucumber/step_definitions/global-search.js
+++ b/test/browser_tests/cucumber/step_definitions/global-search.js
@@ -36,152 +36,147 @@ defineSupportCode( function( { Then, When, Before } ) {
     };
   } );
 
-  if ( browser.params.windowWidth > breakpointsConfig.bpLG.min ) {
-
-    When( /I enter "(.*)" in the search molecule/,
-      function( searchText ) {
-        _dom.trigger.click();
-
-        return _dom.input.sendKeys( searchText );
-      }
-    );
-
-    When( 'I click off the search molecule',
-      function( ) {
-
-
-        return _dom.trigger.click()
-               .then( _nonLinkDom.click );
-      }
-    );
-
-    When( 'I focus on the search molecule trigger',
-      function( ) {
-
-        return _dom.trigger.sendKeys( protractor.Key.SPACE );
-      }
-    );
-
-    When( 'I perform tab actions on the search molecule',
-      function( ) {
-        var activeElement = browser.driver.switchTo().activeElement();
-        activeElement.sendKeys( protractor.Key.TAB );
-        activeElement = browser.driver.switchTo().activeElement();
-
-        return activeElement.sendKeys( protractor.Key.TAB );
-      }
-    );
-
-    Then( /it (should|shouldn't) have a clear button label/,
-      function( shouldHaveLabel ) {
-
-        return expect( _dom.clearBtn.isDisplayed() )
-               .to.eventually
-               .equal( shouldShouldnt( shouldHaveLabel ) );
-      }
-    );
-
-    Then( 'it should focus the search input field',
-      function( ) {
-        var activeElement = browser
-                            .driver
-                            .switchTo()
-                            .activeElement()
-                            .getAttribute( 'id' );
-
-        return activeElement
-              .then( attributeId =>
-                expect( _dom.input.getAttribute( 'id' ) )
-                .to.eventually
-                .equal( attributeId )
-              );
-      }
-    );
-
-    Then( /the search molecule (should|shouldn't) have a search trigger/,
-      function( shouldHaveTrigger ) {
-        let expectedCondition;
-
-        if ( shouldShouldnt( shouldHaveTrigger ) ) {
-          expectedCondition = EC.elementToBeClickable( _dom.trigger );
-        } else {
-          expectedCondition = EC.not( EC.elementToBeClickable( _dom.trigger ) );
-        }
-
-        return browser.wait( expectedCondition )
-               .then( () =>
-                 expect( _dom.trigger.isDisplayed() )
-                 .to.eventually
-                 .equal( shouldShouldnt( shouldHaveTrigger ) )
-               );
-      }
-    );
-
-    Then( /it (should|shouldn't) have search input content/,
-      function( shouldHaveInput ) {
-        let expectedCondition;
-
-        if ( shouldShouldnt( shouldHaveInput ) ) {
-          expectedCondition = EC.elementToBeClickable( _dom.content );
-        } else {
-          expectedCondition = EC.not( EC.elementToBeClickable( _dom.content ) );
-        }
-
-        return browser.wait( expectedCondition )
-               .then( () =>
-                  expect( _dom.content.isDisplayed() )
-                  .to.eventually
-                  .equal( shouldShouldnt( shouldHaveInput ) )
-                );
-      }
-    );
-
-    Then( 'I should navigate to search portal',
-      function( ) {
-
-        return browser.wait( EC.visibilityOf( _dom.searchBtn ) )
-               .then( () => {
-                 const portalUrl =
-                   'https://search.consumerfinance.gov/' +
-                   'search?utf8=%E2%9C%93&affiliate=cfpb&query=test';
-
-                 _dom.searchBtn.click();
-
-                 return expect( browser.getCurrentUrl() )
-                        .to.eventually
-                        .equal( portalUrl );
-               } );
-      }
-    );
-
-    Then( /it (should|shouldn't) have suggested search terms/,
-
-      function( shouldHaveTerms ) {
-
-        return expect( _dom.suggest.isDisplayed() )
-               .to.eventually
-               .equal( shouldShouldnt( shouldHaveTerms ) );
-      }
-    );
-
-  } else if ( browser.params.windowWidth > breakpointsConfig.bpSM.min &&
-              browser.params.windowWidth < breakpointsConfig.bpSM.max ) {
-
-    Then( 'should have suggested search terms',
-
-      function( ) {
-
-        return expect( _dom.suggest.isDisplayed() )
-               .to.eventually
-               .equal( true );
-      }
-    );
-  }
-
   When( 'I click on the search molecule',
     function() {
 
       return _dom.trigger.click();
+    }
+  );
+
+  When( /I enter "(.*)" in the search molecule/,
+    function( searchText ) {
+      _dom.trigger.click();
+
+      return _dom.input.sendKeys( searchText );
+    }
+  );
+
+  When( 'I click off the search molecule',
+    function( ) {
+
+
+      return _dom.trigger.click()
+             .then( _nonLinkDom.click );
+    }
+  );
+
+  When( 'I focus on the search molecule trigger',
+    function( ) {
+
+      return _dom.trigger.sendKeys( protractor.Key.SPACE );
+    }
+  );
+
+  When( 'I perform tab actions on the search molecule',
+    function( ) {
+      var activeElement = browser.driver.switchTo().activeElement();
+      activeElement.sendKeys( protractor.Key.TAB );
+      activeElement = browser.driver.switchTo().activeElement();
+
+      return activeElement.sendKeys( protractor.Key.TAB );
+    }
+  );
+
+  Then( /it (should|shouldn't) have a clear button label/,
+    function( shouldHaveLabel ) {
+
+      return expect( _dom.clearBtn.isDisplayed() )
+             .to.eventually
+             .equal( shouldShouldnt( shouldHaveLabel ) );
+    }
+  );
+
+  Then( 'it should focus the search input field',
+    function( ) {
+      var activeElement = browser
+                          .driver
+                          .switchTo()
+                          .activeElement()
+                          .getAttribute( 'id' );
+
+      return activeElement
+            .then( attributeId =>
+              expect( _dom.input.getAttribute( 'id' ) )
+              .to.eventually
+              .equal( attributeId )
+            );
+    }
+  );
+
+  Then( /the search molecule (should|shouldn't) have a search trigger/,
+    function( shouldHaveTrigger ) {
+      let expectedCondition;
+
+      if ( shouldShouldnt( shouldHaveTrigger ) ) {
+        expectedCondition = EC.elementToBeClickable( _dom.trigger );
+      } else {
+        expectedCondition = EC.not( EC.elementToBeClickable( _dom.trigger ) );
+      }
+
+      return browser.wait( expectedCondition )
+             .then( () =>
+               expect( _dom.trigger.isDisplayed() )
+               .to.eventually
+               .equal( shouldShouldnt( shouldHaveTrigger ) )
+             );
+    }
+  );
+
+  Then( /it (should|shouldn't) have search input content/,
+    function( shouldHaveInput ) {
+      let expectedCondition;
+
+      if ( shouldShouldnt( shouldHaveInput ) ) {
+        expectedCondition = EC.elementToBeClickable( _dom.content );
+      } else {
+        expectedCondition = EC.not( EC.elementToBeClickable( _dom.content ) );
+      }
+
+      return browser.wait( expectedCondition )
+             .then( () =>
+                expect( _dom.content.isDisplayed() )
+                .to.eventually
+                .equal( shouldShouldnt( shouldHaveInput ) )
+              );
+    }
+  );
+
+  Then( 'I should navigate to search portal',
+    function( ) {
+
+      return browser.wait( EC.visibilityOf( _dom.searchBtn ) )
+             .then( () => {
+               const portalUrl =
+                 'https://search.consumerfinance.gov/' +
+                 'search?utf8=%E2%9C%93&affiliate=cfpb&query=test';
+
+               _dom.searchBtn.click();
+
+               return expect( browser.getCurrentUrl() )
+                      .to.eventually
+                      .equal( portalUrl );
+             } );
+    }
+  );
+
+  Then( /it (should|shouldn't) have suggested search terms/,
+
+    function( shouldHaveTerms ) {
+
+      return expect( _dom.suggest.isDisplayed() )
+             .to.eventually
+             .equal( shouldShouldnt( shouldHaveTerms ) );
+    }
+  );
+
+
+  Then( 'should have suggested search terms',
+
+    function( ) {
+
+      return expect( _dom.suggest.isDisplayed() )
+             .to.eventually
+             .equal( true );
     }
   );
 

--- a/test/browser_tests/cucumber/step_definitions/global-search.js
+++ b/test/browser_tests/cucumber/step_definitions/global-search.js
@@ -1,0 +1,188 @@
+'use strict';
+
+const BASE_JS_PATH = '../../../../cfgov/unprocessed/js/';
+const breakpointsConfig = require( BASE_JS_PATH + 'config/breakpoints-config' );
+const chai = require( 'chai' );
+const chaiAsPromised = require( 'chai-as-promised' );
+const { defineSupportCode } = require( 'cucumber' );
+const { expect } = require( 'chai' );
+const { shouldShouldnt } = require( '../../util/index.js' );
+
+const BASE_SEL = '.m-global-search';
+const TRIGGER_SEL = BASE_SEL + ' [data-js-hook="behavior_flyout-menu_trigger"]';
+const CONTENT_SEL = BASE_SEL + ' [data-js-hook="behavior_flyout-menu_content"]';
+const INPUT_SEL = BASE_SEL + ' input#query';
+const SEARCH_SEL = BASE_SEL + ' [data-js-hook="behavior_flyout-menu_content"] .btn';
+const CLEAR_SEL = BASE_SEL + ' .input-contains-label_after';
+const SUGGEST_SEL = BASE_SEL + ' .m-global-search_content-suggestions';
+const EC = protractor.ExpectedConditions;
+
+let _dom;
+let _nonLinkDom;
+
+chai.use( chaiAsPromised );
+
+defineSupportCode( function( { Then, When, Before } ) {
+
+  Before( function() {
+    _nonLinkDom = element( by.css( '.o-footer_official-website' ) );
+    _dom = {
+      trigger:   element( by.css( TRIGGER_SEL ) ),
+      content:   element( by.css( CONTENT_SEL ) ),
+      input:     element( by.css( INPUT_SEL ) ),
+      searchBtn: element( by.css( SEARCH_SEL ) ),
+      clearBtn:  element( by.css( CLEAR_SEL ) ),
+      suggest:   element( by.css( SUGGEST_SEL ) )
+    };
+  } );
+
+  if ( browser.params.windowWidth > breakpointsConfig.bpLG.min ) {
+
+    When( /I enter "(.*)" in the search molecule/,
+      function( searchText ) {
+        _dom.trigger.click();
+
+        return _dom.input.sendKeys( searchText );
+      }
+    );
+
+    When( 'I click off the search molecule',
+      function( ) {
+
+
+        return _dom.trigger.click()
+               .then( _nonLinkDom.click );
+      }
+    );
+
+    When( 'I focus on the search molecule trigger',
+      function( ) {
+
+        return _dom.trigger.sendKeys( protractor.Key.SPACE );
+      }
+    );
+
+    When( 'I perform tab actions on the search molecule',
+      function( ) {
+        var activeElement = browser.driver.switchTo().activeElement();
+        activeElement.sendKeys( protractor.Key.TAB );
+        activeElement = browser.driver.switchTo().activeElement();
+
+        return activeElement.sendKeys( protractor.Key.TAB );
+      }
+    );
+
+    Then( /it (should|shouldn't) have a clear button label/,
+      function( shouldHaveLabel ) {
+
+        return expect( _dom.clearBtn.isDisplayed() )
+               .to.eventually
+               .equal( shouldShouldnt( shouldHaveLabel ) );
+      }
+    );
+
+    Then( 'it should focus the search input field',
+      function( ) {
+        var activeElement = browser
+                            .driver
+                            .switchTo()
+                            .activeElement()
+                            .getAttribute( 'id' );
+
+        return activeElement
+              .then( attributeId =>
+                expect( _dom.input.getAttribute( 'id' ) )
+                .to.eventually
+                .equal( attributeId )
+              );
+      }
+    );
+
+    Then( /the search molecule (should|shouldn't) have a search trigger/,
+      function( shouldHaveTrigger ) {
+        let expectedCondition;
+
+        if ( shouldShouldnt( shouldHaveTrigger ) ) {
+          expectedCondition = EC.elementToBeClickable( _dom.trigger );
+        } else {
+          expectedCondition = EC.not( EC.elementToBeClickable( _dom.trigger ) );
+        }
+
+        return browser.wait( expectedCondition )
+               .then( () =>
+                 expect( _dom.trigger.isDisplayed() )
+                 .to.eventually
+                 .equal( shouldShouldnt( shouldHaveTrigger ) )
+               );
+      }
+    );
+
+    Then( /it (should|shouldn't) have search input content/,
+      function( shouldHaveInput ) {
+        let expectedCondition;
+
+        if ( shouldShouldnt( shouldHaveInput ) ) {
+          expectedCondition = EC.elementToBeClickable( _dom.content );
+        } else {
+          expectedCondition = EC.not( EC.elementToBeClickable( _dom.content ) );
+        }
+
+        return browser.wait( expectedCondition )
+               .then( () =>
+                  expect( _dom.content.isDisplayed() )
+                  .to.eventually
+                  .equal( shouldShouldnt( shouldHaveInput ) )
+                );
+      }
+    );
+
+    Then( 'I should navigate to search portal',
+      function( ) {
+
+        return browser.wait( EC.visibilityOf( _dom.searchBtn ) )
+               .then( () => {
+                 const portalUrl =
+                   'https://search.consumerfinance.gov/' +
+                   'search?utf8=%E2%9C%93&affiliate=cfpb&query=test';
+
+                 _dom.searchBtn.click();
+
+                 return expect( browser.getCurrentUrl() )
+                        .to.eventually
+                        .equal( portalUrl );
+               } );
+      }
+    );
+
+    Then( /it (should|shouldn't) have suggested search terms/,
+
+      function( shouldHaveTerms ) {
+
+        return expect( _dom.suggest.isDisplayed() )
+               .to.eventually
+               .equal( shouldShouldnt( shouldHaveTerms ) );
+      }
+    );
+
+  } else if ( browser.params.windowWidth > breakpointsConfig.bpSM.min &&
+              browser.params.windowWidth < breakpointsConfig.bpSM.max ) {
+
+    Then( 'should have suggested search terms',
+
+      function( ) {
+
+        return expect( _dom.suggest.isDisplayed() )
+               .to.eventually
+               .equal( true );
+      }
+    );
+  }
+
+  When( 'I click on the search molecule',
+    function() {
+
+      return _dom.trigger.click();
+    }
+  );
+
+} );

--- a/test/browser_tests/cucumber/step_definitions/global-search.js
+++ b/test/browser_tests/cucumber/step_definitions/global-search.js
@@ -78,11 +78,11 @@ defineSupportCode( function( { Then, When, Before } ) {
   );
 
   Then( /it (should|shouldn't) have a clear button label/,
-    function( shouldHaveLabel ) {
+    function( haveLabel ) {
 
       return expect( _dom.clearBtn.isDisplayed() )
              .to.eventually
-             .equal( shouldShouldnt( shouldHaveLabel ) );
+             .equal( shouldShouldnt( haveLabel ) );
     }
   );
 
@@ -104,10 +104,10 @@ defineSupportCode( function( { Then, When, Before } ) {
   );
 
   Then( /the search molecule (should|shouldn't) have a search trigger/,
-    function( shouldHaveTrigger ) {
+    function( haveTrigger ) {
       let expectedCondition;
 
-      if ( shouldShouldnt( shouldHaveTrigger ) ) {
+      if ( shouldShouldnt( haveTrigger ) ) {
         expectedCondition = EC.elementToBeClickable( _dom.trigger );
       } else {
         expectedCondition = EC.not( EC.elementToBeClickable( _dom.trigger ) );
@@ -117,16 +117,16 @@ defineSupportCode( function( { Then, When, Before } ) {
              .then( () =>
                expect( _dom.trigger.isDisplayed() )
                .to.eventually
-               .equal( shouldShouldnt( shouldHaveTrigger ) )
+               .equal( shouldShouldnt( haveTrigger ) )
              );
     }
   );
 
   Then( /it (should|shouldn't) have search input content/,
-    function( shouldHaveInput ) {
+    function( haveInput ) {
       let expectedCondition;
 
-      if ( shouldShouldnt( shouldHaveInput ) ) {
+      if ( shouldShouldnt( haveInput ) ) {
         expectedCondition = EC.elementToBeClickable( _dom.content );
       } else {
         expectedCondition = EC.not( EC.elementToBeClickable( _dom.content ) );
@@ -136,7 +136,7 @@ defineSupportCode( function( { Then, When, Before } ) {
              .then( () =>
                 expect( _dom.content.isDisplayed() )
                 .to.eventually
-                .equal( shouldShouldnt( shouldHaveInput ) )
+                .equal( shouldShouldnt( haveInput ) )
               );
     }
   );
@@ -161,11 +161,11 @@ defineSupportCode( function( { Then, When, Before } ) {
 
   Then( /it (should|shouldn't) have suggested search terms/,
 
-    function( shouldHaveTerms ) {
+    function( haveTerms ) {
 
       return expect( _dom.suggest.isDisplayed() )
              .to.eventually
-             .equal( shouldShouldnt( shouldHaveTerms ) );
+             .equal( shouldShouldnt( haveTerms ) );
     }
   );
 

--- a/test/browser_tests/cucumber/step_definitions/header.js
+++ b/test/browser_tests/cucumber/step_definitions/header.js
@@ -4,7 +4,6 @@ const BASE_JS_PATH = '../../../../cfgov/unprocessed/js/';
 const breakpointsConfig = require( BASE_JS_PATH + 'config/breakpoints-config' );
 const { defineSupportCode } = require( 'cucumber' );
 const { shouldShouldnt, toCamelCase } = require( '../../util/index.js' );
-
 const chai = require( 'chai' );
 const expect = chai.expect;
 const chaiAsPromised = require( 'chai-as-promised' );
@@ -25,8 +24,6 @@ const GLOBAL_CTA_LG_SEL = BASE_SEL + ' .m-global-header-cta__horizontal';
 const GLOBAL_CTA_SM_SEL = BASE_SEL + ' .m-global-header-cta__list';
 const GLOBAL_EYEBROW_LG_SEL = BASE_SEL + ' .m-global-eyebrow__horizontal';
 const GLOBAL_EYEBROW_SM_SEL = MEGA_MENU_SEL + ' .m-global-eyebrow__list';
-const EC = protractor.ExpectedConditions;
-
 
 chai.use( chaiAsPromised );
 
@@ -61,57 +58,46 @@ defineSupportCode( function( { Then, When, Before } ) {
 
       return expect( _dom[toCamelCase( element )].isDisplayed() )
              .to.eventually
-             .to.equal( shouldShouldnt( shouldDispayElement ) );
+             .equal( shouldShouldnt( shouldDispayElement ) );
     }
   );
 
   When( 'I click on the mega-menu',
     function( ) {
 
-      return browser
-             .wait( EC.elementToBeClickable( _dom.megaMenu ) )
-             .then( _dom.megaMenu.click );
+      return _dom.megaMenu.click();
     }
   );
 
-  When( 'I click the the mega-menu trigger',
+  When( 'I click on the mega-menu trigger',
     function( ) {
 
-      return  browser
-              .wait( EC.elementToBeClickable( _dom.megaMenuTrigger ) )
-              .then( _dom.megaMenuTrigger.click );
+      return _dom.megaMenuTrigger.click();
     }
   );
 
-  When( 'I click on search', function() {
-    _dom.megaMenuTrigger.click();
+  When( 'I click on the mega-menu search trigger', function() {
 
     return _dom.globalSearchTrigger.click();
   } );
 
-  Then( 'it should show the search and hide megamenu', function() {
-    expect( _dom.globalSearchContent.getAttribute( 'aria-expanded' ) )
-    .to.eventually
-    .to.equal( 'true' );
+  Then(/the mega-menu\s?(shouldn't|should)/, function( shouldDispayElement ) {
+    browser.sleep( 500 );
 
     return expect( _dom.megaMenuContent.getAttribute( 'aria-expanded' ) )
            .to.eventually
-           .to.equal( 'false' );
+           .equal( shouldShouldnt( shouldDispayElement ).toString() );
   } );
 
-  Then( 'it should show the mega menu and hide search', function() {
+  Then( /the mega-menu search form (shouldn't|should)/,
 
-    // Since the code doesn't work when .u-move-transition__disabled is
-    // set to 0ms, we still need a quick sleep.
-    browser.sleep( 2 );
+    function( shouldDispayElement ) {
+      browser.sleep( 500 );
 
-    expect( _dom.megaMenuContent.getAttribute( 'aria-expanded' ) )
-    .to.eventually
-    .equal( 'true' );
-
-    return expect( _dom.globalSearchContent.getAttribute( 'aria-expanded' ) )
-           .to.eventually
-           .equal( 'false' );
-  } );
+      return expect( _dom.globalSearchContent.getAttribute( 'aria-expanded' ) )
+             .to.eventually
+             .equal( shouldShouldnt( shouldDispayElement ).toString() );
+    }
+  );
 
 } );

--- a/test/browser_tests/cucumber/step_definitions/header.js
+++ b/test/browser_tests/cucumber/step_definitions/header.js
@@ -25,6 +25,8 @@ const GLOBAL_CTA_LG_SEL = BASE_SEL + ' .m-global-header-cta__horizontal';
 const GLOBAL_CTA_SM_SEL = BASE_SEL + ' .m-global-header-cta__list';
 const GLOBAL_EYEBROW_LG_SEL = BASE_SEL + ' .m-global-eyebrow__horizontal';
 const GLOBAL_EYEBROW_SM_SEL = MEGA_MENU_SEL + ' .m-global-eyebrow__list';
+const EC = protractor.ExpectedConditions;
+
 
 chai.use( chaiAsPromised );
 
@@ -63,10 +65,21 @@ defineSupportCode( function( { Then, When, Before } ) {
     }
   );
 
-  When( /I click on the mega-menu/,
+  When( 'I click on the mega-menu',
     function( ) {
 
-      return _dom.megaMenu.click();
+      return browser
+             .wait( EC.elementToBeClickable( _dom.megaMenu ) )
+             .then( _dom.megaMenu.click );
+    }
+  );
+
+  When( 'I click the the mega-menu trigger',
+    function( ) {
+
+      return  browser
+              .wait( EC.elementToBeClickable( _dom.megaMenuTrigger ) )
+              .then( _dom.megaMenuTrigger.click );
     }
   );
 

--- a/test/browser_tests/cucumber/step_definitions/header.js
+++ b/test/browser_tests/cucumber/step_definitions/header.js
@@ -54,54 +54,51 @@ defineSupportCode( function( { Then, When, Before } ) {
     browser.executeScript( script );
   } );
 
-  if ( browser.params.windowWidth > breakpointsConfig.bpLG.min ) {
-    Then( /the header organism (should|shouldn't) display the (.*)/,
-      function( shouldDispayElement, element ) {
+  Then( /the header organism (should|shouldn't) display the (.*)/,
+    function( shouldDispayElement, element ) {
 
-        return expect( _dom[toCamelCase( element )].isDisplayed() )
-               .to.eventually
-               .to.equal( shouldShouldnt( shouldDispayElement ) );
-      }
-    );
-
-  } else if ( browser.params.windowWidth < breakpointsConfig.bpSM.max ) {
-    When( /I click on the mega-menu/,
-      function( ) {
-
-        return _dom.megaMenu.click();
-      }
-    );
-
-    When( 'I click on search', function() {
-      _dom.megaMenuTrigger.click();
-
-      return _dom.globalSearchTrigger.click();
-    } );
-
-    Then( 'it should show the search and hide megamenu', function() {
-      expect( _dom.globalSearchContent.getAttribute( 'aria-expanded' ) )
-      .to.eventually
-      .to.equal( 'true' );
-
-      return expect( _dom.megaMenuContent.getAttribute( 'aria-expanded' ) )
+      return expect( _dom[toCamelCase( element )].isDisplayed() )
              .to.eventually
-             .to.equal( 'false' );
-    } );
+             .to.equal( shouldShouldnt( shouldDispayElement ) );
+    }
+  );
 
-    Then( 'it should show the mega menu and hide search', function() {
+  When( /I click on the mega-menu/,
+    function( ) {
 
-      // Since the code doesn't work when .u-move-transition__disabled is
-      // set to 0ms, we still need a quick sleep.
-      browser.sleep( 2 );
+      return _dom.megaMenu.click();
+    }
+  );
 
-      expect( _dom.megaMenuContent.getAttribute( 'aria-expanded' ) )
-      .to.eventually
-      .equal( 'true' );
+  When( 'I click on search', function() {
+    _dom.megaMenuTrigger.click();
 
-      return expect( _dom.globalSearchContent.getAttribute( 'aria-expanded' ) )
-             .to.eventually
-             .equal( 'false' );
-    } );
-  }
+    return _dom.globalSearchTrigger.click();
+  } );
+
+  Then( 'it should show the search and hide megamenu', function() {
+    expect( _dom.globalSearchContent.getAttribute( 'aria-expanded' ) )
+    .to.eventually
+    .to.equal( 'true' );
+
+    return expect( _dom.megaMenuContent.getAttribute( 'aria-expanded' ) )
+           .to.eventually
+           .to.equal( 'false' );
+  } );
+
+  Then( 'it should show the mega menu and hide search', function() {
+
+    // Since the code doesn't work when .u-move-transition__disabled is
+    // set to 0ms, we still need a quick sleep.
+    browser.sleep( 2 );
+
+    expect( _dom.megaMenuContent.getAttribute( 'aria-expanded' ) )
+    .to.eventually
+    .equal( 'true' );
+
+    return expect( _dom.globalSearchContent.getAttribute( 'aria-expanded' ) )
+           .to.eventually
+           .equal( 'false' );
+  } );
 
 } );

--- a/test/browser_tests/cucumber/step_definitions/header.js
+++ b/test/browser_tests/cucumber/step_definitions/header.js
@@ -1,0 +1,107 @@
+'use strict';
+
+const BASE_JS_PATH = '../../../../cfgov/unprocessed/js/';
+const breakpointsConfig = require( BASE_JS_PATH + 'config/breakpoints-config' );
+const { defineSupportCode } = require( 'cucumber' );
+const { shouldShouldnt, toCamelCase } = require( '../../util/index.js' );
+
+const chai = require( 'chai' );
+const expect = chai.expect;
+const chaiAsPromised = require( 'chai-as-promised' );
+
+const BASE_SEL = '.o-header';
+const LOGO_SEL = BASE_SEL + '_logo-img';
+
+// Overlay is technically outside of the header,
+// but makes organizational sense to include here.
+const OVERLAY_SEL = '.a-overlay';
+const MEGA_MENU_SEL = BASE_SEL + ' .o-mega-menu';
+const MEGA_MENU_TRIGGER_SEL = BASE_SEL + ' .o-mega-menu_trigger';
+const MEGA_MENU_CONTENT_SEL = BASE_SEL + ' .o-mega-menu_content';
+const GLOBAL_SEARCH_SEL = BASE_SEL + ' .m-global-search';
+const GLOBAL_SEARCH_TRIGGER_SEL = BASE_SEL + ' .m-global-search_trigger';
+const GLOBAL_SEARCH_CONTENT_SEL = BASE_SEL + ' .m-global-search_content';
+const GLOBAL_CTA_LG_SEL = BASE_SEL + ' .m-global-header-cta__horizontal';
+const GLOBAL_CTA_SM_SEL = BASE_SEL + ' .m-global-header-cta__list';
+const GLOBAL_EYEBROW_LG_SEL = BASE_SEL + ' .m-global-eyebrow__horizontal';
+const GLOBAL_EYEBROW_SM_SEL = MEGA_MENU_SEL + ' .m-global-eyebrow__list';
+
+chai.use( chaiAsPromised );
+
+let _dom;
+
+defineSupportCode( function( { Then, When, Before } ) {
+
+  Before( function() {
+    _dom = {
+      header:              element( by.css( BASE_SEL ) ),
+      logo:                element( by.css( LOGO_SEL ) ),
+      overlay:             element( by.css( OVERLAY_SEL ) ),
+      megaMenu:            element( by.css( MEGA_MENU_SEL ) ),
+      megaMenuTrigger:     element( by.css( MEGA_MENU_TRIGGER_SEL ) ),
+      megaMenuContent:     element.all( by.css( MEGA_MENU_CONTENT_SEL ) ).first(),
+      globalSearch:        element( by.css( GLOBAL_SEARCH_SEL ) ),
+      globalSearchTrigger: element( by.css( GLOBAL_SEARCH_TRIGGER_SEL ) ),
+      globalSearchContent: element( by.css( GLOBAL_SEARCH_CONTENT_SEL ) ),
+      globalHeaderCtaLG:   element( by.css( GLOBAL_CTA_LG_SEL ) ),
+      globalHeaderCtaSM:   element( by.css( GLOBAL_CTA_SM_SEL ) ),
+      globalEyebrowLG:     element( by.css( GLOBAL_EYEBROW_LG_SEL ) ),
+      globalEyebrowSM:     element( by.css( GLOBAL_EYEBROW_SM_SEL ) )
+    };
+
+    const script = 'document.body.className = "u-move-transition__disabled";';
+
+    browser.executeScript( script );
+  } );
+
+  if ( browser.params.windowWidth > breakpointsConfig.bpLG.min ) {
+    Then( /the header organism (should|shouldn't) display the (.*)/,
+      function( shouldDispayElement, element ) {
+
+        return expect( _dom[toCamelCase( element )].isDisplayed() )
+               .to.eventually
+               .to.equal( shouldShouldnt( shouldDispayElement ) );
+      }
+    );
+
+  } else if ( browser.params.windowWidth < breakpointsConfig.bpSM.max ) {
+    When( /I click on the mega-menu/,
+      function( ) {
+
+        return _dom.megaMenu.click();
+      }
+    );
+
+    When( 'I click on search', function() {
+      _dom.megaMenuTrigger.click();
+
+      return _dom.globalSearchTrigger.click();
+    } );
+
+    Then( 'it should show the search and hide megamenu', function() {
+      expect( _dom.globalSearchContent.getAttribute( 'aria-expanded' ) )
+      .to.eventually
+      .to.equal( 'true' );
+
+      return expect( _dom.megaMenuContent.getAttribute( 'aria-expanded' ) )
+             .to.eventually
+             .to.equal( 'false' );
+    } );
+
+    Then( 'it should show the mega menu and hide search', function() {
+
+      // Since the code doesn't work when .u-move-transition__disabled is
+      // set to 0ms, we still need a quick sleep.
+      browser.sleep( 2 );
+
+      expect( _dom.megaMenuContent.getAttribute( 'aria-expanded' ) )
+      .to.eventually
+      .equal( 'true' );
+
+      return expect( _dom.globalSearchContent.getAttribute( 'aria-expanded' ) )
+             .to.eventually
+             .equal( 'false' );
+    } );
+  }
+
+} );

--- a/test/browser_tests/cucumber/step_definitions/header.js
+++ b/test/browser_tests/cucumber/step_definitions/header.js
@@ -54,11 +54,11 @@ defineSupportCode( function( { Then, When, Before } ) {
   } );
 
   Then( /the header organism (should|shouldn't) display the (.*)/,
-    function( shouldDispayElement, element ) {
+    function( dispayElement, element ) {
 
       return expect( _dom[toCamelCase( element )].isDisplayed() )
              .to.eventually
-             .equal( shouldShouldnt( shouldDispayElement ) );
+             .equal( shouldShouldnt( dispayElement ) );
     }
   );
 
@@ -81,22 +81,22 @@ defineSupportCode( function( { Then, When, Before } ) {
     return _dom.globalSearchTrigger.click();
   } );
 
-  Then(/the mega-menu\s?(shouldn't|should)/, function( shouldDispayElement ) {
+  Then(/the mega-menu\s?(shouldn't|should)/, function( dispayElement ) {
     browser.sleep( 500 );
 
     return expect( _dom.megaMenuContent.getAttribute( 'aria-expanded' ) )
            .to.eventually
-           .equal( shouldShouldnt( shouldDispayElement ).toString() );
+           .equal( shouldShouldnt( dispayElement ).toString() );
   } );
 
   Then( /the mega-menu search form (shouldn't|should)/,
 
-    function( shouldDispayElement ) {
+    function( displayElement ) {
       browser.sleep( 500 );
 
       return expect( _dom.globalSearchContent.getAttribute( 'aria-expanded' ) )
              .to.eventually
-             .equal( shouldShouldnt( shouldDispayElement ).toString() );
+             .equal( shouldShouldnt( displayElement ).toString() );
     }
   );
 

--- a/test/browser_tests/cucumber/step_definitions/mega-menu.js
+++ b/test/browser_tests/cucumber/step_definitions/mega-menu.js
@@ -35,7 +35,6 @@ defineSupportCode( function( { Then, When, Before } ) {
 
   When( 'mouse moves from one link to another after a delay',
     function( ) {
-
       browser
       .actions()
       .mouseMove( _dom.triggerPolyCom )
@@ -108,7 +107,7 @@ defineSupportCode( function( { Then, When, Before } ) {
                return expect( _dom.contentAboutUs.isDisplayed() )
                       .to.eventually
                       .equal( true );
-             } );
+           } );
   } );
 
   Then( 'the mega-menu organism should show menu when clicked', function( ) {
@@ -118,7 +117,6 @@ defineSupportCode( function( { Then, When, Before } ) {
            .actions( )
            .click( _dom.triggerBtn )
            .perform()
-
            .then( () => {
              expect( _dom.contentWrapper.isDisplayed() )
              .to.eventually

--- a/test/browser_tests/cucumber/step_definitions/mega-menu.js
+++ b/test/browser_tests/cucumber/step_definitions/mega-menu.js
@@ -1,0 +1,173 @@
+'use strict';
+
+const BASE_JS_PATH = '../../../../cfgov/unprocessed/js/';
+const breakpointsConfig = require( BASE_JS_PATH + 'config/breakpoints-config' );
+const { defineSupportCode } = require( 'cucumber' );
+const chai = require( 'chai' );
+const expect = chai.expect;
+const chaiAsPromised = require( 'chai-as-promised' );
+
+const BASE_SEL = '.o-mega-menu';
+const TRIGGER_BTN = '.o-mega-menu_trigger';
+const CONTENT_WRAPPER = '.o-mega-menu_content';
+const EYEBROW = '.m-global-eyebrow_tagline';
+const TRIGGER_1_SEL = BASE_SEL + '_content-1-link';
+const CONTENT_2_SEL = BASE_SEL + '_content-2';
+const EC = protractor.ExpectedConditions;
+
+chai.use( chaiAsPromised );
+
+let _dom;
+
+defineSupportCode( function( { Then, When, Before } ) {
+
+  Before( function() {
+    _dom = {
+      triggerBtn:     element( by.css( TRIGGER_BTN ) ),
+      contentWrapper: element( by.css( CONTENT_WRAPPER ) ),
+      eyebrow:        element( by.css( EYEBROW ) ),
+      triggerPolyCom: element.all( by.css( TRIGGER_1_SEL ) ).get( 3 ),
+      triggerAboutUs: element.all( by.css( TRIGGER_1_SEL ) ).get( 4 ),
+      contentPolyCom: element.all( by.css( CONTENT_2_SEL ) ).get( 3 ),
+      contentAboutUs: element.all( by.css( CONTENT_2_SEL ) ).get( 4 )
+    };
+  } );
+
+  if ( browser.params.windowWidth > breakpointsConfig.bpLG.min ) {
+
+
+    When( 'mouse moves from one link to another after a delay',
+      function( ) {
+
+        browser
+        .actions()
+        .mouseMove( _dom.triggerPolyCom )
+        .perform();
+
+        // The menu has a built-in delay before it expands.
+        // This waits for that delay.
+        browser.sleep( 500 );
+
+        return browser
+               .actions()
+               .mouseMove( _dom.triggerAboutUs )
+               .perform();
+      }
+    );
+
+    Then( 'the mega-menu organism shouldn\'t show content',
+      function( ) {
+
+        return expect( _dom.contentAboutUs.isDisplayed() )
+               .to.eventually
+               .equal( false );
+      }
+    );
+
+    Then( 'the mega-menu organism shouldn\'t show the first link immediately',
+      function( ) {
+
+        return browser
+               .actions()
+               .mouseMove( _dom.triggerPolyCom )
+               .perform()
+               .then( () =>
+                  expect( _dom.contentPolyCom.isDisplayed() )
+                  .to.eventually
+                  .equal( false )
+               );
+      }
+    );
+
+    Then( /the mega-menu organism should show the first link after a delay/,
+      function( ) {
+
+        return browser
+               .actions( )
+               .mouseMove( _dom.triggerPolyCom )
+               .perform()
+               .then( () =>
+
+                  // Wait for delay to show menu
+                  browser.sleep( 500 )
+                  .then( ( ) =>
+                    expect( _dom.contentPolyCom.isDisplayed() )
+                    .to.eventually
+                    .equal( true )
+                  )
+              );
+      }
+    );
+
+    Then( 'should only show second link content', function( ) {
+
+      return browser.wait(
+               EC.not( EC.elementToBeClickable( _dom.contentPolyCom ) ) )
+               .then( () => {
+                 expect( _dom.contentPolyCom.isDisplayed() )
+                 .to.eventually
+                 .equal( false );
+
+                 return expect( _dom.contentAboutUs.isDisplayed() )
+                        .to.eventually
+                        .equal( true );
+               } );
+    } );
+  } else if ( browser.params.windowWidth > breakpointsConfig.bpSM.min &&
+              browser.params.windowWidth < breakpointsConfig.bpSM.max ) {
+
+    Then( 'the mega-menu organism should show menu when clicked', function( ) {
+
+      return browser
+             .driver
+             .actions( )
+             .click( _dom.triggerBtn )
+             .perform()
+
+             .then( () => {
+               expect( _dom.contentWrapper.isDisplayed() )
+               .to.eventually
+               .equal( true );
+             } );
+    } );
+
+    Then( 'the mega-menu organism should show the PolyCom menu when clicked',
+      function() {
+        browser
+        .driver
+        .actions( )
+        .click( _dom.triggerBtn )
+        .perform( );
+
+        browser.sleep( 500 );
+
+        return browser.driver.actions().click( _dom.triggerPolyCom ).perform()
+               .then( () => {
+                 expect( _dom.contentPolyCom.isDisplayed() )
+                 .to.eventually
+                 .equal( true );
+                 expect( _dom.contentAboutUs.isDisplayed() )
+                 .to.eventually
+                 .equal( false );
+               } );
+      }
+    );
+
+    // This test is failing right now, but should pass
+    // when we fix keyboard tabbing on mobile
+    Then( 'should not shift menus when tabbing',
+      function() {
+        browser.driver.actions().click( _dom.triggerBtn ).perform();
+        browser.driver.actions().sendKeys( protractor.Key.TAB ).perform();
+        browser.driver.actions().sendKeys( protractor.Key.TAB ).perform();
+        browser.driver.actions().sendKeys( protractor.Key.TAB ).perform();
+        browser.driver.actions().sendKeys( protractor.Key.TAB ).perform();
+
+        return expect( _dom.eyebrow.isDisplayed() )
+               .to.eventually
+               .equal( false );
+      }
+    );
+  }
+
+} );

--- a/test/browser_tests/cucumber/step_definitions/mega-menu.js
+++ b/test/browser_tests/cucumber/step_definitions/mega-menu.js
@@ -33,141 +33,135 @@ defineSupportCode( function( { Then, When, Before } ) {
     };
   } );
 
-  if ( browser.params.windowWidth > breakpointsConfig.bpLG.min ) {
+  When( 'mouse moves from one link to another after a delay',
+    function( ) {
 
+      browser
+      .actions()
+      .mouseMove( _dom.triggerPolyCom )
+      .perform();
 
-    When( 'mouse moves from one link to another after a delay',
-      function( ) {
-
-        browser
-        .actions()
-        .mouseMove( _dom.triggerPolyCom )
-        .perform();
-
-        // The menu has a built-in delay before it expands.
-        // This waits for that delay.
-        browser.sleep( 500 );
-
-        return browser
-               .actions()
-               .mouseMove( _dom.triggerAboutUs )
-               .perform();
-      }
-    );
-
-    Then( 'the mega-menu organism shouldn\'t show content',
-      function( ) {
-
-        return expect( _dom.contentAboutUs.isDisplayed() )
-               .to.eventually
-               .equal( false );
-      }
-    );
-
-    Then( 'the mega-menu organism shouldn\'t show the first link immediately',
-      function( ) {
-
-        return browser
-               .actions()
-               .mouseMove( _dom.triggerPolyCom )
-               .perform()
-               .then( () =>
-                  expect( _dom.contentPolyCom.isDisplayed() )
-                  .to.eventually
-                  .equal( false )
-               );
-      }
-    );
-
-    Then( /the mega-menu organism should show the first link after a delay/,
-      function( ) {
-
-        return browser
-               .actions( )
-               .mouseMove( _dom.triggerPolyCom )
-               .perform()
-               .then( () =>
-
-                  // Wait for delay to show menu
-                  browser.sleep( 500 )
-                  .then( ( ) =>
-                    expect( _dom.contentPolyCom.isDisplayed() )
-                    .to.eventually
-                    .equal( true )
-                  )
-              );
-      }
-    );
-
-    Then( 'should only show second link content', function( ) {
-
-      return browser.wait(
-               EC.not( EC.elementToBeClickable( _dom.contentPolyCom ) ) )
-               .then( () => {
-                 expect( _dom.contentPolyCom.isDisplayed() )
-                 .to.eventually
-                 .equal( false );
-
-                 return expect( _dom.contentAboutUs.isDisplayed() )
-                        .to.eventually
-                        .equal( true );
-               } );
-    } );
-  } else if ( browser.params.windowWidth > breakpointsConfig.bpSM.min &&
-              browser.params.windowWidth < breakpointsConfig.bpSM.max ) {
-
-    Then( 'the mega-menu organism should show menu when clicked', function( ) {
+      // The menu has a built-in delay before it expands.
+      // This waits for that delay.
+      browser.sleep( 500 );
 
       return browser
-             .driver
-             .actions( )
-             .click( _dom.triggerBtn )
+             .actions()
+             .mouseMove( _dom.triggerAboutUs )
+             .perform();
+    }
+  );
+
+  Then( 'the mega-menu organism shouldn\'t show content',
+    function( ) {
+
+      return expect( _dom.contentAboutUs.isDisplayed() )
+             .to.eventually
+             .equal( false );
+    }
+  );
+
+  Then( 'the mega-menu organism shouldn\'t show the first link immediately',
+    function( ) {
+
+      return browser
+             .actions()
+             .mouseMove( _dom.triggerPolyCom )
              .perform()
+             .then( () =>
+                expect( _dom.contentPolyCom.isDisplayed() )
+                .to.eventually
+                .equal( false )
+             );
+    }
+  );
 
+  Then( /the mega-menu organism should show the first link after a delay/,
+    function( ) {
+
+      return browser
+             .actions( )
+             .mouseMove( _dom.triggerPolyCom )
+             .perform()
+             .then( () =>
+
+                // Wait for delay to show menu
+                browser.sleep( 500 )
+                .then( ( ) =>
+                  expect( _dom.contentPolyCom.isDisplayed() )
+                  .to.eventually
+                  .equal( true )
+                )
+            );
+    }
+  );
+
+  Then( 'should only show second link content', function( ) {
+
+    return browser.wait(
+             EC.not( EC.elementToBeClickable( _dom.contentPolyCom ) ) )
              .then( () => {
-               expect( _dom.contentWrapper.isDisplayed() )
-               .to.eventually
-               .equal( true );
-             } );
-    } );
-
-    Then( 'the mega-menu organism should show the PolyCom menu when clicked',
-      function() {
-        browser
-        .driver
-        .actions( )
-        .click( _dom.triggerBtn )
-        .perform( );
-
-        browser.sleep( 500 );
-
-        return browser.driver.actions().click( _dom.triggerPolyCom ).perform()
-               .then( () => {
-                 expect( _dom.contentPolyCom.isDisplayed() )
-                 .to.eventually
-                 .equal( true );
-                 expect( _dom.contentAboutUs.isDisplayed() )
-                 .to.eventually
-                 .equal( false );
-               } );
-      }
-    );
-
-    // This test is failing right now, but should pass
-    // when we fix keyboard tabbing on mobile
-    Then( 'should not shift menus when tabbing',
-      function() {
-        browser.driver.actions().click( _dom.triggerBtn ).perform();
-        browser.driver.actions().sendKeys( protractor.Key.TAB ).perform();
-        browser.driver.actions().sendKeys( protractor.Key.TAB ).perform();
-        browser.driver.actions().sendKeys( protractor.Key.TAB ).perform();
-        browser.driver.actions().sendKeys( protractor.Key.TAB ).perform();
-
-        return expect( _dom.eyebrow.isDisplayed() )
+               expect( _dom.contentPolyCom.isDisplayed() )
                .to.eventually
                .equal( false );
-      }
-    );
-  }
+
+               return expect( _dom.contentAboutUs.isDisplayed() )
+                      .to.eventually
+                      .equal( true );
+             } );
+  } );
+
+  Then( 'the mega-menu organism should show menu when clicked', function( ) {
+
+    return browser
+           .driver
+           .actions( )
+           .click( _dom.triggerBtn )
+           .perform()
+
+           .then( () => {
+             expect( _dom.contentWrapper.isDisplayed() )
+             .to.eventually
+             .equal( true );
+           } );
+  } );
+
+  Then( 'the mega-menu organism should show the PolyCom menu when clicked',
+    function() {
+      browser
+      .driver
+      .actions( )
+      .click( _dom.triggerBtn )
+      .perform( );
+
+      browser.sleep( 500 );
+
+      return browser.driver.actions().click( _dom.triggerPolyCom ).perform()
+             .then( () => {
+               expect( _dom.contentPolyCom.isDisplayed() )
+               .to.eventually
+               .equal( true );
+               expect( _dom.contentAboutUs.isDisplayed() )
+               .to.eventually
+               .equal( false );
+             } );
+    }
+  );
+
+  // This test is failing right now, but should pass
+  // when we fix keyboard tabbing on mobile
+  Then( 'should not shift menus when tabbing',
+    function() {
+      browser.driver.actions().click( _dom.triggerBtn ).perform();
+      browser.driver.actions().sendKeys( protractor.Key.TAB ).perform();
+      browser.driver.actions().sendKeys( protractor.Key.TAB ).perform();
+      browser.driver.actions().sendKeys( protractor.Key.TAB ).perform();
+      browser.driver.actions().sendKeys( protractor.Key.TAB ).perform();
+
+      return expect( _dom.eyebrow.isDisplayed() )
+             .to.eventually
+             .equal( false );
+    }
+  );
 
 } );

--- a/test/browser_tests/cucumber/step_definitions/mega-menu.js
+++ b/test/browser_tests/cucumber/step_definitions/mega-menu.js
@@ -107,7 +107,7 @@ defineSupportCode( function( { Then, When, Before } ) {
                return expect( _dom.contentAboutUs.isDisplayed() )
                       .to.eventually
                       .equal( true );
-           } );
+             } );
   } );
 
   Then( 'the mega-menu organism should show menu when clicked', function( ) {
@@ -148,7 +148,7 @@ defineSupportCode( function( { Then, When, Before } ) {
 
   // This test is failing right now, but should pass
   // when we fix keyboard tabbing on mobile
-  Then( 'should not shift menus when tabbing',
+  Then( 'the mega-menu organism should not shift menus when tabbing',
     function() {
       browser.driver.actions().click( _dom.triggerBtn ).perform();
       browser.driver.actions().sendKeys( protractor.Key.TAB ).perform();

--- a/test/browser_tests/cucumber/step_definitions/multi-select.js
+++ b/test/browser_tests/cucumber/step_definitions/multi-select.js
@@ -1,13 +1,187 @@
 'use strict';
 
+const MultiSelect = require( '../../shared_objects/multi-select.js' );
+const { defineSupportCode } = require( 'cucumber' );
+const chai = require( 'chai' );
+const expect = chai.expect;
+const chaiAsPromised = require( 'chai-as-promised' );
 
-var multiSelect = require( '../../shared_objects/multi-select.js' );
-var { defineSupportCode } = require( 'cucumber' );
+let multiSelect;
 
+chai.use( chaiAsPromised );
 
-defineSupportCode( function( { When } ) {
-  When( 'interacting with search input', function( ) {
+defineSupportCode( function( { Then, When, Before } ) {
 
-    return multiSelect.multiSelectSearch.click();
+  Before( function() {
+    multiSelect = new MultiSelect();
   } );
+
+  When( /I (.*) on the multi-select search input/,
+    function( searchInputAction ) {
+
+      return multiSelect.elements.search[searchInputAction]();
+    }
+  );
+
+  When( /I enter "(.*)" in the search input/,
+    function( searchInputText ) {
+
+      return multiSelect.elements.search.sendKeys( searchInputText );
+    }
+  );
+
+  When( 'I hit the escape button on the search input', function( ) {
+
+    return multiSelect.elements.search.sendKeys( protractor.Key.ESCAPE );
+  } );
+
+  When( /I hit the (.*) arrow on the multi-select/,
+    function( arrowDirection ) {
+      const directionConstant = protractor.Key[arrowDirection.toUpperCase()];
+
+      return multiSelect.elements.search.sendKeys(
+               directionConstant
+             );
+    }
+  );
+
+  When( 'I click on the first choices element',
+    function( ) {
+
+      return multiSelect.getChoiceElements()
+             .first()
+             .click();
+    }
+  );
+
+  When( /I click on the first option in the dropdown(?:\s)?(?:again)?/,
+    function( ) {
+
+      return multiSelect.getDrodownLabelElements()
+             .first()
+             .click();
+    }
+  );
+
+  Then( 'the multi-select should be rendered', function( ) {
+
+    return expect( multiSelect.isRendered() )
+           .to.eventually
+           .equal( true );
+  } );
+
+  Then( 'no tags should be selected', function( ) {
+
+    return expect( multiSelect.areTagSelected() )
+           .to.eventually
+           .equal( false );
+  } );
+
+  Then( /the multi-select dropdown (should|shouldn't) be visible/,
+    function( shouldBeVisible ) {
+      let dropdownIsDisplayed = true;
+
+      if ( shouldBeVisible === 'shouldn\'t' ) {
+        dropdownIsDisplayed = false;
+      }
+
+      return expect( multiSelect.elements.fieldSet.isDisplayed() )
+             .to.eventually
+             .equal( dropdownIsDisplayed );
+    }
+  );
+
+  Then( /the multi-select dropdown (should|shouldn't) display "(.*)"/,
+    function( shouldBeDisplayed, dropdownValue ) {
+      let valueIsDisplayed = true;
+
+      if ( shouldBeDisplayed === 'shouldn\'t' ) {
+        valueIsDisplayed = false;
+      }
+
+      return expect( multiSelect.dropdownHasValue( dropdownValue ) )
+             .to.eventually
+             .equal( valueIsDisplayed );
+    }
+  );
+
+  Then( /the multi-select dropdown length should be (.*)/,
+    function( dropDownLength ) {
+
+      return expect( multiSelect.getDropDownCount() )
+             .to.eventually
+             .equal( Number( dropDownLength ) );
+    }
+  );
+
+  Then( /the (.*) field (should|shouldn't) contain the class (.*)/,
+    function( element, shouldContain, className ) {
+      const multiSelectElement =
+        multiSelect.elements[element].getAttribute( 'class' );
+
+      if ( shouldContain === 'shouldn\'t' ) {
+
+        return expect( multiSelectElement )
+               .to.eventually.not.contain( className );
+      }
+
+      return expect( multiSelectElement )
+             .to.eventually
+             .contain( className );
+    }
+  );
+
+  Then( 'the first option should be highlighted',
+    function( ) {
+      function _getfirstElementText() {
+
+        return multiSelect.getDrodownLabelElements()
+               .first()
+               .getText();
+      }
+
+      function _getActiveElementValue() {
+
+        return browser
+               .driver
+               .switchTo()
+               .activeElement()
+               .getAttribute( 'value' );
+      }
+
+      return Promise.all( [ _getfirstElementText(), _getActiveElementValue() ] )
+             .then( function( [ firstElementText, activeElementValue ] ) {
+
+               return expect( firstElementText )
+                      .to.equal( activeElementValue );
+             } );
+    }
+  );
+
+  Then( 'the choices element should contain the first option',
+    function( ) {
+      const getChoicesInfo = [
+        multiSelect.getDrodownLabelElements().first().getText(),
+        multiSelect.getChoiceElements().first().getText(),
+        multiSelect.getChoiceElements().count()
+      ];
+
+      return Promise.all( getChoicesInfo )
+            .then( function( [ firstElementText, choicesText, choicesCount ] ) {
+              expect( choicesCount ).to.equal( 1 );
+
+              return expect( choicesText ).to.contain( firstElementText );
+            } );
+    }
+  );
+
+  Then( /the choices length should be (.*)/,
+    function( choicesCount ) {
+
+      return expect( multiSelect.getChoiceElementsCount() )
+             .to.eventually
+             .equal( Number( choicesCount ) );
+    }
+  );
+
 } );

--- a/test/browser_tests/cucumber/step_definitions/multi-select.js
+++ b/test/browser_tests/cucumber/step_definitions/multi-select.js
@@ -5,6 +5,7 @@ const { defineSupportCode } = require( 'cucumber' );
 const chai = require( 'chai' );
 const expect = chai.expect;
 const chaiAsPromised = require( 'chai-as-promised' );
+const EC = protractor.ExpectedConditions;
 
 let multiSelect;
 
@@ -19,7 +20,10 @@ defineSupportCode( function( { Then, When, Before } ) {
   When( /I (.*) on the multi-select search input/,
     function( searchInputAction ) {
 
-      return multiSelect.elements.search[searchInputAction]();
+      return browser.wait( EC.visibilityOf( multiSelect.elements.search ) )
+             .then( () => {
+               multiSelect.elements.search[searchInputAction]();
+             } );
     }
   );
 

--- a/test/browser_tests/cucumber/step_definitions/pagination.js
+++ b/test/browser_tests/cucumber/step_definitions/pagination.js
@@ -1,0 +1,36 @@
+'use strict';
+
+const pagination = require( '../../shared_objects/pagination.js' );
+const { defineSupportCode } = require( 'cucumber' );
+const chai = require( 'chai' );
+const expect = chai.expect;
+const chaiAsPromised = require( 'chai-as-promised' );
+
+chai.use( chaiAsPromised );
+
+defineSupportCode( function( { Then, When } ) {
+
+  When( /I click on the (.*) button(?:\s)?(?:again)?/,
+    function( navigationButton ) {
+
+      return pagination[navigationButton + 'Btn'].click();
+    }
+  );
+
+  When( /I enter "(\d)" in the page input field/,
+    function( pageNumber ) {
+
+      return pagination.pageInput.sendKeys( pageNumber );
+    }
+  );
+
+  Then( /the page url should contain "(.*)"/,
+    function( urlComponent ) {
+
+      return expect( browser.getCurrentUrl() )
+             .to.eventually
+             .contain( urlComponent );
+    }
+  );
+
+} );

--- a/test/browser_tests/default-suites.js
+++ b/test/browser_tests/default-suites.js
@@ -15,7 +15,7 @@ var defaultSuites = {
       browserName: 'chrome',
       version:     '',
       platform:    'Windows',
-      maxDuration: 20000
+      maxDuration: 10800
     }
   ],
 

--- a/test/browser_tests/default-suites.js
+++ b/test/browser_tests/default-suites.js
@@ -1,57 +1,67 @@
 'use strict';
 
-var envvars = require('../../config/environment').envvars;
+var envvars = require( '../../config/environment' ).envvars;
 
 var defaultSuites = {
-    // Set default browser suites to test.
-    // These values are passed to the `multiCapabilities` property
-    // of the protractor config object.
-    // See https://docs.saucelabs.com/reference/platforms-configurator/
-    // for configuration values for version and platform.
+  // Set default browser suites to test.
+  // These values are passed to the `multiCapabilities` property
+  // of the protractor config object.
+  // See https://docs.saucelabs.com/reference/platforms-configurator/
+  // for configuration values for version and platform.
 
-    // Essential browsers for running locally.
-    essential: [{
-        browserName: 'chrome',
-        version: '',
-        platform: 'Windows',
-        maxDuration: 10800
-    }],
+  // Essential browsers for running locally.
+  essential: [
+    {
+      browserName: 'chrome',
+      version:     '',
+      platform:    'Windows',
+      maxDuration: 20000
+    }
+  ],
 
-    // Legacy browsers to run in the cloud.
-    legacy: [{
-        browserName: 'internet explorer',
-        version: '8.0',
-        platform: 'Windows XP',
-        maxDuration: 10800
-    }],
+  // Legacy browsers to run in the cloud.
+  legacy: [
+    {
+      browserName: 'internet explorer',
+      version:     '8.0',
+      platform:    'Windows XP',
+      maxDuration: 10800
+    }
+  ],
 
-    // Modern browsers to run in the cloud.
-    modern: [{
-        browserName: 'firefox',
-        version: '',
-        platform: 'Windows 10',
-        maxDuration: 10800
-    }, {
-        browserName: 'internet explorer',
-        version: '',
-        platform: 'Windows 10',
-        maxDuration: 10800
-    }],
+  // Modern browsers to run in the cloud.
+  modern: [
+    {
+      browserName: 'firefox',
+      version:     '',
+      platform:    'Windows 10',
+      maxDuration: 10800
+    },
+    {
+      browserName: 'internet explorer',
+      version:     '',
+      platform:    'Windows 10',
+      maxDuration: 10800
+    }
+  ],
 
-    // Headless browser to run on Travis.
-    headless: [{
-        browserName: 'chrome',
-        chromeOptions: {
-            args: ['--headless', '--disable-gpu', '--window-size=1200x900'],
-            binary: envvars.HEADLESS_CHROME_BINARY
-        },
-        maxDuration: 10800
-    }]
+  // Headless browser to run on Travis.
+  headless: [
+    {
+      browserName: 'chrome',
+      chromeOptions: {
+        args: [ '--headless', '--disable-gpu', '--window-size=1200x900' ],
+        binary: envvars.HEADLESS_CHROME_BINARY
+      },
+      maxDuration: 10800
+    }
+  ]
 };
 
 // Run all browsers together.
 defaultSuites.full = defaultSuites.essential.concat(
-defaultSuites.modern,
-defaultSuites.legacy);
+  defaultSuites.modern,
+  defaultSuites.legacy
+);
 
 module.exports = defaultSuites;

--- a/test/browser_tests/default-suites.js
+++ b/test/browser_tests/default-suites.js
@@ -50,7 +50,7 @@ var defaultSuites = {
     {
       browserName: 'chrome',
       chromeOptions: {
-        args: [ '--headless', '--disable-gpu', '--window-size=1200x900' ],
+        args: [ '--headless', '--disable-gpu' ],
         binary: envvars.HEADLESS_CHROME_BINARY
       },
       maxDuration: 10800

--- a/test/browser_tests/default-suites.js
+++ b/test/browser_tests/default-suites.js
@@ -15,7 +15,7 @@ var defaultSuites = {
       browserName: 'chrome',
       version:     '',
       platform:    'Windows',
-      maxDuration: 10800
+      maxDuration: 20000
     }
   ],
 
@@ -50,8 +50,7 @@ var defaultSuites = {
     {
       browserName: 'chrome',
       chromeOptions: {
-        args: [ '--headless', '--disable-gpu', '--window-size=1200x900' ],
-        binary: envvars.HEADLESS_CHROME_BINARY
+        args: [ '--headless', '--disable-gpu', '--window-size=1200x900' ]
       },
       maxDuration: 10800
     }

--- a/test/browser_tests/default-suites.js
+++ b/test/browser_tests/default-suites.js
@@ -1,66 +1,57 @@
 'use strict';
 
-var envvars = require( '../../config/environment' ).envvars;
+var envvars = require('../../config/environment').envvars;
 
 var defaultSuites = {
-  // Set default browser suites to test.
-  // These values are passed to the `multiCapabilities` property
-  // of the protractor config object.
-  // See https://docs.saucelabs.com/reference/platforms-configurator/
-  // for configuration values for version and platform.
+    // Set default browser suites to test.
+    // These values are passed to the `multiCapabilities` property
+    // of the protractor config object.
+    // See https://docs.saucelabs.com/reference/platforms-configurator/
+    // for configuration values for version and platform.
 
-  // Essential browsers for running locally.
-  essential: [
-    {
-      browserName: 'chrome',
-      version:     '',
-      platform:    'Windows',
-      maxDuration: 20000
-    }
-  ],
+    // Essential browsers for running locally.
+    essential: [{
+        browserName: 'chrome',
+        version: '',
+        platform: 'Windows',
+        maxDuration: 10800
+    }],
 
-  // Legacy browsers to run in the cloud.
-  legacy: [
-    {
-      browserName: 'internet explorer',
-      version:     '8.0',
-      platform:    'Windows XP',
-      maxDuration: 10800
-    }
-  ],
+    // Legacy browsers to run in the cloud.
+    legacy: [{
+        browserName: 'internet explorer',
+        version: '8.0',
+        platform: 'Windows XP',
+        maxDuration: 10800
+    }],
 
-  // Modern browsers to run in the cloud.
-  modern: [
-    {
-      browserName: 'firefox',
-      version:     '',
-      platform:    'Windows 10',
-      maxDuration: 10800
-    },
-    {
-      browserName: 'internet explorer',
-      version:     '',
-      platform:    'Windows 10',
-      maxDuration: 10800
-    }
-  ],
+    // Modern browsers to run in the cloud.
+    modern: [{
+        browserName: 'firefox',
+        version: '',
+        platform: 'Windows 10',
+        maxDuration: 10800
+    }, {
+        browserName: 'internet explorer',
+        version: '',
+        platform: 'Windows 10',
+        maxDuration: 10800
+    }],
 
-  // Headless browser to run on Travis.
-  headless: [
-    {
-      browserName: 'chrome',
-      chromeOptions: {
-        args: [ '--headless', '--disable-gpu', '--window-size=1200x900' ]
-      },
-      maxDuration: 10800
-    }
-  ]
+    // Headless browser to run on Travis.
+    headless: [{
+        browserName: 'chrome',
+        chromeOptions: {
+            args: ['--headless', '--disable-gpu', '--window-size=1200x900'],
+            binary: envvars.HEADLESS_CHROME_BINARY
+        },
+        maxDuration: 10800
+    }]
 };
 
 // Run all browsers together.
 defaultSuites.full = defaultSuites.essential.concat(
-  defaultSuites.modern,
-  defaultSuites.legacy
-);
+defaultSuites.modern,
+defaultSuites.legacy);
 
 module.exports = defaultSuites;

--- a/test/browser_tests/environment-test.js
+++ b/test/browser_tests/environment-test.js
@@ -21,8 +21,20 @@ module.exports = {
 
   // The default window width and height.
   // Can be overridden with the --windowSize=w,h command-line flag.
-  windowWidthPx:  1200,
-  windowHeightPx: 900,
+  WINDOW_SIZES: {
+    DESKTOP: {
+      WIDTH:  1200,
+      HEIGHT: 900
+    },
+    TABLET: {
+      WIDTH:  768,
+      HEIGHT: 1024
+    },
+    MOBILE: {
+      WIDTH:  600,
+      HEIGHT: 740
+    }
+  },
 
   // Default test name, which displays in Sauce Labs and the Terminal.
   testName: 'cfgov-refresh screen test'

--- a/test/browser_tests/page_objects/wagtail-admin-pages-page.js
+++ b/test/browser_tests/page_objects/wagtail-admin-pages-page.js
@@ -106,15 +106,16 @@ class WagtailAdminPages extends BasePage {
   }
 
   publish( ) {
+    dropdownToggle.click();
 
-    return clickWhenReady( [ dropdownToggle, publishButton ] );
+    return publishButton.click();
   }
 
   unpublish( ) {
+    dropdownToggle.click();
+    unpublishButton.click();
 
-    return clickWhenReady(
-      [ dropdownToggle, unpublishButton, confirmUnpublishButton ]
-    );
+    return confirmUnpublishButton.click();
   }
 
 }

--- a/test/browser_tests/shared_objects/multi-select.js
+++ b/test/browser_tests/shared_objects/multi-select.js
@@ -1,25 +1,111 @@
 'use strict';
 
-var _multiSelect =
-  element.all( by.css( '.cf-multi-select' ) ).first();
+var _multiSelect = element.all( by.css( '.cf-multi-select' ) ).first();
 
 function _getMultiSelectElement( selector ) {
   return _multiSelect.element( by.css( selector ) );
 }
 
-var multiSelect = {
-  multiSelect: _multiSelect,
+var elements = {
 
-  multiSelectChoices: _getMultiSelectElement( '.cf-multi-select_choices' ),
+  base:     _multiSelect,
 
-  multiSelectHeader: _getMultiSelectElement( '.cf-multi-select_header' ),
+  choices:  _getMultiSelectElement( '.cf-multi-select_choices' ),
 
-  multiSelectSearch: _getMultiSelectElement( '.cf-multi-select_search' ),
+  header:   _getMultiSelectElement( '.cf-multi-select_header' ),
 
-  multiSelectFieldset: _getMultiSelectElement( '.cf-multi-select_fieldset' ),
+  search:   _getMultiSelectElement( '.cf-multi-select_search' ),
 
-  multiSelectOptions: _getMultiSelectElement( '.cf-multi-select_options' )
+  fieldSet: _getMultiSelectElement( '.cf-multi-select_fieldset' ),
+
+  options:  _getMultiSelectElement( '.cf-multi-select_options' )
 
 };
 
-module.exports = multiSelect;
+class MultiSelect {
+
+  constructor( ) {
+    this.elements = elements;
+    this._selectedTags = [];
+
+    this.addFocusToElement( elements.search );
+  }
+
+  addFocusToElement( element ) {
+
+    function _focus( ) {
+
+      return browser.executeScript(
+               'arguments[0].focus()',
+               this
+            );
+    }
+
+    element.focus = _focus.bind( element );
+  }
+
+  areTagSelected( ) {
+    const tagsSelected = this._selectedTags.length;
+
+    return this.getDisplayedTagElements()
+           .count()
+           .then( selectedTagsCount =>
+             tagsSelected !== 0 || selectedTagsCount !== 0
+           );
+  }
+
+  clearTags( ) {
+    this.selectedTags = [];
+
+    return this.selectedTags;
+  }
+
+  dropdownHasValue( value ) {
+    const selector = `li[data-option="${ value }"].filter-match`;
+    const choicesWithValue = element.all( by.css( selector ) );
+
+    return choicesWithValue
+           .count()
+           .then( selectedTagsCount => selectedTagsCount > 0 );
+  }
+
+  getChoiceElements( ) {
+
+    return element.all(
+             by.css( '.cf-multi-select_choices label' )
+           );
+  }
+
+  getChoiceElementsCount( ) {
+
+    return element.all(
+             by.css( '.cf-multi-select_choices label' )
+           ).count();
+  }
+
+  getDropDownCount( ) {
+
+    return element.all( by.css( '.cf-multi-select .filter-match' ) )
+           .count();
+  }
+
+  getDrodownLabelElements( ) {
+
+    return browser.element.all(
+      by.css( '.cf-multi-select_options li .cf-multi-select_label' )
+    );
+  }
+
+  getDisplayedTagElements( ) {
+
+    return element.all( by.css( '.cf-multi-select_choices li' ) );
+  }
+
+  isRendered( ) {
+
+    return this.elements.base.isDisplayed();
+  }
+
+}
+
+module.exports = MultiSelect;

--- a/test/browser_tests/shared_objects/pagination.js
+++ b/test/browser_tests/shared_objects/pagination.js
@@ -3,22 +3,20 @@ var paginationContent = element( by.css( '.m-pagination' ) );
 
 var pagination = {
 
-  paginationContent:
-    paginationContent,
+  paginationContent: paginationContent,
 
-  paginationForm:
-    paginationContent.element( by.css( 'form' ) ),
+  form: paginationContent.element( by.css( 'form' ) ),
 
-  paginationPrevBtn:
+  previousBtn:
     paginationContent.element( by.css( '.m-pagination_btn-prev' ) ),
 
-  paginationNextBtn:
+  nextBtn:
     paginationContent.element( by.css( '.m-pagination_btn-next' ) ),
 
-  paginationPageInput:
+  pageInput:
     paginationContent.element( by.css( '.m-pagination_current-page' ) ),
 
-  paginationPageBtn:
+  pageBtn:
     paginationContent.element( by.css( '.m-pagination_submit-btn' ) )
 
 };

--- a/test/browser_tests/util/index.js
+++ b/test/browser_tests/util/index.js
@@ -1,0 +1,19 @@
+'use strict';
+
+function shouldShouldnt( should ) {
+
+  return should === 'should' ? true : false;
+}
+
+function toCamelCase( string ) {
+
+  return string.replace( /\s(\w)/g, function ( matches, letter ) {
+
+    return letter.toUpperCase();
+  } );
+}
+
+module.exports = {
+  shouldShouldnt: shouldShouldnt,
+  toCamelCase:    toCamelCase
+};

--- a/test/browser_tests/util/index.js
+++ b/test/browser_tests/util/index.js
@@ -7,7 +7,7 @@ function shouldShouldnt( should ) {
 
 function toCamelCase( string ) {
 
-  return string.replace( /\s(\w)/g, function ( matches, letter ) {
+  return string.replace( /\s(\w)/g, function( matches, letter ) {
 
     return letter.toUpperCase();
   } );

--- a/test/browser_tests/util/index.js
+++ b/test/browser_tests/util/index.js
@@ -1,13 +1,13 @@
 'use strict';
 
-function shouldShouldnt( should ) {
+function shouldShouldnt( value ) {
 
-  return should === 'should' ? true : false;
+  return value === 'should' ? true : false;
 }
 
-function toCamelCase( string ) {
+function toCamelCase( value ) {
 
-  return string.replace( /\s(\w)/g, function( matches, letter ) {
+  return value.replace( /\s(\w)/g, function( matches, letter ) {
 
     return letter.toUpperCase();
   } );

--- a/test/browser_tests/util/index.js
+++ b/test/browser_tests/util/index.js
@@ -1,5 +1,11 @@
 'use strict';
 
+
+/**
+ * Converts (should|shouldn't) to Boolean.
+ * @param {string} value - The string value to convert.
+ * @returns {boolean} True if 'should', otherwise false.
+ */
 function shouldShouldnt( value ) {
 
   return value === 'should' ? true : false;


### PR DESCRIPTION
Converting old acceptance tests to use new Cucumber framework

## Additions

- Added files to convert old integration acceptance tests to use the new format.


## Changes

-  Modified `cfgov/scripts/test_data.py` to create 11 records so that  a pagination molecule would be created on the filterable pages.

- Modified `test/browser_tests/conf.js` to exclude mobile and skip tags.

## Testing

- Run `tox -e acceptance-fast` 

## Screenshots


## Notes

- Currently  not able to test the mobile scenarios.

## Todos

- ~~Still need to pass tags from the command line.~~
- Need the ability to specify window size for headless chrome.

## Checklist

* [ ] PR has an informative and human-readable title
* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated
* [ ] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
