### PR TITLE
Restore django-hud API

### DIFF
--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -88,6 +88,7 @@ OPTIONAL_APPS = [
     {'import': 'comparisontool', 'apps': ('comparisontool', 'haystack',)},
     {'import': 'paying_for_college',
      'apps': ('paying_for_college', 'haystack',)},
+    {'import': 'hud_api_replace', 'apps': ('hud_api_replace',)},
     {'import': 'retirement_api', 'apps': ('retirement_api',)},
     {'import': 'complaint', 'apps': ('complaint',
      'complaintdatabase', 'complaint_common',)},
@@ -309,6 +310,10 @@ SHEER_ELASTICSEARCH_SETTINGS = \
 
 STATIC_VERSION = ''
 
+# DJANGO HUD API
+DJANGO_HUD_API_ENDPOINT= os.environ.get('HUD_API_ENDPOINT', 'http://localhost/hud-api-replace/')
+# in seconds, 2592000 == 30 days. Google allows no more than a month of caching
+DJANGO_HUD_GEODATA_EXPIRATION_INTERVAL = 2592000
 MAPBOX_ACCESS_TOKEN = os.environ.get('MAPBOX_ACCESS_TOKEN')
 HOUSING_COUNSELOR_S3_PATH_TEMPLATE = (
     'a/assets/hud/{format}s/{zipcode}.{format}'

--- a/cfgov/cfgov/urls.py
+++ b/cfgov/cfgov/urls.py
@@ -234,6 +234,10 @@ urlpatterns = [
             'paying_for_college', 'paying_for_college.config.urls')),
     url(r'^credit-cards/agreements/',
         include('agreements.urls')),
+    url(r'^hud-api-replace/', include_if_app_enabled(
+        'hud_api_replace',
+        'hud_api_replace.urls',
+        namespace='hud_api_replace')),
     url(r'^consumer-tools/retirement/',
         include_if_app_enabled('retirement_api', 'retirement_api.urls')),
 

--- a/cfgov/legacy/templates/hud/housing_counselor.html
+++ b/cfgov/legacy/templates/hud/housing_counselor.html
@@ -97,7 +97,11 @@ Find a housing counselor
                             </div>
                             <div id="hud_hca_api_more_info_container" class="hud_hca_api_more_info">
                                 <p>
-                                    This tool is powered by <a href="https://data.hud.gov/housing_counseling.html">HUD's</a> official list of housing counselors.
+                                    This tool is open sourced on
+                                    <a href="https://github.com/cfpb/django-hud">GitHub</a>
+                                    and powered by <a href="https://data.hud.gov/housing_counseling.html">HUD's</a>
+                                    official list of housing counselors.
+                                    We encourage you to leverage it in your own applications.
                                 </p>
 
                                 <p>

--- a/requirements/optional-public.txt
+++ b/requirements/optional-public.txt
@@ -6,5 +6,6 @@ https://github.com/cfpb/regulations-site/releases/download/2.2.3/regulations-2.2
 https://github.com/cfpb/retirement/releases/download/0.6.0/retirement-0.6.0-py2-none-any.whl
 git+https://github.com/cfpb/ccdb5-api.git@v1.0.5#egg=ccdb5-api
 git+https://github.com/cfpb/ccdb5-ui.git@v1.0.8#egg=ccdb5_ui
+https://github.com/cfpb/django-hud/releases/download/1.4.3/django_hud-1.4.3-py2-none-any.whl
 https://github.com/cfpb/django-college-costs-comparison/releases/download/1.5.3/comparisontool-1.5.3-py2-none-any.whl
 https://github.com/cfpb/teachers-digital-platform/releases/download/0.5.12/teachers_digital_platform-0.5.12-py2-none-any.whl


### PR DESCRIPTION
This change restores the legacy django-hud API that was removed in #4086 (10766f1). This restores the dependency on https://github.com/cfpb/django-hud and restores the legacy API available
at, for example, https://www.consumerfinance.gov/hud-api-replace/20005.json.