### PR TITLE
Properly alphabetize "Buying a House" in megamenu

### DIFF
--- a/cfgov/jinja2/v1/_includes/organisms/_vars-mega-menu.html
+++ b/cfgov/jinja2/v1/_includes/organisms/_vars-mega-menu.html
@@ -107,11 +107,11 @@
 {% set consumer_tools_group_three = {
     'title': 'Guides',
     'nav_items': [
+        {'text': 'Buying a House', 'url': '/owning-a-home/'},
         {'text': 'Getting an Auto Loan', 'url': '/consumer-tools/getting-an-auto-loan/'},
         {'text': 'Managing Someone Else’s Money', 'url': '/consumer-tools/managing-someone-elses-money/'},
         {'text': 'Money as You Grow', 'url': '/consumer-tools/money-as-you-grow/'},
         {'text': 'Navigating the Military Financial Lifecycle', 'url': '/consumer-tools/military-financial-lifecycle/'},
-        {'text': 'Buying a House', 'url': '/owning-a-home/'},
         {'text': 'Paying for College', 'url': '/paying-for-college/'},
         {'text': 'Planning for Retirement', 'url': '/consumer-tools/retirement/'},
     ]


### PR DESCRIPTION
This commit fixes the ordering of "Buying a House" in the website megamenu. PR #3732 renamed this from "Owning a Home" but neglected to put in proper alphabetical order.

## Changes

- Move "Buying a House" first in the megamenu.

## Testing

1. Run a local server and look at the megamenu.

## Screenshots

![image](https://user-images.githubusercontent.com/654645/35449981-a129eb6c-028c-11e8-924e-3b611ae52040.png)

## Notes

- Thanks to @stephanieosan for pointing out this bug.
- Ping @virginiacc in case the Wagtail megamenu PR #3396 needs something similar.

## Checklist

* [X] PR has an informative and human-readable title
* [X] Changes are limited to a single goal (no scope creep)
* [X] Code can be automatically merged (no conflicts)
* [X] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [X] Passes all existing automated tests
* [X] Any *change* in functionality is tested
* [X] Visually tested in supported browsers and devices
* [X] Reviewers requested with the [Reviewer tool](https://help.github.com/articles/about-pull-request-reviews/) :arrow_right:
