### PR TITLE
Workaround to restore Wagtail S3 file overwriting

### DIFF
--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -393,15 +393,18 @@ ELASTICSEARCH_DEFAULT_ANALYZER = 'snowball'
 # S3 Configuration
 AWS_QUERYSTRING_AUTH = False  # do not add auth-related query params to URL
 AWS_S3_CALLING_FORMAT = 'boto.s3.connection.OrdinaryCallingFormat'
-AWS_S3_ROOT = os.environ.get('AWS_S3_ROOT', 'f')
+AWS_S3_ROOT = 'f'
 AWS_S3_SECURE_URLS = True  # True = use https; False = use http
 AWS_STORAGE_BUCKET_NAME = os.environ.get('AWS_STORAGE_BUCKET_NAME')
+AWS_LOCATION = AWS_S3_ROOT
 
-if os.environ.get('S3_ENABLED', 'False') == 'True':
-    DEFAULT_FILE_STORAGE = 'v1.s3utils.MediaRootS3BotoStorage'
-    AWS_S3_ACCESS_KEY_ID = os.environ.get('AWS_S3_ACCESS_KEY_ID')
-    AWS_S3_SECRET_ACCESS_KEY = os.environ.get('AWS_S3_SECRET_ACCESS_KEY')
-    MEDIA_URL = os.path.join(os.environ.get('AWS_S3_URL'), AWS_S3_ROOT, '')
+if os.getenv('S3_ENABLED'):
+    DEFAULT_FILE_STORAGE = 'v1.storage.OverwritingS3Storage'
+    AWS_S3_ACCESS_KEY_ID = os.environ['AWS_S3_ACCESS_KEY_ID']
+    AWS_S3_SECRET_ACCESS_KEY = os.environ['AWS_S3_SECRET_ACCESS_KEY']
+
+    AWS_S3_URL = os.environ['AWS_S3_URL']
+    MEDIA_URL = os.path.join(AWS_S3_URL, AWS_S3_ROOT, '')
 
 # Govdelivery
 GOVDELIVERY_ACCOUNT_CODE = os.environ.get('GOVDELIVERY_ACCOUNT_CODE')

--- a/cfgov/cfgov/settings/test.py
+++ b/cfgov/cfgov/settings/test.py
@@ -49,3 +49,7 @@ STATICFILES_DIRS += [
 MOCK_STATICFILES_PATTERNS = {
     'icons/*.svg': 'icons/placeholder.svg',
 }
+
+AWS_STORAGE_BUCKET_NAME = 'test_s3_bucket'
+AWS_S3_ACCESS_KEY_ID = 'test_s3_access_key_id'
+AWS_S3_SECRET_ACCESS_KEY = 'test_s3_secret_access_key'

--- a/cfgov/v1/s3utils.py
+++ b/cfgov/v1/s3utils.py
@@ -1,11 +1,4 @@
-"""Custom S3 storage backends to store files in subfolders."""
-
 from django.conf import settings
-
-
-def MediaRootS3BotoStorage():
-    from storages.backends.s3boto import S3BotoStorage
-    return S3BotoStorage(location=settings.AWS_S3_ROOT)
 
 
 def get_s3_url_prefix(https):

--- a/cfgov/v1/storage.py
+++ b/cfgov/v1/storage.py
@@ -1,0 +1,120 @@
+import inspect
+
+from storages.backends.s3boto import S3BotoStorage
+
+
+class WagtailOverwritingStorageMixin(object):
+    """Django storage mixin to support file overwriting in Wagtail 1.13+.
+
+    The Django storage backend convention is that if a file is uploaded to a
+    storage backend with the same name as another file already stored on that
+    backend, the new file's name will be changed:
+
+    https://docs.djangoproject.com/en/2.0/ref/files/storage/#django.core.files.storage.Storage.get_available_name
+
+    Specifically, the new file will have random characters appended to its
+    filename (for example, a second upload of "test.txt" would become something
+    like "test_abcdefg.txt").
+
+    The convention is that typically storage backends will not support
+    deliberate overwriting of files that they store. However, there are some
+    backends that can support this behavior; for example if users desire to
+    maintain a consistent relationship between source filename and filename
+    in storage.
+
+    Wagtail 1.13 included changes that broke support for backends with this
+    overwriting behavior for both documents and images:
+
+    https://github.com/wagtail/wagtail/pull/3821
+    https://github.com/wagtail/wagtail/pull/3822
+
+    The goal of these changes was to clean up old document/image files after
+    the user uploads a new one. Consider an existing document uploaded from
+    some filename "test.txt"; the source file was "test.txt" and the file on
+    the storage backend will be "test.txt". If a user uses the Wagtail UI to
+    replace the document's file with a new file "test2.txt", the change in
+    1.13 tries to clean up the old file by deleting "test.txt" from the storage
+    backend after "test2.txt" has been stored.
+
+    The Wagtail logic looks roughly like this:
+
+        - user uploads a new file for an existing document/image
+        - store the new file to the storage backend
+        - delete the document/image's old file from the storage backend
+
+    This logic is sound as long as it is safe to assume that new uploads with
+    identical filenames never overwrite each other and always get assigned a
+    unique filename when stored. However, as described above, this may not
+    always be the case.
+
+    If, instead, files get overwritten, then the final delete that happens
+    will in fact delete the new file that's just been stored.
+
+    This mixin attempts to prevent this from happening. It uses the Python
+    stack inspect capability to identify if a delete call is being invoked
+    from the Wagtail document/image edit views, and, if so, skips that delete.
+    """
+    def delete(self, name):
+        stack = inspect.stack()
+
+        if self._should_skip_wagtail_delete(stack):
+            return
+
+        super(WagtailOverwritingStorageMixin, self).delete(name)
+
+    def _should_skip_wagtail_delete(self, stack):
+        """Given a call stack, determine whether delete should be skipped."""
+
+        # See Python inspect documentation for structure of stack object:
+        # https://docs.python.org/2/library/inspect.html#the-interpreter-stack
+        caller_frame_record = stack[1]
+        caller_frame_object = caller_frame_record[0]
+        caller_frame_function_name = caller_frame_record[3]
+
+        caller_module = inspect.getmodule(caller_frame_object)
+        caller_module_name = caller_module.__name__
+
+        called_from = caller_module_name + '.' + caller_frame_function_name
+
+        # Only skip delete if it is being called by the wagtaildocs.edit or
+        # wagtailimages.edit views. We want deletes called from other places
+        # to work as expected.
+        skip_for_these_callers = (
+            'wagtail.wagtaildocs.views.documents.edit',
+            'wagtail.wagtailimages.views.images.edit',
+        )
+
+        if called_from not in skip_for_these_callers:
+            return
+
+        # We know this delete is being called from by specific Wagtail views of
+        # interest. Grab the variables from the stack that contain the filename
+        # of the document/image being replaced and the filename of the new
+        # document/image with which it is being replaced.
+        original_file = caller_frame_object.f_locals['original_file']
+        doc = caller_frame_object.f_locals['doc']
+
+        # If these two filenames are the same, we don't want to go ahead with
+        # the delete, because that will remove the new file that's just been
+        # provided to replace the old file.
+        #
+        # If these two filenames are different, we should go ahead with the
+        # deletion, because the intended Wagtail behavior is to clean up
+        # the old file that is being replaced.
+        return original_file.name == doc.file.name
+
+
+class OverwritingS3Storage(WagtailOverwritingStorageMixin, S3BotoStorage):
+    """Boto-based S3 Django storage that supports overwriting from Wagtail.
+
+    Based on the django-storages boto-based storage backend defined here:
+
+    https://github.com/jschneier/django-storages
+
+    This storage has a default setting AWS_S3_FILE_OVERWRITE=True that
+    overwrites existing files when files with the same name are uploaded.
+
+    This class adds v1.storage.WagtailOverwritingStorageMixin to support
+    that use case when using this storage in Wagtail 1.13+.
+    """
+    pass

--- a/cfgov/v1/tests/test_meta_image.py
+++ b/cfgov/v1/tests/test_meta_image.py
@@ -100,14 +100,7 @@ class TestMetaImage(TestCase):
         self.check_template_meta_image_url(expected_root="http://localhost")
 
     @override_settings(
-        AWS_QUERYSTRING_AUTH=False,
-        AWS_S3_ACCESS_KEY_ID='test',
-        AWS_S3_CALLING_FORMAT='boto.s3.connection.OrdinaryCallingFormat',
-        AWS_S3_ROOT='root',
-        AWS_S3_SECRET_ACCESS_KEY='test',
-        AWS_S3_SECURE_URLS=True,
-        AWS_STORAGE_BUCKET_NAME='test_s3_bucket',
-        DEFAULT_FILE_STORAGE='v1.s3utils.MediaRootS3BotoStorage'
+        DEFAULT_FILE_STORAGE='storages.backends.s3boto.S3BotoStorage'
     )
     def test_template_image_image_url_s3(self):
         """Meta image links should work if using S3 storage."""

--- a/cfgov/v1/tests/test_s3utils.py
+++ b/cfgov/v1/tests/test_s3utils.py
@@ -7,21 +7,13 @@ from wagtail.wagtailimages.tests.utils import get_test_image_file
 
 import boto
 import moto
+from storages.backends.s3boto import S3BotoStorage
 
-from v1.s3utils import (
-    MediaRootS3BotoStorage, http_s3_url_prefix, https_s3_url_prefix
-)
+from v1.s3utils import http_s3_url_prefix, https_s3_url_prefix
 
 
 @override_settings(
-    AWS_QUERYSTRING_AUTH=False,
-    AWS_S3_ACCESS_KEY_ID='test',
-    AWS_S3_CALLING_FORMAT='boto.s3.connection.OrdinaryCallingFormat',
-    AWS_S3_ROOT='root',
-    AWS_S3_SECRET_ACCESS_KEY='test',
-    AWS_S3_SECURE_URLS=True,
-    AWS_STORAGE_BUCKET_NAME='test_s3_bucket',
-    DEFAULT_FILE_STORAGE='v1.s3utils.MediaRootS3BotoStorage'
+    DEFAULT_FILE_STORAGE='storages.backends.s3boto.S3BotoStorage'
 )
 class S3UtilsTestCase(TestCase):
     def setUp(self):
@@ -40,12 +32,12 @@ class S3UtilsTestCase(TestCase):
 
         self.assertEqual(
             image.file.url,
-            'https://s3.amazonaws.com/test_s3_bucket/root/test.png'
+            'https://s3.amazonaws.com/test_s3_bucket/f/test.png'
         )
 
     def test_storage_location_uses_settings(self):
-        storage = MediaRootS3BotoStorage()
-        self.assertEqual(storage.location, 'root')
+        storage = S3BotoStorage()
+        self.assertEqual(storage.location, 'f')
 
     def test_storage_writes_to_s3(self):
         f = ContentFile('content')
@@ -53,7 +45,7 @@ class S3UtilsTestCase(TestCase):
         Storage().save('content.txt', f)
 
         bucket = self.s3.get_bucket('test_s3_bucket')
-        key = bucket.get_key('root/content.txt')
+        key = bucket.get_key('f/content.txt')
         self.assertEqual(key.get_contents_as_string(), 'content')
 
 

--- a/cfgov/v1/tests/test_storage.py
+++ b/cfgov/v1/tests/test_storage.py
@@ -1,0 +1,75 @@
+from unittest import TestCase
+
+from django.conf import settings
+from django.core.files.uploadedfile import SimpleUploadedFile
+from django.core.urlresolvers import reverse
+from django.test import TestCase, override_settings
+
+from wagtail.tests.utils import WagtailTestUtils
+from wagtail.wagtaildocs.models import Document
+
+import boto
+import moto
+
+from v1.storage import OverwritingS3Storage
+
+
+@override_settings(
+    DEFAULT_FILE_STORAGE='v1.storage.OverwritingS3Storage'
+)
+class TestOverwritingS3Storage(TestCase, WagtailTestUtils):
+    def setUp(self):
+        self.login()
+
+        mock_s3 = moto.mock_s3_deprecated()
+        mock_s3.start()
+        self.addCleanup(mock_s3.stop)
+
+        self.s3 = boto.connect_s3()
+        self.s3.create_bucket(settings.AWS_STORAGE_BUCKET_NAME)
+
+    def test_replace_deletes_old_file(self):
+        f = SimpleUploadedFile('test.txt', 'Original')
+        doc = Document.objects.create(title='Test document', file=f)
+
+        storage = doc.file.storage
+        old_storage_filename = doc.file.name
+       
+        self.client.post(
+            reverse('wagtaildocs:edit', args=(doc.pk,)),
+            {
+                'title': 'Different file',
+                'file': SimpleUploadedFile('test2.txt', 'Different'),
+            }
+        )
+
+        doc.refresh_from_db()
+        self.assertTrue(storage.exists(doc.file.name))
+        self.assertFalse(storage.exists(old_storage_filename))
+
+    def test_overwrite_file(self):
+        f = SimpleUploadedFile('test.txt', 'Original')
+        doc = Document.objects.create(title='Test document', file=f)
+
+        self.client.post(
+            reverse('wagtaildocs:edit', args=(doc.pk,)),
+            {
+                'title': 'Overwritten',
+                'file': SimpleUploadedFile('test.txt', 'Overwritten'),
+            }
+        )
+
+        doc.refresh_from_db()
+        stored_content = doc.file.storage.open(doc.file.name).read()
+        self.assertEqual(stored_content, 'Overwritten')
+
+    def test_delete_file_works_properly(self):
+        f = SimpleUploadedFile('test.txt', 'Original')
+        doc = Document.objects.create(title='Test document', file=f)
+
+        self.client.post(
+            reverse('wagtaildocs:delete', args=(doc.pk,)),
+        )
+
+        with self.assertRaises(Document.DoesNotExist):
+            doc.refresh_from_db()

--- a/cfgov/v1/tests/views/test_documents.py
+++ b/cfgov/v1/tests/views/test_documents.py
@@ -31,14 +31,8 @@ class ServeViewTestCase(TestCase):
             p.assert_called_once_with(self.request, doc.pk, filename)
 
     @override_settings(
-        AWS_QUERYSTRING_AUTH=False,
-        AWS_STORAGE_BUCKET_NAME='test_s3_bucket',
-        AWS_S3_CALLING_FORMAT='boto.s3.connection.OrdinaryCallingFormat',
-        AWS_S3_SECURE_URLS=True,
-        DEFAULT_FILE_STORAGE='v1.s3utils.MediaRootS3BotoStorage',
+        DEFAULT_FILE_STORAGE='storages.backends.s3boto.S3BotoStorage',
         MEDIA_URL='https://test.s3.amazonaws.com/f/',
-        AWS_S3_ACCESS_KEY_ID='test-access-key',
-        AWS_S3_SECRET_ACCESS_KEY='test-secret-access-key'
     )
     def test_document_serve_view_s3(self):
         filename = 'test.txt'


### PR DESCRIPTION
(See cfgov/v1/storage.py for a very lengthy comment that explains the need for this commit in great detail.)

Wagtail 1.13 introduced some behavior that broke support for Django file storage systems that overwrite saved files that have the same name, for example the django-storages S3 backend we use with the default `AWS_S3_FILE_OVERWRITE=True`.

This commit adds an admittedly very hacky workaround to restore support for this behavior in Wagtail 1.13+. It's not pretty, but it works.

I've opened a PR to Wagtail to restore this behavior the right way at https://github.com/wagtail/wagtail/pull/4567; this code in cfgov-refresh would only be necessary until that is merged in, assuming it is at some point. The unit tests in this commit are copied from that PR.

This change should fix GHE#2750. @Scotchester and I colllaborated on this work.

This commit also includes some minor refactoring and simplification of how S3-related settings are set, to make unit testing easier.

## Testing

To test this from a development environment you need to set the appropriate environment variables to run locally while using S3: `S3_ENABLED`, `AWS_S3_ACCESS_KEY_ID`, `AWS_S3_SECRET_ACCESS_KEY`, `AWS_S3_URL`. Once those are set, you should be able to run a local Wagtail server and upload documents/image to S3. You should then be able to test overwriting files by, say, creating a document and then re-uploading a different file that has the same filename.

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [X] Passes all existing automated tests
- [X] Any _change_ in functionality is tested
- [X] New functions are documented (with a description, list of inputs, and expected output)
- [X] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [X] Project documentation has been updated
- [X] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: