### PR TITLE
Change "BCFP" to "Bureau" in recent notice list

### DIFF
--- a/cfgov/regulations3k/jinja2/regulations3k/recent-notices.html
+++ b/cfgov/regulations3k/jinja2/regulations3k/recent-notices.html
@@ -7,7 +7,7 @@
         </header>
         <ul class="m-list m-list__links" id="regs3k-notices">
             <li class="m-list_item">
-                <a href="https://www.federalregister.gov/agencies/consumer-financial-protection-bureau" class="m-list_link">View all recent BCFP notices</a>
+                <a href="https://www.federalregister.gov/agencies/consumer-financial-protection-bureau" class="m-list_link">View all recent Bureau notices</a>
             </li>
         </ul>
     </div>

--- a/cfgov/unprocessed/apps/regulations3k/js/recent-notices.js
+++ b/cfgov/unprocessed/apps/regulations3k/js/recent-notices.js
@@ -18,7 +18,7 @@ const processNotices = notices => {
   const html = document.createDocumentFragment();
   const lastNotice = {
     html_url: CFPB_NOTICES,
-    title: 'More BCFP notices'
+    title: 'More Bureau notices'
   };
   notices.forEach( notice => {
     html.appendChild( processNotice( notice ) );


### PR DESCRIPTION
Change "BCFP" to "Bureau" in the list of recently issued notices on the interactive Bureau regulations landing page

## Changes

- "BCFP" to "Bureau" at the end of the list of recently issued notices on the interactive Bureau regulations landing page

## Testing

1. Fire up cf.gov as usual
2. Go to `/policy-compliance/rulemaking/regulations/`
3. Check to make sure the link at the bottom of the list of recently issued notices in the sidebar says "More Bureau notices" instead of "More BCFP notices"
4. Quintuple check to make sure I spelled "bureau" right 😄

## Screenshots

Previous | Updated
-------- | ---------
![previous](https://user-images.githubusercontent.com/1862695/45382849-8ba14c00-b5d7-11e8-9af6-f79e06ca9060.png) | ![updated](https://user-images.githubusercontent.com/1862695/45382855-8f34d300-b5d7-11e8-9912-39019fdae623.png)

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [x] Chrome
- [x] Firefox
- [x] Safari
- [x] Internet Explorer 8, 9, 10, and 11
- [x] Edge
- [x] iOS Safari
- [x] Chrome for Android

### Accessibility

- [x] Keyboard friendly
- [x] Screen reader friendly

### Other

- [x] Is useable without CSS
- [x] Is useable without JS
- [x] Flexible from small to large screens
- [x] No linting errors or warnings
- [x] JavaScript tests are passing