### PR TITLE
Fix for OAH rate-checker API urls

### DIFF
--- a/cfgov/unprocessed/apps/owning-a-home/config.json
+++ b/cfgov/unprocessed/apps/owning-a-home/config.json
@@ -1,4 +1,4 @@
 {
-  "rateCheckerAPI": "/oah-api/rates/",
-  "countyAPI":      "/oah-api/county/"
+  "rateCheckerAPI": "/oah-api/rates/rate-checker",
+  "countyAPI":      "/oah-api/county/rater-checker"
 }

--- a/cfgov/unprocessed/apps/owning-a-home/config.json
+++ b/cfgov/unprocessed/apps/owning-a-home/config.json
@@ -1,4 +1,4 @@
 {
-  "rateCheckerAPI": "/oah-api/rates/rate-checker",
+  "rateCheckerAPI": "/oah-api/rates/rate-checker/",
   "countyAPI":      "/oah-api/county/"
 }

--- a/cfgov/unprocessed/apps/owning-a-home/config.json
+++ b/cfgov/unprocessed/apps/owning-a-home/config.json
@@ -1,4 +1,4 @@
 {
   "rateCheckerAPI": "/oah-api/rates/rate-checker",
-  "countyAPI":      "/oah-api/county/rate-checker"
+  "countyAPI":      "/oah-api/county/"
 }

--- a/cfgov/unprocessed/apps/owning-a-home/config.json
+++ b/cfgov/unprocessed/apps/owning-a-home/config.json
@@ -1,4 +1,4 @@
 {
   "rateCheckerAPI": "/oah-api/rates/rate-checker",
-  "countyAPI":      "/oah-api/county/rater-checker"
+  "countyAPI":      "/oah-api/county/rate-checker"
 }


### PR DESCRIPTION
Fix for rate checker API urls

## Changes

-  Modified code to fix issue with rate checker urls `cfgov/unprocessed/apps/owning-a-home/config.json`.


## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Internet Explorer 8, 9, 10, and 11
- [ ] Edge
- [ ] iOS Safari
- [ ] Chrome for Android

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
