### PR TITLE
Fix for hero images being truncated

### DIFF
--- a/cfgov/jinja2/v1/_includes/molecules/hero.html
+++ b/cfgov/jinja2/v1/_includes/molecules/hero.html
@@ -88,6 +88,7 @@
 
         .m-hero_image {
             background-image: url('{{ sm_img.url }}');
+            background-size: cover;
             filter: progid:DXImageTransform.Microsoft.AlphaImageLoader(
                 src='{{ sm_img.url }}',
                 sizingMethod='scale');
@@ -97,6 +98,7 @@
         @media screen and (min-width: 37.5625em) {
             .m-hero_image {
                 background-image: url('{{ img.url }}');
+                background-size: cover;
                 filter: progid:DXImageTransform.Microsoft.AlphaImageLoader(
                     src='{{ img.url }}',
                     sizingMethod='scale');
@@ -105,6 +107,7 @@
 
             .m-hero__overlay .m-hero_wrapper {
                 background-image: url('{{ img.url }}');
+                background-size: cover;
                 filter: progid:DXImageTransform.Microsoft.AlphaImageLoader(
                     src='{{ img.url }}',
                     sizingMethod='scale');


### PR DESCRIPTION
 Some of the hero images on Beta are being truncated. This is a temporary fix until we can resolve the issue through CF.


## Changes

- Modified `cfgov/jinja2/v1/_includes/molecules/hero.html` to add the `background-image` cover property.

## Testing

1. Add hero to page
2. Add background image to page.
3. Visit page using Chrome.
4. Verify image has the proper width.



## Checklist

* [ ] PR has an informative and human-readable title
* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated
* [ ] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
