### PR TITLE
Add the sortable table options to the Wagtail admin

### DIFF
--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -579,4 +579,10 @@ FLAGS = {
     # When enabled this flag will add various Google Optimize code snippets.
     # Intended for use with path conditions.
     'AB_TESTING': {},
+
+    # Add sortable tables to Wagtail
+    # When enabled, the sortable tables option will be added to the Wagtail Admin
+    # The template will render for the front-end, but the sortable code is missing
+    # and the table will not be sortable until cf-tables from CF 4.x is implemented
+    'SORTABLE_TABLES': {}
 }

--- a/cfgov/jinja2/v1/_includes/organisms/table.html
+++ b/cfgov/jinja2/v1/_includes/organisms/table.html
@@ -43,10 +43,11 @@
 {% endmacro %}
 
 <table class="o-table
-              {{ 'o-table__row-links' if value.row_links else '' }}
-              {{ 'o-table__stack-on-small' if value.is_stacked else '' }}
-              {{ 'table__striped' if value.is_striped else '' }}
-              {{ 'u-w100pct' if value.is_full_width else '' }}">
+              {{- ' o-table__row-links' if value.row_links else '' -}}
+              {{- ' o-table__stack-on-small' if value.is_stacked else '' -}}
+              {{- ' table__striped' if value.is_striped else '' -}}
+              {{- ' u-w100pct' if value.is_full_width else '' -}}
+              {{- ' o-table__sortable' if value.is_sortable else '' -}}">
     {% set row_index = 0 %}
     {% set first_row = value.data[row_index] %}
     {% if value.first_row_is_table_header and value.data | list | length > 0 %}
@@ -57,11 +58,18 @@
         {% if first_row | reject('none') | list | length %}
         <tr>
             {% for cell in value.data[0] %}
-                {% if value.fixed_col_widths %}
-                    {% set width_class = 'class="' + value.column_widths[loop.index0] + '"' %}
+                {% if value.fixed_col_widths and value.column_widths[loop.index0] != '' %}
+                    {% set width_class = ' class="' + value.column_widths[loop.index0] + '"' %}
                 {% endif %}
             <th scope="col"{{ width_class | default }}>
-                {{ _render_cell(cell) }}
+                {% if flag_enabled('SORTABLE_TABLES', true) and value.is_sortable and value.sortable_types[loop.index0] != '' %}
+                    {% set data_sort = ' data-sort_type="' + value.sortable_types[loop.index0] + '"' %}
+                    <button class="sortable"{{ data_sort }}>
+                        {{ _render_cell(cell) }}
+                    </button>
+                {% else %}
+                    {{ _render_cell(cell) }}
+                {% endif %}
             </th>
             {% endfor %}
         </tr>

--- a/cfgov/templates/wagtailadmin/css/table-block.css
+++ b/cfgov/templates/wagtailadmin/css/table-block.css
@@ -38,15 +38,15 @@
     font-size: 1.25em;
 }
 
-table[id $=fixed-width-column-input],
-table[id $=sortable-input] {
+table[id$=fixed-width-column-input],
+table[id$=sortable-input] {
     width: 100%;
     margin-bottom: 10px;
     display: none;
 }
 
-table[id $=fixed-width-column-input] .column-width-input,
-table[id $=sortable-input] .sortable-type-input {
+table[id$=fixed-width-column-input] .column-width-input,
+table[id$=sortable-input] .sortable-type-input {
     border: 1px solid #b4b5b6 !important;
     height: 1.875em;
     width: 100%;

--- a/cfgov/templates/wagtailadmin/css/table-block.css
+++ b/cfgov/templates/wagtailadmin/css/table-block.css
@@ -38,7 +38,8 @@
     font-size: 1.25em;
 }
 
-table[id $=fixed-width-column-input] {
+table[id $=fixed-width-column-input],
+table[id $=sortable-input] {
     width: 100%;
     margin-bottom: 10px;
     display: none;

--- a/cfgov/templates/wagtailadmin/css/table-block.css
+++ b/cfgov/templates/wagtailadmin/css/table-block.css
@@ -45,7 +45,8 @@ table[id $=sortable-input] {
     display: none;
 }
 
-table[id $=fixed-width-column-input] .column-width-input {
+table[id $=fixed-width-column-input] .column-width-input,
+table[id $=sortable-input] .sortable-type-input {
     border: 1px solid #b4b5b6 !important;
     height: 1.875em;
     width: 100%;

--- a/cfgov/templates/wagtailadmin/js/table-block.js
+++ b/cfgov/templates/wagtailadmin/js/table-block.js
@@ -33,7 +33,8 @@
                 HEIGHT: 1
             },
 
-            $colWidthSelect: {}
+            $colWidthSelect: {},
+            $sortableSelect: {}
         };
 
         var HandsonTable = {
@@ -121,6 +122,10 @@
                 .find( 'td' ).eq( index - 1 )
                 .after( '<td>' + utilities.$colWidthSelect + '</td>' );
 
+              HandsonTableWagtailBridge.ui.$sortableInput
+                .find( 'td' ).eq( index - 1 )
+                .after( '<td>' + utilities.$sortableSelect + '</td>' );
+
               this.$element.trigger( 'table:change', [this.instance.getData()] );
 
               return this;
@@ -144,6 +149,7 @@
                 var hiddenFieldData;
 
                 utilities.$colWidthSelect = $( this.ui.$inputContainer + ' .column-width-input' ).prop( 'outerHTML' );
+                utilities.$sortableSelect = $( this.ui.$inputContainer + ' .sortable-type-input' ).prop( 'outerHTML' );
 
                 this.options = utilities.assign( {} , options );
                 this.element = document.querySelector( this.ui.$inputContainer );
@@ -195,17 +201,30 @@
                 // On click, toggle visibility of fixed width inputs
                 $( id + '-handsontable-col-fixed' ).click( function() {
                   if ( $( this ).is( ':checked' ) ) {
-                    _this.toggleInputTable( true );
+                    _this.toggleInputTable( _this.ui.$fixedWidthColInput, true );
                   } else {
-                    _this.toggleInputTable( false );
+                    _this.toggleInputTable( _this.ui.$fixedWidthColInput, false );
+                  }
+                } );
+
+                // On click, toggle visibility of sortable inputs
+                $( id + '-handsontable-sortable' ).click( function() {
+                  if ( $( this ).is( ':checked' ) ) {
+                    _this.toggleInputTable( _this.ui.$sortableInput, true );
+                  } else {
+                    _this.toggleInputTable( _this.ui.$sortableInput, false );
                   }
                 } );
 
                 // On change of fixed width values, save data
                 $( id + '-fixed-width-column-input' ).on( 'change', '.column-width-input', function() {
                   _this.saveDataToHiddenField( 'no data' );
-                } )
+                } );
 
+                // On change of sortable values, save data
+                $( id + '-sortable-input' ).on( 'change', '.sortable-type-input', function() {
+                  _this.saveDataToHiddenField( 'no data' );
+                } );
             },
 
             ui: {
@@ -219,7 +238,9 @@
                 $isTableStripedCheckbox:    id + '-handsontable-striped-rows',
                 $fixedWidthColsCheckbox:    id + '-handsontable-col-fixed',
                 $fixedWidthColInput:        id + '-fixed-width-column-input',
-                $widthWarning:             id + '-width_warning',
+                $isSortableCheckbox:        id + '-handsontable-sortable',
+                $sortableInput:             id + '-sortable-input',
+                $widthWarning:              id + '-width_warning',
                 $resizeTargets:             '.input > .handsontable, .wtHider, .wtHolder'
             },
 
@@ -234,7 +255,8 @@
                               is_full_width:               ui.$isFullWidthCheckbox,
                               is_striped:                  ui.$isTableStripedCheckbox,
                               is_stacked:                  ui.$isStackedOnMobileCheckbox,
-                              fixed_col_widths:            ui.$fixedWidthColsCheckbox
+                              fixed_col_widths:            ui.$fixedWidthColsCheckbox,
+                              is_sortable:                 ui.$isSortableCheckbox
                           };
 
                     Object.keys( uiMap ).forEach( function( key ) {
@@ -246,18 +268,31 @@
 
                 // update fixed width input to match table
                 var count = this.handsonTable.instance.countCols();
-                var row = this.ui.$fixedWidthColInput.find( 'tr' );
-                row.empty();
+                var fixedWidthRow = this.ui.$fixedWidthColInput.find( 'tr' );
+                fixedWidthRow.empty();
                 for ( var x = 0; x < count; x++ ) {
-                  row.append( '<td>' + utilities.$colWidthSelect + '</td>' );
+                  fixedWidthRow.append( '<td>' + utilities.$colWidthSelect + '</td>' );
+                }
+
+                var sortableRow = this.ui.$sortableInput.find( 'tr' );
+                sortableRow.empty();
+                for ( var x = 0; x < count; x++ ) {
+                  sortableRow.append( '<td>' + utilities.$sortableSelect + '</td>' );
                 }
 
                 if ( ui.$fixedWidthColsCheckbox.is( ':checked' ) ) {
-                  this.toggleInputTable( true );
+                  this.toggleInputTable( this.ui.$fixedWidthColInput, true );
                   ui.$fixedWidthColInput.find( 'td' ).each( function( index, value) {
                     $( this ).find( 'select' ).val( hiddenFieldData.column_widths[index] );
                   } )
                   this.getColumnWidths();
+                }
+
+                if ( ui.$isSortableCheckbox.is( ':checked' ) ) {
+                  this.toggleInputTable( this.ui.$sortableInput, true );
+                  ui.$sortableInput.find( 'td' ).each( function( index, value) {
+                    $( this ).find( 'select' ).val( hiddenFieldData.sortable_types[index] );
+                  } )
                 }
             },
 
@@ -275,11 +310,13 @@
                   array = [],
                   totalWidth = 0;
 
-              for ( var x = 0; x <  colCount; x++ ) {
+              for ( var x = 0; x < colCount; x++ ) {
                 var i = x + 1;
-                var widthClass = this.ui.$fixedWidthColInput.find( 'tr td:nth-child( ' + i + ') select option:selected' ).val()
+                var widthClass = this.ui.$fixedWidthColInput
+                                     .find( 'tr td:nth-child( ' + i + ') select option:selected' )
+                                     .val();
                 if ( widthClass !== '' ) {
-                  totalWidth += Number( widthClass.substring(3, 5) );
+                  totalWidth += Number( widthClass.substring( 3, 5 ) );
                 } else {
                   totalWidth += 1;
                 }
@@ -302,6 +339,21 @@
 
                 return tableParent.find( '.htCore' ).height() +
                        ( tableParent.find( '.input' ).height() * 2 );
+            },
+
+            getSortableTypes: function getColumnWidths() {
+              var colCount = this.ui.$sortableInput.find( 'tr td' ).length,
+                  array = [];
+
+              for ( var x = 0; x < colCount; x++ ) {
+                var i = x + 1;
+
+                array[x] = this.ui.$sortableInput
+                               .find( 'tr td:nth-child( ' + i + ') select option:selected' )
+                               .val();
+              }
+
+              return array;
             },
 
             getHiddenFieldData: function getHiddenFieldData() {
@@ -344,12 +396,14 @@
                 ui.$hiddenField.val( JSON.stringify( {
                     data:                      this.handsonTable.instance.getData(),
                     column_widths:             this.getColumnWidths(),
+                    sortable_types:            this.getSortableTypes(),
                     first_row_is_table_header: ui.$hasRowHeaderCheckbox.prop( 'checked' ),
                     first_col_is_header:       ui.$hasColHeaderCheckbox.prop( 'checked' ),
                     is_full_width:             ui.$isFullWidthCheckbox.prop( 'checked' ),
                     is_striped:                ui.$isTableStripedCheckbox.prop( 'checked' ),
                     is_stacked:                ui.$isStackedOnMobileCheckbox.prop( 'checked' ),
-                    fixed_col_widths:          ui.$fixedWidthColsCheckbox.prop( 'checked' )
+                    fixed_col_widths:          ui.$fixedWidthColsCheckbox.prop( 'checked' ),
+                    is_sortable:               ui.$isSortableCheckbox.prop( 'checked' )
                 } ) );
             },
 
@@ -375,11 +429,11 @@
                 this.saveDataToHiddenField();
             },
 
-            toggleInputTable: function toggleInputTable( visible ) {
-              if ( visible === true ) {
-                this.ui.$fixedWidthColInput.show();
+            toggleInputTable: function toggleInputTable( inputTable, state = true  ) {
+              if ( state === true ) {
+                inputTable.show();
               } else {
-                this.ui.$fixedWidthColInput.hide();
+                inputTable.hide();
               }
             }
         };

--- a/cfgov/templates/wagtailadmin/js/table-block.js
+++ b/cfgov/templates/wagtailadmin/js/table-block.js
@@ -238,9 +238,9 @@
                 $isTableStripedCheckbox:    id + '-handsontable-striped-rows',
                 $fixedWidthColsCheckbox:    id + '-handsontable-col-fixed',
                 $fixedWidthColInput:        id + '-fixed-width-column-input',
+                $widthWarning:              id + '-width_warning',
                 $isSortableCheckbox:        id + '-handsontable-sortable',
                 $sortableInput:             id + '-sortable-input',
-                $widthWarning:              id + '-width_warning',
                 $resizeTargets:             '.input > .handsontable, .wtHider, .wtHolder'
             },
 
@@ -274,6 +274,7 @@
                   fixedWidthRow.append( '<td>' + utilities.$colWidthSelect + '</td>' );
                 }
 
+                // update sortable input to match table
                 var sortableRow = this.ui.$sortableInput.find( 'tr' );
                 sortableRow.empty();
                 for ( var x = 0; x < count; x++ ) {
@@ -282,17 +283,17 @@
 
                 if ( ui.$fixedWidthColsCheckbox.is( ':checked' ) ) {
                   this.toggleInputTable( this.ui.$fixedWidthColInput, true );
-                  ui.$fixedWidthColInput.find( 'td' ).each( function( index, value) {
+                  ui.$fixedWidthColInput.find( 'td' ).each( function( index, value ) {
                     $( this ).find( 'select' ).val( hiddenFieldData.column_widths[index] );
-                  } )
+                  } );
                   this.getColumnWidths();
                 }
 
                 if ( ui.$isSortableCheckbox.is( ':checked' ) ) {
                   this.toggleInputTable( this.ui.$sortableInput, true );
-                  ui.$sortableInput.find( 'td' ).each( function( index, value) {
+                  ui.$sortableInput.find( 'td' ).each( function( index, value ) {
                     $( this ).find( 'select' ).val( hiddenFieldData.sortable_types[index] );
-                  } )
+                  } );
                 }
             },
 
@@ -313,7 +314,7 @@
               for ( var x = 0; x < colCount; x++ ) {
                 var i = x + 1;
                 var widthClass = this.ui.$fixedWidthColInput
-                                     .find( 'tr td:nth-child( ' + i + ') select option:selected' )
+                                     .find( 'tr td:nth-child( ' + i + ' ) select option:selected' )
                                      .val();
                 if ( widthClass !== '' ) {
                   totalWidth += Number( widthClass.substring( 3, 5 ) );
@@ -341,7 +342,7 @@
                        ( tableParent.find( '.input' ).height() * 2 );
             },
 
-            getSortableTypes: function getColumnWidths() {
+            getSortableTypes: function getSortableTypes() {
               var colCount = this.ui.$sortableInput.find( 'tr td' ).length,
                   array = [];
 
@@ -349,7 +350,7 @@
                 var i = x + 1;
 
                 array[x] = this.ui.$sortableInput
-                               .find( 'tr td:nth-child( ' + i + ') select option:selected' )
+                               .find( 'tr td:nth-child( ' + i + ' ) select option:selected' )
                                .val();
               }
 

--- a/cfgov/templates/wagtailadmin/table_input.html
+++ b/cfgov/templates/wagtailadmin/table_input.html
@@ -18,7 +18,9 @@
     <label for="{{ attrs.id }}-handsontable-striped-rows">Striped rows</label>
     <div class="field-content">
         <div class="input">
-            <input type="checkbox" id="{{ attrs.id }}-handsontable-striped-rows" name="handsontable-striped-rows"/>
+            <input type="checkbox"
+                   id="{{ attrs.id }}-handsontable-striped-rows"
+                   name="handsontable-striped-rows">
             <span class="help">( Display the Table with striped rows )</span>
         </div>
 
@@ -28,7 +30,9 @@
     <label for="{{ attrs.id }}-handsontable-striped-rows">Stacked on mobile</label>
     <div class="field-content">
         <div class="input">
-            <input type="checkbox" id="{{ attrs.id }}-handsontable-stack-on-mobile" name="handsontable-stack-on-mobile"/>
+            <input type="checkbox"
+                   id="{{ attrs.id }}-handsontable-stack-on-mobile"
+                   name="handsontable-stack-on-mobile">
             <span class="help">( Stack the table columns on mobile )</span>
         </div>
     </div>
@@ -37,7 +41,9 @@
     <label for="{{ attrs.id }}-handsontable-full-width">Full-width</label>
     <div class="field-content">
         <div class="input">
-            <input type="checkbox" id="{{ attrs.id }}-handsontable-full-width" name="handsontable-full-width"/>
+            <input type="checkbox"
+                   id="{{ attrs.id }}-handsontable-full-width"
+                   name="handsontable-full-width">
             <span class="help">( Display the table at full-width )</span>
         </div>
     </div>
@@ -46,7 +52,9 @@
     <label for="{{ attrs.id }}-handsontable-header">Row header</label>
     <div class="field-content">
         <div class="input">
-            <input type="checkbox" id="{{ attrs.id }}-handsontable-header" name="handsontable-header"/>
+            <input type="checkbox"
+                   id="{{ attrs.id }}-handsontable-header"
+                   name="handsontable-header">
             <span class="help">( Display the first row as a header )</span>
         </div>
     </div>
@@ -55,7 +63,9 @@
     <label for="{{ attrs.id }}-handsontable-col-header">Column header</label>
     <div class="field-content">
         <div class="input">
-            <input type="checkbox" id="{{ attrs.id }}-handsontable-col-header" name="handsontable-col-header"/>
+            <input type="checkbox"
+                   id="{{ attrs.id }}-handsontable-col-header"
+                   name="handsontable-col-header">
             <span class="help">( Display the first column as a header )</span>
         </div>
     </div>
@@ -64,7 +74,9 @@
     <label for="{{ attrs.id }}-handsontable-col-fixed">Fixed-width columns</label>
     <div class="field-content">
         <div class="input">
-            <input type="checkbox" id="{{ attrs.id }}-handsontable-col-fixed" name="handsontable-col-fixed"/>
+            <input type="checkbox"
+                   id="{{ attrs.id }}-handsontable-col-fixed"
+                   name="handsontable-col-fixed">
             <span class="help">( Enable fixed width columns )</span>
         </div>
     </div>
@@ -73,40 +85,19 @@
     <label for="{{ attrs.id }}-handsontable-sortable">Sortable table</label>
     <div class="field-content">
         <div class="input">
-            <input type="checkbox" id="{{ attrs.id }}-handsontable-sortable" name="handsontable-sortable"/>
+            <input type="checkbox"
+                   id="{{ attrs.id }}-handsontable-sortable"
+                   name="handsontable-sortable">
             <span class="help">( Enable sortable table functionality )</span>
         </div>
     </div>
 </div>
-<br/>
-<div id="{{ attrs.id }}-width_warning" class="table-block-warning">Warning! Your total column width is greater than 100%! Please adjust your column widths to be less than 100% total before continuing.</div>
-
-<table id="{{ attrs.id }}-sortable-input">
-  <thead>Sortable Table Options</thead>
-  <tr>
-    <td>
-      <select class="sortable-type-input">
-        <option value="">None</option>
-        <option value="string">Default</option>
-        <option value="number">Number</option>
-      </select>
-    </td>
-    <td>
-      <select class="sortable-type-input">
-        <option value="">None</option>
-        <option value="string">Default</option>
-        <option value="number">Number</option>
-      </select>
-    </td>
-    <td>
-      <select class="sortable-type-input">
-        <option value="">None</option>
-        <option value="string">Default</option>
-        <option value="number">Number</option>
-      </select>
-    </td>
-  </tr>
-</table>
+<br>
+<div id="{{ attrs.id }}-width_warning"
+     class="table-block-warning">
+    Warning! Your total column width is greater than 100%!
+    Please adjust your column widths to be less than 100% total before continuing.
+</div>
 
 <table id="{{ attrs.id }}-fixed-width-column-input">
   <thead>Fixed Width Column Options</thead>
@@ -173,6 +164,34 @@
     </td>
   </tr>
 </table>
+
+<table id="{{ attrs.id }}-sortable-input">
+  <thead>Sortable Table Options</thead>
+  <tr>
+    <td>
+      <select class="sortable-type-input">
+        <option value="">None</option>
+        <option value="string">Alphabetical</option>
+        <option value="number">Number</option>
+      </select>
+    </td>
+    <td>
+      <select class="sortable-type-input">
+        <option value="">None</option>
+        <option value="string">Alphabetical</option>
+        <option value="number">Number</option>
+      </select>
+    </td>
+    <td>
+      <select class="sortable-type-input">
+        <option value="">None</option>
+        <option value="string">Alphabetical</option>
+        <option value="number">Number</option>
+      </select>
+    </td>
+  </tr>
+</table>
+
 <div id="{{ attrs.id }}-handsontable-container"></div>
 
 {{ original_field_html }}

--- a/cfgov/templates/wagtailadmin/table_input.html
+++ b/cfgov/templates/wagtailadmin/table_input.html
@@ -100,7 +100,6 @@
 </div>
 
 <table id="{{ attrs.id }}-fixed-width-column-input">
-  <thead>Fixed Width Column Options</thead>
   <tr>
     <td>
       <p class="column-width-input_container">
@@ -166,27 +165,26 @@
 </table>
 
 <table id="{{ attrs.id }}-sortable-input">
-  <thead>Sortable Table Options</thead>
   <tr>
     <td>
       <select class="sortable-type-input">
         <option value="">None</option>
         <option value="string">Alphabetical</option>
-        <option value="number">Number</option>
+        <option value="number">Numberical</option>
       </select>
     </td>
     <td>
       <select class="sortable-type-input">
         <option value="">None</option>
         <option value="string">Alphabetical</option>
-        <option value="number">Number</option>
+        <option value="number">Numberical</option>
       </select>
     </td>
     <td>
       <select class="sortable-type-input">
         <option value="">None</option>
         <option value="string">Alphabetical</option>
-        <option value="number">Number</option>
+        <option value="number">Numberical</option>
       </select>
     </td>
   </tr>

--- a/cfgov/templates/wagtailadmin/table_input.html
+++ b/cfgov/templates/wagtailadmin/table_input.html
@@ -69,8 +69,44 @@
         </div>
     </div>
 </div>
+<div class="field boolean_field widget-checkbox_input">
+    <label for="{{ attrs.id }}-handsontable-sortable">Sortable table</label>
+    <div class="field-content">
+        <div class="input">
+            <input type="checkbox" id="{{ attrs.id }}-handsontable-sortable" name="handsontable-sortable"/>
+            <span class="help">( Enable sortable table functionality )</span>
+        </div>
+    </div>
+</div>
 <br/>
 <div id="{{ attrs.id }}-width_warning" class="table-block-warning">Warning! Your total column width is greater than 100%! Please adjust your column widths to be less than 100% total before continuing.</div>
+
+<table id="{{ attrs.id }}-sortable-input">
+  <tr>
+    <td>
+      <select class="sortable-type-input">
+        <option value="">None</option>
+        <option value="string">Default</option>
+        <option value="number">Number</option>
+      </select>
+    </td>
+    <td>
+      <select class="sortable-type-input">
+        <option value="">None</option>
+        <option value="string">Default</option>
+        <option value="number">Number</option>
+      </select>
+    </td>
+    <td>
+      <select class="sortable-type-input">
+        <option value="">None</option>
+        <option value="string">Default</option>
+        <option value="number">Number</option>
+      </select>
+    </td>
+  </tr>
+</table>
+
 <table id="{{ attrs.id }}-fixed-width-column-input">
   <tr>
     <td>

--- a/cfgov/templates/wagtailadmin/table_input.html
+++ b/cfgov/templates/wagtailadmin/table_input.html
@@ -82,6 +82,7 @@
 <div id="{{ attrs.id }}-width_warning" class="table-block-warning">Warning! Your total column width is greater than 100%! Please adjust your column widths to be less than 100% total before continuing.</div>
 
 <table id="{{ attrs.id }}-sortable-input">
+  <thead>Sortable Table Options</thead>
   <tr>
     <td>
       <select class="sortable-type-input">
@@ -108,6 +109,7 @@
 </table>
 
 <table id="{{ attrs.id }}-fixed-width-column-input">
+  <thead>Fixed Width Column Options</thead>
   <tr>
     <td>
       <p class="column-width-input_container">

--- a/test/browser_tests/cucumber/features/suites/wagtail-admin/wagtail-admin-sortable-tables.feature
+++ b/test/browser_tests/cucumber/features/suites/wagtail-admin/wagtail-admin-sortable-tables.feature
@@ -7,8 +7,8 @@ Feature: Rich Text Editor
     Given I am logged into Wagtail as an admin
     And I create a Wagtail Browse Page
     And I open the content menu
-    And I select the Row header option
     And I select the table block option
+    And I select the Row header option
     And I enter "Example 1" in the first column of the first row
     And I enter "Example 2" in the second column of the first row
     And I enter "Example 3" in the third column of the first row

--- a/test/browser_tests/cucumber/features/suites/wagtail-admin/wagtail-admin-sortable-tables.feature
+++ b/test/browser_tests/cucumber/features/suites/wagtail-admin/wagtail-admin-sortable-tables.feature
@@ -1,0 +1,30 @@
+
+Feature: Rich Text Editor
+  As a user of Wagtail
+  I should be able to set sortable options on a table
+
+  Background:
+    Given I am logged into Wagtail as an admin
+    And I create a Wagtail Browse Page
+    And I open the content menu
+    And I select the Row header option
+    And I select the table block option
+    And I enter "Example 1" in the first column of the first row
+    And I enter "Example 2" in the second column of the first row
+    And I enter "Example 3" in the third column of the first row
+
+  Scenario: Turn on sortable tables
+    When I check the "Sortable table" option
+    Then the editor should display the "Sortable Table Options" table
+
+  Scenario: Select Alphabetical sorting
+    When I select the Alphabetical option for the first column
+    Then "Example 1" should be wrapped in a button tag with a data-sort_type="string" attribute
+
+  Scenario: Select Numerical
+    When I select the Alphabetical option for the second column
+    Then "Example 2" should be wrapped in a button tag with a data-sort_type="number" attribute
+
+  Scenario: Select None
+    When I select the None option for the third column
+    Then "Example 3" should be wrapped in a p tag


### PR DESCRIPTION
This is step one of adding sortable tables to Wagtail. It includes the admin options, the front-end markup, and a feature flag to protect the front-end. The front-end won't work until the project has been updated to use cf-tables v4.x. When that work is complete, the feature flag should be removed.

## Additions

- Added sortable code to admin template
- Added sortable code to front-end template
- Added scripting to allow user interaction and data saving
- Added feature flag to protect the rendered template until cf-tables v4.x is implemented

## Changes

- Cleaned up some of the existing code to match our formatting standards.

## Testing

I'm not sure how to test this programmatically, maybe a back-end dev could lend a hand? To test locally, run the site, log in to the admin, and create a table, then:

1. Select the checkbox marked `Sortable table`.
2. Select either `default` or `number` from the sortable options that appear above the table.
3. Save the page, make sure the data has saved and the options appear correctly on reload.
4. Preview the page and verify there are no changes on the rendered template (because they are hidden behind the flag).

## Screenshots

<img width="737" alt="screen shot 2017-06-27 at 9 32 15 am" src="https://user-images.githubusercontent.com/1280430/27592967-8d40fdd4-5b1b-11e7-802b-db0338724261.png">

## Checklist

* [x] PR has an informative and human-readable title
* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [x] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated
* [x] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
