### PR TITLE
Cleanup for apps-install script

### DIFF
--- a/cfgov/unprocessed/apps/cfgov/unprocessed/apps/owning-a-home/package-lock.json
+++ b/cfgov/unprocessed/apps/cfgov/unprocessed/apps/owning-a-home/package-lock.json
@@ -1,3 +1,0 @@
-{
-  "lockfileVersion": 1
-}

--- a/gulp/tasks/scripts.js
+++ b/gulp/tasks/scripts.js
@@ -195,14 +195,14 @@ function scriptsApps() {
   // eslint-disable-next-line no-sync
   let apps = fs.readdirSync( `${ paths.unprocessed }/apps/` );
 
-  // Filter out .DS_STORE directory.
+  // Filter out hidden directories.
   apps = apps.filter( dir => dir.charAt( 0 ) !== '.' );
 
   // Run each application's JS through webpack and store the gulp streams.
   const streams = [];
   apps.forEach( app => {
     /* Check if node_modules directory exists in a particular app's folder.
-       If it doesn't log the command to add it and don't process the scripts. */
+       If it doesn't, don't process the scripts and log the command to run. */
     const appsPath = `${ paths.unprocessed }/apps/${ app }`;
     // eslint-disable-next-line no-sync
     if ( fs.existsSync( `${ appsPath }/package.json` ) ) {

--- a/scripts/npm/apps-install/index.js
+++ b/scripts/npm/apps-install/index.js
@@ -13,25 +13,29 @@ const paths = require( '../../../config/environment' ).paths;
 // eslint-disable-next-line no-sync
 let apps = fs.readdirSync( `${ paths.unprocessed }/apps/` );
 
-// Filter out .DS_STORE directory.
+// Filter out hidden directories.
 apps = apps.filter( dir => dir.charAt( 0 ) !== '.' );
 
-// Run each application's JS through webpack and store the gulp streams.
+// Install each application's dependencies.
 apps.forEach( app => {
-  /* Check if node_modules directory exists in a particular app's folder.
-     If it doesn't log the command to add it and don't process the scripts. */
+  /* Check if package.json exists in a particular app's folder.
+     If it does, run npm install on that directory. */
   const appsPath = `${ paths.unprocessed }/apps/${ app }`;
   // eslint-disable-next-line no-sync
   if ( fs.existsSync( `${ appsPath }/package.json` ) ) {
     exec( `npm --prefix ${ appsPath } install ${ appsPath }`,
       ( error, stdout, stderr ) => {
         // eslint-disable-next-line no-console
-        console.log( 'App\'s npm output: ' + stdout );
-        // eslint-disable-next-line no-console
-        console.log( 'App\'s npm errors: ' + stderr );
+        console.log( `npm output from ${ appsPath }: ${stdout}` );
+
+        if ( stderr !== null ) {
+          // eslint-disable-next-line no-console
+          console.log( `npm errors/warnings from ${ appsPath }: ${stderr}` );
+        }
+
         if ( error !== null ) {
           // eslint-disable-next-line no-console
-          console.log( 'App\'s exec error: ' + error );
+          console.log( `exec error from ${ appsPath }: ${error}` );
         }
       }
     );

--- a/scripts/npm/apps-install/index.js
+++ b/scripts/npm/apps-install/index.js
@@ -5,6 +5,7 @@ under the ./cfgov/unprocessed/apps/ path.
  */
 
 const fs = require( 'fs' );
+// eslint-disable-next-line no-sync
 const execSync = require( 'child_process' ).execSync;
 
 const paths = require( '../../../config/environment' ).paths;
@@ -28,22 +29,18 @@ apps.forEach( app => {
       const stdOut = execSync(
         `npm --prefix ${ appsPath } install ${ appsPath }`
       );
+      // eslint-disable-next-line no-console
       console.log( `${ appsPath }'s npm output: ${ stdOut.toString() }` );
     } catch ( error ) {
       if ( error.stderr ) {
         // eslint-disable-next-line no-console
         console.log( `npm output from ${ appsPath }: ${ error.stderr }` );
       }
-      if ( error !== null ) {
-        if ( stderr !== null ) {
-          // eslint-disable-next-line no-console
-          console.log( `npm errors/warnings from ${ appsPath }: ${ stderr }` );
-        }
 
-        // eslint-disable-next-line no-console
-        console.log( `exec error from ${ appsPath }: ${ error }` );
-        process.exit( 1 );
-      }
+      // eslint-disable-next-line no-console
+      console.log( `exec error from ${ appsPath }: ${ error }` );
+      // eslint-disable-next-line no-process-exit
+      process.exit( 1 );
     }
   }
 } );

--- a/scripts/npm/apps-install/index.js
+++ b/scripts/npm/apps-install/index.js
@@ -5,7 +5,7 @@ under the ./cfgov/unprocessed/apps/ path.
  */
 
 const fs = require( 'fs' );
-const exec = require( 'child_process' ).exec;
+const execSync = require( 'child_process' ).execSync;
 
 const paths = require( '../../../config/environment' ).paths;
 
@@ -23,21 +23,27 @@ apps.forEach( app => {
   const appsPath = `${ paths.unprocessed }/apps/${ app }`;
   // eslint-disable-next-line no-sync
   if ( fs.existsSync( `${ appsPath }/package.json` ) ) {
-    exec( `npm --prefix ${ appsPath } install ${ appsPath }`,
-      ( error, stdout, stderr ) => {
+    try {
+      // eslint-disable-next-line no-sync
+      const stdOut = execSync(
+        `npm --prefix ${ appsPath } install ${ appsPath }`
+      );
+      console.log( `${ appsPath }'s npm output: ${ stdOut.toString() }` );
+    } catch ( error ) {
+      if ( error.stderr ) {
         // eslint-disable-next-line no-console
-        console.log( `npm output from ${ appsPath }: ${stdout}` );
-
+        console.log( `npm output from ${ appsPath }: ${ error.stderr }` );
+      }
+      if ( error !== null ) {
         if ( stderr !== null ) {
           // eslint-disable-next-line no-console
-          console.log( `npm errors/warnings from ${ appsPath }: ${stderr}` );
+          console.log( `npm errors/warnings from ${ appsPath }: ${ stderr }` );
         }
 
-        if ( error !== null ) {
-          // eslint-disable-next-line no-console
-          console.log( `exec error from ${ appsPath }: ${error}` );
-        }
+        // eslint-disable-next-line no-console
+        console.log( `exec error from ${ appsPath }: ${ error }` );
+        process.exit( 1 );
       }
-    );
+    }
   }
 } );


### PR DESCRIPTION
Address @Scotchester comments in https://github.com/cfpb/cfgov-refresh/pull/3831

## Removals
- Removes erroneous `package-lock.json`.

## Changes

- Corrects incorrect code comments in apps-install npm script.
- Wrap npm standard error output in an if statement.

## Testing

1. See testing in https://github.com/cfpb/cfgov-refresh/pull/3831
