### PR TITLE
Deprecate django.VERSION conditionals

### DIFF
--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -1,7 +1,6 @@
 import os
 import sys
 
-import django
 from django.conf import global_settings
 from django.utils.translation import ugettext_lazy as _
 
@@ -138,6 +137,9 @@ TEMPLATES = [
         # Look for Django templates in each app under a templates subdirectory.
         'APP_DIRS': True,
         'OPTIONS': {
+            'builtins': [
+                'overextends.templatetags.overextends_tags',
+            ],
             'context_processors': [
                 'django.template.context_processors.debug',
                 'django.template.context_processors.request',
@@ -178,14 +180,6 @@ TEMPLATES = [
         }
     },
 ]
-
-# TODO: Remove this when support for Django < 1.9 is removed.
-# The ability to specify builtins like this was added in Django 1.9.
-# https://docs.djangoproject.com/en/dev/releases/1.9/#templates
-if django.VERSION[:2] >= (1, 9):
-    TEMPLATES[0]['OPTIONS']['builtins'] = [
-        'overextends.templatetags.overextends_tags',
-    ]
 
 WSGI_APPLICATION = 'cfgov.wsgi.application'
 

--- a/cfgov/core/tests/test_utils.py
+++ b/cfgov/core/tests/test_utils.py
@@ -1,6 +1,5 @@
 import unittest
 
-import django
 from django.test import TestCase
 
 from core.utils import (
@@ -38,12 +37,7 @@ class TestNoMigrations(TestCase):
         self.assertTrue('random-string' in self.nomigrations)
 
     def test_getitem(self):
-        if django.VERSION[:2] < (1, 9):  # pragma: no cover
-            expected = 'nomigrations'
-        else:
-            expected = None
-
-        self.assertEqual(self.nomigrations['random-string'], expected)
+        self.assertIsNone(self.nomigrations['random-string'])
 
 
 class FormatFileSizeTests(unittest.TestCase):

--- a/cfgov/core/utils.py
+++ b/cfgov/core/utils.py
@@ -2,7 +2,6 @@ import re
 from six import text_type as str
 from six.moves.urllib.parse import parse_qs, urlencode, urlparse
 
-import django
 from django.core.signing import Signer
 from django.core.urlresolvers import reverse
 
@@ -139,15 +138,9 @@ class NoMigrations(object):
     for an app's migrations (by default this is the "migrations" subdirectory).
     This class simulates a dictionary where a lookup for any app returns a
     value that causes Django to think that no migrations exist.
-
-    In Django >= 1.9, this can be configured by returning None. In Django <1.9,
-    a nonexistent path string must be returned.
     """
     def __contains__(self, item):
         return True
 
     def __getitem__(self, item):
-        if django.VERSION[:2] < (1, 9):  # pragma: no cover
-            return 'nomigrations'
-        else:
-            return None
+        return None


### PR DESCRIPTION
Now that we're on Django 1.11, we can remove logic that checks `django.VERSION` to support both 1.8 and 1.11. This PR includes two such changes:

1. Simplifies inclusion of overextends templatetags implemented in #4474. Test by visiting the Django admin locally, e.g. http://localhost:8000/django-admin/.
2. Simplifies disabling migrations logic introduced in #4477. Test by running Python tests without migrations, e.g. `tox -e fast`, and note that migrations don't get run.

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [X] Passes all existing automated tests
- [X] Any _change_ in functionality is tested
- [X] New functions are documented (with a description, list of inputs, and expected output)
- [X] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [X] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: