### PR TITLE
Add request context processor to Jinja2 engine

### DIFF
--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -152,6 +152,9 @@ TEMPLATES = [
         ],
         'APP_DIRS': True,
         'OPTIONS': {
+            'context_processors': [
+                'django.template.context_processors.request',
+            ],
             'environment': 'v1.environment',
             'extensions': [
                 'core.jinja2tags.filters',


### PR DESCRIPTION
@willbarton says this is needed to fix cfpb/wagtail-flags#30.

## Additions

- `django.template.context_processors.request` added to Jinja2's `OPTIONS['context_processors']`

## Testing

1. Pull branch
1. ???
1. Profit!!

## Notes
- I suppose I might be able to test this by trying to reimplement the flag that caused the issue in the first place. I'll try that tomorrow if I can find the time.

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: