### PR TITLE
Mortgage Performance: Add logic to date dropdowns

### DIFF
--- a/cfgov/jinja2/v1/_includes/organisms/mortgage-map.html
+++ b/cfgov/jinja2/v1/_includes/organisms/mortgage-map.html
@@ -160,6 +160,20 @@
                     </div>
                 </div>
             </fieldset>
+            <div class="m-notification
+                        m-notification__visible
+                        m-notification__warning"
+                  id="mp-map-notification"
+                  style="display:none">
+                <span class="m-notification_icon cf-icon"></span>
+                <div class="m-notification_content">
+                    <div class="h4 m-notification_message">Invalid date</div>
+                    <p class="h4 m-notification_explanation">
+                      We only have data available through {{ thru_month_formatted }}.
+                      Please select a valid date.
+                    </p>
+                </div>
+            </div>
         </form>
     </div>
     <div class="o-mp-map m-full-width-text">

--- a/cfgov/jinja2/v1/_includes/organisms/mortgage-map.html
+++ b/cfgov/jinja2/v1/_includes/organisms/mortgage-map.html
@@ -146,15 +146,6 @@
                         <label class="a-label u-mb5" for="mp-map-year">Year</label>
                         <div class="a-select">
                             <select id="mp-map-year">
-                                <option value="2008">2008</option>
-                                <option value="2009">2009</option>
-                                <option value="2010">2010</option>
-                                <option value="2011">2011</option>
-                                <option value="2012">2012</option>
-                                <option value="2013">2013</option>
-                                <option value="2014">2014</option>
-                                <option value="2015">2015</option>
-                                <option value="2016">2016</option>
                             </select>
                         </div>
                     </div>

--- a/cfgov/unprocessed/js/organisms/MortgagePerformanceTrends/apps/map.js
+++ b/cfgov/unprocessed/js/organisms/MortgagePerformanceTrends/apps/map.js
@@ -28,8 +28,9 @@ class MortgagePerformanceMap {
     this.$mapTitle = document.querySelector( '#mp-map-title-status' );
     this.$mapTitleLocation = document.querySelector( '#mp-map-title-location' );
     this.$mapTitleDate = document.querySelector( '#mp-map-title-date' );
-    this.$loadingSpinner = document.querySelector( '#mp-map-loading' );
+    this.$notification = document.querySelector( '#mp-map-notification' );
     this.timespan = this.$container.getAttribute( 'data-chart-time-span' );
+    this.endDate = this.$container.getAttribute( 'data-chart-end-date' );
     this.chart = ccb.createChart( {
       el: this.$container.querySelector( '#mp-map' ),
       source: `map-data/${ this.timespan }/states/2008-01`,
@@ -39,7 +40,6 @@ class MortgagePerformanceMap {
       tooltipFormatter: this.renderTooltip()
     } );
     this.eventListeners();
-    utils.hideEl( this.$loadingSpinner );
   }
 
 }
@@ -141,6 +141,11 @@ MortgagePerformanceMap.prototype.renderChart = function( prevState, state ) {
   const prevId = prevState.geo.id;
   const currId = state.geo.id;
   let zoomLevel;
+  if ( !utils.isDateValid( state.date, this.endDate ) ) {
+    utils.showEl( this.$notification );
+    return;
+  }
+  utils.hideEl( this.$notification );
   if ( prevId && prevId !== currId ) {
     this.chart.highchart.chart.get( prevId ).select( false );
   }
@@ -207,6 +212,9 @@ MortgagePerformanceMap.prototype.renderChartForm = function( prevState, state ) 
 
 MortgagePerformanceMap.prototype.renderChartTitle = function( prevState, state ) {
   let loc = state.geo.name;
+  if ( !utils.isDateValid( state.date, this.endDate ) ) {
+    return;
+  }
   if ( !loc ) {
     loc = `${ state.geo.type } view`;
   }

--- a/cfgov/unprocessed/js/organisms/MortgagePerformanceTrends/apps/map.js
+++ b/cfgov/unprocessed/js/organisms/MortgagePerformanceTrends/apps/map.js
@@ -30,6 +30,7 @@ class MortgagePerformanceMap {
     this.$mapTitleDate = document.querySelector( '#mp-map-title-date' );
     this.$notification = document.querySelector( '#mp-map-notification' );
     this.timespan = this.$container.getAttribute( 'data-chart-time-span' );
+    this.startDate = this.$container.getAttribute( 'data-chart-start-date' );
     this.endDate = this.$container.getAttribute( 'data-chart-end-date' );
     this.chart = ccb.createChart( {
       el: this.$container.querySelector( '#mp-map' ),
@@ -40,6 +41,7 @@ class MortgagePerformanceMap {
       tooltipFormatter: this.renderTooltip()
     } );
     this.eventListeners();
+    this.renderYears();
   }
 
 }
@@ -290,7 +292,6 @@ MortgagePerformanceMap.prototype.renderMetros = function( prevState, state ) {
   } );
   fragment.appendChild( option );
   state.metros.forEach( metro => {
-    option = document.createElement( 'option' );
     option = utils.addOption( {
       document,
       value: metro.fips,
@@ -300,6 +301,28 @@ MortgagePerformanceMap.prototype.renderMetros = function( prevState, state ) {
   } );
   this.$metro.innerHTML = '';
   this.$metro.appendChild( fragment );
+};
+
+MortgagePerformanceMap.prototype.renderYears = function() {
+  const fragment = document.createDocumentFragment();
+  let startYear = utils.getYear( this.startDate );
+  const endYear = utils.getYear( this.endDate );
+  let option = utils.addOption( {
+    document,
+    value: startYear,
+    text: startYear
+  } );
+  fragment.appendChild( option );
+  while ( startYear++ < endYear ) {
+    option = utils.addOption( {
+      document,
+      value: startYear,
+      text: startYear
+    } );
+    fragment.appendChild( option );
+  }
+  this.$year.innerHTML = '';
+  this.$year.appendChild( fragment );
 };
 
 MortgagePerformanceMap.prototype.renderTooltip = function() {

--- a/cfgov/unprocessed/js/organisms/MortgagePerformanceTrends/utils.js
+++ b/cfgov/unprocessed/js/organisms/MortgagePerformanceTrends/utils.js
@@ -9,28 +9,79 @@ let counties, metros, nonMetros;
 let globalZoomLevel = 10;
 
 var utils = {
+
+  /**
+   * showEl - Un-hides a page element.
+   *
+   * @param {object} el DOM node to un-hide.
+   *
+   * @returns {object} The un-hidden DOM node.
+   */
   showEl: el => {
     el.style.display = '';
     return el;
   },
+
+  /**
+   * hideEl - Hides a page element.
+   *
+   * @param {object} el DOM node to hide.
+   *
+   * @returns {object} The hidden DOM node.
+   */
   hideEl: el => {
     el.style.display = 'none';
     return el;
   },
+
+  /**
+   * disableEl - Disables a page element. Used for form inputs.
+   *
+   * @param {object} el DOM node to disable.
+   *
+   * @returns {object} The disabled DOM node.
+   */
   disableEl: el => {
     el.disabled = true;
     return el;
   },
+
+  /**
+   * enableEl - Enables a page element. Used for form inputs.
+   *
+   * @param {object} el DOM node to enable.
+   *
+   * @returns {object} The enabled DOM node.
+   */
   enableEl: el => {
     el.disabled = false;
     return el;
   },
-  addOption: ( { document, value, text, selected = false } ) => {
+
+  /**
+   * addOption - Create select option to be injected into HTML select element.
+   *
+   * @param {object} params Param object
+   * @param {type} params.document window.document
+   * @param {string} params.value <option value="VALUE">text</option>
+   * @param {string} params.text <option value="value">TEXT</option>
+   *
+   * @returns {type} Description
+   */
+  addOption: ( { document, value, text } ) => {
     const option = document.createElement( 'option' );
     option.value = value;
     option.text = text;
     return option;
   },
+
+  /**
+   * getCountyData - XHR county metadata
+   *
+   * @param {function} cb Function called with county data.
+   *
+   * @returns {function} Function called with county data.
+   */
   getCountyData: cb => {
     if ( counties ) {
       return cb( counties );
@@ -40,6 +91,14 @@ var utils = {
       cb( data );
     } );
   },
+
+  /**
+   * getMetroData - XHR metro metadata
+   *
+   * @param {function} cb Function called with metro data.
+   *
+   * @returns {function} Function called with metro data.
+   */
   getMetroData: cb => {
     if ( metros ) {
       return cb( metros );
@@ -49,6 +108,14 @@ var utils = {
       cb( data );
     } );
   },
+
+  /**
+   * getNonMetroData - XHR non-metro metadata
+   *
+   * @param {function} cb Function called with non-metro data.
+   *
+   * @returns {function} Function called with non-metro data.
+   */
   getNonMetroData: cb => {
     if ( nonMetros ) {
       return cb( nonMetros );
@@ -58,6 +125,14 @@ var utils = {
       cb( data );
     } );
   },
+
+  /**
+   * getDate - Convert a date from YYYY-MM-DD to Month YYYY.
+   *
+   * @param {string} dateString Date in the format YYYY-MM-DD
+   *
+   * @returns {string} Date in the format Month YYYY.
+   */
   getDate: dateString => {
     var dates = dateString.split( '-' );
     if ( dates.length < 2 ) {
@@ -79,18 +154,67 @@ var utils = {
     ];
     return `${ months[parseInt( dates[1], 10 ) - 1] } ${ dates[0] }`;
   },
-  // Non-metro areas have FIPS that include "-non"
+
+  /**
+   * isNonMetro - Check if a location's FIPS code is for a non-metro area.
+   *
+   * @param {string} fips FIPS code, e.g. 52435 or 06-non.
+   *
+   * @returns {boolean} True if it's a non-metro
+   */
   isNonMetro: fips => fips.indexOf( '-non' ) > -1,
+
+  /**
+   * getZoomLevel - Calculate map's zoom level. Highchart's zooming feature
+   * takes a `howMuch` parameter to determine how much to zoom the map.
+   * Values less than 1 zooms in. 0.5 zooms in to half the current view.
+   * 2 zooms to twice the current view. If omitted, the zoom is reset.
+   * See http://api.highcharts.com/highmaps/Chart.mapZoom
+   *
+   * This function normalizes the map's zooming by keeping track of the current
+   * zoom level and calculating a new one based on the requested amount of zoom.
+   *
+   * @param {number} zoomLevel Requested zoom level from 1 to 10, with 10 being
+   * zoomed all the way out.
+   *
+   * @returns {number} Highcharts-compatible zoom level.
+   */
   getZoomLevel: zoomLevel => {
     const level = zoomLevel / globalZoomLevel;
     globalZoomLevel = zoomLevel;
     return level;
   },
+
+  /**
+   * setZoomLevel - Set global normalized zoom level. See above.
+   *
+   * @param {number} zoomLevel Global zoom level to store.
+   *
+   * @returns {number} Global zoom level.
+   */
   setZoomLevel: zoomLevel => {
     globalZoomLevel = zoomLevel;
     return zoomLevel;
   },
+
+  /**
+   * getYear - Returns the year form a date in the format YYYY-MM-DD.
+   *
+   * @param {string} date Date in format YYYY-MM-DD.
+   *
+   * @returns {string} Year as YYYY.
+   */
   getYear: date => date.split( '-' )[0],
+
+  /**
+   * isDateValid - Check if date is less than or equal to the provided end date.
+   *
+   * @param {string} currDate Date in format YYYY-MM-DD.
+   * @param {string} endDate  Date in format YYYY-MM-DD.
+   *
+   * @returns {boolean} True if date is less than or equal to the provided
+   * end date.
+   */
   isDateValid: ( currDate, endDate ) => {
     currDate = currDate.split( '-' );
     endDate = endDate.split( '-' );
@@ -98,13 +222,18 @@ var utils = {
     if ( currDate.length === 1 || endDate.length === 1 ) {
       return false;
     }
-    // Check if current date is less than or equal to the end date.
+    // Check if current year is less than or equal to the end year and
+    // then verify if current month is less than or equal to end month.
     if ( currDate[0] <= endDate[0] && currDate[1] <= endDate[1] ) {
       return true;
     }
     return false;
   },
-  // Centroid of every state on the map organized by FIPS code
+
+  /**
+   * stateCentroids - Dictionary of every state's centroid coordinates
+   * organized by state abbreviation.
+   */
   stateCentroids: {
     AL: [ 6614, -5006.5 ],
     AK: [ 357, -3476.5 ],
@@ -158,12 +287,30 @@ var utils = {
     WI: [ 5661, -8084 ],
     WY: [ 2328, -7755 ]
   },
+
+  /**
+   * thunkMiddleware - Vanilla JS implementation of redux-thunk.
+   * See: https://github.com/gaearon/redux-thunk
+   *
+   * @param {object} store The app's store.
+   *
+   * @returns {function} Dispatch function with the action provided.
+   */
   thunkMiddleware: store => next => action => {
     if ( typeof action === 'function' ) {
       return action( store.dispatch, store.getState );
     }
     return next( action );
   },
+
+  /**
+   * loggerMiddleware - Vanilla JS implementation redux-devtools.
+   * See: https://github.com/gaearon/redux-devtools
+   *
+   * @param {object} store The app's store.
+   *
+   * @returns {function} Dispatch function with the action provided.
+   */
   loggerMiddleware: store => next => action => {
     if ( !window.MP_DEBUG ) {
       return next( action );

--- a/cfgov/unprocessed/js/organisms/MortgagePerformanceTrends/utils.js
+++ b/cfgov/unprocessed/js/organisms/MortgagePerformanceTrends/utils.js
@@ -90,6 +90,19 @@ var utils = {
     globalZoomLevel = zoomLevel;
     return zoomLevel;
   },
+  isDateValid: ( currDate, endDate ) => {
+    currDate = currDate.split( '-' );
+    endDate = endDate.split( '-' );
+    // If dates are invalid, abort.
+    if ( currDate.length === 1 || endDate.length === 1 ) {
+      return false;
+    }
+    // Check if current date is less than or equal to the end date.
+    if ( currDate[0] <= endDate[0] && currDate[1] <= endDate[1] ) {
+      return true;
+    }
+    return false;
+  },
   // Centroid of every state on the map organized by FIPS code
   stateCentroids: {
     AL: [ 6614, -5006.5 ],

--- a/cfgov/unprocessed/js/organisms/MortgagePerformanceTrends/utils.js
+++ b/cfgov/unprocessed/js/organisms/MortgagePerformanceTrends/utils.js
@@ -90,6 +90,7 @@ var utils = {
     globalZoomLevel = zoomLevel;
     return zoomLevel;
   },
+  getYear: date => date.split( '-' )[0],
   isDateValid: ( currDate, endDate ) => {
     currDate = currDate.split( '-' );
     endDate = endDate.split( '-' );

--- a/test/unit_tests/organisms/MortgagePerformanceTrends/utils-spec.js
+++ b/test/unit_tests/organisms/MortgagePerformanceTrends/utils-spec.js
@@ -72,6 +72,13 @@ describe( 'Mortgage Performance utilities', () => {
     expect( utils.setZoomLevel( 234.56 ) ).to.equal( 234.56 );
   } );
 
+  it( 'should be able to parse years in date strings', () => {
+    expect( utils.getYear( '2008-01' ) ).to.equal( '2008' );
+    expect( utils.getYear( '3099-01' ) ).to.equal( '3099' );
+    expect( utils.getYear( '2012-01-01' ) ).to.equal( '2012' );
+    expect( utils.getYear( 'blah' ) ).to.equal( 'blah' );
+  } );
+
   it( 'should be able to detect valid dates', () => {
     expect( utils.isDateValid( '2008-01', '2016-10-01' ) ).to.be.true;
     expect( utils.isDateValid( '2009-11', '2016-12-01' ) ).to.be.true;

--- a/test/unit_tests/organisms/MortgagePerformanceTrends/utils-spec.js
+++ b/test/unit_tests/organisms/MortgagePerformanceTrends/utils-spec.js
@@ -72,6 +72,23 @@ describe( 'Mortgage Performance utilities', () => {
     expect( utils.setZoomLevel( 234.56 ) ).to.equal( 234.56 );
   } );
 
+  it( 'should be able to detect valid dates', () => {
+    expect( utils.isDateValid( '2008-01', '2016-10-01' ) ).to.be.true;
+    expect( utils.isDateValid( '2009-11', '2016-12-01' ) ).to.be.true;
+    expect( utils.isDateValid( '2009-11', '2016-12' ) ).to.be.true;
+    expect( utils.isDateValid( '2009-11-01', '2009-11-01' ) ).to.be.true;
+    expect( utils.isDateValid( '2009-11-01', '2009-11' ) ).to.be.true;
+    expect( utils.isDateValid( '2009-11', '2009-11' ) ).to.be.true;
+  } );
+
+  it( 'should be able to detect invalid dates', () => {
+    expect( utils.isDateValid( '2017-01', '2014-10-01' ) ).to.be.false;
+    expect( utils.isDateValid( 'foo', '2016-10-01' ) ).to.be.false;
+    expect( utils.isDateValid( '2014-10', 'bar' ) ).to.be.false;
+    expect( utils.isDateValid( 'foo', 'bar' ) ).to.be.false;
+    expect( utils.isDateValid( '2011-01-01', '2010-10-01' ) ).to.be.false;
+  } );
+
   it( 'should parse date strings', () => {
     let date = utils.getDate( '2009-01-01' );
     expect( date ).to.equal( 'January 2009' );


### PR DESCRIPTION
Displays a message to the user if they've selected an invalid date. See https://GHE/CFGOV/mortgage-performance/issues/185.

@ajbush check out the screenshot below. I used the two line "[explanation](https://cfpb.github.io/capital-framework/components/cf-notifications/#explanation)" version that has a title and then text explaining the situation. What do you think? Should I just keep it at one line?

## Additions

- `isDateValid` function to check if the user-selected date is less than or equal to the date we have the most recent data for. Used to show/hide the date error message to the user.
- [cf-notification](https://cfpb.github.io/capital-framework/components/cf-notifications/) with a message stating the selected date is invalid.
- JSDoc comments to all utility functions.

## Removals

- Removed all the hardcoded years. They're now loaded on page load based on data passed to the template.

## Screenshots

<img width="758" alt="screen shot 2017-10-02 at 2 21 34 pm" src="https://user-images.githubusercontent.com/1060248/31092627-0a3775f4-a77d-11e7-9d7b-a5815ecc6032.png">

## Notes

-

## Todos

-

## Checklist

* [ ] PR has an informative and human-readable title
* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [ ] Passes all existing automated tests
* [ ] Any *change* in functionality is tested
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated
* [ ] Reviewers requested with the [Reviewer tool](https://help.github.com/articles/about-pull-request-reviews/) :arrow_right:
