### PR TITLE
Fix for image inset list styling on IE11

### DIFF
--- a/cfgov/unprocessed/css/organisms/full-width-text-group.less
+++ b/cfgov/unprocessed/css/organisms/full-width-text-group.less
@@ -44,6 +44,11 @@
               // when the image is floated right:
               // calc(~"100% - 41.875rem");
               margin-left: unit( @grid_gutter-width / @base-font-size-px, em );
+
+              & + .m-full-width-text ul,
+              & + .m-full-width-text ol {
+                  overflow: hidden;
+              }
           }
 
           .m-inset__left {

--- a/cfgov/unprocessed/css/organisms/full-width-text-group.less
+++ b/cfgov/unprocessed/css/organisms/full-width-text-group.less
@@ -47,6 +47,8 @@
 
               & + .m-full-width-text ul,
               & + .m-full-width-text ol {
+
+                  //Fix for IE11 rendering bullets issue.
                   overflow: hidden;
               }
           }


### PR DESCRIPTION
Fix for image inset styling on IE11
GHE 1002

## Changes

- Modified `cfgov/unprocessed/css/organisms/full-width-text-group.less` to fix issue with list when next to a floated container.


## Testing

1. Run `gulp styles`
2. Add a `Full width-text-organism` to a page. 
3. Add the `Image Inset` molecule.
4. Add a image to the molecule.
5. Float the image to the left.
6. Add a content block beneath image.
7. Add a ul list to the content block, using the RTE.
8. Publish and verify that the block looks correct (using the IE 11).

## Screenshots

Before

- 
<img width="940" alt="screen shot 2017-07-24 at 2 53 58 pm" src="https://user-images.githubusercontent.com/1696212/28540140-34cfe8a0-7082-11e7-985a-94f41de2decd.png">

- After
![ie11 - win7](https://user-images.githubusercontent.com/1696212/28540151-4212611e-7082-11e7-8685-58e6a505b8bd.png)


## Notes

- The ol still gets clipped. We don't apply any CF styles to the Rich Text Editor lists.

## Todos

-

## Checklist

* [ ] PR has an informative and human-readable title
* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated
* [ ] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
