### PR TITLE
Update to use the new a-form-alert from CFv5.3.0

### DIFF
--- a/cfgov/jinja2/v1/owning-a-home/explore-rates/index.html
+++ b/cfgov/jinja2/v1/owning-a-home/explore-rates/index.html
@@ -98,20 +98,24 @@ home price, down payment, and more can affect mortgage interest rates.
                             {#
                               Credit alert for when low credit score is chosen.
                             #}
-                            <div id="credit-score-alert"
-                                 class="result-alert credit-alert u-hidden"
-                                 role="alert">
-                                {# NOTE: Text needs to appear on same line as
-                                   paragraph tag, otherwise there is a space
-                                   in front of the notification text. #}
-                                <p class="alert">Many lenders do not accept
-                                    borrowers with credit scores less than 620.
-                                    Even if your score is low, you may still have options.
-                                    <a href="https://www.consumerfinance.gov/mortgagehelp/">
-                                        Contact a housing counselor
-                                    </a>
-                                    to learn more.
-                                </p>
+
+                            <div class="result-alert
+                                        credit-alert
+                                        u-hidden"
+                             id="credit-score-alert"
+                             role="alert">
+                                <div class="a-form-alert a-form-alert__error">
+                                    {{ svg_icon('warning-round') }}
+                                    <span class="a-form-alert_text">
+                                        Many lenders do not accept
+                                        borrowers with credit scores less than 620.
+                                        Even if your score is low, you may still have options.
+                                        <a href="https://www.consumerfinance.gov/mortgagehelp/">
+                                            Contact a housing counselor
+                                        </a>
+                                        to learn more.
+                                    </span>
+                                </div>
                             </div>
                         </div>
                         <p class="form-sub">Credit score has a big impact on the rate you’ll receive. <a href="/askcfpb/319/how-does-my-credit-score-affect-my-ability-to-get-a-mortgage-loan.html" id="ask-cfpb-credit" target="_blank" rel="noopener noreferrer">Learn more</a></p>
@@ -228,14 +232,25 @@ home price, down payment, and more can affect mortgage interest rates.
                         {#
                           Alert when down payment is greater than house price.
                         #}
-                        <div id="dp-alert"
-                             class="downpayment-warning alert-alt half-width-gt-1230 u-hidden"
+                        <div class="downpayment-warning
+                                    half-width-gt-1230
+                                    u-hidden"
+                             id="dp-alert"
                              role="alert">
-                          Your down payment cannot be more than your house price.
+                            <div class="a-form-alert a-form-alert__warning">
+                                {{ svg_icon('warning-round') }}
+                                <span class="a-form-alert_text">
+                                    Your down payment cannot be more than your
+                                    house price.
+                                </span>
+                            </div>
                         </div>
                     </section>
                     <section class="form-sub warning u-hidden" id="county-warning">
-                        <p class="warning-text"></p>
+                        <div class="a-form-alert a-form-alert__warning">
+                            {{ svg_icon('warning-round') }}
+                            <span class="a-form-alert_text"></span>
+                        </div>
                     </section>
                     <section class="calc-loan-details wrapper">
                         <div class="upper rate-structure half-width-gt-1230">
@@ -279,10 +294,18 @@ home price, down payment, and more can affect mortgage interest rates.
                         </div>
                     </section>
                     <section class="form-sub warning u-hidden" id="arm-warning">
-                        <p class="warning-text">While some lenders may offer FHA, VA, or 15-year adjustable-rate mortgages, they are rare. We don’t have enough data to display results for these combinations. Choose a fixed rate if you’d like to try these options.</p>
+                        <div class="a-form-alert a-form-alert__warning">
+                            {{ svg_icon('warning-round') }}
+                            <span class="a-form-alert_text">
+                                While some lenders may offer FHA, VA, or 15-year adjustable-rate mortgages, they are rare. We don’t have enough data to display results for these combinations. Choose a fixed rate if you’d like to try these options.
+                            </span>
+                        </div>
                     </section>
                     <section class="form-sub warning u-hidden" id="hb-warning">
-                        <p class="warning-text"></p>
+                        <div class="a-form-alert a-form-alert__warning">
+                            {{ svg_icon('warning-round') }}
+                            <span class="a-form-alert_text"></span>
+                        </div>
                     </section>
                     <section class="form-sub calc-subsection">
                         <p><a href="../loan-options/" target="_blank" rel="noopener noreferrer">Learn about loan term, rate type, and loan type</a></p>
@@ -355,13 +378,19 @@ home price, down payment, and more can affect mortgage interest rates.
                         </div>
                         {# Alert Shown when there was an API failure. #}
                         <div id="chart-fail-alert"
-                             class="result-alert chart-alert u-hidden"
+                             class="result-alert
+                                    m-notification
+                                    m-notification__error"
                              role="alert">
-                              <p class="alert">
-                                <strong>We're sorry!</strong>
-                                We're having trouble connecting to our data.<br>
-                                Try again another time.
-                              </p>
+                            {{ svg_icon('error-round') }}
+                            <div class="m-notification_content">
+                                <div class="h4 m-notification_message">We're sorry!</div>
+                                <p class="m-notification_explanation">
+                                    <strong>We're sorry!</strong>
+                                    We're having trouble connecting to our data.<br>
+                                    Try again another time.
+                                </p>
+                            </div>
                         </div>
                     </section>
                     <p id="timestamp-p" class="data-enabled timestamp-message clear">These rates are current as of <strong id="timestamp">…</strong>.</p>

--- a/cfgov/unprocessed/apps/owning-a-home/css/explore-rates.less
+++ b/cfgov/unprocessed/apps/owning-a-home/css/explore-rates.less
@@ -97,12 +97,6 @@
             border-top: none;
         }
 
-        .form-sub {
-            color: @dark-gray;
-            font-size: 0.714285714em;
-            .u-webfont-regular();
-        }
-
         #arm-warning {
             padding-top: 0;
             border-top: 0;
@@ -460,10 +454,6 @@
         padding: 1em 2em 1em 3em;
         background: @white;
         .u-webfont-regular();
-
-        .point-right {
-            font-size: 1.5em;
-        }
     }
 
     .chart-menu {
@@ -526,30 +516,7 @@
     }
 
     .credit-alert {
-        padding: 0.714em 0.714em 0.714em 2.142em;
-        margin: 2.5em 0 1em;
-        background: @gray-5;
-        color: @dark-gray;
-        font-size: 0.75em;
-    }
-
-    .form-sub.warning {
-        padding-top: 0;
-        border-top: 0;
-        margin-top: -20px;
-    }
-
-    .warning-text {
-        padding-left: 1.2em;
-    }
-
-    .warning-text:before {
-        .cf-icon;
-
-        margin-right: 0.2em;
-        color:  @gold;
-        content: '\e103';
-        text-indent: -1.2em;
+        margin-top: 2em;
     }
 
     .about-data {

--- a/cfgov/unprocessed/apps/owning-a-home/css/helpers.less
+++ b/cfgov/unprocessed/apps/owning-a-home/css/helpers.less
@@ -14,34 +14,9 @@
     color:  @gray-40;
 }
 
-.alert {
-    &:before,
-    li&:before {
-        .cf-icon;
-
-        left: -21px;
-        color:  @red;
-        content: '\e103';
-        font-size: 17px;
-    }
-    li&.list_item__spaced:before {
-        top: 3px;
-    }
-    p&:before {
-        text-indent: -1.4em;
-    }
-    li& {
-        position: relative;
-        list-style: none;
-    }
-}
-
-.alert-alt:before {
-    .cf-icon;
-
-    color:  @gold;
-    content: '\e103';
-    text-indent: -1.4em;
+.a-form-alert {
+    color: @dark-gray;
+    font-size: 0.75em;
 }
 
 // alert containers have a background color but no border
@@ -117,13 +92,6 @@
     h5:first-child {
         margin-top: 0;
     }
-}
-
-.point-right:after {
-    .cf-icon;
-
-    margin-left: unit( 10px / @base-font-size-px, em );
-    content: '\e011';
 }
 
 .placeholder {

--- a/cfgov/unprocessed/apps/owning-a-home/js/explore-rates/rate-checker.js
+++ b/cfgov/unprocessed/apps/owning-a-home/js/explore-rates/rate-checker.js
@@ -367,9 +367,9 @@ function checkForJumbo() {
   // Hide any existing message, then show a message if appropriate.
   document.querySelector( '#county-warning' ).classList.add( 'u-hidden' );
   if ( warnings.hasOwnProperty( params.getVal( 'loan-type' ) ) ) {
-    $( '#county-warning' ).removeClass( 'u-hidden' ).find( 'p' ).text( warnings[params.getVal( 'loan-type' )].call() );
+    $( '#county-warning' ).removeClass( 'u-hidden' ).find( 'span' ).text( warnings[params.getVal( 'loan-type' )].call() );
   } else {
-    $( '#county-warning' ).removeClass( 'u-hidden' ).find( 'p' ).text( template.countyGenWarning() );
+    $( '#county-warning' ).removeClass( 'u-hidden' ).find( 'span' ).text( template.countyGenWarning() );
   }
 
   // If the state hasn't changed, we also cool. No need to load new counties.
@@ -438,7 +438,7 @@ function processCounty() {
     // Add links to loan messages.
     loan.msg = loan.msg.replace( 'jumbo (non-conforming)', '<a href="/owning-a-home/loan-options/conventional-loans/" target="_blank" rel="noopener noreferrer">jumbo (non-conforming)</a>' );
     loan.msg = loan.msg.replace( 'conforming jumbo', '<a href="/owning-a-home/loan-options/conventional-loans/" target="_blank" rel="noopener noreferrer">conforming jumbo</a>' );
-    $( '#hb-warning' ).removeClass( 'u-hidden' ).find( 'p' ).html( loan.msg );
+    $( '#hb-warning' ).removeClass( 'u-hidden' ).find( 'span' ).html( loan.msg );
 
   } else {
     params.setVal( 'isJumbo', false );

--- a/package-lock.json
+++ b/package-lock.json
@@ -2881,9 +2881,9 @@
       }
     },
     "cf-forms": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/cf-forms/-/cf-forms-5.1.0.tgz",
-      "integrity": "sha512-dM31tYOhPmBRGWk59ONeJnR/1mTdTDXb6DI0Tcu8xdWHPKszu2ChI2/gZLDEaSWEIoqEo4LuLSiPXbc44weBgw==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/cf-forms/-/cf-forms-5.2.0.tgz",
+      "integrity": "sha512-W7fhimGOzIOXoqt74SiQXpjk8Edb1eHyAwAk94GAlcAOXGuu+tCYRoICGUyp8RHxcdc9oPR2W/MsrcD49YoILQ==",
       "requires": {
         "cf-buttons": "5.0.0",
         "cf-core": "4.6.5",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "cf-buttons": "5.0.0",
     "cf-core": "4.6.5",
     "cf-expandables": "5.0.0",
-    "cf-forms": "5.1.0",
+    "cf-forms": "5.2.0",
     "cf-grid": "4.2.4",
     "cf-icons": "4.4.1",
     "cf-layout": "5.0.0",


### PR DESCRIPTION
The existing errors and warnings in OaH were essentially duplicates of
the new form-alert from cf-forms. Updating the markup, styles, and JS to
allow them to work with the existing infrastructure.

## Changes

- Updated the cf-forms version in package.json
- Replaced existing OaH warnings and alerts with the new `a-form-alert`

## Testing

1. Run `npm install && gulp build`
1. Run `./runserver.sh`
1. Open http://localhost:8000/owning-a-home/explore-rates/
1. Set the credit score as low as it will go, you should get an error like this
    <img width="377" alt="screen shot 2018-07-18 at 9 50 29 am" src="https://user-images.githubusercontent.com/1280430/42889426-00bef048-8a70-11e8-97c1-e2723085237b.png">
1. Reset the credit score to somewhere in the middle
1. Set your state to IL (this will work with any state/county combo, but I know this specific combo shows what we're looking for)
1. Set the house price to $0 and the down payment to $1, you should get a warning like this
    <img width="377" alt="screen shot 2018-07-18 at 9 52 58 am" src="https://user-images.githubusercontent.com/1280430/42889550-5938c7d0-8a70-11e8-96d4-0a9f77937a0a.png">
1. Set the house price to $450,000 and the down payment to 10%, then set the loan type to FHA, you should get a warning like this
    <img width="376" alt="screen shot 2018-07-18 at 9 54 26 am" src="https://user-images.githubusercontent.com/1280430/42889645-8ec89312-8a70-11e8-8592-62380df1b592.png">
1. Set the county to Whiteside, you should get a warning like this
    <img width="376" alt="screen shot 2018-07-18 at 9 55 04 am" src="https://user-images.githubusercontent.com/1280430/42889690-a7a0a3fc-8a70-11e8-8f6e-29ff9a1e7342.png">
1. Reset the house price to $1,000,000 and the county when it asks to Whiteside again, you should get a warning like this
    <img width="377" alt="screen shot 2018-07-18 at 9 56 18 am" src="https://user-images.githubusercontent.com/1280430/42889761-d06828be-8a70-11e8-9a41-5b906c2def62.png">
1. Set the loan type to FHA, you should get a warning like this
    <img width="376" alt="screen shot 2018-07-18 at 9 57 20 am" src="https://user-images.githubusercontent.com/1280430/42889837-f4ece5e4-8a70-11e8-8ace-50e4376fef09.png">
1. Reduce the house price to $250,000, set the loan type to FHA, then the rate to adjustable, you should get a warning like this
    <img width="376" alt="screen shot 2018-07-18 at 10 01 15 am" src="https://user-images.githubusercontent.com/1280430/42890055-8162dbaa-8a71-11e8-9026-d95e376c435b.png">

If all the warnings matched, the scripting that swaps them in and out is working correctly.

## Screenshots

See above

## Notes

- The styles and scripting could use an overhaul, but it's outside the scope of this PR.

## Todos

- There are still some font-icons in the OaH content, generated from the Wagtail Editor. We'll need to figure out how to deal with those and find a clean/simple/better way to include the svg icons in the WYSIWYG before we can make the final push to remove the font-icons from cf-icons.
- There's an existing layout inconsistency between the error and the warnings due to a larger layout issue that I'd like to address in another PR to keep this one in scope, so I'm leaving the warning icons hanging in the gutter for now.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [x] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [x] Chrome
- [x] Firefox
- [x] Safari
- [x] Internet Explorer 8, 9, 10, and 11
- [ ] Edge
- [x] iOS Safari
- [ ] Chrome for Android

### Accessibility

- [x] Keyboard friendly
- [x] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [x] Flexible from small to large screens
- [x] No linting errors or warnings
- [x] JavaScript tests are passing
