### PR TITLE
Remove extra production build steps from frontend.sh

### DIFF
--- a/frontend.sh
+++ b/frontend.sh
@@ -100,14 +100,6 @@ clean_and_install() {
 build() {
   echo "Building project…"
   gulp build
-
-  if [ "$cli_flag" = "production" ]; then
-    echo "Running additional build steps for on-demand and Nemo assets."
-    gulp scripts:ondemand
-    gulp styles:ondemand
-    gulp scripts:nemo
-    gulp styles:nemo
-  fi
 }
 
 # Execute requested (or all) functions.


### PR DESCRIPTION
These are all now run in the default [`gulp scripts`](https://github.com/cfpb/cfgov-refresh/blob/rm-prod-gulp-tasks/gulp/tasks/scripts.js#L264-L266) and [`gulp styles`](https://github.com/cfpb/cfgov-refresh/blob/rm-prod-gulp-tasks/gulp/tasks/styles.js#L297-L298) tasks.

## Removals

- Extra build steps for `ondemand` and `nemo` stuff in production in `frontend.sh`

## Testing

🤷‍♂️ I suppose we wait to see it get merged and deployed onto Build?


## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: