### PR TITLE
Remove closest analytics util

### DIFF
--- a/cfgov/unprocessed/apps/analytics-gtm/js/bah-explainers.js
+++ b/cfgov/unprocessed/apps/analytics-gtm/js/bah-explainers.js
@@ -1,6 +1,5 @@
 import {
   addEventListenerToSelector,
-  closest,
   track
 } from './util/analytics-util';
 
@@ -88,7 +87,7 @@ export default function( label ) {
     if ( isAnimatingExpandable( expandable ) ) { return; }
     recordExpandableState( expandableID );
 
-    const tab = closest( elem, '.explain' ).querySelector( '.active-tab' );
+    const tab = document.querySelector( '.active-tab' );
     const tabText = tab.querySelector( '.tab-label' ).textContent.trim();
     let action = 'Expandable collapsed - ' + tabText;
     const label = elem.querySelector( '.o-expandable_label' );

--- a/cfgov/unprocessed/apps/analytics-gtm/js/util/analytics-util.js
+++ b/cfgov/unprocessed/apps/analytics-gtm/js/util/analytics-util.js
@@ -35,44 +35,10 @@ function analyticsLog( ...msg ) {
   }
 }
 
-/* Search for support of the matches() method by looking at
-   browser prefixes.
-   @param {HTMLNode} elem
-   The element to check for support of matches() method.
-   @returns {Function} The appropriate matches() method of elem. */
-function _getMatchesMethod( elem ) {
-  return elem.matches ||
-         elem.webkitMatchesSelector ||
-         elem.mozMatchesSelector ||
-         elem.msMatchesSelector;
-}
-
 /**
- * Get the nearest parent node of an element.
- *
- * @param {HTMLNode} elem - A DOM element.
- * @param {string} selector - CSS selector.
- * @returns {HTMLNode} Nearest parent node that matches the selector.
+ * Create a delay given a callback function and millisecond delay.
+ * @constructor
  */
-function closest( elem, selector ) {
-  elem = elem.parentNode;
-
-  const matchesSelector = _getMatchesMethod( elem );
-  let match;
-
-  while ( elem ) {
-    if ( matchesSelector.bind( elem )( selector ) ) {
-      match = elem;
-    } else {
-      elem = elem.parentElement;
-    }
-
-    if ( match ) { return elem; }
-  }
-
-  return null;
-}
-
 function Delay() {
   let timer = 0;
   return function( callback, ms ) {
@@ -148,7 +114,6 @@ module.exports = {
   addEventListenerToSelector,
   addEventListenerToElem,
   analyticsLog,
-  closest,
   Delay,
   getQueryParameter,
   hostsAreEqual,


### PR DESCRIPTION
Follow up to https://github.com/cfpb/cfgov-refresh/pull/4085 to remove `closest` utility method.

## Removals

- Removes `closest` analytics util.

## Testing

1. `gulp clean && gulp build`
2. Visit /owning-a-home/closing-disclosure/?debug-gtm=true.
3. Click details and definition tabs and see that they log to the dev console.
4. Repeat for /owning-a-home/loan-estimate/?debug-gtm=true