### PR TITLE
Bump reg-core and reg-site versions

### DIFF
--- a/requirements/optional-public.txt
+++ b/requirements/optional-public.txt
@@ -1,8 +1,8 @@
 https://github.com/cfpb/college-costs/releases/download/2.3.12/college_costs-2.3.12-py2-none-any.whl
 https://github.com/cfpb/complaint/releases/download/1.4.4/complaintdatabase-1.4.4-py2-none-any.whl
 git+https://github.com/cfpb/owning-a-home-api.git@0.10.1#egg=owning-a-home-api
-git+https://github.com/cfpb/regulations-core.git@1.2.5#egg=regcore
-https://github.com/cfpb/regulations-site/releases/download/2.1.15/regulations-2.1.15-py2-none-any.whl
+https://github.com/cfpb/regulations-core/releases/download/1.2.6/regcore-1.2.6-py2-none-any.whl
+https://github.com/cfpb/regulations-site/releases/download/2.1.16/regulations-2.1.16-py2-none-any.whl
 https://github.com/cfpb/retirement/releases/download/0.5.14/retirement-0.5.14-py2-none-any.whl
 git+https://github.com/cfpb/ccdb5-api.git@v1.0.3#egg=ccdb5-api
 git+https://github.com/cfpb/ccdb5-ui.git@v1.0.6#egg=ccdb5_ui


### PR DESCRIPTION
This commit bumps the versions of these optional public repos:

- [regulations-core@1.2.6](https://github.com/cfpb/regulations-core/releases/tag/1.2.6)
- [regulations-site@2.1.16](https://github.com/cfpb/regulations-site/releases/tag/2.1.16)

This is to address some installation issues with incompatibility with Django 2.0.

## Changes

- Bump versions of regulations-core and regulations-site.

## Testing

1. `pip install -r requirements/optional-public.txt`

## Checklist

* [X] PR has an informative and human-readable title
* [X] Changes are limited to a single goal (no scope creep)
* [X] Code can be automatically merged (no conflicts)
* [X] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [X] Passes all existing automated tests
* [X] Any *change* in functionality is tested
* [X] Reviewers requested with the [Reviewer tool](https://help.github.com/articles/about-pull-request-reviews/) :arrow_right:
