### PR TITLE
Bump eregs-2.0 version to 0.0.4 release

### DIFF
--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -100,7 +100,7 @@ OPTIONAL_APPS = [
 
 if DEPLOY_ENVIRONMENT == 'build':
     OPTIONAL_APPS += [
-        {'import': 'eregs', 'apps': ('eregs_core',)},
+        {'import': 'eregs_core', 'apps': ('eregs_core',)},
     ]
 
 MIDDLEWARE_CLASSES = (
@@ -561,7 +561,9 @@ FLAGS = {
 
 
     # The next version of eRegulations
-    'EREGS20': {},
+    'EREGS20': {
+        'boolean': DEPLOY_ENVIRONMENT == 'build',
+    },
 
     # Add sortable tables to Wagtail
     # When enabled, the sortable tables option will be added to the Wagtail Admin

--- a/cfgov/cfgov/urls.py
+++ b/cfgov/cfgov/urls.py
@@ -270,7 +270,7 @@ urlpatterns = [
 
     flagged_url('EREGS20',
                 r'^eregs2/',
-                include_if_app_enabled('eregs_core', 'eregs.urls')
+                include_if_app_enabled('eregs_core', 'eregs_core.urls')
                 ),
     url(r'^eregs-api/',
         include_if_app_enabled('regcore', 'regcore.urls')),

--- a/requirements/optional-public.txt
+++ b/requirements/optional-public.txt
@@ -6,5 +6,5 @@ git+https://github.com/cfpb/regulations-site.git@2.1.8#egg=regulations
 git+https://github.com/cfpb/retirement.git@0.5.7#egg=retirement
 git+https://github.com/cfpb/ccdb5-api.git@v0.7.0#egg=ccdb5-api
 git+https://github.com/cfpb/ccdb5-ui.git@v0.7.0#egg=ccdb5_ui
-git+https://github.com/cfpb/eregs-2.0.git@0.0.2#egg=eregs
+git+https://github.com/cfpb/eregs-2.0.git@0.0.4#egg=eregs
 https://github.com/cfpb/django-hud/releases/download/1.4.3/django_hud-1.4.3-py2-none-any.whl


### PR DESCRIPTION
This change bumps the eregs-2.0 version from 0.0.2 to 0.0.4, and also turns it on by default if the `DEPLOY_ENVIRONMENT` environment variable is set to `build` (this avoids needing manual feature flag creation in the Wagtail UI).

This release includes some retroactive migration changes so before it is deployed it's recommended to fully destroy existing eregs-2.0 tables using these commands:

```sh
$ cfgov/manage.py migrate eregs_core zero
```

## Changes

- Bump eregs-2.0 version to 0.0.4.

## Testing

1. `pip install -r requirements/optional-public.txt`
2. `DEPLOY_ENVIRONMENT=build cfgov/manage.py migrate eregs_core`
3. `DEPLOY_ENVIRONMENT=build ./runserver.sh`
4. Visit http://localhost:8000/eregs2

## Checklist

* [X] PR has an informative and human-readable title
* [X] Changes are limited to a single goal (no scope creep)
* [X] Code can be automatically merged (no conflicts)
* [X] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [X] Passes all existing automated tests
* [X] Visually tested in supported browsers and devices
* [X] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right: