### PR TITLE
Update regulations-site to version 2.1.15

### DIFF
--- a/requirements/optional-public.txt
+++ b/requirements/optional-public.txt
@@ -2,7 +2,7 @@ https://github.com/cfpb/college-costs/releases/download/2.3.12/college_costs-2.3
 https://github.com/cfpb/complaint/releases/download/1.4.4/complaintdatabase-1.4.4-py2-none-any.whl
 git+https://github.com/cfpb/owning-a-home-api.git@0.10.1#egg=owning-a-home-api
 git+https://github.com/cfpb/regulations-core.git@1.2.5#egg=regcore
-https://github.com/cfpb/regulations-site/releases/download/2.1.14/regulations-2.1.14-py2-none-any.whl
+https://github.com/cfpb/regulations-site/releases/download/2.1.15/regulations-2.1.15-py2-none-any.whl
 https://github.com/cfpb/retirement/releases/download/0.5.14/retirement-0.5.14-py2-none-any.whl
 git+https://github.com/cfpb/ccdb5-api.git@v1.0.1#egg=ccdb5-api
 git+https://github.com/cfpb/ccdb5-ui.git@v1.0.2#egg=ccdb5_ui

--- a/requirements/optional-public.txt
+++ b/requirements/optional-public.txt
@@ -2,7 +2,7 @@ https://github.com/cfpb/college-costs/releases/download/2.3.12/college_costs-2.3
 https://github.com/cfpb/complaint/releases/download/1.4.4/complaintdatabase-1.4.4-py2-none-any.whl
 git+https://github.com/cfpb/owning-a-home-api.git@0.10.1#egg=owning-a-home-api
 git+https://github.com/cfpb/regulations-core.git@1.2.5#egg=regcore
-https://github.com/cfpb/regulations-site/releases/download/2.1.13/regulations-2.1.13-py2-none-any.whl
+https://github.com/cfpb/regulations-site/releases/download/2.1.14/regulations-2.1.14-py2-none-any.whl
 https://github.com/cfpb/retirement/releases/download/0.5.14/retirement-0.5.14-py2-none-any.whl
 git+https://github.com/cfpb/ccdb5-api.git@v1.0.1#egg=ccdb5-api
 git+https://github.com/cfpb/ccdb5-ui.git@v1.0.2#egg=ccdb5_ui


### PR DESCRIPTION
This commit updates the optional regulations-site package from version 2.1.13 to new release ~~[2.1.14](https://github.com/cfpb/regulations-site/releases/tag/2.1.14)~~ [2.1.15](https://github.com/cfpb/regulations-site/releases/tag/2.1.15), which fixes an issue with mishandled URLs.

## Changes

- Bump regulations-site version.

## Checklist

* [X] PR has an informative and human-readable title
* [X] Changes are limited to a single goal (no scope creep)
* [X] Code can be automatically merged (no conflicts)
* [X] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [X] Passes all existing automated tests
* [X] Any *change* in functionality is tested
* [X] New functions are documented (with a description, list of inputs, and expected output)
* [X] Visually tested in supported browsers and devices
* [X] Reviewers requested with the [Reviewer tool](https://help.github.com/articles/about-pull-request-reviews/) :arrow_right:
