### PR TITLE
Make alerts tests work with Python3

### DIFF
--- a/cfgov/alerts/tests/test_send_new_relic_messages_to_sqs.py
+++ b/cfgov/alerts/tests/test_send_new_relic_messages_to_sqs.py
@@ -11,7 +11,7 @@ from alerts.send_new_relic_messages_to_sqs import (
 class TestSendNewRelicMessagesToSQS(unittest.TestCase):
 
     def test_cache_known_violations(self):
-        with mock.patch('__builtin__.open', create=True) as mock_open:
+        with mock.patch('six.moves.builtins.open', create=True) as mock_open:
             mock_open.return_value = mock.MagicMock(spec=TextIOBase)
             cache_known_violations('/some/file.json', [12345, '23456'])
 
@@ -19,7 +19,7 @@ class TestSendNewRelicMessagesToSQS(unittest.TestCase):
         file_handle.writelines.assert_called_with(['12345\n', '23456\n'])
 
     def test_read_known_violations_existing(self):
-        with mock.patch('__builtin__.open', create=True) as mock_open:
+        with mock.patch('six.moves.builtins.open', create=True) as mock_open:
             mock_open.return_value = mock.MagicMock(spec=TextIOBase)
             file_handle = mock_open.return_value.__enter__.return_value
             file_handle.readlines.return_value = ['12345\n', '23456\n']
@@ -28,7 +28,7 @@ class TestSendNewRelicMessagesToSQS(unittest.TestCase):
         self.assertEqual([12345, 23456], known_violations)
 
     def test_read_known_violations_nonexisting(self):
-        with mock.patch('__builtin__.open', create=True) as mock_open:
+        with mock.patch('six.moves.builtins.open', create=True) as mock_open:
             mock_open.side_effect = IOError()
             known_violations = read_known_violations('/some/file.json')
         self.assertEqual([], known_violations)


### PR DESCRIPTION
This PR changes the mocking of `builtin` in the alerts package to make its tests pass with Python 3.6.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
