### PR TITLE
Fixes for the Bureau Structure on mobile

### DIFF
--- a/cfgov/unprocessed/css/organisms/bureau-structure.less
+++ b/cfgov/unprocessed/css/organisms/bureau-structure.less
@@ -49,6 +49,11 @@
 
     .respond-to-max( @bp-xs-max, {
         overflow: hidden;
+
+        .m-list, .m-list__links {
+            margin-top: 0;
+            margin-bottom: 0;
+        }
     } );
 }
 
@@ -65,6 +70,7 @@
         .respond-to-max( @bp-xs-max, {
             margin-bottom: @margin;
             background: @white;
+
 
             &:after {
                 content: '';
@@ -177,8 +183,12 @@
 
 .o-bureau-structure_nav-item {
     margin-bottom: @margin;
-    background-color: inherit;
+    background-color: #fff;
     color: @pacific;
+    border-left: none;
+    border-right: none;
+    border-top: 1px solid @node-border-color;
+    border-bottom: 1px solid @node-border-color;
 
     .respond-to-max( @bp-xs-max, {
         display: inline-block;


### PR DESCRIPTION


## Changes

- Modified css to fix visual issues with the Bureau Structure on mobile.

## Testing

1. Visit `http://localhost:8000/about-us/the-bureau/bureau-structure/`
and verify it looks as depicted below.

## Screenshots

Before:
<img width="373" alt="screen shot 2017-11-28 at 9 04 45 am" src="https://user-images.githubusercontent.com/1696212/33323698-51231610-d41b-11e7-8840-f65dbcee706c.png">


After:
<img width="379" alt="screen shot 2017-11-28 at 9 05 02 am" src="https://user-images.githubusercontent.com/1696212/33323688-4ac55b20-d41b-11e7-8377-cf1f7fd5353f.png">

## Notes

-

## Todos

-

## Checklist

* [ ] PR has an informative and human-readable title
* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [ ] Passes all existing automated tests
* [ ] Any *change* in functionality is tested
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated
* [ ] Reviewers requested with the [Reviewer tool](https://help.github.com/articles/about-pull-request-reviews/) :arrow_right:
