### PR TITLE
Add regulations3k to first-party imports and re-sort imports

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -18,6 +18,7 @@ known_first_party=
     jobmanager,
     legacy
     processors,
+    regulations3k,
     search,
     sheerlike,
     transition_utilities,

--- a/cfgov/regulations3k/jinja2tags.py
+++ b/cfgov/regulations3k/jinja2tags.py
@@ -6,6 +6,7 @@ from wagtail.contrib.wagtailroutablepage.templatetags.wagtailroutablepage_tags i
 import jinja2
 from jinja2.ext import Extension
 from jinja2.filters import do_mark_safe
+
 from regulations3k.regdown import regdown as regdown_func
 
 

--- a/cfgov/regulations3k/models/pages.py
+++ b/cfgov/regulations3k/models/pages.py
@@ -15,13 +15,12 @@ from wagtail.wagtailadmin.edit_handlers import (
 from wagtail.wagtailcore.fields import StreamField
 from wagtail.wagtailcore.models import PageManager
 
-from regulations3k.models import Part, Section, sortable_label  # , Subpart
-from regulations3k.regdown import regdown
-from regulations3k.resolver import get_contents_resolver, get_url_resolver
-
 # Our RegDownTextField field doesn't generate a good widget yet
 # from regulations3k.models.fields import RegDownTextField
 from ask_cfpb.models.pages import SecondaryNavigationJSMixin
+from regulations3k.models import Part, Section, sortable_label  # , Subpart
+from regulations3k.regdown import regdown
+from regulations3k.resolver import get_contents_resolver, get_url_resolver
 from v1.atomic_elements import molecules
 from v1.models import CFGOVPage, CFGOVPageManager
 

--- a/cfgov/regulations3k/scripts/ecfr_importer.py
+++ b/cfgov/regulations3k/scripts/ecfr_importer.py
@@ -7,6 +7,7 @@ import sys
 
 import requests
 from bs4 import BeautifulSoup as bS
+
 from regulations3k.models.django import (
     EffectiveVersion, Part, Section, Subpart
 )

--- a/cfgov/regulations3k/tests/test_ecfr_importer.py
+++ b/cfgov/regulations3k/tests/test_ecfr_importer.py
@@ -7,11 +7,12 @@ from django.conf import settings
 from django.test import TestCase as DjangoTestCase
 
 import mock
+from requests import Response
+
 from regulations3k.models import EffectiveVersion, Part, Subpart
 from regulations3k.scripts.ecfr_importer import ecfr_to_regdown, run
 from regulations3k.scripts.patterns import IdLevelState
 from regulations3k.scripts.roman import int_to_roman, roman_to_int
-from requests import Response
 
 
 class ImporterTestCase(DjangoTestCase):

--- a/cfgov/regulations3k/tests/test_models.py
+++ b/cfgov/regulations3k/tests/test_models.py
@@ -8,6 +8,7 @@ from django.http import HttpRequest  # Http404, HttpResponse
 from django.test import TestCase as DjangoTestCase
 
 from model_mommy import mommy
+
 from regulations3k.models.django import (
     EffectiveVersion, Part, Section, Subpart, sortable_label
 )

--- a/cfgov/regulations3k/tests/test_regdown.py
+++ b/cfgov/regulations3k/tests/test_regdown.py
@@ -4,6 +4,7 @@ from __future__ import unicode_literals
 import unittest
 
 import markdown
+
 from regulations3k.regdown import extract_labeled_paragraph, regdown
 
 

--- a/cfgov/regulations3k/tests/test_resolver.py
+++ b/cfgov/regulations3k/tests/test_resolver.py
@@ -6,6 +6,7 @@ import datetime
 from django.test import TestCase, override_settings
 
 from model_mommy import mommy
+
 from regulations3k.models import (
     EffectiveVersion, Part, RegulationLandingPage, RegulationPage, Section,
     Subpart

--- a/cfgov/regulations3k/wagtail_hooks.py
+++ b/cfgov/regulations3k/wagtail_hooks.py
@@ -2,8 +2,9 @@ from __future__ import unicode_literals
 
 from wagtail.contrib.modeladmin.options import modeladmin_register
 
-from regulations3k.models import EffectiveVersion, Part, Section, Subpart
 from treemodeladmin.options import TreeModelAdmin
+
+from regulations3k.models import EffectiveVersion, Part, Section, Subpart
 
 
 class SectionModelAdmin(TreeModelAdmin):


### PR DESCRIPTION
We had previously left regulations3k out of the isort list of first-party imports. This will fix that, and will re-sort all of the regulations3k imports appropriately.

The overall change is to place regulations3k imports *with* the rest of cfgov's imports in the regulations3k code, rather than above them.

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
