### PR TITLE
Fix sizing mistake in Form Explainer styles

### DIFF
--- a/cfgov/unprocessed/apps/owning-a-home/css/form-explainer.less
+++ b/cfgov/unprocessed/apps/owning-a-home/css/form-explainer.less
@@ -121,7 +121,7 @@
         }
 
         .o-expandable_label {
-            font-size: unit( @base-font-size-px, em );
+            font-size: unit( 16 / @base-font-size-px, em );
         }
 
         &.o-expandable__form-explainer-checklist {


### PR DESCRIPTION
A little code review fix that didn't get fully tested slipped into the PR that updated all the expandables, causing giant text and icons in the Form Explainer expandables.

## Changes

- Correctly calculate size of text and icons in Form Explainer expandable labels

## Testing

1. Pull branch
1. `./frontend.sh`
1. Run the server
1. Go to http://localhost:8000/owning-a-home/loan-estimate/ and see appropriately-sized expandable labels on the right side.

## Screenshots

### Before

![screen shot 2018-08-10 at 09 50 01](https://user-images.githubusercontent.com/1044670/43961417-eb2bd500-9c82-11e8-9b7f-a484a532a63b.png)

### After

![screen shot 2018-08-10 at 09 50 44](https://user-images.githubusercontent.com/1044670/43961430-f1ba4c80-9c82-11e8-9bbe-b5a0442139c6.png)

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [x] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: