### PR TITLE
Fix v1.jinja2tags.datetimes for running tests on Python 3

### DIFF
--- a/cfgov/v1/jinja2tags/datetimes.py
+++ b/cfgov/v1/jinja2tags/datetimes.py
@@ -1,4 +1,5 @@
 import datetime
+from six import string_types as basestring
 
 from django.utils.timezone import template_localtime
 


### PR DESCRIPTION
This PR adds an import for [`six.string_types` as `basestring`](https://pythonhosted.org/six/#six.string_types) to our `v1.jinja2tags.datetimes` module to ensure that its use of `basestring` doesn't cause errors when running tests that use the Django test client on Python 3.