### PR TITLE
Add django-watchman and first check (for server time)

### DIFF
--- a/.env_SAMPLE
+++ b/.env_SAMPLE
@@ -160,6 +160,12 @@ export TOXENV=py27
 #export SAUCE_SELENIUM_URL=localhost:4445/wd/hub
 #export SAUCE_TUNNEL=<sauce_tunnel_id>
 
+#########################################################
+# Django-Watchman, our global status monitoring endpoint.
+#########################################################
+
+export WATCHMAN_TOKENS=''
+
 ###############################################
 # Project configuration - set up working state.
 ###############################################

--- a/cfgov/alerts/checks.py
+++ b/cfgov/alerts/checks.py
@@ -1,0 +1,26 @@
+import math
+import ntplib
+
+from django.conf import settings
+
+from watchman.decorators import check
+
+
+@check
+def check_clock_drift():
+    ntp_client = ntplib.NTPClient()
+    response = ntp_client.request(
+        settings.NTP_TIME_SERVER,
+        version=3,
+    )
+    offset = settings.MAX_ALLOWED_TIME_OFFSET
+    if math.fabs(response.offset) > offset:
+        result = {
+            'ok': False,
+            'error': 'Clock has drifted more than {} seconds'.format(offset),
+            'stacktrace': 'Drift is {} seconds'.format(response.offset)
+        }
+    else:
+        result = {'ok': True}
+
+    return {'clock sync': result}

--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -589,6 +589,7 @@ FLAGS = {
     'SORTABLE_TABLES': {},
 }
 
+
 # Watchman tokens, used to authenticate global status endpoint
 WATCHMAN_TOKENS = os.environ.get('WATCHMAN_TOKENS', os.urandom(32))
 
@@ -598,4 +599,14 @@ WATCHMAN_CHECKS = (
     'watchman.checks.databases',
     'watchman.checks.storage',
     'watchman.checks.caches',
+    'alerts.checks.check_clock_drift',
 )
+
+# Used to check server's time against in check_clock_drift
+NTP_TIME_SERVER = 'north-america.pool.ntp.org'
+
+# If server's clock drifts from NTP by more than specified offset
+# (in seconds), check_clock_drift will fail
+MAX_ALLOWED_TIME_OFFSET = 5
+
+

--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -55,6 +55,7 @@ INSTALLED_APPS = (
     'taggit',
     'wagtailsharing',
     'flags',
+    'watchman',
     'haystack',
     'ask_cfpb',
     'overextends',
@@ -587,3 +588,14 @@ FLAGS = {
     # and the table will not be sortable until cf-tables from CF 4.x is implemented
     'SORTABLE_TABLES': {},
 }
+
+# Watchman tokens, used to authenticate global status endpoint
+WATCHMAN_TOKENS = os.environ.get('WATCHMAN_TOKENS', os.urandom(32))
+
+# This specifies what checks Watchman should run and include in its output
+# https://github.com/mwarkentin/django-watchman#custom-checks
+WATCHMAN_CHECKS = (
+    'watchman.checks.databases',
+    'watchman.checks.storage',
+    'watchman.checks.caches',
+)

--- a/cfgov/cfgov/urls.py
+++ b/cfgov/cfgov/urls.py
@@ -379,6 +379,8 @@ urlpatterns = [
 
     es_conv_flag(r'^es/quienes-somos/$', TemplateView.as_view(
                  template_name='es/quienes-somos/index.html')),
+
+    url(r'^_status/', include_if_app_enabled('watchman', 'watchman.urls')),
 ]
 
 if settings.ALLOW_ADMIN_URL:

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -31,6 +31,7 @@ icalendar==3.9.0
 Jinja2==2.7.3
 jsonschema==2.0.0
 lxml==3.6.0
+ntplib==0.3.3
 pbr==1.9.1
 pyelasticsearch==0.6
 python-dateutil==2.1

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -20,6 +20,7 @@ django-reversion==1.10.1
 django-storages==1.1.8
 django-tinymce==2.2.0
 django-treebeard==3.0
+django-watchman==0.13.1
 edgegrid-python==1.0.10
 elasticsearch==2.4.1
 feedparser==5.2.1


### PR DESCRIPTION
[django-watchman](https://github.com/mwarkentin/django-watchman) is an app that lets us create a status endpoint with our own checks for system status.

## Additions

- An `alerts` Python package that we'll use for alerting/monitoring/related code. Not currently a Django app.
- django-watchman dependency
- ntplib dependency
- django-watchman checks for caches, databases, and storages
- Custom watchman check for system clock drift

## Testing

```shell
echo "export WATCHMAN_TOKENS=''" >> .env
pip install -r requirements/local.txt
./runserver.sh
```

Then visit http://localhost:8000/_status and http://localhost:8000/_status/dashboard.

## Screenshots

JSON output at `/_status` looks like this:

```json
{  
  "clock sync":{  
    "ok":true
  },
  "caches":[  
    {  
      "api_cache":{  
        "ok":true
      }
    },
    {  
      "default":{  
        "ok":true
      }
    },
    {  
      "eregs_longterm_cache":{  
        "ok":true
      }
    }
  ],
  "storage":{  
    "ok":true
  },
  "databases":[  
    {  
      "default":{  
        "ok":true
      }
    }
  ]
}
```

The `/_status/dashboard` looks like this:

![image](https://user-images.githubusercontent.com/10562538/29473608-6b00100a-8426-11e7-9c8b-3ba57123c2d3.png)

## Todos

We will need to add `WATCHMAN_TOKENS` to our ansible environment variable configuration.

## Checklist

* [x] PR has an informative and human-readable title
* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [x] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated
* [x] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
