### PR TITLE
Ask CFPB: Exclude redirected pages from index

### DIFF
--- a/cfgov/ask_cfpb/search_indexes.py
+++ b/cfgov/ask_cfpb/search_indexes.py
@@ -47,7 +47,9 @@ class AnswerBaseIndex(indexes.SearchIndex, indexes.Indexable):
 
     def index_queryset(self, using=None):
         ids = [record.id for record in self.get_model().objects.all()
-               if record.english_page and record.english_page.live is True]
+               if record.english_page
+               and record.english_page.live is True
+               and record.english_page.redirect_to is None]
         return self.get_model().objects.filter(id__in=ids)
 
 
@@ -92,7 +94,9 @@ class SpanishBaseIndex(indexes.SearchIndex, indexes.Indexable):
 
     def index_queryset(self, using=None):
         ids = [record.id for record in self.get_model().objects.all()
-               if record.spanish_page and record.spanish_page.live is True]
+               if record.spanish_page
+               and record.spanish_page.live is True
+               and record.spanish_page.redirect_to is None]
         return self.get_model().objects.filter(id__in=ids)
 
 


### PR DESCRIPTION
Redirected pages need to be left in the "live" state so that they can
redirect themselves if an editor sets up a redirect. But their live status
left their related question open to being indexed, which allowed
the redirected answer to show up in search results.

This adjusts the query used to create the elasticsearch index so that
answers for redirected pages are excluded.

Since we index answer objects, and we need to consult the related pages
to determine whether they are redirected, the query is relatively
expensive. But that's not an issue here, because the query only runs
once at index time, and that is once a day.

I confirmed locally that answer 1535, which is currently the first
result for the query "spouse credit card debt," disappears from search
after re-indexing with this new indexing query, along with 147 other
redirected answers.

The index query for Spanish answers is updated as well.

This address GHE issue 2571.