### PR TITLE
Bump TDP release to 1.0.19

### DIFF
--- a/requirements/optional-public.txt
+++ b/requirements/optional-public.txt
@@ -4,4 +4,4 @@ https://github.com/cfpb/retirement/releases/download/0.7.2/retirement-0.7.2-py2-
 https://github.com/cfpb/ccdb5-api/releases/download/v1.0.7/ccdb5_api-1.0.7-py2-none-any.whl
 git+https://github.com/cfpb/ccdb5-ui.git@v1.0.11#egg=ccdb5_ui
 https://github.com/cfpb/django-college-costs-comparison/releases/download/1.7.1/comparisontool-1.7.1-py2-none-any.whl
-https://github.com/cfpb/teachers-digital-platform/releases/download/1.0.18/teachers_digital_platform-1.0.18-py2-none-any.whl
+https://github.com/cfpb/teachers-digital-platform/releases/download/1.0.19/teachers_digital_platform-1.0.19-py2-none-any.whl


### PR DESCRIPTION
Updated content and styles for the building blocks tool.

## Changes

- Updated TDP version to 1.0.19

@Scotchester @willbarton @higs4281 @chosak
