### PR TITLE
Prevent iframe_api loading on pages without iframes

### DIFF
--- a/cfgov/unprocessed/apps/analytics-gtm/js/youtube-event-listeners-older-style.js
+++ b/cfgov/unprocessed/apps/analytics-gtm/js/youtube-event-listeners-older-style.js
@@ -18,11 +18,18 @@ import { analyticsLog } from './util/analytics-util';
       'There is already a function defined at window.onYouTubeIframeAPIReady;' +
       ' aborting LunaMetrics Google Analytics YouTube Tracking'
     );
+    return;
+  }
+
+  const iframes = document.getElementsByTagName( 'iframe' );
+
+  if ( iframes.length === 0 ) {
+    analyticsLog( 'There are no iframes on the page!' );
+    return;
   }
 
   // Invoked by the YouTube API once it has finished loading.
   window.onYouTubeIframeAPIReady = function() {
-    const iframes = document.getElementsByTagName( 'iframe' );
     const embeds = document.getElementsByTagName( 'embed' );
 
     digestPotentialVideos( iframes );

--- a/cfgov/unprocessed/js/modules/YoutubePlayer.js
+++ b/cfgov/unprocessed/js/modules/YoutubePlayer.js
@@ -66,8 +66,10 @@ const API = {
     let player;
     if ( YouTubePlayer && YouTubePlayer.Player ) {
       YouTubePlayer.setConfig( this.YOUTUBE_API_CONFIG );
-      player = new YouTubePlayer.Player( this.iFrameProperties.id
-        , this.playerOptions );
+      player = new YouTubePlayer.Player(
+        this.iFrameProperties.id,
+        this.playerOptions
+      );
       this.state.isPlayerInitialized = true;
     } else if ( this.state.isScriptLoading === false ) {
       window.onYouTubeIframeAPIReady = this.initPlayer.bind( this );


### PR DESCRIPTION
Google analytics youtube script adds the youtube iframe_api to all pages. We should only add it if there's a youtube video on the page. This change checks the page for iframes and if none are found aborts the analytics script.

## Changes

- Checks for existence of iframes on the page before injecting youtube's iframe_api script.
- Minor reformatting of youtube script to avoid dangling comma starting a new line.

## Testing

1. `gulp clean && gulp build`
2. Visit http://localhost:8000/about-us/blog/video-a-message-from-director-cordray/
3. Open the dev console and note that the iframe_api script has loaded in the network tab.
4. Visit the homepage.
5. Note that the iframe_api script has not loaded.

## Note

- You can add `?debug-gtm=true` to the URL and see in the console that it'll say `ANALYTICS DEBUG MODE: There are no iframes on the page!` on pages where there aren't videos.
- If you see `Error parsing header X-XSS-Protection` errors in the dev console, that's a Chrome error fixed in 66 https://stackoverflow.com/questions/48714879/error-parsing-header-x-xss-protection-google-chrome

## Screenshot

![screen shot 2018-04-30 at 6 20 10 pm](https://user-images.githubusercontent.com/704760/39453238-261206e2-4ca3-11e8-9891-271ced7e7ed2.png)
