### PR TITLE
Mortgage performance: restore whitelist update

### DIFF
--- a/cfgov/data_research/mortgage_utilities/fips_meta.py
+++ b/cfgov/data_research/mortgage_utilities/fips_meta.py
@@ -147,7 +147,9 @@ def load_county_mappings():
     """Add lists of counties and non-MSA counties to state_fips attribute."""
     from data_research.models import MortgageMetaData
     msa_meta = MortgageMetaData.objects.get(name='state_msa_meta').json_value
-    for each in FIPS.state_fips:
+    live_fips = [fips for fips in FIPS.state_fips
+                 if fips not in NON_STATES.values()]
+    for each in live_fips:
         _attr = FIPS.state_fips[each]
         abbr = _attr['abbr']
         _attr['counties'] = (


### PR DESCRIPTION
In refactoring our data-processing pipeline, an update routine for our
global FIPS whitelist got left out. This restores it.

There was also a late decision to exclude Puerto Rico from our charts and maps for launch, and this also ensures Puerto Rico is excluded from metadata references for now.

## Testing
You can check that the metadata are getting updated by running the update script and checking the API endpoint for state_county_meta:

```
python cfgov/manage.py runscript update_county_msa_meta
```

Then check http://localhost:8000/data-research/mortgages/api/v1/metadata/state_county_meta/ and search for "Bossier"

Bossier Parish's "valid" value should be "false"
