### PR TITLE
README and docs fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,47 +20,48 @@ are available in [our documentation](https://cfpb.github.io/cfgov-refresh).
 
 This project requires Python 2.7, Node 8, and Gulp 4. We recommend the use of [virtualenv](https://virtualenv.pypa.io/en/stable/) and [virtualenvwrapper](https://virtualenvwrapper.readthedocs.io/en/latest/).
 
-Check out the repository:
+Clone the repository:
 
 ```sh
-$ git clone git@github.com:cfpb/cfgov-refresh.git
+git clone git@github.com:cfpb/cfgov-refresh.git
 ```
 
 Create a virtual environment for Python dependencies:
 
 ```sh
-$ cd cfgov-refresh
-$ mkvirtualenv --python=python2.7 cfgov-refresh
+cd cfgov-refresh
+mkvirtualenv --python=python2.7 cfgov-refresh
 ```
 
 Create and load initial environment settings:
 
 ```
-(cfgov-refresh) $ cp .env_SAMPLE .env
-(cfgov-refresh) $ source .env
+cp -a .env_SAMPLE .env
+source .env
 ```
 
 Install third-party dependencies and build frontend assets:
 
 ```sh
-(cfgov-refresh) $ ./setup.sh
+./setup.sh
 ```
 
 Create a local SQLite database and add some basic pages:
 
 ```sh
-(cfgov-refresh) $ ./initial-data.sh
+./initial-data.sh
 ```
 
 Start your local Django server:
 
 ```sh
-(cfgov-refresh) $ ./runserver.sh
+./runserver.sh
 ```
 
-Your site will be available locally at [http://localhost:8000](http://localhost:8000).
+Your site will be available locally at <http://localhost:8000>.
 
-The site admin will be available at [http://localhost:8000/admin/](http://localhost:8000/admin/), using login `admin` / `admin`.
+The site admin will be available at <http://localhost:8000/admin/>, using login `admin` /
+`admin`.
 
 
 ## Documentation
@@ -72,8 +73,8 @@ If you would like to browse the documentation locally, you can do so
 with [`mkdocs`](http://www.mkdocs.org/):
 
 ```sh
-(cfgov-refresh) $ pip install -r requirements/manual.txt
-(cfgov-refresh) $ mkdocs serve
+pip install -r requirements/manual.txt
+mkdocs serve
 ```
 
 Documentation will be available locally at [http://localhost:8000](http://localhost:8000).

--- a/docs/django-to-wagtail.md
+++ b/docs/django-to-wagtail.md
@@ -1,12 +1,12 @@
 # Wagtail pages vs. Django views
 
-Rather than using “classic” Django views added to urls.py, when feasible an app should provide singleton Wagtail Page. This will allow site editors to drop that page anywhere in the site’s URL structure that they wish. A Wagtail Page subclass can do anything a Django view can [when overriding the serve method](http://docs.wagtail.io/en/v2.0.1/topics/pages.html#more-control-over-page-rendering).
+Rather than using “classic” Django views added to urls.py, when feasible an app should provide a singleton Wagtail Page. This will allow site editors to drop that page anywhere in the site’s URL structure that they wish. A Wagtail Page subclass can do anything a Django view can [when overriding the serve method](http://docs.wagtail.io/en/v2.0.1/topics/pages.html#more-control-over-page-rendering).
 
 ```python
 from django.http import HttpResponse
-from wagtail.wagtailcore.models import Page,
+from wagtail.wagtailcore.models import Page
 
-class HelloWorldPage(CFGOVPage):
+class HelloWorldPage(Page):
     def serve(self, request):
         return HttpResponse("Hello World")
 ```


### PR DESCRIPTION
.@Scotchester expressed a preference (one I endorse) the other day for not including a simulated prompt (`$`) when capturing shell commands in docs. The `$`s make copying-and-pasting these commands more difficult than necessary – you can't triple-click to get the whole line.

Also adding a couple typo fixes in one of the docs pages while I'm here.