### PR TITLE
Fix icon font path + web font variables for nonresponsive CSS

### DIFF
--- a/cfgov/unprocessed/css/main.less
+++ b/cfgov/unprocessed/css/main.less
@@ -31,6 +31,10 @@
 // Icon font path
 @cf-icon-path:                  '../fonts';
 
+@box-sizing-polyfill-path: "/cfgov-refresh/static/vendor/box-sizing-polyfill";
+@grid_box-sizing-polyfill-path: '../js';
+
+
 // Enhancements that are on a migration path to being added to CF.
 // CF Core
 @import (less) "enhancements/vars.less";

--- a/cfgov/unprocessed/css/main.less
+++ b/cfgov/unprocessed/css/main.less
@@ -31,10 +31,6 @@
 // Icon font path
 @cf-icon-path:                  '../fonts';
 
-@box-sizing-polyfill-path: "/cfgov-refresh/static/vendor/box-sizing-polyfill";
-@grid_box-sizing-polyfill-path: '../js';
-
-
 // Enhancements that are on a migration path to being added to CF.
 // CF Core
 @import (less) "enhancements/vars.less";

--- a/cfgov/unprocessed/css/on-demand/footer.less
+++ b/cfgov/unprocessed/css/on-demand/footer.less
@@ -21,6 +21,9 @@
 }
 @import (less) 'cf-typography.less';
 
+@grid_box-sizing-polyfill-path: '../js';
+@box-sizing-polyfill-path: "/cfgov-refresh/static/js/boxsizing.htc";
+
 // Enhancements that are on a migration path to being added to CF.
 // CF Core
 @import (less) "../enhancements/vars.less";

--- a/cfgov/unprocessed/css/on-demand/footer.less
+++ b/cfgov/unprocessed/css/on-demand/footer.less
@@ -21,8 +21,16 @@
 }
 @import (less) 'cf-typography.less';
 
-@grid_box-sizing-polyfill-path: '../js';
-@box-sizing-polyfill-path: "/cfgov-refresh/static/js/boxsizing.htc";
+// Font variables
+@import (less) 'licensed-fonts.css';
+
+@webfont-regular: 'AvenirNextLTW01-Regular';
+@webfont-italic: 'AvenirNextLTW01-Italic';
+@webfont-medium: 'AvenirNextLTW01-Medium';
+@webfont-demi: 'AvenirNextLTW01-Demi';
+
+// // Icon font path
+@cf-icon-path:                  '../fonts';
 
 // Enhancements that are on a migration path to being added to CF.
 // CF Core

--- a/cfgov/unprocessed/css/on-demand/header.less
+++ b/cfgov/unprocessed/css/on-demand/header.less
@@ -21,6 +21,20 @@
     @import (less) 'cf-typography.less';
 }
 
+@grid_box-sizing-polyfill-path: '../js';
+@box-sizing-polyfill-path: "/cfgov-refresh/static/js/boxsizing.htc";
+
+// // Font variables
+// @import (less) 'licensed-fonts.css';
+
+// @webfont-regular: 'AvenirNextLTW01-Regular';
+// @webfont-italic: 'AvenirNextLTW01-Italic';
+// @webfont-medium: 'AvenirNextLTW01-Medium';
+// @webfont-demi: 'AvenirNextLTW01-Demi';
+
+// // Icon font path
+// @cf-icon-path:                  '../fonts';
+
 // Enhancements that are on a migration path to being added to CF.
 // CF Core
 @import (less) "../enhancements/vars.less";

--- a/cfgov/unprocessed/css/on-demand/header.less
+++ b/cfgov/unprocessed/css/on-demand/header.less
@@ -21,19 +21,16 @@
     @import (less) 'cf-typography.less';
 }
 
-@grid_box-sizing-polyfill-path: '../js';
-@box-sizing-polyfill-path: "/cfgov-refresh/static/js/boxsizing.htc";
+// Font variables
+@import (less) 'licensed-fonts.css';
 
-// // Font variables
-// @import (less) 'licensed-fonts.css';
+@webfont-regular: 'AvenirNextLTW01-Regular';
+@webfont-italic: 'AvenirNextLTW01-Italic';
+@webfont-medium: 'AvenirNextLTW01-Medium';
+@webfont-demi: 'AvenirNextLTW01-Demi';
 
-// @webfont-regular: 'AvenirNextLTW01-Regular';
-// @webfont-italic: 'AvenirNextLTW01-Italic';
-// @webfont-medium: 'AvenirNextLTW01-Medium';
-// @webfont-demi: 'AvenirNextLTW01-Demi';
-
-// // Icon font path
-// @cf-icon-path:                  '../fonts';
+// Icon font path
+@cf-icon-path:                  '../fonts';
 
 // Enhancements that are on a migration path to being added to CF.
 // CF Core

--- a/cfgov/unprocessed/css/on-demand/secondary-navigation.less
+++ b/cfgov/unprocessed/css/on-demand/secondary-navigation.less
@@ -23,6 +23,10 @@
 @import (reference) 'cf-layout.less';
 @import (reference) 'cf-typography.less';
 
+
+@grid_box-sizing-polyfill-path: '../js';
+@box-sizing-polyfill-path: "/cfgov-refresh/static/js/boxsizing.htc";
+
 // Enhancements that are on a migration path to being added to CF.
 // CF Core
 @import (reference) "../enhancements/vars.less";

--- a/cfgov/unprocessed/css/on-demand/secondary-navigation.less
+++ b/cfgov/unprocessed/css/on-demand/secondary-navigation.less
@@ -23,9 +23,16 @@
 @import (reference) 'cf-layout.less';
 @import (reference) 'cf-typography.less';
 
+// Font variables
+@import (less) 'licensed-fonts.css';
 
-@grid_box-sizing-polyfill-path: '../js';
-@box-sizing-polyfill-path: "/cfgov-refresh/static/js/boxsizing.htc";
+@webfont-regular: 'AvenirNextLTW01-Regular';
+@webfont-italic: 'AvenirNextLTW01-Italic';
+@webfont-medium: 'AvenirNextLTW01-Medium';
+@webfont-demi: 'AvenirNextLTW01-Demi';
+
+// // Icon font path
+@cf-icon-path:                  '../fonts';
 
 // Enhancements that are on a migration path to being added to CF.
 // CF Core


### PR DESCRIPTION
Fixes failing build on collectstatic step where icon font path and web font variables were not defined in the nonresponsive css files. See https://GHE/CFGOV/platform/issues/1189 for the build failure details.

## Additions

-

## Removals

-

## Changes

- add licensed-fonts.css import and variables to the nonresponsive css files
- declare correct icon-font path for the same files (used to be in cf-brand-overrides.less, which was deleted in #3328)

## Testing

1. `./frontend.sh`
1. `cfgov/manage.py collectstatic`
1. static files should be copied without errors

## Screenshots


## Notes

-

## Todos

-

## Checklist

* [ ] PR has an informative and human-readable title
* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated
* [ ] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
