### PR TITLE
Add Django 1.11 compatibility to CSRF view

### DIFF
--- a/cfgov/cfgov/urls.py
+++ b/cfgov/cfgov/urls.py
@@ -267,7 +267,7 @@ urlpatterns = [
         template_name='knowbeforeyouowe/creditcards/tool.html'),
         name='cckbyo'),
     # Form csrf token provider for JS form submission
-    url(r'^token-provider/', token_provider),
+    url(r'^token-provider/', token_provider, name='csrf-token-provider'),
 
     # data-research-api
     url(r'^data-research/mortgages/api/v1/',

--- a/cfgov/legacy/tests/views/test_views.py
+++ b/cfgov/legacy/tests/views/test_views.py
@@ -1,0 +1,19 @@
+from django.core.urlresolvers import reverse
+from django.test import TestCase
+
+
+class TestTokenProviderView(TestCase):
+    def setUp(self):
+        self.url = reverse('csrf-token-provider')
+
+    def test_get_returns_plain_http_response(self):
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+
+    def test_post_returns_csrf_token(self):
+        response = self.client.post(self.url)
+        self.assertTemplateUsed(response, 'common/csrf.html')
+
+    def test_post_marks_session_as_modified(self):
+        response = self.client.post(self.url)
+        self.assertTrue(response.wsgi_request.session.modified)

--- a/cfgov/legacy/views/__init__.py
+++ b/cfgov/legacy/views/__init__.py
@@ -1,6 +1,5 @@
 from django.http import HttpResponse
-from django.shortcuts import render_to_response
-from django.template import RequestContext
+from django.shortcuts import render
 from django.views.decorators.csrf import csrf_exempt
 
 
@@ -8,6 +7,5 @@ from django.views.decorators.csrf import csrf_exempt
 def token_provider(request):
     request.session.modified = True
     if request.method == 'POST':
-        context = RequestContext(request)
-        return render_to_response('common/csrf.html', context)
+        return render(request, 'common/csrf.html')
     return HttpResponse()


### PR DESCRIPTION
The CSRF token endpoint view (at /token-provider/) is not compatible with Django 1.11. This change fixes that and adds tests for this view.

To run tests against Django 1.11, run:

`tox -e unittest-py27-dj111-wag113-fast`

To access the view locally, run:

`curl -X POST http://localhost:8000/token-provider/`

This view is used by django-college-costs-comparison, for example at:

https://www.consumerfinance.gov/paying-for-college/compare-financial-aid-and-college-cost/

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [X] Passes all existing automated tests
- [X] Any _change_ in functionality is tested
- [X] New functions are documented (with a description, list of inputs, and expected output)
- [X] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [X] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: