### PR TITLE
Enable EMAIL_POPUP_DEBT feature flag

### DIFF
--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -616,7 +616,7 @@ FLAGS = {
 
     # Email popups.
     'EMAIL_POPUP_OAH': {'boolean': True},
-    'EMAIL_POPUP_DEBT': {'after date': '2018-02-01T00:00'},
+    'EMAIL_POPUP_DEBT': {'boolean': True},
 
     # The release of new Whistleblowers content/pages
     'WHISTLEBLOWER_RELEASE': {},


### PR DESCRIPTION
There seems to be an issue with the date-based flag, so enabling via boolean.

## Checklist

* [X] PR has an informative and human-readable title
* [X] Changes are limited to a single goal (no scope creep)
* [X] Code can be automatically merged (no conflicts)
* [X] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [X] Passes all existing automated tests
* [X] Any *change* in functionality is tested
* [X] New functions are documented (with a description, list of inputs, and expected output)
* [X] Placeholder code is flagged
* [X] Visually tested in supported browsers and devices
* [X] Reviewers requested with the [Reviewer tool](https://help.github.com/articles/about-pull-request-reviews/) :arrow_right:
