### PR TITLE
Beta feature flags now based on DEPLOY_ENVIRONMENT

### DIFF
--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -573,7 +573,7 @@ FLAGS = {
     # When enabled, a banner appears across the top of the site proclaiming
     # "This beta site is a work in progress."
     'BETA_NOTICE': {
-        'site': 'beta.consumerfinance.gov:443',
+        'boolean': DEPLOY_ENVIRONMENT == 'beta',
     },
 
     # When enabled, include a recruitment code comment in the base template.
@@ -626,17 +626,17 @@ FLAGS = {
 
     # Teacher's Digital Platform Customer Review Tool
     'TDP_CRTOOL': {
-        'site': 'beta.consumerfinance.gov:443',
+        'boolean': DEPLOY_ENVIRONMENT == 'beta',
     },
 
     # Teacher's Digital Platform Customer Review Tool Prototypes Pages
     'TDP_CRTOOL_PROTOTYPES': {
-        'site': 'beta.consumerfinance.gov:443',
+        'boolean': DEPLOY_ENVIRONMENT == 'beta',
     },
 
     # Teacher's Digital Platform Search Interface Tool
     'TDP_SEARCH_INTERFACE': {
-        'site': 'beta.consumerfinance.gov:443',
+        'boolean': DEPLOY_ENVIRONMENT == 'beta',
     },
 
     # Turbolinks is a JS library that speeds up page loads


### PR DESCRIPTION
This change modifies how various feature flags are triggered to enable functionality that should only be live on beta.cf.gov. Instead of relying on the Wagtail Site (which requires a database modification each time the beta DB is refreshed), the flags now use the Django setting `DEPLOY_ENVIRONMENT`, which is part of the beta system configuration.

To test, run a local server and notice that you don't see a beta banner. Then run again like this:

```sh
DEPLOY_ENVIRONMENT=beta ./runserver.sh
```

and you'll see the banner. Similarly, the TDP pages behind the TDP flags will work, if you have the [teachers-digital-platform](https://github.com/cfpb/cfgov-refresh/blob/master/requirements/optional-public.txt#L10) optional requirement installed.

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [X] Passes all existing automated tests
- [X] Any _change_ in functionality is tested
- [X] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [X] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: