### PR TITLE
Deprecate HUD API

### DIFF
--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -88,7 +88,6 @@ OPTIONAL_APPS = [
     {'import': 'comparisontool', 'apps': ('comparisontool', 'haystack',)},
     {'import': 'paying_for_college',
      'apps': ('paying_for_college', 'haystack',)},
-    {'import': 'hud_api_replace', 'apps': ('hud_api_replace',)},
     {'import': 'retirement_api', 'apps': ('retirement_api',)},
     {'import': 'complaint', 'apps': ('complaint',
      'complaintdatabase', 'complaint_common',)},
@@ -310,10 +309,6 @@ SHEER_ELASTICSEARCH_SETTINGS = \
 
 STATIC_VERSION = ''
 
-# DJANGO HUD API
-DJANGO_HUD_API_ENDPOINT= os.environ.get('HUD_API_ENDPOINT', 'http://localhost/hud-api-replace/')
-# in seconds, 2592000 == 30 days. Google allows no more than a month of caching
-DJANGO_HUD_GEODATA_EXPIRATION_INTERVAL = 2592000
 MAPBOX_ACCESS_TOKEN = os.environ.get('MAPBOX_ACCESS_TOKEN')
 HOUSING_COUNSELOR_S3_PATH_TEMPLATE = (
     'a/assets/hud/{format}s/{zipcode}.{format}'

--- a/cfgov/cfgov/urls.py
+++ b/cfgov/cfgov/urls.py
@@ -214,16 +214,6 @@ urlpatterns = [
     url(r'^credit-cards/agreements/',
         include('agreements.urls')),
 
-    flagged_url(
-        'LEGACY_HUD_API',
-        r'^hud-api-replace/',
-        include_if_app_enabled(
-            'hud_api_replace',
-            'hud_api_replace.urls',
-            namespace='hud_api_replace'
-        )
-    ),
-
     url(r'^consumer-tools/retirement/',
         include_if_app_enabled('retirement_api', 'retirement_api.urls')),
 

--- a/requirements/optional-public.txt
+++ b/requirements/optional-public.txt
@@ -6,6 +6,5 @@ https://github.com/cfpb/regulations-site/releases/download/2.2.4/regulations-2.2
 https://github.com/cfpb/retirement/releases/download/0.6.1/retirement-0.6.1-py2-none-any.whl
 git+https://github.com/cfpb/ccdb5-api.git@v1.0.5#egg=ccdb5-api
 git+https://github.com/cfpb/ccdb5-ui.git@v1.0.10#egg=ccdb5_ui
-https://github.com/cfpb/django-hud/releases/download/1.4.3/django_hud-1.4.3-py2-none-any.whl
 https://github.com/cfpb/django-college-costs-comparison/releases/download/1.5.3/comparisontool-1.5.3-py2-none-any.whl
 https://github.com/cfpb/teachers-digital-platform/releases/download/0.5.22/teachers_digital_platform-0.5.22-py2-none-any.whl


### PR DESCRIPTION
The Housing Counselor API is being permanently decommissioned after June 15, 2018. We recommend using the official public [HUD API](https://data.hud.gov/housing_counseling.html)  as a permanent solution for locating housing counselors, which is what the Bureau uses for our [Find a Housing Counselor](https://www.consumerfinance.gov/find-a-housing-counselor/) tool. 

If you need some of the features that we have developed on top of the HUD API, feel free to explore the code of our [legacy API](https://www.consumerfinance.gov/external-site/?ext_url=https%3A%2F%2Fgithub.com%2Fcfpb%2Fdjango-hud&signature=inr5Ee5f4rgTCpzaOLfAHG4Y9QQ  or the code that powers the current implementation of the page, which can be found in the [cfgov-refresh](https://github.com/cfpb/cfgov-refresh/) project.

## Changes

- Restores deprecation of HUD API per https://github.com/cfpb/cfgov-refresh/pull/4086 (temporarily reversed by https://github.com/cfpb/cfgov-refresh/pull/4118) and disables the legacy HUD API endpoints
- Deprecation notices were posted on individual repositories as well as https://www.consumerfinance.gov/hud-api-replace/

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [x] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
