### PR TITLE
Revert use of direct Python connection for eRegs

### DIFF
--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -471,11 +471,6 @@ BACKENDS = {
     'diffs': 'regcore.db.django_models.DMDiffs',
 }
 
-# Make regulations-site use Python to call regulations-core.
-# https://github.com/cfpb/regulations-site/pull/845
-if 'regcore' in INSTALLED_APPS and 'regulations' in INSTALLED_APPS:
-    EREGS_REGCORE_URLS = 'regcore.urls'
-
 # GovDelivery environment variables
 ACCOUNT_CODE = os.environ.get('GOVDELIVERY_ACCOUNT_CODE')
 


### PR DESCRIPTION
Using direct Python to invoke regcore from regsite seems to have an unexpected negative effect on database performance which will take more investigation to nail down.

Reverting in the interest of restoring previous performance.

This reverts part of #3721.