### PR TITLE
Regs3k: Fix breadcrumbs

### DIFF
--- a/cfgov/regulations3k/models/pages.py
+++ b/cfgov/regulations3k/models/pages.py
@@ -242,7 +242,9 @@ class RegulationPage(RoutablePageMixin, SecondaryNavigationJSMixin, CFGOVPage):
         return list(self.section_query.all())
 
     def get_context(self, request, *args, **kwargs):
-        context = super(CFGOVPage, self).get_context(request, *args, **kwargs)
+        context = super(RegulationPage, self).get_context(
+            request, *args, **kwargs
+        )
         context.update({
             'get_secondary_nav_items': get_reg_nav_items,
             'regulation': self.regulation,
@@ -252,20 +254,13 @@ class RegulationPage(RoutablePageMixin, SecondaryNavigationJSMixin, CFGOVPage):
         return context
 
     def get_breadcrumbs(self, request, section=None):
-        landing_page = self.get_parent()
-        crumbs = [{
-            'href': landing_page.url,
-            'title': landing_page.title,
-        }]
+        crumbs = super(RegulationPage, self).get_breadcrumbs(request)
 
         if section is not None:
             crumbs = crumbs + [
                 {
                     'href': self.url,
                     'title': str(section.subpart.version.part),
-                },
-                {
-                    'title': section.subpart.title,
                 },
             ]
 


### PR DESCRIPTION
This PR fixes the Regulation page breadcrumbs to include parents above its  Regulation Landing page parent. It also removes the subpart from the breadcrumb entirely.

## Screenshots

![image](https://user-images.githubusercontent.com/10562538/43907068-b50f49e0-9bc2-11e8-8b38-eddab17a803f.png)

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
