### PR TITLE
Revert addition of youth fined page to beta drafts

### DIFF
--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -701,7 +701,7 @@ SEARCH_DOT_GOV_ACCESS_KEY = os.environ.get('SEARCH_DOT_GOV_ACCESS_KEY')
 # This value is read by v1.wagtail_hooks.
 SERVE_LATEST_DRAFT_PAGES = []
 if DEPLOY_ENVIRONMENT == 'beta':
-    SERVE_LATEST_DRAFT_PAGES = [1288,1286,3273,11432]
+    SERVE_LATEST_DRAFT_PAGES = [1288,1286,3273]
 
 # Email popup configuration. See v1.templatetags.email_popup.
 EMAIL_POPUP_URLS = {


### PR DESCRIPTION
This change reverts #4069 (9ecb41b) that added the youth financial education page to the list of draft pages on beta.

See GHE/platform#2720 for details/justification.
