### PR TITLE
Regs3k: Add search-term highlighting

### DIFF
--- a/cfgov/regulations3k/jinja2/regulations3k/base.html
+++ b/cfgov/regulations3k/jinja2/regulations3k/base.html
@@ -1,7 +1,6 @@
 
 {% extends 'layout-2-1-bleedbar.html' %}
 
-
 {# HEAD items #}
 
 {% block title -%}
@@ -55,7 +54,7 @@
     <ul>
     {% for reg in regs %}
     <li>
-        <a href="/regulations/{{reg.part_number}}" data-turbolinks="true">
+        <a href="{{ slugurl("regulations") }}{{reg.part_number}}/" data-turbolinks="true">
             <span class="title-num">{{reg.part_number}}</span>
         </a>
         <div class="reg-sub-title">

--- a/cfgov/regulations3k/jinja2/regulations3k/search-regulations.html
+++ b/cfgov/regulations3k/jinja2/regulations3k/search-regulations.html
@@ -44,9 +44,6 @@
 {% block css -%}
     {{ super() }}
     <link rel="stylesheet" href="{{ static('apps/regulations3k/css/main.css') }}">
-<style>
-    span.highlighted {background-color: lightgreen;}    
-</style>
 {%- endblock css %}
 
 

--- a/cfgov/regulations3k/jinja2/regulations3k/search-regulations.html
+++ b/cfgov/regulations3k/jinja2/regulations3k/search-regulations.html
@@ -44,6 +44,9 @@
 {% block css -%}
     {{ super() }}
     <link rel="stylesheet" href="{{ static('apps/regulations3k/css/main.css') }}">
+<style>
+    span.highlighted {background-color: lightgreen;}    
+</style>
 {%- endblock css %}
 
 

--- a/cfgov/regulations3k/models/pages.py
+++ b/cfgov/regulations3k/models/pages.py
@@ -10,6 +10,7 @@ from django.template.loader import get_template
 from django.template.response import TemplateResponse
 from django.utils.functional import cached_property
 from django.utils.text import Truncator
+# from haystack.utils import Highlighter
 from haystack.query import SearchQuerySet
 
 from wagtail.contrib.wagtailroutablepage.models import RoutablePageMixin, route
@@ -50,6 +51,7 @@ class RegulationsSearchPage(RoutablePageMixin, CFGOVPage):
 
     @route(r'^results/')
     def regulation_results_page(self, request):
+        # highlight = ''
         all_regs = Part.objects.order_by('part_number')
         regs = []
         order = request.GET.get('order', 'relevance')
@@ -59,7 +61,8 @@ class RegulationsSearchPage(RoutablePageMixin, CFGOVPage):
         search_query = request.GET.get('q', '')  # haystack cleans this string
         sqs = SearchQuerySet()
         if search_query:
-            sqs = sqs.filter(content=search_query)
+            sqs = sqs.filter(content=search_query).highlight()
+            # highlight = Highlighter(search_query)
         if len(regs) == 1:
             sqs = sqs.filter(part=regs[0])
         elif regs:
@@ -82,7 +85,9 @@ class RegulationsSearchPage(RoutablePageMixin, CFGOVPage):
         }
         for hit in sqs:
             letter_code = LETTER_CODES.get(hit.part)
-            snippet = Truncator(hit.text).words(50, truncate=' ...')
+            snippet = Truncator(hit.text).words(60, truncate=' ...')
+            # if highlight:
+            #     snippet = highlight.highlight(snippet)
             hit_payload = {
                 'id': hit.paragraph_id,
                 'reg': 'Regulation {}'.format(letter_code),

--- a/cfgov/regulations3k/tests/test_models.py
+++ b/cfgov/regulations3k/tests/test_models.py
@@ -135,11 +135,12 @@ class RegModelTests(DjangoTestCase):
             slug='1002')
 
         self.reg_search_page = RegulationsSearchPage(
-            title="Regulation search",
-            slug='reg-search')
+            title="Search regulations",
+            slug='search-regulations')
 
         self.landing_page.add_child(instance=self.reg_page)
         self.landing_page.add_child(instance=self.reg_search_page)
+        self.reg_page.save()
         self.reg_search_page.save()
 
     def test_part_string_method(self):
@@ -299,6 +300,8 @@ class RegModelTests(DjangoTestCase):
         mock_return.part = '1002'
         mock_return.text = ('Now is the time for all good men to come to the '
                             'aid of their country.')
+        mock_return.highlighted = ['Now is the time for all good men',
+                                   'to come to the aid of their country.']
         mock_return.paragraph_id = 'a'
         mock_return.title = 'Section 1002.1 Now is the time.'
         mock_return.section_label = '1'
@@ -319,6 +322,26 @@ class RegModelTests(DjangoTestCase):
                 '?q=disclosure&regs=1002&regs=1003&order=regulation')))
         self.assertEqual(response2.status_code, 200)
         self.assertEqual(mock_sqs.call_count, 2)
+
+    @mock.patch('regulations3k.models.pages.SearchQuerySet.models')
+    def test_routable_search_page_reg_only(self, mock_sqs):
+        mock_return = mock.Mock()
+        mock_return.part = '1002'
+        mock_return.text = ('Now is the time for all good men to come to the '
+                            'aid of their country.')
+        mock_return.paragraph_id = 'a'
+        mock_return.title = 'Section 1002.1 Now is the time.'
+        mock_return.section_label = '1'
+        mock_queryset = mock.Mock()
+        mock_queryset.__iter__ = mock.Mock(return_value=iter([mock_return]))
+        mock_queryset.count.return_value = 1
+        mock_sqs.return_value = mock_queryset
+        response = self.client.get(
+            self.reg_search_page.url + self.reg_search_page.reverse_subpage(
+                'regulation_results_page'),
+            QueryDict(query_string='?regs=1002'))
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(mock_sqs.call_count, 1)
 
     def test_get_breadcrumbs_reg_page(self):
         crumbs = self.reg_page.get_breadcrumbs(HttpRequest())


### PR DESCRIPTION
This is a relatively simple option that makes search terms bold, leaves a reasonable window of text around the search term for context and thus isn't too jarring when jumping to the result's reference link.

The highlighting can be test-driven on dev5 at`/regulations/reg-search/results/?q=appraisal+fee`

<img width="1210" alt="simple_highlighting" src="https://user-images.githubusercontent.com/515885/42644446-9de06290-85c9-11e8-9a03-01108494dfd4.png">

### Notes
Other Haystack options remove content up to the first instance of the search term, which has  drawbacks:
- Highlighting of the first instance of the term becomes redundant, since the terms are always the first words of a result.
- It often fails to provide reasonable context and can be disorienting when clicking on the result link.

