### PR TITLE
Pin urllib3

### DIFF
--- a/requirements/libraries.txt
+++ b/requirements/libraries.txt
@@ -37,6 +37,7 @@ sha3==0.2.1
 six==1.10.0
 unicodecsv==0.14.1
 unipath>=1.1,<=2.0
+# TODO: Remove explicit urllib3 requirement once requests is updated to support urllib3 1.23
 urllib3==1.22
 wagtail-flags==2.0.8
 wagtail-inventory==0.4.2

--- a/requirements/libraries.txt
+++ b/requirements/libraries.txt
@@ -37,6 +37,7 @@ sha3==0.2.1
 six==1.10.0
 unicodecsv==0.14.1
 unipath>=1.1,<=2.0
+urllib3==1.22
 wagtail-flags==2.0.8
 wagtail-inventory==0.4.2
 wagtail-sharing==0.6.1


### PR DESCRIPTION
1. requests specifies urllib3<1.23
1. edgegrid-python specifies any version of urllib3
1. edgegrid-python is installing urllib3 before requests's requirements are evaluated, causing a version conflict

This should fix it.

## Changes

- Pins urllib3 to version 1.22 temporarily

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
