### PR TITLE
Invalidate pages if their social sharing image is too large

### DIFF
--- a/cfgov/ask_cfpb/migrations/0016_modify_help_text_social_sharing_image.py
+++ b/cfgov/ask_cfpb/migrations/0016_modify_help_text_social_sharing_image.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('ask_cfpb', '0015_update_email_signup_options'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='answer',
+            name='social_sharing_image',
+            field=models.ForeignKey(related_name='+', on_delete=django.db.models.deletion.SET_NULL, blank=True, to='v1.CFGOVImage', help_text="Optionally select a custom image to appear when users share this page on social media websites. If no image is selected, this page's category image will be used. Recommended size: 1200w x 630h. Maximum size: 4096w x 4096h.", null=True),
+        ),
+    ]

--- a/cfgov/ask_cfpb/models/django.py
+++ b/cfgov/ask_cfpb/models/django.py
@@ -23,6 +23,7 @@ from wagtail.wagtailcore.models import Page
 from wagtail.wagtailimages.edit_handlers import ImageChooserPanel
 
 from v1.util.migrations import get_or_create_page
+from v1.util.util import validate_social_sharing_image
 
 
 html_parser = HTMLParser.HTMLParser()
@@ -376,7 +377,9 @@ class Answer(models.Model):
         help_text=(
             'Optionally select a custom image to appear when users share this '
             'page on social media websites. If no image is selected, this '
-            'page\'s category image will be used. Minimum size: 1200w x 630h.'
+            'page\'s category image will be used. '
+            'Recommended size: 1200w x 630h. '
+            'Maximum size: 4096w x 4096h.'
         )
     )
 
@@ -458,6 +461,10 @@ class Answer(models.Model):
             html_parser.unescape(self.snippet_es),
             html_parser.unescape(self.answer_es)))
         return html.strip_tags(unescaped).strip()
+
+    def clean(self):
+        super(Answer, self).clean()
+        validate_social_sharing_image(self.social_sharing_image)
 
     def cleaned_questions(self):
         cleaned_terms = html_parser.unescape(self.question)

--- a/cfgov/v1/migrations/0113_modify_help_text_social_sharing_image.py
+++ b/cfgov/v1/migrations/0113_modify_help_text_social_sharing_image.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('v1', '0112_add_menu_item'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='cfgovpage',
+            name='social_sharing_image',
+            field=models.ForeignKey(related_name='+', on_delete=django.db.models.deletion.SET_NULL, blank=True, to='v1.CFGOVImage', help_text=b'Optionally select a custom image to appear when users share this page on social media websites. Recommended size: 1200w x 630h. Maximum size: 4096w x 4096h.', null=True),
+        ),
+    ]

--- a/cfgov/v1/models/base.py
+++ b/cfgov/v1/models/base.py
@@ -31,6 +31,7 @@ from v1 import blocks as v1_blocks, get_protected_url
 from v1.atomic_elements import molecules, organisms
 from v1.models.snippets import ReusableText
 from v1.util import ref
+from v1.util.util import validate_social_sharing_image
 
 
 class CFGOVAuthoredPages(TaggedItemBase):
@@ -78,7 +79,8 @@ class CFGOVPage(Page):
         related_name='+',
         help_text=(
             'Optionally select a custom image to appear when users share this '
-            'page on social media websites. Minimum size: 1200w x 630h.'
+            'page on social media websites. Recommended size: 1200w x 630h. '
+            'Maximum size: 4096w x 4096h.'
         )
     )
 
@@ -125,6 +127,10 @@ class CFGOVPage(Page):
         ObjectList(sidefoot_panels, heading='Sidebar/Footer'),
         ObjectList(settings_panels, heading='Configuration'),
     ])
+
+    def clean(self):
+        super(CFGOVPage, self).clean()
+        validate_social_sharing_image(self.social_sharing_image)
 
     def get_authors(self):
         """ Returns a sorted list of authors. Default is alphabetical """

--- a/cfgov/v1/tests/test_social_sharing_image_validation.py
+++ b/cfgov/v1/tests/test_social_sharing_image_validation.py
@@ -1,0 +1,41 @@
+from django.core.exceptions import ValidationError
+from django.test import TestCase
+
+from model_mommy import mommy
+
+from v1.models.browse_filterable_page import BrowseFilterablePage
+from v1.models.images import CFGOVImage
+from v1.tests.wagtail_pages.helpers import save_new_page
+
+
+class TestSocialSharingImage(TestCase):
+    def setUp(self):
+        self.page = BrowseFilterablePage(
+            title='Browse Filterable Page',
+            slug='browse-filterable-page',
+        )
+        save_new_page(self.page)
+
+    def test_validation_error_thrown_if_width_height_too_large(self):
+        self.page.social_sharing_image = mommy.prepare(CFGOVImage, width=5000, height=5000)
+        with self.assertRaisesRegexp(
+            ValidationError,
+            'Social sharing image must be less than 4096w x 4096h'
+        ):
+            self.page.save()
+
+    def test_validation_error_thrown_if_width_too_large(self):
+        self.page.social_sharing_image = mommy.prepare(CFGOVImage, width=4097, height=1500)
+        with self.assertRaisesRegexp(
+            ValidationError,
+            'Social sharing image must be less than 4096w x 4096h'
+        ):
+            self.page.save()
+
+    def test_validation_error_thrown_if_height_too_large(self):
+        self.page.social_sharing_image = mommy.prepare(CFGOVImage, width=1500, height=4097)
+        with self.assertRaisesRegexp(
+            ValidationError,
+            'Social sharing image must be less than 4096w x 4096h'
+        ):
+            self.page.save()

--- a/cfgov/v1/util/util.py
+++ b/cfgov/v1/util/util.py
@@ -1,6 +1,7 @@
 from time import time
 
 from django.contrib.auth import REDIRECT_FIELD_NAME
+from django.core.exceptions import ValidationError
 from django.core.urlresolvers import resolve
 from django.http import Http404, HttpResponseRedirect
 
@@ -201,3 +202,11 @@ def extended_strftime(dt, format):
     format = format.replace('%_d', dt.strftime('%d').lstrip('0'))
     format = format.replace('%_m', _MONTH_ABBREVIATIONS[dt.month])
     return dt.strftime(format)
+
+
+def validate_social_sharing_image(image):
+    """Raises a validation error if the image is too large or too small."""
+    if image and (image.width > 4096 or image.height > 4096):
+        raise ValidationError(
+            'Social sharing image must be less than 4096w x 4096h'
+        )


### PR DESCRIPTION
### Overview
We want to prevent social sharing images that are too large from getting saved to a page (currently they get saved and then don't display at all on Twitter).
See GHE/CFGOV/platform/issues/2377 for more context. 

### Notes / potential issues
 - Saving a non-Ask page displays the specific error, like so:
<img width="363" alt="screen shot 2018-06-11 at 10 07 06 am" src="https://user-images.githubusercontent.com/354591/41246239-4c923224-6d5f-11e8-890e-898131902e2e.png">

- While saving an Ask answer (a Django model) shows something more generic:
<img width="302" alt="screen shot 2018-06-05 at 11 14 30 pm" src="https://user-images.githubusercontent.com/354591/41020167-a98d939e-6916-11e8-8fc4-bc5c3524ba8b.png">

I think this is related to this issue https://github.com/wagtail/wagtail/issues/3441  which was only recently fixed, so it would not be fixed in our current version of Wagtail.  As part of this work, I also updated the help text (hence the migrations), so I feel like it's not too big of a deal, but just wanted to flag.
