### PR TITLE
Moves fonts.net tracking code to footer

### DIFF
--- a/cfgov/jinja2/v1/_layouts/base.html
+++ b/cfgov/jinja2/v1/_layouts/base.html
@@ -297,6 +297,10 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
 {% endblock javascript %}
 
+<!--[if gt IE 8]><!-->
+<link rel="stylesheet" href="//fast.fonts.net/t/1.css?apiType=css&projectid=44e8c964-4684-44c6-a6e3-3f3da8787b50">
+<!--<![endif]-->
+
 </body>
 
 </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1860,9 +1860,9 @@
       }
     },
     "cf-typography": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/cf-typography/-/cf-typography-4.4.0.tgz",
-      "integrity": "sha512-3X//g6MefNImIwZK/fTAg1JlER2wEmmMHkquv6llJOouOWFdX1Ff/pHtKFQtbQPDgmaPfZDUNlDXsxGaK4w5XQ==",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/cf-typography/-/cf-typography-4.6.0.tgz",
+      "integrity": "sha512-A0ZcroLK82G8lVQLm9Oq+igWD3x7hv+D58RJ/iFyh+WXlu2HSKOqTr6x6w78iQbk1vQONJ0ocO1O/s1VQsXSKQ==",
       "requires": {
         "cf-core": "4.5.2",
         "cf-icons": "4.2.2"
@@ -1877,7 +1877,7 @@
         "cf-core": "4.5.2",
         "cf-grid": "4.2.3",
         "cf-layout": "4.6.1",
-        "cf-typography": "4.4.0",
+        "cf-typography": "4.6.0",
         "core-js": "2.5.0",
         "es6-promise": "4.1.1",
         "highcharts": "5.0.11",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "cf-notifications": "1.0.3",
     "cf-pagination": "4.2.2",
     "cf-tables": "4.2.1",
-    "cf-typography": "4.4.0",
+    "cf-typography": "4.6.0",
     "cfpb-chart-builder": "3.2.0",
     "del": "3.0.0",
     "es5-shim": "4.5.9",


### PR DESCRIPTION
## Additions

- Add fonts.net tracker to footer.

## Todos

- Needed after https://github.com/cfpb/capital-framework/pull/698 is merged, CF is released and CF is updated in this PR.
