### PR TITLE
Fix the printing of Read More expandables

### DIFF
--- a/cfgov/unprocessed/css/organisms/read-more.less
+++ b/cfgov/unprocessed/css/organisms/read-more.less
@@ -44,51 +44,53 @@
 
 .o-expandable__read-more {
     .o-expandable_target__collapsed {
-        .o-expandable_link {
-            display: block;
-            padding-top: 15px;
-            padding-bottom: 15px;
-            border: dotted @link-text;
-            border-width: 1px 0;
-            text-align: center;
-        }
-    }
-
-    .o-expandable_target__expanded {
         display: none;
     }
 
     .o-expandable_content__collapsed {
-        // shows approx. 4 lines of content
-        max-height:  unit( @base-line-height-px * 4 / @base-font-size-px, em ) !important;
-        overflow: hidden;
-        position: relative;
+        max-height: 100% !important;
 
         &:after {
-            // fades content out over approx. 2 lines
-            display: block;
-            height: unit( @base-line-height-px * 2 / @base-font-size-px, em );
-            margin: 0;
-            position: absolute;
-            bottom: 0;
-            left: 0;
-            right: 0;
-            background: linear-gradient(to bottom, rgba(255,255,255,0) 0%,rgba(255,255,255,1) 100% );
-            content: '';
+            display: none;
         }
     }
 
-    .respond-to-min( @bp-med-min, {
+    @media only screen and (max-width:56.25em) {
         .o-expandable_target__collapsed {
+            display: block;
+
+            .o-expandable_link {
+                display: block;
+                padding-top: 15px;
+                padding-bottom: 15px;
+                border: dotted @link-text;
+                border-width: 1px 0;
+                text-align: center;
+            }
+        }
+
+        .o-expandable_target__expanded {
             display: none;
         }
 
         .o-expandable_content__collapsed {
-            max-height: 100% !important;
+            // shows approx. 4 lines of content
+            max-height:  unit( @base-line-height-px * 4 / @base-font-size-px, em ) !important;
+            overflow: hidden;
+            position: relative;
 
             &:after {
-              display: none;
+                // fades content out over approx. 2 lines
+                display: block;
+                height: unit( @base-line-height-px * 2 / @base-font-size-px, em );
+                margin: 0;
+                position: absolute;
+                bottom: 0;
+                left: 0;
+                right: 0;
+                background: linear-gradient(to bottom, rgba(255,255,255,0) 0%,rgba(255,255,255,1) 100% );
+                content: '';
             }
         }
-    } );
+    }
 }


### PR DESCRIPTION
"Read More" expandables (which collapse the bulk of the content of certain pages, such as Ask CFPB answers and job postings, on small screens) were showing as collapsed when printing the page. See https://GHE/CFGOV/platform/issues/2965

This PR addresses that.

## Changes

- Restricts media query in `read-more.less` to `screen` only (note the change to an explicit `@media` directive instead of our `respond-to-` mixin), to ensure that they are open when printed.

## Testing

1. Visit any Ask CFPB answer in Chrome
1. Activate the print function and see the "read more" expandable _collapsed_ in the preview
1. Pull branch
1. `gulp styles`
1. Hard refresh the answer page
1. Activate the print function and see no sign of the "read more" expandable in the preview

## Screenshots

![screen shot 2018-08-31 at 13 04 13](https://user-images.githubusercontent.com/1044670/44926064-3f742300-ad1e-11e8-8feb-19f7051adfc2.png)

## Notes

- This is a **Tier 1** bugfix. I have to leave for the weekend and cannot test more than in Chrome. If anyone else can test this afternoon and get it merged, I'd appreciate it. Would like to deploy first thing Monday morning.

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Internet Explorer 8, 9, 10, and 11
- [ ] Edge
- [ ] iOS Safari
- [ ] Chrome for Android
