### PR TITLE
Regs3k: Fix reference to more regs link

### DIFF
--- a/cfgov/regulations3k/jinja2/regulations3k/regulations-listing.html
+++ b/cfgov/regulations3k/jinja2/regulations3k/regulations-listing.html
@@ -12,7 +12,7 @@
 
    heading:        The heading of the regulations list.
 
-   more_regs_url:  A string for the URL of the more regulations link.
+   more_regs_page: A Wagtail page to link to in the more regulations link.
 
    more_regs_text: A string for the text of the more regulations link.
 
@@ -22,7 +22,7 @@
     <tbody>
         <tr>
             <td>
-                <h4>{{ heading or 'Table of contents' }}</h4>
+                <h4>{{ value.heading or 'Table of contents' }}</h4>
             </td>
         </tr>
 
@@ -47,5 +47,5 @@
 </table>
 {% endif %}
 <p>
-    <a class="" href="{{ get_protected_url(more_regs_url) }}">{{ more_regs_text or 'View more CFPB regulations' }}</a>
+    <a class="" href="{{ pageurl(value.more_regs_page) }}">{{ value.more_regs_text or 'View more CFPB regulations' }}</a>
 </p>

--- a/cfgov/regulations3k/tests/test_blocks.py
+++ b/cfgov/regulations3k/tests/test_blocks.py
@@ -2,9 +2,10 @@ from __future__ import unicode_literals
 
 import datetime
 
-from django.test import Client, TestCase, override_settings
+from django.test import TestCase, override_settings
 
 from wagtail.wagtailcore.blocks import StreamValue
+from wagtail.wagtailcore.models import Page
 
 from model_mommy import mommy
 
@@ -48,11 +49,13 @@ class RegulationsListTestCase(TestCase):
         self.landing_page.save_revision().publish()
         self.reg_page.save_revision().publish()
 
-        self.client = Client()
+        self.more_regs_page = Page.objects.first()
 
     def test_regulations_list_has_regs(self):
         block = RegulationsList()
-        result = block.render(block.to_python({}))
+        result = block.render(block.to_python({
+            'more_regs_page': self.more_regs_page.pk,
+        }))
         self.assertIn('Reg B', result)
         self.assertIn('/regulations/1002/', result)
 
@@ -70,7 +73,8 @@ class RegulationsListTestCase(TestCase):
                         'type': 'regulations_list',
                         'value': {
                             'body': 'this is a quote',
-                            'citation': 'a citation'
+                            'citation': 'a citation',
+                            'more_regs_page': self.more_regs_page.pk,
                         }
                     },
                 ]


### PR DESCRIPTION
The changes in #4395 added a new `RegulationsList` block that included a `more_regs_page` field that can be used to select a Wagtail page to link to for a full set of regulations. The template for the block erroneously refers to `more_regs_url`.

This commit fixes that error and properly provides a value for the page for the existing unit tests. It also fixes the block template to properly refer to block fields using `value.attribute`. See Wagtail
documentation here:

http://docs.wagtail.io/en/v2.1.1/topics/streamfield.html#template-rendering

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [X] Passes all existing automated tests
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [X] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: