### PR TITLE
Remove unnecessary contentinfo role from footer

### DIFF
--- a/cfgov/jinja2/v1/_includes/organisms/footer.html
+++ b/cfgov/jinja2/v1/_includes/organisms/footer.html
@@ -15,7 +15,7 @@
 {% import 'molecules/social-media.html' as social_media with context %}
 {% import 'atoms/tagline.html' as tagline with context %}
 {% set external_redirect_url = '/external-site/?ext_url=' %}
-<footer class="o-footer" role="contentinfo">
+<footer class="o-footer">
     <div class="wrapper wrapper__match-content">
 
         <div class="o-footer_pre">


### PR DESCRIPTION
According to the html validator contentinfo is unnecessary for the role in the footer.

## Changes

- Remove contentinfo unnecessary role from footer.

## Testing

1. You can check this branch locally with https://chrome.google.com/webstore/detail/html-validator/mpbelhhnfhfjnaehkcnnaknldmnocglk?hl=en-US
2. Open the dev console.
3. Click "HTML Validator"
4. Reload the page.
5. Click "W3c online" button. See that the info message shown in the screenshot is not present. Can be compared to master to see the difference.

## Screenshots

![screen shot 2018-06-18 at 2 19 33 pm](https://user-images.githubusercontent.com/704760/41554425-d3d20752-7302-11e8-8286-983b49118fff.png)
