### PR TITLE
Move code comments to the server

### DIFF
--- a/cfgov/jinja2/v1/_includes/organisms/header.html
+++ b/cfgov/jinja2/v1/_includes/organisms/header.html
@@ -87,8 +87,13 @@
 
     </div>
     <!--[if gt IE 8]><!-->
+      {#
+        TODO: scope no-js to individual molecules/organisms.
+        This is a hack to fix no-js on the on-demand header,
+        while also allowing the menu to be scoped to o-header
+        for on-demand pages.
+      #}
       <script>
-      /* TODO: scope no-js to individual molecules/organisms. This is a hack to fix no-js on the on-demand header, while also allowing the menu to be scoped to o-header for on-demand pages. */
       var headerDom = document.querySelector( '.o-header_content' );
       headerDom.className = headerDom.className.replace( 'no-js', 'js' );
       </script>

--- a/cfgov/jinja2/v1/_layouts/base.html
+++ b/cfgov/jinja2/v1/_layouts/base.html
@@ -23,11 +23,11 @@
 
 <head prefix="og: http://ogp.me/ns# fb: http://ogp.me/ns/fb# {% block og_article_prefix %}{% endblock %}">
 
-<!--
+{#
     ===========
     GLOBAL META
     ===========
--->
+#}
 
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta charset="utf-8">
@@ -35,11 +35,11 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     {% endblock meta_viewport %}
 
-<!--
+{#
     ==================
     PAGE-SPECIFIC META
     ==================
--->
+#}
 
     <title>
         {% block title -%}
@@ -59,8 +59,8 @@
             {%- endblock -%}
           ">
 
-    <!-- Open Graph properties -->
-        <!-- Required  -->
+    {# Open Graph properties #}
+        {# Required Open Graph properties #}
         <meta property="og:title" content="{% block og_title %}{{ self.title() }}{% endblock %}">
         <meta property="og:type" content="{% block og_type %}website{% endblock %}">
         <meta property="og:url" content="{{ request.url }}">
@@ -79,7 +79,7 @@
               content="{{ request.scheme }}://{{ request.get_host() }}{{ static('img/logo_open-graph_twitter.png') }}">
     {% endif %}
 {% endblock %}
-        <!--  Optional -->
+        {# Optional Open Graph properties #}
         <meta property="og:description"
               content="
                   {%- block og_desc -%}
@@ -89,21 +89,21 @@
                   {%- endblock -%}
               ">
         <meta property="og:site_name" content="Consumer Financial Protection Bureau">
-        <!-- Facebook -->
+        {# Facebook Open Graph properties #}
         <meta property="fb:app_id" content="210516218981921">
         {% block og_article_author %}{% endblock %}
-    <!-- End of Open Graph properties -->
+    {# End of Open Graph properties #}
 
     <link rel="shortcut icon" type="image/x-icon" href="{{ static('assets/favicon.ico') }}">
 
-<!--
+{#
     ======
     STYLES
     ======
     The number of stylesheets here must be kept to a minimum.
     Unless adding a significant amount of CSS that is specific to a single page or section of the site,
     all new styles should be added to cfgov/v1/unprocessed/css/main.less.
--->
+#}
 
 {% block css %}
 <!--[if lt IE 9]><link rel="stylesheet" href="{{ static('css/main.ie8.css') }}"><![endif]-->
@@ -111,7 +111,7 @@
 <!--[if gt IE 9]><!--><link rel="stylesheet" href="{{ static('css/main.css') }}"><!--<![endif]-->
 {% endblock css %}
 
-<!--
+{#
     ============
     HEAD SCRIPTS
     ============
@@ -119,14 +119,12 @@
     All other scripts should go before the closing body tag.
     If you come across a script that makes a convincing case to be included in
     the head, then file an issue or PR to discuss including it.
--->
+#}
 
     {% if flag_enabled('AB_TESTING', request) %}
-    <!-- Google Optimize page-hiding snippet -->
+    {# Google Optimize page-hiding snippet #}
     <style>
-        .optimize-loading {
-            opacity: 0 !important;
-        }
+        .optimize-loading { opacity: 0 !important; }
     </style>
     <script>
         (function(a,s,y,n,c,h,i,d,e){s.className+=' '+y;h.start=1*new Date;
@@ -135,9 +133,14 @@
         })(window,document.documentElement,'optimize-loading','dataLayer',5000,
         {'GTM-KHB8MB':true});
     </script>
-    <!-- end Google Optimize page-hiding snippet -->
+    {# end Google Optimize page-hiding snippet #}
 
-    <!-- Google Analytics/Optimize snippet -->
+    {# Google Analytics/Optimize snippet #}
+    {#
+      The last line in the script requires Optimize.
+      Pageview call removed, because pagviews are sent to Analytics via
+      the Google Tag Manager tag (code included below).
+    #}
     <script>
         (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
         (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
@@ -145,20 +148,18 @@
         })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
 
         ga('create', 'UA-54439736-1', 'auto');
-        ga('require', 'GTM-KHB8MB'); // Require Optimize
-        // Pageview call removed, because pagviews are sent to Analytics via
-        // the Google Tag Manager tag (code included below).
+        ga('require', 'GTM-KHB8MB');
     </script>
-    <!-- end Google Analytics/Optimize snippet -->
+    {# end Google Analytics/Optimize snippet #}
     {% endif %}
 
-    <!-- Google Tag Manager -->
+    {# Google Tag Manager #}
     <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
     new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
     j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
     })(window,document,'script','dataLayer','GTM-KMMLRS');</script>
-    <!-- end Google Tag Manager -->
+    {# end Google Tag Manager #}
 
     {# Customized Modernizr build that includes html5shiv.
        Built via gulp-modernizer in `scripts.js` task. #}
@@ -174,8 +175,8 @@
     //]]>
     </script>
     <!--[if lt IE 9]>
+    {# If in IE8 reverse no-js/js class change made by modernizr. #}
     <script>
-        // If in IE8 reverse no-js/js class change made by modernizr.
         var docElement = document.documentElement;
         docElement.className = docElement.className.replace( /(^|\s)js(\s|$)/, '$1no-js$2' );
     </script>
@@ -186,15 +187,15 @@
 
 <body>
 
-<!--
+{#
     =========
     Analytics
     =========
--->
-<!-- Google Tag Manager (noscript) -->
+#}
+{# Google Tag Manager (noscript) #}
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-KMMLRS"
 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
-<!-- End Google Tag Manager (noscript) -->
+{# End Google Tag Manager (noscript) #}
 
 {% block body %}
 
@@ -214,12 +215,12 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 {% block banner_top %}
 {% endblock %}
 
-<!-- PRIMARY CONTENT -->
+{# PRIMARY CONTENT #}
 {% block content %}
     {# This will be replaced in templates that extend this template
     and override "content". #}
 {% endblock content %}
- <!-- /PRIMARY CONTENT -->
+{# /PRIMARY CONTENT #}
 
 {% block banner_bottom %}
 {% endblock %}
@@ -231,12 +232,12 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
 {% endblock body %}
 
-<!--
+{#
     ============
     BODY SCRIPTS
     ============
     The number of scripts here must be kept to a minimum.
--->
+#}
 
 {% block javascript scoped %}
 <!--[if gt IE 8]><!-->


### PR DESCRIPTION
Part of the effort to reduce the HTML page size (
https://[GHE]/CFGOV/platform/issues/1824).

## Changes

- Moves code comments to server-side jinja comments so they aren't delivered into the HTML to production.

## Testing

1. Run the site locally and view source and see that their aren't code comments in the output HTML anymore.
