### PR TITLE
Fix empty related posts bug 

### DIFF
--- a/cfgov/jinja2/v1/_includes/organisms/sidebar-breakout.html
+++ b/cfgov/jinja2/v1/_includes/organisms/sidebar-breakout.html
@@ -52,7 +52,7 @@
                           block
                           block__flush-top
                           block__flush-bottom">
-                {% for block in page.sidebar_breakout recursive %}
+                {% for block in page.sidebar_breakout %}
                     {% if 'heading' in block.block_type %}
                         <h3 class="o-sidebar-breakout_heading">
                             {{ render_stream_child(block) }}
@@ -94,10 +94,6 @@
                             <div class="block {{- 'block__flush-top' if loop.index == 1 else '' -}}">
                                 {{ related_posts.render(posts, block, half_width) }}
                             </div>
-                        {% else %}
-                            {% set blocks = streamfield|list %}
-                            {{ loop(blocks[loop.index:]) }}
-                            {% break %}
                         {% endif %}
                     {% elif 'slug' in block.block_type %}
                         <header class="m-slug-header">

--- a/cfgov/jinja2/v1/_includes/templates/streamfield-sidefoot.html
+++ b/cfgov/jinja2/v1/_includes/templates/streamfield-sidefoot.html
@@ -4,17 +4,13 @@
 
 
 {% macro render(streamfield, half_width=false) %}
-    {% for block in streamfield recursive %}
+    {% for block in streamfield %}
         {% if 'related_posts' in block.block_type %}
             {% set posts = page.related_posts(block) %}
             {% if posts %}
                 <div class="block {{ 'block__flush-top' if loop.index == 1 else '' -}}">
                     {{ related_posts.render(posts, block, half_width) }}
                 </div>
-            {% else %}
-                {% set blocks = streamfield|list %}
-                {{ loop(blocks[loop.index:]) }}
-                {% break %}
             {% endif %}
         {% elif 'related_metadata' in block.block_type %}
             <div class="block {{ 'block__flush-top' if loop.index == 1 else '' -}}">


### PR DESCRIPTION
It is unclear what the original intention of this code was, but currently it breaks if you hit this block more than once (which would happen if you have two or more empty related posts blocks) by causing the error `maximum recursion depth exceeded in cmp`

See discussion in GHE/platform/issues/2576

UPDATE: I haven't been able to figure out what `loop()` is supposed to be doing -- there's no real jinja documentation on it, and when I play around with it locally, it seems to expect a Wagtail block-like object (if I pass in an array or dictionary, it complains that it doesn't have the attribute 'block', 'meta', or 'value'). 

I also found this same logic in [`sidebar-breakout.html`](https://github.com/cfpb/cfgov-refresh/blob/master/cfgov/jinja2/v1/_includes/organisms/sidebar-breakout.html#L97) so before I proceed with this PR & removing it there as well, I'd like to better understand what it's supposed to be doing. 