### PR TITLE
Bump satellite apps: Bring in post-Django 1.11 upgrade cleanup

### DIFF
--- a/requirements/optional-public.txt
+++ b/requirements/optional-public.txt
@@ -1,7 +1,7 @@
-https://github.com/cfpb/college-costs/releases/download/2.4.2/college_costs-2.4.2-py2-none-any.whl
-https://github.com/cfpb/owning-a-home-api/releases/download/0.11.1/owning_a_home_api-0.11.1-py2-none-any.whl
-https://github.com/cfpb/retirement/releases/download/0.7.2/retirement-0.7.2-py2-none-any.whl
-https://github.com/cfpb/ccdb5-api/releases/download/v1.0.7/ccdb5_api-1.0.7-py2-none-any.whl
-https://github.com/cfpb/ccdb5-ui/releases/download/v1.0.13/ccdb5_ui-1.0.13-py2-none-any.whl
-https://github.com/cfpb/django-college-costs-comparison/releases/download/1.7.1/comparisontool-1.7.1-py2-none-any.whl
+https://github.com/cfpb/college-costs/releases/download/2.4.3/college_costs-2.4.3-py2-none-any.whl
+https://github.com/cfpb/owning-a-home-api/releases/download/0.11.2/owning_a_home_api-0.11.2-py2-none-any.whl
+https://github.com/cfpb/retirement/releases/download/0.7.3/retirement-0.7.3-py2-none-any.whl
+https://github.com/cfpb/ccdb5-api/releases/download/1.1.0/ccdb5_api-1.1.0-py2-none-any.whl
+https://github.com/cfpb/ccdb5-ui/releases/download/1.1.0/ccdb5_ui-1.1.0-py2-none-any.whl
+https://github.com/cfpb/django-college-costs-comparison/releases/download/1.7.2/comparisontool-1.7.2-py2-none-any.whl
 https://github.com/cfpb/teachers-digital-platform/releases/download/1.0.21/teachers_digital_platform-1.0.21-py2-none-any.whl


### PR DESCRIPTION
In all satellite apps:
- Specify Django 1.11 in setup.py
- Remove tests for Django 1.8 from Tox
- Update documentation where necessary

## Changes

- Update all satellite apps to latest release

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [x] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Internet Explorer 8, 9, 10, and 11
- [ ] Edge
- [ ] iOS Safari
- [ ] Chrome for Android

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
