### PR TITLE
Ignore webpack-config in code coverage

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -9,7 +9,8 @@ module.exports = {
   ],
   coveragePathIgnorePatterns: [
     '<rootDir>/node_modules/',
-    '<rootDir>/cfgov/unprocessed/apps/.?/node_modules/',
+    '<rootDir>/cfgov/unprocessed/apps/.+/node_modules/',
+    '<rootDir>/cfgov/unprocessed/apps/.+/webpack-config\.js$',
     '<rootDir>/cfgov/unprocessed/js/routes/'
   ],
   coverageDirectory: '<rootDir>/test/unit_test_coverage'


### PR DESCRIPTION
## Changes

- Adjust Jest coverage regex to exclude webpack-config.js.

## Testing

1. `gulp test:unit` should not include coverage for apps/owning-a-home/webpack-config.js
