### PR TITLE
Add new page attribute `is_searchable` and limit external links query to those pages

### DIFF
--- a/cfgov/ask_cfpb/models/pages.py
+++ b/cfgov/ask_cfpb/models/pages.py
@@ -201,6 +201,8 @@ class AnswerLandingPage(LandingPage):
     ])
     objects = CFGOVPageManager()
 
+    is_searchable = False
+
     def get_context(self, request, *args, **kwargs):
         from ask_cfpb.models import Category, Audience
         context = super(AnswerLandingPage, self).get_context(request)
@@ -569,6 +571,8 @@ class AnswerPage(CFGOVPage):
         index.SearchField('answer'),
         index.SearchField('snippet')
     ]
+
+    is_searchable = True
 
     edit_handler = TabbedInterface([
         ObjectList(content_panels, heading='Content'),

--- a/cfgov/data_research/models.py
+++ b/cfgov/data_research/models.py
@@ -360,6 +360,7 @@ class MortgagePerformancePage(BrowsePage):
 
     objects = PageManager()
     template = 'browse-basic/index.html'
+    is_searchable = False
 
     def get_mortgage_meta(self):
         meta_names = ['sampling_dates', 'download_files']

--- a/cfgov/search/views.py
+++ b/cfgov/search/views.py
@@ -28,7 +28,8 @@ class SearchView(View):
         pages = []
 
         for cls in get_page_models():
-            pages += list(cls.objects.search(url))
+            if hasattr(cls, 'is_searchable') and cls.is_searchable:
+                pages += list(cls.objects.search(url))
         pages = sorted(pages, key=lambda k: k.title)
 
         contacts = list(

--- a/cfgov/v1/models/base.py
+++ b/cfgov/v1/models/base.py
@@ -88,6 +88,9 @@ class CFGOVPage(Page):
     # This is used solely for subclassing pages we want to make at the CFPB.
     is_creatable = False
 
+    # This is used to limit the search available in /admin/external-links
+    is_searchable = False
+
     objects = CFGOVPageManager()
 
     search_fields = Page.search_fields + [

--- a/cfgov/v1/models/blog_page.py
+++ b/cfgov/v1/models/blog_page.py
@@ -30,6 +30,8 @@ class BlogPage(AbstractFilterPage):
         index.SearchField('content')
     ]
 
+    is_searchable = True
+
 
 class LegacyBlogPage(AbstractFilterPage):
     content = StreamField([
@@ -47,3 +49,5 @@ class LegacyBlogPage(AbstractFilterPage):
     search_fields = AbstractFilterPage.search_fields + [
         index.SearchField('content')
     ]
+
+    is_searchable = True

--- a/cfgov/v1/models/browse_filterable_page.py
+++ b/cfgov/v1/models/browse_filterable_page.py
@@ -55,6 +55,8 @@ class BrowseFilterablePage(FilterableFeedPageMixin,
         index.SearchField('header')
     ]
 
+    is_searchable = True
+
     @property
     def page_js(self):
         return (
@@ -68,6 +70,8 @@ class EventArchivePage(BrowseFilterablePage):
 
     objects = PageManager()
 
+    is_searchable = False
+
     @staticmethod
     def get_form_class():
         from .. import forms
@@ -80,3 +84,5 @@ class NewsroomLandingPage(BrowseFilterablePage):
     filterable_children_only = False
 
     objects = PageManager()
+
+    is_searchable = False

--- a/cfgov/v1/models/browse_page.py
+++ b/cfgov/v1/models/browse_page.py
@@ -79,6 +79,8 @@ class BrowsePage(CFGOVPage):
         index.SearchField('header')
     ]
 
+    is_searchable = True
+
     @property
     def page_js(self):
         return (

--- a/cfgov/v1/models/home_page.py
+++ b/cfgov/v1/models/home_page.py
@@ -48,6 +48,8 @@ class HomePage(CFGOVPage):
 
     search_fields = CFGOVPage.search_fields + [index.SearchField('header')]
 
+    is_searchable = True
+
     def get_category_name(self, category_icon_name):
         cats = dict(ref.limited_categories)
         return cats[str(category_icon_name)]

--- a/cfgov/v1/models/landing_page.py
+++ b/cfgov/v1/models/landing_page.py
@@ -47,3 +47,5 @@ class LandingPage(CFGOVPage):
         index.SearchField('content'),
         index.SearchField('header')
     ]
+
+    is_searchable = True

--- a/cfgov/v1/models/learn_page.py
+++ b/cfgov/v1/models/learn_page.py
@@ -124,6 +124,8 @@ class LearnPage(AbstractFilterPage):
         index.SearchField('content')
     ]
 
+    is_searchable = True
+
 
 class DocumentDetailPage(AbstractFilterPage):
     content = StreamField([
@@ -144,6 +146,8 @@ class DocumentDetailPage(AbstractFilterPage):
     search_fields = AbstractFilterPage.search_fields + [
         index.SearchField('content')
     ]
+
+    is_searchable = True
 
 
 class AgendaItemBlock(blocks.StructBlock):
@@ -239,6 +243,8 @@ class EventPage(AbstractFilterPage):
         index.SearchField('future_body'),
         index.SearchField('agenda_items')
     ]
+
+    is_searchable = True
 
     # General content tab
     content_panels = CFGOVPage.content_panels + [

--- a/cfgov/v1/models/newsroom_page.py
+++ b/cfgov/v1/models/newsroom_page.py
@@ -5,8 +5,10 @@ from v1.models.blog_page import BlogPage, LegacyBlogPage
 class NewsroomPage(BlogPage):
     template = 'newsroom/newsroom-page.html'
     objects = CFGOVPageManager()
+    is_searchable = False
 
 
 class LegacyNewsroomPage(LegacyBlogPage):
     template = 'newsroom/newsroom-page.html'
     objects = CFGOVPageManager()
+    is_searchable = False

--- a/cfgov/v1/models/sublanding_filterable_page.py
+++ b/cfgov/v1/models/sublanding_filterable_page.py
@@ -48,6 +48,8 @@ class SublandingFilterablePage(FilterableFeedPageMixin,
         index.SearchField('header')
     ]
 
+    is_searchable = True
+
 
 class ActivityLogPage(SublandingFilterablePage):
     template = 'activity-log/index.html'
@@ -56,3 +58,5 @@ class ActivityLogPage(SublandingFilterablePage):
     filterable_per_page_limit = 100
 
     objects = PageManager()
+
+    is_searchable = False

--- a/cfgov/v1/models/sublanding_page.py
+++ b/cfgov/v1/models/sublanding_page.py
@@ -83,6 +83,8 @@ class SublandingPage(CFGOVPage):
         index.SearchField('header')
     ]
 
+    is_searchable = True
+
     def get_browsefilterable_posts(self, limit):
         filter_pages = [p.specific
                         for p in self.get_appropriate_descendants()


### PR DESCRIPTION
## Overview

Fixes a bug where there are duplicate results in /admin/external-links (the new external links search) because pages that inherit from `CFGOVPage` (all pages) or e.g.  `AbstractFilterPage` are having their sidefoot and/or header searched at each level of inheritance. You can reproduce this bug by adding a link to the sidefoot or header of an activity log page and then searching for that link in http://localhost:8000/admin/external-links/. 

## Notes

- These changes also make more explicit which pages we’ve audited to include in the search.  Previously, we were searching pages like `RegulationLandingPage`, though we’ve done nothing to add its fields to the search index (`header` and `content` in this case).  It would’ve included results based on the `sidefoot` since that is inherited from CFGOVPage, but I believe partially searching like that would be confusing. 
- Though not all v1 page *types* have had `is_searchable` added to them, all v1 *pages* are searchable because they themselves are being searched, or a subclass or superclass is being searched. 
