### PR TITLE
Only include StreamField media for existing blocks

### DIFF
--- a/cfgov/ask_cfpb/tests/models/test_pages.py
+++ b/cfgov/ask_cfpb/tests/models/test_pages.py
@@ -121,9 +121,7 @@ class AnswerModelTestCase(TestCase):
         kwargs.setdefault('depth', self.english_parent_page.depth + 1)
         kwargs.setdefault('slug', 'category-mortgages')
         kwargs.setdefault('title', 'Mortgages')
-        page = mommy.prepare(AnswerCategoryPage, **kwargs)
-        page.save()
-        return page
+        return AnswerCategoryPage(**kwargs)
 
     def create_audience_page(self, **kwargs):
         kwargs.setdefault(
@@ -131,9 +129,7 @@ class AnswerModelTestCase(TestCase):
         kwargs.setdefault('depth', self.english_parent_page.depth + 1)
         kwargs.setdefault('slug', 'audience-students')
         kwargs.setdefault('title', 'Students')
-        page = mommy.prepare(AnswerAudiencePage, **kwargs)
-        page.save()
-        return page
+        return AnswerAudiencePage.objects.create(**kwargs)
 
     def setUp(self):
         from v1.models import HomePage

--- a/cfgov/v1/tests/models/test_base.py
+++ b/cfgov/v1/tests/models/test_base.py
@@ -323,7 +323,19 @@ class TestCFGOVPageMediaProperty(TestCase):
             True
         )
 
-        self.assertEqual(
-            page.media['organisms'],
-            ['email-signup.js']
+        self.assertEqual(page.media['organisms'], ['email-signup.js'])
+
+    def test_doesnt_pull_in_media_for_nonexistent_child_blocks(self):
+        page = BrowsePage()
+        page.content = blocks.StreamValue(
+            page.content.stream_block,
+            [
+                {
+                    'type': 'full_width_text',
+                    'value': [],
+                },
+            ],
+            True
         )
+
+        self.assertFalse(page.media['organisms'])

--- a/cfgov/v1/tests/test_meta_image.py
+++ b/cfgov/v1/tests/test_meta_image.py
@@ -53,7 +53,7 @@ class TestMetaImage(TestCase):
 
     def test_template_meta_image_no_images(self):
         """Template meta tags should fallback to standard social networks."""
-        page = mommy.prepare(LearnPage, social_sharing_image=None)
+        page = LearnPage(social_sharing_image=None)
         response = page.serve(page.dummy_request())
         response.render()
 
@@ -79,7 +79,7 @@ class TestMetaImage(TestCase):
         """Template meta tags should use an absolute image URL."""
         image_file = get_test_image_file(filename='foo.png')
         image = mommy.make(CFGOVImage, file=image_file)
-        page = mommy.prepare(LearnPage, social_sharing_image=image)
+        page = LearnPage(social_sharing_image=image)
         response = page.serve(page.dummy_request())
         response.render()
 


### PR DESCRIPTION
This change fixes some logic that was trying to include StreamField child block media. We want pages to include all child block media (block-specific JavaScript files) for any blocks that are on the page, but the existing logic includes any files for any blocks that could possibly be on the page.

This change leverages some logic in [wagtail-inventory](https://github.com/cfpb/wagtail-inventory) that lists the block types on a page, instead of incorrectly pulling in all possible child blocks of a parent block.

A few unit tests had to be changed because using `model_mommy.prepare` on Wagtail page types doesn't properly set the Django contenttypes id, which breaks use of `page.specific`.

This addresses the first issue in GHE#1264.

## Changes

- Fix logic in `v1.models.base._add_streamfield_js` to properly include only required block JS.

## Testing

- Create and publish a new BrowsePage that has an empty Full Width Text organism. Use the developer tools to search page JS for `o-table`. You shouldn't see any hits because there's no table block in the page. Also note no hits for `email-signup`.
- Now add an Email Signup to the sidebar, and republish. You'll see the page source JS now properly includes `email-signup`.

## Checklist

* [X] PR has an informative and human-readable title
* [X] Changes are limited to a single goal (no scope creep)
* [X] Code can be automatically merged (no conflicts)
* [X] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [X] Passes all existing automated tests
* [X] Any *change* in functionality is tested
* [X] Visually tested in supported browsers and devices
* [X] Reviewers requested with the [Reviewer tool](https://help.github.com/articles/about-pull-request-reviews/) :arrow_right:
