### PR TITLE
Fix 'ssl' mode in standalone runserver.sh

### DIFF
--- a/runserver.sh
+++ b/runserver.sh
@@ -10,6 +10,8 @@
 set -e
 
 standalone() {
+  local DJANGO_HTTP_PORT=${DJANGO_HTTP_PORT:-8000}
+
   if [ "$1" == "ssl" ]; then
     echo -e '\033[0;32mStarting SSL Django server on port' $DJANGO_HTTP_PORT '...'
     tput sgr0

--- a/runserver.sh
+++ b/runserver.sh
@@ -11,10 +11,12 @@ set -e
 
 standalone() {
   if [ "$1" == "ssl" ]; then
-    echo '\033[0;32mStarting SSL Django server on port' $DJANGO_HTTP_PORT '...'
+    echo -e '\033[0;32mStarting SSL Django server on port' $DJANGO_HTTP_PORT '...'
+    tput sgr0
     python cfgov/manage.py runsslserver $DJANGO_HTTP_PORT
   else
-    echo '\033[0;32mStarting the Django server on port' $DJANGO_HTTP_PORT '...'
+    echo -e '\033[0;32mStarting the Django server on port' $DJANGO_HTTP_PORT '...'
+    tput sgr0
     python cfgov/manage.py runserver $DJANGO_HTTP_PORT
   fi
 }

--- a/runserver.sh
+++ b/runserver.sh
@@ -28,5 +28,5 @@ dockerized() {
 if [ "$1" == "docker" ]; then
   dockerized
 else
-  standalone
+  standalone "$1"
 fi


### PR DESCRIPTION
The args were not being passed, so you could not run your `runserver.sh` in ssl mode. I'm guessing this might have broken when Docker support was added.

(Could not help attempting to fix the ANSI escape code output for the 'Starting ... ' line while I was in there, though if that was not broken for anyone else, let me know and I can remove that commit; I was seeing the code itself, not the color, without `-e`.)