### PR TITLE
Minor linter fixes

### DIFF
--- a/cfgov/unprocessed/apps/analytics-gtm/js/retirement-before-you-claim-listeners.js
+++ b/cfgov/unprocessed/apps/analytics-gtm/js/retirement-before-you-claim-listeners.js
@@ -31,11 +31,11 @@ const BYCAnalytics = ( function() {
 
   $( document ).ready( function() {
 
-    $( '#step-one-form' ).submit( function( e ) {
-      e.preventDefault();
+    $( '#step-one-form' ).submit( function( evt ) {
+      evt.preventDefault();
       stepOneSubmitted = true;
-      let month = $( '#bd-month' ).val(),
-          day = $( '#bd-day' ).val();
+      const month = $( '#bd-month' ).val();
+      const day = $( '#bd-day' ).val();
       track(
         'Before You Claim Interaction',
         'Get Your Estimates submit birthdate',
@@ -43,12 +43,12 @@ const BYCAnalytics = ( function() {
       );
     } );
 
-    $( '#step-one-form' ).submit( function( e ) {
-      e.preventDefault();
-      let month = $( '#bd-month' ).val(),
-          day = $( '#bd-day' ).val(),
-          year = $( '#bd-year' ).val(),
-          age = calculateAge( month, day, year );
+    $( '#step-one-form' ).submit( function( evt ) {
+      evt.preventDefault();
+      const month = $( '#bd-month' ).val();
+      const day = $( '#bd-day' ).val();
+      const year = $( '#bd-year' ).val();
+      const age = calculateAge( month, day, year );
       track(
         'Before You Claim Interaction',
         'Get Your Estimates submit age',
@@ -97,9 +97,9 @@ const BYCAnalytics = ( function() {
     } );
 
     $( 'button.lifestyle-btn' ).click( function() {
-      let $container = $( this ).closest( '.lifestyle-question_container' ),
-          question = $container.find( 'h3' ).text().trim(),
-          value = $( this ).val();
+      const $container = $( this ).closest( '.lifestyle-question_container' );
+      const question = $container.find( 'h3' ).text().trim();
+      const value = $( this ).val();
       if ( questionsAnswered.indexOf( question ) === -1 ) {
         questionsAnswered.push( question );
       }

--- a/cfgov/unprocessed/apps/owning-a-home/js/dropdown-utils.js
+++ b/cfgov/unprocessed/apps/owning-a-home/js/dropdown-utils.js
@@ -78,19 +78,17 @@ const utils = function( id ) {
 
 
   function addOption( values ) {
-    let opts = values || {},
-        label = opts.label || '',
-        value = opts.value || '';
+    const opts = values || {};
+    const label = opts.label || '';
+    const value = opts.value || '';
 
     $el.each( function() {
-      let option;
-
       // If the option already exists, abort.
       if ( $el.children( 'option[value=' + value + ']' ).length > 0 ) {
         return;
       }
 
-      option = document.createElement( 'option' );
+      const option = document.createElement( 'option' );
       option.value = value;
       option.innerHTML = label;
       $( this ).append( option );

--- a/cfgov/unprocessed/apps/owning-a-home/js/explore-rates/data-loader.js
+++ b/cfgov/unprocessed/apps/owning-a-home/js/explore-rates/data-loader.js
@@ -1,10 +1,9 @@
+import axios from 'axios';
 import config from '../../config.json';
 
 // Auto-polyfill Promise for IE10 and IE11.
 import es6Promise from 'es6-promise';
 es6Promise.polyfill();
-
-import axios from 'axios';
 
 const CancelToken = axios.CancelToken;
 

--- a/cfgov/unprocessed/apps/owning-a-home/js/explore-rates/rate-checker.js
+++ b/cfgov/unprocessed/apps/owning-a-home/js/explore-rates/rate-checker.js
@@ -1,8 +1,5 @@
-import $ from 'jquery';
-import {
-  getCounties,
-  getData
-} from './data-loader';
+import * as params from './params';
+import * as template from './template-loader';
 import {
   calcLoanAmount,
   checkIfZero,
@@ -15,19 +12,24 @@ import {
   renderLoanAmount,
   setSelections
 } from './util';
-import * as params from './params';
-import * as template from './template-loader';
-import RateCheckerChart from './RateCheckerChart';
-import Slider from './Slider';
+import {
+  getCounties,
+  getData
+} from './data-loader';
+import { getSelection } from './dom-values';
+import { uniquePrimitives } from '../../../../js/modules/util/array-helpers';
 import amortize from 'amortize';
 import dropdown from '../dropdown-utils';
 import formatUSD from 'format-usd';
 import jumbo from 'jumbo-mortgage';
 import median from 'median';
+import RateCheckerChart from './RateCheckerChart';
+import Slider from './Slider';
 import tab from './tab';
 import unFormatUSD from 'unformat-usd';
-import { getSelection } from './dom-values';
-import { uniquePrimitives } from '../../../../js/modules/util/array-helpers';
+
+// TODO: remove jquery.
+import $ from 'jquery';
 
 // References to alert HTML.
 let creditAlertDom;
@@ -128,9 +130,6 @@ function updateView() {
       const sortedKeys = [];
       const sortedResults = {};
       let key;
-      let x;
-      let len;
-
       for ( key in results ) {
         if ( results.hasOwnProperty( key ) ) {
           sortedKeys.push( key );
@@ -138,9 +137,9 @@ function updateView() {
       }
 
       sortedKeys.sort();
-      len = sortedKeys.length;
 
-      for ( x = 0; x < len; x++ ) {
+      const len = sortedKeys.length;
+      for ( let x = 0; x < len; x++ ) {
         sortedResults[sortedKeys[x]] = results[sortedKeys[x]];
       }
 
@@ -233,12 +232,6 @@ function updateLanguage( totalVals ) {
     }
   }
 
-  function renderMedian( totalVals ) {
-    const loansMedian = median( totalVals ).toFixed( 3 );
-    const medianRate = document.querySelector( '#median-rate' );
-    medianRate.innerText = loansMedian + '%';
-  }
-
   function updateTerm() {
     const termVal = getSelection( 'loan-term' );
     $( '.rc-comparison-long .loan-years' ).text( termVal ).fadeIn();
@@ -255,6 +248,16 @@ function updateLanguage( totalVals ) {
   renderLocation();
   renderMedian( totalVals );
   updateTerm();
+}
+
+/**
+ * Render the median percentage.
+ * @param {Array} totalVals - List of interest rates.
+ */
+function renderMedian( totalVals ) {
+  const loansMedian = median( totalVals ).toFixed( 3 );
+  const medianRate = document.querySelector( '#median-rate' );
+  medianRate.innerText = loansMedian + '%';
 }
 
 /**
@@ -312,7 +315,6 @@ function loadCounties() {
  * Check the loan amount and initiate the jumbo loan interactions if need be.
  */
 function checkForJumbo() {
-  let loan;
   const jumbos = [ 'jumbo', 'agency', 'fha-hb', 'va-hb' ];
   const norms = [ 'conf', 'fha', 'va' ];
   const warnings = {
@@ -321,9 +323,8 @@ function checkForJumbo() {
     va:   template.countyVAWarning
   };
   const bounces = { 'fha-hb': 'fha', 'va-hb': 'va' };
-  let request;
 
-  loan = jumbo( {
+  const loan = jumbo( {
     loanType:   params.getVal( 'loan-type' ),
     loanAmount: params.getVal( 'loan-amount' )
   } );
@@ -600,11 +601,9 @@ function renderInterestAmounts() {
  * @param {number} term - The term used in the HTML element's ID.
  */
 function renderInterestSummary( intVals, term ) {
-
-  let sortedRates;
   const id = '#rc-comparison-summary-' + term;
 
-  sortedRates = intVals.sort( function( a, b ) {
+  const sortedRates = intVals.sort( function( a, b ) {
     return a.rate - b.rate;
   } );
 

--- a/cfgov/unprocessed/apps/owning-a-home/js/explore-rates/tab.js
+++ b/cfgov/unprocessed/apps/owning-a-home/js/explore-rates/tab.js
@@ -15,8 +15,8 @@ function init() {
     _bindTabLink( tabGroup, tabContents );
 
     // Hide all but the first tab.
-    for ( let i = 1; i < tabContents.length; i++ ) {
-      tabContents[i].classList.add( 'u-hidden' );
+    for ( let j = 1; j < tabContents.length; j++ ) {
+      tabContents[j].classList.add( 'u-hidden' );
     }
   }
 }

--- a/cfgov/unprocessed/js/molecules/Notification.js
+++ b/cfgov/unprocessed/js/molecules/Notification.js
@@ -92,12 +92,12 @@ function Notification( element ) {
   function setContent( messageText, explanationText ) {
     let content = `
       <div class="h4 m-notification_message">
-        ${messageText}
+        ${ messageText }
       </div>`;
     if ( typeof explanationText !== 'undefined' ) {
       content += `
         <p class="m-notification_explanation">
-          ${explanationText}
+          ${ explanationText }
         </p>`;
     }
     _contentDom.innerHTML = content;


### PR DESCRIPTION
## Changes

- Sets variables that don't change to be `const`.
- Alphabetizes import order and groups group imports.
- Expands event `e` variable to name `evt`.
- Renames `i` variable defined in outer scope.
- Moves `renderMedian` method to top-level.

## Testing

1. `gulp clean && gulp build` should pass.
2. http://localhost:8000/owning-a-home/explore-rates/ should work as before.
