### PR TITLE
Update owning-a-home-api release

### DIFF
--- a/requirements/optional-public.txt
+++ b/requirements/optional-public.txt
@@ -1,6 +1,6 @@
 https://github.com/cfpb/college-costs/releases/download/2.3.12/college_costs-2.3.12-py2-none-any.whl
 https://github.com/cfpb/complaint/releases/download/1.4.5/complaintdatabase-1.4.5-py2-none-any.whl
-https://github.com/cfpb/owning-a-home-api/releases/download/0.10.2/owning_a_home_api-0.10.2-py2-none-any.whl
+https://github.com/cfpb/owning-a-home-api/releases/download/0.10.3/owning_a_home_api-0.10.3.dev0.2a2b9b1-py2-none-any.whl
 https://github.com/cfpb/regulations-core/releases/download/1.2.6/regcore-1.2.6-py2-none-any.whl
 https://github.com/cfpb/regulations-site/releases/download/2.1.17/regulations-2.1.17-py2-none-any.whl
 https://github.com/cfpb/retirement/releases/download/0.5.14/retirement-0.5.14-py2-none-any.whl

--- a/requirements/optional-public.txt
+++ b/requirements/optional-public.txt
@@ -1,6 +1,6 @@
 https://github.com/cfpb/college-costs/releases/download/2.3.12/college_costs-2.3.12-py2-none-any.whl
 https://github.com/cfpb/complaint/releases/download/1.4.5/complaintdatabase-1.4.5-py2-none-any.whl
-https://github.com/cfpb/owning-a-home-api/releases/download/0.10.3/owning_a_home_api-0.10.3.dev0.2a2b9b1-py2-none-any.whl
+https://github.com/cfpb/owning-a-home-api/releases/download/0.10.3/owning_a_home_api-0.10.3-py2-none-any.whl
 https://github.com/cfpb/regulations-core/releases/download/1.2.6/regcore-1.2.6-py2-none-any.whl
 https://github.com/cfpb/regulations-site/releases/download/2.1.17/regulations-2.1.17-py2-none-any.whl
 https://github.com/cfpb/retirement/releases/download/0.5.14/retirement-0.5.14-py2-none-any.whl


### PR DESCRIPTION
This bumps the oahapi version to 0.10.3 for an annual update

