### PR TITLE
Remove optional eregs-2.0 app

### DIFF
--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -102,12 +102,6 @@ OPTIONAL_APPS = [
     {'import': 'teachers_digital_platform', 'apps': ('teachers_digital_platform', )},
 ]
 
-if DEPLOY_ENVIRONMENT == 'build':
-    OPTIONAL_APPS += [
-        {'import': 'eregs_core', 'apps': ('eregs_core',)},
-    ]
-
-
 POSTGRES_APPS = []
 
 MIDDLEWARE_CLASSES = (
@@ -623,11 +617,6 @@ FLAGS = {
     # Email popups.
     'EMAIL_POPUP_OAH': {'boolean': True},
     'EMAIL_POPUP_DEBT': {'after date': '2018-02-01T00:00'},
-
-    # The next version of eRegulations
-    'EREGS20': {
-        'boolean': DEPLOY_ENVIRONMENT == 'build',
-    },
 
     # The release of new Whistleblowers content/pages
     'WHISTLEBLOWER_RELEASE': {},

--- a/cfgov/cfgov/urls.py
+++ b/cfgov/cfgov/urls.py
@@ -300,10 +300,6 @@ urlpatterns = [
     url(r'^oah-api/county/',
         include_if_app_enabled('countylimits', 'countylimits.urls')),
 
-    flagged_url('EREGS20',
-                r'^eregs2/',
-                include_if_app_enabled('eregs_core', 'eregs_core.urls')
-                ),
     url(r'^eregs-api/',
         include_if_app_enabled('regcore', 'regcore.urls')),
     url(r'^eregulations/',

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -16,7 +16,6 @@ django-compressor==2.0
 django-extensions==1.5.5
 django-haystack==2.6.0
 django-localflavor==1.1
-django-mysql==2.1.0
 django-overextends==0.4.1
 django-reversion==1.10.1
 django-storages==1.1.8

--- a/requirements/optional-public.txt
+++ b/requirements/optional-public.txt
@@ -6,7 +6,6 @@ https://github.com/cfpb/regulations-site/releases/download/2.2.0/regulations-2.2
 https://github.com/cfpb/retirement/releases/download/0.5.14/retirement-0.5.14-py2-none-any.whl
 git+https://github.com/cfpb/ccdb5-api.git@v1.0.5#egg=ccdb5-api
 git+https://github.com/cfpb/ccdb5-ui.git@v1.0.6#egg=ccdb5_ui
-git+https://github.com/cfpb/eregs-2.0.git@0.0.5#egg=eregs
 https://github.com/cfpb/django-hud/releases/download/1.4.3/django_hud-1.4.3-py2-none-any.whl
 https://github.com/cfpb/django-college-costs-comparison/releases/download/1.5.1/comparisontool-1.5.1-py2-none-any.whl
 https://github.com/cfpb/teachers-digital-platform/releases/download/0.0.2/teachers_digital_platform-0.0.2-py2-none-any.whl


### PR DESCRIPTION
This change removes references to the optional [eregs-2.0](https://github.com/cfpb/eregs-2.0) app from this repository, effectively reversing #3089.

## Removals

- Removal of references to eregs-2.0 and its `eregs_core` app.
- Removal of `django-mysql` requirement which was only required for eregs-2.0.

## Notes

- Pinging @lfatty as this is partially motivated by some security concerns he raised.

## Checklist

* [X] PR has an informative and human-readable title
* [X] Changes are limited to a single goal (no scope creep)
* [X] Code can be automatically merged (no conflicts)
* [X] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [X] Passes all existing automated tests
* [X] Reviewers requested with the [Reviewer tool](https://help.github.com/articles/about-pull-request-reviews/) :arrow_right:
