### PR TITLE
regs3k: Adjust admin sorting and labeling

### DIFF
--- a/cfgov/regulations3k/fixtures/tree_limb.json
+++ b/cfgov/regulations3k/fixtures/tree_limb.json
@@ -15,7 +15,7 @@
     "effective_date": "2014-01-18",
     "source": "76 FR 79445, Dec. 21, 2011, unless otherwise noted.",
     "part": 1,
-    "acquired": "2018-06-13",
+    "created": "2018-06-13",
     "authority": "12 U.S.C. 5512, 5581; 15 U.S.C. 1691b.",
     "draft": false
   },

--- a/cfgov/regulations3k/migrations/0010_rename_acquired_field.py
+++ b/cfgov/regulations3k/migrations/0010_rename_acquired_field.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('regulations3k', '0009_sectionparagraph'),
+    ]
+
+    operations = [
+        migrations.RenameField(
+            model_name='effectiveversion',
+            old_name='acquired',
+            new_name='created',
+        ),
+    ]

--- a/cfgov/regulations3k/models/django.py
+++ b/cfgov/regulations3k/models/django.py
@@ -87,7 +87,7 @@ class EffectiveVersion(models.Model):
     authority = models.CharField(max_length=255, blank=True)
     source = models.CharField(max_length=255, blank=True)
     effective_date = models.DateField(blank=True, null=True)
-    acquired = models.DateField(blank=True, null=True)
+    created = models.DateField(blank=True, null=True)
     draft = models.BooleanField(default=False)
     part = models.ForeignKey(Part, related_name="versions")
 
@@ -97,11 +97,25 @@ class EffectiveVersion(models.Model):
         FieldPanel('effective_date'),
         FieldPanel('part'),
         FieldPanel('draft'),
-        FieldPanel('acquired'),
+        FieldPanel('created'),
     ]
 
     def __str__(self):
         return "Effective on {}".format(self.effective_date)
+
+    @property
+    def live_version(self):
+        return self.part.effective_version == self
+
+    @property
+    def status(self):
+        if self.live_version:
+            return 'LIVE'
+        if self.draft is True:
+            return 'Unapproved draft'
+        if self.effective_date >= datetime.today().date():
+            return 'Future version'
+        return 'Previous version'
 
     class Meta:
         ordering = ['effective_date']

--- a/cfgov/regulations3k/parser/payload.py
+++ b/cfgov/regulations3k/parser/payload.py
@@ -90,7 +90,7 @@ class PayLoad(object):
         auth = soup.find('AUTH').find('PSPACE').text.strip()
         source = soup.find('SOURCE').find('PSPACE').text.strip()
         version = EffectiveVersion(
-            acquired=datetime.date.today(),
+            created=datetime.date.today(),
             effective_date=self.effective_date,
             authority=auth,
             part=part,

--- a/cfgov/regulations3k/wagtail_hooks.py
+++ b/cfgov/regulations3k/wagtail_hooks.py
@@ -30,7 +30,7 @@ class SubpartModelAdmin(TreeModelAdmin):
     child_field = 'sections'
     child_model_admin = SectionModelAdmin
     parent_field = 'version'
-    ordering = ['subpart_type', 'label']
+    ordering = ['subpart_type', 'title']
 
 
 class EffectiveVersionModelAdmin(TreeModelAdmin):
@@ -39,8 +39,8 @@ class EffectiveVersionModelAdmin(TreeModelAdmin):
     menu_icon = 'list-ul'
     list_display = (
         'effective_date',
-        'draft',
-        'acquired')
+        'status',
+        'created')
     child_field = 'subparts'
     child_model_admin = SubpartModelAdmin
     parent_field = 'part'


### PR DESCRIPTION
User testing raised some issues with sorting and labeling in Wagtail.
* Subparts were not properly ordered when a reg had more than one section subpart.
* The "acquired" column heading for EffectiveVersion was confusing.
* The "draft" column for EffectiveVersion was confusing (red meant active)
* If more than one version were active, the live version wasn't obvious.

In addition to fixing the subpart sorting, this patch creates a new "status" column
for effective verisons that will distinguish between live, draft, previous, and future versions. 
So a reg with versions in each state might look like this:

<img width="1027" alt="version_status" src="https://user-images.githubusercontent.com/515885/43377812-e00c10cc-9390-11e8-9d62-ff14e7320401.png">

## Testing

This patch includes a migration to rename the "acquired" field for EffectiveVersion, so first run the  migration:

```
./cfgov/manage.py migrate --noinput
```
Then:
- Dive into a reg with multiple section subparts, and subparts should be correctly ordered.
- Check out a reg with multiple versions and test the statuses.

**Notes**  
- An effective version can be a "Future version" only if its effective date is in the future AND it is  not a "draft."
- This addresses GHE issue 143 (subpart ordering) and an undocumented issue about the color of the  "draft" field (red was counter-intuitive).