### PR TITLE
Fix new logo width, update on header-without-nav

### DIFF
--- a/cfgov/jinja2/v1/_includes/templates/header-without-nav.html
+++ b/cfgov/jinja2/v1/_includes/templates/header-without-nav.html
@@ -2,6 +2,19 @@
                wrapper
                wrapper__match-content">
     <a href="/">
+    {% if flag_enabled('BCFP_LOGO', request) %}
+        <img class="o-header_logo-img"
+             src="{{ static('img/bcfp-logo_240x50.png') }}"
+             srcset="{{ static('img/bcfp-logo_160x34.png') }} 160w,
+                     {{ static('img/bcfp-logo_160x34@2x.png') }} 320w,
+                     {{ static('img/bcfp-logo_160x34@3x.png') }} 480w,
+                     {{ static('img/bcfp-logo_160x34@4x.png') }} 640w,
+                     {{ static('img/bcfp-logo_240x50.png') }} 240w,
+                     {{ static('img/bcfp-logo_240x50@2x.png') }} 480w"
+             sizes="(max-width: 900px) 160px,
+                    240px"
+             alt="Bureau of Consumer Financial Protection">
+    {% else %}
         <img class="o-header_logo-img"
              src="{{ static('img/logo_237x50.png') }}"
              srcset="{{ static('img/logo_161x34.png') }} 161w,
@@ -13,5 +26,6 @@
              sizes="(max-width: 900px) 161px,
                     237px"
              alt="Consumer Financial Protection Bureau">
+    {% endif %}
     </a>
 </header>

--- a/cfgov/unprocessed/css/organisms/header.less
+++ b/cfgov/unprocessed/css/organisms/header.less
@@ -32,16 +32,16 @@
                 <div class="m-global-search"></div>
                 <a class="o-header_logo" href="/">
                     <img class="o-header_logo-img"
-                         src="{{ static('img/logo_237x50.png') }}"
-                         srcset="{{ static('img/logo_161x34.png') }} 161w,
-                                 {{ static('img/logo_161x34@2x.png') }} 322w,
-                                 {{ static('img/logo_161x34@3x.png') }} 483w,
-                                 {{ static('img/logo_161x34@4x.png') }} 644w,
-                                 {{ static('img/logo_237x50.png') }} 237w,
-                                 {{ static('img/logo_237x50@2x.png') }} 474w"
-                         sizes="(max-width: 900px) 161px,
-                                237px"
-                         alt="Consumer Financial Protection Bureau">
+                         src="{{ static('img/bcfp-logo_240x50.png') }}"
+                         srcset="{{ static('img/bcfp-logo_160x34.png') }} 160w,
+                                 {{ static('img/bcfp-logo_160x34@2x.png') }} 320w,
+                                 {{ static('img/bcfp-logo_160x34@3x.png') }} 480w,
+                                 {{ static('img/bcfp-logo_160x34@4x.png') }} 640w,
+                                 {{ static('img/bcfp-logo_240x50.png') }} 240w,
+                                 {{ static('img/bcfp-logo_240x50@2x.png') }} 480w"
+                         sizes="(max-width: 900px) 160px,
+                                240px"
+                         alt="Bureau of Consumer Financial Protection">
                 </a>
             </div>
             [o-mega-menu]
@@ -165,7 +165,6 @@
             .respond-to-min( @bp-med-min, {
                 margin: 0 0 unit( 20px / @base-font-size-px, em ) 0;
                 height: 50px;
-                width: 237px;
             } );
         }
     }


### PR DESCRIPTION
I messed up and forgot to include the CSS tweak in #4344. Also missed the `header-without-nav.html` template, which is used for the external site notice.

## Changes

- Remove unnecessary explicit width for logo on medium+ screens
- Add flagged BCFP logo to `header-without-nav.html` template

## Testing

1. Pull branch
1. `gulp styles`
1. Load up a page, inspect the logo, and see that it's rendering at the correct size, 240x50.


## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
