### PR TITLE
Reduce margin by half for post preview images on small screens

### DIFF
--- a/cfgov/unprocessed/css/organisms/post-preview.less
+++ b/cfgov/unprocessed/css/organisms/post-preview.less
@@ -110,7 +110,7 @@
 
     &_image-container {
         .respond-to-max( @bp-sm-max, {
-            margin-bottom: unit( @grid_gutter-width / @base-font-size-px, em );
+            margin-bottom: unit( @grid_gutter-width / 2 / @base-font-size-px, em);
         } );
 
         .respond-to-min( @bp-med-min, {


### PR DESCRIPTION
Fixes remaining visual bug/inconsistency for https://GHE/CFGOV/platform/issues/1089#issuecomment-147885

## Changes

- divide previous margin-bottom value (which equates to 30px) by half to get 15px

## Testing

1. check out branch
1. runserver
1. go to http://localhost:8000/about-us/blog/
1. inspect any missing image element - edit attribute with inspector to add image URL such as https://s3.amazonaws.com/files.consumerfinance.gov/f/images/cfpb_YouthResearch_blog.original.png (so you don't have to mess with wagtail)
1. once image is visible, confirm bottom margin is 15px 

## Screenshots
![screen shot 2018-02-26 at 3 07 41 pm](https://user-images.githubusercontent.com/702526/36692806-1ce6aeba-1b07-11e8-97c8-a3d52ae8d497.png)


## Notes

-

## Todos

-

## Checklist

* [ ] PR has an informative and human-readable title
* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [ ] Passes all existing automated tests
* [ ] Any *change* in functionality is tested
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated
* [ ] Reviewers requested with the [Reviewer tool](https://help.github.com/articles/about-pull-request-reviews/) :arrow_right:
