### PR TITLE
Add Django 1.11 support for use of overextends

### DIFF
--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -1,6 +1,7 @@
 import os
 import sys
 
+import django
 from django.conf import global_settings
 from django.utils.translation import ugettext_lazy as _
 
@@ -182,6 +183,13 @@ TEMPLATES = [
     },
 ]
 
+# TODO: Remove this when support for Django < 1.9 is removed.
+# The ability to specify builtins like this was added in Django 1.9.
+# https://docs.djangoproject.com/en/dev/releases/1.9/#templates
+if django.VERSION[:2] >= (1, 9):
+    TEMPLATES[0]['OPTIONS']['builtins'] = [
+        'overextends.templatetags.overextends_tags',
+    ]
 
 WSGI_APPLICATION = 'cfgov.wsgi.application'
 


### PR DESCRIPTION
Per the overextends documentation at https://github.com/stephenmcd/django-overextends, we need to add the overextends tags to the base Django settings in order to be able to use the `overextends` tag in templates.

These URLs raise 500s on Django 1.11 on master but work with this PR:

http://localhost:8000/login/
http://localhost:8000/django-admin/

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [X] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [X] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [X] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: