### PR TITLE
Fix for table block on older browsers

### DIFF
--- a/cfgov/templates/wagtailadmin/js/table-block.js
+++ b/cfgov/templates/wagtailadmin/js/table-block.js
@@ -430,7 +430,9 @@
                 this.saveDataToHiddenField();
             },
 
-            toggleInputTable: function toggleInputTable( inputTable, state = true  ) {
+            toggleInputTable: function toggleInputTable( inputTable, state ) {
+              state = state || true;
+
               if ( state === true ) {
                 inputTable.show();
               } else {


### PR DESCRIPTION
Fix for table block on older browsers

## Changes

- Modified `cfgov/templates/wagtailadmin/js/table-block.js` to remove usage of  ES5 default param code. 


## Testing
 (Use IE10 or an older Firefox version). 

1. Create a table block module in Wagtail.
2. Click the `Fixed-width columns` input and verify three drop-downs appear.
3. Click the `Sortable table` input and verify three drop-downs appear.


## Checklist

* [ ] PR has an informative and human-readable title
* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated
* [ ] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
