### PR TITLE
regs3k:  Update Regs3K search URL when filters are changed

### DIFF
--- a/cfgov/jinja2/v1/_includes/atoms/checkbox.html
+++ b/cfgov/jinja2/v1/_includes/atoms/checkbox.html
@@ -32,7 +32,7 @@
 {%- set el = value.el_wrapper if value.el_wrapper else 'div' -%}
 {%- set val = value.value if value.value else id -%}
 {%- set name = value.name if value.name else id -%}
-{%- set behavior = 'data-js-hook="behavior_' ~ behavior ~ '"' if value.behavior else '' -%}
+{%- set behavior = 'data-js-hook=behavior_' ~ value.behavior if value.behavior else '' -%}
 {%- set checked = 'checked' if value.selected else '' -%}
 
 <{{ el }} class="m-form-field m-form-field__checkbox {{ value.class }}">

--- a/cfgov/jinja2/v1/_includes/eregs/regulations3k-search-bar.html
+++ b/cfgov/jinja2/v1/_includes/eregs/regulations3k-search-bar.html
@@ -1,15 +1,19 @@
 {% macro render(q='', hidden_fields) %}
 
-<form action=".">
+<form action="." data-js-hook="behavior_submit-search">
     <label class="a-label a-label__heading" for="query">
         Search term
     </label>
     <div class="o-form__input-w-btn">
-        {% for field in hidden_fields %}
-            {% for value in field.value.split(',') %}
-                <input type="hidden" name="{{ field.name }}" value="{{ value }}">
+        {% if hidden_fields | length > 0 %}
+            <div id="regs3k-hidden-filters">
+            {% for field in hidden_fields %}
+                {% for value in field.value.split(',') %}
+                    <input type="hidden" name="{{ field.name }}" value="{{ value }}">
+                {% endfor %}
             {% endfor %}
-        {% endfor %}
+            </div>
+        {% endif %}
         <div class="o-form__input-w-btn_input-container">
             <div class="m-btn-inside-input input-contains-label">
                 <label for="query" class="input-contains-label_before input-contains-label_before__search">{{ svg_icon('search') }}</label>

--- a/cfgov/regulations3k/jinja2/regulations3k/search-regulations.html
+++ b/cfgov/regulations3k/jinja2/regulations3k/search-regulations.html
@@ -87,7 +87,7 @@
     <div class="block block__flush-top">
         <aside class="content_sidebar content__flush-top-on-small content__flush-sides-on-small filters">
             <h3>Refine results</h3>
-            <form action="." method="get" data-js-hook="behavior_submit-search">
+            <form action="." method="get" data-js-hook="behavior_change-filter">
                 {% set expandable_settings = {
                     'label': 'Regulation',
                     'is_expanded': true,
@@ -110,7 +110,6 @@
                                     'id': 'regulation-' ~ reg.id,
                                     'class': 'reg-checkbox',
                                     'name': 'regs',
-                                    'behavior': 'change-filter',
                                     'selected': reg.selected
                                 }) }}
                                 <div class="num-results">{{ reg.num_results }}</div>

--- a/cfgov/regulations3k/jinja2/regulations3k/search-regulations.html
+++ b/cfgov/regulations3k/jinja2/regulations3k/search-regulations.html
@@ -110,7 +110,7 @@
                                     'id': 'regulation-' ~ reg.id,
                                     'class': 'reg-checkbox',
                                     'name': 'regs',
-                                    'behavior': 'submit-search',
+                                    'behavior': 'change-filter',
                                     'selected': reg.selected
                                 }) }}
                                 <div class="num-results">{{ reg.num_results }}</div>

--- a/cfgov/unprocessed/apps/regulations3k/js/search-utils.js
+++ b/cfgov/unprocessed/apps/regulations3k/js/search-utils.js
@@ -42,10 +42,13 @@ function serializeFormFields( fields ) {
  *
  * @param {String} base URL's base.
  * @param {String} params URL's GET parameters.
+ * @param {Object} opts Object of additional options for the URL.
  * @returns {String} Encoded URL.
  */
-function buildSearchResultsURL( base, params ) {
-  return `${ base }?${ params }&partial`;
+function buildSearchResultsURL( base, params, opts ) {
+  // Currently the only option is for a partial search results template
+  opts = opts && opts.partial ? '&partial' : '';
+  return `${ base }?${ params }${ opts }`;
 }
 
 /**

--- a/cfgov/unprocessed/apps/regulations3k/js/search-utils.js
+++ b/cfgov/unprocessed/apps/regulations3k/js/search-utils.js
@@ -23,9 +23,8 @@ function getSearchValues( searchEl, filterEls ) {
 /**
  * Serializes form fields into GET-friendly string.
  *
- * @param {Array} fields Array of objects of form field
- * key-value pairs.
- * @returns {String} xhr
+ * @param {Array} fields Array of objects of form field key-value pairs.
+ * @returns {String} Serialized form fields.
  */
 function serializeFormFields( fields ) {
   fields = fields.map( field => {
@@ -114,17 +113,20 @@ function updateUrl( base, params ) {
 /**
  * Check error and do something with it
  *
- * @param {String} err Error code
+ * @param {String} code Error code
  * @returns {Object} Error object to be handled by DOM.
  */
-function handleError( err ) {
+function handleError( code ) {
   const error = {
     message: null,
-    type: err || 'unknown'
+    code: code || 0
   };
-  switch ( err ) {
+  switch ( code ) {
     case 'no-results':
       error.msg = 'Your query returned zero results.';
+      break;
+    case 0:
+      error.msg = 'Search request was cancelled.';
       break;
     default:
       error.msg = 'Sorry, our search engine is temporarily down.';

--- a/cfgov/unprocessed/apps/regulations3k/js/search-utils.js
+++ b/cfgov/unprocessed/apps/regulations3k/js/search-utils.js
@@ -96,6 +96,19 @@ function fetchSearchResults( url, cb ) {
 }
 
 /**
+ * Update the page's URL via replaceState
+ *
+ * @param {String} base URL's base.
+ * @param {String} params URL's GET parameters.
+ * @returns {String} New URL.
+ */
+function updateUrl( base, params ) {
+  const url = `${ base }?${ params }`;
+  window.history.replaceState( null, null, url );
+  return url;
+}
+
+/**
  * Check error and do something with it
  *
  * @param {String} err Error code
@@ -125,5 +138,6 @@ module.exports = {
   hideLoading: hideLoading,
   clearCheckbox: clearCheckbox,
   handleError: handleError,
-  fetchSearchResults: fetchSearchResults
+  fetchSearchResults: fetchSearchResults,
+  updateUrl: updateUrl
 };

--- a/cfgov/unprocessed/apps/regulations3k/js/search.js
+++ b/cfgov/unprocessed/apps/regulations3k/js/search.js
@@ -58,7 +58,7 @@ function clearFilters( event ) {
       value: target
     } );
   } );
-  handleSubmit();
+  handleFilter( event );
 }
 
 /**
@@ -122,6 +122,11 @@ function handleFilter( event ) {
   } );
 }
 
-window.addEventListener( 'load', () => {
-  init();
-} );
+// Provide the no-JS experience to browsers without `replaceState`
+if ( 'replaceState' in window.history ) {
+  window.addEventListener( 'load', () => {
+    init();
+  } );
+} else {
+  document.getElementById( 'main' ).className += ' no-js';
+}

--- a/cfgov/unprocessed/apps/regulations3k/js/search.js
+++ b/cfgov/unprocessed/apps/regulations3k/js/search.js
@@ -2,6 +2,9 @@ import * as behavior from '../../../js/modules/util/behavior';
 import * as utils from './search-utils';
 import { closest, queryOne as find } from '../../../js/modules/util/dom-traverse';
 
+// Keep track of the most recent XHR request so that we can cancel it if need be
+let searchRequest = {};
+
 /**
  * Initialize search functionality.
  */
@@ -87,6 +90,11 @@ function handleFilter( event ) {
   if ( event instanceof Event ) {
     event.preventDefault();
   }
+  // Abort the previous search request if it's still active
+  /* eslint no-empty: ["error", { "allowEmptyCatch": true }] */
+  try {
+    searchRequest.abort();
+  } catch ( err ) { }
   const searchContainer = find( '#regs3k-results' );
   const filters = document.querySelectorAll( 'input:checked' );
   const searchField = find( 'input[name=q]' );
@@ -99,11 +107,11 @@ function handleFilter( event ) {
   // Update the filter query params in the URL
   utils.updateUrl( baseUrl, searchParams );
   utils.showLoading( searchContainer );
-  utils.fetchSearchResults( searchUrl, ( err, data ) => {
+  searchRequest = utils.fetchSearchResults( searchUrl, ( err, data ) => {
     utils.hideLoading( searchContainer );
-    if ( err ) {
+    if ( err !== null ) {
       // TODO: Add message banner above search results
-      return console.error( utils.handleError( 'no-results' ).msg );
+      return console.error( utils.handleError( err ).msg );
     }
     searchContainer.innerHTML = data;
     // Update the query params in the URL

--- a/cfgov/unprocessed/apps/regulations3k/js/search.js
+++ b/cfgov/unprocessed/apps/regulations3k/js/search.js
@@ -82,6 +82,8 @@ function handleSubmit( event ) {
       return console.error( utils.handleError( 'no-results' ).msg );
     }
     searchContainer.innerHTML = data;
+    // Update the query params in the URL
+    utils.updateUrl( baseUrl, searchParams );
     // Reattach event handlers after tags are reloaded
     attachHandlers();
     return data;

--- a/jest.config.js
+++ b/jest.config.js
@@ -21,5 +21,6 @@ module.exports = {
   coverageDirectory: '<rootDir>/test/unit_test_coverage',
   moduleNameMapper: {
     '\\.(svg)$': '<rootDir>/test/unit_tests/mocks/fileMock.js'
-  }
+  },
+  testURL: 'http://localhost'
 };

--- a/test/unit_tests/apps/regulations3k/js/search-spec.js
+++ b/test/unit_tests/apps/regulations3k/js/search-spec.js
@@ -4,10 +4,13 @@ const BASE_JS_PATH = '../../../../../cfgov/unprocessed/apps/regulations3k';
 const app = require( `${ BASE_JS_PATH }/js/search.js` );
 
 const HTML_SNIPPET = `
-  <input id="query" name="q" type="text" title="Search terms" class="a-text-input" value="money" placeholder="Search terms">
+  <form action="/search" data-js-hook="behavior_submit-search">
+    <input id="query" name="q" type="text" title="Search terms" class="a-text-input" value="money" placeholder="Search terms">
+    <button id="submit">Submit</button>
+  </form>
   <div>
     <div class="m-form-field m-form-field__checkbox reg-checkbox">
-      <input class="a-checkbox" type="checkbox" value="1002" id="regulation-1002" name="regs">
+      <input class="a-checkbox" type="checkbox" value="1002" id="regulation-1002" name="regs" checked>
       <label class="a-label" for="regulation-1002">
           1002 (Regulation B)
       </label>
@@ -44,6 +47,15 @@ describe( 'The Regs3K search page', () => {
 
   it( 'should not throw any errors on init', () => {
     expect( () => app ).not.toThrow();
+  } );
+
+  it( 'should handle search form submissions', () => {
+    global.location.assign = jest.fn();
+    const form = document.querySelector( 'form' );
+
+    simulateEvent( 'submit', form );
+
+    expect( global.location.assign ).toBeCalledWith( 'http://localhost/?q=money&regs=1002' );
   } );
 
   it( 'should clear a filter when its X icon is clicked', () => {

--- a/test/unit_tests/apps/regulations3k/js/search-utils-spec.js
+++ b/test/unit_tests/apps/regulations3k/js/search-utils-spec.js
@@ -54,6 +54,8 @@ describe( 'The Regs3K search utils', () => {
   it( 'should handle errors', () => {
     const searchError = utils.handleError( 'no-results' );
     expect( searchError.msg ).toEqual( 'Your query returned zero results.' );
+    const cancelError = utils.handleError( 0 );
+    expect( cancelError.msg ).toEqual( 'Search request was cancelled.' );
     const unknownError = utils.handleError();
     expect( unknownError.msg ).toEqual( 'Sorry, our search engine is temporarily down.' );
   } );

--- a/test/unit_tests/apps/regulations3k/js/search-utils-spec.js
+++ b/test/unit_tests/apps/regulations3k/js/search-utils-spec.js
@@ -28,8 +28,10 @@ describe( 'The Regs3K search utils', () => {
   } );
 
   it( 'should build a search results URL', () => {
-    const URL = utils.buildSearchResultsURL( 'foo', 'bar' );
-    expect( URL ).toEqual( 'foo?bar&partial' );
+    let url = utils.buildSearchResultsURL( 'foo', 'bar' );
+    expect( url ).toEqual( 'foo?bar' );
+    url = utils.buildSearchResultsURL( 'foo', 'bar', { partial: true } );
+    expect( url ).toEqual( 'foo?bar&partial' );
   } );
 
   it( 'should show an element loading', () => {

--- a/test/unit_tests/apps/regulations3k/js/search-utils-spec.js
+++ b/test/unit_tests/apps/regulations3k/js/search-utils-spec.js
@@ -96,4 +96,17 @@ describe( 'The Regs3K search utils', () => {
     mockXHR.onreadystatechange();
   } );
 
+  it( 'should replace the browser history', () => {
+    const rs = global.history.replaceState = jest.fn();
+    expect( rs.mock.calls.length ).toEqual( 0 );
+
+    utils.updateUrl( 'foo', 'bar' );
+    expect( rs.mock.calls.length ).toEqual( 1 );
+    expect( rs.mock.calls[0] ).toEqual( [ null, null, 'foo?bar' ] );
+
+    utils.updateUrl( '/regulations/search/', 'regs=1002&regs=1010&q=funding' );
+    expect( rs.mock.calls.length ).toEqual( 2 );
+    expect( rs.mock.calls[1] ).toEqual( [ null, null, '/regulations/search/?regs=1002&regs=1010&q=funding' ] );
+  } );
+
 } );


### PR DESCRIPTION
Uses `window.history.replaceState` to update the search results page's URL whenever a filter is changed.

Also fixes GHE issue 122 and uses `replaceState` to [cut the mustard](https://justmarkup.com/log/2015/02/cut-the-mustard-revisited/) (if a browser doesn't support `replaceState` it gets the no-JS experience).

## Testing

1. Select some regs filters.
1. Verify that the browser's URL correctly updates to reflect your chosen filters.
1. Change the search term and hit enter.
1. The page should reload with the same regs filters pre-selected.

## Screenshots

![filters](https://user-images.githubusercontent.com/1060248/42803987-9c6ec5e6-8975-11e8-92da-9ff09365bc2e.gif)
