### PR TITLE
avoid unneccessary redirect on remote.loader.js

### DIFF
--- a/cfgov/jinja2/v1/_includes/on-demand/footer.html
+++ b/cfgov/jinja2/v1/_includes/on-demand/footer.html
@@ -18,7 +18,7 @@
 
     var script = document.createElement( 'script' );
     script.type = 'text/javascript';
-    script.src = 'https://search.usa.gov/javascripts/remote.loader.js';
+    script.src = 'https://search.usa.gov/assets/sayt_loader.js';
     document.getElementsByTagName( 'head' )[0].appendChild( script );
 //]]>
 </script>

--- a/cfgov/jinja2/v1/_layouts/base.html
+++ b/cfgov/jinja2/v1/_layouts/base.html
@@ -325,7 +325,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <script>
 //<![CDATA[
     var usasearch_config = { siteHandle: 'cfpb' };
-    loadScript('https://search.usa.gov/javascripts/remote.loader.js');
+    loadScript('https://search.usa.gov/assets/sayt_loader.js');
 //]]>
 </script>
 


### PR DESCRIPTION
Requests to https://search.usa.gov/javascripts/remote.loader.js redirect to https://search.usa.gov/assets/sayt_loader.js, which has an effect on our loading time. We've consulted with the search.usa.gov, and they have advised that it's safe to use sayt_loader.js directly.


## Changes

- references to remote.loader.js changes to sayt_loader.js


## Screenshots


## Notes

-

## Todos

-

## Checklist

* [ ] PR has an informative and human-readable title
* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [ ] Passes all existing automated tests
* [ ] Any *change* in functionality is tested
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated
* [ ] Reviewers requested with the [Reviewer tool](https://help.github.com/articles/about-pull-request-reviews/) :arrow_right:
