### PR TITLE
Remove legacy database functionality from CFGOVRouter

### DIFF
--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -101,13 +101,6 @@ if DEPLOY_ENVIRONMENT == 'build':
         {'import': 'eregs', 'apps': ('eregs_core',)},
     ]
 
-# These apps use "legacy" database routing
-# See: cfgov/v1/db_router.py
-LEGACY_APPS = [
-    'comparisontool',
-    'agreements',
-]
-
 MIDDLEWARE_CLASSES = (
     'sheerlike.middleware.GlobalRequestMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',

--- a/cfgov/cfgov/settings/production.py
+++ b/cfgov/cfgov/settings/production.py
@@ -77,14 +77,6 @@ if not COLLECTSTATIC:
                 'HOST': os.environ.get('MYSQL_HOST', ''),
                 'PORT': os.environ.get('MYSQL_PORT', ''),
             },
-            'legacy': {
-                'ENGINE': MYSQL_ENGINE,
-                'NAME': os.environ.get('LEGACY_MYSQL_NAME', ''),
-                'USER': os.environ.get('LEGACY_MYSQL_USER', ''),
-                'PASSWORD': os.environ.get('LEGACY_MYSQL_PW', ''),
-                'HOST': os.environ.get('LEGACY_MYSQL_HOST', ''),
-                'PORT': os.environ.get('LEGACY_MYSQL_PORT', ''),
-            },
         }
 
 STATICFILES_STORAGE = 'django.contrib.staticfiles.storage.ManifestStaticFilesStorage'
@@ -94,4 +86,4 @@ if 'STORAGE_ENGINE' in os.environ:
     db_options = {'init_command': os.environ['STORAGE_ENGINE']}
     for db_label in DATABASES.keys():
         if 'mysql' in DATABASES[db_label]['ENGINE']:
-            DATABASES[db_label]['OPTIONS'] = db_options 
+            DATABASES[db_label]['OPTIONS'] = db_options

--- a/cfgov/v1/db_router.py
+++ b/cfgov/v1/db_router.py
@@ -4,26 +4,17 @@ from django.conf import settings
 class CFGOVRouter(object):
     """
     A router that allows for splitting reads and writes to separate
-    databases, and sends a set of legacy apps to a distinct 'legacy' DB
+    databases.
     """
 
     def __init__(self, *args, **lwargs):
-        self.has_legacy = 'legacy' in settings.DATABASES
         self.has_replica = 'replica' in settings.DATABASES
-
-    def model_is_legacy(self, model):
-        return (model._meta.app_label in settings.LEGACY_APPS)
 
     def db_for_read(self, model, **hints):
         """
-        if a 'legacy' DB exists, and this model is in settings.LEGACY_APPS,
-        then all reads should go to 'legacy'
-
-        Exceptions for authentication and user sessions
+        if a 'replica' DB exists and this model is not in the 'auth' or
+        'sessions' app then all reads should go to the replica.
         """
-        if self.has_legacy and self.model_is_legacy(model):
-            return 'legacy'
-
         if self.has_replica and model._meta.app_label not in ('auth',
                                                               'sessions'):
             return 'replica'
@@ -32,32 +23,15 @@ class CFGOVRouter(object):
 
     def db_for_write(self, model, **hints):
         """
-        if a 'legacy' DB exists, and this model is in settings.LEGACY_APPS,
-        then all writes should go to 'legacy'
-
-        Otherwise, all writes go to 'default'
+        All writes go to the default database
         """
-        if self.has_legacy and self.model_is_legacy(model):
-            return 'legacy'
-
         return "default"
 
     def allow_relation(self, obj1, obj2, **hints):
-        """
-        Allow relations if both objs are legacy, or both aren't
-        """
-        if self.has_legacy:
-            return not (self.model_is_legacy(obj1) ^
-                        self.model_is_legacy(obj2))
         return True
 
     def allow_migrate(self, db, app_label, model_name=None, **hints):
         """
-        allow legacy app migrations in the legacy DB, everything else in
-        default
+        Allow migrations only in the default database.
         """
-
-        if self.has_legacy and app_label in settings.LEGACY_APPS:
-            return db == 'legacy'
-        else:
-            return db == 'default'
+        return db == 'default'

--- a/cfgov/v1/tests/test_db_router.py
+++ b/cfgov/v1/tests/test_db_router.py
@@ -13,8 +13,7 @@ def check_app_router(app, method_name):
         return method(model)
 
 
-@override_settings(LEGACY_APPS=['ask_cfpb'],
-                   DATABASES={'default': {}, 'legacy': {}})
+@override_settings(DATABASES={'default': {}})
 class CFGOVRouterNoReplicaTestCase(TestCase):
 
     def test_cfgov_apps_read_from_default_db(self):
@@ -25,17 +24,8 @@ class CFGOVRouterNoReplicaTestCase(TestCase):
         result = check_app_router('v1', 'db_for_write')
         self.assertEqual(result, 'default')
 
-    def test_legacy_app_reads_routed_to_legacy(self):
-        result = check_app_router('ask_cfpb', 'db_for_read')
-        self.assertEqual(result, 'legacy')
 
-    def test_legacy_app_writes_routed_to_legacy(self):
-        result = check_app_router('ask_cfpb', 'db_for_write')
-        self.assertEqual(result, 'legacy')
-
-
-@override_settings(LEGACY_APPS=['ask_cfpb'],
-                   DATABASES={'default': {}, 'legacy': {}, 'replica': {}})
+@override_settings(DATABASES={'default': {}, 'replica': {}})
 class CFGOVRouterReplicaTestCase(TestCase):
 
     def test_cfgov_apps_read_from_replica_db(self):
@@ -44,24 +34,4 @@ class CFGOVRouterReplicaTestCase(TestCase):
 
     def test_cfgov_apps_write_to_default_db(self):
         result = check_app_router('v1', 'db_for_write')
-        self.assertEqual(result, 'default')
-
-    def test_legacy_app_reads_routed_to_legacy(self):
-        result = check_app_router('ask_cfpb', 'db_for_read')
-        self.assertEqual(result, 'legacy')
-
-    def test_legacy_app_writes_routed_to_legacy(self):
-        result = check_app_router('ask_cfpb', 'db_for_write')
-        self.assertEqual(result, 'legacy')
-
-
-@override_settings(LEGACY_APPS=['ask_cfpb'],
-                   DATABASES={'default': {}})
-class CFGOVRouterNoLegacyTestCase(TestCase):
-    def test_legacy_app_reads_routed_to_default(self):
-        result = check_app_router('ask_cfpb', 'db_for_read')
-        self.assertEqual(result, 'default')
-
-    def test_legacy_app_writes_routed_to_default(self):
-        result = check_app_router('ask_cfpb', 'db_for_write')
         self.assertEqual(result, 'default')

--- a/cfgov/v1/tests/test_db_router.py
+++ b/cfgov/v1/tests/test_db_router.py
@@ -4,34 +4,45 @@ from django.test import TestCase, override_settings
 from v1.db_router import CFGOVRouter
 
 
-def check_app_router(app, method_name):
-    router = CFGOVRouter()
-    method = getattr(router, method_name)
+class CFGOVRouterTestCase(TestCase):
 
-    models = apps.get_app_config(app).get_models()
-    for model in models:
-        return method(model)
+    def setUp(self):
+        self.router = CFGOVRouter()
+        self.models = apps.get_app_config('v1').get_models()
 
 
 @override_settings(DATABASES={'default': {}})
-class CFGOVRouterNoReplicaTestCase(TestCase):
+class CFGOVRouterNoReplicaTestCase(CFGOVRouterTestCase):
 
     def test_cfgov_apps_read_from_default_db(self):
-        result = check_app_router('v1', 'db_for_read')
-        self.assertEqual(result, 'default')
+        results = [self.router.db_for_read(m) == 'default'
+                   for m in self.models]
+        self.assertTrue(all(results))
 
     def test_cfgov_apps_write_to_default_db(self):
-        result = check_app_router('v1', 'db_for_write')
-        self.assertEqual(result, 'default')
+        results = [self.router.db_for_write(m) == 'default'
+                   for m in self.models]
+        self.assertTrue(all(results))
+
+    def test_cfgov_apps_allow_migrate_default_db(self):
+        self.assertTrue(self.router.allow_migrate('default', 'v1'))
 
 
 @override_settings(DATABASES={'default': {}, 'replica': {}})
-class CFGOVRouterReplicaTestCase(TestCase):
+class CFGOVRouterReplicaTestCase(CFGOVRouterTestCase):
 
     def test_cfgov_apps_read_from_replica_db(self):
-        result = check_app_router('v1', 'db_for_read')
-        self.assertEqual(result, 'replica')
+        results = [self.router.db_for_read(m) == 'replica'
+                   for m in self.models]
+        self.assertTrue(all(results))
 
     def test_cfgov_apps_write_to_default_db(self):
-        result = check_app_router('v1', 'db_for_write')
-        self.assertEqual(result, 'default')
+        results = [self.router.db_for_write(m) == 'default'
+                   for m in self.models]
+        self.assertTrue(all(results))
+
+    def test_cfgov_apps_allow_migrate_default_db(self):
+        self.assertTrue(self.router.allow_migrate('default', 'v1'))
+
+    def test_cfgov_apps_disallow_migrate_replica_db(self):
+        self.assertFalse(self.router.allow_migrate('replica', 'v1'))


### PR DESCRIPTION
This PR removes the legacy database routing functionality and settings. 

With the Ask CFPB migration completed the largest compelling reason for maintaining the legacy database split is gone. There is not need for the `agreements` and `comparisontool` apps to be stored in separate databases. 

This PR will be accompanied by a corresponding Ansible PR.

## Removals

- `LEGACY` setting
- Legacy DB routing functionality in `CFGOVRouter`

## Checklist

* [ ] PR has an informative and human-readable title
* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated
* [ ] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
