### PR TITLE
wellbeing: A couple more small changes for Friday's round of usability testing

### DIFF
--- a/cfgov/wellbeing/jinja2/wellbeing/results.html
+++ b/cfgov/wellbeing/jinja2/wellbeing/results.html
@@ -58,10 +58,13 @@
         }
         .histogram_toggle,
         .histogram_select-demographic {
-            width: 45%;
             padding: 0;
             border: none;
             margin: 0;
+        }
+        .histogram_select-demographic {
+            width: 30%;
+            margin-left: 30px;
         }
         .histogram_title {
             margin-top: 30px;
@@ -188,74 +191,97 @@
     </figure>
 
     <div class="block">
-        <h2>Review your answers</h2>
         <p>
             We calculated your score based on the answers to
             the financial well-being questionnaire.
             If you’d like to be able to answer the questions differently
-            next time, see the recommendations.
+            next time, see our suggestions and next steps.
         </p>
-        <table>
-            <thead>
-                <tr>
-                    <th>Question</th>
-                    <th>Your answer</th>
-                    <th>Suggestion</th>
-                </tr>
-            </thead>
-            <tbody>
-                <tr>
-                    <td>I could handle a major unexpected expense</td>
-                    <td>Somewhat</td>
-                    <td>Consider action</td>
-                </tr>
-                <tr>
-                    <td>I am securing my financial future</td>
-                    <td>Very little</td>
-                    <td>Take action</td>
-                </tr>
-                <tr>
-                    <td>Because of my money situation, I feel like I will never have the things I want in life</td>
-                    <td>Somewhat</td>
-                    <td>Consider action</td>
-                </tr>
-                <tr>
-                    <td>I can enjoy life because of the way I’m managing my money</td>
-                    <td>Somewhat</td>
-                    <td>Consider action</td>
-                </tr>
-                <tr>
-                    <td>I am just getting by financially</td>
-                    <td>Completely</td>
-                    <td>Take action</td>
-                </tr>
-                <tr>
-                    <td>I am concerned that the money I have or will save won’t last</td>
-                    <td>Not at all</td>
-                    <td>Stay on track</td>
-                </tr>
-                <tr>
-                    <td>Giving a gift for a wedding, birthday or other occasion would put a strain on my finances for the month</td>
-                    <td>Never</td>
-                    <td>Stay on track</td>
-                </tr>
-                <tr>
-                    <td>I have money left over at the end of the month</td>
-                    <td>Rarely</td>
-                    <td>Take action</td>
-                </tr>
-                <tr>
-                    <td>I am behind with my finances</td>
-                    <td>Sometimes</td>
-                    <td>Consider action</td>
-                </tr>
-                <tr>
-                    <td>My finances control my life</td>
-                    <td>Always</td>
-                    <td>Take action</td>
-                </tr>
-            </tbody>
-        </table>
+
+        <div class="o-expandable">
+            <button class="o-expandable_target">
+                <div class="o-expandable_header">
+                    <span class="o-expandable_header-left o-expandable_label">
+                        Review your answers
+                    </span>
+                    <span class="o-expandable_header-right o-expandable_link">
+                        <span class="o-expandable_cue o-expandable_cue-open">
+                            Show
+                            <span class="cf-icon cf-icon-plus-round"></span>
+                        </span>
+                        <span class="o-expandable_cue o-expandable_cue-close">
+                            Hide
+                            <span class="cf-icon cf-icon-minus-round"></span>
+                        </span>
+                    </span>
+                </div>
+            </button>
+            <div class="o-expandable_content">
+                <div class="o-expandable_content-animated">
+                    <table>
+                        <thead>
+                            <tr>
+                                <th>Question</th>
+                                <th>Your answer</th>
+                                <th>Suggestion</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tr>
+                                <td>I could handle a major unexpected expense</td>
+                                <td>Somewhat</td>
+                                <td>Consider action</td>
+                            </tr>
+                            <tr>
+                                <td>I am securing my financial future</td>
+                                <td>Very little</td>
+                                <td>Take action</td>
+                            </tr>
+                            <tr>
+                                <td>Because of my money situation, I feel like I will never have the things I want in life</td>
+                                <td>Somewhat</td>
+                                <td>Consider action</td>
+                            </tr>
+                            <tr>
+                                <td>I can enjoy life because of the way I’m managing my money</td>
+                                <td>Somewhat</td>
+                                <td>Consider action</td>
+                            </tr>
+                            <tr>
+                                <td>I am just getting by financially</td>
+                                <td>Completely</td>
+                                <td>Take action</td>
+                            </tr>
+                            <tr>
+                                <td>I am concerned that the money I have or will save won’t last</td>
+                                <td>Not at all</td>
+                                <td>Stay on track</td>
+                            </tr>
+                            <tr>
+                                <td>Giving a gift for a wedding, birthday or other occasion would put a strain on my finances for the month</td>
+                                <td>Never</td>
+                                <td>Stay on track</td>
+                            </tr>
+                            <tr>
+                                <td>I have money left over at the end of the month</td>
+                                <td>Rarely</td>
+                                <td>Take action</td>
+                            </tr>
+                            <tr>
+                                <td>I am behind with my finances</td>
+                                <td>Sometimes</td>
+                                <td>Consider action</td>
+                            </tr>
+                            <tr>
+                                <td>My finances control my life</td>
+                                <td>Always</td>
+                                <td>Take action</td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        </div>
     </div>
 
     <div class="block">
@@ -366,7 +392,7 @@
                     </div>
                 </fieldset>
 
-                <fieldset class="histogram_select-demographic u-right">
+                <fieldset class="histogram_select-demographic u-left">
                     <div class="m-form-field m-form-field__select">
                         <label class="a-label">Show scores for</label>
                         <div class="a-select">


### PR DESCRIPTION
## Changes

- Put "Review your answers" in an expandable
- Moves the grouping select menu closer to the category radios for the combined histogram

## Testing

1. Pull branch
1. Run server
1. Visit http://localhost:8000/consumer-tools/financial-well-being/results/?45
1. Observe the "review your answers" table now inside an expandable
1. Observe the select menu for the specific grouping of the histogram now floating 30px to the right of the radio buttons to select the category, rather than floating all the way to the right of the available space

## Screenshots

![screen shot 2017-08-24 at 22 53 28](https://user-images.githubusercontent.com/1044670/29697775-31adca74-891f-11e7-91f0-987b000be900.png)

![screen shot 2017-08-24 at 22 53 54](https://user-images.githubusercontent.com/1044670/29697786-38de6c86-891f-11e7-9c7c-b01079b0ef90.png)

## Checklist

* [ ] PR has an informative and human-readable title
* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated
* [ ] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
