### PR TITLE
Add Frauds & Scams to megamenu Consumer Tools

### DIFF
--- a/cfgov/jinja2/v1/_includes/organisms/_vars-mega-menu.html
+++ b/cfgov/jinja2/v1/_includes/organisms/_vars-mega-menu.html
@@ -89,6 +89,7 @@
         {'text': 'Credit Cards', 'url': '/ask-cfpb/category-credit-cards/'},
         {'text': 'Credit Reports & Scores', 'url': '/consumer-tools/credit-reports-and-scores/'},
         {'text': 'Debt Collection', 'url': '/consumer-tools/debt-collection/'},
+        {'text': 'Frauds & Scams', 'url': '/consumer-tools/fraud/'},
     ]
 } %}
 


### PR DESCRIPTION
This change adds an entry for "Frauds & Scams" under the Consumer Tools section of the megamenu. This link is hardcoded to `/consumer-tools/fraud/`.

This addresses GHE#2524.

## Screenshots

![image](https://user-images.githubusercontent.com/654645/37110292-8050dcaa-220a-11e8-90d4-bfae2e15159a.png)

## Notes

- @virginiacc will this need to be added to the long-suffering #3396?

## Checklist

* [X] PR has an informative and human-readable title
* [X] Changes are limited to a single goal (no scope creep)
* [X] Code can be automatically merged (no conflicts)
* [X] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [X] Passes all existing automated tests
* [X] Any *change* in functionality is tested
* [X] New functions are documented (with a description, list of inputs, and expected output)
* [X] Placeholder code is flagged
* [X] Visually tested in supported browsers and devices
* [X] Reviewers requested with the [Reviewer tool](https://help.github.com/articles/about-pull-request-reviews/) :arrow_right:
