### PR TITLE
Log CSP violation parsing failures

### DIFF
--- a/cfgov/core/tests/test_views.py
+++ b/cfgov/core/tests/test_views.py
@@ -332,3 +332,29 @@ class TestExternalURLNoticeView(TestCase):
         request = self.factory.post('/')
         with self.assertRaises(Http404):
             view(request)
+
+
+class TestCSPReportView(TestCase):
+    def test_valid_report(self):
+        report = """{
+  "csp-report": {
+    "document-uri": "http://example.com/signup.html",
+    "referrer": "",
+    "blocked-uri": "http://example.com/css/style.css",
+    "violated-directive": "style-src cdn.example.com",
+    "original-policy": "default-src 'none'; style-src cdn.example.com; report-uri /_/csp-reports"
+  }
+}"""  # noqa: E501
+        response = self.client.post('/csp-report/', report,
+                                    content_type="application/json")
+        self.assertEquals(response.status_code, 200)
+
+    def test_invalid_report(self):
+        report = """{"contents": "just some JSON" }"""  # noqa: E501
+        response = self.client.post('/csp-report/', report,
+                                    content_type="application/json")
+        self.assertEquals(response.status_code, 400)
+
+    def test_invalid_method(self):
+        response = self.client.get('/csp-report/')
+        self.assertEquals(response.status_code, 405)

--- a/cfgov/core/views.py
+++ b/cfgov/core/views.py
@@ -4,8 +4,8 @@ import logging
 import requests
 from django.conf import settings
 from django.contrib import messages
-from django.http import (Http404, HttpResponse, HttpResponseForbidden,
-                         HttpResponseBadRequest, JsonResponse)
+from django.http import (Http404, HttpResponse, HttpResponseBadRequest,
+                         JsonResponse)
 from django.shortcuts import redirect
 from django.utils.decorators import method_decorator
 from django.views.decorators.csrf import csrf_exempt
@@ -134,22 +134,21 @@ def submit_comment(data):
 
 
 @csrf_exempt
+@require_http_methods(['POST'])
 def csp_violation_report(request):
-    if request.method == 'POST':
-        try:
-            csp_dict = json.loads(request.body)['csp-report']
-        # bare except is non-ideal, but if parsing fails for any reason
-        # we need to abort
-        except:
-            logger.error('could not parse CSP report: ' + request.body)
-            return HttpResponseBadRequest()
+    try:
+        csp_dict = json.loads(request.body)['csp-report']
+    # bare except is non-ideal, but if parsing fails for any reason
+    # we need to abort
+    except:
+        logger.error('could not parse CSP report: ' + request.body)
+        return HttpResponseBadRequest()
 
-        message_template = ('{blocked-uri} blocked on {document-uri}, '
-                            'violated {violated-directive}')
-        message = message_template.format(**csp_dict)
-        logger.error(message)
-        return HttpResponse()
-    return HttpResponseForbidden()
+    message_template = ('{blocked-uri} blocked on {document-uri}, '
+                        'violated {violated-directive}')
+    message = message_template.format(**csp_dict)
+    logger.error(message)
+    return HttpResponse()
 
 
 class ExternalURLNoticeView(FormMixin, TemplateView):

--- a/cfgov/core/views.py
+++ b/cfgov/core/views.py
@@ -4,7 +4,7 @@ import logging
 import requests
 from django.conf import settings
 from django.contrib import messages
-from django.http import (Http404, HttpResponse, HttpResponseForbidden, 
+from django.http import (Http404, HttpResponse, HttpResponseForbidden,
                          HttpResponseBadRequest, JsonResponse)
 from django.shortcuts import redirect
 from django.utils.decorators import method_decorator

--- a/cfgov/core/views.py
+++ b/cfgov/core/views.py
@@ -4,8 +4,8 @@ import logging
 import requests
 from django.conf import settings
 from django.contrib import messages
-from django.http import (Http404, HttpResponse, HttpResponseForbidden,
-                         JsonResponse)
+from django.http import (Http404, HttpResponse, HttpResponseForbidden, 
+                         HttpResponseBadRequest, JsonResponse)
 from django.shortcuts import redirect
 from django.utils.decorators import method_decorator
 from django.views.decorators.csrf import csrf_exempt
@@ -141,7 +141,8 @@ def csp_violation_report(request):
         # bare except is non-ideal, but if parsing fails for any reason
         # we need to abort
         except:
-            return HttpResponseForbidden()
+            logger.error('could not parse CSP report: ' + request.body)
+            return HttpResponseBadRequest()
 
         message_template = ('{blocked-uri} blocked on {document-uri}, '
                             'violated {violated-directive}')


### PR DESCRIPTION
We seem to be getting a lot of [CSP violation reports](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP#Enabling_reporting) that aren't matching our expectations (a valid JSON dictionary, with a top-level 'csp-report'. This change will start logging those reports, giving us some visibility into what might be going on.

They will also raise a more appropriate HTTP status (400), instead of 403.

## Changes

- Log un-parseable violation reports
- Raise 400 when this happens, instead of 403

## Checklist

* [ ] PR has an informative and human-readable title
* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [ ] Passes all existing automated tests
* [ ] Any *change* in functionality is tested
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated
* [ ] Reviewers requested with the [Reviewer tool](https://help.github.com/articles/about-pull-request-reviews/) :arrow_right:
