### PR TITLE
Make regulations3k a required Django app

### DIFF
--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -82,6 +82,8 @@ INSTALLED_APPS = (
     'jobmanager',
     'wellbeing',
     'search',
+    'regulations3k',
+    'treemodeladmin',
 )
 
 OPTIONAL_APPS = [
@@ -95,7 +97,6 @@ OPTIONAL_APPS = [
     {'import': 'countylimits', 'apps': ('countylimits', 'rest_framework')},
     {'import': 'regcore', 'apps': ('regcore', 'regcore_read')},
     {'import': 'regulations', 'apps': ('regulations',)},
-    {'import': 'regulations3k', 'apps': ('regulations3k', 'treemodeladmin')},
     {'import': 'complaint_search', 'apps': ('complaint_search', 'rest_framework')},
     {'import': 'ccdb5_ui', 'apps': ('ccdb5_ui', )},
     {'import': 'teachers_digital_platform', 'apps': ('teachers_digital_platform', 'mptt', 'haystack')},


### PR DESCRIPTION
The `regulations3k` app is part of this repository and so is not optional. Its dependency `treemodeladmin` is also not optional. This change moves these apps into `settings.INSTALLED_APPS`.

In future it would be nice to more properly sort and order the list of apps, but I have kept the scope of this PR as small as possible.

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [X] Passes all existing automated tests
- [X] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: