### PR TITLE
owning-a-home/rate-checker: Move add commas util to util module

### DIFF
--- a/cfgov/unprocessed/apps/owning-a-home/js/explore-rates/rate-checker.js
+++ b/cfgov/unprocessed/apps/owning-a-home/js/explore-rates/rate-checker.js
@@ -1034,7 +1034,7 @@ function registerEvents() {
    */
   function priceFocusOutHandler( evt ) {
     evt.target.value = removeDollarAddCommas( evt.target.value );
-  };
+  }
 
 
   // Once the user has edited fields, put the kibosh on the placeholders

--- a/cfgov/unprocessed/apps/owning-a-home/js/explore-rates/rate-checker.js
+++ b/cfgov/unprocessed/apps/owning-a-home/js/explore-rates/rate-checker.js
@@ -5,6 +5,7 @@ import {
   delay,
   isKeyAllowed,
   isVisible,
+  removeDollarAddCommas,
   renderAccessibleData,
   renderDatestamp,
   renderLoanAmount,
@@ -192,7 +193,7 @@ function updateView() {
       if ( $( '#county' ).is( ':visible' ) && $( '#county' ).val() === null ) {
         chart.startLoading();
         dropdown( 'county' ).showHighlight();
-        $( '#hb-warning' ).addClass( 'u-hidden' );
+        document.querySelector( '#hb-warning' ).classList.add( 'u-hidden' );
         return;
       }
 
@@ -364,11 +365,11 @@ function checkForJumbo() {
   } );
   dropdown( 'loan-type' ).enable( norms );
   dropdown( 'loan-type' ).hideHighlight();
-  $( '#county-warning' ).addClass( 'u-hidden' );
+  document.querySelector( '#county-warning' ).classList.add( 'u-hidden' );
 
   // if loan is not a jumbo, hide the loan type warning
   if ( $.inArray( params.getVal( 'loan-type' ), jumbos ) < 0 ) {
-    $( '#hb-warning' ).addClass( 'u-hidden' );
+    document.querySelector( '#hb-warning' ).classList.add( 'u-hidden' );
     dropdown( 'loan-type' ).hideHighlight();
   }
 
@@ -399,7 +400,7 @@ function checkForJumbo() {
   dropdown( 'county' ).show();
 
   // Hide any existing message, then show a message if appropriate.
-  $( '#county-warning' ).addClass( 'u-hidden' );
+  document.querySelector( '#county-warning' ).classList.add( 'u-hidden' );
   if ( warnings.hasOwnProperty( params.getVal( 'loan-type' ) ) ) {
     $( '#county-warning' ).removeClass( 'u-hidden' ).find( 'p' ).text( warnings[params.getVal( 'loan-type' )].call() );
   } else {
@@ -480,7 +481,7 @@ function processCounty() {
     dropdown( 'loan-type' ).removeOption( jumbos );
     dropdown( 'loan-type' ).enable( norms );
 
-    $( '#hb-warning' ).addClass( 'u-hidden' );
+    document.querySelector( '#hb-warning' ).classList.add( 'u-hidden' );
     // Select appropriate loan type if loan was kicked out of jumbo
     if ( params.getVal( 'prevLoanType' ) === 'fha-hb' ) {
       $( '#loan-type' ).val( 'fha' );
@@ -494,7 +495,7 @@ function processCounty() {
   }
 
   // Hide the county warning.
-  $( '#county-warning' ).addClass( 'u-hidden' );
+  document.querySelector( '#county-warning' ).classList.add( 'u-hidden' );
 }
 
 /**
@@ -550,7 +551,7 @@ function renderDownPayment() {
     } else {
       val = getSelection( 'house-price' ) * ( getSelection( 'percent-down' ) / 100 );
       val = val >= 0 ? Math.round( val ) : '';
-      val = addCommas( val );
+      val = removeDollarAddCommas( val );
       down.value = val;
     }
   }
@@ -644,7 +645,7 @@ function renderInterestSummary( intVals, term ) {
  */
 function checkARM() {
   // reset warning and info
-  $( '#arm-warning' ).addClass( 'u-hidden' );
+  document.querySelector( '#arm-warning' ).classList.add( 'u-hidden' );
   $( '.arm-info' ).addClass( 'u-hidden' );
   const disallowedTypes = [ 'fha', 'va', 'va-hb', 'fha-hb' ];
   const disallowedTerms = [ '15' ];
@@ -672,7 +673,7 @@ function checkARM() {
       dropdown( [ 'loan-term', 'loan-type' ] ).enable();
     }
     dropdown( 'arm-type' ).hide();
-    $( '#arm-warning' ).addClass( 'u-hidden' );
+    document.querySelector( '#arm-warning' ).classList.add( 'u-hidden' );
     $( '.arm-info' ).addClass( 'u-hidden' );
     $( '.no-arm' ).removeClass( 'u-hidden' );
   }
@@ -693,7 +694,7 @@ function scoreWarning() {
  */
 function resultWarning() {
   chart.stopLoading( 'error' );
-  $( '#chart-section' ).addClass( 'warning' );
+  document.querySelector( '#chart-section' ).classList.add( 'warning' );
   resultAlertDom.classList.remove( 'u-hidden' );
 }
 
@@ -702,7 +703,7 @@ function resultWarning() {
  */
 function resultFailWarning() {
   chart.stopLoading( 'error' );
-  $( '#chart-section' ).addClass( 'warning' );
+  document.querySelector( '#chart-section' ).classList.add( 'warning' );
   failAlertDom.classList.remove( 'u-hidden' );
 }
 
@@ -736,18 +737,6 @@ function removeCreditScoreAlert() {
     slider.setState( Slider.STATUS_OKAY );
     creditAlertDom.classList.add( 'u-hidden' );
   }
-}
-
-/**
- * Add commas to numbers where appropriate.
- * @param {string} value - Old value where commas will be added.
- * @returns {string} value - Value with commas and no dollar sign.
- */
-function addCommas( value ) {
-  value = unFormatUSD( value );
-  value = formatUSD( value, { decimalPlaces: 0 } )
-    .replace( '$', '' );
-  return value;
 }
 
 /**
@@ -961,13 +950,15 @@ function registerEvents() {
   } );
 
   // ARM highlighting handler.
-  $( '#rate-structure' ).on( 'change', function() {
-    if ( $( this ).val() !== params.getVal( 'rate-structure' ) ) {
+  const rateStructureDom = document.querySelector( '#rate-structure' );
+  rateStructureDom.addEventListener( 'change', evt => {
+    if ( evt.target.value !== params.getVal( 'rate-structure' ) ) {
       dropdown( 'arm-type' ).showHighlight();
     }
   } );
 
-  $( '#arm-type' ).on( 'change', function() {
+  const armTypeDom = document.querySelector( '#arm-type' );
+  armTypeDom.addEventListener( 'change', () => {
     dropdown( 'arm-type' ).hideHighlight();
   } );
 
@@ -976,7 +967,7 @@ function registerEvents() {
     /* If the loan-type is conf, and there's a county visible,
        then we just exited a HB situation.
        Clear the county before proceeding. */
-    $( '#hb-warning' ).addClass( 'u-hidden' );
+    document.querySelector( '#hb-warning' ).classList.add( 'u-hidden' );
     // If the state field changed, wipe out county.
     if ( $( this ).attr( 'id' ) === 'location' ) {
       $( '#county' ).html( '' );
@@ -1019,9 +1010,12 @@ function registerEvents() {
   calcLoanAmountDom.addEventListener( 'keyup', NoCalcOnForbiddenKeys );
   creditScoreDom.addEventListener( 'keyup', NoCalcOnForbiddenKeys );
 
-  function NoCalcOnForbiddenKeys( event ) {
-    const element = event.target;
-    const key = event.which;
+  /**
+   * @param  {KeyboardEvent} evt Event object.
+   */
+  function NoCalcOnForbiddenKeys( evt ) {
+    const element = evt.target;
+    const key = evt.keyCode;
 
     // Don't recalculate on TAB or arrow keys.
     if ( isKeyAllowed( key ) || element.classList.contains( 'a-range' ) ) {
@@ -1029,12 +1023,18 @@ function registerEvents() {
     }
   }
 
-  $( '#house-price, #down-payment' ).on( 'focusout', function( evt ) {
-    let value;
-    value = $( evt.target ).val();
-    value = addCommas( value );
-    $( evt.target ).val( value );
-  } );
+  const housePriceDom = document.querySelector( '#house-price' );
+  const downPaymentDom = document.querySelector( '#down-payment' );
+
+  housePriceDom.addEventListener( 'focusout', priceFocusOutHandler );
+  downPaymentDom.addEventListener( 'focusout', priceFocusOutHandler );
+
+  /**
+   * @param  {FocusEvent} evt Event object.
+   */
+  function priceFocusOutHandler( evt ) {
+    evt.target.value = removeDollarAddCommas( evt.target.value );
+  };
 
 
   // Once the user has edited fields, put the kibosh on the placeholders

--- a/cfgov/unprocessed/apps/owning-a-home/js/explore-rates/util.js
+++ b/cfgov/unprocessed/apps/owning-a-home/js/explore-rates/util.js
@@ -68,6 +68,17 @@ function isVisible( elem ) {
 }
 
 /**
+ * Add commas to numbers where appropriate.
+ * @param {string} value - Old value where commas will be added.
+ * @returns {string} Value with commas and no dollar sign.
+ */
+function removeDollarAddCommas( value ) {
+  let parseValue = unFormatUSD( value );
+  parseValue = formatUSD( parseValue, { decimalPlaces: 0 } ).replace( '$', '' );
+  return parseValue;
+}
+
+/**
  * Render chart data in an accessible format.
  * @param {HTMLNode} tableHead - A <thead> element.
  * @param {HTMLNode} tableBody - A <tbody> element.
@@ -171,6 +182,7 @@ module.exports = {
   formatTimestampMMddyyyy,
   isKeyAllowed,
   isVisible,
+  removeDollarAddCommas,
   renderAccessibleData,
   renderDatestamp,
   renderLoanAmount,

--- a/test/unit_tests/apps/owning-a-home/js/explore-rates/rate-checker-spec.js
+++ b/test/unit_tests/apps/owning-a-home/js/explore-rates/rate-checker-spec.js
@@ -163,12 +163,12 @@ describe( 'explore-rates/rate-checker', () => {
       rateStructureDom = document.querySelector( '#rate-structure' );
       armTypeDom = document.querySelector( '#arm-type' );
       rateChecker.init();
-    } )
+    } );
 
     it( 'Should process value in down payment when leaving focus', () => {
-      expect( downPaymentDom.value ).toBe( "20000" );
+      expect( downPaymentDom.value ).toBe( '20000' );
       simulateEvent( 'focusout', downPaymentDom );
-      expect( downPaymentDom.value ).toBe( "20,000" );
+      expect( downPaymentDom.value ).toBe( '20,000' );
     } );
   } );
 } );

--- a/test/unit_tests/apps/owning-a-home/js/explore-rates/rate-checker-spec.js
+++ b/test/unit_tests/apps/owning-a-home/js/explore-rates/rate-checker-spec.js
@@ -1,6 +1,8 @@
 const BASE_JS_PATH = '../../../../../../cfgov/unprocessed/apps/owning-a-home/';
 const rateChecker = require( BASE_JS_PATH + 'js/explore-rates/rate-checker' );
 
+import { simulateEvent } from '../../../../../util/simulate-event';
+
 const HTML_SNIPPET = `
   <div class="rate-checker">
     <div id="rate-results">
@@ -71,7 +73,7 @@ const HTML_SNIPPET = `
                 <div class="dollar-input">
                     <span class="unit">$</span>
                     <input type="text" placeholder="20,000" name="down-payment"
-                           class="recalc" "="" id="down-payment">
+                           class="recalc" "="" id="down-payment" value="20000">
                 </div>
             </div>
             <div class="loan-amt-total half-width-gt-1230">
@@ -92,6 +94,35 @@ const HTML_SNIPPET = `
               Your down payment cannot be more than your house price.
             </div>
         </section>
+
+        <section class="calc-loan-details">
+
+          <div class="upper rate-structure half-width-gt-1230">
+              <label for="rate-structure">Rate type</label>
+              <div class="select-content a-select">
+                  <select name="rate-structure" class="recalc" id="rate-structure">
+                      <option value="fixed">Fixed</option>
+                      <option value="arm">Adjustable</option>
+                  </select>
+              </div>
+          </div>
+
+          <div class="arm-type half-width-gt-1230 u-hidden">
+              <label for="arm-type">ARM type</label>
+              <div class="select-content a-select">
+                  <select name="arm-type" class="recalc" id="arm-type">
+                      <option value="3-1">3/1</option>
+                      <option value="5-1">5/1</option>
+                      <option value="7-1">7/1</option>
+                      <option value="10-1">10/1</option>
+                  </select>
+              </div>
+          </div>
+        </section>
+
+        <section class="form-sub warning u-hidden" id="arm-warning">
+          <p class="warning-text">While some lenders may offer FHA, VA, or 15-year adjustable-rate mortgages, they are rare. We don’t have enough data to display results for these combinations. Choose a fixed rate if you’d like to try these options.</p>
+        </section>
       </div>
     </div>
     <div class="rc-results" id="rate-results" aria-live="polite">
@@ -103,12 +134,16 @@ const HTML_SNIPPET = `
   </div>
 `;
 
+let downPaymentDom;
+let rateStructureDom;
+let armTypeDom;
+
 describe( 'explore-rates/rate-checker', () => {
-  beforeEach( () => {
-    document.body.innerHTML = HTML_SNIPPET;
-  } );
 
   describe( 'init()', () => {
+    beforeEach( () => {
+      document.body.innerHTML = HTML_SNIPPET;
+    } );
 
     it( 'should not initialize when rate-checker class isn\'t found', () => {
       document.body.innerHTML = '';
@@ -119,5 +154,21 @@ describe( 'explore-rates/rate-checker', () => {
       expect( rateChecker.init() ).toBe( true );
     } );
 
+  } );
+
+  describe( 'interactions', () => {
+    beforeEach( () => {
+      document.body.innerHTML = HTML_SNIPPET;
+      downPaymentDom = document.querySelector( '#down-payment' );
+      rateStructureDom = document.querySelector( '#rate-structure' );
+      armTypeDom = document.querySelector( '#arm-type' );
+      rateChecker.init();
+    } )
+
+    it( 'Should process value in down payment when leaving focus', () => {
+      expect( downPaymentDom.value ).toBe( "20000" );
+      simulateEvent( 'focusout', downPaymentDom );
+      expect( downPaymentDom.value ).toBe( "20,000" );
+    } );
   } );
 } );

--- a/test/unit_tests/apps/owning-a-home/js/explore-rates/util-spec.js
+++ b/test/unit_tests/apps/owning-a-home/js/explore-rates/util-spec.js
@@ -57,6 +57,12 @@ describe( 'explore-rates/util', () => {
       accessibleDataDom.querySelector( '.table-body' );
   } );
 
+  describe( 'removeDollarAddCommas()', () => {
+    it( 'should return true if HTML element has u-hidden class.', () => {
+      expect( util.removeDollarAddCommas( '$10000' ) ).toBe( '10,000' );
+    } );
+  } );
+
   describe( 'calcLoanAmount()', () => {
     it( 'should calculate a loan amount in USD ' +
         'given a house price and down payment amount.', () => {
@@ -120,7 +126,6 @@ describe( 'explore-rates/util', () => {
       }
     );
   } );
-
 
   describe( 'renderAccessibleData()', () => {
     it( 'should format a timestamp as a date.', () => {


### PR DESCRIPTION
## Changes

- Move `removeDollarAddCommas` to util modules.
- Removes jquery references from id lookups.

## Testing

1. `gulp test:unit` should pass.
2. `gulp build` should pass.
3. Should be able to enter 20000 or whatever in the down payment field and it gets formatted as 20,000.
