### PR TITLE
Bump retirement app to version 0.7.0

### DIFF
--- a/cfgov/cfgov/urls.py
+++ b/cfgov/cfgov/urls.py
@@ -214,8 +214,11 @@ urlpatterns = [
     url(r'^credit-cards/agreements/',
         include('agreements.urls')),
 
-    url(r'^consumer-tools/retirement/',
-        include_if_app_enabled('retirement_api', 'retirement_api.urls')),
+    url(r'^consumer-tools/retirement/', include_if_app_enabled(
+        'retirement_api',
+        'retirement_api.urls',
+        namespace='retirement_api'
+    )),
 
     url(r'^data-research/consumer-complaints/',
         include_if_app_enabled('complaintdatabase', 'complaintdatabase.urls')),

--- a/requirements/optional-public.txt
+++ b/requirements/optional-public.txt
@@ -3,7 +3,7 @@ https://github.com/cfpb/complaint/releases/download/1.4.6/complaintdatabase-1.4.
 https://github.com/cfpb/owning-a-home-api/releases/download/0.10.4/owning_a_home_api-0.10.4-py2-none-any.whl
 https://github.com/cfpb/regulations-core/releases/download/1.2.6/regcore-1.2.6-py2-none-any.whl
 https://github.com/cfpb/regulations-site/releases/download/2.2.5/regulations-2.2.5-py2-none-any.whl
-https://github.com/cfpb/retirement/releases/download/0.6.2/retirement-0.6.2-py2-none-any.whl
+https://github.com/cfpb/retirement/releases/download/0.7.0/retirement-0.7.0-py2-none-any.whl
 git+https://github.com/cfpb/ccdb5-api.git@v1.0.6#egg=ccdb5-api
 git+https://github.com/cfpb/ccdb5-ui.git@v1.0.11#egg=ccdb5_ui
 https://github.com/cfpb/django-college-costs-comparison/releases/download/1.7/comparisontool-1.7-py2-none-any.whl


### PR DESCRIPTION
This PR bumps the version of the optional retirement app (https://github.com/cfpb/retirement) from 0.6.2 to version 0.7.0. This new version adds support for Django 1.11, among other things.

This PR should be held until [retirement#225](https://github.com/cfpb/retirement/pull/225) has been merged, and a new 0.7.0 release has been made.

Because this new version isolates the retirement_api templates under a new "retirement_api" Django namespace, this upgrade requires a small change to urls.py to specify that namespace.

## Testing

To test, verify that these URLs work when running locally:

- http://localhost:8000/consumer-tools/retirement/before-you-claim/

  Go through the entire flow, verify that the API calls work. Also
verify that the "Where do these numbers come from?" link works properly
to go to the About page.

- http://localhost:8000/consumer-tools/retirement/before-you-claim/es/

  Same as above, in Spanish.

(You'll need to either use a production dump or load the fixture from
the retirement repo for this to work.)

- http://localhost:8000/consumer-tools/retirement/before-you-claim/about/

- http://localhost:8000/consumer-tools/retirement/before-you-claim/about/es/

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [X] Passes all existing automated tests
- [X] Any _change_ in functionality is tested
- [X] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [X] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: