### PR TITLE
Make cfgov URL tests work with Python3

### DIFF
--- a/cfgov/cfgov/tests/test_urls.py
+++ b/cfgov/cfgov/tests/test_urls.py
@@ -118,8 +118,8 @@ class HandleErrorTestCase(TestCase):
     def test_handle_error_attribute_error(self, mock_render):
         mock_render.side_effect = AttributeError()
         result = urls.handle_error(404, self.factory.get('/test'))
-        self.assertIn('This request could not be processed', result.content)
-        self.assertIn('HTTP Error 404.', result.content)
+        self.assertIn(b'This request could not be processed', result.content)
+        self.assertIn(b'HTTP Error 404.', result.content)
 
     @mock.patch('cfgov.urls.render')
     def test_handle_error(self, mock_render):


### PR DESCRIPTION
This PR adds `bytes` casts for strings that test against a Django Response object's `content` in the `cfgov` package tests. This makes the `cfgov` package tests pass with Python 3.6.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
