### PR TITLE
Remove django-hud support

### DIFF
--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -89,7 +89,6 @@ OPTIONAL_APPS = [
     {'import': 'comparisontool', 'apps': ('comparisontool', 'haystack',)},
     {'import': 'paying_for_college',
      'apps': ('paying_for_college', 'haystack',)},
-    {'import': 'hud_api_replace', 'apps': ('hud_api_replace',)},
     {'import': 'retirement_api', 'apps': ('retirement_api',)},
     {'import': 'complaint', 'apps': ('complaint',
      'complaintdatabase', 'complaint_common',)},
@@ -312,10 +311,6 @@ SHEER_ELASTICSEARCH_SETTINGS = \
 
 STATIC_VERSION = ''
 
-# DJANGO HUD API
-DJANGO_HUD_API_ENDPOINT= os.environ.get('HUD_API_ENDPOINT', 'http://localhost/hud-api-replace/')
-# in seconds, 2592000 == 30 days. Google allows no more than a month of caching
-DJANGO_HUD_GEODATA_EXPIRATION_INTERVAL = 2592000
 MAPBOX_ACCESS_TOKEN = os.environ.get('MAPBOX_ACCESS_TOKEN')
 HOUSING_COUNSELOR_S3_PATH_TEMPLATE = (
     'a/assets/hud/{format}s/{zipcode}.{format}'

--- a/cfgov/cfgov/urls.py
+++ b/cfgov/cfgov/urls.py
@@ -234,10 +234,6 @@ urlpatterns = [
             'paying_for_college', 'paying_for_college.config.urls')),
     url(r'^credit-cards/agreements/',
         include('agreements.urls')),
-    url(r'^hud-api-replace/', include_if_app_enabled(
-        'hud_api_replace',
-        'hud_api_replace.urls',
-        namespace='hud_api_replace')),
     url(r'^consumer-tools/retirement/',
         include_if_app_enabled('retirement_api', 'retirement_api.urls')),
 

--- a/cfgov/legacy/templates/hud/housing_counselor.html
+++ b/cfgov/legacy/templates/hud/housing_counselor.html
@@ -97,11 +97,7 @@ Find a housing counselor
                             </div>
                             <div id="hud_hca_api_more_info_container" class="hud_hca_api_more_info">
                                 <p>
-                                    This tool is open sourced on
-                                    <a href="https://github.com/cfpb/django-hud">GitHub</a>
-                                    and powered by <a href="https://data.hud.gov/housing_counseling.html">HUD's</a>
-                                    official list of housing counselors.
-                                    We encourage you to leverage it in your own applications.
+                                    This tool is powered by <a href="https://data.hud.gov/housing_counseling.html">HUD's</a> official list of housing counselors.
                                 </p>
 
                                 <p>

--- a/requirements/optional-public.txt
+++ b/requirements/optional-public.txt
@@ -6,6 +6,5 @@ https://github.com/cfpb/regulations-site/releases/download/2.2.3/regulations-2.2
 https://github.com/cfpb/retirement/releases/download/0.5.17/retirement-0.5.17-py2-none-any.whl
 git+https://github.com/cfpb/ccdb5-api.git@v1.0.5#egg=ccdb5-api
 git+https://github.com/cfpb/ccdb5-ui.git@v1.0.8#egg=ccdb5_ui
-https://github.com/cfpb/django-hud/releases/download/1.4.3/django_hud-1.4.3-py2-none-any.whl
 https://github.com/cfpb/django-college-costs-comparison/releases/download/1.5.3/comparisontool-1.5.3-py2-none-any.whl
 https://github.com/cfpb/teachers-digital-platform/releases/download/0.5.6/teachers_digital_platform-0.5.6-py2-none-any.whl


### PR DESCRIPTION
We are officially deprecating use of [django-hud](https://github.com/cfpb/django-hud) (see GHE platform issue 2719).  There are two additional PRs needed as documented in the GHE issue -- this should not be merged until those are merged.