### PR TITLE
Fix for Bureau structure copy

### DIFF
--- a/cfgov/jinja2/v1/_includes/organisms/bureau-structure.html
+++ b/cfgov/jinja2/v1/_includes/organisms/bureau-structure.html
@@ -238,7 +238,7 @@
         <li class="m-list_item">
             <span class="o-bureau-structure_legend_symbol">***</span>
             <span class="o-bureau-structure_legend_definition">
-                Position is not part of the CFPB director’s office
+                Position is not part of the Bureau director’s office
             </span>
         </li>
 </section>
@@ -280,8 +280,8 @@
         <div class="content-l_col content-l_col-1-2">
             <h2 class="h3">Request speaking info</h2>
             <p>
-                Ask a CFPB employee to be involved in a forum, publication, discussion, or
-                other event; or to inquire about any CFPB events.
+                Ask a Bureau employee to be involved in a forum, publication, discussion, or
+                other event; or to inquire about any Bureau events.
             </p>
             <span class="cf-icon cf-icon-email m-list_icon"></span>
             <span class="m-list_text">


### PR DESCRIPTION
Fix for Bureau structure copy. GHE issue 2713.

## Changes

- Modified code to fix issue with `cfgov/jinja2/v1/_includes/organisms/bureau-structure.html` copy.


## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Internet Explorer 8, 9, 10, and 11
- [ ] Edge
- [ ] iOS Safari
- [ ] Chrome for Android

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
