### PR TITLE
Add closing tag to table header icon help link

### DIFF
--- a/cfgov/templates/wagtailadmin/table_input.html
+++ b/cfgov/templates/wagtailadmin/table_input.html
@@ -44,7 +44,7 @@
                 <input type="text"
                        id="{{ attrs.id }}-handsontable-heading-icon"
                        name="handsontable-heading-icon">
-                <span class="help">Input the name of an icon to appear to the left of the heading. E.g., approved, help-round, etc. <a href="https://cfpb.github.io/capital-framework/'components/cf-icons/#icons">See full list of icons</span>
+                <span class="help">Input the name of an icon to appear to the left of the heading. E.g., approved, help-round, etc. <a href="https://cfpb.github.io/capital-framework/'components/cf-icons/#icons">See full list of icons</a></span>
             </div>
         </div>
     </div>


### PR DESCRIPTION
I neglected to include a closing `</a>` tag in #4183, which is making it impossible to edit table contents right now 😳 

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [x] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: