### PR TITLE
Fix for validate-assets tox.ini process

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -117,6 +117,7 @@ setenv=
     {[testenv]setenv}
     DJANGO_SETTINGS_MODULE=cfgov.settings.production
     DJANGO_STATIC_ROOT={toxinidir}/collectstatic
+    ALLOWED_HOSTS=["*"]
 commands=
     {toxinidir}/frontend.sh production
     {toxinidir}/cfgov/manage.py collectstatic --noinput


### PR DESCRIPTION
Fix for validate-assets tox.ini

## Changes

- Modified `tox.ini` to fix issue with task.

## Testing

1. Run `tox -e validate-assets` and pray you dont' get any errors.

## Screenshots


## Notes

-

## Todos

-

## Checklist

* [ ] PR has an informative and human-readable title
* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [ ] Passes all existing automated tests
* [ ] Any *change* in functionality is tested
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated
* [ ] Reviewers requested with the [Reviewer tool](https://help.github.com/articles/about-pull-request-reviews/) :arrow_right:
