### PR TITLE
Serve latest draft page for specific pages via a wagtail hook on beta

### DIFF
--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -664,3 +664,9 @@ MAX_ALLOWED_TIME_OFFSET = 5
 # Search.gov values
 SEARCH_DOT_GOV_AFFILIATE = os.environ.get('SEARCH_DOT_GOV_AFFILIATE')
 SEARCH_DOT_GOV_ACCESS_KEY = os.environ.get('SEARCH_DOT_GOV_ACCESS_KEY')
+
+# We want the ability to serve the latest drafts of some pages on beta.
+# This value is read by v1.wagtail_hooks.
+SERVE_LATEST_DRAFT_PAGES = []
+if DEPLOY_ENVIRONMENT == 'beta':
+    SERVE_LATEST_DRAFT_PAGES = [1288]

--- a/cfgov/v1/tests/test_wagtail_hooks.py
+++ b/cfgov/v1/tests/test_wagtail_hooks.py
@@ -7,7 +7,6 @@ import mock
 
 from v1.wagtail_hooks import (
     RelativePageLinkHandler, check_permissions, form_module_handlers,
-    serve_latest_draft_page
 )
 
 

--- a/cfgov/v1/wagtail_hooks.py
+++ b/cfgov/v1/wagtail_hooks.py
@@ -192,3 +192,12 @@ def register_frank_menu_item():
 def register_flag_admin_urls():
     handler = 'v1.admin_views.manage_cdn'
     return [url(r'^cdn/$', handler, name='manage-cdn'), ]
+
+
+@hooks.register('before_serve_page')
+def serve_latest_draft_page(page, request, args, kwargs):
+    if page.pk in settings.SERVE_LATEST_DRAFT_PAGES:
+        latest_draft = page.get_latest_revision_as_page()
+        response = latest_draft.serve(request, *args, **kwargs)
+        response['Serving-Wagtail-Draft'] = '1'
+        return response


### PR DESCRIPTION
This PR enables us to serve specific page primary keys specified in settings on beta.consumerfinance.gov. This is intended to be as non-invasive as possible as we come up with a more long-term solution for previewing content.

## Additions

- `SERVE_LATEST_DRAFT_PAGES` added to settings and page pk 1288 configured on beta
- `serve_latest_draft_page` wagtail hook added that consumes `SERVE_LATEST_DRAFT_PAGES`

## Notes

This code is all @chosak's. I'm just an ape swinging from git branch to git branch.

## Checklist

* [ ] PR has an informative and human-readable title
* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [ ] Passes all existing automated tests
* [ ] Any *change* in functionality is tested
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated
* [ ] Reviewers requested with the [Reviewer tool](https://help.github.com/articles/about-pull-request-reviews/) :arrow_right:
