### PR TITLE
Ask CFPB: sweep out usages of slugurl()

### DIFF
--- a/cfgov/jinja2/v1/ask-cfpb/answer-page-spanish.html
+++ b/cfgov/jinja2/v1/ask-cfpb/answer-page-spanish.html
@@ -49,7 +49,7 @@
                     <h4 class="supplement-title">Preguntas similares</h4>
                     <ul class="unstyled spaced nav-list">
                 {% endif %}
-                    <li><a href="{{ slugurl(a.slug_es) }}">{{ a.question_es|safe }}</a></li>
+                    <li><a href="{{ a.spanish_page.url }}">{{ a.question_es|safe }}</a></li>
                 {% if loop.last %}
                     </ul>
                     </aside>

--- a/cfgov/jinja2/v1/ask-cfpb/audience-page.html
+++ b/cfgov/jinja2/v1/ask-cfpb/audience-page.html
@@ -35,7 +35,7 @@
     <div class="question_list">
   		{% for answer in answers %}
       	<article class="question_summary">
-    		{{ partially_styled_link.render( {'plain_text': answer.question, 'underlined_text': 'Read answer', 'url': slugurl( answer.slug )} ) }}  
+    		{{ partially_styled_link.render( {'plain_text': answer.question, 'underlined_text': 'Read answer', 'url': answer.english_page.url } ) }}  
   		</article>
   		{% endfor %}
 	</div>

--- a/cfgov/jinja2/v1/ask-cfpb/category-page-spanish.html
+++ b/cfgov/jinja2/v1/ask-cfpb/category-page-spanish.html
@@ -34,7 +34,7 @@
                     {% if questions %}
                     {% for question in questions %}
                     {% if question.question_es %}
-                    <a href=" {{ slugurl( question.slug_es ) }} " class="ac-qa-summary">
+                    <a href="/es/obtener-respuestas/{{ question.slug_es }} " class="ac-qa-summary">
 						<article>
 						    <h3 class="ac-qa-question">{{ question.question_es|safe }}</h3>
 						    <div class="ac-qa-answer">

--- a/cfgov/jinja2/v1/ask-cfpb/landing-page-spanish.html
+++ b/cfgov/jinja2/v1/ask-cfpb/landing-page-spanish.html
@@ -20,7 +20,7 @@
                 <ul class="ac-catnav-list unstyled spaced">
                     {% for a in cat.featured_answers() %}
                      <li>
-                        <a href="{{ slugurl( a.slug_es ) }}">{{ a.question_es|safe }}</a>
+                        <a href="{{ a.spanish_page.url }}">{{ a.question_es|safe }}</a>
                      </li>
                     {% endfor %}
                 </ul>


### PR DESCRIPTION
Wagtail's `slugurl()` template function is handy, but it can cause
mischief in the Ask CFPB app if we pass an answer slug to it,
because we purposely don't keep answer slugs and page slugs in sync.

This PR sweeps the Ask CFPB templates for uses of `slugurl()` that involve 
answer object slugs. Uses for other slug types are fine.

## Changes
Use of `slugurl()` was removed on these templates in `cfgov/jinja2/v1/ask-cfpb/`
- answer-page-spanish.html
- audience-page.html
- category-page-spanish.html
- landing-page-spanish.html

Previous PRs removed the function from these templates:
- answer-page.html
- landing-page.html
