### PR TITLE
Refactor `post_sqs_messages` script

### DIFF
--- a/cfgov/alerts/github_alert.py
+++ b/cfgov/alerts/github_alert.py
@@ -3,34 +3,39 @@ import os
 import github3
 
 
-class GithubAlert:
+class GithubAlert(object):
     def __init__(self, credentials):
-        token = credentials.get(
+        self.token = credentials.get(
             'token',
             os.environ.get('GITHUB_TOKEN')
         )
-        url = credentials.get(
+        self.url = credentials.get(
             'url',
             os.environ.get('GITHUB_URL')
         )
-        user = credentials.get(
+        self.user = credentials.get(
             'user',
             os.environ.get('GITHUB_USER')
         )
-        repo_name = credentials.get(
+        self.repo_name = credentials.get(
             'repo_name',
             os.environ.get('GITHUB_REPO')
         )
 
-        gh = github3.login(
-            token=token,
-            url=url,
-        )
-
-        self.repo = gh.repository(user, repo_name)
+    def repo(self):
+        try:
+            gh = github3.login(
+                token=self.token,
+                url=self.url,
+            )
+            return gh.repository(self.user, self.repo_name)
+        except:
+            raise ValueError(
+                'Github credentials provided are incorrect'
+            )
 
     def matching_issue(self, title):
-        issues = self.repo.iter_issues(state='all')
+        issues = self.repo().iter_issues(state='all')
         return next((issue for issue in issues if issue.title == title), None)
 
     def post(self, title, body):
@@ -42,7 +47,7 @@ class GithubAlert:
             issue.create_comment(body=body)
         else:
             # New issue, post to github
-            issue = self.repo.create_issue(
+            issue = self.repo().create_issue(
                 title=title,
                 body=body,
                 labels=[

--- a/cfgov/alerts/github_alert.py
+++ b/cfgov/alerts/github_alert.py
@@ -23,16 +23,11 @@ class GithubAlert(object):
         )
 
     def repo(self):
-        try:
-            gh = github3.login(
-                token=self.token,
-                url=self.url,
-            )
-            return gh.repository(self.user, self.repo_name)
-        except:
-            raise ValueError(
-                'Github credentials provided are incorrect'
-            )
+        gh = github3.login(
+            token=self.token,
+            url=self.url,
+        )
+        return gh.repository(self.user, self.repo_name)
 
     def matching_issue(self, title):
         issues = self.repo().iter_issues(state='all')

--- a/cfgov/alerts/github_alert.py
+++ b/cfgov/alerts/github_alert.py
@@ -1,0 +1,53 @@
+import os
+
+import github3
+
+
+class GithubAlert:
+    def __init__(self, credentials):
+        token = credentials.get(
+            'token',
+            os.environ.get('GITHUB_TOKEN')
+        )
+        url = credentials.get(
+            'url',
+            os.environ.get('GITHUB_URL')
+        )
+        user = credentials.get(
+            'user',
+            os.environ.get('GITHUB_USER')
+        )
+        repo_name = credentials.get(
+            'repo_name',
+            os.environ.get('GITHUB_REPO')
+        )
+
+        gh = github3.login(
+            token=token,
+            url=url,
+        )
+
+        self.repo = gh.repository(user, repo_name)
+
+    def matching_issue(self, title):
+        issues = self.repo.iter_issues(state='all')
+        return next((issue for issue in issues if issue.title == title), None)
+
+    def post(self, title, body):
+        issue = self.matching_issue(title)
+        if issue:  # Issue already exists
+            if issue.is_closed():
+                issue.reopen()
+            # add comment to it to document it happened again
+            issue.create_comment(body=body)
+        else:
+            # New issue, post to github
+            issue = self.repo.create_issue(
+                title=title,
+                body=body,
+                labels=[
+                    'Maintenance and Response',
+                    'alert'
+                ],
+            )
+        return issue

--- a/cfgov/alerts/mattermost_alert.py
+++ b/cfgov/alerts/mattermost_alert.py
@@ -19,7 +19,8 @@ class MattermostAlert(object):
             'text': text,
             'username': self.username,
         }
-        requests.post(
+        resp = requests.post(
             self.webhook_url,
             data=json.dumps(payload),
         )
+        resp.raise_for_status()

--- a/cfgov/alerts/mattermost_alert.py
+++ b/cfgov/alerts/mattermost_alert.py
@@ -1,0 +1,25 @@
+import json
+import os
+import requests
+
+
+class MattermostAlert:
+    def __init__(self, credentials):
+        self.username = credentials.get(
+            'username',
+            os.environ.get('MATTERMOST_USERNAME')
+        )
+        self.webhook_url = credentials.get(
+            'webhook_url',
+            os.environ.get('MATTERMOST_WEBHOOK_URL')
+        )
+
+    def post(self, text):
+        payload = {
+            'text': text,
+            'username': self.username,
+        }
+        requests.post(
+            self.webhook_url,
+            data=json.dumps(payload),
+        )

--- a/cfgov/alerts/mattermost_alert.py
+++ b/cfgov/alerts/mattermost_alert.py
@@ -3,7 +3,7 @@ import os
 import requests
 
 
-class MattermostAlert:
+class MattermostAlert(object):
     def __init__(self, credentials):
         self.username = credentials.get(
             'username',

--- a/cfgov/alerts/post_sqs_messages.py
+++ b/cfgov/alerts/post_sqs_messages.py
@@ -69,7 +69,7 @@ def process_sqs_message(message, github_alert, mattermost_alert):
     body = cleanup_message(message.get('Body'))
     title = body.split(" - ")[0]
 
-    logger.info('Retrieved message {} from SQS'.format(body))
+    logger.debug('Retrieved message {} from SQS'.format(body))
 
     issue = github_alert.post(
         title=title,
@@ -127,6 +127,6 @@ if __name__ == '__main__':
             QueueUrl=args.queue_url,
             ReceiptHandle=message.get('ReceiptHandle')
         )
-        logger.info(
+        logger.debug(
             'Deleted message {} from SQS'.format(message.get('Body'))
         )

--- a/cfgov/alerts/post_sqs_messages.py
+++ b/cfgov/alerts/post_sqs_messages.py
@@ -4,8 +4,8 @@ import argparse
 import boto3
 import logging
 
-from github_alert import GithubAlert
-from mattermost_alert import MattermostAlert
+from alerts.github_alert import GithubAlert
+from alerts.mattermost_alert import MattermostAlert
 
 logger = logging.getLogger(__name__)
 parser = argparse.ArgumentParser()

--- a/cfgov/alerts/post_sqs_messages.py
+++ b/cfgov/alerts/post_sqs_messages.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 import argparse
 import boto3
 import logging
@@ -70,7 +72,7 @@ def post_message(body, title, github_creds={}, mattermost_creds={}):
         )
 
 
-def cleanup_jenkins_message(message):
+def cleanup_message(message):
     return message.replace(
         '#', '# '  # Avoids erroneous Github issue link
     ).replace(
@@ -110,7 +112,7 @@ if __name__ == '__main__':
     )
 
     for message in response.get('Messages', {}):
-        body = cleanup_jenkins_message(message.get('Body'))
+        body = cleanup_message(message.get('Body'))
         title = body.split(" - ")[0]
 
         logger.info('Retrieved message {} from SQS'.format(body))

--- a/cfgov/alerts/tests/test_github_alert.py
+++ b/cfgov/alerts/tests/test_github_alert.py
@@ -1,0 +1,74 @@
+# -*- coding: utf-8 -*-
+
+from django.test import TestCase
+from mock import patch
+
+import github3
+
+from alerts.github_alert import GithubAlert
+
+
+class TestGithubAlert(TestCase):
+
+    closed_issue = github3.issues.issue.Issue(
+        {
+            'html_url': 'https://github.com/foo/bar/issues/1',
+            'labels': [],
+            'user': {},
+            'closed_at': '2017-02-12T13:22:01Z',
+        }
+    )
+
+    open_issue = github3.issues.issue.Issue(
+        {
+            'html_url': 'https://github.com/foo/bar/issues/2',
+            'labels': [],
+            'user': {},
+            'closed_at': None,
+        }
+    )
+
+    def setUp(self):
+        self.text = u'foö'
+
+    @patch('github3.issues.issue.Issue.create_comment')
+    @patch(
+        'alerts.github_alert.GithubAlert.matching_issue',
+        return_value=open_issue
+    )
+    def test_comment(self, matching_issue, create_comment):
+        """ Test that we add a comment when a matching issue is found """
+        GithubAlert({}).post(title=self.text, body=self.text)
+        create_comment.assert_called_once_with(body=self.text)
+
+    @patch('github3.issues.issue.Issue.create_comment')
+    @patch('github3.issues.issue.Issue.reopen')
+    @patch(
+        'alerts.github_alert.GithubAlert.matching_issue',
+        return_value=closed_issue
+    )
+    def test_reopen(self, matching_issue, reopen, create_comment):
+        """ Test that we reopen a Github issue if it was previously closed """
+        GithubAlert({}).post(title=self.text, body=self.text)
+        reopen.assert_called_once_with()
+
+    @patch('github3.repos.repo.Repository.create_issue')
+    @patch(
+        'alerts.github_alert.GithubAlert.repo',
+        return_value=github3.repos.repo.Repository({})
+    )
+    @patch(
+        'alerts.github_alert.GithubAlert.matching_issue',
+        return_value=None,
+    )
+    def test_create_issue(self, matching_issue, repo, create_issue):
+        """ Test that we create an issue when no issue is found """
+        GithubAlert({}).post(title=self.text, body=self.text)
+        create_issue.assert_called_once_with(
+            title=self.text,
+            body=self.text,
+            labels=[
+                'Maintenance and Response',
+                'alert'
+            ],
+        )

--- a/cfgov/alerts/tests/test_mattermost_alert.py
+++ b/cfgov/alerts/tests/test_mattermost_alert.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+
+from django.test import TestCase
+from mock import patch
+
+import json
+
+from alerts.mattermost_alert import MattermostAlert
+
+
+class TestMattermostAlert(TestCase):
+
+    @patch('requests.post')
+    def test_post(self, mock):
+        """ Test that calling MattermostAlert.post
+        makes a requests post with the right parameters
+        """
+        webhook_url = 'www.testurl.com'
+        username = 'test'
+        credentials = {'username': username, 'webhook_url': webhook_url}
+        text = u'foö'
+
+        MattermostAlert(credentials).post(text)
+        mock.assert_called_with(
+            webhook_url,
+            data=json.dumps({'text': text, 'username': username})
+        )

--- a/cfgov/alerts/tests/test_mattermost_alert.py
+++ b/cfgov/alerts/tests/test_mattermost_alert.py
@@ -21,7 +21,7 @@ class TestMattermostAlert(TestCase):
         text = u'foö'
 
         MattermostAlert(credentials).post(text)
-        mock.assert_called_with(
+        mock.assert_called_once_with(
             webhook_url,
             data=json.dumps({'text': text, 'username': username})
         )

--- a/cfgov/alerts/tests/test_post_sqs_messages.py
+++ b/cfgov/alerts/tests/test_post_sqs_messages.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+
+from django.test import TestCase
+from mock import patch
+
+import github3
+
+from alerts.github_alert import GithubAlert
+from alerts.mattermost_alert import MattermostAlert
+from alerts.post_sqs_messages import process_sqs_message
+
+
+class TestPostSQSMessages(TestCase):
+
+    issue = github3.issues.issue.Issue(
+        {
+            'html_url': 'https://github.com/foo/bar/issues/42',
+            'labels': [],
+            'user': {},
+        }
+    )
+
+    @patch('alerts.mattermost_alert.MattermostAlert.post')
+    @patch(
+        'alerts.github_alert.GithubAlert.post',
+        return_value=issue
+    )
+    def test_process_sqs_message(self, github_post, mattermost_post):
+        """ Test that we post to Github and
+        Mattermost with the desired information
+        """
+        process_sqs_message(
+            {'Body': 'Test Job #1234 - Failed'},
+            GithubAlert({}),
+            MattermostAlert({})
+        )
+
+        github_post.assert_called_once_with(
+            title='Test Job # 1234',
+            body='Test Job # 1234 - Failed'
+        )
+        mattermost_post.assert_called_once_with(
+            text=('Alert: Test Job # 1234 - Failed. '
+                  'Github issue at https://github.com/foo/bar/issues/42')
+        )

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,5 +1,6 @@
 -r base.txt
 
+boto3==1.4.6
 configparser==3.5.0
 coverage==4.2
 django-sslserver==0.19

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -5,6 +5,7 @@ coverage==4.2
 django-sslserver==0.19
 enum34==1.1.6
 flake8==3.0.4
+github3.py==0.9.6
 mccabe==0.5.2
 mock==2.0.0
 model_mommy==1.2.6


### PR DESCRIPTION
In addition to cleaning up some of this code, this was necessary for a branch I'm working on which needs to reuse the "post to github" functionality (see https://github.com/cfpb/cfgov-refresh/pull/3322/files#diff-a2de39d3ae75d0257afafb3cb2d587ce)
