### PR TITLE
Improve Regs3K landing page

### DIFF
--- a/cfgov/regulations3k/jinja2/regulations3k/browse-regulation.html
+++ b/cfgov/regulations3k/jinja2/regulations3k/browse-regulation.html
@@ -8,7 +8,7 @@
 {% import 'macros/time.html' as time %}
 
 {% block body_classes %}
-    {{ super() }}  data-turbolinks="false"
+    {{ super() }}
 {% endblock body_classes %}
 
 {% block content_modifiers -%}
@@ -73,12 +73,12 @@
                 <ul>
                     {% if previous_section %}
                     <li class="previous next-prev">
-                        <a href="{{ routablepageurl(page, "section", previous_section.section_number) }}" class="navigation-link backward next-prev-link" data-turbolinks="true"><span class="cf-icon cf-icon-left"></span><span class="next-prev-label">Previous section - </span>{{previous_section.numeric_label or previous_section.label}}</a> <span class="next-prev-title">{{previous_section.title_content}}</span>
+                        <a href="{{ routablepageurl(page, "section", previous_section.section_number) }}" class="navigation-link backward next-prev-link"><span class="cf-icon cf-icon-left"></span><span class="next-prev-label">Previous section - </span>{{previous_section.numeric_label or previous_section.label}}</a> <span class="next-prev-title">{{previous_section.title_content}}</span>
                     </li>
                     {% endif %}
                     {% if next_section %}
                     <li class="next next-prev">
-                        <a href="{{ routablepageurl(page, "section", next_section.section_number) }}" class="navigation-link forward next-prev-link" data-turbolinks="true"><span class="cf-icon cf-icon-right"></span><span class="next-prev-label">Next section - </span>{{next_section.numeric_label or next_section.label}}</a> <span class="next-prev-title">{{next_section.title_content}}</span>
+                        <a href="{{ routablepageurl(page, "section", next_section.section_number) }}" class="navigation-link forward next-prev-link"><span class="cf-icon cf-icon-right"></span><span class="next-prev-label">Next section - </span>{{next_section.numeric_label or next_section.label}}</a> <span class="next-prev-title">{{next_section.title_content}}</span>
                     </li>
                     {% endif %}
                 </ul>

--- a/cfgov/regulations3k/jinja2/regulations3k/inline_interps.html
+++ b/cfgov/regulations3k/jinja2/regulations3k/inline_interps.html
@@ -28,7 +28,7 @@
     <div class="o-expandable_content">
         {{ contents }}
 
-        <p><a href="{{ url }}" data-turbolinks="true">See interpretation of {% if section_title %}{{ section_title }}{% else %}this section{% endif %} in Supplement I</a></p>
+        <p><a href="{{ url }}">See interpretation of {% if section_title %}{{ section_title }}{% else %}this section{% endif %} in Supplement I</a></p>
     </div>
 
 </div>

--- a/cfgov/regulations3k/jinja2/regulations3k/landing-page.html
+++ b/cfgov/regulations3k/jinja2/regulations3k/landing-page.html
@@ -25,7 +25,7 @@
 {# BODY items #}
 
 {% block body_classes %}
-    {{ super() }}  data-turbolinks="false"
+    {{ super() }}
 {% endblock body_classes %}
 
 {% block hero -%}

--- a/cfgov/regulations3k/jinja2/regulations3k/regulations-listing.html
+++ b/cfgov/regulations3k/jinja2/regulations3k/regulations-listing.html
@@ -18,34 +18,19 @@
 
    ========================================================================== #}
 {% if regulations.exists() %}
-<table class="o-table" data-bound="true">
-    <tbody>
-        <tr>
-            <td>
-                <h4>{{ value.heading or 'Table of contents' }}</h4>
-            </td>
-        </tr>
-
+<div id="regulations-listing">
+    <h4>{{ value.heading or 'Table of contents' }}</h4>
+    <ul>
         {% for regulation in regulations %}
-        <tr>
-            <td>
-                <h4>
-                    <a href="{{ regulation.url }}" data-turbolinks="true">
-                        <span class="title-num">{{ regulation.title }}</span>
-                    </a>
-                </h4>
-                <!--
-                  <ul>
-                  <li>New amendment effective 1/1/2019.&nbsp;<a class="" href="">View on Electronic Code of Federal Regulations</a><br></li>
-                  <li>New amendment effective 1/1/2020.&nbsp;<a class="" href="">View on Electronic Code of Federal Regulations</a></li>
-                  </ul>
-                -->
-            </td>
-        </tr>
+        <li class="h4">
+            <a href="{{ regulation.url }}">
+                <span class="title-num">{{ regulation.title }}</span>
+            </a>
+        </li>
         {% endfor %}
-    </tbody>
-</table>
-{% endif %}
-<p>
-    <a class="" href="{{ pageurl(value.more_regs_page) }}">{{ value.more_regs_text or 'View more CFPB regulations' }}</a>
-</p>
+    </ul>
+    {% endif %}
+    <p>
+        <a class="" href="{{ pageurl(value.more_regs_page) }}">{{ value.more_regs_text or 'View more CFPB regulations' }}</a>
+    </p>
+</div>

--- a/cfgov/regulations3k/jinja2/regulations3k/search-regulations.html
+++ b/cfgov/regulations3k/jinja2/regulations3k/search-regulations.html
@@ -50,7 +50,7 @@
 {# BODY items #}
 
 {% block body_classes %}
-    {{ super() }} data-turbolinks="false"
+    {{ super() }}
 {% endblock body_classes %}
 
 {% block content_main_modifiers -%}

--- a/cfgov/regulations3k/models/pages.py
+++ b/cfgov/regulations3k/models/pages.py
@@ -172,7 +172,7 @@ class RegulationLandingPage(RoutablePageMixin, CFGOVPage):
         fr_documents_url = fr_api_url + 'documents.json'
         params = {
             'fields_list': ['html_url', 'title'],
-            'per_page': '10',
+            'per_page': '3',
             'order': 'newest',
             'conditions[agencies][]': 'consumer-financial-protection-bureau',
             'conditions[type][]': 'RULE',

--- a/cfgov/unprocessed/apps/regulations3k/css/main.less
+++ b/cfgov/unprocessed/apps/regulations3k/css/main.less
@@ -5,6 +5,7 @@
 
 
 @import (less) '../../../css/main.less';
+@import (less) './reg-listing.less';
 @import (less) './reg-navigation.less';
 @import (less) './reg-pagination.less';
 @import (less) './reg-search.less';

--- a/cfgov/unprocessed/apps/regulations3k/css/reg-listing.less
+++ b/cfgov/unprocessed/apps/regulations3k/css/reg-listing.less
@@ -1,0 +1,26 @@
+/* ==========================================================================
+   Regulations 3000
+   Regulations listing on landing page
+   ========================================================================== */
+
+#regulations-listing {
+    margin: unit( 45px / @base-font-size-px, em )
+            0
+            unit( 60px / @base-font-size-px, em );
+    ul {
+        margin-bottom: unit( 30px / @base-font-size-px, em );
+        padding-left: 0;
+    }
+    li {
+        border-bottom: 1px solid @gray;
+        list-style-type: none;
+        padding-bottom: unit( 15px / @base-font-size-px, em );
+        &:first-child {
+            border-top: 1px solid @gray;
+            padding-top: unit( 15px / @base-font-size-px, em );
+        }
+    }
+    a {
+        border: 0;
+    }
+}

--- a/cfgov/unprocessed/apps/regulations3k/css/reg-navigation.less
+++ b/cfgov/unprocessed/apps/regulations3k/css/reg-navigation.less
@@ -72,7 +72,9 @@
 
     .o-regs3k-navigation_header {
         .u-show-on-stacked();
-        padding: unit( 10px / @base-font-size-px, em );
+        padding: unit( 10px / @base-font-size-px, em )
+                 0
+                 unit( 5px / @base-font-size-px, em );
         .o-expandable_label {
             text-transform: uppercase;
         }


### PR DESCRIPTION
Some improvements to the Regs3K landing page and secondary nav. See [GHE#325](https://[GHE]/eregs/regulations-3000/issues/325).

## Testing

1. `./frontend.sh`
1. View the Regs3K landing page and confirm it matches the screenshot below (and no longer looks like what's on beta).

## Screenshots

![screen shot 2018-08-21 at 12 05 51 pm](https://user-images.githubusercontent.com/1060248/44414332-7fc3ec00-a53b-11e8-93ed-7ca9a65f2b47.png)

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [x] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [x] Chrome
- [x] Firefox
- [x] Safari
- [x] Internet Explorer 8, 9, 10, and 11
- [x] Edge
- [x] iOS Safari
- [x] Chrome for Android

### Accessibility

- [x] Keyboard friendly
- [x] Screen reader friendly

### Other

- [x] Is useable without CSS
- [x] Is useable without JS
- [x] Flexible from small to large screens
- [x] No linting errors or warnings
- [x] JavaScript tests are passing
