### PR TITLE
Support multiple caches for fragment cache extension

### DIFF
--- a/cfgov/jinja2/v1/_includes/organisms/post-preview.html
+++ b/cfgov/jinja2/v1/_includes/organisms/post-preview.html
@@ -60,7 +60,7 @@
 {% import 'macros/time.html' as time %}
 
 {% macro render(post, controls, url='', post_date_description='') %}
-    {% cache post.post_preview_cache_key %}
+    {% cache post.post_preview_cache_key, 'post_preview' %}
     {% set date_desc = controls.post_date_description or post_date_description or 'Published' %}
     {% set cat_controls = controls.categories %}
     {% set show_categories = cat_controls.show_preview_categories if cat_controls is defined else true %}

--- a/cfgov/v1/__init__.py
+++ b/cfgov/v1/__init__.py
@@ -10,7 +10,6 @@ from six.moves.urllib.parse import parse_qs, urlparse
 from django.conf import settings
 from django.contrib import messages
 from django.contrib.staticfiles.storage import staticfiles_storage
-from django.core.cache import caches
 from django.core.urlresolvers import reverse
 from django.template.defaultfilters import linebreaksbr, pluralize, slugify
 from django.utils.module_loading import import_string
@@ -94,7 +93,6 @@ def environment(**options):
         'pluralize': pluralize,
         'slugify': slugify,
     })
-    env.fragment_cache = caches['post_preview']
     return env
 
 

--- a/cfgov/v1/fragment_cache_extension.py
+++ b/cfgov/v1/fragment_cache_extension.py
@@ -9,15 +9,6 @@ class FragmentCacheExtension(Extension):
     # a set of names that trigger the extension.
     tags = set(['cache'])
 
-    def __init__(self, environment):
-        super(FragmentCacheExtension, self).__init__(environment)
-
-        # add the defaults to the environment
-        environment.extend(
-            fragment_cache_prefix='',
-            fragment_cache=None
-        )
-
     def parse(self, parser):
         # the first token is the token that started the tag.  In our case
         # we only listen to ``'cache'`` so this will be a name token with


### PR DESCRIPTION
This generalizes the fragment cache extension code slightly so that what was previously the `fragment_cache` (defined in the environment) is not hardcoded to use the `post_preview` cache.  Instead, we explicitly pass in the name of the cache in the template, and use that to look up the cache.  

The reason for this change is to support additional caches, so that we're not using `post_preview` for different types of fragment caching.  Specifically, @virginiacc will be using fragment caching on the mega menu template, so this PR will allow us to set up a new cache - whether it's a more generic cache or one specific to the mega menu, it needs to be separate from the current `post_preview` cache.

For more context, this is the PR in which fragment caching was introduced: https://github.com/cfpb/cfgov-refresh/pull/3596