### PR TITLE
Fix fo Travis race condition in unit test 

### DIFF
--- a/test/unit_tests/apps/financial-well-being/js/fwb-results-spec.js
+++ b/test/unit_tests/apps/financial-well-being/js/fwb-results-spec.js
@@ -120,17 +120,16 @@ describe( 'fwb-results', () => {
     );
     expandableContent = document.querySelector( '.o-expandable_content' );
     expandableTarget = document.querySelector( '.o-expandable_target' );
+    initFwbResults();
   } );
 
   it( 'initialize the expandables on page load', () => {
-    initFwbResults();
     expect( expandableTarget.getAttribute( 'aria-pressed' ) ).toBe( 'false' );
     expect( expandableContent.getAttribute( 'aria-expanded' ) ).toBe( 'false' );
   } );
 
   it( 'should submit the correct analytics when a toggle button is clicked',
     () => {
-      initFwbResults();
       simulateEvent( 'click', toggleButtons[0] );
 
       expect( window.dataLayer[0] ).toEqual( dataLayerEvent );
@@ -138,7 +137,6 @@ describe( 'fwb-results', () => {
   );
 
   it( 'should show the initial category on page load', () => {
-    initFwbResults();
     expect( toggleButtons[0].classList.contains( SELECTED_CLASS ) )
       .toBe( true );
     expect( dataPoint[0].classList.contains( HIDDEN_CLASS ) ).toBe( false );
@@ -146,7 +144,6 @@ describe( 'fwb-results', () => {
   } );
 
   it( 'should hide the other categories on page load', () => {
-    initFwbResults();
     expect( toggleButtons[1].classList.contains( SELECTED_CLASS ) )
       .toBe( false );
     expect( dataPoint[4].classList.contains( HIDDEN_CLASS ) ).toBe( true );
@@ -155,7 +152,6 @@ describe( 'fwb-results', () => {
 
   it( 'should hide the initial category content ' +
        'when a differnt toggle is clicked', () => {
-    initFwbResults();
     simulateEvent( 'click', toggleButtons[1] );
     expect( toggleButtons[0].classList.contains( SELECTED_CLASS ) )
       .toBe( false );
@@ -165,7 +161,6 @@ describe( 'fwb-results', () => {
 
   it( 'should show the correct category content ' +
        'when the toggle is clicked', () => {
-    initFwbResults();
     simulateEvent( 'click', toggleButtons[1] );
     expect( toggleButtons[1].classList.contains( SELECTED_CLASS ) )
       .toBe( true );


### PR DESCRIPTION
Fix fo Travis race condition in unit test

## Changes

- Modified spec to move require statement to beforeEach method. It might require forcing Jest to wait until the module resolution has completed. 

## Testing

1. Run `gulp test:unit`.

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Internet Explorer 8, 9, 10, and 11
- [ ] Edge
- [ ] iOS Safari
- [ ] Chrome for Android

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
