### PR TITLE
Modify conference registration form for FinEx conf

### DIFF
--- a/cfgov/data_research/forms.py
+++ b/cfgov/data_research/forms.py
@@ -5,7 +5,7 @@ from django import forms
 from core.govdelivery import get_govdelivery_api
 from data_research.models import ConferenceRegistration
 from data_research.widgets import (
-    CheckboxSelectMultiple, EmailInput, Textarea, TextInput
+    CheckboxSelectMultiple, EmailInput, RadioSelect, Textarea, TextInput
 )
 
 
@@ -19,6 +19,11 @@ class ConferenceRegistrationForm(forms.Form):
     If save(commit=False) is used, a model instance is created but not
     persisted to the database, and GovDelivery subscription is skipped.
     """
+    ATTENDEE_TYPES = tuple((t, t) for t in (
+        'In person',
+        'Virtually',
+    ))
+
     SESSIONS = tuple((s, s) for s in (
         'Thursday morning',
         'Thursday lunch',
@@ -40,18 +45,24 @@ class ConferenceRegistrationForm(forms.Form):
         'Nursing Space',
     ))
 
+    attendee_type = forms.ChoiceField(
+        widget=RadioSelect,
+        choices=ATTENDEE_TYPES,
+        required=True,
+        label='Do you plan to attend in person or virtually?',
+    )
     name = forms.CharField(max_length=250, widget=TextInput(required=True))
     organization = forms.CharField(max_length=250, required=False,
                                    widget=TextInput)
     email = forms.EmailField(max_length=250, widget=EmailInput(required=True))
-    sessions = forms.MultipleChoiceField(
-        widget=CheckboxSelectMultiple,
-        choices=SESSIONS,
-        label="Which sessions will you be attending?",
-        error_messages={
-            'required': "You must select at least one session to attend.",
-        }
-    )
+    # sessions = forms.MultipleChoiceField(
+    #     widget=CheckboxSelectMultiple,
+    #     choices=SESSIONS,
+    #     label="Which sessions will you be attending?",
+    #     error_messages={
+    #         'required': "You must select at least one session to attend.",
+    #     }
+    # )
     dietary_restrictions = forms.MultipleChoiceField(
         widget=CheckboxSelectMultiple,
         choices=DIETARY_RESTRICTIONS,

--- a/cfgov/data_research/handlers.py
+++ b/cfgov/data_research/handlers.py
@@ -5,7 +5,6 @@ import logging
 from django.http import HttpResponseRedirect
 
 from data_research.forms import ConferenceRegistrationForm
-from data_research.models import ConferenceRegistration
 from v1.handlers import Handler
 
 
@@ -28,8 +27,12 @@ class ConferenceRegistrationHandler(Handler):
         self.form_cls = form_cls or ConferenceRegistrationForm
 
     def process(self, is_submitted):
-        is_at_capacity = self._is_at_capacity()
         is_successful_submission = self._is_successful_submission()
+
+        form_kwargs = {
+            'capacity': self.capacity,
+            'govdelivery_code': self.govdelivery_code,
+        }
 
         # If the form was submitted, and there's still room in the conference,
         # and this isn't being processed as part of the response after a
@@ -38,19 +41,10 @@ class ConferenceRegistrationHandler(Handler):
             is_submitted and
             not is_successful_submission
         ):
-            form = self.form_cls(
-                govdelivery_code=self.govdelivery_code,
-                data=self.request.POST
-            )
+            form = self.form_cls(data=self.request.POST, **form_kwargs)
 
             try:
-                if (
-                    form.is_valid() and
-                    (
-                        not is_at_capacity or
-                        form.data['attendee_type'] == "Virtually"
-                    )
-                ):
+                if form.is_valid():
                     form.save()
 
                     return HttpResponseRedirect('{}?{}'.format(
@@ -61,25 +55,13 @@ class ConferenceRegistrationHandler(Handler):
                 logger.exception("conference registration form error")
                 form.add_error(None, self.failure_message)
         else:
-            form = self.form_cls(govdelivery_code=self.govdelivery_code)
+            form = self.form_cls(**form_kwargs)
 
         return {
             'form': form,
-            'is_at_capacity': is_at_capacity,
+            'is_at_capacity': form.at_capacity,
             'is_successful_submission': is_successful_submission,
         }
-
-    def _is_at_capacity(self):
-        attendees = ConferenceRegistration.objects.filter(
-            govdelivery_code=self.govdelivery_code,
-        )
-
-        in_person_attendees = filter(
-            lambda a: a.details['attendee_type'] == 'In person',
-            attendees
-        )
-
-        return len(in_person_attendees) >= self.capacity
 
     def _is_successful_submission(self):
         return self.SUCCESS_QUERY_STRING_PARAMETER in self.request.GET

--- a/cfgov/data_research/jinja2/data_research/conference-registration-form.html
+++ b/cfgov/data_research/jinja2/data_research/conference-registration-form.html
@@ -2,37 +2,33 @@
 {% import 'molecules/notification.html' as notification %}
 
 {% macro render(value, settings, form_id) %}
+
     {#
-        If the conference is already at capacity, just show a message telling
-        the user. Uses the `at_capacity_message` value entered by the user in
+        If the form was just successfully submitted, display a message
+        telling the user. Uses the `is_successful_submission` value
+        provided by the ConferenceRegistrationHandler class.
+    #}
+
+    {% if settings.is_successful_submission %}
+        <div class="block block__flush-top">
+            {{- notification.render(
+                'success',
+                true,
+                value.success_message
+            ) }}
+        </div>
+    {% endif %}
+
+    {#
+        If the conference is already at capacity, show a message telling
+        the user and display form with only the ability to register virtually.
+        Uses the `at_capacity_message` value entered by the user in
         the ConferenceRegistrationForm in the Wagtail admin.
     #}
     {% if settings.is_at_capacity %}
         <div class="block block__flush-top">
             {{ value.at_capacity_message }}
         </div>
-    {% else %}
-
-        {#
-            If the form was just successfully submitted, display a message
-            telling the user. Uses the `is_successful_submission` value
-            provided by the ConferenceRegistrationHandler class.
-        #}
-
-        {% if settings.is_successful_submission %}
-            <div class="block block__flush-top">
-                {{- notification.render(
-                    'success',
-                    true,
-                    value.success_message
-                ) }}
-            </div>
-        {% endif %}
-
-        {#
-            Display any error messages created during form submission.
-            Rendered above the form for styling purposes.
-        #}
 
         {#
             Display the conference registration form itself. Uses the `form`
@@ -47,6 +43,11 @@
               action="."
               class="o-form js-validate-filters"
          >
+
+            {#
+                Display any error messages created during form submission.
+                Rendered above the form for styling purposes.
+            #}
             <div class="u-mb15">
             {% set form = settings.form %}
             {% for error in form.non_field_errors() %}
@@ -69,6 +70,13 @@
                 difficult to reconcile Django's form field rendering with how
                 Capital Framework wants fields to be wrapped.
             #}
+
+            {# Attendee Type -- Only virtual allowed when at capacity #}
+            <div class="o-form_group">
+                <b>Note:</b> Physical attendee capacity has been reached;
+                you may still register to attend virtually.
+                <input type="hidden" name="attendee_type" value="Virtually">
+            </div>
 
             {# Name #}
             <div class="o-form_group">
@@ -104,15 +112,125 @@
             </div>
 
             {# Sessions attending #}
-            <div class="o-form_group{% if form.sessions.errors %} m-form-field__error{% endif %}">
+            {# <div class="o-form_group{% if form.sessions.errors %} m-form-field__error{% endif %}">
                 <legend class="a-legend"
                         for="{{ form.sessions.id_for_label }}"
                 >{{ form.sessions.label }}</legend>
                 <fieldset class="o-form_fieldset">
                     {{ form.sessions }}
                 </fieldset>
+            </div> #}
+
+            {# Accommodations #}
+            <div class="o-form_group">
+                <div class="m-form-field">
+                    <label class="a-label"
+                           for="{{ form.other_accommodations.id_for_label }}"
+                    >Any accessibility accommodations needed to attend?</label>
+                    {{ form.other_accommodations }}
+                </div>
             </div>
-            
+
+            {{ submit_button.render({'button_text': 'Register'})}}
+        </form>
+        </section>
+
+    {% else %}
+
+        {#
+            Display the conference registration form itself. Uses the `form`
+            object provided by the ConferenceRegistrationHandler. This may
+            be an empty form on first load or may contain user input that
+            failed validation and is being displayed with one or more errors.
+        #}
+
+        <section class="o-form-section">
+        <form id="registration-form"
+              method="post"
+              action="."
+              class="o-form js-validate-filters"
+         >
+
+            {#
+                Display any error messages created during form submission.
+                Rendered above the form for styling purposes.
+            #}
+            <div class="u-mb15">
+            {% set form = settings.form %}
+            {% for error in form.non_field_errors() %}
+                {{- notification.render('error', true, error) }}
+            {% endfor %}
+            {% for field in form %}
+                {% for error in field.errors %}
+                    {{- notification.render('error', true, error) }}
+                {% endfor %}
+            {% endfor %}
+            </div>
+
+            <input type="hidden" name="form_id" value="{{ form_id }}">
+
+            {{ csrf_input }}
+
+            {#
+                It would be preferable to be able to loop over form.fields
+                here instead of hardcoding them here, but unfortunately it's
+                difficult to reconcile Django's form field rendering with how
+                Capital Framework wants fields to be wrapped.
+            #}
+
+            {# Attendee Type #}
+            <div class="o-form_group">
+                <legend class="a-legend">
+                    {{ form.attendee_type.label }}
+                </legend>
+                <fieldset class="o-form_fieldset">
+                    {{ form.attendee_type }}
+                </fieldset>
+            </div>
+
+            {# Name #}
+            <div class="o-form_group">
+                <div class="m-form-field">
+                    <label class="a-label a-label__heading"
+                           for="{{ form.name.id_for_label }}"
+                    >{{ form.name.label }}</label>
+                    {{ form.name }}
+                </div>
+            </div>
+
+            {# Organization #}
+            <div class="o-form_group">
+                <div class="m-form-field">
+                    <label class="a-label a-label__heading"
+                           for="{{ form.organization.id_for_label }}"
+                    >
+                        {{ form.organization.label }}
+                        <small class="a-label_helper">(optional)</small>
+                    </label>
+                    {{ form.organization }}
+                </div>
+            </div>
+
+            {# Email #}
+            <div class="o-form_group">
+                <div class="m-form-field">
+                    <label class="a-label a-label__heading"
+                           for="{{ form.email.id_for_label }}"
+                    >{{ form.email.label }}</label>
+                    {{ form.email }}
+                </div>
+            </div>
+
+            {# Sessions attending #}
+            {# <div class="o-form_group{% if form.sessions.errors %} m-form-field__error{% endif %}">
+                <legend class="a-legend"
+                        for="{{ form.sessions.id_for_label }}"
+                >{{ form.sessions.label }}</legend>
+                <fieldset class="o-form_fieldset">
+                    {{ form.sessions }}
+                </fieldset>
+            </div> #}
+
             {# Dietary restrictions #}
             <div class="o-form_group">
                 <legend class="a-legend">

--- a/cfgov/data_research/research_conference.py
+++ b/cfgov/data_research/research_conference.py
@@ -88,7 +88,7 @@ class ConferenceNotifier(object):
 
     Looks up conference attendees by GovDelivery code.
     """
-    conference_name = '2018 CFPB Research Conference'
+    conference_name = '2018 CFPB FinEx Conference'
     subject_template_name = 'data_research/conference_notify_subject.txt'
     email_template_name = 'data_research/conference_notify_email.txt'
     attachment_filename = 'conference_registrations.xlsx'

--- a/cfgov/data_research/research_conference.py
+++ b/cfgov/data_research/research_conference.py
@@ -52,7 +52,8 @@ class ConferenceExporter(object):
     @cached_property
     def fields(self):
         form = ConferenceRegistrationForm(
-            govdelivery_code=self.govdelivery_code
+            govdelivery_code=self.govdelivery_code,
+            capacity=0
         )
 
         return ['created'] + form.fields.keys()

--- a/cfgov/data_research/tests/management/commands/test_conference_export.py
+++ b/cfgov/data_research/tests/management/commands/test_conference_export.py
@@ -17,5 +17,5 @@ class ConferenceExportTests(TestCase):
             call_command('conference_export', 'TEST-GOVDELIVERY-CODE', f.name)
 
             workbook = load_workbook(f.name)
-            self.assertEqual(workbook.active['B2'].value, 'My Name')
-            self.assertEqual(workbook.active['B3'].value, 'Name with Unicodë')
+            self.assertEqual(workbook.active['C2'].value, 'My Name')
+            self.assertEqual(workbook.active['C3'].value, 'Name with Unicodë')

--- a/cfgov/data_research/tests/management/commands/test_conference_notify.py
+++ b/cfgov/data_research/tests/management/commands/test_conference_notify.py
@@ -24,7 +24,7 @@ class ConferenceNotifyTests(TestCase):
         self.assertEqual(len(mail.outbox), 1)
         self.assertEqual(
             mail.outbox[0].subject,
-            '[2018 CFPB Research Conference] Attendance Update'
+            '[2018 CFPB FinEx Conference] Attendance Update'
         )
         self.assertEqual(mail.outbox[0].from_email, 'donotreply@cfpb.gov')
         self.assertEqual(mail.outbox[0].to, ['to@unit.test'])

--- a/cfgov/data_research/tests/test_blocks.py
+++ b/cfgov/data_research/tests/test_blocks.py
@@ -12,4 +12,4 @@ class ConferenceRegistrationFormTests(TestCase):
         page = BrowsePage.objects.get(pk=99999)
         request = self.client.get('/').wsgi_request
         response = page.serve(request)
-        self.assertContains(response, 'Which sessions will you be attending?')
+        self.assertContains(response, 'accommodations needed to attend?')

--- a/cfgov/data_research/tests/test_blocks.py
+++ b/cfgov/data_research/tests/test_blocks.py
@@ -12,4 +12,4 @@ class ConferenceRegistrationFormTests(TestCase):
         page = BrowsePage.objects.get(pk=99999)
         request = self.client.get('/').wsgi_request
         response = page.serve(request)
-        self.assertContains(response, 'accommodations needed to attend?')
+        self.assertContains(response, 'other accommodations needed to attend?')

--- a/cfgov/data_research/tests/test_forms.py
+++ b/cfgov/data_research/tests/test_forms.py
@@ -21,10 +21,11 @@ class ConferenceRegistrationFormTests(TestCase):
         return ConferenceRegistrationForm(
             govdelivery_code=self.govdelivery_code,
             data={
+                'attendee_type': 'In person',
                 'name': 'A User',
                 'organization': 'An Organization',
                 'email': 'user@domain.com',
-                'sessions': ['Thursday morning', 'Thursday lunch'],
+                # 'sessions': ['Thursday morning', 'Thursday lunch'],
             }
         )
 
@@ -52,10 +53,11 @@ class ConferenceRegistrationFormTests(TestCase):
 
         self.assertEqual(registrant.govdelivery_code, 'TEST-CODE')
         self.assertEqual(registrant.details, {
+            'attendee_type': 'In person',
             'name': 'A User',
             'organization': 'An Organization',
             'email': 'user@domain.com',
-            'sessions': ['Thursday morning', 'Thursday lunch'],
+            # 'sessions': ['Thursday morning', 'Thursday lunch'],
             'dietary_restrictions': [],
             'other_dietary_restrictions': '',
             'accommodations': [],

--- a/cfgov/data_research/tests/test_forms.py
+++ b/cfgov/data_research/tests/test_forms.py
@@ -19,12 +19,15 @@ class ConferenceRegistrationFormTests(TestCase):
         )
         self.assertFalse(form.is_valid())
 
-    def get_valid_form(self):
+    def get_valid_form(
+        self,
+        attendee_type=ConferenceRegistrationForm.ATTENDEE_IN_PERSON
+    ):
         return ConferenceRegistrationForm(
             capacity=self.capacity,
             govdelivery_code=self.govdelivery_code,
             data={
-                'attendee_type': ConferenceRegistrationForm.ATTENDEE_IN_PERSON,
+                'attendee_type': attendee_type,
                 'name': 'A User',
                 'organization': 'An Organization',
                 'email': 'user@domain.com',
@@ -123,6 +126,16 @@ class ConferenceRegistrationFormTests(TestCase):
         )
         form = self.get_valid_form()
         self.assertFalse(form.is_valid())
+
+    def test_form_at_capacity_still_valid_for_virtual_attendees(self):
+        self.make_capacity_registrants(
+            self.govdelivery_code,
+            ConferenceRegistrationForm.ATTENDEE_IN_PERSON
+        )
+        form = self.get_valid_form(
+            attendee_type=ConferenceRegistrationForm.ATTENDEE_VIRTUALLY
+        )
+        self.assertTrue(form.is_valid())
 
     def test_form_virtual_attendees_dont_count_against_capacity(self):
         self.make_capacity_registrants(

--- a/cfgov/data_research/tests/test_handlers.py
+++ b/cfgov/data_research/tests/test_handlers.py
@@ -3,16 +3,26 @@ from django.http import HttpResponseRedirect
 from django.test import RequestFactory, TestCase
 
 from data_research.handlers import ConferenceRegistrationHandler
-from data_research.models import ConferenceRegistration
 
 
 class MockConferenceRegistrationForm(forms.Form):
     def __init__(self, *args, **kwargs):
+        kwargs.pop('capacity')
         kwargs.pop('govdelivery_code')
         super(MockConferenceRegistrationForm, self).__init__(*args, **kwargs)
 
     def save(self, commit=False):
         pass
+
+    @property
+    def at_capacity(self):
+        return False
+
+
+class AtCapacityConferenceRegistrationForm(MockConferenceRegistrationForm):
+    @property
+    def at_capacity(self):
+        return True
 
 
 class ExceptionThrowingConferenceRegistrationForm(
@@ -28,17 +38,15 @@ class TestConferenceRegistrationHandler(TestCase):
         self.path = '/path/to/form'
         self.page = object()
 
-        self.govdelivery_code = 'ABC123'
-        self.capacity = 100
         self.block_value = {
-            'capacity': self.capacity,
-            'govdelivery_code': self.govdelivery_code,
+            'capacity': '100',
+            'govdelivery_code': 'ABC123',
             'failure_message': "Something went wrong in a test.",
         }
 
-    def get_handler(self, post_data=None, request=None, form_cls=None):
+    def get_handler(self, request=None, form_cls=None):
         if request is None:
-            request = self.factory.post(self.path, post_data)
+            request = self.factory.post(self.path)
 
         if form_cls is None:
             form_cls = MockConferenceRegistrationForm
@@ -58,26 +66,12 @@ class TestConferenceRegistrationHandler(TestCase):
         response = self.get_handler().process(is_submitted=False)
         self.assertFalse(response['is_at_capacity'])
 
-    def make_capacity_registrants(self, govdelivery_code):
-        registrant = ConferenceRegistration(
-            govdelivery_code=govdelivery_code,
-            details={
-                'attendee_type': 'In person'
-            }
-        )
-        ConferenceRegistration.objects.bulk_create(
-            [registrant] * self.capacity
-        )
-
     def test_process_at_capacity(self):
-        self.make_capacity_registrants(self.govdelivery_code)
-        response = self.get_handler().process(is_submitted=False)
+        handler = self.get_handler(
+            form_cls=AtCapacityConferenceRegistrationForm
+        )
+        response = handler.process(is_submitted=False)
         self.assertTrue(response['is_at_capacity'])
-
-    def test_process_at_capacity_for_some_other_code(self):
-        self.make_capacity_registrants('some-other-code')
-        response = self.get_handler().process(is_submitted=False)
-        self.assertFalse(response['is_at_capacity'])
 
     def test_process_not_submitted_not_successful_submission(self):
         response = self.get_handler().process(is_submitted=False)

--- a/cfgov/data_research/tests/test_handlers.py
+++ b/cfgov/data_research/tests/test_handlers.py
@@ -59,7 +59,12 @@ class TestConferenceRegistrationHandler(TestCase):
         self.assertFalse(response['is_at_capacity'])
 
     def make_capacity_registrants(self, govdelivery_code):
-        registrant = ConferenceRegistration(govdelivery_code=govdelivery_code)
+        registrant = ConferenceRegistration(
+            govdelivery_code=govdelivery_code,
+            details={
+                'attendee_type': 'In person'
+            }
+        )
         ConferenceRegistration.objects.bulk_create(
             [registrant] * self.capacity
         )

--- a/cfgov/data_research/widgets.py
+++ b/cfgov/data_research/widgets.py
@@ -64,6 +64,53 @@ class Textarea(TextInputAttrsMixin, widgets.Textarea):
     ]
 
 
+class RadioChoiceInput(SubWidgetExtraAttrsMixin, widgets.RadioChoiceInput):
+    extra_attrs = [
+        ('class', 'a-radio'),
+    ]
+
+    def render(self, name=None, value=None, attrs=None, choices=()):
+        """Override the render function to add proper CF styling.
+
+        By default Django renders radio choice inputs where the <label>
+        tag wraps the <input> tag. Capital Framework instead specifies
+        that the <input> tag come first, followed by the <label>.
+        """
+        if self.id_for_label:
+            label_for = format_html(' for="{}"', self.id_for_label)
+        else:
+            label_for = ''
+
+        attrs = dict(self.attrs, **attrs) if attrs else self.attrs
+
+        return format_html(
+            (
+                '<div class="m-form-field m-form-field__radio">'
+                '{} <label class="a-label" {}>{}</label>'
+                '</div>'
+            ),
+            self.tag(attrs),
+            label_for,
+            self.choice_label
+        )
+
+
+class RadioFieldRenderer(widgets.RadioFieldRenderer):
+    """Custom renderer that outputs subwidgets with no wrapping.
+
+    By default the renderer used to display checkbox choice inputs wraps the
+    list in a <ul></ul> tag and wraps each element in <li><li>. Capital
+    Framework specifies no such wrapping, so this class removes them.
+    """
+    choice_input_class = RadioChoiceInput
+    outer_html = '{content}'
+    inner_html = '{choice_value}{sub_widgets}'
+
+
+class RadioSelect(widgets.RadioSelect):
+    renderer = RadioFieldRenderer
+
+
 class CheckboxChoiceInput(SubWidgetExtraAttrsMixin,
                           widgets.CheckboxChoiceInput):
     extra_attrs = [

--- a/cfgov/unprocessed/css/organisms/form.less
+++ b/cfgov/unprocessed/css/organisms/form.less
@@ -26,29 +26,28 @@
 */
 
 .o-form-description {
-    margin-top: unit( @grid_gutter-width / @base-font-size-px, em);
-    margin-bottom: unit( @grid_gutter-width * 2 / @base-font-size-px, em);
+    margin-top: unit( @grid_gutter-width / @base-font-size-px, em );
+    margin-bottom: unit( @grid_gutter-width * 2 / @base-font-size-px, em );
 }
 
 .o-form-section {
-    margin: unit( @grid_gutter-width / @base-font-size-px, em)
-            unit( @grid_gutter-width / -2 / @base-font-size-px, em)
-            unit( @grid_gutter-width * 2 / @base-font-size-px, em)
-            unit( @grid_gutter-width / -2 / @base-font-size-px, em);
-    padding: unit( @grid_gutter-width / @base-font-size-px, em)
-             unit( @grid_gutter-width / 2 / @base-font-size-px, em);
+    margin: unit( @grid_gutter-width / @base-font-size-px, em )
+            unit( @grid_gutter-width / -2 / @base-font-size-px, em )
+            unit( @grid_gutter-width * 2 / @base-font-size-px, em )
+            unit( @grid_gutter-width / -2 / @base-font-size-px, em );
+    padding: unit( @grid_gutter-width / @base-font-size-px, em )
+             unit( @grid_gutter-width/ @base-font-size-px, em );
     background: @gray-5;
     border: 1px solid @gray-40;
 
     .respond-to-min(@bp-med-min, {
-        margin-left: unit( -@grid_gutter-width / @base-font-size-px, em);
-        margin-right: unit( -@grid_gutter-width / @base-font-size-px, em);
+        margin-left: unit( -@grid_gutter-width / @base-font-size-px, em );
+        margin-right: unit( -@grid_gutter-width / @base-font-size-px, em );
     });
 }
 
 .o-form-actions {
-    margin-top: unit( @grid_gutter-width / -2 / @base-font-size-px, em);
-    margin-bottom: unit( @grid_gutter-width * 2 / @base-font-size-px, em);
+    margin-top: unit( @grid_gutter-width / @base-font-size-px, em );
 
     .respond-to-max(@bp-sm-max, {
         .a-btn {


### PR DESCRIPTION
We'll be registering folks for a new type of conference soon. Here are some changes to the existing conference registration functionality that will be needed for that.

## Additions

- New radio field for whether attending in person or virtually
- Sets the form up to still allow virtual registration once in-person
capacity has been reached

## Changes

- Hides `sessions` field, which is not needed for this conference
- Fixes a couple styling issues related to margins & padding

## Testing

1. Pull branch
1. Add a Conference Registration Form to a Browse Page with a capacity of 1
1. Fill in the message fields so you know what they are when they appear on the page
1. Submit a virtual attendee registration and see that you can still register a physical attendee
1. Register a physical attendee and see that you can no longer register a physical attendee
1. Submit another virtual attendee registration


## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [x] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: