### PR TITLE
Removes jQuery from OAH tabs and adds coverage

### DIFF
--- a/cfgov/jinja2/v1/owning-a-home/explore-rates/index.html
+++ b/cfgov/jinja2/v1/owning-a-home/explore-rates/index.html
@@ -368,7 +368,7 @@ home price, down payment, and more can affect mortgage interest rates.
                     </section>
                 </div>
                 <!-- END .result -->
-                <section class="next-steps">
+                <section class="next-steps tabs-layout">
                     <h2><strong>Next steps:</strong> How to get the best interest rate on your mortgage</h2>
                     <!-- put into a container to prevent long line length -->
                     <div class="wrapper">

--- a/cfgov/unprocessed/apps/owning-a-home/css/tab.less
+++ b/cfgov/unprocessed/apps/owning-a-home/css/tab.less
@@ -15,7 +15,6 @@
     a {
         position: relative;
         display: block;
-        width: 100%;
         padding: 28px 20px;
         .u-webfont-regular();
         font-size: unit( 22px / @base-font-size-px, em );
@@ -91,15 +90,4 @@
 
 .tab-content {
     margin-top: unit( 50px / @base-font-size-px, em );
-}
-
-// hide tabbed content when js is enabled
-.js {
-    .tab-content {
-        display: none;
-    }
-
-    & .default {
-        display: block;
-    }
 }

--- a/cfgov/unprocessed/apps/owning-a-home/js/explore-rates/index.js
+++ b/cfgov/unprocessed/apps/owning-a-home/js/explore-rates/index.js
@@ -1,4 +1,4 @@
-import * as rateExplorer from './rate-checker';
+import * as rateChecker from './rate-checker';
 
 // Do it!
-rateExplorer.init();
+rateChecker.init();

--- a/cfgov/unprocessed/apps/owning-a-home/js/explore-rates/rate-checker.js
+++ b/cfgov/unprocessed/apps/owning-a-home/js/explore-rates/rate-checker.js
@@ -1,28 +1,29 @@
-const $ = require( 'jquery' );
-const amortize = require( 'amortize' );
-const formatUSD = require( 'format-usd' );
-const isNum = require( 'is-money-usd' );
-const jumbo = require( 'jumbo-mortgage' );
-const median = require( 'median' );
-const unFormatUSD = require( 'unformat-usd' );
+import * as $ from 'jquery';
+import * as amortize from 'amortize';
+import * as formatUSD from 'format-usd';
+import * as isNum from 'is-money-usd';
+import * as jumbo from 'jumbo-mortgage';
+import * as median from 'median';
+import * as unFormatUSD from 'unformat-usd';
 
 // Load and style Highcharts library. https://www.highcharts.com/docs.
-const Highcharts = require( 'highcharts' );
-require( 'highcharts/modules/exporting' )( Highcharts );
-const highchartsTheme = require( './highcharts-theme' );
+import * as Highcharts from 'highcharts';
+import * as highChartsExporting from 'highcharts/modules/exporting';
+highChartsExporting( Highcharts );
+import * as highchartsTheme from './highcharts-theme';
 highchartsTheme.applyThemeTo( Highcharts );
 
 // var geolocation = require('./geolocation');
-const config = require( '../../config.json' );
-const domValues = require( './dom-values' );
-const dropdown = require( '../dropdown-utils' );
-const fetchRates = require( '../rates' );
-const formatTime = require( '../format-timestamp' );
-const params = require( './params' );
+import * as config from '../../config.json';
+import * as domValues from './dom-values';
+import * as dropdown from '../dropdown-utils';
+import * as fetchRates from '../rates';
+import * as formatTime from '../format-timestamp';
+import * as params from './params';
 
-require( 'rangeslider.js' );
-require( './tab' );
-require( '../placeholder-polyfill' );
+import * from 'rangeslider.js';
+import * from './tab';
+import * from '../placeholder-polyfill';
 
 // Load our handlebar templates.
 const template = require( './template-loader' );
@@ -808,7 +809,7 @@ function addCommas( value ) {
  * @param {Function} cb - Optional callback.
  */
 function renderSlider( cb ) {
-
+  const creditScoreDom
   $( '#credit-score' ).rangeslider({
     polyfill:    false,
     rangeClass:  'rangeslider',

--- a/cfgov/unprocessed/apps/owning-a-home/js/explore-rates/rate-checker.js
+++ b/cfgov/unprocessed/apps/owning-a-home/js/explore-rates/rate-checker.js
@@ -1,29 +1,28 @@
-import * as $ from 'jquery';
-import * as amortize from 'amortize';
-import * as formatUSD from 'format-usd';
-import * as isNum from 'is-money-usd';
-import * as jumbo from 'jumbo-mortgage';
-import * as median from 'median';
-import * as unFormatUSD from 'unformat-usd';
+const $ = require( 'jquery' );
+const amortize = require( 'amortize' );
+const formatUSD = require( 'format-usd' );
+const isNum = require( 'is-money-usd' );
+const jumbo = require( 'jumbo-mortgage' );
+const median = require( 'median' );
+const unFormatUSD = require( 'unformat-usd' );
 
 // Load and style Highcharts library. https://www.highcharts.com/docs.
-import * as Highcharts from 'highcharts';
-import * as highChartsExporting from 'highcharts/modules/exporting';
-highChartsExporting( Highcharts );
-import * as highchartsTheme from './highcharts-theme';
+const Highcharts = require( 'highcharts' );
+require( 'highcharts/modules/exporting' )( Highcharts );
+const highchartsTheme = require( './highcharts-theme' );
 highchartsTheme.applyThemeTo( Highcharts );
 
 // var geolocation = require('./geolocation');
 import * as config from '../../config.json';
 import * as domValues from './dom-values';
-import * as dropdown from '../dropdown-utils';
-import * as fetchRates from '../rates';
-import * as formatTime from '../format-timestamp';
-import * as params from './params';
+const dropdown = require( '../dropdown-utils' );
+const fetchRates = require( '../rates' );
+const formatTime = require( '../format-timestamp' );
+const params = require( './params' );
 
-import * from 'rangeslider.js';
-import * from './tab';
-import * from '../placeholder-polyfill';
+import 'rangeslider.js';
+import './tab';
+import '../placeholder-polyfill';
 
 // Load our handlebar templates.
 const template = require( './template-loader' );
@@ -809,7 +808,6 @@ function addCommas( value ) {
  * @param {Function} cb - Optional callback.
  */
 function renderSlider( cb ) {
-  const creditScoreDom
   $( '#credit-score' ).rangeslider({
     polyfill:    false,
     rangeClass:  'rangeslider',

--- a/cfgov/unprocessed/apps/owning-a-home/js/explore-rates/tab.js
+++ b/cfgov/unprocessed/apps/owning-a-home/js/explore-rates/tab.js
@@ -1,20 +1,14 @@
-let tabGroups;
-let tabLinks;
-let tabContents;
-
 /**
  * Initialize the functionality of a group of tabs with content.
  */
 function init() {
-  tabGroups = document.querySelectorAll( '.tabs-layout' );
+  let tabGroups = document.querySelectorAll( '.tabs-layout' );
+  let tabContents;
 
   tabGroups.forEach( tabGroup => {
-    tabLinks = tabGroup.querySelectorAll( '.tab-link' );
     tabContents = tabGroup.querySelectorAll( '.tab-content' );
 
-    tabLinks.forEach( tabLink => {
-      _bindTabLink( tabGroup, tabLink, tabContents );
-    } );
+    _bindTabLink( tabGroup, tabContents );
 
     // Hide all but the first tab.
     for ( let i = 1; i < tabContents.length; i++ ) {
@@ -24,12 +18,11 @@ function init() {
 }
 
 /**
- *
  * @param {HTMLNode} tabGroup - HTML element parent of tabs and tabs-content.
- * @param {HTMLNode} tabLink - HTML element for links in tabs.
+ * @param {HTMLNode} tabContents - HTML element for content in tabs.
  */
-function _bindTabLink( tabGroup, tabLink, tabContents ) {
-  tabLink.addEventListener( 'click', _tabLinkClicked );
+function _bindTabLink( tabGroup, tabContents ) {
+  tabGroup.addEventListener( 'click', _tabLinkClicked );
   const tabs = tabGroup.querySelectorAll( '.tab-list' );
 
   /**
@@ -37,9 +30,12 @@ function _bindTabLink( tabGroup, tabLink, tabContents ) {
    * @param {MouseEvent} evt - Event object for a click on a tab.
    */
   function _tabLinkClicked( evt ) {
+    const target = evt.target;
+    if ( target.tagName !== 'A' ) {
+      return;
+    }
     evt.preventDefault();
 
-    const target = evt.target;
     const tabLi = target.parentNode;
     const current = tabGroup.querySelector( target.getAttribute( 'href' ) );
 

--- a/cfgov/unprocessed/apps/owning-a-home/js/explore-rates/tab.js
+++ b/cfgov/unprocessed/apps/owning-a-home/js/explore-rates/tab.js
@@ -1,19 +1,53 @@
-'use strict';
+let tabGroups;
+let tabLinks;
+let tabContents;
 
-var $ = require( 'jquery' );
+/**
+ * Initialize the functionality of a group of tabs with content.
+ */
+function init() {
+  tabGroups = document.querySelectorAll( '.tabs-layout' );
 
-$( '.tab-link' ).click( function( evt ) {
-  var $tabs = $( '.tab-list' ),
-      $tabLi = $( this ).parent( '.tab-list' ),
-      $tabContent = $( '.tab-content' ),
-      current = $( this ).attr( 'href' );
+  tabGroups.forEach( tabGroup => {
+    tabLinks = tabGroup.querySelectorAll( '.tab-link' );
+    tabContents = tabGroup.querySelectorAll( '.tab-content' );
 
-  $tabs.removeClass( 'active-tab' );
-  $tabLi.addClass( 'active-tab' );
+    tabLinks.forEach( tabLink => {
+      _bindTabLink( tabGroup, tabLink, tabContents );
+    } );
 
-  $tabContent.hide();
-  $( current ).show();
+    // Hide all but the first tab.
+    for ( let i = 1; i < tabContents.length; i++ ) {
+      tabContents[i].classList.add( 'u-hidden' );
+    }
+  } );
+}
 
-  evt.preventDefault();
+/**
+ *
+ * @param {HTMLNode} tabGroup - HTML element parent of tabs and tabs-content.
+ * @param {HTMLNode} tabLink - HTML element for links in tabs.
+ */
+function _bindTabLink( tabGroup, tabLink, tabContents ) {
+  tabLink.addEventListener( 'click', _tabLinkClicked );
+  const tabs = tabGroup.querySelectorAll( '.tab-list' );
 
-} );
+  /**
+   * Handle a click of a tab.
+   * @param {MouseEvent} evt - Event object for a click on a tab.
+   */
+  function _tabLinkClicked( evt ) {
+    evt.preventDefault();
+
+    const target = evt.target;
+    const tabLi = target.parentNode;
+    const current = tabGroup.querySelector( target.getAttribute( 'href' ) );
+
+    tabs.forEach( tab => tab.classList.remove( 'active-tab' ) );
+    tabLi.classList.add( 'active-tab' );
+    tabContents.forEach( tabContent => tabContent.classList.add( 'u-hidden' ) );
+    current.classList.remove( 'u-hidden' );
+  }
+}
+
+module.exports = { init };

--- a/test/unit_tests/apps/owning-a-home/js/explore-rates/tab-spec.js
+++ b/test/unit_tests/apps/owning-a-home/js/explore-rates/tab-spec.js
@@ -1,0 +1,64 @@
+const BASE_JS_PATH = '../../../../../../cfgov/unprocessed/apps/owning-a-home/';
+const tab = require( BASE_JS_PATH + 'js/explore-rates/tab' );
+
+const HTML_SNIPPET = `
+  <section class="next-steps tabs-layout">
+    <ul class="tabs">
+      <li class="tab-list active-tab">
+          <a class="tab-link" href="#tab1">Tab 1</a>
+      </li>
+      <li class="tab-list">
+          <a class="tab-link" href="#tab2">Tab 2</a>
+      </li>
+    </ul>
+
+    <div id="tab1" class="tab-content default">
+      Tab 1 content.
+    </div>
+    <div id="tab2" class="tab-content">
+      Tab 2 content.
+    </div>
+  </section>
+`;
+
+// TODO: Move to shared utility function that all tests that handle clicks use.
+function triggerClick( target ) {
+  const clickEvent = new window.MouseEvent( 'click', {
+    bubbles: true,
+    cancelable: true,
+    view: window
+  } );
+
+  target.dispatchEvent( clickEvent );
+}
+
+let tabLink2;
+let tabContentDom1;
+let tabContentDom2;
+
+describe( 'explore-rates/params', () => {
+  beforeEach( () => {
+    document.body.innerHTML = HTML_SNIPPET;
+    tabLink2 = document.querySelectorAll( '.tab-link' )[1];
+    tabContentDom1 = document.querySelector( '#tab1' );
+    tabContentDom2 = document.querySelector( '#tab2' );
+  } );
+
+  it( 'should not have u-hidden before JS is initialized.', () => {
+    expect( tabContentDom1.classList.contains( 'u-hidden' ) ).toBe( false );
+    expect( tabContentDom2.classList.contains( 'u-hidden' ) ).toBe( false );
+  } );
+
+  it( 'should add u-hidden class when JS is initialized.', () => {
+    tab.init();
+    expect( tabContentDom1.classList.contains( 'u-hidden' ) ).toBe( false );
+    expect( tabContentDom2.classList.contains( 'u-hidden' ) ).toBe( true );
+  } );
+
+  it( 'should move u-hidden class when tab is clicked.', () => {
+    tab.init();
+    triggerClick( tabLink2 );
+    expect( tabContentDom1.classList.contains( 'u-hidden' ) ).toBe( true );
+    expect( tabContentDom2.classList.contains( 'u-hidden' ) ).toBe( false );
+  } );
+} );


### PR DESCRIPTION
## Changes

- Removes jquery from OAH rate checker tabs.
- Adds ~~100%~~ 95.24% test coverage for OAH rate checker tabs code.

## Testing

1. `gulp clean && gulp build`
2. http://localhost:8000/owning-a-home/explore-rates/ and interact with the tabs half-way down the page.
3. `gulp test:unit` should pass.

## Screenshots

![screen shot 2018-03-12 at 2 54 31 pm](https://user-images.githubusercontent.com/704760/37303629-6cf11e28-2605-11e8-9cb1-7e8b5d61be17.png)

![screen shot 2018-03-12 at 2 54 37 pm](https://user-images.githubusercontent.com/704760/37303631-6e7dd66e-2605-11e8-85c0-b8c2fa127e3e.png)

## Notes
- There will be a flash of both tab content showing before the JS runs. In this case it doesn't matter because the tabs are below the page fold, but it could be bothersome in another context. However, here I think it's worthwhile to remove the js CSS that's needed to prevent the flash.

## Todos

- These tabs should be re-written in the markup so that when JS is disabled the tab link text is laid out immediately above its contents (this is existing behavior):

![screen shot 2018-03-12 at 2 53 42 pm](https://user-images.githubusercontent.com/704760/37303623-65519cd8-2605-11e8-8399-410d7806c854.png)
