### PR TITLE
Bump wagtail-flags package to 2.0.8

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -50,7 +50,7 @@ unicodecsv==0.14.1
 unipath>=1.1,<=2.0
 vobject==0.9.1
 wagtail==1.10.1
-wagtail-flags==2.0.7
+wagtail-flags==2.0.8
 wagtail-inventory==0.3
 wagtail-sharing==0.5
 Wand==0.4.2


### PR DESCRIPTION
This change bumps the optional wagtail-flags package from version 2.0.7 to new [release 2.0.8](https://github.com/cfpb/wagtail-flags/releases/tag/2.0.8). The main user-visible change with this upgradte is that now flags and conditions are properly alphabetized in the Wagtail admin.

## Changes

- Wagtail-flags to 2.0.8.

## Testing

1. Browse admin and see proper alphabetization.

## Screenshots

![image](https://user-images.githubusercontent.com/654645/35743264-13036ec4-080b-11e8-8389-f30d17e33567.png)

## Checklist

* [X] PR has an informative and human-readable title
* [X] Changes are limited to a single goal (no scope creep)
* [X] Code can be automatically merged (no conflicts)
* [X] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [X] Passes all existing automated tests
* [X] Any *change* in functionality is tested
* [X] Visually tested in supported browsers and devices
* [X] Reviewers requested with the [Reviewer tool](https://help.github.com/articles/about-pull-request-reviews/) :arrow_right:
