### PR TITLE
Regs3k indexing update

### DIFF
--- a/cfgov/regulations3k/management/commands/update_regulation_index.py
+++ b/cfgov/regulations3k/management/commands/update_regulation_index.py
@@ -24,19 +24,24 @@ class Command(BaseCommand):
             'created': 0,
             'deleted': 0,
             'kept': 0,
+            'dupes': [],
         }
         regulations = Part.objects.all()
         versions = [part.effective_version for part in regulations]
         sections = Section.objects.filter(subpart__version__in=versions)
         for section in sections:
             section_count = section.extract_graphs()
-            for key in counter:
+            for key in ['created', 'deleted', 'kept']:
                 counter[key] += section_count.get(key, 0)
+            counter['dupes'] += section_count['dupes']
+        dupes = sorted(counter['dupes'])
         logger.info(
             "Section paragraphs have been extracted for {} regulations.\n"
-            "{} were created, {} were unchanged, and {} were deleted.".format(
+            "{} were created, {} were unchanged, {} were deleted, and"
+            "{} dupes were found".format(
                 regulations.count(),
                 counter['created'],
                 counter['kept'],
-                counter['deleted']))
+                counter['deleted'],
+                len(dupes)))
         _run_haystack_update()

--- a/cfgov/regulations3k/models/django.py
+++ b/cfgov/regulations3k/models/django.py
@@ -193,32 +193,33 @@ class Section(models.Model):
     def extract_graphs(self):
         """Break out and store a section's paragraphs for indexing."""
         part = self.subpart.version.part
+        section_tag = "{}-{}".format(part.part_number, self.label)
         extractor = regdown.extract_labeled_paragraph
         paragraph_ids = re.findall(r'[^{]*{(?P<label>[\w\-]+)}', self.contents)
         created = 0
         deleted = 0
         kept = 0
         exclude_from_deletion = []
+        known_ids = []
         dupes = []
         for pid in paragraph_ids:
             raw_graph = extractor(pid, self.contents, exact=True)
-            re.sub(r'(See\([^\)]+\))', '', raw_graph)
             markup_graph = regdown.regdown(raw_graph)
             index_graph = strip_tags(markup_graph).strip()
-            if index_graph:
-                graph, cr = SectionParagraph.objects.get_or_create(
-                    paragraph=index_graph,
-                    paragraph_id=pid,
-                    section=self)
-                if cr:
-                    created += 1
+            full_id = "{}-{}".format(section_tag, pid)
+            graph, cr = SectionParagraph.objects.get_or_create(
+                paragraph=index_graph,
+                paragraph_id=pid,
+                section=self)
+            if cr:
+                created += 1
+            else:
+                if full_id in known_ids:
+                    dupes.append(full_id)
                 else:
-                    dupes.append("{}_{}_{}".format(
-                        part.part_number,
-                        self.label,
-                        pid))
+                    known_ids.append(full_id)
                     kept += 1
-                exclude_from_deletion.append(graph.pk)
+            exclude_from_deletion.append(graph.pk)
         to_delete = SectionParagraph.objects.filter(
             section__subpart__version__part=part,
             section__label=self.label).exclude(
@@ -228,7 +229,7 @@ class Section(models.Model):
             graph.delete()
         dupes = sorted(set(dupes))
         return {
-            'section': self.title,
+            'section': section_tag,
             'created': created,
             'deleted': deleted,
             'kept': kept,

--- a/cfgov/regulations3k/models/django.py
+++ b/cfgov/regulations3k/models/django.py
@@ -199,6 +199,7 @@ class Section(models.Model):
         deleted = 0
         kept = 0
         exclude_from_deletion = []
+        dupes = []
         for pid in paragraph_ids:
             raw_graph = extractor(pid, self.contents, exact=True)
             re.sub(r'(See\([^\)]+\))', '', raw_graph)
@@ -212,6 +213,10 @@ class Section(models.Model):
                 if cr:
                     created += 1
                 else:
+                    dupes.append("{}_{}_{}".format(
+                        part.part_number,
+                        self.label,
+                        pid))
                     kept += 1
                 exclude_from_deletion.append(graph.pk)
         to_delete = SectionParagraph.objects.filter(
@@ -221,11 +226,13 @@ class Section(models.Model):
         deleted += to_delete.count()
         for graph in to_delete:
             graph.delete()
+        dupes = sorted(set(dupes))
         return {
             'section': self.title,
             'created': created,
             'deleted': deleted,
             'kept': kept,
+            'dupes': dupes,
         }
 
     def save(self, **kwargs):

--- a/cfgov/regulations3k/scripts/ecfr_importer.py
+++ b/cfgov/regulations3k/scripts/ecfr_importer.py
@@ -214,10 +214,10 @@ def parse_interp_graph(p_element):
         graph = p_element.text.replace(
             '{}.'.format(pid), '**{}.**'.format(pid), 1).replace(
             '  ', ' ').replace(
-            '** **', ' ', 1)
+            '** **', ' ', 1).replace('\n', '')
         graph_text += graph + "\n"
     else:
-        graph_text += p_element.text + "\n"
+        graph_text += p_element.text.replace('\n', '') + "\n"
     return graph_text
 
 

--- a/cfgov/regulations3k/tests/test_models.py
+++ b/cfgov/regulations3k/tests/test_models.py
@@ -87,7 +87,9 @@ class RegModelTests(DjangoTestCase):
             contents=(
                 '{a}\n(a) Regdown paragraph a.\n'
                 '{b}\n(b) Paragraph b\n'
+                '\nsee(4-b-Interp)\n'
                 '{c}\n(c) Paragraph c.\n'
+                '{c-1}\n \n'
                 '{d}\n(1) General rule. A creditor that provides in writing.\n'
             ),
             subpart=self.subpart,
@@ -180,8 +182,8 @@ class RegModelTests(DjangoTestCase):
 
     def test_section_export_graphs(self):
         test_counts = self.section_num4.extract_graphs()
-        self.assertEqual(test_counts['section'], self.section_num4.title)
-        self.assertEqual(test_counts['created'], 3)
+        self.assertEqual(test_counts['section'], "1002-4")
+        self.assertEqual(test_counts['created'], 4)
         self.assertEqual(test_counts['deleted'], 1)
         self.assertEqual(test_counts['kept'], 1)
 

--- a/cfgov/regulations3k/tests/test_search_indexes.py
+++ b/cfgov/regulations3k/tests/test_search_indexes.py
@@ -20,11 +20,11 @@ class RegulationIndexTestCase(TestCase):
         Section.objects.first().extract_graphs()
 
     def test_extract_paragraphs(self):
-        self.assertEqual(SectionParagraph.objects.count(), 6)
+        self.assertEqual(SectionParagraph.objects.count(), 13)
 
     def test_index(self):
         self.assertEqual(self.index.get_model(), SectionParagraph)
-        self.assertEqual(self.index.index_queryset().count(), 6)
+        self.assertEqual(self.index.index_queryset().count(), 13)
         self.assertIs(
             self.index.index_queryset().first().section.subpart.version.draft,
             False)
@@ -35,7 +35,7 @@ class RegulationIndexTestCase(TestCase):
         SectionParagraph.objects.all().delete()
         self.assertEqual(SectionParagraph.objects.count(), 0)
         call_command('update_regulation_index')
-        self.assertEqual(SectionParagraph.objects.count(), 39)
+        self.assertEqual(SectionParagraph.objects.count(), 113)
         self.assertEqual(mock_haystack.call_count, 1)
 
     @mock.patch('regulations3k.management.commands'


### PR DESCRIPTION
regs3k: Update regulation indexing components

This makes minor changes to the indexing routine to better capture
duplicate paragraph IDs, which has proven useful for troubleshooting.

It also makes a minor change in the importer to remove stray line-endings
inside paragraphs caused by how eCFR renders fractions.

## Testing

Using this code, indexing was run against cleaned data on build5, with these results:

```
16849 were created, 0 were unchanged, 0 were deleted, and 0 dupes were found
```

If you run it locally, you shouldn't notice much change, although you should encounter some dupes.


```
./cfgov/manage.py update_regulation_index
```

