### PR TITLE
Remove Wagtail 1.10 from our test matrix

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 skipsdist=True
 tox_pip_extensions_ext_venv_update=True
 # Run these envs when tox is invoked without -e
-envlist=lint-py{27}, unittest-py{27}-dj{18}-wag{110}-slow
+envlist=lint-py{27}, unittest-py{27}-dj{18}-wag{113}-slow
 
 
 [testenv]
@@ -20,55 +20,38 @@ envlist=lint-py{27}, unittest-py{27}-dj{18}-wag{110}-slow
 #   dj18:               Use Django 1.8
 #   dj111:              Use Django 1.11
 #   dj20:               Use Django 2.0
-#   wag110:             Use Wagtail 1.10
 #   wag113:             Use Wagtail 1.13
 #   wag20:              Use Wagtail 2.0
 #
 # These factors are expected to combine into the follow generative environments:
 #
 #   lint-py{27,36}
-#   unittest-py{27,36}-dj{18,110}-wag{110,113}-{fast,slow}
+#   unittest-py{27,36}-dj{18,110}-wag{113}-{fast,slow}
 #   unittest-py{36}-dj{20}-wag{20}-{fast,slow}
-#   missing-migrations-py{27,36}-dj{18,110}-wag{110,113}
-#   acceptance-py{27,36}-dj{18,110}-wag{110,113}-fast
+#   missing-migrations-py{27,36}-dj{18,110}-wag{113}
+#   acceptance-py{27,36}-dj{18,110}-wag{113}-fast
 #
 # These factors are expected to combine to be invoked with:
 #
 #   tox -e lint-py27
 #   tox -e lint-py36
-#   tox -e unittest-py27-dj18-wag110-fast
-#   tox -e unittest-py27-dj18-wag110-slow
 #   tox -e unittest-py27-dj18-wag113-fast
 #   tox -e unittest-py27-dj18-wag113-slow
-#   tox -e unittest-py27-dj111-wag110-fast
-#   tox -e unittest-py27-dj111-wag110-slow
 #   tox -e unittest-py27-dj111-wag113-fast
 #   tox -e unittest-py27-dj111-wag113-slow
-#   tox -e unittest-py36-dj18-wag110-fast
-#   tox -e unittest-py36-dj18-wag110-slow
 #   tox -e unittest-py36-dj18-wag113-fast
 #   tox -e unittest-py36-dj18-wag113-slow
-#   tox -e unittest-py36-dj111-wag110-fast
-#   tox -e unittest-py36-dj111-wag110-slow
 #   tox -e unittest-py36-dj111-wag113-fast
 #   tox -e unittest-py36-dj111-wag113-slow
 #   tox -e unittest-py36-dj20-wag20-fast
 #   tox -e unittest-py36-dj20-wag20-slow
-#   tox -e missing-migrations-py27-dj18-wag110
 #   tox -e missing-migrations-py27-dj18-wag113
-#   tox -e missing-migrations-py27-dj111-wag110
 #   tox -e missing-migrations-py27-dj111-wag113
-#   tox -e missing-migrations-py36-dj18-wag110
 #   tox -e missing-migrations-py36-dj18-wag113
-#   tox -e missing-migrations-py36-dj111-wag110
 #   tox -e missing-migrations-py36-dj111-wag113
-#   tox -e acceptance-py27-dj18-wag110-fast
 #   tox -e acceptance-py27-dj18-wag113-fast
-#   tox -e acceptance-py27-dj111-wag110-fast
 #   tox -e acceptance-py27-dj111-wag113-fast
-#   tox -e acceptance-py36-dj18-wag110-fast
 #   tox -e acceptance-py36-dj18-wag113-fast
-#   tox -e acceptance-py36-dj111-wag110-fast
 #   tox -e acceptance-py36-dj111-wag113-fast
 
 recreate=False
@@ -88,7 +71,6 @@ deps=
     dj18:               Django>=1.8,<1.9
     dj111:              Django>=1.11,<1.12
     dj20:               Django>=2.0,<2.1
-    wag110:             wagtail>=1.10,<1.11
     wag113:             wagtail>=1.13,<1.14
     wag20:              wagtail>=2.0,<2.1
     lint:               {[lint]deps}
@@ -166,7 +148,7 @@ commands=
 # Configuration values necessary to run unittests without migrations.
 # Note: This is not an env will not run if invoked. Use an invocation of:
 #
-#   tox -e unittest-py{27,36}-dj{18,110}-wag{110,113}-fast
+#   tox -e unittest-py{27,36}-dj{18,110}-wag{113}-fast
 #
 # To run unit tests.
 setenv=
@@ -177,7 +159,7 @@ setenv=
 # Configuration values necessary to run unittests with migrations.
 # Note: This is not an env will not run if invoked. Use an invocation of:
 #
-#   tox -e unittest-py{27,36}-dj{18,110}-wag{110,113}-slow
+#   tox -e unittest-py{27,36}-dj{18,110}-wag{113}-slow
 #
 # To run unit tests.
 setenv=
@@ -188,7 +170,7 @@ setenv=
 # Configuration values necessary to run missing migrations test.
 # Note: This is not an env will not run if invoked. Use an invocation of:
 #
-#   tox -e missing-migrations-py{27,36}-dj{18,110}-wag{110,113}
+#   tox -e missing-migrations-py{27,36}-dj{18,110}-wag{113}
 #
 # To run unit tests.
 changedir=
@@ -207,7 +189,7 @@ commands=
 # virtualenv as backend tests.
 # Note: This is not an env will not run if invoked. Use an invocation of:
 #
-#   acceptance-py{27,36}-dj{18,110}-wag{110,113}-fast
+#   acceptance-py{27,36}-dj{18,110}-wag{113}-fast
 #
 # To run acceptance tests.
 changedir=
@@ -244,11 +226,11 @@ commands={[lint]commands}
 
 [testenv:fast]
 # Invoke with: tox -e fast
-# This should run identically to tox -e unittest-py27-dj18-wag110-fast
+# This should run identically to tox -e unittest-py27-dj18-wag113-fast
 recreate=False
 changedir={[unittest]changedir}
 basepython=python2.7
-envdir={toxworkdir}/unittest-py27-dj18-wag110-fast
+envdir={toxworkdir}/unittest-py27-dj18-wag113-fast
 deps=
     -r{toxinidir}/requirements/django.txt
     -r{toxinidir}/requirements/wagtail.txt
@@ -261,11 +243,11 @@ commands={[unittest]commands}
 
 [testenv:missing-migrations]
 # Invoke with: tox -e missing-migrations
-# This should run identically to tox -e unittest-py27-dj18-wag110-fast
+# This should run identically to tox -e unittest-py27-dj18-wag113-fast
 recreate=False
 changedir={[missing-migrations]changedir}
 basepython=python2.7
-envdir={toxworkdir}/unittest-py27-dj18-wag110-fast
+envdir={toxworkdir}/unittest-py27-dj18-wag113-fast
 deps=
     -r{toxinidir}/requirements/django.txt
     -r{toxinidir}/requirements/wagtail.txt
@@ -280,7 +262,7 @@ commands={[missing-migrations]commands}
 recreate=False
 changedir={[acceptance]changedir}
 basepython=python2.7
-envdir={toxworkdir}/acceptance-py27-dj18-wag110
+envdir={toxworkdir}/acceptance-py27-dj18-wag113
 deps=
     -r{toxinidir}/requirements/django.txt
     -r{toxinidir}/requirements/wagtail.txt


### PR DESCRIPTION
This PR removes Wagtail 1.10 from our Tox testing matrix. All backend tests now default to Wagtail 1.13.

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Internet Explorer 8, 9, 10, and 11
- [ ] Edge
- [ ] iOS Safari
- [ ] Chrome for Android

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
