### PR TITLE
Remove test-specific class

### DIFF
--- a/cfgov/unprocessed/css/misc.less
+++ b/cfgov/unprocessed/css/misc.less
@@ -330,8 +330,6 @@
   notes:
     - "Adds transitions utilty classes for transform, opacity,
        and for the removing the transition duration."
-    - "`.u-move-transition__disabled` is used for disabling tests
-        in protractor tests"
   tags:
     - cfgov-misc
 */
@@ -345,13 +343,6 @@
 
 .u-no-animation {
     transition-duration: 0s;
-}
-
-// The mega-menu code doesn't work with a transition of 0ms
-.u-move-transition__disabled {
-  .u-move-transition {
-    transition: transform 1ms ease;
-  }
 }
 
 /* topdoc

--- a/test/browser_tests/cucumber/step_definitions/header.js
+++ b/test/browser_tests/cucumber/step_definitions/header.js
@@ -47,10 +47,6 @@ defineSupportCode( function( { Then, When, Before } ) {
       globalEyebrowLG:     element( by.css( GLOBAL_EYEBROW_LG_SEL ) ),
       globalEyebrowSM:     element( by.css( GLOBAL_EYEBROW_SM_SEL ) )
     };
-
-    const script = 'document.body.className = "u-move-transition__disabled";';
-
-    browser.executeScript( script );
   } );
 
   Then( /the header organism (should|shouldn't) display the (.*)/,


### PR DESCRIPTION
Removes transition class that was specific to tests but was being delivered to production code. Originally added in https://github.com/cfpb/cfgov-refresh/pull/2166.
Tests appear to pass fine without it. Perhaps an update to Protractor has helped ¯\_(ツ)_/¯

If for some reason it's discovered this is needed, it should be defined in the [test](test/browser_tests/cucumber/step_definitions/header.js), not the less with:

```js
const script = `
      var style = document.createElement( 'style' );
      style.type = 'text/css';
      style.innerHTML = '.u-move-transition__disabled ' +
                        '.u-move-transition { ' +
                        'transition: transform 1ms ease; }';
      document.getElementsByTagName( 'head' )[0].appendChild( style );

      document.body.className = 'u-move-transition__disabled';
    `;

browser.executeScript( script );
```

## Removals

- Removes `u-move-transition__disabled`.

## Testing

1. `gulp test:acceptance --specs=header.feature` should pass.
2. `gulp test:acceptance --specs=header.feature --tags=@mobile` should pass.