### PR TITLE
Fix inline interpretation styles in regulations

### DIFF
--- a/cfgov/regulations3k/jinja2/regulations3k/inline_interps.html
+++ b/cfgov/regulations3k/jinja2/regulations3k/inline_interps.html
@@ -6,7 +6,7 @@
             inline-interpretation">
 
     <button class="o-expandable_header o-expandable_target">
-        <span class="h4 o-expandable_header-left o-expandable_label">
+        <span class="o-expandable_header-left o-expandable_label">
             Official interpretation {% if section_title %}of {{ section_title }}{% endif %}
         </span>
         <span class="o-expandable_header-right o-expandable_link">

--- a/cfgov/unprocessed/apps/regulations3k/css/reg-inline-interpretations.less
+++ b/cfgov/unprocessed/apps/regulations3k/css/reg-inline-interpretations.less
@@ -4,11 +4,8 @@
    ========================================================================== */
 
 .inline-interpretation {
-    margin-bottom: .9375em;
+    margin-bottom: 1.875em;
     max-width: 41.875rem;
-    p:last-child {
-      margin-bottom: .9375em;
-    }
 }
 
 .generateInterpLevel(6);


### PR DESCRIPTION
A couple of small fixes to inline interpretation styles to match the designs

## Changes

- Style the header as paragraph (instead of an `h4`)
- Adjust bottom padding to 15px (instead of 30px)
- Adjust bottom margin to 30px (instead of 15px)

## Testing

1. Fire up Regulations 3000 as you normally do
2. Go to any regulations section with inline interpretations, like `/policy-compliance/rulemaking/regulations/1005/2/`
3. Verify that:
    - The text in `.o-expandable_label` is 16px Avenir Next 500
    - There's 15px of padding at the bottom of the expandable
    - There's 30px of margin between the bottom of an expandable and the subsequent paragraph

## Screenshots

![interp-spacing](https://user-images.githubusercontent.com/1862695/44273780-686cc200-a20e-11e8-8053-55050d913867.png)

## Todos

- This PR only fixes the styles of the inline interpretation. We may want to consider changing the markup to make `.o-expandable_label` something more semantic than a `span`, but that seems like it needs more discussion and it outside the scope of these CSS updates.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [x] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Internet Explorer 8, 9, 10, and 11
- [ ] Edge
- [ ] iOS Safari
- [ ] Chrome for Android

### Accessibility

- [x] Keyboard friendly
- [x] Screen reader friendly

### Other

- [x] Is useable without CSS
- [x] Is useable without JS
- [x] Flexible from small to large screens
- [x] No linting errors or warnings
- [x] JavaScript tests are passing