### PR TITLE
Update StdoutCapturingTestRunner to Django 1.11

### DIFF
--- a/docs/testing-be.md
+++ b/docs/testing-be.md
@@ -1,8 +1,8 @@
 # Backend testing
 
-## Django and Python unit tests
+## Django and Python tests
 
-To run the the full suite of unit tests using Tox, cd to the project root and
+To run the the full suite of Python tests using Tox, cd to the project root and
 then run:
 
 ```
@@ -23,6 +23,21 @@ To see Python code coverage information, run
 ```
 ./show_coverage.sh
 ```
+
+## Test output
+
+Python tests should avoid writing to stdout as part of their normal execution.
+To enforce this convention, the tests can be run using a custom Django test
+runner that fails if anything is written to stdout. This test runner is at
+`cfgov.test.StdoutCapturingTestRunner` and can be enabled with the `TEST_RUNNER`
+environment variable:
+
+```
+TEST_RUNNER=cfgov.test.StdoutCapturingTestRunner tox -e fast
+```
+
+This test runner is enabled when tests are run automatically on [Travis CI](https://travis-ci.org/),
+but is not used by defalt when running tests locally.
 
 ## Source code linting
 


### PR DESCRIPTION
This change updates the logic in our custom [StdoutCapturingTestRunner](https://github.com/cfpb/cfgov-refresh/blob/337f9a69aba8f56eb0791d4554463088c482d878/cfgov/cfgov/test.py#L195) class to simplify it a bit and remove a reference to Django 1.8.

Unfortunately this change actually has the side effect of making the unit tests for this custom test runner a bit more complicated.

Between 1.8 and 1.11, a change was made to address this Django ticket:

https://code.djangoproject.com/ticket/26981

The ability was added for Django TestRunner classes to provide custom kwargs to the underlying unittest test runner, which is the thing that actually runs the tests. This was implemented in this PR:

https://github.com/django/django/pull/7009

That PR added the ability for Django TestRunner classes to define a custom get_test_runner_kwargs method to provide custom kwargs.

By default the unittest test runner (TextTestRunner) prints its status to the console using stderr (this is the output that contains `...E..F` and shows how many tests are run). When we actually test our test runner, we want to suppress this output.

See comment in the modified test file for a bit more explanation.

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [X] Passes all existing automated tests
- [X] Any _change_ in functionality is tested
- [X] New functions are documented (with a description, list of inputs, and expected output)
- [X] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: