### PR TITLE
Remove eRegulations

### DIFF
--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -94,8 +94,6 @@ OPTIONAL_APPS = [
     {'import': 'retirement_api', 'apps': ('retirement_api',)},
     {'import': 'ratechecker', 'apps': ('ratechecker', 'rest_framework')},
     {'import': 'countylimits', 'apps': ('countylimits', 'rest_framework')},
-    {'import': 'regcore', 'apps': ('regcore', 'regcore_read')},
-    {'import': 'regulations', 'apps': ('regulations',)},
     {'import': 'complaint_search', 'apps': ('complaint_search', 'rest_framework')},
     {'import': 'ccdb5_ui', 'apps': ('ccdb5_ui', )},
     {'import': 'teachers_digital_platform', 'apps': ('teachers_digital_platform', 'mptt', 'haystack')},
@@ -447,9 +445,6 @@ LOGIN_FAILS_ALLOWED = os.environ.get('LOGIN_FAILS_ALLOWED', 5)
 LOGIN_REDIRECT_URL = '/login/welcome/'
 LOGIN_URL = "/login/"
 
-# The base URL for the API that we use to access layers and the regulation.
-API_BASE = os.environ.get('EREGS_API_BASE', '')
-
 # When we generate an full HTML version of the regulation, we want to
 # write it out somewhere. This is where.
 OFFLINE_OUTPUT_DIR = ''
@@ -458,21 +453,6 @@ DATE_FORMAT = 'n/j/Y'
 
 GOOGLE_ANALYTICS_ID = ''
 GOOGLE_ANALYTICS_SITE = ''
-
-CACHE_MIDDLEWARE_ALIAS = 'default'
-CACHE_MIDDLEWARE_KEY_PREFIX = 'eregs'
-CACHE_MIDDLEWARE_SECONDS = 1800
-
-# eRegs
-BACKENDS = {
-    'regulations': 'regcore.db.django_models.DMRegulations',
-    'layers': 'regcore.db.django_models.DMLayers',
-    'notices': 'regcore.db.django_models.DMNotices',
-    'diffs': 'regcore.db.django_models.DMDiffs',
-}
-
-# Regulations in eRegs that should display the update-in-progress message
-EREGS_REGULATION_UPDATES = ['1002', '1003', '1005', '1010', '1011', '1012', '1013', '1024', '1026']
 
 # Regulations.gov environment variables
 REGSGOV_BASE_URL = os.environ.get('REGSGOV_BASE_URL')
@@ -665,9 +645,6 @@ FLAGS = {
 
     # Ping google on page publication in production only
     'PING_GOOGLE_ON_PUBLISH': {'environment is': 'production'},
-
-    # Feature flag to enable our replacement for eRegs and disable eRegs
-    'REGULATIONS3K': {},
 
     'LEGACY_HUD_API': {'environment is': 'production'},
 

--- a/cfgov/cfgov/settings/local.py
+++ b/cfgov/cfgov/settings/local.py
@@ -56,7 +56,7 @@ CACHES.update({
         'BACKEND': 'django.core.cache.backends.dummy.DummyCache',
         'TIMEOUT': 0,
     } for k in (
-        'default', 'eregs_longterm_cache', 'api_cache', 'post_preview'
+        'default', 'post_preview'
     )
 })
 

--- a/cfgov/cfgov/settings/production.py
+++ b/cfgov/cfgov/settings/production.py
@@ -89,22 +89,6 @@ CACHES.update({
         'BACKEND': 'django.core.cache.backends.filebased.FileBasedCache',
         'LOCATION': '/tmp/eregs_cache',
     },
-    'eregs_longterm_cache': {
-        'BACKEND': 'django.core.cache.backends.filebased.FileBasedCache',
-        'LOCATION': '/tmp/eregs_longterm_cache',
-        'TIMEOUT': 60*60*24*15,     # 15 days
-        'OPTIONS': {
-            'MAX_ENTRIES': 10000,
-        },
-    },
-    'api_cache': {
-        'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
-        'LOCATION': 'api_cache_memory',
-        'TIMEOUT': 3600,
-        'OPTIONS': {
-            'MAX_ENTRIES': 1000,
-        },
-    },
     'post_preview': {
         'BACKEND': 'django.core.cache.backends.db.DatabaseCache',
         'LOCATION': 'post_preview_cache',

--- a/cfgov/cfgov/urls.py
+++ b/cfgov/cfgov/urls.py
@@ -431,15 +431,7 @@ urlpatterns = [
         include_if_app_enabled('teachers_digital_platform',
                                     'teachers_digital_platform.bb_urls')),
 
-    flagged_url(
-        'REGULATIONS3K',
-        r'^policy-compliance/rulemaking/regulations/',
-        lambda request: ServeView.as_view()(request, request.path),
-        fallback=page_not_found,
-        name='regulations'
-    ),
-    flagged_url(
-        'REGULATIONS3K',
+    url(
         r'^regulations3k-service-worker.js',
         TemplateView.as_view(
         template_name='regulations3k/regulations3k-service-worker.js',
@@ -447,22 +439,8 @@ urlpatterns = [
         name='regulations3k-service-worker.js'
     ),
 
-    # Include eRegulations URLs only if the REGULATIONS3K flag state is False
-    flagged_url(
-        'REGULATIONS3K',
-        r'^eregs-api/.*',
-        include_if_app_enabled('regcore', 'regcore.urls'),
-        fallback=page_not_found,
-        state=False
-    ),
-    flagged_url(
-        'REGULATIONS3K',
-        r'^eregulations/.*',
-        include_if_app_enabled('regulations', 'regulations.urls'),
-        fallback=redirect_eregs,
-        name='eregs-redirect',
-        state=False
-    ),
+    # Explicitly redirect eRegulations URLs to Regulations3000
+    url(r'^eregulations/.*', redirect_eregs, name='eregs-redirect'),
 
 ]
 

--- a/cfgov/core/static/robots.txt
+++ b/cfgov/core/static/robots.txt
@@ -6,6 +6,5 @@ Disallow: /external-site
 Disallow: /*?success
 Disallow: *form-id=*
 Disallow: /?page=
-Disallow: /eregulations
 
 sitemap: https://www.consumerfinance.gov/sitemap.xml

--- a/requirements/optional-public.txt
+++ b/requirements/optional-public.txt
@@ -1,7 +1,5 @@
 https://github.com/cfpb/college-costs/releases/download/2.3.12/college_costs-2.3.12-py2-none-any.whl
 https://github.com/cfpb/owning-a-home-api/releases/download/0.11.0/owning_a_home_api-0.11.0-py2-none-any.whl
-https://github.com/cfpb/regulations-core/releases/download/1.2.6/regcore-1.2.6-py2-none-any.whl
-https://github.com/cfpb/regulations-site/releases/download/2.2.5/regulations-2.2.5-py2-none-any.whl
 https://github.com/cfpb/retirement/releases/download/0.7.1/retirement-0.7.1-py2-none-any.whl
 git+https://github.com/cfpb/ccdb5-api.git@v1.0.6#egg=ccdb5-api
 git+https://github.com/cfpb/ccdb5-ui.git@v1.0.11#egg=ccdb5_ui


### PR DESCRIPTION
This PR removes the eRegulations dependencies and related configuration. This should enable us to proceed with the Django 1.11 upgrade.

~~I'm putting a hold label on this for right now until the launch dust clears for Regs3k.~~

## Removals

- eRegulations

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

