### PR TITLE
Migrate cf-buttons to cfv4

### DIFF
--- a/cfgov/jinja2/v1/_includes/atoms/submit-button.html
+++ b/cfgov/jinja2/v1/_includes/atoms/submit-button.html
@@ -1,7 +1,7 @@
 {% macro render(value) -%}
 
 <div class="o-form-actions">
-    <input class="btn btn__super form-actions_item"
+    <input class="a-btn a-btn__super form-actions_item"
            type="submit"
            value="{{ value.button_text }}">
 </div>

--- a/cfgov/jinja2/v1/_includes/blocks/feedback.html
+++ b/cfgov/jinja2/v1/_includes/blocks/feedback.html
@@ -6,15 +6,15 @@
 
     {# JS-disabled result handling #}
 
-<div class="o-feedback 
+<div class="o-feedback
 			block
 	        {% if value.was_it_helpful_text %}
 		        block__bg
 		        block__border
 		        block__padded-top
-	        {% endif %}" 
-	        {% if value.radio_intro %} 
-	        	data-replace="true" 
+	        {% endif %}"
+	        {% if value.radio_intro %}
+	        	data-replace="true"
 	        {% endif %}>
 	<div class="u-mb15">
         {% if get_messages(request) %}
@@ -29,7 +29,7 @@
 	      action="."
 	      class="o-form"
 	      novalidate>
-	      
+
 	<div class="form-l">
 	    <input type="hidden" name="csrfmiddlewaretoken" value="{{ csrf_token }}">
 	    <input type="hidden" name="form_id" value="{{ form_id }}">
@@ -181,7 +181,7 @@
 	                    form-l_col-1">
 	            <label for="email">
 	                <h3>Contact email</h3>
-	                <input id="form_email" type="email" name="email">      
+	                <input id="form_email" type="email" name="email">
 	            </label>
 	    <p>{{ value.contact_advisory }}</p>
 	        </div>
@@ -193,7 +193,7 @@
 	    <fieldset class="o-form-input-group">
 	        <div class="form-l_col
 	                    form-l_col-1">
-	            <button class="btn" type="submit">{{ value.button_text }}</button>
+	            <button class="a-btn" type="submit">{{ value.button_text }}</button>
 	        </div>
 	    </fieldset>
 	  </div>

--- a/cfgov/jinja2/v1/_includes/macros/filters.html
+++ b/cfgov/jinja2/v1/_includes/macros/filters.html
@@ -353,10 +353,10 @@
         <div class="form-l_col
                     form-l_col__flush-bottom
                     form-l_col-1">
-            <input class="btn form-actions_item"
+            <input class="a-btn form-actions_item"
                    type="submit"
                    value="{{ options.submit_label }}">
-            <a class="btn btn__warning btn__link"
+            <a class="a-btn a-btn__warning a-btn__link"
                    href="{{ request.path }}">
                     Reset filters
             </a>

--- a/cfgov/jinja2/v1/_includes/macros/subscribe.html
+++ b/cfgov/jinja2/v1/_includes/macros/subscribe.html
@@ -36,7 +36,7 @@
     </p>
     <div class="form-group">
         <input type="hidden" name="code" value="{{ gd_code }}">
-        <input class="btn" type="submit" value="Sign up">
+        <input class="a-btn" type="submit" value="Sign up">
     </div>
 
 </form>

--- a/cfgov/jinja2/v1/_includes/molecules/call-to-action.html
+++ b/cfgov/jinja2/v1/_includes/molecules/call-to-action.html
@@ -38,8 +38,8 @@
     {% endif %}
 
     {% if value.button %}
-    <a class="btn btn__full
-             {{ 'btn__super' if value.button.size == 'large' else '' }}"
+    <a class="a-btn a-btn__full-on-xs
+             {{ 'a-btn__super' if value.button.size == 'large' else '' }}"
        href="{{ value.button.url or '/' }}">
         {{ value.button.text }}
     </a>

--- a/cfgov/jinja2/v1/_includes/molecules/form-field-with-button.html
+++ b/cfgov/jinja2/v1/_includes/molecules/form-field-with-button.html
@@ -43,5 +43,5 @@
                {{ 'required' if value.required else '' }}>
     </div>
     {{ parse_links(value.info) | safe }}
-    <input class="btn btn__full" type="submit" value="{{ value.btn_text }}">
+    <input class="a-btn a-btn__full-on-xs" type="submit" value="{{ value.btn_text }}">
 </div>

--- a/cfgov/jinja2/v1/_includes/molecules/global-search.html
+++ b/cfgov/jinja2/v1/_includes/molecules/global-search.html
@@ -52,7 +52,7 @@
                            placeholder="Search the CFPB">
                 </div>
                 <div class="input-with-btn_btn">
-                    <button class="btn" type="submit">Search</button>
+                    <button class="a-btn" type="submit">Search</button>
                 </div>
             </div>
 

--- a/cfgov/jinja2/v1/_includes/molecules/hero.html
+++ b/cfgov/jinja2/v1/_includes/molecules/hero.html
@@ -68,7 +68,7 @@
             <div class="m-hero_subhead">{{ parse_links(value.body) | safe }}</div>
             {% for link in value.links %}
                 <a class="m-hero_cta
-                          {{ 'btn' if value.is_button else '' }}"
+                          {{ 'a-btn' if value.is_button else '' }}"
                    href="{{ link.url }}"
                 {% if value.cta_link_color %}
                     style="color: {{ value.cta_link_color }};"

--- a/cfgov/jinja2/v1/_includes/molecules/info-unit.html
+++ b/cfgov/jinja2/v1/_includes/molecules/info-unit.html
@@ -99,7 +99,7 @@
                         {% endif %}
                         {% include 'contact-email.html' with context %}
                     {% else %}
-                        {% set link_class = 'btn m-info-unit_btn' if
+                        {% set link_class = 'a-btn m-info-unit_btn' if
                             value.is_button else 'list_link' %}
                         {% set link_text = link.text if link.text
                             else 'Learn More' %}

--- a/cfgov/jinja2/v1/_includes/molecules/pagination.html
+++ b/cfgov/jinja2/v1/_includes/molecules/pagination.html
@@ -32,38 +32,38 @@
          role="navigation"
          aria-label="Pagination">
         {%- if current_page > 1 %}
-        <a class="btn
-                  btn__super
+        <a class="a-btn
+                  a-btn__super
                   m-pagination_btn-prev"
            href="?page={{ (current_page - 1) ~
                           url_parameters(request.GET) ~
                           fragment_id }}">
         {%- else %}
-        <a class="btn
-                  btn__super
-                  btn__disabled
+        <a class="a-btn
+                  a-btn__super
+                  a-btn__disabled
                   m-pagination_btn-prev">
         {% endif %}
-            <span class="btn_icon__left
+            <span class="a-btn_icon__on-left
                          cf-icon
                          cf-icon-left"></span>
             {{ prev_text }}
         </a>
         {%- if current_page < total_pages %}
-        <a class="btn
-                  btn__super
+        <a class="a-btn
+                  a-btn__super
                   m-pagination_btn-next"
            href="?page={{ (current_page + 1) ~
                           url_parameters(request.GET) ~
                           fragment_id }}">
         {%- else %}
-        <a class="btn
-                  btn__super
-                  btn__disabled
+        <a class="a-btn
+                  a-btn__super
+                  a-btn__disabled
                   m-pagination_btn-next">
         {% endif -%}
             {{ next_text }}
-            <span class="btn_icon__right
+            <span class="a-btn_icon__on-right
                          cf-icon
                          cf-icon-right"></span>
         </a>
@@ -95,8 +95,8 @@
             <span class="m-pagination_label">
                 of {{ total_pages }}
             </span>
-            <button class="btn
-                           btn__link
+            <button class="a-btn
+                           a-btn__link
                            m-pagination_submit-btn"
                     type="submit">
                 Go

--- a/cfgov/jinja2/v1/_includes/organisms/bureau-structure.html
+++ b/cfgov/jinja2/v1/_includes/organisms/bureau-structure.html
@@ -261,9 +261,9 @@
                 Download a printable, PDF copy of this organizational chart. This version
                 is expanded to show all offices.
             </p>
-            <a class="btn"
+            <a class="a-btn"
                href="{{ download_image_url }}">
-                <span class="btn_icon__left cf-icon cf-icon-save"></span>
+                <span class="a-btn_icon__on-left cf-icon cf-icon-save"></span>
                 Download PNG
             </a>
         </div>

--- a/cfgov/jinja2/v1/_includes/organisms/email-popup.html
+++ b/cfgov/jinja2/v1/_includes/organisms/email-popup.html
@@ -41,7 +41,7 @@
                   </a>
                   <br/>
                 </p>
-                <input class="btn btn__full" type="submit" value="Sign up">
+                <input class="a-btn a-btn__full-on-xs" type="submit" value="Sign up">
               </div>
               <div class="form-group">
                 <input type="hidden" name="code" value="USCFPB_127">

--- a/cfgov/jinja2/v1/_includes/organisms/filterable-list-controls.html
+++ b/cfgov/jinja2/v1/_includes/organisms/filterable-list-controls.html
@@ -163,10 +163,10 @@
             <div class="form-l_col
                         form-l_col__flush-bottom
                         form-l_col-1">
-                <input class="btn form-actions_item"
+                <input class="a-btn form-actions_item"
                        type="submit"
                        value="Apply filters">
-                <a class="btn btn__warning btn__link"
+                <a class="a-btn a-btn__warning a-btn__link"
                    href="{{ request.path }}">
                     Clear filters
                 </a>

--- a/cfgov/jinja2/v1/_includes/organisms/footer.html
+++ b/cfgov/jinja2/v1/_includes/organisms/footer.html
@@ -19,8 +19,8 @@
 
         <div class="o-footer_pre">
 
-            <a class="btn
-                      btn__secondary
+            <a class="a-btn
+                      a-btn__secondary
                       o-footer_top-button"
                 data-gtm_ignore="true"
                 data-js-hook="behavior_return-to-top"

--- a/cfgov/jinja2/v1/_includes/organisms/header.html
+++ b/cfgov/jinja2/v1/_includes/organisms/header.html
@@ -39,7 +39,7 @@
                     </p>
                 </div>
             </div>
-            <button class="btn
+            <button class="a-btn
                            m-global-banner_btn
                            o-expandable_target
                            o-expandable_link"

--- a/cfgov/jinja2/v1/_includes/organisms/reg-comment.html
+++ b/cfgov/jinja2/v1/_includes/organisms/reg-comment.html
@@ -81,7 +81,7 @@
             identifying or contact information.
         </p>
 
-        <input class="btn btn__full" type="submit" value="Submit your feedback">
+        <input class="a-btn a-btn__full-on-xs" type="submit" value="Submit your feedback">
 
         <input type="hidden" name="comment_on" value="{{ value.document_id }}">
     </form>

--- a/cfgov/jinja2/v1/_includes/organisms/search-bar.html
+++ b/cfgov/jinja2/v1/_includes/organisms/search-bar.html
@@ -10,7 +10,7 @@
 
    value:                     An object used to customize the markup.
 
-   value.position:            The location of the bar on the page: 
+   value.position:            The location of the bar on the page:
                                 left: in a main section with a right sidebar
                                 right: in a main section with a left nav sidebar
                                 full: in a full-width page.
@@ -28,13 +28,13 @@
 {% macro render( value ) %}
 
 <aside class="o-search-bar
-              block 
-              block__bg 
+              block
+              block__bg
               {% if value.position == 'full' %}
                 o-search-bar__full
               {% else %}
                 o-search-bar__with-sidebar
-                block__flush-sides 
+                block__flush-sides
                 block__bg-extend-{{ value.position }}
               {% endif %}
               {{ value.additional_classes }}" >
@@ -52,7 +52,7 @@
                     <input type="text" name="q" id="q" >
                 </div>
                 <div class="input-with-btn_btn">
-                    <button class="btn" name="btnSearch" id="btnSearch" type="submit">
+                    <button class="a-btn" name="btnSearch" id="btnSearch" type="submit">
                         Search
                     </button>
                 </div>

--- a/cfgov/jinja2/v1/_includes/post-macros.html
+++ b/cfgov/jinja2/v1/_includes/post-macros.html
@@ -72,22 +72,22 @@
          aria-label="Pagination"
          data-ajax-action="posts-paginated.html">
     {%- if query_obj.current_page > 1 %}
-        <a class="btn btn__super pagination_prev"
+        <a class="a-btn a-btn__super pagination_prev"
            href="{{ query_obj.url_for_page(query_obj.current_page - 1) }}#pagination_content">
     {%- else %}
-        <a class="btn btn__super btn__disabled pagination_prev">
+        <a class="a-btn a-btn__super a-btn__disabled pagination_prev">
     {% endif %}
-            <span class="btn_icon__left cf-icon cf-icon-left"></span>
+            <span class="a-btn_icon__on-left cf-icon cf-icon-left"></span>
             Newer
         </a>
     {%- if query_obj.current_page < query_obj.pages %}
-        <a class="btn btn__super pagination_next"
+        <a class="a-btn a-btn__super pagination_next"
            href="{{ query_obj.url_for_page(query_obj.current_page + 1) }}#pagination_content">
     {%- else %}
-        <a class="btn btn__super btn__disabled pagination_next">
+        <a class="a-btn a-btn__super a-btn__disabled pagination_next">
     {% endif -%}
             Older
-            <span class="btn_icon__right cf-icon cf-icon-right"></span>
+            <span class="a-btn_icon__on-right cf-icon cf-icon-right"></span>
         </a>
         <form class="pagination_form" action="#pagination_content">
             <label class="pagination_label" for="pagination_current-page">
@@ -122,7 +122,7 @@
             <span class="pagination_label" aria-hidden="true">
                 of {{ query_obj.pages }}
             </span>
-            <button class="btn btn__link pagination_submit"
+            <button class="a-btn a-btn__link pagination_submit"
                     id="pagination_submit"
                     type="submit">
                 Go

--- a/cfgov/jinja2/v1/_includes/rss.html
+++ b/cfgov/jinja2/v1/_includes/rss.html
@@ -4,8 +4,8 @@
 <p data-qa-hook="rss-subscribe-desc">
     Subscribe to our RSS feed to get the latest content in your reader.
 </p>
-<a class="btn" href="{{ path }}">
-    <span class="btn_icon__left cf-icon cf-icon-rss"></span>
+<a class="a-btn" href="{{ path }}">
+    <span class="a-btn_icon__on-left cf-icon cf-icon-rss"></span>
     Subscribe to RSS
 </a>
 

--- a/cfgov/jinja2/v1/_includes/templates/upcoming-events.html
+++ b/cfgov/jinja2/v1/_includes/templates/upcoming-events.html
@@ -5,5 +5,5 @@
         </span>
     </h2>
     <p>Check out our upcoming events.</p>
-    <a class="btn" href="/about-us/events/">Find out more</a>
+    <a class="a-btn" href="/about-us/events/">Find out more</a>
 </div>

--- a/cfgov/jinja2/v1/_layouts/404.html
+++ b/cfgov/jinja2/v1/_layouts/404.html
@@ -22,16 +22,16 @@
 
     <div class="error_action_container">
         <div class="error_action_col">
-            <a href="/" class="btn btn__full btn__error-home u-inline-block">Visit homepage</a>
+            <a href="/" class="a-btn a-btn__full-on-xs btn__error-home u-inline-block">Visit homepage</a>
         </div>
         <div class="error_action_col">
-            <a class="btn btn__full btn__error-home u-inline-block" href="/about-us/contact-us/">
+            <a class="a-btn a-btn__full-on-xs btn__error-home u-inline-block" href="/about-us/contact-us/">
                 Contact us
             </a>
         </div>
     </div>
-    
-    <p>Are you sure this is the right web address? 
+
+    <p>Are you sure this is the right web address?
         <a class="jump-link" href={{"mailto:CFPB_website@consumerfinance.gov?subject=404%20Error%20at%20%22" + request.build_absolute_uri() + "%22"}}>
             <span class="jump-link_text">Let us know</span>
         </a>

--- a/cfgov/jinja2/v1/_layouts/500.html
+++ b/cfgov/jinja2/v1/_layouts/500.html
@@ -23,16 +23,16 @@
 
         <aside class="error_action_container">
             <div class="error_action_col">
-                <a href="/" class="btn btn__full btn__error-home u-inline-block">Visit homepage</a>
+                <a href="/" class="a-btn a-btn__full-on-xs btn__error-home u-inline-block">Visit homepage</a>
             </div>
             <div class="error_action_col">
-                <a class="btn btn__full btn__error-home u-inline-block" href="/about-us/contact-us/">
+                <a class="a-btn a-btn__full-on-xs btn__error-home u-inline-block" href="/about-us/contact-us/">
                     Contact us
                 </a>
             </div>
         </aside>
 
-        <p>Are you sure this is the right web address? 
+        <p>Are you sure this is the right web address?
             <a class="jump-link" href={{"mailto:CFPB_website@consumerfinance.gov?subject=500%20Error%20at%20%22" + request.build_absolute_uri() + "%22"}} >
                 <span class="jump-link_text">Let us know</span>
             </a>
@@ -46,4 +46,3 @@
     {% include '/js/routes/common.js' %}
 </script>
 {% endblock javascript %}
-

--- a/cfgov/jinja2/v1/_layouts/spanish-ask-base.html
+++ b/cfgov/jinja2/v1/_layouts/spanish-ask-base.html
@@ -83,7 +83,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
         </div><!-- .brand -->
 
         <nav role="navigation" class="main-nav js-showtoggle">
-            <button class="btn js-showtoggle-trigger s-show-on-small"><img src="{{ static('nemo/_/img/icon-menu-retina.png') }}" alt="Main Menu"></button>
+            <button class="a-btn js-showtoggle-trigger s-show-on-small"><img src="{{ static('nemo/_/img/icon-menu-retina.png') }}" alt="Main Menu"></button>
             <ul class="js-showtoggle-content">
                 <li><a href="/es/">Inicio</a></li>
                 <li class="s-active"><a href="/es/obtener-respuestas/">Obtener respuestas</a></li>
@@ -151,10 +151,10 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
                 <li><a href="http://youtube.com/CFPB" hreflang="en-US"><img src="{{ static("nemo/_/img/icon-youtube-retina.png") }}" alt="Youtube" class="icon-25"></a></li>
             </ul>
             <p class="s-show-on-small"><small>Un sitio web oficial del gobierno federal de <span class="usa">los Estados Unidos <img src="{{ static('nemo/_/img/us_flag_small.png') }}" alt=""></span></small></p>
-            <p><a class="btn btn-block-on-small english-link" href="/" hreflang="en-US">English</a></p>
+            <p><a class="a-btn btn-block-on-small english-link" href="/" hreflang="en-US">English</a></p>
         </nav>
         <div class="js-showtoggle policy">
-            <button class="js-showtoggle-trigger btn btn-block-on-small">Política de información</button>
+            <button class="a-btn btn-block-on-small js-showtoggle-trigger">Política de información</button>
             <div class="js-showtoggle-content">
                 <div class="row">
                     <div class="span4">

--- a/cfgov/jinja2/v1/ask-cfpb/answer-page-spanish.html
+++ b/cfgov/jinja2/v1/ask-cfpb/answer-page-spanish.html
@@ -33,9 +33,9 @@
                 <span class="split-left"><a class="print" href="{{ request.url }}imprimir/">
                         <img src="{{ static('nemo/_/img/icon-print-retina.png') }}" alt="" class="icon-20"> <span class="share-label">Imprimir</span></a></span>
                 <span class="split-right"><span class="share-label">Compartir esta página</span>
-                    
+
                     {% include "ask/share-links-spanish.html" with context %}
-                    
+
                 </span>
             </aside><!-- .supplement -->
             <div class="supplement">
@@ -72,7 +72,7 @@
             {% endfor %}
 
             <section class="supplement supplement-plain js-showtoggle ac-disclaimer">
-                <button class="btn btn-block btn-block-on-small js-showtoggle-trigger">Acerca de estas respuestas</button>
+                <button class="a-btn btn-block btn-block-on-small js-showtoggle-trigger">Acerca de estas respuestas</button>
                 <div class="js-showtoggle-content well">
                     Estas respuestas se proveen solamente para efectos informativos generales. Si bien no le aconsejarán sobre su situación exacta, esperamos que le ayuden a entender mejor los productos y servicios financieros. Estas respuestas no constituyen asesoramiento legal ni interpretación del CFPB.
                 </div>
@@ -92,7 +92,7 @@
 {% block babel_share %}
     <div class="share s-show-on-small" data-set="share">
         <span><span class="share-label">Compartir esta página</span>
-            
+
             {% include "ask/share-links-spanish.html" %}
 
         </span>

--- a/cfgov/jinja2/v1/ask-cfpb/answer-page.html
+++ b/cfgov/jinja2/v1/ask-cfpb/answer-page.html
@@ -30,7 +30,7 @@
 
 
 {% block content_main_modifiers -%}
-    {{ super() }} content__flush-bottom 
+    {{ super() }} content__flush-bottom
 {%- endblock %}
 
 {% block content_main %}
@@ -54,7 +54,7 @@
                 {{ page.snippet | safe }}
             </h3>
         {% endif %}
-        <div data-qa-hook="expandable" 
+        <div data-qa-hook="expandable"
              data-read-more="true"
              class="o-expandable
                     o-expandable__read-more">
@@ -63,7 +63,7 @@
                     <div class="answer-text">
                         {{ page.answer | richtext | safe }}
                     </div>
-                    {% if audiences %} 
+                    {% if audiences %}
                     <div class="u-mt15">
                         {{ tags.render( {'links': audiences}, '', is_wagtail=True) }}
                     </div>
@@ -79,7 +79,7 @@
                     </div>
                     {% endif %}
                 </div>
-            </div>            
+            </div>
             <a class="o-expandable_target jump-link o-expandable_link" title="Expand content">
                 <span class="jump-link_text">
                     <span class="o-expandable_cue o-expandable_cue-open">
@@ -93,7 +93,7 @@
                 </span>
             </a>
         </div>
-        
+
 
     </div>
     {{ ask_search_bar.render( 'left' ) }}
@@ -132,7 +132,7 @@
                         </li>
                     {% endfor %}
                     <li class="list_item">
-                      <a class="btn category-button" href="{{slugurl('category-' + category.slug)}}"> 
+                      <a class="a-btn category-button" href="{{slugurl('category-' + category.slug)}}"> 
                         See all {{category.name | lower}} questions
                       </a>
                     </li>
@@ -156,7 +156,7 @@
                             {{ question.question | safe }}
                         </a>
                         </li>
-                    {% endfor %}  
+                    {% endfor %}
                 </ul>
             </div>
         </div>
@@ -166,4 +166,3 @@
          data-category-slug="{{ category.slug }}">
     </div>
 {% endblock %}
-

--- a/cfgov/jinja2/v1/events/_macros.html
+++ b/cfgov/jinja2/v1/events/_macros.html
@@ -87,8 +87,7 @@
         <div class="event-venue_details">
             <header class="event-venue_header">
                 {% if ( event_state == 'present' ) %}
-                <button class="btn
-                          event-venue_live-btn">
+                <button class="a-btn event-venue_live-btn">
                     <span class="cf-icon cf-icon-livestream"></span>
                     <span class="event-venue_live-btn_text">Live</span>
                 </button>

--- a/cfgov/jinja2/v1/events/event.html
+++ b/cfgov/jinja2/v1/events/event.html
@@ -38,8 +38,8 @@
 {#        {% if event_state and event_state != 'future' %}#}
 {#            <p class="event-footer_banner">#}
 {#                <span class="event-footer_banner-message h4">This event requires an RSVP. Reserve your spot here: </span>#}
-{#                <a href="mailto:reserve@cfpb.gov?subject=Event RSVP&body=To RSVP, please fill in your first and last name below and send this email.%0D%0A%0D%0AFirst name:%0D%0ALast name:" class="btn">#}
-{#                    <span class="btn_icon__left cf-icon cf-icon-email-social"></span>#}
+{#                <a href="mailto:reserve@cfpb.gov?subject=Event RSVP&body=To RSVP, please fill in your first and last name below and send this email.%0D%0A%0D%0AFirst name:%0D%0ALast name:" class="a-btn">#}
+{#                    <span class="a-btn_icon__on-left cf-icon cf-icon-email-social"></span>#}
 {#                     reserve@cfpb.gov</a>#}
 {#            </p>#}
 {#        {% endif %}#}

--- a/cfgov/jinja2/v1/external-site/index.html
+++ b/cfgov/jinja2/v1/external-site/index.html
@@ -48,9 +48,9 @@
             <span class="external-site_reload-container" ></span>
         </p>
         <form method="POST" action="{{ url('external-site') }}" id="proceed">
-        <input type="button" 
-           class="btn
-                  btn__full
+        <input type="button"
+           class="a-btn
+                  a-btn__full-on-xs
                   external-site_proceed-btn"
            value="Proceed to external site">
         {{ form }}

--- a/cfgov/jinja2/v1/job-description-page/index.html
+++ b/cfgov/jinja2/v1/job-description-page/index.html
@@ -34,7 +34,7 @@
         </dl>
         <div class="content-l">
             <div class="content-l_col content-l_col-1-2">
-                <a href="#interested" class="btn">
+                <a href="#interested" class="a-btn">
                     Interested in applying?
                 </a>
             </div>
@@ -109,7 +109,7 @@
     </section>
 
     {% set usajobs_links = page.usajobs_application_links.order_by(
-      'applicant_type' 
+      'applicant_type'
     ) %}
     {% for usajobs_link in usajobs_links %}
     <div class="block
@@ -117,7 +117,7 @@
                 block__border">
         <h4>{{ usajobs_link.applicant_type.applicant_type }}</h4>
         <p>{{ usajobs_link.applicant_type.description }}</p>
-        <p><a class="btn" href="{{ usajobs_link.url }}">Apply now</a></p>
+        <p><a class="a-btn" href="{{ usajobs_link.url }}">Apply now</a></p>
         <p>
             You are about to leave consumerfinance.gov. To submit the
             application, you must go to USAJobs.gov.
@@ -131,7 +131,7 @@
                 block__border">
         <h4>{{ email_link.label }}</h4>
         {% if email_link.description %}<p>{{ email_link.description }}</p>{% endif %}
-        <p><a class="btn" href="{{ email_link.mailto_link | safe }}">Email us</a></p>
+        <p><a class="a-btn" href="{{ email_link.mailto_link | safe }}">Email us</a></p>
     </div>
     {% endfor %}
 

--- a/cfgov/unprocessed/css/enhancements/buttons.less
+++ b/cfgov/unprocessed/css/enhancements/buttons.less
@@ -1,30 +1,376 @@
+// BEGIN CF4 BUTTONS - TODO: delete when CFV4 is added to package.json
 
-/* topdoc
-  name: Full Width Buttons
-  family: cf-enhancements
-  notes:
-    - "Modifier to buttons full width at small screen sizes"
-  patterns:
-    - name: Default example
-      markup: |
-        <btn class="btn btn__full">Button Text</btn>
-  tags:
-    - cf-buttons
-*/
+//
+// Theme variables
+//
 
-.btn__full { // Moved to CF, delete freely when migrating to CF4
+// Color variables
+// $color- variables are from 18F's U.S. Web Design Standards
+// https://github.com/18F/web-design-standards/blob/18f-pages-staging/src/stylesheets/core/_variables.scss
 
-    .respond-to-max(@bp-xs-max, {
-        display: block;
-        width: 100%;
+// .btn
+// .btn
+@btn-text:                      #ffffff; // $color-white
+@btn-bg:                        #0071bc; // $color-primary
+@btn-bg-hover:                  #205493; // $color-primary-darker
+@btn-bg-active:                 #112e51; // $color-primary-darkest
 
-        + .btn__full {
-            margin-left: initial;
-        }
-    });
+// .btn__secondary
+@btn__secondary-text:           #212121; // $color-base
+@btn__secondary-bg:             #9bdaf1; // $color-primary-alt-light
+@btn__secondary-bg-hover:       #02bfe7; // $color-primary-alt
+@btn__secondary-bg-active:      #00a6d2; // $color-primary-alt-dark
+
+// .btn__warning
+@btn__warning-text:             #ffffff; // $color-white
+@btn__warning-bg:               #e31c3d; // $color-secondary
+@btn__warning-bg-hover:         #cd2026; // $color-secondary-dark
+@btn__warning-bg-active:        #981b1e; // $color-secondary-darkest
+
+// .btn__disabled
+@btn__disabled-text:            darken( greyscale( #c7336e ), 10% );
+@btn__disabled-bg:              lighten( greyscale( #c7336e ), 40% );
+@btn__disabled-outline:         greyscale( #c7336e );
+
+// Sizing variables
+
+// .btn
+@btn-font-size:                 @base-font-size-px;
+@btn-border-radius-size:        4px;
+@btn-v-padding:                 8px;
+@btn-h-padding:                 14px;
+@btn-v-padding-modifier-ie:     0.8;
+
+// .btn__super
+@btn__super-font-size:          18px;
+
+//
+// Default button
+//
+
+.a-btn {
+  .u-webfont-medium();
+
+  appearance: none;
+
+  display: inline-block;
+
+  box-sizing: border-box;
+  padding:
+    unit( @btn-v-padding / @btn-font-size, em )
+    unit( @btn-h-padding / @btn-font-size, em );
+  border: 0;
+  margin: 0;
+
+  border-radius: unit( @btn-border-radius-size / @btn-font-size, em );
+  cursor: pointer;
+  font-size: unit( @btn-font-size / @base-font-size-px, em );
+  line-height: normal;
+  text-align: center;
+  text-decoration: none;
+  transition: background-color 0.1s;
+
+  &,
+  &:link,
+  &:visited {
+    background-color: @btn-bg;
+    color: @btn-text;
+  }
+
+  &:hover,
+  &.hover,
+  &:focus,
+  &.focus {
+    background-color: @btn-bg-hover;
+  }
+
+  &:focus,
+  &.focus {
+    outline: 1px dotted @btn-bg;
+    // The outline-offset property is not supported everywhere (e.g. IE)
+    // but it adds a nice touch in browsers where it is.
+    outline-offset: 1px;
+  }
+
+  &:active,
+  &.active {
+    background-color: @btn-bg-active;
+  }
+
+  button&::-moz-focus-inner,
+  input&::-moz-focus-inner {
+    // Fixes inconsistent button.btn height in Firefox.
+    // Helps with inconsistent input.btn height in Firefox but not completely.
+    border: 0;
+  }
+
+  // Fixes button and input sizes in IE7.
+  .lt-ie8 button&,
+  .lt-ie8 input& {
+    overflow: visible;
+    padding-top: unit( @btn-v-padding-modifier-ie * @btn-v-padding / @btn-font-size, em );
+    padding-bottom: unit( @btn-v-padding-modifier-ie * @btn-v-padding / @btn-font-size, em );
+  }
+
+  //
+  // Secondary button
+  //
+
+  &__secondary {
+    &,
+    &:link,
+    &:visited {
+      background-color: @btn__secondary-bg;
+      color: @btn__secondary-text;
+    }
+
+    &:hover,
+    &.hover,
+    &:focus,
+    &.focus {
+      background-color: @btn__secondary-bg-hover;
+    }
+
+    &:focus,
+    &.focus {
+      outline-color: @btn__secondary-bg;
+    }
+
+    &:active,
+    &.active {
+      background-color: @btn__secondary-bg-active;
+    }
+  }
+
+  //
+  // Destructive action button
+  //
+
+  &__warning {
+    &,
+    &:link,
+    &:visited {
+      background-color: @btn__warning-bg;
+      color: @btn__warning-text;
+    }
+
+    &:hover,
+    &.hover,
+    &:focus,
+    &.focus {
+      background-color: @btn__warning-bg-hover;
+    }
+
+    &:focus,
+    &.focus {
+      outline-color: @btn__warning-bg;
+    }
+
+    &:active,
+    &.active {
+      background-color: @btn__warning-bg-active;
+    }
+  }
+
+  //
+  // Disabled button
+  //
+
+  &__disabled,
+  &[disabled] {
+    &,
+    &:link,
+    &:visited,
+    &:hover,
+    &.hover,
+    &:focus,
+    &.focus,
+    &:active,
+    &.active {
+      background-color: @btn__disabled-bg;
+      color: @btn__disabled-text;
+      cursor: default; // Fallback for IE/Opera
+      cursor: not-allowed;
+    }
+
+    &:focus,
+    &.focus {
+      outline-color: @btn__disabled-outline;
+    }
+  }
+
+  //
+  // Super button
+  //
+
+  &__super {
+    padding:
+      unit( 11px / @btn__super-font-size, em )
+      unit( 29px / @btn__super-font-size, em );
+    font-size: unit( @btn__super-font-size / @base-font-size-px, em );
+
+    // Fixes button and input sizes in IE7.
+    .lt-ie8 button&,
+    .lt-ie8 input& {
+      padding-top: unit( @btn-v-padding-modifier-ie * 15px / @btn__super-font-size, em );
+      padding-bottom: unit( @btn-v-padding-modifier-ie * 15px / @btn__super-font-size, em );
+    }
+  }
+
+  //
+  // Full width button on x-small screens
+  //
+  &__full-on-xs {
+    .respond-to-max( @bp-xs-max, {
+      display: block;
+      width: 100%;
+    } );
+  }
 }
 
-/* topdoc
-  name: EOF
-  eof: true
-*/
+// END CF4 BUTTONS
+
+// BEGIN CF4 BUTTONS-WITH-ICONS - TODO: delete when CFV4 is added to package.json
+
+// Icon locations
+
+.a-btn_icon__on-left {
+    padding-right: unit( 10.5px / @btn-font-size, em );
+    border-right: 1px solid mix( @btn-bg, @btn-text, 50% );
+    margin-right: unit( 7px / @btn-font-size, em );
+}
+
+.a-btn_icon__on-right {
+    padding-left: unit( 10.5px / @btn-font-size, em );
+    border-left: 1px solid mix( @btn-bg, @btn-text, 50% );
+    margin-left: unit( 7px / @btn-font-size, em );
+}
+
+
+.a-btn_icon {
+    .a-btn__secondary & {
+        border-color: mix( @btn__secondary-bg, @btn__secondary-text, 50% );
+    }
+
+    .a-btn__warning & {
+        border-color: mix( @btn__warning-bg, @btn__warning-text, 50% );
+    }
+
+    .a-btn__disabled &,
+    .a-btn[disabled] & {
+        border-color: mix( @btn__disabled-bg, @btn__disabled-text, 50% );
+    }
+}
+
+// END CF4 BUTTONS-WITH-ICONS
+
+// BEGIN CF4 BUTTONS-LINKS - TODO: delete when CFV4 is added to package.json
+
+//
+// Button link
+//
+
+.a-btn__link {
+  padding: 0;
+
+  border-bottom: 1px dotted @link-underline;
+  border-radius: 0;
+
+  &,
+  &:link,
+  &:visited {
+    background-color: transparent;
+    border-bottom-color: @link-underline-visited;
+    color: @link-text-visited;
+  }
+
+  &:hover,
+  &.hover {
+    background-color: transparent;
+    border-bottom: 1px solid @link-underline-hover;
+    color: @link-text-hover;
+  }
+
+  &:focus,
+  &.focus {
+    border-bottom-style: solid;
+    background-color: transparent;
+    outline: 1px dotted @link-underline;
+  }
+
+  &:active,
+  &.active {
+    border-bottom: 1px solid @link-underline-active;
+    background-color: transparent;
+    color: @link-text-active;
+  }
+
+  .lt-ie8 button&,
+  .lt-ie8 input& {
+    padding: 0;
+  }
+
+  //
+  // Secondary button link
+  //
+
+  &.a-btn__secondary {
+    &,
+    &:link,
+    &:visited {
+      border-bottom-color: @btn__secondary-bg;
+      background-color: transparent;
+      color: @btn__secondary-bg;
+    }
+
+    &:hover,
+    &.hover {
+      border-bottom-color: @btn__secondary-bg-hover;
+      color: @btn__secondary-bg-hover;
+    }
+
+    &:focus,
+    &.focus {
+      outline-color: @btn__secondary-bg;
+    }
+
+    &:active,
+    &.active {
+      border-bottom-color: @btn__secondary-bg-active;
+      color: @btn__secondary-bg-active;
+    }
+  }
+
+  //
+  // Destructive action button link
+  //
+
+  &.a-btn__warning {
+    &,
+    &:link,
+    &:visited {
+      border-bottom-color: @btn__warning-bg;
+      background-color: transparent;
+      color: @btn__warning-bg;
+    }
+
+    &:hover,
+    &.hover {
+      border-bottom-color: @btn__warning-bg-hover;
+      color: @btn__warning-bg-hover;
+    }
+
+    &:focus,
+    &.focus {
+      outline-color: @btn__warning-bg;
+    }
+
+    &:active,
+    &.active {
+      border-bottom-color: @btn__warning-bg-active;
+      color: @btn__warning-bg-active;
+    }
+  }
+}
+
+// END CF4 BUTTONS-LINKS

--- a/cfgov/unprocessed/css/misc.less
+++ b/cfgov/unprocessed/css/misc.less
@@ -16,10 +16,10 @@
                         <button class="btn btn__secondary">
                             Filter activities
                             <span class="expandable_cue-open">
-                                <span class="btn_icon__right cf-icon cf-icon-down"></span>
+                                <span class="a-btn_icon__on-right cf-icon cf-icon-down"></span>
                             </span>
                             <span class="expandable_cue-close">
-                                <span class="btn_icon__right cf-icon cf-icon-up"></span>
+                                <span class="a-btn_icon__on-right cf-icon cf-icon-up"></span>
                             </span>
                         </button>
                     </span>
@@ -41,10 +41,10 @@
                         <button class="btn btn__secondary">
                             Filter activities
                             <span class="expandable_cue-open">
-                                <span class="btn_icon__right cf-icon cf-icon-down"></span>
+                                <span class="a-btn_icon__on-right cf-icon cf-icon-down"></span>
                             </span>
                             <span class="expandable_cue-close">
-                                <span class="btn_icon__right cf-icon cf-icon-up"></span>
+                                <span class="a-btn_icon__on-right cf-icon cf-icon-up"></span>
                             </span>
                         </button>
                     </span>

--- a/cfgov/unprocessed/css/molecules/call-to-action.less
+++ b/cfgov/unprocessed/css/molecules/call-to-action.less
@@ -7,7 +7,7 @@
           <div class="m-call-to-action">
               <div class="m-call-to-action_text">
               </div>
-              <a class="btn btn__full" href="/">
+              <a class="a-btn a-btn__full-on-xs" href="/">
               </a>
           </div>
       codenotes:
@@ -16,8 +16,8 @@
           -----------------------
           .m-call-to-action
             .m-call-to-action_text
-            .btn.btn__full
-            .btn.btn__large
+            .a-btn.a-btn__full-on-xs
+            .a-btn.a-btn__super
   tags:
     - cfgov-molecules
 */

--- a/cfgov/unprocessed/css/molecules/form-field-with-button.less
+++ b/cfgov/unprocessed/css/molecules/form-field-with-button.less
@@ -14,7 +14,7 @@
             </div>
             <p class="short-desc">
             </p>
-            <input class="btn btn__full" type="" value="">
+            <input class="a-btn a-btn__full-on-xs" type="" value="">
         </div>
       codenotes:
         - |

--- a/cfgov/unprocessed/css/molecules/global-banner.less
+++ b/cfgov/unprocessed/css/molecules/global-banner.less
@@ -38,7 +38,9 @@
     }
 
     .o-expandable_target {
-        .btn__secondary();
+        // Taken from .a-btn__secondary.
+        background-color: @btn__secondary-bg;
+        color: @btn__secondary-text;
         width: 100%;
         // Restore standard btn padding, which is removed by .expandable_target.
         padding:

--- a/cfgov/unprocessed/css/molecules/hero.less
+++ b/cfgov/unprocessed/css/molecules/hero.less
@@ -92,7 +92,7 @@
     }
 
     &_subhead,
-    &_cta:not( .btn ) {
+    &_cta:not( .a-btn ) {
         // Not using the `.intro-pagraph()` mixin here because we want the
         // size to change at a different breakpoint.
         font-size: @size-iv;
@@ -116,11 +116,11 @@
 
         margin-top: unit( @grid_gutter-width / 2 / @size-iv, em );
 
-        &.btn {
+        &.a-btn {
             margin-top: unit( @grid_gutter-width / 2 / @btn-font-size, em );
         }
 
-        &:not( .btn ) {
+        &:not( .a-btn ) {
             border-bottom-width: 1px;
         }
 
@@ -260,7 +260,7 @@
             color: @hero-overlay-cta;
         }
 
-        .m-hero_cta.btn {
+        .m-hero_cta.a-btn {
             // Prevent inline style from CMS from overriding button text color.
             color: @btn-text !important;
         }

--- a/cfgov/unprocessed/css/molecules/pagination.less
+++ b/cfgov/unprocessed/css/molecules/pagination.less
@@ -6,12 +6,12 @@
       markup: |
           <nav class="m-pagination">
               <a class="btn btn__super m-pagination_btn_prev" href="#o-pagination-content_list">
-                  <span class="btn_icon__left cf-icon cf-icon-left"></span>
+                  <span class="a-btn_icon__on-left cf-icon cf-icon-left"></span>
                   Previous
               </a>
               <a class="btn btn__super m-pagination_btn_next" href="#o-pagination-content_list">
                   Next
-                  <span class="btn_icon__right cf-icon cf-icon-right"></span>
+                  <span class="a-btn_icon__on-right cf-icon cf-icon-right"></span>
               </a>
               <form action="#o-pagination-content_list">
                   <label for="m-pagination_current-page">

--- a/cfgov/unprocessed/css/organisms/email-popup.less
+++ b/cfgov/unprocessed/css/organisms/email-popup.less
@@ -66,7 +66,7 @@
 
     .respond-to-max( @bp-xs-max, {
       background: none;
-      .m-form-field-with-button .btn {
+      .m-form-field-with-button .a-btn {
         width: 100%;
       }
 
@@ -99,7 +99,7 @@
           position: relative;
           top: .7em;
         }
-        .btn {
+        .a-btn {
           float: left;
         }
       }

--- a/cfgov/unprocessed/css/organisms/email-signup.less
+++ b/cfgov/unprocessed/css/organisms/email-signup.less
@@ -19,7 +19,7 @@
                       <input type="email"
                              class="m-form-field-with-button_field">
                   </div>
-                  <input class="btn btn__full" type="submit">
+                  <input class="a-btn a-btn__full-on-xs" type="submit">
               </div>
           </form>
       codenotes:
@@ -31,7 +31,7 @@
             .m-form-field-with-button
               .form-group
                 .m-form-field-with-button_field
-              .btn.btn_full
+              .a-btn.a-btn__full-on-xs
   tags:
     - cfgov-organisms
 */

--- a/cfgov/unprocessed/css/organisms/form.less
+++ b/cfgov/unprocessed/css/organisms/form.less
@@ -51,7 +51,7 @@
     margin-bottom: unit( @grid_gutter-width * 2 / @base-font-size-px, em);
 
     .respond-to-max(@bp-sm-max, {
-        .btn {
+        .a-btn {
             width: 100%;
         }
     });

--- a/cfgov/unprocessed/css/pages/error.less
+++ b/cfgov/unprocessed/css/pages/error.less
@@ -6,7 +6,7 @@
 .error_action_container {
     margin: unit( @grid_gutter-width / @base-font-size-px, em ) 0;
 
-    .btn {
+    .a-btn {
         margin: unit( ( @grid_gutter-width / 2 ) / @base-font-size-px, em ) 0;
     }
 
@@ -25,7 +25,7 @@
             }
         }
 
-        .btn {
+        .a-btn {
             margin: unit( ( @grid_gutter-width / 4 ) / @base-font-size-px, em ) 0;
         }
     });
@@ -67,7 +67,7 @@
         color: @white;
         border-color: @white;
         margin-top: unit( ( @grid_gutter-width / 4 ) / @base-font-size-px, em );
-    } 
+    }
 
     &__404 {
         .content_main {
@@ -90,13 +90,13 @@
 
             .respond-to-min(@bp-med-min, {
                 background-size: contain;
-            }); 
-            
+            });
+
         }
     }
 
     &__500 {
-        
+
         .main_wrapper {
 
             background: transparent url('../img/server.png') no-repeat right top;
@@ -115,7 +115,7 @@
             .respond-to-range(@bp-sm-min, @bp-sm-max, {
                 background-size: 40%;
             });
-            
+
         }
     }
 }

--- a/cfgov/unprocessed/css/pages/event.less
+++ b/cfgov/unprocessed/css/pages/event.less
@@ -274,7 +274,7 @@
             display: block;
         }
 
-        .btn {
+        .a-btn {
             text-align: center;
         }
 

--- a/cfgov/unprocessed/css/skip-nav.less
+++ b/cfgov/unprocessed/css/skip-nav.less
@@ -20,8 +20,13 @@
 }
 
 #skip-nav:focus {
-    .btn;
-    .btn__super;
+    .a-btn;
+    // Taken from .a-btn__super.
+    padding:
+      unit( 11px / 18px, em )
+      unit( 29px / 18px, em );
+    font-size: unit( 18px / @base-font-size-px, em );
+
     position: absolute;
     top: 0;
     outline: 0;

--- a/test/unit_tests/molecules/GlobalBanner-spec.js
+++ b/test/unit_tests/molecules/GlobalBanner-spec.js
@@ -51,7 +51,7 @@ describe( 'Global Banner State', function() {
                     'www.consumerfinance.gov</a>.' +
             '</p>' +
         '</div>' +
-        '<button class="btn ' +
+        '<button class="a-btn ' +
                        'm-global-banner_btn ' +
                        'o-expandable_target ' +
                        'o-expandable_link" id="m-global-banner_btn" ' +

--- a/test/unit_tests/organisms/Footer-spec.js
+++ b/test/unit_tests/organisms/Footer-spec.js
@@ -14,7 +14,7 @@ var sandbox;
 var lastTime = 0;
 
 var HTML_SNIPPET =
-    '<a class="btn btn__secondary o-footer_top-button" ' +
+    '<a class="a-btn a-btn__secondary o-footer_top-button" ' +
         'data-gtm_ignore="true" data-js-hook="behavior_return-to-top" ' +
         'href="#">' +
         'Back to top <span class="cf-icon cf-icon-arrow-up"></span>' +


### PR DESCRIPTION
Short description explaining the high-level reason for the pull request

## Additions

- cf-buttons styles moved temporarily to enhancements.

## Changes

- Updates outdated `btn` classes to `a-btn`.

## Testing

1. `./frontend.sh` and site should look the same as prod.

## Notes

- Pagination disabled button background color is darker than the pagination background. This will have to be revisited when updating the pagination module.
