### PR TITLE
Removes micro-copy

### DIFF
--- a/cfgov/jinja2/v1/_includes/atoms/input.html
+++ b/cfgov/jinja2/v1/_includes/atoms/input.html
@@ -31,11 +31,11 @@
     <label class="form-label-header" for="{{ id }}">
         {{ value.label }}
         {%- if value.required == false -%}
-            <span class="a-micro-copy">&nbsp;(Optional)</span>
+            <small>&nbsp;(Optional)</small>
         {%- endif -%}
     </label>
     {%- if value.helperText -%}
-        <p class="a-micro-copy" id="{{ ht_id }}">{{ value.helperText | safe }}</p>
+        <p id="{{ ht_id }}"><small>{{ value.helperText | safe }}</small></p>
     {%- endif -%}
     <input id="{{ id }}"
            name="{{ id }}"

--- a/cfgov/jinja2/v1/_includes/atoms/input.html
+++ b/cfgov/jinja2/v1/_includes/atoms/input.html
@@ -31,11 +31,11 @@
     <label class="form-label-header" for="{{ id }}">
         {{ value.label }}
         {%- if value.required == false -%}
-            <span class="micro-copy">&nbsp;(Optional)</span>
+            <span class="a-micro-copy">&nbsp;(Optional)</span>
         {%- endif -%}
     </label>
     {%- if value.helperText -%}
-        <p class="micro-copy" id="{{ ht_id }}">{{ value.helperText | safe }}</p>
+        <p class="a-micro-copy" id="{{ ht_id }}">{{ value.helperText | safe }}</p>
     {%- endif -%}
     <input id="{{ id }}"
            name="{{ id }}"

--- a/cfgov/jinja2/v1/_includes/atoms/textarea.html
+++ b/cfgov/jinja2/v1/_includes/atoms/textarea.html
@@ -26,11 +26,11 @@
     <label for="{{ id }}" class="form-label-header">
         {{ value.label }}
         {%- if value.required == false -%}
-            <span class="micro-copy">&nbsp;(Optional)</span>
+            <span class="a-micro-copy">&nbsp;(Optional)</span>
         {%- endif -%}
     </label>
     {%- if value.helperText -%}
-        <p class="micro-copy" id="{{ ht_id }}">{{ value.helperText | safe }}</p>
+        <p class="a-micro-copy" id="{{ ht_id }}">{{ value.helperText | safe }}</p>
     {%- endif -%}
     <textarea class="input__long"
               id="{{ id }}"

--- a/cfgov/jinja2/v1/_includes/atoms/textarea.html
+++ b/cfgov/jinja2/v1/_includes/atoms/textarea.html
@@ -26,11 +26,11 @@
     <label for="{{ id }}" class="form-label-header">
         {{ value.label }}
         {%- if value.required == false -%}
-            <span class="a-micro-copy">&nbsp;(Optional)</span>
+            <small>&nbsp;(Optional)</small>
         {%- endif -%}
     </label>
     {%- if value.helperText -%}
-        <p class="a-micro-copy" id="{{ ht_id }}">{{ value.helperText | safe }}</p>
+        <p id="{{ ht_id }}"><small>{{ value.helperText | safe }}</small></p>
     {%- endif -%}
     <textarea class="input__long"
               id="{{ id }}"

--- a/cfgov/unprocessed/css/cf-theme-overrides.less
+++ b/cfgov/unprocessed/css/cf-theme-overrides.less
@@ -226,9 +226,6 @@
 @pull-quote_body:               @black;
 @pull-quote_citation:           @gray;
 
-// .micro-copy
-@micro-copy:                    @gray;
-
 // .date
 @date-text:                     @gray;
 

--- a/cfgov/unprocessed/css/cf-theme-overrides.less
+++ b/cfgov/unprocessed/css/cf-theme-overrides.less
@@ -227,7 +227,7 @@
 @pull-quote_citation:           @gray;
 
 // .micro-copy
-@micro-copy-text:               @gray;
+@micro-copy:                    @gray;
 
 // .date
 @date-text:                     @gray;

--- a/cfgov/unprocessed/css/enhancements/typography.less
+++ b/cfgov/unprocessed/css/enhancements/typography.less
@@ -1,10 +1,5 @@
 // TODO: Remove after Capital Framework v4 is merged in.
 
-.a-micro-copy {
-    color: @micro-copy;
-    font-size: unit( @size-v / @base-font-size-px, em );
-}
-
 // .m-slug-header
 @slug-header_border__thin:  @gray-10; // $color-gray-dark
 @slug-header_border__thick: @green; // $color-primary-alt
@@ -474,13 +469,6 @@ ul:last-child,
 
 .m-pull-quote_citation:before {
     content: "\2014 ";
-}
-
-.micro-copy {
-    font-size: 14px;
-    &p {
-        margin-bottom: unit(10px / @base-font-size-px, em);
-    }
 }
 
 /* topdoc

--- a/cfgov/unprocessed/css/enhancements/typography.less
+++ b/cfgov/unprocessed/css/enhancements/typography.less
@@ -1,5 +1,10 @@
 // TODO: Remove after Capital Framework v4 is merged in.
 
+.a-micro-copy {
+    color: @micro-copy;
+    font-size: unit( @size-v / @base-font-size-px, em );
+}
+
 // .m-slug-header
 @slug-header_border__thin:  @gray-10; // $color-gray-dark
 @slug-header_border__thick: @green; // $color-primary-alt


### PR DESCRIPTION
## Removals

- Unused templates (redundant to some in https://github.com/cfpb/cfgov-refresh/pull/3084)

## Changes

- Updates references to `micro-copy` to `a-micro-copy` and adds CSS from CF.
- Updates `@micro-copy-text` to `@micro-copy`.

## Testing

Only place micro copy is currently used is on the non-live conference registration wagtail block from data and research.
1. Run `echo 'delete from django_migrations where app = "data_research"' | python cfgov/manage.py dbshell`
1. Run `python cfgov/manage.py migrate`
1. Create a browse page in Wagtail.
2. Add Conference registration form.
3. Preview the page.

## Screenshots

micro-copy
![screen shot 2017-06-27 at 11 21 46 am](https://user-images.githubusercontent.com/704760/27596652-324d313c-5b2e-11e7-98c8-0e02682a30b9.png)

a-micro-copy
![screen shot 2017-06-27 at 11 21 16 am](https://user-images.githubusercontent.com/704760/27596651-324022c6-5b2e-11e7-8a6b-c9a3ec88aa56.png)


## Notes

- The text ends up larger because it is hardcoded to 14px in `micro-copy`, but uses ems in `a-micro-copy`.