### PR TITLE
Fix FMC image size for 2x displays

### DIFF
--- a/cfgov/jinja2/v1/_includes/molecules/featured-menu-content.html
+++ b/cfgov/jinja2/v1/_includes/molecules/featured-menu-content.html
@@ -14,7 +14,7 @@
    value.link:                  A link object, containing:
 
    value.link.page_link:        A Wagtail page link.
-   
+
    value.link.external_link:    URL for page outside Wagtail.
 
    value.link.link_text:        A string for the text of the link.
@@ -27,7 +27,7 @@
 
 {% macro render( value ) %}
 {% if value.image and value.image.upload %}
-    {% set featured_image = image(value.image.upload, 'width-270') %}
+    {% set featured_image = image(value.image.upload, 'original') %}
     {% set img_src = featured_image.url if featured_image.url else '' %}
 {% else %}
     {% set featured_image = value.image %}


### PR DESCRIPTION
Updates the requested image size for Featured Menu Content images so that they're high-res on 2x displays.

## Changes

- Calls the `original` rendition for FMC images instead of `width-270`

## Testing

1. Pull branch
1. Ensure you have an FMC image uploaded locally
1. Reload a page
1. Inspect the image and see that it's using the original 540x300 image, scaled down to 270x150

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
