### PR TITLE
[TDP] Adding feature flags for TDP static and search pages

### DIFF
--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -658,6 +658,9 @@ FLAGS = {
     # Teacher's Digital Platform Search Interface Tool
     'TDP_SEARCH_INTERFACE': {'environment is': 'beta'},
 
+    # Teacher's Digital Platform Static Pages
+    'TDP_STATIC_PAGE': {'environment is': 'beta'},
+
     # Teacher's Digital Platform Building Blocks Tool
     'TDP_BB_TOOL': {'environment is': 'beta'},
 

--- a/cfgov/cfgov/urls.py
+++ b/cfgov/cfgov/urls.py
@@ -371,24 +371,67 @@ urlpatterns = [
                 r'^search/',
                 include('search.urls')),
 
-    flagged_url('TDP_CRTOOL',
-                r'^practitioner-resources/youth-financial-education/curriculum-review/tool/',  # noqa: E501
-                include_if_app_enabled('teachers_digital_platform',
-                                       'teachers_digital_platform.tool_urls')),
+    flagged_url(
+        'TDP_SEARCH_INTERFACE',
+        r'^practitioner-resources/youth-financial-education/teach/activities/',
+        lambda request: ServeView.as_view()(request, request.path),
+        fallback=page_not_found,
+        name='tdp_search'
+    ),
+
+    flagged_url(
+        'TDP_STATIC_PAGE',
+        r'^practitioner-resources/youth-financial-education/teach/',
+        lambda request: ServeView.as_view()(request, request.path),
+        fallback=page_not_found,
+    ),
+
+    flagged_url(
+        'TDP_STATIC_PAGE',
+        r'^practitioner-resources/youth-financial-education/learn/',
+        lambda request: ServeView.as_view()(request, request.path),
+        fallback=page_not_found,
+    ),
+
+    flagged_url(
+        'TDP_STATIC_PAGE',
+        r'^practitioner-resources/youth-financial-education/glossary-financial-terms/',
+        lambda request: ServeView.as_view()(request, request.path),
+        fallback=page_not_found,
+    ),
+
+    flagged_url(
+        'TDP_STATIC_PAGE',
+        r'^practitioner-resources/youth-financial-education/resources-research/',
+        lambda request: ServeView.as_view()(request, request.path),
+        fallback=page_not_found,
+    ),
 
     flagged_url('TDP_CRTOOL',
-            r'^practitioner-resources/youth-financial-education/curriculum-review/before-you-begin/',  # noqa: E501
-            include_if_app_enabled('teachers_digital_platform',
-                                    'teachers_digital_platform.begin_urls')),
+        r'^practitioner-resources/youth-financial-education/curriculum-review/tool/',  # noqa: E501
+        include_if_app_enabled('teachers_digital_platform',
+                               'teachers_digital_platform.tool_urls')),
+
+    flagged_url('TDP_CRTOOL',
+        r'^practitioner-resources/youth-financial-education/curriculum-review/before-you-begin/',  # noqa: E501
+        include_if_app_enabled('teachers_digital_platform',
+                                'teachers_digital_platform.begin_urls')),
 
     flagged_url('TDP_CRTOOL_PROTOTYPES',
-            r'^practitioner-resources/youth-financial-education/curriculum-review/prototypes/',  # noqa: E501
-            include_if_app_enabled('teachers_digital_platform',
-                                    'teachers_digital_platform.prototypes_urls')),  # noqa: E501
+        r'^practitioner-resources/youth-financial-education/curriculum-review/prototypes/',  # noqa: E501
+        include_if_app_enabled('teachers_digital_platform',
+                                'teachers_digital_platform.prototypes_urls')),  # noqa: E501
+
+    flagged_url(
+        'TDP_CRTOOL',
+        r'^practitioner-resources/youth-financial-education/curriculum-review/',
+        lambda request: ServeView.as_view()(request, request.path),
+        fallback=page_not_found,
+    ),
 
     flagged_url('TDP_BB_TOOL',
-            r'^practitioner-resources/youth-financial-education/learn-about-the-building-blocks/take-a-tour',  # noqa: E501
-            include_if_app_enabled('teachers_digital_platform',
+        r'^practitioner-resources/youth-financial-education/tour',  # noqa: E501
+        include_if_app_enabled('teachers_digital_platform',
                                     'teachers_digital_platform.bb_urls')),
 
     flagged_url(

--- a/cfgov/cfgov/urls.py
+++ b/cfgov/cfgov/urls.py
@@ -51,6 +51,16 @@ def flagged_wagtail_template_view(flag_name, template_name):
         condition=False
     )
 
+def tdp_static_flagged(regex_path):
+    """ Teachers Digital Platform static pages are very similar so 
+    in the name of DRY we are implementing them with this method.
+    """
+    return flagged_url(
+        'TDP_STATIC_PAGE',
+        regex_path,
+        lambda request: ServeView.as_view()(request, request.path),
+        fallback=page_not_found,
+    )
 
 urlpatterns = [
     url(r'^documents/(?P<document_id>\d+)/(?P<document_filename>.*)$',
@@ -376,36 +386,22 @@ urlpatterns = [
         r'^practitioner-resources/youth-financial-education/teach/activities/',
         lambda request: ServeView.as_view()(request, request.path),
         fallback=page_not_found,
-        name='tdp_search'
-    ),
+        name='tdp_search'),
 
-    flagged_url(
-        'TDP_STATIC_PAGE',
-        r'^practitioner-resources/youth-financial-education/teach/',
-        lambda request: ServeView.as_view()(request, request.path),
-        fallback=page_not_found,
-    ),
+    tdp_static_flagged(
+        r'^practitioner-resources/youth-financial-education/teach/'),
 
-    flagged_url(
-        'TDP_STATIC_PAGE',
-        r'^practitioner-resources/youth-financial-education/learn/',
-        lambda request: ServeView.as_view()(request, request.path),
-        fallback=page_not_found,
-    ),
+    tdp_static_flagged(
+        r'^practitioner-resources/youth-financial-education/learn/'),
 
-    flagged_url(
-        'TDP_STATIC_PAGE',
-        r'^practitioner-resources/youth-financial-education/glossary-financial-terms/',  # noqa: E501
-        lambda request: ServeView.as_view()(request, request.path),
-        fallback=page_not_found,
-    ),
+    tdp_static_flagged(
+        r'practitioner-resources/youth-financial-education2/'),
 
-    flagged_url(
-        'TDP_STATIC_PAGE',
-        r'^practitioner-resources/youth-financial-education/resources-research/',  # noqa: E501
-        lambda request: ServeView.as_view()(request, request.path),
-        fallback=page_not_found,
-    ),
+    tdp_static_flagged(
+        r'^practitioner-resources/youth-financial-education/glossary-financial-terms/'),  # noqa: E501
+
+    tdp_static_flagged(
+        r'^practitioner-resources/youth-financial-education/resources-research/'),  # noqa: E501
 
     flagged_url('TDP_CRTOOL',
         r'^practitioner-resources/youth-financial-education/curriculum-review/tool/',  # noqa: E501
@@ -426,8 +422,7 @@ urlpatterns = [
         'TDP_CRTOOL',
         r'^practitioner-resources/youth-financial-education/curriculum-review/',  # noqa: E501
         lambda request: ServeView.as_view()(request, request.path),
-        fallback=page_not_found,
-    ),
+        fallback=page_not_found),
 
     flagged_url('TDP_BB_TOOL',
         r'^practitioner-resources/youth-financial-education/tour',  # noqa: E501

--- a/cfgov/cfgov/urls.py
+++ b/cfgov/cfgov/urls.py
@@ -52,7 +52,7 @@ def flagged_wagtail_template_view(flag_name, template_name):
     )
 
 
-def flagged_static(flag_name, regex_path):
+def flagged_wagtail_only_view(flag_name, regex_path, url_name=None):
     """ Teachers Digital Platform static pages are very similar so
     in the name of DRY we are implementing them with this method.
     """
@@ -61,6 +61,7 @@ def flagged_static(flag_name, regex_path):
         regex_path,
         lambda request: ServeView.as_view()(request, request.path),
         fallback=page_not_found,
+        name=url_name,
     )
 
 
@@ -383,31 +384,29 @@ urlpatterns = [
                 r'^search/',
                 include('search.urls')),
 
-    flagged_url(
+    flagged_wagtail_only_view(
         'TDP_SEARCH_INTERFACE',
         r'^practitioner-resources/youth-financial-education/teach/activities/',
-        lambda request: ServeView.as_view()(request, request.path),
-        fallback=page_not_found,
-        name='tdp_search'),
+        'tdp_search'),
 
-    flagged_static(
-        'TDP_SEARCH_INTERFACE',
+    flagged_wagtail_only_view(
+        'TDP_STATIC_PAGE',
         r'^practitioner-resources/youth-financial-education/teach/'),
 
-    flagged_static(
-        'TDP_SEARCH_INTERFACE',
+    flagged_wagtail_only_view(
+        'TDP_STATIC_PAGE',
         r'^practitioner-resources/youth-financial-education/learn/'),
 
-    flagged_static(
-        'TDP_SEARCH_INTERFACE',
+    flagged_wagtail_only_view(
+        'TDP_STATIC_PAGE',
         r'practitioner-resources/youth-financial-education2/'),
 
-    flagged_static(
-        'TDP_SEARCH_INTERFACE',
+    flagged_wagtail_only_view(
+        'TDP_STATIC_PAGE',
         r'^practitioner-resources/youth-financial-education/glossary-financial-terms/'),  # noqa: E501
 
-    flagged_static(
-        'TDP_SEARCH_INTERFACE',
+    flagged_wagtail_only_view(
+        'TDP_STATIC_PAGE',
         r'^practitioner-resources/youth-financial-education/resources-research/'),  # noqa: E501
 
     flagged_url('TDP_CRTOOL',
@@ -425,11 +424,9 @@ urlpatterns = [
         include_if_app_enabled('teachers_digital_platform',
                                 'teachers_digital_platform.prototypes_urls')),  # noqa: E501
 
-    flagged_url(
+    flagged_wagtail_only_view(
         'TDP_CRTOOL',
-        r'^practitioner-resources/youth-financial-education/curriculum-review/',  # noqa: E501
-        lambda request: ServeView.as_view()(request, request.path),
-        fallback=page_not_found),
+        r'^practitioner-resources/youth-financial-education/curriculum-review/'),  # noqa: E501
 
     flagged_url('TDP_BB_TOOL',
         r'^practitioner-resources/youth-financial-education/tour',  # noqa: E501

--- a/cfgov/cfgov/urls.py
+++ b/cfgov/cfgov/urls.py
@@ -395,14 +395,14 @@ urlpatterns = [
 
     flagged_url(
         'TDP_STATIC_PAGE',
-        r'^practitioner-resources/youth-financial-education/glossary-financial-terms/',
+        r'^practitioner-resources/youth-financial-education/glossary-financial-terms/',  # noqa: E501
         lambda request: ServeView.as_view()(request, request.path),
         fallback=page_not_found,
     ),
 
     flagged_url(
         'TDP_STATIC_PAGE',
-        r'^practitioner-resources/youth-financial-education/resources-research/',
+        r'^practitioner-resources/youth-financial-education/resources-research/',  # noqa: E501
         lambda request: ServeView.as_view()(request, request.path),
         fallback=page_not_found,
     ),
@@ -424,7 +424,7 @@ urlpatterns = [
 
     flagged_url(
         'TDP_CRTOOL',
-        r'^practitioner-resources/youth-financial-education/curriculum-review/',
+        r'^practitioner-resources/youth-financial-education/curriculum-review/',  # noqa: E501
         lambda request: ServeView.as_view()(request, request.path),
         fallback=page_not_found,
     ),

--- a/cfgov/cfgov/urls.py
+++ b/cfgov/cfgov/urls.py
@@ -51,16 +51,18 @@ def flagged_wagtail_template_view(flag_name, template_name):
         condition=False
     )
 
-def tdp_static_flagged(regex_path):
-    """ Teachers Digital Platform static pages are very similar so 
+
+def flagged_static(flag_name, regex_path):
+    """ Teachers Digital Platform static pages are very similar so
     in the name of DRY we are implementing them with this method.
     """
     return flagged_url(
-        'TDP_STATIC_PAGE',
+        flag_name,
         regex_path,
         lambda request: ServeView.as_view()(request, request.path),
         fallback=page_not_found,
     )
+
 
 urlpatterns = [
     url(r'^documents/(?P<document_id>\d+)/(?P<document_filename>.*)$',
@@ -388,19 +390,24 @@ urlpatterns = [
         fallback=page_not_found,
         name='tdp_search'),
 
-    tdp_static_flagged(
+    flagged_static(
+        'TDP_SEARCH_INTERFACE',
         r'^practitioner-resources/youth-financial-education/teach/'),
 
-    tdp_static_flagged(
+    flagged_static(
+        'TDP_SEARCH_INTERFACE',
         r'^practitioner-resources/youth-financial-education/learn/'),
 
-    tdp_static_flagged(
+    flagged_static(
+        'TDP_SEARCH_INTERFACE',
         r'practitioner-resources/youth-financial-education2/'),
 
-    tdp_static_flagged(
+    flagged_static(
+        'TDP_SEARCH_INTERFACE',
         r'^practitioner-resources/youth-financial-education/glossary-financial-terms/'),  # noqa: E501
 
-    tdp_static_flagged(
+    flagged_static(
+        'TDP_SEARCH_INTERFACE',
         r'^practitioner-resources/youth-financial-education/resources-research/'),  # noqa: E501
 
     flagged_url('TDP_CRTOOL',


### PR DESCRIPTION
Add feature flags for TDP related wagtail (static) pages. Add feature flag for TDP Search Interface and Activity Detail pages.

## Review

- @chosak @willbarton @higs4281 @Scotchester 


## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
