### PR TITLE
Update credit-card-agreements page with new zip URLs

### DIFF
--- a/cfgov/agreements/templates/agreements/index.html
+++ b/cfgov/agreements/templates/agreements/index.html
@@ -68,8 +68,13 @@
 
 
     <p id="dwnld">
+        <a href="https://files.consumerfinance.gov/a/assets/Credit_Card_Agreements_2018_Q2.zip">
+            Download all most recent agreements (Q2-2018)
+        </a>
+    </p>
+     <p>
         <a href="https://files.consumerfinance.gov/a/assets/Credit_Card_Agreements_2018_Q1.zip">
-            Download all most recent agreements (Q1-2018)
+            Archived Q1-2018 agreements
         </a>
     </p>
      <p>


### PR DESCRIPTION
Quarterly update to increment the most-recent download reference and add an archival reference.

- Most-recent link is now https://files.consumerfinance.gov/a/assets/Credit_Card_Agreements_2018_Q2.zip
- New archival link is https://files.consumerfinance.gov/a/assets/Credit_Card_Agreements_2018_Q1.zip

## Deployment note
The `cf.gov-load-agreements-data` Jenkins can be run after this code is deployed.