### PR TITLE
Try using deprecated Travis trusty 2017q4 images

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: python
-sudo: false
+sudo: required
 dist: trusty
+group: deprecated-2017Q4
 
 python:
   - "2.7"


### PR DESCRIPTION
We've been getting various weird Travis build failures in the last few days.

This PR tries to use the legacy images, using the approach documented here:

https://github.com/travis-ci/travis-ci/issues/8870

This could be a temporary workaround until we figure out why the builds are failing.

## Changes

- Pin TravisCI infrastructure version.

## Testing

1. Open this PR to see if it works!

## Notes

One big downside of doing this (using `sudo: required`) means we can't use container-based infrastructure, which [increases boot time](https://docs.travis-ci.com/user/reference/overview/#Virtualization-environments) from 1-6 seconds to 20-40 seconds.

## Checklist

* [X] PR has an informative and human-readable title
* [X] Changes are limited to a single goal (no scope creep)
* [X] Code can be automatically merged (no conflicts)
* [X] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [X] Passes all existing automated tests
* [X] Reviewers requested with the [Reviewer tool](https://help.github.com/articles/about-pull-request-reviews/) :arrow_right:
