### PR TITLE
Build docs as part of Travis backend build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,13 +50,6 @@ jobs:
     - stage: run tests
       env: RUNTEST=frontend
     - env: RUNTEST=backend
-    - env: RUNTEST=acceptance
-    - stage: Update documentation
-      script:
-        - pip install virtualenv virtualenvwrapper
-        - source activate-virtualenv.sh
-        - pip install -r requirements/manual.txt
-        - mkdocs build
       deploy:
         provider: pages
         local_dir: site
@@ -64,3 +57,4 @@ jobs:
         github_token: $GITHUB_TOKEN
         on:
           branch: master
+    - env: RUNTEST=acceptance

--- a/travis_run.sh
+++ b/travis_run.sh
@@ -12,6 +12,9 @@ elif [ "$RUNTEST" == "backend" ]; then
     DATABASE_URL=postgres://postgres@localhost/travis_ci_test tox -e fast
     tox -e missing-migrations
     bash <(curl -s https://codecov.io/bash) -F backend
+
+    pip install -r requirements/manual.txt
+    mkdocs build
 elif [ "$RUNTEST" == "acceptance" ]; then
     gulp test:acceptance --headless
 fi


### PR DESCRIPTION
Instead of building the docs in a separate Travis stage, do it as part of the Travis backend stage. This will save time because Travis doesn't have to spin up a new instance, re-clone the repo, etc.

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [X] Passes all existing automated tests
- [X] Any _change_ in functionality is tested
- [X] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: