### PR TITLE
Add support for pseudo-form __ syntax to Regdown

### DIFF
--- a/cfgov/regulations3k/regdown.py
+++ b/cfgov/regulations3k/regdown.py
@@ -80,7 +80,7 @@ STRONG_EM_RE = r'(\*)\2{2}(.+?)\2{2}(.*?)\2'
 # Form field: __
 # __Form Field
 # inline__fields__
-PSEUDO_FORM_RE = r'(?P<underscores>_{2,50})(?P<line-ending>\s*$)?'
+PSEUDO_FORM_RE = r'(?P<underscores>_{2,50})(?P<line_ending>\s*$)?'
 
 
 class RegulationsExtension(Extension):
@@ -150,7 +150,7 @@ class PseudoFormPattern(Pattern):
 
     def handleMatch(self, m):
         el = util.etree.Element('span')
-        if m.group('line-ending') is not None:
+        if m.group('line_ending') is not None:
             el.set('class', 'regdown-form-extend')
         else:
             el.set('class', 'regdown-form')

--- a/cfgov/regulations3k/regdown.py
+++ b/cfgov/regulations3k/regdown.py
@@ -80,7 +80,7 @@ STRONG_EM_RE = r'(\*)\2{2}(.+?)\2{2}(.*?)\2'
 # Form field: __
 # __Form Field
 # inline__fields__
-PSEUDO_FORM_RE = r'(?P<underscores>_{2,50})'
+PSEUDO_FORM_RE = r'(?P<underscores>_{2,50})(?P<line-ending>\s*$)?'
 
 
 class RegulationsExtension(Extension):
@@ -106,8 +106,8 @@ class RegulationsExtension(Extension):
     def extendMarkdown(self, md, md_globals):
         md.registerExtension(self)
 
-        # Add inline pseudo form pattern. Replaace all inlinePatterns that
-        # include an underscore with emphasis patterns without underscores.
+        # Add inline pseudo form pattern. Replace all inlinePatterns that
+        # include an underscore with patterns that do not include underscores.
         md.inlinePatterns['em_strong'] = DoubleTagPattern(
             EM_STRONG_RE, 'strong,em'
         )
@@ -150,7 +150,10 @@ class PseudoFormPattern(Pattern):
 
     def handleMatch(self, m):
         el = util.etree.Element('span')
-        el.set('class', 'pseudo-form')
+        if m.group('line-ending') is not None:
+            el.set('class', 'regdown-form-extend')
+        else:
+            el.set('class', 'regdown-form')
         el.text = m.group('underscores')
         return el
 

--- a/cfgov/regulations3k/regdown.py
+++ b/cfgov/regulations3k/regdown.py
@@ -8,6 +8,7 @@ These features include:
 
 - Labeled paragraphs
 - Block references
+- Inline pseudo forms
 
 ## Labeled Paragraphs
 
@@ -39,6 +40,15 @@ Callbacks:
 - `render_block_reference(contents, url=None)`: render the contents of a block
   reference to HTML. The url to the reference may be give as a keyword argument
   if `url_resolver` is provided.
+
+## Pseudo Forms
+
+`Form field: __`
+`__Form Field`
+`inline__fields__
+
+Example print forms, where the `__` indicate a space for hand-written input.
+Can be any number of underscores between 2 and 50.
 """
 from __future__ import unicode_literals
 
@@ -47,6 +57,7 @@ import re
 from markdown import markdown, util
 from markdown.blockprocessors import BlockProcessor, ParagraphProcessor
 from markdown.extensions import Extension
+from markdown.inlinepatterns import DoubleTagPattern, Pattern, SimpleTagPattern
 
 
 # If we're on Python 3.6+ we have SHA3 built-in, otherwise use the back-ported
@@ -55,6 +66,21 @@ try:
     from hashlib import sha3_224
 except ImportError:
     from sha3 import sha3_224
+
+
+# **strong**
+STRONG_RE = r'(\*{2})(.+?)\2'
+
+# ***strongem*** or ***em*strong**
+EM_STRONG_RE = r'(\*)\2{2}(.+?)\2(.*?)\2{2}'
+
+# ***strong**em*
+STRONG_EM_RE = r'(\*)\2{2}(.+?)\2{2}(.*?)\2'
+
+# Form field: __
+# __Form Field
+# inline__fields__
+PSEUDO_FORM_RE = r'(?P<underscores>_{2,50})'
 
 
 class RegulationsExtension(Extension):
@@ -80,6 +106,22 @@ class RegulationsExtension(Extension):
     def extendMarkdown(self, md, md_globals):
         md.registerExtension(self)
 
+        # Add inline pseudo form pattern. Replaace all inlinePatterns that
+        # include an underscore with emphasis patterns without underscores.
+        md.inlinePatterns['em_strong'] = DoubleTagPattern(
+            EM_STRONG_RE, 'strong,em'
+        )
+        md.inlinePatterns['strong_em'] = DoubleTagPattern(
+            STRONG_EM_RE, 'em,strong'
+        )
+        md.inlinePatterns['strong'] = SimpleTagPattern(
+            STRONG_RE, 'strong'
+        )
+        md.inlinePatterns['pseudo-form'] = PseudoFormPattern(
+            PSEUDO_FORM_RE
+        )
+        del md.inlinePatterns['emphasis2']
+
         # Add block reference processor for `see(label)` syntax
         md.parser.blockprocessors.add(
             'blockreference',
@@ -100,6 +142,17 @@ class RegulationsExtension(Extension):
 
         # Delete the ordered list processor
         del md.parser.blockprocessors['olist']
+
+
+class PseudoFormPattern(Pattern):
+    """ Return a <span class="pseudo-form"></span> element for matches of the
+    given pseudo-form pattern. """
+
+    def handleMatch(self, m):
+        el = util.etree.Element('span')
+        el.set('class', 'pseudo-form')
+        el.text = m.group('underscores')
+        return el
 
 
 class LabeledParagraphProcessor(ParagraphProcessor):
@@ -124,6 +177,7 @@ class LabeledParagraphProcessor(ParagraphProcessor):
             label, text = match.group('label'), match.group('text')
             p = util.etree.SubElement(parent, 'p')
             p.set('id', label)
+
             # We use CSS classes to indent paragraph text. To get the correct
             # class, we count the number of dashes in the label to determine
             # how deeply nested the paragraph is. Inline interps have special
@@ -131,6 +185,7 @@ class LabeledParagraphProcessor(ParagraphProcessor):
             # e.g. 6-a-Interp-1 becomes -1 and gets a `level-1` class
             # e.g. 12-b-Interp-2-i becomes -2-i and gets a `level-2` class
             label = re.sub('^\w+\-\w+\-interp', '', label, flags=re.IGNORECASE)
+
             # Appendices also have special prefixes that need to be stripped.
             # e.g. A-1-a becomes a and gets a `level-0` class
             # e.g. A-2-d-1 becomes d-1 and gets a `level-1` class
@@ -138,6 +193,7 @@ class LabeledParagraphProcessor(ParagraphProcessor):
             level = label.count('-')
             class_name = 'level-{}'.format(level)
             p.set('class', class_name)
+
             p.text = text.lstrip()
 
         elif block.strip():

--- a/cfgov/regulations3k/tests/test_regdown.py
+++ b/cfgov/regulations3k/tests/test_regdown.py
@@ -184,6 +184,39 @@ class RegulationsExtensionTestCase(unittest.TestCase):
         self.assertIn('<th>First Header</th>', regdown(text))
         self.assertIn('<td>Content Cell</td>', regdown(text))
 
+    def test_no_underscore_emphasis(self):
+        self.assertIn('<em>foo</em>', regdown('*foo*'))
+        self.assertIn('<strong>foo</strong>', regdown('**foo**'))
+        self.assertIn('<strong><em>foo</em></strong>', regdown('***foo***'))
+        self.assertNotIn('<em>foo</em>', regdown('_foo_'))
+        self.assertNotIn('<strong>foo</strong>', regdown('__foo__'))
+        self.assertNotIn('<strong><em>foo</em></strong>', regdown('___foo___'))
+
+    def test_pseudo_form_field_end_of_line(self):
+        text = 'Form field: ___'
+        self.assertIn('Form field: <span class="pseudo-form">___</span>',
+                      regdown(text))
+
+    def test_pseudo_form_field_start_of_line(self):
+        text = '__Form Field'
+        self.assertIn('<span class="pseudo-form">__</span>Form Field',
+                      regdown(text))
+
+    def test_pseudo_form_field_inside_line(self):
+        text = 'inline______fields______within paragraph'
+        self.assertIn(
+            'inline<span class="pseudo-form">______</span>'
+            'fields<span class="pseudo-form">______</span>'
+            'within paragraph',
+            regdown(text)
+        )
+
+    def test_pseudo_form_field_number_of_underscores(self):
+        self.assertIn('<span class="pseudo-form">__</span>',
+                      regdown('Field: __'))
+        self.assertIn('<span class="pseudo-form">_______</span>',
+                      regdown('Field: _______'))
+
 
 class RegdownUtilsTestCase(unittest.TestCase):
 

--- a/cfgov/regulations3k/tests/test_regdown.py
+++ b/cfgov/regulations3k/tests/test_regdown.py
@@ -194,27 +194,28 @@ class RegulationsExtensionTestCase(unittest.TestCase):
 
     def test_pseudo_form_field_end_of_line(self):
         text = 'Form field: ___'
-        self.assertIn('Form field: <span class="pseudo-form">___</span>',
+        self.assertIn('Form field: '
+                      '<span class="regdown-form-extend">___</span>',
                       regdown(text))
 
     def test_pseudo_form_field_start_of_line(self):
         text = '__Form Field'
-        self.assertIn('<span class="pseudo-form">__</span>Form Field',
+        self.assertIn('<span class="regdown-form">__</span>Form Field',
                       regdown(text))
 
     def test_pseudo_form_field_inside_line(self):
         text = 'inline______fields______within paragraph'
         self.assertIn(
-            'inline<span class="pseudo-form">______</span>'
-            'fields<span class="pseudo-form">______</span>'
+            'inline<span class="regdown-form">______</span>'
+            'fields<span class="regdown-form">______</span>'
             'within paragraph',
             regdown(text)
         )
 
     def test_pseudo_form_field_number_of_underscores(self):
-        self.assertIn('<span class="pseudo-form">__</span>',
+        self.assertIn('<span class="regdown-form-extend">__</span>',
                       regdown('Field: __'))
-        self.assertIn('<span class="pseudo-form">_______</span>',
+        self.assertIn('<span class="regdown-form-extend">_______</span>',
                       regdown('Field: _______'))
 
 


### PR DESCRIPTION
This adds `__` syntax to Regdown for pseudo-forms, sample forms that exist in the regulation text.

It currently outputs `Date: <span class="pseudo-form">__</span>` for `Date: __` in Regdown. Any number of `_` from 2 to 50 is supported. It supports `__` form entries at the beginning of paragraphs, inline in paragraphs, and at the end of paragraphs. It preserves the number of underscores and outputs them within the `span` element (because sometimes a specific number of underscores is part of the regulation text

This also removes standard Markdown support for using underscores for emphasis by replacing the regulation expressions for those inline patterns with ones that do not contain underscores. Asterisk emphasis syntax is preserved.

@contolini There's currently no styling for the pseudo-form class, and I'm not sure I particularly like the class name either.

## Additions

- `__` syntax for pseudo-forms to Regdown

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Internet Explorer 8, 9, 10, and 11
- [ ] Edge
- [ ] iOS Safari
- [ ] Chrome for Android

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
