### PR TITLE
Replace tabs with spaces

### DIFF
--- a/cfgov/v1/migrations/0116_single_wagtail_site.py
+++ b/cfgov/v1/migrations/0116_single_wagtail_site.py
@@ -16,16 +16,16 @@ def site_str(site):
     methods (like __str__). This logic is copied from Wagtail.
     """
     if site.site_name:
-	return(
-	    site.site_name +
-	    (" [default]" if site.is_default_site else "")
-	)
+        return(
+            site.site_name +
+            (" [default]" if site.is_default_site else "")
+        )
     else:
-	return(
-	    site.hostname +
-	    ("" if site.port == 80 else (":%d" % site.port)) +
-	    (" [default]" if site.is_default_site else "")
-	)
+        return(
+            site.hostname +
+            ("" if site.port == 80 else (":%d" % site.port)) +
+            (" [default]" if site.is_default_site else "")
+        )
 
 
 def delete_non_default_wagtail_sites(apps, schema_editor):


### PR DESCRIPTION
The cfgov/v1/migrations/0116_single_wagtail_site.py file seems to have had a mix of tabs and spaces. This PR replaces the tabs with spaces.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
