### PR TITLE
Regs3k: Migrate Google Analytics events

### DIFF
--- a/cfgov/regulations3k/jinja2/regulations3k/inline_interps.html
+++ b/cfgov/regulations3k/jinja2/regulations3k/inline_interps.html
@@ -5,7 +5,7 @@
             o-expandable__border
             inline-interpretation">
 
-    <button class="o-expandable_header o-expandable_target">
+    <button class="o-expandable_header o-expandable_target"{% if section_title %} data-section="{{ section_title }}"{% endif %}>
         <span class="o-expandable_header-left o-expandable_label">
             Official interpretation {% if section_title %}of {{ section_title }}{% endif %}
         </span>

--- a/cfgov/unprocessed/apps/regulations3k/js/analytics.js
+++ b/cfgov/unprocessed/apps/regulations3k/js/analytics.js
@@ -1,0 +1,20 @@
+import Analytics from '../../../js/modules/Analytics';
+import { queryOne as find } from '../../../js/modules/util/dom-traverse';
+
+/**
+ * Sends the user interaction to Analytics
+ * @param {string} action - The user's action
+ * @param {string} label - The label associated with the action
+ * @param {string} category - Optional category if it's not eRegs-related
+ * @returns {object} Event data
+ */
+const sendEvent = ( action, label, category ) => {
+  category = category || 'eRegs Event';
+  const eventData = Analytics.getDataLayerOptions( action, label, category );
+  Analytics.sendEvent( eventData );
+  return eventData;
+};
+
+module.exports = {
+  sendEvent
+};

--- a/cfgov/unprocessed/apps/regulations3k/js/analytics.js
+++ b/cfgov/unprocessed/apps/regulations3k/js/analytics.js
@@ -1,5 +1,7 @@
 import Analytics from '../../../js/modules/Analytics';
-import { queryOne as find } from '../../../js/modules/util/dom-traverse';
+import { closest } from '../../../js/modules/util/dom-traverse';
+
+/* eslint-disable consistent-return */
 
 /**
  * Sends the user interaction to Analytics
@@ -15,6 +17,78 @@ const sendEvent = ( action, label, category ) => {
   return eventData;
 };
 
+/**
+ * getExpandable - Find the expandable the user clicked.
+ *
+ * @param {event} event Click event
+ *
+ * @returns {DOMNode|null} The expandable or null if it's not an expandable
+ */
+const getExpandable = event => {
+  const el = closest( event.target, '.o-expandable_header' ) || event.target;
+  if ( el.classList.contains( 'o-expandable_header' ) ) {
+    return el;
+  }
+  return null;
+};
+
+
+/**
+ * getExpandableState - Description
+ *
+ * @param {DOMNode} expandable Expandable's HTML element
+ *
+ * @returns {string} Expandable's state, either `open` or `close`
+ */
+const getExpandableState = expandable => {
+  let state = 'close';
+  if ( expandable.classList.contains( 'o-expandable_target__expanded' ) ) {
+    state = 'open';
+  }
+  return state;
+};
+
+/**
+ * handleNavClick - Listen for secondary nav clicks and report to GA if it's a
+ * link to a reg section.
+ *
+ * @param {event} event Click event
+ * @returns {object} Event data
+ */
+const handleNavClick = event => {
+  if ( !event.target.href ) {
+    return;
+  }
+  // Double check that the URL ends in regulations/1234/XXXXXX
+  let section = event.target.href.match( /regulations\/(\d+\/[\w-]+)\/?$/ );
+  if ( !section ) {
+    return;
+  }
+  section = section[1].replace( '/', '-' );
+  return sendEvent( 'toc:click', section );
+};
+
+/**
+ * handleContentClick - Listen for clicks within a reg section's content
+ * and report to GA if they opened or closed an expandable.
+ *
+ * @param {event} event Click event
+ * @returns {object} Event data
+ */
+const handleContentClick = event => {
+  const expandable = getExpandable( event );
+  if ( !expandable ) {
+    return;
+  }
+  const action = `interpexpandables:${ getExpandableState( expandable ) }`;
+  const section = expandable.getAttribute( 'data-section' );
+  return sendEvent( action, section );
+};
+
 module.exports = {
+  getExpandable,
+  getExpandableState,
+  handleContentClick,
+  handleNavClick,
   sendEvent
 };

--- a/cfgov/unprocessed/apps/regulations3k/js/index.js
+++ b/cfgov/unprocessed/apps/regulations3k/js/index.js
@@ -1,42 +1,46 @@
 import Expandable from 'cf-expandables/src/Expandable';
 import { bindEvent } from '../../../js/modules/util/dom-events';
 import { queryOne as find } from '../../../js/modules/util/dom-traverse';
-import { sendEvent } from './analytics';
+import { handleContentClick, handleNavClick } from './analytics';
 
 const navHeader = find( '.o-regs3k-navigation_header' );
 const navItems = find( '.o-regs3k-sections' );
+const regContent = find( '.content_main.regulations3k' );
 
+
+/**
+ * toggleSecondaryNav - Show/hide the secondary nav on smaller screens
+ */
 const toggleSecondaryNav = () => {
   navHeader.classList.toggle( 'o-expandable_target__collapsed' );
   navHeader.classList.toggle( 'o-expandable_target__expanded' );
   navItems.classList.toggle( 'u-hide-on-stacked' );
 };
 
-const handleNavClick = event => {
-  if ( !event.target.href ) {
-    return;
-  }
-  // Double check that the URL ends in regulations/1234/XXXXXX
-  let section = event.target.href.match( /regulations\/(\d+\/[\w\-]+)\/?$/ );
-  if ( !section ) {
-    return;
-  }
-  section = section[1].replace( '/', '-' );
-  sendEvent( 'toc:click', section );
-};
-
+/**
+ * bindSecondaryNav - Set up secondary nav toggling.
+ */
 const bindSecondaryNav = () => {
   bindEvent( navHeader, {
     click: toggleSecondaryNav
   } );
 };
 
+/**
+ * bindAnalytics - Set up analytics reporting.
+ */
 const bindAnalytics = () => {
   bindEvent( navItems, {
     click: handleNavClick
   } );
+  bindEvent( regContent, {
+    click: handleContentClick
+  } );
 };
 
+/**
+ * init - Initialize everything on page load.
+ */
 const init = () => {
   if ( 'serviceWorker' in navigator ) {
     navigator.serviceWorker.register( '/regulations3k-service-worker.js' ).catch( err => {

--- a/cfgov/unprocessed/apps/regulations3k/js/index.js
+++ b/cfgov/unprocessed/apps/regulations3k/js/index.js
@@ -1,6 +1,7 @@
 import Expandable from 'cf-expandables/src/Expandable';
 import { bindEvent } from '../../../js/modules/util/dom-events';
 import { queryOne as find } from '../../../js/modules/util/dom-traverse';
+import { sendEvent } from './analytics';
 
 const navHeader = find( '.o-regs3k-navigation_header' );
 const navItems = find( '.o-regs3k-sections' );
@@ -11,9 +12,28 @@ const toggleSecondaryNav = () => {
   navItems.classList.toggle( 'u-hide-on-stacked' );
 };
 
+const handleNavClick = event => {
+  if ( !event.target.href ) {
+    return;
+  }
+  // Double check that the URL ends in regulations/1234/XXXXXX
+  let section = event.target.href.match( /regulations\/(\d+\/[\w\-]+)\/?$/ );
+  if ( !section ) {
+    return;
+  }
+  section = section[1].replace( '/', '-' );
+  sendEvent( 'toc:click', section );
+};
+
 const bindSecondaryNav = () => {
   bindEvent( navHeader, {
     click: toggleSecondaryNav
+  } );
+};
+
+const bindAnalytics = () => {
+  bindEvent( navItems, {
+    click: handleNavClick
   } );
 };
 
@@ -27,6 +47,7 @@ const init = () => {
     navHeader.classList.add( 'o-expandable_target__collapsed' );
     navItems.classList.add( 'u-hide-on-stacked' );
     bindSecondaryNav();
+    bindAnalytics();
   }
 };
 

--- a/test/unit_tests/apps/regulations3k/js/analytics-spec.js
+++ b/test/unit_tests/apps/regulations3k/js/analytics-spec.js
@@ -2,12 +2,13 @@ const BASE_JS_PATH = '../../../../../cfgov/unprocessed/apps/regulations3k';
 
 const analytics = require( `${ BASE_JS_PATH }/js/analytics.js` );
 
+/* eslint-disable max-lines-per-function, no-undefined */
 describe( 'The Regs3K analytics', () => {
 
   it( 'should send events', () => {
-    const event = analytics.sendEvent( 'click', 'sidebar' );
+    const mockEvent = analytics.sendEvent( 'click', 'sidebar' );
 
-    expect( event ).toEqual( {
+    expect( mockEvent ).toEqual( {
       event: 'eRegs Event',
       action: 'click',
       label: 'sidebar',
@@ -17,15 +18,135 @@ describe( 'The Regs3K analytics', () => {
   } );
 
   it( 'should send events with custom categories', () => {
-    const event = analytics.sendEvent( 'click', 'sidebar', 'eregs' );
+    const mockEvent = analytics.sendEvent( 'click', 'sidebar', 'eregs' );
 
-    expect( event ).toEqual( {
+    expect( mockEvent ).toEqual( {
       event: 'eregs',
       action: 'click',
       label: 'sidebar',
       eventCallback: undefined,
       eventTimeout: 500
     } );
+  } );
+
+  it( 'should find expandables', () => {
+    const mockTarget = {
+      classList: {
+        contains: () => true
+      },
+      parentNode: {
+        matches: () => false
+      }
+    };
+    const event = {
+      target: mockTarget
+    };
+    const expandable = analytics.getExpandable( event );
+
+    expect( expandable ).toEqual( mockTarget );
+  } );
+
+  it( 'should get expandable state', () => {
+    const mockEl = {
+      classList: {
+        contains: () => true
+      }
+    };
+    const mockEl2 = {
+      classList: {
+        contains: () => false
+      }
+    };
+    const state1 = analytics.getExpandableState( mockEl );
+    expect( state1 ).toEqual( 'open' );
+    const state2 = analytics.getExpandableState( mockEl2 );
+    expect( state2 ).toEqual( 'close' );
+  } );
+
+  it( 'should handle navigation clicks on regs links', () => {
+    let event = { target: {
+      href: '/policy-compliance/rulemaking/regulations/1002/11/'
+    } };
+    event = analytics.handleNavClick( event );
+
+    expect( event ).toEqual( {
+      action: 'toc:click',
+      event: 'eRegs Event',
+      eventCallback: undefined,
+      eventTimeout: 500,
+      label: '1002-11'
+    } );
+  } );
+
+  it( 'should handle navigation clicks on interp links', () => {
+    let mockEvent = { target: {
+      href: '/policy-compliance/rulemaking/regulations/1002/Interp-2/'
+    } };
+    mockEvent = analytics.handleNavClick( mockEvent );
+
+    expect( mockEvent ).toEqual( {
+      action: 'toc:click',
+      event: 'eRegs Event',
+      eventCallback: undefined,
+      eventTimeout: 500,
+      label: '1002-Interp-2'
+    } );
+  } );
+
+  it( 'should handle navigation clicks on non-regs links', () => {
+    let mockEvent = { target: {
+      href: 'https://example.com'
+    } };
+    mockEvent = analytics.handleNavClick( mockEvent );
+
+    expect( mockEvent ).toBeUndefined();
+  } );
+
+  it( 'should handle navigation clicks on non-links', () => {
+    let mockEvent = { target: {} };
+    mockEvent = analytics.handleNavClick( mockEvent );
+
+    expect( mockEvent ).toBeUndefined();
+  } );
+
+  it( 'should handle content clicks on expandables', () => {
+    let mockEvent = {
+      target: {
+        classList: {
+          contains: () => true
+        },
+        parentNode: {
+          matches: () => false
+        },
+        getAttribute: () => 'Section 1'
+      }
+    };
+    mockEvent = analytics.handleContentClick( mockEvent );
+
+    expect( mockEvent ).toEqual( {
+      action: 'interpexpandables:open',
+      event: 'eRegs Event',
+      eventCallback: undefined,
+      eventTimeout: 500,
+      label: 'Section 1'
+    } );
+  } );
+
+  it( 'should handle content clicks on non-expandables', () => {
+    let mockEvent = {
+      target: {
+        classList: {
+          contains: () => false
+        },
+        parentNode: {
+          matches: () => false
+        },
+        getAttribute: () => 'Section 1'
+      }
+    };
+    mockEvent = analytics.handleContentClick( mockEvent );
+
+    expect( mockEvent ).toBeUndefined();
   } );
 
 } );

--- a/test/unit_tests/apps/regulations3k/js/analytics-spec.js
+++ b/test/unit_tests/apps/regulations3k/js/analytics-spec.js
@@ -1,0 +1,31 @@
+const BASE_JS_PATH = '../../../../../cfgov/unprocessed/apps/regulations3k';
+
+const analytics = require( `${ BASE_JS_PATH }/js/analytics.js` );
+
+describe( 'The Regs3K analytics', () => {
+
+  it( 'should send events', () => {
+    const event = analytics.sendEvent( 'click', 'sidebar' );
+
+    expect( event ).toEqual( {
+      event: 'eRegs Event',
+      action: 'click',
+      label: 'sidebar',
+      eventCallback: undefined,
+      eventTimeout: 500
+    } );
+  } );
+
+  it( 'should send events with custom categories', () => {
+    const event = analytics.sendEvent( 'click', 'sidebar', 'eregs' );
+
+    expect( event ).toEqual( {
+      event: 'eregs',
+      action: 'click',
+      label: 'sidebar',
+      eventCallback: undefined,
+      eventTimeout: 500
+    } );
+  } );
+
+} );


### PR DESCRIPTION
This migrates analytics tracking from [regulations-site](https://github.com/cfpb/regulations-site) to Regs3K. The majority of the events tracked by eRegs are no longer relevant:

- ~~`link:followCitation`~~
- `interpexpandables:open` (migrated)
- `interpexpandables:close` (migrated)
- ~~`definition:open`~~
- ~~`definition:followCitation`~~
- ~~`searchVersion:change`~~
- ~~`drawer:switchTab`~~
- ~~`drawer:open`~~
- ~~`drawer:close`~~
- ~~`sxs:open`~~
- ~~`sidebarexpanable:open`~~
- ~~`sidebarexpanable:close`~~
- `toc:click` (migrated)

We can track more events if desired if anything surfaces in GHE#287. All the standard cf.gov metrics like unique sessions, referral URLs, pageviews, etc. are automatically tracked alongside any custom events we add.

## Additions

- `regs3k/analytics.js` file to assist with sending events to GA.

## Testing

1. `./frontend.sh`
1. Install [GA debugger](https://chrome.google.com/webstore/detail/google-analytics-debugger/jnkmfdileelhofjcijamephohjechhna?hl=en).
1. Go to a reg page that has an inline interpretation. Open it and you should see the following in your console:

![screen shot 2018-08-10 at 2 41 35 am](https://user-images.githubusercontent.com/1060248/43942765-3e8cd898-9c47-11e8-9c3f-eea0d36fcda4.png)

4. Close it to see the close event.
5. Click a link in the left hand secondary nav and you should see a `toc:click` event.

![screen shot 2018-08-10 at 2 42 11 am](https://user-images.githubusercontent.com/1060248/43942802-6185ddcc-9c47-11e8-8091-bc43a334674f.png)

Note: We don't use `eventValue`, it's supposed to be undefined.

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Internet Explorer 8, 9, 10, and 11
- [ ] Edge
- [ ] iOS Safari
- [ ] Chrome for Android

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
