### PR TITLE
Rate checker design feedback fixes

### DIFF
--- a/cfgov/jinja2/v1/owning-a-home/explore-rates/index.html
+++ b/cfgov/jinja2/v1/owning-a-home/explore-rates/index.html
@@ -308,7 +308,7 @@ home price, down payment, and more can affect mortgage interest rates.
                             <button class="chart-menu_btn
                                            cf-icon
                                            cf-icon__after
-                                           cf-icon-down">
+                                           cf-icon-download">
                                 Download chart
                             </button>
                             <ul class="chart-menu_options">
@@ -536,11 +536,19 @@ home price, down payment, and more can affect mortgage interest rates.
                             block__border-top
                             block__flush-top
                             block__padded-top
-                            note-ctr">
-                    <div class="note">
-                        <p class="alert"><strong>Check your credit report.</strong></p>
-                        If you haven’t checked your credit report recently, <a id="annualcreditreport" class="external-link" href="https://annualcreditreport.com" target="_blank" rel="noopener noreferrer">do so now</a>. If you find errors, <a id="ask-dispute-credit-report" href="/askcfpb/314/how-do-i-dispute-an-error-on-my-credit-report.html" target="_blank" rel="noopener noreferrer">get them corrected</a> <strong>before</strong> you apply for a mortgage.
-                    </div> <!-- /.note -->
+                            credit-note-ctr">
+                    <div class="credit-note
+                                m-notification m-notification__warning
+                                m-notification__visible"
+                        role="alert">
+                        <span class="m-notification_icon cf-icon"></span>
+                        <div class="m-notification_content">
+                            <div class="h4 m-notification_message">Check your credit</div>
+                            <div class="h4 m-notification_explanation">
+                                If you haven’t checked your credit report recently, <a id="annualcreditreport" class="external-link" href="https://annualcreditreport.com" target="_blank" rel="noopener noreferrer">do so now</a>. If you find errors, <a id="ask-dispute-credit-report" href="/askcfpb/314/how-do-i-dispute-an-error-on-my-credit-report.html" target="_blank" rel="noopener noreferrer">get them corrected</a> before you apply for a mortgage.
+                            </div>
+                        </div>
+                    </div>
                 </div>
                 <section id="about" class="about wrapper">
                     <div class="content-l">

--- a/cfgov/jinja2/v1/owning-a-home/explore-rates/index.html
+++ b/cfgov/jinja2/v1/owning-a-home/explore-rates/index.html
@@ -537,15 +537,24 @@ home price, down payment, and more can affect mortgage interest rates.
                             block__flush-top
                             block__padded-top
                             credit-note-ctr">
-                    <div class="credit-note
-                                m-notification m-notification__warning
+                    <div class="m-notification__borderless
+                                m-notification
+                                m-notification__warning
                                 m-notification__visible"
-                        role="alert">
+                         role="alert">
                         <span class="m-notification_icon cf-icon"></span>
                         <div class="m-notification_content">
                             <div class="h4 m-notification_message">Check your credit</div>
                             <div class="h4 m-notification_explanation">
-                                If you haven’t checked your credit report recently, <a id="annualcreditreport" class="external-link" href="https://annualcreditreport.com" target="_blank" rel="noopener noreferrer">do so now</a>. If you find errors, <a id="ask-dispute-credit-report" href="/askcfpb/314/how-do-i-dispute-an-error-on-my-credit-report.html" target="_blank" rel="noopener noreferrer">get them corrected</a> before you apply for a mortgage.
+                                If you haven’t checked your credit report recently,
+                                <a class="external-link"
+                                   href="https://annualcreditreport.com"
+                                   target="_blank"
+                                   rel="noopener noreferrer">do so now</a>. If you find errors,
+                                <a href="/askcfpb/314/how-do-i-dispute-an-error-on-my-credit-report.html"
+                                   target="_blank"
+                                   rel="noopener noreferrer">get them corrected
+                               </a> before you apply for a mortgage.
                             </div>
                         </div>
                     </div>

--- a/cfgov/unprocessed/apps/owning-a-home/css/explore-rates.less
+++ b/cfgov/unprocessed/apps/owning-a-home/css/explore-rates.less
@@ -522,10 +522,6 @@
                 height: 110px;
 
             }
-
-            .chart-menu_btn:after {
-                transform: scaleY( -1 );
-            }
         }
     }
 
@@ -564,21 +560,22 @@
         margin-top: @grid_gutter-width;
     }
 
-    .note-ctr {
+    .credit-note-ctr {
         border-top: 1px solid @gray-10;
     }
 
-    .note {
-        .grid_column( 8 );
-        margin: 0;
-        padding: 0 0 0 25px;
+    .credit-note {
+        padding-top: 0;
+        padding-bottom: 0;
+        border: none;
+        background: none;
 
         .alert:before {
             color: @gold;
         }
 
-        p {
-            width: 100%;
+        .m-notification_icon {
+            top: 0;
         }
     }
 
@@ -645,6 +642,10 @@
     } );
 
     .respond-to-min( @bp-sm-max, {
+
+        .credit-note {
+            .grid_column( 8 );
+        }
 
         .page-intro_cols {
             display: table;

--- a/cfgov/unprocessed/apps/owning-a-home/css/explore-rates.less
+++ b/cfgov/unprocessed/apps/owning-a-home/css/explore-rates.less
@@ -497,7 +497,7 @@
             padding: 0;
             margin: 0;
             overflow: hidden;
-            transition: height 300ms;
+            transition: border 300ms 301ms, height 300ms 100ms;
             cursor: pointer;
 
             li {
@@ -564,7 +564,7 @@
         border-top: 1px solid @gray-10;
     }
 
-    .credit-note {
+    .m-notification__borderless {
         padding-top: 0;
         padding-bottom: 0;
         border: none;
@@ -643,7 +643,7 @@
 
     .respond-to-min( @bp-sm-max, {
 
-        .credit-note {
+        .m-notification__borderless {
             .grid_column( 8 );
         }
 

--- a/test/unit_tests/apps/owning-a-home/js/explore-rates/RateCheckerChartMenu-spec.js
+++ b/test/unit_tests/apps/owning-a-home/js/explore-rates/RateCheckerChartMenu-spec.js
@@ -24,7 +24,7 @@ const HTML_SNIPPET = `
       <button class="chart-menu_btn
                      cf-icon
                      cf-icon__after
-                     cf-icon-down">
+                     cf-icon-download">
         Download chart
       </button>
       <ul class="chart-menu_options">


### PR DESCRIPTION
Rate checker design feedback fixes GHE/19

## Testing

1. Visit `http://localhost:8000/owning-a-home/explore-rates/` and compare to mockup.


## Screenshot

- 
<img width="803" alt="screen shot 2018-05-08 at 11 44 38 am" src="https://user-images.githubusercontent.com/1696212/39767649-3e97abf0-52b5-11e8-9273-bc38c5bcb714.png">
<img width="1312" alt="screen shot 2018-05-08 at 11 44 49 am" src="https://user-images.githubusercontent.com/1696212/39767650-3ea76126-52b5-11e8-8179-a3a62f0c6259.png">



## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Internet Explorer 8, 9, 10, and 11
- [ ] Edge
- [ ] iOS Safari
- [ ] Chrome for Android

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
