### PR TITLE
Moving the Media class to the TableBlock class

### DIFF
--- a/cfgov/v1/atomic_elements/organisms.py
+++ b/cfgov/v1/atomic_elements/organisms.py
@@ -339,9 +339,6 @@ class Table(blocks.StructBlock):
         template = '_includes/organisms/table.html'
         label = ' '
 
-    class Media:
-        js = ['table.js']
-
 
 class BureauStructurePosition(blocks.StructBlock):
     office_name = blocks.CharBlock()
@@ -464,6 +461,9 @@ class AtomicTableBlock(TableBlock):
         icon = 'table'
         template = '_includes/organisms/table.html'
         label = 'TableBlock'
+
+    class Media:
+        js = ['table.js']
 
 
 class ModelBlock(blocks.StructBlock):


### PR DESCRIPTION
## Changes

- Modified  `cfgov/v1/atomic_elements/organisms.py` to move the Media class to the TableBlock class. 

## Notes
- This is needed due to the current bug with assigning atomic components to the page.media property. PR #3551 fixes that issue so we should no longer have random Table.js camping out on our pages. 

## Checklist

* [ ] PR has an informative and human-readable title
* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [ ] Passes all existing automated tests
* [ ] Any *change* in functionality is tested
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated
* [ ] Reviewers requested with the [Reviewer tool](https://help.github.com/articles/about-pull-request-reviews/) :arrow_right:
