### PR TITLE
Revert "Upgrade Wagtail to 1.13.1"

### DIFF
--- a/cfgov/data_research/fixtures/conference_registration_page.json
+++ b/cfgov/data_research/fixtures/conference_registration_page.json
@@ -3,7 +3,6 @@
     "fields": {
         "locked": false,
         "title": "Conference registration test",
-        "draft_title": "Conference registration test",
         "numchild": 0,
         "show_in_menus": false,
         "live": true,

--- a/requirements/wagtail.txt
+++ b/requirements/wagtail.txt
@@ -1,1 +1,1 @@
-wagtail==1.13.1
+wagtail==1.10.1


### PR DESCRIPTION
Reverts cfpb/cfgov-refresh#3841

This upgrade introduced some errors (see https://github.com/cfpb/cfgov-refresh/pull/4084) however that PR is not ready.  Since we are avoiding deploying to production as a result, I think we should revert the upgrade until the fixes are ready. 