### PR TITLE
Use the open source release of 'comparisontool'

### DIFF
--- a/requirements/optional-private.txt
+++ b/requirements/optional-private.txt
@@ -2,5 +2,4 @@
 # configure git with:
 # git config --global url.https://<private hostname>/.insteadOf https://private.repo/
 
-git+https://private.repo/CFPB/django-college-cost-comparison.git@v1.4.0#egg=comparisontool
 git+https://private.repo/eregs/ip.git@1.1.2#egg=eregsip

--- a/requirements/optional-public.txt
+++ b/requirements/optional-public.txt
@@ -8,3 +8,4 @@ git+https://github.com/cfpb/ccdb5-api.git@v1.0.3#egg=ccdb5-api
 git+https://github.com/cfpb/ccdb5-ui.git@v1.0.6#egg=ccdb5_ui
 git+https://github.com/cfpb/eregs-2.0.git@0.0.5#egg=eregs
 https://github.com/cfpb/django-hud/releases/download/1.4.3/django_hud-1.4.3-py2-none-any.whl
+https://github.com/cfpb/django-college-costs-comparison/releases/download/1.5.1/comparisontool-1.5.1-py2-none-any.whl


### PR DESCRIPTION
We've released 'comparisontool' as open source. This PR removes it from 'optional-private.txt', and adds it to 'optional-public.txt'

## Additions

- add https://github.com/cfpb/django-college-costs-comparison/releases/download/1.5.1/comparisontool-1.5.1-py2-none-any.whl to optional-public.txt

## Removals

-  remove comparisontool from optional-private.txt


## Notes

-

## Todos

-

## Checklist

* [ ] PR has an informative and human-readable title
* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [ ] Passes all existing automated tests
* [ ] Any *change* in functionality is tested
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated
* [ ] Reviewers requested with the [Reviewer tool](https://help.github.com/articles/about-pull-request-reviews/) :arrow_right:
