### PR TITLE
Remove deprecated fix_link function

### DIFF
--- a/cfgov/processors/processors_common.py
+++ b/cfgov/processors/processors_common.py
@@ -1,6 +1,3 @@
-from six.moves.urllib.parse import urlsplit, urlunsplit
-
-
 replacements = (
     ('/blog/', '/about-us/blog/'),
     ('/pressrelease/', '/about-us/newsroom/'),
@@ -15,10 +12,3 @@ def update_path(path):
             new_path = path.replace(pattern, substitute)
             return new_path
     return path
-
-
-def fix_link(link):
-    urldata = urlsplit(link['href'])
-    new_href = urlunsplit((urldata.scheme, urldata.netloc, urldata.path,
-                           urldata.query, urldata.fragment))
-    link['href'] = new_href

--- a/cfgov/v1/__init__.py
+++ b/cfgov/v1/__init__.py
@@ -25,7 +25,6 @@ from jinja2 import Markup, contextfunction
 
 from core.templatetags.svg_icon import svg_icon
 from core.utils import signed_redirect, unsigned_redirect
-from processors.processors_common import fix_link
 from sheerlike import environment as sheerlike_environment
 from v1.fragment_cache_extension import FragmentCacheExtension
 from v1.routing import get_protected_url
@@ -183,8 +182,6 @@ def add_link_markup(tags):
             tag.contents = [span, NavigableString(' ')]
             # Appends the SVG icon
             tag.contents.append(BeautifulSoup(svg_icon(icon), 'html.parser'))
-        elif not FILES_LINK_PATTERN.match(tag['href']):
-            fix_link(tag)
 
 
 @contextfunction


### PR DESCRIPTION
As part of the removal of the deprecated sheerlike app, this change removes the `fix_link` method and its inclusion in Wagtail link markup logic.

This method uses [`urlparse.urlsplit`](https://docs.python.org/2/library/urlparse.html#urlparse.urlsplit) to split a URL into five components (scheme, netloc, path, query, and fragment) and then uses [`urlparse.urlunsplit`](https://docs.python.org/2/library/urlparse.html#urlparse.urlunsplit) to join them back together. This is effectively a noop:

```py
>>> urlunsplit(urlsplit('https://www.consumerfinance.gov/?foo=bar#test'))
'https://www.consumerfinance.gov/?foo=bar#test'
```

with one exception, the case of a completely empty query string:

```py
>>> urlunsplit(urlsplit('https://www.consumerfinance.gov/?'))
'https://www.consumerfinance.gov/'
```

We shouldn't have any occurrences of this last kind of URL, so there's no need to maintain this logic.

In the past, this function used to work slightly differently, to purposefully make links relative (see [this commit](https://github.com/cfpb/cfgov-refresh/pull/1811/files#diff-fe16ef71622313a8f4d91e408a59b891R19)). But this was eventually changed over time to the current logic (see [this commit](https://github.com/cfpb/cfgov-refresh/commit/e572cbc5f7084b4afe70e24d3a89b7c74d64ab15)), which makes this function removable.

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [X] Passes all existing automated tests
- [X] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: