### PR TITLE
Deprecate sheerlike.url_for Jinja2 function

### DIFF
--- a/cfgov/jinja2/v1/owning-a-home/closing-disclosure/closing-disclosure-1-data.html
+++ b/cfgov/jinja2/v1/owning-a-home/closing-disclosure/closing-disclosure-1-data.html
@@ -1,6 +1,6 @@
 {% set data = {
 
-"img": url_for("static", filename="img/closing-disclosure-H25B-1.png"),
+"img": static("img/closing-disclosure-H25B-1.png"),
 
 "terms":
     [

--- a/cfgov/jinja2/v1/owning-a-home/closing-disclosure/closing-disclosure-2-data.html
+++ b/cfgov/jinja2/v1/owning-a-home/closing-disclosure/closing-disclosure-2-data.html
@@ -1,6 +1,6 @@
 {% set data = {
 
-"img": url_for("static", filename="img/closing-disclosure-H25B-2.png"),
+"img": static("img/closing-disclosure-H25B-2.png"),
 "terms":
     [
         {
@@ -36,7 +36,7 @@
         {
             "term": "Check that “Services Borrower Did Not Shop For” are similar to what was shown on your Loan Estimate",
             "definition": "<p>These are third-party services required by your lender in order to get a loan. Compare with Section B, “Services You Cannot Shop For” and Section C, “Services You Can Shop For” on page 2 of your Loan Estimate form. Check to see that, overall, there are no new services listed that were not on your Loan Estimate form. The costs should be similar, but may be somewhat different from what was on your Loan Estimate form.</p><p><a href=\"/askcfpb/172/can-the-final-mortgage-costs-be-different-from-the-good-faith-estimate-gfe.html\" target=\"_blank\" rel=\"noopener noreferrer\">Learn more about when these costs are allowed to change between Loan Estimate and closing</a></p><p>Compare to page 2 of your Loan Estimate</p>",
-            "highlight": url_for('static', filename='img/services-not-shopped-for-highlight.png'),
+            "highlight": static('img/services-not-shopped-for-highlight.png'),
             "id": "services-did-not-shop",
             "category": "checklist",
             "left": "5.96%",

--- a/cfgov/jinja2/v1/owning-a-home/closing-disclosure/closing-disclosure-3-data.html
+++ b/cfgov/jinja2/v1/owning-a-home/closing-disclosure/closing-disclosure-3-data.html
@@ -1,6 +1,6 @@
 {% set data = {
 
-"img": url_for("static", filename="img/closing-disclosure-H25B-3.png"),
+"img": static("img/closing-disclosure-H25B-3.png"),
 "terms":
     [
         {

--- a/cfgov/jinja2/v1/owning-a-home/closing-disclosure/closing-disclosure-4-data.html
+++ b/cfgov/jinja2/v1/owning-a-home/closing-disclosure/closing-disclosure-4-data.html
@@ -1,6 +1,6 @@
 {% set data = {
 
-"img": url_for("static", filename="img/closing-disclosure-H25B-4.png"),
+"img": static("img/closing-disclosure-H25B-4.png"),
 
 "terms":
     [

--- a/cfgov/jinja2/v1/owning-a-home/closing-disclosure/closing-disclosure-5-data.html
+++ b/cfgov/jinja2/v1/owning-a-home/closing-disclosure/closing-disclosure-5-data.html
@@ -1,6 +1,6 @@
 {% set data = {
 
-"img": url_for("static", filename="img/closing-disclosure-H25B-5.png"),
+"img": static("img/closing-disclosure-H25B-5.png"),
 "terms":
     [
         {

--- a/cfgov/jinja2/v1/owning-a-home/loan-estimate/loan-estimate-1-data.html
+++ b/cfgov/jinja2/v1/owning-a-home/loan-estimate/loan-estimate-1-data.html
@@ -1,6 +1,6 @@
 {% set data = {
 
-"img": url_for("static", filename="apps/owning-a-home/img/loan-estimate-H24B-1.png"),
+"img": static("apps/owning-a-home/img/loan-estimate-H24B-1.png"),
 "terms":
 [
     {

--- a/cfgov/jinja2/v1/owning-a-home/loan-estimate/loan-estimate-2-data.html
+++ b/cfgov/jinja2/v1/owning-a-home/loan-estimate/loan-estimate-2-data.html
@@ -1,6 +1,6 @@
 {% set data = {
 
-"img": url_for("static", filename="apps/owning-a-home/img/loan-estimate-H24B-2.png"),
+"img": static("apps/owning-a-home/img/loan-estimate-H24B-2.png"),
 'terms':
 [
     {

--- a/cfgov/jinja2/v1/owning-a-home/loan-estimate/loan-estimate-3-data.html
+++ b/cfgov/jinja2/v1/owning-a-home/loan-estimate/loan-estimate-3-data.html
@@ -1,6 +1,6 @@
 {% set data = {
 
-"img": url_for("static", filename="apps/owning-a-home/img/loan-estimate-H24B-3.png"),
+"img": static("apps/owning-a-home/img/loan-estimate-H24B-3.png"),
 'terms':
 [
     {

--- a/cfgov/sheerlike/__init__.py
+++ b/cfgov/sheerlike/__init__.py
@@ -1,7 +1,6 @@
 # Python 2 only
 from __future__ import absolute_import
 
-import functools
 import os
 import os.path
 
@@ -29,15 +28,6 @@ def global_render_template(name, **kwargs):
     context['request'] = request
     template = loader.get_template(name, using='wagtail-env')
     return mark_safe(template.render(context.flatten()))
-
-
-def url_for(app, filename, site_slug=None):
-    if app == 'static' and not site_slug:
-        return staticfiles_storage.url(filename)
-    elif app == 'static':
-        return staticfiles_storage.url(site_slug + '/static/' + filename)
-    else:
-        raise ValueError("url_for doesn't know about %s" % app)
 
 
 class SheerlikeContext(Context):
@@ -89,13 +79,9 @@ def environment(**options):
 
     options.setdefault('extensions', []).append('jinja2.ext.do')
 
-    site_slug = options.get('site_slug')
-    if site_slug:
-        del options['site_slug']
     env = SheerlikeEnvironment(**options)
     env.globals.update({
         'static': staticfiles_storage.url,
-        'url_for': functools.partial(url_for, site_slug=site_slug),
         'url': reverse,
         'queries': queryfinder,
         'more_like_this': more_like_this,


### PR DESCRIPTION
As part of deprecation/cleanup of the sheerlike app, this change removes the custom `url_for` template function in favor of the standard Django `static` tag, which we pass into the Jinja2 environment.

To verify locally, visit:

- http://localhost:8000/owning-a-home/closing-disclosure/
- http://localhost:8000/owning-a-home/loan-estimate/

and verify that all images in the various steps load properly.

These images are all available to the static tag because we include the `static_built` directory in `settings.STATICFILES_DIRS`:

https://github.com/cfpb/cfgov-refresh/blob/3e3aed43d3cef23701ed9d4aaae45c199c4454be/cfgov/cfgov/settings/base.py#L230

The source images are located in `unprocessed/img` and get copied into `static_built` as part of the frontend build. Note that this does require that the frontend build complete before these pages can be viewed; but this is consistent with how other frontend assets are generated.

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [X] Passes all existing automated tests
- [X] Any _change_ in functionality is tested
- [X] New functions are documented (with a description, list of inputs, and expected output)
- [X] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [X] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: