### PR TITLE
Add flag for servicemember pages in Wagtail

### DIFF
--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -639,6 +639,9 @@ FLAGS = {
 
     # Teacher's Digital Platform
     'TDP_RELEASE': {},
+
+    # Servicemembers pages in Wagtail
+    'WAGTAIL_SERVICEMEMBERS': {},
 }
 
 

--- a/cfgov/cfgov/urls.py
+++ b/cfgov/cfgov/urls.py
@@ -12,8 +12,10 @@ from django.views.generic.base import RedirectView, TemplateView
 from wagtail.contrib.wagtailsitemaps.views import sitemap
 from wagtail.wagtailadmin import urls as wagtailadmin_urls
 from wagtailsharing import urls as wagtailsharing_urls
+from wagtailsharing.views import ServeView
 
 from flags.urls import flagged_url
+from flags.views import FlaggedTemplateView
 
 from ask_cfpb.views import (
     ask_autocomplete, ask_search, print_answer, redirect_ask_search,
@@ -36,6 +38,21 @@ from v1.views.documents import DocumentServeView
 
 
 oah = SheerSite('owning-a-home')
+
+
+def flagged_wagtail_template_view(flag_name, template_name):
+    """View that serves Wagtail if a flag is set, and a template if not.
+
+    This uses the wagtail-sharing ServeView to ensure that sharing works
+    properly when viewing the page in Wagtail behind a flag.
+    """
+    return FlaggedTemplateView.as_view(
+        fallback=lambda request: ServeView.as_view()(request, request.path),
+        flag_name=flag_name,
+        template_name=template_name,
+        condition=False
+    )
+
 
 urlpatterns = [
     url(r'^documents/(?P<document_id>\d+)/(?P<document_filename>.*)$',
@@ -126,14 +143,21 @@ urlpatterns = [
                               'ways-to-stay-afloat/index.html'),
                 name='students-helping-borrowers'),
 
-    url(r'^practitioner-resources/servicemembers/$', TemplateView.as_view(
-        template_name='service-members/index.html'),
+    # Servicemembers
+    url(r'^practitioner-resources/servicemembers/$',
+        flagged_wagtail_template_view(
+            flag_name='WAGTAIL_SERVICEMEMBERS',
+            template_name='service-members/index.html'
+        ),
         name='servicemembers'),
     url(r'^practitioner-resources/servicemembers/webinars/$',
-        TemplateView.as_view(
-        template_name='service-members/on-demand-forums-and-tools'
-                      '/index.html'),
-        name='servicemembers'),
+        flagged_wagtail_template_view(
+            flag_name='WAGTAIL_SERVICEMEMBERS',
+            template_name=(
+                'service-members/on-demand-forums-and-tools/index.html'
+            )
+        ),
+        name='servicemembers-webinars'),
     url(r'^practitioner-resources/servicemembers/additionalresources/$',
         TemplateView.as_view(
         template_name='service-members/additionalresources/index.html'),


### PR DESCRIPTION
This change defines a new feature flag, `WAGTAIL_SERVICEMEMBERS`, to serve two pages from Wagtail instead of from Django.

Without the flag, visiting the pages:

`/practitioner-resources/servicemembers/`
`/practitioner-resources/servicemembers/webinars/`

will be served by Django. With the flag defined and enabled, these will be served by Wagtail.

## Additions

- New `WAGTAIL_SERVICEMEMBERS` flags, with no conditions defined.

## Testing

1. Run a local server.
2. Create new Wagtail pages at `/practitioner-resources/servicemembers/` and `/practitioner-resources/servicemembers/webinars/`.
3. Visit http://content.localhost:8000/practitioner-resources/servicemembers/ and http://content.localhost:8000/practitioner-resources/servicemembers/webinars/ to see the legacy Django pages.
4. In the admin, define a new condition for the `WAGTAIL_SERVICEMEMBERS` flag, like this:
  
![image](https://user-images.githubusercontent.com/654645/34528274-61579fc0-f076-11e7-8abb-5670fa8c9a0f.png)

5. Visit http://content.localhost:8000/practitioner-resources/servicemembers/ and http://content.localhost:8000/practitioner-resources/servicemembers/webinars/ to view the draft content of your new pages.

## Checklist

* [X] PR has an informative and human-readable title
* [X] Changes are limited to a single goal (no scope creep)
* [X] Code can be automatically merged (no conflicts)
* [X] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [X] Passes all existing automated tests
* [ ] Any *change* in functionality is tested
* [X] New functions are documented (with a description, list of inputs, and expected output)
* [X] Placeholder code is flagged
* [X] Visually tested in supported browsers and devices
* [X] Reviewers requested with the [Reviewer tool](https://help.github.com/articles/about-pull-request-reviews/) :arrow_right:
