### PR TITLE
Improve formatting of Github issue created from SQS script

### DIFF
--- a/cfgov/alerts/post_sqs_messages.py
+++ b/cfgov/alerts/post_sqs_messages.py
@@ -100,7 +100,11 @@ if __name__ == '__main__':
     )
 
     for message in response.get('Messages', {}):
-        body = message.get('Body')
+        body = message.get('Body').replace(
+            '#', '# '  # Avoids erroneous Github issue link
+        ).replace(
+            '[Open]', ''  # We want to expand the link
+        )
         title = body.split(" - ")[0]
         logger.info('Retrieved message {} from SQS'.format(body))
 


### PR DESCRIPTION
- Adds a space to # so it doesn't erroneously link to a Github issue
- Remove the `[Open]` syntax so that the link expands

See GHE 1146 as an example of how this looks like now, and 1148 as an example of how it will look like after these changes.