### PR TITLE
Set Mortgage Performance map dropdowns to most recent date available

### DIFF
--- a/cfgov/jinja2/v1/_includes/organisms/mortgage-map.html
+++ b/cfgov/jinja2/v1/_includes/organisms/mortgage-map.html
@@ -168,7 +168,7 @@
         </form>
     </div>
     <div class="o-mp-map m-full-width-text">
-        <h3 id="mp-map-title">Percentage of mortgages {% if time_frame == '90' %} at least {% endif %} {{ time_frame }} days delinquent:<br /><span id="mp-map-title-location">state view</span> for <span id="mp-map-title-date"><strong>January 2008</strong></span></h3>
+        <h3 id="mp-map-title">Percentage of mortgages {% if time_frame == '90' %} at least {% endif %} {{ time_frame }} days delinquent:<br /><span id="mp-map-title-location">state view</span> for <span id="mp-map-title-date"><strong>{{ thru_month_formatted }}</strong></span></h3>
         <div id="mp-map">
             {{ value.description }}
         </div>

--- a/cfgov/unprocessed/js/organisms/MortgagePerformanceTrends/apps/map.js
+++ b/cfgov/unprocessed/js/organisms/MortgagePerformanceTrends/apps/map.js
@@ -32,9 +32,11 @@ class MortgagePerformanceMap {
     this.timespan = this.$container.getAttribute( 'data-chart-time-span' );
     this.startDate = this.$container.getAttribute( 'data-chart-start-date' );
     this.endDate = this.$container.getAttribute( 'data-chart-end-date' );
+    this.endMonth = utils.getMonth( this.endDate );
+    this.endYear = utils.getYear( this.endDate );
     this.chart = ccb.createChart( {
       el: this.$container.querySelector( '#mp-map' ),
-      source: `map-data/${ this.timespan }/states/2008-01`,
+      source: `map-data/${ this.timespan }/states/${ this.endYear }-${ this.endMonth }`,
       type: 'geo-map',
       color: this.$container.getAttribute( 'data-chart-color' ),
       metadata: 'states',
@@ -42,6 +44,7 @@ class MortgagePerformanceMap {
     } );
     this.eventListeners();
     this.renderYears();
+    this.setDate();
   }
 
 }
@@ -299,6 +302,13 @@ MortgagePerformanceMap.prototype.renderMetros = function( prevState, state ) {
   } );
   this.$metro.innerHTML = '';
   this.$metro.appendChild( fragment );
+};
+
+MortgagePerformanceMap.prototype.setDate = function() {
+  const month = this.$month.querySelector( `option[value="${ this.endMonth }"]` );
+  const year = this.$year.querySelector( `option[value="${ this.endYear }"]` );
+  month.setAttribute( 'selected', 'selected' );
+  year.setAttribute( 'selected', 'selected' );
 };
 
 MortgagePerformanceMap.prototype.renderYears = function() {

--- a/cfgov/unprocessed/js/organisms/MortgagePerformanceTrends/apps/map.js
+++ b/cfgov/unprocessed/js/organisms/MortgagePerformanceTrends/apps/map.js
@@ -5,8 +5,6 @@ const actions = require( '../actions/map' );
 const Store = require( '../stores/map' );
 const utils = require( '../utils' );
 
-const store = new Store( [ utils.thunkMiddleware, utils.loggerMiddleware ] );
-
 const _plurals = {
   state: 'states',
   metro: 'metros',
@@ -34,9 +32,14 @@ class MortgagePerformanceMap {
     this.endDate = this.$container.getAttribute( 'data-chart-end-date' );
     this.endMonth = utils.getMonth( this.endDate );
     this.endYear = utils.getYear( this.endDate );
+    const date = `${ this.endYear }-${ this.endMonth }`;
+    this.store = new Store( {
+      date,
+      middleware: [ utils.thunkMiddleware, utils.loggerMiddleware ]
+    } );
     this.chart = ccb.createChart( {
       el: this.$container.querySelector( '#mp-map' ),
-      source: `map-data/${ this.timespan }/states/${ this.endYear }-${ this.endMonth }`,
+      source: `map-data/${ this.timespan }/states/${ date }`,
       type: 'geo-map',
       color: this.$container.getAttribute( 'data-chart-color' ),
       metadata: 'states',
@@ -51,11 +54,11 @@ class MortgagePerformanceMap {
 
 MortgagePerformanceMap.prototype.eventListeners = function() {
   this.$form.addEventListener( 'change', this.onChange.bind( this ) );
-  store.subscribe( this.renderChart.bind( this ) );
-  store.subscribe( this.renderChartTitle.bind( this ) );
-  store.subscribe( this.renderChartForm.bind( this ) );
-  store.subscribe( this.renderCounties.bind( this ) );
-  store.subscribe( this.renderMetros.bind( this ) );
+  this.store.subscribe( this.renderChart.bind( this ) );
+  this.store.subscribe( this.renderChartTitle.bind( this ) );
+  this.store.subscribe( this.renderChartForm.bind( this ) );
+  this.store.subscribe( this.renderCounties.bind( this ) );
+  this.store.subscribe( this.renderMetros.bind( this ) );
 };
 
 MortgagePerformanceMap.prototype.onClick = function( event ) {
@@ -80,11 +83,11 @@ MortgagePerformanceMap.prototype.onChange = function( event ) {
       action = actions.updateChart( geoId, geoName, geoType );
       // If a state has been pre-selected, populate the metros dropdown
       if ( abbr && geoType === 'metro' ) {
-        store.dispatch( actions.fetchMetros( abbr ) );
+        this.store.dispatch( actions.fetchMetros( abbr ) );
       }
       // If a state has been pre-selected, populate the counties dropdown
       if ( abbr && geoType === 'county' ) {
-        store.dispatch( actions.fetchCounties( abbr ) );
+        this.store.dispatch( actions.fetchCounties( abbr ) );
       }
       break;
     case 'mp-map-state':
@@ -134,7 +137,7 @@ MortgagePerformanceMap.prototype.onChange = function( event ) {
       action = actions.clearGeo();
   }
 
-  return store.dispatch( action );
+  return this.store.dispatch( action );
 
 };
 
@@ -176,14 +179,14 @@ MortgagePerformanceMap.prototype.renderChart = function( prevState, state ) {
     this.$county.innerHTML = '';
   }
   if ( prevState.date !== state.date || prevType !== currType ) {
-    // store.dispatch( actions.startLoading() );
+    // this.store.dispatch( actions.startLoading() );
     this.chart.highchart.chart.showLoading();
     this.chart.update( {
       source: `map-data/${ this.timespan }/${ _plurals[currType] }/${ state.date }`,
       metadata: _plurals[currType],
       tooltipFormatter: this.renderTooltip()
     } ).then( () => {
-      // store.dispatch( actions.stopLoading() );
+      // this.store.dispatch( actions.stopLoading() );
       if ( prevState.date !== state.date && currId ) {
         this.chart.highchart.chart.get( currId ).select( true );
       }

--- a/cfgov/unprocessed/js/organisms/MortgagePerformanceTrends/stores/map.js
+++ b/cfgov/unprocessed/js/organisms/MortgagePerformanceTrends/stores/map.js
@@ -112,10 +112,11 @@ const initialState = {
 };
 
 class MapStore extends Store {
-  constructor( mid ) {
-    super( mid );
+  constructor( { date, middleware } ) {
+    super( middleware );
     this.prevState = {};
     this.state = initialState;
+    this.state.date = date;
     this.state = this.reduce( this.state, {} );
   }
   reduce( state, action ) {

--- a/cfgov/unprocessed/js/organisms/MortgagePerformanceTrends/utils.js
+++ b/cfgov/unprocessed/js/organisms/MortgagePerformanceTrends/utils.js
@@ -207,6 +207,15 @@ var utils = {
   getYear: date => date.split( '-' )[0],
 
   /**
+   * getMonth - Returns the month form a date in the format YYYY-MM-DD.
+   *
+   * @param {string} date Date in format YYYY-MM-DD.
+   *
+   * @returns {string} Month as MM.
+   */
+  getMonth: date => date.split( '-' )[1],
+
+  /**
    * isDateValid - Check if date is less than or equal to the provided end date.
    *
    * @param {string} currDate Date in format YYYY-MM-DD.

--- a/test/unit_tests/organisms/MortgagePerformanceTrends/stores/map-spec.js
+++ b/test/unit_tests/organisms/MortgagePerformanceTrends/stores/map-spec.js
@@ -11,7 +11,7 @@ let store;
 describe( 'Mortgage Performance map store', () => {
 
   beforeEach( () => {
-    store = new Store();
+    store = new Store( {} );
   } );
 
   it( 'should instantiate a store', () => {

--- a/test/unit_tests/organisms/MortgagePerformanceTrends/utils-spec.js
+++ b/test/unit_tests/organisms/MortgagePerformanceTrends/utils-spec.js
@@ -81,6 +81,13 @@ describe( 'Mortgage Performance utilities', () => {
     expect( utils.getYear( 'blah' ) ).to.equal( 'blah' );
   } );
 
+  it( 'should be able to parse months in date strings', () => {
+    expect( utils.getMonth( '2008-01' ) ).to.equal( '01' );
+    expect( utils.getMonth( '1999-11' ) ).to.equal( '11' );
+    expect( utils.getMonth( '2012-05-01' ) ).to.equal( '05' );
+    expect( utils.getMonth( 'blah' ) ).to.be.undefined;
+  } );
+
   it( 'should be able to detect valid dates', () => {
     expect( utils.isDateValid( '2008-01', '2016-10-01' ) ).to.be.true;
     expect( utils.isDateValid( '2009-11', '2016-12-01' ) ).to.be.true;


### PR DESCRIPTION
See https://GHE/CFGOV/mortgage-performance/issues/202

## Changes

- The month and year dropdowns default to the date of the most recent data.

## Testing

1. Pull down this branch and `./frontend.sh`
2. Set up the [mortgage performance API](https://github.com/cfpb/cfgov-refresh/pull/3189).
3. Create a [mortgage chart block, mortgage map block, and page](https://github.com/cfpb/cfgov-refresh/pull/3260).
4. Open http://localhost:8000/data-research/mortgage-performance-trends/mortgages-30-89-days-delinquent/ and the map should default to whatever date you have the most recent data for.

## Screenshots

<img width="702" alt="screen shot 2017-10-11 at 3 55 14 am" src="https://user-images.githubusercontent.com/1060248/31428277-46ee96aa-ae38-11e7-882b-cce8c3cdd4f2.png">

## Notes

-

## Todos

-

## Checklist

* [ ] PR has an informative and human-readable title
* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [ ] Passes all existing automated tests
* [ ] Any *change* in functionality is tested
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated
* [ ] Reviewers requested with the [Reviewer tool](https://help.github.com/articles/about-pull-request-reviews/) :arrow_right:
