### PR TITLE
Migrate cf-core to cfv4

### DIFF
--- a/cfgov/legacy/static/nemo/_/consumerstories/css/consumerstories.css
+++ b/cfgov/legacy/static/nemo/_/consumerstories/css/consumerstories.css
@@ -12324,10 +12324,10 @@ input[type="number"].pagination_current-page {
           appropriate fonts."
     - name: Webfont mixins
       codenotes:
-        - ".webfont-regular()"
-        - ".webfont-italic()"
-        - ".webfont-medium()"
-        - ".webfont-demi()"
+        - ".u-webfont-regular()"
+        - ".u-webfont-italic()"
+        - ".u-webfont-medium()"
+        - ".u-webfont-demi()"
       notes:
         - "Use these mixins to easily add the Avenir Next font family to your
           elements."

--- a/cfgov/unprocessed/css/enhancements/base.less
+++ b/cfgov/unprocessed/css/enhancements/base.less
@@ -1,28 +1,592 @@
-/* ==========================================================================
-   cfgov-refresh
-   capital framework enhancements
-   ========================================================================== */
+// BEGIN enhancement for normalize-legacy-addon
 
-/* topdoc
-  name: Body Font
-  family: cf-core
-  notes:
-    - "Set the body to Avenir Regular."
-    - "Hides overflow on mobile sizes."
-  patterns:
-    - name: Body
-      codenotes:
-        - |
-          body
-  tags:
-    - cf-core
-*/
+/*
+ * Corrects list images handled incorrectly in IE 7.
+ */
 
-body {
-    .webfont-regular(); // Moved to CF, delete freely when migrating to CF4
+nav ul,
+nav ol,
+nav ul ul,
+nav ol ol {
+    list-style: none;
+    list-style-image: none;
 }
 
-/* topdoc
-  name: EOF
-  eof: true
-*/
+// END enhancement for normalize-legacy-addon
+
+// BEGIN CF4 CORE - TODO: delete when CFV4 is added to package.json
+
+/* ==========================================================================
+   Capital Framework
+   Base styles
+   ========================================================================== */
+
+//
+// Webfonts
+//
+
+.u-webfont-regular() {
+    font-family: @webfont-regular, Arial, sans-serif;
+    font-style: normal;
+    font-weight: normal;
+
+    & em,
+    & i {
+        .u-webfont-italic();
+    }
+
+    & strong,
+    & b {
+        .u-webfont-demi();
+    }
+}
+
+.u-webfont-italic() {
+    font-family: @webfont-italic, Arial, sans-serif;
+    font-style: italic;
+    font-weight: normal;
+
+    .lt-ie9 & {
+        font-style: normal !important;
+    }
+}
+
+.u-webfont-medium() {
+    font-family: @webfont-medium, Arial, sans-serif;
+    font-style: normal;
+    font-weight: 500;
+
+    .lt-ie9 & {
+        font-weight: normal !important;
+    }
+}
+
+.u-webfont-demi() {
+    font-family: @webfont-demi, Arial, sans-serif;
+    font-style: normal;
+    font-weight: bold;
+
+    .lt-ie9 & {
+        font-weight: normal !important;
+    }
+}
+
+//
+// Type hierarchy
+//
+
+body {
+    .u-webfont-regular();
+
+    color: @text;
+    font-size: unit( @base-font-size-px / 16 * 100, % );
+    line-height: @base-line-height;
+}
+
+.heading-1( @fs: @size-i ) {
+    @font-size: @fs;
+    .u-webfont-regular();
+
+    margin-bottom: unit( 15px / @font-size, em );
+    font-size: unit( @font-size / @base-font-size-px, em );
+    line-height: 1.25;
+}
+
+.heading-2( @fs: @size-ii ) {
+    @font-size: @fs;
+    .u-webfont-regular();
+
+    margin-bottom: unit( 15px / @font-size, em );
+    font-size: unit( @font-size / @base-font-size-px, em );
+    line-height: 1.25;
+}
+
+.heading-3( @fs: @size-iii )  {
+    @font-size: @fs;
+    .u-webfont-regular();
+
+    margin-bottom: unit( 15px / @font-size, em );
+    font-size: unit( @font-size / @base-font-size-px, em );
+    line-height: 1.25;
+}
+
+.heading-4( @fs: @size-iv )  {
+    @font-size: @fs;
+    .u-webfont-medium();
+
+    margin-bottom: unit( 15px / @font-size, em );
+    font-size: unit( @font-size / @base-font-size-px, em );
+    line-height: 1.25;
+}
+
+.heading-5( @fs: @size-v )  {
+    @font-size: @fs;
+    .u-webfont-demi();
+
+    margin-bottom: unit( 15px / @font-size, em );
+    font-size: unit( @font-size / @base-font-size-px, em );
+    letter-spacing: 1px;
+    line-height: 1.25;
+    text-transform: uppercase;
+}
+
+.heading-6( @fs: @size-vi )  {
+    @font-size: @fs;
+    .u-webfont-demi();
+
+    margin-bottom: unit( 15px / @font-size, em );
+    font-size: unit( @font-size / @base-font-size-px, em );
+    letter-spacing: 1px;
+    line-height: 1.25;
+    text-transform: uppercase;
+}
+
+// Resetting default browser styling for margin-top on headings
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+    margin-top: 0;
+}
+
+h1,
+.h1 {
+    .heading-1();
+
+    p + &,
+    ul + &,
+    ol + &,
+    dl + &,
+    figure + &,
+    img + &,
+    table + &,
+    blockquote + & {
+        margin-top: unit( 60px / @font-size, em );
+    }
+
+    .respond-to-max( @bp-xs-max, {
+        .heading-2();
+
+        p + &,
+        ul + &,
+        ol + &,
+        dl + &,
+        figure + &,
+        img + &,
+        table + &,
+        blockquote + & {
+            margin-top: unit( 45px / @font-size, em );
+        }
+
+        h2 + &,
+        .h2 + &,
+        h3 + &,
+        .h3 + &,
+        h4 + &,
+        .h4 + &,
+        h5 + &,
+        .h5 + &,
+        h6 + &,
+        .h6 + & {
+            margin-top: unit( 30px / @font-size, em );
+        }
+    } );
+}
+
+h2,
+.h2 {
+    .heading-2();
+
+    p + &,
+    ul + &,
+    ol + &,
+    dl + &,
+    figure + &,
+    img + &,
+    table + &,
+    blockquote + & {
+        margin-top: unit( 45px / @font-size, em );
+    }
+
+    h1 + &,
+    .h1 + &,
+    h3 + &,
+    .h3 + &,
+    h4 + &,
+    .h4 + &,
+    h5 + &,
+    .h5 + &,
+    h6 + &,
+    .h6 + & {
+        margin-top: unit( 30px / @font-size, em );
+    }
+
+    .respond-to-max( @bp-xs-max, {
+        .heading-3();
+
+        p + &,
+        ul + &,
+        ol + &,
+        dl + &,
+        figure + &,
+        img + &,
+        table + &,
+        blockquote + & {
+            margin-top: unit( 30px / @font-size, em );
+        }
+    } );
+}
+
+h3,
+.h3 {
+    .heading-3();
+
+    p + &,
+    ul + &,
+    ol + &,
+    dl + &,
+    figure + &,
+    img + &,
+    table + &,
+    blockquote + &,
+    h1 + &,
+    .h1 + &,
+    h2 + &,
+    .h2 + &,
+    h4 + &,
+    .h4 + &,
+    h5 + &,
+    .h5 + &,
+    h6 + &,
+    .h6 + & {
+        margin-top: unit( 30px / @font-size, em );
+    }
+
+    .respond-to-max( @bp-xs-max, {
+        .heading-4();
+    } );
+}
+
+h4,
+.h4 {
+    .heading-4();
+
+    p + &,
+    ul + &,
+    ol + &,
+    dl + &,
+    figure + &,
+    img + &,
+    table + &,
+    blockquote + &,
+    h1 + &,
+    .h1 + &,
+    h2 + &,
+    .h2 + &,
+    h3 + &,
+    .h3 + &,
+    h5 + &,
+    .h5 + &,
+    h6 + &,
+    .h6 + & {
+        margin-top: unit( 30px / @font-size, em );
+    }
+}
+
+h5,
+.h5 {
+    .heading-5();
+
+    p + &,
+    ul + &,
+    ol + &,
+    dl + &,
+    figure + &,
+    img + &,
+    table + &,
+    blockquote + &,
+    h1 + &,
+    .h1 + &,
+    h2 + &,
+    .h2 + &,
+    h3 + &,
+    .h3 + &,
+    h4 + &,
+    .h4 + &,
+    h6 + &,
+    .h6 + & {
+        margin-top: unit( 30px / @font-size, em );
+    }
+}
+
+h6,
+.h6 {
+    .heading-6();
+
+    p + &,
+    ul + &,
+    ol + &,
+    dl + &,
+    figure + &,
+    img + &,
+    table + &,
+    blockquote + &,
+    h1 + &,
+    .h1 + &,
+    h2 + &,
+    .h2 + &,
+    h3 + &,
+    .h3 + &,
+    h4 + &,
+    .h4 + &,
+    h5 + &,
+    .h5 + & {
+        margin-top: unit( 30px / @font-size, em );
+    }
+}
+
+.lead-paragraph {
+    .heading-3();
+
+    margin-top: unit( 30px / @font-size, em );
+    margin-bottom: unit( 15px / 18px, em );
+
+    .respond-to-max(@bp-xs-max, {
+        // Use the same regular weight but reduce the sizes to h4 size
+        margin-top: unit( 30px / 18px, em );
+        font-size: unit( 18px / @base-font-size-px, em );
+    });
+}
+
+.superheading {
+    // For when you want a heading that's bigger than a normal H1
+    @font-size: @size-xl;
+    .u-webfont-regular();
+
+    margin-bottom: unit( 20px / @font-size, em );
+    font-size: unit( @font-size / @base-font-size-px, em );
+    line-height: 1.25;
+}
+
+//
+// Body copy element vertical margins
+//
+
+p,
+ul,
+ol,
+dl,
+figure,
+table,
+blockquote {
+    margin-top: 0;
+    margin-bottom: unit( 15px / @base-font-size-px, em );
+
+    &:last-child {
+        margin-bottom: 0;
+    }
+}
+
+p + ul,
+p + ol {
+    margin-top: unit( -5px / @base-font-size-px, em );
+}
+
+ul ul,
+ol ol,
+ul ol,
+ol ul {
+    margin-top: unit( 8px / @base-font-size-px, em );
+}
+
+li {
+    margin-bottom: unit( 8px / @base-font-size-px, em );
+
+    &:last-child,
+    nav & {
+        margin-bottom: 0;
+    }
+}
+
+//
+// Default link
+//
+
+a {
+    border-width: 0;
+    border-style: dotted;
+    border-color: @link-underline;
+    color: @link-text;
+    text-decoration: none;
+
+    // Note: The class definitions below are only for use in
+    // demonstrating link states. Do not use in production.
+
+    &:visited,
+    &.visited {
+        border-color: @link-underline-visited;
+        color: @link-text-visited;
+    }
+
+    &:hover,
+    &.hover {
+        border-style: solid;
+        border-color: @link-underline-hover;
+        color: @link-text-hover;
+    }
+
+    &:focus,
+    &.focus {
+        border-style: solid;
+        outline: thin dotted;
+    }
+
+    &:active,
+    &.active {
+        border-style: solid;
+        border-color: @link-underline-active;
+        color: @link-text-active;
+    }
+}
+
+//
+// Underlined links
+//
+
+p,
+li,
+dd {
+    // Restrict bottom borders to inline text links ...
+
+    a {
+        border-bottom-width: 1px;
+    }
+}
+
+nav a {
+    // ... unless they're part of a nav list
+    border-bottom-width: 0;
+}
+
+//
+// Lists
+//
+
+ul, ol {
+    padding-left: unit( 18px / @base-font-size-px, em );
+}
+
+ul {
+    list-style: square;
+}
+
+ul ul {
+    list-style-type: circle;
+}
+
+//
+// Tables
+//
+
+th,
+td {
+    padding: unit( 10px / @base-font-size-px, em );
+
+    thead & {
+        .h5();
+
+        padding: unit( 10px / @font-size, em );
+        background: @thead-bg;
+        color: @thead-text;
+    }
+}
+
+thead,
+tbody tr {
+    border-bottom: 1px solid @table-border;
+}
+
+th {
+    .u-webfont-demi();
+
+    text-align: left;
+}
+
+//
+// Block quote
+//
+
+blockquote {
+    margin-right: unit( 15px / @base-font-size-px, em );
+    margin-left: unit( 15px / @base-font-size-px, em );
+
+    .respond-to-min( @bp-sm-min, {
+        margin-right: unit( 30px / @base-font-size-px, em );
+        margin-left: unit( 30px / @base-font-size-px, em );
+    } );
+}
+
+//
+// Form elements have been moved to the cf-forms component
+//
+
+//
+// Images
+//
+
+img {
+    max-width: 100%;
+}
+
+//
+// Figure
+//
+
+figure {
+    // reset browser default side margins
+    margin-right: 0;
+    margin-left: 0;
+
+    img {
+        // Removes weird vertical spacing below images.
+        // TODO: Discuss whether this could just be universally applied to img
+        vertical-align: middle;
+    }
+}
+
+//
+// Code blocks
+//
+
+pre,
+code {
+    background: @code-bg;
+    border-radius: 4px;
+    color: @code-text;
+    font-family: 'Input Mono', Consolas, Monaco, 'Courier New', monospace;
+}
+
+code {
+    display: inline-block;
+    padding: unit( 3px / @size-code, em )
+             unit( 3px / @size-code, em )
+             0;
+    font-size: unit( @size-code / @base-font-size-px, em );
+}
+
+pre {
+    display: block;
+    padding: unit( 10px / @base-font-size-px, em)
+             unit( 15px / @base-font-size-px, em );
+    white-space: pre-wrap;
+    overflow-wrap: break-word;
+
+    code {
+        padding: 0;
+        background-color: transparent;
+    }
+}
+
+// END CF4 CORE

--- a/cfgov/unprocessed/css/enhancements/forms.less
+++ b/cfgov/unprocessed/css/enhancements/forms.less
@@ -13,7 +13,7 @@ input[type="tel"],
 input[type="number"],
 textarea,
 select[multiple] {
-    .webfont-regular();
+    .u-webfont-regular();
 }
 
 /* topdoc
@@ -324,14 +324,14 @@ legend {
           .input-with-btn.input-with-btn__bar
             .input-with-btn_input
             .input-with-btn_btn
-  notes: "Displays as single unit, with button attached to end of input. 
+  notes: "Displays as single unit, with button attached to end of input.
           Input fills all space that is not needed for button."
   tags:
     - cf-form
 */
 
 .input-with-btn__bar {
-    display: table; 
+    display: table;
     width: 100%;
 
     @supports( display: flex ) {
@@ -356,11 +356,11 @@ legend {
     .input-with-btn_btn {
         margin: 0;
         border: 0;
-        display: table-cell; 
+        display: table-cell;
         // overrides default .input-with-btn_btn width.
         // setting button to very small width & input to 100%
         // means button will only take up space it needs
-        width: 1%; 
+        width: 1%;
         vertical-align: middle;
 
         @supports( display: flex ) {

--- a/cfgov/unprocessed/css/enhancements/media-queries.less
+++ b/cfgov/unprocessed/css/enhancements/media-queries.less
@@ -1,39 +1,45 @@
-/* topdoc
-  name: respond-to-print() (mixin)
-  notes:
-    - "This mixin allows us to easily write styles that target both
-       `@media print` and `.print`."
-  family: media-queries
-  patterns:
-    - name: Usage
-      codenotes:
-        - |
-          // Example Less
-          .example {
-              color: @gray;
+// BEGIN CF4 CORE - TODO: delete when CFV4 is added to package.json
 
-              .respond-to-print({
-                  color: @black;
-              });
-          }
+/* ==========================================================================
+   Capital Framework
+   Media queries
+   ========================================================================== */
 
-          // Exports to
-          .example {
-              color: #75787B;
-          }
-          @media print {
-              .example {
-                  color: #101820;
-              }
-          }
-          .print .example {
-              color: #101820;
-          }
-  tags:
-    - cfgov-cf-enhancements
-*/
+//
+// Media query mixins
+//
 
-.respond-to-print(@rules) {
+.respond-to-min( @bp, @rules ) {
+    @ems: unit( ( @bp / @base-font-size-px ), em );
+    @media only all and ( min-width: @ems ) {
+        @rules();
+    }
+}
+
+.respond-to-max( @bp, @rules ) {
+    @ems: unit( ( @bp / @base-font-size-px ), em);
+    @media only all and ( max-width: @ems ) {
+        @rules();
+    }
+}
+
+.respond-to-range( @bp1, @bp2, @rules ) {
+    @ems1: unit( ( @bp1 / @base-font-size-px ), em );
+    @ems2: unit( ( @bp2 / @base-font-size-px ), em );
+    @media only all and ( min-width: @ems1 ) and ( max-width: @ems2 ) {
+        @rules();
+    }
+}
+
+// TODO: Discuss whether to split this into min and max queries.
+.respond-to-dpi( @ratio, @rules ) {
+    @dpi: ( @ratio * 96dpi );
+    @media ( min-device-pixel-ratio: @ratio ), ( min-resolution: @dpi ) {
+        @rules();
+    }
+}
+
+.respond-to-print( @rules ) {
     @media print {
         @rules();
     }
@@ -41,48 +47,4 @@
         @rules();
     }
 }
-
-/* topdoc
-  name: respond-to-dpi(@ratio) (mixin)
-  notes:
-    - "This mixin allows us to easily write styles
-    that target high-resolution screens,
-    such as Apple retina screens"
-  family: cfgov-cf-enhancements
-  patterns:
-    - name: Usage
-      codenotes:
-        - |
-          // Example Less
-          .example {
-              background: url(regular-resolution-image.png);
-
-              .respond-to-dpi(2, {
-                  background-image: url(retina-image.png);
-              });
-          }
-
-          // Exports to
-          .example {
-              background: url(regular-resolution-image.png);
-          }
-          @media (-webkit-min-device-pixel-ratio: 2), (min-resolution: 192dpi) {
-              .example {
-                  background-image: url(retina-image.png);
-              }
-          }
-  tags:
-    - cfgov-cf-enhancements
-*/
-
-.respond-to-dpi(@ratio, @rules) {
-    @dpi: (@ratio * 96dpi);
-    @media (-webkit-min-device-pixel-ratio: @ratio), (min-resolution: @dpi) {
-        @rules();
-    }
-}
-
-/* topdoc
-  name: EOF
-  eof: true
-*/
+// END CF4 CORE

--- a/cfgov/unprocessed/css/enhancements/typography.less
+++ b/cfgov/unprocessed/css/enhancements/typography.less
@@ -139,7 +139,7 @@
 */
 
 .jump-link {
-    .webfont-medium();
+    .u-webfont-medium();
     .icon-link();
     font-size: unit(16px / @base-font-size-px, em);
 
@@ -333,7 +333,7 @@
 */
 
 .list_link {
-    .webfont-medium();
+    .u-webfont-medium();
 
     &.list_link__phone {
         .respond-to-min(@bp-sm-min, {

--- a/cfgov/unprocessed/css/enhancements/utilities.less
+++ b/cfgov/unprocessed/css/enhancements/utilities.less
@@ -1,3 +1,283 @@
+// BEGIN CF4 CORE - TODO: delete when CFV4 is added to package.json
+
+/* ==========================================================================
+   Capital Framework
+   Utilities
+   ========================================================================== */
+
+//
+// JS-only
+//
+
+.u-js-only {
+    .no-js & {
+        display: none !important;
+    }
+}
+
+//
+// Clearfix
+//
+
+.u-clearfix {
+    &:after {
+        content: "";
+        display: table;
+        clear: both;
+    }
+
+    .lt-ie8 & {
+        zoom: 1; // For IE 6/7 (triggers hasLayout)
+    }
+}
+
+//
+// Visually hidden
+//
+
+.u-visually-hidden {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    border: 0;
+    margin: -1px;
+    padding: 0;
+    overflow: hidden;
+    // `clip` is deprecated, but retained for safety in making sure that this
+    // utility works as expected for screenreaders. Comma-separated syntax is
+    // not used because space-separated is more backward-compatible,
+    // per https://developer.mozilla.org/en-US/docs/Web/CSS/clip
+    clip: rect(0 0 0 0);
+}
+
+//
+// Inline block
+//
+
+.u-inline-block {
+    display: inline-block;
+
+    .lt-ie8 & {
+        // Hack inline-block into submission
+        display: inline;
+    }
+}
+
+//
+// Floating right
+//
+
+.u-right {
+    float: right;
+}
+
+//
+// Break word
+//
+
+.u-break-word {
+    word-break: break-all;
+}
+
+//
+// Align with button
+//
+
+.u-align-with-btn( @font-size: @base-font-size-px ) {
+    display: inline-block;
+    line-height: normal;
+    vertical-align: middle;
+}
+
+//
+// Flexible proportional containers
+//
+
+.u-flexible-container-mixin( @width: 16, @height: 9 ) {
+    @ratio: ( @height / @width ) * 100;
+
+    position: relative;
+    padding-bottom: ~"@{ratio}%";
+    height: 0;
+}
+
+.u-flexible-container {
+    .u-flexible-container-mixin();
+
+    &_inner {
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+    }
+
+    &__4-3 {
+        .u-flexible-container-mixin( 4, 3 );
+    }
+}
+
+//
+// Link mixins
+//
+
+.u-link__colors() {
+    .u-link__colors-base();
+}
+
+.u-link__colors( @c ) {
+    .u-link__colors-base( @c, @c, @c, @c, @c,
+                          @c, @c, @c, @c, @c );
+}
+
+.u-link__colors( @c, @h ) {
+    .u-link__colors-base( @c, @c, @h, @h, @c,
+                          @c, @c, @h, @h, @c );
+}
+
+.u-link__colors( @c, @v, @h, @f, @a ) {
+    .u-link__colors-base( @c, @v, @h, @f, @a,
+                          @c, @v, @h, @f, @a );
+}
+
+.u-link__colors( @c, @v, @h, @f, @a,
+                 @bc, @bv, @bh, @bf, @ba ) {
+    .u-link__colors-base( @c, @v, @h, @f, @a,
+                          @bc, @bv, @bh, @bf, @ba );
+}
+
+.u-link__colors-base( @c:  @link-text,
+                      @v:  @link-text-visited,
+                      @h:  @link-text-hover,
+                      @f:  @link-text,
+                      @a:  @link-text-active,
+                      @bc: @link-underline,
+                      @bv: @link-underline-visited,
+                      @bh: @link-underline-hover,
+                      @bf: @link-underline,
+                      @ba: @link-underline-active ) {
+    color: @c;
+    border-color: @bc;
+
+    &:visited,
+    &.visited {
+        border-color: @bv;
+        color: @v;
+    }
+
+    &:hover,
+    &.hover {
+        border-color: @bh;
+        color: @h;
+    }
+
+    &:focus,
+    &.focus {
+        border-color: @bf;
+        color: @f;
+    }
+
+    &:active,
+    &.active {
+        border-color: @ba;
+        color: @a;
+    }
+}
+
+.u-link__border() {
+    border-bottom-width: 1px;
+}
+
+.u-link__no-border() {
+    border-bottom-width: 0 !important;
+}
+
+.u-link__hover-border() {
+    border-bottom-width: 0 !important;
+
+    &:hover,
+    &.hover,
+    &:focus,
+    &.focus {
+        border-bottom-width: 1px !important;
+    }
+}
+
+//
+// Margin utilities
+//
+
+.u-mt0  { margin-top:    0 !important; }
+.u-mb0  { margin-bottom: 0 !important; }
+.u-mt5  { margin-top:    5px !important; }
+.u-mb5  { margin-bottom: 5px !important; }
+.u-mt10 { margin-top:    10px !important; }
+.u-mb10 { margin-bottom: 10px !important; }
+.u-mt15 { margin-top:    15px !important; }
+.u-mb15 { margin-bottom: 15px !important; }
+.u-mt20 { margin-top:    20px !important; }
+.u-mb20 { margin-bottom: 20px !important; }
+.u-mt30 { margin-top:    30px !important; }
+.u-mb30 { margin-bottom: 30px !important; }
+.u-mt45 { margin-top:    45px !important; }
+.u-mb45 { margin-bottom: 45px !important; }
+.u-mt60 { margin-top:    60px !important; }
+.u-mb60 { margin-bottom: 60px !important; }
+
+//
+// Width utilities
+//
+
+.u-w100pct { width: 100%; }
+.u-w90pct  { width: 90%; }
+.u-w80pct  { width: 80%; }
+.u-w70pct  { width: 70%; }
+.u-w60pct  { width: 60%; }
+.u-w50pct  { width: 50%; }
+.u-w40pct  { width: 40%; }
+.u-w30pct  { width: 30%; }
+.u-w20pct  { width: 20%; }
+.u-w10pct  { width: 10%; }
+.u-w75pct  { width: 75%; }
+.u-w25pct  { width: 25%; }
+.u-w66pct  { width: unit( ( 2 / 3 ) * 100, % ); }
+.u-w33pct  { width: unit( ( 1 / 3 ) * 100, % ); }
+
+//
+// Width-specific display
+//
+
+.u-hide-on-mobile {
+    .respond-to-max( @bp-xs-max {
+        display: none;
+    } );
+}
+
+.u-show-on-mobile {
+    display: none;
+
+    .respond-to-max( @bp-xs-max {
+        display: block;
+    } );
+}
+
+//
+// Small text utility
+//
+
+.u-small-text( @context: @base-font-size-px ) {
+    font-size: unit( 14px / @context, em );
+}
+
+small,
+.u-small-text {
+    .u-small-text();
+}
+
+// END CF4 CORE
+
+// TODO: Determine if the below utilities can be migrated to CFv4.
+
 /* topdoc
   name: Width utilities
   family: cf-utilities

--- a/cfgov/unprocessed/css/enhancements/vars.less
+++ b/cfgov/unprocessed/css/enhancements/vars.less
@@ -1,3 +1,83 @@
+// BEGIN CF4 CORE - TODO: delete when CFV4 is added to package.json
+
+/* ==========================================================================
+   Capital Framework
+   Less variables
+   ========================================================================== */
+
+//
+// Theme variables
+//
+
+// Color variables
+// `$color-` variables referenced in comments are from 18F's U.S. Web Design Standards
+// https://github.com/18F/web-design-standards/blob/staging/src/stylesheets/core/_variables.scss)
+
+// body
+@text:                   #212121; // $color-base
+
+// a
+@link-text:              #0071bc; // $color-primary
+@link-underline:         #0071bc; // $color-primary
+@link-text-visited:      #4c2c92; // $color-visited
+@link-underline-visited: #4c2c92; // $color-visited
+@link-text-hover:        #205493; // $color-primary-darker
+@link-underline-hover:   #205493; // $color-primary-darker
+@link-text-active:       #046b99; // $color-primary-darkest
+@link-underline-active:  #046b99; // $color-primary-darkest
+
+// table
+@table-border:           #5b616b; // $color-gray
+
+// thead
+@thead-text:             @text;
+@thead-bg:               #f1f1f1; // $color-gray-lightest
+
+// code
+@code-text:              @text;
+@code-bg:                #f1f1f1;
+
+
+// Sizing variables
+
+@base-font-size-px:      16px;
+@base-line-height-px:    22px;
+@base-line-height:       unit( @base-line-height-px / @base-font-size-px );
+
+@size-xl:                48px; // Super-size
+
+@size-i:                 34px; // h1-size
+@size-ii:                26px; // h2-size
+@size-iii:               22px; // h3-size
+@size-iv:                18px; // h4-size
+@size-v:                 14px; // h5-site
+@size-vi:                12px; // h6-size
+@size-code:              13px; // Custom size only for Mono code blocks
+
+
+// Breakpoint variables
+
+@bp-xs-max:              600px;
+@bp-sm-min:              @bp-xs-max + 1px;
+@bp-sm-max:              900px;
+@bp-med-min:             @bp-sm-max + 1px;
+@bp-med-max:             1020px;
+@bp-lg-min:              @bp-med-max + 1px;
+@bp-lg-max:              1230px;
+@bp-xl-min:              @bp-lg-max + 1px;
+
+
+// Web fonts
+
+@webfont-regular:        Arial;
+@webfont-italic:         Arial;
+@webfont-medium:         Arial;
+@webfont-demi:           Arial;
+
+// END CF4 CORE
+
+// TODO: Determine if the below utilities can be migrated to CFv4.
+
 /* topdoc
   name: Theme variables
   family: cf-vars

--- a/cfgov/unprocessed/css/lists.less
+++ b/cfgov/unprocessed/css/lists.less
@@ -115,7 +115,7 @@
 
         .respond-to-print({
             & {
-                .webfont-medium();
+                .u-webfont-medium();
                 color: @black;
             }
         });

--- a/cfgov/unprocessed/css/main.less
+++ b/cfgov/unprocessed/css/main.less
@@ -26,12 +26,14 @@
 // The Capital Framework (CF) brand color palette.
 @import (less) "brand-palette.less";
 
+// Vars enhancements that is on migration path to CF Core.
+@import (less) "enhancements/vars.less";
+
 // Override the CF theme variables with colors from the brand color palette.
 @import (less) "cf-theme-overrides.less";
 
 // Enhancements that are on a migration path to being added to CF.
 // CF Core
-@import (less) "enhancements/vars.less";
 @import (less) "enhancements/media-queries.less";
 @import (less) "enhancements/utilities.less";
 @import (less) "enhancements/base.less";

--- a/cfgov/unprocessed/css/misc.less
+++ b/cfgov/unprocessed/css/misc.less
@@ -521,7 +521,7 @@
         position: relative;
         background: @green;
         color: @white;
-        .webfont-medium();
+        .u-webfont-medium();
         line-height: @icon-size;
         text-align: center;
     }
@@ -623,7 +623,7 @@
     margin-bottom: unit(15px / 14px, em);
 
     color: @dark-gray;
-    .webfont-demi();
+    .u-webfont-demi();
     font-size: 14px; // fallback for browsers that don't support rem units
     // rem units needed because the main use case for this is within a heading
     font-size: unit(14px / @base-font-size-px, rem);

--- a/cfgov/unprocessed/css/molecules/global-header-cta.less
+++ b/cfgov/unprocessed/css/molecules/global-header-cta.less
@@ -33,7 +33,7 @@
 .m-global-header-cta {
 
     a {
-        .webfont-medium();
+        .u-webfont-medium();
         // Colors for :link, :visited, :hover, :focus, :active.
         .u-link__colors( @pacific, @pacific, @pacific-60, @pacific, @dark-navy );
 

--- a/cfgov/unprocessed/css/molecules/global-search.less
+++ b/cfgov/unprocessed/css/molecules/global-search.less
@@ -210,7 +210,7 @@
     .respond-to-min( @bp-sm-min, {
         // Add "Search" text in trigger.
         &_trigger-label:before {
-            .webfont-medium();
+            .u-webfont-medium();
 
             content: 'Search';
         }

--- a/cfgov/unprocessed/css/molecules/pagination.less
+++ b/cfgov/unprocessed/css/molecules/pagination.less
@@ -67,7 +67,7 @@
         display: inline-block;
         margin: 0 0 0 @pagination-font-size__em / 2;
         vertical-align: middle;
-        .webfont-medium();
+        .u-webfont-medium();
     }
 
     form {
@@ -87,7 +87,7 @@
         margin: 0 @pagination-font-size__em / 2;
         text-align: right;
         vertical-align: middle;
-        .webfont-medium();
+        .u-webfont-medium();
     }
 
     label,
@@ -105,7 +105,7 @@
         line-height: @pagination-height__px;
         font-size: @pagination-font-size__px;
         text-align: center;
-        .webfont-medium();
+        .u-webfont-medium();
 
         &.btn__disabled {
             background-color: @pagination-bg-color;

--- a/cfgov/unprocessed/css/organisms/bureau-structure.less
+++ b/cfgov/unprocessed/css/organisms/bureau-structure.less
@@ -219,7 +219,7 @@
 }
 
 .o-bureau-structure_node {
-    .webfont-regular();
+    .u-webfont-regular();
     position: relative;
     box-sizing: border-box;
     padding: @margin @margin / 2;
@@ -302,12 +302,12 @@
 
     &_name,
     &_title {
-        .webfont-regular();
+        .u-webfont-regular();
         display: block;
     }
 
     &_name {
-        .webfont-medium();
+        .u-webfont-medium();
     }
 
     + .o-expandable_target {

--- a/cfgov/unprocessed/css/organisms/featured-content-module.less
+++ b/cfgov/unprocessed/css/organisms/featured-content-module.less
@@ -8,7 +8,7 @@
 @fcm-bg: @block__bg;
 
 .o-featured-content-module {
-  .webfont-regular();
+  .u-webfont-regular();
 
   position: relative;
 

--- a/cfgov/unprocessed/css/organisms/mega-menu.less
+++ b/cfgov/unprocessed/css/organisms/mega-menu.less
@@ -280,7 +280,7 @@ body {
             }
 
             &-alt-trigger {
-                .webfont-medium();
+                .u-webfont-medium();
 
                 padding: unit( @grid_gutter-width / 2 / @base-font-size-px, em );
                 width: 100%;

--- a/cfgov/unprocessed/css/organisms/reg-comment.less
+++ b/cfgov/unprocessed/css/organisms/reg-comment.less
@@ -8,7 +8,7 @@
         margin-bottom: unit(15px / @font-size, em);
 
         .label_note {
-            .webfont-regular();
+            .u-webfont-regular();
             font-size: unit(16px / @font-size, em);
         }
     }
@@ -38,6 +38,6 @@
     }
 
     &_disclaimer-em {
-        .webfont-medium();
+        .u-webfont-medium();
     }
 }

--- a/cfgov/unprocessed/css/organisms/secondary-navigation.less
+++ b/cfgov/unprocessed/css/organisms/secondary-navigation.less
@@ -88,7 +88,7 @@
 */
 
 .o-secondary-navigation {
-    .webfont-regular();
+    .u-webfont-regular();
 
     &__no-children {
       .respond-to-max( @bp-sm-max, {
@@ -102,7 +102,7 @@
     //       behavior and handle its own styling
     //       (possibly shared with expandables).
     .o-expandable_target {
-        .webfont-demi();
+        .u-webfont-demi();
 
         text-transform: uppercase;
 

--- a/cfgov/unprocessed/css/organisms/snippet-list.less
+++ b/cfgov/unprocessed/css/organisms/snippet-list.less
@@ -35,7 +35,7 @@
     }
 
     &-item-title {
-        .webfont-medium();
+        .u-webfont-medium();
     }
 
     &-action-list {

--- a/cfgov/unprocessed/css/pages/ask.less
+++ b/cfgov/unprocessed/css/pages/ask.less
@@ -37,9 +37,9 @@
         ul:last-child,
         ol:last-child {
             margin-bottom: 0 !important;
-        } 
+        }
     }
-    
+
     .category-button {
         .respond-to-max(@bp-xs-max, {
             margin-top: unit( ( @grid_gutter-width / 2 ) / @base-font-size-px, em );
@@ -47,7 +47,7 @@
             text-align: center;
         });
 
-    }   
+    }
 
 }
 
@@ -86,7 +86,7 @@
             padding-left: unit( @grid_gutter-width / 2 / @base-font-size-px, em );
             padding-right: unit( @grid_gutter-width / 2 / @base-font-size-px, em );
         } );
-        
+
         .respond-to-range( @bp-med-min, @bp-med-max {
             padding-left: 0;
             padding-right: 0;
@@ -98,7 +98,7 @@
             padding-left: unit( @grid_gutter-width / @base-font-size-px, em );
             padding-right: unit( @grid_gutter-width / @base-font-size-px, em );
         } );
-        
+
     }
 
     .ask-search {
@@ -112,7 +112,7 @@
             margin-bottom: 0;
         } );
     }
-    
+
 }
 
 .ask-cfpb-page {
@@ -127,7 +127,7 @@
     }
 
     .search-results {
-        max-width: @bp-xs-max;    
+        max-width: @bp-xs-max;
     }
 
     .question_summary {
@@ -145,7 +145,7 @@
             .o-search-bar_col + .o-search-bar_col {
                 margin-top: unit( ( @grid_gutter-width / 2 ) / @base-font-size-px, em );
             }
-            
+
             form {
                 margin-right: unit((@grid_gutter-width / 2) / @base-font-size-px, em);
             }
@@ -160,10 +160,10 @@
         &__full {
             form {
                 max-width: 700px;
-            } 
+            }
         }
 
-        &__with-sidebar {   
+        &__with-sidebar {
             .search-bar__full-width-content {
                 .search-bar_label .break {
                     display: inline;
@@ -202,15 +202,15 @@
             .respond-to-range( @bp-xs-max, 700px, {
                 .search-bar__full-width-content;
             } );
-        
+
             .respond-to-range( 700px, @bp-sm-max, {
                 .search-bar__variable-cols;
             } );
-        
+
             .respond-to-range(@bp-med-min, @bp-med-max, {
                 .search-bar__full-width-content;
             });
-        
+
             .respond-to-min(@bp-lg-min, {
                 .search-bar__variable-cols;
             });
@@ -222,7 +222,7 @@
             &__bg-extend-right,
             &__bg-extend-left {
                 position: relative;
-              
+
               &:after {
                   content: '';
                   display: block;
@@ -230,17 +230,17 @@
                   height: 100%;
                   position: absolute;
                   top: 0;
-                  background: @block__bg;   
+                  background: @block__bg;
                   z-index: 0;
               }
             }
-          
+
             &__bg-extend-right {
               &:after {
                   left: 100%;
               }
             }
-            
+
             &__bg-extend-left {
               &:after {
                   margin-left: 10px;
@@ -248,9 +248,9 @@
               }
             }
         } );
-    
+
         &__bg-branded {
-            background: @green-20; 
+            background: @green-20;
         }
     }
 
@@ -270,11 +270,11 @@
     }
 
     .question_summary {
-        padding: unit( (@grid_gutter-width / 2 ) / @base-font-size-px, em ) 
-                 0 
-                 unit( @grid_gutter-width / @base-font-size-px, em ) 
+        padding: unit( (@grid_gutter-width / 2 ) / @base-font-size-px, em )
+                 0
+                 unit( @grid_gutter-width / @base-font-size-px, em )
                  0;
-    
+
         .respond-to-min(@bp-med-min, {
           font-size: @size-iv;
           margin-bottom: 0;
@@ -317,7 +317,7 @@
 
     .subcategory-nav {
         .list_item {
-            .webfont-medium();
+            .u-webfont-medium();
         }
 
         .m-nav-link:not(.m-nav-link__current) {

--- a/cfgov/unprocessed/css/pages/event.less
+++ b/cfgov/unprocessed/css/pages/event.less
@@ -130,7 +130,7 @@
 
 .event-meta {
     &__medium {
-        .webfont-medium();
+        .u-webfont-medium();
     }
 }
 
@@ -211,7 +211,7 @@
     }
 
     .event-calendar_download {
-        .webfont-demi();
+        .u-webfont-demi();
 
         display: block;
         padding-top: .2em;


### PR DESCRIPTION
Trying this workflow toward migrating to CFv4:
 1. Add CF module classes to cfgov-refresh enhancements, module by module.
 2. Check site against live site.
 3. Once all modules are updated, update `package.json` to CFv4 and remove enhancements. 

## Additions

- cf-core styles moved temporarily to enhancements.

## Changes

- Updates `.webfont-*` to `.u-webfont-*` as needed for CFv4.

## Testing

1. `./frontend.sh` and site should look the same as prod.

## Notes

- Not sure if we want to merge this already or wait till all modules are in. I'll be opening PRs for each module that build on this one.
