### PR TITLE
Removing sheer from urls.py

### DIFF
--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -629,12 +629,6 @@ FLAGS = {
     # To be enabled when mortgage-performance data visualizations go live
     'MORTGAGE_PERFORMANCE_RELEASE': {},
 
-    # To be enabled when owning-a-home/explore-rates is de-sheered.
-    'OAH_EXPLORE_RATES': {},
-
-    # To be enabled when journey pages are released in Wagtail.
-    'OAH_JOURNEY': {},
-
     # Google Optimize code snippets for A/B testing
     # When enabled this flag will add various Google Optimize code snippets.
     # Intended for use with path conditions.

--- a/cfgov/cfgov/urls.py
+++ b/cfgov/cfgov/urls.py
@@ -26,8 +26,6 @@ from legacy.views import token_provider
 from legacy.views.housing_counselor import (
     HousingCounselorPDFView, HousingCounselorView
 )
-from sheerlike.sites import SheerSite
-from sheerlike.views.generic import SheerTemplateView
 from transition_utilities.conditional_urls import include_if_app_enabled
 from v1.auth_forms import CFGOVPasswordChangeForm
 from v1.views import (
@@ -35,10 +33,6 @@ from v1.views import (
     password_reset_confirm, welcome
 )
 from v1.views.documents import DocumentServeView
-
-
-oah = SheerSite('owning-a-home')
-
 
 def flagged_wagtail_template_view(flag_name, template_name):
     """View that serves Wagtail if a flag is set, and a template if not.
@@ -74,15 +68,9 @@ urlpatterns = [
             name='closing-disclosure'
     ),
     url(r'^owning-a-home/explore-rates/',
-        FlaggedTemplateView.as_view(
-            flag_name='OAH_EXPLORE_RATES',
-            template_name='owning-a-home/explore-rates/index.html',
-            fallback=SheerTemplateView.as_view(
-                template_engine='owning-a-home',
-                template_name='explore-rates/index.html'
-            )
-        ),
-        name='explore-rates'
+        TemplateView.as_view(
+            template_name='owning-a-home/explore-rates/index.html'),
+            name='explore-rates'
     ),
     url(r'^owning-a-home/loan-estimate/$',
         TemplateView.as_view(
@@ -92,14 +80,10 @@ urlpatterns = [
 
     # Temporarily serve Wagtail OAH journey pages at `/process/` urls.
     # TODO: change to redirects after 2018 homebuying campaign.
-    flagged_url('OAH_JOURNEY', r'^owning-a-home/process/(?P<path>.*)$',
+    url(r'^owning-a-home/process/(?P<path>.*)$',
         lambda req, path: ServeView.as_view()(
             req, 'owning-a-home/{}'.format(path or 'prepare/')
         ),
-        fallback=lambda req, path: SheerTemplateView.as_view(
-            template_engine='owning-a-home',
-            template_name='process/{}/index.html'.format(path or 'prepare')
-        )(req)
     ),
     # END TODO
 
@@ -203,12 +187,6 @@ urlpatterns = [
             name='server_error')],
         namespace='reg_comment')),
 
-    # Testing reg comment form
-    url(r'^reg-comment-form-test/$',
-        SheerTemplateView.as_view(
-            template_name='regulation-comment/reg-comment-form-test.html'),
-        name='reg-comment-form-test'),
-
     url(r'^feed/$',
         RedirectView.as_view(url='/about-us/blog/feed/', permanent=True)),
     url(r'^feed/blog/$',
@@ -223,7 +201,7 @@ urlpatterns = [
 
     url(r'^transcripts/', include([
         url(r'^how-to-apply-for-a-federal-job-with-the-cfpb/$',
-            SheerTemplateView.as_view(
+            TemplateView.as_view(
                 template_name='transcripts/how-to-apply-for-a-federal-job-with-the-cfpb/index.html'),  # noqa: E501
                 name='how-to-apply-for-a-federal-job-with-the-cfpb'), ],
         namespace='transcripts')),

--- a/cfgov/cfgov/urls.py
+++ b/cfgov/cfgov/urls.py
@@ -34,6 +34,7 @@ from v1.views import (
 )
 from v1.views.documents import DocumentServeView
 
+
 def flagged_wagtail_template_view(flag_name, template_name):
     """View that serves Wagtail if a flag is set, and a template if not.
 


### PR DESCRIPTION
Removing sheer from urls.py

## Removals

- Removed test eregs form code, which wasn't being used. OK'ed with @Scotchester.

## Changes

- Modified `urls.py` to remove Sheer references and flagged routes. 

## Testing

1. Visit `localhost:8000/owning-a-home/explore-rates/` and ensure it renders.
2. Visit `localhost:8000/transcripts/how-to-apply-for-a-federal-job-with-the-cfpb/` and ensure it renders.
3. Visit `localhost:8000/owning-a-home/process/` and ensure it renders.

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Internet Explorer 8, 9, 10, and 11
- [ ] Edge
- [ ] iOS Safari
- [ ] Chrome for Android

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
