### PR TITLE
Bump up the version of ccdb5-api

### DIFF
--- a/requirements/optional-public.txt
+++ b/requirements/optional-public.txt
@@ -4,7 +4,7 @@ git+https://github.com/cfpb/owning-a-home-api.git@0.9.96#egg=owning-a-home-api
 git+https://github.com/cfpb/regulations-core.git@1.2.5#egg=regcore
 git+https://github.com/cfpb/regulations-site.git@2.1.8#egg=regulations
 git+https://github.com/cfpb/retirement.git@0.5.7#egg=retirement
-git+https://github.com/cfpb/ccdb5-api.git@v0.6.0#egg=ccdb5-api
+git+https://github.com/cfpb/ccdb5-api.git@v0.7.0#egg=ccdb5-api
 git+https://github.com/cfpb/ccdb5-ui.git@v0.7.0#egg=ccdb5_ui
 git+https://github.com/cfpb/eregs-2.0.git@0.0.2#egg=eregs
 https://github.com/cfpb/django-hud/releases/download/1.4.3/django_hud-1.4.3-py2-none-any.whl


### PR DESCRIPTION
This will point to the latest version of CCDB5-API

## Changes

- Changed CCDB5-API from v0.6.0 to v0.7.0

## Checklist

* [x] PR has an informative and human-readable title
* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [x] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated
* [ ] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
