### PR TITLE
Run ondemand subtask with default gulp scripts run

### DIFF
--- a/gulp/tasks/scripts.js
+++ b/gulp/tasks/scripts.js
@@ -262,6 +262,7 @@ gulp.task( 'scripts',
     'scripts:apps',
     'scripts:external',
     'scripts:nemo',
-    'scripts:spanish'
+    'scripts:spanish',
+    'scripts:ondemand'
   )
 );


### PR DESCRIPTION
Betsy spent more time than she should have trying to debug why the mega menu was open on top of the page on Paying for College. The reason was because we don't run `gulp scripts:ondemand` with a default `gulp scripts` run. Seems like we should just do that, otherwise, devs have to know that they have to run that ondemand subtask manually.

It's also worth noting that we include the ondemand styles in the default `gulp styles` run, so this makes the behavior consistent.

## Additions

- `gulp scripts:ondemand` subtask to `gulp scripts` default task

## Testing

1. `rm -rf cfgov/static_built`
1. `gulp build`
1. Visit http://localhost:8000/paying-for-college/ and see the mega menu open on top of everything
1. Pull branch
1. `gulp build`
1. Refresh the page and see the mega menu functioning normally

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
