### PR TITLE
Migrate filter to CFv4

### DIFF
--- a/cfgov/jinja2/v1/_includes/organisms/filterable-list-controls.html
+++ b/cfgov/jinja2/v1/_includes/organisms/filterable-list-controls.html
@@ -19,17 +19,19 @@
 {% from 'organisms/expandable.html' import expandable with context %}
 
 {% macro _filter_selectable(type, index, label_text, id, name, value, required=None, group=None) %}
-    <input class="cf-input"
-           type="{{ type }}"
-           value="{{ value }}"
-           id="filter{{ index }}_{{ id }}"
-           name="filter{{ index }}_{{ name }}"
-           {{ 'data-required=' ~ required if required else ''  }}
-           {{ 'data-group=' ~ group if group else ''  }}
-           {{ 'checked' if is_filter_selected('filter' ~ index ~ '_' ~ name, value) else '' }}>
-    <label for="filter{{ index }}_{{ id }}" >
-        {{ label_text if label_text else value }}
-    </label>
+    <li class="m-form-field m-form-field__checkbox">
+        <input class="{{ 'a-checkbox' if type == 'checkbox' else 'a-radio' }}"
+               type="{{ type }}"
+               value="{{ value }}"
+               id="filter{{ index }}_{{ id }}"
+               name="filter{{ index }}_{{ name }}"
+               {{ 'data-required=' ~ required if required else ''  }}
+               {{ 'data-group=' ~ group if group else ''  }}
+               {{ 'checked' if is_filter_selected('filter' ~ index ~ '_' ~ name, value) else '' }}>
+        <label class="a-label"  for="filter{{ index }}_{{ id }}">
+            {{ label_text if label_text else value }}
+        </label>
+    </li>
 {% endmacro %}
 
 {% macro _filter_option(label_text, value) %}
@@ -42,102 +44,114 @@
 {% macro _render_filter_fields(controls, form, index) -%}
     {% if controls.title %}
         {% set field_id = 'filter' ~ index ~ '_title' %}
-        <div class="form-l_col
-                    form-l_col-1">
-            <div class="form-group">
-                <label class="form-label-header"
-                       for="{{ field_id }}">
-                    Item name
-                </label>
-                {{ form.render_with_id(form.title, field_id) }}
+        <div class="content-l_col
+                    content-l_col-1">
+            <div class="o-form_group">
+                <fieldset class="o-form_fieldset">
+                    <label class="a-label a-label__heading"
+                           for="{{ field_id }}">
+                        Item name
+                    </label>
+                    {{ form.render_with_id(form.title, field_id) }}
+                </fieldset>
             </div>
         </div>
     {% endif %}
     {% if controls.categories.filter_category %}
-        <div class="form-l_col
-                    form-l_col-1-3">
-            <div class="form-group">
-                <label class="form-label-header"
-                       for="categories">
-                    {% if 'leadership-calendar' in controls.categories.page_type %}
-                        Calendars
-                        </label>
-                        {% for slug, name in choices_for_page_type(controls.categories.page_type) %}
-                            {{ _filter_selectable('radio', index, category_label(slug), 'categories_' ~ slug, 'categories', slug) }}
-                        {% endfor %}
-                    {% else %}
-                        Category
-                        </label>
-                        {% for slug, name in choices_for_page_type(controls.categories.page_type) %}
-                            {{ _filter_selectable('checkbox', index, category_label(slug), 'categories_' ~ slug, 'categories', slug) }}
-                        {% endfor %}
-                    {% endif %}
+        <div class="content-l_col
+                    content-l_col-1-3">
+            <div class="o-form_group">
+                <fieldset class="o-form_fieldset">
+                    <legend class="a-label a-label__heading"
+                            for="categories">
+                        {% if 'leadership-calendar' in controls.categories.page_type %}
+                            Calendars
+                            </legend>
+                            <ul class="m-list m-list__unstyled">
+                            {% for slug, name in choices_for_page_type(controls.categories.page_type) %}
+                                {{ _filter_selectable('radio', index, category_label(slug), 'categories_' ~ slug, 'categories', slug) }}
+                            {% endfor %}
+                            </ul>
+                        {% else %}
+                            Category
+                            </legend>
+                            <ul class="m-list m-list__unstyled">
+                            {% for slug, name in choices_for_page_type(controls.categories.page_type) %}
+                                {{ _filter_selectable('checkbox', index, category_label(slug), 'categories_' ~ slug, 'categories', slug) }}
+                            {% endfor %}
+                            </ul>
+                        {% endif %}
+                  </fieldset>
             </div>
         </div>
     {% endif %}
     {% if controls.topics or controls.authors or controls.date_range %}
-        <div class="form-l_col
-                    form-l_col__flush-bottom
-                    form-l_col-2-3">
-            <div class="form-l">
+        <div class="content-l_col
+                    content-l_col-2-3">
+            <div class="content-l">
                 {% if controls.topics %}
                     {% set field_id = 'filter' ~ index ~ '_topics' %}
-                    <div class="form-l_col
-                                form-l_col-1-2">
-                        <div class="form-group">
-                            <label class="form-label-header"
-                                   for="{{ field_id }}">
-                                Topic
-                            </label>
-                            {{ form.render_with_id(form.topics, field_id) }}
+                    <div class="content-l_col
+                                content-l_col-1-2">
+                        <div class="o-form_group">
+                            <fieldset class="o-form_fieldset">
+                                <label class="a-label a-label__heading"
+                                       for="{{ field_id }}">
+                                    Topic
+                                </label>
+                                {{ form.render_with_id(form.topics, field_id) }}
+                            </fieldset>
                         </div>
                     </div>
                 {% endif %}
                 {% if controls.authors %}
                     {% set field_id = 'filter' ~ index ~ '_authors' %}
-                    <div class="form-l_col
-                                form-l_col-1-2">
-                        <div class="form-group">
-                            <label class="form-label-header"
-                                   for="{{ field_id }}">
-                                Author
-                            </label>
-                            {{ form.render_with_id(form.authors, field_id) }}
+                    <div class="content-l_col
+                                content-l_col-1-2">
+                        <div class="o-form_group">
+                            <fieldset class="o-form_fieldset">
+                                <label class="a-label a-label__heading"
+                                       for="{{ field_id }}">
+                                    Author
+                                </label>
+                                {{ form.render_with_id(form.authors, field_id) }}
+                            </fieldset>
                         </div>
                     </div>
                 {% endif %}
                 {% if controls.date_range %}
-                    <div class="form-l_col
-                                form-l_col__flush-bottom
-                                form-l_col-1">
-                        <div class="form-group">
-                            <label class="form-label-header">
-                                Date range
-                            </label>
-                            <div class="form-l">
-                                <div class="form-l_col
-                                            form-l_col-1-2">
-                                    <div class="form-group">
-                                        <label class="form-label-header"
-                                               for="{{ 'filter' ~ index ~ '_from_date' }}">
-                                            From:
-                                        </label>
-                                        {{ form.render_with_id(form.from_date,
-                                           'filter' ~ index ~ '_from_date') }}
+                    <div class="content-l_col
+                                content-l_col-1">
+                        <div class="o-form_group">
+                            <fieldset class="o-form_fieldset">
+                                <label class="a-label a-label__heading">
+                                    Date range
+                                </label>
+                                <div class="content-l">
+                                    <div class="content-l_col
+                                                content-l_col-1-2">
+                                        <div class="o-form_group">
+                                            <label class="a-label a-label__heading"
+                                                   for="{{ 'filter' ~ index ~ '_from_date' }}">
+                                                From:
+                                            </label>
+                                            {{ form.render_with_id(form.from_date,
+                                               'filter' ~ index ~ '_from_date') }}
+                                        </div>
+                                    </div>
+                                    <div class="content-l_col
+                                                content-l_col-1-2">
+                                        <div class="o-form_group">
+                                            <label class="a-label a-label__heading"
+                                                   for="{{ 'filter' ~ index ~ '_to_date' }}">
+                                                To:
+                                            </label>
+                                            {{ form.render_with_id(form.to_date,
+                                               'filter' ~ index ~ '_to_date') }}
+                                        </div>
                                     </div>
                                 </div>
-                                <div class="form-l_col
-                                            form-l_col-1-2">
-                                    <div class="form-group">
-                                        <label class="form-label-header"
-                                               for="{{ 'filter' ~ index ~ '_to_date' }}">
-                                            To:
-                                        </label>
-                                        {{ form.render_with_id(form.to_date,
-                                           'filter' ~ index ~ '_to_date') }}
-                                    </div>
-                                </div>
-                            </div>
+                            </fieldset>
                         </div>
                     </div>
                 {% endif %}
@@ -158,15 +172,15 @@
         {% endif %}
         <input type="hidden" name="form-id" id="form-id" value="{{ index }}">
 
-        <div class="form-l">
+        <div class="content-l">
             {{ _render_filter_fields(controls, form, index) }}
-            <div class="form-l_col
-                        form-l_col__flush-bottom
-                        form-l_col-1">
-                <input class="btn form-actions_item"
+            <div class="content-l_col
+                        content-l_col-1
+                        m-btn-group">
+                <input class="btn"
                        type="submit"
                        value="Apply filters">
-                <a class="btn btn__warning btn__link"
+                <a class="btn btn__link btn__warning"
                    href="{{ request.path }}">
                     Clear filters
                 </a>

--- a/cfgov/unprocessed/css/enhancements/forms.less
+++ b/cfgov/unprocessed/css/enhancements/forms.less
@@ -1,3 +1,132 @@
+// TODO: Remove after Capital Framework v4 is merged in.
+
+.a-label {
+    display: inline-block;
+}
+
+.a-label__heading {
+    .heading-4();
+
+    display: block;
+
+    // Overwrites heading-5 margin.
+    margin-bottom: 10px;
+}
+
+
+@input-border__focused: @pacific;
+@input-bg__disabled: @gray-5;
+
+.m-form-field {
+    .a-text-input {
+        box-sizing: border-box;
+        width: 100%;
+    }
+
+    .a-label + .a-text-input {
+        margin-top: 5px;
+    }
+
+    &__checkbox,
+    &__radio {
+        .a-label {
+            vertical-align: middle;
+            cursor: pointer;
+
+            &:before {
+                display: inline-block;
+
+                border: 1px solid @input-border;
+                height: unit( 18px / @base-font-size-px, em );
+                width: unit( 18px / @base-font-size-px, em );
+                margin-right: 10px;
+
+                background-color: @input-bg;
+                content: '';
+                vertical-align: top;
+
+                .lt-ie9 & {
+                    display: none !important;
+                }
+            }
+
+            &:hover:before {
+                border-color: @input-border__focused;
+            }
+        }
+
+        .a-checkbox,
+        .a-radio {
+            .u-visually-hidden();
+
+            .lt-ie9 & {
+                height: 20px;
+                width: 20px;
+                border: 0;
+                float: left;
+                margin: 1em;
+                position: static;
+                width: auto;
+                clear: both;
+            }
+
+            &:disabled + .a-label {
+                cursor: not-allowed;
+
+                &:before {
+                    border-color: @input-border;
+                    background: @input-bg__disabled;
+                }
+            }
+        }
+    }
+
+    &__checkbox {
+        .a-label {
+            &:before {
+                font-family: 'CFPB Minicons';
+                text-align: center;
+                line-height: unit( 18px / @base-font-size-px, em );
+            }
+        }
+
+        .a-checkbox {
+            &:focus + .a-label:before,
+            &:hover + .a-label:before {
+                border-color: @input-border__focused;
+                outline: 1px solid @input-border__focused;
+            }
+
+            &:checked + .a-label:before {
+                content: @cf-icon-approved;
+            }
+        }
+    }
+}
+
+.o-form {
+    &_group {
+        margin-bottom: 30px;
+    }
+
+    &_fieldset {
+        // Overwrite Normalize.
+        border: none;
+        margin: 0;
+        padding: 0;
+
+        .m-field + .m-field {
+            margin-top: 10px;
+        }
+    }
+}
+
+.o-form_fieldset .a-text-input {
+  box-sizing: border-box;
+  width: 100%;
+}
+
+
 /* topdoc
   name: Set form elements to base webfont
   family: cf-core
@@ -324,14 +453,14 @@ legend {
           .input-with-btn.input-with-btn__bar
             .input-with-btn_input
             .input-with-btn_btn
-  notes: "Displays as single unit, with button attached to end of input. 
+  notes: "Displays as single unit, with button attached to end of input.
           Input fills all space that is not needed for button."
   tags:
     - cf-form
 */
 
 .input-with-btn__bar {
-    display: table; 
+    display: table;
     width: 100%;
 
     @supports( display: flex ) {
@@ -356,11 +485,11 @@ legend {
     .input-with-btn_btn {
         margin: 0;
         border: 0;
-        display: table-cell; 
+        display: table-cell;
         // overrides default .input-with-btn_btn width.
         // setting button to very small width & input to 100%
         // means button will only take up space it needs
-        width: 1%; 
+        width: 1%;
         vertical-align: middle;
 
         @supports( display: flex ) {

--- a/cfgov/unprocessed/css/enhancements/forms.less
+++ b/cfgov/unprocessed/css/enhancements/forms.less
@@ -60,8 +60,8 @@
             .u-visually-hidden();
 
             .lt-ie9 & {
-                height: 20px;
-                width: 20px;
+                height: unit( 20px / @base-font-size-px, em );
+                width: unit( 20px / @base-font-size-px, em );
                 border: 0;
                 float: left;
                 margin: 1em;
@@ -106,7 +106,7 @@
 
 .o-form {
     &_group {
-        margin-bottom: 30px;
+        margin-bottom: unit( 30px / @base-font-size-px, em );
     }
 
     &_fieldset {
@@ -116,7 +116,7 @@
         padding: 0;
 
         .m-field + .m-field {
-            margin-top: 10px;
+            margin-top: unit( 10px / @base-font-size-px, em );
         }
     }
 }

--- a/cfgov/unprocessed/css/enhancements/forms.less
+++ b/cfgov/unprocessed/css/enhancements/forms.less
@@ -24,7 +24,7 @@
     }
 
     .a-label + .a-text-input {
-        margin-top: 5px;
+        margin-top: unit( 5px / @base-font-size-px, em );
     }
 
     &__checkbox,

--- a/cfgov/unprocessed/css/enhancements/typography.less
+++ b/cfgov/unprocessed/css/enhancements/typography.less
@@ -1,18 +1,15 @@
 // TODO: Remove after Capital Framework v4 is merged in.
 
-.a-heading__icon {
-    .heading-4();
+.m-list__unstyled,
+.m-list__horizontal,
+.m-list__links {
+    padding-left: 0;
 
-    color: @heading__icon;
+    list-style-type: none;
 
-    a& {
-        .u-link__colors( @heading__icon, @heading__icon__hover );
-
-        border-width: 0;
-    }
-
-    .cf-icon {
-        margin-right: unit( 2px / @font-size, em );
+    // This is needed for dd elements.
+    .m-list_item {
+        margin-left: 0;
     }
 }
 

--- a/cfgov/unprocessed/js/molecules/Multiselect.js
+++ b/cfgov/unprocessed/js/molecules/Multiselect.js
@@ -23,6 +23,9 @@ var EventObserver = require( '../modules/util/EventObserver' );
 function Multiselect( element ) { // eslint-disable-line max-statements, inline-comments, max-len
 
   var BASE_CLASS = 'cf-multi-select';
+  var LIST_CLASS = 'm-list';
+  var CHECKBOX_INPUT_CLASS = 'cf-input';
+  var TEXT_INPUT_CLASS = 'a-text-input';
 
   // TODO: As the multiselect is developed further
   //       explore whether it should use an updated
@@ -170,7 +173,9 @@ function Multiselect( element ) { // eslint-disable-line max-statements, inline-
 
     // Create all our markup but wait to manipulate the DOM just once
     _selectionsDom = domCreate( 'ul', {
-      className: 'list__unstyled ' + BASE_CLASS + '_choices',
+      className: LIST_CLASS + ' ' +
+                 LIST_CLASS + '__unstyled ' +
+                 BASE_CLASS + '_choices',
       inside:    _containerDom
     } );
 
@@ -179,7 +184,7 @@ function Multiselect( element ) { // eslint-disable-line max-statements, inline-
     } );
 
     _searchDom = domCreate( 'input', {
-      className:   BASE_CLASS + '_search',
+      className:   BASE_CLASS + '_search ' + TEXT_INPUT_CLASS,
       type:        'text',
       placeholder: _placeholder || 'Choose up to five',
       inside:      _headerDom,
@@ -192,7 +197,9 @@ function Multiselect( element ) { // eslint-disable-line max-statements, inline-
     } );
 
     _optionsDom = domCreate( 'ul', {
-      className: 'list__unstyled ' + BASE_CLASS + '_options',
+      className: LIST_CLASS + ' ' +
+                 LIST_CLASS + '__unstyled ' +
+                 BASE_CLASS + '_options',
       inside:    _fieldsetDom
     } );
 
@@ -207,7 +214,7 @@ function Multiselect( element ) { // eslint-disable-line max-statements, inline-
         'type':    'checkbox',
         'value':   option.value,
         'name':    _name,
-        'class':   'cf-input ' + BASE_CLASS + '_checkbox',
+        'class':   CHECKBOX_INPUT_CLASS + ' ' + BASE_CLASS + '_checkbox',
         'inside':  _optionsItemDom,
         'checked': option.checked
       } );

--- a/cfgov/v1/forms.py
+++ b/cfgov/v1/forms.py
@@ -160,7 +160,10 @@ class FilterableListForm(forms.Form):
     def render_with_id(self, field, attr_id):
         for f in self.fields:
             if field.html_name == f:
-                self.fields[f].widget.attrs.update({'id': attr_id, 'class': 'a-text-input'})
+                self.fields[f].widget.attrs.update({
+                    'id': attr_id,
+                    'class': 'a-text-input'
+                })
                 self.set_field_html_name(self.fields[f], attr_id)
                 return self[f]
 

--- a/cfgov/v1/forms.py
+++ b/cfgov/v1/forms.py
@@ -160,8 +160,7 @@ class FilterableListForm(forms.Form):
     def render_with_id(self, field, attr_id):
         for f in self.fields:
             if field.html_name == f:
-                self.fields[f].widget.attrs.update({'id': attr_id})
-                self.fields[f].widget.attrs.update({'class': 'a-text-input'})
+                self.fields[f].widget.attrs.update({'id': attr_id, 'class': 'a-text-input'})
                 self.set_field_html_name(self.fields[f], attr_id)
                 return self[f]
 

--- a/cfgov/v1/forms.py
+++ b/cfgov/v1/forms.py
@@ -161,6 +161,7 @@ class FilterableListForm(forms.Form):
         for f in self.fields:
             if field.html_name == f:
                 self.fields[f].widget.attrs.update({'id': attr_id})
+                self.fields[f].widget.attrs.update({'class': 'a-text-input'})
                 self.set_field_html_name(self.fields[f], attr_id)
                 return self[f]
 


### PR DESCRIPTION
## Changes

- Updates structure of filterable list controls to use cf-layout classes.
- Updates multiselect to work with CFv4 classes.


## Testing

1. `gulp build` and visit /blog and compare the filter to the live site.

## Screenshots

Live site:
![screen shot 2017-06-26 at 6 39 57 pm](https://user-images.githubusercontent.com/704760/27563449-bb796e60-5a9f-11e7-83d9-5a28e7a73cfd.png)

This PR:
![screen shot 2017-06-26 at 6 40 02 pm](https://user-images.githubusercontent.com/704760/27563450-bba01286-5a9f-11e7-9265-e6747bf3e0e6.png)