### PR TITLE
Regs3K: Add URL permalink hash updating to Regs3K

### DIFF
--- a/cfgov/regulations3k/jinja2/regulations3k/browse-regulation.html
+++ b/cfgov/regulations3k/jinja2/regulations3k/browse-regulation.html
@@ -231,7 +231,8 @@
         !function(){
           {# Include site-wide JavaScript. #}
           var s = [
-            '{{ static('apps/regulations3k/js/index.js') }}'
+            '{{ static('apps/regulations3k/js/index.js') }}',
+            '{{ static('apps/regulations3k/js/permalinks.js') }}'
           ];
           jsl(s);
         }()

--- a/cfgov/unprocessed/apps/regulations3k/js/permalinks-utils.js
+++ b/cfgov/unprocessed/apps/regulations3k/js/permalinks-utils.js
@@ -1,0 +1,123 @@
+// Array that tracks paragraph positions
+let paragraphPositions;
+
+/**
+ * scrollY - Get the Y coord of the current viewport. Older browsers don't
+ * support `scrollY` so use whichever works.
+ *
+ * @returns {function} Browser-supported y offset method.
+ */
+const scrollY = () => window.scrollY || window.pageYOffset;
+
+/**
+ * getYLocation - Get Y location of provided element on the page.
+ *
+ * @param {node} el HTML element
+ *
+ * @returns {type} Description
+ */
+const getYLocation = el => {
+  const elOffset = el.getBoundingClientRect().top;
+  return scrollY() + elOffset - 30;
+};
+
+/**
+ * getParagraphPositions - Get an array of all paragraphs with their IDs
+ * mapped to their Y position (number of pixels from top of page).
+ *
+ * @param {nodelist} paragraphs Nodelist of HTML elements with IDs
+ *
+ * @returns {array} Array of objects w/ paragraph IDs and y positions.
+ */
+const getParagraphPositions = paragraphs => {
+  let paragraphPos = [];
+
+  // IE doesn't support `forEach` w/ node lists :/
+  for ( let i = 0; i < paragraphs.length; i++ ) {
+    paragraphPos.push( {
+      id: paragraphs[i].id,
+      position: getYLocation( paragraphs[i] )
+    } );
+  }
+
+  // Convert it into an array and reverse it
+  paragraphPos = Array.prototype.slice.apply( paragraphPos ).reverse();
+
+  return paragraphPos;
+};
+
+/**
+ * getCurrentParagraph - Get paragraph closest to viewport's current position.
+ *
+ * @param {int} currentPosition Current viewport Y coordinate
+ * @param {array} paragraphs List of paragraphs on the page
+ *
+ * @returns {str} HTML ID of closest paragraph
+ */
+const getCurrentParagraph = ( currentPosition, paragraphs ) => {
+  let currentId = null;
+  // We're using a `for` loop so that we can `break` once a match is found
+  for ( let i = 0; i < paragraphs.length; i++ ) {
+    if ( currentPosition > paragraphs[i].position ) {
+      currentId = paragraphs[i].id;
+      break;
+    }
+  }
+  return currentId;
+};
+
+/**
+ * updateUrlHash - Update the page's URL hash w/ the closest paragraph
+ *
+ * @param {arr} paragraphs List of possible paragraphs on the page
+ *
+ * @returns {object} window object
+ */
+const updateUrlHash = () => {
+  const currentParagraph = getCurrentParagraph( scrollY(), paragraphPositions );
+  // Setting the window state to `.` removes the URL hash
+  const hash = currentParagraph ? `#${ currentParagraph }` : '.';
+  return window.history.replaceState( null, null, hash );
+};
+
+
+/**
+ * updateParagraphPositions - Update the array that tracks paragraph positions
+ *
+ * @returns {type} Array of paragraph positions
+ */
+const updateParagraphPositions = () => {
+  const paragraphs = document.querySelectorAll( '.regdown-block' );
+  paragraphPositions = getParagraphPositions( paragraphs );
+  return paragraphPositions;
+};
+
+/**
+ * debounce - Ensure our callbacks fire only after the action has stopped
+ *
+ * @param {string} event Event name
+ * @param {int} delay Time to wait in milliseconds
+ * @param {function} cb Function to be called after action has stopped
+ *
+ * @returns {object} Timer
+ */
+const debounce = ( event, delay, cb ) => {
+  let timeout;
+  window.addEventListener( event, () => {
+    window.clearTimeout( timeout );
+    timeout = setTimeout( () => {
+      cb();
+    }, delay );
+  }, false );
+  return timeout;
+};
+
+module.exports = {
+  debounce,
+  getCurrentParagraph,
+  getParagraphPositions,
+  getYLocation,
+  scrollY,
+  updateParagraphPositions,
+  updateUrlHash
+};

--- a/cfgov/unprocessed/apps/regulations3k/js/permalinks.js
+++ b/cfgov/unprocessed/apps/regulations3k/js/permalinks.js
@@ -1,0 +1,32 @@
+/**
+ * To auto update the URL's hash as users scroll through regs, we populate an
+ * array of objects that maps every paragraph's ID to its Y coordinate on page
+ * load. We regenerate this array if the user resizes the window or clicks on
+ * an expandable (because both those actions cause paragraphs to move around
+ * the page).
+ *
+ * As users scroll through the page we search the array for the paragraph
+ * closest to the top of the viewport and update the URL hash accordingly.
+ */
+
+import {
+  debounce,
+  updateParagraphPositions,
+  updateUrlHash
+} from './permalinks-utils';
+
+/**
+ * init - Initialize the permalink functionality by cataloging all paragraph
+ * locations and adding event listeneres for re-cataloging when necessary.
+ */
+const init = () => {
+  updateParagraphPositions();
+  debounce( 'resize', 300, updateParagraphPositions );
+  debounce( 'click', 300, updateParagraphPositions );
+  debounce( 'scroll', 100, updateUrlHash );
+};
+
+// Provide the no-JS experience to browsers without `replaceState`
+if ( 'replaceState' in window.history ) {
+  window.addEventListener( 'load', init );
+}

--- a/cfgov/unprocessed/apps/regulations3k/js/regs3k-utils.js
+++ b/cfgov/unprocessed/apps/regulations3k/js/regs3k-utils.js
@@ -1,6 +1,5 @@
 import { ajaxRequest as xhr } from '../../../js/modules/util/ajax-request';
 
-
 /**
  * fetch - Wrapper for our ajax request method with callback support
  *
@@ -14,6 +13,13 @@ const fetch = ( url, cb ) => xhr( 'GET', url, {
   fail: err => cb( err )
 } );
 
+/**
+ * getNewHash - Convert an old eRegs hash into a Regs3K hash.
+ *
+ * @param {string} hash Old eRegs URL hash
+ *
+ * @returns {string} New Regs3K hash
+ */
 const getNewHash = hash => {
   if ( ( /(\w+-)+Interp-/ ).test( hash ) ) {
     // Trim off DDDD- e.g. 1003-2-f-Interp-3 becomes 2-f-Interp-3

--- a/test/unit_tests/apps/regulations3k/js/permalinks-spec.js
+++ b/test/unit_tests/apps/regulations3k/js/permalinks-spec.js
@@ -1,0 +1,18 @@
+const BASE_JS_PATH = '../../../../../cfgov/unprocessed/apps/regulations3k';
+
+const app = require( `${ BASE_JS_PATH }/js/permalinks.js` );
+
+describe( 'Permalinks functionality', () => {
+
+  beforeEach( () => {
+    // Fire `load` event
+    const event = document.createEvent( 'Event' );
+    event.initEvent( 'load', true, true );
+    window.dispatchEvent( event );
+  } );
+
+  it( 'should not throw any errors on init', () => {
+    expect( () => app ).not.toThrow();
+  } );
+
+} );

--- a/test/unit_tests/apps/regulations3k/js/permalinks-utils-spec.js
+++ b/test/unit_tests/apps/regulations3k/js/permalinks-utils-spec.js
@@ -1,0 +1,164 @@
+const BASE_JS_PATH = '../../../../../cfgov/unprocessed/apps/regulations3k';
+
+const utils = require( `${ BASE_JS_PATH }/js/permalinks-utils.js` );
+
+const HTML_SNIPPET1 = `
+  <div class="regdown-block" id="Interp-1"></div>
+  <div class="regdown-block" id="c"></div>
+  <div class="regdown-block" id="z-14-i"></div>
+`;
+
+const HTML_SNIPPET2 = `
+  <div class="regdown-block" id="a"></div>
+  <div class="regdown-block" id="b"></div>
+  <div class="regdown-block" id="c"></div>
+  <div class="regdown-block" id="d"></div>
+  <div class="regdown-block" id="e"></div>
+`;
+
+describe( 'The Regs3K permalinks utils', () => {
+
+  describe( 'Debounce', () => {
+
+    beforeEach( () => {
+      global.spy = done => {
+        if ( done ) done();
+      };
+    } );
+
+    it( 'should only call a function once within a given timespan', done => {
+      const event = document.createEvent( 'Event' );
+      event.initEvent( 'resize', true, true );
+      jest.spyOn( global, 'spy' );
+
+      utils.debounce( 'resize', 100, global.spy );
+
+      // Fire the event three times
+      window.dispatchEvent( event );
+      window.dispatchEvent( event );
+      window.dispatchEvent( event );
+
+      // It should have only been called once
+      setTimeout( () => {
+        expect( global.spy ).toHaveBeenCalledTimes( 1 );
+        done();
+      }, 200 );
+    } );
+
+    it( 'should not call a function if the timespan hasn\'t passed', done => {
+      const event = document.createEvent( 'Event' );
+      event.initEvent( 'scroll', true, true );
+      jest.spyOn( global, 'spy' );
+
+      utils.debounce( 'scroll', 1000, global.spy );
+
+      // Fire the event three times
+      window.dispatchEvent( event );
+      window.dispatchEvent( event );
+      window.dispatchEvent( event );
+
+      setTimeout( () => {
+        expect( global.spy ).toHaveBeenCalledTimes( 0 );
+        done();
+      }, 200 );
+    } );
+
+  } );
+
+  describe( 'scrollY', () => {
+
+    it( 'should return the correct browser method', () => {
+      expect( typeof utils.scrollY ).toBe( 'function' );
+      expect( utils.scrollY() ).toBeGreaterThanOrEqual( 0 );
+    } );
+
+  } );
+
+  describe( 'Y location getter', () => {
+
+    beforeEach( () => {
+      // Load HTML fixture
+      document.body.innerHTML = HTML_SNIPPET1;
+    } );
+
+    it( 'should return the correct browser method', () => {
+      const el = document.querySelector( '#Interp-1' );
+      expect( utils.getYLocation( el ) ).toEqual( -30 );
+    } );
+
+  } );
+
+  describe( 'get paragraph positions', () => {
+
+    beforeEach( () => {
+      // Load HTML fixture
+      document.body.innerHTML = HTML_SNIPPET1;
+    } );
+
+    it( 'should return the positions of all paragraphs', () => {
+      const paragraphs = document.querySelectorAll( '.regdown-block' );
+      expect( utils.getParagraphPositions( paragraphs ) ).toEqual(
+        [{'id': 'z-14-i', 'position': -30}, {'id': 'c', 'position': -30}, {'id': 'Interp-1', 'position': -30}]
+      );
+    } );
+
+  } );
+
+  describe( 'update paragraph positions', () => {
+
+    beforeEach( () => {
+      // Load HTML fixture
+      document.body.innerHTML = HTML_SNIPPET2;
+    } );
+
+    it( 'should update and return the positions of all paragraphs', () => {
+      expect( utils.updateParagraphPositions() ).toEqual(
+        [{'id': 'e', 'position': -30}, {'id': 'd', 'position': -30}, {'id': 'c', 'position': -30}, {'id': 'b', 'position': -30}, {'id': 'a', 'position': -30}]
+      );
+    } );
+
+  } );
+
+  describe( 'paragraph getter', () => {
+
+    const paragraphs = [{'id': 'three', 'position': 30}, {'id': 'two', 'position': 20}, {'id': 'one', 'position': 10}];
+
+    it( 'should get paragraph closest to viewport', () => {
+      expect( utils.getCurrentParagraph( 'sandwich', paragraphs ) ).toEqual( null );
+      expect( utils.getCurrentParagraph( -1, paragraphs ) ).toEqual( null );
+      expect( utils.getCurrentParagraph( 0, paragraphs ) ).toEqual( null );
+      expect( utils.getCurrentParagraph( 5, paragraphs ) ).toEqual( null );
+      expect( utils.getCurrentParagraph( 8, paragraphs ) ).toEqual( null );
+      expect( utils.getCurrentParagraph( 0, paragraphs ) ).toEqual( null );
+      expect( utils.getCurrentParagraph( 12, paragraphs ) ).toEqual( 'one' );
+      expect( utils.getCurrentParagraph( 15, paragraphs ) ).toEqual( 'one' );
+      expect( utils.getCurrentParagraph( 19, paragraphs ) ).toEqual( 'one' );
+      expect( utils.getCurrentParagraph( 20, paragraphs ) ).toEqual( 'one' );
+      expect( utils.getCurrentParagraph( 21, paragraphs ) ).toEqual( 'two' );
+      expect( utils.getCurrentParagraph( 30, paragraphs ) ).toEqual( 'two' );
+      expect( utils.getCurrentParagraph( 31, paragraphs ) ).toEqual( 'three' );
+      expect( utils.getCurrentParagraph( 45, paragraphs ) ).toEqual( 'three' );
+      expect( utils.getCurrentParagraph( 73648576, paragraphs ) ).toEqual( 'three' );
+    } );
+
+  } );
+
+  describe( 'URL hash updater', () => {
+
+    it( 'should update add the paragraph ID to the URL', () => {
+      global.history.replaceState = jest.fn();
+
+      document.body.innerHTML = HTML_SNIPPET1;
+      utils.updateParagraphPositions();
+      utils.updateUrlHash();
+      expect( global.history.replaceState ).toBeCalledWith( null, null, '#z-14-i' );
+
+      document.body.innerHTML = HTML_SNIPPET2;
+      utils.updateParagraphPositions();
+      utils.updateUrlHash();
+      expect( global.history.replaceState ).toBeCalledWith( null, null, '#e' );
+    } );
+
+  } );
+
+} );


### PR DESCRIPTION
Update the URL's hash to point to the currently-viewed paragraph as you scroll.

![permalinks](https://user-images.githubusercontent.com/1060248/46060531-b213cb00-c131-11e8-8b63-a3f0d827a420.gif)

## Additions

- `permalinks.js` file that is loaded only on browse regs pages.

On page load we grab every regdown paragraph (`.regdown-block`) and cache its `id` attribute and Y coordinate. We regenerate this array if the user resizes the window or clicks on an expandable (because both those actions cause paragraphs to change positions on the page).

As users scroll through the page we search the array for the paragraph closest to the top of the viewport and update the URL hash accordingly.

## Testing

1. `./frontend.sh`
1. `gulp test:unit --specs=apps/regulations3k/` and verify all automated tests pass.
1. Scroll through your [favorite reg](http://localhost:8000/policy-compliance/rulemaking/regulations/1026/47/) and verify that the URL updates in real-time

## Notes

- For performance reasons we wait until the user has stopped scrolling for 100 ms before updating the URL.

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Internet Explorer 8, 9, 10, and 11
- [ ] Edge
- [ ] iOS Safari
- [ ] Chrome for Android

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
