### PR TITLE
Set ALLOWED_HOSTS in production with an env var

### DIFF
--- a/cfgov/cfgov/settings/production.py
+++ b/cfgov/cfgov/settings/production.py
@@ -3,8 +3,10 @@ import os
 import sys
 from os.path import exists
 
-from .base import *
-from .database_mixin import *
+from django.core.exceptions import ImproperlyConfigured
+
+from cfgov.settings.base import *
+from cfgov.settings.database_mixin import *
 
 
 default_loggers = []
@@ -121,4 +123,7 @@ CACHES = {
 try:
     ALLOWED_HOSTS = json.loads(os.getenv('ALLOWED_HOSTS'))
 except (TypeError, ValueError):
-    ALLOWED_HOSTS = ['.consumerfinance.gov']
+    raise ImproperlyConfigured(
+        "Environment variable ALLOWED_HOSTS is either not defined or is "
+        "not valid JSON. Expected a JSON array of allowed hostnames."
+    )

--- a/cfgov/cfgov/settings/production.py
+++ b/cfgov/cfgov/settings/production.py
@@ -1,3 +1,4 @@
+import json
 import os
 import sys
 from os.path import exists
@@ -8,13 +9,13 @@ from .database_mixin import *
 
 default_loggers = []
 
-# Is there a syslog device available? 
+# Is there a syslog device available?
 # selects first of these locations that exist, or None
 syslog_device = next((l for l in ['/dev/log', '/var/run/syslog'] if exists(l)), None)
 
 if syslog_device:
     default_loggers.append('syslog')
-                           
+
 # if not running in mod_wsgi, add console logger
 if not (sys.argv and sys.argv[0] == 'mod_wsgi'):
     default_loggers.append('console')
@@ -114,3 +115,10 @@ CACHES = {
         'TIMEOUT': None,
     }
 }
+
+# ALLOWED_HOSTS should be defined as a JSON list in the ALLOWED_HOSTS
+# environment variable.
+try:
+    ALLOWED_HOSTS = json.loads(os.getenv('ALLOWED_HOSTS'))
+except (TypeError, ValueError):
+    ALLOWED_HOSTS = ['.consumerfinance.gov']


### PR DESCRIPTION
This PR adds `ALLOWED_HOSTS` to the production.py settings file and reads its value from an `ALLOWED_HOSTS` env var that contains a **JSON list** of allowed hosts. If that env var is not set, an attempt at a restricted but sane, functional default (`['.consumerfinance.gov']`) is made.

JSON seemed the lowest-effort and least invasive way to define a list in  an env var, since we use env vars for host-specific configuration in Ansible. There will be a corresponding PR to our Ansible role to define the env var.

Despite the fact that host validation is already done before any traffic reaches our web server, this is being done to put us in compliance with our security baseline. 

## Checklist

* [X] PR has an informative and human-readable title
* [X] Changes are limited to a single goal (no scope creep)
* [X] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [X] Passes all existing automated tests
* [ ] Any *change* in functionality is tested
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated
* [X] Reviewers requested with the [Reviewer tool](https://help.github.com/articles/about-pull-request-reviews/) :arrow_right:
