### PR TITLE
Fix AtomicTableBlock heading icon help text

### DIFF
--- a/cfgov/templates/wagtailadmin/table_input.html
+++ b/cfgov/templates/wagtailadmin/table_input.html
@@ -44,7 +44,7 @@
                 <input type="text"
                        id="{{ attrs.id }}-handsontable-heading-icon"
                        name="handsontable-heading-icon">
-                <span class="help">Input the name of an icon to appear to the left of the heading. E.g., approved, help-round, etc. See full list of icons</span>
+                <span class="help">Input the name of an icon to appear to the left of the heading. E.g., approved, help-round, etc. <a href="https://cfpb.github.io/capital-framework/'components/cf-icons/#icons">See full list of icons</span>
             </div>
         </div>
     </div>


### PR DESCRIPTION
The help text for the heading icon in AtomicTableBlock was missing the link to see the list of icons.

## Testing

1. Pull branch
1. Add a TableBlock to a FullWidthText and see the clickable link in the header icon field.

## Screenshots

![screen shot 2018-05-23 at 16 09 48](https://user-images.githubusercontent.com/1044670/40448547-d58c6bbe-5ea3-11e8-8aa5-f5fd66b73e92.png)

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [x] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

