### PR TITLE
Fix an issue with inputs that should be 100% in width

### DIFF
--- a/cfgov/jinja2/v1/_includes/blocks/feedback.html
+++ b/cfgov/jinja2/v1/_includes/blocks/feedback.html
@@ -84,23 +84,28 @@
     {% endif %}
 
     <div class="o-form_group">
-        <label class="a-label a-label__heading" for="comment">
-            {% if value.intro_text %}
-                {{ value.intro_text }}
-            {% elif value.question_text %}
-                {{ value.question_text }}
-            {% elif value.was_it_helpful_text %}
-                {% if page.language == 'es' %}Comentario adicional{% else %}Additional comment{% endif %} <small class="a-label_helper">({% if page.language == 'es' %}opcional{% else %}optional{% endif %})</small>
-            {% endif %}
-        </label>
-        <p class="u-mb15"><small><em>{% if page.language == 'es' %}Nota: No incluya información confidencial, como su nombre, información de contacto, número de cuenta o número de seguro social en este campo.{% else %}Note: Do not include sensitive information like your name, contact information, account number, or social security number in this field.{% endif %}
-        </em></small></p>
-        <textarea class="a-text-input" id="comment" name="comment" rows="6"
-                 {% if not value.was_it_helpful_text %}
-                     required
-                 {% endif %}>
-            {{- form.comment.value() | default('', true) -}}
-        </textarea>
+        <div class="m-form-field">
+            <label class="a-label a-label__heading" for="comment">
+                {% if value.intro_text %}
+                    {{ value.intro_text }}
+                {% elif value.question_text %}
+                    {{ value.question_text }}
+                {% elif value.was_it_helpful_text %}
+                    {% if page.language == 'es' %}Comentario adicional{% else %}Additional comment{% endif %} <small class="a-label_helper">({% if page.language == 'es' %}opcional{% else %}optional{% endif %})</small>
+                {% endif %}
+            </label>
+            <p class="u-mb15"><small><em>{% if page.language == 'es' %}Nota: No incluya información confidencial, como su nombre, información de contacto, número de cuenta o número de seguro social en este campo.{% else %}Note: Do not include sensitive information like your name, contact information, account number, or social security number in this field.{% endif %}
+            </em></small></p>
+            <textarea class="a-text-input a-text-input__full"
+                      id="comment"
+                      name="comment"
+                      rows="6"
+                      {%- if not value.was_it_helpful_text %}
+                      required
+                      {% endif -%}>
+                {{- form.comment.value() | default('', true) -}}
+            </textarea>
+        </div>
     </div>
 
     {% if value.radio_intro and not value.was_it_helpful_text %}
@@ -174,9 +179,11 @@
     </div>
 
     <div class="o-form_group">
-        <label class="a-label a-label__heading" for="email">Contact email</label>
-        <input class="a-text-input" id="form_email" type="email" name="email">
-        <p>{{ value.contact_advisory }}</p>
+        <div class="m-form-field">
+            <label class="a-label a-label__heading" for="email">Contact email</label>
+            <input class="a-text-input" id="form_email" type="email" name="email">
+            <p>{{ value.contact_advisory }}</p>
+        </div>
     </div>
 
     {% endif %}


### PR DESCRIPTION
These forms were never updated to use the latest markup and classes
created in cf-forms to handle full width inputs. This fixes
`/platform/issues/1075`

## Changes

- Updated the form markup to match the recommended pattern in cf-forms

## Testing

1. Navigate to http://localhost:8000/practitioner-resources/servicemembers/
2. Navigate to http://localhost:8000/owning-a-home/help-us-improve/

## Screenshots

<img width="584" alt="screen shot 2018-02-28 at 2 05 00 pm" src="https://user-images.githubusercontent.com/1280430/36810701-1ddc29cc-1c91-11e8-8b4c-fe33659ac277.png">

<img width="654" alt="screen shot 2018-02-28 at 2 04 53 pm" src="https://user-images.githubusercontent.com/1280430/36810704-1f78b82c-1c91-11e8-8836-6e10b34ffdaa.png">

## Checklist

* [x] PR has an informative and human-readable title
* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [x] Passes all existing automated tests
* [x] Any *change* in functionality is tested
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices
* [x] Project documentation has been updated
* [x] Reviewers requested with the [Reviewer tool](https://help.github.com/articles/about-pull-request-reviews/) :arrow_right:
