### PR TITLE
TDP: don't check for wagtail URLs below curriculum-review page

### DIFF
--- a/cfgov/cfgov/urls.py
+++ b/cfgov/cfgov/urls.py
@@ -422,7 +422,7 @@ urlpatterns = [
 
     flagged_wagtail_only_view(
         'TDP_CRTOOL',
-        r'^practitioner-resources/youth-financial-education/curriculum-review/'),  # noqa: E501
+        r'^practitioner-resources/youth-financial-education/curriculum-review/$'),  # noqa: E501
 
     flagged_url('TDP_BB_TOOL',
         r'^practitioner-resources/youth-financial-education/tour',  # noqa: E501


### PR DESCRIPTION
Fix bug that caused the CR tool pages to display page not found.

URLs to test:

- https://www.consumerfinance.gov/practitioner-resources/youth-financial-education/curriculum-review/
- https://www.consumerfinance.gov/practitioner-resources/youth-financial-education/curriculum-review/tool
- https://www.consumerfinance.gov/practitioner-resources/youth-financial-education/curriculum-review/before-you-begin

## Reviewers

@atuggle @Scotchester @chosak @willbarton @higs4281 

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
