### PR TITLE
Mortgage performance: Reformat date range in chart

### DIFF
--- a/cfgov/data_research/models.py
+++ b/cfgov/data_research/models.py
@@ -328,8 +328,8 @@ class MortgagePerformancePage(BrowsePage):
         thru_date = parser.parse(meta['sampling_dates'][-1])
         from_date = parser.parse(meta['sampling_dates'][0])
         meta['thru_month'] = thru_date.strftime("%Y-%m")
-        meta['thru_month_formatted'] = thru_date.strftime("%B %Y")
-        meta['from_month_formatted'] = from_date.strftime("%B %Y")
+        meta['thru_month_formatted'] = thru_date.strftime("%B&nbsp;%Y")
+        meta['from_month_formatted'] = from_date.strftime("%B&nbsp;%Y")
         meta_sample = meta.get(
             'download_files')[meta['thru_month']]['percent_90']['County']
         meta['pub_date'] = meta_sample['pub_date']

--- a/cfgov/jinja2/v1/_includes/organisms/mortgage-chart.html
+++ b/cfgov/jinja2/v1/_includes/organisms/mortgage-chart.html
@@ -138,7 +138,7 @@
         </form>
         <h2 id="mp-line-chart-title" style="margin-top:20px">Percentage of mortgages {{ time_frame }} {% if time_frame == '90' %} or more {% endif %} days delinquent:<br/>
             <span id="mp-line-chart-title-status">
-                <strong><span id="mp-line-chart-title-status-geo">national average</span></strong><span id="mp-line-chart-title-status-comparison"> versus <strong>national average</strong></span></span>, {{ from_month_formatted }}-{{ thru_month_formatted }}
+                <strong><span id="mp-line-chart-title-status-geo">national average</span></strong><span id="mp-line-chart-title-status-comparison"> versus <strong>national average</strong></span></span>, {{ from_month_formatted|safe }}-{{ thru_month_formatted|safe }}
         </h2>
     </div>
     <div class="cfpb-chart" data-chart-ignore="true" data-chart-color="blue" data-chart-type="line-comparison" id="mp-line-chart">


### PR DESCRIPTION
In the chart template we need date ranges to carry no-break spaces to
avoid awkward breaks.

Check source on a chart page, and the chart label's date range should carry no-break spaces.

<img width="521" alt="no_break_dates" src="https://user-images.githubusercontent.com/515885/30457748-9261aa90-9976-11e7-85e5-3719ecdc3a82.png">
