### PR TITLE
Fix for chart error message

### DIFF
--- a/cfgov/unprocessed/apps/owning-a-home/js/explore-rates/RateCheckerChart.js
+++ b/cfgov/unprocessed/apps/owning-a-home/js/explore-rates/RateCheckerChart.js
@@ -174,13 +174,14 @@ function RateCheckerChart() {
 
   /**
    * Show an error alert.
-   * @param {[number]} errorStatusId Pass RateCheckerChart.STATUS_ERROR.
+   * @param {[number]} state
+   *   Pass RateCheckerChart.STATUS_WARNING or RateCheckerChart.STATUS_ERROR.
    */
-  function finishLoading( errorStatusId ) {
+  function finishLoading( state ) {
     _containerDom.classList.remove( 'geolocating' );
 
     if ( errorStatusId ) {
-      setStatus( errorStatusId );
+      setStatus( state );
     } else {
       _dataLoadedDom.classList.remove( 'loading' );
       _dataLoadedDom.classList.add( 'loaded' );

--- a/cfgov/unprocessed/apps/owning-a-home/js/explore-rates/RateCheckerChart.js
+++ b/cfgov/unprocessed/apps/owning-a-home/js/explore-rates/RateCheckerChart.js
@@ -180,7 +180,7 @@ function RateCheckerChart() {
   function finishLoading( state ) {
     _containerDom.classList.remove( 'geolocating' );
 
-    if ( errorStatusId ) {
+    if ( state ) {
       setStatus( state );
     } else {
       _dataLoadedDom.classList.remove( 'loading' );

--- a/cfgov/unprocessed/apps/owning-a-home/js/explore-rates/RateCheckerChart.js
+++ b/cfgov/unprocessed/apps/owning-a-home/js/explore-rates/RateCheckerChart.js
@@ -179,7 +179,9 @@ function RateCheckerChart() {
   function finishLoading( errorStatusId ) {
     _containerDom.classList.remove( 'geolocating' );
 
-    if ( errorStatusId !== RateCheckerChart.STATUS_ERROR ) {
+    if ( errorStatusId ) {
+      setStatus( errorStatusId );
+    } else {
       _dataLoadedDom.classList.remove( 'loading' );
       _dataLoadedDom.classList.add( 'loaded' );
     }


### PR DESCRIPTION
Chart wasn't showing an error when it should have.

## Changes

- Set status of chart when `finishLoading` method is passed a status.

## Testing

1. `gulp clean && gulp build`
2. /owning-a-home/explore-rates/ and move slider to 600 and an error should show on the chart.
