### PR TITLE
Post preview visual bug fixes: adjust whitespace and line break across screen sizes

### DIFF
--- a/cfgov/jinja2/v1/_includes/organisms/post-preview.html
+++ b/cfgov/jinja2/v1/_includes/organisms/post-preview.html
@@ -68,28 +68,32 @@
     {% set post_url = get_protected_url(post) %}
     <article class="o-post-preview">
         <div class="m-meta-header">
-            <span class="a-date m-meta-header_right">
-                {{ date_desc }}
-                {% if 'EventPage' in post.specific_class.__name__ %}
-                    {{ time.render(post.specific.start_dt, {'date':true}) }}
-                {% else %}
-                    {{ time.render(post.date_published, {'date':true}) }}
+            <div class="m-meta-header_right">
+                <span class="a-date">
+                    {{ date_desc }}
+                    {% if 'EventPage' in post.specific_class.__name__ %}
+                        {{ time.render(post.specific.start_dt, {'date':true}) }}
+                    {% else %}
+                        {{ time.render(post.date_published, {'date':true}) }}
+                    {% endif %}
+                </span>
+            </div>
+            <div class="m-meta-header_left">
+                {# Newsroom Blog category logic #}
+                {% if show_categories %}
+                    {% import 'macros/category-slug.html' as category_slug %}
+                    {% if cat_controls and 'newsroom' in cat_controls.page_type and is_blog(post) %}
+                        {{ category_slug.render('blog', page_url, '', false) }}
+                    {% else %}
+                        {% for cat in post.categories.all() %}
+                            {% if loop.index > 1 %}
+                                |
+                            {% endif %}
+                            {{ category_slug.render(cat.name, page_url, '', false) }}
+                        {% endfor %}
+                    {% endif %}
                 {% endif %}
-            </span>
-            {# Newsroom Blog category logic #}
-            {% if show_categories %}
-                {% import 'macros/category-slug.html' as category_slug %}
-                {% if cat_controls and 'newsroom' in cat_controls.page_type and is_blog(post) %}
-                    {{ category_slug.render('blog', page_url, '', false) }}
-                {% else %}
-                    {% for cat in post.categories.all() %}
-                        {% if loop.index > 1 %}
-                            |
-                        {% endif %}
-                        {{ category_slug.render(cat.name, page_url, '', false) }}
-                    {% endfor %}
-                {% endif %}
-            {% endif %}
+            </div>
         </div>
          {% if 'EventPage' in post.specific_class.__name__ %}
             {% set event = post.specific %}

--- a/cfgov/unprocessed/css/enhancements/typography.less
+++ b/cfgov/unprocessed/css/enhancements/typography.less
@@ -130,27 +130,6 @@ ul:last-child,
 }
 
 /* topdoc
-  name: Adjustments to meta-header
-  family: cf-typography
-  notes:
-    - "Changes to meta-header to be ported to cf-typography to allow better adjustments on mobile"
-    - "Changes to better control spacing when a category isn't set"
-  tags:
-    - cf-typography
-*/
-
-.m-meta-header {
-    overflow: auto;
-}
-
-.m-meta-header_right {
-    .respond-to-max(@bp-sm-max, {
-        display: block;
-        margin-bottom: unit( (@grid_gutter-width / 2) / @base-font-size-px, em);
-    });
-}
-
-/* topdoc
   name: EOF
   eof: true
 */

--- a/cfgov/unprocessed/css/organisms/post-preview.less
+++ b/cfgov/unprocessed/css/organisms/post-preview.less
@@ -6,19 +6,23 @@
       markup: |
         <article class="o-post-preview">
             <div class="m-meta-header">
-                <span class="a-date m-meta-header_right">
-                    Published
-                    <span class="datetime">
-                        <time class="datetime_date" datetime="2003-08-05T21:36:11.000000-0400">
-                            AUG 05, 2003
-                        </time>
+                <div class="m-meta-header_right">
+                    <span class="a-date">
+                        Published
+                        <span class="datetime">
+                            <time class="datetime_date" datetime="2003-08-05T21:36:11.000000-0400">
+                                AUG 05, 2003
+                            </time>
+                        </span>
                     </span>
-                </span>
-                <a href="/about-us/blog/?filter_blog_category=Info+for+Consumers" class="a-heading a-heading__icon m-meta-header_left">
-                    <span class="cf-icon cf-icon-information"></span>
-                    <span class="u-visually-hidden">Category:</span>
-                    Info for Consumers
-                </a>
+                </div>
+                <div class="m-meta-header_left">
+                    <a href="/about-us/blog/?filter_blog_category=Info+for+Consumers" class="a-heading a-heading__icon">
+                        <span class="cf-icon cf-icon-information"></span>
+                        <span class="u-visually-hidden">Category:</span>
+                        Info for Consumers
+                    </a>
+                </div>
             </div>
             <div class="o-post-preview_image-container">
                 <img class="o-post-preview_image" src="http://www.placehold.it/160x90" alt="">
@@ -83,6 +87,26 @@
     + .o-post-preview {
         margin-top: unit( @grid_gutter-width * 2 / @base-font-size-px, em);
     }
+
+    .m-meta-header {
+        margin-bottom: unit( 15px / @base-font-size-px, em );
+
+        .respond-to-max(@bp-xs-max, {
+            &_right {
+                margin-bottom: unit( 5px / @base-font-size-px, em );
+            }
+        });
+
+        .respond-to-min(@bp-sm-min, {
+
+            .a-date {
+                line-height: 1.35;
+                vertical-align: bottom;
+            }
+
+        });
+
+    }        
 
     &_description {
         margin-bottom: unit( @grid_gutter-width / 2 / @base-font-size-px, em);

--- a/cfgov/unprocessed/css/organisms/post-preview.less
+++ b/cfgov/unprocessed/css/organisms/post-preview.less
@@ -83,7 +83,6 @@
 */
 
 .o-post-preview {
-
     + .o-post-preview {
         margin-top: unit( @grid_gutter-width * 2 / @base-font-size-px, em);
     }
@@ -91,34 +90,32 @@
     .m-meta-header {
         margin-bottom: unit( 15px / @base-font-size-px, em );
 
-        .respond-to-max(@bp-xs-max, {
+        .respond-to-max( @bp-xs-max, {
             &_right {
                 margin-bottom: unit( 5px / @base-font-size-px, em );
             }
-        });
+        } );
 
-        .respond-to-min(@bp-sm-min, {
-
+        .respond-to-min( @bp-sm-min, {
             .a-date {
                 line-height: 1.35;
                 vertical-align: bottom;
             }
-
-        });
-
-    }        
+        } );
+    }
 
     &_description {
         margin-bottom: unit( @grid_gutter-width / 2 / @base-font-size-px, em);
     }
 
     &_image-container {
-        .respond-to-max(@bp-sm-max, {
+        .respond-to-max( @bp-sm-max, {
             margin-bottom: unit( @grid_gutter-width / @base-font-size-px, em );
-        });
-        .respond-to-min(@bp-med-min, {
-            .grid_column(4);
-        });
+        } );
+
+        .respond-to-min( @bp-med-min, {
+            .grid_column( 4 );
+        } );
     }
 
     &_image {
@@ -138,9 +135,9 @@
 }
 
 .o-post-preview_image-container + .o-post-preview_content {
-    .respond-to-min(@bp-med-min, {
-        .grid_column(8);
-    });
+    .respond-to-min( @bp-med-min, {
+        .grid_column( 8 );
+    } );
 }
 
 .o-post-preview_image-container {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2044,9 +2044,9 @@
       }
     },
     "cf-typography": {
-      "version": "4.10.1",
-      "resolved": "https://registry.npmjs.org/cf-typography/-/cf-typography-4.10.1.tgz",
-      "integrity": "sha512-bxTEQlNc3EnR2uDEECFT9UxY0ED2fmaef6QpBBT83jpv210hojVR2BHQeS3dtvOyvuogKz7W3MmKdxmJ/43zNg==",
+      "version": "4.10.2",
+      "resolved": "https://registry.npmjs.org/cf-typography/-/cf-typography-4.10.2.tgz",
+      "integrity": "sha512-nH3/4gOkzZjPp9RM+pEpOm4+eYWavHzkYa8dS669d7Yc4kCZXfvuY50/nJHUM8lmZMhW6hUHFT/m8ruX8RLsnQ==",
       "requires": {
         "cf-core": "4.6.2",
         "cf-icons": "4.2.2"
@@ -2061,7 +2061,7 @@
         "cf-core": "4.6.2",
         "cf-grid": "4.2.4",
         "cf-layout": "4.8.0",
-        "cf-typography": "4.10.1",
+        "cf-typography": "4.10.2",
         "core-js": "2.5.0",
         "es6-promise": "4.1.1",
         "highcharts": "5.0.11",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "cf-notifications": "1.1.0",
     "cf-pagination": "4.3.0",
     "cf-tables": "4.3.0",
-    "cf-typography": "4.10.1",
+    "cf-typography": "4.10.2",
     "cfpb-chart-builder": "3.2.1",
     "del": "3.0.0",
     "glob-all": "3.1.0",


### PR DESCRIPTION
Fixes for 2 post preview visual bugs, https://GHE/CFGOV/platform/issues/1089 and https://GHE/CFGOV/platform/issues/1090

This is dependent on https://github.com/cfpb/capital-framework/pull/757 getting released and cf-typography getting bumped here before it can get merged.

## Additions

- `a-date` element in post-preview template gets vertical alignment tweaks to align text with the categories baseline on larger screens. fixes https://GHE/CFGOV/platform/issues/1090

## Removals

- CSS from typography enhancements was ported to either Capital Framework at https://github.com/cfpb/capital-framework/pull/757/files#diff-fbe01bf95b92595df0d955810b71204d or to the post-preview parent stylesheet, since that is the main (and only, that I could tell) use case for this element

## Changes

- HTML structure for post-preview template updated to better control left and right aligned child elements, for example, so the text can be stacked on small screens and vertically aligned on large screens
- 

## Testing

1.

## Screenshots

### Beautiful new whitespace...
![image](https://user-images.githubusercontent.com/702526/36051571-8c14092e-0db8-11e8-824b-c3b29153cadb.png)

==

### Check out those margins and paddings...

#### Small screens
![image](https://user-images.githubusercontent.com/702526/36051489-507653ae-0db8-11e8-931f-51749ac1bf63.png)
![image](https://user-images.githubusercontent.com/702526/36051507-5c8e704a-0db8-11e8-8339-4c6928d8684d.png)
![image](https://user-images.githubusercontent.com/702526/36051510-5f091f46-0db8-11e8-962b-ebef62bfca98.png)
![image](https://user-images.githubusercontent.com/702526/36051514-620be6f6-0db8-11e8-8866-60b14b30f3ed.png)
![image](https://user-images.githubusercontent.com/702526/36051522-6792d6fc-0db8-11e8-9d8b-6108736df566.png)
![image](https://user-images.githubusercontent.com/702526/36051524-6aac3df6-0db8-11e8-8364-1b71f8378d0a.png)
==

#### Larger screens

Should be exactly the same, except the category and date float left/right on the same line*:

![image](https://user-images.githubusercontent.com/702526/36051555-82014fb4-0db8-11e8-9d1b-5ef652f37de1.png)
![image](https://user-images.githubusercontent.com/702526/36051557-83d82cc2-0db8-11e8-9029-f50933b570c8.png)

*At some screen sizes, the float will kick in with the categories on the left and the date on the right and the text will be stacked-looking, because the categories text is especially long. This is to be expected since we can't predict a width for all the category text; we can only design the columns for most cases, and longer text that doesn't fit into the screen width like the majority of cases will wrap to the next line. Here's an example:
![screen shot 2018-02-09 at 4 50 01 pm](https://user-images.githubusercontent.com/702526/36051813-5d966c1c-0db9-11e8-9c36-0e50ad53ce3d.png)

==

Multiple categories:
![image](https://user-images.githubusercontent.com/702526/36051564-893883d8-0db8-11e8-88c3-9bf032bc5adc.png)



## Notes

-



## Checklist

* [x] PR has an informative and human-readable title
* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [x] Passes all existing automated tests
* [x] Any *change* in functionality is tested
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices
* [x] Project documentation has been updated
* [x] Reviewers requested with the [Reviewer tool](https://help.github.com/articles/about-pull-request-reviews/) :arrow_right:
