### PR TITLE
Change navigation landmark label

### DIFF
--- a/cfgov/jinja2/v1/_includes/organisms/mega-menu.html
+++ b/cfgov/jinja2/v1/_includes/organisms/mega-menu.html
@@ -185,8 +185,7 @@
 <nav class="{{ base_class }}
             u-hide-on-mobile"
      data-js-hook="behavior_flyout-menu"
-     aria-label="main menu"
-     role="navigation">
+     aria-label="main menu">
     <button class="{{ base_class ~ '_trigger' }}"
             data-js-hook="behavior_flyout-menu_trigger"
             aria-pressed="false">

--- a/cfgov/jinja2/v1/_includes/organisms/mega-menu.html
+++ b/cfgov/jinja2/v1/_includes/organisms/mega-menu.html
@@ -185,7 +185,7 @@
 <nav class="{{ base_class }}
             u-hide-on-mobile"
      data-js-hook="behavior_flyout-menu"
-     aria-label="main navigation"
+     aria-label="main menu"
      role="navigation">
     <button class="{{ base_class ~ '_trigger' }}"
             data-js-hook="behavior_flyout-menu_trigger"


### PR DESCRIPTION
## Changes

- Change mega menu aria-label to `main menu` from `main navigation`.
- Remove `role="navigation", which is covered by the HTML5 `nav` tag.

## Testing

1. Press Cmd+F5 to activate VoiceOver
1. Press Ctrl+Opt+U to activate rotor mode
1. Press the right arrow until you reach the Landmarks menu
1. Press the down arrow to cycle through and hear "main menu navigation"

## Notes

- We could remove the `aria-label` completely ([it's optional](https://www.w3.org/TR/2017/NOTE-wai-aria-practices-1.1-20171214/examples/landmarks/navigation.html)), however, if we had another `role="navigation"` on the page we'd want to have a label, so safer to include it.