### PR TITLE
Persist U.S. state dropdown above Mortgage Performance line chart

### DIFF
--- a/cfgov/jinja2/v1/_includes/organisms/mortgage-chart.html
+++ b/cfgov/jinja2/v1/_includes/organisms/mortgage-chart.html
@@ -48,7 +48,7 @@
             </fieldset>
             <fieldset class="content-l_col content-l_col-1-2">
                 <div class="m-form-field m-form-field__select mp-line-chart-select-container u-mb30" id="mp-line-chart-state-container" style="display:none">
-                    <label class="a-label" for="mp-line-chart-state"><h4>Select state</h4></label>
+                    <label class="a-label" for="mp-line-chart-state"><h4 id="mp-state-dropdown-title">Select state</h4></label>
                     <div class="a-select">
                         <select id="mp-line-chart-state">
                             <option value="01" data-abbr="AL">Alabama</option>
@@ -104,10 +104,13 @@
                             <option value="56" data-abbr="WY">Wyoming</option>
                         </select>
                     </div>
-                    <p class="m-field-helper-text u-mt15" id="mp-line-chart-state-metro-helper-text" style="display:none">
+                    <p class="m-field-helper-text u-mt15" id="mp-state-metro-helper-text" style="display:none">
                       Some metro areas cover multiple states. States are only
                       listed if they have at least one metro area with
                       sufficient data.
+                    </p>
+                    <p class="m-field-helper-text u-mt15" id="mp-state-non-metro-helper-text" style="display:none">
+                      States are only listed if their non-metro area has sufficient data.
                     </p>
                 </div>
                 <div class="m-form-field m-form-field__select mp-line-chart-select-container" id="mp-line-chart-metro-container" style="display:none">
@@ -122,19 +125,6 @@
                       Metro areas with insufficient data not shown. <a
                       href="/data-research/mortgage-performance-trends/about-the-data/#anchor_why-some-counties-are-unavailable"
                       target="_blank" rel="noopener">Learn why.</a>
-                    </p>
-                </div>
-                <div class="m-form-field m-form-field__select mp-line-chart-select-container" id="mp-line-chart-non-metro-container" style="display:none">
-                    <label class="a-label" for="mp-line-chart-non-metro"><h4>Select non-metro area by state</h4></label>
-                    <div class="a-select">
-                        <select id="mp-line-chart-non-metro">
-                          <option value="">
-                          </option>
-                        </select>
-                    </div>
-                    <p class="m-field-helper-text u-mt15">
-                      States are only listed if their non-metro area has
-                      sufficient data.
                     </p>
                 </div>
                 <div class="m-form-field m-form-field__select mp-line-chart-select-container u-mb30" id="mp-line-chart-county-container" style="display:none">

--- a/cfgov/jinja2/v1/_includes/organisms/mortgage-chart.html
+++ b/cfgov/jinja2/v1/_includes/organisms/mortgage-chart.html
@@ -104,6 +104,9 @@
                             <option value="56" data-abbr="WY">Wyoming</option>
                         </select>
                     </div>
+                    <p class="m-field-helper-text u-mt15" id="mp-state-county-helper-text" style="display:none">
+                      States are only listed if they have at least one county with sufficient data.
+                    </p>
                     <p class="m-field-helper-text u-mt15" id="mp-state-metro-helper-text" style="display:none">
                       Some metro areas cover multiple states. States are only
                       listed if they have at least one metro area with

--- a/cfgov/unprocessed/css/organisms/mortgage-performance-trends.less
+++ b/cfgov/unprocessed/css/organisms/mortgage-performance-trends.less
@@ -160,10 +160,6 @@
         font-size: unit(@font-size / @base-font-size-px, em);
     }
 
-    select option:first-child {
-      color: @gray-80;
-    }
-
 }
 
 #mp-line-chart-controls,

--- a/cfgov/unprocessed/css/organisms/mortgage-performance-trends.less
+++ b/cfgov/unprocessed/css/organisms/mortgage-performance-trends.less
@@ -134,6 +134,10 @@
 
 #mp-line-chart-container,
 #mp-map-container {
+
+    // Highcharts auto resizes the charts, causing odd overflow issues
+    overflow: inherit;
+
     .a-label h4 {
         .u-mb15();
     }

--- a/cfgov/unprocessed/js/organisms/MortgagePerformanceTrends/actions/chart.js
+++ b/cfgov/unprocessed/js/organisms/MortgagePerformanceTrends/actions/chart.js
@@ -6,6 +6,122 @@ const defaultActionCreators = require( './default' );
 const chartActionCreators = defaultActionCreators();
 
 /**
+ * fetchMetroStates - Creates async action to fetch list of valid metro states.
+ *
+ * @param {String} metroState Two-letter U.S. state abbreviation.
+ *
+ * @returns {Function} Thunk called with metro states.
+ */
+chartActionCreators.fetchMetroStates = metroState => dispatch =>
+  utils.getMetroData( states => {
+    let metroStates = [];
+    let reuseState = false;
+    Object.keys( states ).forEach( state => {
+      const isValid = states[state].metros.reduce( ( prev, curr ) => {
+        if ( curr.fips.indexOf( '-non' ) > -1 ) {
+          return prev;
+        }
+        return prev || curr.valid || false;
+      }, false );
+      if ( isValid ) {
+        reuseState = reuseState || metroState === state;
+        metroStates.push( {
+          abbr: state,
+          fips: states[state].state_fips,
+          name: states[state].state_name,
+          selected: metroState === state
+        } );
+      }
+    } );
+    // Alphabetical order
+    metroStates = metroStates.sort( ( a, b ) => a.name < b.name ? -1 : 1 );
+    // If the provided state isn't valid for this location type,
+    // use the first state in the list.
+    if ( !reuseState ) {
+      metroState = metroStates[0].abbr;
+    }
+    dispatch( chartActionCreators.setStates( metroStates ) );
+    dispatch( chartActionCreators.fetchMetros( metroState ) );
+    return metroStates;
+  } );
+
+/**
+ * fetchNonMetroStates - Creates async action to fetch list of valid metro states.
+ *
+ * @param {String} nonMetroState Two-letter U.S. state abbreviation.
+ *
+ * @returns {Function} Thunk called with metro states.
+ */
+chartActionCreators.fetchNonMetroStates = nonMetroState => dispatch =>
+  utils.getNonMetroData( states => {
+    let nonMetroStates = [];
+    states.forEach( state => {
+      if ( state.valid ) {
+        nonMetroStates.push( {
+          abbr: state.abbr,
+          fips: state.fips,
+          name: state.state_name,
+          text: state.name,
+          selected: nonMetroState === state.abbr
+        } );
+      }
+    } );
+    // Alphabetical order
+    nonMetroStates = nonMetroStates.sort( ( a, b ) => a.name < b.name ? -1 : 1 );
+    dispatch( chartActionCreators.setStates( nonMetroStates ) );
+    dispatch( chartActionCreators.fetchNonMetros( nonMetroState ) );
+    return nonMetroStates;
+  } );
+
+/**
+ * fetchCountyStates - Creates async action to fetch list of valid metro states.
+ *
+ * @param {String} countyState Two-letter U.S. state abbreviation.
+ *
+ * @returns {Function} Thunk called with county states.
+ */
+chartActionCreators.fetchCountyStates = countyState => dispatch =>
+  utils.getCountyData( states => {
+    let countyStates = [];
+    let reuseState = false;
+    Object.keys( states ).forEach( state => {
+      const isValid = states[state].counties.reduce( ( prev, curr ) =>
+        prev || curr.valid || false
+      , false );
+      if ( isValid ) {
+        reuseState = reuseState || countyState === state;
+        countyStates.push( {
+          abbr: state,
+          fips: states[state].state_fips,
+          name: states[state].state_name,
+          selected: countyState === state
+        } );
+      }
+    } );
+    // Alphabetical order
+    countyStates = countyStates.sort( ( a, b ) => a.name < b.name ? -1 : 1 );
+    // If the provided state isn't valid for this location type,
+    // use the first state in the list.
+    if ( !reuseState ) {
+      countyState = countyStates[0].abbr;
+    }
+    dispatch( chartActionCreators.setStates( countyStates ) );
+    dispatch( chartActionCreators.fetchCounties( countyState ) );
+    return countyStates;
+  } );
+
+/**
+ * setStates - New U.S. states.
+ *
+ * @param {Array} states List of U.S. states.
+ * @returns {Object} Action with new U.S. states.
+ */
+chartActionCreators.setStates = states => ( {
+  type: 'SET_STATES',
+  states: states
+} );
+
+/**
  * fetchMetros - Creates async action to fetch list of metros
  *
  * @param {String} metroState Two-letter U.S. state abbreviation.

--- a/cfgov/unprocessed/js/organisms/MortgagePerformanceTrends/actions/chart.js
+++ b/cfgov/unprocessed/js/organisms/MortgagePerformanceTrends/actions/chart.js
@@ -111,6 +111,34 @@ chartActionCreators.fetchCountyStates = countyState => dispatch =>
   } );
 
 /**
+ * fetchStates - Creates async action to fetch list of valid states.
+ *
+ * @returns {Function} Thunk called with valid states.
+ */
+chartActionCreators.fetchStates = ( selectedState, includeComparison ) => dispatch =>
+  utils.getStateData( states => {
+    states = Object.keys( states ).map( fips => {
+      const state = {
+        abbr: states[fips].abbr,
+        fips: fips,
+        name: states[fips].name,
+        text: states[fips].name
+      };
+      if ( selectedState === states[fips].abbr ) {
+        selectedState = state;
+        state.selected = true;
+      }
+      return state;
+    } );
+    // Alphabetical order
+    states = states.sort( ( a, b ) => a.name < b.name ? -1 : 1 );
+    dispatch( chartActionCreators.setStates( states ) );
+    dispatch( chartActionCreators.setGeo( selectedState.fips, selectedState.name, 'state' ) );
+    dispatch( chartActionCreators.updateChart( selectedState.fips, selectedState.name, 'state', includeComparison ) );
+    return states;
+  } );
+
+/**
  * setStates - New U.S. states.
  *
  * @param {Array} states List of U.S. states.

--- a/cfgov/unprocessed/js/organisms/MortgagePerformanceTrends/actions/chart.js
+++ b/cfgov/unprocessed/js/organisms/MortgagePerformanceTrends/actions/chart.js
@@ -113,6 +113,9 @@ chartActionCreators.fetchCountyStates = countyState => dispatch =>
 /**
  * fetchStates - Creates async action to fetch list of valid states.
  *
+ * @param {String} selectedState Two-letter U.S. state abbreviation.
+ * @param {Boolean} includeComparison Include national comparison?
+ *
  * @returns {Function} Thunk called with valid states.
  */
 chartActionCreators.fetchStates = ( selectedState, includeComparison ) => dispatch =>

--- a/cfgov/unprocessed/js/organisms/MortgagePerformanceTrends/actions/default.js
+++ b/cfgov/unprocessed/js/organisms/MortgagePerformanceTrends/actions/default.js
@@ -118,20 +118,26 @@ const defaultActionCreators = () => {
     /**
      * fetchNonMetros - Creates async action to fetch list of non-metros.
      *
-     * @param {String} metroState Two-letter U.S. state abbreviation.
+     * @param {String} nonMetroState Two-letter U.S. state abbreviation.
      * @param {Boolean} includeComparison Include national comparison?
      *
      * @returns {Function} Thunk called with non metros
      */
-    fetchNonMetros: ( metroState, includeComparison ) => dispatch => {
+    fetchNonMetros: ( nonMetroState, includeComparison ) => dispatch => {
       dispatch( actions.requestNonMetros() );
       return utils.getNonMetroData( data => {
-        var nonMetros = data.filter( nonMetro => nonMetro.valid );
+        let nonMetros = data.filter( nonMetro => nonMetro.valid );
+        let currStateIndex = 0;
+        nonMetros.forEach( ( nonMetro, i ) => {
+          if ( nonMetro.abbr === nonMetroState ) {
+            currStateIndex = i;
+          }
+        } );
         // Alphabetical order
         nonMetros = nonMetros.sort( ( a, b ) => a.name < b.name ? -1 : 1 );
         dispatch( actions.setNonMetros( nonMetros ) );
-        dispatch( actions.setGeo( nonMetros[0].fips, nonMetros[0].name, 'non-metro' ) );
-        dispatch( actions.updateChart( nonMetros[0].fips, nonMetros[0].name, 'non-metro', includeComparison ) );
+        dispatch( actions.setGeo( nonMetros[currStateIndex].fips, nonMetros[currStateIndex].name, 'non-metro' ) );
+        dispatch( actions.updateChart( nonMetros[currStateIndex].fips, nonMetros[currStateIndex].name, 'non-metro', includeComparison ) );
         return nonMetros;
       } );
     },

--- a/cfgov/unprocessed/js/organisms/MortgagePerformanceTrends/apps/chart.js
+++ b/cfgov/unprocessed/js/organisms/MortgagePerformanceTrends/apps/chart.js
@@ -15,7 +15,6 @@ class MortgagePerformanceLineChart {
     this.$geo = this.$container.querySelector( '#mp-line-chart-geo' );
     this.$state = this.$container.querySelector( '#mp-line-chart-state' );
     this.$metro = this.$container.querySelector( '#mp-line-chart-metro' );
-    this.$nonMetro = this.$container.querySelector( '#mp-line-chart-non-metro' );
     this.$county = this.$container.querySelector( '#mp-line-chart-county' );
     this.$compareContainer = this.$container.querySelector( '#mp-line-chart-compare-container' );
     this.$compare = this.$container.querySelector( '#mp-line-chart-compare' );
@@ -44,7 +43,7 @@ MortgagePerformanceLineChart.prototype.eventListeners = function() {
   store.subscribe( this.renderChartForm.bind( this ) );
   store.subscribe( this.renderCounties.bind( this ) );
   store.subscribe( this.renderMetros.bind( this ) );
-  store.subscribe( this.renderNonMetros.bind( this ) );
+  store.subscribe( this.renderStates.bind( this ) );
 };
 
 MortgagePerformanceLineChart.prototype.onClick = function( event ) {
@@ -62,23 +61,23 @@ MortgagePerformanceLineChart.prototype.onChange = function( event ) {
 
   switch ( event.target.id ) {
     case 'mp-line-chart_geo-state':
-      // Reset the metro and county dropdowns to the first item if we're no longer using it
-      this.$metro.selectedIndex = 0;
+      // Reset the metro, non-metro and county dropdowns to the first item if we're no longer using it
       this.$county.selectedIndex = 0;
-      // Keep the non-metro dropdown synced with the state dropdown
-      this.$nonMetro.selectedIndex = this.$state.options[this.$state.selectedIndex] + '-non';
+      this.$metro.selectedIndex = 0;
       geoId = this.$state.value;
       geoName = this.$state.options[this.$state.selectedIndex].text;
       action = actions.setGeo( geoId, geoName, 'state' );
       break;
     case 'mp-line-chart_geo-metro':
-      action = actions.fetchMetros( abbr );
+      this.$metro.selectedIndex = 0;
+      action = actions.fetchMetroStates( abbr );
       break;
     case 'mp-line-chart_geo-non-metro':
-      action = actions.fetchNonMetros( abbr );
+      action = actions.fetchNonMetroStates( abbr );
       break;
     case 'mp-line-chart_geo-county':
-      action = actions.fetchCounties( abbr );
+      this.$county.selectedIndex = 0;
+      action = actions.fetchCountyStates( abbr );
       break;
     case 'mp-line-chart-state':
       geoType = this.$container.querySelector( 'input[name="mp-line-chart_geo"]:checked' ).id.replace( 'mp-line-chart_geo-', '' );
@@ -94,8 +93,8 @@ MortgagePerformanceLineChart.prototype.onChange = function( event ) {
         action = actions.fetchMetros( abbr, includeComparison );
       }
       if ( geoType === 'non-metro' ) {
-        geoId = this.$nonMetro.value;
-        geoName = this.$nonMetro.options[this.$nonMetro.selectedIndex].text;
+        geoId = this.$state.value;
+        geoName = this.$state.options[this.$state.selectedIndex].text;
         action = actions.fetchNonMetros( abbr, includeComparison );
         action = actions.updateChart( geoId, geoName, 'non-metro', includeComparison );
       }
@@ -111,8 +110,8 @@ MortgagePerformanceLineChart.prototype.onChange = function( event ) {
       action = actions.updateChart( geoId, geoName, 'metro', includeComparison );
       break;
     case 'mp-line-chart-non-metro':
-      geoId = this.$nonMetro.value;
-      geoName = this.$nonMetro.options[this.$nonMetro.selectedIndex].text;
+      geoId = this.$state.value;
+      geoName = this.$state.options[this.$state.selectedIndex].text;
       action = actions.updateChart( geoId, geoName, 'non-metro', includeComparison );
       break;
     case 'mp-line-chart-county':
@@ -163,35 +162,22 @@ MortgagePerformanceLineChart.prototype.renderChart = function( prevState, state 
 };
 
 MortgagePerformanceLineChart.prototype.renderChartForm = function( prevState, state ) {
-  // If we're waiting for data, abort.
-  // if ( state.isLoading ) {
-  //   return utils.showEl( this.$loadingSpinner );
-  // }
-  // utils.hideEl( this.$loadingSpinner );
-  var geoType;
-  if ( prevState.isLoadingCounties || state.isLoadingCounties ) {
-    geoType = 'county';
-  } else if ( prevState.isLoadingMetros || state.isLoadingMetros ) {
-    geoType = 'metro';
-  } else if ( prevState.isLoadingNonMetros || state.isLoadingNonMetros ) {
-    geoType = 'non-metro';
-  } else {
-    geoType = state.geo.type;
-  }
+  var geoType = state.geo.type;
+  var title = this.$container.querySelector( '#mp-state-dropdown-title' );
   var geo = this.$container.querySelector( `#mp-line-chart-${ geoType }-container` );
   var containers = this.$container.querySelectorAll( '.mp-line-chart-select-container' );
   for ( var i = 0; i < containers.length; ++i ) {
     utils.hideEl( containers[i] );
   }
-  if ( geoType === 'state' || geoType === 'county' ) {
-    utils.hideEl( this.$container.querySelector( '#mp-line-chart-state-metro-helper-text' ) );
-  }
+  utils.hideEl( this.$container.querySelector( '#mp-state-metro-helper-text' ) );
+  utils.hideEl( this.$container.querySelector( '#mp-state-non-metro-helper-text' ) );
   if ( geoType === 'metro' ) {
-    utils.showEl( this.$container.querySelector( '#mp-line-chart-state-metro-helper-text' ) );
+    utils.showEl( this.$container.querySelector( '#mp-state-metro-helper-text' ) );
   }
-  if ( geoType === 'county' || geoType === 'metro' ) {
-    utils.showEl( this.$container.querySelector( '#mp-line-chart-state-container' ) );
+  if ( geoType === 'non-metro' ) {
+    utils.showEl( this.$container.querySelector( '#mp-state-non-metro-helper-text' ) );
   }
+  utils.showEl( this.$container.querySelector( '#mp-line-chart-state-container' ) );
   if ( geoType ) {
     utils.showEl( this.$compareContainer );
   } else {
@@ -199,6 +185,11 @@ MortgagePerformanceLineChart.prototype.renderChartForm = function( prevState, st
   }
   if ( geo ) {
     utils.showEl( geo );
+  }
+  if ( state.geo.type === 'non-metro' ) {
+    title.innerText = 'Select non-metro area by state';
+  } else {
+    title.innerText = 'Select state';
   }
 };
 
@@ -257,22 +248,23 @@ MortgagePerformanceLineChart.prototype.renderMetros = function( prevState, state
   this.$metro.appendChild( fragment );
 };
 
-MortgagePerformanceLineChart.prototype.renderNonMetros = function( prevState, state ) {
-  this.$nonMetro.disabled = state.isLoadingNonMetros;
-  if ( JSON.stringify( prevState.nonMetros ) === JSON.stringify( state.nonMetros ) ) {
+MortgagePerformanceLineChart.prototype.renderStates = function( prevState, state ) {
+  this.$state.disabled = state.isLoadingStates;
+  if ( JSON.stringify( prevState.states ) === JSON.stringify( state.states ) ) {
     return;
   }
-  state.nonMetros.sort( ( a, b ) => a.state_name < b.state_name ? -1 : 1 );
   var fragment = document.createDocumentFragment();
-  state.nonMetros.forEach( nonMetro => {
+  state.states.forEach( s => {
     var option = document.createElement( 'option' );
-    option.value = nonMetro.fips;
-    option.text = nonMetro.name;
-    option.label = nonMetro.state_name;
+    option.value = s.fips;
+    option.text = s.text || s.name;
+    option.selected = s.selected;
+    option.label = s.name;
+    option.setAttribute( 'data-abbr', s.abbr );
     fragment.appendChild( option );
   } );
-  this.$nonMetro.innerHTML = '';
-  this.$nonMetro.appendChild( fragment );
+  this.$state.innerHTML = '';
+  this.$state.appendChild( fragment );
 };
 
 module.exports = MortgagePerformanceLineChart;

--- a/cfgov/unprocessed/js/organisms/MortgagePerformanceTrends/apps/chart.js
+++ b/cfgov/unprocessed/js/organisms/MortgagePerformanceTrends/apps/chart.js
@@ -64,9 +64,7 @@ MortgagePerformanceLineChart.prototype.onChange = function( event ) {
       // Reset the metro, non-metro and county dropdowns to the first item if we're no longer using it
       this.$county.selectedIndex = 0;
       this.$metro.selectedIndex = 0;
-      geoId = this.$state.value;
-      geoName = this.$state.options[this.$state.selectedIndex].text;
-      action = actions.setGeo( geoId, geoName, 'state' );
+      action = actions.fetchStates( abbr );
       break;
     case 'mp-line-chart_geo-metro':
       this.$metro.selectedIndex = 0;

--- a/cfgov/unprocessed/js/organisms/MortgagePerformanceTrends/apps/chart.js
+++ b/cfgov/unprocessed/js/organisms/MortgagePerformanceTrends/apps/chart.js
@@ -167,8 +167,12 @@ MortgagePerformanceLineChart.prototype.renderChartForm = function( prevState, st
   for ( var i = 0; i < containers.length; ++i ) {
     utils.hideEl( containers[i] );
   }
+  utils.hideEl( this.$container.querySelector( '#mp-state-county-helper-text' ) );
   utils.hideEl( this.$container.querySelector( '#mp-state-metro-helper-text' ) );
   utils.hideEl( this.$container.querySelector( '#mp-state-non-metro-helper-text' ) );
+  if ( geoType === 'county' ) {
+    utils.showEl( this.$container.querySelector( '#mp-state-county-helper-text' ) );
+  }
   if ( geoType === 'metro' ) {
     utils.showEl( this.$container.querySelector( '#mp-state-metro-helper-text' ) );
   }

--- a/cfgov/unprocessed/js/organisms/MortgagePerformanceTrends/stores/chart.js
+++ b/cfgov/unprocessed/js/organisms/MortgagePerformanceTrends/stores/chart.js
@@ -52,6 +52,15 @@ const isLoadingCounties = action => {
   }
 };
 
+const isLoadingStates = action => {
+  switch ( action.type ) {
+    case 'REQUEST_STATES':
+      return true;
+    default:
+      return false;
+  }
+};
+
 const isLoading = action => {
   switch ( action.type ) {
     case 'UPDATE_CHART':
@@ -152,6 +161,7 @@ class LineChartStore extends Store {
       isLoadingMetros: isLoadingMetros( action ),
       isLoadingNonMetros: isLoadingNonMetros( action ),
       isLoadingCounties: isLoadingCounties( action ),
+      isLoadingStates: isLoadingStates( action ),
       includeComparison: includeComparison( state.includeComparison, action ),
       counties: updateCounties( state.counties, action ),
       metros: updateMetros( state.metros, action ),

--- a/cfgov/unprocessed/js/organisms/MortgagePerformanceTrends/stores/chart.js
+++ b/cfgov/unprocessed/js/organisms/MortgagePerformanceTrends/stores/chart.js
@@ -62,6 +62,17 @@ const isLoading = action => {
   }
 };
 
+const updateStates = ( states, action ) => {
+  switch ( action.type ) {
+    case 'SET_STATES':
+      return action.states;
+    case 'FETCH_STATES':
+    case 'REQUEST_STATES':
+    default:
+      return states;
+  }
+};
+
 const updateMetros = ( metros, action ) => {
   switch ( action.type ) {
     case 'SET_METROS':
@@ -116,6 +127,7 @@ const initialState = {
   counties: {},
   metros: {},
   nonMetros: {},
+  states: {},
   // Is the chart waiting for data?
   isLoading: false,
   // Is the county dropdown waiting for data?
@@ -143,7 +155,8 @@ class LineChartStore extends Store {
       includeComparison: includeComparison( state.includeComparison, action ),
       counties: updateCounties( state.counties, action ),
       metros: updateMetros( state.metros, action ),
-      nonMetros: updateNonMetros( state.nonMetros, action )
+      nonMetros: updateNonMetros( state.nonMetros, action ),
+      states: updateStates( state.states, action )
     };
     return newState;
   }

--- a/cfgov/unprocessed/js/organisms/MortgagePerformanceTrends/utils.js
+++ b/cfgov/unprocessed/js/organisms/MortgagePerformanceTrends/utils.js
@@ -88,6 +88,7 @@ var utils = {
     }
     return ajax( { url: COUNTIES_URL }, function( resp ) {
       var data = JSON.parse( resp.data );
+      counties = data;
       cb( data );
     } );
   },
@@ -105,6 +106,7 @@ var utils = {
     }
     return ajax( { url: METROS_URL }, function( resp ) {
       var data = JSON.parse( resp.data );
+      metros = data;
       cb( data );
     } );
   },
@@ -122,6 +124,7 @@ var utils = {
     }
     return ajax( { url: NON_METROS_URL }, function( resp ) {
       var data = JSON.parse( resp.data );
+      nonMetros = data;
       cb( data );
     } );
   },

--- a/cfgov/unprocessed/js/organisms/MortgagePerformanceTrends/utils.js
+++ b/cfgov/unprocessed/js/organisms/MortgagePerformanceTrends/utils.js
@@ -88,7 +88,6 @@ var utils = {
     }
     return ajax( { url: COUNTIES_URL }, function( resp ) {
       var data = JSON.parse( resp.data );
-      counties = data;
       cb( data );
     } );
   },
@@ -106,7 +105,6 @@ var utils = {
     }
     return ajax( { url: METROS_URL }, function( resp ) {
       var data = JSON.parse( resp.data );
-      metros = data;
       cb( data );
     } );
   },
@@ -124,7 +122,6 @@ var utils = {
     }
     return ajax( { url: NON_METROS_URL }, function( resp ) {
       var data = JSON.parse( resp.data );
-      nonMetros = data;
       cb( data );
     } );
   },

--- a/cfgov/unprocessed/js/organisms/MortgagePerformanceTrends/utils.js
+++ b/cfgov/unprocessed/js/organisms/MortgagePerformanceTrends/utils.js
@@ -5,7 +5,8 @@ const ajax = require( 'xdr' );
 const COUNTIES_URL = '/data-research/mortgages/api/v1/metadata/state_county_meta';
 const METROS_URL = '/data-research/mortgages/api/v1/metadata/state_msa_meta';
 const NON_METROS_URL = '/data-research/mortgages/api/v1/metadata/non_msa_fips';
-let counties, metros, nonMetros;
+const STATES_URL = '/data-research/mortgages/api/v1/metadata/state_meta';
+let counties, metros, nonMetros, states;
 let globalZoomLevel = 10;
 
 var utils = {
@@ -73,6 +74,23 @@ var utils = {
     option.value = value;
     option.text = text;
     return option;
+  },
+
+  /**
+   * getStateData - XHR state metadata
+   *
+   * @param {function} cb Function called with state data.
+   *
+   * @returns {function} Function called with state data.
+   */
+  getStateData: cb => {
+    if ( states ) {
+      return cb( states );
+    }
+    return ajax( { url: STATES_URL }, function( resp ) {
+      var data = JSON.parse( resp.data );
+      cb( data );
+    } );
   },
 
   /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1842,9 +1842,9 @@
       }
     },
     "cfpb-chart-builder": {
-      "version": "3.0.9",
-      "resolved": "https://registry.npmjs.org/cfpb-chart-builder/-/cfpb-chart-builder-3.0.9.tgz",
-      "integrity": "sha512-iAm961QpLjpjX73ulOjzyYyclAIzQnvtzgl+/9D8Y1wgv/Qqz5nsc4fAy4nMLu1Sc7MTpRipsStt64ss2nnrmA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/cfpb-chart-builder/-/cfpb-chart-builder-3.1.0.tgz",
+      "integrity": "sha512-wYnlVuLjKGYERz7oQXNl4rc3wIg7bIEc+cYKJu3iShavyXkYJRBsSa9vMD++9HfTkMk4eqS1i1ahG/SUvJpk5w==",
       "requires": {
         "babel-preset-env": "1.6.0",
         "cf-core": "4.5.0",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "cf-pagination": "4.2.1",
     "cf-tables": "4.1.4",
     "cf-typography": "4.3.0",
-    "cfpb-chart-builder": "3.0.9",
+    "cfpb-chart-builder": "3.1.0",
     "del": "2.2.2",
     "es5-shim": "4.5.9",
     "glob-all": "3.1.0",

--- a/test/unit_tests/organisms/MortgagePerformanceTrends/actions/chart-spec.js
+++ b/test/unit_tests/organisms/MortgagePerformanceTrends/actions/chart-spec.js
@@ -23,6 +23,11 @@ mockery.registerMock( '../utils', {
             valid: true,
             fips: '12345',
             name: 'Acme metro'
+          },
+          {
+            valid: true,
+            fips: '12-non',
+            name: 'Acme non-metro'
           }
         ]
       }
@@ -34,7 +39,8 @@ mockery.registerMock( '../utils', {
       {
         valid: true,
         fips: '12345',
-        name: 'Acme metro'
+        name: 'Acme metro',
+        abbr: 'AL'
       }
     ];
     cb( nonMetros );
@@ -62,8 +68,11 @@ const actions = require(
 describe( 'Mortgage Performance chart action creators', () => {
 
   it( 'should dispatch actions to fetch metro states', () => {
-    const dispatch = sinon.spy();
+    let dispatch = sinon.spy();
     actions.fetchMetroStates( 'AL', true )( dispatch );
+    expect( dispatch.callCount ).to.equal( 2 );
+    dispatch = sinon.spy();
+    actions.fetchMetroStates( 'CA', true )( dispatch );
     expect( dispatch.callCount ).to.equal( 2 );
   } );
 
@@ -83,6 +92,7 @@ describe( 'Mortgage Performance chart action creators', () => {
     const dispatch = sinon.spy();
     actions.fetchMetros( 'AL', true )( dispatch );
     expect( dispatch.callCount ).to.equal( 4 );
+    expect( actions.fetchMetros( 'AK', true ) ).to.throw();
   } );
 
   it( 'should fail on bad metro state abbr', () => {

--- a/test/unit_tests/organisms/MortgagePerformanceTrends/actions/chart-spec.js
+++ b/test/unit_tests/organisms/MortgagePerformanceTrends/actions/chart-spec.js
@@ -58,6 +58,23 @@ mockery.registerMock( '../utils', {
       }
     };
     cb( counties );
+  },
+  getStateData: cb => {
+    const counties = {
+      10: {
+        AP: 'Del.',
+        fips: '10',
+        name: 'Delaware',
+        abbr: 'DE'
+      },
+      11: {
+        AP: 'D.C.',
+        fips: '11',
+        name: 'District of Columbia',
+        abbr: 'DC'
+      }
+    };
+    cb( counties );
   }
 } );
 
@@ -86,6 +103,12 @@ describe( 'Mortgage Performance chart action creators', () => {
     const dispatch = sinon.spy();
     actions.fetchCountyStates( 'CA', true )( dispatch );
     expect( dispatch.callCount ).to.equal( 2 );
+  } );
+
+  it( 'should dispatch actions to fetch states', () => {
+    const dispatch = sinon.spy();
+    actions.fetchStates( 'CA', true )( dispatch );
+    expect( dispatch.callCount ).to.equal( 3 );
   } );
 
   it( 'should dispatch actions to fetch metros', () => {

--- a/test/unit_tests/organisms/MortgagePerformanceTrends/actions/chart-spec.js
+++ b/test/unit_tests/organisms/MortgagePerformanceTrends/actions/chart-spec.js
@@ -61,6 +61,24 @@ const actions = require(
 
 describe( 'Mortgage Performance chart action creators', () => {
 
+  it( 'should dispatch actions to fetch metro states', () => {
+    const dispatch = sinon.spy();
+    actions.fetchMetroStates( 'AL', true )( dispatch );
+    expect( dispatch.callCount ).to.equal( 2 );
+  } );
+
+  it( 'should dispatch actions to fetch non-metro states', () => {
+    const dispatch = sinon.spy();
+    actions.fetchNonMetroStates( 'WY', true )( dispatch );
+    expect( dispatch.callCount ).to.equal( 2 );
+  } );
+
+  it( 'should dispatch actions to fetch county states', () => {
+    const dispatch = sinon.spy();
+    actions.fetchCountyStates( 'CA', true )( dispatch );
+    expect( dispatch.callCount ).to.equal( 2 );
+  } );
+
   it( 'should dispatch actions to fetch metros', () => {
     const dispatch = sinon.spy();
     actions.fetchMetros( 'AL', true )( dispatch );

--- a/test/unit_tests/organisms/MortgagePerformanceTrends/actions/default-spec.js
+++ b/test/unit_tests/organisms/MortgagePerformanceTrends/actions/default-spec.js
@@ -20,7 +20,8 @@ mockery.registerMock( '../utils', {
       {
         valid: true,
         fips: '12345',
-        name: 'Acme metro'
+        name: 'Acme metro',
+        abbr: 'AL'
       }
     ];
     cb( nonMetros );
@@ -118,6 +119,8 @@ describe( 'Mortgage Performance default action creators', () => {
     const dispatch = sinon.spy();
     actions.fetchNonMetros( 'AL', true )( dispatch );
     expect( dispatch.callCount ).to.equal( 4 );
+    actions.fetchNonMetros( 'CA', true )( dispatch );
+    expect( dispatch.callCount ).to.equal( 8 );
   } );
 
   it( 'should fail on bad non-metro state abbr', () => {

--- a/test/unit_tests/organisms/MortgagePerformanceTrends/stores/chart-spec.js
+++ b/test/unit_tests/organisms/MortgagePerformanceTrends/stores/chart-spec.js
@@ -160,13 +160,27 @@ describe( 'Mortgage Performance line chart store', () => {
   } );
 
   it( 'should properly reduce u.s. states', () => {
-    const action = {
+    let action = {
       type: 'SET_STATES',
       states: { AL: 'Alabama' }
     };
     store.dispatch( action );
     expect( store.getState().states )
       .to.deep.equal( { AL: 'Alabama' } );
+    action = {
+      type: 'FETCH_STATES',
+      states: { CA: 'California' }
+    };
+    store.dispatch( action );
+    expect( store.getState().states )
+      .to.deep.equal( { AL: 'Alabama' } );
+    action = {
+      type: 'SET_STATES',
+      states: { CA: 'California' }
+    };
+    store.dispatch( action );
+    expect( store.getState().states )
+      .to.deep.equal( { CA: 'California' } );
   } );
 
   it( 'should properly reduce national comparison', () => {

--- a/test/unit_tests/organisms/MortgagePerformanceTrends/stores/chart-spec.js
+++ b/test/unit_tests/organisms/MortgagePerformanceTrends/stores/chart-spec.js
@@ -122,6 +122,14 @@ describe( 'Mortgage Performance line chart store', () => {
     expect( store.getState().isLoadingCounties ).to.be.true;
   } );
 
+  it( 'should properly reduce loading u.s. states', () => {
+    const action = {
+      type: 'REQUEST_STATES'
+    };
+    store.dispatch( action );
+    expect( store.getState().isLoadingStates ).to.be.true;
+  } );
+
   it( 'should properly reduce metros', () => {
     const action = {
       type: 'SET_METROS',
@@ -149,6 +157,16 @@ describe( 'Mortgage Performance line chart store', () => {
     store.dispatch( action );
     expect( store.getState().counties )
       .to.deep.equal( { 12345: 'Acme County' } );
+  } );
+
+  it( 'should properly reduce u.s. states', () => {
+    const action = {
+      type: 'SET_STATES',
+      states: { AL: 'Alabama' }
+    };
+    store.dispatch( action );
+    expect( store.getState().states )
+      .to.deep.equal( { AL: 'Alabama' } );
   } );
 
   it( 'should properly reduce national comparison', () => {

--- a/test/unit_tests/organisms/MortgagePerformanceTrends/utils-spec.js
+++ b/test/unit_tests/organisms/MortgagePerformanceTrends/utils-spec.js
@@ -4,6 +4,7 @@ const BASE_JS_PATH = '../../../../cfgov/unprocessed/js/';
 
 const chai = require( 'chai' );
 const mockery = require( 'mockery' );
+const sinon = require( 'sinon' );
 const expect = chai.expect;
 
 // Disable the AJAX library used by the action creator
@@ -60,6 +61,12 @@ describe( 'Mortgage Performance utilities', () => {
       selected: false
     } );
     expect( option ).to.deep.equal( { value: 'AL', text: 'Alabama' } );
+  } );
+
+  it( 'should get county data', () => {
+    const cb = sinon.spy();
+    utils.getCountyData( cb );
+    expect( cb.called ).to.be.false;
   } );
 
   it( 'should be able to calculate zoom levels', () => {

--- a/test/unit_tests/organisms/MortgagePerformanceTrends/utils-spec.js
+++ b/test/unit_tests/organisms/MortgagePerformanceTrends/utils-spec.js
@@ -8,7 +8,7 @@ const sinon = require( 'sinon' );
 const expect = chai.expect;
 
 // Disable the AJAX library used by the action creator
-const noop = () => ( {} );
+const noop = () => ( { mock: 'data' } );
 mockery.enable( {
   warnOnReplace: false,
   warnOnUnregistered: false
@@ -65,8 +65,12 @@ describe( 'Mortgage Performance utilities', () => {
 
   it( 'should get county data', () => {
     const cb = sinon.spy();
-    utils.getCountyData( cb );
-    expect( cb.called ).to.be.false;
+    expect( utils.getCountyData( cb ) ).to.deep.equal( { mock: 'data' } );
+  } );
+
+  it( 'should get state data', () => {
+    const cb = sinon.spy();
+    expect( utils.getStateData( cb ) ).to.deep.equal( { mock: 'data' } );
   } );
 
   it( 'should be able to calculate zoom levels', () => {

--- a/test/unit_tests/organisms/MortgagePerformanceTrends/utils-spec.js
+++ b/test/unit_tests/organisms/MortgagePerformanceTrends/utils-spec.js
@@ -63,6 +63,16 @@ describe( 'Mortgage Performance utilities', () => {
     expect( option ).to.deep.equal( { value: 'AL', text: 'Alabama' } );
   } );
 
+  it( 'should get metro data', () => {
+    const cb = sinon.spy();
+    expect( utils.getMetroData( cb ) ).to.deep.equal( { mock: 'data' } );
+  } );
+
+  it( 'should get non-metro data', () => {
+    const cb = sinon.spy();
+    expect( utils.getNonMetroData( cb ) ).to.deep.equal( { mock: 'data' } );
+  } );
+
   it( 'should get county data', () => {
     const cb = sinon.spy();
     expect( utils.getCountyData( cb ) ).to.deep.equal( { mock: 'data' } );


### PR DESCRIPTION
Alrighty @marteki pull this down when you have a second and lmk how it looks. I ended up removing the non-metro `<select>` element and using the same U.S. state element that metros and counties use.

In order to accommodate the different valid U.S. states for metros, non-metros and counties, there are three new fetch methods for each location type that connect to the API and grab a list of valid states.

When toggling between the different location types, it'll attempt to preserve the selected state *if* it's valid for the new location type. E.g. If you're viewing Wyoming's non-metro area and you click the `metro` radio button, it won't preserve Wyoming in the U.S. state dropdown because Wyoming isn't a valid metro area state. It instead resets to the first item in the dropdown.

## Additions

- Action creators for fetching U.S. states.

## Removals

- Non-metro area dropdown.

## Testing

1. Pull down this branch and `./setup.sh`
2. Set up the [mortgage performance API](https://github.com/cfpb/cfgov-refresh/pull/3189).
3. Create a [mortgage chart block, mortgage map block, and page](https://github.com/cfpb/cfgov-refresh/pull/3260).
4. Toggle between the metro, non-metro and county dropdowns above the line chart and the selected U.S. state should persist. 

## Screenshots

<img width="712" alt="screen shot 2017-10-14 at 1 42 15 pm" src="https://user-images.githubusercontent.com/1060248/31578027-14c9f136-b0e7-11e7-8a53-2325620e12fe.png">

## Checklist

* [x] PR has an informative and human-readable title
* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [x] Passes all existing automated tests
* [x] Any *change* in functionality is tested
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices
* [x] Project documentation has been updated
* [x] Reviewers requested with the [Reviewer tool](https://help.github.com/articles/about-pull-request-reviews/) :arrow_right:
