### PR TITLE
Bump eregs/ip requirement to 1.1.2

### DIFF
--- a/requirements/optional-private.txt
+++ b/requirements/optional-private.txt
@@ -5,4 +5,4 @@
 git+https://private.repo/CFPB/agreement_database.git@2.2.8#egg=agreement-database
 git+https://private.repo/CFPB/cfgov-selfregistration.git@1.3.1#egg=selfregistration
 git+https://private.repo/CFPB/django-college-cost-comparison.git@v1.3.4#egg=comparisontool
-git+https://private.repo/eregs/ip.git@1.1.1#egg=eregsip
+git+https://private.repo/eregs/ip.git@1.1.2#egg=eregsip


### PR DESCRIPTION
This change bumps the version of the optional private eregs/ip repository from 1.1.1 to 1.1.2.

## Changes

- Increment version of eregs/ip.

## Testing

1. `pip install -r requirements/optional.txt` to install the optional private packages.
2. Navigate to http://localhost:8000/eregulations to view eRegs content.

## Checklist

* [X] PR has an informative and human-readable title
* [X] Changes are limited to a single goal (no scope creep)
* [X] Code can be automatically merged (no conflicts)
* [X] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [X] Passes all existing automated tests
* [X] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated
* [X] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
