### PR TITLE
Minor rate checker cleanup

### DIFF
--- a/cfgov/unprocessed/apps/owning-a-home/css/explore-rates.less
+++ b/cfgov/unprocessed/apps/owning-a-home/css/explore-rates.less
@@ -485,7 +485,7 @@
                      unit( 5px / @base-font-size-px, em )
                      unit( 15px / @base-font-size-px, em );
             border: none;
-            background-color: inherit;
+            background-color: @white;
             color: @pacific;
             font-weight: 500;
             outline: none;

--- a/cfgov/unprocessed/apps/owning-a-home/js/explore-rates/data-loader.js
+++ b/cfgov/unprocessed/apps/owning-a-home/js/explore-rates/data-loader.js
@@ -1,6 +1,11 @@
 import config from '../../config.json';
 
-const axios = require( 'axios' );
+// Auto-polyfill Promise for IE10 and IE11.
+import es6Promise from 'es6-promise';
+es6Promise.polyfill();
+
+import axios from 'axios';
+
 const CancelToken = axios.CancelToken;
 
 let _cancelToken;

--- a/cfgov/unprocessed/apps/owning-a-home/js/explore-rates/index.js
+++ b/cfgov/unprocessed/apps/owning-a-home/js/explore-rates/index.js
@@ -1,6 +1,3 @@
-// Auto-polyfill Promise for IE11.
-require( 'es6-promise' ).polyfill();
-
 import * as rateChecker from './rate-checker';
 
 // Do it!


### PR DESCRIPTION
Minor rate checker cleanup

## Changes

- Modified code to move the promise polyfill to be included only when axios is required. Provided a background color for ie10. 

## Testing

1. Visit `http://localhost:8000/owning-a-home/explore-rates/` on ie10 and ie11.
2. Verify the rate checker works as expected.

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Internet Explorer 8, 9, 10, and 11
- [ ] Edge
- [ ] iOS Safari
- [ ] Chrome for Android

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
