### PR TITLE
Add exception as a kwarg to handle_error

### DIFF
--- a/cfgov/cfgov/urls.py
+++ b/cfgov/cfgov/urls.py
@@ -521,7 +521,7 @@ urlpatterns.append(url(r'', include(wagtailsharing_urls)))
 # urlpatterns.append(url(r'', include(wagtailsharing_urls)))
 
 
-def handle_error(code, request):
+def handle_error(code, request, exception=None):
     try:
         return render(request, '%s.html' % code, context={'request': request},
                       status=code)


### PR DESCRIPTION
New Relic is passing an `exception` kwarg to our `handle_error` function. The function wasn't set up to take that argument, so it's raising a TypeError.

This change adds the `exception` kwarg and adds tests for `handle_error`. Until we do this, all our error analytics in New Relic are obscured by this `TypeError`.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
