### PR TITLE
Add an option for a Mattermost icon URL

### DIFF
--- a/cfgov/alerts/mattermost_alert.py
+++ b/cfgov/alerts/mattermost_alert.py
@@ -4,7 +4,7 @@ import requests
 
 
 class MattermostAlert(object):
-    def __init__(self, credentials):
+    def __init__(self, credentials, icon_url=None):
         self.username = credentials.get(
             'username',
             os.environ.get('MATTERMOST_USERNAME')
@@ -13,11 +13,13 @@ class MattermostAlert(object):
             'webhook_url',
             os.environ.get('MATTERMOST_WEBHOOK_URL')
         )
+        self.icon_url = icon_url
 
     def post(self, text):
         payload = {
             'text': text,
             'username': self.username,
+            'icon_url': self.icon_url
         }
         resp = requests.post(
             self.webhook_url,

--- a/cfgov/alerts/post_sqs_messages.py
+++ b/cfgov/alerts/post_sqs_messages.py
@@ -53,7 +53,10 @@ parser.add_argument(
 parser.add_argument(
     '--mattermost_username',
     help='Mattermost user that is posting the message'
-
+)
+parser.add_argument(
+    '--mattermost_icon_url',
+    help='URL to an icon to use for the Mattermost user'
 )
 
 

--- a/cfgov/alerts/tests/test_mattermost_alert.py
+++ b/cfgov/alerts/tests/test_mattermost_alert.py
@@ -19,9 +19,12 @@ class TestMattermostAlert(TestCase):
         username = 'test'
         credentials = {'username': username, 'webhook_url': webhook_url}
         text = u'foö'
+        icon = 'http://some/icon.png'
 
-        MattermostAlert(credentials).post(text)
+        MattermostAlert(credentials, icon_url=icon).post(text)
         mock.assert_called_once_with(
             webhook_url,
-            data=json.dumps({'text': text, 'username': username})
+            data=json.dumps({'text': text,
+                             'username': username,
+                             'icon_url': icon})
         )


### PR DESCRIPTION
This PR adds an option for an icon URL to our Mattermost alert posting class and SQS polling script. This will let us specify an alternative icon for the alerting bot.