### PR TITLE
Removes reference to sheer.js

### DIFF
--- a/cfgov/cfgov/test.py
+++ b/cfgov/cfgov/test.py
@@ -54,7 +54,6 @@ class PlaceholderJSMixin(object):
     """
     PLACEHOLDER_FILES = (
         'static_built/js/routes/common.js',
-        'static_built/js/routes/sheer.js',
     )
 
     PLACEHOLDER_STRING = (


### PR DESCRIPTION
`sheer.js` removed in https://github.com/cfpb/cfgov-refresh/commit/d74bc50d9247cd6152ca40bf80b4d8c8ae4b1498#diff-89b43ee86bbd4952dc44cf751cfd775c. This additional reference can be removed. 

## Removals

- `sheer.js` reference.

## Testing

1. run `tox`
