### PR TITLE
Bump OAH-api to 0.10.1

### DIFF
--- a/requirements/optional-public.txt
+++ b/requirements/optional-public.txt
@@ -1,6 +1,6 @@
 https://github.com/cfpb/college-costs/releases/download/2.3.12/college_costs-2.3.12-py2-none-any.whl
 https://github.com/cfpb/complaint/releases/download/1.4.2/complaintdatabase-1.4.2-py2-none-any.whl
-git+https://github.com/cfpb/owning-a-home-api.git@0.9.96#egg=owning-a-home-api
+git+https://github.com/cfpb/owning-a-home-api.git@0.10.1#egg=owning-a-home-api
 git+https://github.com/cfpb/regulations-core.git@1.2.5#egg=regcore
 https://github.com/cfpb/regulations-site/releases/download/2.1.13/regulations-2.1.13-py2-none-any.whl
 https://github.com/cfpb/retirement/releases/download/0.5.14/retirement-0.5.14-py2-none-any.whl


### PR DESCRIPTION
Bumps requirement for `owning-a-home-api` to 0.10.1