### PR TITLE
Upgrade django documentation links to 1.11

### DIFF
--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -193,7 +193,7 @@ if os.getenv('DATABASE_URL'):
     DATABASES['default'] = dj_database_url.config()
 
 # Internationalization
-# https://docs.djangoproject.com/en/1.8/topics/i18n/
+# https://docs.djangoproject.com/en/1.11/topics/i18n/
 
 LANGUAGE_CODE = 'en-us'
 
@@ -216,7 +216,7 @@ USE_TZ = True
 
 
 # Static files (CSS, JavaScript, Images)
-# https://docs.djangoproject.com/en/1.8/howto/static-files/
+# https://docs.djangoproject.com/en/1.11/howto/static-files/
 STATIC_URL = '/static/'
 
 # Absolute path to the directory static files should be collected to.

--- a/cfgov/cfgov/wsgi.py
+++ b/cfgov/cfgov/wsgi.py
@@ -4,7 +4,7 @@ WSGI config for cfgov project.
 It exposes the WSGI callable as a module-level variable named `application`.
 
 For more information on this file, see
-https://docs.djangoproject.com/en/1.8/howto/deployment/wsgi/
+https://docs.djangoproject.com/en/1.11/howto/deployment/wsgi/
 """
 
 import os

--- a/docs/wagtail-migrations.md
+++ b/docs/wagtail-migrations.md
@@ -4,7 +4,7 @@ Django data migrations with Wagtail can be challenging because programmatic edit
 
 ## Migrating StreamFields
 
-StreamFields do not follow a fixed structure, rather they're a freeform sequences of blocks. Making a change to a StreamField involves both creating a [Django schema migration](https://docs.djangoproject.com/en/1.8/topics/migrations/#workflow) and a custom [Django data migration](https://docs.djangoproject.com/en/1.8/topics/migrations/#data-migrations). The data migration needs to modify both the existing Wagtail pages that correspond to the changed model and all revisions of that page. It also needs to be able to manipulate the StreamField contents.
+StreamFields do not follow a fixed structure, rather they're a freeform sequences of blocks. Making a change to a StreamField involves both creating a [Django schema migration](https://docs.djangoproject.com/en/1.11/topics/migrations/#workflow) and a custom [Django data migration](https://docs.djangoproject.com/en/1.11/topics/migrations/#data-migrations). The data migration needs to modify both the existing Wagtail pages that correspond to the changed model and all revisions of that page. It also needs to be able to manipulate the StreamField contents.
 
 To this end, there are some utility functions in cfgov-refresh that make this easier. Using these utilities, a Django data migration that modifies a StreamField would use the following format:
 


### PR DESCRIPTION
A few different comments and docs have links to relevant django documentation. They were still pointing to Django 1.8 docs. Now that we're on Django 1.11, we link to the version that we're on, and we don't have to see a scary red "deprecated" banner on the documentation pages when we visit.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [x] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist
No code changes!