### PR TITLE
Ask cfpb go live

### DIFF
--- a/cfgov/ask_cfpb/models/django.py
+++ b/cfgov/ask_cfpb/models/django.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, unicode_literals
 
-from collections import OrderedDict
+from collections import OrderedDict, Counter
 import HTMLParser
 import json
 
@@ -392,16 +392,11 @@ class Answer(models.Model):
         Tags are useless until they can be used to collect at least 2 answers.
         """
         cleaned = []
-        valid = []
         for a in cls.objects.all():
-            if a.search_tags_es.strip():
-                cleaned += [
-                    tag.strip() for tag
-                    in a.search_tags_es.strip().split(',')
-                    if tag.strip()]
-        for tag in sorted(set(cleaned)):
-            if cls.objects.filter(search_tags_es__contains=tag).count() > 1:
-                valid.append(tag)
+            cleaned += a.tags_es
+        tag_counter = Counter(cleaned)
+        valid = sorted(
+            tup[0] for tup in tag_counter.most_common() if tup[1] > 1)
         return valid
 
     def has_live_page(self):

--- a/cfgov/ask_cfpb/tests/test_views.py
+++ b/cfgov/ask_cfpb/tests/test_views.py
@@ -275,8 +275,9 @@ class RedirectAskSearchTestCase(django.test.TestCase):
         request = HttpRequest()
         request.GET = QueryDict(audience_querystring)
         result = redirect_ask_search(request)
-        self.assertEqual(result.get('location'),
-                         '/ask-cfpb/audience-older-americans')
+        self.assertEqual(
+            result.get('location'),
+            '/ask-cfpb/audience-older-americans')
 
     def test_redirect_search_with_tag(self):
         target_tag = 'mytag1'
@@ -285,7 +286,19 @@ class RedirectAskSearchTestCase(django.test.TestCase):
             '&selected_facets=tag_exact:mytag2'.format(target_tag))
         request = HttpRequest()
         request.GET = QueryDict(tag_querystring)
-        result = redirect_ask_search(request)
+        result = redirect_ask_search(request, language='es')
         self.assertEqual(
             result.get('location'),
-            'es/obtener-respuestas/buscar-por-etiqueta/{}/'.format(target_tag))
+            '/es/obtener-respuestas/buscar-por-etiqueta/{}/'.format(
+                target_tag))
+
+    def test_redirect_search_with_english_tag_raises_404(self):
+        """Only Spanish tags are supported"""
+        target_tag = 'mytag1'
+        tag_querystring = (
+            'selected_facets=tag_exact:{}'
+            '&selected_facets=tag_exact:mytag2'.format(target_tag))
+        request = HttpRequest()
+        request.GET = QueryDict(tag_querystring)
+        with self.assertRaises(Http404):
+            redirect_ask_search(request, language='en')

--- a/cfgov/ask_cfpb/tests/test_views.py
+++ b/cfgov/ask_cfpb/tests/test_views.py
@@ -7,7 +7,7 @@ from model_mommy import mommy
 
 from django.apps import apps
 from django.core.urlresolvers import reverse, NoReverseMatch
-from django.http import HttpRequest, Http404
+from django.http import HttpRequest, Http404, QueryDict
 import django.test
 from django.utils import timezone
 from wagtail.wagtailcore.models import Site
@@ -242,7 +242,7 @@ class RedirectAskSearchTestCase(django.test.TestCase):
         with self.assertRaises(Http404):
             redirect_ask_search(request)
 
-    def test_redirect_search_no_category(self):
+    def test_redirect_search_blank_facets(self):
         request = HttpRequest()
         request.GET['selected_facets'] = ''
         with self.assertRaises(Http404):
@@ -254,9 +254,38 @@ class RedirectAskSearchTestCase(django.test.TestCase):
         with self.assertRaises(Http404):
             redirect_ask_search(request)
 
-    def test_redirect_search(self):
+    def test_redirect_search_with_category(self):
+        category_querystring = (
+            'selected_facets=category_exact:my_category'
+            '&selected_facets=category_exact:my_category2'
+            '&selected_facets=audience_exact:Older+Americans'
+            '&selected_facets=audience_exact:my_audience2'
+            '&selected_facets=tag_exact:mytag1'
+            '&selected_facets=tag_exact:mytag2')
         request = HttpRequest()
-        request.GET['selected_facets'] = 'category_exact:my_category'
+        request.GET = QueryDict(category_querystring)
         result = redirect_ask_search(request)
         self.assertEqual(result.get('location'),
                          '/ask-cfpb/category-my_category')
+
+    def test_redirect_search_with_audience(self):
+        audience_querystring = (
+            'selected_facets=audience_exact:Older+Americans'
+            '&selected_facets=audience_exact:my_audience2')
+        request = HttpRequest()
+        request.GET = QueryDict(audience_querystring)
+        result = redirect_ask_search(request)
+        self.assertEqual(result.get('location'),
+                         '/ask-cfpb/audience-older-americans')
+
+    def test_redirect_search_with_tag(self):
+        target_tag = 'mytag1'
+        tag_querystring = (
+            'selected_facets=tag_exact:{}'
+            '&selected_facets=tag_exact:mytag2'.format(target_tag))
+        request = HttpRequest()
+        request.GET = QueryDict(tag_querystring)
+        result = redirect_ask_search(request)
+        self.assertEqual(
+            result.get('location'),
+            'es/obtener-respuestas/buscar-por-etiqueta/{}/'.format(target_tag))

--- a/cfgov/ask_cfpb/views.py
+++ b/cfgov/ask_cfpb/views.py
@@ -178,10 +178,12 @@ def redirect_ask_search(request, language='en'):
                 '/ask-cfpb/audience-{audience}'.format(
                     audience=audience), permanent=True)
 
-        def redirect_to_tag(tag):
+        def redirect_to_tag(tag, language):
             """We currently only offer tag search to Spanish users"""
+            if language != 'es':
+                    raise Http404
             return redirect(
-                'es/obtener-respuestas/buscar-por-etiqueta/{tag}/'.format(
+                '/es/obtener-respuestas/buscar-por-etiqueta/{tag}/'.format(
                     tag=tag), permanent=True)
 
         # Redirect by facet value, if there is one, starting with category.
@@ -193,8 +195,6 @@ def redirect_ask_search(request, language='en'):
                 category = facet.replace(category_facet, '')
                 if category:
                     return redirect_to_category(category, language)
-                else:
-                    raise Http404
 
         for facet in facets:
             if audience_facet in facet:
@@ -202,13 +202,10 @@ def redirect_ask_search(request, language='en'):
                 if audience_raw:
                     audience = slugify(audience_raw.replace('+', '-'))
                     return redirect_to_audience(audience)
-                else:
-                    raise Http404
 
         for facet in facets:
             if tag_facet in facet:
-                tag = facet.replace(tag_facet, '')
-                if tag:
-                    return redirect_to_tag(tag)
-                else:
-                    raise Http404
+                raw_tag = facet.replace(tag_facet, '')
+                if raw_tag:
+                    tag = raw_tag.replace(' ', '_').replace('%20', '_')
+                    return redirect_to_tag(tag, language)

--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -575,7 +575,7 @@ FLAGS = {
 
     # Migration of Ask CFPB to Wagtail
     # When enabled, Ask CFPB is served from Wagtail
-    'WAGTAIL_ASK_CFPB': {},
+    'WAGTAIL_ASK_CFPB': {'boolean': True},
 
     # The next version of the public consumer complaint database
     'CCDB5_RELEASE': {},

--- a/cfgov/cfgov/urls.py
+++ b/cfgov/cfgov/urls.py
@@ -406,19 +406,6 @@ if settings.DEBUG:
     except ImportError:
         pass
 
-kb_patterns = [
-    url(r'^(?i)askcfpb/',
-        include_if_app_enabled(
-            'knowledgebase', 'knowledgebase.urls')),
-    url(r'^es/obtener-respuestas/',
-        include_if_app_enabled(
-            'knowledgebase', 'knowledgebase.babel_urls')),
-]
-
-# knowledgebase URLs will be left on until the final deployment step
-if settings.DEPLOY_ENVIRONMENT not in ['build']:
-    urlpatterns += kb_patterns
-
 redirect_patterns = [
     url(r'^askcfpb/$',
         RedirectView.as_view(
@@ -436,12 +423,8 @@ redirect_patterns = [
         redirect_ask_search,
         name='redirect-ask-search'),
 ]
-# redirects will be turned on in the final deploymnt step
-if settings.DEPLOY_ENVIRONMENT in ['build']:
-    urlpatterns += redirect_patterns
+urlpatterns += redirect_patterns
 
-# The base ask patterns will be exposed in the megamenu
-# when the WAGTAIL_ASK_CFPB feature flag is activated.
 ask_patterns = [
     url(r'^(?P<language>es)/obtener-respuestas/buscar/$',
         ask_search,

--- a/cfgov/cfgov/urls.py
+++ b/cfgov/cfgov/urls.py
@@ -426,7 +426,7 @@ redirect_patterns = [
 urlpatterns += redirect_patterns
 
 ask_patterns = [
-    url(r'^(?P<language>es)/obtener-respuestas/buscar/$',
+    url(r'^(?P<language>es)/obtener-respuestas/buscar/?$',
         ask_search,
         name='ask-search-es'),
     url(r'^(?P<language>es)/obtener-respuestas/buscar/(?P<as_json>json)/$',


### PR DESCRIPTION
This turns off knowledgebase URLs and turns on the redirects to send old
requests to the new cfgov-refresh ask_cfpb app.

Go-live also requires that the `WAGTAIL_ASK_CFPB` flag be set to True in
the admin after code is deployed, to change megamenu links.

We also pick add redirects to capture requests for legacy facet-built 
audience and tag pages.

The facet redirects give priority to category facets, then audience facets,
then tag facets. This should capture the great majority of old search links.

## Testing
These legacy URLs should get redirected:  
#### Category search
- http://localhost:8000/askcfpb/search/?selected_facets=category_exact%3Abank-accounts-and-services 
#### Audience search
- http://localhost:8000/askcfpb/search/?selected_facets=audience_exact%3AOlder+Americans
#### Tag search
- http://localhost:8000/es/obtener-respuestas/buscar?selected_facets=tag_exact:cobrador%20de%20deudas

