### PR TITLE
Bump wagtail-inventory version from 0.5 to 0.5.1

### DIFF
--- a/requirements/libraries.txt
+++ b/requirements/libraries.txt
@@ -51,7 +51,7 @@ unipath>=1.1,<=2.0
 # TODO: Remove explicit urllib3 requirement once requests is updated to support urllib3 1.23
 urllib3==1.22
 wagtail-flags==3.0.0
-wagtail-inventory==0.5
+wagtail-inventory==0.5.1
 wagtail-sharing==0.6.1
 wagtail-treemodeladmin==1.0.3
 Wand==0.4.2


### PR DESCRIPTION
The new [0.5.1 release](https://github.com/cfpb/wagtail-inventory/releases/tag/0.5.1) of wagtail-inventory fixes a bug with broken pagination links (next/previous) in search results.


## Testing

In the Wagtail admin, navigate to Settings, Block Inventory. Do a search for a common block type, like `wagtail.wagtailcore.blocks.field_block.CharBlock`. You should get multiple result pages. Verify that the next/previous links work properly.

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [X] Passes all existing automated tests
- [X] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [X] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: