### PR TITLE
Fix the Bureau Structure page after jinja upgrade broke it

### DIFF
--- a/cfgov/jinja2/v1/_includes/organisms/bureau-structure.html
+++ b/cfgov/jinja2/v1/_includes/organisms/bureau-structure.html
@@ -39,7 +39,7 @@
                 </button>
             </li>
             {% for org in category.data %}
-            {{ _node('li', org, category.sub_title) }}
+            {{ _node(org, 'li', category.sub_title) }}
             {% endfor %}
             {% if loop.last %}
             <li>
@@ -98,14 +98,14 @@
 
    Renders an org chart node when given:
 
-   tagName:   A string representing the encompassing element tag name.
-
    org:       A dictionary object representing an organization.
+
+   tagName:   A string representing the encompassing element tag name.
 
    sub_title: A string representing a sub title for an organization.
 
    ========================================================================== #}
-{% macro _node(tagName="div", org, sub_title="text") -%}
+{% macro _node(org, tagName="div", sub_title="text") -%}
 {% set has_children = org.offices | list | length %}
 
 <{{ tagName }} class="o-bureau-structure_node">


### PR DESCRIPTION
Bugfix: jinja 2.10 requires optional arguments come after required arguments. Some of the code that creates the org chart didn't follow that rule.

## Screenshots

![screen shot 2018-11-15 at 5 03 51 pm](https://user-images.githubusercontent.com/4295388/48584702-7c50be80-e8f8-11e8-862c-7b9c6b7db6fd.png)

## Testing 

- visit https://www.consumerfinance.gov/about-us/the-bureau/bureau-structure/. See that it's no longer a python error, and it looks correct.


## Todos

- Write a smoke test to cover this page (but we should get this fix out the door first)

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [x] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

Should not change any cf.gov functionality