### PR TITLE
Regulations 3000: Add Markdown table extension

### DIFF
--- a/cfgov/regulations3k/regdown.py
+++ b/cfgov/regulations3k/regdown.py
@@ -214,6 +214,7 @@ def regdown(text, **kwargs):
     return markdown(
         text,
         extensions=[
+            'markdown.extensions.tables',
             RegulationsExtension(**kwargs)
         ],
         **kwargs

--- a/cfgov/regulations3k/tests/test_regdown.py
+++ b/cfgov/regulations3k/tests/test_regdown.py
@@ -173,6 +173,17 @@ class RegulationsExtensionTestCase(unittest.TestCase):
         self.assertIn('<h1>§FooBar</h1>',
                       regdown(text, contents_resolver=contents_resolver))
 
+    def test_tables_extension_exists(self):
+        text = (
+            'First Header  | Second Header\n'
+            '------------- | -------------\n'
+            'Content Cell  | Content Cell\n'
+            'Content Cell  | Content Cell\n'
+        )
+        self.assertIn('<table>', regdown(text))
+        self.assertIn('<th>First Header</th>', regdown(text))
+        self.assertIn('<td>Content Cell</td>', regdown(text))
+
 
 class RegdownUtilsTestCase(unittest.TestCase):
 


### PR DESCRIPTION
This PR adds the official Python-Markdown table extension to the `regdown()` convenience function's extension list with our `RegulationsExtension`. This enables tables when using `regdown()` to convert Regdown text to HTML.

Leaving this out was probably an oversight, since tables [don't actually exist in the Markdown spec](https://daringfireball.net/projects/markdown/syntax). With this in mind, there may be [other official Python-Markdown extensions](https://python-markdown.github.io/extensions/#officially-supported-extensions) that we might want to enable.

## Additions

- `markdown.extensions.tables` to `regdown()`

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: