### PR TITLE
Fix alignment of multiple choice field labels

### DIFF
--- a/cfgov/templates/wagtailadmin/css/general-enhancements.css
+++ b/cfgov/templates/wagtailadmin/css/general-enhancements.css
@@ -78,3 +78,11 @@ li.sequence-member .sequence-member-inner .sequence-type-list .sequence-member-i
 .sequence-member:first-child > .sequence-member-inner > .field > .field-content {
     padding-top: 1em;
 }
+
+/* Fix alignment of multiple choice field labels */
+.tree_node_multiple_choice_field .input li label {
+    display: block;
+    width: auto;
+    float: none;
+    padding-top: 0;
+}

--- a/cfgov/templates/wagtailadmin/css/general-enhancements.css
+++ b/cfgov/templates/wagtailadmin/css/general-enhancements.css
@@ -79,7 +79,7 @@ li.sequence-member .sequence-member-inner .sequence-type-list .sequence-member-i
     padding-top: 1em;
 }
 
-/* Fix alignment of multiple choice field labels */
+/* Fix alignment of multiple choice field labels used for TDP Activity search child page Topic field */
 .tree_node_multiple_choice_field .input li label {
     display: block;
     width: auto;


### PR DESCRIPTION
Fix alignment of multiple choice field labels.

## Additions

- CSS to fix alignment of multiple choice field labels.

## Testing

1. In the Wagtail admin, create a new page using the TDP Activity search page type.
2. Create a new child page of the newly created TDP Activity search page.
3. Look at the Topic field.

## Screenshots

### Before
![before](https://user-images.githubusercontent.com/135259/43483857-bf9bdbd8-94da-11e8-95a6-16f06681d310.png)

### After
![after](https://user-images.githubusercontent.com/135259/43483875-ca51056c-94da-11e8-9f14-7c82c6df748e.png)

## Notes

- We’re duplicating the following CSS in Wagtail’s core.css to also apply multiple field labels, which I believe come from the `django/mptt` library we recently added for TDP.
```
.choice_field .input li label, 
.model_multiple_choice_field .input li label {
    display: block;
    width: auto;
    float: none;
    padding-top: 0;
}
```

## Review
- @Scotchester 

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [x] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Internet Explorer 8, 9, 10, and 11
- [ ] Edge
- [ ] iOS Safari
- [ ] Chrome for Android

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
