### PR TITLE
Bug fix - Call get_site() on filter_page only if filter_page is not None

### DIFF
--- a/cfgov/v1/models/base.py
+++ b/cfgov/v1/models/base.py
@@ -208,10 +208,10 @@ class CFGOVPage(Page):
         # Set the tags to correct data format
         tags = {'links': []}
         id, filter_page = self.get_filter_data()
-        relative_url = filter_page.relative_url(filter_page.get_site())
         for tag in self.specific.tags.all():
             tag_link = {'text': tag.name, 'url': ''}
             if id is not None and filter_page is not None:
+                relative_url = filter_page.relative_url(filter_page.get_site())
                 param = '?filter' + str(id) + '_topics=' + tag.slug
                 tag_link['url'] = relative_url + param
             tags['links'].append(tag_link)


### PR DESCRIPTION
This fixes a bug we're seeing right now on the newsroom page - you can replicate it locally by going to this page /about-us/newsroom/?form-id=0&filter0_title=&filter0_topics=mortgage-origination&filter0_from_date=&filter0_to_date= on master, on production it will just 500.

I was planning to do a different fix, in which we get the filter page by directly getting the page we're on (and removing `get_filter_data` altogether), however it's a little more complicated than that because this code isn't only called on the newsroom and blog pages.   In the meantime I'm just reverting the change that I thought would be harmless from a recent refactor: https://github.com/cfpb/cfgov-refresh/pull/3589