### PR TITLE
Fix related posts URLs for duplicate slugs

### DIFF
--- a/cfgov/jinja2/v1/_includes/molecules/related-posts.html
+++ b/cfgov/jinja2/v1/_includes/molecules/related-posts.html
@@ -81,7 +81,7 @@
                m-list__unstyled
                m-list__spaced">
         {% for i in range(limit) %}
-            {% set post_url = slugurl(posts[i].slug) or '' %}
+            {% set post_url = posts[i].url or '' %}
             <li class="m-list_item">
                 <h3 class="h4 u-mb5">
                     <a class="m-list_link"


### PR DESCRIPTION
The current logic in the Related Posts template is using the built-in Wagtail
[`slugurl`](http://docs.wagtail.io/en/v2.0/topics/writing_templates.html#slugurl) template tag, which returns an undetermined link if there are multiple pages with the same slug anywhere in the site.

This change fixes GHE#2533 which was generating an incorrect link due to two pages having the same slug. It instead uses the built-in `page.url` property which returns the best URL for the page.

## Changes

- Use `page.url` instead of `slugurl(page.slug)` in related posts template.

## Testing

To test, use a production dump and visit http://localhost:8000/data-research/ and observe that the "2018 CFPB Research Conference" link properly points to an event page, not the conference landing page.

## Screenshots

![image](https://user-images.githubusercontent.com/654645/37178070-6047e328-22ef-11e8-9236-21de35b5c564.png)

## Notes

1. Note that due to the current way we have our production Wagtail Sites configured (we have multiple), `page.url` may return a full absolute URL rather than a relative URL here. I think the downside of this is outweighed by the simplicity of the required code change. Otherwise we'd
have to put in some complex logic like `page.relative_url(page.get_site())` which I would rather not stick in the template.

    If, hopefully, in future we move to a single Wagtail Site in production these links will properly be relative ones.

2. @higs4281 the only other places where `slugurl` is used in this repository is in Ask templates, e.g. [here](https://github.com/cfpb/cfgov-refresh/blob/master/cfgov/jinja2/v1/ask-cfpb/answer-page-spanish-printable.html#L47) or [here](https://github.com/cfpb/cfgov-refresh/blob/master/cfgov/jinja2/v1/ask-cfpb/answer-page.html#L135). Is there a chance that any of these places (there are 6 in total, try `git grep slugurl`) would ever be checking against a duplicate slug, and thus need a similar replacement?

## Checklist

* [X] PR has an informative and human-readable title
* [X] Changes are limited to a single goal (no scope creep)
* [X] Code can be automatically merged (no conflicts)
* [X] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [X] Passes all existing automated tests
* [X] Any *change* in functionality is tested
* [X] New functions are documented (with a description, list of inputs, and expected output)
* [X] Placeholder code is flagged
* [X] Visually tested in supported browsers and devices
* [X] Project documentation has been updated
* [ ] Reviewers requested with the [Reviewer tool](https://help.github.com/articles/about-pull-request-reviews/) :arrow_right:
