### PR TITLE
Post Django errors to Github

### DIFF
--- a/cfgov/alerts/logging_handlers.py
+++ b/cfgov/alerts/logging_handlers.py
@@ -4,9 +4,6 @@ from alerts.github_alert import GithubAlert
 
 
 class CFGovErrorHandler(logging.Handler):
-    def __init__(self):
-        logging.Handler.__init__(self)
-
     def emit(self, record):
         GithubAlert({}).post(
             title=record.message[:30],

--- a/cfgov/alerts/logging_handlers.py
+++ b/cfgov/alerts/logging_handlers.py
@@ -1,0 +1,14 @@
+import logging
+
+from alerts.github_alert import GithubAlert
+
+
+class CFGovErrorHandler(logging.Handler):
+    def __init__(self):
+        logging.Handler.__init__(self)
+
+    def emit(self, record):
+        GithubAlert({}).post(
+            title=record.message[:30],
+            body=record.message,
+        )

--- a/cfgov/alerts/tests/test_logging_handlers.py
+++ b/cfgov/alerts/tests/test_logging_handlers.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+
+from django.test import TestCase
+from mock import patch, MagicMock
+
+from alerts.logging_handlers import CFGovErrorHandler
+
+
+class TestLoggingHandlers(TestCase):
+
+    @patch('alerts.github_alert.GithubAlert.post')
+    def test_emit(self, github_alert):
+        """ Test that calling CFGOVErrorHandler.emit
+        makes a GithubAlert post with the right parameters
+        """
+        message = (u'Internal Server Error: /tést-page/'
+                   'Traceback (most recent call last):'
+                   '... more details ...')
+        record = MagicMock(message=message)
+        CFGovErrorHandler().emit(record)
+        github_alert.assert_called_once_with(
+            title=message[:30],
+            body=message,
+        )

--- a/cfgov/cfgov/settings/production.py
+++ b/cfgov/cfgov/settings/production.py
@@ -41,6 +41,10 @@ LOGGING = {
             'level': 'DEBUG',
             'class': 'logging.StreamHandler',
         },
+        'db': {
+            'level': 'ERROR',
+            'class': 'alerts.logging_handlers.CFGovErrorHandler',
+        }
         'syslog': {
             'address': syslog_device,
             'class': 'logging.handlers.SysLogHandler',
@@ -49,7 +53,7 @@ LOGGING = {
     },
     'loggers': {
         'django.request': {
-            'handlers': ['console'],
+            'handlers': ['console', 'db'],
             'level': 'WARNING',
             'propagate': True,
         },


### PR DESCRIPTION
- Adds a logging handler to intercept any logging statements of level `ERROR`
- Posts them to Github Enterprise as issues, as we are doing with Jenkins failures and New Relic incidents