### PR TITLE
Ignore routes JS in test coverage

### DIFF
--- a/gulp/tasks/test.js
+++ b/gulp/tasks/test.js
@@ -15,8 +15,6 @@ const paths = environment.paths;
  * @param {Function} cb - Callback function to call on completion.
  */
 function testUnitScripts( cb ) {
-  // eslint-disable-next-line no-process-env
-  process.env.NODE_ENV = 'test';
   const params = minimist( process.argv.slice( 3 ) ) || {};
 
   /* If --specs=path/to/js/spec flag is added on the command-line,

--- a/jest.config.js
+++ b/jest.config.js
@@ -5,9 +5,12 @@ module.exports = {
   },
   collectCoverage: true,
   collectCoverageFrom: [
-    '!<rootDir>/node_modules/**',
-    '!<rootDir>/cfgov/unprocessed/apps/**/node_modules/**',
     '<rootDir>/cfgov/unprocessed/**/*.js'
+  ],
+  coveragePathIgnorePatterns: [
+    '<rootDir>/node_modules/',
+    '<rootDir>/cfgov/unprocessed/apps/.?/node_modules/',
+    '<rootDir>/cfgov/unprocessed/js/routes/'
   ],
   coverageDirectory: '<rootDir>/test/unit_test_coverage'
 };


### PR DESCRIPTION
## Changes

- Utilize `coveragePathIgnorePatterns` regex in Jest config, instead of negated globs in `collectCoverageFrom`.
- Remove `process.env.NODE_ENV = 'test'` call in gulp unit test task (needed independent of https://github.com/cfpb/cfgov-refresh/pull/3874)

## Testing

1. `gulp test:unit`
2. View coverage from `test/unit_test_coverage/lcov-report/index.html` and see that js/routes isn't included.


## Notes

- JS in the routes scripts should **only** call methods on other modules, if it's not doing so that code should be moved to a tested module outside of the routes directory.
