### PR TITLE
Redirect Regs3K paragraph hashes

### DIFF
--- a/cfgov/unprocessed/apps/regulations3k/js/index.js
+++ b/cfgov/unprocessed/apps/regulations3k/js/index.js
@@ -2,6 +2,7 @@ import Expandable from 'cf-expandables/src/Expandable';
 import { bindEvent } from '../../../js/modules/util/dom-events';
 import { queryOne as find } from '../../../js/modules/util/dom-traverse';
 import { handleContentClick, handleNavClick } from './analytics';
+import utils from './regs3k-utils';
 
 const navHeader = find( '.o-regs3k-navigation_header' );
 const navItems = find( '.o-regs3k-sections' );
@@ -52,6 +53,9 @@ const init = () => {
     navItems.classList.add( 'u-hide-on-stacked' );
     bindSecondaryNav();
     bindAnalytics();
+  }
+  if ( utils.isOldHash( window.location.hash ) ) {
+    window.location.hash = utils.getNewHash( window.location.hash );
   }
 };
 

--- a/cfgov/unprocessed/apps/regulations3k/js/regs3k-utils.js
+++ b/cfgov/unprocessed/apps/regulations3k/js/regs3k-utils.js
@@ -1,10 +1,41 @@
 import { ajaxRequest as xhr } from '../../../js/modules/util/ajax-request';
 
+
+/**
+ * fetch - Wrapper for our ajax request method with callback support
+ *
+ * @param {string} url URL to request
+ * @param {function} cb  Success/failure callback
+ *
+ * @returns {object} XMLHttpRequest object
+ */
 const fetch = ( url, cb ) => xhr( 'GET', url, {
   success: data => cb( null, data ),
   fail: err => cb( err )
 } );
 
+const getNewHash = hash => {
+  if ( ( /(\w+-)+Interp-/ ).test( hash ) ) {
+    // Trim off DDDD- e.g. 1003-2-f-Interp-3 becomes 2-f-Interp-3
+    return hash.replace( /^#?\d\d\d\d-/, '' );
+  }
+  // Trim off DDDD-D- e.g. 1003-4-a-9-ii-C becomes a-9-ii-C
+  return hash.replace( /^#?\d\d\d\d-\w+-/, '' );
+};
+
+
+/**
+ * isOldHash - Check if provided hash is from the old eRegs site
+ * All the former eRegs paragraph markers start with their four-digit reg.
+ *
+ * @param {string} hash URL hash
+ *
+ * @returns {boolean} true/false
+ */
+const isOldHash = hash => ( /^#?\d\d\d\d/ ).test( hash );
+
 module.exports = {
-  fetch
+  fetch,
+  getNewHash,
+  isOldHash
 };

--- a/test/unit_tests/apps/regulations3k/js/regs3k-utils-spec.js
+++ b/test/unit_tests/apps/regulations3k/js/regs3k-utils-spec.js
@@ -1,47 +1,89 @@
 const BASE_JS_PATH = '../../../../../cfgov/unprocessed/apps/regulations3k';
 
-const { fetch } = require( `${ BASE_JS_PATH }/js/regs3k-utils.js` );
+const utils = require( `${ BASE_JS_PATH }/js/regs3k-utils.js` );
 
 describe( 'The Regs3K search utils', () => {
 
-  it( 'should fetch a resource', done => {
-    const mockXHR = {
-      open: jest.fn(),
-      send: jest.fn(),
-      readyState: 4,
-      status: 200,
-      onreadystatechange: jest.fn(),
-      responseText: [
-        { searchResult: 'one' },
-        { anotherSearchResult: 'two' }
-      ]
-    };
-    global.XMLHttpRequest = jest.fn( () => mockXHR );
-    fetch( 'api/search', ( err, data ) => {
-      expect( err ).toEqual( null );
-      expect( data ).toEqual(
-        [ { searchResult: 'one' }, { anotherSearchResult: 'two' } ]
-      );
-      done();
+  describe( 'AJAX utils', () => {
+
+    it( 'should fetch a resource', done => {
+      const mockXHR = {
+        open: jest.fn(),
+        send: jest.fn(),
+        readyState: 4,
+        status: 200,
+        onreadystatechange: jest.fn(),
+        responseText: [
+          { searchResult: 'one' },
+          { anotherSearchResult: 'two' }
+        ]
+      };
+      global.XMLHttpRequest = jest.fn( () => mockXHR );
+      utils.fetch( 'api/search', ( err, data ) => {
+        expect( err ).toEqual( null );
+        expect( data ).toEqual(
+          [ { searchResult: 'one' }, { anotherSearchResult: 'two' } ]
+        );
+        done();
+      } );
+      mockXHR.onreadystatechange();
     } );
-    mockXHR.onreadystatechange();
+
+    it( 'should fail to fetch a resource', done => {
+      const mockXHR = {
+        open: jest.fn(),
+        send: jest.fn(),
+        readyState: 4,
+        status: 404,
+        onreadystatechange: jest.fn(),
+        responseText: 'Server error!'
+      };
+      global.XMLHttpRequest = jest.fn( () => mockXHR );
+      utils.fetch( 'api/search', err => {
+        expect( err ).toEqual( 404 );
+        done();
+      } );
+      mockXHR.onreadystatechange();
+    } );
+
   } );
 
-  it( 'should fail to fetch a resource', done => {
-    const mockXHR = {
-      open: jest.fn(),
-      send: jest.fn(),
-      readyState: 4,
-      status: 404,
-      onreadystatechange: jest.fn(),
-      responseText: 'Server error!'
-    };
-    global.XMLHttpRequest = jest.fn( () => mockXHR );
-    fetch( 'api/search', err => {
-      expect( err ).toEqual( 404 );
-      done();
+  describe( 'Hash utils', () => {
+
+    it( 'should convert a hash', () => {
+      expect( utils.getNewHash( '1010-Interp-1' ) ).toEqual( 'Interp-1' );
+      expect( utils.getNewHash( '#1010-Interp-1' ) ).toEqual( 'Interp-1' );
+
+      expect( utils.getNewHash( '1011-4-a' ) ).toEqual( 'a' );
+      expect( utils.getNewHash( '#1011-4-a' ) ).toEqual( 'a' );
+
+      expect( utils.getNewHash( '1003-2-f-Interp-3' ) ).toEqual( '2-f-Interp-3' );
+      expect( utils.getNewHash( '#1003-2-f-Interp-3' ) ).toEqual( '2-f-Interp-3' );
+
+      expect( utils.getNewHash( '1003-4-a-9-ii-C' ) ).toEqual( 'a-9-ii-C' );
+      expect( utils.getNewHash( '#1003-4-a-9-ii-C' ) ).toEqual( 'a-9-ii-C' );
     } );
-    mockXHR.onreadystatechange();
+
+    it( 'should check if a hash needs to be converted', () => {
+      expect( utils.isOldHash( '1010-Interp-1' ) ).toBeTrue;
+      expect( utils.isOldHash( '#1010-Interp-1' ) ).toBeTrue;
+
+      expect( utils.isOldHash( '101-Interp-1' ) ).toBeFalse;
+      expect( utils.isOldHash( '#101-Interp-1' ) ).toBeFalse;
+
+      expect( utils.isOldHash( '1003-2-f-Interp-3' ) ).toBeTrue;
+      expect( utils.isOldHash( '#1003-2-f-Interp-3' ) ).toBeTrue;
+
+      expect( utils.isOldHash( '003-2-f-Interp-3' ) ).toBeFalse;
+      expect( utils.isOldHash( '#003-2-f-Interp-3' ) ).toBeFalse;
+
+      expect( utils.isOldHash( 'bloop' ) ).toBeFalse;
+      expect( utils.isOldHash( '#bloop' ) ).toBeFalse;
+
+      expect( utils.isOldHash( 'asdf-2-f-Interp-3' ) ).toBeFalse;
+      expect( utils.isOldHash( '#asdf-2-f-Interp-3' ) ).toBeFalse;
+    } );
+
   } );
 
 } );


### PR DESCRIPTION
The old eRegs had paragraph IDs in a different format than the new
Regs3K. After the page loads, convert the paragraph markers to the new
format and jump the user to the correct paragraph (if found).

## Testing

1. `./frontend.sh`
1. Visit http://localhost:8000/eregulations/1003-4/2017-18284_20180101#1003-4-a-9-ii-C and see if it redirects you to the correct regs3k paragraph
1. Visit http://localhost:8000/eregulations/1003-Subpart-Interp/2017-18284_20180101#1003-2-f-Interp-3 and see if it redirects you to the correct interp paragraph.

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Internet Explorer 8, 9, 10, and 11
- [ ] Edge
- [ ] iOS Safari
- [ ] Chrome for Android

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
