### PR TITLE
Cleanup unused Picard files/references

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -14,7 +14,6 @@ exclude =
     config,
     docs,
     gulp,
-    picard_scripts,
     requirements,
     node_modules,
     site,

--- a/cfgov/cfgov/tests/test_urls.py
+++ b/cfgov/cfgov/tests/test_urls.py
@@ -22,7 +22,6 @@ ADMIN_URL_WHITELIST = [
     '^login',
     '^logout',
     '^password/',
-    '^picard/',
     '^tasks/',
 ]
 

--- a/cfgov/cfgov/urls.py
+++ b/cfgov/cfgov/urls.py
@@ -455,8 +455,6 @@ if settings.ALLOW_ADMIN_URL:
         url(r'^d/admin/(?P<path>.*)$',
             RedirectView.as_view(url='/django-admin/%(path)s',
                                  permanent=True)),
-        url(r'^picard/(?P<path>.*)$',
-            RedirectView.as_view(url='/admin/cdn/%(path)s', permanent=True)),
 
         url(r'^tasks/(?P<path>.*)$',
             RedirectView.as_view(url='/admin/cdn/%(path)s', permanent=True)),

--- a/picard_scripts/akamai_flush.sh
+++ b/picard_scripts/akamai_flush.sh
@@ -1,3 +1,0 @@
-#!/bin/sh
-echo "this script only exists to prove that Picard is working"
-

--- a/picard_scripts/picard_data_export.sh
+++ b/picard_scripts/picard_data_export.sh
@@ -1,3 +1,0 @@
-#!/bin/sh
-echo "this script only exists to prove that Picard is working"
-

--- a/picard_scripts/picard_synonyms_export.sh
+++ b/picard_scripts/picard_synonyms_export.sh
@@ -1,3 +1,0 @@
-#!/bin/sh
-echo "this script only exists to prove that Picard is working"
-


### PR DESCRIPTION
This change removes some unused scripts and references to the now-deprecated Picard repository, which was removed in https://github.com/cfpb/cfgov-refresh/pull/3110.

## Removals

- Removes defunct `picard_scripts` directory.
- Removes all references to `/picard` URLs.

## Testing

Check [public GH usage](https://github.com/search?q=user%3Acfpb+picard&type=Code&utf8=%E2%9C%93) of Picard to see these aren't used anywhere, and also search on GHE to see similarly that these are deprecated.

## Checklist

* [X] PR has an informative and human-readable title
* [X] Changes are limited to a single goal (no scope creep)
* [X] Code can be automatically merged (no conflicts)
* [X] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [X] Passes all existing automated tests
* [X] Any *change* in functionality is tested
* [X] New functions are documented (with a description, list of inputs, and expected output)
* [X] Placeholder code is flagged
* [X] Reviewers requested with the [Reviewer tool](https://help.github.com/articles/about-pull-request-reviews/) :arrow_right: