### PR TITLE
Update to ESLint 5

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -811,7 +811,7 @@ rules:
 
   # Enforce a maximum number of line of code in a function.
   max-lines-per-function:
-    - 2
+    - 1
     -
       max: 50
       skipBlankLines: true

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,7 +1,7 @@
 # Environments.
 
 parserOptions:
-  ecmaVersion: 6
+  ecmaVersion: 2018
   sourceType: module
 
   # Enable ecmascript 6 features.
@@ -9,7 +9,6 @@ parserOptions:
     globalReturn: false
     impliedStrict: true
     jsx: true
-    experimentalObjectRestSpread: true
 
 parser: espree
 
@@ -188,7 +187,10 @@ rules:
       getWithoutSet: false
 
   # Enforces return statements in callbacks of array's methods.
-  array-callback-return: 2
+  array-callback-return:
+    - 2
+    -
+      allowImplicit: false
 
   # Enforces treating var statements as if they were block scoped.
   block-scoped-var: 1
@@ -235,6 +237,11 @@ rules:
 
   # Enforces necessary if statements in for-in loops.
   guard-for-in: 1
+
+  # Enforce a maximum number of classes per file.
+  max-classes-per-file:
+    - 2
+    - 1
 
   # Disallows use of alert, confirm, and prompt.
   no-alert: 2
@@ -697,6 +704,11 @@ rules:
     -
       properties: false
 
+  # Enforce the location of arrow function bodies.
+  implicit-arrow-linebreak:
+    - 2
+    - beside
+
   # Set a specific tab width for your code.
   indent:
     - 2
@@ -722,6 +734,7 @@ rules:
       ImportDeclaration: 1
       flatTernaryExpressions: false
       ignoredNodes: []
+      ignoreComments: false
 
   # Enforce whether double or single quotes should be used in JSX attributes.
   jsx-quotes:
@@ -795,6 +808,15 @@ rules:
       max: 300
       skipBlankLines: true
       skipComments: true
+
+  # Enforce a maximum number of line of code in a function.
+  max-lines-per-function:
+    - 2
+    -
+      max: 50
+      skipBlankLines: true
+      skipComments: true
+      IIFEs: true
 
   # Specify the maximum depth callbacks can be nested.
   max-nested-callbacks:
@@ -982,6 +1004,9 @@ rules:
       blankLine: always
       prev: "*"
       next: return
+
+  # Prefer the use of object spread when using Object.assign.
+  prefer-object-spread: 2
 
   # Requires quotes around object literal property names.
   quote-props:

--- a/cfgov/unprocessed/apps/owning-a-home/js/Expandable.js
+++ b/cfgov/unprocessed/apps/owning-a-home/js/Expandable.js
@@ -114,12 +114,11 @@ function Expandable( element ) { // eslint-disable-line max-statements, inline-c
     _calcHeight();
     duration = duration || _calculateExpandDuration( _contentHeight );
     this.dispatchEvent( 'expandBegin', { target: _that } );
-    DT.nextFrame( () =>
-      _transitionHeight(
-        _expandComplete,
-        duration,
-        'cubic-bezier(0.190, 1.000, 0.220, 1.000)'
-      )
+    DT.nextFrame( () => _transitionHeight(
+      _expandComplete,
+      duration,
+      'cubic-bezier(0.190, 1.000, 0.220, 1.000)'
+    )
     );
 
     /* on the next frame (as soon as the previous style change has taken effect),
@@ -146,8 +145,7 @@ function Expandable( element ) { // eslint-disable-line max-statements, inline-c
     _setMaxHeight();
     duration = duration || _calculateCollapseDuration( _contentHeight );
     this.dispatchEvent( 'collapseBegin', { target: _that } );
-    DT.nextFrame( () =>
-      _transitionHeight( _collapseComplete, duration, 'ease-in' )
+    DT.nextFrame( () => _transitionHeight( _collapseComplete, duration, 'ease-in' )
     );
 
     /* on the next frame (as soon as the previous style change has taken effect),

--- a/cfgov/unprocessed/apps/owning-a-home/js/dom-tools.js
+++ b/cfgov/unprocessed/apps/owning-a-home/js/dom-tools.js
@@ -64,8 +64,7 @@ function removeClass( selector, className ) {
   applyAll(
     getEls( selector ),
     element => {
-      fastDom.mutate( () =>
-        element.classList.remove( ...className )
+      fastDom.mutate( () => element.classList.remove( ...className )
       );
     } );
 }
@@ -79,10 +78,8 @@ function addClass( selector, className ) {
 
   applyAll(
     getEls( selector ),
-    element =>
-      fastDom.mutate( () =>
-        element.classList.add( ...className )
-      )
+    element => fastDom.mutate( () => element.classList.add( ...className )
+    )
   );
 }
 

--- a/cfgov/unprocessed/apps/regulations3k/js/search.js
+++ b/cfgov/unprocessed/apps/regulations3k/js/search.js
@@ -5,8 +5,8 @@ import * as behavior from '../../../js/modules/util/behavior';
  */
 function init() {
   behavior.attach( 'submit-search', 'submit', event => {
-    // event.preventDefault();
-    // console.log('submitted!');
+    /* event.preventDefault();
+       console.log('submitted!'); */
   } );
 }
 

--- a/cfgov/unprocessed/js/organisms/MegaMenuMobile.js
+++ b/cfgov/unprocessed/js/organisms/MegaMenuMobile.js
@@ -138,9 +138,9 @@ function MegaMenuMobile( menus ) {
         );
       }
 
-      // TODO: Investigate helper functions to mask these crazy long lookups!
-      // Do we really want to remove the overflow here? We're also adding it
-      // in the collapse end.
+      /* TODO: Investigate helper functions to mask these crazy long lookups!
+         Do we really want to remove the overflow here? We're also adding it
+         in the collapse end. */
       menuNode.parent.data.getDom()
         .content.classList.remove( 'u-hidden-overflow' );
     }
@@ -177,7 +177,7 @@ function MegaMenuMobile( menus ) {
       _bodyDom.addEventListener( 'click', _handleBodyClick );
     }
 
-    menuDom.content.classList.add('u-is-animating');
+    menuDom.content.classList.add( 'u-is-animating' );
   }
 
   /**
@@ -195,7 +195,7 @@ function MegaMenuMobile( menus ) {
       menuDom.altTrigger.focus();
     }
 
-    menuDom.content.classList.remove('u-is-animating');
+    menuDom.content.classList.remove( 'u-is-animating' );
   }
 
   /**
@@ -212,7 +212,7 @@ function MegaMenuMobile( menus ) {
       _bodyDom.removeEventListener( 'click', _handleBodyClick );
     }
 
-    menuDom.content.classList.add('u-is-animating');
+    menuDom.content.classList.add( 'u-is-animating' );
   }
 
   /**
@@ -241,7 +241,7 @@ function MegaMenuMobile( menus ) {
       menuDom.trigger.focus();
     }
 
-    menuDom.content.classList.remove('u-is-animating');
+    menuDom.content.classList.remove( 'u-is-animating' );
   }
 
   /**

--- a/cfgov/unprocessed/js/organisms/MortgagePerformanceTrends/actions/chart.js
+++ b/cfgov/unprocessed/js/organisms/MortgagePerformanceTrends/actions/chart.js
@@ -10,39 +10,38 @@ const chartActionCreators = defaultActionCreators();
  *
  * @returns {Function} Thunk called with metro states.
  */
-chartActionCreators.fetchMetroStates = metroState => dispatch =>
-  utils.getMetroData( states => {
-    let metroStates = [];
-    let reuseState = false;
-    Object.keys( states ).forEach( state => {
-      const isValid = states[state].metros.reduce( ( prev, curr ) => {
-        if ( curr.fips.indexOf( '-non' ) > -1 ) {
-          return prev;
-        }
-        return prev || curr.valid || false;
-      }, false );
-      if ( isValid ) {
-        reuseState = reuseState || metroState === state;
-        metroStates.push( {
-          abbr: state,
-          fips: states[state].state_fips,
-          name: states[state].state_name,
-          selected: metroState === state
-        } );
+chartActionCreators.fetchMetroStates = metroState => dispatch => utils.getMetroData( states => {
+  let metroStates = [];
+  let reuseState = false;
+  Object.keys( states ).forEach( state => {
+    const isValid = states[state].metros.reduce( ( prev, curr ) => {
+      if ( curr.fips.indexOf( '-non' ) > -1 ) {
+        return prev;
       }
-    } );
-    // Alphabetical order
-    metroStates = metroStates.sort( ( a, b ) => ( a.name < b.name ? -1 : 1 ) );
-
-    /* If the provided state isn't valid for this location type,
-       use the first state in the list. */
-    if ( !reuseState ) {
-      metroState = metroStates[0].abbr;
+      return prev || curr.valid || false;
+    }, false );
+    if ( isValid ) {
+      reuseState = reuseState || metroState === state;
+      metroStates.push( {
+        abbr: state,
+        fips: states[state].state_fips,
+        name: states[state].state_name,
+        selected: metroState === state
+      } );
     }
-    dispatch( chartActionCreators.setStates( metroStates ) );
-    dispatch( chartActionCreators.fetchMetros( metroState ) );
-    return metroStates;
   } );
+  // Alphabetical order
+  metroStates = metroStates.sort( ( a, b ) => ( a.name < b.name ? -1 : 1 ) );
+
+  /* If the provided state isn't valid for this location type,
+       use the first state in the list. */
+  if ( !reuseState ) {
+    metroState = metroStates[0].abbr;
+  }
+  dispatch( chartActionCreators.setStates( metroStates ) );
+  dispatch( chartActionCreators.fetchMetros( metroState ) );
+  return metroStates;
+} );
 
 /**
  * fetchNonMetroStates -
@@ -52,28 +51,27 @@ chartActionCreators.fetchMetroStates = metroState => dispatch =>
  *
  * @returns {Function} Thunk called with metro states.
  */
-chartActionCreators.fetchNonMetroStates = nonMetroState => dispatch =>
-  utils.getNonMetroData( states => {
-    let nonMetroStates = [];
-    states.forEach( state => {
-      if ( state.valid ) {
-        nonMetroStates.push( {
-          abbr: state.abbr,
-          fips: state.fips,
-          name: state.state_name,
-          text: state.name,
-          selected: nonMetroState === state.abbr
-        } );
-      }
-    } );
-    // Alphabetical order
-    nonMetroStates = nonMetroStates.sort(
-      ( a, b ) => ( a.name < b.name ? -1 : 1 )
-    );
-    dispatch( chartActionCreators.setStates( nonMetroStates ) );
-    dispatch( chartActionCreators.fetchNonMetros( nonMetroState ) );
-    return nonMetroStates;
+chartActionCreators.fetchNonMetroStates = nonMetroState => dispatch => utils.getNonMetroData( states => {
+  let nonMetroStates = [];
+  states.forEach( state => {
+    if ( state.valid ) {
+      nonMetroStates.push( {
+        abbr: state.abbr,
+        fips: state.fips,
+        name: state.state_name,
+        text: state.name,
+        selected: nonMetroState === state.abbr
+      } );
+    }
   } );
+  // Alphabetical order
+  nonMetroStates = nonMetroStates.sort(
+    ( a, b ) => ( a.name < b.name ? -1 : 1 )
+  );
+  dispatch( chartActionCreators.setStates( nonMetroStates ) );
+  dispatch( chartActionCreators.fetchNonMetros( nonMetroState ) );
+  return nonMetroStates;
+} );
 
 /**
  * fetchCountyStates -
@@ -83,38 +81,36 @@ chartActionCreators.fetchNonMetroStates = nonMetroState => dispatch =>
  *
  * @returns {Function} Thunk called with county states.
  */
-chartActionCreators.fetchCountyStates = countyState => dispatch =>
-  utils.getCountyData( states => {
-    let countyStates = [];
-    let reuseState = false;
-    Object.keys( states ).forEach( state => {
-      const isValid = states[state].counties.reduce( ( prev, curr ) =>
-        prev || curr.valid || false
-        , false );
-      if ( isValid ) {
-        reuseState = reuseState || countyState === state;
-        countyStates.push( {
-          abbr: state,
-          fips: states[state].state_fips,
-          name: states[state].state_name,
-          selected: countyState === state
-        } );
-      }
-    } );
-    // Alphabetical order
-    countyStates = countyStates.sort(
-      ( a, b ) => ( a.name < b.name ? -1 : 1 )
-    );
-
-    /* If the provided state isn't valid for this location type,
-       use the first state in the list. */
-    if ( !reuseState ) {
-      countyState = countyStates[0].abbr;
+chartActionCreators.fetchCountyStates = countyState => dispatch => utils.getCountyData( states => {
+  let countyStates = [];
+  let reuseState = false;
+  Object.keys( states ).forEach( state => {
+    const isValid = states[state].counties.reduce( ( prev, curr ) => prev || curr.valid || false
+      , false );
+    if ( isValid ) {
+      reuseState = reuseState || countyState === state;
+      countyStates.push( {
+        abbr: state,
+        fips: states[state].state_fips,
+        name: states[state].state_name,
+        selected: countyState === state
+      } );
     }
-    dispatch( chartActionCreators.setStates( countyStates ) );
-    dispatch( chartActionCreators.fetchCounties( countyState ) );
-    return countyStates;
   } );
+  // Alphabetical order
+  countyStates = countyStates.sort(
+    ( a, b ) => ( a.name < b.name ? -1 : 1 )
+  );
+
+  /* If the provided state isn't valid for this location type,
+       use the first state in the list. */
+  if ( !reuseState ) {
+    countyState = countyStates[0].abbr;
+  }
+  dispatch( chartActionCreators.setStates( countyStates ) );
+  dispatch( chartActionCreators.fetchCounties( countyState ) );
+  return countyStates;
+} );
 
 /**
  * fetchStates - Creates async action to fetch list of valid states.
@@ -124,32 +120,31 @@ chartActionCreators.fetchCountyStates = countyState => dispatch =>
  *
  * @returns {Function} Thunk called with valid states.
  */
-chartActionCreators.fetchStates = ( selectedState, includeComparison ) => dispatch =>
-  utils.getStateData( states => {
-    states = Object.keys( states ).map( fips => {
-      const state = {
-        abbr: states[fips].abbr,
-        fips: fips,
-        name: states[fips].name,
-        text: states[fips].name
-      };
-      if ( selectedState === states[fips].abbr ) {
-        selectedState = state;
-        state.selected = true;
-      }
-      return state;
-    } );
-    // Alphabetical order
-    states = states.sort( ( a, b ) => ( a.name < b.name ? -1 : 1 ) );
-    dispatch( chartActionCreators.setStates( states ) );
-    dispatch( chartActionCreators.setGeo(
-      selectedState.fips, selectedState.name, 'state'
-    ) );
-    dispatch( chartActionCreators.updateChart(
-      selectedState.fips, selectedState.name, 'state', includeComparison
-    ) );
-    return states;
+chartActionCreators.fetchStates = ( selectedState, includeComparison ) => dispatch => utils.getStateData( states => {
+  states = Object.keys( states ).map( fips => {
+    const state = {
+      abbr: states[fips].abbr,
+      fips: fips,
+      name: states[fips].name,
+      text: states[fips].name
+    };
+    if ( selectedState === states[fips].abbr ) {
+      selectedState = state;
+      state.selected = true;
+    }
+    return state;
   } );
+  // Alphabetical order
+  states = states.sort( ( a, b ) => ( a.name < b.name ? -1 : 1 ) );
+  dispatch( chartActionCreators.setStates( states ) );
+  dispatch( chartActionCreators.setGeo(
+    selectedState.fips, selectedState.name, 'state'
+  ) );
+  dispatch( chartActionCreators.updateChart(
+    selectedState.fips, selectedState.name, 'state', includeComparison
+  ) );
+  return states;
+} );
 
 /**
  * setStates - New U.S. states.

--- a/package-lock.json
+++ b/package-lock.json
@@ -260,12 +260,6 @@
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
       "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
     },
-    "accessibility-developer-tools": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/accessibility-developer-tools/-/accessibility-developer-tools-2.12.0.tgz",
-      "integrity": "sha1-PaDM6dbsY3OWS4TzXbfPw996tRQ=",
-      "dev": true
-    },
     "accord": {
       "version": "0.29.0",
       "resolved": "https://registry.npmjs.org/accord/-/accord-0.29.0.tgz",
@@ -310,20 +304,12 @@
       }
     },
     "acorn-jsx": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
-      "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-4.1.1.tgz",
+      "integrity": "sha512-JY+iV6r+cO21KtntVvFkD+iqjtdpRUpGqKWgfkCdZq1R+kbreEl8EcdcJR4SmiIgsIQT33s6QzheQ9a275Q8xw==",
       "dev": true,
       "requires": {
-        "acorn": "3.3.0"
-      },
-      "dependencies": {
-        "acorn": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
-          "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
-          "dev": true
-        }
+        "acorn": "5.5.3"
       }
     },
     "adm-zip": {
@@ -1120,29 +1106,6 @@
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.7.0.tgz",
       "integrity": "sha512-32NDda82rhwD9/JBCCkB+MRYDp0oSvlo2IL6rQWA10PQi7tDUM3eqMSltXmY+Oyl/7N3P3qNtAlv7X0d9bI28w=="
-    },
-    "axe-core": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-2.6.1.tgz",
-      "integrity": "sha512-QFfI3d+x/v92HJWGBaNfgrxdfon9/xXzd04YYfm5w5NJQOLex8qkJCctOt7+ky6e1l9zcQ5E7jsvbnTgQzyfTw==",
-      "dev": true
-    },
-    "axe-webdriverjs": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/axe-webdriverjs/-/axe-webdriverjs-0.2.0.tgz",
-      "integrity": "sha1-XjHtr26bozRCdiz9hd46B0c8EVU=",
-      "dev": true,
-      "requires": {
-        "axe-core": "1.1.1"
-      },
-      "dependencies": {
-        "axe-core": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-1.1.1.tgz",
-          "integrity": "sha1-rp2l2oq08QQZB/H12N/jnJRqksU=",
-          "dev": true
-        }
-      }
     },
     "axios": {
       "version": "0.17.1",
@@ -5818,32 +5781,31 @@
       }
     },
     "eslint": {
-      "version": "4.19.1",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.19.1.tgz",
-      "integrity": "sha512-bT3/1x1EbZB7phzYu7vCr1v3ONuzDtX8WjuM9c0iYxe+cq+pwcKEoQjl7zd3RpC6YOLgnSy3cTN58M2jcoPDIQ==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-5.0.1.tgz",
+      "integrity": "sha512-D5nG2rErquLUstgUaxJlWB5+gu+U/3VDY0fk/Iuq8y9CUFy/7Y6oF4N2cR1tV8knzQvciIbfqfohd359xTLIKQ==",
       "dev": true,
       "requires": {
-        "ajv": "5.5.2",
+        "ajv": "6.5.2",
         "babel-code-frame": "6.26.0",
         "chalk": "2.4.1",
-        "concat-stream": "1.6.2",
-        "cross-spawn": "5.1.0",
+        "cross-spawn": "6.0.5",
         "debug": "3.1.0",
         "doctrine": "2.1.0",
-        "eslint-scope": "3.7.1",
+        "eslint-scope": "4.0.0",
         "eslint-visitor-keys": "1.0.0",
-        "espree": "3.5.4",
+        "espree": "4.0.0",
         "esquery": "1.0.1",
         "esutils": "2.0.2",
         "file-entry-cache": "2.0.0",
         "functional-red-black-tree": "1.0.1",
         "glob": "7.1.2",
-        "globals": "11.5.0",
-        "ignore": "3.3.8",
+        "globals": "11.7.0",
+        "ignore": "3.3.10",
         "imurmurhash": "0.1.4",
-        "inquirer": "3.3.0",
+        "inquirer": "5.2.0",
         "is-resolvable": "1.1.0",
-        "js-yaml": "3.10.0",
+        "js-yaml": "3.12.0",
         "json-stable-stringify-without-jsonify": "1.0.1",
         "levn": "0.3.0",
         "lodash": "4.17.10",
@@ -5857,12 +5819,25 @@
         "regexpp": "1.1.0",
         "require-uncached": "1.0.3",
         "semver": "5.5.0",
+        "string.prototype.matchall": "2.0.0",
         "strip-ansi": "4.0.0",
         "strip-json-comments": "2.0.1",
-        "table": "4.0.2",
+        "table": "4.0.3",
         "text-table": "0.2.0"
       },
       "dependencies": {
+        "ajv": {
+          "version": "6.5.2",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.2.tgz",
+          "integrity": "sha512-hOs7GfvI6tUI1LfZddH82ky6mOMyTuY0mk7kE2pWpmhhUSkumzaTO5vbVwij39MdwPQWCV4Zv57Eo06NtL/GVA==",
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "2.0.1",
+            "fast-json-stable-stringify": "2.0.0",
+            "json-schema-traverse": "0.4.1",
+            "uri-js": "4.2.1"
+          }
+        },
         "ansi-styles": {
           "version": "2.2.1",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
@@ -5904,6 +5879,19 @@
             }
           }
         },
+        "cross-spawn": {
+          "version": "6.0.5",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+          "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+          "dev": true,
+          "requires": {
+            "nice-try": "1.0.4",
+            "path-key": "2.0.1",
+            "semver": "5.5.0",
+            "shebang-command": "1.2.0",
+            "which": "1.3.0"
+          }
+        },
         "doctrine": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
@@ -5913,11 +5901,89 @@
             "esutils": "2.0.2"
           }
         },
-        "globals": {
-          "version": "11.5.0",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-11.5.0.tgz",
-          "integrity": "sha512-hYyf+kI8dm3nORsiiXUQigOU62hDLfJ9G01uyGMxhc6BKsircrUhC4uJPQPUSuq2GrTmiiEt7ewxlMdBewfmKQ==",
+        "eslint-scope": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.0.tgz",
+          "integrity": "sha512-1G6UTDi7Jc1ELFwnR58HV4fK9OQK4S6N985f166xqXxpjU6plxFISJa2Ba9KCQuFa8RCnj/lSFJbHo7UFDBnUA==",
+          "dev": true,
+          "requires": {
+            "esrecurse": "4.2.1",
+            "estraverse": "4.2.0"
+          }
+        },
+        "fast-deep-equal": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+          "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
           "dev": true
+        },
+        "figures": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
+          "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+          "dev": true,
+          "requires": {
+            "escape-string-regexp": "1.0.5"
+          }
+        },
+        "globals": {
+          "version": "11.7.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-11.7.0.tgz",
+          "integrity": "sha512-K8BNSPySfeShBQXsahYB/AbbWruVOTyVpgoIDnl8odPpeSfP2J5QO2oLFFdl2j7GfDCtZj2bMKar2T49itTPCg==",
+          "dev": true
+        },
+        "inquirer": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-5.2.0.tgz",
+          "integrity": "sha512-E9BmnJbAKLPGonz0HeWHtbKf+EeSP93paWO3ZYoUpq/aowXvYGjjCSuashhXPpzbArIjBbji39THkxTz9ZeEUQ==",
+          "dev": true,
+          "requires": {
+            "ansi-escapes": "3.1.0",
+            "chalk": "2.4.1",
+            "cli-cursor": "2.1.0",
+            "cli-width": "2.2.0",
+            "external-editor": "2.2.0",
+            "figures": "2.0.0",
+            "lodash": "4.17.10",
+            "mute-stream": "0.0.7",
+            "run-async": "2.3.0",
+            "rxjs": "5.5.11",
+            "string-width": "2.1.1",
+            "strip-ansi": "4.0.0",
+            "through": "2.3.8"
+          }
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        },
+        "js-yaml": {
+          "version": "3.12.0",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.0.tgz",
+          "integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
+          "dev": true,
+          "requires": {
+            "argparse": "1.0.10",
+            "esprima": "4.0.0"
+          }
+        },
+        "json-schema-traverse": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+          "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+          "dev": true
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "2.0.0",
+            "strip-ansi": "4.0.0"
+          }
         },
         "strip-ansi": {
           "version": "4.0.0",
@@ -5960,13 +6026,21 @@
       "dev": true
     },
     "espree": {
-      "version": "3.5.4",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.4.tgz",
-      "integrity": "sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-4.0.0.tgz",
+      "integrity": "sha512-kapdTCt1bjmspxStVKX6huolXVV5ZfyZguY1lcfhVVZstce3bqxH9mcLzNn3/mlgW6wQ732+0fuG9v7h0ZQoKg==",
       "dev": true,
       "requires": {
-        "acorn": "5.5.3",
-        "acorn-jsx": "3.0.1"
+        "acorn": "5.7.1",
+        "acorn-jsx": "4.1.1"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.1.tgz",
+          "integrity": "sha512-d+nbxBUGKg7Arpsvbnlq61mc12ek3EY8EQldM3GPAhWJ1UVxC6TDGbIvUMNU6obBX3i1+ptCIzV4vq0gFPEGVQ==",
+          "dev": true
+        }
       }
     },
     "esprima": {
@@ -7876,14 +7950,34 @@
       }
     },
     "gulp-eslint": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/gulp-eslint/-/gulp-eslint-4.0.1.tgz",
-      "integrity": "sha512-MPafTtjHqV03g+ElSqvVXPjWQJafmBtSitF3dbTSD5ObcPjz353TGcR0LfCM0tqpBAQCywDL2siYKetnrxkjvg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/gulp-eslint/-/gulp-eslint-5.0.0.tgz",
+      "integrity": "sha512-9GUqCqh85C7rP9120cpxXuZz2ayq3BZc85pCTuPJS03VQYxne0aWPIXWx6LSvsGPa3uRqtSO537vaugOh+5cXg==",
       "dev": true,
       "requires": {
-        "eslint": "4.19.1",
+        "eslint": "5.0.1",
         "fancy-log": "1.3.2",
-        "plugin-error": "0.1.2"
+        "plugin-error": "1.0.1"
+      },
+      "dependencies": {
+        "arr-diff": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+          "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+          "dev": true
+        },
+        "plugin-error": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/plugin-error/-/plugin-error-1.0.1.tgz",
+          "integrity": "sha512-L1zP0dk7vGweZME2i+EeakvUNqSrdiI3F91TwEoYiGrAfUXmVv6fJIq4g82PAXxNsWOp0J7ZqQy/3Szz0ajTxA==",
+          "dev": true,
+          "requires": {
+            "ansi-colors": "1.1.0",
+            "arr-diff": "4.0.0",
+            "arr-union": "3.1.0",
+            "extend-shallow": "3.0.2"
+          }
+        }
       }
     },
     "gulp-header": {
@@ -8554,9 +8648,9 @@
       "integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE="
     },
     "ignore": {
-      "version": "3.3.8",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.8.tgz",
-      "integrity": "sha512-pUh+xUQQhQzevjRHHFqqcTy0/dP/kS9I8HSrUydhihjuD09W6ldVWFtIrwhXdUJHis3i2rZNqEHpZH/cbinFbg==",
+      "version": "3.3.10",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.10.tgz",
+      "integrity": "sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug==",
       "dev": true
     },
     "image-size": {
@@ -13243,6 +13337,12 @@
       "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
       "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw="
     },
+    "nice-try": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.4.tgz",
+      "integrity": "sha512-2NpiFHqC87y/zFke0fC0spBXL3bBsoh/p5H1EFhshxjCR5+0g2d6BiXbUFz9v1sAcxsk2htp2eQnNIci2dIYcA==",
+      "dev": true
+    },
     "no-case": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/no-case/-/no-case-2.3.2.tgz",
@@ -14560,27 +14660,6 @@
         }
       }
     },
-    "protractor-accessibility-plugin": {
-      "version": "github:cfpb/protractor-accessibility-plugin#7319a881e222d9f3588f6d5d8a3d9848bc38c859",
-      "dev": true,
-      "requires": {
-        "accessibility-developer-tools": "2.12.0",
-        "axe-core": "2.6.1",
-        "axe-webdriverjs": "0.2.0",
-        "html-entities": "1.2.1",
-        "lodash": "3.10.1",
-        "q": "1.5.1",
-        "request": "2.86.0"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "3.10.1",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-          "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
-          "dev": true
-        }
-      }
-    },
     "protractor-cucumber-framework": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/protractor-cucumber-framework/-/protractor-cucumber-framework-6.0.0.tgz",
@@ -15099,6 +15178,15 @@
         "safe-regex": "1.1.0"
       }
     },
+    "regexp.prototype.flags": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.2.0.tgz",
+      "integrity": "sha512-ztaw4M1VqgMwl9HlPpOuiYgItcHlunW0He2fE6eNfT6E/CF2FtYi9ofOYe4mKntstYk0Fyh/rDRBdS3AnxjlrA==",
+      "dev": true,
+      "requires": {
+        "define-properties": "1.1.2"
+      }
+    },
     "regexpp": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-1.1.0.tgz",
@@ -15515,6 +15603,15 @@
       "dev": true,
       "requires": {
         "rx-lite": "4.0.8"
+      }
+    },
+    "rxjs": {
+      "version": "5.5.11",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.5.11.tgz",
+      "integrity": "sha512-3bjO7UwWfA2CV7lmwYMBzj4fQ6Cq+ftHc2MvUe+WMS7wcdJ1LosDWmdjPQanYp2dBRj572p7PeU81JUxHKOcBA==",
+      "dev": true,
+      "requires": {
+        "symbol-observable": "1.0.1"
       }
     },
     "safe-buffer": {
@@ -16979,6 +17076,19 @@
         "strip-ansi": "3.0.1"
       }
     },
+    "string.prototype.matchall": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-2.0.0.tgz",
+      "integrity": "sha512-WoZ+B2ypng1dp4iFLF2kmZlwwlE19gmjgKuhL1FJfDgCREWb3ye3SDVHSzLH6bxfnvYmkCxbzkmWcQZHA4P//Q==",
+      "dev": true,
+      "requires": {
+        "define-properties": "1.1.2",
+        "es-abstract": "1.11.0",
+        "function-bind": "1.1.1",
+        "has-symbols": "1.0.0",
+        "regexp.prototype.flags": "1.2.0"
+      }
+    },
     "string_decoder": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
@@ -17193,6 +17303,12 @@
         "util.promisify": "1.0.0"
       }
     },
+    "symbol-observable": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.1.tgz",
+      "integrity": "sha1-g0D8RwLDEi310iKI+IKD9RPT/dQ=",
+      "dev": true
+    },
     "symbol-tree": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.2.tgz",
@@ -17200,24 +17316,30 @@
       "dev": true
     },
     "table": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/table/-/table-4.0.2.tgz",
-      "integrity": "sha512-UUkEAPdSGxtRpiV9ozJ5cMTtYiqz7Ni1OGqLXRCynrvzdtR1p+cfOWe2RJLwvUG8hNanaSRjecIqwOjqeatDsA==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/table/-/table-4.0.3.tgz",
+      "integrity": "sha512-S7rnFITmBH1EnyKcvxBh1LjYeQMmnZtCXSEbHcH6S0NoKit24ZuFO/T1vDcLdYsLQkM188PVVhQmzKIuThNkKg==",
       "dev": true,
       "requires": {
-        "ajv": "5.5.2",
-        "ajv-keywords": "2.1.1",
+        "ajv": "6.5.2",
+        "ajv-keywords": "3.2.0",
         "chalk": "2.4.1",
         "lodash": "4.17.10",
         "slice-ansi": "1.0.0",
         "string-width": "2.1.1"
       },
       "dependencies": {
-        "ajv-keywords": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.1.tgz",
-          "integrity": "sha1-YXmX/F9gV2iUxDX5QNgZ4TW4B2I=",
-          "dev": true
+        "ajv": {
+          "version": "6.5.2",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.2.tgz",
+          "integrity": "sha512-hOs7GfvI6tUI1LfZddH82ky6mOMyTuY0mk7kE2pWpmhhUSkumzaTO5vbVwij39MdwPQWCV4Zv57Eo06NtL/GVA==",
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "2.0.1",
+            "fast-json-stable-stringify": "2.0.0",
+            "json-schema-traverse": "0.4.1",
+            "uri-js": "4.2.1"
+          }
         },
         "ansi-regex": {
           "version": "3.0.0",
@@ -17225,10 +17347,22 @@
           "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
           "dev": true
         },
+        "fast-deep-equal": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+          "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
+          "dev": true
+        },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
           "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        },
+        "json-schema-traverse": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+          "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
           "dev": true
         },
         "string-width": {

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "chai-as-promised": "7.1.1",
     "cucumber": "4.2.1",
     "fancy-log": "1.3.2",
-    "gulp-eslint": "4.0.1",
+    "gulp-eslint": "5.0.0",
     "is-reachable": "2.4.0",
     "jest": "23.3.0",
     "jest-cli": "23.3.0",

--- a/test/unit_tests/js/modules/Analytics-spec.js
+++ b/test/unit_tests/js/modules/Analytics-spec.js
@@ -56,10 +56,10 @@ describe( 'Analytics', () => {
     it( 'should properly add objects to the dataLayer Array', () => {
       const action = 'inbox:clicked';
       const label = 'text:null';
-      const options = Object.assign( {}, dataLayerOptions, {
+      const options = { ...dataLayerOptions,
         action: action,
         label:  label
-      } );
+      };
       window['google_tag_manager'] = {};
       Analytics.init();
       Analytics.sendEvent( getDataLayerOptions( action, label ) );
@@ -104,16 +104,16 @@ describe( 'Analytics', () => {
   describe( '.sendEvents()', () => {
     it( 'should properly add objects to the dataLayer Array', () => {
       const options1 = getDataLayerOptions(
-        Object.assign( {}, dataLayerOptions, {
+        { ...dataLayerOptions,
           action: 'inbox:clicked',
           label:  'text:label_1'
-        } )
+        }
       );
       const options2 = getDataLayerOptions(
-        Object.assign( {}, dataLayerOptions, {
+        { ...dataLayerOptions,
           action: 'checbox:clicked',
           label:  'text:label_2'
-        } )
+        }
       );
       window['google_tag_manager'] = {};
       Analytics.init();
@@ -124,16 +124,16 @@ describe( 'Analytics', () => {
     it( 'shouldn\'t add objects to the dataLayer Array if an array isn\'t passed',
       () => {
         const options1 = getDataLayerOptions(
-          Object.assign( {}, dataLayerOptions, {
+          { ...dataLayerOptions,
             action: 'inbox:clicked',
             label:  'text:label_1'
-          } )
+          }
         );
         const options2 = getDataLayerOptions(
-          Object.assign( {}, dataLayerOptions, {
+          { ...dataLayerOptions,
             action: 'checbox:clicked',
             label:  'text:label_2'
-          } )
+          }
         );
         window['google_tag_manager'] = {};
         Analytics.init();


### PR DESCRIPTION
## Removals

- Removes deprecated `experimentalObjectRestSpread` from eslintrc file.


## Changes

- Update to ESLint 5.
- Adds new `max-classes-per-file` rule.
- Adds new `max-lines-per-function` rule.
- Adds new `implicit-arrow-linebreak` rule.
- Adds new `prefer-object-spread` rule.
- Autofixes linter errors and warnings.

## Testing

1. `./frontend.sh`
1. `gulp lint` should show no errors.
1. `gulp clean && gulp build && gulp test:unit` should pass.

## Todo

- development and capital-framework repos need their eslintrc file updated after this PR is approved.