### PR TITLE
Clean up meta image tests

### DIFF
--- a/cfgov/v1/tests/models/test_base.py
+++ b/cfgov/v1/tests/models/test_base.py
@@ -260,21 +260,3 @@ class TestFeedbackModel(TestCase):
                      "tester@example.com",
                      "{}".format(self.test_feedback.submitted_on.date())]:
             self.assertIn(term, test_csv)
-
-class TestMetaImage(TestCase):
-    def setUp(self):
-        self.social_sharing_image = mommy.prepare(CFGOVImage)
-
-    def test_meta_image_no_images(self):
-        page = mommy.prepare(
-            CFGOVPage,
-            social_sharing_image=None
-        )
-        self.assertIsNone(page.meta_image)
-
-    def test_meta_image(self):
-        page = mommy.prepare(
-            CFGOVPage,
-            social_sharing_image=self.social_sharing_image
-        )
-        self.assertEqual(page.meta_image, page.social_sharing_image)

--- a/cfgov/v1/tests/test_meta_image.py
+++ b/cfgov/v1/tests/test_meta_image.py
@@ -1,7 +1,7 @@
 from django.test import TestCase
 from model_mommy import mommy
 
-from v1.models import AbstractFilterPage, CFGOVImage
+from v1.models import AbstractFilterPage, CFGOVImage, CFGOVPage
 
 
 class TestMetaImage(TestCase):
@@ -10,22 +10,25 @@ class TestMetaImage(TestCase):
         self.social_sharing_image = mommy.prepare(CFGOVImage)
 
     def test_meta_image_no_images(self):
+        """ Meta image should be undefined if no image provided """
         page = mommy.prepare(
-            AbstractFilterPage,
-            social_sharing_image=None,
-            preview_image=None
+            CFGOVPage,
+            social_sharing_image=None
         )
         self.assertIsNone(page.meta_image)
 
     def test_meta_image_only_social_sharing(self):
+        """ Meta image uses social sharing image if provided """
         page = mommy.prepare(
-            AbstractFilterPage,
-            social_sharing_image=self.social_sharing_image,
-            preview_image=None
+            CFGOVPage,
+            social_sharing_image=self.social_sharing_image
         )
         self.assertEqual(page.meta_image, page.social_sharing_image)
 
     def test_meta_image_only_preview(self):
+        """ AbstractFilterPages use preview image for meta image
+        if a social image is not provided
+        """
         page = mommy.prepare(
             AbstractFilterPage,
             social_sharing_image=None,
@@ -34,6 +37,9 @@ class TestMetaImage(TestCase):
         self.assertEqual(page.meta_image, page.preview_image)
 
     def test_meta_image_both(self):
+        """ AbstractFilterPages use social image for meta image
+        if both preview image and social image are provided
+        """
         page = mommy.prepare(
             AbstractFilterPage,
             social_sharing_image=self.social_sharing_image,


### PR DESCRIPTION
Moved meta image tests into a dedicated file and added some notes.

* [ ] PR has an informative and human-readable title
* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated
* [ ] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
