### PR TITLE
Parenthizes `next` generator statement

### DIFF
--- a/cfgov/cfgov/settings/production.py
+++ b/cfgov/cfgov/settings/production.py
@@ -12,7 +12,7 @@ if sys.argv and sys.argv[0] == 'mod_wsgi':
     default_loggers = ['syslog']
     # Every so often, these files temporarily do not exist on the server
     # If so, set device to None and don't add syslog in LOGGING
-    syslog_device = next(l for l in ['/dev/log', '/var/run/syslog'] if exists(l), default=None)
+    syslog_device = next((l for l in ['/dev/log', '/var/run/syslog'] if exists(l)), default=None)
 else:
     default_loggers = ['console', 'syslog']
 


### PR DESCRIPTION
If the python `next` operator has a default value, the generator statement must have parens around it.

## Checklist

* [x] PR has an informative and human-readable title
* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [x] Passes all existing automated tests
* [x] Any *change* in functionality is tested
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices
* [x] Project documentation has been updated
* [x] Reviewers requested with the [Reviewer tool](https://help.github.com/articles/about-pull-request-reviews/) :arrow_right:
