### PR TITLE
Regulations3000: Breadcrumbs

### DIFF
--- a/cfgov/jinja2/v1/_includes/molecules/breadcrumbs.html
+++ b/cfgov/jinja2/v1/_includes/molecules/breadcrumbs.html
@@ -17,9 +17,13 @@
     <nav class="breadcrumbs" aria-label="Breadcrumbs">
         {{ svg_icon('left') }}
         {% for crumb in breadcrumbs %}
-        <a class="breadcrumbs_link" href="{{ crumb.href if crumb.href else get_protected_url(crumb) }}">
-            {{ crumb.title | e }}
-        </a>
+            {% if crumb.href or crumb.live %}
+                <a class="breadcrumbs_link" href="{{ crumb.href if crumb.href else get_protected_url(crumb) }}">
+                    {{ crumb.title | e }}
+                </a>
+            {% else %}
+                <span class="breadcrumbs_text">{{ crumb.title | e }}</span>
+            {% endif %}
         {% endfor %}
     </nav>
 {% endmacro %}

--- a/cfgov/regulations3k/models/pages.py
+++ b/cfgov/regulations3k/models/pages.py
@@ -184,8 +184,29 @@ class RegulationPage(RoutablePageMixin, SecondaryNavigationJSMixin, CFGOVPage):
             'get_secondary_nav_items': get_reg_nav_items,
             'regulation': self.regulation,
             'section': None,
+            'breadcrumb_items': self.get_breadcrumbs(request)
         })
         return context
+
+    def get_breadcrumbs(self, request, section=None):
+        landing_page = self.get_parent()
+        crumbs = [{
+            'href': landing_page.url,
+            'title': landing_page.title,
+        }]
+
+        if section is not None:
+            crumbs = crumbs + [
+                {
+                    'href': self.url,
+                    'title': str(section.subpart.version.part),
+                },
+                {
+                    'title': section.subpart.title,
+                },
+            ]
+
+        return crumbs
 
     @route(r'^(?P<section_label>[0-9A-Za-z-]+)/$', name="section")
     def section_page(self, request, section_label):
@@ -209,6 +230,7 @@ class RegulationPage(RoutablePageMixin, SecondaryNavigationJSMixin, CFGOVPage):
             'previous_section': get_previous_section(
                 self.sections, current_index),
             'section': section,
+            'breadcrumb_items': self.get_breadcrumbs(request, section),
         })
 
         return TemplateResponse(

--- a/cfgov/regulations3k/tests/test_models.py
+++ b/cfgov/regulations3k/tests/test_models.py
@@ -263,6 +263,28 @@ class RegModelTests(DjangoTestCase):
         self.assertEqual(mock_ES.call_count, 1)
         self.assertEqual(response.status_code, 404)
 
+    def test_get_breadcrumbs_reg_page(self):
+        crumbs = self.reg_page.get_breadcrumbs(HttpRequest())
+        self.assertEqual(
+            crumbs,
+            [{'href': '/reg-landing/', 'title': 'Reg Landing'}]
+        )
+
+    def test_get_breadcrumbs_section(self):
+        crumbs = self.reg_page.get_breadcrumbs(
+            HttpRequest(),
+            section=self.section_num4
+        )
+        self.assertEqual(
+            crumbs,
+            [
+                {'href': '/reg-landing/', 'title': 'Reg Landing'},
+                {'href': '/reg-landing/1002/',
+                 'title': '12 CFR Part 1002 (Regulation B)'},
+                {'title': 'General'}
+            ]
+        )
+
 
 class SectionNavTests(unittest.TestCase):
 

--- a/cfgov/unprocessed/css/breadcrumbs.less
+++ b/cfgov/unprocessed/css/breadcrumbs.less
@@ -16,7 +16,7 @@
         padding-bottom: unit( @grid_gutter-width / 2 / 14px, em );
     } );
 
-    &_link {
+    &_link, &_text {
         padding-left: 4px;
 
         &:not( :last-child ):after {


### PR DESCRIPTION
This PR adds breadcrumbs to Regulations 3000 per the design mockup in GHE/regulations-3000/issues/59.

The regulations breadcrumbs need to include a crumb that is not a link, because subparts do not have pages/urls/content that belongs to them other than the sections that live under them. For this reason I've modified the breadcrumbs macro and styles to include the option for a breadcrumb that does not have a link.

![image](https://user-images.githubusercontent.com/10562538/41870418-03f51816-788a-11e8-9eb4-12e007ad9ec1.png)

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Internet Explorer 8, 9, 10, and 11
- [ ] Edge
- [ ] iOS Safari
- [ ] Chrome for Android

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
