### PR TITLE
regs3k: Clean up haystack query sequence.

### DIFF
--- a/cfgov/regulations3k/tests/test_models.py
+++ b/cfgov/regulations3k/tests/test_models.py
@@ -313,7 +313,7 @@ class RegModelTests(DjangoTestCase):
             self.reg_search_page.url + self.reg_search_page.reverse_subpage(
                 'regulation_results_page'),
             {'q': 'disclosure', 'regs': '1002', 'order': 'regulation'})
-        self.assertEqual(mock_sqs.call_count, 1)
+        self.assertEqual(mock_sqs.call_count, 3)
         self.assertEqual(response.status_code, 200)
         response2 = self.client.get(
             self.reg_search_page.url + self.reg_search_page.reverse_subpage(
@@ -321,7 +321,7 @@ class RegModelTests(DjangoTestCase):
             QueryDict(query_string=(
                 'q=disclosure&regs=1002&regs=1003&order=regulation')))
         self.assertEqual(response2.status_code, 200)
-        self.assertEqual(mock_sqs.call_count, 2)
+        self.assertEqual(mock_sqs.call_count, 6)
 
     @mock.patch('regulations3k.models.pages.SearchQuerySet.models')
     def test_routable_search_page_reg_only(self, mock_sqs):


### PR DESCRIPTION
The Haystack queries had acquired some cruft, including defining the base query twice.

Unfortunately we can't get by with a single query, because we need to capture
counts for all regulations before narrowing down to the chosen regulation(s).
The best we can do with Haystack is avoid evaluating the big base query, so that we get a 
speedy page if the reg choices are narrowed down, which they will be by default.

I tried 'optimizing' by capturing the overall counts with a Counter object run against the 
base query, but that actually slows things down by evaluating the base query before its time.
It's actually faster to call `count()` on 11 individual Haystack queries, one for each reg.
