### PR TITLE
Remove unused variable from ask-cfpb

### DIFF
--- a/cfgov/unprocessed/js/routes/ask-cfpb/single.js
+++ b/cfgov/unprocessed/js/routes/ask-cfpb/single.js
@@ -5,12 +5,10 @@ const Analytics = require( '../../modules/Analytics' );
 const analyticsData = document.querySelector( '.analytics-data' );
 
 let answerID;
-let categorySlug;
 let categoryName;
 
 if ( analyticsData ) {
   answerID = analyticsData.getAttribute( 'data-answer-id' );
-  categorySlug = analyticsData.getAttribute( 'data-category-slug' );
   categoryName = analyticsData.getAttribute( 'data-category-name' );
 
   if ( Analytics.tagManagerIsLoaded ) {


### PR DESCRIPTION
## Removals

- Removes unused `categorySlug` variable from ask-cfpb.
