### PR TITLE
Move the lang attribute to the main element

### DIFF
--- a/cfgov/jinja2/v1/_layouts/content-base-sidebar-first.html
+++ b/cfgov/jinja2/v1/_layouts/content-base-sidebar-first.html
@@ -28,10 +28,7 @@
         {% block content_sidebar scoped -%}{%- endblock %}
     </aside>
     <div class="content_main {% block content_main_modifiers -%}{%- endblock %}">
-        {%- import 'macros/accessible-languages.html' as accessible_languages with context-%}
-        <section {{ accessible_languages.render() }}>
-            {% block content_main scoped -%}{%- endblock %}
-        </section>
+        {% block content_main scoped -%}{%- endblock %}
     </div>
 </div>
 {% endblock %}

--- a/cfgov/jinja2/v1/_layouts/content-base.html
+++ b/cfgov/jinja2/v1/_layouts/content-base.html
@@ -1,7 +1,11 @@
 {% extends 'base.html' %}
 
 {% block content scoped %}
-    <main class="content {% block content_modifiers -%}{%- endblock %}" id="main" role="main">
+    {%- import 'macros/accessible-languages.html' as accessible_languages with context-%}
+    <main class="content {% block content_modifiers -%}{%- endblock %}"
+          id="main"
+          role="main"
+          {{- accessible_languages.render() }}>
         {% block hero -%}{%- endblock %}
         {% block pre_content scoped -%}
             {% if breadcrumb_items | length > 0 %}


### PR DESCRIPTION
Currently the sidebar and pre-footer do not have their language set
correctly on pages with a custom language setting because they are not
within the section element that previously set the language.

## Changes

- Moved the language setting from `content_main` to `content` to include the sidebar and prefooter.

## Testing

I don't know of a good way to test this other than inspecting to make sure the language attribute is wrapping everything that's in Spanish on a page like http://localhost:8000/es/el-dinero-mientras-creces/la-adolescencia-y-la-juventud/

## Checklist

* [x] PR has an informative and human-readable title
* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices
* [x] Project documentation has been updated
* [x] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
