### PR TITLE
Re-remove ie9-specific checks

### DIFF
--- a/cfgov/jinja2/v1/_layouts/base-common.html
+++ b/cfgov/jinja2/v1/_layouts/base-common.html
@@ -1,3 +1,7 @@
+{#
+    This is the shared template for both the
+    English and Spanish-language consumerfinance.gov.
+#}
 <!DOCTYPE html>
 {% if flag_enabled('CFPB_RECRUITING', request) %}
 <!--
@@ -112,8 +116,7 @@
 #}
 
 {% block css %}
-<!--[if lt IE 9]><link rel="stylesheet" href="{{ static('css/main.ie8.css') }}"><![endif]-->
-<!--[if IE 9]><link rel="stylesheet" href="{{ static('css/main.ie9.css') }}"><![endif]-->
+<!--[if lt IE 10]><link rel="stylesheet" href="{{ static('css/main.ie.css') }}"><![endif]-->
 <!--[if gt IE 9]><!--><link rel="stylesheet" href="{{ static('css/main.css') }}"><!--<![endif]-->
 {% endblock css %}
 
@@ -188,27 +191,18 @@
       Turn off JavaScript for browsers that don't support ECMAScript 5 features
       (e.g. Internet Explorer 8)
       by reversing no-js/js CSS class change made by modernizr.
-      The following ECMAScript 5 feature checks come from
+      The ECMAScript 5 feature checks are listed in
       https://github.com/Modernizr/Modernizr/tree/master/feature-detects/es5
     #}
     <script>
         var modernizr = window.Modernizr;
-        if ( !( typeof modernizr !== 'undefined' &&
-             modernizr.es5array &&
-             modernizr.es5date &&
-             modernizr.es5function &&
-             modernizr.es5object &&
-             modernizr.json &&
-             modernizr.es5string &&
-             modernizr.es5syntax &&
-             modernizr.es5undefined ) ) {
+        if ( !( typeof modernizr !== 'undefined' && modernizr.es5 ) ) {
           var docElement = document.documentElement;
           docElement.className = docElement.className.replace( /(^|\s)js(\s|$)/, '$1no-js$2' );
         }
     </script>
     {% endblock %}
 
-    <!--[if IE 9]><script src="{{ static('js/ie/common.ie9.js') }}"></script><![endif]-->
 </head>
 
 <body{% block body_classes %}{% endblock body_classes %}>

--- a/cfgov/jinja2/v1/_layouts/base-common.html
+++ b/cfgov/jinja2/v1/_layouts/base-common.html
@@ -195,11 +195,13 @@
       https://github.com/Modernizr/Modernizr/tree/master/feature-detects/es5
     #}
     <script>
-        var modernizr = window.Modernizr;
-        if ( !( typeof modernizr !== 'undefined' && modernizr.es5 ) ) {
-          var docElement = document.documentElement;
-          docElement.className = docElement.className.replace( /(^|\s)js(\s|$)/, '$1no-js$2' );
-        }
+        !function(){
+          var modernizr = window.Modernizr;
+          if ( !( typeof modernizr !== 'undefined' && modernizr.es5 ) ) {
+            var docElement = document.documentElement;
+            docElement.className = docElement.className.replace( /(^|\s)js(\s|$)/, '$1no-js$2' );
+          }
+        }();
     </script>
     {% endblock %}
 

--- a/cfgov/jinja2/v1/_layouts/base.html
+++ b/cfgov/jinja2/v1/_layouts/base.html
@@ -1,3 +1,6 @@
+{#
+    This is the base template for the English-language consumerfinance.gov.
+#}
 {% extends 'base-common.html' %}
 
 {% block preload %}

--- a/cfgov/jinja2/v1/es/es-base.html
+++ b/cfgov/jinja2/v1/es/es-base.html
@@ -1,7 +1,10 @@
+{#
+    This is the base template for the Spanish-language consumerfinance.gov.
+#}
 {% extends 'base-common.html' %}
 
 {%- block title -%}
-    {%- if self.babel_title() -%} 
+    {%- if self.babel_title() -%}
         {{ self.babel_title() | trim }}
     {%- endif %}
 {%- endblock title -%}
@@ -99,7 +102,7 @@
  ============= -->
 
  {% block ask_search %}{% endblock %}
- 
+
  {% block babel_content %}{% endblock %}
 
  <div class="ac-search full-bleed full-bleed-padded s-show-on-small">


### PR DESCRIPTION
IE9 script removal changes added in https://github.com/cfpb/cfgov-refresh/pull/3693/files were overridden with the old template when `base-common.html` was added. This re-adds the removal of IE9-specific coding.
