### PR TITLE
Fix incorrect aria role attribute name

### DIFF
--- a/cfgov/jinja2/v1/_includes/molecules/global-header-cta.html
+++ b/cfgov/jinja2/v1/_includes/molecules/global-header-cta.html
@@ -18,7 +18,7 @@
     <div class="m-global-header-cta
                 m-global-header-cta__{{ 'horizontal' if is_horizontal else 'list' }}">
         <a href="/complaint/"
-           {{- '' if is_horizontal else ' aria-role=menuitem' }}>
+           {{- '' if is_horizontal else ' role=menuitem' }}>
             {{ svg_icon('complaint') }}
             Submit a Complaint
         </a>


### PR DESCRIPTION
## Changes

- Fix incorrect aria role attribute name that was `aria-role` instead of `role`.

## Testing

1. You can check this branch locally with https://chrome.google.com/webstore/detail/html-validator/mpbelhhnfhfjnaehkcnnaknldmnocglk?hl=en-US
2. Open the dev console.
3. Click "HTML Validator"
4. Reload the page.
5. Click "W3c online" button. See that it doesn't report that the aria-role is incorrect on `a`.