### PR TITLE
owing-a-home/rate-checker: Move isVisible and checkIfZero to utils

### DIFF
--- a/cfgov/unprocessed/apps/owning-a-home/js/explore-rates/rate-checker.js
+++ b/cfgov/unprocessed/apps/owning-a-home/js/explore-rates/rate-checker.js
@@ -1,7 +1,9 @@
 import $ from 'jquery';
 import {
   calcLoanAmount,
+  checkIfZero,
   delay,
+  isVisible,
   renderAccessibleData,
   renderDatestamp,
   renderLoanAmount
@@ -550,50 +552,37 @@ function processLoanAmount( element ) {
 }
 
 /**
- * Check if the house price entered is 0
- * @param {Object} $price - TODO: Add description.
- * @param {Object} $percent - TODO: Add description.
- * @param {Object} $down - TODO: Add description.
- * @returns {boolean} TODO: Add description.
- */
-function checkIfZero( $price, $percent, $down ) {
-  if ( params.getVal( 'house-price' ) === '0' ||
-       +Number( params.getVal( 'house-price' ) ) === 0 ) {
-    removeAlerts();
-    chart.stopLoading();
-    downPaymentWarning();
-    return true;
-  }
-  return false;
-}
-
-/**
  * Update either the down payment % or $ amount
  * depending on the input they've changed.
  */
 function renderDownPayment() {
 
   const $el = $( this );
-  const $price = $( '#house-price' );
-  const $percent = $( '#percent-down' );
-  const $down = $( '#down-payment' );
+  const price = document.querySelector( '#house-price' );
+  const percent = document.querySelector( '#percent-down' );
+  const down = document.querySelector( '#down-payment' );
   let val;
 
   if ( !$el.val() ) {
     return;
   }
 
-  checkIfZero( $price, $percent, $down );
+  if ( checkIfZero( params.getVal( 'house-price' ) ) ) {
+    removeAlerts();
+    chart.stopLoading();
+    downPaymentWarning();
+  }
 
-  if ( $price.val() !== 0 ) {
-    if ( $el.attr( 'id' ) === 'down-payment' || options['dp-constant'] === 'down-payment' ) {
+  if ( price.val() !== 0 ) {
+    if ( $el.attr( 'id' ) === 'down-payment' ||
+          options['dp-constant'] === 'down-payment' ) {
       val = ( getSelection( 'down-payment' ) / getSelection( 'house-price' ) * 100 ) || '';
-      $percent.val( Math.round( val ) );
+      percent.val( Math.round( val ) );
     } else {
       val = getSelection( 'house-price' ) * ( getSelection( 'percent-down' ) / 100 );
       val = val >= 0 ? Math.round( val ) : '';
       val = addCommas( val );
-      $down.val( val );
+      down.val( val );
     }
   }
 }
@@ -747,14 +736,6 @@ function resultFailWarning() {
  */
 function downPaymentWarning() {
   dpAlertDom.classList.remove( 'u-hidden' );
-}
-
-/**
- * @param  {HTMLNode} elem - An HTML element to check for u-hidden class.
- * @returns {boolean} True is the element is visible, false otherwise.
- */
-function isVisible( elem ) {
-  return !elem.classList.contains( 'u-hidden' );
 }
 
 /**

--- a/cfgov/unprocessed/apps/owning-a-home/js/explore-rates/util.js
+++ b/cfgov/unprocessed/apps/owning-a-home/js/explore-rates/util.js
@@ -3,6 +3,18 @@ import formatUSD from 'format-usd';
 import unFormatUSD from 'unformat-usd';
 
 /**
+ * Check if the house price entered is 0
+ * @param {string|number} price - A price.
+ * @returns {boolean} True if price is zero, false otherwise.
+ */
+function checkIfZero( price ) {
+  if ( price === '0' || +Number( price ) === 0 ) {
+    return true;
+  }
+  return false;
+}
+
+/**
  * Simple (anonymous) delay function.
  * @return {Object} function that has been delayed.
  */
@@ -27,6 +39,14 @@ function formatTimestampMMddyyyy( timestamp ) {
      return (timestamp.getUTCMonth() + 1) + '/' + timestamp.getUTCDate() +
             '/' +  timestamp.getUTCFullYear(); */
   return formatDate.asString( 'MM/dd/yyyy', new Date( timestamp ) );
+}
+
+/**
+ * @param  {HTMLNode} elem - An HTML element to check for u-hidden class.
+ * @returns {boolean} True is the element is visible, false otherwise.
+ */
+function isVisible( elem ) {
+  return !elem.classList.contains( 'u-hidden' );
 }
 
 /**
@@ -90,7 +110,9 @@ function renderLoanAmount( elem, loanAmount ) {
 
 module.exports = {
   calcLoanAmount,
+  checkIfZero,
   delay,
+  isVisible,
   formatTimestampMMddyyyy,
   renderAccessibleData,
   renderDatestamp,

--- a/test/unit_tests/apps/owning-a-home/js/explore-rates/util-spec.js
+++ b/test/unit_tests/apps/owning-a-home/js/explore-rates/util-spec.js
@@ -45,11 +45,47 @@ describe( 'explore-rates/util', () => {
     } );
   } );
 
+  describe( 'checkIfZero()', () => {
+    it( 'should return true if value is zero.', () => {
+      expect( util.checkIfZero( '0' ) ).toBe( true );
+      expect( util.checkIfZero( 0 ) ).toBe( true );
+    } );
+
+    it( 'should return false if value is NOT zero.', () => {
+      expect( util.checkIfZero( '1' ) ).toBe( false );
+      expect( util.checkIfZero( -1 ) ).toBe( false );
+    } );
+  } );
+
+  describe( 'delay()', () => {
+    it( 'should delay function execution.', () => {
+      const testFunct = () => {
+        // This is an empty function to test the delay callback.
+      };
+      jest.useFakeTimers();
+      util.delay( testFunct, 500 );
+      expect( setTimeout ).toHaveBeenLastCalledWith( testFunct, 500 );
+    } );
+  } );
+
   describe( 'formatTimestampMMddyyyy()', () => {
     it( 'should format a timestamp as a date.', () => {
       expect( util.formatTimestampMMddyyyy( '2018-03-14T04:00:00Z' ) )
         .toBe( '03/14/2018' );
     } );
+  } );
+
+  describe( 'isVisible()', () => {
+    it( 'should return true if HTML element has u-hidden class.', () => {
+      expect( util.isVisible( timeStampDom ) ).toBe( true );
+    } );
+
+    it( 'should return false if HTML element does NOT have u-hidden class.',
+      () => {
+        timeStampDom.classList.add( 'u-hidden' );
+        expect( util.isVisible( timeStampDom ) ).toBe( false );
+      }
+    );
   } );
 
   describe( 'renderAccessibleData()', () => {
@@ -80,17 +116,6 @@ describe( 'explore-rates/util', () => {
     it( 'should format a timestamp as a date.', () => {
       util.renderLoanAmount( loanAmountResultDom, 180000 );
       expect( loanAmountResultDom.textContent ).toBe( '$180,000' );
-    } );
-  } );
-
-  describe( 'delay()', () => {
-    it( 'should delay function execution.', () => {
-      const testFunct = () => {
-        // This is an empty function to test the delay callback.
-      };
-      jest.useFakeTimers();
-      util.delay( testFunct, 500 );
-      expect( setTimeout ).toHaveBeenLastCalledWith( testFunct, 500 );
     } );
   } );
 } );


### PR DESCRIPTION
## Changes

- Move isVisible and checkIfZero to utils

## Testing

1. `gulp build` should pass and entering zero for the house price on http://localhost:8000/owning-a-home/explore-rates/ should produce an error dialog on the chart.
2. `gulp test:unit` should pass.
