### PR TITLE
Bump Wagtail version to 1.13.2

### DIFF
--- a/requirements/wagtail.txt
+++ b/requirements/wagtail.txt
@@ -1,1 +1,1 @@
-wagtail==1.13.1
+wagtail==1.13.2


### PR DESCRIPTION
This change increases the version of Wagtail used from 1.13.1 to 1.13.2. This patch release fixes several bugs, including a set of 500 errors caused by null characters in URLs.

To confirm this fix, visit http://localhost:8000/foo/?x=%00 against a local server and note that it returns 404, not 500 as before.

Release notes for this version are at http://docs.wagtail.io/en/v2.1.1/releases/1.13.2.html.

All unit tests continue to pass; as this is a patch release, there are no major changes to functionality.

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [X] Passes all existing automated tests
- [X] Any _change_ in functionality is tested
- [X] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [X] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: