### PR TITLE
Adds analytics util script

### DIFF
--- a/cfgov/unprocessed/apps/analytics-gtm/js/bah-check-rates-listeners.js
+++ b/cfgov/unprocessed/apps/analytics-gtm/js/bah-check-rates-listeners.js
@@ -1,30 +1,25 @@
+import {
+  addEventListenerToElem,
+  delay,
+  track
+} from './util/analytics-util';
+
 const OAHRCAnalytics = ( function() {
-
-  const delay = ( function() {
-    let timer = 0;
-    return function( callback, ms ) {
-      clearTimeout( timer );
-      timer = setTimeout( callback, ms );
-    };
-  } )();
-
-  const track = function( event, action, label ) {
-    window.dataLayer.push( {
-      event: event,
-      action: action,
-      label: label
-    } );
-    console.log( event, action, label );
-  };
 
   // credit score slider
   const rangeSliders = document.querySelectorAll( '.rangeslider' );
   let rangeSliderEl;
   for ( let i = 0, len = rangeSliders.length; i < len; i++ ) {
     rangeSliderEl = rangeSliders[i];
-    rangeSliderEl.addEventListener( 'click', _rangeSliderEventHandler );
-    rangeSliderEl.addEventListener( 'touchend', _rangeSliderEventHandler );
+    addEventListenerToElem( rangeSliderEl, 'click', _rangeSliderEventHandler );
+    addEventListenerToElem(
+      rangeSliderEl, 'touchend', _rangeSliderEventHandler
+    );
   }
+
+  /**
+   * Event handler for range slider interactions.
+   */
   function _rangeSliderEventHandler() {
     const sliderRangeEl = document.querySelector( '#slider-range' );
     const score = sliderRangeEl.textContent;
@@ -33,7 +28,7 @@ const OAHRCAnalytics = ( function() {
 
   // state select
   const locationEl = document.querySelector( '#location' );
-  locationEl.addEventListener( 'change', function( evt ) {
+  addEventListenerToElem( locationEl, 'change', function( evt ) {
     const target = evt.target;
     const value = target.value;
     track( 'OAH Rate Tool Interactions', 'Select state', value );
@@ -41,7 +36,7 @@ const OAHRCAnalytics = ( function() {
 
   // house price
   const housePriceEl = document.querySelector( '#house-price' );
-  housePriceEl.addEventListener( 'keyup', function( evt ) {
+  addEventListenerToElem( housePriceEl, 'keyup', function( evt ) {
     const target = evt.target;
     const value = target.value;
     delay( function() {
@@ -51,7 +46,7 @@ const OAHRCAnalytics = ( function() {
 
   // down payment percentage
   const percentDownEl = document.querySelector( '#percent-down' );
-  percentDownEl.addEventListener( 'keyup', function( evt ) {
+  addEventListenerToElem( percentDownEl, 'keyup', function( evt ) {
     const target = evt.target;
     const value = target.value;
     delay( function() {
@@ -61,7 +56,7 @@ const OAHRCAnalytics = ( function() {
 
   // down payment $
   const downPaymentEl = document.querySelector( '#down-payment' );
-  downPaymentEl.addEventListener( 'keyup', function( evt ) {
+  addEventListenerToElem( downPaymentEl, 'keyup', function( evt ) {
     const target = evt.target;
     const value = target.value;
     delay( function() {
@@ -71,7 +66,7 @@ const OAHRCAnalytics = ( function() {
 
   // rate structure
   const rateStructureEl = document.querySelector( '#rate-structure' );
-  rateStructureEl.addEventListener( 'change', function( evt ) {
+  addEventListenerToElem( rateStructureEl, 'change', function( evt ) {
     const target = evt.target;
     const value = target.value;
     track( 'OAH Rate Tool Interactions', 'Rate structure', value );
@@ -79,7 +74,7 @@ const OAHRCAnalytics = ( function() {
 
   // loan term
   const loanTermEl = document.querySelector( '#loan-term' );
-  loanTermEl.addEventListener( 'change', function( evt ) {
+  addEventListenerToElem( loanTermEl, 'change', function( evt ) {
     const target = evt.target;
     const value = target.value;
     track( 'OAH Rate Tool Interactions', 'Loan term', value );
@@ -87,7 +82,7 @@ const OAHRCAnalytics = ( function() {
 
   // loan type
   const loanTypeEl = document.querySelector( '#loan-type' );
-  loanTypeEl.addEventListener( 'change', function( evt ) {
+  addEventListenerToElem( loanTypeEl, 'change', function( evt ) {
     const target = evt.target;
     const value = target.value;
     track( 'OAH Rate Tool Interactions', 'Loan type', value );
@@ -95,7 +90,7 @@ const OAHRCAnalytics = ( function() {
 
   // arm type
   const armTypeEl = document.querySelector( '#arm-type' );
-  armTypeEl.addEventListener( 'change', function( evt ) {
+  addEventListenerToElem( armTypeEl, 'change', function( evt ) {
     const target = evt.target;
     const value = target.value;
     track( 'OAH Rate Tool Interactions', 'ARM type', value );
@@ -103,7 +98,7 @@ const OAHRCAnalytics = ( function() {
 
   // rate comparison select #1
   const rateCompare1El = document.querySelector( '#rate-compare-1' );
-  rateCompare1El.addEventListener( 'change', function( evt ) {
+  addEventListenerToElem( rateCompare1El, 'change', function( evt ) {
     const target = evt.target;
     const value = target.value;
     track( 'OAH Rate Tool Interactions', 'Interest cost 1', value );
@@ -111,7 +106,7 @@ const OAHRCAnalytics = ( function() {
 
   // rate comparison select #2
   const rateCompare2El = document.querySelector( '#rate-compare-2' );
-  rateCompare2El.addEventListener( 'change', function( evt ) {
+  addEventListenerToElem( rateCompare2El, 'change', function( evt ) {
     const target = evt.target;
     const value = target.value;
     track( 'OAH Rate Tool Interactions', 'Interest cost 2', value );
@@ -119,21 +114,19 @@ const OAHRCAnalytics = ( function() {
 
   // page reload link
   const reloadLinkEl = document.querySelector( '#reload-link' );
-  if ( reloadLinkEl ) {
-    reloadLinkEl.addEventListener( 'click', function() {
-      track( 'OAH Rate Tool Interactions', 'Revert', '/owning-a-home/rate-checker' );
-    } );
-  }
+  addEventListenerToElem( reloadLinkEl, 'click', function() {
+    track( 'OAH Rate Tool Interactions', 'Revert', '/owning-a-home/rate-checker' );
+  } );
 
   // next steps: I plan to buy in the next couple of months
   const planToBuyTabEl = document.querySelector( '#plan-to-buy-tab' );
-  planToBuyTabEl.addEventListener( 'click', function() {
+  addEventListenerToElem( planToBuyTabEl, 'click', function() {
     track( 'OAH Rate Tool Interactions', 'Click', 'Collapsed_Tabs_Buying' );
   } );
 
   // next steps: I won't buy for several months
   const wontBuyTabEl = document.querySelector( '#wont-buy-tab' );
-  wontBuyTabEl.addEventListener( 'click', function() {
+  addEventListenerToElem( wontBuyTabEl, 'click', function() {
     track( 'OAH Rate Tool Interactions', 'Click', 'Collapsed_Tabs_Not_Buying' );
   } );
 } )();

--- a/cfgov/unprocessed/apps/analytics-gtm/js/bah-closing-disclosure-listeners.js
+++ b/cfgov/unprocessed/apps/analytics-gtm/js/bah-closing-disclosure-listeners.js
@@ -1,30 +1,25 @@
+import {
+  addEventListenerToElem,
+  delay,
+  track
+} from './util/analytics-util';
+
 const OAHRCAnalytics = ( function() {
-
-  const delay = ( function() {
-    let timer = 0;
-    return function( callback, ms ) {
-      clearTimeout( timer );
-      timer = setTimeout( callback, ms );
-    };
-  } )();
-
-  const track = function( event, action, label ) {
-    window.dataLayer.push( {
-      event: event,
-      action: action,
-      label: label
-    } );
-    console.log( event, action, label );
-  };
 
   // credit score slider
   const rangeSliders = document.querySelectorAll( '.rangeslider' );
   let rangeSliderEl;
   for ( let i = 0, len = rangeSliders.length; i < len; i++ ) {
     rangeSliderEl = rangeSliders[i];
-    rangeSliderEl.addEventListener( 'click', _rangeSliderEventHandler );
-    rangeSliderEl.addEventListener( 'touchend', _rangeSliderEventHandler );
+    addEventListenerToElem( rangeSliderEl, 'click', _rangeSliderEventHandler );
+    addEventListenerToElem(
+      rangeSliderEl, 'touchend', _rangeSliderEventHandler
+    );
   }
+
+  /**
+   * Event handler for range slider interactions.
+   */
   function _rangeSliderEventHandler() {
     const sliderRangeEl = document.querySelector( '#slider-range' );
     const score = sliderRangeEl.textContent;
@@ -34,7 +29,7 @@ const OAHRCAnalytics = ( function() {
 
   // state select
   const locationEl = document.querySelector( '#location' );
-  locationEl.addEventListener( 'change', function( evt ) {
+  addEventListenerToElem( locationEl, 'change', function( evt ) {
     const target = evt.target;
     const value = target.value;
     track( 'OAH Rate Tool Interactions', 'Select state', value );
@@ -42,7 +37,7 @@ const OAHRCAnalytics = ( function() {
 
   // house price
   const housePriceEl = document.querySelector( '#house-price' );
-  housePriceEl.addEventListener( 'keyup', function( evt ) {
+  addEventListenerToElem( housePriceEl, 'keyup', function( evt ) {
     const target = evt.target;
     const value = target.value;
     delay( function() {
@@ -52,7 +47,7 @@ const OAHRCAnalytics = ( function() {
 
   // down payment percentage
   const percentDownEl = document.querySelector( '#percent-down' );
-  percentDownEl.addEventListener( 'keyup', function( evt ) {
+  addEventListenerToElem( percentDownEl, 'keyup', function( evt ) {
     const target = evt.target;
     const value = target.value;
     delay( function() {
@@ -62,7 +57,7 @@ const OAHRCAnalytics = ( function() {
 
   // down payment $
   const downPaymentEl = document.querySelector( '#down-payment' );
-  downPaymentEl.addEventListener( 'keyup', function( evt ) {
+  addEventListenerToElem( downPaymentEl, 'keyup', function( evt ) {
     const target = evt.target;
     const value = target.value;
     delay( function() {
@@ -72,7 +67,7 @@ const OAHRCAnalytics = ( function() {
 
   // rate structure
   const rateStructureEl = document.querySelector( '#rate-structure' );
-  rateStructureEl.addEventListener( 'change', function( evt ) {
+  addEventListenerToElem( rateStructureEl, 'change', function( evt ) {
     const target = evt.target;
     const value = target.value;
     track( 'OAH Rate Tool Interactions', 'Rate structure', value );
@@ -80,7 +75,7 @@ const OAHRCAnalytics = ( function() {
 
   // loan term
   const loanTermEl = document.querySelector( '#loan-term' );
-  loanTermEl.addEventListener( 'change', function( evt ) {
+  addEventListenerToElem( loanTermEl, 'change', function( evt ) {
     const target = evt.target;
     const value = target.value;
     track( 'OAH Rate Tool Interactions', 'Loan term', value );
@@ -88,7 +83,7 @@ const OAHRCAnalytics = ( function() {
 
   // loan type
   const loanTypeEl = document.querySelector( '#loan-type' );
-  loanTypeEl.addEventListener( 'change', function( evt ) {
+  addEventListenerToElem( loanTypeEl, 'change', function( evt ) {
     const target = evt.target;
     const value = target.value;
     track( 'OAH Rate Tool Interactions', 'Loan type', value );
@@ -96,7 +91,7 @@ const OAHRCAnalytics = ( function() {
 
   // arm type
   const armTypeEl = document.querySelector( '#arm-type' );
-  armTypeEl.addEventListener( 'change', function( evt ) {
+  addEventListenerToElem( armTypeEl, 'change', function( evt ) {
     const target = evt.target;
     const value = target.value;
     track( 'OAH Rate Tool Interactions', 'ARM type', value );
@@ -104,7 +99,7 @@ const OAHRCAnalytics = ( function() {
 
   // rate comparison select #1
   const rateCompare1El = document.querySelector( '#rate-compare-1' );
-  rateCompare1El.addEventListener( 'change', function( evt ) {
+  addEventListenerToElem( rateCompare1El, 'change', function( evt ) {
     const target = evt.target;
     const value = target.value;
     track( 'OAH Rate Tool Interactions', 'Interest cost 1', value );
@@ -112,7 +107,7 @@ const OAHRCAnalytics = ( function() {
 
   // rate comparison select #2
   const rateCompare2El = document.querySelector( '#rate-compare-2' );
-  rateCompare2El.addEventListener( 'change', function( evt ) {
+  addEventListenerToElem( rateCompare2El, 'change', function( evt ) {
     const target = evt.target;
     const value = target.value;
     track( 'OAH Rate Tool Interactions', 'Interest cost 2', value );
@@ -120,21 +115,19 @@ const OAHRCAnalytics = ( function() {
 
   // page reload link
   const reloadLinkEl = document.querySelector( '#reload-link' );
-  if ( reloadLinkEl ) {
-    reloadLinkEl.addEventListener( 'click', function() {
-      track( 'OAH Rate Tool Interactions', 'Revert', '/owning-a-home/rate-checker' );
-    } );
-  }
+  addEventListenerToElem( reloadLinkEl, 'click', function() {
+    track( 'OAH Rate Tool Interactions', 'Revert', '/owning-a-home/rate-checker' );
+  } );
 
   // next steps: I plan to buy in the next couple of months
   const planToBuyTabEl = document.querySelector( '#plan-to-buy-tab' );
-  planToBuyTabEl.addEventListener( 'click', function() {
+  addEventListenerToElem( planToBuyTabEl, 'click', function() {
     track( 'OAH Rate Tool Interactions', 'Click', 'Collapsed_Tabs_Buying' );
   } );
 
   // next steps: I won't buy for several months
   const wontBuyTabEl = document.querySelector( '#wont-buy-tab' );
-  wontBuyTabEl.addEventListener( 'click', function() {
+  addEventListenerToElem( wontBuyTabEl, 'click', function() {
     track( 'OAH Rate Tool Interactions', 'Click', 'Collapsed_Tabs_Not_Buying' );
   } );
 } )();

--- a/cfgov/unprocessed/apps/analytics-gtm/js/bah-loan-estimate-listeners.js
+++ b/cfgov/unprocessed/apps/analytics-gtm/js/bah-loan-estimate-listeners.js
@@ -1,33 +1,24 @@
+// TODO: Remove jquery.
 import $ from 'jquery';
+
+import {
+  addEventListenerToElem,
+  delay,
+  track
+} from './util/analytics-util';
 
 // Owning a Home - Loan Estimate custom analytics file
 
 const OAHLEAnalytics = ( function() {
 
-  const delay = ( function() {
-    let timer = 0;
-    return function( callback, ms ) {
-      clearTimeout( timer );
-      timer = setTimeout( callback, ms );
-    };
-  } )();
-
   $( '.tab-link' ).click( function() {
     const text = $( this ).text().trim();
-    window.dataLayer.push( {
-      event: 'OAH Loan Estimate Interaction',
-      action: 'Tab click',
-      label: text
-    } );
+    track( 'OAH Loan Estimate Interaction', 'Tab click', text );
   } );
 
   $( '.form-explainer_page-link ' ).click( function() {
     const pageNumber = 'Page ' + $( this ).attr( 'data-page' );
-    window.dataLayer.push( {
-      event: 'OAH Loan Estimate Interaction',
-      action: 'Page link click',
-      label: pageNumber
-    } );
+    track( 'OAH Loan Estimate Interaction', 'Page link click', pageNumber );
   } );
 
   $( '.form-explainer_page-buttons button' ).click( function() {
@@ -36,12 +27,7 @@ const OAHLEAnalytics = ( function() {
     if ( $( this ).hasClass( 'prev' ) ) {
       action = 'Previous Page button clicked';
     }
-    window.dataLayer.push( {
-      event: 'OAH Loan Estimate Interaction',
-      action: action,
-      label: currentPage
-    } );
-
+    track( 'OAH Loan Estimate Interaction', action, currentPage );
   } );
 
   $( '.expandable_target' ).click( function() {
@@ -61,11 +47,7 @@ const OAHLEAnalytics = ( function() {
         if ( state === 'true' ) {
           action = 'Expandable expanded - ' + tabText;
         }
-        window.dataLayer.push( {
-          event: 'OAH Loan Estimate Interaction',
-          action: action,
-          label: text
-        } );
+        track( 'OAH Loan Estimate Interaction', action, text );
       }, 250 );
   } );
 
@@ -79,13 +61,8 @@ const OAHLEAnalytics = ( function() {
         if ( target.hasClass( 'expandable__expanded' ) ) {
           action = 'Image Overlay click - expandable expanded';
         }
-        window.dataLayer.push( {
-          event: 'OAH Loan Estimate Interaction',
-          action: action,
-          label: text
-        } );
+        track( 'OAH Loan Estimate Interaction', action, text );
       }, 250 );
   } );
-
 
 } )( $ );

--- a/cfgov/unprocessed/apps/analytics-gtm/js/enterprise-attribution-cookies.js
+++ b/cfgov/unprocessed/apps/analytics-gtm/js/enterprise-attribution-cookies.js
@@ -61,10 +61,10 @@ const sourceCookies = {
     this._timeStamps.firstVisit = this._timeStamps.currentVisit;
 
     // Determine referral source
-    this.parseDirect( host, query, referrer )
-    this.parseReferral( host, query, referrer )
-    this.parseOrganicSearch( host, query, referrer )
-    this.parseUTMparameters( host, query, referrer )
+    this.parseDirect( host, query, referrer );
+    this.parseReferral( host, query, referrer );
+    this.parseOrganicSearch( host, query, referrer );
+    this.parseUTMparameters( host, query, referrer );
     this.parseAdWords( host, query, referrer );
 
     // .parseSocialMedia(host, query, referrer)

--- a/cfgov/unprocessed/apps/analytics-gtm/js/enterprise-attribution-cookies.js
+++ b/cfgov/unprocessed/apps/analytics-gtm/js/enterprise-attribution-cookies.js
@@ -1,40 +1,24 @@
+import { hostsAreEqual } from './util/analytics-util';
+
 /* ********************************
 Blast Analytics & Marketing
 Create Source Attribution Cookie
 ******************************** */
 
 const sourceCookies = {
-
-  // zeroPad - prepends '0' before numbers 0-9
-  zeroPad: function( n ) {
-    let r = n.toString();
-    if ( n <= 9 && n >= 0 ) { r = '0' + n.toString(); }
-    return r;
-  },
-
-  /**
-  * session length in milliseconds : defaul 30 mins
-  */
+  // Session length in milliseconds : default 30 mins.
   _sessionLength: 1800000,
 
-  /**
-  * Cookie domain name
-  */
+  // Cookie domain name.
   _cookieDomain: '{{cookie domain}}',
 
-  /**
-  * Session cookie name
-  */
+  // Session cookie name.
   _sourceCookieName: '_A_source',
 
-  /**
-  * Session cookie name
-  */
+  // Session cookie name.
   _timeCookieName: '_A_time',
 
-  /**
-  * Classic analytics parameter mapping
-  */
+  // Classic analytics parameter mapping.
   _classicParameterMap: {
     gclid: 'utmgclid',
     source: 'utmcsr',
@@ -44,9 +28,7 @@ const sourceCookies = {
     content: 'utmcct'
   },
 
-  /**
-  * Referral source
-  */
+  // Referral source.
   _referral: {
     gclid: '',
     source: '',
@@ -62,13 +44,12 @@ const sourceCookies = {
     currentVisit: ( new Date() ).getTime()
   },
 
-
   /**
-  * Determine referral source
-  * @param {string} host - A URL.
-  * @param {string} query - A query string.
-  * @param {string} referrer - A referrer URL.
-  */
+   * Determine referral source
+   * @param {string} host - A URL.
+   * @param {string} query - A query string.
+   * @param {string} referrer - A referrer URL.
+   */
   update: function( host, query, referrer ) {
     const q = new Date();
     let sourceString = '';
@@ -80,23 +61,23 @@ const sourceCookies = {
     this._timeStamps.firstVisit = this._timeStamps.currentVisit;
 
     // Determine referral source
-    this
-      .parseDirect( host, query, referrer )
-      .parseReferral( host, query, referrer )
-      .parseOrganicSearch( host, query, referrer )
-      .parseUTMparameters( host, query, referrer )
-      .parseAdWords( host, query, referrer );
+    this.parseDirect( host, query, referrer )
+    this.parseReferral( host, query, referrer )
+    this.parseOrganicSearch( host, query, referrer )
+    this.parseUTMparameters( host, query, referrer )
+    this.parseAdWords( host, query, referrer );
 
     // .parseSocialMedia(host, query, referrer)
 
-    // set temp source values
+    // Set temp source values.
     for ( const property in this._referral ) {
       if ( property !== 'date' && this._referral[property].length > 0 ) {
-        newSource = newSource + this._classicParameterMap[property] + '=' + this._referral[property].replace( /\s/g, '%20' ) + '|';
+        newSource = newSource + this._classicParameterMap[property] + '=' +
+                    this._referral[property].replace( /\s/g, '%20' ) + '|';
       }
     }
 
-    // Remove trailing pipe
+    // Remove trailing pipe.
     newSource = newSource.slice( 0, -1 );
 
     if ( this._getCookie( this._timeCookieName ) !== '' ) {
@@ -113,7 +94,8 @@ const sourceCookies = {
       }
     }
 
-    if ( ( sourceString !== decodeURIComponent( newSource ) ) || this._newSession ) {
+    if ( ( sourceString !== decodeURIComponent( newSource ) ) ||
+         this._newSession ) {
       /* check values
       set cookies */
       this._timeStamps.visitCount++;
@@ -128,10 +110,11 @@ const sourceCookies = {
         window.dataLayer.push( { visitNumber: this._timeStamps.visitCount, event: 'visitCounter' } );
       }
     }
-    // set time values
-    newTime = this._timeStamps.visitCount + '.' + this._timeStamps.firstVisit + '.' + this._timeStamps.currentVisit;
+    // Set time values.
+    newTime = this._timeStamps.visitCount + '.' + this._timeStamps.firstVisit +
+              '.' + this._timeStamps.currentVisit;
 
-    // set time cookie, updated current visit
+    // Set time cookie, updated current visit.
     this._setCookie( this._timeCookieName, newTime, 365 * 2, false );
   },
 
@@ -186,12 +169,12 @@ const sourceCookies = {
 
 
   /**
-  * Check for UTM parameters
-  * @param {string} host - A URL.
-  * @param {string} query - A query string.
-  * @param {string} referrer - A referrer URL.
-  * @returns {Object} visitAttribution
-  */
+   * Check for UTM parameters
+   * @param {string} host - A URL.
+   * @param {string} query - A query string.
+   * @param {string} referrer - A referrer URL.
+   * @returns {Object} visitAttribution
+   */
   parseUTMparameters: function( host, query, referrer ) {
     // Check for gclid or gclsrc
     if ( this._getQueryParameter( query, 'utm_source' ) !== '' ) {
@@ -210,15 +193,15 @@ const sourceCookies = {
 
 
   /**
-  * Check for organic search referral
-  * @param {string} host - A URL.
-  * @param {string} query - A query string.
-  * @param {string} referrer - A referrer URL.
-  * @returns {Object} visitAttribution
-  */
+   * Check for organic search referral
+   * @param {string} host - A URL.
+   * @param {string} query - A query string.
+   * @param {string} referrer - A referrer URL.
+   * @returns {Object} visitAttribution
+   */
   parseOrganicSearch: function( host, query, referrer ) {
     // Referrer must not be the same host
-    if ( this._hostsAreEqual( 'http://' + host, referrer ) === false ) {
+    if ( hostsAreEqual( 'http://' + host, referrer ) === false ) {
 
       // Check for search engine
       const referrerMatch = referrer.match( /^https?:\/\/(.*\.search\.|www\.)?(google|bing|aol|yahoo|ask|comcast).([a-z]+)([\.a-z]{3,5})?\// );
@@ -245,15 +228,16 @@ const sourceCookies = {
 
 
   /**
-  * Check for social media referral
-  * @param {string} host - A URL.
-  * @param {string} query - A query string.
-  * @param {string} referrer - A referrer URL.
-  * @returns {Object} visitAttribution
-  */
+   * Check for social media referral
+   * @param {string} host - A URL.
+   * @param {string} query - A query string.
+   * @param {string} referrer - A referrer URL.
+   * @returns {Object} visitAttribution
+   */
   parseSocialMedia: function( host, query, referrer ) {
     // Referrer must not be the same host
-    if ( typeof referrer === typeof '' && referrer.length > 0 && this._hostsAreEqual( 'http://' + host, referrer ) === false ) {
+    if ( typeof referrer === typeof '' && referrer.length > 0 &&
+         hostsAreEqual( 'http://' + host, referrer ) === false ) {
       // Check for search engine
       const referrerMatch = referrer.match( /^https?:\/\/(www.)?(blogspot\.com|delicious\.com|deviantart\.com|disqus\.com|facebook\.com|faceparty\.com|fc2\.com|flickr\.com|flixster\.com|foursquare\.com|friendfeed\.com|friendster\.com|hi5\.com|linkedin\.com|livejournal\.com|myspace\.com|photobucket\.com|pinterest\.com|plus\.google\.com|reddit\.com|slideshare\.net|smugmug\.com|stumbleupon\.com|t\.co|tumblr\.com|twitter\.com|vimeo\.com|yelp\.com|youtube\.com)($|\/)/ );
       if ( referrerMatch !== null ) {
@@ -276,15 +260,16 @@ const sourceCookies = {
 
 
   /**
-  * Check for website referral
-  * @param {string} host - A URL.
-  * @param {string} query - A query string.
-  * @param {string} referrer - A referrer URL.
-  * @returns {Object} visitAttribution
-  */
+   * Check for website referral
+   * @param {string} host - A URL.
+   * @param {string} query - A query string.
+   * @param {string} referrer - A referrer URL.
+   * @returns {Object} visitAttribution
+   */
   parseReferral: function( host, query, referrer ) {
     // Referrer must not be the same host
-    if ( typeof referrer === typeof '' && referrer.length > 0 && this._hostsAreEqual( 'http://' + host, referrer ) === false ) {
+    if ( typeof referrer === typeof '' && referrer.length > 0 &&
+         hostsAreEqual( 'http://' + host, referrer ) === false ) {
       // Check for search engine
       const referrerMatch = referrer.match( /^https?:\/\/([^\/]+)\/?(.*)$/ );
       if ( referrerMatch !== null ) {
@@ -304,12 +289,12 @@ const sourceCookies = {
 
 
   /**
-  * Check for direct
-  * @param {string} host - A URL.
-  * @param {string} query - A query string.
-  * @param {string} referrer - A referrer URL.
-  * @returns {Object} visitAttribution
-  */
+   * Check for direct
+   * @param {string} host - A URL.
+   * @param {string} query - A query string.
+   * @param {string} referrer - A referrer URL.
+   * @returns {Object} visitAttribution
+   */
   parseDirect: function( host, query, referrer ) {
 
     if ( typeof referrer === typeof '' && referrer.length === 0 ) {
@@ -325,13 +310,13 @@ const sourceCookies = {
   },
 
   /**
-  * Set cookie
-  * @param {string} name - The key for the cookie value.
-  * @param {string|Object} value - The cookie value.
-  * @param {number} days - The lifetime of the cookie in days.
-  * @param {boolean} escapeValue - Whether to escape the value or not.
-  * @returns {Object} Referral
-  */
+   * Set cookie
+   * @param {string} name - The key for the cookie value.
+   * @param {string|Object} value - The cookie value.
+   * @param {number} days - The lifetime of the cookie in days.
+   * @param {boolean} escapeValue - Whether to escape the value or not.
+   * @returns {Object} Referral
+   */
   _setCookie: function( name, value, days, escapeValue ) {
     // Calculate expiration date
     const today = new Date();
@@ -357,10 +342,10 @@ const sourceCookies = {
 
 
   /**
-  * Get cookie
-  * @param {string} name - The key for the cookie value.
-  * @returns {string} The cookie value.
-  */
+   * Get cookie
+   * @param {string} name - The key for the cookie value.
+   * @returns {string} The cookie value.
+   */
   _getCookie: function( name ) {
     // Get cookie value
     let value = ( document.cookie.match( '(^|; )' + name + '=([^;]*)' ) || 0 )[2];
@@ -384,11 +369,11 @@ const sourceCookies = {
 
 
   /**
-  * Get a query parameter value.
-  * @param {string} queryString - A query string.
-  * @param {string} key - The key for the query value.
-  * @returns {string} The query parameter value.
-  */
+   * Get a query parameter value.
+   * @param {string} queryString - A query string.
+   * @param {string} key - The key for the query value.
+   * @returns {string} The query parameter value.
+   */
   _getQueryParameter: function( queryString, key ) {
     const query = queryString.substring( 1 );
     const vars = query.split( '&' );
@@ -403,10 +388,10 @@ const sourceCookies = {
 
 
   /**
-  * Get the query string.
-  * @param {string} fullURL - A URL with query string.
-  * @returns {string} - Just the query string of a full URL.
-  */
+   * Get the query string.
+   * @param {string} fullURL - A URL with query string.
+   * @returns {string} - Just the query string of a full URL.
+   */
   _getQueryString: function( fullURL ) {
     if ( typeof fullURL === typeof '' && fullURL.length > 0 ) {
       const url = document.createElement( 'a' );
@@ -423,34 +408,6 @@ const sourceCookies = {
 
     // Return
     return '?';
-  },
-
-
-  /**
-  * Check if two hosts are the same
-  * @param {string} host1 - A URL.
-  * @param {string} host2 - Another URL.
-  * @returns {boolean} True if the hosts are equal, false otherwise.
-  */
-  _hostsAreEqual: function( host1, host2 ) {
-    let h1 = document.createElement( 'a' );
-    h1.href = host1;
-
-    let h2 = document.createElement( 'a' );
-    h2.href = host2;
-
-    // Check for www
-    h1 = h1.host;
-    if ( h1.substring( 0, 4 ) === 'www.' ) {
-      h1 = h1.substring( 4 );
-    }
-    h2 = h2.host;
-    if ( h2.substring( 0, 4 ) === 'www.' ) {
-      h2 = h2.substring( 4 );
-    }
-
-    // Return
-    return h1 === h2;
   }
 };
 

--- a/cfgov/unprocessed/apps/analytics-gtm/js/enterprise-hash-url-listener.js
+++ b/cfgov/unprocessed/apps/analytics-gtm/js/enterprise-hash-url-listener.js
@@ -1,12 +1,11 @@
+import { track } from './util/analytics-util';
+
 const HashURLListener = ( function() {
-  let action = window.location.pathname + window.location.search + window.location.hash;
+  let action = window.location.pathname +
+               window.location.search +
+               window.location.hash;
   action = action.replace( '#', 'GA_HASHTAG' );
   const label = document.title;
 
-  window.dataLayer.push( {
-    event: 'Virtual Pageview',
-    action: action,
-    label: label
-  } );
-
+  track( 'Virtual Pageview', action, label );
 } )();

--- a/cfgov/unprocessed/apps/analytics-gtm/js/event-listener-scroll-tracking.js
+++ b/cfgov/unprocessed/apps/analytics-gtm/js/event-listener-scroll-tracking.js
@@ -1,7 +1,4 @@
-import $ from 'jquery';
-
-// Debug flag - set this to true to send console logs instead of dataLayer pushes.
-const debugMode = false;
+import { analyticsLog } from './util/analytics-util';
 
 // Default time delay before checking location.
 const callBackTime = 100;
@@ -19,10 +16,10 @@ const startTime = new Date();
 const beginning = startTime.getTime();
 const totalTime = 0;
 
-/* Threshold of pixels at bottom when 100% triggers.
-   For some reason some monitors were found to be a pixel off when scrolling to the bottom,
+/* Threshold of pixels at bottomPos when 100% triggers.
+   For some reason some monitors were found to be a pixel off when scrolling to the bottomPos,
    this gives a little wiggle-room for when the 100% event fires
-   so that it'll be 5px or less from the bottom. */
+   so that it'll be 5px or less from the bottomPos. */
 const threshold = 5;
 
 const totalheight = document.body.offsetHeight - threshold;
@@ -49,7 +46,7 @@ if ( y100 < window.innerHeight ) {
 
 // Check the location and track user
 function trackLocation() {
-  const bottom = window.innerHeight + document.body.scrollTop;
+  const bottomPos = window.innerHeight + document.body.scrollTop;
   let currentTime;
   let scrollStart;
   let timeToScroll;
@@ -57,80 +54,76 @@ function trackLocation() {
   let timeToContentEnd;
 
   // If user starts to scroll send an event, currently disabled
-  if ( bottom > readerLocation && !scroller ) {
+  if ( bottomPos > readerLocation && !scroller ) {
     currentTime = new Date();
     scrollStart = currentTime.getTime();
     timeToScroll = Math.round( ( scrollStart - beginning ) / 1000 );
-    if ( debugMode ) {
-      /* window.dataLayer.push({'event':'scrollEvent',
-         'scrollProgress':'start-scroll',
-         'scrollTime':timeToScroll}); */
-    } else {
-      console.log( 'started scrolling ' + timeToScroll );
-    }
+
+    /* window.dataLayer.push({'event':'scrollEvent',
+       'scrollProgress':'start-scroll',
+       'scrollTime':timeToScroll}); */
+    analyticsLog( 'started scrolling ' + timeToScroll );
+
     scroller = true;
   }
   // If user has hit 25%, currently disabled
-  if ( bottom >= y25 && hit25 === false ) {
+  if ( bottomPos >= y25 && hit25 === false ) {
     currentTime = new Date();
     contentScrollEnd = currentTime.getTime();
     timeToContentEnd = Math.round( ( contentScrollEnd - scrollStart ) / 1000 );
-    if ( debugMode ) {
-      console.log( 'hit 25% ' + timeToContentEnd );
-    } else {
-      /* window.dataLayer.push({'event':'scrollEvent',
-         'scrollProgress':'25%',
-         'scrollTime':timeToContentEnd}); */
-    }
+
+    /* window.dataLayer.push({'event':'scrollEvent',
+       'scrollProgress':'25%',
+       'scrollTime':timeToContentEnd}); */
+    analyticsLog( 'hit 25% ' + timeToContentEnd );
+
     hit25 = true;
   }
   // If user has hit 50%
-  if ( bottom >= y50 && hit50 === false ) {
+  if ( bottomPos >= y50 && hit50 === false ) {
     currentTime = new Date();
     contentScrollEnd = currentTime.getTime();
     timeToContentEnd = Math.round( ( contentScrollEnd - scrollStart ) / 1000 );
-    if ( debugMode ) {
-      console.log( 'hit 50% ' + timeToContentEnd );
-    } else {
-      window.dataLayer.push( {
-        event: 'scrollEvent',
-        scrollProgress: '50%',
-        scrollTime: timeToContentEnd
-      } );
-    }
+
+    window.dataLayer.push( {
+      event: 'scrollEvent',
+      scrollProgress: '50%',
+      scrollTime: timeToContentEnd
+    } );
+    analyticsLog( 'hit 50% ' + timeToContentEnd );
+
     hit50 = true;
   }
   // If user has hit 75%, currently disabled
-  if ( bottom >= y75 && hit75 === false ) {
+  if ( bottomPos >= y75 && hit75 === false ) {
     currentTime = new Date();
     contentScrollEnd = currentTime.getTime();
     timeToContentEnd = Math.round( ( contentScrollEnd - scrollStart ) / 1000 );
-    if ( debugMode ) {
-      console.log( 'hit 75% ' + timeToContentEnd );
-    } else {
-      /* window.dataLayer.push({'event':'scrollEvent',
-         'scrollProgress':'75%',
-         'scrollTime':timeToContentEnd}); */
-    }
+
+    /* window.dataLayer.push({'event':'scrollEvent',
+       'scrollProgress':'75%',
+       'scrollTime':timeToContentEnd}); */
+    analyticsLog( 'hit 75% ' + timeToContentEnd );
+
     hit75 = true;
   }
   // If user has hit 100%
-  if ( bottom >= y100 && hit100 === false ) {
+  if ( bottomPos >= y100 && hit100 === false ) {
     currentTime = new Date();
     contentScrollEnd = currentTime.getTime();
     timeToContentEnd = Math.round( ( contentScrollEnd - scrollStart ) / 1000 );
-    if ( debugMode ) {
-      window.dataLayer.push( {
-        event: 'scrollEvent',
-        scrollProgress: '100%',
-        scrollTime: timeToContentEnd
-      } );
-    } else {
-      console.log( 'hit 100% ' + timeToContentEnd );
-    }
+
+    window.dataLayer.push( {
+      event: 'scrollEvent',
+      scrollProgress: '100%',
+      scrollTime: timeToContentEnd
+    } );
+    analyticsLog( 'hit 100% ' + timeToContentEnd );
+
     hit100 = true;
   }
 }
+
 // Track the scrolling and track location
 window.addEventListener( 'scroll', function() {
   if ( timer ) {

--- a/cfgov/unprocessed/apps/analytics-gtm/js/hdma-explore-event-listeners.js
+++ b/cfgov/unprocessed/apps/analytics-gtm/js/hdma-explore-event-listeners.js
@@ -1,24 +1,14 @@
+// TODO: Remove jquery.
 import $ from 'jquery';
+
+import {
+  delay,
+  track
+} from './util/analytics-util';
 
 // HMDA Explore custom analytics file
 
 const HMDAAnalytics = ( function() {
-
-  const delay = ( function() {
-    let timer = 0;
-    return function( callback, ms ) {
-      clearTimeout( timer );
-      timer = setTimeout( callback, ms );
-    };
-  } )();
-
-  const track = function( event, action, label ) {
-    window.dataLayer.push( {
-      event: event,
-      action: action,
-      label: label
-    } );
-  };
 
   // Collapsible open and close
   $( '#all div.filter' ).click( function() {

--- a/cfgov/unprocessed/apps/analytics-gtm/js/pfc-comparison-tool-listeners.js
+++ b/cfgov/unprocessed/apps/analytics-gtm/js/pfc-comparison-tool-listeners.js
@@ -1,16 +1,15 @@
+// TODO: Remove jquery.
 import $ from 'jquery';
+
+import {
+  analyticsLog,
+  delay,
+  track
+} from './util/analytics-util';
 
 // Paying for College custom analytics file
 
 const PFCAnalytics = ( function() {
-  // -- Delay calculations after keyup --//
-  const delay = ( function() {
-    let t = 0;
-    return function( callback, delay ) {
-      clearTimeout( t );
-      t = setTimeout( callback, delay );
-    };
-  } )(); // end delay()
 
   // -- findEmptyColumn() - finds the first empty column, returns column number [1-3] --//
   function findEmptyColumn() {
@@ -35,11 +34,7 @@ const PFCAnalytics = ( function() {
   $( '.remove-confirm .remove-yes' ).click( function() {
     const columnNumber = $( this ).parents( '[data-column]' ).attr( 'data-column' );
     const schoolID = $( '#institution-row [data-column="' + columnNumber + '"]' ).attr( 'data-schoolid' );
-    window.dataLayer.push( {
-      event: 'School Interactions',
-      action: 'School Cost Comparison',
-      label: 'School Removed'
-    } );
+    track( 'School Interactions', 'School Cost Comparison', 'School Removed' );
     // Important to add a School tracking - reset the global.emptyColumn var
     global.emptyColumn = findEmptyColumn();
   } );
@@ -52,11 +47,7 @@ const PFCAnalytics = ( function() {
       const leftToPay = $( '.breakdown [data-column="' + columnNumber + '"] [data-nickname="gap"]' ).html();
       const schoolID = $( '#institution-row [data-column="' + columnNumber + '"]' ).attr( 'data-schoolid' );
       if ( leftToPay === '$0' && totalCosts !== '$0' ) {
-        window.dataLayer.push( {
-          event: 'School Interactions',
-          action: 'Reached Zero Left to Pay',
-          label: schoolID
-        } );
+        track( 'School Interactions', 'Reached Zero Left to Pay', schoolID );
       }
     }, 1000 );
   } );
@@ -64,11 +55,7 @@ const PFCAnalytics = ( function() {
   // Fire an event when a tooltip is clicked
   $( '.tooltip-info' ).click( function( event ) {
     const tooltip = $( this ).attr( 'data-tipname' );
-    window.dataLayer.push( {
-      event: 'School Interactions',
-      action: 'Tooltip Clicked',
-      label: tooltip
-    } );
+    track( 'School Interactions', 'Tooltip Clicked', tooltip );
   } );
 
   // Fire an event when GI Bill panel opens
@@ -78,11 +65,7 @@ const PFCAnalytics = ( function() {
     delay( function() {
       const GIPanel = $( '[data-column="' + columnNumber + '"] .gibill-panel' );
       if ( GIPanel.is( ':visible' ) ) {
-        window.dataLayer.push( {
-          event: 'School Interactions',
-          action: 'GI Bill Calculator Opened',
-          label: schoolID
-        } );
+        track( 'School Interactions', 'GI Bill Calculator Opened', schoolID );
       }
     }, 500 );
   } );
@@ -92,11 +75,7 @@ const PFCAnalytics = ( function() {
     const buttonID = $( this ).attr( 'data-buttonid' );
     if ( $.inArray( buttonID, rateChangeClicks ) === -1 ) {
       rateChangeClicks.push( buttonID );
-      window.dataLayer.push( {
-        event: 'School Interactions',
-        action: 'Percent Arrow Clicked',
-        label: buttonID
-      } );
+      track( 'School Interactions', 'Percent Arrow Clicked', buttonID );
     }
 
   } );
@@ -110,119 +89,69 @@ const PFCAnalytics = ( function() {
     const residency = $( "[data-column='1'] .military-residency-panel :radio:checked" ).val();
     const control = $( '.header-cell[data-column="' + columnNumber + '"]' ).attr( 'data-control' );
 
-    window.dataLayer.push( {
-      event: 'School Interactions',
-      action: 'GI Bill Calculator Submit',
-      label: schoolID
-    } );
-    window.dataLayer.push( {
-      event: 'School Interactions',
-      action: 'Military Status',
-      label: serving
-    } );
-    window.dataLayer.push( {
-      event: 'School Interactions',
-      action: 'Cumulative service',
-      label: tier
-    } );
+    track( 'School Interactions', 'GI Bill Calculator Submit', schoolID );
+    track( 'School Interactions', 'Military Status', serving );
+    track( 'School Interactions', 'Cumulative service', tier );
     if ( control === 'Public' ) {
-      window.dataLayer.push( {
-        event: 'School Interactions',
-        action: 'GI Residency',
-        label: residency
-      } );
+      track( 'School Interactions', 'GI Residency', residency );
     }
   } );
 
   // Fire an event when Send Email is clicked
   $( '#send-email' ).click( function() {
-    window.dataLayer.push( {
-      event: 'School Interactions',
-      action: 'Save and Share',
-      label: 'Send email'
-    } );
+    track( 'School Interactions', 'Save and Share', 'Send email' );
   } );
 
   // Fire an event when save draw is opened
   $( '#save-and-share' ).click( function( event, nateeve ) {
     let UNDEFINED;
     if ( nateeve === UNDEFINED ) {
-      window.dataLayer.push( {
-        event: 'School Interactions',
-        action: 'Save and Share',
-        label: 'toggle button'
-      } );
+      track( 'School Interactions', 'Save and Share', 'toggle button' );
     }
   } );
 
   // Fire an event when save current is clicked
   $( '#save-current' ).click( function() {
-    window.dataLayer.push( {
-      event: 'School Interactions',
-      action: 'Save and Share',
-      label: 'Save current worksheet'
-    } );
+    track( 'School Interactions', 'Save and Share', 'Save current worksheet' );
   } );
 
   $( '#unique' ).click( function() {
-    window.dataLayer.push( {
-      event: 'School Interactions',
-      action: 'Save and Share',
-      label: 'Copy URL'
-    } );
+    track( 'School Interactions', 'Save and Share', 'Copy URL' );
   } );
 
   $( '#save-drawer .save-share-facebook' ).click( function() {
-    window.dataLayer.push( {
-      event: 'School Interactions',
-      action: 'Save and Share',
-      label: 'Facebook_saveshare'
-    } );
+    track( 'School Interactions', 'Save and Share', 'Facebook_saveshare' );
   } );
 
   $( '#save-drawer .save-share-twitter' ).click( function() {
-    window.dataLayer.push( {
-      event: 'School Interactions',
-      action: 'Save and Share',
-      label: 'Twitter_saveshare'
-    } );
+    track( 'School Interactions', 'Save and Share', 'Twitter_saveshare' );
   } );
 
   // Fire an event when Get Started is clicked
   $( '#get-started-button' ).click( function() {
-    window.dataLayer.push( {
-      event: 'School Interactions',
-      action: 'School Cost Comparison',
-      label: 'Get Started Button'
-    } );
+    track(
+      'School Interactions', 'School Cost Comparison', 'Get Started Button'
+    );
   } );
 
   // Fire an event when Add a School is cancelled
   $( '#introduction .add-cancel' ).click( function() {
-    window.dataLayer.push( {
-      event: 'School Interactions',
-      action: 'School Cost Comparison',
-      label: 'Cancel Button'
-    } );
+    track( 'School Interactions', 'School Cost Comparison', 'Cancel Button' );
   } );
 
   // Fire an event when Continue is clicked
   $( '#introduction .continue' ).click( function() {
-    window.dataLayer.push( {
-      event: 'School Interactions',
-      action: 'School Cost Comparison',
-      label: 'Continue Button'
-    } );
-    console.log( '#introduction .continue clicked' );
+    track( 'School Interactions', 'School Cost Comparison', 'Continue Button' );
+    analyticsLog( '#introduction .continue clicked' );
   } );
 
   // Fire an event when Add another school is clicked
   $( '#introduction .add-another-school' ).click( function() {
-    window.dataLayer.push( {
-      event: 'School Interactions',
-      action: 'School Cost Comparison',
-      label: 'Add another school Button'
-    } );
+    track(
+      'School Interactions',
+      'School Cost Comparison',
+      'Add another school Button'
+    );
   } );
 
   // Fire an event when adding a school.
@@ -241,58 +170,26 @@ const PFCAnalytics = ( function() {
     if ( $( '#finaidoffer' ).is( ':checked' ) ) {
       offer = 'Yes';
     }
-    window.dataLayer.push( {
-      event: 'School Interactions',
-      action: 'Total Schools Added',
-      label: schoolCount
-    } );
-    window.dataLayer.push( {
-      event: 'School Interactions',
-      action: 'School Added',
-      label: schoolID
-    } );
-    window.dataLayer.push( {
-      event: 'School Interactions',
-      action: 'Program Type',
-      label: program
-    } );
-    window.dataLayer.push( {
-      event: 'School Interactions',
-      action: 'Program Length',
-      label: prgmlength
-    } );
-
+    track( 'School Interactions', 'Total Schools Added', schoolCount );
+    track( 'School Interactions', 'School Added', schoolID );
+    track( 'School Interactions', 'Program Type', program );
+    track( 'School Interactions', 'Program Length', prgmlength );
 
     if ( offer === 'Yes' ) {
+      // TODO: Determine what the label should be for this?
       window.dataLayer.push( {
         event: 'School Interactions',
         action: 'Financial Aid Clicked'
       } );
       if ( $( '#xml-text' ).val() === '' && kbyoss === 'Yes' ) {
-        window.dataLayer.push( {
-          event: 'School Interactions',
-          action: 'School Added - XML',
-          label: 'Blank'
-        } );
+        track( 'School Interactions', 'School Added - XML', 'Blank' );
       } else if ( $( '#xml-text' ).val() !== '' && kbyoss === 'Yes' ) {
-        window.dataLayer.push( {
-          event: 'School Interactions',
-          action: 'School Added - XML',
-          label: 'XML text'
-        } );
+        track( 'School Interactions', 'School Added - XML', 'XML text' );
       }
     } else {
-      window.dataLayer.push( {
-        event: 'School Interactions',
-        action: 'Housing',
-        label: housing
-      } );
+      track( 'School Interactions', 'Housing', housing );
       if ( control === 'Public' ) {
-        window.dataLayer.push( {
-          event: 'School Interactions',
-          action: 'Residency',
-          label: residency
-        } );
+        track( 'School Interactions', 'Residency', residency );
       }
     }
   }
@@ -312,11 +209,7 @@ const PFCAnalytics = ( function() {
   // Fire event when user clicks the arrows to open sections
   $( '.arrw-collapse' ).click( function() {
     const arrwName = $( this ).attr( 'data-arrwname' );
-    window.dataLayer.push( {
-      event: 'School Interactions',
-      action: 'Drop Down',
-      label: arrwName
-    } );
+    track( 'School Interactions', 'Drop Down', arrwName );
   } );
 
 } )( $ );

--- a/cfgov/unprocessed/apps/analytics-gtm/js/retirement-before-you-claim-listeners.js
+++ b/cfgov/unprocessed/apps/analytics-gtm/js/retirement-before-you-claim-listeners.js
@@ -7,7 +7,7 @@ import { track } from './util/analytics-util';
 
 const BYCAnalytics = ( function() {
 
-  let questionsAnswered = [];
+  const questionsAnswered = [];
   let sliderClicks = 0;
   let sliderIsActive = false;
   let stepOneSubmitted = false;

--- a/cfgov/unprocessed/apps/analytics-gtm/js/retirement-before-you-claim-listeners.js
+++ b/cfgov/unprocessed/apps/analytics-gtm/js/retirement-before-you-claim-listeners.js
@@ -1,12 +1,16 @@
+// TODO: Remove jquery.
 import $ from 'jquery';
+
+import { track } from './util/analytics-util';
 
 // Retirement - Before You Claim custom analytics file
 
 const BYCAnalytics = ( function() {
-  let questionsAnswered = [],
-      sliderClicks = 0,
-      sliderIsActive = false,
-      stepOneSubmitted = false;
+
+  let questionsAnswered = [];
+  let sliderClicks = 0;
+  let sliderIsActive = false;
+  let stepOneSubmitted = false;
 
   function calculateAge( month, day, year, currentDate ) {
     let now = currentDate;
@@ -25,15 +29,6 @@ const BYCAnalytics = ( function() {
     return age;
   }
 
-
-  const delay = ( function() {
-    let timer = 0;
-    return function( callback, ms ) {
-      clearTimeout( timer );
-      timer = setTimeout( callback, ms );
-    };
-  } )();
-
   $( document ).ready( function() {
 
     $( '#step-one-form' ).submit( function( e ) {
@@ -41,11 +36,11 @@ const BYCAnalytics = ( function() {
       stepOneSubmitted = true;
       let month = $( '#bd-month' ).val(),
           day = $( '#bd-day' ).val();
-      window.dataLayer.push( {
-        event: 'Before You Claim Interaction',
-        action: 'Get Your Estimates submit birthdate',
-        label: 'Birthdate Month and Day - ' + month + '/' + day
-      } );
+      track(
+        'Before You Claim Interaction',
+        'Get Your Estimates submit birthdate',
+        'Birthdate Month and Day - ' + month + '/' + day
+      );
     } );
 
     $( '#step-one-form' ).submit( function( e ) {
@@ -54,49 +49,49 @@ const BYCAnalytics = ( function() {
           day = $( '#bd-day' ).val(),
           year = $( '#bd-year' ).val(),
           age = calculateAge( month, day, year );
-      window.dataLayer.push( {
-        event: 'Before You Claim Interaction',
-        action: 'Get Your Estimates submit age',
-        label: 'Age ' + age
-      } );
+      track(
+        'Before You Claim Interaction',
+        'Get Your Estimates submit age',
+        'Age ' + age
+      );
     } );
 
     $( '#claim-canvas' ).on( 'mousedown', 'rect', function() {
       const age = $( this ).attr( 'data-age' );
-      window.dataLayer.push( {
-        event: 'Before You Claim Interaction',
-        action: 'Graph Age Bar clicked',
-        label: 'Age ' + age
-      } );
+      track(
+        'Before You Claim Interaction',
+        'Graph Age Bar clicked',
+        'Age ' + age
+      );
     } );
 
     $( '#claim-canvas' ).on( 'mousedown', '#graph_slider-input', function() {
       sliderIsActive = true;
       sliderClicks++;
-      window.dataLayer.push( {
-        event: 'Before You Claim Interaction',
-        action: 'Slider clicked',
-        label: 'Slider clicked ' + sliderClicks + ' times'
-      } );
+      track(
+        'Before You Claim Interaction',
+        'Slider clicked',
+        'Slider clicked ' + sliderClicks + ' times'
+      );
     } );
 
     $( '#claim-canvas' ).on( 'click', '.age-text', function() {
       const age = $( this ).attr( 'data-age-value' );
-      window.dataLayer.push( {
-        event: 'Before You Claim Interaction',
-        action: 'Age Text Box clicked',
-        label: 'Age ' + age
-      } );
+      track(
+        'Before You Claim Interaction',
+        'Age Text Box clicked',
+        'Age ' + age
+      );
     } );
 
     $( 'body' ).on( 'mouseup', function() {
       if ( sliderIsActive === true ) {
         const age = $( '.selected-age' ).text();
-        window.dataLayer.push( {
-          event: 'Before You Claim Interaction',
-          action: 'Slider released',
-          label: 'Age ' + age
-        } );
+        track(
+          'Before You Claim Interaction',
+          'Slider released',
+          'Age ' + age
+        );
         sliderIsActive = false;
       }
     } );
@@ -109,55 +104,55 @@ const BYCAnalytics = ( function() {
         questionsAnswered.push( question );
       }
       if ( questionsAnswered.length === 5 ) {
-        window.dataLayer.push( {
-          event: 'Before You Claim Interaction',
-          action: 'All Lifestyle Buttons clicked',
-          label: 'All button clicks'
-        } );
+        track(
+          'Before You Claim Interaction',
+          'All Lifestyle Buttons clicked',
+          'All button clicks'
+        );
       }
-      window.dataLayer.push( {
-        event: 'Before You Claim Interaction',
-        action: 'Lifestyle Button clicked',
-        label: 'Question: ' + question + ' - ' + value
-      } );
+      track(
+        'Before You Claim Interaction',
+        'Lifestyle Button clicked',
+        'Question: ' + question + ' - ' + value
+      );
     } );
 
     $( 'input[name="benefits-display"]' ).click( function() {
       if ( stepOneSubmitted ) {
         const val = $( this ).val();
-        window.dataLayer.push( {
-          event: 'Before You Claim Interaction',
-          action: 'Benefits View clicked',
-          label: val
-        } );
+        track(
+          'Before You Claim Interaction',
+          'Benefits View clicked',
+          val
+        );
       }
     } );
 
     $( '#retirement-age-selector' ).change( function() {
       const val = $( this ).find( 'option:selected' ).val();
-      window.dataLayer.push( {
-        event: 'Before You Claim Interaction',
-        action: 'Planned Retirement Age selected',
-        label: val
-      } );
+      track(
+        'Before You Claim Interaction',
+        'Planned Retirement Age selected',
+        val
+      );
     } );
 
     $( 'button.helpful-btn' ).click( function() {
       const val = $( this ).val();
-      window.dataLayer.push( {
-        event: 'Before You Claim Interaction',
-        action: 'Was This Page Helpful clicked',
-        label: val
-      } );
+      track(
+        'Before You Claim Interaction',
+        'Was This Page Helpful clicked',
+        val
+      );
     } );
 
     $( '[data-tooltip-target]' ).click( function() {
       const target = $( this ).attr( 'data-tooltip-target' );
-      window.dataLayer.push( {
-        event: 'Before You Claim Interaction',
-        action: 'Tooltip clicked',
-        label: 'Target: ' + target
-      } );
+      track(
+        'Before You Claim Interaction',
+        'Tooltip clicked',
+        'Target: ' + target
+      );
     } );
   } );
 

--- a/cfgov/unprocessed/apps/analytics-gtm/js/util/analytics-util.js
+++ b/cfgov/unprocessed/apps/analytics-gtm/js/util/analytics-util.js
@@ -1,4 +1,3 @@
-
 /**
  * Check if an element exists on the page, and if it does, add listeners.
  * @param {[type]}   elem     [description]
@@ -35,7 +34,7 @@ function track( event, action, label ) {
     label: label
   } );
   analyticsLog( event, action, label );
-};
+}
 
 /**
  * Check if two hosts are the same.

--- a/cfgov/unprocessed/apps/analytics-gtm/js/util/analytics-util.js
+++ b/cfgov/unprocessed/apps/analytics-gtm/js/util/analytics-util.js
@@ -1,0 +1,102 @@
+
+/**
+ * Check if an element exists on the page, and if it does, add listeners.
+ * @param {[type]}   elem     [description]
+ * @param {[type]}   event    [description]
+ * @param {Function} callback [description]
+ */
+function addEventListenerToElem( elem, event, callback ) {
+  if ( elem ) {
+    elem.addEventListener( event, callback );
+  } else {
+    analyticsLog( `${ elem } doesn't exist!` );
+  }
+}
+
+const delay = ( function() {
+  let timer = 0;
+  return function( callback, ms ) {
+    clearTimeout( timer );
+    timer = setTimeout( callback, ms );
+  };
+} )();
+
+/**
+ * TODO: Merge with Analytics.js.
+ * Track an analytics event and log the event.
+ * @param {string} event Type of event.
+ * @param {string} action Name of event.
+ * @param {string} label DOM element label.
+ */
+function track( event, action, label ) {
+  window.dataLayer.push( {
+    event: event,
+    action: action,
+    label: label
+  } );
+  analyticsLog( event, action, label );
+};
+
+/**
+ * Check if two hosts are the same.
+ * This only works with a www subdomain.
+ * @param {string} host1 - A URL.
+ * @param {string} host2 - Another URL.
+ * @returns {boolean} True if the hosts are equal, false otherwise.
+ */
+function hostsAreEqual( host1, host2 ) {
+  let h1 = document.createElement( 'a' );
+  h1.href = host1;
+
+  let h2 = document.createElement( 'a' );
+  h2.href = host2;
+
+  // Check for www
+  h1 = h1.host;
+  if ( h1.substring( 0, 4 ) === 'www.' ) {
+    h1 = h1.substring( 4 );
+  }
+  h2 = h2.host;
+  if ( h2.substring( 0, 4 ) === 'www.' ) {
+    h2 = h2.substring( 4 );
+  }
+
+  return h1 === h2;
+}
+
+/**
+ * Retrieve a URL query string parameter by parameter name.
+ * @param  {string} key - The name of the parameter in the URL.
+ * @returns {string|null} The value of the parameter.
+ */
+function getQueryParameter( key ) {
+  const url = window.location.href;
+  const param = key.replace( /[\[\]]/g, '\\$&' );
+  const regex = new RegExp( '[?&]' + param + '(=([^&#]*)|&|#|$)' );
+  const results = regex.exec( url );
+  if ( !results ) return null;
+  if ( !results[2] ) return '';
+  const decoded = decodeURIComponent( results[2].replace( /\+/g, ' ' ) );
+  if ( decoded === 'true' ) return true;
+  if ( decoded === 'false' ) return false;
+  return decoded;
+}
+
+/**
+ * Log a message to the console if the `debug-gtm` URL parameter is set.
+ * @param {string} msg - Message to load to the console.
+ */
+function analyticsLog( msg ) {
+  if ( getQueryParameter( 'debug-gtm' ) === true ) {
+    console.log( `ANALYTICS DEBUG MODE: ${ msg }` );
+  }
+}
+
+module.exports = {
+  addEventListenerToElem,
+  analyticsLog,
+  delay,
+  getQueryParameter,
+  hostsAreEqual,
+  track
+};

--- a/cfgov/unprocessed/apps/analytics-gtm/js/util/analytics-util.js
+++ b/cfgov/unprocessed/apps/analytics-gtm/js/util/analytics-util.js
@@ -1,3 +1,4 @@
+
 /**
  * Check if an element exists on the page, and if it does, add listeners.
  * @param {[type]}   elem     [description]
@@ -34,7 +35,7 @@ function track( event, action, label ) {
     label: label
   } );
   analyticsLog( event, action, label );
-}
+};
 
 /**
  * Check if two hosts are the same.
@@ -44,23 +45,25 @@ function track( event, action, label ) {
  * @returns {boolean} True if the hosts are equal, false otherwise.
  */
 function hostsAreEqual( host1, host2 ) {
-  let h1 = document.createElement( 'a' );
-  h1.href = host1;
 
-  let h2 = document.createElement( 'a' );
-  h2.href = host2;
+  /**
+   * Pick the host out of a URL.
+   * @param {string} srcHost - A URL
+   * @returns {string} A hostname without subdomain.
+   */
+  function createTestHost( srcHost ) {
+    let testHost = document.createElement( 'a' );
+    testHost.href = srcHost;
 
-  // Check for www
-  h1 = h1.host;
-  if ( h1.substring( 0, 4 ) === 'www.' ) {
-    h1 = h1.substring( 4 );
+    testHost = testHost.host;
+    if ( testHost.substring( 0, 4 ) === 'www.' ) {
+      testHost = testHost.substring( 4 );
+    }
+
+    return testHost;
   }
-  h2 = h2.host;
-  if ( h2.substring( 0, 4 ) === 'www.' ) {
-    h2 = h2.substring( 4 );
-  }
 
-  return h1 === h2;
+  return createTestHost( host1 ) === createTestHost( host2 );
 }
 
 /**

--- a/cfgov/unprocessed/apps/analytics-gtm/js/youtube-event-listeners-older-style.js
+++ b/cfgov/unprocessed/apps/analytics-gtm/js/youtube-event-listeners-older-style.js
@@ -1,10 +1,12 @@
+import { analyticsLog } from './util/analytics-util';
+
 /* LunaMetrics Google Analytics YouTube Tracking
    Uses the YouTube Iframe API to fire events
    to Google Analytics. Supports Google Tag Manager
    and IE8+ and tracks all YouTube videos available
    on the page at the time of loading.
    WARNING: Overwrites older <embed> style players
-   and reloads improperly formatted <iframe> players */
+   and reloads improperly formatted <iframe> players. */
 
 /* Put everything into an IIFE to prevent scope pollution
    and run the script automatically. */
@@ -49,12 +51,12 @@
   };
 
   /**
-  * Process list of potential videos and hand qualified
-  * objects to be uniformly formatted and attach
-  * our events to them
-  *
-  * @param {Array} potentialVideos - Aarray objects.
-  */
+   * Process list of potential videos and hand qualified
+   * objects to be uniformly formatted and attach
+   * our events to them
+   *
+   * @param {Array} potentialVideos - Aarray objects.
+   */
   function digestPotentialVideos( potentialVideos ) {
     for ( let i = 0; i < potentialVideos.length; i++ ) {
 
@@ -69,13 +71,13 @@
   }
 
   /**
-  * Checks if the object has an href that a
-  * YouTube video would have, and returns
-  * true or false if it finds a match
-  *
-  * @param {Object} potentialYouTubeVideo object
-  * @returns {boolean} true or false
-  */
+   * Checks if the object has an href that a
+   * YouTube video would have, and returns
+   * true or false if it finds a match
+   *
+   * @param {Object} potentialYouTubeVideo object
+   * @returns {boolean} true or false
+   */
   function checkIfYouTubeVideo( potentialYouTubeVideo ) {
 
     /* Fallback to '' if there is no src attribute, so our test
@@ -92,15 +94,15 @@
   }
 
   /**
-  * Checks if the YouTube video has all the required parameters for tracking,
-  * and if it does not, it reloads it with the appropriate parameters. It will
-  * reload videos that do not have the correct parameters and destroy old-style
-  * <object> embeds and replace them with an <iframe>
-  * WARNING: This may cause the video to briefly flicker on the page
-  *
-  * @param {Object} youTubeVideo iframe or embed
-  * @returns {Object} video object reference
-  */
+   * Checks if the YouTube video has all the required parameters for tracking,
+   * and if it does not, it reloads it with the appropriate parameters. It will
+   * reload videos that do not have the correct parameters and destroy old-style
+   * <object> embeds and replace them with an <iframe>
+   * WARNING: This may cause the video to briefly flicker on the page
+   *
+   * @param {Object} youTubeVideo iframe or embed
+   * @returns {Object} video object reference
+   */
   function normalizeYouTubeIframe( youTubeVideo ) {
 
     /* Create a fake <a> element to use the HREF apis and extract
@@ -160,13 +162,13 @@
   }
 
   /**
-  * Creates a new Player object for each video
-  * detected on the page and binds to the onStateChange
-  * event emitted  by the YouTube API and checks if we
-  * should emit the event to Google Analytics.
-  *
-  * @param {Object} youTubeIframe object
-  */
+   * Creates a new Player object for each video
+   * detected on the page and binds to the onStateChange
+   * event emitted  by the YouTube API and checks if we
+   * should emit the event to Google Analytics.
+   *
+   * @param {Object} youTubeIframe object
+   */
   function addYouTubeEvents( youTubeIframe ) {
     const YouTubePlayer = window.YT;
     // Create a locally scoped new YT.Player for each iframe
@@ -181,11 +183,11 @@
   }
 
   /**
-  * Function we bind to the onStateChange event from the YouTube API
-  *
-  * @param {Event} evt object
-  * @param {Object} youTubeIframe object
-  */
+   * Function we bind to the onStateChange event from the YouTube API
+   *
+   * @param {Event} evt object
+   * @param {Object} youTubeIframe object
+   */
   function onStateChangeHandler( evt, youTubeIframe ) {
 
     const state = playerStatesIndex[evt.data]; // Determine state text from event number
@@ -209,17 +211,14 @@
   }
 
   /**
-  * Function that fires our event to Google Analytics
-  *
-  * @param {Object} youTubeIframe object
-  * @param {number} state number
-  */
+   * Function that fires our event to Google Analytics.
+   *
+   * @param {Object} youTubeIframe object
+   * @param {number} state number
+   */
   function fireAnalyticsEvent( youTubeIframe, state ) {
-
-    // Send an event to the dataLayer with our event info
-
+    // Send an event to the dataLayer with our event info.
     window.dataLayer.push( {
-
       event: 'YouTube Events',
       action: state,
       label: youTubeIframe.videoTitle,
@@ -249,15 +248,15 @@
   }
 
   /**
-  * Function that checks the state of our iframes attributes
-  * and the latest event emitted by the API to determine
-  * whether we want to fire an event or not. Handles many
-  * wrinkles in YouTube iframe API.
-  *
-  * @param {number} stateIndex number
-  * @param {Object} youTubeIframe object
-  * @returns {boolean} true or false
-  */
+   * Function that checks the state of our iframes attributes
+   * and the latest event emitted by the API to determine
+   * whether we want to fire an event or not. Handles many
+   * wrinkles in YouTube iframe API.
+   *
+   * @param {number} stateIndex number
+   * @param {Object} youTubeIframe object
+   * @returns {boolean} true or false
+   */
   function checkIfEventShouldFire( stateIndex, youTubeIframe ) {
 
     if ( stateIndex === 0 ) {
@@ -292,13 +291,13 @@
   }
 
   /**
-  * Adjusts the iframes playback attributes
-  * depending on the state of the player and
-  * the event emitted from the YouTube API
-  *
-  * @param {number} stateIndex number
-  * @param {Object} youTubeIframe object
-  */
+   * Adjusts the iframes playback attributes
+   * depending on the state of the player and
+   * the event emitted from the YouTube API
+   *
+   * @param {number} stateIndex number
+   * @param {Object} youTubeIframe object
+   */
   function interpretState( stateIndex, youTubeIframe ) {
 
     /* Playlists reference NEXT video in the playlist
@@ -334,15 +333,15 @@
   }
 
   /**
-  * Utility: IE 8+, Firefox, Opera, Chrome, Safari XDR object
-  *
-  * modified from code courtesy github user xeoncross
-  * https://gist.github.com/Xeoncross/7663273
-  * @param {string} url - A URL
-  * @param {Function} callback - A callback function.
-  * @param {*} data - Some arbitrary data to send.
-  * @param {null} x - XHR class constructor.
-  */
+   * Utility: IE 8+, Firefox, Opera, Chrome, Safari XDR object
+   *
+   * modified from code courtesy github user xeoncross
+   * https://gist.github.com/Xeoncross/7663273
+   * @param {string} url - A URL
+   * @param {Function} callback - A callback function.
+   * @param {*} data - Some arbitrary data to send.
+   * @param {null} x - XHR class constructor.
+   */
   function ajax( url, callback, data, x ) {
     /* Modified to remove headers causing CORS errors
        Modified to use XDomainRequest
@@ -373,7 +372,7 @@
       }
     } catch ( e ) {
       // If we can't invoke our call, log it to console
-      console.log( e.message );
+      analyticsLog( e.message );
     }
   }
 } )( document, window );

--- a/test/unit_tests/apps/analytics-gtm/js/util/analytics-util-spec.js
+++ b/test/unit_tests/apps/analytics-gtm/js/util/analytics-util-spec.js
@@ -1,0 +1,26 @@
+const BASE_JS_PATH = '../../../../../../cfgov/unprocessed/apps/analytics-gtm/';
+const analyticsUtil = require( BASE_JS_PATH + 'js/util/analytics-util' );
+
+const HTML_SNIPPET = `
+  <div id="test-elem"></div>
+`;
+
+describe( 'analytics-util', () => {
+  beforeEach( () => {
+    document.body.innerHTML = HTML_SNIPPET;
+  } );
+
+  describe( 'hostsAreEqual()', () => {
+    it( 'should return true if hosts are equal', () => {
+      const host1 = 'https://www.example.com';
+      const host2 = 'https://www.example.com';
+      expect( analyticsUtil.hostsAreEqual( host1, host2 ) ).toBe( true );
+    } );
+
+    it( 'should return false if hosts are NOT equal', () => {
+      const host1 = 'https://www.github.com';
+      const host2 = 'https://www.github.io';
+      expect( analyticsUtil.hostsAreEqual( host1, host2 ) ).toBe( false );
+    } );
+  } );
+} );


### PR DESCRIPTION
There is lots of redundant utility code in the analytics scripts. This moves some of that functionality to a utility module. It also makes it so that the console logs in the scripts only show up when the `debug-gtm=true` query string appears in the URL. 

The `track` utility script can likely be consolidated with `Analytics.js` in the future (which should perhaps move into the `analytics-gtm` app?

## Additions

- Add `analytics-util.js` and initial test spec.

## Changes

- Moves `delay` and `track` functions to the utility script.
- Adds helper function to check that an element exists before adding an event listener.
- Renames `bottom` variable `bottomPos` to fix New Relic error.
- Makes script that push to the dataLayer utilize the `track` function.

## Testing

To see that the logging function works, add this to `common.js` and run `gulp clean && gulp build`

```js
// common.js
function getQueryParameter( key ) {
  const url = window.location.href;
  const param = key.replace( /[\[\]]/g, '\\$&' );
  const regex = new RegExp( '[?&]' + param + '(=([^&#]*)|&|#|$)' );
  const results = regex.exec( url );
  if ( !results ) return null;
  if ( !results[2] ) return '';
  const decoded = decodeURIComponent( results[2].replace( /\+/g, ' ' ) );
  if ( decoded === 'true' ) return true;
  if ( decoded === 'false' ) return false;
  return decoded;
}

if ( getQueryParameter( 'debug-gtm' ) === true ) {
  console.log( `ANALYTICS DEBUG MODE:` );
}
```

Then visit http://localhost:8000/?debug-gtm=true and see the log in the dev console. Remove the query string and reload to see the log disappear.

