### PR TITLE
Remove uneeded role

### DIFF
--- a/cfgov/jinja2/v1/_includes/templates/header-without-nav.html
+++ b/cfgov/jinja2/v1/_includes/templates/header-without-nav.html
@@ -1,7 +1,6 @@
 <header class="header
                wrapper
-               wrapper__match-content"
-        role="banner">
+               wrapper__match-content">
     <a href="/">
         <img class="o-header_logo-img"
              src="{{ static('img/logo_237x50.png') }}"


### PR DESCRIPTION
[Short description explaining the high-level reason for the pull request]

## Additions

-

## Removals

- Remove unneeded banner role.

## Changes

-

## Testing

1. Have the HTML Validator chrome extension installed https://chrome.google.com/webstore/detail/html-validator/mpbelhhnfhfjnaehkcnnaknldmnocglk?hl=en-US
1. Visit a blog article. 
2. Click any of the share buttons.
3. _Quickly_ inspect the page and open the HTML Validator tab and click "w3c online".
4. See that banner role warning is not in list of issues.

## Screenshots

Before:
![screen shot 2018-07-09 at 11 18 27 am](https://user-images.githubusercontent.com/704760/42459532-d0b33736-8369-11e8-977f-23e6112587de.png)
