### PR TITLE
Hotfix: Page sets is now page set

### DIFF
--- a/cfgov/v1/feeds.py
+++ b/cfgov/v1/feeds.py
@@ -21,7 +21,7 @@ class FilterableFeed(Feed):
         return "%s | Consumer Financial Protection Bureau" % self.page.title
 
     def items(self):
-        posts = self.context['filter_data']['page_sets'].pop(0)
+        posts = self.context['filter_data']['page_set']
         return posts
 
     def item_link(self, item):


### PR DESCRIPTION
Forgot to update this when updating related code in https://github.com/cfpb/cfgov-refresh/pull/3628.  Currently causing an error on  /about-us/blog/feed/. 