### PR TITLE
Disallow robots for /eregulations

### DIFF
--- a/cfgov/core/static/robots.txt
+++ b/cfgov/core/static/robots.txt
@@ -6,5 +6,6 @@ Disallow: /external-site
 Disallow: /*?success
 Disallow: *form-id=*
 Disallow: /?page=
+Disallow: /eregulations
 
 sitemap: http://www.consumerfinance.gov/sitemap.xml


### PR DESCRIPTION
We've had a lot of robot traffic to eRegulations recently. We'd like to avoid web crawlers crawling all the different versions of regulations and all the possible links within eRegs. This should be a relatively temporary thing until Regulations 3000 launches or we come up with something that's a little less ham-handed.

See GHE/CFGOV/platform/issues/2645 for further discussion.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Internet Explorer 8, 9, 10, and 11
- [ ] Edge
- [ ] iOS Safari
- [ ] Chrome for Android

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
