### PR TITLE
Add missing self.has_legacy check

### DIFF
--- a/cfgov/v1/db_router.py
+++ b/cfgov/v1/db_router.py
@@ -21,7 +21,7 @@ class CFGOVRouter(object):
 
         Exceptions for authentication and user sessions
         """
-        if self.model_is_legacy(model):
+        if self.has_legacy and self.model_is_legacy(model):
             return 'legacy'
 
         if self.has_replica and model._meta.app_label not in ('auth',


### PR DESCRIPTION
## Changes

- The database router now checks that  a legacy database exists, before trying to route queries to it. 

## Checklist

* [ ] PR has an informative and human-readable title
* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated
* [ ] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
