### PR TITLE
Fix layout issues within Firefox when printing

### DIFF
--- a/cfgov/wellbeing/jinja2/wellbeing/results.html
+++ b/cfgov/wellbeing/jinja2/wellbeing/results.html
@@ -162,6 +162,22 @@
                 height: auto !important;
             }
 
+            .o-expandable_content table {
+                height: 510px;
+            }
+
+            .o-expandable_content thead {
+                border-bottom: none;
+            }
+
+            .o-expandable_content th:last-child {
+                width: 25% !important;
+            }
+
+            .o-expandable_content tbody tr {
+                border-bottom: none;
+            }
+
             .content_main {
                 display: block !important;
             }


### PR DESCRIPTION
For whatever reason Firefox isn’t expanding the table within the
expandable, even if it’s displayed on the user’s browser.

## Additions

- Print specific styles for FWB

## Testing

1. Open http://localhost:8000/consumer-tools/financial-well-being/ in Firefox and fill in the form, then try to print the page. The expandable content should be visible in your print preview.

## Screenshots

![screen shot 2017-09-26 at 3 29 34 pm](https://user-images.githubusercontent.com/1280430/30882782-bd663fbe-a2cf-11e7-8e87-93116cb5afd3.png)

## Checklist

* [x] PR has an informative and human-readable title
* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices
* [x] Project documentation has been updated
* [x] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
