### PR TITLE
Regs3k: Initial attempt at a RegML importer

### DIFF
--- a/cfgov/regulations3k/fixtures/reg_d.regml
+++ b/cfgov/regulations3k/fixtures/reg_d.regml
@@ -1,0 +1,39 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<regulation xmlns="eregs">
+  <preamble>
+    <cfr>
+      <title>12</title>
+      <section>1004</section>
+    </cfr>
+    <effectiveDate>2011-07-22</effectiveDate>
+  </preamble>
+  <part label="1004">
+    <content>
+      <subpart label="General">
+        <content>
+          <section label="1004-1" sectionNum="1">
+            <subject>§ 1004.1 Authority, purpose, and scope.</subject>
+            <paragraph label="1004-1-a" marker="(a)">
+              <title type="keyterm">Authority.</title>
+              <content>Authority. This regulation, known as Regulation D, is issued by the Bureau of Consumer Financial Protection to implement the Alternative Mortgage Transaction Parity Act, <ref target="USC:12-3801" reftype="external">12 U.S.C. 3801</ref> et seq., as amended by title X, Section 1083 of the Dodd-Frank Wall Street Reform and Consumer Protection Act (Pub. L. 111-203, <ref target="STATUTES_AT_LARGE:124-Stat.-1376" reftype="external">124 Stat. 1376</ref>). Section <ref target="1004-4" reftype="internal">1004.4</ref> is issued pursuant to the Alternative Mortgage Transaction Parity Act (as amended) and the Truth in Lending Act, <ref target="USC:15-1601" reftype="external">15 U.S.C. 1601</ref> et seq.</content>
+            </paragraph>
+          </section>
+        </content>
+      </subpart>
+      <appendix appendixLetter="A" label="1004-A">
+        <appendixTitle>Appendix A to Part 1004—Official Commentary on Regulation D</appendixTitle>
+        <appendixSection appendixSecNum="1" label="1004-A-h1">
+          <subject>§ 1004.1 Authority, Purpose, and Scope</subject>
+          <paragraph label="1004-A-h1-h2" marker="">
+            <title>1(c) Scope.</title>
+            <content/>
+            <paragraph label="1004-A-h1-h2-1" marker="1.">
+              <title type="keyterm">Application received before July 22, 2011.</title>
+              <content>Application received before July 22, 2011. This Part does not apply to a transaction if the <ref target="1004-2-b" reftype="term">creditor</ref> received the application for that transaction before July 22, 2011, even if the transaction was consummated or completed on or after July 22, 2011. Whether <ref target="USC:12-3803" reftype="external">12 U.S.C. 3803</ref>(c) preempts <ref target="1004-2-e" reftype="term">State law</ref> with respect to such a transaction depends on whether: (1) The transaction was an <ref target="1004-2-a" reftype="term">alternative mortgage transaction</ref> as defined by the version of <ref target="USC:12-3802" reftype="external">12 U.S.C. 3802</ref>(1) in effect at the time of application; and (2) the <ref target="1004-2-d" reftype="term">State</ref> <ref target="1004-2-c" reftype="term">housing creditor</ref> complied with applicable federal regulations issued by the Office of the Comptroller of the Currency, the National Credit Union Administration, the Office of Thrift Supervision, or the Federal Home Loan Bank Board in effect at the time of application.</content>
+            </paragraph>
+          </paragraph>
+        </appendixSection>
+      </appendix>
+    </content>
+  </part>
+</regulation>

--- a/cfgov/regulations3k/migrations/0017_set_default_created_date.py
+++ b/cfgov/regulations3k/migrations/0017_set_default_created_date.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import datetime
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('regulations3k', '0016_require_effective_date'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='effectiveversion',
+            name='created',
+            field=models.DateField(default=datetime.date.today),
+        ),
+    ]

--- a/cfgov/regulations3k/models/django.py
+++ b/cfgov/regulations3k/models/django.py
@@ -88,7 +88,7 @@ class EffectiveVersion(models.Model):
     authority = models.CharField(max_length=255, blank=True)
     source = models.CharField(max_length=255, blank=True)
     effective_date = models.DateField(default=date.today)
-    created = models.DateField(blank=True, null=True)
+    created = models.DateField(default=date.today)
     draft = models.BooleanField(default=False)
     part = models.ForeignKey(Part, related_name="versions")
 

--- a/cfgov/regulations3k/scripts/regml_importer.py
+++ b/cfgov/regulations3k/scripts/regml_importer.py
@@ -1,0 +1,427 @@
+from __future__ import unicode_literals
+
+import datetime
+import logging
+import sys
+
+from lxml import etree
+
+from regulations3k.models.django import (
+    EffectiveVersion, Part, Section, Subpart
+)
+
+
+logger = logging.getLogger(__name__)
+
+CFR_CHAPTER = 'X'
+
+TABLE_XSLT = b'''<?xml version='1.0' encoding='UTF-8'?>
+<xsl:stylesheet version="1.0"
+        xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+        xmlns:eregs="eregs"
+        exclude-result-prefixes="eregs">
+    <xsl:output method="xml" omit-xml-declaration="yes" />
+    <xsl:output encoding="UTF-8"/>
+
+    <xsl:template match="eregs:table">
+        <div class="o-table o-table-wrapper__scrolling">
+            <table>
+                <xsl:apply-templates select="eregs:header"/>
+                <tbody>
+                    <xsl:apply-templates select="eregs:row"/>
+                </tbody>
+            </table>
+        </div>
+    </xsl:template>
+
+    <xsl:template match="eregs:header">
+        <thead>
+            <xsl:apply-templates/>
+        </thead>
+    </xsl:template>
+
+    <xsl:template match="eregs:columnHeaderRow">
+        <tr>
+            <xsl:apply-templates/>
+        </tr>
+    </xsl:template>
+
+    <xsl:template match="eregs:column">
+        <th scope="col">
+            <xsl:attribute name="rowspan">
+                <xsl:value-of select="@rowspan"/>
+            </xsl:attribute>
+            <xsl:attribute name="colspan">
+                <xsl:value-of select="@colspan"/>
+            </xsl:attribute>
+            <xsl:apply-templates/>
+        </th>
+    </xsl:template>
+
+    <xsl:template match="eregs:row">
+        <tr>
+            <xsl:apply-templates/>
+        </tr>
+    </xsl:template>
+
+    <xsl:template match="eregs:cell">
+        <td align="left">
+            <xsl:apply-templates/>
+        </td>
+    </xsl:template>
+
+</xsl:stylesheet>
+'''
+TABLE_TRANSFORM = etree.XSLT(etree.fromstring(TABLE_XSLT))
+
+
+class RegMLParser(object):
+
+    def parse(self, xml_tree, part=None, effective_version=None):
+        # Strip tags we're not interested in
+        etree.strip_tags(xml_tree, '{eregs}ref')
+        etree.strip_tags(xml_tree, '{eregs}def')
+        etree.strip_tags(xml_tree, '{eregs}callout')
+        etree.strip_tags(xml_tree, '{eregs}line')
+        etree.strip_tags(xml_tree, '{eregs}variable')
+        etree.strip_tags(xml_tree, '{eregs}subscript')
+
+        if part is None:
+            part = self.get_part(xml_tree)
+
+        if effective_version is None:
+            effective_version = self.get_effective_version(part, xml_tree)
+
+        subpart_nodes = xml_tree.findall(
+            './{eregs}part/{eregs}content/{eregs}subpart'
+        )
+        appendix_nodes = xml_tree.findall(
+            './{eregs}part/{eregs}content/{eregs}appendix'
+        )
+        interp_node = xml_tree.find(
+            './{eregs}part/{eregs}content/{eregs}interpretations'
+        )
+
+        if subpart_nodes is not None:
+            self.get_subparts(
+                effective_version, subpart_nodes, interp_node=interp_node
+            )
+
+        if appendix_nodes is not None:
+            self.get_appendices(
+                effective_version, appendix_nodes, interp_node=interp_node
+            )
+
+        if interp_node is not None:
+            self.get_interpretations(effective_version, interp_node)
+
+        return effective_version
+
+    def get_part(self, xml_tree):
+        part_number = xml_tree.find(
+            './{eregs}preamble/{eregs}cfr/{eregs}section'
+        ).text
+        cfr_title = xml_tree.find(
+            './{eregs}preamble/{eregs}cfr/{eregs}title'
+        ).text
+        part, created = Part.objects.get_or_create(
+            part_number=part_number,
+            chapter=CFR_CHAPTER,
+            cfr_title_number=cfr_title)
+
+        return part
+
+    def get_effective_version(self, part, xml_tree):
+        effective_date_str = xml_tree.find(
+            './{eregs}preamble/{eregs}effectiveDate'
+        ).text
+        effective_date = datetime.datetime.strptime(
+            effective_date_str, "%Y-%m-%d"
+        ).date()
+        effective_version, created = \
+            EffectiveVersion.objects.get_or_create(
+                effective_date=effective_date,
+                part=part
+            )
+
+        if not created:
+            raise ValueError(
+                'Effecitve date {} already exists for part {}'.format(
+                    effective_date, part)
+            )
+
+        effective_version.draft = True
+        return effective_version
+
+    def get_subparts(self, effective_version, subpart_nodes,
+                     interp_node=None):
+        subparts = []
+        for subpart_node in subpart_nodes:
+            label = subpart_node.get('label')
+            letter = subpart_node.get('subpartLetter')
+
+            title_text = ''
+            title_node = subpart_node.find('{eregs}title')
+            if title_node is not None:
+                title_text = title_node.text
+
+            title = 'Subpart {letter} - {title_text}'.format(
+                letter=letter,
+                title_text=title_text
+            )
+
+            subpart_type = Subpart.BODY
+            subpart = Subpart(
+                label=label,
+                title=title,
+                version=effective_version,
+                subpart_type=subpart_type
+            )
+            subpart.save()
+
+            logger.info('Created subpart {}'.format(subpart))
+
+            section_nodes = subpart_node.findall(
+                './{eregs}content/{eregs}section'
+            )
+            for section_node in section_nodes:
+                self.get_section_for_node(
+                    subpart, section_node, interp_node=interp_node
+                )
+
+            subparts.append(subpart)
+
+        return subparts
+
+    def get_appendices(self, effective_version, appendix_nodes,
+                       interp_node=None):
+        subpart_type = Subpart.APPENDIX
+        subpart = Subpart(
+            label='Appendices',
+            title='Appendices',
+            version=effective_version,
+            subpart_type=subpart_type
+        )
+        subpart.save()
+        logger.info('Created appendix subpart {}'.format(subpart))
+
+        for appendix_node in appendix_nodes:
+            self.get_section_for_appendix(
+                subpart, appendix_node, interp_node=interp_node
+            )
+
+        return subpart
+
+    def get_interpretations(self, effective_version, interp_node):
+        regml_label = interp_node.get('label')
+        label = regml_label.split('-', 1)[1]
+        title = interp_node.find('./{eregs}title').text
+        subpart_type = Subpart.INTERPRETATION
+        subpart = Subpart(
+            label=label,
+            title=title,
+            version=effective_version,
+            subpart_type=subpart_type
+        )
+        subpart.save()
+        logger.info('Created interpretations subpart {}'.format(subpart))
+
+        section_nodes = interp_node.findall(
+            './{eregs}interpSection'
+        )
+        for section_node in section_nodes:
+            self.get_section_for_interp_section_node(
+                subpart, section_node
+            )
+
+        return subpart
+
+    def get_section_for_node(self, subpart, section_node, interp_node=None):
+        regml_label = section_node.get('label')
+        label = regml_label.split('-', 1)[1]
+        title = section_node.find('./{eregs}subject').text
+        contents = ''
+
+        paragraph_nodes = section_node.findall(
+            './{eregs}paragraph'
+        )
+        for paragraph_node in paragraph_nodes:
+            contents += self.get_regdown_for_paragraph(
+                paragraph_node, interp_node=interp_node
+            )
+
+        section = Section(
+            label=label,
+            title=title,
+            contents=contents,
+            subpart=subpart
+        )
+        section.save()
+        logger.info('Created section {}'.format(title))
+        return section
+
+    def get_section_for_appendix(self, subpart, appendix_node,
+                                 interp_node=None):
+        regml_label = appendix_node.get('label')
+        label = regml_label.split('-', 1)[1]
+        title = appendix_node.find('{eregs}appendixTitle').text
+        contents = ''
+
+        section_nodes = appendix_node.findall('{eregs}appendixSection')
+        for section_node in section_nodes:
+            section_regml_label = appendix_node.get('label')
+            section_label = section_regml_label.split('-', 1)[1]
+            contents += '{{{label}}}\n'.format(label=section_label)
+
+            section_subject = section_node.find('{eregs}subject').text
+            contents += '## {subject}\n\n'.format(subject=section_subject)
+
+            paragraph_nodes = section_node.findall(
+                './{eregs}paragraph'
+            )
+            for paragraph_node in paragraph_nodes:
+                contents += self.get_regdown_for_paragraph(
+                    paragraph_node, interp_node=interp_node
+                )
+
+        section = Section(
+            label=label,
+            title=title,
+            contents=contents,
+            subpart=subpart
+        )
+        section.save()
+        logger.info('Created appendix {}'.format(title))
+
+        return section
+
+    def get_section_for_interp_section_node(self, subpart, section_node):
+        regml_label = section_node.get('label').replace('_', '')
+        label = regml_label.split('-', 1)[1]
+        # With Regs3k we've flipped interpretation section labels.
+        label = '{1}-{0}'.format(*label.split('-', 2))
+
+        title = section_node.find('./{eregs}title').text
+        contents = ''
+
+        paragraph_nodes = section_node.findall(
+            './{eregs}interpParagraph'
+        )
+        for paragraph_node in paragraph_nodes:
+            contents += self.get_regdown_for_paragraph(paragraph_node)
+
+        section = Section(
+            label=label,
+            title=title,
+            contents=contents,
+            subpart=subpart
+        )
+        section.save()
+        logger.info('Created interpretation section {}'.format(label))
+        return section
+
+    def get_regdown_for_paragraph(self, paragraph_node, interp_node=None):
+        regdown = ''
+
+        regml_label = paragraph_node.get('label')
+        if regml_label is not None:
+            label = regml_label.split('-', 2)[2]
+            regdown += '{{{label}}}\n'.format(label=label)
+
+        marker = paragraph_node.get('marker')
+
+        title = ''
+        title_node = paragraph_node.find('{eregs}title')
+        if title_node is not None and title_node.text is not None:
+            title = ' ' + title_node.text
+
+        if marker or title:
+            regdown += '**{marker}{title}** '.format(
+                marker=marker, title=title
+            )
+
+        content_node = paragraph_node.find('{eregs}content')
+        contents = content_node.text or ''
+        for child_node in content_node:
+            if child_node.tag == '{eregs}dash':
+                contents += '{text}__{tail}'.format(
+                    text=child_node.text or ' ', tail=child_node.tail or ''
+                )
+            elif child_node.tag == '{eregs}graphic':
+                alttext = child_node.find('./{eregs}altText').text or ''
+                url = child_node.find('./{eregs}url').text or ''
+                contents += '![{alttext}]({url})'.format(
+                    alttext=alttext, url=url
+                )
+            elif child_node.tag == '{eregs}table':
+                table_string = etree.tostring(
+                    TABLE_TRANSFORM(child_node)
+                ).decode()
+                contents += table_string.replace('\n', '').replace('\r', '')
+
+        regdown += '{contents}\n\n'.format(
+            contents=contents
+        )
+
+        if interp_node is not None and regml_label is not None:
+            interp_nodes_targetting_paragraph = [
+                n for n in interp_node.findall(
+                    './/{eregs}interpParagraph[@target]'
+                )
+                if n.get('target') == regml_label
+            ]
+            for interp_node in interp_nodes_targetting_paragraph:
+                interp_regml_label = interp_node.get('label')
+                interp_label = interp_regml_label.split('-', 1)[1]
+                regdown += '\nsee({interp_label})\n\n'.format(
+                    interp_label=interp_label
+                )
+
+        # Get all subparagraphs of this paragraph type
+        subparagraph_nodes = paragraph_node.findall(paragraph_node.tag)
+        for subparagraph_node in subparagraph_nodes:
+            regdown += self.get_regdown_for_paragraph(subparagraph_node)
+
+        return regdown
+
+
+def regml_to_regdown(regulation_file):
+    '''
+    Extract an effective version of a regulation from RegML and create regdown
+    content.
+    '''
+    starter = datetime.datetime.now()
+
+    try:
+        with open(regulation_file, 'rb') as f:
+            reg_xml = f.read()
+    except IOError:
+        logger.info('Could not open local file {}'.format(regulation_file))
+        return
+
+    parser = etree.XMLParser(huge_tree=True, remove_blank_text=True)
+    xml_tree = etree.fromstring(reg_xml, parser)
+    parser = RegMLParser()
+    effective_version = parser.parse(xml_tree)
+
+    msg = (
+        'Draft {version} version of part {part} created.\n'
+        'Parsing took {time}'.format(
+            version=effective_version,
+            part=effective_version.part.part_number,
+            time=(datetime.datetime.now() - starter)
+        )
+    )
+    return msg
+
+
+def run(*args):
+    if len(args) != 1:
+        logger.info(
+            'Usage: ./cfgov/manage.py runscript '
+            'regml_importer --script-args '
+            '[REGML FILE PATH]')
+        sys.exit(1)
+    else:
+        logger.info('Parsing from RegML file {}'.format(args[0]))
+        logger.info(regml_to_regdown(args[0]))

--- a/cfgov/regulations3k/tests/test_regml_importer.py
+++ b/cfgov/regulations3k/tests/test_regml_importer.py
@@ -1,0 +1,382 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from datetime import date
+
+from django.conf import settings
+from django.test import TestCase
+
+import mock
+from lxml import etree
+from model_mommy import mommy
+
+from regulations3k.models.django import EffectiveVersion, Part, Subpart
+from regulations3k.scripts import regml_importer
+
+
+class RegMLImporterTestCase(TestCase):
+
+    def setUp(self):
+        self.part = mommy.make(
+            Part,
+            chapter='X',
+            cfr_title_number='12',
+            part_number='1005',
+        )
+        self.effective_version = mommy.make(
+            EffectiveVersion,
+            effective_date=date(2018, 1, 1),
+            part=self.part,
+            draft=True
+        )
+        self.subpart = mommy.make(Subpart)
+
+        self.parser = regml_importer.RegMLParser()
+
+        self.regml_file = "{}/regulations3k/fixtures/reg_d.regml".format(
+            settings.PROJECT_ROOT
+        )
+
+    @mock.patch('logging.Logger.info')
+    def test_script_run(self, mock_info):
+        regml_importer.run(self.regml_file)
+        mock_info.assert_any_call(
+            'Parsing from RegML file {}'.format(self.regml_file)
+        )
+
+    def test_script_run_without_argument(self):
+        with self.assertRaises(SystemExit):
+            regml_importer.run()
+
+    def test_regml_to_regdown(self):
+        msg = regml_importer.regml_to_regdown(self.regml_file)
+        self.assertIn('version of part 1004 created', msg)
+
+    @mock.patch('logging.Logger.info')
+    def test_regml_to_regdown_file_does_not_exist(self, mock_info):
+        regml_importer.regml_to_regdown('/some/non/existent/file')
+        mock_info.assert_any_call(
+            'Could not open local file /some/non/existent/file'
+        )
+
+    def test_parser_parse(self):
+        regml = b'''<?xml version='1.0' encoding='UTF-8'?>
+            <regulation xmlns="eregs">
+                <preamble>
+                    <cfr>
+                        <title>12</title>
+                        <section>1005</section>
+                    </cfr>
+                    <effectiveDate>2016-11-14</effectiveDate>
+                </preamble>
+                <part label="1005">
+                    <content>
+                        <subpart subpartLetter="A" label="1005-Subpart-A">
+                            <title>General</title>
+                        </subpart>
+                        <appendix appendixLetter="A" label="1005-A">
+                            <appendixTitle>Appendix A</appendixTitle>
+                        </appendix>
+                        <interpretations label="1005-Interp">
+                            <title>Supplement I to Part 1005</title>
+                        </interpretations>
+                    </content>
+                </part>
+            </regulation>'''
+        xml_tree = etree.fromstring(regml)
+        effective_version = self.parser.parse(xml_tree)
+        self.assertEqual(effective_version.subparts.count(), 3)
+
+    def test_regml_part(self):
+        regml = b'''<?xml version='1.0' encoding='UTF-8'?>
+            <regulation xmlns="eregs">
+                <preamble>
+                    <cfr>
+                        <title>12</title>
+                        <section>1005</section>
+                    </cfr>
+                </preamble>
+            </regulation>'''
+        xml_tree = etree.fromstring(regml)
+        part = self.parser.get_part(xml_tree)
+        self.assertEqual(part, self.part)
+
+    def test_regml_effective_version(self):
+        regml = b'''<?xml version='1.0' encoding='UTF-8'?>
+            <regulation xmlns="eregs">
+                <preamble>
+                    <effectiveDate>2016-11-14</effectiveDate>
+                </preamble>
+            </regulation>'''
+        xml_tree = etree.fromstring(regml)
+        effective_version = self.parser.get_effective_version(
+            self.part, xml_tree
+        )
+        self.assertEqual(
+            effective_version.effective_date,
+            date(2016, 11, 14)
+        )
+
+    def test_regml_effective_version_existing(self):
+        regml = b'''<?xml version='1.0' encoding='UTF-8'?>
+            <regulation xmlns="eregs">
+                <preamble>
+                    <effectiveDate>2018-01-01</effectiveDate>
+                </preamble>
+            </regulation>'''
+        xml_tree = etree.fromstring(regml)
+        with self.assertRaises(ValueError):
+            self.parser.get_effective_version(
+                self.part, xml_tree
+            )
+
+    def test_regml_subpart(self):
+        regml = b'''<?xml version='1.0' encoding='UTF-8'?>
+            <content xmlns="eregs">
+                <subpart subpartLetter="A" label="1005-Subpart-A">
+                    <title>General</title>
+                    <content>
+                        <section label="1005-1" sectionNum="1">
+                            <subject>1005.1 Authority and purpose.</subject>
+                        </section>
+                    </content>
+                </subpart>
+                <subpart subpartLetter="B" label="1005-Subpart-B">
+                    <title>Requirements for Remittance Transfers</title>
+                </subpart>
+            </content>'''
+        subpart_nodes = etree.fromstring(regml).findall('{eregs}subpart')
+        subparts = self.parser.get_subparts(
+            self.effective_version, subpart_nodes
+        )
+        self.assertEqual(len(subparts), 2)
+        self.assertEqual(subparts[0].title, 'Subpart A - General')
+        self.assertEqual(subparts[0].sections.count(), 1)
+
+    def test_regml_section(self):
+        regml = b'''<?xml version='1.0' encoding='UTF-8'?>
+            <section xmlns="eregs" label="1005-1" sectionNum="1">
+                <subject>1005.1 Authority and purpose.</subject>
+                <paragraph xmlns="eregs" label="1005-1-a" marker="">
+                    <content>
+                        Test paragraph
+                    </content>
+                </paragraph>
+            </section>'''
+        section_node = etree.fromstring(regml)
+        section = self.parser.get_section_for_node(
+            self.subpart, section_node
+        )
+        self.assertEqual(section.label, '1')
+        self.assertEqual(section.title, '1005.1 Authority and purpose.')
+        self.assertIn('Test paragraph', section.contents)
+
+    def test_regdown_appendices(self):
+        regml = b'''<?xml version='1.0' encoding='UTF-8'?>
+            <regulation xmlns="eregs">
+                <appendix appendixLetter="A" label="1005-A">
+                    <appendixTitle>Appendix A</appendixTitle>
+                </appendix>
+            </regulation>'''
+        appendix_nodes = etree.fromstring(regml).findall('{eregs}appendix')
+        appendix_subpart = self.parser.get_appendices(
+            self.effective_version, appendix_nodes
+        )
+        self.assertEqual(appendix_subpart.sections.count(), 1)
+
+    def test_regdown_appendix_section(self):
+        regml = b'''<?xml version='1.0' encoding='UTF-8'?>
+            <appendix xmlns="eregs" appendixLetter="A" label="1005-A">
+                <appendixTitle>Appendix A</appendixTitle>
+                <appendixSection appendixSecNum="1" label="1005-A-h1">
+                    <subject>Section Subject</subject>
+                    <paragraph label="1005-A-h1-p1" marker="">
+                        <content>This is a paragraph.</content>
+                    </paragraph>
+                </appendixSection>
+            </appendix>'''
+        appendix_node = etree.fromstring(regml)
+        appendix_section = self.parser.get_section_for_appendix(
+            self.subpart, appendix_node
+        )
+        self.assertIn('## Section Subject', appendix_section.contents)
+
+    def test_regdown_interpretations(self):
+        regml = b'''<?xml version='1.0' encoding='UTF-8'?>
+            <interpretations xmlns="eregs" label="1005-Interp">
+                <title>Supplement I to Part 1005</title>
+                <interpSection label="1005-Interp-1">
+                    <title>Introduction</title>
+                </interpSection>
+            </interpretations>'''
+        interp_node = etree.fromstring(regml)
+        interp_subpart = self.parser.get_interpretations(
+            self.effective_version, interp_node
+        )
+        self.assertEqual(interp_subpart.title, 'Supplement I to Part 1005')
+        self.assertEqual(interp_subpart.label, 'Interp')
+        self.assertEqual(interp_subpart.sections.count(), 1)
+
+    def test_regdown_interp_section(self):
+        regml = b'''<?xml version='1.0' encoding='UTF-8'?>
+            <interpSection xmlns="eregs" label="1005-Interp-1">
+                <title>Introduction</title>
+                <interpParagraph label="1005-h1-Interp-1" marker="1.">
+                    <title>General.</title>
+                    <content>Commentary paragraph content.</content>
+                </interpParagraph>
+            </interpSection>'''
+        interp_section_node = etree.fromstring(regml)
+        interp_section = self.parser.get_section_for_interp_section_node(
+            self.subpart, interp_section_node
+        )
+        self.assertEqual(interp_section.title, 'Introduction')
+        self.assertEqual(interp_section.label, '1-Interp')
+        self.assertIn('**1. General.**', interp_section.contents)
+        self.assertIn('Commentary paragraph content', interp_section.contents)
+
+    def test_regdown_paragraph_with_keyterm(self):
+        regml = b'''<?xml version='1.0' encoding='UTF-8'?>
+            <paragraph xmlns="eregs" label="1005-1-a" marker="(a)">
+                <title type="keyterm">Authority.</title>
+                <content>
+                    The regulation in this part, known as Regulation E,
+                    is issued by the Bureau of Consumer Financial Protection
+                </content>
+            </paragraph>'''
+        paragraph_node = etree.fromstring(regml)
+        regdown = self.parser.get_regdown_for_paragraph(paragraph_node)
+        self.assertIn('{a}', regdown)
+        self.assertIn('**(a) Authority.**', regdown)
+
+    def test_regdown_paragraph_without_keyterm(self):
+        regml = b'''<?xml version='1.0' encoding='UTF-8'?>
+            <paragraph xmlns="eregs" label="1005-1-a" marker="(a)">
+                <content>
+                    The regulation in this part, known as Regulation E,
+                    is issued by the Bureau of Consumer Financial Protection
+                </content>
+            </paragraph>'''
+        paragraph_node = etree.fromstring(regml)
+        regdown = self.parser.get_regdown_for_paragraph(paragraph_node)
+        self.assertIn('{a}', regdown)
+        self.assertIn('**(a)**', regdown)
+
+    def test_regdown_paragraph_without_marker_or_keyterm(self):
+        regml = b'''<?xml version='1.0' encoding='UTF-8'?>
+            <paragraph xmlns="eregs" label="1005-1-a" marker="">
+                <content>
+                    Test paragraph
+                </content>
+            </paragraph>'''
+        paragraph_node = etree.fromstring(regml)
+        regdown = self.parser.get_regdown_for_paragraph(paragraph_node)
+        self.assertNotIn('****', regdown)
+
+    def test_regdown_paragraph_with_subparagraph(self):
+        regml = b'''<?xml version='1.0' encoding='UTF-8'?>
+            <paragraph xmlns="eregs" label="1005-1-a" marker="(a)">
+                <content>
+                    This is a paragraph.
+                </content>
+                <paragraph label="1005-1-a-1" marker="(1)">
+                    <content>
+                        This is a subparagraph.
+                    </content>
+                </paragraph>
+            </paragraph>'''
+        paragraph_node = etree.fromstring(regml)
+        regdown = self.parser.get_regdown_for_paragraph(paragraph_node)
+        self.assertIn('{a}', regdown)
+        self.assertIn('**(a)**', regdown)
+        self.assertIn('{a-1}', regdown)
+        self.assertIn('**(1)**', regdown)
+        self.assertIn('This is a paragraph', regdown)
+        self.assertIn('This is a subparagraph', regdown)
+
+    def test_regdown_paragraph_with_interp(self):
+        regml = b'''<?xml version='1.0' encoding='UTF-8'?>
+            <paragraph xmlns="eregs" label="1005-1-a" marker="(a)">
+                <content>
+                    The regulation in this part, known as Regulation E,
+                    is issued by the Bureau of Consumer Financial Protection
+                </content>
+            </paragraph>'''
+        paragraph_node = etree.fromstring(regml)
+
+        interp_regml = b'''<?xml version='1.0' encoding='UTF-8'?>
+            <interpretations xmlns="eregs">
+                <interpSection>
+                    <interpParagraph label="1005-1-a-Interp" target="1005-1-a">
+                    </interpParagraph>
+                </interpSection>
+            </interpretations>
+        '''
+        interp_node = etree.fromstring(interp_regml)
+
+        regdown = self.parser.get_regdown_for_paragraph(
+            paragraph_node, interp_node=interp_node
+        )
+        self.assertIn('see(1-a-Interp)', regdown)
+
+    def test_regdown_paragraph_with_dash_field(self):
+        regml = b'''<?xml version='1.0' encoding='UTF-8'?>
+            <paragraph xmlns="eregs" label="1005-1-a" marker="(a)">
+                <content>
+                    <dash>Name:</dash>
+                </content>
+            </paragraph>'''
+        paragraph_node = etree.fromstring(regml)
+        regdown = self.parser.get_regdown_for_paragraph(paragraph_node)
+        self.assertIn('Name:__', regdown)
+
+    def test_regdown_paragraph_with_dash_no_field(self):
+        regml = b'''<?xml version='1.0' encoding='UTF-8'?>
+            <paragraph xmlns="eregs" label="1005-1-a" marker="(a)">
+                <content>
+                    <dash/>
+                </content>
+            </paragraph>'''
+        paragraph_node = etree.fromstring(regml)
+        regdown = self.parser.get_regdown_for_paragraph(paragraph_node)
+        self.assertIn('__', regdown)
+
+    def test_regdown_paragraph_with_graphic(self):
+        regml = b'''<?xml version='1.0' encoding='UTF-8'?>
+            <paragraph xmlns="eregs" label="1005-1-a" marker="(a)">
+                <content>
+                    <graphic>
+                        <altText>image alt</altText>
+                        <url>https:///images/image_name.png</url>
+                    </graphic>
+                </content>
+            </paragraph>'''
+        paragraph_node = etree.fromstring(regml)
+        regdown = self.parser.get_regdown_for_paragraph(paragraph_node)
+        self.assertIn('![image alt](https:///images/image_name.png)', regdown)
+
+    def test_regdown_paragraph_with_table(self):
+        regml = b'''
+            <paragraph xmlns="eregs" label="1010-A-III-h8-p34" marker="">
+                <content>
+                    <table>
+                        <header>
+                            <columnHeaderRow>
+                                <column colspan="1" rowspan="2"/>
+                                <column colspan="2" rowspan="1">
+                                    Name
+                                </column>
+                            </columnHeaderRow>
+                        </header>
+                        <row>
+                            <cell>Water</cell>
+                        </row>
+                    </table>
+                </content>
+            </paragraph>'''
+        paragraph_node = etree.fromstring(regml)
+        regdown = self.parser.get_regdown_for_paragraph(paragraph_node)
+        self.assertIn('<th scope="col" rowspan="2" colspan="1"/>', regdown)
+        self.assertIn('<td align="left">Water</td>', regdown)
+        self.assertIn('<thead>', regdown)
+        self.assertIn('<tbody>', regdown)


### PR DESCRIPTION
This PR adds a Django script to import a single RegML file as a Regulations3k EffectiveVersion with all the appropriate child models.

This is an initial attempt, and the output should be considered a work-in-progress. It's likely some hand-editing of the resulting Regdown will be required. 

This is intended to give us a head-start on version history in the new interactive bureau regulations tool.

## Testing

1. Check out https://github.com/cfpb/regulations-xml
2. Run the script on any single RegML file:

   ```shell
   ./cfgov/manage.py runscript regml_importer --script-args ../regulations-xml/regulation/1026/2011-31715.xml
   ```

## Todos

- Validate that content comes through alright.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
