### PR TITLE
Mortgage performance: Set a release feature flag

### DIFF
--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -549,6 +549,9 @@ FLAGS = {
     # The next version of the public consumer complaint database
     'CCDB5_RELEASE': {},
 
+    # To be enabled when mortgage-performance data visualizations go live
+    'MORTGAGE_PERFORMANCE_RELEASE': {},
+
     # Google Optimize code snippets for A/B testing
     # When enabled this flag will add various Google Optimize code snippets.
     # Intended for use with path conditions.


### PR DESCRIPTION
This flag will be used to turn on new links in the megamenu's
data-research section.

