### PR TITLE
Data_research chart and map footnote content

### DIFF
--- a/cfgov/data_research/fixtures/mortgage_constants.json
+++ b/cfgov/data_research/fixtures/mortgage_constants.json
@@ -34,5 +34,29 @@
     },
     "model": "data_research.mortgagedataconstant",
     "pk": 3
+},
+{
+    "fields": {
+        "updated": "2017-09-06",
+        "string_value": "Map notes to come.",
+        "value": null,
+        "note": "",
+        "slug": "",
+        "name": "map_notes"
+    },
+    "model": "data_research.mortgagedataconstant",
+    "pk": 6
+},
+{
+    "fields": {
+        "updated": "2017-09-06",
+        "string_value": "Locations with insufficient data are not provided.",
+        "value": null,
+        "note": "",
+        "slug": "",
+        "name": "chart_notes"
+    },
+    "model": "data_research.mortgagedataconstant",
+    "pk": 7
 }
 ]

--- a/cfgov/data_research/models.py
+++ b/cfgov/data_research/models.py
@@ -43,6 +43,13 @@ class MortgageDataConstant(models.Model):
         threshold_year = cls.objects.get(name='threshold_year').value
         return (threshold_count, threshold_year)
 
+    @classmethod
+    def get_viz_notes(cls):
+        """Returns note content that runs below charts and maps."""
+        return {obj.name: obj.string_value
+                for obj in MortgageDataConstant.objects.filter(
+                    name__in=['chart_notes', 'map_notes'])}
+
     class Meta:
         ordering = ['name']
 
@@ -315,7 +322,8 @@ class MortgagePerformancePage(BrowsePage):
     template = 'browse-basic/index.html'
 
     def get_mortgage_meta(self):
-        meta_set = MortgageMetaData.objects.all()
+        meta_names = ['sampling_dates', 'download_files']
+        meta_set = MortgageMetaData.objects.filter(name__in=meta_names)
         meta = {obj.name: obj.json_value for obj in meta_set}
         thru_date_string = meta['sampling_dates'][-1]
         thru_date = parser.parse(thru_date_string)
@@ -326,6 +334,7 @@ class MortgagePerformancePage(BrowsePage):
         meta['pub_date'] = meta_sample['pub_date']
         meta['pub_date_formatted'] = parser.parse(
             meta['pub_date']).strftime("%B %-d, %Y")
+        meta['viz_notes'] = MortgageDataConstant.get_viz_notes()
         return meta
 
     def get_context(self, request, *args, **kwargs):

--- a/cfgov/jinja2/v1/_includes/organisms/mortgage-chart.html
+++ b/cfgov/jinja2/v1/_includes/organisms/mortgage-chart.html
@@ -339,8 +339,10 @@
     <div class="cfpb-chart" data-chart-ignore="true" data-chart-color="blue" data-chart-type="line-comparison" id="mp-line-chart">
         {{ value.description }}
     </div>
-    <p class="m-chart-footnote block__sub block__border-top block short-desc" style="font-size:14px !important"><strong>Source:</strong> Download CSV files with <a class="icon-link icon-link__download" href="{{ state_meta['url'] }}" <span class="icon-link_text">state</span></a> ({{ state_meta['size'] }}), <a class="icon-link icon-link__download" href="{{ metro_meta['url'] }}" <span class="icon-link_text">metro area</span></a> ({{ metro_meta['size'] }}), or <a class="icon-link icon-link__download" href="{{ county_meta['url'] }}"><span class="icon-link_text">county</span></a> ({{ county_meta['size'] }}) data.<br>
-        <strong>Date published:</strong> {{ pub_date_formatted }}<br>
-        <strong>Note:</strong> Data from the last six months are not final. The most recent data available in each visualization is for {{ thru_month_formatted }}.
+    <p class="m-chart-footnote block__sub block__border-top block short-desc" style="font-size:14px !important">
+    <strong>Source:</strong> National Mortgage Database<br>
+    <strong>Date published:</strong> {{ pub_date_formatted }}<br>
+    <strong>Downloads:</strong> CSV files with data by <a class="icon-link icon-link__download" href="{{ state_meta['url'] }}" <span class="icon-link_text">state</span></a> ({{ state_meta['size'] }}), <a class="icon-link icon-link__download" href="{{ metro_meta['url'] }}" <span class="icon-link_text">metro and non-metro areas</span></a> ({{ metro_meta['size'] }}), or <a class="icon-link icon-link__download" href="{{ county_meta['url'] }}"><span class="icon-link_text">county</span></a> ({{ county_meta['size'] }}).<br>
+    <strong>Notes:</strong> {{ viz_notes['chart_notes'] }}<br>
     </p>
 </div>

--- a/cfgov/jinja2/v1/_includes/organisms/mortgage-chart.html
+++ b/cfgov/jinja2/v1/_includes/organisms/mortgage-chart.html
@@ -339,7 +339,7 @@
     <div class="cfpb-chart" data-chart-ignore="true" data-chart-color="blue" data-chart-type="line-comparison" id="mp-line-chart">
         {{ value.description }}
     </div>
-    <p class="m-chart-footnote block__sub block__border-top block short-desc" style="font-size:14px !important">
+    <p class="m-chart-footnote block__sub block__border-top block short-desc">
     <strong>Source:</strong> National Mortgage Database<br>
     <strong>Date published:</strong> {{ pub_date_formatted }}<br>
     <strong>Downloads:</strong> CSV files with data by <a class="icon-link icon-link__download" href="{{ state_meta['url'] }}" <span class="icon-link_text">state</span></a> ({{ state_meta['size'] }}), <a class="icon-link icon-link__download" href="{{ metro_meta['url'] }}" <span class="icon-link_text">metro and non-metro areas</span></a> ({{ metro_meta['size'] }}), or <a class="icon-link icon-link__download" href="{{ county_meta['url'] }}"><span class="icon-link_text">county</span></a> ({{ county_meta['size'] }}).<br>

--- a/cfgov/jinja2/v1/_includes/organisms/mortgage-map.html
+++ b/cfgov/jinja2/v1/_includes/organisms/mortgage-map.html
@@ -410,7 +410,7 @@
             </g>
         </svg>
     </div>
-    <p class="m-chart-footnote block__sub block__border-top block short-desc" style="font-size:14px !important">
+    <p class="m-chart-footnote block__sub block__border-top block short-desc">
     <strong>Source:</strong> National Mortgage Database<br>
     <strong>Date published:</strong> {{ pub_date_formatted }}<br>
     <strong>Downloads:</strong> CSV files with data by <a class="icon-link icon-link__download" href="{{ state_meta['url'] }}" <span class="icon-link_text">state</span></a> ({{ state_meta['size'] }}), <a class="icon-link icon-link__download" href="{{ metro_meta['url'] }}" <span class="icon-link_text">metro and non-metro areas</span></a> ({{ metro_meta['size'] }}), or <a class="icon-link icon-link__download" href="{{ county_meta['url'] }}"><span class="icon-link_text">county</span></a> ({{ county_meta['size'] }}).<br>

--- a/cfgov/jinja2/v1/_includes/organisms/mortgage-map.html
+++ b/cfgov/jinja2/v1/_includes/organisms/mortgage-map.html
@@ -410,8 +410,10 @@
             </g>
         </svg>
     </div>
-    <p class="m-chart-footnote block__sub block__border-top block short-desc" style="font-size:14px !important"><strong>Source:</strong> Download CSV files with <a class="icon-link icon-link__download" href="{{ state_meta['url'] }}" <span class="icon-link_text">state</span></a> ({{ state_meta['size'] }}), <a class="icon-link icon-link__download" href="{{ metro_meta['url'] }}" <span class="icon-link_text">metro area</span></a> ({{ metro_meta['size'] }}), or <a class="icon-link icon-link__download" href="{{ county_meta['url'] }}"><span class="icon-link_text">county</span></a> ({{ county_meta['size'] }}) data.<br>
-        <strong>Date published:</strong> {{ pub_date_formatted }}<br>
-        <strong>Note:</strong> Data from the last six months are not final. The most recent data available in each visualization is for {{ thru_month_formatted }}.
+    <p class="m-chart-footnote block__sub block__border-top block short-desc" style="font-size:14px !important">
+    <strong>Source:</strong> National Mortgage Database<br>
+    <strong>Date published:</strong> {{ pub_date_formatted }}<br>
+    <strong>Downloads:</strong> CSV files with data by <a class="icon-link icon-link__download" href="{{ state_meta['url'] }}" <span class="icon-link_text">state</span></a> ({{ state_meta['size'] }}), <a class="icon-link icon-link__download" href="{{ metro_meta['url'] }}" <span class="icon-link_text">metro and non-metro areas</span></a> ({{ metro_meta['size'] }}), or <a class="icon-link icon-link__download" href="{{ county_meta['url'] }}"><span class="icon-link_text">county</span></a> ({{ county_meta['size'] }}).<br>
+    <strong>Notes:</strong> {{ viz_notes['map_notes'] }}<br>
     </p>
 </div>


### PR DESCRIPTION
This aligns chart and map footnotes with the latest content, as specified in GHE issue 167.
The footnotes'  download links and file sizes will stay in sync with the database, and the
notes string will be editable via the data_research admin.


## Testing

You'll need to refresh your local data (even if you did so recently).
### Load mortgage data locally
Download the latest data here: 
- http://files.consumerfinance.gov.s3.amazonaws.com/data/mortgage-performance/initial_data/mortgagedata.sql.gz

Load it:
```
gunzip -c ~/Downloads/mortgagedata.sql.gz | mysql -uroot v1
```

Footnotes under charts and maps should match content at GHE 167.