### PR TITLE
Regulations3000: Use wagtail-treemodeladmin

### DIFF
--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -96,7 +96,7 @@ OPTIONAL_APPS = [
     {'import': 'countylimits', 'apps': ('countylimits', 'rest_framework')},
     {'import': 'regcore', 'apps': ('regcore', 'regcore_read')},
     {'import': 'regulations', 'apps': ('regulations',)},
-    {'import': 'regulations3k', 'apps': ('regulations3k',)},
+    {'import': 'regulations3k', 'apps': ('regulations3k', 'treemodeladmin')},
     {'import': 'complaint_search', 'apps': ('complaint_search', 'rest_framework')},
     {'import': 'ccdb5_ui', 'apps': ('ccdb5_ui', )},
     {'import': 'teachers_digital_platform', 'apps': ('teachers_digital_platform', )},

--- a/cfgov/regulations3k/fixtures/regdata.json
+++ b/cfgov/regulations3k/fixtures/regdata.json
@@ -171,7 +171,7 @@
   "fields": {
     "title": "Subpart A - General",
     "version": 2,
-    "label": "1005-A"
+    "label": "1005-Subpart-A"
   },
   "model": "regulations3k.subpart",
   "pk": 4
@@ -180,7 +180,7 @@
   "fields": {
     "title": "Subpart B - Requirements for Remittance Transfers",
     "version": 2,
-    "label": "1005-B"
+    "label": "1005-Subpart-B"
   },
   "model": "regulations3k.subpart",
   "pk": 5

--- a/cfgov/regulations3k/models/django.py
+++ b/cfgov/regulations3k/models/django.py
@@ -100,6 +100,7 @@ class EffectiveVersion(models.Model):
 
     class Meta:
         ordering = ['effective_date']
+        default_related_name = 'version'
 
 
 @python_2_unicode_compatible

--- a/cfgov/regulations3k/tests/test_hooks.py
+++ b/cfgov/regulations3k/tests/test_hooks.py
@@ -2,17 +2,26 @@ from __future__ import unicode_literals
 
 from django.test import TestCase
 
-from regulations3k.models import EffectiveVersion, Part, Section, Subpart
-from regulations3k.wagtail_hooks import (
-    EffectiveVersionModelAdmin, PartModelAdmin, SectionModelAdmin,
-    SubpartModelAdmin
-)
+from wagtail.tests.utils import WagtailTestUtils
 
 
-class TestRegs3kHooks(TestCase):
+class TestRegs3kHooks(TestCase, WagtailTestUtils):
 
-    def test_reg_model_hooks(self):
-        self.assertEqual(PartModelAdmin.model, Part)
-        self.assertEqual(SubpartModelAdmin.model, Subpart)
-        self.assertEqual(SectionModelAdmin.model, Section)
-        self.assertEqual(EffectiveVersionModelAdmin.model, EffectiveVersion)
+    def setUp(self):
+        self.login()
+
+    def test_part_model_admin(self):
+        response = self.client.get('/admin/regulations3k/part/')
+        self.assertEqual(response.status_code, 200)
+
+    def test_effectiveversion_model_admin(self):
+        response = self.client.get('/admin/regulations3k/effectiveversion/')
+        self.assertEqual(response.status_code, 200)
+
+    def test_subpart_model_admin(self):
+        response = self.client.get('/admin/regulations3k/subpart/')
+        self.assertEqual(response.status_code, 200)
+
+    def test_section_model_admin(self):
+        response = self.client.get('/admin/regulations3k/section/')
+        self.assertEqual(response.status_code, 200)

--- a/cfgov/regulations3k/wagtail_hooks.py
+++ b/cfgov/regulations3k/wagtail_hooks.py
@@ -1,60 +1,56 @@
 from __future__ import unicode_literals
 
-from wagtail.contrib.modeladmin.options import (
-    ModelAdmin, ModelAdminGroup, modeladmin_register
-)
+from wagtail.contrib.modeladmin.options import modeladmin_register
 
 from regulations3k.models import EffectiveVersion, Part, Section, Subpart
+from treemodeladmin.options import TreeModelAdmin
 
 
-class PartModelAdmin(ModelAdmin):
-    model = Part
-    menu_label = 'Regulation part'
-    menu_icon = 'list-ul'
-    list_display = (
-        'title',
-        'part_number',
-        'letter_code')
-
-
-class SubpartModelAdmin(ModelAdmin):
-    model = Subpart
-    menu_label = 'Regulation subpart'
-    menu_icon = 'list-ul'
-    list_display = (
-        'label',
-        'title',
-        'version')
-    # list_filter = ('label',)
-
-
-class SectionModelAdmin(ModelAdmin):
+class SectionModelAdmin(TreeModelAdmin):
     model = Section
     menu_label = 'Regulation section content'
     menu_icon = 'list-ul'
     list_display = (
-        'label',
-        'subpart',
-        'title')
+        'title',
+    )
     search_fields = (
         'label', 'title')
-    list_filter = ('subpart__version__part__letter_code',)
+    parent_field = 'subpart'
 
 
-class EffectiveVersionModelAdmin(ModelAdmin):
+class SubpartModelAdmin(TreeModelAdmin):
+    model = Subpart
+    menu_label = 'Regulation subpart'
+    menu_icon = 'list-ul'
+    list_display = (
+        'title',
+    )
+    child_field = 'sections'
+    child_model_admin = SectionModelAdmin
+    parent_field = 'version'
+
+
+class EffectiveVersionModelAdmin(TreeModelAdmin):
     model = EffectiveVersion
     menu_label = 'Regulation effective versions'
     menu_icon = 'list-ul'
     list_display = (
-        'part',
-        'effective_date')
-    list_filter = ('effective_date', 'part')
+        'effective_date',
+    )
+    child_field = 'subparts'
+    child_model_admin = SubpartModelAdmin
+    parent_field = 'part'
 
 
 @modeladmin_register
-class Regulations3kModelAdminGroup(ModelAdminGroup):
-    menu_label = 'Regulations3k'
+class PartModelAdmin(TreeModelAdmin):
+    model = Part
+    menu_label = 'Regulations'
     menu_icon = 'list-ul'
-    items = (
-        PartModelAdmin, EffectiveVersionModelAdmin,
-        SubpartModelAdmin, SectionModelAdmin)
+    list_display = (
+        'part_number',
+        'title',
+        'letter_code'
+    )
+    child_field = 'versions'
+    child_model_admin = EffectiveVersionModelAdmin

--- a/requirements/libraries.txt
+++ b/requirements/libraries.txt
@@ -40,4 +40,5 @@ unipath>=1.1,<=2.0
 wagtail-flags==2.0.8
 wagtail-inventory==0.4.2
 wagtail-sharing==0.6.1
+wagtail-treemodeladmin==1.0.1
 Wand==0.4.2


### PR DESCRIPTION
This PR uses [wagtail-treemodeladmin](https://github.com/cfpb/wagtail-treemodeladmin) for the Regulations3k models within the Wagtail Admin. This makes navigating them similar to navigating the Wagtail page tree explorer.

It also makes modifications to the admin hooks for Regulations3k to use TreeModelAdmin and the tests as a result.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: