### PR TITLE
Add postinstall script for apps under cfgov-refresh

### DIFF
--- a/cfgov/unprocessed/apps/cfgov/unprocessed/apps/owning-a-home/package-lock.json
+++ b/cfgov/unprocessed/apps/cfgov/unprocessed/apps/owning-a-home/package-lock.json
@@ -1,0 +1,3 @@
+{
+  "lockfileVersion": 1
+}

--- a/gulp/config.js
+++ b/gulp/config.js
@@ -32,7 +32,8 @@ module.exports = {
     build: [
       'config/**/*.js',
       'gulpfile.js',
-      'gulp/**/*.js'
+      'gulp/**/*.js',
+      'scripts/npm/**/*.js'
     ]
   },
   test: {

--- a/package.json
+++ b/package.json
@@ -101,7 +101,8 @@
     "wcag": "0.3.0"
   },
   "scripts": {
-    "test": "snyk test"
+    "test": "snyk test",
+    "postinstall": "node scripts/npm/apps-install"
   },
   "snyk": true
 }

--- a/scripts/npm/apps-install/index.js
+++ b/scripts/npm/apps-install/index.js
@@ -1,0 +1,39 @@
+/*
+This script handles installing node dependencies for a project that lives
+under cfgov-refresh, but has its own package.json. These projects appear
+under the ./cfgov/unprocessed/apps/ path.
+ */
+
+const fs = require( 'fs' );
+const exec = require( 'child_process' ).exec;
+
+const paths = require( '../../../config/environment' ).paths;
+
+// Aggregate application namespaces that appear in unprocessed/apps.
+// eslint-disable-next-line no-sync
+let apps = fs.readdirSync( `${ paths.unprocessed }/apps/` );
+
+// Filter out .DS_STORE directory.
+apps = apps.filter( dir => dir.charAt( 0 ) !== '.' );
+
+// Run each application's JS through webpack and store the gulp streams.
+apps.forEach( app => {
+  /* Check if node_modules directory exists in a particular app's folder.
+     If it doesn't log the command to add it and don't process the scripts. */
+  const appsPath = `${ paths.unprocessed }/apps/${ app }`;
+  // eslint-disable-next-line no-sync
+  if ( fs.existsSync( `${ appsPath }/package.json` ) ) {
+    exec( `npm --prefix ${ appsPath } install ${ appsPath }`,
+      ( error, stdout, stderr ) => {
+        // eslint-disable-next-line no-console
+        console.log( 'App\'s npm output: ' + stdout );
+        // eslint-disable-next-line no-console
+        console.log( 'App\'s npm errors: ' + stderr );
+        if ( error !== null ) {
+          // eslint-disable-next-line no-console
+          console.log( 'App\'s exec error: ' + error );
+        }
+      }
+    );
+  }
+} );


### PR DESCRIPTION
## Additions
 
- Adds `scripts/npm/apps-install/index.js` script for running `npm install` on `./cfgov/unprocessed/apps/[app namespace]/package.json`.

## Testing

1. Throw out `./cfgov/unprocessed/apps/[app namespace]/node_modules`
2. Run `gulp build`, get `App dependencies not installed…` message. (Do not follow message.)
3. Run `npm install` from the project root.
4. Re-run `gulp build` and check that `./cfgov/unprocessed/apps/[app namespace]/node_modules` exists.
