### PR TITLE
Remove unnecessary data attr from info unit groups

### DIFF
--- a/cfgov/jinja2/v1/_includes/organisms/info-unit-group-2.html
+++ b/cfgov/jinja2/v1/_includes/organisms/info-unit-group-2.html
@@ -11,7 +11,7 @@
    value:                         Object defined from a StreamField block.
 
    value.format:                  The number and width of columns to output.
-   
+
    value.has_top_rule_line:       Boolean for whether or not to add top
                                   border to info-unit-group. Used in
                                   'render_block.html' to modify classes on
@@ -47,8 +47,7 @@
 {%- from 'molecules/info-unit-2.html' import info_unit with context %}
 
 <div class="o-info-unit-group"
-     {{- ' id="' ~ value.heading.text|slugify ~ '" ' if value.heading.text else ' ' -}}
-     data-qa-hook="@TODO: Find out if I need this!">
+     {{- ' id="' ~ value.heading.text|slugify ~ '" ' if value.heading.text else ' ' -}}>
 
 {% if value.heading and value.heading.text %}
     <{{ value.heading.level -}}
@@ -67,7 +66,7 @@
 {% for unit in value.info_units %}
     {% if ( loop.index == 1 ) or
           ( value.format == '50-50' and loop.index % 2 == 1 ) or
-          ( value.format == '33-33-33' and loop.index % 3 == 1 ) 
+          ( value.format == '33-33-33' and loop.index % 3 == 1 )
     %}
     <div class="content-l
                 {{- ' content-l__top-divider' if value.lines_between_items else '' -}}">


### PR DESCRIPTION
The data-attr was left over from the previous info unit group and not necessary. Removing so that we won't be printing todos in production markup.

## Removals

- Removed data-attr from info unit group

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [x] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

