### PR TITLE
Full smoke test script covers the top 25 most visited pages

### DIFF
--- a/cfgov/scripts/http_smoke_test.py
+++ b/cfgov/scripts/http_smoke_test.py
@@ -86,7 +86,7 @@ FULL_RUN = [
     '/data-research/cfpb-research-conference/',
     '/data-research/consumer-complaints/',
     '/data-research/hmda/',
-    '/data-research/hmda/for-filers', # This URL 404s if it has a trailing slash
+    '/data-research/hmda/for-filers',
     '/data-research/consumer-credit-trends/',
     '/data-research/credit-card-data/',
     '/data-research/cfpb-researchers/',
@@ -99,7 +99,7 @@ FULL_RUN = [
     '/policy-compliance/amicus/',
     '/policy-compliance/guidance/implementation-guidance/hmda-implementation/',
     '/policy-compliance/guidance/implementation-guidance/mortserv/',
-    '/policy-compliance/guidance/implementation-guidance/tila-respa-disclosure-rule/',
+    '/policy-compliance/guidance/implementation-guidance/tila-respa-disclosure-rule/',  # noqa: E501
     '/about-us/',
     '/about-us/the-bureau/',
     '/about-us/budget-strategy/',
@@ -115,7 +115,7 @@ FULL_RUN = [
     '/about-us/project-catalyst/',
     '/about-us/contact-us/',
     '/eregulations/',
-    '/eregulations/1026', # This URL 404s if it has a trailing slash
+    '/eregulations/1026',
 ]
 
 # TODO: Document the logic for what gets included/excluded in short-run tests

--- a/cfgov/scripts/http_smoke_test.py
+++ b/cfgov/scripts/http_smoke_test.py
@@ -46,7 +46,15 @@ FULL_RUN = [
      '?selected_facets=category_exact:enviar-dinero'),
     '/learnmore/',
     '/complaint/',
+    '/complaint/getting-started/',
     '/ask-cfpb/',
+    '/askcfpb/1017/',
+    '/askcfpb/135/',
+    '/askcfpb/1447/',
+    '/askcfpb/1695/',
+    '/askcfpb/1791/',
+    '/askcfpb/316/',
+    '/askcfpb/44/',
     '/your-story/',
     '/students/',
     '/find-a-housing-counselor/',
@@ -78,6 +86,7 @@ FULL_RUN = [
     '/data-research/cfpb-research-conference/',
     '/data-research/consumer-complaints/',
     '/data-research/hmda/',
+    '/data-research/hmda/for-filers', # This URL 404s if it has a trailing slash
     '/data-research/consumer-credit-trends/',
     '/data-research/credit-card-data/',
     '/data-research/cfpb-researchers/',
@@ -88,6 +97,9 @@ FULL_RUN = [
     '/policy-compliance/enforcement/',
     '/policy-compliance/notice-opportunities-comment/',
     '/policy-compliance/amicus/',
+    '/policy-compliance/guidance/implementation-guidance/hmda-implementation/',
+    '/policy-compliance/guidance/implementation-guidance/mortserv/',
+    '/policy-compliance/guidance/implementation-guidance/tila-respa-disclosure-rule/',
     '/about-us/',
     '/about-us/the-bureau/',
     '/about-us/budget-strategy/',
@@ -102,6 +114,8 @@ FULL_RUN = [
     '/about-us/advisory-groups/',
     '/about-us/project-catalyst/',
     '/about-us/contact-us/',
+    '/eregulations/',
+    '/eregulations/1026', # This URL 404s if it has a trailing slash
 ]
 
 # TODO: Document the logic for what gets included/excluded in short-run tests


### PR DESCRIPTION
Previously, the automated smoke testing script didn't cover all of the top 25 most visited pages on cf.gov. This PR updates the script to add the remaining pages.

## Additions
This PR adds several URLs to the `FULL_RUN` list of paths in `http_smoke_test.py`. This means that when we run automated smoke tests (e.g. via Jenkins), we can directly confirm that all of the most popular pages on cf.gov return a `200`. 

Added URLs include:
-  several specific ask-cfpb pages
- some specific compliance guidance pages
- eRegs and a specific regulation page

## Testing

This change is being tested on the Staging server with an automated Jenkins job.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

This PR does not affect any cf.gov functionality.