### PR TITLE
Revert "Bump college-costs version from 2.3.12 to 2.4.0"

### DIFF
--- a/requirements/optional-public.txt
+++ b/requirements/optional-public.txt
@@ -1,4 +1,4 @@
-https://github.com/cfpb/college-costs/releases/download/2.4.0/college_costs-2.4.0-py2-none-any.whl
+https://github.com/cfpb/college-costs/releases/download/2.3.12/college_costs-2.3.12-py2-none-any.whl
 https://github.com/cfpb/owning-a-home-api/releases/download/0.11.0/owning_a_home_api-0.11.0-py2-none-any.whl
 https://github.com/cfpb/regulations-core/releases/download/1.2.6/regcore-1.2.6-py2-none-any.whl
 https://github.com/cfpb/regulations-site/releases/download/2.2.5/regulations-2.2.5-py2-none-any.whl


### PR DESCRIPTION
Reverts cfpb/cfgov-refresh#4504.

This might introduce some breakage into the build due to missing CF icons. In combination with [these changes](https://github.com/cfpb/cfgov-refresh/commit/b5d8455c24c9183e11306c01ba3ac3f2a2d1f3ec) in the as-yet-unmerged `eot-icons` branch, the college-costs bump seems to lead to a `collectstatic` error in the builds.