### PR TITLE
owning-a-home: Adds rel="noopener noreferrer" to targets

### DIFF
--- a/cfgov/jinja2/v1/_includes/molecules/social-media.html
+++ b/cfgov/jinja2/v1/_includes/molecules/social-media.html
@@ -131,7 +131,7 @@
                 <li class="m-list_item">
                     <a class="m-social-media_icon"
                        href="{{ link.share_url if link.name != 'email' else link.share_url | trim }}"
-                       {{ 'target=_blank' if link.name != 'email' else '' }}>
+                       {{ 'target="_blank" rel="noopener noreferrer"' if link.name != 'email' else '' }}>
                         <span class="cf-icon {{ link.class }}"></span>
                         <span class="u-visually-hidden">Share on {{ link.name }}</span>
                     </a>

--- a/cfgov/jinja2/v1/owning-a-home/_templates/social-media.html
+++ b/cfgov/jinja2/v1/owning-a-home/_templates/social-media.html
@@ -131,7 +131,7 @@
                 <li class="m-list_item">
                     <a class="m-social-media_icon"
                        href="{{ link.share_url if link.name != 'email' else link.share_url | trim }}"
-                       {{ 'target=_blank' if link.name != 'email' else '' }}>
+                       {{ 'target="_blank" rel="noopener noreferrer"' if link.name != 'email' else '' }}>
                         <span class="cf-icon {{ link.class }}"></span>
                         <span class="u-visually-hidden">Share on {{ link.name }}</span>
                     </a>

--- a/cfgov/jinja2/v1/owning-a-home/closing-disclosure/closing-disclosure-1-data.html
+++ b/cfgov/jinja2/v1/owning-a-home/closing-disclosure/closing-disclosure-1-data.html
@@ -36,7 +36,7 @@
         },
         {
             "term": "Check your interest rate",
-            "definition": "<p>If your interest rate isn't what you were expecting, ask your lender why. If you locked your rate, your lender is only allowed to change it under limited circumstances.</p><p><a href=\"/askcfpb/143/whats-a-lock-in-or-a-rate-lock.html\" target=\"_blank\">Learn more about rate locks</a></p>",
+            "definition": "<p>If your interest rate isn't what you were expecting, ask your lender why. If you locked your rate, your lender is only allowed to change it under limited circumstances.</p><p><a href=\"/askcfpb/143/whats-a-lock-in-or-a-rate-lock.html\" target=\"_blank\" rel=\"noopener noreferrer\">Learn more about rate locks</a></p>",
             "id": "interest-rate",
             "category": "checklist",
             "left": "5.96%",
@@ -46,7 +46,7 @@
         },
         {
             "term": "Monthly Principal & Interest",
-            "definition": "<p>Principal (the amount you will borrow) and interest (the lender's charge for lending you money) usually make up the main components of your monthly mortgage payment.</p><p>Your total monthly payment will typically be more than this amount due to taxes and insurance. See the Estimated Total Monthly Payment.</p><p><a href=\"/askcfpb/1941/on-a-mortgage-whats-the-difference-between-my-principal-and-interest-payment-and-my-total-monthly-payment.html\" target=\"_blank\">Learn about the difference between the principal & interest payment and the total monthly payment</a></p>",
+            "definition": "<p>Principal (the amount you will borrow) and interest (the lender's charge for lending you money) usually make up the main components of your monthly mortgage payment.</p><p>Your total monthly payment will typically be more than this amount due to taxes and insurance. See the Estimated Total Monthly Payment.</p><p><a href=\"/askcfpb/1941/on-a-mortgage-whats-the-difference-between-my-principal-and-interest-payment-and-my-total-monthly-payment.html\" target=\"_blank\" rel=\"noopener noreferrer\">Learn about the difference between the principal & interest payment and the total monthly payment</a></p>",
             "id": "monthly-principle-interest",
             "category": "definitions",
             "left": "5.96%",
@@ -56,7 +56,7 @@
         },
         {
             "term": "Does your loan have a prepayment penalty?",
-            "definition": "<p>This feature is risky. If your loan includes a prepayment penalty, learn more and ask your lender about your other options.</p><p><a href=\"/askcfpb/1957/what-is-a-prepayment-penalty.html\" target=\"_blank\">Learn more about prepayment penalties</a></p>",
+            "definition": "<p>This feature is risky. If your loan includes a prepayment penalty, learn more and ask your lender about your other options.</p><p><a href=\"/askcfpb/1957/what-is-a-prepayment-penalty.html\" target=\"_blank\" rel=\"noopener noreferrer\">Learn more about prepayment penalties</a></p>",
             "id": "prepayment-penalty",
             "category": "checklist",
             "left": "5.96%",
@@ -66,7 +66,7 @@
         },
         {
             "term": "Does your loan have a balloon payment?",
-            "definition": "<p>This feature is risky. If your loan includes a balloon payment, learn more and ask your lender about your other options.</p> <p><a href=\"/askcfpb/104/what-is-a-balloon-loan.html\" target=\"_blank\">Learn more about balloon payments</a></p>",
+            "definition": "<p>This feature is risky. If your loan includes a balloon payment, learn more and ask your lender about your other options.</p> <p><a href=\"/askcfpb/104/what-is-a-balloon-loan.html\" target=\"_blank\" rel=\"noopener noreferrer\">Learn more about balloon payments</a></p>",
             "id": "balloon-payment",
             "category": "checklist",
             "left": "5.96%",
@@ -76,7 +76,7 @@
         },
         {
             "term": "Prepayment Penalty",
-            "definition": "<p>A feature on some mortgages. A prepayment penalty means that the lender can charge you a fee if you pay off your mortgage early.</p><p><a href=\"/askcfpb/1957/what-is-a-prepayment-penalty.html\" target=\"_blank\">Learn more</a></p>",
+            "definition": "<p>A feature on some mortgages. A prepayment penalty means that the lender can charge you a fee if you pay off your mortgage early.</p><p><a href=\"/askcfpb/1957/what-is-a-prepayment-penalty.html\" target=\"_blank\" rel=\"noopener noreferrer\">Learn more</a></p>",
             "id": "prepayment-penalty",
             "category": "definitions",
             "left": "5.96%",
@@ -86,7 +86,7 @@
         },
         {
             "term": "Balloon Payment",
-            "definition": "<p>A feature on some mortgages. A balloon payment means that the final mortgage payment is a lump sum much larger than the regular monthly payments, often tens of thousands of dollars.</p><p><a href=\"/askcfpb/104/what-is-a-balloon-loan.html\" target=\"_blank\">Learn more</a></p>",
+            "definition": "<p>A feature on some mortgages. A balloon payment means that the final mortgage payment is a lump sum much larger than the regular monthly payments, often tens of thousands of dollars.</p><p><a href=\"/askcfpb/104/what-is-a-balloon-loan.html\" target=\"_blank\" rel=\"noopener noreferrer\">Learn more</a></p>",
             "id": "balloon-payment",
             "category": "definitions",
             "left": "5.96%",
@@ -96,7 +96,7 @@
         },
         {
             "term": "Principal & Interest",
-            "definition": "<p>Principal is the amount you will borrow.<br>Interest is the lender's charge for lending you money.</p><p><a href=\"/askcfpb/1943/how-does-paying-down-a-mortgage-work.html\" target=\"_blank\">Learn more</a></p>",
+            "definition": "<p>Principal is the amount you will borrow.<br>Interest is the lender's charge for lending you money.</p><p><a href=\"/askcfpb/1943/how-does-paying-down-a-mortgage-work.html\" target=\"_blank\" rel=\"noopener noreferrer\">Learn more</a></p>",
             "id": "principle-interest",
             "category": "definitions",
             "left": "5.96%",
@@ -106,7 +106,7 @@
         },
         {
             "term": "Mortgage Insurance",
-            "definition": "<p>Mortgage insurance is typically required if your down payment is less than 20 percent of the price of the home.</p><p><a href=\"/askcfpb/1953/what-is-mortgage-insurance-and-how-does-it-work.html\" target=\"_blank\">Learn more</a></p>",
+            "definition": "<p>Mortgage insurance is typically required if your down payment is less than 20 percent of the price of the home.</p><p><a href=\"/askcfpb/1953/what-is-mortgage-insurance-and-how-does-it-work.html\" target=\"_blank\" rel=\"noopener noreferrer\">Learn more</a></p>",
             "id": "mortgage-insurance",
             "category": "definitions",
             "left": "5.96%",
@@ -116,7 +116,7 @@
         },
         {
             "term": "Estimated Escrow",
-            "definition": "<p>Additional charges related to homeownership, such as property taxes and homeowners' insurance, that are bundled in your monthly payment.</p><p><a href=\"/askcfpb/140/what-is-an-escrow-or-impound-account.html\" target=\"_blank\">Learn more</a></p>",
+            "definition": "<p>Additional charges related to homeownership, such as property taxes and homeowners' insurance, that are bundled in your monthly payment.</p><p><a href=\"/askcfpb/140/what-is-an-escrow-or-impound-account.html\" target=\"_blank\" rel=\"noopener noreferrer\">Learn more</a></p>",
             "id": "estimated-escrow",
             "category": "definitions",
             "left": "5.96%",
@@ -126,7 +126,7 @@
         },
         {
             "term": "Estimated Total Monthly Payment",
-            "definition": "<p>The total payment you will make each month, including <a href=\"/askcfpb/1953/what-is-mortgage-insurance-and-how-does-it-work.html\" target=\"_blank\">mortgage insurance</a> and <a href=\"/askcfpb/140/what-is-an-escrow-or-impound-account.html\" target=\"_blank\">escrow</a>, if applicable.</p><p><a href=\"/askcfpb/1941/on-a-mortgage-whats-the-difference-between-my-principal-and-interest-payment-and-my-total-monthly-payment.html\" target=\"_blank\">Learn more</a></p>",
+            "definition": "<p>The total payment you will make each month, including <a href=\"/askcfpb/1953/what-is-mortgage-insurance-and-how-does-it-work.html\" target=\"_blank\" rel=\"noopener noreferrer\">mortgage insurance</a> and <a href=\"/askcfpb/140/what-is-an-escrow-or-impound-account.html\" target=\"_blank\" rel=\"noopener noreferrer\">escrow</a>, if applicable.</p><p><a href=\"/askcfpb/1941/on-a-mortgage-whats-the-difference-between-my-principal-and-interest-payment-and-my-total-monthly-payment.html\" target=\"_blank\" rel=\"noopener noreferrer\">Learn more</a></p>",
             "id": "estimated-total-monthly",
             "category": "definitions",
             "left": "5.96%",
@@ -146,7 +146,7 @@
         },
         {
             "term": "Check to see if you have items in Estimated Taxes, Insurance & Assessments that are not in escrow",
-            "definition": "<p>If so, have you budgeted to pay for these costs separately?</p><p><a href=\"/askcfpb/140/what-is-an-escrow-or-impound-account.html\" target=\"_blank\">Learn more about what escrow is and how it works</a></p>",
+            "definition": "<p>If so, have you budgeted to pay for these costs separately?</p><p><a href=\"/askcfpb/140/what-is-an-escrow-or-impound-account.html\" target=\"_blank\" rel=\"noopener noreferrer\">Learn more about what escrow is and how it works</a></p>",
             "id": "estimated-taxes",
             "category": "checklist",
             "left": "5.96%",

--- a/cfgov/jinja2/v1/owning-a-home/closing-disclosure/closing-disclosure-2-data.html
+++ b/cfgov/jinja2/v1/owning-a-home/closing-disclosure/closing-disclosure-2-data.html
@@ -25,7 +25,7 @@
         },
         {
             "term": "Points",
-            "definition": "<p>An upfront fee that you pay to your lender in exchange for a lower interest rate than you would pay otherwise.</p><p><a href=\"/askcfpb/136/what-are-discount-points-or-points.html\" target=\"_blank\">Learn more</a></p>",
+            "definition": "<p>An upfront fee that you pay to your lender in exchange for a lower interest rate than you would pay otherwise.</p><p><a href=\"/askcfpb/136/what-are-discount-points-or-points.html\" target=\"_blank\" rel=\"noopener noreferrer\">Learn more</a></p>",
             "id": "points",
             "category": "definitions",
             "left": "5.96%",
@@ -35,7 +35,7 @@
         },
         {
             "term": "Check that “Services Borrower Did Not Shop For” are similar to what was shown on your Loan Estimate",
-            "definition": "<p>These are third-party services required by your lender in order to get a loan. Compare with Section B, “Services You Cannot Shop For” and Section C, “Services You Can Shop For” on page 2 of your Loan Estimate form. Check to see that, overall, there are no new services listed that were not on your Loan Estimate form. The costs should be similar, but may be somewhat different from what was on your Loan Estimate form.</p><p><a href=\"/askcfpb/172/can-the-final-mortgage-costs-be-different-from-the-good-faith-estimate-gfe.html\" target=\"_blank\">Learn more about when these costs are allowed to change between Loan Estimate and closing</a></p><p>Compare to page 2 of your Loan Estimate</p>",
+            "definition": "<p>These are third-party services required by your lender in order to get a loan. Compare with Section B, “Services You Cannot Shop For” and Section C, “Services You Can Shop For” on page 2 of your Loan Estimate form. Check to see that, overall, there are no new services listed that were not on your Loan Estimate form. The costs should be similar, but may be somewhat different from what was on your Loan Estimate form.</p><p><a href=\"/askcfpb/172/can-the-final-mortgage-costs-be-different-from-the-good-faith-estimate-gfe.html\" target=\"_blank\" rel=\"noopener noreferrer\">Learn more about when these costs are allowed to change between Loan Estimate and closing</a></p><p>Compare to page 2 of your Loan Estimate</p>",
             "highlight": url_for('static', filename='img/services-not-shopped-for-highlight.png'),
             "id": "services-did-not-shop",
             "category": "checklist",
@@ -76,7 +76,7 @@
         },
         {
             "term": "Initial Escrow Payment at Closing",
-            "definition": "<p>This payment will establish an initial balance in your escrow account.</p><p><a href=\"/askcfpb/160/what-is-an-initial-escrow-deposit.html\" target=\"_blank\">Learn more</a></p>",
+            "definition": "<p>This payment will establish an initial balance in your escrow account.</p><p><a href=\"/askcfpb/160/what-is-an-initial-escrow-deposit.html\" target=\"_blank\" rel=\"noopener noreferrer\">Learn more</a></p>",
             "id": "initial-escrow-payment",
             "category": "definitions",
             "left": "5.96%",
@@ -106,7 +106,7 @@
         },
         {
             "term": "Lender Credits",
-            "definition": "<p>A rebate from your lender that offsets some of your closing costs. Lender credits are typically provided in exchange for a higher interest rate than you would have paid otherwise. Learn about lender credits.</p><p><a href=\"/askcfpb/136/what-are-discount-points-or-points.html\" target=\"_blank\">Learn more</a></p>",
+            "definition": "<p>A rebate from your lender that offsets some of your closing costs. Lender credits are typically provided in exchange for a higher interest rate than you would have paid otherwise. Learn about lender credits.</p><p><a href=\"/askcfpb/136/what-are-discount-points-or-points.html\" target=\"_blank\" rel=\"noopener noreferrer\">Learn more</a></p>",
             "id": "lender-credits",
             "category": "definitions",
             "left": "5.96%",

--- a/cfgov/jinja2/v1/owning-a-home/closing-disclosure/closing-disclosure-4-data.html
+++ b/cfgov/jinja2/v1/owning-a-home/closing-disclosure/closing-disclosure-4-data.html
@@ -26,7 +26,7 @@
         },
         {
             "term": "Will you have an escrow account?",
-            "definition": "<p>Many homeowners pay their property taxes and homeowner’s insurance as part of their monthly payment. This arrangement is called an <a href=\"/askcfpb/140/what-is-an-escrow-or-impound-account.html \" target=\"_blank\">escrow account</a>. This section tells you: whether you have an escrow account, which homeownership expenses are included in the escrow account, and the estimated costs. Ask questions so you understand exactly what is included in the escrow account and what isn’t. For example, homeowner’s association fees are often not included in the escrow account. </p><p>If your Closing Disclosure shows that you don’t have an escrow account, but you would prefer to pay your property taxes and homeowner’s insurance monthly instead of in one large lump sum, talk to the lender.</p>",
+            "definition": "<p>Many homeowners pay their property taxes and homeowner’s insurance as part of their monthly payment. This arrangement is called an <a href=\"/askcfpb/140/what-is-an-escrow-or-impound-account.html \" target=\"_blank\" rel=\"noopener noreferrer\">escrow account</a>. This section tells you: whether you have an escrow account, which homeownership expenses are included in the escrow account, and the estimated costs. Ask questions so you understand exactly what is included in the escrow account and what isn’t. For example, homeowner’s association fees are often not included in the escrow account. </p><p>If your Closing Disclosure shows that you don’t have an escrow account, but you would prefer to pay your property taxes and homeowner’s insurance monthly instead of in one large lump sum, talk to the lender.</p>",
             "id": "escrow-acc",
             "category": "checklist",
             "left": "50.78%",
@@ -36,7 +36,7 @@
         },
         {
             "term": "If you do not have an escrow account, are you paying an escrow waiver fee to the lender?",
-            "definition": "<p>Some lenders may charge a fee if you choose not to have an <a href=\"/askcfpb/140/what-is-an-escrow-or-impound-account.html \" target=\"_blank\">escrow account</a>. Did you discuss this choice with your lender? If your Closing Disclosure shows an escrow waiver fee and you would prefer to pay your property taxes and homeowner’s insurance monthly into an escrow account instead of paying this fee, talk to the lender.</p>",
+            "definition": "<p>Some lenders may charge a fee if you choose not to have an <a href=\"/askcfpb/140/what-is-an-escrow-or-impound-account.html \" target=\"_blank\" rel=\"noopener noreferrer\">escrow account</a>. Did you discuss this choice with your lender? If your Closing Disclosure shows an escrow waiver fee and you would prefer to pay your property taxes and homeowner’s insurance monthly into an escrow account instead of paying this fee, talk to the lender.</p>",
             "id": "escrow-waiver",
             "category": "checklist",
             "left": "51.50%",
@@ -56,7 +56,7 @@
         },
         {
             "term": "Demand Feature",
-            "definition": "<p>A demand feature allows the lender to demand immediate payment of the entire loan at any time.</p><p><a href=\"/askcfpb/1997/what-is-a-demand-feature-what-does-it-mean-if-it-is-checked-off-on-my-closing-disclosure.html\" target=\"_blank\">Learn more about demand features and what you need to know if your loan has one</a></p>",
+            "definition": "<p>A demand feature allows the lender to demand immediate payment of the entire loan at any time.</p><p><a href=\"/askcfpb/1997/what-is-a-demand-feature-what-does-it-mean-if-it-is-checked-off-on-my-closing-disclosure.html\" target=\"_blank\" rel=\"noopener noreferrer\">Learn more about demand features and what you need to know if your loan has one</a></p>",
             "id": "demand-feature",
             "category": "definitions",
             "left": "5.11%",
@@ -66,7 +66,7 @@
         },
         {
             "term": "Negative Amortization",
-            "definition": "<p>Negative amortization means your loan balance can increase even if you make your payments on time and in full. Most loans do not have negative amortization.</p><p><a href=\"/askcfpb/103/what-is-negative-amortization.html\" target=\"_blank\">Learn more about negative amortization</a></p>",
+            "definition": "<p>Negative amortization means your loan balance can increase even if you make your payments on time and in full. Most loans do not have negative amortization.</p><p><a href=\"/askcfpb/103/what-is-negative-amortization.html\" target=\"_blank\" rel=\"noopener noreferrer\">Learn more about negative amortization</a></p>",
             "id": "negative-amortization",
             "category": "definitions",
             "left": "5.11%",
@@ -76,7 +76,7 @@
         },
         {
             "term": "Security Interest",
-            "definition": "<p>The security interest allows the lender to foreclose on your home if you don’t pay back the money you borrowed.</p><p><a href=\"/askcfpb/1999/my-mortgage-closing-forms-mention-a-security-interest-what-does-that-mean.html\" target=\"_blank\">Learn more about a security interest and why it is important</a></p>",
+            "definition": "<p>The security interest allows the lender to foreclose on your home if you don’t pay back the money you borrowed.</p><p><a href=\"/askcfpb/1999/my-mortgage-closing-forms-mention-a-security-interest-what-does-that-mean.html\" target=\"_blank\" rel=\"noopener noreferrer\">Learn more about a security interest and why it is important</a></p>",
             "id": "security-interest",
             "category": "definitions",
             "left": "5.11%",
@@ -86,7 +86,7 @@
         },
         {
             "term": "Escrow Account",
-            "definition": "<p>An escrow account lets you pay your homeowner’s insurance and property taxes monthly as part of your mortgage payment, instead of in a large lump sum.</p><p><a href=\"/askcfpb/140/what-is-an-escrow-or-impound-account.html\" target=\"_blank\">Learn more about escrow accounts and how they work</a></p>",
+            "definition": "<p>An escrow account lets you pay your homeowner’s insurance and property taxes monthly as part of your mortgage payment, instead of in a large lump sum.</p><p><a href=\"/askcfpb/140/what-is-an-escrow-or-impound-account.html\" target=\"_blank\" rel=\"noopener noreferrer\">Learn more about escrow accounts and how they work</a></p>",
             "id": "escrow-account",
             "category": "definitions",
             "left": "50.78%",

--- a/cfgov/jinja2/v1/owning-a-home/explore-rates/index.html
+++ b/cfgov/jinja2/v1/owning-a-home/explore-rates/index.html
@@ -109,7 +109,7 @@ home price, down payment, and more can affect mortgage interest rates.
                               </p>
                             </div>
                         </div>
-                        <p class="form-sub">Credit score has a big impact on the rate you’ll receive. <a href="/askcfpb/319/how-does-my-credit-score-affect-my-ability-to-get-a-mortgage-loan.html" id="ask-cfpb-credit" target="_blank">Learn more</a></p>
+                        <p class="form-sub">Credit score has a big impact on the rate you’ll receive. <a href="/askcfpb/319/how-does-my-credit-score-affect-my-ability-to-get-a-mortgage-loan.html" id="ask-cfpb-credit" target="_blank" rel="noopener noreferrer">Learn more</a></p>
                     </section>
                     <section class="demographics">
                         <div class="state-col">
@@ -281,10 +281,10 @@ home price, down payment, and more can affect mortgage interest rates.
                         <p class="warning-text"></p>
                     </section>
                     <section class="form-sub calc-subsection">
-                        <p><a href="../loan-options/" target="_blank">Learn about loan term, rate type, and loan type</a></p>
+                        <p><a href="../loan-options/" target="_blank" rel="noopener noreferrer">Learn about loan term, rate type, and loan type</a></p>
                     </section>
                     <section class="calc-footer form-sub">
-                        <p>This tool assumes you want to purchase a single family house to be your primary residence. The rates quoted assume -0.5 to 0.5 <a id="ask-discount-points" href="/askcfpb/136/what-are-discount-points-or-points.html" target="_blank">discount points</a> and a 60-day <a id="ask-rate-lock" href="/askcfpb/143/whats-a-lock-in-or-a-rate-lock.html" target="_blank">rate lock</a>.</p>
+                        <p>This tool assumes you want to purchase a single family house to be your primary residence. The rates quoted assume -0.5 to 0.5 <a id="ask-discount-points" href="/askcfpb/136/what-are-discount-points-or-points.html" target="_blank" rel="noopener noreferrer">discount points</a> and a 60-day <a id="ask-rate-lock" href="/askcfpb/143/whats-a-lock-in-or-a-rate-lock.html" target="_blank" rel="noopener noreferrer">rate lock</a>.</p>
                     </section>
                 </div>
                 <!-- END .calculator -->
@@ -375,7 +375,7 @@ home price, down payment, and more can affect mortgage interest rates.
                             </div>
                             <!-- /.select-content-->
                             <div class="rc-comp-5 mobi-no">
-                                <p>Interest is only one of many costs associated with getting a mortgage. <a href="/askcfpb/153/what-costs-will-i-have-to-pay-as-part-of-taking-out-a-mortgage-loan.html" class="go-link" target="_blank">Learn more</a></p>
+                                <p>Interest is only one of many costs associated with getting a mortgage. <a href="/askcfpb/153/what-costs-will-i-have-to-pay-as-part-of-taking-out-a-mortgage-loan.html" class="go-link" target="_blank" rel="noopener noreferrer">Learn more</a></p>
                             </div>
                         </div>
                         <!-- /.rate-selects -->
@@ -419,7 +419,7 @@ home price, down payment, and more can affect mortgage interest rates.
                                 <!-- /.wrapper -->
                             </div>
                             <!-- /.rc-comparison-subsection -->
-                            <p class="mobi-yes l-bump">Interest is only one of many costs associated with getting a mortgage. <a href="/askcfpb/153/what-costs-will-i-have-to-pay-as-part-of-taking-out-a-mortgage-loan.html" class="go-link" target="_blank">Learn more</a></p>
+                            <p class="mobi-yes l-bump">Interest is only one of many costs associated with getting a mortgage. <a href="/askcfpb/153/what-costs-will-i-have-to-pay-as-part-of-taking-out-a-mortgage-loan.html" class="go-link" target="_blank" rel="noopener noreferrer">Learn more</a></p>
                         </div>
                         <!-- /.rc-comparison-section -->
                     </section>
@@ -449,11 +449,11 @@ home price, down payment, and more can affect mortgage interest rates.
                         <ol class="next-steps-list">
                             <li>
                                 <h4 class="next-steps-heading">Shop around.</h4>
-                                <p>Get quotes from three or more lenders so you can see how they compare. Rates often change from when you first talk to a lender and when you submit your mortgage application, so don’t make a final decision before comparing official <a id="ask-gfe" href="/askcfpb/1995/what-is-a-loan-estimate.html" target="_blank">Loan Estimates</a>.</p>
+                                <p>Get quotes from three or more lenders so you can see how they compare. Rates often change from when you first talk to a lender and when you submit your mortgage application, so don’t make a final decision before comparing official <a id="ask-gfe" href="/askcfpb/1995/what-is-a-loan-estimate.html" target="_blank" rel="noopener noreferrer">Loan Estimates</a>.</p>
                             </li>
                             <li>
                                 <h4 class="next-steps-heading">Consider all your options.</h4>
-                                <p>Make sure you’re getting the <a href="../loan-options/" target="_blank">kind of loan</a> that makes the most sense for you. If more than one kind of loan might make sense, ask lenders to give you quotes for each kind so you can compare. Once you’ve chosen a kind of loan, compare prices by getting quotes for the same kind of loan.</p>
+                                <p>Make sure you’re getting the <a href="../loan-options/" target="_blank" rel="noopener noreferrer">kind of loan</a> that makes the most sense for you. If more than one kind of loan might make sense, ask lenders to give you quotes for each kind so you can compare. Once you’ve chosen a kind of loan, compare prices by getting quotes for the same kind of loan.</p>
                             </li>
                             <li>
                                 <h4 class="next-steps-heading">Negotiate.</h4>
@@ -474,7 +474,8 @@ home price, down payment, and more can affect mortgage interest rates.
                                               cf-icon__after
                                               cf-icon-right"
                                         href="/askcfpb/315/what-is-my-credit-score.html"
-                                        target="_blank">
+                                        target="_blank"
+                                        rel="noopener noreferrer">
                                     <span class="a-link_text">Learn more about credit scores</span>
                                     </a>
                                 </p>
@@ -490,7 +491,8 @@ home price, down payment, and more can affect mortgage interest rates.
                                               cf-icon__after
                                               cf-icon-right"
                                        href="/askcfpb/318/how-do-i-get-and-keep-a-good-credit-score.html"
-                                       target="_blank">
+                                       target="_blank"
+                                       rel="noopener noreferrer">
                                         <span class="a-link_text">Learn about improving your credit scores</span>
                                     </a>
                                 </p>
@@ -506,7 +508,8 @@ home price, down payment, and more can affect mortgage interest rates.
                                               cf-icon__after
                                               cf-icon-right"
                                         href="/askcfpb/120/what-kind-of-down-payment-do-i-need-how-does-the-amount-of-down-payment-i-make-affect-the-terms-of-my-mortgage-loan.html"
-                                        target="_blank">
+                                        target="_blank"
+                                        rel="noopener noreferrer">
                                         <span class="a-link_text">Learn more about down payments</span>
                                     </a>
                                 </p>
@@ -516,7 +519,7 @@ home price, down payment, and more can affect mortgage interest rates.
                 </section>
                 <!-- /.next-steps -->
                 <div class="note">
-                    <p class="alert"><strong>Check your credit report.</strong> If you haven’t <a id="annualcreditreport" class="external-link" href="http://annualcreditreport.com" target="_blank">checked your credit report recently</a>, do so now. If you find errors, <a id="ask-dispute-credit-report" href="/askcfpb/314/how-do-i-dispute-an-error-on-my-credit-report.html" target="_blank">get them corrected</a> <strong>before</strong> you apply for a mortgage.</p>
+                    <p class="alert"><strong>Check your credit report.</strong> If you haven’t <a id="annualcreditreport" class="external-link" href="http://annualcreditreport.com" target="_blank" rel="noopener noreferrer">checked your credit report recently</a>, do so now. If you find errors, <a id="ask-dispute-credit-report" href="/askcfpb/314/how-do-i-dispute-an-error-on-my-credit-report.html" target="_blank" rel="noopener noreferrer">get them corrected</a> <strong>before</strong> you apply for a mortgage.</p>
                 </div> <!-- /.note -->
                 <section id="about" class="about wrapper">
                     <div class="content-l">
@@ -530,7 +533,7 @@ home price, down payment, and more can affect mortgage interest rates.
                                         block__flush-top">
                             <h3 class="subhead">About this tool</h3>
                             <p>The lenders in our data include a mix of large banks, regional banks, and credit unions. The data is updated semiweekly every Wednesday and Friday at 7 a.m. In the event of a holiday, data will be refreshed on the next available business day.</p>
-                            <p>The data is provided by Informa Research Services, Inc., Calabasas, CA. <a id="informars" href="http://www.informars.com" target="_blank"  >www.informars.com</a>. Informa collects the data directly from lenders and every effort is made to collect the most accurate data possible, but they cannot guarantee the data’s accuracy.</p>
+                            <p>The data is provided by Informa Research Services, Inc., Calabasas, CA. <a id="informars" href="http://www.informars.com" target="_blank" rel="noopener noreferrer">www.informars.com</a>. Informa collects the data directly from lenders and every effort is made to collect the most accurate data possible, but they cannot guarantee the data’s accuracy.</p>
                             </div>
                         </div>
                     </div>

--- a/cfgov/jinja2/v1/owning-a-home/loan-estimate/loan-estimate-1-data.html
+++ b/cfgov/jinja2/v1/owning-a-home/loan-estimate/loan-estimate-1-data.html
@@ -25,7 +25,7 @@
     },
     {
         "term": "Is your rate locked?",
-        "definition": "<p>Some lenders may lock your rate as part of issuing the Loan Estimate, but some may not.</p><p><a href=\"/askcfpb/143/whats-a-lock-in-or-a-rate-lock.html\" target=\"_blank\">Learn more about what a rate lock is and how it works</a></p>",
+        "definition": "<p>Some lenders may lock your rate as part of issuing the Loan Estimate, but some may not.</p><p><a href=\"/askcfpb/143/whats-a-lock-in-or-a-rate-lock.html\" target=\"_blank\" rel=\"noopener noreferrer\">Learn more about what a rate lock is and how it works</a></p>",
         "id": "rate-locked",
         "category": "checklist",
         "left": "47.09%",
@@ -45,7 +45,7 @@
     },
     {
         "term": "Is your interest rate fixed or adjustable?",
-        "definition": "<p>If the right-hand column says “YES,” your interest rate is adjustable and can change after closing. Make sure your Loan Estimate shows the type of interest rate you were expecting.</p><p>If you have an adjustable rate, your Loan Estimate form will have additional information in the Projected Payments table on page 1 and in two additional tables at the bottom of page 2. See a <a href=\"../resources/adjustable_rate_loan_estimate.pdf\" target=\"_blank\">sample Loan Estimate for an adjustable-rate loan</a>.</p><p><a href=\"../loan-options/#interest-rate-expand-header\" target=\"_blank\">Learn more about the difference between fixed and adjustable rates</a></p>",
+        "definition": "<p>If the right-hand column says “YES,” your interest rate is adjustable and can change after closing. Make sure your Loan Estimate shows the type of interest rate you were expecting.</p><p>If you have an adjustable rate, your Loan Estimate form will have additional information in the Projected Payments table on page 1 and in two additional tables at the bottom of page 2. See a <a href=\"../resources/adjustable_rate_loan_estimate.pdf\" target=\"_blank\" rel=\"noopener noreferrer\">sample Loan Estimate for an adjustable-rate loan</a>.</p><p><a href=\"../loan-options/#interest-rate-expand-header\" target=\"_blank\" rel=\"noopener noreferrer\">Learn more about the difference between fixed and adjustable rates</a></p>",
         "id": "interest-rate",
         "category": "checklist",
         "left": "6.95%",
@@ -55,7 +55,7 @@
     },
     {
         "term": "Monthly Principal & Interest",
-        "definition": "<p>Principal (the amount you will borrow) and interest (the lender's charge for lending you money) usually make up the main components of your monthly mortgage payment.</p><p>Your total monthly payment will typically be more than this amount due to taxes and insurance. See the Estimated Total Monthly Payment.</p><p><a href=\"/askcfpb/1941/on-a-mortgage-whats-the-difference-between-my-principal-and-interest-payment-and-my-total-monthly-payment.html\" target=\"_blank\">Learn more about the difference between the principal & interest payment and the total monthly payment</a></p>",
+        "definition": "<p>Principal (the amount you will borrow) and interest (the lender's charge for lending you money) usually make up the main components of your monthly mortgage payment.</p><p>Your total monthly payment will typically be more than this amount due to taxes and insurance. See the Estimated Total Monthly Payment.</p><p><a href=\"/askcfpb/1941/on-a-mortgage-whats-the-difference-between-my-principal-and-interest-payment-and-my-total-monthly-payment.html\" target=\"_blank\" rel=\"noopener noreferrer\">Learn more about the difference between the principal & interest payment and the total monthly payment</a></p>",
         "id": "monthly-principal",
         "category": "definitions",
         "left": "6.95%",
@@ -65,7 +65,7 @@
     },
     {
         "term": "Prepayment Penalty",
-        "definition": "<p>A feature on some mortgages. A prepayment penalty means that the lender can charge you a fee if you pay off your mortgage early.</p><p><a href=\"/askcfpb/1957/what-is-a-prepayment-penalty.html\" target=\"_blank\">Learn more</a></p>",
+        "definition": "<p>A feature on some mortgages. A prepayment penalty means that the lender can charge you a fee if you pay off your mortgage early.</p><p><a href=\"/askcfpb/1957/what-is-a-prepayment-penalty.html\" target=\"_blank\" rel=\"noopener noreferrer\">Learn more</a></p>",
         "id": "prepayment-penalty",
         "category": "definitions",
         "left": "6.95%",
@@ -75,7 +75,7 @@
     },
     {
         "term": "Balloon Payment",
-        "definition": "<p>A feature on some mortgages. A balloon payment means that the final mortgage payment is a lump sum much larger than the regular monthly payments, often tens of thousands of dollars.</p><p><a href=\"/askcfpb/104/what-is-a-balloon-loan.html\" target=\"_blank\">Learn more</a></p>",
+        "definition": "<p>A feature on some mortgages. A balloon payment means that the final mortgage payment is a lump sum much larger than the regular monthly payments, often tens of thousands of dollars.</p><p><a href=\"/askcfpb/104/what-is-a-balloon-loan.html\" target=\"_blank\" rel=\"noopener noreferrer\">Learn more</a></p>",
         "id": "balloon-payment",
         "category": "definitions",
         "left": "6.95%",
@@ -85,7 +85,7 @@
     },
     {
         "term": "Does your loan have a prepayment penalty?",
-        "definition": "<p>This feature is risky. If your loan includes a prepayment penalty, learn more and ask your lender about your other options.</p><p><a href=\"/askcfpb/1957/what-is-a-prepayment-penalty.html\"target=\"_blank\">Learn more about prepayment penalties</a></p>",
+        "definition": "<p>This feature is risky. If your loan includes a prepayment penalty, learn more and ask your lender about your other options.</p><p><a href=\"/askcfpb/1957/what-is-a-prepayment-penalty.html\"target=\"_blank\" rel=\"noopener noreferrer\">Learn more about prepayment penalties</a></p>",
         "id": "prepayment-penalty",
         "category": "checklist",
         "left": "6.95%",
@@ -95,7 +95,7 @@
     },
     {
         "term": "Does your loan have a balloon payment?",
-        "definition": "<p>This feature is risky. If your loan includes a balloon payment, ask your lender about your other options.</p><p><a href=\"/askcfpb/104/what-is-a-balloon-loan.html\" target=\"_blank\">Learn more about balloon payments</a></p>",
+        "definition": "<p>This feature is risky. If your loan includes a balloon payment, ask your lender about your other options.</p><p><a href=\"/askcfpb/104/what-is-a-balloon-loan.html\" target=\"_blank\" rel=\"noopener noreferrer\">Learn more about balloon payments</a></p>",
         "id": "balloon-payment",
         "category": "checklist",
         "left": "6.95%",
@@ -105,7 +105,7 @@
     },
     {
         "term": "Principal & Interest",
-        "definition": "<p>Principal is the amount you will borrow.<br>Interest is the lender's charge for lending you money.</p><p><a href=\"/askcfpb/1943/how-does-paying-down-a-mortgage-work.html\" target=\"_blank\">Learn more</a></p>",
+        "definition": "<p>Principal is the amount you will borrow.<br>Interest is the lender's charge for lending you money.</p><p><a href=\"/askcfpb/1943/how-does-paying-down-a-mortgage-work.html\" target=\"_blank\" rel=\"noopener noreferrer\">Learn more</a></p>",
         "id": "principle-interest",
         "category": "definitions",
         "left": "6.95%",
@@ -115,7 +115,7 @@
     },
     {
         "term": "Mortgage Insurance",
-        "definition": "<p>Mortgage insurance is typically required if your down payment is less than 20 percent of the price of the home.</p><p><a href=\"/askcfpb/1953/what-is-mortgage-insurance-and-how-does-it-work.html\" target=\"_blank\">Learn more</a></p>",
+        "definition": "<p>Mortgage insurance is typically required if your down payment is less than 20 percent of the price of the home.</p><p><a href=\"/askcfpb/1953/what-is-mortgage-insurance-and-how-does-it-work.html\" target=\"_blank\" rel=\"noopener noreferrer\">Learn more</a></p>",
         "id": "mortgage-insurance",
         "category": "definitions",
         "left": "6.95%",
@@ -125,7 +125,7 @@
     },
     {
         "term": "Estimated Escrow",
-        "definition": "<p>Additional charges related to homeownership, such as property taxes and homeowners' insurance, that are bundled in your monthly payment.</p><p><a href=\"/askcfpb/140/what-is-an-escrow-or-impound-account.html\" target=\"_blank\">Learn more</a></p>",
+        "definition": "<p>Additional charges related to homeownership, such as property taxes and homeowners' insurance, that are bundled in your monthly payment.</p><p><a href=\"/askcfpb/140/what-is-an-escrow-or-impound-account.html\" target=\"_blank\" rel=\"noopener noreferrer\">Learn more</a></p>",
         "id": "estimated-escrow",
         "category": "definitions",
         "left": "6.95%",
@@ -135,7 +135,7 @@
     },
     {
         "term": "Estimated Total Monthly Payment",
-        "definition": "<p>The total payment you will make each month, including <a href=\"/askcfpb/1953/what-is-mortgage-insurance-and-how-does-it-work.html\" target=\"_blank\">mortgage insurance</a> and <a href=\"/askcfpb/140/what-is-an-escrow-or-impound-account.html\" target=\"_blank\">escrow</a>, if applicable.</p><p><a href=\"/askcfpb/1941/on-a-mortgage-whats-the-difference-between-my-principal-and-interest-payment-and-my-total-monthly-payment.html\" target=\"_blank\">Learn more</a></p>",
+        "definition": "<p>The total payment you will make each month, including <a href=\"/askcfpb/1953/what-is-mortgage-insurance-and-how-does-it-work.html\" target=\"_blank\" rel=\"noopener noreferrer\">mortgage insurance</a> and <a href=\"/askcfpb/140/what-is-an-escrow-or-impound-account.html\" target=\"_blank\" rel=\"noopener noreferrer\">escrow</a>, if applicable.</p><p><a href=\"/askcfpb/1941/on-a-mortgage-whats-the-difference-between-my-principal-and-interest-payment-and-my-total-monthly-payment.html\" target=\"_blank\" rel=\"noopener noreferrer\">Learn more</a></p>",
         "id": "estimated-total-monthly-payment",
         "category": "definitions",
         "left": "6.95%",
@@ -155,7 +155,7 @@
     },
     {
         "term": "Do you have items in Estimated Taxes, Insurance & Assessments that are not escrowed?",
-        "definition": "<p>If so, you will have to pay these costs directly, often in large lump sum payments. Are you comfortable spending this additional amount on housing? Do you know how often you will need to make payments for these costs? </p><p><a href=\"/askcfpb/140/what-is-an-escrow-or-impound-account.html\" target=\"_blank\">Learn more about escrow</a></p>",
+        "definition": "<p>If so, you will have to pay these costs directly, often in large lump sum payments. Are you comfortable spending this additional amount on housing? Do you know how often you will need to make payments for these costs? </p><p><a href=\"/askcfpb/140/what-is-an-escrow-or-impound-account.html\" target=\"_blank\" rel=\"noopener noreferrer\">Learn more about escrow</a></p>",
         "id": "estimated-taxes",
         "category": "checklist",
         "left": "6.95%",

--- a/cfgov/jinja2/v1/owning-a-home/loan-estimate/loan-estimate-2-data.html
+++ b/cfgov/jinja2/v1/owning-a-home/loan-estimate/loan-estimate-2-data.html
@@ -15,7 +15,7 @@
     },
     {
         "term": "Does your loan include points?",
-        "definition": "<p>If there is an amount listed on this line, it means that you are paying points to the lender to reduce your interest rate. Did you discuss this choice with the lender? A similar loan may also be available without points, if you prefer. Ask the lender what other options may be available to you, and how the other options would impact your interest rate and the total cost of your loan.</p><p><a href=\"/askcfpb/136/what-are-discount-points-or-points.html\" target=\"_blank\">Learn more about points and how they work</a></p>",
+        "definition": "<p>If there is an amount listed on this line, it means that you are paying points to the lender to reduce your interest rate. Did you discuss this choice with the lender? A similar loan may also be available without points, if you prefer. Ask the lender what other options may be available to you, and how the other options would impact your interest rate and the total cost of your loan.</p><p><a href=\"/askcfpb/136/what-are-discount-points-or-points.html\" target=\"_blank\" rel=\"noopener noreferrer\">Learn more about points and how they work</a></p>",
         "id": "include-points",
         "category": "checklist",
         "left": "7.00%",
@@ -25,7 +25,7 @@
     },
     {
         "term": "Compare the Services You Cannot Shop For to Loan Estimates from other lenders",
-        "definition": "<p>The services and service providers in this section are required and chosen by the lender. Because you can’t shop separately for lower prices from other providers, compare the overall cost of the items in this section to the Loan Estimates from other lenders.</p><p>Some fees in this section may depend on the <a href=\"../loan-options\" target=\"_blank\">kind of loan</a> you have chosen. For example, if you have an <a href=\"../loan-options/FHA-loans\" target=\"_blank\">FHA</a>, <a href=\"../loan-options/special-loan-programs/#va\" target=\"_blank\">VA</a>, or <a href=\"../loan-options/special-loan-programs/#usda\" target=\"_blank\">USDA</a> loan, the upfront mortgage insurance premium or funding fee will appear in this section. These fees are usually set by the government program and not the lender. If you have a <a href=\"../loan-options/conventional-loans\" target=\"_blank\">conventional loan</a> with <a href=\"/askcfpb/122/what-is-private-mortgage-insurance-how-does-pmi-work.html\" target=\"_blank\">private mortgage insurance (PMI)</a>, any upfront mortgage insurance premium would typically be listed in this section. PMI premiums are set by the private mortgage insurance company, which is usually chosen by your lender.</p>",
+        "definition": "<p>The services and service providers in this section are required and chosen by the lender. Because you can’t shop separately for lower prices from other providers, compare the overall cost of the items in this section to the Loan Estimates from other lenders.</p><p>Some fees in this section may depend on the <a href=\"../loan-options\" target=\"_blank\" rel=\"noopener noreferrer\">kind of loan</a> you have chosen. For example, if you have an <a href=\"../loan-options/FHA-loans\" target=\"_blank\" rel=\"noopener noreferrer\">FHA</a>, <a href=\"../loan-options/special-loan-programs/#va\" target=\"_blank\" rel=\"noopener noreferrer\">VA</a>, or <a href=\"../loan-options/special-loan-programs/#usda\" target=\"_blank\" rel=\"noopener noreferrer\">USDA</a> loan, the upfront mortgage insurance premium or funding fee will appear in this section. These fees are usually set by the government program and not the lender. If you have a <a href=\"../loan-options/conventional-loans\" target=\"_blank\" rel=\"noopener noreferrer\">conventional loan</a> with <a href=\"/askcfpb/122/what-is-private-mortgage-insurance-how-does-pmi-work.html\" target=\"_blank\" rel=\"noopener noreferrer\">private mortgage insurance (PMI)</a>, any upfront mortgage insurance premium would typically be listed in this section. PMI premiums are set by the private mortgage insurance company, which is usually chosen by your lender.</p>",
         "id": "compare-lenders",
         "category": "checklist",
         "left": "7.00%",
@@ -35,7 +35,7 @@
     },
     {
         "term": "Review the Services You Can Shop For and shop for these services",
-        "definition": "<p>The services in this section are required by the lender, but you can save money by shopping for these services separately.</p><p>Along with the Loan Estimate, the lender should provide you with a list of approved providers for each of these services. You can choose one of the providers on the list. You can also look for other providers, but check with your lender about any provider not on the list.</p><p><a href=\"../process/close/#services\" target=\"_blank\">Learn more about how to shop for these services</a></p>",
+        "definition": "<p>The services in this section are required by the lender, but you can save money by shopping for these services separately.</p><p>Along with the Loan Estimate, the lender should provide you with a list of approved providers for each of these services. You can choose one of the providers on the list. You can also look for other providers, but check with your lender about any provider not on the list.</p><p><a href=\"../process/close/#services\" target=\"_blank\" rel=\"noopener noreferrer\">Learn more about how to shop for these services</a></p>",
         "id": "shop-services",
         "category": "checklist",
         "left": "7.00%",
@@ -45,7 +45,7 @@
     },
         {
         "term": "Is the homeowner’s insurance premium accurate?",
-        "definition": "<p>The homeowner’s insurance premium is set by the homeowner’s insurance company, not by the lender. You get to choose your homeowner’s insurance company. Comparison shop to find the insurance policy you want and to learn if the amount the lender estimated is accurate for your specific situation. Usually you’ll pay the first 6 to 12 months of homeowner’s insurance premiums at or before closing. Homeowner’s insurance is also sometimes referred to as “hazard insurance.”</p><p><a href=\"../process/close/#insurance\" target=\"_blank\">Learn more about how to shop for homeowner’s insurance</a></p>",
+        "definition": "<p>The homeowner’s insurance premium is set by the homeowner’s insurance company, not by the lender. You get to choose your homeowner’s insurance company. Comparison shop to find the insurance policy you want and to learn if the amount the lender estimated is accurate for your specific situation. Usually you’ll pay the first 6 to 12 months of homeowner’s insurance premiums at or before closing. Homeowner’s insurance is also sometimes referred to as “hazard insurance.”</p><p><a href=\"../process/close/#insurance\" target=\"_blank\" rel=\"noopener noreferrer\">Learn more about how to shop for homeowner’s insurance</a></p>",
         "id": "premium-accurate",
         "category": "checklist",
         "left": "51.40%",
@@ -65,7 +65,7 @@
     },
     {
         "term": "Does your loan include lender credits?",
-        "definition": "<p>If there is an amount listed on this line, it means that the lender is giving you a rebate to offset your closing costs. You may be paying a higher interest rate in exchange for this rebate. Did you discuss this choice with the lender? A similar loan may be available with a lower interest rate and without lender credits, if you prefer. Ask the lender what other options may be available to you, and how the other options would impact your interest rate and the total cost of your loan.</p><p><a href=\"/askcfpb/136/what-are-discount-points-or-points.html\" target=\"_blank\">Learn more about lender credits and how they work</a></p>",
+        "definition": "<p>If there is an amount listed on this line, it means that the lender is giving you a rebate to offset your closing costs. You may be paying a higher interest rate in exchange for this rebate. Did you discuss this choice with the lender? A similar loan may be available with a lower interest rate and without lender credits, if you prefer. Ask the lender what other options may be available to you, and how the other options would impact your interest rate and the total cost of your loan.</p><p><a href=\"/askcfpb/136/what-are-discount-points-or-points.html\" target=\"_blank\" rel=\"noopener noreferrer\">Learn more about lender credits and how they work</a></p>",
         "id": "include-credits",
         "category": "checklist",
         "left": "51.40%",
@@ -95,7 +95,7 @@
     },
     {
         "term": "Points",
-        "definition": "<p>An upfront fee that you pay to your lender in exchange for a lower interest rate than you would have paid otherwise.</p><p><a href=\"/askcfpb/136/what-are-discount-points-or-points.html\" target=\"_blank\">Learn more</a></p>",
+        "definition": "<p>An upfront fee that you pay to your lender in exchange for a lower interest rate than you would have paid otherwise.</p><p><a href=\"/askcfpb/136/what-are-discount-points-or-points.html\" target=\"_blank\" rel=\"noopener noreferrer\">Learn more</a></p>",
         "id": "points",
         "category": "definitions",
         "left": "6.66%",
@@ -105,7 +105,7 @@
     },
     {
         "term": "Closing Services",
-        "definition": "<p>Third-party services required by your lender in order to get a loan. These services are also sometimes referred to as “settlement services.” You can shop separately for services listed in section C.</p><p><a href=\"/askcfpb/1845/what-fees-or-charges-are-paid-closing-and-who-pays-them.html\" target=\"_blank\">Learn more</a></p>",
+        "definition": "<p>Third-party services required by your lender in order to get a loan. These services are also sometimes referred to as “settlement services.” You can shop separately for services listed in section C.</p><p><a href=\"/askcfpb/1845/what-fees-or-charges-are-paid-closing-and-who-pays-them.html\" target=\"_blank\" rel=\"noopener noreferrer\">Learn more</a></p>",
         "id": "b-c",
         "category": "definitions",
         "left": "6.66%",
@@ -125,7 +125,7 @@
     },
     {
         "term": "Lender Credits",
-        "definition": "<p>A rebate from your lender that offsets some of your closing costs. Lender credits are typically provided in exchange for you agreeing to pay a higher interest rate than you would have paid otherwise.</p><p><a href=\"/askcfpb/136/what-are-discount-points-or-points.html\" target=\"_blank\">Learn more</a></p>",
+        "definition": "<p>A rebate from your lender that offsets some of your closing costs. Lender credits are typically provided in exchange for you agreeing to pay a higher interest rate than you would have paid otherwise.</p><p><a href=\"/askcfpb/136/what-are-discount-points-or-points.html\" target=\"_blank\" rel=\"noopener noreferrer\">Learn more</a></p>",
         "id": "lender-credits",
         "category": "definitions",
         "left": "51.27%",

--- a/cfgov/jinja2/v1/owning-a-home/loan-estimate/loan-estimate-3-data.html
+++ b/cfgov/jinja2/v1/owning-a-home/loan-estimate/loan-estimate-3-data.html
@@ -5,7 +5,7 @@
 [
     {
         "term": "Is the information about the loan officer what you were expecting?",
-        "definition": "<p>Is the loan officer that you are working with listed here? If not, ask questions.</p><p>Most loan officers are required to be licensed or registered with the Nationwide Mortgage Licensing System & Registry (NMLS). You can look up the loan officer by name or NMLS ID number in the <a class=\"icon-link icon-link__external-link\" href=\"http://www.nmlsconsumeraccess.org\" target=\"_blank\"><span class=\"icon-link_text\">NMLS database</span></a>. In most cases, it will tell you whether the loan officer is authorized to operate in your state and whether there are any disciplinary actions on their record.</p>",
+        "definition": "<p>Is the loan officer that you are working with listed here? If not, ask questions.</p><p>Most loan officers are required to be licensed or registered with the Nationwide Mortgage Licensing System & Registry (NMLS). You can look up the loan officer by name or NMLS ID number in the <a class=\"icon-link icon-link__external-link\" href=\"http://www.nmlsconsumeraccess.org\" target=\"_blank\" rel=\"noopener noreferrer\"><span class=\"icon-link_text\">NMLS database</span></a>. In most cases, it will tell you whether the loan officer is authorized to operate in your state and whether there are any disciplinary actions on their record.</p>",
         "id": "loan-officer",
         "category": "checklist",
         "left": "6.95%",
@@ -15,7 +15,7 @@
     },
     {
         "term": "Use the Comparisons section to compare Loan Estimates",
-        "definition": "<p>This section offers several useful calculations to compare the cost of this loan offer with other offers from different lenders. Because loan costs vary both across lenders and across different <a href=\"../loan-options\" target=\"_blank\">kinds of loans</a>, it’s important to <a href=\"../process/compare/#request\" target=\"_blank\">request Loan Estimates</a> for the same kind of loan from different lenders.</p><p><a href=\"../process/compare/#compare\" target=\"_blank\">Learn more about how to compare Loan Estimates from different lenders</a></p>",
+        "definition": "<p>This section offers several useful calculations to compare the cost of this loan offer with other offers from different lenders. Because loan costs vary both across lenders and across different <a href=\"../loan-options\" target=\"_blank\">kinds of loans</a>, it’s important to <a href=\"../process/compare/#request\" target=\"_blank\" rel=\"noopener noreferrer\">request Loan Estimates</a> for the same kind of loan from different lenders.</p><p><a href=\"../process/compare/#compare\" target=\"_blank\" rel=\"noopener noreferrer\">Learn more about how to compare Loan Estimates from different lenders</a></p>",
         "id": "comparisons-section",
         "category": "checklist",
         "left": "6.95%",
@@ -35,7 +35,7 @@
     },
     {
         "term": "Annual Percentage Rate (APR)",
-        "definition": "<p>The APR is one measure of your loan’s cost.</p><p><a href=\"/askcfpb/135/what-is-the-difference-between-a-mortgage-interest-rate-and-an-apr.html\" target=\"_blank\">Learn more about how your APR is different from your interest rate</a></p>",
+        "definition": "<p>The APR is one measure of your loan’s cost.</p><p><a href=\"/askcfpb/135/what-is-the-difference-between-a-mortgage-interest-rate-and-an-apr.html\" target=\"_blank\" rel=\"noopener noreferrer\">Learn more about how your APR is different from your interest rate</a></p>",
         "id": "apr",
         "category": "definitions",
         "left": "6.95%",
@@ -45,7 +45,7 @@
     },
     {
         "term": "Total Interest Percentage (TIP)",
-        "definition": "<p>This number helps you understand how much interest you will pay over the life of the loan and lets you make comparisons between loans.</p><p><a href=\"/askcfpb/2001/What-does-the-total-interest-percentage-TIP-mean-on-a-mortgage.html\" target=\"_blank\">Learn more about what this number means</a></p>",
+        "definition": "<p>This number helps you understand how much interest you will pay over the life of the loan and lets you make comparisons between loans.</p><p><a href=\"/askcfpb/2001/What-does-the-total-interest-percentage-TIP-mean-on-a-mortgage.html\" target=\"_blank\" rel=\"noopener noreferrer\">Learn more about what this number means</a></p>",
         "id": "tip",
         "category": "definitions",
         "left": "6.95%",
@@ -55,7 +55,7 @@
     },
     {
         "term": "Appraisal",
-        "definition": "<p>The lender uses an appraisal to decide how much your home is worth. The appraisal is conducted by an independent, professional appraiser. You have a right to receive a copy.</p><p><a href=\"/askcfpb/167/what-is-an-appraisal.html\" target=\"_blank\">Learn more about what to expect from your appraisal</a></p>",
+        "definition": "<p>The lender uses an appraisal to decide how much your home is worth. The appraisal is conducted by an independent, professional appraiser. You have a right to receive a copy.</p><p><a href=\"/askcfpb/167/what-is-an-appraisal.html\" target=\"_blank\" rel=\"noopener noreferrer\">Learn more about what to expect from your appraisal</a></p>",
         "id": "appraisal",
         "category": "definitions",
         "left": "6.95%",
@@ -75,7 +75,7 @@
     },
     {
         "term": "Servicing",
-        "definition": "<p>Servicing means handling the loan on a day-to-day basis once the loan is made&mdash;for example, accepting payments and answering questions from borrowers. The lender can choose to service your loan itself, or transfer that responsibility to a different company.</p><p><a href=\"/askcfpb/198/whats-the-difference-between-a-mortgage-lender-and-a-servicer.html\" target=\"_blank\">Learn more about the difference between a lender and a servicer </a></p>",
+        "definition": "<p>Servicing means handling the loan on a day-to-day basis once the loan is made&mdash;for example, accepting payments and answering questions from borrowers. The lender can choose to service your loan itself, or transfer that responsibility to a different company.</p><p><a href=\"/askcfpb/198/whats-the-difference-between-a-mortgage-lender-and-a-servicer.html\" target=\"_blank\" rel=\"noopener noreferrer\">Learn more about the difference between a lender and a servicer </a></p>",
         "id": "servicing",
         "category": "definitions",
         "left": "6.95%",

--- a/cfgov/legacy/templates/hud/housing_counselor_pdf_selfcontained.html
+++ b/cfgov/legacy/templates/hud/housing_counselor_pdf_selfcontained.html
@@ -219,7 +219,8 @@
                                 <p>
                                     <span class="hud_hca_api_results_print"><span class="hud_hca_api_no_js_print_text">Print with Browser</span></span>
                                     <span class="hud_hca_api_results_save">
-                                        <a href="/save-hud-counselors-list" target="_blank"
+                                        <a href="/save-hud-counselors-list"
+                                           target="_blank"
                                            rel="noopener noreferrer">
                                            Save list as PDF
                                        </a>

--- a/cfgov/unprocessed/apps/owning-a-home/js/explore-rates/rate-checker.js
+++ b/cfgov/unprocessed/apps/owning-a-home/js/explore-rates/rate-checker.js
@@ -521,8 +521,8 @@ function processCounty() {
       dropdown( 'loan-type' ).disable( 'conf' );
     }
     // Add links to loan messages.
-    loan.msg = loan.msg.replace( 'jumbo (non-conforming)', '<a href="/owning-a-home/loan-options/conventional-loans/" target="_blank">jumbo (non-conforming)</a>' );
-    loan.msg = loan.msg.replace( 'conforming jumbo', '<a href="/owning-a-home/loan-options/conventional-loans/" target="_blank">conforming jumbo</a>' );
+    loan.msg = loan.msg.replace( 'jumbo (non-conforming)', '<a href="/owning-a-home/loan-options/conventional-loans/" target="_blank" rel="noopener noreferrer">jumbo (non-conforming)</a>' );
+    loan.msg = loan.msg.replace( 'conforming jumbo', '<a href="/owning-a-home/loan-options/conventional-loans/" target="_blank" rel="noopener noreferrer">conforming jumbo</a>' );
     $( '#hb-warning' ).removeClass( 'u-hidden' ).find( 'p' ).html( loan.msg );
 
   } else {


### PR DESCRIPTION
Addresses security issue in [GHE]/CFGOV/platform/issues/2522

## Changes

- Adds `rel="noopener noreferrer"` to "_blank" href targets.
- Fixes issue in social media molecule where "_blank" was not quoted.

## Testing

1. Ensure `OAH_FORM_EXPLAINERS` flag is true.
2. Visit /owning-a-home/loan-estimate/ (e.g.) and inspect the links in the right-hand sidebar that open in a new window and see that they have `rel="noopener noreferrer" in the link.
 