### PR TITLE
Deprecate Python unit testing of optional apps

### DIFF
--- a/cfgov/cfgov/test.py
+++ b/cfgov/cfgov/test.py
@@ -13,7 +13,7 @@ from django.contrib.staticfiles.testing import StaticLiveServerTestCase
 from django.db import connection
 from django.db.migrations.loader import MigrationLoader
 from django.test import RequestFactory
-from django.test.runner import DiscoverRunner, is_discoverable
+from django.test.runner import DiscoverRunner
 
 from mock import Mock
 from scripts import initial_data, test_data

--- a/cfgov/cfgov/test.py
+++ b/cfgov/cfgov/test.py
@@ -1,7 +1,6 @@
 from __future__ import print_function
 
 import importlib
-import itertools
 import logging
 import os
 import re
@@ -18,25 +17,6 @@ from django.test.runner import DiscoverRunner, is_discoverable
 
 from mock import Mock
 from scripts import initial_data, test_data
-
-
-class OptionalAppsMixin(object):
-    def build_suite(self, test_labels=None, extra_tests=None, **kwargs):
-        if not test_labels:
-            app_names = set(itertools.chain(*(
-                optional_app['apps']
-                for optional_app in settings.OPTIONAL_APPS
-            )))
-
-            discoverable_app_names = filter(is_discoverable, app_names)
-
-            test_labels = list(discoverable_app_names) + ['.']
-
-        return super(OptionalAppsMixin, self).build_suite(
-            test_labels=test_labels,
-            extra_tests=extra_tests,
-            **kwargs
-        )
 
 
 class PlaceholderJSMixin(object):
@@ -71,8 +51,7 @@ class PlaceholderJSMixin(object):
                     f.write(self.PLACEHOLDER_STRING)
 
 
-class TestDataTestRunner(OptionalAppsMixin, PlaceholderJSMixin,
-                         DiscoverRunner):
+class TestDataTestRunner(PlaceholderJSMixin, DiscoverRunner):
     def run_tests(self, test_labels, extra_tests=None, **kwargs):
         # Disable logging below CRITICAL during tests.
         logging.disable(logging.CRITICAL)

--- a/tox.ini
+++ b/tox.ini
@@ -60,24 +60,6 @@ recreate=False
 setenv={[testenv:acceptance]setenv}
 commands=./manage.py test {posargs}
 
-[testenv:optional]
-# Invoke with: tox -e optional
-# Also run tests against public optional Django apps.
-# Uses alternate virtualenv with -optional suffix.
-deps=
-    -r{toxinidir}/requirements/optional-public.txt
-    {[testenv]deps}
-envdir={[testenv]envdir}-optional
-
-[testenv:optional-fast]
-# Invoke with: tox -e optional-fast
-# Include optional public apps but don't recreate virtualenv each time.
-# Also skips unnecessary Django migrations.
-deps={[testenv:optional]deps}
-envdir={[testenv:optional]envdir}
-recreate={[testenv:fast]recreate}
-setenv={[testenv:fast]setenv}
-
 [testenv:missing-migrations]
 # Invoke with: tox -e missing-migrations
 # Check for changes to Django models that are missing migrations by


### PR DESCRIPTION
In the past we tried to enable running the Python unit tests of our optional apps (from requirements/optional-public.txt) using the settings of this cfgov-refresh project.

This practice has fallen out of favor, and instead we now try to make sure that optional packages themselves have robust and comprehensive tests, which negate the need for testing within cfgov-refresh.

This change removes the tox `optional` and `optional-fast`  environments that supported this kind of testing.

This change also removes the `OptionalAppsMixin` mixin class that we have in our test runner that enables testing of those apps. Motivation for this change is to pursue simplification and removal of unused code.

## Removals

- Tox `optional` and `optional-fast` environments.

## Changes

- Test runner no longer looks for optional app tests.

## Testing

1. `tox` still works.

## Checklist

* [X] PR has an informative and human-readable title
* [X] Changes are limited to a single goal (no scope creep)
* [X] Code can be automatically merged (no conflicts)
* [X] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [X] Passes all existing automated tests
* [X] Reviewers requested with the [Reviewer tool](https://help.github.com/articles/about-pull-request-reviews/) :arrow_right:
