### PR TITLE
Fix for missing for fonts, post CF4 conversion

### DIFF
--- a/gulp/config.js
+++ b/gulp/config.js
@@ -93,7 +93,7 @@ module.exports = {
       dest: paths.processed
     },
     icons: {
-      src:  paths.modules + '/capital-framework/src/cf-icons/src/fonts/*',
+      src:  paths.modules + '/cf-icons/src/fonts/*',
       dest: paths.processed + '/fonts/'
     },
     vendorFonts: {


### PR DESCRIPTION
Fix for post CF4 conversion font

## Changes

- Modified `gulp/config.js` to 

## Testing

1. Run `python cfgov/manage.py collectstatic --clear`
2. Run `gulp build`
3. Verify that the font directory exists in the `static_built` directory.

## Todos

-

## Checklist

* [ ] PR has an informative and human-readable title
* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated
* [ ] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
