### PR TITLE
Append U.S. state abbreviation to county chart title

### DIFF
--- a/cfgov/unprocessed/js/organisms/MortgagePerformanceTrends/apps/chart.js
+++ b/cfgov/unprocessed/js/organisms/MortgagePerformanceTrends/apps/chart.js
@@ -199,6 +199,10 @@ MortgagePerformanceLineChart.prototype.renderChartForm = function( prevState, st
 
 MortgagePerformanceLineChart.prototype.renderChartTitle = function( prevState, state ) {
   var geoName = state.geo.name;
+  // Append the U.S. state if it's a county
+  if ( state.geo.type === 'county' ) {
+    geoName = `${ geoName }, ${ utils.getCountyState( state.geo.id ) }`;
+  }
   var includeComparison = state.includeComparison;
   if ( geoName ) {
     utils.showEl( this.$chartTitle );

--- a/cfgov/unprocessed/js/organisms/MortgagePerformanceTrends/apps/map.js
+++ b/cfgov/unprocessed/js/organisms/MortgagePerformanceTrends/apps/map.js
@@ -223,6 +223,8 @@ MortgagePerformanceMap.prototype.renderChartTitle = function( prevState, state )
   }
   if ( !loc ) {
     loc = `${ state.geo.type } view`;
+  } else if ( state.geo.type === 'county' ) {
+    loc = `${ loc }, ${ utils.getCountyState( state.geo.id ) }`;
   }
   this.$mapTitleLocation.innerText = loc;
   this.$mapTitleDate.innerText = utils.getDate( state.date );

--- a/cfgov/unprocessed/js/organisms/MortgagePerformanceTrends/utils.js
+++ b/cfgov/unprocessed/js/organisms/MortgagePerformanceTrends/utils.js
@@ -174,6 +174,78 @@ var utils = {
   },
 
   /**
+   * getCountyState - Get the U.S. state belonging to a county.
+   *
+   * @param {string} fips FIPS county code.
+   *
+   * @returns {string} Two character state abbreviation.
+   */
+  getCountyState: fips => {
+    // Grab the first two digits of the county's FIPS code.
+    fips = fips.substr( 0, 2 );
+    const usStates = {
+      '01': 'AL',
+      '02': 'AK',
+      '04': 'AZ',
+      '05': 'AR',
+      '06': 'CA',
+      '08': 'CO',
+      '09': 'CT',
+      '10': 'DE',
+      '11': 'DC',
+      '12': 'FL',
+      '13': 'GA',
+      '15': 'HI',
+      '16': 'ID',
+      '17': 'IL',
+      '18': 'IN',
+      '19': 'IA',
+      '20': 'KS',
+      '21': 'KY',
+      '22': 'LA',
+      '23': 'ME',
+      '24': 'MD',
+      '25': 'MA',
+      '26': 'MI',
+      '27': 'MN',
+      '28': 'MS',
+      '29': 'MO',
+      '30': 'MT',
+      '31': 'NE',
+      '32': 'NV',
+      '33': 'NH',
+      '34': 'NJ',
+      '35': 'NM',
+      '36': 'NY',
+      '37': 'NC',
+      '38': 'ND',
+      '39': 'OH',
+      '40': 'OK',
+      '41': 'OR',
+      '42': 'PA',
+      '44': 'RI',
+      '45': 'SC',
+      '46': 'SD',
+      '47': 'TN',
+      '48': 'TX',
+      '49': 'UT',
+      '50': 'VT',
+      '51': 'VA',
+      '53': 'WA',
+      '54': 'WV',
+      '55': 'WI',
+      '56': 'WY',
+      '60': 'AS',
+      '66': 'GU',
+      '69': 'MP',
+      '72': 'PR',
+      '74': 'UM',
+      '78': 'VI'
+    };
+    return usStates[fips];
+  },
+
+  /**
    * isNonMetro - Check if a location's FIPS code is for a non-metro area.
    *
    * @param {string} fips FIPS code, e.g. 52435 or 06-non.

--- a/test/unit_tests/organisms/MortgagePerformanceTrends/utils-spec.js
+++ b/test/unit_tests/organisms/MortgagePerformanceTrends/utils-spec.js
@@ -136,6 +136,19 @@ describe( 'Mortgage Performance utilities', () => {
     expect( date ).to.equal( 'cheeseburger' );
   } );
 
+  it( 'should parse counties\' states', () => {
+    let state = utils.getCountyState( '01234' );
+    expect( state ).to.equal( 'AL' );
+    state = utils.getCountyState( '23502' );
+    expect( state ).to.equal( 'ME' );
+    state = utils.getCountyState( '30000' );
+    expect( state ).to.equal( 'MT' );
+    state = utils.getCountyState( '51412' );
+    expect( state ).to.equal( 'VA' );
+    state = utils.getCountyState( 'not a fips' );
+    expect( state ).to.be.undefined;
+  } );
+
   it( 'check if a FIPS is a non-metro area', () => {
     let location = utils.isNonMetro( '87364' );
     expect( location ).to.be.false;


### PR DESCRIPTION
To improve the readability of the trend chart when browsing counties we're adding the state abbreviation after county names. See https://GHE/CFGOV/mortgage-performance/issues/212

## Additions

- Util function to get state abbreviation from county FIPS code.

## Changes

- Append state abbreviation to trend chart title when in county mode.

## Testing

1. Pull down branch.
1. `./front-end.sh`
1. Go to http://localhost:8000/data-research/mortgage-performance-trends/mortgages-90-or-more-days-delinquent/
1. Select `County` location type and see if the chart title shows the state's abbreviation.

## Screenshots

Before:

<img width="724" alt="screen shot 2017-11-01 at 12 13 03 am" src="https://user-images.githubusercontent.com/1060248/32259795-7b9bc334-be99-11e7-8fae-2518d7c46262.png">

After:

<img width="699" alt="screen shot 2017-11-01 at 12 01 42 am" src="https://user-images.githubusercontent.com/1060248/32259778-4c2a4e0e-be99-11e7-8dc7-39cdcc874d3f.png">

## Notes

-

## Todos

-

## Checklist

* [ ] PR has an informative and human-readable title
* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [ ] Passes all existing automated tests
* [ ] Any *change* in functionality is tested
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated
* [ ] Reviewers requested with the [Reviewer tool](https://help.github.com/articles/about-pull-request-reviews/) :arrow_right:
