### PR TITLE
Refactoring related modules for readability and usage

### DIFF
--- a/cfgov/jinja2/v1/_includes/article.html
+++ b/cfgov/jinja2/v1/_includes/article.html
@@ -71,7 +71,7 @@
     </div>
     {% if page.tags.all() | length %}
         <footer>
-            {{ tags.render( related_metadata_tags(page), '', is_wagtail=True) }}
+            {{ tags.render( page.related_metadata_tags(), '', is_wagtail=True) }}
         </footer>
     {% endif %}
 </article>

--- a/cfgov/jinja2/v1/_includes/molecules/related-metadata.html
+++ b/cfgov/jinja2/v1/_includes/molecules/related-metadata.html
@@ -158,5 +158,5 @@
    ========================================================================== #}
 
 {% macro _topics(list) %}
-    {{ _list( related_metadata_tags(page), true ) }}
+    {{ _list( page.related_metadata_tags(), true ) }}
 {% endmacro %}

--- a/cfgov/jinja2/v1/_includes/organisms/item-introduction.html
+++ b/cfgov/jinja2/v1/_includes/organisms/item-introduction.html
@@ -27,7 +27,7 @@
 
 {% macro render(value) %}
 
-{% set form_id, ancestor = get_filter_data(page) %}
+{% set form_id, ancestor = page.get_filter_data() %}
 {% set page_url = get_protected_url(ancestor) %}
 {% set published_date = value.date %}
 {% set has_authors = page.authors.exists() %}

--- a/cfgov/jinja2/v1/_includes/organisms/post-preview.html
+++ b/cfgov/jinja2/v1/_includes/organisms/post-preview.html
@@ -181,7 +181,7 @@
 
             {% if post.tags.exists() %}
                 {%- import 'tags.html' as tags %}
-                {{ tags.render(related_metadata_tags(post), page_url, true, false, form_id, is_wagtail=True) }}
+                {{ tags.render(post.related_metadata_tags(), page_url, true, false, form_id, is_wagtail=True) }}
             {% endif %}
 
             {% if post.secondary_link_url and post.secondary_link_text %}

--- a/cfgov/jinja2/v1/events/_event-detail.html
+++ b/cfgov/jinja2/v1/events/_event-detail.html
@@ -75,7 +75,7 @@
     {% if page.tags.names() | length %}
     <footer>
         {%- import 'tags.html' as tags %}
-        {{ tags.render( related_metadata_tags(page), '', is_wagtail=True) }}
+        {{ tags.render( page.related_metadata_tags(), '', is_wagtail=True) }}
     </footer>
     {% endif %}
 </article>

--- a/cfgov/v1/__init__.py
+++ b/cfgov/v1/__init__.py
@@ -29,6 +29,7 @@ from sheerlike import environment as sheerlike_environment
 from v1.routing import get_protected_url
 from v1.util.util import get_unique_id
 
+
 default_app_config = 'v1.apps.V1AppConfig'
 
 
@@ -73,8 +74,6 @@ def environment(**options):
         'is_blog': ref.is_blog,
         'is_report': ref.is_report,
         'parse_links': parse_links,
-        'related_metadata_tags': related_metadata_tags,
-        'get_filter_data': get_filter_data,
         'cfgovpage_objects': CFGOVPage.objects,
         'signed_redirect': signed_redirect,
         'unsigned_redirect': unsigned_redirect,
@@ -211,32 +210,6 @@ def render_stream_child(context, stream_child):
     unescaped = HTMLParser.HTMLParser().unescape(html)
     # Return the rendered template as safe html
     return Markup(unescaped)
-
-
-@contextfunction
-def related_metadata_tags(context, page):
-    # Set the tags to correct data format
-    tags = {'links': []}
-    # From an ancestor, get the form ids then use the first id since the
-    # filterable list on the page will probably have the first id on the page.
-    id, filter_page = get_filter_data(page)
-    for tag in page.specific.tags.all():
-        tag_link = {'text': tag.name, 'url': ''}
-        if id is not None and filter_page is not None:
-            param = '?filter' + str(id) + '_topics=' + tag.slug
-            tag_link['url'] = get_protected_url(context, filter_page) + param
-        tags['links'].append(tag_link)
-    return tags
-
-
-def get_filter_data(page):
-    for ancestor in page.get_ancestors().reverse().specific():
-        if ancestor.specific_class.__name__ in ['BrowseFilterablePage',
-                                                'SublandingFilterablePage',
-                                                'EventArchivePage',
-                                                'NewsroomLandingPage']:
-            return ancestor.form_id(), ancestor
-    return None, None
 
 
 def get_snippets(snippet_type):

--- a/cfgov/v1/models/base.py
+++ b/cfgov/v1/models/base.py
@@ -156,22 +156,6 @@ class CFGOVPage(Page):
         ]
         specific_categories = block.value['specific_categories']
 
-        def get_appropriate_categories(specific_categories, page_type):
-            """ An array of categories is provided from whatever
-            is selected in the admin, however they each correspond to
-            a page type, e.g. newsroom or blog. This function returns
-            only the categories that belong to the page type in question
-            """
-
-            # Convert the provided categories to their slugs
-            category_slugs = ref.related_posts_category_lookup(
-                specific_categories
-            )
-            # Look up the available categories for the page type in question
-            options = [c[0] for c in ref.choices_for_page_type(page_type)]
-
-            return [c for c in category_slugs if c in options]
-
         for slug, block_name, title in search_types:
             get_related_posts = block.value.get(
                 'relate_{}'.format(block_name), None
@@ -192,7 +176,7 @@ class CFGOVPage(Page):
                 else:
                     # Filter by provided categories for newsroom & blog
                     if specific_categories:
-                        categories = get_appropriate_categories(
+                        categories = ref.get_appropriate_categories(
                             specific_categories=specific_categories,
                             page_type=slug
                         )

--- a/cfgov/v1/models/base.py
+++ b/cfgov/v1/models/base.py
@@ -150,13 +150,13 @@ class CFGOVPage(Page):
         from v1.models.learn_page import AbstractFilterPage
         related = {}
         search_types = [
-            ('blog', 'posts', 'Blog'),
-            ('newsroom', 'newsroom', 'Newsroom'),
-            ('events', 'events', 'Events'),
+            ('blog', 'posts'),
+            ('newsroom', 'newsroom'),
+            ('events', 'events'),
         ]
         specific_categories = block.value['specific_categories']
 
-        for slug, block_name, title in search_types:
+        for slug, block_name in search_types:
             get_related_posts = block.value.get(
                 'relate_{}'.format(block_name), None
             )
@@ -191,7 +191,7 @@ class CFGOVPage(Page):
                 if block.value['and_filtering']:
                     for tag in self.tags.names():
                         final_query = final_query.filter(tags__name=tag)
-                related[title] = final_query[:block.value['limit']]
+                related[slug.title()] = final_query[:block.value['limit']]
 
         # Return a dictionary of lists of each type when there's at least one
         # hit for that type.

--- a/cfgov/v1/models/base.py
+++ b/cfgov/v1/models/base.py
@@ -216,6 +216,29 @@ class CFGOVPage(Page):
         return {search_type: queryset for search_type, queryset in
                 related.items() if queryset}
 
+
+    def related_metadata_tags(self):
+        # Set the tags to correct data format
+        tags = {'links': []}
+        id, filter_page = self.get_filter_data()
+        relative_url = filter_page.relative_url(filter_page.get_site())
+        for tag in self.specific.tags.all():
+            tag_link = {'text': tag.name, 'url': ''}
+            if id is not None and filter_page is not None:
+                param = '?filter' + str(id) + '_topics=' + tag.slug
+                tag_link['url'] = relative_url + param
+            tags['links'].append(tag_link)
+        return tags
+
+    def get_filter_data(self):
+        for ancestor in self.get_ancestors().reverse().specific():
+            if ancestor.specific_class.__name__ in ['BrowseFilterablePage',
+                                                    'SublandingFilterablePage',
+                                                    'EventArchivePage',
+                                                    'NewsroomLandingPage']:
+                return ancestor.form_id(), ancestor
+        return None, None
+
     def get_breadcrumbs(self, request):
         ancestors = self.get_ancestors()
         home_page_children = request.site.root_page.get_children()

--- a/cfgov/v1/models/base.py
+++ b/cfgov/v1/models/base.py
@@ -150,17 +150,14 @@ class CFGOVPage(Page):
         from v1.models.learn_page import AbstractFilterPage
         related = {}
         search_types = [
-            ('blog', 'posts'),
-            ('newsroom', 'newsroom'),
-            ('events', 'events'),
+            ('blog', block.value.get('relate_posts')),
+            ('newsroom', block.value.get('relate_newsroom')),
+            ('events', block.value.get('relate_events')),
         ]
         specific_categories = block.value['specific_categories']
 
-        for slug, block_name in search_types:
-            get_related_posts = block.value.get(
-                'relate_{}'.format(block_name), None
-            )
-            if get_related_posts:
+        for slug, should_get_related_posts in search_types:
+            if should_get_related_posts:
                 # Initialize Q query with a filter on this page's tags
                 query = models.Q(('tags__name__in', self.tags.names()))
 

--- a/cfgov/v1/tests/util/test_ref.py
+++ b/cfgov/v1/tests/util/test_ref.py
@@ -2,7 +2,7 @@ import itertools
 
 from unittest import TestCase
 
-from v1.util.ref import categories
+from v1.util.ref import categories, get_appropriate_categories
 
 
 class TestCategories(TestCase):
@@ -12,3 +12,27 @@ class TestCategories(TestCase):
             dict(page_category).keys() for page_category in page_categories
         )))
         self.assertItemsEqual(slugs, set(slugs))
+
+
+class TestGetAppropriateCategories(TestCase):
+# Note this test is heavily hard-coded with values from cfgov/v1/util/ref.py
+    def test_non_related_post_category_should_not_return_matches(self):
+        result = get_appropriate_categories(['Administrative adjudication'], 'blog')
+        self.assertEqual(result, [])
+
+    def test_related_post_category_should_not_return_matches_if_wrong_page_type(self):
+        result = get_appropriate_categories(['Press Release'], 'blog')
+        self.assertEqual(result, [])
+
+    def test_should_return_matches_only_for_relevant_page_type(self):
+        result = get_appropriate_categories(['Press Release', 'At the CFPB'], 'blog')
+        self.assertEqual(len(result), 1)
+
+    def test_should_return_matches_as_slugs(self):
+        result = get_appropriate_categories(['Press Release'], 'newsroom')
+        self.assertEqual(result, ['press-release'])
+
+    def test_should_return_all_matches(self):
+        result = get_appropriate_categories(['Op-Ed', 'Testimony', 'Speech', 'Press Release'], 'newsroom')
+        self.assertEqual(len(result), 4)
+

--- a/cfgov/v1/util/ref.py
+++ b/cfgov/v1/util/ref.py
@@ -141,6 +141,20 @@ supported_languagues = [
 ]
 
 
+def get_appropriate_categories(specific_categories, page_type):
+    """ An array of specific categories is provided from whatever
+    is selected in the admin for related posts, however they each
+    correspond to a page type, e.g. newsroom or blog. This function returns
+    only the categories that belong to the page type in question
+    """
+    # Convert the provided categories to their slugs
+    category_slugs = related_posts_category_lookup(specific_categories)
+    # Look up the available categories for the page type in question
+    options = [c[0] for c in choices_for_page_type(page_type)]
+
+    return [c for c in category_slugs if c in options]
+
+
 def related_posts_category_lookup(related_categories):
     related = []
     for category in related_categories:


### PR DESCRIPTION
This PR attempts to clean up some of the code around related modules by
- Moving functions onto the CFGOVPage class when possible, instead of as helper functions
- Rewriting `related_posts` so that it's more readable. Does not change functionality 

All tests still pass 