### PR TITLE
Update Regs3K homepage in app manifest

### DIFF
--- a/cfgov/unprocessed/apps/regulations3k/regulations3k-manifest.json
+++ b/cfgov/unprocessed/apps/regulations3k/regulations3k-manifest.json
@@ -56,5 +56,5 @@
       "sizes": "512x512"
     }
   ],
-  "start_url": "/regulations/?utm_source=homescreen"
+  "start_url": "/policy-compliance/rulemaking/regulations/?utm_source=homescreen"
 }


### PR DESCRIPTION
Forgot to update the URL that's used when Regs3K is added to a user's home screen.

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Internet Explorer 8, 9, 10, and 11
- [ ] Edge
- [ ] iOS Safari
- [ ] Chrome for Android

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
