### PR TITLE
Whitelisting google maps image src 

### DIFF
--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -480,6 +480,7 @@ CSP_IMG_SRC = (
     'searchstats.usa.gov',
     'gtrk.s3.amazonaws.com',
     '*.googletagmanager.com',
+    'maps.googleapis.com',
     'optimize.google.com',
     'api.mapbox.com',
     '*.tiles.mapbox.com',


### PR DESCRIPTION
Whitelisting google maps image src 


## Testing

1. Visit `localhost:8000/about-us/events/` and verify that the map images appear. 


## Checklist

* [ ] PR has an informative and human-readable title
* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated
* [ ] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
