### PR TITLE
Move the FWB assets into the main cfgov assets

### DIFF
--- a/cfgov/unprocessed/css/enhancements/forms.less
+++ b/cfgov/unprocessed/css/enhancements/forms.less
@@ -295,84 +295,59 @@ input {
 @radio-button-diameter: 18px;
 
 .o-scale {
-    .u-clearfix();
-    padding-bottom: unit( 30px / @base-font-size-px, em );
-    position: relative;
 
-    &:before {
-        .respond-to-min( @bp-sm-min, {
-            border-top: 1px solid @gray-40;
-            position: absolute;
-            right: -@grid_gutter-width;
-            bottom: 0;
-            left: -@grid_gutter-width;
-            content: '';
-            z-index: 0;
-        } );
+    .m-form-field + .m-form-field {
+        margin-top: 0;
     }
 
-    &:last-of-type {
-        padding-bottom: 0;
-
-        &:before {
-            border-top: none;
-        }
-    }
-
-    .m-form-field__radio {
-        .respond-to-min( @bp-sm-min, {
+    .respond-to-min( @bp-sm-min, {
+        .m-form-field__radio {
             width: percentage( 1 / @scale-point-count );
-            padding: 0;
-            margin-bottom: 0;
+
             float: left;
             position: relative;
-        } );
 
-        &:before {
-            .respond-to-min( @bp-sm-min, {
-              border-top: 1px solid @gray-80;
-              border-left: none;
-              position: absolute;
-              top: ( @radio-button-diameter / 2 );
-              right: 0;
-              left: 0;
-              content: '';
-              z-index: 0;
-            } );
+            &:not(:last-child):before {
+                border-top: 1px solid @gray-80;
+
+                position: absolute;
+                top: ( @radio-button-diameter / 2 );
+                right: 0;
+                left: 0;
+
+                content: '';
+            }
         }
 
-        &:last-of-type:before {
-            border-top: none;
-        }
-    }
-
-    .a-label:before,
-    .a-label {
-        .respond-to-min( @bp-sm-min, {
+        .a-label,
+        .a-label:before, {
             display: block;
-        } );
-    }
+        }
 
-    .a-label:before {
-        .respond-to-min( @bp-sm-min, {
+        .a-label:before {
             margin-bottom: unit( 3px / @base-font-size-px, em );
-        } );
-    }
 
-    .a-label {
-        .respond-to-min( @bp-sm-min, {
             position: relative;
-            z-index: 10;
-        } );
-    }
+            z-index: 1;
+        }
+    } );
 
-    &_header {
-        .h4();
+    .respond-to-min( @bp-xl-min, {
+        .o-scale_answer-prefix {
+            box-sizing: border-box;
+            padding-right: unit( 15px / @base-font-size-px, em );
+            width: percentage( 1 / ( @scale-point-count + 1 ) );
 
-        margin-top: unit( 30px / @base-font-size-px, em );
-    }
+            float: left;
+        }
+
+        .o-scale_answer-options {
+            width: percentage( @scale-point-count / ( @scale-point-count + 1 ) );
+
+            float: left;
+        }
+    } );
 }
-
 
 /* topdoc
   name: EOF

--- a/cfgov/unprocessed/css/enhancements/notifications.less
+++ b/cfgov/unprocessed/css/enhancements/notifications.less
@@ -1,0 +1,8 @@
+/* CF Enhancements */
+.m-notification__subtle {
+    border-width: 0;
+
+    .m-notification_message {
+        font-size: 1em;
+    }
+}

--- a/cfgov/unprocessed/css/main.less
+++ b/cfgov/unprocessed/css/main.less
@@ -38,9 +38,11 @@
 // CF Forms
 @import (less) "enhancements/forms.less";
 
-
 // CF Tables
 @import (less) "enhancements/tables.less";
+
+// CF Notifications
+@import (less) "enhancements/notifications.less";
 
 // CF ???
 @import (less) "enhancements/print.less";

--- a/cfgov/unprocessed/css/organisms/well.less
+++ b/cfgov/unprocessed/css/organisms/well.less
@@ -70,6 +70,26 @@
             padding-left: unit( 45px / @base-font-size-px, em );
         } );
     }
+
+    &__flush {
+        padding-bottom: unit( 30px / @base-font-size-px, em );
+        border-right: none;
+
+        .respond-to-max( @bp-xs-max, {
+            border-left: none;
+            margin-right: unit( -15px / @base-font-size-px, em );
+            margin-left: unit( -15px / @base-font-size-px, em );
+        } );
+
+        .respond-to-min( @bp-sm-min, {
+            margin-left: unit( -30px / @base-font-size-px, em );
+            margin-right: unit( -30px / @base-font-size-px, em );
+        } );
+    }
+
+    &__stacked + &__stacked {
+        border-top: none;
+    }
 }
 
 /* topdoc

--- a/cfgov/wellbeing/jinja2/wellbeing/home.html
+++ b/cfgov/wellbeing/jinja2/wellbeing/home.html
@@ -32,45 +32,6 @@
             );
             padding-bottom: 40.42553191%; /* Image height / max width 940 */
         }
-        .question-group {
-            padding: 0 30px 30px 30px;
-            border: solid #b4b5b6;
-            border-width: 1px 0 1px 1px;
-            margin-right: -30px;
-            margin-left: -30px;
-            background: #f7f8f9;
-        }
-        .o-scale {
-            padding-top: 30px;
-            padding-right: 0;
-            padding-left: 0;
-            border: none;
-        }
-        .o-scale_header {
-            margin-top: 0;
-        }
-        .o-form_fieldset {
-            padding-top: 30px;
-        }
-        @media only all and ( min-width: 76.9375em ) {
-            .answer-prefix {
-                width: 110px;
-                margin-bottom: 15px;
-                margin-right: 15px;
-                float: left;
-            }
-            .o-scale .m-form-field__radio {
-                width: 16.6666666667%;
-            }
-        }
-
-        /* CF Enhancements */
-        .m-notification__subtle {
-            border-width: 0;
-        }
-        .m-notification__subtle .m-notification_message {
-            font-size: 1em;
-        }
     </style>
 {%- endblock %}
 
@@ -134,729 +95,764 @@
     <form id="quiz-form" action="{{ url('fwb_results') }}" method="POST">
         <div class="block">
             <h2>Part 1: How well does this statement describe you or your situation?</h2>
-            <div class="question-group">
-                <fieldset class="o-scale" id="question_1">
-                    <h3 class="o-scale_header">
+            <div class="o-well o-well__flush o-well__stacked o-scale">
+                <fieldset class="o-form_fieldset" id="question_1">
+                    <h3 class="a-legend">
                         I could handle a major unexpected expense
                     </h3>
-                    <div class="answer-prefix">This statement describes me</div>
-                    <div class="m-form-field m-form-field__radio">
-                        <input class="a-radio"
-                               type="radio"
-                               id="question_1-completely"
-                               name="question_1"
-                               value="4"
-                               data-gtm-action="Questionnaire Radio Button Clicked"
-                               data-gtm-label="I could handle a major unexpected expense"
-                               data-gtm-category="Financial Well-Being Tool Interaction">
-                        <label class="a-label" for="question_1-completely">
-                            Completely
-                        </label>
-                    </div>
-                    <div class="m-form-field m-form-field__radio">
-                        <input class="a-radio"
-                               type="radio"
-                               id="question_1-very-well"
-                               name="question_1"
-                               value="3"
-                               data-gtm-action="Questionnaire Radio Button Clicked"
-                               data-gtm-label="I could handle a major unexpected expense"
-                               data-gtm-category="Financial Well-Being Tool Interaction">
-                        <label class="a-label" for="question_1-very-well">
-                            Very well
-                        </label>
-                    </div>
-                    <div class="m-form-field m-form-field__radio">
-                        <input class="a-radio"
-                               type="radio"
-                               id="question_1-somewhat"
-                               name="question_1"
-                               value="2"
-                               data-gtm-action="Questionnaire Radio Button Clicked"
-                               data-gtm-label="I could handle a major unexpected expense"
-                               data-gtm-category="Financial Well-Being Tool Interaction">
-                        <label class="a-label" for="question_1-somewhat">
-                            Somewhat
-                        </label>
-                    </div>
-                    <div class="m-form-field m-form-field__radio">
-                        <input class="a-radio"
-                               type="radio"
-                               id="question_1-very-little"
-                               name="question_1"
-                               value="1"
-                               data-gtm-action="Questionnaire Radio Button Clicked"
-                               data-gtm-label="I could handle a major unexpected expense"
-                               data-gtm-category="Financial Well-Being Tool Interaction">
-                        <label class="a-label" for="question_1-very-little">
-                            Very little
-                        </label>
-                    </div>
-                    <div class="m-form-field m-form-field__radio">
-                        <input class="a-radio"
-                               type="radio"
-                               id="question_1-not-at-all"
-                               name="question_1"
-                               value="0"
-                               data-gtm-action="Questionnaire Radio Button Clicked"
-                               data-gtm-label="I could handle a major unexpected expense"
-                               data-gtm-category="Financial Well-Being Tool Interaction">
-                        <label class="a-label" for="question_1-not-at-all">
-                            Not at all
-                        </label>
+                    <div class="o-scale_answer-prefix">This statement describes me</div>
+                    <div class="o-scale_answer-options">
+                        <div class="m-form-field m-form-field__radio">
+                            <input class="a-radio"
+                                   type="radio"
+                                   id="question_1-completely"
+                                   name="question_1"
+                                   value="4"
+                                   data-gtm-action="Questionnaire Radio Button Clicked"
+                                   data-gtm-label="I could handle a major unexpected expense"
+                                   data-gtm-category="Financial Well-Being Tool Interaction">
+                            <label class="a-label" for="question_1-completely">
+                                Completely
+                            </label>
+                        </div>
+                        <div class="m-form-field m-form-field__radio">
+                            <input class="a-radio"
+                                   type="radio"
+                                   id="question_1-very-well"
+                                   name="question_1"
+                                   value="3"
+                                   data-gtm-action="Questionnaire Radio Button Clicked"
+                                   data-gtm-label="I could handle a major unexpected expense"
+                                   data-gtm-category="Financial Well-Being Tool Interaction">
+                            <label class="a-label" for="question_1-very-well">
+                                Very well
+                            </label>
+                        </div>
+                        <div class="m-form-field m-form-field__radio">
+                            <input class="a-radio"
+                                   type="radio"
+                                   id="question_1-somewhat"
+                                   name="question_1"
+                                   value="2"
+                                   data-gtm-action="Questionnaire Radio Button Clicked"
+                                   data-gtm-label="I could handle a major unexpected expense"
+                                   data-gtm-category="Financial Well-Being Tool Interaction">
+                            <label class="a-label" for="question_1-somewhat">
+                                Somewhat
+                            </label>
+                        </div>
+                        <div class="m-form-field m-form-field__radio">
+                            <input class="a-radio"
+                                   type="radio"
+                                   id="question_1-very-little"
+                                   name="question_1"
+                                   value="1"
+                                   data-gtm-action="Questionnaire Radio Button Clicked"
+                                   data-gtm-label="I could handle a major unexpected expense"
+                                   data-gtm-category="Financial Well-Being Tool Interaction">
+                            <label class="a-label" for="question_1-very-little">
+                                Very little
+                            </label>
+                        </div>
+                        <div class="m-form-field m-form-field__radio">
+                            <input class="a-radio"
+                                   type="radio"
+                                   id="question_1-not-at-all"
+                                   name="question_1"
+                                   value="0"
+                                   data-gtm-action="Questionnaire Radio Button Clicked"
+                                   data-gtm-label="I could handle a major unexpected expense"
+                                   data-gtm-category="Financial Well-Being Tool Interaction">
+                            <label class="a-label" for="question_1-not-at-all">
+                                Not at all
+                            </label>
+                        </div>
                     </div>
                 </fieldset>
-                <fieldset class="o-scale" id="question_2">
-                    <h3 class="o-scale_header">
+            </div>
+            <div class="o-well o-well__flush o-well__stacked o-scale">
+                <fieldset class="o-form_fieldset" id="question_2">
+                    <h3 class="a-legend">
                         I am securing my financial future
                     </h3>
-                    <div class="answer-prefix">This statement describes me</div>
-                    <div class="m-form-field m-form-field__radio">
-                        <input class="a-radio"
-                               type="radio"
-                               id="question_2-completely"
-                               name="question_2"
-                               value="4"
-                               data-gtm-action="Questionnaire Radio Button Clicked"
-                               data-gtm-label="I am securing my financial future"
-                               data-gtm-category="Financial Well-Being Tool Interaction">
-                        <label class="a-label" for="question_2-completely">
-                            Completely
-                        </label>
-                    </div>
-                    <div class="m-form-field m-form-field__radio">
-                        <input class="a-radio"
-                               type="radio"
-                               id="question_2-very-well"
-                               name="question_2"
-                               value="3"
-                               data-gtm-action="Questionnaire Radio Button Clicked"
-                               data-gtm-label="I am securing my financial future"
-                               data-gtm-category="Financial Well-Being Tool Interaction">
-                        <label class="a-label" for="question_2-very-well">
-                            Very well
-                        </label>
-                    </div>
-                    <div class="m-form-field m-form-field__radio">
-                        <input class="a-radio"
-                               type="radio"
-                               id="question_2-somewhat"
-                               name="question_2"
-                               value="2"
-                               data-gtm-action="Questionnaire Radio Button Clicked"
-                               data-gtm-label="I am securing my financial future"
-                               data-gtm-category="Financial Well-Being Tool Interaction">
-                        <label class="a-label" for="question_2-somewhat">
-                            Somewhat
-                        </label>
-                    </div>
-                    <div class="m-form-field m-form-field__radio">
-                        <input class="a-radio"
-                               type="radio"
-                               id="question_2-very-little"
-                               name="question_2"
-                               value="1"
-                               data-gtm-action="Questionnaire Radio Button Clicked"
-                               data-gtm-label="I am securing my financial future"
-                               data-gtm-category="Financial Well-Being Tool Interaction">
-                        <label class="a-label" for="question_2-very-little">
-                            Very little
-                        </label>
-                    </div>
-                    <div class="m-form-field m-form-field__radio">
-                        <input class="a-radio"
-                               type="radio"
-                               id="question_2-not-at-all"
-                               name="question_2"
-                               value="0"
-                               data-gtm-action="Questionnaire Radio Button Clicked"
-                               data-gtm-label="I am securing my financial future"
-                               data-gtm-category="Financial Well-Being Tool Interaction">
-                        <label class="a-label" for="question_2-not-at-all">
-                            Not at all
-                        </label>
+                    <div class="o-scale_answer-prefix">This statement describes me</div>
+                    <div class="o-scale_answer-options">
+                        <div class="m-form-field m-form-field__radio">
+                            <input class="a-radio"
+                                   type="radio"
+                                   id="question_2-completely"
+                                   name="question_2"
+                                   value="4"
+                                   data-gtm-action="Questionnaire Radio Button Clicked"
+                                   data-gtm-label="I am securing my financial future"
+                                   data-gtm-category="Financial Well-Being Tool Interaction">
+                            <label class="a-label" for="question_2-completely">
+                                Completely
+                            </label>
+                        </div>
+                        <div class="m-form-field m-form-field__radio">
+                            <input class="a-radio"
+                                   type="radio"
+                                   id="question_2-very-well"
+                                   name="question_2"
+                                   value="3"
+                                   data-gtm-action="Questionnaire Radio Button Clicked"
+                                   data-gtm-label="I am securing my financial future"
+                                   data-gtm-category="Financial Well-Being Tool Interaction">
+                            <label class="a-label" for="question_2-very-well">
+                                Very well
+                            </label>
+                        </div>
+                        <div class="m-form-field m-form-field__radio">
+                            <input class="a-radio"
+                                   type="radio"
+                                   id="question_2-somewhat"
+                                   name="question_2"
+                                   value="2"
+                                   data-gtm-action="Questionnaire Radio Button Clicked"
+                                   data-gtm-label="I am securing my financial future"
+                                   data-gtm-category="Financial Well-Being Tool Interaction">
+                            <label class="a-label" for="question_2-somewhat">
+                                Somewhat
+                            </label>
+                        </div>
+                        <div class="m-form-field m-form-field__radio">
+                            <input class="a-radio"
+                                   type="radio"
+                                   id="question_2-very-little"
+                                   name="question_2"
+                                   value="1"
+                                   data-gtm-action="Questionnaire Radio Button Clicked"
+                                   data-gtm-label="I am securing my financial future"
+                                   data-gtm-category="Financial Well-Being Tool Interaction">
+                            <label class="a-label" for="question_2-very-little">
+                                Very little
+                            </label>
+                        </div>
+                        <div class="m-form-field m-form-field__radio">
+                            <input class="a-radio"
+                                   type="radio"
+                                   id="question_2-not-at-all"
+                                   name="question_2"
+                                   value="0"
+                                   data-gtm-action="Questionnaire Radio Button Clicked"
+                                   data-gtm-label="I am securing my financial future"
+                                   data-gtm-category="Financial Well-Being Tool Interaction">
+                            <label class="a-label" for="question_2-not-at-all">
+                                Not at all
+                            </label>
+                        </div>
                     </div>
                 </fieldset>
-                <fieldset class="o-scale" id="question_3">
-                    <h3 class="o-scale_header">
+            </div>
+            <div class="o-well o-well__flush o-well__stacked o-scale">
+                <fieldset class="o-form_fieldset" id="question_3">
+                    <h3 class="a-legend">
                         Because of my money situation, I feel like I will never have the things I want in life
                     </h3>
-                    <div class="answer-prefix">This statement describes me</div>
-                    <div class="m-form-field m-form-field__radio">
-                        <input class="a-radio"
-                               type="radio"
-                               id="question_3-completely"
-                               name="question_3"
-                               value="0"
-                               data-gtm-action="Questionnaire Radio Button Clicked"
-                               data-gtm-label="Because of my money situation, I feel like I will never have the things I want in life"
-                               data-gtm-category="Financial Well-Being Tool Interaction">
-                        <label class="a-label" for="question_3-completely">
-                            Completely
-                        </label>
-                    </div>
-                    <div class="m-form-field m-form-field__radio">
-                        <input class="a-radio"
-                               type="radio"
-                               id="question_3-very-well"
-                               name="question_3"
-                               value="1"
-                               data-gtm-action="Questionnaire Radio Button Clicked"
-                               data-gtm-label="Because of my money situation, I feel like I will never have the things I want in life"
-                               data-gtm-category="Financial Well-Being Tool Interaction">
-                        <label class="a-label" for="question_3-very-well">
-                            Very well
-                        </label>
-                    </div>
-                    <div class="m-form-field m-form-field__radio">
-                        <input class="a-radio"
-                               type="radio"
-                               id="question_3-somewhat"
-                               name="question_3"
-                               value="2"
-                               data-gtm-action="Questionnaire Radio Button Clicked"
-                               data-gtm-label="Because of my money situation, I feel like I will never have the things I want in life"
-                               data-gtm-category="Financial Well-Being Tool Interaction">
-                        <label class="a-label" for="question_3-somewhat">
-                            Somewhat
-                        </label>
-                    </div>
-                    <div class="m-form-field m-form-field__radio">
-                        <input class="a-radio"
-                               type="radio"
-                               id="question_3-very-little"
-                               name="question_3"
-                               value="3"
-                               data-gtm-action="Questionnaire Radio Button Clicked"
-                               data-gtm-label="Because of my money situation, I feel like I will never have the things I want in life"
-                               data-gtm-category="Financial Well-Being Tool Interaction">
-                        <label class="a-label" for="question_3-very-little">
-                            Very little
-                        </label>
-                    </div>
-                    <div class="m-form-field m-form-field__radio">
-                        <input class="a-radio"
-                               type="radio"
-                               id="question_3-not-at-all"
-                               name="question_3"
-                               value="4"
-                               data-gtm-action="Questionnaire Radio Button Clicked"
-                               data-gtm-label="Because of my money situation, I feel like I will never have the things I want in life"
-                               data-gtm-category="Financial Well-Being Tool Interaction">
-                        <label class="a-label" for="question_3-not-at-all">
-                            Not at all
-                        </label>
+                    <div class="o-scale_answer-prefix">This statement describes me</div>
+                    <div class="o-scale_answer-options">
+                        <div class="m-form-field m-form-field__radio">
+                            <input class="a-radio"
+                                   type="radio"
+                                   id="question_3-completely"
+                                   name="question_3"
+                                   value="0"
+                                   data-gtm-action="Questionnaire Radio Button Clicked"
+                                   data-gtm-label="Because of my money situation, I feel like I will never have the things I want in life"
+                                   data-gtm-category="Financial Well-Being Tool Interaction">
+                            <label class="a-label" for="question_3-completely">
+                                Completely
+                            </label>
+                        </div>
+                        <div class="m-form-field m-form-field__radio">
+                            <input class="a-radio"
+                                   type="radio"
+                                   id="question_3-very-well"
+                                   name="question_3"
+                                   value="1"
+                                   data-gtm-action="Questionnaire Radio Button Clicked"
+                                   data-gtm-label="Because of my money situation, I feel like I will never have the things I want in life"
+                                   data-gtm-category="Financial Well-Being Tool Interaction">
+                            <label class="a-label" for="question_3-very-well">
+                                Very well
+                            </label>
+                        </div>
+                        <div class="m-form-field m-form-field__radio">
+                            <input class="a-radio"
+                                   type="radio"
+                                   id="question_3-somewhat"
+                                   name="question_3"
+                                   value="2"
+                                   data-gtm-action="Questionnaire Radio Button Clicked"
+                                   data-gtm-label="Because of my money situation, I feel like I will never have the things I want in life"
+                                   data-gtm-category="Financial Well-Being Tool Interaction">
+                            <label class="a-label" for="question_3-somewhat">
+                                Somewhat
+                            </label>
+                        </div>
+                        <div class="m-form-field m-form-field__radio">
+                            <input class="a-radio"
+                                   type="radio"
+                                   id="question_3-very-little"
+                                   name="question_3"
+                                   value="3"
+                                   data-gtm-action="Questionnaire Radio Button Clicked"
+                                   data-gtm-label="Because of my money situation, I feel like I will never have the things I want in life"
+                                   data-gtm-category="Financial Well-Being Tool Interaction">
+                            <label class="a-label" for="question_3-very-little">
+                                Very little
+                            </label>
+                        </div>
+                        <div class="m-form-field m-form-field__radio">
+                            <input class="a-radio"
+                                   type="radio"
+                                   id="question_3-not-at-all"
+                                   name="question_3"
+                                   value="4"
+                                   data-gtm-action="Questionnaire Radio Button Clicked"
+                                   data-gtm-label="Because of my money situation, I feel like I will never have the things I want in life"
+                                   data-gtm-category="Financial Well-Being Tool Interaction">
+                            <label class="a-label" for="question_3-not-at-all">
+                                Not at all
+                            </label>
+                        </div>
                     </div>
                 </fieldset>
-                <fieldset class="o-scale" id="question_4">
-                    <h3 class="o-scale_header">
+            </div>
+            <div class="o-well o-well__flush o-well__stacked o-scale">
+                <fieldset class="o-form_fieldset" id="question_4">
+                    <h3 class="a-legend">
                         I can enjoy life because of the way I’m managing my money
                     </h3>
-                    <div class="answer-prefix">This statement describes me</div>
-                    <div class="m-form-field m-form-field__radio">
-                        <input class="a-radio"
-                               type="radio"
-                               id="question_4-completely"
-                               name="question_4"
-                               value="4"
-                               data-gtm-action="Questionnaire Radio Button Clicked"
-                               data-gtm-label="I can enjoy life because of the way I’m managing my money"
-                               data-gtm-category="Financial Well-Being Tool Interaction">
-                        <label class="a-label" for="question_4-completely">
-                            Completely
-                        </label>
-                    </div>
-                    <div class="m-form-field m-form-field__radio">
-                        <input class="a-radio"
-                               type="radio"
-                               id="question_4-very-well"
-                               name="question_4"
-                               value="3"
-                               data-gtm-action="Questionnaire Radio Button Clicked"
-                               data-gtm-label="I can enjoy life because of the way I’m managing my money"
-                               data-gtm-category="Financial Well-Being Tool Interaction">
-                        <label class="a-label" for="question_4-very-well">
-                            Very well
-                        </label>
-                    </div>
-                    <div class="m-form-field m-form-field__radio">
-                        <input class="a-radio"
-                               type="radio"
-                               id="question_4-somewhat"
-                               name="question_4"
-                               value="2"
-                               data-gtm-action="Questionnaire Radio Button Clicked"
-                               data-gtm-label="I can enjoy life because of the way I’m managing my money"
-                               data-gtm-category="Financial Well-Being Tool Interaction">
-                        <label class="a-label" for="question_4-somewhat">
-                            Somewhat
-                        </label>
-                    </div>
-                    <div class="m-form-field m-form-field__radio">
-                        <input class="a-radio"
-                               type="radio"
-                               id="question_4-very-little"
-                               name="question_4"
-                               value="1"
-                               data-gtm-action="Questionnaire Radio Button Clicked"
-                               data-gtm-label="I can enjoy life because of the way I’m managing my money"
-                               data-gtm-category="Financial Well-Being Tool Interaction">
-                        <label class="a-label" for="question_4-very-little">
-                            Very little
-                        </label>
-                    </div>
-                    <div class="m-form-field m-form-field__radio">
-                        <input class="a-radio"
-                               type="radio"
-                               id="question_4-not-at-all"
-                               name="question_4"
-                               value="0"
-                               data-gtm-action="Questionnaire Radio Button Clicked"
-                               data-gtm-label="I can enjoy life because of the way I’m managing my money"
-                               data-gtm-category="Financial Well-Being Tool Interaction">
-                        <label class="a-label" for="question_4-not-at-all">
-                            Not at all
-                        </label>
+                    <div class="o-scale_answer-prefix">This statement describes me</div>
+                    <div class="o-scale_answer-options">
+                        <div class="m-form-field m-form-field__radio">
+                            <input class="a-radio"
+                                   type="radio"
+                                   id="question_4-completely"
+                                   name="question_4"
+                                   value="4"
+                                   data-gtm-action="Questionnaire Radio Button Clicked"
+                                   data-gtm-label="I can enjoy life because of the way I’m managing my money"
+                                   data-gtm-category="Financial Well-Being Tool Interaction">
+                            <label class="a-label" for="question_4-completely">
+                                Completely
+                            </label>
+                        </div>
+                        <div class="m-form-field m-form-field__radio">
+                            <input class="a-radio"
+                                   type="radio"
+                                   id="question_4-very-well"
+                                   name="question_4"
+                                   value="3"
+                                   data-gtm-action="Questionnaire Radio Button Clicked"
+                                   data-gtm-label="I can enjoy life because of the way I’m managing my money"
+                                   data-gtm-category="Financial Well-Being Tool Interaction">
+                            <label class="a-label" for="question_4-very-well">
+                                Very well
+                            </label>
+                        </div>
+                        <div class="m-form-field m-form-field__radio">
+                            <input class="a-radio"
+                                   type="radio"
+                                   id="question_4-somewhat"
+                                   name="question_4"
+                                   value="2"
+                                   data-gtm-action="Questionnaire Radio Button Clicked"
+                                   data-gtm-label="I can enjoy life because of the way I’m managing my money"
+                                   data-gtm-category="Financial Well-Being Tool Interaction">
+                            <label class="a-label" for="question_4-somewhat">
+                                Somewhat
+                            </label>
+                        </div>
+                        <div class="m-form-field m-form-field__radio">
+                            <input class="a-radio"
+                                   type="radio"
+                                   id="question_4-very-little"
+                                   name="question_4"
+                                   value="1"
+                                   data-gtm-action="Questionnaire Radio Button Clicked"
+                                   data-gtm-label="I can enjoy life because of the way I’m managing my money"
+                                   data-gtm-category="Financial Well-Being Tool Interaction">
+                            <label class="a-label" for="question_4-very-little">
+                                Very little
+                            </label>
+                        </div>
+                        <div class="m-form-field m-form-field__radio">
+                            <input class="a-radio"
+                                   type="radio"
+                                   id="question_4-not-at-all"
+                                   name="question_4"
+                                   value="0"
+                                   data-gtm-action="Questionnaire Radio Button Clicked"
+                                   data-gtm-label="I can enjoy life because of the way I’m managing my money"
+                                   data-gtm-category="Financial Well-Being Tool Interaction">
+                            <label class="a-label" for="question_4-not-at-all">
+                                Not at all
+                            </label>
+                        </div>
                     </div>
                 </fieldset>
-                <fieldset class="o-scale" id="question_5">
-                    <h3 class="o-scale_header">
+            </div>
+            <div class="o-well o-well__flush o-well__stacked o-scale">
+                <fieldset class="o-form_fieldset" id="question_5">
+                    <h3 class="a-legend">
                         I am just getting by financially
                     </h3>
-                    <div class="answer-prefix">This statement describes me</div>
-                    <div class="m-form-field m-form-field__radio">
-                        <input class="a-radio"
-                               type="radio"
-                               id="question_5-completely"
-                               name="question_5"
-                               value="0"
-                               data-gtm-action="Questionnaire Radio Button Clicked"
-                               data-gtm-label="I am just getting by financially"
-                               data-gtm-category="Financial Well-Being Tool Interaction">
-                        <label class="a-label" for="question_5-completely">
-                            Completely
-                        </label>
-                    </div>
-                    <div class="m-form-field m-form-field__radio">
-                        <input class="a-radio"
-                               type="radio"
-                               id="question_5-very-well"
-                               name="question_5"
-                               value="1"
-                               data-gtm-action="Questionnaire Radio Button Clicked"
-                               data-gtm-label="I am just getting by financially"
-                               data-gtm-category="Financial Well-Being Tool Interaction">
-                        <label class="a-label" for="question_5-very-well">
-                            Very well
-                        </label>
-                    </div>
-                    <div class="m-form-field m-form-field__radio">
-                        <input class="a-radio"
-                               type="radio"
-                               id="question_5-somewhat"
-                               name="question_5"
-                               value="2"
-                               data-gtm-action="Questionnaire Radio Button Clicked"
-                               data-gtm-label="I am just getting by financially"
-                               data-gtm-category="Financial Well-Being Tool Interaction">
-                        <label class="a-label" for="question_5-somewhat">
-                            Somewhat
-                        </label>
-                    </div>
-                    <div class="m-form-field m-form-field__radio">
-                        <input class="a-radio"
-                               type="radio"
-                               id="question_5-very-little"
-                               name="question_5"
-                               value="3"
-                               data-gtm-action="Questionnaire Radio Button Clicked"
-                               data-gtm-label="I am just getting by financially"
-                               data-gtm-category="Financial Well-Being Tool Interaction">
-                        <label class="a-label" for="question_5-very-little">
-                            Very little
-                        </label>
-                    </div>
-                    <div class="m-form-field m-form-field__radio">
-                        <input class="a-radio"
-                               type="radio"
-                               id="question_5-not-at-all"
-                               name="question_5"
-                               value="4"
-                               data-gtm-action="Questionnaire Radio Button Clicked"
-                               data-gtm-label="I am just getting by financially"
-                               data-gtm-category="Financial Well-Being Tool Interaction">
-                        <label class="a-label" for="question_5-not-at-all">
-                            Not at all
-                        </label>
+                    <div class="o-scale_answer-prefix">This statement describes me</div>
+                    <div class="o-scale_answer-options">
+                        <div class="m-form-field m-form-field__radio">
+                            <input class="a-radio"
+                                   type="radio"
+                                   id="question_5-completely"
+                                   name="question_5"
+                                   value="0"
+                                   data-gtm-action="Questionnaire Radio Button Clicked"
+                                   data-gtm-label="I am just getting by financially"
+                                   data-gtm-category="Financial Well-Being Tool Interaction">
+                            <label class="a-label" for="question_5-completely">
+                                Completely
+                            </label>
+                        </div>
+                        <div class="m-form-field m-form-field__radio">
+                            <input class="a-radio"
+                                   type="radio"
+                                   id="question_5-very-well"
+                                   name="question_5"
+                                   value="1"
+                                   data-gtm-action="Questionnaire Radio Button Clicked"
+                                   data-gtm-label="I am just getting by financially"
+                                   data-gtm-category="Financial Well-Being Tool Interaction">
+                            <label class="a-label" for="question_5-very-well">
+                                Very well
+                            </label>
+                        </div>
+                        <div class="m-form-field m-form-field__radio">
+                            <input class="a-radio"
+                                   type="radio"
+                                   id="question_5-somewhat"
+                                   name="question_5"
+                                   value="2"
+                                   data-gtm-action="Questionnaire Radio Button Clicked"
+                                   data-gtm-label="I am just getting by financially"
+                                   data-gtm-category="Financial Well-Being Tool Interaction">
+                            <label class="a-label" for="question_5-somewhat">
+                                Somewhat
+                            </label>
+                        </div>
+                        <div class="m-form-field m-form-field__radio">
+                            <input class="a-radio"
+                                   type="radio"
+                                   id="question_5-very-little"
+                                   name="question_5"
+                                   value="3"
+                                   data-gtm-action="Questionnaire Radio Button Clicked"
+                                   data-gtm-label="I am just getting by financially"
+                                   data-gtm-category="Financial Well-Being Tool Interaction">
+                            <label class="a-label" for="question_5-very-little">
+                                Very little
+                            </label>
+                        </div>
+                        <div class="m-form-field m-form-field__radio">
+                            <input class="a-radio"
+                                   type="radio"
+                                   id="question_5-not-at-all"
+                                   name="question_5"
+                                   value="4"
+                                   data-gtm-action="Questionnaire Radio Button Clicked"
+                                   data-gtm-label="I am just getting by financially"
+                                   data-gtm-category="Financial Well-Being Tool Interaction">
+                            <label class="a-label" for="question_5-not-at-all">
+                                Not at all
+                            </label>
+                        </div>
                     </div>
                 </fieldset>
-                <fieldset class="o-scale" id="question_6">
-                    <h3 class="o-scale_header">
+            </div>
+            <div class="o-well o-well__flush o-well__stacked o-scale">
+                <fieldset class="o-form_fieldset" id="question_6">
+                    <h3 class="a-legend">
                         I am concerned that the money I have or will save won’t last
                     </h3>
-                    <div class="answer-prefix">This statement describes me</div>
-                    <div class="m-form-field m-form-field__radio">
-                        <input class="a-radio"
-                               type="radio"
-                               id="question_6-completely"
-                               name="question_6"
-                               value="0"
-                               data-gtm-action="Questionnaire Radio Button Clicked"
-                               data-gtm-label="I am concerned that the money I have or will save won’t last"
-                               data-gtm-category="Financial Well-Being Tool Interaction">
-                        <label class="a-label" for="question_6-completely">
-                            Completely
-                        </label>
-                    </div>
-                    <div class="m-form-field m-form-field__radio">
-                        <input class="a-radio"
-                               type="radio"
-                               id="question_6-very-well"
-                               name="question_6"
-                               value="1"
-                               data-gtm-action="Questionnaire Radio Button Clicked"
-                               data-gtm-label="I am concerned that the money I have or will save won’t last"
-                               data-gtm-category="Financial Well-Being Tool Interaction">
-                        <label class="a-label" for="question_6-very-well">
-                            Very well
-                        </label>
-                    </div>
-                    <div class="m-form-field m-form-field__radio">
-                        <input class="a-radio"
-                               type="radio"
-                               id="question_6-somewhat"
-                               name="question_6"
-                               value="2"
-                               data-gtm-action="Questionnaire Radio Button Clicked"
-                               data-gtm-label="I am concerned that the money I have or will save won’t last"
-                               data-gtm-category="Financial Well-Being Tool Interaction">
-                        <label class="a-label" for="question_6-somewhat">
-                            Somewhat
-                        </label>
-                    </div>
-                    <div class="m-form-field m-form-field__radio">
-                        <input class="a-radio"
-                               type="radio"
-                               id="question_6-very-little"
-                               name="question_6"
-                               value="3"
-                               data-gtm-action="Questionnaire Radio Button Clicked"
-                               data-gtm-label="I am concerned that the money I have or will save won’t last"
-                               data-gtm-category="Financial Well-Being Tool Interaction">
-                        <label class="a-label" for="question_6-very-little">
-                            Very little
-                        </label>
-                    </div>
-                    <div class="m-form-field m-form-field__radio">
-                        <input class="a-radio"
-                               type="radio"
-                               id="question_6-not-at-all"
-                               name="question_6"
-                               value="4"
-                               data-gtm-action="Questionnaire Radio Button Clicked"
-                               data-gtm-label="I am concerned that the money I have or will save won’t last"
-                               data-gtm-category="Financial Well-Being Tool Interaction">
-                        <label class="a-label" for="question_6-not-at-all">
-                            Not at all
-                        </label>
+                    <div class="o-scale_answer-prefix">This statement describes me</div>
+                    <div class="o-scale_answer-options">
+                        <div class="m-form-field m-form-field__radio">
+                            <input class="a-radio"
+                                   type="radio"
+                                   id="question_6-completely"
+                                   name="question_6"
+                                   value="0"
+                                   data-gtm-action="Questionnaire Radio Button Clicked"
+                                   data-gtm-label="I am concerned that the money I have or will save won’t last"
+                                   data-gtm-category="Financial Well-Being Tool Interaction">
+                            <label class="a-label" for="question_6-completely">
+                                Completely
+                            </label>
+                        </div>
+                        <div class="m-form-field m-form-field__radio">
+                            <input class="a-radio"
+                                   type="radio"
+                                   id="question_6-very-well"
+                                   name="question_6"
+                                   value="1"
+                                   data-gtm-action="Questionnaire Radio Button Clicked"
+                                   data-gtm-label="I am concerned that the money I have or will save won’t last"
+                                   data-gtm-category="Financial Well-Being Tool Interaction">
+                            <label class="a-label" for="question_6-very-well">
+                                Very well
+                            </label>
+                        </div>
+                        <div class="m-form-field m-form-field__radio">
+                            <input class="a-radio"
+                                   type="radio"
+                                   id="question_6-somewhat"
+                                   name="question_6"
+                                   value="2"
+                                   data-gtm-action="Questionnaire Radio Button Clicked"
+                                   data-gtm-label="I am concerned that the money I have or will save won’t last"
+                                   data-gtm-category="Financial Well-Being Tool Interaction">
+                            <label class="a-label" for="question_6-somewhat">
+                                Somewhat
+                            </label>
+                        </div>
+                        <div class="m-form-field m-form-field__radio">
+                            <input class="a-radio"
+                                   type="radio"
+                                   id="question_6-very-little"
+                                   name="question_6"
+                                   value="3"
+                                   data-gtm-action="Questionnaire Radio Button Clicked"
+                                   data-gtm-label="I am concerned that the money I have or will save won’t last"
+                                   data-gtm-category="Financial Well-Being Tool Interaction">
+                            <label class="a-label" for="question_6-very-little">
+                                Very little
+                            </label>
+                        </div>
+                        <div class="m-form-field m-form-field__radio">
+                            <input class="a-radio"
+                                   type="radio"
+                                   id="question_6-not-at-all"
+                                   name="question_6"
+                                   value="4"
+                                   data-gtm-action="Questionnaire Radio Button Clicked"
+                                   data-gtm-label="I am concerned that the money I have or will save won’t last"
+                                   data-gtm-category="Financial Well-Being Tool Interaction">
+                            <label class="a-label" for="question_6-not-at-all">
+                                Not at all
+                            </label>
+                        </div>
                     </div>
                 </fieldset>
             </div>
         </div>
         <div class="block">
             <h2>Part 2: How often does this statement apply to you?</h2>
-            <div class="question-group">
-                <fieldset class="o-scale" id="question_7">
-                    <h3 class="o-scale_header">
+            <div class="o-well o-well__flush o-well__stacked o-scale">
+                <fieldset class="o-form_fieldset" id="question_7">
+                    <h3 class="a-legend">
                         Giving a gift for a wedding, birthday or other occasion would put a strain on my finances for the month
                     </h3>
-                    <div class="answer-prefix">This statement applies to me</div>
-                    <div class="m-form-field m-form-field__radio">
-                        <input class="a-radio"
-                               type="radio"
-                               id="question_7-always"
-                               name="question_7"
-                               value="0"
-                               data-gtm-action="Questionnaire Radio Button Clicked"
-                               data-gtm-label="Giving a gift for a wedding, birthday or other occasion would put a strain on my finances for the month"
-                               data-gtm-category="Financial Well-Being Tool Interaction">
-                        <label class="a-label" for="question_7-always">
-                            Always
-                        </label>
-                    </div>
-                    <div class="m-form-field m-form-field__radio">
-                        <input class="a-radio"
-                               type="radio"
-                               id="question_7-often"
-                               name="question_7"
-                               value="1"
-                               data-gtm-action="Questionnaire Radio Button Clicked"
-                               data-gtm-label="Giving a gift for a wedding, birthday or other occasion would put a strain on my finances for the month"
-                               data-gtm-category="Financial Well-Being Tool Interaction">
-                        <label class="a-label" for="question_7-often">
-                            Often
-                        </label>
-                    </div>
-                    <div class="m-form-field m-form-field__radio">
-                        <input class="a-radio"
-                               type="radio"
-                               id="question_7-sometimes"
-                               name="question_7"
-                               value="2"
-                               data-gtm-action="Questionnaire Radio Button Clicked"
-                               data-gtm-label="Giving a gift for a wedding, birthday or other occasion would put a strain on my finances for the month"
-                               data-gtm-category="Financial Well-Being Tool Interaction">
-                        <label class="a-label" for="question_7-sometimes">
-                            Sometimes
-                        </label>
-                    </div>
-                    <div class="m-form-field m-form-field__radio">
-                        <input class="a-radio"
-                               type="radio"
-                               id="question_7-rarely"
-                               name="question_7"
-                               value="3"
-                               data-gtm-action="Questionnaire Radio Button Clicked"
-                               data-gtm-label="Giving a gift for a wedding, birthday or other occasion would put a strain on my finances for the month"
-                               data-gtm-category="Financial Well-Being Tool Interaction">
-                        <label class="a-label" for="question_7-rarely">
-                            Rarely
-                        </label>
-                    </div>
-                    <div class="m-form-field m-form-field__radio">
-                        <input class="a-radio"
-                               type="radio"
-                               id="question_7-never"
-                               name="question_7"
-                               value="4"
-                               data-gtm-action="Questionnaire Radio Button Clicked"
-                               data-gtm-label="Giving a gift for a wedding, birthday or other occasion would put a strain on my finances for the month"
-                               data-gtm-category="Financial Well-Being Tool Interaction">
-                        <label class="a-label" for="question_7-never">
-                            Never
-                        </label>
+                    <div class="o-scale_answer-prefix">This statement applies to me</div>
+                    <div class="o-scale_answer-options">
+                        <div class="m-form-field m-form-field__radio">
+                            <input class="a-radio"
+                                   type="radio"
+                                   id="question_7-always"
+                                   name="question_7"
+                                   value="0"
+                                   data-gtm-action="Questionnaire Radio Button Clicked"
+                                   data-gtm-label="Giving a gift for a wedding, birthday or other occasion would put a strain on my finances for the month"
+                                   data-gtm-category="Financial Well-Being Tool Interaction">
+                            <label class="a-label" for="question_7-always">
+                                Always
+                            </label>
+                        </div>
+                        <div class="m-form-field m-form-field__radio">
+                            <input class="a-radio"
+                                   type="radio"
+                                   id="question_7-often"
+                                   name="question_7"
+                                   value="1"
+                                   data-gtm-action="Questionnaire Radio Button Clicked"
+                                   data-gtm-label="Giving a gift for a wedding, birthday or other occasion would put a strain on my finances for the month"
+                                   data-gtm-category="Financial Well-Being Tool Interaction">
+                            <label class="a-label" for="question_7-often">
+                                Often
+                            </label>
+                        </div>
+                        <div class="m-form-field m-form-field__radio">
+                            <input class="a-radio"
+                                   type="radio"
+                                   id="question_7-sometimes"
+                                   name="question_7"
+                                   value="2"
+                                   data-gtm-action="Questionnaire Radio Button Clicked"
+                                   data-gtm-label="Giving a gift for a wedding, birthday or other occasion would put a strain on my finances for the month"
+                                   data-gtm-category="Financial Well-Being Tool Interaction">
+                            <label class="a-label" for="question_7-sometimes">
+                                Sometimes
+                            </label>
+                        </div>
+                        <div class="m-form-field m-form-field__radio">
+                            <input class="a-radio"
+                                   type="radio"
+                                   id="question_7-rarely"
+                                   name="question_7"
+                                   value="3"
+                                   data-gtm-action="Questionnaire Radio Button Clicked"
+                                   data-gtm-label="Giving a gift for a wedding, birthday or other occasion would put a strain on my finances for the month"
+                                   data-gtm-category="Financial Well-Being Tool Interaction">
+                            <label class="a-label" for="question_7-rarely">
+                                Rarely
+                            </label>
+                        </div>
+                        <div class="m-form-field m-form-field__radio">
+                            <input class="a-radio"
+                                   type="radio"
+                                   id="question_7-never"
+                                   name="question_7"
+                                   value="4"
+                                   data-gtm-action="Questionnaire Radio Button Clicked"
+                                   data-gtm-label="Giving a gift for a wedding, birthday or other occasion would put a strain on my finances for the month"
+                                   data-gtm-category="Financial Well-Being Tool Interaction">
+                            <label class="a-label" for="question_7-never">
+                                Never
+                            </label>
+                        </div>
                     </div>
                 </fieldset>
-                <fieldset class="o-scale" id="question_8">
-                    <h3 class="o-scale_header">
+            </div>
+            <div class="o-well o-well__flush o-well__stacked o-scale">
+                <fieldset class="o-form_fieldset" id="question_8">
+                    <h3 class="a-legend">
                         I have money left over at the end of the month
                     </h3>
-                    <div class="answer-prefix">This statement applies to me</div>
-                    <div class="m-form-field m-form-field__radio">
-                        <input class="a-radio"
-                               type="radio"
-                               id="question_8-always"
-                               name="question_8"
-                               value="4"
-                               data-gtm-action="Questionnaire Radio Button Clicked"
-                               data-gtm-label="I have money left over at the end of the month"
-                               data-gtm-category="Financial Well-Being Tool Interaction">
-                        <label class="a-label" for="question_8-always">
-                            Always
-                        </label>
-                    </div>
-                    <div class="m-form-field m-form-field__radio">
-                        <input class="a-radio"
-                               type="radio"
-                               id="question_8-often"
-                               name="question_8"
-                               value="3"
-                               data-gtm-action="Questionnaire Radio Button Clicked"
-                               data-gtm-label="I have money left over at the end of the month"
-                               data-gtm-category="Financial Well-Being Tool Interaction">
-                        <label class="a-label" for="question_8-often">
-                            Often
-                        </label>
-                    </div>
-                    <div class="m-form-field m-form-field__radio">
-                        <input class="a-radio"
-                               type="radio"
-                               id="question_8-sometimes"
-                               name="question_8"
-                               value="2"
-                               data-gtm-action="Questionnaire Radio Button Clicked"
-                               data-gtm-label="I have money left over at the end of the month"
-                               data-gtm-category="Financial Well-Being Tool Interaction">
-                        <label class="a-label" for="question_8-sometimes">
-                            Sometimes
-                        </label>
-                    </div>
-                    <div class="m-form-field m-form-field__radio">
-                        <input class="a-radio"
-                               type="radio"
-                               id="question_8-rarely"
-                               name="question_8"
-                               value="1"
-                               data-gtm-action="Questionnaire Radio Button Clicked"
-                               data-gtm-label="I have money left over at the end of the month"
-                               data-gtm-category="Financial Well-Being Tool Interaction">
-                        <label class="a-label" for="question_8-rarely">
-                            Rarely
-                        </label>
-                    </div>
-                    <div class="m-form-field m-form-field__radio">
-                        <input class="a-radio"
-                               type="radio"
-                               id="question_8-never"
-                               name="question_8"
-                               value="0"
-                               data-gtm-action="Questionnaire Radio Button Clicked"
-                               data-gtm-label="I have money left over at the end of the month"
-                               data-gtm-category="Financial Well-Being Tool Interaction">
-                        <label class="a-label" for="question_8-never">
-                            Never
-                        </label>
+                    <div class="o-scale_answer-prefix">This statement applies to me</div>
+                    <div class="o-scale_answer-options">
+                        <div class="m-form-field m-form-field__radio">
+                            <input class="a-radio"
+                                   type="radio"
+                                   id="question_8-always"
+                                   name="question_8"
+                                   value="4"
+                                   data-gtm-action="Questionnaire Radio Button Clicked"
+                                   data-gtm-label="I have money left over at the end of the month"
+                                   data-gtm-category="Financial Well-Being Tool Interaction"> <label class="a-label" for="question_8-always">
+                                Always
+                            </label>
+                        </div>
+                        <div class="m-form-field m-form-field__radio">
+                            <input class="a-radio"
+                                   type="radio"
+                                   id="question_8-often"
+                                   name="question_8"
+                                   value="3"
+                                   data-gtm-action="Questionnaire Radio Button Clicked"
+                                   data-gtm-label="I have money left over at the end of the month"
+                                   data-gtm-category="Financial Well-Being Tool Interaction">
+                            <label class="a-label" for="question_8-often">
+                                Often
+                            </label>
+                        </div>
+                        <div class="m-form-field m-form-field__radio">
+                            <input class="a-radio"
+                                   type="radio"
+                                   id="question_8-sometimes"
+                                   name="question_8"
+                                   value="2"
+                                   data-gtm-action="Questionnaire Radio Button Clicked"
+                                   data-gtm-label="I have money left over at the end of the month"
+                                   data-gtm-category="Financial Well-Being Tool Interaction">
+                            <label class="a-label" for="question_8-sometimes">
+                                Sometimes
+                            </label>
+                        </div>
+                        <div class="m-form-field m-form-field__radio">
+                            <input class="a-radio"
+                                   type="radio"
+                                   id="question_8-rarely"
+                                   name="question_8"
+                                   value="1"
+                                   data-gtm-action="Questionnaire Radio Button Clicked"
+                                   data-gtm-label="I have money left over at the end of the month"
+                                   data-gtm-category="Financial Well-Being Tool Interaction">
+                            <label class="a-label" for="question_8-rarely">
+                                Rarely
+                            </label>
+                        </div>
+                        <div class="m-form-field m-form-field__radio">
+                            <input class="a-radio"
+                                   type="radio"
+                                   id="question_8-never"
+                                   name="question_8"
+                                   value="0"
+                                   data-gtm-action="Questionnaire Radio Button Clicked"
+                                   data-gtm-label="I have money left over at the end of the month"
+                                   data-gtm-category="Financial Well-Being Tool Interaction">
+                            <label class="a-label" for="question_8-never">
+                                Never
+                            </label>
+                        </div>
                     </div>
                 </fieldset>
-                <fieldset class="o-scale" id="question_9">
-                    <h3 class="o-scale_header">
+            </div>
+            <div class="o-well o-well__flush o-well__stacked o-scale">
+                <fieldset class="o-form_fieldset" id="question_9">
+                    <h3 class="a-legend">
                         I am behind with my finances
                     </h3>
-                    <div class="answer-prefix">This statement applies to me</div>
-                    <div class="m-form-field m-form-field__radio">
-                        <input class="a-radio"
-                               type="radio"
-                               id="question_9-always"
-                               name="question_9"
-                               value="0"
-                               data-gtm-action="Questionnaire Radio Button Clicked"
-                               data-gtm-label="I am behind with my finances"
-                               data-gtm-category="Financial Well-Being Tool Interaction">
-                        <label class="a-label" for="question_9-always">
-                            Always
-                        </label>
-                    </div>
-                    <div class="m-form-field m-form-field__radio">
-                        <input class="a-radio"
-                               type="radio"
-                               id="question_9-often"
-                               name="question_9"
-                               value="1"
-                               data-gtm-action="Questionnaire Radio Button Clicked"
-                               data-gtm-label="I am behind with my finances"
-                               data-gtm-category="Financial Well-Being Tool Interaction">
-                        <label class="a-label" for="question_9-often">
-                            Often
-                        </label>
-                    </div>
-                    <div class="m-form-field m-form-field__radio">
-                        <input class="a-radio"
-                               type="radio"
-                               id="question_9-sometimes"
-                               name="question_9"
-                               value="2"
-                               data-gtm-action="Questionnaire Radio Button Clicked"
-                               data-gtm-label="I am behind with my finances"
-                               data-gtm-category="Financial Well-Being Tool Interaction">
-                        <label class="a-label" for="question_9-sometimes">
-                            Sometimes
-                        </label>
-                    </div>
-                    <div class="m-form-field m-form-field__radio">
-                        <input class="a-radio"
-                               type="radio"
-                               id="question_9-rarely"
-                               name="question_9"
-                               value="3"
-                               data-gtm-action="Questionnaire Radio Button Clicked"
-                               data-gtm-label="I am behind with my finances"
-                               data-gtm-category="Financial Well-Being Tool Interaction">
-                        <label class="a-label" for="question_9-rarely">
-                            Rarely
-                        </label>
-                    </div>
-                    <div class="m-form-field m-form-field__radio">
-                        <input class="a-radio"
-                               type="radio"
-                               id="question_9-never"
-                               name="question_9"
-                               value="4"
-                               data-gtm-action="Questionnaire Radio Button Clicked"
-                               data-gtm-label="I am behind with my finances"
-                               data-gtm-category="Financial Well-Being Tool Interaction">
-                        <label class="a-label" for="question_9-never">
-                            Never
-                        </label>
+                    <div class="o-scale_answer-prefix">This statement applies to me</div>
+                    <div class="o-scale_answer-options">
+                        <div class="m-form-field m-form-field__radio">
+                            <input class="a-radio"
+                                   type="radio"
+                                   id="question_9-always"
+                                   name="question_9"
+                                   value="0"
+                                   data-gtm-action="Questionnaire Radio Button Clicked"
+                                   data-gtm-label="I am behind with my finances"
+                                   data-gtm-category="Financial Well-Being Tool Interaction">
+                            <label class="a-label" for="question_9-always">
+                                Always
+                            </label>
+                        </div>
+                        <div class="m-form-field m-form-field__radio">
+                            <input class="a-radio"
+                                   type="radio"
+                                   id="question_9-often"
+                                   name="question_9"
+                                   value="1"
+                                   data-gtm-action="Questionnaire Radio Button Clicked"
+                                   data-gtm-label="I am behind with my finances"
+                                   data-gtm-category="Financial Well-Being Tool Interaction">
+                            <label class="a-label" for="question_9-often">
+                                Often
+                            </label>
+                        </div>
+                        <div class="m-form-field m-form-field__radio">
+                            <input class="a-radio"
+                                   type="radio"
+                                   id="question_9-sometimes"
+                                   name="question_9"
+                                   value="2"
+                                   data-gtm-action="Questionnaire Radio Button Clicked"
+                                   data-gtm-label="I am behind with my finances"
+                                   data-gtm-category="Financial Well-Being Tool Interaction">
+                            <label class="a-label" for="question_9-sometimes">
+                                Sometimes
+                            </label>
+                        </div>
+                        <div class="m-form-field m-form-field__radio">
+                            <input class="a-radio"
+                                   type="radio"
+                                   id="question_9-rarely"
+                                   name="question_9"
+                                   value="3"
+                                   data-gtm-action="Questionnaire Radio Button Clicked"
+                                   data-gtm-label="I am behind with my finances"
+                                   data-gtm-category="Financial Well-Being Tool Interaction">
+                            <label class="a-label" for="question_9-rarely">
+                                Rarely
+                            </label>
+                        </div>
+                        <div class="m-form-field m-form-field__radio">
+                            <input class="a-radio"
+                                   type="radio"
+                                   id="question_9-never"
+                                   name="question_9"
+                                   value="4"
+                                   data-gtm-action="Questionnaire Radio Button Clicked"
+                                   data-gtm-label="I am behind with my finances"
+                                   data-gtm-category="Financial Well-Being Tool Interaction">
+                            <label class="a-label" for="question_9-never">
+                                Never
+                            </label>
+                        </div>
                     </div>
                 </fieldset>
-                <fieldset class="o-scale" id="question_10">
-                    <h3 class="o-scale_header">
+            </div>
+            <div class="o-well o-well__flush o-well__stacked o-scale">
+                <fieldset class="o-form_fieldset" id="question_10">
+                    <h3 class="a-legend">
                         My finances control my life
                     </h3>
-                    <div class="answer-prefix">This statement applies to me</div>
-                    <div class="m-form-field m-form-field__radio">
-                        <input class="a-radio"
-                               type="radio"
-                               id="question_10-always"
-                               name="question_10"
-                               value="0"
-                               data-gtm-action="Questionnaire Radio Button Clicked"
-                               data-gtm-label="My finances control my life"
-                               data-gtm-category="Financial Well-Being Tool Interaction">
-                        <label class="a-label" for="question_10-always">
-                            Always
-                        </label>
-                    </div>
-                    <div class="m-form-field m-form-field__radio">
-                        <input class="a-radio"
-                               type="radio"
-                               id="question_10-often"
-                               name="question_10"
-                               value="1"
-                               data-gtm-action="Questionnaire Radio Button Clicked"
-                               data-gtm-label="My finances control my life"
-                               data-gtm-category="Financial Well-Being Tool Interaction">
-                        <label class="a-label" for="question_10-often">
-                            Often
-                        </label>
-                    </div>
-                    <div class="m-form-field m-form-field__radio">
-                        <input class="a-radio"
-                               type="radio"
-                               id="question_10-sometimes"
-                               name="question_10"
-                               value="2"
-                               data-gtm-action="Questionnaire Radio Button Clicked"
-                               data-gtm-label="My finances control my life"
-                               data-gtm-category="Financial Well-Being Tool Interaction">
-                        <label class="a-label" for="question_10-sometimes">
-                            Sometimes
-                        </label>
-                    </div>
-                    <div class="m-form-field m-form-field__radio">
-                        <input class="a-radio"
-                               type="radio"
-                               id="question_10-rarely"
-                               name="question_10"
-                               value="3"
-                               data-gtm-action="Questionnaire Radio Button Clicked"
-                               data-gtm-label="My finances control my life"
-                               data-gtm-category="Financial Well-Being Tool Interaction">
-                        <label class="a-label" for="question_10-rarely">
-                            Rarely
-                        </label>
-                    </div>
-                    <div class="m-form-field m-form-field__radio">
-                        <input class="a-radio"
-                               type="radio"
-                               id="question_10-never"
-                               name="question_10"
-                               value="4"
-                               data-gtm-action="Questionnaire Radio Button Clicked"
-                               data-gtm-label="My finances control my life"
-                               data-gtm-category="Financial Well-Being Tool Interaction">
-                        <label class="a-label" for="question_10-never">
-                            Never
-                        </label>
+                    <div class="o-scale_answer-prefix">This statement applies to me</div>
+                    <div class="o-scale_answer-options">
+                        <div class="m-form-field m-form-field__radio">
+                            <input class="a-radio"
+                                   type="radio"
+                                   id="question_10-always"
+                                   name="question_10"
+                                   value="0"
+                                   data-gtm-action="Questionnaire Radio Button Clicked"
+                                   data-gtm-label="My finances control my life"
+                                   data-gtm-category="Financial Well-Being Tool Interaction">
+                            <label class="a-label" for="question_10-always">
+                                Always
+                            </label>
+                        </div>
+                        <div class="m-form-field m-form-field__radio">
+                            <input class="a-radio"
+                                   type="radio"
+                                   id="question_10-often"
+                                   name="question_10"
+                                   value="1"
+                                   data-gtm-action="Questionnaire Radio Button Clicked"
+                                   data-gtm-label="My finances control my life"
+                                   data-gtm-category="Financial Well-Being Tool Interaction">
+                            <label class="a-label" for="question_10-often">
+                                Often
+                            </label>
+                        </div>
+                        <div class="m-form-field m-form-field__radio">
+                            <input class="a-radio"
+                                   type="radio"
+                                   id="question_10-sometimes"
+                                   name="question_10"
+                                   value="2"
+                                   data-gtm-action="Questionnaire Radio Button Clicked"
+                                   data-gtm-label="My finances control my life"
+                                   data-gtm-category="Financial Well-Being Tool Interaction">
+                            <label class="a-label" for="question_10-sometimes">
+                                Sometimes
+                            </label>
+                        </div>
+                        <div class="m-form-field m-form-field__radio">
+                            <input class="a-radio"
+                                   type="radio"
+                                   id="question_10-rarely"
+                                   name="question_10"
+                                   value="3"
+                                   data-gtm-action="Questionnaire Radio Button Clicked"
+                                   data-gtm-label="My finances control my life"
+                                   data-gtm-category="Financial Well-Being Tool Interaction">
+                            <label class="a-label" for="question_10-rarely">
+                                Rarely
+                            </label>
+                        </div>
+                        <div class="m-form-field m-form-field__radio">
+                            <input class="a-radio"
+                                   type="radio"
+                                   id="question_10-never"
+                                   name="question_10"
+                                   value="4"
+                                   data-gtm-action="Questionnaire Radio Button Clicked"
+                                   data-gtm-label="My finances control my life"
+                                   data-gtm-category="Financial Well-Being Tool Interaction">
+                            <label class="a-label" for="question_10-never">
+                                Never
+                            </label>
+                        </div>
                     </div>
                 </fieldset>
             </div>
         </div>
         <div class="block u-mb30">
             <h2>About you</h2>
-            <div class="question-group">
+            <div class="o-well o-well__flush">
                 <fieldset class="o-form_fieldset" id="age">
-                    <h3 class="o-scale_header">
+                    <h3 class="a-legend">
                         Select your age group. This changes the scoring calculation.
                     </h3>
                     <ul class="m-list m-list__unstyled content-l">
@@ -893,7 +889,7 @@
                     </ul>
                 </fieldset>
                 <fieldset class="o-form_fieldset" id="method">
-                    <h3 class="o-scale_header">
+                    <h3 class="a-legend">
                         Select how you completed the questionnaire. This changes the scoring calculation.
                     </h3>
                     <ul class="m-list m-list__unstyled content-l">


### PR DESCRIPTION
The FWB assets were living on their own within the app code instead of
the main cfgov assets. Tidied up the code and utilized existing asset
code where possible. Could still use some more more optimization before
moving the scale code to Capital Framework as well as a discussion about
the flush well styles.

## Additions

- `o-well__flush` to pull a well left and right
- `o-well__stacked` to allow multiple wells to be stacked without spacing between them
- `o-scale` to control the default form element layouts within the wells
- `m-notification__subtle` to create less "in your face" notifications

## Testing

1. `gulp build`
1. Navigate to `http://localhost:8000/consumer-tools/financial-well-being/`, observe zero visible changes compared to `https://www.consumerfinance.gov/consumer-tools/financial-well-being/`

## Screenshots

![screen shot 2017-11-09 at 9 39 40 am](https://user-images.githubusercontent.com/1280430/32614018-ed4a8224-c531-11e7-9bcd-8964100746a9.png)


## Notes

- I tried using combinations with `block` modifiers but due to spacing that was added in undesirable places I opted to use cfgov-refresh's `o-well`. Both `o-well` and `o-scale` should be moved to Capital Framework as a next step, but will probably depend on some HUB discussions.
- I didn't move the results styles because we don't yet have a great way to load assets for individual pages/components in Less. @Scotchester and I have discussed digging into that as a Design Ops project after we finish svg icons, @ascott1 what do you think?

## Todos

- Open/continue HUB discussions

## Checklist

* [x] PR has an informative and human-readable title
* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [x] Passes all existing automated tests
* [x] Any *change* in functionality is tested
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices
* [x] Project documentation has been updated
* [x] Reviewers requested with the [Reviewer tool](https://help.github.com/articles/about-pull-request-reviews/) :arrow_right:
