### PR TITLE
Fix FLC height adjustment when interacting with multiselect filters

### DIFF
--- a/cfgov/unprocessed/apps/owning-a-home/webpack-config.js
+++ b/cfgov/unprocessed/apps/owning-a-home/webpack-config.js
@@ -84,6 +84,9 @@ const conf = {
     },
     mainFields: [ 'loader', 'main' ]
   },
+  resolve: {
+    symlinks: false
+  },
   plugins: [
     COMMON_CHUNK_CONFIG,
     COMMON_UGLIFY_CONFIG

--- a/cfgov/unprocessed/apps/regulations3k/webpack-config.js
+++ b/cfgov/unprocessed/apps/regulations3k/webpack-config.js
@@ -117,6 +117,9 @@ const conf = {
   plugins: [
     COMMON_UGLIFY_CONFIG
   ],
+  resolve: {
+    symlinks: false
+  },
   stats: STATS_CONFIG.stats
 };
 

--- a/cfgov/unprocessed/js/molecules/Multiselect.js
+++ b/cfgov/unprocessed/js/molecules/Multiselect.js
@@ -330,6 +330,8 @@ function Multiselect( element ) { // eslint-disable-line max-statements, inline-
           _optionsDom.classList.add( 'max-selections' );
         }
       }
+
+      _instance.dispatchEvent( 'selectionsUpdated', { target: _instance } );
     }
 
     _index = -1;

--- a/cfgov/unprocessed/js/organisms/FilterableListControls.js
+++ b/cfgov/unprocessed/js/organisms/FilterableListControls.js
@@ -68,14 +68,14 @@ function FilterableListControls( element ) {
         multiSelect.addEventListener( 'expandBegin', function refresh() {
           window.setTimeout(
             _expandable.transition.expand.bind( _expandable.transition ),
-            300
+            250
           );
         } );
 
         multiSelect.addEventListener( 'expandEnd', function refresh() {
           window.setTimeout(
             _expandable.transition.expand.bind( _expandable.transition ),
-            300
+            250
           );
         } );
       } );

--- a/cfgov/unprocessed/js/organisms/FilterableListControls.js
+++ b/cfgov/unprocessed/js/organisms/FilterableListControls.js
@@ -78,13 +78,6 @@ function FilterableListControls( element ) {
             300
           );
         } );
-
-        multiSelect.addEventListener( 'selectionsUpdated', function refresh() {
-          window.setTimeout(
-            _expandable.transition.expand.bind( _expandable.transition ),
-            300
-          );
-        } );
       } );
     }
 

--- a/cfgov/unprocessed/js/organisms/FilterableListControls.js
+++ b/cfgov/unprocessed/js/organisms/FilterableListControls.js
@@ -66,11 +66,24 @@ function FilterableListControls( element ) {
     if ( _dom.classList.contains( 'o-filterable-list-controls' ) ) {
       multiSelects.forEach( function( multiSelect ) {
         multiSelect.addEventListener( 'expandBegin', function refresh() {
-          window.setTimeout( _expandable.transition.expand, 250 );
+          window.setTimeout(
+            _expandable.transition.expand.bind( _expandable.transition ),
+            300
+          );
         } );
 
         multiSelect.addEventListener( 'expandEnd', function refresh() {
-          window.setTimeout( _expandable.transition.expand, 250 );
+          window.setTimeout(
+            _expandable.transition.expand.bind( _expandable.transition ),
+            300
+          );
+        } );
+
+        multiSelect.addEventListener( 'selectionsUpdated', function refresh() {
+          window.setTimeout(
+            _expandable.transition.expand.bind( _expandable.transition ),
+            300
+          );
         } );
       } );
     }

--- a/config/webpack-config.js
+++ b/config/webpack-config.js
@@ -77,6 +77,9 @@ const commonConf = {
   plugins: [
     COMMON_UGLIFY_CONFIG
   ],
+  resolve: {
+    symlinks: false
+  },
   stats: STATS_CONFIG.stats
 };
 
@@ -90,6 +93,9 @@ const externalConf = {
   plugins: [
     COMMON_UGLIFY_CONFIG
   ],
+  resolve: {
+    symlinks: false
+  },
   stats: STATS_CONFIG.stats
 };
 
@@ -104,11 +110,17 @@ const modernConf = {
     COMMON_CHUNK_CONFIG,
     COMMON_UGLIFY_CONFIG
   ],
+  resolve: {
+    symlinks: false
+  },
   stats: STATS_CONFIG.stats
 };
 
 const onDemandHeaderRawConf = {
-  module: COMMON_MODULE_CONFIG
+  module: COMMON_MODULE_CONFIG,
+  resolve: {
+    symlinks: false
+  }
 };
 
 const appsConf = {
@@ -123,6 +135,9 @@ const appsConf = {
     COMMON_CHUNK_CONFIG,
     COMMON_UGLIFY_CONFIG
   ],
+  resolve: {
+    symlinks: false
+  },
   stats: STATS_CONFIG.stats
 };
 
@@ -136,6 +151,9 @@ const spanishConf = {
   plugins: [
     COMMON_UGLIFY_CONFIG
   ],
+  resolve: {
+    symlinks: false
+  },
   stats: STATS_CONFIG.stats
 };
 
@@ -143,7 +161,10 @@ const devConf = {
   devtool: 'inline-source-map',
   mode: 'development',
   module: COMMON_MODULE_CONFIG,
-  plugins: []
+  plugins: [],
+  resolve: {
+    symlinks: false
+  }
 };
 
 const configExports = {


### PR DESCRIPTION
As reported in https://GHE/CFGOV/platform/issues/2981, the height of a Filterable List Controls expandable is not being correctly adjusted when interacting with the multiselect filters inside. This PR takes care of that.

## Additions

- Added a new event dispatch when selections on a multiselect are updated, which I didn't end up using, but it might still be useful in the future.
- Added `resolve: { symlinks: false }` in `webpack-config.js` files, which I needed to test with an `npm link`ed cf-expandables. This PR no longer needs any changes in cf-expandables, but this will be useful to anyone in the future who wants to test local updates to CF components within cfgov-refresh.

## Changes

- Bind the instance of the FLC expandable's `transition` to the `expand` calls within `window.setTimeout`, because if not, `this` within the `expand` method ends up being `window`

## Testing

1. Pull branch
1. `gulp scripts`
1. Visit a page with FLC like http://localhost:8000/about-us/blog/
1. Open the FLC, click into the Topics multiselect, see that the FLC expands
1. Select one of the topics, see that the FLC expands when the pill is added above the multiselect
1. Select another topic
1. Click outside the multiselect to have it collapse, see that the FLC contracts
1. Click to remove each topic and see that the FLC contracts when they are removed

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [x] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [x] Chrome
- [x] Firefox
- [x] Safari
- [ ] Internet Explorer 8, 9, 10, and 11
- [ ] Edge
- [ ] iOS Safari
- [ ] Chrome for Android
