### PR TITLE
Add default sorting options to the wagtail table editor

### DIFF
--- a/cfgov/jinja2/v1/_includes/organisms/table.html
+++ b/cfgov/jinja2/v1/_includes/organisms/table.html
@@ -62,8 +62,11 @@
                 {% endif %}
             <th scope="col"{{ width_class | default }}>
                 {% if value.is_sortable and value.sortable_types[loop.index0] != '' %}
-                    {% set data_sort = ' data-sort_type="' + value.sortable_types[loop.index0] + '"' %}
-                    <button class="sortable"{{ data_sort }}>
+                    {% set sort_value = value.sortable_types[loop.index0] %}
+                    {% set data_sort = sort_value | replace('-default', '') %}
+                    {% set sort_default = true if '-default' in sort_value else false %}
+                    <button class="sortable{{ ' sorted-up' if sort_default else '' }}"
+                            data-sort_type="{{ data_sort }}">
                         {{ _render_cell(cell) | striptags }}
                     </button>
                 {% else %}

--- a/cfgov/templates/wagtailadmin/table_input.html
+++ b/cfgov/templates/wagtailadmin/table_input.html
@@ -171,6 +171,8 @@
         <option value="">None</option>
         <option value="string">Alphabetical</option>
         <option value="number">Numerical</option>
+        <option value="string-default">Alphabetical - Default</option>
+        <option value="number-default">Numerical - Default</option>
       </select>
     </td>
     <td>
@@ -178,6 +180,8 @@
         <option value="">None</option>
         <option value="string">Alphabetical</option>
         <option value="number">Numerical</option>
+        <option value="string-default">Alphabetical - Default</option>
+        <option value="number-default">Numerical - Default</option>
       </select>
     </td>
     <td>
@@ -185,6 +189,8 @@
         <option value="">None</option>
         <option value="string">Alphabetical</option>
         <option value="number">Numerical</option>
+        <option value="string-default">Alphabetical - Default</option>
+        <option value="number-default">Numerical - Default</option>
       </select>
     </td>
   </tr>


### PR DESCRIPTION
Currently it's unclear that you can sort when a table has the sortable
options set. Adding default sorting options gives the user a clue the
table is sortable and how it's been sorted on page load.

## Additions

- Added default number and string options to the admin
- Added sort value checker to the table template

## Testing

1. Add a table to the page
1. Add sorting options to each column, choosing `Numerical - Default` for one of them (preferably one with reversed number values (see screenshot)
1. Load page and see the values are sorted on page load

## Screenshots

<img width="778" alt="screen shot 2018-04-26 at 3 18 02 pm" src="https://user-images.githubusercontent.com/1280430/39329768-06b4393c-4965-11e8-892a-a72445edc852.png">

<img width="734" alt="screen shot 2018-04-26 at 3 18 13 pm" src="https://user-images.githubusercontent.com/1280430/39329774-0bb50b96-4965-11e8-8799-d92e974eb890.png">

## Notes

I can't seem to find the Cucumber feature I wrote for the sortable tables originally. Can anyone point me to where those moved?

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [x] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
