### PR TITLE
Add 10.0.2.2 to INTERNAL_IPS to support Django Debug Toolbar in Docker

### DIFF
--- a/.env_SAMPLE
+++ b/.env_SAMPLE
@@ -189,3 +189,10 @@ if [ $(uname -s) = "Darwin" ]; then
   export ES_HOST=localhost
   source activate-virtualenv.sh
 fi
+
+###############################################
+# Django Debug Toolbar
+###############################################
+
+# Enable the debug toolbar.
+# export ENABLE_DEBUG_TOOLBAR=True

--- a/cfgov/cfgov/settings/local.py
+++ b/cfgov/cfgov/settings/local.py
@@ -40,7 +40,8 @@ LOGGING = {
 if os.environ.get('ENABLE_DEBUG_TOOLBAR'):
     INSTALLED_APPS += ('debug_toolbar',)
 
-    INTERNAL_IPS = ('127.0.0.1',)
+    INTERNAL_IPS = ('127.0.0.1', '10.0.2.2')
+
     MIDDLEWARE_CLASSES += ('debug_toolbar.middleware.DebugToolbarMiddleware',)
 
     DEBUG_TOOLBAR_CONFIG = {


### PR DESCRIPTION
This PR adds `10.0.2.2` to `INTERNAL_IPS` when `ENABLE_DEBUG_TOOLBAR` is set. This will allow usage of the Django Debug Toolbar in our Docker setup.

~~This PR makes the `INTERNAL_IPS` setting configurable to allow us to use Django Debug Toolbar in Docker when `ENABLE_DEBUG_TOOLBAR` is enabled.~~

~~This is a WIP because: @wpears @rosskarchner I'm not sure where the `10.0.2.2` IP address comes from, or whether it's specific to my machine. I discovered it by printing `request.META['REMOTE_ADDR']` in a request cycle to discover what IP requests from my Mac were coming from inside the python container. Is there a way we can make that information more easily discoverable? Is `10.0.2.2` consistent for everyone using our Docker setup?~~

## Testing

1. Add the following variable to your `.env` file:

   ```
   export ENABLE_DEBUG_TOOLBAR=''
   ```

2. Restart the `python` container
3. Visit http://localhost:8000 and observe that the Django Debug Toolbar is enabled.

## Todos

~~The source of the IP that needs to be added to enable the toolbar on docker needs to be documented.~~

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: