### PR TITLE
Fix for object.assign in IE

### DIFF
--- a/cfgov/unprocessed/js/modules/util/email-popup-helpers.js
+++ b/cfgov/unprocessed/js/modules/util/email-popup-helpers.js
@@ -1,3 +1,7 @@
+
+const _assign = require( './assign' ).assign;
+
+
 /**
  * Stores/retrieves email signup data in localStorage
  */
@@ -102,8 +106,7 @@ function showOnScroll( elToShow, opts ) {
     }
   };
 
-  opts = Object.assign( defaults, opts || {} );
-
+  opts = _assign( defaults, opts || {} );
 
   function _getScrollTargetPosition() {
     const elHeight = elToShow.offsetHeight;


### PR DESCRIPTION
IE doesn't support Object.assign

## Changes

- Modified code to use the utility function instead of `Object.assign`.

## Testing

1. Run `gulp scripts`.
2. Visit `https://www.consumerfinance.gov/owning-a-home/` in IE.
3. Scroll to the bottom of the page and check for errors in the console.


## Screenshots


## Notes

-

## Todos

-

## Checklist

* [ ] PR has an informative and human-readable title
* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [ ] Passes all existing automated tests
* [ ] Any *change* in functionality is tested
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated
* [ ] Reviewers requested with the [Reviewer tool](https://help.github.com/articles/about-pull-request-reviews/) :arrow_right:
