### PR TITLE
Run Travis unit tests against Postgres DB

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,12 @@ dist: trusty
 python:
   - "2.7"
 
+services:
+  - postgresql
+
+addons:
+  postgresql: "9.6"
+
 cache:
   pip: true
   directories:
@@ -24,6 +30,9 @@ install:
 branches:
   only:
     - master
+
+before_script:
+  - psql -c 'create database travis_ci_test;' -U postgres
 
 script:
   - ./travis_run.sh

--- a/travis_run.sh
+++ b/travis_run.sh
@@ -9,7 +9,7 @@ if [ "$RUNTEST" == "frontend" ]; then
     bash <(curl -s https://codecov.io/bash) -F frontend
 elif [ "$RUNTEST" == "backend" ]; then
     tox -e lint
-    tox -e fast
+    DATABASE_URL=postgres://postgres@localhost/travis_ci_test tox -e fast
     tox -e missing-migrations
     bash <(curl -s https://codecov.io/bash) -F backend
 elif [ "$RUNTEST" == "acceptance" ]; then


### PR DESCRIPTION
See platform issue 2618.  As part of our work in preparation for migrating to PostgreSQL, we want to start running our unit tests regularly against a Postgres database. 

I modified `.travis.yml` according to set-up instructions [here](https://docs.travis-ci.com/user/database-setup/#PostgreSQL) as well as modified our `travis_run.sh` script to pass the Postgres `DATABASE_URL` (introduced in https://github.com/cfpb/cfgov-refresh/pull/3910) into `tox -e fast`.  

## Testing
I tested this without the changes to `.travis.yml` and it still passed, so I'm not actually sure the config there is doing anything -- or perhaps it runs its default version of psql.  

However, I also tested this on a commit that I expected to fail and it did, so I think this is overall working. See https://travis-ci.org/cfpb/cfgov-refresh/jobs/364505074#L589, which reintroduced two tests I had removed in https://github.com/cfpb/cfgov-refresh/pull/3939. 