### PR TITLE
Use venv-update/pip-faster with tox to avoid recreating virtualenv

### DIFF
--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -3,5 +3,6 @@
 django-debug-toolbar==1.7
 django-livereload==1.2
 django-sslserver==0.19
-tox==2.3.1
+tox-pip-extensions==1.1.0
+tox==2.8.2
 Werkzeug==0.10.4

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -10,6 +10,5 @@ isort==4.2.15
 mccabe==0.5.2
 mock==2.0.0
 model_mommy==1.2.6
-moto==0.4.30
+moto==0.4.27
 responses==0.5.1
-

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -6,4 +6,5 @@ isort==4.2.15
 mccabe==0.5.2 
 pycodestyle==2.0.0 
 pyflakes==1.2.3
-tox==2.3.1
+tox-pip-extensions==1.1.0
+tox==2.8.2

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,7 @@
 [tox]
 skipsdist=True
 envlist=py27
+tox_pip_extensions_ext_venv_update=True
 
 [py2]
 # Common python2.7 configuration
@@ -28,7 +29,7 @@ commands=
     coverage run --source='.' manage.py test {posargs}
 deps=-r{toxinidir}/requirements/test.txt
 passenv=TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH
-recreate=True
+recreate=False
 # BOTO_CONFIG exists here to work around an incompatability between
 # boto and Travis CI
 # https://github.com/travis-ci/travis-ci/issues/5246#issuecomment-166460882


### PR DESCRIPTION
## Changes

Currently when running backend tests via `tox`, in the default mode, we recreate the `tox` virtualenv each time. This is necessary because we otherwise cannot guarantee that we'll have the correct dependencies installed. It's a known issue with `tox` -- see https://github.com/tox-dev/tox/issues/149

In that thread you can read that a `tox` contributor recommends a solution involving [venv-update](http://venv-update.readthedocs.io/en/master/), and also provides [a tox plugin](https://github.com/tox-dev/tox-pip-extensions) to make it easy -- and this is what we're attempting to adopt here. When using this plugin, `tox` will now use `venv-update` and `pip-faster` to ensure that the virtualenv is synced with our requirements, but will do so without having to recreate the virtualenv from scratch. Local testing so far suggests that this works as advertised.

(`pip-tools` might be another solution to the problem, but it seemed to me that switching to a workflow that involved `pip-compile` would be a bigger deal than dropping in a `tox` plugin. Especially if `pipenv` and `pipfile` are the way of the future -- might as well expend the energy to switch to them rather than `pip-tools`?)

One snag we ran into is that `pip-faster` requires that there be no version conflicts in the dependency tree if you want to use it (something regular `pip`, which is wrapped by `pip-faster`, does not). @chosak has already resolved most of the conflicts I ran into, and the only remaining one has to do with `Jinja2`: the version of `moto` we specified required a newer `Jinja2` than the `Jinja2` we're using. Future `moto` releases may address this, but in the meantime we are proposing to downgrade `moto` by a few versions. Based on the `moto` change-log, it doesn't look like this should have serious consequences, and the tests still pass with this slightly older version.

## Notes

❗️ this should not be merged before https://[GHE]/[ansible-repo]/pull/190
