### PR TITLE
Update CCDB5 API release number

### DIFF
--- a/requirements/optional-public.txt
+++ b/requirements/optional-public.txt
@@ -4,7 +4,7 @@ https://github.com/cfpb/owning-a-home-api/releases/download/0.10.2/owning_a_home
 https://github.com/cfpb/regulations-core/releases/download/1.2.6/regcore-1.2.6-py2-none-any.whl
 https://github.com/cfpb/regulations-site/releases/download/2.1.16/regulations-2.1.16-py2-none-any.whl
 https://github.com/cfpb/retirement/releases/download/0.5.14/retirement-0.5.14-py2-none-any.whl
-git+https://github.com/cfpb/ccdb5-api.git@v1.0.3#egg=ccdb5-api
+git+https://github.com/cfpb/ccdb5-api.git@v1.0.4#egg=ccdb5-api
 git+https://github.com/cfpb/ccdb5-ui.git@v1.0.6#egg=ccdb5_ui
 git+https://github.com/cfpb/eregs-2.0.git@0.0.5#egg=eregs
 https://github.com/cfpb/django-hud/releases/download/1.4.3/django_hud-1.4.3-py2-none-any.whl


### PR DESCRIPTION
This version contains the Swagger/Open API specification for the API.  It is available at the `<ccdb5-api>/docs` endpoint