### PR TITLE
Removing form explainer flags

### DIFF
--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -648,10 +648,6 @@ FLAGS = {
     # To be enabled when owning-a-home/explore-rates is de-sheered.
     'OAH_EXPLORE_RATES': {},
 
-    # To be enabled when owning-a-home/closing-disclosure/
-    # and owning-a-home/loan-estimate/ are de-sheered.
-    'OAH_FORM_EXPLAINERS': {},
-
     # To be enabled when journey pages are released in Wagtail.
     'OAH_JOURNEY': {},
 

--- a/cfgov/cfgov/urls.py
+++ b/cfgov/cfgov/urls.py
@@ -86,9 +86,8 @@ urlpatterns = [
     ),
     url(r'^owning-a-home/loan-estimate/$',
         TemplateView.as_view(
-            template_name='owning-a-home/loan-estimate/index.html')
-        ,
-        name='loan-estimate'
+            template_name='owning-a-home/loan-estimate/index.html'),
+            name='loan-estimate'
     ),
 
     # Temporarily serve Wagtail OAH journey pages at `/process/` urls.

--- a/cfgov/cfgov/urls.py
+++ b/cfgov/cfgov/urls.py
@@ -69,15 +69,9 @@ urlpatterns = [
         RedirectView.as_view(
             url='/static/owning-a-home/resources/%(path)s', permanent=True)),
     url(r'^owning-a-home/closing-disclosure/',
-        FlaggedTemplateView.as_view(
-            flag_name='OAH_FORM_EXPLAINERS',
-            template_name='owning-a-home/closing-disclosure/index.html',
-            fallback=SheerTemplateView.as_view(
-                template_engine='owning-a-home',
-                template_name='closing-disclosure/index.html'
-            )
-        ),
-        name='closing-disclosure'
+        TemplateView.as_view(
+            template_name='owning-a-home/closing-disclosure/index.html'),
+            name='closing-disclosure'
     ),
     url(r'^owning-a-home/explore-rates/',
         FlaggedTemplateView.as_view(
@@ -91,14 +85,8 @@ urlpatterns = [
         name='explore-rates'
     ),
     url(r'^owning-a-home/loan-estimate/',
-        FlaggedTemplateView.as_view(
-            flag_name='OAH_FORM_EXPLAINERS',
-            template_name='owning-a-home/loan-estimate/index.html',
-            fallback=SheerTemplateView.as_view(
-                template_engine='owning-a-home',
-                template_name='loan-estimate/index.html'
-            )
-        ),
+        TemplateView.as_view(
+            template_name='owning-a-home/loan-estimate/index.html'),
         name='loan-estimate'
     ),
 

--- a/cfgov/cfgov/urls.py
+++ b/cfgov/cfgov/urls.py
@@ -68,7 +68,7 @@ urlpatterns = [
     url(r'^owning-a-home/resources/(?P<path>.*)$',
         RedirectView.as_view(
             url='/static/owning-a-home/resources/%(path)s', permanent=True)),
-    url(r'^owning-a-home/closing-disclosure/',
+    url(r'^owning-a-home/closing-disclosure/$',
         TemplateView.as_view(
             template_name='owning-a-home/closing-disclosure/index.html'),
             name='closing-disclosure'
@@ -84,9 +84,10 @@ urlpatterns = [
         ),
         name='explore-rates'
     ),
-    url(r'^owning-a-home/loan-estimate/',
+    url(r'^owning-a-home/loan-estimate/$',
         TemplateView.as_view(
-            template_name='owning-a-home/loan-estimate/index.html'),
+            template_name='owning-a-home/loan-estimate/index.html')
+        ,
         name='loan-estimate'
     ),
 


### PR DESCRIPTION
Removing form explainer flags

## Changes

- Modified code to remove form explainer flags and fixed pattern regex.


## Testing

1. Visit `http://localhost:8000/owning-a-home/closing-disclosure/` and ensure it works.
2. Visit `http://localhost:8000/owning-a-home/loan-estimate/` and ensure it works.


## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Internet Explorer 8, 9, 10, and 11
- [ ] Edge
- [ ] iOS Safari
- [ ] Chrome for Android

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
