### PR TITLE
Push docs to gh-pages on every merge to master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,21 +16,36 @@ cache:
 install:
   - ./install_travis.sh
 
-env:
-  global:
-    - TOXENV=py27
-    - DJANGO_SETTINGS_MODULE=cfgov.settings.test
-    - DJANGO_STAGING_HOSTNAME=content.localhost
-    - COVERALLS_PARALLEL=true
-
-  matrix:
-    - RUNTEST=frontend
-    - RUNTEST=backend
-    - RUNTEST=acceptance
-
 branches:
   only:
     - master
 
 script:
   - ./run_travis.sh
+
+env:
+  global:
+    - TOXENV=py27
+    - DJANGO_SETTINGS_MODULE=cfgov.settings.test
+    - DJANGO_STAGING_HOSTNAME=content.localhost
+    - COVERALLS_PARALLEL=true
+ 
+jobs:
+  include:
+  - stage: run tests
+    env: RUNTEST=frontend
+  - env: RUNTEST=backend
+  - env: RUNTEST=acceptance
+  - stage: build documentation
+    script: 
+      - pip install virtualenv virtualenvwrapper
+      - source activate-virtualenv.sh
+      - pip install -r requirements/manual.txt
+      - mkdocs build
+     deploy:
+      provider: pages
+      local_dir: site
+      skip-cleanup: true
+      github_token: $GITHUB_TOKEN
+      on:
+        branch: master

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ jobs:
       - source activate-virtualenv.sh
       - pip install -r requirements/manual.txt
       - mkdocs build
-     deploy:
+  - deploy:
       provider: pages
       local_dir: site
       skip-cleanup: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,12 +37,14 @@ jobs:
   - env: RUNTEST=backend
   - env: RUNTEST=acceptance
   - stage: build documentation
+    env: BUILDING_DOCS=1
     script: 
       - pip install virtualenv virtualenvwrapper
       - source activate-virtualenv.sh
       - pip install -r requirements/manual.txt
       - mkdocs build
-  - deploy:
+  - stage: deploy documentation
+    deploy:
       provider: pages
       local_dir: site
       skip-cleanup: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,6 @@ dist: trusty
 python:
   - "2.7"
 
-addons:
-  chrome: beta
 
 cache:
   pip: true
@@ -36,6 +34,8 @@ jobs:
     env: RUNTEST=frontend
   - env: RUNTEST=backend
   - env: RUNTEST=acceptance
+    addons:
+      chrome: beta
   - stage: build documentation
     script: 
       - pip install virtualenv virtualenvwrapper

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,6 @@ jobs:
   - env: RUNTEST=backend
   - env: RUNTEST=acceptance
   - stage: build documentation
-    env: BUILDING_DOCS=1
     script: 
       - pip install virtualenv virtualenvwrapper
       - source activate-virtualenv.sh


### PR DESCRIPTION
This re-arranges our Travis yml to use the [build stages feature](https://docs.travis-ci.com/user/build-stages/), and adds config to generate our documentation and push it to https://cfpb.github.io/cfgov-refresh/ on every merge to master.

Build stages are necessary, so that the deploy only runs once, if the three testing jobs pass.

## Additions

- deployment configuration

## Changes

- adapt config to Travis's "build stages" feature.
- Moved the 'addons: chrome' declaration to the acceptance test job. This should make builds a bit faster, since Chrome will only be installed for the acceptance tests (it was previously running even on the backend tests, [for example](https://travis-ci.org/cfpb/cfgov-refresh/jobs/317128510))

## Testing

Check any build from this PR to see build stages in action: https://travis-ci.org/cfpb/cfgov-refresh/builds/318118271

There will be no actual pushes to GitHub pages until it's merged in to master, but if you look at the log on the deploy task, you'll see:

`Skipping a deployment with the pages provider because the current build is a pull request.`

## Checklist

* [ ] PR has an informative and human-readable title
* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [ ] Passes all existing automated tests
* [ ] Any *change* in functionality is tested
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated
* [ ] Reviewers requested with the [Reviewer tool](https://help.github.com/articles/about-pull-request-reviews/) :arrow_right:
