### PR TITLE
Point to latest CCDB5 release

### DIFF
--- a/requirements/optional-public.txt
+++ b/requirements/optional-public.txt
@@ -6,5 +6,5 @@ git+https://github.com/cfpb/regulations-core.git@1.2.5#egg=regcore
 git+https://github.com/cfpb/regulations-site.git@2.1.8#egg=regulations
 git+https://github.com/cfpb/retirement.git@0.5.6#egg=retirement
 git+https://github.com/cfpb/ccdb5-api.git@v0.4.0#egg=ccdb5-api
-git+https://github.com/cfpb/ccdb5-ui.git@v0.3.2#egg=ccdb5_ui
+git+https://github.com/cfpb/ccdb5-ui.git@v0.5.173#egg=ccdb5_ui
 git+https://github.com/cfpb/eregs-2.0.git@0.0.2#egg=eregs


### PR DESCRIPTION
This updates `optional-public.txt` requirements to point to the latest version of the CCDB5 UI

## Checklist

* [x] PR has an informative and human-readable title
* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated
* [x] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
