### PR TITLE
Fix typo in check-round icon name

### DIFF
--- a/cfgov/jinja2/v1/govdelivery-subscribe/success/index.html
+++ b/cfgov/jinja2/v1/govdelivery-subscribe/success/index.html
@@ -9,6 +9,6 @@
 {%- endblock %}
 
 {% block content_main %}
-    <h1>{{ svg_icon('checked-round') }} Success!</h1>
+    <h1>{{ svg_icon('check-round') }} Success!</h1>
     <p>Your subscription was successfully received.</p>
 {% endblock %}

--- a/cfgov/jinja2/v1/owning-a-home/_templates/form-explainer.html
+++ b/cfgov/jinja2/v1/owning-a-home/_templates/form-explainer.html
@@ -25,7 +25,7 @@
             <button class="tab-link tab-link__checklist"
                     data-target="checklist"
                     tabindex="0">
-                {{ svg_icon('checked-round') }}
+                {{ svg_icon('check-round') }}
                 <span class="tab-label">Check details</span>
             </button>
         </li>

--- a/cfgov/jinja2/v1/owning-a-home/_templates/ratings-form.html
+++ b/cfgov/jinja2/v1/owning-a-home/_templates/ratings-form.html
@@ -42,7 +42,7 @@
                 </li>
                 <li class="content-l_col content-l_col-1-3">
                     <div class="rating-message message-column">
-                        {{ svg_icon('checked-round') }}
+                        {{ svg_icon('check-round') }}
                         <span class="rating-message_text">Thank you for your feedback!</span>
                     </div>
                 </li>

--- a/cfgov/jinja2/v1/regulation-comment/success/index.html
+++ b/cfgov/jinja2/v1/regulation-comment/success/index.html
@@ -10,7 +10,7 @@
 
 {% block content_main %}
 
-    <h1>{{ svg_icon('checked-round') }} Success!</h1>
+    <h1>{{ svg_icon('check-round') }} Success!</h1>
     <p>
         Your comment was successfully submitted.
 


### PR DESCRIPTION
The name is `check-round`, not `checked-round`.

## Todos

- It'd be nice if this silently failed instead of raising a 500, maybe? I suppose it would've taken a lot longer for us to notice the issue if it silently failed...

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
