### PR TITLE
Fix New Relic alerts known violation caching

### DIFF
--- a/cfgov/alerts/newrelic_alerts.py
+++ b/cfgov/alerts/newrelic_alerts.py
@@ -67,7 +67,7 @@ class NewRelicAlertViolations(object):
         )
         body = (
             'New Relic {product}, {name}, {label} '
-            '({opened}, violation id {id}).'
+            '({priority}, opened {opened}, violation id {id}).'
             'View incidents: {link}'
         ).format(
             product=violation['entity']['product'],
@@ -75,6 +75,7 @@ class NewRelicAlertViolations(object):
             label=violation['label'],
             name=violation['entity']['name'],
             id=violation['id'],
+            priority=violation['priority'],
             opened=opened_str,
             link=incidents_link
         )

--- a/cfgov/alerts/newrelic_alerts.py
+++ b/cfgov/alerts/newrelic_alerts.py
@@ -35,7 +35,7 @@ class NewRelicAlertViolations(object):
         this method are automatically added to known_violations. """
         violations = []
         for violation in self.get_current_violations():
-            if str(violation['id']) in self.known_violations:
+            if violation['id'] in self.known_violations:
                 continue
 
             self.known_violations.append(violation['id'])

--- a/cfgov/alerts/send_new_relic_messages_to_sqs.py
+++ b/cfgov/alerts/send_new_relic_messages_to_sqs.py
@@ -69,16 +69,23 @@ parser.add_argument(
 
 def cache_known_violations(known_violations_filename, known_violations):
     with open(known_violations_filename, 'w') as known_violations_file:
-        known_violations_file.writelines([str(v) for v in known_violations])
+        known_violations_file.writelines(
+            ["{}\n".format(v) for v in known_violations]
+        )
+
+    logger.info("cached known violations {}".format(known_violations))
 
 
 def read_known_violations(known_violations_filename):
     try:
         with open(known_violations_filename, 'r') as known_violations_file:
-            known_violations = known_violations_file.readlines()
+            known_violations = [
+                int(v) for v in known_violations_file.readlines()
+            ]
     except IOError:
         logger.warning("Known violations file does not exist")
         known_violations = []
+    logger.info("read known violations {}".format(known_violations))
     return known_violations
 
 

--- a/cfgov/alerts/tests/test_newrelic_alerts.py
+++ b/cfgov/alerts/tests/test_newrelic_alerts.py
@@ -27,6 +27,7 @@ class TestNewRelicAlertViolations(unittest.TestCase):
                     'id': 12345678,
                     'label': 'This test opened just now',
                     'policy_name': 'cf.gov unit tests',
+                    'priority': 'Critical',
                     'opened_at': time.time() * 1000.0
                 },
                 {
@@ -39,6 +40,7 @@ class TestNewRelicAlertViolations(unittest.TestCase):
                     'id': 23456781,
                     'label': 'This test opened 2 min ago',
                     'policy_name': 'cf.gov unit tests',
+                    'priority': 'Critical',
                     'opened_at': time.time() * 1000.0
                 },
                 {
@@ -51,6 +53,7 @@ class TestNewRelicAlertViolations(unittest.TestCase):
                     'id': 34567812,
                     'label': 'This is a different application',
                     'policy_name': 'other unit tests',
+                    'priority': 'Critical',
                     'opened_at': time.time() * 1000.0
                 },
             ],
@@ -93,5 +96,5 @@ class TestNewRelicAlertViolations(unittest.TestCase):
         self.assertIn(
             'cf.gov test opened now, cf.gov synthetic entity '
             '- New Relic Synthetic, cf.gov synthetic entity, '
-            'This test opened just now', formatted_violation)
+            'This test opened just now (Critical', formatted_violation)
         self.assertIn(opened_str, formatted_violation)

--- a/cfgov/alerts/tests/test_newrelic_alerts.py
+++ b/cfgov/alerts/tests/test_newrelic_alerts.py
@@ -73,7 +73,7 @@ class TestNewRelicAlertViolations(unittest.TestCase):
             'token',
             'cf.gov',
             '123456',
-            known_violations=['23456781'],
+            known_violations=[23456781],
         )
         violations = nralert_violations.get_new_violations()
         self.assertEqual(len(violations), 1)
@@ -86,7 +86,6 @@ class TestNewRelicAlertViolations(unittest.TestCase):
         )
         formatted_violation = nralert_violations.format_violation(
             self.newrelic_response['violations'][0])
-        print formatted_violation
         violation = self.newrelic_response['violations'][0]
         opened_timestamp = violation['opened_at'] / 1000.0
         opened = datetime.datetime.fromtimestamp(opened_timestamp)

--- a/cfgov/alerts/tests/test_send_new_relic_messages_to_sqs.py
+++ b/cfgov/alerts/tests/test_send_new_relic_messages_to_sqs.py
@@ -18,16 +18,16 @@ class TestSendNewRelicMessagesToSQS(unittest.TestCase):
             cache_known_violations('/some/file.json', [12345, '23456'])
 
         file_handle = mock_open.return_value.__enter__.return_value
-        file_handle.writelines.assert_called_with(['12345', '23456'])
+        file_handle.writelines.assert_called_with(['12345\n', '23456\n'])
 
     def test_read_known_violations_existing(self):
         with mock.patch('__builtin__.open', create=True) as mock_open:
             mock_open.return_value = mock.MagicMock(spec=file)
             file_handle = mock_open.return_value.__enter__.return_value
-            file_handle.readlines.return_value = ['12345', '23456']
+            file_handle.readlines.return_value = ['12345\n', '23456\n']
             known_violations = read_known_violations('/some/file.json')
 
-        self.assertEqual(['12345', '23456'], known_violations)
+        self.assertEqual([12345, 23456], known_violations)
 
     def test_read_known_violations_nonexisting(self):
         with mock.patch('__builtin__.open', create=True) as mock_open:


### PR DESCRIPTION
Yet another attempt to fix the New Relic violation caching. This PR adjusts the way the cache file is written and the way it is read to ensure correctly formatted data all the way through the process.

The New Relic alert polling job is currently running (successfully now!) from this branch.