### PR TITLE
Convert Notification icons to SVGs

### DIFF
--- a/cfgov/jinja2/v1/_includes/molecules/notification.html
+++ b/cfgov/jinja2/v1/_includes/molecules/notification.html
@@ -24,19 +24,21 @@
 {% macro render(type, is_visible, message, explanation=none) %}
 
   {% set type_lookup  = {
-        'success' : 'approved',
-        'warning' : 'error',
-        'error'   : 'delete',
+        'default': 'information-round',
+        'success': 'approved-round',
+        'warning': 'warning-round',
+        'error':   'error-round',
       }
   %}
   {% set icon = type_lookup[type]  %}
-  {% set type = ('m-notification__' + type | string) if type else '' %}
+  {% set type = ('m-notification__' + type | string)
+     if type and type != 'default'
+     else '' %}
 
   <div class="m-notification
               {{ type }}
               {{ 'm-notification__visible' if is_visible else '' }}">
-      <span class="m-notification_icon
-                   cf-icon"></span>
+      {{ svg_icon(icon) }}
       <div class="m-notification_content"
            {{ 'role="alert"' if type == 'warning' or type == 'error' else '' }}>
           <div class="h4 m-notification_message">{{ message }}</div>

--- a/cfgov/jinja2/v1/_includes/organisms/email-signup.html
+++ b/cfgov/jinja2/v1/_includes/organisms/email-signup.html
@@ -34,7 +34,7 @@
       enctype="application/x-www-form-urlencoded">
      <div class="u-mb15">
 	    {% import 'molecules/notification.html' as notification with context %}
-	    {{ notification.render('success', false, '') }}
+	    {{ notification.render('default', false, '') }}
 	</div>
     {% if value.text %}
         <p>

--- a/cfgov/jinja2/v1/_includes/organisms/header.html
+++ b/cfgov/jinja2/v1/_includes/organisms/header.html
@@ -27,7 +27,6 @@
                         m-notification__warning
                         wrapper
                         wrapper__match-content">
-                <span class="m-notification_icon cf-icon"></span>
                 <div class="m-notification_content">
                     <div class="h4 m-notification_message">
                         This beta site is a work in progress.

--- a/cfgov/jinja2/v1/_includes/organisms/mortgage-map.html
+++ b/cfgov/jinja2/v1/_includes/organisms/mortgage-map.html
@@ -157,9 +157,11 @@
                         m-notification__warning u-mt30"
                   id="mp-map-notification"
                   style="display:none">
-                <span class="m-notification_icon cf-icon"></span>
+                  {{ svg_icon('warning') }}
                 <div class="m-notification_content">
-                    <div class="h4 m-notification_message">Invalid date</div>
+                    <div class="h4 m-notification_message">
+                        Invalid date
+                    </div>
                     <p class="h4 m-notification_explanation">
                       We only have data available through {{ thru_month_formatted }}.
                       Please select a valid date.

--- a/cfgov/unprocessed/js/molecules/Notification.js
+++ b/cfgov/unprocessed/js/molecules/Notification.js
@@ -1,6 +1,21 @@
 // Required modules.
 const atomicHelpers = require( '../modules/util/atomic-helpers' );
 const standardType = require( '../modules/util/standard-type' );
+const SUCCESS_ICON = require(
+  'svg-inline-loader!../../../../node_modules/cf-icons/src/icons/check-round.svg'
+);
+const WARNING_ICON = require(
+  'svg-inline-loader!../../../../node_modules/cf-icons/src/icons/warning-round.svg'
+);
+const ERROR_ICON = require(
+  'svg-inline-loader!../../../../node_modules/cf-icons/src/icons/error-round.svg'
+);
+
+const ICON = {
+  success: SUCCESS_ICON,
+  warning: WARNING_ICON,
+  error:   ERROR_ICON
+};
 
 /**
  * Notification
@@ -12,11 +27,14 @@ const standardType = require( '../modules/util/standard-type' );
  *   The DOM element within which to search for the molecule.
  * @returns {Notification} An instance.
  */
-function Notification( element ) { // eslint-disable-line max-statements, inline-comments, max-len
+function Notification( element ) {
 
   const BASE_CLASS = 'm-notification';
 
-  // Constants for the state of this Notification.
+  /**
+   * Constants for the state of this Notification.
+   * If these change, the keys in the ICON object above must be updated to match
+   */
   const SUCCESS = 'success';
   const WARNING = 'warning';
   const ERROR = 'error';
@@ -103,10 +121,16 @@ function Notification( element ) { // eslint-disable-line max-statements, inline
          type === ERROR ) {
       classList.add( BASE_CLASS + '__' + type );
       _currentType = type;
+
+      // Replace <svg> element with contents of type_ICON
+      const currentIcon = _dom.querySelector( '.cf-icon-svg' );
+      const newIcon = document.createRange().createContextualFragment(
+        ICON[type]
+      );
+      _dom.replaceChild( newIcon, currentIcon );
     } else {
       throw new Error( type + ' is not a supported notification type!' );
     }
-
     return this;
   }
 

--- a/cfgov/wellbeing/jinja2/wellbeing/home.html
+++ b/cfgov/wellbeing/jinja2/wellbeing/home.html
@@ -81,7 +81,7 @@
                 m-notification__visible
                 m-notification__warning
                 m-notification__subtle">
-        <span class="m-notification_icon cf-icon"></span>
+        {{ svg_icon('warning-round') }}
         <div class="m-notification_content">
             <p class="h4 m-notification_message">
                 We never collect or store the answers you provide.

--- a/cfgov/wellbeing/jinja2/wellbeing/results.html
+++ b/cfgov/wellbeing/jinja2/wellbeing/results.html
@@ -236,7 +236,7 @@
                 m-notification__visible
                 m-notification__warning
                 u-mb15">
-        <span class="m-notification_icon cf-icon"></span>
+        {{ svg_icon('warning-round') }}
         <div class="m-notification_content">
             <div class="h4 m-notification_message">
                 We never collect or store answers to the financial well-being questionnaire.
@@ -522,7 +522,7 @@
                     m-notification__visible
                     m-notification__warning
                     u-mb15">
-            <span class="m-notification_icon cf-icon"></span>
+            {{ svg_icon('warning-round') }}
             <div class="m-notification_content">
                 <div class="h4 m-notification_message">
                     We never collect or store answers to the financial well-being questionnaire.

--- a/test/unit_tests/js/modules/util/add-email-popup-spec.js
+++ b/test/unit_tests/js/modules/util/add-email-popup-spec.js
@@ -6,7 +6,7 @@ const HTML_SNIPPET = `
 <div class="o-email-popup o-email-popup__visible" lang="en" data-popup-label="testPopup">
     <div class="o-email-popup_header">
         <div class="close">
-            <a>Close <span class="cf-icon cf-icon-delete-round"></span></a>
+            <a>Close</a>
         </div>
     </div>
     <div class="o-email-popup_body">
@@ -32,11 +32,8 @@ const HTML_SNIPPET = `
                 <div class="m-notification
                             m-notification__success
                             ">
-                    <span class="m-notification_icon
-                                 cf-icon"></span>
                     <div class="m-notification_content">
                         <div class="h4 m-notification_message"></div>
-
                     </div>
                 </div>
             </div>

--- a/test/unit_tests/js/organisms/EmailPopup-spec.js
+++ b/test/unit_tests/js/organisms/EmailPopup-spec.js
@@ -8,7 +8,7 @@ const HTML_SNIPPET = `
 <div class="o-email-popup" lang="en" data-popup-label="testPopup">
     <div class="o-email-popup_header">
         <div class="close">
-            <a>Close <span class="cf-icon cf-icon-delete-round"></span></a>
+            <a>Close</a>
         </div>
     </div>
     <div class="o-email-popup_body">
@@ -34,11 +34,8 @@ const HTML_SNIPPET = `
                 <div class="m-notification
                             m-notification__success
                             ">
-                    <span class="m-notification_icon
-                                 cf-icon"></span>
                     <div class="m-notification_content">
                         <div class="h4 m-notification_message"></div>
-
                     </div>
                 </div>
             </div>

--- a/test/unit_tests/js/organisms/FormSubmit-spec.js
+++ b/test/unit_tests/js/organisms/FormSubmit-spec.js
@@ -18,8 +18,6 @@ const HTML_SNIPPET = `
       <div class="u-mb15">
         <div class="m-notification
                     m-notification__success">
-          <span class="m-notification_icon
-                       cf-icon"></span>
           <div class="m-notification_content">
             <div class="h4 m-notification_message"></div>
           </div>


### PR DESCRIPTION
Update all found existences of notification icons to use SVG icons.

Co-authored-by: Scott Cranfill scott.cranfill@cfpb.gov

## Changes

- Updated any files currently using category icons to use their SVG equivalent.

## Testing

1. `npm install`
1. `gulp clean && gulp build`
1. Check out notification icons under the filter at `http://localhost:8000/about-us/blog/` after using the filter.
1. Check out notification icons when entering a bad email in the signup at `http://localhost:8000/about-us/blog/` (I use `test@test` to avoid default browser notifications).
1. Check out the notification at `http://localhost:8000/consumer-tools/financial-well-being/`
1. Check out the notifications at `http://localhost:8000/consumer-tools/financial-well-being/results/`
1. Run `gulp test:unit` (this is currently failing, need a hand fixing this.


## Notes

- This is just one part of the SVG Icon update. It's a lot easier to call these out individually than in the main PR.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [x] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [x] Chrome
- [x] Firefox
- [x] Safari
- [x] Internet Explorer 8, 9, 10, and 11
- [x] Edge
- [x] iOS Safari
- [ ] Chrome for Android

### Accessibility

- [x] Keyboard friendly
- [x] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [x] Is useable without JS
- [x] Flexible from small to large screens
- [x] No linting errors or warnings
- [x] JavaScript tests are passing
