### PR TITLE
Remove form_id from filterable params

### DIFF
--- a/cfgov/jinja2/v1/_includes/article.html
+++ b/cfgov/jinja2/v1/_includes/article.html
@@ -20,7 +20,7 @@
                        '/about-us/blog/'.  Remember to leverage vars.path
                        instead of using the literal string '/about-us/blog/'.
                        Path is used to create the filtered URL:
-                       {{ path }}?filter_tags={{ tag }}
+                       {{ path }}?tags={{ tag }}
 
    ========================================================================== #}
 

--- a/cfgov/jinja2/v1/_includes/macros/category-slug.html
+++ b/cfgov/jinja2/v1/_includes/macros/category-slug.html
@@ -18,27 +18,24 @@
                        Remember to leverage vars.path instead of
                        using the literal string '/about-us/blog/'.
                        Path is used to create the filtered URL:
-                       {{ href }}?filter_category={{ category }}
+                       {{ href }}?category={{ category }}
 
    classes (optional): Space separated list of class names.
 
    use_blog_category (optional): Whether to use the blog category filter or not.
                                  Defaults to false.
 
-   index (optional):             A unique ID for a form filter URL.
-                                 Defaults to 0.
-
    ========================================================================== #}
 
-{% macro render(category, href, classes, use_blog_category=false, index=0) %}
+{% macro render(category, href, classes, use_blog_category=false) %}
     {% import 'macros/category-icon.html' as category_icon %}
 
     {% if href %}
         {# TODO: Remove use_blog_category parameter when this element becomes atomic. #}
         {% if use_blog_category %}
-            {% set href = href + '?filter_blog_category=' + category | urlencode | replace('%20', '+') %}
+            {% set href = href + '?blog_category=' + category | urlencode | replace('%20', '+') %}
         {% else %}
-            {% set href = href + '?filter' + index | string + '_categories=' + category | urlencode | replace('%20', '+') %}
+            {% set href = href + '?categories=' + category | urlencode | replace('%20', '+') %}
         {% endif %}
     {% endif %}
 

--- a/cfgov/jinja2/v1/_includes/organisms/filterable-list-controls.html
+++ b/cfgov/jinja2/v1/_includes/organisms/filterable-list-controls.html
@@ -184,9 +184,8 @@
 {% macro render(controls) %}
     <div class="o-filterable-list-controls"
          id="o-filterable-list-controls">
-        {% set form = filter_data.forms.pop(0) %}
-        {% set posts = filter_data.page_sets.pop(0) %}
-        {% set has_active_filters = request.GET %}
+        {% set form = filter_data.form %}
+        {% set posts = filter_data.page_set %}
         {% if has_active_filters %}
             {% do controls.update({'is_expanded':true}) %}
         {% endif %}

--- a/cfgov/jinja2/v1/_includes/organisms/filterable-list-controls.html
+++ b/cfgov/jinja2/v1/_includes/organisms/filterable-list-controls.html
@@ -13,22 +13,21 @@
 
    form:     Django form that carries the fields that are to be rendered.
 
-   index:    A unique number given to render the form and its fields with.
 
    ========================================================================== #}
 {% from 'organisms/expandable.html' import expandable with context %}
 
-{% macro _filter_selectable(type, index, label_text, id, name, value, required=None, group=None) %}
+{% macro _filter_selectable(type, label_text, id, name, value, required=None, group=None) %}
     <li class="m-form-field m-form-field__checkbox">
         <input class="{{ 'a-checkbox' if type == 'checkbox' else 'a-radio' }}"
                type="{{ type }}"
                value="{{ value }}"
-               id="filter{{ index }}_{{ id }}"
-               name="filter{{ index }}_{{ name }}"
+               id="filter_{{ id }}"
+               name="{{ name }}"
                {{ 'data-required=' ~ required if required else ''  }}
                {{ 'data-group=' ~ group if group else ''  }}
-               {{ 'checked' if is_filter_selected('filter' ~ index ~ '_' ~ name, value) else '' }}>
-        <label class="a-label"  for="filter{{ index }}_{{ id }}">
+               {{ 'checked' if is_filter_selected(name, value) else '' }}>
+        <label class="a-label"  for="filter_{{ id }}">
             {{ label_text if label_text else value }}
         </label>
     </li>
@@ -41,9 +40,9 @@
     </option>
 {% endmacro %}
 
-{% macro _render_filter_fields(controls, form, index) -%}
+{% macro _render_filter_fields(controls, form) -%}
     {% if controls.title %}
-        {% set field_id = 'filter' ~ index ~ '_title' %}
+        {% set field_id = 'title' %}
         <div class="content-l_col
                     content-l_col-1">
             <div class="o-form_group">
@@ -68,7 +67,7 @@
                     </legend>
                     <ul class="m-list m-list__unstyled">
                     {% for slug, name in choices_for_page_type(controls.categories.page_type) %}
-                        {{ _filter_selectable('checkbox', index, category_label(slug), 'categories_' ~ slug, 'categories', slug) }}
+                        {{ _filter_selectable('checkbox', category_label(slug), 'categories_' ~ slug, 'categories', slug) }}
                     {% endfor %}
                     </ul>
                 </fieldset>
@@ -80,7 +79,7 @@
                     content-l_col-2-3">
             <div class="content-l">
                 {% if controls.topics %}
-                    {% set field_id = 'filter' ~ index ~ '_topics' %}
+                    {% set field_id = 'topics' %}
                     <div class="content-l_col
                                 content-l_col-1-2">
                         <div class="o-form_group">
@@ -95,7 +94,7 @@
                     </div>
                 {% endif %}
                 {% if controls.authors %}
-                    {% set field_id = 'filter' ~ index ~ '_authors' %}
+                    {% set field_id = 'authors' %}
                     <div class="content-l_col
                                 content-l_col-1-2">
                         <div class="o-form_group">
@@ -122,22 +121,22 @@
                                                 content-l_col-1-2">
                                         <div class="m-form-field">
                                             <label class="a-label a-label__heading"
-                                                   for="{{ 'filter' ~ index ~ '_from_date' }}">
+                                                   for="{{ 'from_date' }}">
                                                 From:
                                             </label>
                                             {{ form.render_with_id(form.from_date,
-                                               'filter' ~ index ~ '_from_date') }}
+                                               'from_date') }}
                                         </div>
                                     </div>
                                     <div class="content-l_col
                                                 content-l_col-1-2">
                                         <div class="m-form-field">
                                             <label class="a-label a-label__heading"
-                                                   for="{{ 'filter' ~ index ~ '_to_date' }}">
+                                                   for="{{ 'to_date' }}">
                                                 To:
                                             </label>
                                             {{ form.render_with_id(form.to_date,
-                                               'filter' ~ index ~ '_to_date') }}
+                                               'to_date') }}
                                         </div>
                                     </div>
                                 </div>
@@ -150,7 +149,7 @@
     {% endif %}
 {% endmacro %}
 
-{% macro _filters_form(controls, form, index) %}
+{% macro _filters_form(controls, form) %}
     <form
         {% if 'filterable-list' in controls.form_type %}
             method="get"
@@ -160,10 +159,9 @@
             action="pdf/">
         <input type="hidden" name="csrfmiddlewaretoken" value="{{ csrf_token }}">
         {% endif %}
-        <input type="hidden" name="form-id" id="form-id" value="{{ index }}">
 
         <div class="content-l">
-            {{ _render_filter_fields(controls, form, index) }}
+            {{ _render_filter_fields(controls, form) }}
             <div class="content-l_col
                         content-l_col-1
                         m-btn-group">
@@ -183,16 +181,16 @@
 {% from 'molecules/notification.html' import render as notification with context %}
 {% import 'organisms/post-preview.html' as post_preview with context %}
 
-{% macro render(controls, index) %}
+{% macro render(controls) %}
     <div class="o-filterable-list-controls"
-         id="o-filterable-list-controls-{{ index | string }}">
+         id="o-filterable-list-controls">
         {% set form = filter_data.forms.pop(0) %}
         {% set posts = filter_data.page_sets.pop(0) %}
-        {% set has_active_filters = page.has_active_filters(request, index) %}
+        {% set has_active_filters = request.GET %}
         {% if has_active_filters %}
             {% do controls.update({'is_expanded':true}) %}
         {% endif %}
-        {% set form_markup = _filters_form(controls, form, index) %}
+        {% set form_markup = _filters_form(controls, form) %}
         {% call() expandable(controls) %}
             {{ form_markup | safe }}
         {% endcall %}
@@ -210,7 +208,7 @@
         {% endif %}
         {% if 'filterable-list' in controls.form_type and posts is defined %}
             {% set count = posts.paginator.count %}
-            {% if has_active_filters == false %}
+            {% if not has_active_filters %}
                 {{ notification('success', false, count ~ ' filtered results') }}
             {% elif count == 0 %}
                 {{ notification('warning', true,
@@ -222,7 +220,7 @@
         {% endif %}
         {% if controls.categories.page_type == 'activity-log' %}
             {% import 'activity-log/_activity-list.html' as activity_list with context %}
-            {{ activity_list.render(posts, index) }}
+            {{ activity_list.render(posts) }}
         {% elif controls.output_5050 %}
             <div class="o-info-unit-group u-mb30" data-qa-hook="image-text-50-50">
                 <div class="content-l">
@@ -266,13 +264,13 @@
             </div>
         {% else %}
             {% for post in posts %}
-                {{ post_preview.render(post, controls, form_id=index) }}
+                {{ post_preview.render(post, controls) }}
             {% endfor %}
         {% endif %}
         <div class="block block__flush-top block__flush-bottom block__padded-top">
             {% import 'molecules/pagination.html' as pagination with context %}
-            {% set fragment_id = 'o-filterable-list-controls-' + index | string %}
-            {{ pagination.render( posts.paginator.num_pages, posts.number, fragment_id, index ) }}
+            {% set fragment_id = 'o-filterable-list-controls' %}
+            {{ pagination.render( posts.paginator.num_pages, posts.number, fragment_id) }}
         </div>
     </div>
 {% endmacro %}

--- a/cfgov/jinja2/v1/_includes/organisms/item-introduction.html
+++ b/cfgov/jinja2/v1/_includes/organisms/item-introduction.html
@@ -27,14 +27,14 @@
 
 {% macro render(value) %}
 
-{% set form_id, ancestor = page.get_filter_data() %}
+{% set ancestor = page.get_filter_data() %}
 {% set page_url = get_protected_url(ancestor) %}
 {% set published_date = value.date %}
 {% set has_authors = page.authors.exists() %}
 
 <div class="o-item-introduction">
     {% if page.categories.count() > 0 and value.show_category %}
-        {{ category_slug.render(page.categories.first().name, page_url, index=form_id) }}
+        {{ category_slug.render(page.categories.first().name, page_url) }}
     {% endif %}
     <h1>{{ value.heading | safe }}</h1>
 
@@ -49,7 +49,7 @@
             <span class="byline">
             {%- for author in page.get_authors() -%}
                 {{- 'By ' if loop.index == 1 else ' and ' }}
-                <a href="{{ page_url }}?filter{{ form_id }}_authors={{ author.slug }}">
+                <a href="{{ page_url }}?authors={{ author.slug }}">
                     {{ author.name }}
                 </a>
             {%- endfor -%}

--- a/cfgov/jinja2/v1/_includes/organisms/post-preview.html
+++ b/cfgov/jinja2/v1/_includes/organisms/post-preview.html
@@ -50,9 +50,6 @@
    controls.post_date_description: A string of the post publication description.
    controls.categories:            An array with the categories for the post.
 
-   form_id:                        A unique ID for a form filter URL.
-                                   Defaults to 0.
-
    url: A string with the path for the homepage of the pagetype
                               `/about-us/blog/`, `/about-us/newsroom/`
 
@@ -62,7 +59,7 @@
 
 {% import 'macros/time.html' as time %}
 
-{% macro render(post, controls, form_id=0, url='', post_date_description='') %}
+{% macro render(post, controls, url='', post_date_description='') %}
     {% cache post.post_preview_cache_key %}
     {% set date_desc = controls.post_date_description or post_date_description or 'Published' %}
     {% set cat_controls = controls.categories %}
@@ -83,15 +80,13 @@
             {% if show_categories %}
                 {% import 'macros/category-slug.html' as category_slug %}
                 {% if cat_controls and 'newsroom' in cat_controls.page_type and is_blog(post) %}
-                    {{ category_slug.render('blog', page_url, '',
-                                            false, form_id) }}
+                    {{ category_slug.render('blog', page_url, '', false) }}
                 {% else %}
                     {% for cat in post.categories.all() %}
                         {% if loop.index > 1 %}
                             |
                         {% endif %}
-                        {{ category_slug.render(cat.name, page_url, '',
-                                                false, form_id) }}
+                        {{ category_slug.render(cat.name, page_url, '', false) }}
                     {% endfor %}
                 {% endif %}
             {% endif %}
@@ -165,15 +160,15 @@
             <div class="o-post-preview_byline-group">
             {% for author in post.get_authors() %}
                 {% if loop.index == 1  %}
-                    By <a href="{{ page_url }}?filter{{ form_id }}_authors={{ author.slug }}">
+                    By <a href="{{ page_url }}?authors={{ author.slug }}">
                        {{ author.name }}
                        </a>
                 {% elif loop.last == true %}
-                    and <a href="{{ page_url }}?filter{{ form_id }}_authors={{ author.slug }}">
+                    and <a href="{{ page_url }}?authors={{ author.slug }}">
                         {{ author.name }}
                         </a>
                 {% else %}
-                    , <a href="{{ page_url }}?filter{{ form_id }}_authors={{ author.slug }}">
+                    , <a href="{{ page_url }}?authors={{ author.slug }}">
                       {{ author.name }}
                       </a>
                 {% endif %}
@@ -182,7 +177,7 @@
 
             {% if post.tags.exists() %}
                 {%- import 'tags.html' as tags %}
-                {{ tags.render(post.related_metadata_tags(), page_url, true, false, form_id, is_wagtail=True) }}
+                {{ tags.render(post.related_metadata_tags(), page_url, true, false, is_wagtail=True) }}
             {% endif %}
 
             {% if post.secondary_link_url and post.secondary_link_text %}

--- a/cfgov/jinja2/v1/_includes/tags.html
+++ b/cfgov/jinja2/v1/_includes/tags.html
@@ -17,7 +17,7 @@
                   tags are used on a blog article then path should be
                   '/about-us/blog/'. Remember to leverage vars.path instead of
                   using the literal string '/about-us/blog/'. Path is used to
-                  create the filtered URL: {{ path }}?filter_tags={{ tag }}.
+                  create the filtered URL: {{ path }}?tags={{ tag }}.
 
    hide_heading:  The optional boolean flag to hide the tags_heading element.
                   Adds class 'tags__hide-heading' if true value passed.
@@ -29,7 +29,7 @@
 
    ========================================================================== #}
 
-{% macro render(tags, path, hide_heading=false, display_block=false, index=0, is_sheer=False, is_wagtail=False) %}
+{% macro render(tags, path, hide_heading=false, display_block=false, is_sheer=False, is_wagtail=False) %}
 <div class="tags{{' tags__hide-heading' if hide_heading else ''}}{{' tags__block-list' if display_block else '' }}">
     <span class="{{'u-visually-hidden' if hide_heading else 'tags_heading' }}">Topics:</span>
     <ul class="tags_list">
@@ -45,7 +45,7 @@
         {% else %}
             {% for tag in tags %}
                 <li class="tags_tag">
-                    {% set url_arg = 'filter_tags=' if is_sheer else 'selected_facets=audience_exact:' if path == '/askcfpb/search/' else 'filter' ~ index|string ~ '_topics=' %}
+                    {% set url_arg = 'tags=' if is_sheer else 'selected_facets=audience_exact:' if path == '/askcfpb/search/' else 'topics=' %}
                     <a class="tags_link" href="{{ path }}?{{ url_arg }}{{ tag }}">
                         <span class="tags_bullet" aria-hidden="true">&bull;</span>
                         {{ tag }}

--- a/cfgov/jinja2/v1/activity-log/_activity-list.html
+++ b/cfgov/jinja2/v1/activity-log/_activity-list.html
@@ -1,6 +1,6 @@
 {% import 'macros/category-slug.html' as category_slug %}
 
-{% macro render(posts, form_id=0) %}
+{% macro render(posts) %}
     {% set page_url = get_protected_url(page) %}
     <table class="u-w100pct" data-qa-hook="filter-results">
         <tbody>
@@ -20,18 +20,15 @@
             <tr>
                 <td class="u-w20pct">
                     {% if is_blog(post) %}
-                        {{ category_slug.render('blog',
-                                page_url, '', false, form_id) }}
+                        {{ category_slug.render('blog', page_url, '', false) }}
                     {% elif is_report(post) %}
-                        {{ category_slug.render('report',
-                                page_url, '', false, form_id) }}
+                        {{ category_slug.render('report', page_url, '', false) }}
                     {% else %}
                         {% for cat in post.categories.all() %}
                             {% if loop.index > 1 %}
                                 |
                             {% endif %}
-                            {{ category_slug.render(cat.name,
-                                    page_url, '', false, form_id) }}
+                            {{ category_slug.render(cat.name, page_url, '', false) }}
                         {% endfor %}
                     {% endif %}
                 </td>

--- a/cfgov/jinja2/v1/activity-log/index.html
+++ b/cfgov/jinja2/v1/activity-log/index.html
@@ -15,7 +15,7 @@
             <div class="block
                         block__flush-top">
                 {% import 'organisms/filterable-list-controls.html' as flc with context %}
-                {{ flc.render(block.value, loop.index0) }}
+                {{ flc.render(block.value) }}
             </div>
         {% else %}
             {% import 'templates/render_block.html' as render_block with context %}

--- a/cfgov/jinja2/v1/browse-filterable/index.html
+++ b/cfgov/jinja2/v1/browse-filterable/index.html
@@ -26,7 +26,7 @@
         {% if 'filter_controls' in block.block_type %}
             <div class="block
                         block__flush-top">
-                {{ flc.render(block.value, loop.index0) }}
+                {{ flc.render(block.value) }}
             </div>
         {% elif block.block_type == 'feedback' %}
             {{- form_block.render(block, 'content', loop.index0) -}}

--- a/cfgov/jinja2/v1/newsroom/index.html
+++ b/cfgov/jinja2/v1/newsroom/index.html
@@ -28,7 +28,7 @@
                     block__flush-top">
 
                 {% import 'organisms/filterable-list-controls.html' as flc with context %}
-                {{ flc.render(block.value, loop.index0) }}
+                {{ flc.render(block.value) }}
             </div>
         {% else %}
             {% import 'templates/render_block.html' as render_block with context %}

--- a/cfgov/jinja2/v1/sublanding-page/index.html
+++ b/cfgov/jinja2/v1/sublanding-page/index.html
@@ -37,13 +37,13 @@
                 {% set limit = block.value.limit | int %}
                 {% set posts = page.get_browsefilterable_posts(limit) %}
                 {% for post in posts %}
-                    {{ post_preview.render(post=post[1], controls=none, form_id=post[0], url=get_protected_url(post[1].parent()), post_date_description=block.value.post_date_description) }}
+                    {{ post_preview.render(post, controls=none, url=get_protected_url(post.parent()), post_date_description=block.value.post_date_description) }}
                 {% endfor %}
              </div>
         {% elif 'filter_controls' in block.block_type %}
             <div class="block block__flush-top">
                 {% import 'organisms/filterable-list-controls.html' as flc with context %}
-                {{ flc.render(block.value, loop.index0) }}
+                {{ flc.render(block.value) }}
             </div>
         {% elif 'text_introduction' not in block.block_type %}
             {% import 'templates/render_block.html' as render_block with context %}

--- a/cfgov/v1/models/base.py
+++ b/cfgov/v1/models/base.py
@@ -140,9 +140,7 @@ class CFGOVPage(Page):
     def generate_view_more_url(self, request):
         activity_log = CFGOVPage.objects.get(slug='activity-log').specific
         tags = []
-        index = activity_log.form_id()
-        tags = urlencode([('filter%s_topics' % index, tag)
-                          for tag in self.tags.slugs()])
+        tags = urlencode([('topics', tag) for tag in self.tags.slugs()])
         return (get_protected_url({'request': request}, activity_log)
                 + '?' + tags)
 
@@ -207,12 +205,13 @@ class CFGOVPage(Page):
     def related_metadata_tags(self):
         # Set the tags to correct data format
         tags = {'links': []}
-        id, filter_page = self.get_filter_data()
+        filter_page = self.get_filter_data()
+        relative_url = filter_page.relative_url(filter_page.get_site())
         for tag in self.specific.tags.all():
             tag_link = {'text': tag.name, 'url': ''}
-            if id is not None and filter_page is not None:
+            if filter_page:
                 relative_url = filter_page.relative_url(filter_page.get_site())
-                param = '?filter' + str(id) + '_topics=' + tag.slug
+                param = '?topics=' + tag.slug
                 tag_link['url'] = relative_url + param
             tags['links'].append(tag_link)
         return tags
@@ -223,8 +222,8 @@ class CFGOVPage(Page):
                                                     'SublandingFilterablePage',
                                                     'EventArchivePage',
                                                     'NewsroomLandingPage']:
-                return ancestor.form_id(), ancestor
-        return None, None
+                return ancestor
+        return None
 
     def get_breadcrumbs(self, request):
         ancestors = self.get_ancestors()

--- a/cfgov/v1/models/sublanding_page.py
+++ b/cfgov/v1/models/sublanding_page.py
@@ -89,17 +89,16 @@ class SublandingPage(CFGOVPage):
                         for p in self.get_appropriate_descendants()
                         if 'FilterablePage' in p.specific_class.__name__
                         and 'archive' not in p.title.lower()]
-        posts_tuple_list = []
+        posts_list = []
         for page in filter_pages:
             base_query = AbstractFilterPage.objects.live().filter(
                 CFGOVPage.objects.child_of_q(page)
             )
 
             logger.info('Filtering by parent {}'.format(page))
-            form_id = str(page.form_id())
             form = FilterableListForm(base_query=base_query)
             for post in form.get_page_set():
-                posts_tuple_list.append((form_id, post))
-        return sorted(posts_tuple_list,
-                      key=lambda p: p[1].date_published,
+                posts_list.append(post)
+        return sorted(posts_list,
+                      key=lambda p: p.date_published,
                       reverse=True)[:limit]

--- a/cfgov/v1/tests/models/test_sublanding_page.py
+++ b/cfgov/v1/tests/models/test_sublanding_page.py
@@ -74,12 +74,9 @@ class SublandingPageTestCase(TestCase):
         """
         browsefilterable_posts = self.sublanding_page.get_browsefilterable_posts(self.limit)
         self.assertEqual(len(browsefilterable_posts), 3)
-        # the first number in the tuple represents the order of the
-        # filter_controls form in the post's content field, so we test
-        # situations in which that order varies
-        self.assertEqual(('1', self.child1_of_post1), browsefilterable_posts[2])
-        self.assertEqual(('1', self.child2_of_post1), browsefilterable_posts[1])
-        self.assertEqual(('0', self.child1_of_post2), browsefilterable_posts[0])
+        self.assertEqual(self.child1_of_post1, browsefilterable_posts[2])
+        self.assertEqual(self.child2_of_post1, browsefilterable_posts[1])
+        self.assertEqual(self.child1_of_post2, browsefilterable_posts[0])
 
     def test_get_browsefilterable_posts_with_limit(self):
         """
@@ -90,4 +87,4 @@ class SublandingPageTestCase(TestCase):
         self.limit = 1
         browsefilterable_posts = self.sublanding_page.get_browsefilterable_posts(self.limit)
         self.assertEqual(1, len(browsefilterable_posts))
-        self.assertEqual(('0', self.child1_of_post2), browsefilterable_posts[0])
+        self.assertEqual(self.child1_of_post2, browsefilterable_posts[0])

--- a/cfgov/v1/tests/test_filterable_list.py
+++ b/cfgov/v1/tests/test_filterable_list.py
@@ -15,106 +15,13 @@ class TestFilterableListMixin(TestCase):
     def test_per_page_limit_returns_integer(self):
         assert isinstance(self.mixin.per_page_limit(), int)
 
-
-    @mock.patch('v1.util.filterable_list.FilterableListMixin.get_form_specific_filter_data')
-    @mock.patch('v1.util.filterable_list.FilterableListMixin.get_filter_ids')
-    def test_has_active_filters_calls_get_form_specific_filter_data(self, mock_get_filter_ids, mock_getspecific):
-        self.mixin.has_active_filters(mock.Mock(), mock.Mock())
-        assert mock_getspecific.called
-
-
-    @mock.patch('v1.util.filterable_list.FilterableListMixin.get_form_specific_filter_data')
-    @mock.patch('v1.util.filterable_list.FilterableListMixin.get_filter_ids')
-    def test_has_active_filters_calls_get_filter_ids(self, mock_get_filter_ids, mock_getspecific):
-        self.mixin.has_active_filters(mock.Mock(), mock.Mock())
-        assert mock_get_filter_ids.called
-
-
-    @mock.patch('v1.util.filterable_list.FilterableListMixin.get_form_specific_filter_data')
-    @mock.patch('v1.util.filterable_list.FilterableListMixin.get_filter_ids')
-    def test_has_active_filters_returns_false_for_empty_forms_data(self, mock_get_filter_ids, mock_getspecific):
-        mock_getspecific.return_value = None
-        assert not self.mixin.has_active_filters(mock.Mock(), mock.Mock())
-
-
-    @mock.patch('v1.util.filterable_list.FilterableListMixin.get_form_specific_filter_data')
-    @mock.patch('v1.util.filterable_list.FilterableListMixin.get_filter_ids')
-    def test_has_active_filters_returns_false_for_forms_data_with_None_values(self, mock_get_filter_ids, mock_getspecific):
-        mock_getspecific.return_value = [{'key': None}]
-        assert not self.mixin.has_active_filters(mock.Mock(), mock.Mock())
-
-
-    @mock.patch('v1.util.filterable_list.FilterableListMixin.get_form_specific_filter_data')
-    @mock.patch('v1.util.filterable_list.FilterableListMixin.get_filter_ids')
-    def test_has_active_filters_returns_true_for_forms_data_with_values(self, mock_get_filter_ids, mock_getspecific):
-        mock_get_filter_ids.return_value = [0]
-        mock_getspecific.return_value = [{'key': 'value'}]
-        assert self.mixin.has_active_filters(mock.Mock(), 0)
-
-
-    @mock.patch('v1.util.filterable_list.FilterableListMixin.get_form_specific_filter_data')
-    @mock.patch('v1.util.filterable_list.FilterableListMixin.get_filter_ids')
-    def test_has_active_filters_returns_false_for_index_mte_filter_data_length(self, mock_get_filter_ids, mock_getspecific):
-        mock_getspecific.return_value = []
-        assert not self.mixin.has_active_filters(mock.Mock(), 0)
-        assert not self.mixin.has_active_filters(mock.Mock(), 1)
-
-
-    @mock.patch('v1.util.filterable_list.FilterableListMixin.get_form_specific_filter_data')
-    @mock.patch('v1.util.filterable_list.FilterableListMixin.get_filter_ids')
-    def test_has_active_filters_returns_false_for_forms_data_without_values_callable(self, mock_get_filter_ids, mock_getspecific):
-        mock_getspecific.return_value = 'no callable `values`'
-        assert not self.mixin.has_active_filters(mock.Mock(), 0)
-
-
-    # FilterableListMixin.get_filter_ids tests
-    def test_get_filter_ids_returns_list(self):
-        block = mock.Mock()
-        block.block_type = 'filter_controls'
-        self.mixin.content = [block]
-        assert isinstance(self.mixin.get_filter_ids(), list)
-
-
-    def test_get_filter_ids_returns_list_of_integers(self):
-        block = mock.Mock()
-        block.block_type = 'filter_controls'
-        self.mixin.content = [block]
-        for item in self.mixin.get_filter_ids():
-            assert isinstance(item, int)
-
-
-    def test_get_filter_ids_returns_empty_list_when_filter_controls_not_in_blocks(self):
-        block = mock.Mock()
-        block.block_type = 'nottherighttype'
-        self.mixin.content = [block]
-        lst = self.mixin.get_filter_ids()
-        assert isinstance(lst, list) and not lst
-
-
-    def test_get_filter_ids_raises_exception_if_blocks_dont_have_block_type(self):
-        block = mock.Mock()
-        block.block_type = 1 # not a string or iterable
-        self.mixin.content = [block]
-        self.assertRaises(TypeError, self.mixin.get_filter_ids)
-
-    # FilterableListMixin.get_form_specific_filter_data tests
-    @mock.patch('v1.util.filterable_list.FilterableListMixin.get_filter_ids')
-    def test_get_form_specific_filter_data_calls_get_filter_ids(self, mock_getfilterids):
-        self.mixin.get_form_specific_filter_data(
-            mock.Mock())
-        assert mock_getfilterids.called
-
-    @mock.patch('v1.util.filterable_list.FilterableListMixin.get_filter_ids')
-    def test_get_form_specific_filter_data_returns_GET_data_categorized_by_form_id(self, mock_getfilterids):
-        mock_getfilterids.return_value = [0]
-        request_string = '/?filter0_title=test'
+    def test_get_form_specific_filter_data_returns_GET_data(self):
+        request_string = '/?title=test'
         data = self.mixin.get_form_specific_filter_data(self.factory.get(request_string).GET)
         assert data[0]['title'] == 'test'
 
-    @mock.patch('v1.util.filterable_list.FilterableListMixin.get_filter_ids')
-    def test_get_form_specific_filter_data_returns_GET_data_as_list_for_multiple_values(self, mock_getfilterids):
-        mock_getfilterids.return_value = [0]
-        request_string = '/?filter0_categories=test1&filter0_categories=test2'
+    def test_get_form_specific_filter_data_returns_GET_data_as_list_for_multiple_values(self):
+        request_string = '/?categories=test1&categories=test2'
         data = self.mixin.get_form_specific_filter_data(self.factory.get(request_string).GET)
         assert data[0]['categories'] == ['test1', 'test2']
 

--- a/cfgov/v1/tests/test_filterable_list.py
+++ b/cfgov/v1/tests/test_filterable_list.py
@@ -15,58 +15,25 @@ class TestFilterableListMixin(TestCase):
     def test_per_page_limit_returns_integer(self):
         assert isinstance(self.mixin.per_page_limit(), int)
 
-    def test_get_form_specific_filter_data_returns_GET_data(self):
+    def test_get_form_data_returns_GET_data(self):
         request_string = '/?title=test'
-        data = self.mixin.get_form_specific_filter_data(self.factory.get(request_string).GET)
+        data = self.mixin.get_form_data(self.factory.get(request_string).GET)
         assert data[0]['title'] == 'test'
 
-    def test_get_form_specific_filter_data_returns_GET_data_as_list_for_multiple_values(self):
+    def test_get_form_data_returns_GET_data_as_list_for_multiple_values(self):
         request_string = '/?categories=test1&categories=test2'
-        data = self.mixin.get_form_specific_filter_data(self.factory.get(request_string).GET)
+        data = self.mixin.get_form_data(self.factory.get(request_string).GET)
         assert data[0]['categories'] == ['test1', 'test2']
 
     # FilterableListMixin.get_context tests
     def test_get_context_raises_exception_for_super_obj_has_no_get_context(self):
         self.assertRaises(AttributeError, self.mixin.get_context, request=self.factory.get('/'))
 
-    @mock.patch('__builtin__.super')
-    @mock.patch('v1.util.util.get_secondary_nav_items')
-    @mock.patch('v1.util.filterable_list.FilterableListMixin.process_forms')
-    @mock.patch('v1.util.filterable_list.FilterableListMixin.get_forms')
-    def test_get_context_calls_super(self, mock_get_forms, mock_process_forms, mock_nav, mock_super):
-        self.mixin.get_context(self.factory.get('/'))
-        assert mock_super.called
-
-    @mock.patch('__builtin__.super')
-    @mock.patch('v1.util.util.get_secondary_nav_items')
-    @mock.patch('v1.util.filterable_list.FilterableListMixin.process_forms')
-    @mock.patch('v1.util.filterable_list.FilterableListMixin.get_forms')
-    def test_get_context_adds_get_secondary_nav_items_into_context(self, mock_get_forms, mock_process_forms, mock_nav, mock_super):
-        mock_super().get_context.return_value = {}
-        assert 'get_secondary_nav_items' in self.mixin.get_context(self.factory.get('/'))
-
-    @mock.patch('__builtin__.super')
-    @mock.patch('v1.util.util.get_secondary_nav_items')
-    @mock.patch('v1.util.filterable_list.FilterableListMixin.process_forms')
-    @mock.patch('v1.util.filterable_list.FilterableListMixin.get_forms')
-    def test_get_context_adds_filter_data_into_context(self, mock_get_forms, mock_process_forms, mock_nav, mock_super):
-        mock_super().get_context.return_value = {}
-        assert 'filter_data' in self.mixin.get_context(self.factory.get('/'))
-
-    # FilterableListMixin.process_forms tests
-    @mock.patch('v1.util.filterable_list.FilterableListMixin.per_page_limit')
-    def test_process_forms_returns_dictionary_of_forms_and_page_sets(self, mock_per_page_limit):
-        data = self.mixin.process_forms(self.factory.get('/'), [])
-        assert 'forms' in data
-        assert 'page_sets' in data
-
-
     @mock.patch('v1.util.filterable_list.Paginator')
     @mock.patch('v1.util.filterable_list.FilterableListMixin.per_page_limit')
-    def test_process_forms_calls_is_valid_on_each_form(self, mock_per_page_limit, mock_paginator):
+    def test_process_form_calls_is_valid_on_each_form(self, mock_per_page_limit, mock_paginator):
         mock_request = mock.Mock()
         mock_request.GET = self.factory.get('/').GET
-        mock_forms = [mock.Mock(), mock.Mock()]
-        data = self.mixin.process_forms(mock_request, mock_forms)
-        assert mock_forms[0].is_valid.called
-        assert mock_forms[1].is_valid.called
+        mock_form = mock.Mock()
+        data = self.mixin.process_form(mock_request, mock_form)
+        assert mock_form.is_valid.called

--- a/cfgov/v1/util/filterable_list.py
+++ b/cfgov/v1/util/filterable_list.py
@@ -61,53 +61,17 @@ class FilterableListMixin(object):
     # came from.
     def get_form_specific_filter_data(self, request_dict):
         filters_data = []
-        for i in self.get_filter_ids():
-            data = {}
-            for field in FilterableListForm.declared_fields:
-                request_field_name = 'filter' + str(i) + '_' + field
-                if field in ['categories', 'topics', 'authors']:
-                    data[field] = request_dict.getlist(request_field_name, [])
-                else:
-                    data[field] = request_dict.get(request_field_name, '')
+        data = {}
+        for field in FilterableListForm.declared_fields:
+            if field in ['categories', 'topics', 'authors']:
+                data[field] = request_dict.getlist(field, [])
+            else:
+                data[field] = request_dict.get(field, '')
             filters_data.append(data)
         return filters_data
 
-    # Find every form existing on the page and assign a dictionary with its
-    # number as the key.
-    def get_filter_ids(self):
-        keys = []
-        for i, block in enumerate(self.content):
-            try:
-                if 'filter_controls' in block.block_type:
-                    keys.append(i)
-            except TypeError as e:
-                raise e
-        return keys
-
-    def has_active_filters(self, request, index):
-        active_filters = False
-        forms_data = self.get_form_specific_filter_data(
-            request_dict=request.GET)
-        filter_ids = self.get_filter_ids()
-        if forms_data and index in filter_ids:
-            try:
-                for value in forms_data[filter_ids.index(index)].values():
-                    if value:
-                        active_filters = True
-            except TypeError as e:
-                raise e
-
-        return active_filters
-
     def per_page_limit(self):
         return 10
-
-    def form_id(self):
-        form_ids = self.get_filter_ids()
-        if form_ids:
-            return form_ids[0]
-        else:
-            return 0
 
     def serve(self, request, *args, **kwargs):
         """ Modify response header to set a shorter TTL in Akamai """

--- a/cfgov/v1/util/filterable_list.py
+++ b/cfgov/v1/util/filterable_list.py
@@ -16,59 +16,53 @@ class FilterableListMixin(object):
         except AttributeError as e:
             raise e
         context['get_secondary_nav_items'] = get_secondary_nav_items
-        filter_data = self.process_forms(request, self.get_forms(request))
-        context['filter_data'] = filter_data
+        form_data, has_active_filters = self.get_form_data(request.GET)
+        form = FilterableListForm(form_data, base_query=self.base_query())
+        context['has_active_filters'] = has_active_filters
+        context['filter_data'] = self.process_form(request, form)
         return context
 
     def base_query(self):
         return AbstractFilterPage.objects.live().filter(
             CFGOVPage.objects.child_of_q(self))
 
-    def process_forms(self, request, forms):
-        filter_data = {'forms': [], 'page_sets': []}
-        for form in forms:
-            if form.is_valid():
-                paginator = Paginator(form.get_page_set(),
-                                      self.per_page_limit())
-                page = request.GET.get('page')
+    def process_form(self, request, form):
+        filter_data = {}
+        if form.is_valid():
+            paginator = Paginator(form.get_page_set(),
+                                  self.per_page_limit())
+            page = request.GET.get('page')
 
-                # Get the page number in the request and get the page from the
-                # paginator to serve.
-                try:
-                    pages = paginator.page(page)
-                except PageNotAnInteger:
-                    pages = paginator.page(1)
-                except EmptyPage:
-                    pages = paginator.page(paginator.num_pages)
+            # Get the page number in the request and get the page from the
+            # paginator to serve.
+            try:
+                pages = paginator.page(page)
+            except PageNotAnInteger:
+                pages = paginator.page(1)
+            except EmptyPage:
+                pages = paginator.page(paginator.num_pages)
 
-                filter_data['page_sets'].append(pages)
-            else:
-                paginator = Paginator([], self.per_page_limit())
-                filter_data['page_sets'].append(paginator.page(1))
-            filter_data['forms'].append(form)
+            filter_data['page_set'] = pages
+        else:
+            paginator = Paginator([], self.per_page_limit())
+            filter_data['page_set'] = paginator.page(1)
+        filter_data['form'] = form
         return filter_data
 
-    def get_forms(self, request):
-        for form_data in self.get_form_specific_filter_data(
-                request_dict=request.GET):
-            yield FilterableListForm(
-                form_data,
-                base_query=self.base_query()
-            )
-
-    # Transform each GET parameter key from unique ID for the form in the
-    # request and assign it to a dictionary under the form ID from where it
-    # came from.
-    def get_form_specific_filter_data(self, request_dict):
-        filters_data = []
-        data = {}
+    # Set up the form's data either with values from the GET request
+    # or with defaults based on whether it's a dropdown/list or a text field
+    def get_form_data(self, request_dict):
+        form_data = {}
+        has_active_filters = False
         for field in FilterableListForm.declared_fields:
             if field in ['categories', 'topics', 'authors']:
-                data[field] = request_dict.getlist(field, [])
+                value = request_dict.getlist(field, [])
             else:
-                data[field] = request_dict.get(field, '')
-            filters_data.append(data)
-        return filters_data
+                value = request_dict.get(field, '')
+            form_data[field] = value
+            if value:
+                has_active_filters = True
+        return form_data, has_active_filters
 
     def per_page_limit(self):
         return 10


### PR DESCRIPTION
See https://github.com/cfpb/cfgov-refresh/pull/3603 for context -- I had merged that PR but then noticed a bug, so had to revert it.  I'm creating a new commit/ PR here (with the fix) since git otherwise doesn't handle reverting reverts smoothly.

Though the change is limited in scope to removing form_id from filterable params, this touches a lot of files that pass it around (and not always in an obvious way, for instance the bug I hadn't noticed before was that the `render` method on `organisms/filterable-list-controls.html` was still being passed a form ID from `newsroom/index.html`, but it's referred to as `flc` in many places and the form ID might be passed around as a `loop.index` or something like that.  Basically, the code in question is brittle and I don't have a lot of confidence in our existing tests which didn't catch this.  I'm open to pushback that we shouldn't merge this until more test coverage is added, but then again our smoke tests caught it, so that might be an argument for bringing smoke tests into our pre-deploy (rather than post-deploy) checks.

A final BEWD (or FEWD) review is appreciated! 