### PR TITLE
Fix library version, which should fix deploys

### DIFF
--- a/requirements/libraries.txt
+++ b/requirements/libraries.txt
@@ -1,5 +1,5 @@
 address==0.1.1
-beautifulsoup4==4.6.3
+beautifulsoup4==4.6.0
 boto3==1.7.80
 dj-database-url==0.5.0
 djangorestframework==3.6.4


### PR DESCRIPTION
## Short description:

Because of an oversight, I included `beautifulsoup4==4.6.3` in #4564, but wagtail is only compatible with `<4.6.1`. This caused `tox` to fail with a version conflict, which breaks deploys. This PR replaces it with `beautifulsoup4==4.6.0`, so `tox` passes again.

## Long description:

`tox -e fast` installs in the following order (wagtail comes before libraries.txt?). Installing in this order gets us `beautifulsoup4==4.6.3` with no errors.
```
deps=
    -r{toxinidir}/requirements/django.txt
    -r{toxinidir}/requirements/wagtail.txt
    {[unittest]deps}
```


`slow`, which runs when we run `tox` without an environment, appears to install in the opposite order (libraries.txt before wagtail? idk, I might have these backward). Installing this way results in a version conflict error: `version conflict: beautifulsoup4 4.6.3 (.tox/unittest-py27-dj111-wag113-slow/lib/python2.7/site-packages) <-> beautifulsoup4<4.6.1,>=4.5.1 (from wagtail<1.14,>=1.13)`
```
deps=
    -r{toxinidir}/requirements/libraries.txt
    -r{toxinidir}/requirements/postgres.txt
    -r{toxinidir}/requirements/test.txt


unittest-py{27}-dj{111}-wag{113}-slow
```


So we see a version conflict failure in the slow tests, while the fast ones succeed. And since we only run the fast tests in Travis and slow tests in Jenkins, we didn't see the version conflict until after merging #4564.   

This change causes `tox` to pass, so deploys should now succeed.

## Changes

- `beautifulsoup4==4.6.3` ➡️ `4.6.0`

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [x] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
