### PR TITLE
Convert RelatedPosts block to use include_block

### DIFF
--- a/cfgov/jinja2/v1/_includes/molecules/related-posts.html
+++ b/cfgov/jinja2/v1/_includes/molecules/related-posts.html
@@ -1,77 +1,5 @@
 {# ==========================================================================
 
-   related_posts.render()
-
-   ==========================================================================
-
-   Description:
-
-   Creates related posts markup when given:
-
-   posts:                               Collection of related posts for a
-                                        page as returned by the
-                                        related_posts() method on CFGOVPage.
-
-   block:                               Instance of a RelatedPosts block.
-
-   block.value:                         Dictionary of block field values.
-
-   block.value.limit:                   Integer setting the number of
-                                        posts that will be shown for each
-                                        type of posts selected.
-
-   block.value.header_title:            String for the heading at the top
-                                        of the renderd module.
-
-   block.value.show_heading:            Boolean indicating whether or not
-                                        the heading and icon for each type
-                                        of related post will be shown.
-                                        Defaults to True.
-
-   block.value.alternate_view_more_url: Optional string that replace the
-                                        default URL for the "View more" link
-                                        at the bottom of the rendered module.
-
-   is_half_width:                       Boolean indicating whether the
-                                        posts should be at half width.
-                                        Defaults to False.
-
-   hide_header_slug:                    Boolean indicating whether
-                                        the header should be hidden.
-                                        Defaults to False.
-
-   ========================================================================== #}
-
-{% macro render(posts, block, is_half_width=false, hide_header_slug=false) %}
-    {% import 'macros/category-icon.html' as category_icon %}
-    <div class="m-related-posts
-                {{'m-related-posts__half-width'
-                  if is_half_width else ''}}">
-        {% if not hide_header_slug %}
-            <header class="m-slug-header">
-                <h2 class="a-heading">
-                    {{ block.value.header_title }}
-                </h2>
-            </header>
-        {% endif %}
-        {% for post_type, post_type_list in posts.iteritems() %}
-            {% set title, icon = (post_type, category_icon.render(post_type)) or ("Blog", category_icon.render('blog')) %}
-            <div class="m-related-posts_list-container">
-                {% if block.value.show_heading %}
-                    <h3 class="h4">
-                        {{ icon }} {{ title }}
-                    </h3>
-                {% endif %}
-                {{ _related_posts_list(post_type_list, block.value.limit) }}
-            </div>
-        {% endfor %}
-        {{ _view_more(block.value.alternate_view_more_url) }}
-    </div>
-{% endmacro %}
-
-
-{# ==========================================================================
-
    _related_posts_list()
 
    ==========================================================================
@@ -122,17 +50,66 @@
 
 {# ==========================================================================
 
-   _view_more()
+   Template for v1.atomic_elements.organisms.RelatedPosts.
+
+   ==========================================================================
+
+   Description:
+
+   Creates related posts markup for RelatedPosts block.
+
+   Uses these entries from the block's value:
+
+   value.header_title:  String for the heading at the top of the rendered
+                        module.
+
+   value.limit:         Integer setting the number of posts that will be shown
+                        for each type of post selected.
+
+   value.show_heading:  Boolean indicating whether or not the heading and icon
+                        for each type of post will be shown. Defaults to True.
+
+   Also expects context to contain these extra parameters:
+
+   half_width:          Boolean indicating whether the posts should be at half
+                        width. Defaults to False.
+
+   hide_header_slug:    Boolean indicating whether the header should be hidden.
+                        Defaults to False.
+
+   posts:               List of related posts to render. Required.
+
+   view_more_url:       URL for "View more" link. Required.
 
    ========================================================================== #}
 
-{% macro _view_more(alternate_view_more_url) %}
-    {% set view_more_url = alternate_view_more_url
-                           or page.generate_view_more_url(request) %}
+{% import 'macros/category-icon.html' as category_icon %}
+
+<div class="m-related-posts
+    {{'m-related-posts__half-width' if half_width else '' }}">
+    {% if not hide_header_slug %}
+        <header class="m-slug-header">
+            <h2 class="a-heading">
+                {{ value.header_title }}
+            </h2>
+        </header>
+    {% endif %}
+    {% for post_type, post_type_list in posts.iteritems() %}
+        {% set title, icon = (post_type, category_icon.render(post_type)) or ("Blog", category_icon.render('blog')) %}
+        <div class="m-related-posts_list-container">
+            {% if value.show_heading %}
+                <h3 class="h4">
+                    {{ icon }} {{ title }}
+                </h3>
+            {% endif %}
+            {{ _related_posts_list(post_type_list, value.limit) }}
+        </div>
+    {% endfor %}
+
     <a class="a-link a-link__jump"
        href="{{ view_more_url }}">
         <span class="a-link_text">
             {{ _('View more') }}
         </span>
     </a>
-{% endmacro %}
+</div>

--- a/cfgov/jinja2/v1/_includes/organisms/sidebar-breakout.html
+++ b/cfgov/jinja2/v1/_includes/organisms/sidebar-breakout.html
@@ -89,12 +89,9 @@
                             {% endif %}
                         {% endif %}
                     {% elif 'related_posts' in block.block_type %}
-                        {% set posts = page.related_posts(block) %}
-                        {% if posts %}
-                            <div class="block {{- 'block__flush-top' if loop.index == 1 else '' -}}">
-                                {{ related_posts.render(posts, block, half_width) }}
-                            </div>
-                        {% endif %}
+                        <div class="block{{ ' block__flush-top' if loop.first else '' }}">
+                            {% include_block block %}
+                        </div>
                     {% elif 'slug' in block.block_type %}
                         <header class="m-slug-header">
                             <h2 class="a-heading">

--- a/cfgov/jinja2/v1/_includes/templates/streamfield-sidefoot.html
+++ b/cfgov/jinja2/v1/_includes/templates/streamfield-sidefoot.html
@@ -1,4 +1,3 @@
-{% import 'molecules/related-posts.html' as related_posts with context %}
 {% import 'molecules/related-metadata.html' as related_metadata with context %}
 {% import 'molecules/social-media.html' as social_media with context %}
 
@@ -6,18 +5,14 @@
 {% macro render(streamfield, half_width=false) %}
     {% for block in streamfield %}
         {% if 'related_posts' in block.block_type %}
-            {% set posts = page.related_posts(block) %}
-            {% if posts %}
-                <div class="block {{ 'block__flush-top' if loop.index == 1 else '' -}}">
-                    {{ related_posts.render(posts, block, half_width) }}
-                </div>
-            {% endif %}
+            <div class="block{{ ' block__flush-top' if loop.first else '' }}">
+            {% include_block block %}
         {% elif 'related_metadata' in block.block_type %}
-            <div class="block {{ 'block__flush-top' if loop.index == 1 else '' -}}">
+            <div class="block{{ ' block__flush-top' if loop.first else '' }}">
                 {{ related_metadata.render(block.value) }}
             </div>
         {% elif 'social_media' in block.block_type %}
-            <div class="block {{ 'block__flush-top' if loop.index == 1 else '' -}}">
+            <div class="block{{ ' block__flush-top' if loop.first else '' }}">
                 {{ social_media.render(block.value) }}
             </div>
         {% else %}

--- a/cfgov/v1/atomic_elements/organisms.py
+++ b/cfgov/v1/atomic_elements/organisms.py
@@ -1,10 +1,12 @@
 import json
 from functools import partial
 from six import string_types as basestring
+from six.moves.urllib.parse import urlencode
 
 from django import forms
 from django.apps import apps
 from django.core.exceptions import ValidationError
+from django.db.models import Q
 from django.forms.utils import ErrorList
 from django.template.loader import render_to_string
 from django.utils.encoding import smart_text
@@ -14,6 +16,7 @@ from django.utils.safestring import mark_safe
 from wagtail.contrib.table_block.blocks import TableBlock
 from wagtail.utils.widgets import WidgetWithScript
 from wagtail.wagtailcore import blocks
+from wagtail.wagtailcore.models import Page
 from wagtail.wagtailcore.rich_text import DbWhitelister, expand_db_html
 from wagtail.wagtaildocs.blocks import DocumentChooserBlock
 from wagtail.wagtailimages import blocks as images_blocks
@@ -331,6 +334,107 @@ class RelatedPosts(blocks.StructBlock):
                    'Log, filtered based on the above parameters. Enter a URL '
                    'in this field to override that link destination.')
     )
+
+    def get_context(self, value, parent_context=None):
+        context = super(RelatedPosts, self).get_context(
+            value,
+            parent_context=parent_context
+        )
+
+        page = context['page']
+        request = context['request']
+
+        context.update({
+            'posts': self.related_posts(page, value),
+            'view_more_url': (
+                value['alternate_view_more_url'] or
+                self.view_more_url(page, request)
+            ),
+        })
+
+        return context
+
+    @staticmethod
+    def related_posts(page, value):
+        from v1.models.learn_page import AbstractFilterPage
+
+        def tag_set(related_page):
+            return set([tag.pk for tag in related_page.tags.all()])
+
+        def match_all_topic_tags(queryset, page_tags):
+            """Return pages that share every one of the current page's tags."""
+            current_tag_set = set([tag.pk for tag in page_tags])
+            return [page for page in queryset
+                    if current_tag_set.issubset(tag_set(page))]
+
+        related_types = []
+        related_items = {}
+        if value.get('relate_posts'):
+            related_types.append('blog')
+        if value.get('relate_newsroom'):
+            related_types.append('newsroom')
+        if value.get('relate_events'):
+            related_types.append('events')
+        if not related_types:
+            return related_items
+
+        tags = page.tags.all()
+        and_filtering = value['and_filtering']
+        specific_categories = value['specific_categories']
+        limit = int(value['limit'])
+        queryset = AbstractFilterPage.objects.live().exclude(
+            id=page.id).order_by('-date_published').distinct()
+
+        for parent in related_types:  # blog, newsroom or events
+            # Include children of this slug that match at least 1 tag
+            children = Page.objects.child_of_q(Page.objects.get(slug=parent))
+            filters = children & Q(('tags__in', tags))
+
+            if parent == 'events':
+                # Include archived events matches
+                archive = Page.objects.get(slug='archive-past-events')
+                children = Page.objects.child_of_q(archive)
+                filters |= children & Q(('tags__in', tags))
+
+            if specific_categories:
+                # Filter by any additional categories specified
+                categories = ref.get_appropriate_categories(
+                    specific_categories=specific_categories,
+                    page_type=parent
+                )
+                if categories:
+                    filters &= Q(('categories__name__in', categories))
+
+            related_queryset = queryset.filter(filters)
+
+            if and_filtering:
+                # By default, we need to match at least one tag
+                # If specified in the admin, change this to match ALL tags
+                related_queryset = match_all_topic_tags(related_queryset, tags)
+
+            related_items[parent.title()] = related_queryset[:limit]
+
+        # Return items in the dictionary that have non-empty querysets
+        return {key: value for key, value in related_items.items() if value}
+
+    @staticmethod
+    def view_more_url(page, request):
+        """Generate a URL to see more pages like this one.
+        This method generates a link to the Activity Log page (which must
+        exist and must have a unique site-wide slug of "activity-log") with
+        filters set by the tags assigned to this page, like this:
+        /activity-log/?topics=foo&topics=bar&topics=baz
+        If for some reason a page with slug "activity-log" does not exist,
+        this method will raise Page.DoesNotExist.
+        """
+        activity_log = Page.objects.get(slug='activity-log')
+        url = activity_log.get_url(request)
+
+        tags = urlencode([('topics', tag) for tag in page.tags.slugs()])
+        if tags:
+            url += '?' + tags
+
+        return url
 
     class Meta:
         icon = 'link'


### PR DESCRIPTION
This change modifies the way that the RelatedPosts StreamField block is included and rendered in page sidebars. Instead of rendering it using a macro (as we do most of our blocks), this change renders it using the [standard Wagtail `{% include_block %}` method](http://docs.wagtail.io/en/v2.3/topics/streamfield.html#template-rendering).

This change moves the related posts logic from the page class to the block. This consolidates all related posts logic into a single place. Python tests have also been moved accordingly.

To test this, you can visit these two pages using a local server running against a production dump:

http://localhost:8000/data-research/credit-card-data/
http://localhost:8000/about-us/blog/askcfpb-your-questions-about-credit-reports-and-scores/

These two pages represent instances where this block is included in a sidebar-breakout and a streamfield-sidefoot.

This commit makes a minor change to some of the logic in the related posts template; specifically, even if there are no posts to be rendered, it still applies the `block__flush-top` class to the block div. In practice this should never happen, as all pages should have some related posts. Even if it did, using that class on the div seems reasonable, even if the block is only displaying the "View more" link.

See also GHE/platform#378 for more background on why this change is beneficial. If this change seems good to folks, we could consider modifying other StreamField blocks to be included in a similar way, which would reduce some of the complexity of our templates.

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [X] Passes all existing automated tests
- [X] Any _change_ in functionality is tested
- [X] New functions are documented (with a description, list of inputs, and expected output)
- [X] Placeholder code is flagged / future todos are captured in comments
- [X] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [X] Project documentation has been updated
- [X] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: