### PR TITLE
Fix `parse_links` middleware so that Python 3 tests pass

### DIFF
--- a/cfgov/core/middleware.py
+++ b/cfgov/core/middleware.py
@@ -26,8 +26,12 @@ def should_parse_links(request_path, content_type):
     return True
 
 
-def parse_links(html):
+def parse_links(html, encoding=None):
     """Process all links in given html and replace them if markup is added."""
+    if encoding is None:
+        encoding = settings.DEFAULT_CHARSET
+    html = html.decode(encoding)
+
     soup = BeautifulSoup(html, 'html.parser')
     link_tags = get_link_tags(soup)
     for tag in link_tags:
@@ -35,11 +39,15 @@ def parse_links(html):
         link_with_markup = add_link_markup(tag)
         if link_with_markup:
             html = html.replace(original_link, link_with_markup)
-    return html
+
+    return html.encode(encoding)
 
 
 class ParseLinksMiddleware(object):
     def process_response(self, request, response):
         if should_parse_links(request.path, response['content-type']):
-            response.content = parse_links(response.content)
+            response.content = parse_links(
+                response.content,
+                encoding=response.charset
+            )
         return response

--- a/cfgov/core/middleware.py
+++ b/cfgov/core/middleware.py
@@ -1,3 +1,5 @@
+from six import text_type as str
+
 from django.conf import settings
 
 from bs4 import BeautifulSoup

--- a/cfgov/core/tests/test_management_inactive_users.py
+++ b/cfgov/core/tests/test_management_inactive_users.py
@@ -1,8 +1,9 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
+import six
 from datetime import timedelta
-from StringIO import StringIO
+from six.moves import cStringIO as StringIO
 
 from django.contrib.auth import get_user_model
 from django.core import mail
@@ -55,7 +56,10 @@ class InactiveUsersTestCase(TestCase):
         self.stdout = StringIO()
 
     def get_stdout(self):
-        return self.stdout.getvalue().decode('utf-8')
+        if six.PY2:  # pragma: no cover
+            return self.stdout.getvalue().decode('utf-8')
+        else:  # pragma: no cover
+            return self.stdout.getvalue()
 
     def test_format_inactive_users_last_login(self):
         short_date = date_format(self.user_1.last_login,

--- a/cfgov/core/tests/test_middleware.py
+++ b/cfgov/core/tests/test_middleware.py
@@ -10,7 +10,7 @@ class TestParseLinksMiddleware(TestCase):
     def test_parse_links_gets_called(self, mock_parse_links):
         """Middleware correctly invokes parse links when rendering webpage"""
         response = self.client.get('/foo/bar')
-        mock_parse_links.assert_called_with(response.content)
+        mock_parse_links.assert_called_with(response.content, encoding='utf-8')
 
     @override_settings(PARSE_LINKS_BLACKLIST=['/foo/'])
     @mock.patch('core.middleware.parse_links')
@@ -37,38 +37,40 @@ class TestShouldParseLinks(TestCase):
 class TestParseLinks(TestCase):
     def test_relative_link_remains_unmodified(self):
         self.assertEqual(
-            parse_links('<a href="/something">text</a>'),
-            '<a href="/something">text</a>'
+            parse_links(b'<a href="/something">text</a>'),
+            b'<a href="/something">text</a>'
         )
 
     def test_non_gov_link(self):
         """Non gov links get external link icon and redirect."""
-        link = '<a href="https://wwww.google.com">external link</a>'
+        link = b'<a href="https://wwww.google.com">external link</a>'
         output = parse_links(link)
-        self.assertIn('external-site', output)
-        self.assertIn('cf-icon-svg', output)
+        self.assertIn(b'external-site', output)
+        self.assertIn(b'cf-icon-svg', output)
 
     def test_gov_link(self):
         """Gov links get external link icon but not redirect."""
-        link = '<a href="https://www.fdic.gov/bar">gov link</a>'
+        link = b'<a href="https://www.fdic.gov/bar">gov link</a>'
         output = parse_links(link)
-        self.assertIn('cf-icon-svg', output)
+        self.assertIn(b'cf-icon-svg', output)
 
     def test_internal_link(self):
         """Internal links get neither icon nor redirect."""
-        link = '<a href="https://www.consumerfinance.gov/foo">cfpb link</a>'
+        link = b'<a href="https://www.consumerfinance.gov/foo">cfpb link</a>'
         output = parse_links(link)
-        self.assertNotIn('external-site', output)
-        self.assertNotIn('cf-icon-svg', output)
+        self.assertNotIn(b'external-site', output)
+        self.assertNotIn(b'cf-icon-svg', output)
 
     def test_files_get_download_icon(self):
         file_types = ['pdf', 'doc', 'docx', 'xls', 'xlsx', 'csv', 'zip']
         for file_type in file_types:
-            link = '<a href="/something.{}">link</a>'.format(file_type)
+            link = '<a href="/something.{}">link</a>'.format(
+                file_type
+            ).encode('utf-8')
             output = parse_links(link)
-            self.assertIn('cf-icon-svg', output)
+            self.assertIn(b'cf-icon-svg', output)
 
     def test_different_case_pdf_link_gets_download_icon(self):
-        link = '<a href="/something.PDF">link</a>'
+        link = b'<a href="/something.PDF">link</a>'
         output = parse_links(link)
-        self.assertIn('cf-icon-svg', output)
+        self.assertIn(b'cf-icon-svg', output)

--- a/cfgov/core/tests/test_missing_migrations.py
+++ b/cfgov/core/tests/test_missing_migrations.py
@@ -1,4 +1,4 @@
-from cStringIO import StringIO
+from six.moves import cStringIO as StringIO
 
 from django.test import TestCase
 

--- a/cfgov/core/tests/test_views.py
+++ b/cfgov/core/tests/test_views.py
@@ -1,6 +1,6 @@
 import json
 import re
-from urllib import urlencode
+from six.moves.urllib.parse import urlencode
 
 from django.core.urlresolvers import reverse
 from django.http import Http404, QueryDict

--- a/cfgov/core/utils.py
+++ b/cfgov/core/utils.py
@@ -1,4 +1,5 @@
 import re
+from six import text_type as str
 from six.moves.urllib.parse import parse_qs, urlencode, urlparse
 
 from django.core.signing import Signer


### PR DESCRIPTION
The `parse_links` updates introduced some test failures when running the tests on Python 3 because of `bytes`/`str` differences in Python 2 and 3 (Django's `response.content` is `bytes` on Python 3). Because `parse_links` is done in middleware now this caused unrelated tests that use the Django test client to fail on Python 3 (like `regulations3k`, where @higs4281 and I have been trying to maintain Python 3-compatibility). This PR fixes that by decoding/encoding the `response.content` using the `response.charset`.

While I was in `cfgov/core`, I also updated the rest of the tests that were failing on Python 3 so that they will pass too, to get one more corner of cfgov-refresh ready for the inevitable.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
