### PR TITLE
Regs3k accessibility improvements

### DIFF
--- a/cfgov/regulations3k/jinja2/regulations3k/search-regulations-results.html
+++ b/cfgov/regulations3k/jinja2/regulations3k/search-regulations-results.html
@@ -5,17 +5,17 @@
 <div class="results_header">
     {% if current_count > 0 %}
     <div class="results_count">
-        <h3>
+        <h2 class="h3">
             Showing {{ current_count }}
             match{% if current_count > 1 %}es{% endif %}
             {% if total_count > current_count %}
                 out of {{ total_count }} total results
             {% endif %}
-        </h3>
+        </h2>
     </div>
     {% else %}
     <div class="results_count no-results">
-        <h3>No results match your filters.</h3>
+        <h2 class="h3">No results match your filters.</h2>
         <p>Try adjusting your filters or searching for different terms.</p>
     </div>
     {% endif %}

--- a/cfgov/unprocessed/apps/regulations3k/js/search-utils.js
+++ b/cfgov/unprocessed/apps/regulations3k/js/search-utils.js
@@ -6,6 +6,8 @@
  * @returns {Array} Array of objects of form field names and values.
  */
 function getSearchValues( searchEl, filterEls ) {
+  // IE doesn't support forEach w/ node lists so convert it to an array.
+  filterEls = Array.prototype.slice.call( filterEls );
   const fields = [];
   const field = {};
   field[searchEl.name] = searchEl.value;

--- a/cfgov/unprocessed/apps/regulations3k/js/search.js
+++ b/cfgov/unprocessed/apps/regulations3k/js/search.js
@@ -52,7 +52,9 @@ function clearFilter( event ) {
  * @param {Event} event Click event
  */
 function clearFilters( event ) {
-  const filterIcons = document.querySelectorAll( '.a-tag svg' );
+  let filterIcons = document.querySelectorAll( '.a-tag svg' );
+  // IE doesn't support forEach w/ node lists so convert it to an array.
+  filterIcons = Array.prototype.slice.call( filterIcons );
   filterIcons.forEach( filterIcon => {
     const target = closest( filterIcon, 'button' );
     clearFilter( {

--- a/cfgov/unprocessed/apps/regulations3k/js/search.js
+++ b/cfgov/unprocessed/apps/regulations3k/js/search.js
@@ -64,11 +64,11 @@ function removeTag( tag ) {
  * @param {Event} event Click event
  */
 function clearFilters( event ) {
-  let filterIcons = document.querySelectorAll( '.a-tag svg' );
+  let filterIcons = document.querySelectorAll( '.filters_tags svg' );
   // IE doesn't support forEach w/ node lists so convert it to an array.
   filterIcons = Array.prototype.slice.call( filterIcons );
   filterIcons.forEach( filterIcon => {
-    const target = closest( filterIcon, 'button' );
+    const target = closest( filterIcon, '.a-tag' );
     clearFilter( {
       target: filterIcon,
       value: target

--- a/cfgov/unprocessed/apps/regulations3k/js/search.js
+++ b/cfgov/unprocessed/apps/regulations3k/js/search.js
@@ -36,13 +36,25 @@ function clearFilter( event ) {
     return;
   }
   target = closest( event.target, '.a-tag' );
-  const checkbox = find( `#regulation-${ target.dataset.value }` );
+  const checkbox = find( `#regulation-${ target.getAttribute( 'data-value' ) }` );
   // Remove the filter tag
-  target.remove();
+  removeTag( target );
   // Uncheck the filter checkbox
   checkbox.checked = false;
   if ( event instanceof Event ) {
     handleFilter( event );
+  }
+}
+
+/**
+ * Remove a filter tag from the search results page.
+ * node.remove() isn't supported by IE so we have to removeChild();
+ *
+ * @param {Node} tag Filter tag HTML element
+ */
+function removeTag( tag ) {
+  if ( tag.parentNode !== null ) {
+    tag.parentNode.removeChild( tag );
   }
 }
 

--- a/cfgov/unprocessed/js/modules/util/dom-traverse.js
+++ b/cfgov/unprocessed/js/modules/util/dom-traverse.js
@@ -69,14 +69,18 @@ function closest( elem, selector ) {
   const matchesSelector = _getMatchesMethod( elem );
   let match;
 
-  while ( elem ) {
-    if ( matchesSelector.bind( elem )( selector ) ) {
-      match = elem;
-    } else {
-      elem = elem.parentElement;
-    }
+  try {
+    while ( elem ) {
+      if ( matchesSelector.bind( elem )( selector ) ) {
+        match = elem;
+      } else {
+        elem = elem.parentNode;
+      }
 
-    if ( match ) { return elem; }
+      if ( match ) { return elem; }
+    }
+  } catch ( err ) {
+    return null;
   }
 
   return null;

--- a/test/unit_tests/apps/regulations3k/js/search-spec.js
+++ b/test/unit_tests/apps/regulations3k/js/search-spec.js
@@ -16,14 +16,15 @@ const HTML_SNIPPET = `
       </label>
     </div>
   </div>
-  <div>
+  <div class="filters_tags">
     <div class="a-tag" data-value="1002" data-js-hook="behavior_clear-filter">
     1002 (Regulation B)
       <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 718.9 1200" class="cf-icon-svg">
       </svg>
     </div>
   </div>
-  <button id="clear-all" data-js-hook="behavior_clear-all">
+  <button class="a-btn a-btn__link a-btn__warning a-micro-copy filters_clear"
+          data-js-hook="behavior_clear-all">
       Clear all filters
   </button>
   <div id="regs3k-results"></div>
@@ -101,7 +102,7 @@ describe( 'The Regs3K search page', () => {
       responseText: []
     };
     global.XMLHttpRequest = jest.fn( () => mockXHR );
-    const clearAllLink = document.querySelector( '#clear-all' );
+    const clearAllLink = document.querySelector( '.filters_clear' );
 
     let numFilters = document.querySelectorAll( 'div.a-tag' ).length;
     expect( numFilters ).toEqual( 1 );

--- a/test/unit_tests/js/modules/util/dom-traverse-spec.js
+++ b/test/unit_tests/js/modules/util/dom-traverse-spec.js
@@ -91,7 +91,7 @@ describe( 'Dom Traverse', () => {
       expect( parent ).toBeNull();
     } );
 
-    it( 'should return the parent HTMLNode even if the selector wasn’t found',
+    it( 'should return null if the selector wasn’t found',
       () => {
         const child = document.querySelector( '.child' );
         const parent = domTraverse.closest( child, 'greatgrandparent' );


### PR DESCRIPTION
Handful of fixes that came out of accessibility testing.

## Testing

1. `./frontend.sh`
1. `gulp test:unit --specs=apps/regulations3k` and verify all automated tests pass
1. Visit the [search page](http://localhost:8000/policy-compliance/rulemaking/regulations/search-regulations/results/?q=disclosure&regs=1003&regs=1004&results=25&order=relevance) and manually toggle some filters to double check everything looks good

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [x] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [x] Chrome
- [x] Firefox
- [x] Safari
- [x] Internet Explorer 8, 9, 10, and 11
- [x] Edge
- [x] iOS Safari
- [x] Chrome for Android

### Accessibility

- [x] Keyboard friendly
- [x] Screen reader friendly

### Other

- [x] Is useable without CSS
- [x] Is useable without JS
- [x] Flexible from small to large screens
- [x] No linting errors or warnings
- [x] JavaScript tests are passing
