### PR TITLE
Fix input text field width in popup

### DIFF
--- a/cfgov/unprocessed/css/organisms/email-popup.less
+++ b/cfgov/unprocessed/css/organisms/email-popup.less
@@ -64,6 +64,7 @@
     input[type="email"] {
         width: 100%;
         margin-bottom: unit( (@grid_gutter-width / 2) / @base-font-size-px, em);
+        box-sizing: border-box;
     }
 
     .respond-to-max( @bp-xs-max, {


### PR DESCRIPTION
## Changes

- Add box-sizing style rule to fix input field width in pop-up.

## Testing

1. `gulp build`
1. See https://github.com/cfpb/cfgov-refresh/pull/3731

## Screenshots
Before:
<img width="304" alt="screen shot 2018-01-17 at 9 25 38 am" src="https://user-images.githubusercontent.com/704760/35052307-4626f0b6-fb75-11e7-951b-451070c49447.png">


After:
<img width="290" alt="screen shot 2018-01-17 at 10 42 09 am" src="https://user-images.githubusercontent.com/704760/35051657-bf8a182c-fb73-11e7-9768-36278561a1df.png">

<img width="582" alt="screen shot 2018-01-17 at 10 44 16 am" src="https://user-images.githubusercontent.com/704760/35051658-bfa0fbe6-fb73-11e7-8061-45f5da276215.png">
