### PR TITLE
Tweak Docker setup for local development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -115,3 +115,7 @@ coverage.xml
 # IDE Specifc
 ############
 *.idea
+
+# Docker local development #
+############################
+.python_env

--- a/.gitignore
+++ b/.gitignore
@@ -59,7 +59,7 @@ src/vendor
 *.swp
 
 # Python #
-#################
+##########
 *.pyc
 __pycache__/
 *.eggs/
@@ -76,13 +76,13 @@ vendor/
 .floo*
 
 # Documentation #
-##########
+#################
 docs/scripts
 docs/*/slick.html
 docs/*/pdfreactor-fonts.html
 
 # Django #
-#################
+##########
 *.egg-info
 .installed.cfg
 /static/
@@ -96,11 +96,11 @@ develop-apps/*
 static.in/*/
 
 # Ansible #
-#################
+###########
 ansible/roles/*
 
-# Unit test / coverage reports
-#################
+# Unit test / coverage reports #
+################################
 test/unit_test_coverage/
 test/perf_test_results/
 test/screenshot.png
@@ -112,8 +112,8 @@ nosetests.xml
 coverage.xml
 .snyk
 
-# IDE Specifc
-############
+# IDE Specifc #
+###############
 *.idea
 
 # Docker local development #

--- a/attach.sh
+++ b/attach.sh
@@ -1,4 +1,10 @@
 #!/bin/sh
 
-
+# If the user hasn't eval'ed the docker-machine env, do it for them
+if [ -z ${DOCKER_HOST} ] || 
+   [ -z ${DOCKER_CERT_PATH} ] || 
+   [ -z ${DOCKER_TLS_VERIFY} ] || 
+   [ -z ${DOCKER_MACHINE_NAME} ]; then 
+    eval $(docker-machine env) 
+fi
 docker attach cfgovrefresh_python_1

--- a/attach.sh
+++ b/attach.sh
@@ -1,10 +1,20 @@
 #!/bin/sh
 
-# If the user hasn't eval'ed the docker-machine env, do it for them
-if [ -z ${DOCKER_HOST} ] || 
-   [ -z ${DOCKER_CERT_PATH} ] || 
-   [ -z ${DOCKER_TLS_VERIFY} ] || 
-   [ -z ${DOCKER_MACHINE_NAME} ]; then 
-    eval $(docker-machine env) 
+docker ps > /dev/null 2>&1
+if [ $? -ne 0 ]; then
+    # If the user hasn't eval'ed the docker-machine env, do it for them
+    if [ -z ${DOCKER_HOST} ] || 
+       [ -z ${DOCKER_CERT_PATH} ] || 
+       [ -z ${DOCKER_TLS_VERIFY} ] || 
+       [ -z ${DOCKER_MACHINE_NAME} ]; then 
+        docker-machine status > /dev/null 2>&1
+        if [ $? -ne 0 ]; then
+            echo "Can't find a working Docker, try running setup.sh"
+            exit
+        else
+            eval $(docker-machine env) 
+        fi
+    fi
 fi
+
 docker attach cfgovrefresh_python_1

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -2,14 +2,17 @@
 
 ## Clone the repository
 
-Using the console, navigate to the root directory in which your projects live and clone this project's repository:
+Using the console, navigate to the root directory in which your projects 
+live and clone this project's repository:
 
 ```bash
 git clone git@github.com:cfpb/cfgov-refresh.git
 cd cfgov-refresh
 ```
 
-You may also wish to fork the repository on GitHub and clone the resultant personal fork. This is advised if you are going to be doing development on `cfgov-refresh` and contributing to the project.
+You may also wish to fork the repository on GitHub and clone the resultant 
+personal fork. This is advised if you are going to be doing development on 
+`cfgov-refresh` and contributing to the project.
 
 There are two ways to install cfgov-refresh:
 
@@ -143,7 +146,7 @@ npm install -g gulp
 ```
 
 !!! note
-    This project requires Node.js v5.5 or higher, and npm v3 or higher.
+    This project requires Node.js v8 or higher, and npm v5 or higher.
 
 
 #### Set up your environment
@@ -202,70 +205,89 @@ Get any errors? [See our troubleshooting tips.](#troubleshooting)
 
 ### Tools we use for developing with Docker
 
-- **Docker**: You may not need to interact directly with Docker: but you should know that it's a client/server application for managing "containers" (a way of running software in an isolated environment) and "images" (a snapshot of all of the files neccessary to run a container).
-- **Docker Compose**: Compose allows you to configure and run a collection of connected containers (like a web application and it's database) 
-- **Docker Machine**: Docker only runs natively on Linux and Windows. On OS X, we'll use Docker Machine to start the Docker server in a virtual linux environment (using Virtualbox)
-
-#### Frontend note
-
-We have not *yet* brought the front end build process into Docker, so you will still need to follow the "stand alone" guidence for [front-end dependencies](https://cfpb.github.io/cfgov-refresh/installation/#front-end-dependencies) and run `./frontend.sh` to build static assets.
+- **Docker**: You may not need to interact directly with Docker: but you 
+  should know that it's a client/server application for managing "containers"
+  (a way of running software in an isolated environment) and "images" (a 
+  snapshot of all of the files neccessary to run a container).
+- **Docker Compose**: Compose allows you to configure and run a collection of 
+  connected containers (like a web application and it's database) 
+- **Docker Machine**: Docker only runs natively on Linux and Windows. On OS X, 
+  we'll use Docker Machine to start the Docker server in a virtual linux 
+  environment (using Virtualbox)
 
 ### 1. Setup your Docker environment 
 
-If you have never installed Docker before, follow the instructions [here](https://docs.docker.com/engine/installation/) or from your operating system vendor. If you are on a mac and are unable to install the official "Docker for Mac" package, the quickstart instructions below might help.
+If you have never installed Docker before, follow the instructions 
+[here](https://docs.docker.com/engine/installation/) or from your operating 
+system vendor. If you are on a mac and are unable to install the official 
+"Docker for Mac" package, the quickstart instructions below might help.
 
-If you are on a machine that is already set up to run Linux docker containers, please install [Docker Compose](https://docs.docker.com/compose/install/). If `docker-compose ps` runs without error, you can can go to step 2. 
+If you are on a machine that is already set up to run Linux docker containers, 
+please install [Docker Compose](https://docs.docker.com/compose/install/). 
+If `docker-compose ps` runs without error, you can can go to step 2. 
 
 #### Mac + Homebrew + Virtualbox quickstart
 
-**Starting assumptions**: You already have homebrew and virtualbox installed. You can run `brew search docker` without error.
+**Starting assumptions**: You already have homebrew and virtualbox installed. 
+You can run `brew search docker` without error.
 
-1. Install Docker, Docker Machine, and Docker Compose: `brew install docker docker-compose docker-machine`
-2. `source mac-virtualbox-init.sh`
+Install Docker, Docker Machine, and Docker Compose: 
+`brew install docker docker-compose docker-machine`
  
 At this point, `docker-compose ps` should run without error. 
 
-### 2.  Run the site
+### 2. Setup your frontend environment
 
-The following assumes you have checked out cfgov-refresh, and have an open terminal, in the cfgov-refresh directory.
+Refer to the [front-end dependencies](#front-end-dependencies) described above 
+in the [standalone installation instructions](#stand-alone-installation).
 
-Our docker-compose.yml configuration expects there to be a .python_env file. You can create a blank one quickly with:
+### 3. Run setup
 
-`touch .python_env`
+`./setup.sh docker`
 
-However, you could save some time and effort later (if you have access to the CFPB network), by configuring a URL for database dumps. The complete .python_env file will look like this:
+This will install and build the frontend and set up the docker environment.
+
+### 4. Run the for the first time
+
+`./runserver.sh docker`
+
+This will download and/or build images, and then start the containers, as 
+described in the docker-compose.yml file. This will take a few minutes, or 
+longer if you are on a slow internet connection.
+
+When it's all done, you should be able to load http://localhost:8000 in your 
+browser, and see a database error.
+
+### 3. Setup the database
+
+Run `./shell.sh`. This opens a bash shell inside your Python container.
+
+You can either [load initial data](#load-initial-data-into-database) per the 
+instructions below, or load a database dump.
+
+You could save some time and effort later (if you have access to the CFPB 
+network), by configuring a URL for database dumps in the `.python_env` file.
 
 ```
 CFGOV_PROD_DB_LOCATION=https://(rest of the URL)
 ```
 
-You can get that URL at [GHE]/CFGOV/platform/wiki/Database-downloads#resources-available-via-s3
+You can get that URL at 
+[GHE]/CFGOV/platform/wiki/Database-downloads#resources-available-via-s3
 
-From here you should be able to simply run:
-
-`docker-compose up`
-
-This will download and/or build images, and then start the containers, as described in the docker-compose.yml file. This will take a few minutes, or longer if you are on a slow internet connection.
-
-When it's all done, you should be able to load http://localhost:8000 in your browser, and see a database error.
-
-### 3.  Get a database
-
-In a seperate terminal window or tab, run `eval $(docker-machine env)`. This will produce no output, but configures that terminal session so that docker-compose and docker will work.
-
-Run `./shell.sh`. This opens a bash shell inside your Python container.
-
-If you followed the suggestion above about setting CFGOV_PROD_DB_LOCATION in .python_env, you should be able to run:
+With `CFGOV_PROD_DB_LOCATION` in `.python_env` you should be able to run:
 
 `./refresh-data.sh`
 
-Otherwise, [the standalone instructions](https://cfpb.github.io/cfgov-refresh/installation/#load-a-database-dump) should be enough to get you started.
+Otherwise, [the instructions to load a database dump](#load-a-database-dump)
+below should be enough to get you started.
 
-Once you have a database loaded, you should have a functioning copy of site working at http://localhost:8000
+Once you have a database loaded, you should have a functioning copy of site 
+working at [http://localhost:8000](http://localhost:8000)
 
 ### 4. Next Steps
 
-See the Docker section of the [usage](usage) page.
+See the Docker section of the [usage](usage) page to continue after that.
 
 ## Optional steps
 
@@ -279,8 +301,13 @@ migrations are applied to the database, and then does the following:
 `WAGTAIL_ADMIN_PW` environment variable, if set.
 - If it doesn't already exist, creates a new Wagtail home page named `CFGOV`,
 with a slug of `cfgov`.
-- Updates the default Wagtail site to use the port defined by the `DJANGO_HTTP_PORT` environment variable, if defined; otherwise this port is set to 80.
-- If it doesn't already exist, creates a new [wagtail-sharing](https://github.com/cfpb/wagtail-sharing) `SharingSite` with a hostname and port defined by the `DJANGO_STAGING_HOSTNAME` and `DJANGO_HTTP_PORT` environment variables.
+- Updates the default Wagtail site to use the port defined by the 
+`DJANGO_HTTP_PORT` environment variable, if defined; otherwise this port is 
+set to 80.
+- If it doesn't already exist, creates a new 
+[wagtail-sharing](https://github.com/cfpb/wagtail-sharing) `SharingSite` with 
+a hostname and port defined by the `DJANGO_STAGING_HOSTNAME` and 
+`DJANGO_HTTP_PORT` environment variables.
 
 ### Load a database dump
 
@@ -290,7 +317,8 @@ as extensive as you'd probably like it to be.
 You can get a database dump by:
 
 1. Going to [GHE]/CFGOV/platform/wiki/Database-downloads
-1. Selecting one of the extractions and downloading the `production_django.sql.gz` file
+1. Selecting one of the extractions and downloading the 
+   `production_django.sql.gz` file
 1. Unzip it
 1. Run:
 
@@ -298,7 +326,9 @@ You can get a database dump by:
 ./refresh-data.sh /path/to/dump.sql
 ```
 
-The `refresh-data.sh` script will apply the same changes as the `initial-data.sh` script described above (including setting up the `admin` superuser), but will not apply migrations.
+The `refresh-data.sh` script will apply the same changes as the 
+`initial-data.sh` script described above (including setting up the `admin` 
+superuser), but will not apply migrations.
 
 To apply any unapplied migrations to a database created from a dump, run:
 
@@ -358,6 +388,9 @@ Here's a rundown of each of the scripts called by `setup.sh` and what they do.
    `gulp build`.
 
 ### 2. `backend.sh`
+
+!!! note
+    `backend.sh` is not used for our Docker setup.
 
 1. **Confirm environment** (`init`)
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -265,7 +265,7 @@ Once you have a database loaded, you should have a functioning copy of site work
 
 ### 4. Next Steps
 
-See the Docker section of the [usage](../usage/) page.
+See the Docker section of the [usage](usage) page.
 
 ## Optional steps
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -160,10 +160,14 @@ gulp watch           # Watch for source code changes and auto-update a browser i
 
 ## Usage: Docker
 
-Much of the guidance above for the "stand-alone" set-up still stands, and it is worth reviewing in full. Here are some things that might be different:
+Much of the guidance above for the "stand-alone" set-up still stands, and it 
+is worth reviewing in full. Here are some things that might be different:
 
-- `docker-compose` takes care of running Elasticsearch for you, and all Elastisearch, MySQL, and Python output will be shown in a single Terminal window or tab. (whereever you run `docker-compose up`)
-- `manage.py`commands can only be run after you've opened up a terminal in the Python container, which you can do with `./shell.sh`
+- `docker-compose` takes care of running Elasticsearch for you, and all 
+Elastisearch, MySQL, and Python output will be shown in a single Terminal 
+window or tab. (whereever you run `docker-compose up`)
+- `manage.py`commands can only be run after you've opened up a terminal in the 
+Python container, which you can do with `./shell.sh`
 - There is not *yet* a good way to use SSL/HTTPS, but that is in the works
 - You won't ever use these scripts: `setup.sh`, `backend.sh`, `runserver.sh`
 
@@ -171,32 +175,50 @@ Much of the guidance above for the "stand-alone" set-up still stands, and it is 
 
 #### Use Docker Machine
 
-If you used 'mac-virtualbox-init.sh', then we used Docker Machine to create a virtualbox VM, running the docker server. Here are some useful docker machine commands:
+If you used `mac-virtualbox-init.sh` or `setup.sh docker`, then we used Docker 
+Machine to create a virtualbox VM, running the docker server. Here are some 
+useful docker machine commands:
 
 - Start and stop the VM with  `docker-machine start` and `docker-machine stop`
 - get the current machine IP with `docker-machine ip`
-- if for some reason you want to start over, `docker-machine rm default`, and `source mac-virtualbox-init.sh`
+- if for some reason you want to start over, `docker-machine rm default`, and 
+  `source mac-virtualbox-init.sh`
 
 You'll need to run this command in any new terminal window or tab:
 
 `eval $(docker-machine env)`
 
-It may be helpful to run `docker-machine env` by itself, so you understand what's happening. Those variables are what allows docker-compose and the docker command line tool, running natively on your mac, to connect to the Docker server running inside virtualbox.
+It may be helpful to run `docker-machine env` by itself, so you understand 
+what's happening. Those variables are what allows docker-compose and the docker 
+command line tool, running natively on your mac, to connect to the Docker 
+server running inside virtualbox.
 
-If you use autoenv (described in the stand-alone intructions) or something similar, you might consider adding `eval $(docker-machine env)` to your .env file. You could also achieve the same results (and start the VM if it's not running yet) with `source mac-virtualbox-init.sh`
+If you use autoenv (described in the stand-alone intructions) or something 
+similar, you might consider adding `eval $(docker-machine env)` to your .env 
+file. You could also achieve the same results (and start the VM if it's not 
+running yet) with `source mac-virtualbox-init.sh`
 
-Any further Docker documentation will assume you are either in a shell where you have already run `eval $(docker-machine env)`, or you are in an environment where that's not neccessary.
-
+Any further Docker documentation will assume you are either in a shell where 
+you have already run `eval $(docker-machine env)`, or you are in an environment 
+where that's not neccessary.
 
 #### Run manage.py commands like migrate, shell, and dbshell, and shell scripts like refresh-data.sh
 
-run `./shell.sh` to open up a shell *inside* the Python container. From there, commands like `cfgov/manage.py migrate` should run as expected.
+run `./shell.sh` to open up a shell *inside* the Python container. From there, 
+commands like `cfgov/manage.py migrate` should run as expected.
 
-The same goes for scripts like `./refresh-data.sh` and `./initial-data.sh` -- they will work as expected once you're inside the container.
+The same goes for scripts like `./refresh-data.sh` and `./initial-data.sh` -- 
+they will work as expected once you're inside the container.
+
+In addition you can run single commands by passing them as arguments to 
+`shell.sh`, for example:
+
+`./shell.sh cfgov/manage.py migrate`
 
 #### Use PDB
 
-Run `./attach.sh` to connect to the TTY session where `manage.py runserver` is running. If the app is paused at a PDB prompt, this is where you can access it.
+Run `./attach.sh` to connect to the TTY session where `manage.py runserver` is 
+running. If the app is paused at a PDB prompt, this is where you can access it.
 
 #### Handle updates to Python requirements
 
@@ -204,40 +226,68 @@ If Compose is running, stop it with CTRL-C. Run:
 
 `docker-compose build python`
 
-This will update your Python image. The next time you run `docker-compose up`, the new requirements will be in place.
+This will update your Python image. The next time you run `docker-compose up`, 
+the new requirements will be in place.
 
 #### Set environment variables
 
-Your shell environment variables (and the variables in your .env file, if you are using one) are not visible to applications running in Docker. If you need to set variables that will be visible to Django, and in `./shell.sh`, you'll need to set them in the .python_env file, and restart the python container (it might be simpler to simple stop compose with ctrl-c, and start it again with `docker-compose up`)
+Your shell environment variables (and the variables in your .env file, if you 
+are using one) are not visible to applications running in Docker. If you need 
+to set variables that will be visible to Django, and in `./shell.sh`, you'll 
+need to set them in the .python_env file, and restart the python container (it 
+might be simpler to simple stop compose with ctrl-c, and start it again with 
+`docker-compose up`)
 
-.python_env is *not* a shell script, like your .env file, ~/.bash_profile, etc. See the [Docker Compose docs](https://docs.docker.com/compose/compose-file/#env_file)
+.python_env is *not* a shell script, like your .env file, ~/.bash_profile, etc.
+See the [Docker Compose docs](https://docs.docker.com/compose/compose-file/#env_file)
 
 #### Get familiar with Docker Compose, and our configuration
 
-docker-compose.yml contains a sort of "recipe" for running the site. Each entry in the Compose file describes a component of our application stack (MySQL, Elasticsearch, and Python), and either points to a public image on Dockerhub, or to a Dockerfile in cfgov-refresh. You can learn a lot more about Compose files in [the docs](https://docs.docker.com/compose/compose-file/)
+docker-compose.yml contains a sort of "recipe" for running the site. Each entry 
+in the Compose file describes a component of our application stack (MySQL, 
+Elasticsearch, and Python), and either points to a public image on Dockerhub, 
+or to a Dockerfile in cfgov-refresh. You can learn a lot more about Compose 
+files in [the docs](https://docs.docker.com/compose/compose-file/)
 
-Similarly, a Dockerfile contains instructions for transforming some base image, to one that suits our needs. The Dockerfile sitting in the top level of cfgov-refresh is probably the most interesting. It starts with [the public CentOS:7 image](https://hub.docker.com/_/centos/), and installs everything else neccessary to run our Python dependencies and the Django app itself.  This file will only be executed:
+Similarly, a Dockerfile contains instructions for transforming some base image, 
+to one that suits our needs. The Dockerfile sitting in the top level of 
+cfgov-refresh is probably the most interesting. It starts with 
+[the public CentOS:7 image](https://hub.docker.com/_/centos/), and installs 
+everything else neccessary to run our Python dependencies and the Django app 
+itself.  This file will only be executed:
 
-- the first time you run `docker-compose up` (or the first time after you re-create the Docker Machine VM)
+- the first time you run `docker-compose up` (or the first time after you 
+re-create the Docker Machine VM)
 - any time you run `docker-compose build`
 
-That's why you need to run `docker-compose build` after any changes to /requirements/
+That's why you need to run `docker-compose build` after any changes to 
+/requirements/
 
-There are other compose subcommands you might be interested in. Consider [learning about](https://docs.docker.com/compose/reference/overview/) `build`, `restarts`, `logs`, `ps`, `top`, and the `-d` option for `up`.
+There are other compose subcommands you might be interested in. Consider 
+[learning about](https://docs.docker.com/compose/reference/overview/) 
+`build`, `restarts`, `logs`, `ps`, `top`, and the `-d` option for `up`.
 
 #### Develop satellite apps
 
-Check out any apps you are developing into the develop-apps directory. These will automatically be added to the [PYTHONPATH](https://docs.python.org/2/using/cmdline.html#envvar-PYTHONPATH), and apps contained within will be importable from Python running in the container.
+Check out any apps you are developing into the develop-apps directory. These 
+will automatically be added to the 
+[PYTHONPATH](https://docs.python.org/2/using/cmdline.html#envvar-PYTHONPATH), 
+and apps contained within will be importable from Python running in the 
+container.
 
-For example, if your app is called 'foobar', in a repo called foobar-project, you could clone foobar-project in to develop apps:
+For example, if your app is called 'foobar', in a repo called foobar-project, 
+you could clone foobar-project in to develop apps:
 
 `git clone https://github.com/myorg/foobar-project`
 
-... which will create a directory at develop-apps/foobar-project. Assuming 'foobar' is at the top-level of 'foobar-project', you should be able to import it from your python code:
+... which will create a directory at develop-apps/foobar-project. Assuming 
+'foobar' is at the top-level of 'foobar-project', you should be able to 
+import it from your python code:
 
 ```python
 import foobar
 ```
 #### runserver has crashed! How do I start it again
 
-In a seperate terminal window or tab, `docker-compose up python` should restart it. 
+In a seperate terminal window or tab, `docker-compose up python` should restart 
+it. 

--- a/runserver.sh
+++ b/runserver.sh
@@ -9,36 +9,35 @@
 # Set script to exit on any errors.
 set -e
 
-if [ -e /.dockerenv ]
-then
-	echo "This script is not useful in Docker--"
-	echo "See the runserver output in whatever terminal you ran docker-compose up in."
-	echo "Or, try 'docker-compose logs python'"
-	echo https://docs.docker.com/compose/reference/logs/
-	echo
-	echo "is this an 'attach.sh' session? you probably want:"
-	echo "cfgov/manage.py runserver 0.0.0.0:8000"
-	exit
+standalone() {
+    mysql(){
+    if ! mysql.server status; then
+        mysql.server start
+    fi
+    }
+
+    # Run tasks to build the project for distribution.
+    server(){
+    if [ "$1" == "ssl" ]; then
+        echo '\033[0;32mStarting SSL Django server on port' $DJANGO_HTTP_PORT '...'
+        python cfgov/manage.py runsslserver $DJANGO_HTT_PORT
+    else
+        echo '\033[0;32mStarting the Django server on port' $DJANGO_HTTP_PORT '...'
+        python cfgov/manage.py runserver $DJANGO_HTTP_PORT
+    fi
+    }
+
+    mysql
+    server "$1"
+}
+
+dockerized() {
+    docker-compose up
+}
+
+# Execute requested (or all) functions.
+if [ "$1" == "docker" ]; then
+    dockerized
+else
+    standalone
 fi
-
-mysql(){
-  if ! mysql.server status; then
-    mysql.server start
-  fi
-}
-
-# Run tasks to build the project for distribution.
-server(){
-  if [ "$1" == "ssl" ]; then
-    echo '\033[0;32mStarting SSL Django server on port' $DJANGO_HTTP_PORT '...'
-    python cfgov/manage.py runsslserver $DJANGO_HTT_PORT
-  else
-    echo '\033[0;32mStarting the Django server on port' $DJANGO_HTTP_PORT '...'
-    python cfgov/manage.py runserver $DJANGO_HTTP_PORT
-  fi
-}
-
-mysql
-server "$1"
-
-

--- a/setup.sh
+++ b/setup.sh
@@ -9,9 +9,23 @@
 # Set script to exit on any errors.
 set -e
 
-./frontend.sh $1
-./backend.sh $1
+standalone() {
+    ./frontend.sh $1
+    ./backend.sh $1
 
-if [[ ! -z "$CFGOV_SPEAK_TO_ME" ]]; then
-  say "Set up has finished."
+    if [[ ! -z "$CFGOV_SPEAK_TO_ME" ]]; then
+        say "Set up has finished."
+    fi
+}
+
+dockerized() {
+    touch .python_env
+    source mac-virtualbox-init.sh
+}
+
+# Execute requested (or all) functions.
+if [ "$1" == "docker" ]; then
+    dockerized
+else
+    standalone
 fi

--- a/setup.sh
+++ b/setup.sh
@@ -19,6 +19,8 @@ standalone() {
 }
 
 dockerized() {
+    ./frontend.sh $2
+
     touch .python_env
     source mac-virtualbox-init.sh
 }

--- a/shell.sh
+++ b/shell.sh
@@ -17,4 +17,8 @@ if [ $? -ne 0 ]; then
     fi
 fi
 
-docker-compose exec python bash
+if [ -z "$*" ]; then
+    docker-compose exec python bash
+else
+    docker-compose exec python bash -c "$*"
+fi

--- a/shell.sh
+++ b/shell.sh
@@ -1,11 +1,20 @@
 #!/bin/bash
 
-# If the user hasn't eval'ed the docker-machine env, do it for them
-if [ -z ${DOCKER_HOST} ] || 
-   [ -z ${DOCKER_CERT_PATH} ] || 
-   [ -z ${DOCKER_TLS_VERIFY} ] || 
-   [ -z ${DOCKER_MACHINE_NAME} ]; then 
-    eval $(docker-machine env) 
+docker ps > /dev/null 2>&1
+if [ $? -ne 0 ]; then
+    # If the user hasn't eval'ed the docker-machine env, do it for them
+    if [ -z ${DOCKER_HOST} ] || 
+       [ -z ${DOCKER_CERT_PATH} ] || 
+       [ -z ${DOCKER_TLS_VERIFY} ] || 
+       [ -z ${DOCKER_MACHINE_NAME} ]; then 
+        docker-machine status > /dev/null 2>&1
+        if [ $? -ne 0 ]; then
+            echo "Can't find a working Docker, try running setup.sh"
+            exit
+        else
+            eval $(docker-machine env) 
+        fi
+    fi
 fi
 
 docker-compose exec python bash

--- a/shell.sh
+++ b/shell.sh
@@ -1,2 +1,11 @@
 #!/bin/bash
+
+# If the user hasn't eval'ed the docker-machine env, do it for them
+if [ -z ${DOCKER_HOST} ] || 
+   [ -z ${DOCKER_CERT_PATH} ] || 
+   [ -z ${DOCKER_TLS_VERIFY} ] || 
+   [ -z ${DOCKER_MACHINE_NAME} ]; then 
+    eval $(docker-machine env) 
+fi
+
 docker-compose exec python bash


### PR DESCRIPTION
This PR makes a few tweaks to our (wonderful) docker local development setup.

## Additions

- Adds `eval $(docker-machine env)` to shell.sh and attach.sh in case the user forgets to run it (as I frequently find myself doing)
- Adds `.python_env` to `.gitignore`
- Adds a `docker` argument to `setup.sh` and `runserver.sh` to allow them to still be used for setup and running.
- Adds the ability to run a command directly with `shell.sh`, i.e. `./shell.sh cfgov/manage.py migrate`

## Changes

- Fixes the link to the usage document in the installation instructions
- Fixes the comment formatting in the `.gitignore` file
- Updates the documentation for the above changes.

## Checklist

* [x] PR has an informative and human-readable title
* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [ ] Passes all existing automated tests
* [ ] Any *change* in functionality is tested
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated
* [ ] Reviewers requested with the [Reviewer tool](https://help.github.com/articles/about-pull-request-reviews/) :arrow_right:
