### PR TITLE
Fail Python unit tests if anything writes to stdout

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,7 +54,9 @@ jobs:
   include:
     - stage: run tests
       env: RUNTEST=frontend
-    - env: RUNTEST=backend
+    - env: 
+      - RUNTEST=backend
+      - TEST_RUNNER=cfgov.test.StdoutCapturingTestRunner
       deploy:
         provider: pages
         local_dir: site

--- a/cfgov/cfgov/settings/test.py
+++ b/cfgov/cfgov/settings/test.py
@@ -20,7 +20,7 @@ DATABASES = {'default': TEST_DATABASE}
 
 EMAIL_BACKEND = 'django.core.mail.backends.locmem.EmailBackend'
 
-TEST_RUNNER = 'cfgov.test.TestDataTestRunner'
+TEST_RUNNER = os.environ.get('TEST_RUNNER', 'cfgov.test.TestDataTestRunner')
 
 INSTALLED_APPS += (
     'wagtail.contrib.settings',

--- a/cfgov/cfgov/test.py
+++ b/cfgov/cfgov/test.py
@@ -69,18 +69,6 @@ class PlaceholderJSMixin(object):
 
 
 class TestDataTestRunner(PlaceholderJSMixin, DiscoverRunner):
-    def run_suite(self, suite, **kwargs):
-        stdout = StringIO()
-        with redirect_stdout(stdout):
-            return_value = super(TestDataTestRunner, self).run_suite(
-                suite,
-                **kwargs
-            )
-        assert stdout.getvalue() == '', (
-            'there is content in stdout: {}'.format(stdout.getvalue())
-        )
-        return return_value
-
     def run_tests(self, test_labels, extra_tests=None, **kwargs):
         # Disable logging below CRITICAL during tests.
         logging.disable(logging.CRITICAL)
@@ -201,3 +189,17 @@ class HtmlMixin(object):
             self.assertHtmlRegexpMatches(str(rendered_html), s)
         except AssertionError:
             self.fail('rendered page HTML did not match {}'.format(s))
+
+
+class StdoutCapturingTestRunner(TestDataTestRunner):
+    def run_suite(self, suite, **kwargs):
+        stdout = StringIO()
+        with redirect_stdout(stdout):
+            return_value = super(TestDataTestRunner, self).run_suite(
+                suite,
+                **kwargs
+            )
+        assert stdout.getvalue() == '', (
+            'there is content in stdout: {}'.format(stdout.getvalue())
+        )
+        return return_value

--- a/cfgov/cfgov/tests/test_test.py
+++ b/cfgov/cfgov/tests/test_test.py
@@ -1,0 +1,68 @@
+from __future__ import print_function
+
+import six
+import sys
+from six import StringIO
+from unittest import TestCase, TestSuite, defaultTestLoader
+
+from cfgov.test import StdoutCapturingTestRunner, redirect_stdout
+
+
+if six.PY2:
+    class TestRedirectStdout(TestCase):
+
+        def test_redirect_to_string_io(self):
+            stdout = sys.stdout
+            unstdout = StringIO()
+            with redirect_stdout(unstdout):
+                self.assertIs(sys.stdout, unstdout)
+                print('Hello, world!', file=sys.stdout)
+
+            self.assertIs(sys.stdout, stdout)
+            test_str = unstdout.getvalue().strip()
+            self.assertEqual(test_str, 'Hello, world!')
+
+        def test_raises_exception(self):
+            unstdout = StringIO()
+            with self.assertRaises(ValueError):
+                with redirect_stdout(unstdout):
+                    raise ValueError('Test exception handling')
+
+
+class TestStdoutCapturingTestRunner(TestCase):
+
+    def test_with_stdout(self):
+        class LoudTestCase(TestCase):
+            def test(self):
+                print('True is true, who knew!')
+                self.assertTrue(True)
+
+        loud_suite = TestSuite(
+            tests=defaultTestLoader.loadTestsFromTestCase(LoudTestCase)
+        )
+
+        with self.assertRaises(AssertionError):
+            StdoutCapturingTestRunner(verbosity=0).run_suite(
+                loud_suite,
+                stream=StringIO()
+            )
+
+    def test_with_no_stdout(self):
+        class QuietTestCase(TestCase):
+            def test(self):
+                self.assertTrue(True)
+
+        quiet_suite = TestSuite(
+            tests=defaultTestLoader.loadTestsFromTestCase(QuietTestCase)
+        )
+
+        # Supress test case output while this runs so we don't get weird
+        # test-case-in-our-test-case messaging
+        result = StdoutCapturingTestRunner().run_suite(
+            quiet_suite,
+            stream=StringIO()
+        )
+
+        # No errors should be raised and the suite should have passed
+        self.assertEqual(result.errors, [])
+        self.assertEqual(result.failures, [])

--- a/tox.ini
+++ b/tox.ini
@@ -123,7 +123,7 @@ commands=
 changedir=
     {toxinidir}/cfgov
 passenv=
-    TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH TEST_DATABASE_URL
+    TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH TEST_DATABASE_URL TEST_RUNNER
 # BOTO_CONFIG exists here to work around an incompatability between
 # boto and Travis CI
 # https://github.com/travis-ci/travis-ci/issues/5246#issuecomment-166460882


### PR DESCRIPTION
This PR is a proposal for capturing stdout while unit tests run and then failing the tests if anything writes to it. It does this by capturing all stdout during the test run and asserting that it is empty at the end. It uses `redirect_stdout` from Python 3's `contextlib` and a function that approximates it in Python 2.

One disadvantage to this approach is that you don't know where the text came from necessarily. The test run looks like this:

```
Creating test database for alias 'default'...
applying migration wagtail.wagtailcore.migrations.0002_initial_data
applying migration wagtail.wagtailcore.migrations.0025_collection_initial_data
.
----------------------------------------------------------------------
Ran 1 test in 0.113s

OK
Traceback (most recent call last):
  File "manage.py", line 11, in <module>
    execute_from_command_line(sys.argv)

    … (typical traceback) …

AssertionError: there is content in stdout: this is a test

ERROR: InvocationError: '/Users/bartonw/repos/platform/cfgov-refresh/.tox/py27/bin/coverage run --source=. manage.py test cfgov.tests'
_____________________________________________________________________________________________________________________ summary _____________________________________________________________________________________________________________________
ERROR:   fast: commands failed
```

But it's a proposal. I'd love to hear thoughts, and maybe other ideas.

## Checklist

* [x] PR has an informative and human-readable title
* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [x] Passes all existing automated tests
* [x] Any *change* in functionality is tested
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated
* [x] Reviewers requested with the [Reviewer tool](https://help.github.com/articles/about-pull-request-reviews/) :arrow_right:
