### PR TITLE
Flag OAH mortgage routes

### DIFF
--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -609,6 +609,12 @@ FLAGS = {
     # To be enabled when owning-a-home/explore-rates is de-sheered.
     'OAH_EXPLORE_RATES': {},
 
+    # To be enabled when owning-a-home/mortgage-closing is de-sheered.
+    'OAH_MORTGAGE_CLOSING': {},
+
+    # To be enabled when owning-a-home/mortgage-estimate is de-sheered.
+    'OAH_MORTGAGE_ESTIMATE': {},
+
     # Google Optimize code snippets for A/B testing
     # When enabled this flag will add various Google Optimize code snippets.
     # Intended for use with path conditions.

--- a/cfgov/cfgov/urls.py
+++ b/cfgov/cfgov/urls.py
@@ -97,13 +97,27 @@ urlpatterns = [
         include(oah.urls_for_prefix('loan-options/special-loan-programs/'))),
 
     url(r'^owning-a-home/mortgage-closing/',
-        TemplateView.as_view(
-        template_name='owning-a-home/mortgage-closing/index.html'),
-        name='mortgage-closing'),
+        FlaggedTemplateView.as_view(
+            flag_name='OAH_MORTGAGE_CLOSING',
+            template_name='owning-a-home/mortgage-closing/index.html',
+            fallback=SheerTemplateView.as_view(
+                template_engine='owning-a-home',
+                template_name='mortgage-closing/index.html'
+            )
+        ),
+        name='mortgage-closing'
+    ),
     url(r'^owning-a-home/mortgage-estimate/',
-        TemplateView.as_view(
-        template_name='owning-a-home/mortgage-estimate/index.html'),
-        name='mortgage-estimate'),
+        FlaggedTemplateView.as_view(
+            flag_name='OAH_MORTGAGE_ESTIMATE',
+            template_name='owning-a-home/mortgage-estimate/index.html',
+            fallback=SheerTemplateView.as_view(
+                template_engine='owning-a-home',
+                template_name='mortgage-estimate/index.html'
+            )
+        ),
+        name='mortgage-estimate'
+    ),
 
     url(r'^owning-a-home/process/',
         include(oah.urls_for_prefix('process/prepare/'))),


### PR DESCRIPTION
https://github.com/cfpb/cfgov-refresh/pull/3514 was added before we started flagging OAH routes. With the changes to OAH assets this broke on prod. This PR adds flags for the two mortgage routes in OAH to pull off the old pages till prod it set up to install app package.json https://github.com/cfpb/cfgov-refresh/pull/3820 and handle rate checker's config.json file https://github.com/cfpb/cfgov-refresh/pull/3818

## Changes

- Adds flags to the URLs for /owning-a-home/mortgage-closing/ and /owning-a-home/mortgage-estimate/

## Testing

1. Restart the server. 
2. Check that /owning-a-home/mortgage-closing/ and /owning-a-home/mortgage-estimate/ loads.
3. Log into local wagtail and set flags `OAH_MORTGAGE_CLOSING` and `OAH_MORTGAGE_ESTIMATE ` and check that /owning-a-home/mortgage-closing/ and /owning-a-home/mortgage-estimate/ still load.