### PR TITLE
Bump optional complaint requirement to 1.4.5

### DIFF
--- a/requirements/optional-public.txt
+++ b/requirements/optional-public.txt
@@ -1,5 +1,5 @@
 https://github.com/cfpb/college-costs/releases/download/2.3.12/college_costs-2.3.12-py2-none-any.whl
-https://github.com/cfpb/complaint/releases/download/1.4.4/complaintdatabase-1.4.4-py2-none-any.whl
+https://github.com/cfpb/complaint/releases/download/1.4.5/complaintdatabase-1.4.5-py2-none-any.whl
 https://github.com/cfpb/owning-a-home-api/releases/download/0.10.2/owning_a_home_api-0.10.2-py2-none-any.whl
 https://github.com/cfpb/regulations-core/releases/download/1.2.6/regcore-1.2.6-py2-none-any.whl
 https://github.com/cfpb/regulations-site/releases/download/2.1.17/regulations-2.1.17-py2-none-any.whl


### PR DESCRIPTION
This change bumps the version of the optional complaint requirement from 1.4.4 to [1.4.5](https://github.com/cfpb/complaint/releases/tag/1.4.5).

This removes some deprecated processing that was spamming the error log with harmless (but useless) errors.

## Changes

- Bump the complaint app to 1.4.5.

## Checklist

* [X] PR has an informative and human-readable title
* [X] Changes are limited to a single goal (no scope creep)
* [X] Code can be automatically merged (no conflicts)
* [X] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [X] Passes all existing automated tests
* [X] Any *change* in functionality is tested
* [X] Reviewers requested with the [Reviewer tool](https://help.github.com/articles/about-pull-request-reviews/) :arrow_right:
