### PR TITLE
Bump django-college-costs-comparison version to 1.7

### DIFF
--- a/requirements/optional-public.txt
+++ b/requirements/optional-public.txt
@@ -6,5 +6,5 @@ https://github.com/cfpb/regulations-site/releases/download/2.2.5/regulations-2.2
 https://github.com/cfpb/retirement/releases/download/0.6.2/retirement-0.6.2-py2-none-any.whl
 git+https://github.com/cfpb/ccdb5-api.git@v1.0.6#egg=ccdb5-api
 git+https://github.com/cfpb/ccdb5-ui.git@v1.0.10#egg=ccdb5_ui
-https://github.com/cfpb/django-college-costs-comparison/releases/download/1.6.2/comparisontool-1.6.2-py2-none-any.whl
+https://github.com/cfpb/django-college-costs-comparison/releases/download/1.7/comparisontool-1.7-py2-none-any.whl
 https://github.com/cfpb/teachers-digital-platform/releases/download/0.6.0/teachers_digital_platform-0.6.0-py2-none-any.whl


### PR DESCRIPTION
This adds Django 1.11 compatibility to django-college-costs-comparison.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [x] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

This does not change any cf.gov-refresh functionality.