### PR TITLE
Adds django-mptt to libraries.txt

### DIFF
--- a/requirements/libraries.txt
+++ b/requirements/libraries.txt
@@ -10,6 +10,7 @@ django-extensions==2.1.0
 django-flags==3.0.0
 django-haystack==2.7.0
 django-localflavor==1.1
+# django-mptt is required by teachers-digital-platform
 django-mptt==0.9.0
 django-overextends==0.4.3
 # django-storages 1.6.6 drops support for Django 1.8.

--- a/requirements/libraries.txt
+++ b/requirements/libraries.txt
@@ -10,6 +10,7 @@ django-extensions==2.1.0
 django-flags==3.0.0
 django-haystack==2.7.0
 django-localflavor==1.1
+django-mptt==0.9.0
 django-overextends==0.4.3
 # django-storages 1.6.6 drops support for Django 1.8.
 # https://github.com/jschneier/django-storages/blob/master/CHANGELOG.rst


### PR DESCRIPTION
Allows https://github.com/cfpb/teachers-digital-platform to be included in cfgov-refresh without a separate `pip install`.