### PR TITLE
Remove universal jquery reference

### DIFF
--- a/cfgov/jinja2/v1/_layouts/base.html
+++ b/cfgov/jinja2/v1/_layouts/base.html
@@ -117,13 +117,6 @@
     the head, then file an issue or PR to discuss including it.
 -->
 
-    {# TODO: jQuery is provided in the head to satisfy
-             Google Tag Manager (GTM) & Optimize requirements.
-             Ideally GTM would handle its own dependency management
-             and initializing jQuery could be moved to the footer.
-             (Ideally, also, we will move away from jQuery entirely.) #}
-    <script src="{{ static('js/jquery.min.js') }}"></script>
-
     {% if flag_enabled('AB_TESTING', request) %}
     <!-- Google Optimize page-hiding snippet -->
     <style>

--- a/config/webpack-config.js
+++ b/config/webpack-config.js
@@ -15,10 +15,6 @@ var JS_ROUTES_PATH = '/js/routes';
 var COMMON_BUNDLE_NAME = 'common.js';
 
 var modernConf = {
-  // jQuery is imported globally in the HTML head section in base.html,
-  // so it needs to be defined here as an external script to ignore for
-  // unmet dependency references.
-  externals: { jquery: 'jQuery' },
   cache: true,
   context: path.join( __dirname, '/../', paths.unprocessed, JS_ROUTES_PATH ),
   entry: scriptsManifest.getDirectoryMap( paths.unprocessed + JS_ROUTES_PATH ),

--- a/gulp/config.js
+++ b/gulp/config.js
@@ -102,7 +102,6 @@ module.exports = {
     },
     vendorJs: {
       src: [
-        paths.modules + '/jquery/dist/jquery.min.js',
         paths.modules + '/ustream-embedapi/dist/ustream-embedapi.min.js'
       ],
       dest: paths.processed + '/js/'

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -3699,16 +3699,6 @@
       "from": "istextorbinary@1.0.2",
       "resolved": "https://registry.npmjs.org/istextorbinary/-/istextorbinary-1.0.2.tgz"
     },
-    "jquery": {
-      "version": "1.11.3",
-      "from": "jquery@1.11.3",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-1.11.3.tgz"
-    },
-    "jquery.easing": {
-      "version": "1.3.2",
-      "from": "jquery.easing@>=1.3.0 <1.4.0",
-      "resolved": "https://registry.npmjs.org/jquery.easing/-/jquery.easing-1.3.2.tgz"
-    },
     "js-tokens": {
       "version": "3.0.1",
       "from": "js-tokens@>=3.0.0 <4.0.0",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
     "gulp-uglify": "2.0.1",
     "gulp-util": "3.0.8",
     "is-reachable": "2.3.2",
-    "jquery": "1.11.3",
     "psi": "3.0.0",
     "require-dir": "0.3.1",
     "ustream-embedapi": "1.0.0",
@@ -78,8 +77,7 @@
     "wcag": "0.3.0"
   },
   "browser": {
-    "es5-sham": "./node_modules/es5-shim/es5-sham.min.js",
-    "jquery": "./node_modules/jquery/dist/jquery.js"
+    "es5-sham": "./node_modules/es5-shim/es5-sham.min.js"
   },
   "scripts": {
     "test": "snyk test"


### PR DESCRIPTION
GTM tags and variables used across the site have had jquery references removed, so this removes it from the base template. 

## Removals

- Remove universal jquery references.

## Testing

1. `./frontend.sh` and check the site over. Outside apps (OAH, KBYO) should handle jquery themselves, if I understand correctly.

cc @kelleyholden