### PR TITLE
Update wagtail-flags to 2.0.7

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -49,7 +49,7 @@ unicodecsv==0.14.1
 unipath>=1.1,<=2.0
 vobject==0.9.1
 wagtail==1.10.1
-wagtail-flags==2.0.6
+wagtail-flags==2.0.7
 wagtail-inventory==0.3
 wagtail-sharing==0.5
 Wand==0.4.2


### PR DESCRIPTION
The main change here is that the `path` condition (which checked that a path started with a particular string) has changed to `path matches`, and accepts a regular expression to check the path against.

## Checklist

* [x] PR has an informative and human-readable title
* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [x] Passes all existing automated tests
* [x] Any *change* in functionality is tested
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices
* [x] Project documentation has been updated
* [x] Reviewers requested with the [Reviewer tool](https://help.github.com/articles/about-pull-request-reviews/) :arrow_right:
