### PR TITLE
Make agreements tests work with Python 3

### DIFF
--- a/cfgov/agreements/management/commands/_util.py
+++ b/cfgov/agreements/management/commands/_util.py
@@ -1,5 +1,9 @@
-import os
+from __future__ import unicode_literals
 
+import os
+import six
+
+from django.utils.encoding import force_text
 from django.utils.text import slugify
 
 import boto3
@@ -7,7 +11,10 @@ from agreements.models import Issuer
 
 
 def s3_safe_key(path, prefix=''):
-    key = prefix + path.encode('utf-8')
+    if six.PY2:
+        key = prefix + force_text(path)
+    else:
+        key = prefix + path
     key = key.replace(' ', '_')
     key = key.replace('%', '')
     key = key.replace(';', '')
@@ -42,9 +49,13 @@ def save_agreement(agreements_zip, pdf_path, outfile,
     uri_hostname = 'https://files.consumerfinance.gov'
     s3_prefix = 'a/assets/credit-card-agreements/pdf/'
 
-    zipinfo = agreements_zip.getinfo(pdf_path)
+    if six.PY2:
+        zipinfo = agreements_zip.getinfo(pdf_path)
+    else:
+        zipinfo = agreements_zip.getinfo(force_text(pdf_path, 'cp437'))
+
     if windows:
-        path = pdf_path.decode('windows-1252')
+        path = force_text(pdf_path, 'windows-1252')
     else:
         path = pdf_path
     try:

--- a/cfgov/agreements/management/commands/_util.py
+++ b/cfgov/agreements/management/commands/_util.py
@@ -45,19 +45,17 @@ def get_issuer(name):
 
 
 def save_agreement(agreements_zip, pdf_path, outfile,
-                   windows=False, upload=False):
+                   upload=False):
     uri_hostname = 'https://files.consumerfinance.gov'
     s3_prefix = 'a/assets/credit-card-agreements/pdf/'
 
-    if six.PY2:
-        zipinfo = agreements_zip.getinfo(pdf_path)
-    else:
-        zipinfo = agreements_zip.getinfo(force_text(pdf_path, 'cp437'))
+    zipinfo = agreements_zip.getinfo(pdf_path)
 
-    if windows:
-        path = force_text(pdf_path, 'windows-1252')
-    else:
-        path = pdf_path
+    if six.PY3:  # pragma: no cover
+        path = force_text(pdf_path)
+    else:  # pragma: no cover
+        path = pdf_path.decode('cp1252')
+
     try:
         issuer_name, filename = path.split('/')
     except ValueError:

--- a/cfgov/agreements/tests/test_legacy.py
+++ b/cfgov/agreements/tests/test_legacy.py
@@ -132,13 +132,13 @@ class Views(TestCase):
 
         path = reverse('issuer_search', kwargs={'issuer_slug': issuer.slug})
         resp = self.client.get(path)
-        self.assertTrue('page=2' in resp.content)
-        self.assertFalse('page=1' in resp.content)
+        self.assertTrue(b'page=2' in resp.content)
+        self.assertFalse(b'page=1' in resp.content)
 
         resp = self.client.get(path + '?page=2')
-        self.assertTrue('page=1' in resp.content)
-        self.assertFalse('page=2' in resp.content)
-        self.assertFalse('page=3' in resp.content)
+        self.assertTrue(b'page=1' in resp.content)
+        self.assertFalse(b'page=2' in resp.content)
+        self.assertFalse(b'page=3' in resp.content)
 
     @patch('agreements.views.render', return_value=HttpResponse())
     def test_issuer_paging_too_high(self, render):
@@ -152,12 +152,12 @@ class Views(TestCase):
 
         path = reverse('issuer_search', kwargs={'issuer_slug': issuer.slug})
         self.client.get(path + '?page=2')
-        object_ids2 = map(lambda o: o.id,
-                          render.call_args[0][2]['page'].object_list)
+        object_ids2 = list(map(lambda o: o.id,
+                               render.call_args[0][2]['page'].object_list))
 
         self.client.get(path + '?page=5555')
-        object_ids5555 = map(lambda o: o.id,
-                             render.call_args[0][2]['page'].object_list)
+        object_ids5555 = list(map(lambda o: o.id,
+                                  render.call_args[0][2]['page'].object_list))
 
         self.assertEqual(5, len(object_ids2))
         self.assertEqual(5, len(object_ids5555))
@@ -175,12 +175,12 @@ class Views(TestCase):
 
         path = reverse('issuer_search', kwargs={'issuer_slug': issuer.slug})
         self.client.get(path + '?page=1')
-        object_ids1 = map(lambda o: o.id,
-                          render.call_args[0][2]['page'].object_list)
+        object_ids1 = list(map(lambda o: o.id,
+                               render.call_args[0][2]['page'].object_list))
 
         self.client.get(path + '?page=abcd')
-        object_idsabcd = map(lambda o: o.id,
-                             render.call_args[0][2]['page'].object_list)
+        object_idsabcd = list(map(lambda o: o.id,
+                                  render.call_args[0][2]['page'].object_list))
         self.assertEqual(40, len(object_ids1))
         self.assertEqual(40, len(object_idsabcd))
         self.assertEqual(object_ids1, object_idsabcd)

--- a/cfgov/agreements/tests/test_legacy.py
+++ b/cfgov/agreements/tests/test_legacy.py
@@ -132,11 +132,14 @@ class Views(TestCase):
 
         path = reverse('issuer_search', kwargs={'issuer_slug': issuer.slug})
         resp = self.client.get(path)
-        self.assertTrue(b'page=2' in resp.content)
+        self.assertContains(resp, 'page=2')
+        self.assertNotContains(resp, 'page=1')
         self.assertFalse(b'page=1' in resp.content)
 
         resp = self.client.get(path + '?page=2')
-        self.assertTrue(b'page=1' in resp.content)
+        self.assertContains(resp, 'page=1')
+        self.assertNotContains(resp, 'page=2')
+        self.assertNotContains(resp, 'page=3')
         self.assertFalse(b'page=2' in resp.content)
         self.assertFalse(b'page=3' in resp.content)
 

--- a/cfgov/agreements/tests/test_management.py
+++ b/cfgov/agreements/tests/test_management.py
@@ -1,7 +1,7 @@
 import os.path
 import unittest
 import zipfile
-from cStringIO import StringIO
+from six import StringIO
 from zipfile import ZipFile
 
 from django.core import management
@@ -103,7 +103,7 @@ class TestManagementUtils(TestCase):
     def test_save_agreement(self):
         agreements_zip = zipfile.ZipFile(sample_zip)
         # windows-1252 encoded:
-        raw_path = 'Bankers\x92 Bank of Kansas/1.pdf'
+        raw_path = b'Bankers\x92 Bank of Kansas/1.pdf'
         buf = StringIO()
         agreement = _util.save_agreement(
             agreements_zip,


### PR DESCRIPTION
The agreements tests and code makes some assumptions about text encoding in zip files that needs to be more explicit in Python 3.

This PR also cleans up some bytes-to-string comparisons, generators-to-lists, and import moves.

