### PR TITLE
WIP: Restrict pages found to current site

### DIFF
--- a/cfgov/v1/forms.py
+++ b/cfgov/v1/forms.py
@@ -91,8 +91,7 @@ class FilterableListForm(forms.Form):
         self.base_query = kwargs.pop('base_query')
         super(FilterableListForm, self).__init__(*args, **kwargs)
 
-        pages = self.base_query.live()
-        page_ids = pages.values_list('id', flat=True)
+        page_ids = self.base_query.live().values_list('id', flat=True)
 
         clean_categories(selected_categories=self.data.get('categories'))
         self.set_topics(page_ids)

--- a/cfgov/v1/models/browse_filterable_page.py
+++ b/cfgov/v1/models/browse_filterable_page.py
@@ -84,9 +84,9 @@ class NewsroomLandingPage(BrowseFilterablePage):
         )))
 
     @classmethod
-    def base_query(cls):
+    def base_query(cls, site):
         """Newsroom pages should only show content from certain categories."""
-        eligible_pages = AbstractFilterPage.objects.live()
+        eligible_pages = AbstractFilterPage.objects.in_site(site).live()
 
         return eligible_pages.filter(
             categories__name__in=cls.eligible_categories()

--- a/cfgov/v1/models/sublanding_filterable_page.py
+++ b/cfgov/v1/models/sublanding_filterable_page.py
@@ -63,11 +63,11 @@ class ActivityLogPage(SublandingFilterablePage):
         )))
 
     @classmethod
-    def base_query(cls):
+    def base_query(cls, site):
         """
         Recent updates pages should only show content from certain categories.
         """
-        eligible_pages = AbstractFilterPage.objects.live()
+        eligible_pages = AbstractFilterPage.objects.in_site(site).live()
 
         return eligible_pages.filter(
             categories__name__in=cls.eligible_categories()

--- a/cfgov/v1/tests/models/test_browse_filterable_page.py
+++ b/cfgov/v1/tests/models/test_browse_filterable_page.py
@@ -18,8 +18,11 @@ class EventArchivePageTestCase(TestCase):
 
 
 class TestNewsroomLandingPage(TestCase):
+    def setUp(self):
+        self.site = Site.objects.get(is_default_site=True)
+
     def test_no_pages_by_default(self):
-        query = NewsroomLandingPage.base_query()
+        query = NewsroomLandingPage.base_query(site=self.site)
         self.assertFalse(query.exists())
 
     def test_eligible_categories(self):
@@ -46,10 +49,10 @@ class TestNewsroomLandingPage(TestCase):
 
     def test_no_pages_matching_categories(self):
         self.make_page_with_category('test')
-        query = NewsroomLandingPage.base_query()
+        query = NewsroomLandingPage.base_query(site=self.site)
         self.assertFalse(query.exists())
 
     def test_page_matches_categories(self):
         self.make_page_with_category('op-ed')
-        query = NewsroomLandingPage.base_query()
+        query = NewsroomLandingPage.base_query(site=self.site)
         self.assertTrue(query.exists())

--- a/cfgov/v1/tests/test_filterable_list_form.py
+++ b/cfgov/v1/tests/test_filterable_list_form.py
@@ -12,8 +12,9 @@ from v1.util.categories import clean_categories
 class TestFilterableListForm(TestCase):
 
     def setUpFilterableForm(self, data=None):
-        base_query = AbstractFilterPage.objects.live()
-        form = FilterableListForm(base_query=base_query)
+        site = Site.objects.get(is_default_site=True)
+        base_query = AbstractFilterPage.objects.in_site(site).live()
+        form = FilterableListForm(site=site, base_query=base_query)
         form.is_bound = True
         form.cleaned_data = data
         return form
@@ -65,13 +66,13 @@ class TestFilterableListForm(TestCase):
 
     def test_filter_by_author_names(self):
         page1 = BlogPage(title='test page 1')
-        page1.authors.add('richa-agarwal')
-        page1.authors.add('sarah-simpson')
+        page1.authors.add('person-one')
+        page1.authors.add('person-two')
         page2 = BlogPage(title='test page 2')
-        page2.authors.add('richard-cordray')
+        page2.authors.add('person-three')
         publish_page(page1)
         publish_page(page2)
-        form = self.setUpFilterableForm(data={'authors': ['sarah-simpson']})
+        form = self.setUpFilterableForm(data={'authors': ['person-two']})
         page_set = form.get_page_set()
         self.assertEquals(len(page_set), 1)
         self.assertEquals(page_set[0].specific, page1)

--- a/cfgov/v1/util/filterable_list.py
+++ b/cfgov/v1/util/filterable_list.py
@@ -33,13 +33,6 @@ class FilterableListMixin(object):
                                   self.per_page_limit())
             page = request.GET.get('page')
 
-    def process_form(self, request, form):
-        filter_data = {}
-        if form.is_valid():
-            paginator = Paginator(form.get_page_set(),
-                                  self.per_page_limit())
-            page = request.GET.get('page')
-
             # Get the page number in the request and get the page from the
             # paginator to serve.
             try:

--- a/cfgov/v1/util/filterable_list.py
+++ b/cfgov/v1/util/filterable_list.py
@@ -22,9 +22,16 @@ class FilterableListMixin(object):
         context['filter_data'] = self.process_form(request, form)
         return context
 
-    def base_query(self):
-        return AbstractFilterPage.objects.live().filter(
+    def base_query(self, site):
+        return AbstractFilterPage.objects.live().in_site(site).filter(
             CFGOVPage.objects.child_of_q(self))
+
+    def process_form(self, request, form):
+        filter_data = {}
+        if form.is_valid():
+            paginator = Paginator(form.get_page_set(),
+                                  self.per_page_limit())
+            page = request.GET.get('page')
 
     def process_form(self, request, form):
         filter_data = {}


### PR DESCRIPTION
WIP: Expanding the scope to other similarly structured pages.

The activity feed page was searching the entire database for `ActivityLogPage` objects and found a page in Trash that had been left live. The same was also possible for `NewsroomLandingPage` objects.

This now passes the `Site` object instead of a string `hostname` and restricts found objects to only those that belong to the `Site` being served (`in_site(site)`).