### PR TITLE
Revert upgrade of edgegrid-python

### DIFF
--- a/requirements/libraries.txt
+++ b/requirements/libraries.txt
@@ -18,7 +18,7 @@ django-overextends==0.4.3
 django-storages==1.5.0
 django-treebeard==3.0
 django-watchman==0.15.0
-edgegrid-python==1.1.1
+edgegrid-python==1.0.10
 elasticsearch==2.4.1
 govdelivery==1.2
 Jinja2==2.7.3


### PR DESCRIPTION
The upgraded version was requiring a version of Python that is newer than what we have installed on cf.gov servers.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [x] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: