### PR TITLE
Update optional regulations-site package to 2.1.10

### DIFF
--- a/requirements/optional-public.txt
+++ b/requirements/optional-public.txt
@@ -2,7 +2,7 @@ https://github.com/cfpb/college-costs/releases/download/2.3.9/college_costs-2.3.
 https://github.com/cfpb/complaint/releases/download/1.4.2/complaintdatabase-1.4.2-py2-none-any.whl
 git+https://github.com/cfpb/owning-a-home-api.git@0.9.96#egg=owning-a-home-api
 git+https://github.com/cfpb/regulations-core.git@1.2.5#egg=regcore
-git+https://github.com/cfpb/regulations-site.git@2.1.8#egg=regulations
+git+https://github.com/cfpb/regulations-site.git@2.1.10#egg=regulations
 https://github.com/cfpb/retirement/releases/download/0.5.11/retirement-0.5.11-py2-none-any.whl
 git+https://github.com/cfpb/ccdb5-api.git@v0.8.0#egg=ccdb5-api
 git+https://github.com/cfpb/ccdb5-ui.git@v0.7.13#egg=ccdb5_ui


### PR DESCRIPTION
This change updates the optional [regulations-site](https://github.com/cfpb/regulations-site) package to its [2.1.10 release](https://github.com/cfpb/regulations-site/releases/tag/2.1.10).

## Changes

- Bump regulations-site from 2.1.8 to 2.1.10.

## Checklist

* [X] PR has an informative and human-readable title
* [X] Changes are limited to a single goal (no scope creep)
* [X] Code can be automatically merged (no conflicts)
* [X] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [X] Passes all existing automated tests
* [X] Visually tested in supported browsers and devices
* [X] Reviewers requested with the [Assignee tool](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) :arrow_right:
