### PR TITLE
Mega menu: Set the aria attributes on menu trigger and menu items

### DIFF
--- a/cfgov/jinja2/v1/_includes/organisms/mega-menu.html
+++ b/cfgov/jinja2/v1/_includes/organisms/mega-menu.html
@@ -51,7 +51,7 @@
     {% for nav_group in nav_groups %}
     {% set group = nav_group.value %}
     <div class="{{ _classes( nav_depth, '-list' ) }}">
-        
+
         {% if group.group_title %}
         <div class="h5
                   {{ base_class ~ '_group-heading' }}
@@ -74,7 +74,7 @@
             {%- endfor %}
         </ul>
     </div>
-    
+
     {% endfor %}
 </div>
 
@@ -179,15 +179,16 @@
     {% set has_children = nav_item.nav_groups | count > 0 or nav_item.nav_items | count > 0 %}
 
     <li class="m-list_item {{ _classes( nav_depth, '-item' ) }}"
-        {{ 'data-js-hook=behavior_flyout-menu' if has_children else '' }}>
+        {{ 'data-js-hook=behavior_flyout-menu' if has_children else '' }}
+        {{ 'aria-haspopup=menu' if has_children else '' }}
+        role="menuitem">
         {# TODO: Disable link (or overview link) of page user is currently on (on mobile). #}
         <a class="{{ 'u-link__disabled' if url == '' else '' }}
                   {{ _classes( nav_depth, '-link' ) }}
                   {{ _classes( nav_depth, '-link__has-children' ) if has_children else '' }}
                   {{ _classes( nav_depth, '-link__current' ) if url == request.path else '' }}"
            {{ '' if url == '' else 'href=' + url | e }}
-           {{ 'data-js-hook=behavior_flyout-menu_trigger' if has_children else '' }}
-           {{ 'aria-pressed=false' if has_children else '' }}>
+           {{ 'data-js-hook=behavior_flyout-menu_trigger' if has_children else '' }}>
               {{ text }}
               {{ svg_icon('right') }}
         </a>
@@ -217,7 +218,7 @@
     aria-label="main menu">
     <button class="{{ base_class ~ '_trigger' }}"
            data-js-hook="behavior_flyout-menu_trigger"
-           aria-pressed="false">
+           aria-haspopup="menu">
         <span class="{{ base_class ~ '_trigger-open' }}">
             {{ svg_icon('menu') }}
         </span>

--- a/cfgov/unprocessed/js/modules/behavior/FlyoutMenu.js
+++ b/cfgov/unprocessed/js/modules/behavior/FlyoutMenu.js
@@ -97,7 +97,6 @@ function FlyoutMenu( element ) { // eslint-disable-line max-statements, no-inlin
 
     // Set initial aria attributes to false.
     _setAriaAttr( 'expanded', _triggerDom, 'false' );
-    _setAriaAttr( 'pressed', _triggerDom, 'false' );
 
     _triggerDom.addEventListener( 'click', handleTriggerClickedBinded );
     _triggerDom.addEventListener( 'touchstart', _handleTouchStart );
@@ -230,7 +229,7 @@ function FlyoutMenu( element ) { // eslint-disable-line max-statements, no-inlin
         'expandBegin',
         { target: this, type: 'expandBegin' }
       );
-      _setAriaAttr( 'pressed', _triggerDom, true );
+
       if ( _expandTransitionMethod ) {
         const hasTransition = _expandTransition &&
                               _expandTransition.isAnimated();
@@ -296,7 +295,6 @@ function FlyoutMenu( element ) { // eslint-disable-line max-statements, no-inlin
       }
 
       _setAriaAttr( 'expanded', _triggerDom, false );
-      _setAriaAttr( 'pressed', _triggerDom, false );
       _setAriaAttr( 'expanded', _contentDom, false );
 
       /* TODO: Remove or uncomment when keyboard navigation is in.

--- a/test/unit_tests/js/modules/behavior/FlyoutMenu-spec.js
+++ b/test/unit_tests/js/modules/behavior/FlyoutMenu-spec.js
@@ -6,7 +6,7 @@ const MoveTransition =
 const HTML_SNIPPET = `
   <div data-js-hook="behavior_flyout-menu">
       <button data-js-hook="behavior_flyout-menu_trigger"
-              aria-pressed="false"
+              aria-haspopup="menu"
               aria-expanded="false"></button>
       <div data-js-hook="behavior_flyout-menu_content" aria-expanded="false">
         <button data-js-hook="behavior_flyout-menu_alt-trigger"
@@ -54,10 +54,8 @@ describe( 'FlyoutMenu', () => {
     } );
 
     it( 'should have correct state before initializing', () => {
-      expect( triggerDom.getAttribute( 'aria-pressed' ) ).toBe( 'false' );
       expect( triggerDom.getAttribute( 'aria-expanded' ) ).toBe( 'false' );
       expect( contentDom.getAttribute( 'aria-expanded' ) ).toBe( 'false' );
-      expect( altTriggerDom.getAttribute( 'aria-pressed' ) ).toBeNull();
       expect(
         altTriggerDom.getAttribute( 'aria-expanded' )
       ).toBe( 'false' );
@@ -143,10 +141,8 @@ describe( 'FlyoutMenu', () => {
       );
 
       // Check expected aria attributes state.
-      expect( triggerDom.getAttribute( 'aria-pressed' ) ).toBe( 'true' );
       expect( triggerDom.getAttribute( 'aria-expanded' ) ).toBe( 'true' );
       expect( contentDom.getAttribute( 'aria-expanded' ) ).toBe( 'true' );
-      expect( altTriggerDom.getAttribute( 'aria-pressed' ) ).toBeNull();
       expect( altTriggerDom.getAttribute( 'aria-expanded' ) ).toBe( 'true' );
     } );
 
@@ -191,10 +187,8 @@ describe( 'FlyoutMenu', () => {
       );
 
       // Check expected aria attribute states.
-      expect( triggerDom.getAttribute( 'aria-pressed' ) ).toBe( 'false' );
       expect( triggerDom.getAttribute( 'aria-expanded' ) ).toBe( 'false' );
       expect( contentDom.getAttribute( 'aria-expanded' ) ).toBe( 'false' );
-      expect( altTriggerDom.getAttribute( 'aria-pressed' ) ).toBeNull();
       expect( altTriggerDom.getAttribute( 'aria-expanded' ) ).toBe( 'false' );
     } );
 


### PR DESCRIPTION
Fixes [GHE]/CFGOV/platform/issues/2791

## Changes

- Replaces aria-pressed roles with aria-haspopup="menu" and adds aria-role="menuitem" to menu list items.

## Testing

1. Open page in mobile size and run the WAVE chrome extension to see the aria-attributing.

## Screenshot

![screen shot 2018-06-01 at 4 58 53 pm](https://user-images.githubusercontent.com/704760/40863275-2232c5e2-65bd-11e8-89f5-d8b1bb7a40bd.png)

## Notes:

- [This example](https://www.w3.org/TR/wai-aria-practices-1.1/examples/menu-button/menu-button-links.html) notes that 

> The menuitem role is on the HTML a element contained by each li element so link behaviors are available when focus is set on the menu item. Another reason the menuitem role is not on the li element is that the semantics of descendants of ARIA menuitem elements are not exposed in the accessibility tree. That is, an item in a menu can only be a menuitem because accessibility APIs do not enable assistive technologies to render elements contained inside of an item in a menu.

However, [this site](https://www.levelaccess.com/challenges-mega-menus-standard-menus-make-accessible/) notes that

> Nested submenus can be added using the same syntax by placing the same structure within the appropriate list item. However, when adding a nested submenu, the triggering element that includes aria-haspopup must include role=”menuitem”, and not a button role. Focus management is critical and must be strictly observed.

Our nested menus are inside the `li`, not inside the `a`, so I put the `menuitem` on the `li`. However, this likely should be revisited when addressing navigating the menu with VoiceOver.