### PR TITLE
Properly include page StreamBlock children media

### DIFF
--- a/cfgov/v1/models/base.py
+++ b/cfgov/v1/models/base.py
@@ -348,7 +348,10 @@ class CFGOVPage(Page):
     # Recursively search the blocks and classes for declared Media.js
     def _add_block_js(self, block, js):
         self._assign_js(block, js)
-        if issubclass(type(block), blocks.StructBlock):
+        if (
+            issubclass(type(block), blocks.StructBlock) or
+            issubclass(type(block), blocks.StreamBlock)
+        ):
             for child in block.child_blocks.values():
                 self._add_block_js(child, js)
         elif issubclass(type(block), blocks.ListBlock):
@@ -356,23 +359,20 @@ class CFGOVPage(Page):
 
     # Assign the Media js to the dictionary appropriately
     def _assign_js(self, obj, js):
-        try:
-            if hasattr(obj.Media, 'js'):
-                for key in js.keys():
-                    if obj.__module__.endswith(key):
-                        js[key] += obj.Media.js
-                if not [key for key in js.keys()
-                        if obj.__module__.endswith(key)]:
-                    js.update({'other': obj.Media.js})
-        except:
-            pass
+        if hasattr(obj, 'Media') and hasattr(obj.Media, 'js'):
+            for key in js.keys():
+                if obj.__module__.endswith(key):
+                    js[key] += obj.Media.js
+            if not [key for key in js.keys()
+                    if obj.__module__.endswith(key)]:
+                js['other'] += obj.Media.js
 
     # Returns all the JS files specific to this page and it's current
     # Streamfield's blocks
     @property
     def media(self):
         js = OrderedDict()
-        for key in ['template', 'organisms', 'molecules', 'atoms']:
+        for key in ['template', 'organisms', 'molecules', 'atoms', 'other']:
             js.update({key: []})
         self.add_page_js(js)
         self._add_streamfield_js(js)


### PR DESCRIPTION
The `CFGOVPage.media` property returns a dictionary of JS files that were included by child blocks on the page. This logic had a slight bug (discovered by @jimmynotjim) where media files defined on blocks that were nested inside of a `StreamBlock` (or block descendant thereof) were not being included.

This change modifies the `CFGOVPage.media` logic to properly include `StreamBlock` children media in the same way that `StructBlock` children media is included. It also adds a couple of unit tests to
validate this behavior.

## Changes

- Modifications to `CFGOVPage.media` to properly include `StreamBlock` child media files.

## Testing

There's no easy way to replicate this right now without modifying an existing block to define a `class Media`; one example would be `v1.atomic_elements.organisms.AtomicTableBlock`. If you add a media file there, you'll see that current Wagtail behavior includes that media file if the table block is added as a top-level block under a content `StreamField`, but not if added within a nested `FullWidthText` in that
content. This change fixes that behavior.

## Checklist

* [X] PR has an informative and human-readable title
* [X] Changes are limited to a single goal (no scope creep)
* [X] Code can be automatically merged (no conflicts)
* [X] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [X] Passes all existing automated tests
* [X] New functions include new tests
* [X] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
