### PR TITLE
Keep uploaded meta image URLs relative

### DIFF
--- a/cfgov/jinja2/v1/_layouts/base.html
+++ b/cfgov/jinja2/v1/_layouts/base.html
@@ -65,10 +65,9 @@
         <meta property="og:type" content="{% block og_type %}website{% endblock %}">
         <meta property="og:url" content="{{ request.url }}">
     {% if page and page.meta_image %}
-        <meta property="og:image"
-              content="{{ image(page.meta_image, 'original').url }}">
-        <meta property="twitter:image"
-              content="{{ image(page.meta_image, 'original').url }}">
+        {% set meta_image_url = request.build_absolute_uri(image(page.meta_image, 'original').url) %}
+        <meta property="og:image" content="{{ meta_image_url }}">
+        <meta property="twitter:image" content="{{ meta_image_url }}">
     {% else %}
         <meta property="og:image"
               content="{{ request.scheme }}://{{ request.get_host() }}{{ static('img/logo_open-graph_facebook.png') }}">

--- a/cfgov/jinja2/v1/_layouts/base.html
+++ b/cfgov/jinja2/v1/_layouts/base.html
@@ -66,9 +66,9 @@
         <meta property="og:url" content="{{ request.url }}">
     {% if page and page.meta_image %}
         <meta property="og:image"
-              content="{{ request.scheme }}://{{ request.get_host() }}{{ image(page.meta_image, 'original').url }}">
+              content="{{ image(page.meta_image, 'original').url }}">
         <meta property="twitter:image"
-              content="{{ request.scheme }}://{{ request.get_host() }}{{ image(page.meta_image, 'original').url }}">
+              content="{{ image(page.meta_image, 'original').url }}">
     {% else %}
         <meta property="og:image"
               content="{{ request.scheme }}://{{ request.get_host() }}{{ static('img/logo_open-graph_facebook.png') }}">

--- a/cfgov/v1/tests/models/test_base.py
+++ b/cfgov/v1/tests/models/test_base.py
@@ -242,6 +242,7 @@ class TestCFGOVPageQuerySet(TestCase):
         save_new_page(page)
         self.check_live_counts(on_live_host=2)
 
+
 class TestFeedbackModel(TestCase):
     def setUp(self):
         self.test_feedback = Feedback(
@@ -250,7 +251,7 @@ class TestFeedbackModel(TestCase):
             is_helpful=True,
             referrer="http://www.consumerfinance.gov/owing-a-home/",
             submitted_on=datetime.datetime.now()
-            )
+        )
         self.test_feedback.save()
 
     def test_assemble_csv(self):

--- a/cfgov/v1/tests/test_meta_image.py
+++ b/cfgov/v1/tests/test_meta_image.py
@@ -1,7 +1,11 @@
-from django.test import TestCase
-from model_mommy import mommy
+import boto
+import moto
 
-from v1.models import AbstractFilterPage, CFGOVImage, CFGOVPage
+from django.test import TestCase, override_settings
+from model_mommy import mommy
+from wagtail.wagtailimages.tests.utils import get_test_image_file
+
+from v1.models import AbstractFilterPage, CFGOVImage, CFGOVPage, LearnPage
 
 
 class TestMetaImage(TestCase):
@@ -46,3 +50,75 @@ class TestMetaImage(TestCase):
             preview_image=self.preview_image
         )
         self.assertEqual(page.meta_image, page.social_sharing_image)
+
+    def test_template_meta_image_no_images(self):
+        """Template meta tags should fallback to standard social networks."""
+        page = mommy.prepare(LearnPage, social_sharing_image=None)
+        response = page.serve(page.dummy_request())
+        response.render()
+
+        self.assertContains(
+            response,
+            (
+                '<meta property="og:image" content='
+                '"http://localhost/static/img/logo_open-graph_facebook.png">'
+            ),
+            html=True
+        )
+
+        self.assertContains(
+            response,
+            (
+                '<meta property="twitter:image" content='
+                '"http://localhost/static/img/logo_open-graph_twitter.png">'
+            ),
+            html=True
+        )
+
+    def check_template_meta_image_url(self, expected_root):
+        """Template meta tags should use an absolute image URL."""
+        image_file = get_test_image_file(filename='foo.png')
+        image = mommy.make(CFGOVImage, file=image_file)
+        page = mommy.prepare(LearnPage, social_sharing_image=image)
+        response = page.serve(page.dummy_request())
+        response.render()
+
+        rendition_url = image.get_rendition('original').url
+
+        self.assertContains(
+            response,
+            (
+                '<meta property="og:image" content='
+                '"{}{}">'.format(expected_root, rendition_url)
+            ),
+            html=True
+        )
+
+    def test_template_meta_image_url(self):
+        """Meta image links should work if using local storage."""
+        self.check_template_meta_image_url(expected_root="http://localhost")
+
+    @override_settings(
+        AWS_QUERYSTRING_AUTH=False,
+        AWS_S3_ACCESS_KEY_ID='test',
+        AWS_S3_CALLING_FORMAT='boto.s3.connection.OrdinaryCallingFormat',
+        AWS_S3_ROOT='root',
+        AWS_S3_SECRET_ACCESS_KEY='test',
+        AWS_S3_SECURE_URLS=True,
+        AWS_STORAGE_BUCKET_NAME='test_s3_bucket',
+        DEFAULT_FILE_STORAGE='v1.s3utils.MediaRootS3BotoStorage'
+    )
+    def test_template_image_image_url_s3(self):
+        """Meta image links should work if using S3 storage."""
+        mock_s3 = moto.mock_s3()
+        mock_s3.start()
+
+        s3 = boto.connect_s3()
+        s3.create_bucket('test_s3_bucket')
+
+        try:
+            # There should be no root required as the image rendition URL
+            # should generate a fully qualified S3 path.
+            self.check_template_meta_image_url(expected_root='')
+        finally:
+            mock_s3.stop()

--- a/cfgov/v1/tests/test_meta_image.py
+++ b/cfgov/v1/tests/test_meta_image.py
@@ -61,7 +61,7 @@ class TestMetaImage(TestCase):
             response,
             (
                 '<meta property="og:image" content='
-                '"http://localhost/static/img/logo_open-graph_facebook.png">'
+                '"http://testserver/static/img/logo_open-graph_facebook.png">'
             ),
             html=True
         )
@@ -70,7 +70,7 @@ class TestMetaImage(TestCase):
             response,
             (
                 '<meta property="twitter:image" content='
-                '"http://localhost/static/img/logo_open-graph_twitter.png">'
+                '"http://testserver/static/img/logo_open-graph_twitter.png">'
             ),
             html=True
         )
@@ -96,7 +96,7 @@ class TestMetaImage(TestCase):
 
     def test_template_meta_image_url(self):
         """Meta image links should work if using local storage."""
-        self.check_template_meta_image_url(expected_root="http://localhost")
+        self.check_template_meta_image_url(expected_root="http://testserver")
 
     @override_settings(
         AWS_QUERYSTRING_AUTH=False,


### PR DESCRIPTION
In production the `image()` function in templates returns an absolute URL to the image's S3 location. In other environments it returns a relative URL. So prepending `{{ request.scheme }}://{{ request.get_host() }}` doesn't play nicely with production.

## Checklist

* [ ] PR has an informative and human-readable title
* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated
* [ ] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
