### PR TITLE
MakeFilterableListMixin respect Wagtail sites

### DIFF
--- a/cfgov/v1/forms.py
+++ b/cfgov/v1/forms.py
@@ -91,19 +91,18 @@ class FilterableListForm(forms.Form):
     )
 
     def __init__(self, *args, **kwargs):
-        self.base_query = kwargs.pop('base_query')
+        self.filterable_pages = kwargs.pop('filterable_pages')
         super(FilterableListForm, self).__init__(*args, **kwargs)
 
-        pages = self.base_query.live()
-        page_ids = pages.values_list('id', flat=True)
-
         clean_categories(selected_categories=self.data.get('categories'))
+
+        page_ids = self.filterable_pages.values_list('id', flat=True)
         self.set_topics(page_ids)
         self.set_authors(page_ids)
 
     def get_page_set(self):
         query = self.generate_query()
-        return self.base_query.filter(query).distinct().order_by(
+        return self.filterable_pages.filter(query).distinct().order_by(
             '-date_published'
         )
 

--- a/cfgov/v1/models/browse_filterable_page.py
+++ b/cfgov/v1/models/browse_filterable_page.py
@@ -1,5 +1,3 @@
-import itertools
-
 from django.db import models
 
 from wagtail.wagtailadmin.edit_handlers import (
@@ -12,12 +10,11 @@ from v1 import blocks as v1_blocks
 from v1.atomic_elements import molecules, organisms
 from v1.feeds import FilterableFeedPageMixin
 from v1.models.base import CFGOVPage
-from v1.models.learn_page import AbstractFilterPage
-from v1.util import ref
 from v1.util.filterable_list import FilterableListMixin
 
 
-class BrowseFilterablePage(FilterableFeedPageMixin, FilterableListMixin,
+class BrowseFilterablePage(FilterableFeedPageMixin,
+                           FilterableListMixin,
                            CFGOVPage):
     header = StreamField([
         ('text_introduction', molecules.TextIntroduction()),
@@ -73,22 +70,7 @@ class EventArchivePage(BrowseFilterablePage):
 
 class NewsroomLandingPage(BrowseFilterablePage):
     template = 'newsroom/index.html'
+    filterable_categories = ('Blog', 'Newsroom')
+    filterable_children_only = False
 
     objects = PageManager()
-
-    @classmethod
-    def eligible_categories(cls):
-        categories = dict(ref.categories)
-        return sorted(itertools.chain(*(
-            dict(categories[category]).keys()
-            for category in ('Blog', 'Newsroom')
-        )))
-
-    @classmethod
-    def base_query(cls):
-        """Newsroom pages should only show content from certain categories."""
-        eligible_pages = AbstractFilterPage.objects.live()
-
-        return eligible_pages.filter(
-            categories__name__in=cls.eligible_categories()
-        )

--- a/cfgov/v1/models/sublanding_filterable_page.py
+++ b/cfgov/v1/models/sublanding_filterable_page.py
@@ -1,5 +1,3 @@
-import itertools
-
 from wagtail.wagtailadmin.edit_handlers import (
     ObjectList, StreamFieldPanel, TabbedInterface
 )
@@ -10,8 +8,6 @@ from v1 import blocks as v1_blocks
 from v1.atomic_elements import molecules, organisms
 from v1.feeds import FilterableFeedPageMixin
 from v1.models.base import CFGOVPage
-from v1.models.learn_page import AbstractFilterPage
-from v1.util import ref
 from v1.util.filterable_list import FilterableListMixin
 
 
@@ -49,27 +45,8 @@ class SublandingFilterablePage(FilterableFeedPageMixin,
 
 class ActivityLogPage(SublandingFilterablePage):
     template = 'activity-log/index.html'
+    filterable_categories = ('Blog', 'Newsroom', 'Research Report')
+    filterable_children_only = False
+    filterable_per_page_limit = 100
 
     objects = PageManager()
-
-    @classmethod
-    def eligible_categories(cls):
-        categories = dict(ref.categories)
-        return sorted(itertools.chain(*(
-            dict(categories[category]).keys()
-            for category in ('Blog', 'Newsroom', 'Research Report')
-        )))
-
-    @classmethod
-    def base_query(cls):
-        """
-        Recent updates pages should only show content from certain categories.
-        """
-        eligible_pages = AbstractFilterPage.objects.live()
-
-        return eligible_pages.filter(
-            categories__name__in=cls.eligible_categories()
-        )
-
-    def per_page_limit(self):
-        return 100

--- a/cfgov/v1/models/sublanding_page.py
+++ b/cfgov/v1/models/sublanding_page.py
@@ -85,11 +85,11 @@ class SublandingPage(CFGOVPage):
                         and 'archive' not in p.title.lower()]
         posts_list = []
         for page in filter_pages:
-            base_query = AbstractFilterPage.objects.live().filter(
+            eligible_children = AbstractFilterPage.objects.live().filter(
                 CFGOVPage.objects.child_of_q(page)
             )
 
-            form = FilterableListForm(base_query=base_query)
+            form = FilterableListForm(filterable_pages=eligible_children)
             for post in form.get_page_set():
                 posts_list.append(post)
         return sorted(posts_list,

--- a/cfgov/v1/tests/models/test_browse_filterable_page.py
+++ b/cfgov/v1/tests/models/test_browse_filterable_page.py
@@ -1,13 +1,14 @@
 from django.test import TestCase
 
-from wagtail.wagtailcore.models import Site
+from wagtail.wagtailcore.models import Page, Site
 
 from v1.forms import EventArchiveFilterForm
 from v1.models import CFGOVPageCategory
+from v1.models.learn_page import AbstractFilterPage
 from v1.models.browse_filterable_page import (
-    AbstractFilterPage, EventArchivePage, NewsroomLandingPage
+    EventArchivePage, NewsroomLandingPage
 )
-from v1.tests.wagtail_pages.helpers import save_new_page
+from v1.util.ref import get_category_children
 
 
 class EventArchivePageTestCase(TestCase):
@@ -19,25 +20,32 @@ class EventArchivePageTestCase(TestCase):
 
 
 class TestNewsroomLandingPage(TestCase):
-    def test_no_pages_by_default(self):
-        query = NewsroomLandingPage.base_query()
-        self.assertFalse(query.exists())
+    def setUp(self):
+        self.newsroom_page = NewsroomLandingPage(title="News", slug='newsroom')
+        self.site_root = Site.objects.get(is_default_site=True).root_page
+        self.site_root.add_child(instance=self.newsroom_page)
 
     def test_eligible_categories(self):
-        self.assertEqual(NewsroomLandingPage.eligible_categories(), [
-            'at-the-cfpb',
-            'data-research-reports',
-            'info-for-consumers',
-            'op-ed',
-            'policy_compliance',
-            'press-release',
-            'speech',
-            'testimony',
-        ])
+        self.assertEqual(
+            get_category_children(NewsroomLandingPage.filterable_categories),
+            [
+                'at-the-cfpb',
+                'data-research-reports',
+                'info-for-consumers',
+                'op-ed',
+                'policy_compliance',
+                'press-release',
+                'speech',
+                'testimony',
+            ]
+        )
 
-    def make_page_with_category(self, category_name):
+    def test_no_pages_by_default(self):
+        self.assertFalse(self.newsroom_page.filterable_pages().exists())
+
+    def make_page_with_category(self, category_name, parent):
         page = AbstractFilterPage(title='test', slug='test')
-        save_new_page(page)
+        parent.add_child(instance=page)
 
         category = CFGOVPageCategory.objects.create(
             name=category_name,
@@ -46,11 +54,14 @@ class TestNewsroomLandingPage(TestCase):
         page.categories.add(category)
 
     def test_no_pages_matching_categories(self):
-        self.make_page_with_category('test')
-        query = NewsroomLandingPage.base_query()
-        self.assertFalse(query.exists())
+        self.make_page_with_category('test', parent=self.site_root)
+        self.assertFalse(self.newsroom_page.filterable_pages().exists())
 
     def test_page_matches_categories(self):
-        self.make_page_with_category('op-ed')
-        query = NewsroomLandingPage.base_query()
-        self.assertTrue(query.exists())
+        page = self.make_page_with_category('op-ed', parent=self.site_root)
+        self.assertTrue(self.newsroom_page.filterable_pages().exists())
+
+    def test_page_in_other_site_not_included(self):
+        wagtail_root = Page.objects.get(pk=1)
+        self.make_page_with_category('op-ed', parent=wagtail_root)
+        self.assertFalse(self.newsroom_page.filterable_pages().exists())

--- a/cfgov/v1/tests/test_filterable_list.py
+++ b/cfgov/v1/tests/test_filterable_list.py
@@ -12,9 +12,12 @@ class TestFilterableListMixin(TestCase):
         self.mixin = FilterableListMixin()
         self.factory = RequestFactory()
     
-    # FilterableListMixin.per_page_limit tests
+    # FilterableListMixin.filterable_per_page_limit tests
     def test_per_page_limit_returns_integer(self):
-        assert isinstance(self.mixin.per_page_limit(), int)
+        self.assertIsInstance(
+            FilterableListMixin.filterable_per_page_limit,
+            int
+        )
 
     def test_get_form_data_returns_GET_data(self):
         request_string = '/?title=test'
@@ -31,10 +34,16 @@ class TestFilterableListMixin(TestCase):
         self.assertRaises(AttributeError, self.mixin.get_context, request=self.factory.get('/'))
 
     @mock.patch('v1.util.filterable_list.Paginator')
-    @mock.patch('v1.util.filterable_list.FilterableListMixin.per_page_limit')
-    def test_process_form_calls_is_valid_on_each_form(self, mock_per_page_limit, mock_paginator):
+    def test_process_form_calls_is_valid_on_each_form(self, mock_paginator):
         mock_request = mock.Mock()
         mock_request.GET = self.factory.get('/').GET
         mock_form = mock.Mock()
         data = self.mixin.process_form(mock_request, mock_form)
         assert mock_form.is_valid.called
+
+    def test_filterable_pages_not_in_site_returns_no_pages(self):
+        class MockPageInDefaultSite(FilterableListMixin):
+            def get_site(self):
+                return None
+
+        self.assertFalse(MockPageInDefaultSite().filterable_pages().exists())

--- a/cfgov/v1/tests/test_filterable_list_form.py
+++ b/cfgov/v1/tests/test_filterable_list_form.py
@@ -13,8 +13,8 @@ from v1.util.categories import clean_categories
 class TestFilterableListForm(TestCase):
 
     def setUpFilterableForm(self, data=None):
-        base_query = AbstractFilterPage.objects.live()
-        form = FilterableListForm(base_query=base_query)
+        filterable_pages = AbstractFilterPage.objects.live()
+        form = FilterableListForm(filterable_pages=filterable_pages)
         form.is_bound = True
         form.cleaned_data = data
         return form

--- a/cfgov/v1/tests/util/test_ref.py
+++ b/cfgov/v1/tests/util/test_ref.py
@@ -1,7 +1,9 @@
 import itertools
 from unittest import TestCase
 
-from v1.util.ref import categories, get_appropriate_categories
+from v1.util.ref import (
+    categories, get_appropriate_categories, get_category_children
+)
 
 
 class TestCategories(TestCase):
@@ -34,3 +36,21 @@ class TestGetAppropriateCategories(TestCase):
     def test_should_return_all_matches(self):
         result = get_appropriate_categories(['Op-Ed', 'Testimony', 'Speech', 'Press Release'], 'newsroom')
         self.assertEqual(len(result), 4)
+
+
+class TestGetCategoryChildren(TestCase):
+    def test_get_children_of_single_category(self):
+        self.assertEqual(
+            get_category_children(['Amicus Brief']),
+            ['fed-circuit-court', 'fed-district-court', 'state-court', 'us-supreme-court']
+        )
+
+    def test_get_children_of_multiple_categories(self):
+        self.assertEqual(
+            get_category_children(['Final Rule', 'Implementation Resource']),
+            ['compliance-aid', 'final-rule', 'interim-final-rule', 'official-guidance']
+        )
+
+    def test_get_children_with_invalid_category_raises_keyerror(self):
+        with self.assertRaises(KeyError):
+            get_category_children(['This is not a valid category'])

--- a/cfgov/v1/util/ref.py
+++ b/cfgov/v1/util/ref.py
@@ -1,3 +1,6 @@
+import itertools
+
+
 limited_categories = [
     ('speech-bubble', 'Blog'),
     ('newspaper', 'Newsroom'),
@@ -249,3 +252,12 @@ def is_report(page):
 
 def filterable_list_page_types():
     return page_types
+
+
+def get_category_children(category_names):
+    """Return a list of page category slugs for given category names."""
+    categories_dict = dict(categories)
+    return sorted(itertools.chain(*(
+        dict(categories_dict[category]).keys()
+        for category in category_names
+    )))


### PR DESCRIPTION
This change modifies how the `FilterableListMixin` page mixin class selects and limits the pages that it filters, making sure that it only filters pages that are in the same Wagtail Site as itself.

Currently this mixin filters any live `AbstractFilterPage`, even those that are elsewhere in the page tree. This causes problems if, for example, a live page is moved to the Trash, or to some other Site running in the same Wagtail instance.

With this change, the default behavior of Page classes that inherit from `FilterableListMixin` is to only include pages in their same Site.

This change includes some minor refactoring of how the filterable queryset gets passed around, renaming some variables `filterable_` for clarity and using the page's own `Page.get_site` method for convenience. Some logic around page category filtering was also collected in one place, with new tests added.

The default `FilterableListMixin` behavior continues to filter only direct children of the page, and use 10 results per page. This behavior can now be overridden for inherited classes (like `NewsroomLandingPage`) using some class attributes; this removes some code duplication.

One side effect of this change is that any filterable page that lives outside of any Site will be unable to filter any pages. This seemed like a reasonable decision to me: if a page isn't part of a Site, then it's unclear where it should get its filterable pages from.

This PR is a followup to work started in #3580.

## Testing

See unit test changes; Additionally, using a production dump, try publishing an `BlogPage` under the Trash, tagging it with a Blog tag (like "At the CFPB") and then visiting the newsroom page at http://localhost:8000/activity-log/. You won't see the page there, unlike the current behavior where it will show up. Similarly, you'll be able to visit that page's feed at http://localhost:8000/activity-log/feed, unlike the current behavior which raises a 500.

## Checklist

* [X] PR has an informative and human-readable title
* [X] Changes are limited to a single goal (no scope creep)
* [X] Code can be automatically merged (no conflicts)
* [X] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [X] Passes all existing automated tests
* [X] Any *change* in functionality is tested
* [X] New functions are documented (with a description, list of inputs, and expected output)
* [X] Visually tested in supported browsers and devices
* [x] Reviewers requested with the [Reviewer tool](https://help.github.com/articles/about-pull-request-reviews/) :arrow_right:
