### PR TITLE
Removing jQuery from Email Popup flow OAH landing page

### DIFF
--- a/cfgov/jinja2/v1/_includes/organisms/email-popup.html
+++ b/cfgov/jinja2/v1/_includes/organisms/email-popup.html
@@ -10,7 +10,7 @@
 
    ========================================================================== #}
 
-<div class="o-email-popup">
+<div class="o-email-popup u-alpha-transition u-alpha-0">
   <div class="o-email-popup_header u-clearfix">
     <div class="close">
       <a>Close <span class="cf-icon cf-icon-delete-round"></span></a>

--- a/cfgov/unprocessed/css/organisms/email-popup.less
+++ b/cfgov/unprocessed/css/organisms/email-popup.less
@@ -4,7 +4,6 @@
   position: fixed;
   bottom: 1em;
   right: 1em;
-  display: none;
   z-index: 2000;
   background-color: white;
   border: 1px solid @gray-20;

--- a/cfgov/unprocessed/js/modules/util/email-popup-helpers.js
+++ b/cfgov/unprocessed/js/modules/util/email-popup-helpers.js
@@ -1,7 +1,5 @@
 'use strict';
 
-var $ = window.$;
-
 /**
  * Stores/retrieves email signup data in localStorage
  */
@@ -103,15 +101,16 @@ function showOnScroll( elToShow, opts ) {
     cb: function() { return UNDEFINED; }
   };
 
-  opts = $.extend( defaults, opts || {} );
+  opts = Object.assign( defaults, opts || {} );
+
 
   function _getScrollTargetPosition() {
-    var elHeight = elToShow.height();
+    var elHeight = elToShow.offsetHeight;
     if ( opts.targetElement && opts.targetElement.length ) {
       var top = opts.targetElement.offset().top;
       return top + elHeight;
     }
-    var percentageTarget = $( document ).height() * ( opts.scrollPercent / 100 );
+    var percentageTarget = document.body.offsetHeight * ( opts.scrollPercent / 100 );
     return percentageTarget + elHeight;
 
   }

--- a/cfgov/unprocessed/js/organisms/EmailPopup.js
+++ b/cfgov/unprocessed/js/organisms/EmailPopup.js
@@ -29,7 +29,7 @@ function EmailPopup( el ) {
       helpers.recordEmailPopupView();
     }
 
-    return true
+    return true;
   }
 
   function init() {

--- a/cfgov/unprocessed/js/organisms/EmailPopup.js
+++ b/cfgov/unprocessed/js/organisms/EmailPopup.js
@@ -1,8 +1,7 @@
 'use strict';
 
 var helpers = require( '../modules/util/email-popup-helpers' );
-
-var $ = window.$;
+var AlphaTransition = require( '../modules/transition/AlphaTransition' );
 
 /**
  * EmailPopup
@@ -15,23 +14,26 @@ var $ = window.$;
  * @returns {EmailSignup} An instance.
  */
 function EmailPopup( el ) {
-  var _baseElement = $( el );
-  var _closeElement = $( el ).find( '.close' );
+  var _baseElement = document.querySelector( el );
+  var _closeElement = _baseElement.querySelector( '.close' );
+  var transition = new AlphaTransition( _baseElement ).init();
 
   function hidePopup() {
-    _baseElement.fadeOut();
+    transition.fadeOut();
     helpers.recordEmailPopupClosure();
   }
 
   function showPopup() {
     if ( helpers.showEmailPopup() ) {
-      _baseElement.fadeIn();
+      transition.fadeIn();
       helpers.recordEmailPopupView();
     }
+
+    return true
   }
 
   function init() {
-    _closeElement.on( 'click', hidePopup );
+    _closeElement.addEventListener( 'click', hidePopup );
   }
 
   this.init = init;

--- a/cfgov/unprocessed/js/routes/owning-a-home/single.js
+++ b/cfgov/unprocessed/js/routes/owning-a-home/single.js
@@ -4,11 +4,15 @@
 // Required modules.
 var EmailPopup = require( '../../organisms/EmailPopup' );
 var emailHelpers = require( '../../modules/util/email-popup-helpers' );
-if ( $( '.o-email-popup' ).length && emailHelpers.showEmailPopup() ) {
+var emailPopup = document.querySelectorAll( '.o-email-popup' )
+
+
+if ( emailPopup && emailHelpers.showEmailPopup() ) {
+
   var popup = new EmailPopup( '.o-email-popup' );
   popup.init();
   emailHelpers.showOnScroll( popup.el, {
   	cb: popup.showPopup,
-  	targetElement: $('.o-info-unit-group')
+  	targetElement: document.querySelector( '.o-info-unit-group' )
   } );
 }


### PR DESCRIPTION
Removing jQuery from Email Popup

## Changes

- Modified code to eliminate jQuery from email signup flow.


## Testing

1. Delete your local storage value for `http://localhost:8000/owning-a-home/`.
2. Visit `http://localhost:8000/owning-a-home/`
3. Scroll to the bottom of the page.
4. Validate that the email signup worked as before. 

## Screenshots


## Notes




## Checklist

* [ ] PR has an informative and human-readable title
* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated
* [ ] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
