### PR TITLE
Remove boxsizing.htc references

### DIFF
--- a/cfgov/legacy/static/nemo/_/c/v1-nonresponsive-header.css
+++ b/cfgov/legacy/static/nemo/_/c/v1-nonresponsive-header.css
@@ -460,7 +460,6 @@ ul:last-child,.list__links .list_item:last-child {
     display: inline;
     margin-right: 0;
     zoom: 1;
-    *behavior: url('/static/js/boxsizing.htc');;
 }
 .m-featured-menu-content_text {
     display: table-footer-group;
@@ -1006,7 +1005,6 @@ p+.m-global-banner_head,ul+.m-global-banner_head,ol+.m-global-banner_head,dl+.m-
     display: inline;
     margin-right: 0;
     zoom: 1;
-    *behavior: url('/static/js/boxsizing.htc');;
 }
 .o-mega-menu_content-2-link {
     padding-top: .55555556em;
@@ -1039,7 +1037,6 @@ p+.m-global-banner_head,ul+.m-global-banner_head,ol+.m-global-banner_head,dl+.m-
     display: inline;
     margin-right: 0;
     zoom: 1;
-    *behavior: url('/static/js/boxsizing.htc');;
 }
 @media only all and (min-width:76.9375em) {
     .o-mega-menu_content-1-item {


### PR DESCRIPTION
They were breaking `collectstatic`, though you wouldn't see it when deploying to environments that have stale copies of `boxsizing.htc` under the static root. I discovered the problem when deploying to a local Vagrant instance.

The references were originally removed in 085ec579cffb46289e72e0650cee68d8feaf89e3 but got added back in 112aef22532aec651483743eaffef36003c6b7bb.

See also: https://github.com/cfpb/django-college-costs-comparison/pull/13