### PR TITLE
ES5ify all Capital Framework JavaScript

### DIFF
--- a/config/webpack-config.js
+++ b/config/webpack-config.js
@@ -37,8 +37,9 @@ const modernConf = {
       exclude: {
         test: /node_modules/,
         // TODO: Move this into a config variable so that we can easily add
-        // other modules in the future.
-        exclude: /node_modules\/cfpb-chart-builder(\-\w+)?/
+        // other modules in the future. The below regex will capture all
+        // node modules that start with `cf`.
+        exclude: /node_modules\/cf(.+)/
       }
     } ]
   },


### PR DESCRIPTION
Babel explicitly ignores JS in the node_modules directory but now that we're writing ES6 outside of cfgov-refresh we need to ensure we transpile external CFPB dependencies.

## Changes

- Added node modules that start with `cf` to webpack's babel step.

## Testing

1. Pull down branch.
1. `./frontend.sh`
1. `./runserver.sh`
1. Open `http://localhost:8000/about-us/budget-strategy/budget-and-performance/` and view the page's source. There should be no `const` declarations. The same page on master has `const` declarations

## Checklist

* [ ] PR has an informative and human-readable title
* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated
* [ ] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
