### PR TITLE
Remove support for legacy MySQL environment variables

### DIFF
--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -178,22 +178,6 @@ DATABASES = {}
 # If DATABASE_URL is defined in the environment, use it to set the Django DB.
 if os.getenv('DATABASE_URL'):
     DATABASES['default'] = dj_database_url.config()
-# Otherwise, support the legacy use of MySQL-specific environment variables.
-elif os.getenv('MYSQL_NAME'):
-    DATABASES['default'] =  {
-        'ENGINE': 'django.db.backends.mysql',
-        'NAME': os.environ.get('MYSQL_NAME', ''),
-        'USER': os.environ.get('MYSQL_USER', ''),
-        'PASSWORD': os.environ.get('MYSQL_PW', ''),
-        'HOST': os.environ.get('MYSQL_HOST', ''),
-        'PORT': os.environ.get('MYSQL_PORT', ''),
-    }
-
-    if 'STORAGE_ENGINE' in os.environ:
-        DATABASES['default']['OPTIONS'] = {
-            'init_command': os.environ['STORAGE_ENGINE'],
-        }
-
 
 # Internationalization
 # https://docs.djangoproject.com/en/1.8/topics/i18n/

--- a/cfgov/cfgov/settings/local.py
+++ b/cfgov/cfgov/settings/local.py
@@ -69,19 +69,3 @@ if os.environ.get('ENABLE_POST_PREVIEW_CACHE'):
 # Use a mock GovDelivery API instead of the real thing.
 # Remove this line to use the real API instead.
 GOVDELIVERY_API = 'core.govdelivery.LoggingMockGovDelivery'
-
-
-if not os.getenv('DATABASE_URL') and os.getenv('MYSQL_NAME'):
-    MYSQL_VARIABLES_DEPRECATED = """
-The ability to define your MySQL database through the use of environment
-variables like MYSQL_NAME will soon be deprecated in favor of the single
-DATABASE_URL environment variable.
-
-Please modify your environment to instead use something like this:
-
-DATABASE_URL=mysql://username:password@host/dbname
-
-See https://github.com/kennethreitz/dj-database-url for other examples of how
-to define DATABASE_URL.
-"""
-    warnings.warn(MYSQL_VARIABLES_DEPRECATED)


### PR DESCRIPTION
This change removes support for configuration of a Django MySQL database via environment variables like `MYSQL_NAME`, `MYSQL_USER`, etc. The Django database configuration must now be specified exclusively via the `DATABASE_URL` environment variable.

These lines are mentioned [here](https://github.com/cfpb/cfgov-refresh/pull/4241#pullrequestreview-127955375) as being a MySQL cleanup change not covered by #4241.

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [X] Passes all existing automated tests
- [X] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Internet Explorer 8, 9, 10, and 11
- [ ] Edge
- [ ] iOS Safari
- [ ] Chrome for Android

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
