### PR TITLE
Simplify and cleanup MySQL database settings

### DIFF
--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -175,32 +175,6 @@ ALLOW_ADMIN_URL = os.environ.get('ALLOW_ADMIN_URL', False)
 
 DATABASE_ROUTERS = ['v1.db_router.CFGOVRouter']
 
-if 'collectstatic' in sys.argv:
-    COLLECTSTATIC = True
-    DATABASES = {
-        'default': {
-            'ENGINE': 'django.db.backends.sqlite3',
-            'NAME': 'v1',
-        }
-    }
-else:
-    COLLECTSTATIC = False
-    MYSQL_ENGINE = 'django.db.backends.mysql'
-
-    # Database
-    # https://docs.djangoproject.com/en/1.8/ref/settings/#databases
-
-    DATABASES = {
-        'default': {
-            'ENGINE': MYSQL_ENGINE,
-            'NAME': os.environ.get('MYSQL_NAME', 'v1'),
-            'USER': os.environ.get('MYSQL_USER', 'root'),
-            'PASSWORD': os.environ.get('MYSQL_PW', ''),
-            'HOST': os.environ.get('MYSQL_HOST', ''),  # empty string == localhost
-            'PORT': os.environ.get('MYSQL_PORT', ''),  # empty string == default
-        },
-    }
-
 
 # Internationalization
 # https://docs.djangoproject.com/en/1.8/topics/i18n/

--- a/cfgov/cfgov/settings/local.py
+++ b/cfgov/cfgov/settings/local.py
@@ -1,4 +1,6 @@
 from .base import *
+from .mysql_mixin import *
+
 
 DEBUG = True
 SECRET_KEY = 'not-secret-key-for-testing'
@@ -6,42 +8,6 @@ INSTALLED_APPS += (
     'sslserver',
     'wagtail.contrib.wagtailstyleguide',
 )
-
-if not COLLECTSTATIC:
-    if os.environ.get('DATABASE_ROUTING', False):
-
-        DATABASES = {
-            'default': {
-                'ENGINE': MYSQL_ENGINE,
-                'NAME': os.environ.get('MYSQL_NAME', ''),
-                'USER': os.environ.get('MYSQL_USER', ''),
-                'PASSWORD': os.environ.get('MYSQL_PW', ''),
-                'HOST': os.environ.get('MYSQL_HOST', ''),
-                'PORT': os.environ.get('MYSQL_PORT', ''),
-                'OPTIONS': {'init_command': os.environ.get('STORAGE_ENGINE', 'SET storage_engine=MYISAM') },
-            },
-            'legacy': {
-                'ENGINE': MYSQL_ENGINE,
-                'NAME': os.environ.get('LEGACY_MYSQL_NAME', ''),
-                'USER': os.environ.get('LEGACY_MYSQL_USER', ''),
-                'PASSWORD': os.environ.get('LEGACY_MYSQL_PW', ''),
-                'HOST': os.environ.get('LEGACY_MYSQL_HOST', ''),
-                'PORT': os.environ.get('LEGACY_MYSQL_PORT', ''),
-                'OPTIONS': {'init_command': os.environ.get('STORAGE_ENGINE', 'SET storage_engine=MYISAM') },
-            },
-        }
-    else:
-        DATABASES = {
-            'default': {
-                'ENGINE': MYSQL_ENGINE,
-                'NAME': os.environ.get('MYSQL_NAME', ''),
-                'USER': os.environ.get('MYSQL_USER', ''),
-                'PASSWORD': os.environ.get('MYSQL_PW', ''),
-                'HOST': os.environ.get('MYSQL_HOST', ''),
-                'PORT': os.environ.get('MYSQL_PORT', ''),
-                'OPTIONS': {'init_command': os.environ.get('STORAGE_ENGINE', 'SET storage_engine=MYISAM') },
-                },
-            }
 
 STATIC_ROOT = REPOSITORY_ROOT.child('collectstatic')
 

--- a/cfgov/cfgov/settings/mysql_mixin.py
+++ b/cfgov/cfgov/settings/mysql_mixin.py
@@ -1,0 +1,22 @@
+import os
+
+
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.mysql',
+        'NAME': os.environ.get('MYSQL_NAME', ''),
+        'USER': os.environ.get('MYSQL_USER', ''),
+        'PASSWORD': os.environ.get('MYSQL_PW', ''),
+        'HOST': os.environ.get('MYSQL_HOST', ''),
+        'PORT': os.environ.get('MYSQL_PORT', ''),
+    },
+}
+
+# Allow us to configure the default MySQL storage engine via the environment.
+if 'STORAGE_ENGINE' in os.environ:
+    db_options = {
+        'init_command': os.environ['STORAGE_ENGINE'],
+    }
+
+    for db_label in DATABASES.keys():
+        DATABASES[db_label]['OPTIONS'] = db_options

--- a/cfgov/cfgov/settings/production.py
+++ b/cfgov/cfgov/settings/production.py
@@ -1,8 +1,11 @@
 import os
 import sys
 
-from .base import *
 from os.path import exists
+
+from .base import *
+from .mysql_mixin import *
+
 
 # log to disk when running in mod_wsgi, otherwise to console
 if sys.argv and sys.argv[0] == 'mod_wsgi':
@@ -70,25 +73,4 @@ LOGGING = {
 EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
 EMAIL_HOST = os.getenv('EMAIL_HOST')
 
-if not COLLECTSTATIC:
-    if os.environ.get('DATABASE_ROUTING', False):
-
-        DATABASES = {
-            'default': {
-                'ENGINE': MYSQL_ENGINE,
-                'NAME': os.environ.get('MYSQL_NAME', ''),
-                'USER': os.environ.get('MYSQL_USER', ''),
-                'PASSWORD': os.environ.get('MYSQL_PW', ''),
-                'HOST': os.environ.get('MYSQL_HOST', ''),
-                'PORT': os.environ.get('MYSQL_PORT', ''),
-            },
-        }
-
 STATICFILES_STORAGE = 'django.contrib.staticfiles.storage.ManifestStaticFilesStorage'
-
-# allow us to configure the default MySQL storage engine, via the environment
-if 'STORAGE_ENGINE' in os.environ:
-    db_options = {'init_command': os.environ['STORAGE_ENGINE']}
-    for db_label in DATABASES.keys():
-        if 'mysql' in DATABASES[db_label]['ENGINE']:
-            DATABASES[db_label]['OPTIONS'] = db_options


### PR DESCRIPTION
This commit cleans up how MySQL database configuration is defined as centralizes it into a single Python module, `cfgov.settings.mysql_mixin`. This same mixin is included in both `settings.local` and `settings.production`, removing some redundancy that currently exists.

The `STORAGE_ENGINE` environment variable is still relied upon to (optionally) set the default MySQL storage engine.

This change should not modify any existing behavior, either for local development or in production. In local development, the suggested value for `STORAGE_ENGINE` ([as set in the `.env_SAMPLE` file](https://github.com/cfpb/cfgov-refresh/blob/master/.env_SAMPLE#L60)) is

`"SET default_storage_engine=MYISAM"`

This sets the MySQL `default_storage_engine` variable and is valid syntax in modern versions of MySQL.

For legacy versions (e.g. in systems using MySQL 5.1), this environment variable needs instead to be set using

`"SET storage_engine=MYISAM"`

although in practice this is unnecessary for MySQL 5.1 [where this is the default engine](https://downloads.mysql.com/docs/refman-5.1-en.pdf).

## Changes

- MySQL-related settings centralized to `cfgov.settings.mysql_mixin`.

## Testing

1. Run `./refresh-data.sh` to load a production data dump, with various settings for `STORAGE_ENGINE`, e.g. `STORAGE_ENGINE="SET default_storage_engine=InnoDB"`.

## Checklist

* [X] PR has an informative and human-readable title
* [X] Changes are limited to a single goal (no scope creep)
* [X] Code can be automatically merged (no conflicts)
* [X] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [X] Passes all existing automated tests
* [X] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right: