### PR TITLE
Add prompt to Ask CFPB to enter search term if not given

### DIFF
--- a/cfgov/ask_cfpb/tests/test_views.py
+++ b/cfgov/ask_cfpb/tests/test_views.py
@@ -204,6 +204,31 @@ class AnswerViewTestCase(TestCase):
         self.assertTrue(mock_sqs_instance.filter.called_with(
             language='en', q='payday'))
 
+    @mock.patch('ask_cfpb.views.SearchQuerySet')
+    def test_en_search_no_term(self, mock_sqs):
+        from v1.util.migrations import get_or_create_page
+        mock_page = get_or_create_page(
+            apps,
+            'ask_cfpb',
+            'AnswerResultsPage',
+            'Mock results page',
+            'ask-cfpb-search-results',
+            self.ROOT_PAGE,
+            language='en')
+
+        response = self.client.get(reverse(
+            'ask-search-en'), {'q': ''})
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.context_data['page'],
+            mock_page)
+        self.assertEqual(
+            response.context_data['page'].query,
+            '')
+        self.assertEqual(
+            response.context_data['page'].result_query,
+            '')
+
     @override_settings(FLAGS={'ASK_SEARCH_TYPOS': {'boolean': True}})
     @mock.patch('ask_cfpb.views.SearchQuerySet')
     def test_en_search_suggestion(self, mock_sqs):

--- a/cfgov/jinja2/v1/ask-cfpb/answer-search-results.html
+++ b/cfgov/jinja2/v1/ask-cfpb/answer-search-results.html
@@ -72,7 +72,7 @@
 
             </section>
 
-        {% else %}
+        {% elif not results and page.query %}
 
         <section class="search-results block
                         block__flush-top">
@@ -94,6 +94,16 @@
                 </p>
             </div>
         </section>
+
+        {% else %}
+
+        <section class="search-results block
+                        block__flush-top">
+            <p class="short-desc u-mb30">
+                Please enter a search term in the box above.
+            </p>
+        </section>
+
         {% endif %}
 
         {% if disclaimer %}

--- a/cfgov/jinja2/v1/ask-cfpb/answer-search-results.html
+++ b/cfgov/jinja2/v1/ask-cfpb/answer-search-results.html
@@ -99,9 +99,9 @@
 
         <section class="search-results block
                         block__flush-top">
-            <p class="short-desc u-mb30">
+            <h4>
                 Please enter a search term in the box above.
-            </p>
+            </h4>
         </section>
 
         {% endif %}

--- a/cfgov/jinja2/v1/ask-cfpb/answer-search-spanish-results.html
+++ b/cfgov/jinja2/v1/ask-cfpb/answer-search-spanish-results.html
@@ -84,7 +84,7 @@
             {% else %}
 
                 <div class="primary span8">
-                    <p>Escriba un término de búsqueda en el cuadro de texto.</p>
+                    <h4 class="ac-search-prompt">Escriba un término de búsqueda en el cuadro de texto.</h4>
                 </div> 
 
             {% endif %}

--- a/cfgov/jinja2/v1/ask-cfpb/answer-search-spanish-results.html
+++ b/cfgov/jinja2/v1/ask-cfpb/answer-search-spanish-results.html
@@ -64,7 +64,8 @@
 
                 <div class="share s-hide-on-small" data-set="share"></div><!-- .share -->
 
-            {% else %}
+            {% elif not results and page.query %}
+
                 <div class="primary span8">
                     <header class="header">
                         <h3>No pudimos encontrar resultados para "<em>{{ page.result_query }}</em>"</h3>
@@ -79,6 +80,13 @@
                         <li><a href="/obtener-respustas">Obtener respuestas</a></li>
                     </ul>
                 </div>
+
+            {% else %}
+
+                <div class="primary span8">
+                    <p>Escriba un término de búsqueda en el cuadro de texto.</p>
+                </div> 
+
             {% endif %}
 
         </section><!-- .content -->

--- a/cfgov/legacy/static/knowledgebase/less/es-ask-base.less
+++ b/cfgov/legacy/static/knowledgebase/less/es-ask-base.less
@@ -52,6 +52,12 @@
     margin: 0;
 }
 
+.ac-search-prompt {
+    margin-top: 0;
+    text-transform: none;
+    font-size: 1em;
+}
+
 .ac-search-form input,
 .ac-search-form label {
     display: block;


### PR DESCRIPTION
Ask CFPB search used to 404 if you didn't provide a search term. This PR is an attempt to fix that and prompt users to enter a search term.

## Changes

- Prompt for an Ask CFPB search term instead of 404ing when none is given


## Screenshots

![image](https://user-images.githubusercontent.com/10562538/34122543-cc9fb200-e3fa-11e7-80ba-877b88b5221c.png)
![image](https://user-images.githubusercontent.com/10562538/34122546-d1b5e994-e3fa-11e7-9e29-47047364212b.png)


## Checklist

* [x] PR has an informative and human-readable title
* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [x] Passes all existing automated tests
* [x] Any *change* in functionality is tested
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated
* [x] Reviewers requested with the [Reviewer tool](https://help.github.com/articles/about-pull-request-reviews/) :arrow_right:
