### PR TITLE
remove LEGACY_APP_URLS and related logic and tests

### DIFF
--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -305,20 +305,6 @@ PDFREACTOR_LIB = os.environ.get('PDFREACTOR_LIB', '/opt/PDFreactor/wrappers/pyth
 #LEGACY APPS
 
 STATIC_VERSION = ''
-LEGACY_APP_URLS={'comparisontool':True,
-                 'agreements':True,
-                 'knowledgebase':True,
-                 'selfregistration':True,
-                 'hud_api_replace':True,
-                 'retirement_api':True,
-                 'paying_for_college':True,
-                 'complaint':True,
-                 'complaintdatabase':True,
-                 'ratechecker':True,
-                 'regcore':True,
-                 'regulations':True,
-                 'countylimits':True,
-                 'noticeandcomment':True}
 
 # DJANGO HUD API
 DJANGO_HUD_API_ENDPOINT= os.environ.get('HUD_API_ENDPOINT', 'http://localhost/hud-api-replace/')

--- a/cfgov/transition_utilities/conditional_urls.py
+++ b/cfgov/transition_utilities/conditional_urls.py
@@ -8,8 +8,6 @@ def wagtail_fail_through(request):
 
 
 def include_if_app_enabled(app_name, module_or_name, namespace=None):
-    if (hasattr(settings, 'LEGACY_APP_URLS')
-            and settings.LEGACY_APP_URLS.get(app_name, False)):
-        if app_name in settings.INSTALLED_APPS:
-            return include(module_or_name, namespace=namespace)
+    if app_name in settings.INSTALLED_APPS:
+        return include(module_or_name, namespace=namespace)
     return wagtail_fail_through

--- a/cfgov/transition_utilities/tests/test_conditional_urls.py
+++ b/cfgov/transition_utilities/tests/test_conditional_urls.py
@@ -8,7 +8,6 @@ from transition_utilities.conditional_urls import include_if_app_enabled
 class ConditionalURLTests(TestCase):
 
     @override_settings(
-        LEGACY_APP_URLS={'core': True},
         INSTALLED_APPS=['core'],
     )
     @mock.patch('transition_utilities.conditional_urls.include')
@@ -18,28 +17,6 @@ class ConditionalURLTests(TestCase):
         self.assertEqual(mock_include.call_count, 1)
 
     @override_settings(
-        LEGACY_APP_URLS={'core': False},
-        INSTALLED_APPS=['core'],
-    )
-    @mock.patch('transition_utilities.conditional_urls.wagtail_fail_through')
-    def test_include_if_app_enabled_false_in_legacy_apps(
-            self, mock_wagtail_fail_through):
-        """ Test that fail-through is called if LEGACY_APP_URLS[app] is
-        False """
-        result = include_if_app_enabled('core', None)
-        self.assertEqual(mock_wagtail_fail_through, result)
-
-    @override_settings(LEGACY_APP_URLS={})
-    @mock.patch('transition_utilities.conditional_urls.wagtail_fail_through')
-    def test_include_if_app_enabled_not_in_legacy_apps(
-            self, mock_wagtail_fail_through):
-        """ Test that fail-through is called if LEGACY_APP_URLS[app] doesn't
-        exist """
-        result = include_if_app_enabled('core', None)
-        self.assertEqual(mock_wagtail_fail_through, result)
-
-    @override_settings(
-        LEGACY_APP_URLS={'core': True},
         INSTALLED_APPS=[],
     )
     @mock.patch('transition_utilities.conditional_urls.wagtail_fail_through')


### PR DESCRIPTION
Back in the days when we were transitioning to this new codebase, there was a need for to have some apps that were *enabled* (installed, accessible via Django admin, etc) but didn't have exposed URL's. This need no longer exists, and this feature further complicates the story around both feature flags and optional apps.


## Removals

- LEGACY_APP_URLS and related logic and tests



## Checklist

* [x] PR has an informative and human-readable title
* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [x] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated
* [x] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
