### PR TITLE
Regs3k: Improve interpretation redirects

### DIFF
--- a/cfgov/regulations3k/tests/test_views.py
+++ b/cfgov/regulations3k/tests/test_views.py
@@ -16,14 +16,36 @@ class RedirectRegulations3kTestCase(TestCase):
     def setUp(self):
         self.factory = RequestFactory()
 
-        self.test_reg = mommy.make(
+        self.test_reg_1002 = mommy.make(
             Part,
             part_number='1002')
 
-        self.test_version = mommy.make(
+        self.test_reg_1005 = mommy.make(
+            Part,
+            part_number='1005')
+
+        self.test_version_1002 = mommy.make(
             EffectiveVersion,
-            part=self.test_reg,
+            part=self.test_reg_1002,
             effective_date=datetime.date(2016, 7, 11),
+            draft=False)
+
+        self.test_version_1002_2011 = mommy.make(
+            EffectiveVersion,
+            part=self.test_reg_1002,
+            effective_date=datetime.date(2011, 12, 30),
+            draft=False)
+
+        self.test_version_1002_not_live = mommy.make(
+            EffectiveVersion,
+            part=self.test_reg_1002,
+            effective_date=datetime.date(2014, 1, 10),
+            draft=True)
+
+        self.test_version_1005 = mommy.make(
+            EffectiveVersion,
+            part=self.test_reg_1005,
+            effective_date=datetime.date(2013, 3, 26),
             draft=False)
 
     def test_redirect_base_url(self):
@@ -40,36 +62,12 @@ class RedirectRegulations3kTestCase(TestCase):
 
     def test_redirect_reg_section_url(self):
         request = self.factory.get(
-            '/eregulations/1002-1/2017-20417_20180101#1002-1')
+            '/eregulations/1002-1/2017-20417_20180101')
         response = redirect_eregs(request)
         self.assertEqual(response.get('location'),
                          '/policy-compliance/rulemaking/regulations/1002/1/')
 
-    def test_redirect_invalid_part(self):
-        request = self.factory.get(
-            '/eregulations/1020-1/2017-20417_20180101#1002-1')
-        response = redirect_eregs(request)
-        self.assertEqual(
-            response.get('location'),
-            '/policy-compliance/rulemaking/regulations/')
-
-    def test_version_redirect(self):
-        request = self.factory.get(
-            '/eregulations/1002-1/2016-16301#1002-1')
-        response = redirect_eregs(request)
-        self.assertEqual(
-            response.get('location'),
-            '/policy-compliance/rulemaking/regulations/1002/2016-07-11/1/')
-
-    def test_version_redirect_no_version(self):
-        request = self.factory.get(
-            '/eregulations/1002-1/2011-31714#1002-1')
-        response = redirect_eregs(request)
-        self.assertEqual(
-            response.get('location'),
-            '/policy-compliance/rulemaking/regulations/1002/1/')
-
-    def test_search_redirect(self):
+    def test_redirect_search(self):
         request = self.factory.get(
             '/eregulations/search/1002',
             {'q': 'california', 'version': '2011-1'})
@@ -79,53 +77,113 @@ class RedirectRegulations3kTestCase(TestCase):
             '/policy-compliance/rulemaking/regulations/'
             'search-regulations/results/?regs=1002&q=california')
 
-    def test_interp_appendix(self):
+    def test_redirect_invalid_part(self):
         request = self.factory.get(
-            '/eregulations/1002-Appendices-Interp/'
-            '2016-16301#1002-Interp-h1-1')
+            '/eregulations/1020-1/2017-20417_20180101')
         response = redirect_eregs(request)
         self.assertEqual(
             response.get('location'),
-            '/policy-compliance/rulemaking/regulations/1002/')
+            '/policy-compliance/rulemaking/regulations/')
 
-    def test_interp_appendix_invalid_date(self):
+    def test_redirect_invalid_part_pattern(self):
         request = self.factory.get(
-            '/eregulations/1024-Appendices-Interp/'
-            '2017-20417_20180101#1002-Interp-h1-1')
+            '/eregulations/102/')
         response = redirect_eregs(request)
         self.assertEqual(
             response.get('location'),
-            '/policy-compliance/rulemaking/regulations/1024/')
+            '/policy-compliance/rulemaking/regulations/')
 
-    def test_interp_intro(self):
+    def test_redirect_past_version(self):
         request = self.factory.get(
-            '/eregulations/1002-Interp-h1/2016-16301#1030-Interp-h1')
+            '/eregulations/1002-1/2016-16301')
+        response = redirect_eregs(request)
+        self.assertEqual(
+            response.get('location'),
+            '/policy-compliance/rulemaking/regulations/1002/2016-07-11/1/')
+
+    def test_redirect_past_version_not_live(self):
+        request = self.factory.get(
+            '/eregulations/1002-1/2013-22752_20140110')
+        response = redirect_eregs(request)
+        self.assertEqual(
+            response.get('location'),
+            '/policy-compliance/rulemaking/regulations/1002/1/')
+
+    def test_redirect_interp_appendix(self):
+        request = self.factory.get(
+            '/eregulations/1002-Appendices-Interp/2016-16301')
+        response = redirect_eregs(request)
+        self.assertEqual(
+            response.get('location'),
+            '/policy-compliance/rulemaking/regulations/'
+            '1002/2016-07-11/Interp-C/')
+
+    def test_redirect_interp_appendix_invalid_date(self):
+        request = self.factory.get(
+            '/eregulations/1024-Appendices-Interp/2017-20417_20180101')
+        response = redirect_eregs(request)
+        self.assertEqual(
+            response.get('location'),
+            '/policy-compliance/rulemaking/regulations/1024/Interp-MS/')
+
+    def test_redirect_interp_intro(self):
+        request = self.factory.get(
+            '/eregulations/1002-Interp-h1/2016-16301')
         response = redirect_eregs(request)
         self.assertEqual(
             response.get('location'),
             '/policy-compliance/rulemaking/regulations/1002/'
             '2016-07-11/h1-Interp/')
 
-    def test_interp_intro_bad_version(self):
+    def test_redirect_interp_intro_bad_version(self):
         request = self.factory.get(
-            '/eregulations/1030-Interp-h1/2011-31727#1030-Interp-h1')
+            '/eregulations/1030-Interp-h1/2011-31727')
         response = redirect_eregs(request)
         self.assertEqual(
             response.get('location'),
             '/policy-compliance/rulemaking/regulations/1030/Interp-0/')
 
-    def test_interp_section_past(self):
+    def test_redirect_interp_section_past(self):
         request = self.factory.get(
             '/eregulations/1002-Subpart-Interp/2016-16301')
         response = redirect_eregs(request)
         self.assertEqual(
             response.get('location'),
-            '/policy-compliance/rulemaking/regulations/1002/')
+            '/policy-compliance/rulemaking/regulations/1002/'
+            '2016-07-11/Interp-1/')
+
+    def test_redirect_interp_section_past_lowercase(self):
+        # troublemaker URL on launch day
+        request = self.factory.get(
+            '/eregulations/1002-subpart-interp/2011-31714')
+        response = redirect_eregs(request)
+        self.assertEqual(
+            response.get('location'),
+            '/policy-compliance/rulemaking/regulations/1002/'
+            '2011-12-30/Interp-1/')
 
     def test_interp_section_current(self):
         request = self.factory.get(
-            '/eregulations/1002-Subpart-Interp/'
-            '2017-20417_20180101#1002-Subpart-Interp')
+            '/eregulations/1002-Subpart-Interp/2017-20417_20180101')
+        response = redirect_eregs(request)
+        self.assertEqual(
+            response.get('location'),
+            '/policy-compliance/rulemaking/regulations/1002/Interp-1/')
+
+    def test_interp_section_no_subpart_with_default_section(self):
+        # another launch troublemaker
+        request = self.factory.get(
+            '/eregulations/1005-Interp/2013-06861')
+        response = redirect_eregs(request)
+        self.assertEqual(
+            response.get('location'),
+            '/policy-compliance/rulemaking/regulations/1005/'
+            '2013-03-26/Interp-2/')
+
+    def test_redirect_no_pattern_match_after_part(self):
+        """This tests our final fall-through redirect"""
+        request = self.factory.get(
+            '/eregulations/1002/9999/')
         response = redirect_eregs(request)
         self.assertEqual(
             response.get('location'),

--- a/cfgov/regulations3k/views.py
+++ b/cfgov/regulations3k/views.py
@@ -115,12 +115,12 @@ INTERP_SECTION_DEFAULTS = {
 SEARCH_RE = re.compile(r'/eregulations/search/(\d{4})')
 SECTION_RE = re.compile(r'/eregulations/\d{4}-(\d{1,3})/([0-9_-]+)')
 APPENDIX_RE = re.compile(r'/eregulations/\d{4}-([A-Z1-2]{1,3})/([0-9_-]+)')
-INTERP_INTRO_RE = re.compile(r'/eregulations/\d{4}-Interp-h1/([0-9_-]+)')
+INTERP_INTRO_RE = re.compile(
+    r'/eregulations/\d{4}-Interp-h1/([0-9_-]+)', re.IGNORECASE)
 INTERP_APPENDIX_RE = re.compile(
-    r'/eregulations/\d{4}-Appendices-Interp/([0-9_-]+)')
+    r'/eregulations/\d{4}-Appendices-Interp/([0-9_-]+)', re.IGNORECASE)
 INTERP_SECTION_RE = re.compile(
-    r'/eregulations/(?:\d{4}-)(?:Subpart-)?(?:[A-Z-]+)?'
-    r'Interp(?:-[A-Z0-9]{1,2})?/([0-9_-]+)')
+    r'/eregulations/(?:\d{4}-)(?:Subpart-)?(?:[A-Z-]+)?Interp(?:-[A-Z0-9]{1,2})?/([0-9_-]+)', re.IGNORECASE)  # noqa
 
 
 def get_version_date(part_number, doc_number):
@@ -213,6 +213,5 @@ def redirect_eregs(request, **kwargs):
                 else:
                     return redirect("{}{}/Interp-{}/".format(
                         new_base, part, section), permanent=True)
-        else:
-            return redirect("{}{}/".format(new_base, part), permanent=True)
-    return redirect(new_base)
+    # catch-all: we have a valid part, but we can't decipher more than that
+    return redirect("{}{}/".format(new_base, part), permanent=True)


### PR DESCRIPTION
Interpretation redirects were not working for past versions of
appendix and section references after our launch-day hot-fixing.
This was not a pressing issue, because we have yet to turn past
versions on in production, but we hope to soon, and this PR restores
past-version redirects for interpretations.

We also lost some test coverage in the hot-fix, and this restores test coverage.

Addresses GHE issue 375.

## Testing

Interp version redirects should work locally (if you have non-draft versions loaded)
or on the build5 server. Sample eregs version URLs:

* /eregulations/1002-Interp/2016-16301
* /eregulations/1026-Appendices-Interp/2016-30730
