### PR TITLE
Ask CFPB: prevent tag search from finding non-live pages

### DIFF
--- a/cfgov/ask_cfpb/models/pages.py
+++ b/cfgov/ask_cfpb/models/pages.py
@@ -449,6 +449,7 @@ class TagResultsPage(RoutablePageMixin, AnswerResultsPage):
                  a.question_es,
                  Truncator(a.answer_es).words(40, truncate=' ...'))
                 for a in tag_dict['tag_map'][tag]
+                if a.answer_pages.filter(language='es', live=True)
             ]
         else:
             self.answers = [
@@ -456,6 +457,7 @@ class TagResultsPage(RoutablePageMixin, AnswerResultsPage):
                  a.question,
                  Truncator(a.answer).words(40, truncate=' ...'))
                 for a in tag_dict['tag_map'][tag]
+                if a.answer_pages.filter(language='en', live=True)
             ]
         paginator = Paginator(self.answers, 20)
         page_number = validate_page_number(request, paginator)


### PR DESCRIPTION
Our lists of links that 404 included links on some Spanish Ask CFPB tag-results pages.
Tags are applied to Answers, not pages (who came up with *that* idea?),
and the tag filters were not ensuring that found pages were live.

Adding the `live` test should knock off at least a few 404 links.

#### Examples
- The first inked answer on the Spanish SCRA tag results page.
    - https://www.consumerfinance.gov/es/obtener-respuestas/buscar-por-etiqueta/SCRA/
- The fifth link on the HECM tag page (¿Mi pareja ...)
    - https://www.consumerfinance.gov/es/obtener-respuestas/buscar-por-etiqueta/HECM/



