### PR TITLE
Skip machine setup if a default machine exists. Change port mapping t…

### DIFF
--- a/docker-environment.sh
+++ b/docker-environment.sh
@@ -2,25 +2,27 @@
 # we don't need to mess with docker-machine
 docker ps 2>/dev/null
 if [ $? -eq 0 ]; then
+  echo "docker machine up and running!"
   DOCKER_SANE=1
 else
-   MACHINE_IP=$(docker-machine ip cfgov)
-
+   MACHINE_IP=$(docker-machine ip)
     if [ -z "$MACHINE_IP" ]; then
-        docker-machine ls | grep cfgov
-        if [ $? -gt 0 ]; then
-            # like above--if the "cfgov" machine doesn't exist, create it
-            docker-machine create cfgov  --driver virtualbox\
-                --virtualbox-cpu-count "2"\
-                --virtualbox-memory "3072" 
-            vboxmanage controlvm cfgov natpf1 "mysql,tcp,,3306,,3306"
-            vboxmanage controlvm cfgov natpf1 "pdfreactor,tcp,,9423,,9423"
-            vboxmanage controlvm cfgov natpf1 "es1,tcp,,9200,,9200"
-            vboxmanage controlvm cfgov natpf1 "es2,tcp,,9300,,9300"
-        fi
+      echo "No default docker machine found, creating one now..."
+      docker-machine create default --driver virtualbox\
+        --virtualbox-cpu-count "2"\
+        --virtualbox-memory "3072" 
     fi
     # harmless if the machine is already up:
-    docker-machine start cfgov
+    echo "Starting docker machine..."
+    docker-machine start
     # inject environment variables needed for docker/compose:
-    eval $(docker-machine env cfgov)
+    eval $(docker-machine env)
 fi
+
+echo "Setting MySQL and Elasticsearch envvars..."
+MACHINE_IP=$(docker-machine ip)
+export MYSQL_HOST="$MACHINE_IP"
+export MYSQL_NAME='v1'
+export MYSQL_USER='v1'
+export MYSQL_PASSWORD='v1'
+export ES_HOST="$MACHINE_IP"

--- a/start-services.sh
+++ b/start-services.sh
@@ -1,5 +1,8 @@
 #/bin/bash
-
+echo "Setting up docker environment..."
 source ./docker-environment.sh
+echo "Docker environment setup complete!"
 
+echo "Starting docker services"
 docker-compose up -d
+echo "MySQL and Elasticsearch are now setup in docker!"


### PR DESCRIPTION
…o envvar setup.

## Changes

- Changes docker setup to use environment variables to connect to MySQL and Elasticsearch instead of mapping ports in virtualbox.

## Testing

1. Pull and run ./start-services, both with an existing docker-machine and without one.