### PR TITLE
Only set mock GovDelivery API if GOVDELIVERY_BASE_URL is not set

### DIFF
--- a/.env_SAMPLE
+++ b/.env_SAMPLE
@@ -97,9 +97,15 @@ export VENV_NAME=cfgov-refresh
 
 export HUD_API_ENDPOINT=http://localhost:8000/hud-api-replace/
 
-##############################################################
+#####################################################################
 # GOVDELIVERY (optional) - for running the subscription forms.
-##############################################################
+#
+# GovDelivery API calls are mocked by default in a local environment;
+# they will always return a 200 response.
+# If the GOVDELIVERY_BASE_URL line is uncommented below,
+# GovDelivery API calls will be made to that URL,
+# and the other values below must be uncommented and set accordingly.
+#####################################################################
 
 #export GOVDELIVERY_BASE_URL=https://stage-api.govdelivery.com/
 #export GOVDELIVERY_ACCOUNT_CODE=<govdelivery_account_code>

--- a/cfgov/cfgov/settings/local.py
+++ b/cfgov/cfgov/settings/local.py
@@ -68,6 +68,7 @@ if os.environ.get('ENABLE_POST_PREVIEW_CACHE'):
         'TIMEOUT': None,
     }
 
-# Use a mock GovDelivery API instead of the real thing.
-# Remove this line to use the real API instead.
-GOVDELIVERY_API = 'core.govdelivery.LoggingMockGovDelivery'
+# Use a mock GovDelivery API instead of the real thing,
+# unless the GOVDELIVERY_BASE_URL environment variable is set.
+if not os.environ.get('GOVDELIVERY_BASE_URL'):
+    GOVDELIVERY_API = 'core.govdelivery.LoggingMockGovDelivery'


### PR DESCRIPTION
It was unclear to me that a setting in the local Django settings was preventing me from testing the GovDelivery integration on my local machine. It looked like all I needed to do was set my env vars, but no!

This PR updates the setting in `local.py` to only be set if the `GOVDELIVERY_BASE_URL` env var has _not_ been set.

## Changes

- `GOVDELIVERY_API` setting that mocks the API locally is only set if `GOVDELIVERY_BASE_URL` env var is not set

## Testing

Can't test it without some credentials, so contact me for a walkthrough if you want to see it in action. 

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [x] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
