### PR TITLE
Fix for Video Player images not loading

### DIFF
--- a/cfgov/unprocessed/js/modules/VideoPlayer.js
+++ b/cfgov/unprocessed/js/modules/VideoPlayer.js
@@ -42,7 +42,7 @@ function VideoPlayer( element, options ) {
   _this = this;
   options = options || {};
   this.baseElement = _ensureElement( element, options.createIFrame );
-  const dataSet = _assign( {} , elemDataset( this.baseElement ) );
+  const dataSet = _assign( {}, elemDataset( this.baseElement ) );
   this.iFrameProperties = _assign( dataSet, this.iFrameProperties );
 
   _setChildElements( this.childElements );

--- a/cfgov/unprocessed/js/modules/VideoPlayer.js
+++ b/cfgov/unprocessed/js/modules/VideoPlayer.js
@@ -42,8 +42,8 @@ function VideoPlayer( element, options ) {
   _this = this;
   options = options || {};
   this.baseElement = _ensureElement( element, options.createIFrame );
-  this.iFrameProperties = _assign( elemDataset( this.baseElement ) ||
-    {}, this.iFrameProperties );
+  const dataSet = _assign( {} , elemDataset( this.baseElement ) );
+  this.iFrameProperties = _assign( dataSet, this.iFrameProperties );
 
   _setChildElements( this.childElements );
   _initEvents();


### PR DESCRIPTION
Fix for Video Player images not loading

## Changes

- Visit `https://www.consumerfinance.gov/about-us/careers/application-process/` and notice that the video player images are not loading'

## Testing

1. Visit `https://www.consumerfinance.gov/about-us/careers/application-process/` and notice that the youtube max res image is loading.

2. Visit `http://localhost:8000/about-us/events/archive-past-events/public-event-student-loan-servicing-raleigh-nc/` and verify that the youtube max res image is loading.

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Internet Explorer 8, 9, 10, and 11
- [ ] Edge
- [ ] iOS Safari
- [ ] Chrome for Android

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
