### PR TITLE
Properly indent regulation appendices paragraphs

### DIFF
--- a/cfgov/regulations3k/regdown.py
+++ b/cfgov/regulations3k/regdown.py
@@ -131,6 +131,10 @@ class LabeledParagraphProcessor(ParagraphProcessor):
             # e.g. 6-a-Interp-1 becomes -1 and gets a `level-1` class
             # e.g. 12-b-Interp-2-i becomes -2-i and gets a `level-2` class
             label = re.sub('^\w+\-\w+\-interp', '', label, flags=re.IGNORECASE)
+            # Appendices also have special prefixes that need to be stripped.
+            # e.g. A-1-a becomes a and gets a `level-0` class
+            # e.g. A-2-d-1 becomes d-1 and gets a `level-1` class
+            label = re.sub('^[A-Z]\d?\-\w+\-?', '', label)
             level = label.count('-')
             class_name = 'level-{}'.format(level)
             p.set('class', class_name)

--- a/cfgov/regulations3k/tests/test_regdown.py
+++ b/cfgov/regulations3k/tests/test_regdown.py
@@ -74,6 +74,66 @@ class RegulationsExtensionTestCase(unittest.TestCase):
             'This is a paragraph with a label.</p>'
         )
 
+    def test_appendix_label(self):
+        text = '{A-2-d}\nThis is a paragraph with a label.'
+        text2 = '{A-2-d-1}\nThis is another paragraph with a label.'
+        text3 = '{A-2-d-1-v}\nThis is yet another paragraph with a label.'
+        self.assertEqual(
+            regdown(text),
+            '<p class="level-0" id="A-2-d">'
+            'This is a paragraph with a label.</p>'
+        )
+        self.assertEqual(
+            regdown(text2),
+            '<p class="level-1" id="A-2-d-1">'
+            'This is another paragraph with a label.</p>'
+        )
+        self.assertEqual(
+            regdown(text3),
+            '<p class="level-2" id="A-2-d-1-v">'
+            'This is yet another paragraph with a label.</p>'
+        )
+
+    def test_multi_part_appendix_label(self):
+        text = '{M1-1-a}\nThis is a paragraph with a label.'
+        text2 = '{M1-1-a-1}\nThis is another paragraph with a label.'
+        text3 = '{M1-1-a-1-i}\nThis is yet another paragraph with a label.'
+        self.assertEqual(
+            regdown(text),
+            '<p class="level-0" id="M1-1-a">'
+            'This is a paragraph with a label.</p>'
+        )
+        self.assertEqual(
+            regdown(text2),
+            '<p class="level-1" id="M1-1-a-1">'
+            'This is another paragraph with a label.</p>'
+        )
+        self.assertEqual(
+            regdown(text3),
+            '<p class="level-2" id="M1-1-a-1-i">'
+            'This is yet another paragraph with a label.</p>'
+        )
+
+    def test_complex_appendix_label(self):
+        text = '{B-h2-p2}\nThis is a paragraph with a label.'
+        text2 = '{B-h2-p2-1}\nThis is another paragraph with a label.'
+        text3 = '{B-h2-p2-1-i}\nThis is yet another paragraph with a label.'
+        self.assertEqual(
+            regdown(text),
+            '<p class="level-0" id="B-h2-p2">'
+            'This is a paragraph with a label.</p>'
+        )
+        self.assertEqual(
+            regdown(text2),
+            '<p class="level-1" id="B-h2-p2-1">'
+            'This is another paragraph with a label.</p>'
+        )
+        self.assertEqual(
+            regdown(text3),
+            '<p class="level-2" id="B-h2-p2-1-i">'
+            'This is yet another paragraph with a label.</p>'
+        )
+
     def test_list_state(self):
         text = '- {my-label} This is a paragraph in a list.'
         self.assertEqual(


### PR DESCRIPTION
Very similar to #4105 but with regulation appendices. As [noted](https://GHE/eregs/regulations-3000/issues/42#issuecomment-159459) by @niqjohnson, appendices have confusing paragraph markers in the current implementation of eRegs. This PR accommodates the current structure of the appendix markers but once we start user testing we should reevaluate them.

## Changes

- Have indenter ignore appendix prefixes

## Testing

1. `tox -e fast regulations3k.tests.test_regdown`
1. Load a reg section page and see if the expandable inline interps no longer have wonky margins.