### PR TITLE
Convert gulp tasks to ES6

### DIFF
--- a/cfgov/unprocessed/js/molecules/Autocomplete.js
+++ b/cfgov/unprocessed/js/molecules/Autocomplete.js
@@ -54,7 +54,7 @@ function Autocomplete( element, opts ) {
     onSubmit: function( event, selected ) {
       return selected;
     },
-    renderItem: function ( item ) {
+    renderItem: function( item ) {
       var li = document.createElement( 'li' );
       li.setAttribute( 'data-val', item );
       li.innerText = item;

--- a/gulp/tasks/browser-sync.js
+++ b/gulp/tasks/browser-sync.js
@@ -1,12 +1,12 @@
 'use strict';
 
-var browserSync = require( 'browser-sync' );
-var envvars = require( '../../config/environment' ).envvars;
-var gulp = require( 'gulp' );
+const browserSync = require( 'browser-sync' );
+const envvars = require( '../../config/environment' ).envvars;
+const gulp = require( 'gulp' );
 
-gulp.task( 'browsersync', function() {
-  var host = envvars.TEST_HTTP_HOST;
-  var port = envvars.TEST_HTTP_PORT;
+gulp.task( 'browsersync', () => {
+  const host = envvars.TEST_HTTP_HOST;
+  const port = envvars.TEST_HTTP_PORT;
   browserSync.init( {
     proxy: host + ':' + port
   } );

--- a/gulp/tasks/clean.js
+++ b/gulp/tasks/clean.js
@@ -1,9 +1,9 @@
 'use strict';
 
-var configClean = require( '../config' ).clean;
-var del = require( 'del' );
-var gulp = require( 'gulp' );
+const configClean = require( '../config' ).clean;
+const del = require( 'del' );
+const gulp = require( 'gulp' );
 
-gulp.task( 'clean', function() {
+gulp.task( 'clean', () => {
   del( configClean.dest + '/**/*' );
 } );

--- a/gulp/tasks/copy.js
+++ b/gulp/tasks/copy.js
@@ -1,11 +1,11 @@
 'use strict';
 
-var gulp = require( 'gulp' );
-var gulpChanged = require( 'gulp-changed' );
-var gulpReplace = require( 'gulp-replace' );
-var configCopy = require( '../config' ).copy;
-var handleErrors = require( '../utils/handle-errors' );
-var browserSync = require( 'browser-sync' );
+const gulp = require( 'gulp' );
+const gulpChanged = require( 'gulp-changed' );
+const gulpReplace = require( 'gulp-replace' );
+const configCopy = require( '../config' ).copy;
+const handleErrors = require( '../utils/handle-errors' );
+const browserSync = require( 'browser-sync' );
 
 /**
  * Generic copy files flow from source to destination.
@@ -23,23 +23,23 @@ function _genericCopy( src, dest ) {
     } ) );
 }
 
-gulp.task( 'copy:icons', function() {
-  var icons = configCopy.icons;
+gulp.task( 'copy:icons', () => {
+  const icons = configCopy.icons;
   return _genericCopy( icons.src, icons.dest );
 } );
 
-gulp.task( 'copy:codeJson', function() {
-  var codeJson = configCopy.codejson;
+gulp.task( 'copy:codeJson', () => {
+  const codeJson = configCopy.codejson;
   return _genericCopy( codeJson.src, codeJson.dest );
 } );
 
-gulp.task( 'copy:vendorfonts', function() {
-  var vendorFonts = configCopy.vendorFonts;
+gulp.task( 'copy:vendorfonts', () => {
+  const vendorFonts = configCopy.vendorFonts;
   return _genericCopy( vendorFonts.src, vendorFonts.dest );
 } );
 
-gulp.task( 'copy:vendorcss', function() {
-  var vendorCss = configCopy.vendorCss;
+gulp.task( 'copy:vendorcss', () => {
+  const vendorCss = configCopy.vendorCss;
   return gulp.src( vendorCss.src )
     .pipe( gulpChanged( vendorCss.dest ) )
     .on( 'error', handleErrors )
@@ -53,13 +53,13 @@ gulp.task( 'copy:vendorcss', function() {
     } ) );
 } );
 
-gulp.task( 'copy:vendorimg', function() {
-  var vendorImg = configCopy.vendorImg;
+gulp.task( 'copy:vendorimg', () => {
+  const vendorImg = configCopy.vendorImg;
   return _genericCopy( vendorImg.src, vendorImg.dest );
 } );
 
-gulp.task( 'copy:vendorjs', function() {
-  var vendorJs = configCopy.vendorJs;
+gulp.task( 'copy:vendorjs', () => {
+  const vendorJs = configCopy.vendorJs;
   return _genericCopy( vendorJs.src, vendorJs.dest );
 } );
 

--- a/gulp/tasks/docs.js
+++ b/gulp/tasks/docs.js
@@ -1,9 +1,9 @@
 'use strict';
 
-var gulp = require( 'gulp' );
-var gulpUtil = require( 'gulp-util' );
-var paths = require( '../../config/environment' ).paths;
-var spawn = require( 'child_process' ).spawn;
+const gulp = require( 'gulp' );
+const gulpUtil = require( 'gulp-util' );
+const paths = require( '../../config/environment' ).paths;
+const spawn = require( 'child_process' ).spawn;
 
 /**
  * Generate JS scripts documentation.

--- a/gulp/tasks/lint.js
+++ b/gulp/tasks/lint.js
@@ -34,23 +34,17 @@ function _genericLint( src ) {
 /**
  * Lints the gulpfile for errors.
  */
-gulp.task( 'lint:build', function() {
-  return _genericLint( configLint.build );
-} );
+gulp.task( 'lint:build', () => _genericLint( configLint.build ) );
 
 /**
  * Lints the test js files for errors.
  */
-gulp.task( 'lint:tests', function() {
-  return _genericLint( configLint.test );
-} );
+gulp.task( 'lint:tests', () => _genericLint( configLint.test ) );
 
 /**
  * Lints the source js files for errors.
  */
-gulp.task( 'lint:scripts', function() {
-  return _genericLint( configLint.src );
-} );
+gulp.task( 'lint:scripts', () => _genericLint( configLint.src ) );
 
 /**
  * Lints all the js files for errors

--- a/gulp/tasks/scripts.js
+++ b/gulp/tasks/scripts.js
@@ -7,19 +7,19 @@
    from different sources, and to use watch when run from the default task.
 */
 
-var browserSync = require( 'browser-sync' );
-var gulp = require( 'gulp' );
-var gulpConcat = require( 'gulp-concat' );
-var gulpModernizr = require( 'gulp-modernizr' );
-var gulpRename = require( 'gulp-rename' );
-var gulpReplace = require( 'gulp-replace' );
-var gulpUglify = require( 'gulp-uglify' );
-var handleErrors = require( '../utils/handle-errors' );
-var paths = require( '../../config/environment' ).paths;
-var webpack = require( 'webpack' );
-var webpackConfig = require( '../../config/webpack-config.js' );
-var webpackStream = require( 'webpack-stream' );
-var configLegacy = require( '../config.js' ).legacy;
+const browserSync = require( 'browser-sync' );
+const gulp = require( 'gulp' );
+const gulpConcat = require( 'gulp-concat' );
+const gulpModernizr = require( 'gulp-modernizr' );
+const gulpRename = require( 'gulp-rename' );
+const gulpReplace = require( 'gulp-replace' );
+const gulpUglify = require( 'gulp-uglify' );
+const handleErrors = require( '../utils/handle-errors' );
+const paths = require( '../../config/environment' ).paths;
+const webpack = require( 'webpack' );
+const webpackConfig = require( '../../config/webpack-config.js' );
+const webpackStream = require( 'webpack-stream' );
+const configLegacy = require( '../config.js' ).legacy;
 
 /**
  * Standardize webpack workflow for handling script

--- a/gulp/utils/handle-errors.js
+++ b/gulp/utils/handle-errors.js
@@ -6,9 +6,9 @@ module.exports = function() {
   var args = Array.prototype.slice.call( arguments );
   var exitProcessParam = false;
   var errorParam = args[0] || {};
-  var isWatching = this.tasks
-                   && this.tasks.browsersync
-                   && this.tasks.browsersync.done === false;
+  var isWatching = this.tasks &&
+                   this.tasks.browsersync &&
+                   this.tasks.browsersync.done === false;
 
   if ( errorParam.exitProcess ) {
     exitProcessParam = errorParam.exitProcess;


### PR DESCRIPTION
## Changes

- Convert remaining gulp tasks to ES6 syntax.
- Minor linter fixes.

## Testing

1. `./frontend.sh` should pass.
