### PR TITLE
Mattermost alert failures shouldn't be fatal

### DIFF
--- a/cfgov/alerts/post_sqs_messages.py
+++ b/cfgov/alerts/post_sqs_messages.py
@@ -87,13 +87,20 @@ def process_sqs_message(message, github_alert, mattermost_alert):
         title=title,
         body=body
     )
+
     if mattermost_alert:
-        mattermost_alert.post(
-            text='Alert: {}. Github issue at {}'.format(
+        try:
+            mattermost_alert.post(text='Alert: {}. Github issue at {}'.format(
                 body,
                 issue.html_url
-            )
-        )
+            ))
+        except Exception:
+            # Mattermost failures should be considered non-fatal, as the alert
+            # has already been logged to GitHub. Failure here would mean that
+            # the alert wouldn't get popped off of the SQS queue, which would
+            # result in multiple repeated postings of the same alert to GH for
+            # as long as MM is down.
+            logger.exception('Failed to post message to Mattermost.')
 
 
 if __name__ == '__main__':

--- a/cfgov/alerts/tests/test_post_sqs_messages.py
+++ b/cfgov/alerts/tests/test_post_sqs_messages.py
@@ -43,3 +43,13 @@ class TestPostSQSMessages(TestCase):
             text=('Alert: Test Job # 1234 - Failed. '
                   'Github issue at https://github.com/foo/bar/issues/42')
         )
+
+    @patch('alerts.mattermost_alert.MattermostAlert.post',
+           side_effect=Exception)
+    @patch('alerts.github_alert.GithubAlert.post')
+    def test_mattermost_failure_ignored(self, gh, mm):
+        process_sqs_message(
+            {'Body': 'Test Job #1234 - Failed'},
+            GithubAlert({}),
+            MattermostAlert({})
+        )


### PR DESCRIPTION
This change modifies how Mattermost alert failures are handled as part of the SQS alert consumption process.

Currently, when an alert is read off of an incoming SQS queue, the process goes like this:

1. Peek at alert on top of queue.
2. Post alert to GH.
3. Post alert to MM.
4. Delete alert from queue.

If Mattermost happens to be down (as happened recently) and an alert comes it, it'll be repeatedly posted over and over to GH, because a failure at step 3 prevents alert cleanup at step 4.

This change catches exceptions from MM posts and logs them, instead of allowing the alert to exit the process.

In practice that means that if this script is run from e.g. Jenkins the Jenkins job will not fail just because MM is down.

## Changes

- Logic in [`alerts.post_sqs_messages.process_sqs_message`](https://github.com/cfpb/cfgov-refresh/blob/75277246d5533b31911e7a010c544c09210f6b66/cfgov/alerts/post_sqs_messages.py#L97) modified to catch and log Mattermost failures.

## Testing

1. See new unit test.

## Checklist

* [X] PR has an informative and human-readable title
* [X] Changes are limited to a single goal (no scope creep)
* [X] Code can be automatically merged (no conflicts)
* [X] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [X] Passes all existing automated tests
* [X] Any *change* in functionality is tested
* [X] Reviewers requested with the [Reviewer tool](https://help.github.com/articles/about-pull-request-reviews/) :arrow_right:
