### PR TITLE
regs3k: Add results count to search header

### DIFF
--- a/cfgov/jinja2/v1/_includes/atoms/checkbox.html
+++ b/cfgov/jinja2/v1/_includes/atoms/checkbox.html
@@ -45,7 +45,7 @@
            {{ checked }}>
     <label class="a-label"
            for="{{ id }}">
-        {{ value.label }}
+        <span>{{ value.label }}</span>
     </label>
 </{{ el }}>
 

--- a/cfgov/jinja2/v1/_includes/atoms/tag.html
+++ b/cfgov/jinja2/v1/_includes/atoms/tag.html
@@ -20,12 +20,11 @@
 {% macro render( options ) %}
 
 {%- set behavior = 'data-js-hook=behavior_' ~ options.behavior if options.behavior else '' -%}
-{%- set value = 'value=' ~ options.value if options.value else '' -%}
+{%- set value = 'data-value=' ~ options.value if options.value else '' -%}
 
-<button class="a-tag"
-        type="button"
-        {{ value }}
-        {{ behavior }}>
+<div class="a-tag"
+     {{ value }}
+     {{ behavior }}>
     {{ options.label }} {{ svg_icon('error') }}
-</button>
+</div>
 {% endmacro %}

--- a/cfgov/jinja2/v1/_includes/eregs/regulations3k-search-result-item.html
+++ b/cfgov/jinja2/v1/_includes/eregs/regulations3k-search-result-item.html
@@ -1,5 +1,7 @@
 {% macro render(result) %}
 
+{%- set reg_name = result.part ~ ' (' ~ result.reg ~ ')' -%}
+
 <article class="results_item">
     <h4>
       <a href="{{ result.url }}">{{ result.label }}</a>
@@ -9,10 +11,10 @@
         <span class="u-visually-hidden">Topics:</span>
         <ul class="tags_list">
             <li class="tags_tag">
-                <a href="#" class="tags_link">
+                <span class="tags_link">
                     <span class="tags_bullet" aria-hidden="true">•</span>
-                    {{ result.reg }}
-                </a>
+                    {{ reg_name }}
+                </span>
             </li>
         </ul>
     </div>

--- a/cfgov/regulations3k/jinja2/regulations3k/search-regulations-results.html
+++ b/cfgov/regulations3k/jinja2/regulations3k/search-regulations-results.html
@@ -2,12 +2,11 @@
 {% import 'eregs/regulations3k-search-result-item.html' as search_item %}
 {% import 'molecules/pagination.html' as pagination with context %}
 
-{% set total_count = page.results.total_results %}
 {% set current_count = page.results.results | length %}
 
 <div class="results_header">
     {% if current_count > 0 %}
-    <div class="results_count">
+    <div class="results_count"> 
         <h3>
             Showing {{ current_count }}
             match{% if current_count > 1 %}es{% endif %}

--- a/cfgov/regulations3k/jinja2/regulations3k/search-regulations-results.html
+++ b/cfgov/regulations3k/jinja2/regulations3k/search-regulations-results.html
@@ -4,7 +4,7 @@
 
 <div class="results_header">
     {% if current_count > 0 %}
-    <div class="results_count"> 
+    <div class="results_count">
         <h3>
             Showing {{ current_count }}
             match{% if current_count > 1 %}es{% endif %}
@@ -27,8 +27,9 @@
         <div class="filters_tags">
             {% for reg in page.results.all_regs %}
                 {% if reg.selected %}
+                    {%- set reg_name = '(Reg<span class="u-hide-on-mobile">ulation</span> ' ~ reg.letter_code ~ ')' -%}
                     {{ tag.render({
-                        'label': reg.id ~ ' (' ~ reg.name ~ ')',
+                        'label': reg.id ~ ' ' ~ reg_name | safe,
                         'value': reg.id,
                         'behavior': 'clear-filter'
                     }) }}

--- a/cfgov/regulations3k/jinja2/regulations3k/search-regulations-results.html
+++ b/cfgov/regulations3k/jinja2/regulations3k/search-regulations-results.html
@@ -6,25 +6,22 @@
 {% set current_count = page.results.results | length %}
 
 <div class="results_header">
+    {% if current_count > 0 %}
     <div class="results_count">
-        <div class="has-results">
-            <h3>
-                Showing {{ current_count }}
-                match{% if current_count > 1 %}es{% endif %}
-                {% if total_count > current_count %}
-                    out of {{ total_count }} total results
-                {% endif %}
-            </h3>
-        </div>
-        <!-- <div class="no-results-message">
-            <h3>
-                No results match your filters.
-            </h3>
-            <p>
-                Try adjusting your filters or searching for different terms.
-            </p>
-        </div> -->
+        <h3>
+            Showing {{ current_count }}
+            match{% if current_count > 1 %}es{% endif %}
+            {% if total_count > current_count %}
+                out of {{ total_count }} total results
+            {% endif %}
+        </h3>
     </div>
+    {% else %}
+    <div class="results_count no-results">
+        <h3>No results match your filters.</h3>
+        <p>Try adjusting your filters or searching for different terms.</p>
+    </div>
+    {% endif %}
     {% if show_filters %}
     <div class="filters_applied">
         <span class="filters_applied-label">

--- a/cfgov/regulations3k/jinja2/regulations3k/search-regulations-results.html
+++ b/cfgov/regulations3k/jinja2/regulations3k/search-regulations-results.html
@@ -2,8 +2,6 @@
 {% import 'eregs/regulations3k-search-result-item.html' as search_item %}
 {% import 'molecules/pagination.html' as pagination with context %}
 
-{% set current_count = page.results.results | length %}
-
 <div class="results_header">
     {% if current_count > 0 %}
     <div class="results_count"> 

--- a/cfgov/regulations3k/jinja2/regulations3k/search-regulations-results.html
+++ b/cfgov/regulations3k/jinja2/regulations3k/search-regulations-results.html
@@ -2,17 +2,18 @@
 {% import 'eregs/regulations3k-search-result-item.html' as search_item %}
 {% import 'molecules/pagination.html' as pagination with context %}
 
+{% set total_count = page.results.total_results %}
+{% set current_count = page.results.results | length %}
+
 <div class="results_header">
     <div class="results_count">
         <div class="has-results">
             <h3>
-                Showing
-                <span class="filtered-results-count">
-                    <span class="filtered-results-count_number">
-                        {{ page.results.results | length }}
-                    </span>
-                    results
-                </span>
+                Showing {{ current_count }}
+                match{% if current_count > 1 %}es{% endif %}
+                {% if total_count > current_count %}
+                    out of {{ total_count }} total results
+                {% endif %}
             </h3>
         </div>
         <!-- <div class="no-results-message">

--- a/cfgov/regulations3k/jinja2/regulations3k/search-regulations.html
+++ b/cfgov/regulations3k/jinja2/regulations3k/search-regulations.html
@@ -103,9 +103,10 @@
                         <p> </p>
                         <ul class="m-list m-list__unstyled">
                         {% for reg in page.results.all_regs %}
+                            {%- set reg_name = '(Reg<span class="u-hide-on-tablet">ulation</span> ' ~ reg.letter_code ~ ')' -%}
                             <li>
                                 {{ checkbox.render({
-                                    'label': reg.id ~ ' (' ~ reg.name ~ ')',
+                                    'label': reg.id ~ ' ' ~ reg_name | safe,
                                     'value': reg.id,
                                     'id': 'regulation-' ~ reg.id,
                                     'class': 'reg-checkbox',

--- a/cfgov/regulations3k/jinja2/regulations3k/search-regulations.html
+++ b/cfgov/regulations3k/jinja2/regulations3k/search-regulations.html
@@ -196,7 +196,7 @@
                 </div>
             </form>
         </aside>
-        <div id="regs3k-results" class="content_main content__flush-top-on-small content__flush-bottom">
+        <div id="regs3k-results" class="content_main content__flush-all-on-small content__flush-bottom">
             {% include 'search-regulations-results.html' %}
         </div>
     </div>

--- a/cfgov/regulations3k/models/pages.py
+++ b/cfgov/regulations3k/models/pages.py
@@ -96,6 +96,7 @@ class RegulationsSearchPage(RoutablePageMixin, CFGOVPage):
             snippet = Markup(" ".join(hit.highlighted))
             hit_payload = {
                 'id': hit.paragraph_id,
+                'part': hit.part,
                 'reg': 'Regulation {}'.format(letter_code),
                 'label': hit.title,
                 'snippet': snippet,

--- a/cfgov/regulations3k/models/pages.py
+++ b/cfgov/regulations3k/models/pages.py
@@ -80,6 +80,8 @@ class RegulationsSearchPage(RoutablePageMixin, CFGOVPage):
                 'selected': reg.part_number in regs}
                 for reg in all_regs]
         })
+        payload.update({'total_count': sum(
+            [reg['num_results'] for reg in payload['all_regs']])})
         if len(regs) == 1:
             sqs = sqs.filter(part=regs[0])
         elif regs:
@@ -102,7 +104,7 @@ class RegulationsSearchPage(RoutablePageMixin, CFGOVPage):
                     hit.section_label, hit.paragraph_id),
             }
             payload['results'].append(hit_payload)
-        payload.update({'total_results': sqs.count()})
+        payload.update({'current_count': sqs.count()})
         self.results = payload
         context = self.get_context(request)
         num_results = validate_num_results(request)
@@ -110,6 +112,8 @@ class RegulationsSearchPage(RoutablePageMixin, CFGOVPage):
         page_number = validate_page_number(request, paginator)
         paginated_page = paginator.page(page_number)
         context.update({
+            'current_count': payload['current_count'],
+            'total_count': payload['total_count'],
             'paginator': paginator,
             'current_page': page_number,
             'num_results': num_results,

--- a/cfgov/regulations3k/models/pages.py
+++ b/cfgov/regulations3k/models/pages.py
@@ -73,7 +73,7 @@ class RegulationsSearchPage(RoutablePageMixin, CFGOVPage):
         sqs = SearchQuerySet().filter(content=search_query)
         payload.update({
             'all_regs': [{
-                'name': "Regulation {}".format(reg.letter_code),
+                'letter_code': reg.letter_code,
                 'id': reg.part_number,
                 'num_results': sqs.filter(
                     part=reg.part_number).models(SectionParagraph).count(),

--- a/cfgov/unprocessed/apps/regulations3k/css/reg-search.less
+++ b/cfgov/unprocessed/apps/regulations3k/css/reg-search.less
@@ -102,7 +102,7 @@
     }
 }
 
-.respond-to-max( @bp-xs-max {
+.respond-to-max( @bp-sm-max {
     .search_results {
         .content_sidebar {
             padding-top: unit( ( @grid_gutter-width / 2 ) / @base-font-size-px, em );

--- a/cfgov/unprocessed/apps/regulations3k/css/reg-search.less
+++ b/cfgov/unprocessed/apps/regulations3k/css/reg-search.less
@@ -116,6 +116,14 @@
     }
 });
 
+// We have an awkward state where text in the filters sidebar is too long on
+// mid-size screens but is fine on desktop and mobile
+.u-hide-on-tablet {
+    .respond-to-range( @bp-sm-max, 1100px, {
+        display: none;
+    } );
+}
+
 /* PWA */
 
 .regs3k-js {

--- a/cfgov/unprocessed/apps/regulations3k/css/reg-search.less
+++ b/cfgov/unprocessed/apps/regulations3k/css/reg-search.less
@@ -66,7 +66,10 @@
         padding-top: 0;
     }
     .results_count {
-        padding: 15px 15px 0 15px;
+        padding: unit( ( @grid_gutter-width / 2 ) / @base-font-size-px, em )
+                 unit( ( @grid_gutter-width / 2 ) / @base-font-size-px, em )
+                 0
+                 unit( ( @grid_gutter-width / 2 ) / @base-font-size-px, em );
         border-right: 1px solid @gray-40;
         border-bottom: 1px solid @gray-40;
         background-color: @green-20;
@@ -98,6 +101,20 @@
         max-width: 41.875rem;
     }
 }
+
+.respond-to-max( @bp-xs-max {
+    .search_results {
+        .content_sidebar {
+            padding-top: unit( ( @grid_gutter-width / 2 ) / @base-font-size-px, em );
+        }
+        .content_main {
+            margin-top: unit( ( @grid_gutter-width / 2 ) / @base-font-size-px, em );
+        }
+        .results_count {
+            border-left: 1px solid @gray-40;
+        }
+    }
+});
 
 /* PWA */
 

--- a/cfgov/unprocessed/apps/regulations3k/css/reg-search.less
+++ b/cfgov/unprocessed/apps/regulations3k/css/reg-search.less
@@ -28,7 +28,7 @@
 .search_results {
     .content_sidebar {
         padding: 45px 15px 0;
-        border: 1px solid #b4b5b6;
+        border: 1px solid @gray-40;
         background-color: #f7f8f9;
         .o-expandable_content,
         .o-expandable_target {
@@ -62,14 +62,18 @@
             border: 0;
         }
         border: 0;
-        border-top: 1px solid #b4b5b6;
+        border-top: 1px solid @gray-40;
         padding-top: 0;
     }
     .results_count {
         padding: 15px 15px 0 15px;
-        border-right: 1px solid #b4b5b6;
-        border-bottom: 1px solid #b4b5b6;
-        background-color: #e2efd8;
+        border-right: 1px solid @gray-40;
+        border-bottom: 1px solid @gray-40;
+        background-color: @green-20;
+        &.no-results {
+            background-color: @red-20;
+            padding-bottom: 15px;
+        }
     }
     .results_list {
         padding: unit( @grid_gutter-width / @base-font-size-px, em )
@@ -84,7 +88,7 @@
             margin-top: unit( @grid_gutter-width / @base-font-size-px, em );
             h4 {
                 padding-top: unit( @grid_gutter-width / @base-font-size-px, em );
-                border-top: 1px solid #b4b5b6;
+                border-top: 1px solid @gray-40;
             }
         }
     }

--- a/cfgov/unprocessed/apps/regulations3k/js/search.js
+++ b/cfgov/unprocessed/apps/regulations3k/js/search.js
@@ -30,11 +30,13 @@ function attachHandlers() {
  */
 function clearFilter( event ) {
   // Continue only if the X icon was clicked and not the parent button
-  if ( event.target.tagName === 'BUTTON' ) {
+  let target = event.target.tagName.toLowerCase();
+  if ( target !== 'svg' && target !== 'path' ) {
     return;
   }
-  const target = closest( event.target, 'button' );
-  const checkbox = find( `#regulation-${ target.value }` );
+  target = closest( event.target, '.a-tag' );
+  const checkbox = find( `#regulation-${ target.dataset.value }` );
+  window.find = find;
   // Remove the filter tag
   target.remove();
   // Uncheck the filter checkbox

--- a/cfgov/unprocessed/apps/regulations3k/js/search.js
+++ b/cfgov/unprocessed/apps/regulations3k/js/search.js
@@ -36,7 +36,6 @@ function clearFilter( event ) {
   }
   target = closest( event.target, '.a-tag' );
   const checkbox = find( `#regulation-${ target.dataset.value }` );
-  window.find = find;
   // Remove the filter tag
   target.remove();
   // Uncheck the filter checkbox

--- a/test/unit_tests/apps/regulations3k/js/search-spec.js
+++ b/test/unit_tests/apps/regulations3k/js/search-spec.js
@@ -17,11 +17,11 @@ const HTML_SNIPPET = `
     </div>
   </div>
   <div>
-    <button class="a-tag" type="button" value="1002" data-js-hook="behavior_clear-filter">
+    <div class="a-tag" data-value="1002" data-js-hook="behavior_clear-filter">
     1002 (Regulation B)
       <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 718.9 1200" class="cf-icon-svg">
       </svg>
-    </button>
+    </div>
   </div>
   <button id="clear-all" data-js-hook="behavior_clear-all">
       Clear all filters
@@ -70,24 +70,24 @@ describe( 'The Regs3K search page', () => {
     global.XMLHttpRequest = jest.fn( () => mockXHR );
     const clearIcon = document.querySelector( 'svg' );
 
-    let numFilters = document.querySelectorAll( 'button.a-tag' ).length;
+    let numFilters = document.querySelectorAll( 'div.a-tag' ).length;
     expect( numFilters ).toEqual( 1 );
 
     simulateEvent( 'click', clearIcon );
-    numFilters = document.querySelectorAll( 'button.a-tag' ).length;
+    numFilters = document.querySelectorAll( 'div.a-tag' ).length;
     expect( numFilters ).toEqual( 0 );
 
     mockXHR.onreadystatechange();
   } );
 
   it( 'should not clear a filter when its tag is clicked', () => {
-    const button = document.querySelector( 'button.a-tag' );
+    const div = document.querySelector( 'div.a-tag' );
 
-    let numFilters = document.querySelectorAll( 'button.a-tag' ).length;
+    let numFilters = document.querySelectorAll( 'div.a-tag' ).length;
     expect( numFilters ).toEqual( 1 );
 
-    simulateEvent( 'click', button );
-    numFilters = document.querySelectorAll( 'button.a-tag' ).length;
+    simulateEvent( 'click', div );
+    numFilters = document.querySelectorAll( 'div.a-tag' ).length;
     expect( numFilters ).toEqual( 1 );
   } );
 
@@ -103,11 +103,11 @@ describe( 'The Regs3K search page', () => {
     global.XMLHttpRequest = jest.fn( () => mockXHR );
     const clearAllLink = document.querySelector( '#clear-all' );
 
-    let numFilters = document.querySelectorAll( 'button.a-tag' ).length;
+    let numFilters = document.querySelectorAll( 'div.a-tag' ).length;
     expect( numFilters ).toEqual( 1 );
 
     simulateEvent( 'click', clearAllLink );
-    numFilters = document.querySelectorAll( 'button.a-tag' ).length;
+    numFilters = document.querySelectorAll( 'div.a-tag' ).length;
     expect( numFilters ).toEqual( 0 );
 
     mockXHR.onreadystatechange();


### PR DESCRIPTION

Adds `Showing X matches out of XXX total results` text per [GHE#106](https://github.cfpb.gov/eregs/regulations-3000/issues/106):

<img width="766" alt="screen shot 2018-07-26 at 5 45 44 pm" src="https://user-images.githubusercontent.com/1060248/43290987-df46a12e-90fd-11e8-8dcb-67337a677a95.png">

<hr>

Adjusts the tags that appear under search results per [GHE#113](https://GHE/eregs/regulations-3000/issues/113):

<img width="429" alt="screen shot 2018-07-26 at 6 01 35 pm" src="https://user-images.githubusercontent.com/1060248/43291011-f61b1790-90fd-11e8-9d95-6ee5c473a781.png">

<hr>

Makes the search results page a little nicer on smaller screens by shortening `Regulation X` into `Reg X`:

![filter-text](https://user-images.githubusercontent.com/1060248/43291394-469cf23c-90ff-11e8-8ea9-2989220c63f6.gif)

## Testing

1. Visit the regs3k search page and search for something.
1. Verify the above screenshots match your experience.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [x] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
