### PR TITLE
 Hide empty regdown paragraphs

### DIFF
--- a/cfgov/regulations3k/regdown.py
+++ b/cfgov/regulations3k/regdown.py
@@ -178,8 +178,12 @@ class LabeledParagraphProcessor(ParagraphProcessor):
             # the paragraph tag, label id, and initial text, then process the
             # rest of the blocks normally.
             label, text = match.group('label'), match.group('text')
-            p = util.etree.SubElement(parent, 'p')
-            p.set('id', label)
+            # Labeled paragraphs without text should use a div element
+            if text == '':
+                el = util.etree.SubElement(parent, 'div')
+            else:
+                el = util.etree.SubElement(parent, 'p')
+            el.set('id', label)
 
             # We use CSS classes to indent paragraph text. To get the correct
             # class, we count the number of dashes in the label to determine
@@ -195,9 +199,9 @@ class LabeledParagraphProcessor(ParagraphProcessor):
             label = re.sub('^[A-Z]\d?\-\w+\-?', '', label)
             level = label.count('-')
             class_name = 'level-{}'.format(level)
-            p.set('class', class_name)
+            el.set('class', class_name)
 
-            p.text = text.lstrip()
+            el.text = text.lstrip()
 
         elif block.strip():
             if self.parser.state.isstate('list'):

--- a/cfgov/regulations3k/regdown.py
+++ b/cfgov/regulations3k/regdown.py
@@ -191,7 +191,7 @@ class LabeledParagraphProcessor(ParagraphProcessor):
             # prefixes that are removed before counting the dashes.
             # e.g. 6-a-Interp-1 becomes -1 and gets a `level-1` class
             # e.g. 12-b-Interp-2-i becomes -2-i and gets a `level-2` class
-            label = re.sub('^\w+\-\w+\-interp', '', label, flags=re.IGNORECASE)
+            label = re.sub('^(\w+\-)+interp', '', label, flags=re.IGNORECASE)
 
             # Appendices also have special prefixes that need to be stripped.
             # e.g. A-1-a becomes a and gets a `level-0` class

--- a/cfgov/regulations3k/tests/test_regdown.py
+++ b/cfgov/regulations3k/tests/test_regdown.py
@@ -38,7 +38,7 @@ class RegulationsExtensionTestCase(unittest.TestCase):
         text = '{my-label}\n\nThis is a paragraph with a label.'
         self.assertEqual(
             regdown(text),
-            '<p class="level-1" id="my-label"></p>\n'
+            '<div class="level-1" id="my-label"></div>\n'
             '<p id="725445113243d57f132b6408fa8583122d2641e591a9001f04fcde08">'
             'This is a paragraph with a label.</p>'
         )
@@ -73,6 +73,18 @@ class RegulationsExtensionTestCase(unittest.TestCase):
             regdown(text),
             '<p class="level-5" id="12-d-Interp-7-ii-c-A-7">'
             'This is a paragraph with a label.</p>'
+        )
+
+    def test_empty_inline_interp_label(self):
+        text = (
+            '{30-Interp-1}\n'
+            '1. Applicability\n\n'
+            '{30-b-Interp}\n'
+            '#### 30(b) Business Day'
+        )
+        self.assertIn(
+            '<div class="level-0" id="30-b-Interp"></div>',
+            regdown(text)
         )
 
     def test_appendix_label(self):

--- a/cfgov/regulations3k/tests/test_regdown.py
+++ b/cfgov/regulations3k/tests/test_regdown.py
@@ -75,6 +75,20 @@ class RegulationsExtensionTestCase(unittest.TestCase):
             'This is a paragraph with a label.</p>'
         )
 
+    def test_prefixed_inline_interp_label(self):
+        text = '{31-a-1-Interp-1}\nThis is a paragraph with a label.'
+        text2 = '{31-a-1-i-Interp-1}\nThis is a paragraph with a label.'
+        self.assertEqual(
+            regdown(text),
+            '<p class="level-1" id="31-a-1-Interp-1">'
+            'This is a paragraph with a label.</p>'
+        )
+        self.assertEqual(
+            regdown(text2),
+            '<p class="level-1" id="31-a-1-i-Interp-1">'
+            'This is a paragraph with a label.</p>'
+        )
+
     def test_empty_inline_interp_label(self):
         text = (
             '{30-Interp-1}\n'


### PR DESCRIPTION
Inline interps have an erroneous margin at the top caused by the presence of an empty paragraph element.

<img width="1169" alt="caff6f7a-5dc2-11e8-93d4-bf9ec59bbf7b" src="https://user-images.githubusercontent.com/1060248/40705687-8db8f24c-63b9-11e8-84d8-a6d14c2e9efe.png">

The empty paragraph comes from opening interp labels in the regdown.

<img width="782" alt="7aeceb3c-5dc4-11e8-92d4-92b894c3793c" src="https://user-images.githubusercontent.com/1060248/40705697-942ed678-63b9-11e8-95ec-3f03663f2f31.png">

I was originally thinking we should remove empty paragraphs but in retrospect we want to keep the IDs so that users can jump to those sections on the page. By replacing empty paragraphs with divs they naturally disappear from view but remain linkable.

Unrelated: I tweaked the inline interp pattern to support longer label prefixes (`12-b-1-Interp-2` instead of just `12-b-Interp-2`).

## Changes

- Empty regdown paragraphs are now divs instead of paragraphs.
- Inline interps can have longer prefixes.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
