### PR TITLE
Remove the calendar options from the filterable list

### DIFF
--- a/cfgov/jinja2/v1/_includes/organisms/filterable-list-controls.html
+++ b/cfgov/jinja2/v1/_includes/organisms/filterable-list-controls.html
@@ -64,24 +64,14 @@
                 <fieldset class="o-form_fieldset">
                     <legend class="a-label a-label__heading"
                             for="categories">
-                        {% if 'leadership-calendar' in controls.categories.page_type %}
-                            Calendars
-                            </legend>
-                            <ul class="m-list m-list__unstyled">
-                            {% for slug, name in choices_for_page_type(controls.categories.page_type) %}
-                                {{ _filter_selectable('radio', index, category_label(slug), 'categories_' ~ slug, 'categories', slug) }}
-                            {% endfor %}
-                            </ul>
-                        {% else %}
-                            Category
-                            </legend>
-                            <ul class="m-list m-list__unstyled">
-                            {% for slug, name in choices_for_page_type(controls.categories.page_type) %}
-                                {{ _filter_selectable('checkbox', index, category_label(slug), 'categories_' ~ slug, 'categories', slug) }}
-                            {% endfor %}
-                            </ul>
-                        {% endif %}
-                  </fieldset>
+                        Category
+                    </legend>
+                    <ul class="m-list m-list__unstyled">
+                    {% for slug, name in choices_for_page_type(controls.categories.page_type) %}
+                        {{ _filter_selectable('checkbox', index, category_label(slug), 'categories_' ~ slug, 'categories', slug) }}
+                    {% endfor %}
+                    </ul>
+                </fieldset>
             </div>
         </div>
     {% endif %}


### PR DESCRIPTION
The calendar is no longer filtered, this condition isn’t necessary

## Removals

- Removed the calendar condition and it's related options.

## Testing

1. Navigate to http://localhost:8000/about-us/the-bureau/leadership-calendar/ and observe the lack of filtering

## Checklist

* [x] PR has an informative and human-readable title
* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [x] Passes all existing automated tests
* [x] Any *change* in functionality is tested
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices
* [x] Project documentation has been updated
* [x] Reviewers requested with the [Reviewer tool](https://help.github.com/articles/about-pull-request-reviews/) :arrow_right:
