### PR TITLE
Add Django 1.11 support to custom alert logging

### DIFF
--- a/cfgov/alerts/logging_handlers.py
+++ b/cfgov/alerts/logging_handlers.py
@@ -2,8 +2,10 @@ from __future__ import unicode_literals
 
 import logging
 import os
+from pprint import pformat
 
-from django.utils.encoding import force_text
+from django.utils import six
+from django.utils.encoding import force_str
 from django.views.debug import get_exception_reporter_filter
 
 from alerts.sqs_queue import SQSQueue
@@ -14,10 +16,10 @@ class CFGovErrorHandler(logging.Handler):
 
     Based on django.utils.log.AdminEmailHandler.
 
-    Generated GitHub issues include all of the same information that Django
-    admin emails do. Details at:
+    Generated GitHub issues include stack trace and request information.
+    Sensitive request POST parameters are filtered using this Django logic:
 
-    https://docs.djangoproject.com/en/1.8/howto/error-reporting/#filtering-sensitive-information
+    https://docs.djangoproject.com/en/1.11/howto/error-reporting/#filtering-sensitive-information
     """
 
     def __init__(self):
@@ -42,12 +44,87 @@ class CFGovErrorHandler(logging.Handler):
     def format_body(self, record):
         try:
             request = record.request
-            filter = get_exception_reporter_filter(request)
-            request_repr = '\n{}'.format(
-                force_text(filter.get_request_repr(request))
-            )
-        except Exception:
+        except AttributeError:
             request = None
-            request_repr = "unavailable"
 
-        return "%s\n\nRequest repr(): %s" % (self.format(record), request_repr)
+        return "%s\n\nRequest repr(): \n%s" % (
+            self.format(record),
+            self._get_request_repr(request)
+        )
+
+    def _get_request_repr(self, request):
+        """
+        Generates a text representation of a Django request for use in logging
+        500 errors.
+
+        Copy of django.views.debug.ExceptionReporterFilter.get_request_repr,
+        removed in Django 1.9:
+
+        https://github.com/django/django/blob/1.8.19/django/views/debug.py#L118
+        https://docs.djangoproject.com/en/dev/releases/1.9/#httprequest-details-in-error-reporting
+
+        Copied here to maintain existing behavior on upgrade to Django 1.11.
+
+        Slightly modified to encapsulate logic around null requests.
+        """
+        if request is None:
+            return repr(None)
+
+        filter = get_exception_reporter_filter(request)
+        post_override = filter.get_post_parameters(request)
+
+        return self._build_request_repr(request, post_override)
+
+    def _build_request_repr(self, request, POST_override):
+        """
+        Builds and returns the request's representation string. The request's
+        attributes may be overridden by pre-processed values.
+
+        Copy of django.http.request.build_request_repr, removed in Django 1.9:
+
+        https://github.com/django/django/blob/1.8.19/django/http/request.py#L468
+        https://docs.djangoproject.com/en/dev/releases/1.9/#httprequest-details-in-error-reporting
+
+        Copied here to maintain existing behavior on upgrade to Django 1.11.
+
+        This code has been simplified to accept a single required parameter for
+        overriding POST parameters. The original code makes this parameter
+        optional and supports other arguments which are not used anywhere.
+        """
+        # Since this is called as part of error handling, we need to be very
+        # robust against potentially malformed input.
+        try:
+            get = pformat(request.GET)
+        except Exception:
+            get = '<could not parse>'
+
+        if request._post_parse_error:
+            post = '<could not parse>'
+        else:
+            try:
+                post = pformat(POST_override)
+            except Exception:
+                post = '<could not parse>'
+
+        try:
+            cookies = pformat(request.COOKIES)
+        except Exception:
+            cookies = '<could not parse>'
+
+        try:
+            meta = pformat(request.META)
+        except Exception:
+            meta = '<could not parse>'
+
+        path = request.path
+
+        return force_str(
+            '<%s\npath:%s,\nGET:%s,\nPOST:%s,\nCOOKIES:%s,\nMETA:%s>' % (
+                request.__class__.__name__,
+                path,
+                six.text_type(get),
+                six.text_type(post),
+                six.text_type(cookies),
+                six.text_type(meta)
+            )
+        )

--- a/cfgov/alerts/tests/test_logging_handlers.py
+++ b/cfgov/alerts/tests/test_logging_handlers.py
@@ -4,6 +4,7 @@ import logging
 import os
 
 from django.conf import settings
+from django.http import QueryDict
 from django.test import RequestFactory, TestCase
 
 from mock import patch
@@ -84,9 +85,50 @@ class TestLoggingHandlers(TestCase):
         args, kwargs = sqs_queue_post.call_args
         self.assertIn('ValueError: raising an exception', kwargs['message'])
 
-    def test_body_includes_request(self, sqs_queue_post):
+    def test_body_includes_request_if_provided(self, sqs_queue_post):
         request = RequestFactory().get('/')
         self.logger.error('something', extra={'request': request})
 
         args, kwargs = sqs_queue_post.call_args
-        self.assertIn('<WSGIRequest\npath:/', kwargs['message'])
+        self.assertIn(
+            'Request repr(): \n<WSGIRequest\npath:/',
+            kwargs['message']
+        )
+
+    def test_body_shows_none_if_no_request_available(self, sqs_queue_post):
+        self.logger.error('something')
+
+        args, kwargs = sqs_queue_post.call_args
+        self.assertIn('Request repr(): \nNone', kwargs['message'])
+
+    def test_body_handles_unparseable_querydict(self, sqs_queue_post):
+        """Handle when calls to format request.GET or POST fail."""
+        with patch.object(QueryDict, '__repr__', side_effect=Exception):
+            request = RequestFactory().get('/')
+            self.logger.error('something', extra={'request': request})
+
+        args, kwargs = sqs_queue_post.call_args
+        self.assertIn('<could not parse>', kwargs['message'])
+
+    def test_body_handles_unparseable_dict(self, sqs_queue_post):
+        """Handle when calls to format request.COOKIES or META fail."""
+        class ObjectThatCantBeRepresented(object):
+            def __repr__(self):
+                raise Exception
+
+        request = RequestFactory().get('/')
+        request.COOKIES = {'test': ObjectThatCantBeRepresented()}
+        request.META = {'test': ObjectThatCantBeRepresented()}
+        self.logger.error('something', extra={'request': request})
+
+        args, kwargs = sqs_queue_post.call_args
+        self.assertIn('<could not parse>', kwargs['message'])
+
+    def test_body_handles_request_with_invalid_post(self, sqs_queue_post):
+        """Handle case when a request was generated with an invalid POST."""
+        request = RequestFactory().post('/')
+        request._mark_post_parse_error()
+        self.logger.error('something', extra={'request': request})
+
+        args, kwargs = sqs_queue_post.call_args
+        self.assertIn('<could not parse>', kwargs['message'])


### PR DESCRIPTION
Django 1.9 modified some of the code used to generate error messages:

https://docs.djangoproject.com/en/dev/releases/1.9/#httprequest-details-in-error-reporting

We currently rely on some of this code to generate the alert error messages that we log to SQS. In order to make this code compatible with Django 1.11 (and fix a failing unit test), this PR pulls forward the Django 1.8 methods that were used.

This change also adds some additional unit tests to ensure 100% code coverage of the methods that were pulled in.

To run relevant tests against Django 1.8 and Django 1.11:

`tox -e unittest-py27-dj18-wag113-fast alerts.tests.test_logging_handlers.TestLoggingHandlers`
`tox -e unittest-py27-dj111-wag113-fast alerts.tests.test_logging_handlers.TestLoggingHandlers`

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [X] Passes all existing automated tests
- [X] Any _change_ in functionality is tested
- [X] New functions are documented (with a description, list of inputs, and expected output)
- [X] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [X] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: