### PR TITLE
Adjust eslint setting

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -760,7 +760,7 @@ rules:
       afterBlockComment: false
       beforeLineComment: false
       afterLineComment: false
-      allowBlockStart: false
+      allowBlockStart: true
       allowBlockEnd: false
 
   # Require or disallow an empty line between class members.

--- a/cfgov/unprocessed/js/molecules/Multiselect.js
+++ b/cfgov/unprocessed/js/molecules/Multiselect.js
@@ -316,8 +316,8 @@ function Multiselect( element ) { // eslint-disable-line max-statements, inline-
         } );
 
         domCreate( 'span', {
-          'innerHTML': option.text,
-          'inside':    _selectionsItemLabelDom
+          innerHTML: option.text,
+          inside:    _selectionsItemLabelDom
         } );
 
         _selectionsDom.appendChild( _selectionsItemDom );


### PR DESCRIPTION
## Changes

- `allowBlockStart` to `true` in eslint `lines-around-comment` rule.
- Autofixes quoted properties in `Multiselect.js`.

## Testing

1. `gulp lint --fix` should have no changes and pass.
