### PR TITLE
Only show MP state container when necessary

### DIFF
--- a/cfgov/unprocessed/js/organisms/MortgagePerformanceTrends/apps/chart.js
+++ b/cfgov/unprocessed/js/organisms/MortgagePerformanceTrends/apps/chart.js
@@ -172,14 +172,16 @@ MortgagePerformanceLineChart.prototype.renderChartForm = function( prevState, st
   utils.hideEl( this.$container.querySelector( '#mp-state-non-metro-helper-text' ) );
   if ( geoType === 'county' ) {
     utils.showEl( this.$container.querySelector( '#mp-state-county-helper-text' ) );
+    utils.showEl( this.$container.querySelector( '#mp-line-chart-state-container' ) );
   }
   if ( geoType === 'metro' ) {
     utils.showEl( this.$container.querySelector( '#mp-state-metro-helper-text' ) );
+    utils.showEl( this.$container.querySelector( '#mp-line-chart-state-container' ) );
   }
   if ( geoType === 'non-metro' ) {
     utils.showEl( this.$container.querySelector( '#mp-state-non-metro-helper-text' ) );
+    utils.showEl( this.$container.querySelector( '#mp-line-chart-state-container' ) );
   }
-  utils.showEl( this.$container.querySelector( '#mp-line-chart-state-container' ) );
   if ( geoType ) {
     utils.showEl( this.$compareContainer );
   } else {


### PR DESCRIPTION
@higs4281 @marteki Now that we have a new state dropdown we need to hide it when not in use. There's some pretty stupid repetition here but I'll refactor it when I return into an element selecting utility function.

## Additions

-

## Removals

-

## Changes

- Hide state dropdown when not in use.

## Checklist

* [x] PR has an informative and human-readable title
* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [x] Passes all existing automated tests
* [x] Any *change* in functionality is tested
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices
* [x] Project documentation has been updated
* [x] Reviewers requested with the [Reviewer tool](https://help.github.com/articles/about-pull-request-reviews/) :arrow_right:
