### PR TITLE
Ask CFPB: Add count check to avoid index errors

### DIFF
--- a/cfgov/ask_cfpb/models/pages.py
+++ b/cfgov/ask_cfpb/models/pages.py
@@ -274,12 +274,13 @@ class AnswerCategoryPage(RoutablePageMixin, SecondaryNavigationJSMixin,
     def get_context(self, request, *args, **kwargs):
         context = super(
             AnswerCategoryPage, self).get_context(request, *args, **kwargs)
-        sqs = SearchQuerySet().models(self.Category)
+        sqs = SearchQuerySet()
         if self.language == 'es':
             sqs = sqs.filter(content=self.ask_category.name_es)
         else:
             sqs = sqs.filter(content=self.ask_category.name)
-        if sqs:
+        sqs = sqs.models(self.Category)
+        if sqs.count() > 0:
             facet_map = sqs[0].facet_map
         else:
             facet_map = self.ask_category.facet_map

--- a/cfgov/ask_cfpb/tests/models/test_pages.py
+++ b/cfgov/ask_cfpb/tests/models/test_pages.py
@@ -894,6 +894,7 @@ class AnswerModelTestCase(TestCase):
 
     @mock.patch('ask_cfpb.models.pages.SearchQuerySet.models')
     def test_category_page_context_no_elasticsearch_count(self, mock_es_query):
+        """Ensure we fall back to the slower model method if ES returns 0."""
         mock_es_query.return_value = SearchQuerySet().none()
         request = self.factory.get('/ask-cfpb/category-stub-cat/')
         cat_page = self.create_category_page(ask_category=self.category)

--- a/cfgov/ask_cfpb/tests/test_template_tags.py
+++ b/cfgov/ask_cfpb/tests/test_template_tags.py
@@ -1,0 +1,23 @@
+from __future__ import unicode_literals
+
+from unittest import TestCase
+
+from ask_cfpb.templatetags.accent_stripper import strip_accents
+
+
+class StripAccentTests(TestCase):
+
+    def test_strip_unicode(self):
+        code_point_map = [
+            ('\N{LATIN SMALL LETTER N WITH TILDE}', 'n'),
+            ('\N{LATIN CAPITAL LETTER N WITH TILDE}', 'N'),
+            ('\N{LATIN CAPITAL LETTER O WITH ACUTE}', 'O'),
+            ('\N{LATIN SMALL LETTER A WITH ACUTE}', 'a'),
+            ('\N{LATIN SMALL LETTER E WITH ACUTE}', 'e'),
+            ('\N{LATIN SMALL LETTER I WITH ACUTE}', 'i'),
+            ('\N{INVERTED QUESTION MARK}', ''),
+        ]
+        for code in code_point_map:
+            self.assertEqual(
+                strip_accents(code[0]), code[1]
+            )


### PR DESCRIPTION
The ask_cfpb category page had a faulty check for results. It naively
checked for the existence of an unevaluated query, instead of checking
that the *evaluated* query produced results.

It's not clear why zero-result category queries sporadically crop up on the servers, 
and I can't seem to replicate that behavior locally. 

But I've added tests to check that we handle results of 0 and 1 properly, 
and, it is hoped, prevent the index errors.

Since templatetags were recently exposed to testing, this also adds a
test for ask_cfpb's accent stripper.
