### PR TITLE
Remove old feature flags

### DIFF
--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -620,15 +620,6 @@ FLAGS = {
         'boolean': DEPLOY_ENVIRONMENT == 'build',
     },
 
-    # Add sortable tables to Wagtail
-    # When enabled, the sortable tables option will be added to the Wagtail Admin
-    # The template will render for the front-end, but the sortable code is missing
-    # and the table will not be sortable until cf-tables from CF 4.x is implemented
-    'SORTABLE_TABLES': {},
-
-    # The release of the consumer Financial Well Being Scale app
-    'FWB_RELEASE': {},
-
     # The release of new Whistleblowers content/pages
     'WHISTLEBLOWER_RELEASE': {},
 }

--- a/cfgov/cfgov/urls.py
+++ b/cfgov/cfgov/urls.py
@@ -425,9 +425,9 @@ urlpatterns = [
 
     url(r'^_status/', include_if_app_enabled('watchman', 'watchman.urls')),
 
-    flagged_url('FWB_RELEASE',
-                r'^(?i)consumer-tools/financial-well-being/',
-                include('wellbeing.urls')
+    url(
+        r'^(?i)consumer-tools/financial-well-being/',
+        include('wellbeing.urls')
     ),
 ]
 

--- a/cfgov/jinja2/v1/_includes/organisms/table.html
+++ b/cfgov/jinja2/v1/_includes/organisms/table.html
@@ -62,7 +62,7 @@
                     {% set width_class = ' class="' + value.column_widths[loop.index0] + '"' %}
                 {% endif %}
             <th scope="col"{{ width_class | default }}>
-                {% if flag_enabled('SORTABLE_TABLES', true) and value.is_sortable and value.sortable_types[loop.index0] != '' %}
+                {% if value.is_sortable and value.sortable_types[loop.index0] != '' %}
                     {% set data_sort = ' data-sort_type="' + value.sortable_types[loop.index0] + '"' %}
                     <button class="sortable"{{ data_sort }}>
                         {{ _render_cell(cell) | striptags }}

--- a/cfgov/wellbeing/tests/test_views.py
+++ b/cfgov/wellbeing/tests/test_views.py
@@ -1,8 +1,7 @@
 from django.core.urlresolvers import reverse
-from django.test import TestCase, override_settings
+from django.test import TestCase
 
 
-@override_settings(FLAGS={'FWB_RELEASE': {'boolean': True}})
 class TestTemplatesAsViews(TestCase):
     def test_home_template(self):
         response = self.client.get(reverse('fwb_home'))
@@ -13,7 +12,6 @@ class TestTemplatesAsViews(TestCase):
         self.assertEqual(response.status_code, 200)
 
 
-@override_settings(FLAGS={'FWB_RELEASE': {'boolean': True}})
 class TestResultsView(TestCase):
     def test_results_view_get(self):
         response = self.client.get(reverse('fwb_results'))


### PR DESCRIPTION
These two feature flags are no longer necessary and can be removed.

## Removals

- `SORTABLE_TABLES` flag and it's associated code
- `FWB_RELEASE` flag and it's associated code

## Testing

1. All tests should continue to pass


## Checklist

* [x] PR has an informative and human-readable title
* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [x] Passes all existing automated tests
* [x] Any *change* in functionality is tested
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices
* [x] Project documentation has been updated
* [x] Reviewers requested with the [Reviewer tool](https://help.github.com/articles/about-pull-request-reviews/) :arrow_right:
