### PR TITLE
Add feature flag for recruitment code comment

### DIFF
--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -525,10 +525,13 @@ FLAGS = {
         'site': 'beta.consumerfinance.gov',
     },
 
-    # When enabled, Display a "techical issues" banner on /complaintdatabase
+    # When enabled, include a recruitment code comment in the base template.
+    'CFPB_RECRUITING': {},
+
+    # When enabled, display a "techical issues" banner on /complaintdatabase
     'CCDB_TECHNICAL_ISSUES': {},
 
-    # When enabled, use wagtail for /company-signup/ (instead of selfregistration app)
+    # When enabled, use Wagtail for /company-signup/ (instead of selfregistration app)
     'WAGTAIL_COMPANY_SIGNUP': {},
 
     # IA changes to mega menu for user testing

--- a/cfgov/jinja2/v1/_layouts/base.html
+++ b/cfgov/jinja2/v1/_layouts/base.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-
+{% if flag_enabled('CFPB_RECRUITING', request) %}
 <!--
     ============================================================================
 
@@ -17,6 +17,7 @@
 
     ============================================================================
 -->
+{% endif %}
 <!--[if IE 8]>         <html lang="en" class="no-js lt-ie10 lt-ie9"> <![endif]-->
 <!--[if IE 9]>         <html lang="en" class="no-js lt-ie10"> <![endif]-->
 <!--[if gt IE 8]><!--> <html lang="en" class="no-js"> <!--<![endif]-->


### PR DESCRIPTION
To reduce the first paint time of the page we should reduce the size of the HTML page (see https://[GHE]/CFGOV/platform/issues/1824). Removing unused code comments is a way to do this. When we're not recruiting for a fellowship we don't need to show this code block. This flag could also be used to show other recruitment campaigns across the site.

## Additions

- Adds a feature flag `CFPB_RECRUITING` for showing or hiding the recruitment code comment in the base template's HTML source.

## Testing

1. Visit the site locally and view the source. There should be no recruitment code comment at the top.
2. Log into /admin Wagtail locally and set `CFPB_RECRUITING` flag boolean to true.
3. Re-visit site locally and view the source. There should be a recruitment code comment.

## Screenshots

![screen shot 2017-10-31 at 1 17 10 pm](https://user-images.githubusercontent.com/704760/32238450-2a10add2-be3e-11e7-89c7-a1ccafbd92a1.png)

## Notes

I think this can be off in production? We're not hiring are we? @ascott1 Can you confirm?