### PR TITLE
Extend editor whitelist to include table-related tags

### DIFF
--- a/cfgov/ask_cfpb/tests/test_hooks.py
+++ b/cfgov/ask_cfpb/tests/test_hooks.py
@@ -36,7 +36,8 @@ class TestAskHooks(TestCase):
     def test_js_functions(self):
         self.assertIn("registerHalloPlugin('editHtmlButton')", editor_js())
         self.assertIn("css/question_tips.css", editor_css())
-        self.assertEqual(whitelister_element_rules().keys(), ['aside'])
+        self.assertIn('aside', whitelister_element_rules().keys())
+        self.assertIn('table', whitelister_element_rules().keys())
 
     def test_AnswerModelAdminSaveUserEditView(self):
         mock_admin = mock.Mock()

--- a/cfgov/ask_cfpb/wagtail_hooks.py
+++ b/cfgov/ask_cfpb/wagtail_hooks.py
@@ -125,8 +125,17 @@ def editor_css():
 
 
 def whitelister_element_rules():
+    allow_html_class =  attribute_rule({'class': True})
     return {
-        'aside': attribute_rule({'class': True}),
+        'aside': allow_html_class,
+        'table': allow_html_class,
+        'tr': allow_html_class,
+        'td': allow_html_class,
+        'tbody': allow_html_class,
+        'thead': allow_html_class,
+        'tfoot': allow_html_class,
+        'col': allow_html_class,
+        'colgroup': allow_html_class,
     }
 
 hooks.register('insert_editor_js', editor_js)

--- a/cfgov/ask_cfpb/wagtail_hooks.py
+++ b/cfgov/ask_cfpb/wagtail_hooks.py
@@ -125,12 +125,13 @@ def editor_css():
 
 
 def whitelister_element_rules():
-    allow_html_class =  attribute_rule({'class': True})
+    allow_html_class = attribute_rule({'class': True})
 
     allowed_tags = ['aside', 'table', 'tr', 'th', 'td', 'tbody', 'thead',
                     'tfoot', 'col', 'colgroup']
 
-    return {tag: allow_html_class for tag in allowed_tags} 
+    return {tag: allow_html_class for tag in allowed_tags}
+
 
 hooks.register('insert_editor_js', editor_js)
 hooks.register('insert_editor_css', editor_css)

--- a/cfgov/ask_cfpb/wagtail_hooks.py
+++ b/cfgov/ask_cfpb/wagtail_hooks.py
@@ -126,17 +126,11 @@ def editor_css():
 
 def whitelister_element_rules():
     allow_html_class =  attribute_rule({'class': True})
-    return {
-        'aside': allow_html_class,
-        'table': allow_html_class,
-        'tr': allow_html_class,
-        'td': allow_html_class,
-        'tbody': allow_html_class,
-        'thead': allow_html_class,
-        'tfoot': allow_html_class,
-        'col': allow_html_class,
-        'colgroup': allow_html_class,
-    }
+
+    allowed_tags = ['aside', 'table', 'tr', 'th', 'td', 'tbody', 'thead',
+                    'tfoot', 'col', 'colgroup']
+
+    return {tag: allow_html_class for tag in allowed_tags} 
 
 hooks.register('insert_editor_js', editor_js)
 hooks.register('insert_editor_css', editor_css)


### PR DESCRIPTION
## Changes

The Ask CFPB editors discovered that even though some answers (imported from the old system) contained HTML tables, tables could no longer be added, and even the act of editing an answer that *had* a table would destroy them. This is because the editor only allows tags that have been included in a whitelist. This change extends the existing whitelist to include: 'table', 'tr', 'th', 'td', 'tbody', 'thead', 'tfoot', 'col',  and 'colgroup'

Thanks to @virginiacc and @higs4281 for showing me how to update the whitelist!

## Testing

1. try to add a table to an AskCFPB answer, and observe that it survives being saved.


## Checklist

* [ ] PR has an informative and human-readable title
* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated
* [ ] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
