### PR TITLE
Remove unnecessary CR tool prototypes feature flag

### DIFF
--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -652,9 +652,6 @@ FLAGS = {
     # Teacher's Digital Platform Customer Review Tool
     'TDP_CRTOOL': {'environment is': 'beta'},
 
-    # Teacher's Digital Platform Customer Review Tool Prototypes Pages
-    'TDP_CRTOOL_PROTOTYPES': {'environment is': 'beta'},
-
     # Teacher's Digital Platform Search Interface Tool
     'TDP_SEARCH_INTERFACE': {'environment is': 'beta'},
 

--- a/cfgov/cfgov/urls.py
+++ b/cfgov/cfgov/urls.py
@@ -420,11 +420,6 @@ urlpatterns = [
         include_if_app_enabled('teachers_digital_platform',
                                 'teachers_digital_platform.begin_urls')),
 
-    flagged_url('TDP_CRTOOL_PROTOTYPES',
-        r'^practitioner-resources/youth-financial-education/curriculum-review/prototypes/',  # noqa: E501
-        include_if_app_enabled('teachers_digital_platform',
-                                'teachers_digital_platform.prototypes_urls')),  # noqa: E501
-
     flagged_wagtail_only_view(
         'TDP_CRTOOL',
         r'^practitioner-resources/youth-financial-education/curriculum-review/'),  # noqa: E501


### PR DESCRIPTION
Remove unnecessary CR tool prototypes feature flag.

## Removals

- Feature flag for CR tool prototypes
- Flagged url for CR tool prototypes

## Reviews

@Scotchester @chosak @willbarton @higs4281 

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
