### PR TITLE
Use absolute page URL in Wagtail admin live links

### DIFF
--- a/cfgov/templates/wagtailadmin/shared/page_status_tag.html
+++ b/cfgov/templates/wagtailadmin/shared/page_status_tag.html
@@ -1,0 +1,5 @@
+{% if page.live %}
+    <a href="{{ page.full_url }}" target="_blank" class="status-tag primary">{{ page.status_string }}</a>
+{% else %}
+    <span class="status-tag">{{ page.status_string }}</span>
+{% endif %}


### PR DESCRIPTION
The Wagtail admin "Live" links use the `page.url` property which is normally a relative URL when Wagtail has only a single Site (as we have). When accessing the admin from a different domain (e.g.
content.consumerfinance.gov), these "live" links don't actually point to the correct URL.

This change overrides the Wagtail admin page status tag template to use the page's absolute URL instead of its relative URL. This corrects the "Live" links so that they point to the right place.

This is the Wagtail template we are overriding:

https://github.com/wagtail/wagtail/blob/v1.13.4/wagtail/wagtailadmin/templates/wagtailadmin/shared/page_status_tag.html

## Testing

Run a local server, access it via something like http://content.localhost:8000 (this works in Chrome, might not in other browsers), and note that page live links use an absolute URL that goes to http://localhost:8000.

## Screenshots

![image](https://user-images.githubusercontent.com/654645/45223640-c3ca2700-b285-11e8-8b9f-281744654fa2.png)

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [X] Passes all existing automated tests
- [X] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [X] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: