### PR TITLE
 Run all generated JS through Babel

### DIFF
--- a/config/webpack-config.js
+++ b/config/webpack-config.js
@@ -16,33 +16,35 @@ const UglifyWebpackPlugin = require( 'uglifyjs-webpack-plugin' );
 const JS_ROUTES_PATH = '/js/routes';
 const COMMON_BUNDLE_NAME = 'common.js';
 
+// Commmon webpack 'module' option used in each configuration.
+// Runs code through Babel and uses global supported browser list.
+const COMMON_MODULE_CONFIG = {
+  loaders: [ {
+    test: /\.js$/,
+    loaders: [ {
+      loader: 'babel-loader?cacheDirectory=true',
+      options: {
+        presets: [ [ 'env', {
+          targets: {
+            browsers: environment.getSupportedBrowserList( 'js' )
+          },
+          debug: true
+        } ] ]
+      }
+    } ],
+    exclude: {
+      test: /node_modules/,
+      // The below regex will capture all node modules that start with `cf`.
+      exclude: /node_modules\/cf(.+)/
+    }
+  } ]
+};
+
 const modernConf = {
   cache: true,
   context: path.join( __dirname, '/../', paths.unprocessed, JS_ROUTES_PATH ),
   entry: scriptsManifest.getDirectoryMap( paths.unprocessed + JS_ROUTES_PATH ),
-  module: {
-    rules: [ {
-      test: /\.js$/,
-      use: [ {
-        loader: 'babel-loader?cacheDirectory=true',
-        options: {
-          presets: [ [ 'env', {
-            targets: {
-              browsers: environment.getSupportedBrowserList( 'js' )
-            },
-            debug: true
-          } ] ]
-        }
-      } ],
-      exclude: {
-        test: /node_modules/,
-        // TODO: Move this into a config variable so that we can easily add
-        // other modules in the future. The below regex will capture all
-        // node modules that start with `cf`.
-        exclude: /node_modules\/cf(.+)/
-      }
-    } ]
-  },
+  module: COMMON_MODULE_CONFIG,
   output: {
     path: path.join( __dirname, 'js' ),
     filename: '[name]'
@@ -62,6 +64,7 @@ const modernConf = {
 
 const ieConf = {
   entry: paths.unprocessed + '/js/ie/common.ie.js',
+  module: COMMON_MODULE_CONFIG,
   output: {
     filename: 'common.ie.js'
   },
@@ -74,6 +77,7 @@ const ieConf = {
 
 const externalConf = {
   entry: paths.unprocessed + JS_ROUTES_PATH + '/external-site/index.js',
+  module: COMMON_MODULE_CONFIG,
   output: {
     filename: 'external-site.js'
   },
@@ -89,6 +93,7 @@ const onDemandConf = {
                       JS_ROUTES_PATH + '/on-demand' ),
   entry:   scriptsManifest.getDirectoryMap( paths.unprocessed +
                                             JS_ROUTES_PATH + '/on-demand' ),
+  module: COMMON_MODULE_CONFIG,
   output: {
     path:     path.join( __dirname, 'js' ),
     filename: '[name]'
@@ -105,6 +110,7 @@ const onDemandHeaderRawConf = {
   context: path.join( __dirname, '/../', paths.unprocessed,
                       JS_ROUTES_PATH + '/on-demand' ),
   entry:   './header.js',
+  module: COMMON_MODULE_CONFIG,
   output: {
     path:     path.join( __dirname, 'js' ),
     filename: '[name]'
@@ -112,7 +118,9 @@ const onDemandHeaderRawConf = {
 };
 
 const spanishConf = {
-  entry: paths.unprocessed + JS_ROUTES_PATH + '/es/obtener-respuestas/single.js',
+  entry: paths.unprocessed +
+         JS_ROUTES_PATH + '/es/obtener-respuestas/single.js',
+  module: COMMON_MODULE_CONFIG,
   output: {
     filename: 'spanish.js'
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -527,9 +527,9 @@
       }
     },
     "babel-core": {
-      "version": "6.25.0",
-      "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.25.0.tgz",
-      "integrity": "sha1-fdQrBGPHQunVKW3rPsZ6kyLa1yk=",
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.0.tgz",
+      "integrity": "sha1-rzL3izGm/O8RnIew/Y2XU/A6C7g=",
       "requires": {
         "babel-code-frame": "6.26.0",
         "babel-generator": "6.26.0",
@@ -693,9 +693,9 @@
       }
     },
     "babel-loader": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-7.1.1.tgz",
-      "integrity": "sha1-uHE0yLEuPkwqlOBUYIW8aAorhIg=",
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-7.1.2.tgz",
+      "integrity": "sha512-jRwlFbINAeyDStqK6Dd5YuY0k5YuzQUvlz2ZamuXrXmxav3pNqe9vfJ402+2G+OmlJSXxCOpB6Uz0INM7RQe2A==",
       "requires": {
         "find-cache-dir": "1.0.0",
         "loader-utils": "1.1.0",
@@ -1031,34 +1031,6 @@
         "lodash": "4.17.4",
         "mkdirp": "0.5.1",
         "source-map-support": "0.4.17"
-      },
-      "dependencies": {
-        "babel-core": {
-          "version": "6.26.0",
-          "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.0.tgz",
-          "integrity": "sha1-rzL3izGm/O8RnIew/Y2XU/A6C7g=",
-          "requires": {
-            "babel-code-frame": "6.26.0",
-            "babel-generator": "6.26.0",
-            "babel-helpers": "6.24.1",
-            "babel-messages": "6.23.0",
-            "babel-register": "6.26.0",
-            "babel-runtime": "6.26.0",
-            "babel-template": "6.26.0",
-            "babel-traverse": "6.26.0",
-            "babel-types": "6.26.0",
-            "babylon": "6.18.0",
-            "convert-source-map": "1.5.0",
-            "debug": "2.6.8",
-            "json5": "0.5.1",
-            "lodash": "4.17.4",
-            "minimatch": "3.0.4",
-            "path-is-absolute": "1.0.1",
-            "private": "0.1.7",
-            "slash": "1.0.0",
-            "source-map": "0.5.7"
-          }
-        }
       }
     },
     "babel-runtime": {
@@ -2579,7 +2551,7 @@
         "create-hmac": "1.1.6",
         "diffie-hellman": "5.0.2",
         "inherits": "2.0.3",
-        "pbkdf2": "3.0.13",
+        "pbkdf2": "3.0.14",
         "public-encrypt": "4.0.0",
         "randombytes": "2.0.5"
       }
@@ -9836,7 +9808,7 @@
         "browserify-aes": "1.0.8",
         "create-hash": "1.1.3",
         "evp_bytestokey": "1.0.3",
-        "pbkdf2": "3.0.13"
+        "pbkdf2": "3.0.14"
       }
     },
     "parse-filepath": {
@@ -9990,9 +9962,9 @@
       "dev": true
     },
     "pbkdf2": {
-      "version": "3.0.13",
-      "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.13.tgz",
-      "integrity": "sha512-+dCHxDH+djNtjgWmvVC/my3SYBAKpKNqKSjLkp+GtWWYe4XPE+e/PSD2aCanlEZZnqPk2uekTKNC/ccbwd2X2Q==",
+      "version": "3.0.14",
+      "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.14.tgz",
+      "integrity": "sha512-gjsZW9O34fm0R7PaLHRJmLLVfSoesxztjPjE9o6R+qtVJij90ltg1joIovN9GKrRW3t1PzhDDG3UMEMFfZ+1wA==",
       "requires": {
         "create-hash": "1.1.3",
         "create-hmac": "1.1.6",
@@ -13192,9 +13164,9 @@
       "dev": true
     },
     "webpack": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-3.5.3.tgz",
-      "integrity": "sha1-5oZTljvaFG4hKDLASk2AQdK0uMg=",
+      "version": "3.5.6",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-3.5.6.tgz",
+      "integrity": "sha512-sXnxfx6KoZVrFAGLjdhCCwDtDwkYMfwm8mJjkQv3thr5pjTlbxopVlr/kJwc9Bz317gL+gNjvz++ir9TgG1MDg==",
       "requires": {
         "acorn": "5.1.2",
         "acorn-dynamic-import": "2.0.2",
@@ -13420,7 +13392,7 @@
         "memory-fs": "0.4.1",
         "through": "2.3.8",
         "vinyl": "2.1.0",
-        "webpack": "3.5.3"
+        "webpack": "3.5.6"
       },
       "dependencies": {
         "clone": {

--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
     "node": ">=6.0.0"
   },
   "dependencies": {
-    "babel-core": "6.25.0",
-    "babel-loader": "7.1.1",
+    "babel-core": "6.26.0",
+    "babel-loader": "7.1.2",
     "babel-preset-env": "1.6.0",
     "banner-footer-webpack-plugin": "git://github.com/dtothefp/banner-footer-webpack-plugin.git",
     "browser-sync": "2.18.7",
@@ -67,7 +67,7 @@
     "sauce-connect-tunnel": "0.2.1",
     "uglifyjs-webpack-plugin": "1.0.0-beta.1",
     "ustream-embedapi": "1.0.0",
-    "webpack": "3.5.3",
+    "webpack": "3.5.6",
     "webpack-stream": "4.0.0",
     "xdr": "0.5.3"
   },


### PR DESCRIPTION
## Changes

- Moves webpack configuration `module` to a constant shared by all webpack configurations so that each uses the same babel/browserlist pipeline.
- Updates webpack and babel npm modules to latest.

## Testing

1. Run `npm install`
2. Run `gulp build`
3. Search the output JS in `static_built/js/` for `const`.

## Notes

- I restructured the webpack configuration slightly to rename `rules` to `loaders` as I didn't find `module.rules` on https://webpack.github.io/docs/configuration.html#module (I guess maybe it worked before for backward compatibility??? Dunno). Also, I updated `use` to `loaders` per that same doc.
