### PR TITLE
Implement global browser supported environment variable

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,5 +1,4 @@
 {
-  "presets": ["es2015", "stage-2"],
   "env": {
     // only happens if NODE_ENV is undefined or set to 'development'
     "development": {

--- a/config/environment.js
+++ b/config/environment.js
@@ -8,7 +8,7 @@
 /**
  * Environment variable mappings in JavaScript from the project root .env file.
  */
-var envvars = {
+const envvars = {
 
   /* eslint-disable no-process-env */
   DJANGO_STAGING_HOSTNAME: process.env.DJANGO_STAGING_HOSTNAME,
@@ -24,9 +24,25 @@ var envvars = {
 };
 
 /**
+ * @description
+ * Browser list for autoprefixer, see https://github.com/ai/browserslist.
+ * @returns {array} List of supported browser strings.
+ */
+function getSupportedBrowserList() {
+  return [
+    'last 2 version',
+    'Edge >= 11',
+    'not ie <= 8',
+    'android 4',
+    'BlackBerry 7',
+    'BlackBerry 10'
+  ];
+}
+
+/**
  * Convenience settings for various project directory paths.
  */
-var paths = {
+const paths = {
   unprocessed: './cfgov/unprocessed',
   processed:   './cfgov/static_built',
   legacy:      './cfgov/legacy/static',
@@ -37,5 +53,6 @@ var paths = {
 
 module.exports = {
   envvars: envvars,
+  getSupportedBrowserList: getSupportedBrowserList,
   paths: paths
 };

--- a/config/webpack-config.js
+++ b/config/webpack-config.js
@@ -4,17 +4,18 @@
 
 'use strict';
 
-var BannerFooterPlugin = require( 'banner-footer-webpack-plugin' );
-var path = require( 'path' );
-var paths = require( '../config/environment' ).paths;
-var scriptsManifest = require( '../gulp/utils/scripts-manifest' );
-var webpack = require( 'webpack' );
+const BannerFooterPlugin = require( 'banner-footer-webpack-plugin' );
+const path = require( 'path' );
+const environment = require( '../config/environment' );
+const paths = environment.paths;
+const scriptsManifest = require( '../gulp/utils/scripts-manifest' );
+const webpack = require( 'webpack' );
 
 // Constants.
-var JS_ROUTES_PATH = '/js/routes';
-var COMMON_BUNDLE_NAME = 'common.js';
+const JS_ROUTES_PATH = '/js/routes';
+const COMMON_BUNDLE_NAME = 'common.js';
 
-var modernConf = {
+const modernConf = {
   cache: true,
   context: path.join( __dirname, '/../', paths.unprocessed, JS_ROUTES_PATH ),
   entry: scriptsManifest.getDirectoryMap( paths.unprocessed + JS_ROUTES_PATH ),
@@ -22,7 +23,15 @@ var modernConf = {
     rules: [ {
       test: /\.js$/,
       use: [ {
-        loader: 'babel-loader?cacheDirectory=true'
+        loader: 'babel-loader?cacheDirectory=true',
+        options: {
+          presets: [ [ 'env', {
+            targets: {
+              browsers: environment.getSupportedBrowserList()
+            },
+            debug: true
+          } ] ]
+        }
       } ],
       exclude: /node_modules/
     } ]
@@ -44,7 +53,7 @@ var modernConf = {
   ]
 };
 
-var ieConf = {
+const ieConf = {
   entry: paths.unprocessed + '/js/ie/common.ie.js',
   output: {
     filename: 'common.ie.js'
@@ -56,7 +65,7 @@ var ieConf = {
   ]
 };
 
-var externalConf = {
+const externalConf = {
   entry: paths.unprocessed + JS_ROUTES_PATH + '/external-site/index.js',
   output: {
     filename: 'external-site.js'
@@ -68,7 +77,7 @@ var externalConf = {
   ]
 };
 
-var onDemandConf = {
+const onDemandConf = {
   context: path.join( __dirname, '/../', paths.unprocessed,
                       JS_ROUTES_PATH + '/on-demand' ),
   entry:   scriptsManifest.getDirectoryMap( paths.unprocessed +
@@ -85,7 +94,7 @@ var onDemandConf = {
   ]
 };
 
-var onDemandHeaderRawConf = {
+const onDemandHeaderRawConf = {
   context: path.join( __dirname, '/../', paths.unprocessed,
                       JS_ROUTES_PATH + '/on-demand' ),
   entry:   './header.js',
@@ -95,7 +104,7 @@ var onDemandHeaderRawConf = {
   }
 };
 
-var spanishConf = {
+const spanishConf = {
   entry: paths.unprocessed + JS_ROUTES_PATH + '/es/obtener-respuestas/single.js',
   output: {
     filename: 'spanish.js'

--- a/gulp/config.js
+++ b/gulp/config.js
@@ -1,8 +1,8 @@
 'use strict';
 
-var fs = require( 'fs' );
-var paths = require( '../config/environment' ).paths;
-var globAll = require( 'glob-all' );
+const fs = require( 'fs' );
+const paths = require( '../config/environment' ).paths;
+const globAll = require( 'glob-all' );
 
 module.exports = {
   pkg:    JSON.parse( fs.readFileSync( 'package.json' ) ), // eslint-disable-line no-sync, no-inline-comments, max-len

--- a/gulp/tasks/scripts.js
+++ b/gulp/tasks/scripts.js
@@ -107,7 +107,7 @@ function scriptsOnDemand() {
   */
 function scriptsSpanish() {
   return _processScript( webpackConfig.spanishConf,
-                          '/js/routes/es/obtener-respuestas/single.js', '/js/' );
+                         '/js/routes/es/obtener-respuestas/single.js', '/js/' );
 }
 
 /**

--- a/gulp/tasks/styles.js
+++ b/gulp/tasks/styles.js
@@ -1,21 +1,22 @@
 'use strict';
 
-var browserSync = require( 'browser-sync' );
-var config = require( '../config' );
-var configPkg = config.pkg;
-var configBanner = config.banner;
-var configStyles = config.styles;
-var configLegacy = config.legacy;
-var gulp = require( 'gulp' );
-var gulpAutoprefixer = require( 'gulp-autoprefixer' );
-var gulpCleanCss = require( 'gulp-clean-css' );
-var gulpHeader = require( 'gulp-header' );
-var gulpLess = require( 'gulp-less' );
-var gulpRename = require( 'gulp-rename' );
-var gulpSourcemaps = require( 'gulp-sourcemaps' );
-var handleErrors = require( '../utils/handle-errors' );
-var mqr = require( 'gulp-mq-remove' );
-var gulpBless = require( 'gulp-bless' );
+const browserSync = require( 'browser-sync' );
+const config = require( '../config' );
+const configPkg = config.pkg;
+const configBanner = config.banner;
+const configStyles = config.styles;
+const configLegacy = config.legacy;
+const environment = require( '../../config/environment' );
+const gulp = require( 'gulp' );
+const gulpAutoprefixer = require( 'gulp-autoprefixer' );
+const gulpCleanCss = require( 'gulp-clean-css' );
+const gulpHeader = require( 'gulp-header' );
+const gulpLess = require( 'gulp-less' );
+const gulpRename = require( 'gulp-rename' );
+const gulpSourcemaps = require( 'gulp-sourcemaps' );
+const handleErrors = require( '../utils/handle-errors' );
+const mqr = require( 'gulp-mq-remove' );
+const gulpBless = require( 'gulp-bless' );
 
 /**
  * Process modern CSS.
@@ -26,13 +27,9 @@ function stylesModern() {
     .pipe( gulpSourcemaps.init() )
     .pipe( gulpLess( configStyles.settings ) )
     .on( 'error', handleErrors.bind( this, { exitProcess: true } ) )
-    .pipe( gulpAutoprefixer( { browsers: [
-      'last 2 version',
-      'not ie <= 8',
-      'android 4',
-      'BlackBerry 7',
-      'BlackBerry 10'
-    ]} ) )
+    .pipe( gulpAutoprefixer( {
+      browsers: environment.getSupportedBrowserList()
+    } ) )
     .pipe( gulpHeader( configBanner, { pkg: configPkg } ) )
     .pipe( gulpSourcemaps.write( '.' ) )
     .pipe( gulp.dest( configStyles.dest ) )
@@ -101,13 +98,9 @@ function stylesOnDemand() {
   return gulp.src( configStyles.cwd + '/on-demand/*.less' )
     .pipe( gulpLess( configStyles.settings ) )
     .on( 'error', handleErrors )
-    .pipe( gulpAutoprefixer( { browsers: [
-      'last 2 version',
-      'ie 7-8',
-      'android 4',
-      'BlackBerry 7',
-      'BlackBerry 10'
-    ]} ) )
+    .pipe( gulpAutoprefixer( {
+      browsers: environment.getSupportedBrowserList()
+    } ) )
     .pipe( gulpHeader( configBanner, { pkg: configPkg } ) )
     .pipe( gulp.dest( configStyles.dest ) )
     .pipe( mqr( {
@@ -133,13 +126,9 @@ function stylesFeatureFlags() {
   return gulp.src( configStyles.cwd + '/feature-flags/*.less' )
     .pipe( gulpLess( configStyles.settings ) )
     .on( 'error', handleErrors )
-    .pipe( gulpAutoprefixer( { browsers: [
-      'last 2 version',
-      'ie 7-8',
-      'android 4',
-      'BlackBerry 7',
-      'BlackBerry 10'
-    ]} ) )
+    .pipe( gulpAutoprefixer( {
+      browsers: environment.getSupportedBrowserList()
+    } ) )
     .pipe( gulp.dest( configStyles.dest + '/feature-flags' ) )
     .pipe( browserSync.reload( {
       stream: true
@@ -156,13 +145,9 @@ function stylesKnowledgebaseProd() {
     '/knowledgebase/less/es-ask-styles.less' )
     .pipe( gulpLess( { compress: true } ) )
     .on( 'error', handleErrors )
-    .pipe( gulpAutoprefixer( { browsers: [
-      'last 2 version',
-      'not ie <= 8',
-      'android 4',
-      'BlackBerry 7',
-      'BlackBerry 10'
-    ]} ) )
+    .pipe( gulpAutoprefixer( {
+      browsers: environment.getSupportedBrowserList()
+    } ) )
     .pipe( gulpHeader( configBanner, { pkg: configPkg } ) )
     .pipe( gulpRename( 'es-ask-styles.min.css' ) )
     .pipe( gulp.dest( configLegacy.dest + '/knowledgebase/' ) )
@@ -180,13 +165,9 @@ function stylesKnowledgebaseIE() {
     '/knowledgebase/less/es-ask-styles-ie.less' )
     .pipe( gulpLess( { compress: true } ) )
     .on( 'error', handleErrors )
-    .pipe( gulpAutoprefixer( { browsers: [
-      'last 2 version',
-      'not ie <= 8',
-      'android 4',
-      'BlackBerry 7',
-      'BlackBerry 10'
-    ]} ) )
+    .pipe( gulpAutoprefixer( {
+      browsers: environment.getSupportedBrowserList()
+    } ) )
     .pipe( gulpHeader( configBanner, { pkg: configPkg } ) )
     .pipe( gulpRename( 'es-ask-styles-ie.min.css' ) )
     .pipe( gulp.dest( configLegacy.dest + '/knowledgebase/' ) )
@@ -203,13 +184,9 @@ function stylesNemoProd() {
   return gulp.src( configLegacy.cwd + '/nemo/_/c/less/es-styles.less' )
     .pipe( gulpLess( { compress: true } ) )
     .on( 'error', handleErrors )
-    .pipe( gulpAutoprefixer( { browsers: [
-      'last 2 version',
-      'not ie <= 8',
-      'android 4',
-      'BlackBerry 7',
-      'BlackBerry 10'
-    ]} ) )
+    .pipe( gulpAutoprefixer( {
+      browsers: environment.getSupportedBrowserList()
+    } ) )
     .pipe( gulpHeader( configBanner, { pkg: configPkg } ) )
     .pipe( gulpRename( 'es-styles.min.css' ) )
     .pipe( gulp.dest( configLegacy.dest + '/nemo/_/c/' ) )
@@ -226,13 +203,9 @@ function stylesNemoIE() {
   return gulp.src( configLegacy.cwd + '/nemo/_/c/less/es-styles-ie.less' )
     .pipe( gulpLess( { compress: true } ) )
     .on( 'error', handleErrors )
-    .pipe( gulpAutoprefixer( { browsers: [
-      'last 2 version',
-      'not ie <= 8',
-      'android 4',
-      'BlackBerry 7',
-      'BlackBerry 10'
-    ]} ) )
+    .pipe( gulpAutoprefixer( {
+      browsers: environment.getSupportedBrowserList()
+    } ) )
     .pipe( gulpHeader( configBanner, { pkg: configPkg } ) )
     .pipe( gulpRename( 'es-styles-ie.min.css' ) )
     .pipe( gulp.dest( configLegacy.dest + '/nemo/_/c/' ) )

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -306,11 +306,6 @@
       "from": "babel-generator@>=6.25.0 <7.0.0",
       "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.25.0.tgz"
     },
-    "babel-helper-bindify-decorators": {
-      "version": "6.24.1",
-      "from": "babel-helper-bindify-decorators@>=6.24.1 <7.0.0",
-      "resolved": "https://registry.npmjs.org/babel-helper-bindify-decorators/-/babel-helper-bindify-decorators-6.24.1.tgz"
-    },
     "babel-helper-builder-binary-assignment-operator-visitor": {
       "version": "6.24.1",
       "from": "babel-helper-builder-binary-assignment-operator-visitor@>=6.24.1 <7.0.0",
@@ -330,11 +325,6 @@
       "version": "6.24.1",
       "from": "babel-helper-explode-assignable-expression@>=6.24.1 <7.0.0",
       "resolved": "https://registry.npmjs.org/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.24.1.tgz"
-    },
-    "babel-helper-explode-class": {
-      "version": "6.24.1",
-      "from": "babel-helper-explode-class@>=6.24.1 <7.0.0",
-      "resolved": "https://registry.npmjs.org/babel-helper-explode-class/-/babel-helper-explode-class-6.24.1.tgz"
     },
     "babel-helper-function-name": {
       "version": "6.24.1",
@@ -396,60 +386,20 @@
       "from": "babel-plugin-syntax-async-functions@>=6.8.0 <7.0.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz"
     },
-    "babel-plugin-syntax-async-generators": {
-      "version": "6.13.0",
-      "from": "babel-plugin-syntax-async-generators@>=6.5.0 <7.0.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-generators/-/babel-plugin-syntax-async-generators-6.13.0.tgz"
-    },
-    "babel-plugin-syntax-class-properties": {
-      "version": "6.13.0",
-      "from": "babel-plugin-syntax-class-properties@>=6.8.0 <7.0.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-class-properties/-/babel-plugin-syntax-class-properties-6.13.0.tgz"
-    },
-    "babel-plugin-syntax-decorators": {
-      "version": "6.13.0",
-      "from": "babel-plugin-syntax-decorators@>=6.13.0 <7.0.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-decorators/-/babel-plugin-syntax-decorators-6.13.0.tgz"
-    },
-    "babel-plugin-syntax-dynamic-import": {
-      "version": "6.18.0",
-      "from": "babel-plugin-syntax-dynamic-import@>=6.18.0 <7.0.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-dynamic-import/-/babel-plugin-syntax-dynamic-import-6.18.0.tgz"
-    },
     "babel-plugin-syntax-exponentiation-operator": {
       "version": "6.13.0",
       "from": "babel-plugin-syntax-exponentiation-operator@>=6.8.0 <7.0.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz"
-    },
-    "babel-plugin-syntax-object-rest-spread": {
-      "version": "6.13.0",
-      "from": "babel-plugin-syntax-object-rest-spread@>=6.8.0 <7.0.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz"
     },
     "babel-plugin-syntax-trailing-function-commas": {
       "version": "6.22.0",
       "from": "babel-plugin-syntax-trailing-function-commas@>=6.22.0 <7.0.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.22.0.tgz"
     },
-    "babel-plugin-transform-async-generator-functions": {
-      "version": "6.24.1",
-      "from": "babel-plugin-transform-async-generator-functions@>=6.24.1 <7.0.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-async-generator-functions/-/babel-plugin-transform-async-generator-functions-6.24.1.tgz"
-    },
     "babel-plugin-transform-async-to-generator": {
       "version": "6.24.1",
-      "from": "babel-plugin-transform-async-to-generator@>=6.24.1 <7.0.0",
+      "from": "babel-plugin-transform-async-to-generator@>=6.22.0 <7.0.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.24.1.tgz"
-    },
-    "babel-plugin-transform-class-properties": {
-      "version": "6.24.1",
-      "from": "babel-plugin-transform-class-properties@>=6.24.1 <7.0.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-class-properties/-/babel-plugin-transform-class-properties-6.24.1.tgz"
-    },
-    "babel-plugin-transform-decorators": {
-      "version": "6.24.1",
-      "from": "babel-plugin-transform-decorators@>=6.24.1 <7.0.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-decorators/-/babel-plugin-transform-decorators-6.24.1.tgz"
     },
     "babel-plugin-transform-es2015-arrow-functions": {
       "version": "6.22.0",
@@ -463,37 +413,37 @@
     },
     "babel-plugin-transform-es2015-block-scoping": {
       "version": "6.24.1",
-      "from": "babel-plugin-transform-es2015-block-scoping@>=6.24.1 <7.0.0",
+      "from": "babel-plugin-transform-es2015-block-scoping@>=6.23.0 <7.0.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.24.1.tgz"
     },
     "babel-plugin-transform-es2015-classes": {
       "version": "6.24.1",
-      "from": "babel-plugin-transform-es2015-classes@>=6.24.1 <7.0.0",
+      "from": "babel-plugin-transform-es2015-classes@>=6.23.0 <7.0.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz"
     },
     "babel-plugin-transform-es2015-computed-properties": {
       "version": "6.24.1",
-      "from": "babel-plugin-transform-es2015-computed-properties@>=6.24.1 <7.0.0",
+      "from": "babel-plugin-transform-es2015-computed-properties@>=6.22.0 <7.0.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz"
     },
     "babel-plugin-transform-es2015-destructuring": {
       "version": "6.23.0",
-      "from": "babel-plugin-transform-es2015-destructuring@>=6.22.0 <7.0.0",
+      "from": "babel-plugin-transform-es2015-destructuring@>=6.23.0 <7.0.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz"
     },
     "babel-plugin-transform-es2015-duplicate-keys": {
       "version": "6.24.1",
-      "from": "babel-plugin-transform-es2015-duplicate-keys@>=6.24.1 <7.0.0",
+      "from": "babel-plugin-transform-es2015-duplicate-keys@>=6.22.0 <7.0.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.24.1.tgz"
     },
     "babel-plugin-transform-es2015-for-of": {
       "version": "6.23.0",
-      "from": "babel-plugin-transform-es2015-for-of@>=6.22.0 <7.0.0",
+      "from": "babel-plugin-transform-es2015-for-of@>=6.23.0 <7.0.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz"
     },
     "babel-plugin-transform-es2015-function-name": {
       "version": "6.24.1",
-      "from": "babel-plugin-transform-es2015-function-name@>=6.24.1 <7.0.0",
+      "from": "babel-plugin-transform-es2015-function-name@>=6.22.0 <7.0.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz"
     },
     "babel-plugin-transform-es2015-literals": {
@@ -503,37 +453,37 @@
     },
     "babel-plugin-transform-es2015-modules-amd": {
       "version": "6.24.1",
-      "from": "babel-plugin-transform-es2015-modules-amd@>=6.24.1 <7.0.0",
+      "from": "babel-plugin-transform-es2015-modules-amd@>=6.22.0 <7.0.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.24.1.tgz"
     },
     "babel-plugin-transform-es2015-modules-commonjs": {
       "version": "6.24.1",
-      "from": "babel-plugin-transform-es2015-modules-commonjs@>=6.24.1 <7.0.0",
+      "from": "babel-plugin-transform-es2015-modules-commonjs@>=6.23.0 <7.0.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.24.1.tgz"
     },
     "babel-plugin-transform-es2015-modules-systemjs": {
       "version": "6.24.1",
-      "from": "babel-plugin-transform-es2015-modules-systemjs@>=6.24.1 <7.0.0",
+      "from": "babel-plugin-transform-es2015-modules-systemjs@>=6.23.0 <7.0.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.24.1.tgz"
     },
     "babel-plugin-transform-es2015-modules-umd": {
       "version": "6.24.1",
-      "from": "babel-plugin-transform-es2015-modules-umd@>=6.24.1 <7.0.0",
+      "from": "babel-plugin-transform-es2015-modules-umd@>=6.23.0 <7.0.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.24.1.tgz"
     },
     "babel-plugin-transform-es2015-object-super": {
       "version": "6.24.1",
-      "from": "babel-plugin-transform-es2015-object-super@>=6.24.1 <7.0.0",
+      "from": "babel-plugin-transform-es2015-object-super@>=6.22.0 <7.0.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.24.1.tgz"
     },
     "babel-plugin-transform-es2015-parameters": {
       "version": "6.24.1",
-      "from": "babel-plugin-transform-es2015-parameters@>=6.24.1 <7.0.0",
+      "from": "babel-plugin-transform-es2015-parameters@>=6.23.0 <7.0.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz"
     },
     "babel-plugin-transform-es2015-shorthand-properties": {
       "version": "6.24.1",
-      "from": "babel-plugin-transform-es2015-shorthand-properties@>=6.24.1 <7.0.0",
+      "from": "babel-plugin-transform-es2015-shorthand-properties@>=6.22.0 <7.0.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz"
     },
     "babel-plugin-transform-es2015-spread": {
@@ -543,7 +493,7 @@
     },
     "babel-plugin-transform-es2015-sticky-regex": {
       "version": "6.24.1",
-      "from": "babel-plugin-transform-es2015-sticky-regex@>=6.24.1 <7.0.0",
+      "from": "babel-plugin-transform-es2015-sticky-regex@>=6.22.0 <7.0.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz"
     },
     "babel-plugin-transform-es2015-template-literals": {
@@ -553,27 +503,22 @@
     },
     "babel-plugin-transform-es2015-typeof-symbol": {
       "version": "6.23.0",
-      "from": "babel-plugin-transform-es2015-typeof-symbol@>=6.22.0 <7.0.0",
+      "from": "babel-plugin-transform-es2015-typeof-symbol@>=6.23.0 <7.0.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz"
     },
     "babel-plugin-transform-es2015-unicode-regex": {
       "version": "6.24.1",
-      "from": "babel-plugin-transform-es2015-unicode-regex@>=6.24.1 <7.0.0",
+      "from": "babel-plugin-transform-es2015-unicode-regex@>=6.22.0 <7.0.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz"
     },
     "babel-plugin-transform-exponentiation-operator": {
       "version": "6.24.1",
-      "from": "babel-plugin-transform-exponentiation-operator@>=6.24.1 <7.0.0",
+      "from": "babel-plugin-transform-exponentiation-operator@>=6.22.0 <7.0.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-6.24.1.tgz"
-    },
-    "babel-plugin-transform-object-rest-spread": {
-      "version": "6.23.0",
-      "from": "babel-plugin-transform-object-rest-spread@>=6.22.0 <7.0.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.23.0.tgz"
     },
     "babel-plugin-transform-regenerator": {
       "version": "6.24.1",
-      "from": "babel-plugin-transform-regenerator@>=6.24.1 <7.0.0",
+      "from": "babel-plugin-transform-regenerator@>=6.22.0 <7.0.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.24.1.tgz"
     },
     "babel-plugin-transform-strict-mode": {
@@ -581,20 +526,10 @@
       "from": "babel-plugin-transform-strict-mode@>=6.24.1 <7.0.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz"
     },
-    "babel-preset-es2015": {
-      "version": "6.24.1",
-      "from": "babel-preset-es2015@6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-preset-es2015/-/babel-preset-es2015-6.24.1.tgz"
-    },
-    "babel-preset-stage-2": {
-      "version": "6.24.1",
-      "from": "babel-preset-stage-2@6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-preset-stage-2/-/babel-preset-stage-2-6.24.1.tgz"
-    },
-    "babel-preset-stage-3": {
-      "version": "6.24.1",
-      "from": "babel-preset-stage-3@>=6.24.1 <7.0.0",
-      "resolved": "https://registry.npmjs.org/babel-preset-stage-3/-/babel-preset-stage-3-6.24.1.tgz"
+    "babel-preset-env": {
+      "version": "1.6.0",
+      "from": "babel-preset-env@1.6.0",
+      "resolved": "https://registry.npmjs.org/babel-preset-env/-/babel-preset-env-1.6.0.tgz"
     },
     "babel-register": {
       "version": "6.24.1",
@@ -880,9 +815,9 @@
       "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz"
     },
     "browserslist": {
-      "version": "2.1.5",
-      "from": "browserslist@>=2.1.5 <3.0.0",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-2.1.5.tgz"
+      "version": "2.2.0",
+      "from": "browserslist@>=2.1.2 <3.0.0",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-2.2.0.tgz"
     },
     "bs-recipes": {
       "version": "1.3.4",
@@ -975,7 +910,7 @@
     },
     "caniuse-lite": {
       "version": "1.0.30000701",
-      "from": "caniuse-lite@>=1.0.30000697 <2.0.0",
+      "from": "caniuse-lite@>=1.0.30000701 <2.0.0",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000701.tgz"
     },
     "capture-stack-trace": {
@@ -1168,9 +1103,9 @@
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.0.tgz"
     },
     "color-name": {
-      "version": "1.1.2",
+      "version": "1.1.3",
       "from": "color-name@>=1.1.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.2.tgz"
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz"
     },
     "colors": {
       "version": "0.6.2",
@@ -1974,7 +1909,7 @@
     },
     "electron-to-chromium": {
       "version": "1.3.15",
-      "from": "electron-to-chromium@>=1.3.14 <2.0.0",
+      "from": "electron-to-chromium@>=1.3.15 <2.0.0",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.15.tgz"
     },
     "elliptic": {
@@ -3284,9 +3219,9 @@
           "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz"
         },
         "uglify-js": {
-          "version": "3.0.24",
+          "version": "3.0.25",
           "from": "uglify-js@>=3.0.5 <4.0.0",
-          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.0.24.tgz"
+          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.0.25.tgz"
         }
       }
     },
@@ -5071,9 +5006,9 @@
       "resolved": "https://registry.npmjs.org/portscanner/-/portscanner-2.1.1.tgz"
     },
     "postcss": {
-      "version": "6.0.6",
+      "version": "6.0.7",
       "from": "postcss@>=6.0.1 <7.0.0",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.7.tgz",
       "dependencies": {
         "ansi-styles": {
           "version": "3.1.0",
@@ -5087,7 +5022,7 @@
         },
         "supports-color": {
           "version": "4.2.0",
-          "from": "supports-color@>=4.1.0 <5.0.0",
+          "from": "supports-color@>=4.2.0 <5.0.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.2.0.tgz"
         }
       }
@@ -5540,7 +5475,7 @@
     },
     "semver": {
       "version": "5.3.0",
-      "from": "semver@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0||>=4.0.0 <5.0.0||>=5.0.0 <6.0.0",
+      "from": "semver@>=5.3.0 <6.0.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz"
     },
     "semver-diff": {
@@ -6475,14 +6410,19 @@
       "resolved": "https://registry.npmjs.org/ware/-/ware-1.3.0.tgz"
     },
     "watchpack": {
-      "version": "1.3.1",
+      "version": "1.4.0",
       "from": "watchpack@>=1.3.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.4.0.tgz",
       "dependencies": {
         "async": {
           "version": "2.5.0",
           "from": "async@>=2.1.2 <3.0.0",
           "resolved": "https://registry.npmjs.org/async/-/async-2.5.0.tgz"
+        },
+        "chokidar": {
+          "version": "1.7.0",
+          "from": "chokidar@>=1.7.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz"
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -18,8 +18,7 @@
   "dependencies": {
     "babel-core": "6.25.0",
     "babel-loader": "7.1.1",
-    "babel-preset-es2015": "6.24.1",
-    "babel-preset-stage-2": "6.24.1",
+    "babel-preset-env": "1.6.0",
     "banner-footer-webpack-plugin": "git://github.com/dtothefp/banner-footer-webpack-plugin.git",
     "browser-sync": "2.18.7",
     "cf-buttons": "4.4.1",


### PR DESCRIPTION
## Additions

- `getSupportedBrowserList` function in `environment.js` for returning an array of supported browsers in a [browserlist](https://github.com/ai/browserslist) compatible format for use in the script and style build processes.

## Changes

- Changes babel environment to `env` from `es2015` and `stage-2`, which then gets passed browserlist.
- Updates variables to `const.

## Removals

- Removes babel presets from `.babelrc` since it's in the webpack-config.

## Testing

1. `./frontend.sh` should pass.
2. `gulp styles:ondemand` should pass.
2. `gulp scripts:ondemand` should pass.
3. Ideally should be checked in the browsers we support and make sure there are no changes.

## Screenshots

With `debug: true` set in the babel loader, this helpful output happens at build, which seems helpful to keep:
<img width="706" alt="screen shot 2017-07-17 at 2 22 38 pm" src="https://user-images.githubusercontent.com/704760/28284129-fb80cabc-6afd-11e7-83a8-46211b210203.png">

## Notes

- The `'Edge >= 11'` was not in the original browser list, but is in Mosaic, so added it here for consistency.