### PR TITLE
Remove for attribute from legend

### DIFF
--- a/cfgov/jinja2/v1/_includes/organisms/filterable-list-controls.html
+++ b/cfgov/jinja2/v1/_includes/organisms/filterable-list-controls.html
@@ -61,8 +61,7 @@
                     content-l_col-1-3">
             <div class="o-form_group">
                 <fieldset class="o-form_fieldset">
-                    <legend class="a-legend"
-                            for="categories">
+                    <legend class="a-legend">
                         Category
                     </legend>
                     <ul class="m-list m-list__unstyled">


### PR DESCRIPTION
Legend had a `for` attribute from when it was migrated from being a label 😊 

## Removals

- Remove `for` attribute from legend.
