### PR TITLE
Bump moto to more recent version and make related fixes

### DIFF
--- a/cfgov/v1/tests/test_meta_image.py
+++ b/cfgov/v1/tests/test_meta_image.py
@@ -111,7 +111,7 @@ class TestMetaImage(TestCase):
     )
     def test_template_image_image_url_s3(self):
         """Meta image links should work if using S3 storage."""
-        mock_s3 = moto.mock_s3()
+        mock_s3 = moto.mock_s3_deprecated()
         mock_s3.start()
 
         s3 = boto.connect_s3()

--- a/cfgov/v1/tests/test_s3utils.py
+++ b/cfgov/v1/tests/test_s3utils.py
@@ -25,7 +25,7 @@ from v1.s3utils import (
 )
 class S3UtilsTestCase(TestCase):
     def setUp(self):
-        mock_s3 = moto.mock_s3()
+        mock_s3 = moto.mock_s3_deprecated()
         mock_s3.start()
         self.addCleanup(mock_s3.stop)
 

--- a/requirements/libraries.txt
+++ b/requirements/libraries.txt
@@ -31,7 +31,7 @@ pyelasticsearch==0.6.1
 python-dateutil==2.1
 PyYAML==3.11
 pytz
-requests==2.12.4
+requests==2.18.4
 requests_toolbelt==0.6.0
 six==1.10.0
 unicodecsv==0.14.1

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -3,5 +3,5 @@ django-sslserver==0.19
 github3.py==0.9.6
 mock==2.0.0
 model_mommy==1.2.6
-moto==0.4.27
+moto==1.3.1
 responses==0.5.1


### PR DESCRIPTION
Back in 80c7c7e88b4b82953728aedc7156307ea980dd7e we downgraded `moto` to 0.4.27 to fix some conflicting dependency versions that had surfaced through the addition of `venv-update` to the tox setup. At the time, I submitted a PR to `moto` to address the problem with their dependencies, and that eventually got merged. But we had not yet gotten round to bumping `moto` back up to a more recent version.

Now we have no choice: our old version of `moto` specifies an unpinned version of `flask`, and `flask` released version 1.0 today. In flask 1.0, the Jinja2 dep is bumped, meaning that we now have another Jinja2 version conflict when attempting to run `tox`.

All of which is to say, we are now bumping `moto` back up to a more recent version, and fixing a few related tests that needed to be updated as a side-effect. While `moto` 1.3.1 _is_ a lot more recent (one month old), it's not the newest version as of this writing (1.3.3). Upgrading to 1.3.3 would mean upgrading boto3, and we might prefer to kick the can down the road on that one for now.

Also note that we are bumping `requests` to the latest version to address a version conflict (newer `moto` requires newer `requests`). Upgrading `requests` is probably a good idea in general, and should not pose problems since `requests` claims minor versions do not introduce breaking changes.
