### PR TITLE
Fix heading markup in mega menu

### DIFF
--- a/cfgov/jinja2/v1/_includes/organisms/mega-menu.html
+++ b/cfgov/jinja2/v1/_includes/organisms/mega-menu.html
@@ -46,12 +46,12 @@
 {%- for group in nav_groups %}
 <div class="{{ _classes( nav_depth, '-list' ) }}">
     {% if group.title %}
-    <h3 class="h5
+    <div class="h5
               {{ base_class ~ '_group-heading' }}
               {{ base_class ~ '_group-heading' ~ '__hidden' if group.hide_title else ''}} "
         {% if group.hide_title %} aria-hidden="true"{% endif %}>
         {{group.title | safe}}
-    </h3>
+    </div>
     {% endif %}
     <ul class="m-list
                m-list__unstyled">


### PR DESCRIPTION
Currently the headings in the mega menu are part of the document outline. Replaces the `h3` tag with a `span` and relying instead on the default `h5` styles.

## Changes

- Swapped `h3` for `span` 

## Testing

1. Check out the nav and make sure it looks the same.

## Screenshots

Before

<img width="806" alt="screen shot 2018-05-22 at 3 53 34 pm" src="https://user-images.githubusercontent.com/1280430/40389725-b7a7423e-5dd8-11e8-9575-9ff4373030d9.png">

After

<img width="681" alt="screen shot 2018-05-22 at 3 53 22 pm" src="https://user-images.githubusercontent.com/1280430/40389728-b9d485bc-5dd8-11e8-8a44-b9b4376fed2a.png">

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [x] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [x] Chrome
- [x] Firefox
- [x] Safari
- [x] Internet Explorer 8, 9, 10, and 11
- [x] Edge
- [x] iOS Safari
- [x] Chrome for Android

### Accessibility

- [x] Keyboard friendly
- [x] Screen reader friendly

### Other

- [x] Is useable without CSS
- [x] Is useable without JS
- [x] Flexible from small to large screens
- [x] No linting errors or warnings
- [x] JavaScript tests are passing
