### PR TITLE
Scroll to top of page when in submenu

### DIFF
--- a/cfgov/unprocessed/js/organisms/MegaMenuMobile.js
+++ b/cfgov/unprocessed/js/organisms/MegaMenuMobile.js
@@ -115,6 +115,10 @@ function MegaMenuMobile( menus ) {
       }
     } else {
       // Submenu clicked.
+
+      // Scroll to top of page so menu is always at the top.
+      document.body.scrollTop = document.documentElement.scrollTop = 0;
+
       const siblings = _menus.getAllAtLevel( level );
       let siblingMenu;
       for ( let i = 0, len = siblings.length; i < len; i++ ) {


### PR DESCRIPTION
Fixes [GHE]/CFGOV/platform/issues/2470

## Changes

- Scroll page to the top of the page when navigating to a submenu in the mega menu.

## Testing

1. Visit consumerfinance.gov on iOS 11
2. Navigate to About Us > Careers. **Be sure to scroll down on the About Us 2nd-level menu**
3. Note third-level menu is not showing.
4. Hit "X" button.
5. Repeat steps 1 through 4 on this branch and note menu is not missing.

## Screenshots

Before:
![screen shot 2018-04-10 at 12 29 48 pm](https://user-images.githubusercontent.com/704760/38570071-e981a04a-3cba-11e8-9c78-8b7fd495ee46.png)

After:
![screen shot 2018-04-10 at 12 30 02 pm](https://user-images.githubusercontent.com/704760/38570079-ef04a5ee-3cba-11e8-8acf-208c0da9de53.png)


## Notes

- This jumps to the top of the page on clicks of the submenu. Since this is immediately before sliding to the right there may be jump apparent as the page goes to the top, but it didn't strike me as bothersome. cc @schaferjh 
