### PR TITLE
Fix for asset references owning-a-home/mortgage-estimate/index.html

### DIFF
--- a/cfgov/jinja2/v1/owning-a-home/mortgage-estimate/index.html
+++ b/cfgov/jinja2/v1/owning-a-home/mortgage-estimate/index.html
@@ -10,7 +10,7 @@
 {% endblock %}
 
 {% block css %}
-    <link rel="stylesheet" href="{{ static('/owning-a-home/main.css') }}">
+    <link rel="stylesheet" href="{{ static('oah/main.css') }}">
     {{ super() }}
 {% endblock css %}
 

--- a/cfgov/unprocessed/css/apps/owning-a-home/form-resources.less
+++ b/cfgov/unprocessed/css/apps/owning-a-home/form-resources.less
@@ -86,21 +86,21 @@
 
         .respond-to-max( 660px, {
             .hero_img {
-                background-image:url('../../img/form-resources_mortgage-estimate-hero-small.png');
+                background-image:url('../img/form-resources_mortgage-estimate-hero-small.png');
                 background-size: 320px 170px;
             }
         } );
 
         .respond-to-min( 661px, {
             .hero_wrapper {
-                background-image:url('../../img/form-resources_mortgage-estimate-hero-medium.png');
+                background-image:url('../img/form-resources_mortgage-estimate-hero-medium.png');
                 background-size: 400px 310px;
             }
         } );
 
         .respond-to-min( 992px, {
             .hero_wrapper {
-                background-image:url('../../img/form-resources_mortgage-estimate-hero-large.png');
+                background-image:url('../img/form-resources_mortgage-estimate-hero-large.png');
                 background-size: 730px 425px;
               }
         } );

--- a/gulp/tasks/styles.js
+++ b/gulp/tasks/styles.js
@@ -232,7 +232,7 @@ function stylesOAH() {
       inline: [ 'none' ]
     } ) )
     .pipe( gulpHeader( configBanner, { pkg: configPkg } ) )
-    .pipe( gulp.dest( configLegacy.dest + '/owning-a-home/' ) )
+    .pipe( gulp.dest( configLegacy.dest + '/oah/' ) )
     .pipe( browserSync.reload( {
       stream: true
     } ) );


### PR DESCRIPTION
Fix for asset references owning-a-home/mortgage-estimate/index.html

## Changes

- Modified code to adjust asset references.

## Testing

1. Run gulp build and visit `http://localhost:8000/owning-a-home/mortgage-estimate/`

## Screenshots


## Notes

-

## Todos

-

## Checklist

* [ ] PR has an informative and human-readable title
* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [ ] Passes all existing automated tests
* [ ] Any *change* in functionality is tested
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated
* [ ] Reviewers requested with the [Reviewer tool](https://help.github.com/articles/about-pull-request-reviews/) :arrow_right:
