### PR TITLE
Tell travis to build only master when building branches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,5 +28,9 @@ env:
     - RUNTEST=backend
     - RUNTEST=acceptance
 
+branches:
+  only: 
+    - master
+
 script:
   - ./run_travis.sh


### PR DESCRIPTION
This PR changes our Travis config to add a whitelist for branches that we want to build when they're updated. This should enable us to turn on Travis for branch updates and it will only build updates to master. Hopefully this will solve our problem with missing base commits for codecov because Travis will build and submit coverage for each merge commit to master.

I don't really think we can test this without merging this change though, so I'd request just a sanity check.


## Todos

- Enable branch update builds in Travis once this PR is merged (otherwise Travis will build feature/PR branches twice)

## Checklist

* [ ] PR has an informative and human-readable title
* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [ ] Passes all existing automated tests
* [ ] Any *change* in functionality is tested
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated
* [ ] Reviewers requested with the [Reviewer tool](https://help.github.com/articles/about-pull-request-reviews/) :arrow_right:
