### PR TITLE
Fix handling of unicode table block headers

### DIFF
--- a/cfgov/jinja2/v1/_includes/organisms/table.html
+++ b/cfgov/jinja2/v1/_includes/organisms/table.html
@@ -100,10 +100,7 @@
                       first_row[loop.index0] is not none and
                       value.is_stacked
                 %}
-                    {% set attributes = attributes + ' data-label="{0}"'.format(first_row[loop.index0]
-                                        | striptags
-                                        | trim)
-                    %}
+                    {% set attributes = attributes + ' data-label="' + first_row[loop.index0]|striptags|trim + '"' %}
                 {% endif %}
                 <{{ tag | safe }}{{ attributes | safe }}>
                     {{ _render_cell(cell) }}

--- a/cfgov/v1/tests/atomic_elements/organisms/test_tables.py
+++ b/cfgov/v1/tests/atomic_elements/organisms/test_tables.py
@@ -64,3 +64,13 @@ class TestAtomicTableBlock(TestCase):
         block = AtomicTableBlock()
         result = block.render(value)
         self.assertIn('href="/slug/"', result)
+
+    def test_render_header_with_unicode_characters(self):
+        value = {
+            'data': [[u'H\xebader 1', 'Header 2'], ['1', '2']],
+            'first_row_is_table_header': True,
+            'is_stacked': True,
+        }
+        block = AtomicTableBlock()
+        result = block.render(value)
+        self.assertIn(u'H\xebader', result)


### PR DESCRIPTION
If `TableBlock` header values contain unicode characters, the logic that sticks the header value into the cell `"data-label"` attribute raises a `UnicodeEncodeError`.

This commit fixes that handling so that unicode content is properly placed in the page, and adds a regression test to cover this behavior.

## Changes

- Don't use `"{0}".format(some_unicode_string)` in a Django template as the `"{0}"` part is a non-unicode string that you're trying to stick unicode characters into.

## Testing

To reproduce, create a `TableBlock` and check "Stacked on mobile" and "Row header". Then enter some unicode characters into a column header and set some value in the next row. Previewing the page (or viewing a published version) should raise the exception on master but not with this fix.

## Screenshots

Input:

![image](https://user-images.githubusercontent.com/654645/28423623-87ef6ea8-6d39-11e7-938f-69c6658633f9.png)

Proper rendering:

![image](https://user-images.githubusercontent.com/654645/28423524-4709c55a-6d39-11e7-89aa-004596e56062.png)

## Notes

- Partially addresses GHE#1004.

## Checklist

* [X] PR has an informative and human-readable title
* [X] Changes are limited to a single goal (no scope creep)
* [X] Code can be automatically merged (no conflicts)
* [X] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [X] Passes all existing automated tests
* [X] New functions include new tests
* [X] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
