### PR TITLE
regs3k: Make subpart section_range available in admin

### DIFF
--- a/cfgov/regulations3k/migrations/0005_subpart_section_range.py
+++ b/cfgov/regulations3k/migrations/0005_subpart_section_range.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('regulations3k', '0004_add_acquired_and_draft_to_effectiveversion'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='subpart',
+            name='section_range',
+            field=models.TextField(null=True, blank=True),
+        ),
+    ]

--- a/cfgov/regulations3k/models/django.py
+++ b/cfgov/regulations3k/models/django.py
@@ -110,6 +110,7 @@ class Subpart(models.Model):
     label = models.CharField(max_length=255, blank=True)
     title = models.CharField(max_length=255, blank=True)
     version = models.ForeignKey(EffectiveVersion, related_name="subparts")
+    section_range = models.TextField(blank=True, null=True)
 
     panels = [
         FieldPanel('label'),
@@ -121,13 +122,16 @@ class Subpart(models.Model):
         return "{} {}, effective {}".format(
             self.label, self.title, self.version.effective_date)
 
+    def save(self, *args, **kwargs):
+            self.section_range = self.get_section_range()
+            super(Subpart, self).save(*args, **kwargs)
+
     @property
     def subpart_heading(self):
         """Keeping for now as possible hook into secondary nav"""
         return ''
 
-    @property
-    def section_range(self):
+    def get_section_range(self):
         if not self.sections.exists():
             return ''
         if 'Interp' in self.label:

--- a/cfgov/regulations3k/tests/test_models.py
+++ b/cfgov/regulations3k/tests/test_models.py
@@ -194,6 +194,7 @@ class RegModelTests(DjangoTestCase):
         self.assertIn('some contents', result)
 
     def test_section_ranges(self):
+        self.subpart.save()
         self.assertEqual(self.subpart_orphan.section_range, '')
         self.assertEqual(self.subpart_appendices.section_range, '')
         self.assertEqual(self.subpart_interps.section_range, '')

--- a/cfgov/regulations3k/wagtail_hooks.py
+++ b/cfgov/regulations3k/wagtail_hooks.py
@@ -24,6 +24,7 @@ class SubpartModelAdmin(TreeModelAdmin):
     menu_icon = 'list-ul'
     list_display = (
         'title',
+        'section_range',
     )
     child_field = 'sections'
     child_model_admin = SectionModelAdmin


### PR DESCRIPTION
Subparts in the admin tree currently display only subpart title, which 
isn't helpful if you want to edit a particular section of a large reg.

This PR elevates the Subpart's `section_range` value from a property to a
model field that gets populated when a subpart is saved. As a model field, 
we can display it in the admin:


<img width="1251" alt="section_ranges" src="https://user-images.githubusercontent.com/515885/40783949-0dd0d122-64b2-11e8-9aea-2e01704affd5.png">

## Testing
This PR includes a table migration, so you'll need to update your local db with `migrate`

```
./cfgov/manage.py migrate --noinput
```

Then populate the new field by saving all subparts:

```
./cfgov/manage.py shell
from regulations3k.models import Subpart
for each in Subpart.objects.all():
    each.save()
```

The subpart ranges should show up in your regulations admin.


