### PR TITLE
Fix erroneously removed test

### DIFF
--- a/test/browser_tests/cucumber/step_definitions/global-search.js
+++ b/test/browser_tests/cucumber/step_definitions/global-search.js
@@ -7,7 +7,7 @@ const { isShould } = require( '../../util/index.js' );
 const BASE_SEL = '.m-global-search';
 const TRIGGER_SEL = BASE_SEL + ' [data-js-hook="behavior_flyout-menu_trigger"]';
 const CONTENT_SEL = BASE_SEL + ' [data-js-hook="behavior_flyout-menu_content"]';
-const INPUT_SEL = BASE_SEL + ' input#query';
+const INPUT_SEL = BASE_SEL + ' input#m-global-search_query';
 const SEARCH_SEL = BASE_SEL +
   ' [data-js-hook="behavior_flyout-menu_content"] .a-btn';
 const SUGGEST_SEL = BASE_SEL + ' .m-global-search_content-suggestions';

--- a/test/browser_tests/cucumber/step_definitions/global-search.js
+++ b/test/browser_tests/cucumber/step_definitions/global-search.js
@@ -10,7 +10,6 @@ const CONTENT_SEL = BASE_SEL + ' [data-js-hook="behavior_flyout-menu_content"]';
 const INPUT_SEL = BASE_SEL + ' input#query';
 const SEARCH_SEL = BASE_SEL +
   ' [data-js-hook="behavior_flyout-menu_content"] .a-btn';
-const CLEAR_SEL = BASE_SEL + ' .input-contains-label_after';
 const SUGGEST_SEL = BASE_SEL + ' .m-global-search_content-suggestions';
 const EC = protractor.ExpectedConditions;
 
@@ -26,7 +25,6 @@ Before( function() {
     content:   element( by.css( CONTENT_SEL ) ),
     input:     element( by.css( INPUT_SEL ) ),
     searchBtn: element( by.css( SEARCH_SEL ) ),
-    clearBtn:  element( by.css( CLEAR_SEL ) ),
     suggest:   element( by.css( SUGGEST_SEL ) )
   };
 } );
@@ -72,15 +70,6 @@ When( 'I perform tab actions on the search molecule',
   }
 );
 
-Then( /it (should|shouldn't) have a clear button label/,
-  function( haveLabel ) {
-
-    return expect( _dom.clearBtn.isDisplayed() )
-      .to.eventually
-      .equal( isShould( haveLabel ) );
-  }
-);
-
 Then( 'it should focus the search input field',
   async function() {
     const attributeId = await browser
@@ -111,6 +100,16 @@ Then( /the search molecule (should|shouldn't) have a search trigger/,
     return expect( _dom.trigger.isDisplayed() )
       .to.eventually
       .equal( isShould( haveTrigger ) );
+  }
+);
+
+Then( /it (should|shouldn't) have search input content/,
+  async function( haveInput ) {
+    await browser.sleep( 300 );
+
+    return expect( _dom.content.isDisplayed() )
+      .to.eventually
+      .equal( isShould( haveInput ) );
   }
 );
 


### PR DESCRIPTION
The wrong test was removed in https://github.com/cfpb/cfgov-refresh/pull/4125 😱 
This fixes things.

## Additions

- Add erroneously removed global search acceptance test back.

## Removals

- Removes global search clear button acceptance test and associated variables.

## Testing

1. `gulp test:acceptance --headless` should pass.
