### PR TITLE
fixing mistaken url import for eregs

### DIFF
--- a/cfgov/cfgov/urls.py
+++ b/cfgov/cfgov/urls.py
@@ -265,7 +265,7 @@ urlpatterns = [
 
     flagged_url('EREGS20',
                 r'^eregs2/',
-                include_if_app_enabled('eregs', 'eregs.urls')
+                include_if_app_enabled('eregs_core', 'eregs.urls')
                 ),
     url(r'^eregs-api/',
         include_if_app_enabled('regcore', 'regcore.urls')),


### PR DESCRIPTION
URLs for eregs were being imported from the wrong project.