### PR TITLE
Improve basic Wagtail editor styling

### DIFF
--- a/cfgov/templates/wagtailadmin/css/general-enhancements.css
+++ b/cfgov/templates/wagtailadmin/css/general-enhancements.css
@@ -1,0 +1,58 @@
+/* Context: Wagtail's editing interface is generally comprised of a nested set
+   of two-column interfaces, where the narrower left column holds a label,
+   and the wider right column holds either a single field corresponding to
+   that label or a new two-column group of child fields. */
+
+/* Increase the width for things that wrap both a label col and a field col */
+li.sequence-member .sequence-member-inner .sequence-type-list .sequence-container-inner,
+li.sequence-member .struct-block .fields,
+li.sequence-member .struct-block .fields .sequence-container .fields {
+    width: 100%;
+}
+
+/* Standardize field column widths and rnsure that they stay to the right of
+   their label columns */
+li.sequence-member .struct-block .fields .fields,
+li.sequence-member .struct-block .sequence-container {
+    width: 83.333333333%;
+}
+
+/* Prevent fields from intersecting with struct block list controls */
+.list-controls + .sequence-member-inner li > .field .field-content {
+    width: 72%;
+}
+
+/* Restrict inputs to a max-width that isn't overwhelming */
+input,
+textarea,
+select,
+.richtext,
+.tagit,
+.choice_field .input,
+.model_choice_field .input,
+.typed_choice_field .input {
+    max-width: 50em;
+}
+
+/* Reduce size of date inputs */
+.date_time_field input {
+    width: 14em;
+}
+
+
+/* Vertically align checkboxes and choosers with their label */
+
+.widget-checkbox_input .field-content {
+    padding-top: 1.2em;
+}
+
+.chooser {
+    padding-top: 0.75em;
+}
+
+
+/* Visually separate repeating items */
+.sequence-member {
+    /* Color matches other Wagtail borders */
+    border-top: 1px solid #ccf1f1 !important;
+}

--- a/cfgov/templates/wagtailadmin/css/richtext.css
+++ b/cfgov/templates/wagtailadmin/css/richtext.css
@@ -1,7 +1,0 @@
-/*
- * Keep richtext fields within the desktop viewport, even if long or wide
- * blocks of information are entered in them.
- */
-.richtext {
-    max-width: 1000px;
-}

--- a/cfgov/v1/wagtail_hooks.py
+++ b/cfgov/v1/wagtail_hooks.py
@@ -62,8 +62,8 @@ def editor_js():
 @hooks.register('insert_editor_css')
 def editor_css():
     css_files = [
+        'css/general-enhancements.css',
         'css/table-block.css',
-        'css/richtext.css',
         'css/bureau-structure.css'
     ]
     css_includes = format_html_join(


### PR DESCRIPTION
We've long suffered with some pretty poor design decisions in the Wagtail editor's stylesheet. These changes rectify some of those things:

- Cut down on nesting progressively shrinking things
- Better vertical alignment of checkboxes and choosers with their labels
- Add a border to visually separate repeating items

## Additions

- New general-enhancements.css admin stylesheet

## Removals

- richtext.css, whose single effect is brought into general-enhancements.css and modified.


## Testing

1. Pull branch
2. Run server
3. Create a page and add a bunch of stuff, especially deeply nested things like Expandable Group > Expandable > Content > Well

## Screenshots

![localhost-8000-admin-pages-5625-edit-](https://user-images.githubusercontent.com/1044670/27612170-49602174-5b63-11e7-9eed-81741949d994.png)


## Notes

- It's a start. It's certainly not perfect, and perhaps more could be done, but this is enough to make my next idea (a super-combo heading field set) viable. [_(sneak peek)_](https://user-images.githubusercontent.com/1044670/27612285-cf0a5362-5b63-11e7-9053-105be5c5658d.png)


## Checklist

* [ ] PR has an informative and human-readable title
* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated
* [ ] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
