### PR TITLE
Fix path in unit test

### DIFF
--- a/test/unit_tests/apps/owning-a-home/ratings-form-spec.js
+++ b/test/unit_tests/apps/owning-a-home/ratings-form-spec.js
@@ -1,4 +1,4 @@
-const BASE_JS_PATH = '../../../../cfgov/unprocessed/js/';
+const BASE_JS_PATH = '../../../../cfgov/unprocessed/apps/';
 const chai = require( 'chai' );
 const expect = chai.expect;
 const sinon = require( 'sinon' );
@@ -87,7 +87,7 @@ describe( 'ratings-form', () => {
     sandbox = sinon.sandbox.create();
     document.body.innerHTML = HTML_SNIPPET;
     require(
-      BASE_JS_PATH + 'apps/owning-a-home/ratings-form'
+      BASE_JS_PATH + 'owning-a-home/js/ratings-form'
     ).init();
 
     ratingsInputs = document.querySelectorAll( '.rating-inputs input' );


### PR DESCRIPTION
Fixes broken path in unit test. Not sure why Travis didn't pick this up?

## Changes

- Changes path in owning-a-home ratings form test to point to new location added in https://github.com/cfpb/cfgov-refresh/pull/3806

## Testing

1. `gulp test:unit` should pass.
