### PR TITLE
Upgrade Jinja2 to latest

### DIFF
--- a/cfgov/jinja2/v1/_includes/organisms/half-width-link-blob-group.html
+++ b/cfgov/jinja2/v1/_includes/organisms/half-width-link-blob-group.html
@@ -20,4 +20,4 @@
 
 {% from 'organisms/info-unit-group.html' import info_unit_group with context %}
 
-{{ info_unit_group( blocks=value.link_blobs, columns=2, heading=value.heading) }}
+{{ info_unit_group(heading=value.heading, blocks=value.link_blobs, columns=2) }}

--- a/cfgov/jinja2/v1/_includes/organisms/info-unit-group.html
+++ b/cfgov/jinja2/v1/_includes/organisms/info-unit-group.html
@@ -9,16 +9,16 @@
 
    Create an info unit group organism when given:
 
+   heading: A string containing title of the info unit group.
+
    blocks:  A list composed of Wagtail Streamfield blocks.
 
    columns: (Optional) Number of columns in the info unit group.
 
-   heading: A string containing title of the info unit group.
-
 
    ========================================================================== #}
 
-{% macro info_unit_group(blocks=[], columns=2, heading) %}
+{% macro info_unit_group(heading, blocks=[], columns=2) %}
 {% set column_ratio_lookup = {
     2: 'half',
     3: 'third'

--- a/cfgov/jinja2/v1/_includes/organisms/third-width-link-blob-group.html
+++ b/cfgov/jinja2/v1/_includes/organisms/third-width-link-blob-group.html
@@ -20,4 +20,4 @@
 
 {% from 'organisms/info-unit-group.html' import info_unit_group with context %}
 
-{{ info_unit_group( blocks=value.link_blobs, columns=3, heading=value.heading) }}
+{{ info_unit_group(heading=value.heading, blocks=value.link_blobs, columns=3) }}

--- a/cfgov/regulations3k/jinja2/regulations3k/regulations3k-search-bar.html
+++ b/cfgov/regulations3k/jinja2/regulations3k/regulations3k-search-bar.html
@@ -1,4 +1,4 @@
-{% macro render(q='', hidden_fields) %}
+{% macro render(hidden_fields, q='') %}
 
 <form action="." data-js-hook="behavior_submit-search">
     <label class="a-label a-label__heading" for="query">

--- a/cfgov/regulations3k/jinja2/regulations3k/search-regulations.html
+++ b/cfgov/regulations3k/jinja2/regulations3k/search-regulations.html
@@ -77,8 +77,8 @@
     </div>
     <div class="search_wrapper u-mt30">
         {{ search_bar.render(
-            page.results.search_query,
-            [{ 'name': 'regs', 'value': page.results.regs | join(',') }]
+            [{ 'name': 'regs', 'value': page.results.regs | join(',') }],
+            page.results.search_query
         ) }}
     </div>
 </div>

--- a/requirements/libraries.txt
+++ b/requirements/libraries.txt
@@ -17,7 +17,7 @@ django-watchman==0.15.0
 edgegrid-python==1.0.10
 elasticsearch==2.4.1
 govdelivery==1.2
-Jinja2==2.7.3
+Jinja2==2.10
 jsonfield==2.0.2
 lxml==4.2.5
 Markdown==2.6.11


### PR DESCRIPTION
Upgrade our package version of Jinja2 from 2.7.3 to 2.10, the latest released version.

The [`tojson` filter](http://jinja.pocoo.org/docs/2.9/templates/#tojson) is a new feature on Jinja 2.9.x that would be very useful for my work on the UI Improvements project, so I'm taking this opportunity to upgrade cfgov-refresh, if possible.

## Changes

- Upgrade our version of jinja2. This required updating the order of arguments for a few method calls.

## Notes

- ~~I did a quick search and didn't find any satellite apps that explicitly require jinja2.~~ TDP uses jinja2, and initial automated and manual testing seems to indicate that this change won't break it. Is there anywhere else I need to look to make sure this doesn't cause a version mismatch or break things?

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [x] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

Should not change any cf.gov functionality