### PR TITLE
Clean up form submission handler in test

### DIFF
--- a/test/unit_tests/apps/financial-well-being/fwb-questions-spec.js
+++ b/test/unit_tests/apps/financial-well-being/fwb-questions-spec.js
@@ -6,6 +6,7 @@ const expect = chai.expect;
 const sinon = require( 'sinon' );
 let fwbQuestions;
 let sandbox;
+let formDom;
 let submitBtnDom;
 let radioButtonsDom;
 const dataLayerEventRadio = {
@@ -135,14 +136,6 @@ function triggerClickEvent( target ) {
   const event = document.createEvent( 'Event' );
   event.initEvent( 'click', true, true );
 
-  if ( target.id === submitBtnDom.id ) {
-    // Prevent submission of the form if the submit button is clicked.
-    const form = document.querySelector( '#quiz-form' );
-    form.addEventListener( 'submit', evt => {
-      evt.preventDefault();
-    } );
-  }
-
   return target.dispatchEvent( event );
 }
 
@@ -168,8 +161,15 @@ describe( 'fwb-questions', () => {
     document.body.innerHTML = HTML_SNIPPET;
     window.dataLayer = [];
     window.tagManagerIsLoaded = true;
+    formDom = document.querySelector( '#quiz-form' );
     submitBtnDom = document.querySelector( '#submit-quiz' );
     radioButtonsDom = document.querySelectorAll( '[type="radio"]' );
+    // JSDOM does not support form submission at this time
+    // and will throw an error. Prevent the form from submitting,
+    // even when the submit button is triggered.
+    formDom.addEventListener( 'submit', evt => {
+      evt.preventDefault();
+    } );
   } );
 
   afterEach( () => {
@@ -194,7 +194,7 @@ describe( 'fwb-questions', () => {
   } );
 
   it( 'submit button should submit the form ' +
-       'if all the questions are completed before page load.', () => {
+      'if all the questions are completed before page load.', () => {
     fillOutForm();
     fwbQuestions.init();
     const formSubmissionStatus = triggerClickEvent( submitBtnDom );
@@ -203,7 +203,7 @@ describe( 'fwb-questions', () => {
   } );
 
   it( 'submit button should submit the form ' +
-       'if all the questions are completed after page load.', () => {
+      'if all the questions are completed after page load.', () => {
     fwbQuestions.init();
     fillOutForm();
     const formSubmissionStatus = triggerClickEvent( submitBtnDom );
@@ -219,7 +219,7 @@ describe( 'fwb-questions', () => {
   } );
 
   it( 'should send the correct analytics ' +
-       'when the submit button is clicked', () => {
+      'when the submit button is clicked', () => {
     fillOutForm();
     fwbQuestions.init();
     triggerClickEvent( submitBtnDom );


### PR DESCRIPTION
JSDOM does not allow for a form to be submitted and will throw an error.
To avoid any issues we've prevented it from submitting. This change
relocates that code outside of the button click handler and expands on
the comment to make it clearer they are unrelated and that the submission
handler is an outside necessity.

## Changes

- Relocated the form submission handler

## Testing

1. Run `gulp test:unit`

## Checklist

* [x] PR has an informative and human-readable title
* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [x] Passes all existing automated tests
* [x] Any *change* in functionality is tested
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices
* [x] Project documentation has been updated
* [x] Reviewers requested with the [Reviewer tool](https://help.github.com/articles/about-pull-request-reviews/) :arrow_right:
