### PR TITLE
Acceptance tests updates part deux

### DIFF
--- a/docs/testing-fe.md
+++ b/docs/testing-fe.md
@@ -18,7 +18,7 @@ and/or to run it in "fast" mode:
 gulp test:acceptance --suite=wagtail-admin ( runs just the wagtail-admin suite )
 gulp test:acceptance --specs=multi-select.feature ( runs just the multi-select feature )
 gulp test:acceptance --tags=@mobile ( runs all scenarios tagged with @mobile )
-gulp test:acceptance --recreate ( runs the tests without recreating the virtual environment )
+gulp test:acceptance --recreate ( runs the tests and recreates the virtual environment )
 ```
 
 The same options can be used with tox (--omitted):

--- a/docs/testing-fe.md
+++ b/docs/testing-fe.md
@@ -18,7 +18,7 @@ and/or to run it in "fast" mode:
 gulp test:acceptance --suite=wagtail-admin ( runs just the wagtail-admin suite )
 gulp test:acceptance --specs=multi-select.feature ( runs just the multi-select feature )
 gulp test:acceptance --tags=@mobile ( runs all scenarios tagged with @mobile )
-gulp test:acceptance --fast ( runs the tests without recreating the virtual environment )
+gulp test:acceptance --recreate ( runs the tests without recreating the virtual environment )
 ```
 
 The same options can be used with tox (--omitted):
@@ -27,7 +27,7 @@ The same options can be used with tox (--omitted):
 tox -e acceptance suite=wagtail-admin
 tox -e acceptance specs=multi-select.feature
 tox -e acceptance tags=@mobile
-tox -e acceptance-fast
+tox -e acceptance-recreate
 ```
 
 These tests will run on their own server; you do not need to be running your development server.

--- a/docs/testing-fe.md
+++ b/docs/testing-fe.md
@@ -27,7 +27,6 @@ The same options can be used with tox (--omitted):
 tox -e acceptance suite=wagtail-admin
 tox -e acceptance specs=multi-select.feature
 tox -e acceptance tags=@mobile
-tox -e acceptance-recreate
 ```
 
 These tests will run on their own server; you do not need to be running your development server.

--- a/gulp/tasks/test.js
+++ b/gulp/tasks/test.js
@@ -87,12 +87,11 @@ function testUnitScripts( cb ) {
  */
 function testAcceptanceBrowser() {
   const params = minimist( process.argv.slice( 3 ) ) || {};
-  const toxParams = [ '-e' ];
+  const toxParams = [ '-e', 'acceptance' ];
 
   if ( params.recreate ) {
-    toxParams.push( 'acceptance-recreate' );
-  } else {
-    toxParams.push( 'acceptance' );
+    delete params.recreate;
+    toxParams.push( '-r' );
   }
 
   Object.keys( params ).forEach( key => {
@@ -175,9 +174,6 @@ function _getProtractorParams( suite ) {
 
   // If --tags=@tagName flag is added on the command-line.
   params = _addCommandLineFlag( params, commandLineParams, 'tags' );
-
-  // If --headless=false flag is added on the command-line.
-  params = _addCommandLineFlag( params, commandLineParams, 'headless' );
 
   /* If the --suite=suite1,suite2 flag is added on the command-line
      or, if not, if a suite is passed as part of the gulp task definition. */

--- a/gulp/tasks/test.js
+++ b/gulp/tasks/test.js
@@ -175,6 +175,9 @@ function _getProtractorParams( suite ) {
   // If --tags=@tagName flag is added on the command-line.
   params = _addCommandLineFlag( params, commandLineParams, 'tags' );
 
+  // If --headless=false flag is added on the command-line.
+  params = _addCommandLineFlag( params, commandLineParams, 'headless' );
+
   /* If the --suite=suite1,suite2 flag is added on the command-line
      or, if not, if a suite is passed as part of the gulp task definition. */
   const suiteParam = { suite: commandLineParams.suite || suite };

--- a/gulp/tasks/test.js
+++ b/gulp/tasks/test.js
@@ -89,8 +89,8 @@ function testAcceptanceBrowser() {
   const params = minimist( process.argv.slice( 3 ) ) || {};
   const toxParams = [ '-e' ];
 
-  if ( params.fast ) {
-    toxParams.push( 'acceptance-fast' );
+  if ( params.recreate ) {
+    toxParams.push( 'acceptance-recreate' );
   } else {
     toxParams.push( 'acceptance' );
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -98,6 +98,12 @@
         }
       }
     },
+    "accessibility-developer-tools": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/accessibility-developer-tools/-/accessibility-developer-tools-2.12.0.tgz",
+      "integrity": "sha1-PaDM6dbsY3OWS4TzXbfPw996tRQ=",
+      "dev": true
+    },
     "accord": {
       "version": "0.27.3",
       "resolved": "https://registry.npmjs.org/accord/-/accord-0.27.3.tgz",
@@ -579,6 +585,29 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
       "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4="
+    },
+    "axe-core": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-2.6.1.tgz",
+      "integrity": "sha512-QFfI3d+x/v92HJWGBaNfgrxdfon9/xXzd04YYfm5w5NJQOLex8qkJCctOt7+ky6e1l9zcQ5E7jsvbnTgQzyfTw==",
+      "dev": true
+    },
+    "axe-webdriverjs": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/axe-webdriverjs/-/axe-webdriverjs-0.2.0.tgz",
+      "integrity": "sha1-XjHtr26bozRCdiz9hd46B0c8EVU=",
+      "dev": true,
+      "requires": {
+        "axe-core": "1.1.1"
+      },
+      "dependencies": {
+        "axe-core": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-1.1.1.tgz",
+          "integrity": "sha1-rp2l2oq08QQZB/H12N/jnJRqksU=",
+          "dev": true
+        }
+      }
     },
     "babel-code-frame": {
       "version": "6.26.0",
@@ -12497,6 +12526,27 @@
         }
       }
     },
+    "protractor-accessibility-plugin": {
+      "version": "github:cfpb/protractor-accessibility-plugin#7319a881e222d9f3588f6d5d8a3d9848bc38c859",
+      "dev": true,
+      "requires": {
+        "accessibility-developer-tools": "2.12.0",
+        "axe-core": "2.6.1",
+        "axe-webdriverjs": "0.2.0",
+        "html-entities": "1.2.1",
+        "lodash": "3.10.1",
+        "q": "1.5.1",
+        "request": "2.81.0"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "3.10.1",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+          "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
+          "dev": true
+        }
+      }
+    },
     "protractor-cucumber-framework": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/protractor-cucumber-framework/-/protractor-cucumber-framework-4.2.0.tgz",
@@ -12523,7 +12573,8 @@
     "protractor-retry": {
       "version": "1.1.9",
       "resolved": "https://registry.npmjs.org/protractor-retry/-/protractor-retry-1.1.9.tgz",
-      "integrity": "sha1-STowzLnMIl/BBwg2KuM2KFXrAPo="
+      "integrity": "sha1-STowzLnMIl/BBwg2KuM2KFXrAPo=",
+      "dev": true
     },
     "proxy-from-env": {
       "version": "1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -98,12 +98,6 @@
         }
       }
     },
-    "accessibility-developer-tools": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/accessibility-developer-tools/-/accessibility-developer-tools-2.12.0.tgz",
-      "integrity": "sha1-PaDM6dbsY3OWS4TzXbfPw996tRQ=",
-      "dev": true
-    },
     "accord": {
       "version": "0.27.3",
       "resolved": "https://registry.npmjs.org/accord/-/accord-0.27.3.tgz",
@@ -585,29 +579,6 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
       "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4="
-    },
-    "axe-core": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-2.6.1.tgz",
-      "integrity": "sha512-QFfI3d+x/v92HJWGBaNfgrxdfon9/xXzd04YYfm5w5NJQOLex8qkJCctOt7+ky6e1l9zcQ5E7jsvbnTgQzyfTw==",
-      "dev": true
-    },
-    "axe-webdriverjs": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/axe-webdriverjs/-/axe-webdriverjs-0.2.0.tgz",
-      "integrity": "sha1-XjHtr26bozRCdiz9hd46B0c8EVU=",
-      "dev": true,
-      "requires": {
-        "axe-core": "1.1.1"
-      },
-      "dependencies": {
-        "axe-core": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-1.1.1.tgz",
-          "integrity": "sha1-rp2l2oq08QQZB/H12N/jnJRqksU=",
-          "dev": true
-        }
-      }
     },
     "babel-code-frame": {
       "version": "6.26.0",
@@ -12526,27 +12497,6 @@
         }
       }
     },
-    "protractor-accessibility-plugin": {
-      "version": "github:cfpb/protractor-accessibility-plugin#7319a881e222d9f3588f6d5d8a3d9848bc38c859",
-      "dev": true,
-      "requires": {
-        "accessibility-developer-tools": "2.12.0",
-        "axe-core": "2.6.1",
-        "axe-webdriverjs": "0.2.0",
-        "html-entities": "1.2.1",
-        "lodash": "3.10.1",
-        "q": "1.5.1",
-        "request": "2.81.0"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "3.10.1",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-          "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
-          "dev": true
-        }
-      }
-    },
     "protractor-cucumber-framework": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/protractor-cucumber-framework/-/protractor-cucumber-framework-4.2.0.tgz",
@@ -12569,6 +12519,11 @@
           }
         }
       }
+    },
+    "protractor-retry": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/protractor-retry/-/protractor-retry-1.1.9.tgz",
+      "integrity": "sha1-STowzLnMIl/BBwg2KuM2KFXrAPo="
     },
     "proxy-from-env": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "localtunnel": "1.8.3",
     "lodash.throttle": "4.1.1",
     "postcss-unmq": "1.0.2",
+    "protractor-retry": "1.1.9",
     "psi": "3.1.0",
     "require-dir": "1.0.0",
     "sauce-connect-tunnel": "0.2.1",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,6 @@
     "localtunnel": "1.8.3",
     "lodash.throttle": "4.1.1",
     "postcss-unmq": "1.0.2",
-    "protractor-retry": "1.1.9",
     "psi": "3.1.0",
     "require-dir": "1.0.0",
     "sauce-connect-tunnel": "0.2.1",
@@ -96,6 +95,7 @@
     "protractor": "5.3.0",
     "protractor-accessibility-plugin": "github:cfpb/protractor-accessibility-plugin#on-page-load",
     "protractor-cucumber-framework": "4.2.0",
+    "protractor-retry": "1.1.9",
     "selenium-webdriver": "3.6.0",
     "snyk": "1.70.2",
     "wcag": "0.3.0"

--- a/test/browser_tests/conf.js
+++ b/test/browser_tests/conf.js
@@ -258,7 +258,7 @@ const config = {
   onCleanUp:                results => retry.onCleanUp( results ),
   onPrepare:                _onPrepare,
   SELENIUM_PROMISE_MANAGER: false,
-  unknownFlags_:            [ 'cucumberOpts' ],
+  unknownFlags_:            [ 'cucumberOpts' ]
 };
 
 // Set Sauce Labs credientials from .env file.

--- a/test/browser_tests/conf.js
+++ b/test/browser_tests/conf.js
@@ -2,6 +2,8 @@ const environmentTest = require( './environment-test' );
 const envvars = require( '../../config/environment' ).envvars;
 const defaultSuites = require( './default-suites.js' );
 const minimist = require( 'minimist' );
+const retry = require( 'protractor-retry' ).retry;
+
 
 /**
  * Check whether a parameter value is set.
@@ -202,6 +204,7 @@ function _getMultiCapabilities() {
  * See https://github.com/angular/protractor/blob/master/docs/system-setup.md
  */
 function _onPrepare() {
+  retry.onPrepare();
   // Ignore Selenium allowances for non-angular sites.
   browser.ignoreSynchronization = true;
 
@@ -247,13 +250,15 @@ const config = {
     'profile':   false,
     'no-source': true
   },
-  unknownFlags_:            [ 'cucumberOpts' ],
+  afterLaunch:              () => retry.afterLaunch( 1 ),
   directConnect:            true,
   framework:                'custom',
   frameworkPath:            require.resolve( 'protractor-cucumber-framework' ),
   getMultiCapabilities:     _getMultiCapabilities,
+  onCleanUp:                results => retry.onCleanUp( results ),
   onPrepare:                _onPrepare,
-  SELENIUM_PROMISE_MANAGER: false
+  SELENIUM_PROMISE_MANAGER: false,
+  unknownFlags_:            [ 'cucumberOpts' ],
 };
 
 // Set Sauce Labs credientials from .env file.

--- a/test/browser_tests/cucumber/features/suites/default/pagination.feature
+++ b/test/browser_tests/cucumber/features/suites/default/pagination.feature
@@ -7,12 +7,10 @@ Feature: Pagination
   Background:
     Given I goto a browse filterable page
 
-  @skip
   Scenario: Navigate to the next page
     When I click on the next button
     Then the page url should contain "page=2"
 
-  @skip
   Scenario: Navigate to the previous page
     When I click on the next button
     And I click on the previous button again

--- a/tox.ini
+++ b/tox.ini
@@ -97,8 +97,6 @@ deps=
     missing-migrations: {[missing-migrations]deps}
 
 passenv=
-    fast:       {[unittest]passenv}
-    slow:       {[unittest]passenv}
     unittest:   {[unittest]passenv}
     acceptance: {[acceptance]passenv}
 
@@ -288,6 +286,17 @@ setenv=
     LANG=en_US.UTF-8
     LC_ALL=en_US.UTF-8
 commands={[acceptance]commands}
+
+
+[testenv:acceptance-recreate]
+recreate=True
+changedir={[testenv:acceptance]changedir}
+basepython={[testenv:acceptance]basepython}
+envdir={[testenv:acceptance]envdir}
+deps={[testenv:acceptance]deps}
+passenv={[acceptance]passenv}
+setenv={[testenv:acceptance]setenv}
+commands={[testenv:acceptance]commands}
 
 
 [testenv:validate-assets]

--- a/tox.ini
+++ b/tox.ini
@@ -97,6 +97,8 @@ deps=
     missing-migrations: {[missing-migrations]deps}
 
 passenv=
+    fast:       {[unittest]passenv}
+    slow:       {[unittest]passenv}
     unittest:   {[unittest]passenv}
     acceptance: {[acceptance]passenv}
 

--- a/tox.ini
+++ b/tox.ini
@@ -290,17 +290,6 @@ setenv=
 commands={[acceptance]commands}
 
 
-[testenv:acceptance-recreate]
-recreate=True
-changedir={[testenv:acceptance]changedir}
-basepython={[testenv:acceptance]basepython}
-envdir={[testenv:acceptance]envdir}
-deps={[testenv:acceptance]deps}
-passenv={[acceptance]passenv}
-setenv={[testenv:acceptance]setenv}
-commands={[testenv:acceptance]commands}
-
-
 [testenv:validate-assets]
 # Invoke with: tox -e validate-assets
 # Ensure all assets are generated without error.


### PR DESCRIPTION
Acceptance tests updates part deux

## Additions

- Adds `protractor-retry` to retry test failures.

## Changes

- Modifies `tox.ini` to add the ability to recreate the acceptance testing env when running gulp.

## Testing

1. Run `gulp test:acceptance` and ensure it works.
2. Run `gulp test:acceptance` --recreate and ensure it recreates the virtual environment.


## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Internet Explorer 8, 9, 10, and 11
- [ ] Edge
- [ ] iOS Safari
- [ ] Chrome for Android

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
