### PR TITLE
Migrate category-slug to cfv4

### DIFF
--- a/cfgov/jinja2/v1/_includes/macros/category-slug.html
+++ b/cfgov/jinja2/v1/_includes/macros/category-slug.html
@@ -43,7 +43,7 @@
 
     {% call _category_link(href, classes) %}
         {% set cat = category_label(category) or category %}
-        {{ category_icon.render(cat, 'category-slug_icon') | safe }}
+        {{ category_icon.render(cat, '') | safe }}
         <span class="u-visually-hidden">Category:</span>
         {{ cat | safe }}
     {% endcall %}
@@ -52,7 +52,7 @@
 {% macro _category_link(href, classes) %}
     {% if href %}
         <a href="{{ href }}"
-           class="category-slug {{ classes if classes else '' }}">
+           class="a-heading a-heading__icon {{ classes if classes else '' }}">
     {% endif %}
        {{ caller() }}
     {% if href %}

--- a/cfgov/jinja2/v1/_includes/organisms/featured-content.html
+++ b/cfgov/jinja2/v1/_includes/organisms/featured-content.html
@@ -63,7 +63,7 @@
 <section class="o-featured-content-module
                 o-featured-content-module__center">
     <div class="o-featured-content-module_text">
-        <div class="category-slug">
+        <div class="a-heading a-heading__icon">
             {{ category_icon.render( fcm_label(value.category) ) | safe }}
             {{ fcm_label( value.category ) }}
         </div>

--- a/cfgov/jinja2/v1/_includes/organisms/post-preview.html
+++ b/cfgov/jinja2/v1/_includes/organisms/post-preview.html
@@ -64,7 +64,7 @@
                 {% if cat_controls and 'newsroom' in cat_controls.page_type and is_blog(post) %}
                     {{ category_slug.render('blog',
                             page_url,
-                            'post_slug meta-header_left',
+                            'meta-header_left',
                             false, form_id) }}
                 {% else %}
                     {% for cat in post.categories.all() %}
@@ -73,7 +73,7 @@
                         {% endif %}
                         {{ category_slug.render(cat.name,
                                 page_url,
-                                'post_slug meta-header_left',
+                                'meta-header_left',
                                 false, form_id) }}
                     {% endfor %}
                 {% endif %}

--- a/cfgov/jinja2/v1/activity-log/_activity-list.html
+++ b/cfgov/jinja2/v1/activity-log/_activity-list.html
@@ -23,12 +23,12 @@
                     {% if is_blog(post) %}
                         {{ category_slug.render('blog',
                                 page_url,
-                                'post_slug meta-header_left',
+                                'meta-header_left',
                                 false, form_id) }}
                     {% elif is_report(post) %}
                         {{ category_slug.render('report',
                                 page_url,
-                                'post_slug meta-header_left',
+                                'meta-header_left',
                                 false, form_id) }}
                     {% else %}
                         {% for cat in post.categories.all() %}
@@ -37,7 +37,7 @@
                             {% endif %}
                             {{ category_slug.render(cat.name,
                                     page_url,
-                                    'post_slug meta-header_left',
+                                    'meta-header_left',
                                     false, form_id) }}
                         {% endfor %}
                     {% endif %}

--- a/cfgov/unprocessed/css/cf-theme-overrides.less
+++ b/cfgov/unprocessed/css/cf-theme-overrides.less
@@ -229,13 +229,11 @@
 // .date
 @date-text:                     @gray;
 
-// .category-slug
-@category-slug-text:            @black;
-@category-slug-hover:           @link-text-hover;
+// Headings
 
-// .header-slug
-@header-slug-thin-border:       @gray-40;
-@header-slug-thick-border:      @green;
+// .a-heading__icon
+@heading__icon:                 @black;
+@heading__icon__hover:          @link-text-hover;
 
 // .padded-header
 @padded-header-text:            @dark-gray;

--- a/cfgov/unprocessed/css/enhancements/typography.less
+++ b/cfgov/unprocessed/css/enhancements/typography.less
@@ -1,5 +1,21 @@
 // TODO: Remove after Capital Framework v4 is merged in.
 
+.a-heading__icon {
+    .heading-4();
+
+    color: @heading__icon;
+
+    a& {
+        .u-link__colors( @heading__icon, @heading__icon__hover );
+
+        border-width: 0;
+    }
+
+    .cf-icon {
+        margin-right: unit( 2px / @font-size, em );
+    }
+}
+
 // .m-slug-header
 @slug-header_border__thin:  @gray-10; // $color-gray-dark
 @slug-header_border__thick: @green; // $color-primary-alt

--- a/cfgov/unprocessed/css/organisms/post-preview.less
+++ b/cfgov/unprocessed/css/organisms/post-preview.less
@@ -14,8 +14,8 @@
                         </time>
                     </span>
                 </span>
-                <a href="/about-us/blog/?filter_blog_category=Info+for+Consumers" class="category-slug post_slug meta-header_left">
-                    <span class="category-slug_icon cf-icon cf-icon-information"></span>
+                <a href="/about-us/blog/?filter_blog_category=Info+for+Consumers" class="a-heading a-heading__icon m-meta-header_left">
+                    <span class="cf-icon cf-icon-information"></span>
                     <span class="u-visually-hidden">Category:</span>
                     Info for Consumers
                 </a>

--- a/cfgov/unprocessed/css/post.less
+++ b/cfgov/unprocessed/css/post.less
@@ -12,8 +12,8 @@
       markup: |
         <article class="post">
             <header>
-                <a href="#" class="category-slug">
-                    <span class="category-slug_icon cf-icon cf-icon-bullhorn"></span>
+                <a href="#" class="a-heading a-heading__icon">
+                    <span class="cf-icon cf-icon-bullhorn"></span>
                     <span class="u-visually-hidden">Category:</span>
                     Announcements &amp; updates
                 </a>


### PR DESCRIPTION
## Adds

- `@heading__icon` and `@heading__icon__hover`.

## Removals

- Unused `post_slug` class.
- Unused `@category-slug-text`, `@category-slug-hover`, `@header-slug-thin-border`, and `@header-slug-thick-border`.

## Changes

- Migrates `category-slug` to `a-heading` from cfv4.

## Testing

1. `./frondend.sh` and check /newsroom and /activity-log against the live site. They should be unchanged.

## Screenshots
![screen shot 2017-06-28 at 7 10 52 pm](https://user-images.githubusercontent.com/704760/27664433-86450096-5c35-11e7-81c1-d598ada5bc17.png)
