### PR TITLE
Updated Teachers Digital Platform URL for release

### DIFF
--- a/cfgov/cfgov/urls.py
+++ b/cfgov/cfgov/urls.py
@@ -395,7 +395,7 @@ urlpatterns = [
                 include('search.urls')),
 
     flagged_url('TDP_RELEASE',
-                r'^tdp/',
+                r'^practitioner-resources/youth-financial-education/curriculum-review/',
                 include_if_app_enabled('teachers_digital_platform',
                                        'teachers_digital_platform.urls')),
 

--- a/cfgov/cfgov/urls.py
+++ b/cfgov/cfgov/urls.py
@@ -395,7 +395,7 @@ urlpatterns = [
                 include('search.urls')),
 
     flagged_url('TDP_RELEASE',
-                r'^practitioner-resources/youth-financial-education/curriculum-review/',
+                r'^practitioner-resources/youth-financial-education/curriculum-review/', # noqa: E501
                 include_if_app_enabled('teachers_digital_platform',
                                        'teachers_digital_platform.urls')),
 

--- a/cfgov/cfgov/urls.py
+++ b/cfgov/cfgov/urls.py
@@ -395,7 +395,7 @@ urlpatterns = [
                 include('search.urls')),
 
     flagged_url('TDP_RELEASE',
-                r'^practitioner-resources/youth-financial-education/curriculum-review/', # noqa: E501
+                r'^practitioner-resources/youth-financial-education/curriculum-review/',  # noqa: E501
                 include_if_app_enabled('teachers_digital_platform',
                                        'teachers_digital_platform.urls')),
 

--- a/cfgov/cfgov/urls.py
+++ b/cfgov/cfgov/urls.py
@@ -395,9 +395,19 @@ urlpatterns = [
                 include('search.urls')),
 
     flagged_url('TDP_RELEASE',
-                r'^practitioner-resources/youth-financial-education/curriculum-review/',  # noqa: E501
+                r'^practitioner-resources/youth-financial-education/curriculum-review/tool/',  # noqa: E501
                 include_if_app_enabled('teachers_digital_platform',
-                                       'teachers_digital_platform.urls')),
+                                       'teachers_digital_platform.tool-urls')),
+
+    flagged_url('TDP_RELEASE',
+            r'^practitioner-resources/youth-financial-education/curriculum-review/before-you-begin/',  # noqa: E501
+            include_if_app_enabled('teachers_digital_platform',
+                                    'teachers_digital_platform.begin-urls')),
+
+    flagged_url('TDP_RELEASE',
+            r'^practitioner-resources/youth-financial-education/curriculum-review/prototypes/',  # noqa: E501
+            include_if_app_enabled('teachers_digital_platform',
+                                    'teachers_digital_platform.prototypes-urls')),  # noqa: E501
 
     flagged_url(
         'REGULATIONS3K',

--- a/requirements/optional-public.txt
+++ b/requirements/optional-public.txt
@@ -7,4 +7,4 @@ https://github.com/cfpb/retirement/releases/download/0.6.0/retirement-0.6.0-py2-
 git+https://github.com/cfpb/ccdb5-api.git@v1.0.5#egg=ccdb5-api
 git+https://github.com/cfpb/ccdb5-ui.git@v1.0.8#egg=ccdb5_ui
 https://github.com/cfpb/django-college-costs-comparison/releases/download/1.5.3/comparisontool-1.5.3-py2-none-any.whl
-https://github.com/cfpb/teachers-digital-platform/releases/download/0.5.10/teachers_digital_platform-0.5.10-py2-none-any.whl
+https://github.com/cfpb/teachers-digital-platform/releases/download/0.5.11/teachers_digital_platform-0.5.11-py2-none-any.whl


### PR DESCRIPTION
The current release of the Teachers Digital Platform needs the base url to be:
https://www.consumerfinance.gov/practitioner-resources/youth-financial-education/curriculum-review/

[Short description explaining the high-level reason for the pull request]

## Additions

- None

## Removals

- None

## Changes

- Changed 'tdp' to 'practitioner-resources/youth-financial-education/curriculum-review/' in the urls.py

## Testing

1. Verify the new url redirects to the current tdp develop-apps/teachers-digital-platform app

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [x] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Internet Explorer 8, 9, 10, and 11
- [ ] Edge
- [ ] iOS Safari
- [ ] Chrome for Android

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
