### PR TITLE
Add Django 1.11 support to custom field id render

### DIFF
--- a/cfgov/v1/forms.py
+++ b/cfgov/v1/forms.py
@@ -175,12 +175,8 @@ class FilterableListForm(forms.Form):
         allowing for a custom field name (new_name).
         """
         old_render = field.widget.render
-        if isinstance(field.widget, widgets.SelectMultiple):
-            field.widget.render = lambda name, value, attrs=None, choices=(): \
-                old_render(new_name, value, attrs, choices)
-        else:
-            field.widget.render = lambda name, value, attrs=None: \
-                old_render(new_name, value, attrs)
+        field.widget.render = lambda name, value, **kwargs: \
+            old_render(new_name, value, **kwargs)
 
     # Generates a query by iterating over the zipped collection of
     # tuples.


### PR DESCRIPTION
Our `v1.forms.FilterableListForm` form class has a custom method `render_with_id` that renders a form field with a custom `id` attribute. This is used in templates like this:

`{{ form.render_with_id(form.field_name, desired_field_id) }}`

instead of using the default

`{{ form.field_name }}`

This adds an `id="desired_field_id"` when the form's `<input>` tag is rendered.

The existing code is incompatible with Django 1.11 due to this change:

https://docs.djangoproject.com/en/1.11/ref/forms/widgets/#django.forms.Widget.render

In Django 1.11, the signature for the `Widget.render` method was changed to add another parameter.

This commit modifies the code to be more generic and handle both method signatures.

## Testing

To verify that this still works, you can run a local server using a production dump and visit http://localhost:8000/about-us/newsroom/. Inspect the form elements in the filterable list (for example, the Author input) and you'll see `id` elements like `id="authors"`.

In addition, this change fixes one failure against Django 1.11 tests, runnable with `tox -e unittest-py27-dj111-wag113-fast`.

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [X] Passes all existing automated tests
- [X] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [X] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: