### PR TITLE
Add missing coverage for atomic-helpers

### DIFF
--- a/cfgov/unprocessed/js/modules/util/atomic-helpers.js
+++ b/cfgov/unprocessed/js/modules/util/atomic-helpers.js
@@ -132,8 +132,8 @@ function instantiateAll( selector, Constructor ) {
 
 // Expose public methods.
 module.exports = {
-  checkDom:        checkDom,
-  destroyInitFlag: destroyInitFlag,
-  instantiateAll:  instantiateAll,
-  setInitFlag:     setInitFlag
+  checkDom,
+  destroyInitFlag,
+  instantiateAll,
+  setInitFlag
 };

--- a/test/unit_tests/js/modules/util/atomic-helpers-spec.js
+++ b/test/unit_tests/js/modules/util/atomic-helpers-spec.js
@@ -1,27 +1,33 @@
 const BASE_JS_PATH = '../../../../../cfgov/unprocessed/js/';
 const atomicHelpers = require( BASE_JS_PATH + 'modules/util/atomic-helpers' );
+const Footer = require(
+  BASE_JS_PATH + 'organisms/Footer'
+);
 
 let containerDom;
-let expandableDom;
+let componentDom;
+const testClass = 'o-footer';
 const HTML_SNIPPET = `
   <div class="container">
-  <div class="o-expandable"></div></div>
+    <div class="o-footer"></div>
+    <div class="o-footer"></div>
+  </div>
 `;
 
 describe( 'atomic-helpers', () => {
-  beforeAll( () => {
+  beforeEach( () => {
     document.body.innerHTML = HTML_SNIPPET;
     containerDom = document.querySelector( '.container' );
-    expandableDom = document.querySelector( '.o-expandable' );
+    componentDom = document.querySelector( `.${ testClass }` );
   } );
 
   describe( '.checkDom()', () => {
     it( 'should throw an error if element DOM not found', () => {
       const errMsg = 'null is not valid. ' +
                      'Check that element is a DOM node with ' +
-                     'class ".o-expandable"';
+                     `class ".${ testClass }"`;
       function errFunc() {
-        atomicHelpers.checkDom( null, '.o-expandable' );
+        atomicHelpers.checkDom( null, testClass );
       }
       expect( errFunc ).toThrow( Error, errMsg );
     } );
@@ -29,56 +35,60 @@ describe( 'atomic-helpers', () => {
     it( 'should throw an error if element class not found', () => {
       const errMsg = 'mock-class not found on or in passed DOM node.';
       function errFunc() {
-        atomicHelpers.checkDom( expandableDom, 'mock-class' );
+        atomicHelpers.checkDom( componentDom, 'mock-class' );
       }
       expect( errFunc ).toThrow( Error, errMsg );
     } );
 
     it( 'should return the correct HTMLElement when direct element is searched',
       () => {
-        const dom = atomicHelpers.checkDom( expandableDom, 'o-expandable' );
-        expect( dom ).toEqual( expandableDom );
+        const dom = atomicHelpers.checkDom( componentDom, testClass );
+        expect( dom ).toEqual( componentDom );
       }
     );
 
     it( 'should return the correct HTMLElement when parent element is searched',
       () => {
-        const dom = atomicHelpers.checkDom( containerDom, 'o-expandable' );
-        expect( dom ).toEqual( expandableDom );
+        const dom = atomicHelpers.checkDom( containerDom, testClass );
+        expect( dom ).toEqual( componentDom );
       }
     );
   } );
 
   describe( '.instantiateAll()', () => {
-    xit( 'should return an array of instances', () => {
-      // TODO: Implement test.
+    it( 'should return an array of instances', () => {
+      const instArr = atomicHelpers.instantiateAll(
+        `.${ testClass }`, Footer
+      );
+      expect( instArr ).toBeInstanceOf( Array );
+      expect( instArr.length ).toBe( 2 );
     } );
   } );
 
   describe( '.setInitFlag()', () => {
     it( 'should return true when init flag is set', () => {
-      expect( atomicHelpers.setInitFlag( expandableDom ) ).toBe( true );
+      expect( atomicHelpers.setInitFlag( componentDom ) ).toBe( true );
     } );
 
     it( 'should return false when init flag is already set', () => {
-      atomicHelpers.setInitFlag( expandableDom );
-      expect( atomicHelpers.setInitFlag( expandableDom ) ).toBe( false );
+      atomicHelpers.setInitFlag( componentDom );
+      expect( atomicHelpers.setInitFlag( componentDom ) ).toBe( false );
     } );
   } );
 
   describe( '.destroyInitFlag()', () => {
 
     beforeEach( () => {
-      atomicHelpers.setInitFlag( expandableDom );
+      atomicHelpers.setInitFlag( componentDom );
     } );
 
     it( 'should return true when init flag is removed', () => {
-      expect( atomicHelpers.destroyInitFlag( expandableDom ) ).toBe( true );
+      expect( atomicHelpers.destroyInitFlag( componentDom ) ).toBe( true );
     } );
 
     it( 'should return false when init flag has already been removed', () => {
-      atomicHelpers.destroyInitFlag( expandableDom );
-      expect( atomicHelpers.destroyInitFlag( expandableDom ) ).toBe( false );
+      atomicHelpers.destroyInitFlag( componentDom );
+      expect( atomicHelpers.destroyInitFlag( componentDom ) ).toBe( false );
     } );
   } );
 } );


### PR DESCRIPTION
## Additions

- Adds unit test for atomic-helper instantiateAll  method.

## Changes

- Makes atomic-helper test reference o-footer instead of o-expandable, since that's less likely to move to CF.

## Testing

1. `gulp test:unit --specs=js/modules/util/atomic-helpers-spec.js` should pass.
2. `gulp build` should pass.
