### PR TITLE
Modifying menu to remove `The CFPB: Working for you` section

### DIFF
--- a/cfgov/jinja2/v1/_includes/organisms/_vars-mega-menu.html
+++ b/cfgov/jinja2/v1/_includes/organisms/_vars-mega-menu.html
@@ -27,21 +27,7 @@
 
 {% import 'molecules/featured-menu-content.html' as featured_menu_content %}
 
-
 {# Featured Menu Content #}
-
-{% set about_us_content = {
-    'link': {
-        'text': 'The CFPB: Working for you',
-        'url':  '/about-us/the-bureau/',
-    },
-    'image': {
-        'src': 'img/fmc-about-us-540x300.jpg',
-        'alt': '',
-    },
-    'body': 'This short video covers what the CFPB is ' +
-            'and how we are working for American consumers.',
-} %}
 
 {% set poly_com_content = {
     'link': {
@@ -101,7 +87,7 @@
   ( 'Practitioner Resources', featured_menu_content.render( resources_content ) ),
   ( 'Data & Research', featured_menu_content.render( data_research_content ) ),
   ( 'Policy & Compliance', featured_menu_content.render( poly_com_content ) ),
-  ( 'About Us', featured_menu_content.render( about_us_content ) ),
+  ( 'About Us', '' ),
 ] %}
 
 


### PR DESCRIPTION
## Changes

- Modifying menu to remove `The CFPB: Working for you` section

## Testing

1. Visit `http://localhost:8000/` and verify the menu renders correctly.


## Screenshots

- 
<img width="1385" alt="screen shot 2017-11-28 at 11 34 33 am" src="https://user-images.githubusercontent.com/1696212/33333913-43f05bc2-d436-11e7-9024-fa2cf24b8c27.png">


## Checklist

* [x] PR has an informative and human-readable title
* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [x] Passes all existing automated tests
* [x] Any *change* in functionality is tested
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices
* [x] Project documentation has been updated
* [x] Reviewers requested with the [Reviewer tool](https://help.github.com/articles/about-pull-request-reviews/) :arrow_right:
