### PR TITLE
Fix incorrect </br> tags

### DIFF
--- a/cfgov/legacy/templates/hud/housing_counselor.html
+++ b/cfgov/legacy/templates/hud/housing_counselor.html
@@ -167,7 +167,7 @@ Find a housing counselor
                                                         <div class="hud_hca_api_counselor_address">
                                                             <span class="hud_hca_api_adr">{{ counselor.adr1 }}
                                                                 {% if counselor.adr2 and counselor.adr2 != ' '  %}
-                                                                </br>{{ counselor.adr2 }}
+                                                                <br>{{ counselor.adr2 }}
                                                                 {% endif %}
                                                             </span>
                                                             <span class="hud_hca_api_region">{{ counselor.city }}, {{ counselor.statecd }} {{ counselor.zipcd }}</span>

--- a/cfgov/legacy/templates/hud/housing_counselor_pdf.html
+++ b/cfgov/legacy/templates/hud/housing_counselor_pdf.html
@@ -86,7 +86,7 @@
                                             <span class="hud_hca_api_adr">
                                                 {{ counselor.adr1 }}
                                                 {% if counselor.adr2 and counselor.adr2 != ' ' %}
-                                                </br> {{ counselor.adr2 }}
+                                                <br> {{ counselor.adr2 }}
                                                 {% endif %}
                                             </span>
                                             <span class="hud_hca_api_region">{{ counselor.city }}, {{ counselor.statecd }} {{ counselor.zipcd }}</span>

--- a/cfgov/legacy/templates/hud/housing_counselor_pdf_selfcontained.html
+++ b/cfgov/legacy/templates/hud/housing_counselor_pdf_selfcontained.html
@@ -252,7 +252,7 @@
                                             <span class="hud_hca_api_adr">
                                                 {{ counselor.adr1 }}
                                                 {% if counselor.adr2 and counselor.adr2 != ' ' %}
-                                                </br> {{ counselor.adr2 }}
+                                                <br> {{ counselor.adr2 }}
                                                 {% endif %}
                                             </span>
                                             <span class="hud_hca_api_region">{{ counselor.city }}, {{ counselor.statecd }} {{ counselor.zipcd }}</span>

--- a/cfgov/templates/wagtailadmin/js/table-block.js
+++ b/cfgov/templates/wagtailadmin/js/table-block.js
@@ -496,7 +496,7 @@
                                     '</header>',
                                     '<div class="row active nice-padding struct-block object">',
                                         '<input id="table-block-editor" maxlength="255" name="title" type="text">',
-                                    '</div></br>',
+                                    '</div><br>',
                                     '<div class="row active nice-padding m-t-10">',
                                         '<button id="table-block-save-btn" type="button" data-dismiss="modal" class="button" >',
                                             '<span class="icon"></span><em>Save</em>',

--- a/cfgov/unprocessed/js/organisms/FilterableListControls.js
+++ b/cfgov/unprocessed/js/organisms/FilterableListControls.js
@@ -156,7 +156,7 @@ function FilterableListControls( element ) {
   function _buildErrorMessage( fields ) {
     let msg = '';
     fields.forEach( function( validation ) {
-      msg += validation.label + ' ' + validation.msg + '</br>';
+      msg += validation.label + ' ' + validation.msg + '<br>';
     } );
 
     return msg || ERROR_MESSAGES.DEFAULT;


### PR DESCRIPTION
There are instances of the codebase where `</br>` is present, which should be corrected to `<br>` or `<br/>`. This PR fixes those instances. IE11 logs `</br>` as incorrect.

## Changes

- Change `</br>` to `<br>`
