### PR TITLE
Migrate slug header to CFv4

### DIFF
--- a/cfgov/jinja2/v1/_includes/molecules/call-to-action.html
+++ b/cfgov/jinja2/v1/_includes/molecules/call-to-action.html
@@ -24,11 +24,11 @@
 
 <div class="m-call-to-action">
     {% if value.slug_text %}
-    <h2 class="header-slug">
-        <span class="header-slug_inner">
+    <header class="m-slug-header">
+        <h2 class="a-heading">
             {{ value.slug_text }}
-        </span>
-    </h2>
+        </h2>
+    </header>
     {% endif %}
 
     {% if value.paragraph_text %}

--- a/cfgov/jinja2/v1/_includes/molecules/related-content.html
+++ b/cfgov/jinja2/v1/_includes/molecules/related-content.html
@@ -26,11 +26,11 @@
 
 <div class="m-related-links">
     {% if value.heading %}
-        <h2 class="header-slug">
-            <span class="header-slug_inner">
+        <header class="m-slug-header">
+            <h2 class="a-heading">
                 {{ value.heading }}
-            </span>
-        </h2>
+            </h2>
+        </header>
     {% endif %}
 
     {{ parse_links(value.paragraph) | safe }}

--- a/cfgov/jinja2/v1/_includes/molecules/related-metadata.html
+++ b/cfgov/jinja2/v1/_includes/molecules/related-metadata.html
@@ -42,11 +42,11 @@
          to make it clear it's a boolean. #}
 <div class="m-related-metadata
             {{ 'm-related-metadata__half-width' if value.half_width else '' }}">
-    <h2 class="header-slug">
-        <span class="header-slug_inner">
+    <header class="m-slug-header">
+        <h2 class="a-heading">
             {{ value.slug }}
-        </span>
-    </h2>
+        </h2>
+    </header>
     {# For each of the blocks render them if they're there except for Topics.
        In that case, render only if the value `show_topics` is True. #}
     {% for block in value.content %}

--- a/cfgov/jinja2/v1/_includes/molecules/related-posts.html
+++ b/cfgov/jinja2/v1/_includes/molecules/related-posts.html
@@ -36,11 +36,11 @@
                 {{'m-related-posts__half-width'
                   if is_half_width else ''}}">
         {% if not hide_header_slug %}
-            <h2 class="header-slug">
-                <span class="header-slug_inner">
+            <header class="m-slug-header">
+                <h2 class="a-heading">
                     {{ block.value.header_title }}
-                </span>
-            </h2>
+                </h2>
+            </header>
         {% endif %}
         {% for post_type, post_type_list in posts.iteritems() %}
             {% set title, icon = (post_type, category_icon.render(post_type)) or ("Blog", "cf-icon-speech-bubble") %}

--- a/cfgov/jinja2/v1/_includes/molecules/related-topics.html
+++ b/cfgov/jinja2/v1/_includes/molecules/related-topics.html
@@ -22,11 +22,11 @@
 
    ========================================================================== #}
 <div class="m-related-topics">
-    <h2 class="header-slug">
-        <span class="header-slug_inner">
+    <header class="m-slug-header">
+        <h2 class="a-heading">
             {{ value.heading or 'Related Topics' }}
-        </span>
-    </h2>
+        </h2>
+    </header>
     <ul class="list
                list__unstyled
                list__links">

--- a/cfgov/jinja2/v1/_includes/organisms/email-signup.html
+++ b/cfgov/jinja2/v1/_includes/organisms/email-signup.html
@@ -20,11 +20,11 @@
 
 <div class="o-email-signup">
 {% if value.heading %}
-    <h2 class="header-slug">
-        <span class="header-slug_inner">
+    <header class="m-slug-header">
+        <h2 class="a-heading">
             {{ value.heading }}
-        </span>
-    </h2>
+        </h2>
+    </header>
 {% endif %}
 
 <form id="{{ value.id or ('o-email-signup_' ~ range(1, 100) | random) }}"
@@ -52,4 +52,3 @@
     </div>
 </form>
 </div>
-

--- a/cfgov/jinja2/v1/_includes/organisms/sidebar-breakout.html
+++ b/cfgov/jinja2/v1/_includes/organisms/sidebar-breakout.html
@@ -100,11 +100,11 @@
                             {% break %}
                         {% endif %}
                     {% elif 'slug' in block.block_type %}
-                        <h2 class="header-slug">
-                            <span class="header-slug_inner">
+                        <header class="m-slug-header">
+                            <h2 class="a-heading">
                                 {{ block.value }}
-                            </span>
-                        </h2>
+                            </h2>
+                        </header>
                     {% elif 'paragraph' in block.block_type %}
                         <p class="o-sidebar-breakout_text-body">
                             {{ parse_links(block.value) | safe }}

--- a/cfgov/jinja2/v1/_includes/organisms/sidebar-contact-info.html
+++ b/cfgov/jinja2/v1/_includes/organisms/sidebar-contact-info.html
@@ -38,11 +38,11 @@
 
 <div class="o-sidebar-contact-info">
     <div class="o-sidebar-contact-info_heading">
-        <h2 class="header-slug">
-                <span class="header-slug_inner">
-                    Contact Information
-                </span>
-        </h2>
+      <header class="m-slug-header">
+          <h2 class="a-heading">
+              Contact Information
+          </h2>
+      </header>
     </div>
 
     <div class="o-sidebar-contact-info_content">

--- a/cfgov/jinja2/v1/_includes/related-links.html
+++ b/cfgov/jinja2/v1/_includes/related-links.html
@@ -22,11 +22,11 @@
 
 {%- macro render(related_links, related_links_2) -%}
 <div class="related-links">
-    <h2 class="header-slug">
-        <span class="header-slug_inner">
+    <header class="m-slug-header">
+        <h2 class="a-heading">
             Related links
-        </span>
-    </h2>
+        </h2>
+    </header>
 {%- if related_links_2 %}
     <div class="content-l content-l__main content-l__large-gutters">
         <div class="content-l_col content-l_col-1-2">

--- a/cfgov/jinja2/v1/_includes/templates/activities-feed.html
+++ b/cfgov/jinja2/v1/_includes/templates/activities-feed.html
@@ -1,6 +1,6 @@
-<h2 class="header-slug">
-    <span class="header-slug_inner">
+<header class="m-slug-header">
+    <h2 class="a-heading">
         Latest Activities
-    </span>
-</h2>
+    </h2>
+</header>
 {{ activities_feed }}

--- a/cfgov/jinja2/v1/_includes/templates/upcoming-events.html
+++ b/cfgov/jinja2/v1/_includes/templates/upcoming-events.html
@@ -1,9 +1,9 @@
 <div class="upcoming-events">
-    <h2 class="header-slug">
-        <span class="header-slug_inner">
+    <header class="m-slug-header">
+        <h2 class="a-heading">
             Upcoming events
-        </span>
-    </h2>
+        </h2>
+    </header>
     <p>Check out our upcoming events.</p>
     <a class="btn" href="/about-us/events/">Find out more</a>
 </div>

--- a/cfgov/jinja2/v1/ask-cfpb/answer-page.html
+++ b/cfgov/jinja2/v1/ask-cfpb/answer-page.html
@@ -30,7 +30,7 @@
 
 
 {% block content_main_modifiers -%}
-    {{ super() }} content__flush-bottom 
+    {{ super() }} content__flush-bottom
 {%- endblock %}
 
 {% block content_main %}
@@ -54,7 +54,7 @@
                 {{ page.snippet | safe }}
             </h3>
         {% endif %}
-        <div data-qa-hook="expandable" 
+        <div data-qa-hook="expandable"
              data-read-more="true"
              class="o-expandable
                     o-expandable__read-more">
@@ -63,7 +63,7 @@
                     <div class="answer-text">
                         {{ page.answer | richtext | safe }}
                     </div>
-                    {% if audiences %} 
+                    {% if audiences %}
                     <div class="u-mt15">
                         {{ tags.render( {'links': audiences}, '', is_wagtail=True) }}
                     </div>
@@ -79,7 +79,7 @@
                     </div>
                     {% endif %}
                 </div>
-            </div>            
+            </div>
             <a class="o-expandable_target jump-link o-expandable_link" title="Expand content">
                 <span class="jump-link_text">
                     <span class="o-expandable_cue o-expandable_cue-open">
@@ -93,7 +93,7 @@
                 </span>
             </a>
         </div>
-        
+
 
     </div>
     {{ ask_search_bar.render( 'left' ) }}
@@ -119,12 +119,12 @@
     {% if category and subcategories %}
         <div class="block {% if not page.answer_base.next_step %}block__flush-top{% endif %}">
             <div class="m-related-links">
-                <h2 class="header-slug">
-                    <span class="header-slug_inner">
+                <header class="m-slug-header">
+                    <h2 class="a-heading">
                         Related {{category.name}} subjects
-                    </span>
-                </h2>
-                <ul class="list list__unstyled list__links">
+                    </h2>
+                </header>
+                <ul class="m-list m-list__unstyled m-list__links">
                     {% for subcat in subcategories %}
                         <li class="list_item">
 
@@ -132,7 +132,7 @@
                         </li>
                     {% endfor %}
                     <li class="list_item">
-                      <a class="btn category-button" href="{{slugurl('category-' + category.slug)}}"> 
+                      <a class="btn category-button" href="{{slugurl('category-' + category.slug)}}">
                         See all {{category.name | lower}} questions
                       </a>
                     </li>
@@ -144,27 +144,26 @@
     {% if related_questions %}
         <div class="block">
             <div class="m-related-links">
-                <h2 class="header-slug">
-                    <span class="header-slug_inner">
+                <header class="m-slug-header">
+                    <h2 class="a-heading">
                         Related questions
-                    </span>
-                </h2>
-                 <ul class="list list__unstyled list__links">
+                    </h2>
+                </header>
+                <ul class="list list__unstyled list__links">
                     {% for question in related_questions %}
                     <li class="list_item">
                         <a href="{{ slugurl(question.slug) }}" class="list_link">
                             {{ question.question | safe }}
                         </a>
                         </li>
-                    {% endfor %}  
+                    {% endfor %}
                 </ul>
             </div>
         </div>
     {% endif %}
-    <div class="analytics-data" 
+    <div class="analytics-data"
          data-answer-id="{{ answer_id }}"
          data-category-slug="{{ category.slug }}"
          data-category-name="{{ category.name }}">
     </div>
 {% endblock %}
-

--- a/cfgov/jinja2/v1/ask-cfpb/answer-page.html
+++ b/cfgov/jinja2/v1/ask-cfpb/answer-page.html
@@ -124,7 +124,7 @@
                         Related {{category.name}} subjects
                     </h2>
                 </header>
-                <ul class="m-list m-list__unstyled m-list__links">
+                <ul class="list list__unstyled list__links">
                     {% for subcat in subcategories %}
                         <li class="list_item">
 

--- a/cfgov/jinja2/v1/events/index.html
+++ b/cfgov/jinja2/v1/events/index.html
@@ -34,11 +34,11 @@
             <div class="content-l content-l__main">
                 <section class="u-mb20 content-l_col content-l_col-1-2">
                     <div class="u-mb30">
-                        <h2 class="header-slug">
-                            <span class="header-slug_inner">
+                        <header class="m-slug-header">
+                            <h2 class="a-heading">
                                 Stay informed
-                            </span>
-                        </h2>
+                            </h2>
+                        </header>
                         <p>
                             Subscribe to our email newsletter. We will update you on new event updates.
                         </p>

--- a/cfgov/jinja2/v1/index.html
+++ b/cfgov/jinja2/v1/index.html
@@ -26,11 +26,11 @@
         {% from 'molecules/info-unit.html' import info_unit with context %}
         <div class="o-well
                     o-well__full">
-            <h2 class="header-slug">
-                <span class="header-slug_inner">
+            <header class="m-slug-header">
+                <h2 class="a-heading">
                     Featured
-                </span>
-            </h2>
+                </h2>
+            </header>
             <div class="content-l">
                 {% for block in page.header %}
                     <section class="content-l_col content-l_col-1-2">

--- a/cfgov/jinja2/v1/job-description-page/index.html
+++ b/cfgov/jinja2/v1/job-description-page/index.html
@@ -141,11 +141,11 @@
 
 {% block content_sidebar scoped  %}
 <div class="block block__flush-top">
-    <h2 class="header-slug">
-        <span class="header-slug_inner">
+    <header class="m-slug-header">
+        <h2 class="a-heading">
             Before you apply
-        </span>
-    </h2>
+        </h2>
+    </header>
     <p>
         Consider exploring our information about working at the CFPB
         and our application process.
@@ -176,11 +176,11 @@
     ]) -}}
 </div>
 
-<h2 class="header-slug">
-    <span class="header-slug_inner">
+<header class="m-slug-header">
+    <h2 class="a-heading">
         Follow us on LinkedIn
-    </span>
-</h2>
+    </h2>
+</header>
 <p data-qa-hook="info-section-desc">
     The CFPB is one of the most searched for agencies
     in the federal government.

--- a/cfgov/jinja2/v1/newsroom/newsroom-page.html
+++ b/cfgov/jinja2/v1/newsroom/newsroom-page.html
@@ -17,11 +17,11 @@
 {% block content_main %}
     {% include 'article.html' %}
     <aside class="press-information">
-        <h2 class="header-slug">
-            <span class="header-slug_inner">
+        <header class="m-slug-header">
+            <h2 class="a-heading">
                 Press information
-            </span>
-        </h2>
+            </h2>
+        </header>
         <p>
             If you want to republish the article or have questions about the content,
             please contact the press office.

--- a/cfgov/jinja2/v1/newsroom/press-resources/index.html
+++ b/cfgov/jinja2/v1/newsroom/press-resources/index.html
@@ -215,11 +215,11 @@
         <div class="content-l content-l__main">
             <section class="content-l_col content-l_col-1-2"
                      data-qa-hook="stay-informed-section">
-                <h2 class="header-slug">
-                    <span class="header-slug_inner">
+                <header class="m-slug-header">
+                    <h2 class="a-heading">
                         Stay informed
-                    </span>
-                </h2>
+                    </h2>
+                </header>
                 <div class="block block__sub block__flush-top">
                     <p data-qa-hook="stay-informed-desc">
                         Subscribe to get our press releases by email.

--- a/cfgov/unprocessed/css/enhancements/typography.less
+++ b/cfgov/unprocessed/css/enhancements/typography.less
@@ -1,3 +1,24 @@
+// TODO: Remove after Capital Framework v4 is merged in.
+
+// .m-slug-header
+@slug-header_border__thin:  @gray-10; // $color-gray-dark
+@slug-header_border__thick: @green; // $color-primary-alt
+
+.m-slug-header {
+    margin-bottom: unit( 17px / @base-font-size-px, em );
+    border-top: 1px solid @slug-header_border__thin;
+
+    .a-heading {
+        .heading-5();
+
+        display: inline-block;
+
+        padding-top: unit( 4px / @font-size, em) ;
+        border-top: 5px solid @slug-header_border__thick;
+        margin-top: -3px;
+    }
+}
+
 /* topdoc
   name: Download links list
   family: cfgov-cf-enhancements

--- a/cfgov/unprocessed/css/enhancements/typography.less
+++ b/cfgov/unprocessed/css/enhancements/typography.less
@@ -5,7 +5,6 @@
 @slug-header_border__thick: @green; // $color-primary-alt
 
 .m-slug-header {
-    margin-bottom: unit( 17px / @base-font-size-px, em );
     border-top: 1px solid @slug-header_border__thin;
 
     .a-heading {

--- a/cfgov/unprocessed/css/misc.less
+++ b/cfgov/unprocessed/css/misc.less
@@ -33,11 +33,11 @@
       markup: |
         <div class="line-container line-container__no-top">
             <div class="line-container_body">
-                <h2 class="header-slug">
-                    <span class="header-slug_inner">
+                <header class="m-slug-header">
+                    <h2 class="a-heading">
                         Blog summary
-                    </span>
-                </h2>
+                    </h2>
+                </header>
                 <p>
                     Lorem ipsum dolor sit amet, consectetur adipisicing elit.
                     Dolorum ex provident dolorem ipsum molestias eius tenetur

--- a/cfgov/unprocessed/css/molecules/related-metadata.less
+++ b/cfgov/unprocessed/css/molecules/related-metadata.less
@@ -5,11 +5,11 @@
     - name: Default example
       markup: |
     <div class="m-related-metadata">
-        <h2 class="header-slug">
-            <span class="header-slug_inner">
+        <header class="m-slug-header">
+            <h2 class="a-heading">
                 Related Metadata
-            </span>
-        </h2>
+            </h2>
+        </header>
         <div class="m-related-metadata_item-container">
             <h4></h4>
             <ul class="list
@@ -35,8 +35,8 @@
         Structural cheat sheet:
         -----------------------
         .m-related-metadata
-          .header-slug
-            .header-slug_inner
+          .m-slug-header
+            .a-heading
         .m-related-metadata_item-container
           h4
           .list
@@ -115,7 +115,7 @@
             .grid_column(6);
         };
 
-        .header-slug {
+        .m-slug-header {
             margin-left: @margin_half__em;
             margin-right: @margin_half__em;
         }

--- a/cfgov/unprocessed/css/molecules/related-posts.less
+++ b/cfgov/unprocessed/css/molecules/related-posts.less
@@ -5,11 +5,11 @@
     - name: Default example
       markup: |
     <div class="m-related-posts">
-        <h2 class="header-slug">
-            <span class="header-slug_inner">
+        <header class="m-slug-header">
+            <h2 class="a-heading">
                 Related Posts
-            </span>
-        </h2>
+            </h2>
+        </header>
         <ul class="m-related-posts_list">
             <li class="list_item">
                 <h3 class="h4 u-mb5">
@@ -30,8 +30,8 @@
         Structural cheat sheet:
         -----------------------
         .m-related-posts
-          .header-slug
-            .header-slug_inner
+          .m-slug-header
+            .a-heading
         .m-related-posts_list
           .list-item
             h3

--- a/cfgov/unprocessed/css/organisms/sidebar-contact-info.less
+++ b/cfgov/unprocessed/css/organisms/sidebar-contact-info.less
@@ -6,11 +6,11 @@
     - name: Default example
       markup: |
         <div class="o-sidebar-contact-info">
-            <h2 class="header-slug">
-                <span class="header-slug_inner">
+            <header class="m-slug-header">
+                <h2 class="a-heading">
                     Contact Information
-                </span>
-            </h2>
+                </h2>
+            </header>
             <div class="o-sidebar-contact-info_column">
                 <figure>
                     <a href="#">

--- a/cfgov/unprocessed/css/post.less
+++ b/cfgov/unprocessed/css/post.less
@@ -213,11 +213,11 @@
                     consequatur itaque officiis debitis quisquam! Provident!
                 </p>
                 <aside class="post_inset post_inset__right line-container line-container__no-top">
-                    <h2 class="header-slug">
-                        <span class="header-slug_inner">
+                    <header class="m-slug-header">
+                        <h2 class="a-heading">
                             More information
-                        </span>
-                    </h2>
+                        </h2>
+                    </header>
                     <div class="line-container_body">
                         <ul class="list list__unstyled">
                             <li class="list_item list_item__spaced">

--- a/test/browser_tests/shared_objects/stay-informed-section.js
+++ b/test/browser_tests/shared_objects/stay-informed-section.js
@@ -9,7 +9,7 @@ var stayInformedSection = {
   stayInformedSection: _stayInformedSection,
 
   stayInformedSectionTitle:
-  _stayInformedSection.element( by.css( '.header-slug_inner' ) ),
+  _stayInformedSection.element( by.css( '.m-slug-header .a-heading' ) ),
 
   emailSubscribeForm: _emailSubscribeForm,
 


### PR DESCRIPTION
On the road to CFv4 migration…

## Changes

- Updates `header-slug` to use `m-slug-header` syntax from CFv4.

## Testing

1. `./frontend.sh`
2. Any page that has a header slug should be unchanged (though see note below).

## Notes

- A template for the header slug could be created in the future, as all these instances use the same format.

## Todos

- The old heading didn't have a bottom margin under the heading text, the new one does. Which is correct?

Before:

![screen shot 2017-06-21 at 4 44 14 pm](https://user-images.githubusercontent.com/704760/27405809-07c3d1d2-56a1-11e7-9fd1-a80885e4aa2e.png)

After:

![screen shot 2017-06-21 at 4 44 07 pm](https://user-images.githubusercontent.com/704760/27405819-0dba8fae-56a1-11e7-829f-8bdf9c162e9d.png)
