### PR TITLE
Try absolute path for cf-icon-path

### DIFF
--- a/cfgov/unprocessed/css/main.less
+++ b/cfgov/unprocessed/css/main.less
@@ -21,7 +21,7 @@
 @import (less) 'cf-tables.less';
 
 // Icon font path
-@cf-icon-path: '../fonts';
+@cf-icon-path: '/static/fonts';
 
 // Webfont variables
 // This is the path for self-hosted fonts.

--- a/gulp/tasks/styles.js
+++ b/gulp/tasks/styles.js
@@ -15,7 +15,6 @@ const gulpLess = require( 'gulp-less' );
 const gulpNewer = require( 'gulp-newer' );
 const gulpPostcss = require( 'gulp-postcss' );
 const gulpRename = require( 'gulp-rename' );
-const gulpReplace = require( 'gulp-replace' );
 const gulpSourcemaps = require( 'gulp-sourcemaps' );
 const handleErrors = require( '../utils/handle-errors' );
 const mergeStream = require( 'merge-stream' );
@@ -305,7 +304,6 @@ function stylesApps() {
         .pipe( gulpPostcss( [
           autoprefixer( { browsers: BROWSER_LIST.LAST_2_IE_8_UP } )
         ] ) )
-        .pipe( gulpReplace( '../fonts/', '/static/fonts/' ) )
         .pipe( gulpBless( { cacheBuster: false, suffix: '.part' } ) )
         .pipe( gulpCleanCss( {
           compatibility: 'ie9',


### PR DESCRIPTION
Let's try absolute path for the cf-icon-path variable!

## Changes

- Changes `@cf-icon-path` variable from relative to absolute path.

## Removes

- Unneeded font path replacement.