### PR TITLE
Remove milliseconds from timestamp

### DIFF
--- a/cfgov/jinja2/v1/_includes/macros/util/format/datetime.html
+++ b/cfgov/jinja2/v1/_includes/macros/util/format/datetime.html
@@ -64,7 +64,7 @@
 
    Format a date for datetime metadata in the format of:
 
-       YYYY-MM-DDTHH:MM:SS
+       YYYY-MM-DDTHH:MM:SS-Z
 
    When given:
 

--- a/cfgov/jinja2/v1/_includes/macros/util/format/datetime.html
+++ b/cfgov/jinja2/v1/_includes/macros/util/format/datetime.html
@@ -64,7 +64,7 @@
 
    Format a date for datetime metadata in the format of:
 
-       YYYY-MM-DDTHH:MM:SS.MMMM
+       YYYY-MM-DDTHH:MM:SS
 
    When given:
 
@@ -73,5 +73,5 @@
    ========================================================================== #}
 
 {% macro format_datetime(datetime) %}
-    {{- datetime | date('%Y-%m-%dT%H:%M:%S.%f%z') -}}
+    {{- datetime | date('%Y-%m-%dT%H:%M:%S%z') -}}
 {% endmacro %}


### PR DESCRIPTION
Milliseconds were causing an HTML validation error because of the number of decimal places they used. Easiest to just remove them because it doesn't look like they are utilized anyway.

## Changes

- Removes milliseconds from timestamp.

## Testing

1. Pull down branch.
2. Visit homepage.
3. View source.
4. Search for `datetime` and see that `datetime=` attribute only contains seconds in the time, such as `2018-05-23T19:55:00-0400`.

