### PR TITLE
Fix smoke test for changed URL

### DIFF
--- a/cfgov/scripts/http_smoke_test.py
+++ b/cfgov/scripts/http_smoke_test.py
@@ -112,7 +112,7 @@ FULL_RUN = [
     '/about-us/careers/current-openings/',
     '/about-us/doing-business-with-us/',
     '/about-us/advisory-groups/',
-    '/about-us/project-catalyst/',
+    '/about-us/innovation/',
     '/about-us/contact-us/',
     '/eregulations/',
     '/eregulations/1026',
@@ -180,7 +180,7 @@ SHORT_RUN = [
     '/about-us/careers/current-openings/',
     # '/about-us/doing-business-with-us/',
     # '/about-us/advisory-groups/',
-    # '/about-us/project-catalyst/',
+    # '/about-us/innovation/',
     # '/about-us/contact-us/',
 ]
 


### PR DESCRIPTION
This URL changed without a redirect put in place, so the test started failing. I put the redirect in place, but we should still change the canonical URL in the test.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [x] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: