### PR TITLE
Ensure docker is setup before running

### DIFF
--- a/runserver.sh
+++ b/runserver.sh
@@ -32,6 +32,7 @@ standalone() {
 }
 
 dockerized() {
+    source mac-virtualbox-init.sh
     docker-compose up
 }
 


### PR DESCRIPTION
This PR adds a sourcing of `mac-virtualbox-init.sh` to `runserver.sh` so that when we run `./runserver.sh docker`, the docker machine is up and running and the env vars are `eval`ed and everything.

## Checklist

* [x] PR has an informative and human-readable title
* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [ ] Passes all existing automated tests
* [ ] Any *change* in functionality is tested
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated
* [ ] Reviewers requested with the [Reviewer tool](https://help.github.com/articles/about-pull-request-reviews/) :arrow_right:
