### PR TITLE
Give Mortgage Performance legend an explicit width

### DIFF
--- a/cfgov/unprocessed/css/organisms/mortgage-performance-trends.less
+++ b/cfgov/unprocessed/css/organisms/mortgage-performance-trends.less
@@ -77,6 +77,7 @@
 .m-color-ramp {
 
     margin-top: unit( 15px / @base-font-size-px, em );
+    width: 100%;
 
     &[data-chart-color='blue'] {
 


### PR DESCRIPTION
@higs4281 discovered that Safari requires SVGs to have a set width or they'll overflow their bounding box.

## Screenshots

Before:

<img width="918" alt="screen shot 2017-10-11 at 11 54 04 am" src="https://user-images.githubusercontent.com/1060248/31452595-5ecc58f8-ae7d-11e7-9986-62fdf14b5163.png">

After:

<img width="772" alt="screen shot 2017-10-11 at 11 53 52 am" src="https://user-images.githubusercontent.com/1060248/31452601-61c7d690-ae7d-11e7-8f7c-40b23ffabadb.png">