### PR TITLE
Add sortable_label to index and fix section query

### DIFF
--- a/cfgov/regulations3k/search_indexes.py
+++ b/cfgov/regulations3k/search_indexes.py
@@ -2,7 +2,7 @@ from __future__ import unicode_literals
 
 from haystack import indexes
 
-from regulations3k.models import Section
+from regulations3k.models import Part, Section
 
 
 class RegulationSectionIndex(indexes.SearchIndex, indexes.Indexable):
@@ -12,9 +12,11 @@ class RegulationSectionIndex(indexes.SearchIndex, indexes.Indexable):
     title = indexes.CharField(model_attr='title')
     part = indexes.CharField(model_attr='subpart__version__part__part_number')
     date = indexes.DateField(model_attr='subpart__version__effective_date')
+    label = indexes.CharField(model_attr='sortable_label')
 
     def get_model(self):
         return Section
 
     def index_queryset(self, using=None):
-        return self.get_model().objects.filter(subpart__version__draft=False)
+        versions = [part.effective_version for part in Part.objects.all()]
+        return self.get_model().objects.filter(subpart__version__in=versions)


### PR DESCRIPTION
This will allow proper sorting when "order by regulation" is chosen
on our search page. It also fixes the section query so that only
sections that belong to a live effective version are indexed.

## Testing
This requires current work from the `regs3k-search-filters` branch to see search ordering in action, but you should be able to run the index command without errors:

```
./cfgov/manage.py update_index regulations3k --remove
```
