### PR TITLE
expand SERVE_LATEST_DRAFTS on beta to 2 more pages

### DIFF
--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -673,7 +673,7 @@ SEARCH_DOT_GOV_ACCESS_KEY = os.environ.get('SEARCH_DOT_GOV_ACCESS_KEY')
 # This value is read by v1.wagtail_hooks.
 SERVE_LATEST_DRAFT_PAGES = []
 if DEPLOY_ENVIRONMENT == 'beta':
-    SERVE_LATEST_DRAFT_PAGES = [1288]
+    SERVE_LATEST_DRAFT_PAGES = [1288,1286,3273]
 
 # Email popup configuration. See v1.templatetags.email_popup.
 EMAIL_POPUP_URLS = {


### PR DESCRIPTION
Stakeholders have requested that we expand the "SERVE_LATEST_DRAFT_PAGES" setting on beta to two more pages:

https://www.consumerfinance.gov/policy-compliance/guidance/implementation-guidance/hmda-implementation/

https://www.consumerfinance.gov/policy-compliance/guidance/implementation-guidance/mortserv/



[GHE]/CFGOV/platform/issues/2420

## Additions

- the requested page ID's have been added to SERVE_LATEST_DRAFT_PAGES



## Testing

1.

## Screenshots


## Notes

-

## Todos

-

## Checklist

* [ ] PR has an informative and human-readable title
* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [ ] Passes all existing automated tests
* [ ] Any *change* in functionality is tested
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated
* [ ] Reviewers requested with the [Reviewer tool](https://help.github.com/articles/about-pull-request-reviews/) :arrow_right:
