### PR TITLE
Fix BeautifulSoup-related test warnings in Django 1.11

### DIFF
--- a/cfgov/agreements/tests/test_legacy.py
+++ b/cfgov/agreements/tests/test_legacy.py
@@ -7,7 +7,6 @@ from django.template import Context, Template
 from django.test import TestCase
 
 from agreements import models
-from bs4 import BeautifulSoup
 from mock import patch
 
 
@@ -225,11 +224,18 @@ class TemplateTags(TestCase):
             issuer = models.Issuer.objects.create(name=name, slug=name)
             models.Agreement.objects.create(issuer=issuer, size=1234)
 
-        selected = models.Issuer.objects.order_by('?').first()
-
         t = Template("{% load agreements_extras %}" +
                      "{% issuer_select id %}")
-        soup = BeautifulSoup(t.render(Context({'id': selected.slug})))
-        option = soup.find_all('option', selected=True)
-        self.assertTrue(len(option) == 1)
-        self.assertTrue(selected.name in option[0])
+        html = t.render(Context({'id': 'BBB'}))
+        self.assertHTMLEqual(html, """
+<select
+    data-placeholder="Choose an issuer"
+    class="chzn-select"
+    tabindex="2"
+    id="issuer_select"
+>
+    <option value="AAA">AAA</option>
+    <option value="BBB" selected>BBB</option>
+    <option value="CCC">CCC</option>
+</select>
+        """)

--- a/cfgov/ask_cfpb/tests/models/test_pages.py
+++ b/cfgov/ask_cfpb/tests/models/test_pages.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
 import datetime
@@ -9,12 +10,11 @@ from django.apps import apps
 from django.core.urlresolvers import reverse
 from django.http import Http404, HttpRequest, HttpResponse
 from django.template.defaultfilters import slugify
-from django.test import RequestFactory, TestCase
+from django.test import TestCase
 from django.utils import html, timezone
 from django.utils.translation import ugettext as _
 
 import mock
-from bs4 import BeautifulSoup as bs
 from mock import mock_open, patch
 from model_mommy import mommy
 
@@ -538,15 +538,20 @@ class AnswerModelTestCase(TestCase):
         self.assertFalse(test_page.page_js)
 
     def test_spanish_template_used(self):
-        spanish_answer = self.prepare_answer(
-            answer_es='Spanish answer',
-            slug_es='spanish-answer',
-            update_spanish_page=True)
-        spanish_answer.save()
-        spanish_page = spanish_answer.spanish_page
-        request = RequestFactory().get('/')
-        soup = bs(spanish_page.serve(request).rendered_content)
-        self.assertIn('Oficina', soup.title.string)
+        path = reverse(
+            'ask-spanish-answer',
+            args=['mock-spanish-question1', 'es', '1234']
+        )
+        response = self.client.get(path)
+        self.assertContains(
+            response,
+            (
+                '<title>'
+                '> Oficina para la Protección Financiera del Consumidor'
+                '</title>'
+            ),
+            html=True
+        )
 
     def test_spanish_answer_page_handles_referrer_with_unicode_accents(self):
         referrer_unicode = (


### PR DESCRIPTION
Running the Python tests against Django 1.11 (using the test command `tox -e unittest-py27-dj111-wag113-fast`) was generating a BeautifulSoup-related warning message:

```
/Projects/cfgov-refresh/.tox/unittest-py27-dj111-wag113-fast/lib/python2.7/site-packages/bs4/__init__.py:181: UserWarning: No parser was explicitly specified, so I'm using the best available HTML parser for this system ("lxml"). This usually isn't a problem, but if you run this code on another system, or in a different virtual environment, it may use a different parser and behave differently.

The code that caused this warning is on line 11 of the file /Users/chosaka/Projects/cfgov-refresh/.tox/unittest-py27-dj111-wag113-fast/bin/coverage. To get rid of this warning, change code that looks like this:

 BeautifulSoup([your markup])

to this:

 BeautifulSoup([your markup], "lxml")
```

These changes fix that warning by removing those uses of BeautifulSoup. In both cases the tests can be executed without needing to do full HTML parsing.

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [X] Passes all existing automated tests
- [X] Any _change_ in functionality is tested
- [X] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: