### PR TITLE
Fix issues when printing the FWB results page

### DIFF
--- a/cfgov/wellbeing/jinja2/wellbeing/results.html
+++ b/cfgov/wellbeing/jinja2/wellbeing/results.html
@@ -177,10 +177,6 @@
             .content_sidebar {
                 display: none !important;
             }
-            html {
-                border: 1px red dotted;
-                height: auto;
-            }
         }
     </style>
 {% endblock %}

--- a/cfgov/wellbeing/jinja2/wellbeing/results.html
+++ b/cfgov/wellbeing/jinja2/wellbeing/results.html
@@ -26,6 +26,7 @@
             padding-top: 120px;
             margin-top: 30px;
             position: relative;
+            max-width: 770px;
         }
         .score-box {
             height: 150px;
@@ -147,14 +148,6 @@
         }
 
         @media print {
-            /* Hide various things when printing */
-            .save-links,
-            .o-expandable_link,
-            .comparison-chart_toggle,
-            .o-footer {
-                display: none;
-            }
-
             /* Force all these things back on when printing, regardless
                of how the user has interacted with the page */
             .js [class^="comparison_data-point age"],
@@ -168,13 +161,25 @@
                 height: auto !important;
             }
 
-            .content_main,
-            .content_sidebar {
+            .content_main {
                 display: block !important;
             }
 
-            * {
+            .content_main * {
                 overflow: visible !important;
+            }
+
+            /* Hide various things when printing */
+            .save-links,
+            .o-expandable_link,
+            .comparison-chart_toggle,
+            .o-footer,
+            .content_sidebar {
+                display: none !important;
+            }
+            html {
+                border: 1px red dotted;
+                height: auto;
             }
         }
     </style>


### PR DESCRIPTION
When printing, we don't want to include the sidebar. The spectrum was
also printing wider than the image causing the scale to mis-align.

## Changes

- Fixed the FWB print styles

## Testing

1. Run through the questions and attempt to print your results.

## Notes

- I can't figure out why Chrome is printing an extra page. That may have to happen post launch.

## Checklist

* [x] PR has an informative and human-readable title
* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices
* [x] Project documentation has been updated
* [x] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
