### PR TITLE
Properly pass Jinja2 template context to video player

### DIFF
--- a/cfgov/jinja2/v1/_includes/organisms/featured-content.html
+++ b/cfgov/jinja2/v1/_includes/organisms/featured-content.html
@@ -97,7 +97,7 @@
     {% if value.video and
           value.video.url and
           value.video.id %}
-        {% import 'macros/video-player.html' as video_player %}
+        {% import 'macros/video-player.html' as video_player with context %}
         {{ video_player.render(value) }}
     {% elif value.image %}
         <div class="o-featured-content-module_visual">

--- a/cfgov/jinja2/v1/sublanding-page/index.html
+++ b/cfgov/jinja2/v1/sublanding-page/index.html
@@ -1,7 +1,7 @@
 {% extends 'layout-2-1-bleedbar.html' %}
 
 {% import 'form_block.html' as form_block with context %}
-{% import 'organisms/featured-content.html' as featured_content %}
+{% import 'organisms/featured-content.html' as featured_content with context %}
 {% import 'organisms/post-preview.html' as post_preview with context %}
 {% import 'templates/streamfield-sidefoot.html' as streamfield_sidefoot with context %}
 


### PR DESCRIPTION
This commit fixes an issue introduced by #4380 that introduced more strict requirements on page/block templates using the "request" context variable.

The `video-player.html` template [requires this variable](https://github.com/cfpb/cfgov-refresh/blob/481c446afd5439683e094df69b51c5f2905f4e3b/cfgov/jinja2/v1/_includes/macros/video-player.html#L45), but wasn't being loaded with context. This change fixes that.

To test, use a production dump and visit http://localhost:8000/practitioner-resources/library-resources/ as an example page using the video player. This will load successfully, unlike on master where you will get a 500 error.

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [X] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [X] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [X] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: