### PR TITLE
Mega menu: use relative urls for page links

### DIFF
--- a/cfgov/jinja2/v1/_includes/organisms/mega-menu.html
+++ b/cfgov/jinja2/v1/_includes/organisms/mega-menu.html
@@ -185,7 +185,7 @@
 {% macro _nav_item( nav_depth, nav_item ) %}
 {% set link = nav_item.link if nav_item.link else nav_item %}
 {% if link %}
-    {% set url = link.page_link.url if link.page_link else link.external_link | default('#') %}
+    {% set url = link.page_link.specific.get_relative_path() if link.page_link else link.external_link | default('#') %}
     {% set text = link.link_text %}
     {% set has_children = nav_item.nav_groups | count > 0 or nav_item.nav_items | count > 0 %}
 

--- a/cfgov/v1/models/base.py
+++ b/cfgov/v1/models/base.py
@@ -274,6 +274,9 @@ class CFGOVPage(Page):
     def get_appropriate_siblings(self, inclusive=True):
         return CFGOVPage.objects.live().sibling_of(self, inclusive)
 
+    def get_relative_path(self):
+        return self.relative_url(self.get_site())
+
     def get_context(self, request, *args, **kwargs):
         context = super(CFGOVPage, self).get_context(request, *args, **kwargs)
         for hook in hooks.get_hooks('cfgovpage_context_handlers'):

--- a/cfgov/v1/models/base.py
+++ b/cfgov/v1/models/base.py
@@ -275,6 +275,10 @@ class CFGOVPage(Page):
         return CFGOVPage.objects.live().sibling_of(self, inclusive)
 
     def get_relative_path(self):
+        """
+        Returns the relative path for the page even if the
+        current site does not match the page's site.
+        """
         return self.relative_url(self.get_site())
 
     def get_context(self, request, *args, **kwargs):


### PR DESCRIPTION
Ensures that mega menu links to Wagtail pages use relative paths so navigation works as expected on sharing site.

## Additions

- `get_relative_path` method on base page model


## Changes

- use `get_relative_path` instead of `url` method for Wagtail pages in the mega menu template

## Testing

1. Check out branch
2. Generate Wagtail version of mega menu if necessary: `python cfgov/manage.py runscript migrate_mega_menu`
3. Turn on `WAGTAIL_MENU` flag
4. Set up local sharing site (with an entry under `Sites` for sharing site)
5. Verify that mega menu links go to sharing site pages on sharing site and to default site pages on default site



## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
