### PR TITLE
Fix unit test: always sort lists to keep ordering stable, avoid potential breakage

### DIFF
--- a/cfgov/legacy/tests/housing_counselor/test_generator.py
+++ b/cfgov/legacy/tests/housing_counselor/test_generator.py
@@ -105,9 +105,9 @@ class TestGetCounselorJsonFiles(TestCase):
         self.make_empty_file('something.json')
 
         self.assertEqual(
-            list(get_counselor_json_files(self.tempdir)),
-            [
+            sorted(list(get_counselor_json_files(self.tempdir))),
+            sorted([
                 ('20001', os.path.join(self.tempdir, '20001.json')),
                 ('20002', os.path.join(self.tempdir, '20002.json')),
-            ]
+            ])
         )


### PR DESCRIPTION
When running the `tox` tests in a Docker container (filesystem behavior differences are my only guess as to why this has not come up before), I noticed that this test would sometimes break because of the ordering of the items in the first list. When we sort the lists, I can no longer observe the problem.