### PR TITLE
Fix PDF download icon on housing counselor page

### DIFF
--- a/cfgov/legacy/static/hud/hud.css
+++ b/cfgov/legacy/static/hud/hud.css
@@ -1,5 +1,10 @@
 /* Begin HUD HCA API Landing Page additions */
 
+/* Normalize link highlighting */
+a:hover, a:focus {
+    background-color: transparent;
+}
+
 /* Form */
 .hud_hca_api_interactions {
 	margin-bottom: 2em;
@@ -258,4 +263,11 @@
 .bread {
   margin: 0;
 }
+
+/* Override to remove default Nemo PDF download icon */
+.pdf {
+    background: none;
+    padding-right: 0;
+}
+
 /* End HUD HCA API Landing Page additions */

--- a/cfgov/legacy/templates/hud/housing_counselor.html
+++ b/cfgov/legacy/templates/hud/housing_counselor.html
@@ -85,7 +85,9 @@ Find a housing counselor
                     <span class="icon-print"></span>
                     <span class="hud_hca_api_results_print"></span>
                     <span class="icon-save"></span>
-                    <span class="hud_hca_api_results_save"><a id="generate-pdf-link" href="{{ pdf_url }}" target="_blank">Save list as PDF</a></span>
+                    <span class="hud_hca_api_results_save"><a id="generate-pdf-link" href="{{ pdf_url }}" target="_blank" class="icon-link icon-link__download">
+                        <span class="icon-link_text">Save list as PDF</span>
+                      </a></span>
                 </p>
             </div><!-- end .hud_hca_api_results_actions -->
         </div><!-- end .hud_hca_api_results_info -->


### PR DESCRIPTION
This commit adds the standard Wagtail file download icon to the "Save list as PDF link" on the "Find a housing counselor" page. This change was suggested by @schaferjh.

It also removes some legacy link hover highlighting (suggested by @Scotchester).

## Additions

- Adds PDF download link to the housing counselor results page.

## Removals

- Removes custom Nemo link highlighting from housing counselor page.

## Testing

1. Visit [http://localhost:8000/find-a-housing-counselor/?zipcode=18020&s3=True](http://localhost:8000/find-a-housing-counselor/?zipcode=18020&s3=True) locally and observe the PDF download icon, and that links no longer have a background color (compare against https://www.consumerfinance.gov/find-a-housing-counselor/?zipcode=18020&s3=True).

## Screenshots

![image](https://user-images.githubusercontent.com/654645/28171439-6e930a9c-67b6-11e7-823e-57e59dbd695c.png)

## Notes

This required some hackery because this page uses the default Nemo styles which must be overridden.

## Checklist

* [X] PR has an informative and human-readable title
* [X] Changes are limited to a single goal (no scope creep)
* [X] Code can be automatically merged (no conflicts)
* [X] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [X] Visually tested in supported browsers and devices
* [X] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
