### PR TITLE
Adding tox environment for testing asset validation

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -76,9 +76,9 @@ setenv={[testenv:fast]setenv}
 
 [testenv:missing-migrations]
 # Invoke with: tox -e missing-migrations
-# Check for changes to Django models that are missing migrations by 
+# Check for changes to Django models that are missing migrations by
 # running a script that calls makemigrations and examines the result.
-# The missing_migrations script can be removed in favor of 
+# The missing_migrations script can be removed in favor of
 # `makemigrations --check` when we move to Django 1.10+.
 envdir={[testenv]envdir}
 recreate=False
@@ -87,4 +87,23 @@ setenv=
     {[testenv]setenv}
     DJANGO_SETTINGS_MODULE=cfgov.settings.test
 commands=
-    ./manage.py runscript missing_migrations 
+    ./manage.py runscript missing_migrations
+
+[testenv:validate-assets]
+# Invoke with: tox -e validate-assets
+# Ensure all assets are generated without error.
+envdir={[testenv]envdir}
+changedir={toxinidir}
+recreate=False
+deps=
+    -r{toxinidir}/requirements/mysql.txt
+    {[testenv]deps}
+    -r{toxinidir}/requirements/optional-public.txt
+    -r{toxinidir}/requirements/optional-private.txt
+setenv=
+    {[testenv]setenv}
+    DJANGO_SETTINGS_MODULE=cfgov.settings.production
+    DJANGO_STATIC_ROOT={toxinidir}/collectstatic
+commands=
+    {toxinidir}/frontend.sh production
+    {toxinidir}/cfgov/manage.py collectstatic --noinput


### PR DESCRIPTION
Adding tox environment for testing asset validation

## Changes

- Modified `frontend.sh` to add a `dry-run` function.

## Testing

1. Run `tox -e validate-assets -v` and hope you don't see `[object object]`.
2. You can run `tail -f ` on the log file to check the dependency build cycle.

## Screenshots


## Notes

-

## Todos

-

## Checklist

* [ ] PR has an informative and human-readable title
* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [ ] Passes all existing automated tests
* [ ] Any *change* in functionality is tested
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated
* [ ] Reviewers requested with the [Reviewer tool](https://help.github.com/articles/about-pull-request-reviews/) :arrow_right:
