### PR TITLE
Upgrade Python Libraries

### DIFF
--- a/requirements/libraries.txt
+++ b/requirements/libraries.txt
@@ -1,5 +1,5 @@
 address==0.1.1
-beautifulsoup4==4.5.1
+beautifulsoup4==4.6.3
 boto3==1.7.80
 dj-database-url==0.5.0
 djangorestframework==3.6.4

--- a/requirements/libraries.txt
+++ b/requirements/libraries.txt
@@ -19,7 +19,7 @@ django-overextends==0.4.3
 django-storages==1.5.0
 django-treebeard==3.0
 django-watchman==0.15.0
-edgegrid-python==1.0.10
+edgegrid-python==1.1.1
 elasticsearch==2.4.1
 govdelivery==1.2
 Jinja2==2.7.3

--- a/requirements/libraries.txt
+++ b/requirements/libraries.txt
@@ -24,7 +24,7 @@ elasticsearch==2.4.1
 govdelivery==1.2
 Jinja2==2.7.3
 jsonfield==2.0.2
-lxml==4.1.0
+lxml==4.2.5
 Markdown==2.6.11
 markdown-emdash==0.1.0
 ntplib==0.3.3

--- a/requirements/libraries.txt
+++ b/requirements/libraries.txt
@@ -1,7 +1,7 @@
 address==0.1.1
 beautifulsoup4==4.5.1
 boto3==1.7.80
-dj-database-url==0.4.2
+dj-database-url==0.5.0
 djangorestframework==3.6.4
 djangorestframework-csv==2.0.0
 django-csp==3.4

--- a/requirements/libraries.txt
+++ b/requirements/libraries.txt
@@ -5,7 +5,7 @@ dj-database-url==0.4.2
 djangorestframework==3.6.4
 djangorestframework-csv==2.0.0
 django-csp==3.4
-django-extensions==2.1.0
+django-extensions==2.1.3
 django-flags==3.0.2
 django-haystack==2.7.0
 django-localflavor==1.1

--- a/requirements/libraries.txt
+++ b/requirements/libraries.txt
@@ -42,14 +42,12 @@ pyelasticsearch==0.6.1
 python-dateutil==2.1
 PyYAML==3.11
 pytz
-requests==2.18.4
-requests_toolbelt==0.6.0
+requests==2.19.1
+requests_toolbelt==0.8.0
 sha3==0.2.1
 six==1.10.0
 unicodecsv==0.14.1
 unipath>=1.1,<=2.0
-# TODO: Remove explicit urllib3 requirement once requests is updated to support urllib3 1.23
-urllib3==1.22
 wagtail-flags==3.0.1
 wagtail-inventory==0.5.1
 wagtail-sharing==0.6.1

--- a/requirements/libraries.txt
+++ b/requirements/libraries.txt
@@ -30,7 +30,7 @@ markdown-emdash==0.1.0
 ntplib==0.3.3
 openpyxl==2.5.0
 pyelasticsearch==0.6.1
-python-dateutil==2.1
+python-dateutil==2.7.3
 pytz
 # PyYAML is required by college-costs
 PyYAML==3.13

--- a/requirements/libraries.txt
+++ b/requirements/libraries.txt
@@ -28,7 +28,7 @@ lxml==4.1.0
 Markdown==2.6.11
 markdown-emdash==0.1.0
 ntplib==0.3.3
-openpyxl==2.5.0
+openpyxl==2.5.8
 pyelasticsearch==0.6.1
 python-dateutil==2.7.3
 pytz

--- a/requirements/libraries.txt
+++ b/requirements/libraries.txt
@@ -37,7 +37,7 @@ PyYAML==3.13
 requests==2.19.1
 requests_toolbelt==0.8.0
 sha3==0.2.1
-six==1.10.0
+six==1.11.0
 unicodecsv==0.14.1
 unipath>=1.1,<=2.0
 wagtail-flags==3.0.1

--- a/requirements/libraries.txt
+++ b/requirements/libraries.txt
@@ -5,7 +5,6 @@ dj-database-url==0.4.2
 djangorestframework==3.6.4
 djangorestframework-csv==2.0.0
 django-csp==3.4
-django-braces==1.0.0
 django-extensions==2.1.0
 django-flags==3.0.2
 django-haystack==2.7.0

--- a/requirements/libraries.txt
+++ b/requirements/libraries.txt
@@ -3,7 +3,6 @@ beautifulsoup4==4.5.1
 boto3==1.7.80
 dj-database-url==0.5.0
 djangorestframework==3.6.4
-djangorestframework-csv==2.0.0
 django-csp==3.4
 django-extensions==2.1.3
 django-flags==3.0.2

--- a/requirements/libraries.txt
+++ b/requirements/libraries.txt
@@ -18,11 +18,6 @@ django-overextends==0.4.3
 # Versions >1.5.0,<=1.6.5 fail due to this issue:
 # https://github.com/jschneier/django-storages/issues/382
 django-storages==1.5.0
-# django-taggit 0.23.0 requires Django 1.11. Normally django-taggit is pulled
-# in by Wagtail's setup.py, but Wagtail 1.13 specifies >0.20,<1.0, which
-# unfortunately includes this version. This line can be removed once we are
-# on Django 1.11.
-django-taggit==0.22.2
 django-treebeard==3.0
 django-watchman==0.13.1
 edgegrid-python==1.0.10

--- a/requirements/libraries.txt
+++ b/requirements/libraries.txt
@@ -33,8 +33,9 @@ ntplib==0.3.3
 openpyxl==2.5.0
 pyelasticsearch==0.6.1
 python-dateutil==2.1
-PyYAML==3.11
 pytz
+# PyYAML is required by college-costs
+PyYAML==3.13
 requests==2.19.1
 requests_toolbelt==0.8.0
 sha3==0.2.1

--- a/requirements/libraries.txt
+++ b/requirements/libraries.txt
@@ -26,7 +26,6 @@ geocoder==1.12.0
 govdelivery==1.2
 Jinja2==2.7.3
 jsonfield==2.0.2
-jsonschema==2.0.0
 lxml==4.1.0
 Markdown==2.6.11
 markdown-emdash==0.1.0

--- a/requirements/libraries.txt
+++ b/requirements/libraries.txt
@@ -44,4 +44,3 @@ wagtail-flags==3.0.1
 wagtail-inventory==0.5.1
 wagtail-sharing==0.6.1
 wagtail-treemodeladmin==1.0.3
-Wand==0.4.2

--- a/requirements/libraries.txt
+++ b/requirements/libraries.txt
@@ -18,7 +18,7 @@ django-overextends==0.4.3
 # https://github.com/jschneier/django-storages/issues/382
 django-storages==1.5.0
 django-treebeard==3.0
-django-watchman==0.13.1
+django-watchman==0.15.0
 edgegrid-python==1.0.10
 elasticsearch==2.4.1
 govdelivery==1.2

--- a/requirements/libraries.txt
+++ b/requirements/libraries.txt
@@ -22,7 +22,6 @@ django-treebeard==3.0
 django-watchman==0.13.1
 edgegrid-python==1.0.10
 elasticsearch==2.4.1
-geocoder==1.12.0
 govdelivery==1.2
 Jinja2==2.7.3
 jsonfield==2.0.2

--- a/requirements/libraries.txt
+++ b/requirements/libraries.txt
@@ -8,7 +8,7 @@ django-csp==3.4
 django-extensions==2.1.3
 django-flags==3.0.2
 django-haystack==2.7.0
-django-localflavor==1.1
+django-localflavor==1.6.2
 # django-mptt is required by teachers-digital-platform
 django-mptt==0.9.0
 django-overextends==0.4.3

--- a/requirements/libraries.txt
+++ b/requirements/libraries.txt
@@ -41,5 +41,5 @@ unicodecsv==0.14.1
 unipath>=1.1,<=2.0
 wagtail-flags==3.0.1
 wagtail-inventory==0.5.1
-wagtail-sharing==0.6.1
+wagtail-sharing==0.7
 wagtail-treemodeladmin==1.0.3

--- a/requirements/libraries.txt
+++ b/requirements/libraries.txt
@@ -24,7 +24,6 @@ edgegrid-python==1.0.10
 elasticsearch==2.4.1
 geocoder==1.12.0
 govdelivery==1.2
-html5lib==0.9999999
 Jinja2==2.7.3
 jsonfield==2.0.2
 jsonschema==2.0.0

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -2,7 +2,7 @@
 -r postgres.txt
 django-debug-toolbar==1.7
 django-livereload==1.2
-django-sslserver==0.19
+django-sslserver==0.20
 tox-pip-extensions==1.1.0
 tox==2.9.1
 Werkzeug==0.10.4

--- a/requirements/manual.txt
+++ b/requirements/manual.txt
@@ -10,6 +10,6 @@ mkdocs-bootstrap==0.1.1
 mkdocs-bootswatch==0.1.0
 pymdown-extensions==2.0
 singledispatch==3.4.0.3
-six==1.9.0
+six==1.11.0
 tornado==4.1
 mkDOCter==1.0.5

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -3,5 +3,5 @@ django-sslserver==0.19
 github3.py==0.9.6
 mock==2.0.0
 model_mommy==1.2.6
-moto==1.3.1
-responses==0.5.1
+moto==1.3.6
+responses==0.9.0

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,5 +1,5 @@
 coverage==4.5.1
-django-sslserver==0.19
+django-sslserver==0.20
 github3.py==0.9.6
 mock==2.0.0
 model_mommy==1.2.6

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,4 +1,4 @@
-coverage==4.2
+coverage==4.5.1
 django-sslserver==0.19
 github3.py==0.9.6
 mock==2.0.0

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -1,3 +1,3 @@
-coverage==4.4.1
+coverage==4.5.1
 tox-pip-extensions==1.1.0
 tox==2.9.1


### PR DESCRIPTION
Upgrade python libraries where possible.
Note: I did not touch any libraries that are elasticsearch related. I also only touched libraries that are in the `test` and `libraries` requirements collections, since those are covered by unit tests.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [x] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Internet Explorer 8, 9, 10, and 11
- [ ] Edge
- [ ] iOS Safari
- [ ] Chrome for Android

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
