### PR TITLE
Removing css overrides from non responsive templates

### DIFF
--- a/cfgov/legacy/templates/fair-lending/index.html
+++ b/cfgov/legacy/templates/fair-lending/index.html
@@ -8,11 +8,6 @@
 <li>WHAT PROTECTIONS DO I HAVE AGAINST CREDIT DISCRIMINATION?</li>
 {% endblock %}
 
-{% block page_header_footer_css %}
-<link rel="stylesheet" href="{% static 'nemo/_/c/v1-nonresponsive-header.css' %}"/>
-<link rel="stylesheet" href="{% static 'nemo/_/c/v1-nonresponsive-footer.css' %}"/>
-{% endblock %}
-
 {% block content %}
 {% include "front/share_block.html" %}
 <article class="page">

--- a/cfgov/legacy/templates/students/helping-borrowers-find-ways-to-stay-afloat/index.html
+++ b/cfgov/legacy/templates/students/helping-borrowers-find-ways-to-stay-afloat/index.html
@@ -11,11 +11,6 @@
 <li>HELPING BORROWERS FIND WAYS TO STAY AFLOAT</li>
 {% endblock %}
 
-{% block page_header_footer_css %}
-<link rel="stylesheet" href="{% static 'nemo/_/c/v1-nonresponsive-header.css' %}"/>
-<link rel="stylesheet" href="{% static 'nemo/_/c/v1-nonresponsive-footer.css' %}"/>
-{% endblock %}
-
 {% block content %}
 {% include "front/share_block.html" %}
 <article class="page">

--- a/cfgov/legacy/templates/students/index.html
+++ b/cfgov/legacy/templates/students/index.html
@@ -8,11 +8,6 @@
 <li>STUDENTS AND YOUNG CONSUMERS</li>
 {% endblock %}
 
-{% block page_header_footer_css %}
-<link rel="stylesheet" href="{% static 'nemo/_/c/v1-nonresponsive-header.css' %}"/>
-<link rel="stylesheet" href="{% static 'nemo/_/c/v1-nonresponsive-footer.css' %}"/>
-{% endblock %}
-
 {% block content %}
 {% include "front/share_block.html" %}
 <article class="page">

--- a/cfgov/legacy/templates/students/knowbeforeyouowe/index.html
+++ b/cfgov/legacy/templates/students/knowbeforeyouowe/index.html
@@ -11,11 +11,6 @@
 <li>KNOW BEFORE YOU OWE: STUDENT LOANS PROJECT</li>
 {% endblock %}
 
-{% block page_header_footer_css %}
-<link rel="stylesheet" href="{% static 'nemo/_/c/v1-nonresponsive-header.css' %}"/>
-<link rel="stylesheet" href="{% static 'nemo/_/c/v1-nonresponsive-footer.css' %}"/>
-{% endblock %}
-
 {% block content %}
 {% include "front/share_block.html" %}
 <article class="page">


### PR DESCRIPTION
Removing css overrides from non responsive templates


## Testing

1. Visit http://localhost:8000/practitioner-resources/students/ and verify the menu isn't huge.
2. Visit http://localhost:8000/fair-lending/ and verify the menu isn't ginormous.

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Internet Explorer 8, 9, 10, and 11
- [ ] Edge
- [ ] iOS Safari
- [ ] Chrome for Android

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
