### PR TITLE
Upgrade Wagtail to 1.13.1

### DIFF
--- a/cfgov/data_research/tests/management/commands/test_conference_export.py
+++ b/cfgov/data_research/tests/management/commands/test_conference_export.py
@@ -30,9 +30,38 @@ class TestGetRegistrationFormFromPage(TestCase):
         registration_form_block = atomic.conference_registration_form
         set_stream_data(page, 'content', [registration_form_block])
 
+        rendered_block = get_registration_form_from_page(revision.page_id)
         self.assertEqual(
-            get_registration_form_from_page(revision.page_id),
-            registration_form_block
+            rendered_block['type'],
+            registration_form_block['type']
+        )
+        self.assertEqual(
+            rendered_block['value']['at_capacity_message'][0]['value'],
+            registration_form_block['value']['at_capacity_message'][0]['value']
+        )
+        self.assertEqual(
+            rendered_block['value']['code'],
+            registration_form_block['value']['code']
+        )
+        self.assertEqual(
+            rendered_block['value']['capacity'],
+            registration_form_block['value']['capacity']
+        )
+        self.assertEqual(
+            rendered_block['value']['failure_message'],
+            registration_form_block['value']['failure_message']
+        )
+        self.assertEqual(
+            rendered_block['value']['heading'],
+            registration_form_block['value']['heading']
+        )
+        self.assertEqual(
+            rendered_block['value']['sessions'],
+            registration_form_block['value']['sessions']
+        )
+        self.assertEqual(
+            rendered_block['value']['success_message'],
+            registration_form_block['value']['success_message']
         )
 
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -40,7 +40,7 @@ simplejson==3.8.2
 six==1.10.0
 unicodecsv==0.14.1
 unipath>=1.1,<=2.0
-wagtail==1.10.1
+wagtail==1.13.1
 wagtail-flags==2.0.8
 wagtail-inventory==0.3
 wagtail-sharing==0.6.1


### PR DESCRIPTION
This PR bumps our Wagtail version to 1.1.13.1. 

Interesting things we've missed out on so far (that we get now):

- *New React-based admin!*
- Global unique identifiers on StreamField blocks
- URL caching throughout the request cycle with  `page.get_url(request=request)` instead of `page.url` (We'll have to chose to make use of this)

Possible concerns:

- StreamField defaults to `blank=False`. I haven't found a place where this affects us (in fact, we explicitly set `blank=True` where we seem to desire it already), but my testing has not been exhaustive
- Registering Hallo plugins with `registerHalloPlugin` is deprecated and replaced by rich text features. I have not replaced our use of `registerHalloPlugin` just yet — it's deprecated but not removed, and yes we should use configurable rich text features instead and it will be more future-friendly now that Draftail has replaced Hallo in Wagtail 2.0. But I think we should put our effort toward Python3/Django2/Wagtail2 and Draftail.

Full changelogs:

- http://docs.wagtail.io/en/v1.13.1/releases/1.11.html
- http://docs.wagtail.io/en/v1.13.1/releases/1.12.html
- http://docs.wagtail.io/en/v1.13.1/releases/1.13.html

This PR is holding for more thorough testing and input on opinionated choices I've made and described.

## Notes

- I modified the Data & Research conference registration form test `test_returns_form_block` because of the StreamBlock unique ids introduced in 1.12. These mean that a rendered StreamBlock isn't going to be equatable to a fixture. 

## Todos

- More thorough testing.

## Checklist

* [ ] PR has an informative and human-readable title
* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [ ] Passes all existing automated tests
* [ ] Any *change* in functionality is tested
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated
* [ ] Reviewers requested with the [Reviewer tool](https://help.github.com/articles/about-pull-request-reviews/) :arrow_right:
