### PR TITLE
Upgrade version of owning-a-home-api satellite app

### DIFF
--- a/refresh-data.sh
+++ b/refresh-data.sh
@@ -33,7 +33,7 @@ refresh_data() {
     echo 'Importing refresh db'
     gunzip < "$refresh_dump_name" | cfgov/manage.py dbshell > /dev/null
     echo 'Running any necessary migrations'
-    ./cfgov/manage.py migrate --noinput
+    ./cfgov/manage.py migrate --noinput --fake-initial
     echo 'Setting up initial data'
     ./cfgov/manage.py runscript initial_data
 }

--- a/requirements/optional-public.txt
+++ b/requirements/optional-public.txt
@@ -1,6 +1,6 @@
 https://github.com/cfpb/college-costs/releases/download/2.3.12/college_costs-2.3.12-py2-none-any.whl
 https://github.com/cfpb/complaint/releases/download/1.4.6/complaintdatabase-1.4.6-py2-none-any.whl
-https://github.com/cfpb/owning-a-home-api/releases/download/0.10.4/owning_a_home_api-0.10.4-py2-none-any.whl
+https://github.com/cfpb/owning-a-home-api/releases/download/0.11.0/owning_a_home_api-0.11.0-py2-none-any.whl
 https://github.com/cfpb/regulations-core/releases/download/1.2.6/regcore-1.2.6-py2-none-any.whl
 https://github.com/cfpb/regulations-site/releases/download/2.2.5/regulations-2.2.5-py2-none-any.whl
 https://github.com/cfpb/retirement/releases/download/0.7.0/retirement-0.7.0-py2-none-any.whl


### PR DESCRIPTION
Bump owning-a-home-api to the latest version. This adds django 1.11 compatibility to the satellite app.

Also, modify the `./refresh-data` script to use the `--fake-initial` flag when running migrations. This matches the functionality that already exists in our deploy scripts.

This is necessary because some tables (e.g. the `ratechecker` and `countylimits` tables used in the owning-a-home api) were created outside of django, but we have since updated to track those tables in django-migrations. When the `--fake-initial` flag is present, django will see that the tables already exist and will not try to re-create them, allowing the `refresh-data` script to run without issues.

## Checklist

- [x] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: