### PR TITLE
comment-out TDP search url

### DIFF
--- a/cfgov/cfgov/urls.py
+++ b/cfgov/cfgov/urls.py
@@ -409,10 +409,10 @@ urlpatterns = [
             include_if_app_enabled('teachers_digital_platform',
                                     'teachers_digital_platform.prototypes-urls')),  # noqa: E501
 
-    flagged_url('TDP_SEARCH_INTERFACE',
-            r'^practitioner-resources/youth-financial-education/curriculum-review/search/',  # noqa: E501
-            include_if_app_enabled('teachers_digital_platform',
-                                    'teachers_digital_platform.search-urls')),
+    # flagged_url('TDP_SEARCH_INTERFACE',
+    #         r'^practitioner-resources/youth-financial-education/curriculum-review/search/',  # noqa: E501
+    #         include_if_app_enabled('teachers_digital_platform',
+    #                                 'teachers_digital_platform.search-urls')),
 
     flagged_url(
         'REGULATIONS3K',


### PR DESCRIPTION
The Teachers Digital Platform flagged-url for search refers to a URL conf that doesn't yet exist, which currently hoses beta and build.

This comments out the URL until code is lined up.
