### PR TITLE
Fix doubled border in mobile footer

### DIFF
--- a/cfgov/unprocessed/css/organisms/footer.less
+++ b/cfgov/unprocessed/css/organisms/footer.less
@@ -158,6 +158,16 @@
             margin: 0;
         }
 
+        .o-footer_col:nth-child(n+2) {
+            .o-footer_list {
+                .respond-to-max( @bp-xs-max, {
+                    .m-list_item .m-list_link {
+                        border-top-width: 0;
+                    }
+                } );
+            }
+        }
+
         .respond-to-min( @bp-sm-min, {
             .grid_column(8);
             border-right: 1px solid @gray-40;
@@ -174,6 +184,14 @@
     }
 
     &-middle-right {
+        .o-footer_list {
+            .respond-to-max( @bp-xs-max, {
+                .m-list_item .m-list_link {
+                    border-top-width: 0;
+                }
+            } );
+        }
+
         .respond-to-min( @bp-sm-min, {
             .grid_column(4);
 

--- a/cfgov/unprocessed/css/organisms/footer.less
+++ b/cfgov/unprocessed/css/organisms/footer.less
@@ -158,15 +158,16 @@
             margin: 0;
         }
 
-        .o-footer_col:nth-child(n+2) {
-            .o-footer_list {
-                .respond-to-max( @bp-xs-max, {
+        /* Fix doubled border in mobile view */
+        .respond-to-max( @bp-xs-max, {
+            .o-footer_col:nth-child( n+2 ) {
+                .o-footer_list {
                     .m-list_item .m-list_link {
                         border-top-width: 0;
                     }
-                } );
+                }
             }
-        }
+        } );
 
         .respond-to-min( @bp-sm-min, {
             .grid_column(8);
@@ -184,13 +185,14 @@
     }
 
     &-middle-right {
-        .o-footer_list {
-            .respond-to-max( @bp-xs-max, {
+        /* Fix doubled border in mobile view */
+        .respond-to-max( @bp-xs-max, {
+            .o-footer_list {
                 .m-list_item .m-list_link {
                     border-top-width: 0;
                 }
-            } );
-        }
+            }
+        } );
 
         .respond-to-min( @bp-sm-min, {
             .grid_column(4);


### PR DESCRIPTION
Closes #3575 

Does so by zeroing out the border-top-width of all list items except in the first column, which corresponds to the top of the footer in the collapsed mobile view.

To see the fix:

 - Pull branch
 - `npm run gulp styles`
 - Open any page, shrink browser to a mobile view, and bask in the non-doubled borders