### PR TITLE
Properly pass env to tox slow/fast

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -97,6 +97,8 @@ deps=
     missing-migrations: {[missing-migrations]deps}
 
 passenv=
+    fast:       {[unittest]passenv}
+    slow:       {[unittest]passenv}
     unittest:   {[unittest]passenv}
     acceptance: {[acceptance]passenv}
 


### PR DESCRIPTION
The tox `fast` and `slow` environments should get the `PASSENV` directive from the `unittest` environment, so that you can do something like

```sh
$ DATABASE_URL=postgres://user@localhost/cfgov tox -e fast
```

It looks like the tox refactor in #3894 broke this functionality which was introduced in #3910.

## Testing

Try the above command line with a local Postgres database.

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [X] Passes all existing automated testsdated
- [X] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Internet Explorer 8, 9, 10, and 11
- [ ] Edge
- [ ] iOS Safari
- [ ] Chrome for Android

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
