### PR TITLE
Add PGPASSWORD to .python_env_SAMPLE

### DIFF
--- a/.python_env_SAMPLE
+++ b/.python_env_SAMPLE
@@ -15,6 +15,8 @@
 # See https://github.com/kennethreitz/dj-database-url for URL formatting.
 #########################################################################
 DATABASE_URL=postgres://cfpb:cfpb@postgres/cfgov
+# Required for Postgres dbshell in Django < 1.9.
+PGPASSWORD=cfpb
 
 #########################################################################
 # Deprecated MySQL settings; we plan to leave these here during the MySQL to


### PR DESCRIPTION
In Django < 1.9, `manage.py dbshell` won't pass the Postgres DB password automatically when connecting. To avoid getting prompted for the password, we can set the `PGPASSWORD` environment variable.

Here we set the sample .python_env file `PGPASSWORD` to `cfpb` because that is the password set in the `docker-compose.yml` file for the Postgres container.

## Testing

1. Start your Docker containers with `docker-compose up`.
2. Connect to the Python container with `./shell.sh`.
3. Run a Django dbshell with `cfgov/manage.py dbshell`. Note that you are not prompted for a password.

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [X] Passes all existing automated tests
- [X] Any _change_ in functionality is tested
- [X] New functions are documented (with a description, list of inputs, and expected output)
- [X] Placeholder code is flagged / future todos are captured in comments
- [X] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [X] Project documentation has been updated
- [X] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: