### PR TITLE
Use boto3 instead of boto for Django 1.11 compatibility

### DIFF
--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -382,18 +382,18 @@ ELASTICSEARCH_INDEX_SETTINGS = {
 ELASTICSEARCH_DEFAULT_ANALYZER = 'snowball'
 
 # S3 Configuration
+# https://django-storages.readthedocs.io/en/latest/backends/amazon-S3.html#settings
+AWS_LOCATION = 'f'  # A path prefix that will be prepended to all uploads
 AWS_QUERYSTRING_AUTH = False  # do not add auth-related query params to URL
-AWS_S3_CALLING_FORMAT = 'boto.s3.connection.OrdinaryCallingFormat'
-AWS_S3_ROOT = os.environ.get('AWS_S3_ROOT', 'f')
+AWS_S3_FILE_OVERWRITE = False
 AWS_S3_SECURE_URLS = True  # True = use https; False = use http
 AWS_STORAGE_BUCKET_NAME = os.environ.get('AWS_STORAGE_BUCKET_NAME')
-AWS_S3_FILE_OVERWRITE = False
 
 if os.environ.get('S3_ENABLED', 'False') == 'True':
-    DEFAULT_FILE_STORAGE = 'v1.s3utils.MediaRootS3BotoStorage'
-    AWS_S3_ACCESS_KEY_ID = os.environ.get('AWS_S3_ACCESS_KEY_ID')
-    AWS_S3_SECRET_ACCESS_KEY = os.environ.get('AWS_S3_SECRET_ACCESS_KEY')
-    MEDIA_URL = os.path.join(os.environ.get('AWS_S3_URL'), AWS_S3_ROOT, '')
+    AWS_S3_ACCESS_KEY_ID = os.environ['AWS_S3_ACCESS_KEY_ID']
+    AWS_S3_SECRET_ACCESS_KEY = os.environ['AWS_S3_SECRET_ACCESS_KEY']
+    DEFAULT_FILE_STORAGE = 'storages.backends.s3boto3.S3Boto3Storage'
+    MEDIA_URL = os.path.join(os.environ.get('AWS_S3_URL'), AWS_LOCATION, '')
 
 # Govdelivery
 GOVDELIVERY_ACCOUNT_CODE = os.environ.get('GOVDELIVERY_ACCOUNT_CODE')

--- a/cfgov/data_research/mortgage_utilities/s3_utils.py
+++ b/cfgov/data_research/mortgage_utilities/s3_utils.py
@@ -1,21 +1,16 @@
 from __future__ import unicode_literals
 
 import datetime
-import os
 import StringIO
 
 from django.conf import settings
 
-import boto
+import boto3
 import requests
 import unicodecsv
-from boto.s3.connection import OrdinaryCallingFormat
-from boto.s3.key import Key
 
 
 # bake_to_s3 functions require S3 secrets to be stored in the env
-S3_KEY = os.getenv('AWS_S3_ACCESS_KEY_ID')
-S3_SECRET = os.getenv('AWS_S3_SECRET_ACCESS_KEY')
 BASE_BUCKET = settings.AWS_STORAGE_BUCKET_NAME
 MORTGAGE_SUB_BUCKET = "data/mortgage-performance"
 PUBLIC_ACCESS_BASE = 'https://{}/{}'.format(
@@ -32,46 +27,28 @@ def read_in_s3_csv(url):
     return reader
 
 
-def read_in_s3_json(url):
-    """Reads in a json file from S3 and returns a Python object"""
-    response = requests.get(url)
-    return response.json()
-
-
-def bake_json_to_s3(slug, json_string, sub_bucket=None):
-    """A utility for posting json files to a cfgov.files sub_bucket."""
-    expire_date = datetime.datetime.utcnow() + datetime.timedelta(days=365)
-    expires = expire_date.strftime("%a, %d %b %Y %H:%M:%S GMT")
-    headers = {'Cache-Control': 'max-age=2592000,public',
-               'Expires': expires,
-               'Access-Control-Allow-Origin': '*'}
-    if sub_bucket is None:
-        sub_bucket = 'data'
-    s3 = boto.connect_s3(
-        S3_KEY, S3_SECRET, calling_format=OrdinaryCallingFormat())
-    bucket = s3.get_bucket(BASE_BUCKET)
-    key = Key(
-        bucket=bucket,
-        name='{}/{}.json'.format(sub_bucket, slug))
-    key.content_type = 'application/json'
-    key.set_contents_from_string(json_string, headers=headers)
-    key.set_acl('public-read')
-
-
 def bake_csv_to_s3(slug, csv_file_obj, sub_bucket=None):
-    """A utility for posting csv files to a cfgov.files sub_bucket."""
+    """A utility for posting CSV files to a cfgov.files sub_bucket.
+
+    Uses the value of settings.AWS_STORAGE_BUCKET_NAME as the destination S3
+    bucket. If sub_bucket is not provided, defaults to 'data'.
+    """
     expire_date = datetime.datetime.utcnow() + datetime.timedelta(days=365)
     expires = expire_date.strftime("%a, %d %b %Y %H:%M:%S GMT")
-    headers = {'Cache-Control': 'max-age=2592000,public',
-               'Expires': expires}
+
     if sub_bucket is None:
         sub_bucket = 'data'
-    s3 = boto.connect_s3(
-        S3_KEY, S3_SECRET, calling_format=OrdinaryCallingFormat())
-    bucket = s3.get_bucket(BASE_BUCKET)
-    key = Key(
-        bucket=bucket,
-        name='{}/{}.csv'.format(sub_bucket, slug))
-    key.content_type = 'text/csv'
-    key.set_contents_from_file(csv_file_obj, headers=headers, rewind=True)
-    key.set_acl('public-read')
+
+    # Rewind the file to its beginning.
+    csv_file_obj.seek(0)
+
+    s3 = boto3.client('s3')
+    s3.put_object(
+        Bucket=settings.AWS_STORAGE_BUCKET_NAME,
+        Key='{}/{}.csv'.format(sub_bucket, slug),
+        ACL='public-read',
+        ContentType='text/csv',
+        Body=csv_file_obj,
+        CacheControl='max-age=2592000,public',
+        Expires=expires
+    )

--- a/cfgov/data_research/tests/test_s3_utils.py
+++ b/cfgov/data_research/tests/test_s3_utils.py
@@ -1,60 +1,54 @@
 from __future__ import unicode_literals
 
-import json
-import unittest
+import csv
 from cStringIO import StringIO
 
-import mock
-import unicodecsv
+from django.test import TestCase, override_settings
+
+import boto3
+import moto
+import responses
 
 from data_research.mortgage_utilities.s3_utils import (
-    bake_csv_to_s3, bake_json_to_s3, read_in_s3_csv, read_in_s3_json
+    bake_csv_to_s3, read_in_s3_csv
 )
 
 
-class S3UtilsTests(unittest.TestCase):
-
-    def setUp(self):
-
-        self.sample_entry = '\{"12081": \{"county": "Manatee County"\}\}'
-        self.bucket = mock.Mock(
-            name='files.consumerfinance.gov',
-            acls={'files.consumerfinance.gov': 'mock_acl_name'})
-
-    @mock.patch('data_research.mortgage_utilities.s3_utils.requests.get')
-    def test_read_in_s3_csv(self, mock_requests):
-        mock_requests.return_value.content = 'a,b,c\nd,e,f'
-        reader = read_in_s3_csv('fake-s3-url.com')
-        self.assertEqual(mock_requests.call_count, 1)
+class S3UtilsTests(TestCase):
+    @responses.activate
+    def test_read_in_s3_csv(self):
+        url = 'https://test.url/foo.csv'
+        responses.add(responses.GET, url, body='a,b,c\nd,e,f')
+        reader = read_in_s3_csv(url)
         self.assertEqual(reader.fieldnames, ['a', 'b', 'c'])
         self.assertEqual(sorted(reader.next().values()), ['d', 'e', 'f'])
 
-    @mock.patch('data_research.mortgage_utilities.s3_utils.requests.get')
-    def test_read_in_s3_json(self, mock_requests):
-        mock_return = mock.Mock()
-        mock_return.json.return_value = {'test': 'test'}
-        mock_requests.return_value = mock_return
-        returned_json = read_in_s3_json('fake_s3_url.com')
-        self.assertEqual(mock_requests.call_count, 1)
-        self.assertEqual(returned_json, {'test': 'test'})
+    @moto.mock_s3
+    @override_settings(AWS_STORAGE_BUCKET_NAME='test.bucket')
+    def test_bake_csv_to_s3(self):
+        s3 = boto3.resource('s3')
+        bucket = s3.Bucket('test.bucket')
+        bucket.create(ACL='private')
 
-    @mock.patch('data_research.mortgage_utilities.s3_utils.boto.connect_s3')
-    def test_bake_json_to_s3(self, mock_connect):
-        mock_get_bucket = mock.Mock()
-        mock_connect.get_bucket.return_value = mock_get_bucket
-        json_string = json.dumps({'test_json': 'test_payload'})
-        slug = 'test.json'
-        bake_json_to_s3(slug, json_string)
-        self.assertEqual(mock_connect.call_count, 1)
-
-    @mock.patch('data_research.mortgage_utilities.s3_utils.boto.connect_s3')
-    def test_bake_csv_to_s3(self, mock_connect):
-        mock_get_bucket = mock.Mock()
-        mock_connect.get_bucket.return_value = mock_get_bucket
         csvfile = StringIO()
-        writer = unicodecsv.writer(csvfile)
+        writer = csv.writer(csvfile)
         writer.writerow(['a', 'b', 'c'])
         writer.writerow(['1', '2', '3'])
-        slug = 'test.csv'
-        bake_csv_to_s3(slug, csvfile)
-        self.assertEqual(mock_connect.call_count, 1)
+        bake_csv_to_s3('foo', csvfile)
+
+        key = bucket.Object('data/foo.csv')
+        response = key.get()
+        self.assertEqual(response['Body'].read(), 'a,b,c\r\n1,2,3\r\n')
+
+        # bake_csv_to_s3 sets 'public-read' on the item.
+        acl = key.Acl()
+        self.assertIn(
+            {
+                'Permission': 'READ',
+                'Grantee': {
+                    'Type': 'Group',
+                    'URI': 'http://acs.amazonaws.com/groups/global/AllUsers',
+                },
+            },
+            acl.grants
+        )

--- a/cfgov/v1/s3utils.py
+++ b/cfgov/v1/s3utils.py
@@ -1,11 +1,4 @@
-"""Custom S3 storage backends to store files in subfolders."""
-
 from django.conf import settings
-
-
-def MediaRootS3BotoStorage():
-    from storages.backends.s3boto import S3BotoStorage
-    return S3BotoStorage(location=settings.AWS_S3_ROOT)
 
 
 def get_s3_url_prefix(https):

--- a/cfgov/v1/tests/test_meta_image.py
+++ b/cfgov/v1/tests/test_meta_image.py
@@ -2,7 +2,7 @@ from django.test import TestCase, override_settings
 
 from wagtail.wagtailimages.tests.utils import get_test_image_file
 
-import boto
+import boto3
 import moto
 from model_mommy import mommy
 
@@ -100,22 +100,19 @@ class TestMetaImage(TestCase):
         self.check_template_meta_image_url(expected_root="http://localhost")
 
     @override_settings(
-        AWS_QUERYSTRING_AUTH=False,
+        AWS_LOCATION='root',
         AWS_S3_ACCESS_KEY_ID='test',
-        AWS_S3_CALLING_FORMAT='boto.s3.connection.OrdinaryCallingFormat',
-        AWS_S3_ROOT='root',
         AWS_S3_SECRET_ACCESS_KEY='test',
-        AWS_S3_SECURE_URLS=True,
         AWS_STORAGE_BUCKET_NAME='test_s3_bucket',
-        DEFAULT_FILE_STORAGE='v1.s3utils.MediaRootS3BotoStorage'
+        DEFAULT_FILE_STORAGE='storages.backends.s3boto3.S3Boto3Storage'
     )
     def test_template_image_image_url_s3(self):
         """Meta image links should work if using S3 storage."""
-        mock_s3 = moto.mock_s3_deprecated()
+        mock_s3 = moto.mock_s3()
         mock_s3.start()
 
-        s3 = boto.connect_s3()
-        s3.create_bucket('test_s3_bucket')
+        s3 = boto3.client('s3')
+        s3.create_bucket(Bucket='test_s3_bucket')
 
         try:
             # There should be no root required as the image rendition URL

--- a/requirements/libraries.txt
+++ b/requirements/libraries.txt
@@ -1,7 +1,6 @@
 address==0.1.1
 beautifulsoup4==4.5.1
-boto==2.38.0
-boto3==1.5.9
+boto3==1.7.80
 dj-database-url==0.4.2
 djangorestframework==3.1.3
 djangorestframework-csv==2.0.0
@@ -12,7 +11,11 @@ django-flags==3.0.0
 django-haystack==2.7.0
 django-localflavor==1.1
 django-overextends==0.4.3
-django-storages==1.1.8
+# django-storages 1.6.6 drops support for Django 1.8.
+# https://github.com/jschneier/django-storages/blob/master/CHANGELOG.rst
+# Versions >1.5.0,<=1.6.5 fail due to this issue:
+# https://github.com/jschneier/django-storages/issues/382
+django-storages==1.5.0
 # django-taggit 0.23.0 requires Django 1.11. Normally django-taggit is pulled
 # in by Wagtail's setup.py, but Wagtail 1.13 specifies >0.20,<1.0, which
 # unfortunately includes this version. This line can be removed once we are

--- a/requirements/scripts.txt
+++ b/requirements/scripts.txt
@@ -1,4 +1,4 @@
 beautifulsoup4==4.5.1
-boto3==1.4.6
+boto3==1.7.80
 github3.py==0.9.6
 requests==2.19.1

--- a/tox.ini
+++ b/tox.ini
@@ -124,14 +124,10 @@ changedir=
     {toxinidir}/cfgov
 passenv=
     TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH TEST_DATABASE_URL TEST_RUNNER
-# BOTO_CONFIG exists here to work around an incompatability between
-# boto and Travis CI
-# https://github.com/travis-ci/travis-ci/issues/5246#issuecomment-166460882
 # Set DJANGO_SETTINGS_MODULE based on {with,no}-migrations
 setenv=
     GOVDELIVERY_ACCOUNT_CODE=fake_account_code
     DJANGO_STAGING_HOSTNAME=content.localhost
-    BOTO_CONFIG=/bogus/value
     LANG=en_US.UTF-8
     LC_ALL=en_US.UTF-8
 deps=


### PR DESCRIPTION
These set of changes change the AWS S3 package used by this project to boto3 from boto. See this post discussing differences:

https://boto3.readthedocs.io/en/latest/guide/migration.html

Generally, boto3 is a more modern library which is better maintained.

Direct uses of boto have been replaced with boto3, and relatedly this change modifies the django-storages backend to use its boto3 backend. The django-storages dependency has been bumped in version from 1.1.8 to 1.5.0; unfortunately we cannot yet use the most recent version, see
`requirements/libraries.txt` for an explanation.

Some of the Django settings have been simplified or ordered alphabetically related to this change. Specifically, we previously used an `AWS_S3_ROOT` environment variable to set an `AWS_S3_ROOT` setting that was used to instantiate a custom storages backend. This is no longer necessary as the more recent versions of django-storages directly support use of `AWS_LOCATION` to set the root path. As this is always "f" on all systems, I've hardcoded it here.

These changes are necessary to add Django 1.11 compatibility (mainly because django-storages 1.1.8 didn't support Django 1.11) but also get us more up-to-date in our use of S3.

## Testing

Unit tests should cover use of S3 helper methods.

You can also run a local server and enable S3 through environment variables (`S3_ENABLED=True`, set `AWS_S3_ACCESS_KEY_ID`, `AWS_S3_SECRET_ACCESS_KEY`, `AWS_STORAGE_BUCKET_NAME`, `AWS_S3_URL`). You should be able to browse in the Wagtail admin under the Documents section and see that file URLs are properly pointing to S3, and successfully download those files.

## Notes

The boto3 backend adds some logging statements under `boto` and `boto3` loggers at level `INFO` when doing things like opening a connection to S3. Due to the way we have logging set up in this project, you'll see those in your console when running locally, and they'll get written to server logs. We could suppress these if we wanted to.

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [X] Passes all existing automated tests
- [X] Any _change_ in functionality is tested
- [X] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [X] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: