### PR TITLE
Remove deprecated PBR requirement

### DIFF
--- a/requirements/libraries.txt
+++ b/requirements/libraries.txt
@@ -27,7 +27,6 @@ jsonschema==2.0.0
 lxml==4.1.0
 ntplib==0.3.3
 openpyxl==2.5.0
-pbr==1.9.1
 psycopg2==2.7.3.2
 pyelasticsearch==0.6.1
 python-dateutil==2.1


### PR DESCRIPTION
This change removes a deprecated dependency on [pbr==1.9.1](https://pypi.python.org/pypi/pbr/1.9.1).

This library was previously required by our django-sheerlike and publish_eccu packages, but those are no longer used by cfgov-refresh.

A [further search](https://github.com/search?utf8=%E2%9C%93&q=user%3Acfpb+pbr&type=Code) of CFPB code shows no other dependencies in any active satellite apps.

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [X] Passes all existing automated tests
- [X] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: