### PR TITLE
Only warn about deprecated database variables locally

### DIFF
--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -1,6 +1,5 @@
 import os
 import sys
-import warnings
 
 from django.conf import global_settings
 from django.utils.translation import ugettext_lazy as _
@@ -182,20 +181,6 @@ if os.getenv('DATABASE_URL'):
     DATABASES['default'] = dj_database_url.config()
 # Otherwise, support the legacy use of MySQL-specific environment variables.
 elif os.getenv('MYSQL_NAME'):
-    MYSQL_VARIABLES_DEPRECATED = """
-The ability to define your MySQL database through the use of environment
-variables like MYSQL_NAME will soon be deprecated in favor of the single
-DATABASE_URL environment variable.
-
-Please modify your environment to instead use something like this:
-
-DATABASE_URL=mysql://username:password@host/dbname
-
-See https://github.com/kennethreitz/dj-database-url for other examples of how
-to define DATABASE_URL.
-"""
-
-    warnings.warn(MYSQL_VARIABLES_DEPRECATED)
     DATABASES['default'] =  {
         'ENGINE': 'django.db.backends.mysql',
         'NAME': os.environ.get('MYSQL_NAME', ''),

--- a/cfgov/cfgov/settings/local.py
+++ b/cfgov/cfgov/settings/local.py
@@ -1,3 +1,5 @@
+import warnings
+
 from unipath import DIRS
 
 from .base import *
@@ -67,3 +69,19 @@ if os.environ.get('ENABLE_POST_PREVIEW_CACHE'):
 # Use a mock GovDelivery API instead of the real thing.
 # Remove this line to use the real API instead.
 GOVDELIVERY_API = 'core.govdelivery.LoggingMockGovDelivery'
+
+
+if not os.getenv('DATABASE_URL') and os.getenv('MYSQL_NAME'):
+    MYSQL_VARIABLES_DEPRECATED = """
+The ability to define your MySQL database through the use of environment
+variables like MYSQL_NAME will soon be deprecated in favor of the single
+DATABASE_URL environment variable.
+
+Please modify your environment to instead use something like this:
+
+DATABASE_URL=mysql://username:password@host/dbname
+
+See https://github.com/kennethreitz/dj-database-url for other examples of how
+to define DATABASE_URL.
+"""
+    warnings.warn(MYSQL_VARIABLES_DEPRECATED)


### PR DESCRIPTION
The changes in #4013 (c94b26e) introduced a warning message about database environment variables being deprecated. Placing this message in `settings.base` unfortunately means that it is logged even in production, where we still use those legacy variables.

We still want this warning, but only locally and in tests.

This change moves the warning from `settings.base` to `settings.local`.

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [X] Passes all existing automated tests
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: