### PR TITLE
Whistleblower footer

### DIFF
--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -576,6 +576,9 @@ FLAGS = {
 
     # The release of the consumer Financial Well Being Scale app
     'FWB_RELEASE': {},
+
+    # The release of new Whistleblowers content/pages
+    'WHISTLEBLOWER_RELEASE': {},
 }
 
 

--- a/cfgov/jinja2/v1/_includes/organisms/footer.html
+++ b/cfgov/jinja2/v1/_includes/organisms/footer.html
@@ -44,11 +44,13 @@
                         Careers
                     </a>
                 </li>
+                {% if flag_enabled('WHISTLEBLOWER_RELEASE', request) %}
                 <li class="m-list_item">
                     <a class="m-list_link" href="/policy-compliance/enforcement/information-industry-whistleblowers/">
                         Industry Whistleblowers
                     </a>
                 </li>
+                {% endif %}
                 <li class="m-list_item">
                     <a class="m-list_link" href="/cfpb-ombudsman/">
                         CFPB Ombudsman

--- a/cfgov/jinja2/v1/_includes/organisms/footer.html
+++ b/cfgov/jinja2/v1/_includes/organisms/footer.html
@@ -45,6 +45,11 @@
                     </a>
                 </li>
                 <li class="m-list_item">
+                    <a class="m-list_link" href="/policy-compliance/enforcement/information-industry-whistleblowers/">
+                        Industry Whistleblowers
+                    </a>
+                </li>
+                <li class="m-list_item">
                     <a class="m-list_link" href="/cfpb-ombudsman/">
                         CFPB Ombudsman
                     </a>


### PR DESCRIPTION
Adds a footer entry and Wagtail flag for Whistleblower content.

## Testing

1. Run `./runserver.sh`
1. Load http://localhost:8000/ and scroll to the bottom. Verify "Industry Whistleblowers" does not appear next to "CFPB Ombudsman".
1. Go to the Wagtail admin flags interface http://localhost:8000/admin/flags/ and enable `WHISTLEBLOWER_RELEASE`
1. Reload http://localhost:8000/ and verify "Industry Whistleblowers" now appears in the footer.