### PR TITLE
Revert to previous aria attribute

### DIFF
--- a/cfgov/jinja2/v1/_includes/organisms/mega-menu.html
+++ b/cfgov/jinja2/v1/_includes/organisms/mega-menu.html
@@ -231,7 +231,7 @@
 <nav class="{{ base_class }}
             u-hide-on-mobile"
     data-js-hook="behavior_flyout-menu"
-    aria-labelledby="{{ base_class ~ '_label' }}">
+    aria-label="main menu">
     <h2 class="{{ base_class ~ '_heading' }}">
         <button class="{{ base_class ~ '_trigger' }}"
                data-js-hook="behavior_flyout-menu_trigger"


### PR DESCRIPTION
there was an attempt to make another element the label, but that element was removed

## Additions

-

## Removals

-

## Changes

-

## Testing

I tested this on VoiceOver and there was no difference in the text that was read aloud for this element 🤷‍♀️ 

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Internet Explorer 8, 9, 10, and 11
- [ ] Edge
- [ ] iOS Safari
- [ ] Chrome for Android

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
