### PR TITLE
Add new environment-based feature flag condition

### DIFF
--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -572,9 +572,7 @@ FLAGS = {
     # Beta banner, seen on beta.consumerfinance.gov
     # When enabled, a banner appears across the top of the site proclaiming
     # "This beta site is a work in progress."
-    'BETA_NOTICE': {
-        'boolean': DEPLOY_ENVIRONMENT == 'beta',
-    },
+    'BETA_NOTICE': {'environment is': 'beta'},
 
     # When enabled, include a recruitment code comment in the base template.
     'CFPB_RECRUITING': {},
@@ -625,36 +623,24 @@ FLAGS = {
     'FINANCIAL_COACHING': {},
 
     # Teacher's Digital Platform Customer Review Tool
-    'TDP_CRTOOL': {
-        'boolean': DEPLOY_ENVIRONMENT == 'beta',
-    },
+    'TDP_CRTOOL': {'environment is': 'beta'},
 
     # Teacher's Digital Platform Customer Review Tool Prototypes Pages
-    'TDP_CRTOOL_PROTOTYPES': {
-        'boolean': DEPLOY_ENVIRONMENT == 'beta',
-    },
+    'TDP_CRTOOL_PROTOTYPES': {'environment is': 'beta'},
 
     # Teacher's Digital Platform Search Interface Tool
-    'TDP_SEARCH_INTERFACE': {
-        'boolean': DEPLOY_ENVIRONMENT == 'beta',
-    },
+    'TDP_SEARCH_INTERFACE': {'environment is': 'beta'},
 
     # Turbolinks is a JS library that speeds up page loads
     # https://github.com/turbolinks/turbolinks
     'TURBOLINKS': {},
 
     # Ping google on page publication in production only
-    'PING_GOOGLE_ON_PUBLISH': {
-        'boolean': DEPLOY_ENVIRONMENT == 'production'
-    },
+    'PING_GOOGLE_ON_PUBLISH': {'environment is': 'production'},
 
-    'REGULATIONS3K': {
-        'boolean': DEPLOY_ENVIRONMENT == 'build'
-    },
+    'REGULATIONS3K': {'environment is': 'build'},
 
-    'LEGACY_HUD_API': {
-        'boolean': DEPLOY_ENVIRONMENT == 'production',
-    },
+    'LEGACY_HUD_API': {'environment is': 'production'},
 
     # To be enabled when switching the site to use the BCFP logo
     'BCFP_LOGO': {},

--- a/cfgov/core/__init__.py
+++ b/cfgov/core/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = 'core.apps.CoreAppConfig'

--- a/cfgov/core/apps.py
+++ b/cfgov/core/apps.py
@@ -1,0 +1,10 @@
+from django.apps import AppConfig
+
+
+class CoreAppConfig(AppConfig):
+    name = 'core'
+    verbose_name = 'Core'
+
+    def ready(self):
+        # Import this module so that custom flag conditions are registered.
+        import core.feature_flags  # noqa

--- a/cfgov/core/feature_flags.py
+++ b/cfgov/core/feature_flags.py
@@ -1,0 +1,17 @@
+from django.conf import settings
+
+from flags import conditions
+
+
+def _get_deploy_environment():
+    return getattr(settings, 'DEPLOY_ENVIRONMENT', None)
+
+
+@conditions.register('environment is')
+def environment_is(environment, **kwargs):
+    return environment == _get_deploy_environment()
+
+
+@conditions.register('environment is not')
+def environment_is_not(environment, **kwargs):
+    return environment != _get_deploy_environment()

--- a/cfgov/core/jinja2tags.py
+++ b/cfgov/core/jinja2tags.py
@@ -1,3 +1,4 @@
+from flags.template_functions import flag_disabled, flag_enabled
 from jinja2.ext import Extension
 
 from core.templatetags.svg_icon import svg_icon
@@ -7,6 +8,9 @@ class CoreExtension(Extension):
     def __init__(self, environment):
         super(CoreExtension, self).__init__(environment)
         self.environment.globals.update({
+            'flag_enabled': flag_enabled,
+            'flag_disabled': flag_disabled,
+
             'svg_icon': svg_icon,
         })
 

--- a/cfgov/core/tests/test_feature_flags.py
+++ b/cfgov/core/tests/test_feature_flags.py
@@ -1,0 +1,22 @@
+from django.conf import settings
+from django.test import SimpleTestCase, override_settings
+
+from core.feature_flags import environment_is, environment_is_not
+
+
+class TestFeatureFlags(SimpleTestCase):
+    @override_settings()
+    def test_setting_not_defined(self):
+        del settings.DEPLOY_ENVIRONMENT
+        self.assertFalse(environment_is('foo'))
+        self.assertTrue(environment_is_not('foo'))
+
+    @override_settings(DEPLOY_ENVIRONMENT='foo')
+    def test_setting_matches(self):
+        self.assertTrue(environment_is('foo'))
+        self.assertFalse(environment_is_not('foo'))
+
+    @override_settings(DEPLOY_ENVIRONMENT='bar')
+    def test_setting_does_not_match(self):
+        self.assertFalse(environment_is('foo'))
+        self.assertTrue(environment_is_not('foo'))

--- a/cfgov/core/tests/test_jinja2tags.py
+++ b/cfgov/core/tests/test_jinja2tags.py
@@ -6,20 +6,23 @@ from django.test import TestCase, override_settings
 from core.tests.templatetags.test_svg_icon import VALID_SVG
 
 
+_TEST_TEMPLATES = [
+    {
+        'NAME': 'test',
+        'BACKEND': 'django.template.backends.jinja2.Jinja2',
+        'OPTIONS': {
+            'extensions': [
+                'core.jinja2tags.filters',
+            ],
+        },
+    },
+]
+
+
 @override_settings(
+    TEMPLATES=_TEST_TEMPLATES,
     STATICFILES_DIRS=[
         os.path.join(os.path.dirname(__file__), 'staticfiles'),
-    ],
-    TEMPLATES=[
-        {
-            'NAME': 'test',
-            'BACKEND': 'django.template.backends.jinja2.Jinja2',
-            'OPTIONS': {
-                'extensions': [
-                    'core.jinja2tags.filters',
-                ],
-            },
-        },
     ]
 )
 class SvgIconTests(TestCase):
@@ -34,3 +37,24 @@ class SvgIconTests(TestCase):
         template = self.jinja_engine.from_string('{{ svg_icon("invalid") }}')
         with self.assertRaises(ValueError):
             template.render()
+
+
+@override_settings(
+    TEMPLATES=_TEST_TEMPLATES,
+    FLAGS={'MY_FLAG': {'boolean': 'True'}}
+)
+class FeatureFlagTests(TestCase):
+    def setUp(self):
+        self.jinja_engine = engines['test']
+
+    def test_flag_enabled_tag(self):
+        template = self.jinja_engine.from_string(
+            '{{ flag_enabled("MY_FLAG", request) }}'
+        )
+        self.assertEqual(template.render({'request': None}), 'True')
+
+    def test_flag_disabled_tag(self):
+        template = self.jinja_engine.from_string(
+            '{{ flag_disabled("MY_FLAG", request) }}'
+        )
+        self.assertEqual(template.render({'request': None}), 'False')

--- a/cfgov/sheerlike/__init__.py
+++ b/cfgov/sheerlike/__init__.py
@@ -8,7 +8,6 @@ from django.contrib.staticfiles.storage import staticfiles_storage
 from django.core.urlresolvers import reverse
 
 import jinja2.runtime
-from flags.template_functions import flag_disabled, flag_enabled
 from jinja2 import Environment
 from jinja2.runtime import Context
 
@@ -77,8 +76,6 @@ def environment(**options):
         'more_like_this': more_like_this,
         'get_document': get_document,
         'when': when,
-        'flag_enabled': flag_enabled,
-        'flag_disabled': flag_disabled,
     })
     env.filters.update({
         'date': get_date_string,


### PR DESCRIPTION
This change deprecates the use of Wagtail Site-based feature flags, instead using a new flag condition based on the value of `settings.DEPLOY_ENVIRONMENT`.

Two new feature flag conditions are defined: "environment is" and "environment is not". These can be set to match or not match against the value of `DEPLOY_ENVIRONMENT`, as the user prefers.

We currently set the value of this setting by environment variable, and it differs depending on the cf.gov environment. For example, this value is "production" in production, "beta" for beta.cf.gov, etc.

This change unblocks the cleanup of our legacy second Wagtail Site for content.cf.gov, which will simplify some workarounds that we have in the code.

As a related change, this also moves the inclusion of `flag_enabled` and `flag_disabled` in Jinja2 templates from the `sheerlike` app to the `core` app. This is part of more general cleanup of the `sheerlike` app.

## Testing

Using a production dump, visit http://localhost:8000/admin/flags/ and note that all existing flags are properly defined using this new condition.

Experiment creating a new flag at http://localhost:8000/admin/flags/create/ using the new conditions.

## Screenshots

Defining a new flag:

![image](https://user-images.githubusercontent.com/654645/42953305-247b627c-8b48-11e8-99ee-d7c470a6a9f3.png)

![image](https://user-images.githubusercontent.com/654645/42953316-2c097db2-8b48-11e8-9f4a-dfe8bf340ef5.png)

## Todos

@willbarton do you have any thoughts on the best approach for cleaning up "unconfigured flags" that still live in the database?

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [X] Passes all existing automated tests
- [X] Any _change_ in functionality is tested
- [X] New functions are documented (with a description, list of inputs, and expected output)
- [X] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [X] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: