### PR TITLE
Remove unused hostname from params & unused functions

### DIFF
--- a/cfgov/jinja2/v1/_includes/macros/activity-snippets.html
+++ b/cfgov/jinja2/v1/_includes/macros/activity-snippets.html
@@ -72,7 +72,7 @@
 
 {% macro _activity_snippet(activity_type, tags, quantity, include_date_flag=false) %}
     {% import 'macros/category-icon.html' as category_icon %}
-    {% set feed = get_latest_activities(activity_type, request.site.hostname) %}
+    {% set feed = get_latest_activities(activity_type) %}
     {% if feed %}
       {% set header = activity_type.title() %}
       {% set icon = category_icon.render(activity_type) %}

--- a/cfgov/v1/forms.py
+++ b/cfgov/v1/forms.py
@@ -88,7 +88,6 @@ class FilterableListForm(forms.Form):
     )
 
     def __init__(self, *args, **kwargs):
-        self.hostname = kwargs.pop('hostname')
         self.base_query = kwargs.pop('base_query')
         super(FilterableListForm, self).__init__(*args, **kwargs)
 

--- a/cfgov/v1/models/base.py
+++ b/cfgov/v1/models/base.py
@@ -234,22 +234,12 @@ class CFGOVPage(Page):
                 return [ancestor for ancestor in ancestors[i + 1:]]
         return []
 
-    def get_appropriate_descendants(self, hostname, inclusive=True):
+    def get_appropriate_descendants(self, inclusive=True):
         return CFGOVPage.objects.live().descendant_of(
             self, inclusive)
 
-    def get_appropriate_siblings(self, hostname, inclusive=True):
+    def get_appropriate_siblings(self, inclusive=True):
         return CFGOVPage.objects.live().sibling_of(self, inclusive)
-
-    def get_next_appropriate_siblings(self, hostname, inclusive=False):
-        return self.get_appropriate_siblings(
-            hostname=hostname, inclusive=inclusive).filter(
-            path__gte=self.path).order_by('path')
-
-    def get_prev_appropriate_siblings(self, hostname, inclusive=False):
-        return self.get_appropriate_siblings(
-            hostname=hostname, inclusive=inclusive).filter(
-            path__lte=self.path).order_by('-path')
 
     def get_context(self, request, *args, **kwargs):
         context = super(CFGOVPage, self).get_context(request, *args, **kwargs)

--- a/cfgov/v1/models/browse_filterable_page.py
+++ b/cfgov/v1/models/browse_filterable_page.py
@@ -84,7 +84,7 @@ class NewsroomLandingPage(BrowseFilterablePage):
         )))
 
     @classmethod
-    def base_query(cls, hostname):
+    def base_query(cls):
         """Newsroom pages should only show content from certain categories."""
         eligible_pages = AbstractFilterPage.objects.live()
 

--- a/cfgov/v1/models/sublanding_filterable_page.py
+++ b/cfgov/v1/models/sublanding_filterable_page.py
@@ -63,7 +63,7 @@ class ActivityLogPage(SublandingFilterablePage):
         )))
 
     @classmethod
-    def base_query(cls, hostname):
+    def base_query(cls):
         """
         Recent updates pages should only show content from certain categories.
         """

--- a/cfgov/v1/models/sublanding_page.py
+++ b/cfgov/v1/models/sublanding_page.py
@@ -84,10 +84,9 @@ class SublandingPage(CFGOVPage):
 
     objects = PageManager()
 
-    def get_browsefilterable_posts(self, request, limit):
-        hostname = request.site.hostname
+    def get_browsefilterable_posts(self, limit):
         filter_pages = [p.specific
-                        for p in self.get_appropriate_descendants(hostname)
+                        for p in self.get_appropriate_descendants()
                         if 'FilterablePage' in p.specific_class.__name__
                         and 'archive' not in p.title.lower()]
         posts_tuple_list = []
@@ -98,7 +97,7 @@ class SublandingPage(CFGOVPage):
 
             logger.info('Filtering by parent {}'.format(page))
             form_id = str(page.form_id())
-            form = FilterableListForm(hostname=hostname, base_query=base_query)
+            form = FilterableListForm(base_query=base_query)
             for post in form.get_page_set():
                 posts_tuple_list.append((form_id, post))
         return sorted(posts_tuple_list,

--- a/cfgov/v1/templatetags/activity_feed.py
+++ b/cfgov/v1/templatetags/activity_feed.py
@@ -2,7 +2,7 @@ from v1.models.learn_page import AbstractFilterPage
 from v1.util.categories import clean_categories
 
 
-def get_latest_activities(activity_type, hostname, quantity=5):
+def get_latest_activities(activity_type, quantity=5):
     categories = clean_categories([activity_type])
     return AbstractFilterPage.objects.live().filter(
         categories__name__in=categories

--- a/cfgov/v1/tests/models/test_browse_filterable_page.py
+++ b/cfgov/v1/tests/models/test_browse_filterable_page.py
@@ -18,11 +18,8 @@ class EventArchivePageTestCase(TestCase):
 
 
 class TestNewsroomLandingPage(TestCase):
-    def setUp(self):
-        self.hostname = Site.objects.get(is_default_site=True).hostname
-
     def test_no_pages_by_default(self):
-        query = NewsroomLandingPage.base_query(hostname=self.hostname)
+        query = NewsroomLandingPage.base_query()
         self.assertFalse(query.exists())
 
     def test_eligible_categories(self):
@@ -49,10 +46,10 @@ class TestNewsroomLandingPage(TestCase):
 
     def test_no_pages_matching_categories(self):
         self.make_page_with_category('test')
-        query = NewsroomLandingPage.base_query(hostname=self.hostname)
+        query = NewsroomLandingPage.base_query()
         self.assertFalse(query.exists())
 
     def test_page_matches_categories(self):
         self.make_page_with_category('op-ed')
-        query = NewsroomLandingPage.base_query(hostname=self.hostname)
+        query = NewsroomLandingPage.base_query()
         self.assertTrue(query.exists())

--- a/cfgov/v1/tests/models/test_sublanding_page.py
+++ b/cfgov/v1/tests/models/test_sublanding_page.py
@@ -16,7 +16,6 @@ class SublandingPageTestCase(TestCase):
     """
     def setUp(self):
         self.request = mock.MagicMock()
-        self.request.site.hostname = 'localhost:8000'
         self.limit = 10
         self.sublanding_page = SublandingPage(title='title')
 
@@ -60,7 +59,7 @@ class SublandingPageTestCase(TestCase):
         retrieval should be consistent with the order in which they were saved.
         """
 
-        descendants = self.sublanding_page.get_appropriate_descendants(self.request.site.hostname)
+        descendants = self.sublanding_page.get_appropriate_descendants()
         self.assertEqual(descendants[0].title, self.sublanding_page.title)
         self.assertEqual(descendants[1].title, self.post1.title)
         self.assertEqual(descendants[2].title, self.child1_of_post1.title)
@@ -73,7 +72,7 @@ class SublandingPageTestCase(TestCase):
         The posts should be retrieved in reverse chronological order, and if
         the limit exceeds the total number of posts, all should be retrieved.
         """
-        browsefilterable_posts = self.sublanding_page.get_browsefilterable_posts(self.request, self.limit)
+        browsefilterable_posts = self.sublanding_page.get_browsefilterable_posts(self.limit)
         self.assertEqual(len(browsefilterable_posts), 3)
         # the first number in the tuple represents the order of the
         # filter_controls form in the post's content field, so we test
@@ -89,6 +88,6 @@ class SublandingPageTestCase(TestCase):
         specified number of posts, and that the most recent post comes first.
         """
         self.limit = 1
-        browsefilterable_posts = self.sublanding_page.get_browsefilterable_posts(self.request, self.limit)
+        browsefilterable_posts = self.sublanding_page.get_browsefilterable_posts(self.limit)
         self.assertEqual(1, len(browsefilterable_posts))
         self.assertEqual(('0', self.child1_of_post2), browsefilterable_posts[0])

--- a/cfgov/v1/tests/templatetags/test_activity_feed.py
+++ b/cfgov/v1/tests/templatetags/test_activity_feed.py
@@ -13,7 +13,6 @@ class TestActivityFeed(TestCase):
 
 
     def test_get_latest_activities_returns_relevant_activities(self):
-        hostname = Site.objects.get(is_default_site=True).hostname
         page1 = BlogPage(title='test page')
         # Give it a blog subcategory
         page1.categories.add(CFGOVPageCategory(name='at-the-cfpb'))
@@ -23,13 +22,12 @@ class TestActivityFeed(TestCase):
         # Don't give it a blog subcategory
         publish_page(page2)
 
-        activities = activity_feed.get_latest_activities(activity_type='blog', hostname=hostname) 
+        activities = activity_feed.get_latest_activities(activity_type='blog')
         self.assertEquals(len(activities), 1)
         self.assertEquals(activities[0].specific, page1)
 
 
     def test_get_latest_activities_returns_activities_sorted(self):
-        hostname = Site.objects.get(is_default_site=True).hostname
         page1 = BlogPage(title='oldest page', date_published=datetime.date(2015, 9, 3))
         # Give it a newsroom subcategory
         page1.categories.add(CFGOVPageCategory(name='press-release'))
@@ -45,7 +43,7 @@ class TestActivityFeed(TestCase):
         page3.categories.add(CFGOVPageCategory(name='testimony'))
         publish_page(page3)
 
-        activities = activity_feed.get_latest_activities(activity_type='newsroom', hostname=hostname) 
+        activities = activity_feed.get_latest_activities(activity_type='newsroom')
         self.assertEquals(len(activities), 3)
         self.assertEquals(activities[0].specific, page3)
         self.assertEquals(activities[1].specific, page2)

--- a/cfgov/v1/tests/test_filterable_list_form.py
+++ b/cfgov/v1/tests/test_filterable_list_form.py
@@ -12,9 +12,8 @@ from v1.util.categories import clean_categories
 class TestFilterableListForm(TestCase):
 
     def setUpFilterableForm(self, data=None):
-        hostname = Site.objects.get(is_default_site=True).hostname
         base_query = AbstractFilterPage.objects.live()
-        form = FilterableListForm(hostname=hostname, base_query=base_query)
+        form = FilterableListForm(base_query=base_query)
         form.is_bound = True
         form.cleaned_data = data
         return form

--- a/cfgov/v1/util/filterable_list.py
+++ b/cfgov/v1/util/filterable_list.py
@@ -20,7 +20,7 @@ class FilterableListMixin(object):
         context['filter_data'] = filter_data
         return context
 
-    def base_query(self, hostname):
+    def base_query(self):
         return AbstractFilterPage.objects.live().filter(
             CFGOVPage.objects.child_of_q(self))
 
@@ -49,13 +49,11 @@ class FilterableListMixin(object):
         return filter_data
 
     def get_forms(self, request):
-        hostname = request.site.hostname
         for form_data in self.get_form_specific_filter_data(
                 request_dict=request.GET):
             yield FilterableListForm(
                 form_data,
-                hostname=hostname,
-                base_query=self.base_query(hostname)
+                base_query=self.base_query()
             )
 
     # Transform each GET parameter key from unique ID for the form in the

--- a/cfgov/v1/util/util.py
+++ b/cfgov/v1/util/util.py
@@ -75,7 +75,7 @@ def get_secondary_nav_items(request, current_page):
     else:
         pages = filter(
             lambda p: instanceOfBrowseOrFilterablePages(p.specific),
-            page.get_appropriate_siblings(request.site.hostname)
+            page.get_appropriate_siblings()
         )
 
     nav_items = []


### PR DESCRIPTION
At some point we needed `hostname` in these functions, but we no longer do, so just doing a bit of clean-up.  Also removing two functions `get_next_appropriate_siblings` and `get_prev_appropriate_siblings` that don't appear to be used anywhere. 

Tests still pass. 