### PR TITLE
Remove tests that rely on how NULLs are sorted 

### DIFF
--- a/cfgov/v1/migrations/0103_update_resource_order_help_text.py
+++ b/cfgov/v1/migrations/0103_update_resource_order_help_text.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('v1', '0102_recreated'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='resource',
+            name='order',
+            field=models.PositiveSmallIntegerField(help_text=b'Snippets will be listed alphabetically by title in a Snippet List module, unless any in the list have a number in this field; those with an order value will appear in ascending order.', null=True, blank=True),
+        ),
+    ]

--- a/cfgov/v1/models/snippets.py
+++ b/cfgov/v1/models/snippets.py
@@ -132,8 +132,7 @@ class Resource(ClusterableModel):
         blank=True,
         help_text='Snippets will be listed alphabetically by title in a '
         'Snippet List module, unless any in the list have a number in this '
-        'field; those with an order value will appear at the bottom of the '
-        'list, in ascending order.'
+        'field; those with an order value will appear in ascending order.'
     )
 
     tags = TaggableManager(

--- a/cfgov/v1/tests/models/test_snippets.py
+++ b/cfgov/v1/tests/models/test_snippets.py
@@ -58,15 +58,6 @@ class TestOrderedResources(TestCase):
             [self.snippetAbc, self.snippetBBC, self.snippetZebra]
         )
 
-    def test_partial_explicit_ordering(self):
-        self.snippetBBC.order = 1
-        self.snippetBBC.save()
-
-        self.assertSequenceEqual(
-            Resource.objects.all(),
-            [self.snippetAbc, self.snippetZebra, self.snippetBBC]
-        )
-
     def test_total_explicit_ordering(self):
         self.snippetAbc.order = 23
         self.snippetAbc.save()
@@ -79,18 +70,6 @@ class TestOrderedResources(TestCase):
             Resource.objects.all(),
             [self.snippetBBC, self.snippetAbc, self.snippetZebra]
         )
-
-    def test_order_tiebreaking(self):
-        self.snippetAbc.order = 1
-        self.snippetAbc.save()
-        self.snippetBBC.order = 1
-        self.snippetBBC.save()
-
-        self.assertSequenceEqual(
-            Resource.objects.all(),
-            [self.snippetZebra, self.snippetAbc, self.snippetBBC]
-        )
-
 
 class TestUnicodeCompatibility(TestCase):
     def test_unicode_contact_heading_str(self):


### PR DESCRIPTION
These tests promise functionality that is specific to MySQL.  With our impending move to PostgreSQL, the behavior in these two tests will no longer be the case (sorting NULLs first).
However, we don't actually rely on this ordering anywhere, so we can just remove the tests and not promise this behavior.

See platform issue 2569 for discussion on this. 

Note that the migration is because we updated the help text on the `order` field.