### PR TITLE
Temp fix for font path in apps code

### DIFF
--- a/gulp/tasks/styles.js
+++ b/gulp/tasks/styles.js
@@ -15,6 +15,7 @@ const gulpLess = require( 'gulp-less' );
 const gulpNewer = require( 'gulp-newer' );
 const gulpPostcss = require( 'gulp-postcss' );
 const gulpRename = require( 'gulp-rename' );
+const gulpReplace = require( 'gulp-replace' );
 const gulpSourcemaps = require( 'gulp-sourcemaps' );
 const handleErrors = require( '../utils/handle-errors' );
 const mergeStream = require( 'merge-stream' );
@@ -304,6 +305,7 @@ function stylesApps() {
         .pipe( gulpPostcss( [
           autoprefixer( { browsers: BROWSER_LIST.LAST_2_IE_8_UP } )
         ] ) )
+        .pipe( gulpReplace( '../fonts/', '/static/fonts/' ) )
         .pipe( gulpBless( { cacheBuster: false, suffix: '.part' } ) )
         .pipe( gulpCleanCss( {
           compatibility: 'ie9',


### PR DESCRIPTION
Temp fix for font path in apps code

## Changes

- Modified code to fix issue with font path in app code.  Issue is occurring because the OAH `main.less` file is importing `main.less`. There doesn't look to be an easy way to override the `@cf-icon-path:` variable,  although I thought you could so because of Less lazy loading. 

## Testing

1. Run gulp styles and view ` main.part1.css`. Search for `eot` in the file and ensure the path is absolute.

## Checklist

* [ ] PR has an informative and human-readable title
* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [ ] Passes all existing automated tests
* [ ] Any *change* in functionality is tested
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated
* [ ] Reviewers requested with the [Reviewer tool](https://help.github.com/articles/about-pull-request-reviews/) :arrow_right:
