### PR TITLE
Fix button label text to reflect correct file type

### DIFF
--- a/cfgov/jinja2/v1/_includes/organisms/bureau-structure.html
+++ b/cfgov/jinja2/v1/_includes/organisms/bureau-structure.html
@@ -270,7 +270,7 @@
             <a class="a-btn"
                href="{{ download_image_url }}">
                 <span class="a-btn_icon__on-left cf-icon cf-icon-save"></span>
-                Download PNG
+                Download PDF
             </a>
         </div>
         <div class="content-l_col content-l_col-1-2">


### PR DESCRIPTION
## Changes

Modified button label text to say `PDF` instead of `PNG`.
