### PR TITLE
Remove ESLint ignore file

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,0 @@
-# Ignore 3rd-party polyfills.
-cfgov/unprocessed/js/modules/polyfill/**/*.js
-cfgov/unprocessed/js/routes/**/*.js

--- a/cfgov/unprocessed/js/modules/polyfill/class-list.js
+++ b/cfgov/unprocessed/js/modules/polyfill/class-list.js
@@ -1,237 +1,229 @@
-/*
- * classList.js: Cross-browser full element.classList implementation.
- * 2014-07-23
- *
- * By Eli Grey, http://eligrey.com
- * Public Domain.
- * NO WARRANTY EXPRESSED OR IMPLIED. USE AT YOUR OWN RISK.
- */
+/* classList.js: Cross-browser full element.classList implementation.
+   2014-07-23
+   By Eli Grey, http://eligrey.com
+   Public Domain.
+   NO WARRANTY EXPRESSED OR IMPLIED. USE AT YOUR OWN RISK. */
 
-/*global self, document, DOMException */
+/* global self, document, DOMException */
 
-/*! @source http://purl.eligrey.com/github/classList.js/blob/master/classList.js*/
+/*! @source http://purl.eligrey.com/github/classList.js/blob/master/classList.js */
 
-if ("document" in self) {
+if ( 'document' in self ) {
 
 // Full polyfill for browsers with no classList support
-if (!("classList" in document.createElement("_"))) {
+  if ( !( 'classList' in document.createElement( '_' ) ) ) {
 
-(function (view) {
+    ( function( view ) {
 
-"use strict";
 
-if (!('Element' in view)) return;
+      if ( !( 'Element' in view ) ) return;
 
-var
-    classListProp = "classList"
-  , protoProp = "prototype"
-  , elemCtrProto = view.Element[protoProp]
-  , objCtr = Object
-  , strTrim = String[protoProp].trim || function () {
-    return this.replace(/^\s+|\s+$/g, "");
-  }
-  , arrIndexOf = Array[protoProp].indexOf || function (item) {
-    var
-        i = 0
-      , len = this.length
-    ;
-    for (; i < len; i++) {
-      if (i in this && this[i] === item) {
-        return i;
-      }
-    }
-    return -1;
-  }
-  // Vendors: please allow content code to instantiate DOMExceptions
-  , DOMEx = function (type, message) {
-    this.name = type;
-    this.code = DOMException[type];
-    this.message = message;
-  }
-  , checkTokenAndGetIndex = function (classList, token) {
-    if (token === "") {
-      throw new DOMEx(
-          "SYNTAX_ERR"
-        , "An invalid or illegal string was specified"
-      );
-    }
-    if (/\s/.test(token)) {
-      throw new DOMEx(
-          "INVALID_CHARACTER_ERR"
-        , "String contains an invalid character"
-      );
-    }
-    return arrIndexOf.call(classList, token);
-  }
-  , ClassList = function (elem) {
-    var
-        trimmedClasses = strTrim.call(elem.getAttribute("class") || "")
-      , classes = trimmedClasses ? trimmedClasses.split(/\s+/) : []
-      , i = 0
-      , len = classes.length
-    ;
-    for (; i < len; i++) {
-      this.push(classes[i]);
-    }
-    this._updateClassName = function () {
-      elem.setAttribute("class", this.toString());
-    };
-  }
-  , classListProto = ClassList[protoProp] = []
-  , classListGetter = function () {
-    return new ClassList(this);
-  }
+      let
+          classListProp = 'classList',
+          protoProp = 'prototype',
+          elemCtrProto = view.Element[protoProp],
+          objCtr = Object,
+          strTrim = String[protoProp].trim || function() {
+            return this.replace( /^\s+|\s+$/g, '' );
+          },
+          arrIndexOf = Array[protoProp].indexOf || function( item ) {
+            let
+                i = 0,
+                len = this.length;
+            for ( ; i < len; i++ ) {
+              if ( i in this && this[i] === item ) {
+                return i;
+              }
+            }
+            return -1;
+          },
+          // Vendors: please allow content code to instantiate DOMExceptions
+          DOMEx = function( type, message ) {
+            this.name = type;
+            this.code = DOMException[type];
+            this.message = message;
+          },
+          checkTokenAndGetIndex = function( classList, token ) {
+            if ( token === '' ) {
+              throw new DOMEx(
+                'SYNTAX_ERR'
+                , 'An invalid or illegal string was specified'
+              );
+            }
+            if ( /\s/.test( token ) ) {
+              throw new DOMEx(
+                'INVALID_CHARACTER_ERR'
+                , 'String contains an invalid character'
+              );
+            }
+            return arrIndexOf.call( classList, token );
+          },
+          ClassList = function( elem ) {
+            let
+                trimmedClasses = strTrim.call( elem.getAttribute( 'class' ) || '' ),
+                classes = trimmedClasses ? trimmedClasses.split( /\s+/ ) : [],
+                i = 0,
+                len = classes.length;
+            for ( ; i < len; i++ ) {
+              this.push( classes[i] );
+            }
+            this._updateClassName = function() {
+              elem.setAttribute( 'class', this.toString() );
+            };
+          },
+          classListProto = ClassList[protoProp] = [],
+          classListGetter = function() {
+            return new ClassList( this );
+          }
 ;
-// Most DOMException implementations don't allow calling DOMException's toString()
-// on non-DOMExceptions. Error's toString() is sufficient here.
-DOMEx[protoProp] = Error[protoProp];
-classListProto.item = function (i) {
-  return this[i] || null;
-};
-classListProto.contains = function (token) {
-  token += "";
-  return checkTokenAndGetIndex(this, token) !== -1;
-};
-classListProto.add = function () {
-  var
-      tokens = arguments
-    , i = 0
-    , l = tokens.length
-    , token
-    , updated = false
-  ;
-  do {
-    token = tokens[i] + "";
-    if (checkTokenAndGetIndex(this, token) === -1) {
-      this.push(token);
-      updated = true;
-    }
-  }
-  while (++i < l);
 
-  if (updated) {
-    this._updateClassName();
-  }
-};
-classListProto.remove = function () {
-  var
-      tokens = arguments
-    , i = 0
-    , l = tokens.length
-    , token
-    , updated = false
-    , index
-  ;
-  do {
-    token = tokens[i] + "";
-    index = checkTokenAndGetIndex(this, token);
-    while (index !== -1) {
-      this.splice(index, 1);
-      updated = true;
-      index = checkTokenAndGetIndex(this, token);
-    }
-  }
-  while (++i < l);
+/* Most DOMException implementations don't allow calling DOMException's toString()
+   on non-DOMExceptions. Error's toString() is sufficient here. */
+      DOMEx[protoProp] = Error[protoProp];
+      classListProto.item = function( i ) {
+        return this[i] || null;
+      };
+      classListProto.contains = function( token ) {
+        token = String( token );
+        return checkTokenAndGetIndex( this, token ) !== -1;
+      };
+      classListProto.add = function() {
+        let
+            tokens = arguments,
+            i = 0,
+            l = tokens.length,
+            token,
+            updated = false;
+        do {
+          token = String( tokens[i] );
+          if ( checkTokenAndGetIndex( this, token ) === -1 ) {
+            this.push( token );
+            updated = true;
+          }
+        }
+        while ( ++i < l );
 
-  if (updated) {
-    this._updateClassName();
-  }
-};
-classListProto.toggle = function (token, force) {
-  token += "";
-
-  var
-      result = this.contains(token)
-    , method = result ?
-      force !== true && "remove"
-    :
-      force !== false && "add"
-  ;
-
-  if (method) {
-    this[method](token);
-  }
-
-  if (force === true || force === false) {
-    return force;
-  } else {
-    return !result;
-  }
-};
-classListProto.toString = function () {
-  return this.join(" ");
-};
-
-if (objCtr.defineProperty) {
-  var classListPropDesc = {
-      get: classListGetter
-    , enumerable: true
-    , configurable: true
-  };
-  try {
-    objCtr.defineProperty(elemCtrProto, classListProp, classListPropDesc);
-  } catch (ex) { // IE 8 doesn't support enumerable:true
-    if (ex.number === -0x7FF5EC54) {
-      classListPropDesc.enumerable = false;
-      objCtr.defineProperty(elemCtrProto, classListProp, classListPropDesc);
-    }
-  }
-} else if (objCtr[protoProp].__defineGetter__) {
-  elemCtrProto.__defineGetter__(classListProp, classListGetter);
-}
-
-}(self));
-
-} else {
-// There is full or partial native classList support, so just check if we need
-// to normalize the add/remove and toggle APIs.
-
-(function () {
-  "use strict";
-
-  var testElement = document.createElement("_");
-
-  testElement.classList.add("c1", "c2");
-
-  // Polyfill for IE 10/11 and Firefox <26, where classList.add and
-  // classList.remove exist but support only one argument at a time.
-  if (!testElement.classList.contains("c2")) {
-    var createMethod = function(method) {
-      var original = DOMTokenList.prototype[method];
-
-      DOMTokenList.prototype[method] = function(token) {
-        var i, len = arguments.length;
-
-        for (i = 0; i < len; i++) {
-          token = arguments[i];
-          original.call(this, token);
+        if ( updated ) {
+          this._updateClassName();
         }
       };
-    };
-    createMethod('add');
-    createMethod('remove');
-  }
+      classListProto.remove = function() {
+        let
+            tokens = arguments,
+            i = 0,
+            l = tokens.length,
+            token,
+            updated = false,
+            index;
+        do {
+          token = String( tokens[i] );
+          index = checkTokenAndGetIndex( this, token );
+          while ( index !== -1 ) {
+            this.splice( index, 1 );
+            updated = true;
+            index = checkTokenAndGetIndex( this, token );
+          }
+        }
+        while ( ++i < l );
 
-  testElement.classList.toggle("c3", false);
+        if ( updated ) {
+          this._updateClassName();
+        }
+      };
+      classListProto.toggle = function( token, force ) {
+        token = String( token );
 
-  // Polyfill for IE 10 and Firefox <24, where classList.toggle does not
-  // support the second argument.
-  if (testElement.classList.contains("c3")) {
-    var _toggle = DOMTokenList.prototype.toggle;
+        let
+            result = this.contains( token ),
+            method = result ?
+              force !== true && 'remove' :
+              force !== false && 'add';
+        if ( method ) {
+          this[method]( token );
+        }
 
-    DOMTokenList.prototype.toggle = function(token, force) {
-      if (1 in arguments && !this.contains(token) === !force) {
-        return force;
-      } else {
-        return _toggle.call(this, token);
+        if ( force === true || force === false ) {
+          return force;
+        }
+        return !result;
+
+      };
+      classListProto.toString = function() {
+        return this.join( ' ' );
+      };
+
+      if ( objCtr.defineProperty ) {
+        const classListPropDesc = {
+          get: classListGetter,
+          enumerable: true,
+          configurable: true
+        };
+        try {
+          objCtr.defineProperty( elemCtrProto, classListProp, classListPropDesc );
+        } catch ( ex ) { // IE 8 doesn't support enumerable:true
+          if ( ex.number === -0x7FF5EC54 ) {
+            classListPropDesc.enumerable = false;
+            objCtr.defineProperty( elemCtrProto, classListProp, classListPropDesc );
+          }
+        }
+      } else if ( objCtr[protoProp].__defineGetter__ ) {
+        elemCtrProto.__defineGetter__( classListProp, classListGetter );
       }
-    };
+
+    } )( self );
+
+  } else {
+
+    /* There is full or partial native classList support, so just check if we need
+       to normalize the add/remove and toggle APIs. */
+
+    ( function() {
+
+
+      let testElement = document.createElement( '_' );
+
+      testElement.classList.add( 'c1', 'c2' );
+
+      /* Polyfill for IE 10/11 and Firefox <26, where classList.add and
+         classList.remove exist but support only one argument at a time. */
+      if ( !testElement.classList.contains( 'c2' ) ) {
+        const createMethod = function( method ) {
+          const original = DOMTokenList.prototype[method];
+
+          DOMTokenList.prototype[method] = function( token ) {
+            let i,
+                len = arguments.length;
+
+            for ( i = 0; i < len; i++ ) {
+              token = arguments[i];
+              original.call( this, token );
+            }
+          };
+        };
+        createMethod( 'add' );
+        createMethod( 'remove' );
+      }
+
+      testElement.classList.toggle( 'c3', false );
+
+      /* Polyfill for IE 10 and Firefox <24, where classList.toggle does not
+         support the second argument. */
+      if ( testElement.classList.contains( 'c3' ) ) {
+        const _toggle = DOMTokenList.prototype.toggle;
+
+        DOMTokenList.prototype.toggle = function( token, force ) {
+          if ( 1 in arguments && !this.contains( token ) === !force ) {
+            return force;
+          }
+          return _toggle.call( this, token );
+
+        };
+
+      }
+
+      testElement = null;
+    } )();
 
   }
-
-  testElement = null;
-}());
-
-}
 
 }

--- a/cfgov/unprocessed/js/routes/about-us/careers/current-openings/index.js
+++ b/cfgov/unprocessed/js/routes/about-us/careers/current-openings/index.js
@@ -2,6 +2,5 @@
    Scripts for `/about-us/careers/current-openings/.
    ========================================================================== */
 
-'use strict';
 
 require( '../../../../modules/o-table-row-links' ).init();

--- a/cfgov/unprocessed/js/routes/ask-cfpb/single.js
+++ b/cfgov/unprocessed/js/routes/ask-cfpb/single.js
@@ -1,31 +1,31 @@
 require( '../on-demand/ask-autocomplete' );
-var Analytics = require( '../../modules/Analytics' );
+const Analytics = require( '../../modules/Analytics' );
 
-var Expandable = require( '../../organisms/Expandable' );
-var getBreakpointState = require( '../../modules/util/breakpoint-state' ).get;
+const Expandable = require( '../../organisms/Expandable' );
+const getBreakpointState = require( '../../modules/util/breakpoint-state' ).get;
 
-var readMoreContainer = document.querySelector( '.o-expandable__read-more' );
+const readMoreContainer = document.querySelector( '.o-expandable__read-more' );
 if ( readMoreContainer && getBreakpointState().isBpXS ) {
-  var readMoreExpandable = new Expandable( readMoreContainer ).init();
-  readMoreExpandable.addEventListener( 'expandEnd', function () {
+  const readMoreExpandable = new Expandable( readMoreContainer ).init();
+  readMoreExpandable.addEventListener( 'expandEnd', function() {
     readMoreExpandable.destroy();
     readMoreContainer.querySelector( '.o-expandable_content' ).style.height = '';
   } );
 }
 
-var analyticsData = document.querySelector( '.analytics-data' );
+const analyticsData = document.querySelector( '.analytics-data' );
 if ( analyticsData ) {
-  var answerID = analyticsData.getAttribute( 'data-answer-id' );
-  var categorySlug = analyticsData.getAttribute( 'data-category-slug' );
-  var categoryName = analyticsData.getAttribute( 'data-category-name' );
+  const answerID = analyticsData.getAttribute( 'data-answer-id' );
+  const categorySlug = analyticsData.getAttribute( 'data-category-slug' );
+  const categoryName = analyticsData.getAttribute( 'data-category-name' );
 
   function sendEvent() {
-    var eventData = Analytics.getDataLayerOptions( '/askcfpb/' + answerID + '/',
+    const eventData = Analytics.getDataLayerOptions( '/askcfpb/' + answerID + '/',
       document.title, 'Virtual Pageview' );
     eventData.category = categoryName;
     Analytics.sendEvent( eventData );
   }
-  
+
   if ( Analytics.tagManagerIsLoaded ) {
     sendEvent();
   } else {

--- a/cfgov/unprocessed/js/routes/common.js
+++ b/cfgov/unprocessed/js/routes/common.js
@@ -2,18 +2,16 @@
    Common application-wide scripts that are used across the whole site.
    ========================================================================== */
 
-'use strict';
-
 
 // Global modules.
 require( '../modules/focus-target' ).init();
 
-// GLOBAL ATOMIC ELEMENTS.
-// Organisms.
-var Header = require( '../organisms/Header.js' );
-var header = new Header( document.body );
+/* GLOBAL ATOMIC ELEMENTS.
+   Organisms. */
+const Header = require( '../organisms/Header.js' );
+const header = new Header( document.body );
 // Initialize header by passing it reference to global overlay atom.
 header.init( document.body.querySelector( '.a-overlay' ) );
 
-var Footer = require( '../organisms/Footer.js' );
-var footer = new Footer( document.body ).init();
+const Footer = require( '../organisms/Footer.js' );
+const footer = new Footer( document.body ).init();

--- a/cfgov/unprocessed/js/routes/consumer-tools/financial-well-being/index.js
+++ b/cfgov/unprocessed/js/routes/consumer-tools/financial-well-being/index.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const fwbQuestions = require( '../../../apps/financial-well-being/fwb-questions' );
 
 window.addEventListener( 'load', function() {

--- a/cfgov/unprocessed/js/routes/consumer-tools/financial-well-being/results/index.js
+++ b/cfgov/unprocessed/js/routes/consumer-tools/financial-well-being/results/index.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const fwbResults = require( '../../../../apps/financial-well-being/fwb-results' );
 
 fwbResults.init();

--- a/cfgov/unprocessed/js/routes/es/obtener-respuestas/single.js
+++ b/cfgov/unprocessed/js/routes/es/obtener-respuestas/single.js
@@ -1,26 +1,30 @@
 require( '../../on-demand/feedback-form' );
 require( '../../on-demand/ask-autocomplete' );
-var Analytics = require( '../../../modules/Analytics' );
+const Analytics = require( '../../../modules/Analytics' );
 
-var analyticsData = document.querySelector( '.analytics-data' );
+const analyticsData = document.querySelector( '.analytics-data' );
+
+/**
+ * Send event to Google Analytics.
+ */
+function sendEvent() {
+  const eventData = Analytics.getDataLayerOptions(
+    '/es/obtener-respuestas/c/' + categorySlug + '/' + answerID + '/',
+    document.title,
+    'Virtual Pageview' );
+  eventData.category = categoryName;
+  Analytics.sendEvent( eventData );
+}
+
 if ( analyticsData ) {
-  var answerID = analyticsData.getAttribute( 'data-answer-id' );
-  var categorySlug = analyticsData.getAttribute( 'data-category-slug' );
-  var categoryName = analyticsData.getAttribute( 'data-category-name' );
+  const answerID = analyticsData.getAttribute( 'data-answer-id' );
+  const categorySlug = analyticsData.getAttribute( 'data-category-slug' );
+  const categoryName = analyticsData.getAttribute( 'data-category-name' );
 
-  function sendEvent() {
-    var eventData = Analytics.getDataLayerOptions( 
-      '/es/obtener-respuestas/c/'+ categorySlug + '/' + answerID + '/',
-      document.title, 
-      'Virtual Pageview' );
-    eventData.category = categoryName;
-    Analytics.sendEvent( eventData );
-  }
-  
   if ( Analytics.tagManagerIsLoaded ) {
     sendEvent();
   } else {
     Analytics.addEventListener( 'gtmLoaded', sendEvent );
   }
-  
+
 }

--- a/cfgov/unprocessed/js/routes/external-site/index.js
+++ b/cfgov/unprocessed/js/routes/external-site/index.js
@@ -2,8 +2,7 @@
    Scripts for `/external-site/`.
    ========================================================================== */
 
-'use strict';
 
-var ExternalSite = require( '../../modules/ExternalSite.js' );
-var externalSite = new ExternalSite( document.querySelector( '.external-site_container' ) );
+const ExternalSite = require( '../../modules/ExternalSite.js' );
+const externalSite = new ExternalSite( document.querySelector( '.external-site_container' ) );
 externalSite.init();

--- a/cfgov/unprocessed/js/routes/on-demand/ask-autocomplete.js
+++ b/cfgov/unprocessed/js/routes/on-demand/ask-autocomplete.js
@@ -2,31 +2,31 @@
    Scripts for Ask Autocomplete.
    ========================================================================== */
 
-var Autocomplete = require( '../../molecules/Autocomplete' );
+const Autocomplete = require( '../../molecules/Autocomplete' );
 
-var URLS = {
-  'en': '/ask-cfpb/api/autocomplete/?term=',
-  'es': '/es/obtener-respuestas/api/autocomplete/?term='
-}
+const URLS = {
+  en: '/ask-cfpb/api/autocomplete/?term=',
+  es: '/es/obtener-respuestas/api/autocomplete/?term='
+};
 
-var autocompleteContainer = document.querySelector( '.m-autocomplete' );
+const autocompleteContainer = document.querySelector( '.m-autocomplete' );
 
 if ( autocompleteContainer ) {
-  var language = autocompleteContainer.getAttribute( 'data-language' );
+  const language = autocompleteContainer.getAttribute( 'data-language' );
 
-  var autocomplete = new Autocomplete( autocompleteContainer, { 
-    url: language === 'es' ? URLS['es'] : URLS['en'],
+  const autocomplete = new Autocomplete( autocompleteContainer, {
+    url: language === 'es' ? URLS.es : URLS.en,
     onSubmit: function( event, selected ) {
-        var link = selected.querySelector( 'a' );
-        var href = link.getAttribute("href");
-        if ( link && href ) {
-          document.location = href;
-        }
+      const link = selected.querySelector( 'a' );
+      const href = link.getAttribute( 'href' );
+      if ( link && href ) {
+        document.location = href;
+      }
     },
     renderItem: function( item ) {
-      var li = document.createElement( 'li' );
+      const li = document.createElement( 'li' );
       li.setAttribute( 'data-val', item.question );
-      var link = document.createElement( 'a' );
+      const link = document.createElement( 'a' );
       link.setAttribute( 'href', item.url );
       link.innerHTML = item.question;
       li.appendChild( link );

--- a/cfgov/unprocessed/js/routes/on-demand/bureau-structure.js
+++ b/cfgov/unprocessed/js/routes/on-demand/bureau-structure.js
@@ -1,10 +1,8 @@
-
 /* ==========================================================================
    Bureau structure.
    Scripts for `/the-bureau/bureau-structure/`.
    ========================================================================== */
 
-'use strict';
 
-var BureauStructure = require('../../organisms/BureauStructure');
+const BureauStructure = require( '../../organisms/BureauStructure' );
 BureauStructure.initialize();

--- a/cfgov/unprocessed/js/routes/on-demand/chart.js
+++ b/cfgov/unprocessed/js/routes/on-demand/chart.js
@@ -2,7 +2,6 @@
    Scripts for Line Chart molecule.
    ========================================================================== */
 
-'use strict';
 
 // See https://github.com/cfpb/cfpb-chart-builder
 require( 'cfpb-chart-builder' );

--- a/cfgov/unprocessed/js/routes/on-demand/email-signup.js
+++ b/cfgov/unprocessed/js/routes/on-demand/email-signup.js
@@ -2,18 +2,17 @@
    Scripts for Email Signup organism.
    ========================================================================== */
 
-'use strict';
 
-var FormSubmit = require( '../../organisms/FormSubmit.js' );
-var validators = require( '../../modules/util/validators' );
+const FormSubmit = require( '../../organisms/FormSubmit.js' );
+const validators = require( '../../modules/util/validators' );
 
-var BASE_CLASS = 'o-email-signup';
-var language = document.body.querySelector( '.content' ).lang;
-var emailSignUps = document.body.querySelectorAll( '.' + BASE_CLASS )
-var emailSignUpsLength = emailSignUps.length;
-var formSubmit;
+const BASE_CLASS = 'o-email-signup';
+const language = document.body.querySelector( '.content' ).lang;
+const emailSignUps = document.body.querySelectorAll( '.' + BASE_CLASS );
+const emailSignUpsLength = emailSignUps.length;
+let formSubmit;
 
-function emailValidation ( fields ) {
+function emailValidation( fields ) {
   return validators.email(
     fields.email,
     '',
@@ -21,7 +20,7 @@ function emailValidation ( fields ) {
   ).msg;
 }
 
-for ( var i = 0; i < emailSignUpsLength; i++ ) {
+for ( let i = 0; i < emailSignUpsLength; i++ ) {
   formSubmit = new FormSubmit(
     emailSignUps[i],
     BASE_CLASS,

--- a/cfgov/unprocessed/js/routes/on-demand/expandable-group.js
+++ b/cfgov/unprocessed/js/routes/on-demand/expandable-group.js
@@ -2,9 +2,8 @@
    Scripts for Expandable Group organism.
    ========================================================================== */
 
-'use strict';
 
-var atomicHelpers = require( '../../modules/util/atomic-helpers' );
-var ExpandableGroup = require( '../../organisms/ExpandableGroup' );
+const atomicHelpers = require( '../../modules/util/atomic-helpers' );
+const ExpandableGroup = require( '../../organisms/ExpandableGroup' );
 
 atomicHelpers.instantiateAll( '.o-expandable-group', ExpandableGroup );

--- a/cfgov/unprocessed/js/routes/on-demand/expandable.js
+++ b/cfgov/unprocessed/js/routes/on-demand/expandable.js
@@ -2,9 +2,8 @@
    Scripts for Expandable Molecule.
    ========================================================================== */
 
-'use strict';
 
-var atomicHelpers = require( '../../modules/util/atomic-helpers' );
-var Expandable = require( '../../organisms/Expandable' );
+const atomicHelpers = require( '../../modules/util/atomic-helpers' );
+const Expandable = require( '../../organisms/Expandable' );
 
 atomicHelpers.instantiateAll( '.o-expandable', Expandable );

--- a/cfgov/unprocessed/js/routes/on-demand/feedback-form.js
+++ b/cfgov/unprocessed/js/routes/on-demand/feedback-form.js
@@ -2,15 +2,14 @@
    Scripts for Feedback Form organism.
    ========================================================================== */
 
-'use strict';
 
-var COMMENT_ERRORS = require( '../../config/error-messages-config' ).COMMENT || {};
-var OPTION_ERRORS = require( '../../config/error-messages-config' ).OPTION || {};
-var FormSubmit = require( '../../organisms/FormSubmit.js' );
-var BASE_CLASS = 'o-feedback';
-var requiredKey = 'REQUIRED';
-var UNDEFINED;
-var element = document.body.querySelector( '.' + BASE_CLASS );
+const COMMENT_ERRORS = require( '../../config/error-messages-config' ).COMMENT || {};
+const OPTION_ERRORS = require( '../../config/error-messages-config' ).OPTION || {};
+const FormSubmit = require( '../../organisms/FormSubmit.js' );
+const BASE_CLASS = 'o-feedback';
+let requiredKey = 'REQUIRED';
+let UNDEFINED;
+const element = document.body.querySelector( '.' + BASE_CLASS );
 
 function validateFeedback( fields ) {
   if ( fields.comment ) {
@@ -21,7 +20,7 @@ function validateFeedback( fields ) {
     }
   }
   if ( fields.is_helpful ) {
-    for ( var i = 0; i < fields.is_helpful.length; i++ ) {
+    for ( let i = 0; i < fields.is_helpful.length; i++ ) {
       if ( fields.is_helpful[i].checked ) {
         return UNDEFINED;
       }
@@ -32,21 +31,21 @@ function validateFeedback( fields ) {
 }
 
 if ( element ) {
-  var replaceForm = element.getAttribute( 'data-replace' );
-  var languageField = element.querySelector( 'input[name="language"]' );
-  var language = languageField && languageField.value === 'es' ? 'es' : 'en';
+  const replaceForm = element.getAttribute( 'data-replace' );
+  const languageField = element.querySelector( 'input[name="language"]' );
+  const language = languageField && languageField.value === 'es' ? 'es' : 'en';
   if ( language === 'es' ) {
     requiredKey = 'REQUIRED_ES';
   }
 
-  var opts = {
+  const opts = {
     validator: validateFeedback,
     replaceForm:  replaceForm || language === 'es',
     minReplacementHeight: replaceForm,
     language: language
   };
 
-  var formSubmit = new FormSubmit(
+  const formSubmit = new FormSubmit(
     element,
     BASE_CLASS,
     opts

--- a/cfgov/unprocessed/js/routes/on-demand/filterable-list-controls.js
+++ b/cfgov/unprocessed/js/routes/on-demand/filterable-list-controls.js
@@ -2,9 +2,8 @@
    Scripts for Filterable List Controls organism
    ========================================================================== */
 
-'use strict';
 
-var atomicHelpers = require( '../../modules/util/atomic-helpers' );
-var FilterableListControls = require( '../../organisms/FilterableListControls' );
+const atomicHelpers = require( '../../modules/util/atomic-helpers' );
+const FilterableListControls = require( '../../organisms/FilterableListControls' );
 
 atomicHelpers.instantiateAll( '.o-filterable-list-controls', FilterableListControls );

--- a/cfgov/unprocessed/js/routes/on-demand/footer.js
+++ b/cfgov/unprocessed/js/routes/on-demand/footer.js
@@ -2,7 +2,6 @@
    Scripts for Footer organism.
    ========================================================================== */
 
-'use strict';
 
-var Footer = require( '../../organisms/Footer.js' );
-var footer = new Footer( document.body ).init();
+const Footer = require( '../../organisms/Footer.js' );
+const footer = new Footer( document.body ).init();

--- a/cfgov/unprocessed/js/routes/on-demand/header.js
+++ b/cfgov/unprocessed/js/routes/on-demand/header.js
@@ -2,11 +2,10 @@
    Scripts for Header organism.
    ========================================================================== */
 
-'use strict';
 
 require( '../../modules/focus-target' ).init();
 
-var Header = require( '../../organisms/Header.js' );
-var header = new Header( document.body );
+const Header = require( '../../organisms/Header.js' );
+const header = new Header( document.body );
 // Initialize header by passing it reference to global overlay atom.
 header.init( document.body.querySelector( '.a-overlay' ) );

--- a/cfgov/unprocessed/js/routes/on-demand/mortgage-performance-trends.js
+++ b/cfgov/unprocessed/js/routes/on-demand/mortgage-performance-trends.js
@@ -1,17 +1,15 @@
-
 /* ==========================================================================
    Mortgage Performance Trends
    Scripts for `/data-research/mortgage-performance-trends/`.
    ========================================================================== */
 
-'use strict';
 
-// To aid debugging, uncomment the below line.
-// It will enable console logging of state changes (except in IE).
-// window.MP_DEBUG = window.navigator.userAgent.indexOf('MSIE ') === -1;
+/* To aid debugging, uncomment the below line.
+   It will enable console logging of state changes (except in IE).
+   window.MP_DEBUG = window.navigator.userAgent.indexOf('MSIE ') === -1; */
 
-// CFPB's charting library looks for data files on S3 by default.
-// MP uses a custom API so point our charts to it instead.
+/* CFPB's charting library looks for data files on S3 by default.
+   MP uses a custom API so point our charts to it instead. */
 window.CFPB_CHART_DATA_SOURCE_BASE = '/data-research/mortgages/api/v1/';
 
 const MortgagePerformanceTrends = require( '../../organisms/MortgagePerformanceTrends' );

--- a/cfgov/unprocessed/js/routes/on-demand/notification.js
+++ b/cfgov/unprocessed/js/routes/on-demand/notification.js
@@ -2,7 +2,6 @@
    Scripts for Notification molecule.
    ========================================================================== */
 
-'use strict';
 
 const atomicHelpers = require( '../../modules/util/atomic-helpers' );
 const Notification = require( '../../molecules/Notification' );

--- a/cfgov/unprocessed/js/routes/on-demand/secondary-navigation.js
+++ b/cfgov/unprocessed/js/routes/on-demand/secondary-navigation.js
@@ -2,13 +2,13 @@
    Scripts for Secondary Navigation organism
    ========================================================================== */
 
-'use strict';
 
-var SecondaryNavigation = require( '../../organisms/SecondaryNavigation' );
+const SecondaryNavigation = require( '../../organisms/SecondaryNavigation' );
 
-var dom = document.querySelector( '.o-secondary-navigation' );
-// Check that this script has been delivered to a page that actually
-// has secondary navigation markup.
+const dom = document.querySelector( '.o-secondary-navigation' );
+
+/* Check that this script has been delivered to a page that actually
+   has secondary navigation markup. */
 if ( dom ) {
-  var secondaryNavigation = new SecondaryNavigation( dom ).init();
+  const secondaryNavigation = new SecondaryNavigation( dom ).init();
 }

--- a/cfgov/unprocessed/js/routes/on-demand/table.js
+++ b/cfgov/unprocessed/js/routes/on-demand/table.js
@@ -2,7 +2,6 @@
    Scripts for Line Chart molecule.
    ========================================================================== */
 
-'use strict';
 
 // See https://github.com/cfpb/capital-framework/
 require( 'cf-tables' );

--- a/cfgov/unprocessed/js/routes/on-demand/video-player.js
+++ b/cfgov/unprocessed/js/routes/on-demand/video-player.js
@@ -2,6 +2,5 @@
    Scripts for Video Player module.
    ========================================================================== */
 
-'use strict';
 
 require( '../../modules/YoutubePlayer' ).init( '.video-player__youtube' );

--- a/cfgov/unprocessed/js/routes/owning-a-home/common.js
+++ b/cfgov/unprocessed/js/routes/owning-a-home/common.js
@@ -2,20 +2,18 @@
    Common application-wide scripts for owning-a-home.
    ========================================================================== */
 
-var FormSubmit = require( '../../organisms/FormSubmit.js' );
-var validators = require( '../../modules/util/validators' );
-var ratingsForm = require( '../../apps/owning-a-home/ratings-form' );
-var BASE_CLASS = 'o-email-signup';
-var emailSignup = document.body.querySelector( '.' + BASE_CLASS );
+const FormSubmit = require( '../../organisms/FormSubmit.js' );
+const validators = require( '../../modules/util/validators' );
+const ratingsForm = require( '../../apps/owning-a-home/ratings-form' );
+const BASE_CLASS = 'o-email-signup';
+const emailSignup = document.body.querySelector( '.' + BASE_CLASS );
 
 if ( emailSignup ) {
-  var language = document.body.querySelector( '.content' ).lang;
-  var formSubmit = new FormSubmit( emailSignup, BASE_CLASS,
-    { validator: fields => {
-        return validators.email( fields.email, '', { language: language } )
-               .msg;
-      },
-      language: language
+  const language = document.body.querySelector( '.content' ).lang;
+  const formSubmit = new FormSubmit( emailSignup, BASE_CLASS,
+    { validator: fields => validators.email( fields.email, '', { language: language } )
+      .msg,
+    language: language
     }
   );
 

--- a/cfgov/unprocessed/js/routes/owning-a-home/mortgage-estimate/single.js
+++ b/cfgov/unprocessed/js/routes/owning-a-home/mortgage-estimate/single.js
@@ -1,11 +1,9 @@
-'use strict';
-
-var EmailPopup = require( '../../../organisms/EmailPopup' );
-var emailHelpers = require( '../../../modules/util/email-popup-helpers' );
-var emailPopup = document.querySelectorAll( '.o-email-popup' );
+const EmailPopup = require( '../../../organisms/EmailPopup' );
+const emailHelpers = require( '../../../modules/util/email-popup-helpers' );
+const emailPopup = document.querySelectorAll( '.o-email-popup' );
 
 if ( emailPopup.length && emailHelpers.showEmailPopup() ) {
-  var popup = new EmailPopup( '.o-email-popup' );
+  const popup = new EmailPopup( '.o-email-popup' );
   popup.init();
   emailHelpers.showOnScroll( popup.el, {
     cb: popup.showPopup,

--- a/cfgov/unprocessed/js/routes/owning-a-home/single.js
+++ b/cfgov/unprocessed/js/routes/owning-a-home/single.js
@@ -1,11 +1,9 @@
-'use strict';
-
-var EmailPopup = require( '../../organisms/EmailPopup' );
-var emailHelpers = require( '../../modules/util/email-popup-helpers' );
-var emailPopup = document.querySelectorAll( '.o-email-popup' );
+const EmailPopup = require( '../../organisms/EmailPopup' );
+const emailHelpers = require( '../../modules/util/email-popup-helpers' );
+const emailPopup = document.querySelectorAll( '.o-email-popup' );
 
 if ( emailPopup.length && emailHelpers.showEmailPopup() ) {
-  var popup = new EmailPopup( '.o-email-popup' );
+  const popup = new EmailPopup( '.o-email-popup' );
   popup.init();
   emailHelpers.showOnScroll( popup.el, {
     cb: popup.showPopup,


### PR DESCRIPTION
## Removals

- `.eslintignore` file.

## Changes

- Runs autofix linting options on /route/ and class-list scripts.

## Testing

1. `gulp build` should pass.
2. Site should not have any errors in the console in IE9.

## Notes

- I discovered `<!--[if IE 9]>` doesn't trigger in Browser Mode: IE9 Compatibility View, but does in Browser Mode: IE9. Also, our logo is blown up in Browser Mode: IE9. Anyone up on which is the default?

![screen shot 2017-12-14 at 5 02 26 pm](https://user-images.githubusercontent.com/704760/34016619-9aa5e006-e0f0-11e7-934a-56d1f51d3c18.png)
