### PR TITLE
Upgrade retirement satellite app to 0.7.1

### DIFF
--- a/requirements/optional-public.txt
+++ b/requirements/optional-public.txt
@@ -3,7 +3,7 @@ https://github.com/cfpb/complaint/releases/download/1.4.6/complaintdatabase-1.4.
 https://github.com/cfpb/owning-a-home-api/releases/download/0.11.0/owning_a_home_api-0.11.0-py2-none-any.whl
 https://github.com/cfpb/regulations-core/releases/download/1.2.6/regcore-1.2.6-py2-none-any.whl
 https://github.com/cfpb/regulations-site/releases/download/2.2.5/regulations-2.2.5-py2-none-any.whl
-https://github.com/cfpb/retirement/releases/download/0.7.0/retirement-0.7.0-py2-none-any.whl
+https://github.com/cfpb/retirement/releases/download/0.7.1/retirement-0.7.1-py2-none-any.whl
 git+https://github.com/cfpb/ccdb5-api.git@v1.0.6#egg=ccdb5-api
 git+https://github.com/cfpb/ccdb5-ui.git@v1.0.11#egg=ccdb5_ui
 https://github.com/cfpb/django-college-costs-comparison/releases/download/1.7/comparisontool-1.7-py2-none-any.whl


### PR DESCRIPTION
This fixes a library incompatibility issue between cfgov-refresh and
retirement. cfgov-refresh requires djangorestframework 3.6.4 (in order
to support both django 1.8 and 1.11). requests was requiring
django-filters 0.9.2, which is incompatible with drf 3.6.4. This version
bump removes that django-filters dependency.

## Changes

- retirement `0.7.0` -> `0.7.1`

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [x] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

Doesn't affect any cfgov-refresh functionality.