### PR TITLE
Mortgage-performance non-MSA invalid values

### DIFF
--- a/cfgov/data_research/tests/test_views.py
+++ b/cfgov/data_research/tests/test_views.py
@@ -374,7 +374,7 @@ class TimeseriesViewTests(django.test.TestCase):
         self.assertIs(msa_value, None)
 
     def test_map_view_non_msa_below_threshold(self):
-        """The view should deliver a below-threshold MSA with value of None"""
+        """Should deliver a below-threshold non-MSA with value of None"""
         non_msa = NonMSAMortgageData.objects.get(fips='12-non')
         geo = non_msa.state
         geo.non_msa_valid = False

--- a/cfgov/data_research/tests/test_views.py
+++ b/cfgov/data_research/tests/test_views.py
@@ -358,7 +358,7 @@ class TimeseriesViewTests(django.test.TestCase):
         self.assertEqual(response.status_code, 200)
 
     def test_map_view_msa_below_threshold(self):
-        """The view should deliver a below-threshold MSA with value set to 0"""
+        """The view should deliver a below-threshold MSA with value of None"""
         msa = MSAMortgageData.objects.get(fips='35840')
         geo = msa.msa
         geo.valid = False
@@ -371,6 +371,22 @@ class TimeseriesViewTests(django.test.TestCase):
                         'year_month': '2008-01'}))
         self.assertEqual(response.status_code, 200)
         msa_value = json.loads(response.content)['data'][msa.fips]['value']
+        self.assertIs(msa_value, None)
+
+    def test_map_view_non_msa_below_threshold(self):
+        """The view should deliver a below-threshold MSA with value of None"""
+        non_msa = NonMSAMortgageData.objects.get(fips='12-non')
+        geo = non_msa.state
+        geo.non_msa_valid = False
+        geo.save()
+        response = self.client.get(
+            reverse(
+                'data_research_api_mortgage_mapdata',
+                kwargs={'geo': 'metros',
+                        'days_late': '90',
+                        'year_month': '2008-01'}))
+        self.assertEqual(response.status_code, 200)
+        msa_value = json.loads(response.content)['data'][non_msa.fips]['value']
         self.assertIs(msa_value, None)
 
     def test_national_map_data_30_89(self):

--- a/cfgov/data_research/views.py
+++ b/cfgov/data_research/views.py
@@ -195,9 +195,10 @@ class MapData(APIView):
             if geo == 'metros':
                 for metro in MetroArea.objects.filter(valid=False):
                     payload['data'][metro.fips]['value'] = None
-                for record in NonMSAMortgageData.objects.filter(
-                        state__non_msa_valid=True, date=date):
+                for record in NonMSAMortgageData.objects.filter(date=date):
                     non_data_series = record.time_series(days_late)
+                    if record.state.non_msa_valid is False:
+                        non_data_series['value'] = None
                     non_name = "{} non-metro area".format(record.state.name)
                     non_data_series.update({'name': non_name})
                     del non_data_series['date']


### PR DESCRIPTION
Previously non-MSA areas that contained no counties (such as New Jersey)
or that had counties that together didn't meet our display threshold (such
as Massachusetts) were not included in API responses for metro-area maps.

This PR makes sure the five invalid non-MSA objects are represented in data
with a json data value of `null` (represented as `None` in Python view
code).

The five non-MSA areas that should now show up with null values:
- Delaware
- District of Columbia
- Massachusetts
- New Jersey
- Rhode Island

## Testing
Hit a metro map API endpoint and search for the Massachusetts non-MSA FIPS code, `25-non`, which previously was absent.

http://localhost:8000/data-research/mortgages/api/v1/map-data/90/metros/2009-01/