### PR TITLE
Changes analytics variable in fwb tests

### DIFF
--- a/test/unit_tests/apps/financial-well-being/js/fwb-questions-spec.js
+++ b/test/unit_tests/apps/financial-well-being/js/fwb-questions-spec.js
@@ -158,7 +158,7 @@ describe( 'fwb-questions', () => {
     sandbox = sinon.sandbox.create();
     document.body.innerHTML = HTML_SNIPPET;
     window.dataLayer = [];
-    window.tagManagerIsLoaded = true;
+    window['google_tag_manager'] = {};
     formDom = document.querySelector( '#quiz-form' );
     submitBtnDom = document.querySelector( '#submit-quiz' );
     radioButtonsDom = document.querySelectorAll( '[type="radio"]' );

--- a/test/unit_tests/apps/financial-well-being/js/fwb-results-spec.js
+++ b/test/unit_tests/apps/financial-well-being/js/fwb-results-spec.js
@@ -120,7 +120,7 @@ describe( 'fwb-results', () => {
     sandbox = sinon.sandbox.create();
     document.body.innerHTML = HTML_SNIPPET;
     window.dataLayer = [];
-    window.tagManagerIsLoaded = true;
+    window['google_tag_manager'] = {};
 
     toggleButtons = document.querySelectorAll(
       '.comparison-chart_toggle-button'


### PR DESCRIPTION
`window.tagManagerIsLoaded` doesn't appear to be checked, but instead `window.google_tag_manager` is checked https://github.com/cfpb/cfgov-refresh/blob/master/cfgov/unprocessed/js/modules/Analytics.js#L38

## Changes

- Changes mocked variable `window.tagManagerIsLoaded` to `window['google_tag_manager']`.

## Testing

1. `gulp test:unit --specs=apps/financial-well-being/js/fwb-results-spec.js` and `gulp test:unit --specs=apps/financial-well-being/js/fwb-questions-spec.js` fails on master, but pass on this PR.
