### PR TITLE
Administrative Adjudication flag cleanup

### DIFF
--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -557,11 +557,6 @@ FLAGS = {
     # When enabled, the top margin of full-width text insets is increased
     'INSET_TEST': {},
 
-    # Footer link for the Office of Administrative Adjudication
-    # When enabled, a link to "Administrative Adjudication" appears in the
-    # footer
-    'OAA_FOOTER_LINK': {},
-
     # When enabled, serves `/es/` pages from this
     # repo ( excluding /obtener-respuestas/ pages ).
     'ES_CONV_FLAG': {},

--- a/cfgov/jinja2/v1/_includes/organisms/footer.html
+++ b/cfgov/jinja2/v1/_includes/organisms/footer.html
@@ -92,13 +92,11 @@
             </div>
             <div class="o-footer_col">
                 <ul class="o-footer_list m-list">
-                    {% if flag_enabled('OAA_FOOTER_LINK', request) %}
                     <li class="m-list_item">
                         <a class="m-list_link" href="/administrative-adjudication-proceedings/">
                             Administrative Adjudication
                         </a>
                     </li>
-                    {% endif %}
                     <li class="m-list_item">
                         <a class="m-list_link" href="/accessibility/">
                             Accessibility


### PR DESCRIPTION
Administrative Adjudication flag cleanup. This code has been in production long enough to remove the flag. 

## Changes

- Modified code to remove the `OAA_FOOTER_LINK ` flag. 


## Todos

-

## Checklist

* [ ] PR has an informative and human-readable title
* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated
* [ ] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
