### PR TITLE
Pin django-taggit for Django version compatibility

### DIFF
--- a/requirements/libraries.txt
+++ b/requirements/libraries.txt
@@ -12,6 +12,11 @@ django-haystack==2.6.0
 django-localflavor==1.1
 django-overextends==0.4.1
 django-storages==1.1.8
+# django-taggit 0.23.0 requires Django 1.11. Normally django-taggit is pulled
+# in by Wagtail's setup.py, but Wagtail 1.13 specifies >0.20,<1.0, which
+# unfortunately includes this version. This line can be removed once we are
+# on Django 1.11.
+django-taggit==0.22.2
 django-treebeard==3.0
 django-watchman==0.13.1
 edgegrid-python==1.0.10


### PR DESCRIPTION
Yesterday django-taggit released a new version (0.23.0) that is incompatible with Django <1.11:

https://github.com/alex/django-taggit/blob/master/CHANGELOG.txt#L6

django-taggit is normally pulled in by Wagtail's setup.py, but unfortunately in the version of Wagtail we are on (1.13.2) the setup.py specifies `>=0.20,<1.0`, which pulls in this incompatible version:

https://github.com/wagtail/wagtail/blob/v1.13.2/setup.py#L26

Edit to add: this manifests itself in failing unit tests with the error message `ImportError: cannot import name lazy_related_operation`.

This change pins django-taggit to its previous version (0.22.2) to retain Django compatibility. This line should be removed once we upgrade to Django 1.11.

Edit again: l've opened [wagtail#4725](https://github.com/wagtail/wagtail/issues/4725) about this.

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [X] Passes all existing automated tests
- [X] Placeholder code is flagged / future todos are captured in comments
- [X] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: