### PR TITLE
regs3k: Build out 'clear all filters' button

### DIFF
--- a/cfgov/unprocessed/apps/regulations3k/js/search-utils.js
+++ b/cfgov/unprocessed/apps/regulations3k/js/search-utils.js
@@ -71,6 +71,17 @@ function hideLoading( el ) {
 }
 
 /**
+ * Uncheck checkbox.
+ *
+ * @param {HTMLNode} el Input element to uncheck.
+ * @returns {HTMLNode} Input element.
+ */
+function clearCheckbox( el ) {
+  el.checked = false;
+  return el;
+}
+
+/**
  * Fetches search results partial
  *
  * @param {String} url URL's of search results.
@@ -112,6 +123,7 @@ module.exports = {
   buildSearchResultsURL: buildSearchResultsURL,
   showLoading: showLoading,
   hideLoading: hideLoading,
+  clearCheckbox: clearCheckbox,
   handleError: handleError,
   fetchSearchResults: fetchSearchResults
 };

--- a/cfgov/unprocessed/apps/regulations3k/js/search.js
+++ b/cfgov/unprocessed/apps/regulations3k/js/search.js
@@ -26,7 +26,7 @@ function attachHandlers() {
  * @param {Event} event Click event
  */
 function clearFilter( event ) {
-  // Continue only if the X icon was clicked
+  // Continue only if the X icon was clicked and not the parent button
   if ( event.target.tagName === 'BUTTON' ) {
     return;
   }
@@ -36,7 +36,9 @@ function clearFilter( event ) {
   target.remove();
   // Uncheck the filter checkbox
   checkbox.checked = false;
-  handleSubmit( event );
+  if ( event instanceof Event ) {
+    handleSubmit( event );
+  }
 }
 
 /**
@@ -45,8 +47,15 @@ function clearFilter( event ) {
  * @param {Event} event Click event
  */
 function clearFilters( event ) {
-  // TODO: Implement this.
-  console.log( 'cleared all!' );
+  const filterIcons = document.querySelectorAll( '.a-tag svg' );
+  filterIcons.forEach( filterIcon => {
+    const target = closest( filterIcon, 'button' );
+    clearFilter( {
+      target: filterIcon,
+      value: target
+    } );
+  } );
+  handleSubmit();
 }
 
 /**
@@ -55,7 +64,9 @@ function clearFilters( event ) {
  * @param {Event} event Click event
  */
 function handleSubmit( event ) {
-  event.preventDefault();
+  if ( event instanceof Event ) {
+    event.preventDefault();
+  }
   const searchContainer = find( '#regs3k-results' );
   const filters = document.querySelectorAll( 'input:checked' );
   const searchField = find( 'input[name=q]' );

--- a/test/unit_tests/apps/regulations3k/js/search-spec.js
+++ b/test/unit_tests/apps/regulations3k/js/search-spec.js
@@ -79,7 +79,7 @@ describe( 'The Regs3K search page', () => {
     expect( numFilters ).toEqual( 1 );
   } );
 
-  it( 'should clear all filters the `clear all` link is clicked', () => {
+  it( 'should clear all filters when the `clear all` link is clicked', () => {
     const mockXHR = {
       open: jest.fn(),
       send: jest.fn(),
@@ -96,7 +96,7 @@ describe( 'The Regs3K search page', () => {
 
     simulateEvent( 'click', clearAllLink );
     numFilters = document.querySelectorAll( 'button.a-tag' ).length;
-    expect( console.log ).toBeCalled();
+    expect( numFilters ).toEqual( 0 );
 
     mockXHR.onreadystatechange();
   } );

--- a/test/unit_tests/apps/regulations3k/js/search-utils-spec.js
+++ b/test/unit_tests/apps/regulations3k/js/search-utils-spec.js
@@ -44,6 +44,11 @@ describe( 'The Regs3K search utils', () => {
     expect( el.style.opacity ).toEqual( 1 );
   } );
 
+  it( 'should clear a checkbox', () => {
+    const checkbox = utils.clearCheckbox( { checked: true } );
+    expect( checkbox.checked ).toBeFalsy();
+  } );
+
   it( 'should handle errors', () => {
     const searchError = utils.handleError( 'no-results' );
     expect( searchError.msg ).toEqual( 'Your query returned zero results.' );


### PR DESCRIPTION
Clear all regs checkbox filters and remove the filter tags when the red 'Clear all filters' button is clicked.

## Testing

1. Select regs filters.
1. 'Clear all filters' link should appear next to filter tags.
1. Clicking link should clear all filters.

## Screenshots

![eoeg30kl2o](https://user-images.githubusercontent.com/1060248/42742441-8d53eebc-8888-11e8-9444-8c61d8f66678.gif)
