### PR TITLE
Remove dom-delegate

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "cf-typography": "5.0.1",
     "cfpb-chart-builder": "3.3.0",
     "del": "3.0.0",
-    "dom-delegate": "2.0.3",
     "elem-dataset": "1.1.1",
     "glob-all": "3.1.0",
     "gulp": "4.0.0",


### PR DESCRIPTION
`dom-delegate` was added in https://github.com/cfpb/cfgov-refresh/pull/4365, but appears to be unused.

## Removals

- Removes `dom-delegate` dependency.

## Testing
- `./frontend.sh` should pass.