### PR TITLE
Pass additional text to expandable cue label 

### DIFF
--- a/cfgov/jinja2/v1/_includes/organisms/expandable.html
+++ b/cfgov/jinja2/v1/_includes/organisms/expandable.html
@@ -28,7 +28,7 @@
 
    ========================================================================== #}
 
-{% macro expandable(value) %}
+{% macro expandable(value, expandable_cue_additional_text='') %}
 
 <div data-qa-hook="expandable" class="o-expandable
             o-expandable__expanded
@@ -47,13 +47,13 @@
                          u-hidden">
                 <span class="o-expandable_cue
                              o-expandable_cue-open">
-                    <span class="o-expandable_cue-label">Show</span>
+                    <span class="o-expandable_cue-label">Show {{expandable_cue_additional_text}}</span>
                     <span class="o-expandable_cue-label o-expandable_cue-label__es">Mostrar</span>
                     <span class="cf-icon cf-icon-plus-round"></span>
                 </span>
                 <span class="o-expandable_cue
                              o-expandable_cue-close">
-                    <span class="o-expandable_cue-label">Hide</span>
+                    <span class="o-expandable_cue-label">Hide {{expandable_cue_additional_text}}</span>
                     <span class="o-expandable_cue-label o-expandable_cue-label__es">Ocultar</span>
                     <span class="cf-icon cf-icon-minus-round"></span>
                 </span>

--- a/cfgov/jinja2/v1/_includes/organisms/filterable-list-controls.html
+++ b/cfgov/jinja2/v1/_includes/organisms/filterable-list-controls.html
@@ -190,7 +190,7 @@
             {% do controls.update({'is_expanded':true}) %}
         {% endif %}
         {% set form_markup = _filters_form(controls, form) %}
-        {% call() expandable(controls) %}
+        {% call() expandable(controls, expandable_cue_additional_text='filters') %}
             {{ form_markup | safe }}
         {% endcall %}
         {% for field in form %}


### PR DESCRIPTION
See platform issue 2393 for context.

The expandable text we see on filterable list pages, such as https://www.consumerfinance.gov/about-us/blog, will now display "Show filters" and "Hide filters" instead of "Show" and "Hide".  Use of the expandable on non-filterable list pages will remain unaffected, as it is an optional parameter.

Screenshots:
<img width="709" alt="screen shot 2018-01-12 at 1 22 36 pm" src="https://user-images.githubusercontent.com/354591/34895692-b5bd3490-f79b-11e7-8385-a8a72014d791.png">
<img width="671" alt="screen shot 2018-01-12 at 1 22 30 pm" src="https://user-images.githubusercontent.com/354591/34895693-b5e0c6ee-f79b-11e7-86b3-c98b5c387d4c.png">
