### PR TITLE
Bump wagtail-inventory to 0.5

### DIFF
--- a/requirements/libraries.txt
+++ b/requirements/libraries.txt
@@ -40,7 +40,7 @@ unipath>=1.1,<=2.0
 # TODO: Remove explicit urllib3 requirement once requests is updated to support urllib3 1.23
 urllib3==1.22
 wagtail-flags==2.0.8
-wagtail-inventory==0.4.2
+wagtail-inventory==0.5
 wagtail-sharing==0.6.1
 wagtail-treemodeladmin==1.0.3
 Wand==0.4.2


### PR DESCRIPTION
So we can restore sanity to the list of blocks in the select menus.

## Changes

- Bump wagtail-inventory requirement to the latest release, 0.5

## Testing

1. If using Docker, rebuild your Python container (`docker-compose build python`); if using virtualenv, `pip install -r requirements/local.txt`.
1. Open http://localhost:8000/admin/inventory/
1. Open one of the big select menus at the top
1. See all the blocks sorted nicely in alphabetical order

## Screenshots

![screen shot 2018-07-30 at 14 36 42](https://user-images.githubusercontent.com/1044670/43416339-fd363e0a-9405-11e8-84a8-5af9d0eade8b.png)

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: