### PR TITLE
Add logging via syslog to production settings

### DIFF
--- a/cfgov/cfgov/settings/production.py
+++ b/cfgov/cfgov/settings/production.py
@@ -12,6 +12,7 @@ else:
     default_loggers = ['console', 'syslog']
 
 
+# This allows the syslog stuff to work on OS X
 syslog_device = next(l for l in ['/dev/log', '/var/run/syslog'] if exists(l))
 
 # Sends an email to developers in the ADMIN_EMAILS list if Debug=False for errors

--- a/cfgov/cfgov/settings/production.py
+++ b/cfgov/cfgov/settings/production.py
@@ -1,6 +1,7 @@
 import sys
 
 from .base import *
+from os.path import exists
 
 # log to disk when running in mod_wsgi, otherwise to console
 # This avoids permissions problems when logged in users (or CI jobs)
@@ -9,6 +10,9 @@ if sys.argv and sys.argv[0] == 'mod_wsgi':
     default_loggers = ['disk', 'syslog']
 else:
     default_loggers = ['console', 'syslog']
+
+
+syslog_device = next(l for l in ['/dev/log', '/var/run/syslog'] if exists(l))
 
 # Sends an email to developers in the ADMIN_EMAILS list if Debug=False for errors
 #
@@ -23,7 +27,7 @@ LOGGING = {
         'tagged': {
             'format': 'django: %(message)s'
                   },
-    }
+    },
     'handlers': {
         'mail_admins': {
             'level': 'ERROR',
@@ -35,7 +39,7 @@ LOGGING = {
             'class': 'logging.StreamHandler',
         },
         'syslog': {
-            'address': '/dev/log',
+            'address': syslog_device,
             'class': 'logging.handlers.SysLogHandler',
             'formatter': 'tagged'
         },


### PR DESCRIPTION
This adds a (parallel) logging configuration that utilizes the logging subsystem provided by the OS, instead of having Python and Django manage those files. This should prove more robust, since logging messages through syslog does not require any special privileges. 

If this works well, I think we should remove the 'disk' handler-- but there's no reason they can't live side-by-side until we make that call.

## Additions

- a 'syslog' log handler
- a 'tagged' formatter, that adds some metadata for easier filtering

## Testing

as things are right now, you should be set DJANGO_SETTINGS_MODULE=cfgov.settings.production, and do something that would write to the log. Perhaps in the django shell:

```
>>> import logging      
>>> logger = logging.getLogger(__name__)         
>>> logger.info("hey!") 
```

Unfortunately, on our workstations, these messages will get written to /var/log/system.log, which we do not have permission to read. You should be able to observe the timestamp and size of the file changing, at least 😢 .

## In production.

Without any further config, on linux these messages will be logged to /var/log/messages. There is a seperate PR that filters all messages tagged with "django" to /var/log/django.log

[GHE]/cfpb-infra/ansible-consumer-finance/pull/118

## Checklist

* [ ] PR has an informative and human-readable title
* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated
* [ ] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
