### PR TITLE
bump oah api to 0.10.2 and switch to wheel deployment

### DIFF
--- a/requirements/optional-public.txt
+++ b/requirements/optional-public.txt
@@ -1,6 +1,6 @@
 https://github.com/cfpb/college-costs/releases/download/2.3.12/college_costs-2.3.12-py2-none-any.whl
 https://github.com/cfpb/complaint/releases/download/1.4.4/complaintdatabase-1.4.4-py2-none-any.whl
-git+https://github.com/cfpb/owning-a-home-api.git@0.10.1#egg=owning-a-home-api
+https://github.com/cfpb/owning-a-home-api/releases/download/0.10.2/owning_a_home_api-0.10.2-py2-none-any.whl
 https://github.com/cfpb/regulations-core/releases/download/1.2.6/regcore-1.2.6-py2-none-any.whl
 https://github.com/cfpb/regulations-site/releases/download/2.1.16/regulations-2.1.16-py2-none-any.whl
 https://github.com/cfpb/retirement/releases/download/0.5.14/retirement-0.5.14-py2-none-any.whl


### PR DESCRIPTION
Bump OAH API version, switch to wheel deployment and pick up a tweak to assist request troubleshooting.

## Additions
- Adds a `raise_for_status` check to help identify cases where an external request is rejected.
