### PR TITLE
Working Vagrant with updated galaxy roles.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -95,7 +95,7 @@ collectstatic/*
 
 # Ansible #
 #################
-ansible/roles/*
+ansible/galaxy_roles/*
 
 # Unit test / coverage reports
 #################

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,10 +1,36 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
-Vagrant.configure(2) do |config|
+# Install any required plugins
+required_plugins = ['vagrant-hostmanager','vagrant-auto_network']
+
+for plugin in required_plugins
+  unless Vagrant.has_plugin? plugin
+    system("vagrant plugin install #{plugin}")
+    need_vagrant_up = true
+  end
+end
+
+if need_vagrant_up
+  puts 'Vagrant plugins have been modified -- Please re-run vagrant up'
+  exit(1)
+end
+
+# Configure Vagrant-Auto_Network plugin settings
+AutoNetwork.default_pool = '10.10.10.0/24'
+
+# Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
+VAGRANTFILE_API_VERSION = "2"
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+  config.hostmanager.enabled = true
+  config.hostmanager.manage_host = true
+  config.vm.synced_folder '.', '/vagrant', nfs: true
+  config.vm.hostname = "cfbp.dev"
   config.vm.box = "CFPBCentOS64"
   config.vm.box_url = "https://s3.amazonaws.com/virtual-boxes/package.box"
 
+  config.vm.network :private_network, :auto_network => true
   config.vm.network "forwarded_port", guest: 80, host: 8002
   config.vm.network "forwarded_port", guest: 8000, host: 8001
   config.vm.network "forwarded_port", guest: 3306, host: 3307

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -25,16 +25,12 @@ VAGRANTFILE_API_VERSION = "2"
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.hostmanager.enabled = true
   config.hostmanager.manage_host = true
-  config.vm.synced_folder '.', '/vagrant', nfs: true
-  config.vm.hostname = "cfbp.dev"
+  config.vm.synced_folder '.', '/vagrant', sshfs: true
+  config.vm.hostname = "cfbp.devel"
   config.vm.box = "CFPBCentOS64"
   config.vm.box_url = "https://s3.amazonaws.com/virtual-boxes/package.box"
 
   config.vm.network :private_network, :auto_network => true
-  config.vm.network "forwarded_port", guest: 80, host: 8002
-  config.vm.network "forwarded_port", guest: 8000, host: 8001
-  config.vm.network "forwarded_port", guest: 3306, host: 3307
-  config.vm.network "forwarded_port", guest: 9200, host: 9201
 
   config.vm.provider "virtualbox" do |vb|
     vb.memory = "4096"

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -26,7 +26,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.hostmanager.enabled = true
   config.hostmanager.manage_host = true
   config.vm.synced_folder '.', '/vagrant', sshfs: true
-  config.vm.hostname = "cfbp.devel"
+  config.vm.hostname = "cfpb.devel"
   config.vm.box = "CFPBCentOS64"
   config.vm.box_url = "https://s3.amazonaws.com/virtual-boxes/package.box"
 

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -2,4 +2,4 @@
 # ==============================================
 
 [defaults]
-roles_path    = ansible/roles
+roles_path    = ansible/roles:ansible/galaxy_roles

--- a/ansible/cfgov_refresh_setup.yml
+++ b/ansible/cfgov_refresh_setup.yml
@@ -1,4 +1,5 @@
 ---
+# vi: set ft=ansible :
 - hosts: db
   sudo: yes
   sudo_user: root
@@ -13,6 +14,20 @@
   sudo: yes
   sudo_user: root
   gather_facts: true
+  pre_tasks:
+    - name: Install the EPEL package
+      yum:
+        name: epel-release
+        state: present
+        update_cache: yes
+
+    - name: yum 
+      yum:
+        name: '*'
+        state: latest
+        update_cache: yes
+        disablerepo: epel
+
   vars_files:
     - vars/app.yml
   roles:
@@ -21,7 +36,7 @@
     - { role: geerlingguy.git }
     - { role: Ken24.python }
     - { role: geerlingguy.firewall }
-    - { role: xcezx.httpd }
+    - { role: smbambling.apache }
     - { role: vickumar1981.nodejs }
   tasks:
     - name: Install python dependencies
@@ -40,13 +55,15 @@
         - "libxslt-devel"
         - "libxml2-devel"
 
-    - name: Import CERN's GPG key
-      shell: "rpm --import http://ftp.scientificlinux.org/linux/scientific/5x/x86_64/RPM-GPG-KEYs/RPM-GPG-KEY-cern"
-      sudo: yes
-
-    - name: Save slc6-devtoolset.repo repository information
-      shell: "wget -O /etc/yum.repos.d/slc6-devtoolset.repo http://linuxsoft.cern.ch/cern/devtoolset/slc6-devtoolset.repo"
-      sudo: yes
+    - name: Add the SLC Repos
+      yum_repository:
+        name: "{{ item.key }}"
+        description: "{{ item.value.description }}"
+        file: scl6-devtoolset.repo
+        baseurl: "{{ item.value.baseurl }}"
+        gpgkey: http://linuxsoft.cern.ch/cern/slc6X/x86_64/RPM-GPG-KEY-cern
+        gpgcheck: yes
+      with_dict: "{{ slc6_repos }}"
 
     - name: Install devtoolset-2
       yum:

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -1,22 +1,27 @@
-- src: https://github.com/vickumar1981/ansible-role-mysql.git
-  version: origin/version_fix
+- src: https://github.com/geerlingguy/ansible-role-mysql.git 
+  version: 68fad51
   name: vickumar1981.mysql
 
-- src: geerlingguy.git
+- src: https://github.com/geerlingguy/ansible-role-git.git
+  version: 5988cc6
+  name: geerlingguy.git
 
-- src: geerlingguy.firewall
+- src: https://github.com/geerlingguy/ansible-role-firewall.git
+  version: eb66a45
+  name: geerlingguy.firewall
 
-- src: xcezx.httpd
+- src: https://github.com/smbambling/ansible-role-apache.git
+  version: a221268
+  name: smbambling.apache
 
-- src: https://github.com/vickumar1981/ansible-role-nodejs.git
-  version: origin/version_fix
+- src: https://github.com/geerlingguy/ansible-role-nodejs.git
+  version: 885d12b
   name: vickumar1981.nodejs
 
 - src: https://github.com/Ken24/ansible-role-python.git
-  version: master
+  version: 1b54429 
   name: Ken24.python
 
 - src: https://github.com/vccabral/ansible-role-elasticsearch.git
-  version: master
+  version: e9343ca
   name: vccabral.elasticsearch
-

--- a/ansible/vars/app.yml
+++ b/ansible/vars/app.yml
@@ -12,3 +12,23 @@ npm_packages:
   - gulp
   - less
   - protractor
+
+slc6_repos:
+  slc6-devtoolset:
+    description: Scientific Linux CERN 6 (SLC6) - Devtoolset addons
+    baseurl: http://linuxsoft.cern.ch/cern/devtoolset/slc6X/$basearch/yum/devtoolset/
+  slc6-devtoolset-source:
+    description: Scientific Linux CERN 6 (SLC6) - Devtoolset addons - source RPMs
+    baseurl: http://linuxsoft.cern.ch/cern/devtoolset/slc6X/$basearch/yum/devtoolset-source/
+  slc6-devtoolset-debug:
+    description: Scientific Linux CERN 6 (SLC6) - Devtoolset addons - debug RPMs
+    baseurl: http://linuxsoft.cern.ch/cern/devtoolset/slc6X/$basearch/yum/devtoolset-debug/
+  slc6-devtoolset-testing:
+    description: Scientific Linux CERN 6 (SLC6) - Devtoolset addons
+    baseurl: http://linuxsoft.cern.ch/cern/devtoolset/slc6X/testing/$basearch/yum/devtoolset-testing/
+  slc6-devtoolset-testing-source:
+    description: Scientific Linux CERN 6 (SLC6) - Devtoolset addons - source RPMs
+    baseurl: http://linuxsoft.cern.ch/cern/devtoolset/slc6X/testing/$basearch/yum/devtoolset-testing-source/
+  slc6-devtoolset-testing-debug:
+    description: Scientific Linux CERN 6 (SLC6) - Devtoolset addons - debug RPMs
+    baseurl: http://linuxsoft.cern.ch/cern/devtoolset/slc6X/testing/$basearch/yum/devtoolset-testing-debug/

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -5,4 +5,5 @@ django-debug-toolbar==1.7
 django-livereload==1.2
 django-sslserver==0.19
 tox==2.3.1
+virtualenvwrapper==4.7.2
 Werkzeug==0.10.4


### PR DESCRIPTION
This PR fixes a couple of bugs with the Vagrant environment setup. Notably it removes some Ansible roles that have fallen out of support. It attempts to maintain the same functionality of the code that was there when I was looking into this and doesn't make any assumptions about what could be left out of the guest machine.

## Additions
- Vagrant auto-networking and sshfs
- Updated galaxy roles and location
- Refactored some ansible commands
- Pinned galaxy roles to commit hashes

## Removals
- Port forwarding rules

## Changes

- Using galaxy roles that work out of the box

## Testing

1. `vagrant up` to provision the vagrant environment

## Screenshots

![image](https://user-images.githubusercontent.com/6773712/29425800-89c19862-8352-11e7-8272-38f2a4354a27.png)

## Notes

- Liberties have been taken with sudo access, particularly with `/etc/hosts` files edits

## Todos

- Strip out unnecessary tools
- Move the DB to its own server
- Work with devs to figure out what can be run host-side
- Move the rest of ansible code to `roles` layout

## Checklist

* [ ] PR has an informative and human-readable title
* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated
* [ ] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
