### PR TITLE
Support DATABASE_URL to customize test database

### DIFF
--- a/cfgov/cfgov/settings/test.py
+++ b/cfgov/cfgov/settings/test.py
@@ -1,3 +1,5 @@
+import dj_database_url
+
 from .local import *
 
 
@@ -7,6 +9,9 @@ DATABASES = {
         'NAME': os.path.join(REPOSITORY_ROOT, 'db.sqlite3'),
     }
 }
+
+if 'DATABASE_URL' in os.environ:
+    DATABASES['default'] = dj_database_url.config()
 
 EMAIL_BACKEND = 'django.core.mail.backends.locmem.EmailBackend'
 

--- a/docs/testing-be.md
+++ b/docs/testing-be.md
@@ -10,6 +10,10 @@ and then run:
 tox
 ```
 
+By default this uses a local SQLite database for tests. To override this, you
+can set the `DATABASE_URL` environment variable to a database connection
+sring as supported by [dj-database-url](https://github.com/kennethreitz/dj-database-url).
+
 If you haven't changed any installed packages and you don't need to test 
 all migrations, you can run a much faster Python code test using:
 ```

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 skipsdist=True
 tox_pip_extensions_ext_venv_update=True
-# Run these envs when tox is invokved without -e
+# Run these envs when tox is invoked without -e
 envlist=lint-py{27}, unittest-py{27}-dj{18}-wag{110}-slow
 
 
@@ -139,7 +139,7 @@ commands=
 changedir=
     {toxinidir}/cfgov
 passenv=
-    TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH
+    TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH DATABASE_URL
 # BOTO_CONFIG exists here to work around an incompatability between
 # boto and Travis CI
 # https://github.com/travis-ci/travis-ci/issues/5246#issuecomment-166460882


### PR DESCRIPTION
The Python unit tests in this project use a SQLite database. It would be useful to support alternate databases, for example for testing test compatibility with Postgres.

This change allows users to define the `DATABASE_URL` environment variable to test against different databases, for example:

```sh
$ DATABASE_URL=postgres://user@localhost/cfgov tox -e fast
```

This makes use of the [dj-database-url](https://github.com/kennethreitz/dj-database-url) library.

## Screenshots

I've updated the manual to describe this change:

![image](https://user-images.githubusercontent.com/654645/37728862-c17c9c7a-2d11-11e8-9bee-b577de5eb8a2.png)

## Notes

Note that in future it might be interesting or desirable to consider simplifying our DB configuration so that we always use a database URL. For example, tox could pass in different URLs for testing instead of having numerous settings files with different DBs. I considered this but decided to keep the scope of this PR small.

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [X] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [X] Project documentation has been updated
- [X] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Internet Explorer 8, 9, 10, and 11
- [ ] Edge
- [ ] iOS Safari
- [ ] Chrome for Android

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
