### PR TITLE
Post Django errors to SQS Queue instead of directly to GitHub

### DIFF
--- a/cfgov/alerts/github_alert.py
+++ b/cfgov/alerts/github_alert.py
@@ -33,7 +33,7 @@ class GithubAlert(object):
         issues = self.repo().iter_issues(state='all')
         return next((issue for issue in issues if issue.title == title), None)
 
-    def post(self, title, body, labels=['Maintenance and Response', 'alert']):
+    def post(self, title, body, labels=['alert']):
         # Truncate the title if needed, max is 256 chars
         title = title[:256]
         issue = self.matching_issue(title)

--- a/cfgov/alerts/logging_handlers.py
+++ b/cfgov/alerts/logging_handlers.py
@@ -1,13 +1,16 @@
+from __future__ import unicode_literals
+
 import logging
+import os
 
 from django.utils.encoding import force_text
 from django.views.debug import get_exception_reporter_filter
 
-from alerts.github_alert import GithubAlert
+from alerts.sqs_queue import SQSQueue
 
 
 class CFGovErrorHandler(logging.Handler):
-    """Logging handler that posts errors to GitHub.
+    """Logging handler that posts errors to our SQS queue.
 
     Based on django.utils.log.AdminEmailHandler.
 
@@ -16,17 +19,22 @@ class CFGovErrorHandler(logging.Handler):
 
     https://docs.djangoproject.com/en/1.8/howto/error-reporting/#filtering-sensitive-information
     """
+
+    def __init__(self):
+        logging.Handler.__init__(self)
+        self.sqs_queue = SQSQueue(
+            queue_url=os.environ['QUEUE_URL'],
+            credentials={
+                'access_key': os.environ['AWS_S3_ACCESS_KEY_ID'],
+                'secret_key': os.environ['AWS_S3_SECRET_ACCESS_KEY'],
+            }
+        )
+
     def emit(self, record):
         title = self.format_title(record)
         body = self.format_body(record)
-
-        github_api = GithubAlert(credentials={})
-        github_api.post(title=title,
-                        body=body,
-                        labels=[
-                            'logging',
-                            'Maintenance and Response'
-                        ])
+        message = '{title} - {body}'.format(title=title, body=body)
+        self.sqs_queue.post(message=message)
 
     def format_title(self, record):
         return record.getMessage()

--- a/cfgov/alerts/sqs_queue.py
+++ b/cfgov/alerts/sqs_queue.py
@@ -1,0 +1,22 @@
+import boto3
+
+
+class SQSQueue(object):
+    def __init__(self, queue_url, client=None, credentials={}):
+        self.queue_url = queue_url
+        self.client = client or self.get_client(credentials)
+
+    def get_client(self, credentials):
+        return boto3.client(
+            'sqs',
+            aws_access_key_id=credentials.get('access_key'),
+            aws_secret_access_key=credentials.get('secret_key'),
+            region_name=credentials.get('region_name', 'us-east-1')
+        )
+
+    def post(self, message):
+        response = self.client.send_message(
+            QueueUrl=self.queue_url,
+            MessageBody=message,
+        )
+        return response

--- a/cfgov/alerts/tests/test_github_alert.py
+++ b/cfgov/alerts/tests/test_github_alert.py
@@ -68,7 +68,6 @@ class TestGithubAlert(TestCase):
             title=self.text,
             body=self.text,
             labels=[
-                'Maintenance and Response',
                 'alert'
             ],
         )

--- a/cfgov/alerts/tests/test_logging_handlers.py
+++ b/cfgov/alerts/tests/test_logging_handlers.py
@@ -1,6 +1,7 @@
 from __future__ import unicode_literals
 
 import logging
+import os
 
 from django.conf import settings
 from django.test import RequestFactory, TestCase
@@ -8,7 +9,7 @@ from django.test import RequestFactory, TestCase
 from mock import patch
 
 
-@patch('alerts.github_alert.GithubAlert.post')
+@patch('alerts.sqs_queue.SQSQueue.post')
 class TestLoggingHandlers(TestCase):
     @classmethod
     def setUpClass(cls):
@@ -21,25 +22,32 @@ class TestLoggingHandlers(TestCase):
         cls._logging = settings.LOGGING
         cls._logging_disable_level = logging.root.manager.disable
 
-        logging.config.dictConfig({
-            'version': 1,
-            'handlers': {
-                'cfgov': {
-                    'level': 'ERROR',
-                    'class': 'alerts.logging_handlers.CFGovErrorHandler',
-                },
-            },
-            'loggers': {
-                'testing': {
-                    'handlers': ['cfgov'],
-                    'level': 'ERROR',
-                    'propagate': False,
-                },
-            },
-        })
-        logging.disable(logging.NOTSET)
+        credentials = {
+            'QUEUE_URL': 'test-queue',
+            'AWS_S3_ACCESS_KEY_ID': 'access-key',
+            'AWS_S3_SECRET_ACCESS_KEY': 'secret-key',
+        }
 
-        cls.logger = logging.getLogger('testing')
+        with patch.dict(os.environ, credentials):
+            logging.config.dictConfig({
+                'version': 1,
+                'handlers': {
+                    'cfgov': {
+                        'level': 'ERROR',
+                        'class': 'alerts.logging_handlers.CFGovErrorHandler',
+                    },
+                },
+                'loggers': {
+                    'testing': {
+                        'handlers': ['cfgov'],
+                        'level': 'ERROR',
+                        'propagate': False,
+                    },
+                },
+            })
+            logging.disable(logging.NOTSET)
+
+            cls.logger = logging.getLogger('testing')
 
     @classmethod
     def tearDownClass(cls):
@@ -48,43 +56,37 @@ class TestLoggingHandlers(TestCase):
         logging.disable(cls._logging_disable_level)
         super(TestLoggingHandlers, cls).tearDownClass()
 
-    def test_logger_calls_github_api_post(self, github_api):
+    def test_logger_calls_sqs_queue_post(self, sqs_queue_post):
         self.logger.error('something')
-        self.assertEqual(github_api.call_count, 1)
+        self.assertEqual(sqs_queue_post.call_count, 1)
 
-    def test_title_equals_message(self, github_api):
+    def test_body_includes_message(self, sqs_queue_post):
         message = 'error message with unic\xf3de characters'
         self.logger.error(message)
-        args, kwargs = github_api.call_args
-        self.assertEqual(kwargs['title'], message)
+        args, kwargs = sqs_queue_post.call_args
+        self.assertIn(message, kwargs['message'])
 
-    def test_body_includes_message(self, github_api):
-        message = 'error message with unic\xf3de characters'
-        self.logger.error(message)
-        args, kwargs = github_api.call_args
-        self.assertIn(message, kwargs['body'])
-
-    def test_body_includes_stack_trace_for_exception(self, github_api):
+    def test_body_includes_stack_trace_for_exception(self, sqs_queue_post):
         try:
             raise ValueError('raising an exception')
         except ValueError:
             self.logger.exception('logging the exception')
 
-        args, kwargs = github_api.call_args
-        self.assertIn('Traceback (most recent call last)', kwargs['body'])
+        args, kwargs = sqs_queue_post.call_args
+        self.assertIn('Traceback (most recent call last)', kwargs['message'])
 
-    def test_body_includes_exception_content(self, github_api):
+    def test_body_includes_exception_content(self, sqs_queue_post):
         try:
             raise ValueError('raising an exception')
         except ValueError:
             self.logger.exception('logging the exception')
 
-        args, kwargs = github_api.call_args
-        self.assertIn('ValueError: raising an exception', kwargs['body'])
+        args, kwargs = sqs_queue_post.call_args
+        self.assertIn('ValueError: raising an exception', kwargs['message'])
 
-    def test_body_includes_request(self, github_api):
+    def test_body_includes_request(self, sqs_queue_post):
         request = RequestFactory().get('/')
         self.logger.error('something', extra={'request': request})
 
-        args, kwargs = github_api.call_args
-        self.assertIn('<WSGIRequest\npath:/', kwargs['body'])
+        args, kwargs = sqs_queue_post.call_args
+        self.assertIn('<WSGIRequest\npath:/', kwargs['message'])

--- a/cfgov/alerts/tests/test_sqs_queue.py
+++ b/cfgov/alerts/tests/test_sqs_queue.py
@@ -1,0 +1,24 @@
+import mock
+import unittest
+
+import boto3
+
+from alerts.sqs_queue import SQSQueue
+
+
+class TestSQSQueue(unittest.TestCase):
+
+    def test_post(self):
+        mock_boto3_client = mock.MagicMock(boto3.session.Session.client)()
+        sqs_queue = SQSQueue(
+            queue_url='http://queue',
+            client=mock_boto3_client
+        )
+        mock_boto3_client.send_message.return_value = {
+            'ResponseMetadata': {'HTTPStatusCode': 200}
+        }
+        sqs_queue.post(message='test message')
+        sqs_queue.client.send_message.assert_called_once_with(
+            MessageBody='test message',
+            QueueUrl='http://queue'
+        )

--- a/cfgov/cfgov/settings/production.py
+++ b/cfgov/cfgov/settings/production.py
@@ -43,14 +43,10 @@ LOGGING = {
             'level': 'DEBUG',
             'class': 'logging.StreamHandler',
         },
-        'db': {
-            'level': 'ERROR',
-            'class': 'alerts.logging_handlers.CFGovErrorHandler',
-        },
     },
     'loggers': {
         'django.request': {
-            'handlers': ['console', 'db'],
+            'handlers': ['console'],
             'level': 'WARNING',
             'propagate': True,
         },
@@ -70,6 +66,13 @@ LOGGING = {
         }
     }
 }
+
+if os.environ.get('SQS_QUEUE_ENABLED'):
+    LOGGING['handlers']['sqs'] = {
+        'level': 'ERROR',
+        'class': 'alerts.logging_handlers.CFGovErrorHandler',
+    }
+    LOGGING['loggers']['django.request']['handlers'].append('sqs')
 
 # Only add syslog to LOGGING if it's in default_loggers
 if 'syslog' in default_loggers:


### PR DESCRIPTION
See GHE/platform/2180 for more context.

Instead of posting 500s directly to GitHub, this PR makes use of our SQS queue and posts them there, so that the more intensive processing (e.g. finding a matching issue)in `GithubAlert` can be done asynchronously. 

While this leaves the current process mostly as-is, there are a few changes:
- Everything in the SQS queue (as configured in the Jenkins job's call to `post_sqs_messages`) gets posted to GitHub AND chat, whereas before we were not posting 500 errors to chat. Now we will be.
- The default `GithubAlert` configuration is to add the label `alert` to all issues created (note that @hillaryj requested we remove the `Maintenance and Response` label). Since there are no longer custom labels coming in through the logging handler code, 500s won't be labeled `logging`.  I'm not sure how people are currently using those labels so please chime in if you feel strongly against this change. 

There's a corresponding PR over in our ansible repo to add the new environment variables. This now fixes the current bug where we are trying to post 500 errors in build and beta environments by instead checking if `SQS_QUEUE_ENABLED` is set when initializing the loggers in `settings/production.py`.
  