### PR TITLE
Add tests to custom makemessages command

### DIFF
--- a/cfgov/v1/management/commands/makemessages.py
+++ b/cfgov/v1/management/commands/makemessages.py
@@ -5,18 +5,12 @@
 # The code is based on this StackOverflow question and answer:
 # https://stackoverflow.com/questions/2090717/getting-translation-strings-for-jinja2-templates-integrated-with-django-1-x
 # And the Django docs:
-# https://docs.djangoproject.com/en/1.8/topics/i18n/translation/#customizing-the-makemessages-command
+# https://docs.djangoproject.com/en/1.11/topics/i18n/translation/#customizing-the-makemessages-command
 
 import re
 
-from django import VERSION
 from django.core.management.commands import makemessages
-
-
-if VERSION[:2] < (1, 11):
-    from django.utils.translation import trans_real
-else:
-    from django.utils.translation import template as trans_real
+from django.utils.translation import template as trans_real
 
 
 class Command(makemessages.Command):
@@ -39,9 +33,9 @@ class Command(makemessages.Command):
         # plural_re, constant_re, and one_percent_re should match both Jinja2
         # and Django conventions.
         trans_real.block_re = re.compile(
-            django_block_re + '|' + jinja_block_re)
+            django_block_re.pattern + '|' + jinja_block_re.pattern)
         trans_real.endblock_re = re.compile(
-            django_endblock_re + '|' + jinja_endblock_re)
+            django_endblock_re.pattern + '|' + jinja_endblock_re.pattern)
 
         # The rest of trans_real's regular expressions should match conventions
         # used in both Django and Jinja2 templates.

--- a/cfgov/v1/tests/management/commands/test_makemessages.py
+++ b/cfgov/v1/tests/management/commands/test_makemessages.py
@@ -1,0 +1,81 @@
+import os
+import shutil
+import tempfile
+
+from django.core.management import call_command
+from django.test import SimpleTestCase
+from django.utils._os import upath
+
+
+class TestCustomMakeMessages(SimpleTestCase):
+    DATA_DIR = 'test_makemessages_data'
+
+    LOCALE = 'de'
+
+    PO_FILE = 'locale/%s/LC_MESSAGES/django.po' % LOCALE
+
+    def setUp(self):
+        # https://github.com/django/django/blob/1.11.15/tests/i18n/utils.py#L33
+        self._cwd = os.getcwd()
+
+        # Create a temporary test directory to extract messages from.
+        self.temp_dir = tempfile.mkdtemp()
+
+        # Copy test data to temporary test directory.
+        test_dir = os.path.join(self.temp_dir, self.DATA_DIR)
+        shutil.copytree(
+            os.path.join(os.path.dirname(__file__), self.DATA_DIR),
+            test_dir,
+            ignore=shutil.ignore_patterns('*.pyc', '__pycache__')
+        )
+
+        # Create a destination locale directory in the temp directory. We don't
+        # include this in the source data being copied because we don't want it
+        # to be in the source tree when makemigrations is run normally.
+        os.mkdir(os.path.join(test_dir, 'locale'))
+
+        # Remove the temporary test directory on cleanup.
+        self.addCleanup(self._rmrf, self.temp_dir)
+
+        # Change back to the previous working directory on cleanup.
+        self.addCleanup(os.chdir, self._cwd)
+
+        # Change to the test directory so that running makemessages both reads
+        # the files located there and writes its output there.
+        os.chdir(test_dir)
+
+    def _rmrf(self, dname):
+        # Only remove this location if we're really deleting the right thing.
+        # https://github.com/django/django/blob/1.11.15/tests/i18n/utils.py
+        if (
+            os.path.commonprefix([self.temp_dir, os.path.abspath(dname)]) !=
+            self.temp_dir
+        ):
+            return
+
+        shutil.rmtree(dname)
+
+    def test_extraction_works_as_expected_including_jinja2_block(self):
+        call_command('makemessages', locale=[self.LOCALE], verbosity=0)
+
+        with open(self.PO_FILE, 'r') as f:
+            contents = f.read()
+
+        expected = '''
+#: __init__.py:4
+msgid "Test string from Python file."
+msgstr ""
+
+#: jinja2/test.html:1
+msgid ""
+"\\n"
+"Test string from Jinja template.\\n"
+"This is in a multi-line block.\\n"
+msgstr ""
+
+#: templates/test.html:2
+msgid "Test string from Django template."
+msgstr ""
+'''
+
+        self.assertIn(expected, contents)

--- a/cfgov/v1/tests/management/commands/test_makemessages.py
+++ b/cfgov/v1/tests/management/commands/test_makemessages.py
@@ -1,12 +1,19 @@
 import os
 import shutil
 import tempfile
+from unittest import skipUnless
 
 from django.core.management import call_command
+from django.core.management.utils import find_command
 from django.test import SimpleTestCase
 from django.utils._os import upath
 
 
+# https://github.com/django/django/blob/1.11.15/tests/i18n/test_extraction.py
+has_xgettext = find_command('xgettext')
+
+
+@skipUnless(has_xgettext, 'xgettext is mandatory for extraction tests')
 class TestCustomMakeMessages(SimpleTestCase):
     DATA_DIR = 'test_makemessages_data'
 

--- a/cfgov/v1/tests/management/commands/test_makemessages_data/__init__.py
+++ b/cfgov/v1/tests/management/commands/test_makemessages_data/__init__.py
@@ -1,0 +1,4 @@
+from django.utils.translation import ugettext as _
+
+
+test = _("Test string from Python file.")

--- a/cfgov/v1/tests/management/commands/test_makemessages_data/jinja2/test.html
+++ b/cfgov/v1/tests/management/commands/test_makemessages_data/jinja2/test.html
@@ -1,0 +1,4 @@
+{% trans %}
+Test string from Jinja template.
+This is in a multi-line block.
+{% endtrans %}

--- a/cfgov/v1/tests/management/commands/test_makemessages_data/templates/test.html
+++ b/cfgov/v1/tests/management/commands/test_makemessages_data/templates/test.html
@@ -1,0 +1,2 @@
+{% load i18n %}
+{% trans "Test string from Django template." %}

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -360,6 +360,37 @@ Uncomment and set the GovDelivery environment variables in your `.env` file.
     The API is used by subscribe forms on our website.
     Users may decide to swap this tool out for another third-party service.
 
+### Install GNU gettext for Django translation support
+
+In order to generate Django translations as documented
+[here](translation.md), you'll need to install the
+[GNU gettext](https://www.gnu.org/software/gettext/) library.
+
+On MacOS, GNU gettext is available via Homebrew:
+
+```
+brew install gettext
+```
+
+but it gets installed as
+["keg-only"](https://docs.brew.sh/FAQ#what-does-keg-only-mean) due to conflicts
+with the default installation of BSD gettext. This means that GNU gettext won't
+be loaded in your PATH by default. To fix this, you can run
+
+```
+brew link --force gettext
+```
+
+to force its installation, or see `brew info gettext` for an alternate
+solution.
+
+If installed locally, you should be able to run this command successfully:
+
+```
+$ gettext --version
+```
+
+GNU gettext is also required to run our translation-related unit tests locally.
 
 ## Curious about what the setup scripts are doing?
 

--- a/docs/translation.md
+++ b/docs/translation.md
@@ -1,10 +1,13 @@
 # Translation
 
-As cfgov-refresh is a Django project, the [Django translation documentation is a good place to start](https://docs.djangoproject.com/en/1.8/topics/i18n/translation/#set-language-redirect-view). What follows is a brief introduction to translations with the particular tools cfgov-refresh uses (like Jinja2 templates) and the conventions we use.
+As cfgov-refresh is a Django project, the [Django translation documentation is a good place to start](https://docs.djangoproject.com/en/1.11/topics/i18n/translation/). What follows is a brief introduction to translations with the particular tools cfgov-refresh uses (like Jinja2 templates) and the conventions we use.
 
 ## Overview
 
-Translation is generally handled by one form or another of [gettext](https://en.wikipedia.org/wiki/Gettext). By convention, this is usually performed in code by wrapping a string to be translated in a function that is either named or aliased with an underscore. For example:
+Django translations use [GNU gettext](https://en.wikipedia.org/wiki/Gettext) (see
+[the installation instructions](installation.md#install-gnu-gettext-for-django-translation-support)).
+
+By convention, translations are usually performed in code by wrapping a string to be translated in a function that is either named or aliased with an underscore. For example:
 
 ```python
 _("This is a translatable string.")


### PR DESCRIPTION
This change adds a Python test for the v1 app's custom `makemessages` Django management command, which overrides the default one documented at

https://docs.djangoproject.com/en/1.11/ref/django-admin/#django-admin-makemessages

Our custom makemessages command adds support for block tags like this:

```
{% trans %}
Multi-line
statement
here
{% endtrans %}
```

which is not supported in Django templates.

This change also removes support in this command for Django 1.8 now that this project is solely targeted at Django 1.11.

## Testing

To test this locally, you can verify that the unit test passes, and then remove our custom makemessages command (including the .pyc file if on Python 2). The built-in command will fail as it does not detect the multi-line Jinja2 tag.

Additionally, you can run through the makemessages workflow documented [here](https://cfpb.github.io/cfgov-refresh/translation/) to confirm that the command still works.

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [X] Passes all existing automated tests
- [X] Any _change_ in functionality is tested
- [X] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Project documentation has been updated
- [X] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: