### PR TITLE
Switch to gulp-uglify-es

### DIFF
--- a/gulp/tasks/scripts.js
+++ b/gulp/tasks/scripts.js
@@ -14,7 +14,7 @@ const gulpModernizrBuild = require( 'gulp-modernizr-build' );
 const gulpNewer = require( 'gulp-newer' );
 const gulpRename = require( 'gulp-rename' );
 const gulpReplace = require( 'gulp-replace' );
-const gulpUglify = require( 'gulp-uglify' );
+const gulpUglifyEs = require( 'gulp-uglify-es' ).default;
 const handleErrors = require( '../utils/handle-errors' );
 const vinylNamed = require( 'vinyl-named' );
 const mergeStream = require( 'merge-stream' );
@@ -64,7 +64,7 @@ function scriptsPolyfill() {
       addFeatures: [ 'css/pointerevents', 'es5/specification' ],
       options: [ 'setClasses', 'html5printshiv' ]
     } ) )
-    .pipe( gulpUglify( {
+    .pipe( gulpUglifyEs( {
       compress: {
         properties: false
       }
@@ -169,7 +169,7 @@ function scriptsNemo() {
     } ) )
     .pipe( gulpConcat( 'scripts.js' ) )
     .on( 'error', handleErrors )
-    .pipe( gulpUglify() )
+    .pipe( gulpUglifyEs() )
     .pipe( gulpRename( 'scripts.min.js' ) )
     .pipe( gulp.dest( configLegacy.dest + '/nemo/_/js' ) );
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -80,12 +80,6 @@
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
       "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
     },
-    "accessibility-developer-tools": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/accessibility-developer-tools/-/accessibility-developer-tools-2.12.0.tgz",
-      "integrity": "sha1-PaDM6dbsY3OWS4TzXbfPw996tRQ=",
-      "dev": true
-    },
     "accord": {
       "version": "0.29.0",
       "resolved": "https://registry.npmjs.org/accord/-/accord-0.29.0.tgz",
@@ -907,29 +901,6 @@
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.7.0.tgz",
       "integrity": "sha512-32NDda82rhwD9/JBCCkB+MRYDp0oSvlo2IL6rQWA10PQi7tDUM3eqMSltXmY+Oyl/7N3P3qNtAlv7X0d9bI28w=="
-    },
-    "axe-core": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-2.6.1.tgz",
-      "integrity": "sha512-QFfI3d+x/v92HJWGBaNfgrxdfon9/xXzd04YYfm5w5NJQOLex8qkJCctOt7+ky6e1l9zcQ5E7jsvbnTgQzyfTw==",
-      "dev": true
-    },
-    "axe-webdriverjs": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/axe-webdriverjs/-/axe-webdriverjs-0.2.0.tgz",
-      "integrity": "sha1-XjHtr26bozRCdiz9hd46B0c8EVU=",
-      "dev": true,
-      "requires": {
-        "axe-core": "1.1.1"
-      },
-      "dependencies": {
-        "axe-core": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-1.1.1.tgz",
-          "integrity": "sha1-rp2l2oq08QQZB/H12N/jnJRqksU=",
-          "dev": true
-        }
-      }
     },
     "babel-code-frame": {
       "version": "7.0.0-beta.3",
@@ -7828,6 +7799,55 @@
         }
       }
     },
+    "gulp-uglify-es": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/gulp-uglify-es/-/gulp-uglify-es-1.0.1.tgz",
+      "integrity": "sha512-lwVTOhSPNJvoPZ8wC1mrDiqSszS8INK2R4kaslBKf9wyMVXLWckKs+LRh5bgcymeB5zsczGKT9bGCTNKeEoCvQ==",
+      "dev": true,
+      "requires": {
+        "o-stream": "0.2.2",
+        "plugin-error": "1.0.1",
+        "uglify-es": "3.3.9",
+        "vinyl": "2.1.0",
+        "vinyl-sourcemaps-apply": "0.2.1"
+      },
+      "dependencies": {
+        "arr-diff": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+          "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+          "dev": true
+        },
+        "commander": {
+          "version": "2.13.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.13.0.tgz",
+          "integrity": "sha512-MVuS359B+YzaWqjCL/c+22gfryv+mCBPHAv3zyVI2GN8EY6IRP8VwtasXn8jyyhvvq84R4ImN1OKRtcbIasjYA==",
+          "dev": true
+        },
+        "plugin-error": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/plugin-error/-/plugin-error-1.0.1.tgz",
+          "integrity": "sha512-L1zP0dk7vGweZME2i+EeakvUNqSrdiI3F91TwEoYiGrAfUXmVv6fJIq4g82PAXxNsWOp0J7ZqQy/3Szz0ajTxA==",
+          "dev": true,
+          "requires": {
+            "ansi-colors": "1.1.0",
+            "arr-diff": "4.0.0",
+            "arr-union": "3.1.0",
+            "extend-shallow": "3.0.2"
+          }
+        },
+        "uglify-es": {
+          "version": "3.3.9",
+          "resolved": "https://registry.npmjs.org/uglify-es/-/uglify-es-3.3.9.tgz",
+          "integrity": "sha512-r+MU0rfv4L/0eeW3xZrd16t4NZfK8Ld4SWVglYBb7ez5uXFWHuVRs6xCTrf1yirs9a4j4Y27nn7SRfO6v67XsQ==",
+          "dev": true,
+          "requires": {
+            "commander": "2.13.0",
+            "source-map": "0.6.1"
+          }
+        }
+      }
+    },
     "gulp-util": {
       "version": "3.0.8",
       "resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
@@ -11971,6 +11991,12 @@
       "integrity": "sha512-3iuY4N5dhgMpCUrOVnuAdGrgxVqV2cJpM+XNccjR2DKOB1RUP0aA+wGXEiNziG/UKboFyGBIoKOaNlJxx8bciQ==",
       "dev": true
     },
+    "o-stream": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/o-stream/-/o-stream-0.2.2.tgz",
+      "integrity": "sha512-V3j76KU3g/Gyl8rpdi2z72rn5zguMvTCQgAXfBe3pxEefKqXmOUOD7mvx/mNjykdxGqDVfpSoo8r+WdrkWg/1Q==",
+      "dev": true
+    },
     "oauth-sign": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
@@ -13022,27 +13048,6 @@
             "semver": "5.5.0",
             "xml2js": "0.4.19"
           }
-        }
-      }
-    },
-    "protractor-accessibility-plugin": {
-      "version": "github:cfpb/protractor-accessibility-plugin#7319a881e222d9f3588f6d5d8a3d9848bc38c859",
-      "dev": true,
-      "requires": {
-        "accessibility-developer-tools": "2.12.0",
-        "axe-core": "2.6.1",
-        "axe-webdriverjs": "0.2.0",
-        "html-entities": "1.2.1",
-        "lodash": "3.10.1",
-        "q": "1.5.1",
-        "request": "2.85.0"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "3.10.1",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-          "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
-          "dev": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "gulp-rename": "1.2.2",
     "gulp-replace": "0.6.1",
     "gulp-sourcemaps": "2.6.4",
-    "gulp-uglify": "3.0.0",
+    "gulp-uglify-es": "1.0.1",
     "imagemin-gifsicle": "5.2.0",
     "imagemin-jpegtran": "5.0.2",
     "imagemin-optipng": "5.2.1",


### PR DESCRIPTION
The spanish language pages are using gulp-uglify, but they are throwing an error after uglifying. I switched to gulp-uglify-es (es6 support) and it appears to have solved the issue.

## Changes

- Swap gulp-uglify with gulp-uglify-es.

## Testing

1. `npm install`
2. `gulp clean && gulp build`
3. Visit consumerfinance.gov/es/obtener-respuestas/  and not there's an error in the dev console and search doesn't appear.
4. Visit http://localhost:8000/es/obtener-respuestas/ and note there is no error in the dev console and the search DOES appear.

## Screenshots

The error:
![screen shot 2018-05-07 at 6 02 50 pm](https://user-images.githubusercontent.com/704760/39727487-de606932-5220-11e8-9f63-04b597d2a0a5.png)

## Note
The search doesn't appear to be working. I enter `¿Cómo puedo revisar mi informe de crédito?` and it says `No pudimos encontrar resultados para "None"`. I'm guessing this is an existing issue? Who's familiar with how this search works?