### PR TITLE
Bug fix: allow us to specify default MYSQL engine when using production settings

### DIFF
--- a/cfgov/cfgov/settings/production.py
+++ b/cfgov/cfgov/settings/production.py
@@ -1,4 +1,5 @@
 import sys
+import os
 
 from .base import *
 from os.path import exists
@@ -87,3 +88,9 @@ if not COLLECTSTATIC:
         }
 
 STATICFILES_STORAGE = 'django.contrib.staticfiles.storage.ManifestStaticFilesStorage'
+
+# allow us to configure the default MySQL storage engine, via the environment
+if 'STORAGE_ENGINE' in os.environ:
+    db_options = {'init_command': os.environ['STORAGE_ENGINE']}
+    for db_label in DATABASES.keys():
+        DATABASES[db_label]['OPTIONS'] = db_options 

--- a/cfgov/cfgov/settings/production.py
+++ b/cfgov/cfgov/settings/production.py
@@ -93,5 +93,5 @@ STATICFILES_STORAGE = 'django.contrib.staticfiles.storage.ManifestStaticFilesSto
 if 'STORAGE_ENGINE' in os.environ:
     db_options = {'init_command': os.environ['STORAGE_ENGINE']}
     for db_label in DATABASES.keys():
-        if 'mysql' in DATABASES[db_label]['engine']:
+        if 'mysql' in DATABASES[db_label]['ENGINE']:
             DATABASES[db_label]['OPTIONS'] = db_options 

--- a/cfgov/cfgov/settings/production.py
+++ b/cfgov/cfgov/settings/production.py
@@ -1,5 +1,5 @@
-import sys
 import os
+import sys
 
 from .base import *
 from os.path import exists
@@ -93,4 +93,5 @@ STATICFILES_STORAGE = 'django.contrib.staticfiles.storage.ManifestStaticFilesSto
 if 'STORAGE_ENGINE' in os.environ:
     db_options = {'init_command': os.environ['STORAGE_ENGINE']}
     for db_label in DATABASES.keys():
-        DATABASES[db_label]['OPTIONS'] = db_options 
+        if 'mysql' in DATABASES[db_label]['engine']:
+            DATABASES[db_label]['OPTIONS'] = db_options 


### PR DESCRIPTION
## Testing

```
export DJANGO_SETTINGS_MODULE=cfgov.settings.production                                                                                                                   
export STORAGE_ENGINE="SET default_storage_engine=MYISAM" 
cfgov/manage.py shell
>>> from django.conf import settings                     
>>> settings.DATABASES                                   
{'default': {'ENGINE': 'django.db.backends.mysql', 'AUTOCOMMIT': True, 'ATOMIC_REQUESTS': False, 'NAME': 'v1', 'CONN_MAX_AGE': 0, 'TIME_ZONE': 'UTC', 'OPTIONS': {'init_command': 'SET default_storage_engine=MYISAM'}, 'HOST': 'localhost.', 'USER': 'v1', 'TEST': {'COLLATION': None, 'CHARSET': None, 'NAME': None, 'MIRROR': None}, 'PASSWORD': 'v1', 'PORT': ''}}
```
(note the OPTIONS value)
## Screenshots


## Notes

-

## Todos

-

## Checklist

* [ ] PR has an informative and human-readable title
* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated
* [ ] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
