### PR TITLE
pin urllib3 to 1.23

### DIFF
--- a/requirements/libraries.txt
+++ b/requirements/libraries.txt
@@ -35,6 +35,7 @@ sha3==0.2.1
 six==1.11.0
 unicodecsv==0.14.1
 unipath>=1.1,<=2.0
+urllib3==1.23
 wagtail-flags==3.0.1
 wagtail-inventory==0.5.1
 wagtail-sharing==0.7


### PR DESCRIPTION
urllib3 1.24 broke compatibility with the `requests` library. Here's an example bug report:

https://bugs.archlinux.org/task/60436

You can duplicate the issue locally by running `tox`. Pinning urllib3 to 1.23 resolves the error



## Additions

- added urllib3 to requirements/libraries.txt

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Internet Explorer 8, 9, 10, and 11
- [ ] Edge
- [ ] iOS Safari
- [ ] Chrome for Android

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
