### PR TITLE
Remove duplicate gulp-changed dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1785,7 +1785,7 @@
     "cf-core": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/cf-core/-/cf-core-4.5.0.tgz",
-      "integrity": "sha512-MUdo0pq9r5TGU1TxzxJaw8hXBLdDIHWXRMGltuaAv5CF5Zvw/aY5d0PQDxvhMHR88thtqqHb/i83qP4yMqI9yA==",
+      "integrity": "sha1-DIP4H5th72QMx2m7EhBuNEiM/Ak=",
       "requires": {
         "normalize-css": "2.3.1",
         "normalize-legacy-addon": "0.1.0"
@@ -6171,7 +6171,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/gulp-changed/-/gulp-changed-3.1.0.tgz",
       "integrity": "sha1-h80Vk6C7SlEp3C8im+zm2UiMJyo=",
-      "dev": true,
       "requires": {
         "gulp-util": "3.0.8",
         "pify": "2.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13270,7 +13270,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/vinyl-named/-/vinyl-named-1.1.0.tgz",
       "integrity": "sha1-lOT+dB442w7DA+Wz2Giyl6Leq2Y=",
-      "dev": true,
       "requires": {
         "through": "2.3.8"
       }

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "timelinejs": "2.35.6",
     "uglifyjs-webpack-plugin": "1.0.1",
     "ustream-embedapi": "1.0.0",
+    "vinyl-named": "1.1.0",
     "webpack": "3.8.1",
     "webpack-stream": "4.0.0",
     "xdr": "0.5.3"
@@ -91,7 +92,6 @@
     "selenium-webdriver": "3.5.0",
     "sinon": "4.0.2",
     "snyk": "1.25.0",
-    "vinyl-named": "1.1.0",
     "wcag": "0.3.0"
   },
   "browser": {

--- a/package.json
+++ b/package.json
@@ -77,7 +77,6 @@
     "chai": "4.1.2",
     "chai-as-promised": "7.1.1",
     "cucumber": "3.0.6",
-    "gulp-changed": "3.1.0",
     "jasmine-reporters": "2.2.1",
     "jasmine-spec-reporter": "4.2.1",
     "jsdoc": "3.4.3",


### PR DESCRIPTION
Because it was set to `"dev": true` in `package-lock.json`, gulp-changed was not getting installed when the `--production` flag was used in our Jenkins build jobs, causing the build to fail.

## Removals

- gulp-changed removed from `devDependencies`

## Testing

1. Merge and see that the next build job works

## Checklist

* [ ] PR has an informative and human-readable title
* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [ ] Passes all existing automated tests
* [ ] Any *change* in functionality is tested
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated
* [ ] Reviewers requested with the [Reviewer tool](https://help.github.com/articles/about-pull-request-reviews/) :arrow_right:
