### PR TITLE
Add social media images to Ask categories

### DIFF
--- a/cfgov/ask_cfpb/migrations/0004_add_ask_category_images.py
+++ b/cfgov/ask_cfpb/migrations/0004_add_ask_category_images.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('v1', '0069_add_social_sharing_image'),
+        ('ask_cfpb', '0003_add_answercategorypage'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='answer',
+            name='social_sharing_image',
+            field=models.ForeignKey(related_name='+', on_delete=django.db.models.deletion.SET_NULL, blank=True, to='v1.CFGOVImage', help_text="Optionally select a custom image to appear when users share this page on social media websites. If no image is selected, this page's category image will be used.", null=True),
+        ),
+        migrations.AddField(
+            model_name='category',
+            name='category_image',
+            field=models.ForeignKey(related_name='+', on_delete=django.db.models.deletion.SET_NULL, blank=True, to='v1.CFGOVImage', help_text='Select a custom image to appear when visitors share pages belonging to this category on social media.', null=True),
+        ),
+    ]

--- a/cfgov/ask_cfpb/models/django.py
+++ b/cfgov/ask_cfpb/models/django.py
@@ -20,6 +20,7 @@ from wagtail.wagtailadmin.edit_handlers import (
 from wagtail.wagtailcore.blocks.stream_block import StreamValue
 from wagtail.wagtailcore.fields import RichTextField
 from wagtail.wagtailcore.models import Page
+from wagtail.wagtailimages.edit_handlers import ImageChooserPanel
 
 from v1.util.migrations import get_or_create_page
 
@@ -86,6 +87,17 @@ class Category(models.Model):
     slug_es = models.SlugField()
     intro = RichTextField(blank=True)
     intro_es = RichTextField(blank=True)
+    category_image = models.ForeignKey(
+        'v1.CFGOVImage',
+        null=True,
+        blank=True,
+        on_delete=models.SET_NULL,
+        related_name='+',
+        help_text=(
+            'Select a custom image to appear when visitors share pages '
+            'belonging to this category on social media.'
+        )
+    )
     panels = [
         FieldPanel('name', classname="title"),
         FieldPanel('slug'),
@@ -93,6 +105,7 @@ class Category(models.Model):
         FieldPanel('name_es', classname="title"),
         FieldPanel('slug_es'),
         FieldPanel('intro_es'),
+        ImageChooserPanel('category_image')
     ]
 
     def __str__(self):
@@ -229,6 +242,18 @@ class Answer(models.Model):
         blank=True,
         related_name='related_question',
         help_text='Maximum of 3')
+    social_sharing_image = models.ForeignKey(
+        'v1.CFGOVImage',
+        null=True,
+        blank=True,
+        on_delete=models.SET_NULL,
+        related_name='+',
+        help_text=(
+            'Optionally select a custom image to appear when users share this '
+            'page on social media websites. If no image is selected, this '
+            'page\'s category image will be used.'
+        )
+    )
 
     panels = [
         MultiFieldPanel([
@@ -266,7 +291,8 @@ class Answer(models.Model):
                     'subcategory',
                     widget=forms.CheckboxSelectMultiple)]),
             FieldPanel('related_questions', widget=forms.SelectMultiple),
-            FieldPanel('search_tags')],
+            FieldPanel('search_tags'),
+            ImageChooserPanel('social_sharing_image')],
             heading="Metadata",
             classname="collapsible"),
     ]

--- a/cfgov/ask_cfpb/models/pages.py
+++ b/cfgov/ask_cfpb/models/pages.py
@@ -197,6 +197,11 @@ class AnswerCategoryPage(RoutablePageMixin, CFGOVPage):
 
         return context
 
+    # Returns an image for the page's meta Open Graph tag
+    @property
+    def meta_image(self):
+        return self.ask_category.category_image
+
     @route(r'^$')
     def category_page(self, request):
         context = self.get_context(request)
@@ -492,3 +497,14 @@ class AnswerPage(CFGOVPage):
                 return _("redirected")
         else:
             return super(AnswerPage, self).status_string
+
+    # Returns an image for the page's meta Open Graph tag
+    @property
+    def meta_image(self):
+        if self.answer_base.social_sharing_image:
+            return self.answer_base.social_sharing_image
+
+        if not self.answer_base.category.exists():
+            return None
+
+        return self.answer_base.category.first().category_image

--- a/cfgov/ask_cfpb/tests/models/test_pages.py
+++ b/cfgov/ask_cfpb/tests/models/test_pages.py
@@ -73,8 +73,8 @@ class AnswerModelTestCase(TestCase):
             SubCategory, name='stub_subcat', parent=self.category, _quantity=3)
         self.category.subcategories.add(self.subcategories[0])
         self.category.save()
-        self.social_image = mommy.make(CFGOVImage)
-        self.social_image2 = mommy.make(CFGOVImage)
+        self.test_image = mommy.make(CFGOVImage)
+        self.test_image2 = mommy.make(CFGOVImage)
         self.next_step = mommy.make(NextStep, title='stub_step')
         page_clean = patch('ask_cfpb.models.pages.CFGOVPage.clean')
         page_clean.start()
@@ -741,20 +741,20 @@ class AnswerModelTestCase(TestCase):
             get_reusable_text_snippet('Nonexistent Snippet'),
             None)
 
-    def test_category_meta_image_empty(self):
+    def test_category_meta_image_undefined(self):
         """ Category page's meta image is undefined if the category has
         no image
         """
         category_page = self.create_category_page(ask_category=self.category)
         self.assertIsNone(category_page.meta_image)
 
-    def test_category_meta_image(self):
+    def test_category_meta_image_uses_category_image(self):
         """ Category page's meta image is its category's image """
-        category = mommy.make(Category, category_image=self.social_image)
+        category = mommy.make(Category, category_image=self.test_image)
         category_page = self.create_category_page(ask_category=category)
-        self.assertEqual(category_page.meta_image, self.social_image)
+        self.assertEqual(category_page.meta_image, self.test_image)
 
-    def test_answer_meta_image_empty(self):
+    def test_answer_meta_image_undefined(self):
         """ Answer page's meta image is undefined if social image is
         not provided
         """
@@ -763,27 +763,27 @@ class AnswerModelTestCase(TestCase):
         page = self.create_answer_page(answer_base=answer)
         self.assertIsNone(page.meta_image)
 
-    def test_answer_meta_image(self):
+    def test_answer_meta_image_uses_social_image(self):
         """ Answer page's meta image is its answer's social image """
-        answer = self.prepare_answer(social_sharing_image=self.social_image)
+        answer = self.prepare_answer(social_sharing_image=self.test_image)
         answer.save()
         page = self.create_answer_page(answer_base=answer)
-        self.assertEqual(page.meta_image, self.social_image)
+        self.assertEqual(page.meta_image, self.test_image)
 
-    def test_answer_meta_image_from_category(self):
+    def test_answer_meta_image_uses_category_image_if_no_social_image(self):
         """ Answer page's meta image is its category's image """
-        category = mommy.make(Category, category_image=self.social_image)
+        category = mommy.make(Category, category_image=self.test_image)
         answer = self.prepare_answer()
         answer.save()
         answer.category.add(category)
         page = self.create_answer_page(answer_base=answer)
-        self.assertEqual(page.meta_image, self.social_image)
+        self.assertEqual(page.meta_image, self.test_image)
 
-    def test_answer_meta_image_category_override(self):
+    def test_answer_meta_image_uses_social_image_not_category_image(self):
         """ Answer page's social image overrides its category's image """
-        category = mommy.make(Category, category_image=self.social_image)
-        answer = self.prepare_answer(social_sharing_image=self.social_image2)
+        category = mommy.make(Category, category_image=self.test_image)
+        answer = self.prepare_answer(social_sharing_image=self.test_image2)
         answer.save()
         answer.category.add(category)
         page = self.create_answer_page(answer_base=answer)
-        self.assertEqual(page.meta_image, self.social_image2)
+        self.assertEqual(page.meta_image, self.test_image2)

--- a/cfgov/ask_cfpb/tests/models/test_pages.py
+++ b/cfgov/ask_cfpb/tests/models/test_pages.py
@@ -73,10 +73,8 @@ class AnswerModelTestCase(TestCase):
             SubCategory, name='stub_subcat', parent=self.category, _quantity=3)
         self.category.subcategories.add(self.subcategories[0])
         self.category.save()
-        self.social_image = mommy.prepare(CFGOVImage)
-        self.social_image.save()
-        self.social_image2 = mommy.prepare(CFGOVImage)
-        self.social_image2.save()
+        self.social_image = mommy.make(CFGOVImage)
+        self.social_image2 = mommy.make(CFGOVImage)
         self.next_step = mommy.make(NextStep, title='stub_step')
         page_clean = patch('ask_cfpb.models.pages.CFGOVPage.clean')
         page_clean.start()
@@ -744,24 +742,36 @@ class AnswerModelTestCase(TestCase):
             None)
 
     def test_category_meta_image_empty(self):
+        """ Category page's meta image is undefined if the category has
+        no image
+        """
         category_page = self.create_category_page(ask_category=self.category)
         self.assertIsNone(category_page.meta_image)
 
     def test_category_meta_image(self):
+        """ Category page's meta image is its category's image """
         category = mommy.make(Category, category_image=self.social_image)
         category_page = self.create_category_page(ask_category=category)
         self.assertEqual(category_page.meta_image, self.social_image)
 
     def test_answer_meta_image_empty(self):
-        self.assertIsNone(self.page2.meta_image)
+        """ Answer page's meta image is undefined if social image is
+        not provided
+        """
+        answer = self.prepare_answer()
+        answer.save()
+        page = self.create_answer_page(answer_base=answer)
+        self.assertIsNone(page.meta_image)
 
     def test_answer_meta_image(self):
+        """ Answer page's meta image is its answer's social image """
         answer = self.prepare_answer(social_sharing_image=self.social_image)
         answer.save()
         page = self.create_answer_page(answer_base=answer)
         self.assertEqual(page.meta_image, self.social_image)
 
     def test_answer_meta_image_from_category(self):
+        """ Answer page's meta image is its category's image """
         category = mommy.make(Category, category_image=self.social_image)
         answer = self.prepare_answer()
         answer.save()
@@ -770,6 +780,7 @@ class AnswerModelTestCase(TestCase):
         self.assertEqual(page.meta_image, self.social_image)
 
     def test_answer_meta_image_category_override(self):
+        """ Answer page's social image overrides its category's image """
         category = mommy.make(Category, category_image=self.social_image)
         answer = self.prepare_answer(social_sharing_image=self.social_image2)
         answer.save()


### PR DESCRIPTION
This feeds off #2952. Editors would like AskCFPB answer pages to have social media images corresponding to pages' categories. Logic has been added to pass the page's `social_sharing_image` to the template's meta tag if an image has been manually selected. Otherwise, use the page's category's image.

## Additions

- Image chooser to both Answer and Category models

## Testing

```
./drop-db.sh
./create-mysql-db.sh
mysql -uroot v1 < ~/Downloads/production_django.sql
python cfgov/manage.py migrate
python cfgov/manage.py runscript migrate_knowledgebase
```

1. Edit a category and add an image via the image chooser panel.
1. Load a live answer page that belongs to the above category.
1. View the page's source and look for `<meta property="og:image" content="*THE IMAGE YOU SELECTED*">`.

## Screenshots

## Checklist

* [ ] PR has an informative and human-readable title
* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated
* [ ] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
