### PR TITLE
Fix outdated analytics selector

### DIFF
--- a/cfgov/unprocessed/apps/analytics-gtm/js/bah-loan-estimate-listeners.js
+++ b/cfgov/unprocessed/apps/analytics-gtm/js/bah-loan-estimate-listeners.js
@@ -30,7 +30,7 @@ const OAHLEAnalytics = ( function() {
     track( 'OAH Loan Estimate Interaction', action, currentPage );
   } );
 
-  $( '.expandable_target' ).click( function() {
+  $( '.o-expandable_target' ).click( function() {
     let ele = $( this ),
         tab = ele.closest( '.explain' ).find( '.active-tab' ),
         tabText = tab.find( '.tab-label' ).text().trim();
@@ -38,7 +38,7 @@ const OAHLEAnalytics = ( function() {
       function() {
         let state = ele.attr( 'aria-pressed' ),
             action = 'Expandable collapsed - ' + tabText,
-            label = $( '<p>' + ele.find( '.expandable_label' ).html() + '</p>' ),
+            label = $( '<p>' + ele.find( '.o-expandable_label' ).html() + '</p>' ),
             text = '';
 
         label.find( 'span' ).empty();
@@ -58,7 +58,7 @@ const OAHLEAnalytics = ( function() {
       function() {
         let action = 'Image Overlay click - expandable collapsed',
             target = $( href );
-        if ( target.hasClass( 'expandable__expanded' ) ) {
+        if ( target.hasClass( 'o-expandable__expanded' ) ) {
           action = 'Image Overlay click - expandable expanded';
         }
         track( 'OAH Loan Estimate Interaction', action, text );


### PR DESCRIPTION
Fixes a selector that was set to old-style expandables and was preventing an analytics script from firing. For use on https://www.consumerfinance.gov/owning-a-home/loan-estimate/

## Changes

- Updates selector to `o-expandable` from `expandable`
