### PR TITLE
Regs3k: Support viewing multiple effective versions

### DIFF
--- a/cfgov/regulations3k/models/pages.py
+++ b/cfgov/regulations3k/models/pages.py
@@ -4,12 +4,12 @@ import re
 from collections import OrderedDict
 from functools import partial
 
+from django.core.exceptions import PermissionDenied
 from django.core.paginator import InvalidPage, Paginator
 from django.db import models
 from django.http import HttpResponse, JsonResponse
 from django.template.loader import get_template
 from django.template.response import TemplateResponse
-from django.utils.functional import cached_property
 from haystack.query import SearchQuerySet
 
 from wagtail.contrib.wagtailroutablepage.models import RoutablePageMixin, route
@@ -230,25 +230,33 @@ class RegulationPage(RoutablePageMixin, SecondaryNavigationJSMixin, CFGOVPage):
         ObjectList(CFGOVPage.settings_panels, heading='Configuration'),
     ])
 
-    @cached_property
-    def section_query(self):
-        """Query set for Sections in this regulation's effective version."""
-        return Section.objects.filter(
-            subpart__version=self.regulation.effective_version,
+    def get_effective_version(self, request, date_str):
+        """ Get the requested effective version if the user has permission """
+        effective_version = self.regulation.versions.get(
+            effective_date=date_str
         )
 
-    @cached_property
-    def sections(self):
-        return list(self.section_query.all())
+        if effective_version.draft:
+            page_perms = self.permissions_for_user(request.user)
+            if not page_perms.can_edit():
+                raise PermissionDenied
+
+        return effective_version
+
+    def get_section_query(self, effective_version=None):
+        """Query set for Sections in this regulation's effective version."""
+        if effective_version is None:
+            effective_version = self.regulation.effective_version
+        return Section.objects.filter(
+            subpart__version=effective_version
+        )
 
     def get_context(self, request, *args, **kwargs):
         context = super(RegulationPage, self).get_context(
             request, *args, **kwargs
         )
         context.update({
-            'get_secondary_nav_items': get_reg_nav_items,
             'regulation': self.regulation,
-            'section': None,
             'breadcrumb_items': self.get_breadcrumbs(request)
         })
         return context
@@ -265,39 +273,6 @@ class RegulationPage(RoutablePageMixin, SecondaryNavigationJSMixin, CFGOVPage):
             ]
 
         return crumbs
-
-    @route(r'^(?P<section_label>[0-9A-Za-z-]+)/$', name="section")
-    def section_page(self, request, section_label):
-        section = self.section_query.get(label=section_label)
-        current_index = self.sections.index(section)
-        context = self.get_context(request)
-
-        content = regdown(
-            section.contents,
-            url_resolver=get_url_resolver(self),
-            contents_resolver=get_contents_resolver(self),
-            render_block_reference=partial(self.render_interp, context)
-        )
-
-        context.update({
-            'version': self.regulation.effective_version,
-            'content': content,
-            'get_secondary_nav_items': get_reg_nav_items,
-            'next_section': get_next_section(
-                self.sections, current_index),
-            'previous_section': get_previous_section(
-                self.sections, current_index),
-            'section': section,
-            'breadcrumb_items': self.get_breadcrumbs(request, section),
-            'search_url': (self.get_parent().url +
-                           'search-regulations/results/?regs=' +
-                           self.regulation.part_number)
-        })
-
-        return TemplateResponse(
-            request,
-            self.template,
-            context)
 
     def render_interp(self, context, raw_contents, **kwargs):
         template = get_template('regulations3k/inline_interps.html')
@@ -319,6 +294,81 @@ class RegulationPage(RoutablePageMixin, SecondaryNavigationJSMixin, CFGOVPage):
 
         return template.render(context)
 
+    @route(r'^((?P<date_str>[0-9]{4}-[0-9]{2}-[0-9]{2})/)?$')
+    def index_route(self, request, date_str=None, *args, **kwargs):
+        request.is_preview = getattr(request, 'is_preview', False)
+
+        if date_str is not None:
+            effective_version = self.get_effective_version(request, date_str)
+            section_query = self.get_section_query(
+                effective_version=effective_version
+            )
+        else:
+            section_query = self.get_section_query()
+
+        sections = list(section_query.all())
+
+        context = self.get_context(request, *args, **kwargs)
+        context.update({
+            'get_secondary_nav_items': partial(
+                get_reg_nav_items, sections=sections, date_str=date_str
+            ),
+        })
+
+        return TemplateResponse(
+            request,
+            self.get_template(request, *args, **kwargs),
+            context
+        )
+
+    @route(r'^(?:(?P<date_str>[0-9]{4}-[0-9]{2}-[0-9]{2})/)?'
+           r'(?P<section_label>[0-9A-Za-z-]+)/$',
+           name="section")
+    def section_page(self, request, date_str=None, section_label=None):
+        """ Render a section of the currently effective regulation """
+
+        if date_str is not None:
+            effective_version = self.get_effective_version(request, date_str)
+            section_query = self.get_section_query(
+                effective_version=effective_version
+            )
+        else:
+            section_query = self.get_section_query()
+
+        sections = list(section_query.all())
+        section = section_query.get(label=section_label)
+        current_index = sections.index(section)
+        context = self.get_context(request, sections=sections)
+
+        content = regdown(
+            section.contents,
+            url_resolver=get_url_resolver(self),
+            contents_resolver=get_contents_resolver(self),
+            render_block_reference=partial(self.render_interp, context)
+        )
+
+        context.update({
+            'version': self.regulation.effective_version,
+            'content': content,
+            'get_secondary_nav_items': partial(
+                get_reg_nav_items, sections=sections, date_str=date_str
+            ),
+            'next_section': get_next_section(
+                sections, current_index),
+            'previous_section': get_previous_section(
+                sections, current_index),
+            'section': section,
+            'breadcrumb_items': self.get_breadcrumbs(request, section),
+            'search_url': (self.get_parent().url +
+                           'search-regulations/results/?regs=' +
+                           self.regulation.part_number)
+        })
+
+        return TemplateResponse(
+            request,
+            self.template,
+            context)
+
 
 def get_next_section(section_list, current_index):
     if current_index == len(section_list) - 1:
@@ -334,11 +384,14 @@ def get_previous_section(section_list, current_index):
         return section_list[current_index - 1]
 
 
-def get_reg_nav_items(request, current_page):
+def get_reg_nav_items(request, current_page, sections=[], date_str=None):
     url_bits = [bit for bit in request.path.split('/') if bit]
     current_label = url_bits[-1]
-    sections = current_page.sections
     subpart_dict = OrderedDict()
+
+    section_kwargs = {}
+    if date_str is not None:
+        section_kwargs['date_str'] = date_str
 
     for section in sections:
         # If the section's subpart isn't in the subpart dict yet, add it
@@ -347,13 +400,14 @@ def get_reg_nav_items(request, current_page):
                 'sections': [],
                 'expanded': False
             }
+        section_kwargs['section_label'] = section.label
 
         # Create the section dictionary for navigation
         section_dict = {
             'title': section.title,
             'url': current_page.url + current_page.reverse_subpage(
                 'section',
-                args=([section.label])
+                kwargs=section_kwargs
             ),
             'active': section.label == current_label,
             'expanded': True,


### PR DESCRIPTION
This PR makes some changes to the `RegulationPage` to allow us to view more than just the current effective version of a regulation. It does that by adding an optional date component to the URL pattern for the section page and index page. 

With this change, the following URLs have the following results:

- `/policy-compliance/rulemaking/regulations/1002/`: Reg B landing page with links to sections in the currently effective version
- `/policy-compliance/rulemaking/regulations/1002/2018-01-01/`: Reg B landing page with links to sections in the 2018-01-01 version explicitly
- `/policy-compliance/rulemaking/regulations/1002/02`: Section 2 of the currently effective version of Reg B
- `/policy-compliance/rulemaking/regulations/1002/2018-01-01/02`: Section 2 of the 2018-01-01 version of Reg B explicitly.

*If* a user has permission to edit the Regulation page in question, the user will also be able to request effective versions that are in a draft state. This should enable us to allow previews of content that is in the draft state.

There is no UI attached to the PR that lets a user navigate to any URL with a date in it from any source (admin or frontend). That work will come after this.

**Note** There's some overlap in the use of `RequestFactory` in this PR and in #4425. Once one or the other is merged I'll take care of any conflicts that causes.

## Testing

1. Pull down this branch and the latest production database dump
2. Visit http://localhost:8000/policy-compliance/rulemaking/regulations/1002/ and confirm it works as expected.
3. Visit http://localhost:8000/policy-compliance/rulemaking/regulations/1002/2/ and confirm it works as expected.
4. Visit http://localhost:8000/policy-compliance/rulemaking/regulations/1002/2018-01-01/ and confirm it works as expected
5. Visit http://localhost:8000/policy-compliance/rulemaking/regulations/1002/2018-01-01/2/ and confirm it works as expected.
6. Create a new effective version for Reg B by copying the current version and setting a new effective date at http://localhost:8000/admin/regulations3k/effectiveversion/?part=1 
7. Make some changes to text in your new version of Reg B. Do not make it live.
8. Confirm that you can see your changes in http://localhost:8000/policy-compliance/rulemaking/regulations/1002/[the date you chose]/

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
