### PR TITLE
Increase decimal range to make toBeCloseTo less brittle

### DIFF
--- a/test/unit_tests/js/modules/util/email-popup-helpers-spec.js
+++ b/test/unit_tests/js/modules/util/email-popup-helpers-spec.js
@@ -45,8 +45,8 @@ describe( 'email-popup-helpers', () => {
       );
       /* To avoid being off by a millisecond, we need to convert to a decimal
          and check using toBeCloseTo matcher instead of toBe. */
-      expect( localStorage.getItem( 'testPopupPopupShowNext' ) / 100 )
-        .toBeCloseTo( testDate / 100 );
+      expect( localStorage.getItem( 'testPopupPopupShowNext' ) / 10000 )
+        .toBeCloseTo( testDate / 10000 );
     } );
   } );
 
@@ -61,8 +61,8 @@ describe( 'email-popup-helpers', () => {
       expect( localStorage.getItem( 'testPopupPopupCount' ) ).toBe( 2 );
       /* To avoid being off by a millisecond, we need to convert to a decimal
          and check using toBeCloseTo matcher instead of toBe. */
-      expect( localStorage.getItem( 'testPopupPopupShowNext' ) / 100 )
-        .toBeCloseTo( testDate / 100 );
+      expect( localStorage.getItem( 'testPopupPopupShowNext' ) / 10000 )
+        .toBeCloseTo( testDate / 10000 );
     } );
   } );
 } );


### PR DESCRIPTION
Compared values are timestamps that were divided by 100 so toBeCloseTo can be used to make them less brittle since we only care if they are way off. Default for toBeCloseTo is to use two decimal places, so the timestamps actually need to be divided by 10000 to create four decimal places that'll drop the last two digits. (Alternately, the signature of `toBeCloseTo` could be passed `0` as the second parameter, but this allows us to keep the default behavior.)

## Changes

- Increase decimal range to make toBeCloseTo less brittle

## Testing

1. `gulp test:unit --specs=js/modules/util/email-popup-helpers-spec.js`
