### PR TITLE
Upgrade djangorestframework to support Django 1.11

### DIFF
--- a/requirements/libraries.txt
+++ b/requirements/libraries.txt
@@ -2,7 +2,7 @@ address==0.1.1
 beautifulsoup4==4.5.1
 boto3==1.7.80
 dj-database-url==0.4.2
-djangorestframework==3.1.3
+djangorestframework==3.6.4
 djangorestframework-csv==2.0.0
 django-csp==3.4
 django-braces==1.0.0


### PR DESCRIPTION
`djangorestframework` 3.6.4 is the latest version that supports both Django1.8 and 1.11. 

This is part of our preparation for upgrading cfgov-refresh to Django 1.11.

## Changes

- Updates library version: djangorestframework. Doesn't change any behavior.


## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [x] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

Doesn't change any cf.gov functionality..