### PR TITLE
Include the previous query in the Ask CFPB search box

### DIFF
--- a/cfgov/jinja2/v1/_includes/ask/ask-search-bar.html
+++ b/cfgov/jinja2/v1/_includes/ask/ask-search-bar.html
@@ -4,14 +4,15 @@
 {% set default_classes = 'block__bg-branded block__flush-top block__flush-bottom' %}
 {% set default_position = 'full' %}
 
-{% macro render( position=default_position, label=default_label, additional_classes=default_classes ) %}
+{% macro render( position=default_position, label=default_label, additional_classes=default_classes, q='' ) %}
 
 {% set search_opts = {
     'label': label,
     'position': position,
     'action': '/ask-cfpb/search',
     'additional_classes': additional_classes,
-    'autocomplete': 'true'
+    'autocomplete': 'true',
+    'q': q,
   } %}
 {{ search_bar.render( search_opts ) }}
 

--- a/cfgov/jinja2/v1/_includes/organisms/search-bar.html
+++ b/cfgov/jinja2/v1/_includes/organisms/search-bar.html
@@ -23,6 +23,8 @@
 
    value.autocomplete         Whether autocomplete will be activated for search.
 
+   value.q                    The previous search query string
+
    ========================================================================== #}
 
 {% macro render( value ) %}
@@ -49,7 +51,7 @@
         <div class="o-search-bar_input o-search-bar_col">
             <div class="input-with-btn input-with-btn__bar">
                 <div class="input-with-btn_input {% if value.autocomplete %} m-autocomplete{% endif %}">
-                    <input class="a-text-input" type="text" name="q" id="q">
+                    <input class="a-text-input" type="text" name="q" id="q" value="{{ value.q }}">
                 </div>
                 <div class="input-with-btn_btn">
                     <button class="a-btn" name="btnSearch" id="btnSearch" type="submit">

--- a/cfgov/jinja2/v1/ask-cfpb/answer-search-results.html
+++ b/cfgov/jinja2/v1/ask-cfpb/answer-search-results.html
@@ -29,7 +29,7 @@
                 u-mb15">
         <h1>Ask CFPB</h1>
 
-        {{ ask_search_bar.render( 'right', '', 'block__bg-branded u-mt30 u-mb30' ) }}
+        {{ ask_search_bar.render( 'right', '', 'block__bg-branded u-mt30 u-mb30', q=page.query ) }}
 
       
         {% if results %}


### PR DESCRIPTION
This PR adds `value.q` to the search bar organism so that the search bar can be pre-populated with a previous search query and uses that value in the Ask CFPB search bar for that exact purpose.

## Screenshots

![screen shot 2017-11-16 at 2 30 38 pm](https://user-images.githubusercontent.com/10562538/32911661-c9618840-cada-11e7-8a83-844fb30e1fff.png)

## Checklist

* [x] PR has an informative and human-readable title
* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [x] Passes all existing automated tests
* [ ] Any *change* in functionality is tested
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated
* [x] Reviewers requested with the [Reviewer tool](https://help.github.com/articles/about-pull-request-reviews/) :arrow_right:
