### PR TITLE
regs3k: Remove duplicate interp references in appendices

### DIFF
--- a/cfgov/regulations3k/scripts/ecfr_importer.py
+++ b/cfgov/regulations3k/scripts/ecfr_importer.py
@@ -352,10 +352,6 @@ def parse_appendix_graph(p_element, label):
         graph_text += graph + "\n"
     else:
         graph_text += p_element.text + "\n"
-    if pid and PAYLOAD.interp_refs and PAYLOAD.interp_refs.get(label):
-        interp_ref = PAYLOAD.interp_refs.get(label).get(pid)
-        if interp_ref:
-            graph_text += '\n' + interp_ref + '\n'
     return graph_text
 
 

--- a/cfgov/regulations3k/scripts/ecfr_importer.py
+++ b/cfgov/regulations3k/scripts/ecfr_importer.py
@@ -603,9 +603,8 @@ def parse_interps(interp_div, part, subpart):
     for section_heading in section_headings:
         LEVEL_STATE.current_id = ''
         section_hed = section_heading.text.strip()
-        section_tag = get_interp_section_tag(section_hed)
-        section_label = section_tag
-        interp_section_label = "Interp-{}".format(section_tag)
+        section_label = get_interp_section_tag(section_hed)
+        interp_section_label = "Interp-{}".format(section_label)
         section = Section(
             subpart=subpart,
             label=interp_section_label,
@@ -614,36 +613,36 @@ def parse_interps(interp_div, part, subpart):
         )
         if divine_interp_tag_use(
                 section_heading, part.part_number) == 'appendix':
-            interp_id = '{}-1-Interp'.format(section_tag)
+            interp_id = '{}-1-Interp'.format(section_label)
             LEVEL_STATE.current_id = interp_id
             see = "see({}-1-Interp)".format(section_label)
             ref = {section_label: {'1': see}}
             PAYLOAD.interp_refs.update(ref)
         for element in section_heading.findNextSiblings():
-            if element.name in ['HD1', 'XREF', 'CITA']:
-                continue
             if element in section_headings:
                 section.save()
                 PAYLOAD.interpretations.append(section)
                 break
-            elif (element.name in ['HD2', 'HD3']
+            if element.name in ['HD1', 'XREF', 'CITA']:
+                continue
+            if (element.name in ['HD2', 'HD3']
                     and divine_interp_tag_use(element, part.part_number)
                     in ['graph_id', 'graph_id_inferred_section']):
                 _hed = element.text.strip()
                 interp_id = parse_interp_graph_reference(
-                    element, part.part_number, section_tag)
-                register_interp_reference(interp_id, section_tag)
+                    element, part.part_number, section_label)
+                register_interp_reference(interp_id, section_label)
                 section.contents += '\n{' + interp_id + '}\n'
                 section.contents += "### {}\n".format(_hed)
             elif element.name == 'P':
                 tag_use = divine_interp_tag_use(element, part.part_number)
                 if tag_use in ['graph_id', 'graph_id_inferred_section']:
                     interp_id = parse_interp_graph_reference(
-                        element, part.part_number, section_tag)
-                    register_interp_reference(interp_id, section_tag)
+                        element, part.part_number, section_label)
+                    register_interp_reference(interp_id, section_label)
                     section.contents += '\n{' + interp_id + '}\n'
                     if tag_use == 'graph_id_inferred_section':
-                        element.insert(0, section_tag)
+                        element.insert(0, section_label)
                     p = pre_process_tags(element)
                     section.contents += p.text.strip() + "\n"
                 else:

--- a/cfgov/regulations3k/tests/test_ecfr_importer.py
+++ b/cfgov/regulations3k/tests/test_ecfr_importer.py
@@ -103,7 +103,7 @@ class ImporterTestCase(DjangoTestCase):
         p_soup = bS(self.test_xml, 'lxml-xml')
         appendix = p_soup.find('DIV5').find('DIV9')
         parsed_appendix = parse_appendix_elements(appendix, '1002-A')
-        self.assertIn("see(1002-A-1-Interp)", parsed_appendix)
+        self.assertIn("{1}", parsed_appendix)
 
     @mock.patch(
         'regulations3k.scripts.ecfr_importer.requests.get')

--- a/cfgov/regulations3k/tests/test_ecfr_importer.py
+++ b/cfgov/regulations3k/tests/test_ecfr_importer.py
@@ -17,7 +17,7 @@ from regulations3k.scripts.ecfr_importer import (
     divine_interp_tag_use, ecfr_to_regdown, get_appendix_label,
     get_effective_date, get_interp_section_tag, parse_appendices,
     parse_appendix_elements, parse_appendix_graph, parse_appendix_paragraphs,
-    parse_ids, parse_interp_graph_reference, parse_interps,
+    parse_ids, parse_interp_graph, parse_interp_graph_reference, parse_interps,
     parse_multi_id_graph, parse_part, parse_section_paragraphs,
     parse_singleton_graph, parse_version, run
 )
@@ -363,6 +363,13 @@ class ParagraphParsingTestCase(unittest.TestCase):
             parse_interp_graph_reference(
                 valid_inferred_section_graph_element, '1030', '2'),
             "2-c-1-Interp")
+
+    def test_parse_interp_graph_no_id(self):
+        section_graph_element_no_id = bS(
+            "<P>This is a bare interp paragraph with no ID.</P>", 'lxml-xml')
+        parsed_graph = parse_interp_graph(section_graph_element_no_id)
+        # import pdb; pdb.set_trace()
+        self.assertTrue(parsed_graph.startswith('This is a bare interp'))
 
     def test_get_interp_section_tag(self):
         headline = 'Section 1003.2 - Definitions'


### PR DESCRIPTION
The ecfr_importer was errantly checking individual appendix paragraphs
for interpretation references, resulting in doubled refs in some cases.

Example: `/regulations/1002/C/`

<img width="1293" alt="dupe_references" src="https://user-images.githubusercontent.com/515885/42104952-a507c432-7b9c-11e8-8281-b54e41f954fc.png">

Can also be seen in `/1026/F/` and `/1026/O/`

## Testing

After checking out this branch, running the importer for 1002 (and unsetting "draft" on the resulting new effective_version) should result in only one interp reference in `/1002/C/`

```
./cfgov/manage.py runscript ecfr_importer --script-args 1002
```


<img width="1308" alt="single_reference" src="https://user-images.githubusercontent.com/515885/42111063-223d23f2-7bb1-11e8-8ee4-ae9cc5317efe.png">

