### PR TITLE
Better og:descriptions for Ask CFPB answer pages

### DIFF
--- a/cfgov/jinja2/v1/ask-cfpb/answer-page.html
+++ b/cfgov/jinja2/v1/ask-cfpb/answer-page.html
@@ -12,6 +12,9 @@
 {% block desc %}
     {{ description | striptags | safe}}
 {% endblock %}
+{%- block og_desc -%}
+  {{- page.search_description or page.seo_title or page.snippet -}}
+{%- endblock -%}
 
 {% block banner_top %}
     {% if about_us %}


### PR DESCRIPTION
We add the "Ask ID" to page titles, for the convenience of editors, like this:

<img width="1235" alt="screen shot 2018-02-08 at 3 05 04 pm" src="https://user-images.githubusercontent.com/235397/35996995-2d83034c-0ce6-11e8-87b1-de735ba1dc3d.png">

This makes it a bad default for og:description

![2a5a909c-e5ac-11e7-8d5d-a05dcc740924](https://user-images.githubusercontent.com/235397/35997008-39dfa460-0ce6-11e8-847e-9b1de2b96e86.png)

This PR makes it so that Ask pages will default to the "snippet" value, instead of the wagtail page title. (which has a pretty pleasing effect, I think)

<img width="559" alt="screen shot 2018-02-08 at 3 35 30 pm" src="https://user-images.githubusercontent.com/235397/35997061-59ee925c-0ce6-11e8-941a-ac3d9694c103.png">

(preview generated with [this chrome plugin](https://chrome.google.com/webstore/detail/open-graph-preview/ehaigphokkgebnmdiicabhjhddkaekgh)) 

## Additions

- added an og_description block to the answer-page.html template, overriding that block's default definition (from base.html)


## Checklist

* [ ] PR has an informative and human-readable title
* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [ ] Passes all existing automated tests
* [ ] Any *change* in functionality is tested
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated
* [ ] Reviewers requested with the [Reviewer tool](https://help.github.com/articles/about-pull-request-reviews/) :arrow_right:
