### PR TITLE
Fix browser support list IE support

### DIFF
--- a/config/environment.js
+++ b/config/environment.js
@@ -28,17 +28,37 @@ const envvars = {
 /**
  * @description
  * Browser list for autoprefixer, see https://github.com/ai/browserslist.
+ * Support output lists can be viewed via copy/pasting into http://browserl.ist.
+ * @param {string} codeType - The code to support. Either 'js' or 'css'.
  * @returns {array} List of supported browser strings.
  */
-function getSupportedBrowserList() {
-  return [
-    'last 2 version',
-    'Edge >= 11',
-    'not ie <= 8',
-    'android 4',
-    'BlackBerry 7',
-    'BlackBerry 10'
-  ];
+function getSupportedBrowserList( codeType ) {
+  let supportList;
+  if ( codeType === 'js' ) {
+    supportList = [
+      'last 2 version',
+      'Edge >= 11',
+      'ie >= 9',
+      'android 4',
+      'BlackBerry 7',
+      'BlackBerry 10'
+    ];
+  } else if ( codeType === 'css' ) {
+    supportList = [
+      'last 2 version',
+      'Edge >= 11',
+      'ie >= 8',
+      'android 4',
+      'BlackBerry 7',
+      'BlackBerry 10'
+    ];
+  } else {
+    const msg = 'Browser support not found for code type! ' +
+                'Should \'js\' or \'css\' to be passed to ' +
+                'environment.getSupportedBrowserList(…)?';
+    throw new Error( msg );
+  }
+  return supportList;
 }
 
 /**

--- a/config/webpack-config.js
+++ b/config/webpack-config.js
@@ -28,7 +28,7 @@ const modernConf = {
         options: {
           presets: [ [ 'env', {
             targets: {
-              browsers: environment.getSupportedBrowserList()
+              browsers: environment.getSupportedBrowserList( 'js' )
             },
             debug: true
           } ] ]

--- a/gulp/tasks/styles.js
+++ b/gulp/tasks/styles.js
@@ -28,7 +28,7 @@ function stylesModern() {
     .pipe( gulpLess( configStyles.settings ) )
     .on( 'error', handleErrors.bind( this, { exitProcess: true } ) )
     .pipe( gulpAutoprefixer( {
-      browsers: environment.getSupportedBrowserList()
+      browsers: environment.getSupportedBrowserList( 'css' )
     } ) )
     .pipe( gulpHeader( configBanner, { pkg: configPkg } ) )
     .pipe( gulpSourcemaps.write( '.' ) )
@@ -99,7 +99,7 @@ function stylesOnDemand() {
     .pipe( gulpLess( configStyles.settings ) )
     .on( 'error', handleErrors )
     .pipe( gulpAutoprefixer( {
-      browsers: environment.getSupportedBrowserList()
+      browsers: environment.getSupportedBrowserList( 'css' )
     } ) )
     .pipe( gulpHeader( configBanner, { pkg: configPkg } ) )
     .pipe( gulp.dest( configStyles.dest ) )
@@ -127,7 +127,7 @@ function stylesFeatureFlags() {
     .pipe( gulpLess( configStyles.settings ) )
     .on( 'error', handleErrors )
     .pipe( gulpAutoprefixer( {
-      browsers: environment.getSupportedBrowserList()
+      browsers: environment.getSupportedBrowserList( 'css' )
     } ) )
     .pipe( gulp.dest( configStyles.dest + '/feature-flags' ) )
     .pipe( browserSync.reload( {
@@ -146,7 +146,7 @@ function stylesKnowledgebaseProd() {
     .pipe( gulpLess( { compress: true } ) )
     .on( 'error', handleErrors )
     .pipe( gulpAutoprefixer( {
-      browsers: environment.getSupportedBrowserList()
+      browsers: environment.getSupportedBrowserList( 'css' )
     } ) )
     .pipe( gulpHeader( configBanner, { pkg: configPkg } ) )
     .pipe( gulpRename( 'es-ask-styles.min.css' ) )
@@ -166,7 +166,7 @@ function stylesKnowledgebaseIE() {
     .pipe( gulpLess( { compress: true } ) )
     .on( 'error', handleErrors )
     .pipe( gulpAutoprefixer( {
-      browsers: environment.getSupportedBrowserList()
+      browsers: environment.getSupportedBrowserList( 'css' )
     } ) )
     .pipe( gulpHeader( configBanner, { pkg: configPkg } ) )
     .pipe( gulpRename( 'es-ask-styles-ie.min.css' ) )
@@ -185,7 +185,7 @@ function stylesNemoProd() {
     .pipe( gulpLess( { compress: true } ) )
     .on( 'error', handleErrors )
     .pipe( gulpAutoprefixer( {
-      browsers: environment.getSupportedBrowserList()
+      browsers: environment.getSupportedBrowserList( 'css' )
     } ) )
     .pipe( gulpHeader( configBanner, { pkg: configPkg } ) )
     .pipe( gulpRename( 'es-styles.min.css' ) )
@@ -204,7 +204,7 @@ function stylesNemoIE() {
     .pipe( gulpLess( { compress: true } ) )
     .on( 'error', handleErrors )
     .pipe( gulpAutoprefixer( {
-      browsers: environment.getSupportedBrowserList()
+      browsers: environment.getSupportedBrowserList( 'css' )
     } ) )
     .pipe( gulpHeader( configBanner, { pkg: configPkg } ) )
     .pipe( gulpRename( 'es-styles-ie.min.css' ) )


### PR DESCRIPTION
@contolini found that the ie string in the browser support list was not doing anything. This changes the array to support IE9. It also splits the array into two for js and css to support different sets.

## Changes

- Split `getSupportedBrowserList` into two arrays for css and js.
- Change browser list support list to properly include older IE support.

## Testing

1. `gulp build` should pass.
2. IE9 should not look blown up.
