### PR TITLE
Add govdelivery to CSP allow list

### DIFF
--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -553,6 +553,7 @@ CSP_CONNECT_SRC = ("'self'",
                    'bam.nr-data.net',
                    'files.consumerfinance.gov',
                    's3.amazonaws.com',
+                   'public.govdelivery.com',
                    'api.iperceptions.com')
 
 # Feature flags
@@ -714,7 +715,7 @@ else:
         'default_fragment_cache': {
             'BACKEND': 'django.core.cache.backends.dummy.DummyCache',
             'TIMEOUT': 0,
-        } 
+        }
     }
 
 PARSE_LINKS_BLACKLIST = [


### PR DESCRIPTION
Currently, an email signup breaks silently because the request to GovDelivery is blocked by CSP. This should fix that by adding the domain to the CSP list.

## Additions

- Adds `public.govdelivery.com` to CSP connect list

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [x] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
