### PR TITLE
Update jQuery load call

### DIFF
--- a/cfgov/templates/wagtailadmin/js/table-block.js
+++ b/cfgov/templates/wagtailadmin/js/table-block.js
@@ -193,7 +193,7 @@
 
                 if ( 'resize' in $window ) {
                     this.resize( utilities.DIMENSIONS.HEIGHT, this.getHeight() );
-                    $window.load( function() {
+                    $window.on('load', function() {
                         $window.resize();
                     } );
                 }


### PR DESCRIPTION
Fixes one of the jquery deprecated load references in https://[GHE]/CFGOV/platform/issues/1006.

## Changes

- Changes `load(` to `on('load'`

## Testing

1. Put a console log above the line 196 in the changed file. 
2. Log into Wagtail and add a table-block.
3. open the dev console and hard reload the page and see that your console message logs.