### PR TITLE
Cleanup references to TOXENV env variable

### DIFF
--- a/.env_SAMPLE
+++ b/.env_SAMPLE
@@ -146,9 +146,6 @@ export TEST_HTTP_HOST=localhost
 # Web service ID for accessibility testing via http://achecker.ca site.
 #export ACHECKER_ID=<web_service_id>
 
-# Tox Django unit testing Python version.
-export TOXENV=py27
-
 #################################################################
 # SAUCE LABS (optional) - for handling cloud testing of the site.
 #################################################################

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,6 @@ script:
 
 env:
   global:
-    - TOXENV=py27
     - DJANGO_SETTINGS_MODULE=cfgov.settings.test
     - DJANGO_STAGING_HOSTNAME=content.localhost
     - COVERALLS_PARALLEL=true

--- a/docs/testing-be.md
+++ b/docs/testing-be.md
@@ -2,9 +2,8 @@
 
 ## Django and Python unit tests
 
-To run the the full suite of Python 2.7 unit tests using Tox, cd to the 
-project root, make sure the `TOXENV` variable is set in your `.env` file 
-and then run:
+To run the the full suite of unit tests using Tox, cd to the project root and
+then run:
 
 ```
 tox


### PR DESCRIPTION
As a followup to #3894, the use of the `py27` environment for tox is now deprecated and so references to it should be removed. The invocation of just plain `tox` now aliases to both `lint-py27` and the equivalent `unittest-py27-dj18-wag110-slow` environment.

## Removals

- Removed outdated references to `py27` tox environment.

## Notes

- Developers should remove `TOXENV` if they have it set in their existing `.env` file, unless they want to take the opportunity to set it to `fast`.

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [X] Passes all existing automated tests
- [X] Project documentation has been updated
- [X] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Internet Explorer 8, 9, 10, and 11
- [ ] Edge
- [ ] iOS Safari
- [ ] Chrome for Android

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
