### PR TITLE
Hardcoding event url into event template for upcoming event

### DIFF
--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -566,7 +566,8 @@ CSP_FRAME_SRC = (
     '*.doubleclick.net',
     'universal.iperceptions.com',
     'www.facebook.com',
-    'staticxx.facebook.com')
+    'staticxx.facebook.com',
+    'mediasite.yorkcast.com')
 
 # These specify where we allow fonts to come from
 CSP_FONT_SRC = ("'self'", "data:", "fast.fonts.net", "fonts.google.com", "fonts.gstatic.com")
@@ -587,7 +588,7 @@ FLAGS = {
     # Ask CFPB search spelling correction support
     # When enabled, spelling suggestions will appear in Ask CFPB search and
     # will be used when the given search term provides no results.
-	'ASK_SEARCH_TYPOS': {},
+    'ASK_SEARCH_TYPOS': {},
 
     # Beta banner, seen on beta.consumerfinance.gov
     # When enabled, a banner appears across the top of the site proclaiming

--- a/cfgov/jinja2/v1/events/_macros.html
+++ b/cfgov/jinja2/v1/events/_macros.html
@@ -83,6 +83,7 @@
 {% macro event_venue(event, event_state) %}
     {% set state_prefix = ', ' if event.venue_city and event.venue_state else '' %}
     {% set city_prefix_state = event.venue_city ~ state_prefix ~ event.venue_state %}
+
     <section class="event-venue">
         <div class="event-venue_details">
             <header class="event-venue_header">
@@ -148,6 +149,8 @@
                         'url':    event.live_stream_url
                     }
                 }) }}
+            {% elif event_state == 'present' and request.path == '/about-us/events/town-hall-topeka-kan-fighting-elder-financial-exploitation-your-community/' %}
+                <iframe style="min-height:400px; width:100%" src="https://mediasite.yorkcast.com/webcast/Play/4f3f75532e824c519793852e5f0a0ab71d?autostart=true"></iframe>
             {% else %}
               <img src="{{ event.location_image_url(size='640x320') }}"
                    alt="Google Maps image of {{ event.venue_name }}">


### PR DESCRIPTION
Hardcoding event url into event template for upcoming event

## Changes

- Modified code to hardcode event details for non youtube based live event. 

## Testing

1. Modify the `town-hall-topeka-kan-fighting-elder-financial-exploitation-your-community/` event to make it live. 
2. Visit http://localhost:8000/about-us/events/town-hall-topeka-kan-fighting-elder-financial-exploitation-your-community/ and verify it plays as expected.

## Notes

- The livestream url must remain the same or this won't work.

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Internet Explorer 8, 9, 10, and 11
- [ ] Edge
- [ ] iOS Safari
- [ ] Chrome for Android

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
