### PR TITLE
Only post alert titles to Mattermost

### DIFF
--- a/cfgov/alerts/post_sqs_messages.py
+++ b/cfgov/alerts/post_sqs_messages.py
@@ -93,7 +93,7 @@ def process_sqs_message(message, github_alert, mattermost_alert):
     if mattermost_alert:
         try:
             mattermost_alert.post(text='Alert: {}. Github issue at {}'.format(
-                body,
+                title,
                 issue.html_url
             ))
         except Exception:

--- a/cfgov/alerts/tests/test_post_sqs_messages.py
+++ b/cfgov/alerts/tests/test_post_sqs_messages.py
@@ -40,7 +40,7 @@ class TestPostSQSMessages(TestCase):
             body='Test Job # 1234 - Failed'
         )
         mattermost_post.assert_called_once_with(
-            text=('Alert: Test Job # 1234 - Failed. '
+            text=('Alert: Test Job # 1234. '
                   'Github issue at https://github.com/foo/bar/issues/42')
         )
 


### PR DESCRIPTION
Instead of posting full alerts to Mattermost, including stack traces and request content, we should only post the alert titles along with the GH issue for more detail.

## Changes

- MM alerts should only receive alert titles, not full alert bodies.

## Testing

See unit tests in `alerts.tests.test_post_sqs_messages`.

## Checklist

* [X] PR has an informative and human-readable title
* [X] Changes are limited to a single goal (no scope creep)
* [X] Code can be automatically merged (no conflicts)
* [X] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [X] Passes all existing automated tests
* [X] Any *change* in functionality is tested
* [X] Reviewers requested with the [Reviewer tool](https://help.github.com/articles/about-pull-request-reviews/) :arrow_right:
