### PR TITLE
Regs3K: Add recent notices to landing page

### DIFF
--- a/cfgov/regulations3k/jinja2/regulations3k/landing-page.html
+++ b/cfgov/regulations3k/jinja2/regulations3k/landing-page.html
@@ -2,6 +2,7 @@
 
 {% import 'templates/streamfield-sidefoot.html' as streamfield_sidefoot with context %}
 {% import 'templates/render_block.html' as render_block with context %}
+{% import 'recent-notices.html' as recent_notices with context %}
 
 {# HEAD items #}
 
@@ -44,6 +45,7 @@
 {%- endblock %}
 
 {% block content_sidebar scoped -%}
+    {{ recent_notices }}
     {{ streamfield_sidefoot.render(page.sidefoot) }}
 {%- endblock %}
 
@@ -54,7 +56,8 @@
         !function(){
           {# Include site-wide JavaScript. #}
           var s = [
-            '{{ static('apps/regulations3k/js/index.js') }}'
+            '{{ static('apps/regulations3k/js/index.js') }}',
+            '{{ static('apps/regulations3k/js/recent-notices.js') }}'
           ];
           jsl(s);
         }()

--- a/cfgov/regulations3k/jinja2/regulations3k/recent-notices.html
+++ b/cfgov/regulations3k/jinja2/regulations3k/recent-notices.html
@@ -1,0 +1,14 @@
+<div class="block block__flush-top">
+    <div class="m-related-links">
+        <header class="m-slug-header">
+            <h2 class="a-heading">
+                Recently issued notices
+            </h2>
+        </header>
+        <ul class="m-list m-list__links" id="regs3k-notices">
+            <li class="m-list_item">
+                <a href="https://www.federalregister.gov/agencies/consumer-financial-protection-bureau" class="m-list_link">View all recent BCFP notices</a>
+            </li>
+        </ul>
+    </div>
+</div>

--- a/cfgov/regulations3k/tests/test_models.py
+++ b/cfgov/regulations3k/tests/test_models.py
@@ -377,6 +377,30 @@ class RegModelTests(DjangoTestCase):
             ]
         )
 
+    @mock.patch('regulations3k.models.pages.requests.get')
+    def test_landing_page_recent_notices(self, mock_requests_get):
+        mock_response = mock.Mock()
+        mock_response.json.return_value = {'some': 'json'}
+        mock_response.status_code = 200
+        mock_requests_get.return_value = mock_response
+        response = self.client.get(
+            self.landing_page.url +
+            self.landing_page.reverse_subpage('recent_notices')
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.content, '{"some": "json"}')
+
+    @mock.patch('regulations3k.models.pages.requests.get')
+    def test_landing_page_recent_notices_error(self, mock_requests_get):
+        mock_response = mock.Mock()
+        mock_response.status_code = 500
+        mock_requests_get.return_value = mock_response
+        response = self.client.get(
+            self.landing_page.url +
+            self.landing_page.reverse_subpage('recent_notices')
+        )
+        self.assertEqual(response.status_code, 500)
+
 
 class SectionNavTests(unittest.TestCase):
 

--- a/cfgov/unprocessed/apps/regulations3k/js/index.js
+++ b/cfgov/unprocessed/apps/regulations3k/js/index.js
@@ -23,9 +23,11 @@ const init = () => {
       console.error( 'Error during service worker registration:', err );
     } );
   }
-  navHeader.classList.add( 'o-expandable_target__collapsed' );
-  navItems.classList.add( 'u-hide-on-stacked' );
-  bindSecondaryNav();
+  if ( navHeader ) {
+    navHeader.classList.add( 'o-expandable_target__collapsed' );
+    navItems.classList.add( 'u-hide-on-stacked' );
+    bindSecondaryNav();
+  }
 };
 
 Expandable.init();

--- a/cfgov/unprocessed/apps/regulations3k/js/recent-notices.js
+++ b/cfgov/unprocessed/apps/regulations3k/js/recent-notices.js
@@ -1,0 +1,49 @@
+import { fetch } from './regs3k-utils';
+import { queryOne as find } from '../../../js/modules/util/dom-traverse';
+
+const NOTICES_URL = './recent-notices-json';
+const CFPB_NOTICES = 'https://www.federalregister.gov/agencies/consumer-financial-protection-bureau';
+
+const processNotice = notice => {
+  const a = document.createElement( 'a' );
+  const li = document.createElement( 'li' );
+  a.href = encodeURI( notice.html_url );
+  a.textContent = notice.title;
+  li.className = 'm-list_link';
+  li.appendChild( a );
+  return li;
+};
+
+const processNotices = notices => {
+  const html = document.createDocumentFragment();
+  const lastNotice = {
+    html_url: CFPB_NOTICES,
+    title: 'More BCFP notices'
+  };
+  notices.forEach( notice => {
+    html.appendChild( processNotice( notice ) );
+  } );
+  html.appendChild( processNotice( lastNotice ) );
+  return html;
+};
+
+const init = () => {
+  const noticesContainer = find( '#regs3k-notices' );
+  fetch( NOTICES_URL, ( err, notices ) => {
+    if ( err !== null ) {
+      // No need to handle the error, the default HTML is a graceful fallback.
+      return console.error( err );
+    }
+    notices = JSON.parse( notices ).results;
+    const html = processNotices( notices );
+    noticesContainer.innerHTML = '';
+    return noticesContainer.appendChild( html );
+  } );
+};
+
+window.addEventListener( 'load', init );
+
+module.exports = {
+  processNotice,
+  processNotices
+};

--- a/cfgov/unprocessed/apps/regulations3k/js/regs3k-utils.js
+++ b/cfgov/unprocessed/apps/regulations3k/js/regs3k-utils.js
@@ -1,0 +1,10 @@
+import { ajaxRequest as xhr } from '../../../js/modules/util/ajax-request';
+
+const fetch = ( url, cb ) => xhr( 'GET', url, {
+  success: data => cb( null, data ),
+  fail: err => cb( err )
+} );
+
+module.exports = {
+  fetch
+};

--- a/cfgov/unprocessed/apps/regulations3k/js/search-utils.js
+++ b/cfgov/unprocessed/apps/regulations3k/js/search-utils.js
@@ -1,5 +1,3 @@
-import { ajaxRequest as xhr } from '../../../js/modules/util/ajax-request';
-
 /**
  * Get the search form field's values.
  *
@@ -84,20 +82,6 @@ function clearCheckbox( el ) {
 }
 
 /**
- * Fetches search results partial
- *
- * @param {String} url URL's of search results.
- * @param {Function} cb Function called with the HTML search results partial.
- * @returns {String} Encoded URL.
- */
-function fetchSearchResults( url, cb ) {
-  return xhr( 'GET', url, {
-    success: data => cb( null, data ),
-    fail: err => cb( err )
-  } );
-}
-
-/**
  * Update the page's URL via replaceState
  *
  * @param {String} base URL's base.
@@ -143,6 +127,5 @@ module.exports = {
   hideLoading: hideLoading,
   clearCheckbox: clearCheckbox,
   handleError: handleError,
-  fetchSearchResults: fetchSearchResults,
   updateUrl: updateUrl
 };

--- a/cfgov/unprocessed/apps/regulations3k/js/search.js
+++ b/cfgov/unprocessed/apps/regulations3k/js/search.js
@@ -1,6 +1,7 @@
 import * as behavior from '../../../js/modules/util/behavior';
 import * as utils from './search-utils';
 import { closest, queryOne as find } from '../../../js/modules/util/dom-traverse';
+import { fetch } from './regs3k-utils';
 
 // Keep track of the most recent XHR request so that we can cancel it if need be
 let searchRequest = {};
@@ -108,7 +109,7 @@ function handleFilter( event ) {
   // Update the filter query params in the URL
   utils.updateUrl( baseUrl, searchParams );
   utils.showLoading( searchContainer );
-  searchRequest = utils.fetchSearchResults( searchUrl, ( err, data ) => {
+  searchRequest = fetch( searchUrl, ( err, data ) => {
     utils.hideLoading( searchContainer );
     if ( err !== null ) {
       // TODO: Add message banner above search results

--- a/test/unit_tests/apps/regulations3k/js/recent-notices-spec.js
+++ b/test/unit_tests/apps/regulations3k/js/recent-notices-spec.js
@@ -1,0 +1,113 @@
+const simulateEvent = require( '../../../../util/simulate-event' ).simulateEvent;
+const BASE_JS_PATH = '../../../../../cfgov/unprocessed/apps/regulations3k';
+
+const app = require( `${ BASE_JS_PATH }/js/recent-notices.js` );
+
+const HTML_SNIPPET = `
+  <ul id="regs3k-notices"></ul>
+`;
+
+const TEST_DATA = {
+  results: [
+    {
+      html_url: 'https://example.com',
+      title: 'Notice A'
+    },
+    {
+      html_url: 'https://example.com',
+      title: 'Notice B'
+    },
+    {
+      html_url: 'https://example.com',
+      title: 'Notice C'
+    }
+  ]
+};
+
+// Back up global xhr
+const xhr = global.XMLHttpRequest;
+// Mock console logging
+global.console = { error: jest.fn(), log: jest.fn() };
+
+describe( 'The Regs3K search page', () => {
+
+  beforeEach( () => {
+    // Reset global XHR
+    global.XMLHttpRequest = xhr;
+    // Load HTML fixture
+    document.body.innerHTML = HTML_SNIPPET;
+  } );
+
+  it( 'should process a notice', () => {
+    const notice = {
+      html_url: 'https://federalregister.gov/',
+      title: 'Really great notice'
+    };
+    const processedNotice = app.processNotice( notice );
+    expect( processedNotice.constructor.name ).toEqual( 'HTMLLIElement' );
+    expect( processedNotice.className ).toEqual( 'm-list_link' );
+    expect( processedNotice.querySelector( 'a' ).href ).toEqual( 'https://federalregister.gov/' );
+  } );
+
+  it( 'should process notices', () => {
+    const notices = [
+      {
+        html_url: 'https://federalregister.gov/1',
+        title: 'Really great notice'
+      },
+      {
+        html_url: 'https://federalregister.gov/2',
+        title: 'Another really great notice'
+      }
+    ];
+    const processedNotices = app.processNotices( notices );
+    expect( processedNotices.querySelectorAll( 'li' ).length ).toEqual( 3 );
+    expect( processedNotices.querySelectorAll( 'a' )[2].textContent ).toContain( 'More' );
+  } );
+
+  it( 'should load recent notices', () => {
+    // Mock the browser's XHR
+    const mockXHR = {
+      open: jest.fn(),
+      send: jest.fn(),
+      readyState: 4,
+      status: 200,
+      responseText: JSON.stringify( TEST_DATA )
+    };
+    global.XMLHttpRequest = jest.fn( () => mockXHR );
+    // Fire `load` event
+    const event = document.createEvent( 'Event' );
+    event.initEvent( 'load', true, true );
+    window.dispatchEvent( event );
+    // Complete XHR
+    mockXHR.onreadystatechange();
+
+    const numNotices = document.querySelectorAll( '.m-list_link' ).length;
+    expect( numNotices ).toEqual( 4 );
+  } );
+
+  it( 'should fail to load recent notices', done => {
+    // Mock the browser's XHR
+    const mockXHR = {
+      open: jest.fn(),
+      send: jest.fn(),
+      readyState: 4,
+      status: 404,
+      onreadystatechange: jest.fn(),
+      responseText: 'Server error!'
+    };
+    global.XMLHttpRequest = jest.fn( () => mockXHR );
+    // Fire `load` event
+    const event = document.createEvent( 'Event' );
+    event.initEvent( 'load', true, true );
+    window.dispatchEvent( event );
+    // Complete XHR
+    mockXHR.onreadystatechange();
+
+    setTimeout( () => {
+      expect( console.error ).toBeCalled();
+      done();
+    }, 100 );
+  } );
+
+} );

--- a/test/unit_tests/apps/regulations3k/js/regs3k-utils-spec.js
+++ b/test/unit_tests/apps/regulations3k/js/regs3k-utils-spec.js
@@ -1,0 +1,47 @@
+const BASE_JS_PATH = '../../../../../cfgov/unprocessed/apps/regulations3k';
+
+const { fetch } = require( `${ BASE_JS_PATH }/js/regs3k-utils.js` );
+
+describe( 'The Regs3K search utils', () => {
+
+  it( 'should fetch a resource', done => {
+    const mockXHR = {
+      open: jest.fn(),
+      send: jest.fn(),
+      readyState: 4,
+      status: 200,
+      onreadystatechange: jest.fn(),
+      responseText: [
+        { searchResult: 'one' },
+        { anotherSearchResult: 'two' }
+      ]
+    };
+    global.XMLHttpRequest = jest.fn( () => mockXHR );
+    fetch( 'api/search', ( err, data ) => {
+      expect( err ).toEqual( null );
+      expect( data ).toEqual(
+        [ { searchResult: 'one' }, { anotherSearchResult: 'two' } ]
+      );
+      done();
+    } );
+    mockXHR.onreadystatechange();
+  } );
+
+  it( 'should fail to fetch a resource', done => {
+    const mockXHR = {
+      open: jest.fn(),
+      send: jest.fn(),
+      readyState: 4,
+      status: 404,
+      onreadystatechange: jest.fn(),
+      responseText: 'Server error!'
+    };
+    global.XMLHttpRequest = jest.fn( () => mockXHR );
+    fetch( 'api/search', err => {
+      expect( err ).toEqual( 404 );
+      done();
+    } );
+    mockXHR.onreadystatechange();
+  } );
+
+} );

--- a/test/unit_tests/apps/regulations3k/js/search-utils-spec.js
+++ b/test/unit_tests/apps/regulations3k/js/search-utils-spec.js
@@ -60,46 +60,6 @@ describe( 'The Regs3K search utils', () => {
     expect( unknownError.msg ).toEqual( 'Sorry, our search engine is temporarily down.' );
   } );
 
-  it( 'should fetch search results', done => {
-    const mockXHR = {
-      open: jest.fn(),
-      send: jest.fn(),
-      readyState: 4,
-      status: 200,
-      onreadystatechange: jest.fn(),
-      responseText: [
-        { searchResult: 'one' },
-        { anotherSearchResult: 'two' }
-      ]
-    };
-    global.XMLHttpRequest = jest.fn( () => mockXHR );
-    utils.fetchSearchResults( 'api/search', ( err, data ) => {
-      expect( err ).toEqual( null );
-      expect( data ).toEqual(
-        [ { searchResult: 'one' }, { anotherSearchResult: 'two' } ]
-      );
-      done();
-    } );
-    mockXHR.onreadystatechange();
-  } );
-
-  it( 'should fail to fetch search results', done => {
-    const mockXHR = {
-      open: jest.fn(),
-      send: jest.fn(),
-      readyState: 4,
-      status: 404,
-      onreadystatechange: jest.fn(),
-      responseText: 'Server error!'
-    };
-    global.XMLHttpRequest = jest.fn( () => mockXHR );
-    utils.fetchSearchResults( 'api/search', err => {
-      expect( err ).toEqual( 404 );
-      done();
-    } );
-    mockXHR.onreadystatechange();
-  } );
-
   it( 'should replace the browser history', () => {
     const rs = global.history.replaceState = jest.fn();
     expect( rs.mock.calls.length ).toEqual( 0 );


### PR DESCRIPTION
Adds recent notices to landing page's sidebar via AJAX. They are pulled from the federalregister.gov API. Unfortunately, their API has no `Access-Control-Allow-Origin` header so we can't have the browser fetch the data directly from them (eregs uses a [JSONP hack](https://github.com/cfpb/regulations-site/blob/092bd0ef21a78b7bbabb019953adff6c70953f34/regulations/static/regulations/js/landing.js#L18)). Instead, we set up a cf.gov view to proxy the data to the front-end.

![screen shot 2018-08-08 at 1 40 04 am](https://user-images.githubusercontent.com/1060248/43818361-3a90318c-9aac-11e8-904a-d8959c212ff7.png)

## Additions

- `regulations/recent-notices-json/` route
- `recent-notices.js` file that fetches JSON from the above view

## Changes

- I moved the regs3k `fetch` utility into its own file to share it across the app.

## Testing

1. `./frontend.sh`
1. Visit http://localhost:8000/policy-compliance/rulemaking/regulations/ and see if the recent regulations appear

## Notes

- If JS fails to load or the API request fails it'll simply display a link to the [register's CFPB page](https://www.federalregister.gov/agencies/consumer-financial-protection-bureau).

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Internet Explorer 8, 9, 10, and 11
- [ ] Edge
- [ ] iOS Safari
- [ ] Chrome for Android

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
