### PR TITLE
Search pages & snippets for external links

### DIFF
--- a/cfgov/ask_cfpb/models/pages.py
+++ b/cfgov/ask_cfpb/models/pages.py
@@ -566,10 +566,8 @@ class AnswerPage(CFGOVPage):
     sidebar_panels = [StreamFieldPanel('sidebar'), ]
 
     search_fields = Page.search_fields + [
-        index.SearchField('question'),
         index.SearchField('answer'),
-        index.SearchField('answer_base'),
-        index.FilterField('language')
+        index.SearchField('snippet')
     ]
 
     edit_handler = TabbedInterface([

--- a/cfgov/search/forms.py
+++ b/cfgov/search/forms.py
@@ -1,0 +1,5 @@
+from django import forms
+
+
+class ExternalLinksForm(forms.Form):
+    url = forms.CharField()

--- a/cfgov/search/templates/search/external_links.html
+++ b/cfgov/search/templates/search/external_links.html
@@ -1,0 +1,95 @@
+{% extends "wagtailadmin/base.html" %}
+{% load i18n %}
+{% block titletag %}{% trans "External Links Management" %}{% endblock %}
+
+{% block content %}
+
+    <div class="nice-padding">
+        <h2>External links</h2>
+
+        <div class="help-block help-info">
+            <p>Enter an external link in the input field to see a list of pages that contain the URL.</p>
+        </div>
+        <form method="post">
+            {% csrf_token %}
+            <ul class="fields">
+                <li>
+            <div class="field url_field url_input">
+            <div class="input">
+            {{ form.url }}
+            </div>
+            </div>
+            </li>
+        </ul>
+        <button type="submit" class="button">Search</button>
+        </form>
+        <br>
+
+        {% if request.POST %}
+        
+            <h2>Number of page results: {{ num_page_results }}</h2>
+            {% include "wagtailadmin/pages/listing/_list_explore.html" with show_parent=1 allow_navigation=0 %}
+
+            <h2>Number of snippet results: {{ num_snippet_results }}</h2>
+            <table class="listing">
+                <thead>
+                    <tr class="table-headers">
+                        <th>Title</th>
+                        <th>Type</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for snippet in contacts %}
+                    <tr>
+                        <td class="title" valign="top">
+                            <h2>
+                                <a href="{% url 'wagtailsnippets:edit' 'v1' 'contact' snippet.pk %}" target="_blank">
+                                    {{ snippet }}
+                                </a>
+                            </h2>
+                        </td>
+                        <td>
+                            <a href="{% url 'wagtailsnippets:list' 'v1' 'contact' %}" target="_blank">
+                                Contacts
+                            </a>
+                        </td>
+                    </tr>
+                    {% endfor %}
+                    {% for snippet in resources %}
+                    <tr>
+                        <td valign="top"class="title" valign="top">
+                            <h2>
+                                <a href="{% url 'v1_resource_modeladmin_edit' snippet.pk %}" target="_blank">
+                                    {{ snippet }}
+                                </a>
+                            </h2>
+                        </td>
+                        <td>
+                            <a href="{% url 'v1_resource_modeladmin_index' %}" target="_blank">
+                                Resources
+                            </a>
+                        </td>
+                    </tr>
+                    {% endfor %}
+                    {% for snippet in reusable_texts %}
+                    <tr>
+                        <td class="title" valign="top">
+                            <h2>
+                                <a href="{% url 'wagtailsnippets:edit' 'v1' 'reusabletext' snippet.pk %}" target="_blank">
+                                    {{ snippet }}
+                                </a>
+                            </h2>
+                        </td>
+                        <td valign="top">
+                            <a href="{% url 'wagtailsnippets:list' 'v1' 'reusabletext' %}" target="_blank">
+                                Reusable Texts
+                            </a>
+                        </td>
+                    </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        {% endif %}
+
+
+{% endblock %}

--- a/cfgov/search/views.py
+++ b/cfgov/search/views.py
@@ -1,6 +1,57 @@
+from django.shortcuts import render
 from django.template.response import TemplateResponse
+from django.views.generic import View
+
+from wagtail.wagtailcore.models import get_page_models
 
 from search import dotgov
+from search.forms import ExternalLinksForm
+from v1.models.resources import Resource
+from v1.models.snippets import Contact, ReusableText
+
+
+class SearchView(View):
+    template_name = 'search/external_links.html'
+
+    def get(self, request):
+        return render(request, self.template_name, {
+            'form': ExternalLinksForm()
+        })
+
+    def post(self, request):
+        form = ExternalLinksForm(request.POST)
+        if not form.is_valid():
+            return render(request, self.template_name, {
+                'form': form
+            })
+        url = form.cleaned_data['url']
+        pages = []
+
+        for cls in get_page_models():
+            pages += list(cls.objects.search(url))
+        pages = sorted(pages, key=lambda k: k.title)
+
+        contacts = list(
+            Contact.objects.filter(body__contains=url).order_by('heading'))
+        resources = sorted(list(
+            Resource.objects.filter(link__contains=url)) + list(
+            Resource.objects.filter(alternate_link__contains=url)),
+            key=lambda k: k.title)
+        reusable_texts = list(
+            ReusableText.objects.filter(text__contains=url).order_by('title'))
+
+        num_page_results = len(pages)
+        num_snippet_results = len(contacts + resources + reusable_texts)
+
+        return render(request, self.template_name, {
+            'form': form,
+            'pages': pages,
+            'contacts': contacts,
+            'resources': resources,
+            'reusable_texts': reusable_texts,
+            'num_page_results': num_page_results,
+            'num_snippet_results': num_snippet_results,
+        })
 
 
 def results_view(request):

--- a/cfgov/search/wagtail_hooks.py
+++ b/cfgov/search/wagtail_hooks.py
@@ -1,0 +1,24 @@
+from __future__ import absolute_import, unicode_literals
+
+from django.conf.urls import url
+from django.core.urlresolvers import reverse
+
+from wagtail.wagtailadmin.menu import MenuItem
+from wagtail.wagtailcore import hooks
+
+from search.views import SearchView
+
+
+@hooks.register('register_admin_urls')
+def register_external_links_url():
+    return [url(
+        r'^external-links/$', SearchView.as_view(), name='external-links'
+    )]
+
+
+@hooks.register('register_admin_menu_item')
+def register_external_links_menu():
+    return MenuItem('External Links',
+                    reverse('external-links'),
+                    classnames='icon icon-search',
+                    order=10000)

--- a/cfgov/v1/models/base.py
+++ b/cfgov/v1/models/base.py
@@ -21,6 +21,7 @@ from wagtail.wagtailcore.models import (
     Orderable, Page, PageManager, PageQuerySet
 )
 from wagtail.wagtailimages.edit_handlers import ImageChooserPanel
+from wagtail.wagtailsearch import index
 
 from modelcluster.fields import ParentalKey
 from modelcluster.tags import ClusterTaggableManager
@@ -88,6 +89,10 @@ class CFGOVPage(Page):
     is_creatable = False
 
     objects = CFGOVPageManager()
+
+    search_fields = Page.search_fields + [
+        index.SearchField('sidefoot'),
+    ]
 
     # These fields show up in either the sidebar or the footer of the page
     # depending on the page type.

--- a/cfgov/v1/models/blog_page.py
+++ b/cfgov/v1/models/blog_page.py
@@ -2,6 +2,7 @@ from wagtail.wagtailadmin.edit_handlers import StreamFieldPanel
 from wagtail.wagtailcore import blocks
 from wagtail.wagtailcore.fields import StreamField
 from wagtail.wagtailcore.models import PageManager
+from wagtail.wagtailsearch import index
 
 from v1 import blocks as v1_blocks
 from v1.atomic_elements import organisms
@@ -25,6 +26,9 @@ class BlogPage(AbstractFilterPage):
     template = 'blog/blog_page.html'
 
     objects = PageManager()
+    search_fields = AbstractFilterPage.search_fields + [
+        index.SearchField('content')
+    ]
 
 
 class LegacyBlogPage(AbstractFilterPage):
@@ -39,3 +43,7 @@ class LegacyBlogPage(AbstractFilterPage):
         content_panel=StreamFieldPanel('content')
     )
     template = 'blog/blog_page.html'
+
+    search_fields = AbstractFilterPage.search_fields + [
+        index.SearchField('content')
+    ]

--- a/cfgov/v1/models/browse_filterable_page.py
+++ b/cfgov/v1/models/browse_filterable_page.py
@@ -5,6 +5,7 @@ from wagtail.wagtailadmin.edit_handlers import (
 )
 from wagtail.wagtailcore.fields import StreamField
 from wagtail.wagtailcore.models import PageManager
+from wagtail.wagtailsearch import index
 
 from v1 import blocks as v1_blocks
 from v1.atomic_elements import molecules, organisms
@@ -48,6 +49,11 @@ class BrowseFilterablePage(FilterableFeedPageMixin,
     template = 'browse-filterable/index.html'
 
     objects = PageManager()
+
+    search_fields = CFGOVPage.search_fields + [
+        index.SearchField('content'),
+        index.SearchField('header')
+    ]
 
     @property
     def page_js(self):

--- a/cfgov/v1/models/browse_page.py
+++ b/cfgov/v1/models/browse_page.py
@@ -6,6 +6,7 @@ from wagtail.wagtailadmin.edit_handlers import (
 from wagtail.wagtailcore import blocks
 from wagtail.wagtailcore.fields import StreamField
 from wagtail.wagtailcore.models import PageManager
+from wagtail.wagtailsearch import index
 
 from data_research.blocks import (
     ConferenceRegistrationForm, MortgageDataDownloads
@@ -72,6 +73,11 @@ class BrowsePage(CFGOVPage):
     template = 'browse-basic/index.html'
 
     objects = PageManager()
+
+    search_fields = CFGOVPage.search_fields + [
+        index.SearchField('content'),
+        index.SearchField('header')
+    ]
 
     @property
     def page_js(self):

--- a/cfgov/v1/models/home_page.py
+++ b/cfgov/v1/models/home_page.py
@@ -4,6 +4,7 @@ from wagtail.wagtailadmin.edit_handlers import (
 from wagtail.wagtailcore import blocks
 from wagtail.wagtailcore.fields import StreamField
 from wagtail.wagtailcore.models import PageManager
+from wagtail.wagtailsearch import index
 
 from v1.atomic_elements import atoms, molecules
 from v1.models.base import CFGOVPage
@@ -44,6 +45,8 @@ class HomePage(CFGOVPage):
     template = 'index.html'
 
     objects = PageManager()
+
+    search_fields = CFGOVPage.search_fields + [index.SearchField('header')]
 
     def get_category_name(self, category_icon_name):
         cats = dict(ref.limited_categories)

--- a/cfgov/v1/models/landing_page.py
+++ b/cfgov/v1/models/landing_page.py
@@ -3,6 +3,7 @@ from wagtail.wagtailadmin.edit_handlers import (
 )
 from wagtail.wagtailcore.fields import StreamField
 from wagtail.wagtailcore.models import PageManager
+from wagtail.wagtailsearch import index
 
 from v1 import blocks as v1_blocks
 from v1.atomic_elements import molecules, organisms
@@ -41,3 +42,8 @@ class LandingPage(CFGOVPage):
     template = 'landing-page/index.html'
 
     objects = PageManager()
+
+    search_fields = CFGOVPage.search_fields + [
+        index.SearchField('content'),
+        index.SearchField('header')
+    ]

--- a/cfgov/v1/models/learn_page.py
+++ b/cfgov/v1/models/learn_page.py
@@ -13,6 +13,7 @@ from wagtail.wagtailcore.fields import RichTextField, StreamField
 from wagtail.wagtailcore.models import Page, PageManager
 from wagtail.wagtaildocs.edit_handlers import DocumentChooserPanel
 from wagtail.wagtailimages.edit_handlers import ImageChooserPanel
+from wagtail.wagtailsearch import index
 
 from localflavor.us.models import USStateField
 
@@ -73,6 +74,10 @@ class AbstractFilterPage(CFGOVPage):
 
     objects = CFGOVPageManager()
 
+    search_fields = CFGOVPage.search_fields + [
+        index.SearchField('header')
+    ]
+
     @classmethod
     def generate_edit_handler(self, content_panel):
         content_panels = [
@@ -115,6 +120,10 @@ class LearnPage(AbstractFilterPage):
 
     objects = PageManager()
 
+    search_fields = AbstractFilterPage.search_fields + [
+        index.SearchField('content')
+    ]
+
 
 class DocumentDetailPage(AbstractFilterPage):
     content = StreamField([
@@ -131,6 +140,10 @@ class DocumentDetailPage(AbstractFilterPage):
     template = 'document-detail/index.html'
 
     objects = PageManager()
+
+    search_fields = AbstractFilterPage.search_fields + [
+        index.SearchField('content')
+    ]
 
 
 class AgendaItemBlock(blocks.StructBlock):
@@ -216,6 +229,16 @@ class EventPage(AbstractFilterPage):
     agenda_items = StreamField([('item', AgendaItemBlock())], blank=True)
 
     objects = CFGOVPageManager()
+
+    search_fields = AbstractFilterPage.search_fields + [
+        index.SearchField('body'),
+        index.SearchField('archive_body'),
+        index.SearchField('live_stream_url'),
+        index.SearchField('flickr_url'),
+        index.SearchField('youtube_url'),
+        index.SearchField('future_body'),
+        index.SearchField('agenda_items')
+    ]
 
     # General content tab
     content_panels = CFGOVPage.content_panels + [

--- a/cfgov/v1/models/sublanding_filterable_page.py
+++ b/cfgov/v1/models/sublanding_filterable_page.py
@@ -3,6 +3,7 @@ from wagtail.wagtailadmin.edit_handlers import (
 )
 from wagtail.wagtailcore.fields import StreamField
 from wagtail.wagtailcore.models import PageManager
+from wagtail.wagtailsearch import index
 
 from v1 import blocks as v1_blocks
 from v1.atomic_elements import molecules, organisms
@@ -41,6 +42,11 @@ class SublandingFilterablePage(FilterableFeedPageMixin,
     template = 'sublanding-page/index.html'
 
     objects = PageManager()
+
+    search_fields = CFGOVPage.search_fields + [
+        index.SearchField('content'),
+        index.SearchField('header')
+    ]
 
 
 class ActivityLogPage(SublandingFilterablePage):

--- a/cfgov/v1/models/sublanding_page.py
+++ b/cfgov/v1/models/sublanding_page.py
@@ -5,6 +5,7 @@ from wagtail.wagtailcore import blocks
 from wagtail.wagtailcore.fields import StreamField
 from wagtail.wagtailcore.models import PageManager
 from wagtail.wagtailimages.blocks import ImageChooserBlock
+from wagtail.wagtailsearch import index
 
 from jobmanager.models import JobListingList
 from v1 import blocks as v1_blocks
@@ -76,6 +77,11 @@ class SublandingPage(CFGOVPage):
     template = 'sublanding-page/index.html'
 
     objects = PageManager()
+
+    search_fields = CFGOVPage.search_fields + [
+        index.SearchField('content'),
+        index.SearchField('header')
+    ]
 
     def get_browsefilterable_posts(self, limit):
         filter_pages = [p.specific


### PR DESCRIPTION
## Overview

This introduces a new view in the Wagtail admin, called "External Links" in the sidebar, to search across all pages and snippets.  The use case is to search for an external link, but it can technically be used to search any text. See GHE/CFGOV/enhanced-cms/issues/4 for the user story & its related issues.

## What it's searching 
Specifically, these are the columns on each model it's searching:
  - Search `content`, `sidefoot`, and `header` sections of pages (except EventPage which is different - see next line).  Pages are any page that inherit from `CFGOVPage` - these are mostly defined in the `v1` app but there are also pages defined outside of `v1`.
  - Search `body`, `archive_body`, `live_stream_url`, `flickr_url`, `youtube_url`, `future_body`, and `agenda_items` of EventPages
  - Search `snippet` and `answer` of ask_cfpb pages (AnswerPages)
  - Search `body` of Contacts
  - Search `link` and `alternate_link` of Resources
  - Search `text` of ReusableTexts

For all of these, I had to add the corresponding search indexes to the models.  For ask_cfpb, I only had to add `snippet` since `answer` was already being indexed. However, I did remove the other indexes on ask_cfpb (`question`, `answer_base`, and `language`), as it seems they are unused & would not be needed for this search. 

## Test
- To play with this locally, pull down this branch, `links-search`, and navigate to http://localhost:8000/admin/external-links/.  There are no migrations or scripts you need to run, or any other dependencies.
- All existing tests pass and I've also added new test coverage.  Note that my tests are fairly basic -- checking if the number of results for a search correspond to the test page/URL I added.   If a URL exists in a field we haven't indexed here, it's not going to show up in the results, and it's not going to be caught by any tests.  See my next comment regarding this.

## Notes / future considerations
- While we search all pages for their `content`, `sidefoot`, and `header` fields, where applicable, this is not comprehensive.  The `EventPage` (outlined above) is a good example of what I needed to do to include it in the search, since it's set up differently than the other v1 pages.  However, there are other (non v1) pages set up differently as well -- e.g. a `JobListingPage` -- that I did not audit or include indexes for.  If we want to make sure every possible external link is captured, a little bit more auditing and work would be required, but based on the user story I think that capturing external links contained in v1 pages is enough for at least the first iteration.
- As noted in comments below, this is using the default database backend, which is not as performant as using elasticsearch or the [postgres_search backend](http://docs.wagtail.io/en/v2.0/reference/contrib/postgres_search.html).  There are a couple reasons I did not implement this using the postgres_search backend, but perhaps these could be addressed in the future:
  - It would impact the main Wagtail admin search (searching all the fields indexed in this PR, instead of just the title, as it does now).  
  - The partial searches we need for this to work is not something set up by default. See my comment here https://github.com/cfpb/cfgov-refresh/pull/4540#issuecomment-426503556
- Search results are based on the live/published state of the page, with one caveat: if the page is a draft only (that has been unpublished or has never been published), it will search based on the first revision created since it was unpublished, or the very first revision in the case it was never published.  This is obviously confusing & what I imagine is an oversight with Wagtail search, but it is how our default search works as well, so this PR does not attempt to change this behavior.

@ascott1 @schaferjh I think the above notes and overview capture what I've talked about in sprint review.  Let me know if I've missed anything & if you'd like me to open up corresponding GHE issues for any of this.