### PR TITLE
Fail frontend.sh script if not using Node 8

### DIFF
--- a/frontend.sh
+++ b/frontend.sh
@@ -22,6 +22,7 @@ init() {
 
   if [[ "$(node -v)" != 'v8.'* ]]; then
     printf "\033[1;31mPlease install Node 8.x: 'nvm install 8'\033[0m\n"
+    exit 1;
   fi
 
   NODE_DIR=node_modules


### PR DESCRIPTION
This change modifies the frontend.sh script so that instead of only warning if a version of Node besides 8 is being used, it fails.

This behavior was originally introduced as a failure in #3177 but then removed in #3178 due to Jenkins version incompatibility. Jenkins is now properly using Node 8 so this can be changed back to a failure.

If a user isn't using Node 8, there's no point in continuing the script, as the build will fail.

## Testing

1. `nvm use 6 && ./frontend.sh` - should fail.
1. `nvm use 8 && ./frontend.sh` - should work.

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [X] Passes all existing automated tests
- [X] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Internet Explorer 8, 9, 10, and 11
- [ ] Edge
- [ ] iOS Safari
- [ ] Chrome for Android

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
