### PR TITLE
TDP Bump back to release before messed up wheel file 0.5.16

### DIFF
--- a/requirements/optional-public.txt
+++ b/requirements/optional-public.txt
@@ -8,4 +8,4 @@ git+https://github.com/cfpb/ccdb5-api.git@v1.0.5#egg=ccdb5-api
 git+https://github.com/cfpb/ccdb5-ui.git@v1.0.9#egg=ccdb5_ui
 https://github.com/cfpb/django-hud/releases/download/1.4.3/django_hud-1.4.3-py2-none-any.whl
 https://github.com/cfpb/django-college-costs-comparison/releases/download/1.5.3/comparisontool-1.5.3-py2-none-any.whl
-https://github.com/cfpb/teachers-digital-platform/releases/download/0.5.18/teachers_digital_platform-0.5.18.dev0.beaf958-py2-none-any.whl
+https://github.com/cfpb/teachers-digital-platform/releases/download/0.5.16/teachers_digital_platform-0.5.16-py2-none-any.whl


### PR DESCRIPTION
Rolling back TDP repo to last solid release before tox/wheel/npm issues with build

Changes
Updated TDP version to 0.5.16
@Scotchester @cfarm @willbarton @higs4281