### PR TITLE
Add templatetags to Python test coverage

### DIFF
--- a/cfgov/.coveragerc
+++ b/cfgov/.coveragerc
@@ -3,7 +3,6 @@ omit =
     *wsgi.py
     */admin/*
     */migrations/*
-    *templatetags/*
     */site-packages*
     */python2.7/*
     *setup.py


### PR DESCRIPTION
Currently all templatetags directories are excluded from Python test coverage. They should not be -- this is Python code that we (sometimes) include in our templates, and it should be tested like other code.

There numerous tests either directly against these tags or that invoke these tags in their processing, so we should include them in coverage.

This will likely cause our coverage numbers to drop slightly.

(I'm opening this because I'm making changes to template tags in another branch and was wondering why they weren't included in coverage. I isolated this as its own PR to keep things separate when possible.)

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [X] Passes all existing automated tests
- [X] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: