### PR TITLE
Init notifications in the correct location

### DIFF
--- a/cfgov/unprocessed/js/organisms/FormSubmit.js
+++ b/cfgov/unprocessed/js/organisms/FormSubmit.js
@@ -28,7 +28,7 @@ function FormSubmit( element, baseClass, opts ) {
   const _baseElement = atomicHelpers.checkDom( element, baseClass );
   const _formElement = _baseElement.querySelector( 'form' );
   const _notificationElement = _baseElement.querySelector( '.m-notification' );
-  const _notification = new Notification( _baseElement );
+  let _notification;
   let _cachedFields;
   const eventObserver = new EventObserver();
   const self = this;
@@ -46,6 +46,8 @@ function FormSubmit( element, baseClass, opts ) {
     }
     _cachedFields = _cacheFields();
     _formElement.addEventListener( 'submit', _onSubmit );
+    _notification = new Notification( _baseElement );
+    _notification.init();
 
     return this;
   }

--- a/test/unit_tests/js/organisms/FormSubmit-spec.js
+++ b/test/unit_tests/js/organisms/FormSubmit-spec.js
@@ -1,0 +1,80 @@
+const BASE_JS_PATH = '../../../../cfgov/unprocessed/js/';
+const FormSubmit = require( BASE_JS_PATH + 'organisms/FormSubmit' );
+const BASE_CLASS = 'o-email-signup';
+const HTML_SNIPPET = `
+  <div class="o-email-signup">
+    <header class="m-slug-header">
+      <h2 class="a-heading">
+        Stay informed
+      </h2>
+    </header>
+
+    <form id="o-email-signup_54"
+          class="o-form o-form__email-signup"
+          action="/subscriptions/new/"
+          method="POST"
+          enctype="application/x-www-form-urlencoded">
+
+      <div class="u-mb15">
+        <div class="m-notification
+                    m-notification__success">
+          <span class="m-notification_icon
+                       cf-icon"></span>
+          <div class="m-notification_content">
+            <div class="h4 m-notification_message"></div>
+          </div>
+        </div>
+      </div>
+
+      <p>Subscribe to our email newsletter. We will update you on new blogs.</p>
+
+      <div class="m-form-field-with-button" data-qa-hook="formfield-with-button">
+        <div class="m-form-field">
+          <label class="a-label a-label__heading" for="form_3">
+            Email address
+          </label>
+          <input id="form_3"
+                 type="email"
+                 placeholder="example@mail.com"
+                 name="email"
+                 class="a-text-input a-text-input__full">
+        </div>
+        <p>
+          The information you provide will permit the Consumer Financial
+          Protection Bureau to process your request or
+          inquiry.&nbsp;<a class="" href="/privacy/privacy-policy/">See more</a>.
+        </p>
+        <input class="a-btn a-btn__full-on-xs" type="submit" value="Sign up">
+      </div>
+
+      <div class="form-group">
+        <input type="hidden" name="code">
+      </div>
+
+    </form>
+  </div>
+`;
+
+describe( 'FormSubmit', () => {
+  let signupForm;
+  let formSubmit;
+  let thisFormSubmit;
+
+  beforeEach( () => {
+    document.body.innerHTML = HTML_SNIPPET;
+    signupForm = document.querySelector( `.${ BASE_CLASS }` );
+    formSubmit = new FormSubmit( signupForm, BASE_CLASS, {} );
+    thisFormSubmit = formSubmit.init();
+  } );
+
+  describe( 'init()', () => {
+    it( 'should return the FormSubmit instance when initialized', () => {
+      expect( typeof thisFormSubmit ).toEqual('object');
+      expect( signupForm.dataset.jsHook ).toEqual('state_atomic_init');
+    } );
+
+    it( 'should return undefined if already initialized', () => {
+      expect( formSubmit.init() ).toBeUndefined();
+    } );
+  } );
+} );


### PR DESCRIPTION
Currently notifications are initialized within the formSubmit which lead
to errors where the notifications weren't being updated correctly (a new 
instance was created every submission). Moving them to their direct 
parent and passing them into the formSubmit resolves the issue.

## Changes

- Moves notification init to it's parent function
- Passes notification into the formSubmit function

## Testing

1. Run `gulp test:unit` and everything should continue to pass

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [x] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
