### PR TITLE
Fix for using import statements with Mocha / Instanbul

### DIFF
--- a/cfgov/unprocessed/js/modules/BreakpointHandler.js
+++ b/cfgov/unprocessed/js/modules/BreakpointHandler.js
@@ -1,5 +1,5 @@
-const getBreakpointState = require( './util/breakpoint-state' ).get;
-const _breakpointsConfig = require( '../config/breakpoints-config' );
+import  { get as getBreakpointState } from  './util/breakpoint-state';
+import  _breakpointsConfig from '../config/breakpoints-config';
 
 /* Used for checking browser capabilities.
    TODO: Check what browsers this is necessary for and

--- a/cfgov/unprocessed/js/modules/BreakpointHandler.js
+++ b/cfgov/unprocessed/js/modules/BreakpointHandler.js
@@ -1,5 +1,5 @@
-import  { get as getBreakpointState } from  './util/breakpoint-state';
-import  _breakpointsConfig from '../config/breakpoints-config';
+import { get as getBreakpointState } from './util/breakpoint-state';
+import _breakpointsConfig from '../config/breakpoints-config';
 
 /* Used for checking browser capabilities.
    TODO: Check what browsers this is necessary for and

--- a/gulp/tasks/test.js
+++ b/gulp/tasks/test.js
@@ -1,3 +1,5 @@
+const BROWSER_LIST = require( '../../config/browser-list-config' );
+const gulpBabel = require( 'gulp-babel' );
 const configTest = require( '../config' ).test;
 const envvars = require( '../../config/environment' ).envvars;
 const fsHelper = require( '../utils/fs-helper' );
@@ -28,6 +30,14 @@ function testUnitScripts( cb ) {
   }
 
   gulp.src( configTest.src )
+    .pipe( gulpBabel( {
+      presets: [ [ 'babel-preset-env', {
+        targets: {
+          browsers: BROWSER_LIST.LAST_2_IE_9_UP
+        },
+        debug: true
+      } ] ]
+    } ) )
     .pipe( gulpIstanbul( {
       includeUntested: false
     } ) )

--- a/package-lock.json
+++ b/package-lock.json
@@ -6683,6 +6683,57 @@
         }
       }
     },
+    "gulp-babel": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/gulp-babel/-/gulp-babel-7.0.1.tgz",
+      "integrity": "sha512-UqHS3AdxZyJCRxqnAX603Dj3k/Wx6hzcgmav3QcxvsIFq3Y8ZkU7iXd0O+JwD5ivqCc6o0r1S7tCB/xxLnuSNw==",
+      "requires": {
+        "plugin-error": "1.0.1",
+        "replace-ext": "0.0.1",
+        "through2": "2.0.3",
+        "vinyl-sourcemaps-apply": "0.2.1"
+      },
+      "dependencies": {
+        "arr-diff": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+          "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
+        },
+        "extend-shallow": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+          "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+          "requires": {
+            "assign-symbols": "1.0.0",
+            "is-extendable": "1.0.1"
+          }
+        },
+        "is-extendable": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+          "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+          "requires": {
+            "is-plain-object": "2.0.4"
+          }
+        },
+        "plugin-error": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/plugin-error/-/plugin-error-1.0.1.tgz",
+          "integrity": "sha512-L1zP0dk7vGweZME2i+EeakvUNqSrdiI3F91TwEoYiGrAfUXmVv6fJIq4g82PAXxNsWOp0J7ZqQy/3Szz0ajTxA==",
+          "requires": {
+            "ansi-colors": "1.0.1",
+            "arr-diff": "4.0.0",
+            "arr-union": "3.1.0",
+            "extend-shallow": "3.0.2"
+          }
+        },
+        "replace-ext": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
+          "integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ="
+        }
+      }
+    },
     "gulp-bless": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/gulp-bless/-/gulp-bless-4.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "del": "3.0.0",
     "glob-all": "3.1.0",
     "gulp": "3.9.1",
+    "gulp-babel": "7.0.1",
     "gulp-bless": "4.0.0",
     "gulp-changed": "3.2.0",
     "gulp-clean-css": "3.9.2",


### PR DESCRIPTION
Fix for using import statements with Mocha / Instanbul


## Changes

- Modified test script to fix issue with requiring scripts that contain import statements. 

## Testing

1. Run `gulp test:unit`.



## Checklist

* [ ] PR has an informative and human-readable title
* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [ ] Passes all existing automated tests
* [ ] Any *change* in functionality is tested
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated
* [ ] Reviewers requested with the [Reviewer tool](https://help.github.com/articles/about-pull-request-reviews/) :arrow_right:
