### PR TITLE
Bump TDP release version to 0.3.2

### DIFF
--- a/requirements/optional-public.txt
+++ b/requirements/optional-public.txt
@@ -8,4 +8,4 @@ git+https://github.com/cfpb/ccdb5-api.git@v1.0.5#egg=ccdb5-api
 git+https://github.com/cfpb/ccdb5-ui.git@v1.0.7#egg=ccdb5_ui
 https://github.com/cfpb/django-hud/releases/download/1.4.3/django_hud-1.4.3-py2-none-any.whl
 https://github.com/cfpb/django-college-costs-comparison/releases/download/1.5.1/comparisontool-1.5.1-py2-none-any.whl
-https://github.com/cfpb/teachers-digital-platform/releases/download/0.3.1/teachers_digital_platform-0.3.1-py2-none-any.whl
+https://github.com/cfpb/teachers-digital-platform/releases/download/0.3.2/teachers_digital_platform-0.3.2-py2-none-any.whl


### PR DESCRIPTION
Updated content for getting started page.

## Changes

- Updated TDP version to 0.3.2

@Scotchester @cfarm @willbarton @higs4281