### PR TITLE
Apply download icon to links regardless of case

### DIFF
--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -238,7 +238,7 @@ EXTERNAL_URL_WHITELIST = (r'^https:\/\/facebook\.com\/cfpb$',
 EXTERNAL_LINK_PATTERN = r'https?:\/\/(?:www\.)?(?![^\?]+gov)(?!(content\.)?localhost).*'
 NONCFPB_LINK_PATTERN = r'(https?:\/\/(?:www\.)?(?![^\?]*(cfpb|consumerfinance).gov)(?!(content\.)?localhost).*)'
 FILES_LINK_PATTERN = r'https?:\/\/files\.consumerfinance.gov\/f\/\S+\.[a-z]+'
-DOWNLOAD_LINK_PATTERN = r'(\.pdf|\.doc|\.docx|\.xls|\.xlsx|\.csv|\.zip)$'
+DOWNLOAD_LINK_PATTERN = r'(?i)(\.pdf|\.doc|\.docx|\.xls|\.xlsx|\.csv|\.zip)$'
 
 # Wagtail settings
 

--- a/cfgov/v1/tests/test_links.py
+++ b/cfgov/v1/tests/test_links.py
@@ -5,12 +5,19 @@ from django.test import TestCase
 
 from wagtail.wagtailcore.models import Site
 
+from bs4 import BeautifulSoup
+
 from v1 import get_protected_url, parse_links
 from v1.models import CFGOVPage
 from v1.tests.wagtail_pages.helpers import save_new_page
 
 
-class ImportDataTest(TestCase):
+class ParseLinksTests(TestCase):
+    def test_parse_links_returns_beautiful_soup(self):
+        self.assertIsInstance(
+            parse_links('<a href="/something">text</a>'),
+            BeautifulSoup
+        )
 
     def test_external_link(self):
         link = '<a href="https://wwww.google.com">external link/a>'
@@ -29,6 +36,16 @@ class ImportDataTest(TestCase):
         output = str(parse_links(link))
         self.assertNotIn('external-site', output)
         self.assertIn('cf-icon-external-link', output)
+
+    def test_pdf_link_gets_download_icon(self):
+        link = '<a href="/something.pdf">link</a>'
+        parsed = str(parse_links(link))
+        self.assertIn('cf-icon-download', parsed)
+
+    def test_different_case_pdf_link_gets_download_icon(self):
+        link = '<a href="/something.PDF">link</a>'
+        parsed = str(parse_links(link))
+        self.assertIn('cf-icon-download', parsed)
 
 
 class GetProtectedUrlTestCase(TestCase):


### PR DESCRIPTION
The current logic that applies the download icon (class="cf-icon-download") to certain links only works if the link file extension is all lowercase. For example, "foo.pdf" will get the icon but "foo.PDF" will not.

The list of extensions that triggers the download icon is defined in `settings.DOWNLOAD_LINK_PATTERN`. This change adds case insensitivity `(?i)` to the regular expression that matches against links, so that all files with the specified extensions get the icon.

This change fixes platform#788.

## Changes

- Add case insensitivity to download link pattern by modifying regex to be
    `r'(?i)(\.pdf|\.doc|\.docx|\.xls|\.xlsx|\.csv|\.zip)$'`.

## Testing

See the new unit test that validates this behavior. Additionally, using a production dump you can visit
[this page](http://localhost:8000/about-us/blog/what-do-if-youre-wrongfully-billed-medicare-costs/) and notice that the link "printer-friendly-version" towards the bottom of the article properly gets the download icon, even though it links to a file ending in `.PDF`. This is better than the current production behavior at [this page](https://www.consumerfinance.gov/about-us/blog/what-do-if-youre-wrongfully-billed-medicare-costs/) which is missing the icon.

## Screenshots

![image](https://user-images.githubusercontent.com/654645/37667552-9f2bba2c-2c38-11e8-8cef-09ae91425da7.png)

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [X] Passes all existing automated tests
- [X] Any _change_ in functionality is tested
- [X] New functions are documented (with a description, list of inputs, and expected output)
- [X] Placeholder code is flagged / future todos are captured in comments
- [X] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [X] Project documentation has been updated
- [X] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [X] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Internet Explorer 8, 9, 10, and 11
- [ ] Edge
- [ ] iOS Safari
- [ ] Chrome for Android

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
