### PR TITLE
 Add ability to expose page drafts based on feature flag state

### DIFF
--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -639,6 +639,11 @@ FLAGS = {
 
     # Teacher's Digital Platform
     'TDP_RELEASE': {},
+
+    # For Wagtail pages that need to expose their latest drafts on beta
+    'EXPOSE_DRAFT_ON_BETA': {
+        'site': 'beta.consumerfinance.gov',
+    },
 }
 
 

--- a/cfgov/v1/migrations/0098_cfgovpage_flaggablepagemixin.py
+++ b/cfgov/v1/migrations/0098_cfgovpage_flaggablepagemixin.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('v1', '0097_move_reusable_text_chooser_block'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='cfgovpage',
+            name='feature_flag_name',
+            field=models.CharField(max_length=64, blank=True),
+        ),
+        migrations.AddField(
+            model_name='cfgovpage',
+            name='show_draft_with_feature_flag',
+            field=models.BooleanField(default=False, help_text=b"Whether a this page's latest draft will appear when the selected feature flag is enabled", verbose_name=b'show draft with feature flag'),
+        ),
+    ]

--- a/cfgov/v1/models/base.py
+++ b/cfgov/v1/models/base.py
@@ -22,6 +22,7 @@ from wagtail.wagtailcore.models import (
 )
 from wagtail.wagtailimages.edit_handlers import ImageChooserPanel
 
+from flags.models import FlaggablePageMixin
 from modelcluster.fields import ParentalKey
 from modelcluster.tags import ClusterTaggableManager
 from taggit.models import TaggedItemBase
@@ -53,10 +54,11 @@ class BaseCFGOVPageManager(PageManager):
     def get_queryset(self):
         return PageQuerySet(self.model).order_by('path')
 
+
 CFGOVPageManager = BaseCFGOVPageManager.from_queryset(PageQuerySet)
 
 
-class CFGOVPage(Page):
+class CFGOVPage(Page, FlaggablePageMixin):
     authors = ClusterTaggableManager(through=CFGOVAuthoredPages, blank=True,
                                      verbose_name='Authors',
                                      help_text='A comma separated list of '
@@ -116,6 +118,7 @@ class CFGOVPage(Page):
         FieldPanel('authors', 'Authors'),
         MultiFieldPanel(Page.settings_panels, 'Scheduled Publishing'),
         FieldPanel('language', 'language'),
+        MultiFieldPanel(FlaggablePageMixin.flag_panels, 'Feature flag'),
     ]
 
     # Tab handler interface guide because it must be repeated for each subclass
@@ -251,6 +254,9 @@ class CFGOVPage(Page):
             hook(self, request, context, *args, **kwargs)
         return context
 
+    def route(self, request, path_components):
+        return self.route_flaggable(request, path_components)
+
     def serve(self, request, *args, **kwargs):
         """
         If request is ajax, then return the ajax request handler response, else
@@ -262,7 +268,7 @@ class CFGOVPage(Page):
         # Force the page's language on the request
         translation.activate(self.language)
         request.LANGUAGE_CODE = translation.get_language()
-        return super(CFGOVPage, self).serve(request, *args, **kwargs)
+        return self.serve_flaggable(request, *args, **kwargs)
 
     def _return_bad_post_response(self, request):
         if request.is_ajax():

--- a/cfgov/v1/models/base.py
+++ b/cfgov/v1/models/base.py
@@ -118,7 +118,8 @@ class CFGOVPage(Page, FlaggablePageMixin):
         FieldPanel('authors', 'Authors'),
         MultiFieldPanel(Page.settings_panels, 'Scheduled Publishing'),
         FieldPanel('language', 'language'),
-        MultiFieldPanel(FlaggablePageMixin.flag_panels, 'Feature flag'),
+        MultiFieldPanel(FlaggablePageMixin.flag_panels,
+                        'Feature flagged drafts'),
     ]
 
     # Tab handler interface guide because it must be repeated for each subclass

--- a/cfgov/v1/models/learn_page.py
+++ b/cfgov/v1/models/learn_page.py
@@ -66,6 +66,7 @@ class AbstractFilterPage(CFGOVPage):
             FieldPanel('comments_close_by'),
         ], 'Relevant Dates', classname='collapsible'),
         MultiFieldPanel(Page.settings_panels, 'Scheduled Publishing'),
+        MultiFieldPanel(CFGOVPage.flag_panels, 'Feature flag'),
     ]
 
     # This page class cannot be created.

--- a/cfgov/v1/models/learn_page.py
+++ b/cfgov/v1/models/learn_page.py
@@ -66,7 +66,7 @@ class AbstractFilterPage(CFGOVPage):
             FieldPanel('comments_close_by'),
         ], 'Relevant Dates', classname='collapsible'),
         MultiFieldPanel(Page.settings_panels, 'Scheduled Publishing'),
-        MultiFieldPanel(CFGOVPage.flag_panels, 'Feature flag'),
+        MultiFieldPanel(CFGOVPage.flag_panels, 'Feature flagged drafts'),
     ]
 
     # This page class cannot be created.

--- a/refresh-data.sh
+++ b/refresh-data.sh
@@ -24,6 +24,8 @@ refresh_data(){
 	./create-mysql-db.sh
 	echo 'Importing refresh db'
 	mysql v1 --user='root' --password="$MYSQL_ROOT_PW" < $refresh_dump_name
+	echo 'Running migrations'
+    ./cfgov/manage.py migrate --noinput
 	echo 'Setting up initial data'
 	./cfgov/manage.py runscript initial_data
 }

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -49,7 +49,7 @@ unicodecsv==0.14.1
 unipath>=1.1,<=2.0
 vobject==0.9.1
 wagtail==1.10.1
-wagtail-flags==2.0.7
+wagtail-flags==2.0.8
 wagtail-inventory==0.3
 wagtail-sharing==0.5
 Wand==0.4.2


### PR DESCRIPTION
This PR brings in support for Wagtail-Flags's flaggable pages: https://github.com/cfpb/wagtail-flags/pull/21

Flaggable pages allow for page drafts to be exposed live instead of the published copy of a page based on feature flag state. When "Show draft" is selected and the specified feature flag is enabled, the latest draft will be shown at the page's URL instead of the published page. See the Wagtail-Flags PR for more details.

## Additions

- `EXPOSE_DRAFT_ON_BETA` feature flag that is enabled when the Wagtail site is beta.consumerfinance.gov.

## Changes

- Add Wagtail-Flags's `FlaggablePageMixin` as a superclass of `CFGOVPage`
- Bumped the Wagtail-Flags requirement in anticipation of release.

## Testing

1. `cd develop-apps`
2. `git clone https://github.com/cfpb/wagtail-flags`
3. `cd wagtail-flags`
4. `git checkout flagged-page`

Testing is possible with the docker setup:

1. `cd ../../`
2. `docker-compose build python`
3. `docker-compose up`

Or with the non-docker setup with your cfgov-refresh virtualenv active:

1. `pip uninstall wagtail-flags`
2. `pip install -e wagtail-flags`
3. `cd ../../`
4. `./runserver.sh`

Then test in Wagtail:

1. Visit http://localhost:8000/admin/ and add a BrowsePage
2. In "Configuration", under "Feature flag", check the box and select the `EXPOSE_DRAFT_ON_BETA` feature flag.
3. Publish the page
4. Make changes to the page and save them as draft.
5. Visit the page and see that the draft changes are not exposed.
6. In "Settings" -> "Feature Flags" add a condition for `EXPOSE_DRAFT_ON_BETA` to be enabled when `boolean` is `True`.
5. Visit the page and see that the draft changes *are* exposed.

## Screenshots

![screenshot_page](https://user-images.githubusercontent.com/10562538/34265017-bf3fc268-e642-11e7-96b5-3b3bb8300ece.png)

## Checklist

* [x] PR has an informative and human-readable title
* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [x] Passes all existing automated tests
* [x] Any *change* in functionality is tested
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [x] Project documentation has been updated
* [x] Reviewers requested with the [Reviewer tool](https://help.github.com/articles/about-pull-request-reviews/) :arrow_right:
