### PR TITLE
Updates deprecated header-slug

### DIFF
--- a/cfgov/jinja2/v1/_includes/snippets/reusable_text.html
+++ b/cfgov/jinja2/v1/_includes/snippets/reusable_text.html
@@ -14,7 +14,7 @@
                             gets displayed on the webpage.
 
    value.sidefoot_heading:  Heading text to be used if this snippet is only
-                            for use in sidefoots.
+                            for use in sidebars and prefooters (the "sidefoot").
 
    value.text:              Rich text field that gets displayed on the page.
 
@@ -23,11 +23,11 @@
 <div class="m-reusable-text-snippet">
 
 {% if value.sidefoot_heading %}
-    <h2 class="header-slug">
-       <span class="header-slug_inner">
+    <header class="m-slug-header">
+       <h2 class="a-heading">
            {{ value.sidefoot_heading }}
-       </span>
-    </h2>
+       </h2>
+    </header>
 {% endif %}
 
     {{ value.text|richtext }}

--- a/test/browser_tests/cucumber/step_definitions/reusable-text-snippets.js
+++ b/test/browser_tests/cucumber/step_definitions/reusable-text-snippets.js
@@ -27,7 +27,7 @@ defineSupportCode( function( { When, Then } ) {
         rts = element.all( by.css( '.m-reusable-text-snippet' ) ).last();
       }
 
-      return expect( rts.element( by.css( '.header-slug' ) ).isPresent() )
+      return expect( rts.element( by.css( '.m-slug-header' ) ).isPresent() )
              .to.eventually.equal( shouldShouldnt( includeHeader ) );
     }
   );


### PR DESCRIPTION
## Changes

- Changes `header-slug` to `m-slug-header` in reusable text snippet.

## Testing

1. Create a test Document detail page in Wagtail.
2. Click on the sidebar and add a Reusable Text.
3. Choose a Reusable Text, edit it to add "sidefoot heading" if absent (latest database dump appears not to have any reusable text snippets with a sidefoot heading set.
4. Preview the page.

## Screenshots

Before
![screen shot 2017-07-24 at 5 00 58 pm](https://user-images.githubusercontent.com/704760/28545060-8155c332-7093-11e7-8378-aa8cefcac514.png)

After
![screen shot 2017-07-24 at 5 02 08 pm](https://user-images.githubusercontent.com/704760/28545059-814e2730-7093-11e7-85bc-7f0702b6e3e2.png)
