### PR TITLE
Update Python Docker container to use Postgres 10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 FROM centos:7
-RUN yum -y install which gcc gcc-c++ kernel-devel mailcap make mariadb mariadb-devel postgresql postgresql-devel python-devel && yum clean all
+RUN yum -y install https://download.postgresql.org/pub/repos/yum/10/redhat/rhel-7-x86_64/pgdg-centos10-10-2.noarch.rpm
+RUN yum -y install which gcc gcc-c++ kernel-devel mailcap make mariadb mariadb-devel postgresql10 postgresql10-devel python-devel && yum clean all
 ADD  https://bootstrap.pypa.io/get-pip.py /src/get-pip.py
 run python /src/get-pip.py
 copy requirements /src/requirements


### PR DESCRIPTION
Currently the Python Docker container (that runs the Django code) installs the PostgreSQL 9 client. This is sufficient for using Postgres from Django, and for running `psql`, but fails with this error if you try to run `pg_dump` from inside the Python container:

```
$ pg_dump $DATABASE_URL
pg_dump: server version: 10.3 (Debian 10.3-1.pgdg90+1); pg_dump version: 9.2.23
pg_dump: aborting because of server version mismatch
```

@schbetsy and I discovered this while pairing.

This change upgrades the version of the Postgres client in the Python container to version 10. It follows the CentOS installation instructions from this page:

https://www.postgresql.org/download/linux/redhat/

To test, shut down and delete all running Docker containers:

```
$ docker-compose kill
$ docker-compose rm
```

and then rebuild and restart your containers:

```
$ docker-compose build --no-cache
$ docker-compose up
```

Then try the above `pg_dump` command from within the Python container, and it should work properly:

```
$ pg_dump $DATABASE_URL | more
--
-- PostgreSQL database dump
--

-- Dumped from database version 10.3 (Debian 10.3-1.pgdg90+1)
-- Dumped by pg_dump version 10.4

SET statement_timeout = 0;
...
```

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows the standards laid out in the [development playbook](hXtps://github.com/cfpb/development)
- [X] Passes all existing automated tests
- [X] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: