### PR TITLE
Regs3k: Navigate effective versions of regulations

### DIFF
--- a/cfgov/regulations3k/jinja2/regulations3k/browse-regulation.html
+++ b/cfgov/regulations3k/jinja2/regulations3k/browse-regulation.html
@@ -155,7 +155,7 @@
         </div>
         {% endif %}
 
-        <div class="block block__flush-top">
+        <div class="block block__flush-regs3k">
                 <ul class="m-list m-list__links m-full-width-text">
                     {% if version == regulation.effective_version %}
                         <li class="m-list_item">

--- a/cfgov/regulations3k/jinja2/regulations3k/browse-regulation.html
+++ b/cfgov/regulations3k/jinja2/regulations3k/browse-regulation.html
@@ -5,7 +5,6 @@
 {% import 'eregs/regulations3k-search-bar.html' as search_bar with context %}
 {% import 'templates/render_block.html' as render_block with context %}
 {% import 'templates/streamfield-sidefoot.html' as streamfield_sidefoot with context %}
-{% import 'macros/time.html' as time %}
 
 {% block body_classes %}
     {{ super() }}
@@ -22,7 +21,7 @@
 {% block preload %}
     {{ super() }}
     {% if next_section %}
-    <link rel="prerender" href="{{ routablepageurl(page, "section", next_section.section_number) }}">
+    <link rel="prerender" href="{{ routablepageurl(page, 'section', next_section.section_number) }}">
     {% endif %}
     <link rel="manifest" href="{{ static('apps/regulations3k/regulations3k-manifest.json') }}">
     <link rel="icon" sizes="192x192" href="{{ static('apps/regulations3k/img/regulations3k-icon-192.png') }}">
@@ -41,32 +40,159 @@
 {% block content_main %}
     {% if section %}
         <h1>{{section.title}}</h1>
+
         <div class="regulation-meta">
-            <div class="a-date">
-                Most recently amended
-                {{ time.render(section.subpart.version.effective_date, {'date':true, 'time':false, 'timezone':false}) }}
-            </div>
-            <ul class="m-list m-list__links">
-                <li class="m-list_item">
-                    <a class="m-list_link" href="{{ search_url }}">
-                        Search {{ regulation }}
-                    </a>
-                </li>
-            </ul>
+            {% if section.subpart.version == regulation.effective_version %}
+                <div class="a-date">
+                    This version is current law.
+                </div>
+                <ul class="m-list m-list__links">
+                    {% if num_versions > 1 %}
+                    <li class="m-list_item">
+                        <a class="m-list_link" href="{{ routablepageurl(page, 'versions', section_label=section.label) }}">
+                            {% include 'icons/date.svg' %}
+                            View all versions of this regulation
+                        </a>
+                    </li>
+                    {% endif %}
+                    <li class="m-list_item">
+                        <a class="m-list_link" href="{{ search_url }}">
+                            {% include 'icons/search.svg' %}
+                            Search this regulation
+                        </a>
+                    </li>
+                </ul>
+            {% else %}
+                <div class="m-full-width-text
+                            m-notification
+                            m-notification__visible
+                            m-notification__warning">
+                    {% include 'icons/warning-round.svg' %}
+                    <div class="m-notification_content">
+                        <div class="h4 m-notification_message">This version is not current law.</div>
+                        <p class="m-notification_explanation">
+                        {% if section.subpart.version.effective_date < regulation.effective_version.effective_date %}
+                            You are viewing a previous version of this regulation with ammendments that went into effect on
+                        {% endif %}
+                        {% if section.subpart.version.effective_date > regulation.effective_version.effective_date %}
+                            You are viewing a future version of this regulation with ammendments that will go into effect on
+                        {% endif %}
+                        {{ ap_date(section.subpart.version.effective_date) }}. <a class="m-list_link" href="{{ routablepageurl(page, 'versions', section_label=section.label) }}">View all versions of this regulation</a>
+                        </p>
+                    </div>
+                </div>
+            {% endif %}
         </div>
+
+        <div class="a-rule-break m-full-width-text"></div>
 
         <section class="block block__flush-top">
             {{content|safe}}
         </section>
+
+    {% elif versions %}
+
+        <h3>All versions of {{ page.regulation }}</h3>
+        <ul>
+        {% for version in versions %}
+            <li>
+                {% if section_label %}
+                    {% if version.effective_date == page.regulation.effective_version.effective_date  %}
+                        <a href="{{ routablepageurl(page, 'section', section_label=section_label) }}">
+                    {% else %}
+                        <a href="{{ routablepageurl(page, 'section', date_str=version.date_str, section_label=section_label) }}">
+                    {% endif %}
+                {% else %}
+                    <a href="{{ routablepageurl(page, 'index', version.date_str) }}">
+                {% endif %}
+                   {{ ap_date(version.effective_date) }}
+                </a>
+
+                {% if version.effective_date == page.regulation.effective_version.effective_date %}
+                (current law)
+                {% endif %}
+            </li>
+        {% endfor %}
+        </ul>
+
     {% else %}
+        <div class="block block__flush-top block__flush-bottom">
+            <h1>{{ page.title }}</h1>
+            {% if version == regulation.effective_version %}
+                <div class="regulation-meta">
+                    <div class="a-date">
+                            Most recently amended {{ ap_date(version.effective_date) }}
+                    </div>
+                </div>
+            {% endif %}
+        </div>
+
         {% for block in page.header -%}
             {{ render_block.render(block, loop.index) }}
         {%- endfor %}
 
+        {% if version != regulation.effective_version %}
+        <div class="block block__flush-top">
+            <div class="m-full-width-text 
+                        m-notification
+                        m-notification__visible
+                        m-notification__warning">
+                {% include 'icons/warning-round.svg' %}
+                <div class="m-notification_content">
+                    <div class="h4 m-notification_message">This version is not current law.</div>
+                    <p class="m-notification_explanation">
+                        {% if version.effective_date < regulation.effective_version.effective_date %}
+                            You are viewing a previous version of this regulation with ammendments that went into effect on {{ ap_date(version.effective_date) }}.
+                        {% endif %}
+                        {% if version.effective_date > regulation.effective_version.effective_date %}
+                            You are viewing a future version of this regulation with ammendments that will go into effect on {{ ap_date(version.effective_date) }}.
+                        {% endif %}
+                    </p>
+                </div>
+            </div>
+        </div>
+        {% endif %}
+
+        <div class="block block__flush-top">
+                <ul class="m-list m-list__links m-full-width-text">
+                    {% if version == regulation.effective_version %}
+                    <li class="m-list_item">
+                        <a class="m-list_link" href="{{ routablepageurl(page, 'section', section_label=sections[0].label) }}">
+                            View current law
+                        </a>
+                    </li>
+                    {% else %}
+                    <li class="m-list_item">
+                        <a class="m-list_link" href="{{ routablepageurl(page, 'section', date_str=date_str, section_label=sections[0].label) }}">
+                            View this version
+                        </a>
+                    </li>
+                    {% endif %}
+
+                    {% if num_versions > 1 %}
+                    <li class="m-list_item">
+                        <a class="m-list_link" href="{{ routablepageurl(page, 'versions') }}">
+                            View all versions of this regulation
+                        </a>
+                    </li>
+                    {% endif %}
+
+                    <li class="m-list_item">
+                        <a class="m-list_link" href="{{ search_url }}">
+                            Search this regulation
+                        </a>
+                    </li>
+                </ul>
+        </div>
+
+        <div class="a-rule-break m-full-width-text"></div>
+
         {% for block in page.content -%}
             {{ render_block.render(block, loop.index) }}
         {%- endfor %}
+
     {% endif %}
+
     {% if section %}
         <div class="block block__sub">
             <nav class="section-nav" role="navigation">
@@ -91,6 +217,7 @@
             </aside>
         {% endif %}
     {% endif %}
+
 {% endblock %}
 
 {% block javascript scoped %}

--- a/cfgov/regulations3k/jinja2/regulations3k/browse-regulation.html
+++ b/cfgov/regulations3k/jinja2/regulations3k/browse-regulation.html
@@ -73,12 +73,12 @@
                 <ul>
                     {% if previous_section %}
                     <li class="previous next-prev">
-                        <a href="{{ routablepageurl(page, "section", previous_section.section_number) }}" class="navigation-link backward next-prev-link"><span class="cf-icon cf-icon-left"></span><span class="next-prev-label">Previous section - </span>{{previous_section.numeric_label or previous_section.label}}</a> <span class="next-prev-title">{{previous_section.title_content}}</span>
+                        <a href="{{ previous_url }}" class="navigation-link backward next-prev-link"><span class="cf-icon cf-icon-left"></span><span class="next-prev-label">Previous section - </span>{{previous_section.numeric_label or previous_section.label}}</a> <span class="next-prev-title">{{previous_section.title_content}}</span>
                     </li>
                     {% endif %}
                     {% if next_section %}
                     <li class="next next-prev">
-                        <a href="{{ routablepageurl(page, "section", next_section.section_number) }}" class="navigation-link forward next-prev-link"><span class="cf-icon cf-icon-right"></span><span class="next-prev-label">Next section - </span>{{next_section.numeric_label or next_section.label}}</a> <span class="next-prev-title">{{next_section.title_content}}</span>
+                        <a href="{{ next_url }}" class="navigation-link forward next-prev-link"><span class="cf-icon cf-icon-right"></span><span class="next-prev-label">Next section - </span>{{next_section.numeric_label or next_section.label}}</a> <span class="next-prev-title">{{next_section.title_content}}</span>
                     </li>
                     {% endif %}
                 </ul>

--- a/cfgov/regulations3k/jinja2/regulations3k/browse-regulation.html
+++ b/cfgov/regulations3k/jinja2/regulations3k/browse-regulation.html
@@ -50,14 +50,14 @@
                     {% if num_versions > 1 %}
                     <li class="m-list_item">
                         <a class="m-list_link" href="{{ routablepageurl(page, 'versions', section_label=section.label) }}">
-                            {% include 'icons/date.svg' %}
+                            {{ svg_icon('date') }}
                             View all versions of this regulation
                         </a>
                     </li>
                     {% endif %}
                     <li class="m-list_item">
                         <a class="m-list_link" href="{{ search_url }}">
-                            {% include 'icons/search.svg' %}
+                            {{ svg_icon('search') }}
                             Search this regulation
                         </a>
                     </li>
@@ -67,7 +67,7 @@
                             m-notification
                             m-notification__visible
                             m-notification__warning">
-                    {% include 'icons/warning-round.svg' %}
+                    {{ svg_icon('warning-round') }}
                     <div class="m-notification_content">
                         <div class="h4 m-notification_message">This version is not current law.</div>
                         <p class="m-notification_explanation">
@@ -137,7 +137,7 @@
                         m-notification
                         m-notification__visible
                         m-notification__warning">
-                {% include 'icons/warning-round.svg' %}
+                {{ svg_icon('warning-round') }}
                 <div class="m-notification_content">
                     <div class="h4 m-notification_message">This version is not current law.</div>
                     <p class="m-notification_explanation">

--- a/cfgov/regulations3k/jinja2/regulations3k/browse-regulation.html
+++ b/cfgov/regulations3k/jinja2/regulations3k/browse-regulation.html
@@ -134,8 +134,8 @@
         {%- endfor %}
 
         {% if version != regulation.effective_version %}
-        <div class="block block__flush-top">
-            <div class="m-full-width-text 
+        <div class="block block__flush-regs3k">
+            <div class="m-full-width-text
                         m-notification
                         m-notification__visible
                         m-notification__warning">

--- a/cfgov/regulations3k/jinja2/regulations3k/browse-regulation.html
+++ b/cfgov/regulations3k/jinja2/regulations3k/browse-regulation.html
@@ -44,7 +44,7 @@
         <div class="regulation-meta">
             {% if section.subpart.version == regulation.effective_version %}
                 <div class="a-date">
-                    This version is current law.
+                    This version is current law
                 </div>
                 <ul class="m-list m-list__links">
                     {% if num_versions > 1 %}
@@ -84,7 +84,9 @@
             {% endif %}
         </div>
 
-        <div class="a-rule-break m-full-width-text"></div>
+        {% if section.subpart.version == regulation.effective_version %}
+            <div class="a-rule-break m-full-width-text"></div>
+        {% endif %}
 
         <section class="block block__flush-top">
             {{content|safe}}
@@ -156,32 +158,34 @@
         <div class="block block__flush-top">
                 <ul class="m-list m-list__links m-full-width-text">
                     {% if version == regulation.effective_version %}
-                    <li class="m-list_item">
-                        <a class="m-list_link" href="{{ routablepageurl(page, 'section', section_label=sections[0].label) }}">
-                            View current law
-                        </a>
-                    </li>
+                        <li class="m-list_item">
+                            <a class="m-list_link" href="{{ routablepageurl(page, 'section', section_label=sections[0].label) }}">
+                                View current law
+                            </a>
+                        </li>
                     {% else %}
-                    <li class="m-list_item">
-                        <a class="m-list_link" href="{{ routablepageurl(page, 'section', date_str=date_str, section_label=sections[0].label) }}">
-                            View this version
-                        </a>
-                    </li>
+                        <li class="m-list_item">
+                            <a class="m-list_link" href="{{ routablepageurl(page, 'section', date_str=date_str, section_label=sections[0].label) }}">
+                                View this version
+                            </a>
+                        </li>
                     {% endif %}
 
                     {% if num_versions > 1 %}
-                    <li class="m-list_item">
-                        <a class="m-list_link" href="{{ routablepageurl(page, 'versions') }}">
-                            View all versions of this regulation
-                        </a>
-                    </li>
+                        <li class="m-list_item">
+                            <a class="m-list_link" href="{{ routablepageurl(page, 'versions') }}">
+                                View all versions of this regulation
+                            </a>
+                        </li>
                     {% endif %}
 
-                    <li class="m-list_item">
-                        <a class="m-list_link" href="{{ search_url }}">
-                            Search this regulation
-                        </a>
-                    </li>
+                    {% if version == regulation.effective_version %}
+                        <li class="m-list_item">
+                            <a class="m-list_link" href="{{ search_url }}">
+                                Search this regulation
+                            </a>
+                        </li>
+                    {% endif %}
                 </ul>
         </div>
 

--- a/cfgov/regulations3k/jinja2tags.py
+++ b/cfgov/regulations3k/jinja2tags.py
@@ -1,13 +1,32 @@
+import datetime
 
 from wagtail.contrib.wagtailroutablepage.templatetags.wagtailroutablepage_tags import (  # noqa: E501
     routablepageurl
 )
 
 import jinja2
+from dateutil import parser
 from jinja2.ext import Extension
 from jinja2.filters import do_mark_safe
 
 from regulations3k.regdown import regdown as regdown_func
+
+
+def ap_date(date):
+    """ Convert a date object or date string into an AP-styled date string. """
+    if date is None:
+        return None
+    if type(date) != datetime.date:
+        try:
+            date = parser.parse(date).date()
+        except ValueError:
+            return
+    if date.month in [3, 4, 5, 6, 7]:
+        return date.strftime("%B {}, %Y").format(date.day)
+    elif date.month == 9:
+        return date.strftime("Sept. {}, %Y").format(date.day)
+    else:
+        return date.strftime("%b. {}, %Y").format(date.day)
 
 
 def regdown_filter(text):
@@ -21,6 +40,7 @@ class RegulationsExtension(Extension):
 
         self.environment.globals.update({
             'routablepageurl': jinja2.contextfunction(routablepageurl),
+            'ap_date': ap_date,
         })
         self.environment.filters.update({
             'regdown': regdown_filter,

--- a/cfgov/regulations3k/models/pages.py
+++ b/cfgov/regulations3k/models/pages.py
@@ -333,6 +333,7 @@ class RegulationPage(RoutablePageMixin, SecondaryNavigationJSMixin, CFGOVPage):
                 effective_version=effective_version
             )
         else:
+            effective_version = self.regulation.effective_version
             section_query = self.get_section_query()
 
         sections = list(section_query.all())
@@ -342,8 +343,8 @@ class RegulationPage(RoutablePageMixin, SecondaryNavigationJSMixin, CFGOVPage):
 
         content = regdown(
             section.contents,
-            url_resolver=get_url_resolver(self),
-            contents_resolver=get_contents_resolver(self),
+            url_resolver=get_url_resolver(self, date_str=date_str),
+            contents_resolver=get_contents_resolver(effective_version),
             render_block_reference=partial(self.render_interp, context)
         )
 

--- a/cfgov/regulations3k/resolver.py
+++ b/cfgov/regulations3k/resolver.py
@@ -37,13 +37,13 @@ def resolve_reference(reference):
     return (None, None)
 
 
-def get_contents_resolver(page):
+def get_contents_resolver(effective_version):
     """ Return a Regdown contents_resolver function for the RegulationPage
     This constructs a contents_resolver that will resolve references and
     return their contents for all sections that are part of the current
     EffectiveVersion served by the given page. """
     section_query = Section.objects.filter(
-        subpart__version=page.regulation.effective_version
+        subpart__version=effective_version
     )
 
     def contents_resolver(reference):
@@ -62,17 +62,25 @@ def get_contents_resolver(page):
     return contents_resolver
 
 
-def get_url_resolver(page):
+def get_url_resolver(page, date_str=None):
     """ Returns a Regdown url_resolver function for the RegulationPage
     This constructs a url_resolver that will resolve the URL of references to
     any section that is part of the current EffectiveVersion served by the
     given page. """
+
+    section_kwargs = {}
+    if date_str is not None:
+        section_kwargs['date_str'] = date_str
+
     def url_resolver(reference):
         dest_section_label, dest_paragraph_label = resolve_reference(reference)
+        section_kwargs['section_label'] = dest_section_label
         return '{page_url}{section_url}#{paragraph_label}'.format(
             page_url=page.url,
-            section_url=page.reverse_subpage('section',
-                                             args=([dest_section_label])),
+            section_url=page.reverse_subpage(
+                'section',
+                kwargs=section_kwargs
+            ),
             paragraph_label=dest_paragraph_label
         )
 

--- a/cfgov/regulations3k/tests/test_jinja2tags.py
+++ b/cfgov/regulations3k/tests/test_jinja2tags.py
@@ -1,8 +1,41 @@
+import datetime
+
 from django.template import engines
 from django.test import TestCase
 
+from regulations3k.jinja2tags import ap_date
 
-class RegDownExtensionTestCase(TestCase):
+
+class RegulationsExtensionTestCase(TestCase):
+
+    def test_ap_date(self):
+        test_date = datetime.date(2011, 1, 1)
+        result = ap_date(test_date)
+        self.assertEqual(result, 'Jan. 1, 2011')
+
+    def test_ap_date_sept(self):
+        test_date = datetime.date(2011, 9, 1)
+        result = ap_date(test_date)
+        self.assertEqual(result, 'Sept. 1, 2011')
+
+    def test_ap_date_march(self):
+        test_date = datetime.date(2011, 3, 1)
+        result = ap_date(test_date)
+        self.assertEqual(result, 'March 1, 2011')
+
+    def test_ap_date_string(self):
+        test_date = '2011-01-01'
+        result = ap_date(test_date)
+        self.assertEqual(result, 'Jan. 1, 2011')
+
+    def test_ap_date_invalid_string(self):
+        test_date = "I am not a date"
+        result = ap_date(test_date)
+        self.assertEqual(result, None)
+
+    def test_ap_date_none_date(self):
+        result = ap_date(None)
+        self.assertEqual(result, None)
 
     def test_regdown_filter_available(self):
         jinja2_engine = engines['wagtail-env']

--- a/cfgov/regulations3k/tests/test_models.py
+++ b/cfgov/regulations3k/tests/test_models.py
@@ -513,6 +513,22 @@ class RegModelTests(DjangoTestCase):
             response.content
         )
 
+    def test_get_breadcrumbs_section_with_date(self):
+        crumbs = self.reg_page.get_breadcrumbs(
+            self.get_request(),
+            section=self.section_num4,
+            date_str='2011-01-01'
+        )
+        self.assertEqual(
+            crumbs,
+            [
+                {
+                    'href': '/reg-landing/1002/2011-01-01/',
+                    'title': '12 CFR Part 1002 (Regulation B)'
+                },
+            ]
+        )
+
     def test_effective_version_date_unique(self):
         new_effective_version = mommy.make(
             EffectiveVersion,

--- a/cfgov/regulations3k/tests/test_models.py
+++ b/cfgov/regulations3k/tests/test_models.py
@@ -21,8 +21,8 @@ from regulations3k.models.django import (
 )
 from regulations3k.models.pages import (
     RegulationLandingPage, RegulationPage, RegulationsSearchPage,
-    get_next_section, get_previous_section, get_reg_nav_items,
-    validate_num_results, validate_page_number
+    get_next_section, get_previous_section, get_secondary_nav_items,
+    get_section_url, validate_num_results, validate_page_number
 )
 
 
@@ -285,11 +285,13 @@ class RegModelTests(DjangoTestCase):
             test_context['regulation'],
             self.reg_page.regulation)
 
-    def test_get_reg_nav_items(self):
+    def test_get_secondary_nav_items(self):
         request = self.get_request()
         request.path = '/regulations/1002/4/'
         sections = list(self.reg_page.get_section_query().all())
-        test_nav_items = get_reg_nav_items(request, self.reg_page, sections)[0]
+        test_nav_items = get_secondary_nav_items(
+            request, self.reg_page, sections
+        )[0]
         self.assertEqual(
             len(test_nav_items),
             Subpart.objects.filter(
@@ -299,10 +301,33 @@ class RegModelTests(DjangoTestCase):
             ).count()
         )
 
-    def test_routable_page_view(self):
-        response = self.reg_page.section_page(
-            self.get_request(), section_label='4')
+    def test_get_section_url(self):
+        url = get_section_url(self.reg_page, self.section_num4)
+        self.assertEqual(url, '/reg-landing/1002/4/')
+
+    def test_get_section_url_no_section(self):
+        url = get_section_url(self.reg_page, None)
+        self.assertIsNone(url)
+
+    def test_section_page_view(self):
+        response = self.client.get('/reg-landing/1002/4/')
         self.assertEqual(response.status_code, 200)
+
+    def test_section_page_view_section_does_not_exist(self):
+        response = self.client.get('/reg-landing/1002/82/')
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(
+            response.get('location'),
+            'http://testserver/reg-landing/1002/'
+        )
+
+    def test_section_page_view_section_does_not_exist_with_date(self):
+        response = self.client.get('/reg-landing/1002/2011-01-01/82/')
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(
+            response.get('location'),
+            'http://testserver/reg-landing/1002/2011-01-01/'
+        )
 
     def test_sortable_label(self):
         self.assertEqual(sortable_label('1-A-Interp'), ('0001', 'A', 'interp'))
@@ -453,24 +478,38 @@ class RegModelTests(DjangoTestCase):
     def test_index_page_with_effective_date(self):
         response = self.client.get('/reg-landing/1002/2011-01-01/')
         self.assertEqual(response.status_code, 200)
+        self.assertIn(b'This version is not current law', response.content)
+        self.assertIn(b'Jan. 1, 2011', response.content)
 
     def test_index_page_without_effective_date(self):
         response = self.client.get('/reg-landing/1002/')
         self.assertEqual(response.status_code, 200)
+        self.assertIn(b'Most recently amended Jan. 18, 2014', response.content)
 
     def test_section_page_with_effective_date(self):
         response = self.client.get('/reg-landing/1002/2011-01-01/4/')
         self.assertEqual(response.status_code, 200)
-        self.assertIn(
-            b'JAN 01, 2011',
-            response.content,
-        )
+        self.assertIn(b'This version is not current law', response.content)
 
     def test_section_page_without_effective_date(self):
         response = self.client.get('/reg-landing/1002/4/')
         self.assertEqual(response.status_code, 200)
+        self.assertIn(b'This version is current law', response.content)
+        self.assertIn(b'Search this regulation', response.content)
+
+    def test_versions_page_view_without_section(self):
+        response = self.client.get('/reg-landing/1002/versions/')
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b'Jan. 18, 2014', response.content)
+        self.assertIn(b'(current law)', response.content)
+        self.assertIn(b'Jan. 1, 2011', response.content)
+        self.assertNotIn(b'Jan. 1, 2020', response.content)
+
+    def test_versions_page_view_with_section(self):
+        response = self.client.get('/reg-landing/1002/versions/4/')
+        self.assertEqual(response.status_code, 200)
         self.assertIn(
-            b'JAN 18, 2014',
+            b'href="/reg-landing/1002/2011-01-01/4/"',
             response.content
         )
 

--- a/cfgov/regulations3k/tests/test_resolver.py
+++ b/cfgov/regulations3k/tests/test_resolver.py
@@ -101,7 +101,9 @@ class ReferenceResolutionTestCase(TestCase):
         self.assertIsNone(paragraph)
 
     def test_get_contents_resolver(self):
-        contents_resolver = get_contents_resolver(self.reg_page)
+        contents_resolver = get_contents_resolver(
+            self.reg_page.regulation.effective_version
+        )
         result = regdown(
             self.section_2.contents,
             contents_resolver=contents_resolver,
@@ -110,7 +112,9 @@ class ReferenceResolutionTestCase(TestCase):
         self.assertIn('Interpreting adverse action', result)
 
     def test_get_contents_resolver_reference_doesnt_exist(self):
-        contents_resolver = get_contents_resolver(self.reg_page)
+        contents_resolver = get_contents_resolver(
+            self.reg_page.regulation.effective_version
+        )
         result = regdown(
             self.section_3.contents,
             contents_resolver=contents_resolver,

--- a/cfgov/unprocessed/apps/regulations3k/css/reg-text.less
+++ b/cfgov/unprocessed/apps/regulations3k/css/reg-text.less
@@ -40,3 +40,9 @@
         white-space: normal;
     }
 }
+
+// Helper class to correct regs3k notifications alignment
+.block__flush-regs3k {
+    margin-top: -30px;
+    margin-bottom: 30px;
+}


### PR DESCRIPTION
This PR makes it possible to navigate versions in the Regulations 3000 UI and makes changes to the way effective dates are shown to users on the current law version of a regulation.

This PR will replace the use of the Text Introduction heading and links with the hard-coded use of the page's title and generated links to versions and search. So all of those should be removed from the Text Introduction block on a Regulation page otherwise you'll see double.

## Testing

1. Load past versions JSON or a database dump containing them (see chat), or create copies of effective versions with future or past effective dates.
2. Browse the regulation and navigate between versions using the "View all versions of this regulation" links.

## Screenshots

- **Current law**
   - Landing page: 
      ![image](https://user-images.githubusercontent.com/10562538/45370193-b24e8b00-b5b5-11e8-8ce7-ad8b7c7b55f7.png)
   - Section page: 
      ![image](https://user-images.githubusercontent.com/10562538/45370726-ce9ef780-b5b6-11e8-8854-11447d2e6cc7.png)

- **Past version**
   - Landing page: 
      ![image](https://user-images.githubusercontent.com/10562538/45370791-f55d2e00-b5b6-11e8-9f49-546664e985a8.png)
   - Section page: 
      ![image](https://user-images.githubusercontent.com/10562538/45370761-e5454e80-b5b6-11e8-8818-38cc23d4d2ca.png)


- **Future version**
   - Landing page: 
      ![image](https://user-images.githubusercontent.com/10562538/45370925-42d99b00-b5b7-11e8-9d39-00010b75eb1e.png)
   - Section page: 
      ![image](https://user-images.githubusercontent.com/10562538/45370944-51c04d80-b5b7-11e8-8df1-26e6236af68c.png)

- **All versions**
   ![image](https://user-images.githubusercontent.com/10562538/45370902-38b79c80-b5b7-11e8-8a77-052ca9adff86.png)



## Todos

- There is epic amounts of space on the landing page between the Wagtail and effective version-related bits. @contolini do you mind taking a look and seeing if there are better elements we can use there?
- Future effective versions *do not* show up on the main regulations listing landing page yet. That will be done in a future PR.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
