### PR TITLE
regs3k: Update ecfr_importer to handle appendices

### DIFF
--- a/cfgov/regulations3k/fixtures/graftest.xml
+++ b/cfgov/regulations3k/fixtures/graftest.xml
@@ -71,8 +71,8 @@ Title 12: Banks and Banking</TITLE>
 
 </PSPACE></SOURCE>
 
-<DIV8 N="§ 1.1" NODE="12:1.0.1.1.1.0.1.1" TYPE="SECTION">
-<HEAD>§ 1.1   Authority, purpose, scope, and reservation of authority.</HEAD>
+<DIV8 N="§ 1002.1" NODE="12:1.0.1.1.1.0.1.1" TYPE="SECTION">
+<HEAD>§ 1002.1   Authority, purpose, scope, and reservation of authority.</HEAD>
 <P>(a) <I>Authority.</I> (1) This part is issued pursuant to 12 U.S.C. 1 <I>et seq.,</I> 12 U.S.C. 24 (Seventh), and 12 U.S.C. 93a, § 1. 
 </P>
 <P>(b) <I>Purpose</I> This part prescribes standards under which national banks may purchase, sell, deal in, underwrite, and hold securities, consistent with the authority contained in 12 U.S.C. 24 (Seventh) and safe and sound banking practices. 
@@ -90,6 +90,37 @@ Title 12: Banks and Banking</TITLE>
 </P>
 <P>9. <I>Retailers, Finance Companies, and All Other Creditors Not Listed Above:</I> FTC Regional Office for region in which the creditor operates or Federal Trade Commission, Equal Credit Opportunity, Washington, DC 20580.
 </P>
+
+<DIV9 N="" NODE="12:8.0.2.6.3.2.1.1.6" TYPE="APPENDIX">
+<HEAD>Supplement I to Part 1002 - Official Interpretations
+</HEAD>
+<HD1>Introduction</HD1>
+<P>1.<I>Official status.</I> Section 706(e) of the Equal Credit Opportunity Act protects a creditor from civil liability for any act done or omitted in good faith in conformity with an interpretation issued by a duly authorized official of the Bureau. This commentary is the means by which the Bureau of Consumer Financial Protection issues official interpretations of Regulation B. Good-faith compliance with this commentary affords a creditor protection under section 706(e) of the Act.
+</P>
+<HD1>Section 1002.1 - Authority, Scope, and Purpose
+</HD1>
+<P><I>1(a) Authority and scope.</I>
+</P>
+<P>1. <I>Scope.</I> The Equal Credit Opportunity Act and Regulation B apply to all credit - commercial as well as personal - without regard to the nature or type of the credit or the creditor, except for an entity excluded from coverage of this part (but not the Act) by section 1029 of the Consumer Financial Protection Act of 2010 (12 U.S.C. 5519). If a transaction provides for the deferral of the payment of a debt, it is credit covered by Regulation B even though it may not be a credit transaction covered by Regulation Z (Truth in Lending) (12 CFR part 1026). Further, the definition of creditor is not restricted to the party or person to whom the obligation is initially payable, as is the case under Regulation Z. Moreover, the Act and regulation apply to all methods of credit evaluation, whether performed judgmentally or by use of a credit scoring system.
+</P>
+<HD2>1(a)(1)</HD2>
+<P>2. <I>Foreign applicability.</I> Regulation B generally does not apply to lending activities that occur outside the United States. The regulation does apply to lending activities that take place within the United States (as well as the Commonwealth of Puerto Rico and any territory or possession of the United States), whether or not the applicant is a citizen.
+</P>
+<HD1>Section 1002.2 - Definitions
+</HD1>
+<P><I>2(c) Adverse action.</I>
+</P>
+<P><I>Paragraph 2(c)(1)(i).</I>
+</P>
+<P>1. <I>Application for credit.</I> If the applicant applied in accordance with the creditor's procedures, a refusal to refinance or extend the term of a business or other loan is adverse action.
+</P>
+<P><I>Paragraph 2(c)(1)(ii).</I>
+</P>
+<CITA>Interp citation</CITA>
+
+</DIV9>
+
+
 </DIV8>
 </DIV5>
 
@@ -101,10 +132,9 @@ Title 12: Banks and Banking</TITLE>
 <HED>Authority:</HED><PSPACE>12 U.S.C. 2803, 2804, 2805, 5512, 5581.
 </PSPACE></AUTH>
 <SOURCE>
-<HED>Source:</HED><PSPACE>76 FR 78468, Dec. 19, 2011, unless otherwise noted.
-
-
-</PSPACE></SOURCE>
+<HED>Source:</HED>
+<PSPACE>76 FR 78468, Dec. 19, 2011, unless otherwise noted.</PSPACE>
+</SOURCE>
 
 <DIV6 N="A" NODE="12:8.0.2.6.6.1" TYPE="SUBPART">
 <HEAD>Subpart A - General</HEAD>
@@ -128,7 +158,7 @@ Title 12: Banks and Banking</TITLE>
 </DIV8>
 </DIV6>
 <DIV9 N="Appendix A" NODE="12:8.0.2.6.3.2.1.1.1" TYPE="APPENDIX">
-<HEAD>Appendix A to Part 1002 - Federal Agencies to be Listed in Adverse Action Notices
+<HEAD>Appendix A to Part 1003 - Federal Agencies to be Listed in Adverse Action Notices
 </HEAD>
 <P>The following list indicates the Federal agency or agencies that should be listed in notices provided by creditors pursuant to § 1002.9(b)(1). Any questions concerning a particular creditor may be directed to such agencies. This list is not intended to describe agencies' enforcement authority for ECOA and Regulation B. Terms that are not defined in the Federal Deposit Insurance Act (12 U.S.C. 1813(s)) shall have the meaning given to them in the International Banking Act of 1978 (12 U.S.C. 3101).
 </P>
@@ -160,19 +190,87 @@ Title 12: Banks and Banking</TITLE>
 </P>
 </DIV9>
 
+<DIV9 N="Appendix B" NODE="12:8.0.2.6.3.2.1.1.1" TYPE="APPENDIX">
+<HEAD>Appendix B to Part 1003 - Test Appendix
+</HEAD>
+<P>(a) The following list indicates the Federal agency or agencies that should be listed in notices provided by creditors pursuant to § 1002.9(b)(1). Any questions concerning a particular creditor may be directed to such agencies. This list is not intended to describe agencies' enforcement authority for ECOA and Regulation B. Terms that are not defined in the Federal Deposit Insurance Act (12 U.S.C. 1813(s)) shall have the meaning given to them in the International Banking Act of 1978 (12 U.S.C. 3101).
+</P>
+<HD1>Introduction</HD1>
+<P>(1) <I>Banks, savings associations, and credit unions with total assets of over $10 billion and their affiliates:</I> Bureau of Consumer Financial Protection, 1700 G Street NW., Washington DC 20006. Such affiliates that are not banks, savings associations, or credit unions also should list, in addition to the Bureau: FTC Regional Office for region in which the creditor operates or Federal Trade Commission, Equal Credit Opportunity, Washington, DC 20580.
+</P>
+<P>(2) To the extent not included in item 1 above:
+</P>
+<P>(i) <I>National banks, Federal savings associations, and Federal branches and Federal agencies of foreign banks:</I> Office of the Comptroller of the Currency, Customer Assistance Group, 1301 McKinney Street, Suite 3450, Houston, TX 77010-9050
+</P>
+<P>(ii) <I>State member banks, branches and agencies of foreign banks (other than Federal branches, Federal agencies, and insured state branches of foreign banks), commercial lending companies owned or controlled by foreign banks, and organizations operating under section 25 or 25A of the Federal Reserve Act:</I> Federal Reserve Consumer Help Center, P.O. Box 1200, Minneapolis, MN 55480.
+</P>
+<P>(iii) <I>Nonmember Insured Banks, Insured State Branches of Foreign Banks, and Insured State Savings Associations:</I> FDIC Consumer Response Center, 1100 Walnut Street, Box #11, Kansas City, MO 64106.
+</P>
+<P>(iv) <I>Federal Credit Unions:</I> National Credit Union Administration, Office of Consumer Protection, 1775 Duke Street, Alexandria, VA 22314.
+</P>
+<HD2>Fake subhed2</HD2>
+<P>(3) <I>Air carriers:</I> Assistant General Counsel for Aviation Enforcement and Proceedings, Department of Transportation, 400 Seventh Street SW., Washington, DC 20590.
+</P>
+<HD3>Fake subhed3</HD3>
+<P>(4) <I>Creditors Subject to Surface Transportation Board:</I> Office of Proceedings, Surface Transportation Board, Department of Transportation, 1925 K Street NW., Washington, DC 20423.
+</P>
+<CITA>Citation</CITA>
+</DIV9>
+
+<DIV9 N="Appendix C" NODE="12:8.0.2.6.3.2.1.1.1" TYPE="APPENDIX">
+<HEAD>Appendix C to Part 1003 - Appendix with no ID type
+</HEAD>
+<P>The following list indicates the Federal agency or agencies that should be listed in notices provided by creditors pursuant to § 1002.9(b)(1). Any questions concerning a particular creditor may be directed to such agencies. This list is not intended to describe agencies' enforcement authority for ECOA and Regulation B. Terms that are not defined in the Federal Deposit Insurance Act (12 U.S.C. 1813(s)) shall have the meaning given to them in the International Banking Act of 1978 (12 U.S.C. 3101).
+</P>
+<HD1>Introduction</HD1>
+<P><I>Banks, savings associations, and credit unions with total assets of over $10 billion and their affiliates:</I> Bureau of Consumer Financial Protection, 1700 G Street NW., Washington DC 20006. Such affiliates that are not banks, savings associations, or credit unions also should list, in addition to the Bureau: FTC Regional Office for region in which the creditor operates or Federal Trade Commission, Equal Credit Opportunity, Washington, DC 20580.
+</P>
+</DIV9>
+
+<DIV9 N="Appendix MS" NODE="12:8.0.2.6.19.5.1.1.53" TYPE="APPENDIX">
+<HEAD>Appendix MS to Part 1003 - Servicing
+</HEAD>
+<P> 
+Blank graph.
+</P>
+</DIV9>
+
+<DIV9 N="Appendix MS" NODE="12:8.0.2.6.19.5.1.1.54" TYPE="APPENDIX">
+<HEAD>Appendix MS-1 to Part 1003 - Example
+</HEAD>
+<P>[Sample language; use business stationery or similar heading]
+</P>
+</DIV9>
+
 <DIV9 N="" NODE="12:8.0.2.6.3.2.1.1.6" TYPE="APPENDIX">
-<HEAD>Supplement I to Part 1002 - Official Interpretations
+<HEAD>Supplement I to Part 1003 - Official Interpretations
 </HEAD>
 <P>Following is an official interpretation of Regulation B (12 CFR part 1002) issued by the Bureau of Consumer Financial Protection. References are to sections of the regulation or the Equal Credit Opportunity Act (15 U.S.C. 1601 <I>et seq.</I>).
 </P>
-<HD1>Introduction
-</HD1>
+<HD1>Introduction</HD1>
 <P>1.<I>Official status.</I> Section 706(e) of the Equal Credit Opportunity Act protects a creditor from civil liability for any act done or omitted in good faith in conformity with an interpretation issued by a duly authorized official of the Bureau. This commentary is the means by which the Bureau of Consumer Financial Protection issues official interpretations of Regulation B. Good-faith compliance with this commentary affords a creditor protection under section 706(e) of the Act.
 </P>
-<P>2. <I>Issuance of interpretations.</I> Under appendix D to the regulation, any person may request an official interpretation. Interpretations will be issued at the discretion of designated officials and incorporated in this commentary following publication for comment in the <E T="04">Federal Register.</E> Except in unusual circumstances, official interpretations will be issued only by means of this commentary.
+<HD2>Section 1002.1 - Authority, Scope, and Purpose
+</HD2>
+<P><I>1(a) Authority and scope.</I>
 </P>
-<P>3. <I>Comment designations.</I> The comments are designated with as much specificity as possible according to the particular regulatory provision addressed. Each comment in the commentary is identified by a number and the regulatory section or paragraph that it interprets. For example, comments to § 1002.2(c) are further divided by subparagraph, such as comment 2(c)(1)(ii)-1 and comment 2(c)(2)(ii-1.
+<P>1. <I>Scope.</I> The Equal Credit Opportunity Act and Regulation B apply to all credit - commercial as well as personal - without regard to the nature or type of the credit or the creditor, except for an entity excluded from coverage of this part (but not the Act) by section 1029 of the Consumer Financial Protection Act of 2010 (12 U.S.C. 5519). If a transaction provides for the deferral of the payment of a debt, it is credit covered by Regulation B even though it may not be a credit transaction covered by Regulation Z (Truth in Lending) (12 CFR part 1026). Further, the definition of creditor is not restricted to the party or person to whom the obligation is initially payable, as is the case under Regulation Z. Moreover, the Act and regulation apply to all methods of credit evaluation, whether performed judgmentally or by use of a credit scoring system.
 </P>
+<HD3>1(a)(1)</HD3>
+<P>2. <I>Foreign applicability.</I> Regulation B generally does not apply to lending activities that occur outside the United States. The regulation does apply to lending activities that take place within the United States (as well as the Commonwealth of Puerto Rico and any territory or possession of the United States), whether or not the applicant is a citizen.
+</P>
+<HD2>Section 1002.2 - Definitions
+</HD2>
+<P><I>2(c) Adverse action.</I>
+</P>
+<P><I>Paragraph 2(c)(1)(i).</I>
+</P>
+<P>1. <I>Application for credit.</I> If the applicant applied in accordance with the creditor's procedures, a refusal to refinance or extend the term of a business or other loan is adverse action.
+</P>
+<P><I>Paragraph 2(c)(1)(ii).</I>
+</P>
+<CITA>Interp citation</CITA>
+
 </DIV9>
 
 </DIV5>

--- a/cfgov/regulations3k/fixtures/graftest.xml
+++ b/cfgov/regulations3k/fixtures/graftest.xml
@@ -127,6 +127,54 @@ Title 12: Banks and Banking</TITLE>
 </P>
 </DIV8>
 </DIV6>
+<DIV9 N="Appendix A" NODE="12:8.0.2.6.3.2.1.1.1" TYPE="APPENDIX">
+<HEAD>Appendix A to Part 1002 - Federal Agencies to be Listed in Adverse Action Notices
+</HEAD>
+<P>The following list indicates the Federal agency or agencies that should be listed in notices provided by creditors pursuant to § 1002.9(b)(1). Any questions concerning a particular creditor may be directed to such agencies. This list is not intended to describe agencies' enforcement authority for ECOA and Regulation B. Terms that are not defined in the Federal Deposit Insurance Act (12 U.S.C. 1813(s)) shall have the meaning given to them in the International Banking Act of 1978 (12 U.S.C. 3101).
+</P>
+<P>1. <I>Banks, savings associations, and credit unions with total assets of over $10 billion and their affiliates:</I> Bureau of Consumer Financial Protection, 1700 G Street NW., Washington DC 20006. Such affiliates that are not banks, savings associations, or credit unions also should list, in addition to the Bureau: FTC Regional Office for region in which the creditor operates or Federal Trade Commission, Equal Credit Opportunity, Washington, DC 20580.
+</P>
+<P>2. To the extent not included in item 1 above:
+</P>
+<P>a. <I>National banks, Federal savings associations, and Federal branches and Federal agencies of foreign banks:</I> Office of the Comptroller of the Currency, Customer Assistance Group, 1301 McKinney Street, Suite 3450, Houston, TX 77010-9050
+</P>
+<P>b. <I>State member banks, branches and agencies of foreign banks (other than Federal branches, Federal agencies, and insured state branches of foreign banks), commercial lending companies owned or controlled by foreign banks, and organizations operating under section 25 or 25A of the Federal Reserve Act:</I> Federal Reserve Consumer Help Center, P.O. Box 1200, Minneapolis, MN 55480.
+</P>
+<P>c. <I>Nonmember Insured Banks, Insured State Branches of Foreign Banks, and Insured State Savings Associations:</I> FDIC Consumer Response Center, 1100 Walnut Street, Box #11, Kansas City, MO 64106.
+</P>
+<P>d. <I>Federal Credit Unions:</I> National Credit Union Administration, Office of Consumer Protection, 1775 Duke Street, Alexandria, VA 22314.
+</P>
+<P>3. <I>Air carriers:</I> Assistant General Counsel for Aviation Enforcement and Proceedings, Department of Transportation, 400 Seventh Street SW., Washington, DC 20590.
+</P>
+<P>4. <I>Creditors Subject to Surface Transportation Board:</I> Office of Proceedings, Surface Transportation Board, Department of Transportation, 1925 K Street NW., Washington, DC 20423.
+</P>
+<P>5. <I>Creditors Subject to Packers and Stockyards Act:</I> Nearest Packers and Stockyards Administration area supervisor.
+</P>
+<P>6. <I>Small Business Investment Companies:</I> Associate Deputy Administrator for Capital Access, United States Small Business Administration, 409 Third Street SW., 8th Floor, Washington, DC 20416.
+</P>
+<P>7. <I>Brokers and Dealers:</I> Securities and Exchange Commission, Washington, DC 20549.
+</P>
+<P>8. <I>Federal Land Banks, Federal Land Bank Associations, Federal Intermediate Credit Banks, and Production Credit Associations:</I> Farm Credit Administration, 1501 Farm Credit Drive, McLean, VA 22102-5090.
+</P>
+<P>9. <I>Retailers, Finance Companies, and All Other Creditors Not Listed Above:</I> FTC Regional Office for region in which the creditor operates or Federal Trade Commission, Equal Credit Opportunity, Washington, DC 20580.
+</P>
+</DIV9>
+
+<DIV9 N="" NODE="12:8.0.2.6.3.2.1.1.6" TYPE="APPENDIX">
+<HEAD>Supplement I to Part 1002 - Official Interpretations
+</HEAD>
+<P>Following is an official interpretation of Regulation B (12 CFR part 1002) issued by the Bureau of Consumer Financial Protection. References are to sections of the regulation or the Equal Credit Opportunity Act (15 U.S.C. 1601 <I>et seq.</I>).
+</P>
+<HD1>Introduction
+</HD1>
+<P>1.<I>Official status.</I> Section 706(e) of the Equal Credit Opportunity Act protects a creditor from civil liability for any act done or omitted in good faith in conformity with an interpretation issued by a duly authorized official of the Bureau. This commentary is the means by which the Bureau of Consumer Financial Protection issues official interpretations of Regulation B. Good-faith compliance with this commentary affords a creditor protection under section 706(e) of the Act.
+</P>
+<P>2. <I>Issuance of interpretations.</I> Under appendix D to the regulation, any person may request an official interpretation. Interpretations will be issued at the discretion of designated officials and incorporated in this commentary following publication for comment in the <E T="04">Federal Register.</E> Except in unusual circumstances, official interpretations will be issued only by means of this commentary.
+</P>
+<P>3. <I>Comment designations.</I> The comments are designated with as much specificity as possible according to the particular regulatory provision addressed. Each comment in the commentary is identified by a number and the regulatory section or paragraph that it interprets. For example, comments to § 1002.2(c) are further divided by subparagraph, such as comment 2(c)(1)(ii)-1 and comment 2(c)(2)(ii-1.
+</P>
+</DIV9>
+
 </DIV5>
 </DIV3>
 </DIV1>

--- a/cfgov/regulations3k/jinja2/regulations3k/browse-regulation.html
+++ b/cfgov/regulations3k/jinja2/regulations3k/browse-regulation.html
@@ -63,12 +63,12 @@
             <ul>
                 {% if previous_section %}
                 <li class="previous next-prev">
-                    <a href="{{ routablepageurl(page, "section", previous_section.section_number) }}" class="navigation-link backward next-prev-link" data-turbolinks="true"><span class="cf-icon cf-icon-left"></span><span class="next-prev-label">Previous section - </span>{{previous_section.numeric_label}}</a> <span class="next-prev-title">{{previous_section.title_content}}</span>
+                    <a href="{{ routablepageurl(page, "section", previous_section.section_number) }}" class="navigation-link backward next-prev-link" data-turbolinks="true"><span class="cf-icon cf-icon-left"></span><span class="next-prev-label">Previous section - </span>{{previous_section.numeric_label or previous_section.label}}</a> <span class="next-prev-title">{{previous_section.title_content}}</span>
                 </li>
                 {% endif %}
                 {% if next_section %}
                 <li class="next next-prev">
-                    <a href="{{ routablepageurl(page, "section", next_section.section_number) }}" class="navigation-link forward next-prev-link" data-turbolinks="true"><span class="cf-icon cf-icon-right"></span><span class="next-prev-label">Next section - </span>{{next_section.numeric_label}}</a> <span class="next-prev-title">{{next_section.title_content}}</span>
+                    <a href="{{ routablepageurl(page, "section", next_section.section_number) }}" class="navigation-link forward next-prev-link" data-turbolinks="true"><span class="cf-icon cf-icon-right"></span><span class="next-prev-label">Next section - </span>{{next_section.numeric_label or next_section.label}}</a> <span class="next-prev-title">{{next_section.title_content}}</span>
                 </li>
                 {% endif %}
             </ul>

--- a/cfgov/regulations3k/models/django.py
+++ b/cfgov/regulations3k/models/django.py
@@ -174,6 +174,8 @@ class Section(models.Model):
         part, number = self.label.split('-')[:2]
         if number.isdigit():
             return '\xa7\xa0{}.{}'.format(part, number)
+        else:
+            return ''
 
     @property
     def section_number(self):
@@ -182,4 +184,7 @@ class Section(models.Model):
 
     @property
     def title_content(self):
-        return self.title.replace(self.numeric_label, '')
+        if self.numeric_label:
+            return self.title.replace(self.numeric_label, '')
+        else:
+            return self.title

--- a/cfgov/regulations3k/models/django.py
+++ b/cfgov/regulations3k/models/django.py
@@ -171,9 +171,9 @@ class Section(models.Model):
 
     @property
     def numeric_label(self):
-        part, number = self.label.split('-')[:2]
-        if number.isdigit():
-            return '\xa7\xa0{}.{}'.format(part, number)
+        part, section = sortable_label(self.label)[:2]
+        if section.isdigit():
+            return '\xa7\xa0{}.{}'.format(part, int(section))
         else:
             return ''
 

--- a/cfgov/regulations3k/scripts/patterns.py
+++ b/cfgov/regulations3k/scripts/patterns.py
@@ -80,6 +80,21 @@ class IdLevelState(object):
         """Determine whether an alpha token is the next logical alpha token"""
         return alpha_to_int(next_token) == alpha_to_int(token) + 1
 
+    def next_appendix_id(self):
+        _next = self.next_token
+        if self.level() == 1:  # digit level
+            if not self.current_id:
+                self.current_id = _next
+            if _next == 'a':
+                return self.dive()
+            else:
+                return self.surf()
+        if self.level() == 2:  # lowercase-alpha level: 1-a
+            if _next.isalpha():
+                return self.surf()
+            elif _next.isdigit():
+                return self.rise(1)
+
     def next_id(self):
         _next = self.next_token
         if self.level() == 1:  # lowercase-alpha level

--- a/cfgov/regulations3k/tests/test_ecfr_importer.py
+++ b/cfgov/regulations3k/tests/test_ecfr_importer.py
@@ -10,10 +10,11 @@ import mock
 from bs4 import BeautifulSoup as bS
 from requests import Response
 
-from regulations3k.models import Part, Subpart
+from regulations3k.models import Part
 from regulations3k.scripts.ecfr_importer import (
-    ecfr_to_regdown, multiple_id_test, parse_ids, parse_section_paragraphs,
-    parse_singleton_graph, run
+    ecfr_to_regdown, multiple_id_test, parse_appendix_graph,
+    parse_appendix_paragraphs, parse_ids, parse_section_paragraphs,
+    parse_singleton_graph, run, sniff_appendix_id_type
 )
 from regulations3k.scripts.integer_conversion import (
     alpha_to_int, int_to_alpha, int_to_roman, roman_to_int
@@ -22,20 +23,46 @@ from regulations3k.scripts.patterns import IdLevelState
 
 
 class ImporterTestCase(DjangoTestCase):
+    """Tests for section and appendix parsing."""
 
     fixtures = ['test_parts.json']
     # xml_fixture has partial XML for regs 1002 and 1005
     xml_fixture = "{}/regulations3k/fixtures/graftest.xml".format(
         settings.PROJECT_ROOT)
+    with open(xml_fixture, 'r') as f:
+        test_xml = f.read()
+
+    def test_appendix_id_type_sniffer(self):
+        p_soup = bS(self.test_xml, 'lxml-xml')
+        appendix_graphs = p_soup.find('DIV9').find_all('P')
+        appendix_type = sniff_appendix_id_type(appendix_graphs)
+        self.assertEqual('appendix', appendix_type)
+        section_graphs = p_soup.find('DIV8').find_all('P')
+        section_type = sniff_appendix_id_type(section_graphs)
+        self.assertEqual('section', section_type)
+
+    def test_appendix_graph_parsing(self):
+        p_soup = bS(self.test_xml, 'lxml-xml')
+        graphs = p_soup.find('DIV9').find_all('P')
+        parsed_graph2 = parse_appendix_graph(graphs[2])
+        self.assertIn(
+            "{2}\n**2.** To the extent not included in item 1 above:",
+            parsed_graph2
+        )
+        parsed_graph3 = parse_appendix_graph(graphs[3])
+        self.assertIn(
+            "{2-a}",
+            parsed_graph3
+        )
+        parse_appendix_paragraphs(graphs, 'appendix')
+        self.assertIn('{2-b}', p_soup.text)
 
     @mock.patch(
         'regulations3k.scripts.ecfr_importer.requests.get')
     def test_parser_good_request(self, mock_get):
         part_number = '1002'
-        with open(self.xml_fixture, 'r') as f:
-            test_xml = f.read()
         mock_response = mock.Mock(
-            Response, reason='OK', text=test_xml, encoding='utf-8')
+            Response, reason='OK', text=self.test_xml, encoding='utf-8')
         mock_get.return_value = mock_response
         ecfr_to_regdown(part_number)
         self.assertEqual(mock_get.call_count, 1)
@@ -55,7 +82,6 @@ class ImporterTestCase(DjangoTestCase):
         ecfr_to_regdown(part_number, file_path=self.xml_fixture)
         self.assertEqual(Part.objects.filter(
             part_number=part_number).count(), 1)
-        self.assertEqual(Subpart.objects.count(), 3)
 
     def test_part_parser_create_new(self):
         part_number = '1002'  # This part does not exist in the test fixture
@@ -138,9 +164,6 @@ class ParagraphParsingTestCase(unittest.TestCase):
         parse_ids(test_graph)
         mock_parser.assert_called_with(test_graph, two_good_ids)
 
-    def new_test(self):
-        pass
-
 
 class ParserIdTestCase(unittest.TestCase):
 
@@ -168,12 +191,47 @@ class PatternsTestCase(unittest.TestCase):
 
     levelstate = IdLevelState()
 
-    def test_level_1_surf(self):
-        self.levelstate.current_id = 'a'
-        self.levelstate.next_token = 'b'
-        self.assertEqual(self.levelstate.next_id(), 'b')
+    def test_appendix_level_1_initial(self):
+        self.levelstate.current_id = ''
+        self.levelstate.next_token = '1'
+        self.assertEqual(self.levelstate.next_appendix_id(), '1')
         self.assertEqual(self.levelstate.level(), 1)
+        self.assertEqual(self.levelstate.current_token(), '1')
+
+    def test_appendix_level_1_surf(self):
+        self.levelstate.current_id = '1'
+        self.levelstate.next_token = '2'
+        self.assertEqual(self.levelstate.next_appendix_id(), '2')
+        self.assertEqual(self.levelstate.level(), 1)
+        self.assertEqual(self.levelstate.current_token(), '2')
+
+    def test_appendix_level_1_dive(self):
+        self.levelstate.current_id = '1'
+        self.levelstate.next_token = 'a'
+        self.assertEqual(self.levelstate.next_appendix_id(), '1-a')
+        self.assertEqual(self.levelstate.level(), 2)
+        self.assertEqual(self.levelstate.current_token(), 'a')
+
+    def test_appendix_level_2_surf(self):
+        self.levelstate.current_id = '1-a'
+        self.levelstate.next_token = 'b'
+        self.assertEqual(self.levelstate.next_appendix_id(), '1-b')
+        self.assertEqual(self.levelstate.level(), 2)
         self.assertEqual(self.levelstate.current_token(), 'b')
+
+    def test_appendix_level_2_rise(self):
+        self.levelstate.current_id = '1-b'
+        self.levelstate.next_token = '2'
+        self.assertEqual(self.levelstate.next_appendix_id(), '2')
+        self.assertEqual(self.levelstate.level(), 1)
+        self.assertEqual(self.levelstate.current_token(), '2')
+
+    def test_level_1_initial(self):
+        self.levelstate.current_id = ''
+        self.levelstate.next_token = 'a'
+        self.assertEqual(self.levelstate.next_id(), 'a')
+        self.assertEqual(self.levelstate.level(), 1)
+        self.assertEqual(self.levelstate.current_token(), 'a')
 
     def test_level_1_dive(self):
         self.levelstate.current_id = 'b'

--- a/cfgov/regulations3k/tests/test_ecfr_importer.py
+++ b/cfgov/regulations3k/tests/test_ecfr_importer.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
+import datetime
+import json
 import unittest
 
 from django.conf import settings
@@ -10,11 +12,12 @@ import mock
 from bs4 import BeautifulSoup as bS
 from requests import Response
 
-from regulations3k.models import Part
+from regulations3k.models import Part, Subpart
 from regulations3k.scripts.ecfr_importer import (
-    ecfr_to_regdown, multiple_id_test, parse_appendix_graph,
-    parse_appendix_paragraphs, parse_ids, parse_section_paragraphs,
-    parse_singleton_graph, run, sniff_appendix_id_type
+    ecfr_to_regdown, get_effective_date, multiple_id_test, parse_appendices,
+    parse_appendix_elements, parse_appendix_graph, parse_appendix_paragraphs,
+    parse_ids, parse_interps, parse_part, parse_section_paragraphs,
+    parse_singleton_graph, parse_version, run, sniff_appendix_id_type
 )
 from regulations3k.scripts.integer_conversion import (
     alpha_to_int, int_to_alpha, int_to_roman, roman_to_int
@@ -34,50 +37,113 @@ class ImporterTestCase(DjangoTestCase):
 
     def test_appendix_id_type_sniffer(self):
         p_soup = bS(self.test_xml, 'lxml-xml')
-        appendix_graphs = p_soup.find('DIV9').find_all('P')
-        appendix_type = sniff_appendix_id_type(appendix_graphs)
-        self.assertEqual('appendix', appendix_type)
-        section_graphs = p_soup.find('DIV8').find_all('P')
-        section_type = sniff_appendix_id_type(section_graphs)
-        self.assertEqual('section', section_type)
+        appendices = p_soup.find_all('DIV5')[1].find_all('DIV9')
+        appendix_0_graphs = appendices[0].find_all('P')
+        appendix_0_type = sniff_appendix_id_type(appendix_0_graphs)
+        self.assertEqual('appendix', appendix_0_type)
+        appendix_1_graphs = appendices[1].find_all('P')
+        appendix_1_type = sniff_appendix_id_type(appendix_1_graphs)
+        self.assertEqual('section', appendix_1_type)
+        appendix_2_graphs = appendices[2].find_all('P')
+        appendix_2_type = sniff_appendix_id_type(appendix_2_graphs)
+        self.assertIs(appendix_2_type, None)
 
     def test_appendix_graph_parsing(self):
         p_soup = bS(self.test_xml, 'lxml-xml')
-        graphs = p_soup.find('DIV9').find_all('P')
+        graphs = p_soup.find_all('DIV5')[1].find_all('DIV9')[1].find_all('P')
         parsed_graph2 = parse_appendix_graph(graphs[2])
         self.assertIn(
-            "{2}\n**2.** To the extent not included in item 1 above:",
+            "(2) To the extent not included in item 1 above:",
             parsed_graph2
         )
         parsed_graph3 = parse_appendix_graph(graphs[3])
         self.assertIn(
-            "{2-a}",
+            "(i) National banks",
             parsed_graph3
         )
         parse_appendix_paragraphs(graphs, 'appendix')
-        self.assertIn('{2-b}', p_soup.text)
+        self.assertIn('\n1(a)', p_soup.text)
+
+    def test_interp_graph_parsing(self):
+        soup = bS(self.test_xml, 'lxml-xml')
+        part_soup = soup.find('DIV5')
+        part = parse_part(part_soup, '1002')
+        version = parse_version(part_soup, part)
+        interp_subpart = Subpart(
+            title="Supplement I to Part {}".format(part.part_number),
+            label="Official Interpretations",
+            version=version)
+        interp_subpart.save()
+        interp = [div for div
+                  in part_soup.find_all('DIV9')
+                  if div.find('HEAD').text.startswith('Supplement I')][0]
+        parse_interps(interp, part, interp_subpart)
+        self.assertEqual(
+            Subpart.objects.filter(title__contains='Supplement I').count(),
+            1,
+        )
+
+    def test_parse_appendices_no_appendix(self):
+        self.assertIs(parse_appendices('', {}), None)
+
+    def test_parse_appendix_elements(self):
+        p_soup = bS(self.test_xml, 'lxml-xml')
+        appendices = p_soup.find_all('DIV5')[1].find_all('DIV9')
+        test_element = appendices[1]
+        parsed_appendix = parse_appendix_elements(test_element)
+        self.assertIn("**(a)**", parsed_appendix)
 
     @mock.patch(
         'regulations3k.scripts.ecfr_importer.requests.get')
     def test_parser_good_request(self, mock_get):
         part_number = '1002'
         mock_response = mock.Mock(
-            Response, reason='OK', text=self.test_xml, encoding='utf-8')
+            Response,
+            ok=True,
+            text=self.test_xml, encoding='utf-8')
         mock_get.return_value = mock_response
+        mock_response.json.return_value = json.loads(
+            '{"results": [{"effective_on": "2018-01-01"}]}')
         ecfr_to_regdown(part_number)
-        self.assertEqual(mock_get.call_count, 1)
+        self.assertEqual(mock_get.call_count, 2)
+
+    @mock.patch('regulations3k.scripts.ecfr_importer.requests.get')
+    def test_good_effective_date_request(self, mock_get):
+        mock_response = mock.Mock(
+            Response,
+            ok=True)
+        mock_response.json.return_value = json.loads(
+            '{"results": [{"effective_on": "2018-01-01"}]}')
+        mock_get.return_value = mock_response
+        self.assertEqual(get_effective_date('1002'), datetime.date(2018, 1, 1))
+
+    @mock.patch('regulations3k.scripts.ecfr_importer.requests.get')
+    def test_bad_effective_date_request_returns_none(self, mock_get):
+        mock_response = mock.Mock(
+            Response,
+            ok=False)
+        mock_get.return_value = mock_response
+        self.assertIs(get_effective_date('1002'), None)
 
     @mock.patch('regulations3k.scripts.ecfr_importer.requests.get')
     def test_failed_parser_request_returns_none(self, mock_get):
         mock_response = mock.Mock(
             Response,
             reason='REQUESTS FOR HUMANS MY EYE',
-            status_code='404')
+            status_code=404,
+            ok=False)
         mock_get.return_value = mock_response
         self.assertIs(ecfr_to_regdown('1002'), None)
         self.assertEqual(mock_get.call_count, 1)
 
-    def test_part_parser_use_existing(self):
+    @mock.patch('regulations3k.scripts.ecfr_importer.requests.get')
+    def test_part_parser_uses_existing(self, mock_get):
+        mock_response = mock.Mock(  # mock to skip the effective_date request
+            Response,
+            reason='REQUESTS FOR HUMANS MY EYE',
+            status_code=404,
+            ok=False)
+        mock_get.return_value = mock_response
         part_number = '1003'  # This part exists in the test fixture
         ecfr_to_regdown(part_number, file_path=self.xml_fixture)
         self.assertEqual(Part.objects.filter(

--- a/cfgov/regulations3k/wagtail_hooks.py
+++ b/cfgov/regulations3k/wagtail_hooks.py
@@ -12,7 +12,7 @@ class SectionModelAdmin(TreeModelAdmin):
     menu_label = 'Regulation section content'
     menu_icon = 'list-ul'
     list_display = (
-        'title',
+        'label', 'title',
     )
     search_fields = (
         'label', 'title')


### PR DESCRIPTION
Appendices and interpretations share the same DIVs in our source XML.
This change teases them out and processes them separately.

In the pursuit of small PRs, this is an incremental change, focusing on parsing just the main text of appendices with subheadings, and recognizing when they're using a different indentation scheme.

This code doesn't work for all regs yet, nor does it properly handle our oddities: pseudo-forms, tables and images.

Some other improvements included:
- A fix to the Section model's "numeric_label" property so that it doesn't choke on appendices, which have alpha section labels.
- A fix to the ordering of side navigation subparts and sections.
- The addition of "label" field to list display for sections in the admin, to help identify appendices.

## Testing
Appendix imports aren't working for all regs, but you can test B with:

```
./cfgov/manage.py runscript ecfr_importer --script-args 1002
```

There's a slight drop in test coverage that will be addressed in the next iteration.
