### PR TITLE
Ask subcategory prefixes

### DIFF
--- a/cfgov/ask_cfpb/migrations/0007_subcategory_prefixes.py
+++ b/cfgov/ask_cfpb/migrations/0007_subcategory_prefixes.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('ask_cfpb', '0006_update_help_text'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='answer',
+            name='subcategory',
+            field=models.ManyToManyField(help_text='Choose only subcategories that belong to one of the categories checked above.', to='ask_cfpb.SubCategory', blank=True),
+        ),
+        migrations.AlterField(
+            model_name='answer',
+            name='update_english_page',
+            field=models.BooleanField(default=False, help_text='Check this box to push your English edits to the page for review. This does not publish your edits.', verbose_name='Send to English page for review'),
+        ),
+        migrations.AlterField(
+            model_name='answer',
+            name='update_spanish_page',
+            field=models.BooleanField(default=False, help_text='Check this box to push your Spanish edits to the page for review. This does not publish your edits.', verbose_name='Send to Spanish page for review'),
+        ),
+    ]

--- a/cfgov/ask_cfpb/migrations/0008_fix_verbose_name_plural.py
+++ b/cfgov/ask_cfpb/migrations/0008_fix_verbose_name_plural.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('ask_cfpb', '0007_subcategory_prefixes'),
+    ]
+
+    operations = [
+        migrations.AlterModelOptions(
+            name='subcategory',
+            options={'ordering': ['weight'], 'verbose_name_plural': 'subcategories'},
+        ),
+    ]

--- a/cfgov/ask_cfpb/models/django.py
+++ b/cfgov/ask_cfpb/models/django.py
@@ -233,7 +233,7 @@ class SubCategory(models.Model):
 
     class Meta:
         ordering = ['weight']
-        verbose_name_plural = "Subcategories"
+        verbose_name_plural = "subcategories"
 
 
 class Answer(models.Model):

--- a/cfgov/ask_cfpb/tests/models/test_pages.py
+++ b/cfgov/ask_cfpb/tests/models/test_pages.py
@@ -601,7 +601,9 @@ class AnswerModelTestCase(TestCase):
 
     def test_subcategory_str(self):
         subcategory = self.subcategories[0]
-        self.assertEqual(subcategory.__str__(), subcategory.name)
+        self.assertEqual(
+            subcategory.__str__(),
+            "{}: {}".format(self.category.name, subcategory.name))
 
     def test_nextstep_str(self):
         next_step = self.next_step

--- a/cfgov/ask_cfpb/wagtail_hooks.py
+++ b/cfgov/ask_cfpb/wagtail_hooks.py
@@ -8,6 +8,7 @@ from wagtail.contrib.modeladmin.views import EditView
 
 from django.conf import settings
 from django.utils.html import format_html, format_html_join
+# from haystack.query import SearchQuerySet
 from wagtail.wagtailcore import hooks
 from wagtail.wagtailcore.whitelist import attribute_rule
 
@@ -20,6 +21,10 @@ from ask_cfpb.models import (
 
 
 class AnswerModelAdminSaveUserEditView(EditView):
+    """
+    An edit_handler that saves the current user as the 'last user'
+    on an Answer object so that it can be passed to a created or updated page.
+    """
 
     def save_instance_user(self):
         self.instance.last_user = self.request.user
@@ -42,8 +47,8 @@ class AnswerModelAdmin(ModelAdmin):
         'question_es',
         'last_edited_es')
     search_fields = (
-        'id', 'question', 'question_es', 'answer', 'answer_es')
-    list_filter = ('category', 'featured')
+        'id', 'question', 'question_es', 'answer', 'answer_es', 'search_tags')
+    list_filter = ('category', 'featured', 'audiences')
     edit_view_class = AnswerModelAdminSaveUserEditView
 
 

--- a/cfgov/ask_cfpb/wagtail_hooks.py
+++ b/cfgov/ask_cfpb/wagtail_hooks.py
@@ -8,7 +8,6 @@ from wagtail.contrib.modeladmin.views import EditView
 
 from django.conf import settings
 from django.utils.html import format_html, format_html_join
-# from haystack.query import SearchQuerySet
 from wagtail.wagtailcore import hooks
 from wagtail.wagtailcore.whitelist import attribute_rule
 


### PR DESCRIPTION
Ask CFPB: Add prefixes to subcategory labels

To work around the lack of Wagtail widget helpers for many-to-many fields
(such as `filter_horizontal` and `filter_vertical`) we need to make
selections friendlier for Ask CFPB editors.

This PR adds category prefixes to subcategory __str__ representations,
plus some other helper-text improvements and code cleanup.

The [main change](https://github.com/cfpb/cfgov-refresh/blob/00e67ded9d3e57e1ae42a13bc65e16dcc3c5462a/cfgov/ask_cfpb/models/django.py#L231-L232) gives editors a way to more easily see and choose relevant subcategories:

<img width="723" alt="subcat_prefixes" src="https://user-images.githubusercontent.com/515885/27752180-a99d1f96-5dad-11e7-9691-f99433b55d02.png">
