### PR TITLE
Bump regulations-site from 2.1.11 to 2.1.12

### DIFF
--- a/requirements/optional-public.txt
+++ b/requirements/optional-public.txt
@@ -2,7 +2,7 @@ https://github.com/cfpb/college-costs/releases/download/2.3.12/college_costs-2.3
 https://github.com/cfpb/complaint/releases/download/1.4.2/complaintdatabase-1.4.2-py2-none-any.whl
 git+https://github.com/cfpb/owning-a-home-api.git@0.9.96#egg=owning-a-home-api
 git+https://github.com/cfpb/regulations-core.git@1.2.5#egg=regcore
-https://github.com/cfpb/regulations-site/releases/download/2.1.11/regulations-2.1.11-py2-none-any.whl
+https://github.com/cfpb/regulations-site/releases/download/2.1.12/regulations-2.1.12-py2-none-any.whl
 https://github.com/cfpb/retirement/releases/download/0.5.13/retirement-0.5.13-py2-none-any.whl
 git+https://github.com/cfpb/ccdb5-api.git@v0.9.2#egg=ccdb5-api
 git+https://github.com/cfpb/ccdb5-ui.git@v0.7.34#egg=ccdb5_ui


### PR DESCRIPTION
This commit bumps the optional [regulations-site](https://github.com/cfpb/regulations-site) package from version 2.1.11 to 2.1.12. This fixes a minor issue with missing diffs.

## Changes

- Bump regulations-site from version 2.1.11 to 2.1.12.

## Checklist

* [X] PR has an informative and human-readable title
* [X] Changes are limited to a single goal (no scope creep)
* [X] Code can be automatically merged (no conflicts)
* [X] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [X] Passes all existing automated tests
* [X] Any *change* in functionality is tested
* [X] Reviewers requested with the [Reviewer tool](https://help.github.com/articles/about-pull-request-reviews/) :arrow_right:
