### PR TITLE
Restore flake8

### DIFF
--- a/cfgov/alerts/tests/test_newrelic_alerts.py
+++ b/cfgov/alerts/tests/test_newrelic_alerts.py
@@ -1,5 +1,4 @@
 import datetime
-import re
 import time
 import unittest
 

--- a/cfgov/alerts/tests/test_send_new_relic_messages_to_sqs.py
+++ b/cfgov/alerts/tests/test_send_new_relic_messages_to_sqs.py
@@ -2,7 +2,6 @@ import unittest
 
 import boto3
 import mock
-from botocore.stub import Stubber
 
 from alerts.send_new_relic_messages_to_sqs import (
     cache_known_violations,

--- a/run_travis.sh
+++ b/run_travis.sh
@@ -10,6 +10,7 @@ if [ "$RUNTEST" == "frontend" ]; then
     gulp "test" --travis
     bash <(curl -s https://codecov.io/bash) -F frontend
 elif [ "$RUNTEST" == "backend" ]; then
+    flake8
     tox -e fast
     tox -e missing-migrations
     bash <(curl -s https://codecov.io/bash) -F backend


### PR DESCRIPTION
I accidentally removed flake8 [when adding codecov](https://github.com/cfpb/cfgov-refresh/commit/369625e33f6196cea9dc17d9e477de0eb41cd7d9#diff-166a8c44f1ec1d519e437119223c84d5L13). This PR restores it (and fixes some failures introduced in the meantime, by me).