### PR TITLE
Fix fragment cache unit test

### DIFF
--- a/cfgov/v1/tests/test_fragment_cache_extension.py
+++ b/cfgov/v1/tests/test_fragment_cache_extension.py
@@ -13,13 +13,8 @@ from v1.tests.wagtail_pages.helpers import (
 )
 
 
-django_client = Client()
-cache = caches['post_preview']
-
 class TestFragmentCacheExtension(TestCase):
-
-    @patch.object(cache, 'add')
-    def test_cache_gets_called_when_visiting_filterable_page(self, add_to_cache):
+    def test_cache_gets_called_when_visiting_filterable_page(self):
         # Create a filterable page
         page = BrowseFilterablePage(
             title='test browse filterable page',
@@ -39,7 +34,9 @@ class TestFragmentCacheExtension(TestCase):
         )
         page.add_child(instance=child_page)
 
-        # Navigate to the filterable page so that `post-preview.html` loads
-        django_client.get('/test-browse-filterable-page/')
+        cache = caches['post_preview']
+        with patch.object(cache, 'add') as add_to_cache:
+            # Navigate to the filterable page so that `post-preview.html` loads
+            self.client.get('/test-browse-filterable-page/')
 
-        self.assertTrue(add_to_cache.called)
+            self.assertTrue(add_to_cache.called)


### PR DESCRIPTION
This change fixes the unit test `v1.tests.test_fragment_cache_extension.TestFragmentCacheExtension.test_cache_gets_called_when_visiting_filterable_page`.

For some reason defining the cache outside of the test case can sometimes cause the mock to not work as expected if the unit tests are run in a certain order.

Defining the cache inside the test does work - this might be because if defined outside the cache gets accessed at module import time, but I'm not sure why this would cause mocking to work differently.

Either way this change makes the tests work in any order.

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [X] Passes all existing automated tests
- [X] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: