### PR TITLE
Remove references to Django 1.8 in tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,6 @@ envlist=lint-py{27}, unittest-py{27}-dj{111}-wag{113}-slow
 #   acceptance:         Run a Django server and acceptance tests
 #   py27:               Use Python 2.7
 #   py36:               Use Python 3.6
-#   dj18:               Use Django 1.8
 #   dj111:              Use Django 1.11
 #   dj20:               Use Django 2.0
 #   wag113:             Use Wagtail 1.13
@@ -26,32 +25,23 @@ envlist=lint-py{27}, unittest-py{27}-dj{111}-wag{113}-slow
 # These factors are expected to combine into the follow generative environments:
 #
 #   lint-py{27,36}
-#   unittest-py{27,36}-dj{18,111}-wag{113}-{fast,slow}
+#   unittest-py{27,36}-dj{111}-wag{113}-{fast,slow}
 #   unittest-py{36}-dj{20}-wag{20}-{fast,slow}
-#   missing-migrations-py{27,36}-dj{18,111}-wag{113}
-#   acceptance-py{27,36}-dj{18,111}-wag{113}-fast
+#   missing-migrations-py{27,36}-dj{111}-wag{113}
+#   acceptance-py{27,36}-dj{111}-wag{113}-fast
 #
 # These factors are expected to combine to be invoked with:
 #
 #   tox -e lint-py27
 #   tox -e lint-py36
-#   tox -e unittest-py27-dj18-wag113-fast
-#   tox -e unittest-py27-dj18-wag113-slow
 #   tox -e unittest-py27-dj111-wag113-fast
 #   tox -e unittest-py27-dj111-wag113-slow
-#   tox -e unittest-py36-dj18-wag113-fast
-#   tox -e unittest-py36-dj18-wag113-slow
 #   tox -e unittest-py36-dj111-wag113-fast
 #   tox -e unittest-py36-dj111-wag113-slow
 #   tox -e unittest-py36-dj20-wag20-fast
 #   tox -e unittest-py36-dj20-wag20-slow
-#   tox -e missing-migrations-py27-dj18-wag113
-#   tox -e missing-migrations-py27-dj111-wag113
-#   tox -e missing-migrations-py36-dj18-wag113
 #   tox -e missing-migrations-py36-dj111-wag113
-#   tox -e acceptance-py27-dj18-wag113-fast
 #   tox -e acceptance-py27-dj111-wag113-fast
-#   tox -e acceptance-py36-dj18-wag113-fast
 #   tox -e acceptance-py36-dj111-wag113-fast
 
 recreate=False
@@ -68,7 +58,6 @@ basepython=
     py36: python3.6
 
 deps=
-    dj18:               Django>=1.8,<1.9
     dj111:              Django>=1.11,<1.12
     dj20:               Django>=2.0,<2.1
     wag113:             wagtail>=1.13,<1.14


### PR DESCRIPTION
☝️ 

## Testing

`tox`

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [X] Passes all existing automated tests
- [X] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: