### PR TITLE
Updates scroll tracking analytics

### DIFF
--- a/cfgov/unprocessed/apps/analytics-gtm/js/event-listener-scroll-tracking.js
+++ b/cfgov/unprocessed/apps/analytics-gtm/js/event-listener-scroll-tracking.js
@@ -31,7 +31,7 @@ const startTime = new Date();
 const timeAtPageLoad = startTime.getTime();
 
 /**
- * @return {number} The number of seconds that have elapsed since the base time.
+ * @returns {number} Seconds that have elapsed since the page load time.
  */
 function getTimeStamp() {
   const currentTime = new Date();

--- a/cfgov/unprocessed/apps/analytics-gtm/js/event-listener-scroll-tracking.js
+++ b/cfgov/unprocessed/apps/analytics-gtm/js/event-listener-scroll-tracking.js
@@ -8,13 +8,7 @@ const readerLocation = 200;
 
 // Set some flags for tracking & execution.
 let timer = 0;
-let scroller = false;
-const didComplete = false;
-
-// Set some time variables to calculate reading time.
-const startTime = new Date();
-const beginning = startTime.getTime();
-const totalTime = 0;
+let hasStartScroll = false;
 
 /* Threshold of pixels at bottomPos when 100% triggers.
    For some reason some monitors were found to be a pixel off when scrolling to the bottomPos,
@@ -22,106 +16,89 @@ const totalTime = 0;
    so that it'll be 5px or less from the bottomPos. */
 const threshold = 5;
 
+const viewableHeight = window.innerHeight;
 const totalheight = document.body.offsetHeight - threshold;
+const totalHiddenHeight = totalheight - viewableHeight;
 
-// These will make sure the events only fire once.
-let hit25 = false;
-let hit50 = false;
-let hit75 = false;
-let hit100 = false;
+// This will record events so they only fire once.
+const hasFired = {};
 
-const y100 = totalheight; // End of page.
-const y25 = y100 * 0.25; // Breakpoint 25%.
-const y50 = y100 * 0.50; // Breakpoint 50%.
-const y75 = y100 * 0.75; // Breakpoint 75%.
+// This will store the y-position of the breakpoints at which to fire events.
+const yPosCache = {};
 
-// Check if the window is bigger than the scrollpoints.
-if ( y50 < window.innerHeight ) {
-  hit50 = true;
+// Set some time variables to calculate reading time.
+const startTime = new Date();
+const timeAtPageLoad = startTime.getTime();
+
+/**
+ * @return {number} The number of seconds that have elapsed since the base time.
+ */
+function getTimeStamp() {
+  const currentTime = new Date();
+  return Math.round( ( currentTime.getTime() - timeAtPageLoad ) / 1000 );
 }
 
-if ( y100 < window.innerHeight ) {
-  hit100 = true;
+/**
+ * [trackSpecificLocation description]
+ * @param {number} bottomPos -
+ *   Number of pixels from the top of the page to current scroll top position.
+ * @param {number} percent - Percent of the scrollable height to fire from.
+ */
+function trackSpecificLocation( bottomPos, percent ) {
+  let yPos = yPosCache[percent];
+
+  if ( !yPos ) {
+    const percentAsDecimal = percent / 100;
+    yPos = ( totalHiddenHeight * percentAsDecimal ) + viewableHeight;
+    yPosCache[percent] = yPos;
+  }
+
+  const hasFiredID = `hit${ percent }`;
+
+  if ( !hasFired[hasFiredID] && bottomPos >= yPos ) {
+    const timeToContentEnd = getTimeStamp();
+
+    window.dataLayer.push( {
+      event: 'scrollEvent',
+      scrollProgress: `${ percent }%`,
+      scrollTime: timeToContentEnd
+    } );
+    analyticsLog(
+      `Scrolled ${ percent }% of hidden height ` +
+      `${ timeToContentEnd }s after page load.`
+    );
+
+    hasFired[hasFiredID] = true;
+  }
 }
 
 // Check the location and track user
 function trackLocation() {
-  const bottomPos = window.innerHeight + document.body.scrollTop;
-  let currentTime;
-  let scrollStart;
-  let timeToScroll;
-  let contentScrollEnd;
-  let timeToContentEnd;
+  const bottomPos = viewableHeight + document.documentElement.scrollTop;
 
   // If user starts to scroll send an event, currently disabled
-  if ( bottomPos > readerLocation && !scroller ) {
-    currentTime = new Date();
-    scrollStart = currentTime.getTime();
-    timeToScroll = Math.round( ( scrollStart - beginning ) / 1000 );
+  if ( bottomPos > readerLocation && !hasStartScroll ) {
+    const timeToScroll = getTimeStamp();
 
     /* window.dataLayer.push({'event':'scrollEvent',
-       'scrollProgress':'start-scroll',
-       'scrollTime':timeToScroll}); */
-    analyticsLog( 'started scrolling ' + timeToScroll );
+       scrollProgress: 'start-scroll',
+       scrollTime: timeToScroll}); */
+    analyticsLog( `Started scrolling ${ timeToScroll }s after page load.` );
 
-    scroller = true;
+    hasStartScroll = true;
   }
-  // If user has hit 25%, currently disabled
-  if ( bottomPos >= y25 && hit25 === false ) {
-    currentTime = new Date();
-    contentScrollEnd = currentTime.getTime();
-    timeToContentEnd = Math.round( ( contentScrollEnd - scrollStart ) / 1000 );
 
-    /* window.dataLayer.push({'event':'scrollEvent',
-       'scrollProgress':'25%',
-       'scrollTime':timeToContentEnd}); */
-    analyticsLog( 'hit 25% ' + timeToContentEnd );
+  // If user has hit 25%, currently disabled.
+  // trackSpecificLocation( bottomPos, 25 );
 
-    hit25 = true;
-  }
-  // If user has hit 50%
-  if ( bottomPos >= y50 && hit50 === false ) {
-    currentTime = new Date();
-    contentScrollEnd = currentTime.getTime();
-    timeToContentEnd = Math.round( ( contentScrollEnd - scrollStart ) / 1000 );
+  // If user has hit 50%.
+  trackSpecificLocation( bottomPos, 50 );
 
-    window.dataLayer.push( {
-      event: 'scrollEvent',
-      scrollProgress: '50%',
-      scrollTime: timeToContentEnd
-    } );
-    analyticsLog( 'hit 50% ' + timeToContentEnd );
+  // If user has hit 75%, currently disabled.
+  // trackSpecificLocation( bottomPos, 75 );
 
-    hit50 = true;
-  }
-  // If user has hit 75%, currently disabled
-  if ( bottomPos >= y75 && hit75 === false ) {
-    currentTime = new Date();
-    contentScrollEnd = currentTime.getTime();
-    timeToContentEnd = Math.round( ( contentScrollEnd - scrollStart ) / 1000 );
-
-    /* window.dataLayer.push({'event':'scrollEvent',
-       'scrollProgress':'75%',
-       'scrollTime':timeToContentEnd}); */
-    analyticsLog( 'hit 75% ' + timeToContentEnd );
-
-    hit75 = true;
-  }
-  // If user has hit 100%
-  if ( bottomPos >= y100 && hit100 === false ) {
-    currentTime = new Date();
-    contentScrollEnd = currentTime.getTime();
-    timeToContentEnd = Math.round( ( contentScrollEnd - scrollStart ) / 1000 );
-
-    window.dataLayer.push( {
-      event: 'scrollEvent',
-      scrollProgress: '100%',
-      scrollTime: timeToContentEnd
-    } );
-    analyticsLog( 'hit 100% ' + timeToContentEnd );
-
-    hit100 = true;
-  }
+  // If user has hit 100%.
+  trackSpecificLocation( bottomPos, 100 );
 }
 
 // Track the scrolling and track location


### PR DESCRIPTION
Scroll tracking analytics had some deprecated code https://stackoverflow.com/questions/19635188/why-is-body-scrolltop-deprecated

It also could be condensed to reuse code via helper functions.

Additionally, it tracked total page height instead of a percentage of hidden page height, which would be the area that scrolls.

## Changes

- Consolidated code to allow function to track any percentage of page scrolling area.
- Changes reporting to show number of seconds since page load, not since start of scrolling.

## Testing

1. `gulp clean && gulp build`
2. Visit http://localhost:8000/about-us/blog/?debug-gtm=true and check the dev console and scroll.

## Screenshots

![screen shot 2018-04-04 at 5 19 58 pm](https://user-images.githubusercontent.com/704760/38335592-c96756de-382c-11e8-8402-f3b99b7fe2ab.png)

## Note:

Start of scroll is not currently reported. Should it be, @kelleyholden ?