### PR TITLE
Disable legacy HUD API for non-prod environments

### DIFF
--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -671,7 +671,11 @@ FLAGS = {
 
     'REGULATIONS3K': {
         'boolean': DEPLOY_ENVIRONMENT == 'build'
-    }
+    },
+
+    'LEGACY_HUD_API': {
+        'boolean': DEPLOY_ENVIRONMENT == 'production',
+    },
 }
 
 

--- a/cfgov/cfgov/urls.py
+++ b/cfgov/cfgov/urls.py
@@ -213,10 +213,17 @@ urlpatterns = [
             'paying_for_college', 'paying_for_college.config.urls')),
     url(r'^credit-cards/agreements/',
         include('agreements.urls')),
-    url(r'^hud-api-replace/', include_if_app_enabled(
-        'hud_api_replace',
-        'hud_api_replace.urls',
-        namespace='hud_api_replace')),
+
+    flagged_url(
+        'LEGACY_HUD_API',
+        r'^hud-api-replace/',
+        include_if_app_enabled(
+            'hud_api_replace',
+            'hud_api_replace.urls',
+            namespace='hud_api_replace'
+        )
+    ),
+
     url(r'^consumer-tools/retirement/',
         include_if_app_enabled('retirement_api', 'retirement_api.urls')),
 


### PR DESCRIPTION
The legacy HUD API (powered by https://github.com/cfpb/django-hud) should only be enabled for the production environment. Other environments (those using Postgres) do not support that app, and accessing the legacy API endpoints will cause 500 errors.

This change creates a new (temporary) feature flag, `LEGACY_HUD_API`, that is only enabled in production.

To test, run a local server and visit http://localhost:8000/hud-api-replace/20005.json/. With this change, you'll get a 404 at that location. Then re-run your server, first setting the environment variable `DEPLOY_ENVIRONMENT` to `production`. At that page you'll either get results (if using MySQL and a valid dump) or an (expected) Postgres error if you're missing the table from the dump.

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [X] Passes all existing automated tests
- [X] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: