### PR TITLE
Ask CFPB: fix for answer images and videos

### DIFF
--- a/cfgov/jinja2/v1/ask-cfpb/answer-page-spanish.html
+++ b/cfgov/jinja2/v1/ask-cfpb/answer-page-spanish.html
@@ -24,7 +24,7 @@
             <article class="ac-qa">
                 <h1 class="ac-qa-question">{{ page.question | striptags }}</h1>
                 <div class="ac-qa-answer">
-                    {{ page.answer|safe }}
+                    {{ page.answer|richtext|safe }}
                 </div>
             </article><!-- .ac-qa -->
 

--- a/cfgov/jinja2/v1/ask-cfpb/answer-page.html
+++ b/cfgov/jinja2/v1/ask-cfpb/answer-page.html
@@ -61,7 +61,7 @@
             <div class="o-expandable_content" id="answer-content">
                 <div class="o-expandable_content-animated">
                     <div class="answer-text">
-                        {{ page.answer | safe }}
+                        {{ page.answer | richtext | safe }}
                     </div>
                     {% if audiences %} 
                     <div class="u-mt15">

--- a/cfgov/unprocessed/css/pages/ask.less
+++ b/cfgov/unprocessed/css/pages/ask.less
@@ -116,6 +116,10 @@
 }
 
 .ask-cfpb-page {
+    .responsive-object {
+        padding-bottom: unit( @grid_gutter-width / 2 / @base-font-size-px, em ) !important;
+    }
+
     .m-pagination {
         .respond-to-max(@bp-xs-max, {
             height: auto;


### PR DESCRIPTION
Add richtextfilter so images and videos are output correctly in Ask answer content

## Additions

- Richtextfilter in answers
- Padding for media items in answers

## Testing

1. Check out branch
2. Run `gulp styles`
3. Add image and video to an answer in admin, publish, and verify that media items display correctly

## Screenshots


<img width="822" alt="screen shot 2017-06-14 at 8 03 30 am" src="https://user-images.githubusercontent.com/778171/27139623-59d7fd64-50d8-11e7-9c77-179ca39fc940.png">




## Checklist

* [ ] PR has an informative and human-readable title
* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated
* [ ] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
