### PR TITLE
regs3k: add 'ALL' option to ecfr_importer

### DIFF
--- a/cfgov/regulations3k/scripts/ecfr_importer.py
+++ b/cfgov/regulations3k/scripts/ecfr_importer.py
@@ -38,6 +38,10 @@ PART_WHITELIST = [
     '1070', '1071', '1072', '1073', '1074', '1075', '1076',
     '1080', '1081', '1082', '1083', '1090', '1091',
 ]
+LEGACY_PARTS = [
+    '1002', '1003', '1004', '1005', '1010', '1011', '1012', '1013',
+    '1024', '1026', '1030',
+]
 # The latest eCFR version of title-12, updated every few days
 LATEST_ECFR = ("https://www.gpo.gov/fdsys/bulkdata/ECFR/"
                "title-{0}/ECFR-title{0}.xml".format(CFR_TITLE))
@@ -611,9 +615,21 @@ def run(*args):
         logger.info(
             "Usage: ./cfgov/manage.py runscript "
             "ecfr_importer --script-args "
-            "[PART NUMBER] [OPTIONAL XML FILE PATH]")
+            "[PART NUMBER or 'ALL'] [OPTIONAL XML FILE PATH]")
         sys.exit(1)
     elif len(args) == 1:
-        ecfr_to_regdown(args[0])
+        if args[0] == 'ALL':
+            for part in LEGACY_PARTS:
+                logger.info("parsing {} from the latest eCFR XML".format(part))
+                logger.info(ecfr_to_regdown(part))
+        else:
+            logger.info("parsing {} from the latest eCFR XML".format(args[0]))
+            logger.info(ecfr_to_regdown(args[0]))
     else:
-        ecfr_to_regdown(args[0], file_path=args[1])
+        if args[0] == 'ALL':
+            for part in LEGACY_PARTS:
+                logger.info('parsing {} from local XML file'.format(part))
+                logger.info(ecfr_to_regdown(part, file_path=args[1]))
+        else:
+            logger.info('parsing {} from local XML file'.format(args[0]))
+            logger.info(ecfr_to_regdown(args[0], file_path=args[1]))

--- a/cfgov/regulations3k/tests/test_ecfr_importer.py
+++ b/cfgov/regulations3k/tests/test_ecfr_importer.py
@@ -161,14 +161,29 @@ class ImporterTestCase(DjangoTestCase):
             None)
         self.assertEqual(Part.objects.filter(part_number='1002').count(), 0)
 
+
+class ImporterRunTestCase(unittest.TestCase):
+    """Tests for running the ecfr importer via commands."""
+
     @mock.patch('regulations3k.scripts.ecfr_importer.ecfr_to_regdown')
     def test_run_with_one_arg_calls_importer(self, mock_importer):
         run('1002')
         self.assertEqual(mock_importer.call_count, 1)
 
-    def test_run_works_with_local_file(self):
-        run('1002', self.xml_fixture)
-        self.assertEqual(Part.objects.filter(part_number='1002').count(), 1)
+    @mock.patch('regulations3k.scripts.ecfr_importer.ecfr_to_regdown')
+    def test_run_works_with_local_file(self, mock_importer):
+        run('1002', '/mock/local/file.xml')
+        self.assertEqual(mock_importer.call_count, 1)
+
+    @mock.patch('regulations3k.scripts.ecfr_importer.ecfr_to_regdown')
+    def test_run_all(self, mock_importer):
+        run('ALL')
+        self.assertEqual(mock_importer.call_count, 11)
+
+    @mock.patch('regulations3k.scripts.ecfr_importer.ecfr_to_regdown')
+    def test_run_all_with_local_file(self, mock_importer):
+        run('ALL', '/mock/local/file.xml')
+        self.assertEqual(mock_importer.call_count, 11)
 
     def test_run_importer_no_args(self):
         with self.assertRaises(SystemExit):


### PR DESCRIPTION
This allows you to import all 11 of our legacy eregs regulations
as regdown, saved as draft versions in Wagtail.

## Testing

Imports are roughly twice as fast if you parse a local file.  
This will get you one:

```
cd ~/Downloads && curl -O https://www.gpo.gov/fdsys/bulkdata/ECFR/title-12/ECFR-title12.xml
```

Then you can import all regs with:

```
./cfgov/manage.py runscript ecfr_importer --script-args ALL ~/Downloads/ECFR-title12.xml
```
