### PR TITLE
Add national average to meta field of map API calls

### DIFF
--- a/cfgov/data_research/views.py
+++ b/cfgov/data_research/views.py
@@ -169,9 +169,8 @@ class MapData(APIView):
             payload = {'meta': {'fips_type': geo_dict[geo]['fips_type'],
                                 'date': '{}'.format(date)},
                        'data': {}}
-            data_series = nat_records.time_series(days_late)
-            data_series.update({'name': 'United States'})
-            payload['data'].update(data_series)
+            nat_data_series.update({'name': 'United States'})
+            payload['data'].update(nat_data_series)
         else:
             records = geo_dict[geo]['queryset']
             fips_meta = geo_dict[geo]['fips_meta']

--- a/cfgov/data_research/views.py
+++ b/cfgov/data_research/views.py
@@ -163,16 +163,22 @@ class MapData(APIView):
         }
         if geo not in geo_dict:
             return Response("Unkown geographic unit")
-        records = geo_dict[geo]['queryset']
-        fips_meta = geo_dict[geo]['fips_meta']
-        payload = {'meta': {'fips_type': geo_dict[geo]['fips_type'],
-                            'date': '{}'.format(date)},
-                   'data': {}}
+        nat_records = geo_dict['national']['queryset']
+        nat_data_series = nat_records.time_series(days_late)
         if geo == 'national':
-            data_series = records.time_series(days_late)
+            payload = {'meta': {'fips_type': geo_dict[geo]['fips_type'],
+                                'date': '{}'.format(date)},
+                       'data': {}}
+            data_series = nat_records.time_series(days_late)
             data_series.update({'name': 'United States'})
             payload['data'].update(data_series)
         else:
+            records = geo_dict[geo]['queryset']
+            fips_meta = geo_dict[geo]['fips_meta']
+            payload = {'meta': {'fips_type': geo_dict[geo]['fips_type'],
+                                'date': '{}'.format(date),
+                                'national_average': nat_data_series['value']},
+                       'data': {}}
             for record in records:
                 data_series = record.time_series(days_late)
                 data_series.update(


### PR DESCRIPTION
This only adds the national average to avoid the need for a separate API
request for map pages.

So a [state map request](http://localhost:8000/data-research/mortgages/api/v1/map-data/30-89/states/2009-01/) would start with an enhanced meta field. Same would apply to [county](http://localhost:8000/data-research/mortgages/api/v1/map-data/30-89/counties/2009-01/) or [metro](http://localhost:8000/data-research/mortgages/api/v1/map-data/30-89/metros/2009-01/) requests. [National](http://localhost:8000/data-research/mortgages/api/v1/map-data/30-89/national/2009-01/) requests do not change.

<img width="374" alt="states_api_new" src="https://user-images.githubusercontent.com/515885/29839218-78f02ef4-8ccb-11e7-9ae9-463bf39dfea8.png">


