### PR TITLE
Fix beta banner feature flag

### DIFF
--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -600,7 +600,7 @@ FLAGS = {
     # When enabled, a banner appears across the top of the site proclaiming
     # "This beta site is a work in progress."
     'BETA_NOTICE': {
-        'site': 'beta.consumerfinance.gov',
+        'site': 'beta.consumerfinance.gov:443',
     },
 
     # When enabled, include a recruitment code comment in the base template.


### PR DESCRIPTION
This change fixes the BETA_NOTICE feature flag so that it appears properly on beta.consumerfinance.gov when being served over HTTPS.

Currently this flag is configured with a "site" condition against "beta.consumerfinance.gov". The logic in wagtail-flags here:

https://github.com/cfpb/wagtail-flags/blob/master/flags/conditions.py#L132

matches against both host and port. On beta.consumerfinance.gov the Wagtail Site is configured with port 443, but the flag condition doesn't include a port. Because wagtail-flags defaults to matching against port 80, the flag doesn't match properly.