### PR TITLE
Turn off polyfilling in analytics

### DIFF
--- a/cfgov/unprocessed/apps/analytics-gtm/webpack-config.js
+++ b/cfgov/unprocessed/apps/analytics-gtm/webpack-config.js
@@ -37,7 +37,9 @@ const COMMON_MODULE_CONFIG = {
       options: {
         presets: [ [ 'babel-preset-env', {
           configPath: __dirname,
-          useBuiltIns: 'usage',
+          /* Use useBuiltIns: 'usage' and set `debug: false` to see what
+             scripts require polyfilling. */
+          useBuiltIns: false,
           debug: false
         } ] ]
       }


### PR DESCRIPTION
Polyfilled scripts are throwing errors in Chrome and perhaps other browsers. This turns off the polyfilling so we can address the root cause of why they're necessary at all.

## Changes

- Turns off polyfilling in analytics scripts.

## Testing

1. `gulp build` should pass.
