### PR TITLE
Add Django-Flags requirement and bump Wagtail-Flags

### DIFF
--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -59,6 +59,7 @@ INSTALLED_APPS = (
     'wagtailinventory',
     'wagtailsharing',
     'flags',
+    'wagtailflags',
     'watchman',
     'haystack',
     'ask_cfpb',

--- a/requirements/libraries.txt
+++ b/requirements/libraries.txt
@@ -8,6 +8,7 @@ djangorestframework-csv==2.0.0
 django-csp==3.1
 django-braces==1.0.0
 django-extensions==1.5.5
+django-flags==3.0.0
 django-haystack==2.6.0
 django-localflavor==1.1
 django-overextends==0.4.1
@@ -44,7 +45,7 @@ unicodecsv==0.14.1
 unipath>=1.1,<=2.0
 # TODO: Remove explicit urllib3 requirement once requests is updated to support urllib3 1.23
 urllib3==1.22
-wagtail-flags==2.0.8
+wagtail-flags==3.0.0
 wagtail-inventory==0.5
 wagtail-sharing==0.6.1
 wagtail-treemodeladmin==1.0.3


### PR DESCRIPTION
This PR updates Wagtail-Flags to 3.0.0 and adds the new dependency Django-Flags 3.0.0.

To make it possible to use our feature flag library independently of Wagtail, we've isolated the Wagtail-specifics in [Wagtail-Flags](https://github.com/cfpb/wagtail-flags) and put all the general-purpose Django code in [Django-Flags](https://github.com/cfpb/django-flags). There is no change to the feature flag functionality in these releases, just changes to the way the code is organized. https://github.com/cfpb/wagtail-flags/pull/29 explains the changes.

## Testing

1. Checkout this `django-wagtail-flags` branch
2. Install Django-Flags and Wagtail-Flags:
    - Docker:
        1. `./shell.sh`
        2. `pip install wagtail-flags==3.0.0`
    - Standalone local virtualenv:
        1. Activate your virtualenv (i.e. `workon cfgov-refresh`)
        2. `pip install git+https://github.com/cfpb/wagtail-flags.git@django-flags`
3. Run cfgov-refresh
4. Visit http://localhost:8000/admin/flags/
5. Verify that existing feature flags work as expected, conditions can be added and removed and work as expected.
