### PR TITLE
Fix video player so that native GTM tracking works

### DIFF
--- a/cfgov/jinja2/v1/_includes/macros/video-player.html
+++ b/cfgov/jinja2/v1/_includes/macros/video-player.html
@@ -24,16 +24,16 @@
    ========================================================================== #}
 
 {% macro render(options={}) -%}
-    {% set video_url    = options.video.url | default('/') %}
+    {% set video_url = options.video.url | default('/') %}
     {% set image_url = static('img/cfpb_video_cover_card_1380x776.png') %}
     {% set video_id = options.video.id | default('') %}
 
     {# TODO: Move the advanced Jinja logic into Django. #}
-     {% if video_url.find( '?' ) == -1 -%}
+    {% if video_url.find( '?' ) == -1 -%}
         {% set video_url = video_url ~ '?'  %}
     {% endif %}
-    {% if video_url.find( 'autoplay=' ) == -1 -%}
-        {% set video_url = _buildParam( video_url, 'autoplay=1' )  %}
+    {% if video_url.find( 'autoplay=1' ) != -1 -%}
+        {% set video_url = video_url | replace('autoplay=1', '')  %}
     {% endif %}
     {% set video_id = video_url.split('?')[0].split('/') | last if video_id == '' else video_id %}
     {% if video_url.find( 'enablejsapi=' ) == -1 -%}

--- a/cfgov/unprocessed/js/modules/VideoPlayer.js
+++ b/cfgov/unprocessed/js/modules/VideoPlayer.js
@@ -90,12 +90,15 @@ VideoPlayer.init = function init( selector ) {
   if ( videoPlayerElement ) {
     videoPlayer = new this( videoPlayerElement );
   }
+  _attachIFrame();
 
   return videoPlayer;
 };
 
 // Private Methods.
 
+// TODO Fix complexity issue
+/* eslint-disable complexity */
 /**
  * Function used to attach the video iframe.
  * @throws Will throw an error if no iframe element is found.
@@ -111,8 +114,9 @@ function _attachIFrame() {
     iFrameElement.classList.add( CLASSES.IFRAME_CLASS_NAME );
     iFrameElement.setAttribute( 'frameborder', 0 );
     _this.state.isIframeLoading = true;
-    iFrameElement.onload =
-      function oniFrameLoad() { _this.state.setIsIframeLoaded( true ); };
+    iFrameElement.onload = function onload() {
+      _this.state.setIsIframeLoaded( true );
+    };
     iFrameContainerElement.appendChild( iFrameElement );
   } else if ( _this.childElements.iframeContainer === null ) {
     throw new Error( 'No iframe container element found.' );
@@ -276,9 +280,6 @@ const API = {
    * Function used to play the video player.
    */
   play: function play( ) {
-    if ( _isIframeLoaded === false ) {
-      _attachIFrame();
-    }
     this.baseElement.classList.add( CLASSES.VIDEO_PLAYING_STATE );
     this.state.setIsVideoPlaying( true );
   },

--- a/cfgov/unprocessed/js/modules/YoutubePlayer.js
+++ b/cfgov/unprocessed/js/modules/YoutubePlayer.js
@@ -52,6 +52,7 @@ const API = {
     this.videoId = this.baseElement &&
       this.baseElement.getAttribute( 'data-id' );
     this.loadImage();
+    this.initPlayer();
   },
 
 


### PR DESCRIPTION
As reported in https://GHE/CFGOV/platform/issues/2895, our current video player implementation is preventing native Google Tag Manager tracking of YouTube videos. We want to use this native tracking to reduce the amount of custom tracking code we have to use. This PR should fix the issue.

## Changes

- Attach and init the video on first load, not after the user clicks the play button, but leave it hidden
- This necessitates _not_ having videos autoplay, contrary to our previous guidance. The `video_url` modification in the template has been changed to _remove_ `autoplay=1` if found, rather than adding it if missing.

## Testing

Full testing requires GTM access, but if you want to ensure nothing's broken:

1. Pull branch
1. `gulp scripts`
1. Visit a page with a video, like http://localhost:8000/practitioner-resources/your-money-your-goals/
1. Play the video as normal

## Notes

- The removal of the need to have videos autoplay makes the FCM help text for the video URL a bit out of date, but the template transformation compensates for that. I would prefer to tackle the Wagtail interface in a more comprehensive PR that simplifies what we ask for down to just the video ID.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [x] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [x] Chrome
- [x] Firefox
- [x] Safari
- [x] Internet Explorer 8, 9, 10, and 11
- [x] Edge