### PR TITLE
regs3k: expose section_range in subpart admin

### DIFF
--- a/cfgov/regulations3k/wagtail_hooks.py
+++ b/cfgov/regulations3k/wagtail_hooks.py
@@ -25,6 +25,7 @@ class SubpartModelAdmin(TreeModelAdmin):
     menu_icon = 'list-ul'
     list_display = (
         'title',
+        'section_range'
     )
     child_field = 'sections'
     child_model_admin = SectionModelAdmin


### PR DESCRIPTION
One-line change for admin display.

Should produce this:

<img width="1249" alt="one_line_admin_change" src="https://user-images.githubusercontent.com/515885/40849206-47bde07c-658f-11e8-9ab8-8c5d761d16a9.png">


