### PR TITLE
Ask CFPB: Hide redirected pages from Category pages

### DIFF
--- a/cfgov/ask_cfpb/models/django.py
+++ b/cfgov/ask_cfpb/models/django.py
@@ -161,14 +161,15 @@ class Category(models.Model):
             (str(answer.pk),
              {'question': answer.question,
               'url': '/ask-cfpb/slug-en-{}'.format(answer.pk)}
-             ) for answer in answers if answer.english_page])
+             ) for answer in answers
+            if answer.answer_pages.filter(language='en', redirect_to=None)])
         subcat_data = {}
         for subcat in subcats:
             key = str(subcat.id)
             subcat_data[key] = [
                 str(answer.pk) for answer
                 in subcat.answer_set.all()
-                if answer.english_page]
+                if answer.answer_pages.filter(language='en', redirect_to=None)]
         container['subcategories'].update(subcat_data)
         audience_map = {audience: {'all': [], 'name': audience.name}
                         for audience in audiences}

--- a/cfgov/ask_cfpb/models/pages.py
+++ b/cfgov/ask_cfpb/models/pages.py
@@ -249,7 +249,7 @@ class AnswerCategoryPage(RoutablePageMixin, CFGOVPage):
         context.update({
             'answers': answers,
             'audiences': audiences,
-            'facet_map': facet_map,
+            'facets': facet_dict,
             'choices': subcats,
             'results_count': answers.count(),
             'get_secondary_nav_items': get_ask_nav_items
@@ -295,10 +295,10 @@ class AnswerCategoryPage(RoutablePageMixin, CFGOVPage):
             self.ask_subcategory = subcat
         else:
             raise Http404
-        answers = self.ask_subcategory.answer_set.order_by(
-            '-pk').values(
-            'id', 'question', 'slug')
         context = self.get_context(request)
+        id_key = str(subcat.pk)
+        answers = context['answers'].filter(
+            pk__in=context['facets']['subcategories'][id_key])
         paginator = Paginator(answers, 20)
         page_number = validate_page_number(request, paginator)
         page = paginator.page(page_number)

--- a/cfgov/ask_cfpb/tests/models/test_pages.py
+++ b/cfgov/ask_cfpb/tests/models/test_pages.py
@@ -828,11 +828,11 @@ class AnswerModelTestCase(TestCase):
 
     @mock.patch('ask_cfpb.models.pages.SearchQuerySet.filter')
     def test_category_page_context_no_es(self, mock_es_query):
+        blank_facets = {'answers': {},
+                        'audiences': {},
+                        'subcategories': {}}
         mock_return_value = mock.Mock()
-        mock_return_value.facet_map = json.dumps(
-            {'answers': {},
-             'audiences': {},
-             'subcategories': {}})
+        mock_return_value.facet_map = json.dumps(blank_facets)
         mock_es_query.return_value = [mock_return_value]
         mock_site = mock.Mock()
         mock_site.hostname = 'localhost'
@@ -840,9 +840,7 @@ class AnswerModelTestCase(TestCase):
         mock_request.site = mock_site
         cat_page = self.create_category_page(ask_category=self.category)
         test_context = cat_page.get_context(mock_request)
-        self.assertEqual(
-            test_context['facet_map'],
-            mock_return_value.facet_map)
+        self.assertEqual(test_context['facets'], blank_facets)
 
     def test_category_page_get_english_template(self):
         mock_site = mock.Mock()


### PR DESCRIPTION
Redirected pages in Ask CFPB need to remain live in order to do their
job of redirecting requests to another page. But Category and
SubCategory pages were not excluding redirected pages from their
collection of associated pages, resulting in some duplication in the
list of answers offered.

Addresses GHE issue 1292.