### PR TITLE
Change chart footnote color from Gray 80 to CFPB Black

### DIFF
--- a/cfgov/unprocessed/css/organisms/chart.less
+++ b/cfgov/unprocessed/css/organisms/chart.less
@@ -27,7 +27,7 @@
 .m-chart-footnote {
   padding-top: unit(15px / @base-font-size-px, em);
   margin-top: unit(30px / @base-font-size-px, em);
-  color: @gray-80;
+  color: @black;
   @font-size: 12px;
   font-size: unit(@font-size / @base-font-size-px, em);
 }


### PR DESCRIPTION
The Mortgage Performance footnotes were failing the WCAG 2.0 AA color contrast test. They were Gray 80, so we are changing them to CFPB Black.

## Changes

- Change footnote color from Gray 80 to CFPB Black

## Testing

1. Pull down this branch and `./setup.sh`
2. Set up the [mortgage performance API](https://github.com/cfpb/cfgov-refresh/pull/3189).
3. Create a [mortgage chart block and page](https://github.com/cfpb/cfgov-refresh/pull/3260).

## Checklist

* [x] PR has an informative and human-readable title
* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices
* [x] Project documentation has been updated
* [x] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
