### PR TITLE
Fix for share icons on video player

### DIFF
--- a/cfgov/unprocessed/css/video-player.less
+++ b/cfgov/unprocessed/css/video-player.less
@@ -167,6 +167,7 @@
     // Adding white background to the share icons
     // without overlap.
     .cf-icon {
+        display: inline-block;
         height: 20px;
         width: 22px;
         background: @white;


### PR DESCRIPTION
Fix for share icons on video player


## Changes

- Modified `cfgov/unprocessed/css/video-player.less` to fix visual appearance of icons on video player.


## Testing

1. Run gulp styles
2. Visit `http://localhost:8000/about-us/the-bureau/` and hit the play button.

## Screenshots

Before:
<img width="264" alt="screen shot 2017-07-21 at 2 31 03 pm" src="https://user-images.githubusercontent.com/1696212/28477279-44c67688-6e21-11e7-85a4-49a110a80992.png">

After:
<img width="171" alt="screen shot 2017-07-21 at 2 43 23 pm" src="https://user-images.githubusercontent.com/1696212/28477635-fe2b9288-6e22-11e7-85c6-033cd1f4885f.png">

## Notes

-

## Todos

-

## Checklist

* [ ] PR has an informative and human-readable title
* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated
* [ ] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
