### PR TITLE
Fix incorrect URL

### DIFF
--- a/cfgov/jinja2/v1/_includes/organisms/_vars-mega-menu.html
+++ b/cfgov/jinja2/v1/_includes/organisms/_vars-mega-menu.html
@@ -219,7 +219,7 @@
     'nav_items': [
         {'text': 'Consumer Credit Trends', 'url': '/data-research/consumer-credit-trends/'},
         {'text': 'Credit Card Surveys & Agreements', 'url': '/data-research/credit-card-data/'},
-        {'text': 'Financial Well-Being Survey', 'url': '/data-research/financial-well-being-survey-data'},
+        {'text': 'Financial Well-Being Survey', 'url': '/data-research/financial-well-being-survey-data/'},
     ]
 } %}
 

--- a/cfgov/jinja2/v1/_includes/organisms/_vars-mega-menu.html
+++ b/cfgov/jinja2/v1/_includes/organisms/_vars-mega-menu.html
@@ -219,7 +219,7 @@
     'nav_items': [
         {'text': 'Consumer Credit Trends', 'url': '/data-research/consumer-credit-trends/'},
         {'text': 'Credit Card Surveys & Agreements', 'url': '/data-research/credit-card-data/'},
-        {'text': 'Financial Well-Being Survey', 'url': '/data-research/financial-well-being-survey'},
+        {'text': 'Financial Well-Being Survey', 'url': '/data-research/financial-well-being-survey-data'},
     ]
 } %}
 


### PR DESCRIPTION
The URL for the Financial Well-Being Survey changed since the issue was filed, updating to the full path.