### PR TITLE
Change method of setting origin param on YouTube URLs

### DIFF
--- a/cfgov/jinja2/v1/_includes/macros/video-player.html
+++ b/cfgov/jinja2/v1/_includes/macros/video-player.html
@@ -42,7 +42,7 @@
     {% if video_url.find( 'origin=' ) == -1 -%}
         {% set video_url = _buildParam(
              video_url,
-             'origin=' ~ request.scheme ~ '://' ~ request.META['HTTP_HOST']
+             'origin=' ~ request.scheme ~ '://' ~ request.get_host()
         ) %}
     {% endif %}
     {% set button_pos   = options.button_pos or 'center' %}


### PR DESCRIPTION
The fact that we don't have a reliable way to produce this `origin` string across different environments is probably causing us some issues.

See https://GHE/CFGOV/platform/issues/2895#issuecomment-186171 for further explanation.