### PR TITLE
Remove chai expect

### DIFF
--- a/cfgov/unprocessed/apps/regulations3k/js/index.js
+++ b/cfgov/unprocessed/apps/regulations3k/js/index.js
@@ -9,7 +9,7 @@ const app = {
     module1.init();
     module2.init();
     const payment = module1.getMonthlyPayment( 180000, 4.25, 360, 60 );
-    console.log( `Your monthly payment is $${payment}.` );
+    console.log( `Your monthly payment is $${ payment }.` );
   }
 };
 

--- a/test/browser_tests/cucumber/step_definitions/filterable-page.js
+++ b/test/browser_tests/cucumber/step_definitions/filterable-page.js
@@ -17,7 +17,6 @@ let selectedFilterablePage;
 let UNDEFINED;
 
 
-
 After( function() {
   selectedFilterablePage = UNDEFINED;
 } );

--- a/test/unit_tests/apps/regulations3k/js/index-spec.js
+++ b/test/unit_tests/apps/regulations3k/js/index-spec.js
@@ -1,13 +1,11 @@
 const BASE_JS_PATH = '../../../../../cfgov/unprocessed/apps/regulations3k';
 
-const expect = require( 'chai' ).expect;
-
 const app = require( `${ BASE_JS_PATH }/js/index.js` );
 
-describe( 'The app', function() {
+describe( 'The app', () => {
 
-  it( 'should not throw any errors on init', function() {
-    expect( () => app ).to.not.throw();
+  it( 'should not throw any errors on init', () => {
+    expect( () => app ).not.toThrow();
   } );
 
 } );

--- a/test/unit_tests/apps/regulations3k/js/module1-spec.js
+++ b/test/unit_tests/apps/regulations3k/js/module1-spec.js
@@ -1,18 +1,16 @@
 const BASE_JS_PATH = '../../../../../cfgov/unprocessed/apps/regulations3k';
 
-const expect = require( 'chai' ).expect;
-
 const loanCalculator = require( `${ BASE_JS_PATH }/js/module1.js` );
 
-describe( 'Loan calculator helps users calculate loan data', function() {
+describe( 'Loan calculator helps users calculate loan data', () => {
 
-  it( 'should not throw any errors on init', function() {
-    expect( () => loanCalculator.init() ).to.not.throw();
+  it( 'should not throw any errors on init', () => {
+    expect( () => loanCalculator.init() ).not.toThrow();
   } );
 
-  it( 'should calculate a loan\'s monthly payment', function() {
+  it( 'should calculate a loan\'s monthly payment', () => {
     const payment = loanCalculator.getMonthlyPayment( 180000, 4.25, 360, 60 );
-    expect( payment ).to.equal( 885.4918039430557 );
+    expect( payment ).toBe( 885.4918039430557 );
   } );
 
 } );

--- a/test/unit_tests/apps/regulations3k/js/module2-spec.js
+++ b/test/unit_tests/apps/regulations3k/js/module2-spec.js
@@ -1,13 +1,11 @@
 const BASE_JS_PATH = '../../../../../cfgov/unprocessed/apps/regulations3k';
 
-const expect = require( 'chai' ).expect;
-
 const module = require( `${ BASE_JS_PATH }/js/module2.js` );
 
-describe( 'Some other module that does somthing', function() {
+describe( 'Some other module that does somthing', () => {
 
-  it( 'should not throw any errors on init', function() {
-    expect( () => module.init() ).to.not.throw();
+  it( 'should not throw any errors on init', () => {
+    expect( () => module.init() ).not.toThrow();
   } );
 
 } );

--- a/test/unit_tests/js/modules/util/breakpoint-state-spec.js
+++ b/test/unit_tests/js/modules/util/breakpoint-state-spec.js
@@ -57,8 +57,9 @@ describe( 'breakpoint-state', () => {
   describe( '.isInDesktop()', () => {
     it( 'should determine whether inside desktop breakpoint threshold', () => {
       expect( breakpointState.isInDesktop() ).toBe( true );
-      // TODO: Mock breakpointState.get() to a smaller size so this has false.
-      // expect( breakpointState.isInDesktop() ).toBe( false );
+
+      /* TODO: Mock breakpointState.get() to a smaller size so this has false.
+         expect( breakpointState.isInDesktop() ).toBe( false ); */
     } );
   } );
 


### PR DESCRIPTION
## Changes

- Removes Chai from regulations3k unit tests.
- Fixes linter errors in unit tests and cucumber test.

## Testing

1. `gulp test:unit` should pass.
