### PR TITLE
Bump regulations-site from 2.2.2 to 2.2.3

### DIFF
--- a/requirements/optional-public.txt
+++ b/requirements/optional-public.txt
@@ -2,7 +2,7 @@ https://github.com/cfpb/college-costs/releases/download/2.3.12/college_costs-2.3
 https://github.com/cfpb/complaint/releases/download/1.4.5/complaintdatabase-1.4.5-py2-none-any.whl
 https://github.com/cfpb/owning-a-home-api/releases/download/0.10.4/owning_a_home_api-0.10.4-py2-none-any.whl
 https://github.com/cfpb/regulations-core/releases/download/1.2.6/regcore-1.2.6-py2-none-any.whl
-https://github.com/cfpb/regulations-site/releases/download/2.2.2/regulations-2.2.2-py2-none-any.whl
+https://github.com/cfpb/regulations-site/releases/download/2.2.3/regulations-2.2.3-py2-none-any.whl
 https://github.com/cfpb/retirement/releases/download/0.5.17/retirement-0.5.17-py2-none-any.whl
 git+https://github.com/cfpb/ccdb5-api.git@v1.0.5#egg=ccdb5-api
 git+https://github.com/cfpb/ccdb5-ui.git@v1.0.7#egg=ccdb5_ui


### PR DESCRIPTION
As a followup to https://github.com/cfpb/cfgov-refresh/pull/4059 and https://github.com/cfpb/regulations-site/pull/852, this PR bumps the version of regulations-site from 2.2.2 to [2.2.3](https://github.com/cfpb/regulations-site/releases/tag/2.2.3).

This will ensure consistency of versions for the requests package.

FYI @acrewdson.