### PR TITLE
Fix doc link to Elasticsearch instructions

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -8,7 +8,7 @@ which will be used for:
     such as `git checkout master`.
  2. **Elasticsearch**.
     Run an Elasticsearch (ES) instance.
-    See instructions [below](#2-run-elasticsearch).
+    See instructions [below](#2-run-elasticsearch-optional).
  3. **Django server**. Start and stop the web server.
     Server is started with `./runserver.sh`,
     but see more details [below](#3-load-indexes--launch-site).


### PR DESCRIPTION
PR #4242 (88bffb0) broke a section link in the docs by renaming a section.

See [the live docs](https://cfpb.github.io/cfgov-refresh/usage/#2-run-elasticsearch) for the currently broken link.