### PR TITLE
Fix jobmanager unit tests DB usage

### DIFF
--- a/cfgov/jobmanager/tests/models/test_panels.py
+++ b/cfgov/jobmanager/tests/models/test_panels.py
@@ -1,6 +1,5 @@
-from unittest import TestCase
-
 from django.core.exceptions import ValidationError
+from django.test import TestCase
 
 from wagtail.wagtailcore.models import Page
 
@@ -19,6 +18,7 @@ class ApplicationLinkTestCaseMixin(object):
 
     @classmethod
     def setUpClass(cls):
+        super(ApplicationLinkTestCaseMixin, cls).setUpClass()
         cls.root = Page.objects.get(slug='root')
 
     def setUp(self):


### PR DESCRIPTION
This commit modifies some of the jobmanager app's unit tests so that they properly rollback the DB changes that are made during tests. Instead of inheriting from `unittest.TestCase`, these tests need to inherit from `django.test.TestCase` so that the database changes happen in a transaction.

This fixes the usage of these tests when running against a Postgres DB, as described in platform#2619.

This can be verified by running, e.g.:

```sh
$  DATABASE_URL=postgres://user@localhost/cfgov tox -e fast jobmanager.tests
```

(This requires the fix to the Tox config in #3954.)

This PR also fixes a tiny bug (which may not have been causing the failures) around not properly calling the parent `setUpClass`.

## Changes

- Fix jobmanager unit tests.

## Testing

Use command line above to run tests against a Postgres DB, and observe success.

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [X] Passes all existing automated tests
- [X] Any _change_ in functionality is tested
- [X] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Internet Explorer 8, 9, 10, and 11
- [ ] Edge
- [ ] iOS Safari
- [ ] Chrome for Android

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
