### PR TITLE
remove selfregistration app

### DIFF
--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -86,7 +86,6 @@ OPTIONAL_APPS = [
     {'import': 'paying_for_college',
      'apps': ('paying_for_college', 'haystack',)},
     {'import': 'agreements', 'apps': ('agreements', 'haystack',)},
-    {'import': 'selfregistration', 'apps': ('selfregistration',)},
     {'import': 'hud_api_replace', 'apps': ('hud_api_replace',)},
     {'import': 'retirement_api', 'apps': ('retirement_api',)},
     {'import': 'complaint', 'apps': ('complaint',
@@ -592,9 +591,6 @@ FLAGS = {
 
     # When enabled, display a "techical issues" banner on /complaintdatabase
     'CCDB_TECHNICAL_ISSUES': {},
-
-    # When enabled, use Wagtail for /company-signup/ (instead of selfregistration app)
-    'WAGTAIL_COMPANY_SIGNUP': {},
 
     # IA changes to mega menu for user testing
     # When enabled, the mega menu under "Consumer Tools" is arranged by topic

--- a/cfgov/cfgov/urls.py
+++ b/cfgov/cfgov/urls.py
@@ -10,7 +10,6 @@ from django.shortcuts import render
 from django.views.generic.base import RedirectView, TemplateView
 from wagtail.wagtailadmin import urls as wagtailadmin_urls
 from wagtailsharing import urls as wagtailsharing_urls
-from wagtailsharing.views import ServeView
 
 from flags.urls import flagged_url
 
@@ -260,8 +259,6 @@ urlpatterns = [
             'paying_for_college', 'paying_for_college.config.urls')),
     url(r'^credit-cards/agreements/',
         include_if_app_enabled('agreements', 'agreements.urls')),
-    url(r'^selfregs/',
-        include_if_app_enabled('selfregistration', 'selfregistration.urls')),
     url(r'^hud-api-replace/', include_if_app_enabled(
         'hud_api_replace',
         'hud_api_replace.urls',
@@ -484,9 +481,6 @@ if settings.ALLOW_ADMIN_URL:
 
     ]
 
-    if 'selfregistration' in settings.INSTALLED_APPS:
-        patterns.append(url(r'^selfregs/', include('selfregistration.urls')))
-
     if 'csp.middleware.CSPMiddleware' in settings.MIDDLEWARE_CLASSES:
         # allow browsers to push CSP error reports back to the server
         patterns.append(url(r'^csp-report/',
@@ -494,13 +488,6 @@ if settings.ALLOW_ADMIN_URL:
 
     urlpatterns = patterns + urlpatterns
 
-
-if 'selfregistration' in settings.INSTALLED_APPS:
-    from selfregistration.views import CompanySignup
-    pattern = flagged_url('WAGTAIL_COMPANY_SIGNUP', r'^company-signup/',
-                          CompanySignup.as_view(), state=False,
-                          fallback=lambda req: ServeView.as_view()(req, req.path)) # noqa
-    urlpatterns.append(pattern)
 
 if settings.DEBUG:
     urlpatterns += static(settings.MEDIA_URL,

--- a/requirements/optional-private.txt
+++ b/requirements/optional-private.txt
@@ -3,6 +3,5 @@
 # git config --global url.https://<private hostname>/.insteadOf https://private.repo/
 
 git+https://private.repo/CFPB/agreement_database.git@2.2.10#egg=agreement-database
-git+https://private.repo/CFPB/cfgov-selfregistration.git@1.3.1#egg=selfregistration
 git+https://private.repo/CFPB/django-college-cost-comparison.git@v1.4.0#egg=comparisontool
 git+https://private.repo/eregs/ip.git@1.1.2#egg=eregsip


### PR DESCRIPTION
The functionality of this app has been replaced by a Wagtail page and a PDF:

https://www.consumerfinance.gov/company-signup/

## Removals

- the 'selfregistration' app.
- related settings and urls.py entries.

## Checklist

* [ ] PR has an informative and human-readable title
* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [ ] Passes all existing automated tests
* [ ] Any *change* in functionality is tested
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated
* [ ] Reviewers requested with the [Reviewer tool](https://help.github.com/articles/about-pull-request-reviews/) :arrow_right:
