### PR TITLE
Replace gulpUtil with fancyLog

### DIFF
--- a/cfgov/unprocessed/apps/owning-a-home/package-lock.json
+++ b/cfgov/unprocessed/apps/owning-a-home/package-lock.json
@@ -7,7 +7,6 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
-      "dev": true,
       "requires": {
         "kind-of": "3.2.2",
         "longest": "1.0.1",
@@ -17,39 +16,33 @@
     "amdefine": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
-      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
-      "dev": true
+      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU="
     },
     "amortize": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/amortize/-/amortize-0.2.2.tgz",
-      "integrity": "sha1-TcC6L28P4wjK6cMPU2ZU31F3t6A=",
-      "dev": true
+      "integrity": "sha1-TcC6L28P4wjK6cMPU2ZU31F3t6A="
     },
     "async": {
       "version": "1.5.2",
       "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-      "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
-      "dev": true
+      "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
     },
     "big.js": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.2.0.tgz",
-      "integrity": "sha512-+hN/Zh2D08Mx65pZ/4g5bsmNiZUuChDiQfTUQ7qJr4/kuopCr88xZsAXv6mBoZEsUI4OuGHlX59qE94K2mMW8Q==",
-      "dev": true
+      "integrity": "sha512-+hN/Zh2D08Mx65pZ/4g5bsmNiZUuChDiQfTUQ7qJr4/kuopCr88xZsAXv6mBoZEsUI4OuGHlX59qE94K2mMW8Q=="
     },
     "camelcase": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
       "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
-      "dev": true,
       "optional": true
     },
     "center-align": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
       "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
-      "dev": true,
       "optional": true,
       "requires": {
         "align-text": "0.1.4",
@@ -60,7 +53,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
       "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
-      "dev": true,
       "optional": true,
       "requires": {
         "center-align": "0.1.3",
@@ -72,7 +64,6 @@
           "version": "0.0.2",
           "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
           "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
-          "dev": true,
           "optional": true
         }
       }
@@ -80,27 +71,23 @@
     "date-format": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/date-format/-/date-format-0.0.2.tgz",
-      "integrity": "sha1-+v1Ej3IRXvHitzkVWukvK+bCjdE=",
-      "dev": true
+      "integrity": "sha1-+v1Ej3IRXvHitzkVWukvK+bCjdE="
     },
     "decamelize": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
-      "dev": true,
       "optional": true
     },
     "emojis-list": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
-      "integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k=",
-      "dev": true
+      "integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k="
     },
     "fastdom": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/fastdom/-/fastdom-1.0.6.tgz",
       "integrity": "sha1-D6WGYjjh6L6jXcFOMc3zRUfw23M=",
-      "dev": true,
       "requires": {
         "strictdom": "1.0.1"
       }
@@ -108,20 +95,17 @@
     "fastparse": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/fastparse/-/fastparse-1.1.1.tgz",
-      "integrity": "sha1-0eJkOzipTXWDtHkGDmxK/8lAcfg=",
-      "dev": true
+      "integrity": "sha1-0eJkOzipTXWDtHkGDmxK/8lAcfg="
     },
     "format-usd": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/format-usd/-/format-usd-0.2.0.tgz",
-      "integrity": "sha1-sqV9jWeMZb5ZtDjYP2jIOaBlb5s=",
-      "dev": true
+      "integrity": "sha1-sqV9jWeMZb5ZtDjYP2jIOaBlb5s="
     },
     "handlebars": {
       "version": "4.0.11",
       "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.11.tgz",
       "integrity": "sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=",
-      "dev": true,
       "requires": {
         "async": "1.5.2",
         "optimist": "0.6.1",
@@ -133,7 +117,6 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/handlebars-loader/-/handlebars-loader-1.6.0.tgz",
       "integrity": "sha512-FsM1ALql8+RNJuTgD1qPrVT8GpB209hPUKml/uIoR6aJIoeoLB+l/jt8xBnpfzN74aaQ9kMXaZajhIE6PNHusg==",
-      "dev": true,
       "requires": {
         "async": "0.2.10",
         "fastparse": "1.1.1",
@@ -144,46 +127,39 @@
         "async": {
           "version": "0.2.10",
           "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
-          "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E=",
-          "dev": true
+          "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E="
         }
       }
     },
     "highcharts": {
       "version": "4.2.7",
       "resolved": "https://registry.npmjs.org/highcharts/-/highcharts-4.2.7.tgz",
-      "integrity": "sha1-RcvtjpnJwELpX5xRB2cmSW9oaGI=",
-      "dev": true
+      "integrity": "sha1-RcvtjpnJwELpX5xRB2cmSW9oaGI="
     },
     "is-buffer": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-      "dev": true
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
     },
     "is-money-usd": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/is-money-usd/-/is-money-usd-0.1.2.tgz",
-      "integrity": "sha1-B6dxXXsn/kRLRvS0fNYNqEPdIws=",
-      "dev": true
+      "integrity": "sha1-B6dxXXsn/kRLRvS0fNYNqEPdIws="
     },
     "jquery": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.3.1.tgz",
-      "integrity": "sha512-Ubldcmxp5np52/ENotGxlLe6aGMvmF4R8S6tZjsP6Knsaxd/xp3Zrh50cG93lR6nPXyUFwzN3ZSOQI0wRJNdGg==",
-      "dev": true
+      "integrity": "sha512-Ubldcmxp5np52/ENotGxlLe6aGMvmF4R8S6tZjsP6Knsaxd/xp3Zrh50cG93lR6nPXyUFwzN3ZSOQI0wRJNdGg=="
     },
     "json5": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
-      "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
-      "dev": true
+      "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE="
     },
     "jumbo-mortgage": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/jumbo-mortgage/-/jumbo-mortgage-2.0.0.tgz",
       "integrity": "sha1-DTWGcX5xS4g4arvszpGM4SCOxXI=",
-      "dev": true,
       "requires": {
         "format-usd": "0.1.0"
       },
@@ -191,8 +167,7 @@
         "format-usd": {
           "version": "0.1.0",
           "resolved": "https://registry.npmjs.org/format-usd/-/format-usd-0.1.0.tgz",
-          "integrity": "sha1-b/VHWk3c62/F09L5P+3XDiZwrT4=",
-          "dev": true
+          "integrity": "sha1-b/VHWk3c62/F09L5P+3XDiZwrT4="
         }
       }
     },
@@ -200,7 +175,6 @@
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-      "dev": true,
       "requires": {
         "is-buffer": "1.1.6"
       }
@@ -209,14 +183,12 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
       "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
-      "dev": true,
       "optional": true
     },
     "loader-utils": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.0.4.tgz",
       "integrity": "sha1-E/Vhl/FSOjBYkSSLTHJEVAhIQmw=",
-      "dev": true,
       "requires": {
         "big.js": "3.2.0",
         "emojis-list": "2.1.0",
@@ -226,32 +198,27 @@
     "longest": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
-      "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-      "dev": true
+      "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc="
     },
     "median": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/median/-/median-0.0.2.tgz",
-      "integrity": "sha1-G3FyvCIes+m/T0efrare/FDER4c=",
-      "dev": true
+      "integrity": "sha1-G3FyvCIes+m/T0efrare/FDER4c="
     },
     "minimist": {
       "version": "0.0.10",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
-      "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
-      "dev": true
+      "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8="
     },
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-      "dev": true
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
     },
     "optimist": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
       "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
-      "dev": true,
       "requires": {
         "minimist": "0.0.10",
         "wordwrap": "0.0.3"
@@ -261,7 +228,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/rangeslider.js/-/rangeslider.js-2.3.2.tgz",
       "integrity": "sha512-ghYGdrOiS0/Btz1jel03TCucgeW1pqPKI0RVG7neYw3ZeOgOVrNgx2p4V2FVIkKGiLfJRuqlqkIC/Eq/5ARmoQ==",
-      "dev": true,
       "requires": {
         "jquery": "3.3.1"
       }
@@ -269,14 +235,12 @@
     "repeat-string": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
-      "dev": true
+      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
     },
     "right-align": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
       "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
-      "dev": true,
       "optional": true,
       "requires": {
         "align-text": "0.1.4"
@@ -286,7 +250,6 @@
       "version": "0.4.4",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
       "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
-      "dev": true,
       "requires": {
         "amdefine": "1.0.1"
       }
@@ -294,14 +257,12 @@
     "strictdom": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/strictdom/-/strictdom-1.0.1.tgz",
-      "integrity": "sha1-GJ3pFkn3PUTVm4Qy76aO+dJllGA=",
-      "dev": true
+      "integrity": "sha1-GJ3pFkn3PUTVm4Qy76aO+dJllGA="
     },
     "uglify-js": {
       "version": "2.8.29",
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
       "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
-      "dev": true,
       "optional": true,
       "requires": {
         "source-map": "0.5.7",
@@ -313,7 +274,6 @@
           "version": "0.5.7",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
           "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-          "dev": true,
           "optional": true
         }
       }
@@ -322,33 +282,28 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
       "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
-      "dev": true,
       "optional": true
     },
     "unformat-usd": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/unformat-usd/-/unformat-usd-0.1.1.tgz",
-      "integrity": "sha1-+bUOnFsKF43hc4tN5VU369AKuPc=",
-      "dev": true
+      "integrity": "sha1-+bUOnFsKF43hc4tN5VU369AKuPc="
     },
     "window-size": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
       "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
-      "dev": true,
       "optional": true
     },
     "wordwrap": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-      "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
-      "dev": true
+      "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
     },
     "yargs": {
       "version": "3.10.0",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
       "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
-      "dev": true,
       "optional": true,
       "requires": {
         "camelcase": "1.2.1",

--- a/gulp/tasks/audit.js
+++ b/gulp/tasks/audit.js
@@ -1,7 +1,7 @@
 const envvars = require( '../../config/environment' ).envvars;
+const fancyLog = require( 'fancy-log' );
 const fsHelper = require( '../utils/fs-helper' );
 const gulp = require( 'gulp' );
-const gulpUtil = require( 'gulp-util' );
 const isReachable = require( 'is-reachable' );
 const localtunnel = require( 'localtunnel' );
 const minimist = require( 'minimist' );
@@ -18,10 +18,10 @@ function testA11y() {
     { stdio: 'inherit' }
   ).once( 'close', code => {
     if ( code ) {
-      gulpUtil.log( 'WCAG tests exited with code ' + code );
+      fancyLog( 'WCAG tests exited with code ' + code );
       process.exit( 1 );
     }
-    gulpUtil.log( 'WCAG tests done!' );
+    fancyLog( 'WCAG tests done!' );
   } );
 }
 
@@ -40,7 +40,7 @@ function _getWCAGParams() {
   const checkerId = envvars.ACHECKER_ID;
   const urlPath = _parsePath( commandLineParams.u );
   const url = host + ':' + port + urlPath;
-  gulpUtil.log( 'WCAG tests checking URL: http://' + url );
+  fancyLog( 'WCAG tests checking URL: http://' + url );
 
   return [ '--u=' + url, '--id=' + checkerId ];
 }
@@ -52,7 +52,7 @@ function testPerf() {
   _createPSITunnel()
     .then( _runPSI )
     .catch( err => {
-      gulpUtil.log( err );
+      fancyLog( err );
     } );
 }
 
@@ -137,14 +137,14 @@ function _parsePath( urlPath ) {
  * @param {Object} params - url, options, and tunnel for running PSI.
  */
 function _runPSI( params ) {
-  gulpUtil.log( 'PSI tests checking URL: http://' + params.url );
+  fancyLog( 'PSI tests checking URL: http://' + params.url );
   psi.output( params.url, params.options )
     .then( () => {
-      gulpUtil.log( 'PSI tests done!' );
+      fancyLog( 'PSI tests done!' );
       params.tunnel.close();
     } )
     .catch( err => {
-      gulpUtil.log( err.message );
+      fancyLog( err.message );
       params.tunnel.close();
       process.exit( 1 );
     } );

--- a/gulp/tasks/docs.js
+++ b/gulp/tasks/docs.js
@@ -1,5 +1,5 @@
+const fancyLog = require( 'fancy-log' );
 const gulp = require( 'gulp' );
-const gulpUtil = require( 'gulp-util' );
 const paths = require( '../../config/environment' ).paths;
 const spawn = require( 'child_process' ).spawn;
 
@@ -15,7 +15,7 @@ function docsScripts() {
       './docs/scripts' ],
     { stdio: 'inherit' }
   ).once( 'close', function() {
-    gulpUtil.log( 'Scripts documentation generated!' );
+    fancyLog( 'Scripts documentation generated!' );
   } );
 }
 

--- a/gulp/tasks/test.js
+++ b/gulp/tasks/test.js
@@ -1,7 +1,9 @@
+const ansiColors = require( 'ansi-colors' );
 const BROWSER_LIST = require( '../../config/browser-list-config' );
 const gulpBabel = require( 'gulp-babel' );
 const configTest = require( '../config' ).test;
 const envvars = require( '../../config/environment' ).envvars;
+const fancyLog = require( 'fancy-log' );
 const fsHelper = require( '../utils/fs-helper' );
 const gulp = require( 'gulp' );
 const gulpIstanbul = require( 'gulp-istanbul' );
@@ -82,10 +84,10 @@ function testAcceptanceBrowser() {
   spawn( 'tox', toxParams, { stdio: 'inherit' } )
     .once( 'close', function( code ) {
       if ( code ) {
-        gulpUtil.log( 'Tox tests exited with code ' + code );
+        fancyLog( 'Tox tests exited with code ' + code );
         process.exit( 1 );
       }
-      gulpUtil.log( 'Tox tests done!' );
+      fancyLog( 'Tox tests done!' );
     } );
 }
 
@@ -173,8 +175,7 @@ function _createSauceTunnel( ) {
 
   if ( !( SAUCE_USERNAME && SAUCE_ACCESS_KEY && SAUCE_TUNNEL_ID ) ) {
     const ERROR_MSG = 'Please ensure your SAUCE variables are set.';
-    gulpUtil.colors.enabled = true;
-    gulpUtil.log( gulpUtil.colors.red( ERROR_MSG ) );
+    fancyLog( ansiColors.red( ERROR_MSG ) );
 
     return Promise.reject( new Error( ERROR_MSG ) );
   }
@@ -186,7 +187,7 @@ function _createSauceTunnel( ) {
     const sauceTunnelParam = { sauceTunnel: sauceTunnel };
 
     sauceTunnel.on( 'verbose:debug', debugMsg => {
-      gulpUtil.log( debugMsg );
+      fancyLog( debugMsg );
     } );
 
     sauceTunnel.start( status => {
@@ -221,7 +222,7 @@ function spawnProtractor( ) {
    * @returns {Promise} Promise which runs Protractor.
    */
   function _runProtractor( args ) {
-    gulpUtil.log( 'Running Protractor with params: ' + params );
+    fancyLog( 'Running Protractor with params: ' + params );
 
     return new Promise( ( resolve, reject ) => {
       spawn(
@@ -230,10 +231,10 @@ function spawnProtractor( ) {
         { stdio: 'inherit' }
       ).once( 'close', code => {
         if ( code ) {
-          gulpUtil.log( 'Protractor tests exited with code ' + code );
+          fancyLog( 'Protractor tests exited with code ' + code );
           reject( args );
         }
-        gulpUtil.log( 'Protractor tests done!' );
+        fancyLog( 'Protractor tests done!' );
         resolve( args );
       } );
     } );

--- a/package-lock.json
+++ b/package-lock.json
@@ -252,9 +252,9 @@
       }
     },
     "ansi-colors": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-1.0.1.tgz",
-      "integrity": "sha512-yopkAU0ZD/WQ56Tms3xLn6jRuX3SyUMAVi0FdmDIbmmnHW3jHiI1sQFdUl3gfVddjnrsP3Y6ywFKvCRopvoVIA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-1.1.0.tgz",
+      "integrity": "sha512-SFKX67auSNoVR38N3L+nvsPjOE0bybKTYbkf5tRvushrAPQ9V75huw0ZxBkKVeRU9kqH3d6HA4xTckbwZ4ixmA==",
       "requires": {
         "ansi-wrap": "0.1.0"
       }
@@ -6729,7 +6729,7 @@
           "resolved": "https://registry.npmjs.org/plugin-error/-/plugin-error-1.0.1.tgz",
           "integrity": "sha512-L1zP0dk7vGweZME2i+EeakvUNqSrdiI3F91TwEoYiGrAfUXmVv6fJIq4g82PAXxNsWOp0J7ZqQy/3Szz0ajTxA==",
           "requires": {
-            "ansi-colors": "1.0.1",
+            "ansi-colors": "1.1.0",
             "arr-diff": "4.0.0",
             "arr-union": "3.1.0",
             "extend-shallow": "3.0.2"
@@ -7157,7 +7157,7 @@
       "resolved": "https://registry.npmjs.org/gulp-notify/-/gulp-notify-3.1.0.tgz",
       "integrity": "sha512-DmGfTdno/KWPMHfVQVM2/3LJQyUKvxgmL1xYS72eqxDw/v9MUv5Wg+PALunptIry4ZVEZOF56KYj3I8s2N0W3Q==",
       "requires": {
-        "ansi-colors": "1.0.1",
+        "ansi-colors": "1.1.0",
         "fancy-log": "1.3.2",
         "lodash.template": "4.4.0",
         "node-notifier": "5.2.1",

--- a/package.json
+++ b/package.json
@@ -79,9 +79,11 @@
     "xdr": "0.5.3"
   },
   "devDependencies": {
+    "ansi-colors": "1.1.0",
     "chai": "4.1.2",
     "chai-as-promised": "7.1.1",
     "cucumber": "3.2.1",
+    "fancy-log": "1.3.2",
     "jasmine-reporters": "2.3.0",
     "jasmine-spec-reporter": "4.2.1",
     "jsdoc": "3.5.5",


### PR DESCRIPTION
gulp-util is deprecated and log should be migrated to fancy-log per https://medium.com/gulpjs/gulp-util-ca3b1f9f9ac5 

## Changes

- Replace gulp-util.log with fancy-log.
- Replace gulp-util.colors with ansi-colors.

## Testing

1. `npm install`
2. `gulp audit:perf` and `gulp audit:a11y` should log to the console as before (with server running).
3. `gulp test` and `gulp docs` should pass.
