### PR TITLE
Handle unicode characters in feedback output when exporting

### DIFF
--- a/cfgov/v1/models/base.py
+++ b/cfgov/v1/models/base.py
@@ -473,8 +473,13 @@ class Feedback(models.Model):
         for feedback in queryset:
             feedback.submitted_on = "{}".format(feedback.submitted_on.date())
             feedback.comment = feedback.comment.encode('utf-8')
-            writer.writerow(
-                ["{}".format(getattr(feedback, heading))
-                 for heading in headings]
-            )
+            try:
+                writer.writerow(
+                    ["{}".format(getattr(feedback, heading))
+                     for heading in headings]
+                )
+            except UnicodeEncodeError as e:
+                print("Error occurred encoding a character in:")
+                print(feedback)
+                raise e
         return csvfile.getvalue()

--- a/cfgov/v1/models/base.py
+++ b/cfgov/v1/models/base.py
@@ -473,13 +473,10 @@ class Feedback(models.Model):
         for feedback in queryset:
             feedback.submitted_on = "{}".format(feedback.submitted_on.date())
             feedback.comment = feedback.comment.encode('utf-8')
-            try:
-                writer.writerow(
-                    ["{}".format(getattr(feedback, heading))
-                     for heading in headings]
-                )
-            except UnicodeEncodeError as e:
-                print("Error occurred encoding a character in:")
-                print(feedback)
-                raise e
+            if feedback.referrer is not None:
+                feedback.referrer = feedback.referrer.encode('utf-8')
+            writer.writerow(
+                ["{}".format(getattr(feedback, heading))
+                 for heading in headings]
+            )
         return csvfile.getvalue()


### PR DESCRIPTION
Feedback export was failing due to an unhandled Unicode character in the output.

## Additions

- Adds encoding for the referrer URL, which may contain a unicode checkbox.

## Testing

1. Go to your local admin in the feedback: http://localhost:8000/django-admin/v1/feedback/
1. Select all rows.
1. Click "Select all 87233 feedbacks" in the table header area
1. Select the export option in the drop down and click "Go".

You should get a message that a CSV file has been sent and not a 500 error.

## Notes

- In the python3 future, we'll be able to specify the coding for the csv writer instead.

## Checklist

* [x] PR has an informative and human-readable title
* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [x] Passes all existing automated tests
* [x] Any *change* in functionality is tested
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices
* [x] Project documentation has been updated
* [x] Reviewers requested with the [Reviewer tool](https://help.github.com/articles/about-pull-request-reviews/) :arrow_right:
