### PR TITLE
Removing remaining wp-content references from repo

### DIFF
--- a/cfgov/v1/static-legacy/css/styles.css
+++ b/cfgov/v1/static-legacy/css/styles.css
@@ -2919,7 +2919,7 @@ body.page-template-page-mortgage-php {
 }
 
 .mortgages_sidekick a.mortgages_sidekick_link .not-icon-mortgage-alt {
-	background: url('/wp-content/themes/cfpb_nemo/_/img/mortgage-sign-icon.png');
+	background: url('/static/nemo/_/img/mortgage-sign-icon.png');
 	background-position: 0px 10px;
 	background-repeat: no-repeat;
 	display: block;

--- a/cfgov/v1/tests/test_page_validation.py
+++ b/cfgov/v1/tests/test_page_validation.py
@@ -35,12 +35,12 @@ class TestConvertHttpImageLinks(TestCase):
         html = (
             '<img src="http://bucket.name/img.png">'
             '<div>Other text</div>'
-            '<img src="http://www.com/wp-content/uploads/img2.png">'
+            '<img src="http://www.com/static/uploads/img2.png">'
             '<img src="/relative/img3.png">'
         )
         url_mappings = [
             ('http://bucket.name/', 'https://bucket.name/'),
-            ('http://www.com/wp-content/uploads/', 'https://other.site/'),
+            ('http://www.com/static/uploads/', 'https://other.site/'),
         ]
         self.assertEqual(
             convert_http_image_links(html, url_mappings),


### PR DESCRIPTION
Removing remaining wp-content references from repo

## Changes

- Modified files to remove remaining references from repo.

## Testing

1. Run `tox -e fast`
2. Visit `https://www.consumerfinance.gov/static/nemo/_/img/mortgage-sign-icon.png` and ensure the image exists. 

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Internet Explorer 8, 9, 10, and 11
- [ ] Edge
- [ ] iOS Safari
- [ ] Chrome for Android

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
