### PR TITLE
Refactor for script loading in base.html

### DIFF
--- a/cfgov/jinja2/v1/_layouts/base.html
+++ b/cfgov/jinja2/v1/_layouts/base.html
@@ -252,10 +252,25 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
 {% block javascript scoped %}
 
+
+{#
+  Modernizr adds a no-js class the HTML element if ECMAScript 5 features aren't
+  available. Check for that CSS class here and act accordingly.
+#}
+
 <script>
-    {# Minified dynamic JavaScript loader that injects a script tag in the head
-       of the page. It also provides a callback parameter. #}
-    function loadScript(t,e){var n=document.createElement('script');n.type='text/javascript',n.onload=function(){return e?e():null},n.src=t,document.getElementsByTagName('head')[0].appendChild(n)}
+  if ( document.body.parentElement.className.indexOf( 'no-js' ) === -1 ) {
+    {# Include site-wide JavaScript. #}
+    var a = [ '{{ static('js/routes/common.js') }}' ];
+    {# Check and include template-level JavaScript. #}
+    {% macro template_js() %}
+       {% include 'js/routes/' + request.path.split('/')[1] + '/single.js' ignore missing %}
+    {% endmacro %}
+    {% set js_source = template_js() | trim %}
+    {% if js_source | length > 0 %}
+      a.push( '{{ static('js/routes/' + request.path.split('/')[1] + '/single.js') }}' );
+    {% endif %}
+
 
     {#
       Check and include component-level JavaScript.
@@ -263,35 +278,11 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
       unprocessed/js/routes/on-demand/[component].js
       to the page, based on what components were added in Wagtail.
     #}
-    function loadScriptComponent(){
-      {% if page and page.media %}
-         {% for js in page.media %}
-           loadScript('{{ static('js/routes/on-demand/' + js) }}');
-         {% endfor %}
-      {% endif %}
-    }
-
-    {#
-      TODO: Remove the below blocks when all pages
-            using this template are moved to Wagtail.
-            This moves us away from a URL-dependant script inclusion scheme.
-    #}
-
-    {#
-      Check and include template-level JavaScript.
-      Template-level JavaScript applies to all pages under the URL scheme
-      www.consumerfinance.gov/[app-url]/
-      and JavaScript appears in unprocessed/js/routes/[app-url]/single.js.
-    #}
-    function loadScriptTemplate(){
-      {% macro template_js() %}
-         {% include 'js/routes/' + request.path.split('/')[1] + '/single.js' ignore missing %}
-      {% endmacro %}
-      {% set js_source = template_js() | trim %}
-      {% if js_source | length > 0 %}
-        loadScript('{{ static('js/routes/' + request.path.split('/')[1] + '/single.js') }}');
-      {% endif %}
-    }
+    {% if page and page.media %}
+       {% for js in page.media %}
+         a.push( '{{ static('js/routes/on-demand/' + js) }}' );
+       {% endfor %}
+    {% endif %}
 
     {#
       Check and include page-level JavaScript.
@@ -299,36 +290,23 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
       www.consumerfinance.gov/[app-url]/somepage
       and JavaScript appears in unprocessed/js/routes/[app-url]/index.js.
     #}
-    function loadScriptPage(){
-      {# Check and include page-level JavaScript. #}
-      {% macro page_js() %}
-         {% include 'js/routes/' + request.path[1:] + 'index.js' ignore missing %}
-      {% endmacro %}
-      {% set js_source = page_js() | trim %}
-      {% if js_source | length > 0 %}
-        loadScript('{{ static('js/routes/' + request.path[1:] + 'index.js') }}');
-      {% endif %}
-    }
+    {% macro page_js() %}
+       {% include 'js/routes/' + request.path[1:] + 'index.js' ignore missing %}
+    {% endmacro %}
+    {% set js_source = page_js() | trim %}
+    {% if js_source | length > 0 %}
+      a.push( '{{ static('js/routes/' + request.path[1:] + 'index.js') }}' );
+    {% endif %}
 
-    {#
-      Modernizr adds a no-js class the HTML element if ECMAScript 5 features
-      are not available. Check for that CSS class here and act accordingly.
-    #}
-    if (document.body.parentElement.className.indexOf('no-js')===-1){
-      {# Include site-wide JavaScript. #}
-      loadScript('{{ static('js/routes/common.js') }}', function(){
-        loadScriptTemplate();loadScriptComponent();loadScriptPage();
-      });
-    }
+    {# Minified dynamic JavaScript loader that injects a script tag in the head
+      of the page. It also provides a callback parameter. #}
+    var b,c,d=[],f=document.scripts[0];function g(){for(var e;d[0]&&'loaded'==d[0].readyState;)e=d.shift(),e.onreadystatechange=null,f.parentNode.insertBefore(e,f)}for(;b=a.shift();)'async'in f?(c=document.createElement('script'),c.async=!1,c.src=b,document.head.appendChild(c)):f.readyState&&(c=document.createElement('script'),d.push(c),c.onreadystatechange=g,c.src=b);
+  }
+
+  var usasearch_config = { siteHandle: 'cfpb' };
 </script>
 
-<script>
-//<![CDATA[
-    var usasearch_config = { siteHandle: 'cfpb' };
-    loadScript('https://search.usa.gov/assets/sayt_loader.js');
-//]]>
-</script>
-
+<script async="true" src="https://search.usa.gov/javascripts/remote.loader.js"></script>
 {% endblock javascript %}
 
 <!--[if gt IE 8]><!-->

--- a/cfgov/jinja2/v1/_layouts/base.html
+++ b/cfgov/jinja2/v1/_layouts/base.html
@@ -117,7 +117,7 @@
     PRELOADING DYNAMIC ASSETS
     ======
 #}
-<link rel="preload" src="{{ static('js/routes/common.js') }}" as="script">
+<link rel="preload" href="{{ static('js/routes/common.js') }}" as="script">
 
 {#
     ============

--- a/cfgov/jinja2/v1/_layouts/base.html
+++ b/cfgov/jinja2/v1/_layouts/base.html
@@ -316,7 +316,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   var usasearch_config = { siteHandle: 'cfpb' };
 </script>
 
-<script async src="https://search.usa.gov/javascripts/remote.loader.js"></script>
+<script async src="https://search.usa.gov/assets/sayt_loader.js"></script>
 {% endblock javascript %}
 
 <!--[if gt IE 8]><!-->

--- a/cfgov/jinja2/v1/_layouts/base.html
+++ b/cfgov/jinja2/v1/_layouts/base.html
@@ -313,7 +313,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   var usasearch_config = { siteHandle: 'cfpb' };
 </script>
 
-<script async="true" src="https://search.usa.gov/javascripts/remote.loader.js"></script>
+<script async src="https://search.usa.gov/javascripts/remote.loader.js"></script>
 {% endblock javascript %}
 
 <!--[if gt IE 8]><!-->

--- a/cfgov/jinja2/v1/_layouts/base.html
+++ b/cfgov/jinja2/v1/_layouts/base.html
@@ -262,13 +262,18 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   Modernizr adds a no-js class the HTML element if ECMAScript 5 features aren't
   available. Check for that CSS class here and act accordingly.
 #}
-
 <script async>
   if ( document.body.parentElement.className.indexOf( 'no-js' ) === -1 ) {
     !function(){
     {# Include site-wide JavaScript. #}
     var a = [ '{{ static('js/routes/common.js') }}' ];
-    {# Check and include template-level JavaScript. #}
+
+    {#
+      Check and include template-level JavaScript.
+      Template-level JavaScript applies to all pages under the URL scheme
+      www.consumerfinance.gov/[app-url]/
+      and JavaScript appears in unprocessed/js/routes/[app-url]/single.js.
+    #}
     {% macro template_js() %}
        {% include 'js/routes/' + request.path.split('/')[1] + '/single.js' ignore missing %}
     {% endmacro %}
@@ -276,7 +281,6 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
     {% if js_source | length > 0 %}
       a.push( '{{ static('js/routes/' + request.path.split('/')[1] + '/single.js') }}' );
     {% endif %}
-
 
     {#
       Check and include component-level JavaScript.
@@ -304,9 +308,8 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
       a.push( '{{ static('js/routes/' + request.path[1:] + 'index.js') }}' );
     {% endif %}
 
-    {# Minified dynamic JavaScript loader that injects a script tag in the head
-      of the page. It also provides a callback parameter. #}
-    var b,c,d="async"in document.createElement("script");for(;b=a.shift();)c=document.createElement("script"),d&&(c.async=!1),c.src=b,document.head.appendChild(c);
+    {# Minified dynamic JavaScript loader that injects a script tag in the head of the page #}
+    for(var b,c,d=[],f=document.scripts[0];b=a.shift();)c=document.createElement("script"),"async"in c?(c.async=!1,c.src=b,document.head.appendChild(c)):(d.push(c),c.onreadystatechange=function(){for(var e;d[0]&&"loaded"==d[0].readyState;)e=d.shift(),e.onreadystatechange=null,f.parentNode.insertBefore(e,f)},c.src=b);
     }();
   }
 

--- a/cfgov/jinja2/v1/_layouts/base.html
+++ b/cfgov/jinja2/v1/_layouts/base.html
@@ -97,7 +97,6 @@
     {# End of Open Graph properties #}
 
     <link rel="shortcut icon" type="image/x-icon" href="{{ static('assets/favicon.ico') }}">
-
 {#
     ======
     STYLES
@@ -112,6 +111,13 @@
 <!--[if IE 9]><link rel="stylesheet" href="{{ static('css/main.ie9.css') }}"><![endif]-->
 <!--[if gt IE 9]><!--><link rel="stylesheet" href="{{ static('css/main.css') }}"><!--<![endif]-->
 {% endblock css %}
+
+{#
+    ======
+    PRELOADING DYNAMIC ASSETS
+    ======
+#}
+<link rel="preload" src="{{ static('js/routes/common.js') }}" as="script">
 
 {#
     ============
@@ -192,7 +198,6 @@
           docElement.className = docElement.className.replace( /(^|\s)js(\s|$)/, '$1no-js$2' );
         }
     </script>
-
     <!--[if IE 9]><script src="{{ static('js/ie/common.ie9.js') }}"></script><![endif]-->
 </head>
 
@@ -258,8 +263,9 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   available. Check for that CSS class here and act accordingly.
 #}
 
-<script>
+<script async>
   if ( document.body.parentElement.className.indexOf( 'no-js' ) === -1 ) {
+    !function(){
     {# Include site-wide JavaScript. #}
     var a = [ '{{ static('js/routes/common.js') }}' ];
     {# Check and include template-level JavaScript. #}
@@ -300,7 +306,8 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
     {# Minified dynamic JavaScript loader that injects a script tag in the head
       of the page. It also provides a callback parameter. #}
-    var b,c,d=[],f=document.scripts[0];function g(){for(var e;d[0]&&'loaded'==d[0].readyState;)e=d.shift(),e.onreadystatechange=null,f.parentNode.insertBefore(e,f)}for(;b=a.shift();)'async'in f?(c=document.createElement('script'),c.async=!1,c.src=b,document.head.appendChild(c)):f.readyState&&(c=document.createElement('script'),d.push(c),c.onreadystatechange=g,c.src=b);
+    var b,c,d="async"in document.createElement("script");for(;b=a.shift();)c=document.createElement("script"),d&&(c.async=!1),c.src=b,document.head.appendChild(c);
+    }();
   }
 
   var usasearch_config = { siteHandle: 'cfpb' };


### PR DESCRIPTION
Refactor for script loading in base.html


## Changes

- Modified `cfgov/jinja2/v1/_layouts/base.html` to use script detailed in https://www.html5rocks.com/en/tutorials/speed/script-loading/. Uses `async=true` for script tags to ensure proper loading order.  This should allow us to take advantage of loading scripts in parallel and executing sequentially.

## Testing

1. Visit http://localhost:8000/about-us/blog and ensure the page works.
2. Visit http://localhost:8000/data-research/consumer-credit-trends/student-loans/borrower-risk-profiles/ and ensure the page works.


## Notes

- We need a write up on manually testing pages. 
- We should add the ability to use the `rel="preload` attribute.
## Todos

-

## Checklist

* [ ] PR has an informative and human-readable title
* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [ ] Passes all existing automated tests
* [ ] Any *change* in functionality is tested
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated
* [ ] Reviewers requested with the [Reviewer tool](https://help.github.com/articles/about-pull-request-reviews/) :arrow_right:

  
  