### PR TITLE
BAH: Temporarily serve Sheer journey sources page

### DIFF
--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -617,6 +617,9 @@ FLAGS = {
     # To be enabled when journey pages are released in Wagtail.
     'OAH_JOURNEY': {},
 
+    # To be enabled while journey sources page is migrated to Wagtail.
+    'OAH_JOURNEY_SHEER_SOURCE_PAGE': {},
+
     # Google Optimize code snippets for A/B testing
     # When enabled this flag will add various Google Optimize code snippets.
     # Intended for use with path conditions.

--- a/cfgov/cfgov/urls.py
+++ b/cfgov/cfgov/urls.py
@@ -129,7 +129,10 @@ urlpatterns = [
         lambda req, path: SheerTemplateView.as_view(
             template_engine='owning-a-home',
             template_name='process/sources{}index.html'.format(path or '/')
-        )(req)
+        )(req),
+        fallback=lambda req, path: ServeView.as_view()(
+            req, 'owning-a-home/sources{}'.format(path or '/')
+        ),
     ),
     # END TODO
 

--- a/cfgov/cfgov/urls.py
+++ b/cfgov/cfgov/urls.py
@@ -122,6 +122,17 @@ urlpatterns = [
         name='mortgage-estimate'
     ),
 
+    # Temporarily serve sheer version of OAH Journey sources page.
+    # TODO: remove once page is migrated into Wagtail.
+    flagged_url('OAH_JOURNEY_SHEER_SOURCE_PAGE',
+        r'^owning-a-home/process/sources(?P<path>.*)$',
+        lambda req, path: SheerTemplateView.as_view(
+            template_engine='owning-a-home',
+            template_name='process/sources{}index.html'.format(path or '/')
+        )(req)
+    ),
+    # END TODO
+
     # Temporarily serve Wagtail OAH journey pages at `/process/` urls.
     # TODO: change to redirects after 2018 homebuying campaign.
     flagged_url('OAH_JOURNEY', r'^owning-a-home/process/(?P<path>.*)$',


### PR DESCRIPTION
The Journey sources page is still being migrated to Wagtail, so this adds a flagged route to temporarily serve the Sheer version.

## Additions

- Flag & flagged route for sources page

## Testing

1. Turn on `OAH_JOURNEY_SHEER_SOURCE_PAGE` flag and verify that Sheer version of sources page is served.




## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Internet Explorer 8, 9, 10, and 11
- [ ] Edge
- [ ] iOS Safari
- [ ] Chrome for Android

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
