### PR TITLE
Bump oah, retirement, and django-college-costs

### DIFF
--- a/requirements/optional-public.txt
+++ b/requirements/optional-public.txt
@@ -1,7 +1,7 @@
 https://github.com/cfpb/college-costs/releases/download/2.4.2/college_costs-2.4.2-py2-none-any.whl
-https://github.com/cfpb/owning-a-home-api/releases/download/0.11.0/owning_a_home_api-0.11.0-py2-none-any.whl
-https://github.com/cfpb/retirement/releases/download/0.7.1/retirement-0.7.1-py2-none-any.whl
+https://github.com/cfpb/owning-a-home-api/releases/download/0.11.1/owning_a_home_api-0.11.1-py2-none-any.whl
+https://github.com/cfpb/retirement/releases/download/0.7.2/retirement-0.7.2-py2-none-any.whl
 https://github.com/cfpb/ccdb5-api/releases/download/v1.0.7/ccdb5_api-1.0.7-py2-none-any.whl
 git+https://github.com/cfpb/ccdb5-ui.git@v1.0.11#egg=ccdb5_ui
-https://github.com/cfpb/django-college-costs-comparison/releases/download/1.7/comparisontool-1.7-py2-none-any.whl
+https://github.com/cfpb/django-college-costs-comparison/releases/download/1.7.1/comparisontool-1.7.1-py2-none-any.whl
 https://github.com/cfpb/teachers-digital-platform/releases/download/1.0.18/teachers_digital_platform-1.0.18-py2-none-any.whl


### PR DESCRIPTION
Bring in new versions of owning-a-home, retirement, and django-college-costs-comparison. These include updates to python requirements lists, so they are compatible with django1.11 and with the versions required in cfgov-refresh.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [x] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Internet Explorer 8, 9, 10, and 11
- [ ] Edge
- [ ] iOS Safari
- [ ] Chrome for Android

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
