### PR TITLE
Mortgage Performance SVG fix for IE

### DIFF
--- a/cfgov/jinja2/v1/_includes/organisms/mortgage-map.html
+++ b/cfgov/jinja2/v1/_includes/organisms/mortgage-map.html
@@ -18,7 +18,7 @@
 
 <div class="o-full-width-text-group" id="mp-map-container" data-chart-time-span="{{ time_frame }}" data-chart-color="{{ data_vis_color }}" data-chart-start-date="{{ sampling_dates|first }}" data-chart-end-date="{{ sampling_dates|last }}">
     <div class="m-full-width-text">
-        <div class="block 
+        <div class="block
                 block__flush-top
                 block__flush-bottom
                 block__padded-bottom">
@@ -175,13 +175,13 @@
             <g>
                 <g>
                     <g>
-                        <rect y="30.1535" x="1.2" class="a-ramp-value-0" />
-                        <rect y="30.1535" x="92.4" class="a-ramp-value-1" />
-                        <rect y="30.1535" x="181.9" class="a-ramp-value-2" />
-                        <rect y="30.1535" x="272.1" class="a-ramp-value-3" />
-                        <rect y="30.1535" x="361.6" class="a-ramp-value-4" />
-                        <rect y="30.1535" x="452.8" class="a-ramp-value-5" />
-                        <rect y="30.1535" x="545.2" class="a-ramp-value-6" />
+                        <rect y="30.1535" x="1.2" height="15" width="91" class="a-ramp-value-0" />
+                        <rect y="30.1535" x="92.4" height="15" width="91" class="a-ramp-value-1" />
+                        <rect y="30.1535" x="181.9" height="15" width="91" class="a-ramp-value-2" />
+                        <rect y="30.1535" x="272.1" height="15" width="91" class="a-ramp-value-3" />
+                        <rect y="30.1535" x="361.6" height="15" width="91" class="a-ramp-value-4" />
+                        <rect y="30.1535" x="452.8" height="15" width="91" class="a-ramp-value-5" />
+                        <rect y="30.1535" x="545.2" height="15" width="91" class="a-ramp-value-6" />
                     </g>
                     <text x="0.999965" y="1.75349" transform="matrix(1,0.00001,0.00002,1,0.9696,10.2465)">Delinquency rates</text>
                 </g>

--- a/cfgov/unprocessed/css/organisms/mortgage-performance-trends.less
+++ b/cfgov/unprocessed/css/organisms/mortgage-performance-trends.less
@@ -122,10 +122,10 @@
 
     .respond-to-max( @bp-sm-max, {
         text {
-            font-size: unit( 14px / @base-font-size-px, em );;
+            font-size: unit( 16px / @base-font-size-px, em );;
         }
         tspan {
-            font-size: unit( 14px / @base-font-size-px, em );;
+            font-size: unit( 16px / @base-font-size-px, em );;
         }
     } );
 

--- a/cfgov/unprocessed/js/routes/on-demand/mortgage-performance-trends.js
+++ b/cfgov/unprocessed/js/routes/on-demand/mortgage-performance-trends.js
@@ -6,9 +6,9 @@
 
 'use strict';
 
-// Enable console logging of state changes (except in IE).
-// TODO: Set to false before release.
-window.MP_DEBUG = window.navigator.userAgent.indexOf('MSIE ') === -1;
+// To aid debugging, uncomment the below line.
+// It will enable console logging of state changes (except in IE).
+// window.MP_DEBUG = window.navigator.userAgent.indexOf('MSIE ') === -1;
 
 // CFPB's charting library looks for data files on S3 by default.
 // MP uses a custom API so point our charts to it instead.
@@ -18,10 +18,3 @@ const MortgagePerformanceTrends = require( '../../organisms/MortgagePerformanceT
 
 const chart = new MortgagePerformanceTrends.Chart( { container: 'mp-line-chart-container' } );
 const map = new MortgagePerformanceTrends.Map( { container: 'mp-map-container' } );
-
-// Expose charts to aid debugging while in development.
-// TODO: Remove before release.
-window.CFPB_CHART_DEBUG = {
-  chart,
-  map
-}


### PR DESCRIPTION
@marteki IE isn't rendering the legend because it requires SVG shapes to have an explicit height and width. This fixes that.

## Removals

- The `MP_DEBUG` variable that enables logging of the state whenever it changes. It can be reenabled by uncommenting the line.

## Changes

- The SVG `rect`s now have a height/width property.
- Text in the legend is a little larger on mobile devices. IMHO it needs to be even larger but we'll have to adjust the size of the SVG's bounding box to avoid the text getting cut off so I'm leaving it at 16px for now.

## Screenshots

<img width="914" alt="screen shot 2017-10-01 at 5 27 57 pm" src="https://user-images.githubusercontent.com/1060248/31060122-7bc7646a-a6db-11e7-8d47-bf40d07f2f16.png">

## Checklist

* [ ] PR has an informative and human-readable title
* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [ ] Passes all existing automated tests
* [ ] Any *change* in functionality is tested
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated
* [ ] Reviewers requested with the [Reviewer tool](https://help.github.com/articles/about-pull-request-reviews/) :arrow_right:
