### PR TITLE
Make references to CSS background images root-relative

### DIFF
--- a/cfgov/unprocessed/css/molecules/global-eyebrow.less
+++ b/cfgov/unprocessed/css/molecules/global-eyebrow.less
@@ -53,10 +53,10 @@
 
     &_tagline {
         padding-left: 32px; //22px flag + 10px spacing
-        background: url('../img/us-flag_22x13.png') no-repeat 0 0;
+        background: url('/static/img/us-flag_22x13.png') no-repeat 0 0;
 
         .respond-to-dpi(2, {
-            background-image: url('../img/us-flag_44x26.png');
+            background-image: url('/static/img/us-flag_44x26.png');
             background-size: 22px;
         });
 

--- a/cfgov/unprocessed/css/organisms/footer.less
+++ b/cfgov/unprocessed/css/organisms/footer.less
@@ -199,7 +199,7 @@
         .o-footer_official-website {
             .u-webfont-regular();
             padding-left: 37px; //22px flag + 15px spacing
-            background: url( '../img/us-flag_22x13.png' ) no-repeat 0 4px;
+            background: url( '/static/img/us-flag_22x13.png' ) no-repeat 0 4px;
 
             // This media query is to keep 'United States Government'
             // on one line.
@@ -208,7 +208,7 @@
             } );
 
             .respond-to-dpi( 2, {
-                background-image: url( '../img/us-flag_44x26.png' );
+                background-image: url( '/static/img/us-flag_44x26.png' );
                 background-size: 22px;
             } );
         }


### PR DESCRIPTION
These being relative and getting pulled into projects via the on-demand header and footer generated for cfgov-sheer-tempaltes was causing `collectstatic` to fail

## Changes

- Changes relative CSS background image paths into root-relative paths

## Notes

- From what I'm seeing locally, this may not be the only thing we need to do to fix the build, but let's get it going and see if the Jenkins output shows what I'm seeing locally for `collectstatic`. Maybe it's an issue particular to the local environment.

## Checklist

* [x] PR has an informative and human-readable title
* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [ ] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices
* [x] Project documentation has been updated
* [x] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
