### PR TITLE
Fix height of Hero images on small screens

### DIFF
--- a/cfgov/jinja2/v1/_includes/molecules/hero.html
+++ b/cfgov/jinja2/v1/_includes/molecules/hero.html
@@ -40,25 +40,12 @@
 {# TODO: This is simple now, but in the future we'll hopefully be able to
    provide 1x and 2x values as well. We should update this to be an image
    array delivered by Django in the future. #}
-{% set img=image(value.image, 'original') %}
+{% set img = image(value.image, 'original') %}
 
 {% if value.small_image %}
-    {% set sm_img=image(value.small_image, 'original') %}
+    {% set sm_img = image(value.small_image, 'original') %}
 {% else %}
     {% set sm_img = image(value.image, 'original') %}
-{% endif %}
-
-{# TODO: Magic numbers are set by dividing the height by the width of the
-   existing images. These could change, we should update this to reading the
-   image dimensions with Django and passing the calculation to the template. #}
-{% set bp_sm_padding = "41.4893617%" %}
-
-{% if value.is_bleeding %}
-    {% set bp_xs_padding = "25.1020408%" %}
-{% elif value.is_overlay %}
-    {% set bg_xs_padding = "56.25%" %}
-{% else %}
-    {% set bp_xs_padding = "41.4893617%" %}
 {% endif %}
 
 <section class="m-hero
@@ -72,10 +59,14 @@
                 {{ value.body | safe }}
             </div>
         </div>
+    {% if img %}
         <div class="m-hero_image-wrapper">
             <div class="m-hero_image"></div>
         </div>
+    {% endif %}
     </div>
+
+{% if img %}
     {# Due to the nature of setting backgrounds and padding dynamically,
        these styles are set in an element to both contain them and make
        it clear where to change them in the future. #}
@@ -91,7 +82,7 @@
             filter: progid:DXImageTransform.Microsoft.AlphaImageLoader(
                 src='{{ sm_img.url }}',
                 sizingMethod='scale');
-            padding-bottom: {{ bp_xs_padding }};
+            padding-bottom: {{ sm_img.height / sm_img.width * 100 }}%;
         }
 
         @media screen and (min-width: 37.5625em) {
@@ -100,7 +91,7 @@
                 filter: progid:DXImageTransform.Microsoft.AlphaImageLoader(
                     src='{{ img.url }}',
                     sizingMethod='scale');
-                padding-bottom: {{ bp_sm_padding }}
+                padding-bottom: {{ img.height / img.width * 100 }}%;
             }
 
             .m-hero__overlay .m-hero_wrapper {
@@ -112,4 +103,5 @@
             }
         }
     </style>
+{% endif %}
 </section>


### PR DESCRIPTION
Correcting my laziness when setting up the OG bleeding illustration on Prepaid Cards and subsequently not following up on the TODO I left in the template.

Such a simple fix. Shame I didn't realize at the time how easy it was.

## Changes

- Small hero image height is now determined by calculation based on the actual image dimensions

## Testing

This is a PITA to test on localhost. Take my word for it and we'll confirm it on Beta before deploying to Prod 😁 

(You can see the `img.height` and `img.width` code pattern working in [Info Unit images](https://github.com/cfpb/cfgov-refresh/blob/fix-hero-sm-img-height/cfgov/jinja2/v1/_includes/molecules/info-unit-2.html#L75).)

## Screenshots

### Before

![screen shot 2018-09-06 at 17 06 15](https://user-images.githubusercontent.com/1044670/45185200-64bdd100-b1f7-11e8-8e3a-8b7f3238b017.png)

### After

![screen shot 2018-09-06 at 17 07 25](https://user-images.githubusercontent.com/1044670/45185205-69828500-b1f7-11e8-8293-e18e61da6319.png)

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [x] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: