### PR TITLE
Deprecate file cache for eRegs and default caches

### DIFF
--- a/cfgov/cfgov/settings/local.py
+++ b/cfgov/cfgov/settings/local.py
@@ -49,6 +49,7 @@ if os.environ.get('ENABLE_DEBUG_TOOLBAR'):
 MIDDLEWARE_CLASSES += CSP_MIDDLEWARE_CLASSES
 
 # Disable caching when working locally.
+# eregs_longterm_cache and api_cache are required by regulations-site.
 CACHES = {
     k: {
         'BACKEND': 'django.core.cache.backends.dummy.DummyCache',

--- a/cfgov/cfgov/settings/production.py
+++ b/cfgov/cfgov/settings/production.py
@@ -86,24 +86,16 @@ STATICFILES_STORAGE = 'django.contrib.staticfiles.storage.ManifestStaticFilesSto
 
 CACHES = {
     'default': {
-        'BACKEND': 'django.core.cache.backends.filebased.FileBasedCache',
-        'LOCATION': '/tmp/eregs_cache',
+        'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
     },
+    # eregs_longterm_cache and api_cache are required by regulations-site.
     'eregs_longterm_cache': {
-        'BACKEND': 'django.core.cache.backends.filebased.FileBasedCache',
-        'LOCATION': '/tmp/eregs_longterm_cache',
-        'TIMEOUT': 60*60*24*15,     # 15 days
-        'OPTIONS': {
-            'MAX_ENTRIES': 10000,
-        },
+        'BACKEND': 'django.core.cache.backends.dummy.DummyCache',
+        'TIMEOUT': 0,
     },
     'api_cache': {
-        'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
-        'LOCATION': 'api_cache_memory',
-        'TIMEOUT': 3600,
-        'OPTIONS': {
-            'MAX_ENTRIES': 1000,
-        },
+        'BACKEND': 'django.core.cache.backends.dummy.DummyCache',
+        'TIMEOUT': 0,
     },
     'post_preview': {
         'BACKEND': 'django.core.cache.backends.db.DatabaseCache',


### PR DESCRIPTION
This change modifies the two eRegs caches (`eregs_longterm_cache` and `api_cache`) so that they use the passthrough cache instead of a disk-based cache. These two caches are required by the optional [regulations-site](https://github.com/cfpb/regulations-site) app. Unfortunately that app requires that these caches be defined (including with a `TIMEOUT`) parameter and doesn't handle the fallback case where they aren't.

eRegs pages don't need to be specially cached to disk because the typical production deployment of cfgov-refresh has a comprehensive cache sitting in front of it. These caches thus add complexity without adding any benefit.

This change also modifies the `default` cache so that it uses Django's default of in-memory, instead of disk (if you don't define any caches at all, [you don't need to define this in settings](https://docs.djangoproject.com/en/1.8/topics/cache/#local-memory-caching), but since we do other ones, we have to define a default). The way this cache is currently defined means that doing various things (like the built-in Wagtail caching of sites) requires write permission to `/tmp`, which is not always available.

Is there any particular reason we use a disk cache here instead of memory? @rosskarchner

## Changes

- Change eRegs caches to be pass-through and Django default cache to be in-memory.

## Checklist

* [X] PR has an informative and human-readable title
* [X] Changes are limited to a single goal (no scope creep)
* [X] Code can be automatically merged (no conflicts)
* [X] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [X] Passes all existing automated tests
* [X] Reviewers requested with the [Reviewer tool](https://help.github.com/articles/about-pull-request-reviews/) :arrow_right:
