### PR TITLE
Updates autoprefixer to 8 and gulp-modernizr-build to 0.0.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -89,12 +89,6 @@
         "negotiator": "0.6.1"
       }
     },
-    "accessibility-developer-tools": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/accessibility-developer-tools/-/accessibility-developer-tools-2.12.0.tgz",
-      "integrity": "sha1-PaDM6dbsY3OWS4TzXbfPw996tRQ=",
-      "dev": true
-    },
     "accord": {
       "version": "0.29.0",
       "resolved": "https://registry.npmjs.org/accord/-/accord-0.29.0.tgz",
@@ -648,16 +642,27 @@
       "integrity": "sha1-NCQX2PLzRhsUzwkIjV7fh5HcmDI="
     },
     "autoprefixer": {
-      "version": "7.2.4",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-7.2.4.tgz",
-      "integrity": "sha512-am8jJ7Rbh1sy7FvLvNxxQScWvhv2FwLAS3bIhvrZpx9HbX5PEcc/7v6ecgpWuiu0Dwlj+p/z/1boHd8x60JFwA==",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-8.2.0.tgz",
+      "integrity": "sha512-xBVQpGAcSNNS1PBnEfT+F9VF8ZJeoKZ121I3OVQ0n1F0SqVuj4oLI6yFeEviPV8Z/GjoqBRXcYis0oSS8zjNEg==",
       "requires": {
-        "browserslist": "2.11.3",
+        "browserslist": "3.2.4",
         "caniuse-lite": "1.0.30000823",
         "normalize-range": "0.1.2",
         "num2fraction": "1.2.2",
         "postcss": "6.0.21",
         "postcss-value-parser": "3.3.0"
+      },
+      "dependencies": {
+        "browserslist": {
+          "version": "3.2.4",
+          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-3.2.4.tgz",
+          "integrity": "sha512-Dwe62y/fNAcMfknzGJnkh7feISrrN0SmRvMFozb+Y2+qg7rfTIH5MS8yHzaIXcEWl8fPeIcdhZNQi1Lux+7dlg==",
+          "requires": {
+            "caniuse-lite": "1.0.30000823",
+            "electron-to-chromium": "1.3.42"
+          }
+        }
       }
     },
     "aws-sign2": {
@@ -669,29 +674,6 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
       "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4="
-    },
-    "axe-core": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-2.6.1.tgz",
-      "integrity": "sha512-QFfI3d+x/v92HJWGBaNfgrxdfon9/xXzd04YYfm5w5NJQOLex8qkJCctOt7+ky6e1l9zcQ5E7jsvbnTgQzyfTw==",
-      "dev": true
-    },
-    "axe-webdriverjs": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/axe-webdriverjs/-/axe-webdriverjs-0.2.0.tgz",
-      "integrity": "sha1-XjHtr26bozRCdiz9hd46B0c8EVU=",
-      "dev": true,
-      "requires": {
-        "axe-core": "1.1.1"
-      },
-      "dependencies": {
-        "axe-core": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-1.1.1.tgz",
-          "integrity": "sha1-rp2l2oq08QQZB/H12N/jnJRqksU=",
-          "dev": true
-        }
-      }
     },
     "babel-code-frame": {
       "version": "6.26.0",
@@ -7517,14 +7499,16 @@
       }
     },
     "gulp-modernizr-build": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/gulp-modernizr-build/-/gulp-modernizr-build-0.0.5.tgz",
-      "integrity": "sha1-Kxes5OPaaye+99aYg4cBlWu0sLc=",
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/gulp-modernizr-build/-/gulp-modernizr-build-0.0.6.tgz",
+      "integrity": "sha512-6R2s+4v+20I+MJnbaxNMCaG77187hAPkQNcUInT16CNEH2It8SAAsd1j2I3cJEXjc3xTA7QUQHQsfk6p/cKv6A==",
       "requires": {
-        "gulp-util": "3.0.8",
+        "ansi-colors": "1.1.0",
+        "fancy-log": "1.3.2",
         "lodash.defaults": "4.2.0",
         "modernizr": "3.6.0",
-        "through2": "2.0.3"
+        "through2": "2.0.3",
+        "vinyl": "2.1.0"
       }
     },
     "gulp-mq-remove": {
@@ -12965,27 +12949,6 @@
             "semver": "5.5.0",
             "xml2js": "0.4.19"
           }
-        }
-      }
-    },
-    "protractor-accessibility-plugin": {
-      "version": "github:cfpb/protractor-accessibility-plugin#7319a881e222d9f3588f6d5d8a3d9848bc38c859",
-      "dev": true,
-      "requires": {
-        "accessibility-developer-tools": "2.12.0",
-        "axe-core": "2.6.1",
-        "axe-webdriverjs": "0.2.0",
-        "html-entities": "1.2.1",
-        "lodash": "3.10.1",
-        "q": "1.5.1",
-        "request": "2.81.0"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "3.10.1",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-          "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
-          "dev": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "node": ">=6.0.0"
   },
   "dependencies": {
-    "autoprefixer": "7.2.4",
+    "autoprefixer": "8.2.0",
     "babel-core": "6.26.0",
     "babel-loader": "7.1.4",
     "babel-preset-env": "1.6.1",
@@ -46,7 +46,7 @@
     "gulp-header": "2.0.5",
     "gulp-imagemin": "4.1.0",
     "gulp-less": "4.0.0",
-    "gulp-modernizr-build": "0.0.5",
+    "gulp-modernizr-build": "0.0.6",
     "gulp-mq-remove": "0.0.2",
     "gulp-newer": "1.4.0",
     "gulp-notify": "3.2.0",


### PR DESCRIPTION
## Changes

- Updates autoprefixer to 8.x ([changelog](https://github.com/postcss/autoprefixer/blob/master/CHANGELOG.md#82-ad-astra-per-aspera))
- Updates gulp-modernizr-build ([changes](https://github.com/madlandproject/gulp-modernizr-build/commit/296ecae43d9363eb15c72618c2ba48edb7452f22))

## Testing

1. `gulp build` should pass.
