### PR TITLE
Fix expandable cue label

### DIFF
--- a/cfgov/jinja2/v1/_includes/organisms/expandable.html
+++ b/cfgov/jinja2/v1/_includes/organisms/expandable.html
@@ -54,7 +54,7 @@
             </span>
             <span class="o-expandable_cue o-expandable_cue-close">
                 <span class="u-visually-hidden-on-mobile
-                             {{ 'class=u-visually-hidden' if value.hide_cue_label else '' }}">
+                             {{ 'u-visually-hidden' if value.hide_cue_label else '' }}">
                     {{ _('Hide') }}
                     {{ expandable_cue_additional_text }}
                 </span>


### PR DESCRIPTION
Found a typo from yesterday's big expandables PR. The current code erroneously results in `<span class="u-visually-hidden-on-mobile class=u-visually-hidden">`.

## Changes

- Fix `value.hide_cue_label` output.

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
