### PR TITLE
Change to https, adds note about domain

### DIFF
--- a/cfgov/legacy/templates/common/reset_password_email.html
+++ b/cfgov/legacy/templates/common/reset_password_email.html
@@ -1,4 +1,6 @@
     {% load i18n wagtailadmin_tags %}{% base_url_setting as base_url %}
+    Note: Please change 'http' to 'https' and remove ':443' if these appear in the password reset link.
+
     {% trans "Please follow the link below to reset your password:" %}
     {% if base_url %}{{ base_url }}{% else %}{{ protocol }}://{{ domain }}{% endif %}{% url 'wagtailadmin_password_reset_confirm' uidb64=uid token=token %}
 
@@ -6,9 +8,6 @@
     {% trans "Your username (in case you've forgotten):" %} {{ user.get_username }}
     {% endif %}
 
-    Note: Please change 'http' to 'https' and remove ':443' if these appear in the password reset link above.
-
-    
     Thanks for using our site!
 
     The {{ site_name }} team.

--- a/cfgov/legacy/templates/common/reset_password_email.html
+++ b/cfgov/legacy/templates/common/reset_password_email.html
@@ -3,9 +3,11 @@
 
     Please go to the following page and choose a new password:
     {% block reset_link %}
-       http://{{ domain }}{% url 'reset_password' uidb36=uid token=token %}
+       https://{{ domain }}{% url 'reset_password' uidb36=uid token=token %}
     {% endblock %}
     Your username, in case you've forgotten: {{ user.username }}
+
+    Note: If you see a ':443' in the URL above, please remove it before navigating to the password reset page.
 
     Thanks for using our site!
 

--- a/cfgov/templates/wagtailadmin/account/password_reset/email.txt
+++ b/cfgov/templates/wagtailadmin/account/password_reset/email.txt
@@ -1,13 +1,12 @@
     {% load i18n wagtailadmin_tags %}{% base_url_setting as base_url %}
+    Note: Please change 'http' to 'https' and remove ':443' if these appear in the password reset link.
+
     {% trans "Please follow the link below to reset your password:" %}
     {% if base_url %}{{ base_url }}{% else %}{{ protocol }}://{{ domain }}{% endif %}{% url 'wagtailadmin_password_reset_confirm' uidb64=uid token=token %}
 
     {% if user.USERNAME_FIELD != "email" %}
     {% trans "Your username (in case you've forgotten):" %} {{ user.get_username }}
     {% endif %}
-
-    Note: If you see a ':443' in the URL above, please remove it before navigating to the password reset page.
-
 
     Thanks for using our site!
 

--- a/cfgov/templates/wagtailadmin/account/password_reset/email.txt
+++ b/cfgov/templates/wagtailadmin/account/password_reset/email.txt
@@ -6,9 +6,9 @@
     {% trans "Your username (in case you've forgotten):" %} {{ user.get_username }}
     {% endif %}
 
-    Note: Please change 'http' to 'https' and remove ':443' if these appear in the password reset link above.
+    Note: If you see a ':443' in the URL above, please remove it before navigating to the password reset page.
 
-    
+
     Thanks for using our site!
 
     The {{ site_name }} team.


### PR DESCRIPTION
Changes password reset link from `http` to `https`.

We still need to figure out why `domain` is returning the site plus `:443`, but until then we will include the instructions to remove it in the password reset email.

## Testing

1. Open your local instance and go to the password reset page
    - e.g. http://0.0.0.0:8000/admin/password_reset/
1. Enter your email address and click the `reset password` button
1. Check your console - an email will have printed there
1. Check that the email includes a note about `:443` and `https`

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
