### PR TITLE
Add the http endpoint for CCT charts

### DIFF
--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -570,6 +570,9 @@ CSP_CONNECT_SRC = ("'self'",
                    'bam.nr-data.net',
                    'files.consumerfinance.gov',
                    's3.amazonaws.com',
+                   # Todo: Take the following URL out as it's only
+                   # for http access to chart data for CCT
+                   'files.consumerfinance.gov.s3.amazonaws.com',
                    'public.govdelivery.com',
                    'api.iperceptions.com')
 

--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -572,6 +572,8 @@ CSP_CONNECT_SRC = ("'self'",
                    's3.amazonaws.com',
                    # Todo: Take the following URL out as it's only
                    # for http access to chart data for CCT
+                   # Remove when build moves to https or when
+                   # cfpb-chart-builder#126 PR gets merged
                    'files.consumerfinance.gov.s3.amazonaws.com',
                    'public.govdelivery.com',
                    'api.iperceptions.com')


### PR DESCRIPTION
For now, will allow the http-endpoint access to files.cf.gov for loading chart data on `build`.

This should be removed in the future when we move to https on `build`. I left a comment to that effect.

## Todos

- Remove this endpoint once https://github.com/cfpb/cfpb-chart-builder/pull/126 is merged.

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Internet Explorer 8, 9, 10, and 11
- [ ] Edge
- [ ] iOS Safari
- [ ] Chrome for Android

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
