### PR TITLE
Brings in latest cf-layout

### DIFF
--- a/cfgov/unprocessed/css/enhancements/layout.less
+++ b/cfgov/unprocessed/css/enhancements/layout.less
@@ -170,20 +170,6 @@
     - cf-layout
 */
 
-.content_main,
-.content_intro {
-    dd,
-    dt,
-    h3,
-    h4,
-    h5,
-    h6,
-    li,
-    p {
-        max-width: 41.875rem;
-    }
-}
-
 .content__2-1 .content_main .o-email-signup {
     width: 100%;
     max-width: 41.875rem;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1796,9 +1796,9 @@
       }
     },
     "cf-layout": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/cf-layout/-/cf-layout-4.5.1.tgz",
-      "integrity": "sha512-8RByl3aYIzzyEN/lXjKWugm5F0aqTCK+84U3OUaz8SHb+8WMHiqdIUnYnCa4aYQJHDhCaH3gQTysuJV72B0EoQ==",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/cf-layout/-/cf-layout-4.6.0.tgz",
+      "integrity": "sha512-BCxtkM0Ek3LFsy+PTRg44TBMM5WnZleh2tNBkaA/OhndxTrjQWM1gIQ+5hUdI+NP+9d4ITrmDoU7cyYWZypBGA==",
       "requires": {
         "cf-core": "4.5.0",
         "cf-grid": "4.2.2"
@@ -1849,7 +1849,7 @@
         "babel-preset-env": "1.6.0",
         "cf-core": "4.5.0",
         "cf-grid": "4.2.2",
-        "cf-layout": "4.5.1",
+        "cf-layout": "4.6.0",
         "cf-typography": "4.3.0",
         "core-js": "2.5.0",
         "es6-promise": "4.1.1",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "cf-forms": "4.4.1",
     "cf-grid": "4.2.2",
     "cf-icons": "4.2.1",
-    "cf-layout": "4.5.1",
+    "cf-layout": "4.6.0",
     "cf-notifications": "1.0.2",
     "cf-pagination": "4.2.1",
     "cf-tables": "4.1.4",


### PR DESCRIPTION
Brings in latest cf-layout to include https://github.com/cfpb/capital-framework/pull/637

## Removals

- Unneeded cf-layout enhancement CSS for setting max-width on global elements, which comes in via cf-layout now.

## Changes

- Updates `cf-layout` to version `4.6.0`.

## Testing

1. `./frontend.sh` should pass.
2. Paragraph, label, definition list, bulleted lists, and h3-h6 headings should be truncated to 41.875rem. There should be no change compared to the live site beyond long labels being truncated.
