### PR TITLE
Bail from video-player init if element isn't present

### DIFF
--- a/cfgov/unprocessed/js/modules/VideoPlayer.js
+++ b/cfgov/unprocessed/js/modules/VideoPlayer.js
@@ -94,6 +94,7 @@ VideoPlayer.init = function init( selector ) {
 
   _attachIFrame();
 
+  /* eslint-disable consistent-return */
   return videoPlayer;
 };
 

--- a/cfgov/unprocessed/js/modules/VideoPlayer.js
+++ b/cfgov/unprocessed/js/modules/VideoPlayer.js
@@ -85,11 +85,13 @@ VideoPlayer.init = function init( selector ) {
   'not([class*="' + CLASSES.VIDEO_PLAYER_SELECTOR + '"__"])';
 
   // There should only be one video player on the page.
-  let videoPlayer;
   const videoPlayerElement = document.querySelector( selector );
-  if ( videoPlayerElement ) {
-    videoPlayer = new this( videoPlayerElement );
-  }
+
+  // Nothing to initialize
+  if ( !videoPlayerElement ) return;
+
+  const videoPlayer = new this( videoPlayerElement );
+
   _attachIFrame();
 
   return videoPlayer;


### PR DESCRIPTION
Fixes rogue `childElement` errors