### PR TITLE
Hotfix: Remove duplicate line in related_metadata_tags

### DIFF
--- a/cfgov/v1/models/base.py
+++ b/cfgov/v1/models/base.py
@@ -206,7 +206,6 @@ class CFGOVPage(Page):
         # Set the tags to correct data format
         tags = {'links': []}
         filter_page = self.get_filter_data()
-        relative_url = filter_page.relative_url(filter_page.get_site())
         for tag in self.specific.tags.all():
             tag_link = {'text': tag.name, 'url': ''}
             if filter_page:


### PR DESCRIPTION
Somehow a line that got removed here https://github.com/cfpb/cfgov-refresh/pull/3621/files made its way back in, in a merge yesterday https://github.com/cfpb/cfgov-refresh/commit/f89dde83c6259a5dbb968bfdb53125703cdaef36#diff-8e8a3e28d46ee12516bea4f5b50bf5a4R209.  Fixing that.