### PR TITLE
Bump optional college-costs version to 2.4.1

### DIFF
--- a/requirements/optional-public.txt
+++ b/requirements/optional-public.txt
@@ -1,4 +1,4 @@
-https://github.com/cfpb/college-costs/releases/download/2.3.12/college_costs-2.3.12-py2-none-any.whl
+https://github.com/cfpb/college-costs/releases/download/2.4.1/college_costs-2.4.1-py2-none-any.whl
 https://github.com/cfpb/owning-a-home-api/releases/download/0.11.0/owning_a_home_api-0.11.0-py2-none-any.whl
 https://github.com/cfpb/retirement/releases/download/0.7.1/retirement-0.7.1-py2-none-any.whl
 git+https://github.com/cfpb/ccdb5-api.git@v1.0.6#egg=ccdb5-api


### PR DESCRIPTION
This change bumps the version of the optional [college-costs](https://github.com/cfpb/college-costs) dependency from 2.3.12 to the new 2.4.1 release:

https://github.com/cfpb/college-costs/releases/tag/2.4.1

This change modernizes the frontend build and adds Django 1.11 support.

To test, pip install the new wheel file and visit the test page:

http://localhost:8000/paying-for-college2/understanding-your-financial-aid-offer/offer/test/

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [X] Passes all existing automated tests
- [X] Any _change_ in functionality is tested
- [X] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [X] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: