### PR TITLE
Fix for charts not rendering on IE

### DIFF
--- a/config/webpack-config.js
+++ b/config/webpack-config.js
@@ -48,7 +48,7 @@ const COMMON_UGLIFY_CONFIG = new UglifyWebpackPlugin( {
   parallel: true,
   uglifyOptions: {
     ie8: false,
-    ecma: 6,
+    ecma: 5,
     warnings: false,
     mangle: true,
     output: {


### PR DESCRIPTION
Fix for charts not rendering on IE

## Changes

- Fixes issue with charts not rendering on IE due to ES6 features in the build. Not sure why Babel doesn't run after the Uglifier but I will investigate.

- Run `gulp build`
- Visit `localhost:8000/data-research/mortgage-performance-trends/mortgages-30-89-days-delinquent/` and ensure it works on IE.

## Checklist

* [ ] PR has an informative and human-readable title
* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [ ] Passes all existing automated tests
* [ ] Any *change* in functionality is tested
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated
* [ ] Reviewers requested with the [Reviewer tool](https://help.github.com/articles/about-pull-request-reviews/) :arrow_right:
