### PR TITLE
Silence runtime warning in tests on dj111

### DIFF
--- a/cfgov/scripts/test_data.py
+++ b/cfgov/scripts/test_data.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 from django.contrib.auth.models import User
 from django.utils.timezone import datetime, timedelta
 

--- a/cfgov/v1/tests/models/test_author_names.py
+++ b/cfgov/v1/tests/models/test_author_names.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 from django.test import TestCase
 
 from mock import patch

--- a/cfgov/v1/tests/models/test_related_posts.py
+++ b/cfgov/v1/tests/models/test_related_posts.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 import datetime as dt
 
 from django.test import RequestFactory, TestCase

--- a/cfgov/v1/tests/models/test_snippets.py
+++ b/cfgov/v1/tests/models/test_snippets.py
@@ -10,10 +10,10 @@ from v1.models.snippets import Contact, Resource, ReusableText
 class TestFilterByTags(TestCase):
     def setUp(self):
         self.snippet1 = Resource.objects.create(title='Test snippet 1')
-        self.snippet1.tags.add('tagA')
+        self.snippet1.tags.add(u'tagA')
         self.snippet2 = Resource.objects.create(title='Test snippet 2')
-        self.snippet2.tags.add('tagA')
-        self.snippet2.tags.add('tagB')
+        self.snippet2.tags.add(u'tagA')
+        self.snippet2.tags.add(u'tagB')
 
     def test_empty_list_argument_returns_all(self):
         self.assertSequenceEqual(

--- a/cfgov/v1/tests/test_filterable_list_form.py
+++ b/cfgov/v1/tests/test_filterable_list_form.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 from django.test import TestCase
 
 from wagtail.wagtailcore.models import Site


### PR DESCRIPTION
Previously, running unit tests on Django 1.11 produced the following warning:

```
.tox/unittest-py27-dj111-wag113-fast/lib/python2.7/site-packages/unidecode/__init__.py:47:
RuntimeWarning: Argument <type 'str'> is not an unicode object. Passing
an encoded string will likely have unexpected results.
  _warn_if_not_unicode(string)
```

The warning occurred when adding authors and tags (fields provided by
django-taggit) on instances of CFGOVPage in tests, e.g.
`page.authors.add('unencoded string')`.

To prevent this, we use `from __future__ import unicode_literals` where
possible. It was not possible in one test file that contains tests for
unicode conversion. So, in that file, we explicitly use unicode strings
in the tests that are affected by the warning.

[Short description explaining the high-level reason for the pull request]

## Additions

- Use unicode strings in some test files

## Testing

`tox -e unittest-py27-dj111-wag113-fast` should now be warning-free!

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [x] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

Doesn't affect any cfgov functionality.