### PR TITLE
Fix missing context in FCMs, part 2

### DIFF
--- a/cfgov/jinja2/v1/browse-basic/index.html
+++ b/cfgov/jinja2/v1/browse-basic/index.html
@@ -1,7 +1,7 @@
 {% extends 'layout-side-nav.html' %}
 
 {% import 'form_block.html' as form_block with context %}
-{% import 'organisms/featured-content.html' as featured_content %}
+{% import 'organisms/featured-content.html' as featured_content with context %}
 {% import 'templates/render_block.html' as render_block with context %}
 {% import 'templates/streamfield-sidefoot.html' as streamfield_sidefoot with context %}
 

--- a/cfgov/jinja2/v1/browse-filterable/index.html
+++ b/cfgov/jinja2/v1/browse-filterable/index.html
@@ -1,7 +1,7 @@
 {% extends 'layout-side-nav.html' %}
 
 {% import 'form_block.html' as form_block with context %}
-{% import 'organisms/featured-content.html' as featured_content %}
+{% import 'organisms/featured-content.html' as featured_content with context %}
 {% import 'organisms/filterable-list-controls.html' as flc with context %}
 {% import 'templates/render_block.html' as render_block with context %}
 {% import 'templates/streamfield-sidefoot.html' as streamfield_sidefoot with context %}

--- a/cfgov/jinja2/v1/newsroom/index.html
+++ b/cfgov/jinja2/v1/newsroom/index.html
@@ -1,6 +1,6 @@
 {% extends 'layout-side-nav.html' %}
 
-{% import 'organisms/featured-content.html' as featured_content %}
+{% import 'organisms/featured-content.html' as featured_content with context %}
 {% import 'templates/streamfield-sidefoot.html' as streamfield_sidefoot with context %}
 
 {% block content_main_modifiers -%}

--- a/cfgov/regulations3k/jinja2/regulations3k/browse-regulation.html
+++ b/cfgov/regulations3k/jinja2/regulations3k/browse-regulation.html
@@ -1,7 +1,7 @@
 {% extends 'eregs/regulations3k-side-nav.html' %}
 
 {% import 'form_block.html' as form_block with context %}
-{% import 'organisms/featured-content.html' as featured_content %}
+{% import 'organisms/featured-content.html' as featured_content with context %}
 {% import 'eregs/regulations3k-search-bar.html' as search_bar with context %}
 {% import 'templates/render_block.html' as render_block with context %}
 {% import 'templates/streamfield-sidefoot.html' as streamfield_sidefoot with context %}


### PR DESCRIPTION
This change was made on Sublanding Pages in #4429 but also needs to be applied on these templates.

## Changes
- Updates Browse, BrowseFilterable, Newsroom, and BrowseRegulation templates to pass the context into the FCM macro

## Testing
1. Visit http://localhost:8000/about-us/careers/application-process/ and see a 500
1. Pull branch
1. http://localhost:8000/about-us/careers/application-process/, play the video, and see it working properly

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [x] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: