### PR TITLE
Modifying OAH flagged routes

### DIFF
--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -609,11 +609,9 @@ FLAGS = {
     # To be enabled when owning-a-home/explore-rates is de-sheered.
     'OAH_EXPLORE_RATES': {},
 
-    # To be enabled when owning-a-home/mortgage-closing is de-sheered.
-    'OAH_MORTGAGE_CLOSING': {},
-
-    # To be enabled when owning-a-home/mortgage-estimate is de-sheered.
-    'OAH_MORTGAGE_ESTIMATE': {},
+    # To be enabled when owning-a-home/closing-disclosure/
+    # and owning-a-home/loan-estimate/ are de-sheered.
+    'OAH_FORM_EXPLAINERS': {},
 
     # Google Optimize code snippets for A/B testing
     # When enabled this flag will add various Google Optimize code snippets.

--- a/cfgov/cfgov/urls.py
+++ b/cfgov/cfgov/urls.py
@@ -68,11 +68,17 @@ urlpatterns = [
     url(r'^owning-a-home/resources/(?P<path>.*)$',
         RedirectView.as_view(
             url='/static/owning-a-home/resources/%(path)s', permanent=True)),
-
     url(r'^owning-a-home/closing-disclosure/',
-        TemplateView.as_view(
-        template_name='owning-a-home/closing-disclosure/index.html'),
-        name='closing-disclosure'),
+        FlaggedTemplateView.as_view(
+            flag_name='OAH_FORM_EXPLAINERS',
+            template_name='owning-a-home/closing-disclosure/index.html',
+            fallback=SheerTemplateView.as_view(
+                template_engine='owning-a-home',
+                template_name='closing-disclosure/index.html'
+            )
+        ),
+        name='closing-disclosure'
+    ),
     url(r'^owning-a-home/explore-rates/',
         FlaggedTemplateView.as_view(
             flag_name='OAH_EXPLORE_RATES',
@@ -95,30 +101,18 @@ urlpatterns = [
         include(oah.urls_for_prefix('loan-options/conventional-loans/'))),
     url(r'^owning-a-home/loan-options/special-loan-programs/',
         include(oah.urls_for_prefix('loan-options/special-loan-programs/'))),
-
     url(r'^owning-a-home/mortgage-closing/',
-        FlaggedTemplateView.as_view(
-            flag_name='OAH_MORTGAGE_CLOSING',
-            template_name='owning-a-home/mortgage-closing/index.html',
-            fallback=SheerTemplateView.as_view(
-                template_engine='owning-a-home',
-                template_name='mortgage-closing/index.html'
-            )
+        TemplateView.as_view(
+            template_name='owning-a-home/mortgage-closing/index.html'
         ),
         name='mortgage-closing'
     ),
     url(r'^owning-a-home/mortgage-estimate/',
-        FlaggedTemplateView.as_view(
-            flag_name='OAH_MORTGAGE_ESTIMATE',
+        TemplateView.as_view(
             template_name='owning-a-home/mortgage-estimate/index.html',
-            fallback=SheerTemplateView.as_view(
-                template_engine='owning-a-home',
-                template_name='mortgage-estimate/index.html'
-            )
         ),
         name='mortgage-estimate'
     ),
-
     url(r'^owning-a-home/process/',
         include(oah.urls_for_prefix('process/prepare/'))),
     url(r'^owning-a-home/process/prepare/',


### PR DESCRIPTION
Modifying OAH flagged routes

## Changes

- Modified code to group routes. Removed the flags from the static pages. They aren't necessary and will render properly when #3831 is merged.

## Testing

1. Visit `http://localhost:8000/owning-a-home/closing-disclosure/` and ensure the route works with the flag `OAH_FORM_EXPLAINERS` set / unset. 
2. Visit `http://localhost:8000/owning-a-home/mortgage-closing` and ensure the route works .
3. Visit `http://localhost:8000/owning-a-home/mortgage-estimate` and ensure the route works .


## Screenshots


## Notes

-

## Todos

-

## Checklist

* [ ] PR has an informative and human-readable title
* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [ ] Passes all existing automated tests
* [ ] Any *change* in functionality is tested
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated
* [ ] Reviewers requested with the [Reviewer tool](https://help.github.com/articles/about-pull-request-reviews/) :arrow_right:
