### PR TITLE
Mega menu: Add aria attributes to menu footer links

### DIFF
--- a/cfgov/jinja2/v1/_includes/organisms/_vars-mega-menu.html
+++ b/cfgov/jinja2/v1/_includes/organisms/_vars-mega-menu.html
@@ -43,7 +43,7 @@
                 'replaces four disclosure forms with two new ones. ' +
                 'We have resources to help you comply.',
     }
-    
+
 } %}
 
 {% set consumer_tools_content = {
@@ -200,9 +200,25 @@
     'footer': {
         'type': 'footer',
         'value': {
-            'content': 
-                '<p>Browse answers to hundreds of financial questions. <a href="/ask-cfpb/">Ask CFPB</a></p>
-                <p>Have an issue with a financial product? <a href="/complaint/">Submit a complaint</a></p>',
+            'content':
+                '<p>
+                    <span aria-hidden="true">
+                        Browse answers to hundreds of financial questions.
+                    </span>
+                    <a aria-label="Ask CFPB: browse answers to hundreds of financial questions."
+                       href="/ask-cfpb/">
+                       Ask CFPB
+                    </a>
+                </p>
+                <p>
+                    <span aria-hidden="true">
+                        Have an issue with a financial product?
+                    </span>
+                    <a aria-label="Have an issue with a financial product? Submit a complaint."
+                       href="/complaint/">
+                       Submit a complaint
+                    </a>
+                </p>',
         }
     },
     'nav_groups': [
@@ -366,7 +382,7 @@
                 }},
           ]
       }
-    
+
   } %}
   {% set data_research_group_three = {
       'type': 'nav_group',
@@ -508,7 +524,7 @@
                     'external_link': '/policy-compliance/guidance/'
                 },
                 'nav_groups': [{
-                    'value': { 
+                    'value': {
                         'nav_items': [
                             {'link':{
                                 'link_text': 'Implementation & Guidance',
@@ -691,7 +707,7 @@
                         ]
                     }
                 }]
-        
+
             },
             {'link':{
                 'link_text': 'Doing Business With Us',

--- a/cfgov/jinja2/v1/_includes/organisms/_vars-mega-menu.html
+++ b/cfgov/jinja2/v1/_includes/organisms/_vars-mega-menu.html
@@ -205,7 +205,7 @@
                     <span aria-hidden="true">
                         Browse answers to hundreds of financial questions.
                     </span>
-                    <a aria-label="Ask CFPB: browse answers to hundreds of financial questions."
+                    <a aria-label="Browse answers to hundreds of financial questions with Ask CFPB."
                        href="/ask-cfpb/">
                        Ask CFPB
                     </a>


### PR DESCRIPTION
## Changes

- Adds aria- attributes to menu footer links.

## Testing

1. Pull down branch.
2. Visit the site locally.
3. `Cmd`+`F5` to start VoiceOver
4. Tab through to Consumer Tools (scrolling down slightly and clicking "Consumer Tools" and then tabbing from there may be the easiest)
5. `Enter` to open Consumer Tools
6. Tab to `Ask CFPB` and listen that it reads a complete sentence.
7. Tab to `Submit a complaint` and listen that it also reads a complete sentence.

## Note

- With the move to Mega Menu in Wagtail, the `_vars-mega-menu.html` template is deprecated, so we'll need a solution that works in Wagtail, but the changes here can be used as a reference for what's needed in Wagtail.