### PR TITLE
Send notifications to govdelivery subscribers

### DIFF
--- a/cfgov/core/tests/test_views.py
+++ b/cfgov/core/tests/test_views.py
@@ -83,7 +83,8 @@ class GovDeliverySubscribeTest(TestCase):
         self.check_post(post, response_check, ajax=ajax)
         gd.set_subscriber_topics.assert_called_with(
             post['email'],
-            [post['code']]
+            [post['code']],
+            send_notifications=True
         )
 
         if include_answers:

--- a/cfgov/core/views.py
+++ b/cfgov/core/views.py
@@ -47,7 +47,7 @@ def govdelivery_subscribe(request):
     codes = request.POST.getlist('code')
     gd = GovDelivery(account_code=settings.ACCOUNT_CODE)
     try:
-        subscription_response = gd.set_subscriber_topics(email_address, codes)
+        subscription_response = gd.set_subscriber_topics(email_address, codes, send_notifications=True)
         if subscription_response.status_code != 200:
             return failing_response
     except Exception:

--- a/cfgov/core/views.py
+++ b/cfgov/core/views.py
@@ -47,7 +47,10 @@ def govdelivery_subscribe(request):
     codes = request.POST.getlist('code')
     gd = GovDelivery(account_code=settings.ACCOUNT_CODE)
     try:
-        subscription_response = gd.set_subscriber_topics(email_address, codes, send_notifications=True)
+        subscription_response = gd.set_subscriber_topics(
+            email_address,
+            codes,
+            send_notifications=True)
         if subscription_response.status_code != 200:
             return failing_response
     except Exception:

--- a/cfgov/data_research/handlers.py
+++ b/cfgov/data_research/handlers.py
@@ -77,7 +77,8 @@ class ConferenceRegistrationHandler(Handler):
 
             subscription_response = gd.set_subscriber_topics(
                 email_address=email,
-                topic_codes=[code]
+                topic_codes=[code],
+                send_notifications=True,
             )
 
             subscription_response.raise_for_status()

--- a/cfgov/data_research/tests/test_handlers.py
+++ b/cfgov/data_research/tests/test_handlers.py
@@ -194,7 +194,8 @@ class TestConferenceRegistrationHandler(TestCase):
         mock_govdelivery = self.patched_govdelivery.return_value
         mock_govdelivery.set_subscriber_topics.assert_called_with(
             email_address='em@il.com',
-            topic_codes=['code']
+            topic_codes=['code'],
+            send_notifications=True,
         )
 
     def test_subscribe_returns_true_for_success(self):

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -26,7 +26,7 @@ elasticsearch==2.4.1
 feedparser==5.2.1
 geocoder==1.12.0
 github3.py==0.9.6
-govdelivery==1.0
+govdelivery==1.1
 html5lib==0.9999999
 icalendar==3.9.0
 Jinja2==2.7.3


### PR DESCRIPTION
This updates the govdelivery python package to 1.1, and takes advantage of the [new](https://github.com/cfpb/govdelivery/pull/1) ability to set send_notifications on calls to set_subscriber_topics (resolving a stakeholder concern, since they expected that notifications WERE being set)


## Changes

- govdelivery updated in requirements/base.txt
- calls to set_subscriber_topics now include send_notificiation=True


## Checklist

* [ ] PR has an informative and human-readable title
* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [ ] Passes all existing automated tests
* [ ] Any *change* in functionality is tested
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated
* [ ] Reviewers requested with the [Reviewer tool](https://help.github.com/articles/about-pull-request-reviews/) :arrow_right:
