### PR TITLE
Update mkDOCter version, fix broken docs link

### DIFF
--- a/docs/new-projects.md
+++ b/docs/new-projects.md
@@ -46,7 +46,7 @@ How to change | See below | With the release cycle | Use [API versioning](http:/
 
 ## Front-end Resources
 
-Front-end resources should conform to the [CFPB front-end guides](front-end-guide.md) and should use atomic elements, organisms, existing structure and convention. When applicable, front-end components should be added to Capital Framework using atomic design principles.
+Front-end resources should conform to [CFPB development standards](https://github.com/cfpb/development) and should use atomic elements, organisms, existing structure and convention. When applicable, front-end components should be added to Capital Framework using atomic design principles.
 
 Projects that will be part of cfgov but live in their own repositories should:
 

--- a/requirements/manual.txt
+++ b/requirements/manual.txt
@@ -5,11 +5,11 @@ certifi==2016.8.2
 click==3.3
 django-livereload==1.2
 livereload==2.3.2
-mkdocs==0.15.3
+mkdocs==0.16.3
 mkdocs-bootstrap==0.1.1
 mkdocs-bootswatch==0.1.0
 pymdown-extensions==2.0
 singledispatch==3.4.0.3
 six==1.9.0
 tornado==4.1
-mkDOCter
+mkDOCter==1.0.4


### PR DESCRIPTION
This commit bumps the version of mkDOCter (the mkdocs theme) we use for documentation from 0.1.3 to 0.1.4, and also bumps mkdocs itself to the latest 0.16.3 version.

It also fixes a broken link in the documentation to point to our development standards.

## Changes

- Bump mkdocs to latest version, and our theme mkdocter with it.
- Fix broken link.

## Testing

1. Run `pip install -r requirements/manual.txt` then `mkdocs serve` to browse documentation locally.

## Todos

- This PR first requires a 0.1.4 release of [mkDOCter](https://pypi.python.org/pypi/mkDOCter) on PyPI.

## Checklist

* [X] PR has an informative and human-readable title
* [X] Changes are limited to a single goal (no scope creep)
* [X] Code can be automatically merged (no conflicts)
* [X] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [X] Passes all existing automated tests
* [X] Visually tested in supported browsers and devices
* [X] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
