### PR TITLE
Bump TDP release to 1.0.9

### DIFF
--- a/cfgov/cfgov/urls.py
+++ b/cfgov/cfgov/urls.py
@@ -393,11 +393,6 @@ urlpatterns = [
             include_if_app_enabled('teachers_digital_platform',
                                     'teachers_digital_platform.prototypes_urls')),  # noqa: E501
 
-    # flagged_url('TDP_SEARCH_INTERFACE',
-    #         r'^practitioner-resources/youth-financial-education/curriculum-review/search/',  # noqa: E501
-    #         include_if_app_enabled('teachers_digital_platform',
-    #                                 'teachers_digital_platform.search_urls')),
-
     flagged_url('TDP_BB_TOOL',
             r'^practitioner-resources/youth-financial-education/learn-about-the-building-blocks/take-a-tour',  # noqa: E501
             include_if_app_enabled('teachers_digital_platform',

--- a/requirements/optional-public.txt
+++ b/requirements/optional-public.txt
@@ -7,4 +7,4 @@ https://github.com/cfpb/retirement/releases/download/0.7.0/retirement-0.7.0-py2-
 git+https://github.com/cfpb/ccdb5-api.git@v1.0.6#egg=ccdb5-api
 git+https://github.com/cfpb/ccdb5-ui.git@v1.0.11#egg=ccdb5_ui
 https://github.com/cfpb/django-college-costs-comparison/releases/download/1.7/comparisontool-1.7-py2-none-any.whl
-https://github.com/cfpb/teachers-digital-platform/releases/download/1.0.8/teachers_digital_platform-1.0.8-py2-none-any.whl
+https://github.com/cfpb/teachers-digital-platform/releases/download/1.0.9/teachers_digital_platform-1.0.9-py2-none-any.whl


### PR DESCRIPTION
Releasing improvements to the TDP Activity detail page and initial search page development behind a feature flag.

## Additions

- Removed unused urls.py feature flag and added it directly to the routable SearchIndexPage
- Bumped TDP from release 1.0.8 to 1.0.9

## Reviewers
@Scotchester @willbarton @higs4281 @chosak 

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Internet Explorer 8, 9, 10, and 11
- [ ] Edge
- [ ] iOS Safari
- [ ] Chrome for Android

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
