### PR TITLE
Text change for HUD API

### DIFF
--- a/cfgov/legacy/templates/hud/housing_counselor.html
+++ b/cfgov/legacy/templates/hud/housing_counselor.html
@@ -97,11 +97,7 @@ Find a housing counselor
                             </div>
                             <div id="hud_hca_api_more_info_container" class="hud_hca_api_more_info">
                                 <p>
-                                    This tool is open sourced on
-                                    <a href="https://github.com/cfpb/django-hud">GitHub</a>
-                                    and powered by <a href="https://data.hud.gov/housing_counseling.html">HUD's</a>
-                                    official list of housing counselors.
-                                    We encourage you to leverage it in your own applications.
+                                    This tool is powered by <a href="https://data.hud.gov/housing_counseling.html">HUD's</a> official list of housing counselors.
                                 </p>
 
                                 <p>


### PR DESCRIPTION
Changes the text in the sidebar for the "Find a Housing Counselor" tool to link to the HUD page and information.

## Changes

- Enacts only the text change from #4086

## Testing

1. Visit your local version of https://www.consumerfinance.gov/find-a-housing-counselor/
1. Verify the text in the gray box has changed

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [x] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Internet Explorer 8, 9, 10, and 11
- [ ] Edge
- [ ] iOS Safari
- [ ] Chrome for Android

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
