### PR TITLE
Add gtm ignore to JS only links

### DIFF
--- a/cfgov/legacy/templates/hud/housing_counselor.html
+++ b/cfgov/legacy/templates/hud/housing_counselor.html
@@ -18,10 +18,12 @@ Find a housing counselor
     <li><a href="/">Home</a></li>
         <li>Find a housing counselor</li>
   </ul>
-  <div class="share mini">  <a href="http://www.facebook.com/sharer.php?u=http://www.consumerfinance.gov/find-a-housing-counselor/&amp;t=Find a housing counselor" class="share-facebook noStyles"><img src="{% static 'nemo/_/img/icon_small_facebook.png' %}" alt="Share on Facebook"></a>
-            <a href="http://twitter.com/intent/tweet/?url=http://www.consumerfinance.gov/find-a-housing-counselor/&amp;via=CFPB" class="share-twitter noStyles"><img src="{% static 'nemo/_/img/icon_small_twitter.png' %}" alt="Share on Twitter"></a>
-            <a href="http://api.addthis.com/oexchange/0.8/forward/email/offer?url=http://www.consumerfinance.gov/find-a-housing-counselor/&amp;title=Find a housing counselor&amp;pubid=ra-4da354ee346886d2" class="share-email noStyles"><img src="{% static 'nemo/_/img/icon_small_email.png' %}" alt="Share via email"></a>
-</div>    <article class="page">
+  <div class="share mini">
+    <a href="http://www.facebook.com/sharer.php?u=http://www.consumerfinance.gov/find-a-housing-counselor/&amp;t=Find a housing counselor" class="share-facebook noStyles"><img src="{% static 'nemo/_/img/icon_small_facebook.png' %}" alt="Share on Facebook"></a>
+    <a href="http://twitter.com/intent/tweet/?url=http://www.consumerfinance.gov/find-a-housing-counselor/&amp;via=CFPB" class="share-twitter noStyles"><img src="{% static 'nemo/_/img/icon_small_twitter.png' %}" alt="Share on Twitter"></a>
+    <a href="http://api.addthis.com/oexchange/0.8/forward/email/offer?url=http://www.consumerfinance.gov/find-a-housing-counselor/&amp;title=Find a housing counselor&amp;pubid=ra-4da354ee346886d2" class="share-email noStyles"><img src="{% static 'nemo/_/img/icon_small_email.png' %}" alt="Share via email"></a>
+  </div>
+    <article class="page">
 
         <div class="hud_hca_api_print-header">
         <!-- Show different content on print -->
@@ -58,7 +60,7 @@ Find a housing counselor
     <div id="hud_hca_api_more_info_container" class="hud_hca_api_more_info">
       <p>This tool is open sourced on <a href="https://github.com/cfpb/django-hud">GitHub</a> and powered by <a href="http://data.hud.gov/housing_counseling.html">HUD's</a> official list of housing counselors. We encourage you to leverage it in your own applications.</p>
 
-<p>If you notice errors in the housing counselor data, contact <a href="mailto: housing.counseling@hud.gov ">housing.counseling@hud.gov .</a></p>
+<p>If you notice errors in the housing counselor data, contact <a href="mailto:housing.counseling@hud.gov">housing.counseling@hud.gov.</a></p>
     </div><!-- end .cfpb_hud_hca_api_more_info -->
   </div><!-- end .hud_hca_api_form_container -->
 
@@ -156,7 +158,7 @@ Find a housing counselor
           </div>
           <div class="show-hide default-hidden hud_hca_api_print_hide hud_hca_api_pras">
       <span class="show-hide-icon icon-plus-alt"></span>
-        <a href="javascript:void(0)" class="show-hide-link" data-texthide="Hide" data-textshow="View">
+        <a href="javascript:void(0)" class="show-hide-link" data-texthide="Hide" data-textshow="View" data-gtm_ignore="true">
           <span class="show-hide-name">View</span>
           Paperwork Reduction Act statement       </a>
       <div class="show-hide-content" style="display: none;">

--- a/cfgov/legacy/templates/hud/housing_counselor_pdf.html
+++ b/cfgov/legacy/templates/hud/housing_counselor_pdf.html
@@ -78,7 +78,7 @@
 													<a href="mailto:{{counselor.email}}">{{counselor.email}}</a>												</span></span>
 												<div class="show-hide-mod default-hidden">
 													<span class="show-hide-icon hud_hca_api_print_hide"></span>
-														<a href="javascript:void(0)" class="show-hide-link hud_hca_api_print_hide" data-texthide="Hide" data-textshow="View">
+														<a href="javascript:void(0)" class="show-hide-link hud_hca_api_print_hide" data-texthide="Hide" data-textshow="View" data-gtm_ignore="true">
 															<span class="show-hide-name">View</span>
 															languages offered at this location														</a>
 													<div class="show-hide-content hud_hca_api_print_show">

--- a/cfgov/legacy/templates/hud/housing_counselor_pdf_selfcontained.html
+++ b/cfgov/legacy/templates/hud/housing_counselor_pdf_selfcontained.html
@@ -246,7 +246,7 @@ img.hud_hca_api_print_logo {
 													<a href="mailto:{{counselor.email}}">{{counselor.email}}</a>												</span></span>
 												<div class="show-hide-mod default-hidden">
 													<span class="show-hide-icon hud_hca_api_print_hide"></span>
-														<a href="javascript:void(0)" class="show-hide-link hud_hca_api_print_hide" data-texthide="Hide" data-textshow="View">
+														<a href="javascript:void(0)" class="show-hide-link hud_hca_api_print_hide" data-texthide="Hide" data-textshow="View" data-gtm_ignore="true">
 															<span class="show-hide-name">View</span>
 															languages offered at this location														</a>
 													<div class="show-hide-content hud_hca_api_print_show">


### PR DESCRIPTION
Links that contain `javascript:void(0)` for the `href` will register Google analytics data for a link click, but won't navigate anywhere so should be ignored in analytics data. Adding the `data-gtm_ignore` custom attribute used by the analytics team will ignore clicks on these links for analytics purposes.

## Additions

- `data-gtm_ignore` added to "Paperwork Reduction Act statement" link on find a housing counselor results page.

## Changes

- Removed spaces in email address link that prevented it from working properly.
- Fixed some spacing in the HTML (source code cosmetic only)

## Testing

1. Visit /find-a-housing-counselor/, search for a zip, and check that the Paperwork Reduction Act at the bottom still shows/hides the associated text, but also has a `data-gtm_ignore="true"` attribute on the link.

## Notes

- Part of https://github.cfpb.gov/CFGOV/platform/issues/965