### PR TITLE
Disabling acceptance testing on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,17 +27,16 @@ env:
     - DJANGO_SETTINGS_MODULE=cfgov.settings.test
     - DJANGO_STAGING_HOSTNAME=content.localhost
     - COVERALLS_PARALLEL=true
- 
+
 jobs:
   include:
   - stage: run tests
     env: RUNTEST=frontend
   - env: RUNTEST=backend
-  - env: RUNTEST=acceptance
     addons:
       chrome: beta
   - stage: Update documentation
-    script: 
+    script:
       - pip install virtualenv virtualenvwrapper
       - source activate-virtualenv.sh
       - pip install -r requirements/manual.txt


### PR DESCRIPTION
Due to issues with the acceptance tests hanging and other quirks, I'm disabling them until I can better analyze the issues surrounding their usage.

## Checklist

* [ ] PR has an informative and human-readable title
* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [ ] Passes all existing automated tests
* [ ] Any *change* in functionality is tested
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated
* [ ] Reviewers requested with the [Reviewer tool](https://help.github.com/articles/about-pull-request-reviews/) :arrow_right:
