### PR TITLE
Don't create the disk logger unless we plan to use it

### DIFF
--- a/cfgov/cfgov/settings/production.py
+++ b/cfgov/cfgov/settings/production.py
@@ -24,13 +24,6 @@ LOGGING = {
             'level': 'DEBUG',
             'class': 'logging.StreamHandler',
         },
-        'disk': {
-            'level': 'INFO',
-            'class': 'logging.handlers.RotatingFileHandler',
-            'filename': os.getenv('CFGOV_DJANGO_LOG'),
-            'maxBytes': 1024*1024*10,  # max 10 MB per file
-            'backupCount': 5,  # keep 5 files around
-        },
     },
     'loggers': {
         'django.request': {
@@ -49,6 +42,15 @@ LOGGING = {
         }
     }
 }
+
+if 'disk' in default_loggers:
+   LOGGING['handlers']['disk'] = {
+            'level': 'INFO',
+            'class': 'logging.handlers.RotatingFileHandler',
+            'filename': os.getenv('CFGOV_DJANGO_LOG'),
+            'maxBytes': 1024*1024*10,  # max 10 MB per file
+            'backupCount': 5,  # keep 5 files around
+        }
 
 EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
 EMAIL_HOST = os.getenv('EMAIL_HOST')


### PR DESCRIPTION
This is a refinement to the changes added in #3073. We were still creating the disk logger, even in situations where we don't plan to use it (interactive, CI, etc), which can create permissions issues.

## Checklist

* [ ] PR has an informative and human-readable title
* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated
* [ ] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
