### PR TITLE
Make ask_cfpb tests compatible with PostgreSQL

### DIFF
--- a/cfgov/ask_cfpb/tests/test_hooks.py
+++ b/cfgov/ask_cfpb/tests/test_hooks.py
@@ -34,14 +34,13 @@ class TestAskHooks(TestCase):
         mock_admin = mock.Mock()
         mock_admin.is_page = True
         mock_admin.model = Answer
-        mock_answer = Answer()
-        mock_answer.save()
+        mock_answer = Answer.objects.create(id=98765)
         mock_user = User(username='Goliath')
         mock_user.save()
         mock_request = HttpRequest()
         mock_request.user = mock_user
         mock_request.method = "GET"
-        mock_edit_view = AnswerModelAdminSaveUserEditView(mock_admin, '1')
+        mock_edit_view = AnswerModelAdminSaveUserEditView(mock_admin, '98765')
         mock_edit_view.request = mock_request
         mock_edit_view.instance = mock_answer
         mock_edit_view.dispatch(mock_request)


### PR DESCRIPTION
This change fixes two `ask_cfpb` Python unit tests that were failing when being run against a Postgres database. In both cases this seems to be due to differences in how predictable model IDs are when generated by Model Mommy - when using SQLite this seems to reliably start at 1 but with Postgres that isn't predictable.

At a high level these tests were failing because they were testing an assumed model ID instead of explicitly setting it in the test.

@richaagarwal and I paired on this; we broke up `AnswerModelTestCase.test_facet_map` into three smaller tests that more explicitly test a single piece of functionality and rely less on common setup being done in the test case `setUp`.

## Testing

To validate these changes against a local Postgres DB:

```sh
$ DATABASE_URL=postgres://user@localhost/db tox -e fast
```

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [X] Passes all existing automated tests
- [X] Any _change_ in functionality is tested
- [X] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: