### PR TITLE
Ask CFPB: Handle IndexError explicitly

### DIFF
--- a/cfgov/ask_cfpb/models/pages.py
+++ b/cfgov/ask_cfpb/models/pages.py
@@ -280,9 +280,9 @@ class AnswerCategoryPage(RoutablePageMixin, SecondaryNavigationJSMixin,
         else:
             sqs = sqs.filter(content=self.ask_category.name)
         sqs = sqs.models(self.Category)
-        if sqs.count() > 0:
+        try:
             facet_map = sqs[0].facet_map
-        else:
+        except IndexError:
             facet_map = self.ask_category.facet_map
         facet_dict = json.loads(facet_map)
         subcat_ids = facet_dict['subcategories'].keys()


### PR DESCRIPTION
Since we can't replicate or predict when Ask CFPB's haystack request cycle
will produce an IndexError, we can instead capture it when it happens and deliver
a slower but guaranteed-success option.

Someday I'll understand how a request with > 0 results has no first result.
Haystack defines its own query `__getitem__` method, and I wonder if [this assumption](https://github.com/django-haystack/django-haystack/blob/master/haystack/query.py#L319) can sometimes be wrong when using Elasticsearch.

This is in response to recently bumped GHE cfgov-alerts issues 298, 721, and 766.