### PR TITLE
Travis: merge documentation build and deploy stages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ jobs:
   - env: RUNTEST=acceptance
     addons:
       chrome: beta
-  - stage: build documentation
+  - stage: Update documentation
     script: 
       - pip install virtualenv virtualenvwrapper
       - source activate-virtualenv.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,6 @@ jobs:
       - source activate-virtualenv.sh
       - pip install -r requirements/manual.txt
       - mkdocs build
-  - stage: deploy documentation
     deploy:
       provider: pages
       local_dir: site


### PR DESCRIPTION
PR #3688 contained a flaw, where the documentation deployment job didn't have access to the 'site' directory created in the documentation *build* job.

This should merge the two into a single job (I hope)

It seems to work, but (again) we can't tell for sure until it's merged: https://travis-ci.org/cfpb/cfgov-refresh/jobs/318150030



## Todos

-

## Checklist

* [ ] PR has an informative and human-readable title
* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [ ] Passes all existing automated tests
* [ ] Any *change* in functionality is tested
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated
* [ ] Reviewers requested with the [Reviewer tool](https://help.github.com/articles/about-pull-request-reviews/) :arrow_right:
