### PR TITLE
Fixed timestamp so all US timezones will pass

### DIFF
--- a/test/unit_tests/apps/owning-a-home/js/explore-rates/util-spec.js
+++ b/test/unit_tests/apps/owning-a-home/js/explore-rates/util-spec.js
@@ -93,7 +93,7 @@ describe( 'explore-rates/util', () => {
 
   describe( 'formatTimestampMMddyyyy()', () => {
     it( 'should format a timestamp as a date.', () => {
-      expect( util.formatTimestampMMddyyyy( '2018-03-14T04:00:00Z' ) )
+      expect( util.formatTimestampMMddyyyy( '2018-03-14T12:00:00Z' ) )
         .toBe( '03/14/2018' );
     } );
   } );
@@ -130,7 +130,7 @@ describe( 'explore-rates/util', () => {
 
   describe( 'renderDatestamp()', () => {
     it( 'should format a timestamp as a date.', () => {
-      util.renderDatestamp( timeStampDom, '2018-03-14T04:00:00Z' );
+      util.renderDatestamp( timeStampDom, '2018-03-14T12:00:00Z' );
       expect( timeStampDom.textContent ).toBe( '03/14/2018' );
     } );
   } );


### PR DESCRIPTION
Currently if you reside West of the Eastern time zone this test will
fail, updated to a sane time check to ensure all US time zone workers
are covered. (Discovered in #3887)

## Changes

- Updates tested time stamp

## Testing

1. Run `gulp test:unit`, all tests should pass

## Screenshots

Before:

<img width="727" alt="screen shot 2018-04-19 at 3 05 44 pm" src="https://user-images.githubusercontent.com/1280430/39015483-1dfaa626-43e3-11e8-9f5d-8c6f407ccf83.png">

After:

<img width="373" alt="screen shot 2018-04-19 at 3 06 31 pm" src="https://user-images.githubusercontent.com/1280430/39015505-36044074-43e3-11e8-99d4-e523cc0ba82f.png">

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [x] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
