### PR TITLE
Adding `.python-version` to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,10 @@ __pycache__/
 *.eggs/
 *.egg/
 
+# pyenv #
+#########
+.python-version
+
 # Front-End #
 #############
 bower_components/


### PR DESCRIPTION
`pyenv` is an alternative to managing Python versions with homebrew.
One pyenv option is to add a `.python-version` file to a directory
to specify which python versions should be available. This can be used
to help run tox tests against, say, Python 2.7.14 and 3.6.4

There are other considerations to testing cfgov against Python 3
(such as our requirement for MySQL-python==1.2.5, which py3 can't use).
At least that one will soon go away!
