### PR TITLE
Add mapbox dependencies

### DIFF
--- a/cfgov/housing_counselor/jinja2/housing_counselor/improved_index.html
+++ b/cfgov/housing_counselor/jinja2/housing_counselor/improved_index.html
@@ -62,7 +62,7 @@
                                                 <label class="a-label a-label__heading" for="zip">
                                                     Search by ZIP code:
                                                 </label>
-                                                <input id="zip" type="text" name="zip" class="a-text-input a-text-input__full" value="52246">
+                                                <input id="zip" type="text" name="zipcode" class="a-text-input a-text-input__full" value="52246">
                                             </div>
                                             <div class="m-form-field-with-button_wrapper">
                                                 <input class="a-btn a-btn__full-on-xs" type="submit" value="Find a counselor">
@@ -196,7 +196,10 @@
     <script type='text/javascript'
             src='https://api.mapbox.com/mapbox.js/v2.4.0/mapbox.js'></script>
     <script>
-    var hud_data = {{ api_json | tojson }};
+    var hud_data = {};
+    {% if api_json %}
+    hud_data = {{ api_json | tojson }};
+    {% endif %}
     var mapbox_access_token = "{{ mapbox_access_token }}";
     </script>
 

--- a/cfgov/housing_counselor/jinja2/housing_counselor/improved_index.html
+++ b/cfgov/housing_counselor/jinja2/housing_counselor/improved_index.html
@@ -6,7 +6,11 @@
 {% endblock %}
 
 {% block css %}
+<link rel='stylesheet'
+      href='https://api.mapbox.com/mapbox.js/v2.4.0/mapbox.css' />
 {{ super() }}
+<link rel="stylesheet"
+      href="{{ static('apps/find-a-housing-counselor/css/main.css') }}">
 {% endblock %}
 
 {% block hero %}
@@ -76,7 +80,13 @@
                                 </div>
                             </div>
                             <div class="col-9">
-                                MAP GOES HERE
+                                <!-- Mapbox map is ignored during voiceover navigation
+                                     as set by aria-hidden. -->
+                                <div id="hud_hca_api_map_container"
+                                     class="hud_hca_api_map col"
+                                     aria-hidden="true">
+                                    <div id="hud_hca_api_map_canvas"></div>
+                                </div><!-- end .hud_hca_api_map -->
                             </div>
                         </div>
                     </div>
@@ -180,3 +190,25 @@
         </div>
     </main>
 {% endblock %}
+
+{% block javascript %}
+    {{ super() }}
+    <script type='text/javascript'
+            src='https://api.mapbox.com/mapbox.js/v2.4.0/mapbox.js'></script>
+    <script>
+    var hud_data = {{ api_json | tojson }};
+    var mapbox_access_token = "{{ mapbox_access_token }}";
+    </script>
+
+    <script async>
+      if ( document.body.parentElement.className.indexOf( 'no-js' ) === -1 ) {
+        !function(){
+          {# Include site-wide JavaScript. #}
+          var s = [
+            '{{ static('apps/find-a-housing-counselor/js/hud.js') }}'
+          ];
+          jsl(s);
+        }()
+      }
+    </script>
+{% endblock javascript %}

--- a/cfgov/unprocessed/apps/find-a-housing-counselor/browserslist
+++ b/cfgov/unprocessed/apps/find-a-housing-counselor/browserslist
@@ -1,0 +1,6 @@
+# Browsers that Google Analytics Tag manager custom tags support.
+# This file (browserlist) is picked up by babel-preset-env (in webpack config).
+# See https://github.com/browserslist/browserslist#config-file
+
+last 2 versions
+Explorer >= 9

--- a/cfgov/unprocessed/apps/find-a-housing-counselor/css/hud.css
+++ b/cfgov/unprocessed/apps/find-a-housing-counselor/css/hud.css
@@ -1,0 +1,279 @@
+/* Begin HUD HCA API Landing Page additions */
+
+/* Normalize link highlighting */
+a:hover, a:focus {
+    background-color: transparent;
+}
+
+/* Form */
+.hud_hca_api_interactions {
+    margin-bottom: 2em;
+    margin-top: 1em;
+}
+
+.hud_hca_api_form_container {
+    background-color: #d7d2cb;
+    border: 1px solid #babbbd !important;
+    position: relative;
+}
+
+.hud_hca_api_form_container a {
+    background: transparent;
+    border-bottom-color: #101820;
+    color: #101820;
+}
+
+.hud_hca_api_form_container a:hover,
+.hud_hca_api_form_container a:focus,
+.hud_hca_api_form_container a:active {
+    border-bottom-width: solid;
+}
+
+.hud_hca_api_form {
+    margin: 0 1em;
+    padding: 2.5em 0 1em;
+}
+
+.hud_hca_api_form input {
+    border-bottom-right-radius: 0;
+    border-top-right-radius: 0;
+    margin-bottom: 2.5em;
+    padding: 2% 1%;
+    position: relative;
+    width: 95%;
+}
+
+.hud_hca_api_form label {
+    cursor: default;
+    display: block;
+    font-family: "Avenir Next", Verdana, sans-serif;
+    font-weight: 600;
+    margin-bottom: 2.5em;
+}
+
+.hud_hca_api_form_button {
+    margin-top: 2em;
+    margin-bottom: 2.5em;
+    padding-bottom: 1em;
+    padding-top: 1em;
+    width: 100%;
+}
+
+.hud_hca_api_more_info {
+    border-top: 1px solid #75787b;
+    margin: 0 1em;
+    padding: 1em 0;
+}
+
+/* Flexible iFrame for Map
+   http://niklausgerber.com/blog/responsive-google-or-bing-maps/
+*/
+.flex_container {
+    position: relative;
+    padding-bottom: 61%;
+    padding-top: 30px;
+    height: 0;
+    overflow: hidden;
+}
+
+.flex_container iframe,
+.flex_containe object,
+.flex_containe embed {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+}
+
+#hud_hca_api_map_container {
+    /* Prevent map controls from appearing on top of mega menu. */
+    z-index: 0;
+}
+
+#hud_hca_api_map_canvas {
+    position: relative;
+    top: -2em;
+    height: 443px;
+    width: 678px;
+}
+
+#hud_hca_api_map_canvas img {
+    max-width: none;
+}
+
+/* Grid */
+.hud_hca_api_grid_twothird > .col {
+    display: inline-block;
+    /* IE7 hack to mimic inline-block on block elements */
+    *display: inline;
+    *zoom: 1;
+    width: 69.4%;
+    vertical-align: top;
+}
+
+.hud_hca_api_grid_twothird > div.col:first-child {
+    margin-right: 2.04918%;
+    width: 27.7%;
+}
+
+/* Results listing */
+.hud_hca_api_results_listing {
+    border: 0;
+    width: 100%;
+}
+
+.hud_hca_api_titles {
+    background-color: #fff;
+    border-bottom: 1px solid #101820;
+    border-top: 1px solid #101820;
+    border-left: 0;
+    border-right: 0;
+    color: #333;
+    font-size: 1.25em;
+    padding: 1em;
+    text-align: left;
+}
+
+.hud_hca_api_titles_left {
+    padding-left: 2%;
+    width: 40%;
+}
+
+.hud_hca_api_titles_middle {
+    padding-left: 2%;
+    width: 40%;
+}
+
+.hud_hca_api_titles_right {
+    width: 12%;
+}
+
+#hud_hca_api_message {
+    font-size: 1.25em;
+    font-weight: 600;
+    margin: 1em 0;
+}
+
+.hud_hca_api_results {
+    font-family: "Avenir Next", Arial, sans-serif;
+}
+
+.hud_hca_api_results_total {
+    float: left;
+    margin-right: 2.04918%;
+    margin-top: 1em;
+    width: 48.75%;
+}
+
+.hud_hca_api_results_actions {
+    float: right;
+    margin-top: 1em;
+    width: 48.75%;
+}
+
+.hud_hca_api_results_total p {
+    font-weight: 600;
+    line-height: 1.85;
+    padding: 0 1em;
+}
+
+.hud_hca_api_results_actions p {
+    font-size: 0.875em;
+    line-height: 1.85;
+    padding: 0 1em;
+    text-align: right;
+}
+
+.hud_hca_api_results_print {
+    display: inline-block;
+    /* IE7 hack to mimic inline-block on block elements */
+    *display: inline;
+    *zoom: 1;
+    vertical-align: top;
+    height: 1.875em;
+    margin-right: 2.04918%;
+}
+.hud_hca_api_results_save {
+    display: inline-block;
+    /* IE7 hack to mimic inline-block on block elements */
+    *display: inline;
+    *zoom: 1;
+    vertical-align: top;
+    height: 1.875em;
+}
+
+.hud_hca_api_result {
+    border-bottom: 1px solid #babbbd;
+    border-top: 0;
+    border-left: 0;
+    border-right: 0;
+    line-height: 1.5;
+    padding: 1.5em 1em;
+}
+
+.hud_hca_api_num {
+    float: left;
+    padding-right: 2.04918%;
+    width: 5%;
+}
+
+.hud_hca_api_counselor_info_container {
+    float: left;
+    width: 88.95082%;
+}
+
+.hud_hca_api_counselor,
+.hud_hca_api_results_listing_title {
+    font-weight: 600;
+}
+
+.hud_hca_api_adr,
+.hud_hca_api_region {
+    display: block;
+}
+
+.hud_hca_api_results_listing_title span {
+    font-weight: normal;
+}
+
+.hud_hca_api_counselor_address {
+    display: block;
+    margin-bottom: 1em;
+}
+
+.hud_hca_api_results_listing_title,
+.hud_hca_api_counselor_address,
+.hud_hca_api_serv_item {
+    display: block;
+}
+
+.hud_hca_api_serv_item:before {
+    content: "\2013\00a0";
+}
+
+/* Show/Hide for results */
+.hud_hca_api_pras .show-hide-icon {
+    color: #4d819a;
+}
+
+.hud_hca_api_pras .show-hide-link {
+    font-size: 0.875em;
+}
+
+.hud_hca_api_pras {
+    font-family: Georgia, "Times New Roman", serif;
+    margin: 1em 0;
+}
+
+.bread {
+    margin: 0;
+}
+
+/* Override to remove default Nemo PDF download icon */
+.pdf {
+    background: none;
+    padding-right: 0;
+}
+
+/* End HUD HCA API Landing Page additions */

--- a/cfgov/unprocessed/apps/find-a-housing-counselor/css/hud_print.css
+++ b/cfgov/unprocessed/apps/find-a-housing-counselor/css/hud_print.css
@@ -1,0 +1,189 @@
+/***** PRINT STYLES FOR FIND A HOUSING COUNSELOR *****/
+
+@media print {
+    body {
+        background: transparent !important;
+        color: #000 !important; /* Black prints faster: h5bp.com/s */
+        box-shadow: none !important;
+        text-shadow: none !important;
+    }
+
+    a,
+    a:link,
+    a:visited {
+        border: 0;
+        color: #000 !important; /* Black prints faster: h5bp.com/s */
+        text-decoration: underline;
+    }
+
+    abbr[title]:after {
+        content: " (" attr(title) ")";
+    }
+
+    /*
+     * Don't show links for images, or javascript/internal links
+     */
+
+    a[href^="javascript:"]:after,
+    a[href^="#"]:after {
+        content: "";
+    }
+
+    pre,
+    blockquote {
+        border: 1px solid #999;
+        page-break-inside: avoid;
+    }
+
+    thead {
+        display: table-header-group; /* h5bp.com/t */
+    }
+
+    tr,
+    img {
+        page-break-inside: avoid;
+    }
+
+    img {
+        max-width: 100% !important;
+    }
+
+    @page {
+        size: letter;
+        margin: .5in .5in .5in .5in;
+        padding: 0;
+    }
+
+    p,
+    h1,
+    h2,
+    h3,
+    h4 {
+        orphans: 3;
+        widows: 3;
+    }
+
+    h1,
+    h2,
+    h3,
+    h4 {
+        page-break-after: avoid;
+    }
+
+    /* Hide unneeded content */
+    .o-header,
+    .bread,
+    .share,
+    .o-footer,
+    .hud_hca_api_print_hide {
+        display: none !important;
+    }
+
+    /* Some adjustments */
+    table, thead, tbody, tfoot, tr, td, th, caption {
+        border: 0 !important;
+        display: block !important;
+        margin: 0 !important;
+        padding: 0 !important;
+    }
+
+    .pagetitle > h1 {
+        font-size: 16pt;
+    }
+
+    img.hud_hca_api_print_logo {
+        float: right;
+        max-width: 20% !important;
+    }
+
+    .cfpb_hud_hca_api_print_text {
+        border-bottom: 4px solid #101820;
+        padding-bottom: 1em;
+    }
+
+    .hud_hca_api_the_results {
+        font-weight: bold;
+        text-transform: uppercase;
+    }
+
+    /* Grid adjustments */
+    tr.hud_hca_api_result:before,
+    tr.hud_hca_api_result:after {
+        content: " ";
+        display: table;
+    }
+
+    tr.hud_hca_api_result:after {
+        clear: both;
+    }
+
+    tr.hud_hca_api_result {
+        *zoom: 1;
+    }
+
+    tr.hud_hca_api_result {
+        border-bottom: 1px solid #babbbd !important;
+        padding: 1.5em 0 !important;
+    }
+
+    .hud_hca_api_counselors_td,
+    .hud_hca_api_services_td {
+        float: left;
+        width: 88%;
+    }
+
+    .hud_hca_api_distances_td {
+        float: right;
+        margin-left: 2% !important;
+        margin-top: -255px !important;
+        text-align: right;
+        width: 10%;
+    }
+
+    .hud_hca_api_counselor_address,
+    .hud_hca_api_site,
+    .hud_hca_api_tel,
+    .hud_hca_api_lang,
+    .hud_hca_api_serv,
+    .hud_hca_api_distance {
+        page-break-inside: avoid;
+    }
+
+    .hud_hca_api_print_show {
+        display: block !important;
+        visibility: visible;
+    }
+
+    .hud_hca_api_results_listing_title {
+        margin-top: 1em;
+    }
+
+    .hud_hca_api_services {
+        padding-left: 7.04918%;
+    }
+
+    .hud_hca_api_serv_item {
+        display: inline;
+    }
+
+    .hud_hca_api_serv_item:before {
+        content: " | ";
+    }
+
+    .hud_hca_api_serv_item:first-child:before {
+        content: "";
+    }
+
+    .hud_hca_api_distances_td .hud_hca_api_results_listing_title {
+        margin-top: 0;
+    }
+
+    .hud_hca_api_site > .hud_hca_api_results_listing_title,
+    .hud_hca_api_tel > .hud_hca_api_results_listing_title {
+        display: inline;
+    }
+
+    .hud_hca_api_lang {
+        display: block;
+    }
+}

--- a/cfgov/unprocessed/apps/find-a-housing-counselor/css/main.less
+++ b/cfgov/unprocessed/apps/find-a-housing-counselor/css/main.less
@@ -1,0 +1,2 @@
+@import (less) './hud.css';
+@import (less) './hud_print.css';

--- a/cfgov/unprocessed/apps/find-a-housing-counselor/js/hud.js
+++ b/cfgov/unprocessed/apps/find-a-housing-counselor/js/hud.js
@@ -1,0 +1,199 @@
+const jQuery = require( 'jquery' );
+
+/* 	This script uses a local Django API to acquire a list of the 10 closest
+HUD Counselors by zip code. See hud_api_replace for more details on the
+API queries. -wernerc */
+
+/*	This class represents a namespace of functions that should be exposed
+for testing purposes. */
+var cfpb_hud_hca = ( function() {
+  /*	check_zip() is an easy, useful function that takes a string and returns a valid zip code, or returns false.
+  NOTE: 'Valid' means 5 numeric characters, not necessarily 'existant' and 'actually addressable.' */
+  var check_zip = function( zip ) {
+    if ( ( zip === null ) || ( zip === undefined ) || ( zip === false ) ) {
+      return false;
+    }
+    else {
+      zip = zip.toString().replace( /[^0-9]+/g,'' );
+      zip = zip.slice(0,5);
+      if ( zip.length === 5 ) {
+        return zip;
+      }
+      else {
+        return false;
+      }
+    }
+  }
+
+  /*	check_data_structure() just makes sure your data has the correct structure before you start
+  requesting properties that don't exist in generate_html() and update_map() */
+  var check_hud_data = function( data ) {
+    if ( ( data === null ) || ( data === 0 ) || ( data === undefined ) ) {
+      return false;
+    }
+    else if ( data.hasOwnProperty( 'error' ) ) {
+      return 'error';
+    }
+    else if ( !( data.hasOwnProperty( 'counseling_agencies' ) ) ) {
+      return false;
+    }
+    else if ( !( data.hasOwnProperty( 'zip' ) ) ) {
+      return false;
+    }
+    else {
+      return true;
+    }
+  }
+
+  return {
+    check_zip: check_zip,
+    check_hud_data: check_hud_data
+  }
+}() );
+
+(function($, L) { // start jQuery capsule
+
+  var map;
+  var marker_array = [];
+  var zip_marker = null;
+
+
+  /*	get_url_zip() is a simple function to retrieve the zip variable from the URL */
+  function get_url_zip() {
+    var zip = '';
+    var keyvals = window.location.href.slice( window.location.href.indexOf( '?' ) + 1 ).split( '&' );
+    $.each( keyvals , function( i, val ) {
+      var parts = val.split( '=' );
+      if ( parts[0] == 'zip' ) {
+        zip = parts[1];
+      }
+    } );
+    return ( cfpb_hud_hca.check_zip( zip ) );
+  }
+
+  /*	initialize_map() sets options and creates the map */
+  function initialize_map() {
+    L.mapbox.accessToken = mapbox_access_token,
+    map = L.mapbox.map( 'hud_hca_api_map_container', 'mapbox.streets' )
+      .setView( [40, -80], 2 );
+
+    if (hud_data.counseling_agencies) {
+      update_map( hud_data );
+    }
+  }
+
+  $( document ).ready( initialize_map );
+
+  /*	generate_google_map(data) takes the data and plots the markers, etc, on
+  the google map. It's called by get_counselors_by_zip(). */
+
+  function update_map( data ) {
+    // reset the map
+    for (var i = 0; i < marker_array.length; i++ ) {
+      map.removeLayer( marker_array[i] );
+    }
+    marker_array = [];
+    if ( zip_marker != null ) {
+      map.removeLayer( zip_marker );
+    }
+    map.setZoom( 2 );
+    map.setView( [40, -80] );
+
+    if ( cfpb_hud_hca.check_hud_data( data ) === true ) {
+      var lat = data.zip.lat;
+      var lng = data.zip.lng;
+      var ziplatlng = [lat, lng];
+      var zoom = 14;
+
+      map.setZoom( zoom );
+      map.setView( ziplatlng );
+
+      var bounds = map.getBounds();
+      var xmax = -Infinity;
+      var xmin = Infinity;
+      var ymax = -Infinity;
+      var ymin = Infinity;
+
+      zip_marker = L.circle( ziplatlng, 3 ).addTo( map );
+
+      $.each( data.counseling_agencies, function( i, val ) {
+        var lat = val.agc_ADDR_LATITUDE;
+        var lng = val.agc_ADDR_LONGITUDE
+        var position = new L.LatLng( lat, lng );
+
+        if ( lat > ymax ) ymax = lat;
+        if ( lat < ymin ) ymin = lat;
+        if ( lng > xmax ) xmax = lng;
+        if ( lng < xmin ) xmin = lng;
+
+        var number = i + 1;
+
+        if ( number < 10 ) {
+          number = '0' + number;
+        }
+
+        var icon = L.icon({
+          iconUrl: '/static/nemo/_/img/hud_gmap/agc_' + number + '.png',
+          iconAnchor: [20, 50]
+        } );
+
+        var marker = new L.Marker( position, { icon: icon } ).addTo( map );
+        marker_array[i] = marker;
+
+        marker.on( 'click', function() {
+          $( document.body ).animate( { 'scrollTop': $( '#hud-result-' + number ).offset().top }, 1000);
+        } );
+      } );
+
+      //shift the max bounds so that the dropped pins are always on screen
+      var xd = ( xmax - xmin ) / 10;
+      var yd = ( ymax - ymin ) / 10;
+
+      map.fitBounds( [[ymin - yd, xmin - xd], [ymax + yd, xmax + xd]] );
+    }
+  }
+
+  $( document ).ready( function() {
+
+    // On click of the print link, open print dialog
+    $( '.hud_hca_api_no_js_print_text' ).remove();
+    $( '.hud_hca_api_results_print' ).append( '<a class="hud-hca-api-print" href="#print">Print list</a>' );
+    $( '.hud_hca_api_results_print a.hud-hca-api-print' ).click( function() {
+      window.print();
+      return false;
+    } );
+
+    // Provide a fallback for HTML5 placeholder for older browsers
+    $( '#hud_hca_api_query', function() {
+      var input = document.createElement( 'input' );
+      if ( ( 'placeholder' in input ) == false ) {
+        $( '[placeholder]' ).focus( function() {
+          var i = $( this );
+          if ( i.val() == i.attr( 'placeholder' ) ) {
+            i.val( '' ).removeClass( 'placeholder' );
+          }
+        } ).blur(function() {
+          var i = $( this );
+          if ( i.val() == '' || i.val() == i.attr( 'placeholder' ) ) {
+            i.addClass( 'placeholder' ).val(i.attr( 'placeholder' ) );
+          }
+        } ).blur().parents( 'form' ).submit( function() {
+          $( this ).find( '[placeholder]' ).each(function() {
+            var i = $( this );
+            if ( i.val() == i.attr( 'placeholder' ) )
+            i.val( '' );
+          } )
+        } );
+      }
+    } );
+
+    // If there is a GET value for zip, load that zip immediately.
+    var getzip = get_url_zip();
+    if ( getzip != '' ) {
+      $( '#hud_hca_api_query' ).val( getzip );
+      $( '.hud_hca_api_form_button' ).trigger( 'click' );
+    }
+
+  } );
+
+} )( jQuery, L ); // end anonymous function capsule

--- a/cfgov/unprocessed/apps/find-a-housing-counselor/js/hud.js
+++ b/cfgov/unprocessed/apps/find-a-housing-counselor/js/hud.js
@@ -1,155 +1,154 @@
 const jQuery = require( 'jquery' );
 
-/* 	This script uses a local Django API to acquire a list of the 10 closest
+let UNDEFINED;
+
+/* This script uses a local Django API to acquire a list of the 10 closest
 HUD Counselors by zip code. See hud_api_replace for more details on the
 API queries. -wernerc */
 
-/*	This class represents a namespace of functions that should be exposed
+/* This class represents a namespace of functions that should be exposed
 for testing purposes. */
-var cfpb_hud_hca = ( function() {
-  /*	check_zip() is an easy, useful function that takes a string and returns a valid zip code, or returns false.
+const cfpb_hud_hca = ( function() {
+  /* check_zip() is an easy, useful function that takes a string and returns a valid zip code, or returns false.
   NOTE: 'Valid' means 5 numeric characters, not necessarily 'existant' and 'actually addressable.' */
-  var check_zip = function( zip ) {
-    if ( ( zip === null ) || ( zip === undefined ) || ( zip === false ) ) {
+  const check_zip = function( zip ) {
+    if ( ( zip === null ) || ( zip === UNDEFINED ) || ( zip === false ) ) {
       return false;
     }
-    else {
-      zip = zip.toString().replace( /[^0-9]+/g,'' );
-      zip = zip.slice(0,5);
-      if ( zip.length === 5 ) {
-        return zip;
-      }
-      else {
-        return false;
-      }
-    }
-  }
 
-  /*	check_data_structure() just makes sure your data has the correct structure before you start
+    zip = zip.toString().replace( /[^0-9]+/g, '' );
+    zip = zip.slice( 0, 5 );
+    if ( zip.length === 5 ) {
+      return zip;
+    }
+
+    return false;
+
+
+  };
+
+  /* check_data_structure() just makes sure your data has the correct structure before you start
   requesting properties that don't exist in generate_html() and update_map() */
-  var check_hud_data = function( data ) {
-    if ( ( data === null ) || ( data === 0 ) || ( data === undefined ) ) {
+  const check_hud_data = function( data ) {
+    if ( ( data === null ) || ( data === 0 ) || ( data === UNDEFINED ) ) {
       return false;
-    }
-    else if ( data.hasOwnProperty( 'error' ) ) {
+    } else if ( data.hasOwnProperty( 'error' ) ) {
       return 'error';
-    }
-    else if ( !( data.hasOwnProperty( 'counseling_agencies' ) ) ) {
+    } else if ( !data.hasOwnProperty( 'counseling_agencies' ) ) {
+      return false;
+    } else if ( !data.hasOwnProperty( 'zip' ) ) {
       return false;
     }
-    else if ( !( data.hasOwnProperty( 'zip' ) ) ) {
-      return false;
-    }
-    else {
-      return true;
-    }
-  }
+
+    return true;
+
+  };
 
   return {
     check_zip: check_zip,
     check_hud_data: check_hud_data
-  }
-}() );
+  };
+} )();
 
-(function($, L) { // start jQuery capsule
+( function( $, L ) { // start jQuery capsule
 
-  var map;
-  var marker_array = [];
-  var zip_marker = null;
+  let map;
+  let marker_array = [];
+  let zip_marker = null;
 
 
-  /*	get_url_zip() is a simple function to retrieve the zip variable from the URL */
+  /* get_url_zip() is a simple function to retrieve the zip variable from the URL */
   function get_url_zip() {
-    var zip = '';
-    var keyvals = window.location.href.slice( window.location.href.indexOf( '?' ) + 1 ).split( '&' );
-    $.each( keyvals , function( i, val ) {
-      var parts = val.split( '=' );
-      if ( parts[0] == 'zip' ) {
+    let zip = '';
+    const keyvals = window.location.href.slice( window.location.href.indexOf( '?' ) + 1 ).split( '&' );
+    $.each( keyvals, function( i, val ) {
+      const parts = val.split( '=' );
+      if ( parts[0] === 'zip' ) {
         zip = parts[1];
       }
     } );
-    return ( cfpb_hud_hca.check_zip( zip ) );
+    return cfpb_hud_hca.check_zip( zip );
   }
 
-  /*	initialize_map() sets options and creates the map */
+  /* initialize_map() sets options and creates the map */
   function initialize_map() {
-    L.mapbox.accessToken = mapbox_access_token,
+    L.mapbox.accessToken = window.mapbox_access_token;
     map = L.mapbox.map( 'hud_hca_api_map_container', 'mapbox.streets' )
-      .setView( [40, -80], 2 );
+      .setView( [ 40, -80 ], 2 );
 
-    if (hud_data.counseling_agencies) {
-      update_map( hud_data );
+    if ( window.hud_data.counseling_agencies ) {
+      update_map( window.hud_data );
     }
   }
 
   $( document ).ready( initialize_map );
 
-  /*	generate_google_map(data) takes the data and plots the markers, etc, on
+  /* generate_google_map(data) takes the data and plots the markers, etc, on
   the google map. It's called by get_counselors_by_zip(). */
 
   function update_map( data ) {
     // reset the map
-    for (var i = 0; i < marker_array.length; i++ ) {
+    for ( let i = 0; i < marker_array.length; i++ ) {
       map.removeLayer( marker_array[i] );
     }
     marker_array = [];
-    if ( zip_marker != null ) {
+    if ( zip_marker !== null ) {
       map.removeLayer( zip_marker );
     }
     map.setZoom( 2 );
-    map.setView( [40, -80] );
+    map.setView( [ 40, -80 ] );
 
     if ( cfpb_hud_hca.check_hud_data( data ) === true ) {
-      var lat = data.zip.lat;
-      var lng = data.zip.lng;
-      var ziplatlng = [lat, lng];
-      var zoom = 14;
+      const lat = data.zip.lat;
+      const lng = data.zip.lng;
+      const ziplatlng = [ lat, lng ];
+      const zoom = 14;
 
       map.setZoom( zoom );
       map.setView( ziplatlng );
 
-      var bounds = map.getBounds();
-      var xmax = -Infinity;
-      var xmin = Infinity;
-      var ymax = -Infinity;
-      var ymin = Infinity;
+      const bounds = map.getBounds();
+      let xmax = -Infinity;
+      let xmin = Infinity;
+      let ymax = -Infinity;
+      let ymin = Infinity;
 
       zip_marker = L.circle( ziplatlng, 3 ).addTo( map );
 
       $.each( data.counseling_agencies, function( i, val ) {
-        var lat = val.agc_ADDR_LATITUDE;
-        var lng = val.agc_ADDR_LONGITUDE
-        var position = new L.LatLng( lat, lng );
+        const lat = val.agc_ADDR_LATITUDE;
+        const lng = val.agc_ADDR_LONGITUDE;
+        const position = new L.LatLng( lat, lng );
 
         if ( lat > ymax ) ymax = lat;
         if ( lat < ymin ) ymin = lat;
         if ( lng > xmax ) xmax = lng;
         if ( lng < xmin ) xmin = lng;
 
-        var number = i + 1;
+        let number = i + 1;
 
         if ( number < 10 ) {
           number = '0' + number;
         }
 
-        var icon = L.icon({
+        const icon = L.icon( {
           iconUrl: '/static/nemo/_/img/hud_gmap/agc_' + number + '.png',
-          iconAnchor: [20, 50]
+          iconAnchor: [ 20, 50 ]
         } );
 
-        var marker = new L.Marker( position, { icon: icon } ).addTo( map );
+        const marker = new L.Marker( position, { icon: icon } ).addTo( map );
         marker_array[i] = marker;
 
         marker.on( 'click', function() {
-          $( document.body ).animate( { 'scrollTop': $( '#hud-result-' + number ).offset().top }, 1000);
+          $( document.body ).animate( { scrollTop: $( '#hud-result-' + number ).offset().top }, 1000 );
         } );
       } );
 
-      //shift the max bounds so that the dropped pins are always on screen
-      var xd = ( xmax - xmin ) / 10;
-      var yd = ( ymax - ymin ) / 10;
+      // shift the max bounds so that the dropped pins are always on screen
+      const xd = ( xmax - xmin ) / 10;
+      const yd = ( ymax - ymin ) / 10;
 
-      map.fitBounds( [[ymin - yd, xmin - xd], [ymax + yd, xmax + xd]] );
+      map.fitBounds( [ [ ymin - yd, xmin - xd ], [ ymax + yd, xmax + xd ] ] );
     }
   }
 
@@ -165,35 +164,38 @@ var cfpb_hud_hca = ( function() {
 
     // Provide a fallback for HTML5 placeholder for older browsers
     $( '#hud_hca_api_query', function() {
-      var input = document.createElement( 'input' );
-      if ( ( 'placeholder' in input ) == false ) {
+      const input = document.createElement( 'input' );
+      if ( ( 'placeholder' in input ) === false ) {
+        // eslint-disable-next-line max-nested-callbacks
         $( '[placeholder]' ).focus( function() {
-          var i = $( this );
-          if ( i.val() == i.attr( 'placeholder' ) ) {
+          const i = $( this );
+          if ( i.val() === i.attr( 'placeholder' ) ) {
             i.val( '' ).removeClass( 'placeholder' );
           }
-        } ).blur(function() {
-          var i = $( this );
-          if ( i.val() == '' || i.val() == i.attr( 'placeholder' ) ) {
-            i.addClass( 'placeholder' ).val(i.attr( 'placeholder' ) );
+        // eslint-disable-next-line max-nested-callbacks
+        } ).blur( function() {
+          const i = $( this );
+          if ( i.val() === '' || i.val() === i.attr( 'placeholder' ) ) {
+            i.addClass( 'placeholder' ).val( i.attr( 'placeholder' ) );
           }
+        // eslint-disable-next-line max-nested-callbacks
         } ).blur().parents( 'form' ).submit( function() {
-          $( this ).find( '[placeholder]' ).each(function() {
-            var i = $( this );
-            if ( i.val() == i.attr( 'placeholder' ) )
-            i.val( '' );
-          } )
+          // eslint-disable-next-line max-nested-callbacks
+          $( this ).find( '[placeholder]' ).each( function() {
+            const i = $( this );
+            if ( i.val() === i.attr( 'placeholder' ) ) i.val( '' );
+          } );
         } );
       }
     } );
 
     // If there is a GET value for zip, load that zip immediately.
-    var getzip = get_url_zip();
-    if ( getzip != '' ) {
+    const getzip = get_url_zip();
+    if ( getzip !== '' ) {
       $( '#hud_hca_api_query' ).val( getzip );
       $( '.hud_hca_api_form_button' ).trigger( 'click' );
     }
 
   } );
 
-} )( jQuery, L ); // end anonymous function capsule
+} )( jQuery, window.L ); // end anonymous function capsule

--- a/cfgov/unprocessed/apps/find-a-housing-counselor/package-lock.json
+++ b/cfgov/unprocessed/apps/find-a-housing-counselor/package-lock.json
@@ -1,0 +1,31 @@
+{
+  "name": "find-a-housing-counselor",
+  "requires": true,
+  "lockfileVersion": 1,
+  "dependencies": {
+    "babel-polyfill": {
+      "version": "7.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-7.0.0-beta.3.tgz",
+      "integrity": "sha512-wEXpYXn61nCd+so0TOSzydX1mwUjst5Mx2yUV5fVs6AaK+PKqDdoecty2BHoEwaQTKcsq6ihoQZf9oaKV5DvEg==",
+      "requires": {
+        "core-js": "2.5.7",
+        "regenerator-runtime": "0.11.1"
+      }
+    },
+    "core-js": {
+      "version": "2.5.7",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
+      "integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw=="
+    },
+    "jquery": {
+      "version": "1.12.4",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-1.12.4.tgz",
+      "integrity": "sha1-AeHfuikP5z3rp3zurLD5ui/sngw="
+    },
+    "regenerator-runtime": {
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
+    }
+  }
+}

--- a/cfgov/unprocessed/apps/find-a-housing-counselor/package.json
+++ b/cfgov/unprocessed/apps/find-a-housing-counselor/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "find-a-housing-counselor",
+  "description": "The consumerfinance.gov/find-a-housing-counselor website.",
+  "homepage": "https://www.consumerfinance.gov/find-a-housing-counselor",
+  "author": {
+    "name": "Consumer Financial Protection Bureau",
+    "email": "tech@cfpb.gov",
+    "url": "https://cfpb.github.io/"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/cfpb/cfgov-refresh.git"
+  },
+  "license": "SEE LICENSE IN TERMS.md",
+  "engines": {
+    "node": ">=8.0.0"
+  },
+  "dependencies": {
+    "babel-polyfill": "^7.0.0-beta.3",
+    "jquery": "^1.9.1"
+  }
+}

--- a/cfgov/unprocessed/apps/find-a-housing-counselor/webpack-config.js
+++ b/cfgov/unprocessed/apps/find-a-housing-counselor/webpack-config.js
@@ -1,0 +1,71 @@
+/* ==========================================================================
+   Settings for webpack JavaScript bundling system.
+   ========================================================================== */
+
+const BROWSER_LIST = require( '../../../../config/browser-list-config' );
+const webpack = require( 'webpack' );
+const UglifyWebpackPlugin = require( 'uglifyjs-webpack-plugin' );
+
+/* Set warnings to true to show linter-style warnings.
+   Set mangle to false and beautify to true to debug the output code. */
+const COMMON_UGLIFY_CONFIG = new UglifyWebpackPlugin( {
+  cache: true,
+  parallel: true,
+  uglifyOptions: {
+    ie8: false,
+    ecma: 5,
+    warnings: false,
+    mangle: true,
+    output: {
+      comments: false,
+      beautify: false
+    }
+  }
+} );
+
+/* Commmon webpack 'module' option used in each configuration.
+   Runs code through Babel and uses global supported browser list. */
+const COMMON_MODULE_CONFIG = {
+  rules: [ {
+    test: /\.js$/,
+
+    /* The below regex will capture all node modules
+       that start with `cf-` or `cfpb-`.
+       Regex test: https://regex101.com/r/zizz3V/5 */
+    exclude: /node_modules\/(?:cf\-.+|cfpb\-.+)/,
+    use: {
+      loader: 'babel-loader?cacheDirectory=true',
+      options: {
+        presets: [ [ 'babel-preset-env', {
+          configPath: __dirname,
+          /* Use useBuiltIns: 'usage' and set `debug: true` to see what
+             scripts require polyfilling. */
+          useBuiltIns: false,
+          debug: false
+        } ] ]
+      }
+    }
+  } ]
+};
+
+const STATS_CONFIG  = {
+  stats: {
+    entrypoints: false
+  }
+};
+
+const conf = {
+  cache: true,
+  module: COMMON_MODULE_CONFIG,
+  mode: 'production',
+  output: {
+    filename: '[name]',
+    jsonpFunction: 'findAHousingCounselor'
+  },
+  plugins: [
+    COMMON_UGLIFY_CONFIG
+  ],
+  stats: STATS_CONFIG.stats
+};
+
+module.exports = { conf };

--- a/config/webpack-config.js
+++ b/config/webpack-config.js
@@ -17,6 +17,7 @@ const COMMON_BUNDLE_NAME = 'common.js';
 const COMMON_MODULE_CONFIG = {
   rules: [ {
     test: /\.js$/,
+
     /* The `exclude` rule is a double negative.
        It excludes all of `node_modules/` but it then un-excludes modules that
        start with `cf-` and `cfpb-` (CF components and cfpb-chart-builder).

--- a/test/unit_tests/apps/regulations3k/js/analytics-spec.js
+++ b/test/unit_tests/apps/regulations3k/js/analytics-spec.js
@@ -66,7 +66,7 @@ describe( 'The Regs3K analytics', () => {
   it( 'should handle navigation clicks on regs links', () => {
     let event = { target: {
       href: '/policy-compliance/rulemaking/regulations/1002/11/'
-    } };
+    }};
     event = analytics.handleNavClick( event );
 
     expect( event ).toEqual( {
@@ -81,7 +81,7 @@ describe( 'The Regs3K analytics', () => {
   it( 'should handle navigation clicks on interp links', () => {
     let mockEvent = { target: {
       href: '/policy-compliance/rulemaking/regulations/1002/Interp-2/'
-    } };
+    }};
     mockEvent = analytics.handleNavClick( mockEvent );
 
     expect( mockEvent ).toEqual( {
@@ -96,14 +96,14 @@ describe( 'The Regs3K analytics', () => {
   it( 'should handle navigation clicks on non-regs links', () => {
     let mockEvent = { target: {
       href: 'https://example.com'
-    } };
+    }};
     mockEvent = analytics.handleNavClick( mockEvent );
 
     expect( mockEvent ).toBeUndefined();
   } );
 
   it( 'should handle navigation clicks on non-links', () => {
-    let mockEvent = { target: {} };
+    let mockEvent = { target: {}};
     mockEvent = analytics.handleNavClick( mockEvent );
 
     expect( mockEvent ).toBeUndefined();

--- a/test/unit_tests/apps/regulations3k/js/permalinks-utils-spec.js
+++ b/test/unit_tests/apps/regulations3k/js/permalinks-utils-spec.js
@@ -98,7 +98,7 @@ describe( 'The Regs3K permalinks utils', () => {
     it( 'should return the positions of all paragraphs', () => {
       const paragraphs = document.querySelectorAll( '.regdown-block' );
       expect( utils.getParagraphPositions( paragraphs ) ).toEqual(
-        [{'id': 'z-14-i', 'position': -30}, {'id': 'c', 'position': -30}, {'id': 'Interp-1', 'position': -30}]
+        [ { id: 'z-14-i', position: -30 }, { id: 'c', position: -30 }, { id: 'Interp-1', position: -30 } ]
       );
     } );
 
@@ -113,7 +113,7 @@ describe( 'The Regs3K permalinks utils', () => {
 
     it( 'should update and return the positions of all paragraphs', () => {
       expect( utils.updateParagraphPositions() ).toEqual(
-        [{'id': 'e', 'position': -30}, {'id': 'd', 'position': -30}, {'id': 'c', 'position': -30}, {'id': 'b', 'position': -30}, {'id': 'a', 'position': -30}]
+        [ { id: 'e', position: -30 }, { id: 'd', position: -30 }, { id: 'c', position: -30 }, { id: 'b', position: -30 }, { id: 'a', position: -30 } ]
       );
     } );
 
@@ -121,7 +121,7 @@ describe( 'The Regs3K permalinks utils', () => {
 
   describe( 'paragraph getter', () => {
 
-    const paragraphs = [{'id': 'three', 'position': 30}, {'id': 'two', 'position': 20}, {'id': 'one', 'position': 10}];
+    const paragraphs = [ { id: 'three', position: 30 }, { id: 'two', position: 20 }, { id: 'one', position: 10 } ];
 
     it( 'should get paragraph closest to viewport', () => {
       expect( utils.getCurrentParagraph( 'sandwich', paragraphs ) ).toEqual( null );


### PR DESCRIPTION
Moves mapbox into new template with minimal cleanup, so future cleanup is easier to review.

## Additions

- Adds mapbox map and dependencies to improved finding-a-housing-counselor template.

## Testing

1. `./frontend.sh` and http://localhost:8000/find-a-housing-counselor/?zipcode=05201 should show a map

## Screenshots

<img width="764" alt="screen shot 2018-11-15 at 1 30 40 pm" src="https://user-images.githubusercontent.com/704760/48573590-ac896480-e8da-11e8-8c86-c78d2b778a5c.png">
