### PR TITLE
Force known New Relic violations to be strings when caching

### DIFF
--- a/cfgov/alerts/newrelic_alerts.py
+++ b/cfgov/alerts/newrelic_alerts.py
@@ -34,7 +34,7 @@ class NewRelicAlertViolations(object):
         this method are automatically added to known_violations. """
         violations = []
         for violation in self.get_current_violations():
-            if violation['id'] in self.known_violations:
+            if str(violation['id']) in self.known_violations:
                 continue
 
             self.known_violations.append(violation['id'])

--- a/cfgov/alerts/newrelic_alerts.py
+++ b/cfgov/alerts/newrelic_alerts.py
@@ -1,3 +1,4 @@
+import datetime
 import re
 
 import requests
@@ -51,6 +52,9 @@ class NewRelicAlertViolations(object):
     def format_violation(self, violation):
         """ Format the given violation dictionary into an SQS message
         dictionary """
+        opened_timestamp = violation['opened_at'] / 1000.0
+        opened = datetime.datetime.fromtimestamp(opened_timestamp)
+        opened_str = opened.strftime('%a, %b %d %Y, at %I:%M %p %z')
         title = '{condition_name}, {entity_name}'.format(
             condition_name=violation['condition_name'],
             entity_name=violation['entity']['name']
@@ -62,13 +66,16 @@ class NewRelicAlertViolations(object):
             account_number=self.account_number
         )
         body = (
-            'New Relic {product}, {name}, {label}.'
+            'New Relic {product}, {name}, {label} '
+            '({opened}, violation id {id}).'
             'View incidents: {link}'
         ).format(
             product=violation['entity']['product'],
             type=violation['entity']['type'],
             label=violation['label'],
             name=violation['entity']['name'],
+            id=violation['id'],
+            opened=opened_str,
             link=incidents_link
         )
         message_body = '{title} - {body}'.format(title=title, body=body)

--- a/cfgov/alerts/send_new_relic_messages_to_sqs.py
+++ b/cfgov/alerts/send_new_relic_messages_to_sqs.py
@@ -69,7 +69,7 @@ parser.add_argument(
 
 def cache_known_violations(known_violations_filename, known_violations):
     with open(known_violations_filename, 'w') as known_violations_file:
-        known_violations_file.writelines(known_violations)
+        known_violations_file.writelines([str(v) for v in known_violations])
 
 
 def read_known_violations(known_violations_filename):

--- a/cfgov/alerts/tests/test_newrelic_alerts.py
+++ b/cfgov/alerts/tests/test_newrelic_alerts.py
@@ -1,3 +1,4 @@
+import datetime
 import re
 import time
 import unittest
@@ -27,6 +28,7 @@ class TestNewRelicAlertViolations(unittest.TestCase):
                     'id': 12345678,
                     'label': 'This test opened just now',
                     'policy_name': 'cf.gov unit tests',
+                    'opened_at': time.time() * 1000.0
                 },
                 {
                     'condition_name': 'cf.gov test opened > 2 min ago',
@@ -38,6 +40,7 @@ class TestNewRelicAlertViolations(unittest.TestCase):
                     'id': 23456781,
                     'label': 'This test opened 2 min ago',
                     'policy_name': 'cf.gov unit tests',
+                    'opened_at': time.time() * 1000.0
                 },
                 {
                     'condition_name': 'not cf.gov condition',
@@ -49,6 +52,7 @@ class TestNewRelicAlertViolations(unittest.TestCase):
                     'id': 34567812,
                     'label': 'This is a different application',
                     'policy_name': 'other unit tests',
+                    'opened_at': time.time() * 1000.0
                 },
             ],
         }
@@ -83,7 +87,13 @@ class TestNewRelicAlertViolations(unittest.TestCase):
         )
         formatted_violation = nralert_violations.format_violation(
             self.newrelic_response['violations'][0])
+        print formatted_violation
+        violation = self.newrelic_response['violations'][0]
+        opened_timestamp = violation['opened_at'] / 1000.0
+        opened = datetime.datetime.fromtimestamp(opened_timestamp)
+        opened_str = opened.strftime('%a, %b %d %Y, at %I:%M %p %z')
         self.assertIn(
             'cf.gov test opened now, cf.gov synthetic entity '
             '- New Relic Synthetic, cf.gov synthetic entity, '
-            'This test opened just now.', formatted_violation)
+            'This test opened just now', formatted_violation)
+        self.assertIn(opened_str, formatted_violation)

--- a/cfgov/alerts/tests/test_newrelic_alerts.py
+++ b/cfgov/alerts/tests/test_newrelic_alerts.py
@@ -70,7 +70,7 @@ class TestNewRelicAlertViolations(unittest.TestCase):
             'token',
             'cf.gov',
             '123456',
-            known_violations=[23456781],
+            known_violations=['23456781'],
         )
         violations = nralert_violations.get_new_violations()
         self.assertEqual(len(violations), 1)

--- a/cfgov/alerts/tests/test_send_new_relic_messages_to_sqs.py
+++ b/cfgov/alerts/tests/test_send_new_relic_messages_to_sqs.py
@@ -16,7 +16,7 @@ class TestSendNewRelicMessagesToSQS(unittest.TestCase):
     def test_cache_known_violations(self):
         with mock.patch('__builtin__.open', create=True) as mock_open:
             mock_open.return_value = mock.MagicMock(spec=file)
-            cache_known_violations('/some/file.json', ['12345', '23456'])
+            cache_known_violations('/some/file.json', [12345, '23456'])
 
         file_handle = mock_open.return_value.__enter__.return_value
         file_handle.writelines.assert_called_with(['12345', '23456'])


### PR DESCRIPTION
This PR forces `known_violations` to be strings when writing to our cache file. This should fix caching of New Relic alerts.