### PR TITLE
Removing unnecessary flagged /es/ routes

### DIFF
--- a/cfgov/cfgov/urls.py
+++ b/cfgov/cfgov/urls.py
@@ -41,7 +41,6 @@ from v1.views.documents import DocumentServeView
 
 fin_ed = SheerSite('fin-ed-resources')
 oah = SheerSite('owning-a-home')
-es_conv_flag = partial(flagged_url, 'ES_CONV_FLAG')
 
 urlpatterns = [
 
@@ -385,19 +384,19 @@ urlpatterns = [
     url(r'^(?P<language>es)/obtener-respuestas/api/autocomplete/$',
         ask_autocomplete, name='ask-autocomplete-es'),
 
-    es_conv_flag(r'^es/$', TemplateView.as_view(
+    url(r'^es/$', TemplateView.as_view(
                  template_name='/es/index.html')),
 
-    es_conv_flag(r'^es/hogar/$', TemplateView.as_view(
+    url(r'^es/hogar/$', TemplateView.as_view(
                  template_name='es/hogar/index.html')),
 
-    es_conv_flag(r'^es/nuestra-historia/$', TemplateView.as_view(
+    url(r'^es/nuestra-historia/$', TemplateView.as_view(
                  template_name='es/nuestra-historia/index.html')),
 
-    es_conv_flag(r'^es/presentar-una-queja/$', TemplateView.as_view(
+    url(r'^es/presentar-una-queja/$', TemplateView.as_view(
                  template_name='es/presentar-una-queja/index.html')),
 
-    es_conv_flag(r'^es/quienes-somos/$', TemplateView.as_view(
+    url(r'^es/quienes-somos/$', TemplateView.as_view(
                  template_name='es/quienes-somos/index.html')),
 
     url(r'^_status/', include_if_app_enabled('watchman', 'watchman.urls')),


### PR DESCRIPTION
Removing unnecessary flagged routes


## Changes

- Modified `cfgov/cfgov/urls.py` to remove the flagged routes. These routes are controlled by the apache config file and we are ready for these pages to go live. 

## Testing

Visit http://localhost:8000/es/ and verify the page renders.
Visit http://localhost:8000/es/presentar-una-queja/ and verify that the page renders.
Visit http://localhost:8000/es/quienes-somos/ and verify that the page renders.
Visit http://localhost:8000/es/hogar/` and verify that the page renders.
Visit http://localhost:8000/es/nuestra-historia/ and verify that the page renders.


## Screenshots


## Notes

-

## Todos

-

## Checklist

* [ ] PR has an informative and human-readable title
* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated
* [ ] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
