### PR TITLE
Update webpack-config.js

### DIFF
--- a/config/webpack-config.js
+++ b/config/webpack-config.js
@@ -20,9 +20,9 @@ const COMMON_MODULE_CONFIG = {
     exclude: {
       test: /node_modules/,
 
-      /* The below regex will capture all node modules that start with `cf`
-        or atomic-component. Regex test: https://regex101.com/r/zizz3V/1/. */
-      exclude: /node_modules\/(?:cf.+|atomic-component)/
+      /* The below regex will capture all node modules that start with `cf-`.
+        Regex test: https://regex101.com/r/zizz3V/3. */
+      exclude: /node_modules\/(?:cf-.+)/
     },
     use: {
       loader: 'babel-loader?cacheDirectory=true',


### PR DESCRIPTION
atomic-component has been moved into Capital Framework under cf-atomic-component, so we no longer have to filter it out.

## Changes

- Changes exclusion regex to search for modules with `cf-` and removes search for `atomic-component`.

## Testing

1. `./frontend.sh` should pass.
