### PR TITLE
Fix expandable button type

### DIFF
--- a/cfgov/jinja2/v1/_includes/organisms/expandable.html
+++ b/cfgov/jinja2/v1/_includes/organisms/expandable.html
@@ -39,7 +39,7 @@
             {{ 'o-expandable__background' if value.is_midtone else '' }}
             {{ 'o-expandable__border' if value.is_bordered else '' }}">
 
-    <button class="o-expandable_header o-expandable_target">
+    <button class="o-expandable_header o-expandable_target" type="button">
         <span class="h4 o-expandable_header-left o-expandable_label">
             {{ value.label }}
         </span>


### PR DESCRIPTION
Fix button within expandable Jinja template to allow it to work within forms. 

Since the button element defaults to `type="submit"` anytime an expandable button is clicked within a form it submits that form even though it has nothing to do with that form. By setting the type to button it no longer automatically submits the form.

You can see an example of this behavior on the eregs search page: https://beta.consumerfinance.gov/policy-compliance/rulemaking/regulations/search-regulations/results/?q=test&regs=1002&results=25&order=relevance


## Additions

- Add `type="button"` to the button element within the expandable Jinja template

## Reviews
- @Scotchester 

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Internet Explorer 8, 9, 10, and 11
- [ ] Edge
- [ ] iOS Safari
- [ ] Chrome for Android

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
