### PR TITLE
Correct the naming conventions for the browser list config

### DIFF
--- a/config/browser-list-config.js
+++ b/config/browser-list-config.js
@@ -1,32 +1,32 @@
 'use strict';
 
 // See CONTRIBUTING.md for a list of browsers included in 'last 2 versions'
-const last2 = [
+const LAST_2 = [
   'last 2 versions'
 ];
 
-const onlyIE9 = [
+const ONLY_IE_9 = [
   'Explorer 9'
 ];
 
-const onlyIE8 = [
+const ONLY_IE_8 = [
   'Explorer 8'
 ];
 
-const last2IE9up = [
+const LAST_2_IE_9_UP = [
   'last 2 versions',
   'Explorer >= 9'
 ];
 
-const last2IE8up = [
+const LAST_2_IE_8_UP = [
   'last 2 versions',
   'Explorer >= 8'
 ];
 
 module.exports = {
-  last2,
-  onlyIE9,
-  onlyIE8,
-  last2IE9up,
-  last2IE8up
+  LAST_2,
+  ONLY_IE_9,
+  ONLY_IE_8,
+  LAST_2_IE_9_UP,
+  LAST_2_IE_8_UP
 };

--- a/config/webpack-config.js
+++ b/config/webpack-config.js
@@ -4,7 +4,7 @@
 
 'use strict';
 
-const browserList = require( '../config/browserList-config' );
+const BROWSER_LIST = require( '../config/browser-list-config' );
 const webpack = require( 'webpack' );
 const UglifyWebpackPlugin = require( 'uglifyjs-webpack-plugin' );
 
@@ -22,7 +22,7 @@ const COMMON_MODULE_CONFIG = {
       options: {
         presets: [ [ 'env', {
           targets: {
-            browsers: browserList.last2IE9up
+            browsers: BROWSER_LIST.LAST_2_IE_9_UP
           },
           debug: true
         } ] ]

--- a/gulp/tasks/styles.js
+++ b/gulp/tasks/styles.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const browserList = require( '../../config/browserList-config' );
+const BROWSER_LIST = require( '../../config/browser-list-config' );
 const browserSync = require( 'browser-sync' );
 const config = require( '../config' );
 const configPkg = config.pkg;
@@ -30,7 +30,7 @@ function stylesModern() {
     .pipe( gulpLess( configStyles.settings ) )
     .on( 'error', handleErrors.bind( this, { exitProcess: true } ) )
     .pipe( gulpAutoprefixer( {
-      browsers: browserList.last2
+      browsers: BROWSER_LIST.LAST_2
     } ) )
     .pipe( gulpHeader( configBanner, { pkg: configPkg } ) )
     .pipe( gulpSourcemaps.write( '.' ) )
@@ -50,7 +50,7 @@ function stylesIE9() {
     .pipe( gulpLess( configStyles.settings ) )
     .on( 'error', handleErrors )
     .pipe( gulpAutoprefixer( {
-      browsers: browserList.onlyIE9
+      browsers: BROWSER_LIST.ONLY_IE_9
     } ) )
     .pipe( gulpRename( {
       suffix:  '.ie9',
@@ -77,7 +77,7 @@ function stylesIE8() {
     .pipe( gulpLess( configStyles.settings ) )
     .on( 'error', handleErrors )
     .pipe( gulpAutoprefixer( {
-      browsers: browserList.onlyIE8
+      browsers: BROWSER_LIST.ONLY_IE_8
     } ) )
     .pipe( mqr( {
       width: '75em'
@@ -107,7 +107,7 @@ function stylesOnDemand() {
     .pipe( gulpLess( configStyles.settings ) )
     .on( 'error', handleErrors )
     .pipe( gulpAutoprefixer( {
-      browsers: browserList.last2IE8up
+      browsers: BROWSER_LIST.LAST_2_IE_8_UP
     } ) )
     .pipe( gulpHeader( configBanner, { pkg: configPkg } ) )
     .pipe( gulp.dest( configStyles.dest ) )
@@ -139,7 +139,7 @@ function stylesFeatureFlags() {
     .pipe( gulpLess( configStyles.settings ) )
     .on( 'error', handleErrors )
     .pipe( gulpAutoprefixer( {
-      browsers: browserList.last2IE8up
+      browsers: BROWSER_LIST.LAST_2_IE_8_UP
     } ) )
     .pipe( gulp.dest( configStyles.dest + '/feature-flags' ) )
     .pipe( browserSync.reload( {
@@ -162,7 +162,7 @@ function stylesKnowledgebaseSpanishProd() {
     .pipe( gulpLess( { compress: true } ) )
     .on( 'error', handleErrors )
     .pipe( gulpAutoprefixer( {
-      browsers: browserList.last2IE9up
+      browsers: BROWSER_LIST.LAST_2_IE_9_UP
     } ) )
     .pipe( gulpHeader( configBanner, { pkg: configPkg } ) )
     .pipe( gulpRename( {
@@ -189,7 +189,7 @@ function stylesKnowledgebaseSpanishIE() {
     .pipe( gulpLess( { compress: true } ) )
     .on( 'error', handleErrors )
     .pipe( gulpAutoprefixer( {
-      browsers: browserList.onlyIE8
+      browsers: BROWSER_LIST.ONLY_IE_8
     } ) )
     .pipe( gulpHeader( configBanner, { pkg: configPkg } ) )
     .pipe( gulpRename( {
@@ -215,7 +215,7 @@ function stylesNemoProd() {
     .pipe( gulpLess( { compress: true } ) )
     .on( 'error', handleErrors )
     .pipe( gulpAutoprefixer( {
-      browsers: browserList.last2IE9up
+      browsers: BROWSER_LIST.LAST_2_IE_9_UP
     } ) )
     .pipe( gulpHeader( configBanner, { pkg: configPkg } ) )
     .pipe( gulpRename( {
@@ -241,7 +241,7 @@ function stylesNemoIE() {
     .pipe( gulpLess( { compress: true } ) )
     .on( 'error', handleErrors )
     .pipe( gulpAutoprefixer( {
-      browsers: browserList.onlyIE8
+      browsers: BROWSER_LIST.ONLY_IE_8
     } ) )
     .pipe( gulpHeader( configBanner, { pkg: configPkg } ) )
     .pipe( gulpRename( {
@@ -268,7 +268,7 @@ function stylesOAH() {
     .pipe( gulpLess( configStyles.settings ) )
     .on( 'error', handleErrors )
     .pipe( gulpAutoprefixer( {
-      browsers: browserList.last2IE8up
+      browsers: BROWSER_LIST.LAST_2_IE_8_UP
     } ) )
     .pipe( gulpBless( { cacheBuster: false, suffix: '.part' } ) )
     .pipe( gulpCleanCss( {


### PR DESCRIPTION
Steven pointed out that the constants should be formatted in caps with
underscore separators.

## Testing

1. Run `gulp clean`
1. Run `gulp build`
1. Run `gulp scripts:ondemand`

Everything should build and none of the site styles or interactions should differ in any browsers.

## Checklist

* [x] PR has an informative and human-readable title
* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [x] Passes all existing automated tests
* [x] Any *change* in functionality is tested
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices
* [x] Project documentation has been updated
* [x] Reviewers requested with the [Reviewer tool](https://help.github.com/articles/about-pull-request-reviews/) :arrow_right:
