### PR TITLE
Don't let SheerlikeContext replace the context request.

### DIFF
--- a/cfgov/sheerlike/__init__.py
+++ b/cfgov/sheerlike/__init__.py
@@ -51,10 +51,14 @@ class SheerlikeContext(Context):
             parent,
             name,
             blocks)
-        try:
-            self.vars['request'] = get_request()
-        except:
-            pass
+
+        # Don't overwrite an existing request already coming into the context,
+        # for example one provided during Wagtail rendering.
+        if 'request' not in self.vars and 'request' not in self.keys():
+            try:
+                self.vars['request'] = get_request()
+            except:
+                pass
 
 # Monkey patch not needed in master version of Jinja2
 # https://github.com/mitsuhiko/jinja2/commit/f22fdd5ffe81aab743f78290071b0aa506705533

--- a/cfgov/v1/tests/test_meta_image.py
+++ b/cfgov/v1/tests/test_meta_image.py
@@ -61,7 +61,7 @@ class TestMetaImage(TestCase):
             response,
             (
                 '<meta property="og:image" content='
-                '"http://testserver/static/img/logo_open-graph_facebook.png">'
+                '"http://localhost/static/img/logo_open-graph_facebook.png">'
             ),
             html=True
         )
@@ -70,7 +70,7 @@ class TestMetaImage(TestCase):
             response,
             (
                 '<meta property="twitter:image" content='
-                '"http://testserver/static/img/logo_open-graph_twitter.png">'
+                '"http://localhost/static/img/logo_open-graph_twitter.png">'
             ),
             html=True
         )
@@ -96,7 +96,7 @@ class TestMetaImage(TestCase):
 
     def test_template_meta_image_url(self):
         """Meta image links should work if using local storage."""
-        self.check_template_meta_image_url(expected_root="http://testserver")
+        self.check_template_meta_image_url(expected_root="http://localhost")
 
     @override_settings(
         AWS_QUERYSTRING_AUTH=False,


### PR DESCRIPTION
This fixes some unit tests from #3036 that were breaking intermittently in a puzzling way. It turns out this is caused by how our [`SheerlikeContext`](https://github.com/cfpb/cfgov-refresh/blob/master/cfgov/sheerlike/__init__.py#L44) class (which is the default context class for Jinja templates) tries to handle and replace the context `request` object.

`SheerlikeContext` assumes that the current request is put on the local thread using [this](https://github.com/cfpb/cfgov-refresh/blob/master/cfgov/sheerlike/middleware.py#L26) middleware call, but in unit tests this doesn't always happen. Then when templates get rendered, `SheerlikeContext` tries to grab the local thread's request to stick it back in the context, but (since not every test updates this) it might be hanging around from an old test.

This change modifies how `SheerlikeContext` works so that it won't replace an existing `request` in the context if one is already there.

It also makes a minor fix to the tests in #3036 so that they pass properly, now that it's more clear what was going on. 

## Changes

- Make `SheerlikeContext` more conservative about updating the context's `request` object.

## Testing

1. Observe that all unit tests pass.
2. Locally test a page which is served by Sheerlike, for example [http://localhost:8000/owning-a-home/closing-disclosure/](http://localhost:8000/owning-a-home/closing-disclosure/).

## Checklist

* [X] PR has an informative and human-readable title
* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [x] Passes all existing automated tests
* [ ] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices
* [x] Project documentation has been updated
* [x] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
