### PR TITLE
Consolidate base template Modernizr code

### DIFF
--- a/cfgov/jinja2/v1/_layouts/base-common.html
+++ b/cfgov/jinja2/v1/_layouts/base-common.html
@@ -188,30 +188,7 @@
     })(window,document,'script','dataLayer','GTM-KMMLRS');</script>
     {# end Google Tag Manager #}
 
-    {# Customized Modernizr build that includes html5printshiv.
-       Built via gulp-modernizer in `scripts.js` task.
-       TODO: Determine if modernizr is actually needed! #}
-    {% block modernizr %}
-    {#
-      Turn off JavaScript for browsers that don't support ECMAScript 5 features
-      (e.g. Internet Explorer 8)
-      by reversing no-js/js CSS class change made by modernizr.
-      The ECMAScript 5 feature checks are listed in
-      https://github.com/Modernizr/Modernizr/tree/master/feature-detects/es5
-    #}
-    <script>
-        {% include '/js/modernizr.min.js' %}
-
-        !function(){
-          var modernizr = window.Modernizr;
-          if ( !( typeof modernizr !== 'undefined' && modernizr.es5 ) ) {
-            var docElement = document.documentElement;
-            docElement.className = docElement.className.replace( /(^|\s)js(\s|$)/, '$1no-js$2' );
-          }
-        }();
-    </script>
-    {% endblock %}
-
+    {% include "v1/modernizr.html" %}
 </head>
 
 <body{% block body_classes %}{% endblock body_classes %}>

--- a/cfgov/jinja2/v1/ask-cfpb/answer-page-spanish-printable.html
+++ b/cfgov/jinja2/v1/ask-cfpb/answer-page-spanish-printable.html
@@ -21,7 +21,6 @@
 <!--[if lt IE 9]> <script src="{{ static('nemo/_/js/html5shim.js') }}"></script> <![endif]-->
 
 {% include "v1/modernizr.html" %}
-
 </head>
 <body class="s-printable">
 <!-- Google Tag Manager -->

--- a/cfgov/jinja2/v1/ask-cfpb/answer-page-spanish-printable.html
+++ b/cfgov/jinja2/v1/ask-cfpb/answer-page-spanish-printable.html
@@ -12,9 +12,6 @@
 <meta name="description" content="">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 
-<!-- Custom modernizr for touch detection and svg support only, see the .js file for the build link -->
-<script src="{{ static('nemo/_/js/modernizr.custom.js') }}"></script>
-
 <!--[if lt IE 9]>      <link rel="stylesheet" href="{{ static('nemo/_/c/es-styles-ie.min.css') }}"> <![endif]-->
     <!--[if gt IE 8]><!--> <link rel="stylesheet" href="{{ static('nemo/_/c/es-styles.min.css') }}"> <!--<![endif]-->
 
@@ -22,6 +19,8 @@
     <!--[if gt IE 8]><!--> <link rel="stylesheet" href="{{ static('knowledgebase/es-ask-styles.min.css') }}"> <!--<![endif]-->
 
 <!--[if lt IE 9]> <script src="{{ static('nemo/_/js/html5shim.js') }}"></script> <![endif]-->
+
+{% include "v1/modernizr.html" %}
 
 </head>
 <body class="s-printable">

--- a/cfgov/jinja2/v1/es/es-base.html
+++ b/cfgov/jinja2/v1/es/es-base.html
@@ -16,11 +16,6 @@
     <meta property="fb:page_id" content="141576752553390">
 {% endblock %}
 
-{% block modernizr %}
-    <!-- Custom modernizr for touch detection and svg support only, see the .js file for the build link -->
-    <script src="{{ static('nemo/_/js/modernizr.custom.js') }}"></script>
-{% endblock %}
-
 {% block css %}
     <!--[if lt IE 9]>      <link rel="stylesheet" href="{{ static('nemo/_/c/es-styles-ie.min.css') }}"> <![endif]-->
     <!--[if gt IE 8]><!--> <link rel="stylesheet" href="{{ static('nemo/_/c/es-styles.min.css') }}"> <!--<![endif]-->

--- a/cfgov/legacy/templates/front/base_nonresponsive.html
+++ b/cfgov/legacy/templates/front/base_nonresponsive.html
@@ -1,4 +1,4 @@
-{% load header_footer %}
+{% load base_elements %}
 {% load i18n %}
 {% load static from staticfiles %}
 {% load staticversions %}
@@ -105,6 +105,8 @@ please send an email with your full name to tech@cfpb.gov.
 
     {% block analytics_js %}
     {% endblock %}
+
+    {% include_modernizr %}
 </head>
 
 <body class="{% block body_class %}page{% endblock %}" data-lang="{% trans "en" %}">
@@ -114,19 +116,7 @@ please send an email with your full name to tech@cfpb.gov.
 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
 {% endblock %}
-<script src="{% static 'js/modernizr.min.js'  %}"></script>
 
-
-
-<!--[if lt IE 9]>
-    <script>
-    // If in IE8 reverse no-js/js class change made by modernizr.
-    var docElement = document.documentElement;
-    docElement.className = docElement.className.replace( /(^|\s)js(\s|$)/, '$1no-js$2' );
-    </script>
-<![endif]-->
-
-<!--[if IE 9]><script src="{% static 'js/ie/common.ie9.js'  %}"></script><![endif]-->
         {% include_header %}
     <div id="page">
         {% block app_notification %}

--- a/cfgov/legacy/templates/front/base_update.html
+++ b/cfgov/legacy/templates/front/base_update.html
@@ -1,4 +1,4 @@
-{% load header_footer %}
+{% load base_elements %}
 {% load i18n %}
 {% load remit_var %}
 {% load static from staticfiles %}
@@ -148,25 +148,16 @@
     'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
     })(window,document,'script','dataLayer','GTM-KMMLRS');</script>
 
-    <script src="{% static 'js/modernizr.min.js' %}"></script>
     <!--[if lt IE 9]>
     <script src="{% static 'nemo/_/js/html5shim.js' %}"></script>
     <![endif]-->
-
-    <!--[if lt IE 9]>
-    <script>
-        // If in IE8 reverse no-js/js class change made by modernizr.
-        var docElement = document.documentElement;
-        docElement.className = docElement.className.replace( /(^|\s)js(\s|$)/, '$1no-js$2' );
-    </script>
-    <![endif]-->
-
-    <!--[if IE 9]><script src="{% static 'js/ie/common.ie9.js' %}"></script><![endif]-->
 
     <script src="{% static 'nemo/_/js/jquery-1.9.1.min.js' %}"></script>
 
     {% block analytics_js %}
     {% endblock %}
+
+    {% include_modernizr %}
 </head>
 
 <body class="{% block body_class %}page{% endblock %}" data-lang="{% trans "en" %}">

--- a/cfgov/v1/jinja2/v1/footer.html
+++ b/cfgov/v1/jinja2/v1/footer.html
@@ -2,7 +2,7 @@
 
    Render the site footer.
 
-   See v1.templatetags.header_footer. This template allows for inclusion of the
+   See v1.templatetags.base_elements. This template allows for inclusion of the
    Jinja2 site footer in templates written using the Django template language.
 
    ========================================================================== #}

--- a/cfgov/v1/jinja2/v1/header.html
+++ b/cfgov/v1/jinja2/v1/header.html
@@ -2,7 +2,7 @@
 
    Render the site header without the banner.
 
-   See v1.templatetags.header_footer. This template allows for inclusion of the
+   See v1.templatetags.base_elements. This template allows for inclusion of the
    Jinja2 site header in templates written using the Django template language.
 
    ========================================================================== #}

--- a/cfgov/v1/jinja2/v1/modernizr.html
+++ b/cfgov/v1/jinja2/v1/modernizr.html
@@ -1,0 +1,23 @@
+{# =========================================================================
+
+   Customized Modernizr build that includes html5printshiv.
+   Built via gulp-modernizer in `scripts.js` task.
+   TODO: Determine if modernizr is actually needed!
+
+   Turns off JavaScript for browsers that don't support ECMAScript 5 features
+   (e.g. Internet Explorer 8) by reversing no-js/js CSS class change made by
+   modernizr. The ECMAScript 5 feature checks are listed in
+   https://github.com/Modernizr/Modernizr/tree/master/feature-detects/es5
+
+   ========================================================================= #}
+<script>
+  {% include '/js/modernizr.min.js' %}
+
+  !function(){
+    var modernizr = window.Modernizr;
+    if ( !( typeof modernizr !== 'undefined' && modernizr.es5 ) ) {
+      var docElement = document.documentElement;
+      docElement.className = docElement.className.replace( /(^|\s)js(\s|$)/, '$1no-js$2' );
+    }
+  }();
+</script>

--- a/cfgov/v1/templatetags/base_elements.py
+++ b/cfgov/v1/templatetags/base_elements.py
@@ -1,16 +1,23 @@
-"""Render the website header and footer using Django templates.
+"""Render website base template elements using Django templates.
 
-The cf.gov header and footer templates are written in the Jinja2 template
+Certain cf.gov base template elements are written in the Jinja2 template
 language and are typically rendered as part of a Jinja2 template. This module
-makes the hader and footer available to the Django template engine as well,
-through two Django template tags. This allows for a custom header and footer
-even on pages that aren't rendered using the Jinja2 engine.
+makes these template elements available to the Django template engine as well
+through Django template tags. This allows for inclusion of these template
+element even on pages that aren't rendered using the Jinja2 engine.
+
+These elements include:
+
+    - The page header.
+    - The page footer.
+    - Code that includes Modernizr.js and disables JS where appropriate.
 
 An example Django template using these might look like:
 
-    {% load header_footer %}
+    {% load base_elements %}
 
     {% include_header %}
+    {% include_modernizr %}
 
     /* Other content here */
 
@@ -43,3 +50,8 @@ def include_header(context):
 @register.simple_tag(takes_context=True)
 def include_footer(context):
     return _render_jinja_template('v1/footer.html', context)
+
+
+@register.simple_tag(takes_context=True)
+def include_modernizr(context):
+    return _render_jinja_template('v1/modernizr.html', context)

--- a/cfgov/v1/tests/templatetags/test_base_elements.py
+++ b/cfgov/v1/tests/templatetags/test_base_elements.py
@@ -10,11 +10,16 @@ class TestHeaderFooter(TestCase):
         self.context = Context({'request': request})
 
     def test_render_header(self):
-        tmpl = Template('{% load header_footer %}{% include_header %}')
+        tmpl = Template('{% load base_elements %}{% include_header %}')
         html = tmpl.render(self.context)
         self.assertIn('<header class="o-header">', html)
 
     def test_render_footer(self):
-        tmpl = Template('{% load header_footer %}{% include_footer %}')
+        tmpl = Template('{% load base_elements %}{% include_footer %}')
         html = tmpl.render(self.context)
         self.assertIn('<footer class="o-footer">', html)
+
+    def test_render_modernizr(self):
+        tmpl = Template('{% load base_elements %}{% include_modernizr %}')
+        html = tmpl.render(self.context)
+        self.assertIn('window.Modernizr', html)


### PR DESCRIPTION
Currently multiple cf.gov base page templates include Modernizr.js (and use it to disable JS) in different ways. This PR consolidates this logic and unifies it across the templates. This change is motivated by, and also removes, reference to a deprecated `common.ie9.js` file that was removed in 9afbc47.

The three base templates involved in this change are:

1) [cfgov/jinja2/v1/_layouts/base-common.html](https://github.com/cfpb/cfgov-refresh/blob/modernize-modernizr/cfgov/jinja2/v1/_layouts/base-common.html): This is a Jinja2 template rendered by Django with the Jinja2 template engine. This is used as the base template for most, if not all, of the Wagtail page templates.

2) [cfgov/legacy/templates/front/base_nonresponsive.html](https://github.com/cfpb/cfgov-refresh/blob/modernize-modernizr/cfgov/legacy/templates/front/base_nonresponsive.html): This is a Django template rendered by Django with the Django template engine. This is used by some pages in cfgov-refresh (for example, the agreements app at https://www.consumerfinance.gov/credit-cards/agreements/) as well as pages from satellite apps (for example, the Paying for College page at https://www.consumerfinance.gov/paying-for-college/compare-financial-aid-and-college-cost/).

3) [cfgov/legacy/templates/front/base_update.html](https://github.com/cfpb/cfgov-refresh/blob/modernize-modernizr/cfgov/legacy/templates/front/base_update.html): This is a Django template rendered by Django with the Django template engine. This is not used by any pages in cfgov-refresh but is used by satellite apps (for example, the retirement app at https://www.consumerfinance.gov/consumer-tools/retirement/before-you-claim/).

This change unifies the way that the Modernizr code is loaded into each of these templates. Before, the Jinja2 template loaded the code directly with an `{% include %}` tag, and the Django templates loaded with a `<script>` tag. Now, both embed the code directly.

The code exists only once now, as a Jinja template snippet at [cfgov/v1/jinja/v1/modernizr.html](https://github.com/cfpb/cfgov-refresh/blob/modernize-modernizr/cfgov/v1/jinja2/v1/modernizr.html), alongside other similar snippets for the site header and footer. All of those snippets are now exposed to the Django template engine through a [`base_elements`](https://github.com/cfpb/cfgov-refresh/blob/modernize-modernizr/cfgov/v1/templatetags/base_elements.py) templatetag library (formerly named `header_footer`). Old references and unit tests have all been updated.

Some other minor changes in this PR: I've removed the custom Modernizr build for Spanish Ask CFPB answer pages instead of using the global one. This change also makes it so that all of the pages include the Modernizr script at the end of the `<head>` section, instead of in the `<body>` tag.

To test, run a local server with the [retirement](https://github.com/cfpb/retirement) satellite app installed. Visit these pages to test each template:

http://localhost:8000/
http://localhost:8000/credit-cards/agreements/
http://localhost:8000/consumer-tools/retirement/before-you-claim/

When accessing these pages in IE9, you should see a `"no-js"` class on the page `<html>` tag.

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [X] Passes all existing automated tests
- [X] Any _change_ in functionality is tested
- [X] New functions are documented (with a description, list of inputs, and expected output)
- [X] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [X] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: