### PR TITLE
Missing Migrations script now handles Django 1.11

### DIFF
--- a/cfgov/core/tests/test_missing_migrations.py
+++ b/cfgov/core/tests/test_missing_migrations.py
@@ -2,19 +2,10 @@ from six.moves import cStringIO as StringIO
 
 from django.test import TestCase
 
-from core.scripts.missing_migrations import (
-    check_missing_migrations, is_django_110_plus
-)
+from core.scripts.missing_migrations import migrations_are_missing
 
 
 class MissingMigrationsTestCase(TestCase):
     def test_check_for_missing_migrations(self):
-        if is_django_110_plus:
-            self.fail(
-                'makemigrations --exit deprecated in Django 1.10: '
-                'https://docs.djangoproject.com/en/1.10/ref/django-admin/'
-                '#cmdoption-makemigrations--exit'
-            )
-
-        if check_missing_migrations(out=StringIO()):
+        if migrations_are_missing(out=StringIO()):
             self.fail('missing migrations, run manage.py makemigrations')


### PR DESCRIPTION


## Changes

- Updates `missing_migrations.py` to handle both Django 1.8 and 1.11 (where it used to only handle 1.8, and would always fail on 1.11). 

## Testing

To test locally, pull down this branch and:
1. Make a change to a django model (for example, changing a default value for a model field in `cfgov/vi/models/base.py`)
2. Run `tox -e missing-migrations-py27-dj111-wag113`
3. Run `tox -e missing-migrations-py27-dj18-wag113`

On both commands, you should see an error message like this:

```
Missing migrations found:
Migrations for 'v1':
  v1/migrations/0121_auto_20180821_1818.py
    - Alter field shared on cfgovpage

ERROR: InvocationError: '/Users/lortone/dev/cfgov-project/cfgov-refresh/cfgov/manage.py runscript missing_migrations'
```

If you discard the model change and re-run those commands, both Tox commands should both succeed.

## Notes

After we upgrade to django 1.11, this script will no longer be necessary. Anyone wanting to check for missing migrations (including Travis and the missing-migrations Tox command) will be able to use this command:

```
cfgov/manage.py makemigrations --check
```

That returns a nonzero exit code when there are missing migrations (as
does this script)

## Todos

After the django 1.11 upgrade, we will:
- remove the `missing_migrations.py` script
- remove the `test_missing_migrations.py` specs
- update the `tox.ini` file to use the simple `cfgov/manage.py makemigrations --check` command. 

These follow-up tasks are captured in a GHE ticket.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

This change does not affect any cfgov user-facing functionality.
