### PR TITLE
Bump cfpb-chart-builder to 3.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3021,9 +3021,9 @@
       }
     },
     "cfpb-chart-builder": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/cfpb-chart-builder/-/cfpb-chart-builder-3.4.0.tgz",
-      "integrity": "sha512-/344xWgQ8oCnXaZGl8rOR/4jhDwR2EZufgeiqusec5qwYrwo2sONIj3WPX1KTznj7/m3SjikXb9Lq8sQ6eCYmg==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/cfpb-chart-builder/-/cfpb-chart-builder-3.5.0.tgz",
+      "integrity": "sha512-7e+8k4rw4MQN/v+SF54UNudBjeip0GvvAQsPQHVZhhprn8fq5JUb2Cd3MfVW/kn9QLOEBlBkdS4Sbej/SJ8UJQ==",
       "requires": {
         "cf-core": "4.10.0",
         "cf-layout": "4.8.0",
@@ -13356,7 +13356,7 @@
       "dependencies": {
         "lodash": {
           "version": "3.10.1",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+          "resolved": "http://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
           "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
           "dev": true
         }

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "cf-pagination": "5.0.1",
     "cf-tables": "5.0.0",
     "cf-typography": "5.0.1",
-    "cfpb-chart-builder": "3.4.0",
+    "cfpb-chart-builder": "3.5.0",
     "del": "3.0.0",
     "elem-dataset": "1.1.1",
     "glob-all": "3.1.0",


### PR DESCRIPTION
Brings in latest chart builder, which changes default behavior of y-axis values.

## Changes

- Bump `cfpb-chart-builder` to `3.5.0`.

## Testing

1. Run `./frontend.sh`
2. Log into local wagtail.
3. Create a new Browse page.
4. Add a ChartBlock.
5. Add required fields (set `consumer-credit-trends/auto-loans/inq_data_AUT.csv` as data source).
6. Save and preview and see that the y-axis values are integers. (If y-axis values are still millions or billions, inspect the page and reload to not use the cache.)
