### PR TITLE
strip HTML from og:description in Ask CFPB

### DIFF
--- a/cfgov/jinja2/v1/ask-cfpb/answer-page.html
+++ b/cfgov/jinja2/v1/ask-cfpb/answer-page.html
@@ -13,7 +13,7 @@
     {{ description | striptags | safe}}
 {% endblock %}
 {%- block og_desc -%}
-  {{- page.search_description or page.seo_title or page.snippet -}}
+  {{- page.search_description or page.seo_title or page.snippet|striptags -}}
 {%- endblock -%}
 
 {% block banner_top %}


### PR DESCRIPTION
I was following up on #3781 and noticed that for some Ask CFPB questions, the snippet included HTML <p> tags.

![screen shot 2018-02-09 at 2 59 15 pm](https://user-images.githubusercontent.com/235397/36047350-d793fcc4-0da9-11e8-976b-098b299f96f8.png)

With this change, we run snippets through Django's [striptags](https://docs.djangoproject.com/en/2.0/ref/templates/builtins/#striptags) filter, which produces clean snippets

![screen shot 2018-02-09 at 3 01 16 pm](https://user-images.githubusercontent.com/235397/36047438-1ae80d62-0daa-11e8-809c-b47aafd7f6bc.png)

## Additions

- add |striptags filter to og:description on AskCFPB pages

## Screenshots


## Notes

-

## Todos

-

## Checklist

* [ ] PR has an informative and human-readable title
* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [ ] Passes all existing automated tests
* [ ] Any *change* in functionality is tested
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated
* [ ] Reviewers requested with the [Reviewer tool](https://help.github.com/articles/about-pull-request-reviews/) :arrow_right:
