### PR TITLE
Fix for `/es/` meta tags and minor spacing cleanup

### DIFF
--- a/cfgov/jinja2/v1/es/es-base.html
+++ b/cfgov/jinja2/v1/es/es-base.html
@@ -7,22 +7,16 @@
 
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
-    <title>
-        {% block babel_title %}
-        {% endblock %}
-    </title>
-
-    {% block page_meta %}
+    <title>{{ self.babel_title() | trim }}</title>
+    <meta name="description" content="">
+    <meta name="viewport" content="width=device-width initial-scale=1">
+    <meta name="title" content="{{ self.babel_title() | trim }}" />
+    <meta property="og:title" content="{{ self.babel_title() | trim }}" />
     <meta property="og:url" content="{{ request.url }}">
-    {% endblock %}
-
     <meta property="og:type" content="government">
     <meta property="og:site_name" content="Oficina para la Protección Financiera del Consumidor">
     <meta property="fb:page_id" content="141576752553390">
     <meta property="fb:app_id" content="210516218981921">
-
-    <meta name="description" content="">
-    <meta name="viewport" content="width=device-width initial-scale=1">
     <meta name="Copyright" content="Public domain">
     <link rel="apple-touch-icon" href="{{ static('nemo/_/img/apple-touch-icon-precomposed.png') }}">
     <link rel="apple-touch-icon" size="72x72" href="{{ static('nemo/_/img/apple-touch-icon-72x72-precomposed.png') }}">
@@ -43,9 +37,9 @@
     <!--[if IE 9]><script src="{{ static('js/ie/common.ie.js') }}"></script><![endif]-->
 </head>
 <body class="page {% block body_class %} page-parent {% endblock %}
-page-template
-page-template-page-babel
-page-template-page-babel-php">
+             page-template
+             page-template-page-babel
+             page-template-page-babel-php">
 <!-- Google Tag Manager -->
 <noscript><iframe src="//www.googletagmanager.com/ns.html?id=GTM-KMMLRS"
     height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
@@ -105,9 +99,9 @@ page-template-page-babel-php">
                 <a href="/es/hogar">Hogar</a>
             </li>
         </ul>
-    </nav><!-- .main-nav -->
+        </nav><!-- .main-nav -->
 
-</div><!-- .wrapper-container -->
+    </div><!-- .wrapper-container -->
 
 </header><!-- .wrapper-header -->
 

--- a/cfgov/jinja2/v1/es/hogar/index.html
+++ b/cfgov/jinja2/v1/es/hogar/index.html
@@ -1,12 +1,15 @@
 {% extends 'es/es-base.html' %}
 
+{% block babel_title %}
+	Hogar &gt; Oficina para la Protección Financiera del Consumidor
+{% endblock %}
+
 {% block body_class %}
 {% endblock %}
 
 {% block nav_item_hogar %}
 	s-active
 {% endblock %}
-
 
 {% block babel_content %}
 <header class="hero full-bleed full-bleed-padded">
@@ -16,7 +19,7 @@
 		<div class="hero-copy">
 			<h1><span class="heading-inner-small">¿Le gustaría comprar una casa?<br>¿Ya tiene una hipoteca?</span><br><strong>Como las normas del CFPB<br>le pueden ayudar.</strong></h1>
 		</div>
-	</div><!-- .hero-container-->
+	</div>
 </header>
 <section class="content">
 	<div class="primary">
@@ -73,6 +76,6 @@
 					<ol>
 					</ol></article><article></article><article></article>
 			</ol></ol></article>
-	</div><!-- .primary -->
-</section><!-- .content -->
+	</div>
+</section>
 {% endblock %}

--- a/cfgov/jinja2/v1/es/nuestra-historia/index.html
+++ b/cfgov/jinja2/v1/es/nuestra-historia/index.html
@@ -1,5 +1,9 @@
 {% extends 'es/es-base.html' %}
 
+{% block babel_title %}
+	Nuestra historia &gt; Oficina para la Protección Financiera del Consumidor
+{% endblock %}
+
 {% block body_class %}
 {% endblock %}
 
@@ -7,8 +11,6 @@
 <section class="content">
 	<div class="primary">
 		<article>
-
-
 			<article>
 				<p>
 				</p><h2 class="heading">Nuestra historia</h2>
@@ -41,10 +43,8 @@
 				<p>
 					En julio de 2010, el Congreso aprobó y el presidente Obama firmó la Ley Dodd-Frank de Reforma de Wall Street y Protección al Consumidor. La ley creó el CFPB (la Oficina para la Protección Financiera del Consumidor). El CFPB consolida la mayor autoridad federal de protección financiera al consumidor en un solo lugar. El servicio al consumidor se centra en un objetivo: vigilar el mercado de productos y servicios financiero en beneficio de los consumidores estadounidenses.
 				</p>
-			</article></article></div>
-
-			<!-- .row -->
-
-
-		</section>
+			</article>
+		</article>
+	</div>
+</section>
 {% endblock %}

--- a/cfgov/jinja2/v1/es/presentar-una-queja/index.html
+++ b/cfgov/jinja2/v1/es/presentar-una-queja/index.html
@@ -1,10 +1,12 @@
 {% extends 'es/es-base.html' %}
 
 {% block babel_title %}
+	Después de presentar una queja &gt; Oficina para la Protección Financiera del Consumidor
 {% endblock %}
 
 {% block body_class %}
 {% endblock %}
+
 {% block nav_item_presentar %}
 	s-active
 {% endblock %}

--- a/cfgov/jinja2/v1/es/quienes-somos/index.html
+++ b/cfgov/jinja2/v1/es/quienes-somos/index.html
@@ -1,5 +1,9 @@
 {% extends 'es/es-base.html' %}
 
+{% block babel_title %}
+	¿Quiénes somos? &gt; Oficina para la Protección Financiera del Consumidor
+{% endblock %}
+
 {% block body_class %}
 {% endblock %}
 


### PR DESCRIPTION
Fix for `/es/` meta tags and minor spacing cleanup

## Changes

- Modified template files to ensure each page had the proper meta tags and title.


## Testing

1. Visit the `/es/` pages and view source. Compare the meta tags to those on consumerfinance.gov.

## Checklist

* [ ] PR has an informative and human-readable title
* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated
* [ ] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
