### PR TITLE
Even simpler approach to flagged drafts

### DIFF
--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -639,6 +639,9 @@ FLAGS = {
 
     # Teacher's Digital Platform
     'TDP_RELEASE': {},
+
+    # Serve some pages with their draft content.
+    'SERVE_AS_DRAFT': {},
 }
 
 
@@ -664,9 +667,3 @@ MAX_ALLOWED_TIME_OFFSET = 5
 # Search.gov values
 SEARCH_DOT_GOV_AFFILIATE = os.environ.get('SEARCH_DOT_GOV_AFFILIATE')
 SEARCH_DOT_GOV_ACCESS_KEY = os.environ.get('SEARCH_DOT_GOV_ACCESS_KEY')
-
-# We want the ability to serve the latest drafts of some pages on beta.
-# This value is read by v1.wagtail_hooks.
-SERVE_LATEST_DRAFT_PAGES = []
-if DEPLOY_ENVIRONMENT == 'beta':
-    SERVE_LATEST_DRAFT_PAGES = [1288]

--- a/cfgov/v1/tests/test_wagtail_hooks.py
+++ b/cfgov/v1/tests/test_wagtail_hooks.py
@@ -174,12 +174,13 @@ class TestServeLatestDraftPage(TestCase):
         self.page.title = 'draft'
         self.page.save_revision()
 
-    @override_settings(SERVE_LATEST_DRAFT_PAGES=[])
+    @override_settings(FLAGS={})
     def test_not_serving_draft_serves_published_revision(self):
         response = self.client.get('/test/')
         self.assertContains(response, 'live')
         self.assertIsNone(response.get('Serving-Wagtail-Draft'))
 
+    @override_settings(FLAGS={'SERVE_AS_DRAFT': {'path matches': '^/test/$'}})
     def test_serving_draft_serves_latest_revision_and_adds_header(self):
         with override_settings(SERVE_LATEST_DRAFT_PAGES=[self.page.pk]):
             response = self.client.get('/test/')

--- a/cfgov/v1/wagtail_hooks.py
+++ b/cfgov/v1/wagtail_hooks.py
@@ -7,6 +7,7 @@ from django.core.exceptions import PermissionDenied
 from django.core.urlresolvers import reverse
 from django.utils.html import escape, format_html_join
 
+from flags.state import flag_enabled
 from wagtail.wagtailadmin.menu import MenuItem
 from wagtail.wagtailcore import hooks
 from wagtail.wagtailcore.models import Page
@@ -196,7 +197,7 @@ def register_flag_admin_urls():
 
 @hooks.register('before_serve_page')
 def serve_latest_draft_page(page, request, args, kwargs):
-    if page.pk in settings.SERVE_LATEST_DRAFT_PAGES:
+    if flag_enabled('SERVE_AS_DRAFT', request=request):
         latest_draft = page.get_latest_revision_as_page()
         response = latest_draft.serve(request, *args, **kwargs)
         response['Serving-Wagtail-Draft'] = '1'


### PR DESCRIPTION
This change is a follow up / alternative to #3707 to support exposure of draft content given certain conditions. Instead of relying on a hardcoded set of page primary keys, it utilizes built-in [wagtail-flags](https://github.com/cfpb/wagtail-flags) capability to control draft exposure via feature flag.

So, for example, Wagtail users could create a flag for a particular site with the condition:

`"path matches": "/path/to/page/"`

and that page will be served with its draft content. A more complicated regular expression would support multiple pages like this, e.g.

`"patch matches": "/page1/|/page2/"`

This lets draft serving be controlled through the Wagtail UI, instead of relying on code changes.

## Removals

- Remove hardcoded set of draft page PKs.

## Changes

- Change draft serving logic to rely on built-in feature flag capability.

## Testing

1. Create a feature flag in the UI for flag `SERVE_AS_DRAFT` with the condition `"path matches": "/path/to/your/page/"`. View that page at its published URL and you should see the draft content there.

## Todos

- Create feature flags in the Wagtail UI for any pages that need to be served like this.

## Checklist

* [X] PR has an informative and human-readable title
* [X] Changes are limited to a single goal (no scope creep)
* [X] Code can be automatically merged (no conflicts)
* [X] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [X] Passes all existing automated tests
* [X] Any *change* in functionality is tested
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [X] Visually tested in supported browsers and devices
* [X] Reviewers requested with the [Reviewer tool](https://help.github.com/articles/about-pull-request-reviews/) :arrow_right:
