### PR TITLE
Bug: Fix template typos

### DIFF
--- a/cfgov/jinja2/v1/_includes/molecules/notification.html
+++ b/cfgov/jinja2/v1/_includes/molecules/notification.html
@@ -38,7 +38,7 @@
       <span class="m-notification_icon
                    cf-icon"></span>
       <div class="m-notification_content"
-           { 'role="alert"' if type == 'warning' or type == 'error' else '' }}>
+           {{ 'role="alert"' if type == 'warning' or type == 'error' else '' }}>
           <div class="h4 m-notification_message">{{ message }}</div>
           {% if explanation %}
               <p class="h4 m-notification_explanation">{{ explanation }}</p>

--- a/cfgov/jinja2/v1/_layouts/content-base.html
+++ b/cfgov/jinja2/v1/_layouts/content-base.html
@@ -5,7 +5,7 @@
     <main class="content {% block content_modifiers -%}{%- endblock %}"
           id="main"
           role="main"
-          {{- accessible_languages.render() }}>
+          {{ accessible_languages.render() }}>
         {% block hero -%}{%- endblock %}
         {% block pre_content scoped -%}
             {% if breadcrumb_items | length > 0 %}


### PR DESCRIPTION
A jinja typo was letting jinja markup into the output HTML 😱 
Also, whitespace was being removed from two attributes in jinja, leading to them having no space separation in the generated output HTML (`role="main"lang="en"`).

Both of these typos were causing errors in IE. 

## Changes

- Fixes jinja typo of missing double bracket.
- Removes whitespace removal in jinja markup.
