### PR TITLE
bump owning-a-home-api version to 0.11.3

### DIFF
--- a/requirements/optional-public.txt
+++ b/requirements/optional-public.txt
@@ -1,5 +1,5 @@
 https://github.com/cfpb/college-costs/releases/download/2.4.3/college_costs-2.4.3-py2-none-any.whl
-https://github.com/cfpb/owning-a-home-api/releases/download/0.11.2/owning_a_home_api-0.11.2-py2-none-any.whl
+https://github.com/cfpb/owning-a-home-api/releases/download/0.11.3/owning_a_home_api-0.11.3-py2-none-any.whl
 https://github.com/cfpb/retirement/releases/download/0.7.3/retirement-0.7.3-py2-none-any.whl
 https://github.com/cfpb/ccdb5-api/releases/download/1.1.0/ccdb5_api-1.1.0-py2-none-any.whl
 https://github.com/cfpb/ccdb5-ui/releases/download/1.1.0/ccdb5_ui-1.1.0-py2-none-any.whl


### PR DESCRIPTION
Add two improvements to the ratechecker data-loading routine:
- Fix an IndexError that led to server errors.
- Re-sequence data loading to catch partial-load conditions.