### PR TITLE
Fix for CF4 link styles in Wagtail content parser

### DIFF
--- a/cfgov/v1/__init__.py
+++ b/cfgov/v1/__init__.py
@@ -128,10 +128,16 @@ NONCFPB_LINK_PATTERN = re.compile(settings.NONCFPB_LINK_PATTERN)
 FILES_LINK_PATTERN = re.compile(settings.FILES_LINK_PATTERN)
 DOWNLOAD_LINK_PATTERN = re.compile(settings.DOWNLOAD_LINK_PATTERN)
 EXTERNAL_A_CSS = os.environ.get('EXTERNAL_A_CSS',
-                                'icon-link icon-link__external-link')
+                                'a-link '
+                                'a-link__icon '
+                                'cf-icon cf-icon__after '
+                                'cf-icon-external-link')
 DOWNLOAD_A_CSS = os.environ.get('DOWNLOAD_A_CSS',
-                                'icon-link icon-link__download')
-EXTERNAL_SPAN_CSS = os.environ.get('EXTERNAL_SPAN_CSS', 'icon-link_text')
+                                'a-link '
+                                'a-link__icon '
+                                'cf-icon cf-icon__after '
+                                'cf-icon-download')
+EXTERNAL_SPAN_CSS = os.environ.get('EXTERNAL_SPAN_CSS', 'a-link_text')
 
 
 def add_link_markup(tags):

--- a/cfgov/v1/tests/test_links.py
+++ b/cfgov/v1/tests/test_links.py
@@ -16,19 +16,19 @@ class ImportDataTest(TestCase):
         link = '<a href="https://wwww.google.com">external link/a>'
         output = str(parse_links(link))
         self.assertIn('external-site', output)
-        self.assertIn('class="icon-link_text"', output)
+        self.assertIn('cf-icon-external-link', output)
 
     def test_cfpb_link(self):
         link = '<a href="http://www.consumerfinance.gov/foo">cfpb link</a>'
         output = str(parse_links(link))
         self.assertNotIn('external-site', output)
-        self.assertNotIn('class="icon-link_text"', output)
+        self.assertNotIn('cf-icon-external-link', output)
 
     def test_gov_link(self):
         link = '<a href="http://www.fdic.gov/bar">gov link</a>'
         output = str(parse_links(link))
         self.assertNotIn('external-site', output)
-        self.assertIn('class="icon-link_text"', output)
+        self.assertIn('cf-icon-external-link', output)
 
 
 class GetProtectedUrlTestCase(TestCase):


### PR DESCRIPTION
Fix for CF4 link styles in Wagtail content parser

## Additions

-

## Removals

-

## Changes

- Modified `cfgov/v1/__init__.py` to fix add to CF4 styles to links.


## Testing

1. Visit `http://localhost:8000/educational-resources/resources-for-tax-preparers/` and verify that the download links are present (shown is screenshot).

## Screenshots

- 
<img width="814" alt="screen shot 2017-07-20 at 7 52 40 am" src="https://user-images.githubusercontent.com/1696212/28416062-710f0842-6d20-11e7-83e8-60011b9c6542.png">


## Notes

-

## Todos

-

## Checklist

* [ ] PR has an informative and human-readable title
* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated
* [ ] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
