### PR TITLE
MP: add non-msa metadata to msa endpoints

### DIFF
--- a/cfgov/data_research/mortgage_utilities/fips_meta.py
+++ b/cfgov/data_research/mortgage_utilities/fips_meta.py
@@ -111,7 +111,9 @@ def load_county_mappings():
         _attr['counties'] = (
             [county_fips for county_fips in FIPS.county_fips
              if county_fips[:2] == each])
-        _attr['msas'] = [entry['fips'] for entry in msa_meta[abbr]['metros']]
+        _attr['msas'] = [entry['fips']
+                         for entry in msa_meta[abbr]['metros']
+                         if 'non' not in entry['fips']]
         _attr['msa_counties'] = []
         for msa in _attr['msas']:
             _attr['msa_counties'] += (

--- a/cfgov/data_research/scripts/update_county_msa_meta.py
+++ b/cfgov/data_research/scripts/update_county_msa_meta.py
@@ -3,7 +3,7 @@ from __future__ import unicode_literals
 import json
 import logging
 
-from data_research.models import MortgageMetaData, NonMSAMortgageData
+from data_research.models import MortgageMetaData
 from data_research.mortgage_utilities.s3_utils import bake_json_to_s3
 from data_research.mortgage_utilities.fips_meta import FIPS, load_fips_meta
 
@@ -41,11 +41,12 @@ def update_state_to_geo_meta(geo):
     Areas are marked `valid: true` or `valid: false` based on whether they meet
     our display threshold of reporting at least 1,000 open mortgages.
 
-    An MSA meta entry, showing all MSAs in a state, will look like this:
+    An MSA entry, delivering metadata for a state's MSA and non-MSA areas,
+    will look like this:
     ```json
     {
         "HI": {
-            "msas": [
+            "metros": [
                 {
                     "fips": "27980",
                     "name": "Kahului-Wailuku-Lahaina, HI",
@@ -57,28 +58,18 @@ def update_state_to_geo_meta(geo):
                     "valid": true
                 }
             ],
+            "non_msa":
+                {
+                    "fips": "15-non",
+                    "valid": true,
+                    "non_msa_counties": ["15007", "15005", "15001"],
+                },
             "state_fips": "15",
             "state_name": "Hawaii"
         },
     ...
     }
     ```
-
-    A non-MSA meta entry, combining all non-MSA counties in a state:
-    ```json
-    {
-        "HI": {
-            "non_msa_fips": "15-non",
-            "valid": true,
-            "non_msa_countiess": ["15007", "15005", "15001"],
-            "msa_counties": ["15003", "15009"],
-            "state_fips": "15",
-            "state_name": "Hawaii"
-        },
-    ...
-    }
-    ```
-
 
     A county meta entry, showing all counties in a state, will look like this:
     ```json
@@ -108,6 +99,7 @@ def update_state_to_geo_meta(geo):
     }
     ```
     """
+    non_msa_fips_output = []
     geo_dict = {
         'county': {'label': 'counties',
                    'output_slug': 'state_county_meta',
@@ -118,12 +110,7 @@ def update_state_to_geo_meta(geo):
                 'output_slug': 'state_msa_meta',
                 'fips_dict': FIPS.msa_fips,
                 'query': MortgageMetaData.objects.get_or_create(
-                    name='state_msa_meta')},
-        'non_msa': {'label': 'non-metro-counties',
-                    'output_slug': 'state_non_msa_meta',
-                    'fips_dict': FIPS.state_fips,
-                    'query': MortgageMetaData.objects.get_or_create(
-                        name='state_non_msa_meta')},
+                    name='state_msa_meta')}
     }
     g_dict = geo_dict[geo]
     fips_dict = g_dict['fips_dict']
@@ -138,8 +125,8 @@ def update_state_to_geo_meta(geo):
     for fips in fips_dict:
         _dict = fips_dict[fips]
         geo_name = _dict['name']
+        geo_valid = fips in FIPS.whitelist
         if geo == 'msa':
-            geo_valid = fips in FIPS.whitelist
             msa_state_list = []
             for county_fips in _dict['county_list']:
                 state = FIPS.county_fips[county_fips]['state']
@@ -150,25 +137,32 @@ def update_state_to_geo_meta(geo):
                     {'name': geo_name,
                      'fips': fips,
                      'valid': geo_valid})
-        elif geo == 'non_msa':
-            non_fips = '{}-non'.format(fips)
-            s_dict = FIPS.state_fips[fips]
-            abbr = s_dict['abbr']
-            geo_valid = non_fips in FIPS.whitelist
-            for each in ['msa_counties', 'non_msa_counties', 'msas']:
-                setup[abbr][each] = s_dict[each]
-            setup[abbr]['non_fips'] = non_fips
-        else:
-            geo_valid = fips in FIPS.whitelist
+        else:  # geo is 'county'
             this_state = FIPS.county_fips[fips]['state']
             setup[this_state]['counties'].append(
                 {'name': geo_name,
                  'fips': fips,
                  'valid': geo_valid})
-        if geo != 'non_msa':
             for state_abbr in setup:
                 setup[state_abbr][label].sort(
                     key=lambda entry: entry['fips'])
+    if geo == 'msa':
+        for state_fips in FIPS.state_fips:
+            non_fips = '{}-non'.format(state_fips)
+            s_dict = FIPS.state_fips[state_fips]
+            state_abbr = s_dict['abbr']
+            state_name = s_dict['name']
+            non_fips_name = "{} non-metro area".format(state_name)
+            non_valid = non_fips in FIPS.whitelist
+            setup[state_abbr]['metros'].append(
+                {'fips': non_fips,
+                 'valid': non_valid,
+                 'name': "{} non-metro area".format(state_name)})
+            non_msa_fips_output.append(
+                {'fips': non_fips,
+                 'valid': non_valid,
+                 'name': non_fips_name,
+                 'abbr': state_abbr})
     json_out = json.dumps(setup)
     # dump to s3 and save to database
     slug = geo_dict[geo]['output_slug']
@@ -182,20 +176,15 @@ def update_state_to_geo_meta(geo):
     meta_obj.json_value = setup
     meta_obj.save()
     logger.info("Saved metadata object '{}.'".format(slug))
-
-
-def update_non_msa_fips():
-    fips = sorted(set(
-        [obj.fips for obj in NonMSAMortgageData.objects.filter(
-            state__non_msa_valid=True)]))
-    meta_obj, cr = MortgageMetaData.objects.get_or_create(
-        name='non_msa_fips')
-    meta_obj.json_value = fips
-    meta_obj.save()
+    if non_msa_fips_output:
+        non_meta_obj, cr = MortgageMetaData.objects.get_or_create(
+            name='non_msa_fips')
+        non_meta_obj.json_value = non_msa_fips_output
+        non_meta_obj.save()
+        logger.info("Saved non_msa_fips")
 
 
 def run():
     load_fips_meta()
-    for geo in ['msa', 'county', 'non_msa']:
+    for geo in ['msa', 'county']:
         update_state_to_geo_meta(geo)
-    update_non_msa_fips()

--- a/cfgov/data_research/scripts/update_county_msa_meta.py
+++ b/cfgov/data_research/scripts/update_county_msa_meta.py
@@ -56,13 +56,11 @@ def update_state_to_geo_meta(geo):
                     "fips": "46520",
                     "name": "Urban Honolulu, HI",
                     "valid": true
-                }
-            ],
-            "non_msa":
+                },
                 {
                     "fips": "15-non",
                     "valid": true,
-                    "non_msa_counties": ["15007", "15005", "15001"],
+                    "name": "Hawaii non-metro area"
                 },
             "state_fips": "15",
             "state_name": "Hawaii"

--- a/cfgov/data_research/tests/test_scripts.py
+++ b/cfgov/data_research/tests/test_scripts.py
@@ -684,19 +684,6 @@ class BuildStateMsaDropdownTests(django.test.TestCase):
                 'update_county_msa_meta.bake_json_to_s3')
     @mock.patch('data_research.scripts.'
                 'update_county_msa_meta.FIPS')
-    def test_update_non_msa_meta(self, mock_FIPS, mock_bake_s3):
-        mock_FIPS = self.load_fips(mock_FIPS)
-        self.assertFalse(
-            MortgageMetaData.objects.filter(name='state_msa_meta').exists())
-        update_state_to_geo_meta('non_msa')
-        self.assertTrue(
-            MortgageMetaData.objects.filter(name='state_msa_meta').exists())
-        self.assertEqual(mock_bake_s3.call_count, 1)
-
-    @mock.patch('data_research.scripts.'
-                'update_county_msa_meta.bake_json_to_s3')
-    @mock.patch('data_research.scripts.'
-                'update_county_msa_meta.FIPS')
     def test_update_county_meta(self, mock_FIPS, mock_bake_s3):
         mock_FIPS = self.load_fips(mock_FIPS)
         self.assertFalse(
@@ -716,4 +703,4 @@ class UpdateStateMsaDropdownTests(django.test.TestCase):
                 'update_county_msa_meta.update_state_to_geo_meta')
     def test_run_rebuild(self, mock_update):
         run_update()
-        self.assertEqual(mock_update.call_count, 3)
+        self.assertEqual(mock_update.call_count, 2)


### PR DESCRIPTION
Since we display MSA and non-MSA data together, building drop-down lists
will be easier if we combine the metadata in one endpoint.

Toward the same end, we're adding drop-down info to the `non_msa_fips` endpoint.

This PR just changes the script that updates metadata once a quarter.
The new endpoints can be checked on build
- [BUILD]/data-research/mortgages/api/v1/metadata/state_msa_meta/
- [BUILD]/data-research/mortgages/api/v1/metadata/non_msa_fips/
