### PR TITLE
Add dynamic tooltip to Mortgage Performance map

### DIFF
--- a/cfgov/jinja2/v1/_includes/organisms/mortgage-map.html
+++ b/cfgov/jinja2/v1/_includes/organisms/mortgage-map.html
@@ -180,16 +180,16 @@
                     <text x="0.999965" y="1.75349" transform="matrix(1,0.00001,0.00002,1,0.9696,10.2465)">Delinquency rates</text>
                 </g>
                 <g class="labels">
-                    <text y="60" x="4">
+                    <text y="63" x="4">
                         <tspan x="0">Insuff. data</tspan>
                         <!-- <tspan x="0" dy="1.2em">data</tspan> -->
                     </text>
-                    <text y="60" x="85">0%</text>
-                    <text y="60" x="174">1%</text>
-                    <text y="60" x="264">2%</text>
-                    <text y="60" x="354">3%</text>
-                    <text y="60" x="446">4%</text>
-                    <text y="60" x="537">5%+</text>
+                    <text y="63" x="85">0%</text>
+                    <text y="63" x="174">1%</text>
+                    <text y="63" x="264">2%</text>
+                    <text y="63" x="354">3%</text>
+                    <text y="63" x="446">4%</text>
+                    <text y="63" x="537">5%+</text>
                 </g>
             </g>
         </svg>

--- a/cfgov/unprocessed/css/organisms/mortgage-performance-trends.less
+++ b/cfgov/unprocessed/css/organisms/mortgage-performance-trends.less
@@ -24,7 +24,7 @@
         .highcharts-point:hover {
             stroke: @black !important;
             stroke-width: 2px !important;
-            transition: stroke-width 0 !important;
+            transition: fill 500ms, fill-opacity 500ms, stroke-width 0 !important;
         }
         .highcharts-point {
             stroke: #838588;

--- a/cfgov/unprocessed/css/organisms/mortgage-performance-trends.less
+++ b/cfgov/unprocessed/css/organisms/mortgage-performance-trends.less
@@ -30,15 +30,31 @@
             stroke: #838588;
         }
     }
-
     .highcharts-color-0 {
         stroke: #838588;
     }
-
     .highcharts-tooltip-box {
         fill: @white;
+        fill-opacity: 1;
     }
 
+}
+
+.m-mp-map-tooltip {
+  .u-webfont-regular();
+  dt {
+    border-bottom: 1px solid @black;
+    font-size: @size-vi;
+    margin-bottom: 5px;
+    padding-bottom: 5px;
+    width: 100%;
+    text-transform: none;
+  }
+  dd {
+    display: block;
+    font-size: @size-vi;
+    padding: 2px 0;
+  }
 }
 
 .m-color-ramp {
@@ -74,7 +90,7 @@
     }
 
     rect {
-        font-size: @size-vi;
+        font-size: unit( 12px / @base-font-size-px, em );;
         height: 15px;
         stroke: #838588;
         stroke-miterlimit: 10;
@@ -83,16 +99,16 @@
     }
 
     text {
-        font-size: @size-vi;
+        font-size: unit( 12px / @base-font-size-px, em );;
         text-anchor: start;
     }
 
     .respond-to-max( @bp-sm-max, {
         text {
-            font-size: @size-v;
+            font-size: unit( 14px / @base-font-size-px, em );;
         }
         tspan {
-            font-size: @size-v;
+            font-size: unit( 14px / @base-font-size-px, em );;
         }
     } );
 
@@ -107,9 +123,9 @@
     // Fieldsets have silly default values. We should remove them at the CF level
     // but for now I'm removing them only within our app.
     fieldset {
-        padding-left: 0;
-        margin-left: 0;
         border: 0;
+        margin-left: 0;
+        padding-left: 0;
     }
     .content-l_col {
         border-left-width: 0;

--- a/cfgov/unprocessed/css/organisms/mortgage-performance-trends.less
+++ b/cfgov/unprocessed/css/organisms/mortgage-performance-trends.less
@@ -24,7 +24,7 @@
         .highcharts-point:hover {
             stroke: @black !important;
             stroke-width: 2px !important;
-            transition: stroke-width 200ms !important;
+            transition: stroke-width 0 !important;
         }
         .highcharts-point {
             stroke: #838588;
@@ -41,20 +41,20 @@
 }
 
 .m-mp-map-tooltip {
-  .u-webfont-regular();
-  dt {
-    border-bottom: 1px solid @black;
-    font-size: @size-vi;
-    margin-bottom: 5px;
-    padding-bottom: 5px;
-    width: 100%;
-    text-transform: none;
-  }
-  dd {
-    display: block;
-    font-size: @size-vi;
-    padding: 2px 0;
-  }
+    .u-webfont-regular();
+    dt {
+        border-bottom: 1px solid @black;
+        font-size: @size-vi;
+        margin-bottom: 5px;
+        padding-bottom: 5px;
+        width: 100%;
+        text-transform: none;
+    }
+    dd {
+        display: block;
+        font-size: @size-vi;
+        padding: 2px 0;
+    }
 }
 
 .m-color-ramp {

--- a/cfgov/unprocessed/js/organisms/MortgagePerformanceTrends/apps/map.js
+++ b/cfgov/unprocessed/js/organisms/MortgagePerformanceTrends/apps/map.js
@@ -172,12 +172,12 @@ MortgagePerformanceMap.prototype.renderChartForm = function( prevState, state ) 
 };
 
 MortgagePerformanceMap.prototype.renderChartTitle = function( prevState, state ) {
-  let location = state.geo.name;
-  if ( !location ) {
-    location = `${ state.geo.type } view`;
+  let loc = state.geo.name;
+  if ( !loc ) {
+    loc = `${ state.geo.type } view`;
   }
-  this.$mapTitleLocation.innerText = location;
-  this.$mapTitleDate.innerHTML = utils.getDate( state.date );
+  this.$mapTitleLocation.innerText = loc;
+  this.$mapTitleDate.innerText = utils.getDate( state.date );
 };
 
 MortgagePerformanceMap.prototype.renderCounties = function( prevState, state ) {

--- a/cfgov/unprocessed/js/organisms/MortgagePerformanceTrends/apps/map.js
+++ b/cfgov/unprocessed/js/organisms/MortgagePerformanceTrends/apps/map.js
@@ -216,11 +216,17 @@ MortgagePerformanceMap.prototype.renderMetros = function( prevState, state ) {
 
 MortgagePerformanceMap.prototype.renderTooltip = function() {
   return ( point, meta ) => {
-    var percent = Math.round( point.value * 10 ) / 10;
+    var percent;
     var nationalPercent = Math.round( meta.national_average * 1000 ) / 10;
+    if ( point.value < 0 ) {
+      percent = 'Insufficient data';
+    } else {
+      percent = Math.round( point.value * 10 ) / 10;
+      percent = `<strong>${ percent }%</strong> mortgage delinquency rate`;
+    }
     return `<dl class='m-mp-map-tooltip'>
       <dt>${ point.name }</dt>
-      <dd><strong>${ percent }%</strong> mortgage delinquency rate</dd>
+      <dd>${ percent }</dd>
       <dd><strong>${ nationalPercent }%</strong> national average</dd>
     </dl>`;
   };

--- a/cfgov/unprocessed/js/organisms/MortgagePerformanceTrends/apps/map.js
+++ b/cfgov/unprocessed/js/organisms/MortgagePerformanceTrends/apps/map.js
@@ -14,6 +14,7 @@ var _plurals = {
 };
 
 class MortgagePerformanceMap {
+
   constructor( { container } ) {
     this.$container = document.getElementById( container );
     this.$form = this.$container.querySelector( '#mp-map-controls' );
@@ -31,14 +32,16 @@ class MortgagePerformanceMap {
     this.timespan = this.$container.getAttribute( 'data-chart-time-span' );
     this.chart = ccb.createChart( {
       el: this.$container.querySelector( '#mp-map' ),
-      source: `map-data/${ this.timespan }/states/2009-01`,
+      source: `map-data/${ this.timespan }/states/2008-01`,
       type: 'geo-map',
       color: this.$container.getAttribute( 'data-chart-color' ),
-      metadata: 'states'
+      metadata: 'states',
+      tooltipFormatter: this.renderTooltip()
     } );
     this.eventListeners();
     utils.hideEl( this.$loadingSpinner );
   }
+
 }
 
 MortgagePerformanceMap.prototype.eventListeners = function() {
@@ -128,7 +131,8 @@ MortgagePerformanceMap.prototype.renderChart = function( prevState, state ) {
     store.dispatch( actions.startLoading() );
     this.chart.update( {
       source: `map-data/${ this.timespan }/${ _plurals[state.geo.type] }/${ state.date }`,
-      metadata: _plurals[state.geo.type]
+      metadata: _plurals[state.geo.type],
+      tooltipFormatter: this.renderTooltip()
     } ).then( () => {
       if ( prevState.geo.type !== state.geo.type ) {
         this.$state.value = '';
@@ -143,11 +147,6 @@ MortgagePerformanceMap.prototype.renderChart = function( prevState, state ) {
 };
 
 MortgagePerformanceMap.prototype.renderChartForm = function( prevState, state ) {
-  // If we're waiting for data, abort.
-  // if ( state.isLoading ) {
-  //   return utils.showEl( this.$loadingSpinner );
-  // }
-  // utils.hideEl( this.$loadingSpinner );
   var geoType = state.geo.type;
   if ( state.isLoadingCounties ) {
     geoType = 'county';
@@ -177,7 +176,7 @@ MortgagePerformanceMap.prototype.renderChartTitle = function( prevState, state )
   if ( !location ) {
     location = `${ state.geo.type } view`;
   }
-  this.$mapTitleLocation.innerHTML = location;
+  this.$mapTitleLocation.innerText = location;
   this.$mapTitleDate.innerHTML = utils.getDate( state.date );
 };
 
@@ -213,6 +212,18 @@ MortgagePerformanceMap.prototype.renderMetros = function( prevState, state ) {
   } );
   this.$metro.innerHTML = '';
   this.$metro.appendChild( fragment );
+};
+
+MortgagePerformanceMap.prototype.renderTooltip = function() {
+  return ( point, meta ) => {
+    var percent = Math.round( point.value * 10 ) / 10;
+    var nationalPercent = Math.round( meta.national_average * 1000 ) / 10;
+    return `<dl class='m-mp-map-tooltip'>
+      <dt>${ point.name }</dt>
+      <dd><strong>${ percent }%</strong> mortgage delinquency rate</dd>
+      <dd><strong>${ nationalPercent }%</strong> national average</dd>
+    </dl>`;
+  };
 };
 
 module.exports = MortgagePerformanceMap;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1904,15 +1904,15 @@
       }
     },
     "cfpb-chart-builder": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/cfpb-chart-builder/-/cfpb-chart-builder-3.0.1.tgz",
-      "integrity": "sha512-d1Ybzub5FsnnRyYnu0QozpmQQNjZ6Tmp7GgKOsvMj+plyV5Lj3PGDTvN0cMPpuTKrsr3WkGPXvppEksCTTq48Q==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/cfpb-chart-builder/-/cfpb-chart-builder-3.0.3.tgz",
+      "integrity": "sha512-suNvPiKFl8rrz6K68IVLe7mn9tbmpNX8TJBLgquCZOi3H+3dt/YzHKcH6zcUdVLi2K7mB3P9/00owk41AZNBiw==",
       "requires": {
         "babel-preset-env": "1.6.0",
-        "cf-core": "4.3.1",
-        "cf-grid": "4.2.1",
-        "cf-layout": "4.4.2",
-        "cf-typography": "4.1.2",
+        "cf-core": "4.4.1",
+        "cf-grid": "4.2.2",
+        "cf-layout": "4.5.1",
+        "cf-typography": "4.2.1",
         "core-js": "2.5.0",
         "es6-promise": "4.1.1",
         "highcharts": "5.0.11",
@@ -1920,6 +1920,42 @@
         "xdr": "github:contolini/xdr#4f53e8dc68d14cd4a387874e75faae46c3a4961b"
       },
       "dependencies": {
+        "cf-core": {
+          "version": "4.4.1",
+          "resolved": "https://registry.npmjs.org/cf-core/-/cf-core-4.4.1.tgz",
+          "integrity": "sha512-6x4zo0mKj3BVNj9EpSrhB2+eTM3324ADl9qtX5CYrx93J8GfJ2Ll7MCOE3CBdiqBm93GP6fNWmomg0yhUFJehw==",
+          "requires": {
+            "normalize-css": "2.3.1",
+            "normalize-legacy-addon": "0.1.0"
+          }
+        },
+        "cf-grid": {
+          "version": "4.2.2",
+          "resolved": "https://registry.npmjs.org/cf-grid/-/cf-grid-4.2.2.tgz",
+          "integrity": "sha512-P2uIvpcKACqrJqKDNeANpyAEgKovQMXpaz5GhigY2OL42d/txGXvqL2kZqaHNUkEUwcVdJPlOIxGv/nDF0rF1Q==",
+          "requires": {
+            "normalize-css": "2.3.1",
+            "normalize-legacy-addon": "0.1.0"
+          }
+        },
+        "cf-layout": {
+          "version": "4.5.1",
+          "resolved": "https://registry.npmjs.org/cf-layout/-/cf-layout-4.5.1.tgz",
+          "integrity": "sha512-8RByl3aYIzzyEN/lXjKWugm5F0aqTCK+84U3OUaz8SHb+8WMHiqdIUnYnCa4aYQJHDhCaH3gQTysuJV72B0EoQ==",
+          "requires": {
+            "cf-core": "4.4.1",
+            "cf-grid": "4.2.2"
+          }
+        },
+        "cf-typography": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/cf-typography/-/cf-typography-4.2.1.tgz",
+          "integrity": "sha512-oVI6nYUysYsZnZ10FIZ8+kzsrewchrcdqx0Q9Kz03gMPwHhWbdiAN2Jy/YFdkO3LTWVuK3eCAGEJBkE3uOimPg==",
+          "requires": {
+            "cf-core": "4.4.1",
+            "cf-icons": "4.1.1"
+          }
+        },
         "core-js": {
           "version": "2.5.0",
           "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.0.tgz",
@@ -5394,14 +5430,6 @@
             }
           }
         },
-        "string_decoder": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.1.tgz",
-          "integrity": "sha1-YuIA8DmVWmgQ2N8KM//A8BNmLZg=",
-          "requires": {
-            "safe-buffer": "5.0.1"
-          }
-        },
         "string-width": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
@@ -5410,6 +5438,14 @@
             "code-point-at": "1.1.0",
             "is-fullwidth-code-point": "1.0.0",
             "strip-ansi": "3.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.1.tgz",
+          "integrity": "sha1-YuIA8DmVWmgQ2N8KM//A8BNmLZg=",
+          "requires": {
+            "safe-buffer": "5.0.1"
           }
         },
         "stringstream": {
@@ -11926,14 +11962,6 @@
       "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
       "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM="
     },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "requires": {
-        "safe-buffer": "5.1.1"
-      }
-    },
     "string-argv": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.0.2.tgz",
@@ -11962,6 +11990,14 @@
         "code-point-at": "1.1.0",
         "is-fullwidth-code-point": "1.0.0",
         "strip-ansi": "3.0.1"
+      }
+    },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "requires": {
+        "safe-buffer": "5.1.1"
       }
     },
     "stringstream": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "cf-pagination": "4.1.3",
     "cf-tables": "4.1.2",
     "cf-typography": "4.1.2",
-    "cfpb-chart-builder": "3.0.2",
+    "cfpb-chart-builder": "3.0.3",
     "del": "2.2.2",
     "es5-shim": "4.5.9",
     "glob-all": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "cf-pagination": "4.1.3",
     "cf-tables": "4.1.2",
     "cf-typography": "4.1.2",
-    "cfpb-chart-builder": "3.0.1",
+    "cfpb-chart-builder": "3.0.2",
     "del": "2.2.2",
     "es5-shim": "4.5.9",
     "glob-all": "3.1.0",


### PR DESCRIPTION
The MP map needs to show the selected location's delinquency rate alongside the national average. A tooltip formatting function is passed to cfpb-chart-builder that uses it to render HTML for the tooltip.

## Additions

- `renderTooltip` function that returns HTML for the tooltip.
- CSS for the tooltip.

## Changes

- Misc. font size cleanup.
- Updated cfpb-chart-builder to the latest version that supports custom tooltips.
- Renames the `location` variable to `loc` to avoid Checkmarx false positive. (I think it's confusing it with `window.location`).

## Testing

1. Pull down this branch and `./setup.sh`
1. Set up the [mortgage performance API](https://github.com/cfpb/cfgov-refresh/pull/3189).
1. Create a [mortgage chart block and page](https://github.com/cfpb/cfgov-refresh/pull/3260).

## Screenshots

![30201641-822dd27a-9449-11e7-9d05-8e956e860354](https://user-images.githubusercontent.com/1060248/30259670-8c9485d0-9690-11e7-8c29-13176dd4bfb3.png)

## Checklist

* [ ] PR has an informative and human-readable title
* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated
* [ ] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
