### PR TITLE
Enforce case-insensitive tag matching for snippets

### DIFF
--- a/cfgov/v1/models/snippets.py
+++ b/cfgov/v1/models/snippets.py
@@ -80,7 +80,7 @@ class TaggableSnippetManager(models.Manager):
     def filter_by_tags(self, tags):
         snippets = self.all()
         for tag in tags or []:
-            snippets = snippets.filter(tags__name=tag)
+            snippets = snippets.filter(tags__name__iexact=tag)
 
         return snippets
 

--- a/cfgov/v1/tests/models/test_snippets.py
+++ b/cfgov/v1/tests/models/test_snippets.py
@@ -27,6 +27,12 @@ class TestFilterByTags(TestCase):
             [self.snippet1, self.snippet2]
         )
 
+    def test_case_insensitive_matching(self):
+        self.assertSequenceEqual(
+            Resource.objects.filter_by_tags(['TaGa']),
+            [self.snippet1, self.snippet2]
+        )
+
     def test_nothing_returned_when_tag_is_unused(self):
         self.assertSequenceEqual(
             Resource.objects.filter_by_tags(['tagC']),


### PR DESCRIPTION
The SnippetList organism lets users specify tags that limit which snippets are returned in the list. The help text for this organism [claims](https://github.com/cfpb/cfgov-refresh/blob/81fd2fb9a5142bd2ad825ec7c385697e0b9e0c12/cfgov/v1/atomic_elements/organisms.py#L1009) that case-insensitive matching is used, but currently it is not. This happens to work properly on MySQL but is broken on PostgreSQL.

This change explicitly uses Django's [`iexact`](https://docs.djangoproject.com/en/dev/ref/models/querysets/#iexact) matching for case-insensitive tag matching, and adds a regression unit test to cover this behavior.

## Testing

With a local production dump, verify that [this page](http://localhost:8000/practitioner-resources/resources-for-tax-preparers/outreach-materials-encourage-saving/) on your local server properly shows both English and Spanish resources.

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [X] Passes all existing automated tests
- [X] Any _change_ in functionality is tested
- [X] New functions are documented (with a description, list of inputs, and expected output)
- [X] Placeholder code is flagged / future todos are captured in comments
- [X] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [X] Project documentation has been updated
- [X] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Internet Explorer 8, 9, 10, and 11
- [ ] Edge
- [ ] iOS Safari
- [ ] Chrome for Android

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
