### PR TITLE
regsek: Fix redirect errors

### DIFF
--- a/cfgov/cfgov/urls.py
+++ b/cfgov/cfgov/urls.py
@@ -450,7 +450,7 @@ urlpatterns = [
     # Include eRegulations URLs only if the REGULATIONS3K flag state is False
     flagged_url(
         'REGULATIONS3K',
-        r'^eregs-api/',
+        r'^eregs-api/.*',
         include_if_app_enabled('regcore', 'regcore.urls'),
         fallback=page_not_found,
         state=False

--- a/cfgov/cfgov/urls.py
+++ b/cfgov/cfgov/urls.py
@@ -457,7 +457,7 @@ urlpatterns = [
     ),
     flagged_url(
         'REGULATIONS3K',
-        r'^eregulations/',
+        r'^eregulations/.*',
         include_if_app_enabled('regulations', 'regulations.urls'),
         fallback=redirect_eregs,
         name='eregs-redirect',

--- a/cfgov/regulations3k/tests/test_views.py
+++ b/cfgov/regulations3k/tests/test_views.py
@@ -2,7 +2,6 @@ from __future__ import unicode_literals
 
 import datetime
 
-from django.http import Http404
 from django.test import RequestFactory, TestCase, override_settings
 
 from model_mommy import mommy
@@ -49,8 +48,10 @@ class RedirectRegulations3kTestCase(TestCase):
     def test_redirect_invalid_part(self):
         request = self.factory.get(
             '/eregulations/1020-1/2017-20417_20180101#1002-1')
-        with self.assertRaises(Http404):
-            redirect_eregs(request)
+        response = redirect_eregs(request)
+        self.assertEqual(
+            response.get('location'),
+            '/policy-compliance/rulemaking/regulations/')
 
     def test_version_redirect(self):
         request = self.factory.get(
@@ -85,8 +86,7 @@ class RedirectRegulations3kTestCase(TestCase):
         response = redirect_eregs(request)
         self.assertEqual(
             response.get('location'),
-            '/policy-compliance/rulemaking/regulations/1002/'
-            '2016-07-11/Interp-C/')
+            '/policy-compliance/rulemaking/regulations/1002/')
 
     def test_interp_appendix_invalid_date(self):
         request = self.factory.get(
@@ -95,7 +95,7 @@ class RedirectRegulations3kTestCase(TestCase):
         response = redirect_eregs(request)
         self.assertEqual(
             response.get('location'),
-            '/policy-compliance/rulemaking/regulations/1024/Interp-MS/')
+            '/policy-compliance/rulemaking/regulations/1024/')
 
     def test_interp_intro(self):
         request = self.factory.get(
@@ -120,8 +120,7 @@ class RedirectRegulations3kTestCase(TestCase):
         response = redirect_eregs(request)
         self.assertEqual(
             response.get('location'),
-            '/policy-compliance/rulemaking/regulations/1002/'
-            '2016-07-11/Interp-1/')
+            '/policy-compliance/rulemaking/regulations/1002/')
 
     def test_interp_section_current(self):
         request = self.factory.get(
@@ -130,7 +129,7 @@ class RedirectRegulations3kTestCase(TestCase):
         response = redirect_eregs(request)
         self.assertEqual(
             response.get('location'),
-            '/policy-compliance/rulemaking/regulations/1002/Interp-1/')
+            '/policy-compliance/rulemaking/regulations/1002/')
 
     def test_get_version_date_bad_doc_number(self):
         part = '1002'

--- a/cfgov/regulations3k/views.py
+++ b/cfgov/regulations3k/views.py
@@ -214,4 +214,4 @@ def redirect_eregs(request, **kwargs):
                             new_base, part, section), permanent=True)
             else:
                 return redirect("{}{}/".format(new_base, part), permanent=True)
-    return redirect("{}{}/".format(new_base, part), permanent=True)
+    return redirect(new_base)

--- a/cfgov/regulations3k/views.py
+++ b/cfgov/regulations3k/views.py
@@ -156,62 +156,62 @@ def redirect_eregs(request, **kwargs):
         return redirect("{}search-regulations/results/?regs={}&q={}".format(
             new_base, part, query), permanent=True)
     part_match = re.match(r'/eregulations/(\d{4})', original_url)
-    if part_match:
-        if part_match.group(1) in VERSION_MAP:
-            part = part_match.group(1)
+    if not part_match:
+        return redirect(new_base)
+    if part_match.group(1) in VERSION_MAP:
+        part = part_match.group(1)
+    else:
+        return redirect(new_base, permanent=True)
+    if original_url == "{}{}".format(original_base, part):
+        return redirect("{}{}/".format(new_base, part), permanent=True)
+    for pattern in [SECTION_RE, APPENDIX_RE]:
+        match_base = pattern.match(original_url)
+        if match_base:
+            (section, doc) = (match_base.group(1), match_base.group(2))
+            # permanently redirect current or unknown versions
+            if doc not in VERSION_MAP[part]:
+                return redirect("{}{}/{}/".format(
+                    new_base, part, section, permanent=True))
+            version_date = get_version_date(part, doc)
+            # if known version is not ready, temp redirect to current
+            if not version_date:
+                return redirect("{}{}/{}/".format(
+                    new_base, part, section))
+            # permanently redirect known, ready versions
+            return redirect("{}{}/{}/{}/".format(
+                new_base, part, version_date, section),
+                permanent=True)
+    for pattern in [INTERP_INTRO_RE,
+                    INTERP_APPENDIX_RE,
+                    INTERP_SECTION_RE]:
+        match_base = pattern.match(original_url)
+        if match_base:
+            doc = match_base.group(1)
+            version_date = get_version_date(part, doc)
+            if pattern == INTERP_INTRO_RE:
+                if version_date:
+                    return redirect("{}{}/{}/h1-Interp/".format(
+                        new_base, part, version_date), permanent=True)
+                else:
+                    return redirect("{}{}/Interp-0/".format(
+                        new_base, part), permanent=True)
+            if pattern == INTERP_APPENDIX_RE:
+                appendix = INTERP_APPENDIX_DEFAULTS.get(part, 'A')
+                if version_date:
+                    return redirect("{}{}/{}/Interp-{}/".format(
+                        new_base, part, version_date,
+                        appendix), permanent=True)
+                else:
+                    return redirect("{}{}/Interp-{}/".format(
+                        new_base, part, appendix), permanent=True)
+            if pattern == INTERP_SECTION_RE:
+                section = INTERP_SECTION_DEFAULTS.get(part, '1')
+                if version_date:
+                    return redirect("{}{}/{}/Interp-{}/".format(
+                        new_base, part, version_date,
+                        section), permanent=True)
+                else:
+                    return redirect("{}{}/Interp-{}/".format(
+                        new_base, part, section), permanent=True)
         else:
-            return redirect(new_base, permanent=True)
-        if original_url == "{}{}".format(original_base, part):
             return redirect("{}{}/".format(new_base, part), permanent=True)
-        for pattern in [SECTION_RE, APPENDIX_RE]:
-            match_base = pattern.match(original_url)
-            if match_base:
-                (section, doc) = (match_base.group(1), match_base.group(2))
-                # permanently redirect current or unknown versions
-                if doc not in VERSION_MAP[part]:
-                    return redirect("{}{}/{}/".format(
-                        new_base, part, section, permanent=True))
-                version_date = get_version_date(part, doc)
-                # if known version is not ready, temp redirect to current
-                if not version_date:
-                    return redirect("{}{}/{}/".format(
-                        new_base, part, section))
-                # permanently redirect known, ready versions
-                return redirect("{}{}/{}/{}/".format(
-                    new_base, part, version_date, section),
-                    permanent=True)
-        for pattern in [INTERP_INTRO_RE,
-                        INTERP_APPENDIX_RE,
-                        INTERP_SECTION_RE]:
-            match_base = pattern.match(original_url)
-            if match_base:
-                doc = match_base.group(1)
-                version_date = get_version_date(part, doc)
-                if pattern == INTERP_INTRO_RE:
-                    if version_date:
-                        return redirect("{}{}/{}/h1-Interp/".format(
-                            new_base, part, version_date), permanent=True)
-                    else:
-                        return redirect("{}{}/Interp-0/".format(
-                            new_base, part), permanent=True)
-                if pattern == INTERP_APPENDIX_RE:
-                    appendix = INTERP_APPENDIX_DEFAULTS.get(part, 'A')
-                    if version_date:
-                        return redirect("{}{}/{}/Interp-{}/".format(
-                            new_base, part, version_date,
-                            appendix), permanent=True)
-                    else:
-                        return redirect("{}{}/Interp-{}/".format(
-                            new_base, part, appendix), permanent=True)
-                if pattern == INTERP_SECTION_RE:
-                    section = INTERP_SECTION_DEFAULTS.get(part, '1')
-                    if version_date:
-                        return redirect("{}{}/{}/Interp-{}/".format(
-                            new_base, part, version_date,
-                            section), permanent=True)
-                    else:
-                        return redirect("{}{}/Interp-{}/".format(
-                            new_base, part, section), permanent=True)
-            else:
-                return redirect("{}{}/".format(new_base, part), permanent=True)
-    return redirect(new_base)

--- a/cfgov/regulations3k/views.py
+++ b/cfgov/regulations3k/views.py
@@ -215,3 +215,4 @@ def redirect_eregs(request, **kwargs):
                         new_base, part, section), permanent=True)
         else:
             return redirect("{}{}/".format(new_base, part), permanent=True)
+    return redirect(new_base)


### PR DESCRIPTION
Our redirect URL wasn't greedy enough, and some interpretation requests weren't matching.

Interp matching still needs work.