### PR TITLE
Support running individual unit tests.

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -207,7 +207,9 @@ The audit will run against
 [Google's PageSpeed Insights](https://github.com/addyosmani/psi).
 
 
-# Django and Python unit tests
+# Unit testing
+
+## Django and Python unit tests
 
 To run the the full suite of Python 2.7 unit tests using Tox, cd to the project
 root, make sure the `TOXENV` variable is set in your `.env` file and then run
@@ -225,6 +227,16 @@ To see Python code coverage information, run
 ```
 ./show_coverage.sh
 ```
+
+## JavaScript unit tests
+
+JavaScript module unit tests are run with `gulp test:unit`.
+
+If you want to run individual spec files, pass in the `--specs` command-line
+argument with the path to the spec,
+such as `gulp test:unit --specs=modules/Tree-spec.js`.
+Globs can be used to run a group of unit tests in the same directory,
+such as `gulp test:unit --specs=modules/transition/*.js`.
 
 
 # Accessibility Testing

--- a/gulp/tasks/test.js
+++ b/gulp/tasks/test.js
@@ -19,13 +19,26 @@ const SauceConnectTunnel = require( 'sauce-connect-tunnel' );
  * @param {Function} cb - Callback function to call on completion.
  */
 function testUnitScripts( cb ) {
+  const params = minimist( process.argv.slice( 3 ) ) || {};
+
+  // If --specs=path/to/js/spec flag is added on the command-line,
+  // pass the value to mocha to test individual unit test files.
+  const specs = params.specs;
+  let src = configTest.tests + '/unit_tests/';
+
+  if ( specs ) {
+    src += specs;
+  } else {
+    src += '**/*.js';
+  }
+
   gulp.src( configTest.src )
     .pipe( gulpIstanbul( {
       includeUntested: false
     } ) )
     .pipe( gulpIstanbul.hookRequire() )
     .on( 'finish', () => {
-      gulp.src( configTest.tests + '/unit_tests/**/*.js' )
+      gulp.src( src )
         .pipe( gulpMocha( {
           reporter: configTest.reporter ? 'spec' : 'nyan'
         } ) )


### PR DESCRIPTION
When refactoring an individual module it is helpful to be able to run only its associated unit tests. This PR adds support to run an individual unit test spec. Similar to what can be done with acceptance tests.

## Additions

- Adds support for running individual unit tests to `gulp test:unit` command.

## Testing

1. `gulp test:unit` should run all unit tests.
2. `gulp test:unit --specs=modules/o-table-row-links-spec.js` should run an indvidual test.
3. `gulp test:unit --specs=modules/transition/*.js` should run all transition and dependent unit tests.
