### PR TITLE
Add optional heading block to the table block

### DIFF
--- a/cfgov/jinja2/v1/_includes/organisms/table.html
+++ b/cfgov/jinja2/v1/_includes/organisms/table.html
@@ -11,6 +11,14 @@
 
    value.data:            A multi-dimensional list representing table rows.
 
+   value.heading_text:    (Optional) The text of a heading.
+
+   value.heading_level:   The heading level (H2, H3, H4). Default: H2
+
+   value.heading_icon:    (Optional) A string containing cf-icon name
+                          that triggers the insertion of an icon before
+                          the heading.
+
    value.row_links:       Boolean indicating if the table contains row links.
 
    value.is_stacked:      Boolean indicating if the table columns
@@ -34,6 +42,8 @@
    value.column_widths:   A list of column width (classes) to be applied in
                           order to the table columns.
 
+   value.sortable:        Boolean indicating if the table is sortable.
+
    ========================================================================== #}
 
 
@@ -41,6 +51,14 @@
 {% macro _render_cell(cell) %}
     {{ parse_links(cell or '&nbsp;') | safe | trim | linebreaksbr }}
 {% endmacro %}
+{% if value.heading_text %}
+    <{{ value.heading_level -}}
+        {%- if value.heading_icon -%}
+            {{- ' class="cf-icon cf-icon-' ~ value.heading_icon ~ '"' -}}
+        {%- endif -%}>
+        {{ value.heading_text }}
+    </{{ value.heading_level}}>
+{% endif %}
 <table class="o-table
               {{- ' o-table__row-links' if value.row_links else '' -}}
               {{- ' o-table__stack-on-small' if value.is_stacked else '' -}}

--- a/cfgov/templates/wagtailadmin/css/table-block.css
+++ b/cfgov/templates/wagtailadmin/css/table-block.css
@@ -4,6 +4,12 @@
     z-index: 10000;
 }
 
+.heading-text-block,
+.heading-level-block,
+.heading-icon-block {
+    vertical-align: top;
+}
+
 
 .table-block-modal {
     box-sizing: border-box;

--- a/cfgov/templates/wagtailadmin/js/table-block.js
+++ b/cfgov/templates/wagtailadmin/js/table-block.js
@@ -216,6 +216,11 @@
                   }
                 } );
 
+                // On change to Heading level, save data
+                $( id + '-handsontable-heading-level' ).on( 'change', function() {
+                    _this.saveDataToHiddenField( 'no data' );
+                } );
+
                 // On change of fixed width values, save data
                 $( id + '-fixed-width-column-input' ).on( 'change', '.column-width-input', function() {
                   _this.saveDataToHiddenField( 'no data' );
@@ -230,6 +235,9 @@
             ui: {
                 $container:                 id + '-handsontable-container',
                 $inputContainer:            id + '-handsontable-input-container',
+                $headingText:               id + '-handsontable-heading-text',
+                $headingLevel:              id + '-handsontable-heading-level',
+                $headingIcon:               id + '-handsontable-heading-icon',
                 $hasColHeaderCheckbox:      id + '-handsontable-col-header',
                 $hasRowHeaderCheckbox:      id + '-handsontable-header',
                 $hiddenField:               id,
@@ -247,10 +255,14 @@
             initializeForm: function initializeForm( hiddenFieldData ) {
                 var ui = this.ui;
                 var uiMap;
+                var elem;
                 var value;
 
                 if ( hiddenFieldData !== null ) {
-                    uiMap = { first_row_is_table_header:   ui.$hasRowHeaderCheckbox,
+                    uiMap = { heading_text:                ui.$headingText,
+                              heading_level:               ui.$headingLevel,
+                              heading_icon:                ui.$headingIcon,
+                              first_row_is_table_header:   ui.$hasRowHeaderCheckbox,
                               first_col_is_header:         ui.$hasColHeaderCheckbox,
                               is_full_width:               ui.$isFullWidthCheckbox,
                               is_striped:                  ui.$isTableStripedCheckbox,
@@ -260,8 +272,17 @@
                           };
 
                     Object.keys( uiMap ).forEach( function( key ) {
-                        if ( value = hiddenFieldData[key] ) {
+                        elem = uiMap[key][0];
+                        value = hiddenFieldData[key];
+
+                        if ( elem.tagName === 'INPUT' && elem.type === 'checkbox' && value ) {
                             uiMap[key].prop( 'checked', value );
+                        } else if ( elem.tagName === 'INPUT' && elem.type === 'text' && value ) {
+                            uiMap[key].prop( 'value', value );
+                        } else if ( elem.tagName === 'SELECT' && value ) {
+                            uiMap[key].prop( 'value', value );
+                        } else {
+                            return;
                         }
                     } );
                 }
@@ -398,6 +419,9 @@
                     data:                      this.handsonTable.instance.getData(),
                     column_widths:             this.getColumnWidths(),
                     sortable_types:            this.getSortableTypes(),
+                    heading_text:              ui.$headingText.prop( 'value' ),
+                    heading_level:             ui.$headingLevel.prop( 'value' ),
+                    heading_icon:              ui.$headingIcon.prop( 'value' ),
                     first_row_is_table_header: ui.$hasRowHeaderCheckbox.prop( 'checked' ),
                     first_col_is_header:       ui.$hasColHeaderCheckbox.prop( 'checked' ),
                     is_full_width:             ui.$isFullWidthCheckbox.prop( 'checked' ),

--- a/cfgov/templates/wagtailadmin/table_input.html
+++ b/cfgov/templates/wagtailadmin/table_input.html
@@ -14,6 +14,42 @@
 
 <div id="{{ attrs.id }}-handsontable-input-container">
 
+<div class="field">
+    <label for="{{ attrs.id }}-handsontable-heading">Heading</label>
+
+    <div class="field-content">
+        <div class="heading-text-block">
+            <label for="{{ attrs.id }}-handsontable-heading-text">Text:</label>
+            <div class="input">
+                <input type="text"
+                       id="{{ attrs.id }}-handsontable-heading-text"
+                       name="handsontable-heading-text">
+            </div>
+        </div>
+        <div class="heading-level-block">
+            <label for="{{ attrs.id }}-handsontable-heading-level">Level:</label>
+            <div class="input">
+                <select id="{{ attrs.id }}-handsontable-heading-level"
+                        name="handsontable-heading-level"
+                        placeholder="Level">
+                    <option value="h2">H2</option>
+                    <option value="h3">H3</option>
+                    <option value="h4">H4</option>
+                </select>
+            </div>
+        </div>
+        <div class="heading-icon-block">
+            <label for="{{ attrs.id }}-handsontable-heading-icon">Icon:</label>
+            <div class="input">
+                <input type="text"
+                       id="{{ attrs.id }}-handsontable-heading-icon"
+                       name="handsontable-heading-icon">
+                <span class="help">Input the name of an icon to appear to the left of the heading. E.g., approved, help-round, etc. See full list of icons</span>
+            </div>
+        </div>
+    </div>
+</div>
+
 <div class="field boolean_field widget-checkbox_input">
     <label for="{{ attrs.id }}-handsontable-striped-rows">Striped rows</label>
     <div class="field-content">


### PR DESCRIPTION
When a user adds a table that is outside the full width text module,
there is no way to add a heading without relying on another block and
the spacing that goes with it (typically 60px). To alleviate this issue
I have added the heading block as a custom entry to the Table Block JS
as well as a necessary style fix to the Table Block CSS.

## Additions

- Adds heading block markup to table block template
- Adds JS handlers for new text input and select fields
- Adds heading inputs to table input template
- Adds CSS necessary to align heading block inputs

## Testing

1. Add or edit a table in Wagtail
2. Add heading text, select a level, and add an icon name
3. Save and view page, the appropriate heading level should be used with the text and icon entered in the admin.

## Screenshots

<img width="736" alt="screen shot 2018-04-30 at 4 14 46 pm" src="https://user-images.githubusercontent.com/1280430/39451526-8afaf33e-4c94-11e8-8fbd-1cdf57e71490.png">

## Notes

- Due to the nature of the table block, we could not use the existing heading block in the `organisms.py` file like elsewhere.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [x] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
