### PR TITLE
No mobile view on IE9

### DIFF
--- a/cfgov/unprocessed/js/organisms/MegaMenu.js
+++ b/cfgov/unprocessed/js/organisms/MegaMenu.js
@@ -166,6 +166,15 @@ function MegaMenu( element ) {
    * suspends or resumes the mobile or desktop menu behaviors.
    */
   function _resizeHandler() {
+
+    /* If in Internet Explorer 9-, don't support mobile responsive view.
+       lt-ie10 class is added by modernizr. */
+    const htmlEl = document.body.parentElement;
+    let onlyDesktop = false;
+    if ( htmlEl.classList.contains( 'lt-ie10' ) ) {
+      onlyDesktop = true;
+    }
+
     if ( breakpointState.isInDesktop() ) {
       _mobileNav.suspend();
       _desktopNav.resume();

--- a/gulp/tasks/styles.js
+++ b/gulp/tasks/styles.js
@@ -55,6 +55,9 @@ function stylesIE9() {
     .pipe( gulpLess( configStyles.settings ) )
     .on( 'error', handleErrors )
     .pipe( gulpPostcss( [
+      postcssUnmq( {
+        width: '75em'
+      } ),
       autoprefixer( { browsers: BROWSER_LIST.ONLY_IE_9 } )
     ] ) )
     .pipe( gulpRename( {


### PR DESCRIPTION
There is a bug in IE9 (non-compatibility mode, which I believe is the default?) where the resize event will fire unexpectedly, causing the mobile menu to get stuck showing on load at mobile sizes. I believe this is because IE9 fires the resize event on resize of any elements on the page, not just the whole window. Instead of hacking around that, this PR turns off the mobile responsive view for IE9, like we do for IE8.

## Changes

- Disable mobile responsive view for IE9-.

## Testing

1. `gulp build` and check IE9 at mobile window sizes and observe it's still the desktop menu.

## Screenshots

Before:

![screen shot 2017-12-14 at 7 25 27 pm](https://user-images.githubusercontent.com/704760/34021018-76445872-e105-11e7-88e3-f0b27bf7fe66.png)

After:

![screen shot 2017-12-14 at 7 25 39 pm](https://user-images.githubusercontent.com/704760/34021019-766295d0-e105-11e7-9721-e44e50fac804.png)

