### PR TITLE
Regs3k: Preview iteration

### DIFF
--- a/cfgov/regulations3k/migrations/0016_require_effective_date.py
+++ b/cfgov/regulations3k/migrations/0016_require_effective_date.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import datetime
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('regulations3k', '0015_rename_regpage_part_related_field'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='effectiveversion',
+            name='effective_date',
+            field=models.DateField(default=datetime.date.today),
+        ),
+    ]

--- a/cfgov/regulations3k/models/django.py
+++ b/cfgov/regulations3k/models/django.py
@@ -2,8 +2,9 @@
 from __future__ import absolute_import, unicode_literals
 
 import re
-from datetime import datetime
+from datetime import datetime, date
 
+from django.core.exceptions import ValidationError
 from django.db import models
 from django.utils.encoding import python_2_unicode_compatible
 from django.utils.functional import cached_property
@@ -75,7 +76,7 @@ class Part(models.Model):
         the current date and version is not a draft. """
         effective_version = self.versions.filter(
             draft=False,
-            effective_date__lte=datetime.now()
+            effective_date__lte=date.today()
         ).order_by(
             '-effective_date'
         ).first()
@@ -86,7 +87,7 @@ class Part(models.Model):
 class EffectiveVersion(models.Model):
     authority = models.CharField(max_length=255, blank=True)
     source = models.CharField(max_length=255, blank=True)
-    effective_date = models.DateField(blank=True, null=True)
+    effective_date = models.DateField(default=date.today)
     created = models.DateField(blank=True, null=True)
     draft = models.BooleanField(default=False)
     part = models.ForeignKey(Part, related_name="versions")
@@ -113,9 +114,32 @@ class EffectiveVersion(models.Model):
             return 'LIVE'
         if self.draft is True:
             return 'Unapproved draft'
-        if self.effective_date >= datetime.today().date():
+        if self.effective_date >= date.today():
             return 'Future version'
         return 'Previous version'
+
+    def validate_unique(self, exclude=None):
+        super(EffectiveVersion, self).validate_unique(exclude=exclude)
+
+        # Enforce some uniqueness on the effective-date. It will need to be
+        # unique within a part, so if this part has a date the same as this
+        # one, we throw a validation error.
+        versions_with_this_date = self.part.versions.filter(
+            effective_date=self.effective_date
+        )
+
+        if self.pk:
+            versions_with_this_date = versions_with_this_date.exclude(
+                pk=self.pk
+            )
+
+        if versions_with_this_date.count() > 0:
+            raise ValidationError({
+                'effective_date': [
+                    'The part selected below already has an effective version '
+                    'with this date.'
+                ]
+            })
 
     class Meta:
         ordering = ['effective_date']

--- a/cfgov/regulations3k/models/django.py
+++ b/cfgov/regulations3k/models/django.py
@@ -2,7 +2,7 @@
 from __future__ import absolute_import, unicode_literals
 
 import re
-from datetime import datetime, date
+from datetime import date
 
 from django.core.exceptions import ValidationError
 from django.db import models

--- a/cfgov/regulations3k/tests/test_hooks.py
+++ b/cfgov/regulations3k/tests/test_hooks.py
@@ -50,6 +50,27 @@ class TestRegs3kHooks(TestCase, WagtailTestUtils):
             subpart=self.subpart,
         )
 
+        self.draft_effective_version = mommy.make(
+            EffectiveVersion,
+            effective_date=date(2020, 1, 18),
+            part=self.part_1002,
+            draft=True,
+        )
+        self.draft_subpart = mommy.make(
+            Subpart,
+            label='Subpart General',
+            title='General',
+            subpart_type=Subpart.BODY,
+            version=self.draft_effective_version
+        )
+        self.draft_section_num4 = mommy.make(
+            Section,
+            label='4',
+            title='\xa7\xa01002.4 General rules.',
+            contents='{a}\n(a) Regdown paragraph a.\n',
+            subpart=self.draft_subpart,
+        )
+
         self.login()
 
     def test_part_model_admin(self):
@@ -71,7 +92,8 @@ class TestRegs3kHooks(TestCase, WagtailTestUtils):
     def test_section_model_admin_no_preview_button(self):
         response = self.client.get('/admin/regulations3k/section/')
         self.assertEqual(response.status_code, 200)
-        self.assertNotIn(b'Preview', response.content)
+        self.assertNotIn(b'View live', response.content)
+        self.assertNotIn(b'View draft', response.content)
 
     def test_section_model_admin_has_preview_button(self):
         reg_page = RegulationPage(
@@ -83,4 +105,5 @@ class TestRegs3kHooks(TestCase, WagtailTestUtils):
 
         response = self.client.get('/admin/regulations3k/section/')
         self.assertEqual(response.status_code, 200)
-        self.assertIn(b'Preview', response.content)
+        self.assertIn(b'View live', response.content)
+        self.assertIn(b'View draft', response.content)

--- a/cfgov/regulations3k/tests/test_models.py
+++ b/cfgov/regulations3k/tests/test_models.py
@@ -6,7 +6,7 @@ import unittest
 
 # from django.core.urlresolvers import reverse
 from django.contrib.auth.models import AnonymousUser, User
-from django.core.exceptions import PermissionDenied
+from django.core.exceptions import PermissionDenied, ValidationError
 from django.core.paginator import Paginator
 from django.http import HttpRequest, QueryDict  # Http404, HttpResponse
 from django.test import RequestFactory, TestCase as DjangoTestCase
@@ -473,6 +473,16 @@ class RegModelTests(DjangoTestCase):
             b'JAN 18, 2014',
             response.content
         )
+
+    def test_effective_version_date_unique(self):
+        new_effective_version = mommy.make(
+            EffectiveVersion,
+            effective_date=datetime.date(2020, 1, 1),
+            part=self.part_1002,
+            draft=True,
+        )
+        with self.assertRaises(ValidationError):
+            new_effective_version.validate_unique()
 
 
 class SectionNavTests(unittest.TestCase):

--- a/cfgov/regulations3k/wagtail_hooks.py
+++ b/cfgov/regulations3k/wagtail_hooks.py
@@ -23,13 +23,18 @@ class SectionPreviewIndexView(TreeIndexView):
         page = part.page.first()
 
         if page is not None:
+            if effective_version.draft:
+                label = 'View draft'
+            else:
+                label = 'View live'
+
             preview_url = page.url + page.reverse_subpage(
                 'section',
                 kwargs={'date_str': date_str, 'section_label': obj.label}
             )
             preview_button = {
                 'url': preview_url,
-                'label': 'Preview',
+                'label': label,
                 'classname': 'button button-small button-secondary',
                 'title': 'Preview this {}'.format(self.verbose_name),
             }


### PR DESCRIPTION
This PR makes two changes related to our previewability of effective versions:

- Effective versions that are created through the admin now validate the uniqueness of their effective dates within their part. This means a user cannot create two effective versions in the same part with the same effective date.
- The "Preview" button sections will now either say "View Live" for sections that belong to the "Live" effective version or "View Draft" for sections that belong to a non-live effective version.

## Screenshots

![image](https://user-images.githubusercontent.com/10562538/44726316-7986c000-aaa5-11e8-8765-1dd3152d9114.png)


## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
