### PR TITLE
bump TDP release

### DIFF
--- a/requirements/optional-public.txt
+++ b/requirements/optional-public.txt
@@ -8,4 +8,4 @@ git+https://github.com/cfpb/ccdb5-api.git@v1.0.5#egg=ccdb5-api
 git+https://github.com/cfpb/ccdb5-ui.git@v1.0.7#egg=ccdb5_ui
 https://github.com/cfpb/django-hud/releases/download/1.4.3/django_hud-1.4.3-py2-none-any.whl
 https://github.com/cfpb/django-college-costs-comparison/releases/download/1.5.1/comparisontool-1.5.1-py2-none-any.whl
-https://github.com/cfpb/teachers-digital-platform/releases/download/v0.1.0-alpha/teachers_digital_platform-v0.1.0.devalpha_0-py2-none-any.whl
+https://github.com/cfpb/teachers-digital-platform/releases/download/0.1.0/teachers_digital_platform-0.1.0-py2-none-any.whl


### PR DESCRIPTION
Simplified release and wheel name. Verified that it can be pip-installed and has assets.