### PR TITLE
Differentiate GHE issues posted via logging from alerts

### DIFF
--- a/cfgov/alerts/github_alert.py
+++ b/cfgov/alerts/github_alert.py
@@ -33,7 +33,7 @@ class GithubAlert(object):
         issues = self.repo().iter_issues(state='all')
         return next((issue for issue in issues if issue.title == title), None)
 
-    def post(self, title, body):
+    def post(self, title, body, labels=['Maintenance and Response', 'alert']):
         # Truncate the title if needed, max is 256 chars
         title = title[:256]
         issue = self.matching_issue(title)
@@ -47,9 +47,6 @@ class GithubAlert(object):
             issue = self.repo().create_issue(
                 title=title,
                 body=body,
-                labels=[
-                    'Maintenance and Response',
-                    'alert'
-                ],
+                labels=labels,
             )
         return issue

--- a/cfgov/alerts/logging_handlers.py
+++ b/cfgov/alerts/logging_handlers.py
@@ -21,7 +21,12 @@ class CFGovErrorHandler(logging.Handler):
         body = self.format_body(record)
 
         github_api = GithubAlert(credentials={})
-        github_api.post(title=title, body=body)
+        github_api.post(title=title,
+                        body=body,
+                        labels=[
+                            'logging',
+                            'Maintenance and Response'
+                        ])
 
     def format_title(self, record):
         return record.getMessage()


### PR DESCRIPTION
This PR changes the `GitHubAlert.post` to take an optional `labels` kwarg, and the logging handler to use that kwarg to assign the `logging` label instead of `alert`. This is because, as we've seen, some logged issues are not singularly actionable, instead they are all related to the same single problem. This is contrary to our alert policy, where we want each individual alert to be actionable. The practical effect of this is that a large number of issues opened by the logging handler obscures other issues when filtering for "alert" (and makes it very difficult, at least for me, to find other alert issues I'm looking for). Thus I am proposing that we open logged issues with a different tag, `logging`. 

## Notes

This PR is currently based on #3516, when that PR is merged I'll rebase to master. @chosak refactored some of this code in that PR, and it seemed like the best starting point.

## Checklist

* [ ] PR has an informative and human-readable title
* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [ ] Passes all existing automated tests
* [ ] Any *change* in functionality is tested
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated
* [ ] Reviewers requested with the [Reviewer tool](https://help.github.com/articles/about-pull-request-reviews/) :arrow_right:
