### PR TITLE
Bump Wagtail to 1.13.3

### DIFF
--- a/requirements/wagtail.txt
+++ b/requirements/wagtail.txt
@@ -1,1 +1,1 @@
-wagtail==1.13.2
+wagtail==1.13.3


### PR DESCRIPTION
Fixes incompatibility reported in https://github.com/wagtail/wagtail/issues/4725.

Following the instructions in that that issue as reported by @chosak, but with 1.13.3 swapped for 1.13.2 should report no errors.