### PR TITLE
Add MySQL-specific refresh script

### DIFF
--- a/refresh-mysql.sh
+++ b/refresh-mysql.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# ==========================================================================
+# Wrapper script for refresh-data.sh that grants proper MySQL permissions.
+# This script is only needed for MySQL dumps that require SUPER privileges.
+# NOTE: Run this script while in the project root directory.
+# ==========================================================================
+
+# Set script to exit on any errors.
+set -e
+
+MYSQL=`which mysql`
+
+UPDATE="UPDATE mysql.user SET Super_Priv='Y' WHERE user='$MYSQL_USER'"
+FLUSH="FLUSH PRIVILEGES"
+SQL="$UPDATE;$FLUSH;"
+
+$MYSQL -uroot --password=$MYSQL_ROOT_PW $MYSQL_NAME -e "$SQL"
+
+./refresh-data.sh $@


### PR DESCRIPTION
After the changes in #4013 (c94b26e), the database refresh script will fail if the Django database user doesn't have sufficient privileges to import the database dump. For MySQL this can happen if the dump contains the `CREATE ALGORITHM` statements that are used for a view. In practice this shouldn't happen, but as an artifact of the current production database, it does.

This change adds a new `refresh-mysql.sh` script that wraps the existing `refresh-data.sh` script with a new preface that first ensures that the Django database user has super privileges.

Once the site transitions to Postgres, this will no longer be an issue. Either at that time, or when those views are removed from production data dumps, this script can be removed.

See platform#2711 and comments by @higs4281 there.

## Additions

- New `refresh-mysql.sh` script.

## Testing

1. Make sure all MySQL-specific variables are set in `.env` (natively) or `.python_env` (in Docker) and that your `DATABASE_URL` is set to a MySQL URL. You'll need `MYSQL_ROOT_PW` if the root password is non-empty.
2. Run `./refresh-mysql.sh` and observe a dump successfully loaded into your MySQL database.

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [X] Passes all existing automated tests
- [X] Any _change_ in functionality is tested
- [X] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: