### PR TITLE
Adjust jinja whitespace removal to fix lack of spaces

### DIFF
--- a/cfgov/jinja2/v1/_includes/molecules/global-header-cta.html
+++ b/cfgov/jinja2/v1/_includes/molecules/global-header-cta.html
@@ -18,7 +18,7 @@
     <div class="m-global-header-cta
                 m-global-header-cta__{{ 'horizontal' if is_horizontal else 'list' }}">
         <a href="/complaint/"
-           {{- '' if is_horizontal else 'aria-role=menuitem' }}>
+           {{- '' if is_horizontal else ' aria-role=menuitem' }}>
             {{ svg_icon('complaint') }}
             Submit a Complaint
         </a>

--- a/cfgov/jinja2/v1/_includes/organisms/mega-menu.html
+++ b/cfgov/jinja2/v1/_includes/organisms/mega-menu.html
@@ -180,13 +180,13 @@
     {% set has_children = nav_item.nav_groups | count > 0 or nav_item.nav_items | count > 0 %}
 
     <li class="m-list_item {{ _classes( nav_depth, '-item' ) }}"
-        {{- 'data-js-hook=behavior_flyout-menu' if has_children else '' }}>
+        {{ 'data-js-hook=behavior_flyout-menu' if has_children else '' }}>
         {# TODO: Disable link (or overview link) of page user is currently on (on mobile). #}
         <a class="{{- 'u-link__disabled' if url == '' else '' -}}
                   {{- _classes( nav_depth, '-link' ) -}}
                   {{- _classes( nav_depth, '-link__has-children' ) if has_children else '' -}}
                   {{- _classes( nav_depth, '-link__current' ) if url == request.path else '' -}}"
-           {{- '' if url == '' else 'href=' + url | e }}
+           {{ '' if url == '' else 'href=' + url | e }}
            {{
              'data-js-hook=behavior_flyout-menu_trigger
               aria-haspopup=menu'


### PR DESCRIPTION
https://validator.w3.org/nu/?showoutline=yes&showimagereport=yes&doc=https%3A%2F%2Fwww.consumerfinance.gov/

Flagged attributes that were missing spaces between them.

## Changes

- Adjusts whitespace stripping in jinja to fix attributes in the menu that had no whitespace separation.

## Testing

1. You can check this branch locally with https://chrome.google.com/webstore/detail/html-validator/mpbelhhnfhfjnaehkcnnaknldmnocglk?hl=en-US It will have errors, but shouldn't have errors related to lack of space between attributes.
