### PR TITLE
Update conf reg email notification format to support in-person/virtual attendance

### DIFF
--- a/cfgov/data_research/fixtures/conference_registrants.json
+++ b/cfgov/data_research/fixtures/conference_registrants.json
@@ -2,7 +2,7 @@
 {
     "fields": {
         "govdelivery_code": "TEST-GOVDELIVERY-CODE",
-        "details": "{\"other_dietary_restrictions\":\"\",\"name\":\"My Name\",\"other_accommodations\":\"\",\"sessions\":[\"Thursday morning\",\"Friday morning\"],\"accommodations\":[],\"dietary_restrictions\":[],\"organization\":\"My Organization\",\"email\":\"name@example.com\"}",
+        "details": "{\"other_dietary_restrictions\":\"\",\"name\":\"My Name\",\"other_accommodations\":\"\",\"sessions\":[\"Thursday morning\",\"Friday morning\"],\"accommodations\":[],\"dietary_restrictions\":[],\"organization\":\"My Organization\",\"email\":\"name@example.com\",\"attendee_type\":\"In person\"}",
         "created": "2018-01-01T12:00:00Z"
     },
     "model": "data_research.conferenceregistration",
@@ -11,7 +11,7 @@
 {
     "fields": {
         "govdelivery_code": "TEST-GOVDELIVERY-CODE",
-        "details": "{\"other_dietary_restrictions\":\"Only green foods.\",\"name\":\"Name with Unicod\\u00eb\",\"other_accommodations\":\"Great music.\",\"sessions\":[\"Thursday lunch\"],\"accommodations\":[\"Nursing Space\"],\"dietary_restrictions\":[\"Vegan\"],\"organization\":\"Another Organization\",\"email\":\"name2@example.com\"}",
+        "details": "{\"other_dietary_restrictions\":\"Only green foods.\",\"name\":\"Name with Unicod\\u00eb\",\"other_accommodations\":\"Great music.\",\"sessions\":[\"Thursday lunch\"],\"accommodations\":[\"Nursing Space\"],\"dietary_restrictions\":[\"Vegan\"],\"organization\":\"Another Organization\",\"email\":\"name2@example.com\",\"attendee_type\":\"Virtually\"}",
         "created": "2018-02-01T12:00:00Z"
     },
     "model": "data_research.conferenceregistration",

--- a/cfgov/data_research/forms.py
+++ b/cfgov/data_research/forms.py
@@ -33,8 +33,8 @@ class ConferenceRegistrationForm(forms.Form):
     If save(commit=False) is used, a model instance is created but not
     persisted to the database, and GovDelivery subscription is skipped.
     """
-    ATTENDEE_IN_PERSON = 'In person'
-    ATTENDEE_VIRTUALLY = 'Virtually'
+    ATTENDEE_IN_PERSON = ConferenceRegistration.IN_PERSON
+    ATTENDEE_VIRTUALLY = ConferenceRegistration.VIRTUAL
     ATTENDEE_TYPES = tuple((t, t) for t in (
         ATTENDEE_IN_PERSON,
         ATTENDEE_VIRTUALLY,

--- a/cfgov/data_research/forms.py
+++ b/cfgov/data_research/forms.py
@@ -138,22 +138,7 @@ class ConferenceRegistrationForm(forms.Form):
             govdelivery_code=self.govdelivery_code
         )
 
-        # TODO: In Django 1.9+, this logic can be optimized through use of
-        # Django's built-in Postgres JSONFields. This will require migrating
-        # the details field of the ConferenceRegistration model.
-        #
-        # attendees = ConferenceRegistrationForm.objects.filter(
-        #     govdelivery_code=self.govdelivery_code,
-        #     details__attendee_type=self.ATTENDEE_IN_PERSON
-        # )
-        in_person_attendees = filter(
-            lambda a: (
-                a.details.get('attendee_type') == self.ATTENDEE_IN_PERSON
-            ),
-            attendees
-        )
-
-        return len(in_person_attendees) >= self.capacity
+        return len(attendees.in_person()) >= self.capacity
 
     def save(self, commit=True):
         registration = ConferenceRegistration(

--- a/cfgov/data_research/models.py
+++ b/cfgov/data_research/models.py
@@ -15,10 +15,42 @@ from v1.models import BrowsePage
 logger = logging.getLogger(__name__)
 
 
+class ConferenceRegistrationQuerySet(models.QuerySet):
+    # TODO: In Django 1.9+, this logic can be optimized through use of
+    # Django's built-in Postgres JSONFields. This will require migrating
+    # the details field of the ConferenceRegistration model.
+    #
+    # return self.filter(
+    #     details__attendee_type=self.IN_PERSON
+    # )
+    def in_person(self):
+        return filter(
+            lambda a: (
+                a.details.get('attendee_type') ==
+                ConferenceRegistration.IN_PERSON
+            ),
+            self
+        )
+
+    def virtual(self):
+        return filter(
+            lambda a: (
+                a.details.get('attendee_type') ==
+                ConferenceRegistration.VIRTUAL
+            ),
+            self
+        )
+
+
 class ConferenceRegistration(models.Model):
+    IN_PERSON = 'In person'
+    VIRTUAL = 'Virtually'
+
     created = models.DateTimeField(auto_now_add=True)
     govdelivery_code = models.CharField(max_length=250)
     details = JSONField()
+
+    objects = ConferenceRegistrationQuerySet.as_manager()
 
 
 # mortgage metadata models

--- a/cfgov/data_research/research_conference.py
+++ b/cfgov/data_research/research_conference.py
@@ -101,23 +101,10 @@ class ConferenceNotifier(object):
 
     def __init__(self, govdelivery_code, capacity):
         exporter = ConferenceExporter(govdelivery_code)
-        form = ConferenceRegistrationForm
-        in_person_attendees = filter(
-            lambda a: (
-                a.details.get('attendee_type') == form.ATTENDEE_IN_PERSON
-            ),
-            exporter.registrants
-        )
-        virtual_attendees = filter(
-            lambda a: (
-                a.details.get('attendee_type') == form.ATTENDEE_VIRTUALLY
-            ),
-            exporter.registrants
-        )
 
         self.count = exporter.registrants.count()
-        self.count_in_person = len(in_person_attendees)
-        self.count_virtual = len(virtual_attendees)
+        self.count_in_person = len(exporter.registrants.in_person())
+        self.count_virtual = len(exporter.registrants.virtual())
         self.capacity = capacity
 
         if self.count:

--- a/cfgov/data_research/research_conference.py
+++ b/cfgov/data_research/research_conference.py
@@ -101,8 +101,23 @@ class ConferenceNotifier(object):
 
     def __init__(self, govdelivery_code, capacity):
         exporter = ConferenceExporter(govdelivery_code)
+        form = ConferenceRegistrationForm
+        in_person_attendees = filter(
+            lambda a: (
+                a.details.get('attendee_type') == form.ATTENDEE_IN_PERSON
+            ),
+            exporter.registrants
+        )
+        virtual_attendees = filter(
+            lambda a: (
+                a.details.get('attendee_type') == form.ATTENDEE_VIRTUALLY
+            ),
+            exporter.registrants
+        )
 
         self.count = exporter.registrants.count()
+        self.count_in_person = len(in_person_attendees)
+        self.count_virtual = len(virtual_attendees)
         self.capacity = capacity
 
         if self.count:
@@ -112,8 +127,10 @@ class ConferenceNotifier(object):
         context = {
             'conference_name': self.conference_name,
             'count': self.count,
+            'count_in_person': self.count_in_person,
+            'count_virtual': self.count_virtual,
             'capacity': self.capacity,
-            'at_capacity': self.count >= self.capacity,
+            'at_capacity': self.count_in_person >= self.capacity,
         }
 
         subject = loader.render_to_string(self.subject_template_name, context)

--- a/cfgov/data_research/templates/data_research/conference_notify_email.txt
+++ b/cfgov/data_research/templates/data_research/conference_notify_email.txt
@@ -1,9 +1,17 @@
 {% if at_capacity %}
-The {{ conference_name }} has reached capacity with {{ count }} submissions. Signups are now closed.
+The {{ conference_name }} has reached capacity with {{ count_in_person }} in-person attendees. In-person registration is now closed.
 
 The capacity for this event was set to {{ capacity }} at the time of this email.
+
+Total registrations for the {{ conference_name }}: {{ count }}
+
+In-person attendees: {{ count_in_person }}
+Virtual attendees: {{ count_virtual }}
 {% elif count %}
-The {{ conference_name }} is at {{ count }} of {{ capacity }} capacity for signups.
+Total registrations for the {{ conference_name }}: {{ count }}
+
+In-person attendees: {{ count_in_person }} (these count against the physical capacity of {{ capacity }})
+Virtual attendees: {{ count_virtual }}
 {% else %}
 The {{ conference_name }} has no registrations yet.
 {% endif %}

--- a/cfgov/data_research/templates/data_research/conference_notify_subject.txt
+++ b/cfgov/data_research/templates/data_research/conference_notify_subject.txt
@@ -1,1 +1,1 @@
-[{{ conference_name }}] Attendance {{ at_capacity|yesno:"Full,Update" }}
+[{{ conference_name }}] Attendance Update{{ at_capacity|yesno:" (in-person capacity reached)," }}


### PR DESCRIPTION
The conference registration notification email template was not updated to support the new option for in-person or virtual attendee registration, and the way in which that affects the capacity. This PR corrects that.

## Changes

- Updates `ConferenceNotifier` so that it has the information it needs about the different attendee counts and the question of being at capacity
- Updates the email body and subject templates to output the information accurately

## Testing

1. With a recent DB dump, edit http://localhost:8000/admin/pages/11796/edit/ to change the capacity to `1`.
1. Submit a registration for a virtual attendee
1. Run `./cfgov/manage.py conference_notify 11796 -t a@b.c --dry-run` to see the resulting email
1. Submit a registration for a physical attendee
1. Run `./cfgov/manage.py conference_notify 11796 -t a@b.c --dry-run` to see the resulting email
1. Submit another registration for a virtual attendee
1. Run `./cfgov/manage.py conference_notify 11796 -t a@b.c --dry-run` to see the resulting email

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [x] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: