### PR TITLE
Add the Financial Coaching link to the mega menu

### DIFF
--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -622,6 +622,9 @@ FLAGS = {
 
     # The release of new Whistleblowers content/pages
     'WHISTLEBLOWER_RELEASE': {},
+
+    # The release of the new Financial Coaching pages
+    'FINANCIAL_COACHING': {},
 }
 
 

--- a/cfgov/jinja2/v1/_includes/organisms/_vars-mega-menu.html
+++ b/cfgov/jinja2/v1/_includes/organisms/_vars-mega-menu.html
@@ -172,6 +172,18 @@
     ]
 } %}
 
+{% if flag_enabled('FINANCIAL_COACHING', request) %}
+    {% set practitioner_resources_group_three = {
+        'title': 'Programs',
+        'nav_items': [
+            {'text': 'Financial Coaching', 'url': '/practitioner-resources/financial-coaching/'},
+            {'text': 'Resources for Libraries', 'url': '/practitioner-resources/library-resources/'},
+            {'text': 'Resources for Tax Preparers', 'url': '/practitioner-resources/resources-for-tax-preparers/'},
+            {'text': 'Your Money, Your Goals', 'url': '/practitioner-resources/your-money-your-goals/'},
+        ]
+    } %}
+{% endif %}
+
 {% set practitioner_resources = {
     'text': 'Practitioner Resources',
     'url': '#',


### PR DESCRIPTION
The Financial Coaching pages are approaching release and require
navigation to allow users to get to them. Hiding the menu item behind a
feature flag allows us to turn it on when the pages are published.

## Changes

- Updated the list of available feature flags for Financial Coaching
- Updated the menu variables to conditionally add the Financial Coaching menu item when the feature flag is enabled.

## Testing

1. Turn on the feature flag
2. Confirm the "Financial Coaching" item falls under Practitioner Resources -> Programs

## Screenshots

![screen shot 2017-11-27 at 2 25 55 pm](https://user-images.githubusercontent.com/1280430/33287633-e9e57fac-d37e-11e7-8804-ed249a83572c.png)

## Notes

- It's probably time to clean out some of these flags. I'm going to submit another PR doing that to keep this scope on point.

## Checklist

* [x] PR has an informative and human-readable title
* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [x] Passes all existing automated tests
* [ ] Any *change* in functionality is tested
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices
* [x] Project documentation has been updated
* [x] Reviewers requested with the [Reviewer tool](https://help.github.com/articles/about-pull-request-reviews/) :arrow_right:
