### PR TITLE
Fix HDMA explorer non-firing "change" events

### DIFF
--- a/cfgov/unprocessed/apps/analytics-gtm/js/hdma-explore-event-listeners.js
+++ b/cfgov/unprocessed/apps/analytics-gtm/js/hdma-explore-event-listeners.js
@@ -3,41 +3,6 @@ import {
   track
 } from './util/analytics-util';
 
-/* Search for support of the matches() method by looking at
-   browser prefixes.
-   @param {HTMLNode} elem
-   The element to check for support of matches() method.
-   @returns {Function} The appropriate matches() method of elem. */
-function _getMatchesMethod( elem ) {
-  return elem.matches ||
-         elem.webkitMatchesSelector ||
-         elem.mozMatchesSelector ||
-         elem.msMatchesSelector;
-}
-
-/* Get the nearest parent node of an element.
-   @param {HTMLNode} elem - A DOM element.
-   @param {string} selector - CSS selector.
-   @returns {HTMLNode} Nearest parent node that matches the selector. */
-function closest( elem, selector ) {
-  elem = elem.parentNode;
-
-  const matchesSelector = _getMatchesMethod( elem );
-  let match;
-
-  while ( elem ) {
-    if ( matchesSelector.bind( elem )( selector ) ) {
-      match = elem;
-    } else {
-      elem = elem.parentElement;
-    }
-
-    if ( match ) { return elem; }
-  }
-
-  return null;
-}
-
 // HMDA Explore custom analytics file
 
 const HMDAAnalytics = ( function() {
@@ -50,7 +15,7 @@ const HMDAAnalytics = ( function() {
 
   /**
    * Handle clicks on filter divs.
-   * @param       {MouseEvent} evt - Event object.
+   * @param {MouseEvent} evt - Event object.
    */
   function _handleDivFilterClick( evt ) {
     const target = evt.target;
@@ -119,6 +84,7 @@ const HMDAAnalytics = ( function() {
   // Chosen menu selections for suggested filters
   const selectSuggestedEl = document.querySelector( '#suggested_chzn' );
   selectSuggestedEl.addEventListener( 'mouseup', function( evt ) {
+    const target = evt.currentTarget;
 
     // If the drop-down isn't closed, we're still selecting an item.
     if ( target.classList.contains( 'chzn-with-drop' ) ) {

--- a/cfgov/unprocessed/apps/analytics-gtm/js/hdma-explore-event-listeners.js
+++ b/cfgov/unprocessed/apps/analytics-gtm/js/hdma-explore-event-listeners.js
@@ -63,9 +63,9 @@ const HMDAAnalytics = ( function() {
   }
 
   // Chosen menu selections for Summary Table Variables
-  const selectChznSingleEls = document.querySelectorAll( 'select.chzn-single' );
+  const selectChznSingleEls = document.querySelectorAll( 'select.chzn-single + .chzn-container' );
   for ( let j = 0, len = selectChznSingleEls.length; j < len; j++ ) {
-    selectChznSingleEls[j].addEventListener( 'change', _handleSelectChange );
+    selectChznSingleEls[j].addEventListener( 'mouseup', _handleSelectChange );
   }
 
   /**
@@ -73,20 +73,43 @@ const HMDAAnalytics = ( function() {
    * @param {Event} evt - Event object.
    */
   function _handleSelectChange( evt ) {
-    const target = evt.target;
-    const label = target.parentNode.querySelector( '.chzn-container a.chzn-single' ).textContent;
-    const parent = closest( target, 'div' );
-    const divs = document.querySelectorAll( '.drop-downs > div' );
-    const n = divs.indexOf( parent ) + 1;
+    const target = evt.currentTarget;
+
+    // If the drop-down isn't closed, we're still selecting an item.
+    if ( target.classList.contains( 'chzn-with-drop' ) ) {
+      return;
+    }
+
+    const label = target.querySelector( 'a.chzn-single' ).textContent;
+
+    // Find the number of this drop-down.
+    const id = target.id;
+    let n;
+    if ( id === 'calculate_by_chzn' ) {
+      n = 4
+    } else {
+      // This relies on the div's id in format variable[n]_chzn.
+      n = Number( target.id.substr(-6, 1) ) + 1;
+    }
+
     const action = 'Variable Dropdown Menu #' + n;
     track( 'HMDA Explore Interactions', action, label );
   };
 
   // Chosen menu selections for Year filter
   const selectAsOfYearDelay = new Delay();
-  const selectAsOfYear = document.querySelector( 'select#as_of_year' );
-  selectAsOfYear.addEventListener( 'change', function( evt ) {
-    const lastItem = document.querySelector( '#as_of_year_chzn .search-choice:last' );
+  const selectAsOfYear = document.querySelector( 'div#as_of_year_chzn' );
+  selectAsOfYear.addEventListener( 'mouseup', function( evt ) {
+    const target = evt.currentTarget;
+    const nodes = target.querySelectorAll( '.search-choice' );
+
+    // If the drop-down isn't closed, we're still selecting an item.
+    if ( target.classList.contains( 'chzn-with-drop' ) ||
+         nodes.length === 0 ) {
+      return;
+    }
+
+    const lastItem = nodes[nodes.length- 1];
     const label = lastItem.textContent;
     selectAsOfYearDelay( () => {
       track( 'HMDA Explore Interactions', 'Year Dropdown', label );
@@ -94,10 +117,15 @@ const HMDAAnalytics = ( function() {
   } );
 
   // Chosen menu selections for suggested filters
-  const selectSuggestedEl = document.querySelector( 'select#suggested' );
-  selectSuggestedEl.addEventListener( 'change', function( evt ) {
-    const target = evt.target;
-    const label = target.value;
+  const selectSuggestedEl = document.querySelector( '#suggested_chzn' );
+  selectSuggestedEl.addEventListener( 'mouseup', function( evt ) {
+
+    // If the drop-down isn't closed, we're still selecting an item.
+    if ( target.classList.contains( 'chzn-with-drop' ) ) {
+      return;
+    }
+
+    const label = target.querySelector( 'a.chzn-single' ).textContent;
     track( 'HMDA Explore Interactions', 'Suggested Dropdown', label );
   } );
 

--- a/cfgov/unprocessed/apps/analytics-gtm/js/hdma-explore-event-listeners.js
+++ b/cfgov/unprocessed/apps/analytics-gtm/js/hdma-explore-event-listeners.js
@@ -51,15 +51,15 @@ const HMDAAnalytics = ( function() {
     const id = target.id;
     let n;
     if ( id === 'calculate_by_chzn' ) {
-      n = 4
+      n = 4;
     } else {
       // This relies on the div's id in format variable[n]_chzn.
-      n = Number( target.id.substr(-6, 1) ) + 1;
+      n = Number( target.id.substr( -6, 1 ) ) + 1;
     }
 
     const action = 'Variable Dropdown Menu #' + n;
     track( 'HMDA Explore Interactions', action, label );
-  };
+  }
 
   // Chosen menu selections for Year filter
   const selectAsOfYearDelay = new Delay();
@@ -74,7 +74,7 @@ const HMDAAnalytics = ( function() {
       return;
     }
 
-    const lastItem = nodes[nodes.length- 1];
+    const lastItem = nodes[nodes.length - 1];
     const label = lastItem.textContent;
     selectAsOfYearDelay( () => {
       track( 'HMDA Explore Interactions', 'Year Dropdown', label );

--- a/cfgov/unprocessed/apps/analytics-gtm/js/hdma-explore-event-listeners.js
+++ b/cfgov/unprocessed/apps/analytics-gtm/js/hdma-explore-event-listeners.js
@@ -47,6 +47,11 @@ const HMDAAnalytics = ( function() {
   for ( let i = 0, len = divFilterEls.length; i < len; i++ ) {
     divFilterEls[i].addEventListener( 'click', _handleDivFilterClick );
   }
+
+  /**
+   * Handle clicks on filter divs.
+   * @param       {MouseEvent} evt - Event object.
+   */
   function _handleDivFilterClick( evt ) {
     const target = evt.target;
     let action = 'Filter Expandable Opened';
@@ -58,8 +63,16 @@ const HMDAAnalytics = ( function() {
   }
 
   // Chosen menu selections for Summary Table Variables
-  const selectChznSingleEl = document.querySelector( 'select.chzn-single' );
-  selectChznSingleEl.addEventListener( 'change', function( evt ) {
+  const selectChznSingleEls = document.querySelectorAll( 'select.chzn-single' );
+  for ( let j = 0, len = selectChznSingleEls.length; j < len; j++ ) {
+    selectChznSingleEls[j].addEventListener( 'change', _handleSelectChange );
+  }
+
+  /**
+   * Handle select menu changes.
+   * @param {Event} evt - Event object.
+   */
+  function _handleSelectChange( evt ) {
     const target = evt.target;
     const label = target.parentNode.querySelector( '.chzn-container a.chzn-single' ).textContent;
     const parent = closest( target, 'div' );
@@ -67,7 +80,7 @@ const HMDAAnalytics = ( function() {
     const n = divs.indexOf( parent ) + 1;
     const action = 'Variable Dropdown Menu #' + n;
     track( 'HMDA Explore Interactions', action, label );
-  } );
+  };
 
   // Chosen menu selections for Year filter
   const selectAsOfYearDelay = new Delay();


### PR DESCRIPTION
HDMA explorer events were relying on the "change" event on select drop-down menus that were hidden, so the event was never firing. This adjusts the scripts to listen on "mouseup" on the faux drop-downs that are created on top of the native drop-downs.

## Removals

- Removes unnecessary "closest" helper.

## Changes

- Moves event firing to faux drop-down instead of hidden native drop-down.

## Testing

1. We'll test on build after merging.
