### PR TITLE
Fix for "flicker" in retirement due to Google Optimize

### DIFF
--- a/cfgov/legacy/templates/front/base_update.html
+++ b/cfgov/legacy/templates/front/base_update.html
@@ -51,13 +51,6 @@
 
     <title>{% block title %}{% endblock %} > {% trans "Consumer Financial Protection Bureau" %}</title>
 
-    {# Google Optimize page-hiding snippet #}
-
-    <style> .optimize-loading { opacity: 0 !important; } </style>
-    <script> (function(a,s,y,n,c,h,i,d,e){s.className+=' '+y;h.start=1*new Date; h.end=i=function(){s.className=s.className.replace(RegExp(' ?'+y),'')}; (a[n]=a[n]||[]).hide=h;setTimeout(function(){i();h.end=null},c);h.timeout=c; })(window,document.documentElement,'optimize-loading','dataLayer',5000, {'GTM-KHB8MB':true}); </script>
-
-    {# end Google Optimize page-hiding snippet #}
-
     <!-- Meta -->
     <meta name="google-site-verification" content=""> <!-- http://google.com/webmasters -->
     <meta name="Copyright" content="Public domain">
@@ -144,6 +137,10 @@
     the head, then file an issue or PR to discuss including it.
 -->
 
+    {# Google Optimize page-hiding snippet #}
+    <style> .optimize-loading { opacity: 0 !important; } </style>
+    <script> (function(a,s,y,n,c,h,i,d,e){s.className+=' '+y;h.start=1*new Date; h.end=i=function(){s.className=s.className.replace(RegExp(' ?'+y),'')}; (a[n]=a[n]||[]).hide=h;setTimeout(function(){i();h.end=null},c);h.timeout=c; })(window,document.documentElement,'optimize-loading','dataLayer',1000, {'GTM-KHB8MB':true}); </script>
+    {# end Google Optimize page-hiding snippet #}
     {# Google Tag Manager #}
     <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
     new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],

--- a/cfgov/legacy/templates/front/base_update.html
+++ b/cfgov/legacy/templates/front/base_update.html
@@ -51,6 +51,13 @@
 
     <title>{% block title %}{% endblock %} > {% trans "Consumer Financial Protection Bureau" %}</title>
 
+    {# Google Optimize page-hiding snippet #}
+
+    <style> .optimize-loading { opacity: 0 !important; } </style>
+    <script> (function(a,s,y,n,c,h,i,d,e){s.className+=' '+y;h.start=1*new Date; h.end=i=function(){s.className=s.className.replace(RegExp(' ?'+y),'')}; (a[n]=a[n]||[]).hide=h;setTimeout(function(){i();h.end=null},c);h.timeout=c; })(window,document.documentElement,'optimize-loading','dataLayer',5000, {'GTM-KHB8MB':true}); </script>
+
+    {# end Google Optimize page-hiding snippet #}
+
     <!-- Meta -->
     <meta name="google-site-verification" content=""> <!-- http://google.com/webmasters -->
     <meta name="Copyright" content="Public domain">


### PR DESCRIPTION
A visual "flicker" was occurring when a Google Optimize A/B was turned on for our retirement "Before You Claim" tool. These changes will serve as a temporary fix for the duration of the experiment.

## Additions
- A `style` and `script` tag were added to `base_update.html`

## Testing
You can test this PR by pulling it in and making sure nothing changes on any pages that use `base_update.html`. Ideally, nothing should happen on any of these pages, although you may notice the page appears all at once.

Once the experiment starts (after this PR is merged), we will further verify that the new code is seamless on the live site.

## Checklist

* [ ] PR has an informative and human-readable title
* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [ ] Passes all existing automated tests
* [ ] Any *change* in functionality is tested
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated
* [ ] Reviewers requested with the [Reviewer tool](https://help.github.com/articles/about-pull-request-reviews/) :arrow_right:
