### PR TITLE
Fix for oah style reference which is causing build problems

### DIFF
--- a/cfgov/jinja2/v1/owning-a-home/mortgage-estimate/index.html
+++ b/cfgov/jinja2/v1/owning-a-home/mortgage-estimate/index.html
@@ -10,7 +10,7 @@
 {% endblock %}
 
 {% block css %}
-    <link rel="stylesheet" href="{{ static('css/owning-a-home/main.css') }}">
+    <link rel="stylesheet" href="{{ static('/owning-a-home/main.css') }}">
     {{ super() }}
 {% endblock css %}
 

--- a/gulp/tasks/styles.js
+++ b/gulp/tasks/styles.js
@@ -232,7 +232,7 @@ function stylesOAH() {
       inline: [ 'none' ]
     } ) )
     .pipe( gulpHeader( configBanner, { pkg: configPkg } ) )
-    .pipe( gulp.dest( configStyles.dest + '/owning-a-home/' ) )
+    .pipe( gulp.dest( configLegacy.dest + '/owning-a-home/' ) )
     .pipe( browserSync.reload( {
       stream: true
     } ) );


### PR DESCRIPTION
Fix for oah style reference which is causing build problems

## Changes

- Moved the base OAH stylesheet up a level so the file references work. 

## Testing

1. Run gulp styles.

## Checklist

* [ ] PR has an informative and human-readable title
* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [ ] Passes all existing automated tests
* [ ] Any *change* in functionality is tested
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated
* [ ] Reviewers requested with the [Reviewer tool](https://help.github.com/articles/about-pull-request-reviews/) :arrow_right:
