### PR TITLE
MP line chart fixes

### DIFF
--- a/cfgov/unprocessed/js/organisms/MortgagePerformanceTrends/apps/chart.js
+++ b/cfgov/unprocessed/js/organisms/MortgagePerformanceTrends/apps/chart.js
@@ -234,6 +234,9 @@ MortgagePerformanceLineChart.prototype.renderMetros = function( prevState, state
   state.metros.sort( ( a, b ) => a.name < b.name ? -1 : 1 );
   var fragment = document.createDocumentFragment();
   state.metros.forEach( metro => {
+    if ( metro.fips.indexOf( '-non' ) > -1 ) {
+      return;
+    }
     var option = document.createElement( 'option' );
     option.value = metro.fips;
     option.text = metro.name;

--- a/cfgov/unprocessed/js/organisms/MortgagePerformanceTrends/apps/chart.js
+++ b/cfgov/unprocessed/js/organisms/MortgagePerformanceTrends/apps/chart.js
@@ -202,7 +202,8 @@ MortgagePerformanceLineChart.prototype.renderChartTitle = function( prevState, s
   } else {
     this.$chartTitleGeo.innerText = 'national average';
   }
-  if ( includeComparison ) {
+  // Only show comparison text if a location type is selected
+  if ( geoName && includeComparison ) {
     utils.showEl( this.$chartTitleComparison );
   } else {
     utils.hideEl( this.$chartTitleComparison );
@@ -234,6 +235,7 @@ MortgagePerformanceLineChart.prototype.renderMetros = function( prevState, state
   state.metros.sort( ( a, b ) => a.name < b.name ? -1 : 1 );
   var fragment = document.createDocumentFragment();
   state.metros.forEach( metro => {
+    // Remove non-metros (locations with fips ending in -non)
     if ( metro.fips.indexOf( '-non' ) > -1 ) {
       return;
     }


### PR DESCRIPTION
@marteki couple small fixes for the things we noticed this morn.

## Changes

- Remove non-metros from metro dropdown.
- Don't show the "versus national" text when only national is selected.

## Testing

1. Pull down this branch and `./setup.sh`
2. Set up the [mortgage performance API](https://github.com/cfpb/cfgov-refresh/pull/3189).
3. Create a [mortgage chart block and page](https://github.com/cfpb/cfgov-refresh/pull/3260).

## Checklist

* [ ] PR has an informative and human-readable title
* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated
* [ ] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
