### PR TITLE
Mega menu: fix for hard-coded fmc images

### DIFF
--- a/cfgov/jinja2/v1/_includes/molecules/featured-menu-content.html
+++ b/cfgov/jinja2/v1/_includes/molecules/featured-menu-content.html
@@ -28,8 +28,11 @@
 {% macro render( value ) %}
 {% if value.image and value.image.upload %}
     {% set featured_image = image(value.image.upload, 'width-270') %}
+    {% set img_src = featured_image.url if featured_image.url else '' %}
 {% else %}
     {% set featured_image = value.image %}
+    {% set img_src = static(featured_image.url) if featured_image.url else '' %}
+
 {% endif %}
 {% if value.link %}
     {% set link = value.link %}
@@ -39,8 +42,8 @@
 
 <aside class="m-featured-menu-content">
     <a class="m-featured-menu-content_link" href="{{ link_url }}">
-        {% if featured_image and featured_image.url %}
-        <img src="{{ featured_image.url }}"
+        {% if img_src %}
+        <img src="{{ img_src }}"
              alt=""
              height="150"
              width="270">


### PR DESCRIPTION
Use correct urls for featured menu content images in hard-coded mega menu version

## Changes

- Use static filter with hard-coded featured menu content image urls

## Testing

1. Check out branch
2. Verify that images show in the mega menu's featured menu items


## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Internet Explorer 8, 9, 10, and 11
- [ ] Edge
- [ ] iOS Safari
- [ ] Chrome for Android

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
