### PR TITLE
Update the browser list config and support documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,13 +23,13 @@ guidance below.
 
 ## Changing the codebase
 
-If you are a contributor from outside of CFPB, you should fork this 
-repository, make changes in your own fork, and then submit a pull request. 
+If you are a contributor from outside of CFPB, you should fork this
+repository, make changes in your own fork, and then submit a pull request.
 
-If you are a contributor within CFPB, you may also fork, or follow our 
+If you are a contributor within CFPB, you may also fork, or follow our
 [documentation for branching](https://cfpb.github.io/cfgov-refresh/branching-merging/).
 
-For timely code reviews of pull requests, please tag @cfpb/cfgov-backends and 
+For timely code reviews of pull requests, please tag @cfpb/cfgov-backends and
 @cfpb/cfgov-frontends as appropriate for your changes.
 
 All new code should have associated unit tests and/or functional tests that
@@ -40,5 +40,86 @@ Python code is expected to follow
 [PEP8](https://www.python.org/dev/peps/pep-0008/) and
 [not commit atrocities](https://www.youtube.com/watch?v=wf-BqAjZb8M).
 JavaScript, CSS/Less, and markup should follow our
-[front-end standards](https://github.com/cfpb/front-end).
+[front-end standards](https://github.com/cfpb/development).
 When in doubt, mimic the styles and patterns in the existing codebase.
+
+### Browser support
+
+We configure [Autoprefixer](#autoprefixer) and [Babel](#babel) to support the following list of browsers.
+
+- Latest 2 releases of all browsers including:
+    - Chrome
+    - Firefox
+    - Safari
+    - Internet Explorer
+    - Edge
+    - Opera
+    - iOS Safari
+    - Opera Mini
+    - Android Browser
+    - BlackBerry Browser
+    - Opera Mobile
+    - Chrome for Android
+    - Firefox for Android
+    - Samsung Internet
+- Internet Explorer 9
+
+http://browserl.ist/?q=last+2+versions%2C+Explorer+%3E%3D+9
+
+As well as additional Autoprefixer support for:
+
+- Internet Explorer 8
+
+http://browserl.ist/?q=last+2+versions%2C+Explorer+%3E%3D+8
+
+What this means to the end-user is we've added a level of backward
+compatability for modern features as much as possible. This doesn't
+necessarily mean feature parity. Where it's impossible or impractical to
+implement a modern feature, we fallback to standard practices for that browser.
+For example, we do not deliver interactive scripting for Internet Explorer 8,
+but we do ensure that default browser features continue to work so users
+that can't or don't want to upgrade continue to have access to the site and
+our content.
+
+#### Browser Testing
+
+We have automated tests that use a headless version of Chrome to ensure
+the majority of the site is working as expected. For manual testing, we
+realistically test this project locally or in a virtual environment with the
+following list of browsers:
+
+- Chrome
+- Firefox
+- Safari
+- Internet Explorer 8, 9, 10, and 11
+- Edge
+- iOS Safari
+- Chrome for Android
+
+#### Autoprefixer
+
+Autoprefixer parses our CSS and adds vendor prefixes to rules where necessary
+using reported feature support by [Can I Use](https://caniuse.com/). For more
+information visit the [Autoprefixer documentation site]
+(https://autoprefixer.github.io/).
+
+#### Babel
+
+Babel compiles our [ES6](http://es6-features.org/) JavaScript where necessary
+for the browsers that either don't support or have limited support of ES6
+features. For more information visit the [Babel documentation site]
+(https://babeljs.io/).
+
+#### Known feature differences
+
+- JavaScript: We do not serve interactive scripting to IE 8 but we do deliver
+  analytics via JavaScript.
+- Icons: We currently use icon fonts to deliver scalable icons. Browsers that
+  do not support icon fonts unfortunately do not receive backups but we try to
+  always pair icons with text.
+
+#### Resources
+
+- https://developer.microsoft.com/en-us/microsoft-edge/tools/vms/
+- https://saucelabs.com/beta/dashboard/tests
+- http://developer.samsung.com/remotetestlab/rtlDeviceList.action#

--- a/config/browserList-config.js
+++ b/config/browserList-config.js
@@ -1,0 +1,32 @@
+'use strict';
+
+// See CONTRIBUTING.md for a list of browsers included in 'last 2 versions'
+const last2 = [
+  'last 2 versions'
+];
+
+const onlyIE9 = [
+  'Explorer 9'
+];
+
+const onlyIE8 = [
+  'Explorer 8'
+];
+
+const last2IE9up = [
+  'last 2 versions',
+  'Explorer >= 9'
+];
+
+const last2IE8up = [
+  'last 2 versions',
+  'Explorer >= 8'
+];
+
+module.exports = {
+  last2,
+  onlyIE9,
+  onlyIE8,
+  last2IE9up,
+  last2IE8up
+};

--- a/config/environment.js
+++ b/config/environment.js
@@ -25,43 +25,6 @@ const envvars = {
   /* eslint-enable no-process-env */
 };
 
-
-/**
- * @description
- * Browser list for autoprefixer, see https://github.com/ai/browserslist.
- * Support output lists can be viewed via copy/pasting into http://browserl.ist.
- * @param {string} codeType - The code to support. Either 'js' or 'css'.
- * @returns {array} List of supported browser strings.
- */
-function getSupportedBrowserList( codeType ) {
-  let supportList;
-  if ( codeType === 'js' ) {
-    supportList = [
-      'last 2 version',
-      'Edge >= 11',
-      'ie >= 9',
-      'android 4',
-      'BlackBerry 7',
-      'BlackBerry 10'
-    ];
-  } else if ( codeType === 'css' ) {
-    supportList = [
-      'last 2 version',
-      'Edge >= 11',
-      'ie >= 8',
-      'android 4',
-      'BlackBerry 7',
-      'BlackBerry 10'
-    ];
-  } else {
-    const msg = 'Browser support not found for code type! ' +
-                'Should \'js\' or \'css\' to be passed to ' +
-                'environment.getSupportedBrowserList(…)?';
-    throw new Error( msg );
-  }
-  return supportList;
-}
-
 /**
  * Convenience settings for various project directory paths.
  */
@@ -75,7 +38,6 @@ const paths = {
 };
 
 module.exports = {
-  envvars: envvars,
-  getSupportedBrowserList: getSupportedBrowserList,
-  paths: paths
+  envvars,
+  paths
 };

--- a/config/webpack-config.js
+++ b/config/webpack-config.js
@@ -4,7 +4,7 @@
 
 'use strict';
 
-const environment = require( '../config/environment' );
+const browserList = require( '../config/browserList-config' );
 const webpack = require( 'webpack' );
 const UglifyWebpackPlugin = require( 'uglifyjs-webpack-plugin' );
 
@@ -22,7 +22,7 @@ const COMMON_MODULE_CONFIG = {
       options: {
         presets: [ [ 'env', {
           targets: {
-            browsers: environment.getSupportedBrowserList( 'js' )
+            browsers: browserList.last2IE9up
           },
           debug: true
         } ] ]

--- a/gulp/tasks/styles.js
+++ b/gulp/tasks/styles.js
@@ -1,12 +1,12 @@
 'use strict';
 
+const browserList = require( '../../config/browserList-config' );
 const browserSync = require( 'browser-sync' );
 const config = require( '../config' );
 const configPkg = config.pkg;
 const configBanner = config.banner;
 const configStyles = config.styles;
 const configLegacy = config.legacy;
-const environment = require( '../../config/environment' );
 const gulp = require( 'gulp' );
 const gulpAutoprefixer = require( 'gulp-autoprefixer' );
 const gulpChanged = require( 'gulp-changed' );
@@ -30,7 +30,7 @@ function stylesModern() {
     .pipe( gulpLess( configStyles.settings ) )
     .on( 'error', handleErrors.bind( this, { exitProcess: true } ) )
     .pipe( gulpAutoprefixer( {
-      browsers: environment.getSupportedBrowserList( 'css' )
+      browsers: browserList.last2
     } ) )
     .pipe( gulpHeader( configBanner, { pkg: configPkg } ) )
     .pipe( gulpSourcemaps.write( '.' ) )
@@ -50,7 +50,7 @@ function stylesIE9() {
     .pipe( gulpLess( configStyles.settings ) )
     .on( 'error', handleErrors )
     .pipe( gulpAutoprefixer( {
-      browsers: [ 'ie 9' ]
+      browsers: browserList.onlyIE9
     } ) )
     .pipe( gulpRename( {
       suffix:  '.ie9',
@@ -77,7 +77,7 @@ function stylesIE8() {
     .pipe( gulpLess( configStyles.settings ) )
     .on( 'error', handleErrors )
     .pipe( gulpAutoprefixer( {
-      browsers: [ 'ie 8' ]
+      browsers: browserList.onlyIE8
     } ) )
     .pipe( mqr( {
       width: '75em'
@@ -107,7 +107,7 @@ function stylesOnDemand() {
     .pipe( gulpLess( configStyles.settings ) )
     .on( 'error', handleErrors )
     .pipe( gulpAutoprefixer( {
-      browsers: environment.getSupportedBrowserList( 'css' )
+      browsers: browserList.last2IE8up
     } ) )
     .pipe( gulpHeader( configBanner, { pkg: configPkg } ) )
     .pipe( gulp.dest( configStyles.dest ) )
@@ -139,7 +139,7 @@ function stylesFeatureFlags() {
     .pipe( gulpLess( configStyles.settings ) )
     .on( 'error', handleErrors )
     .pipe( gulpAutoprefixer( {
-      browsers: environment.getSupportedBrowserList( 'css' )
+      browsers: browserList.last2IE8up
     } ) )
     .pipe( gulp.dest( configStyles.dest + '/feature-flags' ) )
     .pipe( browserSync.reload( {
@@ -162,7 +162,7 @@ function stylesKnowledgebaseSpanishProd() {
     .pipe( gulpLess( { compress: true } ) )
     .on( 'error', handleErrors )
     .pipe( gulpAutoprefixer( {
-      browsers: environment.getSupportedBrowserList( 'css' )
+      browsers: browserList.last2IE9up
     } ) )
     .pipe( gulpHeader( configBanner, { pkg: configPkg } ) )
     .pipe( gulpRename( {
@@ -189,7 +189,7 @@ function stylesKnowledgebaseSpanishIE() {
     .pipe( gulpLess( { compress: true } ) )
     .on( 'error', handleErrors )
     .pipe( gulpAutoprefixer( {
-      browsers: environment.getSupportedBrowserList( 'css' )
+      browsers: browserList.onlyIE8
     } ) )
     .pipe( gulpHeader( configBanner, { pkg: configPkg } ) )
     .pipe( gulpRename( {
@@ -215,7 +215,7 @@ function stylesNemoProd() {
     .pipe( gulpLess( { compress: true } ) )
     .on( 'error', handleErrors )
     .pipe( gulpAutoprefixer( {
-      browsers: environment.getSupportedBrowserList( 'css' )
+      browsers: browserList.last2IE9up
     } ) )
     .pipe( gulpHeader( configBanner, { pkg: configPkg } ) )
     .pipe( gulpRename( {
@@ -241,7 +241,7 @@ function stylesNemoIE() {
     .pipe( gulpLess( { compress: true } ) )
     .on( 'error', handleErrors )
     .pipe( gulpAutoprefixer( {
-      browsers: environment.getSupportedBrowserList( 'css' )
+      browsers: browserList.onlyIE8
     } ) )
     .pipe( gulpHeader( configBanner, { pkg: configPkg } ) )
     .pipe( gulpRename( {
@@ -268,7 +268,7 @@ function stylesOAH() {
     .pipe( gulpLess( configStyles.settings ) )
     .on( 'error', handleErrors )
     .pipe( gulpAutoprefixer( {
-      browsers: environment.getSupportedBrowserList( 'css' )
+      browsers: browserList.last2IE8up
     } ) )
     .pipe( gulpBless( { cacheBuster: false, suffix: '.part' } ) )
     .pipe( gulpCleanCss( {


### PR DESCRIPTION
As part of the FEWD Browser Support Working Group we have been
re-evaluating what browsers we're supporting. We had agreed to use a
browserlistrc file to track our needs, but as we looked closer we
realized our build process is broken up by browser and would necessitate
a complex browserlistrc setup.

## Changes

- Converted browser config to a new separate config file.
- Reduced configs to only those necessary (many browsers are included in
  "last2").
- Added human readable browser support notes to contributing doc.
## Testing

1. Run `gulp clean`
1. Run `gulp build`
1. Run `gulp scripts:ondemand`

Everything should build and none of the site styles or interactions should differ in any browsers.

## Todos

- Explore whether the IE nemo and ondemand tasks are still necessary and if they are, can IE 9 be bundled with IE 8.

## Checklist

* [x] PR has an informative and human-readable title
* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [x] Passes all existing automated tests
* [x] Any *change* in functionality is tested
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices
* [x] Project documentation has been updated
* [x] Reviewers requested with the [Reviewer tool](https://help.github.com/articles/about-pull-request-reviews/) :arrow_right:
