### PR TITLE
Removing wp-content reference from /students page

### DIFF
--- a/cfgov/legacy/templates/students/index.html
+++ b/cfgov/legacy/templates/students/index.html
@@ -96,7 +96,7 @@
         <div class="col">
             <h3><a href="/students/knowbeforeyouowe/">Know Before You Owe</a></h3>
             <p>In partnership with the Department of Education, we’ve developed a <a href="https://collegecost.ed.gov/shopping_sheet.pdf">financial aid shopping sheet</a> to improve the way schools communicate financial aid offers. More than 3,000 colleges have agreed to use the shopping sheet.</p>
-            <p><a href="/wp-content/uploads/2012/01/Memorandum_KBYOStudentLoans_FeedbackSummary_Jan2012.pdf"><strong>What we heard</strong></a> – We released a prototype and received feedback from the public.</p>
+            <p><a href="https://s3.amazonaws.com/files.consumerfinance.gov/f/2012/01/Memorandum_KBYOStudentLoans_FeedbackSummary_Jan2012.pdf"><strong>What we heard</strong></a> – We released a prototype and received feedback from the public.</p>
             <p><a href="/blog/does-your-college-help-you-know-before-you-owe/"><strong>Does your college help you know before you owe?</strong></a></p>
         </div>
         <div class="col">


### PR DESCRIPTION
Removing wp-content reference from /students page

## Changes

- Modified `Removing wp-content reference from /students page` to remove `wp-content` reference. 