### PR TITLE
Fix incorrect for attribute value

### DIFF
--- a/cfgov/jinja2/v1/_includes/molecules/global-search.html
+++ b/cfgov/jinja2/v1/_includes/molecules/global-search.html
@@ -57,7 +57,7 @@
                               class="a-text-input"
                               value=""
                               placeholder="Search the CFPB">
-                       <label for="query"
+                       <label for="m-global-search_query"
                               class="input-contains-label_after
                                      input-contains-label_after__clear
                                      u-hidden">


### PR DESCRIPTION
The id for the query has been updated to `m-global-search_query`, so this outdated `query` value needs to be updated.


## Changes

- Fix bug where delete label in global search had an outdated for attribute value.

## Testing

- When in the mobile size of the homepage, enter text into the search input (an "x" should appear). Click the "x" to clear the text.