### PR TITLE
Bump eregs-2.0 to version 0.0.5

### DIFF
--- a/requirements/optional-public.txt
+++ b/requirements/optional-public.txt
@@ -6,5 +6,5 @@ git+https://github.com/cfpb/regulations-site.git@2.1.8#egg=regulations
 git+https://github.com/cfpb/retirement.git@0.5.7#egg=retirement
 git+https://github.com/cfpb/ccdb5-api.git@v0.7.0#egg=ccdb5-api
 git+https://github.com/cfpb/ccdb5-ui.git@v0.7.0#egg=ccdb5_ui
-git+https://github.com/cfpb/eregs-2.0.git@0.0.4#egg=eregs
+git+https://github.com/cfpb/eregs-2.0.git@0.0.5#egg=eregs
 https://github.com/cfpb/django-hud/releases/download/1.4.3/django_hud-1.4.3-py2-none-any.whl


### PR DESCRIPTION
This version bumps the optional eregs-2.0 package from version 0.0.4 to version 0.0.5. This change mainly affects the static frontend assets that are contributed by that package.

## Changes

- Bump eregs-2.0 from version 0.0.4 to version 0.0.5.

## Testing

1. `pip install -r requirements/optional-public.txt`
2. `DEPLOY_ENVIRONMENT=build cfgov/manage.py migrate eregs_core`
3. `DEPLOY_ENVIRONMENT=build ./runserver.sh`
4. Visit http://localhost:8000/eregs2

## Checklist

* [X] PR has an informative and human-readable title
* [X] Changes are limited to a single goal (no scope creep)
* [X] Code can be automatically merged (no conflicts)
* [X] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [X] Passes all existing automated tests
* [X] Visually tested in supported browsers and devices
* [X] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right: