### PR TITLE
Adds initial base template to HUD

### DIFF
--- a/cfgov/housing_counselor/jinja2/housing_counselor/improved_index.html
+++ b/cfgov/housing_counselor/jinja2/housing_counselor/improved_index.html
@@ -1,4 +1,5 @@
-{% extends 'content-base.html' %}
+{% extends "base.html" %}
+{% import "molecules/social-media.html" as social_media with context %}
 
 {% block title %}
     Find a Housing Counselor | Consumer Financial Protection Bureau
@@ -6,62 +7,6 @@
 
 {% block css %}
 {{ super() }}
-<style>
-    .m-hero {
-        background-color: #d6e5e4 !important;
-    }
-
-    .m-hero_image {
-        background-image: url('{{ static("apps/know-before-you-owe/img/kbyo-hero_laptop-2x.png") }}');
-        filter: progid:DXImageTransform.Microsoft.AlphaImageLoader(
-                src='{{ static("apps/know-before-you-owe/img/kbyo-hero_laptop-2x.png") }}',
-                sizingMethod='scale' );
-        padding-bottom: 0;
-    }
-
-    @media screen and (min-width: 37.5625em) {
-        .m-hero_image {
-            background-image: url('{{ static("apps/know-before-you-owe/img/kbyo-hero_laptop-2x.png") }}');
-            filter: progid:DXImageTransform.Microsoft.AlphaImageLoader(
-                    src='{{ static("apps/know-before-you-owe/img/kbyo-hero_laptop-2x.png") }}',
-                    sizingMethod='scale' );
-            padding-bottom: 41.4893617%
-        }
-    }
-
-    @media screen and (max-width: 56.250em) {
-        .kbyo-tools .content-l_col-1-2 {
-            width: 100%;
-            margin-bottom: 30px;
-        }
-    }
-
-    .kbyo-video {
-        margin-top: 3.75em;
-        margin-bottom: 3.75em;
-    }
-
-    .kbyo-tools,
-    .kbyo-mortgage-disclosures,
-    .kbyo-timeline {
-        border-top: 1px solid #e3e4e5;
-        padding-top: 1.875em;
-        padding-bottom: 2.8125em;
-    }
-
-    .kbyo-professional-resources, .kbyo-footer {
-        background-color: #f1f2f2;
-        border-bottom: 1px solid #e3e4e5;
-        border-top: 1px solid #e3e4e5;
-        padding-top: 2.8125em;
-        padding-bottom: 2.8125em;
-    }
-
-    .o-info-unit-group .content-l:first-child {
-        margin-top: 0;
-    }
-
-</style>
 {% endblock %}
 
 {% block hero %}
@@ -91,35 +36,147 @@
 </section>
 {% endblock %}
 
-{% block body_content %}
-<section class="kbyo-footer">
-    <div class="wrapper wrapper__match-content">
-        <div class="content-l">
-          <div class="content-l_col
-                    content-l_col-1-2">
-            <header class="m-slug-header">
-                <h2 class="a-heading">
-                    Reports
-                </h2>
-            </header>
+{% block content %}
+    <main class="content" id="main" lang="en">
+        <div class="wrapper content_wrapper">
+            <div class="content_main">
+                <section lang="en">
+                    <div class="block block__flush-top block__flush-top">
+                        <h1>Find a housing counselor</h1>
+                        <div class="rich-text">
+                            <p>Housing counselors throughout the country can provide advice on buying a home, renting, defaults, foreclosures, and credit issues. Using the search box below, you can find one near you. The counseling agencies on this list are approved by the U.S. Department of Housing and Urban Development (HUD) and they can offer independent advice about whether a particular set of mortgage loan terms is a good fit based on your objectives and circumstances, often at little or no cost to you. This list will show you several approved agencies in your area. There is also a <a class="a-link a-link__icon" href="https://apps.hud.gov/offices/hsg/sfh/hcc/hcs.cfm"><span class="a-link_text">list of nationwide HUD-approved counseling agencies</span> <svg class="cf-icon-svg" viewbox="0 0 790.1 1200" xmlns="http://www.w3.org/2000/svg">
+                            <path d="M740.1 178.8H449.5c-27.6 0-50 22.4-50 50s22.4 50 50 50h169.9L518.2 379.9c-14.7-6.2-30.5-9.4-46.4-9.4H120c-66.2.1-119.9 53.8-120 120v351.8c.1 66.2 53.8 119.9 120 120h351.8c66.2-.1 119.9-53.8 120-120V490.6c0-12.6-2-25-5.8-37l104.1-104.1v169.9c0 27.6 22.4 50 50 50s50-22.4 50-50V228.8c0-27.7-22.4-50-50-50zM491.8 842.3c-.1 11-9 19.9-20 20H120c-11-.1-19.9-9-20-20V490.6c.1-11 9-19.9 20-20h307.5L267 631.1c-19.4 19.6-19.3 51.3.3 70.7 19.5 19.3 50.9 19.3 70.4 0l154-154 .1 294.5z"></path></svg></a>.</p>
+                        </div>
+                    </div>
+                    <div class="block">
+                        <div class="o-full-width-text-group content-l">
+                            <div class="col-3">
+                                <div class="o-well">
+                                    <form class="o-form" action="#">
+                                        <div class="m-form-field-with-button">
+                                            <div class="m-form-field">
+                                                <label class="a-label a-label__heading" for="zip">
+                                                    Search by ZIP code:
+                                                </label>
+                                                <input id="zip" type="text" name="zip" class="a-text-input a-text-input__full" value="52246">
+                                            </div>
+                                            <div class="m-form-field-with-button_wrapper">
+                                                <input class="a-btn a-btn__full-on-xs" type="submit" value="Find a counselor">
+                                                <div class="m-form-field-with-button_info">
+                                                    <p>
+                                                        This tool is powered by <a class="a-link a-link__icon" href="https://data.hud.gov/housing_counseling.html"><span class="a-link_text">HUD's</span> <svg class="cf-icon-svg" viewBox="0 0 790.1 1200" xmlns="http://www.w3.org/2000/svg"> <path d="M740.1 178.8H449.5c-27.6 0-50 22.4-50 50s22.4 50 50 50h169.9L518.2 379.9c-14.7-6.2-30.5-9.4-46.4-9.4H120c-66.2.1-119.9 53.8-120 120v351.8c.1 66.2 53.8 119.9 120 120h351.8c66.2-.1 119.9-53.8 120-120V490.6c0-12.6-2-25-5.8-37l104.1-104.1v169.9c0 27.6 22.4 50 50 50s50-22.4 50-50V228.8c0-27.7-22.4-50-50-50zM491.8 842.3c-.1 11-9 19.9-20 20H120c-11-.1-19.9-9-20-20V490.6c.1-11 9-19.9 20-20h307.5L267 631.1c-19.4 19.6-19.3 51.3.3 70.7 19.5 19.3 50.9 19.3 70.4 0l154-154 .1 294.5z"></path></svg></a> official list of housing counselors.
+                                                    </p>
+                                                    <p>
+                                                        If you notice errors in the housing counselor data, contact <a href="mailto:housing.counseling@hud.gov">housing.counseling@hud.gov</a>.
+                                                    </p>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </form>
+                                </div>
+                            </div>
+                            <div class="col-9">
+                                MAP GOES HERE
+                            </div>
+                        </div>
+                    </div>
+                    <div class="block">
+                        <div class="results-header">
+                            <h2 class="h4">Displaying the 10 locations closest to ZIP code 52246</h2>
+                            <div class="action-buttons">
+                                <button class="a-btn a-btn__link">
+                                    Print list
+                                </button>
+                                <button class="a-btn a-btn__link">
+                                    Save list as PDF
+                                </button>
+                            </div>
+                        </div>
+                        <table class="o-table o-table__stack-on-small u-w100pct">
+                            <thead>
+                                <tr>
+                                    <th scope="col">
+                                        <div class="rich-text">
+                                            <p>Agency</p>
+                                        </div>
+                                    </th>
+                                    <th scope="col">
+                                        <div class="rich-text">
+                                            <p>Services</p>
+                                        </div>
+                                    </th>
+                                    <th scope="col">
+                                        <div class="rich-text">
+                                            <p>Distance</p>
+                                        </div>
+                                    </th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td data-label="Agency">
+                                        <div class="rich-text">
+                                            <p>
+                                                <span class="result-number">1.</span>
+                                                <a class="a-link a-link__icon" href=""><span class="a-link_text">Name</span>
+                                                  <svg class="cf-icon-svg" viewbox="0 0 790.1 1200" xmlns="http://www.w3.org/2000/svg">
+                                            <path d="M740.1 178.8H449.5c-27.6 0-50 22.4-50 50s22.4 50 50 50h169.9L518.2 379.9c-14.7-6.2-30.5-9.4-46.4-9.4H120c-66.2.1-119.9 53.8-120 120v351.8c.1 66.2 53.8 119.9 120 120h351.8c66.2-.1 119.9-53.8 120-120V490.6c0-12.6-2-25-5.8-37l104.1-104.1v169.9c0 27.6 22.4 50 50 50s50-22.4 50-50V228.8c0-27.7-22.4-50-50-50zM491.8 842.3c-.1 11-9 19.9-20 20H120c-11-.1-19.9-9-20-20V490.6c.1-11 9-19.9 20-20h307.5L267 631.1c-19.4 19.6-19.3 51.3.3 70.7 19.5 19.3 50.9 19.3 70.4 0l154-154 .1 294.5z"></path></svg></a><b><br></b>Address<br>
+                                            Iowa City, IA 52240-8132</p>
+                                            <p><b>Website:</b> <a class="a-link a-link__icon" href=""><span class="a-link_text">http://www.example.com</span> <svg class="cf-icon-svg" viewbox="0 0 790.1 1200" xmlns="http://www.w3.org/2000/svg">
+                                            <path d="M740.1 178.8H449.5c-27.6 0-50 22.4-50 50s22.4 50 50 50h169.9L518.2 379.9c-14.7-6.2-30.5-9.4-46.4-9.4H120c-66.2.1-119.9 53.8-120 120v351.8c.1 66.2 53.8 119.9 120 120h351.8c66.2-.1 119.9-53.8 120-120V490.6c0-12.6-2-25-5.8-37l104.1-104.1v169.9c0 27.6 22.4 50 50 50s50-22.4 50-50V228.8c0-27.7-22.4-50-50-50zM491.8 842.3c-.1 11-9 19.9-20 20H120c-11-.1-19.9-9-20-20V490.6c.1-11 9-19.9 20-20h307.5L267 631.1c-19.4 19.6-19.3 51.3.3 70.7 19.5 19.3 50.9 19.3 70.4 0l154-154 .1 294.5z"></path></svg></a><br>
+                                            <b>Phone:</b> 000-000-0000<br>
+                                            <b>Email Address:</b> example@example.com<br>
+                                            <b>Languages:</b> English</p>
+                                        </div>
+                                    </td>
+                                    <td data-label="Services">
+                                        <div class="rich-text">
+                                            <ul>
+                                                <li>Mortgage Delinquency and Default Resolution Counse<br></li>
+                                                <li>Financial Management/Budget Counseling<br></li>
+                                                <li>Services for Homeless Counseling<br></li>
+                                                <li>Pre-purchase Counseling<br></li>
+                                                <li>Pre-purchase Homebuyer Education Workshops<br></li>
+                                                <li>Rental Housing Counseling<br></li>
+                                            </ul>
+                                            <p></p>
+                                        </div>
+                                    </td>
+                                    <td data-label="Distance">
+                                        <div class="rich-text">
+                                            <p>3.1 miles</p>
+                                        </div>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                    <div class="block">
+                        <div class="o-full-width-text-group">
+                            <div class="m-full-width-text">
+                                <h3>Paperwork Reduction Act statement</h3>
+                                <p class="u-mb0">According to the Paperwork Reduction Act of 1995, an agency may not conduct or sponsor, and a person is not required to respond to a collection of information unless it displays a valid OMB control number. The OMB control number for this collection is <a class="a-link a-link__icon" href="https://www.reginfo.gov/public/do/PRAOMBHistory?ombControlNumber=3170-0025"><span class="a-link_text">3170-0025</span> <svg class="cf-icon-svg" viewbox="0 0 790.1 1200" xmlns="http://www.w3.org/2000/svg">
+                                <path d="M740.1 178.8H449.5c-27.6 0-50 22.4-50 50s22.4 50 50 50h169.9L518.2 379.9c-14.7-6.2-30.5-9.4-46.4-9.4H120c-66.2.1-119.9 53.8-120 120v351.8c.1 66.2 53.8 119.9 120 120h351.8c66.2-.1 119.9-53.8 120-120V490.6c0-12.6-2-25-5.8-37l104.1-104.1v169.9c0 27.6 22.4 50 50 50s50-22.4 50-50V228.8c0-27.7-22.4-50-50-50zM491.8 842.3c-.1 11-9 19.9-20 20H120c-11-.1-19.9-9-20-20V490.6c.1-11 9-19.9 20-20h307.5L267 631.1c-19.4 19.6-19.3 51.3.3 70.7 19.5 19.3 50.9 19.3 70.4 0l154-154 .1 294.5z"></path></svg></a>. It expires on 04/30/2016. Using this tool to generate a list of HUD-Approved Housing Counseling Agencies is voluntary however, if you are an entity subject to 12 CFR § 1024 (78 FR 6856 (Jan. 31, 2013)), you are required to provide this list as specified in the regulation. Comments regarding this collection of information, including suggestions for improving the usefulness of the information, or suggestions for reducing the burden to respond to this collection should be submitted to the Bureau of Consumer Financial Protection (Attention: PRA Office), 1700 G Street NW, Washington, DC 20552, or by email to <a href="mailto:PRA@cfpb.gov">PRA@cfpb.gov</a>.<br></p>
 
-            <header class="m-slug-header">
-                <h2 class="a-heading">
-                    Legal disclaimer
-                </h2>
-            </header>
-            <p>
-              The content on this page provides general consumer information.
-              It is not legal advice or regulatory guidance.
-              The CFPB updates this information periodically.
-              This information may include links or references
-              to third-party resources or content.
-              We do not endorse the third-party or guarantee the accuracy
-              of this third-party information.
-              There may be other resources that also serve your needs.
-            </p>
-          </div><!-- /.kbyo-footer__col -->
-        </div><!-- /.kbyo-footer__row -->
-      </div><!-- /.kbyo-footer__wrapper -->
-</section>
+                                <div class="block
+                                            block__flush-bottom
+                                            block__flush-top
+                                            block__padded-top">
+                                    {{ social_media.render( {
+                                    "twitter_text": "Use the @CFPB’s interactive tool to double-check all the details of your Closing Disclosure.",
+                                    "email_title": "Get Closing Disclosure help from the CFPB",
+                                    "email_text": "The CFPB’s tool helps you double-check your closing disclosure:",
+                                    "email_signature": "-- From the CFPB",
+                                    "linkedin_title": "Double-check your Closing Disclosure with the @CFPB",
+                                    "linkedin_text": "Use this tool from the @CFPB to double-check that all the details in your closing disclosure are correct. Via @CFPB"
+                                    } ) }}
+                                </div>
+
+                            </div>
+                        </div>
+                    </div>
+                </section>
+            </div>
+        </div>
+    </main>
 {% endblock %}


### PR DESCRIPTION
Adding an initial setup for the find-a-housing counselor page to use the base template. Merging right away so I can work on this with @mistergone easier.
