### PR TITLE
Update babel and webpack

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -260,14 +260,14 @@
       "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz"
     },
     "babel-core": {
-      "version": "6.22.1",
-      "from": "babel-core@6.22.1",
-      "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.22.1.tgz"
+      "version": "6.25.0",
+      "from": "babel-core@6.25.0",
+      "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.25.0.tgz"
     },
     "babel-generator": {
-      "version": "6.24.1",
-      "from": "babel-generator@>=6.22.0 <7.0.0",
-      "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.24.1.tgz"
+      "version": "6.25.0",
+      "from": "babel-generator@>=6.25.0 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.25.0.tgz"
     },
     "babel-helper-bindify-decorators": {
       "version": "6.24.1",
@@ -336,17 +336,17 @@
     },
     "babel-helpers": {
       "version": "6.24.1",
-      "from": "babel-helpers@>=6.22.0 <7.0.0",
+      "from": "babel-helpers@>=6.24.1 <7.0.0",
       "resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz"
     },
     "babel-loader": {
-      "version": "6.2.10",
-      "from": "babel-loader@6.2.10",
-      "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-6.2.10.tgz"
+      "version": "7.0.0",
+      "from": "babel-loader@7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-7.0.0.tgz"
     },
     "babel-messages": {
       "version": "6.23.0",
-      "from": "babel-messages@>=6.22.0 <7.0.0",
+      "from": "babel-messages@>=6.23.0 <7.0.0",
       "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz"
     },
     "babel-plugin-check-es2015-constants": {
@@ -406,12 +406,12 @@
     },
     "babel-plugin-transform-class-properties": {
       "version": "6.24.1",
-      "from": "babel-plugin-transform-class-properties@>=6.22.0 <7.0.0",
+      "from": "babel-plugin-transform-class-properties@>=6.24.1 <7.0.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-class-properties/-/babel-plugin-transform-class-properties-6.24.1.tgz"
     },
     "babel-plugin-transform-decorators": {
       "version": "6.24.1",
-      "from": "babel-plugin-transform-decorators@>=6.22.0 <7.0.0",
+      "from": "babel-plugin-transform-decorators@>=6.24.1 <7.0.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-decorators/-/babel-plugin-transform-decorators-6.24.1.tgz"
     },
     "babel-plugin-transform-es2015-arrow-functions": {
@@ -426,17 +426,17 @@
     },
     "babel-plugin-transform-es2015-block-scoping": {
       "version": "6.24.1",
-      "from": "babel-plugin-transform-es2015-block-scoping@>=6.22.0 <7.0.0",
+      "from": "babel-plugin-transform-es2015-block-scoping@>=6.24.1 <7.0.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.24.1.tgz"
     },
     "babel-plugin-transform-es2015-classes": {
       "version": "6.24.1",
-      "from": "babel-plugin-transform-es2015-classes@>=6.22.0 <7.0.0",
+      "from": "babel-plugin-transform-es2015-classes@>=6.24.1 <7.0.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz"
     },
     "babel-plugin-transform-es2015-computed-properties": {
       "version": "6.24.1",
-      "from": "babel-plugin-transform-es2015-computed-properties@>=6.22.0 <7.0.0",
+      "from": "babel-plugin-transform-es2015-computed-properties@>=6.24.1 <7.0.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz"
     },
     "babel-plugin-transform-es2015-destructuring": {
@@ -446,7 +446,7 @@
     },
     "babel-plugin-transform-es2015-duplicate-keys": {
       "version": "6.24.1",
-      "from": "babel-plugin-transform-es2015-duplicate-keys@>=6.22.0 <7.0.0",
+      "from": "babel-plugin-transform-es2015-duplicate-keys@>=6.24.1 <7.0.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.24.1.tgz"
     },
     "babel-plugin-transform-es2015-for-of": {
@@ -456,7 +456,7 @@
     },
     "babel-plugin-transform-es2015-function-name": {
       "version": "6.24.1",
-      "from": "babel-plugin-transform-es2015-function-name@>=6.22.0 <7.0.0",
+      "from": "babel-plugin-transform-es2015-function-name@>=6.24.1 <7.0.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz"
     },
     "babel-plugin-transform-es2015-literals": {
@@ -466,37 +466,37 @@
     },
     "babel-plugin-transform-es2015-modules-amd": {
       "version": "6.24.1",
-      "from": "babel-plugin-transform-es2015-modules-amd@>=6.22.0 <7.0.0",
+      "from": "babel-plugin-transform-es2015-modules-amd@>=6.24.1 <7.0.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.24.1.tgz"
     },
     "babel-plugin-transform-es2015-modules-commonjs": {
       "version": "6.24.1",
-      "from": "babel-plugin-transform-es2015-modules-commonjs@>=6.22.0 <7.0.0",
+      "from": "babel-plugin-transform-es2015-modules-commonjs@>=6.24.1 <7.0.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.24.1.tgz"
     },
     "babel-plugin-transform-es2015-modules-systemjs": {
       "version": "6.24.1",
-      "from": "babel-plugin-transform-es2015-modules-systemjs@>=6.22.0 <7.0.0",
+      "from": "babel-plugin-transform-es2015-modules-systemjs@>=6.24.1 <7.0.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.24.1.tgz"
     },
     "babel-plugin-transform-es2015-modules-umd": {
       "version": "6.24.1",
-      "from": "babel-plugin-transform-es2015-modules-umd@>=6.22.0 <7.0.0",
+      "from": "babel-plugin-transform-es2015-modules-umd@>=6.24.1 <7.0.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.24.1.tgz"
     },
     "babel-plugin-transform-es2015-object-super": {
       "version": "6.24.1",
-      "from": "babel-plugin-transform-es2015-object-super@>=6.22.0 <7.0.0",
+      "from": "babel-plugin-transform-es2015-object-super@>=6.24.1 <7.0.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.24.1.tgz"
     },
     "babel-plugin-transform-es2015-parameters": {
       "version": "6.24.1",
-      "from": "babel-plugin-transform-es2015-parameters@>=6.22.0 <7.0.0",
+      "from": "babel-plugin-transform-es2015-parameters@>=6.24.1 <7.0.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz"
     },
     "babel-plugin-transform-es2015-shorthand-properties": {
       "version": "6.24.1",
-      "from": "babel-plugin-transform-es2015-shorthand-properties@>=6.22.0 <7.0.0",
+      "from": "babel-plugin-transform-es2015-shorthand-properties@>=6.24.1 <7.0.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz"
     },
     "babel-plugin-transform-es2015-spread": {
@@ -506,7 +506,7 @@
     },
     "babel-plugin-transform-es2015-sticky-regex": {
       "version": "6.24.1",
-      "from": "babel-plugin-transform-es2015-sticky-regex@>=6.22.0 <7.0.0",
+      "from": "babel-plugin-transform-es2015-sticky-regex@>=6.24.1 <7.0.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz"
     },
     "babel-plugin-transform-es2015-template-literals": {
@@ -521,7 +521,7 @@
     },
     "babel-plugin-transform-es2015-unicode-regex": {
       "version": "6.24.1",
-      "from": "babel-plugin-transform-es2015-unicode-regex@>=6.22.0 <7.0.0",
+      "from": "babel-plugin-transform-es2015-unicode-regex@>=6.24.1 <7.0.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz"
     },
     "babel-plugin-transform-exponentiation-operator": {
@@ -536,7 +536,7 @@
     },
     "babel-plugin-transform-regenerator": {
       "version": "6.24.1",
-      "from": "babel-plugin-transform-regenerator@>=6.22.0 <7.0.0",
+      "from": "babel-plugin-transform-regenerator@>=6.24.1 <7.0.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.24.1.tgz"
     },
     "babel-plugin-transform-strict-mode": {
@@ -545,31 +545,24 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz"
     },
     "babel-preset-es2015": {
-      "version": "6.22.0",
-      "from": "babel-preset-es2015@6.22.0",
-      "resolved": "https://registry.npmjs.org/babel-preset-es2015/-/babel-preset-es2015-6.22.0.tgz"
+      "version": "6.24.1",
+      "from": "babel-preset-es2015@6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-preset-es2015/-/babel-preset-es2015-6.24.1.tgz"
     },
     "babel-preset-stage-2": {
-      "version": "6.22.0",
-      "from": "babel-preset-stage-2@6.22.0",
-      "resolved": "https://registry.npmjs.org/babel-preset-stage-2/-/babel-preset-stage-2-6.22.0.tgz"
+      "version": "6.24.1",
+      "from": "babel-preset-stage-2@6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-preset-stage-2/-/babel-preset-stage-2-6.24.1.tgz"
     },
     "babel-preset-stage-3": {
       "version": "6.24.1",
-      "from": "babel-preset-stage-3@>=6.22.0 <7.0.0",
+      "from": "babel-preset-stage-3@>=6.24.1 <7.0.0",
       "resolved": "https://registry.npmjs.org/babel-preset-stage-3/-/babel-preset-stage-3-6.24.1.tgz"
     },
     "babel-register": {
       "version": "6.24.1",
-      "from": "babel-register@>=6.22.0 <7.0.0",
-      "resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.24.1.tgz",
-      "dependencies": {
-        "babel-core": {
-          "version": "6.24.1",
-          "from": "babel-core@>=6.24.1 <7.0.0",
-          "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.24.1.tgz"
-        }
-      }
+      "from": "babel-register@>=6.24.1 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.24.1.tgz"
     },
     "babel-runtime": {
       "version": "6.23.0",
@@ -577,24 +570,24 @@
       "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz"
     },
     "babel-template": {
-      "version": "6.24.1",
-      "from": "babel-template@>=6.22.0 <7.0.0",
-      "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.24.1.tgz"
+      "version": "6.25.0",
+      "from": "babel-template@>=6.25.0 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.25.0.tgz"
     },
     "babel-traverse": {
-      "version": "6.24.1",
-      "from": "babel-traverse@>=6.22.1 <7.0.0",
-      "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.24.1.tgz"
+      "version": "6.25.0",
+      "from": "babel-traverse@>=6.25.0 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.25.0.tgz"
     },
     "babel-types": {
-      "version": "6.24.1",
-      "from": "babel-types@>=6.22.0 <7.0.0",
-      "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.24.1.tgz"
+      "version": "6.25.0",
+      "from": "babel-types@>=6.25.0 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz"
     },
     "babylon": {
-      "version": "6.17.2",
-      "from": "babylon@>=6.11.0 <7.0.0",
-      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.17.2.tgz"
+      "version": "6.17.3",
+      "from": "babylon@>=6.17.2 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.17.3.tgz"
     },
     "backo2": {
       "version": "1.0.2",
@@ -902,9 +895,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30000679",
+      "version": "1.0.30000680",
       "from": "caniuse-lite@>=1.0.30000670 <2.0.0",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000679.tgz"
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000680.tgz"
     },
     "capital-framework": {
       "version": "3.6.1",
@@ -954,9 +947,9 @@
       "resolved": "https://registry.npmjs.org/cf-icons/-/cf-icons-4.1.0.tgz"
     },
     "cf-layout": {
-      "version": "4.2.0",
+      "version": "4.3.0",
       "from": "cf-layout@>=4.0.1 <5.0.0",
-      "resolved": "https://registry.npmjs.org/cf-layout/-/cf-layout-4.2.0.tgz"
+      "resolved": "https://registry.npmjs.org/cf-layout/-/cf-layout-4.3.0.tgz"
     },
     "cf-typography": {
       "version": "4.1.0",
@@ -1849,9 +1842,9 @@
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz"
     },
     "electron-to-chromium": {
-      "version": "1.3.13",
+      "version": "1.3.14",
       "from": "electron-to-chromium@>=1.3.11 <2.0.0",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.13.tgz"
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.14.tgz"
     },
     "elliptic": {
       "version": "6.4.0",
@@ -3869,9 +3862,9 @@
       "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-2.3.0.tgz"
     },
     "loader-utils": {
-      "version": "0.2.17",
-      "from": "loader-utils@>=0.2.11 <0.3.0",
-      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz"
+      "version": "1.1.0",
+      "from": "loader-utils@>=1.0.2 <2.0.0",
+      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz"
     },
     "localtunnel": {
       "version": "1.8.2",
@@ -4867,9 +4860,16 @@
       "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.6.tgz"
     },
     "randombytes": {
-      "version": "2.0.4",
+      "version": "2.0.5",
       "from": "randombytes@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.4.tgz"
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.5.tgz",
+      "dependencies": {
+        "safe-buffer": {
+          "version": "5.1.0",
+          "from": "safe-buffer@>=5.1.0 <6.0.0",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.0.tgz"
+        }
+      }
     },
     "range-parser": {
       "version": "1.2.0",
@@ -5396,9 +5396,9 @@
       "resolved": "https://registry.npmjs.org/sort-on/-/sort-on-1.3.0.tgz"
     },
     "source-list-map": {
-      "version": "0.1.8",
-      "from": "source-list-map@>=0.1.7 <0.2.0",
-      "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-0.1.8.tgz"
+      "version": "1.1.2",
+      "from": "source-list-map@>=1.1.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-1.1.2.tgz"
     },
     "source-map": {
       "version": "0.5.6",
@@ -5446,9 +5446,9 @@
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz"
     },
     "sshpk": {
-      "version": "1.13.0",
+      "version": "1.13.1",
       "from": "sshpk@>=1.7.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.0.tgz",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
       "dependencies": {
         "assert-plus": {
           "version": "1.0.0",
@@ -6032,7 +6032,7 @@
     },
     "watchpack": {
       "version": "1.3.1",
-      "from": "watchpack@>=1.2.0 <2.0.0",
+      "from": "watchpack@>=1.3.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.3.1.tgz",
       "dependencies": {
         "async": {
@@ -6048,19 +6048,24 @@
       "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz"
     },
     "webpack": {
-      "version": "2.2.1",
-      "from": "webpack@2.2.1",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-2.2.1.tgz",
+      "version": "2.6.1",
+      "from": "webpack@2.6.1",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-2.6.1.tgz",
       "dependencies": {
         "acorn": {
-          "version": "4.0.13",
-          "from": "acorn@>=4.0.4 <5.0.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz"
+          "version": "5.0.3",
+          "from": "acorn@>=5.0.0 <6.0.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.0.3.tgz"
         },
         "async": {
           "version": "2.4.1",
           "from": "async@>=2.1.2 <3.0.0",
           "resolved": "https://registry.npmjs.org/async/-/async-2.4.1.tgz"
+        },
+        "loader-utils": {
+          "version": "0.2.17",
+          "from": "loader-utils@>=0.2.16 <0.3.0",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz"
         },
         "supports-color": {
           "version": "3.2.3",
@@ -6082,9 +6087,9 @@
       }
     },
     "webpack-sources": {
-      "version": "0.1.5",
-      "from": "webpack-sources@>=0.1.4 <0.2.0",
-      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-0.1.5.tgz"
+      "version": "0.2.3",
+      "from": "webpack-sources@>=0.2.3 <0.3.0",
+      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-0.2.3.tgz"
     },
     "webpack-stream": {
       "version": "3.2.0",
@@ -6123,6 +6128,11 @@
           "from": "interpret@>=0.6.4 <0.7.0",
           "resolved": "https://registry.npmjs.org/interpret/-/interpret-0.6.6.tgz"
         },
+        "loader-utils": {
+          "version": "0.2.17",
+          "from": "loader-utils@>=0.2.11 <0.3.0",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz"
+        },
         "memory-fs": {
           "version": "0.3.0",
           "from": "memory-fs@>=0.3.0 <0.4.0",
@@ -6142,6 +6152,11 @@
           "version": "2.2.6",
           "from": "sha.js@2.2.6",
           "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.2.6.tgz"
+        },
+        "source-list-map": {
+          "version": "0.1.8",
+          "from": "source-list-map@>=0.1.7 <0.2.0",
+          "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-0.1.8.tgz"
         },
         "string_decoder": {
           "version": "0.10.31",

--- a/package.json
+++ b/package.json
@@ -16,10 +16,10 @@
     "node": ">=5.5.0"
   },
   "dependencies": {
-    "babel-core": "6.22.1",
-    "babel-loader": "6.2.10",
-    "babel-preset-es2015": "6.22.0",
-    "babel-preset-stage-2": "6.22.0",
+    "babel-core": "6.25.0",
+    "babel-loader": "7.0.0",
+    "babel-preset-es2015": "6.24.1",
+    "babel-preset-stage-2": "6.24.1",
     "banner-footer-webpack-plugin": "git://github.com/dtothefp/banner-footer-webpack-plugin.git",
     "browser-sync": "2.18.7",
     "capital-framework": "3.6.1",
@@ -53,7 +53,7 @@
     "psi": "3.0.0",
     "require-dir": "0.3.1",
     "ustream-embedapi": "1.0.0",
-    "webpack": "2.2.1",
+    "webpack": "2.6.1",
     "webpack-stream": "3.2.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Prepares dependencies for babel-core@7.

## Changes

- Update `babel-core` from `6.22.1` to `6.25.0`, which includes backported issues from babel-core@7.
- Update `babel-preset-es2015` from `6.22.0` to `6.24.1`.
- Update `babel-preset-stage-2` from `6.22.0` to `6.24.1`.
- Update `babel-loader` from `6.2.10` to `7.0.0`, which drops support for older node and webpack.
- Update `webpack` from `2.2.1` to `2.6.1`, which includes bugfixes.

## Testing

1. Throw out `node_modules`
2. Run `./frontend.sh`
3. Site should build fine.
