### PR TITLE
Changes Activity Log to Recent updates

### DIFF
--- a/cfgov/jinja2/v1/_includes/organisms/_vars-mega-menu.html
+++ b/cfgov/jinja2/v1/_includes/organisms/_vars-mega-menu.html
@@ -298,10 +298,10 @@
 
 {% set about_us_group_two = {
     'nav_items': [
+        {'text': 'Recent Updates', 'url': '/activity-log/'},
         {'text': 'Blog', 'url': '/about-us/blog/'},
         {'text': 'Newsroom', 'url': '/about-us/newsroom/'},
         {'text': 'Events', 'url': '/about-us/events/'},
-        {'text': 'Recent Postings', 'url': '/activity-log/'},
     ]
 } %}
 

--- a/cfgov/jinja2/v1/activity-log/index.html
+++ b/cfgov/jinja2/v1/activity-log/index.html
@@ -3,7 +3,7 @@
 {% block content_main %}
 
     <div class="block block__flush-top">
-        <h1 data-qa-hook="main-title">Activity Log</h1>
+        <h1 data-qa-hook="main-title">Recent updates</h1>
         <p class="lead-paragraph" data-qa-hook="main-summary">
             Find the latest CFPB activities and publications here. Use the filters
             below to browse by date, specific topics, or types of posts.

--- a/cfgov/jinja2/v1/index.html
+++ b/cfgov/jinja2/v1/index.html
@@ -195,7 +195,7 @@
                                 <a class="a-link
                                           a-link__jump"
                                    href="/activity-log/">
-                                    See all activities
+                                    See all updates
                                 </a>
                             </div>
                         {% endif %}

--- a/cfgov/v1/models/sublanding_filterable_page.py
+++ b/cfgov/v1/models/sublanding_filterable_page.py
@@ -65,7 +65,7 @@ class ActivityLogPage(SublandingFilterablePage):
     @classmethod
     def base_query(cls, hostname):
         """
-        Activity log pages should only show content from certain categories.
+        Recent updates pages should only show content from certain categories.
         """
         eligible_pages = AbstractFilterPage.objects.live()
 

--- a/cfgov/v1/util/ref.py
+++ b/cfgov/v1/util/ref.py
@@ -25,7 +25,7 @@ related_posts_categories = [
 ]
 
 page_types = [
-    ('activity-log', 'Activity Log'),
+    ('activity-log', 'Recent updates'),
     ('administrative-adjudication', 'Administrative adjudication'),
     ('amicus-brief', 'Amicus Brief'),
     ('blog', 'Blog'),
@@ -159,7 +159,7 @@ def related_posts_category_lookup(related_categories):
 
 def page_type_choices():
     new_choices = [
-        ('Activity Log', (
+        ('Recent updates', (
             ('blog', 'Blog'),
             ('op-ed', 'Op-Ed'),
             ('press-release', 'Press Release'),


### PR DESCRIPTION
Fixes https://[GHE]/CFGOV/platform/issues/1112

## Changes

- Changes Activity Log page title to "Recent updates" (sentence case)
- Changes "Activity Log" in mega menu to "Recent Updates". Within the mega menu, moves "Recent Updates" to the top of the column, above Blog, Newsroom, Events.
- Changes "See all activities" link under "Latest updates" section at the bottom of the Homepage to "See all updates".

## Testing

1. Visit homepage for "See all updates" change.
2. localhost:8000/activity-log/ to see change to page title, and to check mega menu.

## Screenshots

<img width="405" alt="screen shot 2017-09-11 at 10 32 14 am" src="https://user-images.githubusercontent.com/704760/30279948-89278f22-96dc-11e7-82d6-779d09bde97b.png">

<img width="696" alt="screen shot 2017-09-11 at 10 32 18 am" src="https://user-images.githubusercontent.com/704760/30279945-88b10212-96dc-11e7-91fe-62dbf2b5b9db.png">

![screen shot 2017-09-11 at 12 09 35 pm](https://user-images.githubusercontent.com/704760/30284848-21367d3e-96ea-11e7-9012-90836e22f093.png)
