### PR TITLE
Remove unused vendorImg task

### DIFF
--- a/gulp/config.js
+++ b/gulp/config.js
@@ -117,10 +117,6 @@ module.exports = {
       ],
       dest: paths.processed + '/css'
     },
-    vendorImg: {
-      src: [],
-      dest: paths.processed + '/img'
-    },
     timelinejs: {
       src: [
         paths.modules + '/timelinejs/build/**/*'

--- a/gulp/tasks/copy.js
+++ b/gulp/tasks/copy.js
@@ -1,6 +1,5 @@
 const gulp = require( 'gulp' );
 const gulpChanged = require( 'gulp-changed' );
-const gulpReplace = require( 'gulp-replace' );
 const configCopy = require( '../config' ).copy;
 const handleErrors = require( '../utils/handle-errors' );
 const browserSync = require( 'browser-sync' );
@@ -42,19 +41,10 @@ gulp.task( 'copy:vendorcss', () => {
   return gulp.src( vendorCss.src )
     .pipe( gulpChanged( vendorCss.dest ) )
     .on( 'error', handleErrors )
-    .pipe( gulpReplace(
-      /url\(".\/ajax-loader.gif"\)/ig,
-      'url("/img/ajax-loader.gif")'
-    ) )
     .pipe( gulp.dest( vendorCss.dest ) )
     .pipe( browserSync.reload( {
       stream: true
     } ) );
-} );
-
-gulp.task( 'copy:vendorimg', () => {
-  const vendorImg = configCopy.vendorImg;
-  return _genericCopy( vendorImg.src, vendorImg.dest );
 } );
 
 gulp.task( 'copy:timelinejs', () => {
@@ -81,7 +71,6 @@ gulp.task( 'copy',
     'copy:codeJson',
     'copy:vendorfonts',
     'copy:vendorcss',
-    'copy:vendorimg',
     'copy:vendorjs',
     'copy:timelinejs',
     'copy:lightbox2'


### PR DESCRIPTION
Vendorimg appears to have been used over a year ago for the slick carousel ajax-loader image. It now has an empty src array and the copy task included renaming the ajax-loader in the PDF reactor CSS, which doesn't contain a reference to that image anymore.

## Removals

- Removes `gulp copy:vendorimg` task and associated configuration.

## Testing

1. `gulp build` should pass.
