### PR TITLE
Add is animating class to extend style options

### DIFF
--- a/cfgov/unprocessed/css/organisms/mega-menu.less
+++ b/cfgov/unprocessed/css/organisms/mega-menu.less
@@ -295,23 +295,26 @@ body {
         // Menu flyout.
         // All menus - Tablet/Mobile.
         &_content {
+            .u-drop-shadow-after();
+
             display: none;
             box-sizing: border-box;
             width: 100%;
 
+            background-color: @gray-5;
+            border-top: 1px solid @gray-40;
+            border-bottom: 1px solid @gray-40;
+
             .js & {
-                display: block;
                 position: absolute;
                 left: 0;
                 top: -1px;
                 z-index: 10;
             }
 
-            background-color: @gray-5;
-            border-top: 1px solid @gray-40;
-            border-bottom: 1px solid @gray-40;
-
-            .u-drop-shadow-after();
+            .js .u-is-animating & {
+                display: block;
+            }
 
             &[aria-expanded="true"] {
                 display: block;

--- a/cfgov/unprocessed/js/modules/transition/BaseTransition.js
+++ b/cfgov/unprocessed/js/modules/transition/BaseTransition.js
@@ -111,6 +111,7 @@ function BaseTransition( element, classes ) {
    * complete handler immediately if transition not supported.
    */
   function _addEventListener() {
+    _dom.classList.add( BaseTransition.ANIMATING_CLASS );
     _isAnimating = true;
     // If transition is not supported, call handler directly (IE9/OperaMini).
     if ( _transitionEndEvent ) {
@@ -137,6 +138,7 @@ function BaseTransition( element, classes ) {
    */
   function _transitionComplete() {
     _removeEventListener();
+    _dom.classList.remove( BaseTransition.ANIMATING_CLASS );
     this.dispatchEvent( BaseTransition.END_EVENT, { target: this } );
     _isAnimating = false;
   }
@@ -249,5 +251,6 @@ function BaseTransition( element, classes ) {
 BaseTransition.BEGIN_EVENT = 'transitionBegin';
 BaseTransition.END_EVENT = 'transitionEnd';
 BaseTransition.NO_ANIMATION_CLASS = 'u-no-animation';
+BaseTransition.ANIMATING_CLASS = 'u-is-animating';
 
 module.exports = BaseTransition;


### PR DESCRIPTION
When an item is animating there are situations where we need temporary
style changes. Adding an `u-is-animating` class to the base transition
gives us a hook to add those temporary styles.

## Additions

- Adds `u-is-animating` class during the animation

## Changes

- Reorganized the related styles a bit to make it easier to understand what's going on.

## Testing

1. Run `gulp build`
1. Run `./runserver.sh` and navigate to the website
1. With a narrow browser window, click the menu button and then tab through the items
1. Open an item by clicking on it or hitting enter why it's focused.
1. Navigate to the sub-items by tabbing
1. Repeat these steps with your mobile device using localtunnel and swiping in place of tabbing.

When tabbing the top level items, the focus should not enter the sub-items unless you hit enter or click a top level item. 

## Notes

- I'm working on a fix that moves the focus from the panel that swipes away to the panel that comes into view so that it's not focusing hidden content after moving between panels. This fix will be in a new PR.

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [x] Chrome
- [x] Firefox
- [x] Safari
- [x] Internet Explorer 8, 9, 10, and 11
- [x] Edge
- [x] iOS Safari
- [ ] Chrome for Android

### Accessibility

- [x] Keyboard friendly
- [x] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
