### PR TITLE
Wrapper around the Search.gov API

### DIFF
--- a/.env_SAMPLE
+++ b/.env_SAMPLE
@@ -166,6 +166,14 @@ export TOXENV=py27
 
 export WATCHMAN_TOKENS=''
 
+
+########################################
+# Search.gov affiliate id and access key
+########################################
+
+# export SEARCH_DOT_GOV_AFFILIATE=<search.gov affiliate id>
+# export SEARCH_DOT_GOV_ACCESS_KEY=<search.gov access key>
+
 ###############################################
 # Project configuration - set up working state.
 ###############################################

--- a/.python_env_SAMPLE
+++ b/.python_env_SAMPLE
@@ -1,0 +1,10 @@
+############################################
+# Production DB location for refresh-data.sh
+############################################
+# CFGOV_PROD_DB_LOCATION=''
+
+########################################
+# Search.gov affiliate id and access key
+########################################
+# SEARCH_DOT_GOV_AFFILIATE=''
+# SEARCH_DOT_GOV_ACCESS_KEY=''

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,3 +5,7 @@ run python /src/get-pip.py
 copy requirements /src/requirements
 run pip install -r /src/requirements/local.txt
 copy extend-environment.sh /etc/profile.d/extend-environment.sh
+
+# Search.gov API affiliate/access key
+# ENV SEARCH_DOT_GOV_AFFILIATE=''
+# ENV SEARCH_DOT_GOV_ACCESS_KEY=''

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,3 @@ run python /src/get-pip.py
 copy requirements /src/requirements
 run pip install -r /src/requirements/local.txt
 copy extend-environment.sh /etc/profile.d/extend-environment.sh
-
-# Search.gov API affiliate/access key
-# ENV SEARCH_DOT_GOV_AFFILIATE=''
-# ENV SEARCH_DOT_GOV_ACCESS_KEY=''

--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -602,6 +602,9 @@ FLAGS = {
     # When enabled, display a "techical issues" banner on /complaintdatabase
     'CCDB_TECHNICAL_ISSUES': {},
 
+    # When enabled, use Wagtail for /company-signup/ (instead of selfregistration app)
+    'WAGTAIL_COMPANY_SIGNUP': {},
+
     # IA changes to mega menu for user testing
     # When enabled, the mega menu under "Consumer Tools" is arranged by topic
     'IA_USER_TESTING_MENU': {},
@@ -635,6 +638,9 @@ FLAGS = {
 
     # The release of new Whistleblowers content/pages
     'WHISTLEBLOWER_RELEASE': {},
+
+    # Search.gov API-based site-search
+    'SEARCH_DOTGOV_API': {},
 
     # The release of the new Financial Coaching pages
     'FINANCIAL_COACHING': {},

--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -81,6 +81,7 @@ INSTALLED_APPS = (
     'tinymce',
     'jobmanager',
     'wellbeing',
+    'search',
 )
 
 OPTIONAL_APPS = [
@@ -661,3 +662,7 @@ NTP_TIME_SERVER = 'north-america.pool.ntp.org'
 # If server's clock drifts from NTP by more than specified offset
 # (in seconds), check_clock_drift will fail
 MAX_ALLOWED_TIME_OFFSET = 5
+
+# Search.gov values
+SEARCH_DOT_GOV_AFFILIATE = os.environ.get('SEARCH_DOT_GOV_AFFILIATE')
+SEARCH_DOT_GOV_ACCESS_KEY = os.environ.get('SEARCH_DOT_GOV_ACCESS_KEY')

--- a/cfgov/cfgov/urls.py
+++ b/cfgov/cfgov/urls.py
@@ -48,9 +48,6 @@ urlpatterns = [
         DocumentServeView.as_view(),
         name='wagtaildocs_serve'),
 
-    # TODO: Enable search route when search is available.
-    # url(r'^search/$', 'search.views.search', name='search'),
-
     url(r'^home/(?P<path>.*)$',
         RedirectView.as_view(url='/%(path)s', permanent=True)),
 
@@ -428,6 +425,10 @@ urlpatterns = [
     ),
 
     url('^sitemap\.xml$', sitemap),
+
+    flagged_url('SEARCH_DOTGOV_API',
+                r'^search/',
+                include('search.urls')),
 
     flagged_url('TDP_RELEASE',
                 r'^tdp/',

--- a/cfgov/jinja2/v1/search/results.html
+++ b/cfgov/jinja2/v1/search/results.html
@@ -1,0 +1,5 @@
+{% extends 'layout-2-1-bleedbar.html' %}
+
+{% block content %}
+<h1>IMPLEMENT SEARCH RESULTS HERE</h1>
+{% endblock content %}

--- a/cfgov/jinja2/v1/search/results.html
+++ b/cfgov/jinja2/v1/search/results.html
@@ -1,5 +1,26 @@
 {% extends 'layout-2-1-bleedbar.html' %}
 
-{% block content %}
-<h1>IMPLEMENT SEARCH RESULTS HERE</h1>
-{% endblock content %}
+{% block title %}Search results for {{ q }}{% endblock %}
+
+{% block desc %}
+{% endblock %}
+
+{% block content_main %}
+<h2>Search results</h2>
+
+{% for result in results.text_best_bets %}
+
+<h4><a href="{{ result.url }}">{{ result.title }}</a></h4>
+<p>{{ result.description }}</p>
+
+{% endfor %}
+
+{% for result in results.web.results %}
+
+<h4><a href="{{ result.url }}">{{ result.title }}</a></h4>
+<p>{{ result.snippet }}</p>
+{{ result.snippet }}
+
+{% endfor %}
+
+{% endblock content_main %}

--- a/cfgov/search/dotgov.py
+++ b/cfgov/search/dotgov.py
@@ -1,0 +1,58 @@
+import logging
+
+from django.conf import settings
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+SEARCH_DOT_GOV_AFFILIATE = settings.SEARCH_DOT_GOV_AFFILIATE
+SEARCH_DOT_GOV_ACCESS_KEY = settings.SEARCH_DOT_GOV_ACCESS_KEY
+
+
+def search(query, limit=20, offset=0,
+           enable_highlighting=True, sort_by='relevance'):
+
+    if 1 > limit or limit > 50:
+        raise ValueError('limit has to be between 1-50')
+
+    if 0 > offset or offset > 999:
+        raise ValueError('limit has to be between 1-50')
+
+    if sort_by not in ('relevance', 'date'):
+        raise ValueError('sort_by must be one of relevance or date')
+
+    search_url = 'https://search.usa.gov/api/v2/search'
+    search_params = {
+        'query': query,
+        'affiliate': SEARCH_DOT_GOV_AFFILIATE,
+        'access_key': SEARCH_DOT_GOV_ACCESS_KEY,
+        'limit': limit,
+        'offset': offset,
+        'enable_highlighting': enable_highlighting,
+        'sort_by': sort_by
+    }
+
+    response = requests.get(search_url, params=search_params)
+
+    if not response.ok:
+        logging.error("Got a bad response from search.gov search API")
+        return {}
+
+    return response.json()
+
+
+def typeahead(query):
+    typeahead_url = 'https://search.usa.gov/sayt'
+    typeahead_params = {
+        'q': query,
+        'name': SEARCH_DOT_GOV_AFFILIATE,
+    }
+
+    response = requests.get(typeahead_url, params=typeahead_params)
+
+    if not response.ok:
+        logging.error("Got a bad response from search.gov typeahead API")
+        return []
+
+    return response.json()

--- a/cfgov/search/dotgov.py
+++ b/cfgov/search/dotgov.py
@@ -22,7 +22,7 @@ def search(query, limit=20, offset=0,
     if sort_by not in ('relevance', 'date'):
         raise ValueError('sort_by must be one of relevance or date')
 
-    search_url = 'https://search.usa.gov/api/v2/search'
+    search_url = 'https://search.usa.gov/api/v2/search/i14y'
     search_params = {
         'query': query,
         'affiliate': SEARCH_DOT_GOV_AFFILIATE,

--- a/cfgov/search/dotgov.py
+++ b/cfgov/search/dotgov.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import logging
 
 from django.conf import settings
@@ -17,7 +18,7 @@ def search(query, limit=20, offset=0,
         raise ValueError('limit has to be between 1-50')
 
     if 0 > offset or offset > 999:
-        raise ValueError('limit has to be between 1-50')
+        raise ValueError('offset has to be between 0-999')
 
     if sort_by not in ('relevance', 'date'):
         raise ValueError('sort_by must be one of relevance or date')

--- a/cfgov/search/tests/test_dotgov.py
+++ b/cfgov/search/tests/test_dotgov.py
@@ -13,26 +13,6 @@ class SearchDotGovTestCase(TestCase):
     @mock.patch('search.dotgov.requests.get')
     def test_search_query(self, mock_get):
         mock_get.return_value.ok = True
-        mock_get.return_value.json.return_value = {
-            'query': 'query',
-            'web': {
-                'total': 1,
-                'next_offset': None,
-                'spelling_correction': None,
-                'results': [
-
-                ],
-            },
-            'text_best_bets': [
-                {
-                    'id': 12345,
-                    'title': 'Test Text Best Bet',
-                    'url': 'http://best/bet',
-                    'description': 'This is a best bet that is text',
-                },
-            ],
-        }
-
         search('query')
         mock_get.return_value.json.assert_called()
 

--- a/cfgov/search/tests/test_dotgov.py
+++ b/cfgov/search/tests/test_dotgov.py
@@ -1,0 +1,74 @@
+from django.test import TestCase
+
+import mock
+
+from search.dotgov import (
+    search,
+    typeahead,
+)
+
+
+class SearchDotGovTestCase(TestCase):
+
+    @mock.patch('search.dotgov.requests.get')
+    def test_search_query(self, mock_get):
+        mock_get.return_value.ok = True
+        mock_get.return_value.json.return_value = {
+            'query': 'query',
+            'web': {
+                'total': 1,
+                'next_offset': None,
+                'spelling_correction': None,
+                'results': [
+
+                ],
+            },
+            'text_best_bets': [
+                {
+                    'id': 12345,
+                    'title': 'Test Text Best Bet',
+                    'url': 'http://best/bet',
+                    'description': 'This is a best bet that is text',
+                },
+            ],
+        }
+
+        search('query')
+        mock_get.return_value.json.assert_called()
+
+    @mock.patch('search.dotgov.requests.get')
+    def test_search_query_bad_upstream_response(self, mock_get):
+        mock_get.return_value.ok = False
+        result = search('')
+        self.assertEquals(result, {})
+
+    def test_search_limit_out_of_bounds(self):
+        with self.assertRaises(ValueError):
+            search('query', limit=0)
+
+        with self.assertRaises(ValueError):
+            search('query', limit=51)
+
+    def test_search_offset_out_of_bounds(self):
+        with self.assertRaises(ValueError):
+            search('query', offset=-1)
+
+        with self.assertRaises(ValueError):
+            search('query', offset=1000)
+
+    def test_search_sort_by_out_of_bounds(self):
+        with self.assertRaises(ValueError):
+            search('query', sort_by='alpha')
+
+    @mock.patch('search.dotgov.requests.get')
+    def test_typeahead(self, mock_get):
+        mock_get.return_value.ok = True
+        mock_get.return_value.json.return_value = ['auto']
+        result = typeahead('au')
+        self.assertEqual(result, ['auto'])
+
+    @mock.patch('search.dotgov.requests.get')
+    def test_typeahead_bad_upstream_response(self, mock_get):
+        mock_get.return_value.ok = False
+        result = typeahead('')
+        self.assertEqual(result, [])

--- a/cfgov/search/tests/test_views.py
+++ b/cfgov/search/tests/test_views.py
@@ -9,9 +9,10 @@ class SearchViewsTestCase(TestCase):
 
     @mock.patch('search.dotgov.search')
     def test_results_view(self, mock_search):
-        mock_search.return_value = {}
+        mock_search.return_value = {'web': {'results': []}}
         response = self.client.get(reverse('search_results'), {'q': 'auto'})
         mock_search.assert_called()
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.context_data['q'], 'auto')
-        self.assertEqual(response.context_data['results'], {})
+        self.assertEqual(response.context_data['results'],
+                         {'web': {'results': []}})

--- a/cfgov/search/tests/test_views.py
+++ b/cfgov/search/tests/test_views.py
@@ -1,0 +1,17 @@
+from django.test import TestCase, override_settings
+from django.core.urlresolvers import reverse
+
+import mock
+
+
+@override_settings(FLAGS={'SEARCH_DOTGOV_API': {'boolean': 'True'}})
+class SearchViewsTestCase(TestCase):
+
+    @mock.patch('search.dotgov.search')
+    def test_results_view(self, mock_search):
+        mock_search.return_value = {}
+        response = self.client.get(reverse('search_results'), {'q': 'auto'})
+        mock_search.assert_called()
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.context_data['q'], 'auto')
+        self.assertEqual(response.context_data['results'], {})

--- a/cfgov/search/urls.py
+++ b/cfgov/search/urls.py
@@ -1,0 +1,10 @@
+from django.conf.urls import url
+
+from search.views import results_view
+
+urlpatterns = [
+    url(r'^$',
+        results_view,
+        # TemplateView.as_view(template_name='wellbeing/about.html')
+        name='search_results'),
+]

--- a/cfgov/search/views.py
+++ b/cfgov/search/views.py
@@ -1,0 +1,17 @@
+from django.template.response import TemplateResponse
+
+from search import dotgov
+
+
+def results_view(request):
+    query = request.GET.get('q', '')
+
+    results = dotgov.search(query)
+
+    context = {
+        'q': query,
+        'results': results
+    }
+
+    response = TemplateResponse(request, 'search/results.html', context)
+    return response.render()


### PR DESCRIPTION
This PR is a start at building a wrapper around the Search.gov API to use for search. It adds to the `search` package a module that wraps the Search.gov search and typeahead APIs. It also adds two settings and env vars for the Search.gov affiliate name and our API key, as well as a stub view and template for search results and a feature flag that enables that view. Completing the view and template are not in scope for this PR, but they provide a starting point for using the API wrapper.

I've also added a `.python_env_SAMPLE` file for use with docker that corresponds to `.env_SAMPLE`. This is based on discussions with @rosskarchner.

## Additions

- Search.gov API wrappers in `search.dotgov`
- Search results view and template stubs
- Sample `.python_env` file corresponding to `.env_SAMPLE` for our docker setup

## Checklist

* [x] PR has an informative and human-readable title
* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [x] Passes all existing automated tests
* [x] Any *change* in functionality is tested
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated
* [x] Reviewers requested with the [Reviewer tool](https://help.github.com/articles/about-pull-request-reviews/) :arrow_right:
