### PR TITLE
Re-add port forwarding localhost:8000

### DIFF
--- a/mac-virtualbox-init.sh
+++ b/mac-virtualbox-init.sh
@@ -13,6 +13,8 @@ else
       docker-machine create default --driver virtualbox\
         --virtualbox-cpu-count "2"\
         --virtualbox-memory "3072" 
+      vboxmanage controlvm default natpf1 "http,tcp,,8000,,8000"
+      vboxmanage controlvm default natpf1 "https,tcp,,8443,,8443"
     fi
     # harmless if the machine is already up:
     echo "Starting your machine..."


### PR DESCRIPTION
This was somehow didn't make it with #3106 : this allows the application to be reached at localhost:8000, when running in docker-compose + docker-machine.

Without this, you would need to get the IP of the docker machine (`docker-machine ip`), and access the app there


## Changes

- mac-virtualbox-init.sh now includes commands that map localhost:8000 to port 8000 on the docker machine VM.

## Testing

1.

## Screenshots


## Notes

-

## Todos

-

## Checklist

* [ ] PR has an informative and human-readable title
* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [ ] Passes all existing automated tests
* [ ] Any *change* in functionality is tested
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated
* [ ] Reviewers requested with the [Reviewer tool](https://help.github.com/articles/about-pull-request-reviews/) :arrow_right:
