### PR TITLE
Better default social images for 'django' templates

### DIFF
--- a/cfgov/legacy/templates/front/base_nonresponsive.html
+++ b/cfgov/legacy/templates/front/base_nonresponsive.html
@@ -42,7 +42,10 @@ please send an email with your full name to tech@cfpb.gov.
     <meta property="fb:app_id" content="210516218981921">
 
     {% block open_graph_image %}
-    <meta property="og:image" content="{% static 'nemo/_/img/logo.svg' %}">
+    <meta property="og:image"
+          content="{% static 'img/logo_open-graph_facebook.png' %}">
+    <meta property="twitter:image"
+          content="{% static 'img/logo_open-graph_twitter.png' %}">
     {% endblock %}
 
     {% block page_meta %}

--- a/cfgov/legacy/templates/front/base_update.html
+++ b/cfgov/legacy/templates/front/base_update.html
@@ -54,7 +54,12 @@ please send an email with your full name to tech@cfpb.gov.
     <meta property="fb:app_id" content="210516218981921">
 
     {% block open_graph_image %}
-    <meta property="og:image" content="{% static 'nemo/_/img/logo.svg' %}">
+    
+    <meta property="og:image"
+          content="{% static 'img/logo_open-graph_facebook.png' %}">
+    <meta property="twitter:image"
+          content="{% static 'img/logo_open-graph_twitter.png' %}">
+    
     {% endblock %}
 
     {% block page_meta %}


### PR DESCRIPTION
A few months ago, we updated our default images for Twitter and opengraph(facebook, etc). These changes were never applied to apps using our older base templates

## Additions

- a "twitter:image" value, which better fits how Twitter crops images.

## Changes

- og:image is now img/logo_open-graph_facebook.png

## Checklist

* [x] PR has an informative and human-readable title
* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated
* [ ] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
