### PR TITLE
Run Python tests in "fast" mode on Travis

### DIFF
--- a/run_travis.sh
+++ b/run_travis.sh
@@ -8,7 +8,7 @@ if [ "$RUNTEST" == "frontend" ]; then
     gulp "test:unit"
     gulp "test:coveralls"
 elif [ "$RUNTEST" == "backend" ]; then
-    tox
+    tox -e fast
     flake8
     coveralls
 elif [ "$RUNTEST" == "acceptance" ]; then


### PR DESCRIPTION
This commit modifies how Travis runs the Python unit tests, using `tox -e fast` instead of just `tox`. This skips most Django migrations (see [`cfgov.settings.test_nomigrations`](https://github.com/cfpb/cfgov-refresh/blob/master/cfgov/cfgov/settings/test_nomigrations.py)) which speeds up the tests
considerably.

Testing with full migrations has been added to the build/deploy pipeline as a replacement for this testing on Travis.

## Changes

- Travis runs `tox -e fast` instead of just `tox`.

## Testing

1. See Travis build!

## Checklist

* [X] PR has an informative and human-readable title
* [X] Changes are limited to a single goal (no scope creep)
* [X] Code can be automatically merged (no conflicts)
* [X] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [X] Passes all existing automated tests
* [X] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
