### PR TITLE
Correct the CCDB5 urls and up the version for CCDB5-API

### DIFF
--- a/cfgov/cfgov/urls.py
+++ b/cfgov/cfgov/urls.py
@@ -247,7 +247,7 @@ urlpatterns = [
     # If 'CCDB5_RELEASE' is True, include CCDB5 urls.
     # Otherwise include CCDB4 urls
     flagged_url('CCDB5_RELEASE',
-                r'^data-research/consumer-complaints/',
+                r'^data-research/consumer-complaints/search',
                 include_if_app_enabled(
                     'ccdb5_ui', 'ccdb5_ui.config.urls'
                 ),
@@ -300,7 +300,7 @@ urlpatterns = [
 
     # CCDB5-API
     flagged_url('CCDB5_RELEASE',
-                r'^data-research/consumer-complaints/api/v1/',
+                r'^data-research/consumer-complaints/search/api/v1/',
                 include_if_app_enabled('complaint_search',
                                        'complaint_search.urls')
                 ),

--- a/requirements/optional-public.txt
+++ b/requirements/optional-public.txt
@@ -5,6 +5,6 @@ git+https://github.com/cfpb/owning-a-home-api.git@0.9.96#egg=owning-a-home-api
 git+https://github.com/cfpb/regulations-core.git@1.2.5#egg=regcore
 git+https://github.com/cfpb/regulations-site.git@2.1.8#egg=regulations
 git+https://github.com/cfpb/retirement.git@0.5.6#egg=retirement
-git+https://github.com/cfpb/ccdb5-api.git@v0.0.2#egg=ccdb5-api
+git+https://github.com/cfpb/ccdb5-api.git@v0.4.0#egg=ccdb5-api
 git+https://github.com/cfpb/ccdb5-ui.git@v0.2.1#egg=ccdb5_ui
 git+https://github.com/cfpb/eregs-2.0.git@0.0.2#egg=eregs


### PR DESCRIPTION
This is to correct CCDB5 URLs and point to the latest version of CCDB5-API

## Changes

- Previous URLs for CCDB5 are not correct, now setting to the right location
- Up CCDB5-API to the latest version


## Checklist

* [ ] PR has an informative and human-readable title
* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated
* [ ] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
