### PR TITLE
Reduce Travis queue by moving docs deploy to its own stage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,15 +55,16 @@ env:
 jobs:
   fast_finish: true
   include:
-    - stage: run tests
+    - stage: Run Tests
       env: RUNTEST=frontend
     - env:
-      - RUNTEST=backend
-      - TEST_RUNNER=cfgov.test.StdoutCapturingTestRunner
+        - RUNTEST=backend
+        - TEST_RUNNER=cfgov.test.StdoutCapturingTestRunner
+    - stage: Docs Deploy
+      if: tag IS present
+      env: RUNTEST=docs
       deploy:
         provider: pages
         local_dir: site
         skip-cleanup: true
         github_token: $GITHUB_TOKEN
-        on:
-          branch: master

--- a/travis_install.sh
+++ b/travis_install.sh
@@ -11,10 +11,16 @@ backend() {
     pip install -r requirements/travis.txt
 }
 
+docs() {
+    pip install -r requirements/manual.txt
+}
+
 echo "installing $RUNTEST dependencies"
 if [ "$RUNTEST" == "frontend" ]; then
     frontend
     backend
 elif [ "$RUNTEST" == "backend" ]; then
     backend
+elif [ "$RUNTEST" == "docs" ]; then
+    docs
 fi

--- a/travis_run.sh
+++ b/travis_run.sh
@@ -15,7 +15,6 @@ elif [ "$RUNTEST" == "backend" ]; then
     TEST_DATABASE_URL=postgres://travis:travis@localhost:5433/travis tox -e fast
     tox -e missing-migrations
     bash <(curl -s https://codecov.io/bash) -F backend
-
-    # pip install -r requirements/manual.txt
-    # mkdocs build
+elif [ "$RUNTEST" == "docs" ]; then
+    mkdocs build
 fi


### PR DESCRIPTION
The master branch doesn't need to run the test suites on ever PR merge, but the docs deploy currently relies on the master branch. Additionally, the docs should only deploy when a tag is released, otherwise the docs don't represent what's on production. This PR moves the docs to it's own stage that relies on a tagged release condition.

## Changes

- Reorganize travis for docs install and script tasks to live within docs stage.
- Reduce the depth of git commits to something reasonable.

## Testing

1. ¯\\_(ツ)_/¯ [Travis confirms it's not running the docs stage](https://travis-ci.org/cfpb/cfgov-refresh/builds/400606760), but there's no way to test the docs deploy without a tag 

## Notes

- There's more we can do to speed up the front-end side of the tests but this does drop about 30secs of every backend build and removing the master jobs entirely will reduce the queue.

## Todos

- Turn off branch building in Travis settings 
- Update Travis Concurrent jobs to 4 (even numbers will ensure most PRs run both suites concurrently)

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
