### PR TITLE
Remove print output from agreements unit test

### DIFF
--- a/cfgov/agreements/tests/test_management.py
+++ b/cfgov/agreements/tests/test_management.py
@@ -15,7 +15,11 @@ sample_zip = os.path.dirname(__file__) + '/sample-agreements.zip'
 
 class TestDataLoad(TestCase):
     def test_import_no_s3(self):
-        management.call_command('import_agreements', '--path=' + sample_zip)
+        management.call_command(
+            'import_agreements',
+            '--path=' + sample_zip,
+            verbosity=0
+        )
         self.assertEqual(Issuer.objects.all().count(), 2)
 
     @mock.patch.dict(os.environ, {'AGREEMENTS_S3_UPLOAD_ENABLED': 'yes'})
@@ -49,7 +53,11 @@ class TestDataLoad(TestCase):
 class TestManagementUtils(TestCase):
 
     def test_get_existing_issuer(self):
-        management.call_command('import_agreements', '--path=' + sample_zip)
+        management.call_command(
+            'import_agreements',
+            '--path=' + sample_zip,
+            verbosity=0
+        )
         issuer = util.get_issuer(u'Bankers\u2019 Bank of Kansas')
         self.assertEqual(issuer.slug, u'bankers-bank-of-kansas')
 


### PR DESCRIPTION
This change removes some visible print output being generated by one of the agreements unit tests. It restores our pristine set of `....` when running Python unit tests.

## Changes

- Pass `verbosity=0` to `call_command` calls in agreements unit tests, to avoid printing output to console.

## Testing

1. `tox` and see a nice series of dots.

## Screenshots

![image](https://user-images.githubusercontent.com/654645/36226719-a6d4d012-119c-11e8-85fd-626072b48dfc.png)

## Notes

Thanks @Scotchester for pointing this out. Print was accidentally introduced [in this commit](https://github.com/cfpb/cfgov-refresh/commit/57fabfcd50524a83a4288d179cef4055f9412c07#diff-ed68be87bd57a8ef3375ac8943c89e64R50).

## Checklist

* [X] PR has an informative and human-readable title
* [X] Changes are limited to a single goal (no scope creep)
* [X] Code can be automatically merged (no conflicts)
* [X] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [X] Passes all existing automated tests
* [X] Reviewers requested with the [Reviewer tool](https://help.github.com/articles/about-pull-request-reviews/) :arrow_right:
