### PR TITLE
Fix big icon on Spanish site

### DIFF
--- a/cfgov/legacy/static/nemo/_/c/less/es-styles.less
+++ b/cfgov/legacy/static/nemo/_/c/less/es-styles.less
@@ -7,4 +7,5 @@
 @import "vars.less";
 @import "grid.less";
 @import "fonts.less";
+@import "icons.less";
 @import "es-base.less";

--- a/cfgov/legacy/static/nemo/_/c/less/icons.less
+++ b/cfgov/legacy/static/nemo/_/c/less/icons.less
@@ -1,0 +1,55 @@
+/* ==========================================================================
+   Capital Framework
+   Icons
+   ========================================================================== */
+
+//
+// Theme variables
+//
+
+//
+// Size variables
+//
+
+// Icon height matches the 19px rendered canvas of text set in Avenir Next
+// sized at 16px ( 19/16 = 1.1875 )
+@cf-icon-height: 1.1875em;
+
+
+//
+// The basics
+//
+
+.cf-icon-svg {
+    height: @cf-icon-height;
+    vertical-align: text-top;
+    fill: currentColor;
+
+    // IE 10 & 11 require a max-width otherwise the SVG takes up 100%
+    max-width: 1em;
+
+    .lt-ie10 & {
+        // IE 9 require a width otherwise the SVG takes up 100%
+        width: 1em;
+    }
+
+    .lt-ie9 & {
+        // IE 8 doesn't support currentColor, hide icons and let the paired
+        // text stand on its own
+        display: none;
+    }
+
+    &__updating {
+        animation: updating-animation 1.25s infinite linear;
+        transform-origin: 50% 50%;
+    }
+}
+
+@keyframes updating-animation {
+    0% {
+        transform: rotate( 0deg );
+    }
+    100% {
+        transform: rotate( 359deg );
+    }
+}


### PR DESCRIPTION
There's a giant icon on the Spanish homepage caused by the page now being run through the `parse_links` middleware, adding an external link icon to a link that didn't used to have one. This PR copies the standard `.cf-icon-svg` Less into the Spanish styles so that the icon is sized and colored appropriately.

## Additions

- SVG icon styles added to the Spanish stylesheet

## Testing

1. Pull branch
1. `gulp styles`
1. Load http://localhost:8000/es/ and see a normally sized icon, in the same color as the link

## Screenshots

### Before

<img width="320" alt="screen shot 2018-09-11 at 15 44 10" src="https://user-images.githubusercontent.com/1044670/45383564-99f06780-b5d9-11e8-9264-b43e101ae205.png">

### After

<img width="320" alt="screen shot 2018-09-11 at 15 44 37" src="https://user-images.githubusercontent.com/1044670/45383583-a07edf00-b5d9-11e8-93fc-27cb18ab0d35.png">

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [x] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [ ] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Internet Explorer 8, 9, 10, and 11
- [ ] Edge
- [ ] iOS Safari
- [ ] Chrome for Android
