### PR TITLE
Ignore index files in test coverage

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -12,6 +12,7 @@ module.exports = {
     '<rootDir>/node_modules/',
     '<rootDir>/cfgov/unprocessed/apps/.+/node_modules/',
     '<rootDir>/cfgov/unprocessed/apps/.+/webpack-config.js$',
+    '<rootDir>/cfgov/unprocessed/apps/.+/index.js$',
     '<rootDir>/cfgov/unprocessed/js/routes/'
   ],
   coverageDirectory: '<rootDir>/test/unit_test_coverage'


### PR DESCRIPTION
`index.js` files should just be calling other modules so don't need their own coverage and tests.

## Changes

- Ignores `index.js` files in Jest test coverage.

## Testing

1. `gulp test:unit` should not include `apps/owning-a-home/js/explore-rates/index.js`


