### PR TITLE
Stopping mysql lockups, take 2

### DIFF
--- a/cfgov/v1/models/base.py
+++ b/cfgov/v1/models/base.py
@@ -147,10 +147,14 @@ class CFGOVPage(Page):
     def related_posts(self, block):
         from v1.models.learn_page import AbstractFilterPage
 
-        def match_all_topic_tags(queryset, tags):
-            for tag in tags:
-                queryset = queryset.filter(tags__name=tag)
-            return queryset
+        def tag_set(related_page):
+            return set([tag.pk for tag in related_page.tags.all()])
+
+        def match_all_topic_tags(queryset, page_tags):
+            """Return pages that share every one of the current page's tags."""
+            current_tag_set = set([tag.pk for tag in page_tags])
+            return [page for page in queryset
+                    if current_tag_set.issubset(tag_set(page))]
 
         related_types = []
         related_items = {}
@@ -163,7 +167,7 @@ class CFGOVPage(Page):
         if not related_types:
             return related_items
 
-        tags = self.tags.names()
+        tags = self.tags.all()
         and_filtering = block.value['and_filtering']
         specific_categories = block.value['specific_categories']
         limit = int(block.value['limit'])
@@ -173,13 +177,13 @@ class CFGOVPage(Page):
         for parent in related_types:  # blog, newsroom or events
             # Include children of this slug that match at least 1 tag
             children = Page.objects.child_of_q(Page.objects.get(slug=parent))
-            filters = children & Q(('tags__name__in', tags))
+            filters = children & Q(('tags__in', tags))
 
             if parent == 'events':
                 # Include archived events matches
                 archive = Page.objects.get(slug='archive-past-events')
                 children = Page.objects.child_of_q(archive)
-                filters |= children & Q(('tags__name__in', tags))
+                filters |= children & Q(('tags__in', tags))
 
             if specific_categories:
                 # Filter by any additional categories specified


### PR DESCRIPTION
Editors helped us discover a combination of page tags and the use of
"match-all-topic-tags" that locked up mysql. The offending query
was a string of filter queries, one for each page tag,
appended to a query composed of Q objects.

This here attempt uses Python sets instead of SQL to determine
whether all tags are shared.

## Testing

Previously you could replicate the mysql lockup this way:
- With recent prod data, edit page at `/admin/pages/10848/edit/`
- Restore the revision from Oct 18 (12:12 p.m.)
- Choose the "match-all-topic-tags" box in the sidebar tab
- Save draft and preview, or publish ad view the live page

You could also replicate the crash with the most recent version of
10848:
- Edit the page and make sure it still has at least 9 tags listed
in the configuration tab
- Choose "match-all-topic-tags" box in the sidebar
- Save draft and preview, or publish and view live

## Notes

- The lockup only occurred on the version of mysql we use for web
servers. To replicate this locally, you might need to use
cfgov's [Docker setup](https://cfpb.github.io/cfgov-refresh/installation/#docker-compose-installation), which matches the mysql version used on our servers.

- This addresses GHE issue 1805
