### PR TITLE
Rename megamenu/home page references to Owning a Home

### DIFF
--- a/cfgov/jinja2/v1/_includes/organisms/_vars-mega-menu.html
+++ b/cfgov/jinja2/v1/_includes/organisms/_vars-mega-menu.html
@@ -111,7 +111,7 @@
         {'text': 'Managing Someone Else’s Money', 'url': '/consumer-tools/managing-someone-elses-money/'},
         {'text': 'Money as You Grow', 'url': '/consumer-tools/money-as-you-grow/'},
         {'text': 'Navigating the Military Financial Lifecycle', 'url': '/consumer-tools/military-financial-lifecycle/'},
-        {'text': 'Owning a Home', 'url': '/owning-a-home/'},
+        {'text': 'Buying a House', 'url': '/owning-a-home/'},
         {'text': 'Paying for College', 'url': '/paying-for-college/'},
         {'text': 'Planning for Retirement', 'url': '/consumer-tools/retirement/'},
     ]

--- a/cfgov/jinja2/v1/index.html
+++ b/cfgov/jinja2/v1/index.html
@@ -102,7 +102,7 @@
                                     'url':  '/paying-for-college/'
                                 },
                                 {
-                                    'text': 'Owning a Home',
+                                    'text': 'Buying a House',
                                     'url':  '/owning-a-home/'
                                 },
                                 {


### PR DESCRIPTION
This change modifies the megamenu reference from "Owning a Home" to "Buying a House". It also changes the link on the homepage in the same way.

The change to the megamenu will hopefully be temporary pending migration of that menu into Wagtail, i.e. in #3396.

## Changes

- Renaming "Owning a Home" to "Buying a House" on the home page and megamenu.

## Testing

1. Run a local server and visit http://localhost:8000.

## Screenshots

![image](https://user-images.githubusercontent.com/654645/34796210-c2d83096-f622-11e7-8b7e-ad404a23c6d9.png)

## Checklist

* [X] PR has an informative and human-readable title
* [X] Changes are limited to a single goal (no scope creep)
* [X] Code can be automatically merged (no conflicts)
* [X] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [X] Passes all existing automated tests
* [X] Visually tested in supported browsers and devices
* [X] Reviewers requested with the [Reviewer tool](https://help.github.com/articles/about-pull-request-reviews/) :arrow_right:
