### PR TITLE
Let smoketests pass if only one timeout occurs

### DIFF
--- a/cfgov/scripts/http_smoke_test.py
+++ b/cfgov/scripts/http_smoke_test.py
@@ -223,11 +223,11 @@ def check_urls(base, full=False):
 
     if failures:
         logger.error("These URLs failed: {}".format(failures))
-    if timeouts:
+    if len(timeouts) > 1:
         logger.error("These URLs timed out after {} seconds: "
                      "{}".format(TIMEOUT, timeouts))
 
-    if failures or timeouts:
+    if failures or len(timeouts) > 1:
         logger.error("FAIL")
         return False
 

--- a/cfgov/scripts/http_smoke_test.py
+++ b/cfgov/scripts/http_smoke_test.py
@@ -35,6 +35,7 @@ parser.add_argument(
 )
 
 TIMEOUT = 30
+ALLOWED_TIMEOUTS = 1
 FULL = False
 BASE = 'https://www.consumerfinance.gov'
 
@@ -223,11 +224,11 @@ def check_urls(base, full=False):
 
     if failures:
         logger.error("These URLs failed: {}".format(failures))
-    if len(timeouts) > 1:
+    if len(timeouts) > ALLOWED_TIMEOUTS:
         logger.error("These URLs timed out after {} seconds: "
                      "{}".format(TIMEOUT, timeouts))
 
-    if failures or len(timeouts) > 1:
+    if failures or len(timeouts) > ALLOWED_TIMEOUTS:
         logger.error("FAIL")
         return False
 

--- a/cfgov/scripts/http_smoke_test.py
+++ b/cfgov/scripts/http_smoke_test.py
@@ -227,6 +227,10 @@ def check_urls(base, full=False):
     if len(timeouts) > ALLOWED_TIMEOUTS:
         logger.error("These URLs timed out after {} seconds: "
                      "{}".format(TIMEOUT, timeouts))
+    elif timeouts:
+        logger.info(
+            "{} allowed timeouts occurred:\n"
+            "{}".format(len(timeouts), "\n".join(timeouts)))
 
     if failures or len(timeouts) > ALLOWED_TIMEOUTS:
         logger.error("FAIL")

--- a/cfgov/scripts/tests/test_smoke_tests.py
+++ b/cfgov/scripts/tests/test_smoke_tests.py
@@ -86,8 +86,9 @@ class HttpTests(unittest.TestCase):
         mock_ok_response = mock.Mock()
         mock_ok_response.status_code = 200
         short_run_remainder = len(http_smoke_test.SHORT_RUN) - allowed
+        allowed_list = [requests.exceptions.Timeout] * allowed
         ok_list = [mock_ok_response] * short_run_remainder
-        side_effect_list = [requests.exceptions.Timeout] + ok_list
+        side_effect_list = allowed_list + ok_list
         mock_get.side_effect = side_effect_list
         self.assertTrue(http_smoke_test.check_urls('pro1'))
 

--- a/cfgov/scripts/tests/test_smoke_tests.py
+++ b/cfgov/scripts/tests/test_smoke_tests.py
@@ -82,9 +82,10 @@ class HttpTests(unittest.TestCase):
 
     @mock.patch('scripts.http_smoke_test.requests.get')
     def test_singleton_timeout_passes(self, mock_get):
+        allowed = http_smoke_test.ALLOWED_TIMEOUTS
         mock_ok_response = mock.Mock()
         mock_ok_response.status_code = 200
-        short_run_remainder = len(http_smoke_test.SHORT_RUN) - 1
+        short_run_remainder = len(http_smoke_test.SHORT_RUN) - allowed
         ok_list = [mock_ok_response] * short_run_remainder
         side_effect_list = [requests.exceptions.Timeout] + ok_list
         mock_get.side_effect = side_effect_list

--- a/cfgov/scripts/tests/test_smoke_tests.py
+++ b/cfgov/scripts/tests/test_smoke_tests.py
@@ -81,6 +81,16 @@ class HttpTests(unittest.TestCase):
         self.assertEqual(mock_get.call_count, len(http_smoke_test.FULL_RUN))
 
     @mock.patch('scripts.http_smoke_test.requests.get')
+    def test_singleton_timeout_passes(self, mock_get):
+        mock_ok_response = mock.Mock()
+        mock_ok_response.status_code = 200
+        short_run_remainder = len(http_smoke_test.SHORT_RUN) - 1
+        ok_list = [mock_ok_response] * short_run_remainder
+        side_effect_list = [requests.exceptions.Timeout] + ok_list
+        mock_get.side_effect = side_effect_list
+        self.assertTrue(http_smoke_test.check_urls('pro1'))
+
+    @mock.patch('scripts.http_smoke_test.requests.get')
     def test_http_fail_connection_error(self, mock_get):
         mock_get.side_effect = requests.exceptions.ConnectionError
         http_smoke_test.check_urls('pro1')

--- a/cfgov/scripts/tests/test_smoke_tests.py
+++ b/cfgov/scripts/tests/test_smoke_tests.py
@@ -81,7 +81,7 @@ class HttpTests(unittest.TestCase):
         self.assertEqual(mock_get.call_count, len(http_smoke_test.FULL_RUN))
 
     @mock.patch('scripts.http_smoke_test.requests.get')
-    def test_singleton_timeout_passes(self, mock_get):
+    def test_allowed_timeouts(self, mock_get):
         allowed = http_smoke_test.ALLOWED_TIMEOUTS
         mock_ok_response = mock.Mock()
         mock_ok_response.status_code = 200


### PR DESCRIPTION
Our smoketests sometimes fail because the initial test can time out
 while servers are restarting. This PR allows one timeout to occur
 without failing the build.

Also added a test of the test.
