### PR TITLE
Fixes for rate checker

### DIFF
--- a/cfgov/unprocessed/apps/owning-a-home/css/explore-rates.less
+++ b/cfgov/unprocessed/apps/owning-a-home/css/explore-rates.less
@@ -509,8 +509,8 @@
                 margin: 0;
 
                 &:hover {
-                    background-color: @pacific;
-                    color: @white;
+                    background-color: @gray-5;
+                    color: @pacific;
                 }
             }
         }

--- a/cfgov/unprocessed/apps/owning-a-home/js/explore-rates/rate-checker.js
+++ b/cfgov/unprocessed/apps/owning-a-home/js/explore-rates/rate-checker.js
@@ -214,7 +214,6 @@ function updateView() {
 
       updateComparisons( data );
       renderInterestAmounts();
-      tab.init();
     } );
   }
 }


### PR DESCRIPTION
Fixes for rate checker


## Changes

- Modified code to fix tab visibility issue. Tabs were disappearing when the rate checker `updateView` method was called. `.Tab.init` was already invoked in `init` method.
- Minor design change for the drop down.

## Testing

1. Visit `http://localhost:8000/owning-a-home/explore-rates/#tab2` 
2. Click on the tabs and ensure that they work.
3. Click on the slider and cause an error.
4. Click on the sider, so the error is no longer created.
5. Verify that the tabs are still visible.

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Internet Explorer 8, 9, 10, and 11
- [ ] Edge
- [ ] iOS Safari
- [ ] Chrome for Android

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
