### PR TITLE
Add new svg_icon template tag to render SVG icons

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,7 +35,6 @@ cfgov-refresh/
 ._*
 .Spotlight-V100
 .Trashes
-Icon?
 ehthumbs.db
 Thumbs.db
 

--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ cfgov-refresh/
 ._*
 .Spotlight-V100
 .Trashes
+Icon
 ehthumbs.db
 Thumbs.db
 

--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -155,6 +155,7 @@ TEMPLATES = [
         'OPTIONS': {
             'environment': 'v1.environment',
             'extensions': [
+                'core.jinja2tags.filters',
                 'v1.jinja2tags.filters',
                 'wagtail.wagtailcore.jinja2tags.core',
                 'wagtail.wagtailadmin.jinja2tags.userbar',

--- a/cfgov/core/jinja2tags.py
+++ b/cfgov/core/jinja2tags.py
@@ -1,0 +1,14 @@
+from jinja2.ext import Extension
+
+from core.templatetags.svg_icon import svg_icon
+
+
+class CoreExtension(Extension):
+    def __init__(self, environment):
+        super(CoreExtension, self).__init__(environment)
+        self.environment.globals.update({
+            'svg_icon': svg_icon,
+        })
+
+
+filters = CoreExtension

--- a/cfgov/core/templatetags/svg_icon.py
+++ b/cfgov/core/templatetags/svg_icon.py
@@ -1,0 +1,38 @@
+import re
+
+from django import template
+from django.contrib.staticfiles import finders
+from django.utils.safestring import mark_safe
+
+
+register = template.Library()
+
+
+SVG_REGEX = re.compile(
+    r'^'                    # start of string
+    '\s*'                   # any leading whitespace
+    '<svg[^>]*>'            # opening <svg> tag with any attributes
+    '(?!.*</svg>.*</svg>)'  # only allow one closing </svg> tag
+    '.*</svg>'              # match anything and then the closing tag
+    '\s*'                   # any trailing whitespace
+    '$',                    # end of string
+    re.DOTALL | re.IGNORECASE | re.MULTILINE
+)
+
+
+@register.simple_tag()
+def svg_icon(name):
+    """Return SVG content given an icon name."""
+    relative_path = 'icons/{}.svg'.format(name)
+    static_filename = finders.find(relative_path)
+
+    if not static_filename:
+        raise ValueError('{} not found in staticfiles'.format(relative_path))
+
+    with open(static_filename, 'r') as f:
+        content = f.read()
+
+        if not SVG_REGEX.match(content):
+            raise ValueError('{} is not a valid SVG'.format(static_filename))
+
+        return mark_safe(content)

--- a/cfgov/core/tests/staticfiles/icons/invalid.svg
+++ b/cfgov/core/tests/staticfiles/icons/invalid.svg
@@ -1,0 +1,1 @@
+This is an invalid SVG file!

--- a/cfgov/core/tests/staticfiles/icons/test.svg
+++ b/cfgov/core/tests/staticfiles/icons/test.svg
@@ -1,0 +1,3 @@
+<svg width="100" height="100">
+  <circle cx="50" cy="50" r="40" stroke="green" fill="yellow" />
+</svg>

--- a/cfgov/core/tests/templatetags/test_svg_icon.py
+++ b/cfgov/core/tests/templatetags/test_svg_icon.py
@@ -1,0 +1,72 @@
+import os
+
+from django.template import Context, Template
+from django.test import TestCase, override_settings
+from django.utils.safestring import SafeData
+
+from core.templatetags.svg_icon import SVG_REGEX, svg_icon
+
+
+VALID_SVG = (
+    '<svg width="100" height="100">\n'
+    '  <circle cx="50" cy="50" r="40" stroke="green" fill="yellow" />\n'
+    '</svg>\n'
+)
+
+
+class SvgRegexTests(TestCase):
+    def test_empty_svg_matches(self):
+        self.assertTrue(SVG_REGEX.match('<svg></svg>'))
+
+    def test_case_insensitive_matching(self):
+        self.assertTrue(SVG_REGEX.match('<sVg></SvG>'))
+
+    def test_valid_svg_matches(self):
+        self.assertTrue(SVG_REGEX.match(VALID_SVG))
+
+    def test_valid_svg_with_extra_whitespace_matches(self):
+        self.assertTrue(SVG_REGEX.match(' ' + VALID_SVG + '\n\n'))
+
+    def test_invalid_svg_does_not_match(self):
+        self.assertFalse(SVG_REGEX.match('<script type="malicious"></script>'))
+
+    def test_nested_invalid_svg_does_not_match(self):
+        self.assertFalse(SVG_REGEX.match(
+            '<svg></svg>'
+            '<script type="this looks valid but is malicious"></script>'
+            '<svg></svg>'
+        ))
+
+
+@override_settings(
+    MOCK_STATICFILES_PATTERNS={},
+    STATICFILES_DIRS=[
+        os.path.join(
+            os.path.dirname(os.path.dirname(__file__)),
+            'staticfiles'
+        ),
+    ]
+)
+class SvgIconTests(TestCase):
+    def test_assert_renders_valid_svg_from_staticfiles_icons(self):
+        self.assertEqual(svg_icon('test'), VALID_SVG)
+
+    def test_svg_icon_result_marked_safe_for_rendering(self):
+        self.assertIsInstance(svg_icon('test'), SafeData)
+
+    def test_invalid_svg_raises_valueerror(self):
+        with self.assertRaises(ValueError):
+            svg_icon('invalid')
+
+    def test_missing_svg_raises_valueerror(self):
+        with self.assertRaises(ValueError):
+            svg_icon('missing')
+
+    def test_template_tag(self):
+        template = Template('{% load svg_icon %}{% svg_icon "test" %}')
+        self.assertEqual(template.render(Context()), VALID_SVG)
+
+    def test_template_tag_invalid(self):
+        template = Template('{% load svg_icon %}{% svg_icon "invalid" %}')
+        with self.assertRaises(ValueError):
+            template.render(Context())

--- a/cfgov/core/tests/test_jinja2tags.py
+++ b/cfgov/core/tests/test_jinja2tags.py
@@ -1,0 +1,36 @@
+import os
+
+from django.template import engines
+from django.test import TestCase, override_settings
+
+from core.tests.templatetags.test_svg_icon import VALID_SVG
+
+
+@override_settings(
+    STATICFILES_DIRS=[
+        os.path.join(os.path.dirname(__file__), 'staticfiles'),
+    ],
+    TEMPLATES=[
+        {
+            'NAME': 'test',
+            'BACKEND': 'django.template.backends.jinja2.Jinja2',
+            'OPTIONS': {
+                'extensions': [
+                    'core.jinja2tags.filters',
+                ],
+            },
+        },
+    ]
+)
+class SvgIconTests(TestCase):
+    def setUp(self):
+        self.jinja_engine = engines['test']
+
+    def test_jinja_tag(self):
+        template = self.jinja_engine.from_string('{{ svg_icon("test") }}')
+        self.assertEqual(template.render(), VALID_SVG)
+
+    def test_jinja_tag_invalid(self):
+        template = self.jinja_engine.from_string('{{ svg_icon("invalid") }}')
+        with self.assertRaises(ValueError):
+            template.render()


### PR DESCRIPTION
This change adds a new `svg_icon` template tag for both Django and Jinja templates, that allows users to render the contents of a static SVG file in their templates.

Usage in Django templates is like this:

```html
{% load svg_icon %}
{% svg_icon "test" %}
```

And in Jinja templates like this:

```html
{{ svg_icon("test") }}
```

(This requires the filter to be added to the environment in the `settings.TEMPLATES` Jinja engine.)

In both cases the tag will look for a file named `icons/test.svg` in the regular Django staticfiles search path.

This PR is intended to implement some groundwork to enable the use of Capital Framework icons as in #3887.

## Testing

See new unit tests that demonstrate the use of this template tag. This PR does not include any uses of this tag in any existing website templates.

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [X] Passes all existing automated tests
- [X] Any _change_ in functionality is tested
- [X] New functions are documented (with a description, list of inputs, and expected output)
- [X] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [X] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: