### PR TITLE
Upgrade to latest cfpb-chart-builder v4.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2994,9 +2994,9 @@
       }
     },
     "cfpb-chart-builder": {
-      "version": "3.8.1",
-      "resolved": "https://registry.npmjs.org/cfpb-chart-builder/-/cfpb-chart-builder-3.8.1.tgz",
-      "integrity": "sha512-ToiG8rnVj3IzAM9ZmPmBmctpJkQL4ZSLGfEOW2Bivhm3Qost+G0oXzW6vQA8NgAjrLAlSOqUC+6eALxmihpWAw==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/cfpb-chart-builder/-/cfpb-chart-builder-4.0.1.tgz",
+      "integrity": "sha512-KfZTFrR3ci4w84WT1TSNdiO7ir/lrROQb2A2lLe7Qyx33eLUz9eFXClLvmEJhN+GvrdGOFjAS2UYakX85yqVCw==",
       "requires": {
         "cf-core": "4.10.0",
         "cf-layout": "5.0.0",
@@ -3019,9 +3019,6 @@
           "version": "2.5.7",
           "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
           "integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw=="
-        },
-        "highcharts": {
-          "version": "git+https://github.com/cfpb/highcharts-dist.git#0c151c2eae85e2ffaef537ecea97769c082a2d50"
         },
         "xdr": {
           "version": "github:contolini/xdr#4f53e8dc68d14cd4a387874e75faae46c3a4961b"
@@ -7991,6 +7988,9 @@
         "hoek": "4.2.1",
         "sntp": "2.1.0"
       }
+    },
+    "highcharts": {
+      "version": "git+https://github.com/cfpb/highcharts-dist.git#0c151c2eae85e2ffaef537ecea97769c082a2d50"
     },
     "hmac-drbg": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "cf-pagination": "5.0.1",
     "cf-tables": "5.0.0",
     "cf-typography": "5.0.1",
-    "cfpb-chart-builder": "3.8.1",
+    "cfpb-chart-builder": "4.0.1",
     "del": "3.0.0",
     "elem-dataset": "1.1.1",
     "glob-all": "3.1.0",


### PR DESCRIPTION
Upgrades with [4.0.0](https://github.com/cfpb/cfpb-chart-builder/releases/tag/v4.0.0) and [4.0.1](https://github.com/cfpb/cfpb-chart-builder/releases/tag/v4.0.1) releases

Includes changes to the filenames for credit tightness index data (previously inferred denials index).



## Testing

1. `./frontend.sh`
1. Edit local Credit tightness index chart file source to use `crt_` prefix instead of `den_`, for example: `consumer-credit-trends/auto-loans/crt_data_AUT.csv`
1. load charts locally at http://localhost:8000/data-research/consumer-credit-trends/auto-loans/inquiry-activity/ and confirm the Inquiry index and Credit tightness charts work as expected. Inquiry index should have 4 months of projected data, Credit tightness should have 0.

## Screenshots
![screen shot 2018-09-25 at 5 38 40 pm](https://user-images.githubusercontent.com/702526/46044827-e5326c00-c0e9-11e8-9691-5097a8da5e10.png)

![screen shot 2018-09-25 at 5 38 46 pm](https://user-images.githubusercontent.com/702526/46044826-e5326c00-c0e9-11e8-9b4e-220927cc1443.png)



## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Internet Explorer 8, 9, 10, and 11
- [ ] Edge
- [ ] iOS Safari
- [ ] Chrome for Android

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
