### PR TITLE
Regs3k: Add future effective versions to regulations listing

### DIFF
--- a/cfgov/regulations3k/jinja2/regulations3k/regulations-listing.html
+++ b/cfgov/regulations3k/jinja2/regulations3k/regulations-listing.html
@@ -29,7 +29,7 @@
             {% if regulation.regulation.future_versions %}
             <ul>
             {% for version in regulation.regulation.future_versions %}
-                <li>New amendment effective 
+                <li class="new-version">New amendment effective 
                     <a href="{{ regulation.url }}{{ version.effective_date|string }}/">
                     {{ ap_date(version.effective_date) }}
                     </a>

--- a/cfgov/regulations3k/jinja2/regulations3k/regulations-listing.html
+++ b/cfgov/regulations3k/jinja2/regulations3k/regulations-listing.html
@@ -26,6 +26,18 @@
             <a href="{{ regulation.url }}">
                 <span class="title-num">{{ regulation.title }}</span>
             </a>
+            {% if regulation.regulation.future_versions %}
+            <ul>
+            {% for version in regulation.regulation.future_versions %}
+                <li>New amendment effective 
+                    <a href="{{ regulation.url }}{{ version.effective_date|string }}/">
+                    {{ ap_date(version.effective_date) }}
+                    </a>
+                </li>
+            {% endfor %}
+            </ul>
+            {% endif %}
+
         </li>
         {% endfor %}
     </ul>

--- a/cfgov/regulations3k/tests/test_blocks.py
+++ b/cfgov/regulations3k/tests/test_blocks.py
@@ -47,6 +47,11 @@ class RegulationsListTestCase(TestCase):
             effective_date=datetime.date(2014, 1, 18),
             part=self.part_1002
         )
+        self.future_effective_version = mommy.make(
+            EffectiveVersion,
+            effective_date=datetime.date(2022, 1, 1),
+            part=self.part_1002
+        )
         self.reg_page_1002 = RegulationPage(
             regulation=self.part_1002,
             title='Reg B',
@@ -74,6 +79,7 @@ class RegulationsListTestCase(TestCase):
         }))
         self.assertIn('Reg B', result)
         self.assertIn('/regulations/1002/', result)
+        self.assertIn('New amendment effective', result)
         self.assertNotIn('Reg C', result)
         self.assertNotIn('/regulations/1003/', result)
 

--- a/cfgov/unprocessed/apps/regulations3k/css/reg-listing.less
+++ b/cfgov/unprocessed/apps/regulations3k/css/reg-listing.less
@@ -10,14 +10,19 @@
     > ul {
         margin-bottom: unit( 30px / @base-font-size-px, em );
         padding-left: 0;
-    }
-    > ul > li {
-        border-bottom: 1px solid @gray;
-        list-style-type: none;
-        padding-bottom: unit( 15px / @base-font-size-px, em );
-        &:first-child {
-            border-top: 1px solid @gray;
-            padding-top: unit( 15px / @base-font-size-px, em );
+        > li {
+            border-bottom: 1px solid @gray;
+            list-style-type: none;
+            padding-bottom: unit( 15px / @base-font-size-px, em );
+            &:first-child {
+                border-top: 1px solid @gray;
+                padding-top: unit( 15px / @base-font-size-px, em );
+            }
+        }
+        .new-version {
+            font-size: unit( @size-v / @base-font-size-px, em );
+            font-weight: normal;
+            list-style-type: square;
         }
     }
     a {

--- a/cfgov/unprocessed/apps/regulations3k/css/reg-listing.less
+++ b/cfgov/unprocessed/apps/regulations3k/css/reg-listing.less
@@ -7,11 +7,11 @@
     margin: unit( 45px / @base-font-size-px, em )
             0
             unit( 60px / @base-font-size-px, em );
-    ul {
+    > ul {
         margin-bottom: unit( 30px / @base-font-size-px, em );
         padding-left: 0;
     }
-    li {
+    > ul > li {
         border-bottom: 1px solid @gray;
         list-style-type: none;
         padding-bottom: unit( 15px / @base-font-size-px, em );


### PR DESCRIPTION
This PR adds future effective versions to the regulations listing, for example:

![image](https://user-images.githubusercontent.com/10562538/45778203-fbda4e00-bc25-11e8-9840-b6b7ea82e3c0.png)

## Todos

- The styling could use some work. Currently the future version `li` is inheriting the `h4` class from the parent `li`.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
