### PR TITLE
Fix for SVG not having children in IE11

### DIFF
--- a/cfgov/unprocessed/js/organisms/MegaMenu.js
+++ b/cfgov/unprocessed/js/organisms/MegaMenu.js
@@ -108,6 +108,9 @@ function MegaMenu( element ) {
    */
   function _populateTreeFromDom( dom, parentNode, callback ) {
     const children = dom.children;
+    if ( !children ) {
+      return;
+    }
     let child;
     for ( let i = 0, len = children.length; i < len; i++ ) {
       let newParentNode = parentNode;


### PR DESCRIPTION
https://github.com/cfpb/cfgov-refresh/pull/4154 adds SVG nodes in the mega menu. SVG nodes return `undefined` in IE11, so this loop fails in IE11 https://github.com/cfpb/cfgov-refresh/blob/master/cfgov/unprocessed/js/organisms/MegaMenu.js#L112. This PR adds a check for whether the node it's processing has children.

## Additions

- Fix issue in IE11 SVG icons in menu by adding a check when first traversing the menu dom to skip dom nodes that don't have children.

## Testing

1. Visit the homepage in IE11 in the master branch. Note the mega menu is broken and covers the page's content.
2. Pull down this branch.
3. Visit the homepage in IE11 and note the mega menu is not broken.
4. Check that menu is navigable. Resize to tablet and mobile size and see that menu is still navigable.

## Screenshots

Without fix:
![screen shot 2018-05-17 at 10 01 15 pm](https://user-images.githubusercontent.com/704760/40212443-d9f4a1e2-5a1d-11e8-8d35-172cae3cc584.png)
