### PR TITLE
Regulations 3000: Enforce using the default block renderer in regdown/resolver tests

### DIFF
--- a/cfgov/regulations3k/regdown.py
+++ b/cfgov/regulations3k/regdown.py
@@ -84,23 +84,28 @@ STRONG_EM_RE = r'(\*)\2{2}(.+?)\2{2}(.*?)\2'
 PSEUDO_FORM_RE = r'(?P<underscores>_{2,50})(?P<line_ending>\s*$)?'
 
 
+DEFAULT_URL_RESOLVER = lambda l: ''
+DEFAULT_CONTENTS_RESOLVER = lambda l: ''
+DEFAULT_RENDER_BLOCK_REFERENCE = lambda c, **kwargs: \
+    '<blockquote>{}</blockquote>'.format(regdown(c))
+
+
 class RegulationsExtension(Extension):
 
     config = {
         'url_resolver': [
-            lambda l: '',
+            DEFAULT_URL_RESOLVER,
             'Function to resolve the URL of a reference. '
             'Should return (title, url).'
         ],
         'contents_resolver': [
-            lambda l: '',
+            DEFAULT_CONTENTS_RESOLVER,
             'Function to resolve the contents of a reference. '
             'Should return markdown contents of the reference or an empty '
             'string.'
         ],
         'render_block_reference': [
-            lambda c, **kwargs: '<blockquote>{}</blockquote>'.format(
-                regdown(c)),
+            DEFAULT_RENDER_BLOCK_REFERENCE,
             'Function that will render a block reference'
         ],
     }

--- a/cfgov/regulations3k/tests/test_regdown.py
+++ b/cfgov/regulations3k/tests/test_regdown.py
@@ -5,7 +5,9 @@ import unittest
 
 import markdown
 
-from regulations3k.regdown import extract_labeled_paragraph, regdown
+from regulations3k.regdown import (
+    DEFAULT_RENDER_BLOCK_REFERENCE, extract_labeled_paragraph, regdown
+)
 
 
 class RegulationsExtensionTestCase(unittest.TestCase):
@@ -182,7 +184,14 @@ class RegulationsExtensionTestCase(unittest.TestCase):
 
     def test_block_reference_resolver_not_callable(self):
         text = 'see(foo-bar)'
-        self.assertEqual(regdown(text, contents_resolver=None), '')
+        self.assertEqual(
+            regdown(
+                text,
+                contents_resolver=None,
+                render_block_reference=DEFAULT_RENDER_BLOCK_REFERENCE
+            ),
+            ''
+        )
 
     def test_block_reference_renderer_not_callable(self):
         text = 'see(foo-bar)'
@@ -192,21 +201,23 @@ class RegulationsExtensionTestCase(unittest.TestCase):
         contents_resolver = lambda l: ''
         text = 'see(foo-bar)'
         self.assertEqual(
-            regdown(text, contents_resolver=contents_resolver),
+            regdown(
+                text,
+                contents_resolver=contents_resolver,
+                render_block_reference=DEFAULT_RENDER_BLOCK_REFERENCE
+            ),
             ''
         )
 
     def test_block_reference(self):
         contents_resolver = lambda l: '{foo-bar}\n# §FooBar\n\n'
-        render_block_reference = lambda c, **kwargs: \
-            '<blockquote>{}</blockquote>'.format(regdown(c))
         text = 'see(foo-bar)'
         self.assertIn(
             '<h1>§FooBar</h1>',
             regdown(
                 text,
                 contents_resolver=contents_resolver,
-                render_block_reference=render_block_reference
+                render_block_reference=DEFAULT_RENDER_BLOCK_REFERENCE
             )
         )
 

--- a/cfgov/regulations3k/tests/test_resolver.py
+++ b/cfgov/regulations3k/tests/test_resolver.py
@@ -11,7 +11,7 @@ from regulations3k.models import (
     EffectiveVersion, Part, RegulationLandingPage, RegulationPage, Section,
     Subpart
 )
-from regulations3k.regdown import regdown
+from regulations3k.regdown import DEFAULT_RENDER_BLOCK_REFERENCE, regdown
 from regulations3k.resolver import (
     get_contents_resolver, get_url_resolver, resolve_reference
 )
@@ -102,14 +102,20 @@ class ReferenceResolutionTestCase(TestCase):
 
     def test_get_contents_resolver(self):
         contents_resolver = get_contents_resolver(self.reg_page)
-        result = regdown(self.section_2.contents,
-                         contents_resolver=contents_resolver)
+        result = regdown(
+            self.section_2.contents,
+            contents_resolver=contents_resolver,
+            render_block_reference=DEFAULT_RENDER_BLOCK_REFERENCE
+        )
         self.assertIn('Interpreting adverse action', result)
 
     def test_get_contents_resolver_reference_doesnt_exist(self):
         contents_resolver = get_contents_resolver(self.reg_page)
-        result = regdown(self.section_3.contents,
-                         contents_resolver=contents_resolver)
+        result = regdown(
+            self.section_3.contents,
+            contents_resolver=contents_resolver,
+            render_block_reference=DEFAULT_RENDER_BLOCK_REFERENCE
+        )
         self.assertEqual(
             result,
             '<p class="regdown-block level-0" id="b">Securities credit.</p>'


### PR DESCRIPTION
There doesn't seem to be a clean way to clear markdown extension config options in between tests, so this change is to always use the default block renderer (instead of another custom one) in all tests when testing things that are not the block renderer support.

This should stop some inconsistent test failures we were seeing in the resolver tests (the ultimate cause of those failures is still something I'm troubleshooting, but new tests should be written to test for that).