### PR TITLE
Regs3k: Fix regulation list ordering and ensure only live pages get listed

### DIFF
--- a/cfgov/regulations3k/blocks.py
+++ b/cfgov/regulations3k/blocks.py
@@ -20,6 +20,9 @@ class RegulationsList(organisms.ModelBlock):
         help_text='Text to show on link to more regulations'
     )
 
+    def filter_queryset(self, qs, value):
+        return qs.live()
+
     def get_context(self, value, parent_context=None):
         context = super(RegulationsList, self).get_context(
             value, parent_context=parent_context

--- a/cfgov/regulations3k/blocks.py
+++ b/cfgov/regulations3k/blocks.py
@@ -6,7 +6,7 @@ from v1.atomic_elements import organisms
 
 class RegulationsList(organisms.ModelBlock):
     model = 'regulations3k.RegulationPage'
-    ordering = ('regulation')
+    ordering = 'title'
 
     heading = blocks.CharBlock(
         required=False,

--- a/cfgov/regulations3k/tests/test_blocks.py
+++ b/cfgov/regulations3k/tests/test_blocks.py
@@ -35,19 +35,35 @@ class RegulationsListTestCase(TestCase):
             letter_code='B',
             chapter='X'
         )
+        self.part_1003 = mommy.make(
+            Part,
+            part_number='1003',
+            title='Home Mortgage Disclosure',
+            letter_code='C',
+            chapter='X'
+        )
         self.effective_version = mommy.make(
             EffectiveVersion,
             effective_date=datetime.date(2014, 1, 18),
             part=self.part_1002
         )
-        self.reg_page = RegulationPage(
+        self.reg_page_1002 = RegulationPage(
             regulation=self.part_1002,
             title='Reg B',
-            slug='1002')
+            slug='1002'
+        )
+        self.reg_page_1003 = RegulationPage(
+            regulation=self.part_1003,
+            title='Reg C',
+            slug='1003',
+            live=False,
+        )
 
-        self.landing_page.add_child(instance=self.reg_page)
+        self.landing_page.add_child(instance=self.reg_page_1002)
+        self.landing_page.add_child(instance=self.reg_page_1003)
         self.landing_page.save_revision().publish()
-        self.reg_page.save_revision().publish()
+        self.reg_page_1002.save_revision().publish()
+        self.reg_page_1003.save_revision()
 
         self.more_regs_page = Page.objects.first()
 
@@ -58,6 +74,8 @@ class RegulationsListTestCase(TestCase):
         }))
         self.assertIn('Reg B', result)
         self.assertIn('/regulations/1002/', result)
+        self.assertNotIn('Reg C', result)
+        self.assertNotIn('/regulations/1003/', result)
 
     def test_regulations_full_width_text(self):
         self.landing_page.content = StreamValue(


### PR DESCRIPTION
This PR makes two small fixes to the regulation list on the regulations landing page:

- Ordering is now done by regulation page title, which should follow the CFR part number ordering
- The regulations list will no longer list Regulation Page objects that exist but have never been published.
