### PR TITLE
Post-launch cleanup for Ask CFPB

### DIFF
--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -83,7 +83,6 @@ OPTIONAL_APPS = [
     {'import': 'paying_for_college',
      'apps': ('paying_for_college', 'haystack',)},
     {'import': 'agreements', 'apps': ('agreements', 'haystack',)},
-    {'import': 'knowledgebase', 'apps': ('knowledgebase', 'haystack',)},
     {'import': 'selfregistration', 'apps': ('selfregistration',)},
     {'import': 'hud_api_replace', 'apps': ('hud_api_replace',)},
     {'import': 'retirement_api', 'apps': ('retirement_api',)},
@@ -572,10 +571,6 @@ FLAGS = {
     # Transition of /compltain to Wagtail
     # When enabled, the "Submit a complaint" page is served from Wagtail
     'MOSAIC_COMPLAINTS': {},
-
-    # Migration of Ask CFPB to Wagtail
-    # When enabled, Ask CFPB is served from Wagtail
-    'WAGTAIL_ASK_CFPB': {'boolean': True},
 
     # The next version of the public consumer complaint database
     'CCDB5_RELEASE': {},

--- a/cfgov/cfgov/urls.py
+++ b/cfgov/cfgov/urls.py
@@ -304,6 +304,48 @@ urlpatterns = [
     # CCDB5-API
     url(r'^data-research/consumer-complaints/api/v1/',
         include_if_app_enabled('complaint_search', 'complaint_search.urls')),
+
+    # ask-cfpb
+    url(r'^askcfpb/$',
+        RedirectView.as_view(
+            url='/ask-cfpb/',
+            permanent=True)),
+    url(r'^(?P<language>es)/obtener-respuestas/c/(.+)/(?P<ask_id>\d+)/(.+)\.html$',  # noqa: E501
+         RedirectView.as_view(
+             url='/es/obtener-respuestas/slug-es-%(ask_id)s',
+             permanent=True)),
+    url(r'^askcfpb/(?P<ask_id>\d+)/(.*)$',
+         RedirectView.as_view(
+             url='/ask-cfpb/slug-en-%(ask_id)s',
+             permanent=True)),
+    url(r'^askcfpb/search/',
+        redirect_ask_search,
+        name='redirect-ask-search'),
+    url(r'^(?P<language>es)/obtener-respuestas/buscar/?$',
+        ask_search,
+        name='ask-search-es'),
+    url(r'^(?P<language>es)/obtener-respuestas/buscar/(?P<as_json>json)/$',
+        ask_search,
+        name='ask-search-es-json'),
+    url(r'^(?i)ask-cfpb/([-\w]{1,244})-(en)-(\d{1,6})/?$',
+        view_answer,
+        name='ask-english-answer'),
+    url(r'^es/obtener-respuestas/([-\w]{1,244})-(es)-(\d{1,6})/?$',
+        view_answer,
+        name='ask-spanish-answer'),
+    url(r'^es/obtener-respuestas/([-\w]{1,244})-(es)-(\d{1,6})/imprimir/?$',
+        print_answer,
+        name='ask-spanish-print-answer'),
+    url(r'^(?i)ask-cfpb/search/$',
+        ask_search,
+        name='ask-search-en'),
+    url(r'^(?i)ask-cfpb/search/(?P<as_json>json)/$',
+        ask_search,
+        name='ask-search-en-json'),
+    url(r'^(?i)ask-cfpb/api/autocomplete/$',
+        ask_autocomplete, name='ask-autocomplete-en'),
+    url(r'^(?P<language>es)/obtener-respuestas/api/autocomplete/$',
+        ask_autocomplete, name='ask-autocomplete-es'),
 ]
 
 if settings.ALLOW_ADMIN_URL:
@@ -405,55 +447,6 @@ if settings.DEBUG:
         urlpatterns.append(url(r'^__debug__/', include(debug_toolbar.urls)))
     except ImportError:
         pass
-
-redirect_patterns = [
-    url(r'^askcfpb/$',
-        RedirectView.as_view(
-            url='/ask-cfpb/',
-            permanent=True)),
-    url(r'^(?P<language>es)/obtener-respuestas/c/(.+)/(?P<ask_id>\d+)/(.+)\.html$',  # noqa: E501
-         RedirectView.as_view(
-             url='/es/obtener-respuestas/slug-es-%(ask_id)s',
-             permanent=True)),
-    url(r'^askcfpb/(?P<ask_id>\d+)/(.*)$',
-         RedirectView.as_view(
-             url='/ask-cfpb/slug-en-%(ask_id)s',
-             permanent=True)),
-    url(r'^askcfpb/search/',
-        redirect_ask_search,
-        name='redirect-ask-search'),
-]
-urlpatterns += redirect_patterns
-
-ask_patterns = [
-    url(r'^(?P<language>es)/obtener-respuestas/buscar/?$',
-        ask_search,
-        name='ask-search-es'),
-    url(r'^(?P<language>es)/obtener-respuestas/buscar/(?P<as_json>json)/$',
-        ask_search,
-        name='ask-search-es-json'),
-    url(r'^(?i)ask-cfpb/([-\w]{1,244})-(en)-(\d{1,6})/?$',
-        view_answer,
-        name='ask-english-answer'),
-    url(r'^es/obtener-respuestas/([-\w]{1,244})-(es)-(\d{1,6})/?$',
-        view_answer,
-        name='ask-spanish-answer'),
-    url(r'^es/obtener-respuestas/([-\w]{1,244})-(es)-(\d{1,6})/imprimir/?$',
-        print_answer,
-        name='ask-spanish-print-answer'),
-    url(r'^(?i)ask-cfpb/search/$',
-        ask_search,
-        name='ask-search-en'),
-    url(r'^(?i)ask-cfpb/search/(?P<as_json>json)/$',
-        ask_search,
-        name='ask-search-en-json'),
-    url(r'^(?i)ask-cfpb/api/autocomplete/$',
-        ask_autocomplete, name='ask-autocomplete-en'),
-    url(r'^(?P<language>es)/obtener-respuestas/api/autocomplete/$',
-        ask_autocomplete, name='ask-autocomplete-es'),
-]
-urlpatterns += ask_patterns
-
 
 # Catch remaining URL patterns that did not match a route thus far.
 urlpatterns.append(url(r'', include(wagtailsharing_urls)))

--- a/cfgov/jinja2/v1/_includes/organisms/_vars-mega-menu.html
+++ b/cfgov/jinja2/v1/_includes/organisms/_vars-mega-menu.html
@@ -69,7 +69,7 @@
 {% set nav_items = [(
     ('Consumer Tools', '#', [(
         ('Submit a Complaint', '/complaint/', []),
-        ('Ask CFPB', '/ask-cfpb/' if flag_enabled('WAGTAIL_ASK_CFPB', request) else '/askcfpb/', []),
+        ('Ask CFPB', '/ask-cfpb/', []),
         ('Tell Your Story', '/your-story/', []),
         ('Information for Students', '/students/', []),
         ('Information for Servicemembers & Veterans', '/servicemembers/', [])

--- a/cfgov/jinja2/v1/index.html
+++ b/cfgov/jinja2/v1/index.html
@@ -80,7 +80,7 @@
                             'links': [
                                 {
                                     'text': 'Find answers to common questions',
-                                    'url':  '/ask-cfpb/' if flag_enabled('WAGTAIL_ASK_CFPB', request) else '/askcfpb/'
+                                    'url':  '/ask-cfpb/'
                                 }
                             ]
                         } ) }}

--- a/cfgov/scripts/http_smoke_test.py
+++ b/cfgov/scripts/http_smoke_test.py
@@ -25,11 +25,16 @@ parser.add_argument(
 parser.add_argument(
     "-v", "--verbose",
     action="store_true",
-    help="set logging level to info to see all message output."
+    help="Set logging level to info to see all message output."
+)
+parser.add_argument(
+    "-t", "--timeout",
+    type=str,
+    help="Set a timeout level, in seconds; the default is 30."
 )
 
-FULL = False
 TIMEOUT = 30
+FULL = False
 BASE = 'https://www.consumerfinance.gov'
 
 FULL_RUN = [
@@ -237,5 +242,7 @@ if __name__ == '__main__':
         BASE = args.base
     if args.full:
         FULL = True
+    if args.timeout:
+        TIMEOUT = int(args.timeout)
     if not check_urls(BASE, full=FULL):
         sys.exit(1)

--- a/cfgov/scripts/http_smoke_test.py
+++ b/cfgov/scripts/http_smoke_test.py
@@ -29,7 +29,7 @@ parser.add_argument(
 )
 
 FULL = False
-TIMEOUT = 10
+TIMEOUT = 30
 BASE = 'https://www.consumerfinance.gov'
 
 FULL_RUN = [

--- a/requirements/optional-private.txt
+++ b/requirements/optional-private.txt
@@ -5,6 +5,5 @@
 git+https://private.repo/CFPB/agreement_database.git@2.2.7#egg=agreement-database
 git+https://private.repo/CFPB/cfgov-selfregistration.git@1.3.1#egg=selfregistration
 git+https://private.repo/CFPB/django-college-cost-comparison.git@v1.2.9#egg=comparisontool
-git+https://private.repo/CFPB/knowledgebase.git@2.4.0#egg=knowledgebase
 git+https://private.repo/CFPB/Picard.git@1.7.0#egg=picard
 git+https://private.repo/eregs/ip.git@1.0.3#egg=eregsip

--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,6 @@ setenv=
     GOVDELIVERY_ACCOUNT_CODE=fake_account_code
     DJANGO_SETTINGS_MODULE=cfgov.settings.test
     DJANGO_STAGING_HOSTNAME=content.localhost
-    DEPLOY_ENVIRONMENT=build
     LANG=en_US.UTF-8
     LC_ALL=en_US.UTF-8
 


### PR DESCRIPTION
This finalizes the retirement of knowledgebase and cleans up code needed
only for the migration.

Changes included:
- removal of knowledgebase from settings and requirements
- cleanup of urls.py to incorporate new URLs in the main pattern
- removal of tox DEPLOY_ENVIRONMENT variable
- retirement of the `WAGTAIL_ASK_CFPB` feature flag
- removal of the `WAGTAIL_ASK_CFPB` conditional code in
    - `jinja2/v1/_includes/organisms/_vars-mega-menu.html`
    -  `jinja2/v1/index.html`
- bump the smoketest timeout value to accommodate a slow
deployment completion. Normally the timeout is never reached, but just in case
the deployment needs a few more seconds to finish, this adds a cushion
so that the whole build doesn't fail.

These no-op cleanups should not have any effect on site.
