### PR TITLE
Adds package.json for apps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,12 +47,8 @@ Thumbs.db
 # npm packages #
 ####################
 node_modules/
+cfgov/unprocessed/apps/*/node_modules/
 npm-debug.log
-
-# Bower packages #
-##################
-bower_components/
-src/vendor
 
 # Vim swap files #
 ##################
@@ -67,7 +63,7 @@ __pycache__/
 
 # Front-End #
 #############
-node_modules/
+cfgov/unprocessed/apps/*/config.json
 bower_components/
 vendor/
 

--- a/cfgov/unprocessed/apps/owning-a-home/js/dom-tools.js
+++ b/cfgov/unprocessed/apps/owning-a-home/js/dom-tools.js
@@ -1,0 +1,135 @@
+import fastDom from '../node_modules/fastdom';
+
+const NO_OP = function( ) {
+  // Placeholder function meant to be overridden.
+};
+
+const DT = {
+  applyAll: function applyAll( elements, applyFn ) {
+    if ( elements instanceof HTMLElement ) {
+      elements = [ elements ];
+    }
+
+    return [].slice.call( elements ).forEach( applyFn );
+  },
+  bindEvents: function bindEvents( elements, events, callback = NO_OP ) {
+    if ( Array.isArray( events ) === false ) {
+      events = [ events ];
+    }
+
+    if ( typeof elements === 'string' ) {
+      elements = DT.getEls( elements );
+    }
+
+    DT.applyAll( elements, function( element ) {
+      events.forEach( event => {
+        element.addEventListener( event, callback );
+      } );
+    } );
+  },
+  createElement: function createElement( HTML ) {
+    const div = document.createElement( 'div' );
+    div.innerHTML = HTML;
+
+    return div.firstChild;
+  },
+  removeClass: function removeClass( selector, className ) {
+    className = className.split( ', ' );
+
+    return DT.applyAll(
+      DT.getEls( selector ),
+      element => {
+        fastDom.mutate( () =>
+          element.classList.remove( ...className )
+        );
+      } );
+  },
+  addClass: function addClass( selector, className ) {
+    className = className.split( ', ' );
+
+    return DT.applyAll(
+      DT.getEls( selector ),
+      element =>
+        fastDom.mutate( () =>
+          element.classList.add( ...className )
+        )
+    );
+  },
+  hasClass: function hasClass( selector, className ) {
+    return DT.getEl( selector ).classList.contains( className );
+  },
+  getEls: function getEls( selector ) {
+    if ( DT.isEl( selector ) ) {
+      return selector;
+    }
+
+    return document.querySelectorAll( selector );
+  },
+  getEl: function getEl( selector ) {
+    if ( DT.isEl( selector ) ) {
+      return selector;
+    }
+
+    return document.querySelector( selector );
+  },
+  getPreviousEls: function getPreviousEls( element, filter = '*' ) {
+    const previousSiblings = [];
+    let prevEl = element.previousElementSibling;
+    function _getMatches( el ) {
+      return el.matches ||
+               el.webkitMatchesSelector ||
+               el.mozMatchesSelector ||
+               el.msMatchesSelector;
+    }
+    const _matchesMethod = _getMatches( element );
+
+    while ( prevEl ) {
+      if ( _matchesMethod.bind( prevEl )( filter ) ) {
+        previousSiblings.push( prevEl );
+      }
+      prevEl = prevEl.previousElementSibling;
+    }
+    return previousSiblings;
+  },
+  isEl: function isEl( element ) {
+    return element instanceof NodeList ||
+           element instanceof HTMLElement ||
+           element instanceof Window;
+  },
+  hide: function hide( selector ) {
+    return DT.applyAll( DT.getEls( selector ),
+      element => fastDom.mutate(
+        () => ( element.style.display = 'none' )
+      )
+    );
+  },
+  show: function show( selector ) {
+    return DT.applyAll( DT.getEls( selector ),
+      element => fastDom.mutate(
+        () => ( element.style.display = 'block' )
+      )
+    );
+  },
+  fadeIn: function fadeIn( element, time, callback = NO_OP ) {
+    element.style.transition = 'opacity ' + time + 'ms ease-in-out';
+    element.style.opacity = 0.05;
+    element.style.display = 'block';
+    window.setTimeout( () => ( element.style.opacity = 1 ), 100 );
+    window.setTimeout( () => callback(), time );
+  },
+  fadeOut: function fadeOut( element, time, callback = NO_OP ) {
+    element.style.transition = 'opacity ' + time + 'ms ease-in-out';
+    element.style.opacity = 1;
+    window.setTimeout( () => ( element.style.opacity = 0.05 ), 100 );
+    window.setTimeout(
+      () => {
+        element.style.display = 'none';
+        return callback();
+      },
+      time
+    );
+  },
+  nextFrame: fastDom.raf
+};
+
+export default DT;

--- a/cfgov/unprocessed/apps/owning-a-home/package-lock.json
+++ b/cfgov/unprocessed/apps/owning-a-home/package-lock.json
@@ -1,0 +1,22 @@
+{
+  "name": "owning-a-home",
+  "requires": true,
+  "lockfileVersion": 1,
+  "dependencies": {
+    "fastdom": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/fastdom/-/fastdom-1.0.6.tgz",
+      "integrity": "sha1-D6WGYjjh6L6jXcFOMc3zRUfw23M=",
+      "dev": true,
+      "requires": {
+        "strictdom": "1.0.1"
+      }
+    },
+    "strictdom": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/strictdom/-/strictdom-1.0.1.tgz",
+      "integrity": "sha1-GJ3pFkn3PUTVm4Qy76aO+dJllGA=",
+      "dev": true
+    }
+  }
+}

--- a/cfgov/unprocessed/apps/owning-a-home/package.json
+++ b/cfgov/unprocessed/apps/owning-a-home/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "owning-a-home",
+  "description": "The consumerfinance.gov/owning-a-home website.",
+  "homepage": "http://www.consumerfinance.gov/owning-a-home",
+  "author": {
+    "name": "Consumer Financial Protection Bureau",
+    "email": "tech@cfpb.gov",
+    "url": "https://cfpb.github.io/"
+  },
+  "repository": {
+    "type": "git",
+    "url": "http://github.com/cfpb/cfgov-refresh.git"
+  },
+  "license": "SEE LICENSE IN TERMS.md",
+  "engines": {
+    "node": ">=8.0.0"
+  },
+  "devDependencies": {
+    "fastdom": "1.0.6"
+  }
+}


### PR DESCRIPTION
This overlaps with https://github.com/cfpb/cfgov-refresh/pull/3818, but is a simpler example that may make it easier to review just the gulp task part without all the rate explorer scripts and templates.

## Changes

- Modifies scripts:apps task to check for existence of an apps package.json file and require npm install be run in the app folder to continue processing the script if node_modules doesn't exist.

## Testing

3. Run `gulp clean`.
5. Run `gulp scripts:apps`.
6. Verify message appears: `App dependencies not installed, please run from project root: npm --prefix ./cfgov/unprocessed/apps/owning-a-home install ./cfgov/unprocessed/apps/owning-a-home`.
7. Run  `npm --prefix ./cfgov/unprocessed/apps/owning-a-home install ./cfgov/unprocessed/apps/owning-a-home` from project root.
8. Re-run `gulp scripts:apps` and verify it passes.
9. Run `gulp build`.

## Notes

- Contains https://github.com/cfpb/cfgov-refresh/pull/3819
