### PR TITLE
turn off askcfpb smoketests while environments are in flux

### DIFF
--- a/cfgov/scripts/http_smoke_test.py
+++ b/cfgov/scripts/http_smoke_test.py
@@ -39,8 +39,8 @@ FULL_RUN = [
      '?selected_facets=category_exact:enviar-dinero'),
     '/learnmore/',
     '/complaint/',
-    '/askcfpb/',
-    '/askcfpb/search',
+    # '/askcfpb/',  # on hold
+    # '/askcfpb/search',  # on hold
     '/your-story/',
     '/students/',
     '/find-a-housing-counselor/',


### PR DESCRIPTION
For the next few days, environments may have different URL settings active for askcfpb and ask_cfpb.
Smoketests are too blunt to be useful in testing these environments, so this turns off the two URLs we test while deployment plays out.