### PR TITLE
Add Feature Flag for Housing Counselor page improvements

### DIFF
--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -642,6 +642,10 @@ FLAGS = {
 
     # To be enabled when switching the site to use the BCFP logo
     'BCFP_LOGO': {},
+
+    # Improvements to Find A Housing Counselor page
+    # (UI Improvements project, Fall 2018)
+    'HUD_TOOL_IMPROVEMENTS': { 'environment is': 'local' },
 }
 
 

--- a/cfgov/housing_counselor/jinja2/housing_counselor/improved_index.html
+++ b/cfgov/housing_counselor/jinja2/housing_counselor/improved_index.html
@@ -1,0 +1,125 @@
+{% extends 'content-base.html' %}
+
+{% block title %}
+    Find a Housing Counselor | Consumer Financial Protection Bureau
+{% endblock %}
+
+{% block css %}
+{{ super() }}
+<style>
+    .m-hero {
+        background-color: #d6e5e4 !important;
+    }
+
+    .m-hero_image {
+        background-image: url('{{ static("apps/know-before-you-owe/img/kbyo-hero_laptop-2x.png") }}');
+        filter: progid:DXImageTransform.Microsoft.AlphaImageLoader(
+                src='{{ static("apps/know-before-you-owe/img/kbyo-hero_laptop-2x.png") }}',
+                sizingMethod='scale' );
+        padding-bottom: 0;
+    }
+
+    @media screen and (min-width: 37.5625em) {
+        .m-hero_image {
+            background-image: url('{{ static("apps/know-before-you-owe/img/kbyo-hero_laptop-2x.png") }}');
+            filter: progid:DXImageTransform.Microsoft.AlphaImageLoader(
+                    src='{{ static("apps/know-before-you-owe/img/kbyo-hero_laptop-2x.png") }}',
+                    sizingMethod='scale' );
+            padding-bottom: 41.4893617%
+        }
+    }
+
+    @media screen and (max-width: 56.250em) {
+        .kbyo-tools .content-l_col-1-2 {
+            width: 100%;
+            margin-bottom: 30px;
+        }
+    }
+
+    .kbyo-video {
+        margin-top: 3.75em;
+        margin-bottom: 3.75em;
+    }
+
+    .kbyo-tools,
+    .kbyo-mortgage-disclosures,
+    .kbyo-timeline {
+        border-top: 1px solid #e3e4e5;
+        padding-top: 1.875em;
+        padding-bottom: 2.8125em;
+    }
+
+    .kbyo-professional-resources, .kbyo-footer {
+        background-color: #f1f2f2;
+        border-bottom: 1px solid #e3e4e5;
+        border-top: 1px solid #e3e4e5;
+        padding-top: 2.8125em;
+        padding-bottom: 2.8125em;
+    }
+
+    .o-info-unit-group .content-l:first-child {
+        margin-top: 0;
+    }
+
+</style>
+{% endblock %}
+
+{% block hero %}
+<section class="m-hero">
+    <div class="m-hero_wrapper wrapper">
+        <div class="m-hero_text">
+            <h1 class="m-hero_heading">Find a Housing Counselor</h1>
+            <div class="m-hero_subhead">
+                {% if zipcode %}
+                    <div>
+                      <h2>Context:</h2>
+                      <p><b>zipcode</b>: {{ zipcode }}</p>
+                      <p><b>pdf_url</b>: {{ pdf_url }}</p>
+                      <p><b>api_json</b>: {{ api_json }}</p>
+                    </div>
+                    <br>
+                {% else %}
+                    <p> Lorem ipsum dolor amet Lomo dreamcatcher roof party tofu vegan woke four dollar toast whatever readymade 3 wolf moon kinfolk intelligentsia mixtape. Keffiyeh palo santo pickled, you probably haven't heard of them cray venmo portland bushwick. Drinking vinegar readymade pinterest brunch fanny pack occupy narwhal humblebrag four dollar toast. Four loko iceland tumblr, master cleanse williamsburg live-edge iPhone freegan fashion axe banh mi semiotics.
+                    </p>
+                {% endif %}
+            </div>
+        </div>
+        <div class="m-hero_image-wrapper">
+            <div class="m-hero_image"></div>
+        </div>
+    </div>
+</section>
+{% endblock %}
+
+{% block body_content %}
+<section class="kbyo-footer">
+    <div class="wrapper wrapper__match-content">
+        <div class="content-l">
+          <div class="content-l_col
+                    content-l_col-1-2">
+            <header class="m-slug-header">
+                <h2 class="a-heading">
+                    Reports
+                </h2>
+            </header>
+
+            <header class="m-slug-header">
+                <h2 class="a-heading">
+                    Legal disclaimer
+                </h2>
+            </header>
+            <p>
+              The content on this page provides general consumer information.
+              It is not legal advice or regulatory guidance.
+              The CFPB updates this information periodically.
+              This information may include links or references
+              to third-party resources or content.
+              We do not endorse the third-party or guarantee the accuracy
+              of this third-party information.
+              There may be other resources that also serve your needs.
+            </p>
+          </div><!-- /.kbyo-footer__col -->
+        </div><!-- /.kbyo-footer__row -->
+      </div><!-- /.kbyo-footer__wrapper -->
+</section>
+{% endblock %}

--- a/cfgov/housing_counselor/views.py
+++ b/cfgov/housing_counselor/views.py
@@ -6,6 +6,7 @@ from django.shortcuts import redirect
 from django.views.generic import TemplateView, View
 
 import requests
+from flags.state import flag_enabled
 
 from legacy.forms import HousingCounselorForm
 from v1.s3utils import https_s3_url_prefix
@@ -31,7 +32,11 @@ class HousingCounselorS3URLMixin(object):
 
 
 class HousingCounselorView(TemplateView, HousingCounselorS3URLMixin):
-    template_name = 'housing_counselor/index.html'
+    def get_template_names(self):
+        if flag_enabled('HUD_TOOL_IMPROVEMENTS'):
+            return 'housing_counselor/improved_index.html'
+        else:
+            return 'housing_counselor/index.html'
 
     def get_context_data(self, **kwargs):
         context = super(HousingCounselorView, self).get_context_data(**kwargs)


### PR DESCRIPTION
This PR adds a feature flag for the Find a Housing Counselor page, which the UI improvements team is in the process of remaking.

When the flag, called `HUD_TOOL_IMPROVEMENTS`, is not enabled (which is the default behavior), we show the existing Find a Housing Counselor page.

When the flag is enabled, we show the new template, which is stored in `jinja2/housing_counselor/improved_index.html`. When the new page is enabled and a `zipcode` parameter is included in the GET request, show the context values returned in the response, to aid in
future front-end development.

## Additions

- `HUD_TOOL_IMPROVEMENTS` flag
- `jinja2/housing_counselor/improved_index.html`

*^ I'm open to feedback on the names of both of those things, by the way. I wasn't sure how best to name them.*

## Testing

1. With this branch running, visit http://localhost:8000/find-a-housing-counselor/ and http://localhost:8000/find-a-housing-counselor/?zipcode=53703. Note that the page matches http://consumerfinance.gov/find-a-housing-counselor.
2. Log in to wagtail, navigate to Settings > Flags. Scroll down and press the Add A Condition button.
3. Fill out the New Flag Condition form to say "HUD_TOOL_IMPROVEMENTS is enabled when boolean is True". Press "Save New Condition".
4. Visit http://localhost:8000/find-a-housing-counselor/, see that it's a placeholder page with Lorem Ipsum text.
5. Visit http://localhost:8000/find-a-housing-counselor/?zipcode=53703, see that it is still a placeholder page, but with housing counselor info for the given zip code, in raw json format. This is to show that the back end is hooked up correctly to provide data to the front end, for when front-end development begins.


## Notes

Note that the placeholder pages will not be public facing on cf.gov, since the flag is disabled by default. When this is merged, behavior on the production site will not change.


## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

Does not change any cf.gov functionality.