### PR TITLE
Update jest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,18 +4,18 @@
   "lockfileVersion": 1,
   "dependencies": {
     "@babel/code-frame": {
-      "version": "7.0.0-beta.47",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.47.tgz",
-      "integrity": "sha512-W7IeG4MoVf4oUvWfHUx9VG9if3E0xSUDf1urrnNYtC2ow1dz2ptvQ6YsJfyVXDuPTFXz66jkHhzMW7a5Eld7TA==",
+      "version": "7.0.0-beta.49",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.49.tgz",
+      "integrity": "sha1-vs2AVIJzREDJ0TfkbXc0DmTX9Rs=",
       "dev": true,
       "requires": {
-        "@babel/highlight": "7.0.0-beta.47"
+        "@babel/highlight": "7.0.0-beta.49"
       }
     },
     "@babel/highlight": {
-      "version": "7.0.0-beta.47",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.47.tgz",
-      "integrity": "sha512-d505K3Hth1eg0b2swfEF7oFMw3J9M8ceFg0s6dhCSxOOF+07WDvJ0HKT/YbK/Jk9wn8Wyr6HIRAUPKJ9Wfv8Rg==",
+      "version": "7.0.0-beta.49",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.49.tgz",
+      "integrity": "sha1-lr3GtD4TSCASumaRsQGEktOWIsw=",
       "dev": true,
       "requires": {
         "chalk": "2.4.1",
@@ -228,12 +228,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
       "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
-    },
-    "accessibility-developer-tools": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/accessibility-developer-tools/-/accessibility-developer-tools-2.12.0.tgz",
-      "integrity": "sha1-PaDM6dbsY3OWS4TzXbfPw996tRQ=",
-      "dev": true
     },
     "accord": {
       "version": "0.29.0",
@@ -1073,29 +1067,6 @@
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.7.0.tgz",
       "integrity": "sha512-32NDda82rhwD9/JBCCkB+MRYDp0oSvlo2IL6rQWA10PQi7tDUM3eqMSltXmY+Oyl/7N3P3qNtAlv7X0d9bI28w=="
     },
-    "axe-core": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-2.6.1.tgz",
-      "integrity": "sha512-QFfI3d+x/v92HJWGBaNfgrxdfon9/xXzd04YYfm5w5NJQOLex8qkJCctOt7+ky6e1l9zcQ5E7jsvbnTgQzyfTw==",
-      "dev": true
-    },
-    "axe-webdriverjs": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/axe-webdriverjs/-/axe-webdriverjs-0.2.0.tgz",
-      "integrity": "sha1-XjHtr26bozRCdiz9hd46B0c8EVU=",
-      "dev": true,
-      "requires": {
-        "axe-core": "1.1.1"
-      },
-      "dependencies": {
-        "axe-core": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-1.1.1.tgz",
-          "integrity": "sha1-rp2l2oq08QQZB/H12N/jnJRqksU=",
-          "dev": true
-        }
-      }
-    },
     "axios": {
       "version": "0.17.1",
       "resolved": "https://registry.npmjs.org/axios/-/axios-0.17.1.tgz",
@@ -1327,13 +1298,13 @@
       }
     },
     "babel-jest": {
-      "version": "22.4.3",
-      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-22.4.3.tgz",
-      "integrity": "sha512-BgSjmtl3mW3i+VeVHEr9d2zFSAT66G++pJcHQiUjd00pkW+voYXFctIm/indcqOWWXw5a1nUpR1XWszD9fJ1qg==",
+      "version": "23.0.0",
+      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-23.0.0.tgz",
+      "integrity": "sha1-Djg6KqazU14ZfbKSlXCiGCvQhOg=",
       "dev": true,
       "requires": {
         "babel-plugin-istanbul": "4.1.6",
-        "babel-preset-jest": "22.4.3"
+        "babel-preset-jest": "23.0.0"
       }
     },
     "babel-loader": {
@@ -1380,9 +1351,9 @@
       }
     },
     "babel-plugin-jest-hoist": {
-      "version": "22.4.3",
-      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-22.4.3.tgz",
-      "integrity": "sha512-zhvv4f6OTWy2bYevcJftwGCWXMFe7pqoz41IhMi4xna7xNsX5NygdagsrE0y6kkfuXq8UalwvPwKTyAxME2E/g==",
+      "version": "23.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-23.0.0.tgz",
+      "integrity": "sha1-5h5oeZ90M5Gh5jBu4nBHeqz5Rsg=",
       "dev": true
     },
     "babel-plugin-syntax-async-functions": {
@@ -1766,12 +1737,12 @@
       }
     },
     "babel-preset-jest": {
-      "version": "22.4.3",
-      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-22.4.3.tgz",
-      "integrity": "sha512-a+M3LTEXTq3gxv0uBN9Qm6ahUl7a8pj923nFbCUdqFUSsf3YrX8Uc+C3MEwji5Af3LiQjSC7w4ooYewlz8HRTA==",
+      "version": "23.0.0",
+      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-23.0.0.tgz",
+      "integrity": "sha1-Sd4DA/G2h13K1hY+qn64Mw1Ugk0=",
       "dev": true,
       "requires": {
-        "babel-plugin-jest-hoist": "22.4.3",
+        "babel-plugin-jest-hoist": "23.0.0",
         "babel-plugin-syntax-object-rest-spread": "6.13.0"
       },
       "dependencies": {
@@ -1955,15 +1926,6 @@
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
           "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
           "dev": true
-        },
-        "source-map-support": {
-          "version": "0.4.18",
-          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
-          "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
-          "dev": true,
-          "requires": {
-            "source-map": "0.5.7"
-          }
         },
         "supports-color": {
           "version": "2.0.0",
@@ -4323,9 +4285,9 @@
       "dev": true
     },
     "cssstyle": {
-      "version": "0.2.37",
-      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-0.2.37.tgz",
-      "integrity": "sha1-VBCXI0yyUTyDzu06zdwn/yeYfVQ=",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-0.3.1.tgz",
+      "integrity": "sha512-tNvaxM5blOnxanyxI6panOsnfiyLRj3HV4qjqqS45WPNS1usdYWRUQjqTEEELK73lpeP/1KoIGYUwrBn/VcECA==",
       "dev": true,
       "requires": {
         "cssom": "0.3.2"
@@ -6047,17 +6009,17 @@
       }
     },
     "expect": {
-      "version": "22.4.3",
-      "resolved": "https://registry.npmjs.org/expect/-/expect-22.4.3.tgz",
-      "integrity": "sha512-XcNXEPehqn8b/jm8FYotdX0YrXn36qp4HWlrVT4ktwQas1l1LPxiVWncYnnL2eyMtKAmVIaG0XAp0QlrqJaxaA==",
+      "version": "23.0.0",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-23.0.0.tgz",
+      "integrity": "sha1-LDqwpE2uMZ4Apz41YXYnaNA6Kyc=",
       "dev": true,
       "requires": {
         "ansi-styles": "3.2.1",
-        "jest-diff": "22.4.3",
+        "jest-diff": "23.0.0",
         "jest-get-type": "22.4.3",
-        "jest-matcher-utils": "22.4.3",
-        "jest-message-util": "22.4.3",
-        "jest-regex-util": "22.4.3"
+        "jest-matcher-utils": "23.0.0",
+        "jest-message-util": "23.0.0",
+        "jest-regex-util": "23.0.0"
       }
     },
     "extend": {
@@ -9268,27 +9230,6 @@
         "js-yaml": "3.10.0",
         "mkdirp": "0.5.1",
         "once": "1.4.0"
-      },
-      "dependencies": {
-        "istanbul-lib-source-maps": {
-          "version": "1.2.4",
-          "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.4.tgz",
-          "integrity": "sha512-UzuK0g1wyQijiaYQxj/CdNycFhAd2TLtO2obKQMTZrZ1jzEMRY3rvpASEKkaxbRR6brvdovfA03znPa/pXcejg==",
-          "dev": true,
-          "requires": {
-            "debug": "3.1.0",
-            "istanbul-lib-coverage": "1.2.0",
-            "mkdirp": "0.5.1",
-            "rimraf": "2.6.2",
-            "source-map": "0.5.7"
-          }
-        },
-        "source-map": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-          "dev": true
-        }
       }
     },
     "istanbul-lib-coverage": {
@@ -9486,9 +9427,9 @@
       }
     },
     "istanbul-lib-source-maps": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.3.tgz",
-      "integrity": "sha512-fDa0hwU/5sDXwAklXgAoCJCOsFsBplVQ6WBldz5UwaqOzmDhUK4nfuR7/G//G2lERlblUNJB8P6e8cXq3a7MlA==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.4.tgz",
+      "integrity": "sha512-UzuK0g1wyQijiaYQxj/CdNycFhAd2TLtO2obKQMTZrZ1jzEMRY3rvpASEKkaxbRR6brvdovfA03znPa/pXcejg==",
       "dev": true,
       "requires": {
         "debug": "3.1.0",
@@ -9559,13 +9500,13 @@
       "dev": true
     },
     "jest": {
-      "version": "22.4.3",
-      "resolved": "https://registry.npmjs.org/jest/-/jest-22.4.3.tgz",
-      "integrity": "sha512-FFCdU/pXOEASfHxFDOWUysI/+FFoqiXJADEIXgDKuZyqSmBD3tZ4BEGH7+M79v7czj7bbkhwtd2LaEDcJiM/GQ==",
+      "version": "23.0.0",
+      "resolved": "https://registry.npmjs.org/jest/-/jest-23.0.0.tgz",
+      "integrity": "sha1-koKYAwn1zeJ6rcWa5YPxEXwORDA=",
       "dev": true,
       "requires": {
         "import-local": "1.0.0",
-        "jest-cli": "22.4.3"
+        "jest-cli": "23.0.0"
       }
     },
     "jest-changed-files": {
@@ -9578,9 +9519,9 @@
       }
     },
     "jest-cli": {
-      "version": "22.4.3",
-      "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-22.4.3.tgz",
-      "integrity": "sha512-IiHybF0DJNqZPsbjn4Cy4vcqcmImpoFwNFnkehzVw8lTUSl4axZh5DHewu5bdpZF2Y5gUqFKYzH0FH4Qx2k+UA==",
+      "version": "23.0.0",
+      "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-23.0.0.tgz",
+      "integrity": "sha1-KSh0mMnYRNzaWq8BGkyC+aiIg24=",
       "dev": true,
       "requires": {
         "ansi-escapes": "3.1.0",
@@ -9593,21 +9534,21 @@
         "istanbul-api": "1.3.1",
         "istanbul-lib-coverage": "1.2.0",
         "istanbul-lib-instrument": "1.10.1",
-        "istanbul-lib-source-maps": "1.2.3",
+        "istanbul-lib-source-maps": "1.2.4",
         "jest-changed-files": "22.4.3",
-        "jest-config": "22.4.3",
-        "jest-environment-jsdom": "22.4.3",
+        "jest-config": "23.0.0",
+        "jest-environment-jsdom": "23.0.0",
         "jest-get-type": "22.4.3",
-        "jest-haste-map": "22.4.3",
-        "jest-message-util": "22.4.3",
-        "jest-regex-util": "22.4.3",
-        "jest-resolve-dependencies": "22.4.3",
-        "jest-runner": "22.4.3",
-        "jest-runtime": "22.4.3",
-        "jest-snapshot": "22.4.3",
-        "jest-util": "22.4.3",
-        "jest-validate": "22.4.3",
-        "jest-worker": "22.4.3",
+        "jest-haste-map": "23.0.0",
+        "jest-message-util": "23.0.0",
+        "jest-regex-util": "23.0.0",
+        "jest-resolve-dependencies": "23.0.0",
+        "jest-runner": "23.0.0",
+        "jest-runtime": "23.0.0",
+        "jest-snapshot": "23.0.0",
+        "jest-util": "23.0.0",
+        "jest-validate": "23.0.0",
+        "jest-worker": "23.0.0",
         "micromatch": "2.3.11",
         "node-notifier": "5.2.1",
         "realpath-native": "1.0.0",
@@ -9616,7 +9557,7 @@
         "string-length": "2.0.0",
         "strip-ansi": "4.0.0",
         "which": "1.3.0",
-        "yargs": "10.1.2"
+        "yargs": "11.0.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -9624,50 +9565,6 @@
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
           "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
           "dev": true
-        },
-        "camelcase": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
-          "dev": true
-        },
-        "cliui": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
-          "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
-          "dev": true,
-          "requires": {
-            "string-width": "2.1.1",
-            "strip-ansi": "4.0.0",
-            "wrap-ansi": "2.1.0"
-          }
-        },
-        "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-          "dev": true
-        },
-        "os-locale": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
-          "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
-          "dev": true,
-          "requires": {
-            "execa": "0.7.0",
-            "lcid": "1.0.0",
-            "mem": "1.1.0"
-          }
-        },
-        "string-width": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-          "dev": true,
-          "requires": {
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "4.0.0"
-          }
         },
         "strip-ansi": {
           "version": "4.0.0",
@@ -9677,270 +9574,30 @@
           "requires": {
             "ansi-regex": "3.0.0"
           }
-        },
-        "which-module": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-          "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
-          "dev": true
-        },
-        "yargs": {
-          "version": "10.1.2",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-10.1.2.tgz",
-          "integrity": "sha512-ivSoxqBGYOqQVruxD35+EyCFDYNEFL/Uo6FcOnz+9xZdZzK0Zzw4r4KhbrME1Oo2gOggwJod2MnsdamSG7H9ig==",
-          "dev": true,
-          "requires": {
-            "cliui": "4.1.0",
-            "decamelize": "1.2.0",
-            "find-up": "2.1.0",
-            "get-caller-file": "1.0.2",
-            "os-locale": "2.1.0",
-            "require-directory": "2.1.1",
-            "require-main-filename": "1.0.1",
-            "set-blocking": "2.0.0",
-            "string-width": "2.1.1",
-            "which-module": "2.0.0",
-            "y18n": "3.2.1",
-            "yargs-parser": "8.1.0"
-          }
-        },
-        "yargs-parser": {
-          "version": "8.1.0",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-8.1.0.tgz",
-          "integrity": "sha512-yP+6QqN8BmrgW2ggLtTbdrOyBNSI7zBa4IykmiV5R1wl1JWNxQvWhMfMdmzIYtKU7oP3OOInY/tl2ov3BDjnJQ==",
-          "dev": true,
-          "requires": {
-            "camelcase": "4.1.0"
-          }
         }
       }
     },
     "jest-config": {
-      "version": "22.4.3",
-      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-22.4.3.tgz",
-      "integrity": "sha512-KSg3EOToCgkX+lIvenKY7J8s426h6ahXxaUFJxvGoEk0562Z6inWj1TnKoGycTASwiLD+6kSYFALcjdosq9KIQ==",
-      "dev": true,
-      "requires": {
-        "chalk": "2.4.1",
-        "glob": "7.1.2",
-        "jest-environment-jsdom": "22.4.3",
-        "jest-environment-node": "22.4.3",
-        "jest-get-type": "22.4.3",
-        "jest-jasmine2": "22.4.3",
-        "jest-regex-util": "22.4.3",
-        "jest-resolve": "22.4.3",
-        "jest-util": "22.4.3",
-        "jest-validate": "22.4.3",
-        "pretty-format": "22.4.3"
-      }
-    },
-    "jest-diff": {
-      "version": "22.4.3",
-      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-22.4.3.tgz",
-      "integrity": "sha512-/QqGvCDP5oZOF6PebDuLwrB2BMD8ffJv6TAGAdEVuDx1+uEgrHpSFrfrOiMRx2eJ1hgNjlQrOQEHetVwij90KA==",
-      "dev": true,
-      "requires": {
-        "chalk": "2.4.1",
-        "diff": "3.5.0",
-        "jest-get-type": "22.4.3",
-        "pretty-format": "22.4.3"
-      }
-    },
-    "jest-docblock": {
-      "version": "22.4.3",
-      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-22.4.3.tgz",
-      "integrity": "sha512-uPKBEAw7YrEMcXueMKZXn/rbMxBiSv48fSqy3uEnmgOlQhSX+lthBqHb1fKWNVmFqAp9E/RsSdBfiV31LbzaOg==",
-      "dev": true,
-      "requires": {
-        "detect-newline": "2.1.0"
-      }
-    },
-    "jest-environment-jsdom": {
-      "version": "22.4.3",
-      "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-22.4.3.tgz",
-      "integrity": "sha512-FviwfR+VyT3Datf13+ULjIMO5CSeajlayhhYQwpzgunswoaLIPutdbrnfUHEMyJCwvqQFaVtTmn9+Y8WCt6n1w==",
-      "dev": true,
-      "requires": {
-        "jest-mock": "22.4.3",
-        "jest-util": "22.4.3",
-        "jsdom": "11.10.0"
-      }
-    },
-    "jest-environment-node": {
-      "version": "22.4.3",
-      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-22.4.3.tgz",
-      "integrity": "sha512-reZl8XF6t/lMEuPWwo9OLfttyC26A5AMgDyEQ6DBgZuyfyeNUzYT8BFo6uxCCP/Av/b7eb9fTi3sIHFPBzmlRA==",
-      "dev": true,
-      "requires": {
-        "jest-mock": "22.4.3",
-        "jest-util": "22.4.3"
-      }
-    },
-    "jest-get-type": {
-      "version": "22.4.3",
-      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-22.4.3.tgz",
-      "integrity": "sha512-/jsz0Y+V29w1chdXVygEKSz2nBoHoYqNShPe+QgxSNjAuP1i8+k4LbQNrfoliKej0P45sivkSCh7yiD6ubHS3w==",
-      "dev": true
-    },
-    "jest-haste-map": {
-      "version": "22.4.3",
-      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-22.4.3.tgz",
-      "integrity": "sha512-4Q9fjzuPVwnaqGKDpIsCSoTSnG3cteyk2oNVjBX12HHOaF1oxql+uUiqZb5Ndu7g/vTZfdNwwy4WwYogLh29DQ==",
-      "dev": true,
-      "requires": {
-        "fb-watchman": "2.0.0",
-        "graceful-fs": "4.1.11",
-        "jest-docblock": "22.4.3",
-        "jest-serializer": "22.4.3",
-        "jest-worker": "22.4.3",
-        "micromatch": "2.3.11",
-        "sane": "2.5.2"
-      }
-    },
-    "jest-jasmine2": {
-      "version": "22.4.3",
-      "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-22.4.3.tgz",
-      "integrity": "sha512-yZCPCJUcEY6R5KJB/VReo1AYI2b+5Ky+C+JA1v34jndJsRcLpU4IZX4rFJn7yDTtdNbO/nNqg+3SDIPNH2ecnw==",
-      "dev": true,
-      "requires": {
-        "chalk": "2.4.1",
-        "co": "4.6.0",
-        "expect": "22.4.3",
-        "graceful-fs": "4.1.11",
-        "is-generator-fn": "1.0.0",
-        "jest-diff": "22.4.3",
-        "jest-matcher-utils": "22.4.3",
-        "jest-message-util": "22.4.3",
-        "jest-snapshot": "22.4.3",
-        "jest-util": "22.4.3",
-        "source-map-support": "0.5.6"
-      },
-      "dependencies": {
-        "co": {
-          "version": "4.6.0",
-          "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-          "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
-          "dev": true
-        }
-      }
-    },
-    "jest-leak-detector": {
-      "version": "22.4.3",
-      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-22.4.3.tgz",
-      "integrity": "sha512-NZpR/Ls7+ndO57LuXROdgCGz2RmUdC541tTImL9bdUtU3WadgFGm0yV+Ok4Fuia/1rLAn5KaJ+i76L6e3zGJYQ==",
-      "dev": true,
-      "requires": {
-        "pretty-format": "22.4.3"
-      }
-    },
-    "jest-matcher-utils": {
-      "version": "22.4.3",
-      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-22.4.3.tgz",
-      "integrity": "sha512-lsEHVaTnKzdAPR5t4B6OcxXo9Vy4K+kRRbG5gtddY8lBEC+Mlpvm1CJcsMESRjzUhzkz568exMV1hTB76nAKbA==",
-      "dev": true,
-      "requires": {
-        "chalk": "2.4.1",
-        "jest-get-type": "22.4.3",
-        "pretty-format": "22.4.3"
-      }
-    },
-    "jest-message-util": {
-      "version": "22.4.3",
-      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-22.4.3.tgz",
-      "integrity": "sha512-iAMeKxhB3Se5xkSjU0NndLLCHtP4n+GtCqV0bISKA5dmOXQfEbdEmYiu2qpnWBDCQdEafNDDU6Q+l6oBMd/+BA==",
-      "dev": true,
-      "requires": {
-        "@babel/code-frame": "7.0.0-beta.47",
-        "chalk": "2.4.1",
-        "micromatch": "2.3.11",
-        "slash": "1.0.0",
-        "stack-utils": "1.0.1"
-      }
-    },
-    "jest-mock": {
-      "version": "22.4.3",
-      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-22.4.3.tgz",
-      "integrity": "sha512-+4R6mH5M1G4NK16CKg9N1DtCaFmuxhcIqF4lQK/Q1CIotqMs/XBemfpDPeVZBFow6iyUNu6EBT9ugdNOTT5o5Q==",
-      "dev": true
-    },
-    "jest-regex-util": {
-      "version": "22.4.3",
-      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-22.4.3.tgz",
-      "integrity": "sha512-LFg1gWr3QinIjb8j833bq7jtQopiwdAs67OGfkPrvy7uNUbVMfTXXcOKXJaeY5GgjobELkKvKENqq1xrUectWg==",
-      "dev": true
-    },
-    "jest-resolve": {
-      "version": "22.4.3",
-      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-22.4.3.tgz",
-      "integrity": "sha512-u3BkD/MQBmwrOJDzDIaxpyqTxYH+XqAXzVJP51gt29H8jpj3QgKof5GGO2uPGKGeA1yTMlpbMs1gIQ6U4vcRhw==",
-      "dev": true,
-      "requires": {
-        "browser-resolve": "1.11.2",
-        "chalk": "2.4.1"
-      }
-    },
-    "jest-resolve-dependencies": {
-      "version": "22.4.3",
-      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-22.4.3.tgz",
-      "integrity": "sha512-06czCMVToSN8F2U4EvgSB1Bv/56gc7MpCftZ9z9fBgUQM7dzHGCMBsyfVA6dZTx8v0FDcnALf7hupeQxaBCvpA==",
-      "dev": true,
-      "requires": {
-        "jest-regex-util": "22.4.3"
-      }
-    },
-    "jest-runner": {
-      "version": "22.4.3",
-      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-22.4.3.tgz",
-      "integrity": "sha512-U7PLlQPRlWNbvOHWOrrVay9sqhBJmiKeAdKIkvX4n1G2tsvzLlf77nBD28GL1N6tGv4RmuTfI8R8JrkvCa+IBg==",
-      "dev": true,
-      "requires": {
-        "exit": "0.1.2",
-        "jest-config": "22.4.3",
-        "jest-docblock": "22.4.3",
-        "jest-haste-map": "22.4.3",
-        "jest-jasmine2": "22.4.3",
-        "jest-leak-detector": "22.4.3",
-        "jest-message-util": "22.4.3",
-        "jest-runtime": "22.4.3",
-        "jest-util": "22.4.3",
-        "jest-worker": "22.4.3",
-        "throat": "4.1.0"
-      }
-    },
-    "jest-runtime": {
-      "version": "22.4.3",
-      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-22.4.3.tgz",
-      "integrity": "sha512-Eat/esQjevhx9BgJEC8udye+FfoJ2qvxAZfOAWshYGS22HydHn5BgsvPdTtt9cp0fSl5LxYOFA1Pja9Iz2Zt8g==",
+      "version": "23.0.0",
+      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-23.0.0.tgz",
+      "integrity": "sha1-lETYWIc61Wc3b4z+E5/Ygo6NSUs=",
       "dev": true,
       "requires": {
         "babel-core": "6.26.3",
-        "babel-jest": "22.4.3",
-        "babel-plugin-istanbul": "4.1.6",
+        "babel-jest": "23.0.0",
         "chalk": "2.4.1",
-        "convert-source-map": "1.5.1",
-        "exit": "0.1.2",
-        "graceful-fs": "4.1.11",
-        "jest-config": "22.4.3",
-        "jest-haste-map": "22.4.3",
-        "jest-regex-util": "22.4.3",
-        "jest-resolve": "22.4.3",
-        "jest-util": "22.4.3",
-        "jest-validate": "22.4.3",
-        "json-stable-stringify": "1.0.1",
-        "micromatch": "2.3.11",
-        "realpath-native": "1.0.0",
-        "slash": "1.0.0",
-        "strip-bom": "3.0.0",
-        "write-file-atomic": "2.3.0",
-        "yargs": "10.1.2"
+        "glob": "7.1.2",
+        "jest-environment-jsdom": "23.0.0",
+        "jest-environment-node": "23.0.0",
+        "jest-get-type": "22.4.3",
+        "jest-jasmine2": "23.0.0",
+        "jest-regex-util": "23.0.0",
+        "jest-resolve": "23.0.0",
+        "jest-util": "23.0.0",
+        "jest-validate": "23.0.0",
+        "pretty-format": "23.0.0"
       },
       "dependencies": {
-        "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "dev": true
-        },
         "ansi-styles": {
           "version": "2.2.1",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
@@ -10074,33 +9731,396 @@
           "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
           "dev": true
         },
-        "camelcase": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
-          "dev": true
-        },
-        "cliui": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
-          "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "dev": true,
           "requires": {
-            "string-width": "2.1.1",
-            "strip-ansi": "4.0.0",
-            "wrap-ansi": "2.1.0"
+            "ms": "2.0.0"
+          }
+        },
+        "globals": {
+          "version": "9.18.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
+          "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
+          "dev": true
+        },
+        "jsesc": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
+          "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s=",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+          "dev": true
+        },
+        "to-fast-properties": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
+          "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
+          "dev": true
+        }
+      }
+    },
+    "jest-diff": {
+      "version": "23.0.0",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-23.0.0.tgz",
+      "integrity": "sha1-CgCyFX9RjuwzgSHM+IecUpJpqI4=",
+      "dev": true,
+      "requires": {
+        "chalk": "2.4.1",
+        "diff": "3.5.0",
+        "jest-get-type": "22.4.3",
+        "pretty-format": "23.0.0"
+      }
+    },
+    "jest-docblock": {
+      "version": "22.4.3",
+      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-22.4.3.tgz",
+      "integrity": "sha512-uPKBEAw7YrEMcXueMKZXn/rbMxBiSv48fSqy3uEnmgOlQhSX+lthBqHb1fKWNVmFqAp9E/RsSdBfiV31LbzaOg==",
+      "dev": true,
+      "requires": {
+        "detect-newline": "2.1.0"
+      }
+    },
+    "jest-environment-jsdom": {
+      "version": "23.0.0",
+      "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-23.0.0.tgz",
+      "integrity": "sha1-V7Dw3SYzWahteVKktxKz+ryhpiU=",
+      "dev": true,
+      "requires": {
+        "jest-mock": "23.0.0",
+        "jest-util": "23.0.0",
+        "jsdom": "11.11.0"
+      }
+    },
+    "jest-environment-node": {
+      "version": "23.0.0",
+      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-23.0.0.tgz",
+      "integrity": "sha1-75OkFKYSSEz1hcizLMxa4wzmCVw=",
+      "dev": true,
+      "requires": {
+        "jest-mock": "23.0.0",
+        "jest-util": "23.0.0"
+      }
+    },
+    "jest-get-type": {
+      "version": "22.4.3",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-22.4.3.tgz",
+      "integrity": "sha512-/jsz0Y+V29w1chdXVygEKSz2nBoHoYqNShPe+QgxSNjAuP1i8+k4LbQNrfoliKej0P45sivkSCh7yiD6ubHS3w==",
+      "dev": true
+    },
+    "jest-haste-map": {
+      "version": "23.0.0",
+      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-23.0.0.tgz",
+      "integrity": "sha1-Cb4cmjfBay4vJTmIZOsoBtMJypY=",
+      "dev": true,
+      "requires": {
+        "fb-watchman": "2.0.0",
+        "graceful-fs": "4.1.11",
+        "jest-docblock": "22.4.3",
+        "jest-serializer": "23.0.0",
+        "jest-worker": "23.0.0",
+        "micromatch": "2.3.11",
+        "sane": "2.5.2"
+      }
+    },
+    "jest-jasmine2": {
+      "version": "23.0.0",
+      "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-23.0.0.tgz",
+      "integrity": "sha1-6ib4e1wiPhpwmFAy8HJ9j4VeWd8=",
+      "dev": true,
+      "requires": {
+        "chalk": "2.4.1",
+        "co": "4.6.0",
+        "expect": "23.0.0",
+        "is-generator-fn": "1.0.0",
+        "jest-diff": "23.0.0",
+        "jest-matcher-utils": "23.0.0",
+        "jest-message-util": "23.0.0",
+        "jest-snapshot": "23.0.0",
+        "jest-util": "23.0.0",
+        "pretty-format": "23.0.0"
+      },
+      "dependencies": {
+        "co": {
+          "version": "4.6.0",
+          "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+          "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+          "dev": true
+        }
+      }
+    },
+    "jest-leak-detector": {
+      "version": "23.0.0",
+      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-23.0.0.tgz",
+      "integrity": "sha1-7JPXVbIeiyxMTlm4zMqxgFpwSrM=",
+      "dev": true,
+      "requires": {
+        "pretty-format": "23.0.0"
+      }
+    },
+    "jest-matcher-utils": {
+      "version": "23.0.0",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-23.0.0.tgz",
+      "integrity": "sha1-yiFo/lp6QWwNfykW6Wnonczp2So=",
+      "dev": true,
+      "requires": {
+        "chalk": "2.4.1",
+        "jest-get-type": "22.4.3",
+        "pretty-format": "23.0.0"
+      }
+    },
+    "jest-message-util": {
+      "version": "23.0.0",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-23.0.0.tgz",
+      "integrity": "sha1-Bz89dscB98cYpLmvHrfxOHksR5Y=",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "7.0.0-beta.49",
+        "chalk": "2.4.1",
+        "micromatch": "2.3.11",
+        "slash": "1.0.0",
+        "stack-utils": "1.0.1"
+      }
+    },
+    "jest-mock": {
+      "version": "23.0.0",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-23.0.0.tgz",
+      "integrity": "sha1-2diXobdNwFxmpzchOTFJYhWJfdg=",
+      "dev": true
+    },
+    "jest-regex-util": {
+      "version": "23.0.0",
+      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-23.0.0.tgz",
+      "integrity": "sha1-3Vwf3gxG9DcTFM8Q96dRoj9Oj3Y=",
+      "dev": true
+    },
+    "jest-resolve": {
+      "version": "23.0.0",
+      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-23.0.0.tgz",
+      "integrity": "sha1-8ENi/QUxtFRjmd92xVwyFKn0XgI=",
+      "dev": true,
+      "requires": {
+        "browser-resolve": "1.11.2",
+        "chalk": "2.4.1",
+        "realpath-native": "1.0.0"
+      }
+    },
+    "jest-resolve-dependencies": {
+      "version": "23.0.0",
+      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-23.0.0.tgz",
+      "integrity": "sha1-w+HP7g5UPe4Q5uwGKN9pzSOSRMk=",
+      "dev": true,
+      "requires": {
+        "jest-regex-util": "23.0.0",
+        "jest-snapshot": "23.0.0"
+      }
+    },
+    "jest-runner": {
+      "version": "23.0.0",
+      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-23.0.0.tgz",
+      "integrity": "sha1-sZii3XjVeiwPP418f5e2JnOSICA=",
+      "dev": true,
+      "requires": {
+        "exit": "0.1.2",
+        "graceful-fs": "4.1.11",
+        "jest-config": "23.0.0",
+        "jest-docblock": "22.4.3",
+        "jest-haste-map": "23.0.0",
+        "jest-jasmine2": "23.0.0",
+        "jest-leak-detector": "23.0.0",
+        "jest-message-util": "23.0.0",
+        "jest-runtime": "23.0.0",
+        "jest-util": "23.0.0",
+        "jest-worker": "23.0.0",
+        "source-map-support": "0.5.6",
+        "throat": "4.1.0"
+      },
+      "dependencies": {
+        "source-map-support": {
+          "version": "0.5.6",
+          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.6.tgz",
+          "integrity": "sha512-N4KXEz7jcKqPf2b2vZF11lQIz9W5ZMuUcIOGj243lduidkf2fjkVKJS9vNxVWn3u/uxX38AcE8U9nnH9FPcq+g==",
+          "dev": true,
+          "requires": {
+            "buffer-from": "1.0.0",
+            "source-map": "0.6.1"
+          }
+        }
+      }
+    },
+    "jest-runtime": {
+      "version": "23.0.0",
+      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-23.0.0.tgz",
+      "integrity": "sha1-hhkif+LgFgPVQrkQHdPmTvRZP2Y=",
+      "dev": true,
+      "requires": {
+        "babel-core": "6.26.3",
+        "babel-plugin-istanbul": "4.1.6",
+        "chalk": "2.4.1",
+        "convert-source-map": "1.5.1",
+        "exit": "0.1.2",
+        "graceful-fs": "4.1.11",
+        "jest-config": "23.0.0",
+        "jest-haste-map": "23.0.0",
+        "jest-message-util": "23.0.0",
+        "jest-regex-util": "23.0.0",
+        "jest-resolve": "23.0.0",
+        "jest-snapshot": "23.0.0",
+        "jest-util": "23.0.0",
+        "jest-validate": "23.0.0",
+        "json-stable-stringify": "1.0.1",
+        "micromatch": "2.3.11",
+        "realpath-native": "1.0.0",
+        "slash": "1.0.0",
+        "strip-bom": "3.0.0",
+        "write-file-atomic": "2.3.0",
+        "yargs": "11.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "dev": true
+        },
+        "babel-code-frame": {
+          "version": "6.26.0",
+          "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
+          "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
+          "dev": true,
+          "requires": {
+            "chalk": "1.1.3",
+            "esutils": "2.0.2",
+            "js-tokens": "3.0.2"
           },
           "dependencies": {
-            "strip-ansi": {
-              "version": "4.0.0",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-              "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+            "chalk": {
+              "version": "1.1.3",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+              "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
               "dev": true,
               "requires": {
-                "ansi-regex": "3.0.0"
+                "ansi-styles": "2.2.1",
+                "escape-string-regexp": "1.0.5",
+                "has-ansi": "2.0.0",
+                "strip-ansi": "3.0.1",
+                "supports-color": "2.0.0"
               }
             }
           }
+        },
+        "babel-core": {
+          "version": "6.26.3",
+          "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.3.tgz",
+          "integrity": "sha512-6jyFLuDmeidKmUEb3NM+/yawG0M2bDZ9Z1qbZP59cyHLz8kYGKYwpJP0UwUKKUiTRNvxfLesJnTedqczP7cTDA==",
+          "dev": true,
+          "requires": {
+            "babel-code-frame": "6.26.0",
+            "babel-generator": "6.26.1",
+            "babel-helpers": "6.24.1",
+            "babel-messages": "6.23.0",
+            "babel-register": "6.26.0",
+            "babel-runtime": "6.26.0",
+            "babel-template": "6.26.0",
+            "babel-traverse": "6.26.0",
+            "babel-types": "6.26.0",
+            "babylon": "6.18.0",
+            "convert-source-map": "1.5.1",
+            "debug": "2.6.9",
+            "json5": "0.5.1",
+            "lodash": "4.17.10",
+            "minimatch": "3.0.4",
+            "path-is-absolute": "1.0.1",
+            "private": "0.1.8",
+            "slash": "1.0.0",
+            "source-map": "0.5.7"
+          }
+        },
+        "babel-generator": {
+          "version": "6.26.1",
+          "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.1.tgz",
+          "integrity": "sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==",
+          "dev": true,
+          "requires": {
+            "babel-messages": "6.23.0",
+            "babel-runtime": "6.26.0",
+            "babel-types": "6.26.0",
+            "detect-indent": "4.0.0",
+            "jsesc": "1.3.0",
+            "lodash": "4.17.10",
+            "source-map": "0.5.7",
+            "trim-right": "1.0.1"
+          }
+        },
+        "babel-helpers": {
+          "version": "6.24.1",
+          "resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
+          "integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
+          "dev": true,
+          "requires": {
+            "babel-runtime": "6.26.0",
+            "babel-template": "6.26.0"
+          }
+        },
+        "babel-template": {
+          "version": "6.26.0",
+          "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
+          "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
+          "dev": true,
+          "requires": {
+            "babel-runtime": "6.26.0",
+            "babel-traverse": "6.26.0",
+            "babel-types": "6.26.0",
+            "babylon": "6.18.0",
+            "lodash": "4.17.10"
+          }
+        },
+        "babel-traverse": {
+          "version": "6.26.0",
+          "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
+          "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
+          "dev": true,
+          "requires": {
+            "babel-code-frame": "6.26.0",
+            "babel-messages": "6.23.0",
+            "babel-runtime": "6.26.0",
+            "babel-types": "6.26.0",
+            "babylon": "6.18.0",
+            "debug": "2.6.9",
+            "globals": "9.18.0",
+            "invariant": "2.2.4",
+            "lodash": "4.17.10"
+          }
+        },
+        "babel-types": {
+          "version": "6.26.0",
+          "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
+          "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
+          "dev": true,
+          "requires": {
+            "babel-runtime": "6.26.0",
+            "esutils": "2.0.2",
+            "lodash": "4.17.10",
+            "to-fast-properties": "1.0.3"
+          }
+        },
+        "babylon": {
+          "version": "6.18.0",
+          "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
+          "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
+          "dev": true
         },
         "debug": {
           "version": "2.6.9",
@@ -10117,55 +10137,17 @@
           "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
           "dev": true
         },
-        "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-          "dev": true
-        },
         "jsesc": {
           "version": "1.3.0",
           "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
           "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s=",
           "dev": true
         },
-        "os-locale": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
-          "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
-          "dev": true,
-          "requires": {
-            "execa": "0.7.0",
-            "lcid": "1.0.0",
-            "mem": "1.1.0"
-          }
-        },
         "source-map": {
           "version": "0.5.7",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
           "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
           "dev": true
-        },
-        "string-width": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-          "dev": true,
-          "requires": {
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "4.0.0"
-          },
-          "dependencies": {
-            "strip-ansi": {
-              "version": "4.0.0",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-              "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-              "dev": true,
-              "requires": {
-                "ansi-regex": "3.0.0"
-              }
-            }
-          }
         },
         "strip-bom": {
           "version": "3.0.0",
@@ -10184,75 +10166,40 @@
           "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
           "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
           "dev": true
-        },
-        "which-module": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-          "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
-          "dev": true
-        },
-        "yargs": {
-          "version": "10.1.2",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-10.1.2.tgz",
-          "integrity": "sha512-ivSoxqBGYOqQVruxD35+EyCFDYNEFL/Uo6FcOnz+9xZdZzK0Zzw4r4KhbrME1Oo2gOggwJod2MnsdamSG7H9ig==",
-          "dev": true,
-          "requires": {
-            "cliui": "4.1.0",
-            "decamelize": "1.2.0",
-            "find-up": "2.1.0",
-            "get-caller-file": "1.0.2",
-            "os-locale": "2.1.0",
-            "require-directory": "2.1.1",
-            "require-main-filename": "1.0.1",
-            "set-blocking": "2.0.0",
-            "string-width": "2.1.1",
-            "which-module": "2.0.0",
-            "y18n": "3.2.1",
-            "yargs-parser": "8.1.0"
-          }
-        },
-        "yargs-parser": {
-          "version": "8.1.0",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-8.1.0.tgz",
-          "integrity": "sha512-yP+6QqN8BmrgW2ggLtTbdrOyBNSI7zBa4IykmiV5R1wl1JWNxQvWhMfMdmzIYtKU7oP3OOInY/tl2ov3BDjnJQ==",
-          "dev": true,
-          "requires": {
-            "camelcase": "4.1.0"
-          }
         }
       }
     },
     "jest-serializer": {
-      "version": "22.4.3",
-      "resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-22.4.3.tgz",
-      "integrity": "sha512-uPaUAppx4VUfJ0QDerpNdF43F68eqKWCzzhUlKNDsUPhjOon7ZehR4C809GCqh765FoMRtTVUVnGvIoskkYHiw==",
+      "version": "23.0.0",
+      "resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-23.0.0.tgz",
+      "integrity": "sha1-JjQRrJLh493iQ4WGQrsE6KmG6Mo=",
       "dev": true
     },
     "jest-snapshot": {
-      "version": "22.4.3",
-      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-22.4.3.tgz",
-      "integrity": "sha512-JXA0gVs5YL0HtLDCGa9YxcmmV2LZbwJ+0MfyXBBc5qpgkEYITQFJP7XNhcHFbUvRiniRpRbGVfJrOoYhhGE0RQ==",
+      "version": "23.0.0",
+      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-23.0.0.tgz",
+      "integrity": "sha1-Sc25Kmm5mZ2/kuBjTVuh6KhYaAM=",
       "dev": true,
       "requires": {
         "chalk": "2.4.1",
-        "jest-diff": "22.4.3",
-        "jest-matcher-utils": "22.4.3",
+        "jest-diff": "23.0.0",
+        "jest-matcher-utils": "23.0.0",
         "mkdirp": "0.5.1",
         "natural-compare": "1.4.0",
-        "pretty-format": "22.4.3"
+        "pretty-format": "23.0.0"
       }
     },
     "jest-util": {
-      "version": "22.4.3",
-      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-22.4.3.tgz",
-      "integrity": "sha512-rfDfG8wyC5pDPNdcnAlZgwKnzHvZDu8Td2NJI/jAGKEGxJPYiE4F0ss/gSAkG4778Y23Hvbz+0GMrDJTeo7RjQ==",
+      "version": "23.0.0",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-23.0.0.tgz",
+      "integrity": "sha1-hjhoAP++P+F6BjIODPnKm3hoJjs=",
       "dev": true,
       "requires": {
         "callsites": "2.0.0",
         "chalk": "2.4.1",
         "graceful-fs": "4.1.11",
         "is-ci": "1.1.0",
-        "jest-message-util": "22.4.3",
+        "jest-message-util": "23.0.0",
         "mkdirp": "0.5.1",
         "source-map": "0.6.1"
       },
@@ -10266,22 +10213,21 @@
       }
     },
     "jest-validate": {
-      "version": "22.4.3",
-      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-22.4.3.tgz",
-      "integrity": "sha512-CfFM18W3GSP/xgmA4UouIx0ljdtfD2mjeBC6c89Gg17E44D4tQhAcTrZmf9djvipwU30kSTnk6CzcxdCCeSXfA==",
+      "version": "23.0.0",
+      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-23.0.0.tgz",
+      "integrity": "sha1-+IvIl7bMN2l5r/AmLRAl3xMC1SA=",
       "dev": true,
       "requires": {
         "chalk": "2.4.1",
-        "jest-config": "22.4.3",
         "jest-get-type": "22.4.3",
         "leven": "2.1.0",
-        "pretty-format": "22.4.3"
+        "pretty-format": "23.0.0"
       }
     },
     "jest-worker": {
-      "version": "22.4.3",
-      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-22.4.3.tgz",
-      "integrity": "sha512-B1ucW4fI8qVAuZmicFxI1R3kr2fNeYJyvIQ1rKcuLYnenFV5K5aMbxFj6J0i00Ju83S8jP2d7Dz14+AvbIHRYQ==",
+      "version": "23.0.0",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-23.0.0.tgz",
+      "integrity": "sha1-5rE3i4H45qEI874zofqoMMIupFA=",
       "dev": true,
       "requires": {
         "merge-stream": "1.0.1"
@@ -10376,9 +10322,9 @@
       }
     },
     "jsdom": {
-      "version": "11.10.0",
-      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-11.10.0.tgz",
-      "integrity": "sha512-x5No5FpJgBg3j5aBwA8ka6eGuS5IxbC8FOkmyccKvObtFT0bDMict/LOxINZsZGZSfGdNomLZ/qRV9Bpq/GIBA==",
+      "version": "11.11.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-11.11.0.tgz",
+      "integrity": "sha512-ou1VyfjwsSuWkudGxb03FotDajxAto6USAlmMZjE2lc0jCznt7sBWkhfRBRaWwbnmDqdMSTKTLT5d9sBFkkM7A==",
       "dev": true,
       "requires": {
         "abab": "1.0.4",
@@ -10386,13 +10332,13 @@
         "acorn-globals": "4.1.0",
         "array-equal": "1.0.0",
         "cssom": "0.3.2",
-        "cssstyle": "0.2.37",
+        "cssstyle": "0.3.1",
         "data-urls": "1.0.0",
         "domexception": "1.0.1",
         "escodegen": "1.9.1",
         "html-encoding-sniffer": "1.0.2",
         "left-pad": "1.3.0",
-        "nwmatcher": "1.4.4",
+        "nwsapi": "2.0.0",
         "parse5": "4.0.0",
         "pn": "1.1.0",
         "request": "2.86.0",
@@ -12114,10 +12060,10 @@
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
       "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
     },
-    "nwmatcher": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/nwmatcher/-/nwmatcher-1.4.4.tgz",
-      "integrity": "sha512-3iuY4N5dhgMpCUrOVnuAdGrgxVqV2cJpM+XNccjR2DKOB1RUP0aA+wGXEiNziG/UKboFyGBIoKOaNlJxx8bciQ==",
+    "nwsapi": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.0.0.tgz",
+      "integrity": "sha512-9kj1oCEDNq+LHDAVPGDPg9+qRcBcpXb1IYC8q89jR8xJvOC2byQwEVsM3W1qQcSPVyzGGaXN7wZHnXORCiZl4w==",
       "dev": true
     },
     "o-stream": {
@@ -13011,9 +12957,9 @@
       "integrity": "sha1-sr+C5zUNZcbDOqlaqlpPYyf2HNk="
     },
     "pretty-format": {
-      "version": "22.4.3",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-22.4.3.tgz",
-      "integrity": "sha512-S4oT9/sT6MN7/3COoOy+ZJeA92VmOnveLHgrwBE3Z1W5N9S2A1QGNYiE1z75DAENbJrXXUb+OWXhpJcg05QKQQ==",
+      "version": "23.0.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-23.0.0.tgz",
+      "integrity": "sha1-tm3FhKCQexlpeDxMIOTRGAsYrHU=",
       "dev": true,
       "requires": {
         "ansi-regex": "3.0.0",
@@ -13238,27 +13184,6 @@
             "semver": "5.5.0",
             "xml2js": "0.4.19"
           }
-        }
-      }
-    },
-    "protractor-accessibility-plugin": {
-      "version": "github:cfpb/protractor-accessibility-plugin#7319a881e222d9f3588f6d5d8a3d9848bc38c859",
-      "dev": true,
-      "requires": {
-        "accessibility-developer-tools": "2.12.0",
-        "axe-core": "2.6.1",
-        "axe-webdriverjs": "0.2.0",
-        "html-entities": "1.2.1",
-        "lodash": "3.10.1",
-        "q": "1.5.1",
-        "request": "2.86.0"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "3.10.1",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-          "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
-          "dev": true
         }
       }
     },
@@ -15218,13 +15143,20 @@
       }
     },
     "source-map-support": {
-      "version": "0.5.6",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.6.tgz",
-      "integrity": "sha512-N4KXEz7jcKqPf2b2vZF11lQIz9W5ZMuUcIOGj243lduidkf2fjkVKJS9vNxVWn3u/uxX38AcE8U9nnH9FPcq+g==",
+      "version": "0.4.18",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
+      "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
       "dev": true,
       "requires": {
-        "buffer-from": "1.0.0",
-        "source-map": "0.6.1"
+        "source-map": "0.5.7"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true
+        }
       }
     },
     "source-map-url": {
@@ -16424,13 +16356,13 @@
       "integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
       "dev": true,
       "requires": {
-        "punycode": "2.1.0"
+        "punycode": "2.1.1"
       },
       "dependencies": {
         "punycode": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.0.tgz",
-          "integrity": "sha1-X4Y+3Im5bbCQdLrXlHvwkFbKTn0=",
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+          "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
           "dev": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -65,15 +65,15 @@
     "xdr": "0.5.3"
   },
   "devDependencies": {
-    "babel-jest": "22.4.3",
+    "babel-jest": "23.0.0",
     "chai": "4.1.2",
     "chai-as-promised": "7.1.1",
     "cucumber": "4.2.1",
     "fancy-log": "1.3.2",
     "gulp-eslint": "4.0.1",
     "is-reachable": "2.4.0",
-    "jest": "22.4.3",
-    "jest-cli": "22.4.3",
+    "jest": "23.0.0",
+    "jest-cli": "23.0.0",
     "jsdoc": "3.5.5",
     "localtunnel": "1.9.0",
     "merge-stream": "1.0.1",

--- a/test/unit_tests/apps/financial-well-being/js/fwb-questions-spec.js
+++ b/test/unit_tests/apps/financial-well-being/js/fwb-questions-spec.js
@@ -195,7 +195,7 @@ describe( 'fwb-questions', () => {
       'when a radio button is clicked', () => {
     fwbQuestions.init();
     simulateEvent( 'click', radioButtonsDom[0] );
-    expect( window.dataLayer[0] ).toEqual( dataLayerEventRadio );
+    expect( window.dataLayer[0] ).toStrictEqual( dataLayerEventRadio );
   } );
 
   it( 'should send the correct analytics ' +
@@ -203,6 +203,6 @@ describe( 'fwb-questions', () => {
     fillOutForm();
     fwbQuestions.init();
     simulateEvent( 'click', submitBtnDom );
-    expect( window.dataLayer[0] ).toEqual( dataLayerEventSubmit );
+    expect( window.dataLayer[0] ).toStrictEqual( dataLayerEventSubmit );
   } );
 } );

--- a/test/unit_tests/apps/financial-well-being/js/fwb-results-spec.js
+++ b/test/unit_tests/apps/financial-well-being/js/fwb-results-spec.js
@@ -132,7 +132,7 @@ describe( 'fwb-results', () => {
     () => {
       simulateEvent( 'click', toggleButtons[0] );
 
-      expect( window.dataLayer[0] ).toEqual( dataLayerEvent );
+      expect( window.dataLayer[0] ).toStrictEqual( dataLayerEvent );
     }
   );
 

--- a/test/unit_tests/apps/owning-a-home/js/explore-rates/RateCheckerChartMenu-spec.js
+++ b/test/unit_tests/apps/owning-a-home/js/explore-rates/RateCheckerChartMenu-spec.js
@@ -59,11 +59,11 @@ describe( 'explore-rates/RateCheckerChartMenu', () => {
 
   describe( 'new RateCheckerChartMenu()', () => {
     it( 'should set the state to closed', () => {
-      expect( chartMenu.state ).toEqual( { position: STATES.CLOSED } );
+      expect( chartMenu.state ).toStrictEqual( { position: STATES.CLOSED } );
     } );
 
     it( 'should set a reference to the highcharts instance', () => {
-      expect( highCharts ).toEqual( chartMenu.highCharts );
+      expect( highCharts ).toStrictEqual( chartMenu.highCharts );
     } );
 
     it( 'should set a reference to the base element', () => {
@@ -84,14 +84,14 @@ describe( 'explore-rates/RateCheckerChartMenu', () => {
   describe( 'open()', () => {
     it( 'should set the open state', () => {
       chartMenu.open();
-      expect( chartMenu.state ).toEqual( { position: STATES.OPEN } );
+      expect( chartMenu.state ).toStrictEqual( { position: STATES.OPEN } );
     } );
   } );
 
   describe( 'close()', () => {
     it( 'should set the closed state', () => {
       chartMenu.close();
-      expect( chartMenu.state ).toEqual( { position: STATES.CLOSED } );
+      expect( chartMenu.state ).toStrictEqual( { position: STATES.CLOSED } );
     } );
   } );
 
@@ -99,21 +99,21 @@ describe( 'explore-rates/RateCheckerChartMenu', () => {
     it( 'should set the proper classes on the menu DOM', () => {
       chartMenu.open();
       expect( chartMenuDOM.classList.contains( 'chart-menu__open' ) )
-        .toEqual( true );
+        .toStrictEqual( true );
     } );
   } );
 
   describe( '_setState()', () => {
     it( 'should set the state when passed an object', () => {
       chartMenu._setState( { position: STATES.OPEN } );
-      expect( chartMenu.state ).toEqual( { position: STATES.OPEN } );
+      expect( chartMenu.state ).toStrictEqual( { position: STATES.OPEN } );
     } );
 
     it( 'should maintain the state when an object isn\'t passed', () => {
       chartMenu.open();
-      expect( chartMenu.state ).toEqual( { position: STATES.OPEN } );
+      expect( chartMenu.state ).toStrictEqual( { position: STATES.OPEN } );
       chartMenu._setState();
-      expect( chartMenu.state ).toEqual( { position: STATES.OPEN } );
+      expect( chartMenu.state ).toStrictEqual( { position: STATES.OPEN } );
     } );
   } );
 
@@ -121,17 +121,17 @@ describe( 'explore-rates/RateCheckerChartMenu', () => {
     it( 'should set the proper classes when the menu button is clicked', () => {
       simulateEvent( 'click', chartMenuBtnDOM );
       expect( chartMenuDOM.classList.contains( 'chart-menu__open' ) )
-        .toEqual( true );
+        .toStrictEqual( true );
       simulateEvent( 'click', chartMenuBtnDOM );
       expect( chartMenuDOM.classList.contains( 'chart-menu__open' ) )
-        .toEqual( false );
+        .toStrictEqual( false );
     } );
 
     it( 'should set the proper state when the menu button is clicked', () => {
       simulateEvent( 'click', chartMenuBtnDOM );
-      expect( chartMenu.state ).toEqual( { position: STATES.OPEN } );
+      expect( chartMenu.state ).toStrictEqual( { position: STATES.OPEN } );
       simulateEvent( 'click', chartMenuBtnDOM );
-      expect( chartMenu.state ).toEqual( { position: STATES.CLOSED } );
+      expect( chartMenu.state ).toStrictEqual( { position: STATES.CLOSED } );
     } );
 
     it( 'should call exportChart when a menu export option is clicked', () => {

--- a/test/unit_tests/apps/owning-a-home/js/explore-rates/dom-values-spec.js
+++ b/test/unit_tests/apps/owning-a-home/js/explore-rates/dom-values-spec.js
@@ -22,10 +22,10 @@ describe( 'explore-rates/dom-values', () => {
 
   it( 'should be able to get a value', () => {
     expect( domValues.getSelection( 'not-found-elm' ) ).toBeUndefined();
-    expect( domValues.getSelection( 'location' ) ).toEqual( 'AL' );
-    expect( domValues.getSelection( 'credit-score' ) ).toEqual( 700 );
-    expect( domValues.getSelection( 'arm-type' ) ).toEqual( '3-1' );
-    expect( domValues.getSelection( 'test-price' ) ).toEqual( 300000 );
-    expect( domValues.getSelection( 'house-price' ) ).toEqual( 200000 );
+    expect( domValues.getSelection( 'location' ) ).toStrictEqual( 'AL' );
+    expect( domValues.getSelection( 'credit-score' ) ).toStrictEqual( 700 );
+    expect( domValues.getSelection( 'arm-type' ) ).toStrictEqual( '3-1' );
+    expect( domValues.getSelection( 'test-price' ) ).toStrictEqual( 300000 );
+    expect( domValues.getSelection( 'house-price' ) ).toStrictEqual( 200000 );
   } );
 } );

--- a/test/unit_tests/apps/owning-a-home/js/explore-rates/params-spec.js
+++ b/test/unit_tests/apps/owning-a-home/js/explore-rates/params-spec.js
@@ -80,7 +80,7 @@ describe( 'explore-rates/params', () => {
       'request':        UNDEFINED
     };
     const storedValues = params.getAllParams();
-    expect( storedValues ).toEqual( mockData );
+    expect( storedValues ).toStrictEqual( mockData );
   } );
 
   it( 'should be able to update a value from the HTML', () => {

--- a/test/unit_tests/js/modules/Analytics-spec.js
+++ b/test/unit_tests/js/modules/Analytics-spec.js
@@ -48,7 +48,7 @@ describe( 'Analytics', () => {
       expect( Analytics.tagManagerIsLoaded === false ).toBe( true );
       window['google_tag_manager'] = mockGTMObject;
       expect( Analytics.tagManagerIsLoaded === true ).toBe( true );
-      expect( window.google_tag_manager ).toEqual( mockGTMObject );
+      expect( window.google_tag_manager ).toStrictEqual( mockGTMObject );
     } );
   } );
 
@@ -64,7 +64,7 @@ describe( 'Analytics', () => {
       Analytics.init();
       Analytics.sendEvent( getDataLayerOptions( action, label ) );
       expect( window.dataLayer.length === 1 ).toBe( true );
-      expect( window.dataLayer[0] ).toEqual( options );
+      expect( window.dataLayer[0] ).toStrictEqual( options );
     } );
 
     it( 'shouldn\'t add objects to the dataLayer Array if GTM is undefined',

--- a/test/unit_tests/js/modules/BreakpointHandler-spec.js
+++ b/test/unit_tests/js/modules/BreakpointHandler-spec.js
@@ -49,14 +49,14 @@ describe( 'BreakpointHandler', () => {
   it( 'should allow responsive breakpoints as arguments', () => {
     args.breakpoint = 'bpXS';
     let breakpointHandler = new BreakpointHandler( args );
-    expect( breakpointHandler.breakpoint ).toEqual( 600 );
+    expect( breakpointHandler.breakpoint ).toStrictEqual( 600 );
     expect( breakpointHandler.type === 'max' ).toBe( true );
     expect( breakpointHandler.testBreakpoint( 300 ) ).toBe( true );
 
     args.breakpoint = 'bpSM';
     args.type = 'min';
     breakpointHandler = new BreakpointHandler( args );
-    expect( breakpointHandler.breakpoint ).toEqual( 601 );
+    expect( breakpointHandler.breakpoint ).toStrictEqual( 601 );
     expect( breakpointHandler.type === 'min' ).toBe( true );
     expect( breakpointHandler.testBreakpoint( 601 ) ).toBe( true );
   } );

--- a/test/unit_tests/js/modules/ClearableInput-spec.js
+++ b/test/unit_tests/js/modules/ClearableInput-spec.js
@@ -37,13 +37,13 @@ describe( 'ClearableInput', () => {
   describe( 'init function', () => {
     it( 'should hide the clear button when a value is empty', () => {
       new ClearableInput( baseDom ).init();
-      expect( clearBtnDom.classList.contains( 'u-hidden' ) ).toEqual( true );
+      expect( clearBtnDom.classList.contains( 'u-hidden' ) ).toStrictEqual( true );
     } );
 
     it( 'should display the clear button when a value is present', () => {
       inputDom.value = 'testing init function';
       new ClearableInput( baseDom ).init();
-      expect( clearBtnDom.classList.contains( 'u-hidden' ) ).toEqual( false );
+      expect( clearBtnDom.classList.contains( 'u-hidden' ) ).toStrictEqual( false );
     } );
   } );
 
@@ -51,16 +51,16 @@ describe( 'ClearableInput', () => {
     it( 'should hide itself', () => {
       inputDom.value = 'testing clear button';
       new ClearableInput( baseDom ).init();
-      expect( clearBtnDom.classList.contains( 'u-hidden' ) ).toEqual( false );
+      expect( clearBtnDom.classList.contains( 'u-hidden' ) ).toStrictEqual( false );
       simulateEvent( 'mousedown', clearBtnDom );
-      expect( clearBtnDom.classList.contains( 'u-hidden' ) ).toEqual( true );
+      expect( clearBtnDom.classList.contains( 'u-hidden' ) ).toStrictEqual( true );
     } );
 
     it( 'should clear the input value', () => {
       inputDom.value = 'testing clear button';
       new ClearableInput( baseDom ).init();
       simulateEvent( 'mousedown', clearBtnDom );
-      expect( inputDom.value ).toEqual( '' );
+      expect( inputDom.value ).toStrictEqual( '' );
     } );
   } );
 
@@ -70,7 +70,7 @@ describe( 'ClearableInput', () => {
 
       // Event code 65 is the `a` character.
       simulateEvent( 'keyup', inputDom, { keyCode: 65 } );
-      expect( clearBtnDom.classList.contains( 'u-hidden' ) ).toEqual( false );
+      expect( clearBtnDom.classList.contains( 'u-hidden' ) ).toStrictEqual( false );
     } );
 
     it( 'should hide the clear button, if value not present', () => {
@@ -78,9 +78,9 @@ describe( 'ClearableInput', () => {
 
       // Event code 8 is backspace.
       simulateEvent( 'keyup', inputDom, { keyCode: 65 } );
-      expect( clearBtnDom.classList.contains( 'u-hidden' ) ).toEqual( false );
+      expect( clearBtnDom.classList.contains( 'u-hidden' ) ).toStrictEqual( false );
       simulateEvent( 'keyup', inputDom, { keyCode: 8 } );
-      expect( clearBtnDom.classList.contains( 'u-hidden' ) ).toEqual( true );
+      expect( clearBtnDom.classList.contains( 'u-hidden' ) ).toStrictEqual( true );
     } );
   } );
 

--- a/test/unit_tests/js/modules/Tree-spec.js
+++ b/test/unit_tests/js/modules/Tree-spec.js
@@ -13,7 +13,7 @@ describe( 'Tree', () => {
       expect( tree instanceof Tree ).toBe( true );
       expect( tree.getRoot() ).toBeNull();
       expect( tree.getAllAtLevel( 0 ) instanceof Array ).toBe( true );
-      expect( tree.getAllAtLevel( 0 ).length ).toEqual( 0 );
+      expect( tree.getAllAtLevel( 0 ).length ).toStrictEqual( 0 );
     } );
 
     it( 'should have a proper state after initialization', () => {
@@ -28,11 +28,11 @@ describe( 'Tree', () => {
       tree.init( 'R' );
       expect( tree.getRoot() ).not.toBeNull();
       expect( tree.getRoot().constructor.name === 'TreeNode' ).toBe( true );
-      expect( tree.getRoot().tree ).toEqual( tree );
-      expect( tree.getRoot().data ).toEqual( 'R' );
+      expect( tree.getRoot().tree ).toStrictEqual( tree );
+      expect( tree.getRoot().data ).toStrictEqual( 'R' );
       expect( tree.getRoot().parent ).toBeUndefined();
-      expect( tree.getRoot().children.length ).toEqual( 0 );
-      expect( tree.getRoot().level ).toEqual( 0 );
+      expect( tree.getRoot().children.length ).toStrictEqual( 0 );
+      expect( tree.getRoot().level ).toStrictEqual( 0 );
     } );
   } );
 
@@ -40,7 +40,7 @@ describe( 'Tree', () => {
     it( 'should return the root level', () => {
       tree.init( 'R' );
       const nodeR = tree.getRoot();
-      expect( tree.getAllAtLevel( 0 )[0] ).toEqual( nodeR );
+      expect( tree.getAllAtLevel( 0 )[0] ).toStrictEqual( nodeR );
     } );
 
     /**
@@ -54,9 +54,9 @@ describe( 'Tree', () => {
       const nodeR = tree.getRoot();
       const nodeA = tree.add( 'A', nodeR );
       const nodeB = tree.add( 'B', nodeR );
-      expect( tree.getAllAtLevel( 0 )[0] ).toEqual( nodeR );
-      expect( tree.getAllAtLevel( 1 )[0] ).toEqual( nodeA );
-      expect( tree.getAllAtLevel( 1 )[1] ).toEqual( nodeB );
+      expect( tree.getAllAtLevel( 0 )[0] ).toStrictEqual( nodeR );
+      expect( tree.getAllAtLevel( 1 )[0] ).toStrictEqual( nodeA );
+      expect( tree.getAllAtLevel( 1 )[1] ).toStrictEqual( nodeB );
     } );
 
     /**
@@ -73,10 +73,10 @@ describe( 'Tree', () => {
       const nodeA = tree.add( 'A', nodeR );
       const nodeB = tree.add( 'B', nodeR );
       const nodeC = tree.add( 'C', nodeA );
-      expect( tree.getAllAtLevel( 0 )[0] ).toEqual( nodeR );
-      expect( tree.getAllAtLevel( 1 )[0] ).toEqual( nodeA );
-      expect( tree.getAllAtLevel( 1 )[1] ).toEqual( nodeB );
-      expect( tree.getAllAtLevel( 2 )[0] ).toEqual( nodeC );
+      expect( tree.getAllAtLevel( 0 )[0] ).toStrictEqual( nodeR );
+      expect( tree.getAllAtLevel( 1 )[0] ).toStrictEqual( nodeA );
+      expect( tree.getAllAtLevel( 1 )[1] ).toStrictEqual( nodeB );
+      expect( tree.getAllAtLevel( 2 )[0] ).toStrictEqual( nodeC );
     } );
   } );
 
@@ -87,14 +87,14 @@ describe( 'Tree', () => {
       const nodeA = tree.add( 'A', nodeR );
       expect( nodeA ).not.toBeNull();
       expect( nodeA.constructor.name === 'TreeNode' ).toBe( true );
-      expect( nodeA.tree ).toEqual( tree );
-      expect( nodeA.data ).toEqual( 'A' );
-      expect( nodeA.parent ).toEqual( nodeR );
-      expect( nodeA.children.length ).toEqual( 0 );
-      expect( nodeA.level ).toEqual( 1 );
-      expect( nodeR.children[0] ).toEqual( nodeA );
-      expect( tree.getAllAtLevel( 0 ).length ).toEqual( 1 );
-      expect( tree.getAllAtLevel( 1 ).length ).toEqual( 1 );
+      expect( nodeA.tree ).toStrictEqual( tree );
+      expect( nodeA.data ).toStrictEqual( 'A' );
+      expect( nodeA.parent ).toStrictEqual( nodeR );
+      expect( nodeA.children.length ).toStrictEqual( 0 );
+      expect( nodeA.level ).toStrictEqual( 1 );
+      expect( nodeR.children[0] ).toStrictEqual( nodeA );
+      expect( tree.getAllAtLevel( 0 ).length ).toStrictEqual( 1 );
+      expect( tree.getAllAtLevel( 1 ).length ).toStrictEqual( 1 );
     } );
   } );
 } );

--- a/test/unit_tests/js/modules/behavior/FlyoutMenu-spec.js
+++ b/test/unit_tests/js/modules/behavior/FlyoutMenu-spec.js
@@ -258,9 +258,9 @@ describe( 'FlyoutMenu', () => {
       const transition = new MoveTransition( contentDom ).init();
       flyoutMenu.setExpandTransition( transition, transition.moveLeft );
       flyoutMenu.setCollapseTransition( transition, transition.moveToOrigin );
-      expect( flyoutMenu.getTransition() ).toEqual( transition );
+      expect( flyoutMenu.getTransition() ).toStrictEqual( transition );
       expect( flyoutMenu.getTransition( FlyoutMenu.COLLAPSE_TYPE ) )
-        .toEqual( transition );
+        .toStrictEqual( transition );
     } );
   } );
 
@@ -283,10 +283,10 @@ describe( 'FlyoutMenu', () => {
     it( 'should return references to full dom', () => {
       flyoutMenu.init();
       const dom = flyoutMenu.getDom();
-      expect( dom.container ).toEqual( containerDom );
-      expect( dom.trigger ).toEqual( triggerDom );
-      expect( dom.content ).toEqual( contentDom );
-      expect( dom.altTrigger ).toEqual( altTriggerDom );
+      expect( dom.container ).toStrictEqual( containerDom );
+      expect( dom.trigger ).toStrictEqual( triggerDom );
+      expect( dom.content ).toStrictEqual( contentDom );
+      expect( dom.altTrigger ).toStrictEqual( altTriggerDom );
     } );
   } );
 

--- a/test/unit_tests/js/modules/transition/AlphaTransition-spec.js
+++ b/test/unit_tests/js/modules/transition/AlphaTransition-spec.js
@@ -28,7 +28,7 @@ describe( 'AlphaTransition', () => {
     it( 'should apply u-alpha-100 class', () => {
       transition.fadeIn();
       const classes = 'content-1 u-alpha-transition u-alpha-100';
-      expect( contentDom.className ).toEqual( classes );
+      expect( contentDom.className ).toStrictEqual( classes );
     } );
   } );
 
@@ -40,7 +40,7 @@ describe( 'AlphaTransition', () => {
     it( 'should apply u-alpha-0 class', () => {
       transition.fadeOut();
       const classes = 'content-1 u-alpha-transition u-alpha-0';
-      expect( contentDom.className ).toEqual( classes );
+      expect( contentDom.className ).toStrictEqual( classes );
     } );
   } );
 } );

--- a/test/unit_tests/js/modules/transition/BaseTransition-spec.js
+++ b/test/unit_tests/js/modules/transition/BaseTransition-spec.js
@@ -22,9 +22,9 @@ describe( 'BaseTransition', () => {
 
   describe( '.init()', () => {
     it( 'should have public static methods', () => {
-      expect( BaseTransition.BEGIN_EVENT ).toEqual( 'transitionBegin' );
-      expect( BaseTransition.END_EVENT ).toEqual( 'transitionEnd' );
-      expect( BaseTransition.NO_ANIMATION_CLASS ).toEqual( 'u-no-animation' );
+      expect( BaseTransition.BEGIN_EVENT ).toStrictEqual( 'transitionBegin' );
+      expect( BaseTransition.END_EVENT ).toStrictEqual( 'transitionEnd' );
+      expect( BaseTransition.NO_ANIMATION_CLASS ).toStrictEqual( 'u-no-animation' );
     } );
 
     it( 'should have correct state before initializing', () => {

--- a/test/unit_tests/js/modules/transition/MoveTransition-spec.js
+++ b/test/unit_tests/js/modules/transition/MoveTransition-spec.js
@@ -28,7 +28,7 @@ describe( 'MoveTransition', () => {
     it( 'should apply u-move-to-origin class', () => {
       transition.moveToOrigin();
       const classes = 'content-1 u-move-transition u-move-to-origin';
-      expect( contentDom.className ).toEqual( classes );
+      expect( contentDom.className ).toStrictEqual( classes );
     } );
   } );
 
@@ -40,7 +40,7 @@ describe( 'MoveTransition', () => {
     it( 'should apply u-move-to-origin class', () => {
       transition.moveRight();
       const classes = 'content-1 u-move-transition u-move-right';
-      expect( contentDom.className ).toEqual( classes );
+      expect( contentDom.className ).toStrictEqual( classes );
     } );
   } );
 
@@ -52,7 +52,7 @@ describe( 'MoveTransition', () => {
     it( 'should apply u-move-to-origin class', () => {
       transition.moveUp();
       const classes = 'content-1 u-move-transition u-move-up';
-      expect( contentDom.className ).toEqual( classes );
+      expect( contentDom.className ).toStrictEqual( classes );
     } );
   } );
 
@@ -64,19 +64,19 @@ describe( 'MoveTransition', () => {
     it( 'should apply u-move-left class', () => {
       transition.moveLeft();
       const classes = 'content-1 u-move-transition u-move-left';
-      expect( contentDom.className ).toEqual( classes );
+      expect( contentDom.className ).toStrictEqual( classes );
     } );
 
     it( 'should apply u-move-left-2x class', () => {
       transition.moveLeft( 2 );
       const classes = 'content-1 u-move-transition u-move-left-2x';
-      expect( contentDom.className ).toEqual( classes );
+      expect( contentDom.className ).toStrictEqual( classes );
     } );
 
     it( 'should apply u-move-left-3x class', () => {
       transition.moveLeft( 3 );
       const classes = 'content-1 u-move-transition u-move-left-3x';
-      expect( contentDom.className ).toEqual( classes );
+      expect( contentDom.className ).toStrictEqual( classes );
     } );
 
     it( 'should throw error when move left range is out-of-range', () => {

--- a/test/unit_tests/js/modules/util/array-helpers-spec.js
+++ b/test/unit_tests/js/modules/util/array-helpers-spec.js
@@ -43,7 +43,7 @@ describe( 'array-helpers', () => {
 
       const newArr = arrayHelpers.uniquePrimitives( testArray );
 
-      expect( newArr ).toEqual( testArrayMatch );
+      expect( newArr ).toStrictEqual( testArrayMatch );
     } );
   } );
 } );

--- a/test/unit_tests/js/modules/util/atomic-helpers-spec.js
+++ b/test/unit_tests/js/modules/util/atomic-helpers-spec.js
@@ -43,14 +43,14 @@ describe( 'atomic-helpers', () => {
     it( 'should return the correct HTMLElement when direct element is searched',
       () => {
         const dom = atomicHelpers.checkDom( componentDom, testClass );
-        expect( dom ).toEqual( componentDom );
+        expect( dom ).toStrictEqual( componentDom );
       }
     );
 
     it( 'should return the correct HTMLElement when parent element is searched',
       () => {
         const dom = atomicHelpers.checkDom( containerDom, testClass );
-        expect( dom ).toEqual( componentDom );
+        expect( dom ).toStrictEqual( componentDom );
       }
     );
   } );

--- a/test/unit_tests/js/modules/util/behavior-spec.js
+++ b/test/unit_tests/js/modules/util/behavior-spec.js
@@ -94,14 +94,14 @@ describe( 'behavior', () => {
         'when direct element is searched', () => {
       const dom = behavior.checkBehaviorDom( containerDom,
         'behavior_flyout-menu' );
-      expect( dom ).toEqual( containerDom );
+      expect( dom ).toStrictEqual( containerDom );
     } );
 
     it( 'should return the correct HTMLElement ' +
         'when child element is searched', () => {
       const dom = behavior.checkBehaviorDom( behaviorElmDom,
         'behavior_flyout-menu_content' );
-      expect( dom ).toEqual( behaviorElmDom );
+      expect( dom ).toStrictEqual( behaviorElmDom );
     } );
   } );
 

--- a/test/unit_tests/js/modules/util/js-loader-spec.js
+++ b/test/unit_tests/js/modules/util/js-loader-spec.js
@@ -17,7 +17,7 @@ describe( 'loadScript method', () => {
     } );
 
     return loaderPromise.then( result => {
-      expect( result ).toEqual( 'Callback called' );
+      expect( result ).toStrictEqual( 'Callback called' );
     } );
   } );
 

--- a/test/unit_tests/js/modules/util/tree-traversal-spec.js
+++ b/test/unit_tests/js/modules/util/tree-traversal-spec.js
@@ -40,10 +40,10 @@ describe( 'Tree traversal', () => {
         nodes.push( node );
       } );
 
-      expect( that ).toEqual( treeTraversal );
-      expect( nodes[0] ).toEqual( nodeC );
-      expect( nodes[1] ).toEqual( nodeA );
-      expect( nodes[2] ).toEqual( nodeR );
+      expect( that ).toStrictEqual( treeTraversal );
+      expect( nodes[0] ).toStrictEqual( nodeC );
+      expect( nodes[1] ).toStrictEqual( nodeA );
+      expect( nodes[2] ).toStrictEqual( nodeR );
     } );
   } );
 
@@ -56,13 +56,13 @@ describe( 'Tree traversal', () => {
         nodes.push( node );
       } );
 
-      expect( that ).toEqual( treeTraversal );
-      expect( nodes[0] ).toEqual( nodeR );
-      expect( nodes[1] ).toEqual( nodeA );
-      expect( nodes[2] ).toEqual( nodeB );
-      expect( nodes[3] ).toEqual( nodeC );
-      expect( nodes[4] ).toEqual( nodeD );
-      expect( nodes[5] ).toEqual( nodeE );
+      expect( that ).toStrictEqual( treeTraversal );
+      expect( nodes[0] ).toStrictEqual( nodeR );
+      expect( nodes[1] ).toStrictEqual( nodeA );
+      expect( nodes[2] ).toStrictEqual( nodeB );
+      expect( nodes[3] ).toStrictEqual( nodeC );
+      expect( nodes[4] ).toStrictEqual( nodeD );
+      expect( nodes[5] ).toStrictEqual( nodeE );
     } );
   } );
 
@@ -75,13 +75,13 @@ describe( 'Tree traversal', () => {
         nodes.push( node );
       } );
 
-      expect( that ).toEqual( treeTraversal );
-      expect( nodes[0] ).toEqual( nodeR );
-      expect( nodes[1] ).toEqual( nodeA );
-      expect( nodes[2] ).toEqual( nodeC );
-      expect( nodes[3] ).toEqual( nodeD );
-      expect( nodes[4] ).toEqual( nodeE );
-      expect( nodes[5] ).toEqual( nodeB );
+      expect( that ).toStrictEqual( treeTraversal );
+      expect( nodes[0] ).toStrictEqual( nodeR );
+      expect( nodes[1] ).toStrictEqual( nodeA );
+      expect( nodes[2] ).toStrictEqual( nodeC );
+      expect( nodes[3] ).toStrictEqual( nodeD );
+      expect( nodes[4] ).toStrictEqual( nodeE );
+      expect( nodes[5] ).toStrictEqual( nodeB );
     } );
   } );
 

--- a/test/unit_tests/js/modules/util/validators-spec.js
+++ b/test/unit_tests/js/modules/util/validators-spec.js
@@ -14,7 +14,7 @@ describe( 'Validators', () => {
       testField.value = '11/12/2007';
       returnedObject = validators.date( testField );
 
-      expect( returnedObject ).toEqual( {} );
+      expect( returnedObject ).toStrictEqual( {} );
     } );
 
     it( 'should return an error object for a malformed date', () => {
@@ -43,7 +43,7 @@ describe( 'Validators', () => {
       testField.value = 'test@demo.com';
       returnedObject = validators.email( testField );
 
-      expect( returnedObject ).toEqual( {} );
+      expect( returnedObject ).toStrictEqual( {} );
     } );
 
     it( 'should return an error object for a missing domain', () => {
@@ -73,7 +73,7 @@ describe( 'Validators', () => {
       testField.value = 'testing';
       returnedObject = validators.empty( testField );
 
-      expect( returnedObject ).toEqual( {} );
+      expect( returnedObject ).toStrictEqual( {} );
     } );
 
     it( 'should return an error object for am empty field', () => {
@@ -100,7 +100,7 @@ describe( 'Validators', () => {
       ];
       returnedObject = validators.checkbox( testField, null, fieldset );
 
-      expect( returnedObject ).toEqual( {} );
+      expect( returnedObject ).toStrictEqual( {} );
     } );
 
     it( 'should return an empty object ' +
@@ -112,7 +112,7 @@ describe( 'Validators', () => {
       ];
       returnedObject = validators.checkbox( testField, null, fieldset );
 
-      expect( returnedObject ).toEqual( {} );
+      expect( returnedObject ).toStrictEqual( {} );
     } );
 
     it( 'should return an error object ' +
@@ -135,7 +135,7 @@ describe( 'Validators', () => {
       ];
       returnedObject = validators.checkbox( testField, null, fieldset );
 
-      expect( returnedObject ).toEqual( {} );
+      expect( returnedObject ).toStrictEqual( {} );
     } );
   } );
 
@@ -153,7 +153,7 @@ describe( 'Validators', () => {
       ];
       returnedObject = validators.radio( testField, null, fieldset );
 
-      expect( returnedObject ).toEqual( {} );
+      expect( returnedObject ).toStrictEqual( {} );
     } );
 
     it( 'should return an empty object ' +
@@ -164,7 +164,7 @@ describe( 'Validators', () => {
       ];
       returnedObject = validators.radio( testField, null, fieldset );
 
-      expect( returnedObject ).toEqual( {} );
+      expect( returnedObject ).toStrictEqual( {} );
     } );
 
     it( 'should return an error object ' +
@@ -185,7 +185,7 @@ describe( 'Validators', () => {
       ];
       returnedObject = validators.radio( testField, null, fieldset );
 
-      expect( returnedObject ).toEqual( {} );
+      expect( returnedObject ).toStrictEqual( {} );
     } );
   } );
 } );

--- a/test/unit_tests/js/molecules/Notification-spec.js
+++ b/test/unit_tests/js/molecules/Notification-spec.js
@@ -25,8 +25,8 @@ describe( 'Notification', () => {
   describe( 'init()', () => {
     it( 'should return the Notification instance when initialized', () => {
       thisNotification = notification.init();
-      expect( typeof thisNotification ).toEqual( 'object' );
-      expect( notificationElem.dataset.jsHook ).toEqual( 'state_atomic_init' );
+      expect( typeof thisNotification ).toStrictEqual( 'object' );
+      expect( notificationElem.dataset.jsHook ).toStrictEqual( 'state_atomic_init' );
     } );
 
     it( 'should return undefined if already initialized', () => {
@@ -41,7 +41,7 @@ describe( 'Notification', () => {
 
       notification.init();
 
-      expect( notificationElem.dataset.jsHook ).toEqual( 'state_atomic_init' );
+      expect( notificationElem.dataset.jsHook ).toStrictEqual( 'state_atomic_init' );
     } );
 
     it( 'should return the Notification istance if it has a warning class', () => {
@@ -50,7 +50,7 @@ describe( 'Notification', () => {
 
       notification.init();
 
-      expect( notificationElem.dataset.jsHook ).toEqual( 'state_atomic_init' );
+      expect( notificationElem.dataset.jsHook ).toStrictEqual( 'state_atomic_init' );
     } );
 
     it( 'should return the Notification istance if it has a error class', () => {
@@ -59,7 +59,7 @@ describe( 'Notification', () => {
 
       notification.init();
 
-      expect( notificationElem.dataset.jsHook ).toEqual( 'state_atomic_init' );
+      expect( notificationElem.dataset.jsHook ).toStrictEqual( 'state_atomic_init' );
     } );
   } );
 

--- a/test/unit_tests/js/organisms/EmailPopup-spec.js
+++ b/test/unit_tests/js/organisms/EmailPopup-spec.js
@@ -66,7 +66,7 @@ describe( 'EmailPopup', () => {
   describe( 'getDom()', () => {
     it( 'should return the base element', () => {
       const baseElement = document.querySelector( '.o-email-popup' );
-      expect( baseElement ).toEqual( emailPopup.getDom() );
+      expect( baseElement ).toStrictEqual( emailPopup.getDom() );
     } );
   } );
 

--- a/test/unit_tests/js/organisms/FormSubmit-spec.js
+++ b/test/unit_tests/js/organisms/FormSubmit-spec.js
@@ -67,8 +67,8 @@ describe( 'FormSubmit', () => {
 
   describe( 'init()', () => {
     it( 'should return the FormSubmit instance when initialized', () => {
-      expect( typeof thisFormSubmit ).toEqual( 'object' );
-      expect( signupForm.dataset.jsHook ).toEqual( 'state_atomic_init' );
+      expect( typeof thisFormSubmit ).toStrictEqual( 'object' );
+      expect( signupForm.dataset.jsHook ).toStrictEqual( 'state_atomic_init' );
     } );
 
     it( 'should return undefined if already initialized', () => {

--- a/test/unit_tests/js/organisms/MortgagePerformanceTrends/actions/default-spec.js
+++ b/test/unit_tests/js/organisms/MortgagePerformanceTrends/actions/default-spec.js
@@ -20,7 +20,7 @@ describe( 'Mortgage Performance default action creators', () => {
 
   it( 'should create an action to set a geo', () => {
     const action = actions.setGeo( 12345, 'Alabama', 'state' );
-    expect( action ).toEqual( {
+    expect( action ).toStrictEqual( {
       type: 'SET_GEO',
       geo: {
         type: 'state',
@@ -32,14 +32,14 @@ describe( 'Mortgage Performance default action creators', () => {
 
   it( 'should create an action to clear geos', () => {
     const action = actions.clearGeo();
-    expect( action ).toEqual( {
+    expect( action ).toStrictEqual( {
       type: 'CLEAR_GEO'
     } );
   } );
 
   it( 'should create actions to update charts', () => {
     let action = actions.updateChart( 12345, 'Alabama', 'state', false );
-    expect( action ).toEqual( {
+    expect( action ).toStrictEqual( {
       type: 'UPDATE_CHART',
       geo: {
         type: 'state',
@@ -49,7 +49,7 @@ describe( 'Mortgage Performance default action creators', () => {
       includeComparison: false
     } );
     action = actions.updateChart( null, null, null, false );
-    expect( action ).toEqual( {
+    expect( action ).toStrictEqual( {
       type: 'UPDATE_CHART',
       geo: {
         id: null,
@@ -61,7 +61,7 @@ describe( 'Mortgage Performance default action creators', () => {
 
   it( 'should create an action to update the national comparison', () => {
     const action = actions.updateNational( false );
-    expect( action ).toEqual( {
+    expect( action ).toStrictEqual( {
       type: 'UPDATE_CHART',
       includeComparison: false
     } );
@@ -69,7 +69,7 @@ describe( 'Mortgage Performance default action creators', () => {
 
   it( 'should create an action to update the date', () => {
     const action = actions.updateDate( '2010-01' );
-    expect( action ).toEqual( {
+    expect( action ).toStrictEqual( {
       type: 'UPDATE_DATE',
       date: '2010-01'
     } );
@@ -77,7 +77,7 @@ describe( 'Mortgage Performance default action creators', () => {
 
   it( 'should create an action to request counties', () => {
     const action = actions.requestCounties();
-    expect( action ).toEqual( {
+    expect( action ).toStrictEqual( {
       type: 'REQUEST_COUNTIES',
       isLoadingCounties: true
     } );
@@ -85,7 +85,7 @@ describe( 'Mortgage Performance default action creators', () => {
 
   it( 'should create an action to request metros', () => {
     const action = actions.requestMetros();
-    expect( action ).toEqual( {
+    expect( action ).toStrictEqual( {
       type: 'REQUEST_METROS',
       isLoadingMetros: true
     } );
@@ -93,7 +93,7 @@ describe( 'Mortgage Performance default action creators', () => {
 
   it( 'should create an action to request non-metros', () => {
     const action = actions.requestNonMetros();
-    expect( action ).toEqual( {
+    expect( action ).toStrictEqual( {
       type: 'REQUEST_NON_METROS',
       isLoadingNonMetros: true
     } );
@@ -113,7 +113,7 @@ describe( 'Mortgage Performance default action creators', () => {
 
   it( 'should create an action to set metros', () => {
     const action = actions.setMetros( [ { name: 'Akron, OH' } ] );
-    expect( action ).toEqual( {
+    expect( action ).toStrictEqual( {
       type: 'SET_METROS',
       metros: [ { name: 'Akron, OH' } ]
     } );
@@ -121,7 +121,7 @@ describe( 'Mortgage Performance default action creators', () => {
 
   it( 'should create an action to set non-metros', () => {
     const action = actions.setNonMetros( [ { name: 'Tampa, FL' } ] );
-    expect( action ).toEqual( {
+    expect( action ).toStrictEqual( {
       type: 'SET_NON_METROS',
       nonMetros: [ { name: 'Tampa, FL' } ]
     } );
@@ -129,7 +129,7 @@ describe( 'Mortgage Performance default action creators', () => {
 
   it( 'should create an action to set counties', () => {
     const action = actions.setCounties( [ { name: 'Acme County' } ] );
-    expect( action ).toEqual( {
+    expect( action ).toStrictEqual( {
       type: 'SET_COUNTIES',
       counties: [ { name: 'Acme County' } ]
     } );
@@ -137,7 +137,7 @@ describe( 'Mortgage Performance default action creators', () => {
 
   it( 'should create an action to start loading', () => {
     const action = actions.startLoading();
-    expect( action ).toEqual( {
+    expect( action ).toStrictEqual( {
       type: 'START_LOADING',
       isLoading: true
     } );
@@ -145,7 +145,7 @@ describe( 'Mortgage Performance default action creators', () => {
 
   it( 'should create an action to stop loading', () => {
     const action = actions.stopLoading();
-    expect( action ).toEqual( {
+    expect( action ).toStrictEqual( {
       type: 'STOP_LOADING',
       isLoading: false
     } );

--- a/test/unit_tests/js/organisms/MortgagePerformanceTrends/actions/map-spec.js
+++ b/test/unit_tests/js/organisms/MortgagePerformanceTrends/actions/map-spec.js
@@ -38,7 +38,7 @@ describe( 'Mortgage Performance map action creators', () => {
 
   it( 'should create an action to update the chart', () => {
     const action = actions.updateChart( 123, 'Alabama', 'state' );
-    expect( action ).toEqual( {
+    expect( action ).toStrictEqual( {
       type: 'UPDATE_CHART',
       geo: {
         id: 123,
@@ -50,7 +50,7 @@ describe( 'Mortgage Performance map action creators', () => {
 
   it( 'should create an action without a geo type', () => {
     const action = actions.updateChart( 123, 'Alabama' );
-    expect( action ).toEqual( {
+    expect( action ).toStrictEqual( {
       type: 'UPDATE_CHART',
       geo: {
         id: 123,
@@ -61,7 +61,7 @@ describe( 'Mortgage Performance map action creators', () => {
 
   it( 'should create an action without a geoId', () => {
     const action = actions.updateChart( null, null );
-    expect( action ).toEqual( {
+    expect( action ).toStrictEqual( {
       type: 'UPDATE_CHART',
       geo: {
         id: null,

--- a/test/unit_tests/js/organisms/MortgagePerformanceTrends/stores/chart-spec.js
+++ b/test/unit_tests/js/organisms/MortgagePerformanceTrends/stores/chart-spec.js
@@ -29,7 +29,7 @@ describe( 'Mortgage Performance line chart store', () => {
       states: {}
     };
 
-    expect( store.getState() ).toEqual( mockData );
+    expect( store.getState() ).toStrictEqual( mockData );
   } );
 
   it( 'should be able to add subscribers', () => {
@@ -44,7 +44,7 @@ describe( 'Mortgage Performance line chart store', () => {
   } );
 
   it( 'should default to having an empty previous state', () => {
-    expect( store.prevState ).toEqual( {} );
+    expect( store.prevState ).toStrictEqual( {} );
   } );
 
   it( 'should default to comparing national data', () => {
@@ -61,9 +61,9 @@ describe( 'Mortgage Performance line chart store', () => {
       }
     };
     store.dispatch( action );
-    expect( store.getState().geo.type ).toEqual( 'county' );
-    expect( store.getState().geo.id ).toEqual( 12345 );
-    expect( store.getState().geo.name ).toEqual( 'Acme County' );
+    expect( store.getState().geo.type ).toStrictEqual( 'county' );
+    expect( store.getState().geo.id ).toStrictEqual( 12345 );
+    expect( store.getState().geo.name ).toStrictEqual( 'Acme County' );
   } );
 
   it( 'should properly clear geos', () => {
@@ -146,7 +146,7 @@ describe( 'Mortgage Performance line chart store', () => {
       metros: { 12345: 'Akron, OH' }
     };
     store.dispatch( action );
-    expect( store.getState().metros ).toEqual( { 12345: 'Akron, OH' } );
+    expect( store.getState().metros ).toStrictEqual( { 12345: 'Akron, OH' } );
   } );
 
   it( 'should properly reduce non-metros', () => {
@@ -155,7 +155,7 @@ describe( 'Mortgage Performance line chart store', () => {
       nonMetros: { 67890: 'Boston, MA' }
     };
     store.dispatch( action );
-    expect( store.getState().nonMetros ).toEqual( { 67890: 'Boston, MA' } );
+    expect( store.getState().nonMetros ).toStrictEqual( { 67890: 'Boston, MA' } );
   } );
 
   it( 'should properly reduce counties', () => {
@@ -164,7 +164,7 @@ describe( 'Mortgage Performance line chart store', () => {
       counties: { 12345: 'Acme County' }
     };
     store.dispatch( action );
-    expect( store.getState().counties ).toEqual( { 12345: 'Acme County' } );
+    expect( store.getState().counties ).toStrictEqual( { 12345: 'Acme County' } );
   } );
 
   it( 'should properly reduce u.s. states', () => {
@@ -173,19 +173,19 @@ describe( 'Mortgage Performance line chart store', () => {
       states: { AL: 'Alabama' }
     };
     store.dispatch( action );
-    expect( store.getState().states ).toEqual( { AL: 'Alabama' } );
+    expect( store.getState().states ).toStrictEqual( { AL: 'Alabama' } );
     action = {
       type: 'FETCH_STATES',
       states: { CA: 'California' }
     };
     store.dispatch( action );
-    expect( store.getState().states ).toEqual( { AL: 'Alabama' } );
+    expect( store.getState().states ).toStrictEqual( { AL: 'Alabama' } );
     action = {
       type: 'SET_STATES',
       states: { CA: 'California' }
     };
     store.dispatch( action );
-    expect( store.getState().states ).toEqual( { CA: 'California' } );
+    expect( store.getState().states ).toStrictEqual( { CA: 'California' } );
   } );
 
   it( 'should properly reduce national comparison', () => {

--- a/test/unit_tests/js/organisms/MortgagePerformanceTrends/stores/map-spec.js
+++ b/test/unit_tests/js/organisms/MortgagePerformanceTrends/stores/map-spec.js
@@ -15,7 +15,9 @@ describe( 'Mortgage Performance map store', () => {
   } );
 
   it( 'should inherit helper methods', () => {
+    let UNDEFINED;
     const mockData = {
+      date: UNDEFINED,
       geo: { type: 'state', id: null, name: null },
       isLoadingMetros: false,
       isLoadingCounties: false,
@@ -25,7 +27,7 @@ describe( 'Mortgage Performance map store', () => {
       metros: []
     };
 
-    expect( store.getState() ).toEqual( mockData );
+    expect( store.getState() ).toStrictEqual( mockData );
   } );
 
   it( 'should be able to add subscribers', () => {
@@ -43,7 +45,7 @@ describe( 'Mortgage Performance map store', () => {
   } );
 
   it( 'should default to having an empty previous state', () => {
-    expect( store.prevState ).toEqual( {} );
+    expect( store.prevState ).toStrictEqual( {} );
   } );
 
   it( 'should properly clear geos', () => {
@@ -108,7 +110,7 @@ describe( 'Mortgage Performance map store', () => {
       metros: { 12345: 'Akron, OH' }
     };
     store.dispatch( action );
-    expect( store.getState().metros ).toEqual( { 12345: 'Akron, OH' } );
+    expect( store.getState().metros ).toStrictEqual( { 12345: 'Akron, OH' } );
     action = {
       type: 'UPDATE_CHART',
       geo: {
@@ -119,7 +121,7 @@ describe( 'Mortgage Performance map store', () => {
       metros: { 67890: 'Boston, MA' }
     };
     store.dispatch( action );
-    expect( store.getState().metros ).toEqual( { 67890: 'Boston, MA' } );
+    expect( store.getState().metros ).toStrictEqual( { 67890: 'Boston, MA' } );
   } );
 
   it( 'should properly reduce counties', () => {
@@ -128,7 +130,7 @@ describe( 'Mortgage Performance map store', () => {
       counties: { 12345: 'Acme County' }
     };
     store.dispatch( action );
-    expect( store.getState().counties ).toEqual( { 12345: 'Acme County' } );
+    expect( store.getState().counties ).toStrictEqual( { 12345: 'Acme County' } );
     action = {
       type: 'UPDATE_CHART',
       geo: {
@@ -140,7 +142,7 @@ describe( 'Mortgage Performance map store', () => {
     };
     store.dispatch( action );
     expect( store.getState().counties )
-      .toEqual( { 67890: 'Some other county' } );
+      .toStrictEqual( { 67890: 'Some other county' } );
   } );
 
   it( 'should properly chart zooming', () => {

--- a/test/unit_tests/js/organisms/MortgagePerformanceTrends/utils-spec.js
+++ b/test/unit_tests/js/organisms/MortgagePerformanceTrends/utils-spec.js
@@ -51,22 +51,22 @@ describe( 'Mortgage Performance utilities', () => {
 
   it( 'should get metro data', () => {
     const cb = jest.fn();
-    expect( utils.getMetroData( cb ) ).toEqual( { mock: 'data' } );
+    expect( utils.getMetroData( cb ) ).toStrictEqual( { mock: 'data' } );
   } );
 
   it( 'should get non-metro data', () => {
     const cb = jest.fn();
-    expect( utils.getNonMetroData( cb ) ).toEqual( { mock: 'data' } );
+    expect( utils.getNonMetroData( cb ) ).toStrictEqual( { mock: 'data' } );
   } );
 
   it( 'should get county data', () => {
     const cb = jest.fn();
-    expect( utils.getCountyData( cb ) ).toEqual( { mock: 'data' } );
+    expect( utils.getCountyData( cb ) ).toStrictEqual( { mock: 'data' } );
   } );
 
   it( 'should get state data', () => {
     const cb = jest.fn();
-    expect( utils.getStateData( cb ) ).toEqual( { mock: 'data' } );
+    expect( utils.getStateData( cb ) ).toStrictEqual( { mock: 'data' } );
   } );
 
   it( 'should be able to calculate zoom levels', () => {


### PR DESCRIPTION
Updates Jest to utilize`toStrictEquals`. See https://facebook.github.io/jest/docs/en/expect.html#tostrictequalvalue

## Changes

- Update `babel-jest` to `23.0.0`.
- Update `jest` to `23.0.0`.
- Update `jest-cli` to `23.0.0`.
- Convert `toEquals` to `toStrictEquals`.
- Adds "date" field to mock data object in map-spec "should inherit helper methods" test.

## Testing

1. `npm install && gulp test:unit` should pass.
