### PR TITLE
Correctly output info unit image and heading links

### DIFF
--- a/cfgov/jinja2/v1/_includes/molecules/info-unit-2.html
+++ b/cfgov/jinja2/v1/_includes/molecules/info-unit-2.html
@@ -61,7 +61,7 @@
 {%- if value.image.upload %}
     {%- set img = image(value.image.upload, 'original') %}
     {% if link_image_and_heading %}
-        <a href="{{ value.links[0].url }}">
+        <a href="{{ parse_links( value.links[0].url ) | safe }}">
     {% endif %}
         {%- if value.image.alt %}
             <img class="m-info-unit_image
@@ -85,7 +85,8 @@
 
     {%- if value.heading %}
         {% if link_image_and_heading %}
-            <a class="m-info-unit_heading-link" href="{{ value.links[0].url }}">
+            <a class="m-info-unit_heading-link"
+               href="{{ parse_links( value.links[0].url ) | safe }}">
         {%- endif %}
                 <{{ value.heading.level -}}
                     {%- if value.heading.icon -%}


### PR DESCRIPTION
Currently if the info unit link points to an outside resource it creates
an interstitial page warning the user they are leaving the site. The
linked image and heading were not getting that interstitial url and were
directing the user to the outside resource without warning.

## Changes

- Updated the template to parse the links prior to outputting them.

## Testing

1. Create a page with an 25/75 info unit and set the link to an outside resource (ex: a YouTube video). Note that the url printed to the page includes our interstitial page (https://www.consumerfinance.gov/external-site/)

## Checklist

* [x] PR has an informative and human-readable title
* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [x] Passes all existing automated tests
* [ ] Any *change* in functionality is tested
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices
* [x] Project documentation has been updated
* [x] Reviewers requested with the [Reviewer tool](https://help.github.com/articles/about-pull-request-reviews/) :arrow_right:
