### PR TITLE
Remove logging statement from FilterableList

### DIFF
--- a/cfgov/v1/util/filterable_list.py
+++ b/cfgov/v1/util/filterable_list.py
@@ -1,13 +1,9 @@
-import logging
-
 from django.core.paginator import EmptyPage, PageNotAnInteger, Paginator
 
 from v1.forms import FilterableListForm
 from v1.models.base import CFGOVPage
 from v1.models.learn_page import AbstractFilterPage
 from v1.util.util import get_secondary_nav_items
-
-logger = logging.getLogger(__name__)
 
 
 class FilterableListMixin(object):
@@ -25,7 +21,6 @@ class FilterableListMixin(object):
         return context
 
     def base_query(self, hostname):
-        logger.info('Filtering by parent {}'.format(self))
         return AbstractFilterPage.objects.live().filter(
             CFGOVPage.objects.child_of_q(self))
 


### PR DESCRIPTION
This change removes the logging statement that happens when a FilterableList is invoked, e.g. `Filtering by parent Foo`. This might be useful from a debugging POV but seems excessive for general use.

## Removals

- Logging statement from FilterableList.

## Testing

1. All unit tests continue to pass; this is a non-functional change.

## Checklist

* [X] PR has an informative and human-readable title
* [X] Changes are limited to a single goal (no scope creep)
* [X] Code can be automatically merged (no conflicts)
* [X] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [X] Passes all existing automated tests
* [X] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
