### PR TITLE
Updates chart source footer

### DIFF
--- a/cfgov/jinja2/v1/_includes/organisms/chart.html
+++ b/cfgov/jinja2/v1/_includes/organisms/chart.html
@@ -9,11 +9,11 @@
 
    Create a chart organism with data.
    See [GHE]/flapjack/Modules-V1/wiki/Chart
-   
+
    value.has_top_rule_line:        Boolean for whether or not to add top
-                                   border to chart. Used in
-                                   'render_block.html' to modify classes on
-                                   wrapping 'div.block'.
+                                   border to chart.
+                                   Used in 'render_block.html' to modify
+                                   classes on wrapping 'div.block'.
 
    ========================================================================== #}
 
@@ -22,29 +22,35 @@
     <h3>{{ value.title }}</h3>
     {% endif %}
 
-  <div class="m-chart-image cfpb-chart"
-       {% if value.title %}data-chart-title="{{ value.title }}"{% endif %}
-       {% if value.chart_type %}data-chart-type="{{ value.chart_type }}"{% endif %}
-       {% if value.y_axis_label %}
-            data-chart-y-axis-label="{{ value.y_axis_label }}"
-       {% endif %}
-       {% if value.metadata %}data-chart-metadata="{{ value.metadata }}"{% endif %}
-       {% if value.data_source %}data-chart-source="{{ value.data_source }}"{% endif %}
-       {% if value.description %}data-chart-description="{{ value.description }}"{% endif %}
-       {% if value.color_scheme %}data-chart-color="{{ value.color_scheme }}"{% endif %}
-       >
-       {% if value.description %}{{ value.description }}{% endif %}
-  </div>
+    <div class="m-chart-image cfpb-chart"
+         {% if value.title %}data-chart-title="{{ value.title }}"{% endif %}
+         {% if value.chart_type %}data-chart-type="{{ value.chart_type }}"{% endif %}
+         {% if value.y_axis_label %}
+              data-chart-y-axis-label="{{ value.y_axis_label }}"
+         {% endif %}
+         {% if value.metadata %}data-chart-metadata="{{ value.metadata }}"{% endif %}
+         {% if value.data_source %}data-chart-source="{{ value.data_source }}"{% endif %}
+         {% if value.description %}data-chart-description="{{ value.description }}"{% endif %}
+         {% if value.color_scheme %}data-chart-color="{{ value.color_scheme }}"{% endif %}
+         >
+         {% if value.description %}{{ value.description }}{% endif %}
+    </div>
 
-  <p class="m-chart-footnote block__sub block__border-top block short-desc">
-      {% if value.data_source %}
-      <strong>Source:</strong> <a class="icon-link icon-link__download" href="https://s3.amazonaws.com/files.consumerfinance.gov/data/{{ value.data_source }}"> <span class="icon-link_text">Download CSV file</span> </a><br>
-      {% endif %}
+    <p class="m-chart-footnote block__sub block__border-top block short-desc">
+        <strong>Source:</strong> BCFP Consumer Credit Panel<br>
+        <strong>Date published:</strong> {{ value.date_published.strftime('%B %Y') }}<br>
 
-      <strong>Date published:</strong> {{ value.date_published.strftime('%B %Y') }}<br>
+        {% if value.data_source %}
+        <a class="icon-link icon-link__download"
+           href="https://files.consumerfinance.gov/data/{{ value.data_source }}">
+            <span class="icon-link_text">Download CSV file</span>
+        </a><br>
+        {% endif %}
 
-      {% if value.note %}
-      <strong>Note:</strong> {{ value.note }} The most recent data available in each visualization is for {{ value.last_updated_projected_data.strftime('%B %Y') }}.
-      {% endif %}
+        {% if value.note %}
+        <strong>Note:</strong>
+        {{ value.note }} The most recent data available in each visualization
+        is for {{ value.last_updated_projected_data.strftime('%B %Y') }}.
+        {% endif %}
     </p>
 </div>

--- a/cfgov/jinja2/v1/_includes/organisms/chart.html
+++ b/cfgov/jinja2/v1/_includes/organisms/chart.html
@@ -41,9 +41,10 @@
         <strong>Date published:</strong> {{ value.date_published.strftime('%B %Y') }}<br>
 
         {% if value.data_source %}
+        <strong>Download:</strong>
         <a class="icon-link icon-link__download"
            href="https://files.consumerfinance.gov/data/{{ value.data_source }}">
-            <span class="icon-link_text">Download CSV file</span>
+            <span class="icon-link_text">CSV file</span>
         </a><br>
         {% endif %}
 

--- a/cfgov/jinja2/v1/_includes/organisms/chart.html
+++ b/cfgov/jinja2/v1/_includes/organisms/chart.html
@@ -42,10 +42,12 @@
 
         {% if value.data_source %}
         <strong>Download:</strong>
+        {# Note: link closing tag needs to be on the same line to avoid a
+                 trailing space in the link. #}
         <a class="icon-link icon-link__download"
            href="https://files.consumerfinance.gov/data/{{ value.data_source }}">
-            <span class="icon-link_text">CSV file</span>
-        </a><br>
+            <span class="icon-link_text">CSV file</span></a>
+        <br>
         {% endif %}
 
         {% if value.note %}

--- a/cfgov/jinja2/v1/_includes/organisms/chart.html
+++ b/cfgov/jinja2/v1/_includes/organisms/chart.html
@@ -52,6 +52,7 @@
 
         {% if value.note %}
         <strong>Note:</strong>
+        {{ value.note }}
         The most recent data available in each visualization are for {{ value.last_updated_projected_data.strftime('%B %Y') }}.
         {% endif %}
     </p>

--- a/cfgov/jinja2/v1/_includes/organisms/chart.html
+++ b/cfgov/jinja2/v1/_includes/organisms/chart.html
@@ -52,8 +52,7 @@
 
         {% if value.note %}
         <strong>Note:</strong>
-        {{ value.note }} The most recent data available in each visualization
-        is for {{ value.last_updated_projected_data.strftime('%B %Y') }}.
+        The most recent data available in each visualization are for {{ value.last_updated_projected_data.strftime('%B %Y') }}.
         {% endif %}
     </p>
 </div>

--- a/cfgov/scripts/_atomic_helpers.py
+++ b/cfgov/scripts/_atomic_helpers.py
@@ -456,7 +456,7 @@ chart_block = {
         'date_published': u'2018-01-01',
         'description': u'Description',
         'last_updated_projected_data': u'2016-04-01',
-        'note': 'Data not final',
+        'note': 'Data not final.',
     }
 }
 

--- a/cfgov/v1/tests/atomic_elements/organisms/test_organisms.py
+++ b/cfgov/v1/tests/atomic_elements/organisms/test_organisms.py
@@ -355,10 +355,10 @@ class OrganismsTestCase(TestCase):
         response = self.client.get('/browse/')
         self.assertContains(response, 'Volume of credit cards originated')
         self.assertContains(response, 'foo/bar.csv')
-        self.assertContains(response, 'Data not final')
+        self.assertContains(response, 'Data not final.')
         self.assertContains(
             response,
-            'The most recent data available in each visualization is for April 2016'
+            'The most recent data available in each visualization are for April 2016'
         )
         self.assertContains(response, 'January 2018')
 

--- a/cfgov/v1/tests/management/commands/test_update_chart_block_dates.py
+++ b/cfgov/v1/tests/management/commands/test_update_chart_block_dates.py
@@ -42,7 +42,7 @@ class UpdateChartBlockDatesTestCase(TestCase):
             # Tests last_updated_projected_data is correct
             self.assertContains(
                 response,
-                'The most recent data available in each visualization is for June 2017'
+                'The most recent data available in each visualization are for June 2017'
             )
             # Tests date_published is correct
             self.assertContains(response, 'August 2017')


### PR DESCRIPTION
## Changes

- Updates charts footer to set footer source text to "BCFP Consumer Credit Panel" and moves download to its own line.
- Fixes template file indenting.

## Testing

1. Run local server.
2. Check CCT charts and see the footer is updated (e.g. http://localhost:8000/data-research/consumer-credit-trends/auto-loans/origination-activity/) 

## Screenshots

<img width="718" alt="screen shot 2018-10-01 at 11 34 09 am" src="https://user-images.githubusercontent.com/704760/46298793-f78b2a80-c56d-11e8-9ca7-f82065f072a6.png">



