### PR TITLE
Upgrade Wagtail-TreeModelAdmin to 1.0.3

### DIFF
--- a/cfgov/regulations3k/models/django.py
+++ b/cfgov/regulations3k/models/django.py
@@ -97,8 +97,7 @@ class EffectiveVersion(models.Model):
     ]
 
     def __str__(self):
-        return "{}, effective {}".format(
-            self.part, self.effective_date)
+        return "Effective on {}".format(self.effective_date)
 
     class Meta:
         ordering = ['effective_date']
@@ -118,8 +117,7 @@ class Subpart(models.Model):
     ]
 
     def __str__(self):
-        return "{} {}, effective {}".format(
-            self.label, self.title, self.version.effective_date)
+        return self.title
 
     @property
     def subpart_heading(self):
@@ -164,7 +162,7 @@ class Section(models.Model):
     ]
 
     def __str__(self):
-        return "{} {}".format(self.label, self.title)
+        return self.title
 
     class Meta:
         ordering = ['label']

--- a/cfgov/regulations3k/tests/test_models.py
+++ b/cfgov/regulations3k/tests/test_models.py
@@ -129,17 +129,17 @@ class RegModelTests(DjangoTestCase):
     def test_subpart_string_method(self):
         self.assertEqual(
             self.subpart.__str__(),
-            '1002 General, effective 2014-01-18')
+            'General')
 
     def test_section_string_method(self):
         if sys.version_info >= (3, 0):
             self.assertEqual(
                 self.section_num4.__str__(),
-                '1002-4 \xa7\xa01002.4 General rules.')
+                '\xa7\xa01002.4 General rules.')
         else:
             self.assertEqual(
                 self.section_num4.__str__(),
-                '1002-4 \xa7\xa01002.4 General rules.'.encode('utf8'))
+                '\xa7\xa01002.4 General rules.'.encode('utf8'))
 
     def test_subpart_headings(self):
         for each in Subpart.objects.all():
@@ -148,7 +148,7 @@ class RegModelTests(DjangoTestCase):
     def test_effective_version_string_method(self):
         self.assertEqual(
             self.effective_version.__str__(),
-            '12 CFR Part 1002 (Regulation B), effective 2014-01-18')
+            'Effective on 2014-01-18')
 
     def test_landing_page_get_context(self):
         test_context = self.landing_page.get_context(HttpRequest())

--- a/requirements/libraries.txt
+++ b/requirements/libraries.txt
@@ -42,5 +42,5 @@ urllib3==1.22
 wagtail-flags==2.0.8
 wagtail-inventory==0.4.2
 wagtail-sharing==0.6.1
-wagtail-treemodeladmin==1.0.2
+wagtail-treemodeladmin==1.0.3
 Wand==0.4.2


### PR DESCRIPTION
This PR updates Wagtail-TreeModelAdmin to 1.0.3, which uses the parent's string representation as the breadcrumb. This PR also slightly modifies the `__str__` methods of some of our Regulations 3000 models so that make more sense in that context.


## Screenshots

<img width="632" alt="image" src="https://user-images.githubusercontent.com/10562538/41318561-c359b686-6e66-11e8-8df5-129c4ce3abfa.png">


## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: