### PR TITLE
Fix some text from the move from Sheer, update OAH references to BAH

### DIFF
--- a/cfgov/jinja2/v1/know-before-you-owe/index.html
+++ b/cfgov/jinja2/v1/know-before-you-owe/index.html
@@ -187,12 +187,12 @@
                                 style="background-image: url( /static/img/owning-a-home_324.png );">
                             </div>
                             <div class="m-info-unit_content">
-                                <h3>Owning a Home</h3>
+                                <h3>Buying a House</h3>
                                 <p>This suite of tools and resources guides you through the process of getting a mortgage. It will help you explore interest rates in your area, understand loan options, and prepare you for closing.</p>
                                 <ul class="m-list m-list__links">
                                     <li class="m-list_item">
                                         <a class="m-list_link" href="/owning-a-home/">
-                                        Visit Owning a Home
+                                        Visit Buying a House
                                         </a>
                                     </li>
                                 </ul>
@@ -277,11 +277,11 @@
                         <div class="m-info-unit_content">
                             <div class="m-info-unit">
                                 <div class="m-info-unit_content">
-                                    <h3>Sample Closing Disclosure</h3>
+                                    <h3>Real estate professionals</h3>
                                     <p>Engage, educate, and inform your clients on the new mortgage disclosures and process with our tools and resources. Learn how to ensure smooth and on time closings and find resources to share with your clients.</p>
                                     <ul class="m-list m-list__links">
                                         <li class="m-list_item">
-                                            <a class="m-list_link" href="/owning-a-home/loan-estimate/">
+                                            <a class="m-list_link" href="/policy-compliance/know-you-owe-mortgages/real-estate-professionals/">
                                             Visit our real estate professional’s guide
                                             </a>
                                         </li>


### PR DESCRIPTION
## Changes

- Corrected the heading and link for the real estate professionals guide
- Updated "Owning a Home" references to "Buying a House"

## Testing

1. Pull branch
2. Visit http://localhost:8000/know-before-you-owe/
3. See the correctly-titled "Real estate professionals" section and click through to it

## Todos

- Once the canonical URL has changed from `/owning-a-home` to `/buying-a-house`, update the URL references in this file, as well.

## Checklist

* [x] PR has an informative and human-readable title
* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [x] Passes all existing automated tests
* [x] Any *change* in functionality is tested
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices
* [x] Project documentation has been updated
* [x] Reviewers requested with the [Reviewer tool](https://help.github.com/articles/about-pull-request-reviews/) :arrow_right:
