### PR TITLE
Add Financial Well-Being to the megamenu

### DIFF
--- a/cfgov/jinja2/v1/_includes/organisms/_vars-mega-menu.html
+++ b/cfgov/jinja2/v1/_includes/organisms/_vars-mega-menu.html
@@ -154,6 +154,7 @@
 {% set practitioner_resources_group_three = {
     'title': 'Programs',
     'nav_items': [
+        {'text': 'Financial Well-Being Questionnaire', 'url': '/consumer-tools/financial-well-being/'},
         {'text': 'Resources for Libraries', 'url': '/practitioner-resources/library-resources/'},
         {'text': 'Resources for Tax Preparers', 'url': '/practitioner-resources/resources-for-tax-preparers/'},
         {'text': 'Your Money, Your Goals', 'url': '/practitioner-resources/your-money-your-goals/'},
@@ -165,6 +166,7 @@
         'title': 'Programs',
         'nav_items': [
             {'text': 'Financial Coaching', 'url': '/practitioner-resources/financial-coaching/'},
+            {'text': 'Financial Well-Being Questionnaire', 'url': '/consumer-tools/financial-well-being/'},
             {'text': 'Resources for Libraries', 'url': '/practitioner-resources/library-resources/'},
             {'text': 'Resources for Tax Preparers', 'url': '/practitioner-resources/resources-for-tax-preparers/'},
             {'text': 'Your Money, Your Goals', 'url': '/practitioner-resources/your-money-your-goals/'},


### PR DESCRIPTION
Add a link to the "Financial Well-Being Questinnaire" at URL [/consumer-tools/financial-well-being/](https://www.consumerfinance.gov/consumer-tools/financial-well-being/) in the megamenu.

This is added both with and without the `FINANCIAL_COACHING` feature flag.

## Additions

- Add FWB link to the megamenu.

## Testing

1. Run a local server and look at the megamenu.

## Screenshots

![image](https://user-images.githubusercontent.com/654645/35452568-f5f9952c-0294-11e8-8a08-3a4a1c6b6e1f.png)

## Notes

- Ping @virginiacc in case the Wagtail megamenu PR #3396 needs something similar.

## Checklist

* [X] PR has an informative and human-readable title
* [X] Changes are limited to a single goal (no scope creep)
* [X] Code can be automatically merged (no conflicts)
* [X] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [X] Passes all existing automated tests
* [X] Any *change* in functionality is tested
* [X] New functions are documented (with a description, list of inputs, and expected output)
* [X] Visually tested in supported browsers and devices
* [X] Reviewers requested with the [Reviewer tool](https://help.github.com/articles/about-pull-request-reviews/) :arrow_right:
