### PR TITLE
Convert tests to ES6

### DIFF
--- a/cfgov/unprocessed/js/organisms/MortgagePerformanceTrends/actions.js
+++ b/cfgov/unprocessed/js/organisms/MortgagePerformanceTrends/actions.js
@@ -62,7 +62,7 @@ actions.fetchMetros = ( metroState, includeNational ) => dispatch => {
       return console.error( 'Error getting metro data', err );
     }
     // Alphabetical order
-    var newMetros = data[metroState].msas.sort( ( a, b ) => (a.name < b.name ? -1 : 1) );
+    var newMetros = data[metroState].msas.sort( ( a, b ) => a.name < b.name ? -1 : 1 );
     newMetros = newMetros.filter( msa => msa.valid );
     dispatch( actions.setMetros( newMetros ) );
     dispatch( actions.setGeo( newMetros[0].fips, newMetros[0].name, 'metro' ) );

--- a/gulp/utils/scripts-manifest.js
+++ b/gulp/utils/scripts-manifest.js
@@ -5,9 +5,9 @@
 
 'use strict';
 
-var fs = require( 'fs' );
+const fs = require( 'fs' );
 
-var _sourcePathCache = {};
+const _sourcePathCache = {};
 
 /**
  * Traverse a directory and return an object with keys
@@ -21,13 +21,13 @@ var _sourcePathCache = {};
  */
 function _traverseDirectory( dir, list, baseDir ) {
   if ( !baseDir ) { baseDir = dir; }
-  var stats = fs.lstatSync( dir ); // eslint-disable-line no-sync, no-inline-comments, max-len
+  const stats = fs.lstatSync( dir ); // eslint-disable-line no-sync, no-inline-comments, max-len
   if ( stats.isDirectory() ) {
     fs.readdirSync( dir ).map( function( child ) { // eslint-disable-line no-sync, no-inline-comments, max-len
       return _traverseDirectory( dir + '/' + child, list, baseDir );
     } );
   } else if ( !_isHidden( dir ) ) {
-    var relativePath = dir.substring( baseDir.length + 1 );
+    const relativePath = dir.substring( baseDir.length + 1 );
     list[relativePath] = './' + relativePath;
   }
 
@@ -51,7 +51,7 @@ function _isHidden( path ) {
  *   Hash with keys and values equal to the files in the directory tree.
  */
 function getDirectoryMap( dir ) {
-  var cache = _sourcePathCache[dir];
+  let cache = _sourcePathCache[dir];
   if ( !_sourcePathCache[dir] ) {
     var directoryMap = _traverseDirectory( dir, {} );
     _sourcePathCache[dir] = directoryMap;

--- a/test/browser_tests/conf.js
+++ b/test/browser_tests/conf.js
@@ -45,7 +45,7 @@ function _chooseSuite( params ) {
       windowWidthPx = WINDOW_SIZES.MOBILE.WIDTH;
       windowHeightPx = WINDOW_SIZES.MOBILE.HEIGHT;
     }
-    let windowSize = `--window-size=${windowWidthPx}x${windowHeightPx}`;
+    const windowSize = `--window-size=${ windowWidthPx }x${ windowHeightPx }`;
     capabilities[0].chromeOptions.args.push( windowSize );
   } else if ( paramsAreNotSet && _useSauceLabs() ) {
     capabilities = defaultSuites.full;

--- a/test/browser_tests/cucumber/step_definitions/global-search.js
+++ b/test/browser_tests/cucumber/step_definitions/global-search.js
@@ -1,7 +1,5 @@
 'use strict';
 
-const BASE_JS_PATH = '../../../../cfgov/unprocessed/js/';
-const breakpointsConfig = require( BASE_JS_PATH + 'config/breakpoints-config' );
 const chai = require( 'chai' );
 const chaiAsPromised = require( 'chai-as-promised' );
 const { defineSupportCode } = require( 'cucumber' );

--- a/test/browser_tests/cucumber/step_definitions/header.js
+++ b/test/browser_tests/cucumber/step_definitions/header.js
@@ -1,7 +1,5 @@
 'use strict';
 
-const BASE_JS_PATH = '../../../../cfgov/unprocessed/js/';
-const breakpointsConfig = require( BASE_JS_PATH + 'config/breakpoints-config' );
 const { defineSupportCode } = require( 'cucumber' );
 const { shouldShouldnt, toCamelCase } = require( '../../util/index.js' );
 const chai = require( 'chai' );
@@ -81,7 +79,7 @@ defineSupportCode( function( { Then, When, Before } ) {
     return _dom.globalSearchTrigger.click();
   } );
 
-  Then(/the mega-menu\s?(shouldn't|should)/, function( dispayElement ) {
+  Then( /the mega-menu\s?(shouldn't|should)/, function( dispayElement ) {
     browser.sleep( 500 );
 
     return expect( _dom.megaMenuContent.getAttribute( 'aria-expanded' ) )

--- a/test/browser_tests/cucumber/step_definitions/mega-menu.js
+++ b/test/browser_tests/cucumber/step_definitions/mega-menu.js
@@ -1,7 +1,5 @@
 'use strict';
 
-const BASE_JS_PATH = '../../../../cfgov/unprocessed/js/';
-const breakpointsConfig = require( BASE_JS_PATH + 'config/breakpoints-config' );
 const { defineSupportCode } = require( 'cucumber' );
 const chai = require( 'chai' );
 const expect = chai.expect;

--- a/test/browser_tests/page_objects/browse-filterable-page.js
+++ b/test/browser_tests/page_objects/browse-filterable-page.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const filterableListControl = require( '../shared_objects/filterable-list-control' );
 const BaseFilteablePage = require( './base-filterable-page.js' );
 
 class BrowseFilterablePage extends BaseFilteablePage {

--- a/test/browser_tests/shared_objects/filterable-list-control.js
+++ b/test/browser_tests/shared_objects/filterable-list-control.js
@@ -1,10 +1,10 @@
 'use strict';
 
-var _oFilterableListControls =
-    element( by.css( '.o-filterable-list-controls' ) );
+const _oFilterableListControls =
+  element( by.css( '.o-filterable-list-controls' ) );
 
-var multiselect = require( '../shared_objects/multi-select' );
-var EC = protractor.ExpectedConditions;
+const multiselect = require( '../shared_objects/multi-select' );
+const EC = protractor.ExpectedConditions;
 
 
 function _getFilterableElement( selector ) {
@@ -12,27 +12,23 @@ function _getFilterableElement( selector ) {
 }
 
 function open() {
-  var expandable = this.mExpandable;
+  const expandable = this.mExpandable;
 
   return expandable.click()
-         .then( function() {
-           return browser.wait( EC.elementToBeClickable( expandable ) );
-         } );
+    .then( function() {
+      return browser.wait( EC.elementToBeClickable( expandable ) );
+    } );
 }
 
 function close() {
   return this.mExpandable.click();
 }
 
-var oFilterableListControls = {
+const oFilterableListControls = {
   mExpandable:   _getFilterableElement( '.o-expandable' ),
-
   mNotification: _getFilterableElement( '.m-notification' ),
-
   oPostPreview:  _getFilterableElement( '.o-post-preview' ),
-
   open:          open,
-
   close:         close
 };
 

--- a/test/browser_tests/shared_objects/stream-menu.js
+++ b/test/browser_tests/shared_objects/stream-menu.js
@@ -1,39 +1,25 @@
 'use strict';
 
-var _streamMenu = element.all( by.css( '.stream-menu' ) ).first();
+const _streamMenu = element.all( by.css( '.stream-menu' ) ).first();
 
 function _getContentElement( selector ) {
   return _streamMenu.element( by.css( selector ) );
 }
 
-var content = {
-
-  callToActionBtn:       _getContentElement( '.action-add-block-call_to_action' ),
-
-  contentBtn:            _getContentElement( '.action-add-block-content' ),
-
-  contentWithAnchorBtn:  _getContentElement( '.action-add-block-image_text_25_75_group' ),
-
-  emailSignupBtn:        _getContentElement( '.action-add-block-email_signup' ),
-
-  expandableBtn:         _getContentElement( '.action-add-block-expandable' ),
-
-  expandableGroupBtn:    _getContentElement( '.action-add-block-expandable_group' ),
-
-  feedbackBtn:           _getContentElement( '. action-add-block-feedback' ),
-
-  fullWidthTextBtn:      _getContentElement( '.action-add-block-full_width_text' ),
-
-  mediaBtn:              _getContentElement( '.action-add-block-media' ),
-
-  quoteBtn:              _getContentElement( '.action-add-block-quote' ),
-
-  tableBlock:            _getContentElement( '.action-add-block-table_block' ),
-
-  videoPlayerBtn:        _getContentElement( '.action-add-block-video_player' ),
-
-  wellBtn:               _getContentElement( '.action-add-block-well' )
-
+const content = {
+  callToActionBtn:      _getContentElement( '.action-add-block-call_to_action' ),
+  contentBtn:           _getContentElement( '.action-add-block-content' ),
+  contentWithAnchorBtn: _getContentElement( '.action-add-block-image_text_25_75_group' ),
+  emailSignupBtn:       _getContentElement( '.action-add-block-email_signup' ),
+  expandableBtn:        _getContentElement( '.action-add-block-expandable' ),
+  expandableGroupBtn:   _getContentElement( '.action-add-block-expandable_group' ),
+  feedbackBtn:          _getContentElement( '. action-add-block-feedback' ),
+  fullWidthTextBtn:     _getContentElement( '.action-add-block-full_width_text' ),
+  mediaBtn:             _getContentElement( '.action-add-block-media' ),
+  quoteBtn:             _getContentElement( '.action-add-block-quote' ),
+  tableBlock:           _getContentElement( '.action-add-block-table_block' ),
+  videoPlayerBtn:       _getContentElement( '.action-add-block-video_player' ),
+  wellBtn:              _getContentElement( '.action-add-block-well' )
 };
 
 module.exports = content;

--- a/test/browser_tests/shared_objects/wagtail-admin-content-menu.js
+++ b/test/browser_tests/shared_objects/wagtail-admin-content-menu.js
@@ -11,33 +11,20 @@ const _content = element
 const EC = protractor.ExpectedConditions;
 
 const menuItems = {
-
   callToActionBtn:      _getStreamMenuElement( '.action-add-block-call_to_action' ),
-
   contentBtn:           _getStreamMenuElement( '.action-add-block-content' ),
-
   contentWithAnchorBtn: _getStreamMenuElement( '.action-add-block-image_text_25_75_group' ),
-
   emailSignupBtn:       _getStreamMenuElement( '.action-add-block-email_signup' ),
-
   expandableBtn:        _getStreamMenuElement( '.action-add-block-expandable' ),
-
   expandableGroupBtn:   _getStreamMenuElement( '.action-add-block-expandable_group' ),
-
   fullWidthTextBtn:     _getStreamMenuElement( '.action-add-block-full_width_text' ),
-
   imageText2575Btn:     _getStreamMenuElement( '.action-add-block-image_text_25_75_group' ),
-
   tableBlock:           _getStreamMenuElement( '.action-add-block-table_block' ),
-
   videoPlayerBtn:       _getStreamMenuElement( '.action-add-block-video_player' ),
-
   wellBtn:              _getStreamMenuElement( '.action-add-block-well' )
-
 };
 
 function _getStreamMenuElement( selector ) {
-
   return _content.element( by.css( selector ) );
 }
 
@@ -86,12 +73,10 @@ function selectItem( componentName ) {
 }
 
 function open() {
-
   return toggleBtn.click();
 }
 
 function close() {
-
   return toggleBtn.click();
 }
 

--- a/test/browser_tests/shared_objects/wagtail-admin-full-width-text-menu.js
+++ b/test/browser_tests/shared_objects/wagtail-admin-full-width-text-menu.js
@@ -5,9 +5,7 @@ const fullWidthTextSelector = 'input[value=\'full_width_text\']' +
                             ' + .sequence-member-inner';
 
 function isActive( ) {
-
   function _getElement( selector ) {
-
     return document.querySelector( selector ) !== null;
   }
 
@@ -25,25 +23,15 @@ function getMenuItems() {
   }
 
   return {
-
     callToActionBtn:      _getFullWidthTextElement( '.action-add-block-cta' ),
-
     contentBtn:           _getFullWidthTextElement( '.action-add-block-content' ),
-
     contentWithAnchorBtn: _getFullWidthTextElement( '.action-add-block-image_text_25_75_group' ),
-
     imageInsetBtn:        _getFullWidthTextElement( '.action-add-block-image_inset' ),
-
     mediaBtn:             _getFullWidthTextElement( '.action-add-block-media' ),
-
     quoteBtn:             _getFullWidthTextElement( '.action-add-block-quote' ),
-
     relatedLinksBtn:      _getFullWidthTextElement( '.action-add-block-related_links' ),
-
     reusableTextBtn:      _getFullWidthTextElement( '.action-add-block-reusable_text' ),
-
     tableBlock:           _getFullWidthTextElement( '.action-add-block-table_block' )
-
   };
 
 }

--- a/test/unit_tests/fixtures/StorageMock.js
+++ b/test/unit_tests/fixtures/StorageMock.js
@@ -1,6 +1,5 @@
 'use strict';
 
-
 function StorageMock() {
   this.storage = {};
 }

--- a/test/unit_tests/modules/Analytics-spec.js
+++ b/test/unit_tests/modules/Analytics-spec.js
@@ -1,26 +1,26 @@
 'use strict';
 
-var BASE_JS_PATH = '../../../cfgov/unprocessed/js/';
+const BASE_JS_PATH = '../../../cfgov/unprocessed/js/';
 
-var chai = require( 'chai' );
-var expect = chai.expect;
-var jsdom = require( 'mocha-jsdom' );
-var sinon = require( 'sinon' );
-var sandbox;
-var Analytics;
-var dataLayerOptions;
-var getDataLayerOptions;
-var UNDEFINED;
+const chai = require( 'chai' );
+const expect = chai.expect;
+const jsdom = require( 'mocha-jsdom' );
+const sinon = require( 'sinon' );
+let sandbox;
+let Analytics;
+let dataLayerOptions;
+let getDataLayerOptions;
+let UNDEFINED;
 
-describe( 'Analytics', function() {
+describe( 'Analytics', () => {
   jsdom();
 
-  before( function() {
+  before( () => {
     Analytics = require( BASE_JS_PATH + 'modules/Analytics' );
     getDataLayerOptions = Analytics.getDataLayerOptions;
   } );
 
-  beforeEach( function() {
+  beforeEach( () => {
     sandbox = sinon.sandbox.create();
 
     function push( object ) {
@@ -46,20 +46,20 @@ describe( 'Analytics', function() {
 
   } );
 
-  afterEach( function() {
+  afterEach( () => {
     sandbox.restore();
   } );
 
-  describe( '.init()', function() {
-    it( 'should have a proper state after initialization', function() {
+  describe( '.init()', () => {
+    it( 'should have a proper state after initialization', () => {
       expect( Analytics.tagManagerIsLoaded === false ).to.be.true;
       window.google_tag_manager = {};
       Analytics.init();
       expect( Analytics.tagManagerIsLoaded === true ).to.be.true;
     } );
 
-    it( 'should properly set the google_tag_manager object', function() {
-      var mockGTMObject = { testing: true };
+    it( 'should properly set the google_tag_manager object', () => {
+      const mockGTMObject = { testing: true };
       Analytics.init();
       expect( Analytics.tagManagerIsLoaded === false ).to.be.true;
       window.google_tag_manager = mockGTMObject;
@@ -68,11 +68,11 @@ describe( 'Analytics', function() {
     } );
   } );
 
-  describe( '.sendEvent()', function() {
-    it( 'should properly add objects to the dataLayer Array', function() {
-      var action = 'inbox:clicked';
-      var label = 'text:null';
-      var options = Object.assign( {}, dataLayerOptions, {
+  describe( '.sendEvent()', () => {
+    it( 'should properly add objects to the dataLayer Array', () => {
+      const action = 'inbox:clicked';
+      const label = 'text:null';
+      const options = Object.assign( {}, dataLayerOptions, {
         action: action,
         label:  label
       } );
@@ -83,60 +83,68 @@ describe( 'Analytics', function() {
       expect( window.dataLayer[0] ).to.deep.equal( options );
     } );
 
-    it( 'shouldn\'t add objects to the dataLayer Array if GTM is undefined',
-    function() {
-      var action = 'inbox:clicked';
-      var label = 'text:null';
-      delete window.google_tag_manager;
-      Analytics.init();
-      Analytics.sendEvent( getDataLayerOptions( action, label ) );
-      expect( window.dataLayer.length === 0 ).to.be.true;
-    } );
+    it( "shouldn't add objects to the dataLayer Array if GTM is undefined",
+      () => {
+        const action = 'inbox:clicked';
+        const label = 'text:null';
+        delete window.google_tag_manager;
+        Analytics.init();
+        Analytics.sendEvent( getDataLayerOptions( action, label ) );
+        expect( window.dataLayer.length === 0 ).to.be.true;
+      }
+    );
 
-    it( 'should invoke the callback if provided', function() {
+    it( 'should invoke the callback if provided', () => {
       Analytics.init();
-      var action = 'inbox:clicked';
-      var label = 'text:null';
-      var callback = sinon.stub();
+      const action = 'inbox:clicked';
+      const label = 'text:null';
+      const callback = sinon.stub();
       window.google_tag_manager = {};
       Analytics.sendEvent( getDataLayerOptions( action, label, '', callback ) );
       expect( callback.called ).to.be.true;
     } );
   } );
 
-  describe( '.sendEvents()', function() {
-    it( 'should properly add objects to the dataLayer Array', function() {
-      var options1 = getDataLayerOptions( Object.assign( {}, dataLayerOptions,
-        {
+  describe( '.sendEvents()', () => {
+    it( 'should properly add objects to the dataLayer Array', () => {
+      const options1 = getDataLayerOptions(
+        Object.assign( {}, dataLayerOptions, {
           action: 'inbox:clicked',
           label:  'text:label_1'
-        } ) );
-      var options2 = getDataLayerOptions( Object.assign( {}, dataLayerOptions,
-        {
+        } )
+      );
+      const options2 = getDataLayerOptions(
+        Object.assign( {}, dataLayerOptions, {
           action: 'checbox:clicked',
           label:  'text:label_2'
-        } ) );
+        } )
+      );
       window.google_tag_manager = {};
       Analytics.init();
       Analytics.sendEvents( [ options1, options2 ] );
       expect( window.dataLayer.length === 2 ).to.be.true;
     } );
 
-    it( 'shouldn\'t add objects to the dataLayer Array if an array isn\'t passed',
-    function() {
-      var options1 = getDataLayerOptions( Object.assign( {}, dataLayerOptions, {
-        action: 'inbox:clicked',
-        label:  'text:label_1'
-      } ) );
-      var options2 = getDataLayerOptions( Object.assign( {}, dataLayerOptions, {
-        action: 'checbox:clicked',
-        label:  'text:label_2'
-      } ) );
-      window.google_tag_manager = {};
-      Analytics.init();
-      Analytics.sendEvents( options1, options2 );
-      expect( window.dataLayer.length === 0 ).to.be.true;
-    } );
+    it( "shouldn't add objects to the dataLayer Array if an array isn't passed",
+      () => {
+        const options1 = getDataLayerOptions(
+          Object.assign( {}, dataLayerOptions, {
+            action: 'inbox:clicked',
+            label:  'text:label_1'
+          } )
+        );
+        const options2 = getDataLayerOptions(
+          Object.assign( {}, dataLayerOptions, {
+            action: 'checbox:clicked',
+            label:  'text:label_2'
+          } )
+        );
+        window.google_tag_manager = {};
+        Analytics.init();
+        Analytics.sendEvents( options1, options2 );
+        expect( window.dataLayer.length === 0 ).to.be.true;
+      }
+    );
   } );
 
 } );

--- a/test/unit_tests/modules/BreakpointHandler-spec.js
+++ b/test/unit_tests/modules/BreakpointHandler-spec.js
@@ -1,14 +1,15 @@
 'use strict';
-var chai = require( 'chai' );
-var expect = chai.expect;
-var jsdom = require( 'mocha-jsdom' );
-var sinon = require( 'sinon' );
-var BreakpointHandler;
-var args;
-var BASE_LOC = '../../../cfgov/unprocessed/js/';
-var standardType = require( BASE_LOC + 'modules/util/standard-type' );
 
-beforeEach( function() {
+const chai = require( 'chai' );
+const expect = chai.expect;
+const jsdom = require( 'mocha-jsdom' );
+const sinon = require( 'sinon' );
+let BreakpointHandler;
+let args;
+const BASE_LOC = '../../../cfgov/unprocessed/js/';
+const standardType = require( BASE_LOC + 'modules/util/standard-type' );
+
+beforeEach( () => {
   args = {
     enter:      standardType.noopFunct,
     leave:      standardType.noopFunct,
@@ -18,7 +19,7 @@ beforeEach( function() {
   BreakpointHandler = require( BASE_LOC + 'modules/BreakpointHandler' );
 } );
 
-describe( 'BreakpointHandler', function() {
+describe( 'BreakpointHandler', () => {
 
   jsdom( {
     created: function( error, win ) {
@@ -26,7 +27,7 @@ describe( 'BreakpointHandler', function() {
         console.log( error );
       }
 
-      var resizeEvent = win.document.createEvent( 'Event' );
+      const resizeEvent = win.document.createEvent( 'Event' );
       resizeEvent.initEvent( 'resize', true, true );
 
       win.resizeTo = function( width, height ) {
@@ -36,7 +37,7 @@ describe( 'BreakpointHandler', function() {
       };
 
       win.useMock = function() {
-        var mockwin = {
+        const mockwin = {
           addEventListener: win.addEventListener,
           document:         { documentElement: {}},
           innerWidth:       win.innerWidth,
@@ -60,8 +61,8 @@ describe( 'BreakpointHandler', function() {
     }
   } );
 
-  it( 'should throw an error if passed incomplete arguments', function() {
-    var errorTxt = 'BreakpointHandler constructor requires arguments!';
+  it( 'should throw an error if passed incomplete arguments', () => {
+    const errorTxt = 'BreakpointHandler constructor requires arguments!';
     function createBreakpointInstance() {
       return new BreakpointHandler();
     }
@@ -69,7 +70,7 @@ describe( 'BreakpointHandler', function() {
     expect( createBreakpointInstance ).to.throw( errorTxt );
   } );
 
-  it( 'should compute window width properly on older browsers', function() {
+  it( 'should compute window width properly on older browsers', () => {
     function createBreakpointInstance() {
       return new BreakpointHandler( args );
     }
@@ -83,22 +84,22 @@ describe( 'BreakpointHandler', function() {
     window.restore();
   } );
 
-  it( 'should correctly create BreakpointHandler instances', function() {
-    var breakpointHandler = new BreakpointHandler( args );
+  it( 'should correctly create BreakpointHandler instances', () => {
+    let breakpointHandler = new BreakpointHandler( args );
     expect( breakpointHandler.watchWindowResize )
-    .to.be.an.instanceof( Function );
+      .to.be.an.instanceof( Function );
     expect( breakpointHandler.handleViewportChange )
-    .to.be.an.instanceof( Function );
+      .to.be.an.instanceof( Function );
     expect( breakpointHandler.testBreakpoint )
-    .to.be.an.instanceof( Function );
+      .to.be.an.instanceof( Function );
 
     expect( breakpointHandler.match ).to.be.false;
     expect( breakpointHandler.type === 'max' ).to.be.true;
   } );
 
-  it( 'should allow responsive breakpoints as arguments', function() {
+  it( 'should allow responsive breakpoints as arguments', () => {
     args.breakpoint = 'bpXS';
-    var breakpointHandler = new BreakpointHandler( args );
+    let breakpointHandler = new BreakpointHandler( args );
     expect( breakpointHandler.breakpoint ).to.equal( 600 );
     expect( breakpointHandler.type === 'max' ).to.be.true;
     expect( breakpointHandler.testBreakpoint( 300 ) ).to.be.true;
@@ -111,8 +112,8 @@ describe( 'BreakpointHandler', function() {
     expect( breakpointHandler.testBreakpoint( 601 ) ).to.be.true;
   } );
 
-  it( 'should test a breakpoint', function() {
-    var breakpointHandler = new BreakpointHandler( args );
+  it( 'should test a breakpoint', () => {
+    let breakpointHandler = new BreakpointHandler( args );
     expect( breakpointHandler.testBreakpoint( 601 ) ).to.be.false;
 
     args.type = 'min';
@@ -126,20 +127,20 @@ describe( 'BreakpointHandler', function() {
     expect( breakpointHandler.testBreakpoint( 601 ) ).to.be.false;
   } );
 
-  it( 'should handle viewport changes', function() {
-    var breakpointHandler = new BreakpointHandler( args );
-    var enterSpy = sinon.spy( breakpointHandler, 'enter' );
-    var leaveSpy = sinon.spy( breakpointHandler, 'leave' );
+  it( 'should handle viewport changes', () => {
+    let breakpointHandler = new BreakpointHandler( args );
+    let enterSpy = sinon.spy( breakpointHandler, 'enter' );
+    let leaveSpy = sinon.spy( breakpointHandler, 'leave' );
 
     window.resizeTo( 598, 800 );
     expect( enterSpy.calledOnce ).to.be.true;
     expect( enterSpy.calledWithMatch( sinon.match.has( 'isBpXS', true ) ) )
-    .to.be.true;
+      .to.be.true;
 
     window.resizeTo( 601, 800 );
     expect( leaveSpy.calledOnce ).to.be.true;
     expect( leaveSpy.calledWithMatch( sinon.match.has( 'isBpSM', true ) ) )
-    .to.be.true;
+      .to.be.true;
 
     args.type = 'min';
     args.breakpoint = 901;
@@ -148,7 +149,7 @@ describe( 'BreakpointHandler', function() {
     window.resizeTo( 1000, 800 );
     expect( enterSpy.calledOnce ).to.be.true;
     expect( enterSpy.calledWithMatch( sinon.match.has( 'isBpMED', true ) ) )
-    .to.be.true;
+      .to.be.true;
 
     args.type = 'max';
     args.breakpoint = 1020;
@@ -157,12 +158,12 @@ describe( 'BreakpointHandler', function() {
     window.resizeTo( 1021, 800 );
     expect( leaveSpy.calledOnce ).to.be.true;
     expect( leaveSpy.calledWithMatch( sinon.match.has( 'isBpLG', true ) ) )
-    .to.be.true;
+      .to.be.true;
   } );
 
-  it( 'should watch for window resize events', function() {
-    var breakpointHandler = new BreakpointHandler( args );
-    var handleViewportChangeSpy =
+  it( 'should watch for window resize events', () => {
+    const breakpointHandler = new BreakpointHandler( args );
+    const handleViewportChangeSpy =
     sinon.spy( breakpointHandler, 'handleViewportChange' );
 
     expect( handleViewportChangeSpy.called ).to.be.false;

--- a/test/unit_tests/modules/ClearableInput-spec.js
+++ b/test/unit_tests/modules/ClearableInput-spec.js
@@ -1,17 +1,18 @@
 'use strict';
-var BASE_JS_PATH = '../../../cfgov/unprocessed/js/';
 
-var chai = require( 'chai' );
-var expect = chai.expect;
-var jsdom = require( 'mocha-jsdom' );
-var sinon = require( 'sinon' );
-var ClearableInput = require( BASE_JS_PATH + 'modules/ClearableInput' );
-var sandbox;
-var baseDom;
-var clearBtnDom;
-var inputDom;
+const BASE_JS_PATH = '../../../cfgov/unprocessed/js/';
 
-var HTML_SNIPPET =
+const chai = require( 'chai' );
+const expect = chai.expect;
+const jsdom = require( 'mocha-jsdom' );
+const sinon = require( 'sinon' );
+const ClearableInput = require( BASE_JS_PATH + 'modules/ClearableInput' );
+let sandbox;
+let baseDom;
+let clearBtnDom;
+let inputDom;
+
+const HTML_SNIPPET =
   `<div class="o-form__input-w-btn_input-container">
        <div class="m-btn-inside-input
                    input-contains-label">
@@ -39,10 +40,10 @@ function triggerEvent( target, eventType, eventOption ) {
 }
 
 
-describe( 'ClearableInput', function() {
+describe( 'ClearableInput', () => {
   jsdom();
 
-  beforeEach( function() {
+  beforeEach( () => {
     sandbox = sinon.sandbox.create();
     document.body.innerHTML = HTML_SNIPPET;
     baseDom = document.querySelector( '.o-form__input-w-btn_input-container' );
@@ -50,25 +51,25 @@ describe( 'ClearableInput', function() {
     clearBtnDom = baseDom.querySelector( '.input-contains-label_after__clear' );
   } );
 
-  afterEach( function() {
+  afterEach( () => {
     sandbox.restore();
   } );
 
-  describe( 'init function', function() {
-    it( 'should hide the clear button when a value is empty', function() {
+  describe( 'init function', () => {
+    it( 'should hide the clear button when a value is empty', () => {
       new ClearableInput( baseDom ).init();
       expect( clearBtnDom.classList.contains( 'u-hidden' ) ).to.equal( true );
     } );
 
-    it( 'should display the clear button when a value is present', function() {
+    it( 'should display the clear button when a value is present', () => {
       inputDom.value = 'testing init function';
       new ClearableInput( baseDom ).init();
       expect( clearBtnDom.classList.contains( 'u-hidden' ) ).to.equal( false );
     } );
   } );
 
-  describe( 'on clear button click', function() {
-    it( 'should hide itself', function() {
+  describe( 'on clear button click', () => {
+    it( 'should hide itself', () => {
       inputDom.value = 'testing clear button';
       new ClearableInput( baseDom ).init();
       expect( clearBtnDom.classList.contains( 'u-hidden' ) ).to.equal( false );
@@ -76,7 +77,7 @@ describe( 'ClearableInput', function() {
       expect( clearBtnDom.classList.contains( 'u-hidden' ) ).to.equal( true );
     } );
 
-    it( 'should clear the input value', function() {
+    it( 'should clear the input value', () => {
       inputDom.value = 'testing clear button';
       new ClearableInput( baseDom ).init();
       triggerEvent( clearBtnDom, 'mousedown' );
@@ -84,8 +85,8 @@ describe( 'ClearableInput', function() {
     } );
   } );
 
-  describe( 'on input keystroke', function() {
-    it( 'should show the clear button, if value present', function() {
+  describe( 'on input keystroke', () => {
+    it( 'should show the clear button, if value present', () => {
       new ClearableInput( baseDom ).init();
 
       // Event code 65 is the `a` character.
@@ -93,7 +94,7 @@ describe( 'ClearableInput', function() {
       expect( clearBtnDom.classList.contains( 'u-hidden' ) ).to.equal( false );
     } );
 
-    it( 'should hide the clear button, if value not present', function() {
+    it( 'should hide the clear button, if value not present', () => {
       new ClearableInput( baseDom ).init();
 
       // Event code 8 is backspace.

--- a/test/unit_tests/modules/ExternalSite-spec.js
+++ b/test/unit_tests/modules/ExternalSite-spec.js
@@ -1,10 +1,11 @@
 'use strict';
-var BASE_JS_PATH = '../../../cfgov/unprocessed/js/';
 
-var chai = require( 'chai' );
-var expect = chai.expect;
-var ExternalSite = require( BASE_JS_PATH + 'modules/ExternalSite' );
+const BASE_JS_PATH = '../../../cfgov/unprocessed/js/';
 
-describe( 'ExternalSite', function() {
+const chai = require( 'chai' );
+const expect = chai.expect;
+const ExternalSite = require( BASE_JS_PATH + 'modules/ExternalSite' );
+
+describe( 'ExternalSite', () => {
   // TODO: Implement tests.
 } );

--- a/test/unit_tests/modules/FlyoutMenu-spec.js
+++ b/test/unit_tests/modules/FlyoutMenu-spec.js
@@ -1,33 +1,33 @@
 'use strict';
 
-var BASE_JS_PATH = '../../../cfgov/unprocessed/js/';
+const BASE_JS_PATH = '../../../cfgov/unprocessed/js/';
 
-var chai = require( 'chai' );
-var expect = chai.expect;
-var jsdom = require( 'jsdom' );
-var sinon = require( 'sinon' );
+const chai = require( 'chai' );
+const expect = chai.expect;
+const jsdom = require( 'jsdom' );
+const sinon = require( 'sinon' );
 
-var FlyoutMenu = require( BASE_JS_PATH + 'modules/behavior/FlyoutMenu' );
-var MoveTransition =
+const FlyoutMenu = require( BASE_JS_PATH + 'modules/behavior/FlyoutMenu' );
+const MoveTransition =
   require( BASE_JS_PATH + 'modules/transition/MoveTransition' );
 
-describe( 'FlyoutMenu', function() {
+describe( 'FlyoutMenu', () => {
 
-  var flyoutMenu;
+  let flyoutMenu;
 
   // Sinon-related settings.
-  var triggerClickSpy;
-  var triggerOverSpy;
-  var expandBeginSpy;
-  var expandEndSpy;
-  var collapseBeginSpy;
-  var collapseEndSpy;
+  let triggerClickSpy;
+  let triggerOverSpy;
+  let expandBeginSpy;
+  let expandEndSpy;
+  let collapseBeginSpy;
+  let collapseEndSpy;
 
   // DOM-related settings.
-  var initdom;
-  var window;
-  var document;
-  var HTML_SNIPPET =
+  let initdom;
+  let window;
+  let document;
+  const HTML_SNIPPET =
     '<div data-js-hook="behavior_flyout-menu">' +
       '<button data-js-hook="behavior_flyout-menu_trigger" ' +
               'aria-pressed="false" ' +
@@ -37,14 +37,14 @@ describe( 'FlyoutMenu', function() {
                 'aria-expanded="false"></button>' +
       '</div>' +
     '</div>';
-  var SEL_PREFIX = '[data-js-hook=behavior_flyout-menu';
+  const SEL_PREFIX = '[data-js-hook=behavior_flyout-menu';
 
-  var containerDom;
-  var triggerDom;
-  var contentDom;
-  var altTriggerDom;
+  let containerDom;
+  let triggerDom;
+  let contentDom;
+  let altTriggerDom;
 
-  beforeEach( function() {
+  beforeEach( () => {
     initdom = jsdom.jsdom( HTML_SNIPPET );
     window = initdom.defaultView;
     document = window.document;
@@ -61,14 +61,14 @@ describe( 'FlyoutMenu', function() {
     flyoutMenu = new FlyoutMenu( containerDom );
   } );
 
-  describe( '.init()', function() {
-    it( 'should have public static methods', function() {
+  describe( '.init()', () => {
+    it( 'should have public static methods', () => {
       expect( FlyoutMenu.EXPAND_TYPE ).to.equal( 'expand' );
       expect( FlyoutMenu.COLLAPSE_TYPE ).to.equal( 'collapse' );
       expect( FlyoutMenu.BASE_CLASS ).to.equal( 'behavior_flyout-menu' );
     } );
 
-    it( 'should have correct state before initializing', function() {
+    it( 'should have correct state before initializing', () => {
       expect( triggerDom.getAttribute( 'aria-pressed' ) ).to.equal( 'false' );
       expect( triggerDom.getAttribute( 'aria-expanded' ) ).to.equal( 'false' );
       expect( contentDom.getAttribute( 'aria-expanded' ) ).to.equal( 'false' );
@@ -81,13 +81,13 @@ describe( 'FlyoutMenu', function() {
       expect( flyoutMenu.getData() ).to.be.undefined;
     } );
 
-    it( 'should have correct state after initializing', function() {
+    it( 'should have correct state after initializing', () => {
       expect( flyoutMenu.init() instanceof FlyoutMenu ).to.be.true;
     } );
   } );
 
-  describe( 'mouseover/click', function() {
-    beforeEach( function() {
+  describe( 'mouseover/click', () => {
+    beforeEach( () => {
       // Set up expected event listeners.
       triggerOverSpy = sinon.spy();
       triggerClickSpy = sinon.spy();
@@ -97,10 +97,10 @@ describe( 'FlyoutMenu', function() {
       flyoutMenu.addEventListener( 'triggerClick', triggerClickSpy );
     } );
 
-    afterEach( function() {
+    afterEach( () => {
       // Check expected event broadcasts.
       expect( triggerOverSpy.callCount ).to.equal( 1 );
-      var args = triggerOverSpy.getCall( 0 ).args[0];
+      let args = triggerOverSpy.getCall( 0 ).args[0];
       expect( args.target ).to.equal( flyoutMenu );
       expect( args.type ).to.equal( 'triggerOver' );
 
@@ -110,28 +110,28 @@ describe( 'FlyoutMenu', function() {
       expect( args.type ).to.equal( 'triggerClick' );
     } );
 
-    it( 'should dispatch events when called by trigger click', function() {
+    it( 'should dispatch events when called by trigger click', () => {
       // TODO: Ideally this would use `new MouseEvent`,
       //       but how do we import MouseEvent (or Event) into Mocha.
       //       Please investigate.
-      var mouseEvent = document.createEvent( 'MouseEvents' );
+      const mouseEvent = document.createEvent( 'MouseEvents' );
       mouseEvent.initEvent( 'mouseover', true, true );
       triggerDom.dispatchEvent( mouseEvent );
       triggerDom.click();
     } );
 
-    xit( 'should dispatch events when called by alt trigger click', function() {
+    xit( 'should dispatch events when called by alt trigger click', () => {
       // TODO: alt trigger doesn't dispatch mouseover events,
       //       but it probably should to match the trigger API.
-      var mouseEvent = document.createEvent( 'MouseEvents' );
+      const mouseEvent = document.createEvent( 'MouseEvents' );
       mouseEvent.initEvent( 'mouseover', true, true );
       altTriggerDom.dispatchEvent( mouseEvent );
       altTriggerDom.click();
     } );
   } );
 
-  describe( '.expand()', function() {
-    beforeEach( function() {
+  describe( '.expand()', () => {
+    beforeEach( () => {
       // Set up expected event listeners.
       expandBeginSpy = sinon.spy();
       expandEndSpy = sinon.spy();
@@ -141,7 +141,7 @@ describe( 'FlyoutMenu', function() {
       flyoutMenu.addEventListener( 'expandEnd', expandEndSpy );
     } );
 
-    afterEach( function() {
+    afterEach( () => {
       // Check expected event broadcasts.
       expect( expandBeginSpy.callCount ).to.equal( 1 );
       var args = expandBeginSpy.getCall( 0 ).args[0];
@@ -163,23 +163,23 @@ describe( 'FlyoutMenu', function() {
     } );
 
     it( 'should dispatch events and set aria attributes, ' +
-        'when called by trigger click', function() {
+        'when called by trigger click', () => {
       triggerDom.click();
     } );
 
     it( 'should dispatch events and set aria attributes, ' +
-        'when called by alt trigger click', function() {
+        'when called by alt trigger click', () => {
       altTriggerDom.click();
     } );
 
     it( 'should dispatch events and set aria attributes, ' +
-        'when called directly', function() {
+        'when called directly', () => {
       flyoutMenu.expand();
     } );
   } );
 
-  describe( '.collapse()', function() {
-    beforeEach( function() {
+  describe( '.collapse()', () => {
+    beforeEach( () => {
       // Set up expected event listeners.
       collapseBeginSpy = sinon.spy();
       collapseEndSpy = sinon.spy();
@@ -190,7 +190,7 @@ describe( 'FlyoutMenu', function() {
       triggerDom.click();
     } );
 
-    afterEach( function() {
+    afterEach( () => {
       // Check expected event broadcasts.
       expect( collapseBeginSpy.callCount ).to.equal( 1 );
       var args = collapseBeginSpy.getCall( 0 ).args[0];
@@ -212,29 +212,29 @@ describe( 'FlyoutMenu', function() {
     } );
 
     it( 'should dispatch events and set aria attributes, ' +
-        'when called by trigger click', function() {
+        'when called by trigger click', () => {
       triggerDom.click();
     } );
 
     it( 'should dispatch events and set aria attributes, ' +
-        'when called by alt trigger click', function() {
+        'when called by alt trigger click', () => {
       altTriggerDom.click();
     } );
 
     it( 'should dispatch events and set aria attributes, ' +
-        'when called directly', function() {
+        'when called directly', () => {
       flyoutMenu.collapse();
     } );
   } );
 
-  describe( '.setExpandTransition()', function() {
+  describe( '.setExpandTransition()', () => {
     it( 'should set a transition', function( done ) {
       flyoutMenu.init();
-      var transition = new MoveTransition( contentDom ).init();
+      const transition = new MoveTransition( contentDom ).init();
       flyoutMenu.setExpandTransition( transition, transition.moveLeft );
-      flyoutMenu.addEventListener( 'expandEnd', function() {
+      flyoutMenu.addEventListener( 'expandEnd', () => {
         try {
-          var hasClass = contentDom.classList.contains( 'u-move-transition' );
+          const hasClass = contentDom.classList.contains( 'u-move-transition' );
           expect( hasClass ).to.be.true;
           done();
         } catch ( err ) {
@@ -245,15 +245,15 @@ describe( 'FlyoutMenu', function() {
     } );
   } );
 
-  describe( '.setCollapseTransition()', function() {
+  describe( '.setCollapseTransition()', () => {
     it( 'should set a transition', function( done ) {
       flyoutMenu.init();
-      var transition = new MoveTransition( contentDom ).init();
+      const transition = new MoveTransition( contentDom ).init();
       triggerDom.click();
       flyoutMenu.setCollapseTransition( transition, transition.moveLeft );
-      flyoutMenu.addEventListener( 'collapseEnd', function() {
+      flyoutMenu.addEventListener( 'collapseEnd', () => {
         try {
-          var hasClass = contentDom.classList.contains( 'u-move-transition' );
+          const hasClass = contentDom.classList.contains( 'u-move-transition' );
           expect( hasClass ).to.be.true;
           done();
         } catch ( err ) {
@@ -264,11 +264,11 @@ describe( 'FlyoutMenu', function() {
     } );
   } );
 
-  describe( '.getTransition()', function() {
-    it( 'should return a transition instance', function() {
+  describe( '.getTransition()', () => {
+    it( 'should return a transition instance', () => {
       flyoutMenu.init();
       expect( flyoutMenu.getTransition() ).to.be.undefined;
-      var transition = new MoveTransition( contentDom ).init();
+      const transition = new MoveTransition( contentDom ).init();
       flyoutMenu.setExpandTransition( transition, transition.moveLeft );
       flyoutMenu.setCollapseTransition( transition, transition.moveToOrigin );
       expect( flyoutMenu.getTransition() ).to.equal( transition );
@@ -277,13 +277,13 @@ describe( 'FlyoutMenu', function() {
     } );
   } );
 
-  describe( '.clearTransitions()', function() {
-    it( 'should remove all transitions', function() {
+  describe( '.clearTransitions()', () => {
+    it( 'should remove all transitions', () => {
       flyoutMenu.init();
-      var transition = new MoveTransition( contentDom ).init();
+      const transition = new MoveTransition( contentDom ).init();
       flyoutMenu.setExpandTransition( transition, transition.moveLeft );
       flyoutMenu.setCollapseTransition( transition, transition.moveToOrigin );
-      var hasClass = contentDom.classList.contains( 'u-move-transition' );
+      let hasClass = contentDom.classList.contains( 'u-move-transition' );
       expect( hasClass ).to.be.true;
       flyoutMenu.clearTransitions();
       expect( flyoutMenu.getTransition() ).to.be.undefined;
@@ -292,10 +292,10 @@ describe( 'FlyoutMenu', function() {
     } );
   } );
 
-  describe( '.getDom()', function() {
-    it( 'should return references to full dom', function() {
+  describe( '.getDom()', () => {
+    it( 'should return references to full dom', () => {
       flyoutMenu.init();
-      var dom = flyoutMenu.getDom();
+      const dom = flyoutMenu.getDom();
       expect( dom.container ).to.equal( containerDom );
       expect( dom.trigger ).to.equal( triggerDom );
       expect( dom.content ).to.equal( contentDom );
@@ -303,8 +303,8 @@ describe( 'FlyoutMenu', function() {
     } );
   } );
 
-  describe( 'suspend/resume behavior', function() {
-    beforeEach( function() {
+  describe( 'suspend/resume behavior', () => {
+    beforeEach( () => {
       // Set up expected event listeners.
       expandBeginSpy = sinon.spy();
       expandEndSpy = sinon.spy();
@@ -317,8 +317,8 @@ describe( 'FlyoutMenu', function() {
       flyoutMenu.addEventListener( 'collapseEnd', collapseEndSpy );
     } );
 
-    describe( '.suspend()', function() {
-      it( 'should not broadcast events after being suspended', function() {
+    describe( '.suspend()', () => {
+      it( 'should not broadcast events after being suspended', () => {
         // Set up expected event listeners.
         flyoutMenu.suspend();
         triggerDom.click();
@@ -329,8 +329,8 @@ describe( 'FlyoutMenu', function() {
       } );
     } );
 
-    describe( '.resume()', function() {
-      it( 'should broadcast events after resuming from suspended', function() {
+    describe( '.resume()', () => {
+      it( 'should broadcast events after resuming from suspended', () => {
         // Set up expected event listeners.
         flyoutMenu.suspend();
         flyoutMenu.resume();
@@ -345,26 +345,26 @@ describe( 'FlyoutMenu', function() {
 
   } );
 
-  describe( '.setData()', function() {
-    it( 'should return the instance when set', function() {
+  describe( '.setData()', () => {
+    it( 'should return the instance when set', () => {
       flyoutMenu.init();
       var inst = flyoutMenu.setData( 'test-data' );
       expect( inst instanceof FlyoutMenu ).to.be.true;
     } );
   } );
 
-  describe( '.getData()', function() {
-    it( 'should return the set data', function() {
+  describe( '.getData()', () => {
+    it( 'should return the set data', () => {
       flyoutMenu.init();
       flyoutMenu.setData( 'test-data' );
       expect( flyoutMenu.getData() ).to.equal( 'test-data' );
     } );
   } );
 
-  describe( '.isAnimating()', function() {
+  describe( '.isAnimating()', () => {
     it( 'should return true when expanding', function( done ) {
       flyoutMenu.init();
-      flyoutMenu.addEventListener( 'expandBegin', function() {
+      flyoutMenu.addEventListener( 'expandBegin', () => {
         try {
           expect( flyoutMenu.isAnimating() ).to.be.true;
           done();
@@ -377,7 +377,7 @@ describe( 'FlyoutMenu', function() {
 
     it( 'should return false after expanding', function( done ) {
       flyoutMenu.init();
-      flyoutMenu.addEventListener( 'expandEnd', function() {
+      flyoutMenu.addEventListener( 'expandEnd', () => {
         try {
           expect( flyoutMenu.isAnimating() ).to.be.false;
           done();
@@ -390,7 +390,7 @@ describe( 'FlyoutMenu', function() {
 
     it( 'should return true while collapsing', function( done ) {
       flyoutMenu.init();
-      flyoutMenu.addEventListener( 'collapseBegin', function() {
+      flyoutMenu.addEventListener( 'collapseBegin', () => {
         try {
           expect( flyoutMenu.isAnimating() ).to.be.true;
           done();
@@ -404,7 +404,7 @@ describe( 'FlyoutMenu', function() {
 
     it( 'should return false after collapsing', function( done ) {
       flyoutMenu.init();
-      flyoutMenu.addEventListener( 'collapseEnd', function() {
+      flyoutMenu.addEventListener( 'collapseEnd', () => {
         try {
           expect( flyoutMenu.isAnimating() ).to.be.false;
           done();
@@ -417,10 +417,10 @@ describe( 'FlyoutMenu', function() {
     } );
   } );
 
-  describe( '.isExpanded()', function() {
+  describe( '.isExpanded()', () => {
     it( 'should return false before expanding', function( done ) {
       flyoutMenu.init();
-      flyoutMenu.addEventListener( 'expandBegin', function() {
+      flyoutMenu.addEventListener( 'expandBegin', () => {
         try {
           expect( flyoutMenu.isExpanded() ).to.be.false;
           done();
@@ -433,7 +433,7 @@ describe( 'FlyoutMenu', function() {
 
     it( 'should return true after expanding', function( done ) {
       flyoutMenu.init();
-      flyoutMenu.addEventListener( 'expandEnd', function() {
+      flyoutMenu.addEventListener( 'expandEnd', () => {
         try {
           expect( flyoutMenu.isExpanded() ).to.be.true;
           done();
@@ -447,7 +447,7 @@ describe( 'FlyoutMenu', function() {
     it( 'should return true before collapsing', function( done ) {
       flyoutMenu.init();
       triggerDom.click();
-      flyoutMenu.addEventListener( 'triggerClick', function() {
+      flyoutMenu.addEventListener( 'triggerClick', () => {
         try {
           expect( flyoutMenu.isExpanded() ).to.be.true;
           done();
@@ -460,7 +460,7 @@ describe( 'FlyoutMenu', function() {
 
     it( 'should return false after collapsing', function( done ) {
       flyoutMenu.init();
-      flyoutMenu.addEventListener( 'collapseEnd', function() {
+      flyoutMenu.addEventListener( 'collapseEnd', () => {
         try {
           expect( flyoutMenu.isExpanded() ).to.be.false;
           done();

--- a/test/unit_tests/modules/Tree-spec.js
+++ b/test/unit_tests/modules/Tree-spec.js
@@ -1,35 +1,35 @@
 'use strict';
 
-var BASE_JS_PATH = '../../../cfgov/unprocessed/js/';
+const BASE_JS_PATH = '../../../cfgov/unprocessed/js/';
 
-var chai = require( 'chai' );
-var expect = chai.expect;
-var Tree = require( BASE_JS_PATH + 'modules/Tree' );
+const chai = require( 'chai' );
+const expect = chai.expect;
+const Tree = require( BASE_JS_PATH + 'modules/Tree' );
 
-describe( 'Tree', function() {
-  var tree;
+describe( 'Tree', () => {
+  let tree;
 
-  beforeEach( function() {
+  beforeEach( () => {
     tree = new Tree();
   } );
 
-  describe( '.init()', function() {
-    it( 'should have a proper state before initialization', function() {
+  describe( '.init()', () => {
+    it( 'should have a proper state before initialization', () => {
       expect( tree instanceof Tree ).to.be.true;
       expect( tree.getRoot() ).to.be.null;
       expect( tree.getAllAtLevel( 0 ) instanceof Array ).to.be.true;
       expect( tree.getAllAtLevel( 0 ).length ).to.equal( 0 );
     } );
 
-    it( 'should have a proper state after initialization', function() {
+    it( 'should have a proper state after initialization', () => {
       expect( tree.init( 'R' ) instanceof Tree ).to.be.true;
       expect( tree.getRoot().constructor.name === 'TreeNode' ).to.be.true;
       expect( tree.getAllAtLevel( 0 ) instanceof Array ).to.be.true;
     } );
   } );
 
-  describe( '.getRoot()', function() {
-    it( 'should have a properly initialized root node', function() {
+  describe( '.getRoot()', () => {
+    it( 'should have a properly initialized root node', () => {
       tree.init( 'R' );
       expect( tree.getRoot() ).to.not.be.null;
       expect( tree.getRoot().constructor.name === 'TreeNode' ).to.be.true;
@@ -41,10 +41,10 @@ describe( 'Tree', function() {
     } );
   } );
 
-  describe( '.getAllAtLevel()', function() {
-    it( 'should return the root level', function() {
+  describe( '.getAllAtLevel()', () => {
+    it( 'should return the root level', () => {
       tree.init( 'R' );
-      var nodeR = tree.getRoot();
+      const nodeR = tree.getRoot();
       expect( tree.getAllAtLevel( 0 )[0] ).to.equal( nodeR );
     } );
 
@@ -54,11 +54,11 @@ describe( 'Tree', function() {
      *       / \
      *      A   B
      */
-    it( 'should return the first level', function() {
+    it( 'should return the first level', () => {
       tree.init( 'R' );
-      var nodeR = tree.getRoot();
-      var nodeA = tree.add( 'A', nodeR );
-      var nodeB = tree.add( 'B', nodeR );
+      const nodeR = tree.getRoot();
+      const nodeA = tree.add( 'A', nodeR );
+      const nodeB = tree.add( 'B', nodeR );
       expect( tree.getAllAtLevel( 0 )[0] ).to.equal( nodeR );
       expect( tree.getAllAtLevel( 1 )[0] ).to.equal( nodeA );
       expect( tree.getAllAtLevel( 1 )[1] ).to.equal( nodeB );
@@ -72,12 +72,12 @@ describe( 'Tree', function() {
      *    /
      *   C
      */
-    it( 'should return the second level', function() {
+    it( 'should return the second level', () => {
       tree.init( 'R' );
-      var nodeR = tree.getRoot();
-      var nodeA = tree.add( 'A', nodeR );
-      var nodeB = tree.add( 'B', nodeR );
-      var nodeC = tree.add( 'C', nodeA );
+      const nodeR = tree.getRoot();
+      const nodeA = tree.add( 'A', nodeR );
+      const nodeB = tree.add( 'B', nodeR );
+      const nodeC = tree.add( 'C', nodeA );
       expect( tree.getAllAtLevel( 0 )[0] ).to.equal( nodeR );
       expect( tree.getAllAtLevel( 1 )[0] ).to.equal( nodeA );
       expect( tree.getAllAtLevel( 1 )[1] ).to.equal( nodeB );
@@ -85,11 +85,11 @@ describe( 'Tree', function() {
     } );
   } );
 
-  describe( '.add()', function() {
-    it( 'should have a properly initialzed child node', function() {
+  describe( '.add()', () => {
+    it( 'should have a properly initialzed child node', () => {
       tree.init( 'R' );
-      var nodeR = tree.getRoot();
-      var nodeA = tree.add( 'A', nodeR );
+      const nodeR = tree.getRoot();
+      const nodeA = tree.add( 'A', nodeR );
       expect( nodeA ).to.not.be.null;
       expect( nodeA.constructor.name === 'TreeNode' ).to.be.true;
       expect( nodeA.tree ).to.equal( tree );
@@ -103,8 +103,8 @@ describe( 'Tree', function() {
     } );
   } );
 
-  describe( '.remove()', function() {
-    xit( 'should have a properly initialized tree', function() {
+  describe( '.remove()', () => {
+    xit( 'should have a properly initialized tree', () => {
       // TODO: Implement tree.remove() method.
     } );
   } );

--- a/test/unit_tests/modules/UStreamPlayer-spec.js
+++ b/test/unit_tests/modules/UStreamPlayer-spec.js
@@ -1,10 +1,11 @@
 'use strict';
-var BASE_JS_PATH = '../../../cfgov/unprocessed/js/';
 
-var chai = require( 'chai' );
-var expect = chai.expect;
-var UStreamPlayer = require( BASE_JS_PATH + 'modules/UStreamPlayer' );
+const BASE_JS_PATH = '../../../cfgov/unprocessed/js/';
 
-describe( 'UStreamPlayer', function() {
+const chai = require( 'chai' );
+const expect = chai.expect;
+const UStreamPlayer = require( BASE_JS_PATH + 'modules/UStreamPlayer' );
+
+describe( 'UStreamPlayer', () => {
   // TODO: Implement tests.
 } );

--- a/test/unit_tests/modules/VideoPlayer-spec.js
+++ b/test/unit_tests/modules/VideoPlayer-spec.js
@@ -1,10 +1,11 @@
 'use strict';
-var BASE_JS_PATH = '../../../cfgov/unprocessed/js/';
 
-var chai = require( 'chai' );
-var expect = chai.expect;
-var VideoPlayer = require( BASE_JS_PATH + 'modules/VideoPlayer' );
+const BASE_JS_PATH = '../../../cfgov/unprocessed/js/';
 
-describe( 'VideoPlayer', function() {
+const chai = require( 'chai' );
+const expect = chai.expect;
+const VideoPlayer = require( BASE_JS_PATH + 'modules/VideoPlayer' );
+
+describe( 'VideoPlayer', () => {
   // TODO: Implement tests.
 } );

--- a/test/unit_tests/modules/YouTubePlayer-spec.js
+++ b/test/unit_tests/modules/YouTubePlayer-spec.js
@@ -1,10 +1,11 @@
 'use strict';
-var BASE_JS_PATH = '../../../cfgov/unprocessed/js/';
 
-var chai = require( 'chai' );
-var expect = chai.expect;
-var YoutubePlayer = require( BASE_JS_PATH + 'modules/YoutubePlayer' );
+const BASE_JS_PATH = '../../../cfgov/unprocessed/js/';
 
-describe( 'YoutubePlayer', function() {
+const chai = require( 'chai' );
+const expect = chai.expect;
+const YoutubePlayer = require( BASE_JS_PATH + 'modules/YoutubePlayer' );
+
+describe( 'YoutubePlayer', () => {
   // TODO: Implement tests.
 } );

--- a/test/unit_tests/modules/o-table-row-links-spec.js
+++ b/test/unit_tests/modules/o-table-row-links-spec.js
@@ -1,20 +1,20 @@
 'use strict';
 
-var BASE_JS_PATH = '../../../cfgov/unprocessed/js/';
-var simpleTableRowLinks =
+const BASE_JS_PATH = '../../../cfgov/unprocessed/js/';
+const simpleTableRowLinks =
   require( BASE_JS_PATH + 'modules/o-table-row-links' );
 
-var chai = require( 'chai' );
-var expect = chai.expect;
-var jsdom = require( 'mocha-jsdom' );
-var sinon = require( 'sinon' );
-var sandbox;
-var tableDom;
-var linkDom;
-var linkRowCellDom;
-var nonLinkRowCellDom;
+const chai = require( 'chai' );
+const expect = chai.expect;
+const jsdom = require( 'mocha-jsdom' );
+const sinon = require( 'sinon' );
+let sandbox;
+let tableDom;
+let linkDom;
+let linkRowCellDom;
+let nonLinkRowCellDom;
 
-var HTML_SNIPPET =
+const HTML_SNIPPET =
   '<table class="o-table__row-links">' +
   '<tbody>' +
     '<tr>' +
@@ -39,10 +39,10 @@ function triggerClickEvent( target ) {
 }
 
 
-describe( 'o-table-row-links', function() {
+describe( 'o-table-row-links', () => {
   jsdom();
-  beforeEach( function() {
-    var windowLocation;
+  beforeEach( () => {
+    let windowLocation;
     sandbox = sinon.sandbox.create();
 
     document.body.innerHTML = HTML_SNIPPET;
@@ -52,7 +52,7 @@ describe( 'o-table-row-links', function() {
     nonLinkRowCellDom = tableDom.querySelector( '.nonLinkRowCell' );
 
     Object.defineProperty( window, 'location', {
-      get: function() { return windowLocation; },
+      get: () => windowLocation,
       set: function( location ) {
         windowLocation = location;
       },
@@ -71,24 +71,26 @@ describe( 'o-table-row-links', function() {
     simpleTableRowLinks.init();
   } );
 
-  afterEach( function() {
+  afterEach( () => {
     sandbox.restore();
   } );
 
-  it( 'should navigate to new location when link row cell clicked', function() {
+  it( 'should navigate to new location when link row cell clicked', () => {
     triggerClickEvent( linkRowCellDom );
     expect( window.location ).to.equal( 'http://www.example.info' );
   } );
 
   it( 'should bubble click events to the parent element when a link is clicked',
-  function() {
-    triggerClickEvent( linkDom );
-    expect( window.location ).to.equal( 'http://www.example.info' );
-  } );
+    () => {
+      triggerClickEvent( linkDom );
+      expect( window.location ).to.equal( 'http://www.example.info' );
+    }
+  );
 
   it( 'should not navigate to new location when non link row cell clicked',
-  function() {
-    triggerClickEvent( nonLinkRowCellDom );
-    expect( window.location ).to.equal( 'http://www.example.com' );
-  } );
+    () => {
+      triggerClickEvent( nonLinkRowCellDom );
+      expect( window.location ).to.equal( 'http://www.example.com' );
+    }
+  );
 } );

--- a/test/unit_tests/modules/transition/AlphaTransition-spec.js
+++ b/test/unit_tests/modules/transition/AlphaTransition-spec.js
@@ -1,14 +1,14 @@
 'use strict';
 
-var BASE_JS_PATH = '../../../../cfgov/unprocessed/js/';
+const BASE_JS_PATH = '../../../../cfgov/unprocessed/js/';
 
-var chai = require( 'chai' );
-var expect = chai.expect;
-var jsdom = require( 'jsdom' );
+const chai = require( 'chai' );
+const expect = chai.expect;
+const jsdom = require( 'jsdom' );
 
-var AlphaTransition =
+const AlphaTransition =
   require( BASE_JS_PATH + 'modules/transition/AlphaTransition' );
 
-describe( 'AlphaTransition', function() {
+describe( 'AlphaTransition', () => {
   // TODO: Implement tests.
 } );

--- a/test/unit_tests/modules/transition/BaseTransition-spec.js
+++ b/test/unit_tests/modules/transition/BaseTransition-spec.js
@@ -1,27 +1,27 @@
 'use strict';
 
-var BASE_JS_PATH = '../../../../cfgov/unprocessed/js/';
+const BASE_JS_PATH = '../../../../cfgov/unprocessed/js/';
 
-var chai = require( 'chai' );
-var expect = chai.expect;
-var jsdom = require( 'jsdom' );
+const chai = require( 'chai' );
+const expect = chai.expect;
+const jsdom = require( 'jsdom' );
 
-var BaseTransition =
+const BaseTransition =
   require( BASE_JS_PATH + 'modules/transition/BaseTransition' );
 
-describe( 'BaseTransition', function() {
+describe( 'BaseTransition', () => {
 
-  var transition;
+  let transition;
 
   // DOM-related settings.
-  var initdom;
-  var document;
-  var HTML_SNIPPET = '<div class="content-1"></div>' +
+  let initdom;
+  let document;
+  const HTML_SNIPPET = '<div class="content-1"></div>' +
                      '<div class="content-2"></div>';
-  var contentDom;
-  var content2Dom;
+  let contentDom;
+  let content2Dom;
 
-  beforeEach( function() {
+  beforeEach( () => {
     initdom = jsdom.jsdom( HTML_SNIPPET );
     document = initdom.defaultView.document;
     contentDom = document.querySelector( '.content-1' );
@@ -30,27 +30,27 @@ describe( 'BaseTransition', function() {
       new BaseTransition( contentDom, { BASE_CLASS: 'u-test-transition' } );
   } );
 
-  describe( '.init()', function() {
-    it( 'should have public static methods', function() {
+  describe( '.init()', () => {
+    it( 'should have public static methods', () => {
       expect( BaseTransition.BEGIN_EVENT ).to.equal( 'transitionBegin' );
       expect( BaseTransition.END_EVENT ).to.equal( 'transitionEnd' );
       expect( BaseTransition.NO_ANIMATION_CLASS ).to.equal( 'u-no-animation' );
     } );
 
-    it( 'should have correct state before initializing', function() {
+    it( 'should have correct state before initializing', () => {
       expect( transition.isAnimated() ).to.be.false;
       expect( transition.remove() ).to.be.false;
       expect( transition.animateOn() instanceof BaseTransition ).to.be.true;
       expect( transition.animateOff() instanceof BaseTransition ).to.be.true;
     } );
 
-    it( 'should have correct state after initializing', function() {
+    it( 'should have correct state after initializing', () => {
       expect( transition.init() instanceof BaseTransition ).to.be.true;
     } );
   } );
 
-  describe( '.setElement()', function() {
-    it( 'should move classes from old element to new element', function() {
+  describe( '.setElement()', () => {
+    it( 'should move classes from old element to new element', () => {
       var className = 'u-test-transition';
       expect( contentDom.classList.contains( className ) ).to.be.false;
       transition.init();
@@ -61,18 +61,18 @@ describe( 'BaseTransition', function() {
     } );
   } );
 
-  describe( '.halt()', function() {
-    xit( 'should immediately fire transition end event', function() {
+  describe( '.halt()', () => {
+    xit( 'should immediately fire transition end event', () => {
       // TODO: To test halt() the transition needs to be started and
       //       then halt() needs to be called before the transition
       //       duration has completed.
     } );
   } );
 
-  describe( '.remove()', function() {
-    it( 'should remove transition classes from element', function() {
+  describe( '.remove()', () => {
+    it( 'should remove transition classes from element', () => {
       transition.init();
-      var hasClass = contentDom.classList.contains( 'u-test-transition' );
+      let hasClass = contentDom.classList.contains( 'u-test-transition' );
       expect( hasClass ).to.be.true;
       expect( transition.remove() ).to.be.true;
       hasClass = contentDom.classList.contains( 'u-test-transition' );
@@ -80,60 +80,60 @@ describe( 'BaseTransition', function() {
     } );
   } );
 
-  describe( '.isAnimated()', function() {
-    beforeEach( function() {
+  describe( '.isAnimated()', () => {
+    beforeEach( () => {
       transition.init();
     } );
 
-    it( 'should be true after animation is initialized', function() {
+    it( 'should be true after animation is initialized', () => {
       expect( transition.isAnimated() ).to.be.true;
     } );
 
-    it( 'should be true after animation is turned On', function() {
+    it( 'should be true after animation is turned On', () => {
       transition.animateOn();
       expect( transition.isAnimated() ).to.be.true;
     } );
 
-    it( 'should be false after animation is turned Off', function() {
+    it( 'should be false after animation is turned Off', () => {
       transition.animateOff();
       expect( transition.isAnimated() ).to.be.false;
     } );
   } );
 
-  describe( '.animateOff()', function() {
-    beforeEach( function() {
+  describe( '.animateOff()', () => {
+    beforeEach( () => {
       transition.init();
     } );
 
-    it( 'should return an instance', function() {
+    it( 'should return an instance', () => {
       expect( transition.animateOff() instanceof BaseTransition ).to.be.true;
     } );
 
-    it( 'should set u-no-animation class when called', function() {
+    it( 'should set u-no-animation class when called', () => {
       expect( contentDom.classList.contains( 'u-no-animation' ) ).to.be.false;
       transition.animateOff();
       expect( contentDom.classList.contains( 'u-no-animation' ) ).to.be.true;
     } );
   } );
 
-  describe( '.animateOn()', function() {
-    beforeEach( function() {
+  describe( '.animateOn()', () => {
+    beforeEach( () => {
       transition.init();
     } );
 
-    it( 'should return an instance', function() {
+    it( 'should return an instance', () => {
       expect( transition.animateOn() instanceof BaseTransition ).to.be.true;
     } );
 
-    it( 'should remove u-no-animation class, if set', function() {
+    it( 'should remove u-no-animation class, if set', () => {
       transition.animateOff();
       transition.animateOn();
       expect( contentDom.classList.contains( 'u-no-animation' ) ).to.be.false;
     } );
   } );
 
-  describe( '.applyClass()', function() {
-    it( 'should apply a class', function() {
+  describe( '.applyClass()', () => {
+    it( 'should apply a class', () => {
       expect( transition.applyClass( 'u-test-transition' ) ).to.be.false;
       transition.init();
       contentDom.classList.remove( 'u-test-transition' );

--- a/test/unit_tests/modules/transition/MoveTransition-spec.js
+++ b/test/unit_tests/modules/transition/MoveTransition-spec.js
@@ -1,14 +1,14 @@
 'use strict';
 
-var BASE_JS_PATH = '../../../../cfgov/unprocessed/js/';
+const BASE_JS_PATH = '../../../../cfgov/unprocessed/js/';
 
-var chai = require( 'chai' );
-var expect = chai.expect;
-var jsdom = require( 'jsdom' );
+const chai = require( 'chai' );
+const expect = chai.expect;
+const jsdom = require( 'jsdom' );
 
-var MoveTransition =
+const MoveTransition =
   require( BASE_JS_PATH + 'modules/transition/MoveTransition' );
 
-describe( 'MoveTransition', function() {
+describe( 'MoveTransition', () => {
   // TODO: Implement tests.
 } );

--- a/test/unit_tests/modules/util/EventObserver-spec.js
+++ b/test/unit_tests/modules/util/EventObserver-spec.js
@@ -1,11 +1,11 @@
 'use strict';
 
-var BASE_JS_PATH = '../../../../cfgov/unprocessed/js/';
+const BASE_JS_PATH = '../../../../cfgov/unprocessed/js/';
 
-var chai = require( 'chai' );
-var expect = chai.expect;
-var EventObserver = require( BASE_JS_PATH + 'modules/util/EventObserver' );
+const chai = require( 'chai' );
+const expect = chai.expect;
+const EventObserver = require( BASE_JS_PATH + 'modules/util/EventObserver' );
 
-describe( 'EventObserver', function() {
+describe( 'EventObserver', () => {
   // TODO: Implement tests.
 } );

--- a/test/unit_tests/modules/util/array-helpers-spec.js
+++ b/test/unit_tests/modules/util/array-helpers-spec.js
@@ -1,23 +1,23 @@
 'use strict';
 
-var BASE_JS_PATH = '../../../../cfgov/unprocessed/js/';
+const BASE_JS_PATH = '../../../../cfgov/unprocessed/js/';
 
-var chai = require( 'chai' );
-var expect = chai.expect;
-var arrayHelpers = require( BASE_JS_PATH + 'modules/util/array-helpers' );
-var array;
-var index;
+const chai = require( 'chai' );
+const expect = chai.expect;
+const arrayHelpers = require( BASE_JS_PATH + 'modules/util/array-helpers' );
+let array;
+let index;
 
-describe( 'Array Helpers indexOfObject', function() {
+describe( 'Array Helpers indexOfObject', () => {
 
-  it( 'should return -1 if the array is empty', function() {
+  it( 'should return -1 if the array is empty', () => {
     array = [];
     index = arrayHelpers.indexOfObject( array, 'foo' );
 
     expect( index ).to.equal( -1 );
   } );
 
-  it( 'should return -1 if there is no match', function() {
+  it( 'should return -1 if there is no match', () => {
     array = [
       { value: 'bar' },
       { value: 'baz' }
@@ -27,7 +27,7 @@ describe( 'Array Helpers indexOfObject', function() {
     expect( index ).to.equal( -1 );
   } );
 
-  it( 'should return the matched index', function() {
+  it( 'should return the matched index', () => {
     array = [
       { value: 'foo' },
       { value: 'bar' },

--- a/test/unit_tests/modules/util/assign-spec.js
+++ b/test/unit_tests/modules/util/assign-spec.js
@@ -1,21 +1,21 @@
 'use strict';
 
-var BASE_JS_PATH = '../../../../cfgov/unprocessed/js/';
+const BASE_JS_PATH = '../../../../cfgov/unprocessed/js/';
 
-var chai = require( 'chai' );
-var expect = chai.expect;
-var assign = require( BASE_JS_PATH + 'modules/util/assign.js' ).assign;
-var testObjectA;
-var testObjectB;
-var testObjectC;
-var undefinedVar;
+const chai = require( 'chai' );
+const expect = chai.expect;
+const assign = require( BASE_JS_PATH + 'modules/util/assign.js' ).assign;
+let testObjectA;
+let testObjectB;
+let testObjectC;
+let undefinedVar;
 
 
-beforeEach( function() {
+beforeEach( () => {
 
   testObjectA = {
     str:  'test',
-    func: function() { return 'testStr'; },
+    func: () => 'testStr',
     num:  1
   };
 
@@ -33,9 +33,9 @@ beforeEach( function() {
 
 } );
 
-describe( 'Assign', function() {
+describe( 'Assign', () => {
 
-  it( 'should assign properties from source to destination', function() {
+  it( 'should assign properties from source to destination', () => {
     assign( testObjectA, testObjectB );
 
     expect( testObjectA.hasOwnProperty( 'obj' ) ).to.be.true;
@@ -43,7 +43,7 @@ describe( 'Assign', function() {
     expect( testObjectA.hasOwnProperty( '_null' ) ).to.be.true;
   } );
 
-  it( 'should assign values from source to destination', function() {
+  it( 'should assign values from source to destination', () => {
     assign( testObjectA, testObjectB );
 
     expect( testObjectA.obj.test === 2 ).to.be.true;
@@ -51,7 +51,7 @@ describe( 'Assign', function() {
     expect( testObjectA._null === null ).to.be.true;
   } );
 
-  it( 'should assign multiple source properties to destination', function() {
+  it( 'should assign multiple source properties to destination', () => {
     assign( testObjectA, testObjectB, testObjectC );
 
     expect( testObjectA.hasOwnProperty( 'bool' ) ).to.be.true;
@@ -59,7 +59,7 @@ describe( 'Assign', function() {
     expect( testObjectA.hasOwnProperty( 'num' ) ).to.be.true;
   } );
 
-  it( 'should assign multiple source values to destination', function() {
+  it( 'should assign multiple source values to destination', () => {
     assign( testObjectA, testObjectB, testObjectC );
 
     expect( testObjectA.bool === false ).to.be.true;
@@ -67,7 +67,7 @@ describe( 'Assign', function() {
     expect( testObjectA.num === 4 ).to.be.true;
   } );
 
-  it( 'should selectively overwrite existing source properties', function() {
+  it( 'should selectively overwrite existing source properties', () => {
     expect( testObjectA.num === 1 ).to.be.true;
 
     assign( testObjectA, testObjectC );

--- a/test/unit_tests/modules/util/atomic-helpers-spec.js
+++ b/test/unit_tests/modules/util/atomic-helpers-spec.js
@@ -1,91 +1,88 @@
 'use strict';
 
-var BASE_JS_PATH = '../../../../cfgov/unprocessed/js/';
+const BASE_JS_PATH = '../../../../cfgov/unprocessed/js/';
 
-var chai = require( 'chai' );
-var expect = chai.expect;
-var jsdom = require( 'jsdom' );
+const chai = require( 'chai' );
+const expect = chai.expect;
+const jsdom = require( 'jsdom' );
 
-var atomicHelpers = require( BASE_JS_PATH + 'modules/util/atomic-helpers' );
+const atomicHelpers = require( BASE_JS_PATH + 'modules/util/atomic-helpers' );
 
-describe( 'atomic-helpers', function() {
+describe( 'atomic-helpers', () => {
 
-  var HTML_SNIPPET = '<div class="container">' +
-                     '<div class="o-expandable"></div></div>';
-  var initdom = jsdom.jsdom( HTML_SNIPPET );
-  var document = initdom.defaultView.document;
+  const HTML_SNIPPET = '<div class="container">' +
+                       '<div class="o-expandable"></div></div>';
+  const initdom = jsdom.jsdom( HTML_SNIPPET );
+  const document = initdom.defaultView.document;
 
-  var containerDom;
-  var expandableDom;
+  let containerDom;
+  let expandableDom;
 
-  before( function() {
+  before( () => {
     containerDom = document.querySelector( '.container' );
     expandableDom = document.querySelector( '.o-expandable' );
   } );
 
-  describe( '.checkDom()', function() {
-    it( 'should throw an error if element DOM not found', function() {
-      var errMsg = 'null is not valid. ' +
-                   'Check that element is a DOM node with ' +
-                   'class ".o-expandable"';
+  describe( '.checkDom()', () => {
+    it( 'should throw an error if element DOM not found', () => {
+      const errMsg = 'null is not valid. ' +
+                     'Check that element is a DOM node with ' +
+                     'class ".o-expandable"';
       function errFunc() {
         atomicHelpers.checkDom( null, '.o-expandable' );
       }
       expect( errFunc ).to.throw( Error, errMsg );
     } );
 
-    it( 'should throw an error if element class not found', function() {
-      var errMsg = 'mock-class not found on or in passed DOM node.';
+    it( 'should throw an error if element class not found', () => {
+      const errMsg = 'mock-class not found on or in passed DOM node.';
       function errFunc() {
         atomicHelpers.checkDom( expandableDom, 'mock-class' );
       }
       expect( errFunc ).to.throw( Error, errMsg );
     } );
 
-    it( 'should return the correct HTMLElement ' +
-        'when direct element is searched', function() {
-      var dom =
-        atomicHelpers.checkDom( expandableDom, 'o-expandable' );
+    it( 'should return the correct HTMLElement when direct element is searched',
+    () => {
+      const dom = atomicHelpers.checkDom( expandableDom, 'o-expandable' );
       expect( dom ).to.be.equal( expandableDom );
     } );
 
-    it( 'should return the correct HTMLElement ' +
-        'when parent element is searched', function() {
-      var dom =
-        atomicHelpers.checkDom( containerDom, 'o-expandable' );
+    it( 'should return the correct HTMLElement when parent element is searched',
+    () => {
+      const dom = atomicHelpers.checkDom( containerDom, 'o-expandable' );
       expect( dom ).to.be.equal( expandableDom );
     } );
   } );
 
-  describe( '.instantiateAll()', function() {
-    xit( 'should return an array of instances', function() {
+  describe( '.instantiateAll()', () => {
+    xit( 'should return an array of instances', () => {
       // TODO: Implement test.
     } );
   } );
 
-  describe( '.setInitFlag()', function() {
-    it( 'should return true when init flag is set', function() {
+  describe( '.setInitFlag()', () => {
+    it( 'should return true when init flag is set', () => {
       expect( atomicHelpers.setInitFlag( expandableDom ) ).to.be.true;
     } );
 
-    it( 'should return false when init flag is already set', function() {
+    it( 'should return false when init flag is already set', () => {
       atomicHelpers.setInitFlag( expandableDom );
       expect( atomicHelpers.setInitFlag( expandableDom ) ).to.be.false;
     } );
   } );
 
-  describe( '.destroyInitFlag()', function() {
+  describe( '.destroyInitFlag()', () => {
 
     beforeEach( function() {
       atomicHelpers.setInitFlag( expandableDom );
     } );
 
-    it( 'should return true when init flag is removed', function() {
+    it( 'should return true when init flag is removed', () => {
       expect( atomicHelpers.destroyInitFlag( expandableDom ) ).to.be.true;
     } );
 
-    it( 'should return false when init ' +
-        'flag has already been removed', function() {
+    it( 'should return false when init flag has already been removed', () => {
       atomicHelpers.destroyInitFlag( expandableDom );
       expect( atomicHelpers.destroyInitFlag( expandableDom ) ).to.be.false;
     } );

--- a/test/unit_tests/modules/util/behavior-spec.js
+++ b/test/unit_tests/modules/util/behavior-spec.js
@@ -1,15 +1,16 @@
 'use strict';
-var BASE_JS_PATH = '../../../../cfgov/unprocessed/js/';
-var chai = require( 'chai' );
-var expect = chai.expect;
-var jsdom = require( 'mocha-jsdom' );
-var sinon = require( 'sinon' );
-var sandbox;
 
-var behavior = require( BASE_JS_PATH + 'modules/util/behavior' );
+const BASE_JS_PATH = '../../../../cfgov/unprocessed/js/';
+const chai = require( 'chai' );
+const expect = chai.expect;
+const jsdom = require( 'mocha-jsdom' );
+const sinon = require( 'sinon' );
+let sandbox;
+
+const behavior = require( BASE_JS_PATH + 'modules/util/behavior' );
 
 function triggerEvent( target, eventType, eventOption ) {
-  var event = document.createEvent( 'Event' );
+  const event = document.createEvent( 'Event' );
   if ( eventType === 'keyup' ) {
     event.keyCode = eventOption || '';
   }
@@ -20,85 +21,83 @@ function triggerEvent( target, eventType, eventOption ) {
 describe( 'behavior', function() {
   jsdom();
 
-  var HTML_SNIPPET =
-  '<a href="#main" id="skip-nav">Skip to main content</a>' +
-  '<a class="o-mega-menu_content-link o-mega-menu_content-1-link"' +
-      'data-js-hook="behavior_flyout-menu_trigger">' +
-        'Consumer Tools' +
-  '</a>' +
-  '<a class="o-mega-menu_content-link o-mega-menu_content-1-link"' +
-      'data-js-hook="behavior_flyout-menu_trigger">' +
-        'Educational Resources' +
-  '</a>' +
-  '<div data-js-hook="behavior_flyout-menu">' +
-      '<div data-js-hook="behavior_flyout-menu_content"></div>' +
-  '</div>';
+  const HTML_SNIPPET =
+    '<a href="#main" id="skip-nav">Skip to main content</a>' +
+    '<a class="o-mega-menu_content-link o-mega-menu_content-1-link"' +
+        'data-js-hook="behavior_flyout-menu_trigger">' +
+          'Consumer Tools' +
+    '</a>' +
+    '<a class="o-mega-menu_content-link o-mega-menu_content-1-link"' +
+        'data-js-hook="behavior_flyout-menu_trigger">' +
+          'Educational Resources' +
+    '</a>' +
+    '<div data-js-hook="behavior_flyout-menu">' +
+        '<div data-js-hook="behavior_flyout-menu_content"></div>' +
+    '</div>';
 
-  var containerDom;
-  var behaviorElmDom;
-  var selector = 'data-js-hook=behavior_flyout-menu';
+  let containerDom;
+  let behaviorElmDom;
+  const selector = 'data-js-hook=behavior_flyout-menu';
 
-  beforeEach( function() {
+  beforeEach( () => {
     sandbox = sinon.sandbox.create();
     document.body.innerHTML = HTML_SNIPPET;
     containerDom = document.querySelector( '[' + selector + ']' );
     behaviorElmDom = document.querySelector( '[' + selector + '_content]' );
   } );
 
-  afterEach( function() {
+  afterEach( () => {
     sandbox.restore();
   } );
 
-  describe( 'attach function', function() {
+  describe( 'attach function', () => {
     it( 'should register an event callback when passed a Node',
     function() {
-      var spy = sinon.spy();
-      var linkDom = document.querySelector( 'a[href^="#"]' );
+      const spy = sinon.spy();
+      const linkDom = document.querySelector( 'a[href^="#"]' );
       behavior.attach( linkDom, 'click', spy );
       triggerEvent( linkDom, 'click' );
       expect( spy.called ).to.equal( true );
     } );
 
-    it( 'should register an event callback when passed a NodeList',
-    function() {
-      var spy = sinon.spy();
-      var behaviorDom = behavior.find( 'flyout-menu_trigger' );
+    it( 'should register an event callback when passed a NodeList', () => {
+      const spy = sinon.spy();
+      const behaviorDom = behavior.find( 'flyout-menu_trigger' );
       behavior.attach( behaviorDom, 'mouseover', spy );
       triggerEvent( behaviorDom[0], 'mouseover' );
       expect( spy.called ).to.equal( true );
     } );
 
     it( 'should register an event callback when passed a behavior selector',
-    function() {
-      var spy = sinon.spy();
-      var behaviorDom = behavior.find( 'flyout-menu_trigger' );
+    () => {
+      const spy = sinon.spy();
+      const behaviorDom = behavior.find( 'flyout-menu_trigger' );
       behavior.attach( 'flyout-menu_trigger', 'mouseover', spy );
       triggerEvent( behaviorDom[0], 'mouseover' );
       expect( spy.called ).to.equal( true );
     } );
 
-    it( 'should register an event callback when passed a dom selector',
-    function() {
-      var spy = sinon.spy();
-      var linkDom = document.querySelector( 'a[href^="#"]' );
+    it( 'should register an event callback when passed a dom selector', () => {
+      const spy = sinon.spy();
+      const linkDom = document.querySelector( 'a[href^="#"]' );
       behavior.attach( 'a[href^="#"]', 'click', spy );
       triggerEvent( linkDom, 'click' );
       expect( spy.called ).to.equal( true );
     } );
   } );
 
-  describe( 'checkBehaviorDom function ', function() {
-    it( 'should throw an error if element DOM not found', function() {
-      var errMsg = 'behavior_flyout-menu ' +
-                   'behavior not found on passed DOM node!';
+  describe( 'checkBehaviorDom function ', () => {
+    it( 'should throw an error if element DOM not found', () => {
+      const errMsg = 'behavior_flyout-menu ' +
+                     'behavior not found on passed DOM node!';
       function errFunc() {
         behavior.checkBehaviorDom( null, 'behavior_flyout-menu' );
       }
       expect( errFunc ).to.throw( Error, errMsg );
     } );
 
-    it( 'should throw an error if behavior attribute not found', function() {
-      var errMsg = 'mock-attr behavior not found on passed DOM node!';
+    it( 'should throw an error if behavior attribute not found', () => {
+      const errMsg = 'mock-attr behavior not found on passed DOM node!';
       function errFunc() {
         behavior.checkBehaviorDom( containerDom, 'mock-attr' );
       }
@@ -106,44 +105,43 @@ describe( 'behavior', function() {
     } );
 
     it( 'should return the correct HTMLElement ' +
-        'when direct element is searched', function() {
-      var dom = behavior.checkBehaviorDom( containerDom,
-                                           'behavior_flyout-menu' );
+        'when direct element is searched', () => {
+      const dom = behavior.checkBehaviorDom( containerDom,
+                                             'behavior_flyout-menu' );
       expect( dom ).to.be.equal( containerDom );
     } );
 
     it( 'should return the correct HTMLElement ' +
-        'when child element is searched', function() {
-      var dom = behavior.checkBehaviorDom( behaviorElmDom,
-                                           'behavior_flyout-menu_content' );
+        'when child element is searched', () => {
+      const dom = behavior.checkBehaviorDom( behaviorElmDom,
+                                             'behavior_flyout-menu_content' );
       expect( dom ).to.be.equal( behaviorElmDom );
     } );
   } );
 
-  describe( 'find function', function() {
-    it( 'should find all elements with the specific behavior hook',
-    function() {
-      var behaviorDom = behavior.find( 'flyout-menu_trigger' );
+  describe( 'find function', () => {
+    it( 'should find all elements with the specific behavior hook', () => {
+      let behaviorDom = behavior.find( 'flyout-menu_trigger' );
       expect( behaviorDom.length === 2 ).to.equal( true );
       behaviorDom = behavior.find( 'flyout-menu_content' );
       expect( behaviorDom.length === 1 ).to.equal( true );
     } );
 
     it( 'should throw an error when passed an invalid behavior selector',
-    function() {
-      var behaviorSelector = 'a[href^="#"]';
-      var errorMsg =
-        '[data-js-hook*=behavior_' + behaviorSelector + '] not found in DOM!';
-      var findFunction = behavior.find.bind( this, behaviorSelector );
+    () => {
+      const behaviorSelector = 'a[href^="#"]';
+      const errorMsg = '[data-js-hook*=behavior_' +
+                       behaviorSelector + '] not found in DOM!';
+      const findFunction = behavior.find.bind( this, behaviorSelector );
       expect( findFunction ).to.throw( Error, errorMsg );
     } );
   } );
 
-  describe( 'remove function', function() {
+  describe( 'remove function', () => {
     it( 'should remove the event callback for the specific behavior hook',
-    function() {
-      var spy = sinon.spy();
-      var linkDom = document.querySelector( 'a[href^="#"]' );
+    () => {
+      const spy = sinon.spy();
+      const linkDom = document.querySelector( 'a[href^="#"]' );
       behavior.attach( linkDom, 'click', spy );
       triggerEvent( linkDom, 'click' );
       expect( spy.called ).to.equal( true );

--- a/test/unit_tests/modules/util/breakpoint-state-spec.js
+++ b/test/unit_tests/modules/util/breakpoint-state-spec.js
@@ -1,69 +1,65 @@
 'use strict';
 
-var BASE_JS_PATH = '../../../../cfgov/unprocessed/js/';
+const BASE_JS_PATH = '../../../../cfgov/unprocessed/js/';
 
-var chai = require( 'chai' );
-var expect = chai.expect;
-var jsdom = require( 'mocha-jsdom' );
-var getBreakpointState =
-require( BASE_JS_PATH + 'modules/util/breakpoint-state.js' ).get;
-var breakpointConfig =
-require( BASE_JS_PATH + 'config/breakpoints-config.js' );
+const chai = require( 'chai' );
+const expect = chai.expect;
+const jsdom = require( 'mocha-jsdom' );
+const getBreakpointState =
+  require( BASE_JS_PATH + 'modules/util/breakpoint-state.js' ).get;
+const breakpointConfig =
+  require( BASE_JS_PATH + 'config/breakpoints-config.js' );
 
-var breakpointState;
-var configKeys;
+let breakpointState;
+let configKeys;
 
-beforeEach( function() {
+beforeEach( () => {
   configKeys = Object.keys( breakpointConfig );
 } );
 
-describe( 'getBreakpointState', function() {
+describe( 'getBreakpointState', () => {
 
   jsdom();
 
-  it( 'should return an object with properties from config file', function() {
-    var breakpointStatekeys =
-        Object.keys( breakpointConfig ).map( function( key ) {
-          key.replace( 'is', '' );
-          key.charAt( 0 ).toLowerCase() + key.slice( 1 );
-          return key;
-        } );
+  it( 'should return an object with properties from config file', () => {
+    const breakpointStatekeys =
+      Object.keys( breakpointConfig ).map( key => {
+        key.replace( 'is', '' );
+        key.charAt( 0 ).toLowerCase() + key.slice( 1 );
+        return key;
+      } );
 
     breakpointState = getBreakpointState();
 
     expect( breakpointState instanceof Object ).to.be.true;
     expect( configKeys.sort().join() === breakpointStatekeys.sort().join() )
-    .to.be.true;
+      .to.be.true;
   } );
 
-  it(
-    'should return an object with one state property set to true',
-    function() {
-      var trueValueCount = 0;
+  it( 'should return an object with one state property set to true', () => {
+    let trueValueCount = 0;
 
-      breakpointState = getBreakpointState();
-      for ( var stateKey in breakpointState ) { // eslint-disable-line guard-for-in, no-inline-comments, max-len
-        if ( breakpointState[stateKey] === true ) trueValueCount++;
-      }
+    breakpointState = getBreakpointState();
+    for ( let stateKey in breakpointState ) { // eslint-disable-line guard-for-in, no-inline-comments, max-len
+      if ( breakpointState[stateKey] === true ) trueValueCount++;
+    }
 
-      expect( trueValueCount === 1 ).to.be.true;
-    } );
+    expect( trueValueCount === 1 ).to.be.true;
+  } );
 
-  it(
-    'should set the correct state property when passed width',
-    function() {
-      var width;
-      var breakpointStateKey;
+  it( 'should set the correct state property when passed width', () => {
+    let width;
+    let breakpointStateKey;
 
-      for ( var rangeKey in breakpointConfig ) { // eslint-disable-line guard-for-in, no-inline-comments, max-len
-        width = breakpointConfig[rangeKey].max ||
-                breakpointConfig[rangeKey].min;
-        breakpointState = getBreakpointState( width );
-        breakpointStateKey =
-        'is' + rangeKey.charAt( 0 ).toUpperCase() + rangeKey.slice( 1 );
+    for ( let rangeKey in breakpointConfig ) { // eslint-disable-line guard-for-in, no-inline-comments, max-len
+      width = breakpointConfig[rangeKey].max ||
+              breakpointConfig[rangeKey].min;
+      breakpointState = getBreakpointState( width );
+      breakpointStateKey =
+      'is' + rangeKey.charAt( 0 ).toUpperCase() + rangeKey.slice( 1 );
 
-        expect( breakpointState[breakpointStateKey] ).to.be.true;
-      }
-    } );
+      expect( breakpointState[breakpointStateKey] ).to.be.true;
+    }
+  } );
 
 } );

--- a/test/unit_tests/modules/util/data-hook-spec.js
+++ b/test/unit_tests/modules/util/data-hook-spec.js
@@ -1,11 +1,11 @@
 'use strict';
 
-var BASE_JS_PATH = '../../../../cfgov/unprocessed/js/';
+const BASE_JS_PATH = '../../../../cfgov/unprocessed/js/';
 
-var chai = require( 'chai' );
-var expect = chai.expect;
-var dataHook = require( BASE_JS_PATH + 'modules/util/data-hook' );
+const chai = require( 'chai' );
+const expect = chai.expect;
+const dataHook = require( BASE_JS_PATH + 'modules/util/data-hook' );
 
-describe( 'data-hook', function() {
+describe( 'data-hook', () => {
   // TODO: Implement tests.
 } );

--- a/test/unit_tests/modules/util/data-set-spec.js
+++ b/test/unit_tests/modules/util/data-set-spec.js
@@ -1,16 +1,16 @@
 'use strict';
 
-var BASE_JS_PATH = '../../../../cfgov/unprocessed/js/';
-var dataSet = require( BASE_JS_PATH + 'modules/util/data-set' ).dataSet;
+const BASE_JS_PATH = '../../../../cfgov/unprocessed/js/';
+const dataSet = require( BASE_JS_PATH + 'modules/util/data-set' ).dataSet;
 
-var chai = require( 'chai' );
-var expect = chai.expect;
-var jsdom = require( 'mocha-jsdom' );
-var sinon = require( 'sinon' );
-var sandbox;
-var baseDom;
+const chai = require( 'chai' );
+const expect = chai.expect;
+const jsdom = require( 'mocha-jsdom' );
+const sinon = require( 'sinon' );
+let sandbox;
+let baseDom;
 
-var HTML_SNIPPET =
+const HTML_SNIPPET =
   '<div data-test-value-a="testValueA"' +
         'data-test-value-B="testValueB"' +
         'data-testValue-C="testValueC"' +
@@ -21,7 +21,7 @@ var HTML_SNIPPET =
 
 // JSdom hasn't implmented Element.dataset so I used Chrome to determine
 // the correct values : http://jsfiddle.net/0j9u66h0/13/.
-var datasetLookup = {
+const datasetLookup = {
   testValueA: 'testValueA',
   testValueB: 'testValueB',
   testvalueC: 'testValueC',
@@ -29,24 +29,22 @@ var datasetLookup = {
   testValueE: 'testValueE'
 };
 
-describe( 'data-set', function() {
+describe( 'data-set', () => {
   jsdom();
 
-  beforeEach( function() {
+  beforeEach( () => {
     sandbox = sinon.sandbox.create();
     document.body.innerHTML = HTML_SNIPPET;
     baseDom = document.querySelector( 'div' );
   } );
 
-  afterEach( function() {
+  afterEach( () => {
     sandbox.restore();
   } );
 
-  it( 'should have the correct keys and values when using utility',
-    function() {
-      var dataset = dataSet( baseDom );
-      expect( JSON.stringify( dataset ) ===
-        JSON.stringify( datasetLookup ) ).to.equal( true );
-    }
-  );
+  it( 'should have the correct keys and values when using utility', () => {
+    const dataset = dataSet( baseDom );
+    expect( JSON.stringify( dataset ) ===
+      JSON.stringify( datasetLookup ) ).to.equal( true );
+  } );
 } );

--- a/test/unit_tests/modules/util/dom-events-spec.js
+++ b/test/unit_tests/modules/util/dom-events-spec.js
@@ -1,46 +1,43 @@
 'use strict';
-var chai = require( 'chai' );
-var expect = chai.expect;
-var jsdom = require( 'mocha-jsdom' );
-var BASE_JS_PATH = '../../../../cfgov/unprocessed/js/';
-var domEvents = require( BASE_JS_PATH + 'modules/util/dom-events' );
-var input;
-var clicked;
 
-describe( 'Dom Events bindEvent', function() {
+const chai = require( 'chai' );
+const expect = chai.expect;
+const jsdom = require( 'mocha-jsdom' );
+const BASE_JS_PATH = '../../../../cfgov/unprocessed/js/';
+const domEvents = require( BASE_JS_PATH + 'modules/util/dom-events' );
+let input;
+let clicked;
+
+describe( 'Dom Events bindEvent', () => {
   jsdom();
 
-  beforeEach( function() {
+  beforeEach( () => {
     input = document.createElement( 'input' );
     input.type = 'checkbox';
     input.value = 'test-bind-event';
     clicked = false;
   } );
 
-  it( 'should not update the var until event is triggered', function() {
+  it( 'should not update the var until event is triggered', () => {
     domEvents.bindEvent( input, {
       click: function() { clicked = true; }
     } );
     expect( clicked ).to.be.false;
   } );
 
-  it( 'should not update the var if another event is triggered',
-    function() {
-      domEvents.bindEvent( input, {
-        click: function() { clicked = true; }
-      } );
-      input.focus();
-      expect( clicked ).to.be.false;
-    }
-  );
+  it( 'should not update the var if another event is triggered', () => {
+    domEvents.bindEvent( input, {
+      click: function() { clicked = true; }
+    } );
+    input.focus();
+    expect( clicked ).to.be.false;
+  } );
 
-  it( 'should update the var when the event is triggered',
-    function() {
-      domEvents.bindEvent( input, {
-        click: function() { clicked = true; }
-      } );
-      input.click();
-      expect( clicked ).to.be.true;
-    }
-  );
+  it( 'should update the var when the event is triggered', () => {
+    domEvents.bindEvent( input, {
+      click: function() { clicked = true; }
+    } );
+    input.click();
+    expect( clicked ).to.be.true;
+  } );
 } );

--- a/test/unit_tests/modules/util/dom-manipulators-spec.js
+++ b/test/unit_tests/modules/util/dom-manipulators-spec.js
@@ -1,17 +1,17 @@
 'use strict';
 
-var BASE_JS_PATH = '../../../../cfgov/unprocessed/js/';
+const BASE_JS_PATH = '../../../../cfgov/unprocessed/js/';
 
-var chai = require( 'chai' );
-var expect = chai.expect;
-var jsdom = require( 'mocha-jsdom' );
-var domManipulators = require( BASE_JS_PATH + 'modules/util/dom-manipulators' );
+const chai = require( 'chai' );
+const expect = chai.expect;
+const jsdom = require( 'mocha-jsdom' );
+const domManipulators = require( BASE_JS_PATH + 'modules/util/dom-manipulators' );
 
-describe( 'Dom Manipulators create', function() {
+describe( 'Dom Manipulators create', () => {
   jsdom();
 
-  before( function() {
-    var heading = domManipulators.create( 'h1', {
+  before( () => {
+    const heading = domManipulators.create( 'h1', {
       'textContent': 'Create Heading Text',
       'id':          'create-heading-id',
       'className':   'create-heading-class',
@@ -37,8 +37,8 @@ describe( 'Dom Manipulators create', function() {
   } );
 
 
-  it( 'should create a single elem', function() {
-    var query = document.querySelector( 'h1' );
+  it( 'should create a single elem', () => {
+    const query = document.querySelector( 'h1' );
 
     expect( query.id ).to.equal( 'create-heading-id' );
     expect( query.className ).to.equal( 'create-heading-class' );
@@ -46,8 +46,8 @@ describe( 'Dom Manipulators create', function() {
       .to.equal( 'create-heading-data' );
   } );
 
-  it( 'should create an elem inside another', function() {
-    var query = document.querySelector( 'span' );
+  it( 'should create an elem inside another', () => {
+    const query = document.querySelector( 'span' );
 
     expect( query.textContent ).to.equal( 'Heading Span' );
     expect( query.id ).to.equal( 'create-span-id' );
@@ -56,8 +56,8 @@ describe( 'Dom Manipulators create', function() {
       .to.equal( 'create-span-data' );
   } );
 
-  it( 'should create an elem around another', function() {
-    var query = document.querySelector( 'div' );
+  it( 'should create an elem around another', () => {
+    const query = document.querySelector( 'div' );
 
     expect( query.id ).to.equal( 'create-div-id' );
     expect( query.className ).to.equal( 'create-div-class' );

--- a/test/unit_tests/modules/util/dom-traverse-spec.js
+++ b/test/unit_tests/modules/util/dom-traverse-spec.js
@@ -1,121 +1,113 @@
 'use strict';
 
-var BASE_JS_PATH = '../../../../cfgov/unprocessed/js/';
+const BASE_JS_PATH = '../../../../cfgov/unprocessed/js/';
 
-var chai = require( 'chai' );
-var expect = chai.expect;
-var jsdom = require( 'mocha-jsdom' );
-var domTraverse = require( BASE_JS_PATH + 'modules/util/dom-traverse' );
+const chai = require( 'chai' );
+const expect = chai.expect;
+const jsdom = require( 'mocha-jsdom' );
+const domTraverse = require( BASE_JS_PATH + 'modules/util/dom-traverse' );
 
-describe( 'Dom Traverse queryOne()', function() {
+describe( 'Dom Traverse queryOne()', () => {
   jsdom();
 
-  before( function() {
+  before( () => {
     document.body.innerHTML =
       '<div class="div-1"></div><div class="div-2"></div>';
   } );
 
-  it( 'should return the first elem if the expr is a string', function() {
-    var query = domTraverse.queryOne( 'div' );
+  it( 'should return the first elem if the expr is a string', () => {
+    const query = domTraverse.queryOne( 'div' );
 
     expect( query.className ).to.equal( 'div-1' );
   } );
 
-  it( 'should return the passed expr if it’s an object', function() {
-    var obj = document.createElement( 'div' );
+  it( 'should return the passed expr if it’s an object', () => {
+    const obj = document.createElement( 'div' );
     obj.className = 'div-3';
-    var query = domTraverse.queryOne( obj );
+    const query = domTraverse.queryOne( obj );
 
     expect( query.className ).to.equal( 'div-3' );
   } );
 
-  it( 'should return null if the elem doesn’t exist', function() {
+  it( 'should return null if the elem doesn’t exist', () => {
     var query = document.querySelector( '.div-4' );
 
     expect( query ).to.equal( null );
   } );
 } );
 
-describe( 'Dom Traverse getSiblings()', function() {
+describe( 'Dom Traverse getSiblings()', () => {
   jsdom();
 
-  before( function() {
+  before( () => {
     document.body.innerHTML =
       '<div class="div-1"></div><div class="div-2"></div>';
   } );
 
-  it( 'should return an array with a single sibling',
-    function() {
-      var elem = document.querySelector( '.div-1' );
-      var siblings = domTraverse.getSiblings( elem, 'div' );
+  it( 'should return an array with a single sibling', () => {
+    const elem = document.querySelector( '.div-1' );
+    const siblings = domTraverse.getSiblings( elem, 'div' );
 
-      expect( siblings.length ).to.equal( 1 );
-      expect( siblings[0].className ).to.equal( 'div-2' );
-    }
-  );
+    expect( siblings.length ).to.equal( 1 );
+    expect( siblings[0].className ).to.equal( 'div-2' );
+  } );
 } );
 
-describe( 'Dom Traverse not()', function() {
+describe( 'Dom Traverse not()', () => {
   jsdom();
 
-  before( function() {
+  before( () => {
     document.body.innerHTML =
       '<div class="div-1"></div><div class="div-2"></div>';
   } );
 
-  it( 'should return an array with the item that wasn’t excluded',
-    function() {
-      var items = document.querySelectorAll( 'div' );
-      var exclude = document.querySelector( '.div-2' );
+  it( 'should return an array with the item that wasn’t excluded', () => {
+    let items = document.querySelectorAll( 'div' );
+    const exclude = document.querySelector( '.div-2' );
 
-      items = domTraverse.not( items, exclude );
+    items = domTraverse.not( items, exclude );
 
-      expect( items.length ).to.equal( 1 );
-      expect( items[0].className ).to.equal( 'div-1' );
-    }
-  );
+    expect( items.length ).to.equal( 1 );
+    expect( items[0].className ).to.equal( 'div-1' );
+  } );
 } );
 
-describe( 'Dom Traverse closest()', function() {
+describe( 'Dom Traverse closest()', () => {
   jsdom();
 
-  before( function() {
+  before( () => {
     document.body.innerHTML =
       '<div class="grandparent"><div class="parent"><div class="child">' +
       '</div></div></div>';
   } );
 
   it( 'should return the immediate parent HTMLNode with a passed selector',
-    function() {
-      var child = document.querySelector( '.child' );
-      var parent = domTraverse.closest( child, 'div' );
+    () => {
+      const child = document.querySelector( '.child' );
+      const parent = domTraverse.closest( child, 'div' );
 
       expect( parent.className ).to.equal( 'parent' );
     }
   );
 
-  it( 'should return the grandparent HTMLNode with a passed selector',
-    function() {
-      var child = document.querySelector( '.child' );
-      var parent = domTraverse.closest( child, '.grandparent' );
+  it( 'should return the grandparent HTMLNode with a passed selector', () => {
+    const child = document.querySelector( '.child' );
+    const parent = domTraverse.closest( child, '.grandparent' );
 
-      expect( parent.className ).to.equal( 'grandparent' );
-    }
-  );
+    expect( parent.className ).to.equal( 'grandparent' );
+  } );
 
-  it( 'should return null without a passed selector',
-    function() {
-      var child = document.querySelector( '.child' );
-      var parent = domTraverse.closest( child );
+  it( 'should return null without a passed selector', () => {
+    const child = document.querySelector( '.child' );
+    const parent = domTraverse.closest( child );
 
-      expect( parent ).to.equal( null );
-    }
-  );
+    expect( parent ).to.equal( null );
+  } );
 
   it( 'should return the parent HTMLNode even if the selector wasn’t found',
-    function() {
-      var child = document.querySelector( '.child' );
-      var parent = domTraverse.closest( child, 'greatgrandparent' );
+    () => {
+      const child = document.querySelector( '.child' );
+      const parent = domTraverse.closest( child, 'greatgrandparent' );
 
       expect( parent ).to.equal( null );
     }

--- a/test/unit_tests/modules/util/expanded-state-spec.js
+++ b/test/unit_tests/modules/util/expanded-state-spec.js
@@ -1,96 +1,100 @@
 'use strict';
 
-var BASE_JS_PATH = '../../../../cfgov/unprocessed/js/';
+const BASE_JS_PATH = '../../../../cfgov/unprocessed/js/';
 
-var chai = require( 'chai' );
-var sinon = require( 'sinon' );
-var expect = chai.expect;
-var jsdom = require( 'mocha-jsdom' );
+const chai = require( 'chai' );
+const sinon = require( 'sinon' );
+const expect = chai.expect;
+const jsdom = require( 'mocha-jsdom' );
 
-describe( 'Event States', function() {
-  var expandedState, sandbox, divExpanded, divClosed, openMenu;
+describe( 'Event States', () => {
+  let expandedState;
+  let sandbox;
+  let divExpanded;
+  let divClosed;
+  let openMenu;
 
   jsdom();
 
-  before( function() {
+  before( () => {
     expandedState = require( BASE_JS_PATH + 'modules/util/expanded-state.js' );
     sandbox = sinon.sandbox.create();
   } );
 
-  beforeEach( function() {
-    var mockedContent = '<div class="div-expanded" aria-expanded="true" />' +
-                        '<div class="div-closed" aria-expanded="false" />';
+  beforeEach( () => {
+    const mockedContent = '<div class="div-expanded" aria-expanded="true" />' +
+                          '<div class="div-closed" aria-expanded="false" />';
     document.body.innerHTML = mockedContent;
     divExpanded = document.querySelector( '.div-expanded' );
     divClosed = document.querySelector( '.div-closed' );
     openMenu = document.querySelectorAll( 'div' );
   } );
 
-  afterEach( function() {
+  afterEach( () => {
     sandbox.restore();
   } );
 
-  describe( 'get expanded state', function() {
-    it( 'should return true when expanded', function() {
+  describe( 'get expanded state', () => {
+    it( 'should return true when expanded', () => {
       expect( expandedState.isThisExpanded( divExpanded ) ).to.be.true;
     } );
 
-    it( 'should return false when closed', function() {
+    it( 'should return false when closed', () => {
       expect( expandedState.isThisExpanded( divClosed ) ).to.be.false;
     } );
 
-    it( 'should return true if at least one is expanded', function() {
-      var testExpandedDivs = document.querySelectorAll( 'div' );
+    it( 'should return true if at least one is expanded', () => {
+      const testExpandedDivs = document.querySelectorAll( 'div' );
 
       expect( expandedState.isOneExpanded( testExpandedDivs ) ).to.be.true;
     } );
 
-    it( 'should return false if at least one isn’t expanded', function() {
-      var testClosedDivs = document.querySelectorAll( 'div' );
-      for ( var i = 0, len = testClosedDivs.length; i < len; i++ ) {
+    it( 'should return false if at least one isn’t expanded', () => {
+      const testClosedDivs = document.querySelectorAll( 'div' );
+      for ( let i = 0, len = testClosedDivs.length; i < len; i++ ) {
         expect( expandedState.isOneExpanded( testClosedDivs[i] ) ).to.be.false;
       }
     } );
   } );
 
-  describe( 'set expanded state - default state', function() {
-    it( 'should toggle a closed div open', function() {
+  describe( 'set expanded state - default state', () => {
+    it( 'should toggle a closed div open', () => {
       expandedState.toggleExpandedState( divClosed );
       expect( expandedState.isThisExpanded( divClosed ) ).to.be.true;
     } );
 
-    it( 'should toggle an open div closed', function() {
+    it( 'should toggle an open div closed', () => {
       expandedState.toggleExpandedState( divExpanded );
       expect( expandedState.isThisExpanded( divExpanded ) ).to.be.false;
     } );
 
-    it( 'should use null state to toggle an open div closed', function() {
+    it( 'should use null state to toggle an open div closed', () => {
       expandedState.toggleExpandedState( divExpanded, null );
       expect( expandedState.isThisExpanded( divExpanded ) ).to.be.false;
     } );
 
-    it( 'should use false state to close an open div', function() {
+    it( 'should use false state to close an open div', () => {
       expandedState.toggleExpandedState( divExpanded, 'false' );
       expect( expandedState.isThisExpanded( divExpanded ) ).to.be.false;
     } );
 
-    it( 'should use true state to open a closed div', function() {
+    it( 'should use true state to open a closed div', () => {
       expandedState.toggleExpandedState( divClosed, 'true' );
       expect( expandedState.isThisExpanded( divClosed ) ).to.be.true;
     } );
   } );
 
-  describe( 'set expanded state - open state', function() {
-    it( 'should close all open divs', function() {
+  describe( 'set expanded state - open state', () => {
+    it( 'should close all open divs', () => {
       for ( var i = 0, len = openMenu.length; i < len; i++ ) {
         expandedState.toggleExpandedState( openMenu[i], 'false' );
         expect( expandedState.isOneExpanded( openMenu[i] ) ).to.be.false;
       }
     } );
 
-    it( 'should fire a callback after toggling', function( done ) {
+    it( 'should fire a callback after toggling', done => {
       for ( var i = 0, len = openMenu.length; i < len; i++ ) {
-        expandedState.toggleExpandedState( openMenu[i], null, function() { // eslint-disable-line no-loop-func, no-inline-comments, max-len
+        expandedState.toggleExpandedState( openMenu[i], null, () => { // eslint-disable-line no-loop-func, no-inline-comments, max-len
           expect( expandedState.isThisExpanded( divClosed ) ).to.be.true;
           done();
         } );

--- a/test/unit_tests/modules/util/fn-bind.js
+++ b/test/unit_tests/modules/util/fn-bind.js
@@ -1,11 +1,11 @@
 'use strict';
 
-var BASE_JS_PATH = '../../../../cfgov/unprocessed/js/';
+const BASE_JS_PATH = '../../../../cfgov/unprocessed/js/';
 
-var chai = require( 'chai' );
-var expect = chai.expect;
-var fnBind = require( BASE_JS_PATH + 'modules/util/fn-bind' );
+const chai = require( 'chai' );
+const expect = chai.expect;
+const fnBind = require( BASE_JS_PATH + 'modules/util/fn-bind' );
 
-describe( 'fn-bind', function() {
+describe( 'fn-bind', () => {
   // TODO: Implement tests.
 } );

--- a/test/unit_tests/modules/util/get-viewport-dimensions-spec.js
+++ b/test/unit_tests/modules/util/get-viewport-dimensions-spec.js
@@ -1,12 +1,12 @@
 'use strict';
 
-var BASE_JS_PATH = '../../../../cfgov/unprocessed/js/';
+const BASE_JS_PATH = '../../../../cfgov/unprocessed/js/';
 
-var chai = require( 'chai' );
-var expect = chai.expect;
-var getViewportDimensions =
+const chai = require( 'chai' );
+const expect = chai.expect;
+const getViewportDimensions =
   require( BASE_JS_PATH + 'modules/util/get-viewport-dimensions' );
 
-describe( 'get-viewport-dimensions', function() {
+describe( 'get-viewport-dimensions', () => {
   // TODO: Implement tests.
 } );

--- a/test/unit_tests/modules/util/js-loader-spec.js
+++ b/test/unit_tests/modules/util/js-loader-spec.js
@@ -1,12 +1,12 @@
 'use strict';
 
-var BASE_JS_PATH = '../../../../cfgov/unprocessed/js/';
-var chai = require( 'chai' );
-var expect = chai.expect;
-var jsdom = require( 'mocha-jsdom' );
-var jsLoader = require( BASE_JS_PATH + 'modules/util/js-loader' );
+const BASE_JS_PATH = '../../../../cfgov/unprocessed/js/';
+const chai = require( 'chai' );
+const expect = chai.expect;
+const jsdom = require( 'mocha-jsdom' );
+const jsLoader = require( BASE_JS_PATH + 'modules/util/js-loader' );
 
-describe( 'loadScript method', function() {
+describe( 'loadScript method', () => {
   jsdom( {
     features: {
       FetchExternalResources:   [ 'script' ],
@@ -15,20 +15,18 @@ describe( 'loadScript method', function() {
     }
   } );
 
-  it( 'should invoke the callback method when the script loads',
-    function() {
-      var loaderPromise = new Promise( function( resolve, reject ) {
-        var scriptLocation = 'http://code.jquery.com/jquery-1.5.min.js';
-        jsLoader.loadScript( scriptLocation, function() {
-          resolve( 'Callback called' );
-        } );
+  it( 'should invoke the callback method when the script loads', () => {
+    const loaderPromise = new Promise( function( resolve, reject ) {
+      const scriptLocation = 'http://code.jquery.com/jquery-1.5.min.js';
+      jsLoader.loadScript( scriptLocation, function() {
+        resolve( 'Callback called' );
       } );
+    } );
 
-      return loaderPromise.then( function( result ) {
-        expect( result ).to.equal( 'Callback called' );
-      } );
-    }
-  );
+    return loaderPromise.then( result => {
+      expect( result ).to.equal( 'Callback called' );
+    } );
+  } );
 
   // TODO: Add Test for script.onreadystatechange
 } );

--- a/test/unit_tests/modules/util/standard-type-spec.js
+++ b/test/unit_tests/modules/util/standard-type-spec.js
@@ -1,21 +1,21 @@
 'use strict';
 
-var BASE_JS_PATH = '../../../../cfgov/unprocessed/js/';
+const BASE_JS_PATH = '../../../../cfgov/unprocessed/js/';
 
-var chai = require( 'chai' );
-var expect = chai.expect;
-var standardType = require( BASE_JS_PATH + 'modules/util/standard-type' );
+const chai = require( 'chai' );
+const expect = chai.expect;
+const standardType = require( BASE_JS_PATH + 'modules/util/standard-type' );
 
-describe( 'standard-type', function() {
-  it( 'should include a standard JS data hook', function() {
+describe( 'standard-type', () => {
+  it( 'should include a standard JS data hook', () => {
     expect( standardType.JS_HOOK ).to.equal( 'data-js-hook' );
   } );
 
-  it( 'should include a non operational function', function() {
+  it( 'should include a non operational function', () => {
     expect( standardType.noopFunct() ).to.be.undefined;
   } );
 
-  it( 'should include a standard undefined reference', function() {
+  it( 'should include a standard undefined reference', () => {
     expect( standardType.UNDEFINED ).to.be.undefined;
   } );
 } );

--- a/test/unit_tests/modules/util/strings-spec.js
+++ b/test/unit_tests/modules/util/strings-spec.js
@@ -1,89 +1,84 @@
 'use strict';
-var chai = require( 'chai' );
-var expect = chai.expect;
-var BASE_JS_PATH = '../../../../cfgov/unprocessed/js/';
-var strings = require( BASE_JS_PATH + 'modules/util/strings' );
-var string;
-var control;
 
-describe( 'Strings stringEscape()', function() {
+const chai = require( 'chai' );
+const expect = chai.expect;
+const BASE_JS_PATH = '../../../../cfgov/unprocessed/js/';
+const strings = require( BASE_JS_PATH + 'modules/util/strings' );
+let string;
+let control;
 
-  it( 'should escape a url', function() {
+describe( 'Strings stringEscape()', () => {
+
+  it( 'should escape a url', () => {
     string = 'http://google.com';
 
     expect( strings.stringEscape( string ) )
       .to.equal( 'http://google\\.com' );
   } );
 
-  it( 'should escape a hyphenated name', function() {
+  it( 'should escape a hyphenated name', () => {
     string = 'Miller-Webster';
 
     expect( strings.stringEscape( string ) )
       .to.equal( 'Miller\\-Webster' );
   } );
 
-  it( 'should escape a comma', function() {
+  it( 'should escape a comma', () => {
     string = 'Students, Parents, and Teachers';
 
     expect( strings.stringEscape( string ) )
-      .to.equal( 'Students\, Parents\, and Teachers' );
+      .to.equal( 'Students, Parents, and Teachers' );
   } );
 } );
 
-describe( 'Strings stringValid()', function() {
-  it( 'should return true when testing a standard string', function() {
+describe( 'Strings stringValid()', () => {
+  it( 'should return true when testing a standard string', () => {
     string = 'Test String';
 
     expect( strings.stringValid( string ) ).to.be.true;
   } );
 
-  it( 'should return true when testing a hyphenated string', function() {
+  it( 'should return true when testing a hyphenated string', () => {
     string = 'Test-String';
 
     expect( strings.stringValid( string ) ).to.be.true;
   } );
 
-  it( 'should return true when testing an underscored string', function() {
+  it( 'should return true when testing an underscored string', () => {
     string = 'Test_String';
 
     expect( strings.stringValid( string ) ).to.be.true;
   } );
 
   it( 'should return false when testing a string containing a single tick',
-    function() {
+    () => {
       string = 'Person\'s Name';
 
       expect( strings.stringValid( string ) ).to.be.false;
     }
   );
 
-  it( 'should return false when testing a string containing a period',
-    function() {
-      string = 'Some P. Name';
+  it( 'should return false when testing a string containing a period', () => {
+    string = 'Some P. Name';
 
-      expect( strings.stringValid( string ) ).to.be.false;
-    }
-  );
+    expect( strings.stringValid( string ) ).to.be.false;
+  } );
 
-  it( 'should return false when testing a string containing a colon',
-    function() {
-      string = 'Person: Name';
+  it( 'should return false when testing a string containing a colon', () => {
+    string = 'Person: Name';
 
-      expect( strings.stringValid( string ) ).to.be.false;
-    }
-  );
+    expect( strings.stringValid( string ) ).to.be.false;
+  } );
 
-  it( 'should return false when testing a string containing a gt or lt',
-    function() {
-      string = '<body>';
+  it( 'should return false when testing a string containing a gt or lt', () => {
+    string = '<body>';
 
-      expect( strings.stringValid( string ) ).to.be.false;
-    }
-  );
+    expect( strings.stringValid( string ) ).to.be.false;
+  } );
 } );
 
-describe( 'Strings stringMatch()', function() {
-  it( 'should return true when testing matching strings', function() {
+describe( 'Strings stringMatch()', () => {
+  it( 'should return true when testing matching strings', () => {
     string = 'Test String';
     control = 'Test String';
 
@@ -92,7 +87,7 @@ describe( 'Strings stringMatch()', function() {
   } );
 
   it( 'should return true when testing matching strings with differing casing',
-    function() {
+    () => {
       string = 'test string';
       control = 'Test String';
 
@@ -101,7 +96,7 @@ describe( 'Strings stringMatch()', function() {
     }
   );
 
-  it( 'should return false when testing differing strings', function() {
+  it( 'should return false when testing differing strings', () => {
     string = 'Test String';
     control = 'Result String';
 

--- a/test/unit_tests/modules/util/tree-traversal-spec.js
+++ b/test/unit_tests/modules/util/tree-traversal-spec.js
@@ -1,21 +1,21 @@
 'use strict';
 
-var BASE_JS_PATH = '../../../../cfgov/unprocessed/js/';
+const BASE_JS_PATH = '../../../../cfgov/unprocessed/js/';
 
-var chai = require( 'chai' );
-var expect = chai.expect;
-var Tree = require( BASE_JS_PATH + 'modules/Tree' );
-var treeTraversal = require( BASE_JS_PATH + 'modules/util/tree-traversal' );
+const chai = require( 'chai' );
+const expect = chai.expect;
+const Tree = require( BASE_JS_PATH + 'modules/Tree' );
+const treeTraversal = require( BASE_JS_PATH + 'modules/util/tree-traversal' );
 
-describe( 'Tree traversal', function() {
+describe( 'Tree traversal', () => {
 
-  var tree;
-  var nodeR;
-  var nodeA;
-  var nodeB;
-  var nodeC;
-  var nodeD;
-  var nodeE;
+  let tree;
+  let nodeR;
+  let nodeA;
+  let nodeB;
+  let nodeC;
+  let nodeD;
+  let nodeE;
 
   /**
    * Make this Tree:
@@ -25,7 +25,7 @@ describe( 'Tree traversal', function() {
    *    / | \
    *   C  D  E
    */
-  beforeEach( function() {
+  beforeEach( () => {
     tree = new Tree();
     tree.init( 'R' );
     nodeR = tree.getRoot();
@@ -36,10 +36,10 @@ describe( 'Tree traversal', function() {
     nodeE = tree.add( 'E', nodeA );
   } );
 
-  describe( 'backtrack', function() {
-    it( 'should traverse up the tree', function() {
-      var nodes = [];
-      var that;
+  describe( 'backtrack', () => {
+    it( 'should traverse up the tree', () => {
+      const nodes = [];
+      let that;
       treeTraversal.backtrack( nodeC, function( node ) {
         that = this;
         nodes.push( node );
@@ -52,10 +52,10 @@ describe( 'Tree traversal', function() {
     } );
   } );
 
-  describe( 'breadth-first search', function() {
-    it( 'should traverse down the tree', function() {
-      var nodes = [];
-      var that;
+  describe( 'breadth-first search', () => {
+    it( 'should traverse down the tree', () => {
+      const nodes = [];
+      let that;
       treeTraversal.bfs( nodeR, function( node ) {
         that = this;
         nodes.push( node );
@@ -71,10 +71,10 @@ describe( 'Tree traversal', function() {
     } );
   } );
 
-  describe( 'depth-first search', function() {
-    it( 'should traverse down the tree', function() {
-      var nodes = [];
-      var that;
+  describe( 'depth-first search', () => {
+    it( 'should traverse down the tree', () => {
+      const nodes = [];
+      let that;
       treeTraversal.dfs( nodeR, function( node ) {
         that = this;
         nodes.push( node );

--- a/test/unit_tests/modules/util/type-checkers-spec.js
+++ b/test/unit_tests/modules/util/type-checkers-spec.js
@@ -1,120 +1,121 @@
 'use strict';
-var chai = require( 'chai' );
-var expect = chai.expect;
-var typeCheckers = require(
+
+const chai = require( 'chai' );
+const expect = chai.expect;
+const typeCheckers = require(
   '../../../../cfgov/unprocessed/js/modules/util/type-checkers.js'
 );
 
-var undefinedVar;
-var blankVar = '';
-var aString = 'bar';
-var aNum = 42;
-var aDate = new Date( 2011, 7, 21 );
+let undefinedVar;
+const blankVar = '';
+const aString = 'bar';
+const aNum = 42;
+const aDate = new Date( 2011, 7, 21 );
 function aFunction() {
   return true;
 }
-var anObject = {
+const anObject = {
   a: '1',
   b: '2',
   c: '3'
 };
-var anArray = [ 1, 2, 3 ];
+const anArray = [ 1, 2, 3 ];
 
-describe( 'TypeCheckers isUndefined', function() {
-  it( 'should identify undefined variables', function() {
+describe( 'TypeCheckers isUndefined', () => {
+  it( 'should identify undefined variables', () => {
     expect( typeCheckers.isUndefined( undefinedVar ) ).to.be.true;
   } );
 
-  it( 'should NOT return true for blank variables', function() {
+  it( 'should NOT return true for blank variables', () => {
     expect( typeCheckers.isUndefined( blankVar ) ).to.be.false;
   } );
 
-  it( 'should NOT return true for defined variables', function() {
+  it( 'should NOT return true for defined variables', () => {
     expect( typeCheckers.isUndefined( aString ) ).to.be.false;
   } );
 } );
 
-describe( 'TypeCheckers isDefined', function() {
-  it( 'should return true for defined variables', function() {
+describe( 'TypeCheckers isDefined', () => {
+  it( 'should return true for defined variables', () => {
     expect( typeCheckers.isDefined( aString ) ).to.be.true;
   } );
 
-  it( 'should return true for blank variables', function() {
+  it( 'should return true for blank variables', () => {
     expect( typeCheckers.isDefined( blankVar ) ).to.be.true;
   } );
 
-  it( 'should NOT return true for undefined variables', function() {
+  it( 'should NOT return true for undefined variables', () => {
     expect( typeCheckers.isDefined( undefinedVar ) ).to.be.false;
   } );
 } );
 
-describe( 'TypeCheckers isObject', function() {
-  it( 'should return true for objects', function() {
+describe( 'TypeCheckers isObject', () => {
+  it( 'should return true for objects', () => {
     expect( typeCheckers.isObject( anObject ) ).to.be.true;
   } );
 
-  it( 'should return false for strings', function() {
+  it( 'should return false for strings', () => {
     expect( typeCheckers.isObject( aString ) ).to.be.false;
   } );
 } );
 
-describe( 'TypeCheckers isString', function() {
-  it( 'should return true for strings', function() {
+describe( 'TypeCheckers isString', () => {
+  it( 'should return true for strings', () => {
     expect( typeCheckers.isString( aString ) ).to.be.true;
   } );
 
-  it( 'should return false for objects', function() {
+  it( 'should return false for objects', () => {
     expect( typeCheckers.isString( anObject ) ).to.be.false;
   } );
 } );
 
-describe( 'TypeCheckers isNumber', function() {
-  it( 'should return true for numbers', function() {
+describe( 'TypeCheckers isNumber', () => {
+  it( 'should return true for numbers', () => {
     expect( typeCheckers.isNumber( aNum ) ).to.be.true;
   } );
 
-  it( 'should return false for strings', function() {
+  it( 'should return false for strings', () => {
     expect( typeCheckers.isNumber( aString ) ).to.be.false;
     expect( typeCheckers.isNumber( '42' ) ).to.be.false;
   } );
 } );
 
-describe( 'TypeCheckers isDate', function() {
-  it( 'should return true for dates', function() {
+describe( 'TypeCheckers isDate', () => {
+  it( 'should return true for dates', () => {
     expect( typeCheckers.isDate( aDate ) ).to.be.true;
   } );
 
-  it( 'should return false for numbers', function() {
+  it( 'should return false for numbers', () => {
     expect( typeCheckers.isDate( aNum ) ).to.be.false;
   } );
 } );
 
-describe( 'TypeCheckers isArray', function() {
-  it( 'should return true for arrays', function() {
+describe( 'TypeCheckers isArray', () => {
+  it( 'should return true for arrays', () => {
     expect( typeCheckers.isArray( anArray ) ).to.be.true;
   } );
 
-  it( 'should return false for objects', function() {
+  it( 'should return false for objects', () => {
     expect( typeCheckers.isArray( anObject ) ).to.be.false;
   } );
 } );
 
-describe( 'TypeCheckers isFunction', function() {
-  it( 'should return true for a functions', function() {
+describe( 'TypeCheckers isFunction', () => {
+  it( 'should return true for a functions', () => {
     expect( typeCheckers.isFunction( aFunction ) ).to.be.true;
   } );
 
-  it( 'should return false for a non-function', function() {
+  it( 'should return false for a non-function', () => {
     expect( typeCheckers.isFunction( aString ) ).to.be.false;
   } );
 } );
 
-describe( 'TypeCheckers isEmpty', function() {
-  it( 'should return true for empty vars', function() {
+describe( 'TypeCheckers isEmpty', () => {
+  it( 'should return true for empty vars', () => {
     expect( typeCheckers.isEmpty( blankVar ) ).to.be.true;
   } );
 
-  it( 'should return false for non-empty vars', function() {
+  it( 'should return false for non-empty vars', () => {
     expect( typeCheckers.isEmpty( aString ) ).to.be.false;
   } );
 } );

--- a/test/unit_tests/modules/util/validators-spec.js
+++ b/test/unit_tests/modules/util/validators-spec.js
@@ -1,28 +1,29 @@
 'use strict';
-var chai = require( 'chai' );
-var expect = chai.expect;
-var jsdom = require( 'mocha-jsdom' );
-var BASE_JS_PATH = '../../../../cfgov/unprocessed/js/';
-var ERROR_MESSAGES = require( BASE_JS_PATH + 'config/error-messages-config' );
-var validators = require( BASE_JS_PATH + 'modules/util/validators.js' );
-var testField;
-var returnedObject;
 
-describe( 'Validators date field', function() {
+const chai = require( 'chai' );
+const expect = chai.expect;
+const jsdom = require( 'mocha-jsdom' );
+const BASE_JS_PATH = '../../../../cfgov/unprocessed/js/';
+const ERROR_MESSAGES = require( BASE_JS_PATH + 'config/error-messages-config' );
+const validators = require( BASE_JS_PATH + 'modules/util/validators.js' );
+let testField;
+let returnedObject;
+
+describe( 'Validators date field', () => {
   jsdom();
 
-  beforeEach( function() {
+  beforeEach( () => {
     testField = document.createElement( 'input' );
   } );
 
-  it( 'should return an empty object for a valid date', function() {
+  it( 'should return an empty object for a valid date', () => {
     testField.value = '11/12/2007';
     returnedObject = validators.date( testField );
 
     expect( returnedObject ).to.be.empty;
   } );
 
-  it( 'should return an error object for a malformed date', function() {
+  it( 'should return an error object for a malformed date', () => {
     testField.value = '11-12-07';
     returnedObject = validators.date( testField );
 
@@ -31,7 +32,7 @@ describe( 'Validators date field', function() {
       .to.have.property( 'msg', ERROR_MESSAGES.DATE.INVALID );
   } );
 
-  it( 'should return an error object for a UTC date', function() {
+  it( 'should return an error object for a UTC date', () => {
     testField.value = new Date( 2007, 11, 12 );
     returnedObject = validators.date( testField );
 
@@ -41,21 +42,21 @@ describe( 'Validators date field', function() {
   } );
 } );
 
-describe( 'Validators email field', function() {
+describe( 'Validators email field', () => {
   jsdom();
 
-  beforeEach( function() {
+  beforeEach( () => {
     testField = document.createElement( 'input' );
   } );
 
-  it( 'should return an empty object for a valid email', function() {
+  it( 'should return an empty object for a valid email', () => {
     testField.value = 'test@demo.com';
     returnedObject = validators.email( testField );
 
     expect( returnedObject ).to.be.empty;
   } );
 
-  it( 'should return an error object for a missing domain', function() {
+  it( 'should return an error object for a missing domain', () => {
     testField.value = 'test';
     returnedObject = validators.email( testField );
 
@@ -64,7 +65,7 @@ describe( 'Validators email field', function() {
       .to.have.property( 'msg', ERROR_MESSAGES.EMAIL.INVALID );
   } );
 
-  it( 'should return an error object for a missing user', function() {
+  it( 'should return an error object for a missing user', () => {
     testField.value = '@demo.com';
     returnedObject = validators.email( testField );
 
@@ -74,22 +75,22 @@ describe( 'Validators email field', function() {
   } );
 } );
 
-describe( 'Validators empty field', function() {
+describe( 'Validators empty field', () => {
   jsdom();
 
-  beforeEach( function() {
+  beforeEach( () => {
     testField = document.createElement( 'input' );
     testField.setAttribute( 'required', '' );
   } );
 
-  it( 'should return an empty object for a filed field', function() {
+  it( 'should return an empty object for a filed field', () => {
     testField.value = 'testing';
     returnedObject = validators.empty( testField );
 
     expect( returnedObject ).to.be.empty;
   } );
 
-  it( 'should return an error object for am empty field', function() {
+  it( 'should return an error object for am empty field', () => {
     testField.value = '';
     returnedObject = validators.empty( testField );
 
@@ -99,18 +100,18 @@ describe( 'Validators empty field', function() {
   } );
 } );
 
-describe( 'Validators checkbox field', function() {
+describe( 'Validators checkbox field', () => {
   jsdom();
 
-  beforeEach( function() {
+  beforeEach( () => {
     testField = document.createElement( 'label' );
     testField.setAttribute( 'name', 'test-checkboxes' );
     testField.setAttribute( 'data-required', '2' );
   } );
 
   it( 'should return an empty object ' +
-      'when total checkboxes equals required total', function() {
-    var fieldset = [
+      'when total checkboxes equals required total', () => {
+    const fieldset = [
       document.createElement( 'input' ),
       document.createElement( 'input' )
     ];
@@ -120,8 +121,8 @@ describe( 'Validators checkbox field', function() {
   } );
 
   it( 'should return an empty object ' +
-      'when total checkboxes is more than required total', function() {
-    var fieldset = [
+      'when total checkboxes is more than required total', () => {
+    const fieldset = [
       document.createElement( 'input' ),
       document.createElement( 'input' ),
       document.createElement( 'input' )
@@ -132,8 +133,8 @@ describe( 'Validators checkbox field', function() {
   } );
 
   it( 'should return an error object ' +
-       'when total checkboxes is less than required total', function() {
-    var fieldset = [
+       'when total checkboxes is less than required total', () => {
+    const fieldset = [
       document.createElement( 'input' )
     ];
     returnedObject = validators.checkbox( testField, null, fieldset );
@@ -144,10 +145,9 @@ describe( 'Validators checkbox field', function() {
     );
   } );
 
-  it( 'should return an empty object ' +
-      'when required total is empty', function() {
+  it( 'should return an empty object when required total is empty', () => {
     testField.removeAttribute( 'data-required' );
-    var fieldset = [
+    const fieldset = [
       document.createElement( 'input' )
     ];
     returnedObject = validators.checkbox( testField, null, fieldset );
@@ -156,7 +156,7 @@ describe( 'Validators checkbox field', function() {
   } );
 } );
 
-describe( 'Validators radio field', function() {
+describe( 'Validators radio field', () => {
   jsdom();
 
   beforeEach( function() {
@@ -166,8 +166,8 @@ describe( 'Validators radio field', function() {
   } );
 
   it( 'should return an empty object ' +
-      'when total radios equals required total', function() {
-    var fieldset = [
+      'when total radios equals required total', () => {
+    const fieldset = [
       document.createElement( 'input' )
     ];
     returnedObject = validators.radio( testField, null, fieldset );
@@ -176,8 +176,8 @@ describe( 'Validators radio field', function() {
   } );
 
   it( 'should return an empty object ' +
-      'when total radios is more than required total', function() {
-    var fieldset = [
+      'when total radios is more than required total', () => {
+    const fieldset = [
       document.createElement( 'input' ),
       document.createElement( 'input' )
     ];
@@ -187,8 +187,8 @@ describe( 'Validators radio field', function() {
   } );
 
   it( 'should return an error object ' +
-      'when total checkboxes is less than required total', function() {
-    var fieldset = [];
+      'when total checkboxes is less than required total', () => {
+    const fieldset = [];
     returnedObject = validators.radio( testField, null, fieldset );
 
     expect( returnedObject ).to.have.property( 'radio', false );
@@ -198,9 +198,9 @@ describe( 'Validators radio field', function() {
   } );
 
   it( 'should return an empty object ' +
-      'when required total is empty', function() {
+      'when required total is empty', () => {
     testField.removeAttribute( 'data-required' );
-    var fieldset = [
+    const fieldset = [
       document.createElement( 'input' )
     ];
     returnedObject = validators.radio( testField, null, fieldset );

--- a/test/unit_tests/modules/util/web-storage-proxy-spec.js
+++ b/test/unit_tests/modules/util/web-storage-proxy-spec.js
@@ -1,18 +1,23 @@
 'use strict';
 
-var BASE_JS_PATH = '../../../../cfgov/unprocessed/js/';
+const BASE_JS_PATH = '../../../../cfgov/unprocessed/js/';
 
-var chai = require( 'chai' );
-var sinon = require( 'sinon' );
-var expect = chai.expect;
-var jsdom = require( 'mocha-jsdom' );
+const chai = require( 'chai' );
+const sinon = require( 'sinon' );
+const expect = chai.expect;
+const jsdom = require( 'mocha-jsdom' );
 
-describe( 'web-storage-proxy', function() {
-  var webStorageProxy, sandbox, setItem, getItem, removeItem, setStorage;
+describe( 'web-storage-proxy', () => {
+  let webStorageProxy;
+  let sandbox;
+  let setItem;
+  let getItem;
+  let removeItem;
+  let setStorage;
 
   jsdom();
 
-  before( function() {
+  before( () => {
     webStorageProxy =
       require( BASE_JS_PATH + 'modules/util/web-storage-proxy.js' );
     setItem = webStorageProxy.setItem;
@@ -22,10 +27,10 @@ describe( 'web-storage-proxy', function() {
     sandbox = sinon.sandbox.create();
   } );
 
-  beforeEach( function() {
+  beforeEach( () => {
     // Storage Mock
     function storageMock() {
-      var storage = {};
+      const storage = {};
 
       return {
         setItem: function( key, value ) {
@@ -52,13 +57,13 @@ describe( 'web-storage-proxy', function() {
     window.sessionStorage = storageMock();
   } );
 
-  afterEach( function() {
+  afterEach( () => {
     sandbox.restore();
   } );
 
-  describe( '.setItem()', function() {
+  describe( '.setItem()', () => {
     it( 'should set an item of "bar" for the key "foo" in sessionStorage',
-      function() {
+      () => {
         setItem( 'foo', 'bar', window.sessionStorage );
         expect( window.sessionStorage.getItem( 'foo' ) ).to.equal( 'bar' );
         expect( window.localStorage.getItem( 'foo' ) ).to.be.undefined;
@@ -66,202 +71,169 @@ describe( 'web-storage-proxy', function() {
     );
 
     it( 'should set an item of "baz" for the key "foo" in localStorage',
-      function() {
+      () => {
         setItem( 'foo', 'baz', window.localStorage );
         expect( window.localStorage.getItem( 'foo' ) ).to.equal( 'baz' );
         expect( window.sessionStorage.getItem( 'foo' ) ).to.be.undefined;
       }
     );
 
-    it( 'should default to sessionStorage is storage arg is omitted',
-      function() {
-        setItem( 'foo', 'bar' );
-        expect( window.sessionStorage.getItem( 'foo' ) ).to.equal( 'bar' );
-        expect( window.localStorage.getItem( 'foo' ) ).to.be.undefined;
-      }
-    );
+    it( 'should default to sessionStorage is storage arg is omitted', () => {
+      setItem( 'foo', 'bar' );
+      expect( window.sessionStorage.getItem( 'foo' ) ).to.equal( 'bar' );
+      expect( window.localStorage.getItem( 'foo' ) ).to.be.undefined;
+    } );
 
-    it( 'should default to sessionStorage if storage arg is a string',
-      function() {
-        setItem( 'foo', 'baz', 'bar' );
-        expect( window.sessionStorage.getItem( 'foo' ) ).to.equal( 'baz' );
-        expect( window.localStorage.getItem( 'foo' ) ).to.be.undefined;
-      }
-    );
+    it( 'should default to sessionStorage if storage arg is a string', () => {
+      setItem( 'foo', 'baz', 'bar' );
+      expect( window.sessionStorage.getItem( 'foo' ) ).to.equal( 'baz' );
+      expect( window.localStorage.getItem( 'foo' ) ).to.be.undefined;
+    } );
 
-    it( 'should default to sessionStorage if storage arg is a boolean',
-      function() {
-        setItem( 'foo', 'baz', true );
-        expect( window.sessionStorage.getItem( 'foo' ) ).to.equal( 'baz' );
-        expect( window.localStorage.getItem( 'foo' ) ).to.be.undefined;
-      }
-    );
+    it( 'should default to sessionStorage if storage arg is a boolean', () => {
+      setItem( 'foo', 'baz', true );
+      expect( window.sessionStorage.getItem( 'foo' ) ).to.equal( 'baz' );
+      expect( window.localStorage.getItem( 'foo' ) ).to.be.undefined;
+    } );
   } );
 
 
-  describe( '.getItem()', function() {
-    beforeEach( function() {
+  describe( '.getItem()', () => {
+    beforeEach( () => {
       window.sessionStorage.setItem( 'foo', 'bar' );
       window.localStorage.setItem( 'foo', 'baz' );
     } );
 
     it( 'should return an item of "bar" for the key "foo" in sessionStorage',
-      function() {
-        var item = getItem( 'foo', window.sessionStorage );
+      () => {
+        const item = getItem( 'foo', window.sessionStorage );
         expect( item ).to.equal( 'bar' );
       }
     );
 
     it( 'should return an item of "baz" for the key "foo" in localStorage',
-      function() {
-        var item = getItem( 'foo', window.localStorage );
+      () => {
+        const item = getItem( 'foo', window.localStorage );
         expect( item ).to.equal( 'baz' );
       }
     );
 
     it( 'should default to sessionStorage if storage arg is omitted',
-      function() {
-        var item = getItem( 'foo' );
+      () => {
+        const item = getItem( 'foo' );
         expect( item ).to.equal( 'bar' );
       }
     );
 
     it( 'should default to sessionStorage if storage arg is a string',
-      function() {
-        var item = getItem( 'foo', 'baz' );
+      () => {
+        const item = getItem( 'foo', 'baz' );
         expect( item ).to.equal( 'bar' );
       }
     );
 
     it( 'should default to sessionStorage if storage arg is a boolean',
-      function() {
-        var item = getItem( 'foo', false );
+      () => {
+        const item = getItem( 'foo', false );
         expect( item ).to.equal( 'bar' );
       }
     );
   } );
 
-  describe( '.removeItem()', function() {
-    beforeEach( function() {
+  describe( '.removeItem()', () => {
+    beforeEach( () => {
       window.sessionStorage.setItem( 'foo', 'bar' );
       window.localStorage.setItem( 'foo', 'baz' );
     } );
 
-    it( 'should remove the key "foo" in sessionStorage',
-      function() {
-        removeItem( 'foo', window.sessionStorage );
-        expect( window.sessionStorage.getItem( 'foo' ) ).to.be.undefined;
-      }
-    );
+    it( 'should remove the key "foo" in sessionStorage', () => {
+      removeItem( 'foo', window.sessionStorage );
+      expect( window.sessionStorage.getItem( 'foo' ) ).to.be.undefined;
+    } );
 
-    it( 'should remove the key "foo" in localStorage',
-      function() {
-        removeItem( 'foo', window.localStorage );
-        expect( window.localStorage.getItem( 'foo' ) ).to.be.undefined;
-      }
-    );
+    it( 'should remove the key "foo" in localStorage', () => {
+      removeItem( 'foo', window.localStorage );
+      expect( window.localStorage.getItem( 'foo' ) ).to.be.undefined;
+    } );
 
-    it( 'should default to sessionStorage if storage arg is omitted',
-      function() {
-        removeItem( 'foo' );
-        expect( window.sessionStorage.getItem( 'foo' ) ).to.be.undefined;
-      }
-    );
+    it( 'should default to sessionStorage if storage arg is omitted', () => {
+      removeItem( 'foo' );
+      expect( window.sessionStorage.getItem( 'foo' ) ).to.be.undefined;
+    } );
 
-    it( 'should default to sessionStorage if storage arg is a string',
-      function() {
-        removeItem( 'foo', 'baz' );
-        expect( window.sessionStorage.getItem( 'foo' ) ).to.be.undefined;
-      }
-    );
+    it( 'should default to sessionStorage if storage arg is a string', () => {
+      removeItem( 'foo', 'baz' );
+      expect( window.sessionStorage.getItem( 'foo' ) ).to.be.undefined;
+    } );
 
-    it( 'should default to sessionStorage if storage arg is a boolean',
-      function() {
-        removeItem( 'foo', true );
-        expect( window.sessionStorage.getItem( 'foo' ) ).to.be.undefined;
-      }
-    );
+    it( 'should default to sessionStorage if storage arg is a boolean', () => {
+      removeItem( 'foo', true );
+      expect( window.sessionStorage.getItem( 'foo' ) ).to.be.undefined;
+    } );
 
-    it( 'should do nothing if passed key does not exist',
-      function() {
-        var removed = removeItem( 'baz' );
-        expect( window.sessionStorage.getItem( 'foo' ) ).to.equal( 'bar' );
-        expect( removed ).to.equal( false );
-      }
-    );
+    it( 'should do nothing if passed key does not exist', () => {
+      const removed = removeItem( 'baz' );
+      expect( window.sessionStorage.getItem( 'foo' ) ).to.equal( 'bar' );
+      expect( removed ).to.equal( false );
+    } );
   } );
 
-  describe( '.setStorage()', function() {
-    beforeEach( function() {
+  describe( '.setStorage()', () => {
+    beforeEach( () => {
       setStorage( window.localStorage );
     } );
 
-    it(
-      'should default to storage set in setStorage ' +
-      'if storage arg is omitted in setItem',
-      function() {
-        setItem( 'foo', 'bar' );
-        expect( window.localStorage.getItem( 'foo' ) ).to.equal( 'bar' );
-        expect( window.sessionStorage.getItem( 'foo' ) ).to.be.undefined;
+    it( 'should default to storage set in setStorage ' +
+        'if storage arg is omitted in setItem', () => {
+      setItem( 'foo', 'bar' );
+      expect( window.localStorage.getItem( 'foo' ) ).to.equal( 'bar' );
+      expect( window.sessionStorage.getItem( 'foo' ) ).to.be.undefined;
+    } );
+
+    it( 'should default to storage set in setStorage ' +
+        'if storage arg is omitted in getItem', () => {
+      window.localStorage.setItem( 'foo', 'bar' );
+      window.sessionStorage.setItem( 'foo', 'baz' );
+
+      var item = getItem( 'foo' );
+
+      expect( item ).to.equal( 'bar' );
+      expect( item ).to.not.equal( 'baz' );
+    } );
+
+    it( 'should default to storage set in setStorage' +
+        'if storage arg is omitted in removeItem', () => {
+      window.localStorage.setItem( 'foo', 'bar' );
+      window.sessionStorage.setItem( 'foo', 'baz' );
+
+      removeItem( 'foo', window.localStorage );
+      expect( window.localStorage.getItem( 'foo' ) ).to.be.undefined;
+      expect( window.sessionStorage.getItem( 'foo' ) ).to.equal( 'baz' );
+    } );
+
+    it( 'should throw an error if passed arg is empty', () => {
+      function storageError() {
+        setStorage();
       }
-    );
+      expect( storageError, Error ).to.throw( Error );
+    } );
 
-    it(
-      'should default to storage set in setStorage ' +
-      'if storage arg is omitted in getItem',
-      function() {
-        window.localStorage.setItem( 'foo', 'bar' );
-        window.sessionStorage.setItem( 'foo', 'baz' );
-
-        var item = getItem( 'foo' );
-
-        expect( item ).to.equal( 'bar' );
-        expect( item ).to.not.equal( 'baz' );
+    it( 'should throw an error if passed arg is a string', () => {
+      function storageError() {
+        setStorage( 'string' );
       }
-    );
+      expect( storageError, Error ).to.throw( Error );
+    } );
 
-    it(
-      'should default to storage set in setStorage' +
-      'if storage arg is omitted in removeItem',
-      function() {
-        window.localStorage.setItem( 'foo', 'bar' );
-        window.sessionStorage.setItem( 'foo', 'baz' );
-
-        removeItem( 'foo', window.localStorage );
-        expect( window.localStorage.getItem( 'foo' ) ).to.be.undefined;
-        expect( window.sessionStorage.getItem( 'foo' ) ).to.equal( 'baz' );
+    it( 'should throw an error if passed arg is a boolean', () => {
+      function storageError() {
+        setStorage( true );
       }
-    );
-
-    it( 'should throw an error if passed arg is empty',
-      function() {
-        function storageError() {
-          setStorage();
-        }
-        expect( storageError, Error ).to.throw( Error );
-      }
-    );
-
-    it( 'should throw an error if passed arg is a string',
-      function() {
-        function storageError() {
-          setStorage( 'string' );
-        }
-        expect( storageError, Error ).to.throw( Error );
-      }
-    );
-
-    it( 'should throw an error if passed arg is a boolean',
-      function() {
-        function storageError() {
-          setStorage( true );
-        }
-        expect( storageError, Error ).to.throw( Error );
-      }
-    );
+      expect( storageError, Error ).to.throw( Error );
+    } );
 
     xit( 'should set storage to an object if sessionStorage throws an error',
-      function() {
+      () => {
         // TODO: If cookies are disabled, window.sessionStorage
         //       will throw a SecurityError and the internal storage will be
         //       an object literal.

--- a/test/unit_tests/molecules/GlobalBanner-spec.js
+++ b/test/unit_tests/molecules/GlobalBanner-spec.js
@@ -1,70 +1,70 @@
 'use strict';
 
-var chai = require( 'chai' );
-var expect = chai.expect;
-var jsdom = require( 'mocha-jsdom' );
-var sinon = require( 'sinon' );
-var StorageMock = require( '../fixtures/StorageMock' );
+const chai = require( 'chai' );
+const expect = chai.expect;
+const jsdom = require( 'mocha-jsdom' );
+const sinon = require( 'sinon' );
+const StorageMock = require( '../fixtures/StorageMock' );
 
-var BASE_JS_PATH = '../../../cfgov/unprocessed/js/';
-var globalBanner;
-var clickEvent;
-var contentDom;
-var contentAnimatedDom;
-var GlobalBanner;
-var targetDom;
-var toggleStoredStateSpy;
-var webStorageProxy;
+const BASE_JS_PATH = '../../../cfgov/unprocessed/js/';
+let globalBanner;
+let clickEvent;
+let contentDom;
+let contentAnimatedDom;
+let GlobalBanner;
+let targetDom;
+let toggleStoredStateSpy;
+let webStorageProxy;
 
-describe( 'Global Banner State', function() {
+describe( 'Global Banner State', () => {
 
   jsdom();
 
-  before( function() {
+  before( () => {
     webStorageProxy =
       require( BASE_JS_PATH + 'modules/util/web-storage-proxy.js' );
   } );
 
-  beforeEach( function() {
+  beforeEach( () => {
 
     // TODO: Investigate importing the HTML directly from the atomic template.
     document.body.innerHTML =
-    '<div class="m-global-banner">' +
-    '<div class="wrapper ' +
-                'wrapper__match-content ' +
-                'o-expandable ' +
-                'o-expandable__expanded">' +
-        '<div class="m-global-banner_head">' +
-            '<span class="cf-icon ' +
-                         'cf-icon-error-round ' +
-                         'm-global-banner_icon"></span>' +
-            'This beta site is a work in progress.' +
-        '</div>' +
-        '<div class="o-expandable_content" ' +
-              'aria-expanded="true" style="height: 22px;">' +
-            '<p class="m-global-banner_desc ' +
-                      'o-expandable_content-animated">' +
-                'We’re prototyping new designs. ' +
-                'Things may not work as expected. ' +
-                'Our regular site continues to be at ' +
-                '<a href="http://www.consumerfinance.gov/">' +
-                    'www.consumerfinance.gov</a>.' +
-            '</p>' +
-        '</div>' +
-        '<button class="a-btn ' +
-                       'm-global-banner_btn ' +
-                       'o-expandable_target ' +
-                       'o-expandable_link" id="m-global-banner_btn" ' +
-                 'aria-pressed="true">' +
-            '<span class="o-expandable_cue o-expandable_cue-close">' +
-                'Collapse <span class="cf-icon cf-icon-up"></span>' +
-            '</span>' +
-            '<span class="o-expandable_cue o-expandable_cue-open">' +
-                'More info <span class="cf-icon cf-icon-down"></span>' +
-            '</span>' +
-        '</button>' +
-    '</div>' +
-    '</div>';
+      '<div class="m-global-banner">' +
+      '<div class="wrapper ' +
+                  'wrapper__match-content ' +
+                  'o-expandable ' +
+                  'o-expandable__expanded">' +
+          '<div class="m-global-banner_head">' +
+              '<span class="cf-icon ' +
+                           'cf-icon-error-round ' +
+                           'm-global-banner_icon"></span>' +
+              'This beta site is a work in progress.' +
+          '</div>' +
+          '<div class="o-expandable_content" ' +
+                'aria-expanded="true" style="height: 22px;">' +
+              '<p class="m-global-banner_desc ' +
+                        'o-expandable_content-animated">' +
+                  'We’re prototyping new designs. ' +
+                  'Things may not work as expected. ' +
+                  'Our regular site continues to be at ' +
+                  '<a href="http://www.consumerfinance.gov/">' +
+                      'www.consumerfinance.gov</a>.' +
+              '</p>' +
+          '</div>' +
+          '<button class="a-btn ' +
+                         'm-global-banner_btn ' +
+                         'o-expandable_target ' +
+                         'o-expandable_link" id="m-global-banner_btn" ' +
+                   'aria-pressed="true">' +
+              '<span class="o-expandable_cue o-expandable_cue-close">' +
+                  'Collapse <span class="cf-icon cf-icon-up"></span>' +
+              '</span>' +
+              '<span class="o-expandable_cue o-expandable_cue-open">' +
+                  'More info <span class="cf-icon cf-icon-down"></span>' +
+              '</span>' +
+          '</button>' +
+      '</div>' +
+      '</div>';
 
     contentDom = document.querySelector( '.o-expandable_content' );
     contentAnimatedDom =
@@ -85,66 +85,65 @@ describe( 'Global Banner State', function() {
     toggleStoredStateSpy = sinon.spy( globalBanner, 'toggleStoredState' );
   } );
 
-  afterEach( function() {
+  afterEach( () => {
     // Removed spy from method.
     globalBanner.toggleStoredState.restore();
   } );
 
-  describe( 'init', function() {
-    it( 'should have instantiated an Expandable instance', function() {
+  describe( 'init', () => {
+    it( 'should have instantiated an Expandable instance', () => {
       globalBanner.init();
-      var isExpandable = contentDom.hasAttribute( 'style' );
+      const isExpandable = contentDom.hasAttribute( 'style' );
       expect( isExpandable ).to.be.true;
     } );
 
-    it( 'should have called the initEvents function', function() {
+    it( 'should have called the initEvents function', () => {
       globalBanner.init();
       targetDom.dispatchEvent( clickEvent );
 
-      window.setTimeout( function() {
+      window.setTimeout( () => {
         expect( toggleStoredStateSpy.called ).to.be.true;
       }, 0 );
     } );
   } );
 
-  describe( 'toggleStoredState', function() {
-    it( 'should set the localStorage state to collasped', function() {
+  describe( 'toggleStoredState', () => {
+    it( 'should set the localStorage state to collasped', () => {
       expect( webStorageProxy.getItem( 'globalBannerIsExpanded' ) )
        .to.be.undefined;
       globalBanner.init();
       globalBanner.toggleStoredState();
-      var isSet = webStorageProxy.getItem( 'globalBannerIsExpanded' );
+      const isSet = webStorageProxy.getItem( 'globalBannerIsExpanded' );
       expect( isSet ).to.equal( 'false' );
     } );
 
-    it( 'should set the localStorage state to expanded', function() {
+    it( 'should set the localStorage state to expanded', () => {
       expect( webStorageProxy.getItem( 'globalBannerIsExpanded' ) )
         .to.be.undefined;
       globalBanner.init();
       globalBanner.toggleStoredState();
       globalBanner.toggleStoredState();
-      var isSet = webStorageProxy.getItem( 'globalBannerIsExpanded' );
+      const isSet = webStorageProxy.getItem( 'globalBannerIsExpanded' );
       expect( isSet ).to.equal( 'true' );
     } );
   } );
 
-  describe( 'destroy', function() {
-    it( 'should remove event handlers and local storage data', function() {
+  describe( 'destroy', () => {
+    it( 'should remove event handlers and local storage data', () => {
       globalBanner.init();
       globalBanner.toggleStoredState();
-      var isSet = webStorageProxy.getItem( 'globalBannerIsExpanded' );
+      let isSet = webStorageProxy.getItem( 'globalBannerIsExpanded' );
       expect( isSet ).to.equal( 'false' );
       globalBanner.destroy();
       isSet = webStorageProxy.getItem( 'globalBannerIsExpanded' );
       expect( isSet ).to.be.undefined;
 
       targetDom.dispatchEvent( clickEvent );
-      window.setTimeout( function() {
+      window.setTimeout( () => {
         expect( toggleStoredStateSpy.called ).to.be.false;
       }, 0 );
 
     } );
   } );
-
 
 } );

--- a/test/unit_tests/molecules/GlobalSearch-spec.js
+++ b/test/unit_tests/molecules/GlobalSearch-spec.js
@@ -1,10 +1,11 @@
 'use strict';
-var BASE_JS_PATH = '../../../cfgov/unprocessed/js/';
 
-var chai = require( 'chai' );
-var expect = chai.expect;
-var GlobalSearch = require( BASE_JS_PATH + 'molecules/GlobalSearch' );
+const BASE_JS_PATH = '../../../cfgov/unprocessed/js/';
 
-describe( 'GlobalSearch', function() {
+const chai = require( 'chai' );
+const expect = chai.expect;
+const GlobalSearch = require( BASE_JS_PATH + 'molecules/GlobalSearch' );
+
+describe( 'GlobalSearch', () => {
   // TODO: Implement tests.
 } );

--- a/test/unit_tests/organisms/Expandable-spec.js
+++ b/test/unit_tests/organisms/Expandable-spec.js
@@ -1,10 +1,11 @@
 'use strict';
-var BASE_JS_PATH = '../../../cfgov/unprocessed/js/';
 
-var chai = require( 'chai' );
-var expect = chai.expect;
-var Expandable = require( BASE_JS_PATH + 'organisms/Expandable' );
+const BASE_JS_PATH = '../../../cfgov/unprocessed/js/';
 
-describe( 'Expandable', function() {
+const chai = require( 'chai' );
+const expect = chai.expect;
+const Expandable = require( BASE_JS_PATH + 'organisms/Expandable' );
+
+describe( 'Expandable', () => {
   // TODO: Implement tests.
 } );

--- a/test/unit_tests/organisms/ExpandableGroup-spec.js
+++ b/test/unit_tests/organisms/ExpandableGroup-spec.js
@@ -1,10 +1,11 @@
 'use strict';
-var BASE_JS_PATH = '../../../cfgov/unprocessed/js/';
 
-var chai = require( 'chai' );
-var expect = chai.expect;
-var ExpandableGroup = require( BASE_JS_PATH + 'organisms/ExpandableGroup' );
+const BASE_JS_PATH = '../../../cfgov/unprocessed/js/';
 
-describe( 'ExpandableGroup', function() {
+const chai = require( 'chai' );
+const expect = chai.expect;
+const ExpandableGroup = require( BASE_JS_PATH + 'organisms/ExpandableGroup' );
+
+describe( 'ExpandableGroup', () => {
   // TODO: Implement tests.
 } );

--- a/test/unit_tests/organisms/FilterableListControls-spec.js
+++ b/test/unit_tests/organisms/FilterableListControls-spec.js
@@ -1,15 +1,16 @@
 'use strict';
-var BASE_JS_PATH = '../../../cfgov/unprocessed/js/';
 
-var chai = require( 'chai' );
-var expect = chai.expect;
-var jsdom = require( 'mocha-jsdom' );
+const BASE_JS_PATH = '../../../cfgov/unprocessed/js/';
 
-describe( 'FilterableListControls', function() {
+const chai = require( 'chai' );
+const expect = chai.expect;
+const jsdom = require( 'mocha-jsdom' );
+
+describe( 'FilterableListControls', () => {
   jsdom();
 
-  before( function() {
-    var FilterableListControls =
+  before( () => {
+    const FilterableListControls =
      require( BASE_JS_PATH + 'organisms/FilterableListControls' );
   } );
 

--- a/test/unit_tests/organisms/Footer-spec.js
+++ b/test/unit_tests/organisms/Footer-spec.js
@@ -1,24 +1,24 @@
 'use strict';
 
-var chai = require( 'chai' );
-var expect = chai.expect;
-var jsdom = require( 'mocha-jsdom' );
-var sinon = require( 'sinon' );
+const chai = require( 'chai' );
+const expect = chai.expect;
+const jsdom = require( 'mocha-jsdom' );
+const sinon = require( 'sinon' );
 
-var BASE_JS_PATH = '../../../cfgov/unprocessed/js/';
-var FooterButton = require( BASE_JS_PATH + 'modules/footer-button.js' );
+const BASE_JS_PATH = '../../../cfgov/unprocessed/js/';
+const FooterButton = require( BASE_JS_PATH + 'modules/footer-button.js' );
 
-var footerBtnDom;
-var bodyDom;
-var sandbox;
-var lastTime = 0;
+let footerBtnDom;
+let bodyDom;
+let sandbox;
+let lastTime = 0;
 
-var HTML_SNIPPET =
-    '<a class="a-btn a-btn__secondary o-footer_top-button" ' +
-        'data-gtm_ignore="true" data-js-hook="behavior_return-to-top" ' +
-        'href="#">' +
-        'Back to top <span class="cf-icon cf-icon-arrow-up"></span>' +
-    '</a>';
+const HTML_SNIPPET =
+  '<a class="a-btn a-btn__secondary o-footer_top-button" ' +
+      'data-gtm_ignore="true" data-js-hook="behavior_return-to-top" ' +
+      'href="#">' +
+      'Back to top <span class="cf-icon cf-icon-arrow-up"></span>' +
+  '</a>';
 
 function triggerClick( target ) {
   var clickEvent = new window.MouseEvent( 'click', {
@@ -49,17 +49,17 @@ function requestAnimationFrame( callback ) {
   return id;
 }
 
-describe( 'Footer', function() {
+describe( 'Footer', () => {
   jsdom();
 
-  before( function() {
+  before( () => {
     sandbox = sinon.sandbox.create();
 
     global.NodeList = window.NodeList;
     global.Node = window.Node;
   } );
 
-  beforeEach( function( ) {
+  beforeEach( () => {
     bodyDom = document.body;
     bodyDom.innerHTML = HTML_SNIPPET;
     footerBtnDom = document.querySelector( '.o-footer_top-button' );
@@ -68,7 +68,7 @@ describe( 'Footer', function() {
     window.scrollTo = scrollTo;
   } );
 
-  afterEach( function() {
+  afterEach( () => {
     sandbox.restore();
   } );
 
@@ -78,9 +78,10 @@ describe( 'Footer', function() {
       FooterButton.init();
       triggerClick( footerBtnDom );
       this.timeout( 3000 );
-      window.setTimeout( function( ) {
+      window.setTimeout( () => {
         expect( window.scrollY ).to.equal( 0 );
         done();
       }, 2000 );
-    } );
+    }
+  );
 } );

--- a/test/unit_tests/organisms/Header-spec.js
+++ b/test/unit_tests/organisms/Header-spec.js
@@ -1,10 +1,11 @@
 'use strict';
-var BASE_JS_PATH = '../../../cfgov/unprocessed/js/';
 
-var chai = require( 'chai' );
-var expect = chai.expect;
-var Header = require( BASE_JS_PATH + 'organisms/Header' );
+const BASE_JS_PATH = '../../../cfgov/unprocessed/js/';
 
-describe( 'Header', function() {
+const chai = require( 'chai' );
+const expect = chai.expect;
+const Header = require( BASE_JS_PATH + 'organisms/Header' );
+
+describe( 'Header', () => {
   // TODO: Implement tests.
 } );

--- a/test/unit_tests/organisms/MegaMenu-spec.js
+++ b/test/unit_tests/organisms/MegaMenu-spec.js
@@ -1,10 +1,11 @@
 'use strict';
-var BASE_JS_PATH = '../../../cfgov/unprocessed/js/';
 
-var chai = require( 'chai' );
-var expect = chai.expect;
-var MegaMenu = require( BASE_JS_PATH + 'organisms/MegaMenu' );
+const BASE_JS_PATH = '../../../cfgov/unprocessed/js/';
 
-describe( 'MegaMenu', function() {
+const chai = require( 'chai' );
+const expect = chai.expect;
+const MegaMenu = require( BASE_JS_PATH + 'organisms/MegaMenu' );
+
+describe( 'MegaMenu', () => {
   // TODO: Implement tests.
 } );

--- a/test/unit_tests/organisms/MegaMenuDesktop-spec.js
+++ b/test/unit_tests/organisms/MegaMenuDesktop-spec.js
@@ -1,10 +1,11 @@
 'use strict';
-var BASE_JS_PATH = '../../../cfgov/unprocessed/js/';
 
-var chai = require( 'chai' );
-var expect = chai.expect;
-var MegaMenuDesktop = require( BASE_JS_PATH + 'organisms/MegaMenuDesktop' );
+const BASE_JS_PATH = '../../../cfgov/unprocessed/js/';
 
-describe( 'MegaMenuDesktop', function() {
+const chai = require( 'chai' );
+const expect = chai.expect;
+const MegaMenuDesktop = require( BASE_JS_PATH + 'organisms/MegaMenuDesktop' );
+
+describe( 'MegaMenuDesktop', () => {
   // TODO: Implement tests.
 } );

--- a/test/unit_tests/organisms/MegaMenuMobile-spec.js
+++ b/test/unit_tests/organisms/MegaMenuMobile-spec.js
@@ -1,10 +1,11 @@
 'use strict';
-var BASE_JS_PATH = '../../../cfgov/unprocessed/js/';
 
-var chai = require( 'chai' );
-var expect = chai.expect;
-var MegaMenuMobile = require( BASE_JS_PATH + 'organisms/MegaMenuMobile' );
+const BASE_JS_PATH = '../../../cfgov/unprocessed/js/';
 
-describe( 'MegaMenuMobile', function() {
+const chai = require( 'chai' );
+const expect = chai.expect;
+const MegaMenuMobile = require( BASE_JS_PATH + 'organisms/MegaMenuMobile' );
+
+describe( 'MegaMenuMobile', () => {
   // TODO: Implement tests.
 } );

--- a/test/unit_tests/organisms/MortgagePerformanceTrends/actions-spec.js
+++ b/test/unit_tests/organisms/MortgagePerformanceTrends/actions-spec.js
@@ -2,15 +2,15 @@
 const BASE_JS_PATH = '../../../../cfgov/unprocessed/js/';
 
 const chai = require( 'chai' );
-const mockery = require('mockery');
+const mockery = require( 'mockery' );
 const expect = chai.expect;
 
 // Disable the AJAX library used by the action creator
 const noop = () => ( {} );
-mockery.enable({
+mockery.enable( {
   warnOnReplace: false,
   warnOnUnregistered: false
-});
+} );
 mockery.registerMock( 'xdr', noop );
 
 const actions = require( BASE_JS_PATH + 'organisms/MortgagePerformanceTrends/actions.js' );

--- a/test/unit_tests/organisms/MortgagePerformanceTrends/stores/chart-spec.js
+++ b/test/unit_tests/organisms/MortgagePerformanceTrends/stores/chart-spec.js
@@ -97,7 +97,7 @@ describe( 'Mortgage Performance line chart store', () => {
   } );
 
   it( 'should properly reduce loading metros state', () => {
-    let action = {
+    const action = {
       type: 'REQUEST_METROS'
     };
     store.dispatch( action );
@@ -105,7 +105,7 @@ describe( 'Mortgage Performance line chart store', () => {
   } );
 
   it( 'should properly reduce loading counties state', () => {
-    let action = {
+    const action = {
       type: 'REQUEST_COUNTIES'
     };
     store.dispatch( action );
@@ -113,7 +113,7 @@ describe( 'Mortgage Performance line chart store', () => {
   } );
 
   it( 'should properly reduce metros', () => {
-    let action = {
+    const action = {
       type: 'SET_METROS',
       metros: { 12345: 'Akron, OH' }
     };
@@ -122,7 +122,7 @@ describe( 'Mortgage Performance line chart store', () => {
   } );
 
   it( 'should properly reduce counties', () => {
-    let action = {
+    const action = {
       type: 'SET_COUNTIES',
       counties: { 12345: 'Acme County' }
     };

--- a/test/unit_tests/organisms/MortgagePerformanceTrends/stores/map-spec.js
+++ b/test/unit_tests/organisms/MortgagePerformanceTrends/stores/map-spec.js
@@ -97,7 +97,7 @@ describe( 'Mortgage Performance map store', () => {
   } );
 
   it( 'should properly reduce loading metros state', () => {
-    let action = {
+    const action = {
       type: 'REQUEST_METROS'
     };
     store.dispatch( action );
@@ -105,7 +105,7 @@ describe( 'Mortgage Performance map store', () => {
   } );
 
   it( 'should properly reduce loading counties state', () => {
-    let action = {
+    const action = {
       type: 'REQUEST_COUNTIES'
     };
     store.dispatch( action );
@@ -113,7 +113,7 @@ describe( 'Mortgage Performance map store', () => {
   } );
 
   it( 'should properly reduce metros', () => {
-    let action = {
+    const action = {
       type: 'SET_METROS',
       metros: { 12345: 'Akron, OH' }
     };
@@ -122,7 +122,7 @@ describe( 'Mortgage Performance map store', () => {
   } );
 
   it( 'should properly reduce counties', () => {
-    let action = {
+    const action = {
       type: 'SET_COUNTIES',
       counties: { 12345: 'Acme County' }
     };

--- a/test/unit_tests/organisms/SecondaryNavigation-spec.js
+++ b/test/unit_tests/organisms/SecondaryNavigation-spec.js
@@ -1,11 +1,12 @@
 'use strict';
-var BASE_JS_PATH = '../../../cfgov/unprocessed/js/';
 
-var chai = require( 'chai' );
-var expect = chai.expect;
-var SecondaryNavigation =
+const BASE_JS_PATH = '../../../cfgov/unprocessed/js/';
+
+const chai = require( 'chai' );
+const expect = chai.expect;
+const SecondaryNavigation =
   require( BASE_JS_PATH + 'organisms/SecondaryNavigation' );
 
-describe( 'SecondaryNavigation', function() {
+describe( 'SecondaryNavigation', () => {
   // TODO: Implement tests.
 } );


### PR DESCRIPTION
## Changes

- Converts unit tests to ES6 syntax.
- Autofixes linter issues.

## Testing

1. `gulp test` and `gulp test:acceptance` should pass.
