### PR TITLE
Ask spanish tag fix

### DIFF
--- a/cfgov/ask_cfpb/models/django.py
+++ b/cfgov/ask_cfpb/models/django.py
@@ -119,10 +119,12 @@ class Category(models.Model):
     @property
     def top_tags_es(self):
         import collections
+        valid_list = Answer.valid_spanish_tags
         cleaned = []
         for a in self.answer_set.all():
             cleaned += a.tags_es
-        counter = collections.Counter(cleaned)
+        valid_clean = [tag for tag in cleaned if tag in valid_list]
+        counter = collections.Counter(valid_clean)
         return counter.most_common()[:10]
 
     @cached_property
@@ -389,7 +391,7 @@ class Answer(models.Model):
         """
         cleaned = []
         for a in cls.objects.all():
-            cleaned += a.tags_es
+            cleaned += (a.tags_es, a)
         tag_counter = Counter(cleaned)
         valid = sorted(
             tup[0] for tup in tag_counter.most_common() if tup[1] > 1)

--- a/cfgov/ask_cfpb/models/django.py
+++ b/cfgov/ask_cfpb/models/django.py
@@ -119,11 +119,12 @@ class Category(models.Model):
     @property
     def top_tags_es(self):
         import collections
-        valid_list = Answer.valid_spanish_tags
+        valid_dict = Answer.valid_spanish_tags()
         cleaned = []
         for a in self.answer_set.all():
             cleaned += a.tags_es
-        valid_clean = [tag for tag in cleaned if tag in valid_list]
+        valid_clean = [tag for tag in cleaned
+                       if tag in valid_dict['valid_tags']]
         counter = collections.Counter(valid_clean)
         return counter.most_common()[:10]
 
@@ -414,11 +415,6 @@ class Answer(models.Model):
             if page.live:
                 return True
         return False
-
-    @classmethod
-    def spanish_tag_map(cls):
-        tags = cls.valid_spanish_tags()
-
 
     def create_or_update_page(self, language=None):
         """Create or update an English or Spanish Answer page"""

--- a/cfgov/ask_cfpb/models/pages.py
+++ b/cfgov/ask_cfpb/models/pages.py
@@ -39,7 +39,7 @@ def get_valid_spanish_tags():
         sqs = SearchQuerySet().models(AnswerTagProxy)
         valid_spanish_tags = sqs.filter(content='tags')[0].valid_spanish
     except (IndexError, AttributeError):  # ES not available; go to plan B
-        valid_spanish_tags = Answer.valid_spanish_tags()
+        valid_spanish_tags = Answer.valid_spanish_tags()['valid_tags']
     return valid_spanish_tags
 
 

--- a/cfgov/ask_cfpb/models/pages.py
+++ b/cfgov/ask_cfpb/models/pages.py
@@ -195,7 +195,8 @@ class AnswerCategoryPage(RoutablePageMixin, CFGOVPage):
             context['disclaimer'] = get_reusable_text_snippet(
                 DISCLAIMER_SNIPPET_TITLE)
             context['breadcrumb_items'] = get_ask_breadcrumbs()
-
+        elif self.language == 'es':
+            context['tags'] = self.ask_category.top_tags_es
         return context
 
     # Returns an image for the page's meta Open Graph tag

--- a/cfgov/ask_cfpb/models/pages.py
+++ b/cfgov/ask_cfpb/models/pages.py
@@ -34,12 +34,12 @@ DISCLAIMER_SNIPPET_TITLE = 'Legal disclaimer for consumer materials'
 
 
 def get_valid_spanish_tags():
-    from ask_cfpb.models import AnswerTagProxy
+    from ask_cfpb.models import Answer, AnswerTagProxy
     try:
         sqs = SearchQuerySet().models(AnswerTagProxy)
         valid_spanish_tags = sqs.filter(content='tags')[0].valid_spanish
     except (IndexError, AttributeError):  # ES not available; go to plan B
-        valid_spanish_tags = AnswerTagProxy.valid_spanish_tags()
+        valid_spanish_tags = Answer.valid_spanish_tags()
     return valid_spanish_tags
 
 
@@ -368,15 +368,15 @@ class TagResultsPage(RoutablePageMixin, AnswerResultsPage):
     @route(r'^(?P<tag>[^/]+)/$')
     def buscar_por_etiqueta(self, request, **kwargs):
         from ask_cfpb.models import Answer
-        valid_tags = get_valid_spanish_tags()
+        tag_dict = Answer.valid_spanish_tags()
         tag = kwargs.get('tag').replace('_', ' ')
-        if not tag or tag not in valid_tags:
+        if not tag or tag not in tag_dict['valid_tags']:
             raise Http404
         self.answers = [
             (SPANISH_ANSWER_SLUG_BASE.format(a.id),
              a.question_es,
              Truncator(a.answer_es).words(40, truncate=' ...'))
-            for a in Answer.objects.filter(search_tags_es__contains=tag)
+            for a in tag_dict['tag_map'][tag]
         ]
         context = self.get_context(request)
         context['tag'] = tag
@@ -462,8 +462,9 @@ class AnswerPage(CFGOVPage):
                     slugify(audience.name))}
             for audience in self.answer_base.audiences.all()]
         if self.language == 'es':
+            tag_dict = self.Answer.valid_spanish_tags()
             context['tags_es'] = [tag for tag in self.answer_base.tags_es
-                                  if tag in get_valid_spanish_tags()]
+                                  if tag in tag_dict['valid_tags']]
             context['tweet_text'] = Truncator(self.question).chars(
                 100, truncate=' ...')
 

--- a/cfgov/ask_cfpb/tests/models/test_pages.py
+++ b/cfgov/ask_cfpb/tests/models/test_pages.py
@@ -190,8 +190,8 @@ class AnswerModelTestCase(TestCase):
             json.loads(facet_map)['subcategories']['1'], [])
 
     def test_answer_valid_tags(self):
-        test_list = Answer.valid_spanish_tags()
-        self.assertIn('hipotecas', test_list)
+        test_dict = Answer.valid_spanish_tags()
+        self.assertIn('hipotecas', test_dict['valid_tags'])
 
     def test_get_valid_tags(self):
         from ask_cfpb.models import get_valid_spanish_tags


### PR DESCRIPTION
Workaround for encoding issue for Spanish search tags

And encoding issue is preventing Spanish search tags with diacritical
marks from being found in Django `field__contains` queries and from
Elasticsearch indexing.  

This PR avoids both the `field__contains` search and
Elasticsearch in building the master list of valid tags and a mapping of tags-to-answers, 
which is more accurate than the previous method.

## Testing
This code is currently running on Build (build `#763`), and can be tested there by going to a Spanish category page, seeing if accented tag links show up in the right sidebar and seeing if the tag links resolve.

http://build.consumerfinance.gov/es/obtener-respuestas/categoria-obtener-una-tarjeta-de-credito/

Any merge will overwrite Build, so it might not last long.