### PR TITLE
Adds underlines to mega menu footer links

### DIFF
--- a/cfgov/jinja2/v1/_includes/organisms/_vars-mega-menu.html
+++ b/cfgov/jinja2/v1/_includes/organisms/_vars-mega-menu.html
@@ -122,8 +122,8 @@
     'text': 'Consumer Tools',
     'url': '#',
     'footer': [
-        'Browse answers to hundreds of financial questions. <a href="/ask-cfpb/" class="o-mega-menu_content-link">Ask CFPB</a>',
-        'Have an issue with a financial product? <a href="/complaint/" class="o-mega-menu_content-link">Submit a complaint</a>',
+        'Browse answers to hundreds of financial questions. <a href="/ask-cfpb/">Ask CFPB</a>',
+        'Have an issue with a financial product? <a href="/complaint/">Submit a complaint</a>',
     ],
     'nav_groups': [
         consumer_tools_group_one,
@@ -179,7 +179,7 @@
     'text': 'Practitioner Resources',
     'url': '#',
     'footer': [
-        '<a href="https://pueblo.gpo.gov/CFPBPubs/CFPBPubs.php" class="o-mega-menu_content-link">Order free brochures</a>',
+        '<a href="https://pueblo.gpo.gov/CFPBPubs/CFPBPubs.php">Order free brochures</a>',
     ],
     'nav_groups': [
         practitioner_resources_group_one,

--- a/cfgov/unprocessed/css/organisms/mega-menu.less
+++ b/cfgov/unprocessed/css/organisms/mega-menu.less
@@ -218,6 +218,11 @@ body {
     &_footer {
         border-top: 1px solid @gray-40;
         padding: @grid_gutter-width / 2 0;
+
+        a {
+            // Override "nav a" style in Capital Framework cf-core.
+            border-bottom-width: 1px;
+        }
     }
 
 


### PR DESCRIPTION
Adds underlines requested in [GHE]/CFGOV/platform/issues/2747

## Changes

- Adds underlines to links in mega menu footer.

## Testing

1. Pull branch down.
2. `gulp clean && gulp build`
3. Check `Consumer Tools` and `Practitioner Resources` in desktop and mobile sizes and verify they have dotted underlines.

## Screenshots

![screen shot 2018-05-22 at 3 43 42 pm](https://user-images.githubusercontent.com/704760/40386336-7511b860-5dd7-11e8-8fe9-b67d48a05f7b.png)
![screen shot 2018-05-22 at 3 44 38 pm](https://user-images.githubusercontent.com/704760/40386337-75240272-5dd7-11e8-8194-ea6d639bde7d.png)
![screen shot 2018-05-22 at 3 44 22 pm](https://user-images.githubusercontent.com/704760/40386341-76d58640-5dd7-11e8-81d8-8c44e07315a9.png)
![screen shot 2018-05-22 at 3 44 10 pm](https://user-images.githubusercontent.com/704760/40386340-76bd229e-5dd7-11e8-93bc-30ddc14f14f2.png)

