### PR TITLE
Initial production deployment for ask_cfpb

### DIFF
--- a/cfgov/ask_cfpb/tests/models/test_pages.py
+++ b/cfgov/ask_cfpb/tests/models/test_pages.py
@@ -789,3 +789,21 @@ class AnswerModelTestCase(TestCase):
         answer.category.add(category)
         page = self.create_answer_page(answer_base=answer)
         self.assertEqual(page.meta_image, self.test_image2)
+
+    def test_answer_page_context_collects_subcategories(self):
+        """ Answer page's context delivers all related subcategories """
+        answer = self.answer1234
+        related_subcat = mommy.make(
+            SubCategory,
+            name='related_subcat',
+            parent=self.category)
+        subcat1 = self.subcategories[0]
+        subcat1.related_subcategories.add(related_subcat)
+        for each in self.subcategories:
+            answer.subcategory.add(each)
+        answer.update_english_page = True
+        answer.save()
+        page = answer.english_page
+        request = HttpRequest()
+        context = page.get_context(request)
+        self.assertEqual(len(context['subcategories']), 4)

--- a/cfgov/ask_cfpb/tests/test_views.py
+++ b/cfgov/ask_cfpb/tests/test_views.py
@@ -7,14 +7,14 @@ from model_mommy import mommy
 
 from django.apps import apps
 from django.core.urlresolvers import reverse, NoReverseMatch
-from django.http import HttpRequest
+from django.http import HttpRequest, Http404
 import django.test
 from django.utils import timezone
 from wagtail.wagtailcore.models import Site
 
 from ask_cfpb.models import (
     AnswerResultsPage, ENGLISH_PARENT_SLUG, SPANISH_PARENT_SLUG)
-from ask_cfpb.views import annotate_links
+from ask_cfpb.views import annotate_links, redirect_ask_search, ask_search
 from v1.util.migrations import get_or_create_page, get_free_path
 
 now = timezone.now()
@@ -117,6 +117,28 @@ class AnswerViewTestCase(django.test.TestCase):
             response.context_data['page'],
             mock_page)
 
+    @mock.patch('ask_cfpb.views.redirect_ask_search')
+    def test_ask_search_encounters_facets(self, mock_redirect):
+        request = HttpRequest()
+        request.GET['selected_facets'] = 'category_exact:my_category'
+        ask_search(request)
+        self.assertEqual(mock_redirect.call_count, 1)
+
+    @mock.patch('ask_cfpb.views.redirect')
+    def test_redirect_ask_search_passes_query_string(self, mock_redirect):
+        request = HttpRequest()
+        request.GET['q'] = 'hoodoo'
+        redirect_ask_search(request)
+        self.assertEqual(mock_redirect.call_count, 1)
+
+    @mock.patch('ask_cfpb.views.redirect')
+    def test_spanish_redirect_ask_search_passes_query_string(
+            self, mock_redirect):
+        request = HttpRequest()
+        request.GET['selected_facets'] = 'category_exact:my_categoria'
+        redirect_ask_search(request, language='es')
+        self.assertEqual(mock_redirect.call_count, 1)
+
     @mock.patch('ask_cfpb.views.SearchQuerySet.filter')
     def test_es_search(self, mock_query):
         self.client.get(reverse(
@@ -211,3 +233,30 @@ class AnswerViewTestCase(django.test.TestCase):
         self.assertEqual(
             sorted(output[0].keys()),
             ['question', 'url'])
+
+
+class RedirectAskSearchTestCase(django.test.TestCase):
+
+    def test_redirect_search_no_facets(self):
+        request = HttpRequest()
+        with self.assertRaises(Http404):
+            redirect_ask_search(request)
+
+    def test_redirect_search_no_category(self):
+        request = HttpRequest()
+        request.GET['selected_facets'] = ''
+        with self.assertRaises(Http404):
+            redirect_ask_search(request)
+
+    def test_redirect_search_no_query(self):
+        request = HttpRequest()
+        request.GET['q'] = ' '
+        with self.assertRaises(Http404):
+            redirect_ask_search(request)
+
+    def test_redirect_search(self):
+        request = HttpRequest()
+        request.GET['selected_facets'] = 'category_exact:my_category'
+        result = redirect_ask_search(request)
+        self.assertEqual(result.get('location'),
+                         '/ask-cfpb/category-my_category')

--- a/cfgov/ask_cfpb/views.py
+++ b/cfgov/ask_cfpb/views.py
@@ -144,7 +144,7 @@ def redirect_ask_search(request, language='en'):
 
     cat_string = 'category_exact:'  # the facet prefix for categories
     if request.GET.get('q'):
-        querystring = request.GET.get('q')
+        querystring = request.GET.get('q').strip()
         if not querystring:
             raise Http404
         return redirect(
@@ -152,6 +152,7 @@ def redirect_ask_search(request, language='en'):
                 query=querystring, permanent=True))
     else:
         facets = request.GET.getlist('selected_facets')
+        category = ''
         if not facets:
             raise Http404
         # Get the category, if there is one

--- a/cfgov/cfgov/urls.py
+++ b/cfgov/cfgov/urls.py
@@ -406,7 +406,7 @@ if settings.DEBUG:
     except ImportError:
         pass
 
-if settings.DEPLOY_ENVIRONMENT not in ['build', 'beta']:
+if settings.DEPLOY_ENVIRONMENT not in ['build']:
     kb_patterns = [
         url(r'^(?i)askcfpb/',
             include_if_app_enabled(


### PR DESCRIPTION
This is the first of two staging steps for migrating knowledgebase
to Wagtail in production. This step prepares the content and
production servers for the migration of knowledgebase data
and pages into Wagtail, but without turning off the knowledgebase URLs.

Knowledgebase URLs should be active on Beta after this is merged (line 409 in `urls.py`), allowing us 
to confirm that current functionality will continue while we migrate data in production.

After the migration and testing, the second stage will turn off
KB URLs and switch navigation links to let Wagtail pages take over.

This also picks up a few missing tests.
