### PR TITLE
Align inline interpretations to paragraph text

### DIFF
--- a/cfgov/regulations3k/jinja2/regulations3k/inline_interps.html
+++ b/cfgov/regulations3k/jinja2/regulations3k/inline_interps.html
@@ -1,7 +1,8 @@
 <div data-qa-hook="expandable" class="o-expandable
             o-expandable__expanded
             o-expandable__borders
-            o-expandable__midtone">
+            o-expandable__midtone
+            inline-interpretation">
 
     <button class="o-expandable_target">
         <div class="o-expandable_header">

--- a/cfgov/unprocessed/apps/regulations3k/css/main.less
+++ b/cfgov/unprocessed/apps/regulations3k/css/main.less
@@ -9,6 +9,7 @@
 @import (less) './reg-pagination.less';
 @import (less) './reg-search.less';
 @import (less) './reg-text.less';
+@import (less) './reg-inline-interpretations.less';
 
 .section-nav {
   .u-clearfix;

--- a/cfgov/unprocessed/apps/regulations3k/css/reg-inline-interpretations.less
+++ b/cfgov/unprocessed/apps/regulations3k/css/reg-inline-interpretations.less
@@ -1,0 +1,19 @@
+/* ==========================================================================
+   Regulations 3000
+   Regulation inline interpretation styling and cf-expandable overrides
+   ========================================================================== */
+
+.inline-interpretation {
+    max-width: 41.875rem;
+}
+
+.generateInterpLevel(6);
+
+// Generate six indentation levels for inline interpretations
+.generateInterpLevel(@n, @i: 1) when (@i =< @n) {
+    .level-@{i} + .inline-interpretation {
+        margin-left: (@i * 2rem);
+        max-width: (41.875rem - (@i*2));
+    }
+    .generateInterpLevel(@n, (@i + 1));
+}


### PR DESCRIPTION
Align inline interpretations to the text of the paragraph they interpret

## Additions

- `inline-interpretation` class to inline interpretation expandables
- LESS to style inline interpretation expandables

## Testing

1. Fire up Regulations 3000 as normal
2. Go to any section that has inline interpretations
3. Verify that inline interpretation styles match those seen in the screenshot below; namely:
    - Inline interpretations are only as wide as the main column of text (i.e. they don't bleed past the right edge of the paragraph text)
    - Each Inline interpretation is indented to the same level as the interpreted paragraph right above it

## Screenshots

![inline-interp-widths](https://user-images.githubusercontent.com/1862695/42472339-ed111a36-838e-11e8-92b4-31318e369dd4.png)

## Notes

- These styles rely on inline interpretations always directly following the paragraph they interpret, which I believe will always be the case. If we don't think the next sibling combinator method used in these styles will be bulletproof enough, though, we can refactor to add a `level-N` class to the inline interpretations themselves instead.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Internet Explorer 8, 9, 10, and 11
- [ ] Edge
- [ ] iOS Safari
- [ ] Chrome for Android

### Accessibility

- [x] Keyboard friendly
- [x] Screen reader friendly

### Other

- [x] Is useable without CSS
- [x] Is useable without JS
- [x] Flexible from small to large screens
- [x] No linting errors or warnings
- [x] JavaScript tests are passing
