### PR TITLE
Regs3k: Use flag to disable URLs in production

### DIFF
--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -655,7 +655,7 @@ FLAGS = {
     # Ping google on page publication in production only
     'PING_GOOGLE_ON_PUBLISH': {'environment is': 'production'},
 
-    'REGULATIONS3K': {'environment is': 'build'},
+    'REGULATIONS3K': {},
 
     'LEGACY_HUD_API': {'environment is': 'production'},
 

--- a/cfgov/cfgov/urls.py
+++ b/cfgov/cfgov/urls.py
@@ -7,6 +7,7 @@ from django.contrib import admin
 from django.contrib.auth import views as auth_views
 from django.http import HttpResponse
 from django.shortcuts import render
+from django.views.defaults import page_not_found
 from django.views.generic.base import RedirectView, TemplateView
 
 from wagtail.contrib.wagtailsitemaps.views import sitemap
@@ -404,10 +405,9 @@ urlpatterns = [
 
     flagged_url(
         'REGULATIONS3K',
-        r'^regulations/$',
+        r'^policy-compliance/rulemaking/regulations/',
         lambda request: ServeView.as_view()(request, request.path),
-        fallback=RedirectView.as_view(
-            url='/policy-compliance/rulemaking/', permanent=False),
+        fallback=page_not_found,
         name='regulations'
     ),
     flagged_url(


### PR DESCRIPTION
This removes the settings condition from the REGULATIONS3K flag so that
it can be flipped on by environment via the admin.

The plan is that we can use `environment is not` ... `production` to allow
regs3k URLs to be active on dev servers and on Beta, for user testing and
for a pilot run of the new app. But the flagged URL will return 404
on production for any regs3k page.

## Testing

You can test this locally by using the Wagtail admin to add the 'environment is not' ... 'production'
condition to the REGULATIONS3K flag. This should allow the regs3k pages
to render locally (unless you have a local evironment variable set to
`DEPLOY_ENVIRONMENT=production`).

Set or unset the flag and visit:

<http://localhost:8000/policy-compliance/rulemaking/regulations/>

If you add no flag, the pages should also return 404.

## Notes
- I removed the `$` from the URL conf so that any downstream pages will also 404.
- We recently changed our flag libraries, so you may need to update requirements with:

```
pip install -r requirements/local.txt
```


