### PR TITLE
Move inline JS to external requests

### DIFF
--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -218,8 +218,6 @@ MEDIA_URL = '/f/'
 #Enabling compression for use in base.html
 COMPRESS_ENABLED = True
 
-COMPRESS_ROOT = MEDIA_ROOT
-
 COMPRESS_JS_FILTERS = []
 
 # List of finder classes that know how to find static files in

--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -171,6 +171,7 @@ TEMPLATES = [
     },
 ]
 
+
 WSGI_APPLICATION = 'cfgov.wsgi.application'
 
 # Admin Url Access
@@ -212,6 +213,14 @@ STATIC_ROOT = os.environ.get('DJANGO_STATIC_ROOT', '/var/www/html/static')
 MEDIA_ROOT = os.environ.get('MEDIA_ROOT',
                             os.path.join(PROJECT_ROOT, 'f'))
 MEDIA_URL = '/f/'
+
+
+#Enabling compression for use in base.html
+COMPRESS_ENABLED = True
+
+COMPRESS_ROOT = MEDIA_ROOT
+
+COMPRESS_JS_FILTERS = []
 
 # List of finder classes that know how to find static files in
 # various locations.

--- a/cfgov/jinja2/v1/_layouts/base.html
+++ b/cfgov/jinja2/v1/_layouts/base.html
@@ -243,32 +243,42 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 {% block javascript scoped %}
 <!--[if gt IE 8]><!-->
 {# Include site-wide JavaScript. #}
-<script>
-    {% include '/js/routes/common.js' %}
-</script>
+<script src="{{ static('js/routes/common.js') }}"></script>
 
-{# Include template and page-specific JavaScript. #}
-{% macro page_template_js() %}
-    {# Check and include template-level JavaScript. #}
-    {% include '/js/routes/' + request.path.split('/')[1] + '/single.js' ignore missing %}
-
-    {# TODO: Remove Else conditional when this is fully moved to wagtail. #}
-    {# Check and include page-level JavaScript. #}
-    {% if page and page.media %}
-        {% for type, jsfiles in page.media.iteritems() %}
-            {% for js in jsfiles %}
-                {% include '/js/routes/on-demand/' + js ignore missing %}
-            {% endfor %}
-        {% endfor %}
-    {% else %}
-        {% include '/js/routes/' + request.path[1:] + 'index.js' ignore missing %}
-    {% endif %}
+{# Check and include template-level JavaScript. #}
+{% macro template_js() %}
+    {% include 'js/routes/' + request.path.split('/')[1] + '/single.js' ignore missing %}
 {% endmacro %}
-{% set js_source = page_template_js() | trim %}
+{% set js_source = template_js() | trim %}
 {% if js_source | length > 0 %}
-<script>
-    {{ js_source }}
-</script>
+<script src="{{ static('js/routes/' + request.path.split('/')[1] + '/single.js') }}"></script>
+{% endif %}
+
+{# Check and include component-level JavaScript. #}
+{% macro component_ondemand_js(js) %}
+    {% include 'js/routes/on-demand/' + js ignore missing %}
+{% endmacro %}
+
+{% if page and page.media %}
+   {% for type, jsfiles in page.media.iteritems() %}
+       {% for js in jsfiles %}
+           {% set js_source = component_ondemand_js(js) | trim %}
+           {% if js_source | length > 0 %}
+           <script src="{{ static('js/routes/on-demand/' + js) }}"></script>
+           {% endif %}
+       {% endfor %}
+    {% endfor %}
+{% endif %}
+
+{# TODO: Remove the below block when all pages
+         using this template are moved to Wagtail. #}
+{# Check and include page-level JavaScript. #}
+{% macro page_js() %}
+    {% include 'js/routes/' + request.path[1:] + 'index.js' ignore missing %}
+{% endmacro %}
+{% set js_source = page_js() | trim %}
+{% if js_source | length > 0 %}
+<script src="{{ static('js/routes/' + request.path[1:] + 'index.js') }}"></script>
 {% endif %}
 <!--<![endif]-->
 

--- a/cfgov/jinja2/v1/_layouts/base.html
+++ b/cfgov/jinja2/v1/_layouts/base.html
@@ -260,14 +260,18 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 {% endmacro %}
 
 {% if page and page.media %}
-   {% for type, jsfiles in page.media.iteritems() %}
+    {% compress js %}
+    <script>
+    {% for type, jsfiles in page.media.iteritems() %}
        {% for js in jsfiles %}
-           {% set js_source = component_ondemand_js(js) | trim %}
-           {% if js_source | length > 0 %}
-           <script src="{{ static('js/routes/on-demand/' + js) }}"></script>
+           {% set compononet_js_source = component_ondemand_js(js) | trim %}
+           {% if compononet_js_source | length > 0 %}
+                {{ compononet_js_source }}
            {% endif %}
        {% endfor %}
     {% endfor %}
+    </script>
+    {% endcompress %}
 {% endif %}
 
 {# TODO: Remove the below block when all pages

--- a/config/webpack-config.js
+++ b/config/webpack-config.js
@@ -4,7 +4,6 @@
 
 'use strict';
 
-const BannerFooterPlugin = require( 'banner-footer-webpack-plugin' );
 const path = require( 'path' );
 const environment = require( '../config/environment' );
 const paths = environment.paths;
@@ -72,9 +71,7 @@ const modernConf = {
     new webpack.optimize.CommonsChunkPlugin( {
       name: COMMON_BUNDLE_NAME
     } ),
-    COMMON_UGLIFY_CONFIG,
-    // Wrap JS in raw Jinja tags so included JS won't get parsed by Jinja.
-    new BannerFooterPlugin( '{% raw %}', '{% endraw %}', { raw: true } )
+    COMMON_UGLIFY_CONFIG
   ]
 };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "resolved": "https://registry.npmjs.org/@gulp-sourcemaps/identity-map/-/identity-map-1.0.1.tgz",
       "integrity": "sha1-z6I7xYQPkQTOMqZedNt+epdLvuE=",
       "requires": {
-        "acorn": "5.2.1",
+        "acorn": "5.1.2",
         "css": "2.2.1",
         "normalize-path": "2.1.1",
         "source-map": "0.5.7",
@@ -25,9 +25,9 @@
       }
     },
     "@types/node": {
-      "version": "6.0.90",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.90.tgz",
-      "integrity": "sha512-tXoGRVdi7wZX7P1VWoV9Wfk0uYDOAHdEYXAttuWgSrN76Q32wQlSrMX0Rgyv3RTEaQY2ZLQrzYHVM2e8rfo8sA==",
+      "version": "6.0.89",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.89.tgz",
+      "integrity": "sha512-Z/67L97+6H1qJiEEHSN1SQapkWjDss1D90rAnFcQ6UxKkah9juzotK5UNEP1bDv/0lJ3NAQTnVfc/JWdgCGruA==",
       "dev": true
     },
     "@types/q": {
@@ -83,16 +83,16 @@
         "lodash.partialright": "4.2.1",
         "lodash.pick": "4.4.0",
         "lodash.uniq": "4.5.0",
-        "resolve": "1.5.0",
+        "resolve": "1.4.0",
         "semver": "5.4.1",
         "uglify-js": "2.8.29",
         "when": "3.7.8"
       }
     },
     "acorn": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.2.1.tgz",
-      "integrity": "sha512-jG0u7c4Ly+3QkkW18V+NRDN+4bWHdln30NL1ZL2AvFZZmQe/BfopYCtghCKKVBUSetZ4QKcyA0pY6/4Gw8Pv8w=="
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.1.2.tgz",
+      "integrity": "sha512-o96FZLJBPY1lvTuJylGA9Bk3t/GKPPJG8H0ydQQl01crzwJgspa4AEIq/pVTXigmK0PHVQhiAtn8WMBLL9D2WA=="
     },
     "acorn-dynamic-import": {
       "version": "2.0.2",
@@ -115,7 +115,7 @@
       "integrity": "sha512-KjZwU26uG3u6eZcfGbTULzFcsoz6pegNKtHPksZPOUsiKo5bUmiBPa38FuHZ/Eun+XYh/JCCkS9AS3Lu4McQOQ==",
       "dev": true,
       "requires": {
-        "acorn": "5.2.1"
+        "acorn": "5.1.2"
       }
     },
     "acorn-jsx": {
@@ -390,9 +390,9 @@
       "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
     },
     "asn1.js": {
-      "version": "4.9.2",
-      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.9.2.tgz",
-      "integrity": "sha512-b/OsSjvWEo8Pi8H0zsDd2P6Uqo2TK2pH8gNLSJtNLM2Db0v2QaAZ0pBQJXVjAn4gBuugeVDr7s63ZogpUIwWDg==",
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.9.1.tgz",
+      "integrity": "sha1-SLokC0WpKA6UdImQull9IWYX/UA=",
       "requires": {
         "bn.js": "4.11.8",
         "inherits": "2.0.3",
@@ -468,12 +468,12 @@
       "integrity": "sha1-NCQX2PLzRhsUzwkIjV7fh5HcmDI="
     },
     "autoprefixer": {
-      "version": "7.1.6",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-7.1.6.tgz",
-      "integrity": "sha512-C9yv/UF3X+eJTi/zvfxuyfxmLibYrntpF3qoJYrMeQwgUJOZrZvpJiMG2FMQ3qnhWtF/be4pYONBBw95ZGe3vA==",
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-7.1.5.tgz",
+      "integrity": "sha512-sMN453qIm8Z+tunzYWW+Y490wWkICHhCYm/VohLjjl+N7ARSFuF5au7E6tr7oEbeeXj8mNjpSw2kxjJaO6YCOw==",
       "requires": {
-        "browserslist": "2.6.1",
-        "caniuse-lite": "1.0.30000756",
+        "browserslist": "2.5.1",
+        "caniuse-lite": "1.0.30000746",
         "normalize-range": "0.1.2",
         "num2fraction": "1.2.2",
         "postcss": "6.0.13",
@@ -1011,7 +1011,7 @@
         "babel-plugin-transform-es2015-unicode-regex": "6.24.1",
         "babel-plugin-transform-exponentiation-operator": "6.24.1",
         "babel-plugin-transform-regenerator": "6.26.0",
-        "browserslist": "2.6.1",
+        "browserslist": "2.5.1",
         "invariant": "2.2.2",
         "semver": "5.4.1"
       }
@@ -1092,12 +1092,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
-    },
-    "banner-footer-webpack-plugin": {
-      "version": "git://github.com/dtothefp/banner-footer-webpack-plugin.git#96a1f3914d5390cb8ab1b9c2532a346cf407ee54",
-      "requires": {
-        "webpack-core": "0.4.8"
-      }
     },
     "base64-arraybuffer": {
       "version": "0.1.5",
@@ -1328,7 +1322,7 @@
       "requires": {
         "ansi-align": "2.0.0",
         "camelcase": "4.1.0",
-        "chalk": "2.3.0",
+        "chalk": "2.1.0",
         "cli-boxes": "1.0.0",
         "string-width": "2.1.1",
         "term-size": "1.2.0",
@@ -1354,13 +1348,13 @@
           "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
         },
         "chalk": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
-          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
+          "integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
           "requires": {
             "ansi-styles": "3.2.0",
             "escape-string-regexp": "1.0.5",
-            "supports-color": "4.5.0"
+            "supports-color": "4.4.0"
           }
         },
         "is-fullwidth-code-point": {
@@ -1386,9 +1380,9 @@
           }
         },
         "supports-color": {
-          "version": "4.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
-          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "version": "4.4.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
+          "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
           "requires": {
             "has-flag": "2.0.0"
           }
@@ -1544,12 +1538,12 @@
       }
     },
     "browserslist": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-2.6.1.tgz",
-      "integrity": "sha512-HBZwVT7ciQB9KlXM3AUMQbnQXtHWPsEUKQTiS0BEFfY5bOrMl94ORaqQD1GyuTGh69ZmYeue9QBqiw219e09eQ==",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-2.5.1.tgz",
+      "integrity": "sha512-jAvM2ku7YDJ+leAq3bFH1DE0Ylw+F+EQDq4GkqZfgPEqpWYw9ofQH85uKSB9r3Tv7XDbfqVtE+sdvKJW7IlPJA==",
       "requires": {
-        "caniuse-lite": "1.0.30000756",
-        "electron-to-chromium": "1.3.27"
+        "caniuse-lite": "1.0.30000746",
+        "electron-to-chromium": "1.3.26"
       }
     },
     "bs-recipes": {
@@ -1710,9 +1704,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30000756",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000756.tgz",
-      "integrity": "sha1-PacBwVIbn6uHAExt58l/pH2+qtI="
+      "version": "1.0.30000746",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000746.tgz",
+      "integrity": "sha1-xk+Vo5Jc/TAgejCO12wa6W6gnqA="
     },
     "capitalize": {
       "version": "1.0.0",
@@ -1791,7 +1785,7 @@
     "cf-core": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/cf-core/-/cf-core-4.5.0.tgz",
-      "integrity": "sha512-MUdo0pq9r5TGU1TxzxJaw8hXBLdDIHWXRMGltuaAv5CF5Zvw/aY5d0PQDxvhMHR88thtqqHb/i83qP4yMqI9yA==",
+      "integrity": "sha1-DIP4H5th72QMx2m7EhBuNEiM/Ak=",
       "requires": {
         "normalize-css": "2.3.1",
         "normalize-legacy-addon": "0.1.0"
@@ -1931,7 +1925,7 @@
             "babel-plugin-transform-es2015-unicode-regex": "6.24.1",
             "babel-plugin-transform-exponentiation-operator": "6.24.1",
             "babel-plugin-transform-regenerator": "6.26.0",
-            "browserslist": "2.6.1",
+            "browserslist": "2.5.1",
             "invariant": "2.2.2",
             "semver": "5.4.1"
           }
@@ -2298,7 +2292,7 @@
       "resolved": "https://registry.npmjs.org/coa/-/coa-1.0.4.tgz",
       "integrity": "sha1-qe8VNmDWqGqL3sAomlxoTSF0Mv0=",
       "requires": {
-        "q": "1.5.1"
+        "q": "1.5.0"
       }
     },
     "code-point-at": {
@@ -2396,7 +2390,7 @@
       "requires": {
         "dot-prop": "4.2.0",
         "graceful-fs": "4.1.11",
-        "make-dir": "1.1.0",
+        "make-dir": "1.0.0",
         "unique-string": "1.0.0",
         "write-file-atomic": "2.3.0",
         "xdg-basedir": "3.0.0"
@@ -2690,7 +2684,7 @@
         "lodash": "4.17.4",
         "mz": "2.7.0",
         "progress": "2.0.0",
-        "resolve": "1.5.0",
+        "resolve": "1.4.0",
         "stack-chain": "2.0.0",
         "stacktrace-js": "2.0.0",
         "string-argv": "0.0.2",
@@ -2699,6 +2693,15 @@
         "verror": "1.10.0"
       },
       "dependencies": {
+        "cucumber-expressions": {
+          "version": "5.0.2",
+          "resolved": "https://registry.npmjs.org/cucumber-expressions/-/cucumber-expressions-5.0.2.tgz",
+          "integrity": "sha1-9OA8Jpi9Q+kgEaBV2cTOV3GLkbA=",
+          "dev": true,
+          "requires": {
+            "becke-ch--regex--s0-0-v1--base--pl--lib": "1.2.0"
+          }
+        },
         "figures": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
@@ -2719,16 +2722,13 @@
           "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.0.tgz",
           "integrity": "sha1-ihvjZr+Pwj2yvSPxDG/pILQ4nR8=",
           "dev": true
+        },
+        "stack-chain": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/stack-chain/-/stack-chain-2.0.0.tgz",
+          "integrity": "sha512-GGrHXePi305aW7XQweYZZwiRwR7Js3MWoK/EHzzB9ROdc75nCnjSJVi21rdAGxFl+yCx2L2qdfl5y7NO4lTyqg==",
+          "dev": true
         }
-      }
-    },
-    "cucumber-expressions": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/cucumber-expressions/-/cucumber-expressions-5.0.2.tgz",
-      "integrity": "sha1-9OA8Jpi9Q+kgEaBV2cTOV3GLkbA=",
-      "dev": true,
-      "requires": {
-        "becke-ch--regex--s0-0-v1--base--pl--lib": "1.2.0"
       }
     },
     "cucumber-tag-expressions": {
@@ -3244,7 +3244,7 @@
         "strip-dirs": "1.1.1",
         "through2": "2.0.3",
         "vinyl": "1.2.0",
-        "yauzl": "2.9.1"
+        "yauzl": "2.8.0"
       },
       "dependencies": {
         "vinyl": {
@@ -3302,6 +3302,13 @@
         "p-map": "1.2.0",
         "pify": "3.0.0",
         "rimraf": "2.6.2"
+      },
+      "dependencies": {
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+        }
       }
     },
     "delayed-stream": {
@@ -3710,9 +3717,9 @@
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
     },
     "electron-to-chromium": {
-      "version": "1.3.27",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.27.tgz",
-      "integrity": "sha1-eOy4o5kGYYe7N07t412ccFZagD0="
+      "version": "1.3.26",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.26.tgz",
+      "integrity": "sha1-mWQnKUhhp02cfIK5Jg6jAejALWY="
     },
     "elliptic": {
       "version": "6.4.0",
@@ -4047,7 +4054,7 @@
         "file-entry-cache": "2.0.0",
         "glob": "7.1.2",
         "globals": "9.18.0",
-        "ignore": "3.3.7",
+        "ignore": "3.3.5",
         "imurmurhash": "0.1.4",
         "inquirer": "0.12.0",
         "is-my-json-valid": "2.16.1",
@@ -4091,7 +4098,7 @@
       "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.1.tgz",
       "integrity": "sha1-DJiLirRttTEAoZVK5LqZXd0n2H4=",
       "requires": {
-        "acorn": "5.2.1",
+        "acorn": "5.1.2",
         "acorn-jsx": "3.0.1"
       }
     },
@@ -4170,6 +4177,13 @@
         "pify": "3.0.0",
         "rimraf": "2.6.2",
         "tempfile": "2.0.0"
+      },
+      "dependencies": {
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+        }
       }
     },
     "exec-series": {
@@ -4444,7 +4458,7 @@
       "integrity": "sha1-kojj6ePMN0hxfTnq3hfPcfww7m8=",
       "requires": {
         "commondir": "1.0.1",
-        "make-dir": "1.1.0",
+        "make-dir": "1.0.0",
         "pkg-dir": "2.0.0"
       }
     },
@@ -4557,11 +4571,6 @@
             "pify": "2.3.0",
             "pinkie-promise": "2.0.1"
           }
-        },
-        "pify": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
         }
       }
     },
@@ -5855,13 +5864,6 @@
         "object-assign": "4.1.1",
         "pify": "2.3.0",
         "pinkie-promise": "2.0.1"
-      },
-      "dependencies": {
-        "pify": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
-        }
       }
     },
     "globule": {
@@ -5923,7 +5925,7 @@
       "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-0.10.0.tgz",
       "integrity": "sha1-bhW6vuhf0d0U2NEoopW2g41SE24=",
       "requires": {
-        "gtoken": "1.2.3",
+        "gtoken": "1.2.2",
         "jws": "3.1.4",
         "lodash.noop": "3.0.1",
         "request": "2.81.0"
@@ -6056,9 +6058,9 @@
       }
     },
     "gtoken": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-1.2.3.tgz",
-      "integrity": "sha512-wQAJflfoqSgMWrSBk9Fg86q+sd6s7y6uJhIvvIPz++RElGlMtEqsdAR2oWwZ/WTEtp7P9xFbJRrT976oRgzJ/w==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-1.2.2.tgz",
+      "integrity": "sha1-Fyd2oanZasCfwioA9b6DzubeiCA=",
       "requires": {
         "google-p12-pem": "0.1.2",
         "jws": "3.1.4",
@@ -6105,7 +6107,7 @@
       "resolved": "https://registry.npmjs.org/gulp-autoprefixer/-/gulp-autoprefixer-4.0.0.tgz",
       "integrity": "sha1-4AqMVxuF0GUWrCY0G+kN/Z/B6rA=",
       "requires": {
-        "autoprefixer": "7.1.6",
+        "autoprefixer": "7.1.5",
         "gulp-util": "3.0.8",
         "postcss": "6.0.13",
         "through2": "2.0.3",
@@ -6173,13 +6175,6 @@
         "gulp-util": "3.0.8",
         "pify": "2.3.0",
         "through2": "2.0.3"
-      },
-      "dependencies": {
-        "pify": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
-        }
       }
     },
     "gulp-clean-css": {
@@ -6330,7 +6325,7 @@
       "requires": {
         "accord": "0.27.3",
         "gulp-util": "3.0.8",
-        "less": "2.7.3",
+        "less": "2.7.2",
         "object-assign": "4.1.1",
         "through2": "2.0.3",
         "vinyl-sourcemaps-apply": "0.2.1"
@@ -6347,6 +6342,69 @@
         "req-cwd": "1.0.1",
         "temp": "0.8.3",
         "through": "2.3.8"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.9.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+          "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
+          "requires": {
+            "graceful-readlink": "1.0.1"
+          }
+        },
+        "debug": {
+          "version": "2.6.8",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+          "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "glob": {
+          "version": "7.1.1",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
+          "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
+        },
+        "has-flag": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+        },
+        "mocha": {
+          "version": "3.5.3",
+          "resolved": "https://registry.npmjs.org/mocha/-/mocha-3.5.3.tgz",
+          "integrity": "sha512-/6na001MJWEtYxHOV1WLfsmR4YIynkUEhBwzsb+fk2qmQ3iqsi258l/Q2MWHJMImAcNpZ8DEdYAK72NHoIQ9Eg==",
+          "requires": {
+            "browser-stdout": "1.3.0",
+            "commander": "2.9.0",
+            "debug": "2.6.8",
+            "diff": "3.2.0",
+            "escape-string-regexp": "1.0.5",
+            "glob": "7.1.1",
+            "growl": "1.9.2",
+            "he": "1.1.1",
+            "json3": "3.3.2",
+            "lodash.create": "3.1.1",
+            "mkdirp": "0.5.1",
+            "supports-color": "3.1.2"
+          }
+        },
+        "supports-color": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
+          "integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
+          "requires": {
+            "has-flag": "1.0.0"
+          }
+        }
       }
     },
     "gulp-modernizr": {
@@ -6841,7 +6899,7 @@
         "lodash": "4.17.4",
         "make-error-cause": "1.2.2",
         "through2": "2.0.3",
-        "uglify-js": "3.1.6",
+        "uglify-js": "3.1.4",
         "vinyl-sourcemaps-apply": "0.2.1"
       },
       "dependencies": {
@@ -6851,9 +6909,9 @@
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
         },
         "uglify-js": {
-          "version": "3.1.6",
-          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.1.6.tgz",
-          "integrity": "sha512-/rseyxEKEVMBo8279lqpoJgD6C/i/CIi+9TJDvWmb+Xo6mqMKwjA8Io3IMHlcXQzj99feR6zrN8m3wqqvm/nYA==",
+          "version": "3.1.4",
+          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.1.4.tgz",
+          "integrity": "sha512-DcbkPg11Lw2lAWpwCmQDX+qoR4JiII6ypsQmF6tscZtlxGPFAmSRUGuMoVT3/0EHqypVik/TpkH4ITiMJeQqQA==",
           "requires": {
             "commander": "2.11.0",
             "source-map": "0.6.1"
@@ -7174,9 +7232,9 @@
       "integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE="
     },
     "ignore": {
-      "version": "3.3.7",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.7.tgz",
-      "integrity": "sha512-YGG3ejvBNHRqu0559EOxxNFihD0AjpvHlC/pdGKd3X3ofe+CoJkYazwNJYTNebqpPKN+VVQbh4ZFn1DivMNuHA=="
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.5.tgz",
+      "integrity": "sha512-JLH93mL8amZQhh/p6mfQgVBH3M6epNq3DfsXsTSuSrInVjwyYlFE1nv2AgfRCC8PoOhM0jwQ5v8s9LgbK7yGDw=="
     },
     "image-size": {
       "version": "0.5.5",
@@ -7191,17 +7249,12 @@
       "requires": {
         "file-type": "4.4.0",
         "globby": "6.1.0",
-        "make-dir": "1.1.0",
+        "make-dir": "1.0.0",
         "p-pipe": "1.2.0",
         "pify": "2.3.0",
         "replace-ext": "1.0.0"
       },
       "dependencies": {
-        "pify": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
-        },
         "replace-ext": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
@@ -7393,9 +7446,9 @@
       }
     },
     "is-buffer": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
+      "integrity": "sha1-Hzsm72E7IUuIy8ojzGwB2Hlh7sw="
     },
     "is-builtin-module": {
       "version": "1.0.0",
@@ -7634,11 +7687,6 @@
             "unzip-response": "2.0.1",
             "url-parse-lax": "1.0.0"
           }
-        },
-        "pify": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
         },
         "timed-out": {
           "version": "4.0.1",
@@ -7973,7 +8021,7 @@
       "dev": true,
       "requires": {
         "abab": "1.0.4",
-        "acorn": "5.2.1",
+        "acorn": "5.1.2",
         "acorn-globals": "4.1.0",
         "array-equal": "1.0.0",
         "content-type-parser": "1.0.2",
@@ -8316,9 +8364,9 @@
       }
     },
     "just-extend": {
-      "version": "1.1.27",
-      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-1.1.27.tgz",
-      "integrity": "sha512-mJVp13Ix6gFo3SBAy9U/kL+oeZqzlYYYLQBwXVBlVzIsZwBqGREnOro24oC/8s8aox+rJhtZ2DiQof++IrkA+g==",
+      "version": "1.1.26",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-1.1.26.tgz",
+      "integrity": "sha512-IIG0FXHB/XpUZ7vGbktoc2EGsF+fLHJ1tU+vaqoKkVRBwH2FDxLTmkGkSp0XHRp6Y3KGZPIldH1YW8lOluGYrA==",
       "dev": true
     },
     "jwa": {
@@ -8347,7 +8395,7 @@
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
       "requires": {
-        "is-buffer": "1.1.6"
+        "is-buffer": "1.1.5"
       }
     },
     "klaw": {
@@ -8393,9 +8441,9 @@
       }
     },
     "less": {
-      "version": "2.7.3",
-      "resolved": "https://registry.npmjs.org/less/-/less-2.7.3.tgz",
-      "integrity": "sha512-KPdIJKWcEAb02TuJtaLrhue0krtRLoRoo7x6BNJIBelO00t/CCdJQUnHW5V34OnHMWzIktSalJxRO+FvytQlCQ==",
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/less/-/less-2.7.2.tgz",
+      "integrity": "sha1-No1sxz4fsDmBGDKAkYdDxdz5s98=",
       "requires": {
         "errno": "0.1.4",
         "graceful-fs": "4.1.11",
@@ -8446,7 +8494,7 @@
         "lodash.isstring": "4.0.1",
         "lodash.mapvalues": "4.6.0",
         "rechoir": "0.6.2",
-        "resolve": "1.5.0"
+        "resolve": "1.4.0"
       }
     },
     "lightbox2": {
@@ -8469,13 +8517,6 @@
         "pify": "2.3.0",
         "pinkie-promise": "2.0.1",
         "strip-bom": "2.0.0"
-      },
-      "dependencies": {
-        "pify": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
-        }
       }
     },
     "loader-runner": {
@@ -8951,11 +8992,11 @@
       }
     },
     "make-dir": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.1.0.tgz",
-      "integrity": "sha512-0Pkui4wLJ7rxvmfUvs87skoEaxmu0hCUApF8nonzpl7q//FWp9zu8W61Scz4sd/kUiqDxvUhtoam2efDyiBzcA==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.0.0.tgz",
+      "integrity": "sha1-l6ARdR6R3YfPre9Ygy67BJNt6Xg=",
       "requires": {
-        "pify": "3.0.0"
+        "pify": "2.3.0"
       }
     },
     "make-error": {
@@ -9186,69 +9227,6 @@
         }
       }
     },
-    "mocha": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-3.5.3.tgz",
-      "integrity": "sha512-/6na001MJWEtYxHOV1WLfsmR4YIynkUEhBwzsb+fk2qmQ3iqsi258l/Q2MWHJMImAcNpZ8DEdYAK72NHoIQ9Eg==",
-      "requires": {
-        "browser-stdout": "1.3.0",
-        "commander": "2.9.0",
-        "debug": "2.6.8",
-        "diff": "3.2.0",
-        "escape-string-regexp": "1.0.5",
-        "glob": "7.1.1",
-        "growl": "1.9.2",
-        "he": "1.1.1",
-        "json3": "3.3.2",
-        "lodash.create": "3.1.1",
-        "mkdirp": "0.5.1",
-        "supports-color": "3.1.2"
-      },
-      "dependencies": {
-        "commander": {
-          "version": "2.9.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
-          "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
-          "requires": {
-            "graceful-readlink": "1.0.1"
-          }
-        },
-        "debug": {
-          "version": "2.6.8",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-          "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "glob": {
-          "version": "7.1.1",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
-          "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
-          "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
-          }
-        },
-        "has-flag": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
-        },
-        "supports-color": {
-          "version": "3.1.2",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
-          "integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
-          "requires": {
-            "has-flag": "1.0.0"
-          }
-        }
-      }
-    },
     "mockery": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/mockery/-/mockery-2.1.0.tgz",
@@ -9445,7 +9423,7 @@
       "dev": true,
       "requires": {
         "formatio": "1.2.0",
-        "just-extend": "1.1.27",
+        "just-extend": "1.1.26",
         "lolex": "1.6.0",
         "path-to-regexp": "1.7.0",
         "text-encoding": "0.6.4"
@@ -9973,7 +9951,7 @@
       "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.0.tgz",
       "integrity": "sha1-N8T5t+06tlx0gXtfJICTf7+XxxI=",
       "requires": {
-        "asn1.js": "4.9.2",
+        "asn1.js": "4.9.1",
         "browserify-aes": "1.1.1",
         "create-hash": "1.1.3",
         "evp_bytestokey": "1.0.3",
@@ -10020,7 +9998,7 @@
       "integrity": "sha1-Be/1fw70V3+xRKefi5qWemzERRA=",
       "dev": true,
       "requires": {
-        "@types/node": "6.0.90"
+        "@types/node": "6.0.89"
       }
     },
     "parsejson": {
@@ -10125,13 +10103,6 @@
         "graceful-fs": "4.1.11",
         "pify": "2.3.0",
         "pinkie-promise": "2.0.1"
-      },
-      "dependencies": {
-        "pify": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
-        }
       }
     },
     "pathval": {
@@ -10163,9 +10134,9 @@
       "integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU="
     },
     "pify": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-      "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
     },
     "pinkie": {
       "version": "2.0.4",
@@ -10226,9 +10197,9 @@
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.13.tgz",
       "integrity": "sha512-nHsrD1PPTMSJDfU+osVsLtPkSP9YGeoOz4FDLN4r1DW4N5vqL1J+gACzTQHsfwIiWG/0/nV4yCzjTMo1zD8U1g==",
       "requires": {
-        "chalk": "2.3.0",
+        "chalk": "2.1.0",
         "source-map": "0.6.1",
-        "supports-color": "4.5.0"
+        "supports-color": "4.4.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -10240,13 +10211,13 @@
           }
         },
         "chalk": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
-          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
+          "integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
           "requires": {
             "ansi-styles": "3.2.0",
             "escape-string-regexp": "1.0.5",
-            "supports-color": "4.5.0"
+            "supports-color": "4.4.0"
           }
         },
         "source-map": {
@@ -10255,9 +10226,9 @@
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
         },
         "supports-color": {
-          "version": "4.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
-          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "version": "4.4.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
+          "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
           "requires": {
             "has-flag": "2.0.0"
           }
@@ -10360,7 +10331,7 @@
       "integrity": "sha1-myIXQXCaTGLVzVPGqt1UpxE36V8=",
       "dev": true,
       "requires": {
-        "@types/node": "6.0.90",
+        "@types/node": "6.0.89",
         "@types/q": "0.0.32",
         "@types/selenium-webdriver": "2.53.42",
         "blocking-proxy": "0.0.5",
@@ -10377,21 +10348,6 @@
         "webdriver-manager": "12.0.6"
       },
       "dependencies": {
-        "del": {
-          "version": "2.2.2",
-          "resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
-          "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
-          "dev": true,
-          "requires": {
-            "globby": "5.0.0",
-            "is-path-cwd": "1.0.0",
-            "is-path-in-cwd": "1.0.0",
-            "object-assign": "4.1.1",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1",
-            "rimraf": "2.6.2"
-          }
-        },
         "globby": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
@@ -10405,12 +10361,6 @@
             "pify": "2.3.0",
             "pinkie-promise": "2.0.1"
           }
-        },
-        "pify": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-          "dev": true
         },
         "q": {
           "version": "1.4.1",
@@ -10447,6 +10397,23 @@
             "rimraf": "2.6.2",
             "semver": "5.4.1",
             "xml2js": "0.4.19"
+          },
+          "dependencies": {
+            "del": {
+              "version": "2.2.2",
+              "resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
+              "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
+              "dev": true,
+              "requires": {
+                "globby": "5.0.0",
+                "is-path-cwd": "1.0.0",
+                "is-path-in-cwd": "1.0.0",
+                "object-assign": "4.1.1",
+                "pify": "2.3.0",
+                "pinkie-promise": "2.0.1",
+                "rimraf": "2.6.2"
+              }
+            }
           }
         }
       }
@@ -10460,7 +10427,7 @@
         "axe-webdriverjs": "0.2.0",
         "html-entities": "1.2.1",
         "lodash": "3.10.1",
-        "q": "1.5.1",
+        "q": "1.5.0",
         "request": "2.81.0"
       },
       "dependencies": {
@@ -10480,7 +10447,7 @@
       "requires": {
         "debug": "3.1.0",
         "glob": "7.1.2",
-        "q": "1.5.1",
+        "q": "1.5.0",
         "tmp": "0.0.33"
       },
       "dependencies": {
@@ -10530,13 +10497,6 @@
         "pretty-bytes": "4.0.2",
         "sort-on": "1.3.0",
         "update-notifier": "2.3.0"
-      },
-      "dependencies": {
-        "pify": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
-        }
       }
     },
     "public-encrypt": {
@@ -10586,9 +10546,9 @@
       "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
     },
     "q": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
-      "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc="
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/q/-/q-1.5.0.tgz",
+      "integrity": "sha1-3QG6ydBtMObyGa7LglPunr3DCPE="
     },
     "qs": {
       "version": "6.2.1",
@@ -10641,7 +10601,7 @@
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "requires": {
-                "is-buffer": "1.1.6"
+                "is-buffer": "1.1.5"
               }
             }
           }
@@ -10651,7 +10611,7 @@
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
           "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-buffer": "1.1.5"
           }
         }
       }
@@ -10767,7 +10727,7 @@
       "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
       "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
       "requires": {
-        "resolve": "1.5.0"
+        "resolve": "1.4.0"
       }
     },
     "redent": {
@@ -11048,9 +11008,9 @@
       }
     },
     "resolve": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz",
-      "integrity": "sha512-hgoSGrc3pjzAPHNBg+KnFcK2HwlHTs/YrAGUr6qgTVUZmXv1UEXXl0bZNBKMA9fud6lRYFdPGz0xXxycPzmmiw==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.4.0.tgz",
+      "integrity": "sha512-aW7sVKPufyHqOmyyLzg/J+8606v5nevBgaliIlV7nUpVMsDnoBGV/cbSLNjZAg9q0Cfd/+easKVKQ8vOu8fn1Q==",
       "requires": {
         "path-parse": "1.0.5"
       }
@@ -12121,12 +12081,6 @@
         "safe-buffer": "5.1.1"
       }
     },
-    "stack-chain": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/stack-chain/-/stack-chain-2.0.0.tgz",
-      "integrity": "sha512-GGrHXePi305aW7XQweYZZwiRwR7Js3MWoK/EHzzB9ROdc75nCnjSJVi21rdAGxFl+yCx2L2qdfl5y7NO4lTyqg==",
-      "dev": true
-    },
     "stack-generator": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/stack-generator/-/stack-generator-2.0.2.tgz",
@@ -12991,7 +12945,7 @@
       "integrity": "sha1-TognpruRUUCrCTVZ1wFOPruDdFE=",
       "requires": {
         "boxen": "1.2.2",
-        "chalk": "2.3.0",
+        "chalk": "2.1.0",
         "configstore": "3.1.1",
         "import-lazy": "2.1.0",
         "is-installed-globally": "0.1.0",
@@ -13010,19 +12964,19 @@
           }
         },
         "chalk": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
-          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
+          "integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
           "requires": {
             "ansi-styles": "3.2.0",
             "escape-string-regexp": "1.0.5",
-            "supports-color": "4.5.0"
+            "supports-color": "4.4.0"
           }
         },
         "supports-color": {
-          "version": "4.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
-          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "version": "4.4.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
+          "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
           "requires": {
             "has-flag": "2.0.0"
           }
@@ -13568,10 +13522,10 @@
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-3.8.1.tgz",
       "integrity": "sha512-5ZXLWWsMqHKFr5y0N3Eo5IIisxeEeRAajNq4mELb/WELOR7srdbQk2N5XiyNy2A/AgvlR3AmeBCZJW8lHrolbw==",
       "requires": {
-        "acorn": "5.2.1",
+        "acorn": "5.1.2",
         "acorn-dynamic-import": "2.0.2",
-        "ajv": "5.3.0",
-        "ajv-keywords": "2.1.1",
+        "ajv": "5.2.3",
+        "ajv-keywords": "2.1.0",
         "async": "2.5.0",
         "enhanced-resolve": "3.4.1",
         "escope": "3.6.0",
@@ -13593,20 +13547,20 @@
       },
       "dependencies": {
         "ajv": {
-          "version": "5.3.0",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.3.0.tgz",
-          "integrity": "sha1-RBT/dKUIecII7l/cgm4ywwNUnto=",
+          "version": "5.2.3",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.2.3.tgz",
+          "integrity": "sha1-wG9Zh3jETGsWGrr+NGa4GtGBTtI=",
           "requires": {
             "co": "4.6.0",
             "fast-deep-equal": "1.0.0",
-            "fast-json-stable-stringify": "2.0.0",
-            "json-schema-traverse": "0.3.1"
+            "json-schema-traverse": "0.3.1",
+            "json-stable-stringify": "1.0.1"
           }
         },
         "ajv-keywords": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.1.tgz",
-          "integrity": "sha1-YXmX/F9gV2iUxDX5QNgZ4TW4B2I="
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.0.tgz",
+          "integrity": "sha1-opbhf3v658HOT34N5T0pyzIWLfA="
         },
         "ansi-regex": {
           "version": "3.0.0",
@@ -13659,11 +13613,6 @@
           "requires": {
             "pify": "2.3.0"
           }
-        },
-        "pify": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
         },
         "read-pkg": {
           "version": "2.0.0",
@@ -13755,24 +13704,6 @@
           "integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
           "requires": {
             "camelcase": "4.1.0"
-          }
-        }
-      }
-    },
-    "webpack-core": {
-      "version": "0.4.8",
-      "resolved": "https://registry.npmjs.org/webpack-core/-/webpack-core-0.4.8.tgz",
-      "integrity": "sha1-B/xVq6gdF9uoyuWkPWvWkjb4tfg=",
-      "requires": {
-        "source-map": "0.1.43"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.1.43",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
-          "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
-          "requires": {
-            "amdefine": "1.0.1"
           }
         }
       }
@@ -14092,9 +14023,9 @@
       }
     },
     "yauzl": {
-      "version": "2.9.1",
-      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.9.1.tgz",
-      "integrity": "sha1-qBmB6nCleUYTOIPwKcWCGok1mn8=",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.8.0.tgz",
+      "integrity": "sha1-eUUK/yKyqcWkHvVOAtuQfM+/nuI=",
       "requires": {
         "buffer-crc32": "0.2.13",
         "fd-slicer": "1.0.1"

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "babel-core": "6.26.0",
     "babel-loader": "7.1.2",
     "babel-preset-env": "1.6.1",
-    "banner-footer-webpack-plugin": "git://github.com/dtothefp/banner-footer-webpack-plugin.git",
     "browser-sync": "2.18.13",
     "cf-atomic-component": "1.5.1",
     "cf-buttons": "4.5.1",


### PR DESCRIPTION
To decrease the time to first paint of the page, we should aim to reduce the HTML page size. One step to doing that is removing the inlined JS. (Part of https://[GHE]/CFGOV/platform/issues/1824).

## Removals

- `banner-footer-webpack-plugin` plugin.
 
## Changes

- Removes inlined JS and moves it instead to external JS asset requests.

## Testing

1. `./frontend.sh` and check

http://localhost:8000/about-us/careers/current-openings/ for testing template-level script (single.js)
http://localhost:8000/ask-cfpb/ for testing page-level script (index.js)
http://localhost:8000/about-us/the-bureau/bureau-structure/ for testing on-demand script (on-demand/bureau-structure.js)

**Note: I don't think you need `./cfgov/manage.py collectstatic`, but try that if the scripts 404.

## Screenshots

HTML byte size before:
![screen shot 2017-10-31 at 12 39 45 pm](https://user-images.githubusercontent.com/704760/32236745-6da41174-be39-11e7-8ad6-e38eec09f11e.png)

HTML byte size after:
![screen shot 2017-10-31 at 12 39 49 pm](https://user-images.githubusercontent.com/704760/32236749-7245c2a4-be39-11e7-897d-131a1d14e46a.png)