### PR TITLE
Remove deprecated simplejson requirement

### DIFF
--- a/requirements/libraries.txt
+++ b/requirements/libraries.txt
@@ -35,7 +35,6 @@ PyYAML==3.11
 pytz
 requests==2.12.4
 requests_toolbelt==0.6.0
-simplejson==3.8.2
 six==1.10.0
 unicodecsv==0.14.1
 unipath>=1.1,<=2.0


### PR DESCRIPTION
This change removes a deprecated dependency on [simplejson==3.8.2](https://pypi.python.org/pypi/simplejson/3.8.2).

There's one remaining reference to this library in the optional [cfpb/retirement](https://github.com/cfpb/retirement) app; however that reference is only used as a fallback when `json` is not defined. That was added in Python 2.6 and this repository requires Python 2.7, so that fallback is no longer needed. Additionally that code [only exists](
https://github.com/cfpb/retirement/blob/46f0610392fd94fcf52e87cf83275c63f75e55c7/browser_testing/features/environment.py#L17) as part of some browser testing code.

This library was used in various other libraries which are no longer part of cfgov-refresh ([see search
here](https://pypi.python.org/pypi/simplejson/3.8.2)).

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [X] Passes all existing automated tests
- [X] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: