### PR TITLE
Ask CFPB: Add category page results count notification

### DIFF
--- a/cfgov/ask_cfpb/models/pages.py
+++ b/cfgov/ask_cfpb/models/pages.py
@@ -234,7 +234,8 @@ class AnswerCategoryPage(RoutablePageMixin, CFGOVPage):
         context.update({
             'paginator': paginator,
             'current_page': int(page),
-            'questions': answers,
+            'results_count': answers.count(),
+            'questions': paginator.page(page),
             'breadcrumb_items': get_ask_breadcrumbs(
                 self.ask_category)
         })

--- a/cfgov/jinja2/v1/ask-cfpb/category-page.html
+++ b/cfgov/jinja2/v1/ask-cfpb/category-page.html
@@ -65,6 +65,10 @@
     {% endif %}
 
     <section class="search-results block block__flush-top">
+        <div class="search-results_notification u-mt30">
+            {% from 'molecules/notification.html' import render as notification with context %}
+            {{ notification('success', false, results_count ~ ' results') }}
+        </div>
         
         <div class="question_list">
             {% for question in questions %}

--- a/cfgov/unprocessed/css/pages/ask.less
+++ b/cfgov/unprocessed/css/pages/ask.less
@@ -335,6 +335,10 @@
 
     }
 
+    .search-results_notification .m-notification {
+        display: block;
+    }
+
     .question_list {
         .respond-to-max(@bp-sm-max, {
             margin-top: unit( @grid_gutter-width / @base-font-size-px, em );


### PR DESCRIPTION
Add notification of results count on English category page so users can tell results have changed when a subcategory is selected


## Additions

- Results notification on English category pages

## Changes

- Paginate results on subcategory pages

## Testing

1. Check out branch and run `gulp styles`
2. Navigate to [category page](http://localhost:8000/ask-cfpb/category-auto-loans/) and verify that results notification update when subcategory is changed 

## Screenshots

<img width="1212" alt="screen shot 2017-06-19 at 12 14 27 pm" src="https://user-images.githubusercontent.com/778171/27301705-1519ad84-54e9-11e7-9a8a-a9552fb0db4f.png">

## Checklist

* [ ] PR has an informative and human-readable title
* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated
* [ ] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
