### PR TITLE
Remove duplicates from external links search results

### DIFF
--- a/cfgov/search/templates/search/external_links.html
+++ b/cfgov/search/templates/search/external_links.html
@@ -25,7 +25,10 @@
 
     {% block content_main %}
     <div class="nice-padding external-links">
-        <p class="external-links-intro">Enter an external URL to see where it occurs on our site. If a link appears within more than one section of a given page, such as the body and sidebar, the results will list that page multiple times--once for each occurrence.</p>
+        <p class="external-links-intro">Enter an external link to see a list of
+          pages and snippets that contain that URL. Each page result will
+          appear only once, regardless of how many times a searched URL is
+          present on a page.</p>
         <form method="post">
             {% csrf_token %}
             <div class="field iconfield field-small">
@@ -45,11 +48,11 @@
                         There are no matching pages or snippets.
                     {% endif %}
                 </p>
-            
+
                 {% if num_page_results %}
                     <h2 class="external-links-page-results">Page results</h2>
                     {% include "./_list_explore_revised.html" with show_parent=1 allow_navigation=0 %}
-                    
+
                 {% endif %}
 
                 {% if num_snippet_results %}
@@ -125,7 +128,7 @@
                         </tbody>
                     </table>
                 {% endif%}
-            
+
 
         {% endif %}
     </div>

--- a/cfgov/search/views.py
+++ b/cfgov/search/views.py
@@ -29,6 +29,8 @@ class SearchView(View):
 
         for cls in get_page_models():
             pages += list(cls.objects.search(url))
+
+        pages = self.remove_duplicates(pages)
         pages = sorted(pages, key=lambda k: k.title)
 
         contacts = list(
@@ -52,6 +54,14 @@ class SearchView(View):
             'num_page_results': num_page_results,
             'num_snippet_results': num_snippet_results,
         })
+
+    @staticmethod
+    def remove_duplicates(pages):
+        seen = set()
+        for page in pages:
+            if page.pk not in seen:
+                seen.add(page.pk)
+                yield page
 
 
 def results_view(request):


### PR DESCRIPTION
This is a more simplified version of addressing what https://github.com/cfpb/cfgov-refresh/pull/4611 was attempting to address, by removing duplicates at the time of the search. 

See PR above and GHE/CFGOV/enhanced-cms/issues/39 for more context.

In addition to removing the duplicates:
  - We've updated the help text (thank you @marteki and @nataliafitzgerald)
  - Added tests (if you run those same tests off master currently, they will fail, as expected)
