### PR TITLE
Remove logging of page filtering

### DIFF
--- a/cfgov/v1/models/sublanding_page.py
+++ b/cfgov/v1/models/sublanding_page.py
@@ -95,7 +95,7 @@ class SublandingPage(CFGOVPage):
                 CFGOVPage.objects.child_of_q(page)
             )
 
-            logger.info('Filtering by parent {}'.format(page))
+            logger.debug('Filtering by parent {}'.format(page))
             form = FilterableListForm(base_query=base_query)
             for post in form.get_page_set():
                 posts_list.append(post)

--- a/cfgov/v1/models/sublanding_page.py
+++ b/cfgov/v1/models/sublanding_page.py
@@ -1,5 +1,3 @@
-import logging
-
 from wagtail.wagtailadmin.edit_handlers import (
     ObjectList,
     StreamFieldPanel,
@@ -16,8 +14,6 @@ from v1.atomic_elements import molecules, organisms
 from v1.forms import FilterableListForm
 from v1.models.base import CFGOVPage
 from v1.models.learn_page import AbstractFilterPage
-
-logger = logging.getLogger(__name__)
 
 
 class SublandingPage(CFGOVPage):
@@ -95,7 +91,6 @@ class SublandingPage(CFGOVPage):
                 CFGOVPage.objects.child_of_q(page)
             )
 
-            logger.debug('Filtering by parent {}'.format(page))
             form = FilterableListForm(base_query=base_query)
             for post in form.get_page_set():
                 posts_list.append(post)

--- a/cfgov/v1/util/categories.py
+++ b/cfgov/v1/util/categories.py
@@ -1,8 +1,4 @@
-import logging
-
 from v1.util import ref
-
-logger = logging.getLogger(__name__)
 
 
 def clean_categories(selected_categories):
@@ -23,5 +19,4 @@ def clean_categories(selected_categories):
                 unicorn = 'Research Report'
             for category in subcategories_dict[unicorn.title()]:
                 selected_categories.append(category[0].lower())
-    logger.debug('Filtering by categories {}'.format(selected_categories))
     return selected_categories

--- a/cfgov/v1/util/categories.py
+++ b/cfgov/v1/util/categories.py
@@ -23,5 +23,5 @@ def clean_categories(selected_categories):
                 unicorn = 'Research Report'
             for category in subcategories_dict[unicorn.title()]:
                 selected_categories.append(category[0].lower())
-    logger.info('Filtering by categories {}'.format(selected_categories))
+    logger.debug('Filtering by categories {}'.format(selected_categories))
     return selected_categories


### PR DESCRIPTION
This change modifies the logging in two places where pages get filtered. ~~Right now these filters get logged at the `INFO` level, which means they go to the console and log files by default.~~

~~This fills up the logs with filtering every time a filter is chosen, which seems overly verbose. If we want these to be logged, could we instead log them to `DEBUG`?~~ Per feedback from @richaagarwal below, I'm just removing these logging statements.

## Changes

- ~~Reduce filter logging from INFO to DEBUG.~~ Remove filter logging.

## Checklist

* [X] PR has an informative and human-readable title
* [X] Changes are limited to a single goal (no scope creep)
* [X] Code can be automatically merged (no conflicts)
* [X] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [X] Passes all existing automated tests
* [ ] Any *change* in functionality is tested
* [X] Reviewers requested with the [Reviewer tool](https://help.github.com/articles/about-pull-request-reviews/) :arrow_right:
