### PR TITLE
Fix for gulp copy and cleaning up some other gulp tasks

### DIFF
--- a/gulp/tasks/copy.js
+++ b/gulp/tasks/copy.js
@@ -3,7 +3,6 @@
 const gulp = require( 'gulp' );
 const gulpChanged = require( 'gulp-changed' );
 const gulpReplace = require( 'gulp-replace' );
-const gulpUtil = require( 'gulp-util' );
 const configCopy = require( '../config' ).copy;
 const handleErrors = require( '../utils/handle-errors' );
 const browserSync = require( 'browser-sync' );
@@ -63,9 +62,9 @@ gulp.task( 'copy:vendorimg', () => {
 gulp.task( 'copy:timelinejs', () => {
   const timelinejs = configCopy.timelinejs;
   return _genericCopy( timelinejs.src, timelinejs.dest )
-    .pipe( gulpUtil.buffer( () => {
-      del.sync( timelinejs.dest + '/css/themes' );
-    } ) );
+    .on( 'end', () => {
+      del( timelinejs.dest + '/css/themes' );
+    } );
 } );
 
 gulp.task( 'copy:lightbox2', () => {

--- a/gulp/tasks/images.js
+++ b/gulp/tasks/images.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const browserSync = require( 'browser-sync' );
 const configImages = require( '../config' ).images;
 const gulp = require( 'gulp' );
 const gulpChanged = require( 'gulp-changed' );
@@ -21,8 +20,5 @@ gulp.task( 'images', () => {
       imageminSvgo()
     ] ) )
     .on( 'error', handleErrors )
-    .pipe( gulp.dest( configImages.dest ) )
-    .pipe( browserSync.reload( {
-      stream: true
-    } ) );
+    .pipe( gulp.dest( configImages.dest ) );
 } );


### PR DESCRIPTION
Fix for gulp copy and cleaning up some other gulp tasks

## Changes

- Modified `gulp/tasks/images.js` to fix issue with gulp copy process ending before all the images were copied. Removed `browserSync` which was causing async issues. I'll look into closer.

- Modified `gulp/tasks/copy.js` to simplify the code. 

## Testing

1. Run `gulp clean && gulp build` and verify your existence.


## Checklist

* [ ] PR has an informative and human-readable title
* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [ ] Passes all existing automated tests
* [ ] Any *change* in functionality is tested
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated
* [ ] Reviewers requested with the [Reviewer tool](https://help.github.com/articles/about-pull-request-reviews/) :arrow_right:
