### PR TITLE
Use Django-Flags middleware and bump Django-Flags and Wagtail-Flags versions

### DIFF
--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -112,7 +112,8 @@ MIDDLEWARE_CLASSES = (
     'wagtail.wagtailredirects.middleware.RedirectMiddleware',
 
     'core.middleware.ParseLinksMiddleware',
-    'core.middleware.DownstreamCacheControlMiddleware'
+    'core.middleware.DownstreamCacheControlMiddleware',
+    'flags.middleware.FlagConditionsMiddleware',
 )
 
 CSP_MIDDLEWARE_CLASSES = ('csp.middleware.CSPMiddleware', )

--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -171,6 +171,8 @@ TEMPLATES = [
                 'wagtail.wagtailadmin.jinja2tags.userbar',
                 'wagtail.wagtailimages.jinja2tags.images',
 
+                'flags.jinja2tags.flags',
+
                 'core.jinja2tags.filters',
                 'regulations3k.jinja2tags.regulations',
                 'v1.jinja2tags.datetimes_extension',

--- a/cfgov/core/jinja2tags.py
+++ b/cfgov/core/jinja2tags.py
@@ -1,4 +1,3 @@
-from flags.template_functions import flag_disabled, flag_enabled
 from jinja2.ext import Extension
 
 from core.templatetags.svg_icon import svg_icon
@@ -9,9 +8,6 @@ class CoreExtension(Extension):
     def __init__(self, environment):
         super(CoreExtension, self).__init__(environment)
         self.environment.globals.update({
-            'flag_enabled': flag_enabled,
-            'flag_disabled': flag_disabled,
-
             'signed_redirect': signed_redirect,
             'unsigned_redirect': unsigned_redirect,
 

--- a/requirements/libraries.txt
+++ b/requirements/libraries.txt
@@ -5,7 +5,7 @@ dj-database-url==0.5.0
 djangorestframework==3.6.4
 django-csp==3.4
 django-extensions==2.1.3
-django-flags==3.0.2
+django-flags==4.0.0
 django-haystack==2.7.0
 django-localflavor==1.6.2
 # django-mptt is required by teachers-digital-platform
@@ -36,7 +36,7 @@ six==1.11.0
 unicodecsv==0.14.1
 unipath>=1.1,<=2.0
 urllib3==1.23
-wagtail-flags==3.0.1
+wagtail-flags==4.0.0
 wagtail-inventory==0.5.1
 wagtail-sharing==0.7
 wagtail-treemodeladmin==1.0.4


### PR DESCRIPTION
This change makes use of the Django-Flags middleware introduced in https://github.com/cfpb/django-flags/pull/11, which should reduce the number of database queries per request made for checking flag state.

## Testing

Before checking out this branch, do some benchmarking with the Django Debug Toolbar without the middleware:

1. Enable the Django Debug Toolbar. 

   Add `export ENABLE_DEBUG_TOOLBAR=True` to your .env file.

2. Restart your Docker Python container or re-source your .env file and restart your local running cfgov-refresh.

3. Visit the homepage and observe the number of SQL queries for flag_state. Particularly the number of duplicated flags.

![image](https://user-images.githubusercontent.com/10562538/46151205-466a5480-c23c-11e8-9d68-1d763198acc4.png)

With the middleware:

1. Checkout this branch and make sure to update the requirements in the docker container:
   - Docker:

      ```shell
      ./shell.sh
      ...
      pip install -r requirements/libraries.txt
      ```

   - Local virtualenv:

      With your cfgov-refresh virtualenv active:

      ```shell
      pip install -r requirements/libraries.txt
      ```

2. Start or restart your local instance of cfgov-refresh or the Docker Python container.

3. Visit the homepage and observe the lack of repeated SQL queries to `flag_state`.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
