### PR TITLE
Remove Django 1.11-incompatible form widget code

### DIFF
--- a/cfgov/data_research/forms.py
+++ b/cfgov/data_research/forms.py
@@ -4,9 +4,7 @@ from django import forms
 
 from core.govdelivery import get_govdelivery_api
 from data_research.models import ConferenceRegistration
-from data_research.widgets import (
-    CheckboxSelectMultiple, EmailInput, RadioSelect, Textarea, TextInput
-)
+from data_research.widgets import EmailInput, Textarea, TextInput
 
 
 class ConferenceRegistrationForm(forms.Form):
@@ -48,7 +46,7 @@ class ConferenceRegistrationForm(forms.Form):
     ))
 
     attendee_type = forms.ChoiceField(
-        widget=RadioSelect,
+        widget=forms.RadioSelect,
         choices=ATTENDEE_TYPES,
         required=True,
         label='Do you plan to attend in person or virtually?',
@@ -66,7 +64,7 @@ class ConferenceRegistrationForm(forms.Form):
     #     }
     # )
     dietary_restrictions = forms.MultipleChoiceField(
-        widget=CheckboxSelectMultiple,
+        widget=forms.CheckboxSelectMultiple,
         choices=DIETARY_RESTRICTIONS,
         required=False,
         label="Please let us know about any food allergies or restrictions."
@@ -77,7 +75,7 @@ class ConferenceRegistrationForm(forms.Form):
         label="Any other food allergies or restrictions?"
     )
     accommodations = forms.MultipleChoiceField(
-        widget=CheckboxSelectMultiple,
+        widget=forms.CheckboxSelectMultiple,
         choices=ACCOMMODATIONS,
         required=False,
         label=(

--- a/cfgov/data_research/widgets.py
+++ b/cfgov/data_research/widgets.py
@@ -6,7 +6,6 @@ documentation on the styles that are being duplicated here.
 from __future__ import unicode_literals
 
 from django.forms import widgets
-from django.utils.html import format_html
 
 
 class WidgetExtraAttrsMixin(object):
@@ -28,21 +27,6 @@ class WidgetExtraAttrsMixin(object):
         super(WidgetExtraAttrsMixin, self).__init__(*args, **kwargs)
 
 
-class SubWidgetExtraAttrsMixin(object):
-    """Mixin object to add extra attributes to a Django SubWidget."""
-    extra_attrs = []
-
-    def __init__(self, name, value, attrs, choice, index):
-        attrs.update(self.extra_attrs)
-        super(SubWidgetExtraAttrsMixin, self).__init__(
-            name,
-            value,
-            attrs,
-            choice,
-            index
-        )
-
-
 class TextInputAttrsMixin(WidgetExtraAttrsMixin):
     extra_attrs = [
         ('class', 'a-text-input a-text-input__full'),
@@ -62,98 +46,3 @@ class Textarea(TextInputAttrsMixin, widgets.Textarea):
         ('rows', None),
         ('cols', None),
     ]
-
-
-class RadioChoiceInput(SubWidgetExtraAttrsMixin, widgets.RadioChoiceInput):
-    extra_attrs = [
-        ('class', 'a-radio'),
-    ]
-
-    def render(self, name=None, value=None, attrs=None, choices=()):
-        """Override the render function to add proper CF styling.
-
-        By default Django renders radio choice inputs where the <label>
-        tag wraps the <input> tag. Capital Framework instead specifies
-        that the <input> tag come first, followed by the <label>.
-        """
-        if self.id_for_label:
-            label_for = format_html(' for="{}"', self.id_for_label)
-        else:
-            label_for = ''
-
-        attrs = dict(self.attrs, **attrs) if attrs else self.attrs
-
-        return format_html(
-            (
-                '<div class="m-form-field m-form-field__radio">'
-                '{} <label class="a-label" {}>{}</label>'
-                '</div>'
-            ),
-            self.tag(attrs),
-            label_for,
-            self.choice_label
-        )
-
-
-class RadioFieldRenderer(widgets.RadioFieldRenderer):
-    """Custom renderer that outputs subwidgets with no wrapping.
-
-    By default the renderer used to display checkbox choice inputs wraps the
-    list in a <ul></ul> tag and wraps each element in <li><li>. Capital
-    Framework specifies no such wrapping, so this class removes them.
-    """
-    choice_input_class = RadioChoiceInput
-    outer_html = '{content}'
-    inner_html = '{choice_value}{sub_widgets}'
-
-
-class RadioSelect(widgets.RadioSelect):
-    renderer = RadioFieldRenderer
-
-
-class CheckboxChoiceInput(SubWidgetExtraAttrsMixin,
-                          widgets.CheckboxChoiceInput):
-    extra_attrs = [
-        ('class', 'a-checkbox'),
-    ]
-
-    def render(self, name=None, value=None, attrs=None, choices=()):
-        """Override the render function to add proper CF styling.
-
-        By default Django renders checkbox choice inputs where the <label>
-        tag wraps the <input> tag. Capital Framework instead specifies
-        that the <input> tag come first, followed by the <label>.
-        """
-        if self.id_for_label:
-            label_for = format_html(' for="{}"', self.id_for_label)
-        else:
-            label_for = ''
-
-        attrs = dict(self.attrs, **attrs) if attrs else self.attrs
-
-        return format_html(
-            (
-                '<div class="m-form-field m-form-field__checkbox">'
-                '{} <label class="a-label" {}>{}</label>'
-                '</div>'
-            ),
-            self.tag(attrs),
-            label_for,
-            self.choice_label
-        )
-
-
-class CheckboxFieldRenderer(widgets.CheckboxFieldRenderer):
-    """Custom renderer that outputs subwidgets with no wrapping.
-
-    By default the renderer used to display checkbox choice inputs wraps the
-    list in a <ul></ul> tag and wraps each element in <li><li>. Capital
-    Framework specifies no such wrapping, so this class removes them.
-    """
-    choice_input_class = CheckboxChoiceInput
-    outer_html = '{content}'
-    inner_html = '{choice_value}{sub_widgets}'
-
-
-class CheckboxSelectMultiple(widgets.CheckboxSelectMultiple):
-    renderer = CheckboxFieldRenderer

--- a/cfgov/unprocessed/css/organisms/form.less
+++ b/cfgov/unprocessed/css/organisms/form.less
@@ -46,9 +46,16 @@
     });
 }
 
-.o-form_fieldset ul {
-    list-style: none;
-    padding-left: 0;
+.o-form_fieldset {
+    ul {
+        list-style: none;
+        padding-left: 0;
+    }
+
+    input[type="checkbox"],
+    input[type="radio"] {
+        margin-right: 4px;
+    }
 }
 
 .o-form-actions {

--- a/cfgov/unprocessed/css/organisms/form.less
+++ b/cfgov/unprocessed/css/organisms/form.less
@@ -46,6 +46,11 @@
     });
 }
 
+.o-form_fieldset ul {
+    list-style: none;
+    padding-left: 0;
+}
+
 .o-form-actions {
     margin-top: unit( @grid_gutter-width / @base-font-size-px, em );
 


### PR DESCRIPTION
The conference registration form block currently makes use of some Python code that customizes how its field widgets are rendered, to make them compatible with Capital Framework.

Unfortunately, the hooks that this code (primarily in `cfgov/data_research/widgets.py`) used are no longer compatible with Django 1.11. As part of our Django 1.8 -> 1.11 upgrade, this PR removes
this customization, instead falling back on the standard widget rendering for checkboxes and radio buttons (we can still keep our customizations for text/email inputs and Textareas).

Some additional CSS styling is added to improve the look of these buttons. Unfortunately this is no longer compatible with CF.

## Testing

To test, create a BrowsePage in Wagtail and then add a Conference Registration Form block to the Content field. Add some test data and preview the page to see the buttons.

## Screenshots

New look:

![image](https://user-images.githubusercontent.com/654645/44480492-5b3a4380-a611-11e8-8cf6-cda85da4594d.png)

![image](https://user-images.githubusercontent.com/654645/44480520-63927e80-a611-11e8-8ac7-8d037fc3511e.png)

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [X] Passes all existing automated tests
- [X] Any _change_ in functionality is tested
- [X] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [X] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: