### PR TITLE
Update scripts.txt requirement versions

### DIFF
--- a/requirements/libraries.txt
+++ b/requirements/libraries.txt
@@ -17,7 +17,7 @@ django-watchman==0.13.1
 edgegrid-python==1.0.10
 elasticsearch==2.4.1
 geocoder==1.12.0
-github3.py==0.9.6
+github3.py==1.1.0
 govdelivery==1.1
 html5lib==0.9999999
 Jinja2==2.7.3

--- a/requirements/libraries.txt
+++ b/requirements/libraries.txt
@@ -17,6 +17,7 @@ django-watchman==0.13.1
 edgegrid-python==1.0.10
 elasticsearch==2.4.1
 geocoder==1.12.0
+github3.py==1.1.0
 govdelivery==1.1
 html5lib==0.9999999
 Jinja2==2.7.3

--- a/requirements/libraries.txt
+++ b/requirements/libraries.txt
@@ -17,7 +17,6 @@ django-watchman==0.13.1
 edgegrid-python==1.0.10
 elasticsearch==2.4.1
 geocoder==1.12.0
-github3.py==1.1.0
 govdelivery==1.1
 html5lib==0.9999999
 Jinja2==2.7.3

--- a/requirements/scripts.txt
+++ b/requirements/scripts.txt
@@ -1,4 +1,4 @@
 beautifulsoup4==4.5.1
 boto3==1.4.6
-github3.py==0.9.6
-requests==2.7.0
+github3.py==1.1.0
+requests==2.19.1

--- a/requirements/scripts.txt
+++ b/requirements/scripts.txt
@@ -1,4 +1,4 @@
 beautifulsoup4==4.5.1
 boto3==1.4.6
-github3.py==1.1.0
+github3.py==0.9.6
 requests==2.19.1

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,6 +1,6 @@
 coverage==4.2
 django-sslserver==0.19
-github3.py==1.1.0
+github3.py==0.9.6
 mock==2.0.0
 model_mommy==1.2.6
 moto==1.3.1

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,6 +1,6 @@
 coverage==4.2
 django-sslserver==0.19
-github3.py==0.9.6
+github3.py==1.1.0
 mock==2.0.0
 model_mommy==1.2.6
 moto==1.3.1


### PR DESCRIPTION
Bumps `requests` to 2.19.1 and `github3` to `1.1.0`.

We ran into issues with our SQS messages for alerts which stemmed from an out of date `requests` library.

Please note: There is a separate `requests` entry in [libraries.txt](https://github.com/cfpb/cfgov-refresh/blob/master/requirements/libraries.txt). This requirements file is not used to run any cfgov specific code, just by Jenkins to log messages, so these versions may differ without causing errors due to version mismatch.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Internet Explorer 8, 9, 10, and 11
- [ ] Edge
- [ ] iOS Safari
- [ ] Chrome for Android

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
