### PR TITLE
Bump optional ccdb5-ui package to version 1.0.7

### DIFF
--- a/requirements/optional-public.txt
+++ b/requirements/optional-public.txt
@@ -5,7 +5,7 @@ https://github.com/cfpb/regulations-core/releases/download/1.2.6/regcore-1.2.6-p
 https://github.com/cfpb/regulations-site/releases/download/2.2.1/regulations-2.2.1-py2-none-any.whl
 https://github.com/cfpb/retirement/releases/download/0.5.14/retirement-0.5.14-py2-none-any.whl
 git+https://github.com/cfpb/ccdb5-api.git@v1.0.5#egg=ccdb5-api
-git+https://github.com/cfpb/ccdb5-ui.git@v1.0.6#egg=ccdb5_ui
+git+https://github.com/cfpb/ccdb5-ui.git@v1.0.7#egg=ccdb5_ui
 https://github.com/cfpb/django-hud/releases/download/1.4.3/django_hud-1.4.3-py2-none-any.whl
 https://github.com/cfpb/django-college-costs-comparison/releases/download/1.5.1/comparisontool-1.5.1-py2-none-any.whl
 https://github.com/cfpb/teachers-digital-platform/releases/download/0.0.2/teachers_digital_platform-0.0.2-py2-none-any.whl


### PR DESCRIPTION
This change bumps the optional ccdb5-ui package (https://github.com/cfpb/ccdb5-ui) from version 1.0.6 to new version 1.0.7 (https://github.com/cfpb/ccdb5-ui/releases/tag/v1.0.7). This fixes an issue where requests without a HTTP_USER_AGENT header were causing a 500 error.

## Changes

- Bump ccdb5 to version 1.0.7.

## Testing

1. See https://github.com/cfpb/ccdb5-ui/pull/129.

## Checklist

* [X] PR has an informative and human-readable title
* [X] Changes are limited to a single goal (no scope creep)
* [X] Code can be automatically merged (no conflicts)
* [X] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [X] Passes all existing automated tests
* [X] Any *change* in functionality is tested
* [X] Reviewers requested with the [Reviewer tool](https://help.github.com/articles/about-pull-request-reviews/) :arrow_right:
