### PR TITLE
Update CR links

### DIFF
--- a/cfgov/jinja2/v1/es/presentar-una-queja/index.html
+++ b/cfgov/jinja2/v1/es/presentar-una-queja/index.html
@@ -53,7 +53,7 @@
 
 				<img class="icon-80 alignnone" src="{{ static('nemo/_/img/complaintstep1.png') }}" alt="">
 				<h2><span class="circle-text">1</span> Presentación de la queja</h2>
-				<p>Usted presenta una queja sobre un problema que tenga con una empresa acerca de un producto o servicio financiero de consumo. Usted recibirá actualizaciones por correo electrónico y <a href="https://help.consumerfinance.gov/app/utils/login_form/" hreflang="en-US">podrá entrar al sistema</a> <sub><i>página en inglés</i></sub> para darle seguimiento al estado de su queja.</p>
+				<p>Usted presenta una queja sobre un problema que tenga con una empresa acerca de un producto o servicio financiero de consumo. Usted recibirá actualizaciones por correo electrónico y <a href="https://portal.consumerfinance.gov/consumer/s/" hreflang="en-US">podrá entrar al sistema</a> <sub><i>página en inglés</i></sub> para darle seguimiento al estado de su queja.</p>
 
 			</div>
 			<div class="full-bleed full-bleed-padded complaint-step">

--- a/cfgov/legacy/templates/students/index.html
+++ b/cfgov/legacy/templates/students/index.html
@@ -34,7 +34,7 @@
     <h3>Helping borrowers understand their repayment options</h3>
     <p>Thank you for submitting your feedback on our Payback Playbook, which may help millions of student loan borrowers better understand their available repayment options. Check out the <a href="https://www.regulations.gov/#!docketBrowser;rpp=25;po=0;dct=PS;D=CFPB-2016-0018">comments</a> we received, and make sure to keep an eye out for updates on our Payback Playbook in the coming months!</p>
     <p><a href="/payback-playbook/">Learn more about how the Payback Playbook can help you better manage your student debt</a></p>
-    <p>If you are having trouble with your student loan servicer (the company that sends you a bill each month), including problems getting information on ways to make your monthly payment more affordable, you can <a href="https://help.consumerfinance.gov/app/studentloan/ask">submit a complaint</a>.</p>
+    <p>If you are having trouble with your student loan servicer (the company that sends you a bill each month), including problems getting information on ways to make your monthly payment more affordable, you can <a href="https://www.consumerfinance.gov/complaint/">submit a complaint</a>.</p>
     <h3>Inquiry into student loan servicing</h3>
     <p>In response to our public inquiry into student loan servicing practices, we received over 30,000 comments from the public, highlighting the costly surprises and runarounds some borrowers face when dealing with their servicers. We documented these widespread servicing failures reported by borrowers in our recent report, <a href="https://www.consumerfinance.gov/data-research/research-reports/student-loan-servicing/">Student Loan Servicing</a>.</p>
     <p>We also joined the Department of Education and the Department of the Treasury to issue a series of joint principles that offers a roadmap to <a href="https://s3.amazonaws.com/files.consumerfinance.gov/f/201509_cfpb_treasury_education-joint-statement-of-principles-on-student-loan-servicing.pdf">strengthen the student loan servicing market for all borrowers</a>.</p>
@@ -52,7 +52,7 @@
         <div class="col">
             <h3>Submit a student loan complaint</h3>
             <p>We’ll forward your issue to the company, give you a tracking number, and keep you updated on the status of your complaint.</p>
-            <p><a class="buttonish" href="https://help.consumerfinance.gov/app/studentloan/ask">Submit now</a></p>
+            <p><a class="buttonish" href="https://www.consumerfinance.gov/complaint/">Submit now</a></p>
         </div>
     </div>
     <hr />

--- a/requirements/optional-private.txt
+++ b/requirements/optional-private.txt
@@ -2,7 +2,7 @@
 # configure git with:
 # git config --global url.https://<private hostname>/.insteadOf https://private.repo/
 
-git+https://private.repo/CFPB/agreement_database.git@2.2.8#egg=agreement-database
+git+https://private.repo/CFPB/agreement_database.git@2.2.9#egg=agreement-database
 git+https://private.repo/CFPB/cfgov-selfregistration.git@1.3.1#egg=selfregistration
 git+https://private.repo/CFPB/django-college-cost-comparison.git@v1.4.0#egg=comparisontool
 git+https://private.repo/eregs/ip.git@1.1.2#egg=eregsip


### PR DESCRIPTION
## Changes

- 'help.consumerfinance.gov' doesn't exist anymore-- this PR fixes a few hard-coded links.


## Checklist

* [ ] PR has an informative and human-readable title
* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [ ] Passes all existing automated tests
* [ ] Any *change* in functionality is tested
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated
* [ ] Reviewers requested with the [Reviewer tool](https://help.github.com/articles/about-pull-request-reviews/) :arrow_right:
