### PR TITLE
Update InfoUnit template to use image_alt_value template tag

### DIFF
--- a/cfgov/jinja2/v1/_includes/molecules/info-unit-2.html
+++ b/cfgov/jinja2/v1/_includes/molecules/info-unit-2.html
@@ -63,11 +63,11 @@
     {% if link_image_and_heading %}
         <a href="{{ parse_links( value.links[0].url ) | safe }}">
     {% endif %}
-        {%- if value.image.alt %}
+        {%- if image_alt_value(value.image) %}
             <img class="m-info-unit_image
                         {{- ' m-info-unit_image__square' if img.is_square else '' }}"
                  src="{{ img.url }}"
-                 alt="{{ value.image.alt }}">
+                 alt="{{ image_alt_value(value.image) }}">
         {%- else %}
             <div class="m-info-unit_image
                         {{- ' m-info-unit_image__square' if img.is_square else '' }}"


### PR DESCRIPTION
`image_alt_value` was added in #2920, but for some reason (possibly related to parallel development of the InfoUnitGroup feature?), it never made it into the InfoUnit template. This PR rectifies that.

## Changes

- `alt` output on an InfoUnit's image is now handled by the `image_alt_value` Jinja tag.

## Testing

1. Pull branch
1. Create a new InfoUnitGroup with four InfoUnits with varying alt text data
   1. No alt
   1. Alt on upload
   1. Alt in InfoUnit module, not on upload
   1. Alt on upload and in InfoUnit module
1. Observe the expected output of (respectively):
   1. Image is set as CSS `background-image`
   1. Image has alt text of what was set on upload
   1. Image has alt text that was set in the InfoUnit module
   1. Image has alt text that was set in the InfoUnit module

## Screenshots

![screen shot 2018-05-01 at 17 53 37](https://user-images.githubusercontent.com/1044670/39495535-a38c5986-4d68-11e8-9131-e84142cb1915.png)


## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [x] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Internet Explorer 8, 9, 10, and 11
- [ ] Edge
- [ ] iOS Safari
- [ ] Chrome for Android

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
