### PR TITLE
Check for a search count before rendering Regs3K results

### DIFF
--- a/cfgov/regulations3k/jinja2/regulations3k/search-regulations-results.html
+++ b/cfgov/regulations3k/jinja2/regulations3k/search-regulations-results.html
@@ -3,7 +3,7 @@
 {% import 'molecules/pagination.html' as pagination with context %}
 
 <div class="results_header">
-    {% if current_count > 0 %}
+    {% if current_count and current_count > 0 %}
     <div class="results_count">
         <h2 class="h3">
             Showing {{ current_count }}
@@ -43,6 +43,7 @@
     </div>
     {% endif %}
 </div>
+{% if current_count %}
 <div class="results_list">
     {% for result in results %}
         {{ search_item.render( result ) }}
@@ -51,3 +52,4 @@
 <div class="results_paginator">
     {{ pagination.render( paginator.num_pages, current_page, '', '', 'Previous', 'Next' ) }}
 </div>
+{% endif %}


### PR DESCRIPTION
The search results template barfs if either `current_count` or `paginator` are undefined. This happens when no query is provided by the user.

The solution is to only render those parts of the template if `current_count` is defined, meaning they provided a search query.

## Testing

See if http://localhost:8000/policy-compliance/rulemaking/regulations/search-regulations/results/?q=&partial=&regs=1024 returns `No results match your filters` instead of a 500 error.

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Internet Explorer 8, 9, 10, and 11
- [ ] Edge
- [ ] iOS Safari
- [ ] Chrome for Android

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
