### PR TITLE
Wrap /company-signup/ page in a feature flag

### DIFF
--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -534,6 +534,9 @@ FLAGS = {
     # When enabled, Display a "techical issues" banner on /complaintdatabase
     'CCDB_TECHNICAL_ISSUES': {},
 
+    # When enabled, use wagtail for /company-signup/ (instead of selfregistration app)
+    'WAGTAIL_COMPANY_SIGNUP': {},
+
     # IA changes to mega menu for user testing
     # When enabled, the mega menu under "Consumer Tools" is arranged by topic
     'IA_USER_TESTING_MENU': {},

--- a/cfgov/cfgov/urls.py
+++ b/cfgov/cfgov/urls.py
@@ -10,6 +10,7 @@ from django.shortcuts import render
 from django.views.generic.base import RedirectView, TemplateView
 from wagtail.wagtailadmin import urls as wagtailadmin_urls
 from wagtailsharing import urls as wagtailsharing_urls
+from wagtailsharing.views import ServeView
 
 from flags.urls import flagged_url
 
@@ -469,7 +470,9 @@ if settings.ALLOW_ADMIN_URL:
 
 if 'selfregistration' in settings.INSTALLED_APPS:
     from selfregistration.views import CompanySignup
-    pattern = url(r'^company-signup/', CompanySignup.as_view())
+    pattern = flagged_url('WAGTAIL_COMPANY_SIGNUP', r'^company-signup/',
+                          CompanySignup.as_view(), state=False,
+                          fallback=lambda req: ServeView.as_view()(req, req.path)) # noqa
     urlpatterns.append(pattern)
 
 if settings.DEBUG:
@@ -516,6 +519,7 @@ def handle_error(code, request):
 
         return HttpResponse("This request could not be processed, "
                             "HTTP Error %s." % str(code), status=code)
+
 
 handler404 = partial(handle_error, 404)
 handler500 = partial(handle_error, 500)


### PR DESCRIPTION
We are moving this page into wagtail! By default, this PR doesn't change anything. Enable the WAGTAIL_COMPANY_SIGNUP flag to *disable* the existing company-signup page, and allow a wagtail page with that URL to shine through.

## Additions

- WAGTAIL_COMPANY_SIGNUP

## Changes

- urls.py changes to accomodate the new flag


## Todos

- After we've switched this flag permanently , we should remove the 'selfregistration' app.

## Checklist

* [ ] PR has an informative and human-readable title
* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [ ] Passes all existing automated tests
* [ ] Any *change* in functionality is tested
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated
* [ ] Reviewers requested with the [Reviewer tool](https://help.github.com/articles/about-pull-request-reviews/) :arrow_right:
