### PR TITLE
Modifying code to fail build on script error

### DIFF
--- a/gulp/tasks/scripts.js
+++ b/gulp/tasks/scripts.js
@@ -40,7 +40,7 @@ function _processScript( localWebpackConfig, src, dest ) {
     } ) )
     .pipe( vinylNamed( file => file.relative ) )
     .pipe( webpackStream( localWebpackConfig, webpack ) )
-    .on( 'error', handleErrors )
+    .on( 'error', handleErrors.bind( this, { exitProcess: true } ) )
     .pipe( gulp.dest( paths.processed + dest ) )
     .pipe( browserSync.reload( {
       stream: true

--- a/gulp/tasks/watch.js
+++ b/gulp/tasks/watch.js
@@ -7,5 +7,5 @@ const config = require( '../config' );
 gulp.task( 'watch', [ 'browsersync' ], function() {
   gulp.watch( config.scripts.src, [ 'scripts' ] );
   gulp.watch( config.styles.cwd + '/**/*.less', [ 'styles' ] );
-  gulp.watch( config.images.src, [ 'images' ] );
 } );
+

--- a/gulp/utils/handle-errors.js
+++ b/gulp/utils/handle-errors.js
@@ -5,8 +5,8 @@ module.exports = function() {
   let exitProcessParam = false;
   let errorParam = args[0] || {};
   const isWatching = this.tasks &&
-                   this.tasks.browsersync &&
-                   this.tasks.browsersync.done === false;
+                     this.tasks.browsersync &&
+                     this.tasks.browsersync.done === false;
 
   if ( errorParam.exitProcess ) {
     exitProcessParam = errorParam.exitProcess;
@@ -24,7 +24,6 @@ module.exports = function() {
   } else {
 
     // Keep gulp from hanging on this task.
-    this.emit( 'end' );
+    this.process.emit( 'end' );
   }
-
 };


### PR DESCRIPTION
Modifying code to fail build or error

## Changes

- Modified scripts to fail build on error.

## Testing

1. Modify a js file within the `unprocessed` directory to cause a build error.
2. Run`frontend.sh` and verify that the build fails.
3. Modify a less file within the `unprocessed` directory to cause a build error.
4. Run`frontend.sh` and verify that the build fails.
5. Run `gulp watch` and cause an error as requested above.
6. Verify the watch process is still active.


## Notes
-  I removed the images watch command.
-  The watch doesn't always catch files changes.

## Todos

-

## Checklist

* [ ] PR has an informative and human-readable title
* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [ ] Passes all existing automated tests
* [ ] Any *change* in functionality is tested
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated
* [ ] Reviewers requested with the [Reviewer tool](https://help.github.com/articles/about-pull-request-reviews/) :arrow_right:
