### PR TITLE
Stop overwriting when uploading files to S3 that already exist

### DIFF
--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -387,6 +387,7 @@ AWS_S3_CALLING_FORMAT = 'boto.s3.connection.OrdinaryCallingFormat'
 AWS_S3_ROOT = os.environ.get('AWS_S3_ROOT', 'f')
 AWS_S3_SECURE_URLS = True  # True = use https; False = use http
 AWS_STORAGE_BUCKET_NAME = os.environ.get('AWS_STORAGE_BUCKET_NAME')
+AWS_S3_FILE_OVERWRITE = False
 
 if os.environ.get('S3_ENABLED', 'False') == 'True':
     DEFAULT_FILE_STORAGE = 'v1.s3utils.MediaRootS3BotoStorage'

--- a/cfgov/v1/tests/views/test_documents.py
+++ b/cfgov/v1/tests/views/test_documents.py
@@ -1,11 +1,9 @@
 from django.core.files.base import ContentFile
 from django.core.urlresolvers import resolve, reverse
-from django.http import Http404
-from django.test import TestCase, override_settings
+from django.http import Http404, StreamingHttpResponse
+from django.test import RequestFactory, TestCase, override_settings
 
 from wagtail.wagtaildocs.models import get_document_model
-
-from mock import Mock, patch
 
 from v1.views.documents import DocumentServeView
 
@@ -13,46 +11,38 @@ from v1.views.documents import DocumentServeView
 def create_document(filename):
     Document = get_document_model()
     document = Document(title='Test document')
-    document.file.save(filename, ContentFile('Some content'))
+    document.file.save(filename, ContentFile('Test content'))
     return document
 
 
 class ServeViewTestCase(TestCase):
     def setUp(self):
         self.view = DocumentServeView()
-        self.request = Mock()
+        self.request = RequestFactory().get('/')
 
-    def test_local_document_uses_wagtail_serve(self):
-        filename = 'test.txt'
-        doc = create_document(filename)
+    def test_local_document_returns_file_contents(self):
+        doc = create_document('test.txt')
+        response = self.view.get(self.request, doc.pk, doc.filename)
+        self.assertEqual(response.status_code, 200)
+        self.assertIsInstance(response, StreamingHttpResponse)
+        self.assertEqual(''.join(response.streaming_content), 'Test content')
 
-        with patch('v1.views.documents.wagtail_serve') as p:
-            self.view.get(self.request, doc.pk, filename)
-            p.assert_called_once_with(self.request, doc.pk, filename)
-
-    @override_settings(
-        AWS_QUERYSTRING_AUTH=False,
-        AWS_STORAGE_BUCKET_NAME='test_s3_bucket',
-        AWS_S3_CALLING_FORMAT='boto.s3.connection.OrdinaryCallingFormat',
-        AWS_S3_SECURE_URLS=True,
-        DEFAULT_FILE_STORAGE='v1.s3utils.MediaRootS3BotoStorage',
-        MEDIA_URL='https://test.s3.amazonaws.com/f/',
-        AWS_S3_ACCESS_KEY_ID='test-access-key',
-        AWS_S3_SECRET_ACCESS_KEY='test-secret-access-key'
-    )
-    def test_document_serve_view_s3(self):
-        filename = 'test.txt'
-        with patch(
-            'storages.backends.s3boto.S3BotoStorage._save',
-            return_value=filename
-        ):
-            doc = create_document(filename)
-
-        response = self.view.get(self.request, doc.pk, filename)
+    @override_settings(DEFAULT_FILE_STORAGE=(
+        'wagtail.tests.dummy_external_storage.DummyExternalStorage'
+    ))
+    def test_external_document_uses_redirect(self):
+        doc = create_document('test.txt')
+        response = self.view.get(self.request, doc.pk, doc.filename)
         self.assertEqual(response.status_code, 302)
-        self.assertEqual(
+
+        # The redirect URL may or may not alter the original filename
+        # depending on what else is stored in the dummy storage. If a file
+        # named test.txt already exists, the filename will get 7 random
+        # alphanumeric characters appended. See Django docs:
+        # https://docs.djangoproject.com/en/2.1/howto/custom-file-storage/#django.core.files.storage.get_available_name
+        self.assertRegexpMatches(
             response['Location'],
-            'https://s3.amazonaws.com/test_s3_bucket/f/test.txt'
+            '/test(_[a-zA-Z0-9]{7})?.txt$'
         )
 
     def test_missing_document_returns_404(self):


### PR DESCRIPTION
Per decision in GHE/CFGOV/platform/issues/2750, we will no longer (theoretically) allow files to overwrite files of the same name when being uploaded to S3 via Wagtail's Documents and Image libraries. (This has been broken since the upgrade to 1.13, anyway.)

## Additions

- Django setting of `AWS_S3_FILE_OVERWRITE = False`

## Testing

Not 100% sure how to test this, but I think @chosak knows how.

## Todos

- [x] Send out notice to all Wagtail content editors that if they need to re-upload a document, they must go through D&D to do it.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [x] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: