### PR TITLE
Add Django 1.11 compatibility to Wagtail only URLs

### DIFF
--- a/cfgov/cfgov/urls.py
+++ b/cfgov/cfgov/urls.py
@@ -5,9 +5,8 @@ from django.conf.urls import include, url
 from django.conf.urls.static import static
 from django.contrib import admin
 from django.contrib.auth import views as auth_views
-from django.http import HttpResponse
+from django.http import Http404, HttpResponse
 from django.shortcuts import render
-from django.views.defaults import page_not_found
 from django.views.generic.base import RedirectView, TemplateView
 
 from wagtail.contrib.wagtailsitemaps.views import sitemap
@@ -55,14 +54,15 @@ def flagged_wagtail_template_view(flag_name, template_name):
 
 
 def flagged_wagtail_only_view(flag_name, regex_path, url_name=None):
-    """ Teachers Digital Platform static pages are very similar so
-    in the name of DRY we are implementing them with this method.
-    """
+    """If flag is set, serve page from Wagtail, otherwise raise 404."""
+    def this_view_always_raises_http404(request, *args, **kwargs):
+        raise Http404('flag {} not set'.format(flag_name))
+
     return flagged_url(
         flag_name,
         regex_path,
         lambda request: ServeView.as_view()(request, request.path),
-        fallback=page_not_found,
+        fallback=this_view_always_raises_http404,
         name=url_name,
     )
 


### PR DESCRIPTION
The `flagged_wagtail_only_view` helper from urls.py is not compatible with Django 1.11 due to a signature change in Django 1.9:

https://docs.djangoproject.com/en/1.9/ref/views/#the-404-page-not-found-view

This change adds Django 1.11 compatibility to this helper, improves the docstring, and adds unit tests.

@schbetsy and I paired on this change. Shoutout to @willbarton for the very slick `@override_settings(ROOT_URLCONF=__name__)` trick.

FYI @atuggle.

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [X] Passes all existing automated tests
- [X] Any _change_ in functionality is tested
- [X] New functions are documented (with a description, list of inputs, and expected output)
- [X] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [X] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: