### PR TITLE
Removing warning messages when running ESLint on Travis

### DIFF
--- a/gulp/tasks/lint.js
+++ b/gulp/tasks/lint.js
@@ -31,7 +31,7 @@ function _genericLint( src ) {
 /**
  * Lints the gulpfile for errors.
  */
-gulp.task(   'lint:build', () => _genericLint( configLint.build ) );
+gulp.task( 'lint:build', () => _genericLint( configLint.build ) );
 
 /**
  * Lints the test js files for errors.

--- a/gulp/tasks/lint.js
+++ b/gulp/tasks/lint.js
@@ -13,17 +13,17 @@ const through2 = require( 'through2' );
 function _genericLint( src ) {
   // Pass all command line flags to EsLint.
   const options = minimist( process.argv.slice( 2 ) );
+  let errorHandler = through2.obj();
+
+  if( options.travis ) {
+    options.quiet = true;
+    errorHandler = gulpEslint.failAfterError();
+  }
 
   return gulp.src( src, { base: './' } )
     .pipe( gulpEslint( options ) )
     .pipe( gulpEslint.format() )
-    .pipe( ( () => {
-      if ( options.travis ) {
-        return gulpEslint.failAfterError();
-      }
-
-      return through2.obj();
-    } )( ) )
+    .pipe( errorHandler )
     .pipe( gulp.dest( './' ) )
     .on( 'error', handleErrors );
 }
@@ -31,7 +31,7 @@ function _genericLint( src ) {
 /**
  * Lints the gulpfile for errors.
  */
-gulp.task( 'lint:build', () => _genericLint( configLint.build ) );
+gulp.task(   'lint:build', () => _genericLint( configLint.build ) );
 
 /**
  * Lints the test js files for errors.

--- a/gulp/tasks/test.js
+++ b/gulp/tasks/test.js
@@ -52,6 +52,17 @@ function testUnitScripts( cb ) {
     fileTestRegex += '.*-spec.js';
   }
 
+  const jestOptions = [
+    '--no-cache',
+    '--config=jest.config.js',
+    `--collectCoverageFrom=${ fileSrcPath }`,
+    `--testRegex=${ fileTestRegex }`
+  ];
+
+  if ( params.travis ) {
+    jestOptions.push(  '--runInBand' );
+  }
+
   /*
     The --no-cache flag is needed so the transforms don't cache.
     If they are cached, preprocessor-handlebars.js can't find handlebars. See
@@ -59,12 +70,7 @@ function testUnitScripts( cb ) {
   */
   spawn(
     fsHelper.getBinary( 'jest-cli', 'jest.js', '../bin' ),
-    [
-      '--no-cache',
-      '--config=jest.config.js',
-      `--collectCoverageFrom=${ fileSrcPath }`,
-      `--testRegex=${ fileTestRegex }`
-    ],
+    jestOptions,
     { stdio: 'inherit' }
   ).once( 'close', code => {
     if ( code ) {

--- a/gulp/tasks/test.js
+++ b/gulp/tasks/test.js
@@ -60,7 +60,7 @@ function testUnitScripts( cb ) {
   ];
 
   if ( params.travis ) {
-    jestOptions.push(  '--runInBand' );
+    jestOptions.push( '--runInBand' );
   }
 
   /*

--- a/package-lock.json
+++ b/package-lock.json
@@ -104,6 +104,12 @@
         }
       }
     },
+    "accessibility-developer-tools": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/accessibility-developer-tools/-/accessibility-developer-tools-2.12.0.tgz",
+      "integrity": "sha1-PaDM6dbsY3OWS4TzXbfPw996tRQ=",
+      "dev": true
+    },
     "accord": {
       "version": "0.27.3",
       "resolved": "https://registry.npmjs.org/accord/-/accord-0.27.3.tgz",
@@ -585,6 +591,29 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
       "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4="
+    },
+    "axe-core": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-2.6.1.tgz",
+      "integrity": "sha512-QFfI3d+x/v92HJWGBaNfgrxdfon9/xXzd04YYfm5w5NJQOLex8qkJCctOt7+ky6e1l9zcQ5E7jsvbnTgQzyfTw==",
+      "dev": true
+    },
+    "axe-webdriverjs": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/axe-webdriverjs/-/axe-webdriverjs-0.2.0.tgz",
+      "integrity": "sha1-XjHtr26bozRCdiz9hd46B0c8EVU=",
+      "dev": true,
+      "requires": {
+        "axe-core": "1.1.1"
+      },
+      "dependencies": {
+        "axe-core": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-1.1.1.tgz",
+          "integrity": "sha1-rp2l2oq08QQZB/H12N/jnJRqksU=",
+          "dev": true
+        }
+      }
     },
     "babel-code-frame": {
       "version": "6.26.0",
@@ -12477,6 +12506,27 @@
             "semver": "5.5.0",
             "xml2js": "0.4.19"
           }
+        }
+      }
+    },
+    "protractor-accessibility-plugin": {
+      "version": "github:cfpb/protractor-accessibility-plugin#7319a881e222d9f3588f6d5d8a3d9848bc38c859",
+      "dev": true,
+      "requires": {
+        "accessibility-developer-tools": "2.12.0",
+        "axe-core": "2.6.1",
+        "axe-webdriverjs": "0.2.0",
+        "html-entities": "1.2.1",
+        "lodash": "3.10.1",
+        "q": "1.5.1",
+        "request": "2.81.0"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "3.10.1",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+          "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
+          "dev": true
         }
       }
     },


### PR DESCRIPTION
Removing warning messages when running ESLint  on Travis

## Changes

- Modified code to only display ESLint errors on Travis, not warnings.

## Testing

1. Run `gulp lint --travis` and verify that you see no warnings.
2. Run `gulp lint` and verify that warnings appear.
3. Check the Travis console log and verify you see no linter warnings.

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Internet Explorer 8, 9, 10, and 11
- [ ] Edge
- [ ] iOS Safari
- [ ] Chrome for Android

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
