### PR TITLE
ask-cfpb in python3

### DIFF
--- a/cfgov/ask_cfpb/templatetags/accent_stripper.py
+++ b/cfgov/ask_cfpb/templatetags/accent_stripper.py
@@ -1,5 +1,6 @@
+from __future__ import unicode_literals
+
 import unicodedata
-from six import text_type as unicode
 
 from django import template
 
@@ -8,7 +9,7 @@ register = template.Library()
 
 
 def strip_accents(value):
-    nfkd_form = unicodedata.normalize('NFKD', unicode(value))
+    nfkd_form = unicodedata.normalize('NFKD', value)
     only_ascii = nfkd_form.encode('ASCII', 'ignore')
     return only_ascii
 

--- a/cfgov/ask_cfpb/tests/models/test_pages.py
+++ b/cfgov/ask_cfpb/tests/models/test_pages.py
@@ -98,7 +98,7 @@ class OutputScriptFunctionTests(unittest.TestCase):
         timestamp = datetime.datetime.now().strftime("%Y-%m-%d")
         slug = 'ask-cfpb-{}.csv'.format(timestamp)
         m = mock_open()
-        with patch('__builtin__.open', m, create=True):
+        with patch('six.moves.builtins.open', m, create=True):
             export_questions()
         self.assertEqual(mock_output.call_count, 1)
         m.assert_called_once_with("/tmp/{}".format(slug), 'w')
@@ -334,9 +334,9 @@ class AnswerModelTestCase(TestCase):
         answer2.subcategory.add(subcategory)
 
         category_facet_map = json.loads(category.facet_map)
-        self.assertItemsEqual(
-            category_facet_map['subcategories']['7'],
-            ['14', '21']
+        self.assertEqual(
+            sorted(category_facet_map['subcategories']['7']),
+            sorted(['14', '21'])
         )
 
     def test_facet_map_skips_draft_page(self):

--- a/cfgov/ask_cfpb/tests/test_template_tags.py
+++ b/cfgov/ask_cfpb/tests/test_template_tags.py
@@ -9,13 +9,13 @@ class StripAccentTests(TestCase):
 
     def test_strip_unicode(self):
         code_point_map = [
-            ('\N{LATIN SMALL LETTER N WITH TILDE}', 'n'),
-            ('\N{LATIN CAPITAL LETTER N WITH TILDE}', 'N'),
-            ('\N{LATIN CAPITAL LETTER O WITH ACUTE}', 'O'),
-            ('\N{LATIN SMALL LETTER A WITH ACUTE}', 'a'),
-            ('\N{LATIN SMALL LETTER E WITH ACUTE}', 'e'),
-            ('\N{LATIN SMALL LETTER I WITH ACUTE}', 'i'),
-            ('\N{INVERTED QUESTION MARK}', ''),
+            ('\N{LATIN SMALL LETTER N WITH TILDE}', b'n'),
+            ('\N{LATIN CAPITAL LETTER N WITH TILDE}', b'N'),
+            ('\N{LATIN CAPITAL LETTER O WITH ACUTE}', b'O'),
+            ('\N{LATIN SMALL LETTER A WITH ACUTE}', b'a'),
+            ('\N{LATIN SMALL LETTER E WITH ACUTE}', b'e'),
+            ('\N{LATIN SMALL LETTER I WITH ACUTE}', b'i'),
+            ('\N{INVERTED QUESTION MARK}', b''),
         ]
         for code in code_point_map:
             self.assertEqual(


### PR DESCRIPTION
Refactor tests and code for Python3 compliance.

## Testing
Tests should run in python 2 and 3:

```
tox -e unittest-py36-dj111-wag113-fast ask_cfpb
tox -e fast ask_cfpb
```
