### PR TITLE
Bump regulations-site to 2.2.1

### DIFF
--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -462,6 +462,9 @@ BACKENDS = {
     'diffs': 'regcore.db.django_models.DMDiffs',
 }
 
+# Regulations in eRegs that should display the update-in-progress message
+EREGS_REGULATION_UPDATES = ['1002', '1003', '1005', '1010', '1011', '1012', '1013', '1024', '1026']
+
 # GovDelivery environment variables
 ACCOUNT_CODE = os.environ.get('GOVDELIVERY_ACCOUNT_CODE')
 

--- a/requirements/optional-public.txt
+++ b/requirements/optional-public.txt
@@ -2,7 +2,7 @@ https://github.com/cfpb/college-costs/releases/download/2.3.12/college_costs-2.3
 https://github.com/cfpb/complaint/releases/download/1.4.5/complaintdatabase-1.4.5-py2-none-any.whl
 https://github.com/cfpb/owning-a-home-api/releases/download/0.10.3/owning_a_home_api-0.10.3-py2-none-any.whl
 https://github.com/cfpb/regulations-core/releases/download/1.2.6/regcore-1.2.6-py2-none-any.whl
-https://github.com/cfpb/regulations-site/releases/download/2.2.0/regulations-2.2.0-py2-none-any.whl
+https://github.com/cfpb/regulations-site/releases/download/2.2.1/regulations-2.2.1-py2-none-any.whl
 https://github.com/cfpb/retirement/releases/download/0.5.14/retirement-0.5.14-py2-none-any.whl
 git+https://github.com/cfpb/ccdb5-api.git@v1.0.5#egg=ccdb5-api
 git+https://github.com/cfpb/ccdb5-ui.git@v1.0.6#egg=ccdb5_ui


### PR DESCRIPTION
This commit bumps the optional regulations-site package to 2.2.1. That release adds support for a new Django setting, `EREGS_REGULATION_UPDATES`, that allows for placement of a message on the landing page of any regulation to let users know that we're working on incorporating the latest updates to that regulation. See cfpb/regulations-site#843

## Additions

- `EREGS_REGULATION_UPDATES` Django setting

## Changes

- Bump `regulations-site` to 2.2.1

## Testing

1. Run a local server with `EREGS_API_BASE=https://www.consumerfinance.gov/eregs-api/ ./runserver.sh`
2. Pop on over to eRegs at http://localhost:8000/eregulations/
3. View any of the regs that have an update in progress but *don't* have new amendments effective in the future: 1002, 1010, 1011, 1012, 1013, 1024, or 1026. The landing page for those regs should look like the "update only" screenshot below.
4. View any of the regs that have both an update in progress *and* new amendments effective in the future: 1003 or 1005. The landing page for those regs should look like the "update and amendments" screenshot below.
5. The link in either version of the notification should point to https://www.consumerfinance.gov/policy-compliance/rulemaking/final-rules/
6. View any of the other regs that have neither an update in progress or amendments effective in the future: 1004 or 1030. The landing page for those regs should look like the "none" screenshot below.

## Screenshots

Update only | Update and amendments | None
----------- | --------------------- | ----
![update-only](https://user-images.githubusercontent.com/1862695/35883893-e78be84e-0b56-11e8-84fb-e89f86051baa.png) | ![both](https://user-images.githubusercontent.com/1862695/35883896-eb7af846-0b56-11e8-9a0a-f23a6d6bc250.png) | ![none](https://user-images.githubusercontent.com/1862695/35883906-f07df0b4-0b56-11e8-8c4b-59c603736169.png)

## Notes

@chosak helped me prepare the `regulations-site` release and this PR (thanks!) and is going to review. I don't have push access to cfgov-refresh, so I couldn't add a reviewer and had to make this PR from my fork.

## Checklist

* [x] PR has an informative and human-readable title
* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [x] Passes all existing automated tests
* [x] Any *change* in functionality is tested
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices
* [x] Project documentation has been updated
* [ ] Reviewers requested with the [Reviewer tool](https://help.github.com/articles/about-pull-request-reviews/) :arrow_right:
