### PR TITLE
Simplify gulp watch syntax

### DIFF
--- a/gulp/tasks/watch.js
+++ b/gulp/tasks/watch.js
@@ -9,13 +9,15 @@ const paths = require( '../../config/environment' ).paths;
  * @param {FSWatcher} watcher - Output from gulp.watch.
  */
 function _addChangeListener( watcher ) {
-  watcher.on( 'change', function( path, stats ) {
-    fancyLog.info( 'File ' + path + ' was changed' );
-  } );
+  watcher.on(
+    'change',
+    path => fancyLog.info( 'File ' + path + ' was changed' )
+  );
 
-  watcher.on('unlink', function( path ) {
-    fancyLog.info( 'File ' + path + ' was removed' );
-  } );
+  watcher.on(
+    'unlink',
+    path => fancyLog.info( 'File ' + path + ' was removed' )
+  );
 }
 
 gulp.task( 'watch',


### PR DESCRIPTION
## Changes

- Removes unused parameter and simplifies event functions to be arrow functions.

## Testing

1. `gulp watch`
2. Edit a source JS file and see that the Terminal reports the file you changed was changed.
3. Edit a source CSS file and see that the Terminal reports the file you changed was changed.
