### PR TITLE
Add a note for invalid media attr

### DIFF
--- a/cfgov/jinja2/v1/_layouts/base-common.html
+++ b/cfgov/jinja2/v1/_layouts/base-common.html
@@ -239,6 +239,11 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
 {% block font_tracker %}
 <!--[if gt IE 8]><!-->
+{#
+    The invalid media attribute is intentional. It forces the browser to
+    download the stylesheet without blocking rendering and is updated after
+    the stylesheet is downloaded.
+#}
 <link rel="stylesheet"
       href="//fast.fonts.net/t/1.css?apiType=css&projectid=44e8c964-4684-44c6-a6e3-3f3da8787b50"
       media="none"


### PR DESCRIPTION
The invalid media attribute on the font stylesheet causes HTML validation errors. Added a note to the layout template so future developers know the intent.

## Additions

- Add a note on intent of invalid attribute

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Internet Explorer 8, 9, 10, and 11
- [ ] Edge
- [ ] iOS Safari
- [ ] Chrome for Android

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
