### PR TITLE
Add default catchall logging handler

### DIFF
--- a/cfgov/cfgov/settings/production.py
+++ b/cfgov/cfgov/settings/production.py
@@ -57,12 +57,7 @@ LOGGING = {
             'level': 'ERROR',
             'propagate': False,
         },
-        'v1': {
-            'handlers': default_loggers,
-            'level': 'INFO',
-            'propagate': True,
-        },
-        'core.views': {
+        '': {
             'handlers': default_loggers,
             'level': 'INFO',
             'propagate': True,


### PR DESCRIPTION
This change modifies the production logging setting so that all loggers use the default logging handlers for level `INFO` and above. Currently the log only includes messages from `v1` and `core.views`, which not only omits logging from other apps but also means that we don't have logging for important things like `django.security.DisallowedHost` (more important as of `ALLOWED_HOSTS` in #3772).

## Additions

- Add new catchall logger with an empty string (`''`) that uses default handlers in production.

## Removals

- Remove specific loggers for `core.views` and `v1` since they fall under the catchall logger.

## Testing

From a shell, try this:

```sh
$ DJANGO_SETTINGS_MODULE=cfgov.settings.production cfgov/manage.py shell
...
>>> import logging
>>> logger = logging.getLogger('something')
>>> logger.info('foo')
foo
```

In `master`, nothing will be echoed because there is no logger configured to handle this message.

## Checklist

* [X] PR has an informative and human-readable title
* [X] Changes are limited to a single goal (no scope creep)
* [X] Code can be automatically merged (no conflicts)
* [X] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [X] Passes all existing automated tests
* [X] Reviewers requested with the [Reviewer tool](https://help.github.com/articles/about-pull-request-reviews/) :arrow_right:
