### PR TITLE
Fix FCM video preview images

### DIFF
--- a/cfgov/jinja2/v1/_includes/macros/video-player.html
+++ b/cfgov/jinja2/v1/_includes/macros/video-player.html
@@ -35,7 +35,7 @@
     {% if video_url.find( 'autoplay=' ) == -1 -%}
         {% set video_url = _buildParam( video_url, 'autoplay=1' )  %}
     {% endif %}
-    {% set video_id =  video_url.split('?')[0].split('/') | last %}
+    {% set video_id = video_url.split('?')[0].split('/') | last if video_id == '' else video_id %}
     {% if video_url.find( 'enablejsapi=' ) == -1 -%}
         {% set video_url = _buildParam( video_url, 'enablejsapi=1' )  %}
     {% endif -%}
@@ -50,7 +50,7 @@
     <div class="video-player
                 video-player__youtube
                 {{ 'o-featured-content-module_visual' if is_flexible == false else '' }}"
-         {{ 'data-id="' ~ video_id ~ '"' if video_id else '' }}
+         data-id="{{ video_id }}"
          data-src="{{ video_url }}"
          data-width="{{ options.video.width if options.video.width else '' }}"
          data-height="{{ options.video.height if options.video.height else '' }}">


### PR DESCRIPTION
A change to string concatenation in the video player template broke the preview images for videos within Featured Content Modules, e.g., https://www.consumerfinance.gov/practitioner-resources/library-resources/. This PR remedies that.

## Changes

- Fixes FCM video preview images

## Testing

1. Pull branch
1. Open a page with an FCM, like http://localhost:8000/practitioner-resources/library-resources/, and confirm that the preview image now loads (you should see a person, not just the CFPB logo)
1. Confirm that other uses of the video player macro still correctly show their preview images:
   - Events: http://localhost:8000/about-us/events/archive-past-events/fall-2017-consumer-advisory-board-meeting-tampa-fla/
   - Standalone organism: http://localhost:8000/consumer-tools/everyone-has-a-story/ana-debts-you-dont-owe/

## Notes

- It would be really nice to standardize the various places that call the video player macro a bit more. If we did, the video player template logic could get way simpler.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [x] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
