### PR TITLE
Change label for regulation effective dates

### DIFF
--- a/cfgov/regulations3k/jinja2/regulations3k/browse-regulation.html
+++ b/cfgov/regulations3k/jinja2/regulations3k/browse-regulation.html
@@ -48,7 +48,7 @@
     </div>
     <h1>{{section.title}}</h1>
     <div class="a-date effective-date">
-        Effective date:
+        Most recently amended
         {{ time.render(section.subpart.version.effective_date, {'date':true, 'time':false, 'timezone':false}) }}
     </div>
 


### PR DESCRIPTION
Update the label for regulation effective dates from "Effective date:" to "Most recently amended"

## Changes

- Label for regulation effective dates changed from "Effective date:" to "Most recently amended"

## Testing

1. Fire up Regulations 3000 as usual
2. Go to any section, appendix, or interpretation of any regulation
3. Verify that the effective date that shows under the page's `h1` reads "MOST RECENTLY AMENDED [DATE]" as in the screenshot below

## Screenshots

![most-recently-amended](https://user-images.githubusercontent.com/1862695/42388083-57860f0e-8112-11e8-8f37-3a2397d2dcff.png)

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Internet Explorer 8, 9, 10, and 11
- [ ] Edge
- [ ] iOS Safari
- [ ] Chrome for Android

### Accessibility

- [x] Keyboard friendly
- [x] Screen reader friendly

### Other

- [x] Is useable without CSS
- [x] Is useable without JS
- [x] Flexible from small to large screens
- [x] No linting errors or warnings
- [x] JavaScript tests are passing
