### PR TITLE
Parse links middleware fix: Add back expand_db_html call

### DIFF
--- a/cfgov/core/middleware.py
+++ b/cfgov/core/middleware.py
@@ -2,6 +2,8 @@ from six import text_type as str
 
 from django.conf import settings
 
+from wagtail.wagtailcore.rich_text import expand_db_html
+
 from bs4 import BeautifulSoup
 
 from core.utils import add_link_markup, get_link_tags
@@ -33,7 +35,7 @@ def parse_links(html, encoding=None):
     if encoding is None:
         encoding = settings.DEFAULT_CHARSET
     html = html.decode(encoding)
-
+    html = expand_db_html(html)
     soup = BeautifulSoup(html, 'html.parser')
     link_tags = get_link_tags(soup)
     for tag in link_tags:

--- a/cfgov/core/tests/test_middleware.py
+++ b/cfgov/core/tests/test_middleware.py
@@ -3,6 +3,8 @@ from django.test import TestCase, override_settings
 import mock
 
 from core.middleware import parse_links, should_parse_links
+from v1.models import CFGOVPage
+from v1.tests.wagtail_pages.helpers import publish_page
 
 
 class TestParseLinksMiddleware(TestCase):
@@ -74,3 +76,10 @@ class TestParseLinks(TestCase):
         link = b'<a href="/something.PDF">link</a>'
         output = parse_links(link)
         self.assertIn(b'cf-icon-svg', output)
+
+    def test_rich_text_links_get_expanded(self):
+        page = CFGOVPage(title='foo bar', slug='foo-bar')
+        publish_page(page)
+        link = b'<a id="{}" linktype="page">foo bar</a>'.format(page.id)
+        output = parse_links(link)
+        self.assertEqual(b'<a href="/foo-bar/">foo bar</a>', output)


### PR DESCRIPTION
## Overview
Fixes a bug introduced in https://github.com/cfpb/cfgov-refresh/pull/4363, which refactored `parse_links` and removed a call to `expand_db_html`.   As a result, I had added a call to the `richtext` filter [here](https://github.com/cfpb/cfgov-refresh/pull/4363/files#diff-6a8e044564accdfeb5d0bd4c115b59afL52) but as reported in GHE/CFGOV/platform/issues/2956, this is not comprehensive.  

## Notes
- Instead of adding several `richtext` calls across templates, which I believe would be hard to maintain for the same reasons our previous usage of `parse_links` was, I thought it would be best to add back in the call to `expand_db_html`.  
- We'll want to do some additional clean-up if we go with this approach, which is removing any template calls to `richtext`, since those would no longer be needed.  I'd rather do that clean-up work in a separate PR though, since it also involves updating some tests.

## Testing
This fixes the links reported in the GHE issue. To test, visit the pages reported in that issue and confirm the links are working on my branch. I also added a test to confirm that the internal page link representation gets expanded as expected.