### PR TITLE
Update filter controls to use CF full-width inputs

### DIFF
--- a/cfgov/jinja2/v1/_includes/organisms/filterable-list-controls.html
+++ b/cfgov/jinja2/v1/_includes/organisms/filterable-list-controls.html
@@ -47,13 +47,13 @@
         <div class="content-l_col
                     content-l_col-1">
             <div class="o-form_group">
-                <fieldset class="o-form_fieldset">
+                <div class="m-form-field">
                     <label class="a-label a-label__heading"
                            for="{{ field_id }}">
                         Item name
                     </label>
                     {{ form.render_with_id(form.title, field_id) }}
-                </fieldset>
+                </div>
             </div>
         </div>
     {% endif %}

--- a/cfgov/unprocessed/css/enhancements/forms.less
+++ b/cfgov/unprocessed/css/enhancements/forms.less
@@ -121,11 +121,6 @@
     }
 }
 
-.o-form_fieldset .a-text-input {
-  box-sizing: border-box;
-  width: 100%;
-}
-
 
 /* topdoc
   name: Set form elements to base webfont

--- a/cfgov/unprocessed/css/organisms/form.less
+++ b/cfgov/unprocessed/css/organisms/form.less
@@ -56,8 +56,3 @@
         }
     });
 }
-
-.o-form_fieldset .a-text-input {
-  box-sizing: border-box;
-  width: 100%;
-}

--- a/cfgov/v1/forms.py
+++ b/cfgov/v1/forms.py
@@ -162,7 +162,7 @@ class FilterableListForm(forms.Form):
             if field.html_name == f:
                 self.fields[f].widget.attrs.update({
                     'id': attr_id,
-                    'class': 'a-text-input'
+                    'class': 'a-text-input a-text-input__full'
                 })
                 self.set_field_html_name(self.fields[f], attr_id)
                 return self[f]


### PR DESCRIPTION
The filter controls are using old full-width styles that is removed as
part of this update.

## Removals

- Removed old full width input styles

## Changes

- Updated filter controls to use new full-width input styles

## Testing

1. Run `gulp build`
2. Run the site locally
3. Test filterable list controls "Item name" inputs (/blog/ and /newsroom/)

## Screenshots

![screen shot 2017-09-21 at 3 14 32 pm](https://user-images.githubusercontent.com/1280430/30716514-ea5cb4b0-9edf-11e7-9955-2268d1c12de1.png)

## Notes

- There's an extra bit of space between the label and the input. I'm working on a fix for this in Capital Framework and will make sure it's updated here after the release.


## Checklist

* [x] PR has an informative and human-readable title
* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices
* [x] Project documentation has been updated
* [x] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
