### PR TITLE
Removing cover property from the image in the hero styles

### DIFF
--- a/cfgov/jinja2/v1/_includes/molecules/hero.html
+++ b/cfgov/jinja2/v1/_includes/molecules/hero.html
@@ -88,7 +88,6 @@
 
         .m-hero_image {
             background-image: url('{{ sm_img.url }}');
-            background-size: cover;
             filter: progid:DXImageTransform.Microsoft.AlphaImageLoader(
                 src='{{ sm_img.url }}',
                 sizingMethod='scale');
@@ -98,7 +97,6 @@
         @media screen and (min-width: 37.5625em) {
             .m-hero_image {
                 background-image: url('{{ img.url }}');
-                background-size: cover;
                 filter: progid:DXImageTransform.Microsoft.AlphaImageLoader(
                     src='{{ img.url }}',
                     sizingMethod='scale');


### PR DESCRIPTION
The image doesn't need the cover property. I can't copy / paste worth a damn.

## Changes

- Modified `cfgov/jinja2/v1/_includes/molecules/hero.html` to remove the cover property from the image.

## Checklist

* [ ] PR has an informative and human-readable title
* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated
* [ ] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
