### PR TITLE
Add a hard-coded condition for the beta banner

### DIFF
--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -542,7 +542,9 @@ FLAGS = {
     # Beta banner, seen on beta.consumerfinance.gov
     # When enabled, a banner appears across the top of the site proclaiming
     # "This beta site is a work in progress."
-    'BETA_NOTICE': {},
+    'BETA_NOTICE': {
+        'site': 'beta.consumerfinance.gov',
+    },
 
     # When enabled, Display a "techical issues" banner on /complaintdatabase
     'CCDB_TECHNICAL_ISSUES': {},


### PR DESCRIPTION
This PR adds a hard-coded condition to the `BETA_BANNER` flag to always enable it when the Wagtail Site hostname is "beta.consumerfinance.gov".

## Additions

- Condition on the `BETA_BANNER` feature flag

## Checklist

* [ ] PR has an informative and human-readable title
* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated
* [ ] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
