### PR TITLE
Disable eRegs if the REGULATIONS3K flag is turned on

### DIFF
--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -660,6 +660,7 @@ FLAGS = {
     # Ping google on page publication in production only
     'PING_GOOGLE_ON_PUBLISH': {'environment is': 'production'},
 
+    # Feature flag to enable our replacement for eRegs and disable eRegs
     'REGULATIONS3K': {},
 
     'LEGACY_HUD_API': {'environment is': 'production'},

--- a/cfgov/cfgov/urls.py
+++ b/cfgov/cfgov/urls.py
@@ -240,11 +240,6 @@ urlpatterns = [
     url(r'^oah-api/county/',
         include_if_app_enabled('countylimits', 'countylimits.urls')),
 
-    url(r'^eregs-api/',
-        include_if_app_enabled('regcore', 'regcore.urls')),
-    url(r'^eregulations/',
-        include_if_app_enabled('regulations', 'regulations.urls')),
-
     url(r'^find-a-housing-counselor/$',
         HousingCounselorView.as_view(),
         name='housing-counselor'),
@@ -410,6 +405,24 @@ urlpatterns = [
         template_name='regulations3k/regulations3k-service-worker.js',
         content_type='application/javascript'),
         name='regulations3k-service-worker.js'
+    ),
+
+    # Include eRegulations URLs only if the REGULATIONS3K flag state is False
+    flagged_url(
+        'REGULATIONS3K',
+        r'^eregs-api/',
+        include_if_app_enabled('regcore', 'regcore.urls'),
+        fallback=lambda request: ServeView.as_view()(request, request.path),
+        state=False
+    ),
+    flagged_url(
+        'REGULATIONS3K',
+        r'^eregulations/',
+        include_if_app_enabled('regulations', 'regulations.urls'),
+        fallback=lambda request, **kwargs: ServeView.as_view()(
+            request, request.path
+        ),
+        state=False
     ),
 
 ]


### PR DESCRIPTION
This PR will disable the eRegulations URLs if the `REGULATIONS3K` feature flag is on. 

This will allow us to create and test redirects from eRegulations to Regulations3k.

## Testing

Not difficult, per se, but cumbersome. These instructions *should* work in either Docker or local venvs (I think).

1. Install `regulations-core` and `regulations-site`:

   ```
   pip install https://github.com/cfpb/regulations-core/releases/download/1.2.6/regcore-1.2.6-py2-none-any.whl
   pip install https://github.com/cfpb/regulations-site/releases/download/2.2.5/regulations-2.2.5-py2-none-any.whl
   ```

2. Add `EREGS_API_BASE` to your .env file:

   ```shell
   export EREGS_API_BASE=http://localhost:8000/eregs-api/
   ```

3. Check out https://github.com/cfpb/regulations-stub/ to get some data to load

4. Load data:

   ```shell
   ./cfgov/manage.py regcore_import_reg -s ./develop-apps/regulations-stub/stub/ -r 1004
   ```

5. Disable the `REGULATIONS3K` flag if it is not already.

6. Visit http://localhost:8000/eregulations/ and see eRegs!

7. Enable the `REGULATIONS3K` flag.

8. Visit http://localhost:8000/eregulations/ and see a 404!

## Todos

- Craft redirects that redirect users to the Interactive Bureau Regulations pages from eRegs URLs.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
