### PR TITLE
Bump college-costs version from 2.3.12 to 2.4.0

### DIFF
--- a/requirements/optional-public.txt
+++ b/requirements/optional-public.txt
@@ -1,4 +1,4 @@
-https://github.com/cfpb/college-costs/releases/download/2.3.12/college_costs-2.3.12-py2-none-any.whl
+https://github.com/cfpb/college-costs/releases/download/2.4.0/college_costs-2.4.0-py2-none-any.whl
 https://github.com/cfpb/owning-a-home-api/releases/download/0.11.0/owning_a_home_api-0.11.0-py2-none-any.whl
 https://github.com/cfpb/regulations-core/releases/download/1.2.6/regcore-1.2.6-py2-none-any.whl
 https://github.com/cfpb/regulations-site/releases/download/2.2.5/regulations-2.2.5-py2-none-any.whl


### PR DESCRIPTION
This change bumps the version of the optional satellite app college-costs from version 2.3.12 to the new version 2.4.0:

https://github.com/cfpb/college-costs/releases/tag/2.4.0

This new version adds Django 1.11 support, fixes functional tests, and modernizes the build.

To test with a local server, pip install the new wheel:

```
pip install https://github.com/cfpb/college-costs/releases/download/2.4.0/college_costs-2.4.0-py2-none-any.whl
```

After doing this, re-pip-instal the cfgov-refresh requirements:

```
pip install requirements/libraries.txt
```

Then test these pages locally to verify functionality:

http://localhost:8000/paying-for-college2/understanding-your-financial-aid-offer/offer/test/
http://localhost:8000/paying-for-college2/understanding-your-financial-aid-offer/api/search-schools.json?q=jayhawks

(This second link requires a locl Elasticsearch and ES content which can be loaded using: `cfgov/manage.py update_index -r paying_for_college`.)

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [X] Passes all existing automated tests
- [X] Any _change_ in functionality is tested
- [X] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [X] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: