### PR TITLE
Further whitelist additions to support Google Tag Manager debugger

### DIFF
--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -470,7 +470,7 @@ CSP_STYLE_SRC = (
     'tagmanager.google.com',
     'optimize.google.com',
     'api.mapbox.com',
-    'fonts.googleapis.com')
+    'fonts.googleapis.com',)
 
 # These specify valid image sources
 CSP_IMG_SRC = (
@@ -505,7 +505,7 @@ CSP_FRAME_SRC = (
     'universal.iperceptions.com')
 
 # These specify where we allow fonts to come from
-CSP_FONT_SRC = ("'self'",'data:', 'fast.fonts.net', 'fonts.google.com')
+CSP_FONT_SRC = ("'self'", "data:", "fast.fonts.net", "fonts.google.com")
 
 # These specify hosts we can make (potentially) cross-domain AJAX requests to.
 CSP_CONNECT_SRC = ("'self'",

--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -469,12 +469,15 @@ CSP_STYLE_SRC = (
     'fast.fonts.net',
     'tagmanager.google.com',
     'optimize.google.com',
-    'api.mapbox.com')
+    'api.mapbox.com',
+    'fonts.googleapis.com')
 
 # These specify valid image sources
 CSP_IMG_SRC = (
     "'self'",
     's3.amazonaws.com',
+    'www.gstatic.com',
+    'ssl.gstatic.com',
     'stats.g.doubleclick.net',
     'files.consumerfinance.gov',
     'img.youtube.com',
@@ -502,7 +505,7 @@ CSP_FRAME_SRC = (
     'universal.iperceptions.com')
 
 # These specify where we allow fonts to come from
-CSP_FONT_SRC = ("'self'", 'fast.fonts.net')
+CSP_FONT_SRC = ("'self'",'data:', 'fast.fonts.net', 'fonts.google.com')
 
 # These specify hosts we can make (potentially) cross-domain AJAX requests to.
 CSP_CONNECT_SRC = ("'self'",


### PR DESCRIPTION
Resolves some CSP errors that fire when you enable the debugger:

<img width="1472" alt="screen shot 2017-09-22 at 9 17 32 am" src="https://user-images.githubusercontent.com/235397/30746384-ad1a4002-9f77-11e7-92ac-081c00055c21.png">


## Additions

- Allow fonts from data: URL's and fonts.google.com
- allow images from gstatic.com
- allow stylesheets from 'fonts.googleapis.com'


## Checklist

* [ ] PR has an informative and human-readable title
* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated
* [ ] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
