### PR TITLE
Fix post preview cache

### DIFF
--- a/cfgov/jinja2/v1/_includes/article.html
+++ b/cfgov/jinja2/v1/_includes/article.html
@@ -71,7 +71,7 @@
     </div>
     {% if page.tags.all() | length %}
         <footer>
-            {{ tags.render( page.related_metadata_tags(), '', is_wagtail=True) }}
+            {{ tags.render( page.related_metadata_tags(), is_wagtail=True) }}
         </footer>
     {% endif %}
 </article>

--- a/cfgov/jinja2/v1/_includes/macros/category-slug.html
+++ b/cfgov/jinja2/v1/_includes/macros/category-slug.html
@@ -27,7 +27,7 @@
 
    ========================================================================== #}
 
-{% macro render(category, href, classes, use_blog_category=false) %}
+{% macro render(category, href, classes='', use_blog_category=false) %}
     {% import 'macros/category-icon.html' as category_icon %}
 
     {% if href %}
@@ -50,7 +50,7 @@
 {% macro _category_link(href, classes) %}
     {% if href %}
         <a href="{{ href }}"
-           class="a-heading a-heading__icon {{ classes if classes else '' }}">
+           class="a-heading a-heading__icon {{ classes }}">
     {% endif %}
        {{ caller() }}
     {% if href %}

--- a/cfgov/jinja2/v1/_includes/organisms/item-introduction.html
+++ b/cfgov/jinja2/v1/_includes/organisms/item-introduction.html
@@ -34,7 +34,7 @@
 
 <div class="o-item-introduction">
     {% if page.categories.count() > 0 and value.show_category %}
-        {{ category_slug.render(page.categories.first().name, page_url) }}
+        {{ category_slug.render(category=page.categories.first().name, href=page_url) }}
     {% endif %}
     <h1>{{ value.heading | safe }}</h1>
 

--- a/cfgov/jinja2/v1/_includes/organisms/post-preview.html
+++ b/cfgov/jinja2/v1/_includes/organisms/post-preview.html
@@ -60,12 +60,9 @@
 {% import 'macros/time.html' as time %}
 
 {% macro render(post, controls, url='', post_date_description='') %}
-    {% cache post.post_preview_cache_key, 'post_preview' %}
     {% set date_desc = controls.post_date_description or post_date_description or 'Published' %}
     {% set cat_controls = controls.categories %}
     {% set show_categories = cat_controls.show_preview_categories if cat_controls is defined else true %}
-    {% set page_url = url or get_protected_url(page) %}
-    {% set post_url = get_protected_url(post) %}
     <article class="o-post-preview">
         <div class="m-meta-header">
             <div class="m-meta-header_right">
@@ -83,19 +80,21 @@
                 {% if show_categories %}
                     {% import 'macros/category-slug.html' as category_slug %}
                     {% if cat_controls and 'newsroom' in cat_controls.page_type and is_blog(post) %}
-                        {{ category_slug.render('blog', page_url, '', false) }}
+                        {{ category_slug.render(category='blog', href=url) }}
                     {% else %}
                         {% for cat in post.categories.all() %}
                             {% if loop.index > 1 %}
                                 |
                             {% endif %}
-                            {{ category_slug.render(cat.name, page_url, '', false) }}
+                            {{ category_slug.render(category=cat.name, href=url) }}
                         {% endfor %}
                     {% endif %}
                 {% endif %}
             </div>
         </div>
-         {% if 'EventPage' in post.specific_class.__name__ %}
+        {% cache post.post_preview_cache_key, 'post_preview' %}
+        {% set post_url = get_protected_url(post) %}
+        {% if 'EventPage' in post.specific_class.__name__ %}
             {% set event = post.specific %}
             {% if event.start_dt %}
                 <div class="o-post-preview_image-container">
@@ -164,15 +163,15 @@
             <div class="o-post-preview_byline-group">
             {% for author in post.get_authors() %}
                 {% if loop.index == 1  %}
-                    By <a href="{{ page_url }}?authors={{ author.slug }}">
+                    By <a href="{{ url }}?authors={{ author.slug }}">
                        {{ author.name }}
                        </a>
                 {% elif loop.last == true %}
-                    and <a href="{{ page_url }}?authors={{ author.slug }}">
+                    and <a href="{{ url }}?authors={{ author.slug }}">
                         {{ author.name }}
                         </a>
                 {% else %}
-                    , <a href="{{ page_url }}?authors={{ author.slug }}">
+                    , <a href="{{ url }}?authors={{ author.slug }}">
                       {{ author.name }}
                       </a>
                 {% endif %}
@@ -181,7 +180,7 @@
 
             {% if post.tags.exists() %}
                 {%- import 'tags.html' as tags %}
-                {{ tags.render(post.related_metadata_tags(), page_url, true, false, is_wagtail=True) }}
+                {{ tags.render(post.related_metadata_tags(), hide_heading=true, is_wagtail=True) }}
             {% endif %}
 
             {% if post.secondary_link_url and post.secondary_link_text %}
@@ -190,6 +189,6 @@
                 </a>
             {% endif %}
         </div>
+        {% endcache %}
     </article>
-    {% endcache %}
 {% endmacro %}

--- a/cfgov/jinja2/v1/_includes/tags.html
+++ b/cfgov/jinja2/v1/_includes/tags.html
@@ -29,7 +29,7 @@
 
    ========================================================================== #}
 
-{% macro render(tags, path, hide_heading=false, display_block=false, is_sheer=False, is_wagtail=False) %}
+{% macro render(tags, path='', hide_heading=false, display_block=false, is_sheer=False, is_wagtail=False) %}
 <div class="tags{{' tags__hide-heading' if hide_heading else ''}}{{' tags__block-list' if display_block else '' }}">
     <span class="{{'u-visually-hidden' if hide_heading else 'tags_heading' }}">Topics:</span>
     <ul class="tags_list">

--- a/cfgov/jinja2/v1/activity-log/_activity-list.html
+++ b/cfgov/jinja2/v1/activity-log/_activity-list.html
@@ -20,15 +20,15 @@
             <tr>
                 <td class="u-w20pct">
                     {% if is_blog(post) %}
-                        {{ category_slug.render('blog', page_url, '', false) }}
+                        {{ category_slug.render(category='blog', href=page_url) }}
                     {% elif is_report(post) %}
-                        {{ category_slug.render('report', page_url, '', false) }}
+                        {{ category_slug.render(category='report', href=page_url) }}
                     {% else %}
                         {% for cat in post.categories.all() %}
                             {% if loop.index > 1 %}
                                 |
                             {% endif %}
-                            {{ category_slug.render(cat.name, page_url, '', false) }}
+                            {{ category_slug.render(category=cat.name, href=page_url) }}
                         {% endfor %}
                     {% endif %}
                 </td>

--- a/cfgov/jinja2/v1/ask-cfpb/answer-page.html
+++ b/cfgov/jinja2/v1/ask-cfpb/answer-page.html
@@ -67,7 +67,7 @@
                 </div>
                 {% if audiences %}
                 <div class="u-mt15">
-                    {{ tags.render( {'links': audiences}, '', is_wagtail=True) }}
+                    {{ tags.render( {'links': audiences}, is_wagtail=True) }}
                 </div>
                 {% endif %}
 

--- a/cfgov/jinja2/v1/ask-cfpb/landing-page.html
+++ b/cfgov/jinja2/v1/ask-cfpb/landing-page.html
@@ -80,7 +80,7 @@
                         </div>
 
                         <div class="block block__sub">
-                            {{ tags.render( {'links': audiences}, '', is_wagtail=True ) }}
+                            {{ tags.render( {'links': audiences}, is_wagtail=True ) }}
                         </div>
 
                         {% if disclaimer %}

--- a/cfgov/jinja2/v1/events/_event-detail.html
+++ b/cfgov/jinja2/v1/events/_event-detail.html
@@ -75,7 +75,7 @@
     {% if page.tags.names() | length %}
     <footer>
         {%- import 'tags.html' as tags %}
-        {{ tags.render( page.related_metadata_tags(), '', is_wagtail=True) }}
+        {{ tags.render( page.related_metadata_tags(), is_wagtail=True) }}
     </footer>
     {% endif %}
 </article>


### PR DESCRIPTION
## Overview

See GHE/CFGOV/platform/issues/2825 for bug report. 

This fixes a bug introduced by https://github.com/cfpb/cfgov-refresh/pull/3596, in which certain information on a post preview (such as the icon displayed) was getting cached across blog and newsroom pages, which displayed the icon differently, and with no way to differentiate.  This PR resolves it by moving that logic out of the cache.  

I also identified another issue where the author URLs were incorrectly getting cached, and this PR resolves it by ensuring a relative link is used on the blog and newsroom pages since it's unnecessary to pass in an absolute URL. 

## Testing

First, to view the bug locally, check out the `master` branch locally and run it with the cache enabled, e.g. `ENABLE_POST_PREVIEW_CACHE=1 ./runserver.sh`. You do not need to refresh your production dump, but you should be running on a production dump.  Depending on the exact data snapshot you have, you'll see that the icons are off either on http://localhost:8000/about-us/blog/ or on http://localhost:8000/about-us/newsroom/.  On whichever page the icons are off, the author URLs will be off too.   Alternatively, you can clear the cache by running the shell like so:
`ENABLE_POST_PREVIEW_CACHE=1 ./manage.py shell`
`from django.core.cache import caches`
`caches['post_preview'].clear()`
and then loading the newsroom page, and then the blog page -- you'll notice the blog page has the incorrect information because the newsroom page was cached first.

Now, switch to my branch `fix-post-preview`, and clear the cache.  Then run the server (with cache enabled still), and confirm that the links and icons are as expected.