### PR TITLE
Deprecate sheerlike middleware

### DIFF
--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -104,7 +104,6 @@ OPTIONAL_APPS = [
 POSTGRES_APPS = []
 
 MIDDLEWARE_CLASSES = (
-    'sheerlike.middleware.GlobalRequestMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.locale.LocaleMiddleware',
     'django.middleware.common.CommonMiddleware',

--- a/cfgov/sheerlike/__init__.py
+++ b/cfgov/sheerlike/__init__.py
@@ -7,42 +7,14 @@ import os.path
 from django.contrib.staticfiles.storage import staticfiles_storage
 from django.core.urlresolvers import reverse
 
-import jinja2.runtime
 from flags.template_functions import flag_disabled, flag_enabled
 from jinja2 import Environment
-from jinja2.runtime import Context
 
-from .middleware import get_request
 from .query import QueryFinder, get_document, more_like_this, when
 from .templates import get_date_obj, get_date_string
 
 
 default_app_config = 'sheerlike.apps.SheerlikeConfig'
-
-
-class SheerlikeContext(Context):
-
-    def __init__(self, environment, parent, name, blocks):
-        super(
-            SheerlikeContext,
-            self).__init__(
-            environment,
-            parent,
-            name,
-            blocks)
-
-        # Don't overwrite an existing request already coming into the context,
-        # for example one provided during Wagtail rendering.
-        if 'request' not in self.vars and 'request' not in self.keys():
-            try:
-                self.vars['request'] = get_request()
-            except Exception:
-                pass
-
-
-# Monkey patch not needed in master version of Jinja2
-# https://github.com/mitsuhiko/jinja2/commit/f22fdd5ffe81aab743f78290071b0aa506705533
-jinja2.runtime.Context = SheerlikeContext
 
 
 class SheerlikeEnvironment(Environment):

--- a/cfgov/sheerlike/middleware.py
+++ b/cfgov/sheerlike/middleware.py
@@ -6,24 +6,3 @@ _active = local()
 
 def get_request():
     return _active.request
-
-
-class FlaskyHeaderGetter(object):
-
-    def __init__(self, request):
-        self.request = request
-
-    def __getitem__(self, key):
-        django_key = 'HTTP_' + key.upper().replace('-', '_')
-        return self.request.META.get(django_key)
-
-    def get(self, key):
-        return self.__getitem__(key)
-
-
-class GlobalRequestMiddleware(object):
-
-    def process_view(self, request, view_func, view_args, view_kwargs):
-        _active.request = request
-        request.headers = FlaskyHeaderGetter(request)
-        return None


### PR DESCRIPTION
This commit deprecates use of the `sheerlike.middleware.GlobalRequestMiddleware`. This middleware did two things:

1. Added a global `request` variable to the Jinja2 context, passed via the local Python thread.

    This is no longer needed as the request should be properly passed into all Django and Jinja-rendered templates.

2. Adds the ability to access the request meta variables using dictionary syntax, e.g. `request.headers['foo']` gets converted to `request.META['HTTP_FOO']`.

    We don't access headers this way anymore (`git grep headers -- *.py`).

All unit tests continue to pass.

Note that the deprecated `sheerlike.middleware.get_request` method will be removed in a future PR; although there is some other sheerlike code that still calls it, that code is also unused and so breaking it causes no harm downstream.

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [X] Passes all existing automated tests
- [X] Any _change_ in functionality is tested
- [X] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [X] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: