### PR TITLE
Remove u-hidden class

### DIFF
--- a/cfgov/unprocessed/css/enhancements/utilities.less
+++ b/cfgov/unprocessed/css/enhancements/utilities.less
@@ -127,27 +127,6 @@
 }
 
 /* topdoc
-  name: Hidden
-  family: cf-core
-  patterns:
-    - name: Utility class
-      markup: |
-        <span class="u-hidden">Not shown</span>
-      codenotes:
-        - .u-hidden;
-      notes:
-        - "Use this class to hide something from everything.
-           Useful if you want to show it using JS after
-           checking for browser-support."
-  tags:
-    - cf-core
-*/
-
-.u-hidden {
-    display: none;
-}
-
-/* topdoc
   name: Hidden Overflow
   family: cf-core
   patterns:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1743,14 +1743,14 @@
       "resolved": "https://registry.npmjs.org/cf-buttons/-/cf-buttons-4.5.1.tgz",
       "integrity": "sha512-TKiCCDec5c7oyoqBRizJceI1lWPotQlcDS/pM1r3Xs+ZZthCF2Kt2EKJpmy+S1JCDI6jS5xnlYoBikfj+8ER5g==",
       "requires": {
-        "cf-core": "4.4.2",
+        "cf-core": "4.5.0",
         "cf-icons": "4.2.1"
       }
     },
     "cf-core": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/cf-core/-/cf-core-4.4.2.tgz",
-      "integrity": "sha512-SbjEiyoDELT/kIYHItbX2FVZ5kTBF7lsySCmKXyWaoZXJI8+8waZVQnvFTKOwLsJvg7XbX0HkzPcHxpg9otEOQ==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/cf-core/-/cf-core-4.5.0.tgz",
+      "integrity": "sha512-MUdo0pq9r5TGU1TxzxJaw8hXBLdDIHWXRMGltuaAv5CF5Zvw/aY5d0PQDxvhMHR88thtqqHb/i83qP4yMqI9yA==",
       "requires": {
         "normalize-css": "2.3.1",
         "normalize-legacy-addon": "0.1.0"
@@ -1762,7 +1762,7 @@
       "integrity": "sha512-8iXsGRm0phxbKzSIMrV3ALvax7b2TYGZDzfRW0jX/KoxFiuj0KYRrT9f44Y4ropgePvokF6PuqpxDL1SP1hG+w==",
       "requires": {
         "atomic-component": "1.3.2",
-        "cf-core": "4.4.2",
+        "cf-core": "4.5.0",
         "cf-icons": "4.2.1",
         "classlist-polyfill": "1.0.3"
       }
@@ -1773,7 +1773,7 @@
       "integrity": "sha512-Qo/DNWerQJhSKL3iV0jgEwnnCn0ZFACvZebtiK7HXGMIeZRGfy/AFo7NNEeVcmYGaIYkVbCai3CL0SPz8nmynA==",
       "requires": {
         "cf-buttons": "4.5.1",
-        "cf-core": "4.4.2",
+        "cf-core": "4.5.0",
         "cf-grid": "4.2.2",
         "cf-icons": "4.2.1"
       }
@@ -1792,7 +1792,7 @@
       "resolved": "https://registry.npmjs.org/cf-icons/-/cf-icons-4.2.1.tgz",
       "integrity": "sha512-pmYD9WuHPkI6gjqbD4sEWcciglQTXn7pV9MjYsOwIHx9tVcP10So1o1VHSdYffBAPbRicW24qEfQUN71DL9nEQ==",
       "requires": {
-        "cf-core": "4.4.2"
+        "cf-core": "4.5.0"
       }
     },
     "cf-layout": {
@@ -1800,7 +1800,7 @@
       "resolved": "https://registry.npmjs.org/cf-layout/-/cf-layout-4.5.1.tgz",
       "integrity": "sha512-8RByl3aYIzzyEN/lXjKWugm5F0aqTCK+84U3OUaz8SHb+8WMHiqdIUnYnCa4aYQJHDhCaH3gQTysuJV72B0EoQ==",
       "requires": {
-        "cf-core": "4.4.2",
+        "cf-core": "4.5.0",
         "cf-grid": "4.2.2"
       }
     },
@@ -1809,7 +1809,7 @@
       "resolved": "https://registry.npmjs.org/cf-notifications/-/cf-notifications-1.0.2.tgz",
       "integrity": "sha512-XECEXwToP0NSkoMwYMteRy+R9NQLSzP38n/G0B3F94fiAGUVuPX8QsjHQW0m+2wP6xQmsdfQAdICNCJG94R/Lg==",
       "requires": {
-        "cf-core": "4.4.2",
+        "cf-core": "4.5.0",
         "cf-icons": "4.2.1"
       }
     },
@@ -1819,7 +1819,7 @@
       "integrity": "sha512-ueq4Z22/70escIX6vDNjIS3BgMaoNhUpnp4yizjeiE1Ah6UF8NocyJ2qG2XJpHSMEqHAzLPaPHjKPhBcnufnmQ==",
       "requires": {
         "cf-buttons": "4.5.1",
-        "cf-core": "4.4.2",
+        "cf-core": "4.5.0",
         "cf-icons": "4.2.1"
       }
     },
@@ -1829,7 +1829,7 @@
       "integrity": "sha512-K0TXwFOal72pxCnOhy+8GyBVm2hIpVbi3NueMREUzDO6ivXfk/byUuzZk4cpDxPLqkPbkoIMs5JKjeaSR/KiEg==",
       "requires": {
         "atomic-component": "1.3.2",
-        "cf-core": "4.4.2"
+        "cf-core": "4.5.0"
       }
     },
     "cf-typography": {
@@ -1837,7 +1837,7 @@
       "resolved": "https://registry.npmjs.org/cf-typography/-/cf-typography-4.3.0.tgz",
       "integrity": "sha512-4mAINE6bnFu9SlNIk455ahgW9HCT2CYtIjOY75xAmPzjtbo6ln1RUIGdpB5XU0RGGJOAq7YE9nFSnM8ikLTqeA==",
       "requires": {
-        "cf-core": "4.4.2",
+        "cf-core": "4.5.0",
         "cf-icons": "4.2.1"
       }
     },
@@ -1847,7 +1847,7 @@
       "integrity": "sha512-iAm961QpLjpjX73ulOjzyYyclAIzQnvtzgl+/9D8Y1wgv/Qqz5nsc4fAy4nMLu1Sc7MTpRipsStt64ss2nnrmA==",
       "requires": {
         "babel-preset-env": "1.6.0",
-        "cf-core": "4.4.2",
+        "cf-core": "4.5.0",
         "cf-grid": "4.2.2",
         "cf-layout": "4.5.1",
         "cf-typography": "4.3.0",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "banner-footer-webpack-plugin": "git://github.com/dtothefp/banner-footer-webpack-plugin.git",
     "browser-sync": "2.18.13",
     "cf-buttons": "4.5.1",
-    "cf-core": "4.4.2",
+    "cf-core": "4.5.0",
     "cf-expandables": "4.1.5",
     "cf-forms": "4.4.1",
     "cf-grid": "4.2.2",


### PR DESCRIPTION
## Removals

- Removes `u-hidden` utility class that has been added to Capital Framework.

## Changes

- Bumps to latest `cf-core` version (`4.5.0`).

## Testing

1. run `npm update cf-core`
1. `gulp build` should pass.
