### PR TITLE
Mega menu: set default value for link url

### DIFF
--- a/cfgov/jinja2/v1/_includes/organisms/mega-menu.html
+++ b/cfgov/jinja2/v1/_includes/organisms/mega-menu.html
@@ -175,7 +175,7 @@
 {% macro _nav_item( nav_depth, nav_item ) %}
 {% set link = nav_item.link if nav_item.link else nav_item %}
 {% if link %}
-    {% set url = link.page_link.url if link.page_link else link.external_link %}
+    {% set url = link.page_link.url if link.page_link else link.external_link | default('#') %}
     {% set text = link.link_text %}
     {% set has_children = nav_item.nav_groups | count > 0 or nav_item.nav_items | count > 0 %}
 
@@ -197,7 +197,7 @@
               {{ svg_icon('right') }}
         </a>
         {% if has_children %}
-            {{ _nav_level( nav_depth | int + 1, nav_item, url | default('#'), text ) }}
+            {{ _nav_level( nav_depth | int + 1, nav_item, url, text ) }}
         {% endif %}
     </li>
 {% endif %}


### PR DESCRIPTION
Fix for url issue after removal of overview external_link field from MenuItem.

## Changes

- Set default for link urls in mega-menu.html

## Testing

1. Check out branch
2. Turn on Wagtail version of menu (flip `WAGTAIL_MENU` flag)
3. Run `python cfgov/manage.py runscript migrate_mega_menu` if necessary to set up Wagtail menu items
4. Verify that `href` of `Consumer Tools` link is set to `#` 



## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Internet Explorer 8, 9, 10, and 11
- [ ] Edge
- [ ] iOS Safari
- [ ] Chrome for Android

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
