### PR TITLE
Clean up regulation inline interpretations

### DIFF
--- a/cfgov/regulations3k/jinja2/regulations3k/browse-regulation.html
+++ b/cfgov/regulations3k/jinja2/regulations3k/browse-regulation.html
@@ -15,7 +15,7 @@
 {%- endblock %}
 
 {% block content_main_modifiers -%}
-    {{ super() }} content__flush-bottom
+    {{ super() }} content__flush-bottom regulations3k
 {%- endblock %}
 
 {% block preload %}

--- a/cfgov/regulations3k/regdown.py
+++ b/cfgov/regulations3k/regdown.py
@@ -124,6 +124,13 @@ class LabeledParagraphProcessor(ParagraphProcessor):
             label, text = match.group('label'), match.group('text')
             p = util.etree.SubElement(parent, 'p')
             p.set('id', label)
+            # We use CSS classes to indent paragraph text. To assign the correct
+            # class, we count the number of dashes in the label to determine
+            # how deeply nested the paragraph is. Inline interps have special
+            # prefixes that are removed before counting the dashes.
+            # e.g. 6-a-Interp-1 becomes -1 and gets a `level-1` class
+            # e.g. 12-b-Interp-2-i becomes -2-i and gets a `level-2` class
+            label = re.sub('^\w+\-\w+\-interp', '', label, flags=re.IGNORECASE)
             level = label.count('-')
             class_name = 'level-{}'.format(level)
             p.set('class', class_name)

--- a/cfgov/regulations3k/tests/test_regdown.py
+++ b/cfgov/regulations3k/tests/test_regdown.py
@@ -42,6 +42,38 @@ class RegulationsExtensionTestCase(unittest.TestCase):
             'This is a paragraph with a label.</p>'
         )
 
+    def test_inline_interp_label(self):
+        text = '{1-a-Interp-1}\nThis is a paragraph with a label.'
+        self.assertEqual(
+            regdown(text),
+            '<p class="level-1" id="1-a-Interp-1">'
+            'This is a paragraph with a label.</p>'
+        )
+
+    def test_deeper_inline_interp_label(self):
+        text = '{1-a-Interp-1-i}\nThis is a paragraph with a label.'
+        self.assertEqual(
+            regdown(text),
+            '<p class="level-2" id="1-a-Interp-1-i">'
+            'This is a paragraph with a label.</p>'
+        )
+
+    def test_even_deeper_inline_interp_label(self):
+        text = '{1-a-Interp-1-i-a}\nThis is a paragraph with a label.'
+        self.assertEqual(
+            regdown(text),
+            '<p class="level-3" id="1-a-Interp-1-i-a">'
+            'This is a paragraph with a label.</p>'
+        )
+
+    def test_complicated_inline_interp_label(self):
+        text = '{12-d-Interp-7-ii-c-A-7}\nThis is a paragraph with a label.'
+        self.assertEqual(
+            regdown(text),
+            '<p class="level-5" id="12-d-Interp-7-ii-c-A-7">'
+            'This is a paragraph with a label.</p>'
+        )
+
     def test_list_state(self):
         text = '- {my-label} This is a paragraph in a list.'
         self.assertEqual(

--- a/cfgov/unprocessed/apps/regulations3k/css/main.less
+++ b/cfgov/unprocessed/apps/regulations3k/css/main.less
@@ -9,8 +9,6 @@
 @import (less) './reg-search.less';
 @import (less) './reg-text.less';
 
-@import (less) 'cf-expandables.less';
-
 .section-nav {
   .u-clearfix;
 }

--- a/cfgov/unprocessed/apps/regulations3k/css/reg-text.less
+++ b/cfgov/unprocessed/apps/regulations3k/css/reg-text.less
@@ -3,18 +3,41 @@
    Regulation section text styling and type hierarchy
    ========================================================================== */
 
-p[id] em {
-   font-style: normal;
-   font-weight: bold;
+.regulations3k {
+
+    // Swap regdown paragraph italics with bold text
+    p[class^='level'] em {
+        font-style: normal;
+        font-weight: bold;
+    }
+
+    // Inline interpretations
+    .o-expandable {
+        &_target,
+        &_content {
+            background-color: transparent;
+            border: 0;
+        }
+        &__expanded {
+            background-color: @gray-10;
+            &_content {
+                border-bottom: 1px solid @gray-40;
+            }
+            &:hover {
+                background-color: @gray-20;
+            }
+        }
+    }
+
 }
 
 .generateLevel(6);
 
 // Generate six indentation levels for reg text
 .generateLevel(@n, @i: 1) when (@i =< @n) {
-  .level-@{i} {
-    box-sizing: border-box;
-    padding-left: (@i * 2em);
-  }
-  .generateLevel(@n, (@i + 1));
+    .level-@{i} {
+        box-sizing: border-box;
+        padding-left: (@i * 2em);
+    }
+    .generateLevel(@n, (@i + 1));
 }

--- a/cfgov/unprocessed/apps/regulations3k/js/index.js
+++ b/cfgov/unprocessed/apps/regulations3k/js/index.js
@@ -1,7 +1,6 @@
-import turbolinks from 'turbolinks';
-
 import Expandable from '../../../js/organisms/Expandable.js';
 import { instantiateAll } from '../../../js/modules/util/atomic-helpers';
+import turbolinks from 'turbolinks';
 
 instantiateAll( '.o-expandable', Expandable );
 


### PR DESCRIPTION
Couple fixes to our new reg pages: inline interp expandables are improved and the indentation of the interp text is fixed.

## Changes

- Add correct indentation classes to inline interp text.
- Expandables margins and colors are improved.

## Testing

1. `tox -e fast regulations3k.tests.test_regdown`
1. Load a reg section page and see if the expandable inline interps no longer have wonky margins.

## Todos

- An empty paragraph is generated at the start of inline interps by the `{X-x-Interp}` tag in the regdown. We should either have the regdown parser strip out empty paragraphs before returning HTML or modify the regdown spec to not require the opening interp tag.

| Regdown | Generated HTML |
|---------|----------------|
| <img width="785" alt="screen shot 2018-05-09 at 2 27 49 am" src="https://user-images.githubusercontent.com/1060248/39799056-dd8e2e20-5330-11e8-830a-ea5c4ff78cfe.png">     | <img width="733" alt="screen shot 2018-05-09 at 2 30 34 am" src="https://user-images.githubusercontent.com/1060248/39799088-fa8b4dfa-5330-11e8-9207-5bde58c33f13.png">            |