### PR TITLE
remove disk logging, in favor of syslog

### DIFF
--- a/cfgov/cfgov/settings/production.py
+++ b/cfgov/cfgov/settings/production.py
@@ -4,8 +4,6 @@ from .base import *
 from os.path import exists
 
 # log to disk when running in mod_wsgi, otherwise to console
-# This avoids permissions problems when logged in users (or CI jobs)
-# can't write to the log file.
 if sys.argv and sys.argv[0] == 'mod_wsgi':
     default_loggers = ['syslog']
 else:

--- a/cfgov/cfgov/settings/production.py
+++ b/cfgov/cfgov/settings/production.py
@@ -7,7 +7,7 @@ from os.path import exists
 # This avoids permissions problems when logged in users (or CI jobs)
 # can't write to the log file.
 if sys.argv and sys.argv[0] == 'mod_wsgi':
-    default_loggers = ['disk', 'syslog']
+    default_loggers = ['syslog']
 else:
     default_loggers = ['console', 'syslog']
 
@@ -62,15 +62,6 @@ LOGGING = {
         }
     }
 }
-
-if 'disk' in default_loggers:
-   LOGGING['handlers']['disk'] = {
-            'level': 'INFO',
-            'class': 'logging.handlers.RotatingFileHandler',
-            'filename': os.getenv('CFGOV_DJANGO_LOG'),
-            'maxBytes': 1024*1024*10,  # max 10 MB per file
-            'backupCount': 5,  # keep 5 files around
-        }
 
 EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
 EMAIL_HOST = os.getenv('EMAIL_HOST')


### PR DESCRIPTION
The 'disk' logger depends on the (apparently) fragile assumption that permissions won't change on the log file. In particular, it appears whenever the httpd packages is updated in RHEL6, ownership of those files is changed back to 'root'.

On Friday, we added the 'syslog' configuration that appears to be working pretty well, and depends on services provided by the operating system, instead of maintaining write-access to a particular file.


## Removals

- the 'disk' logger and associated logic


## Checklist

* [x] PR has an informative and human-readable title
* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated
* [ ] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
