### PR TITLE
Bump regulations-site to 2.2.0, use Python for regulations-core

### DIFF
--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -471,6 +471,11 @@ BACKENDS = {
     'diffs': 'regcore.db.django_models.DMDiffs',
 }
 
+# Make regulations-site use Python to call regulations-core.
+# https://github.com/cfpb/regulations-site/pull/845
+if 'regcore' in INSTALLED_APPS and 'regulations' in INSTALLED_APPS:
+    EREGS_REGCORE_URLS = 'regcore.urls'
+
 # GovDelivery environment variables
 ACCOUNT_CODE = os.environ.get('GOVDELIVERY_ACCOUNT_CODE')
 

--- a/requirements/optional-public.txt
+++ b/requirements/optional-public.txt
@@ -2,7 +2,7 @@ https://github.com/cfpb/college-costs/releases/download/2.3.12/college_costs-2.3
 https://github.com/cfpb/complaint/releases/download/1.4.5/complaintdatabase-1.4.5-py2-none-any.whl
 https://github.com/cfpb/owning-a-home-api/releases/download/0.10.3/owning_a_home_api-0.10.3-py2-none-any.whl
 https://github.com/cfpb/regulations-core/releases/download/1.2.6/regcore-1.2.6-py2-none-any.whl
-https://github.com/cfpb/regulations-site/releases/download/2.1.17/regulations-2.1.17-py2-none-any.whl
+https://github.com/cfpb/regulations-site/releases/download/2.2.0/regulations-2.2.0-py2-none-any.whl
 https://github.com/cfpb/retirement/releases/download/0.5.14/retirement-0.5.14-py2-none-any.whl
 git+https://github.com/cfpb/ccdb5-api.git@v1.0.5#egg=ccdb5-api
 git+https://github.com/cfpb/ccdb5-ui.git@v1.0.6#egg=ccdb5_ui


### PR DESCRIPTION
This change bumps the version of the optional [regulations-site](https://github.com/cfpb/regulations-site) package from version 2.1.17 to version [2.2.0](https://github.com/cfpb/regulations-site/releases/tag/2.2.0). It also enables the optional functionality in this new version to use Python imports to communicate between regulations-site and [regulations-core](https://github.com/cfpb/regulations-core), instead of HTTP.

Unlike most version bumps, this has potential to have a significant performance impact on the way that eRegs is served. This new version does everything on a single Apache thread instead of farming out to multiple parallel threads for each request. This means that servers should have less threads but that each request may take slightly longer. Overall process stability should increase as less Apache processes are needed for each request.

This in-process handling is only enabled if both regulations-core and regulations-site are installed as optional apps; this still allows for testing of cfgov-refresh with, say, only regulations-site when running against a remote (production) API.

## Changes

- Bump regulations-site to version 2.2.0.
- Enable in-process communication between regulations-site and regulations-core.

## Testing

The best way to test this is to either load production data with eRegs as part of the dump or manually loading eRegs data yourself. Then do a `pip install` of the regulations-core and regulations-site wheels in `requirements/optional-public.txt`, and browse around your local server to some eRegs pages. You'll notice that each browser request only shows up as a single request to the Django debug server, instead of using multiple requests as in the past.

## Notes

As a decision for future followup, with this change it is no longer (and really hasn't ever been) necessary to expose the underlying eRegs API publicly ([at /eregs-api/](https://www.consumerfinance.gov/eregs-api/regulation)). This has proven useful for testing but in theory could be restricted or turned off as of this change. Pinging @ascott1 in case he has any input here.

## Checklist

* [X] PR has an informative and human-readable title
* [X] Changes are limited to a single goal (no scope creep)
* [X] Code can be automatically merged (no conflicts)
* [X] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [X] Passes all existing automated tests
* [X] Visually tested in supported browsers and devices
* [X] Reviewers requested with the [Reviewer tool](https://help.github.com/articles/about-pull-request-reviews/) :arrow_right:
