### PR TITLE
Bump Markdown version for manual

### DIFF
--- a/requirements/manual.txt
+++ b/requirements/manual.txt
@@ -1,4 +1,4 @@
-Markdown==2.3.1
+Markdown==2.6.9
 PyYAML==3.10
 backports-abc==0.4
 certifi==2016.8.2


### PR DESCRIPTION
PR #3304 bumped the version of `mkdocs` used for the manual but neglected to also bump the required version of `Markdown`. This change bumps that package from 2.3.1 to 2.6.9.

## Changes

- Bump version of `Markdown` in `requirements/manual.txt`.

## Testing

To test, do `pip install -r requirements/manual.txt` and then `mkdocs serve`.

## Checklist

* [X] PR has an informative and human-readable title
* [X] Changes are limited to a single goal (no scope creep)
* [X] Code can be automatically merged (no conflicts)
* [X] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [X] Passes all existing automated tests
* [X] Visually tested in supported browsers and devices
* [X] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right: