### PR TITLE
Fix for svg checkmark on es answer pages

### DIFF
--- a/cfgov/legacy/static/knowledgebase/less/es-ask-styles.less
+++ b/cfgov/legacy/static/knowledgebase/less/es-ask-styles.less
@@ -5,4 +5,6 @@
 
 @import "vars.less";
 @import "grid.less";
+@import "../../../../../node_modules/cf-core/src/cf-brand-colors.less";
+@import "notification.less";
 @import "es-ask-base.less";

--- a/cfgov/legacy/static/knowledgebase/less/notification.less
+++ b/cfgov/legacy/static/knowledgebase/less/notification.less
@@ -1,0 +1,103 @@
+/* ==========================================================================
+   Capital Framework
+   Notifications Styling
+   ========================================================================== */
+
+//
+// Theme variables
+//
+
+// Color variables
+
+@base-font-size-px:      16px;
+@notification-bg:             @gray-10;
+@notification-bg-success:     @green-20;
+@notification-bg-warning:     @gold-20;
+@notification-bg-error:       @red-20;
+
+@notification-border:         @gray-40;
+@notification-border-success: @green;
+@notification-border-warning: @gold;
+@notification-border-error:   @red;
+
+@notification-icon:           @gray;
+@notification-icon-success:   @green;
+@notification-icon-warning:   @gold;
+@notification-icon-error:     @red;
+
+// Sizing variables
+
+@notification-padding__px:    15px;
+
+.m-notification {
+   display: none;
+   position: relative;
+
+   padding: @notification-padding__px;
+
+   background: @notification-bg;
+   border: 1px solid @notification-border;
+
+   .cf-icon-svg {
+      position: absolute;
+      top: @notification-padding__px;
+      left: @notification-padding__px;
+      font-size: unit( 18px / 16px, em );
+      float: left;
+      fill: @notification-icon;
+   }
+
+   &__success {
+      background: @notification-bg-success;
+      border-color: @notification-border-success;
+
+      .cf-icon-svg {
+         fill: @notification-icon-success;
+      }
+   }
+
+   &__warning {
+       background: @notification-bg-warning;
+       border-color: @notification-border-warning;
+
+      .cf-icon-svg {
+         fill: @notification-icon-warning;
+      }
+   }
+
+   &__error {
+       background: @notification-bg-error;
+       border-color: @notification-border-error;
+
+      .cf-icon-svg {
+         fill: @notification-icon-error;
+      }
+   }
+
+   &__visible {
+       display: block;
+   }
+
+   // Only adding left padding if an icon is present.
+   .cf-icon-svg + &_content {
+       padding-left: 25px;
+   }
+
+   &_message {
+     margin-bottom: 0;
+   }
+
+   &_explanation {
+       font-size: 1em;
+       // This is necessary because the standard markup pattern uses an h4
+       // class for, presumably, just sizing.
+       // TODO: Refactor standard markup pattern to stop using h4 classes.
+       font-weight: normal;
+       margin-top: unit( 5px / @base-font-size-px, em );
+       margin-bottom: 0;
+
+       a {
+           border-bottom-width: 1px;
+       }
+   }
+}

--- a/cfgov/legacy/static/knowledgebase/less/notification.less
+++ b/cfgov/legacy/static/knowledgebase/less/notification.less
@@ -3,13 +3,12 @@
    Notifications Styling
    ========================================================================== */
 
-//
 // Theme variables
-//
+
+@base-font-size-px:           @16px;
 
 // Color variables
 
-@base-font-size-px:      16px;
 @notification-bg:             @gray-10;
 @notification-bg-success:     @green-20;
 @notification-bg-warning:     @gold-20;


### PR DESCRIPTION
Fix for svg checkmark on es answer pages

## Changes

- Modified code to fix issue with svg on es-ask pages. I had to minimize some of the imports because they were affecting the layout on some es pages. I included the color vars from cf but not cf-notification, because cf-notification includes cf-core. 

## Testing

1. Visit `http://localhost:8000/es/obtener-respuestas/como-puedo-encontrar-a-un-abogado-que-me-represente-ante-la-demanda-de-un-acreedor-o-cobrador-es-1433/` and compare to production.

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Internet Explorer 8, 9, 10, and 11
- [ ] Edge
- [ ] iOS Safari
- [ ] Chrome for Android

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
