### PR TITLE
Update hidden class in owning-a-home/explore-rates

### DIFF
--- a/cfgov/jinja2/v1/owning-a-home/explore-rates/index.html
+++ b/cfgov/jinja2/v1/owning-a-home/explore-rates/index.html
@@ -194,7 +194,7 @@ home price, down payment, and more can affect mortgage interest rates.
                 </div>
               </div>
 
-              <div class="col-7 county hidden">
+              <div class="col-7 county u-hidden">
                 <div class="wrapper-first">
                 <label for="county">County</label>
                 <div class="select-content">
@@ -206,7 +206,7 @@ home price, down payment, and more can affect mortgage interest rates.
 
             </section>
 
-            <section class="form-sub hidden warning" id="county-warning">
+            <section class="form-sub u-hidden warning" id="county-warning">
                 <p class="warning-text"></p>
             </section>
 
@@ -249,7 +249,7 @@ home price, down payment, and more can affect mortgage interest rates.
                 </div>
               </div>
 
-              <div class="col-6 flex-input hidden arm-type">
+              <div class="col-6 flex-input u-hidden arm-type">
                 <div class="wrapper-last">
                 <label for="arm-type">ARM type</label>
                 <div class="select-content">
@@ -265,11 +265,11 @@ home price, down payment, and more can affect mortgage interest rates.
 
             </section>
 
-            <section class="form-sub hidden warning" id="arm-warning">
+            <section class="form-sub u-hidden warning" id="arm-warning">
                 <p class="warning-text">While some lenders may offer FHA, VA, or 15-year adjustable-rate mortgages, they are rare. We don’t have enough data to display results for these combinations. Choose a fixed rate if you’d like to try these options.</p>
             </section>
 
-            <section class="form-sub hidden warning" id="hb-warning">
+            <section class="form-sub u-hidden warning" id="hb-warning">
                 <p class="warning-text"></p>
             </section>
 
@@ -369,18 +369,18 @@ home price, down payment, and more can affect mortgage interest rates.
                     <div class="wrapper">
                       <div class="interest-cost interest-cost-primary rc-comp-3">
                         <span class="new-cost no-arm">$150,000</span>
-                        <span class="arm-info hidden">Can change</span>
+                        <span class="arm-info u-hidden">Can change</span>
                       </div>
 
                       <div class="interest-cost interest-cost-secondary rc-comp-3-push">
                         <span class="new-cost no-arm">$150,000</span>
-                        <span class="arm-info hidden">Can change</span>
+                        <span class="arm-info u-hidden">Can change</span>
                       </div>
 
                       <div class="interest-summary rc-comp-5" id="rc-comparison-summary-long">
                         <p class="no-arm">Over <span class="comparison-term">30</span> years, an interest rate of <span class="higher-rate">1%</span> costs <strong class="rate-diff">$0</strong> more than an interest rate of <span class="lower-rate">1%</span>.</p>
 
-                        <p class="arm-info hidden">With the <strong>adjustable-rate mortgage</strong> you've chosen, the rate is only fixed for the <strong>first <span class="arm-comparison-term">5</span> years.</strong> Your interest costs in the future can change.</p>
+                        <p class="arm-info u-hidden">With the <strong>adjustable-rate mortgage</strong> you've chosen, the rate is only fixed for the <strong>first <span class="arm-comparison-term">5</span> years.</strong> Your interest costs in the future can change.</p>
                       </div>
                   </div> <!-- /.wrapper -->
                 </div> <!-- /.rc-comparison-subsection -->

--- a/cfgov/unprocessed/apps/owning-a-home/js/dropdown-utils.js
+++ b/cfgov/unprocessed/apps/owning-a-home/js/dropdown-utils.js
@@ -143,7 +143,7 @@ var utils = function( id ) {
   function show() {
     $el.each( function() {
       var $container = $( '.' + $( this ).attr( 'id' ) );
-      $container.removeClass( 'hidden' );
+      $container.removeClass( 'u-hidden' );
     } );
 
     return this;
@@ -156,7 +156,7 @@ var utils = function( id ) {
   function hide() {
     $el.each( function() {
       var $container = $( '.' + $( this ).attr( 'id' ) );
-      $container.addClass( 'hidden' );
+      $container.addClass( 'u-hidden' );
     } );
 
     return this;

--- a/cfgov/unprocessed/apps/owning-a-home/js/explore-rates.js
+++ b/cfgov/unprocessed/apps/owning-a-home/js/explore-rates.js
@@ -331,7 +331,7 @@ function updateView() {
       if ( $( '#county' ).is( ':visible' ) && $( '#county' ).val() === null ) {
         chart.startLoading();
         dropdown( 'county' ).showHighlight();
-        $( '#hb-warning' ).addClass( 'hidden' );
+        $( '#hb-warning' ).addClass( 'u-hidden' );
         return;
       }
 
@@ -509,11 +509,11 @@ function checkForJumbo() {
   } );
   dropdown( 'loan-type' ).enable( norms );
   dropdown( 'loan-type' ).hideHighlight();
-  $( '#county-warning' ).addClass( 'hidden' );
+  $( '#county-warning' ).addClass( 'u-hidden' );
 
   // if loan is not a jumbo, hide the loan type warning
   if ( jQuery.inArray( params['loan-type'], jumbos ) < 0 ) {
-    $( '#hb-warning' ).addClass( 'hidden' );
+    $( '#hb-warning' ).addClass( 'u-hidden' );
     dropdown( 'loan-type' ).hideHighlight();
   }
 
@@ -527,7 +527,7 @@ function checkForJumbo() {
       params['loan-type'] = 'conf';
       $( '#loan-type' ).val( 'conf' );
     }
-    $( '#county-warning, #hb-warning' ).addClass( 'hidden' );
+    $( '#county-warning, #hb-warning' ).addClass( 'u-hidden' );
     dropdown( 'loan-type' ).enable( norms );
     dropdown( 'loan-type' ).showHighlight();
   }
@@ -544,11 +544,11 @@ function checkForJumbo() {
   dropdown( 'county' ).show();
 
   // Hide any existing message, then show a message if appropriate.
-  $( '#county-warning' ).addClass( 'hidden' );
+  $( '#county-warning' ).addClass( 'u-hidden' );
   if ( warnings.hasOwnProperty( params['loan-type'] ) ) {
-    $( '#county-warning' ).removeClass( 'hidden' ).find( 'p' ).text( warnings[params['loan-type']].call() );
+    $( '#county-warning' ).removeClass( 'u-hidden' ).find( 'p' ).text( warnings[params['loan-type']].call() );
   } else {
-    $( '#county-warning' ).removeClass( 'hidden' ).find( 'p' ).text( template.countyGenWarning() );
+    $( '#county-warning' ).removeClass( 'u-hidden' ).find( 'p' ).text( template.countyGenWarning() );
   }
 
   // If the state hasn't changed, we also cool. No need to load new counties.
@@ -579,7 +579,7 @@ function processCounty() {
   };
   var loan;
 
-  // If the county field is hidden or they haven't selected a county, abort.
+  // If the county field is u-hidden or they haven't selected a county, abort.
   if ( !$counties.is( ':visible' ) || !$counties.val() ) {
     return;
   }
@@ -617,14 +617,14 @@ function processCounty() {
     // Add links to loan messages.
     loan.msg = loan.msg.replace( 'jumbo (non-conforming)', '<a href="/owning-a-home/loan-options/conventional-loans/" target="_blank">jumbo (non-conforming)</a>' );
     loan.msg = loan.msg.replace( 'conforming jumbo', '<a href="/owning-a-home/loan-options/conventional-loans/" target="_blank">conforming jumbo</a>' );
-    $( '#hb-warning' ).removeClass( 'hidden' ).find( 'p' ).html( loan.msg );
+    $( '#hb-warning' ).removeClass( 'u-hidden' ).find( 'p' ).html( loan.msg );
 
   } else {
     params.isJumbo = false;
     dropdown( 'loan-type' ).removeOption( jumbos );
     dropdown( 'loan-type' ).enable( norms );
 
-    $( '#hb-warning' ).addClass( 'hidden' );
+    $( '#hb-warning' ).addClass( 'u-hidden' );
     // Select appropriate loan type if loan was kicked out of jumbo
     if ( params.prevLoanType === 'fha-hb' ) {
       $( '#loan-type' ).val( 'fha' );
@@ -640,7 +640,7 @@ function processCounty() {
   }
 
   // Hide the county warning.
-  $( '#county-warning' ).addClass( 'hidden' );
+  $( '#county-warning' ).addClass( 'u-hidden' );
 }
 
 /**
@@ -811,8 +811,8 @@ function renderInterestSummary( intVals, term ) {
  */
 function checkARM() {
   // reset warning and info
-  $( '#arm-warning' ).addClass( 'hidden' );
-  $( '.arm-info' ).addClass( 'hidden' );
+  $( '#arm-warning' ).addClass( 'u-hidden' );
+  $( '.arm-info' ).addClass( 'u-hidden' );
   var disallowedTypes = [ 'fha', 'va', 'va-hb', 'fha-hb' ];
   var disallowedTerms = [ '15' ];
 
@@ -821,27 +821,27 @@ function checkARM() {
     if ( disallowedTerms.indexOf( params['loan-term'] ) !== -1 ) {
       dropdown( 'loan-term' ).reset();
       dropdown( 'loan-term' ).showHighlight();
-      $( '#arm-warning' ).removeClass( 'hidden' );
+      $( '#arm-warning' ).removeClass( 'u-hidden' );
     }
     // Reset and highlight if the loan type is disallowed
     if ( disallowedTypes.indexOf( params['loan-type'] ) !== -1 ) {
       dropdown( 'loan-type' ).reset();
       dropdown( 'loan-type' ).showHighlight();
-      $( '#arm-warning' ).removeClass( 'hidden' );
+      $( '#arm-warning' ).removeClass( 'u-hidden' );
     }
     dropdown( 'loan-term' ).disable( '15' );
     dropdown( 'loan-type' ).disable( [ 'fha', 'va' ] );
     dropdown( 'arm-type' ).show();
-    $( '.no-arm' ).addClass( 'hidden' );
-    $( '.arm-info' ).removeClass( 'hidden' );
+    $( '.no-arm' ).addClass( 'u-hidden' );
+    $( '.arm-info' ).removeClass( 'u-hidden' );
   } else {
     if ( params.isJumbo === false ) {
       dropdown( [ 'loan-term', 'loan-type' ] ).enable();
     }
     dropdown( 'arm-type' ).hide();
-    $( '#arm-warning' ).addClass( 'hidden' );
-    $( '.arm-info' ).addClass( 'hidden' );
-    $( '.no-arm' ).removeClass( 'hidden' );
+    $( '#arm-warning' ).addClass( 'u-hidden' );
+    $( '.arm-info' ).addClass( 'u-hidden' );
+    $( '.no-arm' ).removeClass( 'u-hidden' );
   }
 }
 
@@ -1139,7 +1139,7 @@ $( '.demographics, .calc-loan-details, .county' ).on( 'change', '.recalc', funct
   // If the loan-type is conf, and there's a county visible,
   // then we just exited a HB situation.
   // Clear the county before proceeding.
-  $( '#hb-warning' ).addClass( 'hidden' );
+  $( '#hb-warning' ).addClass( 'u-hidden' );
   // If the state field changed, wipe out county.
   if ( $( this ).attr( 'id' ) === 'location' ) {
     $( '#county' ).html( '' );


### PR DESCRIPTION
## Changes

- Updates `hidden` class to `u-hidden`.

## Testing

1. Log into local wagtail and set the flag `OAH_EXPLORE_RATES` to `true`
2. Restart the server.
3. Run `cp ./cfgov/unprocessed/apps/owning-a-home/example-config.json ./cfgov/unprocessed/apps/owning-a-home/config.json` (if needed) and `gulp build`.
3. View http://localhost:8000/owning-a-home/explore-rates/
4. See that warning icons aren't showing in the right-hand column

![screen shot 2018-02-26 at 10 26 07 am](https://user-images.githubusercontent.com/704760/36679825-2dd7a0aa-1ae2-11e8-9204-011c6acda1c3.png)

