### PR TITLE
Adds gulp task for verifying transpiling

### DIFF
--- a/gulp/tasks/scripts.js
+++ b/gulp/tasks/scripts.js
@@ -10,6 +10,7 @@
 const browserSync = require( 'browser-sync' );
 const gulp = require( 'gulp' );
 const gulpConcat = require( 'gulp-concat' );
+const gulpContains = require( 'gulp-contains' );
 const gulpModernizr = require( 'gulp-modernizr' );
 const gulpRename = require( 'gulp-rename' );
 const gulpReplace = require( 'gulp-replace' );
@@ -165,6 +166,17 @@ function scriptsEs5Shim() {
     } ) );
 }
 
+/**
+ * Rudimentary check to verify that transpiled JavaScript does not contain
+ * common ES6 "const" feature, indicating transpiling didn't happen on all
+ * generated JavaScript.
+ */
+function verifyTranspiling() {
+  return gulp.src( paths.processed + '/js/**/*.js' )
+    .pipe( gulpContains( 'const ' ) );
+}
+
+
 gulp.task( 'scripts:polyfill', scriptsPolyfill );
 gulp.task( 'scripts:modern', scriptsModern );
 gulp.task( 'scripts:ie', scriptsIE );
@@ -178,6 +190,7 @@ gulp.task( 'scripts:ondemand', [
 ] );
 gulp.task( 'scripts:nemo', scriptsNemo );
 gulp.task( 'scripts:es5-shim', scriptsEs5Shim );
+gulp.task( 'scripts:verifyTranspiling', verifyTranspiling )
 
 gulp.task( 'scripts', [
   'scripts:polyfill',
@@ -186,5 +199,6 @@ gulp.task( 'scripts', [
   'scripts:external',
   'scripts:nemo',
   'scripts:es5-shim',
-  'scripts:spanish'
+  'scripts:spanish',
+  'scripts:verifyTranspiling'
 ] );

--- a/package-lock.json
+++ b/package-lock.json
@@ -6175,6 +6175,52 @@
         }
       }
     },
+    "gulp-contains": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/gulp-contains/-/gulp-contains-1.1.0.tgz",
+      "integrity": "sha1-wGnVEI+IsZHOIqNKPwra00ZdWN0=",
+      "dev": true,
+      "requires": {
+        "gulp-util": "3.0.8",
+        "through2": "0.6.5"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "1.0.34",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+          "dev": true,
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "0.0.1",
+            "string_decoder": "0.10.31"
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+          "dev": true
+        },
+        "through2": {
+          "version": "0.6.5",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+          "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
+          "dev": true,
+          "requires": {
+            "readable-stream": "1.0.34",
+            "xtend": "4.0.1"
+          }
+        }
+      }
+    },
     "gulp-decompress": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gulp-decompress/-/gulp-decompress-1.2.0.tgz",

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "chai": "4.0.2",
     "chai-as-promised": "7.0.0",
     "cucumber": "2.3.1",
+    "gulp-contains": "1.1.0",
     "jasmine-reporters": "2.2.1",
     "jasmine-spec-reporter": "4.1.1",
     "jsdoc": "3.4.3",


### PR DESCRIPTION
## Additions

- Adds transpiled JS verification gulp task.

## Testing
- Running `gulp build` should throw an error if `const ` is found in the generated JS that will go to production.

## Notes

- @sebworks @contolini Just opening this and closing it so there's a reference for this if we want it. I think the overhead of having another dependency for this isn't worth it, but maybe this would be useful in travis or something?
