### PR TITLE
Add github3 dependency to base.txt

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,7 +1,7 @@
 codecov:
   branch: master
   notify:
-    require_ci_to_pass: yes
+    require_ci_to_pass: no
 
 comment: off
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -25,6 +25,7 @@ edgegrid-python==1.0.10
 elasticsearch==2.4.1
 feedparser==5.2.1
 geocoder==1.12.0
+github3.py==0.9.6
 govdelivery==1.0
 html5lib==0.9999999
 icalendar==3.9.0


### PR DESCRIPTION
Previously this was only in `scripts.txt` because it was only called from Jenkins, but with the introduction of https://github.com/cfpb/cfgov-refresh/pull/3322 it's needed in cfgov as well.  I didn't catch it because I already had the lib installed locally as well as in `test.txt` :( 