### PR TITLE
First stab at full build in docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,7 +3,6 @@ develop-apps
 collectstatic
 *.sql
 .github
-gulp
 node_modules
 docs
 .vendor

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,11 @@
 FROM centos:7
 RUN yum -y install https://download.postgresql.org/pub/repos/yum/10/redhat/rhel-7-x86_64/pgdg-centos10-10-2.noarch.rpm && \
-    yum -y install which gcc gcc-c++ kernel-devel mailcap make postgresql10 postgresql10-devel python-devel && \
+    yum -y install which gcc gcc-c++ git kernel-devel mailcap make postgresql10 postgresql10-devel python-devel && \
+    curl --silent --location https://rpm.nodesource.com/setup_10.x | bash - && \
+    yum -y install nodejs && \
     yum clean all
+WORKDIR /src
+ADD . /src
 ADD  https://bootstrap.pypa.io/get-pip.py /src/get-pip.py
-COPY requirements /src/requirements
-COPY extend-environment.sh /etc/profile.d/extend-environment.sh
-RUN python /src/get-pip.py && pip install -r /src/requirements/local.txt
+RUN python /src/get-pip.py && \
+  /src/setup.sh docker

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,4 +8,5 @@ WORKDIR /src
 ADD . /src
 ADD  https://bootstrap.pypa.io/get-pip.py /src/get-pip.py
 RUN python /src/get-pip.py && \
+  npm set unsafe-perm true && \
   /src/setup.sh docker

--- a/backend.sh
+++ b/backend.sh
@@ -25,5 +25,8 @@ install() {
   pip install -r ./requirements/local.txt
 }
 
-init "$1"
+if [ "$1" != "docker" ]; then
+  init "$1"
+fi
+
 install

--- a/cfgov/entrypoint.sh
+++ b/cfgov/entrypoint.sh
@@ -1,3 +1,2 @@
 source /src/cfgov-refresh/.env
-source /etc/profile.d/extend-environment.sh
 python /src/cfgov-refresh/cfgov/manage.py runserver 0.0.0.0:8000

--- a/extend-environment.sh
+++ b/extend-environment.sh
@@ -1,3 +1,0 @@
-for d in /src/cfgov-refresh/develop-apps/*/ ; do
-    export PYTHONPATH=$d:$PYTHONPATH
-done

--- a/frontend.sh
+++ b/frontend.sh
@@ -28,6 +28,13 @@ init() {
 
   # Set the NODE_ENV for this session.
   export NODE_ENV=$NODE_ENV
+
+  # Set SUM variable based on presence of shasum command
+  if command -v shasum >/dev/null 2>&1; then
+    SUM="shasum"
+  else
+    SUM="sha1sum"
+  fi
 }
 
 # Clean project dependencies.
@@ -65,7 +72,7 @@ install() {
 
 # Calculate checksum value.
 calc_checksum() {
-  DEP_CHECKSUM=$(cat package*.json cfgov/unprocessed/apps/**/package*.json | shasum -a 256)
+  DEP_CHECKSUM=$(cat package*.json cfgov/unprocessed/apps/**/package*.json | $SUM)
 }
 
 # Add a checksum file

--- a/setup.sh
+++ b/setup.sh
@@ -9,28 +9,15 @@
 # Set script to exit on any errors.
 set -e
 
-standalone() {
-    ./frontend.sh $1
-    ./backend.sh $1
+ENVVAR=.env
+if [ ! -f $ENVVAR ]; then
+  echo 'Creating default environment variables...'
+  cp "$ENVVAR"_SAMPLE $ENVVAR
+fi
+ls /src
+./frontend.sh $1
+./backend.sh $1
 
-    if [[ ! -z "$CFGOV_SPEAK_TO_ME" ]]; then
-        say "Set up has finished."
-    fi
-}
-
-dockerized() {
-    ./frontend.sh $2
-
-    ENVVAR=.python_env
-    if [ ! -f $ENVVAR ]; then
-        echo 'Creating default environment variables...'
-        cp "$ENVVAR"_SAMPLE $ENVVAR
-    fi
-}
-
-# Execute requested (or all) functions.
-if [ "$1" == "docker" ]; then
-    dockerized
-else
-    standalone $1
+if [[ ! -z "$CFGOV_SPEAK_TO_ME" ]]; then
+  say "Set up has finished."
 fi


### PR DESCRIPTION
Closes #4468 
Closes #4462 

This is my first stab at running the full build in the backend. From a fresh repo, with the `cfgov-refresh_python` image removed, you should be able to simply `docker-compose up` to end up with working dockerized cfgov. (no front-end stuff, the .env_SAMPLE is copied over by default). The only thing you'd need to do afterwards to check it out at `localhost:8000`, is run `./shell.sh` and `./refresh-data.sh` with a dump once inside. This process could be done automatically (say, based on the existence of a `data.tar.gz` file or something) but I've elided that for now.

Satellite apps are currently unsupported as there are some decisions to be made around what is optional/what should be baked into the image that I didn't want to cloud this PR. That is, should `optional-public` be installed at build time? The argument **for** is to move all the painful installation stuff into one place and to then have everything available by default, the argument **against** is to limit the pain of that first image build. I'm more in the **for** camp, but reasonable people may disagree (and please do with comments on this PR).

If installation of the wheels **is** done at image build time, then, on container startup, we'd walk develop-apps, `pip uninstall` as needed, and `pip install -e` each app there. This preserves the ability to locally edit satellites without any mucking around inside the container, while also not affecting anyone who isn't editing satellites.

I'll be out for two weeks starting tomorrow 😅 , but I'll likely peep in on this issue to address questions/comments in the evenings over the next fews days.