### PR TITLE
Add MP map highlighting feature

### DIFF
--- a/cfgov/unprocessed/css/organisms/mortgage-performance-trends.less
+++ b/cfgov/unprocessed/css/organisms/mortgage-performance-trends.less
@@ -65,3 +65,16 @@
     } );
 
 }
+
+// Override some cfpb-chart-builder styles
+.highcharts-map-series {
+  .highcharts-point-select,
+  .highcharts-point:hover {
+    stroke: @black !important;
+    stroke-width: 2px !important;
+  }
+}
+
+.highcharts-tooltip-box {
+  fill: @white;
+}

--- a/cfgov/unprocessed/js/organisms/MortgagePerformanceTrends/apps/map.js
+++ b/cfgov/unprocessed/js/organisms/MortgagePerformanceTrends/apps/map.js
@@ -108,6 +108,7 @@ MortgagePerformanceMap.prototype.onChange = function( event ) {
 
 MortgagePerformanceMap.prototype.zoom = function( prevState, state ) {
   this.chart.highchart.chart.get( state.geo.id ).zoomTo();
+  this.chart.highchart.chart.get( state.geo.id ).select();
 };
 
 MortgagePerformanceMap.prototype.renderChart = function( prevState, state ) {
@@ -125,11 +126,11 @@ MortgagePerformanceMap.prototype.renderChart = function( prevState, state ) {
       source: `map-data/${ this.timespan }/${ _plurals[state.geo.type] }/${ state.date }`,
       metadata: _plurals[state.geo.type]
     } ).then( () => {
-      this.$state.value = '';
-      this.$metro.value = '';
-      this.$county.value = '';
-      this.$county.innerHTML = '';
       if ( prevState.geo.type !== state.geo.type ) {
+        this.$state.value = '';
+        this.$metro.value = '';
+        this.$county.value = '';
+        this.$county.innerHTML = '';
         this.chart.highchart.chart.zoomOut();
       }
       store.dispatch( actions.stopLoading() );

--- a/package-lock.json
+++ b/package-lock.json
@@ -1989,9 +1989,9 @@
       }
     },
     "cfpb-chart-builder": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/cfpb-chart-builder/-/cfpb-chart-builder-3.0.0.tgz",
-      "integrity": "sha512-QBlh/V5jzHo2MN+81NXinKZBBMlizUhzIHf20RlEPLaU6hByMXnapiDV2wvJAWjh7NEeDRfHx4qnBi4TUEYkNQ==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/cfpb-chart-builder/-/cfpb-chart-builder-3.0.1.tgz",
+      "integrity": "sha512-d1Ybzub5FsnnRyYnu0QozpmQQNjZ6Tmp7GgKOsvMj+plyV5Lj3PGDTvN0cMPpuTKrsr3WkGPXvppEksCTTq48Q==",
       "requires": {
         "babel-preset-env": "1.6.0",
         "cf-core": "4.3.1",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "cf-pagination": "4.1.3",
     "cf-tables": "4.1.2",
     "cf-typography": "4.1.2",
-    "cfpb-chart-builder": "3.0.0",
+    "cfpb-chart-builder": "3.0.1",
     "del": "2.2.2",
     "es5-shim": "4.5.9",
     "glob-all": "3.1.0",


### PR DESCRIPTION
Tweaks the choropleth map to use the highcharts `select()` feature.

## Additions

- Locations are highlighted after being selected in the dropdown.

## Changes

- Bump cfpb-chart-builder to v3.0.1.

## Testing

1. Pull down this branch and `./setup.sh`
1. Set up the [mortgage performance API](https://github.com/cfpb/cfgov-refresh/pull/3189).
1. Create a [mortgage chart block and page](https://github.com/cfpb/cfgov-refresh/pull/3260).

## Screenshots

![screen shot 2017-09-06 at 12 22 51 pm](https://user-images.githubusercontent.com/1060248/30122913-2af02a2c-92fe-11e7-8254-adda32071129.png)

## Checklist

* [ ] PR has an informative and human-readable title
* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated
* [ ] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
