### PR TITLE
Add data format plugin for elasticsearch

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,3 +15,6 @@ services:
         ports:
             - "9200:9200"
             - "9300:9300"
+        volumes:
+            - ./docker:/apps
+        entrypoint: /apps/docker-entrypoint-es-plugins.sh

--- a/docker/docker-entrypoint-es-plugins.sh
+++ b/docker/docker-entrypoint-es-plugins.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# setting up prerequisites
+
+plugin install org.codelibs/elasticsearch-dataformat/2.3.0
+
+exec /docker-entrypoint.sh elasticsearch


### PR DESCRIPTION
We are using Data Format plugin for CCDB, so adding the installation instruction to the docker compose

## Additions

- Add installation instructions for data-format plugin


## Removals

-

## Changes

-

## Testing

1. Check out this branch
1. `docker-compose up`
1. Go to http://ip_for_your_elasticsearch:9200/_nodes/_all
  1. You should see:
```
..."plugins":[{"name":"dataformat","version":"2.3.0","description":"This plugin provides several response formats.","jvm":true,"classname":"org.codelibs.elasticsearch.df.DataFormatPlugin","isolated":true,"site":false}]...
```

## Screenshots


## Notes

-

## Todos

-

## Checklist

* [ ] PR has an informative and human-readable title
* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated
* [ ] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
