### PR TITLE
Fix missing static wellbeing image

### DIFF
--- a/cfgov/wellbeing/jinja2/wellbeing/results.html
+++ b/cfgov/wellbeing/jinja2/wellbeing/results.html
@@ -288,7 +288,7 @@
     <h2>Your result</h2>
 
     <figure class="spectrum u-clearfix">
-        <img src="{{ static('img/spectrum_1540x60.png') }}"
+        <img src="{{ static('apps/wellbeing/img/spectrum_1540x60.png') }}"
              alt="Chart showing that financial well-being scores below 40 are in the lowest of five ranges. Scores between 40 and 50 are in the second lowest. Scores between 50 and 60 are in the middle range. Scores between 60 and 70 are in the second highest range. Scores above 70 are in the highest range."
              height="30">
     {% if user_score %}


### PR DESCRIPTION
This change fixes a reference to a static image on the wellbeing results page. This missing reference causes a 500 error in Django 1.11.

## Testing

Visit http://localhost:8000/consumer-tools/financial-well-being/results/ locally and confirm that the rainbow spectrum image loads.

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [X] Passes all existing automated tests
- [X] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [X] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: