### PR TITLE
Fix an issue where richtext images are being distorted

### DIFF
--- a/cfgov/unprocessed/css/images.less
+++ b/cfgov/unprocessed/css/images.less
@@ -1,0 +1,10 @@
+// Images inserted via rich text field are given strict width and height
+// attributes in the resulting markup. This resets the dimensions to allow
+// the image to resize to its container without distortion
+//
+// TODO: Check if this can be removed after upgrading to Wagtail 2.0
+
+.richtext-image {
+    height: auto;
+    width: auto;
+}

--- a/cfgov/unprocessed/css/main.less
+++ b/cfgov/unprocessed/css/main.less
@@ -59,6 +59,7 @@
    ========================================================================== */
 
 @import (less) "forms.less";
+@import (less) "images.less";
 @import (less) "media.less";
 @import (less) "meta.less";
 @import (less) "misc.less";


### PR DESCRIPTION
Currently richtext images are printed to the markup with static height
and width attributes. When the image is resized in one dirction, it
can be distorted in the opposite direction. Resetting the height and
width to auto avoids this issue allowing the image to take up the
dimensions of it's container without causing distortion.

## Additions

- New global `images.less` file because this change is limited to Wagtail and not necessary to be moved to CF. This file will also be the future home of whatever Wagtail high-dpi/responsive image solutions we explore.

## Testing

1. Gulp build
1. Create a table with fixed dimensions
1. Add an image to one of the columns (best if the column is narrow, like 20%)
1. Observe the image is not distorted in the way you can [see it is here](http://build.consumerfinance.gov/consumer-tools/mayg-by-topic/money-as-you-grow-bookshelf-at-home/)

## Screenshots
Before:

<img width="758" alt="screen shot 2018-05-01 at 1 07 23 pm" src="https://user-images.githubusercontent.com/1280430/39486103-9fc61030-4d40-11e8-8d86-c1816fba502a.png">

After:

<img width="759" alt="screen shot 2018-05-01 at 1 07 59 pm" src="https://user-images.githubusercontent.com/1280430/39486122-afe47e2a-4d40-11e8-8141-67437f84dc6f.png">

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [x] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [x] Chrome
- [x] Firefox
- [x] Safari
- [x] Internet Explorer 8, 9, 10, and 11
- [x] Edge
- [ ] iOS Safari
- [ ] Chrome for Android

