### PR TITLE
Fixing issue with double require for email popup module

### DIFF
--- a/cfgov/unprocessed/js/organisms/EmailPopup.js
+++ b/cfgov/unprocessed/js/organisms/EmailPopup.js
@@ -1,6 +1,5 @@
 'use strict';
 
-var helpers = require( '../modules/util/email-popup-helpers' );
 var FormSubmit = require( './FormSubmit.js' );
 var validators = require( '../modules/util/validators' );
 var emailHelpers = require( '../modules/util/email-popup-helpers' );
@@ -27,7 +26,7 @@ function EmailPopup( el ) {
    */
   function hidePopup() {
     _baseElement.classList.remove( VISIBLE_CLASS );
-    helpers.recordEmailPopupClosure();
+    emailHelpers.recordEmailPopupClosure();
   }
 
   /**
@@ -35,9 +34,9 @@ function EmailPopup( el ) {
    * @returns {boolean} true.
    */
   function showPopup() {
-    if ( helpers.showEmailPopup() ) {
+    if ( emailHelpers.showEmailPopup() ) {
       _baseElement.classList.add( VISIBLE_CLASS );
-      helpers.recordEmailPopupView();
+      emailHelpers.recordEmailPopupView();
     }
 
     return true;


### PR DESCRIPTION
Fixing issue with double require for email popup module

## Changes

- Modified code to require `email-popup-helpers` only once. 

## Testing

1. Run gulp build and visit `http://localhost:8000/owning-a-home/mortgage-estimate/` and ensure email popup only runs once. 


## Checklist

* [ ] PR has an informative and human-readable title
* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [ ] Passes all existing automated tests
* [ ] Any *change* in functionality is tested
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated
* [ ] Reviewers requested with the [Reviewer tool](https://help.github.com/articles/about-pull-request-reviews/) :arrow_right:
