### PR TITLE
Upgrade django-storages to latest

### DIFF
--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -384,6 +384,7 @@ AWS_QUERYSTRING_AUTH = False  # do not add auth-related query params to URL
 AWS_S3_FILE_OVERWRITE = False
 AWS_S3_SECURE_URLS = True  # True = use https; False = use http
 AWS_STORAGE_BUCKET_NAME = os.environ.get('AWS_STORAGE_BUCKET_NAME')
+AWS_DEFAULT_ACL = None  # Default to using the ACL of the bucket
 
 if os.environ.get('S3_ENABLED', 'False') == 'True':
     AWS_S3_ACCESS_KEY_ID = os.environ['AWS_S3_ACCESS_KEY_ID']

--- a/requirements/libraries.txt
+++ b/requirements/libraries.txt
@@ -11,11 +11,7 @@ django-localflavor==1.6.2
 # django-mptt is required by teachers-digital-platform
 django-mptt==0.9.0
 django-overextends==0.4.3
-# django-storages 1.6.6 drops support for Django 1.8.
-# https://github.com/jschneier/django-storages/blob/master/CHANGELOG.rst
-# Versions >1.5.0,<=1.6.5 fail due to this issue:
-# https://github.com/jschneier/django-storages/issues/382
-django-storages==1.5.0
+django-storages==1.7.1
 django-treebeard==3.0
 django-watchman==0.15.0
 edgegrid-python==1.0.10


### PR DESCRIPTION
 Upgrade django-storages library from 1.5.0 to its latest version (1.7.1), which requires updating the `AWS_DEFAULT_ACL` setting.

`AWS_DEFAULT_ACL` determines what permissions (ACL, Access Control List) are added to individual files when they are uploaded to our S3 bucket. That file's permissions are also dictated by the permissions of the bucket that contains it.

Version 2.0 of django-storages will change the default value of `AWS_DEFAULT_ACL` from `public-read` to `None`, to improve security. When set to `None`, it will not add the public-read ACL directly to each file; intstead, files fall back on the bucket's ACL. We added `AWS_DEFAULT_ACL = None` to silence a warning in 1.7.1, and to adopt the newly preferred behavior early.

@chosak and I tested and found that this update will not result in a change of behavior for us. Since the buckets in question have `public-read` permissions set up, all files will be publicly readable.


## Changes

- Upgrade version of django-storages, update a setting to keep behavior the same.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [x] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Internet Explorer 8, 9, 10, and 11
- [ ] Edge
- [ ] iOS Safari
- [ ] Chrome for Android

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
