### PR TITLE
Fix for snippet-list link link icons

### DIFF
--- a/cfgov/jinja2/v1/_includes/organisms/snippet-list.html
+++ b/cfgov/jinja2/v1/_includes/organisms/snippet-list.html
@@ -86,8 +86,9 @@
                             {%- set href = snippet[action.snippet_field].url
                                if snippet[action.snippet_field].url is defined
                                else snippet[action.snippet_field] -%}
+                            {% set link = '<a href="' ~ href ~ '">' ~ action.link_label ~ '</a>' %}
                             <li class="m-list_item">
-                                <a href="{{ href }}">{{ action.link_label }}</a>
+                               {{ parse_links(link) | safe }}
                             </li>
                         {% endif %}
                     {% endfor %}


### PR DESCRIPTION
Fix for snippet-list link link icons

## Changes

- Modified `educational-resources/library-resources/outreach-materials-to-use-in-the-library/` to fix issue rendering link icons.

## Testing

1. Visit `educational-resources/library-resources/outreach-materials-to-use-in-the-library/` and verify that the link icons are present.

## Screenshots
- 
<img width="362" alt="screen shot 2017-07-27 at 10 42 58 am" src="https://user-images.githubusercontent.com/1696212/28676337-64a3a0b6-72b8-11e7-99ea-12689a663a00.png">

## Notes

- The spacing is a bit tight

## Checklist

* [ ] PR has an informative and human-readable title
* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated
* [ ] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
