### PR TITLE
Restore MySQL to tox testing environment

### DIFF
--- a/cfgov/jobmanager/tests/models/test_panels.py
+++ b/cfgov/jobmanager/tests/models/test_panels.py
@@ -6,7 +6,7 @@ from wagtail.wagtailcore.models import Page
 from mock import Mock
 from model_mommy import mommy
 
-from jobmanager.models.django import ApplicantType
+from jobmanager.models.django import ApplicantType, JobLocation
 from jobmanager.models.pages import JobListingPage
 from jobmanager.models.panels import (
     EmailApplicationLink, USAJobsApplicationLink
@@ -22,7 +22,12 @@ class ApplicationLinkTestCaseMixin(object):
         cls.root = Page.objects.get(slug='root')
 
     def setUp(self):
-        self.job_listing = mommy.prepare(JobListingPage, description='foo')
+        location = JobLocation.objects.create(abbreviation='US', name='USA')
+        self.job_listing = mommy.prepare(
+            JobListingPage,
+            description='foo',
+            location=location
+        )
         self.job_listing.full_clean = Mock(return_value=None)
         self.root.add_child(instance=self.job_listing)
 

--- a/tox.ini
+++ b/tox.ini
@@ -154,6 +154,7 @@ setenv=
     LC_ALL=en_US.UTF-8
 deps=
     -r{toxinidir}/requirements/libraries.txt
+    -r{toxinidir}/requirements/mysql.txt
     -r{toxinidir}/requirements/postgres.txt
     -r{toxinidir}/requirements/test.txt
 commands=


### PR DESCRIPTION
PR #4013 (bbaa311) mistakenly broke tox testing against a MySQL database. This adds the MySQL dependencies back to the tox environment.

## Testing

Confirm that this command works properly to run the unit tests against a MySQL database, with necessary dependencies installed in the tox environment:

`DATABASE_URL=mysql://root@localhost/v1 tox -e fast`

(Note that there may be some test failures that are MySQL-specific. This PR is just making sure that the tests can be run against MySQL.)

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [X] Passes all existing automated tests
- [X] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: