### PR TITLE
Update Regs3K secondary nav expandable

### DIFF
--- a/cfgov/jinja2/v1/_includes/eregs/regulations3k-secondary-navigation.html
+++ b/cfgov/jinja2/v1/_includes/eregs/regulations3k-secondary-navigation.html
@@ -38,7 +38,7 @@
 {% from 'organisms/expandable.html' import expandable with context %}
 <nav class="o-regs3k-navigation o-expandable__padded"
      aria-label="Section navigation">
-    <button class="o-regs3k-navigation_header o-expandable_header o-expandable_target o-expandable_target__collapsed">
+    <button class="o-regs3k-navigation_header o-expandable_header o-expandable_target">
         <span class="h4 o-expandable_header-left o-expandable_label">
             Table of Contents
         </span>
@@ -59,7 +59,7 @@
             </span>
         </span>
     </button>
-    <div class="o-regs3k-sections u-hide-on-stacked">
+    <div class="o-regs3k-sections">
         {% import 'molecules/nav-link.html' as nav_link %}
         {%- for subpart in nav_items %}
             {% set sec_nav_settings = {

--- a/cfgov/jinja2/v1/_includes/eregs/regulations3k-secondary-navigation.html
+++ b/cfgov/jinja2/v1/_includes/eregs/regulations3k-secondary-navigation.html
@@ -35,22 +35,44 @@
 {% if nav_items is not defined and has_children is not defined %}
     {% set nav_items, has_children = get_secondary_nav_items(request, page) %}
 {% endif %}
-<nav class="o-secondary-navigation
-            {{ '' if has_children else 'o-secondary-navigation__no-children' }}"
+{% from 'organisms/expandable.html' import expandable with context %}
+<nav class="o-regs3k-navigation o-expandable__padded"
      aria-label="Section navigation">
-    {% import 'molecules/nav-link.html' as nav_link %}
-    {% from 'organisms/expandable.html' import expandable with context %}
-    {%- for subpart in nav_items %}
-        {% set sec_nav_settings = {
-            'label': subpart.subpart_heading ~ ' ' ~ subpart.title ~ ' ' ~ subpart.section_range|safe,
-            'hide_cue_label': true,
-            'is_expanded': nav_items[subpart].expanded
-        } %}
-        {% call() expandable(sec_nav_settings) %}
-        {% for section in nav_items[subpart].sections %}
-            {{ nav_link.render(section.title, section.url, true, section.active, true) }}
+    <button class="o-regs3k-navigation_header o-expandable_header o-expandable_target o-expandable_target__collapsed">
+        <span class="h4 o-expandable_header-left o-expandable_label">
+            Table of Contents
+        </span>
+        <span class="o-expandable_header-right o-expandable_link">
+            <span class="o-expandable_cue o-expandable_cue-open">
+                <span class="u-visually-hidden">
+                    {{ _('Show') }}
+                    {{ expandable_cue_additional_text }}
+                </span>
+                {{ svg_icon('plus-round') }}
+            </span>
+            <span class="o-expandable_cue o-expandable_cue-close">
+                <span class="u-visually-hidden">
+                    {{ _('Hide') }}
+                    {{ expandable_cue_additional_text }}
+                </span>
+                {{ svg_icon('minus-round') }}
+            </span>
+        </span>
+    </button>
+    <div class="o-regs3k-sections u-hide-on-stacked">
+        {% import 'molecules/nav-link.html' as nav_link %}
+        {%- for subpart in nav_items %}
+            {% set sec_nav_settings = {
+                'label': subpart.subpart_heading ~ ' ' ~ subpart.title ~ ' ' ~ subpart.section_range|safe,
+                'hide_cue_label': true,
+                'is_expanded': nav_items[subpart].expanded
+            } %}
+            {% call() expandable(sec_nav_settings) %}
+            {% for section in nav_items[subpart].sections %}
+                {{ nav_link.render(section.title, section.url, true, section.active, true) }}
+            {%- endfor %}
+            {% endcall %}
         {%- endfor %}
-        {% endcall %}
-    {%- endfor %}
+    </div>
 </nav>
 {% endmacro %}

--- a/cfgov/jinja2/v1/_includes/eregs/regulations3k-side-nav.html
+++ b/cfgov/jinja2/v1/_includes/eregs/regulations3k-side-nav.html
@@ -25,6 +25,8 @@
 
 {# Extra classes needed for .content_sidebar #}
 {% block content_sidebar_modifiers -%}
+    o-regs3k-sidebar
+    content__flush-bottom
     content__flush-top-on-small
     content__flush-sides-on-small
     {{ 'content__half-top-on-desk' if breadcrumb_items | length > 0 else '' }}

--- a/cfgov/jinja2/v1/_includes/organisms/expandable.html
+++ b/cfgov/jinja2/v1/_includes/organisms/expandable.html
@@ -45,14 +45,14 @@
         </span>
         <span class="o-expandable_header-right o-expandable_link">
             <span class="o-expandable_cue o-expandable_cue-open">
-                <span {{ 'class="u-visually-hidden"' if value.hide_cue_label else '' }}>
+                <span {{ 'class=u-visually-hidden' if value.hide_cue_label else '' }}>
                     {{ _('Show') }}
                     {{ expandable_cue_additional_text }}
                 </span>
                 {{ svg_icon('plus-round') }}
             </span>
             <span class="o-expandable_cue o-expandable_cue-close">
-                <span {{ 'class="u-visually-hidden"' if value.hide_cue_label else '' }}>
+                <span {{ 'class=u-visually-hidden' if value.hide_cue_label else '' }}>
                     {{ _('Hide') }}
                     {{ expandable_cue_additional_text }}
                 </span>

--- a/cfgov/jinja2/v1/_includes/organisms/expandable.html
+++ b/cfgov/jinja2/v1/_includes/organisms/expandable.html
@@ -45,13 +45,17 @@
         </span>
         <span class="o-expandable_header-right o-expandable_link">
             <span class="o-expandable_cue o-expandable_cue-open">
-                {{ _('Show') }}
-                {{ expandable_cue_additional_text }}
+                <span {{ 'class="u-visually-hidden"' if value.hide_cue_label else '' }}>
+                    {{ _('Show') }}
+                    {{ expandable_cue_additional_text }}
+                </span>
                 {{ svg_icon('plus-round') }}
             </span>
             <span class="o-expandable_cue o-expandable_cue-close">
-                {{ _('Hide') }}
-                {{ expandable_cue_additional_text }}
+                <span {{ 'class="u-visually-hidden"' if value.hide_cue_label else '' }}>
+                    {{ _('Hide') }}
+                    {{ expandable_cue_additional_text }}
+                </span>
                 {{ svg_icon('minus-round') }}
             </span>
         </span>

--- a/cfgov/unprocessed/apps/regulations3k/css/reg-navigation.less
+++ b/cfgov/unprocessed/apps/regulations3k/css/reg-navigation.less
@@ -16,23 +16,12 @@
 // Regs3K secondary nav sections
 .o-regs3k-sections {
 
-    .o-expandable {
-        margin-bottom: 0;
-    }
-
     .o-expandable_target {
         .respond-to-min( @bp-med-min, {
             display: block;
             padding: unit( ( @grid_gutter-width / 2 ) / @base-font-size-px, em ) 0;
         } );
         border: 0;
-    }
-
-    .o-expandable_label {
-        .heading-4();
-        letter-spacing: inherit;
-        margin-bottom: 0;
-        text-transform: none;
     }
 
     .o-expandable_header {
@@ -77,9 +66,6 @@
 
     .o-regs3k-navigation_header {
         .u-show-on-stacked;
-        .h4 {
-            text-transform: uppercase;
-        }
     }
 
     .o-expandable_header-left {

--- a/cfgov/unprocessed/apps/regulations3k/css/reg-navigation.less
+++ b/cfgov/unprocessed/apps/regulations3k/css/reg-navigation.less
@@ -3,65 +3,128 @@
    Custom eRegs secondary navigation styles
    ========================================================================== */
 
-.o-secondary-navigation {
-    &__no-children {
-        .respond-to-max( @bp-sm-max, {
+// Regs3K sidebar
+.o-regs3k-sidebar {
+    .respond-to-max( @bp-sm-max {
+        background-color: @gray-5;
+        border-bottom: 1px solid @gray-40;
+        border-top: 1px solid @gray-40;
+        margin-bottom: unit( ( @grid_gutter-width / 2 ) / @base-font-size-px, em );
+    } );
+}
+
+// Regs3K secondary nav sections
+.o-regs3k-sections {
+
+    .o-expandable {
+        margin-bottom: 0;
+    }
+
+    .o-expandable_target {
+        .respond-to-min( @bp-med-min, {
+            display: block;
+            padding: unit( ( @grid_gutter-width / 2 ) / @base-font-size-px, em ) 0;
+        } );
+        border: 0;
+    }
+
+    .o-expandable_label {
+        .heading-4();
+        letter-spacing: inherit;
+        margin-bottom: 0;
+        text-transform: none;
+    }
+
+    .o-expandable_header {
+        &-left {
+            width: 88%;
+        }
+        &-left {
+            width: 12%;
+        }
+    }
+
+    .o-expandable_content {
+        padding: 0;
+        .respond-to-min( @bp-med-min, {
+            background: none;
+            border: none;
+        } );
+        &:before {
+            border: 0;
+            padding: 0;
+        }
+    }
+
+    &:before {
+        .respond-to-max( @bp-sm-max {
+            border-bottom: 1px solid @gray-40;
+            content: ' ';
+            margin: 0 15px;
             display: block;
         } );
     }
 
-    // .o-expandable {
-    //     margin-bottom: 0;
-    // }
+}
 
-    // // TODO: If secondary navigation is overriding o-expandables appearance,
-    // //       they aren't atomic expandables anymore per the design spec.
-    // //       Secondary navigation should use FlyoutMenu for expandable-like
-    // //       behavior and handle its own styling
-    // //       (possibly shared with expandables).
-    // .o-expandable_target {
-    //     .respond-to-min( @bp-med-min, {
-    //         display: block;
-    //         padding: unit( ( @grid_gutter-width / 2 ) / @base-font-size-px, em ) 0;
-    //     } );
+// Regs3K secondary nav header
+.o-regs3k-navigation {
 
-    //     border: 0;
-    // }
+    .respond-to-max( @bp-sm-max {
+        padding: unit( 10px / @base-font-size-px, em )
+                 unit( 15px / @base-font-size-px, em );
+    } );
 
-    // .o-expandable_label {
-    //     .heading-4();
-    //     letter-spacing: inherit;
-    //     margin-bottom: 0;
-    //     text-transform: none;
-    // }
+    .o-regs3k-navigation_header {
+        .u-show-on-stacked;
+        .h4 {
+            text-transform: uppercase;
+        }
+    }
 
-    // .o-expandable_header-left {
-    //     width: 88%;
-    // }
+    .o-expandable_header-left {
+        width: 88%;
+    }
 
-    // .o-expandable_header-right {
-    //     width: 12%;
-    // }
-
-    // .o-expandable_content {
-    //     .respond-to-min( @bp-med-min, {
-    //         background: none;
-    //         border: none;
-    //         height: 0 !important;
-    //     } );
-
-    //     &-animated {
-    //         padding: 0;
-    //     }
-    // }
+    .o-expandable_header-right {
+        text-align: right;
+        width: 12%;
+    }
 
 }
 
-// .m-nav-link {
-//     &__parent {
-//         .heading-4();
-//         font-size: 1em;
-//         font-weight: 300;
-//         margin-bottom: 0;
-//     }
-// }
+.m-nav-link {
+
+    color: @pacific;
+
+    &__current {
+        color: @black;
+    }
+
+    &__parent {
+        .heading-4();
+        font-size: 1em;
+        font-weight: 300;
+        margin-bottom: 0;
+    }
+
+}
+
+// Utility methods specific to when regs3k secondary nav
+// is stacked on top of the page's content
+.u-hide-on-stacked {
+
+    .respond-to-max( @bp-sm-max {
+        display: none;
+    } );
+
+}
+
+.u-show-on-stacked {
+
+    display: none;
+    .respond-to-max( @bp-sm-max {
+        display: block;
+    } );
+
+}

--- a/cfgov/unprocessed/apps/regulations3k/css/reg-search.less
+++ b/cfgov/unprocessed/apps/regulations3k/css/reg-search.less
@@ -31,11 +31,16 @@
         border: 1px solid @gray-40;
         background-color: #f7f8f9;
 
-        // .o-expandable_content,
-        // .o-expandable_target {
-        //     border: 0;
-        //     padding: 0;
-        // }
+        .o-expandable_content,
+        .o-expandable_target {
+            border: 0;
+            padding: 0;
+            &:before,
+            &:after {
+                border: 0;
+                padding: 0;
+            }
+        }
 
         .reg-checkbox {
             display: inline-block;
@@ -54,6 +59,9 @@
                 .h4;
                 margin-bottom: 0;
             }
+        }
+        .o-form_group {
+            margin-bottom: 0;
         }
     }
     .content_main {

--- a/cfgov/unprocessed/apps/regulations3k/js/index.js
+++ b/cfgov/unprocessed/apps/regulations3k/js/index.js
@@ -23,7 +23,8 @@ const init = () => {
       console.error( 'Error during service worker registration:', err );
     } );
   }
-  navItems.classList.toggle( 'u-hide-on-stacked' );
+  navHeader.classList.add( 'o-expandable_target__collapsed' );
+  navItems.classList.add( 'u-hide-on-stacked' );
   bindSecondaryNav();
 };
 

--- a/cfgov/unprocessed/apps/regulations3k/js/index.js
+++ b/cfgov/unprocessed/apps/regulations3k/js/index.js
@@ -1,18 +1,32 @@
 import Expandable from 'cf-expandables/src/Expandable';
+import { bindEvent } from '../../../js/modules/util/dom-events';
+import { queryOne as find } from '../../../js/modules/util/dom-traverse';
 
-Expandable.init();
+const navHeader = find( '.o-regs3k-navigation_header' );
+const navItems = find( '.o-regs3k-sections' );
 
-if ( 'serviceWorker' in navigator ) {
-  /* Delay registration until after the page has loaded, to ensure that our
-     precaching requests don't degrade the first visit experience.
-     See https://developers.google.com/web/fundamentals/instant-and-offline/service-worker/registration */
-  window.addEventListener( 'load', () => {
-    /* Your service-worker.js *must* be located at the top-level directory relative to your site.
-       It won't be able to control pages unless it's located at the same level or higher than them.
-       *Don't* register service worker file in, e.g., a scripts/ sub-directory!
-       See https://github.com/slightlyoff/ServiceWorker/issues/468 */
+const toggleSecondaryNav = () => {
+  navHeader.classList.toggle( 'o-expandable_target__collapsed' );
+  navHeader.classList.toggle( 'o-expandable_target__expanded' );
+  navItems.classList.toggle( 'u-hide-on-stacked' );
+};
+
+const bindSecondaryNav = () => {
+  bindEvent( navHeader, {
+    click: toggleSecondaryNav
+  } );
+};
+
+const init = () => {
+  if ( 'serviceWorker' in navigator ) {
     navigator.serviceWorker.register( '/regulations3k-service-worker.js' ).catch( err => {
       console.error( 'Error during service worker registration:', err );
     } );
-  } );
-}
+  }
+  navItems.classList.toggle( 'u-hide-on-stacked' );
+  bindSecondaryNav();
+};
+
+Expandable.init();
+
+window.addEventListener( 'load', init );


### PR DESCRIPTION
@jimmynotjim This adds the specific Regs3K secondary nav expandables functionality that we discussed yesterday. The changes below only affect Regs3K pages with the exception of the `hide_cue_label` option that I added to the expandable organism.

Instead of nesting expandables I faked it by having the outer container just show/hide the inner expandables when clicked.

I didn't want to push directly to your branch so this is a PR for your PR #4365.

![localhost_8000_policy-compliance_rulemaking_regulations_1002_a_ pixel 2 xl](https://user-images.githubusercontent.com/1060248/43508476-02d68dfe-953e-11e8-990e-ad258e77a27f.png)
