### PR TITLE
Cache activity log

### DIFF
--- a/cfgov/jinja2/v1/activity-log/_activity-list.html
+++ b/cfgov/jinja2/v1/activity-log/_activity-list.html
@@ -16,6 +16,7 @@
                 </th>
             </tr>
         {%- for post in posts %}
+            {% cache post.activity_list_cache_key %}
             {% set post_url = get_protected_url(post) %}
             <tr>
                 <td class="u-w20pct">
@@ -44,6 +45,7 @@
                     {{ time.render(post.date_published, {'date':true}) }}
                 </td>
             </tr>
+            {% endcache %}
         {%- endfor %}
         </tbody>
     </table>

--- a/cfgov/v1/models/base.py
+++ b/cfgov/v1/models/base.py
@@ -364,6 +364,10 @@ class CFGOVPage(Page):
     def post_preview_cache_key(self):
         return 'post_preview_{}'.format(self.id)
 
+    @property
+    def activity_list_cache_key(self):
+        return 'activity_list_{}'.format(self.id)
+
 
 class CFGOVPageCategory(Orderable):
     page = ParentalKey(CFGOVPage, related_name='categories')

--- a/cfgov/v1/signals.py
+++ b/cfgov/v1/signals.py
@@ -41,7 +41,9 @@ def user_save_callback(sender, **kwargs):
 
 
 def invalidate_post_preview(sender, **kwargs):
+    """ Invalidates all places that a preview of this post appears """
     instance = kwargs['instance']
     caches['post_preview'].delete(instance.post_preview_cache_key)
+    caches['post_preview'].delete(instance.activity_list_cache_key)
 
 page_published.connect(invalidate_post_preview)


### PR DESCRIPTION
Caches the previews on the activity log page: https://www.consumerfinance.gov/activity-log/

This is mostly an example for the documentation on caching I added, but could be merged in. It decreases (locally) the queries from 200 to 117, and the CPU time from 10 seconds to 5.6 seconds.  Since it's only a single page (and not a set of pages in the case of the post previews work), not sure it's all that worthwhile adding this extra code.  