### PR TITLE
Switch to using gulp-modernizr-build

### DIFF
--- a/gulp/tasks/scripts.js
+++ b/gulp/tasks/scripts.js
@@ -10,7 +10,7 @@ const configLegacy = config.legacy;
 const configScripts = config.scripts;
 const gulp = require( 'gulp' );
 const gulpConcat = require( 'gulp-concat' );
-const gulpModernizr = require( 'gulp-modernizr' );
+const gulpModernizrBuild = require( 'gulp-modernizr-build' );
 const gulpNewer = require( 'gulp-newer' );
 const gulpRename = require( 'gulp-rename' );
 const gulpReplace = require( 'gulp-replace' );
@@ -63,8 +63,8 @@ function scriptsPolyfill() {
        setClasses sets detection checks as feat/no-feat CSS in html element.
        html5printshiv enables use of HTML5 sectioning elements in IE8
        See https://github.com/aFarkas/html5shiv */
-    .pipe( gulpModernizr( {
-      tests:   [ 'csspointerevents', 'es5' ],
+    .pipe( gulpModernizrBuild( 'modernizr.min.js', {
+      addFeatures: [ 'css/pointerevents', 'es5/specification' ],
       options: [ 'setClasses', 'html5printshiv' ]
     } ) )
     .pipe( gulpUglify( {
@@ -72,7 +72,6 @@ function scriptsPolyfill() {
         properties: false
       }
     } ) )
-    .pipe( gulpRename( 'modernizr.min.js' ) )
     .on( 'error', handleErrors )
     .pipe( gulp.dest( paths.processed + '/js/' ) )
     .pipe( browserSync.reload( {

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,9 +32,9 @@
       }
     },
     "@types/node": {
-      "version": "8.5.7",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.5.7.tgz",
-      "integrity": "sha512-+1ZfzGIq8Y3EV7hPF7bs3i+Gi2mqYOiEGGRxGYPrn+hTYLMmzg+/5TkMkCHiRtLB38XSNvr/43aQ9+cUq4BbBg==",
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-9.3.0.tgz",
+      "integrity": "sha512-wNBfvNjzsJl4tswIZKXCFQY0lss9nKUyJnG6T94X/eqjRgI2jHZ4evdjhQYBSan/vGtF6XVXPApOmNH2rf0KKw==",
       "dev": true
     },
     "@types/q": {
@@ -91,7 +91,7 @@
         "lodash.pick": "4.4.0",
         "lodash.uniq": "4.5.0",
         "resolve": "1.5.0",
-        "semver": "5.4.1",
+        "semver": "5.5.0",
         "uglify-js": "2.8.29",
         "when": "3.7.8"
       }
@@ -465,9 +465,9 @@
       "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ="
     },
     "assertion-error": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.2.tgz",
-      "integrity": "sha1-E8pRXYYgbaC6xm6DTdOX2HWBCUw=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
       "dev": true
     },
     "assertion-error-formatter": {
@@ -531,11 +531,11 @@
       "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-7.2.4.tgz",
       "integrity": "sha512-am8jJ7Rbh1sy7FvLvNxxQScWvhv2FwLAS3bIhvrZpx9HbX5PEcc/7v6ecgpWuiu0Dwlj+p/z/1boHd8x60JFwA==",
       "requires": {
-        "browserslist": "2.11.0",
-        "caniuse-lite": "1.0.30000787",
+        "browserslist": "2.11.3",
+        "caniuse-lite": "1.0.30000792",
         "normalize-range": "0.1.2",
         "num2fraction": "1.2.2",
-        "postcss": "6.0.15",
+        "postcss": "6.0.16",
         "postcss-value-parser": "3.3.0"
       }
     },
@@ -1108,9 +1108,9 @@
         "babel-plugin-transform-es2015-unicode-regex": "6.24.1",
         "babel-plugin-transform-exponentiation-operator": "6.24.1",
         "babel-plugin-transform-regenerator": "6.26.0",
-        "browserslist": "2.11.0",
+        "browserslist": "2.11.3",
         "invariant": "2.2.2",
-        "semver": "5.4.1"
+        "semver": "5.5.0"
       }
     },
     "babel-register": {
@@ -1196,7 +1196,7 @@
       "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
       "requires": {
         "cache-base": "1.0.1",
-        "class-utils": "0.3.5",
+        "class-utils": "0.3.6",
         "component-emitter": "1.2.1",
         "define-property": "1.0.0",
         "isobject": "3.0.1",
@@ -1647,7 +1647,7 @@
       "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
       "requires": {
         "bn.js": "4.11.8",
-        "randombytes": "2.0.5"
+        "randombytes": "2.0.6"
       }
     },
     "browserify-sign": {
@@ -1673,11 +1673,11 @@
       }
     },
     "browserslist": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-2.11.0.tgz",
-      "integrity": "sha512-mNYp0RNeu1xueGuJFSXkU+K0nH+dBE/gcjtyhtNKfU8hwdrVIfoA7i5iFSjOmzkGdL2QaO7YX9ExiVPE7AY9JA==",
+      "version": "2.11.3",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-2.11.3.tgz",
+      "integrity": "sha512-yWu5cXT7Av6mVwzWc8lMsJMHWn4xyjSuGYi4IozbVTLUOEYPSagUB8kiMDUHA1fS3zjr8nkxkn9jdvug4BBRmA==",
       "requires": {
-        "caniuse-lite": "1.0.30000787",
+        "caniuse-lite": "1.0.30000792",
         "electron-to-chromium": "1.3.30"
       }
     },
@@ -1733,10 +1733,25 @@
         "vinyl": "1.2.0"
       },
       "dependencies": {
+        "clone": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.3.tgz",
+          "integrity": "sha1-KY1+IjFmD0DAA8LtMUDezz9TCF8="
+        },
+        "clone-stats": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
+          "integrity": "sha1-uI+UqCzzi4eR1YBG6kAprYjKmdE="
+        },
         "file-type": {
           "version": "3.9.0",
           "resolved": "https://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
           "integrity": "sha1-JXoHg4TR24CHvESdEH1SpSZyuek="
+        },
+        "replace-ext": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
+          "integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ="
         },
         "uuid": {
           "version": "2.0.3",
@@ -1771,9 +1786,9 @@
       "integrity": "sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug="
     },
     "cacache": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/cacache/-/cacache-10.0.1.tgz",
-      "integrity": "sha512-dRHYcs9LvG9cHgdPzjiI+/eS7e1xRhULrcyOx04RZQsszNJXU2SL9CyG60yLnge282Qq5nwTv+ieK2fH+WPZmA==",
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/cacache/-/cacache-10.0.2.tgz",
+      "integrity": "sha512-dljb7dk1jqO5ogE+dRpoR9tpHYv5xz9vPSNunh1+0wRuNdYxmzp9WmsyokgW/DUF1FDRVA/TMsmxt027R8djbQ==",
       "requires": {
         "bluebird": "3.5.1",
         "chownr": "1.0.1",
@@ -1788,17 +1803,6 @@
         "ssri": "5.0.0",
         "unique-filename": "1.1.0",
         "y18n": "3.2.1"
-      },
-      "dependencies": {
-        "lru-cache": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
-          "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
-          "requires": {
-            "pseudomap": "1.0.2",
-            "yallist": "2.1.2"
-          }
-        }
       }
     },
     "cache-base": {
@@ -1869,9 +1873,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30000787",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000787.tgz",
-      "integrity": "sha1-p2xPodasAGQER+yDwefGsz3WFcU="
+      "version": "1.0.30000792",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000792.tgz",
+      "integrity": "sha1-0M6pgfgRjzlhRxr7tDyaHlu/AzI="
     },
     "capitalize": {
       "version": "1.0.0",
@@ -2097,9 +2101,9 @@
             "babel-plugin-transform-es2015-unicode-regex": "6.24.1",
             "babel-plugin-transform-exponentiation-operator": "6.24.1",
             "babel-plugin-transform-regenerator": "6.26.0",
-            "browserslist": "2.11.0",
+            "browserslist": "2.11.3",
             "invariant": "2.2.2",
-            "semver": "5.4.1"
+            "semver": "5.5.0"
           }
         },
         "core-js": {
@@ -2118,12 +2122,12 @@
       "integrity": "sha1-D2RYS6ZC8PKs4oBiefTwbKI61zw=",
       "dev": true,
       "requires": {
-        "assertion-error": "1.0.2",
+        "assertion-error": "1.1.0",
         "check-error": "1.0.2",
         "deep-eql": "3.0.1",
         "get-func-name": "2.0.0",
         "pathval": "1.1.0",
-        "type-detect": "4.0.5"
+        "type-detect": "4.0.6"
       }
     },
     "chai-as-promised": {
@@ -2234,14 +2238,13 @@
       }
     },
     "class-utils": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.5.tgz",
-      "integrity": "sha1-F+eTEDdQ+WJ7IXbqNM/RtWWQPIA=",
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
+      "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
       "requires": {
         "arr-union": "3.1.0",
         "define-property": "0.2.5",
         "isobject": "3.0.1",
-        "lazy-cache": "2.0.2",
         "static-extend": "0.1.2"
       },
       "dependencies": {
@@ -2477,7 +2480,7 @@
             "got": "5.7.1",
             "registry-auth-token": "3.3.1",
             "registry-url": "3.1.0",
-            "semver": "5.4.1"
+            "semver": "5.5.0"
           }
         },
         "supports-color": {
@@ -2586,9 +2589,9 @@
       }
     },
     "clone": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.3.tgz",
-      "integrity": "sha1-KY1+IjFmD0DAA8LtMUDezz9TCF8="
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.1.tgz",
+      "integrity": "sha1-0hfR6WERjjrJpLi7oyhVU79kfNs="
     },
     "clone-buffer": {
       "version": "1.0.0",
@@ -2619,9 +2622,9 @@
       }
     },
     "clone-stats": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
-      "integrity": "sha1-uI+UqCzzi4eR1YBG6kAprYjKmdE="
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
+      "integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA="
     },
     "cloneable-readable": {
       "version": "1.0.0",
@@ -2639,9 +2642,9 @@
       "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
     },
     "coa": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/coa/-/coa-2.0.0.tgz",
-      "integrity": "sha1-r4geviFPwpvuTp52tJVrYTIpVUY=",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/coa/-/coa-2.0.1.tgz",
+      "integrity": "sha512-5wfTTO8E2/ja4jFSxePXlG5nRu5bBtL/r1HCIpJW/lzT6yDtKl0u0Z4o/Vpz32IpKmBn7HerheEZQgA9N2DarQ==",
       "optional": true,
       "requires": {
         "q": "1.5.1"
@@ -2702,9 +2705,9 @@
       }
     },
     "commander": {
-      "version": "2.12.2",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.12.2.tgz",
-      "integrity": "sha512-BFnaq5ZOGcDN7FlrtBT4xxkgIToalIIxwjxLWVJ8bGTpe1LroqMiqQXdA7ygc7CRvaYS+9zfPGFnJqFSayx+AA=="
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.13.0.tgz",
+      "integrity": "sha512-MVuS359B+YzaWqjCL/c+22gfryv+mCBPHAv3zyVI2GN8EY6IRP8VwtasXn8jyyhvvq84R4ImN1OKRtcbIasjYA=="
     },
     "commondir": {
       "version": "1.0.1",
@@ -2742,18 +2745,11 @@
       }
     },
     "concat-with-sourcemaps": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/concat-with-sourcemaps/-/concat-with-sourcemaps-1.0.4.tgz",
-      "integrity": "sha1-9Vs74q60dgGxCi1SWcz7cP0vHdY=",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/concat-with-sourcemaps/-/concat-with-sourcemaps-1.0.5.tgz",
+      "integrity": "sha512-YtnS0VEY+e2Khzsey/6mra9EoM6h/5gxaC0e3mcHpA5yfDxafhygytNmcJWodvUgyXzSiL5MSkPO6bQGgfliHw==",
       "requires": {
-        "source-map": "0.5.7"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
-        }
+        "source-map": "0.6.1"
       }
     },
     "configstore": {
@@ -2935,17 +2931,6 @@
         "lru-cache": "4.1.1",
         "shebang-command": "1.2.0",
         "which": "1.3.0"
-      },
-      "dependencies": {
-        "lru-cache": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
-          "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
-          "requires": {
-            "pseudomap": "1.0.2",
-            "yallist": "2.1.2"
-          }
-        }
       }
     },
     "cryptiles": {
@@ -2970,7 +2955,7 @@
         "inherits": "2.0.3",
         "pbkdf2": "3.0.14",
         "public-encrypt": "4.0.0",
-        "randombytes": "2.0.5",
+        "randombytes": "2.0.6",
         "randomfill": "1.0.3"
       }
     },
@@ -3071,6 +3056,7 @@
       "version": "1.0.0-alpha25",
       "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.0.0-alpha25.tgz",
       "integrity": "sha512-XC6xLW/JqIGirnZuUWHXCHRaAjje2b3OIB0Vj5RIJo6mIi/AdJo30quQl5LxUl0gkXDIrTrFGbMlcZjyFplz1A==",
+      "optional": true,
       "requires": {
         "mdn-data": "1.0.0",
         "source-map": "0.5.7"
@@ -3079,7 +3065,8 @@
         "source-map": {
           "version": "0.5.7",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "optional": true
         }
       }
     },
@@ -3096,12 +3083,30 @@
       "optional": true
     },
     "csso": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/csso/-/csso-3.4.0.tgz",
-      "integrity": "sha1-V7J+9VPMy/WqlkxkF0hkHprxE/M=",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/csso/-/csso-3.5.0.tgz",
+      "integrity": "sha512-WtJjFP3ZsSdWhiZr4/k1B9uHPgYjFYnDxfbaJxk1hz5PDLIJ5BCRWkJqaztZ0DbP8d2ZIVwUPIJb2YmCwkPaMw==",
       "optional": true,
       "requires": {
-        "css-tree": "1.0.0-alpha25"
+        "css-tree": "1.0.0-alpha.27"
+      },
+      "dependencies": {
+        "css-tree": {
+          "version": "1.0.0-alpha.27",
+          "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.0.0-alpha.27.tgz",
+          "integrity": "sha512-BAYp9FyN4jLXjfvRpTDchBllDptqlK9I7OsagXCG9Am5C+5jc8eRZHgqb9x500W2OKS14MMlpQc/nmh/aA7TEQ==",
+          "optional": true,
+          "requires": {
+            "mdn-data": "1.0.0",
+            "source-map": "0.5.7"
+          }
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "optional": true
+        }
       }
     },
     "cssom": {
@@ -3130,7 +3135,7 @@
         "bluebird": "3.5.1",
         "cli-table": "0.3.1",
         "colors": "1.1.2",
-        "commander": "2.12.2",
+        "commander": "2.13.0",
         "cucumber-expressions": "5.0.7",
         "cucumber-tag-expressions": "1.1.1",
         "duration": "0.2.0",
@@ -3184,62 +3189,6 @@
         "array-find-index": "1.0.2"
       }
     },
-    "customizr": {
-      "version": "1.0.0-alpha",
-      "resolved": "https://registry.npmjs.org/customizr/-/customizr-1.0.0-alpha.tgz",
-      "integrity": "sha1-fuWHH04K7vONKj+wPIBLrmG8Ie4=",
-      "requires": {
-        "colors": "0.6.2",
-        "deep-equal": "0.1.2",
-        "glob": "3.2.11",
-        "grunt-legacy-log": "0.1.3",
-        "mkdirp": "0.3.5",
-        "modernizr": "3.5.0",
-        "nopt": "2.1.2",
-        "optimist": "0.6.1",
-        "promised-io": "0.3.5",
-        "underscore": "1.5.2",
-        "win-spawn": "2.0.0"
-      },
-      "dependencies": {
-        "colors": {
-          "version": "0.6.2",
-          "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
-          "integrity": "sha1-JCP+ZnisDF2uiFLl0OW+CMmXq8w="
-        },
-        "glob": {
-          "version": "3.2.11",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
-          "integrity": "sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=",
-          "requires": {
-            "inherits": "2.0.3",
-            "minimatch": "0.3.0"
-          }
-        },
-        "minimatch": {
-          "version": "0.3.0",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
-          "integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=",
-          "requires": {
-            "lru-cache": "2.7.3",
-            "sigmund": "1.0.1"
-          }
-        },
-        "mkdirp": {
-          "version": "0.3.5",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz",
-          "integrity": "sha1-3j5fiWHIjHh+4TaN+EmsRBPsqNc="
-        },
-        "nopt": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/nopt/-/nopt-2.1.2.tgz",
-          "integrity": "sha1-bMzZd7gBMqB3MdbozljCyDA8+a8=",
-          "requires": {
-            "abbrev": "1.1.1"
-          }
-        }
-      }
-    },
     "cyclist": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/cyclist/-/cyclist-0.2.2.tgz",
@@ -3250,7 +3199,7 @@
       "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
       "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
       "requires": {
-        "es5-ext": "0.10.37"
+        "es5-ext": "0.10.38"
       }
     },
     "dashdash": {
@@ -3332,6 +3281,16 @@
         "vinyl-fs": "2.4.4"
       },
       "dependencies": {
+        "clone": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.3.tgz",
+          "integrity": "sha1-KY1+IjFmD0DAA8LtMUDezz9TCF8="
+        },
+        "clone-stats": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
+          "integrity": "sha1-uI+UqCzzi4eR1YBG6kAprYjKmdE="
+        },
         "glob": {
           "version": "5.0.15",
           "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
@@ -3415,6 +3374,11 @@
             "is-extglob": "2.1.1"
           }
         },
+        "is-valid-glob": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/is-valid-glob/-/is-valid-glob-0.3.0.tgz",
+          "integrity": "sha1-1LVcafUYhvm2XHDWwmItN+KfSP4="
+        },
         "isarray": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
@@ -3429,18 +3393,22 @@
             "readable-stream": "2.3.3"
           }
         },
+        "replace-ext": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
+          "integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ="
+        },
         "string_decoder": {
           "version": "0.10.31",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
           "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
         },
-        "unique-stream": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-2.2.1.tgz",
-          "integrity": "sha1-WqADz76Uxf+GbE59ZouxxNuts2k=",
+        "to-absolute-glob": {
+          "version": "0.1.1",
+          "resolved": "https://registry.npmjs.org/to-absolute-glob/-/to-absolute-glob-0.1.1.tgz",
+          "integrity": "sha1-HN+kcqnvUMI57maZm2YsoOs5k38=",
           "requires": {
-            "json-stable-stringify": "1.0.1",
-            "through2-filter": "2.0.0"
+            "extend-shallow": "2.0.1"
           }
         },
         "vinyl": {
@@ -3458,7 +3426,7 @@
           "resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-2.4.4.tgz",
           "integrity": "sha1-vm/zJwy1Xf19MGNkDegfJddTIjk=",
           "requires": {
-            "duplexify": "3.5.1",
+            "duplexify": "3.5.3",
             "glob-stream": "5.3.5",
             "graceful-fs": "4.1.11",
             "gulp-sourcemaps": "1.6.0",
@@ -3504,6 +3472,11 @@
           "version": "0.2.0",
           "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
           "integrity": "sha1-xhJqkK1Pctv1rNskPMN3JP6T/B8="
+        },
+        "clone-stats": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
+          "integrity": "sha1-uI+UqCzzi4eR1YBG6kAprYjKmdE="
         },
         "isarray": {
           "version": "0.0.1",
@@ -3570,6 +3543,11 @@
           "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
           "integrity": "sha1-xhJqkK1Pctv1rNskPMN3JP6T/B8="
         },
+        "clone-stats": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
+          "integrity": "sha1-uI+UqCzzi4eR1YBG6kAprYjKmdE="
+        },
         "isarray": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
@@ -3634,6 +3612,11 @@
           "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
           "integrity": "sha1-xhJqkK1Pctv1rNskPMN3JP6T/B8="
         },
+        "clone-stats": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
+          "integrity": "sha1-uI+UqCzzi4eR1YBG6kAprYjKmdE="
+        },
         "isarray": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
@@ -3694,6 +3677,21 @@
         "yauzl": "2.9.1"
       },
       "dependencies": {
+        "clone": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.3.tgz",
+          "integrity": "sha1-KY1+IjFmD0DAA8LtMUDezz9TCF8="
+        },
+        "clone-stats": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
+          "integrity": "sha1-uI+UqCzzi4eR1YBG6kAprYjKmdE="
+        },
+        "replace-ext": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
+          "integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ="
+        },
         "vinyl": {
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
@@ -3712,13 +3710,8 @@
       "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
       "dev": true,
       "requires": {
-        "type-detect": "4.0.5"
+        "type-detect": "4.0.6"
       }
-    },
-    "deep-equal": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-0.1.2.tgz",
-      "integrity": "sha1-skbCuApXCkfBG+HZvRBw7IeLh84="
     },
     "deep-extend": {
       "version": "0.4.2",
@@ -3736,6 +3729,13 @@
       "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
       "requires": {
         "clone": "1.0.3"
+      },
+      "dependencies": {
+        "clone": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.3.tgz",
+          "integrity": "sha1-KY1+IjFmD0DAA8LtMUDezz9TCF8="
+        }
       }
     },
     "define-properties": {
@@ -3774,9 +3774,9 @@
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
     "depd": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.1.tgz",
-      "integrity": "sha1-V4O04cRZ8G+lyif5kfPQbnoxA1k="
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+      "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
     },
     "deprecated": {
       "version": "0.0.1",
@@ -3832,13 +3832,13 @@
       "requires": {
         "bn.js": "4.11.8",
         "miller-rabin": "4.0.1",
-        "randombytes": "2.0.5"
+        "randombytes": "2.0.6"
       }
     },
     "doctrine": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.0.2.tgz",
-      "integrity": "sha512-y0tm5Pq6ywp3qSTZ1vPgVdAnbDEoeoc5wlOHXoY1c4Wug/a7JvqHIl7BTvwodaHmejWkK/9dSb3sCYfyo/om8A==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+      "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
       "requires": {
         "esutils": "2.0.2"
       }
@@ -3923,6 +3923,16 @@
         "ware": "1.3.0"
       },
       "dependencies": {
+        "clone": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.3.tgz",
+          "integrity": "sha1-KY1+IjFmD0DAA8LtMUDezz9TCF8="
+        },
+        "clone-stats": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
+          "integrity": "sha1-uI+UqCzzi4eR1YBG6kAprYjKmdE="
+        },
         "glob": {
           "version": "5.0.15",
           "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
@@ -4006,6 +4016,11 @@
             "is-extglob": "2.1.1"
           }
         },
+        "is-valid-glob": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/is-valid-glob/-/is-valid-glob-0.3.0.tgz",
+          "integrity": "sha1-1LVcafUYhvm2XHDWwmItN+KfSP4="
+        },
         "isarray": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
@@ -4020,18 +4035,22 @@
             "readable-stream": "2.3.3"
           }
         },
+        "replace-ext": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
+          "integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ="
+        },
         "string_decoder": {
           "version": "0.10.31",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
           "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
         },
-        "unique-stream": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-2.2.1.tgz",
-          "integrity": "sha1-WqADz76Uxf+GbE59ZouxxNuts2k=",
+        "to-absolute-glob": {
+          "version": "0.1.1",
+          "resolved": "https://registry.npmjs.org/to-absolute-glob/-/to-absolute-glob-0.1.1.tgz",
+          "integrity": "sha1-HN+kcqnvUMI57maZm2YsoOs5k38=",
           "requires": {
-            "json-stable-stringify": "1.0.1",
-            "through2-filter": "2.0.0"
+            "extend-shallow": "2.0.1"
           }
         },
         "vinyl": {
@@ -4049,7 +4068,7 @@
           "resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-2.4.4.tgz",
           "integrity": "sha1-vm/zJwy1Xf19MGNkDegfJddTIjk=",
           "requires": {
-            "duplexify": "3.5.1",
+            "duplexify": "3.5.3",
             "glob-stream": "5.3.5",
             "graceful-fs": "4.1.11",
             "gulp-sourcemaps": "1.6.0",
@@ -4107,24 +4126,14 @@
       "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI="
     },
     "duplexify": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.5.1.tgz",
-      "integrity": "sha512-j5goxHTwVED1Fpe5hh3q9R93Kip0Bg2KVAt4f8CEYM3UEwYcPSvWbXaUQOzdX/HtiNomipv+gU7ASQPDbV7pGQ==",
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.5.3.tgz",
+      "integrity": "sha512-g8ID9OroF9hKt2POf8YLayy+9594PzmM3scI00/uBXocX3TWNgoB67hjzkFe9ITAbQOne/lLdBxHXvYUM4ZgGA==",
       "requires": {
-        "end-of-stream": "1.4.0",
+        "end-of-stream": "1.4.1",
         "inherits": "2.0.3",
         "readable-stream": "2.3.3",
         "stream-shift": "1.0.0"
-      },
-      "dependencies": {
-        "end-of-stream": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.0.tgz",
-          "integrity": "sha1-epDYM+/abPpurA9JSduw+tOmMgY=",
-          "requires": {
-            "once": "1.4.0"
-          }
-        }
       }
     },
     "duration": {
@@ -4134,7 +4143,7 @@
       "dev": true,
       "requires": {
         "d": "0.1.1",
-        "es5-ext": "0.10.37"
+        "es5-ext": "0.10.38"
       },
       "dependencies": {
         "d": {
@@ -4143,7 +4152,7 @@
           "integrity": "sha1-2hhMU10Y2O57oqoim5FACfrhEwk=",
           "dev": true,
           "requires": {
-            "es5-ext": "0.10.37"
+            "es5-ext": "0.10.38"
           }
         }
       }
@@ -4259,21 +4268,11 @@
       "integrity": "sha1-eePVhlU0aQn+bw9Fpd5oEDspTSA="
     },
     "end-of-stream": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-0.1.5.tgz",
-      "integrity": "sha1-jhdyBsPICDfYVjLouTWd/osvbq8=",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
+      "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
       "requires": {
-        "once": "1.3.3"
-      },
-      "dependencies": {
-        "once": {
-          "version": "1.3.3",
-          "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
-          "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
-          "requires": {
-            "wrappy": "1.0.2"
-          }
-        }
+        "once": "1.4.0"
       }
     },
     "engine.io": {
@@ -4315,7 +4314,7 @@
         "parseqs": "0.0.5",
         "parseuri": "0.0.5",
         "ws": "3.3.3",
-        "xmlhttprequest-ssl": "1.5.4",
+        "xmlhttprequest-ssl": "1.5.5",
         "yeast": "0.1.2"
       }
     },
@@ -4396,9 +4395,9 @@
       }
     },
     "es5-ext": {
-      "version": "0.10.37",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.37.tgz",
-      "integrity": "sha1-DudB0Ui4AGm6J9AgOTdWryV978M=",
+      "version": "0.10.38",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.38.tgz",
+      "integrity": "sha512-jCMyePo7AXbUESwbl8Qi01VSH2piY9s/a3rSU/5w/MlTIx8HPL1xn2InGN8ejt/xulcJgnTO7vqNtOAxzYd2Kg==",
       "requires": {
         "es6-iterator": "2.0.3",
         "es6-symbol": "3.1.1"
@@ -4410,7 +4409,7 @@
       "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.37",
+        "es5-ext": "0.10.38",
         "es6-symbol": "3.1.1"
       }
     },
@@ -4420,7 +4419,7 @@
       "integrity": "sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=",
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.37",
+        "es5-ext": "0.10.38",
         "es6-iterator": "2.0.3",
         "es6-set": "0.1.5",
         "es6-symbol": "3.1.1",
@@ -4438,7 +4437,7 @@
       "integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.37",
+        "es5-ext": "0.10.38",
         "es6-iterator": "2.0.3",
         "es6-symbol": "3.1.1",
         "event-emitter": "0.3.5"
@@ -4450,7 +4449,7 @@
       "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.37"
+        "es5-ext": "0.10.38"
       }
     },
     "es6-weak-map": {
@@ -4459,7 +4458,7 @@
       "integrity": "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=",
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.37",
+        "es5-ext": "0.10.38",
         "es6-iterator": "2.0.3",
         "es6-symbol": "3.1.1"
       }
@@ -4519,9 +4518,9 @@
       }
     },
     "eslint": {
-      "version": "4.14.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.14.0.tgz",
-      "integrity": "sha512-Ul6CSGRjKscEyg0X/EeNs7o2XdnbTEOD1OM8cTjmx85RPcBJQrEhZLevhuJZNAE/vS2iVl5Uhgiqf3h5uLMCJQ==",
+      "version": "4.15.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.15.0.tgz",
+      "integrity": "sha512-zEO/Z1ZUxIQ+MhDVKkVTUYpIPDTEJLXGMrkID+5v1NeQHtCz6FZikWuFRgxE1Q/RV2V4zVl1u3xmpPADHhMZ6A==",
       "requires": {
         "ajv": "5.5.2",
         "babel-code-frame": "6.26.0",
@@ -4529,7 +4528,7 @@
         "concat-stream": "1.6.0",
         "cross-spawn": "5.1.0",
         "debug": "3.1.0",
-        "doctrine": "2.0.2",
+        "doctrine": "2.1.0",
         "eslint-scope": "3.7.1",
         "eslint-visitor-keys": "1.0.0",
         "espree": "3.5.2",
@@ -4555,7 +4554,7 @@
         "pluralize": "7.0.0",
         "progress": "2.0.0",
         "require-uncached": "1.0.3",
-        "semver": "5.4.1",
+        "semver": "5.5.0",
         "strip-ansi": "4.0.0",
         "strip-json-comments": "2.0.1",
         "table": "4.0.2",
@@ -4667,7 +4666,7 @@
       "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.37"
+        "es5-ext": "0.10.38"
       }
     },
     "eventemitter3": {
@@ -4991,7 +4990,7 @@
       "requires": {
         "detect-file": "1.0.0",
         "is-glob": "3.1.0",
-        "micromatch": "3.1.4",
+        "micromatch": "3.1.5",
         "resolve-dir": "1.0.1"
       },
       "dependencies": {
@@ -5048,9 +5047,9 @@
           }
         },
         "extglob": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.3.tgz",
-          "integrity": "sha512-AyptZexgu7qppEPq59DtN/XJGZDrLcVxSHai+4hdgMMS9EpF4GBvygcWWApno8lL9qSjVpYt7Raao28qzJX1ww==",
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
+          "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
           "requires": {
             "array-unique": "0.3.2",
             "define-property": "1.0.0",
@@ -5168,19 +5167,19 @@
           "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
         },
         "micromatch": {
-          "version": "3.1.4",
-          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.4.tgz",
-          "integrity": "sha512-kFRtviKYoAJT+t7HggMl0tBFGNAKLw/S7N+CO9qfEQyisob1Oy4pao+geRbkyeEd+V9aOkvZ4mhuyPvI/q9Sfg==",
+          "version": "3.1.5",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.5.tgz",
+          "integrity": "sha512-ykttrLPQrz1PUJcXjwsTUjGoPJ64StIGNE2lGVD1c9CuguJ+L7/navsE8IcDNndOoCMvYV0qc/exfVbMHkUhvA==",
           "requires": {
             "arr-diff": "4.0.0",
             "array-unique": "0.3.2",
             "braces": "2.3.0",
             "define-property": "1.0.0",
             "extend-shallow": "2.0.1",
-            "extglob": "2.0.3",
+            "extglob": "2.0.4",
             "fragment-cache": "0.2.1",
             "kind-of": "6.0.2",
-            "nanomatch": "1.2.6",
+            "nanomatch": "1.2.7",
             "object.pick": "1.3.0",
             "regex-not": "1.0.0",
             "snapdragon": "0.8.1",
@@ -6068,13 +6067,6 @@
             }
           }
         },
-        "string_decoder": {
-          "version": "1.0.1",
-          "bundled": true,
-          "requires": {
-            "safe-buffer": "5.0.1"
-          }
-        },
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
@@ -6223,7 +6215,7 @@
       "resolved": "https://registry.npmjs.org/get-proxy/-/get-proxy-1.1.0.tgz",
       "integrity": "sha1-iUhUSRvFkbDxR9euVw9cZ4tyVus=",
       "requires": {
-        "rc": "1.2.2"
+        "rc": "1.2.3"
       }
     },
     "get-stdin": {
@@ -6387,6 +6379,11 @@
             "readable-stream": "1.0.34",
             "xtend": "4.0.1"
           }
+        },
+        "unique-stream": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-1.0.0.tgz",
+          "integrity": "sha1-1ZpKdUJ0R9mqbJHnAmP40mpLEEs="
         }
       }
     },
@@ -6494,6 +6491,11 @@
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-1.0.2.tgz",
           "integrity": "sha1-j1dWDIO1n8JwvT1WG2kAQ0MOJVE="
+        },
+        "lru-cache": {
+          "version": "2.7.3",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
+          "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI="
         },
         "minimatch": {
           "version": "0.2.14",
@@ -6614,52 +6616,6 @@
       "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
       "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE="
     },
-    "grunt-legacy-log": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/grunt-legacy-log/-/grunt-legacy-log-0.1.3.tgz",
-      "integrity": "sha1-7ClCboAwIa9ZAp+H0vnNczWgVTE=",
-      "requires": {
-        "colors": "0.6.2",
-        "grunt-legacy-log-utils": "0.1.1",
-        "hooker": "0.2.3",
-        "lodash": "2.4.2",
-        "underscore.string": "2.3.3"
-      },
-      "dependencies": {
-        "colors": {
-          "version": "0.6.2",
-          "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
-          "integrity": "sha1-JCP+ZnisDF2uiFLl0OW+CMmXq8w="
-        },
-        "lodash": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
-          "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4="
-        }
-      }
-    },
-    "grunt-legacy-log-utils": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/grunt-legacy-log-utils/-/grunt-legacy-log-utils-0.1.1.tgz",
-      "integrity": "sha1-wHBrndkGThFvNvI/5OawSGcsD34=",
-      "requires": {
-        "colors": "0.6.2",
-        "lodash": "2.4.2",
-        "underscore.string": "2.3.3"
-      },
-      "dependencies": {
-        "colors": {
-          "version": "0.6.2",
-          "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
-          "integrity": "sha1-JCP+ZnisDF2uiFLl0OW+CMmXq8w="
-        },
-        "lodash": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
-          "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4="
-        }
-      }
-    },
     "gtoken": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-1.2.3.tgz",
@@ -6733,7 +6689,7 @@
       "integrity": "sha512-R4wxmX57EDhJ5NP+uwnS+sHj+G9JhMCXP17WXtEsZjx0Cay0NQKVfgkEWiAOLs5oaZAZ9S60zg1wcATTah92EA==",
       "requires": {
         "bless": "4.0.4",
-        "concat-with-sourcemaps": "1.0.4",
+        "concat-with-sourcemaps": "1.0.5",
         "gulp-util": "3.0.8",
         "lodash.isfunction": "3.0.8",
         "lodash.isstring": "4.0.1",
@@ -6791,13 +6747,6 @@
         "replace-ext": "1.0.0",
         "through2": "2.0.3",
         "touch": "3.1.0"
-      },
-      "dependencies": {
-        "replace-ext": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
-          "integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs="
-        }
       }
     },
     "gulp-clean-css": {
@@ -6816,39 +6765,9 @@
       "resolved": "https://registry.npmjs.org/gulp-concat/-/gulp-concat-2.6.1.tgz",
       "integrity": "sha1-Yz0WyV2IUEYorQJmVmPO5aR5M1M=",
       "requires": {
-        "concat-with-sourcemaps": "1.0.4",
+        "concat-with-sourcemaps": "1.0.5",
         "through2": "2.0.3",
         "vinyl": "2.1.0"
-      },
-      "dependencies": {
-        "clone": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.1.tgz",
-          "integrity": "sha1-0hfR6WERjjrJpLi7oyhVU79kfNs="
-        },
-        "clone-stats": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
-          "integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA="
-        },
-        "replace-ext": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
-          "integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs="
-        },
-        "vinyl": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.1.0.tgz",
-          "integrity": "sha1-Ah+cLPlR1rk5lDyJ617lrdT9kkw=",
-          "requires": {
-            "clone": "2.1.1",
-            "clone-buffer": "1.0.0",
-            "clone-stats": "1.0.0",
-            "cloneable-readable": "1.0.0",
-            "remove-trailing-separator": "1.1.0",
-            "replace-ext": "1.0.0"
-          }
-        }
       }
     },
     "gulp-decompress": {
@@ -6867,7 +6786,7 @@
       "resolved": "https://registry.npmjs.org/gulp-eslint/-/gulp-eslint-4.0.1.tgz",
       "integrity": "sha512-MPafTtjHqV03g+ElSqvVXPjWQJafmBtSitF3dbTSD5ObcPjz353TGcR0LfCM0tqpBAQCywDL2siYKetnrxkjvg==",
       "requires": {
-        "eslint": "4.14.0",
+        "eslint": "4.15.0",
         "fancy-log": "1.3.2",
         "plugin-error": "0.1.2"
       }
@@ -6877,7 +6796,7 @@
       "resolved": "https://registry.npmjs.org/gulp-header/-/gulp-header-1.8.9.tgz",
       "integrity": "sha1-yfEP7gYy2B6Tl4nG7PRaFRvzCYs=",
       "requires": {
-        "concat-with-sourcemaps": "1.0.4",
+        "concat-with-sourcemaps": "1.0.5",
         "gulp-util": "3.0.8",
         "object-assign": "4.1.1",
         "through2": "2.0.3"
@@ -6939,13 +6858,6 @@
         "replace-ext": "1.0.0",
         "through2": "2.0.3",
         "vinyl-sourcemaps-apply": "0.2.1"
-      },
-      "dependencies": {
-        "replace-ext": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
-          "integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs="
-        }
       }
     },
     "gulp-mocha": {
@@ -6961,215 +6873,15 @@
         "through": "2.3.8"
       }
     },
-    "gulp-modernizr": {
-      "version": "1.0.0-alpha",
-      "resolved": "https://registry.npmjs.org/gulp-modernizr/-/gulp-modernizr-1.0.0-alpha.tgz",
-      "integrity": "sha1-C0z/IIRY9SHAaZKd+7FAhfAPawc=",
+    "gulp-modernizr-build": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/gulp-modernizr-build/-/gulp-modernizr-build-0.0.5.tgz",
+      "integrity": "sha1-Kxes5OPaaye+99aYg4cBlWu0sLc=",
       "requires": {
-        "customizr": "1.0.0-alpha",
-        "grunt-legacy-log": "0.1.3",
-        "gulp-util": "2.2.20",
-        "through2": "0.4.2"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "0.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
-          "integrity": "sha1-DY6UaWej2BQ/k+JOKYUl/BsiNfk="
-        },
-        "ansi-styles": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz",
-          "integrity": "sha1-6uy/Zs1waIJ2Cy9GkVgrj1XXp94="
-        },
-        "chalk": {
-          "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
-          "integrity": "sha1-Zjs6ZItotV0EaQ1JFnqoN4WPIXQ=",
-          "requires": {
-            "ansi-styles": "1.1.0",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "0.1.0",
-            "strip-ansi": "0.3.0",
-            "supports-color": "0.2.0"
-          }
-        },
-        "dateformat": {
-          "version": "1.0.12",
-          "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz",
-          "integrity": "sha1-nxJLZ1lMk3/3BpMuSmQsyo27/uk=",
-          "requires": {
-            "get-stdin": "4.0.1",
-            "meow": "3.7.0"
-          }
-        },
-        "gulp-util": {
-          "version": "2.2.20",
-          "resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-2.2.20.tgz",
-          "integrity": "sha1-1xRuVyiRC9jwR6awseVJvCLb1kw=",
-          "requires": {
-            "chalk": "0.5.1",
-            "dateformat": "1.0.12",
-            "lodash._reinterpolate": "2.4.1",
-            "lodash.template": "2.4.1",
-            "minimist": "0.2.0",
-            "multipipe": "0.1.2",
-            "through2": "0.5.1",
-            "vinyl": "0.2.3"
-          },
-          "dependencies": {
-            "through2": {
-              "version": "0.5.1",
-              "resolved": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
-              "integrity": "sha1-390BLrnHAOIyP9M084rGIqs3Lac=",
-              "requires": {
-                "readable-stream": "1.0.34",
-                "xtend": "3.0.0"
-              }
-            }
-          }
-        },
-        "has-ansi": {
-          "version": "0.1.0",
-          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
-          "integrity": "sha1-hPJlqujA5qiKEtcCKJS3VoiUxi4=",
-          "requires": {
-            "ansi-regex": "0.2.1"
-          }
-        },
-        "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
-        },
-        "lodash._reinterpolate": {
-          "version": "2.4.1",
-          "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-2.4.1.tgz",
-          "integrity": "sha1-TxInqlqHEfxjL1sHofRgequLMiI="
-        },
-        "lodash.defaults": {
-          "version": "2.4.1",
-          "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-2.4.1.tgz",
-          "integrity": "sha1-p+iIXwXmiFEUS24SqPNngCa8TFQ=",
-          "requires": {
-            "lodash._objecttypes": "2.4.1",
-            "lodash.keys": "2.4.1"
-          }
-        },
-        "lodash.escape": {
-          "version": "2.4.1",
-          "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-2.4.1.tgz",
-          "integrity": "sha1-LOEsXghNsKV92l5dHu659dF1o7Q=",
-          "requires": {
-            "lodash._escapehtmlchar": "2.4.1",
-            "lodash._reunescapedhtml": "2.4.1",
-            "lodash.keys": "2.4.1"
-          }
-        },
-        "lodash.keys": {
-          "version": "2.4.1",
-          "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz",
-          "integrity": "sha1-SN6kbfj/djKxDXBrissmWR4rNyc=",
-          "requires": {
-            "lodash._isnative": "2.4.1",
-            "lodash._shimkeys": "2.4.1",
-            "lodash.isobject": "2.4.1"
-          }
-        },
-        "lodash.template": {
-          "version": "2.4.1",
-          "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-2.4.1.tgz",
-          "integrity": "sha1-nmEQB+32KRKal0qzxIuBez4c8g0=",
-          "requires": {
-            "lodash._escapestringchar": "2.4.1",
-            "lodash._reinterpolate": "2.4.1",
-            "lodash.defaults": "2.4.1",
-            "lodash.escape": "2.4.1",
-            "lodash.keys": "2.4.1",
-            "lodash.templatesettings": "2.4.1",
-            "lodash.values": "2.4.1"
-          }
-        },
-        "lodash.templatesettings": {
-          "version": "2.4.1",
-          "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-2.4.1.tgz",
-          "integrity": "sha1-6nbHXRHrhtTb6JqDiTu4YZKaxpk=",
-          "requires": {
-            "lodash._reinterpolate": "2.4.1",
-            "lodash.escape": "2.4.1"
-          }
-        },
-        "minimist": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.2.0.tgz",
-          "integrity": "sha1-Tf/lJdriuGTGbC4jxicdev3s784="
-        },
-        "object-keys": {
-          "version": "0.4.0",
-          "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
-          "integrity": "sha1-KKaq50KN0sOpLz2V8hM13SBOAzY="
-        },
-        "readable-stream": {
-          "version": "1.0.34",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
-          }
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
-        },
-        "strip-ansi": {
-          "version": "0.3.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
-          "integrity": "sha1-JfSOoiynkYfzF0pNuHWTR7sSYiA=",
-          "requires": {
-            "ansi-regex": "0.2.1"
-          }
-        },
-        "supports-color": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz",
-          "integrity": "sha1-2S3iaU6z9nMjlz1649i1W0wiGQo="
-        },
-        "through2": {
-          "version": "0.4.2",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-0.4.2.tgz",
-          "integrity": "sha1-2/WGYDEVHsg1K7bE22SiKSqEC5s=",
-          "requires": {
-            "readable-stream": "1.0.34",
-            "xtend": "2.1.2"
-          },
-          "dependencies": {
-            "xtend": {
-              "version": "2.1.2",
-              "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
-              "integrity": "sha1-bv7MKk2tjmlixJAbM3znuoe10os=",
-              "requires": {
-                "object-keys": "0.4.0"
-              }
-            }
-          }
-        },
-        "vinyl": {
-          "version": "0.2.3",
-          "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.2.3.tgz",
-          "integrity": "sha1-vKk4IJWC7FpJrVOKAPofEl5RMlI=",
-          "requires": {
-            "clone-stats": "0.0.1"
-          }
-        },
-        "xtend": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz",
-          "integrity": "sha1-XM50B7r2Qsunvs2laBEcST9ZZlo="
-        }
+        "gulp-util": "3.0.8",
+        "lodash.defaults": "4.2.0",
+        "modernizr": "3.5.0",
+        "through2": "2.0.3"
       }
     },
     "gulp-mq-remove": {
@@ -7204,6 +6916,11 @@
             "strip-ansi": "0.3.0",
             "supports-color": "0.2.0"
           }
+        },
+        "clone-stats": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
+          "integrity": "sha1-uI+UqCzzi4eR1YBG6kAprYjKmdE="
         },
         "css": {
           "version": "1.6.0",
@@ -7384,7 +7101,7 @@
         "ansi-colors": "1.0.1",
         "fancy-log": "1.3.2",
         "lodash.template": "4.4.0",
-        "node-notifier": "5.1.2",
+        "node-notifier": "5.2.1",
         "node.extend": "1.1.6",
         "plugin-error": "0.1.2",
         "through2": "2.0.3"
@@ -7416,7 +7133,7 @@
       "requires": {
         "fancy-log": "1.3.2",
         "plugin-error": "0.1.2",
-        "postcss": "6.0.15",
+        "postcss": "6.0.16",
         "postcss-load-config": "1.2.0",
         "vinyl-sourcemaps-apply": "0.2.1"
       }
@@ -7464,16 +7181,16 @@
         "lodash": "4.17.4",
         "make-error-cause": "1.2.2",
         "through2": "2.0.3",
-        "uglify-js": "3.3.4",
+        "uglify-js": "3.3.7",
         "vinyl-sourcemaps-apply": "0.2.1"
       },
       "dependencies": {
         "uglify-js": {
-          "version": "3.3.4",
-          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.3.4.tgz",
-          "integrity": "sha512-hfIwuAQI5dlXP30UtdmWoYF9k+ypVqBXIdmd6ZKBiaNHHvA8ty7ZloMe3+7S5AEKVkxHbjByl4DfRHQ7QpZquw==",
+          "version": "3.3.7",
+          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.3.7.tgz",
+          "integrity": "sha512-esJIpNQIC44EFSrbeFPhiXHy2HJ+dTcnn0Zdkn+5meuLsvoV0mFJffKlyezNIIHNfhF0NpgbifygCfEyAogIhQ==",
           "requires": {
-            "commander": "2.12.2",
+            "commander": "2.13.0",
             "source-map": "0.6.1"
           }
         }
@@ -7521,15 +7238,40 @@
             "supports-color": "2.0.0"
           }
         },
+        "clone": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.3.tgz",
+          "integrity": "sha1-KY1+IjFmD0DAA8LtMUDezz9TCF8="
+        },
+        "clone-stats": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
+          "integrity": "sha1-uI+UqCzzi4eR1YBG6kAprYjKmdE="
+        },
         "object-assign": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
           "integrity": "sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I="
         },
+        "replace-ext": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
+          "integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ="
+        },
         "supports-color": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
           "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+        },
+        "vinyl": {
+          "version": "0.5.3",
+          "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz",
+          "integrity": "sha1-sEVbOPxeDPMNQyUTLkYZcMIJHN4=",
+          "requires": {
+            "clone": "1.0.3",
+            "clone-stats": "0.0.1",
+            "replace-ext": "0.0.1"
+          }
         }
       }
     },
@@ -7781,11 +7523,6 @@
         "parse-passwd": "1.0.0"
       }
     },
-    "hooker": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz",
-      "integrity": "sha1-uDT3I8xKJCqmWWNFnfbZhMXT2Vk="
-    },
     "hosted-git-info": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
@@ -7919,11 +7656,6 @@
           "version": "2.3.0",
           "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
           "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
-        },
-        "replace-ext": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
-          "integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs="
         }
       }
     },
@@ -8569,7 +8301,7 @@
         "p-any": "1.1.0",
         "p-timeout": "1.2.1",
         "pify": "3.0.0",
-        "port-numbers": "2.0.15",
+        "port-numbers": "2.0.17",
         "prepend-http": "1.0.4",
         "router-ips": "1.0.0",
         "url-parse": "1.2.0"
@@ -8685,11 +8417,6 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
       "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI="
-    },
-    "is-valid-glob": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/is-valid-glob/-/is-valid-glob-0.3.0.tgz",
-      "integrity": "sha1-1LVcafUYhvm2XHDWwmItN+KfSP4="
     },
     "is-windows": {
       "version": "1.0.1",
@@ -9157,7 +8884,7 @@
             "stringstream": "0.0.5",
             "tough-cookie": "2.3.3",
             "tunnel-agent": "0.6.0",
-            "uuid": "3.1.0"
+            "uuid": "3.2.1"
           }
         },
         "sntp": {
@@ -9985,16 +9712,20 @@
       }
     },
     "lru-cache": {
-      "version": "2.7.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
-      "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI="
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
+      "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
+      "requires": {
+        "pseudomap": "1.0.2",
+        "yallist": "2.1.2"
+      }
     },
     "lru-queue": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/lru-queue/-/lru-queue-0.1.0.tgz",
       "integrity": "sha1-Jzi9nw089PhEkMVzbEhpmsYyzaM=",
       "requires": {
-        "es5-ext": "0.10.37"
+        "es5-ext": "0.10.38"
       }
     },
     "make-dir": {
@@ -10114,7 +9845,7 @@
       "integrity": "sha1-vemBdmPJ5A/bKk6hw2cpYIeujI8=",
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.37",
+        "es5-ext": "0.10.38",
         "es6-weak-map": "2.0.2",
         "event-emitter": "0.3.5",
         "is-promise": "2.1.0",
@@ -10248,22 +9979,23 @@
       "integrity": "sha1-0gFYPrEjJ+PFwWQqQEqcrPlONPU=",
       "requires": {
         "concat-stream": "1.6.0",
-        "duplexify": "3.5.1",
-        "end-of-stream": "1.4.0",
+        "duplexify": "3.5.3",
+        "end-of-stream": "1.4.1",
         "flush-write-stream": "1.0.2",
         "from2": "2.3.0",
         "parallel-transform": "1.1.0",
         "pump": "1.0.3",
-        "pumpify": "1.3.5",
+        "pumpify": "1.3.6",
         "stream-each": "1.2.2",
         "through2": "2.0.3"
       },
       "dependencies": {
-        "end-of-stream": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.0.tgz",
-          "integrity": "sha1-epDYM+/abPpurA9JSduw+tOmMgY=",
+        "pump": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/pump/-/pump-1.0.3.tgz",
+          "integrity": "sha512-8k0JupWme55+9tCVE+FS5ULT3K6AbgqrGa58lTT49RpyfwwcGedHqaC5LlQNdEAumn/wFsu6aPwkuPMioy8kqw==",
           "requires": {
+            "end-of-stream": "1.4.1",
             "once": "1.4.0"
           }
         }
@@ -10507,9 +10239,9 @@
       "integrity": "sha512-yw4Fhe2/UTzanQ4f0yHWkRnfTuHZFAi4GZDjXS4G+qv5BqXTqPJBbSxpa7MyyW9v4Y4ZySZQik1vcbNkhdnIOg=="
     },
     "nanomatch": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.6.tgz",
-      "integrity": "sha512-WJ6XTCbvWXUFPbi/bDwKcYkCeOGUHzaJj72KbuPqGn78Ba/F5Vu26Zlo6SuMQbCIst1RGKL1zfWBCOGAlbRLAg==",
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.7.tgz",
+      "integrity": "sha512-/5ldsnyurvEw7wNpxLFgjVvBLMta43niEYOy0CJ4ntcYSbx6bugRUTQeFb4BR/WanEL1o3aQgHuVLHQaB6tOqg==",
       "requires": {
         "arr-diff": "4.0.0",
         "array-unique": "0.3.2",
@@ -10684,7 +10416,7 @@
         "querystring-es3": "0.2.1",
         "readable-stream": "2.3.3",
         "stream-browserify": "2.0.1",
-        "stream-http": "2.7.2",
+        "stream-http": "2.8.0",
         "string_decoder": "1.0.3",
         "timers-browserify": "2.0.4",
         "tty-browserify": "0.0.0",
@@ -10694,12 +10426,12 @@
       }
     },
     "node-notifier": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-5.1.2.tgz",
-      "integrity": "sha1-L6nhJgX6EACdRFSdb82KY93g5P8=",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-5.2.1.tgz",
+      "integrity": "sha512-MIBs+AAd6dJ2SklbbE8RUDRlIVhU8MaNLh1A9SUZDUHPiZkWLFde6UNwG41yQHZEToHgJMXqyVZ9UcS/ReOVTg==",
       "requires": {
         "growly": "1.3.0",
-        "semver": "5.4.1",
+        "semver": "5.5.0",
         "shellwords": "0.1.1",
         "which": "1.3.0"
       }
@@ -10745,7 +10477,7 @@
       "requires": {
         "hosted-git-info": "2.5.0",
         "is-builtin-module": "1.0.0",
-        "semver": "5.4.1",
+        "semver": "5.5.0",
         "validate-npm-package-license": "3.0.1"
       }
     },
@@ -11120,6 +10852,24 @@
         "end-of-stream": "0.1.5",
         "sequencify": "0.0.7",
         "stream-consume": "0.1.0"
+      },
+      "dependencies": {
+        "end-of-stream": {
+          "version": "0.1.5",
+          "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-0.1.5.tgz",
+          "integrity": "sha1-jhdyBsPICDfYVjLouTWd/osvbq8=",
+          "requires": {
+            "once": "1.3.3"
+          }
+        },
+        "once": {
+          "version": "1.3.3",
+          "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+          "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
+          "requires": {
+            "wrappy": "1.0.2"
+          }
+        }
       }
     },
     "ordered-read-streams": {
@@ -11257,7 +11007,7 @@
         "got": "6.7.1",
         "registry-auth-token": "3.3.1",
         "registry-url": "3.1.0",
-        "semver": "5.4.1"
+        "semver": "5.5.0"
       },
       "dependencies": {
         "got": {
@@ -11377,7 +11127,7 @@
       "integrity": "sha512-rgO9Zg5LLLkfJF9E6CCmXlSE4UVceloys8JrFqCcHloC3usd/kJCyPDwH2SOlzix2j3xaP9sUX3e8+kvkuleAA==",
       "dev": true,
       "requires": {
-        "@types/node": "8.5.7"
+        "@types/node": "9.3.0"
       }
     },
     "parseqs": {
@@ -11608,9 +11358,9 @@
       "dev": true
     },
     "port-numbers": {
-      "version": "2.0.15",
-      "resolved": "https://registry.npmjs.org/port-numbers/-/port-numbers-2.0.15.tgz",
-      "integrity": "sha512-KqwSSVvTgm3XG8hw5WZHhNorCyKPCLqOHIzz0+EWjvgp0lkMZw6q+mRTbBHzNbnYjCTQPtSZz/Z+7VhIKyb+Aw=="
+      "version": "2.0.17",
+      "resolved": "https://registry.npmjs.org/port-numbers/-/port-numbers-2.0.17.tgz",
+      "integrity": "sha512-YJp4ryb/CBFKgby8C/imUL38hnD+QvAjKmhhVEOrmzo0CeLkVj3d7GBlcAImerNFmioBDZRpaC6kpRXfgholYw=="
     },
     "portscanner": {
       "version": "2.1.1",
@@ -11627,9 +11377,9 @@
       "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs="
     },
     "postcss": {
-      "version": "6.0.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.15.tgz",
-      "integrity": "sha512-v/SpyMzLbtkmh45zUdaqLAaqXqzPdSrw8p4cQVO0/w6YiYfpj4k+Wkzhn68qk9br+H+0qfddhdPEVnbmBPfXVQ==",
+      "version": "6.0.16",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.16.tgz",
+      "integrity": "sha512-m758RWPmSjFH/2MyyG3UOW1fgYbR9rtdzz5UNJnlm7OLtu4B2h9C6gi+bE4qFKghsBRFfZT8NzoQBs6JhLotoA==",
       "requires": {
         "chalk": "2.3.0",
         "source-map": "0.6.1",
@@ -11792,11 +11542,6 @@
       "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
       "integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM="
     },
-    "promised-io": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/promised-io/-/promised-io-0.3.5.tgz",
-      "integrity": "sha1-StIXuzZYvKrplGsXqGaOzYUeE1Y="
-    },
     "property-is-enumerable-x": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/property-is-enumerable-x/-/property-is-enumerable-x-1.1.0.tgz",
@@ -11945,7 +11690,7 @@
             "q": "1.4.1",
             "request": "2.81.0",
             "rimraf": "2.6.2",
-            "semver": "5.4.1",
+            "semver": "5.5.0",
             "xml2js": "0.4.19"
           }
         }
@@ -12067,36 +11812,26 @@
         "browserify-rsa": "4.0.1",
         "create-hash": "1.1.3",
         "parse-asn1": "5.1.0",
-        "randombytes": "2.0.5"
+        "randombytes": "2.0.6"
       }
     },
     "pump": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/pump/-/pump-1.0.3.tgz",
-      "integrity": "sha512-8k0JupWme55+9tCVE+FS5ULT3K6AbgqrGa58lTT49RpyfwwcGedHqaC5LlQNdEAumn/wFsu6aPwkuPMioy8kqw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.0.tgz",
+      "integrity": "sha512-6MYypjOvtiXhBSTOD0Zs5eNjCGfnqi5mPsCsW+dgKTxrZzQMZQNpBo3XRkLx7id753f3EeyHLBqzqqUymIolgw==",
       "requires": {
-        "end-of-stream": "1.4.0",
+        "end-of-stream": "1.4.1",
         "once": "1.4.0"
-      },
-      "dependencies": {
-        "end-of-stream": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.0.tgz",
-          "integrity": "sha1-epDYM+/abPpurA9JSduw+tOmMgY=",
-          "requires": {
-            "once": "1.4.0"
-          }
-        }
       }
     },
     "pumpify": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.3.5.tgz",
-      "integrity": "sha1-G2ccYZlAq8rqwK0OOjwWS+dgmTs=",
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.3.6.tgz",
+      "integrity": "sha512-BurGAcvezsINL5US9T9wGHHcLNrG6MCp//ECtxron3vcR+Rfx5Anqq7HbZXNJvFQli8FGVsWCAvywEJFV5Hx/Q==",
       "requires": {
-        "duplexify": "3.5.1",
+        "duplexify": "3.5.3",
         "inherits": "2.0.3",
-        "pump": "1.0.3"
+        "pump": "2.0.0"
       }
     },
     "punycode": {
@@ -12176,9 +11911,9 @@
       }
     },
     "randombytes": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.5.tgz",
-      "integrity": "sha512-8T7Zn1AhMsQ/HI1SjcCfT/t4ii3eAqco3yOcSzS4mozsOz69lHLsoMXmF9nZgnFanYscnSlUSgs8uZyKzpE6kg==",
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.6.tgz",
+      "integrity": "sha512-CIQ5OFxf4Jou6uOKe9t1AOgqpeU5fd70A8NPdHSGeYXqXsPe6peOwI0cUl88RWZ6sP1vPMV3avd/R6cZ5/sP1A==",
       "requires": {
         "safe-buffer": "5.1.1"
       }
@@ -12188,7 +11923,7 @@
       "resolved": "https://registry.npmjs.org/randomfill/-/randomfill-1.0.3.tgz",
       "integrity": "sha512-YL6GrhrWoic0Eq8rXVbMptH7dAxCs0J+mh5Y0euNekPPYaxEmdVGim6GdoxoRzKW2yJoU8tueifS7mYxvcFDEQ==",
       "requires": {
-        "randombytes": "2.0.5",
+        "randombytes": "2.0.6",
         "safe-buffer": "5.1.1"
       }
     },
@@ -12198,9 +11933,9 @@
       "integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4="
     },
     "rc": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.2.tgz",
-      "integrity": "sha1-2M6ctX6NZNnHut2YdsfDTL48cHc=",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.3.tgz",
+      "integrity": "sha1-UVdakA+N1oOBxxC0cSwhVMPiA1s=",
       "requires": {
         "deep-extend": "0.4.2",
         "ini": "1.3.5",
@@ -12355,7 +12090,7 @@
       "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.3.1.tgz",
       "integrity": "sha1-+w0yie4Nmtosu1KvXf5mywcNMAY=",
       "requires": {
-        "rc": "1.2.2",
+        "rc": "1.2.3",
         "safe-buffer": "5.1.1"
       }
     },
@@ -12364,7 +12099,7 @@
       "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz",
       "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
       "requires": {
-        "rc": "1.2.2"
+        "rc": "1.2.3"
       }
     },
     "regjsgen": {
@@ -12404,16 +12139,6 @@
             "underscore": "1.7.0",
             "underscore.string": "2.4.0"
           }
-        },
-        "underscore": {
-          "version": "1.7.0",
-          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz",
-          "integrity": "sha1-a7rwh3UA02vjTsqlhODbn+8DUgk="
-        },
-        "underscore.string": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz",
-          "integrity": "sha1-jN2PusTi0uoefi6Al8QvRCKA+Fs="
         }
       }
     },
@@ -12450,9 +12175,9 @@
       }
     },
     "replace-ext": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
-      "integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ="
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
+      "integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs="
     },
     "replacestream": {
       "version": "4.0.3",
@@ -12513,7 +12238,7 @@
         "stringstream": "0.0.5",
         "tough-cookie": "2.3.3",
         "tunnel-agent": "0.6.0",
-        "uuid": "3.1.0"
+        "uuid": "3.2.1"
       },
       "dependencies": {
         "qs": {
@@ -12848,16 +12573,16 @@
       }
     },
     "semver": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
-      "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg=="
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
+      "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
     },
     "semver-diff": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.1.0.tgz",
       "integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
       "requires": {
-        "semver": "5.4.1"
+        "semver": "5.5.0"
       }
     },
     "semver-regex": {
@@ -12870,7 +12595,7 @@
       "resolved": "https://registry.npmjs.org/semver-truncate/-/semver-truncate-1.1.2.tgz",
       "integrity": "sha1-V/Qd5pcHpicJp+AQS6IRcQnqR+g=",
       "requires": {
-        "semver": "5.4.1"
+        "semver": "5.5.0"
       }
     },
     "send": {
@@ -12879,7 +12604,7 @@
       "integrity": "sha1-+R+rRAO8+H5xb3DOtdsvV4vcF9Y=",
       "requires": {
         "debug": "2.6.4",
-        "depd": "1.1.1",
+        "depd": "1.1.2",
         "destroy": "1.0.4",
         "encodeurl": "1.0.1",
         "escape-html": "1.0.3",
@@ -12922,6 +12647,13 @@
             "inherits": "2.0.3",
             "setprototypeof": "1.0.3",
             "statuses": "1.3.1"
+          },
+          "dependencies": {
+            "depd": {
+              "version": "1.1.1",
+              "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.1.tgz",
+              "integrity": "sha1-V4O04cRZ8G+lyif5kfPQbnoxA1k="
+            }
           }
         },
         "ms": {
@@ -13108,7 +12840,7 @@
         "lolex": "2.3.1",
         "nise": "1.2.0",
         "supports-color": "4.5.0",
-        "type-detect": "4.0.5"
+        "type-detect": "4.0.6"
       },
       "dependencies": {
         "supports-color": {
@@ -13280,7 +13012,7 @@
         "open": "0.0.5",
         "os-name": "1.0.3",
         "proxy-from-env": "1.0.0",
-        "semver": "5.4.1",
+        "semver": "5.5.0",
         "snyk-config": "1.0.1",
         "snyk-go-plugin": "1.4.5",
         "snyk-gradle-plugin": "1.2.0",
@@ -13301,7 +13033,7 @@
         "undefsafe": "0.0.3",
         "update-notifier": "0.5.0",
         "url": "0.11.0",
-        "uuid": "3.1.0"
+        "uuid": "3.2.1"
       },
       "dependencies": {
         "ansi-escapes": {
@@ -13384,7 +13116,7 @@
           "integrity": "sha1-5dDtSvVfw+701WAHdp2YGSvLLso=",
           "dev": true,
           "requires": {
-            "duplexify": "3.5.1",
+            "duplexify": "3.5.3",
             "infinity-agent": "2.0.3",
             "is-redirect": "1.0.0",
             "is-stream": "1.1.0",
@@ -13642,7 +13374,7 @@
         "es6-promise": "3.3.1",
         "js-yaml": "3.10.0",
         "lodash.clonedeep": "4.5.0",
-        "semver": "5.4.1",
+        "semver": "5.5.0",
         "snyk-module": "1.8.1",
         "snyk-resolve": "1.0.0",
         "snyk-try-require": "1.2.0",
@@ -13707,7 +13439,7 @@
         "lodash": "4.17.4",
         "lru-cache": "4.1.1",
         "minimist": "1.2.0",
-        "semver": "5.4.1",
+        "semver": "5.5.0",
         "snyk-module": "1.8.1",
         "snyk-resolve": "1.0.0",
         "snyk-tree": "1.0.0",
@@ -13720,16 +13452,6 @@
           "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.3.1.tgz",
           "integrity": "sha1-oIzd6EzNvzTQJ6FFG8kdS80ophM=",
           "dev": true
-        },
-        "lru-cache": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
-          "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
-          "dev": true,
-          "requires": {
-            "pseudomap": "1.0.2",
-            "yallist": "2.1.2"
-          }
         }
       }
     },
@@ -13766,16 +13488,6 @@
           "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.3.1.tgz",
           "integrity": "sha1-oIzd6EzNvzTQJ6FFG8kdS80ophM=",
           "dev": true
-        },
-        "lru-cache": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
-          "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
-          "dev": true,
-          "requires": {
-            "pseudomap": "1.0.2",
-            "yallist": "2.1.2"
-          }
         }
       }
     },
@@ -14193,24 +13905,14 @@
       "resolved": "https://registry.npmjs.org/stream-each/-/stream-each-1.2.2.tgz",
       "integrity": "sha512-mc1dbFhGBxvTM3bIWmAAINbqiuAk9TATcfIQC8P+/+HJefgaiTlMn2dHvkX8qlI12KeYKSQ1Ua9RrIqrn1VPoA==",
       "requires": {
-        "end-of-stream": "1.4.0",
+        "end-of-stream": "1.4.1",
         "stream-shift": "1.0.0"
-      },
-      "dependencies": {
-        "end-of-stream": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.0.tgz",
-          "integrity": "sha1-epDYM+/abPpurA9JSduw+tOmMgY=",
-          "requires": {
-            "once": "1.4.0"
-          }
-        }
       }
     },
     "stream-http": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.7.2.tgz",
-      "integrity": "sha512-c0yTD2rbQzXtSsFSVhtpvY/vS6u066PcXOX9kBB3mSO76RiUQzL340uJkGBWnlBg4/HZzqiUXtaVA7wcRcJgEw==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.8.0.tgz",
+      "integrity": "sha512-sZOFxI/5xw058XIRHl4dU3dZ+TTOIGJR78Dvo0oEAejIt4ou27k+3ne1zYmCV+v7UucbxIFQuOgnkTVHh8YPnw==",
       "requires": {
         "builtin-status-codes": "3.0.0",
         "inherits": "2.0.3",
@@ -14229,7 +13931,7 @@
       "resolved": "https://registry.npmjs.org/stream-throttle/-/stream-throttle-0.1.3.tgz",
       "integrity": "sha1-rdV8jXzHOoFjDTHNVdOWHPr7qcM=",
       "requires": {
-        "commander": "2.12.2",
+        "commander": "2.13.0",
         "limiter": "1.1.2"
       }
     },
@@ -14237,14 +13939,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
       "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM="
-    },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "requires": {
-        "safe-buffer": "5.1.1"
-      }
     },
     "string-argv": {
       "version": "0.0.2",
@@ -14274,6 +13968,14 @@
         "code-point-at": "1.1.0",
         "is-fullwidth-code-point": "1.0.0",
         "strip-ansi": "3.0.1"
+      }
+    },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "requires": {
+        "safe-buffer": "5.1.1"
       }
     },
     "stringstream": {
@@ -14438,13 +14140,13 @@
       "integrity": "sha512-1/ZmC89pyy0OtUaM6+/ffe7NpbeRNaPjHd0fxF3cXCpjaGKmER2RlRKxvmxnsi7EcWI0K7niK1wQtHIu8wOdXA==",
       "optional": true,
       "requires": {
-        "coa": "2.0.0",
+        "coa": "2.0.1",
         "colors": "1.1.2",
         "css-select": "1.3.0-rc0",
         "css-select-base-adapter": "0.1.0",
         "css-tree": "1.0.0-alpha25",
         "css-url-regex": "1.1.0",
-        "csso": "3.4.0",
+        "csso": "3.5.0",
         "js-yaml": "3.10.0",
         "mkdirp": "0.5.1",
         "object.values": "1.0.4",
@@ -14530,19 +14232,9 @@
       "integrity": "sha512-mQdgLPc/Vjfr3VWqWbfxW8yQNiJCbAZ+Gf6GDu1Cy0bdb33ofyiNGBtAY96jHFhDuivCwgW1H9DgTON+INiXgg==",
       "requires": {
         "bl": "1.2.1",
-        "end-of-stream": "1.4.0",
+        "end-of-stream": "1.4.1",
         "readable-stream": "2.3.3",
         "xtend": "4.0.1"
-      },
-      "dependencies": {
-        "end-of-stream": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.0.tgz",
-          "integrity": "sha1-epDYM+/abPpurA9JSduw+tOmMgY=",
-          "requires": {
-            "once": "1.4.0"
-          }
-        }
       }
     },
     "temp": {
@@ -14572,7 +14264,7 @@
       "integrity": "sha1-awRGhWqbERTRhW/8vlCczLCXcmU=",
       "requires": {
         "temp-dir": "1.0.0",
-        "uuid": "3.1.0"
+        "uuid": "3.2.1"
       }
     },
     "term-size": {
@@ -14724,7 +14416,7 @@
       "resolved": "https://registry.npmjs.org/timers-ext/-/timers-ext-0.1.2.tgz",
       "integrity": "sha1-YcxHp2wavTGV8UUn+XjViulMUgQ=",
       "requires": {
-        "es5-ext": "0.10.37",
+        "es5-ext": "0.10.38",
         "next-tick": "1.0.0"
       }
     },
@@ -14744,14 +14436,6 @@
       "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
       "requires": {
         "os-tmpdir": "1.0.2"
-      }
-    },
-    "to-absolute-glob": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/to-absolute-glob/-/to-absolute-glob-0.1.1.tgz",
-      "integrity": "sha1-HN+kcqnvUMI57maZm2YsoOs5k38=",
-      "requires": {
-        "extend-shallow": "2.0.1"
       }
     },
     "to-array": {
@@ -15078,9 +14762,9 @@
       }
     },
     "type-detect": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.5.tgz",
-      "integrity": "sha512-N9IvkQslUGYGC24RkJk1ba99foK6TkwC2FHAEBlQFBP0RxQZS8ZpJuAZcwiY/w9ZJHFQb1aOXBI60OdxhTrwEQ==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.6.tgz",
+      "integrity": "sha512-qZ3bAurt2IXGPR3c57PyaSYEnQiLRwPeS60G9TahElBZsdOABo+iKYch/PhRjSTZJ5/DF08x43XMt9qec2g3ig==",
       "dev": true
     },
     "typedarray": {
@@ -15152,22 +14836,22 @@
       "resolved": "https://registry.npmjs.org/uglifyjs-webpack-plugin/-/uglifyjs-webpack-plugin-1.1.6.tgz",
       "integrity": "sha512-VUja+7rYbznEvUaeb8IxOCTUrq4BCb1ml0vffa+mfwKtrAwlqnU0ENF14DtYltV1cxd/HSuK51CCA/D/8kMQVw==",
       "requires": {
-        "cacache": "10.0.1",
+        "cacache": "10.0.2",
         "find-cache-dir": "1.0.0",
         "schema-utils": "0.4.3",
         "serialize-javascript": "1.4.0",
         "source-map": "0.6.1",
-        "uglify-es": "3.3.4",
+        "uglify-es": "3.3.7",
         "webpack-sources": "1.1.0",
         "worker-farm": "1.5.2"
       },
       "dependencies": {
         "uglify-es": {
-          "version": "3.3.4",
-          "resolved": "https://registry.npmjs.org/uglify-es/-/uglify-es-3.3.4.tgz",
-          "integrity": "sha512-vDOyDaf7LcABZI5oJt8bin5FD8kYONux5jd8FY6SsV2SfD+MMXaPeGUotysbycSxdu170y5IQ8FvlKzU/TUryw==",
+          "version": "3.3.7",
+          "resolved": "https://registry.npmjs.org/uglify-es/-/uglify-es-3.3.7.tgz",
+          "integrity": "sha512-fGMnE6SsDRsCjxm78C+lv7MuXsse/dtF7QuTUT43BYf4jlxPjd+XTnGB8YjaCQJ3sv2LT4zk0mwpp9+QJocU6g==",
           "requires": {
-            "commander": "2.12.2",
+            "commander": "2.13.0",
             "source-map": "0.6.1"
           }
         }
@@ -15190,9 +14874,9 @@
       "dev": true
     },
     "underscore": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.5.2.tgz",
-      "integrity": "sha1-EzXF5PXm0zu7SwBrqMhqAPVW3gg="
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz",
+      "integrity": "sha1-a7rwh3UA02vjTsqlhODbn+8DUgk="
     },
     "underscore-contrib": {
       "version": "0.3.0",
@@ -15212,9 +14896,9 @@
       }
     },
     "underscore.string": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz",
-      "integrity": "sha1-ccCL9rQosRM/N+ePo6Icgvcymw0="
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz",
+      "integrity": "sha1-jN2PusTi0uoefi6Al8QvRCKA+Fs="
     },
     "union-value": {
       "version": "1.0.0",
@@ -15257,9 +14941,13 @@
       }
     },
     "unique-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-1.0.0.tgz",
-      "integrity": "sha1-1ZpKdUJ0R9mqbJHnAmP40mpLEEs="
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-2.2.1.tgz",
+      "integrity": "sha1-WqADz76Uxf+GbE59ZouxxNuts2k=",
+      "requires": {
+        "json-stable-stringify": "1.0.1",
+        "through2-filter": "2.0.0"
+      }
     },
     "unique-string": {
       "version": "1.0.0",
@@ -15537,9 +15225,9 @@
       "integrity": "sha1-ApT7kiu5N1FTVBxPcJYjHyh8ivg="
     },
     "uuid": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
-      "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g=="
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
+      "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA=="
     },
     "uws": {
       "version": "0.14.5",
@@ -15632,13 +15320,16 @@
       }
     },
     "vinyl": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz",
-      "integrity": "sha1-sEVbOPxeDPMNQyUTLkYZcMIJHN4=",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.1.0.tgz",
+      "integrity": "sha1-Ah+cLPlR1rk5lDyJ617lrdT9kkw=",
       "requires": {
-        "clone": "1.0.3",
-        "clone-stats": "0.0.1",
-        "replace-ext": "0.0.1"
+        "clone": "2.1.1",
+        "clone-buffer": "1.0.0",
+        "clone-stats": "1.0.0",
+        "cloneable-readable": "1.0.0",
+        "remove-trailing-separator": "1.1.0",
+        "replace-ext": "1.0.0"
       }
     },
     "vinyl-assign": {
@@ -15669,6 +15360,11 @@
           "version": "0.2.0",
           "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
           "integrity": "sha1-xhJqkK1Pctv1rNskPMN3JP6T/B8="
+        },
+        "clone-stats": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
+          "integrity": "sha1-uI+UqCzzi4eR1YBG6kAprYjKmdE="
         },
         "graceful-fs": {
           "version": "3.0.11",
@@ -15849,7 +15545,7 @@
           "integrity": "sha1-5dDtSvVfw+701WAHdp2YGSvLLso=",
           "dev": true,
           "requires": {
-            "duplexify": "3.5.1",
+            "duplexify": "3.5.3",
             "infinity-agent": "2.0.3",
             "is-redirect": "1.0.0",
             "is-stream": "1.1.0",
@@ -16246,36 +15942,6 @@
         "through": "2.3.8",
         "vinyl": "2.1.0",
         "webpack": "3.10.0"
-      },
-      "dependencies": {
-        "clone": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.1.tgz",
-          "integrity": "sha1-0hfR6WERjjrJpLi7oyhVU79kfNs="
-        },
-        "clone-stats": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
-          "integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA="
-        },
-        "replace-ext": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
-          "integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs="
-        },
-        "vinyl": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.1.0.tgz",
-          "integrity": "sha1-Ah+cLPlR1rk5lDyJ617lrdT9kkw=",
-          "requires": {
-            "clone": "2.1.1",
-            "clone-buffer": "1.0.0",
-            "clone-stats": "1.0.0",
-            "cloneable-readable": "1.0.0",
-            "remove-trailing-separator": "1.1.0",
-            "replace-ext": "1.0.0"
-          }
-        }
       }
     },
     "whatwg-encoding": {
@@ -16369,13 +16035,8 @@
       "integrity": "sha1-X6VeAr58qTTt/BJmVjLoSbcuUgk=",
       "dev": true,
       "requires": {
-        "semver": "5.4.1"
+        "semver": "5.5.0"
       }
-    },
-    "win-spawn": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/win-spawn/-/win-spawn-2.0.0.tgz",
-      "integrity": "sha1-OXopEw7JjQqgvIa6pGITk+/9Cwc="
     },
     "window-size": {
       "version": "0.1.4",
@@ -16498,9 +16159,9 @@
       "dev": true
     },
     "xmlhttprequest-ssl": {
-      "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.4.tgz",
-      "integrity": "sha1-BPVgkVcks4kIhxXMDteBPpZ3v1c="
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.5.tgz",
+      "integrity": "sha1-wodrBhaKrcQOV9l+gRkayPQ5iz4="
     },
     "xtend": {
       "version": "4.0.1",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "gulp-istanbul": "1.1.3",
     "gulp-less": "3.4.0",
     "gulp-mocha": "3.0.1",
-    "gulp-modernizr": "1.0.0-alpha",
+    "gulp-modernizr-build": "0.0.5",
     "gulp-mq-remove": "0.0.2",
     "gulp-newer": "1.4.0",
     "gulp-notify": "3.1.0",


### PR DESCRIPTION
`gulp-modernizr` is abandoned and doesn't work with gulp 4. Switches to using `gulp-modernizr-build`.

## Changes

- Changes `gulp-modernizr` to `gulp-modernizr-build`.
- Removes `gulpRename` in polyfill task because it can be done in the modernizr task directly.

## Testing

1. `npm install`
2. `gulp scripts` should pass.
