### PR TITLE
Add temporary fix for double expandable borders

### DIFF
--- a/cfgov/unprocessed/css/organisms/expandable-group.less
+++ b/cfgov/unprocessed/css/organisms/expandable-group.less
@@ -43,6 +43,10 @@
     margin-bottom: unit(30px / @base-font-size-px, em);
 }
 
+.o-expandable-group .o-expandable {
+    border-bottom: none;
+}
+
 .o-expandable-group .o-expandable:not(:last-child) .o-expandable_content {
     border-bottom: none;
 }


### PR DESCRIPTION
See https://[GHE]/CFPB/hubcap/issues/76

## Testing

1. Pull branch
2. `gulp styles`
3. Load http://localhost:8000/consumer-tools/prepaid-cards/choose-the-right-card/ and observe the lack of double-borders

## Notes

- The correct fix will be to remove the custom expandable code and use only stock cf-expandables code, but that might take a bit. In the meantime, this fixes the issue.

## Checklist

* [ ] PR has an informative and human-readable title
* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [ ] Passes all existing automated tests
* [ ] Any *change* in functionality is tested
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated
* [ ] Reviewers requested with the [Reviewer tool](https://help.github.com/articles/about-pull-request-reviews/) :arrow_right:
