### PR TITLE
Undockerize setup.sh/runserver.sh and update installation docs

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -230,6 +230,15 @@ Get any errors? [See our troubleshooting tips.](#troubleshooting)
   we'll use Docker Machine to start the Docker server in a virtual linux
   environment (using Virtualbox)
 
+#### Quickstart
+
+```shell
+brew install docker docker-compose docker-machine
+source mac-virtualbox-init.sh
+cp .python_env_SAMPLE .python_env
+docker-compose up
+```
+
 ### 1. Setup your Docker environment
 
 If you have never installed Docker before, follow the instructions
@@ -241,13 +250,15 @@ If you are on a machine that is already set up to run Linux docker containers,
 please install [Docker Compose](https://docs.docker.com/compose/install/).
 If `docker-compose ps` runs without error, you can can go to step 2.
 
-#### Mac + Homebrew + Virtualbox quickstart
+#### Mac + Homebrew + Virtualbox 
 
 **Starting assumptions**: You already have homebrew and virtualbox installed.
 You can run `brew search docker` without error.
 
-Install Docker, Docker Machine, and Docker Compose:
-`brew install docker docker-compose docker-machine`
+1. Install Docker, Docker Machine, and Docker Compose: 
+   `brew install docker docker-compose docker-machine`
+2. Create a default docker machine, if necessary, and configure it to map the 
+   appropriate ports locally: `source mac-virtualbox-init.sh`
 
 At this point, `docker-compose ps` should run without error.
 
@@ -256,15 +267,22 @@ At this point, `docker-compose ps` should run without error.
 Refer to the [front-end dependencies](#front-end-dependencies) described above
 in the [standalone installation instructions](#stand-alone-installation).
 
-### 3. Run setup
+### 3. Configure your Python environment
 
-`./setup.sh docker`
+Our docker-compose.yml configuration expects there to be a .python_env file. 
+We provide a sample with some default values that can be copied:
 
-This will install and build the frontend and set up the docker environment.
+```shell
+cp .python_env_SAMPLE .python_env
+```
+
+!!! note
+    This file informs the shell environment in which Python runs and contains 
+    variable definitions but it's not itself a shell script.
 
 ### 4. Run the for the first time
 
-`./runserver.sh docker`
+`docker-compose up`
 
 This will download and/or build images, and then start the containers, as
 described in the docker-compose.yml file. This will take a few minutes, or

--- a/runserver.sh
+++ b/runserver.sh
@@ -9,36 +9,22 @@
 # Set script to exit on any errors.
 set -e
 
-standalone() {
-  mysql(){
-  if ! mysql.server status; then
-    mysql.server start
-  fi
-  }
-
-  # Run tasks to build the project for distribution.
-  server(){
-  if [ "$1" == "ssl" ]; then
-    echo '\033[0;32mStarting SSL Django server on port' $DJANGO_HTTP_PORT '...'
-    python cfgov/manage.py runsslserver $DJANGO_HTT_PORT
-  else
-    echo '\033[0;32mStarting the Django server on port' $DJANGO_HTTP_PORT '...'
-    python cfgov/manage.py runserver $DJANGO_HTTP_PORT
-  fi
-  }
-
-  mysql
-  server "$1"
+mysql(){
+    if ! mysql.server status; then
+        mysql.server start
+    fi
 }
 
-dockerized() {
-  source mac-virtualbox-init.sh
-  docker-compose up
+# Run tasks to build the project for distribution.
+server(){
+    if [ "$1" == "ssl" ]; then
+        echo '\033[0;32mStarting SSL Django server on port' $DJANGO_HTTP_PORT '...'
+        python cfgov/manage.py runsslserver $DJANGO_HTT_PORT
+    else
+        echo '\033[0;32mStarting the Django server on port' $DJANGO_HTTP_PORT '...'
+        python cfgov/manage.py runserver $DJANGO_HTTP_PORT
+    fi
 }
 
-# Execute requested (or all) functions.
-if [ "$1" == "docker" ]; then
-  dockerized
-else
-  standalone
-fi
+mysql
+server "$1"

--- a/setup.sh
+++ b/setup.sh
@@ -9,25 +9,9 @@
 # Set script to exit on any errors.
 set -e
 
-standalone() {
-    ./frontend.sh $1
-    ./backend.sh $1
+./frontend.sh $1
+./backend.sh $1
 
-    if [[ ! -z "$CFGOV_SPEAK_TO_ME" ]]; then
-        say "Set up has finished."
-    fi
-}
-
-dockerized() {
-    ./frontend.sh $2
-
-    touch .python_env
-    source mac-virtualbox-init.sh
-}
-
-# Execute requested (or all) functions.
-if [ "$1" == "docker" ]; then
-    dockerized
-else
-    standalone
+if [[ ! -z "$CFGOV_SPEAK_TO_ME" ]]; then
+    say "Set up has finished."
 fi


### PR DESCRIPTION
This PR removes my attempt to make the docker setup work like the standalone setup. To that end it:

- Removes the docker option for setup.sh
- Removes the docker option for runserver.sh
- Reverts the installation documentation (with tweaks) to call out exactly what needs to be run and why.

## Checklist

* [x] PR has an informative and human-readable title
* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [ ] Passes all existing automated tests
* [ ] Any *change* in functionality is tested
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [x] Project documentation has been updated
* [x] Reviewers requested with the [Reviewer tool](https://help.github.com/articles/about-pull-request-reviews/) :arrow_right:
