### PR TITLE
regs3k: Add sorting and pagination options to Regs3k search

### DIFF
--- a/cfgov/jinja2/v1/_includes/atoms/radio-button.html
+++ b/cfgov/jinja2/v1/_includes/atoms/radio-button.html
@@ -1,0 +1,48 @@
+{# ==========================================================================
+
+   form.input()
+
+   ==========================================================================
+
+   Description: Builds form radio button.
+
+   label:       The radio's label attribute. Required.
+
+   id:          The radio's id attribute. Defaults to `input_${ label }`
+
+   class:       The radio's class attribute. Optional.
+
+   value:       The radio's value attribute. Defaults to `id`.
+
+   name:        The radio's name attribute. Defaults to `id`.
+
+   selected:    Whether or not the radio is selected by default.
+                Boolean. Defaults to false.
+
+   el_wrapper:  Element to wrap the radio in. Defaults to div.
+
+   ========================================================================== #}
+{% from 'macros/util/format/url.html' import slugify as slugify %}
+
+{% macro render(value) -%}
+
+{%- set id = value.id or get_unique_id('input_', '_') ~ slugify( value.label ) -%}
+{%- set el = value.el_wrapper if value.el_wrapper else 'div' -%}
+{%- set val = value.value if value.value else id -%}
+{%- set name = value.name if value.name else id -%}
+{%- set checked = 'checked' if value.selected else '' -%}
+
+<{{ el }} class="m-form-field m-form-field__radio {{ value.class }}">
+    <input class="a-radio"
+           type="radio"
+           value="{{ val }}"
+           id="{{ id }}"
+           name="{{ name }}"
+           {{ checked }}>
+    <label class="a-label"
+           for="{{ id }}">
+        {{ value.label }}
+    </label>
+</{{ el }}>
+
+{%- endmacro %}

--- a/cfgov/jinja2/v1/_includes/eregs/regulations3k-search-bar.html
+++ b/cfgov/jinja2/v1/_includes/eregs/regulations3k-search-bar.html
@@ -3,9 +3,6 @@
 <form action="." data-js-hook="behavior_submit-search">
     <label class="a-label a-label__heading" for="query">
         Search term
-        <small class="a-label_helper a-label_helper__block">
-            Boolean operators (AND, OR, and NOT) are supported
-        </small>
     </label>
     <div class="o-form__input-w-btn">
         {% for field in hidden_fields %}

--- a/cfgov/jinja2/v1/_includes/organisms/expandable.html
+++ b/cfgov/jinja2/v1/_includes/organisms/expandable.html
@@ -39,7 +39,7 @@
             {{ 'o-expandable__midtone' if value.is_midtone else '' }}"
             {{ 'data-state=expanded' if value.is_expanded else '' }}>
 
-    <button class="o-expandable_target">
+    <button type="button" class="o-expandable_target">
         <div class="o-expandable_header">
             <span class="o-expandable_header-left
                          o-expandable_label">

--- a/cfgov/regulations3k/jinja2/regulations3k/search-regulations.html
+++ b/cfgov/regulations3k/jinja2/regulations3k/search-regulations.html
@@ -3,6 +3,7 @@
 {% import 'atoms/radio-button.html' as radio %}
 {% import 'eregs/regulations3k-search-bar.html' as search_bar %}
 {% import 'eregs/regulations3k-search-result-item.html' as search_item %}
+{% import 'molecules/pagination.html' as pagination with context %}
 {% from 'organisms/expandable.html' import expandable with context %}
 
 {# HEAD items #}
@@ -119,7 +120,7 @@
                 {% endcall %}
                 {% set expandable_settings = {
                     'label': 'Results per page',
-                    'is_expanded': false,
+                    'is_expanded': true,
                     'is_midtone': true,
                     'hide_cue_label': true
                 } %}
@@ -129,32 +130,34 @@
                         <p> </p>
                         {{ radio.render({
                             'label': '25 per page',
-                            'value': '',
+                            'value': '25',
                             'id': 'results_25',
                             'class': 'reg-radio',
                             'name': 'results',
-                            'selected': true
+                            'selected': true if (num_results == 25)
                         }) }}
                         {{ radio.render({
                             'label': '50 per page',
-                            'value': '',
+                            'value': '50',
                             'id': 'results_50',
                             'class': 'reg-radio',
-                            'name': 'results'
+                            'name': 'results',
+                            'selected': true if (num_results == 50)
                         }) }}
                         {{ radio.render({
                             'label': '100 per page',
-                            'value': '',
+                            'value': '100',
                             'id': 'results_100',
                             'class': 'reg-radio',
-                            'name': 'results'
+                            'name': 'results',
+                            'selected': true if (num_results == 100)
                         }) }}
                     </fieldset>
                 </div>
                 {% endcall %}
                 {% set expandable_settings = {
                     'label': 'Order',
-                    'is_expanded': false,
+                    'is_expanded': true,
                     'is_midtone': true,
                     'hide_cue_label': true
                 } %}
@@ -164,18 +167,19 @@
                         <p> </p>
                         {{ radio.render({
                             'label': 'By relevance',
-                            'value': '',
-                            'id': 'sort_rev',
+                            'value': 'relevance',
+                            'id': 'sort_rel',
                             'class': 'reg-radio',
-                            'name': 'sort',
-                            'selected': true
+                            'name': 'order',
+                            'selected': true if (order == 'relevance')
                         }) }}
                         {{ radio.render({
                             'label': 'By regulation',
-                            'value': '',
+                            'value': 'regulation',
                             'id': 'sort_reg',
                             'class': 'reg-radio',
-                            'name': 'sort'
+                            'name': 'order',
+                            'selected': true if (order == 'regulation')
                         }) }}
                     </fieldset>
                 </div>
@@ -227,9 +231,12 @@
                 </div> -->
             </div>
             <div class="results_list">
-                {% for result in page.results.results %}
+                {% for result in results %}
                     {{ search_item.render( result ) }}
                 {% endfor %}
+            </div>
+            <div class="results_paginator">
+                {{ pagination.render( paginator.num_pages, current_page ) }}
             </div>
         </div>
     </div>

--- a/cfgov/regulations3k/jinja2/regulations3k/search-regulations.html
+++ b/cfgov/regulations3k/jinja2/regulations3k/search-regulations.html
@@ -120,7 +120,7 @@
                 {% endcall %}
                 {% set expandable_settings = {
                     'label': 'Results per page',
-                    'is_expanded': true,
+                    'is_expanded': false,
                     'is_midtone': true,
                     'hide_cue_label': true
                 } %}
@@ -157,7 +157,7 @@
                 {% endcall %}
                 {% set expandable_settings = {
                     'label': 'Order',
-                    'is_expanded': true,
+                    'is_expanded': false,
                     'is_midtone': true,
                     'hide_cue_label': true
                 } %}

--- a/cfgov/regulations3k/jinja2/regulations3k/search-regulations.html
+++ b/cfgov/regulations3k/jinja2/regulations3k/search-regulations.html
@@ -1,7 +1,9 @@
 {% extends 'layout-full.html' %}
 {% import 'atoms/checkbox.html' as checkbox %}
+{% import 'atoms/radio-button.html' as radio %}
 {% import 'eregs/regulations3k-search-bar.html' as search_bar %}
 {% import 'eregs/regulations3k-search-result-item.html' as search_item %}
+{% from 'organisms/expandable.html' import expandable with context %}
 
 {# HEAD items #}
 
@@ -66,7 +68,7 @@
         <div class="lead-paragraph">
             <p>
                 <span class="search_intro__all">
-                    Search for terms in the sections, interpretations, and appendices across the 12 Bureau regulations we currently have online.
+                    Search for terms in the sections, interpretations, and appendices in the Bureau regulations we currently have online.
                 </span>
             </p>
         </div>
@@ -83,15 +85,14 @@
     <div class="block block__flush-top">
         <aside class="content_sidebar content__flush-top-on-small content__flush-sides-on-small filters">
             <h3>Refine results</h3>
-            {% set expandable_settings = {
-                'label': 'Regulation',
-                'is_expanded': true,
-                'is_midtone': true,
-                'hide_cue_label': true
-            } %}
-            {% from 'organisms/expandable.html' import expandable with context %}
-            {% call() expandable(expandable_settings) %}
             <form action="." method="get" data-js-hook="behavior_submit-search">
+                {% set expandable_settings = {
+                    'label': 'Regulation',
+                    'is_expanded': true,
+                    'is_midtone': true,
+                    'hide_cue_label': true
+                } %}
+                {% call() expandable(expandable_settings) %}
                 <div class="o-form_group">
                     <fieldset class="o-form_fieldset">
                         {% if page.results.search_query %}
@@ -114,6 +115,72 @@
                         {% endfor %}
                         </ul>
                     </fieldset>
+                </div>
+                {% endcall %}
+                {% set expandable_settings = {
+                    'label': 'Results per page',
+                    'is_expanded': false,
+                    'is_midtone': true,
+                    'hide_cue_label': true
+                } %}
+                {% call() expandable(expandable_settings) %}
+                <div class="o-form_group">
+                    <fieldset class="o-form_fieldset">
+                        <p> </p>
+                        {{ radio.render({
+                            'label': '25 per page',
+                            'value': '',
+                            'id': 'results_25',
+                            'class': 'reg-radio',
+                            'name': 'results',
+                            'selected': true
+                        }) }}
+                        {{ radio.render({
+                            'label': '50 per page',
+                            'value': '',
+                            'id': 'results_50',
+                            'class': 'reg-radio',
+                            'name': 'results'
+                        }) }}
+                        {{ radio.render({
+                            'label': '100 per page',
+                            'value': '',
+                            'id': 'results_100',
+                            'class': 'reg-radio',
+                            'name': 'results'
+                        }) }}
+                    </fieldset>
+                </div>
+                {% endcall %}
+                {% set expandable_settings = {
+                    'label': 'Order',
+                    'is_expanded': false,
+                    'is_midtone': true,
+                    'hide_cue_label': true
+                } %}
+                {% call() expandable(expandable_settings) %}
+                <div class="o-form_group">
+                    <fieldset class="o-form_fieldset">
+                        <p> </p>
+                        {{ radio.render({
+                            'label': 'By relevance',
+                            'value': '',
+                            'id': 'sort_rev',
+                            'class': 'reg-radio',
+                            'name': 'sort',
+                            'selected': true
+                        }) }}
+                        {{ radio.render({
+                            'label': 'By regulation',
+                            'value': '',
+                            'id': 'sort_reg',
+                            'class': 'reg-radio',
+                            'name': 'sort'
+                        }) }}
+                    </fieldset>
+                </div>
+                {% endcall %}
+                <div class="o-form_group">
                     <fieldset class="o-form_fieldset u-mt20">
                         <div class="input-with-btn_btn">
                             <button class="a-btn" type="submit">
@@ -123,7 +190,6 @@
                     </fieldset>
                 </div>
             </form>
-            {% endcall %}
         </aside>
         <div class="content_main content__flush-top-on-small content__flush-bottom">
             <div class="results_header">

--- a/cfgov/regulations3k/jinja2/regulations3k/search-regulations.html
+++ b/cfgov/regulations3k/jinja2/regulations3k/search-regulations.html
@@ -236,7 +236,7 @@
                 {% endfor %}
             </div>
             <div class="results_paginator">
-                {{ pagination.render( paginator.num_pages, current_page ) }}
+                {{ pagination.render( paginator.num_pages, current_page, '', '', 'Previous', 'Next' ) }}
             </div>
         </div>
     </div>

--- a/cfgov/regulations3k/models/pages.py
+++ b/cfgov/regulations3k/models/pages.py
@@ -50,17 +50,20 @@ class RegulationsSearchPage(RoutablePageMixin, CFGOVPage):
         all_regs = Part.objects.order_by('part_number')
         regs = []
         sqs = SearchQuerySet()
+        search_query = request.GET.get('q', '')
+        order = validate_results_order(request)
         if 'regs' in request.GET:
             regs = request.GET.getlist('regs')
         if len(regs) == 1:
             sqs = sqs.filter(part=regs[0])
         elif regs:
             sqs = sqs.filter(part__in=regs)
-        search_query = request.GET.get('q', '')  # haystack cleans this string
         if search_query:
             query_sqs = sqs.filter(content=search_query).models(Section)
         else:
             query_sqs = sqs.models(Section)
+        if order == 'regulation':
+            query_sqs = query_sqs.order_by('part')
         payload = {
             'search_query': search_query,
             'results': [],
@@ -92,7 +95,6 @@ class RegulationsSearchPage(RoutablePageMixin, CFGOVPage):
 
         context = self.get_context(request)
         num_results = validate_num_results(request)
-        order = validate_results_order(request)
         paginator = Paginator(payload['results'], num_results)
         page_number = validate_page_number(request, paginator)
         paginated_page = paginator.page(page_number)

--- a/cfgov/unprocessed/apps/regulations3k/css/reg-search.less
+++ b/cfgov/unprocessed/apps/regulations3k/css/reg-search.less
@@ -30,6 +30,14 @@
         .num-results {
             float: right;
         }
+        .o-expandable {
+            padding-bottom: 15px;
+            border-bottom: 1px solid #b4b5b6;
+            margin-bottom: 15px;
+            &:last-child {
+                border: 0;
+            }
+        }
     }
     .content_main {
         &:after {

--- a/cfgov/unprocessed/apps/regulations3k/css/reg-search.less
+++ b/cfgov/unprocessed/apps/regulations3k/css/reg-search.less
@@ -32,7 +32,7 @@
         }
         .o-expandable {
             padding-bottom: 15px;
-            border-bottom: 1px solid #b4b5b6;
+            border-bottom: 1px solid @gray-40;
             margin-bottom: 15px;
             &:last-child {
                 border: 0;

--- a/cfgov/unprocessed/apps/regulations3k/css/reg-search.less
+++ b/cfgov/unprocessed/apps/regulations3k/css/reg-search.less
@@ -70,6 +70,11 @@
             }
         }
     }
+    .results_paginator {
+        margin: 0 unit( ( @grid_gutter-width / 2 ) / @base-font-size-px, em );
+        padding: 0 unit( ( @grid_gutter-width / 2 ) / @base-font-size-px, em );
+        max-width: 41.875rem;
+    }
 }
 
 /* Footer search bar */

--- a/cfgov/unprocessed/apps/regulations3k/js/search.js
+++ b/cfgov/unprocessed/apps/regulations3k/js/search.js
@@ -1,7 +1,7 @@
 import * as behavior from '../../../js/modules/util/behavior';
 
 /**
- * Set up event handler for button to scroll to top of page.
+ * Set up event handler to override search form submission.
  */
 function init() {
   behavior.attach( 'submit-search', 'submit', event => {
@@ -11,5 +11,5 @@ function init() {
 }
 
 window.addEventListener( 'load', () => {
-  // init();
+  init();
 } );

--- a/cfgov/unprocessed/apps/regulations3k/js/search.js
+++ b/cfgov/unprocessed/apps/regulations3k/js/search.js
@@ -11,5 +11,5 @@ function init() {
 }
 
 window.addEventListener( 'load', () => {
-  init();
+  // init();
 } );


### PR DESCRIPTION
Adds a 'Results per page' and 'Order' section to the Regs3k sidebar. 

<img width="659" alt="screen shot 2018-07-02 at 12 26 10 am" src="https://user-images.githubusercontent.com/1060248/42145661-80a93ed6-7d90-11e8-9601-5fb5f0945544.png">

cc @rrstoll @dcmouyard who are building a similar search interface for TDP. You can find most of our search markup in [`search-regulations.html`](https://github.com/cfpb/cfgov-refresh/blob/4c888cfd07b2bb8d2f3afd274430810ae3c8854b/cfgov/regulations3k/jinja2/regulations3k/search-regulations.html). Feel free to reach out if you have any questions about our approach.

## Additions

- Sorting and pagination radio buttons to the Regs3k sidebar.
- Radio button atomic component.

## Testing

1. [Set up Regs3k search](https://github.com/cfpb/cfgov-refresh/pull/4266).
1. Search for something and try changing the results per page and sorting order.

## Todos

- Teeeeeeeests :grimacing:

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [x] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
