### PR TITLE
Tweak Codecov, require PRs to be fully tested

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -7,16 +7,15 @@ comment: off
 
 coverage:
   status:
-    project:
-      frontend:
-        threshold: 0%
-        flags: frontend
-      backend:
-        threshold: 0%
-        flags: backend
     patch:
-      default:
-        threshold: 0%
+      frontend:
+        flags: frontend
+        target: 100%
+        only_pulls: true
+      backend:
+        flags: backend
+        target: 100%
+        only_pulls: true
 
 flags:
   backend:


### PR DESCRIPTION
This PR changes our Codecov config to rely on Codecov's "patch" status instead of "project" for reporting frontend and backend and restores simple absolute coverage checking of the "project".

Per the documentation, "patch" [only measures coverage of the changes in a PR, not the entire codebase](https://github.com/codecov/support/wiki/Patch-Status#require-fully-tested-pull-requests). This seems more immediately useful anyway. This way we can also require PRs to be fully tested by requiring that they have 100% patch coverage.

I would recommend we make the frontend and backend "patch" coverage required for PRs, and abandon the idea of tracking PRs by absolute "project" coverage numbers. "Project" has seemed a bit wonky, with coverage decreasing by hundredths of a percent for seemingly no reason whatsoever while "patch" is at 100%.

--

This PR has changed quite a bit since I opened it, so @higs4281 I'm going to dismiss your review.