### PR TITLE
Temporarily hide event maps until we can replace the Google Maps Static API with Mapbox

### DIFF
--- a/cfgov/jinja2/v1/events/_macros.html
+++ b/cfgov/jinja2/v1/events/_macros.html
@@ -152,9 +152,14 @@
             {% elif event_state == 'present' and request.path == '/about-us/events/town-hall-topeka-kan-fighting-elder-financial-exploitation-your-community/' %}
                 <iframe alt="Fighting elder financial exploitation in your community."
                         style="display: block; width: 100%; min-height: 470px; border: none;" src="https://mediasite.yorkcast.com/webcast/Play/fe85017780f840d7b931141f063ee5211d?autostart=true"></iframe>
+            {# TODO: Replace this call to the Google Maps Static API
+               (which now requires an API key we don't have)
+               with Mapbox (for which we do have an API key).
             {% else %}
               <img src="{{ event.location_image_url(size='640x320') }}"
-                   alt="Google Maps image of {{ event.venue_name }}">
+                   alt="Google Maps image of
+                        {{ event.venue_city }}{{ ', ' ~ event.venue_state if event.venue_state else '' }}">
+            #}
             {% endif %}
             </figure>
         </footer>


### PR DESCRIPTION
Google recently began requiring an API key to use the Google Maps Static API, resulting in an unfortunate error message in place of where we used to have maps on event pages. This is a hotfix for an event getting published today that simply hides the map. In the future, we should replace the Google Maps Static API call with Mapbox integration.

## Changes

- Comments out map display on event pages

## Testing

1. Create a new event page with a venue city and state
1. Preview the page and see the alt text of the map, not the map itself
1. Pull branch
1. Refresh the page and see nothing

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [x] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: