### PR TITLE
Remove turbolinks from Regs3K pages

### DIFF
--- a/cfgov/unprocessed/apps/regulations3k/js/index.js
+++ b/cfgov/unprocessed/apps/regulations3k/js/index.js
@@ -1,10 +1,7 @@
 import Expandable from '../../../js/organisms/Expandable.js';
 import { instantiateAll } from '../../../js/modules/util/atomic-helpers';
-import turbolinks from 'turbolinks';
 
 instantiateAll( '.o-expandable', Expandable );
-
-turbolinks.start();
 
 if ( 'serviceWorker' in navigator ) {
   /* Delay registration until after the page has loaded, to ensure that our


### PR DESCRIPTION
Turbolinks hijacks the browser's back button and user testing has shown that it unreliably loads cfgov-refresh's JS resulting in broken pages. I'm leaving the [feature flag](https://github.com/cfpb/cfgov-refresh/blob/62d08cca1296ac1897ec4df78d7a73f24fc21c54/cfgov/cfgov/settings/base.py#L634-L636) that will enable it sitewide for testing purposes but removing it from Regs3K's JS file. See [GHE#116](https://GHE/eregs/regulations-3000/issues/116).
