### PR TITLE
Regs3k: Add support for copying Effective Versions

### DIFF
--- a/cfgov/.coveragerc
+++ b/cfgov/.coveragerc
@@ -1,7 +1,7 @@
 [run]
 omit = 
     *wsgi.py
-    *admin*
+    */admin/*
     */migrations/*
     *templatetags/*
     */site-packages*

--- a/cfgov/regulations3k/copyable_modeladmin.py
+++ b/cfgov/regulations3k/copyable_modeladmin.py
@@ -16,7 +16,7 @@ from treemodeladmin.views import TreeViewParentMixin
 class CopyButtonHelper(TreeButtonHelper):
 
     def copy_button(self, pk):
-        cn = self.edit_button_classnames
+        cn = 'button button-small button-secondary'
         return {
             'url': self.url_helper.get_action_url('copy', quote(pk)),
             'label': 'Copy',

--- a/cfgov/regulations3k/copyable_modeladmin.py
+++ b/cfgov/regulations3k/copyable_modeladmin.py
@@ -1,0 +1,91 @@
+from __future__ import unicode_literals
+
+from django.conf.urls import url
+from django.contrib.admin.utils import quote
+from django.contrib.auth.decorators import login_required
+from django.shortcuts import redirect
+from django.utils.decorators import method_decorator
+
+from wagtail.contrib.modeladmin.views import InstanceSpecificView
+
+from treemodeladmin.helpers import TreeButtonHelper
+from treemodeladmin.options import TreeModelAdmin
+from treemodeladmin.views import TreeViewParentMixin
+
+
+class CopyButtonHelper(TreeButtonHelper):
+
+    def copy_button(self, pk):
+        cn = self.edit_button_classnames
+        return {
+            'url': self.url_helper.get_action_url('copy', quote(pk)),
+            'label': 'Copy',
+            'classname': cn,
+            'title': 'Copy this {}'.format(self.verbose_name),
+        }
+
+    def get_buttons_for_obj(self, obj, exclude=None, classnames_add=None,
+                            classnames_exclude=None):
+        if exclude is None:
+            exclude = []
+
+        usr = self.request.user
+        ph = self.permission_helper
+        pk = getattr(obj, self.opts.pk.attname)
+
+        btns = super(CopyButtonHelper, self).get_buttons_for_obj(
+            obj,
+            exclude=exclude,
+            classnames_add=classnames_add,
+            classnames_exclude=classnames_exclude
+        )
+
+        # Use the edit permission to double for copying
+        if('copy' not in exclude and ph.user_can_edit_obj(usr, obj)):
+            btns.insert(
+                -1,
+                self.copy_button(pk)
+            )
+
+        return btns
+
+
+class CopyView(TreeViewParentMixin, InstanceSpecificView):
+
+    @method_decorator(login_required)
+    def dispatch(self, request, *arg, **kwargs):
+        new_instance = self.model_admin.copy(self.instance)
+        return redirect(
+            self.url_helper.get_action_url('edit', quote(new_instance.pk))
+        )
+
+
+class CopyableModelAdmin(TreeModelAdmin):
+    button_helper_class = CopyButtonHelper
+    copy_view_class = CopyView
+
+    def copy(self, instance):
+        raise NotImplementedError(
+            "The copy() method must be implemented for each model admin"
+        )  # pragma: no cover
+
+    def copy_view(self, request, instance_pk):
+        return self.copy_view_class.as_view(
+            model_admin=self, instance_pk=instance_pk
+        )(request)
+
+    def get_admin_urls_for_registration(self, parent=None):
+        urls = super(
+            CopyableModelAdmin, self
+        ).get_admin_urls_for_registration()
+
+        # Add the copy URL
+        urls = urls + (
+            url(
+                self.url_helper.get_action_url_pattern('copy'),
+                self.copy_view,
+                name=self.url_helper.get_action_url_name('copy')
+            ),
+        )
+
+        return urls

--- a/cfgov/regulations3k/tests/test_copyable_modeladmin.py
+++ b/cfgov/regulations3k/tests/test_copyable_modeladmin.py
@@ -1,0 +1,84 @@
+from __future__ import unicode_literals
+
+from datetime import date
+
+from django.test import TestCase
+
+from wagtail.tests.utils import WagtailTestUtils
+
+from model_mommy import mommy
+
+from regulations3k.models.django import (
+    EffectiveVersion, Part, Section, Subpart
+)
+
+
+class TestCopyableModelAdmin(TestCase, WagtailTestUtils):
+
+    def setUp(self):
+        self.part_1002 = mommy.make(
+            Part,
+            part_number='1002',
+            title='Equal Credit Opportunity Act',
+            letter_code='B',
+            chapter='X'
+        )
+        self.effective_version = mommy.make(
+            EffectiveVersion,
+            effective_date=date(2014, 1, 18),
+            part=self.part_1002
+        )
+        self.subpart = mommy.make(
+            Subpart,
+            label='Subpart General',
+            title='General',
+            subpart_type=Subpart.BODY,
+            version=self.effective_version
+        )
+        self.section_num4 = mommy.make(
+            Section,
+            label='4',
+            title='\xa7\xa01002.4 General rules.',
+            contents='{a}\n(a) Regdown paragraph a.\n',
+            subpart=self.subpart,
+        )
+
+        self.login()
+
+    def test_effectiveversion_copyable(self):
+        response = self.client.get('/admin/regulations3k/effectiveversion/')
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'Copy this effective version')
+
+    def test_copy_effectiveversion(self):
+        self.assertEqual(EffectiveVersion.objects.count(), 1)
+        self.assertEqual(Subpart.objects.count(), 1)
+        self.assertEqual(Section.objects.count(), 1)
+
+        num_versions = EffectiveVersion.objects.count()
+
+        existing_url = (
+            '/admin/regulations3k/effectiveversion/copy/' +
+            str(self.effective_version.pk) +
+            '/'
+        )
+        response = self.client.get(existing_url)
+        self.assertEqual(response.status_code, 302)
+
+        self.assertEqual(EffectiveVersion.objects.count(), num_versions + 1)
+        new_effective_version = EffectiveVersion.objects.all().order_by(
+            '-id'
+        ).first()
+
+        self.assertEqual(new_effective_version.subparts.count(), 1)
+        new_subpart = new_effective_version.subparts.first()
+        self.assertEqual(new_subpart.version, new_effective_version)
+        self.assertNotEqual(self.subpart, new_subpart)
+
+        self.assertEqual(new_subpart.sections.count(), 1)
+        new_section = new_subpart.sections.first()
+        self.assertEqual(new_section.subpart, new_subpart)
+        self.assertNotEqual(self.section_num4, new_section)
+
+        self.assertEqual(self.effective_version.subparts.count(), 1)
+        self.assertEqual(self.subpart.sections.count(), 1)

--- a/cfgov/regulations3k/wagtail_hooks.py
+++ b/cfgov/regulations3k/wagtail_hooks.py
@@ -49,26 +49,26 @@ class EffectiveVersionModelAdmin(CopyableModelAdmin):
     parent_field = 'part'
 
     def copy(self, instance):
-        # Create a new instance
-        new_version = EffectiveVersion(
-            authority=instance.authority,
-            source=instance.source,
-            part=instance.part,
-            effective_date=date.today(),
-            acquired=date.today(),
-            draft=True,
-        )
+        subparts = instance.subparts.all()
+
+        # Copy the instance
+        new_version = instance
+        new_version.pk = None
+        new_version.created = date.today()
+        new_version.draft = True
         new_version.save()
 
-        # Copy subparts and sections
-        for subpart in instance.subparts.all():
+        for subpart in subparts:
             sections = subpart.sections.all()
+
+            # Copy the subpart
             new_subpart = subpart
             new_subpart.pk = None
             new_subpart.version = new_version
             new_subpart.save()
 
             for section in sections:
+                # Copy the section
                 new_section = section
                 new_section.pk = None
                 new_section.subpart = new_subpart

--- a/cfgov/regulations3k/wagtail_hooks.py
+++ b/cfgov/regulations3k/wagtail_hooks.py
@@ -1,9 +1,12 @@
 from __future__ import unicode_literals
 
+from datetime import date
+
 from wagtail.contrib.modeladmin.options import modeladmin_register
 
 from treemodeladmin.options import TreeModelAdmin
 
+from regulations3k.copyable_modeladmin import CopyableModelAdmin
 from regulations3k.models import EffectiveVersion, Part, Section, Subpart
 
 
@@ -33,7 +36,7 @@ class SubpartModelAdmin(TreeModelAdmin):
     ordering = ['subpart_type', 'title']
 
 
-class EffectiveVersionModelAdmin(TreeModelAdmin):
+class EffectiveVersionModelAdmin(CopyableModelAdmin):
     model = EffectiveVersion
     menu_label = 'Regulation effective versions'
     menu_icon = 'list-ul'
@@ -44,6 +47,34 @@ class EffectiveVersionModelAdmin(TreeModelAdmin):
     child_field = 'subparts'
     child_model_admin = SubpartModelAdmin
     parent_field = 'part'
+
+    def copy(self, instance):
+        # Create a new instance
+        new_version = EffectiveVersion(
+            authority=instance.authority,
+            source=instance.source,
+            part=instance.part,
+            effective_date=date.today(),
+            acquired=date.today(),
+            draft=True,
+        )
+        new_version.save()
+
+        # Copy subparts and sections
+        for subpart in instance.subparts.all():
+            sections = subpart.sections.all()
+            new_subpart = subpart
+            new_subpart.pk = None
+            new_subpart.version = new_version
+            new_subpart.save()
+
+            for section in sections:
+                new_section = section
+                new_section.pk = None
+                new_section.subpart = new_subpart
+                new_section.save()
+
+        return new_version
 
 
 @modeladmin_register


### PR DESCRIPTION
This PR adds a button to the Effective Version admin to allow copying an effective version and all its subparts and their sections to another version, giving regulations content editors the ability to duplicate an effective version instead of creating a new one from scratch.
