### PR TITLE
Removes code climate badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # cfgov-refresh
 
 [![Build Status](https://travis-ci.org/cfpb/cfgov-refresh.png?branch=master)](https://travis-ci.org/cfpb/cfgov-refresh?branch=master)
-[![Code Climate](https://codeclimate.com/github/cfpb/cfgov-refresh.png?branch=master)](https://codeclimate.com/github/cfpb/cfgov-refresh?branch=master)
 [![codecov](https://codecov.io/gh/cfpb/cfgov-refresh/branch/master/graph/badge.svg)](https://codecov.io/gh/cfpb/cfgov-refresh)
 
 The redesign of the [www.consumerfinance.gov](http://www.consumerfinance.gov) website.


### PR DESCRIPTION
The Code Climate badge hasn't been updated in more than a year because the org permissions don't allow Code Climate and until GH allows finer grained control of permissions this doesn't look like it will updated any time soon.

## Removals

- Removes outdated Code Climate badge from Readme :-(
