### PR TITLE
Updates fake emails

### DIFF
--- a/cfgov/jinja2/v1/_includes/macros/subscribe.html
+++ b/cfgov/jinja2/v1/_includes/macros/subscribe.html
@@ -26,7 +26,7 @@
         <input id="email-subscribe-form_email"
                type="email"
                name="email"
-               placeholder="example@mail.com"
+               placeholder="mail@example.com"
                required>
     </div>
     <p class="u-mt10">

--- a/cfgov/jinja2/v1/_includes/organisms/reg-comment.html
+++ b/cfgov/jinja2/v1/_includes/organisms/reg-comment.html
@@ -66,7 +66,7 @@
             <span class="label_note">(optional)</span>
         </label>
         <input type="email" id="email" name="email"
-               placeholder="example@mail.com">
+               placeholder="mail@example.com">
 
         <p class="o-reg-comment_disclaimer">
             <span class="o-reg-comment_disclaimer-em">


### PR DESCRIPTION
We should always use example.com for filler domains, mail.com is a spammy actual domain.

## Changes

- Changes `mail.com` to `example.com` in email signup.
