### PR TITLE
Hotfix to repair img height and margin on extant Media blocks

### DIFF
--- a/cfgov/unprocessed/css/organisms/full-width-text-group.less
+++ b/cfgov/unprocessed/css/organisms/full-width-text-group.less
@@ -24,6 +24,18 @@
 .o-full-width-text-group {
     overflow: auto;
 
+    /**
+     * Fix for Wagtail's default img markup that includes height attribute
+     * and for loss of margin on extant Media block images.
+     * TODO: Remove once data migration from Media to ContentImage is complete
+     */
+
+    > img {
+        height: auto;
+        margin-bottom: unit( @grid_gutter-width / @base-font-size-px, em );
+    }
+
+
       .m-inset {
           margin-bottom: unit( @grid_gutter-width / @base-font-size-px, em );
 


### PR DESCRIPTION
Deprecation of some Media block code caused images in those blocks to be vertically stretched and lose their margin. This temporary fix will restore that until we can complete a data migration to move Media block images to the new unified ContentImage block.

## Additions

- CSS to fix Media images

## Testing

1. With a recent database dump, go to http://localhost:8000/admin/pages/11594/edit/ and replace the image with one from your computer that is significantly wider than 770px.
1. Preview the page and notice that the image is stretched vertically.
1. `gulp styles`
1. Refresh the preview and see the image back to normal height, with 30px margin under it.


## Todos

- Write data migration to move data from Media to ContentImage (not in this PR)

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [x] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [x] Chrome
- [x] Firefox
- [x] Safari
- [ ] Internet Explorer 8, 9, 10, and 11
- [ ] Edge
- [x] iOS Safari
- [ ] Chrome for Android

### Other

- [ ] Is useable without CSS
- [x] Is useable without JS
- [x] Flexible from small to large screens
- [x] No linting errors or warnings
- [x] JavaScript tests are passing
