### PR TITLE
Prep for ask_cfpb deployment

### DIFF
--- a/cfgov/ask_cfpb/models/django.py
+++ b/cfgov/ask_cfpb/models/django.py
@@ -420,10 +420,11 @@ class Answer(models.Model):
             get_feedback_stream_value(_page),
             is_lazy=True)
         _page.save_revision(user=self.last_user)
-        base_page.refresh_from_db()
-        base_page.has_unpublished_changes = True
-        base_page.save()
-        return base_page
+        # _page.save()
+        # base_page.refresh_from_db()
+        # base_page.has_unpublished_changes = True
+        # base_page.save()
+        return _page
 
     def create_or_update_pages(self):
         counter = 0

--- a/cfgov/ask_cfpb/scripts/migrate_knowledgebase.py
+++ b/cfgov/ask_cfpb/scripts/migrate_knowledgebase.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
+import datetime
+import pytz
 import re
 import sys
 import time
@@ -22,6 +24,10 @@ from ask_cfpb.models import (
 from ask_cfpb.models import Audience as ASK_audience
 from v1.util.migrations import get_or_create_page
 
+TZ = pytz.timezone('US/Eastern')
+
+# Go live is 11 a.m. Wednesday, June 14, 2017
+GO_LIVE_AT = datetime.datetime(2017, 6, 14, 11, 0, tzinfo=TZ)
 
 logging.basicConfig(level=logging.WARNING)
 logging.disable(logging.INFO)
@@ -144,6 +150,18 @@ def fix_tips(answer_text):
     return clean2
 
 
+# PAGE CREATION
+
+def prep_page(page, go_live_date=False):
+    """Set the go-live date, create a revision, save page, publish revision"""
+    page.has_unpublished_changes = True
+    if go_live_date:
+        page.go_live_at = GO_LIVE_AT
+    revision = page.save_revision()
+    page.save()
+    revision.publish()
+
+
 def get_or_create_landing_pages():
     """
     Create Spanish and English landing pages.
@@ -183,16 +201,13 @@ def get_or_create_landing_pages():
             _map['slug'],
             _map['parent'],
             language=language)
-        landing_page.has_unpublished_changes = True
         if _map['hero']:
             stream_block = landing_page.header.stream_block
             landing_page.header = StreamValue(
                 stream_block,
                 _map['hero'],
                 is_lazy=True)
-        revision = landing_page.save_revision()
-        landing_page.save()
-        revision.publish()
+        prep_page(landing_page)
         time.sleep(1)
         counter += 1
 
@@ -232,10 +247,7 @@ def get_or_create_search_results_pages():
             _map['parent'])
         if _map['language']:
             results_page.language = _map['language']
-        results_page.has_unpublished_changes = True
-        revision = results_page.save_revision()
-        results_page.save()
-        revision.publish()
+        prep_page(results_page)
         time.sleep(1)
         counter += 1
     print("Created {} search results pages".format(counter))
@@ -266,10 +278,7 @@ def get_or_create_category_pages():
                 parent,
                 language=language,
                 ask_category=cat)
-            cat_page.has_unpublished_changes = True
-            revision = cat_page.save_revision()
-            cat_page.save()
-            revision.publish()
+            prep_page(cat_page)
             time.sleep(1)
             counter += 1
     print("Created {} category pages".format(counter))
@@ -289,10 +298,7 @@ def get_or_create_audience_pages():
             parent,
             language='en',
             ask_audience=audience)
-        audience_page.has_unpublished_changes = True
-        revision = audience_page.save_revision()
-        audience_page.save()
-        revision.publish()
+        prep_page(audience_page)
         time.sleep(1)
         counter += 1
     print("Created {} audience pages".format(counter))
@@ -323,7 +329,9 @@ def create_answer_pages(queryset):
                         count_es += 1
                         sys.stdout.write('+')
                         sys.stdout.flush()
-                    revision = _page.get_latest_revision()
+                    _page.go_live_at = GO_LIVE_AT
+                    revision = _page.save_revision(
+                        approved_go_live_at=GO_LIVE_AT)
                     revision.publish()
     else:
         print("No Answer objects found in queryset.")
@@ -336,6 +344,8 @@ def create_pages():
     print("Creating Answer pages: . = English, + = Spanish")
     create_answer_pages(Answer.objects.all())
 
+
+# ANSWER AND METADATA CREATION
 
 def migrate_categories():
     """Move parent QuestionCategories into the new Category model"""
@@ -460,8 +470,10 @@ def migrate_audiences():
                 ASK_audience.objects.get(id=audience.id))
             audience_relation_count += 1
     print("Migrated {} Audience objects\n"
+          "Found {} already created\n"
           "Created {} Audience links".format(
               audiences_created,
+              Audience.objects.count(),
               audience_relation_count))
 
 

--- a/cfgov/ask_cfpb/scripts/publish_ask_pages.py
+++ b/cfgov/ask_cfpb/scripts/publish_ask_pages.py
@@ -1,0 +1,46 @@
+from __future__ import unicode_literals
+import datetime
+import logging
+import pytz
+import sys
+
+from django.utils import timezone
+
+from ask_cfpb.models import (
+    AnswerPage,
+    AnswerAudiencePage,
+    AnswerCategoryPage,
+    AnswerLandingPage,
+    AnswerResultsPage,
+    TagResultsPage)
+
+logger = logging.getLogger('wagtail.core')
+logger.setLevel(logging.ERROR)
+TZ = pytz.timezone('US/Eastern')
+AWARE_NOW = timezone.now().astimezone(TZ)
+YESTERDAY = AWARE_NOW - datetime.timedelta(days=1)
+
+
+def publish_ask_pages():
+    print("Setting page go_live_at dates to yesterady")
+    count = 0
+    for cls in [AnswerPage,
+                AnswerAudiencePage,
+                AnswerCategoryPage,
+                AnswerLandingPage,
+                AnswerResultsPage,
+                TagResultsPage]:
+        for page in cls.objects.all():
+            count += 1
+            page.go_live_at = YESTERDAY
+            revision = page.save_revision(approved_go_live_at=YESTERDAY)
+            revision.publish()
+            sys.stdout.write('.')
+            sys.stdout.flush()
+
+    print('\nBackdated go_live_at dates '
+          'and published {} pages\n'.format(count))
+
+
+def run():
+    publish_ask_pages()

--- a/cfgov/ask_cfpb/wagtail_hooks.py
+++ b/cfgov/ask_cfpb/wagtail_hooks.py
@@ -125,8 +125,7 @@ def whitelister_element_rules():
         'aside': attribute_rule({'class': True}),
     }
 
-if settings.DEPLOY_ENVIRONMENT == 'build':
-    hooks.register('insert_editor_js', editor_js)
-    hooks.register('insert_editor_css', editor_css)
-    hooks.register(
-        'construct_whitelister_element_rules', whitelister_element_rules)
+hooks.register('insert_editor_js', editor_js)
+hooks.register('insert_editor_css', editor_css)
+hooks.register(
+    'construct_whitelister_element_rules', whitelister_element_rules)

--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -56,7 +56,7 @@ INSTALLED_APPS = (
     'wagtailsharing',
     'flags',
     'haystack',
-
+    'ask_cfpb',
     'overextends',
     'django.contrib.admin',
     'django.contrib.auth',
@@ -77,9 +77,6 @@ INSTALLED_APPS = (
     'jobmanager',
     'ccdb5'
 )
-
-if DEPLOY_ENVIRONMENT == 'build':
-    INSTALLED_APPS += ('ask_cfpb',)
 
 OPTIONAL_APPS = [
     {'import': 'noticeandcomment', 'apps': ('noticeandcomment',)},
@@ -578,9 +575,7 @@ FLAGS = {
 
     # Migration of Ask CFPB to Wagtail
     # When enabled, Ask CFPB is served from Wagtail
-    'WAGTAIL_ASK_CFPB': {
-        'boolean': True if DEPLOY_ENVIRONMENT in ['build'] else False
-    },
+    'WAGTAIL_ASK_CFPB': {},
 
     # The next version of the public consumer complaint database
     'CCDB5_RELEASE': {},

--- a/cfgov/cfgov/urls.py
+++ b/cfgov/cfgov/urls.py
@@ -417,7 +417,9 @@ if settings.DEPLOY_ENVIRONMENT not in ['build', 'beta']:
     ]
     urlpatterns += kb_patterns
 
-
+# The redirects in ask_patterns (below) won't be exposed until the
+# knowledgebase URLs in kb_patters (above) are turned off, because the kb URLs
+# will serve the requests before they reach ask_patterns.
 ask_patterns = [
     url(r'^askcfpb/$',
      RedirectView.as_view(

--- a/cfgov/cfgov/urls.py
+++ b/cfgov/cfgov/urls.py
@@ -406,7 +406,7 @@ if settings.DEBUG:
     except ImportError:
         pass
 
-if settings.DEPLOY_ENVIRONMENT != 'build':
+if settings.DEPLOY_ENVIRONMENT not in ['build', 'beta']:
     kb_patterns = [
         url(r'^(?i)askcfpb/',
             include_if_app_enabled(
@@ -418,35 +418,54 @@ if settings.DEPLOY_ENVIRONMENT != 'build':
     urlpatterns += kb_patterns
 
 
-if settings.DEPLOY_ENVIRONMENT == 'build':
-    ask_patterns = [
-        url(r'^(?i)ask-cfpb/([-\w]{1,244})-(en)-(\d{1,6})/?$',
-            view_answer,
-            name='ask-english-answer'),
-        url(r'^es/obtener-respuestas/([-\w]{1,244})-(es)-(\d{1,6})/?$',
-            view_answer,
-            name='ask-spanish-answer'),
-        url(r'^es/obtener-respuestas/([-\w]{1,244})-(es)-(\d{1,6})/imprimir/?$',  # noqa: E501
-            print_answer,
-            name='ask-spanish-print-answer'),
-        url(r'^(?i)ask-cfpb/search/$',
-            ask_search,
-            name='ask-search-en'),
-        url(r'^(?i)ask-cfpb/search/(?P<as_json>json)/$',
-            ask_search,
-            name='ask-search-en-json'),
-        url(r'^(?P<language>es)/obtener-respuestas/buscar/$',
-            ask_search,
-            name='ask-search-es'),
-        url(r'^(?P<language>es)/obtener-respuestas/buscar/(?P<as_json>json)/$',
-            ask_search,
-            name='ask-search-es-json'),
-        url(r'^(?i)ask-cfpb/api/autocomplete/$',
-            ask_autocomplete, name='ask-autocomplete-en'),
-        url(r'^(?P<language>es)/obtener-respuestas/api/autocomplete/$',
-            ask_autocomplete, name='ask-autocomplete-es'),
-    ]
-    urlpatterns += ask_patterns
+ask_patterns = [
+    url(r'^askcfpb/$',
+     RedirectView.as_view(
+         url='/ask-cfpb/',
+         permanent=True)),
+    url(r'^askcfpb/(?P<ask_id>\d+)/(.*)$',
+         RedirectView.as_view(
+             url='/ask-cfpb/slug-en-%(ask_id)s',
+             permanent=True)),
+    url(r'^askcfpb/search/\?selected_facets=category_exact:(?P<category>[^&]+)',  # noqa: E501
+         RedirectView.as_view(
+             url='/ask-cfpb/category-%(category)s',
+             permanent=True)),
+    url(r'^es/obtener-respuestas/c/(.+)/(?P<ask_id>\d+)/(.+)\.html$',
+         RedirectView.as_view(
+             url='/es/obtener-respuestas/slug-es-%(ask_id)s',
+             permanent=True)),
+    url(r'es/obtener-respuestas/buscar\?selected_facets=category_exact:(?P<categoria>[^&]+)',  # noqa: E501
+        RedirectView.as_view(
+            url='/es/obtener-respuestas/categoria-%(categoria)s',
+             permanent=True)),
+    url(r'^(?i)ask-cfpb/([-\w]{1,244})-(en)-(\d{1,6})/?$',
+        view_answer,
+        name='ask-english-answer'),
+    url(r'^es/obtener-respuestas/([-\w]{1,244})-(es)-(\d{1,6})/?$',
+        view_answer,
+        name='ask-spanish-answer'),
+    url(r'^es/obtener-respuestas/([-\w]{1,244})-(es)-(\d{1,6})/imprimir/?$',  # noqa: E501
+        print_answer,
+        name='ask-spanish-print-answer'),
+    url(r'^(?i)ask-cfpb/search/$',
+        ask_search,
+        name='ask-search-en'),
+    url(r'^(?i)ask-cfpb/search/(?P<as_json>json)/$',
+        ask_search,
+        name='ask-search-en-json'),
+    url(r'^(?P<language>es)/obtener-respuestas/buscar/$',
+        ask_search,
+        name='ask-search-es'),
+    url(r'^(?P<language>es)/obtener-respuestas/buscar/(?P<as_json>json)/$',
+        ask_search,
+        name='ask-search-es-json'),
+    url(r'^(?i)ask-cfpb/api/autocomplete/$',
+        ask_autocomplete, name='ask-autocomplete-en'),
+    url(r'^(?P<language>es)/obtener-respuestas/api/autocomplete/$',
+        ask_autocomplete, name='ask-autocomplete-es'),
+]
+urlpatterns += ask_patterns
 
 
 # Catch remaining URL patterns that did not match a route thus far.

--- a/cfgov/core/tests/test_views.py
+++ b/cfgov/core/tests/test_views.py
@@ -1,294 +1,213 @@
+from __future__ import unicode_literals
+
 import json
-from urllib import urlencode
+import mock
 
-import django
-from django.core.urlresolvers import reverse
-from django.http import QueryDict
-from django.test import RequestFactory, TestCase
-from mock import Mock, call, patch
-from requests_toolbelt.multipart.encoder import MultipartEncoder
+from model_mommy import mommy
 
-from core.views import govdelivery_subscribe, regsgov_comment, submit_comment
+from django.apps import apps
+from django.core.urlresolvers import reverse, NoReverseMatch
+from django.http import HttpRequest
+import django.test
+from django.utils import timezone
+from wagtail.wagtailcore.models import Site
 
-django.setup()
+from ask_cfpb.models import (
+    AnswerResultsPage, ENGLISH_PARENT_SLUG, SPANISH_PARENT_SLUG)
+from ask_cfpb.views import annotate_links
+from v1.util.migrations import get_or_create_page, get_free_path
+
+now = timezone.now()
 
 
-class GovDeliverySubscribeTest(TestCase):
+class AnswerViewTestCase(django.test.TestCase):
+
     def setUp(self):
-        self.factory = RequestFactory()
+        from v1.models import HomePage
+        self.ROOT_PAGE = HomePage.objects.get(slug='cfgov')
+        self.english_parent_page = get_or_create_page(
+            apps,
+            'ask_cfpb',
+            'AnswerLandingPage',
+            'Ask CFPB',
+            ENGLISH_PARENT_SLUG,
+            self.ROOT_PAGE,
+            language='en',
+            live=True)
+        self.spanish_parent_page = get_or_create_page(
+            apps,
+            'ask_cfpb',
+            'AnswerLandingPage',
+            'Obtener respuestas',
+            SPANISH_PARENT_SLUG,
+            self.ROOT_PAGE,
+            language='es',
+            live=True)
 
-    def post(self, post, ajax=False):
-        kwargs = {'HTTP_X_REQUESTED_WITH': 'XMLHttpRequest'} if ajax else {}
-        request = self.factory.post(reverse('govdelivery'), post, **kwargs)
-        return govdelivery_subscribe(request)
+    def create_answer_results_page(self, **kwargs):
+        kwargs.setdefault(
+            'path', get_free_path(apps, self.english_parent_page))
+        kwargs.setdefault('depth', self.english_parent_page.depth + 1)
+        kwargs.setdefault('slug', 'mock-answer-page-en-1234')
+        kwargs.setdefault('title', 'Mock answer page title')
+        page = mommy.prepare(AnswerResultsPage, **kwargs)
+        page.save()
+        return page
 
-    def assertRedirect(self, response, redirect):
+    def test_annotate_links(self):
+        mock_answer = (
+            '<p>Answer with a <a href="http://fake.com">fake link.</a></p>')
+        (annotated_answer, links) = annotate_links(mock_answer)
         self.assertEqual(
-            (response['Location'], response.status_code),
-            (reverse(redirect), 302)
-        )
+            annotated_answer,
+            '<html><body><p>Answer with a <a href="http://fake.com">fake '
+            'link.</a><sup>1</sup></p></body></html>')
+        self.assertEqual(links, [(1, str('http://fake.com'))])
 
-    def assertRedirectSuccess(self, response):
-        self.assertRedirect(response, 'govdelivery:success')
+    def test_annotate_links_no_href(self):
+        mock_answer = (
+            '<p>Answer with a <a>fake link.</a></p>')
+        (annotated_answer, links) = annotate_links(mock_answer)
+        self.assertEqual(links, [])
 
-    def assertRedirectUserError(self, response):
-        self.assertRedirect(response, 'govdelivery:user_error')
+    def test_annotate_links_no_site(self):
+        site = Site.objects.get(is_default_site=True)
+        site.is_default_site = False
+        site.save()
+        with self.assertRaises(RuntimeError) as context:
+            annotate_links('answer')
+        self.assertIn('no default wagtail site', str(context.exception))
 
-    def assertRedirectServerError(self, response):
-        self.assertRedirect(response, 'govdelivery:server_error')
+    def test_bad_language_search(self):
+        with self.assertRaises(NoReverseMatch):
+            self.client.get(reverse(
+                'ask-search-en',
+                kwargs={'language': 'zz'}), {'q': 'payday'})
 
-    def assertJSON(self, response, result):
+    @mock.patch('ask_cfpb.views.SearchQuerySet.filter')
+    def test_en_search_no_such_page(self, mock_query):
+        response = self.client.get(reverse(
+            'ask-search-en'), {'q': 'payday'})
+        self.assertEqual(mock_query.call_count, 1)
+        self.assertTrue(mock_query.called_with(language='en', q='payday'))
+        self.assertEqual(response.status_code, 404)
+
+    @mock.patch('ask_cfpb.views.SearchQuerySet.filter')
+    def test_en_search(self, mock_query):
+        from v1.util.migrations import get_or_create_page
+        mock_page = get_or_create_page(
+            apps,
+            'ask_cfpb',
+            'AnswerResultsPage',
+            'Mock results page',
+            'ask-cfpb-search-results',
+            self.ROOT_PAGE,
+            language='en')
+        mock_return = mock.Mock()
+        mock_return.url = 'mockcfpb.gov'
+        mock_return.autocomplete = 'A mock question'
+        mock_return.text = 'Mock answer text.'
+        mock_query.return_value = [mock_return]
+        response = self.client.get(reverse(
+            'ask-search-en'), {'q': 'payday'})
+        self.assertEqual(mock_query.call_count, 1)
+        self.assertTrue(mock_query.called_with(language='en', q='payday'))
+        self.assertEqual(response.status_code, 200)
         self.assertEqual(
-            response.content.decode('utf-8'),
-            json.dumps({'result': result})
-        )
+            response.context_data['page'],
+            mock_page)
 
-    def assertJSONSuccess(self, response):
-        return self.assertJSON(response, 'pass')
+    @mock.patch('ask_cfpb.views.SearchQuerySet.filter')
+    def test_es_search(self, mock_query):
+        self.client.get(reverse(
+            'ask-search-es', kwargs={'language': 'es'}), {'q': 'payday'})
+        self.assertEqual(mock_query.call_count, 1)
+        self.assertTrue(mock_query.called_with(language='es', q='payday'))
 
-    def assertJSONError(self, response):
-        return self.assertJSON(response, 'fail')
-
-    def check_post(self, post, response_check, ajax=False):
-        response_check(self.post(post, ajax=ajax))
-
-    def mock_govdelivery(self, status_code=200):
-        gd = Mock(set_subscriber_topics=Mock(
-            return_value=Mock(status_code=status_code)
-        ))
-
-        patcher = patch('core.views.GovDelivery', return_value=gd)
-        patcher.start()
-        self.addCleanup(patcher.stop)
-
-        return gd
-
-    def check_subscribe(self, response_check, ajax=False, status_code=200,
-                        include_answers=False):
-        post = {
-            'code': 'FAKE_CODE',
-            'email': 'fake@example.com',
-        }
-
-        answers = [
-            ('batman', 'robin'),
-            ('hello', 'goodbye'),
-        ]
-
-        if include_answers:
-            post.update({'questionid_' + q: a for q, a in answers})
-
-        gd = self.mock_govdelivery(status_code=status_code)
-        self.check_post(post, response_check, ajax=ajax)
-        gd.set_subscriber_topics.assert_called_with(
-            post['email'],
-            [post['code']]
-        )
-
-        if include_answers:
-            gd.set_subscriber_answers_to_question.assert_has_calls(
-                [call(post['email'], q, a) for q, a in answers],
-                any_order=True
-            )
-
-    def test_missing_email_address(self):
-        post = {'code': 'FAKE_CODE'}
-        self.check_post(post, self.assertRedirectUserError)
-
-    def test_missing_gd_code(self):
-        post = {'email': 'fake@example.com'}
-        self.check_post(post, self.assertRedirectUserError)
-
-    def test_missing_email_address_ajax(self):
-        post = {'code': 'FAKE_CODE'}
-        self.check_post(post, self.assertJSONError, ajax=True)
-
-    def test_missing_gd_code_ajax(self):
-        post = {'email': 'fake@example.com'}
-        self.check_post(post, self.assertJSONError, ajax=True)
-
-    def test_successful_subscribe(self):
-        self.check_subscribe(self.assertRedirectSuccess)
-
-    def test_successful_subscribe_ajax(self):
-        self.check_subscribe(self.assertJSONSuccess, ajax=True)
-
-    def test_server_error(self):
-        self.check_subscribe(self.assertRedirectServerError, status_code=500)
-
-    def test_server_error_ajax(self):
-        self.check_subscribe(self.assertJSONError, ajax=True, status_code=500)
-
-    def test_setting_subscriber_answers_to_questions(self):
-        self.check_subscribe(self.assertRedirectSuccess, include_answers=True)
-
-
-class RegsgovCommentTest(TestCase):
-    def setUp(self):
-        self.factory = RequestFactory()
-        self.data = {
-            'comment_on': 'FAKE_DOC_NUM',
-            'general_comment': 'FAKE_COMMENT',
-            'first_name': 'FAKE_FIRST',
-            'last_name': 'FAKE_LAST',
-        }
-        self.tracking_number = 'FAKE_TRACKING_NUMBER'
-
-    def post(self, post, ajax=False):
-        kwargs = {'HTTP_X_REQUESTED_WITH': 'XMLHttpRequest'} if ajax else {}
-        request = self.factory.post(reverse('reg_comment'), post, **kwargs)
-        response = regsgov_comment(request)
-        return request, response
-
-    def assertRedirect(self, response, redirect):
+    @mock.patch('ask_cfpb.views.SearchQuerySet.filter')
+    def test_search_page_en_selection(self, mock_query):
+        return_mock = mock.Mock()
+        mock_query.return_value = [return_mock]
+        return_mock.url = 'url'
+        return_mock.autocomplete = 'question text'
+        page = self.create_answer_results_page(language='en')
+        self.client.get(reverse(
+            'ask-search-en'))
+        self.assertEqual(mock_query.call_count, 1)
+        self.assertEqual(page.language, 'en')
+        self.assertEqual(page.answers, [])
         self.assertEqual(
-            (response['Location'], response.status_code),
-            (reverse(redirect), 302)
-        )
+            page.get_template(HttpRequest()),
+            'ask-cfpb/answer-search-results.html')
 
-    def assertRedirectSuccess(self, response):
-        self.assertRedirect(response, 'reg_comment:success')
-
-    def assertRedirectUserError(self, response):
-        self.assertRedirect(response, 'reg_comment:user_error')
-
-    def assertRedirectServerError(self, response):
-        self.assertRedirect(response, 'reg_comment:server_error')
-
-    def assertJSON(self, response, result, has_tracking_num=False):
-        expected = {'result': result}
-        if has_tracking_num:
-            expected.update({'tracking_number': self.tracking_number})
-
+    @mock.patch('ask_cfpb.views.SearchQuerySet.filter')
+    def test_search_page_es_selection(self, mock_query):
+        return_mock = mock.Mock()
+        mock_query.return_value = [return_mock]
+        return_mock.url = 'url'
+        return_mock.autocomplete = 'question text'
+        page = self.create_answer_results_page(language='es')
+        self.client.get(reverse(
+            'ask-search-es',
+            kwargs={'language': 'es'}))
+        self.assertEqual(mock_query.call_count, 1)
+        self.assertEqual(page.language, 'es')
+        self.assertEqual(page.answers, [])
         self.assertEqual(
-            response.content.decode('utf-8'),
-            json.dumps(expected)
-        )
+            page.get_template(HttpRequest()),
+            'ask-cfpb/answer-search-spanish-results.html')
 
-    def assertJSONSuccess(self, response):
-        return self.assertJSON(response, 'success')
+    @mock.patch('ask_cfpb.views.SearchQuerySet.filter')
+    def test_en_search_as_json(self, mock_query):
+        mock_query.autocomplete.return_value = ['question text']
+        mock_query.url.return_value = ['answer/url']
+        self.client.get(reverse(
+            'ask-search-en-json',
+            kwargs={'as_json': 'json'}))
+        self.assertEqual(mock_query.call_count, 1)
+        self.assertTrue(
+            mock_query.called_with(
+                language='en',
+                as_json='json'))
 
-    def assertJSONSuccessCommented(self, response):
-        return self.assertJSON(response, 'pass', has_tracking_num=True)
+    def test_autocomplete_en_blank_term(self):
+        result = self.client.get(reverse(
+            'ask-autocomplete-en'), {'term': ''})
+        output = json.loads(result.content)
+        self.assertEqual(output, [])
 
-    def assertJSONError(self, response):
-        return self.assertJSON(response, 'fail')
+    def test_autocomplete_es_blank_term(self):
+        result = self.client.get(reverse(
+            'ask-autocomplete-es',
+            kwargs={'language': 'es'}), {'term': ''})
+        output = json.loads(result.content)
+        self.assertEqual(output, [])
 
-    def check_post(self, post, response_check, ajax=False):
-        request, response = self.post(post, ajax=ajax)
-        response_check(response)
-        return request, response
+    @mock.patch('ask_cfpb.views.SearchQuerySet.autocomplete')
+    def test_autocomplete_en(self, mock_autocomplete):
+        mock_search_result = mock.Mock()
+        mock_search_result.autocomplete = 'question'
+        mock_search_result.url = 'url'
+        mock_autocomplete.return_value = [mock_search_result]
+        result = self.client.get(reverse(
+            'ask-autocomplete-en'), {'term': 'question'})
+        self.assertEqual(mock_autocomplete.call_count, 1)
+        output = json.loads(result.content)
+        self.assertEqual(
+            sorted(output[0].keys()),
+            ['question', 'url'])
 
-    def mock_submit_data(self, status_code=201):
-        submit = Mock(
-            status_code=status_code,
-            text=json.dumps({'trackingNumber': self.tracking_number})
-        )
-
-        patcher = patch('core.views.submit_comment', return_value=submit)
-        patched = patcher.start()
-        self.addCleanup(patcher.stop)
-        return patched
-
-    def mock_messages(self):
-        patcher = patch('core.views.messages.success')
-        patched = patcher.start()
-        self.addCleanup(patcher.stop)
-        return patched
-
-    def check_comment(self, response_check, ajax=False, status_code=201):
-        submit = self.mock_submit_data(status_code=status_code)
-        messages = self.mock_messages()
-
-        request, response = self.check_post(self.data, response_check,
-                                            ajax=ajax)
-
-        submit.assert_called_with(request.POST)
-
-        if 201 == status_code:
-            messages.assert_called_with(request, self.tracking_number)
-
-    def test_missing_comment_on(self):
-        del self.data['comment_on']
-        self.check_post(self.data, self.assertRedirectServerError)
-
-    def test_missing_general_comment(self):
-        del self.data['general_comment']
-        self.check_post(self.data, self.assertRedirectUserError)
-
-    def test_missing_comment_on_ajax(self):
-        del self.data['comment_on']
-        self.check_post(self.data, self.assertJSONError, ajax=True)
-
-    def test_missing_general_comment_ajax(self):
-        del self.data['general_comment']
-        self.check_post(self.data, self.assertJSONError, ajax=True)
-
-    def test_missing_first_name_ajax(self):
-        del self.data['first_name']
-        self.check_post(self.data, self.assertJSONError, ajax=True)
-
-    def test_missing_last_name_ajax(self):
-        del self.data['last_name']
-        self.check_post(self.data, self.assertJSONError, ajax=True)
-
-    def test_successful_comment(self):
-        self.check_comment(self.assertRedirectSuccess)
-
-    def test_successful_comment_ajax(self):
-        self.check_comment(self.assertJSONSuccessCommented, ajax=True)
-
-    def test_server_error(self):
-        self.check_comment(self.assertRedirectServerError, status_code=500)
-
-    @patch('requests.post')
-    @patch('django.conf.settings.REGSGOV_BASE_URL', 'FAKE_URL')
-    @patch('django.conf.settings.REGSGOV_API_KEY', 'FAKE_API_KEY')
-    def test_submit_comment_success_no_email(self, mock_post):
-        mock_post.return_value = {'response': 'fake_response'}
-
-        data = {'comment_on': u'FAKE_DOC_NUM',
-                'general_comment': u'FAKE_COMMENT',
-                'first_name': u'FAKE_FIRST',
-                'last_name': u'FAKE_LAST'}
-        submit_comment(QueryDict(urlencode(data)))
-        act_args, act_kwargs = mock_post.call_args
-
-        self.assertEqual(act_args[0],
-                         'FAKE_URL?api_key=FAKE_API_KEY&D=FAKE_DOC_NUM')
-        exp_data_field = data
-        exp_data_field['email'] = u'NA'
-        exp_data_field['organization'] = u'NA'
-        exp_data = MultipartEncoder(fields=exp_data_field)
-        self.assertTrue(act_kwargs.get('data'), exp_data)
-        self.assertEqual(act_kwargs.get('data').fields, exp_data.fields)
-        self.assertIn('Content-Type', act_kwargs.get('headers'))
-
-        self.assertIn('multipart/form-data',
-                      act_kwargs.get('headers').get('Content-Type'))
-
-    @patch('requests.post')
-    @patch('django.conf.settings.REGSGOV_BASE_URL', 'FAKE_URL')
-    @patch('django.conf.settings.REGSGOV_API_KEY', 'FAKE_API_KEY')
-    def test_submit_comment_success_email(self, mock_post):
-        mock_post.return_value = {'response': 'fake_response'}
-
-        data = {'comment_on': u'FAKE_DOC_NUM',
-                'general_comment': u'FAKE_COMMENT',
-                'first_name': u'FAKE_FIRST',
-                'last_name': u'FAKE_LAST',
-                'email': u'FAKE_EMAIL'}
-        submit_comment(QueryDict(urlencode(data)))
-        act_args, act_kwargs = mock_post.call_args
-
-        self.assertEqual(act_args[0],
-                         'FAKE_URL?api_key=FAKE_API_KEY&D=FAKE_DOC_NUM')
-        exp_data_field = data
-        exp_data_field['organization'] = u'NA'
-        exp_data = MultipartEncoder(fields=exp_data_field)
-        self.assertTrue(act_kwargs.get('data'), exp_data)
-        self.assertEqual(act_kwargs.get('data').fields, exp_data.fields)
-        self.assertIn('Content-Type', act_kwargs.get('headers'))
-
-        self.assertIn('multipart/form-data',
-                      act_kwargs.get('headers').get('Content-Type'))
+    @mock.patch('ask_cfpb.views.SearchQuerySet.autocomplete')
+    def test_autocomplete_es(self, mock_autocomplete):
+        mock_search_result = mock.Mock()
+        mock_search_result.autocomplete = 'question'
+        mock_search_result.url = 'url'
+        mock_autocomplete.return_value = [mock_search_result]
+        result = self.client.get(reverse(
+            'ask-autocomplete-es',
+            kwargs={'language': 'es'}), {'term': 'question'})
+        self.assertEqual(mock_autocomplete.call_count, 1)
+        output = json.loads(result.content)
+        self.assertEqual(
+            sorted(output[0].keys()),
+            ['question', 'url'])

--- a/cfgov/jinja2/v1/_includes/organisms/_vars-mega-menu.html
+++ b/cfgov/jinja2/v1/_includes/organisms/_vars-mega-menu.html
@@ -69,7 +69,7 @@
 {% set nav_items = [(
     ('Consumer Tools', '#', [(
         ('Submit a Complaint', '/complaint/', []),
-        ('Ask CFPB', '/askcfpb/', []),
+        ('Ask CFPB', '/ask-cfpb/' if flag_enabled('WAGTAIL_ASK_CFPB', request) else '/askcfpb/', []),
         ('Tell Your Story', '/your-story/', []),
         ('Information for Students', '/students/', []),
         ('Information for Servicemembers & Veterans', '/servicemembers/', [])
@@ -173,3 +173,4 @@
         ('Contact Us', '/about-us/contact-us/', [])
     )])
 )] -%}
+

--- a/cfgov/jinja2/v1/index.html
+++ b/cfgov/jinja2/v1/index.html
@@ -80,7 +80,7 @@
                             'links': [
                                 {
                                     'text': 'Find answers to common questions',
-                                    'url':  '/askcfpb/'
+                                    'url':  '/ask-cfpb/' if flag_enabled('WAGTAIL_ASK_CFPB', request) else '/askcfpb/'
                                 }
                             ]
                         } ) }}

--- a/cfgov/v1/db_router.py
+++ b/cfgov/v1/db_router.py
@@ -5,6 +5,7 @@ cfgov_apps = [
     'sessions',
     'admin',
     'contenttypes',
+    'ask_cfpb',
     'v1',
     'flags',
     'taggit',
@@ -14,7 +15,6 @@ cfgov_apps = [
 optional_apps = [
     'countylimits',
     'ratechecker',
-    'ask_cfpb',
 ]
 
 


### PR DESCRIPTION
This puts code in place for the deployment, minus code for flagged URLs,
which will be dealt with separately.

Included:
- A fallback script for batch-deploying pages
- A fallback migration option for deploying with a set go-live date
- Making the WAGTAIL_ASK_CFPB flag an empty flag in settings so
  that it can be controlled with simple admin change.
- removal of conditional code from ask_cfpb/wagtail_hooks.py
- setting up URLs so that removing knowledgebase from installed apps
  will let all of the new ask-cfpb to go live.
- changes to megamenu and index to put new ask-cfpb links behind a
  feature flag.
- adds ask_cfpb to the v1/dbrouter's list of cfgov apps so its tables
  are shared between content and prod

If flags don't work out, we can deploy with a code push to remove knowledgebase URLs.

This is the same code delivered via PR 2998, minus code and tests related to flagged URLs.