### PR TITLE
Update date stamp on homepage

### DIFF
--- a/cfgov/jinja2/v1/index.html
+++ b/cfgov/jinja2/v1/index.html
@@ -162,7 +162,7 @@
                 </section>
             </div>
 
-            <p style="margin-top: 30px;margin-bottom: 0;">Figures are updated quarterly. Last update on 02/28/2017</p>
+            <p style="margin-top: 30px;margin-bottom: 0;">Figures are updated quarterly. Last update on 07/20/2017</p>
         </div>
 
         <div class="wrapper">


### PR DESCRIPTION
Figures were updated in #3159, but not the date stamp. This corrects that.

## Checklist

* [ ] PR has an informative and human-readable title
* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated
* [ ] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
