### PR TITLE
Modifying rate-checker code to use import statements

### DIFF
--- a/cfgov/unprocessed/apps/owning-a-home/js/explore-rates/rate-checker.js
+++ b/cfgov/unprocessed/apps/owning-a-home/js/explore-rates/rate-checker.js
@@ -1,37 +1,30 @@
-const $ = require( 'jquery' );
-const amortize = require( 'amortize' );
+
+import $ from 'jquery'
+import '../placeholder-polyfill';
+import './tab';
+import 'rangeslider.js';
+import * as params from './params';
+import * as template from './template-loader';
+import amortize from 'amortize';
+import config from '../../config.json';
+import dropdown from '../dropdown-utils';
+import fetchRates from '../rates';
+import formatTime from  '../format-timestamp';
 import formatUSD from 'format-usd';
-const isNum = require( 'is-money-usd' );
-const jumbo = require( 'jumbo-mortgage' );
-const median = require( 'median' );
+import Highcharts from 'highcharts';
+import HighchartsExport from 'highcharts/modules/exporting';
+import isNum from 'is-money-usd';
+import jumbo from 'jumbo-mortgage';
+import median from 'median';
 import unFormatUSD from 'unformat-usd';
-import {
-  calcLoanAmount,
-  renderAccessibleData,
-  renderDatestamp,
-  renderLoanAmount
-} from './util';
+import { applyThemeTo } from './highcharts-theme';
+import { getSelection } from './dom-values';
+import { uniquePrimitives } from '../../../../js/modules/util/array-helpers';
 
 // Load and style Highcharts library. https://www.highcharts.com/docs.
-const Highcharts = require( 'highcharts' );
-require( 'highcharts/modules/exporting' )( Highcharts );
-const highchartsTheme = require( './highcharts-theme' );
-highchartsTheme.applyThemeTo( Highcharts );
+HighchartsExport( Highcharts );
+applyThemeTo( Highcharts );
 
-// var geolocation = require('./geolocation');
-import * as config from '../../config.json';
-import * as domValues from './dom-values';
-const dropdown = require( '../dropdown-utils' );
-const fetchRates = require( '../rates' );
-const params = require( './params' );
-
-import 'rangeslider.js';
-import './tab';
-
-// Load our handlebar templates.
-const template = require( './template-loader' );
-
-import { uniquePrimitives } from '../../../../js/modules/util/array-helpers';
 
 // Set some properties for the histogram.
 const chart = {
@@ -71,8 +64,13 @@ const slider = {
   max:    params.getVal( 'credit-score' ) + 20,
   step:   20,
   update: function() {
+<<<<<<< HEAD
     const leftVal = +Number( $( '.rangeslider__handle' ).css( 'left' ).replace( 'px', '' ) );
     this.min = domValues.getSelection( 'credit-score' );
+=======
+    var leftVal = +Number( $( '.rangeslider__handle' ).css( 'left' ).replace( 'px', '' ) );
+    this.min = getSelection( 'credit-score' );
+>>>>>>> Modifying code to use import statements
     if ( this.min === 840 || this.min === '840' ) {
       this.max = this.min + 10;
     } else {
@@ -315,12 +313,21 @@ function updateLanguage( data ) {
   }
 
   function updateTerm() {
+<<<<<<< HEAD
     const termVal = domValues.getSelection( 'loan-term' );
     $( '.rc-comparison-long .loan-years' ).text( termVal ).fadeIn();
     // change from 5 years to x if an ARM
     if ( domValues.getSelection( 'rate-structure' ) === 'arm' ) {
       const armVal = domValues.getSelection( 'arm-type' );
       const term = armVal.match( /[^-]*/i )[0];
+=======
+    var termVal = getSelection( 'loan-term' );
+    $( '.rc-comparison-long .loan-years' ).text( termVal ).fadeIn();
+    // change from 5 years to x if an ARM
+    if ( getSelection( 'rate-structure' ) === 'arm' ) {
+      var armVal = getSelection( 'arm-type' );
+      var term = armVal.match( /[^-]*/i )[0];
+>>>>>>> Modifying code to use import statements
       $( '.rc-comparison-short .loan-years, .arm-comparison-term' ).text( term ).fadeIn();
     } else {
       $( '.rc-comparison-short .loan-years' ).text( 5 ).fadeIn();
@@ -560,8 +567,8 @@ function processLoanAmount( element ) {
   }
 
   renderDownPayment.apply( element );
-  params.setVal( 'house-price', domValues.getSelection( 'house-price' ) );
-  params.setVal( 'down-payment', domValues.getSelection( 'down-payment' ) );
+  params.setVal( 'house-price', getSelection( 'house-price' ) );
+  params.setVal( 'down-payment', getSelection( 'down-payment' ) );
   params.update();
   renderLoanAmountResult();
   checkForJumbo();
@@ -607,10 +614,10 @@ function renderDownPayment() {
 
   if ( $price.val() !== 0 ) {
     if ( $el.attr( 'id' ) === 'down-payment' || options['dp-constant'] === 'down-payment' ) {
-      val = ( domValues.getSelection( 'down-payment' ) / domValues.getSelection( 'house-price' ) * 100 ) || '';
+      val = ( getSelection( 'down-payment' ) / getSelection( 'house-price' ) * 100 ) || '';
       $percent.val( Math.round( val ) );
     } else {
-      val = domValues.getSelection( 'house-price' ) * ( domValues.getSelection( 'percent-down' ) / 100 );
+      val = getSelection( 'house-price' ) * ( getSelection( 'percent-down' ) / 100 );
       val = val >= 0 ? Math.round( val ) : '';
       val = addCommas( val );
       $down.val( val );
@@ -641,7 +648,11 @@ function renderInterestAmounts() {
   let shortTermVal = [],
       longTermVal = [],
       rate,
+<<<<<<< HEAD
       fullTerm = Number( domValues.getSelection( 'loan-term' ) ) * 12;
+=======
+      fullTerm = +( getSelection( 'loan-term' ) ) * 12;
+>>>>>>> Modifying code to use import statements
   $( '.interest-cost' ).each( function( index ) {
     if ( $( this ).hasClass( 'interest-cost-primary' ) ) {
       rate = $( '#rate-compare-1' ).val().replace( '%', '' );

--- a/cfgov/unprocessed/apps/owning-a-home/js/explore-rates/rate-checker.js
+++ b/cfgov/unprocessed/apps/owning-a-home/js/explore-rates/rate-checker.js
@@ -1,4 +1,4 @@
-import $ from 'jquery'
+import $ from 'jquery';
 import './tab';
 import 'rangeslider.js';
 import * as params from './params';
@@ -9,7 +9,7 @@ import dropdown from '../dropdown-utils';
 import fetchRates from '../rates';
 import formatUSD from 'format-usd';
 import Highcharts from 'highcharts';
-import HighchartsExport from 'highcharts/modules/exporting';
+import highchartsExport from 'highcharts/modules/exporting';
 import isNum from 'is-money-usd';
 import jumbo from 'jumbo-mortgage';
 import median from 'median';
@@ -25,7 +25,7 @@ import {
 } from './util';
 
 // Load and style Highcharts library. https://www.highcharts.com/docs.
-HighchartsExport( Highcharts );
+highchartsExport( Highcharts );
 applyThemeTo( Highcharts );
 
 

--- a/cfgov/unprocessed/apps/owning-a-home/js/explore-rates/rate-checker.js
+++ b/cfgov/unprocessed/apps/owning-a-home/js/explore-rates/rate-checker.js
@@ -1,4 +1,3 @@
-
 import $ from 'jquery'
 import './tab';
 import 'rangeslider.js';
@@ -18,6 +17,12 @@ import unFormatUSD from 'unformat-usd';
 import { applyThemeTo } from './highcharts-theme';
 import { getSelection } from './dom-values';
 import { uniquePrimitives } from '../../../../js/modules/util/array-helpers';
+import {
+  calcLoanAmount,
+  renderAccessibleData,
+  renderDatestamp,
+  renderLoanAmount
+} from './util';
 
 // Load and style Highcharts library. https://www.highcharts.com/docs.
 HighchartsExport( Highcharts );
@@ -63,7 +68,7 @@ const slider = {
   step:   20,
   update: function() {
     const leftVal = +Number( $( '.rangeslider__handle' ).css( 'left' ).replace( 'px', '' ) );
-    this.min = domValues.getSelection( 'credit-score' );
+    this.min = getSelection( 'credit-score' );
     if ( this.min === 840 || this.min === '840' ) {
       this.max = this.min + 10;
     } else {
@@ -306,11 +311,11 @@ function updateLanguage( data ) {
   }
 
   function updateTerm() {
-    const termVal = domValues.getSelection( 'loan-term' );
+    const termVal = getSelection( 'loan-term' );
     $( '.rc-comparison-long .loan-years' ).text( termVal ).fadeIn();
     // change from 5 years to x if an ARM
-    if ( domValues.getSelection( 'rate-structure' ) === 'arm' ) {
-      const armVal = domValues.getSelection( 'arm-type' );
+    if ( getSelection( 'rate-structure' ) === 'arm' ) {
+      const armVal = getSelection( 'arm-type' );
       const term = armVal.match( /[^-]*/i )[0];
       $( '.rc-comparison-short .loan-years, .arm-comparison-term' ).text( term ).fadeIn();
     } else {
@@ -551,8 +556,8 @@ function processLoanAmount( element ) {
   }
 
   renderDownPayment.apply( element );
-  params.setVal( 'house-price', domValues.getSelection( 'house-price' ) );
-  params.setVal( 'down-payment', domValues.getSelection( 'down-payment' ) );
+  params.setVal( 'house-price', getSelection( 'house-price' ) );
+  params.setVal( 'down-payment', getSelection( 'down-payment' ) );
   params.update();
   renderLoanAmountResult();
   checkForJumbo();
@@ -598,10 +603,10 @@ function renderDownPayment() {
 
   if ( $price.val() !== 0 ) {
     if ( $el.attr( 'id' ) === 'down-payment' || options['dp-constant'] === 'down-payment' ) {
-      val = ( domValues.getSelection( 'down-payment' ) / domValues.getSelection( 'house-price' ) * 100 ) || '';
+      val = ( getSelection( 'down-payment' ) / getSelection( 'house-price' ) * 100 ) || '';
       $percent.val( Math.round( val ) );
     } else {
-      val = domValues.getSelection( 'house-price' ) * ( domValues.getSelection( 'percent-down' ) / 100 );
+      val = getSelection( 'house-price' ) * ( getSelection( 'percent-down' ) / 100 );
       val = val >= 0 ? Math.round( val ) : '';
       val = addCommas( val );
       $down.val( val );
@@ -632,7 +637,7 @@ function renderInterestAmounts() {
   let shortTermVal = [],
       longTermVal = [],
       rate,
-      fullTerm = Number( domValues.getSelection( 'loan-term' ) ) * 12;
+      fullTerm = Number( getSelection( 'loan-term' ) ) * 12;
   $( '.interest-cost' ).each( function( index ) {
     if ( $( this ).hasClass( 'interest-cost-primary' ) ) {
       rate = $( '#rate-compare-1' ).val().replace( '%', '' );

--- a/cfgov/unprocessed/apps/owning-a-home/js/explore-rates/rate-checker.js
+++ b/cfgov/unprocessed/apps/owning-a-home/js/explore-rates/rate-checker.js
@@ -1,6 +1,5 @@
 
 import $ from 'jquery'
-import '../placeholder-polyfill';
 import './tab';
 import 'rangeslider.js';
 import * as params from './params';
@@ -9,7 +8,6 @@ import amortize from 'amortize';
 import config from '../../config.json';
 import dropdown from '../dropdown-utils';
 import fetchRates from '../rates';
-import formatTime from  '../format-timestamp';
 import formatUSD from 'format-usd';
 import Highcharts from 'highcharts';
 import HighchartsExport from 'highcharts/modules/exporting';
@@ -64,13 +62,8 @@ const slider = {
   max:    params.getVal( 'credit-score' ) + 20,
   step:   20,
   update: function() {
-<<<<<<< HEAD
     const leftVal = +Number( $( '.rangeslider__handle' ).css( 'left' ).replace( 'px', '' ) );
     this.min = domValues.getSelection( 'credit-score' );
-=======
-    var leftVal = +Number( $( '.rangeslider__handle' ).css( 'left' ).replace( 'px', '' ) );
-    this.min = getSelection( 'credit-score' );
->>>>>>> Modifying code to use import statements
     if ( this.min === 840 || this.min === '840' ) {
       this.max = this.min + 10;
     } else {
@@ -313,21 +306,12 @@ function updateLanguage( data ) {
   }
 
   function updateTerm() {
-<<<<<<< HEAD
     const termVal = domValues.getSelection( 'loan-term' );
     $( '.rc-comparison-long .loan-years' ).text( termVal ).fadeIn();
     // change from 5 years to x if an ARM
     if ( domValues.getSelection( 'rate-structure' ) === 'arm' ) {
       const armVal = domValues.getSelection( 'arm-type' );
       const term = armVal.match( /[^-]*/i )[0];
-=======
-    var termVal = getSelection( 'loan-term' );
-    $( '.rc-comparison-long .loan-years' ).text( termVal ).fadeIn();
-    // change from 5 years to x if an ARM
-    if ( getSelection( 'rate-structure' ) === 'arm' ) {
-      var armVal = getSelection( 'arm-type' );
-      var term = armVal.match( /[^-]*/i )[0];
->>>>>>> Modifying code to use import statements
       $( '.rc-comparison-short .loan-years, .arm-comparison-term' ).text( term ).fadeIn();
     } else {
       $( '.rc-comparison-short .loan-years' ).text( 5 ).fadeIn();
@@ -567,8 +551,8 @@ function processLoanAmount( element ) {
   }
 
   renderDownPayment.apply( element );
-  params.setVal( 'house-price', getSelection( 'house-price' ) );
-  params.setVal( 'down-payment', getSelection( 'down-payment' ) );
+  params.setVal( 'house-price', domValues.getSelection( 'house-price' ) );
+  params.setVal( 'down-payment', domValues.getSelection( 'down-payment' ) );
   params.update();
   renderLoanAmountResult();
   checkForJumbo();
@@ -614,10 +598,10 @@ function renderDownPayment() {
 
   if ( $price.val() !== 0 ) {
     if ( $el.attr( 'id' ) === 'down-payment' || options['dp-constant'] === 'down-payment' ) {
-      val = ( getSelection( 'down-payment' ) / getSelection( 'house-price' ) * 100 ) || '';
+      val = ( domValues.getSelection( 'down-payment' ) / domValues.getSelection( 'house-price' ) * 100 ) || '';
       $percent.val( Math.round( val ) );
     } else {
-      val = getSelection( 'house-price' ) * ( getSelection( 'percent-down' ) / 100 );
+      val = domValues.getSelection( 'house-price' ) * ( domValues.getSelection( 'percent-down' ) / 100 );
       val = val >= 0 ? Math.round( val ) : '';
       val = addCommas( val );
       $down.val( val );
@@ -648,11 +632,7 @@ function renderInterestAmounts() {
   let shortTermVal = [],
       longTermVal = [],
       rate,
-<<<<<<< HEAD
       fullTerm = Number( domValues.getSelection( 'loan-term' ) ) * 12;
-=======
-      fullTerm = +( getSelection( 'loan-term' ) ) * 12;
->>>>>>> Modifying code to use import statements
   $( '.interest-cost' ).each( function( index ) {
     if ( $( this ).hasClass( 'interest-cost-primary' ) ) {
       rate = $( '#rate-compare-1' ).val().replace( '%', '' );


### PR DESCRIPTION
Modifying rate-checker code to use import statements

## Changes

- Modifying `rate-checker.js` code to use import statements. 

## Testing

1.  Run `gulp clean && gulp build`
2.  Visit `http://localhost:8000/owning-a-home/explore-rates/` and ensure the tools works as expected.
3. Check the console for errors.


## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Internet Explorer 8, 9, 10, and 11
- [ ] Edge
- [ ] iOS Safari
- [ ] Chrome for Android

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
