### PR TITLE
Add second email popup for debt collection pages

### DIFF
--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -620,8 +620,9 @@ FLAGS = {
     # Intended for use with path conditions.
     'AB_TESTING': {},
 
-    # When enabled, should display the email popup.
-    'EMAIL_POPUP': {},
+    # Email popups.
+    'EMAIL_POPUP_OAH': {'boolean': True},
+    'EMAIL_POPUP_DEBT': {'after date': '2018-02-01T00:00'},
 
     # The next version of eRegulations
     'EREGS20': {
@@ -673,3 +674,17 @@ SEARCH_DOT_GOV_ACCESS_KEY = os.environ.get('SEARCH_DOT_GOV_ACCESS_KEY')
 SERVE_LATEST_DRAFT_PAGES = []
 if DEPLOY_ENVIRONMENT == 'beta':
     SERVE_LATEST_DRAFT_PAGES = [1288]
+
+# Email popup configuration. See v1.templatetags.email_popup.
+EMAIL_POPUPS = {
+    'debt': [
+        '/ask-cfpb/what-is-a-statute-of-limitations-on-a-debt-en-1389/',
+        '/ask-cfpb/what-is-the-best-way-to-negotiate-a-settlement-with-a-debt-collector-en-1447/',
+        '/ask-cfpb/what-should-i-do-when-a-debt-collector-contacts-me-en-1695/',
+        '/consumer-tools/debt-collection/',
+    ],
+    'oah': [
+        '/owning-a-home/',
+        '/owning-a-home/mortgage-estimate/',
+    ],
+}

--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -676,7 +676,7 @@ if DEPLOY_ENVIRONMENT == 'beta':
     SERVE_LATEST_DRAFT_PAGES = [1288]
 
 # Email popup configuration. See v1.templatetags.email_popup.
-EMAIL_POPUPS = {
+EMAIL_POPUP_URLS = {
     'debt': [
         '/ask-cfpb/what-is-a-statute-of-limitations-on-a-debt-en-1389/',
         '/ask-cfpb/what-is-the-best-way-to-negotiate-a-settlement-with-a-debt-collector-en-1447/',

--- a/cfgov/jinja2/v1/_includes/organisms/email-popup/base.html
+++ b/cfgov/jinja2/v1/_includes/organisms/email-popup/base.html
@@ -41,9 +41,7 @@
                     <p>
                         <a href="{{ privacy_link_url }}"
                            target="_blank"
-                           rel="noopener noreferrer">
-                            {{ privacy_link_text }}
-                        </a>
+                           rel="noopener noreferrer">Privacy Act statement</a>
                         <br/>
                     </p>
                     <input class="a-btn a-btn__full-on-xs" type="submit" value="Sign up">

--- a/cfgov/jinja2/v1/_includes/organisms/email-popup/base.html
+++ b/cfgov/jinja2/v1/_includes/organisms/email-popup/base.html
@@ -6,29 +6,29 @@
 
  Description:
 
- Sidebar popup that fades in upon scrolling on the Owning a Home sublanding
- page at /owning-a-home/.
+ Sidebar popup that fades in upon scrolling.
 
  Creates Pop-up organism:
 
  ========================================================================== #}
 
-<div class="o-email-popup">
+<div class="o-email-popup" data-popup-label="{{ popup_label }}">
     <div class="o-email-popup_header u-clearfix">
         <div class="close">
             <a>Close <span class="cf-icon cf-icon-delete-round"></span></a>
         </div>
     </div>
-    <div class="o-email-popup_body">
+    <div class="o-email-popup_body"
+         style="background-image: url('{{ static(popup_image) }}')">
         <div class="o-email-signup">
-            <h2>Buying a home?</h2>
+            <h2>{{ popup_headline }}</h2>
             <form id="{{ ('o-email-signup_' ~ range(1, 100) | random) }}"
                   class="o-form o-form__email-signup u-clearfix"
-                  action="/subscriptions/new/"
+                  action="{{ url('govdelivery') }}"
                   method="POST"
                   enctype="application/x-www-form-urlencoded"
                   novalidate>
-                <p>Sign up for email tips and info to help you through the process.</p>
+                <p>{{ popup_content }}</p>
                 <div class="m-form-field-with-button" data-qa-hook="formfield-with-button">
                     <div class="form-group">
                         <input id="form_18"
@@ -39,17 +39,17 @@
                                required>
                     </div>
                     <p>
-                        <a href="/owning-a-home/privacy-act-statement/"
+                        <a href="{{ privacy_link_url }}"
                            target="_blank"
                            rel="noopener noreferrer">
-                            View Privacy Act statement
+                            {{ privacy_link_text }}
                         </a>
                         <br/>
                     </p>
                     <input class="a-btn a-btn__full-on-xs" type="submit" value="Sign up">
                 </div>
                 <div class="form-group">
-                    <input type="hidden" name="code" value="USCFPB_128">
+                    <input type="hidden" name="code" value="{{ mailing_list_code }}">
                 </div>
             </form>
             <div class="o-email-signup_footer">

--- a/cfgov/jinja2/v1/_includes/organisms/email-popup/debt.html
+++ b/cfgov/jinja2/v1/_includes/organisms/email-popup/debt.html
@@ -3,5 +3,4 @@
 {% set popup_content = "Get a handle on it with our 21-day email boot camp." %}
 {% set popup_headline = "Debt getting in your way?" %}
 {% set popup_image = "img/modal-house.png" %}
-{% set privacy_link_text= "Privacy Act statement" %}
 {% set privacy_link_url = "/consumer-tools/debt-collection/debt-email-sign-privacy-act-statement/" %}

--- a/cfgov/jinja2/v1/_includes/organisms/email-popup/debt.html
+++ b/cfgov/jinja2/v1/_includes/organisms/email-popup/debt.html
@@ -1,0 +1,7 @@
+{% extends "base.html" %}
+{% set popup_headline = "Debt getting in your way?" %}
+{% set popup_content = "Get a handle on it with our 21-day email boot camp." %}
+{% set popup_image = "img/modal-house.png" %}
+{% set privacy_link_text= "Privacy Act statement" %}
+{% set privacy_link_url = "/consumer-tools/debt-collection/debt-email-sign-privacy-act-statement/" %}
+{% set mailing_list_code = "USCFPB_147" %}

--- a/cfgov/jinja2/v1/_includes/organisms/email-popup/debt.html
+++ b/cfgov/jinja2/v1/_includes/organisms/email-popup/debt.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
-{% set popup_headline = "Debt getting in your way?" %}
+{% set mailing_list_code = "USCFPB_147" %}
 {% set popup_content = "Get a handle on it with our 21-day email boot camp." %}
+{% set popup_headline = "Debt getting in your way?" %}
 {% set popup_image = "img/modal-house.png" %}
 {% set privacy_link_text= "Privacy Act statement" %}
 {% set privacy_link_url = "/consumer-tools/debt-collection/debt-email-sign-privacy-act-statement/" %}
-{% set mailing_list_code = "USCFPB_147" %}

--- a/cfgov/jinja2/v1/_includes/organisms/email-popup/oah.html
+++ b/cfgov/jinja2/v1/_includes/organisms/email-popup/oah.html
@@ -3,6 +3,5 @@
 {% set popup_content = "Sign up for email tips and info to help you through the process." %}
 {% set popup_headline = "Buying a home?" %}
 {% set popup_image = "img/modal-house.png" %}
-{% set privacy_link_text= "View Privacy Act statement" %}
 {% set privacy_link_url = "/owning-a-home-privacy-act-statement/" %}
 

--- a/cfgov/jinja2/v1/_includes/organisms/email-popup/oah.html
+++ b/cfgov/jinja2/v1/_includes/organisms/email-popup/oah.html
@@ -1,8 +1,8 @@
 {% extends "base.html" %}
-{% set popup_headline = "Buying a home?" %}
-{% set popup_content = "Sign up for email tips and info to help you through the process." %}
-{% set popup_image = "img/modal-house.png" %}
 {% set mailing_list_code = "USCFPB_128" %}
+{% set popup_content = "Sign up for email tips and info to help you through the process." %}
+{% set popup_headline = "Buying a home?" %}
+{% set popup_image = "img/modal-house.png" %}
 {% set privacy_link_text= "View Privacy Act statement" %}
 {% set privacy_link_url = "/owning-a-home-privacy-act-statement/" %}
 

--- a/cfgov/jinja2/v1/_includes/organisms/email-popup/oah.html
+++ b/cfgov/jinja2/v1/_includes/organisms/email-popup/oah.html
@@ -1,0 +1,8 @@
+{% extends "base.html" %}
+{% set popup_headline = "Buying a home?" %}
+{% set popup_content = "Sign up for email tips and info to help you through the process." %}
+{% set popup_image = "img/modal-house.png" %}
+{% set mailing_list_code = "USCFPB_128" %}
+{% set privacy_link_text= "View Privacy Act statement" %}
+{% set privacy_link_url = "/owning-a-home-privacy-act-statement/" %}
+

--- a/cfgov/jinja2/v1/ask-cfpb/answer-page.html
+++ b/cfgov/jinja2/v1/ask-cfpb/answer-page.html
@@ -98,7 +98,7 @@
     </div>
     {{ ask_search_bar.render( 'left' ) }}
 
-
+    {{ email_popup(request) }}
 {% endblock %}
 
 {% block content_sidebar_modifiers -%}

--- a/cfgov/jinja2/v1/owning-a-home/mortgage-estimate/index.html
+++ b/cfgov/jinja2/v1/owning-a-home/mortgage-estimate/index.html
@@ -179,6 +179,7 @@
     </aside>
     <!-- .content_sidebar -->
   </div>
-  {% include 'organisms/email-popup.html' ignore missing %}
+
+  {{ email_popup(request) }}
 </main>
 {% endblock %}

--- a/cfgov/jinja2/v1/sublanding-page/index.html
+++ b/cfgov/jinja2/v1/sublanding-page/index.html
@@ -54,9 +54,7 @@
         {% endif %}
     {%- endfor %}
 
-    {% if flag_enabled('EMAIL_POPUP', request) %}
-        {% include 'organisms/email-popup.html' ignore missing %}
-    {% endif %}
+    {{ email_popup(request) }}
 {% endblock %}
 
 {% block content_sidebar_modifiers -%}

--- a/cfgov/unprocessed/css/organisms/email-popup.less
+++ b/cfgov/unprocessed/css/organisms/email-popup.less
@@ -67,7 +67,7 @@
     }
 
     .respond-to-max( @bp-xs-max, {
-        background: none;
+        background: none !important;
 
         .o-email-signup.form-submitted {
             margin-bottom: unit( (@grid_gutter-width * 3) / @base-font-size-px, em);
@@ -80,10 +80,8 @@
                 unit( @grid_gutter-width  / @base-font-size-px, em);
 
         padding-right: 155px;
-        background: url( '../img/modal-house.png' )
-                    no-repeat
-                    right
-                    20px;
+        background-repeat: no-repeat;
+        background-position: right 20px;
         background-size: 130px;
 
         h2 {

--- a/cfgov/unprocessed/css/organisms/email-popup.less
+++ b/cfgov/unprocessed/css/organisms/email-popup.less
@@ -67,7 +67,9 @@
     }
 
     .respond-to-max( @bp-xs-max, {
-        background: none !important;
+        // This is needed because the image can vary and so is specified in the
+        // template. "!important" is needed to override the element's style tag.
+        background-image: none !important;
 
         .o-email-signup.form-submitted {
             margin-bottom: unit( (@grid_gutter-width * 3) / @base-font-size-px, em);

--- a/cfgov/unprocessed/js/organisms/EmailPopup.js
+++ b/cfgov/unprocessed/js/organisms/EmailPopup.js
@@ -1,6 +1,7 @@
 const FormSubmit = require( './FormSubmit.js' );
 const validators = require( '../modules/util/validators' );
 const emailHelpers = require( '../modules/util/email-popup-helpers' );
+
 const BASE_CLASS = 'o-email-signup';
 const language = document.body.querySelector( '.content' ).lang;
 
@@ -17,6 +18,7 @@ const language = document.body.querySelector( '.content' ).lang;
 function EmailPopup( el ) {
   const _baseElement = document.querySelector( el );
   const _closeElement = _baseElement.querySelector( '.close' );
+  const _popupLabel = _baseElement.getAttribute( 'data-popup-label' );
   const VISIBLE_CLASS = 'o-email-popup__visible';
 
   /**
@@ -24,7 +26,7 @@ function EmailPopup( el ) {
    */
   function hidePopup() {
     _baseElement.classList.remove( VISIBLE_CLASS );
-    emailHelpers.recordEmailPopupClosure();
+    emailHelpers.recordEmailPopupClosure( _popupLabel );
   }
 
   /**
@@ -32,9 +34,9 @@ function EmailPopup( el ) {
    * @returns {boolean} true.
    */
   function showPopup() {
-    if ( emailHelpers.showEmailPopup() ) {
+    if ( emailHelpers.showEmailPopup( _popupLabel ) ) {
       _baseElement.classList.add( VISIBLE_CLASS );
-      emailHelpers.recordEmailPopupView();
+      emailHelpers.recordEmailPopupView( _popupLabel );
     }
 
     return true;
@@ -59,14 +61,8 @@ function EmailPopup( el ) {
    * @param {event} event Click event.
    *
    */
-  function _onEmailSignupSuccess( event ) {
-    const form = event.form;
-    const input = form.querySelector( 'input[name="code"]' );
-    const code = input.value;
-
-    if ( code === 'USCFPB_128' ) {
-      emailHelpers.recordEmailRegistration();
-    }
+  function _onEmailSignupSuccess() {
+    emailHelpers.recordEmailRegistration( _popupLabel );
   }
 
   /**

--- a/cfgov/unprocessed/js/routes/ask-cfpb/single.js
+++ b/cfgov/unprocessed/js/routes/ask-cfpb/single.js
@@ -37,3 +37,18 @@ function sendEvent() {
   eventData.category = categoryName;
   Analytics.sendEvent( eventData );
 }
+
+
+const EmailPopup = require( '../../organisms/EmailPopup' );
+const emailHelpers = require( '../../modules/util/email-popup-helpers' );
+const emailPopup = document.querySelectorAll( '.o-email-popup' );
+
+
+if ( emailPopup.length && emailHelpers.showEmailPopup() ) {
+  const popup = new EmailPopup( '.o-email-popup' );
+  popup.init();
+  emailHelpers.showOnScroll( popup.el, {
+    cb: popup.showPopup,
+    targetElement: document.querySelector( '.o-info-unit-group' )
+  } );
+}

--- a/cfgov/unprocessed/js/routes/consumer-tools/debt-collection/index.js
+++ b/cfgov/unprocessed/js/routes/consumer-tools/debt-collection/index.js
@@ -1,0 +1,12 @@
+const EmailPopup = require( '../../../organisms/EmailPopup' );
+const emailHelpers = require( '../../../modules/util/email-popup-helpers' );
+const emailPopup = document.querySelectorAll( '.o-email-popup' );
+
+if ( emailPopup.length && emailHelpers.showEmailPopup() ) {
+  const popup = new EmailPopup( '.o-email-popup' );
+  popup.init();
+  emailHelpers.showOnScroll( popup.el, {
+    cb: popup.showPopup,
+    targetElement: document.querySelector( '.o-info-unit-group' )
+  } );
+}

--- a/cfgov/v1/jinja2tags.py
+++ b/cfgov/v1/jinja2tags.py
@@ -1,6 +1,7 @@
 from jinja2.ext import Extension
 
 from v1.models import CFGOVRendition
+from v1.templatetags.email_popup import email_popup
 from v1.util.util import extended_strftime
 
 
@@ -43,7 +44,7 @@ class V1FiltersExtension(Extension):
         self.environment.globals.update({
             'image_alt_value': image_alt_value,
             'date_formatter': date_formatter,
-
+            'email_popup': email_popup,
         })
 
 

--- a/cfgov/v1/templatetags/email_popup.py
+++ b/cfgov/v1/templatetags/email_popup.py
@@ -1,0 +1,26 @@
+from django import template
+from django.conf import settings
+from django.template.loader import render_to_string
+from django.utils.safestring import mark_safe
+
+from flags.state import flag_enabled
+
+
+register = template.Library()
+
+
+@register.simple_tag
+def email_popup(request):
+    for label, urls in settings.EMAIL_POPUPS.items():
+        if request.path not in urls:
+            continue
+
+        feature_flag = 'EMAIL_POPUP_{}'.format(label.upper())
+        if not flag_enabled(feature_flag, request=request):
+            continue
+
+        template = 'organisms/email-popup/{}.html'.format(label)
+        context = {'popup_label': label}
+        return mark_safe(render_to_string(template, context=context))
+
+    return ''

--- a/cfgov/v1/templatetags/email_popup.py
+++ b/cfgov/v1/templatetags/email_popup.py
@@ -11,7 +11,7 @@ register = template.Library()
 
 @register.simple_tag
 def email_popup(request):
-    for label, urls in settings.EMAIL_POPUPS.items():
+    for label, urls in settings.EMAIL_POPUP_URLS.items():
         if request.path not in urls:
             continue
 

--- a/cfgov/v1/tests/templatetags/test_email_popup.py
+++ b/cfgov/v1/tests/templatetags/test_email_popup.py
@@ -7,10 +7,10 @@ from django.test import RequestFactory, SimpleTestCase, override_settings
 
 class TestEmailPopupSettings(TestCase):
     def test_setting_should_be_dict(self):
-        self.assertIsInstance(settings.EMAIL_POPUPS, dict)
+        self.assertIsInstance(settings.EMAIL_POPUP_URLS, dict)
 
     def test_setting_keys_and_values(self):
-        for k, v in settings.EMAIL_POPUPS.items():
+        for k, v in settings.EMAIL_POPUP_URLS.items():
             self.assertIsInstance(k, str)
             self.assertIsInstance(v, list)
 
@@ -21,13 +21,13 @@ class TestEmailPopupTag(TestCase):
         template = Template('{% load email_popup %}{% email_popup request %}')
         return template.render(Context({'request': request}))
 
-    @override_settings(EMAIL_POPUPS={})
+    @override_settings(EMAIL_POPUP_URLS={})
     def test_no_popups_configured_returns_blank(self):
         response = self.render('/no/pages/configured/')
         self.assertEqual(response, '')
 
     @override_settings(
-        EMAIL_POPUPS={'foo': ['/page/configured/']},
+        EMAIL_POPUP_URLS={'foo': ['/page/configured/']},
         FLAGS={}
     )
     def test_popup_configured_but_no_flag(self):
@@ -35,7 +35,7 @@ class TestEmailPopupTag(TestCase):
         self.assertEqual(response, '')
 
     @override_settings(
-        EMAIL_POPUPS={'foo': ['/page/configured/']},
+        EMAIL_POPUP_URLS={'foo': ['/page/configured/']},
         FLAGS={'EMAIL_POPUP_FOO': {'boolean': False}} 
     )
     def test_popup_configured_but_flag_false(self):
@@ -43,7 +43,7 @@ class TestEmailPopupTag(TestCase):
         self.assertEqual(response, '')
 
     @override_settings(
-        EMAIL_POPUPS={'foo': ['/page/configured/']},
+        EMAIL_POPUP_URLS={'foo': ['/page/configured/']},
         FLAGS={'EMAIL_POPUP_FOO': {'boolean': False}} 
     )
     def test_popup_configured_and_flag_true_but_path_doesnt_match(self):
@@ -51,7 +51,7 @@ class TestEmailPopupTag(TestCase):
         self.assertEqual(response, '')
 
     @override_settings(
-        EMAIL_POPUPS={'oah': ['/page/configured/']},
+        EMAIL_POPUP_URLS={'oah': ['/page/configured/']},
         FLAGS={'EMAIL_POPUP_OAH': {'boolean': True}} 
     )
     def test_popup_configured_and_flag_true_and_path_matches(self):

--- a/cfgov/v1/tests/templatetags/test_email_popup.py
+++ b/cfgov/v1/tests/templatetags/test_email_popup.py
@@ -1,0 +1,59 @@
+from unittest import TestCase
+
+from django.conf import settings
+from django.template import Context, Template
+from django.test import RequestFactory, SimpleTestCase, override_settings
+
+
+class TestEmailPopupSettings(TestCase):
+    def test_setting_should_be_dict(self):
+        self.assertIsInstance(settings.EMAIL_POPUPS, dict)
+
+    def test_setting_keys_and_values(self):
+        for k, v in settings.EMAIL_POPUPS.items():
+            self.assertIsInstance(k, str)
+            self.assertIsInstance(v, list)
+
+
+class TestEmailPopupTag(TestCase):
+    def render(self, path):
+        request = RequestFactory().get(path)
+        template = Template('{% load email_popup %}{% email_popup request %}')
+        return template.render(Context({'request': request}))
+
+    @override_settings(EMAIL_POPUPS={})
+    def test_no_popups_configured_returns_blank(self):
+        response = self.render('/no/pages/configured/')
+        self.assertEqual(response, '')
+
+    @override_settings(
+        EMAIL_POPUPS={'foo': ['/page/configured/']},
+        FLAGS={}
+    )
+    def test_popup_configured_but_no_flag(self):
+        response = self.render('/page/configured/')
+        self.assertEqual(response, '')
+
+    @override_settings(
+        EMAIL_POPUPS={'foo': ['/page/configured/']},
+        FLAGS={'EMAIL_POPUP_FOO': {'boolean': False}} 
+    )
+    def test_popup_configured_but_flag_false(self):
+        response = self.render('/page/configured/')
+        self.assertEqual(response, '')
+
+    @override_settings(
+        EMAIL_POPUPS={'foo': ['/page/configured/']},
+        FLAGS={'EMAIL_POPUP_FOO': {'boolean': False}} 
+    )
+    def test_popup_configured_and_flag_true_but_path_doesnt_match(self):
+        response = self.render('/page/not/configured/')
+        self.assertEqual(response, '')
+
+    @override_settings(
+        EMAIL_POPUPS={'oah': ['/page/configured/']},
+        FLAGS={'EMAIL_POPUP_OAH': {'boolean': True}} 
+    )
+    def test_popup_configured_and_flag_true_and_path_matches(self):
+        response = self.render('/page/configured/')
+        self.assertIn('o-email-popup_body', response)

--- a/cfgov/v1/tests/test_jinja2tags.py
+++ b/cfgov/v1/tests/test_jinja2tags.py
@@ -1,11 +1,11 @@
 from datetime import date
 
-from django.test import TestCase
+from django.test import RequestFactory, TestCase
 
 from model_mommy import mommy
 
 from v1.atomic_elements.atoms import ImageBasic
-from v1.jinja2tags import date_formatter, image_alt_value
+from v1.jinja2tags import date_formatter, email_popup, image_alt_value
 from v1.models import CFGOVImage, CFGOVRendition
 
 
@@ -63,3 +63,9 @@ class TestDateFormatter(TestCase):
         test_date = date(2018, 9, 5)
         output = date_formatter(test_date, text_format=False)
         self.assertIn('Sep 05, 2018', output)
+
+
+class TestEmailPopup(TestCase):
+    def test_email_popup_defined_and_returns_empty_for_no_popup(self):
+        request = RequestFactory().get('/page/without/a/popup')
+        self.assertEqual(email_popup(request), '')


### PR DESCRIPTION
This change modifies the existing JS email popup so that it can appear on a wider set of pages, and also supports multiple simultaneous popups at the same time with different content and target email lists.

It leaves the existing Owning a Home popup on these pages:

- /owning-a-home/
- /owning-a-home/mortgage-estimate/

and adds a new Debt Collection popup on these pages:

- /ask-cfpb/what-is-a-statute-of-limitations-on-a-debt-en-1389/
- /ask-cfpb/what-is-the-best-way-to-negotiate-a-settlement-with-a-debt-collector-en-1447/
- /ask-cfpb/what-should-i-do-when-a-debt-collector-contacts-me-en-1695/
- /consumer-tools/debt-collection/

This new popup will not turn on until February 1st, and can be configured using the `EMAIL_POPUP_DEBT` feature flag. The existing `EMAIL_POPUP` feature flag that was previously being used to control the OaH popup has now been renamed to `EMAIL_POPUP_OAH`, and is enabled by default.

Specific popup content and configuration, including text/image content and the mailing list to subscribe users to, can be configured using the Django template files in

`cfgov/jinja2/v1/_includes/organisms/email-popup/`

for example, `oah.html` and `debt.html`. This use of code-based configuration instead of full integration in the Wagtail editor is deliberate.

A new `email_popup` template tag has been created that works in both Django and Jinja templates. This tag inserts the HTML code for the email popup if the page request is configured for a popup in settings. The necessary JS code for each page must also be setup through the use of `cfgov/unprocessed/js/routes` files.

The existing email popup uses two browser local storage keys to store information about how many times the user has seen the popup, and when they should see it next. These keys are used to throttle how often the popup appears.

The current OaH popup uses the keys `oahPopupCount` and `oahPopupShowNext`. The new debt popup uses the keys `debtPopupCount` and `debtPopupShowNext`. For debugging/testing purposes these keys can be viewed and deleted in Chrome Developer Tools under Application, Storage, Local Storage, and then the domain of the site you are testing against (e.g. localhost).

## Additions

- New email popup for debt collection pages (behind feature flag until 2/1).

## Changes

- Refactor of email popup code to support multiple sets of pages with independent popups.

## Testing

The best way to test this change (besides the unit tests) is to run a local server and visit the pages listed above to see if the popup appears. In order to enable the debt popup before the go-live date of 2/1, you'll need to manually set the `EMAIL_POPUP_DEBT` flag to something via the Wagtail admin, for example a boolean condition of "True".

## Screenshots

![image](https://user-images.githubusercontent.com/654645/34785099-2848e832-f5fe-11e7-9feb-e479a8f0df2f.png)

## Todos

The use of `modal-house.png` for the debt popup [here](https://github.com/cfpb/cfgov-refresh/compare/email-popup#diff-afca900319cd83827ac48ee8eacf7498R4) is a temporary placeholder pending new imagery.

## Checklist

* [X] PR has an informative and human-readable title
* [X] Changes are limited to a single goal (no scope creep)
* [X] Code can be automatically merged (no conflicts)
* [X] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [X] Passes all existing automated tests
* [X] Any *change* in functionality is tested
* [X] New functions are documented (with a description, list of inputs, and expected output)
* [X] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated
* [X] Reviewers requested with the [Reviewer tool](https://help.github.com/articles/about-pull-request-reviews/) :arrow_right: