### PR TITLE
Use pre-built satellite apps

### DIFF
--- a/requirements/optional-public.txt
+++ b/requirements/optional-public.txt
@@ -1,5 +1,5 @@
 https://github.com/cfpb/college-costs/releases/download/2.3.8/college_costs-2.3.4-py2-none-any.whl
-git+https://github.com/cfpb/complaint.git@1.4.1#egg=complaintdatabase
+https://github.com/cfpb/complaint/releases/download/1.4.1/complaintdatabase-1.3.3-py2-none-any.whl
 git+https://github.com/cfpb/owning-a-home-api.git@0.9.96#egg=owning-a-home-api
 git+https://github.com/cfpb/regulations-core.git@1.2.5#egg=regcore
 git+https://github.com/cfpb/regulations-site.git@2.1.8#egg=regulations

--- a/requirements/optional-public.txt
+++ b/requirements/optional-public.txt
@@ -3,7 +3,7 @@ https://github.com/cfpb/complaint/releases/download/1.4.1/complaintdatabase-1.3.
 git+https://github.com/cfpb/owning-a-home-api.git@0.9.96#egg=owning-a-home-api
 git+https://github.com/cfpb/regulations-core.git@1.2.5#egg=regcore
 git+https://github.com/cfpb/regulations-site.git@2.1.8#egg=regulations
-git+https://github.com/cfpb/retirement.git@0.5.7#egg=retirement
+https://github.com/cfpb/retirement/releases/download/0.5.7/retirement-0.5.6-py2-none-any.whl
 git+https://github.com/cfpb/ccdb5-api.git@v0.7.0#egg=ccdb5-api
 git+https://github.com/cfpb/ccdb5-ui.git@v0.7.0#egg=ccdb5_ui
 git+https://github.com/cfpb/eregs-2.0.git@0.0.5#egg=eregs

--- a/requirements/optional-public.txt
+++ b/requirements/optional-public.txt
@@ -1,4 +1,4 @@
-git+https://github.com/cfpb/college-costs.git@2.3.8#egg=college-costs
+https://github.com/cfpb/college-costs/releases/download/2.3.8/college_costs-2.3.4-py2-none-any.whl
 git+https://github.com/cfpb/complaint.git@1.4.1#egg=complaintdatabase
 git+https://github.com/cfpb/owning-a-home-api.git@0.9.96#egg=owning-a-home-api
 git+https://github.com/cfpb/regulations-core.git@1.2.5#egg=regcore


### PR DESCRIPTION
Some of our apps aren't building yet under Node 8-- the replaces their optional-public.txt entries with absolute links to pre-built wheels, on Github.

## Changes

- some (more) entries in optional-public.txt now point to pre-built wheels

## Checklist

* [ ] PR has an informative and human-readable title
* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated
* [ ] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
