### PR TITLE
Support running unit tests against Django 1.11

### DIFF
--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -739,3 +739,8 @@ PARSE_LINKS_BLACKLIST = [
     '/admin/',
     '/django-admin/'
 ]
+
+# Required by django-extensions to determine the execution directory used by
+# scripts executed with the "runscript" management command.
+# See https://django-extensions.readthedocs.io/en/latest/runscript.html.
+BASE_DIR = 'scripts'

--- a/cfgov/cfgov/settings/test_nomigrations.py
+++ b/cfgov/cfgov/settings/test_nomigrations.py
@@ -1,6 +1,13 @@
+from collections import defaultdict
+
+import django
+
 from core.utils import NoMigrations
 
 from .test import *
 
 
-MIGRATION_MODULES = NoMigrations()
+if django.VERSION[:2] < (1, 9):
+    MIGRATION_MODULES = NoMigrations()
+else:
+    MIGRATION_MODULES = defaultdict(None)

--- a/cfgov/cfgov/urls.py
+++ b/cfgov/cfgov/urls.py
@@ -22,7 +22,9 @@ from ask_cfpb.views import (
     ask_autocomplete, ask_search, print_answer, redirect_ask_search,
     view_answer
 )
-from core.views import ExternalURLNoticeView
+from core.views import (
+    ExternalURLNoticeView, govdelivery_subscribe, regsgov_comment
+)
 from legacy.views import token_provider
 from legacy.views.housing_counselor import (
     HousingCounselorPDFView, HousingCounselorView
@@ -150,9 +152,7 @@ urlpatterns = [
     url(r'^external-site/$', ExternalURLNoticeView.as_view(),
         name='external-site'),
 
-    url(r'^subscriptions/new/$',
-        'core.views.govdelivery_subscribe',
-        name='govdelivery'),
+    url(r'^subscriptions/new/$', govdelivery_subscribe, name='govdelivery'),
 
     url(r'^govdelivery-subscribe/', include([
         url(r'^success/$',
@@ -169,9 +169,7 @@ urlpatterns = [
             name='server_error')],
         namespace='govdelivery')),
 
-    url(r'^regulation-comment/new/$',
-        'core.views.regsgov_comment',
-        name='reg_comment'),
+    url(r'^regulation-comment/new/$', regsgov_comment, name='reg_comment'),
 
     url(r'^regulation-comment/', include([
         url(r'^success/$',
@@ -452,7 +450,7 @@ if settings.ALLOW_ADMIN_URL:
                 name='password_reset_confirm')
         ])),
         url(r'^django-admin/password_change',
-            'django.contrib.auth.views.password_change',
+            auth_views.password_change,
             {'password_change_form': CFGOVPasswordChangeForm}),
         url(r'^password/change/done/$',
             auth_views.password_change_done,

--- a/cfgov/v1/wagtail_hooks.py
+++ b/cfgov/v1/wagtail_hooks.py
@@ -12,6 +12,7 @@ from wagtail.contrib.modeladmin.options import ModelAdmin, modeladmin_register
 from wagtail.wagtailadmin.menu import MenuItem
 from wagtail.wagtailcore import hooks
 
+from v1.admin_views import manage_cdn
 from v1.models.menu_item import MenuItem as MegaMenuItem
 from v1.util import util
 
@@ -131,8 +132,7 @@ def register_frank_menu_item():
 
 @hooks.register('register_admin_urls')
 def register_flag_admin_urls():
-    handler = 'v1.admin_views.manage_cdn'
-    return [url(r'^cdn/$', handler, name='manage-cdn'), ]
+    return [url(r'^cdn/$', manage_cdn, name='manage-cdn'), ]
 
 
 @hooks.register('before_serve_page')

--- a/requirements/libraries.txt
+++ b/requirements/libraries.txt
@@ -5,13 +5,13 @@ boto3==1.5.9
 dj-database-url==0.4.2
 djangorestframework==3.1.3
 djangorestframework-csv==2.0.0
-django-csp==3.1
+django-csp==3.4
 django-braces==1.0.0
 django-extensions==2.1.0
 django-flags==3.0.0
-django-haystack==2.6.0
+django-haystack==2.7.0
 django-localflavor==1.1
-django-overextends==0.4.1
+django-overextends==0.4.3
 django-storages==1.1.8
 # django-taggit 0.23.0 requires Django 1.11. Normally django-taggit is pulled
 # in by Wagtail's setup.py, but Wagtail 1.13 specifies >0.20,<1.0, which

--- a/requirements/libraries.txt
+++ b/requirements/libraries.txt
@@ -7,7 +7,7 @@ djangorestframework==3.1.3
 djangorestframework-csv==2.0.0
 django-csp==3.1
 django-braces==1.0.0
-django-extensions==1.5.5
+django-extensions==2.1.0
 django-flags==3.0.0
 django-haystack==2.6.0
 django-localflavor==1.1


### PR DESCRIPTION
Currently when trying to run Python unit tests against Django 1.11, for example with this command:

`tox -r -e unittest-py27-dj111-wag113-slow`

the test runner command fails immediately, before any tests are run. This change fixes a few things that are incompatible with Django 1.11, which allows the test command to run, and individual test failures to be reported. This does not actually make the tests work, but at least lets them run.

All tests continue to pass with Django 1.8.

Specific changes are:

- As of 1.9, the use of `settings.MIGRATION_MODULES` to disable migrations has changed, and so our logic in cfgov.settings.test_nomigrations must as well. See Django docs at https://docs.djangoproject.com/en/2.1/releases/1.9/#migrations.
- As of 1.10, support for string view paths to `url()` has been removed, and the module itself must be passed. See Django docs at https://docs.djangoproject.com/en/2.1/releases/1.10/#features-removed-in-1-10.
- The version of django-extensions we were using, 1.5.5, is not compatible with Django 1.11 due to the existence of a migration that tries to import from South. Support for Django 1.11 is added to django-extensions in version 1.7.8. This PR bumps the version to the latest one, 2.1.0, which will include Django 2.0 support in future.

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [X] Passes all existing automated tests
- [X] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: