### PR TITLE
Refactor New Relic alerts, use a local cache file of violations

### DIFF
--- a/cfgov/alerts/newrelic_alerts.py
+++ b/cfgov/alerts/newrelic_alerts.py
@@ -63,7 +63,7 @@ class NewRelicAlertViolations(object):
         )
         body = (
             'New Relic {product}, {name}, {label}.'
-            '<a href="{link}">View incidents</a>'
+            'View incidents: {link}'
         ).format(
             product=violation['entity']['product'],
             type=violation['entity']['type'],

--- a/cfgov/alerts/newrelic_alerts.py
+++ b/cfgov/alerts/newrelic_alerts.py
@@ -1,0 +1,75 @@
+import re
+
+import requests
+
+
+class NewRelicAlertViolations(object):
+
+    newrelic_url = 'https://api.newrelic.com/v2/'
+
+    def __init__(self, newrelic_token, policy_filter, account_number,
+                 known_violations=[]):
+        self.newrelic_token = newrelic_token
+        self.policy_filter_re = re.compile(policy_filter)
+        self.account_number = account_number
+        self.known_violations = known_violations
+
+    def get_current_violations(self):
+        """ Check for all violations currently open in New Relic """
+        headers = {'X-Api-Key': self.newrelic_token}
+        violations_url = (self.newrelic_url +
+                          'alerts_violations.json?only_open=true')
+        r = requests.get(violations_url, headers=headers)
+        response_json = r.json()
+
+        # Filter on the policy name
+        violations = [v for v in response_json['violations']
+                      if self.policy_filter_re.search(v['policy_name'])]
+
+        return violations
+
+    def get_new_violations(self):
+        """ Determine which current violations are new. Non-new violations
+        are expected to be in known_violations. Any violations returned by
+        this method are automatically added to known_violations. """
+        violations = []
+        for violation in self.get_current_violations():
+            if violation['id'] in self.known_violations:
+                continue
+
+            self.known_violations.append(violation['id'])
+            violations.append(violation)
+
+        return violations
+
+    def get_new_violation_messages(self):
+        violations = self.get_new_violations()
+        formatted_violations = [self.format_violation(v)
+                                for v in violations]
+        return formatted_violations
+
+    def format_violation(self, violation):
+        """ Format the given violation dictionary into an SQS message
+        dictionary """
+        title = '{condition_name}, {entity_name}'.format(
+            condition_name=violation['condition_name'],
+            entity_name=violation['entity']['name']
+        )
+        incidents_link = (
+            'https://alerts.newrelic.com/accounts/'
+            '{account_number}/incidents'
+        ).format(
+            account_number=self.account_number
+        )
+        body = (
+            'New Relic {product}, {name}, {label}.'
+            '<a href="{link}">View incidents</a>'
+        ).format(
+            product=violation['entity']['product'],
+            type=violation['entity']['type'],
+            label=violation['label'],
+            name=violation['entity']['name'],
+            link=incidents_link
+        )
+        message_body = '{title} - {body}'.format(title=title, body=body)
+        return message_body

--- a/cfgov/alerts/send_new_relic_messages_to_sqs.py
+++ b/cfgov/alerts/send_new_relic_messages_to_sqs.py
@@ -1,10 +1,10 @@
 import argparse
-import boto3
 import logging
-import re
 import sys
 
-import requests
+import boto3
+
+from alerts.newrelic_alerts import NewRelicAlertViolations
 
 logger = logging.getLogger(__name__)
 logger.addHandler(logging.StreamHandler())
@@ -39,9 +39,9 @@ parser.add_argument(
     help='New Relic account number, used to construct alert link URLs'
 )
 parser.add_argument(
-    '--newrelic_url',
-    default="https://api.newrelic.com/v2/",
-    help='URL base for the New Relic API v2'
+    '--known_violations_file',
+    required=True,
+    help='File to store known New Relic violations across invocations'
 )
 parser.add_argument(
     '--threshold',
@@ -67,52 +67,35 @@ parser.add_argument(
 )
 
 
-def get_new_violations(newrelic_token, newrelic_url, threshold, policy_filter):
-    """ Check for violations in New Relic that are newer than the
-    newness_threshold in minutes. """
-    headers = {'X-Api-Key': newrelic_token}
-    violations_url = (newrelic_url +
-                      'alerts_violations.json?only_open=true')
-    r = requests.get(violations_url, headers=headers)
-    response_json = r.json()
-
-    violations = []
-    for violation in response_json['violations']:
-        logger.debug("Found violation: {violation}".format(
-                     violation=violation))
-        # Filter on the policy name
-        policy_name = violation['policy_name']
-        if policy_filter.search(policy_name) and \
-                violation['duration'] <= threshold:
-            violations.append(violation)
-
-    return violations
+def cache_known_violations(known_violations_filename, known_violations):
+    with open(known_violations_filename, 'w') as known_violations_file:
+        known_violations_file.writelines(known_violations)
 
 
-def format_message_for_violation(violation, account_number):
-    """ Format the given violation dictionary into an SQS message
-    dictionary """
-    title = '{condition_name}, {entity_name}'.format(
-        condition_name=violation['condition_name'],
-        entity_name=violation['entity']['name']
-    )
-    incidents_link = (
-        'https://alerts.newrelic.com/accounts/'
-        '{account_number}/incidents'
-    ).format(
-        account_number=account_number
-    )
-    body = (
-        'New Relic {product}, {label}.'
-        '<a href="{link}">View incidents</a>'
-    ).format(
-        product=violation['entity']['product'],
-        type=violation['entity']['type'],
-        label=violation['label'],
-        link=incidents_link
-    )
-    message_body = '{title} - {body}'.format(title=title, body=body)
-    return message_body
+def read_known_violations(known_violations_filename):
+    try:
+        with open(known_violations_filename, 'r') as known_violations_file:
+            known_violations = known_violations_file.readlines()
+    except IOError:
+        logger.warning("Known violations file does not exist")
+        known_violations = []
+    return known_violations
+
+
+def send_violations(sqs_client, queue_url, violation_messages, dryrun=False):
+    for message in violation_messages:
+        logger.info("Sending message '{}' to SQS".format(message))
+        if not dryrun:
+            response = sqs_client.send_message(
+                QueueUrl=queue_url,
+                MessageBody=message,
+            )
+            if response['ResponseMetadata']['HTTPStatusCode'] != 200:
+                logger.error("There was an error posting the message "
+                             "'{}' to SQS".format(message))
+                sys.exit(1)
+        else:
+            logger.info(message)
 
 
 if __name__ == "__main__":
@@ -128,28 +111,19 @@ if __name__ == "__main__":
     if args.verbose > 0:
         logger.setLevel(logging.DEBUG)
 
-    try:
-        policy_filter = re.compile(args.policy_filter)
-    except Exception as err:
-        logging.error("Unable to compile policy filter regular expression")
-        raise err
+    # Read cached known violations
+    known_violations = read_known_violations(args.known_violations_file)
 
-    violations = get_new_violations(args.newrelic_token,
-                                    args.newrelic_url,
-                                    args.threshold, policy_filter)
     # Send the violations to SQS as messages
-    for violation in violations:
-        message_body = format_message_for_violation(
-            violation, args.newrelic_account)
-        logger.info("Sending message '{}' to SQS".format(message_body))
-        if not args.dryrun:
-            response = client.send_message(
-                QueueUrl=args.queue_url,
-                MessageBody=message_body,
-            )
-            if response['ResponseMetadata']['HTTPStatusCode'] != 200:
-                logger.error("There was an error posting the message "
-                             "'{}' to SQS".format(message_body))
-                sys.exit(1)
-        else:
-            logger.info(message_body)
+    nralert_violations = NewRelicAlertViolations(
+        args.newrelic_token,
+        args.policy_filter,
+        args.newrelic_account,
+        known_violations=known_violations
+    )
+    messages = nralert_violations.get_new_violation_messages()
+    send_violations(client, args.queue_url, messages, dryrun=args.dryrun)
+
+    # Cache known violations
+    cache_known_violations(args.known_violations_file,
+                           nralert_violations.known_violations)

--- a/cfgov/alerts/tests/test_newrelic_alerts.py
+++ b/cfgov/alerts/tests/test_newrelic_alerts.py
@@ -1,0 +1,89 @@
+import re
+import time
+import unittest
+
+import mock
+import requests
+
+from alerts.newrelic_alerts import NewRelicAlertViolations
+
+
+class TestNewRelicAlertViolations(unittest.TestCase):
+
+    def setUp(self):
+        # Set up patcher for all requests.get calls to New Relic
+        patcher = mock.patch('requests.get')
+        self.addCleanup(patcher.stop)
+        self.mock_requests_get = patcher.start()
+        self.newrelic_response = {
+            u'violations': [
+                {
+                    'condition_name': 'cf.gov test opened now',
+                    'entity': {
+                        'name': 'cf.gov synthetic entity',
+                        'product': 'Synthetic',
+                        'type': 'Monitor'
+                    },
+                    'id': 12345678,
+                    'label': 'This test opened just now',
+                    'policy_name': 'cf.gov unit tests',
+                },
+                {
+                    'condition_name': 'cf.gov test opened > 2 min ago',
+                    'entity': {
+                        'name': 'cf.gov application entity',
+                        'product': 'Apm',
+                        'type': 'Application'
+                    },
+                    'id': 23456781,
+                    'label': 'This test opened 2 min ago',
+                    'policy_name': 'cf.gov unit tests',
+                },
+                {
+                    'condition_name': 'not cf.gov condition',
+                    'entity': {
+                        'name': 'other application entity',
+                        'product': 'Apm',
+                        'type': 'Application'
+                    },
+                    'id': 34567812,
+                    'label': 'This is a different application',
+                    'policy_name': 'other unit tests',
+                },
+            ],
+        }
+        mock_response = mock.MagicMock(requests.Response)
+        mock_response.json.return_value = self.newrelic_response
+        self.mock_requests_get.return_value = mock_response
+
+    def test_get_current_violations(self):
+        nralert_violations = NewRelicAlertViolations(
+            'token',
+            'cf.gov',
+            '123456',
+        )
+        violations = nralert_violations.get_current_violations()
+        self.assertEqual(len(violations), 2)
+
+    def test_get_new_violations(self):
+        nralert_violations = NewRelicAlertViolations(
+            'token',
+            'cf.gov',
+            '123456',
+            known_violations=[23456781],
+        )
+        violations = nralert_violations.get_new_violations()
+        self.assertEqual(len(violations), 1)
+
+    def test_format_violation(self):
+        nralert_violations = NewRelicAlertViolations(
+            'token',
+            'cf.gov',
+            '123456'
+        )
+        formatted_violation = nralert_violations.format_violation(
+            self.newrelic_response['violations'][0])
+        self.assertIn(
+            'cf.gov test opened now, cf.gov synthetic entity '
+            '- New Relic Synthetic, cf.gov synthetic entity, '
+            'This test opened just now.', formatted_violation)

--- a/cfgov/alerts/tests/test_send_new_relic_messages_to_sqs.py
+++ b/cfgov/alerts/tests/test_send_new_relic_messages_to_sqs.py
@@ -1,0 +1,67 @@
+import unittest
+
+import boto3
+import mock
+from botocore.stub import Stubber
+
+from alerts.send_new_relic_messages_to_sqs import (
+    cache_known_violations,
+    read_known_violations,
+    send_violations
+)
+
+
+class TestSendNewRelicMessagesToSQS(unittest.TestCase):
+
+    def test_cache_known_violations(self):
+        with mock.patch('__builtin__.open', create=True) as mock_open:
+            mock_open.return_value = mock.MagicMock(spec=file)
+            cache_known_violations('/some/file.json', ['12345', '23456'])
+
+        file_handle = mock_open.return_value.__enter__.return_value
+        file_handle.writelines.assert_called_with(['12345', '23456'])
+
+    def test_read_known_violations_existing(self):
+        with mock.patch('__builtin__.open', create=True) as mock_open:
+            mock_open.return_value = mock.MagicMock(spec=file)
+            file_handle = mock_open.return_value.__enter__.return_value
+            file_handle.readlines.return_value = ['12345', '23456']
+            known_violations = read_known_violations('/some/file.json')
+
+        self.assertEqual(['12345', '23456'], known_violations)
+
+    def test_read_known_violations_nonexisting(self):
+        with mock.patch('__builtin__.open', create=True) as mock_open:
+            mock_open.side_effect = IOError()
+            known_violations = read_known_violations('/some/file.json')
+        self.assertEqual([], known_violations)
+
+    def test_send_violations(self):
+        mock_boto3_client = mock.MagicMock(boto3.session.Session.client)()
+        mock_boto3_client.send_message.return_value = {
+            'ResponseMetadata': {'HTTPStatusCode': 200}
+        }
+        send_violations(mock_boto3_client,
+                        'http://queue',
+                        ['test violation message'])
+        mock_boto3_client.send_message.assert_called_once_with(
+            MessageBody='test violation message',
+            QueueUrl='http://queue')
+
+    def test_send_violations_not200(self):
+        mock_boto3_client = mock.MagicMock(boto3.session.Session.client)()
+        mock_boto3_client.send_message.return_value = {
+            'ResponseMetadata': {'HTTPStatusCode': 400}
+        }
+        with self.assertRaises(SystemExit):
+            send_violations(mock_boto3_client,
+                            'http://queue',
+                            ['test violation message'])
+
+    def test_send_violations_dryrun(self):
+        mock_boto3_client = mock.MagicMock(boto3.session.Session.client)()
+        send_violations(mock_boto3_client,
+                        'http://queue',
+                        ['test violation message'],
+                        dryrun=True)
+        mock_boto3_client.send_message.assert_not_called()


### PR DESCRIPTION
This PR refactors the New Relic alert violation processing to make it more testable and to handle previously-seen violations differently.

We had been trying to use the New Relic `opened_at` and `duration` values for violations to track when a violation occurred. If we run every 60 seconds, our assumption was that violations that have been open for less than 60 seconds were new. This turns out not to be true — some violations are not available via the API until well after 60 seconds, but their duration still reflects when the condition began — they'd first appear with durations of 180+ seconds.

Instead, this script now takes a `--known_violations_file` in which to store violation ids, one per-line, and violations are added to this file when they are first observed by the script. That file is presumed to persist.
