### PR TITLE
Remove print statement in agreements tests

### DIFF
--- a/cfgov/agreements/management/commands/import_agreements.py
+++ b/cfgov/agreements/management/commands/import_agreements.py
@@ -18,6 +18,8 @@ class Command(BaseCommand):
         parser.add_argument('-p', '--path', action='store', required=True)
 
     def handle(self, *args, **options):
+        verbosity = options['verbosity']
+
         now = datetime.now()
         suffix = '%s_%s_' % (now.month, now.year)
 
@@ -48,7 +50,12 @@ class Command(BaseCommand):
                         (uri_hostname, s3_key, unique_fname)))
 
                 if os.environ.get('AGREEMENTS_S3_UPLOAD_ENABLED', False):
-                    upload_to_s3(
-                        file_path=os.path.join(current_dir, fname),
-                        s3_dest_path=("%s/%s" % (s3_key, unique_fname))
-                    )
+                    file_path = os.path.join(current_dir, fname)
+                    s3_dest_path = "%s/%s" % (s3_key, unique_fname)
+                    upload_to_s3(file_path, s3_dest_path)
+
+                    if verbosity >= 1:
+                        self.stdout.write('{} uploaded to {}'.format(
+                            file_path,
+                            s3_dest_path
+                        ))

--- a/cfgov/agreements/management/commands/util.py
+++ b/cfgov/agreements/management/commands/util.py
@@ -47,9 +47,8 @@ def update_agreement(
     return agreement
 
 
-def upload_to_s3(file_path=None, s3_dest_path=None):
+def upload_to_s3(file_path, s3_dest_path):
     import tinys3
-
     AWS_S3_ACCESS_KEY_ID = os.environ.get('AWS_S3_ACCESS_KEY_ID')
     AWS_S3_SECRET_ACCESS_KEY = os.environ.get('AWS_S3_SECRET_ACCESS_KEY')
     AWS_STORAGE_BUCKET_NAME = os.environ.get('AWS_STORAGE_BUCKET_NAME')
@@ -62,4 +61,3 @@ def upload_to_s3(file_path=None, s3_dest_path=None):
 
     file = open(file_path, 'rb')
     conn.upload(s3_dest_path, file, AWS_STORAGE_BUCKET_NAME)
-    print '%s uploaded to %s' % (file_path, s3_dest_path)

--- a/cfgov/agreements/tests/test_management.py
+++ b/cfgov/agreements/tests/test_management.py
@@ -1,4 +1,5 @@
 import os.path
+from cStringIO import StringIO
 
 import mock
 
@@ -24,11 +25,28 @@ class TestDataLoad(TestCase):
     @mock.patch('agreements.management.commands.' +
                 'import_agreements.upload_to_s3')
     def test_import_with_s3(self, upload_func):
-        management.call_command('import_agreements', '--path=' + sample_dir)
+        management.call_command(
+            'import_agreements',
+            '--path=' + sample_dir,
+            verbosity=0
+        )
 
         # this isn't great, but the dest_name changes to reflect the month
         # AND we can't predict the order agreements will be processed in.
         upload_func.assert_called()
+
+    @mock.patch.dict(os.environ, {'AGREEMENTS_S3_UPLOAD_ENABLED': 'yes'})
+    @mock.patch(
+        'agreements.management.commands.import_agreements.upload_to_s3'
+    )
+    def test_import_with_s3_calls_print_statement(self, _):
+        buf = StringIO()
+        management.call_command(
+            'import_agreements',
+            '--path=' + sample_dir,
+            stdout=buf
+        )
+        self.assertIn('uploaded to', buf.getvalue())
 
 
 class TestManagementUtils(TestCase):


### PR DESCRIPTION
This change removes a `print` statement that was getting called in unit tests. As of #3381 the agreements app was moved into cfgov-refresh, but one of those unit tests included a `print` statement.

This change modifies those tests so that the management command instead does the logging, and respects its `verbosity` option to enable/disable the logging.

A new unit test has been added to verify that the print statement is properly called by the command.

## Changes

- Small logic change to agreements unit tests to properly handle logging of S3 uploads.

## Testing

1. `tox -e fast` and behold the nice output of dots without any print statements.

## Checklist

* [X] PR has an informative and human-readable title
* [X] Changes are limited to a single goal (no scope creep)
* [X] Code can be automatically merged (no conflicts)
* [X] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [X] Passes all existing automated tests
* [X] Any *change* in functionality is tested
* [X] Project documentation has been updated
* [X] Reviewers requested with the [Reviewer tool](https://help.github.com/articles/about-pull-request-reviews/) :arrow_right:
