### PR TITLE
Use TEST_DATABASE_URL to specify Django test database

### DIFF
--- a/cfgov/cfgov/settings/test.py
+++ b/cfgov/cfgov/settings/test.py
@@ -1,23 +1,22 @@
 from .local import *
 
 
-# If a database wasn't defined in settings.base through the use of environment
-# variables, default to using an in-memory SQLite one for unit tests.
-#
-# If a database is configured through environment settings, the unit tests will
-# be run against a new test database on the same backend.
-#
-# See https://docs.djangoproject.com/en/dev/topics/testing/overview/#the-test-database
-if not DATABASES:
-    DATABASES = {
-        'default': {
-            'ENGINE': 'django.db.backends.sqlite3',
+# A test database may be specified through use of the TEST_DATABASE_URL
+# environment variable. If not provided, unit tests will be run against an
+# in-memory SQLite database.
+TEST_DATABASE_URL = os.getenv('TEST_DATABASE_URL')
+if TEST_DATABASE_URL:
+    TEST_DATABASE = dj_database_url.parse(TEST_DATABASE_URL)
+else:
+    TEST_DATABASE = {
+        'ENGINE': 'django.db.backends.sqlite3',
+        'NAME': ':memory:',
+        'TEST': {
             'NAME': ':memory:',
-            'TEST': {
-                'NAME': ':memory:',
-            },
-        }
+        },
     }
+
+DATABASES = {'default': TEST_DATABASE}
 
 EMAIL_BACKEND = 'django.core.mail.backends.locmem.EmailBackend'
 

--- a/tox.ini
+++ b/tox.ini
@@ -141,7 +141,7 @@ commands=
 changedir=
     {toxinidir}/cfgov
 passenv=
-    TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH DATABASE_URL
+    TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH TEST_DATABASE_URL
 # BOTO_CONFIG exists here to work around an incompatability between
 # boto and Travis CI
 # https://github.com/travis-ci/travis-ci/issues/5246#issuecomment-166460882

--- a/travis_run.sh
+++ b/travis_run.sh
@@ -9,7 +9,7 @@ if [ "$RUNTEST" == "frontend" ]; then
     bash <(curl -s https://codecov.io/bash) -F frontend -X coveragepy
 elif [ "$RUNTEST" == "backend" ]; then
     tox -e lint
-    DATABASE_URL=postgres://postgres@localhost/travis_ci_test tox -e fast
+    TEST_DATABASE_URL=postgres://postgres@localhost/travis_ci_test tox -e fast
     tox -e missing-migrations
     bash <(curl -s https://codecov.io/bash) -F backend
 


### PR DESCRIPTION
This change modifies how the Python/Django unit test database isspecified. Instead of using `DATABASE_URL` (which is also used to configure the Django server), the tests now use `TEST_DATABASE_URL`.

If not provided, the tests default to using an in-memory SQLite database.

This allows developers to run a local server against MySQL or PostgreSQL but still run their tests quickly against SQLite.

Automated PR testing on TravisCI will continue to run against Postgres.

## Additions

- New `TEST_DATABASE_URL` environment variable can be used to specify Django test database.

## Changes

- `DATABASE_URL` environment variable no longer specifies Django test database.

## Testing

1. Run `tox -e fast` and you'll see the tests complete successfully (and quickly) against SQLite.
2. Run something like `TEST_DATABASE_URL=postgres://this:doesnt@localhost/exist` and you'll see a failure, confirming that Django is using that environment variable to try to test.
3. Run something like `TEST_DATABASE_URL=mysql://root@localhost/v1` (assuming you have that database) and you'll see tests run against MySQL.

## Notes

- See platform#2710 for some background.

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [X] Passes all existing automated tests
- [X] Any _change_ in functionality is tested
- [X] New functions are documented (with a description, list of inputs, and expected output)
- [X] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: