### PR TITLE
Remove outdated section from installation docs

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -199,8 +199,6 @@ that you may want to perform before continuing.
 Want to know more about what the setup scripts are doing?
 [Read the detailed rundown.](#curious-about-what-the-setup-scripts-are-doing)
 
-Get any errors? [See our troubleshooting tips.](#troubleshooting)
-
 **Continue following the [usage instructions](usage).**
 
 ## Docker-compose installation
@@ -452,21 +450,3 @@ Here's a rundown of each of the scripts called by `setup.sh` and what they do.
 
    Python dependencies are installed into the virtualenv via pip.
    Dependencies vary slightly depending on whether we're in dev, test, or prod.
-
-
-## Troubleshooting
-
-Here are some common issues and how you can fix them:
-
-### Errors referencing South, or other Python errors:
-
-Since moving to Django 1.8, we use Django's built-in migration engine,
-and we no longer use South.
-If you're getting South errors, you probably have it installed globally.
-To solve this, from outside the virtual environment, run `pip uninstall south`.
-
-If you're getting other kinds of Python errors (for example, when running tox),
-you may even want to go as far as uninstalling all globally-installed
-Python packages: `pip freeze | grep -v "^-e" | xargs pip uninstall -y`.
-After doing that, you'll need to reinstall virtualenv:
-`pip install virtualenv virtualenvwrapper`.


### PR DESCRIPTION
This change removes a troubleshooting section from the installation docs which is a bit outdated.

First, now that we're on Django 1.11, it's been quite some time since we've used South, so the instructions pertaining to it should no longer be needed.

Second, the recommendation to globally uninstall all Python packages (including virtualenv) seems overly broad, especially now that some people are using the Docker workflow. If not using Docker, all work should be done in a virtual environment, so the recommendation to uninstall all packages feels too strong.

## Testing

To test, `pip install -r requirements/manual.txt` then `mkdocs serve`, and navigate to http://localhost:8000/installation/.

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [X] Passes all existing automated tests
- [X] Any _change_ in functionality is tested
- [X] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [X] Project documentation has been updated
- [X] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: