### PR TITLE
Fix for webpack-build feature regex

### DIFF
--- a/test/browser_tests/cucumber/step_definitions/webpack-build.js
+++ b/test/browser_tests/cucumber/step_definitions/webpack-build.js
@@ -14,7 +14,7 @@ defineSupportCode( ( { When, Given } ) => {
   } );
 
   When( /the JS bundles shouldn't contain double arrows or constants/, () => {
-    const transpileRegex = /\(\)\s?=>|const .*=/g;
+    const transpileRegex = /\(\)\s?=>|const \w*=/g;
     const directoryMapKeys = Object.keys( directoryMap );
     const directoryMapLength = directoryMapKeys.length;
 


### PR DESCRIPTION
Fix for `webpack-build` feature regex

## Changes

- Modified `test/browser_tests/cucumber/step_definitions/webpack-build.js` feature to fix issue with regex.


## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Internet Explorer 8, 9, 10, and 11
- [ ] Edge
- [ ] iOS Safari
- [ ] Chrome for Android

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
