### PR TITLE
Fix condition for rendering the FMC

### DIFF
--- a/cfgov/jinja2/v1/_includes/organisms/mega-menu.html
+++ b/cfgov/jinja2/v1/_includes/organisms/mega-menu.html
@@ -154,7 +154,7 @@
          {% endif %}
             </div>
             {% for parent_name, fmc in media_items %}
-                {% if parent_name + ' Overview' == nav_overview %}
+                {% if parent_name == nav_overview %}
                 {{ fmc }}
                 {% endif %}
             {% endfor %}


### PR DESCRIPTION
When the "Overview" text was stripped from `nav_overview` it broke the condition for the FMC stopping it from being rendered. Removing the "Overview" text there and comparing the `nav_overview` to the `parent_name` fixes everything.

## Removals

- Removed the string concat with "Overview" text from the FMC condition

## Testing

1. Startup local server and check all the main menu items for an FMC (all but About Us should have one).

## Screenshots

<img width="1035" alt="screen shot 2018-05-23 at 11 53 07 am" src="https://user-images.githubusercontent.com/1280430/40439211-e11ceb62-5e7f-11e8-8958-cb36abcfa0d8.png">

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [x] Chrome
- [x] Firefox
- [x] Safari
- [x] Internet Explorer 8, 9, 10, and 11
- [ ] Edge
- [ ] iOS Safari
- [ ] Chrome for Android

### Accessibility

- [x] Keyboard friendly
- [x] Screen reader friendly

### Other

- [x] Is useable without CSS
- [x] Is useable without JS
- [x] Flexible from small to large screens
- [x] No linting errors or warnings
- [x] JavaScript tests are passing
