### PR TITLE
Enforce specific Node version

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "license": "SEE LICENSE IN TERMS.md",
   "engines": {
-    "node": ">=6.0.0"
+    "node": ">=8.5.0"
   },
   "dependencies": {
     "autoprefixer": "8.2.0",
@@ -91,8 +91,9 @@
     "yargs": "11.0.0"
   },
   "scripts": {
-    "test": "snyk test",
-    "postinstall": "node scripts/npm/apps-install"
+    "postinstall": "node scripts/npm/apps-install",
+    "preinstall": "npx enforce-node-version || (echo 'Please install npm v5.2 or greater' && exit 1)",
+    "test": "snyk test"
   },
   "snyk": true
 }


### PR DESCRIPTION
Simpler version of #4209 

We introduced a webpack method that requires Node version 8.5+. This
commit introduces a preinstall script that prevents `npm install` from
continuing if the user's version of Node is less than what's specified
in package.json.

## Additions

- npm preinstall script

## Changes

- Required node version in `package.json` is now 8.5.

## Testing

1. `nvm use 7` (or any version lower than 8.5)
1. `npm install`
1. Installation should fail.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [x] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: