### PR TITLE
Stop crawlers from trying filter combinations

### DIFF
--- a/cfgov/core/static/robots.txt
+++ b/cfgov/core/static/robots.txt
@@ -4,5 +4,6 @@ Disallow: /about-us/the-bureau/leadership-calendar/pdf
 Disallow: /es/obtener-respuestas/*.imprimir.html
 Disallow: /external-site
 Disallow: /*?success
+Disallow: *form-id=*
 
 sitemap: http://www.consumerfinance.gov/activity-log/feed/


### PR DESCRIPTION
This came out of the investigation of crawler errors (GHE 1015). It doesn't really provide us with any benefit for Google, etc to crawl every filter combination. Every page is accessible by paginating through the primary set of results.

## Additions

- add the line `Disallow: *form-id=*` to robots.txt

## Checklist

* [ ] PR has an informative and human-readable title
* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated
* [ ] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
