### PR TITLE
wellbeing: Send Analytics event from questionnaire submit button

### DIFF
--- a/cfgov/unprocessed/js/apps/financial-well-being/fwb-questions.js
+++ b/cfgov/unprocessed/js/apps/financial-well-being/fwb-questions.js
@@ -72,6 +72,7 @@ function init() {
     submitDom.title = 'Get your score';
     submitDom.disabled = false;
     submitDom.removeEventListener( 'click', handleDisabledSubmit );
+    submitDom.addEventListener( 'click', evt => handleAnalytics( evt.target ) );
   }
 
 
@@ -102,14 +103,15 @@ function init() {
   }
 
   /**
-   * Determines the state of Analytics and either passes the data-sets
-   * or waits for Analytics to report readiness
-   * @param {HTMLNode} input - A DOM element
+   * Grabs analytics event data from the passed element's data attributes.
+   * Determines the state of the Analytics module and either passes the data
+   * or waits for Analytics to report readiness, then passes the data.
+   * @param {HTMLNode} el - A DOM element
    */
-  function handleRadioAnalytics( input ) {
-    const action = input.getAttribute( 'data-gtm-action' );
-    const label = input.getAttribute( 'data-gtm-label' );
-    const category = input.getAttribute( 'data-gtm-category' );
+  function handleAnalytics( el ) {
+    const action = el.getAttribute( 'data-gtm-action' );
+    const label = el.getAttribute( 'data-gtm-label' );
+    const category = el.getAttribute( 'data-gtm-category' );
 
     if ( Analytics.tagManagerIsLoaded ) {
       sendEvent( action, label, category );
@@ -128,7 +130,7 @@ function init() {
         const input = event.target;
 
         handleRadio( input );
-        handleRadioAnalytics( input );
+        handleAnalytics( input );
       } );
     } );
   }

--- a/cfgov/unprocessed/js/apps/financial-well-being/fwb-results.js
+++ b/cfgov/unprocessed/js/apps/financial-well-being/fwb-results.js
@@ -67,14 +67,15 @@ function init() {
   }
 
   /**
-   * Determines the state of Analytics and either passes the data-sets
-   * or waits for Analytics to report readiness
-   * @param {HTMLNode} input - A dom element
+   * Grabs analytics event data from the passed element's data attributes.
+   * Determines the state of the Analytics module and either passes the data
+   * or waits for Analytics to report readiness, then passes the data.
+   * @param {HTMLNode} el - A dom element
    */
-  function handleButtonAnalytics( input ) {
-    const action = input.getAttribute( 'data-gtm-action' );
-    const label = input.getAttribute( 'data-gtm-label' );
-    const category = input.getAttribute( 'data-gtm-category' );
+  function handleAnalytics( el ) {
+    const action = el.getAttribute( 'data-gtm-action' );
+    const label = el.getAttribute( 'data-gtm-label' );
+    const category = el.getAttribute( 'data-gtm-category' );
 
     if ( Analytics.tagManagerIsLoaded ) {
       sendEvent( action, label, category );
@@ -93,7 +94,7 @@ function init() {
         const input = event.target;
 
         switchComparisons( input.getAttribute( 'data-compare-by' ) );
-        handleButtonAnalytics( input );
+        handleAnalytics( input );
       } );
     } );
   }

--- a/test/unit_tests/apps/financial-well-being/fwb-questions.js
+++ b/test/unit_tests/apps/financial-well-being/fwb-questions.js
@@ -9,10 +9,17 @@ let fwbQuestions;
 let sandbox;
 let submitBtnDom;
 let radioButtonsDom;
-const dataLayerEvent = {
+const dataLayerEventRadio = {
   event: 'Financial Well-Being Tool Interaction',
   action: 'Questionnaire Radio Button Clicked',
   label: 'I could handle a major unexpected expense',
+  eventCallback: undefined, // eslint-disable-line  no-undefined
+  eventTimeout: 500
+};
+const dataLayerEventSubmit = {
+  event: 'Financial Well-Being Tool Interaction',
+  action: 'Questionnaire Submitted',
+  label: 'Get my score',
   eventCallback: undefined, // eslint-disable-line  no-undefined
   eventTimeout: 500
 };
@@ -203,6 +210,14 @@ describe( 'fwb-questions', () => {
        'when a radio button is clicked', () => {
     initFwbQuestions();
     triggerClickEvent( radioButtonsDom[0] );
-    expect( window.dataLayer[0] ).to.deep.equal( dataLayerEvent );
+    expect( window.dataLayer[0] ).to.deep.equal( dataLayerEventRadio );
+  } );
+
+  it( 'should send the correct analytics ' +
+       'when the submit button is clicked', () => {
+    fillOutForm();
+    initFwbQuestions();
+    triggerClickEvent( submitBtnDom );
+    expect( window.dataLayer[0] ).to.deep.equal( dataLayerEventSubmit );
   } );
 } );


### PR DESCRIPTION
I, uh, forgot to add the `sendEvent` call from the questionnaire submit button 😳 

## Additions

- Event listener on the "Get your score" button to fire an Analytics event
- A test for said event

## Changes

- Generalizes the `handleRadioAnalytics` and `handleButtonAnalytics` to work generically for any passed element with the necessary data attributes.

## Testing

1. Pull branch
2. `gulp test:unit` should pass

## Notes

- We want to get this fix on prod pretty quickly, but advice is welcome for how to use a single `handleAnalytics` function, rather than the duplicate code that now exists in the two FWB JS files. Perhaps a new method in the `Analytics` module?

## Checklist

* [x] PR has an informative and human-readable title
* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [x] Passes all existing automated tests
* [x] Any *change* in functionality is tested
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices
* [x] Project documentation has been updated
* [x] Reviewers requested with the [Reviewer tool](https://help.github.com/articles/about-pull-request-reviews/) :arrow_right:
