### PR TITLE
Moving Jest code comment to proper location

### DIFF
--- a/gulp/tasks/test.js
+++ b/gulp/tasks/test.js
@@ -52,6 +52,11 @@ function testUnitScripts( cb ) {
     fileTestRegex += '.*-spec.js';
   }
 
+  /*
+    The --no-cache flag is needed so the transforms don't cache.
+    If they are cached, preprocessor-handlebars.js can't find handlebars. See
+    https://facebook.github.io/jest/docs/en/troubleshooting.html#caching-issues
+  */
   const jestOptions = [
     '--no-cache',
     '--config=jest.config.js',
@@ -63,11 +68,6 @@ function testUnitScripts( cb ) {
     jestOptions.push( '--runInBand' );
   }
 
-  /*
-    The --no-cache flag is needed so the transforms don't cache.
-    If they are cached, preprocessor-handlebars.js can't find handlebars. See
-    https://facebook.github.io/jest/docs/en/troubleshooting.html#caching-issues
-  */
   spawn(
     fsHelper.getBinary( 'jest-cli', 'jest.js', '../bin' ),
     jestOptions,


### PR DESCRIPTION
Moving Jest code comment to proper location


## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Internet Explorer 8, 9, 10, and 11
- [ ] Edge
- [ ] iOS Safari
- [ ] Chrome for Android

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
