### PR TITLE
Properly disable migrations in Django 1.11

### DIFF
--- a/cfgov/cfgov/settings/test_nomigrations.py
+++ b/cfgov/cfgov/settings/test_nomigrations.py
@@ -1,13 +1,6 @@
-from collections import defaultdict
-
-import django
-
 from core.utils import NoMigrations
 
 from .test import *
 
 
-if django.VERSION[:2] < (1, 9):
-    MIGRATION_MODULES = NoMigrations()
-else:
-    MIGRATION_MODULES = defaultdict(None)
+MIGRATION_MODULES = NoMigrations()

--- a/cfgov/core/tests/test_utils.py
+++ b/cfgov/core/tests/test_utils.py
@@ -1,5 +1,6 @@
 import unittest
 
+import django
 from django.test import TestCase
 
 from core.utils import (
@@ -37,7 +38,12 @@ class TestNoMigrations(TestCase):
         self.assertTrue('random-string' in self.nomigrations)
 
     def test_getitem(self):
-        self.assertEqual(self.nomigrations['random-string'], 'nomigrations')
+        if django.VERSION[:2] < (1, 9):  # pragma: no cover
+            expected = 'nomigrations'
+        else:
+            expected = None
+
+        self.assertEqual(self.nomigrations['random-string'], expected)
 
 
 class FormatFileSizeTests(unittest.TestCase):

--- a/cfgov/core/utils.py
+++ b/cfgov/core/utils.py
@@ -2,6 +2,7 @@ import re
 from six import text_type as str
 from six.moves.urllib.parse import parse_qs, urlencode, urlparse
 
+import django
 from django.core.signing import Signer
 from django.core.urlresolvers import reverse
 
@@ -132,8 +133,21 @@ def add_link_markup(tag):
 
 
 class NoMigrations(object):
+    """Class to disable app migrations through settings.MIGRATION_MODULES.
+
+    The MIGRATION_MODULES setting can be used to tell Django where to look
+    for an app's migrations (by default this is the "migrations" subdirectory).
+    This class simulates a dictionary where a lookup for any app returns a
+    value that causes Django to think that no migrations exist.
+
+    In Django >= 1.9, this can be configured by returning None. In Django <1.9,
+    a nonexistent path string must be returned.
+    """
     def __contains__(self, item):
         return True
 
     def __getitem__(self, item):
-        return 'nomigrations'
+        if django.VERSION[:2] < (1, 9):  # pragma: no cover
+            return 'nomigrations'
+        else:
+            return None


### PR DESCRIPTION
PR #4444 (014df5a7) attempted to add the ability to run Python tests against Django 1.11, but did not properly disable migrations when running with `settings.test_nomigrations`.

This commit fixes testing without migrations (e.g. with `tox -e unittest-py27-dj111-wag113-fast`) in Django 1.11.

To test this change, you can run that command and notice how much faster the tests run, because the migrations aren't being run.

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [X] Passes all existing automated tests
- [X] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: