### PR TITLE
Megamenu fix: Rename and move link

### DIFF
--- a/cfgov/jinja2/v1/_includes/organisms/_vars-mega-menu.html
+++ b/cfgov/jinja2/v1/_includes/organisms/_vars-mega-menu.html
@@ -135,14 +135,14 @@
     'title': 'Populations Served',
     'nav_items': [
         {'text': 'Financial Education for Adults', 'url': '/adult-financial-education/'},
-        {'text': 'Financial Education for Youth', 'url': '/practitioner-resources/youth-financial-education/'},
-        {'text': 'Low-to-Moderate Income', 'url': '/empowerment/'}
+        {'text': 'Financial Education for Youth', 'url': '/practitioner-resources/youth-financial-education/'}
     ]
 } %}
 {% set practitioner_resources_group_two = {
     'title': 'Populations Served',
     'hide_title': 'true',
     'nav_items': [
+        {'text': 'Economically Vulnerable Consumers', 'url': '/empowerment/'},
         {'text': 'Older Adults & Their Families', 'url': '/practitioner-resources/resources-for-older-adults/'},
         {'text': 'Servicemembers & Veterans', 'url': '/servicemembers/'},
         {'text': 'Students', 'url': '/students/'},


### PR DESCRIPTION
Megamenu quick fix: rename `Low-to-Moderate Income` to `Economically Vulnerable Consumers` and move it to second column under `Practitioner Resources`

## Changes

- Rename and move  `Low-to-Moderate Income` link

## Testing

1. Check out branch
2. Verify that `Practitioner Resources` menu matches screenshot

## Screenshots

<img width="1066" alt="screen shot 2017-08-10 at 7 56 05 am" src="https://user-images.githubusercontent.com/778171/29178932-d6655b32-7da7-11e7-9167-30ac6168c1a8.png">


## Checklist

* [ ] PR has an informative and human-readable title
* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated
* [ ] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
