### PR TITLE
Adds youth financial education page to beta drafts

### DIFF
--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -701,7 +701,7 @@ SEARCH_DOT_GOV_ACCESS_KEY = os.environ.get('SEARCH_DOT_GOV_ACCESS_KEY')
 # This value is read by v1.wagtail_hooks.
 SERVE_LATEST_DRAFT_PAGES = []
 if DEPLOY_ENVIRONMENT == 'beta':
-    SERVE_LATEST_DRAFT_PAGES = [1288,1286,3273]
+    SERVE_LATEST_DRAFT_PAGES = [1288,1286,3273,11432]
 
 # Email popup configuration. See v1.templatetags.email_popup.
 EMAIL_POPUP_URLS = {


### PR DESCRIPTION
This change adds Wagtail page ID 11432 to the set of pages that are publicly visible in draft on beta. This change makes it so that the latest draft version of Wagtail page 11432 will be visible at its URL on beta, even if the page isn't/is never published.

This is to support work to preview the Teachers Digital Platform.