### PR TITLE
Expand current subpart in side nav on page load

### DIFF
--- a/cfgov/jinja2/v1/_includes/eregs/regulations3k-secondary-navigation.html
+++ b/cfgov/jinja2/v1/_includes/eregs/regulations3k-secondary-navigation.html
@@ -43,10 +43,11 @@
     {%- for subpart in nav_items %}
         {% set sec_nav_settings = {
             'label': subpart.subpart_heading ~ ' ' ~ subpart.title ~ ' ' ~ subpart.section_range|safe,
-            'hide_cue_label': true
+            'hide_cue_label': true,
+            'is_expanded': nav_items[subpart].expanded
         } %}
         {% call() expandable(sec_nav_settings) %}
-        {% for section in nav_items[subpart] %}
+        {% for section in nav_items[subpart].sections %}
             {{ nav_link.render(section.title, section.url, true, section.active, true) }}
         {%- endfor %}
         {% endcall %}

--- a/cfgov/regulations3k/models/pages.py
+++ b/cfgov/regulations3k/models/pages.py
@@ -181,11 +181,15 @@ def get_reg_nav_items(request, current_page):
         [(subpart, None) for subpart in subpart_list]
     )
     for subpart in subpart_dict:
+        subpart_dict[subpart] = {
+            'sections': [],
+            'expanded': False
+        }
         sorted_sections = sorted(
             subpart.sections.all(),
             key=lambda s: sortable_label(s.label))
-        subpart_dict[subpart] = [
-            {
+        for section in sorted_sections:
+            section_dict = {
                 'title': section.title,
                 'url': current_page.url + current_page.reverse_subpage(
                     'section',
@@ -197,6 +201,8 @@ def get_reg_nav_items(request, current_page):
                 'expanded': True,
                 'section': section,
             }
-            for section in sorted_sections
-        ]
+            subpart_dict[subpart]['sections'].append(section_dict)
+            subpart_dict[subpart]['expanded'] = (
+                subpart_dict[subpart]['expanded'] or section_dict['active']
+            )
     return subpart_dict, False


### PR DESCRIPTION
Opens relevant subpart expandable in the side nav on page load (instead of all the expandables being closed by default).

## Changes

- Adds an 'expanded' key to subpart dictionaries that is True if any of the subpart's sections are active.

## Testing

1. Open `http://localhost:8000/regulations/1005/5/` and `Subpart A` should be expanded in the secondary navigation with a green border next to 1005.5

## Screenshots

<img width="844" alt="58cc27f6-5e83-11e8-9133-2ce56356ca22" src="https://user-images.githubusercontent.com/1060248/40922417-21e37936-67e0-11e8-8a1f-38cf09abbf71.png">

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
