### PR TITLE
Moving Search API up one level

### DIFF
--- a/cfgov/cfgov/urls.py
+++ b/cfgov/cfgov/urls.py
@@ -299,7 +299,7 @@ urlpatterns = [
 
     # CCDB5-API
     flagged_url('CCDB5_RELEASE',
-                r'^data-research/consumer-complaints/search/api/v1/',
+                r'^data-research/consumer-complaints/api/v1/',
                 include_if_app_enabled('complaint_search',
                                        'complaint_search.urls')
                 ),


### PR DESCRIPTION
To avoid any url wildcard / routing issues, this PR suggests moving the URL for the ccdb API up one level.

@amymok @willbarton (secondary)

Short description explaining the high-level reason for the pull request

## Additions

- N/A

## Removals

- N/A

## Changes

- Removes `/search/` from CCDB API url route

## Testing

1.

## Screenshots


## Notes

-

## Todos

-

## Checklist

* [ ] PR has an informative and human-readable title
* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated
* [ ] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
