### PR TITLE
Add insufficient data tooltip to county map

### DIFF
--- a/cfgov/unprocessed/css/organisms/mortgage-performance-trends.less
+++ b/cfgov/unprocessed/css/organisms/mortgage-performance-trends.less
@@ -27,11 +27,26 @@
             transition: fill 500ms, fill-opacity 500ms, stroke-width 0 !important;
         }
         .highcharts-point {
-            stroke: #838588;
+            stroke: @black;
+            &.highcharts-null-point {
+              stroke-width: 0 !important;
+            }
         }
     }
-    .highcharts-color-0 {
-        stroke: #838588;
+    .cfpb-chart-geo- {
+        &state-outline-states,
+        &state-outline-metros,
+        &state-outline-counties,
+        &map-separators {
+            .highcharts-point {
+                stroke: @black;
+            }
+        }
+        &data-outline-metros {
+            .highcharts-point {
+                stroke: #838588;
+            }
+        }
     }
     .highcharts-tooltip-box {
         fill: @white;
@@ -64,7 +79,7 @@
     &[data-chart-color='blue'] {
 
         .a-ramp-value {
-            &-0 { fill: @gray-10; }
+            &-0 { fill: @gray-5; }
             &-1 { fill: @pacific-20; }
             &-2 { fill: @pacific-40; }
             &-3 { fill: @pacific-60; }
@@ -78,7 +93,7 @@
     &[data-chart-color='navy'] {
 
         .a-ramp-value {
-            &-0 { fill: @gray-10; }
+            &-0 { fill: @gray-5; }
             &-1 { fill: @navy-20; }
             &-2 { fill: @navy-40; }
             &-3 { fill: @navy-60; }

--- a/cfgov/unprocessed/css/organisms/mortgage-performance-trends.less
+++ b/cfgov/unprocessed/css/organisms/mortgage-performance-trends.less
@@ -42,6 +42,7 @@
                 stroke: @black;
             }
         }
+        &data-outline-counties,
         &data-outline-metros {
             .highcharts-point {
                 stroke: #838588;
@@ -51,6 +52,7 @@
     .highcharts-tooltip-box {
         fill: @white;
         fill-opacity: 1;
+        stroke: @black;
     }
 
 }

--- a/cfgov/unprocessed/js/organisms/MortgagePerformanceTrends/apps/map.js
+++ b/cfgov/unprocessed/js/organisms/MortgagePerformanceTrends/apps/map.js
@@ -218,6 +218,9 @@ MortgagePerformanceMap.prototype.renderTooltip = function() {
   return ( point, meta ) => {
     var percent;
     var nationalPercent = Math.round( meta.national_average * 1000 ) / 10;
+    if ( point.value === null ) {
+      return "<div class='m-mp-map-tooltip'>Insufficient data for this area</div>";
+    }
     if ( point.value < 0 ) {
       percent = 'Insufficient data';
     } else {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1868,9 +1868,9 @@
       }
     },
     "cfpb-chart-builder": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/cfpb-chart-builder/-/cfpb-chart-builder-3.0.3.tgz",
-      "integrity": "sha512-suNvPiKFl8rrz6K68IVLe7mn9tbmpNX8TJBLgquCZOi3H+3dt/YzHKcH6zcUdVLi2K7mB3P9/00owk41AZNBiw==",
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/cfpb-chart-builder/-/cfpb-chart-builder-3.0.6.tgz",
+      "integrity": "sha512-bTdOQiTqnHEY0vg5QurOPk5OR7wS8nOxGQkTO6SWV762j2HNkyhoY+phZ125hLZhsne5P+Ek1WhRMS19TDHa2Q==",
       "requires": {
         "babel-preset-env": "1.6.0",
         "cf-core": "4.4.1",
@@ -1884,42 +1884,6 @@
         "xdr": "github:contolini/xdr#4f53e8dc68d14cd4a387874e75faae46c3a4961b"
       },
       "dependencies": {
-        "cf-core": {
-          "version": "4.4.1",
-          "resolved": "https://registry.npmjs.org/cf-core/-/cf-core-4.4.1.tgz",
-          "integrity": "sha512-6x4zo0mKj3BVNj9EpSrhB2+eTM3324ADl9qtX5CYrx93J8GfJ2Ll7MCOE3CBdiqBm93GP6fNWmomg0yhUFJehw==",
-          "requires": {
-            "normalize-css": "2.3.1",
-            "normalize-legacy-addon": "0.1.0"
-          }
-        },
-        "cf-grid": {
-          "version": "4.2.2",
-          "resolved": "https://registry.npmjs.org/cf-grid/-/cf-grid-4.2.2.tgz",
-          "integrity": "sha512-P2uIvpcKACqrJqKDNeANpyAEgKovQMXpaz5GhigY2OL42d/txGXvqL2kZqaHNUkEUwcVdJPlOIxGv/nDF0rF1Q==",
-          "requires": {
-            "normalize-css": "2.3.1",
-            "normalize-legacy-addon": "0.1.0"
-          }
-        },
-        "cf-layout": {
-          "version": "4.5.1",
-          "resolved": "https://registry.npmjs.org/cf-layout/-/cf-layout-4.5.1.tgz",
-          "integrity": "sha512-8RByl3aYIzzyEN/lXjKWugm5F0aqTCK+84U3OUaz8SHb+8WMHiqdIUnYnCa4aYQJHDhCaH3gQTysuJV72B0EoQ==",
-          "requires": {
-            "cf-core": "4.4.1",
-            "cf-grid": "4.2.2"
-          }
-        },
-        "cf-typography": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/cf-typography/-/cf-typography-4.2.1.tgz",
-          "integrity": "sha512-oVI6nYUysYsZnZ10FIZ8+kzsrewchrcdqx0Q9Kz03gMPwHhWbdiAN2Jy/YFdkO3LTWVuK3eCAGEJBkE3uOimPg==",
-          "requires": {
-            "cf-core": "4.4.1",
-            "cf-icons": "4.1.1"
-          }
-        },
         "core-js": {
           "version": "2.5.0",
           "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.0.tgz",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "cf-pagination": "4.2.1",
     "cf-tables": "4.1.4",
     "cf-typography": "4.2.1",
-    "cfpb-chart-builder": "3.0.3",
+    "cfpb-chart-builder": "3.0.6",
     "del": "2.2.2",
     "es5-shim": "4.5.9",
     "glob-all": "3.1.0",


### PR DESCRIPTION
Adds the "insufficient data" tooltip to the county view and changes the insufficient data color from `@gray-10` to `@gray-5`.

## Additions

- Tooltip when the map point has a value of `null`.

## Changes

- Update lowest item in the color range from `@gray-10` to `@gray-5`.
- Use the full namespaced CSS classes instead of `.highcharts-color-0` to avoid conflicts with other CFPB charts.

## Testing

1. Pull down this branch and `./setup.sh`
1. Set up the [mortgage performance API](https://github.com/cfpb/cfgov-refresh/pull/3189).
1. Create a [mortgage chart block and page](https://github.com/cfpb/cfgov-refresh/pull/3260).

## Screenshots

<img width="660" alt="screen shot 2017-09-18 at 4 45 07 am" src="https://user-images.githubusercontent.com/1060248/30534435-3614fe64-9c2c-11e7-82ac-35ac0e6f5d76.png">

## Checklist

* [ ] PR has an informative and human-readable title
* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated
* [ ] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
