### PR TITLE
Mortgage Performance: display county information using the right variable

### DIFF
--- a/cfgov/unprocessed/js/organisms/MortgagePerformanceTrends/apps/chart.js
+++ b/cfgov/unprocessed/js/organisms/MortgagePerformanceTrends/apps/chart.js
@@ -183,12 +183,12 @@ MortgagePerformanceLineChart.prototype.renderCounties = function( prevState, sta
   if ( JSON.stringify( prevState.counties ) === JSON.stringify( state.counties ) ) {
     return;
   }
-  state.counties.sort( ( a, b ) => a.county < b.county ? -1 : 1 );
+  state.counties.sort( ( a, b ) => a.name < b.name ? -1 : 1 );
   var fragment = document.createDocumentFragment();
   state.counties.forEach( county => {
     var option = document.createElement( 'option' );
     option.value = county.fips;
-    option.text = county.county;
+    option.text = county.name;
     fragment.appendChild( option );
   } );
   this.$county.innerHTML = '';


### PR DESCRIPTION
In one of our last PRs that modified how we displayed the county information, we missed making some needed changes in one file.

## Changes

- Call the `name` variable rather than `county` in `chart.js`, to prevent the appearance of `undefined` as text.

## Testing

1. Pull down the branch and load the page.
2. Select the "county" location type. The list of counties should have actual counties listed in it.

## Screenshots

Current status on build:
![screen shot 2017-09-08 at 2 23 23 pm](https://user-images.githubusercontent.com/1183435/30225720-74ebbd86-94a1-11e7-84b6-ff9617ef05fd.png)

Desired status after this PR lands:
![screen shot 2017-09-08 at 2 23 37 pm](https://user-images.githubusercontent.com/1183435/30225734-81593558-94a1-11e7-9c00-8233d4d50938.png)

## Checklist

* [x] PR has an informative and human-readable title
* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices
* [x] Project documentation has been updated
* [x] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
