### PR TITLE
Reopen a github issue if it was previously closed (SQS script enhancement)

### DIFF
--- a/cfgov/alerts/post_sqs_messages.py
+++ b/cfgov/alerts/post_sqs_messages.py
@@ -108,9 +108,13 @@ if __name__ == '__main__':
         title = body.split(" - ")[0]
         logger.info('Retrieved message {} from SQS'.format(body))
 
-        issue = matching_issue(title=title, issues=repo.iter_issues())
-        if issue:
-            # Issue already exists,
+        issue = matching_issue(
+            title=title,
+            issues=repo.iter_issues(state='all')
+        )
+        if issue:  # Issue already exists
+            if issue.is_closed():
+                issue.reopen()
             # add comment to it to document it happened again
             issue.create_comment(body=body)
         else:


### PR DESCRIPTION
Previously, we were only looking at open issues when deciding whether to create a new issue or comment on an existing one.  After this PR, we will simply re-open matching closed issues and comment on them, so the record is all in the same place.  Reasons for this happening might be that an issue gets resolved by a human and they close it, but then it starts failing at some future date for other reasons. 
