### PR TITLE
wellbeing: Update analytics event data

### DIFF
--- a/cfgov/unprocessed/js/routes/consumer-tools/financial-well-being/results/index.js
+++ b/cfgov/unprocessed/js/routes/consumer-tools/financial-well-being/results/index.js
@@ -1,7 +1,7 @@
 /* eslint no-extra-semi: "off" */
 'use strict';
 
-var Analytics = require( '../../../modules/Analytics' );
+var Analytics = require( '../../../../modules/Analytics' );
 var Expandable = require( '../../../../organisms/Expandable' );
 
 var expandableDom = document.querySelectorAll( '.content .o-expandable' );

--- a/cfgov/unprocessed/js/routes/consumer-tools/financial-well-being/results/index.js
+++ b/cfgov/unprocessed/js/routes/consumer-tools/financial-well-being/results/index.js
@@ -1,16 +1,17 @@
 /* eslint no-extra-semi: "off" */
 'use strict';
 
+var Analytics = require( '../../../modules/Analytics' );
 var Expandable = require( '../../../../organisms/Expandable' );
 
 var expandableDom = document.querySelectorAll( '.content .o-expandable' );
- var expandable;
- if ( expandableDom ) {
-   for ( var i = 0, len = expandableDom.length; i < len; i++ ) {
-     expandable = new Expandable( expandableDom[i] );
-     expandable.init();
-   }
- }
+var expandable;
+if ( expandableDom ) {
+  for ( var i = 0, len = expandableDom.length; i < len; i++ ) {
+    expandable = new Expandable( expandableDom[i] );
+    expandable.init();
+  }
+}
 
 ( function() {
 
@@ -64,6 +65,16 @@ var expandableDom = document.querySelectorAll( '.content .o-expandable' );
       var input = event.target;
       var category = input.dataset.compareBy;
       switchComparisons( category );
+
+      var action = input.getAttribute( 'data-gtm-action' );
+      var label = input.getAttribute( 'data-gtm-label' );
+      var category = input.getAttribute( 'data-gtm-category' );
+
+      if ( Analytics.tagManagerIsLoaded ) {
+        sendEvent( action, label, category );
+      } else {
+        Analytics.addEventListener( 'gtmLoaded', sendEvent );
+      }
     } );
   } );
 

--- a/cfgov/wellbeing/jinja2/wellbeing/about.html
+++ b/cfgov/wellbeing/jinja2/wellbeing/about.html
@@ -93,7 +93,7 @@
     </p>
     <a class="a-link__jump"
        href="/data-research/research-reports/financial-well-being-america/">
-        See the report
+        <span class="a-link_text">See the report</span>
     </a>
 {% endblock %}
 

--- a/cfgov/wellbeing/jinja2/wellbeing/home.html
+++ b/cfgov/wellbeing/jinja2/wellbeing/home.html
@@ -138,7 +138,7 @@
                                value="4"
                                data-gtm-action="Questionnaire Radio Button Clicked"
                                data-gtm-label="I could handle a major unexpected expense"
-                               data-gtm-category="Page Interaction">
+                               data-gtm-category="Financial Well-Being Tool Interaction">
                         <label class="a-label" for="question-1-completely">
                             Completely
                         </label>
@@ -151,7 +151,7 @@
                                value="3"
                                data-gtm-action="Questionnaire Radio Button Clicked"
                                data-gtm-label="I could handle a major unexpected expense"
-                               data-gtm-category="Page Interaction">
+                               data-gtm-category="Financial Well-Being Tool Interaction">
                         <label class="a-label" for="question-1-very-well">
                             Very well
                         </label>
@@ -164,7 +164,7 @@
                                value="2"
                                data-gtm-action="Questionnaire Radio Button Clicked"
                                data-gtm-label="I could handle a major unexpected expense"
-                               data-gtm-category="Page Interaction">
+                               data-gtm-category="Financial Well-Being Tool Interaction">
                         <label class="a-label" for="question-1-somewhat">
                             Somewhat
                         </label>
@@ -177,7 +177,7 @@
                                value="1"
                                data-gtm-action="Questionnaire Radio Button Clicked"
                                data-gtm-label="I could handle a major unexpected expense"
-                               data-gtm-category="Page Interaction">
+                               data-gtm-category="Financial Well-Being Tool Interaction">
                         <label class="a-label" for="question-1-very-little">
                             Very little
                         </label>
@@ -190,7 +190,7 @@
                                value="0"
                                data-gtm-action="Questionnaire Radio Button Clicked"
                                data-gtm-label="I could handle a major unexpected expense"
-                               data-gtm-category="Page Interaction">
+                               data-gtm-category="Financial Well-Being Tool Interaction">
                         <label class="a-label" for="question-1-not-at-all">
                             Not at all
                         </label>
@@ -209,7 +209,7 @@
                                value="4"
                                data-gtm-action="Questionnaire Radio Button Clicked"
                                data-gtm-label="I am securing my financial future"
-                               data-gtm-category="Page Interaction">
+                               data-gtm-category="Financial Well-Being Tool Interaction">
                         <label class="a-label" for="question-2-completely">
                             Completely
                         </label>
@@ -222,7 +222,7 @@
                                value="3"
                                data-gtm-action="Questionnaire Radio Button Clicked"
                                data-gtm-label="I am securing my financial future"
-                               data-gtm-category="Page Interaction">
+                               data-gtm-category="Financial Well-Being Tool Interaction">
                         <label class="a-label" for="question-2-very-well">
                             Very well
                         </label>
@@ -235,7 +235,7 @@
                                value="2"
                                data-gtm-action="Questionnaire Radio Button Clicked"
                                data-gtm-label="I am securing my financial future"
-                               data-gtm-category="Page Interaction">
+                               data-gtm-category="Financial Well-Being Tool Interaction">
                         <label class="a-label" for="question-2-somewhat">
                             Somewhat
                         </label>
@@ -248,7 +248,7 @@
                                value="1"
                                data-gtm-action="Questionnaire Radio Button Clicked"
                                data-gtm-label="I am securing my financial future"
-                               data-gtm-category="Page Interaction">
+                               data-gtm-category="Financial Well-Being Tool Interaction">
                         <label class="a-label" for="question-2-very-little">
                             Very little
                         </label>
@@ -261,7 +261,7 @@
                                value="0"
                                data-gtm-action="Questionnaire Radio Button Clicked"
                                data-gtm-label="I am securing my financial future"
-                               data-gtm-category="Page Interaction">
+                               data-gtm-category="Financial Well-Being Tool Interaction">
                         <label class="a-label" for="question-2-not-at-all">
                             Not at all
                         </label>
@@ -280,7 +280,7 @@
                                value="0"
                                data-gtm-action="Questionnaire Radio Button Clicked"
                                data-gtm-label="Because of my money situation, I feel like I will never have the things I want in life"
-                               data-gtm-category="Page Interaction">
+                               data-gtm-category="Financial Well-Being Tool Interaction">
                         <label class="a-label" for="question-3-completely">
                             Completely
                         </label>
@@ -293,7 +293,7 @@
                                value="1"
                                data-gtm-action="Questionnaire Radio Button Clicked"
                                data-gtm-label="Because of my money situation, I feel like I will never have the things I want in life"
-                               data-gtm-category="Page Interaction">
+                               data-gtm-category="Financial Well-Being Tool Interaction">
                         <label class="a-label" for="question-3-very-well">
                             Very well
                         </label>
@@ -306,7 +306,7 @@
                                value="2"
                                data-gtm-action="Questionnaire Radio Button Clicked"
                                data-gtm-label="Because of my money situation, I feel like I will never have the things I want in life"
-                               data-gtm-category="Page Interaction">
+                               data-gtm-category="Financial Well-Being Tool Interaction">
                         <label class="a-label" for="question-3-somewhat">
                             Somewhat
                         </label>
@@ -319,7 +319,7 @@
                                value="3"
                                data-gtm-action="Questionnaire Radio Button Clicked"
                                data-gtm-label="Because of my money situation, I feel like I will never have the things I want in life"
-                               data-gtm-category="Page Interaction">
+                               data-gtm-category="Financial Well-Being Tool Interaction">
                         <label class="a-label" for="question-3-very-little">
                             Very little
                         </label>
@@ -332,7 +332,7 @@
                                value="4"
                                data-gtm-action="Questionnaire Radio Button Clicked"
                                data-gtm-label="Because of my money situation, I feel like I will never have the things I want in life"
-                               data-gtm-category="Page Interaction">
+                               data-gtm-category="Financial Well-Being Tool Interaction">
                         <label class="a-label" for="question-3-not-at-all">
                             Not at all
                         </label>
@@ -351,7 +351,7 @@
                                value="4"
                                data-gtm-action="Questionnaire Radio Button Clicked"
                                data-gtm-label="I can enjoy life because of the way I’m managing my money"
-                               data-gtm-category="Page Interaction">
+                               data-gtm-category="Financial Well-Being Tool Interaction">
                         <label class="a-label" for="question-4-completely">
                             Completely
                         </label>
@@ -364,7 +364,7 @@
                                value="3"
                                data-gtm-action="Questionnaire Radio Button Clicked"
                                data-gtm-label="I can enjoy life because of the way I’m managing my money"
-                               data-gtm-category="Page Interaction">
+                               data-gtm-category="Financial Well-Being Tool Interaction">
                         <label class="a-label" for="question-4-very-well">
                             Very well
                         </label>
@@ -377,7 +377,7 @@
                                value="2"
                                data-gtm-action="Questionnaire Radio Button Clicked"
                                data-gtm-label="I can enjoy life because of the way I’m managing my money"
-                               data-gtm-category="Page Interaction">
+                               data-gtm-category="Financial Well-Being Tool Interaction">
                         <label class="a-label" for="question-4-somewhat">
                             Somewhat
                         </label>
@@ -390,7 +390,7 @@
                                value="1"
                                data-gtm-action="Questionnaire Radio Button Clicked"
                                data-gtm-label="I can enjoy life because of the way I’m managing my money"
-                               data-gtm-category="Page Interaction">
+                               data-gtm-category="Financial Well-Being Tool Interaction">
                         <label class="a-label" for="question-4-very-little">
                             Very little
                         </label>
@@ -403,7 +403,7 @@
                                value="0"
                                data-gtm-action="Questionnaire Radio Button Clicked"
                                data-gtm-label="I can enjoy life because of the way I’m managing my money"
-                               data-gtm-category="Page Interaction">
+                               data-gtm-category="Financial Well-Being Tool Interaction">
                         <label class="a-label" for="question-4-not-at-all">
                             Not at all
                         </label>
@@ -422,7 +422,7 @@
                                value="0"
                                data-gtm-action="Questionnaire Radio Button Clicked"
                                data-gtm-label="I am just getting by financially"
-                               data-gtm-category="Page Interaction">
+                               data-gtm-category="Financial Well-Being Tool Interaction">
                         <label class="a-label" for="question-5-completely">
                             Completely
                         </label>
@@ -435,7 +435,7 @@
                                value="1"
                                data-gtm-action="Questionnaire Radio Button Clicked"
                                data-gtm-label="I am just getting by financially"
-                               data-gtm-category="Page Interaction">
+                               data-gtm-category="Financial Well-Being Tool Interaction">
                         <label class="a-label" for="question-5-very-well">
                             Very well
                         </label>
@@ -448,7 +448,7 @@
                                value="2"
                                data-gtm-action="Questionnaire Radio Button Clicked"
                                data-gtm-label="I am just getting by financially"
-                               data-gtm-category="Page Interaction">
+                               data-gtm-category="Financial Well-Being Tool Interaction">
                         <label class="a-label" for="question-5-somewhat">
                             Somewhat
                         </label>
@@ -461,7 +461,7 @@
                                value="3"
                                data-gtm-action="Questionnaire Radio Button Clicked"
                                data-gtm-label="I am just getting by financially"
-                               data-gtm-category="Page Interaction">
+                               data-gtm-category="Financial Well-Being Tool Interaction">
                         <label class="a-label" for="question-5-very-little">
                             Very little
                         </label>
@@ -474,7 +474,7 @@
                                value="4"
                                data-gtm-action="Questionnaire Radio Button Clicked"
                                data-gtm-label="I am just getting by financially"
-                               data-gtm-category="Page Interaction">
+                               data-gtm-category="Financial Well-Being Tool Interaction">
                         <label class="a-label" for="question-5-not-at-all">
                             Not at all
                         </label>
@@ -493,7 +493,7 @@
                                value="0"
                                data-gtm-action="Questionnaire Radio Button Clicked"
                                data-gtm-label="I am concerned that the money I have or will save won’t last"
-                               data-gtm-category="Page Interaction">
+                               data-gtm-category="Financial Well-Being Tool Interaction">
                         <label class="a-label" for="question-6-completely">
                             Completely
                         </label>
@@ -506,7 +506,7 @@
                                value="1"
                                data-gtm-action="Questionnaire Radio Button Clicked"
                                data-gtm-label="I am concerned that the money I have or will save won’t last"
-                               data-gtm-category="Page Interaction">
+                               data-gtm-category="Financial Well-Being Tool Interaction">
                         <label class="a-label" for="question-6-very-well">
                             Very well
                         </label>
@@ -519,7 +519,7 @@
                                value="2"
                                data-gtm-action="Questionnaire Radio Button Clicked"
                                data-gtm-label="I am concerned that the money I have or will save won’t last"
-                               data-gtm-category="Page Interaction">
+                               data-gtm-category="Financial Well-Being Tool Interaction">
                         <label class="a-label" for="question-6-somewhat">
                             Somewhat
                         </label>
@@ -532,7 +532,7 @@
                                value="3"
                                data-gtm-action="Questionnaire Radio Button Clicked"
                                data-gtm-label="I am concerned that the money I have or will save won’t last"
-                               data-gtm-category="Page Interaction">
+                               data-gtm-category="Financial Well-Being Tool Interaction">
                         <label class="a-label" for="question-6-very-little">
                             Very little
                         </label>
@@ -545,7 +545,7 @@
                                value="4"
                                data-gtm-action="Questionnaire Radio Button Clicked"
                                data-gtm-label="I am concerned that the money I have or will save won’t last"
-                               data-gtm-category="Page Interaction">
+                               data-gtm-category="Financial Well-Being Tool Interaction">
                         <label class="a-label" for="question-6-not-at-all">
                             Not at all
                         </label>
@@ -569,7 +569,7 @@
                                value="0"
                                data-gtm-action="Questionnaire Radio Button Clicked"
                                data-gtm-label="Giving a gift for a wedding, birthday or other occasion would put a strain on my finances for the month"
-                               data-gtm-category="Page Interaction">
+                               data-gtm-category="Financial Well-Being Tool Interaction">
                         <label class="a-label" for="question-7-always">
                             Always
                         </label>
@@ -582,7 +582,7 @@
                                value="1"
                                data-gtm-action="Questionnaire Radio Button Clicked"
                                data-gtm-label="Giving a gift for a wedding, birthday or other occasion would put a strain on my finances for the month"
-                               data-gtm-category="Page Interaction">
+                               data-gtm-category="Financial Well-Being Tool Interaction">
                         <label class="a-label" for="question-7-often">
                             Often
                         </label>
@@ -595,7 +595,7 @@
                                value="2"
                                data-gtm-action="Questionnaire Radio Button Clicked"
                                data-gtm-label="Giving a gift for a wedding, birthday or other occasion would put a strain on my finances for the month"
-                               data-gtm-category="Page Interaction">
+                               data-gtm-category="Financial Well-Being Tool Interaction">
                         <label class="a-label" for="question-7-sometimes">
                             Sometimes
                         </label>
@@ -608,7 +608,7 @@
                                value="3"
                                data-gtm-action="Questionnaire Radio Button Clicked"
                                data-gtm-label="Giving a gift for a wedding, birthday or other occasion would put a strain on my finances for the month"
-                               data-gtm-category="Page Interaction">
+                               data-gtm-category="Financial Well-Being Tool Interaction">
                         <label class="a-label" for="question-7-rarely">
                             Rarely
                         </label>
@@ -621,7 +621,7 @@
                                value="4"
                                data-gtm-action="Questionnaire Radio Button Clicked"
                                data-gtm-label="Giving a gift for a wedding, birthday or other occasion would put a strain on my finances for the month"
-                               data-gtm-category="Page Interaction">
+                               data-gtm-category="Financial Well-Being Tool Interaction">
                         <label class="a-label" for="question-7-never">
                             Never
                         </label>
@@ -640,7 +640,7 @@
                                value="4"
                                data-gtm-action="Questionnaire Radio Button Clicked"
                                data-gtm-label="I have money left over at the end of the month"
-                               data-gtm-category="Page Interaction">
+                               data-gtm-category="Financial Well-Being Tool Interaction">
                         <label class="a-label" for="question-8-always">
                             Always
                         </label>
@@ -653,7 +653,7 @@
                                value="3"
                                data-gtm-action="Questionnaire Radio Button Clicked"
                                data-gtm-label="I have money left over at the end of the month"
-                               data-gtm-category="Page Interaction">
+                               data-gtm-category="Financial Well-Being Tool Interaction">
                         <label class="a-label" for="question-8-often">
                             Often
                         </label>
@@ -666,7 +666,7 @@
                                value="2"
                                data-gtm-action="Questionnaire Radio Button Clicked"
                                data-gtm-label="I have money left over at the end of the month"
-                               data-gtm-category="Page Interaction">
+                               data-gtm-category="Financial Well-Being Tool Interaction">
                         <label class="a-label" for="question-8-sometimes">
                             Sometimes
                         </label>
@@ -679,7 +679,7 @@
                                value="1"
                                data-gtm-action="Questionnaire Radio Button Clicked"
                                data-gtm-label="I have money left over at the end of the month"
-                               data-gtm-category="Page Interaction">
+                               data-gtm-category="Financial Well-Being Tool Interaction">
                         <label class="a-label" for="question-8-rarely">
                             Rarely
                         </label>
@@ -692,7 +692,7 @@
                                value="0"
                                data-gtm-action="Questionnaire Radio Button Clicked"
                                data-gtm-label="I have money left over at the end of the month"
-                               data-gtm-category="Page Interaction">
+                               data-gtm-category="Financial Well-Being Tool Interaction">
                         <label class="a-label" for="question-8-never">
                             Never
                         </label>
@@ -711,7 +711,7 @@
                                value="0"
                                data-gtm-action="Questionnaire Radio Button Clicked"
                                data-gtm-label="I am behind with my finances"
-                               data-gtm-category="Page Interaction">
+                               data-gtm-category="Financial Well-Being Tool Interaction">
                         <label class="a-label" for="question-9-always">
                             Always
                         </label>
@@ -724,7 +724,7 @@
                                value="1"
                                data-gtm-action="Questionnaire Radio Button Clicked"
                                data-gtm-label="I am behind with my finances"
-                               data-gtm-category="Page Interaction">
+                               data-gtm-category="Financial Well-Being Tool Interaction">
                         <label class="a-label" for="question-9-often">
                             Often
                         </label>
@@ -737,7 +737,7 @@
                                value="2"
                                data-gtm-action="Questionnaire Radio Button Clicked"
                                data-gtm-label="I am behind with my finances"
-                               data-gtm-category="Page Interaction">
+                               data-gtm-category="Financial Well-Being Tool Interaction">
                         <label class="a-label" for="question-9-sometimes">
                             Sometimes
                         </label>
@@ -750,7 +750,7 @@
                                value="3"
                                data-gtm-action="Questionnaire Radio Button Clicked"
                                data-gtm-label="I am behind with my finances"
-                               data-gtm-category="Page Interaction">
+                               data-gtm-category="Financial Well-Being Tool Interaction">
                         <label class="a-label" for="question-9-rarely">
                             Rarely
                         </label>
@@ -763,7 +763,7 @@
                                value="4"
                                data-gtm-action="Questionnaire Radio Button Clicked"
                                data-gtm-label="I am behind with my finances"
-                               data-gtm-category="Page Interaction">
+                               data-gtm-category="Financial Well-Being Tool Interaction">
                         <label class="a-label" for="question-9-never">
                             Never
                         </label>
@@ -782,7 +782,7 @@
                                value="0"
                                data-gtm-action="Questionnaire Radio Button Clicked"
                                data-gtm-label="My finances control my life"
-                               data-gtm-category="Page Interaction">
+                               data-gtm-category="Financial Well-Being Tool Interaction">
                         <label class="a-label" for="question-10-always">
                             Always
                         </label>
@@ -795,7 +795,7 @@
                                value="1"
                                data-gtm-action="Questionnaire Radio Button Clicked"
                                data-gtm-label="My finances control my life"
-                               data-gtm-category="Page Interaction">
+                               data-gtm-category="Financial Well-Being Tool Interaction">
                         <label class="a-label" for="question-10-often">
                             Often
                         </label>
@@ -808,7 +808,7 @@
                                value="2"
                                data-gtm-action="Questionnaire Radio Button Clicked"
                                data-gtm-label="My finances control my life"
-                               data-gtm-category="Page Interaction">
+                               data-gtm-category="Financial Well-Being Tool Interaction">
                         <label class="a-label" for="question-10-sometimes">
                             Sometimes
                         </label>
@@ -821,7 +821,7 @@
                                value="3"
                                data-gtm-action="Questionnaire Radio Button Clicked"
                                data-gtm-label="My finances control my life"
-                               data-gtm-category="Page Interaction">
+                               data-gtm-category="Financial Well-Being Tool Interaction">
                         <label class="a-label" for="question-10-rarely">
                             Rarely
                         </label>
@@ -834,7 +834,7 @@
                                value="4"
                                data-gtm-action="Questionnaire Radio Button Clicked"
                                data-gtm-label="My finances control my life"
-                               data-gtm-category="Page Interaction">
+                               data-gtm-category="Financial Well-Being Tool Interaction">
                         <label class="a-label" for="question-10-never">
                             Never
                         </label>
@@ -856,7 +856,10 @@
                                        type="radio"
                                        name="age"
                                        id="age-18-61"
-                                       value="18-61">
+                                       value="18-61"
+                                       data-gtm-action="Questionnaire Radio Button Clicked"
+                                       data-gtm-label="Select your age group: 18-61"
+                                       data-gtm-category="Financial Well-Being Tool Interaction">
                                 <label class="a-label" for="age-18-61">
                                     18–61
                                 </label>
@@ -868,7 +871,10 @@
                                        type="radio"
                                        name="age"
                                        id="age-62-plus"
-                                       value="62-plus">
+                                       value="62-plus"
+                                       data-gtm-action="Questionnaire Radio Button Clicked"
+                                       data-gtm-label="Select your age group: 62+"
+                                       data-gtm-category="Financial Well-Being Tool Interaction">
                                 <label class="a-label" for="age-62-plus">
                                     62+
                                 </label>
@@ -888,6 +894,9 @@
                                        name="method"
                                        id="read-self"
                                        value="read-self"
+                                       data-gtm-action="Questionnaire Radio Button Clicked"
+                                       data-gtm-label="Select how you completed the questionnaire: I read and answered the questions myself"
+                                       data-gtm-category="Financial Well-Being Tool Interaction"
                                        checked>
                                 <label class="a-label" for="read-self">
                                     I read and answered the questions myself
@@ -900,7 +909,10 @@
                                        type="radio"
                                        name="method"
                                        id="read-to-me"
-                                       value="read-to-me">
+                                       value="read-to-me"
+                                       data-gtm-action="Questionnaire Radio Button Clicked"
+                                       data-gtm-label="Select how you completed the questionnaire: I read the questions to someone else and recorded their answers"
+                                       data-gtm-category="Financial Well-Being Tool Interaction">
                                 <label class="a-label" for="read-to-me">
                                     I read the questions to someone else and recorded their answers
                                 </label>
@@ -914,7 +926,13 @@
         <input type="hidden" name="csrfmiddlewaretoken" value="{{ csrf_token }}">
 
         <div class="o-form_group">
-            <input class="submit-quiz a-btn" id="submit-quiz" type="submit" value="Get my score">
+            <input class="submit-quiz a-btn"
+                   id="submit-quiz"
+                   type="submit"
+                   value="Get my score"
+                   data-gtm-action="Questionnaire Submitted"
+                   data-gtm-label="Get my score"
+                   data-gtm-category="Financial Well-Being Tool Interaction">
         </div>
     </form>
 {%- endblock %}

--- a/cfgov/wellbeing/jinja2/wellbeing/results.html
+++ b/cfgov/wellbeing/jinja2/wellbeing/results.html
@@ -517,17 +517,26 @@
                 <button class="a-btn
                                comparison-chart_toggle-button
                                comparison-chart_toggle-button__selected"
-                        data-compare-by="age">
+                        data-compare-by="age"
+                        data-gtm-action="Compare By Radio Button Clicked"
+                        data-gtm-label="Age"
+                        data-gtm-category="Financial Well-Being Tool Interaction">
                     Age
                 </button>
                 <button class="a-btn
                                comparison-chart_toggle-button"
-                        data-compare-by="income">
+                        data-compare-by="income"
+                        data-gtm-action="Compare By Radio Button Clicked"
+                        data-gtm-label="Household income"
+                        data-gtm-category="Financial Well-Being Tool Interaction">
                     Household income
                 </button>
                 <button class="a-btn
                                comparison-chart_toggle-button"
-                        data-compare-by="employment">
+                        data-compare-by="employment"
+                        data-gtm-action="Compare By Radio Button Clicked"
+                        data-gtm-label="Employment status"
+                        data-gtm-category="Financial Well-Being Tool Interaction">
                     Employment status
                 </button>
             </div>


### PR DESCRIPTION
Our analytics team requested some updates to the events that fire on the financial well-being questionnaire and results pages.

## Additions

- Event data for the categorization questions at the end of the questionnaire
- Event data for the Compare By buttons on the results page

## Changes

- Renames event category from "Page Interaction" to "Financial Well-Being Tool Interaction"

## Testing

I'm not sure if it's possible to test these locally. Anyone know how?

## Checklist

* [ ] PR has an informative and human-readable title
* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated
* [ ] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
