### PR TITLE
Updated codecov settings for missing base commit

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -11,9 +11,11 @@ coverage:
       frontend:
         threshold: 0.02%
         flags: frontend
+        if_not_found: success  # no commit found? still set a success
       backend:
         threshold: 0.02%
         flags: backend
+        if_not_found: success  # no commit found? still set a success
     patch:
       default:
         target: 100%


### PR DESCRIPTION
Codecov keeps failing because of missing base branches to compare against. Supposedly this should fix it based on the very end of this thread https://github.com/SBoudrias/gulp-istanbul

## Additions

- Codecov settings for missing base commit

## Testing

1. ¯\_(ツ)_/¯ 

## Checklist

* [ ] PR has an informative and human-readable title
* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [ ] Passes all existing automated tests
* [ ] Any *change* in functionality is tested
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated
* [ ] Reviewers requested with the [Reviewer tool](https://help.github.com/articles/about-pull-request-reviews/) :arrow_right:
