### PR TITLE
Suppress database load output in refresh script

### DIFF
--- a/refresh-data.sh
+++ b/refresh-data.sh
@@ -31,7 +31,7 @@ download_data() {
 
 refresh_data() {
     echo 'Importing refresh db'
-    gunzip < "$refresh_dump_name" | cfgov/manage.py dbshell
+    gunzip < "$refresh_dump_name" | cfgov/manage.py dbshell > /dev/null
     echo 'Running any necessary migrations'
     ./cfgov/manage.py migrate --noinput
     echo 'Setting up initial data'


### PR DESCRIPTION
This change modifies the `refresh-data.sh` script so that the console output from the database load step is suppressed via redirection to `/dev/null`. The current process echoes many, many lines of output when loading a database dump which is not particularly useful.

This only redirects stdout, and so error messages should still get displayed (if any occur).

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [X] Passes all existing automated tests
- [X] Any _change_ in functionality is tested
- [X] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: