### PR TITLE
regs3k: Lint paragraphs for italics and dashes.

### DIFF
--- a/cfgov/regulations3k/fixtures/parts.json
+++ b/cfgov/regulations3k/fixtures/parts.json
@@ -1,0 +1,123 @@
+[
+{
+    "fields": {
+        "cfr_title_number": "12",
+        "chapter": "X",
+        "part_number": "1002",
+        "letter_code": "B",
+        "title": "Equal Credit Opportunity Act"
+    },
+    "model": "regulations3k.part",
+    "pk": 1
+},
+{
+    "fields": {
+        "cfr_title_number": "12",
+        "chapter": "X",
+        "part_number": "1003",
+        "letter_code": "C",
+        "title": "Home Mortgage Disclosure"
+    },
+    "model": "regulations3k.part",
+    "pk": 2
+},
+{
+    "fields": {
+        "cfr_title_number": "12",
+        "chapter": "X",
+        "part_number": "1004",
+        "letter_code": "D",
+        "title": "Alternative Mortgage Transaction Parity"
+    },
+    "model": "regulations3k.part",
+    "pk": 3
+},
+{
+    "fields": {
+        "cfr_title_number": "12",
+        "chapter": "X",
+        "part_number": "1005",
+        "letter_code": "E",
+        "title": "Electronic Fund Transfers"
+    },
+    "model": "regulations3k.part",
+    "pk": 4
+},
+{
+    "fields": {
+        "cfr_title_number": "12",
+        "chapter": "X",
+        "part_number": "1010",
+        "letter_code": "J",
+        "title": "Land Registration"
+    },
+    "model": "regulations3k.part",
+    "pk": 5
+},
+{
+    "fields": {
+        "cfr_title_number": "12",
+        "chapter": "X",
+        "part_number": "1011",
+        "letter_code": "K",
+        "title": "Purchasers' Revocation Rights, Sales Practices And Standards"
+    },
+    "model": "regulations3k.part",
+    "pk": 6
+},
+{
+    "fields": {
+        "cfr_title_number": "12",
+        "chapter": "X",
+        "part_number": "1012",
+        "letter_code": "L",
+        "title": "Special Rules Of Practice"
+    },
+    "model": "regulations3k.part",
+    "pk": 7
+},
+{
+    "fields": {
+        "cfr_title_number": "12",
+        "chapter": "X",
+        "part_number": "1013",
+        "letter_code": "M",
+        "title": "Consumer Leasing"
+    },
+    "model": "regulations3k.part",
+    "pk": 8
+},
+{
+    "fields": {
+        "cfr_title_number": "12",
+        "chapter": "X",
+        "part_number": "1024",
+        "letter_code": "X",
+        "title": "Real Estate Settlement Procedures Act"
+    },
+    "model": "regulations3k.part",
+    "pk": 9
+},
+{
+    "fields": {
+        "cfr_title_number": "12",
+        "chapter": "X",
+        "part_number": "1026",
+        "letter_code": "Z",
+        "title": "Truth In Lending"
+    },
+    "model": "regulations3k.part",
+    "pk": 10
+},
+{
+    "fields": {
+        "cfr_title_number": "12",
+        "chapter": "X",
+        "part_number": "1030",
+        "letter_code": "DD",
+        "title": "Truth In Savings"
+    },
+    "model": "regulations3k.part",
+    "pk": 11
+}
+]

--- a/cfgov/regulations3k/parser/paragraphs.py
+++ b/cfgov/regulations3k/parser/paragraphs.py
@@ -6,6 +6,8 @@ by the patterns.IdLevelState class.
 """
 from __future__ import unicode_literals
 
+import re
+
 
 def bold_first_italics(graph_text):
     """For a newly broken-up graph, convert the first italics text to bold."""
@@ -34,6 +36,32 @@ def graph_top(graph_text):
         'paragraph')[0].partition(
         '12 CFR')[0].partition(
         '\xa7')[0][:200]
+
+
+def lint_paragraph(graph_text):
+    """Clean formatting anomalies.
+
+    - Missing em dashes
+    - restoring italics
+    """
+    fix1 = restore_emdash(graph_text)
+    fix2 = restore_italics(fix1)
+    return fix2
+
+
+def restore_italics(graph_text):
+    fix1 = re.sub(
+        r'\*\*(see)\*\*', '*\g<1>*', graph_text, flags=re.IGNORECASE)
+    fix2 = re.sub(
+        r'\*\*(et[.]? seq[. ]?)\*\*?', '*\g<1>*', fix1, flags=re.IGNORECASE)
+    return fix2
+
+
+def restore_emdash(graph_text):
+    stripped = graph_text.rstrip()
+    if stripped.endswith('-'):
+        return stripped + '--\n'
+    return graph_text
 
 
 def pre_process_tags(paragraph_element):

--- a/cfgov/regulations3k/parser/paragraphs.py
+++ b/cfgov/regulations3k/parser/paragraphs.py
@@ -53,7 +53,7 @@ def restore_italics(graph_text):
     fix1 = re.sub(
         r'\*\*(see)\*\*', '*\g<1>*', graph_text, flags=re.IGNORECASE)
     fix2 = re.sub(
-        r'\*\*(et[.]? seq[. ]?)\*\*?', '*\g<1>*', fix1, flags=re.IGNORECASE)
+        r'\*\*(et\.? seq\.? ?)\*\*?', '*\g<1>*', fix1, flags=re.IGNORECASE)
     return fix2
 
 

--- a/cfgov/regulations3k/regdown.py
+++ b/cfgov/regulations3k/regdown.py
@@ -58,6 +58,7 @@ from markdown import markdown, util
 from markdown.blockprocessors import BlockProcessor, ParagraphProcessor
 from markdown.extensions import Extension
 from markdown.inlinepatterns import DoubleTagPattern, Pattern, SimpleTagPattern
+from mdx_emdash import EmDashExtension
 
 
 # If we're on Python 3.6+ we have SHA3 built-in, otherwise use the back-ported
@@ -282,7 +283,8 @@ def regdown(text, **kwargs):
         text,
         extensions=[
             'markdown.extensions.tables',
-            RegulationsExtension(**kwargs)
+            RegulationsExtension(**kwargs),
+            EmDashExtension(),
         ],
         **kwargs
     )

--- a/cfgov/regulations3k/scripts/ecfr_importer.py
+++ b/cfgov/regulations3k/scripts/ecfr_importer.py
@@ -331,6 +331,7 @@ def parse_appendices(appendices, part):
     for i, _appendix in enumerate(appendices):
         n_value = _appendix['N']
         head = _appendix.find('HEAD').text.strip()
+        _appendix.find('HEAD').replaceWith('')
         default_label = int_to_alpha(i + 1).upper()
         label = get_appendix_label(n_value, head, default_label)
         if PAYLOAD.interp_refs and label in PAYLOAD.interp_refs:
@@ -415,7 +416,7 @@ def parse_interp_graph_reference(element, part_num, section_tag):
 def get_interp_section_tag(headline):
     """"Derive an interp section tag from the HD content."""
 
-    interp_numeric_pattern = ur'(?:Section|\xa7) \d{4}\.(\d{1,3}) '
+    interp_numeric_pattern = r'(?:Section|\xa7) \d{4}\.(\d{1,3}) '
     if headline.upper() == 'INTRODUCTION':
         return '0'
     if re.match(interp_numeric_pattern, headline):

--- a/requirements/libraries.txt
+++ b/requirements/libraries.txt
@@ -24,6 +24,7 @@ jsonfield==2.0.2
 jsonschema==2.0.0
 lxml==4.1.0
 Markdown==2.6.11
+markdown-emdash==0.1.0
 ntplib==0.3.3
 openpyxl==2.5.0
 pyelasticsearch==0.6.1


### PR DESCRIPTION
QA testers identified some recurring format errors:
* Improper boldface on references such as **see** and **et seq.**
* Hyphens where em dashes should be.
* Interp graph references that didn't match the content (GHE issue 209)
* Some interp sections were not broken out in Reg X because of non-standard section naming.

This PR adjusts the importer and adds a paragraph linting routine to fix such cases.

## New dependency
Neither unicode nor html entities work as-is for passing an em dash character
from regdown to our templates, and either would sprinkle code through our regdown.  
To give editors a friendly way to handle em dashes, this PR adds a requirement for 
a Markdown extension,  `markdown-emdash`. It translates a triple hyphen 
--- a convention used in other flavors of Markdown and LaTex --- into an em dash.

This appears to play nice with Markdown tables (which also use multiple hyphens, to denote colums) and with our pseudoform underline extension.

It's still viable to enter a utf-8 '—' em dash character, but to use it an editor needs to know how to generate it or where to find a source to copy. The triple hyphen is more obvious and avoids using a non-ascii character.

## Testing

You can check the linting by importing a fresh copy of Reg E:

If you have a copy of ECFR xml in develop-apps, this would import it:

```
./cfgov/manage.py runscript ecfr_importer --script-args 1005 develop-apps/ECFR-title12.xml
```

Then uncheck 'draft' status on the newly imported effective-version. You should be able to
check the following spots for linted formatting:

### bold/italics

<http://localhost:8000/policy-compliance/rulemaking/regulations/1005/2/#b-2>

This spot shows both a bold 'see' and a bold 'et seq.'

Before linting:

<img width="712" alt="before_linting_1005_2" src="https://user-images.githubusercontent.com/515885/42987067-f61be8e2-8bc5-11e8-9216-f9bbe9334a22.png">


After linting:

<img width="714" alt="after_linting_1005-2" src="https://user-images.githubusercontent.com/515885/42987077-fcc3bf80-8bc5-11e8-9fda-60263d143508.png">

### em dashes

<http://localhost:8000/policy-compliance/rulemaking/regulations/1005/12/#c>

This graph should show a hyphen that is fixed to be an em dash.

Before linting:

<img width="698" alt="before_dashing" src="https://user-images.githubusercontent.com/515885/42987118-211c2fe8-8bc6-11e8-872f-2bab2375f42e.png">

After linting:

<img width="698" alt="after_dashing" src="https://user-images.githubusercontent.com/515885/42987121-25b8aee6-8bc6-11e8-8db5-2abc800653ed.png">

### Interp graph labels
The interp reference labels in <http://localhost:8000/policy-compliance/rulemaking/regulations/1026/1/> should now match the graphs they refer to.

### Reg X interp sections

If you import Reg X 1024 anew, you should find some more Interp sections (such as Interp-30).  
They were previously delivered inside interp-17 and thus ignored.
