### PR TITLE
Remove duplicate definition of Django admin URLs

### DIFF
--- a/cfgov/cfgov/urls.py
+++ b/cfgov/cfgov/urls.py
@@ -458,7 +458,6 @@ if settings.ALLOW_ADMIN_URL:
         url(r'^admin/account/change_password/$',
             change_password,
             name='wagtailadmin_account_change_password'),
-        url(r'^django-admin/', include(admin.site.urls)),
         url(r'^admin/', include(wagtailadmin_urls)),
 
     ]


### PR DESCRIPTION
We erroneously include the Django admin URLs twice in our main URL file (lines [444](https://github.com/cfpb/cfgov-refresh/blob/master/cfgov/cfgov/urls.py#L444) and [461](https://github.com/cfpb/cfgov-refresh/blob/master/cfgov/cfgov/urls.py#L461)). On Django 1.11 this results in the following warning:

> ?: (urls.W005) URL namespace 'admin' isn't unique. You may not be able to reverse all URLs in this namespace

This commit removes the second definition. You can confirm that the Django admin URLs still work locally by visiting http://localhost:8000/django-admin/ with a local server (although note this will require the change in #4474 to work properly).

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [X] Passes all existing automated tests
- [X] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [X] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: