### PR TITLE
Make legacy tests work on Python 3

### DIFF
--- a/cfgov/legacy/housing_counselor/cleaner.py
+++ b/cfgov/legacy/housing_counselor/cleaner.py
@@ -11,7 +11,7 @@ REQUIRED_COUNSELOR_KEYS = {
 
 def clean_counselors(counselors):
     """Returns a cleaned set of HUD housing counselors."""
-    return map(clean_counselor, counselors)
+    return list(map(clean_counselor, counselors))
 
 
 def clean_counselor(counselor):

--- a/cfgov/legacy/housing_counselor/fetcher.py
+++ b/cfgov/legacy/housing_counselor/fetcher.py
@@ -55,10 +55,10 @@ def replace_abbreviations(counselors, attribute, url):
 
     for counselor in counselors:
         abbreviations = counselor[attribute]
-        counselor[attribute] = map(
+        counselor[attribute] = list(map(
             lambda key: values_dict[key],
             abbreviations.split(',') if abbreviations else []
-        )
+        ))
 
 
 def get_json_from_url(url):

--- a/cfgov/legacy/housing_counselor/generator.py
+++ b/cfgov/legacy/housing_counselor/generator.py
@@ -144,10 +144,10 @@ def get_counselor_json_files(directory):
     Returns iterator of (zipcode, filename) pairs.
     """
     search_path = os.path.join(directory, '*.json')
-    filenames = filter(
+    filenames = list(filter(
         lambda f: re.search(r'/\d{5}.json$', f),
         glob.glob(search_path)
-    )
+    ))
 
     if not filenames:
         raise RuntimeError('no input files found in {}'.format(directory))

--- a/cfgov/legacy/housing_counselor/geocoder.py
+++ b/cfgov/legacy/housing_counselor/geocoder.py
@@ -32,7 +32,7 @@ class ZipCodeBasedCounselorGeocoder(object):
         self.zipcodes = zipcodes
 
     def geocode(self, counselors):
-        return map(self.geocode_counselor, counselors)
+        return list(map(self.geocode_counselor, counselors))
 
     def geocode_counselor(self, counselor):
         counselor = dict(counselor)

--- a/cfgov/legacy/tests/housing_counselor/test_generator.py
+++ b/cfgov/legacy/tests/housing_counselor/test_generator.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import, print_function
 import json
 import os
 import shutil
+import six
 import tempfile
 from unittest import TestCase
 
@@ -41,7 +42,8 @@ class TestGeneratorCounselorJson(TestCase):
 
     def test_generate_creates_json_files(self):
         generate_counselor_json(self.counselors, self.zipcodes, self.tempdir)
-        self.assertItemsEqual(
+        six.assertCountEqual(
+            self,
             os.listdir(self.tempdir),  # os.listdir order not guaranteed.
             ['20001.json', '20002.json']
         )
@@ -74,7 +76,7 @@ class TestGeneratorCounselorJson(TestCase):
         ]
 
         for a, b in zip(agencies, expected_agencies):
-            self.assertItemsEqual(a.keys(), b.keys())
+            six.assertCountEqual(self, a.keys(), b.keys())
 
             for k in a:
                 self.assertAlmostEqual(a[k], b[k])


### PR DESCRIPTION
This is a cleanup of map/filter generators and translating unittest `assertItemsEqual` to `assertCountEqual`.