### PR TITLE
Removes jQuery from owning-a-home analytics scripts

### DIFF
--- a/cfgov/unprocessed/apps/analytics-gtm/js/bah-check-rates-listeners.js
+++ b/cfgov/unprocessed/apps/analytics-gtm/js/bah-check-rates-listeners.js
@@ -1,6 +1,6 @@
 import {
   addEventListenerToElem,
-  delay,
+  Delay,
   track
 } from './util/analytics-util';
 
@@ -35,31 +35,34 @@ const OAHRCAnalytics = ( function() {
   } );
 
   // house price
+  const housePriceDelay = new Delay();
   const housePriceEl = document.querySelector( '#house-price' );
   addEventListenerToElem( housePriceEl, 'keyup', function( evt ) {
     const target = evt.target;
     const value = target.value;
-    delay( function() {
+    housePriceDelay( () => {
       track( 'OAH Rate Tool Interactions', 'House price', value );
     }, 5000 );
   } );
 
   // down payment percentage
+  let percentDownDelay = new Delay();
   const percentDownEl = document.querySelector( '#percent-down' );
   addEventListenerToElem( percentDownEl, 'keyup', function( evt ) {
     const target = evt.target;
     const value = target.value;
-    delay( function() {
+    percentDownDelay( () => {
       track( 'OAH Rate Tool Interactions', 'Down payment percent', value );
     }, 5000 );
   } );
 
   // down payment $
+  let downPaymentDelay = new Delay();
   const downPaymentEl = document.querySelector( '#down-payment' );
   addEventListenerToElem( downPaymentEl, 'keyup', function( evt ) {
     const target = evt.target;
     const value = target.value;
-    delay( function() {
+    downPaymentDelay( () => {
       track( 'OAH Rate Tool Interactions', 'Down payment amount', value );
     }, 5000 );
   } );

--- a/cfgov/unprocessed/apps/analytics-gtm/js/hdma-explore-event-listeners.js
+++ b/cfgov/unprocessed/apps/analytics-gtm/js/hdma-explore-event-listeners.js
@@ -2,7 +2,7 @@
 import $ from 'jquery';
 
 import {
-  delay,
+  Delay,
   track
 } from './util/analytics-util';
 
@@ -30,9 +30,10 @@ const HMDAAnalytics = ( function() {
   } );
 
   // Chosen menu selections for Year filter
+  const selectAsOfYearDelay = new Delay();
   $( 'select#as_of_year' ).change( function() {
     const label = $( '#as_of_year_chzn .search-choice:last' ).text();
-    delay( function() {
+    selectAsOfYearDelay( () => {
       track( 'HMDA Explore Interactions', 'Year Dropdown', label );
     }, 250 );
   } );
@@ -87,14 +88,6 @@ function closest( elem, selector ) {
 
 var HMDAAnalytics = (function() {
 
-  var delay = (function(){
-    var timer = 0;
-    return function(callback, ms){
-      clearTimeout (timer);
-      timer = setTimeout(callback, ms);
-    };
-  })();
-
   var track = function(event, action, label) {
     window.dataLayer.push({
       "event": event,
@@ -131,11 +124,12 @@ var HMDAAnalytics = (function() {
   });
 
   // Chosen menu selections for Year filter
+  const selectAsOfYearDelay = new Delay();
   var selectAsOfYear = document.querySelector( 'select#as_of_year' );
   selectAsOfYear.addEventListener( 'change', function(evt) {
     var lastItem = document.querySelector( '#as_of_year_chzn .search-choice:last' );
     var label = lastItem.textContent;
-    delay(function() {
+    selectAsOfYearDelay( () => {
       track('HMDA Explore Interactions', 'Year Dropdown', label);
     }, 250);
   });

--- a/cfgov/unprocessed/apps/analytics-gtm/js/pfc-comparison-tool-listeners.js
+++ b/cfgov/unprocessed/apps/analytics-gtm/js/pfc-comparison-tool-listeners.js
@@ -3,7 +3,7 @@ import $ from 'jquery';
 
 import {
   analyticsLog,
-  delay,
+  Delay,
   track
 } from './util/analytics-util';
 
@@ -40,9 +40,10 @@ const PFCAnalytics = ( function() {
   } );
 
   // Fire an event when Left to Pay = $0 and Costs > $0
+  const comparisonTablesDelay = new Delay();
   $( '#comparison-tables' ).on( 'keyup', 'input.school-data', function( ev ) {
     const columnNumber = $( this ).parents( '[data-column]' ).attr( 'data-column' );
-    delay( function() {
+    comparisonTablesDelay( () => {
       const totalCosts = $( '.breakdown [data-column="' + columnNumber + '"] .costs-value' ).html();
       const leftToPay = $( '.breakdown [data-column="' + columnNumber + '"] [data-nickname="gap"]' ).html();
       const schoolID = $( '#institution-row [data-column="' + columnNumber + '"]' ).attr( 'data-schoolid' );
@@ -59,10 +60,11 @@ const PFCAnalytics = ( function() {
   } );
 
   // Fire an event when GI Bill panel opens
+  const giBillDelay = new Delay();
   $( ".gibill-calculator, input[data-nickname='gibill']" ).click( function() {
     const columnNumber = $( this ).parents( '[data-column]' ).attr( 'data-column' );
     const schoolID = $( "#institution-row [data-column='" + columnNumber + "']" ).attr( 'data-schoolid' );
-    delay( function() {
+    giBillDelay( () => {
       const GIPanel = $( '[data-column="' + columnNumber + '"] .gibill-panel' );
       if ( GIPanel.is( ':visible' ) ) {
         track( 'School Interactions', 'GI Bill Calculator Opened', schoolID );
@@ -195,8 +197,9 @@ const PFCAnalytics = ( function() {
   }
 
   // Check for a new school added when .continue and .add-another-school are clicked
+  const introDelay = new Delay();
   $( '#introduction .continue, #introduction .add-another-school' ).click( function() {
-    delay( function() {
+    introDelay( () => {
       const newEmpty = findEmptyColumn();
       if ( newEmpty !== global.emptyColumn ) {
         newSchoolEvent();

--- a/cfgov/unprocessed/apps/analytics-gtm/js/util/analytics-util.js
+++ b/cfgov/unprocessed/apps/analytics-gtm/js/util/analytics-util.js
@@ -1,5 +1,21 @@
 /**
  * Check if an element exists on the page, and if it does, add listeners.
+ * @param {NodeList} elems - A list of elements.
+ * @param {string} event - An event string, probably a "MouseEvent."
+ * @param {Function} callback - The event handler.
+ */
+function addEventListenerToElems( elems, event, callback ) {
+  let elem;
+  for ( const i in elems ) {
+    elem = elems[i];
+    if ( elem.addEventListener ) {
+      addEventListenerToElem( elems[i], event, callback );
+    }
+  }
+}
+
+/**
+ * Check if an element exists on the page, and if it does, add listeners.
  * @param {[type]}   elem     [description]
  * @param {[type]}   event    [description]
  * @param {Function} callback [description]
@@ -12,13 +28,61 @@ function addEventListenerToElem( elem, event, callback ) {
   }
 }
 
-const delay = ( function() {
+/**
+ * Log a message to the console if the `debug-gtm` URL parameter is set.
+ * @param {string} msg - Message to load to the console.
+ */
+function analyticsLog( ...msg ) {
+  if ( getQueryParameter( 'debug-gtm' ) === true ) {
+    console.log( `ANALYTICS DEBUG MODE: ${ msg }` );
+  }
+}
+
+/* Search for support of the matches() method by looking at
+   browser prefixes.
+   @param {HTMLNode} elem
+   The element to check for support of matches() method.
+   @returns {Function} The appropriate matches() method of elem. */
+function _getMatchesMethod( elem ) {
+  return elem.matches ||
+       elem.webkitMatchesSelector ||
+       elem.mozMatchesSelector ||
+       elem.msMatchesSelector;
+}
+
+/**
+ * Get the nearest parent node of an element.
+ *
+ * @param {HTMLNode} elem - A DOM element.
+ * @param {string} selector - CSS selector.
+ * @returns {HTMLNode} Nearest parent node that matches the selector.
+ */
+function closest( elem, selector ) {
+  elem = elem.parentNode;
+
+  const matchesSelector = _getMatchesMethod( elem );
+  let match;
+
+  while ( elem ) {
+    if ( matchesSelector.bind( elem )( selector ) ) {
+      match = elem;
+    } else {
+      elem = elem.parentElement;
+    }
+
+    if ( match ) { return elem; }
+  }
+
+  return null;
+}
+
+function Delay() {
   let timer = 0;
   return function( callback, ms ) {
     clearTimeout( timer );
     timer = setTimeout( callback, ms );
   };
-} )();
+};
 
 /**
  * TODO: Merge with Analytics.js.
@@ -83,20 +147,12 @@ function getQueryParameter( key ) {
   return decoded;
 }
 
-/**
- * Log a message to the console if the `debug-gtm` URL parameter is set.
- * @param {string} msg - Message to load to the console.
- */
-function analyticsLog( msg ) {
-  if ( getQueryParameter( 'debug-gtm' ) === true ) {
-    console.log( `ANALYTICS DEBUG MODE: ${ msg }` );
-  }
-}
-
 module.exports = {
+  addEventListenerToElems,
   addEventListenerToElem,
   analyticsLog,
-  delay,
+  closest,
+  Delay,
   getQueryParameter,
   hostsAreEqual,
   track

--- a/cfgov/unprocessed/apps/analytics-gtm/webpack-config.js
+++ b/cfgov/unprocessed/apps/analytics-gtm/webpack-config.js
@@ -37,7 +37,7 @@ const COMMON_MODULE_CONFIG = {
       options: {
         presets: [ [ 'babel-preset-env', {
           configPath: __dirname,
-          /* Use useBuiltIns: 'usage' and set `debug: false` to see what
+          /* Use useBuiltIns: 'usage' and set `debug: true` to see what
              scripts require polyfilling. */
           useBuiltIns: false,
           debug: false


### PR DESCRIPTION
## Additions

- `addEventListenerToElems` utility method to analytics utils.
- `closest` utility method to analytics utils.

## Removals

- Removes jquery for owning-a-home analytics scripts.
- Removes delay requirement from owning-a-home disclosure pages analytics scripts.

## Changes

- Makes delays individual instances.

## Testing

1. `gulp clean && gulp build`
2. Visit `/owning-a-home/closing-disclosure/?debug-gtm=true`.
3. Open dev console.
4. Click pages, next/prev button, expandables, and image overlays and ensure analytics log correctly in console (e.g. should say "expanded" when expanding the expandable, and "collapsed" when it's collapsing).
3. Repeat for `/owning-a-home/loan-estimate/?debug-gtm=true`

## Notes

- Ideally the analytics could listen to an expand/collapse event on the expandables instead of inferring their state. What it the current thinking on the architecture of having components communicate with each other?
