### PR TITLE
Dom tools tests

### DIFF
--- a/cfgov/unprocessed/apps/owning-a-home/js/dom-tools.js
+++ b/cfgov/unprocessed/apps/owning-a-home/js/dom-tools.js
@@ -4,135 +4,166 @@ const NO_OP = function( ) {
   // Placeholder function meant to be overridden.
 };
 
-const DT = {
-  applyAll: function applyAll( elements, applyFn ) {
-    if ( elements instanceof HTMLElement ) {
-      elements = [ elements ];
-    }
+function applyAll( elements, applyFn ) {
+  if ( elements instanceof HTMLElement ) {
+    elements = [ elements ];
+  }
 
-    return [].slice.call( elements ).forEach( applyFn );
-  },
-  bindEvents: function bindEvents( elements, events, callback = NO_OP ) {
-    if ( Array.isArray( events ) === false ) {
-      events = [ events ];
-    }
+  return [].slice.call( elements ).forEach( applyFn );
+}
 
-    if ( typeof elements === 'string' ) {
-      elements = DT.getEls( elements );
-    }
+function bindEvents( elements, events, callback = NO_OP ) {
+  if ( Array.isArray( events ) === false ) {
+    events = [ events ];
+  }
 
-    DT.applyAll( elements, function( element ) {
-      events.forEach( event => {
-        element.addEventListener( event, callback );
-      } );
+  if ( typeof elements === 'string' ) {
+    elements = DT.getEls( elements );
+  }
+
+  DT.applyAll( elements, function( element ) {
+    events.forEach( event => {
+      element.addEventListener( event, callback );
     } );
-  },
-  createElement: function createElement( HTML ) {
-    const div = document.createElement( 'div' );
-    div.innerHTML = HTML;
+  } );
+}
 
-    return div.firstChild;
-  },
-  removeClass: function removeClass( selector, className ) {
-    className = className.split( ', ' );
+function createElement( HTML ) {
+  const div = document.createElement( 'div' );
+  div.innerHTML = HTML;
 
-    return DT.applyAll(
-      DT.getEls( selector ),
-      element => {
-        fastDom.mutate( () =>
-          element.classList.remove( ...className )
-        );
-      } );
-  },
-  addClass: function addClass( selector, className ) {
-    className = className.split( ', ' );
+  return div.firstChild;
+}
 
-    return DT.applyAll(
-      DT.getEls( selector ),
-      element =>
-        fastDom.mutate( () =>
-          element.classList.add( ...className )
-        )
-    );
-  },
-  hasClass: function hasClass( selector, className ) {
-    return DT.getEl( selector ).classList.contains( className );
-  },
-  getEls: function getEls( selector ) {
-    if ( DT.isEl( selector ) ) {
-      return selector;
-    }
+function removeClass( selector, className ) {
+  className = className.split( ', ' );
 
-    return document.querySelectorAll( selector );
-  },
-  getEl: function getEl( selector ) {
-    if ( DT.isEl( selector ) ) {
-      return selector;
-    }
+  return DT.applyAll(
+    DT.getEls( selector ),
+    element => {
+      fastDom.mutate( () =>
+        element.classList.remove( ...className )
+      );
+    } );
+}
 
-    return document.querySelector( selector );
-  },
-  getPreviousEls: function getPreviousEls( element, filter = '*' ) {
-    const previousSiblings = [];
-    let prevEl = element.previousElementSibling;
-    function _getMatches( el ) {
-      return el.matches ||
-               el.webkitMatchesSelector ||
-               el.mozMatchesSelector ||
-               el.msMatchesSelector;
-    }
-    const _matchesMethod = _getMatches( element );
+function addClass( selector, className ) {
+  className = className.split( ', ' );
 
-    while ( prevEl ) {
-      if ( _matchesMethod.bind( prevEl )( filter ) ) {
-        previousSiblings.push( prevEl );
-      }
-      prevEl = prevEl.previousElementSibling;
-    }
-    return previousSiblings;
-  },
-  isEl: function isEl( element ) {
-    return element instanceof NodeList ||
-           element instanceof HTMLElement ||
-           element instanceof Window;
-  },
-  hide: function hide( selector ) {
-    return DT.applyAll( DT.getEls( selector ),
-      element => fastDom.mutate(
-        () => ( element.style.display = 'none' )
+  return DT.applyAll(
+    DT.getEls( selector ),
+    element =>
+      fastDom.mutate( () =>
+        element.classList.add( ...className )
       )
-    );
-  },
-  show: function show( selector ) {
-    return DT.applyAll( DT.getEls( selector ),
-      element => fastDom.mutate(
-        () => ( element.style.display = 'block' )
-      )
-    );
-  },
-  fadeIn: function fadeIn( element, time, callback = NO_OP ) {
-    element.style.transition = 'opacity ' + time + 'ms ease-in-out';
-    element.style.opacity = 0.05;
-    element.style.display = 'block';
-    window.setTimeout( () => ( element.style.opacity = 1 ), 100 );
-    window.setTimeout( () => callback(), time );
-  },
-  fadeOut: function fadeOut( element, time, callback = NO_OP ) {
-    element.style.transition = 'opacity ' + time + 'ms ease-in-out';
-    element.style.opacity = 1;
-    window.setTimeout( () => ( element.style.opacity = 0.05 ), 100 );
-    window.setTimeout(
-      () => {
-        element.style.display = 'none';
-        return callback();
-      },
-      time
-    );
-  },
+  );
+}
+
+function hasClass( selector, className ) {
+  return DT.getEl( selector ).classList.contains( className );
+}
+
+function getEls( selector ) {
+  if ( _isEl( selector ) ) {
+    return selector;
+  }
+
+  return document.querySelectorAll( selector );
+}
+
+function getEl( selector ) {
+  if ( _isEl( selector ) ) {
+    return selector;
+  }
+
+  return document.querySelector( selector );
+}
+
+function getPreviousEls( element, filter = '*' ) {
+  const previousSiblings = [];
+  let prevEl = element.previousElementSibling;
+  function _getMatches( el ) {
+    return el.matches ||
+             el.webkitMatchesSelector ||
+             el.mozMatchesSelector ||
+             el.msMatchesSelector;
+  }
+  const _matchesMethod = _getMatches( element );
+
+  while ( prevEl ) {
+    if ( _matchesMethod.bind( prevEl )( filter ) ) {
+      previousSiblings.push( prevEl );
+    }
+    prevEl = prevEl.previousElementSibling;
+  }
+  return previousSiblings;
+}
+
+/**
+ * Check whether something is an element or not.
+ * @param  {[type]}  element [description]
+ * @return {Boolean}         [description]
+ */
+function _isEl( element ) {
+  return element instanceof NodeList ||
+         element instanceof HTMLElement ||
+         element instanceof Window;
+}
+
+function hide( selector ) {
+  return DT.applyAll(
+    DT.getEls( selector ),
+    element => fastDom.mutate(
+      () => ( element.style.display = 'none' )
+    )
+  );
+}
+
+function show( selector ) {
+  return DT.applyAll(
+    DT.getEls( selector ),
+    element => fastDom.mutate(
+      () => ( element.style.display = 'block' )
+    )
+  );
+}
+
+function fadeIn( element, time, callback = NO_OP ) {
+  element.style.transition = 'opacity ' + time + 'ms ease-in-out';
+  element.style.opacity = 0.05;
+  element.style.display = 'block';
+  window.setTimeout( () => ( element.style.opacity = 1 ), 100 );
+  window.setTimeout( () => callback(), time );
+}
+
+function fadeOut( element, time, callback = NO_OP ) {
+  element.style.transition = 'opacity ' + time + 'ms ease-in-out';
+  element.style.opacity = 1;
+  window.setTimeout( () => ( element.style.opacity = 0.05 ), 100 );
+  window.setTimeout(
+    () => {
+      element.style.display = 'none';
+      return callback();
+    },
+    time
+  );
+}
+
+export default {
+  applyAll,
+  bindEvents,
+  createElement,
+  removeClass,
+  addClass,
+  hasClass,
+  getEls,
+  getEl,
+  getPreviousEls,
+  hide,
+  show,
+  fadeIn,
+  fadeOut,
   mutate: fastDom.mutate.bind( fastDom ),
   measure: fastDom.measure.bind( fastDom ),
   nextFrame: fastDom.raf
 };
-
-export default DT;
-

--- a/cfgov/unprocessed/apps/owning-a-home/js/dom-tools.js
+++ b/cfgov/unprocessed/apps/owning-a-home/js/dom-tools.js
@@ -7,6 +7,7 @@ const NO_OP = () => {
 /**
  * Apply a function to one or more elements.
  * @param {HTMLElement|NodeList} elements - An HTML element or a list of them.
+ * @param {Function} applyFn - A function to apply to the elements.
  * @returns {boolean} True if function was applied, false otherwise.
  */
 function applyAll( elements, applyFn ) {
@@ -88,6 +89,7 @@ function addClass( selector, className ) {
 /**
  * @param {string} selector - A DOM selector.
  * @param {string} className - A CSS class name.
+ * @returns {boolean} True if it contains the class, false otherwise.
  */
 function hasClass( selector, className ) {
   return getEl( selector ).classList.contains( className );
@@ -95,6 +97,7 @@ function hasClass( selector, className ) {
 
 /**
  * @param {string} selector - A DOM selector.
+ * @returns {NodeList} List of retrieved elements.
  * TODO: This should have a conistent return type if possible.
  */
 function getEls( selector ) {
@@ -107,6 +110,7 @@ function getEls( selector ) {
 
 /**
  * @param {string} selector - A DOM selector.
+ * @returns {HTMLNode} The retrieved element.
  * TODO: This should have a conistent return type if possible.
  */
 function getEl( selector ) {
@@ -118,7 +122,9 @@ function getEl( selector ) {
 }
 
 /**
- * @param {string} selector - A DOM selector.
+ * @param {string} element - An HTML element.
+ * @param {string} filter - Selector for matching on elements.
+ * @returns {Array} List of previous elements.
  * TODO: This should have a conistent return type if possible.
  */
 function getPreviousEls( element, filter = '*' ) {

--- a/test/unit_tests/apps/owning-a-home/js/dom-tools-spec.js
+++ b/test/unit_tests/apps/owning-a-home/js/dom-tools-spec.js
@@ -1,0 +1,38 @@
+const BASE_JS_PATH = '../../../../../cfgov/unprocessed/apps/owning-a-home/';
+const domTools = require( BASE_JS_PATH + 'js/dom-tools.js' ).default;
+
+const HTML_SNIPPET = `
+  <div id="test"></div>
+  <div class="test"></div>
+  <div class="test"></div>
+  <div class="test"></div>
+`;
+
+let testDom;
+let testDomList;
+
+describe( 'dom-tools', () => {
+
+  beforeEach( () => {
+    document.body.innerHTML = HTML_SNIPPET;
+    testDom = document.querySelector( '#test' );
+    testDomList = document.querySelectorAll( '.test' );
+  } );
+
+  describe( 'applyAll()', () => {
+    it( 'should apply a function to an element or list of elements', () => {
+      const testFunc = () => {
+        // Empty function for testing.
+      };
+      expect( domTools.applyAll( 'wrong', testFunc ) ).toBe( false );
+      expect( domTools.applyAll( testDom, testFunc ) ).toBe( true );
+      expect( domTools.applyAll( testDomList, testFunc ) ).toBe( true );
+    } );
+
+    it( 'should create a div containing arbitrary HTML', () => {
+      expect( domTools.createElement( HTML_SNIPPET ).outerHTML ).toBe(
+        `<div id="test"></div>`
+      );
+    } );
+  } );
+} );

--- a/test/unit_tests/apps/owning-a-home/js/dom-tools-spec.js
+++ b/test/unit_tests/apps/owning-a-home/js/dom-tools-spec.js
@@ -31,7 +31,7 @@ describe( 'dom-tools', () => {
 
     it( 'should create a div containing arbitrary HTML', () => {
       expect( domTools.createElement( HTML_SNIPPET ).outerHTML ).toBe(
-        `<div id="test"></div>`
+        '<div id="test"></div>'
       );
     } );
   } );


### PR DESCRIPTION
## Additions

- Adds initial BAH dom-tools spec.

## Changes

- Minor refactoring of dom-tools:
  - Remove unnecessary nesting.
  - Removes returns of applyAll, which runs forEach, which doesn't appear to return anything but undefined.
  - Changes `return div.firstChild` to `div.children[0]` to avoid returning text nodes.
  - Returns boolean from `applyAll`
  - Don't run split on arrays on `applyAll`.
  - Make isEl method internal.
  - Documents methods.

## Testing

1. `gulp test:unit` should pass and show 20% coverage in dom-tools.
2. `gulp clean && gulp build` should pass and form explainers should be unchanged in functionality.
