### PR TITLE
Ask CFPB: Fix broken ask question link on subcategory page

### DIFF
--- a/cfgov/jinja2/v1/ask-cfpb/category-page.html
+++ b/cfgov/jinja2/v1/ask-cfpb/category-page.html
@@ -77,7 +77,7 @@
         <div class="question_list">
             {% for question in questions %}
             <article class="question_summary question_summary__basic">
-                {{ partially_styled_link.render( {'plain_text': question.question, 'underlined_text': 'Read answer', 'url': slugurl( question.slug )} ) }}
+                {{ partially_styled_link.render( {'plain_text': question.question, 'underlined_text': 'Read answer', 'url': '/ask-cfpb/' + question.slug} ) }}
             </article>
             {% endfor %}
         </div>


### PR DESCRIPTION
Change the way question links are built on category pages to fix broken link

## Changes

- Generate question links on category page without using slugurl

## Testing

1. Check out branch
2. Navigate to [first Credit card subcategory page](http://localhost:8000/ask-cfpb/category-credit-cards/applying-credit-card/) and verify that first question link works


## Screenshots

<img width="902" alt="screen shot 2017-07-14 at 12 38 17 pm" src="https://user-images.githubusercontent.com/778171/28228108-e5b51b48-6891-11e7-9dd3-c0ab5c55b468.png">

## Checklist

* [ ] PR has an informative and human-readable title
* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated
* [ ] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
