### PR TITLE
Mortgage performance: Exclude Puerto Rico from exports

### DIFF
--- a/cfgov/data_research/scripts/export_public_csvs.py
+++ b/cfgov/data_research/scripts/export_public_csvs.py
@@ -21,6 +21,7 @@ from data_research.mortgage_utilities.s3_utils import (
 from data_research.mortgage_utilities.fips_meta import FIPS, load_fips_meta
 
 NATION_QUERYSET = NationalMortgageData.objects.all()
+STATES_TO_IGNORE = ['72']  # Excluding Puerto Rico from project launch
 
 
 NATION_STARTER = {
@@ -151,7 +152,8 @@ def export_downloadable_csv(geo_type, late_value):
             'queryset': StateMortgageData.objects.all(),
             'headings': ['RegionType', 'Name', 'FIPSCode'],
             'fips_list': sorted(
-                [state.fips for state in State.objects.all()])
+                [state.fips for state in State.objects.exclude(
+                    fips__in=STATES_TO_IGNORE)])
         },
     }
     slug = "{}Mortgages{}DaysLate-thru-{}".format(


### PR DESCRIPTION
Data from Puerto Rico has been deemed out of scope for this project's
launch. This ensures that Puerto Rico (and any other states we want to
exclude) don't show up in download CSV files.

## Testing

The updated script has been run against our latest data, and our state-based CSVs are now free of Puerto Rico references.
- http://files.consumerfinance.gov.s3.amazonaws.com/data/mortgage-performance/downloads/StateMortgagesPercent-90-plusDaysLate-thru-2017-03.csv
- http://files.consumerfinance.gov.s3.amazonaws.com/data/mortgage-performance/downloads/StateMortgagesPercent-30-89DaysLate-thru-2017-03.csv

