### PR TITLE
Fix unit test that was writing to stdout

### DIFF
--- a/cfgov/core/tests/test_missing_migrations.py
+++ b/cfgov/core/tests/test_missing_migrations.py
@@ -1,3 +1,4 @@
+from cStringIO import StringIO
 from django.test import TestCase
 
 from core.scripts.missing_migrations import (
@@ -15,5 +16,5 @@ class MissingMigrationsTestCase(TestCase):
                 '#cmdoption-makemigrations--exit'
             )
 
-        if check_missing_migrations():
+        if check_missing_migrations(out=StringIO()):
             self.fail('missing migrations, run manage.py makemigrations')


### PR DESCRIPTION
The unit test `core.tests.test_missing_migration` was invoking the `check_missing_migrations` function and having it write to `sys.stdout`, which we don't want during unit tests. This change just fixes it so that output goes to a buffer instead.

## Changes

- Unit test should invoke `check_missing_migrations` with in-memory buffer instead of `sys.stdout`.

## Testing

1. Run unit tests using `tox -e fast` and note that no `"No changes detected"` message gets written to the console, unlike in the `master` branch.

## Checklist

* [X] PR has an informative and human-readable title
* [X] Changes are limited to a single goal (no scope creep)
* [X] Code can be automatically merged (no conflicts)
* [X] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [X] Passes all existing automated tests
* [X] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
