### PR TITLE
remove server-side CSP reporting

### DIFF
--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -124,13 +124,9 @@ MIDDLEWARE_CLASSES = (
 
 CSP_MIDDLEWARE_CLASSES = ('csp.middleware.CSPMiddleware', )
 
-if ('CSP_ENFORCE' in os.environ or 'CSP_REPORT' in os.environ):
+if ('CSP_ENFORCE' in os.environ):
     MIDDLEWARE_CLASSES += CSP_MIDDLEWARE_CLASSES
 
-if 'CSP_REPORT' in os.environ:
-    CSP_REPORT_ONLY = True
-
-CSP_REPORT_URI = '/csp-report/'
 
 ROOT_URLCONF = 'cfgov.urls'
 

--- a/cfgov/cfgov/urls.py
+++ b/cfgov/cfgov/urls.py
@@ -481,9 +481,7 @@ if settings.ALLOW_ADMIN_URL:
 
     ]
 
-
     urlpatterns = patterns + urlpatterns
-
 
 if settings.DEBUG:
     urlpatterns += static(settings.MEDIA_URL,

--- a/cfgov/cfgov/urls.py
+++ b/cfgov/cfgov/urls.py
@@ -487,11 +487,6 @@ if settings.ALLOW_ADMIN_URL:
     if 'selfregistration' in settings.INSTALLED_APPS:
         patterns.append(url(r'^selfregs/', include('selfregistration.urls')))
 
-    if 'csp.middleware.CSPMiddleware' in settings.MIDDLEWARE_CLASSES:
-        # allow browsers to push CSP error reports back to the server
-        patterns.append(url(r'^csp-report/',
-                            'core.views.csp_violation_report'))
-
     urlpatterns = patterns + urlpatterns
 
 

--- a/cfgov/core/tests/test_views.py
+++ b/cfgov/core/tests/test_views.py
@@ -333,29 +333,3 @@ class TestExternalURLNoticeView(TestCase):
         request = self.factory.post('/')
         with self.assertRaises(Http404):
             view(request)
-
-
-class TestCSPReportView(TestCase):
-    def test_valid_report(self):
-        report = """{
-  "csp-report": {
-    "document-uri": "http://example.com/signup.html",
-    "referrer": "",
-    "blocked-uri": "http://example.com/css/style.css",
-    "violated-directive": "style-src cdn.example.com",
-    "original-policy": "default-src 'none'; style-src cdn.example.com; report-uri /_/csp-reports"
-  }
-}"""  # noqa: E501
-        response = self.client.post('/csp-report/', report,
-                                    content_type="application/json")
-        self.assertEquals(response.status_code, 200)
-
-    def test_invalid_report(self):
-        report = """{"contents": "just some JSON" }"""  # noqa: E501
-        response = self.client.post('/csp-report/', report,
-                                    content_type="application/json")
-        self.assertEquals(response.status_code, 400)
-
-    def test_invalid_method(self):
-        response = self.client.get('/csp-report/')
-        self.assertEquals(response.status_code, 405)

--- a/cfgov/core/views.py
+++ b/cfgov/core/views.py
@@ -4,8 +4,7 @@ import logging
 import requests
 from django.conf import settings
 from django.contrib import messages
-from django.http import (Http404, HttpResponse, HttpResponseBadRequest,
-                         JsonResponse)
+from django.http import (Http404, JsonResponse)
 from django.shortcuts import redirect
 from django.utils.decorators import method_decorator
 from django.views.decorators.csrf import csrf_exempt
@@ -134,24 +133,6 @@ def submit_comment(data):
                              })
 
     return response
-
-
-@csrf_exempt
-@require_http_methods(['POST'])
-def csp_violation_report(request):
-    try:
-        csp_dict = json.loads(request.body)['csp-report']
-    # bare except is non-ideal, but if parsing fails for any reason
-    # we need to abort
-    except:
-        logger.error('could not parse CSP report: ' + request.body)
-        return HttpResponseBadRequest()
-
-    message_template = ('{blocked-uri} blocked on {document-uri}, '
-                        'violated {violated-directive}')
-    message = message_template.format(**csp_dict)
-    logger.error(message)
-    return HttpResponse()
 
 
 class ExternalURLNoticeView(FormMixin, TemplateView):


### PR DESCRIPTION
This never actually worked for us in production, and nobody seems to be poorer for not having that data. Exposing a URL that would allow arbitrary outside parties to log arbitrary (if correctly formatted) data to our server, also seems like a recipe for trouble.

This doesn't change the front-end experience of CSP: violations will still be logged to the javascript console

## Removals

- views, tests, and configuration around Content Security Policy server-side logging.

## Changes

-

## Testing

1.

## Screenshots


## Notes

-

## Todos

-

## Checklist

* [ ] PR has an informative and human-readable title
* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [ ] Passes all existing automated tests
* [ ] Any *change* in functionality is tested
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated
* [ ] Reviewers requested with the [Reviewer tool](https://help.github.com/articles/about-pull-request-reviews/) :arrow_right:
