### PR TITLE
Use SQS-specific AWS credentials for SQS

### DIFF
--- a/cfgov/alerts/logging_handlers.py
+++ b/cfgov/alerts/logging_handlers.py
@@ -23,10 +23,10 @@ class CFGovErrorHandler(logging.Handler):
     def __init__(self):
         logging.Handler.__init__(self)
         self.sqs_queue = SQSQueue(
-            queue_url=os.environ['QUEUE_URL'],
+            queue_url=os.environ['AWS_SQS_QUEUE_URL'],
             credentials={
-                'access_key': os.environ['AWS_S3_ACCESS_KEY_ID'],
-                'secret_key': os.environ['AWS_S3_SECRET_ACCESS_KEY'],
+                'access_key': os.environ['AWS_SQS_ACCESS_KEY_ID'],
+                'secret_key': os.environ['AWS_SQS_SECRET_ACCESS_KEY'],
             }
         )
 

--- a/cfgov/alerts/tests/test_logging_handlers.py
+++ b/cfgov/alerts/tests/test_logging_handlers.py
@@ -23,9 +23,9 @@ class TestLoggingHandlers(TestCase):
         cls._logging_disable_level = logging.root.manager.disable
 
         credentials = {
-            'QUEUE_URL': 'test-queue',
-            'AWS_S3_ACCESS_KEY_ID': 'access-key',
-            'AWS_S3_SECRET_ACCESS_KEY': 'secret-key',
+            'AWS_SQS_QUEUE_URL': 'test-queue',
+            'AWS_SQS_ACCESS_KEY_ID': 'access-key',
+            'AWS_SQS_SECRET_ACCESS_KEY': 'secret-key',
         }
 
         with patch.dict(os.environ, credentials):


### PR DESCRIPTION
The AWS credentials for SQS may be distinct from those used for S3, so they need to be specified separately. Specifically, the S3 credentials may not have permission to access SQS.

This change replaces the use of the `AWS_S3_ACCESS_KEY_ID` and `AWS_S3_SECRET_ACCESS_KEY` environment variables with `AWS_SQS_ACCESS_KEY_ID` and `AWS_SQS_SECRET_ACCESS_KEY`.

Additionally, the use of the `QUEUE_URL` environment variable is changed to `AWS_SQS_QUEUE_URL` to be more precise.

## Changes

- Modifying use of environment variables.

## Testing

1. See unit tests.

## Notes

See related PR in Ansible deployment scripts.

## Checklist

* [X] PR has an informative and human-readable title
* [X] Changes are limited to a single goal (no scope creep)
* [X] Code can be automatically merged (no conflicts)
* [X] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [X] Passes all existing automated tests
* [X] Reviewers requested with the [Reviewer tool](https://help.github.com/articles/about-pull-request-reviews/) :arrow_right:
