### PR TITLE
Restore logging config, allow separate behavior when run interactively

### DIFF
--- a/cfgov/cfgov/settings/production.py
+++ b/cfgov/cfgov/settings/production.py
@@ -15,6 +15,13 @@ LOGGING = {
             'level': 'DEBUG',
             'class': 'logging.StreamHandler',
         },
+        'disk': {
+            'level': 'INFO',
+            'class': 'logging.handlers.RotatingFileHandler',
+            'filename': os.getenv('CFGOV_DJANGO_LOG'),
+            'maxBytes': 1024*1024*10,  # max 10 MB per file
+            'backupCount': 5,  # keep 5 files around
+        },
     },
     'loggers': {
         'django.request': {
@@ -26,6 +33,11 @@ LOGGING = {
             'level': 'ERROR',
             'propagate': False,
         },
+        'v1': {
+            'handlers': ['disk'],
+            'level': 'INFO',
+            'propagate': True,
+        }
     }
 }
 

--- a/cfgov/cfgov/settings/production.py
+++ b/cfgov/cfgov/settings/production.py
@@ -1,7 +1,14 @@
+import sys
+
 from .base import *
 
-# Sends an email to developers in the ADMIN_EMAILS list if Debug=False for errors
+# log to disk when running in mod_wsgi, otherwise to console
+if sys.argv and sys.argv[0] == 'mod_wsgi':
+    default_loggers = ['disk']
+else:
+    default_loggers = ['console']
 
+# Sends an email to developers in the ADMIN_EMAILS list if Debug=False for errors
 LOGGING = {
     'version': 1,
     'disable_existing_loggers': False,
@@ -34,7 +41,7 @@ LOGGING = {
             'propagate': False,
         },
         'v1': {
-            'handlers': ['disk'],
+            'handlers': default_loggers,
             'level': 'INFO',
             'propagate': True,
         }

--- a/cfgov/cfgov/settings/production.py
+++ b/cfgov/cfgov/settings/production.py
@@ -3,6 +3,8 @@ import sys
 from .base import *
 
 # log to disk when running in mod_wsgi, otherwise to console
+# This avoids permissions problems when logged in users (or CI jobs)
+# can't write to the log file.
 if sys.argv and sys.argv[0] == 'mod_wsgi':
     default_loggers = ['disk']
 else:


### PR DESCRIPTION
Restores the disk-based logging config removed in 623a10f26ba502a6eb47a4217ff48bb0c937949b, but allows different behavior when django is being used interactively via manage.py or django-admin
## Additions

- Logs INFO messages to disk, when sys.argv[0] is 'mod_wsgi'
- otherwise, those messages get logged to the console

## Testing

- I'm not sure if there's a good way to test this locally, beyond manually hacking production.py to force disk logging. 


## Checklist

* [ ] PR has an informative and human-readable title
* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated
* [ ] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
