### PR TITLE
Move six to the standard library imports

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -7,7 +7,8 @@ not_skip=__init__.py
 use_parentheses=1
 known_django=django,haystack
 known_wagtail=wagtail,wagtailsharing
-known_future_library=future,six
+known_future_library=future
+known_standard_library=six
 known_first_party=
     alerts,
     ask_cfpb,


### PR DESCRIPTION
Haivng six in `known_future_library` can cause some weirdness that breaks things. isort ends up wanting `import six` before `from __future__ import ...`.

## Checklist

* [x] PR has an informative and human-readable title
* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [x] Passes all existing automated tests
* [ ] Any *change* in functionality is tested
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated
* [x] Reviewers requested with the [Reviewer tool](https://help.github.com/articles/about-pull-request-reviews/) :arrow_right:
