### PR TITLE
Add the option to swap out the OG Image in non-wagtail pages

### DIFF
--- a/cfgov/jinja2/v1/_layouts/base.html
+++ b/cfgov/jinja2/v1/_layouts/base.html
@@ -64,6 +64,7 @@
         <meta property="og:title" content="{% block og_title %}{{ self.title() }}{% endblock %}">
         <meta property="og:type" content="{% block og_type %}website{% endblock %}">
         <meta property="og:url" content="{{ request.url }}">
+{% block og_image %}
     {% if page and page.meta_image %}
         {% set meta_image_url = request.build_absolute_uri(image(page.meta_image, 'original').url) %}
         <meta property="og:image" content="{{ meta_image_url }}">
@@ -77,6 +78,7 @@
         <meta property="twitter:image"
               content="{{ request.scheme }}://{{ request.get_host() }}{{ static('img/logo_open-graph_twitter.png') }}">
     {% endif %}
+{% endblock %}
         <!--  Optional -->
         <meta property="og:description"
               content="

--- a/cfgov/wellbeing/jinja2/wellbeing/about.html
+++ b/cfgov/wellbeing/jinja2/wellbeing/about.html
@@ -8,6 +8,16 @@
     Learn about the financial well-being scale and why we created it.
 {%- endblock %}
 
+{% block og_desc -%}
+    Learn about the financial well-being scale and why we created it.
+{%- endblock %}
+
+{% block og_image %}
+        <meta property="og:image" content="https://s3.amazonaws.com/files.consumerfinance.gov/f/images/cfpb_fwb_tool-graphic_1200.original.png">
+        <meta property="twitter:image" content="https://s3.amazonaws.com/files.consumerfinance.gov/f/images/cfpb_fwb_tool-graphic_1200.original.png">
+        <meta name="twitter:card" content="summary_large_image">
+{% endblock %}
+
 
 {% block pre_content %}
     <div class="content_wrapper">

--- a/cfgov/wellbeing/jinja2/wellbeing/home.html
+++ b/cfgov/wellbeing/jinja2/wellbeing/home.html
@@ -8,6 +8,16 @@
     Answer ten questions to measure your own current financial well-being and see steps you can take to improve it.
 {%- endblock %}
 
+{% block og_desc -%}
+    Find out your financial well-being by answering ten questions, and then see steps you can take to improve it.
+{%- endblock %}
+
+{% block og_image %}
+        <meta property="og:image" content="https://s3.amazonaws.com/files.consumerfinance.gov/f/images/cfpb_fwb_tool-graphic_1200.original.png">
+        <meta property="twitter:image" content="https://s3.amazonaws.com/files.consumerfinance.gov/f/images/cfpb_fwb_tool-graphic_1200.original.png">
+        <meta name="twitter:card" content="summary_large_image">
+{% endblock %}
+
 {% block css -%}
     {{ super() }}
     <style>

--- a/cfgov/wellbeing/jinja2/wellbeing/results.html
+++ b/cfgov/wellbeing/jinja2/wellbeing/results.html
@@ -13,6 +13,16 @@
     See your survey results and learn how you may be able to improve your score.
 {%- endblock %}
 
+{% block og_desc -%}
+    See your survey results and learn how you may be able to improve your score.
+{%- endblock %}
+
+{% block og_image %}
+        <meta property="og:image" content="https://s3.amazonaws.com/files.consumerfinance.gov/f/images/cfpb_fwb_tool-graphic_1200.original.png">
+        <meta property="twitter:image" content="https://s3.amazonaws.com/files.consumerfinance.gov/f/images/cfpb_fwb_tool-graphic_1200.original.png">
+        <meta name="twitter:card" content="summary_large_image">
+{% endblock %}
+
 {% block css %}
     {{ super() }}
     <style>


### PR DESCRIPTION
Apps like Well Being are not able to set their own Open Graph Images.
Wrapping the OG Image code in a block allows a developer to override the
default images.

## Additions

- OG Block wrapper to the `base.html` templates.
- OG Image block to each of the Well Being templates.
- OG Description block to each of the Well Being templates.

## Testing

1. It's not possible to test Open Graph locally other than viewing the page source.

## Screenshots

![screen shot 2017-09-27 at 9 48 23 am](https://user-images.githubusercontent.com/1280430/30920205-0718c822-a369-11e7-89ff-061054fafcb7.png)

## Checklist

* [x] PR has an informative and human-readable title
* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices
* [x] Project documentation has been updated
* [x] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
