### PR TITLE
Regulations 3000: Use database fields for sorting sections and subparts

### DIFF
--- a/cfgov/regulations3k/migrations/0005_add_sortable_label_subpart_type.py
+++ b/cfgov/regulations3k/migrations/0005_add_sortable_label_subpart_type.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('regulations3k', '0004_add_acquired_and_draft_to_effectiveversion'),
+    ]
+
+    operations = [
+        migrations.AlterModelOptions(
+            name='section',
+            options={'ordering': ['sortable_label']},
+        ),
+        migrations.AlterModelOptions(
+            name='subpart',
+            options={'ordering': ['subpart_type', 'label']},
+        ),
+        migrations.AddField(
+            model_name='section',
+            name='sortable_label',
+            field=models.CharField(max_length=255, blank=True),
+        ),
+        migrations.AddField(
+            model_name='subpart',
+            name='subpart_type',
+            field=models.IntegerField(default=0, choices=[(0, 'Regulation Body'), (1000, 'Appendix'), (2000, 'Interpretation')]),
+        ),
+    ]

--- a/cfgov/regulations3k/migrations/0006_set_sortable_label_subpart_type.py
+++ b/cfgov/regulations3k/migrations/0006_set_sortable_label_subpart_type.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+from regulations3k.models import sortable_label
+
+
+def forwards(apps, schema_editor):
+    Subpart = apps.get_model("regulations3k", "Subpart")
+    for subpart in Subpart.objects.all():
+        if 'appendi' in subpart.label.lower():
+            subpart.subpart_type = 1000
+        elif 'interp' in subpart.label.lower():
+            subpart.subpart_type = 2000
+        subpart.save()
+
+    Section = apps.get_model("regulations3k", "Section")
+    for section in Section.objects.all():
+        # Save the section again to apply our sortable label logic
+        section.sortable_label = '-'.join(sortable_label(section.label))
+        section.save()
+
+
+def backwards(apps, schema_editor):
+    # There's no need to go backwards, because these fields will simply
+    # disappear with no loss of information that's captured with existing
+    # fields.
+    pass
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('regulations3k', '0005_add_sortable_label_subpart_type'),
+    ]
+
+    operations = [
+        migrations.RunPython(forwards, backwards)
+    ]

--- a/cfgov/regulations3k/migrations/0007_make_sortable_label_required.py
+++ b/cfgov/regulations3k/migrations/0007_make_sortable_label_required.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('regulations3k', '0006_set_sortable_label_subpart_type'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='section',
+            name='sortable_label',
+            field=models.CharField(max_length=255),
+        ),
+    ]

--- a/cfgov/regulations3k/models/django.py
+++ b/cfgov/regulations3k/models/django.py
@@ -196,6 +196,6 @@ class Section(models.Model):
     @property
     def title_content(self):
         if self.numeric_label:
-            return self.title.replace(self.numeric_label, '')
+            return self.title.replace(self.numeric_label, '').strip()
         else:
             return self.title

--- a/cfgov/regulations3k/models/django.py
+++ b/cfgov/regulations3k/models/django.py
@@ -110,9 +110,23 @@ class Subpart(models.Model):
     title = models.CharField(max_length=255, blank=True)
     version = models.ForeignKey(EffectiveVersion, related_name="subparts")
 
+    BODY = 0000
+    APPENDIX = 1000
+    INTERPRETATION = 2000
+    SUBPART_TYPE_CHOICES = (
+        (BODY, 'Regulation Body'),
+        (APPENDIX, 'Appendix'),
+        (INTERPRETATION, 'Interpretation'),
+    )
+    subpart_type = models.IntegerField(
+        choices=SUBPART_TYPE_CHOICES,
+        default=BODY,
+    )
+
     panels = [
         FieldPanel('label'),
         FieldPanel('title'),
+        FieldPanel('subpart_type'),
         FieldPanel('version'),
     ]
 
@@ -126,25 +140,15 @@ class Subpart(models.Model):
 
     @property
     def section_range(self):
-        if not self.sections.exists():
+        if self.subpart_type != Subpart.BODY or not self.sections.exists():
             return ''
-        if 'Interp' in self.label:
-            return ''
-        if 'Append' in self.title:
-            return ''
-        if self.sections.first().section_number.isdigit():
-            sections = sorted(
-                self.sections.all(), key=lambda x: int(x.section_number))
-            return "{}–{}".format(
-                sections[0].numeric_label, sections[-1].numeric_label)
-        # else:
-        #     sections = sorted(
-        #         self.sections.all(), key=lambda x: x.section_number)
-        #     return "{}–{}".format(
-        #         sections[0].label, sections[-1].label)
+
+        sections = self.sections.all()
+        return "{}–{}".format(
+            sections[0].numeric_label, sections.reverse()[0].numeric_label)
 
     class Meta:
-        ordering = ['label']
+        ordering = ['subpart_type', 'label']
 
 
 @python_2_unicode_compatible
@@ -153,6 +157,7 @@ class Section(models.Model):
     title = models.CharField(max_length=255, blank=True)
     contents = models.TextField(blank=True)
     subpart = models.ForeignKey(Subpart, related_name="sections")
+    sortable_label = models.CharField(max_length=255)
 
     panels = [
         FieldPanel('label'),
@@ -165,20 +170,28 @@ class Section(models.Model):
         return self.title
 
     class Meta:
-        ordering = ['label']
+        ordering = ['sortable_label']
 
-    @property
-    def numeric_label(self):
-        part, section = sortable_label(self.label)[:2]
-        if section.isdigit():
-            return '\xa7\xa0{}.{}'.format(part, int(section))
-        else:
-            return ''
+    def save(self, **kwargs):
+        self.sortable_label = '-'.join(sortable_label(self.label))
+        super(Section, self).save(**kwargs)
+
+    @cached_property
+    def part(self):
+        return self.subpart.version.part.part_number
 
     @property
     def section_number(self):
         part, number = self.label.split('-')[:2]
         return number
+
+    @property
+    def numeric_label(self):
+        part, section = self.sortable_label.split('-')[:2]
+        if section.isdigit():
+            return '\xa7\xa0{}.{}'.format(part, int(section))
+        else:
+            return ''
 
     @property
     def title_content(self):

--- a/cfgov/regulations3k/models/pages.py
+++ b/cfgov/regulations3k/models/pages.py
@@ -19,7 +19,7 @@ from wagtail.wagtailcore.models import PageManager
 # Our RegDownTextField field doesn't generate a good widget yet
 # from regulations3k.models.fields import RegDownTextField
 from ask_cfpb.models.pages import SecondaryNavigationJSMixin
-from regulations3k.models import Part, Section, sortable_label  # , Subpart
+from regulations3k.models import Part, Section
 from regulations3k.regdown import regdown
 from regulations3k.resolver import get_contents_resolver, get_url_resolver
 from v1.atomic_elements import molecules
@@ -90,10 +90,8 @@ class RegulationPage(RoutablePageMixin, SecondaryNavigationJSMixin, CFGOVPage):
         )
 
     @cached_property
-    def sorted_sections(self):
-        """ Sort all sections within our section_query on sortable_label """
-        return sorted(self.section_query.all(),
-                      key=lambda s: sortable_label(s.label))
+    def sections(self):
+        return list(self.section_query.all())
 
     def get_context(self, request, *args, **kwargs):
         context = super(CFGOVPage, self).get_context(request, *args, **kwargs)
@@ -110,7 +108,7 @@ class RegulationPage(RoutablePageMixin, SecondaryNavigationJSMixin, CFGOVPage):
             self.regulation.part_number, section)
 
         section = self.section_query.get(label=section_label)
-        current_index = self.sorted_sections.index(section)
+        current_index = self.sections.index(section)
         context = self.get_context(request)
 
         content = regdown(
@@ -125,9 +123,9 @@ class RegulationPage(RoutablePageMixin, SecondaryNavigationJSMixin, CFGOVPage):
             'content': content,
             'get_secondary_nav_items': get_reg_nav_items,
             'next_section': get_next_section(
-                self.sorted_sections, current_index),
+                self.sections, current_index),
             'previous_section': get_previous_section(
-                self.sorted_sections, current_index),
+                self.sections, current_index),
             'section': section,
         })
 
@@ -175,9 +173,19 @@ def get_reg_nav_items(request, current_page):
     url_bits = [bit for bit in request.url.split('/') if bit]
     current_label = url_bits[-1]
     current_part = current_page.regulation.part_number
-    sorted_sections = current_page.sorted_sections
-    nav_elements = {
-        section: {
+    sections = current_page.sections
+    subpart_dict = OrderedDict()
+
+    for section in sections:
+        # If the section's subpart isn't in the subpart dict yet, add it
+        if section.subpart not in subpart_dict:
+            subpart_dict[section.subpart] = {
+                'sections': [],
+                'expanded': False
+            }
+
+        # Create the section dictionary for navigation
+        section_dict = {
             'title': section.title,
             'url': current_page.url + current_page.reverse_subpage(
                 'section',
@@ -189,23 +197,14 @@ def get_reg_nav_items(request, current_page):
             'expanded': True,
             'section': section,
         }
-        for section in sorted_sections
-    }
-    subpart_dict = OrderedDict()
-    for section in sorted_sections:
-        if section.subpart in subpart_dict:
-            subpart_dict[section.subpart]['sections'].append(
-                nav_elements[section])
-        else:
-            subpart_dict[section.subpart] = {
-                'sections': [],
-                'expanded': False
-            }
-            subpart_dict[section.subpart]['sections'].append(
-                nav_elements[section])
-    for subpart in subpart_dict:
-        nav_dict = subpart_dict[subpart]
-        for section_dict in nav_dict['sections']:
-            if section_dict['active']:
-                nav_dict['expanded'] = True
+
+        # Add it to the subpart
+        subpart_dict[section.subpart]['sections'].append(
+            section_dict
+        )
+
+        # Set the subpart to active if the section is active
+        if section_dict['active']:
+            subpart_dict[section.subpart]['expanded'] = True
+
     return subpart_dict, False

--- a/cfgov/regulations3k/tests/test_models.py
+++ b/cfgov/regulations3k/tests/test_models.py
@@ -215,8 +215,26 @@ class RegModelTests(DjangoTestCase):
 
     def test_section_title_content(self):
         self.assertEqual(
-            self.section_num15.title_content.strip(),
+            self.section_num15.title_content,
             'Rules concerning requests for information.')
+
+    def test_section_part(self):
+        self.assertEqual(self.section_num4.part, '1002')
+
+    def test_section_section_number(self):
+        self.assertEqual(self.section_num4.section_number, '4')
+
+    def test_section_numeric_label(self):
+        self.assertEqual(self.section_num4.numeric_label, '\xa7\xa01002.4')
+
+    def test_section_numeric_label_not_digits(self):
+        self.assertEqual(self.section_alpha.numeric_label, '')
+
+    def test_section_title_content_not_digits(self):
+        self.assertEqual(
+            self.section_beta.title_content,
+            'Appendix B to Part 1002-Errata'
+        )
 
 
 class SectionNavTests(unittest.TestCase):

--- a/cfgov/regulations3k/tests/test_models.py
+++ b/cfgov/regulations3k/tests/test_models.py
@@ -48,18 +48,21 @@ class RegModelTests(DjangoTestCase):
             Subpart,
             label='1002',
             title='General',
+            subpart_type=Subpart.BODY,
             version=self.effective_version
         )
         self.subpart_appendices = mommy.make(
             Subpart,
             label='1002-Appendices',
             title='Appendices',
+            subpart_type=Subpart.APPENDIX,
             version=self.effective_version
         )
         self.subpart_interps = mommy.make(
             Subpart,
             label='Official Interpretations',
             title='Supplement I to Part 1002',
+            subpart_type=Subpart.INTERPRETATION,
             version=self.effective_version
         )
         self.subpart_orphan = mommy.make(
@@ -183,10 +186,10 @@ class RegModelTests(DjangoTestCase):
     def test_sortable_label(self):
         self.assertEqual(sortable_label('1-A-Interp'), ('0001', 'A', 'interp'))
 
-    def test_sorted_sections(self):
-        sorted_sections = [s.label for s in self.reg_page.sorted_sections]
+    def test_sections(self):
+        sections = [s.label for s in self.reg_page.sections]
         self.assertEqual(
-            sorted_sections,
+            sections,
             ['1002-4', '1002-15', 'Appendix 1002-A',
              'Appendix 1002-B', 'Interpretations for Appendix 1002-A'])
 

--- a/cfgov/regulations3k/wagtail_hooks.py
+++ b/cfgov/regulations3k/wagtail_hooks.py
@@ -30,6 +30,7 @@ class SubpartModelAdmin(TreeModelAdmin):
     child_field = 'sections'
     child_model_admin = SectionModelAdmin
     parent_field = 'version'
+    ordering = ['subpart_type', 'label']
 
 
 class EffectiveVersionModelAdmin(TreeModelAdmin):


### PR DESCRIPTION
Subparts and sections of regulations have some human-friendly sorting keys attached to them, but they're not friendly for database sorting. This PR makes two changes to enable us to sort these in our database queries:

- Adds `subpart_type` to `Subpart`, with possible values of `Subpart.BODY`, `Subpart.APPENDIX`, and `Subpart.INTERPRETATION`. Subparts are now sorted based on the subpart type and then their label.
- Adds `sortable_label` to `Section`, which will be automatically populared with a "-"-joined result of a call to our `sortable_label()` function, which was already in use for sorting on the front-end. Sections are now sorted based on this field.

These two changes are accompanied by changes to the front-end to end our sorting in the `RegulationPage` object and rely instead on the ordering with which they come out of the database. For this I've renamed the `sorted_sections` property to `sections`, which returns a list containing all the section queryset objects. Then this is used everywhere `sorted_sections` was.

I also refactored `get_reg_nav_items()` while I was there to only loop over sections once.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
