### PR TITLE
Remove obsolete pubdate boolean attribute

### DIFF
--- a/cfgov/jinja2/v1/ask-cfpb/answer-page.html
+++ b/cfgov/jinja2/v1/ask-cfpb/answer-page.html
@@ -41,7 +41,7 @@
                 block__flush-top
                 block__sub">
         {% if last_edited %}
-        <time datetime='{{ last_edited }}' pubdate class="answer-edited-date">updated {{ dt.format_date(last_edited) }}</time>
+        <time datetime='{{ last_edited }}' class="answer-edited-date">updated {{ dt.format_date(last_edited) }}</time>
         {% endif %}
 
         <h2>{{ page.question | striptags }}</h2>


### PR DESCRIPTION
`pubdate` boolean attribute has been removed from the html spec. We could use microdata schema https://www.sitepoint.com/5-obsolete-features-html5/#2-the-pubdate-attribute, but since we don't use that elsewhere it's probably best to remove it altogether for now.

## Removals

- Remove obsolete `pubdate` boolean attribute
