### PR TITLE
Remove ansi-colors

### DIFF
--- a/gulp/tasks/test.js
+++ b/gulp/tasks/test.js
@@ -1,4 +1,3 @@
-const ansiColors = require( 'ansi-colors' );
 const environment = require( '../../config/environment' );
 const envvars = environment.envvars;
 const fancyLog = require( 'fancy-log' );
@@ -199,8 +198,9 @@ function _createSauceTunnel( ) {
   const SAUCE_TUNNEL_ID = envvars.SAUCE_TUNNEL;
 
   if ( !( SAUCE_USERNAME && SAUCE_ACCESS_KEY && SAUCE_TUNNEL_ID ) ) {
+    const RED_COLOR = '\x1b[31m%s\x1b[0m';
     const ERROR_MSG = 'Please ensure your SAUCE variables are set.';
-    fancyLog( ansiColors.red( ERROR_MSG ) );
+    fancyLog( RED_COLOR, ERROR_MSG );
 
     return Promise.reject( new Error( ERROR_MSG ) );
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -261,7 +261,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-1.1.0.tgz",
       "integrity": "sha512-SFKX67auSNoVR38N3L+nvsPjOE0bybKTYbkf5tRvushrAPQ9V75huw0ZxBkKVeRU9kqH3d6HA4xTckbwZ4ixmA==",
-      "dev": true,
       "requires": {
         "ansi-wrap": "0.1.0"
       }
@@ -7447,16 +7446,6 @@
             "semver-greatest-satisfied-range": "1.1.0",
             "v8flags": "3.0.2",
             "yargs": "7.1.0"
-          },
-          "dependencies": {
-            "ansi-colors": {
-              "version": "1.1.0",
-              "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-1.1.0.tgz",
-              "integrity": "sha512-SFKX67auSNoVR38N3L+nvsPjOE0bybKTYbkf5tRvushrAPQ9V75huw0ZxBkKVeRU9kqH3d6HA4xTckbwZ4ixmA==",
-              "requires": {
-                "ansi-wrap": "0.1.0"
-              }
-            }
           }
         },
         "isobject": {

--- a/package.json
+++ b/package.json
@@ -75,7 +75,6 @@
     "xdr": "0.5.3"
   },
   "devDependencies": {
-    "ansi-colors": "1.1.0",
     "babel-jest": "22.4.3",
     "chai": "4.1.2",
     "chai-as-promised": "7.1.1",


### PR DESCRIPTION
Red output was only used in one error state place. Probably not worth having the dependency for that (which includes a bunch of colors and bold, etc.).

## Removals

- Removes `ansi-colors` dependency in favor of inlining red color.
