### PR TITLE
Fix email-related tests that fail on Django 1.11

### DIFF
--- a/cfgov/core/tests/test_management_inactive_users.py
+++ b/cfgov/core/tests/test_management_inactive_users.py
@@ -27,29 +27,35 @@ class InactiveUsersTestCase(TestCase):
 
         # This user is clearly inactive at 91 days
         self.user_1 = User.objects.create(username='user_1',
+                                          email='user_1@test.test',
                                           last_login=days_91,
                                           date_joined=days_91)
 
         # This user is inactive because it's the 90th day
         self.user_2 = User.objects.create(username='user_2',
+                                          email='user_2@test.test',
                                           last_login=days_90,
                                           date_joined=days_91)
 
         # This user is not inactive because it's been 89 days
         # This user will receive a warning email
         self.user_3 = User.objects.create(username='üser_3',
+                                          email='üser_3@test.test',
                                           last_login=days_89,
                                           date_joined=days_91)
 
         # This user has never logged in, joined 91 days ago
         self.user_4 = User.objects.create(username='user_4',
+                                          email='user_4@test.test',
                                           date_joined=days_91)
 
         # This user has never logged in, joined today.
-        self.user_5 = User.objects.create(username='user_5')
+        self.user_5 = User.objects.create(username='user_5',
+                                          email='user_5@test.test')
 
         # This user last logged on 61 days ago, will be warned.
         self.user_6 = User.objects.create(username='user_6',
+                                          email='user_6@test.test',
                                           last_login=days_61,
                                           date_joined=days_91)
 


### PR DESCRIPTION
Some unit tests were failing under Django 1.11 because they were testing whether email was being sent to users that didn't have email addresses. In Django 1.8, emails can be (improperly) sent to users with empty string addresses. This was fixed in https://github.com/django/django/pull/7535, which made it into Django 1.11. Because these tests didn't properly provide email addresses for users, they start to fail on Django 1.11.

To test, run:

```
tox -e unittest-py27-dj111-wag113-fast core.tests.test_management_inactive_users
```

On this branch, all 11 of these tests will pass. On master, 3 of these tests will fail.

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [X] Passes all existing automated tests
- [X] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: