### PR TITLE
Regs3k: Preview sections from the admin

### DIFF
--- a/cfgov/regulations3k/migrations/0015_rename_regpage_part_related_field.py
+++ b/cfgov/regulations3k/migrations/0015_rename_regpage_part_related_field.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('regulations3k', '0014_rm_imageinset_and_media_from_fullwidthtext'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='regulationpage',
+            name='regulation',
+            field=models.ForeignKey(related_name='page', on_delete=django.db.models.deletion.PROTECT, blank=True, to='regulations3k.Part', null=True),
+        ),
+    ]

--- a/cfgov/regulations3k/models/pages.py
+++ b/cfgov/regulations3k/models/pages.py
@@ -209,7 +209,7 @@ class RegulationPage(RoutablePageMixin, SecondaryNavigationJSMixin, CFGOVPage):
         blank=True,
         null=True,
         on_delete=models.PROTECT,
-        related_name='eregs3k_page'
+        related_name='page'
     )
 
     content_panels = CFGOVPage.content_panels + [

--- a/cfgov/regulations3k/tests/test_hooks.py
+++ b/cfgov/regulations3k/tests/test_hooks.py
@@ -1,13 +1,55 @@
 from __future__ import unicode_literals
 
+from datetime import date
+
 from django.test import TestCase
 
 from wagtail.tests.utils import WagtailTestUtils
+
+from model_mommy import mommy
+
+from regulations3k.models.django import (
+    EffectiveVersion, Part, Section, Subpart
+)
+from regulations3k.models.pages import RegulationLandingPage, RegulationPage
 
 
 class TestRegs3kHooks(TestCase, WagtailTestUtils):
 
     def setUp(self):
+        from v1.models import HomePage
+        self.ROOT_PAGE = HomePage.objects.get(slug='cfgov')
+        self.landing_page = RegulationLandingPage(
+            title='Reg Landing', slug='reg-landing')
+        self.ROOT_PAGE.add_child(instance=self.landing_page)
+
+        self.part_1002 = mommy.make(
+            Part,
+            part_number='1002',
+            title='Equal Credit Opportunity Act',
+            letter_code='B',
+            chapter='X'
+        )
+        self.effective_version = mommy.make(
+            EffectiveVersion,
+            effective_date=date(2014, 1, 18),
+            part=self.part_1002
+        )
+        self.subpart = mommy.make(
+            Subpart,
+            label='Subpart General',
+            title='General',
+            subpart_type=Subpart.BODY,
+            version=self.effective_version
+        )
+        self.section_num4 = mommy.make(
+            Section,
+            label='4',
+            title='\xa7\xa01002.4 General rules.',
+            contents='{a}\n(a) Regdown paragraph a.\n',
+            subpart=self.subpart,
+        )
+
         self.login()
 
     def test_part_model_admin(self):
@@ -25,3 +67,20 @@ class TestRegs3kHooks(TestCase, WagtailTestUtils):
     def test_section_model_admin(self):
         response = self.client.get('/admin/regulations3k/section/')
         self.assertEqual(response.status_code, 200)
+
+    def test_section_model_admin_no_preview_button(self):
+        response = self.client.get('/admin/regulations3k/section/')
+        self.assertEqual(response.status_code, 200)
+        self.assertNotIn(b'Preview', response.content)
+
+    def test_section_model_admin_has_preview_button(self):
+        reg_page = RegulationPage(
+            regulation=self.part_1002,
+            title='Reg B',
+            slug='1002')
+        self.landing_page.add_child(instance=reg_page)
+        reg_page.save()
+
+        response = self.client.get('/admin/regulations3k/section/')
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b'Preview', response.content)

--- a/cfgov/regulations3k/wagtail_hooks.py
+++ b/cfgov/regulations3k/wagtail_hooks.py
@@ -5,9 +5,37 @@ from datetime import date
 from wagtail.contrib.modeladmin.options import modeladmin_register
 
 from treemodeladmin.options import TreeModelAdmin
+from treemodeladmin.views import TreeIndexView
 
 from regulations3k.copyable_modeladmin import CopyableModelAdmin
 from regulations3k.models import EffectiveVersion, Part, Section, Subpart
+
+
+class SectionPreviewIndexView(TreeIndexView):
+
+    def get_buttons_for_obj(self, obj):
+        btns = self.button_helper.get_buttons_for_obj(
+            obj, classnames_add=['button-small', 'button-secondary'])
+
+        effective_version = obj.subpart.version
+        date_str = effective_version.effective_date.isoformat()
+        part = obj.subpart.version.part
+        page = part.page.first()
+
+        if page is not None:
+            preview_url = page.url + page.reverse_subpage(
+                'section',
+                kwargs={'date_str': date_str, 'section_label': obj.label}
+            )
+            preview_button = {
+                'url': preview_url,
+                'label': 'Preview',
+                'classname': 'button button-small button-secondary',
+                'title': 'Preview this {}'.format(self.verbose_name),
+            }
+            btns.insert(-1, preview_button)
+
+        return btns
 
 
 class SectionModelAdmin(TreeModelAdmin):
@@ -20,6 +48,7 @@ class SectionModelAdmin(TreeModelAdmin):
     search_fields = (
         'label', 'title')
     parent_field = 'subpart'
+    index_view_class = SectionPreviewIndexView
 
 
 class SubpartModelAdmin(TreeModelAdmin):


### PR DESCRIPTION
This PR adds a button to the Regulations3k Section model admin to allow a user to view or preview a section whether the effective version it belongs to is live or not. This uses the functionality added in #4426 to allow for viewing an effective version that is not yet live if the user has permission to edit the regulation page.

![image](https://user-images.githubusercontent.com/10562538/44113277-8b143ea4-9fd5-11e8-8349-2787c30b3e37.png)

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
