### PR TITLE
Mortgage Performance: show "national average" text on default view

### DIFF
--- a/cfgov/jinja2/v1/_includes/organisms/mortgage-chart.html
+++ b/cfgov/jinja2/v1/_includes/organisms/mortgage-chart.html
@@ -342,8 +342,9 @@
             </fieldset>
         </form>
         <h2 id="mp-line-chart-title" style="margin-top:20px">Percentage of mortgages {{ time_frame }} {% if time_frame == '90' %} or more {% endif %} days delinquent:<br/>
-          <span id="mp-line-chart-title-status">
-          <strong><span id="mp-line-chart-title-status-geo"></span></strong><span id="mp-line-chart-title-status-comparison"> versus </span><span id="mp-line-chart-title-status-national"><strong>national average</strong></span></span>, {{ from_month_formatted }}-{{ thru_month_formatted }}</h2>
+            <span id="mp-line-chart-title-status">
+                <strong><span id="mp-line-chart-title-status-geo">national average</span></strong><span id="mp-line-chart-title-status-comparison"> versus <strong>national average</strong></span></span>, {{ from_month_formatted }}-{{ thru_month_formatted }}
+        </h2>
     </div>
     <div class="cfpb-chart" data-chart-ignore="true" data-chart-color="blue" data-chart-type="line-comparison" id="mp-line-chart">
         {{ value.description }}

--- a/cfgov/jinja2/v1/_includes/organisms/mortgage-chart.html
+++ b/cfgov/jinja2/v1/_includes/organisms/mortgage-chart.html
@@ -342,8 +342,8 @@
             </fieldset>
         </form>
         <h2 id="mp-line-chart-title" style="margin-top:20px">Percentage of mortgages {{ time_frame }} {% if time_frame == '90' %} or more {% endif %} days delinquent:<br/>
-          <span id="mp-line-chart-title-status" style="display:none">
-          <strong><span id="mp-line-chart-title-status-geo"></span></strong><span id="mp-line-chart-title-status-comparison"> versus <strong>national average</strong></span></span>, {{ from_month_formatted }}-{{ thru_month_formatted }}</h2>
+          <span id="mp-line-chart-title-status">
+          <strong><span id="mp-line-chart-title-status-geo"></span></strong><span id="mp-line-chart-title-status-comparison"> versus </span><span id="mp-line-chart-title-status-national"><strong>national average</strong></span></span>, {{ from_month_formatted }}-{{ thru_month_formatted }}</h2>
     </div>
     <div class="cfpb-chart" data-chart-ignore="true" data-chart-color="blue" data-chart-type="line-comparison" id="mp-line-chart">
         {{ value.description }}

--- a/cfgov/jinja2/v1/_includes/organisms/mortgage-chart.html
+++ b/cfgov/jinja2/v1/_includes/organisms/mortgage-chart.html
@@ -33,7 +33,7 @@
                         <input class="a-radio" id="mp-line-chart_geo-metro" name="mp-line-chart_geo" type="radio"> <label class="a-label" for="mp-line-chart_geo-metro">Metro area</label>
                     </div>
                     <div class="m-form-field m-form-field__radio u-mb10">
-                        <input class="a-radio" id="mp-line-chart_geo-non-metro" name="mp-line-chart_non_geo" type="radio"> <label class="a-label" for="mp-line-chart_geo-non-metro">Non-metro area</label>
+                        <input class="a-radio" id="mp-line-chart_geo-non-metro" name="mp-line-chart_geo" type="radio"> <label class="a-label" for="mp-line-chart_geo-non-metro">Non-metro area</label>
                     </div>
                     <div class="m-form-field m-form-field__radio u-mb10">
                         <input class="a-radio" id="mp-line-chart_geo-county" name="mp-line-chart_geo" type="radio"> <label class="a-label" for="mp-line-chart_geo-county">County</label>
@@ -41,229 +41,6 @@
                 </div>
             </fieldset>
             <fieldset class="content-l_col content-l_col-1-2" style="margin-left:0;padding-left:0;border:0;">
-                <div class="m-form-field m-form-field__select mp-line-chart-select-container" id="mp-line-chart-metro-container" style="display:none">
-                    <label class="a-label" for="mp-line-chart-metro"><h4>Select metro area</h4></label>
-                    <div class="a-select">
-                        <select id="mp-line-chart-metro">
-                            <option value="10420">Akron, OH</option>
-                            <option value="10580">Albany-Schenectady-Troy, NY</option>
-                            <option value="10740">Albuquerque, NM</option>
-                            <option value="10900">Allentown-Bethlehem-Easton, PA-NJ</option>
-                            <option value="11260">Anchorage, AK</option>
-                            <option value="11460">Ann Arbor, MI</option>
-                            <option value="11700">Asheville, NC</option>
-                            <option value="12060">Atlanta-Sandy Springs-Roswell, GA</option>
-                            <option value="12100">Atlantic City-Hammonton, NJ</option>
-                            <option value="12220">Auburn-Opelika, AL</option>
-                            <option value="12260">Augusta-Richmond County, GA-SC</option>
-                            <option value="12420">Austin-Round Rock, TX</option>
-                            <option value="12540">Bakersfield, CA</option>
-                            <option value="12580">Baltimore-Columbia-Towson, MD</option>
-                            <option value="12620">Bangor, ME</option>
-                            <option value="12700">Barnstable Town, MA</option>
-                            <option value="12940">Baton Rouge, LA</option>
-                            <option value="13380">Bellingham, WA</option>
-                            <option value="13460">Bend-Redmond, OR</option>
-                            <option value="13780">Binghamton, NY</option>
-                            <option value="13820">Birmingham-Hoover, AL</option>
-                            <option value="14260">Boise City, ID</option>
-                            <option value="14460">Boston-Cambridge-Newton, MA-NH</option>
-                            <option value="14500">Boulder, CO</option>
-                            <option value="14740">Bremerton-Silverdale, WA</option>
-                            <option value="14860">Bridgeport-Stamford-Norwalk, CT</option>
-                            <option value="15180">Brownsville-Harlingen, TX</option>
-                            <option value="15380">Buffalo-Cheektowaga-Niagara Falls, NY</option>
-                            <option value="15500">Burlington, NC</option>
-                            <option value="15540">Burlington-South Burlington, VT</option>
-                            <option value="15680">California-Lexington Park, MD</option>
-                            <option value="15980">Cape Coral-Fort Myers, FL</option>
-                            <option value="16540">Chambersburg-Waynesboro, PA</option>
-                            <option value="16580">Champaign-Urbana, IL</option>
-                            <option value="16700">Charleston-North Charleston, SC</option>
-                            <option value="16740">Charlotte-Concord-Gastonia, NC-SC</option>
-                            <option value="16860">Chattanooga, TN-GA</option>
-                            <option value="16980">Chicago-Naperville-Elgin, IL-IN-WI</option>
-                            <option value="17020">Chico, CA</option>
-                            <option value="17140">Cincinnati, OH-KY-IN</option>
-                            <option value="17460">Cleveland-Elyria, OH</option>
-                            <option value="17660">Coeur d'Alene, ID</option>
-                            <option value="17780">College Station-Bryan, TX</option>
-                            <option value="17820">Colorado Springs, CO</option>
-                            <option value="17860">Columbia, MO</option>
-                            <option value="17900">Columbia, SC</option>
-                            <option value="18140">Columbus, OH</option>
-                            <option value="18880">Crestview-Fort Walton Beach-Destin, FL</option>
-                            <option value="19100">Dallas-Fort Worth-Arlington, TX</option>
-                            <option value="19300">Daphne-Fairhope-Foley, AL</option>
-                            <option value="19340">Davenport-Moline-Rock Island, IA-IL</option>
-                            <option value="19380">Dayton, OH</option>
-                            <option value="19660">Deltona-Daytona Beach-Ormond Beach, FL</option>
-                            <option value="19740">Denver-Aurora-Lakewood, CO</option>
-                            <option value="19780">Des Moines-West Des Moines, IA</option>
-                            <option value="19820">Detroit-Warren-Dearborn, MI</option>
-                            <option value="20100">Dover, DE</option>
-                            <option value="20500">Durham-Chapel Hill, NC</option>
-                            <option value="20700">East Stroudsburg, PA</option>
-                            <option value="21140">Elkhart-Goshen, IN</option>
-                            <option value="21340">El Paso, TX</option>
-                            <option value="21500">Erie, PA</option>
-                            <option value="21660">Eugene, OR</option>
-                            <option value="22180">Fayetteville, NC</option>
-                            <option value="22220">Fayetteville-Springdale-Rogers, AR-MO</option>
-                            <option value="22420">Flint, MI</option>
-                            <option value="22660">Fort Collins, CO</option>
-                            <option value="23060">Fort Wayne, IN</option>
-                            <option value="23420">Fresno, CA</option>
-                            <option value="23540">Gainesville, FL</option>
-                            <option value="23580">Gainesville, GA</option>
-                            <option value="24300">Grand Junction, CO</option>
-                            <option value="24340">Grand Rapids-Wyoming, MI</option>
-                            <option value="24540">Greeley, CO</option>
-                            <option value="24580">Green Bay, WI</option>
-                            <option value="24660">Greensboro-High Point, NC</option>
-                            <option value="24780">Greenville, NC</option>
-                            <option value="24860">Greenville-Anderson-Mauldin, SC</option>
-                            <option value="25180">Hagerstown-Martinsburg, MD-WV</option>
-                            <option value="25420">Harrisburg-Carlisle, PA</option>
-                            <option value="25540">Hartford-West Hartford-East Hartford, CT</option>
-                            <option value="25940">Hilton Head Island-Bluffton-Beaufort, SC</option>
-                            <option value="26420">Houston-The Woodlands-Sugar Land, TX</option>
-                            <option value="26620">Huntsville, AL</option>
-                            <option value="26900">Indianapolis-Carmel-Anderson, IN</option>
-                            <option value="26980">Iowa City, IA</option>
-                            <option value="27100">Jackson, MI</option>
-                            <option value="27140">Jackson, MS</option>
-                            <option value="27260">Jacksonville, FL</option>
-                            <option value="27340">Jacksonville, NC</option>
-                            <option value="27500">Janesville-Beloit, WI</option>
-                            <option value="28020">Kalamazoo-Portage, MI</option>
-                            <option value="28140">Kansas City, MO-KS</option>
-                            <option value="28420">Kennewick-Richland, WA</option>
-                            <option value="28660">Killeen-Temple, TX</option>
-                            <option value="28740">Kingston, NY</option>
-                            <option value="28940">Knoxville, TN</option>
-                            <option value="29180">Lafayette, LA</option>
-                            <option value="29340">Lake Charles, LA</option>
-                            <option value="29420">Lake Havasu City-Kingman, AZ</option>
-                            <option value="29460">Lakeland-Winter Haven, FL</option>
-                            <option value="29540">Lancaster, PA</option>
-                            <option value="29620">Lansing-East Lansing, MI</option>
-                            <option value="29700">Laredo, TX</option>
-                            <option value="29740">Las Cruces, NM</option>
-                            <option value="29820">Las Vegas-Henderson-Paradise, NV</option>
-                            <option value="30460">Lexington-Fayette, KY</option>
-                            <option value="30700">Lincoln, NE</option>
-                            <option value="30780">Little Rock-North Little Rock-Conway, AR</option>
-                            <option value="31080">Los Angeles-Long Beach-Anaheim, CA</option>
-                            <option value="31140">Louisville/Jefferson County, KY-IN</option>
-                            <option value="31540">Madison, WI</option>
-                            <option value="31700">Manchester-Nashua, NH</option>
-                            <option value="32580">McAllen-Edinburg-Mission, TX</option>
-                            <option value="32780">Medford, OR</option>
-                            <option value="32820">Memphis, TN-MS-AR</option>
-                            <option value="32900">Merced, CA</option>
-                            <option value="33100">Miami-Fort Lauderdale-West Palm Beach, FL</option>
-                            <option value="33340">Milwaukee-Waukesha-West Allis, WI</option>
-                            <option value="33460">Minneapolis-St. Paul-Bloomington, MN-WI</option>
-                            <option value="33660">Mobile, AL</option>
-                            <option value="33700">Modesto, CA</option>
-                            <option value="33780">Monroe, MI</option>
-                            <option value="33860">Montgomery, AL</option>
-                            <option value="34740">Muskegon, MI</option>
-                            <option value="34820">Myrtle Beach-Conway-North Myrtle Beach, SC-NC</option>
-                            <option value="34900">Napa, CA</option>
-                            <option value="34940">Naples-Immokalee-Marco Island, FL</option>
-                            <option value="34980">Nashville-Davidson--Murfreesboro--Franklin, TN</option>
-                            <option value="35300">New Haven-Milford, CT</option>
-                            <option value="35380">New Orleans-Metairie, LA</option>
-                            <option value="35620">New York-Newark-Jersey City, NY-NJ-PA</option>
-                            <option value="35660">Niles-Benton Harbor, MI</option>
-                            <option value="35840">North Port-Sarasota-Bradenton, FL</option>
-                            <option value="35980">Norwich-New London, CT</option>
-                            <option value="36100">Ocala, FL</option>
-                            <option value="36140">Ocean City, NJ</option>
-                            <option value="36260">Ogden-Clearfield, UT</option>
-                            <option value="36420">Oklahoma City, OK</option>
-                            <option value="36500">Olympia-Tumwater, WA</option>
-                            <option value="36540">Omaha-Council Bluffs, NE-IA</option>
-                            <option value="36740">Orlando-Kissimmee-Sanford, FL</option>
-                            <option value="36780">Oshkosh-Neenah, WI</option>
-                            <option value="37100">Oxnard-Thousand Oaks-Ventura, CA</option>
-                            <option value="37340">Palm Bay-Melbourne-Titusville, FL</option>
-                            <option value="37460">Panama City, FL</option>
-                            <option value="37860">Pensacola-Ferry Pass-Brent, FL</option>
-                            <option value="37980">Philadelphia-Camden-Wilmington, PA-NJ-DE-MD</option>
-                            <option value="38060">Phoenix-Mesa-Scottsdale, AZ</option>
-                            <option value="38300">Pittsburgh, PA</option>
-                            <option value="38340">Pittsfield, MA</option>
-                            <option value="38860">Portland-South Portland, ME</option>
-                            <option value="38900">Portland-Vancouver-Hillsboro, OR-WA</option>
-                            <option value="38940">Port St. Lucie, FL</option>
-                            <option value="39140">Prescott, AZ</option>
-                            <option value="39300">Providence-Warwick, RI-MA</option>
-                            <option value="39340">Provo-Orem, UT</option>
-                            <option value="39380">Pueblo, CO</option>
-                            <option value="39460">Punta Gorda, FL</option>
-                            <option value="39540">Racine, WI</option>
-                            <option value="39580">Raleigh, NC</option>
-                            <option value="39740">Reading, PA</option>
-                            <option value="39820">Redding, CA</option>
-                            <option value="40060">Richmond, VA</option>
-                            <option value="40140">Riverside-San Bernardino-Ontario, CA</option>
-                            <option value="40380">Rochester, NY</option>
-                            <option value="40420">Rockford, IL</option>
-                            <option value="40900">Sacramento--Roseville--Arden-Arcade, CA</option>
-                            <option value="40980">Saginaw, MI</option>
-                            <option value="41100">St. George, UT</option>
-                            <option value="41180">St. Louis, MO-IL</option>
-                            <option value="41420">Salem, OR</option>
-                            <option value="41500">Salinas, CA</option>
-                            <option value="41540">Salisbury, MD-DE</option>
-                            <option value="41620">Salt Lake City, UT</option>
-                            <option value="41700">San Antonio-New Braunfels, TX</option>
-                            <option value="41740">San Diego-Carlsbad, CA</option>
-                            <option value="41860">San Francisco-Oakland-Hayward, CA</option>
-                            <option value="41940">San Jose-Sunnyvale-Santa Clara, CA</option>
-                            <option value="42020">San Luis Obispo-Paso Robles-Arroyo Grande, CA</option>
-                            <option value="42100">Santa Cruz-Watsonville, CA</option>
-                            <option value="42140">Santa Fe, NM</option>
-                            <option value="42200">Santa Maria-Santa Barbara, CA</option>
-                            <option value="42220">Santa Rosa, CA</option>
-                            <option value="42340">Savannah, GA</option>
-                            <option value="42540">Scranton--Wilkes-Barre--Hazleton, PA</option>
-                            <option value="42660">Seattle-Tacoma-Bellevue, WA</option>
-                            <option value="42680">Sebastian-Vero Beach, FL</option>
-                            <option value="43340">Shreveport-Bossier City, LA</option>
-                            <option value="43780">South Bend-Mishawaka, IN-MI</option>
-                            <option value="43900">Spartanburg, SC</option>
-                            <option value="44060">Spokane-Spokane Valley, WA</option>
-                            <option value="44140">Springfield, MA</option>
-                            <option value="44180">Springfield, MO</option>
-                            <option value="44700">Stockton-Lodi, CA</option>
-                            <option value="45060">Syracuse, NY</option>
-                            <option value="45300">Tampa-St. Petersburg-Clearwater, FL</option>
-                            <option value="45780">Toledo, OH</option>
-                            <option value="45940">Trenton, NJ</option>
-                            <option value="46060">Tucson, AZ</option>
-                            <option value="46140">Tulsa, OK</option>
-                            <option value="46340">Tyler, TX</option>
-                            <option value="46520">Urban Honolulu, HI</option>
-                            <option value="46700">Vallejo-Fairfield, CA</option>
-                            <option value="47260">Virginia Beach-Norfolk-Newport News, VA-NC</option>
-                            <option value="47300">Visalia-Porterville, CA</option>
-                            <option value="47580">Warner Robins, GA</option>
-                            <option value="47900">Washington-Arlington-Alexandria, DC-VA-MD-WV</option>
-                            <option value="48620">Wichita, KS</option>
-                            <option value="48900">Wilmington, NC</option>
-                            <option value="49180">Winston-Salem, NC</option>
-                            <option value="49340">Worcester, MA-CT</option>
-                            <option value="49420">Yakima, WA</option>
-                            <option value="49620">York-Hanover, PA</option>
-                            <option value="49660">Youngstown-Warren-Boardman, OH-PA</option>
-                            <option value="49740">Yuma, AZ</option>
-                        </select>
-                    </div>
-                </div>
                 <div class="m-form-field m-form-field__select mp-line-chart-select-container" id="mp-line-chart-state-container" style="display:none">
                     <label class="a-label" for="mp-line-chart-state"><h4>Select state</h4></label>
                     <div class="a-select">
@@ -318,7 +95,25 @@
                             <option value="53" data-abbr="WA">Washington</option>
                             <option value="54" data-abbr="WV">West Virginia</option>
                             <option value="55" data-abbr="WI">Wisconsin</option>
-                            <!-- <option value="56" data-abbr="WY">Wyoming</option> -->
+                            <option value="56" data-abbr="WY">Wyoming</option>
+                        </select>
+                    </div>
+                </div>
+                <div class="m-form-field m-form-field__select mp-line-chart-select-container" id="mp-line-chart-metro-container" style="display:none">
+                    <label class="a-label" for="mp-line-chart-metro"><h4>Select metro area</h4></label>
+                    <div class="a-select">
+                        <select id="mp-line-chart-metro">
+                          <option value="">
+                          </option>
+                        </select>
+                    </div>
+                </div>
+                <div class="m-form-field m-form-field__select mp-line-chart-select-container" id="mp-line-chart-non-metro-container" style="display:none">
+                    <label class="a-label" for="mp-line-chart-non-metro"><h4>Select non-metro area by state</h4></label>
+                    <div class="a-select">
+                        <select id="mp-line-chart-non-metro">
+                          <option value="">
+                          </option>
                         </select>
                     </div>
                 </div>

--- a/cfgov/unprocessed/js/organisms/MortgagePerformanceTrends/actions.js
+++ b/cfgov/unprocessed/js/organisms/MortgagePerformanceTrends/actions.js
@@ -55,6 +55,11 @@ actions.requestMetros = () => ( {
   isLoadingMetros: true
 } );
 
+actions.requestNonMetros = () => ( {
+  type: 'REQUEST_NON_METROS',
+  isLoadingNonMetros: true
+} );
+
 actions.fetchMetros = ( metroState, includeComparison ) => dispatch => {
   dispatch( actions.requestMetros( metroState ) );
   return utils.getMetroData( ( err, data ) => {
@@ -64,10 +69,32 @@ actions.fetchMetros = ( metroState, includeComparison ) => dispatch => {
     // Alphabetical order
     var newMetros = data[metroState].metros.sort( ( a, b ) => a.name < b.name ? -1 : 1 );
     newMetros = newMetros.filter( metro => metro.valid );
+    if ( !newMetros.length ) {
+      newMetros = [{
+        fips: null,
+        name: 'No metros have sufficient data'
+      }];
+    }
     dispatch( actions.setMetros( newMetros ) );
     dispatch( actions.setGeo( newMetros[0].fips, newMetros[0].name, 'metro' ) );
     dispatch( actions.updateChart( newMetros[0].fips, newMetros[0].name, 'metro', includeComparison ) );
     return newMetros;
+  } );
+};
+
+actions.fetchNonMetros = ( metroState, includeComparison ) => dispatch => {
+  dispatch( actions.requestNonMetros() );
+  return utils.getNonMetroData( ( err, data ) => {
+    if ( err ) {
+      return console.error( 'Error getting non-metro data', err );
+    }
+    var nonMetros = data.filter( nonMetro => nonMetro.valid );
+    // Alphabetical order
+    nonMetros = nonMetros.sort( ( a, b ) => a.name < b.name ? -1 : 1 );
+    dispatch( actions.setNonMetros( nonMetros ) );
+    dispatch( actions.setGeo( nonMetros[0].fips, nonMetros[0].name, 'non-metro' ) );
+    dispatch( actions.updateChart( nonMetros[0].fips, nonMetros[0].name, 'non-metro', includeComparison ) );
+    return nonMetros;
   } );
 };
 
@@ -90,6 +117,11 @@ actions.fetchCounties = ( countyState, includeComparison ) => dispatch => {
 actions.setMetros = metros => ( {
   type: 'SET_METROS',
   metros: metros
+} );
+
+actions.setNonMetros = metros => ( {
+  type: 'SET_NON_METROS',
+  nonMetros: metros
 } );
 
 actions.setCounties = counties => ( {

--- a/cfgov/unprocessed/js/organisms/MortgagePerformanceTrends/actions.js
+++ b/cfgov/unprocessed/js/organisms/MortgagePerformanceTrends/actions.js
@@ -17,14 +17,14 @@ actions.clearGeo = () => ( {
   type: 'CLEAR_GEO'
 } );
 
-actions.updateChart = ( geoId, geoName, geoType, includeNational ) => {
+actions.updateChart = ( geoId, geoName, geoType, includeComparison ) => {
   var action = {
     type: 'UPDATE_CHART',
     geo: {
       id: geoId,
       name: geoName
     },
-    includeNational
+    includeComparison
   };
   if ( geoType ) {
     action.geo.type = geoType;
@@ -32,10 +32,10 @@ actions.updateChart = ( geoId, geoName, geoType, includeNational ) => {
   return action;
 };
 
-actions.updateNational = includeNational => {
+actions.updateNational = includeComparison => {
   var action = {
     type: 'UPDATE_CHART',
-    includeNational
+    includeComparison
   };
   return action;
 };
@@ -55,7 +55,7 @@ actions.requestMetros = () => ( {
   isLoadingMetros: true
 } );
 
-actions.fetchMetros = ( metroState, includeNational ) => dispatch => {
+actions.fetchMetros = ( metroState, includeComparison ) => dispatch => {
   dispatch( actions.requestMetros( metroState ) );
   return utils.getMetroData( ( err, data ) => {
     if ( err ) {
@@ -66,12 +66,12 @@ actions.fetchMetros = ( metroState, includeNational ) => dispatch => {
     newMetros = newMetros.filter( metro => metro.valid );
     dispatch( actions.setMetros( newMetros ) );
     dispatch( actions.setGeo( newMetros[0].fips, newMetros[0].name, 'metro' ) );
-    dispatch( actions.updateChart( newMetros[0].fips, newMetros[0].name, 'metro', includeNational ) );
+    dispatch( actions.updateChart( newMetros[0].fips, newMetros[0].name, 'metro', includeComparison ) );
     return newMetros;
   } );
 };
 
-actions.fetchCounties = ( countyState, includeNational ) => dispatch => {
+actions.fetchCounties = ( countyState, includeComparison ) => dispatch => {
   dispatch( actions.requestCounties( countyState ) );
   return utils.getCountyData( ( err, data ) => {
     if ( err ) {
@@ -82,7 +82,7 @@ actions.fetchCounties = ( countyState, includeNational ) => dispatch => {
     newCounties = newCounties.filter( county => county.valid );
     dispatch( actions.setCounties( newCounties ) );
     dispatch( actions.setGeo( newCounties[0].fips, newCounties[0].name, 'county' ) );
-    dispatch( actions.updateChart( newCounties[0].fips, newCounties[0].name, 'county', includeNational ) );
+    dispatch( actions.updateChart( newCounties[0].fips, newCounties[0].name, 'county', includeComparison ) );
     return newCounties;
   } );
 };

--- a/cfgov/unprocessed/js/organisms/MortgagePerformanceTrends/apps/chart.js
+++ b/cfgov/unprocessed/js/organisms/MortgagePerformanceTrends/apps/chart.js
@@ -56,7 +56,7 @@ MortgagePerformanceLineChart.prototype.onClick = function( event ) {
 MortgagePerformanceLineChart.prototype.onChange = function( event ) {
 
   var action, geoEl, geoType, geoId, geoName;
-  var includeNational = this.$compare.checked;
+  var includeComparison = this.$compare.checked;
 
   switch ( event.target.id ) {
     case 'mp-line-chart_geo-state':
@@ -77,29 +77,29 @@ MortgagePerformanceLineChart.prototype.onChange = function( event ) {
       if ( geoType === 'state' ) {
         geoId = this.$state.value;
         geoName = this.$state.options[this.$state.selectedIndex].text;
-        action = actions.updateChart( geoId, geoName, 'state', includeNational );
+        action = actions.updateChart( geoId, geoName, 'state', includeComparison );
       } else {
         geoId = this.$county.value;
         geoName = this.$county.options[this.$county.selectedIndex].text;
-        action = actions.fetchCounties( this.$state.options[this.$state.selectedIndex].getAttribute( 'data-abbr' ), includeNational );
+        action = actions.fetchCounties( this.$state.options[this.$state.selectedIndex].getAttribute( 'data-abbr' ), includeComparison );
       }
       break;
     case 'mp-line-chart-metro':
       geoId = this.$metro.value;
       geoName = this.$metro.options[this.$metro.selectedIndex].text;
-      action = actions.updateChart( geoId, geoName, 'metro', includeNational );
+      action = actions.updateChart( geoId, geoName, 'metro', includeComparison );
       break;
     case 'mp-line-chart-county':
       geoId = this.$county.value;
       geoName = this.$county.options[this.$county.selectedIndex].text;
-      action = actions.updateChart( geoId, geoName, 'county', includeNational );
+      action = actions.updateChart( geoId, geoName, 'county', includeComparison );
       break;
     case 'mp-line-chart-compare':
-      action = actions.updateNational( includeNational );
+      utils.hideEl( this.$chartTitleComparison );
+      utils.hideEl( this.$chartTitleNational );
+      action = actions.updateNational( includeComparison );
       break;
     default:
-      utils.hideEl( this.$chartTitleComparison );
-      utils.showEl( this.$chartTitleNational );
       action = actions.clearGeo();
   }
 
@@ -111,7 +111,7 @@ MortgagePerformanceLineChart.prototype.renderChart = function( prevState, state 
   var source;
   var baseSource = `time-series/${ this.timespan }/national`;
   // If the geo hasn't changed, don't re-render the chart.
-  if ( prevState.geo.id === state.geo.id && prevState.includeNational === state.includeNational ) {
+  if ( prevState.geo.id === state.geo.id && prevState.includeComparison === state.includeComparison ) {
     return;
   }
 
@@ -127,7 +127,7 @@ MortgagePerformanceLineChart.prototype.renderChart = function( prevState, state 
 
   // Otherwise, load the geo and optionally national data
   source = `time-series/${ this.timespan }/${ state.geo.id }`;
-  if ( state.includeNational ) {
+  if ( state.includeComparison ) {
     source = `${ source };${ baseSource }`;
   }
   this.chart.update( {
@@ -169,14 +169,14 @@ MortgagePerformanceLineChart.prototype.renderChartForm = function( prevState, st
 
 MortgagePerformanceLineChart.prototype.renderChartTitle = function( prevState, state ) {
   var geoName = state.geo.name;
-  var includeNational = state.includeNational;
+  var includeComparison = state.includeComparison;
   if ( geoName ) {
     utils.showEl( this.$chartTitle );
     this.$chartTitleGeo.innerHTML = geoName;
   } else {
     utils.hideEl( this.$chartTitle );
   }
-  if ( includeNational ) {
+  if ( includeComparison ) {
     utils.showEl( this.$chartTitleComparison );
   } else {
     utils.hideEl( this.$chartTitleComparison );

--- a/cfgov/unprocessed/js/organisms/MortgagePerformanceTrends/apps/chart.js
+++ b/cfgov/unprocessed/js/organisms/MortgagePerformanceTrends/apps/chart.js
@@ -15,6 +15,7 @@ class MortgagePerformanceLineChart {
     this.$geo = this.$container.querySelector( '#mp-line-chart-geo' );
     this.$state = this.$container.querySelector( '#mp-line-chart-state' );
     this.$metro = this.$container.querySelector( '#mp-line-chart-metro' );
+    this.$nonMetro = this.$container.querySelector( '#mp-line-chart-non-metro' );
     this.$county = this.$container.querySelector( '#mp-line-chart-county' );
     this.$compareContainer = this.$container.querySelector( '#mp-line-chart-compare-container' );
     this.$compare = this.$container.querySelector( '#mp-line-chart-compare' );
@@ -42,6 +43,8 @@ MortgagePerformanceLineChart.prototype.eventListeners = function() {
   store.subscribe( this.renderChartTitle.bind( this ) );
   store.subscribe( this.renderChartForm.bind( this ) );
   store.subscribe( this.renderCounties.bind( this ) );
+  store.subscribe( this.renderMetros.bind( this ) );
+  store.subscribe( this.renderNonMetros.bind( this ) );
 };
 
 MortgagePerformanceLineChart.prototype.onClick = function( event ) {
@@ -58,25 +61,42 @@ MortgagePerformanceLineChart.prototype.onChange = function( event ) {
 
   switch ( event.target.id ) {
     case 'mp-line-chart_geo-state':
-    case 'mp-line-chart_geo-metro':
       // Reset the county dropdown to the first item if we're no longer using it
+      this.$metro.selectedIndex = 0;
+      this.$nonMetro.selectedIndex = 0;
       this.$county.selectedIndex = 0;
-      geoType = this.$container.querySelector( 'input[name="mp-line-chart_geo"]:checked' ).id.replace( 'mp-line-chart_geo-', '' );
-      geoEl = this['$' + geoType];
-      geoId = geoEl.value;
-      geoName = geoEl.options[geoEl.selectedIndex].text;
-      action = actions.setGeo( geoId, geoName, geoType );
+      geoId = this.$state.value;
+      geoName = this.$state.options[this.$state.selectedIndex].text;
+      action = actions.setGeo( geoId, geoName, 'state' );
+      break;
+    case 'mp-line-chart_geo-metro':
+      action = actions.fetchMetros( this.$state.options[this.$state.selectedIndex].getAttribute( 'data-abbr' ) );
+      break;
+    case 'mp-line-chart_geo-non-metro':
+      action = actions.fetchNonMetros();
       break;
     case 'mp-line-chart_geo-county':
       action = actions.fetchCounties( this.$state.options[this.$state.selectedIndex].getAttribute( 'data-abbr' ) );
       break;
     case 'mp-line-chart-state':
       geoType = this.$container.querySelector( 'input[name="mp-line-chart_geo"]:checked' ).id.replace( 'mp-line-chart_geo-', '' );
+      // TODO: Waaaaay too much code repetition here.
       if ( geoType === 'state' ) {
         geoId = this.$state.value;
         geoName = this.$state.options[this.$state.selectedIndex].text;
         action = actions.updateChart( geoId, geoName, 'state', includeComparison );
-      } else {
+      }
+      if ( geoType === 'metro' ) {
+        geoId = this.$metro.value;
+        geoName = this.$metro.options[this.$metro.selectedIndex].text;
+        action = actions.fetchMetros( this.$state.options[this.$state.selectedIndex].getAttribute( 'data-abbr' ), includeComparison );
+      }
+      if ( geoType === 'non-metro' ) {
+        geoId = this.$nonMetro.value;
+        geoName = this.$nonMetro.options[this.$nonMetro.selectedIndex].text;
+        action = actions.fetchNonMetros( this.$state.options[this.$state.selectedIndex].getAttribute( 'data-abbr' ), includeComparison );
+      }
+      if ( geoType === 'county' ) {
         geoId = this.$county.value;
         geoName = this.$county.options[this.$county.selectedIndex].text;
         action = actions.fetchCounties( this.$state.options[this.$state.selectedIndex].getAttribute( 'data-abbr' ), includeComparison );
@@ -86,6 +106,11 @@ MortgagePerformanceLineChart.prototype.onChange = function( event ) {
       geoId = this.$metro.value;
       geoName = this.$metro.options[this.$metro.selectedIndex].text;
       action = actions.updateChart( geoId, geoName, 'metro', includeComparison );
+      break;
+    case 'mp-line-chart-non-metro':
+      geoId = this.$nonMetro.value;
+      geoName = this.$nonMetro.options[this.$nonMetro.selectedIndex].text;
+      action = actions.updateChart( geoId, geoName, 'non-metro', includeComparison );
       break;
     case 'mp-line-chart-county':
       geoId = this.$county.value;
@@ -143,6 +168,10 @@ MortgagePerformanceLineChart.prototype.renderChartForm = function( prevState, st
   var geoType;
   if ( prevState.isLoadingCounties || state.isLoadingCounties ) {
     geoType = 'county';
+  } else if ( prevState.isLoadingMetros || state.isLoadingMetros ) {
+    geoType = 'metro';
+  } else if ( prevState.isLoadingNonMetros || state.isLoadingNonMetros ) {
+    geoType = 'non-metro';
   } else {
     geoType = state.geo.type;
   }
@@ -151,10 +180,10 @@ MortgagePerformanceLineChart.prototype.renderChartForm = function( prevState, st
   for ( var i = 0; i < containers.length; ++i ) {
     utils.hideEl( containers[i] );
   }
-  if ( geoType === 'county' ) {
+  if ( geoType === 'county' || geoType === 'metro' ) {
     utils.showEl( this.$container.querySelector( '#mp-line-chart-state-container' ) );
   }
-  if ( state.geo.type ) {
+  if ( geoType ) {
     utils.showEl( this.$compareContainer );
   } else {
     utils.hideEl( this.$compareContainer );
@@ -195,6 +224,40 @@ MortgagePerformanceLineChart.prototype.renderCounties = function( prevState, sta
   } );
   this.$county.innerHTML = '';
   this.$county.appendChild( fragment );
+};
+
+MortgagePerformanceLineChart.prototype.renderMetros = function( prevState, state ) {
+  this.$metro.disabled = state.isLoadingMetros;
+  if ( JSON.stringify( prevState.metros ) === JSON.stringify( state.metros ) ) {
+    return;
+  }
+  state.metros.sort( ( a, b ) => a.name < b.name ? -1 : 1 );
+  var fragment = document.createDocumentFragment();
+  state.metros.forEach( metro => {
+    var option = document.createElement( 'option' );
+    option.value = metro.fips;
+    option.text = metro.name;
+    fragment.appendChild( option );
+  } );
+  this.$metro.innerHTML = '';
+  this.$metro.appendChild( fragment );
+};
+
+MortgagePerformanceLineChart.prototype.renderNonMetros = function( prevState, state ) {
+  this.$nonMetro.disabled = state.isLoadingNonMetros;
+  if ( JSON.stringify( prevState.nonMetros ) === JSON.stringify( state.nonMetros ) ) {
+    return;
+  }
+  state.nonMetros.sort( ( a, b ) => a.name < b.name ? -1 : 1 );
+  var fragment = document.createDocumentFragment();
+  state.nonMetros.forEach( nonMetro => {
+    var option = document.createElement( 'option' );
+    option.value = nonMetro.fips;
+    option.text = nonMetro.name;
+    fragment.appendChild( option );
+  } );
+  this.$nonMetro.innerHTML = '';
+  this.$nonMetro.appendChild( fragment );
 };
 
 module.exports = MortgagePerformanceLineChart;

--- a/cfgov/unprocessed/js/organisms/MortgagePerformanceTrends/apps/chart.js
+++ b/cfgov/unprocessed/js/organisms/MortgagePerformanceTrends/apps/chart.js
@@ -22,6 +22,7 @@ class MortgagePerformanceLineChart {
     this.$chartTitle = document.querySelector( '#mp-line-chart-title-status' );
     this.$chartTitleGeo = document.querySelector( '#mp-line-chart-title-status-geo' );
     this.$chartTitleComparison = document.querySelector( '#mp-line-chart-title-status-comparison' );
+    this.$chartTitleNational = document.querySelector( '#mp-line-chart-title-status-national' );
     this.$loadingSpinner = document.querySelector( '#mp-chart-loading' );
     this.timespan = this.$container.getAttribute( 'data-chart-time-span' );
     this.chart = ccb.createChart( {
@@ -30,6 +31,8 @@ class MortgagePerformanceLineChart {
       type: 'line-comparison'
     } );
     this.eventListeners();
+    utils.hideEl( this.$chartTitleComparison );
+    utils.showEl( this.$chartTitleNational );
     utils.hideEl( this.$loadingSpinner );
     utils.hideEl( this.$compareContainer );
   }
@@ -95,6 +98,8 @@ MortgagePerformanceLineChart.prototype.onChange = function( event ) {
       action = actions.updateNational( includeNational );
       break;
     default:
+      utils.hideEl( this.$chartTitleComparison );
+      utils.showEl( this.$chartTitleNational );
       action = actions.clearGeo();
   }
 

--- a/cfgov/unprocessed/js/organisms/MortgagePerformanceTrends/apps/chart.js
+++ b/cfgov/unprocessed/js/organisms/MortgagePerformanceTrends/apps/chart.js
@@ -22,7 +22,6 @@ class MortgagePerformanceLineChart {
     this.$chartTitle = document.querySelector( '#mp-line-chart-title-status' );
     this.$chartTitleGeo = document.querySelector( '#mp-line-chart-title-status-geo' );
     this.$chartTitleComparison = document.querySelector( '#mp-line-chart-title-status-comparison' );
-    this.$chartTitleNational = document.querySelector( '#mp-line-chart-title-status-national' );
     this.$loadingSpinner = document.querySelector( '#mp-chart-loading' );
     this.timespan = this.$container.getAttribute( 'data-chart-time-span' );
     this.chart = ccb.createChart( {
@@ -32,7 +31,6 @@ class MortgagePerformanceLineChart {
     } );
     this.eventListeners();
     utils.hideEl( this.$chartTitleComparison );
-    utils.showEl( this.$chartTitleNational );
     utils.hideEl( this.$loadingSpinner );
     utils.hideEl( this.$compareContainer );
   }
@@ -96,7 +94,6 @@ MortgagePerformanceLineChart.prototype.onChange = function( event ) {
       break;
     case 'mp-line-chart-compare':
       utils.hideEl( this.$chartTitleComparison );
-      utils.hideEl( this.$chartTitleNational );
       action = actions.updateNational( includeComparison );
       break;
     default:
@@ -172,9 +169,9 @@ MortgagePerformanceLineChart.prototype.renderChartTitle = function( prevState, s
   var includeComparison = state.includeComparison;
   if ( geoName ) {
     utils.showEl( this.$chartTitle );
-    this.$chartTitleGeo.innerHTML = geoName;
+    this.$chartTitleGeo.innerText = geoName;
   } else {
-    utils.hideEl( this.$chartTitle );
+    this.$chartTitleGeo.innerText = 'national average';
   }
   if ( includeComparison ) {
     utils.showEl( this.$chartTitleComparison );

--- a/cfgov/unprocessed/js/organisms/MortgagePerformanceTrends/stores/chart.js
+++ b/cfgov/unprocessed/js/organisms/MortgagePerformanceTrends/stores/chart.js
@@ -34,6 +34,15 @@ const isLoadingMetros = action => {
   }
 };
 
+const isLoadingNonMetros = action => {
+  switch ( action.type ) {
+    case 'REQUEST_NON_METROS':
+      return true;
+    default:
+      return false;
+  }
+};
+
 const isLoadingCounties = action => {
   switch ( action.type ) {
     case 'REQUEST_COUNTIES':
@@ -61,6 +70,17 @@ const updateMetros = ( metros, action ) => {
     case 'REQUEST_METROS':
     default:
       return metros;
+  }
+};
+
+const updateNonMetros = ( nonMetros, action ) => {
+  switch ( action.type ) {
+    case 'SET_NON_METROS':
+      return action.nonMetros;
+    case 'FETCH_NON__METROS':
+    case 'REQUEST_NON_METROS':
+    default:
+      return nonMetros;
   }
 };
 
@@ -95,6 +115,7 @@ const initialState = {
   },
   counties: {},
   metros: {},
+  nonMetros: {},
   // Is the chart waiting for data?
   isLoading: false,
   // Is the county dropdown waiting for data?
@@ -117,10 +138,12 @@ class LineChartStore extends Store {
       geo: updateGeo( state.geo, action ),
       isLoading: isLoading( action ),
       isLoadingMetros: isLoadingMetros( action ),
+      isLoadingNonMetros: isLoadingNonMetros( action ),
       isLoadingCounties: isLoadingCounties( action ),
       includeComparison: includeComparison( state.includeComparison, action ),
       counties: updateCounties( state.counties, action ),
-      metros: updateMetros( state.metros, action )
+      metros: updateMetros( state.metros, action ),
+      nonMetros: updateNonMetros( state.nonMetros, action )
     };
     return newState;
   }

--- a/cfgov/unprocessed/js/organisms/MortgagePerformanceTrends/stores/chart.js
+++ b/cfgov/unprocessed/js/organisms/MortgagePerformanceTrends/stores/chart.js
@@ -75,10 +75,10 @@ const updateCounties = ( counties, action ) => {
   }
 };
 
-const includeNational = ( include, action ) => {
+const includeComparison = ( include, action ) => {
   switch ( action.type ) {
     case 'UPDATE_CHART':
-      return typeof action.includeNational === 'undefined' ? include : action.includeNational;
+      return typeof action.includeComparison === 'undefined' ? include : action.includeComparison;
     default:
       return include;
   }
@@ -102,7 +102,7 @@ const initialState = {
   // Is the chart being re-rendered?
   isLoadingChart: false,
   // Should the national trend be shown alongside the geo's?
-  includeNational: true
+  includeComparison: true
 };
 
 class LineChartStore extends Store {
@@ -118,7 +118,7 @@ class LineChartStore extends Store {
       isLoading: isLoading( action ),
       isLoadingMetros: isLoadingMetros( action ),
       isLoadingCounties: isLoadingCounties( action ),
-      includeNational: includeNational( state.includeNational, action ),
+      includeComparison: includeComparison( state.includeComparison, action ),
       counties: updateCounties( state.counties, action ),
       metros: updateMetros( state.metros, action )
     };

--- a/cfgov/unprocessed/js/organisms/MortgagePerformanceTrends/utils.js
+++ b/cfgov/unprocessed/js/organisms/MortgagePerformanceTrends/utils.js
@@ -5,8 +5,10 @@ var ajax = require( 'xdr' );
 
 var COUNTIES_URL = '/data-research/mortgages/api/v1/metadata/state_county_meta';
 var METROS_URL = '/data-research/mortgages/api/v1/metadata/state_msa_meta';
+var NON_METROS_URL = '/data-research/mortgages/api/v1/metadata/non_msa_fips';
 var counties;
 var metros;
+var nonMetros;
 
 var utils = {
   showEl: el => {
@@ -31,6 +33,15 @@ var utils = {
       return cb( null, metros );
     }
     return ajax( { url: METROS_URL }, function( resp ) {
+      var data = JSON.parse( resp.data );
+      cb( null, data );
+    } );
+  },
+  getNonMetroData: cb => {
+    if ( nonMetros ) {
+      return cb( null, nonMetros );
+    }
+    return ajax( { url: NON_METROS_URL }, function( resp ) {
       var data = JSON.parse( resp.data );
       cb( null, data );
     } );

--- a/test/unit_tests/organisms/MortgagePerformanceTrends/actions-spec.js
+++ b/test/unit_tests/organisms/MortgagePerformanceTrends/actions-spec.js
@@ -45,7 +45,7 @@ describe( 'Mortgage Performance action creator', () => {
         id: 12345,
         name: 'Alabama'
       },
-      includeNational: false
+      includeComparison: false
     } );
     action = actions.updateChart( null, null, null, false );
     expect( action ).to.deep.equal( {
@@ -54,7 +54,7 @@ describe( 'Mortgage Performance action creator', () => {
         id: null,
         name: null
       },
-      includeNational: false
+      includeComparison: false
     } );
   } );
 
@@ -62,7 +62,7 @@ describe( 'Mortgage Performance action creator', () => {
     const action = actions.updateNational( false );
     expect( action ).to.deep.equal( {
       type: 'UPDATE_CHART',
-      includeNational: false
+      includeComparison: false
     } );
   } );
 
@@ -90,11 +90,11 @@ describe( 'Mortgage Performance action creator', () => {
     } );
   } );
 
-  it( 'should create an action to request metros', () => {
-    const action = actions.requestMetros();
+  it( 'should create an action to request non-metros', () => {
+    const action = actions.requestNonMetros();
     expect( action ).to.deep.equal( {
-      type: 'REQUEST_METROS',
-      isLoadingMetros: true
+      type: 'REQUEST_NON_METROS',
+      isLoadingNonMetros: true
     } );
   } );
 
@@ -103,6 +103,14 @@ describe( 'Mortgage Performance action creator', () => {
     expect( action ).to.deep.equal( {
       type: 'SET_METROS',
       metros: [ { name: 'Akron, OH' } ]
+    } );
+  } );
+
+  it( 'should create an action to set non-metros', () => {
+    const action = actions.setNonMetros( [ { name: 'Tampa, FL' } ] );
+    expect( action ).to.deep.equal( {
+      type: 'SET_NON_METROS',
+      nonMetros: [ { name: 'Tampa, FL' } ]
     } );
   } );
 

--- a/test/unit_tests/organisms/MortgagePerformanceTrends/stores/chart-spec.js
+++ b/test/unit_tests/organisms/MortgagePerformanceTrends/stores/chart-spec.js
@@ -36,7 +36,7 @@ describe( 'Mortgage Performance line chart store', () => {
   } );
 
   it( 'should default to comparing national data', () => {
-    expect( store.state.includeNational ).to.be.true;
+    expect( store.state.includeComparison ).to.be.true;
   } );
 
   it( 'should properly reduce geos', () => {
@@ -104,6 +104,14 @@ describe( 'Mortgage Performance line chart store', () => {
     expect( store.getState().isLoadingMetros ).to.be.true;
   } );
 
+  it( 'should properly reduce loading non-metros state', () => {
+    const action = {
+      type: 'REQUEST_NON_METROS'
+    };
+    store.dispatch( action );
+    expect( store.getState().isLoadingNonMetros ).to.be.true;
+  } );
+
   it( 'should properly reduce loading counties state', () => {
     const action = {
       type: 'REQUEST_COUNTIES'
@@ -121,6 +129,15 @@ describe( 'Mortgage Performance line chart store', () => {
     expect( store.getState().metros ).to.deep.equal( { 12345: 'Akron, OH' } );
   } );
 
+  it( 'should properly reduce non-metros', () => {
+    const action = {
+      type: 'SET_NON_METROS',
+      nonMetros: { 67890: 'Boston, MA' }
+    };
+    store.dispatch( action );
+    expect( store.getState().nonMetros ).to.deep.equal( { 67890: 'Boston, MA' } );
+  } );
+
   it( 'should properly reduce counties', () => {
     const action = {
       type: 'SET_COUNTIES',
@@ -135,13 +152,13 @@ describe( 'Mortgage Performance line chart store', () => {
       type: 'UPDATE_CHART'
     };
     store.dispatch( action );
-    expect( store.getState().includeNational ).to.be.true;
+    expect( store.getState().includeComparison ).to.be.true;
     action = {
       type: 'UPDATE_CHART',
-      includeNational: false
+      includeComparison: false
     };
     store.dispatch( action );
-    expect( store.getState().includeNational ).to.be.false;
+    expect( store.getState().includeComparison ).to.be.false;
   } );
 
 } );


### PR DESCRIPTION
This PR shows the "national average" dynamic title text for the default national view.

## Additions

- Added a span to allow the "versus" comparison dynamic text to be treated differently from the "national average" dynamic text

## Changes

- Renamed the variables for the "Compare to national average" checkbox

## Testing

1. Pull down this branch and `./setup.sh`
2. Set up the [mortgage performance API](https://github.com/cfpb/cfgov-refresh/pull/3189).
3. Create a [mortgage chart block and page](https://github.com/cfpb/cfgov-refresh/pull/3260).


## Todos

Two items, but I wanted to get this PR up:

1. When you click on any other location and then return to nation, it doesn't show the default "national average" text.
2. When you uncheck the "compare to national average" checkbox, and then check it again, it doesn't show the words "national average". Still need to make sure that the new span shows, and is removed on uncheck along with the "versus" text.

@contolini can you take a look at this, please?

## Checklist

* [x] PR has an informative and human-readable title
* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices
* [x] Project documentation has been updated
* [x] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
