### PR TITLE
Correct the markup within the sorting buttons in sortable-tables

### DIFF
--- a/cfgov/jinja2/v1/_includes/organisms/table.html
+++ b/cfgov/jinja2/v1/_includes/organisms/table.html
@@ -65,7 +65,7 @@
                 {% if flag_enabled('SORTABLE_TABLES', true) and value.is_sortable and value.sortable_types[loop.index0] != '' %}
                     {% set data_sort = ' data-sort_type="' + value.sortable_types[loop.index0] + '"' %}
                     <button class="sortable"{{ data_sort }}>
-                        {{ _render_cell(cell) }}
+                        {{ _render_cell(cell) | striptags }}
                     </button>
                 {% else %}
                     {{ _render_cell(cell) }}


### PR DESCRIPTION
Jinja was outputting a paragraph tag wtihin the button causing layout
and scripting issues.

## Changes

- Updated the markup template to remove the tags from the content within the sortable button.

## Testing

1. Create a sortable table
2. Attempt to sort one column, observe the arrow on it's own line and that it doesn't stay displayed after activated.
3. Checkout this branch and observe the arrow stays displayed and doesn't break to it's own line.

## Screenshots

__Before__

![screen shot 2017-09-08 at 9 51 21 am](https://user-images.githubusercontent.com/1280430/30217463-d751f8e4-947b-11e7-8a9a-cf1ef880ef80.png)

__After__

![screen shot 2017-09-08 at 9 51 08 am](https://user-images.githubusercontent.com/1280430/30217474-e098f506-947b-11e7-85a0-befae37d4deb.png)


## Notes

- The sortable tables code didn't consider a button that is more than one line. I have opened an [issue in Capital Framework](https://github.com/cfpb/capital-framework/issues/598) to explore a fix.

## Checklist

* [x] PR has an informative and human-readable title
* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices
* [x] Project documentation has been updated
* [x] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
