### PR TITLE
Remove unused reference

### DIFF
--- a/gulp/tasks/audit.js
+++ b/gulp/tasks/audit.js
@@ -3,7 +3,6 @@ const fancyLog = require( 'fancy-log' );
 const fs = require( 'fs' );
 const fsHelper = require( '../utils/fs-helper' );
 const gulp = require( 'gulp' );
-const lighthouse = require( 'lighthouse' );
 const minimist = require( 'minimist' );
 const spawn = require( 'child_process' ).spawn;
 


### PR DESCRIPTION
Lighthouse module is run from within node_modules, so the module doesn't need to be referenced in the audit script.

## Removals

- Removes unused reference to `lighthouse` module.

## Testing

1. `gulp audit:perf` should run.
