### PR TITLE
Redirect eregulations to regs3k

### DIFF
--- a/cfgov/cfgov/urls.py
+++ b/cfgov/cfgov/urls.py
@@ -29,6 +29,7 @@ from legacy.views import token_provider
 from legacy.views.housing_counselor import (
     HousingCounselorPDFView, HousingCounselorView
 )
+from regulations3k.views import redirect_eregs
 from transition_utilities.conditional_urls import include_if_app_enabled
 from v1.auth_forms import CFGOVPasswordChangeForm
 from v1.views import (
@@ -454,16 +455,14 @@ urlpatterns = [
         'REGULATIONS3K',
         r'^eregs-api/',
         include_if_app_enabled('regcore', 'regcore.urls'),
-        fallback=lambda request: ServeView.as_view()(request, request.path),
+        fallback=page_not_found,
         state=False
     ),
     flagged_url(
         'REGULATIONS3K',
         r'^eregulations/',
         include_if_app_enabled('regulations', 'regulations.urls'),
-        fallback=lambda request, **kwargs: ServeView.as_view()(
-            request, request.path
-        ),
+        fallback=lambda request, **kwargs: redirect_eregs(request),
         state=False
     ),
 

--- a/cfgov/cfgov/urls.py
+++ b/cfgov/cfgov/urls.py
@@ -463,6 +463,7 @@ urlpatterns = [
         r'^eregulations/',
         include_if_app_enabled('regulations', 'regulations.urls'),
         fallback=lambda request, **kwargs: redirect_eregs(request),
+        name='eregs-redirect',
         state=False
     ),
 

--- a/cfgov/cfgov/urls.py
+++ b/cfgov/cfgov/urls.py
@@ -462,7 +462,7 @@ urlpatterns = [
         'REGULATIONS3K',
         r'^eregulations/',
         include_if_app_enabled('regulations', 'regulations.urls'),
-        fallback=lambda request, **kwargs: redirect_eregs(request),
+        fallback=redirect_eregs,
         name='eregs-redirect',
         state=False
     ),

--- a/cfgov/regulations3k/tests/test_views.py
+++ b/cfgov/regulations3k/tests/test_views.py
@@ -59,3 +59,11 @@ class RedirectRegulations3kTestCase(TestCase):
         self.assertEqual(
             response.get('location'),
             '/policy-compliance/rulemaking/regulations/1002/2016-07-11/1/')
+
+    def test_version_redirect_no_version(self):
+        request = self.factory.get(
+            '/eregulations/1002-1/2011-31714#1002-1')
+        response = redirect_eregs(request)
+        self.assertEqual(
+            response.get('location'),
+            '/policy-compliance/rulemaking/regulations/1002/1/')

--- a/cfgov/regulations3k/tests/test_views.py
+++ b/cfgov/regulations3k/tests/test_views.py
@@ -8,7 +8,7 @@ from django.test import RequestFactory, TestCase, override_settings
 from model_mommy import mommy
 
 from regulations3k.models import EffectiveVersion, Part
-from regulations3k.views import redirect_eregs
+from regulations3k.views import get_version_date, redirect_eregs
 
 
 @override_settings(FLAGS={'REGULATIONS3K': {'boolean': 'True'}})
@@ -67,3 +67,72 @@ class RedirectRegulations3kTestCase(TestCase):
         self.assertEqual(
             response.get('location'),
             '/policy-compliance/rulemaking/regulations/1002/1/')
+
+    def test_search_redirect(self):
+        request = self.factory.get(
+            '/eregulations/search/1002',
+            {'q': 'california', 'version': '2011-1'})
+        response = redirect_eregs(request)
+        self.assertEqual(
+            response.get('location'),
+            '/policy-compliance/rulemaking/regulations/'
+            'search-regulations/results/?regs=1002&q=california')
+
+    def test_interp_appendix(self):
+        request = self.factory.get(
+            '/eregulations/1002-Appendices-Interp/'
+            '2016-16301#1002-Interp-h1-1')
+        response = redirect_eregs(request)
+        self.assertEqual(
+            response.get('location'),
+            '/policy-compliance/rulemaking/regulations/1002/'
+            '2016-07-11/Interp-C/')
+
+    def test_interp_appendix_invalid_date(self):
+        request = self.factory.get(
+            '/eregulations/1024-Appendices-Interp/'
+            '2017-20417_20180101#1002-Interp-h1-1')
+        response = redirect_eregs(request)
+        self.assertEqual(
+            response.get('location'),
+            '/policy-compliance/rulemaking/regulations/1024/Interp-MS/')
+
+    def test_interp_intro(self):
+        request = self.factory.get(
+            '/eregulations/1002-Interp-h1/2016-16301#1030-Interp-h1')
+        response = redirect_eregs(request)
+        self.assertEqual(
+            response.get('location'),
+            '/policy-compliance/rulemaking/regulations/1002/'
+            '2016-07-11/h1-Interp/')
+
+    def test_interp_intro_bad_version(self):
+        request = self.factory.get(
+            '/eregulations/1030-Interp-h1/2011-31727#1030-Interp-h1')
+        response = redirect_eregs(request)
+        self.assertEqual(
+            response.get('location'),
+            '/policy-compliance/rulemaking/regulations/1030/Interp-0/')
+
+    def test_interp_section_past(self):
+        request = self.factory.get(
+            '/eregulations/1002-Subpart-Interp/2016-16301')
+        response = redirect_eregs(request)
+        self.assertEqual(
+            response.get('location'),
+            '/policy-compliance/rulemaking/regulations/1002/'
+            '2016-07-11/Interp-1/')
+
+    def test_interp_section_current(self):
+        request = self.factory.get(
+            '/eregulations/1002-Subpart-Interp/'
+            '2017-20417_20180101#1002-Subpart-Interp')
+        response = redirect_eregs(request)
+        self.assertEqual(
+            response.get('location'),
+            '/policy-compliance/rulemaking/regulations/1002/Interp-1/')
+
+    def test_get_version_date_bad_doc_number(self):
+        part = '1002'
+        doc = '2015-16301'
+        self.assertIs(get_version_date(part, doc), None)

--- a/cfgov/regulations3k/tests/test_views.py
+++ b/cfgov/regulations3k/tests/test_views.py
@@ -1,3 +1,61 @@
-# from django.test import TestCase
+from __future__ import unicode_literals
 
-# Create your tests here.
+import datetime
+
+from django.http import Http404
+from django.test import RequestFactory, TestCase, override_settings
+
+from model_mommy import mommy
+
+from regulations3k.models import EffectiveVersion, Part
+from regulations3k.views import redirect_eregs
+
+
+@override_settings(FLAGS={'REGULATIONS3K': {'boolean': 'True'}})
+class RedirectRegulations3kTestCase(TestCase):
+
+    def setUp(self):
+        self.factory = RequestFactory()
+
+        self.test_reg = mommy.make(
+            Part,
+            part_number='1002')
+
+        self.test_version = mommy.make(
+            EffectiveVersion,
+            part=self.test_reg,
+            effective_date=datetime.date(2016, 7, 11),
+            draft=False)
+
+    def test_redirect_base_url(self):
+        request = self.factory.get('/eregulations/')
+        response = redirect_eregs(request)
+        self.assertEqual(response.get('location'),
+                         '/policy-compliance/rulemaking/regulations/')
+
+    def test_redirect_reg_base_url(self):
+        request = self.factory.get('/eregulations/1002')
+        response = redirect_eregs(request)
+        self.assertEqual(response.get('location'),
+                         '/policy-compliance/rulemaking/regulations/1002/')
+
+    def test_redirect_reg_section_url(self):
+        request = self.factory.get(
+            '/eregulations/1002-1/2017-20417_20180101#1002-1')
+        response = redirect_eregs(request)
+        self.assertEqual(response.get('location'),
+                         '/policy-compliance/rulemaking/regulations/1002/1/')
+
+    def test_redirect_invalid_part(self):
+        request = self.factory.get(
+            '/eregulations/1020-1/2017-20417_20180101#1002-1')
+        with self.assertRaises(Http404):
+            redirect_eregs(request)
+
+    def test_version_redirect(self):
+        request = self.factory.get(
+            '/eregulations/1002-1/2016-16301#1002-1')
+        response = redirect_eregs(request)
+        self.assertEqual(
+            response.get('location'),
+            '/policy-compliance/rulemaking/regulations/1002/2016-07-11/1/')

--- a/cfgov/regulations3k/views.py
+++ b/cfgov/regulations3k/views.py
@@ -135,7 +135,7 @@ def get_version_date(part_number, doc_number):
         return version_date
 
 
-def redirect_eregs(request):
+def redirect_eregs(request, **kwargs):
     """
     Redirect legacy eregulations pages to the relevant regulations3k page.
 

--- a/cfgov/regulations3k/views.py
+++ b/cfgov/regulations3k/views.py
@@ -1,3 +1,151 @@
-# from django.shortcuts import render
+from __future__ import unicode_literals
 
-# Create your views here.
+import re
+
+from django.http import Http404  # , HttpResponse, JsonResponse
+from django.shortcuts import redirect  # , get_object_or_404, render
+
+from dateutil import parser
+
+from regulations3k.models import EffectiveVersion
+
+
+# TODO
+# search queries
+# appendices
+# interpretations
+
+# Mapping of document number to effective date
+VERSION_MAP = {
+    '1002': {
+        '2017-20417_20220101': '2022-01-01',
+        # '2017-20417_20180101': '2018-01-01',  # current law
+        '2016-16301': '2016-07-11',
+        '2013-22752_20140118': '2014-01-18',
+        '2013-22752_20140110': '2014-01-10',
+        '2013-22752_20140101': '2014-01-01',
+        '2011-31714': '2011-12-30',
+    },
+    '1003': {
+        '2015-26607_20200101': '2020-01-01',
+        '2015-26607_20190101': '2019-01-01',
+        # '2017-18284_20180101': '2018-01-01',  # current law
+        '2015-26607_20170101': '2017-01-01',
+        '2016-30731': '2016-01-01',
+        '2014-30404': '2015-01-01',
+        '2013-31223': '2014-01-01',
+        '2012-31311': '2012-12-31',
+        '2012-3460': '2012-02-15',
+        '2011-31712': '2011-12-30',
+    },
+    '1004': {
+        # '2011-18676': '2011-07-22',  # current law
+    },
+    '1005': {
+        '2018-01305': '2019-01-01',
+        # '2016-24506': '2016-11-14',  # current law
+        '2014-20681': '2014-11-17',
+        '2013-19503': '2013-10-28',
+        '2013-06861': '2013-03-26',
+        '2011-31725': '2011-12-30',
+    },
+    '1010': {
+        # '2016-10715': '2016-06-10',  # current law
+        '2011-31713': '2011-12-30',
+    },
+    '1011': {
+        # '2011-31713': '2011-12-30',  # current law
+    },
+    '1012': {
+        # '2012-10602': '2012-05-03',  # current law
+        '2011-31713': '2011-12-30',
+    },
+    '1013': {
+        # '2017-24411': '2018-01-01',  # current law
+        '2016-28710': '2017-01-01',
+        '2015-30071': '2016-01-01',
+        '2014-21847': '2015-01-01',
+        '2013-28194': '2014-01-01',
+        '2012-27996': '2013-01-01',
+        '2011-31723': '2011-12-30',
+    },
+    '1024': {
+        # '2017-21912': '2017-10-19',  # current law
+        '2015-18239': '2015-10-03',
+        '2013-15466': '2014-02-14',
+        '2013-24521': '2014-01-10',
+        '2013-09750': '2013-06-03',
+        '2011-31722': '2011-12-30',
+    },
+    '1026': {
+        '2018-01305': '2019-04-01',
+        # '2018-09243': '2018-06-01',  # current law
+        '2018-04823': '2018-04-19',
+        '2017-24445': '2018-01-01',
+        '2017-15764': '2017-10-10',
+        '2016-24503': '2017-10-01',
+        '2016-30730': '2017-01-01',
+        '2016-14782_20160627': '2016-06-27',
+        '2016-06834': '2016-03-31',
+        '2015-32293': '2016-01-01',
+        '2015-32463': '2015-12-24',
+        '2015-18239': '2015-10-03',
+        '2015-12719': '2015-08-10',
+        '2013-30108_20150718': '2015-07-18',
+        '2015-09000': '2015-04-17',
+        '2014-30419': '2015-01-01',
+        '2013-30108_20140118': '2014-01-18',
+        '2013-24521': '2014-01-10',
+        '2013-31225': '2014-01-01',
+        '2013-16962_20130724': '2013-07-24',
+        '2013-12125': '2013-06-01',
+        '2013-10429': '2013-05-03',
+        '2013-07066': '2013-03-28',
+        '2012-27997': '2013-01-01',
+        '2012-28341': '2012-11-23',
+        '2011-31715': '2011-12-30',
+    },
+    '1030': {
+        # '2011-31727': '2011-12-30',  # current law
+    },
+}
+
+
+def redirect_eregs(request):
+    """
+    Redirect legacy eregulations pages to the relevant regulations3k page.
+
+    Requests for past or future versions of a regulation will be sent to the
+    current-law version in regulations3k, from which past versions will be
+    available in the future.
+    """
+    original_base = '/eregulations/'
+    new_base = '/policy-compliance/rulemaking/regulations/'
+    reg_re = re.compile(r'/eregulations/(\d{4})$')
+    part_re = re.compile(r'/eregulations/(\d{4})-(\d{1,3})/([0-9_-]+)')
+    original_url = request.path
+    if original_url == original_base:
+        return redirect(new_base, permanent=True)
+    reg_base = reg_re.match(original_url)
+    if reg_base:
+        return redirect(new_base + reg_base.group(1) + '/', permanent=True)
+    part_base = part_re.match(original_url)
+    if part_base:
+        (part, section, doc) = (
+            part_base.group(1), part_base.group(2), part_base.group(3))
+        if part not in VERSION_MAP:
+            raise Http404
+        eff_date_string = VERSION_MAP[part].get(doc)
+        if not eff_date_string:
+            return redirect("{}{}/{}/".format(
+                new_base, part, section), permanent=True)
+        eff_date = parser.parse(eff_date_string).date()
+        version = EffectiveVersion.objects.filter(
+            part__part_number=part,
+            effective_date=eff_date,
+            draft=False).first()
+        if version:
+            return redirect("{}{}/{}/{}/".format(
+                new_base, part, eff_date_string, section),
+                permanent=True)
+        return redirect("{}{}/{}/".format(new_base, part, section))


### PR DESCRIPTION
We need to rescue as many eregulations requests as possible and
send them to the appropriate regulations3k page. The URL formats
have some crucial differences.
* The base URL changes
* Section references change
* Versions are now referenced by effective date, not by notice document ID

old | new
:-- | :---
/eregulations/ | /policy-compliance/rulemaking/regulations/
/eregulations/1002 | /policy-compliance/rulemaking/regulations/1002/
/eregulations/1002-1 | /policy-compliance/rulemaking/regulations/1002/1/
/eregulations/1002-1/2017-20417_20180101 | /policy-compliance/rulemaking/regulations/1002/2016-07-11/1/
