### PR TITLE
Remove references to u-inline-block

### DIFF
--- a/cfgov/jinja2/v1/_layouts/404.html
+++ b/cfgov/jinja2/v1/_layouts/404.html
@@ -22,16 +22,16 @@
 
     <div class="error_action_container">
         <div class="error_action_col">
-            <a href="/" class="btn btn__full btn__error-home u-inline-block">Visit homepage</a>
+            <a href="/" class="btn btn__full">Visit homepage</a>
         </div>
         <div class="error_action_col">
-            <a class="btn btn__full btn__error-home u-inline-block" href="/about-us/contact-us/">
+            <a class="btn btn__full" href="/about-us/contact-us/">
                 Contact us
             </a>
         </div>
     </div>
-    
-    <p>Are you sure this is the right web address? 
+
+    <p>Are you sure this is the right web address?
         <a class="jump-link" href={{"mailto:CFPB_website@consumerfinance.gov?subject=404%20Error%20at%20%22" + request.build_absolute_uri() + "%22"}}>
             <span class="jump-link_text">Let us know</span>
         </a>

--- a/cfgov/jinja2/v1/_layouts/500.html
+++ b/cfgov/jinja2/v1/_layouts/500.html
@@ -23,16 +23,16 @@
 
         <aside class="error_action_container">
             <div class="error_action_col">
-                <a href="/" class="btn btn__full btn__error-home u-inline-block">Visit homepage</a>
+                <a href="/" class="btn btn__full">Visit homepage</a>
             </div>
             <div class="error_action_col">
-                <a class="btn btn__full btn__error-home u-inline-block" href="/about-us/contact-us/">
+                <a class="btn btn__full" href="/about-us/contact-us/">
                     Contact us
                 </a>
             </div>
         </aside>
 
-        <p>Are you sure this is the right web address? 
+        <p>Are you sure this is the right web address?
             <a class="jump-link" href={{"mailto:CFPB_website@consumerfinance.gov?subject=500%20Error%20at%20%22" + request.build_absolute_uri() + "%22"}} >
                 <span class="jump-link_text">Let us know</span>
             </a>
@@ -46,4 +46,3 @@
     {% include '/js/routes/common.js' %}
 </script>
 {% endblock javascript %}
-

--- a/cfgov/unprocessed/css/enhancements/typography.less
+++ b/cfgov/unprocessed/css/enhancements/typography.less
@@ -353,7 +353,7 @@
 */
 dt {
     .h5();
-    .u-inline-block();
+    display: inline-block;
 
     margin-bottom: 0.5em;
 

--- a/cfgov/unprocessed/css/meta.less
+++ b/cfgov/unprocessed/css/meta.less
@@ -232,7 +232,7 @@
         line-height: 1;
 
         .respond-to-min(@bp-sm-min, {
-            .u-inline-block();
+            display: inline-block;
             margin-right: unit(15px / @base-font-size-px, em);
             // Eyeballed to be 15px of vertical space between each.
             margin-bottom: unit(8px / @base-font-size-px, em);

--- a/cfgov/unprocessed/css/pages/error.less
+++ b/cfgov/unprocessed/css/pages/error.less
@@ -7,6 +7,7 @@
     margin: unit( @grid_gutter-width / @base-font-size-px, em ) 0;
 
     .btn {
+        display: inline-block;
         margin: unit( ( @grid_gutter-width / 2 ) / @base-font-size-px, em ) 0;
     }
 
@@ -67,7 +68,7 @@
         color: @white;
         border-color: @white;
         margin-top: unit( ( @grid_gutter-width / 4 ) / @base-font-size-px, em );
-    } 
+    }
 
     &__404 {
         .content_main {
@@ -90,13 +91,13 @@
 
             .respond-to-min(@bp-med-min, {
                 background-size: contain;
-            }); 
-            
+            });
+
         }
     }
 
     &__500 {
-        
+
         .main_wrapper {
 
             background: transparent url('../img/server.png') no-repeat right top;
@@ -115,7 +116,7 @@
             .respond-to-range(@bp-sm-min, @bp-sm-max, {
                 background-size: 40%;
             });
-            
+
         }
     }
 }


### PR DESCRIPTION
References to [`u-inline-block`](https://github.com/cfpb/capital-framework/blob/master/src/cf-core/src/cf-utilities.less#L55) can be replaced with native `display: inline-block` since the utility only adds a (now unsupported) hack for IE7 and below. We barely used it anyway. Should be deprecated in CF too I'd say.

## Changes

- Replace calls to `u-inline-block` with `display: inline-block`. 

## Removes

- Unused `btn__error-home` classes from the 404 and 500 pages.

## Testing

1. In `urls.py` temporarily replace `template_name='test-fixture/index.html'), name='test-fixture'` with  `template_name='404.html'), name='404'`
2. Restart the server.
3. Visit `localhost:8000/test-fixture` to view the 404 page.
4. Repeat for `500.html`
5. Should appear unchanged from live site versions.
