### PR TITLE
Fix for external links on blog page

### DIFF
--- a/cfgov/jinja2/v1/blog/blog_page.html
+++ b/cfgov/jinja2/v1/blog/blog_page.html
@@ -18,7 +18,22 @@
     {% include 'article.html' %}
     <div class="block">
         <p>
-            Join the conversation. Follow CFPB on <a class="icon-link icon-link__external-link" href="{{ unsigned_redirect('https://twitter.com/cfpb') }}"><span class="icon-link_text">Twitter</span> </a> and <a class="icon-link icon-link__external-link" href="{{ unsigned_redirect('https://facebook.com/cfpb') }}"><span class="icon-link_text">Facebook</span> </a>.
+            Join the conversation. Follow CFPB on
+            <a class="a-link
+                      a-link__icon
+                      cf-icon
+                      cf-icon__after
+                      cf-icon-external-link"
+                href="{{ unsigned_redirect('https://twitter.com/cfpb') }}">
+                    <span class="a-link_text">Twitter</span>
+            </a> and <a class="a-link
+                               a-link__icon
+                               cf-icon
+                               cf-icon__after
+                               cf-icon-external-link"
+                         href="{{ unsigned_redirect('https://facebook.com/cfpb') }}">
+                    <span class="a-link_text">Facebook</span>
+            </a>.
         </p>
     </div>
 {% endblock %}


### PR DESCRIPTION
Fix for external links on blog page


## Changes

- Fix for ` cfgov/jinja2/v1/blog/blog_page.html` for external link on blog page.

## Testing

1. Visit `http://localhost:8000/about-us/blog/guides-public-service-loan-forgiveness/` and verify the links have the external link icons.

## Screenshots

<img width="679" alt="screen shot 2017-07-26 at 2 33 12 pm" src="https://user-images.githubusercontent.com/1696212/28637404-68dcd75a-720f-11e7-8b6f-d48afc5efacc.png">


## Checklist

* [ ] PR has an informative and human-readable title
* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated
* [ ] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
