### PR TITLE
Adding check to frontend.sh to print warning if Node 8 isn't used

### DIFF
--- a/frontend.sh
+++ b/frontend.sh
@@ -22,7 +22,7 @@ init() {
   fi
 
   if [[ "$(node -v)" != 'v8.'* ]]; then
-    printf "\033[1;31mPlease install Node 8.x\033[0m\n"
+    printf "\033[1;31mPlease install Node 8.x: 'nvm install 8'\033[0m\n"
     exit 1
   fi
 

--- a/frontend.sh
+++ b/frontend.sh
@@ -21,6 +21,10 @@ init() {
     DEP_CHECKSUM=$(cat package.json | shasum -a 256)
   fi
 
+  if [[ "$(node -v)" != 'v8.'* ]]; then
+    printf "\033[1;31mPlease install Node 8.x\033[0m\n"
+  fi
+
   echo "npm components directory: $NODE_DIR"
 }
 

--- a/frontend.sh
+++ b/frontend.sh
@@ -23,6 +23,7 @@ init() {
 
   if [[ "$(node -v)" != 'v8.'* ]]; then
     printf "\033[1;31mPlease install Node 8.x\033[0m\n"
+    exit 1
   fi
 
   echo "npm components directory: $NODE_DIR"


### PR DESCRIPTION
Adding check to frontend.sh to print warning if Node 8 isn't used 

## Changes

- Modifying 'frontend.sh` to add Node 8 warning.

## Testing

1. Run `node -v ` to determine your version.
2. Run frontend.sh, if you aren't running `node 8` you should get a warning.

## Screenshots

- 
<img width="316" alt="screen shot 2017-07-25 at 5 28 45 pm" src="https://user-images.githubusercontent.com/1696212/28594691-d837d0c0-715e-11e7-809b-86daf9c96827.png">


## Notes

-

## Todos

-

## Checklist

* [ ] PR has an informative and human-readable title
* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated
* [ ] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
