### PR TITLE
Fix megamenu typo: should be "Fraud" not "Frauds"

### DIFF
--- a/cfgov/jinja2/v1/_includes/organisms/_vars-mega-menu.html
+++ b/cfgov/jinja2/v1/_includes/organisms/_vars-mega-menu.html
@@ -89,7 +89,7 @@
         {'text': 'Credit Cards', 'url': '/ask-cfpb/category-credit-cards/'},
         {'text': 'Credit Reports & Scores', 'url': '/consumer-tools/credit-reports-and-scores/'},
         {'text': 'Debt Collection', 'url': '/consumer-tools/debt-collection/'},
-        {'text': 'Frauds & Scams', 'url': '/consumer-tools/fraud/'},
+        {'text': 'Fraud & Scams', 'url': '/consumer-tools/fraud/'},
     ]
 } %}
 


### PR DESCRIPTION
This is a correction to #3856 that added a link to `/consumer-tools/fraud` from the mega menu. Instead of being "Frauds & Scams" it should have been "Fraud & Scams". See GHE#2524 for details.

## Screenshots

![image](https://user-images.githubusercontent.com/654645/37174510-b8223734-22e4-11e8-8ca7-9c4350a98a00.png)

## Checklist

* [X] PR has an informative and human-readable title
* [X] Changes are limited to a single goal (no scope creep)
* [X] Code can be automatically merged (no conflicts)
* [X] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [X] Passes all existing automated tests
* [X] Any *change* in functionality is tested
* [X] New functions are documented (with a description, list of inputs, and expected output)
* [X] Placeholder code is flagged
* [X] Visually tested in supported browsers and devices
* [X] Project documentation has been updated
* [X] Reviewers requested with the [Reviewer tool](https://help.github.com/articles/about-pull-request-reviews/) :arrow_right: