### PR TITLE
Mega Menu: Hack for WAVE validation empty button error

### DIFF
--- a/cfgov/jinja2/v1/_includes/organisms/mega-menu.html
+++ b/cfgov/jinja2/v1/_includes/organisms/mega-menu.html
@@ -193,5 +193,13 @@
     {# Create a root menu at depth one.
        This is the 1st level of a 3-level menu. #}
     {{ _nav( 1, vars.nav_groups ) }}
-    <button class="{{ base_class ~ '_tab-trigger' }}" aria-hidden="true"></button>
+    <button class="m-global-search_tab-trigger u-visually-hidden"
+            aria-hidden="true">
+      .
+      {# The tab trigger is hidden, but is used to listen for keyup events
+      when the tab key is pressed on it while it has focus, so that
+      the menu can be collapsed.
+      The period is because HTML validation requires the button
+      contain some content. #}
+    </button>
 </nav>


### PR DESCRIPTION
## Changes

- Adds a period to the mege menu's tab trigger as a hack to pass the WAVE validation.

## Testing

1. Pull this branch.
2. Check WAVE extension and see that there is one less error on the page vs master branch.

## Notes

- Not sure if this is the best way to satisfy the content requirement, but the idea was if for some reason this button was shown, it would only be a period and wouldn't otherwise visually disrupt things. 

## Todos

- Tab trigger should be its own module. https://github.com/cfpb/cfgov-refresh/blob/master/cfgov/unprocessed/js/molecules/GlobalSearch.js#L30
