### PR TITLE
Adds template-loader

### DIFF
--- a/cfgov/unprocessed/apps/owning-a-home/js/explore-rates/index.js
+++ b/cfgov/unprocessed/apps/owning-a-home/js/explore-rates/index.js
@@ -24,37 +24,8 @@ require( '../../node_modules/rangeslider.js' );
 require( './tab' );
 require( '../placeholder-polyfill' );
 
-var TEMPLATE_DIR = '../../templates/explore-rates/';
-
 // Load our handlebar templates.
-var county = require( TEMPLATE_DIR + 'county-option.hbs' );
-var countyConfWarning = require( TEMPLATE_DIR + 'county-conf-warning.hbs' );
-var countyFHAWarning = require( TEMPLATE_DIR + 'county-fha-warning.hbs' );
-var countyVAWarning = require( TEMPLATE_DIR + 'county-va-warning.hbs' );
-var countyGenWarning = require( TEMPLATE_DIR + 'county-general-warning.hbs' );
-var sliderLabel = require( TEMPLATE_DIR + 'slider-range-label.hbs' );
-var creditAlert = require( TEMPLATE_DIR + 'credit-alert.hbs' );
-var resultAlert = require( TEMPLATE_DIR + 'result-alert.hbs' );
-var failAlert = require( TEMPLATE_DIR + 'fail-alert.hbs' );
-var dpWarning = require( TEMPLATE_DIR + 'down-payment-warning.hbs' );
-var chartTooltipSingle = require( TEMPLATE_DIR + 'chart-tooltip-single.hbs' );
-var chartTooltipMultiple =
-  require( TEMPLATE_DIR + 'chart-tooltip-multiple.hbs' );
-
-var template = {
-  county: county,
-  countyConfWarning: countyConfWarning,
-  countyFHAWarning: countyFHAWarning,
-  countyVAWarning: countyVAWarning,
-  countyGenWarning: countyGenWarning,
-  sliderLabel: sliderLabel,
-  creditAlert: creditAlert,
-  resultAlert: resultAlert,
-  failAlert: failAlert,
-  dpWarning: dpWarning,
-  chartTooltipSingle: chartTooltipSingle,
-  chartTooltipMultiple: chartTooltipMultiple
-};
+const template = require( './template-loader' );
 
 // Set some properties for the histogram.
 var chart = {

--- a/cfgov/unprocessed/apps/owning-a-home/js/explore-rates/template-loader.js
+++ b/cfgov/unprocessed/apps/owning-a-home/js/explore-rates/template-loader.js
@@ -1,0 +1,31 @@
+const TEMPLATE_DIR = '../../templates/explore-rates/';
+
+// Load our handlebar templates.
+const county = require( TEMPLATE_DIR + 'county-option.hbs' );
+const countyConfWarning = require( TEMPLATE_DIR + 'county-conf-warning.hbs' );
+const countyFHAWarning = require( TEMPLATE_DIR + 'county-fha-warning.hbs' );
+const countyVAWarning = require( TEMPLATE_DIR + 'county-va-warning.hbs' );
+const countyGenWarning = require( TEMPLATE_DIR + 'county-general-warning.hbs' );
+const sliderLabel = require( TEMPLATE_DIR + 'slider-range-label.hbs' );
+const creditAlert = require( TEMPLATE_DIR + 'credit-alert.hbs' );
+const resultAlert = require( TEMPLATE_DIR + 'result-alert.hbs' );
+const failAlert = require( TEMPLATE_DIR + 'fail-alert.hbs' );
+const dpWarning = require( TEMPLATE_DIR + 'down-payment-warning.hbs' );
+const chartTooltipSingle = require( TEMPLATE_DIR + 'chart-tooltip-single.hbs' );
+const chartTooltipMultiple =
+  require( TEMPLATE_DIR + 'chart-tooltip-multiple.hbs' );
+
+module.exports = {
+  county,
+  countyConfWarning,
+  countyFHAWarning,
+  countyVAWarning,
+  countyGenWarning,
+  sliderLabel,
+  creditAlert,
+  resultAlert,
+  failAlert,
+  dpWarning,
+  chartTooltipSingle,
+  chartTooltipMultiple
+};

--- a/cfgov/unprocessed/apps/owning-a-home/templates/explore-rates/chart-tooltip-multiple.hbs
+++ b/cfgov/unprocessed/apps/owning-a-home/templates/explore-rates/chart-tooltip-multiple.hbs
@@ -1,2 +1,7 @@
-<div class="chart-tooltip"><strong class="lenders">{{y}}</strong>
-<span class="text">Lenders are offering <br> rates at <strong>{{key}}</strong>.</text></div>
+<div class="chart-tooltip">
+  <strong class="lenders">{{y}}</strong>
+  <span class="text">
+    Lenders are offering <br>
+    rates at <strong>{{key}}</strong>.
+  </span>
+</div>

--- a/cfgov/unprocessed/apps/owning-a-home/templates/explore-rates/credit-alert.hbs
+++ b/cfgov/unprocessed/apps/owning-a-home/templates/explore-rates/credit-alert.hbs
@@ -1,5 +1,10 @@
 <div class="result-alert credit-alert" role="alert">
-  <p class="alert">Many lenders do not accept borrowers with credit scores less than 620.
-  Even if your score is low, you may still have options.
-  <a href="http://www.consumerfinance.gov/mortgagehelp/">Contact a housing counselor</a> to learn more.</p>
+  <p class="alert">
+    Many lenders do not accept borrowers with credit scores less than 620.
+    Even if your score is low, you may still have options.
+    <a href="http://www.consumerfinance.gov/mortgagehelp/">
+      Contact a housing counselor
+    </a>
+    to learn more.
+  </p>
 </div>

--- a/cfgov/unprocessed/apps/owning-a-home/templates/explore-rates/down-payment-warning.hbs
+++ b/cfgov/unprocessed/apps/owning-a-home/templates/explore-rates/down-payment-warning.hbs
@@ -1,1 +1,3 @@
-<div id="dp-alert" class="downpayment-warning alert-alt col-7" role="alert">Your down payment cannot be more than your house price.</div>
+<div id="dp-alert" class="downpayment-warning alert-alt col-7" role="alert">
+  Your down payment cannot be more than your house price.
+</div>

--- a/cfgov/unprocessed/apps/owning-a-home/templates/explore-rates/fail-alert.hbs
+++ b/cfgov/unprocessed/apps/owning-a-home/templates/explore-rates/fail-alert.hbs
@@ -1,4 +1,7 @@
 <div class="result-alert chart-alert" role="alert">
-  <p class="alert"><strong>We're sorry!</strong> We're having trouble connecting to our data.<br>
-  Try again another time.</p>
+  <p class="alert">
+    <strong>We're sorry!</strong>
+    We're having trouble connecting to our data.<br>
+    Try again another time.
+  </p>
 </div>

--- a/cfgov/unprocessed/apps/owning-a-home/templates/explore-rates/result-alert.hbs
+++ b/cfgov/unprocessed/apps/owning-a-home/templates/explore-rates/result-alert.hbs
@@ -1,5 +1,15 @@
 <div class="result-alert chart-alert" role="alert">
-  <p class="alert"><strong>We're sorry!</strong> Based on the information you entered, we don't have enough data to display results.</p>
-  <p class="point-right">Change your settings</p>
-  <p><a id ="reload-link" class="defaults-link" href="">Or, revert to our default values</a>
+  <p class="alert">
+    <strong>We're sorry!</strong>
+    Based on the information you entered,
+    we don't have enough data to display results.
+  </p>
+  <p class="point-right">
+    Change your settings
+  </p>
+  <p>
+    <a id ="reload-link" class="defaults-link" href="">
+      Or, revert to our default values
+    </a>
+  </p>
 </div>

--- a/gulp/config.js
+++ b/gulp/config.js
@@ -26,6 +26,7 @@ module.exports = {
   lint: {
     src: [ paths.unprocessed + '/js/**/*.js' ],
     test:  [
+      paths.test + '/util/**/*.js',
       paths.test + '/unit_tests/**/*.js',
       paths.test + '/browser_tests/**/*.js'
     ],

--- a/gulp/tasks/test.js
+++ b/gulp/tasks/test.js
@@ -53,9 +53,15 @@ function testUnitScripts( cb ) {
     fileTestRegex += '.*-spec.js';
   }
 
+  /*
+    The --no-cache flag is needed so the transforms don't cache.
+    If they are cached, preprocessor-handlebars.js can't find handlebars. See
+    https://facebook.github.io/jest/docs/en/troubleshooting.html#caching-issues
+  */
   spawn(
     fsHelper.getBinary( 'jest-cli', 'jest.js', '../bin' ),
     [
+      '--no-cache',
       '--config=jest.config.js',
       `--collectCoverageFrom=${ fileSrcPath }`,
       `--testRegex=${ fileTestRegex }`

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,7 +1,8 @@
 module.exports = {
   verbose: false,
   transform: {
-    '^.+\\.jsx?$': 'babel-jest'
+    '^.+\\.jsx?$': 'babel-jest',
+    '^.+\\.hbs$': '<rootDir>/test/util/preprocessor-handlebars.js'
   },
   collectCoverage: true,
   collectCoverageFrom: [

--- a/test/unit_tests/apps/owning-a-home/js/explore-rates/template-loader-spec.js
+++ b/test/unit_tests/apps/owning-a-home/js/explore-rates/template-loader-spec.js
@@ -1,0 +1,90 @@
+const BASE_JS_PATH = '../../../../../../cfgov/unprocessed/apps/owning-a-home/';
+const templateLoader = require( BASE_JS_PATH + 'js/explore-rates/template-loader' );
+
+describe( 'explore-rates/template-loader', () => {
+
+  it( 'should be able to render county template', () => {
+    const mockData = {
+      complete_fips: 1,
+      gse_limit: 1,
+      fha_limit: 1,
+      va_limit: 1,
+      county: 'Test'
+    };
+    const testTemplate = templateLoader.county( mockData );
+    expect( testTemplate ).toBe(
+      '<option value="1" data-gse="1" data-fha="1" data-va="1">Test</option>\n'
+    );
+  } );
+
+  it( 'should be able to render countyConfWarning template', () => {
+    const testTemplate = templateLoader.countyConfWarning();
+    expect( typeof testTemplate ).toBe( 'string' );
+  } );
+
+  it( 'should be able to render countyFHAWarning template', () => {
+    const testTemplate = templateLoader.countyFHAWarning();
+    expect( typeof testTemplate ).toBe( 'string' );
+  } );
+
+  it( 'should be able to render countyVAWarning template', () => {
+    const testTemplate = templateLoader.countyVAWarning();
+    expect( typeof testTemplate ).toBe( 'string' );
+  } );
+
+  it( 'should be able to render countyGenWarning template', () => {
+    const testTemplate = templateLoader.countyGenWarning();
+    expect( typeof testTemplate ).toBe( 'string' );
+  } );
+
+  it( 'should be able to render sliderLabel template', () => {
+    const mockData = {
+      min: 1,
+      max: 360
+    };
+    const testTemplate = templateLoader.sliderLabel( mockData );
+    expect( testTemplate ).toBe( '1 - 360\n' );
+  } );
+
+  it( 'should be able to render creditAlert template', () => {
+    const testTemplate = templateLoader.creditAlert();
+    expect( typeof testTemplate ).toBe( 'string' );
+  } );
+
+  it( 'should be able to render resultAlert template', () => {
+    const testTemplate = templateLoader.resultAlert();
+    expect( typeof testTemplate ).toBe( 'string' );
+  } );
+
+  it( 'should be able to render failAlert template', () => {
+    const testTemplate = templateLoader.failAlert();
+    expect( typeof testTemplate ).toBe( 'string' );
+  } );
+
+  it( 'should be able to render dpWarning template', () => {
+    const testTemplate = templateLoader.dpWarning();
+    expect( typeof testTemplate ).toBe( 'string' );
+  } );
+
+  it( 'should be able to render chartTooltipSingle template', () => {
+    const testTemplate = templateLoader.chartTooltipSingle();
+    expect( typeof testTemplate ).toBe( 'string' );
+  } );
+
+  it( 'should be able to render chartTooltipMultiple template', () => {
+    const mockData = {
+      y: 1,
+      key: '50%'
+    };
+    const testTemplate = templateLoader.chartTooltipMultiple( mockData );
+    expect( testTemplate ).toBe(
+      '<div class="chart-tooltip">\n' +
+      '  <strong class="lenders">1</strong>\n' +
+      '  <span class="text">\n' +
+      '    Lenders are offering <br>\n' +
+      '    rates at <strong>50%</strong>.\n' +
+      '  </span>\n' +
+      '</div>\n'
+    );
+  } );
+} );

--- a/test/util/preprocessor-handlebars.js
+++ b/test/util/preprocessor-handlebars.js
@@ -1,0 +1,9 @@
+// Preprocess Handlebars templates for tests.
+module.exports = {
+  process( src ) {
+    return `
+    const Handlebars = require( 'handlebars' );
+    module.exports = Handlebars.compile( \`${ src }\` );
+    `;
+  }
+};


### PR DESCRIPTION
## Changes

- Moves handlebar templates from rate-checker to their own module and adds unit tests.
- Edits handlebar templates to adjust long line lengths and fix errors like `</text>` and missing `</p`>.

## Testing

1. `gulp test:unit --specs=apps/owning-a-home/js/explore-rates/template-loader-spec.js` should pass.
