### PR TITLE
Fix for square image within the image inset

### DIFF
--- a/cfgov/jinja2/v1/_includes/molecules/image-inset.html
+++ b/cfgov/jinja2/v1/_includes/molecules/image-inset.html
@@ -41,7 +41,6 @@
 {% set image_inset = image(value.image.upload, 'original') %}
 {% set image_mobile = image(value.image.upload, 'width-1200') %}
 
-
 <div class="m-inset
             m-inset__image
             {{ 'm-inset__left' if value.image_position == 'left' else '' }}

--- a/cfgov/jinja2/v1/_includes/molecules/image-inset.html
+++ b/cfgov/jinja2/v1/_includes/molecules/image-inset.html
@@ -46,7 +46,7 @@
             {{ 'm-inset__left' if value.image_position == 'left' else '' }}
             {{ 'm-inset__' ~ ( value.image_width
                if value.image_width else 270 ) }}
-            {{ 'm-inset__' + image_inset.get_orientation() }}
+            {{ 'm-inset__' + image_inset.orientation }}
             {{ 'm-inset__bottom-rule'
                if value.is_bottom_rule else '' }}">
     <div class="m-inset_image-container">

--- a/cfgov/jinja2/v1/_includes/molecules/image-inset.html
+++ b/cfgov/jinja2/v1/_includes/molecules/image-inset.html
@@ -40,13 +40,14 @@
    are never stretched or upscaled and maintain their aspect ratio. #}
 {% set image_inset = image(value.image.upload, 'original') %}
 {% set image_mobile = image(value.image.upload, 'width-1200') %}
+
+
 <div class="m-inset
             m-inset__image
             {{ 'm-inset__left' if value.image_position == 'left' else '' }}
             {{ 'm-inset__' ~ ( value.image_width
                if value.image_width else 270 ) }}
-            {{ 'm-inset__portrait'
-               if image_inset.height > image_inset.width else '' }}
+            {{ 'm-inset__' + image_inset.get_orientation() }}
             {{ 'm-inset__bottom-rule'
                if value.is_bottom_rule else '' }}">
     <div class="m-inset_image-container">

--- a/cfgov/unprocessed/css/molecules/inset.less
+++ b/cfgov/unprocessed/css/molecules/inset.less
@@ -104,6 +104,12 @@
                 padding-bottom: 75%;
             }
         }
+
+        &__square {
+            .m-inset_image-container {
+                padding-bottom: 100%;
+            }
+        }
     } );
 
     .respond-to-min( @bp-sm-min, {

--- a/cfgov/v1/models/images.py
+++ b/cfgov/v1/models/images.py
@@ -103,6 +103,27 @@ class CFGOVRendition(AbstractRendition):
     def alt(self):
         return self.image.alt
 
+    def get_orientation(self):
+        orientation='square'
+        if self.is_portrait:
+            orientation = 'portrait'
+        elif self.is_landscape:
+            orientation = 'landscape'
+
+        return orientation
+
+    @property
+    def is_square(self):
+        return self.height == self.width
+
+    @property
+    def is_portrait(self):
+        return self.height > self.width
+
+    @property
+    def is_landscape(self):
+        return self.height < self.width
+
     class Meta:
         unique_together = (
             ('image', 'filter_spec', 'focal_point_key'),

--- a/cfgov/v1/models/images.py
+++ b/cfgov/v1/models/images.py
@@ -104,7 +104,7 @@ class CFGOVRendition(AbstractRendition):
         return self.image.alt
 
     def get_orientation(self):
-        orientation='square'
+        orientation = 'square'
         if self.is_portrait:
             orientation = 'portrait'
         elif self.is_landscape:

--- a/cfgov/v1/models/images.py
+++ b/cfgov/v1/models/images.py
@@ -1,4 +1,5 @@
 from django.db import models
+from django.utils.functional import cached_property
 from django.utils.six import string_types
 from wagtail.wagtailimages.image_operations import (DoNothingOperation,
                                                     MinMaxOperation,
@@ -103,7 +104,8 @@ class CFGOVRendition(AbstractRendition):
     def alt(self):
         return self.image.alt
 
-    def get_orientation(self):
+    @cached_property
+    def orientation(self):
         orientation = 'square'
         if self.is_portrait:
             orientation = 'portrait'
@@ -112,15 +114,15 @@ class CFGOVRendition(AbstractRendition):
 
         return orientation
 
-    @property
+    @cached_property
     def is_square(self):
         return self.height == self.width
 
-    @property
+    @cached_property
     def is_portrait(self):
         return self.height > self.width
 
-    @property
+    @cached_property
     def is_landscape(self):
         return self.height < self.width
 


### PR DESCRIPTION
Fix for square image inset 
GHE/1002

## Changes

- Modified `cfgov/jinja2/v1/_includes/molecules/image-inset.html` to use call method on `CFGOVRendition` model.

- Modified `cfgov/v1/models/images.py` to add orientation method and properties.

## Testing

Square Image
1. Add an image inset to a page.
2. Upload a square image and verify, using Chrome dev tools, that the image has the `__square` modifier.
3. Resize browse to mobile width and verify that the padding bottom is 100%;
4. Verify that the image isn't being cropped.

Landscape Image
1. Add an image inset to a page.
2. Upload a landscape image and verify, using Chrome dev tools, that the image has the `__landscape` modifier.
3. Resize browse to mobile width and verify that the padding bottom is 56%;

Portrait Image
1. Add an image inset to a page.
2. Upload a portrait image and verify, using Chrome dev tools, that the image has the `__portrait` modifier.
3. Resize browse to mobile width and verify that the padding bottom is 75%;

## Screenshots


## Notes

- I'll write tests for this if people are ok with the approach.

## Todos

-

## Checklist

* [ ] PR has an informative and human-readable title
* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated
* [ ] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
