### PR TITLE
Add survey link to data & research mega menu

### DIFF
--- a/cfgov/jinja2/v1/_includes/organisms/_vars-mega-menu.html
+++ b/cfgov/jinja2/v1/_includes/organisms/_vars-mega-menu.html
@@ -59,74 +59,50 @@
 
 {% set consumer_tools_content = {
     'link': {
-        'text': 'Take action together',
-        'url':  '/arbitration-rule/',
+        'text': 'Get your financial well-being score',
+        'url':  '/consumer-tools/financial-well-being/',
     },
     'image': {
         'src': 'img/fmc-consumer-tools-540x300.png',
         'alt': '',
     },
-    'body': 'Learn how our new arbitration rule will make sure that groups ' +
-            'of people can take companies to court.',
+    'body': 'Answer ten questions and see your financial well-being score, ' +
+            'along with national averages.',
 } %}
 
+{% set resources_content = {
+    'link': {
+        'text': 'Explore financial well-being survey results',
+        'url':  '/data-research/research-reports/financial-well-being-america/',
+    },
+    'image': {
+        'src': 'img/fmc-resources-540x300.png',
+        'alt': '',
+    },
+    'body': 'See national survey results on financial well-being and how it ' +
+            'relates to other factors in a person’s financial life.',
+} %}
+
+{% set data_research_content = {
+    'link': {
+        'text': 'Help advance financial well-being',
+        'url':  '/data-research/financial-well-being-survey-data/',
+    },
+    'image': {
+        'src': 'img/fmc-data-research-540x300.png',
+        'alt': '',
+    },
+    'body': 'Explore our national survey data and think about ways to empower ' +
+            'families to achieve higher financial well-being.',
+} %}
 
 {% set media_items = [
   ( 'Consumer Tools', featured_menu_content.render( consumer_tools_content ) ),
+  ( 'Practitioner Resources', featured_menu_content.render( resources_content ) ),
+  ( 'Data & Research', featured_menu_content.render( data_research_content ) ),
   ( 'Policy & Compliance', featured_menu_content.render( poly_com_content ) ),
   ( 'About Us', featured_menu_content.render( about_us_content ) ),
 ] %}
-
-{% if flag_enabled('FWB_RELEASE', request) %}
-
-    {% set consumer_tools_content = {
-        'link': {
-            'text': 'Get your financial well-being score',
-            'url':  '/consumer-tools/financial-well-being/',
-        },
-        'image': {
-            'src': 'img/fmc-consumer-tools-540x300.png',
-            'alt': '',
-        },
-        'body': 'Answer ten questions and see your financial well-being score, ' +
-                'along with national averages.',
-    } %}
-
-    {% set resources_content = {
-        'link': {
-            'text': 'Explore financial well-being survey results',
-            'url':  'data-research/research-reports/financial-well-being-america/',
-        },
-        'image': {
-            'src': 'img/fmc-resources-540x300.png',
-            'alt': '',
-        },
-        'body': 'See national survey results on financial well-being and how it ' +
-                'relates to other factors in a person’s financial life.',
-    } %}
-
-    {% set data_research_content = {
-        'link': {
-            'text': 'Help advance financial well-being',
-            'url':  '/data-research/financial-well-being-survey-data/',
-        },
-        'image': {
-            'src': 'img/fmc-data-research-540x300.png',
-            'alt': '',
-        },
-        'body': 'Explore our national survey data and think about ways to empower ' +
-                'families to achieve higher financial well-being.',
-    } %}
-
-    {% set media_items = [
-      ( 'Consumer Tools', featured_menu_content.render( consumer_tools_content ) ),
-      ( 'Practitioner Resources', featured_menu_content.render( resources_content ) ),
-      ( 'Data & Research', featured_menu_content.render( data_research_content ) ),
-      ( 'Policy & Compliance', featured_menu_content.render( poly_com_content ) ),
-      ( 'About Us', featured_menu_content.render( about_us_content ) ),
-    ] %}
-
-{% endif %}
 
 
 {# Consumer Tools menu items #}
@@ -230,6 +206,7 @@
     'nav_items': [
         {'text': 'Research & Reports', 'url': '/data-research/research-reports/'},
         {'text': 'CFPB Research Conference', 'url': '/data-research/cfpb-research-conference/'},
+        {'text': 'CFPB Researchers', 'url': '/data-research/cfpb-researchers/'},
     ]
 } %}
 {% set data_research_group_two = {
@@ -242,28 +219,9 @@
     'nav_items': [
         {'text': 'Consumer Credit Trends', 'url': '/data-research/consumer-credit-trends/'},
         {'text': 'Credit Card Surveys & Agreements', 'url': '/data-research/credit-card-data/'},
-        {'text': 'CFPB Researchers', 'url': '/data-research/cfpb-researchers/'},
+        {'text': 'Financial Well-Being Survey', 'url': '/data-research/financial-well-being-survey'},
     ]
 } %}
-
-{% if flag_enabled('FWB_RELEASE', request) %}
-
-    {% set data_research_group_one = {
-        'nav_items': [
-            {'text': 'Research & Reports', 'url': '/data-research/research-reports/'},
-            {'text': 'CFPB Research Conference', 'url': '/data-research/cfpb-research-conference/'},
-            {'text': 'CFPB Researchers', 'url': '/data-research/cfpb-researchers/'},
-        ]
-    } %}
-    {% set data_research_group_three = {
-        'nav_items': [
-            {'text': 'Consumer Credit Trends', 'url': '/data-research/consumer-credit-trends/'},
-            {'text': 'Credit Card Surveys & Agreements', 'url': '/data-research/credit-card-data/'},
-            {'text': 'Financial Well-Being Survey', 'url': '/data-research/financial-well-being-survey'},
-        ]
-    } %}
-
-{% endif %}
 
 {% set data_research = {
     'text': 'Data & Research',

--- a/cfgov/jinja2/v1/_includes/organisms/_vars-mega-menu.html
+++ b/cfgov/jinja2/v1/_includes/organisms/_vars-mega-menu.html
@@ -246,16 +246,6 @@
     ]
 } %}
 
-{% set data_research = {
-    'text': 'Data & Research',
-    'url': '/data-research/',
-    'nav_groups': [
-        data_research_group_one,
-        data_research_group_two,
-        data_research_group_three,
-    ],
-} %}
-
 {% if flag_enabled('FWB_RELEASE', request) %}
 
     {% set data_research_group_one = {
@@ -273,17 +263,17 @@
         ]
     } %}
 
-    {% set data_research = {
-        'text': 'Data & Research',
-        'url': '/data-research/',
-        'nav_groups': [
-            data_research_group_one,
-            data_research_group_two,
-            data_research_group_three,
-        ],
-    } %}
-
 {% endif %}
+
+{% set data_research = {
+    'text': 'Data & Research',
+    'url': '/data-research/',
+    'nav_groups': [
+        data_research_group_one,
+        data_research_group_two,
+        data_research_group_three,
+    ],
+} %}
 
 {# Policy & Compliance menu items #}
 

--- a/cfgov/jinja2/v1/_includes/organisms/_vars-mega-menu.html
+++ b/cfgov/jinja2/v1/_includes/organisms/_vars-mega-menu.html
@@ -256,6 +256,34 @@
     ],
 } %}
 
+{% if flag_enabled('FWB_RELEASE', request) %}
+
+    {% set data_research_group_one = {
+        'nav_items': [
+            {'text': 'Research & Reports', 'url': '/data-research/research-reports/'},
+            {'text': 'CFPB Research Conference', 'url': '/data-research/cfpb-research-conference/'},
+            {'text': 'CFPB Researchers', 'url': '/data-research/cfpb-researchers/'},
+        ]
+    } %}
+    {% set data_research_group_three = {
+        'nav_items': [
+            {'text': 'Consumer Credit Trends', 'url': '/data-research/consumer-credit-trends/'},
+            {'text': 'Credit Card Surveys & Agreements', 'url': '/data-research/credit-card-data/'},
+            {'text': 'Financial Well-Being Survey', 'url': '/data-research/financial-well-being-survey'},
+        ]
+    } %}
+
+    {% set data_research = {
+        'text': 'Data & Research',
+        'url': '/data-research/',
+        'nav_groups': [
+            data_research_group_one,
+            data_research_group_two,
+            data_research_group_three,
+        ],
+    } %}
+
+{% endif %}
 
 {# Policy & Compliance menu items #}
 


### PR DESCRIPTION
Adds Financial Well-Being Survey links to the Data & Research portion of the mega menu. ~Uses a flag to stage these changes until go-live.~

## Additions

- New "Financial Well-Being Survey" page placed at the bottom of column 3, underneath “Credit Card Surveys & Agreements”

## Changes

- Moves “CFPB Researchers” to column 1 (underneath “CFPB Research Conference”)

## Testing

1. Verify that the menu has changed to reflect the addition and changes above.
