### PR TITLE
Update regulations search link

### DIFF
--- a/cfgov/regulations3k/jinja2/regulations3k/browse-regulation.html
+++ b/cfgov/regulations3k/jinja2/regulations3k/browse-regulation.html
@@ -40,16 +40,19 @@
 
 {% block content_main %}
     {% if section %}
-    <div class="search-this-regulation">
-        <a href="#">
-            {% include 'icons/search.svg' %}
-            Search {{ regulation }}
-        </a>
-    </div>
     <h1>{{section.title}}</h1>
-    <div class="a-date effective-date">
-        Most recently amended
-        {{ time.render(section.subpart.version.effective_date, {'date':true, 'time':false, 'timezone':false}) }}
+    <div class="regulation-meta">
+        <div class="a-date">
+            Most recently amended
+            {{ time.render(section.subpart.version.effective_date, {'date':true, 'time':false, 'timezone':false}) }}
+        </div>
+        <ul class="m-list m-list__links">
+            <li class="m-list_item">
+                <a class="m-list_link" href="{{ search_url }}">
+                    Search {{ regulation }}
+                </a>
+            </li>
+        </ul>
     </div>
 
     <section class="block block__flush-top">

--- a/cfgov/regulations3k/models/pages.py
+++ b/cfgov/regulations3k/models/pages.py
@@ -236,9 +236,9 @@ class RegulationPage(RoutablePageMixin, SecondaryNavigationJSMixin, CFGOVPage):
                 self.sections, current_index),
             'section': section,
             'breadcrumb_items': self.get_breadcrumbs(request, section),
-            'search_url': self.get_parent().url +
-                'search-regulations/results/?regs=' +
-                self.regulation.part_number,
+            'search_url': (self.get_parent().url +
+                           'search-regulations/results/?regs=' +
+                           self.regulation.part_number)
         })
 
         return TemplateResponse(

--- a/cfgov/regulations3k/models/pages.py
+++ b/cfgov/regulations3k/models/pages.py
@@ -236,6 +236,9 @@ class RegulationPage(RoutablePageMixin, SecondaryNavigationJSMixin, CFGOVPage):
                 self.sections, current_index),
             'section': section,
             'breadcrumb_items': self.get_breadcrumbs(request, section),
+            'search_url': self.get_parent().url +
+                'search-regulations/results/?regs=' +
+                self.regulation.part_number,
         })
 
         return TemplateResponse(

--- a/cfgov/unprocessed/apps/regulations3k/css/reg-text.less
+++ b/cfgov/unprocessed/apps/regulations3k/css/reg-text.less
@@ -32,11 +32,11 @@
     }
 }
 
-.effective-date {
-    margin-bottom: unit( 30px / @base-font-size-px, rem );
-    white-space: normal;
-}
+.regulation-meta {
+    margin-bottom: unit( 25px / @base-font-size-px, rem );
 
-.search-this-regulation {
-    margin-bottom: unit( 15px / @base-font-size-px, rem );
+    .a-date {
+        margin-bottom: unit( 8px / @base-font-size-px, rem );
+        white-space: normal;
+    }
 }


### PR DESCRIPTION
Move the search link on regulations section pages a little further down the page and point it to the correct URL.

## Additions

- Added `search_url` to the section page's context

## Removals

- Ditched the search icon at the beginning of the link

## Changes

- Reorganized the HTML for a section page's metadata elements
- Moved the search link below the `h1`
- Underlined the search link

## Testing

1. Fire up Regulations 3000 as you usually do
2. Go to any section of any regulation
3. Make sure the search link now appears underneath the effective date, reads "Search 12 CFR Part [NNNN] (Regulation [X])" and matches the style shown in the screenshot.
4. Make sure the search link points to regulations/search-regulations/results/?regs=[NNNN]. When you do a search on the page that link points to, you should initially only see results from the regulation you came from.

## Screenshots

![regs-search-link](https://user-images.githubusercontent.com/1862695/42700282-4048e1b6-8691-11e8-868e-de7c88a4ffab.png)

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [x] Chrome
- [ ] Firefox
- [x] Safari
- [ ] Internet Explorer 8, 9, 10, and 11
- [ ] Edge
- [ ] iOS Safari
- [ ] Chrome for Android

### Accessibility

- [x] Keyboard friendly
- [x] Screen reader friendly

### Other

- [x] Is useable without CSS
- [x] Is useable without JS
- [x] Flexible from small to large screens
- [x] No linting errors or warnings
- [x] JavaScript tests are passing
