### PR TITLE
Removing video player code from common.js

### DIFF
--- a/cfgov/unprocessed/js/routes/common.js
+++ b/cfgov/unprocessed/js/routes/common.js
@@ -7,8 +7,6 @@
 
 // Global modules.
 require( '../modules/focus-target' ).init();
-require( '../modules/UStreamPlayer' ).init( '.video-player__ustream' );
-require( '../modules/YoutubePlayer' ).init( '.video-player__youtube' );
 
 // GLOBAL ATOMIC ELEMENTS.
 // Organisms.

--- a/cfgov/unprocessed/js/routes/on-demand/video-player.js
+++ b/cfgov/unprocessed/js/routes/on-demand/video-player.js
@@ -1,0 +1,7 @@
+/* ==========================================================================
+   Scripts for Video Player module.
+   ========================================================================== */
+
+'use strict';
+
+require( '../../modules/YoutubePlayer' ).init( '.video-player__youtube' );

--- a/cfgov/v1/atomic_elements/molecules.py
+++ b/cfgov/v1/atomic_elements/molecules.py
@@ -213,6 +213,9 @@ class FeaturedContent(blocks.StructBlock):
         label = 'Featured Content'
         classname = 'block__flush'
 
+    class Media:
+        js = ['video-player.js']
+
 
 class CallToAction(blocks.StructBlock):
     slug_text = blocks.CharBlock(required=False)

--- a/cfgov/v1/atomic_elements/organisms.py
+++ b/cfgov/v1/atomic_elements/organisms.py
@@ -797,6 +797,9 @@ class VideoPlayer(blocks.StructBlock):
         icon = 'media'
         template = '_includes/organisms/video-player.html'
 
+    class Media:
+        js = ['video-player.js']
+
 
 class HTMLBlock(blocks.StructBlock):
     html_url = blocks.RegexBlock(

--- a/cfgov/v1/models/learn_page.py
+++ b/cfgov/v1/models/learn_page.py
@@ -279,6 +279,9 @@ class EventPage(AbstractFilterPage):
 
     template = 'events/event.html'
 
+    def add_page_js(self, js):
+        js['template'] = ['video-player.js']
+
     def location_image_url(self, scale='2', size='276x155', zoom='12'):
         center = 'Washington, DC'
         if self.venue_city:


### PR DESCRIPTION
All pages which contain the video-player have been converted to Wagtail. This PR removes the video player from commons.js. It will result in the common.js bundle, which is on every page, being 5kb smaller. I have also removed the Ustream code from the bundle because it's no longer used. I'll remove the Ustream related code in a subsequent PR. 

## Changes

- Modified files to remove vidoe player.js from commons.js. 

## Testing

1. Run `gulp build`
2. Visit `http://localhost:8000/about-us/events/archive-past-events/public-event-about-debt-collection-washington-dc/` and ensure the video player works.
3. Visit `http://localhost:8000/about-us/the-bureau/` and ensure that the video player works.
4. Visit `http://localhost:8000/about-us/careers/application-process/` and ensure the video player works. 

## Checklist

* [ ] PR has an informative and human-readable title
* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [ ] Passes all existing automated tests
* [ ] Any *change* in functionality is tested
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated
* [ ] Reviewers requested with the [Reviewer tool](https://help.github.com/articles/about-pull-request-reviews/) :arrow_right:
