### PR TITLE
Django error handler enhancements

### DIFF
--- a/cfgov/alerts/github_alert.py
+++ b/cfgov/alerts/github_alert.py
@@ -34,6 +34,8 @@ class GithubAlert(object):
         return next((issue for issue in issues if issue.title == title), None)
 
     def post(self, title, body):
+        # Truncate the title if needed, max is 256 chars
+        title = title[:256]
         issue = self.matching_issue(title)
         if issue:  # Issue already exists
             if issue.is_closed():

--- a/cfgov/alerts/logging_handlers.py
+++ b/cfgov/alerts/logging_handlers.py
@@ -6,6 +6,6 @@ from alerts.github_alert import GithubAlert
 class CFGovErrorHandler(logging.Handler):
     def emit(self, record):
         GithubAlert({}).post(
-            title=record.message[:30],
-            body=record.message,
+            title=record.message,
+            body=record.exc_text,
         )

--- a/cfgov/alerts/tests/test_logging_handlers.py
+++ b/cfgov/alerts/tests/test_logging_handlers.py
@@ -13,12 +13,15 @@ class TestLoggingHandlers(TestCase):
         """ Test that calling CFGOVErrorHandler.emit
         makes a GithubAlert post with the right parameters
         """
-        message = (u'Internal Server Error: /tést-page/'
-                   'Traceback (most recent call last):'
-                   '... more details ...')
-        record = MagicMock(message=message)
+        message = u'Internal Server Error: /tést'
+        exc_text = ('Traceback (most recent call last)'
+                    'TypeError: NoneType object has no attribute __getitem__')
+        record = MagicMock(
+            message=message,
+            exc_text=exc_text,
+        )
         CFGovErrorHandler().emit(record)
         github_alert.assert_called_once_with(
-            title=message[:30],
-            body=message,
+            title=message,
+            body=exc_text,
         )


### PR DESCRIPTION
Some minor enhancements to the Django error handler
- Pass in the full message as a title to Github, letting the `GithubAlert` class deal with length limits
- Pass in the exception message as the body to Github

See GHE/richa/testbot/issues/122 as an example.