### PR TITLE
Flatten CFGOVPage.media from dict to list

### DIFF
--- a/cfgov/ask_cfpb/models/pages.py
+++ b/cfgov/ask_cfpb/models/pages.py
@@ -178,7 +178,18 @@ class AnswerLandingPage(LandingPage):
         return 'ask-cfpb/landing-page.html'
 
 
-class AnswerCategoryPage(RoutablePageMixin, CFGOVPage):
+class SecondaryNavigationJSMixin(object):
+    """A page mixin that adds navigation JS for English pages."""
+    @property
+    def page_js(self):
+        js = super(SecondaryNavigationJSMixin, self).page_js
+        if self.language == 'en':
+            js += ['secondary-navigation.js']
+        return js
+
+
+class AnswerCategoryPage(RoutablePageMixin, SecondaryNavigationJSMixin,
+                         CFGOVPage):
     """
     A routable page type for Ask CFPB category pages and their subcategories.
     """
@@ -213,11 +224,6 @@ class AnswerCategoryPage(RoutablePageMixin, CFGOVPage):
             return 'ask-cfpb/category-page-spanish.html'
 
         return 'ask-cfpb/category-page.html'
-
-    def add_page_js(self, js):
-        if self.language == 'en':
-            super(AnswerCategoryPage, self).add_page_js(js)
-            js['template'] += ['secondary-navigation.js']
 
     def get_context(self, request, *args, **kwargs):
         context = super(
@@ -316,7 +322,7 @@ class AnswerCategoryPage(RoutablePageMixin, CFGOVPage):
             request, self.get_template(request), context)
 
 
-class AnswerResultsPage(CFGOVPage):
+class AnswerResultsPage(SecondaryNavigationJSMixin, CFGOVPage):
 
     objects = CFGOVPageManager()
     answers = []
@@ -332,11 +338,6 @@ class AnswerResultsPage(CFGOVPage):
         ObjectList(content_panels, heading='Content'),
         ObjectList(CFGOVPage.settings_panels, heading='Configuration'),
     ])
-
-    def add_page_js(self, js):
-        if self.language == 'en':
-            super(AnswerResultsPage, self).add_page_js(js)
-            js['template'] += ['secondary-navigation.js']
 
     def get_context(self, request, **kwargs):
 
@@ -368,7 +369,7 @@ class AnswerResultsPage(CFGOVPage):
             return 'ask-cfpb/answer-search-spanish-results.html'
 
 
-class AnswerAudiencePage(CFGOVPage):
+class AnswerAudiencePage(SecondaryNavigationJSMixin, CFGOVPage):
     from ask_cfpb.models import Audience
 
     objects = CFGOVPageManager()
@@ -389,11 +390,6 @@ class AnswerAudiencePage(CFGOVPage):
         ObjectList(content_panels, heading='Content'),
         ObjectList(CFGOVPage.settings_panels, heading='Configuration'),
     ])
-
-    def add_page_js(self, js):
-        if self.language == 'en':
-            super(AnswerAudiencePage, self).add_page_js(js)
-            js['template'] += ['secondary-navigation.js']
 
     def get_context(self, request, *args, **kwargs):
         from ask_cfpb.models import Answer

--- a/cfgov/ask_cfpb/tests/models/test_pages.py
+++ b/cfgov/ask_cfpb/tests/models/test_pages.py
@@ -462,20 +462,12 @@ class AnswerModelTestCase(TestCase):
 
     def test_audience_page_add_js(self):
         test_page = self.create_audience_page(language='en')
-        test_js = {'template': []}
-        test_page.add_page_js(test_js)
-        self.assertTrue(
-            'secondary-navigation.js'
-            in test_page.media['template'])
+        self.assertEqual(test_page.page_js, ['secondary-navigation.js'])
 
     def test_audience_page_add_js_wrong_language(self):
-        """add_page_js should only work on English Audience pages"""
+        """page_js should only be added on English Audience pages"""
         test_page = self.create_audience_page(language='es')
-        test_js = {'template': []}
-        test_page.add_page_js(test_js)
-        self.assertFalse(
-            'secondary-navigation.js'
-            in test_page.media['template'])
+        self.assertFalse(test_page.page_js)
 
     def test_spanish_template_used(self):
         spanish_answer = self.prepare_answer(
@@ -900,9 +892,7 @@ class AnswerModelTestCase(TestCase):
 
     def test_category_page_add_js_function(self):
         cat_page = self.create_category_page(ask_category=self.category)
-        js = {}
-        cat_page.add_page_js(js)
-        self.assertEqual(js, {'template': [u'secondary-navigation.js']})
+        self.assertEqual(cat_page.page_js, ['secondary-navigation.js'])
 
     def test_answer_language_page_exists(self):
         self.assertEqual(self.answer5678.english_page, self.page2)

--- a/cfgov/jinja2/v1/_layouts/base.html
+++ b/cfgov/jinja2/v1/_layouts/base.html
@@ -262,13 +262,11 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 {% if page and page.media %}
     {% compress js %}
     <script>
-    {% for type, jsfiles in page.media.iteritems() %}
-       {% for js in jsfiles %}
-           {% set compononet_js_source = component_ondemand_js(js) | trim %}
-           {% if compononet_js_source | length > 0 %}
-                {{ compononet_js_source }}
-           {% endif %}
-       {% endfor %}
+    {% for js in page.media %}
+       {% set compononet_js_source = component_ondemand_js(js) | trim %}
+       {% if compononet_js_source | length > 0 %}
+            {{ compononet_js_source }}
+       {% endif %}
     {% endfor %}
     </script>
     {% endcompress %}

--- a/cfgov/v1/models/browse_filterable_page.py
+++ b/cfgov/v1/models/browse_filterable_page.py
@@ -51,9 +51,12 @@ class BrowseFilterablePage(FilterableFeedPageMixin, FilterableListMixin,
 
     objects = PageManager()
 
-    def add_page_js(self, js):
-        super(BrowseFilterablePage, self).add_page_js(js)
-        js['template'] += ['secondary-navigation.js']
+    @property
+    def page_js(self):
+        return (
+            super(BrowseFilterablePage, self).page_js
+            + ['secondary-navigation.js']
+        )
 
 
 class EventArchivePage(BrowseFilterablePage):

--- a/cfgov/v1/models/browse_page.py
+++ b/cfgov/v1/models/browse_page.py
@@ -76,9 +76,11 @@ class BrowsePage(CFGOVPage):
 
     objects = PageManager()
 
-    def add_page_js(self, js):
-        super(BrowsePage, self).add_page_js(js)
-        js['template'] += ['secondary-navigation.js']
+    @property
+    def page_js(self):
+        return (
+            super(BrowsePage, self).page_js + ['secondary-navigation.js']
+        )
 
     def get_context(self, request, *args, **kwargs):
         context = super(BrowsePage, self).get_context(request, *args, **kwargs)

--- a/cfgov/v1/models/learn_page.py
+++ b/cfgov/v1/models/learn_page.py
@@ -279,8 +279,9 @@ class EventPage(AbstractFilterPage):
 
     template = 'events/event.html'
 
-    def add_page_js(self, js):
-        js['template'] = ['video-player.js']
+    @property
+    def page_js(self):
+        return super(EventPage, self).page_js + ['video-player.js']
 
     def location_image_url(self, scale='2', size='276x155', zoom='12'):
         center = 'Washington, DC'

--- a/cfgov/v1/tests/models/test_base.py
+++ b/cfgov/v1/tests/models/test_base.py
@@ -301,14 +301,14 @@ class TestFeedbackModel(TestCase):
 
 class TestCFGOVPageMediaProperty(TestCase):
     """Tests how the page.media property pulls in child block JS."""
-    def setUp(self):
-        self.expected_keys = (
-            'template', 'organisms', 'molecules', 'atoms', 'other',
-        )
-        self.empty_dict = {k: [] for k in self.expected_keys}
-
     def test_empty_page_has_no_media(self):
-        return self.assertEqual(CFGOVPage().media, self.empty_dict)
+        return self.assertEqual(CFGOVPage().media, [])
+
+    def test_empty_page_has_no_page_js(self):
+        return self.assertEqual(CFGOVPage().page_js, [])
+
+    def test_empty_page_has_no_streamfield_js(self):
+        return self.assertEqual(CFGOVPage().streamfield_js, [])
 
     def test_page_pulls_in_child_block_media(self):
         page = CFGOVPage()
@@ -323,7 +323,7 @@ class TestCFGOVPageMediaProperty(TestCase):
             True
         )
 
-        self.assertEqual(page.media['organisms'], ['email-signup.js'])
+        self.assertEqual(page.media, ['email-signup.js'])
 
     def test_doesnt_pull_in_media_for_nonexistent_child_blocks(self):
         page = BrowsePage()
@@ -338,4 +338,6 @@ class TestCFGOVPageMediaProperty(TestCase):
             True
         )
 
-        self.assertFalse(page.media['organisms'])
+        # The page media should only include the default BrowsePae media, and
+        # shouldn't add any additional files because of the FullWithText.
+        self.assertEqual(page.media, ['secondary-navigation.js'])


### PR DESCRIPTION
This change flattens the `@media` property on `CFGOVPage` to return a simple list of JavaScript filenames instead of a dictionary. The dictionary keys were never used downstream in the template, so maintaining them serves no purpose and makes it harder to test for files by checking for an empty dictionary.

This change also slightly cleans up the class methods around this functionality, converting `CFGOVPage.add_page_js(js)` (which adds to a dictionary) into `CFGOVPage.page_js` (which just returns a list).

Several Ask CFPB classes and tests had to be modified for this; pinging @higs4281 for a quick review.

Note that this change somewhat strengthens the existing requirement that page/block JS filenames have to be globally unique.

## Changes

- Cleanup of page media into simple list.

## Testing

1. See new/changed unit tests.
2. Create a BrowsePage and notice that the secondary navigation JS is included (compressed) in the scripts (search `o-secondary-navigation` in developer tools).
3. Create a HomePage and notice that this page JS is not included in the template or scripts.

## Notes

- This is the issue referred to by @sebworks on #3539 [here](https://github.com/cfpb/cfgov-refresh/pull/3539#discussion_r148601763).

## Checklist

* [X] PR has an informative and human-readable title
* [X] Changes are limited to a single goal (no scope creep)
* [X] Code can be automatically merged (no conflicts)
* [X] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [X] Passes all existing automated tests
* [X] Any *change* in functionality is tested
* [X] New functions are documented (with a description, list of inputs, and expected output)
* [X] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated
* [X] Reviewers requested with the [Reviewer tool](https://help.github.com/articles/about-pull-request-reviews/) :arrow_right:
