### PR TITLE
Remove mysql.txt requirements file and all references to it

### DIFF
--- a/requirements/deployment.txt
+++ b/requirements/deployment.txt
@@ -1,4 +1,3 @@
 -r base.txt
--r mysql.txt
 -r postgres.txt
 newrelic==2.96.0.80

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -1,5 +1,4 @@
 -r base.txt
--r mysql.txt
 -r postgres.txt
 django-debug-toolbar==1.7
 django-livereload==1.2

--- a/requirements/mysql.txt
+++ b/requirements/mysql.txt
@@ -1,1 +1,0 @@
-MySQL-python==1.2.5

--- a/tox.ini
+++ b/tox.ini
@@ -136,7 +136,6 @@ setenv=
     LC_ALL=en_US.UTF-8
 deps=
     -r{toxinidir}/requirements/libraries.txt
-    -r{toxinidir}/requirements/mysql.txt
     -r{toxinidir}/requirements/postgres.txt
     -r{toxinidir}/requirements/test.txt
 commands=


### PR DESCRIPTION
Now that we have migrated all environments to Postgres, we no longer need to test on mysql or develop for it.

## Removals

- `requirements/mysql.txt` and the 3 references to it that I found in the codebase

## Checklist

- [x] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

This does not change any cf.gov functionality.