### PR TITLE
Move is_filter_selected jinja tag to v1 app

### DIFF
--- a/cfgov/jinja2/v1/events/_macros.html
+++ b/cfgov/jinja2/v1/events/_macros.html
@@ -241,31 +241,6 @@
 
 {# ==========================================================================
 
-   event_filter_args()
-
-   ==========================================================================
-
-   Description:
-
-   Create an event agenda table when given
-
-   post: A post from a query result.
-
-   ========================================================================== #}
-
-{% macro event_filter_args(filters) %}
-{%- for filter in filters -%}
-   {%- set selected_filters = selected_filters_for_field(filter) -%}
-   {%- for value in selected_filters -%}
-       {%- if value -%}
-          &{{ filter }}={{ value }}
-       {%- endif -%}
-   {%- endfor -%}
-{%- endfor -%}
-{% endmacro %}
-
-{# ==========================================================================
-
    event_media()
 
    ==========================================================================

--- a/cfgov/sheerlike/__init__.py
+++ b/cfgov/sheerlike/__init__.py
@@ -15,7 +15,6 @@ from flags.template_functions import flag_disabled, flag_enabled
 from jinja2 import Environment
 from jinja2.runtime import Context
 
-from .filters import is_filter_selected, selected_filters_for_field
 from .middleware import get_request
 from .query import QueryFinder, get_document, more_like_this, when
 from .templates import get_date_obj, get_date_string
@@ -101,8 +100,6 @@ def environment(**options):
         'queries': queryfinder,
         'more_like_this': more_like_this,
         'get_document': get_document,
-        'selected_filters_for_field': selected_filters_for_field,
-        'is_filter_selected': is_filter_selected,
         'when': when,
         'flag_enabled': flag_enabled,
         'flag_disabled': flag_disabled,

--- a/cfgov/sheerlike/filters.py
+++ b/cfgov/sheerlike/filters.py
@@ -4,8 +4,6 @@ import re
 
 from dateutil.parser import parse
 
-from .middleware import get_request
-
 
 def generate_term_filters(multidict, filter_keys):
     '''
@@ -108,18 +106,3 @@ def filter_dsl_from_multidict(multidict):
         range_clause = generate_range_filters(multidict, range_filter_keys)
         final_filters.append(range_clause)
     return final_filters
-
-
-def selected_filters_from_multidict(multidict, field):
-    return [k for k in multidict.getlist(field) +
-            multidict.getlist('filter_' + field) if k]
-
-
-def selected_filters_for_field(fieldname):
-    multidict = get_request().GET
-    return selected_filters_from_multidict(multidict, fieldname)
-
-
-def is_filter_selected(fieldname, value):
-    multidict = get_request().GET
-    return value in selected_filters_from_multidict(multidict, fieldname)

--- a/cfgov/sheerlike/tests/test_filters.py
+++ b/cfgov/sheerlike/tests/test_filters.py
@@ -32,12 +32,6 @@ class TestArgParsing(TestCase):
         assert('2014-6-1' == filter_dsl[1]['range']['date']['lte'])
         assert('100' == filter_dsl[1]['range']['comment_count']['gt'])
 
-    def test_filters_for_field(self):
-        selected = filters.selected_filters_from_multidict(
-            self.args, 'category')
-        assert (('cats') in selected)
-        assert (('dogs') in selected)
-
 
 class TestDateValidation(TestCase):
 

--- a/cfgov/v1/jinja2tags.py
+++ b/cfgov/v1/jinja2tags.py
@@ -1,3 +1,4 @@
+from jinja2 import contextfunction
 from jinja2.ext import Extension
 
 from v1.models import CFGOVRendition
@@ -37,14 +38,28 @@ def image_alt_value(image):
     return ''
 
 
+def is_filter_selected(context, fieldname, value):
+    request_get = context['request'].GET
+
+    query_string_values = [
+        k for k in
+        request_get.getlist(fieldname) +
+        request_get.getlist('filter_' + fieldname)
+        if k
+    ]
+
+    return value in query_string_values
+
+
 class V1FiltersExtension(Extension):
     def __init__(self, environment):
         super(V1FiltersExtension, self).__init__(environment)
 
         self.environment.globals.update({
-            'image_alt_value': image_alt_value,
             'date_formatter': date_formatter,
             'email_popup': email_popup,
+            'image_alt_value': image_alt_value,
+            'is_filter_selected': contextfunction(is_filter_selected),
         })
 
 


### PR DESCRIPTION
This change moves where the `is_filter_selected` Jinja function is defined, from the sheerlike app to the v1 app. This function is used in the filterable list rendering logic.

To test locally using a production dump, run a local server and visit http://localhost:8000/about-us/blog/. Test and verify that filtering by various options continues to work properly.

This change also removes the deprecated `event_filter_args` macro which is not used anywhere in the codebase. It also removes the `selected_filters_for_field` tag which is also not used.

This change is part of a larger goal to remove the deprecated sheerlike app, initially by reducing dependencies on the `sheerlike.get_request` method.

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [X] Passes all existing automated tests
- [X] Any _change_ in functionality is tested
- [X] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [X] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: