### PR TITLE
Convert to ES6 import/export and upgrade babel and cfpb-chart-builder to latest.

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,7 +1,0 @@
-{
-  "presets": [
-    [
-      "babel-preset-env"
-    ]
-  ]
-}

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  "presets": [
+    [
+      "@babel/preset-env"
+    ]
+  ]
+}

--- a/cfgov/unprocessed/apps/analytics-gtm/browserslist
+++ b/cfgov/unprocessed/apps/analytics-gtm/browserslist
@@ -1,5 +1,5 @@
 # Browsers that Google Analytics Tag manager custom tags support.
-# This file (browserlist) is picked up by babel-preset-env (in webpack config).
+# This file (browserlist) is picked up by @babel/preset-env (in webpack config).
 # See https://github.com/browserslist/browserslist#config-file
 #
 # browserslist-stats.json

--- a/cfgov/unprocessed/apps/analytics-gtm/webpack-config.js
+++ b/cfgov/unprocessed/apps/analytics-gtm/webpack-config.js
@@ -36,7 +36,7 @@ const COMMON_MODULE_CONFIG = {
     use: {
       loader: 'babel-loader?cacheDirectory=true',
       options: {
-        presets: [ [ 'babel-preset-env', {
+        presets: [ [ '@babel/preset-env', {
           configPath: __dirname,
           /* Use useBuiltIns: 'usage' and set `debug: true` to see what
              scripts require polyfilling. */

--- a/cfgov/unprocessed/apps/financial-well-being/js/fwb-questions.js
+++ b/cfgov/unprocessed/apps/financial-well-being/js/fwb-questions.js
@@ -1,4 +1,4 @@
-const Analytics = require( '../../../js/modules/Analytics' );
+import Analytics from '../../../js/modules/Analytics';
 
 /**
  * Initialize the questionnaire

--- a/cfgov/unprocessed/apps/financial-well-being/js/fwb-results.js
+++ b/cfgov/unprocessed/apps/financial-well-being/js/fwb-results.js
@@ -1,7 +1,6 @@
-const Analytics = require( '../../../js/modules/Analytics' );
+import Analytics from '../../../js/modules/Analytics';
 
 require( 'cf-expandables/src/Expandable' ).init();
-
 
 /**
  * Initialize the results interactions
@@ -99,4 +98,4 @@ function init() {
   setUpUI();
 }
 
-module.exports = { init: init };
+export { init };

--- a/cfgov/unprocessed/apps/find-a-housing-counselor/webpack-config.js
+++ b/cfgov/unprocessed/apps/find-a-housing-counselor/webpack-config.js
@@ -36,7 +36,7 @@ const COMMON_MODULE_CONFIG = {
     use: {
       loader: 'babel-loader?cacheDirectory=true',
       options: {
-        presets: [ [ 'babel-preset-env', {
+        presets: [ [ '@babel/preset-env', {
           configPath: __dirname,
           /* Use useBuiltIns: 'usage' and set `debug: true` to see what
              scripts require polyfilling. */

--- a/cfgov/unprocessed/apps/owning-a-home/browserslist
+++ b/cfgov/unprocessed/apps/owning-a-home/browserslist
@@ -1,5 +1,5 @@
 # Browsers that Google Analytics Tag manager custom tags support.
-# This file (browserlist) is picked up by babel-preset-env (in webpack config).
+# This file (browserlist) is picked up by @babel/preset-env (in webpack config).
 # See https://github.com/browserslist/browserslist#config-file
 
 last 2 versions

--- a/cfgov/unprocessed/apps/owning-a-home/js/common.js
+++ b/cfgov/unprocessed/apps/owning-a-home/js/common.js
@@ -2,9 +2,9 @@
    Common application-wide scripts for owning-a-home.
    ========================================================================== */
 
-const FormSubmit = require( '../../../js/organisms/FormSubmit.js' );
-const validators = require( '../../../js/modules/util/validators' );
-const ratingsForm = require( './ratings-form' );
+import FormSubmit from '../../../js/organisms/FormSubmit.js';
+import * as validators from '../../../js/modules/util/validators';
+import * as ratingsForm from './ratings-form';
 
 const BASE_CLASS = 'o-email-signup';
 const emailSignup = document.body.querySelector( '.' + BASE_CLASS );

--- a/cfgov/unprocessed/apps/owning-a-home/js/dropdown-utils.js
+++ b/cfgov/unprocessed/apps/owning-a-home/js/dropdown-utils.js
@@ -1,4 +1,4 @@
-const $ = require( 'jquery' );
+import $ from 'jquery';
 
 /**
  * Some dropdown utility methods.
@@ -233,4 +233,4 @@ const utils = function( id ) {
 
 };
 
-module.exports = utils;
+export default utils;

--- a/cfgov/unprocessed/apps/owning-a-home/js/explore-rates/RateCheckerChart.js
+++ b/cfgov/unprocessed/apps/owning-a-home/js/explore-rates/RateCheckerChart.js
@@ -204,4 +204,4 @@ RateCheckerChart.STATUS_OKAY = 0;
 RateCheckerChart.STATUS_WARNING = 1;
 RateCheckerChart.STATUS_ERROR = 2;
 
-module.exports = RateCheckerChart;
+export default RateCheckerChart;

--- a/cfgov/unprocessed/apps/owning-a-home/js/explore-rates/Slider.js
+++ b/cfgov/unprocessed/apps/owning-a-home/js/explore-rates/Slider.js
@@ -135,4 +135,4 @@ function Slider( element ) {
 Slider.STATUS_OKAY = 0;
 Slider.STATUS_WARNING = 1;
 
-module.exports = Slider;
+export default Slider;

--- a/cfgov/unprocessed/apps/owning-a-home/js/explore-rates/data-loader.js
+++ b/cfgov/unprocessed/apps/owning-a-home/js/explore-rates/data-loader.js
@@ -64,7 +64,7 @@ function getCounties( forState ) {
   };
 }
 
-module.exports = {
+export {
   getLastCancelToken,
   getData,
   getCounties

--- a/cfgov/unprocessed/apps/owning-a-home/js/explore-rates/dom-values.js
+++ b/cfgov/unprocessed/apps/owning-a-home/js/explore-rates/dom-values.js
@@ -33,6 +33,6 @@ function getSelection( param ) {
   return val;
 }
 
-module.exports = {
-  getSelection: getSelection
+export {
+  getSelection
 };

--- a/cfgov/unprocessed/apps/owning-a-home/js/explore-rates/highcharts-theme.js
+++ b/cfgov/unprocessed/apps/owning-a-home/js/explore-rates/highcharts-theme.js
@@ -73,4 +73,4 @@ function applyThemeTo( highcharts ) {
   highcharts.setOptions( highcharts.theme );
 }
 
-module.exports = { applyThemeTo: applyThemeTo };
+export { applyThemeTo };

--- a/cfgov/unprocessed/apps/owning-a-home/js/explore-rates/params.js
+++ b/cfgov/unprocessed/apps/owning-a-home/js/explore-rates/params.js
@@ -72,7 +72,7 @@ function update() {
   }
 }
 
-module.exports = {
+export {
   getAllParams,
   getVal,
   setVal,

--- a/cfgov/unprocessed/apps/owning-a-home/js/explore-rates/rate-checker.js
+++ b/cfgov/unprocessed/apps/owning-a-home/js/explore-rates/rate-checker.js
@@ -25,7 +25,7 @@ import jumbo from 'jumbo-mortgage';
 import median from 'median';
 import RateCheckerChart from './RateCheckerChart';
 import Slider from './Slider';
-import tab from './tab';
+import * as tab from './tab';
 import unFormatUSD from 'unformat-usd';
 
 // TODO: remove jquery.
@@ -925,4 +925,4 @@ function registerEvents() {
   rateSelectsDom.addEventListener( 'change', renderInterestAmounts );
 }
 
-module.exports = { init };
+export { init };

--- a/cfgov/unprocessed/apps/owning-a-home/js/explore-rates/tab.js
+++ b/cfgov/unprocessed/apps/owning-a-home/js/explore-rates/tab.js
@@ -58,4 +58,4 @@ function _bindTabLink( tabGroup, tabContents ) {
   }
 }
 
-module.exports = { init };
+export { init };

--- a/cfgov/unprocessed/apps/owning-a-home/js/explore-rates/template-loader.js
+++ b/cfgov/unprocessed/apps/owning-a-home/js/explore-rates/template-loader.js
@@ -7,7 +7,7 @@ const countyGenWarning = require( '../../templates/county-general-warning.hbs' )
 const chartTooltipSingle = require( '../../templates/chart-tooltip-single.hbs' );
 const chartTooltipMultiple = require( '../../templates/chart-tooltip-multiple.hbs' );
 
-module.exports = {
+export {
   county,
   countyConfWarning,
   countyFHAWarning,

--- a/cfgov/unprocessed/apps/owning-a-home/js/explore-rates/util.js
+++ b/cfgov/unprocessed/apps/owning-a-home/js/explore-rates/util.js
@@ -182,7 +182,7 @@ function setSelection( el, val ) {
   }
 }
 
-module.exports = {
+export {
   calcLoanAmount,
   checkIfZero,
   delay,

--- a/cfgov/unprocessed/apps/owning-a-home/js/ratings-form.js
+++ b/cfgov/unprocessed/apps/owning-a-home/js/ratings-form.js
@@ -33,4 +33,4 @@ function init() {
   }
 }
 
-module.exports = { init: init };
+export { init };

--- a/cfgov/unprocessed/apps/owning-a-home/webpack-config.js
+++ b/cfgov/unprocessed/apps/owning-a-home/webpack-config.js
@@ -2,7 +2,6 @@
    Settings for webpack JavaScript bundling system.
    ========================================================================== */
 
-
 const BROWSER_LIST = require( '../../../../config/browser-list-config' );
 const webpack = require( 'webpack' );
 const UglifyWebpackPlugin = require( 'uglifyjs-webpack-plugin' );
@@ -41,7 +40,7 @@ const COMMON_MODULE_CONFIG = {
     use: {
       loader: 'babel-loader?cacheDirectory=true',
       options: {
-        presets: [ [ 'babel-preset-env', {
+        presets: [ [ '@babel/preset-env', {
           configPath: __dirname,
           /* Use useBuiltIns: 'usage' and set `debug: true` to see what
              scripts require polyfilling. */
@@ -93,6 +92,5 @@ const conf = {
   ],
   stats: STATS_CONFIG.stats
 };
-
 
 module.exports = { conf };

--- a/cfgov/unprocessed/apps/regulations3k/browserslist
+++ b/cfgov/unprocessed/apps/regulations3k/browserslist
@@ -1,5 +1,5 @@
 # Browsers that Google Analytics Tag manager custom tags support.
-# This file (browserlist) is picked up by babel-preset-env (in webpack config).
+# This file (browserlist) is picked up by @babel/preset-env (in webpack config).
 # See https://github.com/browserslist/browserslist#config-file
 
 last 2 versions

--- a/cfgov/unprocessed/apps/regulations3k/js/analytics.js
+++ b/cfgov/unprocessed/apps/regulations3k/js/analytics.js
@@ -85,7 +85,7 @@ const handleContentClick = event => {
   return sendEvent( action, section );
 };
 
-module.exports = {
+export {
   getExpandable,
   getExpandableState,
   handleContentClick,

--- a/cfgov/unprocessed/apps/regulations3k/js/index.js
+++ b/cfgov/unprocessed/apps/regulations3k/js/index.js
@@ -2,7 +2,7 @@ import Expandable from 'cf-expandables/src/Expandable';
 import { bindEvent } from '../../../js/modules/util/dom-events';
 import { queryOne as find } from '../../../js/modules/util/dom-traverse';
 import { handleContentClick, handleNavClick } from './analytics';
-import utils from './regs3k-utils';
+import * as utils from './regs3k-utils';
 
 const navHeader = find( '.o-regs3k-navigation_header' );
 const navItems = find( '.o-regs3k-sections' );

--- a/cfgov/unprocessed/apps/regulations3k/js/recent-notices.js
+++ b/cfgov/unprocessed/apps/regulations3k/js/recent-notices.js
@@ -43,7 +43,7 @@ const init = () => {
 
 window.addEventListener( 'load', init );
 
-module.exports = {
+export {
   processNotice,
   processNotices
 };

--- a/cfgov/unprocessed/apps/regulations3k/js/regs3k-utils.js
+++ b/cfgov/unprocessed/apps/regulations3k/js/regs3k-utils.js
@@ -40,7 +40,7 @@ const getNewHash = hash => {
  */
 const isOldHash = hash => ( /^#?\d\d\d\d/ ).test( hash );
 
-module.exports = {
+export {
   fetch,
   getNewHash,
   isOldHash

--- a/cfgov/unprocessed/apps/regulations3k/webpack-config.js
+++ b/cfgov/unprocessed/apps/regulations3k/webpack-config.js
@@ -44,7 +44,7 @@ const COMMON_MODULE_CONFIG = {
     use: {
       loader: 'babel-loader?cacheDirectory=true',
       options: {
-        presets: [ [ 'babel-preset-env', {
+        presets: [ [ '@babel/preset-env', {
           configPath: __dirname,
           /* Use useBuiltIns: 'usage' and set `debug: true` to see what
              scripts require polyfilling. */

--- a/cfgov/unprocessed/js/config/breakpoints-config.js
+++ b/cfgov/unprocessed/js/config/breakpoints-config.js
@@ -1,7 +1,7 @@
 /* TODO: Read these values directly from cf-vars.less.
    All values are pixel based. */
 
-module.exports = {
+const breakPointsConfig = {
   bpXS: {
     min: 0,
     max: 600
@@ -22,3 +22,5 @@ module.exports = {
     min: 1201
   }
 };
+
+export default breakPointsConfig;

--- a/cfgov/unprocessed/js/config/error-messages-config.js
+++ b/cfgov/unprocessed/js/config/error-messages-config.js
@@ -3,7 +3,6 @@
    These messages are manually mirrored on the Python side in config.py
    ========================================================================== */
 
-
 const ERROR_MESSAGES = {
   CHECKBOX: {
     REQUIRED: 'Please select at least %s of the options.'
@@ -47,4 +46,4 @@ const ERROR_MESSAGES = {
   }
 };
 
-module.exports = Object.freeze( ERROR_MESSAGES );
+export default Object.freeze( ERROR_MESSAGES );

--- a/cfgov/unprocessed/js/modules/Analytics.js
+++ b/cfgov/unprocessed/js/modules/Analytics.js
@@ -1,5 +1,5 @@
-const isArray = require( './util/type-checkers' ).isArray;
-const EventObserver = require( '../modules/util/EventObserver' );
+import { isArray } from './util/type-checkers';
+import EventObserver from '../modules/util/EventObserver';
 
 const eventObserver = new EventObserver();
 const Analytics = {
@@ -95,4 +95,4 @@ const Analytics = {
 
 Analytics.init();
 
-module.exports = Analytics;
+export default Analytics;

--- a/cfgov/unprocessed/js/modules/BreakpointHandler.js
+++ b/cfgov/unprocessed/js/modules/BreakpointHandler.js
@@ -93,4 +93,4 @@ BreakpointHandler.prototype.watchWindowResize = watchWindowResize;
 BreakpointHandler.prototype.handleViewportChange = handleViewportChange;
 BreakpointHandler.prototype.testBreakpoint = testBreakpoint;
 
-module.exports = BreakpointHandler;
+export default BreakpointHandler;

--- a/cfgov/unprocessed/js/modules/ClearableInput.js
+++ b/cfgov/unprocessed/js/modules/ClearableInput.js
@@ -1,5 +1,5 @@
 // Required modules.
-const atomicHelpers = require( '../modules/util/atomic-helpers' );
+import { checkDom } from '../modules/util/atomic-helpers';
 
 /**
  * ClearableInput
@@ -14,7 +14,7 @@ const atomicHelpers = require( '../modules/util/atomic-helpers' );
 function ClearableInput( element ) {
   const BASE_CLASS = 'input-contains-label';
 
-  const _dom = atomicHelpers.checkDom( element, BASE_CLASS );
+  const _dom = checkDom( element, BASE_CLASS );
   const _inputDom = _dom.querySelector( 'input' );
   const _clearBtnDom = _dom.querySelector( '.' + BASE_CLASS + '_after__clear' );
 
@@ -87,4 +87,4 @@ function ClearableInput( element ) {
   return this;
 }
 
-module.exports = ClearableInput;
+export default ClearableInput;

--- a/cfgov/unprocessed/js/modules/ExternalSite.js
+++ b/cfgov/unprocessed/js/modules/ExternalSite.js
@@ -3,8 +3,7 @@
    Used on at least `/external-site/`.
    ========================================================================== */
 
-
-const atomicHelpers = require( '../modules/util/atomic-helpers' );
+import { checkDom } from '../modules/util/atomic-helpers';
 
 /**
  * ExternalSite
@@ -19,7 +18,7 @@ function ExternalSite( element ) {
   const TOTAL_DURATION = 5;
   const INTERVAL = 1000;
 
-  const _dom = atomicHelpers.checkDom( element, BASE_CLASS );
+  const _dom = checkDom( element, BASE_CLASS );
   const _durationEl = _dom.querySelector( '.external-site_reload-container' );
   const _directEl = _dom.querySelector( '.external-site_proceed-btn' );
   let _duration = TOTAL_DURATION;
@@ -77,4 +76,4 @@ function ExternalSite( element ) {
 }
 
 // Expose public methods.
-module.exports = ExternalSite;
+export default ExternalSite;

--- a/cfgov/unprocessed/js/modules/TabTrigger.js
+++ b/cfgov/unprocessed/js/modules/TabTrigger.js
@@ -1,5 +1,5 @@
 // Required modules.
-const EventObserver = require( '../modules/util/EventObserver' );
+import EventObserver from '../modules/util/EventObserver';
 
 // Key code for the tab key on the keyboard.
 const KEY_TAB = 9;
@@ -71,4 +71,4 @@ function TabTrigger( element ) {
   return this;
 }
 
-module.exports = TabTrigger;
+export default TabTrigger;

--- a/cfgov/unprocessed/js/modules/Tree.js
+++ b/cfgov/unprocessed/js/modules/Tree.js
@@ -117,4 +117,4 @@ function TreeNode( tree, data, parent, children ) {
   return this;
 }
 
-module.exports = Tree;
+export default Tree;

--- a/cfgov/unprocessed/js/modules/VideoPlayer.js
+++ b/cfgov/unprocessed/js/modules/VideoPlayer.js
@@ -2,10 +2,9 @@
    Base Video Player Class
    ========================================================================== */
 
-
-const _assign = require( './util/assign' ).assign;
-const _noopFunct = require( './util/standard-type' ).noopFunct;
-const _jsLoader = require( './util/js-loader' );
+import { assign } from './util/assign';
+import { noopFunct } from './util/standard-type';
+import * as jsLoader from './util/js-loader';
 
 // TODO: Remove data-set ponyfill when IE10 support is dropped in this.
 import elemDataset from 'elem-dataset';
@@ -42,8 +41,8 @@ function VideoPlayer( element, options ) {
   _this = this;
   options = options || {};
   this.baseElement = _ensureElement( element, options.createIFrame );
-  const dataSet = _assign( {}, elemDataset( this.baseElement ) );
-  this.iFrameProperties = _assign( dataSet, this.iFrameProperties );
+  const dataSet = assign( {}, elemDataset( this.baseElement ) );
+  this.iFrameProperties = assign( dataSet, this.iFrameProperties );
 
   _setChildElements( this.childElements );
   _initEvents();
@@ -68,7 +67,7 @@ VideoPlayer.extend = function extend( attributes ) {
     return VideoPlayer.apply( this, arguments );
   }
   child.prototype = Object.create( VideoPlayer.prototype );
-  _assign( child.prototype, attributes );
+  assign( child.prototype, attributes );
   child.init = VideoPlayer.init;
 
   return child;
@@ -240,10 +239,10 @@ const API = {
      */
     function onScriptLoad() { _this.state.isScriptLoading = false; }
     this.state.isScriptLoading = true;
-    _jsLoader.loadScript( script || this.SCRIPT_API, callback || onScriptLoad );
+    jsLoader.loadScript( script || this.SCRIPT_API, callback || onScriptLoad );
   },
 
-  init: _noopFunct,
+  init: noopFunct,
 
   iFrameProperties: {
     allowfullscreen: 'true',
@@ -296,7 +295,7 @@ const API = {
   }
 };
 
-_assign( VideoPlayer.prototype, API );
+assign( VideoPlayer.prototype, API );
 
 // Expose public methods.
-module.exports = VideoPlayer;
+export default VideoPlayer;

--- a/cfgov/unprocessed/js/modules/VideoPlayer.js
+++ b/cfgov/unprocessed/js/modules/VideoPlayer.js
@@ -6,10 +6,12 @@ import { assign } from './util/assign';
 import { noopFunct } from './util/standard-type';
 import * as jsLoader from './util/js-loader';
 
-// TODO: Remove data-set ponyfill when IE10 support is dropped in this.
+// TODO: Remove data-set ponyfill when IE10 support is dropped.
 import elemDataset from 'elem-dataset';
 
-const DOM_INVALID = require( '../config/error-messages-config' ).DOM.INVALID;
+import ERROR_MESSAGES from '../config/error-messages-config';
+
+const DOM_INVALID = ERROR_MESSAGES.DOM.INVALID;
 
 const CLASSES = Object.freeze( {
   VIDEO_PLAYER_SELECTOR:     '.video-player',

--- a/cfgov/unprocessed/js/modules/YoutubePlayer.js
+++ b/cfgov/unprocessed/js/modules/YoutubePlayer.js
@@ -4,7 +4,7 @@
    ========================================================================== */
 
 import { noopFunct } from './util/standard-type';
-import * as VideoPlayer from './VideoPlayer';
+import VideoPlayer from './VideoPlayer';
 let YoutubePlayer;
 
 const CLASSES = Object.freeze( {

--- a/cfgov/unprocessed/js/modules/YoutubePlayer.js
+++ b/cfgov/unprocessed/js/modules/YoutubePlayer.js
@@ -3,9 +3,8 @@
    Extends Video Player Class.
    ========================================================================== */
 
-
-const _noopFunct = require( './util/standard-type' ).noopFunct;
-const VideoPlayer = require( './VideoPlayer' );
+import { noopFunct } from './util/standard-type';
+import * as VideoPlayer from './VideoPlayer';
 let YoutubePlayer;
 
 const CLASSES = Object.freeze( {
@@ -37,8 +36,8 @@ const API = {
       suggestedQuality: 'highres'
     },
     events: {
-      onReady: _noopFunct,
-      onStateChange: _noopFunct
+      onReady: noopFunct,
+      onStateChange: noopFunct
     }
   },
 
@@ -173,4 +172,4 @@ const API = {
 YoutubePlayer = VideoPlayer.extend( API );
 
 // Expose public methods.
-module.exports = YoutubePlayer;
+export default YoutubePlayer;

--- a/cfgov/unprocessed/js/modules/behavior/FlyoutMenu.js
+++ b/cfgov/unprocessed/js/modules/behavior/FlyoutMenu.js
@@ -1,9 +1,14 @@
 // Required modules.
-const BaseTransition = require( '../../modules/transition/BaseTransition' );
-const behavior = require( '../../modules/util/behavior' );
-const breakpointState = require( '../../modules/util/breakpoint-state' );
-const EventObserver = require( '../../modules/util/EventObserver' );
-const standardType = require( '../../modules/util/standard-type' );
+import BaseTransition from '../../modules/transition/BaseTransition';
+import { checkBehaviorDom } from '../../modules/util/behavior';
+import * as breakpointState from '../../modules/util/breakpoint-state';
+import EventObserver from '../../modules/util/EventObserver';
+import {
+  BEHAVIOR_PREFIX,
+  JS_HOOK,
+  noopFunct,
+  UNDEFINED
+} from '../../modules/util/standard-type';
 
 /**
  * FlyoutMenu
@@ -30,16 +35,14 @@ const standardType = require( '../../modules/util/standard-type' );
  */
 function FlyoutMenu( element ) { // eslint-disable-line max-statements, no-inline-comments, max-len
 
-  const BASE_CLASS = standardType.BEHAVIOR_PREFIX + 'flyout-menu';
-  const SEL_PREFIX = '[' + standardType.JS_HOOK + '=' + BASE_CLASS;
+  const BASE_CLASS = BEHAVIOR_PREFIX + 'flyout-menu';
+  const SEL_PREFIX = '[' + JS_HOOK + '=' + BASE_CLASS;
   const BASE_SEL = SEL_PREFIX + ']';
 
   // Verify that the expected dom attributes are present.
-  const _dom = behavior.checkBehaviorDom( element, BASE_CLASS );
-  const _triggerDom =
-    behavior.checkBehaviorDom( element, BASE_CLASS + '_trigger' );
-  const _contentDom =
-    behavior.checkBehaviorDom( element, BASE_CLASS + '_content' );
+  const _dom = checkBehaviorDom( element, BASE_CLASS );
+  const _triggerDom = checkBehaviorDom( element, BASE_CLASS + '_trigger' );
+  const _contentDom = checkBehaviorDom( element, BASE_CLASS + '_content' );
 
   let _altTriggerDom = _dom.querySelector( SEL_PREFIX + '_alt-trigger]' );
 
@@ -69,7 +72,7 @@ function FlyoutMenu( element ) { // eslint-disable-line max-statements, no-inlin
   /* Set this function to a queued collapse function,
      which is called if collapse is called while
      expand is animating. */
-  let _deferFunct = standardType.noopFunct;
+  let _deferFunct = noopFunct;
 
   // Whether this instance's behaviors are suspended or not.
   let _suspended = true;
@@ -224,7 +227,7 @@ function FlyoutMenu( element ) { // eslint-disable-line max-statements, no-inlin
   function expand() {
     if ( !_isExpanded && !_isAnimating ) {
       _isAnimating = true;
-      _deferFunct = standardType.noopFunct;
+      _deferFunct = noopFunct;
       this.dispatchEvent(
         'expandBegin',
         { target: this, type: 'expandBegin' }
@@ -263,7 +266,7 @@ function FlyoutMenu( element ) { // eslint-disable-line max-statements, no-inlin
    */
   function collapse() {
     if ( _isExpanded && !_isAnimating ) {
-      _deferFunct = standardType.noopFunct;
+      _deferFunct = noopFunct;
       _isAnimating = true;
       _isExpanded = false;
       this.dispatchEvent(
@@ -381,12 +384,12 @@ function FlyoutMenu( element ) { // eslint-disable-line max-statements, no-inlin
     transition = getTransition( FlyoutMenu.COLLAPSE_TYPE );
     if ( transition ) { transition.remove(); }
 
-    _expandTransition = standardType.UNDEFINED;
-    _expandTransitionMethod = standardType.UNDEFINED;
+    _expandTransition = UNDEFINED;
+    _expandTransitionMethod = UNDEFINED;
     _expandTransitionMethodArgs = [];
 
-    _collapseTransition = standardType.UNDEFINED;
-    _collapseTransitionMethod = standardType.UNDEFINED;
+    _collapseTransition = UNDEFINED;
+    _collapseTransitionMethod = UNDEFINED;
     _collapseTransitionMethodArgs = [];
   }
 
@@ -510,4 +513,4 @@ function FlyoutMenu( element ) { // eslint-disable-line max-statements, no-inlin
   return this;
 }
 
-module.exports = FlyoutMenu;
+export default FlyoutMenu;

--- a/cfgov/unprocessed/js/modules/behavior/FlyoutMenu.js
+++ b/cfgov/unprocessed/js/modules/behavior/FlyoutMenu.js
@@ -6,8 +6,8 @@ import EventObserver from '../../modules/util/EventObserver';
 import {
   BEHAVIOR_PREFIX,
   JS_HOOK,
-  noopFunct,
-  UNDEFINED
+  UNDEFINED,
+  noopFunct
 } from '../../modules/util/standard-type';
 
 /**

--- a/cfgov/unprocessed/js/modules/footer-button.js
+++ b/cfgov/unprocessed/js/modules/footer-button.js
@@ -54,4 +54,4 @@ function _scrollToTop() {
   }
 }
 
-module.exports = { init };
+export { init };

--- a/cfgov/unprocessed/js/modules/o-table-row-links.js
+++ b/cfgov/unprocessed/js/modules/o-table-row-links.js
@@ -28,4 +28,4 @@ function _tableClicked( event ) {
   window.location.assign( target.querySelector( 'a' ).getAttribute( 'href' ) );
 }
 
-module.exports = { init: init };
+export { init };

--- a/cfgov/unprocessed/js/modules/transition/AlphaTransition.js
+++ b/cfgov/unprocessed/js/modules/transition/AlphaTransition.js
@@ -1,6 +1,6 @@
 // Required modules.
-const EventObserver = require( '../../modules/util/EventObserver' );
-const BaseTransition = require( './BaseTransition' );
+import EventObserver from '../../modules/util/EventObserver';
+import BaseTransition from './BaseTransition';
 
 // Exported constants.
 const CLASSES = {
@@ -84,4 +84,4 @@ function AlphaTransition( element ) {
 // Public static properties.
 AlphaTransition.CLASSES = CLASSES;
 
-module.exports = AlphaTransition;
+export default AlphaTransition;

--- a/cfgov/unprocessed/js/modules/transition/BaseTransition.js
+++ b/cfgov/unprocessed/js/modules/transition/BaseTransition.js
@@ -1,5 +1,5 @@
 // Required modules.
-const EventObserver = require( '../../modules/util/EventObserver' );
+import EventObserver from '../../modules/util/EventObserver';
 
 // eslint-disable-next-line max-statements
 /**
@@ -253,4 +253,4 @@ BaseTransition.END_EVENT = 'transitionEnd';
 BaseTransition.NO_ANIMATION_CLASS = 'u-no-animation';
 BaseTransition.ANIMATING_CLASS = 'u-is-animating';
 
-module.exports = BaseTransition;
+export default BaseTransition;

--- a/cfgov/unprocessed/js/modules/transition/MoveTransition.js
+++ b/cfgov/unprocessed/js/modules/transition/MoveTransition.js
@@ -1,6 +1,6 @@
 // Required modules.
-const EventObserver = require( '../../modules/util/EventObserver' );
-const BaseTransition = require( './BaseTransition' );
+import EventObserver from '../../modules/util/EventObserver';
+import BaseTransition from './BaseTransition';
 
 // Exported constants.
 const CLASSES = {
@@ -125,4 +125,4 @@ function MoveTransition( element ) {
 // Public static properties.
 MoveTransition.CLASSES = CLASSES;
 
-module.exports = MoveTransition;
+export default MoveTransition;

--- a/cfgov/unprocessed/js/modules/util/EventObserver.js
+++ b/cfgov/unprocessed/js/modules/util/EventObserver.js
@@ -75,4 +75,4 @@ function EventObserver() {
   return this;
 }
 
-module.exports = EventObserver;
+export default EventObserver;

--- a/cfgov/unprocessed/js/modules/util/add-email-popup.js
+++ b/cfgov/unprocessed/js/modules/util/add-email-popup.js
@@ -1,5 +1,6 @@
-const EmailPopup = require( '../../organisms/EmailPopup' );
-const emailHelpers = require( './email-popup-helpers' );
+import EmailPopup from '../../organisms/EmailPopup';
+import * as emailHelpers from './email-popup-helpers';
+
 const emailPopup = document.querySelector( '.' + EmailPopup.BASE_CLASS );
 
 if ( emailPopup && emailHelpers.showEmailPopup() ) {

--- a/cfgov/unprocessed/js/modules/util/ajax-request.js
+++ b/cfgov/unprocessed/js/modules/util/ajax-request.js
@@ -43,6 +43,6 @@ function ajaxRequest( type, url, opts ) {
   return xhr;
 }
 
-module.exports = {
-  ajaxRequest: ajaxRequest
+export {
+  ajaxRequest
 };

--- a/cfgov/unprocessed/js/modules/util/array-helpers.js
+++ b/cfgov/unprocessed/js/modules/util/array-helpers.js
@@ -3,7 +3,6 @@
    Utilities for checking arrays.
    ========================================================================== */
 
-
 /**
  * Searches an array for the first object with the matching key:value pair.
  * @param   {Array}  array - List to query through for the expected value.
@@ -37,7 +36,7 @@ function uniquePrimitives( array ) {
   return array.filter( ( val, i, self ) => self.indexOf( val ) === i );
 }
 
-module.exports = {
+export {
   indexOfObject,
   uniquePrimitives
 };

--- a/cfgov/unprocessed/js/modules/util/assign.js
+++ b/cfgov/unprocessed/js/modules/util/assign.js
@@ -42,4 +42,4 @@ function assign( destination ) {
 }
 
 // Expose public methods.
-module.exports = { assign: assign };
+export { assign };

--- a/cfgov/unprocessed/js/modules/util/atomic-helpers.js
+++ b/cfgov/unprocessed/js/modules/util/atomic-helpers.js
@@ -9,9 +9,8 @@
    - Atom
    ========================================================================= */
 
-
-const dataHook = require( './data-hook' );
-const standardType = require( './standard-type' );
+import * as dataHook from './data-hook';
+import { STATE_PREFIX } from './standard-type';
 
 /**
  * @constant
@@ -22,7 +21,7 @@ const standardType = require( './standard-type' );
  * component won't get initialized a second time after it
  * has already been initialized.
  */
-const INIT_FLAG = standardType.STATE_PREFIX + 'atomic_init';
+const INIT_FLAG = STATE_PREFIX + 'atomic_init';
 
 /**
  * Check that a particular element passed into the constructor of
@@ -131,7 +130,7 @@ function instantiateAll( selector, Constructor ) {
 }
 
 // Expose public methods.
-module.exports = {
+export {
   checkDom,
   destroyInitFlag,
   instantiateAll,

--- a/cfgov/unprocessed/js/modules/util/behavior.js
+++ b/cfgov/unprocessed/js/modules/util/behavior.js
@@ -22,8 +22,8 @@
 
 
 // Required modules.
-const standardType = require( './standard-type' );
-const dataHook = require( '../../modules/util/data-hook' );
+import { BEHAVIOR_PREFIX, JS_HOOK } from './standard-type';
+import * as dataHook from '../../modules/util/data-hook';
 
 
 /**
@@ -45,7 +45,7 @@ function _findElements( behaviorSelector, baseElement ) {
   }
 
   if ( behaviorElements.length === 0 &&
-       behaviorSelector.indexOf( standardType.BEHAVIOR_PREFIX ) === -1 ) {
+       behaviorSelector.indexOf( BEHAVIOR_PREFIX ) === -1 ) {
     behaviorElements = find( behaviorSelector, baseElement );
   }
 
@@ -101,7 +101,7 @@ function checkBehaviorDom( element, behaviorDataAttr ) {
   /* If the passed DOM node isn't null,
      query the node to see if it's in the children. */
   if ( element ) {
-    const selector = '[' + standardType.JS_HOOK + '=' + behaviorDataAttr + ']';
+    const selector = '[' + JS_HOOK + '=' + behaviorDataAttr + ']';
     dom = element.querySelector( selector );
   }
 
@@ -120,8 +120,7 @@ function checkBehaviorDom( element, behaviorDataAttr ) {
  * @returns {HTMLNodeList} if it exists in the dom, null otherwise.
  */
 function find( behaviorSelector, baseElement ) {
-  behaviorSelector =
-  standardType.JS_HOOK + '*=' + standardType.BEHAVIOR_PREFIX + behaviorSelector;
+  behaviorSelector = JS_HOOK + '*=' + BEHAVIOR_PREFIX + behaviorSelector;
   behaviorSelector = '[' + behaviorSelector + ']';
 
   return _findElements( behaviorSelector, baseElement );
@@ -137,9 +136,9 @@ function remove( behaviorElement, event, eventHandler ) {
 }
 
 // Expose public methods.
-module.exports = {
-  attach: attach,
-  checkBehaviorDom: checkBehaviorDom,
-  find: find,
-  remove: remove
+export {
+  attach,
+  checkBehaviorDom,
+  find,
+  remove
 };

--- a/cfgov/unprocessed/js/modules/util/breakpoint-state.js
+++ b/cfgov/unprocessed/js/modules/util/breakpoint-state.js
@@ -2,9 +2,8 @@
    Get Breakpoint State
    ========================================================================== */
 
-const _breakpointsConfig = require( '../../config/breakpoints-config' );
-const _getViewportDimensions = require( './get-viewport-dimensions' )
-  .getViewportDimensions;
+import breakpointsConfig from '../../config/breakpoints-config';
+import { getViewportDimensions } from './get-viewport-dimensions';
 
 /**
  * @param {Object} breakpointRange - Object containing breakpoint constants.
@@ -26,14 +25,14 @@ function _inBreakpointRange( breakpointRange, width ) {
 function get( width ) {
   const breakpointState = {};
   let breakpointKey;
-  width = width || _getViewportDimensions().width;
+  width = width || getViewportDimensions().width;
 
   // eslint-disable-next-line guard-for-in
-  for ( const rangeKey in _breakpointsConfig ) {
+  for ( const rangeKey in breakpointsConfig ) {
     breakpointKey = 'is' + rangeKey.charAt( 0 ).toUpperCase() +
                     rangeKey.slice( 1 );
     breakpointState[breakpointKey] =
-      _inBreakpointRange( _breakpointsConfig[rangeKey], width );
+      _inBreakpointRange( breakpointsConfig[rangeKey], width );
   }
 
   return breakpointState;
@@ -55,7 +54,7 @@ function isInDesktop() {
 }
 
 // Expose public methods.
-module.exports = {
-  get: get,
-  isInDesktop: isInDesktop
+export {
+  get,
+  isInDesktop
 };

--- a/cfgov/unprocessed/js/modules/util/data-hook.js
+++ b/cfgov/unprocessed/js/modules/util/data-hook.js
@@ -1,5 +1,5 @@
 // Required modules.
-const standardType = require( './standard-type' );
+import { JS_HOOK } from './standard-type';
 
 /**
  * @param {HTMLNode} element - DOM element.
@@ -11,15 +11,15 @@ const standardType = require( './standard-type' );
  */
 function add( element, value ) {
   if ( value.indexOf( ' ' ) !== -1 ) {
-    const msg = standardType.JS_HOOK + ' values cannot contain spaces!';
+    const msg = JS_HOOK + ' values cannot contain spaces!';
     throw new Error( msg );
   }
 
-  const values = element.getAttribute( standardType.JS_HOOK );
+  const values = element.getAttribute( JS_HOOK );
   if ( values !== null ) {
     value = values + ' ' + value;
   }
-  element.setAttribute( standardType.JS_HOOK, value );
+  element.setAttribute( JS_HOOK, value );
 
   return value;
 }
@@ -31,12 +31,12 @@ function add( element, value ) {
  * @returns {boolean} True if value was removed, false otherwise.
  */
 function remove( element, value ) {
-  const values = element.getAttribute( standardType.JS_HOOK );
+  const values = element.getAttribute( JS_HOOK );
   const index = values.indexOf( value );
   const valuesList = values.split( ' ' );
   if ( index > -1 ) {
     valuesList.splice( index, 1 );
-    element.setAttribute( standardType.JS_HOOK, valuesList.join( ' ' ) );
+    element.setAttribute( JS_HOOK, valuesList.join( ' ' ) );
     return true;
   }
 
@@ -51,7 +51,7 @@ function remove( element, value ) {
  */
 function contains( element, value ) {
   if ( !element ) { return false; }
-  let values = element.getAttribute( standardType.JS_HOOK );
+  let values = element.getAttribute( JS_HOOK );
   // If JS data-* hook is not set return immediately.
   if ( !values ) { return false; }
   values = values.split( ' ' );
@@ -59,8 +59,8 @@ function contains( element, value ) {
   return values.indexOf( value ) > -1 ? true : false;
 }
 
-module.exports = {
-  add:      add,
-  contains: contains,
-  remove:   remove
+export {
+  add,
+  contains,
+  remove
 };

--- a/cfgov/unprocessed/js/modules/util/dom-events.js
+++ b/cfgov/unprocessed/js/modules/util/dom-events.js
@@ -14,6 +14,6 @@ function bindEvent( elem, events ) {
   }
 }
 
-module.exports = {
-  bindEvent: bindEvent
+export {
+  bindEvent
 };

--- a/cfgov/unprocessed/js/modules/util/dom-manipulators.js
+++ b/cfgov/unprocessed/js/modules/util/dom-manipulators.js
@@ -1,4 +1,4 @@
-const queryOne = require( './dom-traverse' ).queryOne;
+import { queryOne } from './dom-traverse';
 
 /**
  * Shortcut for creating new dom elements
@@ -32,6 +32,6 @@ function create( tag, options ) {
   return elem;
 }
 
-module.exports = {
-  create: create
+export {
+  create
 };

--- a/cfgov/unprocessed/js/modules/util/dom-traverse.js
+++ b/cfgov/unprocessed/js/modules/util/dom-traverse.js
@@ -1,4 +1,4 @@
-const typeCheckers = require( './type-checkers' );
+import * as typeCheckers from './type-checkers';
 
 /**
  * Queries for the first match unless an HTMLNode is passed
@@ -100,9 +100,9 @@ function _getMatchesMethod( elem ) {
          elem.msMatchesSelector;
 }
 
-module.exports = {
-  queryOne:    queryOne,
-  closest:     closest,
-  getSiblings: getSiblings,
-  not:         not
+export {
+  queryOne,
+  closest,
+  getSiblings,
+  not
 };

--- a/cfgov/unprocessed/js/modules/util/email-popup-helpers.js
+++ b/cfgov/unprocessed/js/modules/util/email-popup-helpers.js
@@ -1,5 +1,5 @@
-const _assign = require( './assign' ).assign;
-const throttle = require( 'lodash.throttle' );
+import { assign } from './assign';
+import throttle from 'lodash.throttle';
 
 /**
  * Stores/retrieves email signup data in localStorage
@@ -108,7 +108,7 @@ function showOnScroll( elToShow, opts ) {
     }
   };
 
-  opts = _assign( defaults, opts || {} );
+  opts = assign( defaults, opts || {} );
 
   function _getScrollTargetPosition() {
     const elHeight = elToShow.offsetHeight;
@@ -141,7 +141,7 @@ function showOnScroll( elToShow, opts ) {
   window.addEventListener( 'scroll', handler );
 }
 
-module.exports = {
+export {
   showEmailPopup,
   recordEmailPopupView,
   recordEmailRegistration,

--- a/cfgov/unprocessed/js/modules/util/expanded-state.js
+++ b/cfgov/unprocessed/js/modules/util/expanded-state.js
@@ -2,7 +2,6 @@
    Expanded State Utils
    ========================================================================== */
 
-
 let navTimeOut;
 
 /**
@@ -68,8 +67,8 @@ function toggleExpandedState( elems, state, cb, delay ) {
   }
 }
 
-module.exports = {
-  isThisExpanded: isThisExpanded,
-  isOneExpanded:  isOneExpanded,
-  toggleExpandedState: toggleExpandedState
+export {
+  isThisExpanded,
+  isOneExpanded,
+  toggleExpandedState
 };

--- a/cfgov/unprocessed/js/modules/util/get-viewport-dimensions.js
+++ b/cfgov/unprocessed/js/modules/util/get-viewport-dimensions.js
@@ -2,7 +2,6 @@
    Get Viewport Dimensions
    ========================================================================== */
 
-
 /**
  * @returns {object} An object literal with the viewport
  *   width and height as properties.
@@ -26,6 +25,6 @@ function getViewportDimensions() {
 }
 
 // Expose public methods.
-module.exports = {
-  getViewportDimensions: getViewportDimensions
+export {
+  getViewportDimensions
 };

--- a/cfgov/unprocessed/js/modules/util/js-loader.js
+++ b/cfgov/unprocessed/js/modules/util/js-loader.js
@@ -2,7 +2,6 @@
    Dynamic Nonblocking script loader.
    ========================================================================== */
 
-
 /**
  * Dynamically attach and load a script tag in the head of the page.
  * @param {string} url The URL of the script to load.
@@ -24,4 +23,4 @@ function loadScript( url, callback ) {
 }
 
 // Expose public methods.
-module.exports = { loadScript: loadScript };
+export { loadScript };

--- a/cfgov/unprocessed/js/modules/util/scroll.js
+++ b/cfgov/unprocessed/js/modules/util/scroll.js
@@ -1,4 +1,4 @@
-const assign = require( './assign' ).assign;
+import { assign } from './assign';
 
 const _requestAnimationFrame = window.requestAnimationFrame ||
     window.webkitRequestAnimationFrame ||
@@ -130,11 +130,10 @@ function elementInView( elem, strict ) {
   return elementBottom >= windowTop && elementTop <= windowBottom;
 }
 
-
-module.exports = {
-  elementInView: elementInView,
-  scrollIntoView: scrollIntoView,
-  scrollTo: scrollTo
-};
-
 window.scrollToElement = scrollTo;
+
+export {
+  elementInView,
+  scrollIntoView,
+  scrollTo
+};

--- a/cfgov/unprocessed/js/modules/util/standard-type.js
+++ b/cfgov/unprocessed/js/modules/util/standard-type.js
@@ -56,10 +56,10 @@ function noopFunct() {
 
 let UNDEFINED;
 
-module.exports = {
-  BEHAVIOR_PREFIX: BEHAVIOR_PREFIX,
-  JS_HOOK:         JS_HOOK,
-  noopFunct:       noopFunct,
-  STATE_PREFIX:    STATE_PREFIX,
-  UNDEFINED:       UNDEFINED
+export {
+  BEHAVIOR_PREFIX,
+  JS_HOOK,
+  noopFunct,
+  STATE_PREFIX,
+  UNDEFINED
 };

--- a/cfgov/unprocessed/js/modules/util/strings.js
+++ b/cfgov/unprocessed/js/modules/util/strings.js
@@ -27,8 +27,8 @@ function stringMatch( x, y ) {
   return RegExp( stringEscape( y.trim() ), 'i' ).test( x );
 }
 
-module.exports = {
-  stringEscape: stringEscape,
-  stringValid:  stringValid,
-  stringMatch:  stringMatch
+export {
+  stringEscape,
+  stringValid,
+  stringMatch
 };

--- a/cfgov/unprocessed/js/modules/util/tree-traversal.js
+++ b/cfgov/unprocessed/js/modules/util/tree-traversal.js
@@ -76,8 +76,8 @@ function dfs( node, callback ) {
   }
 }
 
-module.exports = {
-  backtrack: backtrack,
-  bfs:       bfs,
-  dfs:       dfs
+export {
+  backtrack,
+  bfs,
+  dfs
 };

--- a/cfgov/unprocessed/js/modules/util/type-checkers.js
+++ b/cfgov/unprocessed/js/modules/util/type-checkers.js
@@ -6,7 +6,6 @@
    Copyright (c) 2010-2015 Google, Inc. https://angularjs.org
    ========================================================================== */
 
-
 const _toString = Object.prototype.toString;
 
 /**
@@ -156,16 +155,15 @@ function isEmpty( value ) {
          ( /^\s*$/ ).test( value );
 }
 
-
 // Expose public methods.
-module.exports = {
-  isUndefined: isUndefined,
-  isDefined:   isDefined,
-  isObject:    isObject,
-  isString:    isString,
-  isNumber:    isNumber,
-  isDate:      isDate,
-  isArray:     isArray,
-  isFunction:  isFunction,
-  isEmpty:     isEmpty
+export {
+  isUndefined,
+  isDefined,
+  isObject,
+  isString,
+  isNumber,
+  isDate,
+  isArray,
+  isFunction,
+  isEmpty
 };

--- a/cfgov/unprocessed/js/modules/util/validators.js
+++ b/cfgov/unprocessed/js/modules/util/validators.js
@@ -3,10 +3,9 @@
    Various utility functions to check if a field contains a valid value
    ========================================================================== */
 
-
 // Required Modules
-const ERROR_MESSAGES = require( '../../config/error-messages-config' );
-const typeCheckers = require( '../../modules/util/type-checkers' );
+import ERROR_MESSAGES from '../../config/error-messages-config';
+import * as typeCheckers from '../../modules/util/type-checkers';
 
 /* TODO: Update all the validators to return both passed and failed states
    instead of returning an empty object if the value passed */
@@ -150,10 +149,10 @@ function _checkableInput( field, currentStatus, fieldset, type ) {
   return currentStatus;
 }
 
-module.exports = {
-  date:     date,
-  email:    email,
-  empty:    empty,
-  checkbox: checkbox,
-  radio:    radio
+export {
+  date,
+  email,
+  empty,
+  checkbox,
+  radio
 };

--- a/cfgov/unprocessed/js/modules/util/web-storage-proxy.js
+++ b/cfgov/unprocessed/js/modules/util/web-storage-proxy.js
@@ -114,9 +114,9 @@ function _getStorageType( storage ) {
 }
 
 // Expose public methods.
-module.exports = {
-  setItem:    setItem,
-  getItem:    getItem,
-  removeItem: removeItem,
-  setStorage: setStorage
+export {
+  setItem,
+  getItem,
+  removeItem,
+  setStorage
 };

--- a/cfgov/unprocessed/js/molecules/Autocomplete.js
+++ b/cfgov/unprocessed/js/molecules/Autocomplete.js
@@ -1,10 +1,10 @@
 // Required modules.
-const assign = require( '../modules/util/assign' ).assign;
-const atomicHelpers = require( '../modules/util/atomic-helpers' );
-const ajaxRequest = require( '../modules/util/ajax-request' ).ajaxRequest;
-const bindEvent = require( '../modules/util/dom-events' ).bindEvent;
-const standardType = require( '../modules/util/standard-type' );
-const throttle = require( 'lodash.throttle' );
+import { assign } from '../modules/util/assign';
+import * as atomicHelpers from '../modules/util/atomic-helpers';
+import { ajaxRequest } from '../modules/util/ajax-request';
+import { bindEvent } from '../modules/util/dom-events';
+import { UNDEFINED } from '../modules/util/standard-type';
+import * as throttle from 'lodash.throttle';
 
 /**
  * Autocomplete
@@ -86,7 +86,7 @@ function Autocomplete( element, opts ) {
    */
   function init() {
     if ( !atomicHelpers.setInitFlag( _dom ) ) {
-      return standardType.UNDEFINED;
+      return UNDEFINED;
     }
 
     _autocomplete = _addContainer();
@@ -321,4 +321,4 @@ function Autocomplete( element, opts ) {
   return this;
 }
 
-module.exports = Autocomplete;
+export default Autocomplete;

--- a/cfgov/unprocessed/js/molecules/GlobalSearch.js
+++ b/cfgov/unprocessed/js/molecules/GlobalSearch.js
@@ -1,12 +1,12 @@
 // Required modules.
-const atomicHelpers = require( '../modules/util/atomic-helpers' );
-const breakpointState = require( '../modules/util/breakpoint-state' );
-const ClearableInput = require( '../modules/ClearableInput' );
-const EventObserver = require( '../modules/util/EventObserver' );
-const FlyoutMenu = require( '../modules/behavior/FlyoutMenu' );
-const MoveTransition = require( '../modules/transition/MoveTransition' );
-const standardType = require( '../modules/util/standard-type' );
-const TabTrigger = require( '../modules/TabTrigger' );
+import * as atomicHelpers from '../modules/util/atomic-helpers';
+import * as breakpointState from '../modules/util/breakpoint-state';
+import ClearableInput from '../modules/ClearableInput';
+import EventObserver from '../modules/util/EventObserver';
+import FlyoutMenu from '../modules/behavior/FlyoutMenu';
+import MoveTransition from '../modules/transition/MoveTransition';
+import { UNDEFINED } from '../modules/util/standard-type';
+import TabTrigger from '../modules/TabTrigger';
 
 /**
  * GlobalSearch
@@ -38,7 +38,7 @@ function GlobalSearch( element ) { // eslint-disable-line max-statements, no-inl
    */
   function init() {
     if ( !atomicHelpers.setInitFlag( _dom ) ) {
-      return standardType.UNDEFINED;
+      return UNDEFINED;
     }
 
     // Set initial appearance.
@@ -199,4 +199,4 @@ function GlobalSearch( element ) { // eslint-disable-line max-statements, no-inl
   return this;
 }
 
-module.exports = GlobalSearch;
+export default GlobalSearch;

--- a/cfgov/unprocessed/js/molecules/Multiselect.js
+++ b/cfgov/unprocessed/js/molecules/Multiselect.js
@@ -1,12 +1,12 @@
 // Required modules.
-const arrayHelpers = require( '../modules/util/array-helpers' );
-const atomicHelpers = require( '../modules/util/atomic-helpers' );
-const bindEvent = require( '../modules/util/dom-events' ).bindEvent;
-const domCreate = require( '../modules/util/dom-manipulators' ).create;
-const queryOne = require( '../modules/util/dom-traverse' ).queryOne;
-const standardType = require( '../modules/util/standard-type' );
-const strings = require( '../modules/util/strings' );
-const EventObserver = require( '../modules/util/EventObserver' );
+import * as arrayHelpers from '../modules/util/array-helpers';
+import * as atomicHelpers from '../modules/util/atomic-helpers';
+import { bindEvent } from '../modules/util/dom-events';
+import { create } from '../modules/util/dom-manipulators';
+import { queryOne } from '../modules/util/dom-traverse';
+import { UNDEFINED } from '../modules/util/standard-type';
+import { stringMatch, stringValid } from '../modules/util/strings';
+import EventObserver from '../modules/util/EventObserver';
 
 const closeIcon = require(
   'svg-inline-loader!../../../../node_modules/cf-icons/src/icons/close.svg'
@@ -77,7 +77,7 @@ function Multiselect( element ) { // eslint-disable-line max-statements, inline-
    */
   function init() {
     if ( !atomicHelpers.setInitFlag( _dom ) ) {
-      return standardType.UNDEFINED;
+      return UNDEFINED;
     }
 
     _instance = this;
@@ -144,7 +144,7 @@ function Multiselect( element ) { // eslint-disable-line max-statements, inline-
       item = list[i];
 
       // If the value isn't valid kill the script and prompt the developer.
-      if ( !strings.stringValid( item.value ) ) {
+      if ( !stringValid( item.value ) ) {
         // TODO: Update to throw an error and handle the error vs logging.
         console.log( '\'' + item.value + '\' is not a valid value' );
         // TODO: Remove this line if the class is added via markup.
@@ -169,24 +169,24 @@ function Multiselect( element ) { // eslint-disable-line max-statements, inline-
    */
   function _populateMarkup() {
     // Add a container for our markup
-    _containerDom = domCreate( 'div', {
+    _containerDom = create( 'div', {
       className: BASE_CLASS,
       around:    _dom
     } );
 
     // Create all our markup but wait to manipulate the DOM just once
-    _selectionsDom = domCreate( 'ul', {
+    _selectionsDom = create( 'ul', {
       className: LIST_CLASS + ' ' +
                  LIST_CLASS + '__unstyled ' +
                  BASE_CLASS + '_choices',
       inside:    _containerDom
     } );
 
-    _headerDom = domCreate( 'header', {
+    _headerDom = create( 'header', {
       className: BASE_CLASS + '_header'
     } );
 
-    _searchDom = domCreate( 'input', {
+    _searchDom = create( 'input', {
       className:   BASE_CLASS + '_search ' + TEXT_INPUT_CLASS,
       type:        'text',
       placeholder: _placeholder || 'Choose up to five',
@@ -194,12 +194,12 @@ function Multiselect( element ) { // eslint-disable-line max-statements, inline-
       id:          _name
     } );
 
-    _fieldsetDom = domCreate( 'fieldset', {
+    _fieldsetDom = create( 'fieldset', {
       'className':   BASE_CLASS + '_fieldset u-invisible',
       'aria-hidden': 'true'
     } );
 
-    _optionsDom = domCreate( 'ul', {
+    _optionsDom = create( 'ul', {
       className: LIST_CLASS + ' ' +
                  LIST_CLASS + '__unstyled ' +
                  BASE_CLASS + '_options',
@@ -207,12 +207,12 @@ function Multiselect( element ) { // eslint-disable-line max-statements, inline-
     } );
 
     _optionsData.forEach( function( option ) {
-      const _optionsItemDom = domCreate( 'li', {
+      const _optionsItemDom = create( 'li', {
         'data-option': option.value,
         'class': 'm-form-field m-form-field__checkbox'
       } );
 
-      domCreate( 'input', {
+      create( 'input', {
         'id':     option.value,
         // Type must come before value or IE fails
         'type':    'checkbox',
@@ -223,7 +223,7 @@ function Multiselect( element ) { // eslint-disable-line max-statements, inline-
         'checked': option.checked
       } );
 
-      domCreate( 'label', {
+      create( 'label', {
         'for':         option.value,
         'textContent': option.text,
         'className':   BASE_CLASS + '_label a-label',
@@ -233,12 +233,12 @@ function Multiselect( element ) { // eslint-disable-line max-statements, inline-
       _optionsDom.appendChild( _optionsItemDom );
 
       if ( option.checked ) {
-        const selectionsItemDom = domCreate( 'li', {
+        const selectionsItemDom = create( 'li', {
           'data-option': option.value,
           'class': 'm-form-field m-form-field__checkbox'
         } );
 
-        domCreate( 'label', {
+        create( 'label', {
           'for':         option.value,
           'textContent': option.text,
           'className':   BASE_CLASS + '_label',
@@ -310,11 +310,11 @@ function Multiselect( element ) { // eslint-disable-line max-statements, inline-
         option.checked = false;
         _selectionsCount -= 1;
       } else {
-        _selectionsItemDom = domCreate( 'li', {
+        _selectionsItemDom = create( 'li', {
           'data-option': option.value
         } );
 
-        const _selectionsItemLabelDom = domCreate( 'label', {
+        const _selectionsItemLabelDom = create( 'label', {
           'innerHTML': option.text + closeIcon,
           'for':       option.value,
           'inside':    _selectionsItemDom
@@ -354,7 +354,7 @@ function Multiselect( element ) { // eslint-disable-line max-statements, inline-
       _index = -1;
 
       _filteredData = _optionsData.filter( function( item ) {
-        return strings.stringMatch( item.text, value );
+        return stringMatch( item.text, value );
       } );
 
       _filterResults();

--- a/cfgov/unprocessed/js/molecules/Multiselect.js
+++ b/cfgov/unprocessed/js/molecules/Multiselect.js
@@ -517,4 +517,4 @@ function Multiselect( element ) { // eslint-disable-line max-statements, inline-
   return this;
 }
 
-module.exports = Multiselect;
+export default Multiselect;

--- a/cfgov/unprocessed/js/molecules/Notification.js
+++ b/cfgov/unprocessed/js/molecules/Notification.js
@@ -1,6 +1,6 @@
 // Required modules.
-const atomicHelpers = require( '../modules/util/atomic-helpers' );
-const standardType = require( '../modules/util/standard-type' );
+import * as atomicHelpers from '../modules/util/atomic-helpers';
+import { UNDEFINED } from '../modules/util/standard-type';
 const SUCCESS_ICON = require(
   'svg-inline-loader!../../../../node_modules/cf-icons/src/icons/check-round.svg'
 );
@@ -53,7 +53,7 @@ function Notification( element ) {
    */
   function init() {
     if ( !atomicHelpers.setInitFlag( _dom ) ) {
-      return standardType.UNDEFINED;
+      return UNDEFINED;
     }
 
     // Check and set default type of notification.
@@ -171,4 +171,4 @@ function Notification( element ) {
   return this;
 }
 
-module.exports = Notification;
+export default Notification;

--- a/cfgov/unprocessed/js/organisms/BureauStructure.js
+++ b/cfgov/unprocessed/js/organisms/BureauStructure.js
@@ -3,8 +3,7 @@
    Scripts for `/the-bureau/bureau-structure/`.
    ========================================================================== */
 
-
-const BreakpointHandler = require( '../modules/BreakpointHandler' );
+import BreakpointHandler from '../modules/BreakpointHandler';
 require( 'cf-expandables/src/Expandable' ).init();
 
 let BS;
@@ -211,4 +210,4 @@ const BureauStructure = BS = {
   }
 };
 
-module.exports = BureauStructure;
+export default BureauStructure;

--- a/cfgov/unprocessed/js/organisms/EmailPopup.js
+++ b/cfgov/unprocessed/js/organisms/EmailPopup.js
@@ -1,8 +1,8 @@
-const FormSubmit = require( './FormSubmit.js' );
-const atomicHelpers = require( '../modules/util/atomic-helpers' );
-const standardType = require( '../modules/util/standard-type' );
-const validators = require( '../modules/util/validators' );
-const emailHelpers = require( '../modules/util/email-popup-helpers' );
+import FormSubmit from './FormSubmit.js';
+import { checkDom, setInitFlag } from '../modules/util/atomic-helpers';
+import { UNDEFINED } from '../modules/util/standard-type';
+import * as validators from '../modules/util/validators';
+import * as emailHelpers from '../modules/util/email-popup-helpers';
 
 /**
  * EmailPopup
@@ -18,7 +18,7 @@ function EmailPopup( element ) {
 
   const VISIBLE_CLASS = 'o-email-popup__visible';
 
-  const _dom = atomicHelpers.checkDom( element, EmailPopup.BASE_CLASS );
+  const _dom = checkDom( element, EmailPopup.BASE_CLASS );
   const _popupLabel = _dom.getAttribute( 'data-popup-label' );
 
   // Set language default.
@@ -85,8 +85,8 @@ function EmailPopup( element ) {
    *   or undefined if it was already initialized.
    */
   function init() {
-    if ( !atomicHelpers.setInitFlag( _dom ) ) {
-      return standardType.UNDEFINED;
+    if ( !setInitFlag( _dom ) ) {
+      return UNDEFINED;
     }
 
     // Ensure EmailPopup is definitely hidden on initialization.
@@ -118,4 +118,4 @@ function EmailPopup( element ) {
 }
 EmailPopup.BASE_CLASS = 'o-email-popup';
 
-module.exports = EmailPopup;
+export default EmailPopup;

--- a/cfgov/unprocessed/js/organisms/FilterableListControls.js
+++ b/cfgov/unprocessed/js/organisms/FilterableListControls.js
@@ -1,13 +1,17 @@
 // Required modules.
-const Analytics = require( '../modules/Analytics' );
-const atomicHelpers = require( '../modules/util/atomic-helpers' );
-const ERROR_MESSAGES = require( '../config/error-messages-config' );
-const getClosestElement = require( '../modules/util/dom-traverse' ).closest;
-const Multiselect = require( '../molecules/Multiselect' );
-const Notification = require( '../molecules/Notification' );
-const standardType = require( '../modules/util/standard-type' );
-const validators = require( '../modules/util/validators' );
-const Expandable = require( 'cf-expandables/src/Expandable' );
+import Analytics from '../modules/Analytics';
+import {
+  checkDom,
+  instantiateAll,
+  setInitFlag
+} from '../modules/util/atomic-helpers';
+import ERROR_MESSAGES from '../config/error-messages-config';
+import { closest } from '../modules/util/dom-traverse';
+import Multiselect from '../molecules/Multiselect';
+import Notification from '../molecules/Notification';
+import { UNDEFINED } from '../modules/util/standard-type';
+import * as validators from '../modules/util/validators';
+import Expandable from 'cf-expandables/src/Expandable';
 let _expandable;
 
 /* eslint-disable max-lines-per-function */
@@ -24,7 +28,7 @@ let _expandable;
  */
 function FilterableListControls( element ) {
   const BASE_CLASS = 'o-filterable-list-controls';
-  const _dom = atomicHelpers.checkDom( element, BASE_CLASS );
+  const _dom = checkDom( element, BASE_CLASS );
   const _form = _dom.querySelector( 'form' );
   let _notification;
   let _fieldGroups;
@@ -48,17 +52,14 @@ function FilterableListControls( element ) {
    *   or undefined if it was already initialized.
    */
   function init() {
-    if ( !atomicHelpers.setInitFlag( _dom ) ) {
-      return standardType.UNDEFINED;
+    if ( !setInitFlag( _dom ) ) {
+      return UNDEFINED;
     }
 
     /* instantiate multiselects before their containing expandable
        so height of any 'selected choice' buttons is included when
        expandable height is calculated initially */
-    const multiSelects = atomicHelpers.instantiateAll(
-      'select[multiple]',
-      Multiselect
-    );
+    const multiSelects = instantiateAll( 'select[multiple]', Multiselect );
 
     const _expandables = Expandable.init();
     _expandable = _expandables[0];
@@ -184,7 +185,7 @@ function FilterableListControls( element ) {
     let labelDom;
 
     if ( isInGroup && !selector ) {
-      labelDom = getClosestElement( field, 'fieldset' );
+      labelDom = closest( field, 'fieldset' );
       if ( labelDom ) labelDom = labelDom.querySelector( 'legend' );
     } else {
       selector = selector ||
@@ -325,4 +326,4 @@ function FilterableListControls( element ) {
 }
 /* eslint-enable max-lines-per-function */
 
-module.exports = FilterableListControls;
+export default FilterableListControls;

--- a/cfgov/unprocessed/js/organisms/Footer.js
+++ b/cfgov/unprocessed/js/organisms/Footer.js
@@ -1,7 +1,7 @@
 // Required modules.
-const atomicHelpers = require( '../modules/util/atomic-helpers' );
-const footerButton = require( '../modules/footer-button' );
-const standardType = require( '../modules/util/standard-type' );
+import { checkDom, setInitFlag } from '../modules/util/atomic-helpers';
+import * as footerButton from '../modules/footer-button';
+import { UNDEFINED } from '../modules/util/standard-type';
 
 /**
  * Footer
@@ -17,15 +17,15 @@ function Footer( element ) {
 
   const BASE_CLASS = 'o-footer';
 
-  const _dom = atomicHelpers.checkDom( element, BASE_CLASS );
+  const _dom = checkDom( element, BASE_CLASS );
 
   /**
    * @returns {Footer|undefined} An instance,
    *   or undefined if it was already initialized.
    */
   function init() {
-    if ( !atomicHelpers.setInitFlag( _dom ) ) {
-      return standardType.UNDEFINED;
+    if ( !setInitFlag( _dom ) ) {
+      return UNDEFINED;
     }
 
     footerButton.init();
@@ -38,4 +38,4 @@ function Footer( element ) {
   return this;
 }
 
-module.exports = Footer;
+export default Footer;

--- a/cfgov/unprocessed/js/organisms/FormSubmit.js
+++ b/cfgov/unprocessed/js/organisms/FormSubmit.js
@@ -1,12 +1,13 @@
 // Required modules.
-const atomicHelpers = require( '../modules/util/atomic-helpers' );
-const scroll = require( '../modules/util/scroll' );
-const AlphaTransition = require( '../modules/transition/AlphaTransition' );
-const BaseTransition = require( '../modules/transition/BaseTransition' );
-const ERROR_MESSAGES = require( '../config/error-messages-config' );
+import { checkDom, setInitFlag } from '../modules/util/atomic-helpers';
+import { scrollIntoView } from '../modules/util/scroll';
+import AlphaTransition from '../modules/transition/AlphaTransition';
+import BaseTransition from '../modules/transition/BaseTransition';
+import ERROR_MESSAGES from '../config/error-messages-config';
+import Notification from '../molecules/Notification';
+import EventObserver from '../modules/util/EventObserver';
+
 const FORM_MESSAGES = ERROR_MESSAGES.FORM.SUBMISSION;
-const Notification = require( '../molecules/Notification' );
-const EventObserver = require( '../modules/util/EventObserver' );
 
 /**
  * FormSubmit
@@ -25,7 +26,7 @@ const EventObserver = require( '../modules/util/EventObserver' );
 function FormSubmit( element, baseClass, opts ) {
   opts = opts || {};
   let UNDEFINED;
-  const _baseElement = atomicHelpers.checkDom( element, baseClass );
+  const _baseElement = checkDom( element, baseClass );
   const _formElement = _baseElement.querySelector( 'form' );
   const _notificationElement = _baseElement.querySelector( '.m-notification' );
   let _notification;
@@ -41,7 +42,7 @@ function FormSubmit( element, baseClass, opts ) {
    *   or undefined if it was already initialized.
    */
   function init() {
-    if ( !atomicHelpers.setInitFlag( _baseElement ) ) {
+    if ( !setInitFlag( _baseElement ) ) {
       return UNDEFINED;
     }
     _cachedFields = _cacheFields();
@@ -89,7 +90,7 @@ function FormSubmit( element, baseClass, opts ) {
   function _displayNotification( type, content ) {
     _notification.setTypeAndContent( type, content );
     _notification.show();
-    scroll.scrollIntoView( _notificationElement );
+    scrollIntoView( _notificationElement );
   }
 
   /**
@@ -152,7 +153,7 @@ function FormSubmit( element, baseClass, opts ) {
    */
   function _replaceFormWithNotification( message ) {
     const transition = new AlphaTransition( _baseElement ).init();
-    scroll.scrollIntoView( _formElement, { offset: 100, callback: fadeOutForm } );
+    scrollIntoView( _formElement, { offset: 100, callback: fadeOutForm } );
 
     function fadeOutForm() {
       transition.addEventListener( BaseTransition.END_EVENT, fadeInMessage );
@@ -239,4 +240,4 @@ function FormSubmit( element, baseClass, opts ) {
   return this;
 }
 
-module.exports = FormSubmit;
+export default FormSubmit;

--- a/cfgov/unprocessed/js/organisms/Header.js
+++ b/cfgov/unprocessed/js/organisms/Header.js
@@ -1,8 +1,8 @@
 // Required modules.
-const atomicHelpers = require( '../modules/util/atomic-helpers' );
-const GlobalSearch = require( '../molecules/GlobalSearch.js' );
-const MegaMenu = require( '../organisms/MegaMenu.js' );
-const standardType = require( '../modules/util/standard-type' );
+import { checkDom, setInitFlag } from '../modules/util/atomic-helpers';
+import GlobalSearch from '../molecules/GlobalSearch.js';
+import MegaMenu from '../organisms/MegaMenu.js';
+import { UNDEFINED } from '../modules/util/standard-type';
 
 /**
  * Header
@@ -18,7 +18,7 @@ function Header( element ) {
 
   const BASE_CLASS = 'o-header';
 
-  const _dom = atomicHelpers.checkDom( element, BASE_CLASS );
+  const _dom = checkDom( element, BASE_CLASS );
 
   let _globalSearch;
   let _megaMenu;
@@ -31,8 +31,8 @@ function Header( element ) {
    *   or undefined if it was already initialized.
    */
   function init( overlay ) {
-    if ( !atomicHelpers.setInitFlag( _dom ) ) {
-      return standardType.UNDEFINED;
+    if ( !setInitFlag( _dom ) ) {
+      return UNDEFINED;
     }
 
     // Semi-opaque overlay that shows over the content when the menu flies out.
@@ -80,4 +80,4 @@ function Header( element ) {
   return this;
 }
 
-module.exports = Header;
+export default Header;

--- a/cfgov/unprocessed/js/organisms/MegaMenu.js
+++ b/cfgov/unprocessed/js/organisms/MegaMenu.js
@@ -1,15 +1,15 @@
 // Required modules.
-const atomicHelpers = require( '../modules/util/atomic-helpers' );
-const breakpointState = require( '../modules/util/breakpoint-state' );
-const dataHook = require( '../modules/util/data-hook' );
-const EventObserver = require( '../modules/util/EventObserver' );
-const FlyoutMenu = require( '../modules/behavior/FlyoutMenu' );
-const MegaMenuDesktop = require( '../organisms/MegaMenuDesktop' );
-const MegaMenuMobile = require( '../organisms/MegaMenuMobile' );
-const MoveTransition = require( '../modules/transition/MoveTransition' );
-const TabTrigger = require( '../modules/TabTrigger' );
-const Tree = require( '../modules/Tree' );
-const standardType = require( '../modules/util/standard-type' );
+import { checkDom, setInitFlag } from '../modules/util/atomic-helpers';
+import { isInDesktop } from '../modules/util/breakpoint-state';
+import { contains } from '../modules/util/data-hook';
+import EventObserver from '../modules/util/EventObserver';
+import FlyoutMenu from '../modules/behavior/FlyoutMenu';
+import MegaMenuDesktop from '../organisms/MegaMenuDesktop';
+import MegaMenuMobile from '../organisms/MegaMenuMobile';
+import MoveTransition from '../modules/transition/MoveTransition';
+import TabTrigger from '../modules/TabTrigger';
+import Tree from '../modules/Tree';
+import { UNDEFINED } from '../modules/util/standard-type';
 
 /**
  * MegaMenu
@@ -24,7 +24,7 @@ const standardType = require( '../modules/util/standard-type' );
 function MegaMenu( element ) {
   const BASE_CLASS = 'o-mega-menu';
 
-  const _dom = atomicHelpers.checkDom( element, BASE_CLASS );
+  const _dom = checkDom( element, BASE_CLASS );
 
   // Tree data model.
   let _menus;
@@ -42,8 +42,8 @@ function MegaMenu( element ) {
    *   or undefined if it was already initialized.
    */
   function init() {
-    if ( !atomicHelpers.setInitFlag( _dom ) ) {
-      return standardType.UNDEFINED;
+    if ( !setInitFlag( _dom ) ) {
+      return UNDEFINED;
     }
 
     // DOM selectors.
@@ -84,7 +84,7 @@ function MegaMenu( element ) {
       window.addEventListener( 'orientationchange', _resizeHandler );
     }
 
-    if ( breakpointState.isInDesktop() ) {
+    if ( isInDesktop() ) {
       _desktopNav.resume();
     } else {
       _mobileNav.resume();
@@ -132,7 +132,7 @@ function MegaMenu( element ) {
   function _addMenu( dom, parentNode ) {
     let newParentNode = parentNode;
     let transition;
-    if ( dataHook.contains( dom, FlyoutMenu.BASE_CLASS ) ) {
+    if ( contains( dom, FlyoutMenu.BASE_CLASS ) ) {
       const menu = new FlyoutMenu( dom ).init();
       transition = new MoveTransition( menu.getDom().content ).init();
       menu.setExpandTransition( transition, transition.moveToOrigin );
@@ -164,7 +164,7 @@ function MegaMenu( element ) {
    * @param {Object} event - A FlyoutMenu event object.
    */
   function _handleEvent( event ) {
-    const activeNav = breakpointState.isInDesktop() ? _desktopNav : _mobileNav;
+    const activeNav = isInDesktop() ? _desktopNav : _mobileNav;
     activeNav.handleEvent( event );
   }
 
@@ -173,7 +173,7 @@ function MegaMenu( element ) {
    * suspends or resumes the mobile or desktop menu behaviors.
    */
   function _resizeHandler() {
-    if ( breakpointState.isInDesktop() ) {
+    if ( isInDesktop() ) {
       _mobileNav.suspend();
       _desktopNav.resume();
     } else {
@@ -194,7 +194,7 @@ function MegaMenu( element ) {
    * @returns {MegaMenu} An instance.
    */
   function collapse() {
-    if ( !breakpointState.isInDesktop() ) {
+    if ( !isInDesktop() ) {
       _mobileNav.collapse();
     }
 
@@ -227,4 +227,4 @@ function MegaMenu( element ) {
   return this;
 }
 
-module.exports = MegaMenu;
+export default MegaMenu;

--- a/cfgov/unprocessed/js/organisms/MegaMenuDesktop.js
+++ b/cfgov/unprocessed/js/organisms/MegaMenuDesktop.js
@@ -1,7 +1,7 @@
 // Required modules.
-const EventObserver = require( '../modules/util/EventObserver' );
-const MoveTransition = require( '../modules/transition/MoveTransition' );
-const treeTraversal = require( '../modules/util/tree-traversal' );
+import EventObserver from '../modules/util/EventObserver';
+import MoveTransition from '../modules/transition/MoveTransition';
+import * as treeTraversal from '../modules/util/tree-traversal';
 
 /**
  * MegaMenuDesktop
@@ -341,4 +341,4 @@ function MegaMenuDesktop( menus ) {
   return this;
 }
 
-module.exports = MegaMenuDesktop;
+export default MegaMenuDesktop;

--- a/cfgov/unprocessed/js/organisms/MegaMenuMobile.js
+++ b/cfgov/unprocessed/js/organisms/MegaMenuMobile.js
@@ -1,7 +1,7 @@
 // Required modules.
-const EventObserver = require( '../modules/util/EventObserver' );
-const MoveTransition = require( '../modules/transition/MoveTransition' );
-const treeTraversal = require( '../modules/util/tree-traversal' );
+import EventObserver from '../modules/util/EventObserver';
+import MoveTransition from '../modules/transition/MoveTransition';
+import * as treeTraversal from '../modules/util/tree-traversal';
 
 /**
  * MegaMenuMobile
@@ -333,4 +333,4 @@ function MegaMenuMobile( menus ) {
   return this;
 }
 
-module.exports = MegaMenuMobile;
+export default MegaMenuMobile;

--- a/cfgov/unprocessed/js/organisms/MortgagePerformanceTrends/actions/chart.js
+++ b/cfgov/unprocessed/js/organisms/MortgagePerformanceTrends/actions/chart.js
@@ -1,5 +1,5 @@
-const utils = require( '../utils' );
-const defaultActionCreators = require( './default' );
+import * as utils from '../utils';
+import defaultActionCreators from './default';
 
 const chartActionCreators = defaultActionCreators();
 

--- a/cfgov/unprocessed/js/organisms/MortgagePerformanceTrends/actions/chart.js
+++ b/cfgov/unprocessed/js/organisms/MortgagePerformanceTrends/actions/chart.js
@@ -1,4 +1,4 @@
-import * as utils from '../utils';
+import utils from '../utils';
 import defaultActionCreators from './default';
 
 const chartActionCreators = defaultActionCreators();
@@ -215,4 +215,4 @@ chartActionCreators.fetchCounties = ( countyState, includeComparison ) => dispat
   } );
 };
 
-module.exports = chartActionCreators;
+export default chartActionCreators;

--- a/cfgov/unprocessed/js/organisms/MortgagePerformanceTrends/actions/default.js
+++ b/cfgov/unprocessed/js/organisms/MortgagePerformanceTrends/actions/default.js
@@ -1,4 +1,4 @@
-const utils = require( '../utils' );
+import * as utils from '../utils';
 
 const defaultActionCreators = () => {
 
@@ -196,4 +196,4 @@ const defaultActionCreators = () => {
 
 };
 
-module.exports = defaultActionCreators;
+export default defaultActionCreators;

--- a/cfgov/unprocessed/js/organisms/MortgagePerformanceTrends/actions/default.js
+++ b/cfgov/unprocessed/js/organisms/MortgagePerformanceTrends/actions/default.js
@@ -1,4 +1,4 @@
-import * as utils from '../utils';
+import utils from '../utils';
 
 const defaultActionCreators = () => {
 

--- a/cfgov/unprocessed/js/organisms/MortgagePerformanceTrends/actions/map.js
+++ b/cfgov/unprocessed/js/organisms/MortgagePerformanceTrends/actions/map.js
@@ -1,5 +1,5 @@
-const utils = require( '../utils' );
-const defaultActionCreators = require( './default' );
+import * as utils from '../utils';
+import defaultActionCreators from './default';
 
 const mapActionCreators = defaultActionCreators();
 

--- a/cfgov/unprocessed/js/organisms/MortgagePerformanceTrends/actions/map.js
+++ b/cfgov/unprocessed/js/organisms/MortgagePerformanceTrends/actions/map.js
@@ -95,4 +95,4 @@ mapActionCreators.fetchCounties = ( countyState, shouldZoom ) => dispatch => {
   } );
 };
 
-module.exports = mapActionCreators;
+export default mapActionCreators;

--- a/cfgov/unprocessed/js/organisms/MortgagePerformanceTrends/apps/chart.js
+++ b/cfgov/unprocessed/js/organisms/MortgagePerformanceTrends/apps/chart.js
@@ -1,7 +1,7 @@
-const ccb = require( 'cfpb-chart-builder' );
-const actions = require( '../actions/chart' );
-const Store = require( '../stores/chart' );
-const utils = require( '../utils' );
+import * as ccb from 'cfpb-chart-builder';
+import * as actions from '../actions/chart';
+import Store from '../stores/chart';
+import * as utils from '../utils';
 
 const store = new Store( [ utils.thunkMiddleware, utils.loggerMiddleware ] );
 
@@ -273,4 +273,4 @@ MortgagePerformanceLineChart.prototype.renderStates = function( prevState, state
   this.$state.appendChild( fragment );
 };
 
-module.exports = MortgagePerformanceLineChart;
+export default MortgagePerformanceLineChart;

--- a/cfgov/unprocessed/js/organisms/MortgagePerformanceTrends/apps/chart.js
+++ b/cfgov/unprocessed/js/organisms/MortgagePerformanceTrends/apps/chart.js
@@ -1,7 +1,7 @@
 import * as ccb from 'cfpb-chart-builder';
-import * as actions from '../actions/chart';
+import actions from '../actions/chart';
 import Store from '../stores/chart';
-import * as utils from '../utils';
+import utils from '../utils';
 
 const store = new Store( [ utils.thunkMiddleware, utils.loggerMiddleware ] );
 

--- a/cfgov/unprocessed/js/organisms/MortgagePerformanceTrends/apps/map.js
+++ b/cfgov/unprocessed/js/organisms/MortgagePerformanceTrends/apps/map.js
@@ -1,7 +1,7 @@
-const ccb = require( 'cfpb-chart-builder' );
-const actions = require( '../actions/map' );
-const Store = require( '../stores/map' );
-const utils = require( '../utils' );
+import * as ccb from 'cfpb-chart-builder';
+import * as actions from '../actions/chart';
+import Store from '../stores/chart';
+import * as utils from '../utils';
 
 const _plurals = {
   state: 'states',
@@ -358,4 +358,4 @@ MortgagePerformanceMap.prototype.renderTooltip = function() {
   };
 };
 
-module.exports = MortgagePerformanceMap;
+export default MortgagePerformanceMap;

--- a/cfgov/unprocessed/js/organisms/MortgagePerformanceTrends/apps/map.js
+++ b/cfgov/unprocessed/js/organisms/MortgagePerformanceTrends/apps/map.js
@@ -1,7 +1,7 @@
 import * as ccb from 'cfpb-chart-builder';
-import * as actions from '../actions/chart';
+import actions from '../actions/chart';
 import Store from '../stores/chart';
-import * as utils from '../utils';
+import utils from '../utils';
 
 const _plurals = {
   state: 'states',

--- a/cfgov/unprocessed/js/organisms/MortgagePerformanceTrends/index.js
+++ b/cfgov/unprocessed/js/organisms/MortgagePerformanceTrends/index.js
@@ -1,7 +1,7 @@
 import Chart from './apps/chart';
 import Map from './apps/map';
 
-module.exports = {
+export {
   Chart,
   Map
 };

--- a/cfgov/unprocessed/js/organisms/MortgagePerformanceTrends/index.js
+++ b/cfgov/unprocessed/js/organisms/MortgagePerformanceTrends/index.js
@@ -1,5 +1,5 @@
-const Chart = require( './apps/chart' );
-const Map = require( './apps/map' );
+import Chart from './apps/chart';
+import Map from './apps/map';
 
 module.exports = {
   Chart,

--- a/cfgov/unprocessed/js/organisms/MortgagePerformanceTrends/stores/chart.js
+++ b/cfgov/unprocessed/js/organisms/MortgagePerformanceTrends/stores/chart.js
@@ -1,4 +1,4 @@
-const Store = require( './store' );
+import Store from './store';
 
 const updateGeo = ( geo, action ) => {
   switch ( action.type ) {
@@ -171,4 +171,4 @@ class LineChartStore extends Store {
   }
 }
 
-module.exports = LineChartStore;
+export default LineChartStore;

--- a/cfgov/unprocessed/js/organisms/MortgagePerformanceTrends/stores/map.js
+++ b/cfgov/unprocessed/js/organisms/MortgagePerformanceTrends/stores/map.js
@@ -1,4 +1,4 @@
-const Store = require( './store' );
+import Store from './store';
 
 const updateGeo = ( geo, action ) => {
   switch ( action.type ) {
@@ -133,4 +133,4 @@ class MapStore extends Store {
   }
 }
 
-module.exports = MapStore;
+export default MapStore;

--- a/cfgov/unprocessed/js/organisms/MortgagePerformanceTrends/stores/store.js
+++ b/cfgov/unprocessed/js/organisms/MortgagePerformanceTrends/stores/store.js
@@ -53,4 +53,4 @@ Store.prototype.notifySubscribers = function() {
   }.bind( this ) );
 };
 
-module.exports = Store;
+export default Store;

--- a/cfgov/unprocessed/js/organisms/MortgagePerformanceTrends/utils.js
+++ b/cfgov/unprocessed/js/organisms/MortgagePerformanceTrends/utils.js
@@ -1,4 +1,4 @@
-const ajax = require( 'xdr' );
+import ajax from 'xdr';
 
 const COUNTIES_URL = '/data-research/mortgages/api/v1/metadata/state_county_meta';
 const METROS_URL = '/data-research/mortgages/api/v1/metadata/state_msa_meta';
@@ -434,4 +434,4 @@ const utils = {
   }
 };
 
-module.exports = utils;
+export default utils;

--- a/cfgov/unprocessed/js/routes/about-us/careers/current-openings/index.js
+++ b/cfgov/unprocessed/js/routes/about-us/careers/current-openings/index.js
@@ -2,5 +2,4 @@
    Scripts for `/about-us/careers/current-openings/.
    ========================================================================== */
 
-
 require( '../../../../modules/o-table-row-links' ).init();

--- a/cfgov/unprocessed/js/routes/ask-cfpb/single.js
+++ b/cfgov/unprocessed/js/routes/ask-cfpb/single.js
@@ -1,7 +1,7 @@
-require( '../../modules/util/add-email-popup' );
-require( '../on-demand/ask-autocomplete' );
-require( '../on-demand/read-more' );
-const Analytics = require( '../../modules/Analytics' );
+import '../../modules/util/add-email-popup';
+import '../on-demand/ask-autocomplete';
+import '../on-demand/read-more';
+import Analytics from '../../modules/Analytics';
 
 const analyticsData = document.querySelector( '.analytics-data' );
 

--- a/cfgov/unprocessed/js/routes/common.js
+++ b/cfgov/unprocessed/js/routes/common.js
@@ -5,11 +5,12 @@
 // GLOBAL ATOMIC ELEMENTS.
 
 // Organisms.
-const Header = require( '../organisms/Header.js' );
+import Header from '../organisms/Header.js';
+import Footer from '../organisms/Footer.js';
+
 const header = new Header( document.body );
 // Initialize header by passing it reference to global overlay atom.
 header.init( document.body.querySelector( '.a-overlay' ) );
 
-const Footer = require( '../organisms/Footer.js' );
 const footer = new Footer( document.body );
 footer.init();

--- a/cfgov/unprocessed/js/routes/on-demand/ask-autocomplete.js
+++ b/cfgov/unprocessed/js/routes/on-demand/ask-autocomplete.js
@@ -2,7 +2,7 @@
    Scripts for Ask Autocomplete.
    ========================================================================== */
 
-const Autocomplete = require( '../../molecules/Autocomplete' );
+import Autocomplete from '../../molecules/Autocomplete';
 
 const URLS = {
   en: '/ask-cfpb/api/autocomplete/?term=',

--- a/cfgov/unprocessed/js/routes/on-demand/bureau-structure.js
+++ b/cfgov/unprocessed/js/routes/on-demand/bureau-structure.js
@@ -3,6 +3,5 @@
    Scripts for `/the-bureau/bureau-structure/`.
    ========================================================================== */
 
-
-const BureauStructure = require( '../../organisms/BureauStructure' );
+import BureauStructure from '../../organisms/BureauStructure';
 BureauStructure.initialize();

--- a/cfgov/unprocessed/js/routes/on-demand/chart.js
+++ b/cfgov/unprocessed/js/routes/on-demand/chart.js
@@ -2,6 +2,5 @@
    Scripts for Line Chart molecule.
    ========================================================================== */
 
-
 // See https://github.com/cfpb/cfpb-chart-builder
 require( 'cfpb-chart-builder' );

--- a/cfgov/unprocessed/js/routes/on-demand/chart.js
+++ b/cfgov/unprocessed/js/routes/on-demand/chart.js
@@ -2,5 +2,8 @@
    Scripts for Line Chart molecule.
    ========================================================================== */
 
+// Polyfill Promise for IE10/11
+import 'core-js/es6/promise';
+
 // See https://github.com/cfpb/cfpb-chart-builder
 require( 'cfpb-chart-builder' );

--- a/cfgov/unprocessed/js/routes/on-demand/email-signup.js
+++ b/cfgov/unprocessed/js/routes/on-demand/email-signup.js
@@ -3,7 +3,7 @@
    ========================================================================== */
 
 import FormSubmit from '../../organisms/FormSubmit.js';
-import validators from '../../modules/util/validators';
+import * as validators from '../../modules/util/validators';
 
 const BASE_CLASS = 'o-email-signup';
 const language = document.body.querySelector( '.content' ).lang;

--- a/cfgov/unprocessed/js/routes/on-demand/email-signup.js
+++ b/cfgov/unprocessed/js/routes/on-demand/email-signup.js
@@ -2,9 +2,8 @@
    Scripts for Email Signup organism.
    ========================================================================== */
 
-
-const FormSubmit = require( '../../organisms/FormSubmit.js' );
-const validators = require( '../../modules/util/validators' );
+import FormSubmit from '../../organisms/FormSubmit.js';
+import validators from '../../modules/util/validators';
 
 const BASE_CLASS = 'o-email-signup';
 const language = document.body.querySelector( '.content' ).lang;

--- a/cfgov/unprocessed/js/routes/on-demand/expandable-group.js
+++ b/cfgov/unprocessed/js/routes/on-demand/expandable-group.js
@@ -2,5 +2,4 @@
    Scripts for Expandable Group organism.
    ========================================================================== */
 
-
 require( 'cf-expandables/src/Expandable' ).init();

--- a/cfgov/unprocessed/js/routes/on-demand/expandable.js
+++ b/cfgov/unprocessed/js/routes/on-demand/expandable.js
@@ -2,5 +2,4 @@
    Scripts for Expandable Molecule.
    ========================================================================== */
 
-
 require( 'cf-expandables/src/Expandable' ).init();

--- a/cfgov/unprocessed/js/routes/on-demand/feedback-form.js
+++ b/cfgov/unprocessed/js/routes/on-demand/feedback-form.js
@@ -2,9 +2,9 @@
    Scripts for Feedback Form organism.
    ========================================================================== */
 
-const COMMENT_ERRORS = require( '../../config/error-messages-config' ).COMMENT;
-const OPTION_ERRORS = require( '../../config/error-messages-config' ).OPTION;
-const FormSubmit = require( '../../organisms/FormSubmit.js' );
+import { COMMENT, OPTION } from '../../config/error-messages-config';
+import FormSubmit from '../../organisms/FormSubmit.js';
+
 const BASE_CLASS = 'o-feedback';
 let requiredKey = 'REQUIRED';
 let UNDEFINED;
@@ -15,7 +15,7 @@ function validateFeedback( fields ) {
     if ( fields.comment.value ) {
       return UNDEFINED;
     } else if ( fields.comment.hasAttribute( 'required' ) ) {
-      return COMMENT_ERRORS[requiredKey];
+      return COMMENT[requiredKey];
     }
   }
   if ( fields.is_helpful ) {
@@ -24,7 +24,7 @@ function validateFeedback( fields ) {
         return UNDEFINED;
       }
     }
-    return OPTION_ERRORS[requiredKey];
+    return OPTION[requiredKey];
   }
   return UNDEFINED;
 }

--- a/cfgov/unprocessed/js/routes/on-demand/feedback-form.js
+++ b/cfgov/unprocessed/js/routes/on-demand/feedback-form.js
@@ -2,7 +2,7 @@
    Scripts for Feedback Form organism.
    ========================================================================== */
 
-import { COMMENT, OPTION } from '../../config/error-messages-config';
+import ERROR_MESSAGES from '../../config/error-messages-config';
 import FormSubmit from '../../organisms/FormSubmit.js';
 
 const BASE_CLASS = 'o-feedback';
@@ -15,7 +15,7 @@ function validateFeedback( fields ) {
     if ( fields.comment.value ) {
       return UNDEFINED;
     } else if ( fields.comment.hasAttribute( 'required' ) ) {
-      return COMMENT[requiredKey];
+      return ERROR_MESSAGES.COMMENT[requiredKey];
     }
   }
   if ( fields.is_helpful ) {
@@ -24,7 +24,7 @@ function validateFeedback( fields ) {
         return UNDEFINED;
       }
     }
-    return OPTION[requiredKey];
+    return ERROR_MESSAGES.OPTION[requiredKey];
   }
   return UNDEFINED;
 }

--- a/cfgov/unprocessed/js/routes/on-demand/filterable-list-controls.js
+++ b/cfgov/unprocessed/js/routes/on-demand/filterable-list-controls.js
@@ -2,8 +2,7 @@
    Scripts for Filterable List Controls organism
    ========================================================================== */
 
+import { instantiateAll } from '../../modules/util/atomic-helpers';
+import FilterableListControls from '../../organisms/FilterableListControls';
 
-const atomicHelpers = require( '../../modules/util/atomic-helpers' );
-const FilterableListControls = require( '../../organisms/FilterableListControls' );
-
-atomicHelpers.instantiateAll( '.o-filterable-list-controls', FilterableListControls );
+instantiateAll( '.o-filterable-list-controls', FilterableListControls );

--- a/cfgov/unprocessed/js/routes/on-demand/footer.js
+++ b/cfgov/unprocessed/js/routes/on-demand/footer.js
@@ -2,7 +2,7 @@
    Scripts for Footer organism.
    ========================================================================== */
 
+import Footer from '../../organisms/Footer.js';
 
-const Footer = require( '../../organisms/Footer.js' );
 const footer = new Footer( document.body );
 footer.init();

--- a/cfgov/unprocessed/js/routes/on-demand/header.js
+++ b/cfgov/unprocessed/js/routes/on-demand/header.js
@@ -2,8 +2,8 @@
    Scripts for Header organism.
    ========================================================================== */
 
+import Header from '../../organisms/Header.js';
 
-const Header = require( '../../organisms/Header.js' );
 const header = new Header( document.body );
 // Initialize header by passing it reference to global overlay atom.
 header.init( document.body.querySelector( '.a-overlay' ) );

--- a/cfgov/unprocessed/js/routes/on-demand/mortgage-performance-trends.js
+++ b/cfgov/unprocessed/js/routes/on-demand/mortgage-performance-trends.js
@@ -11,6 +11,10 @@
    MP uses a custom API so point our charts to it instead. */
 window.CFPB_CHART_DATA_SOURCE_BASE = '/data-research/mortgages/api/v1/';
 
+// Polyfill Promise for IE10/11
+import 'core-js/es6/promise';
+import 'core-js/es6/object';
+
 import { Chart, Map } from '../../organisms/MortgagePerformanceTrends';
 
 const chart = new Chart( { container: 'mp-line-chart-container' } );

--- a/cfgov/unprocessed/js/routes/on-demand/mortgage-performance-trends.js
+++ b/cfgov/unprocessed/js/routes/on-demand/mortgage-performance-trends.js
@@ -3,7 +3,6 @@
    Scripts for `/data-research/mortgage-performance-trends/`.
    ========================================================================== */
 
-
 /* To aid debugging, uncomment the below line.
    It will enable console logging of state changes (except in IE).
    window.MP_DEBUG = window.navigator.userAgent.indexOf('MSIE ') === -1; */
@@ -12,7 +11,7 @@
    MP uses a custom API so point our charts to it instead. */
 window.CFPB_CHART_DATA_SOURCE_BASE = '/data-research/mortgages/api/v1/';
 
-const MortgagePerformanceTrends = require( '../../organisms/MortgagePerformanceTrends' );
+import MortgagePerformanceTrends from '../../organisms/MortgagePerformanceTrends';
 
 const chart = new MortgagePerformanceTrends.Chart( { container: 'mp-line-chart-container' } );
 const map = new MortgagePerformanceTrends.Map( { container: 'mp-map-container' } );

--- a/cfgov/unprocessed/js/routes/on-demand/mortgage-performance-trends.js
+++ b/cfgov/unprocessed/js/routes/on-demand/mortgage-performance-trends.js
@@ -11,7 +11,7 @@
    MP uses a custom API so point our charts to it instead. */
 window.CFPB_CHART_DATA_SOURCE_BASE = '/data-research/mortgages/api/v1/';
 
-import MortgagePerformanceTrends from '../../organisms/MortgagePerformanceTrends';
+import { Chart, Map } from '../../organisms/MortgagePerformanceTrends';
 
-const chart = new MortgagePerformanceTrends.Chart( { container: 'mp-line-chart-container' } );
-const map = new MortgagePerformanceTrends.Map( { container: 'mp-map-container' } );
+const chart = new Chart( { container: 'mp-line-chart-container' } );
+const map = new Map( { container: 'mp-map-container' } );

--- a/cfgov/unprocessed/js/routes/on-demand/notification.js
+++ b/cfgov/unprocessed/js/routes/on-demand/notification.js
@@ -2,8 +2,7 @@
    Scripts for Notification molecule.
    ========================================================================== */
 
+import { instantiateAll } from '../../modules/util/atomic-helpers';
+import Notification from '../../molecules/Notification';
 
-const atomicHelpers = require( '../../modules/util/atomic-helpers' );
-const Notification = require( '../../molecules/Notification' );
-
-atomicHelpers.instantiateAll( '.m-notification', Notification );
+instantiateAll( '.m-notification', Notification );

--- a/cfgov/unprocessed/js/routes/on-demand/table.js
+++ b/cfgov/unprocessed/js/routes/on-demand/table.js
@@ -2,6 +2,5 @@
    Scripts for Line Chart molecule.
    ========================================================================== */
 
-
 // See https://github.com/cfpb/capital-framework/
 require( 'cf-tables/src/Table' ).init();

--- a/cfgov/unprocessed/js/routes/on-demand/turbolinks.js
+++ b/cfgov/unprocessed/js/routes/on-demand/turbolinks.js
@@ -3,6 +3,6 @@
    https://github.com/turbolinks/turbolinks
    ========================================================================= */
 
-const Turbolinks = require( 'turbolinks' );
+import * as Turbolinks from 'turbolinks';
 
 Turbolinks.start();

--- a/cfgov/unprocessed/js/routes/on-demand/video-player.js
+++ b/cfgov/unprocessed/js/routes/on-demand/video-player.js
@@ -2,4 +2,5 @@
    Scripts for Video Player module.
    ========================================================================== */
 
-require( '../../modules/YoutubePlayer' ).init( '.video-player__youtube' );
+import YoutubePlayer from '../../modules/YoutubePlayer';
+YoutubePlayer.init( '.video-player__youtube' );

--- a/cfgov/unprocessed/js/routes/on-demand/video-player.js
+++ b/cfgov/unprocessed/js/routes/on-demand/video-player.js
@@ -2,5 +2,4 @@
    Scripts for Video Player module.
    ========================================================================== */
 
-
 require( '../../modules/YoutubePlayer' ).init( '.video-player__youtube' );

--- a/config/webpack-config.js
+++ b/config/webpack-config.js
@@ -2,12 +2,10 @@
    Settings for webpack JavaScript bundling system.
    ========================================================================== */
 
-
 const BROWSER_LIST = require( '../config/browser-list-config' );
 const envvars = require( '../config/environment' ).envvars;
 const webpack = require( 'webpack' );
 const UglifyWebpackPlugin = require( 'uglifyjs-webpack-plugin' );
-
 
 // Constants
 const COMMON_BUNDLE_NAME = 'common.js';
@@ -29,7 +27,7 @@ const COMMON_MODULE_CONFIG = {
     use: {
       loader: 'babel-loader?cacheDirectory=true',
       options: {
-        presets: [ [ 'babel-preset-env', {
+        presets: [ [ '@babel/preset-env', {
           targets: {
             browsers: BROWSER_LIST.LAST_2
           },

--- a/docs/development-tips.md
+++ b/docs/development-tips.md
@@ -21,7 +21,7 @@ The structure looks like this:
 #### Browserlist
 - Apps may include a
   [browserlist config](https://github.com/browserslist/browserslist#config-file)
-  file, which is automatically picked up by `babel-preset-env` inside the
+  file, which is automatically picked up by `@babel/preset-env` inside the
   webpack config, if no `browsers` option is supplied.
 
 #### Templates

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,27 +13,45 @@
       }
     },
     "@babel/core": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.1.2.tgz",
-      "integrity": "sha512-IFeSSnjXdhDaoysIlev//UzHZbdEmm7D0EIH2qtse9xK7mXEZQpYjs2P00XlP1qYsYvid79p+Zgg6tz1mp6iVw==",
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.1.6.tgz",
+      "integrity": "sha512-Hz6PJT6e44iUNpAn8AoyAs6B3bl60g7MJQaI0rZEar6ECzh6+srYO1xlIdssio34mPaUtAb1y+XlkkSJzok3yw==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "7.0.0",
-        "@babel/generator": "7.1.3",
-        "@babel/helpers": "7.1.2",
-        "@babel/parser": "7.1.3",
+        "@babel/generator": "7.1.6",
+        "@babel/helpers": "7.1.5",
+        "@babel/parser": "7.1.6",
         "@babel/template": "7.1.2",
-        "@babel/traverse": "7.1.4",
-        "@babel/types": "7.1.3",
+        "@babel/traverse": "7.1.6",
+        "@babel/types": "7.1.6",
         "convert-source-map": "1.6.0",
-        "debug": "3.2.6",
-        "json5": "0.5.1",
+        "debug": "4.1.0",
+        "json5": "2.1.0",
         "lodash": "4.17.11",
         "resolve": "1.8.1",
         "semver": "5.6.0",
         "source-map": "0.5.7"
       },
       "dependencies": {
+        "debug": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.0.tgz",
+          "integrity": "sha512-heNPJUJIqC+xB6ayLAMHaIrmN9HKa7aQO8MGqKpvCA+uJYVcvR6l5kgdrhRuwPFHU7P5/A1w0BjByPHwpfTDKg==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.1"
+          }
+        },
+        "json5": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.0.tgz",
+          "integrity": "sha512-8Mh9h6xViijj36g7Dxi+Y4S6hNGV96vcJZr/SrlHh1LR/pEn/8j/+qIBbs44YKl69Lrfctp4QD+AdWLTMqEZAQ==",
+          "dev": true,
+          "requires": {
+            "minimist": "1.2.0"
+          }
+        },
         "source-map": {
           "version": "0.5.7",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
@@ -43,13 +61,13 @@
       }
     },
     "@babel/generator": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.1.3.tgz",
-      "integrity": "sha512-ZoCZGcfIJFJuZBqxcY9OjC1KW2lWK64qrX1o4UYL3yshVhwKFYgzpWZ0vvtGMNJdTlvkw0W+HR1VnYN8q3QPFQ==",
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.1.6.tgz",
+      "integrity": "sha512-brwPBtVvdYdGxtenbQgfCdDPmtkmUBZPjUoK5SXJEBuHaA5BCubh9ly65fzXz7R6o5rA76Rs22ES8Z+HCc0YIQ==",
       "dev": true,
       "requires": {
-        "@babel/types": "7.1.3",
-        "jsesc": "2.5.1",
+        "@babel/types": "7.1.6",
+        "jsesc": "2.5.2",
         "lodash": "4.17.11",
         "source-map": "0.5.7",
         "trim-right": "1.0.1"
@@ -69,7 +87,7 @@
       "integrity": "sha512-3UYcJUj9kvSLbLbUIfQTqzcy5VX7GRZ/CCDrnOaZorFFM01aXp1+GJwuFGV4NDDoAS+mOUyHcO6UD/RfqOks3Q==",
       "dev": true,
       "requires": {
-        "@babel/types": "7.1.3"
+        "@babel/types": "7.1.6"
       }
     },
     "@babel/helper-builder-binary-assignment-operator-visitor": {
@@ -79,7 +97,7 @@
       "dev": true,
       "requires": {
         "@babel/helper-explode-assignable-expression": "7.1.0",
-        "@babel/types": "7.1.3"
+        "@babel/types": "7.1.6"
       }
     },
     "@babel/helper-call-delegate": {
@@ -89,8 +107,8 @@
       "dev": true,
       "requires": {
         "@babel/helper-hoist-variables": "7.0.0",
-        "@babel/traverse": "7.1.4",
-        "@babel/types": "7.1.3"
+        "@babel/traverse": "7.1.6",
+        "@babel/types": "7.1.6"
       }
     },
     "@babel/helper-define-map": {
@@ -100,7 +118,7 @@
       "dev": true,
       "requires": {
         "@babel/helper-function-name": "7.1.0",
-        "@babel/types": "7.1.3",
+        "@babel/types": "7.1.6",
         "lodash": "4.17.11"
       }
     },
@@ -110,8 +128,8 @@
       "integrity": "sha512-NRQpfHrJ1msCHtKjbzs9YcMmJZOg6mQMmGRB+hbamEdG5PNpaSm95275VD92DvJKuyl0s2sFiDmMZ+EnnvufqA==",
       "dev": true,
       "requires": {
-        "@babel/traverse": "7.1.4",
-        "@babel/types": "7.1.3"
+        "@babel/traverse": "7.1.6",
+        "@babel/types": "7.1.6"
       }
     },
     "@babel/helper-function-name": {
@@ -122,7 +140,7 @@
       "requires": {
         "@babel/helper-get-function-arity": "7.0.0",
         "@babel/template": "7.1.2",
-        "@babel/types": "7.1.3"
+        "@babel/types": "7.1.6"
       }
     },
     "@babel/helper-get-function-arity": {
@@ -131,7 +149,7 @@
       "integrity": "sha512-r2DbJeg4svYvt3HOS74U4eWKsUAMRH01Z1ds1zx8KNTPtpTL5JAsdFv8BNyOpVqdFhHkkRDIg5B4AsxmkjAlmQ==",
       "dev": true,
       "requires": {
-        "@babel/types": "7.1.3"
+        "@babel/types": "7.1.6"
       }
     },
     "@babel/helper-hoist-variables": {
@@ -140,7 +158,7 @@
       "integrity": "sha512-Ggv5sldXUeSKsuzLkddtyhyHe2YantsxWKNi7A+7LeD12ExRDWTRk29JCXpaHPAbMaIPZSil7n+lq78WY2VY7w==",
       "dev": true,
       "requires": {
-        "@babel/types": "7.1.3"
+        "@babel/types": "7.1.6"
       }
     },
     "@babel/helper-member-expression-to-functions": {
@@ -149,7 +167,7 @@
       "integrity": "sha512-avo+lm/QmZlv27Zsi0xEor2fKcqWG56D5ae9dzklpIaY7cQMK5N8VSpaNVPPagiqmy7LrEjK1IWdGMOqPu5csg==",
       "dev": true,
       "requires": {
-        "@babel/types": "7.1.3"
+        "@babel/types": "7.1.6"
       }
     },
     "@babel/helper-module-imports": {
@@ -158,7 +176,7 @@
       "integrity": "sha512-aP/hlLq01DWNEiDg4Jn23i+CXxW/owM4WpDLFUbpjxe4NS3BhLVZQ5i7E0ZrxuQ/vwekIeciyamgB1UIYxxM6A==",
       "dev": true,
       "requires": {
-        "@babel/types": "7.1.3"
+        "@babel/types": "7.1.6"
       }
     },
     "@babel/helper-module-transforms": {
@@ -171,7 +189,7 @@
         "@babel/helper-simple-access": "7.1.0",
         "@babel/helper-split-export-declaration": "7.0.0",
         "@babel/template": "7.1.2",
-        "@babel/types": "7.1.3",
+        "@babel/types": "7.1.6",
         "lodash": "4.17.11"
       }
     },
@@ -181,7 +199,7 @@
       "integrity": "sha512-u8nd9NQePYNQV8iPWu/pLLYBqZBa4ZaY1YWRFMuxrid94wKI1QNt67NEZ7GAe5Kc/0LLScbim05xZFWkAdrj9g==",
       "dev": true,
       "requires": {
-        "@babel/types": "7.1.3"
+        "@babel/types": "7.1.6"
       }
     },
     "@babel/helper-plugin-utils": {
@@ -208,8 +226,8 @@
         "@babel/helper-annotate-as-pure": "7.0.0",
         "@babel/helper-wrap-function": "7.1.0",
         "@babel/template": "7.1.2",
-        "@babel/traverse": "7.1.4",
-        "@babel/types": "7.1.3"
+        "@babel/traverse": "7.1.6",
+        "@babel/types": "7.1.6"
       }
     },
     "@babel/helper-replace-supers": {
@@ -220,8 +238,8 @@
       "requires": {
         "@babel/helper-member-expression-to-functions": "7.0.0",
         "@babel/helper-optimise-call-expression": "7.0.0",
-        "@babel/traverse": "7.1.4",
-        "@babel/types": "7.1.3"
+        "@babel/traverse": "7.1.6",
+        "@babel/types": "7.1.6"
       }
     },
     "@babel/helper-simple-access": {
@@ -231,7 +249,7 @@
       "dev": true,
       "requires": {
         "@babel/template": "7.1.2",
-        "@babel/types": "7.1.3"
+        "@babel/types": "7.1.6"
       }
     },
     "@babel/helper-split-export-declaration": {
@@ -240,7 +258,7 @@
       "integrity": "sha512-MXkOJqva62dfC0w85mEf/LucPPS/1+04nmmRMPEBUB++hiiThQ2zPtX/mEWQ3mtzCEjIJvPY8nuwxXtQeQwUag==",
       "dev": true,
       "requires": {
-        "@babel/types": "7.1.3"
+        "@babel/types": "7.1.6"
       }
     },
     "@babel/helper-wrap-function": {
@@ -251,19 +269,19 @@
       "requires": {
         "@babel/helper-function-name": "7.1.0",
         "@babel/template": "7.1.2",
-        "@babel/traverse": "7.1.4",
-        "@babel/types": "7.1.3"
+        "@babel/traverse": "7.1.6",
+        "@babel/types": "7.1.6"
       }
     },
     "@babel/helpers": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.1.2.tgz",
-      "integrity": "sha512-Myc3pUE8eswD73aWcartxB16K6CGmHDv9KxOmD2CeOs/FaEAQodr3VYGmlvOmog60vNQ2w8QbatuahepZwrHiA==",
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.1.5.tgz",
+      "integrity": "sha512-2jkcdL02ywNBry1YNFAH/fViq4fXG0vdckHqeJk+75fpQ2OH+Az6076tX/M0835zA45E0Cqa6pV5Kiv9YOqjEg==",
       "dev": true,
       "requires": {
         "@babel/template": "7.1.2",
-        "@babel/traverse": "7.1.4",
-        "@babel/types": "7.1.3"
+        "@babel/traverse": "7.1.6",
+        "@babel/types": "7.1.6"
       }
     },
     "@babel/highlight": {
@@ -286,9 +304,9 @@
       }
     },
     "@babel/parser": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.1.3.tgz",
-      "integrity": "sha512-gqmspPZOMW3MIRb9HlrnbZHXI1/KHTOroBwN1NcLL6pWxzqzEKGvRTq0W/PxS45OtQGbaFikSQpkS5zbnsQm2w==",
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.1.6.tgz",
+      "integrity": "sha512-dWP6LJm9nKT6ALaa+bnL247GHHMWir3vSlZ2+IHgHgktZQx0L3Uvq2uAWcuzIe+fujRsYWBW2q622C5UvGK9iQ==",
       "dev": true
     },
     "@babel/plugin-proposal-async-generator-functions": {
@@ -409,9 +427,9 @@
       }
     },
     "@babel/plugin-transform-block-scoping": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.0.0.tgz",
-      "integrity": "sha512-GWEMCrmHQcYWISilUrk9GDqH4enf3UmhOEbNbNrlNAX1ssH3MsS1xLOS6rdjRVPgA7XXVPn87tRkdTEoA/dxEg==",
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.1.5.tgz",
+      "integrity": "sha512-jlYcDrz+5ayWC7mxgpn1Wj8zj0mmjCT2w0mPIMSwO926eXBRxpEgoN/uQVRBfjtr8ayjcmS+xk2G1jaP8JjMJQ==",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "7.0.0",
@@ -431,7 +449,7 @@
         "@babel/helper-plugin-utils": "7.0.0",
         "@babel/helper-replace-supers": "7.1.0",
         "@babel/helper-split-export-declaration": "7.0.0",
-        "globals": "11.8.0"
+        "globals": "11.9.0"
       }
     },
     "@babel/plugin-transform-computed-properties": {
@@ -588,17 +606,6 @@
       "dev": true,
       "requires": {
         "regenerator-transform": "0.13.3"
-      },
-      "dependencies": {
-        "regenerator-transform": {
-          "version": "0.13.3",
-          "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.13.3.tgz",
-          "integrity": "sha512-5ipTrZFSq5vU2YoGoww4uaRVAK4wyYC4TSICibbfEPOruUu8FFP7ErV0BjmbIOEpn3O/k9na9UEdYR/3m7N6uA==",
-          "dev": true,
-          "requires": {
-            "private": "0.1.8"
-          }
-        }
       }
     },
     "@babel/plugin-transform-shorthand-properties": {
@@ -660,9 +667,9 @@
       }
     },
     "@babel/preset-env": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.1.0.tgz",
-      "integrity": "sha512-ZLVSynfAoDHB/34A17/JCZbyrzbQj59QC1Anyueb4Bwjh373nVPq5/HMph0z+tCmcDjXDe+DlKQq9ywQuvWrQg==",
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.1.6.tgz",
+      "integrity": "sha512-YIBfpJNQMBkb6MCkjz/A9J76SNCSuGVamOVBgoUkLzpJD/z8ghHi9I42LQ4pulVX68N/MmImz6ZTixt7Azgexw==",
       "dev": true,
       "requires": {
         "@babel/helper-module-imports": "7.0.0",
@@ -678,7 +685,7 @@
         "@babel/plugin-transform-arrow-functions": "7.0.0",
         "@babel/plugin-transform-async-to-generator": "7.1.0",
         "@babel/plugin-transform-block-scoped-functions": "7.0.0",
-        "@babel/plugin-transform-block-scoping": "7.0.0",
+        "@babel/plugin-transform-block-scoping": "7.1.5",
         "@babel/plugin-transform-classes": "7.1.0",
         "@babel/plugin-transform-computed-properties": "7.0.0",
         "@babel/plugin-transform-destructuring": "7.1.3",
@@ -728,31 +735,42 @@
       "dev": true,
       "requires": {
         "@babel/code-frame": "7.0.0",
-        "@babel/parser": "7.1.3",
-        "@babel/types": "7.1.3"
+        "@babel/parser": "7.1.6",
+        "@babel/types": "7.1.6"
       }
     },
     "@babel/traverse": {
-      "version": "7.1.4",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.1.4.tgz",
-      "integrity": "sha512-my9mdrAIGdDiSVBuMjpn/oXYpva0/EZwWL3sm3Wcy/AVWO2eXnsoZruOT9jOGNRXU8KbCIu5zsKnXcAJ6PcV6Q==",
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.1.6.tgz",
+      "integrity": "sha512-CXedit6GpISz3sC2k2FsGCUpOhUqKdyL0lqNrImQojagnUMXf8hex4AxYFRuMkNGcvJX5QAFGzB5WJQmSv8SiQ==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "7.0.0",
-        "@babel/generator": "7.1.3",
+        "@babel/generator": "7.1.6",
         "@babel/helper-function-name": "7.1.0",
         "@babel/helper-split-export-declaration": "7.0.0",
-        "@babel/parser": "7.1.3",
-        "@babel/types": "7.1.3",
-        "debug": "3.2.6",
-        "globals": "11.8.0",
+        "@babel/parser": "7.1.6",
+        "@babel/types": "7.1.6",
+        "debug": "4.1.0",
+        "globals": "11.9.0",
         "lodash": "4.17.11"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.0.tgz",
+          "integrity": "sha512-heNPJUJIqC+xB6ayLAMHaIrmN9HKa7aQO8MGqKpvCA+uJYVcvR6l5kgdrhRuwPFHU7P5/A1w0BjByPHwpfTDKg==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.1"
+          }
+        }
       }
     },
     "@babel/types": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.1.3.tgz",
-      "integrity": "sha512-RpPOVfK+yatXyn8n4PB1NW6k9qjinrXrRR8ugBN8fD6hCy5RXI6PSbVqpOJBO9oSaY7Nom4ohj35feb0UR9hSA==",
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.1.6.tgz",
+      "integrity": "sha512-DMiUzlY9DSjVsOylJssxLHSgj6tWM9PRFJOGW/RaOglVOK9nzTxoOMfTfRQXGUCUQ/HmlG2efwC+XqUEJ5ay4w==",
       "dev": true,
       "requires": {
         "esutils": "2.0.2",
@@ -769,7 +787,18 @@
         "css": "2.2.4",
         "normalize-path": "2.1.1",
         "source-map": "0.6.1",
-        "through2": "2.0.4"
+        "through2": "2.0.5"
+      },
+      "dependencies": {
+        "through2": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+          "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+          "requires": {
+            "readable-stream": "2.3.6",
+            "xtend": "4.0.1"
+          }
+        }
       }
     },
     "@gulp-sourcemaps/map-sources": {
@@ -778,7 +807,18 @@
       "integrity": "sha1-iQrnxdjId/bThIYCFazp1+yUW9o=",
       "requires": {
         "normalize-path": "2.1.1",
-        "through2": "2.0.4"
+        "through2": "2.0.5"
+      },
+      "dependencies": {
+        "through2": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+          "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+          "requires": {
+            "readable-stream": "2.3.6",
+            "xtend": "4.0.1"
+          }
+        }
       }
     },
     "@mrmlnc/readdir-enhanced": {
@@ -1026,12 +1066,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
       "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
-    },
-    "accessibility-developer-tools": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/accessibility-developer-tools/-/accessibility-developer-tools-2.12.0.tgz",
-      "integrity": "sha1-PaDM6dbsY3OWS4TzXbfPw996tRQ=",
-      "dev": true
     },
     "accord": {
       "version": "0.29.0",
@@ -1904,23 +1938,6 @@
       "resolved": "http://registry.npmjs.org/axe-core/-/axe-core-3.0.0-beta.2.tgz",
       "integrity": "sha512-JyMXnHDuzr6hei+mINWsR/iEyPBFSjpgF4/lUijO7QDGVKtTmdpDxc2+7X/xW+rPIwhcd72euJ2UunbRXF+1Eg==",
       "dev": true
-    },
-    "axe-webdriverjs": {
-      "version": "0.2.0",
-      "resolved": "http://registry.npmjs.org/axe-webdriverjs/-/axe-webdriverjs-0.2.0.tgz",
-      "integrity": "sha1-XjHtr26bozRCdiz9hd46B0c8EVU=",
-      "dev": true,
-      "requires": {
-        "axe-core": "1.1.1"
-      },
-      "dependencies": {
-        "axe-core": {
-          "version": "1.1.1",
-          "resolved": "http://registry.npmjs.org/axe-core/-/axe-core-1.1.1.tgz",
-          "integrity": "sha1-rp2l2oq08QQZB/H12N/jnJRqksU=",
-          "dev": true
-        }
-      }
     },
     "axios": {
       "version": "0.17.1",
@@ -4879,8 +4896,20 @@
             "convert-source-map": "1.6.0",
             "graceful-fs": "4.1.11",
             "strip-bom": "2.0.0",
-            "through2": "2.0.4",
+            "through2": "2.0.5",
             "vinyl": "1.2.0"
+          },
+          "dependencies": {
+            "through2": {
+              "version": "2.0.5",
+              "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+              "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+              "dev": true,
+              "requires": {
+                "readable-stream": "2.3.6",
+                "xtend": "4.0.1"
+              }
+            }
           }
         },
         "is-extglob": {
@@ -4971,10 +5000,22 @@
             "readable-stream": "2.3.6",
             "strip-bom": "2.0.0",
             "strip-bom-stream": "1.0.0",
-            "through2": "2.0.4",
+            "through2": "2.0.5",
             "through2-filter": "2.0.0",
             "vali-date": "1.0.0",
             "vinyl": "1.2.0"
+          },
+          "dependencies": {
+            "through2": {
+              "version": "2.0.5",
+              "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+              "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+              "dev": true,
+              "requires": {
+                "readable-stream": "2.3.6",
+                "xtend": "4.0.1"
+              }
+            }
           }
         }
       }
@@ -5232,7 +5273,7 @@
         "read-all-stream": "3.1.0",
         "stat-mode": "0.2.2",
         "strip-dirs": "1.1.1",
-        "through2": "2.0.4",
+        "through2": "2.0.5",
         "vinyl": "1.2.0",
         "yauzl": "2.10.0"
       },
@@ -5254,6 +5295,16 @@
           "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
           "integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ=",
           "dev": true
+        },
+        "through2": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+          "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+          "dev": true,
+          "requires": {
+            "readable-stream": "2.3.6",
+            "xtend": "4.0.1"
+          }
         },
         "vinyl": {
           "version": "1.2.0",
@@ -5705,8 +5756,20 @@
             "convert-source-map": "1.6.0",
             "graceful-fs": "4.1.11",
             "strip-bom": "2.0.0",
-            "through2": "2.0.4",
+            "through2": "2.0.5",
             "vinyl": "1.2.0"
+          },
+          "dependencies": {
+            "through2": {
+              "version": "2.0.5",
+              "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+              "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+              "dev": true,
+              "requires": {
+                "readable-stream": "2.3.6",
+                "xtend": "4.0.1"
+              }
+            }
           }
         },
         "is-extglob": {
@@ -5797,10 +5860,22 @@
             "readable-stream": "2.3.6",
             "strip-bom": "2.0.0",
             "strip-bom-stream": "1.0.0",
-            "through2": "2.0.4",
+            "through2": "2.0.5",
             "through2-filter": "2.0.0",
             "vali-date": "1.0.0",
             "vinyl": "1.2.0"
+          },
+          "dependencies": {
+            "through2": {
+              "version": "2.0.5",
+              "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+              "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+              "dev": true,
+              "requires": {
+                "readable-stream": "2.3.6",
+                "xtend": "4.0.1"
+              }
+            }
           }
         }
       }
@@ -7405,7 +7480,18 @@
       "integrity": "sha1-C3gV/DIBxqaeFNuYzgmMFpNSWes=",
       "requires": {
         "graceful-fs": "4.1.11",
-        "through2": "2.0.4"
+        "through2": "2.0.5"
+      },
+      "dependencies": {
+        "through2": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+          "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+          "requires": {
+            "readable-stream": "2.3.6",
+            "xtend": "4.0.1"
+          }
+        }
       }
     },
     "fs-promise": {
@@ -8281,9 +8367,9 @@
       }
     },
     "globals": {
-      "version": "11.8.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-11.8.0.tgz",
-      "integrity": "sha512-io6LkyPVuzCHBSQV9fmOwxZkUk6nIaGmxheLDgmuFv89j0fm2aqDbIXKAGfzCMHqz3HLF2Zf8WSG6VqMh2qFmA==",
+      "version": "11.9.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-11.9.0.tgz",
+      "integrity": "sha512-5cJVtyXWH8PiJPVLZzzoIizXx944O4OmRro5MWKx5fT4MgcN7OfaMutPeaTdJCCURwbWdhhcCWcKIffPnmTzBg==",
       "dev": true
     },
     "globby": {
@@ -8543,7 +8629,7 @@
         "pify": "3.0.0",
         "plugin-error": "0.1.2",
         "replace-ext": "1.0.0",
-        "through2": "2.0.4",
+        "through2": "2.0.5",
         "touch": "3.1.0"
       },
       "dependencies": {
@@ -8590,6 +8676,15 @@
             "arr-union": "2.1.0",
             "extend-shallow": "1.1.4"
           }
+        },
+        "through2": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+          "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+          "requires": {
+            "readable-stream": "2.3.6",
+            "xtend": "4.0.1"
+          }
         }
       }
     },
@@ -8600,7 +8695,19 @@
       "requires": {
         "clean-css": "4.2.1",
         "plugin-error": "1.0.1",
+        "through2": "2.0.3",
         "vinyl-sourcemaps-apply": "0.2.1"
+      },
+      "dependencies": {
+        "through2": {
+          "version": "2.0.3",
+          "resolved": "http://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+          "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
+          "requires": {
+            "readable-stream": "2.3.6",
+            "xtend": "4.0.1"
+          }
+        }
       }
     },
     "gulp-concat": {
@@ -8609,8 +8716,19 @@
       "integrity": "sha1-Yz0WyV2IUEYorQJmVmPO5aR5M1M=",
       "requires": {
         "concat-with-sourcemaps": "1.1.0",
-        "through2": "2.0.4",
+        "through2": "2.0.5",
         "vinyl": "2.2.0"
+      },
+      "dependencies": {
+        "through2": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+          "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+          "requires": {
+            "readable-stream": "2.3.6",
+            "xtend": "4.0.1"
+          }
+        }
       }
     },
     "gulp-decompress": {
@@ -8643,7 +8761,18 @@
       "requires": {
         "concat-with-sourcemaps": "1.1.0",
         "lodash.template": "4.4.0",
-        "through2": "2.0.4"
+        "through2": "2.0.5"
+      },
+      "dependencies": {
+        "through2": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+          "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+          "requires": {
+            "readable-stream": "2.3.6",
+            "xtend": "4.0.1"
+          }
+        }
       }
     },
     "gulp-imagemin": {
@@ -8681,7 +8810,7 @@
         "object-assign": "4.1.1",
         "plugin-error": "0.1.2",
         "replace-ext": "1.0.0",
-        "through2": "2.0.4",
+        "through2": "2.0.5",
         "vinyl-sourcemaps-apply": "0.2.1"
       },
       "dependencies": {
@@ -8744,6 +8873,15 @@
             "arr-union": "2.1.0",
             "extend-shallow": "1.1.4"
           }
+        },
+        "through2": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+          "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+          "requires": {
+            "readable-stream": "2.3.6",
+            "xtend": "4.0.1"
+          }
         }
       }
     },
@@ -8756,8 +8894,19 @@
         "fancy-log": "1.3.2",
         "lodash.defaults": "4.2.0",
         "modernizr": "3.6.0",
-        "through2": "2.0.4",
+        "through2": "2.0.5",
         "vinyl": "2.2.0"
+      },
+      "dependencies": {
+        "through2": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+          "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+          "requires": {
+            "readable-stream": "2.3.6",
+            "xtend": "4.0.1"
+          }
+        }
       }
     },
     "gulp-newer": {
@@ -8827,7 +8976,7 @@
         "node-notifier": "5.3.0",
         "node.extend": "2.0.0",
         "plugin-error": "0.1.2",
-        "through2": "2.0.4"
+        "through2": "2.0.5"
       },
       "dependencies": {
         "arr-diff": {
@@ -8872,6 +9021,15 @@
             "arr-diff": "1.1.0",
             "arr-union": "2.1.0",
             "extend-shallow": "1.1.4"
+          }
+        },
+        "through2": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+          "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+          "requires": {
+            "readable-stream": "2.3.6",
+            "xtend": "4.0.1"
           }
         }
       }
@@ -8964,7 +9122,18 @@
         "graceful-fs": "4.1.11",
         "source-map": "0.6.1",
         "strip-bom-string": "1.0.0",
-        "through2": "2.0.4"
+        "through2": "2.0.5"
+      },
+      "dependencies": {
+        "through2": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+          "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+          "requires": {
+            "readable-stream": "2.3.6",
+            "xtend": "4.0.1"
+          }
+        }
       }
     },
     "gulp-uglify-es": {
@@ -9001,7 +9170,7 @@
         "multipipe": "0.1.2",
         "object-assign": "3.0.0",
         "replace-ext": "0.0.1",
-        "through2": "2.0.4",
+        "through2": "2.0.5",
         "vinyl": "0.5.3"
       },
       "dependencies": {
@@ -9080,6 +9249,16 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
           "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
           "dev": true
+        },
+        "through2": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+          "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+          "dev": true,
+          "requires": {
+            "readable-stream": "2.3.6",
+            "xtend": "4.0.1"
+          }
         },
         "vinyl": {
           "version": "0.5.3",
@@ -11791,9 +11970,9 @@
       }
     },
     "jsesc": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.1.tgz",
-      "integrity": "sha1-5CGiqOINawgZ3yiQj3glJrlt0f4=",
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+      "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
       "dev": true
     },
     "json-buffer": {
@@ -13326,7 +13505,18 @@
         "pump": "2.0.1",
         "pumpify": "1.5.1",
         "stream-each": "1.2.3",
-        "through2": "2.0.4"
+        "through2": "2.0.5"
+      },
+      "dependencies": {
+        "through2": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+          "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+          "requires": {
+            "readable-stream": "2.3.6",
+            "xtend": "4.0.1"
+          }
+        }
       }
     },
     "mixin-deep": {
@@ -15004,33 +15194,6 @@
         }
       }
     },
-    "protractor-accessibility-plugin": {
-      "version": "github:cfpb/protractor-accessibility-plugin#7319a881e222d9f3588f6d5d8a3d9848bc38c859",
-      "dev": true,
-      "requires": {
-        "accessibility-developer-tools": "2.12.0",
-        "axe-core": "2.6.1",
-        "axe-webdriverjs": "0.2.0",
-        "html-entities": "1.2.1",
-        "lodash": "3.10.1",
-        "q": "1.5.1",
-        "request": "2.88.0"
-      },
-      "dependencies": {
-        "axe-core": {
-          "version": "2.6.1",
-          "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-2.6.1.tgz",
-          "integrity": "sha512-QFfI3d+x/v92HJWGBaNfgrxdfon9/xXzd04YYfm5w5NJQOLex8qkJCctOt7+ky6e1l9zcQ5E7jsvbnTgQzyfTw==",
-          "dev": true
-        },
-        "lodash": {
-          "version": "3.10.1",
-          "resolved": "http://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-          "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
-          "dev": true
-        }
-      }
-    },
     "protractor-cucumber-framework": {
       "version": "6.1.1",
       "resolved": "https://registry.npmjs.org/protractor-cucumber-framework/-/protractor-cucumber-framework-6.1.1.tgz",
@@ -15997,6 +16160,15 @@
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
       "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
     },
+    "regenerator-transform": {
+      "version": "0.13.3",
+      "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.13.3.tgz",
+      "integrity": "sha512-5ipTrZFSq5vU2YoGoww4uaRVAK4wyYC4TSICibbfEPOruUu8FFP7ErV0BjmbIOEpn3O/k9na9UEdYR/3m7N6uA==",
+      "dev": true,
+      "requires": {
+        "private": "0.1.8"
+      }
+    },
     "regex-cache": {
       "version": "0.4.4",
       "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
@@ -16071,7 +16243,7 @@
       "dependencies": {
         "jsesc": {
           "version": "0.5.0",
-          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+          "resolved": "http://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
           "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
           "dev": true
         }
@@ -16113,7 +16285,18 @@
       "requires": {
         "remove-bom-buffer": "3.0.0",
         "safe-buffer": "5.1.2",
-        "through2": "2.0.4"
+        "through2": "2.0.5"
+      },
+      "dependencies": {
+        "through2": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+          "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+          "requires": {
+            "readable-stream": "2.3.6",
+            "xtend": "4.0.1"
+          }
+        }
       }
     },
     "remove-trailing-separator": {
@@ -17216,9 +17399,9 @@
       }
     },
     "snyk": {
-      "version": "1.108.0",
-      "resolved": "https://registry.npmjs.org/snyk/-/snyk-1.108.0.tgz",
-      "integrity": "sha512-QKeERkklW4DFyd49sqbwZ4xNYXtHOPCcUjNUzDfcvXzNwyxfRKhTf43nmPw6lnIcgBesrY95hMozos4WmgYl3w==",
+      "version": "1.108.2",
+      "resolved": "https://registry.npmjs.org/snyk/-/snyk-1.108.2.tgz",
+      "integrity": "sha512-VfSHSRj4ISWf4EfySTdAVqUWnDspoFUaGs4uGp7FIbjZb35+JPaQ/hqgWKcDal+ZwTtzQvxKAdPsB3WUCBoSKg==",
       "dev": true,
       "requires": {
         "abbrev": "1.1.1",
@@ -17237,9 +17420,9 @@
         "recursive-readdir": "2.2.2",
         "semver": "5.6.0",
         "snyk-config": "2.2.0",
-        "snyk-docker-plugin": "1.12.1",
+        "snyk-docker-plugin": "1.12.2",
         "snyk-go-plugin": "1.6.0",
-        "snyk-gradle-plugin": "2.1.0",
+        "snyk-gradle-plugin": "2.1.1",
         "snyk-module": "1.9.1",
         "snyk-mvn-plugin": "2.0.0",
         "snyk-nodejs-lockfile-parser": "1.7.0",
@@ -17361,9 +17544,9 @@
       }
     },
     "snyk-docker-plugin": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-1.12.1.tgz",
-      "integrity": "sha512-9/k+tZORb0CUoE+nFvG+ADc6vzHAkgiGR/7aZ35vxpuc9vW37LFWjmXZAfyoiGNOn1ICrPxSxarah8YsFEwE8Q==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-1.12.2.tgz",
+      "integrity": "sha512-8bEn6tDSXPtNS6d1XRM6CSRMwM0bI3N0vRzcKVMZ9E52W9sIpv2E50noYjxcMpoRFxpLWAJ4WMtamcMtLPnNeQ==",
       "dev": true,
       "requires": {
         "debug": "3.2.6",
@@ -17382,9 +17565,9 @@
       }
     },
     "snyk-gradle-plugin": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/snyk-gradle-plugin/-/snyk-gradle-plugin-2.1.0.tgz",
-      "integrity": "sha512-9gYJluomFZ5kaww5FoBvp4zUIsr27pEJ12jQJaVf0FJ0BmyYHmbCoxvHdqjCSYS2fVtF+fmPnvw0XKQOIwA1SA==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/snyk-gradle-plugin/-/snyk-gradle-plugin-2.1.1.tgz",
+      "integrity": "sha512-aFeVC5y3XkJ5BxknHhtYo76as3xJbzSQlXACGZrQZGQ/w/UhNdM8VI1QB6Eq4uEzexleB/hcJwYxNmhI2CNCeA==",
       "dev": true,
       "requires": {
         "clone-deep": "0.3.0"
@@ -18392,9 +18575,10 @@
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
     },
     "through2": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.4.tgz",
-      "integrity": "sha512-q030OX7royN1Bo549nYMOpKwiGJIzUppv10IgB6ALN6DiJ/XgsRIehiz18x5RWCA3+s4G6ovKqtzgU+pYhjvvg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-3.0.0.tgz",
+      "integrity": "sha512-8B+sevlqP4OiCjonI1Zw03Sf8PuV1eRsYQgLad5eonILOdyeRsY27A/2Ze8IlvlMvq31OH+3fz/styI7Ya62yQ==",
+      "dev": true,
       "requires": {
         "readable-stream": "2.3.6",
         "xtend": "4.0.1"
@@ -18405,7 +18589,18 @@
       "resolved": "https://registry.npmjs.org/through2-concurrent/-/through2-concurrent-2.0.0.tgz",
       "integrity": "sha512-R5/jLkfMvdmDD+seLwN7vB+mhbqzWop5fAjx5IX8/yQq7VhBhzDmhXgaHAOnhnWkCpRMM7gToYHycB0CS/pd+A==",
       "requires": {
-        "through2": "2.0.4"
+        "through2": "2.0.5"
+      },
+      "dependencies": {
+        "through2": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+          "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+          "requires": {
+            "readable-stream": "2.3.6",
+            "xtend": "4.0.1"
+          }
+        }
       }
     },
     "through2-filter": {
@@ -18413,8 +18608,19 @@
       "resolved": "https://registry.npmjs.org/through2-filter/-/through2-filter-2.0.0.tgz",
       "integrity": "sha1-YLxVoNrLdghdsfna6Zq0P4PWIuw=",
       "requires": {
-        "through2": "2.0.4",
+        "through2": "2.0.5",
         "xtend": "4.0.1"
+      },
+      "dependencies": {
+        "through2": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+          "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+          "requires": {
+            "readable-stream": "2.3.6",
+            "xtend": "4.0.1"
+          }
+        }
       }
     },
     "thunkify": {
@@ -18544,7 +18750,18 @@
       "resolved": "https://registry.npmjs.org/to-through/-/to-through-2.0.0.tgz",
       "integrity": "sha1-/JKtq6ByZHvAtn1rA2ZKoZUJOvY=",
       "requires": {
-        "through2": "2.0.4"
+        "through2": "2.0.5"
+      },
+      "dependencies": {
+        "through2": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+          "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+          "requires": {
+            "readable-stream": "2.3.6",
+            "xtend": "4.0.1"
+          }
+        }
       }
     },
     "toml": {
@@ -19245,11 +19462,22 @@
         "remove-bom-buffer": "3.0.0",
         "remove-bom-stream": "1.2.0",
         "resolve-options": "1.1.0",
-        "through2": "2.0.4",
+        "through2": "2.0.5",
         "to-through": "2.0.0",
         "value-or-function": "3.0.0",
         "vinyl": "2.2.0",
         "vinyl-sourcemap": "1.1.0"
+      },
+      "dependencies": {
+        "through2": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+          "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+          "requires": {
+            "readable-stream": "2.3.6",
+            "xtend": "4.0.1"
+          }
+        }
       }
     },
     "vinyl-named": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3734,16 +3734,15 @@
       }
     },
     "cfpb-chart-builder": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/cfpb-chart-builder/-/cfpb-chart-builder-4.0.3.tgz",
-      "integrity": "sha512-KtFeDhTOz+E+UMUub4eosvkM8m4o8oatLPijfk+4BDzPLhs9iIFz8K8nwD/v1mzFs/5rIFHVwijQBWsdxGXijA==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/cfpb-chart-builder/-/cfpb-chart-builder-5.0.0.tgz",
+      "integrity": "sha512-3kpMHckSx4a7WAqLoP1tUS4JoE15F9Fpd8JdHT0jW1gi1Fu+wox2wiZRX8rhfiNTU8pT5E8oV7xaHfjTAoD80Q==",
       "requires": {
         "cf-core": "4.10.0",
         "cf-layout": "5.0.0",
         "cf-typography": "5.0.1",
-        "core-js": "2.5.7",
-        "highcharts": "git+https://github.com/cfpb/highcharts-dist.git#0c151c2eae85e2ffaef537ecea97769c082a2d50",
-        "xdr": "git+https://github.com/contolini/xdr.git#4f53e8dc68d14cd4a387874e75faae46c3a4961b"
+        "highcharts": "6.2.0",
+        "xdr": "0.5.3"
       },
       "dependencies": {
         "cf-core": {
@@ -3755,8 +3754,10 @@
             "normalize-legacy-addon": "0.1.0"
           }
         },
-        "xdr": {
-          "version": "git+https://github.com/contolini/xdr.git#4f53e8dc68d14cd4a387874e75faae46c3a4961b"
+        "highcharts": {
+          "version": "6.2.0",
+          "resolved": "https://registry.npmjs.org/highcharts/-/highcharts-6.2.0.tgz",
+          "integrity": "sha512-A4E89MA+kto8giic7zyLU6ZxfXnVeCUlKOyzFsah3+n4BROx4bgonl92KIBtwLud/mIWir8ahqhuhe2by9LakQ=="
         }
       }
     },
@@ -9469,9 +9470,6 @@
         "inherits": "2.0.3",
         "minimalistic-assert": "1.0.1"
       }
-    },
-    "highcharts": {
-      "version": "git+https://github.com/cfpb/highcharts-dist.git#0c151c2eae85e2ffaef537ecea97769c082a2d50"
     },
     "hmac-drbg": {
       "version": "1.0.1",
@@ -16243,7 +16241,7 @@
       "dependencies": {
         "jsesc": {
           "version": "0.5.0",
-          "resolved": "http://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
           "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
           "dev": true
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1027,12 +1027,6 @@
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
       "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
     },
-    "accessibility-developer-tools": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/accessibility-developer-tools/-/accessibility-developer-tools-2.12.0.tgz",
-      "integrity": "sha1-PaDM6dbsY3OWS4TzXbfPw996tRQ=",
-      "dev": true
-    },
     "accord": {
       "version": "0.29.0",
       "resolved": "https://registry.npmjs.org/accord/-/accord-0.29.0.tgz",
@@ -1904,23 +1898,6 @@
       "resolved": "http://registry.npmjs.org/axe-core/-/axe-core-3.0.0-beta.2.tgz",
       "integrity": "sha512-JyMXnHDuzr6hei+mINWsR/iEyPBFSjpgF4/lUijO7QDGVKtTmdpDxc2+7X/xW+rPIwhcd72euJ2UunbRXF+1Eg==",
       "dev": true
-    },
-    "axe-webdriverjs": {
-      "version": "0.2.0",
-      "resolved": "http://registry.npmjs.org/axe-webdriverjs/-/axe-webdriverjs-0.2.0.tgz",
-      "integrity": "sha1-XjHtr26bozRCdiz9hd46B0c8EVU=",
-      "dev": true,
-      "requires": {
-        "axe-core": "1.1.1"
-      },
-      "dependencies": {
-        "axe-core": {
-          "version": "1.1.1",
-          "resolved": "http://registry.npmjs.org/axe-core/-/axe-core-1.1.1.tgz",
-          "integrity": "sha1-rp2l2oq08QQZB/H12N/jnJRqksU=",
-          "dev": true
-        }
-      }
     },
     "axios": {
       "version": "0.17.1",
@@ -15001,33 +14978,6 @@
             "semver": "5.6.0",
             "xml2js": "0.4.19"
           }
-        }
-      }
-    },
-    "protractor-accessibility-plugin": {
-      "version": "github:cfpb/protractor-accessibility-plugin#7319a881e222d9f3588f6d5d8a3d9848bc38c859",
-      "dev": true,
-      "requires": {
-        "accessibility-developer-tools": "2.12.0",
-        "axe-core": "2.6.1",
-        "axe-webdriverjs": "0.2.0",
-        "html-entities": "1.2.1",
-        "lodash": "3.10.1",
-        "q": "1.5.1",
-        "request": "2.88.0"
-      },
-      "dependencies": {
-        "axe-core": {
-          "version": "2.6.1",
-          "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-2.6.1.tgz",
-          "integrity": "sha512-QFfI3d+x/v92HJWGBaNfgrxdfon9/xXzd04YYfm5w5NJQOLex8qkJCctOt7+ky6e1l9zcQ5E7jsvbnTgQzyfTw==",
-          "dev": true
-        },
-        "lodash": {
-          "version": "3.10.1",
-          "resolved": "http://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-          "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
-          "dev": true
         }
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1899,99 +1899,11 @@
         "is-buffer": "1.1.6"
       }
     },
-    "babel-code-frame": {
-      "version": "7.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-7.0.0-beta.3.tgz",
-      "integrity": "sha512-flMsJ9eSpShupt2Gwpka84DoMePvE4HlDObzdEc+1iNkacv3+NHlsJ7dMKmbnVA/AT22UhcGEBHwbJLoXWBO6Q==",
-      "dev": true,
-      "requires": {
-        "chalk": "2.4.1",
-        "esutils": "2.0.2",
-        "js-tokens": "3.0.2"
-      }
-    },
     "babel-core": {
-      "version": "7.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-7.0.0-beta.3.tgz",
-      "integrity": "sha512-zdng6WxI4cUjvstvFo/ke+hxohXCi/vxrMTM1S/bsAqnvKb+C+pHx78T3ZdJlWC3bGGxYqUnmM4p9VMzJ0uVVg==",
-      "dev": true,
-      "requires": {
-        "babel-code-frame": "7.0.0-beta.3",
-        "babel-generator": "7.0.0-beta.3",
-        "babel-helpers": "7.0.0-beta.3",
-        "babel-template": "7.0.0-beta.3",
-        "babel-traverse": "7.0.0-beta.3",
-        "babel-types": "7.0.0-beta.3",
-        "babylon": "7.0.0-beta.27",
-        "convert-source-map": "1.6.0",
-        "debug": "3.2.6",
-        "json5": "0.5.1",
-        "lodash": "4.17.11",
-        "micromatch": "2.3.11",
-        "resolve": "1.8.1",
-        "source-map": "0.5.7"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-          "dev": true
-        }
-      }
-    },
-    "babel-generator": {
-      "version": "7.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-7.0.0-beta.3.tgz",
-      "integrity": "sha512-Bok77tKwQZUVaLBRnDGDEaMZ4xEeyvzsgnCRxlVgfKmgn+vPxuka//ug3nrMmmgZ8TAMVPoXzeaAcs47lExrPg==",
-      "dev": true,
-      "requires": {
-        "babel-types": "7.0.0-beta.3",
-        "jsesc": "2.5.2",
-        "lodash": "4.17.11",
-        "source-map": "0.5.7",
-        "trim-right": "1.0.1"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-          "dev": true
-        }
-      }
-    },
-    "babel-helper-function-name": {
-      "version": "7.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-7.0.0-beta.3.tgz",
-      "integrity": "sha512-iMWYqwDarQOVlEGcK1MfbtK9vrFGs5Z4UQsdASJUHdhBp918EM5kndwriiIbhUX8gr2B/CEV/udJkFTrHsjdMQ==",
-      "dev": true,
-      "requires": {
-        "babel-helper-get-function-arity": "7.0.0-beta.3",
-        "babel-template": "7.0.0-beta.3",
-        "babel-traverse": "7.0.0-beta.3",
-        "babel-types": "7.0.0-beta.3"
-      }
-    },
-    "babel-helper-get-function-arity": {
-      "version": "7.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-7.0.0-beta.3.tgz",
-      "integrity": "sha512-ZkYFRMWKx1c9fUW72YNM3eieBG701CMbLjmLLWmJTTPc0F0kddS9Fwok26EAmndUAgD6kFdh7ms3PH94MdGuGQ==",
-      "dev": true,
-      "requires": {
-        "babel-types": "7.0.0-beta.3"
-      }
-    },
-    "babel-helpers": {
-      "version": "7.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-7.0.0-beta.3.tgz",
-      "integrity": "sha512-zNX7FgdXT8645igxTyAVIArMbxUsFl1w3K+v+SKlGbDocIVjWMnRszRfgVwJflzI11yE0kY+fy6SNfulykW8CA==",
-      "dev": true,
-      "requires": {
-        "babel-template": "7.0.0-beta.3",
-        "babel-traverse": "7.0.0-beta.3",
-        "babel-types": "7.0.0-beta.3"
-      }
+      "version": "7.0.0-bridge.0",
+      "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-7.0.0-bridge.0.tgz",
+      "integrity": "sha512-poPX9mZH/5CSanm50Q+1toVci6pv5KSRv/5TWCwtzQS5XEwn40BcCrgIeMFWP9CKKIniKXNxoIOnOq4VVlGXhg==",
+      "dev": true
     },
     "babel-jest": {
       "version": "23.6.0",
@@ -2049,6 +1961,12 @@
       "integrity": "sha1-5h+uBaHKiAGq3uV6bWa4zvr0QWc=",
       "dev": true
     },
+    "babel-plugin-syntax-object-rest-spread": {
+      "version": "6.13.0",
+      "resolved": "http://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
+      "integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U=",
+      "dev": true
+    },
     "babel-preset-jest": {
       "version": "23.2.0",
       "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-23.2.0.tgz",
@@ -2057,14 +1975,6 @@
       "requires": {
         "babel-plugin-jest-hoist": "23.2.0",
         "babel-plugin-syntax-object-rest-spread": "6.13.0"
-      },
-      "dependencies": {
-        "babel-plugin-syntax-object-rest-spread": {
-          "version": "6.13.0",
-          "resolved": "http://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
-          "integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U=",
-          "dev": true
-        }
       }
     },
     "babel-register": {
@@ -2277,60 +2187,6 @@
         "core-js": "2.5.7",
         "regenerator-runtime": "0.11.1"
       }
-    },
-    "babel-template": {
-      "version": "7.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-7.0.0-beta.3.tgz",
-      "integrity": "sha512-urJduLja89kSDGqY8ryw8iIwQnMl30IvhMtMNmDD7vBX0l0oylaLgK+7df/9ODX9vR/PhXuif6HYl5HlzAKXMg==",
-      "dev": true,
-      "requires": {
-        "babel-code-frame": "7.0.0-beta.3",
-        "babel-traverse": "7.0.0-beta.3",
-        "babel-types": "7.0.0-beta.3",
-        "babylon": "7.0.0-beta.27",
-        "lodash": "4.17.11"
-      }
-    },
-    "babel-traverse": {
-      "version": "7.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-7.0.0-beta.3.tgz",
-      "integrity": "sha512-xyh/aPYuedMAfQlSj2kjHjsEmY5/Dpxs576L05DySAVMrV+ADX6l4mTOLysAEGwJfkePJlDLhFuS6SKaxv1V7w==",
-      "dev": true,
-      "requires": {
-        "babel-code-frame": "7.0.0-beta.3",
-        "babel-helper-function-name": "7.0.0-beta.3",
-        "babel-types": "7.0.0-beta.3",
-        "babylon": "7.0.0-beta.27",
-        "debug": "3.2.6",
-        "globals": "10.4.0",
-        "invariant": "2.2.4",
-        "lodash": "4.17.11"
-      },
-      "dependencies": {
-        "globals": {
-          "version": "10.4.0",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-10.4.0.tgz",
-          "integrity": "sha512-uNUtxIZpGyuaq+5BqGGQHsL4wUlJAXRqOm6g3Y48/CWNGTLONgBibI0lh6lGxjR2HljFYUfszb+mk4WkgMntsA==",
-          "dev": true
-        }
-      }
-    },
-    "babel-types": {
-      "version": "7.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-7.0.0-beta.3.tgz",
-      "integrity": "sha512-36k8J+byAe181OmCMawGhw+DtKO7AwexPVtsPXoMfAkjtZgoCX3bEuHWfdE5sYxRM8dojvtG/+O08M0Z/YDC6w==",
-      "dev": true,
-      "requires": {
-        "esutils": "2.0.2",
-        "lodash": "4.17.11",
-        "to-fast-properties": "2.0.0"
-      }
-    },
-    "babylon": {
-      "version": "7.0.0-beta.27",
-      "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.27.tgz",
-      "integrity": "sha512-ksRx+r8eFIfdt63MCgLc9VxGL7W3jcyveQvMpNMVHgW+eb9mq3Xbm45FLCNkw8h92RvoNp4uuiwzcCEwxjDBZg==",
-      "dev": true
     },
     "bach": {
       "version": "1.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",
       "integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
-      "dev": true,
       "requires": {
         "@babel/highlight": "7.0.0"
       }
@@ -16,7 +15,6 @@
       "version": "7.1.6",
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.1.6.tgz",
       "integrity": "sha512-Hz6PJT6e44iUNpAn8AoyAs6B3bl60g7MJQaI0rZEar6ECzh6+srYO1xlIdssio34mPaUtAb1y+XlkkSJzok3yw==",
-      "dev": true,
       "requires": {
         "@babel/code-frame": "7.0.0",
         "@babel/generator": "7.1.6",
@@ -38,7 +36,6 @@
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.0.tgz",
           "integrity": "sha512-heNPJUJIqC+xB6ayLAMHaIrmN9HKa7aQO8MGqKpvCA+uJYVcvR6l5kgdrhRuwPFHU7P5/A1w0BjByPHwpfTDKg==",
-          "dev": true,
           "requires": {
             "ms": "2.1.1"
           }
@@ -47,7 +44,6 @@
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.0.tgz",
           "integrity": "sha512-8Mh9h6xViijj36g7Dxi+Y4S6hNGV96vcJZr/SrlHh1LR/pEn/8j/+qIBbs44YKl69Lrfctp4QD+AdWLTMqEZAQ==",
-          "dev": true,
           "requires": {
             "minimist": "1.2.0"
           }
@@ -55,8 +51,7 @@
         "source-map": {
           "version": "0.5.7",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-          "dev": true
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
         }
       }
     },
@@ -64,7 +59,6 @@
       "version": "7.1.6",
       "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.1.6.tgz",
       "integrity": "sha512-brwPBtVvdYdGxtenbQgfCdDPmtkmUBZPjUoK5SXJEBuHaA5BCubh9ly65fzXz7R6o5rA76Rs22ES8Z+HCc0YIQ==",
-      "dev": true,
       "requires": {
         "@babel/types": "7.1.6",
         "jsesc": "2.5.2",
@@ -76,8 +70,7 @@
         "source-map": {
           "version": "0.5.7",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-          "dev": true
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
         }
       }
     },
@@ -85,7 +78,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.0.0.tgz",
       "integrity": "sha512-3UYcJUj9kvSLbLbUIfQTqzcy5VX7GRZ/CCDrnOaZorFFM01aXp1+GJwuFGV4NDDoAS+mOUyHcO6UD/RfqOks3Q==",
-      "dev": true,
       "requires": {
         "@babel/types": "7.1.6"
       }
@@ -94,7 +86,6 @@
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.1.0.tgz",
       "integrity": "sha512-qNSR4jrmJ8M1VMM9tibvyRAHXQs2PmaksQF7c1CGJNipfe3D8p+wgNwgso/P2A2r2mdgBWAXljNWR0QRZAMW8w==",
-      "dev": true,
       "requires": {
         "@babel/helper-explode-assignable-expression": "7.1.0",
         "@babel/types": "7.1.6"
@@ -104,7 +95,6 @@
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-call-delegate/-/helper-call-delegate-7.1.0.tgz",
       "integrity": "sha512-YEtYZrw3GUK6emQHKthltKNZwszBcHK58Ygcis+gVUrF4/FmTVr5CCqQNSfmvg2y+YDEANyYoaLz/SHsnusCwQ==",
-      "dev": true,
       "requires": {
         "@babel/helper-hoist-variables": "7.0.0",
         "@babel/traverse": "7.1.6",
@@ -115,7 +105,6 @@
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.1.0.tgz",
       "integrity": "sha512-yPPcW8dc3gZLN+U1mhYV91QU3n5uTbx7DUdf8NnPbjS0RMwBuHi9Xt2MUgppmNz7CJxTBWsGczTiEp1CSOTPRg==",
-      "dev": true,
       "requires": {
         "@babel/helper-function-name": "7.1.0",
         "@babel/types": "7.1.6",
@@ -126,7 +115,6 @@
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.1.0.tgz",
       "integrity": "sha512-NRQpfHrJ1msCHtKjbzs9YcMmJZOg6mQMmGRB+hbamEdG5PNpaSm95275VD92DvJKuyl0s2sFiDmMZ+EnnvufqA==",
-      "dev": true,
       "requires": {
         "@babel/traverse": "7.1.6",
         "@babel/types": "7.1.6"
@@ -136,7 +124,6 @@
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.1.0.tgz",
       "integrity": "sha512-A95XEoCpb3TO+KZzJ4S/5uW5fNe26DjBGqf1o9ucyLyCmi1dXq/B3c8iaWTfBk3VvetUxl16e8tIrd5teOCfGw==",
-      "dev": true,
       "requires": {
         "@babel/helper-get-function-arity": "7.0.0",
         "@babel/template": "7.1.2",
@@ -147,7 +134,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0.tgz",
       "integrity": "sha512-r2DbJeg4svYvt3HOS74U4eWKsUAMRH01Z1ds1zx8KNTPtpTL5JAsdFv8BNyOpVqdFhHkkRDIg5B4AsxmkjAlmQ==",
-      "dev": true,
       "requires": {
         "@babel/types": "7.1.6"
       }
@@ -156,7 +142,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.0.0.tgz",
       "integrity": "sha512-Ggv5sldXUeSKsuzLkddtyhyHe2YantsxWKNi7A+7LeD12ExRDWTRk29JCXpaHPAbMaIPZSil7n+lq78WY2VY7w==",
-      "dev": true,
       "requires": {
         "@babel/types": "7.1.6"
       }
@@ -165,7 +150,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.0.0.tgz",
       "integrity": "sha512-avo+lm/QmZlv27Zsi0xEor2fKcqWG56D5ae9dzklpIaY7cQMK5N8VSpaNVPPagiqmy7LrEjK1IWdGMOqPu5csg==",
-      "dev": true,
       "requires": {
         "@babel/types": "7.1.6"
       }
@@ -174,7 +158,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.0.0.tgz",
       "integrity": "sha512-aP/hlLq01DWNEiDg4Jn23i+CXxW/owM4WpDLFUbpjxe4NS3BhLVZQ5i7E0ZrxuQ/vwekIeciyamgB1UIYxxM6A==",
-      "dev": true,
       "requires": {
         "@babel/types": "7.1.6"
       }
@@ -183,7 +166,6 @@
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.1.0.tgz",
       "integrity": "sha512-0JZRd2yhawo79Rcm4w0LwSMILFmFXjugG3yqf+P/UsKsRS1mJCmMwwlHDlMg7Avr9LrvSpp4ZSULO9r8jpCzcw==",
-      "dev": true,
       "requires": {
         "@babel/helper-module-imports": "7.0.0",
         "@babel/helper-simple-access": "7.1.0",
@@ -197,7 +179,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.0.0.tgz",
       "integrity": "sha512-u8nd9NQePYNQV8iPWu/pLLYBqZBa4ZaY1YWRFMuxrid94wKI1QNt67NEZ7GAe5Kc/0LLScbim05xZFWkAdrj9g==",
-      "dev": true,
       "requires": {
         "@babel/types": "7.1.6"
       }
@@ -205,14 +186,12 @@
     "@babel/helper-plugin-utils": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0.tgz",
-      "integrity": "sha512-CYAOUCARwExnEixLdB6sDm2dIJ/YgEAKDM1MOeMeZu9Ld/bDgVo8aiWrXwcY7OBh+1Ea2uUcVRcxKk0GJvW7QA==",
-      "dev": true
+      "integrity": "sha512-CYAOUCARwExnEixLdB6sDm2dIJ/YgEAKDM1MOeMeZu9Ld/bDgVo8aiWrXwcY7OBh+1Ea2uUcVRcxKk0GJvW7QA=="
     },
     "@babel/helper-regex": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.0.0.tgz",
       "integrity": "sha512-TR0/N0NDCcUIUEbqV6dCO+LptmmSQFQ7q70lfcEB4URsjD0E1HzicrwUH+ap6BAQ2jhCX9Q4UqZy4wilujWlkg==",
-      "dev": true,
       "requires": {
         "lodash": "4.17.11"
       }
@@ -221,7 +200,6 @@
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.1.0.tgz",
       "integrity": "sha512-3fOK0L+Fdlg8S5al8u/hWE6vhufGSn0bN09xm2LXMy//REAF8kDCrYoOBKYmA8m5Nom+sV9LyLCwrFynA8/slg==",
-      "dev": true,
       "requires": {
         "@babel/helper-annotate-as-pure": "7.0.0",
         "@babel/helper-wrap-function": "7.1.0",
@@ -234,7 +212,6 @@
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.1.0.tgz",
       "integrity": "sha512-BvcDWYZRWVuDeXTYZWxekQNO5D4kO55aArwZOTFXw6rlLQA8ZaDicJR1sO47h+HrnCiDFiww0fSPV0d713KBGQ==",
-      "dev": true,
       "requires": {
         "@babel/helper-member-expression-to-functions": "7.0.0",
         "@babel/helper-optimise-call-expression": "7.0.0",
@@ -246,7 +223,6 @@
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.1.0.tgz",
       "integrity": "sha512-Vk+78hNjRbsiu49zAPALxTb+JUQCz1aolpd8osOF16BGnLtseD21nbHgLPGUwrXEurZgiCOUmvs3ExTu4F5x6w==",
-      "dev": true,
       "requires": {
         "@babel/template": "7.1.2",
         "@babel/types": "7.1.6"
@@ -256,7 +232,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0.tgz",
       "integrity": "sha512-MXkOJqva62dfC0w85mEf/LucPPS/1+04nmmRMPEBUB++hiiThQ2zPtX/mEWQ3mtzCEjIJvPY8nuwxXtQeQwUag==",
-      "dev": true,
       "requires": {
         "@babel/types": "7.1.6"
       }
@@ -265,7 +240,6 @@
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.1.0.tgz",
       "integrity": "sha512-R6HU3dete+rwsdAfrOzTlE9Mcpk4RjU3aX3gi9grtmugQY0u79X7eogUvfXA5sI81Mfq1cn6AgxihfN33STjJA==",
-      "dev": true,
       "requires": {
         "@babel/helper-function-name": "7.1.0",
         "@babel/template": "7.1.2",
@@ -277,7 +251,6 @@
       "version": "7.1.5",
       "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.1.5.tgz",
       "integrity": "sha512-2jkcdL02ywNBry1YNFAH/fViq4fXG0vdckHqeJk+75fpQ2OH+Az6076tX/M0835zA45E0Cqa6pV5Kiv9YOqjEg==",
-      "dev": true,
       "requires": {
         "@babel/template": "7.1.2",
         "@babel/traverse": "7.1.6",
@@ -288,7 +261,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0.tgz",
       "integrity": "sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==",
-      "dev": true,
       "requires": {
         "chalk": "2.4.1",
         "esutils": "2.0.2",
@@ -298,22 +270,19 @@
         "js-tokens": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-          "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-          "dev": true
+          "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
         }
       }
     },
     "@babel/parser": {
       "version": "7.1.6",
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.1.6.tgz",
-      "integrity": "sha512-dWP6LJm9nKT6ALaa+bnL247GHHMWir3vSlZ2+IHgHgktZQx0L3Uvq2uAWcuzIe+fujRsYWBW2q622C5UvGK9iQ==",
-      "dev": true
+      "integrity": "sha512-dWP6LJm9nKT6ALaa+bnL247GHHMWir3vSlZ2+IHgHgktZQx0L3Uvq2uAWcuzIe+fujRsYWBW2q622C5UvGK9iQ=="
     },
     "@babel/plugin-proposal-async-generator-functions": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.1.0.tgz",
       "integrity": "sha512-Fq803F3Jcxo20MXUSDdmZZXrPe6BWyGcWBPPNB/M7WaUYESKDeKMOGIxEzQOjGSmW/NWb6UaPZrtTB2ekhB/ew==",
-      "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "7.0.0",
         "@babel/helper-remap-async-to-generator": "7.1.0",
@@ -324,7 +293,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.0.0.tgz",
       "integrity": "sha512-kfVdUkIAGJIVmHmtS/40i/fg/AGnw/rsZBCaapY5yjeO5RA9m165Xbw9KMOu2nqXP5dTFjEjHdfNdoVcHv133Q==",
-      "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "7.0.0",
         "@babel/plugin-syntax-json-strings": "7.0.0"
@@ -334,7 +302,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.0.0.tgz",
       "integrity": "sha512-14fhfoPcNu7itSen7Py1iGN0gEm87hX/B+8nZPqkdmANyyYWYMY2pjA3r8WXbWVKMzfnSNS0xY8GVS0IjXi/iw==",
-      "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "7.0.0",
         "@babel/plugin-syntax-object-rest-spread": "7.0.0"
@@ -344,7 +311,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.0.0.tgz",
       "integrity": "sha512-JPqAvLG1s13B/AuoBjdBYvn38RqW6n1TzrQO839/sIpqLpbnXKacsAgpZHzLD83Sm8SDXMkkrAvEnJ25+0yIpw==",
-      "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "7.0.0",
         "@babel/plugin-syntax-optional-catch-binding": "7.0.0"
@@ -354,7 +320,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.0.0.tgz",
       "integrity": "sha512-tM3icA6GhC3ch2SkmSxv7J/hCWKISzwycub6eGsDrFDgukD4dZ/I+x81XgW0YslS6mzNuQ1Cbzh5osjIMgepPQ==",
-      "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "7.0.0",
         "@babel/helper-regex": "7.0.0",
@@ -365,7 +330,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.0.0.tgz",
       "integrity": "sha512-im7ged00ddGKAjcZgewXmp1vxSZQQywuQXe2B1A7kajjZmDeY/ekMPmWr9zJgveSaQH0k7BcGrojQhcK06l0zA==",
-      "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "7.0.0"
       }
@@ -374,7 +338,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.0.0.tgz",
       "integrity": "sha512-UlSfNydC+XLj4bw7ijpldc1uZ/HB84vw+U6BTuqMdIEmz/LDe63w/GHtpQMdXWdqQZFeAI9PjnHe/vDhwirhKA==",
-      "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "7.0.0"
       }
@@ -383,7 +346,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.0.0.tgz",
       "integrity": "sha512-5A0n4p6bIiVe5OvQPxBnesezsgFJdHhSs3uFSvaPdMqtsovajLZ+G2vZyvNe10EzJBWWo3AcHGKhAFUxqwp2dw==",
-      "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "7.0.0"
       }
@@ -392,7 +354,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.0.0.tgz",
       "integrity": "sha512-Wc+HVvwjcq5qBg1w5RG9o9RVzmCaAg/Vp0erHCKpAYV8La6I94o4GQAmFYNmkzoMO6gzoOSulpKeSSz6mPEoZw==",
-      "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "7.0.0"
       }
@@ -401,7 +362,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.0.0.tgz",
       "integrity": "sha512-2EZDBl1WIO/q4DIkIp4s86sdp4ZifL51MoIviLY/gG/mLSuOIEg7J8o6mhbxOTvUJkaN50n+8u41FVsr5KLy/w==",
-      "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "7.0.0"
       }
@@ -410,7 +370,6 @@
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.1.0.tgz",
       "integrity": "sha512-rNmcmoQ78IrvNCIt/R9U+cixUHeYAzgusTFgIAv+wQb9HJU4szhpDD6e5GCACmj/JP5KxuCwM96bX3L9v4ZN/g==",
-      "dev": true,
       "requires": {
         "@babel/helper-module-imports": "7.0.0",
         "@babel/helper-plugin-utils": "7.0.0",
@@ -421,7 +380,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.0.0.tgz",
       "integrity": "sha512-AOBiyUp7vYTqz2Jibe1UaAWL0Hl9JUXEgjFvvvcSc9MVDItv46ViXFw2F7SVt1B5k+KWjl44eeXOAk3UDEaJjQ==",
-      "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "7.0.0"
       }
@@ -430,7 +388,6 @@
       "version": "7.1.5",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.1.5.tgz",
       "integrity": "sha512-jlYcDrz+5ayWC7mxgpn1Wj8zj0mmjCT2w0mPIMSwO926eXBRxpEgoN/uQVRBfjtr8ayjcmS+xk2G1jaP8JjMJQ==",
-      "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "7.0.0",
         "lodash": "4.17.11"
@@ -440,7 +397,6 @@
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.1.0.tgz",
       "integrity": "sha512-rNaqoD+4OCBZjM7VaskladgqnZ1LO6o2UxuWSDzljzW21pN1KXkB7BstAVweZdxQkHAujps5QMNOTWesBciKFg==",
-      "dev": true,
       "requires": {
         "@babel/helper-annotate-as-pure": "7.0.0",
         "@babel/helper-define-map": "7.1.0",
@@ -456,7 +412,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.0.0.tgz",
       "integrity": "sha512-ubouZdChNAv4AAWAgU7QKbB93NU5sHwInEWfp+/OzJKA02E6Woh9RVoX4sZrbRwtybky/d7baTUqwFx+HgbvMA==",
-      "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "7.0.0"
       }
@@ -465,7 +420,6 @@
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.1.3.tgz",
       "integrity": "sha512-Mb9M4DGIOspH1ExHOUnn2UUXFOyVTiX84fXCd+6B5iWrQg/QMeeRmSwpZ9lnjYLSXtZwiw80ytVMr3zue0ucYw==",
-      "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "7.0.0"
       }
@@ -474,7 +428,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.0.0.tgz",
       "integrity": "sha512-00THs8eJxOJUFVx1w8i1MBF4XH4PsAjKjQ1eqN/uCH3YKwP21GCKfrn6YZFZswbOk9+0cw1zGQPHVc1KBlSxig==",
-      "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "7.0.0",
         "@babel/helper-regex": "7.0.0",
@@ -485,7 +438,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.0.0.tgz",
       "integrity": "sha512-w2vfPkMqRkdxx+C71ATLJG30PpwtTpW7DDdLqYt2acXU7YjztzeWW2Jk1T6hKqCLYCcEA5UQM/+xTAm+QCSnuQ==",
-      "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "7.0.0"
       }
@@ -494,7 +446,6 @@
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.1.0.tgz",
       "integrity": "sha512-uZt9kD1Pp/JubkukOGQml9tqAeI8NkE98oZnHZ2qHRElmeKCodbTZgOEUtujSCSLhHSBWbzNiFSDIMC4/RBTLQ==",
-      "dev": true,
       "requires": {
         "@babel/helper-builder-binary-assignment-operator-visitor": "7.1.0",
         "@babel/helper-plugin-utils": "7.0.0"
@@ -504,7 +455,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.0.0.tgz",
       "integrity": "sha512-TlxKecN20X2tt2UEr2LNE6aqA0oPeMT1Y3cgz8k4Dn1j5ObT8M3nl9aA37LLklx0PBZKETC9ZAf9n/6SujTuXA==",
-      "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "7.0.0"
       }
@@ -513,7 +463,6 @@
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.1.0.tgz",
       "integrity": "sha512-VxOa1TMlFMtqPW2IDYZQaHsFrq/dDoIjgN098NowhexhZcz3UGlvPgZXuE1jEvNygyWyxRacqDpCZt+par1FNg==",
-      "dev": true,
       "requires": {
         "@babel/helper-function-name": "7.1.0",
         "@babel/helper-plugin-utils": "7.0.0"
@@ -523,7 +472,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.0.0.tgz",
       "integrity": "sha512-1NTDBWkeNXgpUcyoVFxbr9hS57EpZYXpje92zv0SUzjdu3enaRwF/l3cmyRnXLtIdyJASyiS6PtybK+CgKf7jA==",
-      "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "7.0.0"
       }
@@ -532,7 +480,6 @@
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.1.0.tgz",
       "integrity": "sha512-wt8P+xQ85rrnGNr2x1iV3DW32W8zrB6ctuBkYBbf5/ZzJY99Ob4MFgsZDFgczNU76iy9PWsy4EuxOliDjdKw6A==",
-      "dev": true,
       "requires": {
         "@babel/helper-module-transforms": "7.1.0",
         "@babel/helper-plugin-utils": "7.0.0"
@@ -542,7 +489,6 @@
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.1.0.tgz",
       "integrity": "sha512-wtNwtMjn1XGwM0AXPspQgvmE6msSJP15CX2RVfpTSTNPLhKhaOjaIfBaVfj4iUZ/VrFSodcFedwtPg/NxwQlPA==",
-      "dev": true,
       "requires": {
         "@babel/helper-module-transforms": "7.1.0",
         "@babel/helper-plugin-utils": "7.0.0",
@@ -553,7 +499,6 @@
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.1.3.tgz",
       "integrity": "sha512-PvTxgjxQAq4pvVUZF3mD5gEtVDuId8NtWkJsZLEJZMZAW3TvgQl1pmydLLN1bM8huHFVVU43lf0uvjQj9FRkKw==",
-      "dev": true,
       "requires": {
         "@babel/helper-hoist-variables": "7.0.0",
         "@babel/helper-plugin-utils": "7.0.0"
@@ -563,7 +508,6 @@
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.1.0.tgz",
       "integrity": "sha512-enrRtn5TfRhMmbRwm7F8qOj0qEYByqUvTttPEGimcBH4CJHphjyK1Vg7sdU7JjeEmgSpM890IT/efS2nMHwYig==",
-      "dev": true,
       "requires": {
         "@babel/helper-module-transforms": "7.1.0",
         "@babel/helper-plugin-utils": "7.0.0"
@@ -573,7 +517,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.0.0.tgz",
       "integrity": "sha512-yin069FYjah+LbqfGeTfzIBODex/e++Yfa0rH0fpfam9uTbuEeEOx5GLGr210ggOV77mVRNoeqSYqeuaqSzVSw==",
-      "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "7.0.0"
       }
@@ -582,7 +525,6 @@
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.1.0.tgz",
       "integrity": "sha512-/O02Je1CRTSk2SSJaq0xjwQ8hG4zhZGNjE8psTsSNPXyLRCODv7/PBozqT5AmQMzp7MI3ndvMhGdqp9c96tTEw==",
-      "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "7.0.0",
         "@babel/helper-replace-supers": "7.1.0"
@@ -592,7 +534,6 @@
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.1.0.tgz",
       "integrity": "sha512-vHV7oxkEJ8IHxTfRr3hNGzV446GAb+0hgbA7o/0Jd76s+YzccdWuTU296FOCOl/xweU4t/Ya4g41yWz80RFCRw==",
-      "dev": true,
       "requires": {
         "@babel/helper-call-delegate": "7.1.0",
         "@babel/helper-get-function-arity": "7.0.0",
@@ -603,7 +544,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.0.0.tgz",
       "integrity": "sha512-sj2qzsEx8KDVv1QuJc/dEfilkg3RRPvPYx/VnKLtItVQRWt1Wqf5eVCOLZm29CiGFfYYsA3VPjfizTCV0S0Dlw==",
-      "dev": true,
       "requires": {
         "regenerator-transform": "0.13.3"
       }
@@ -612,7 +552,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.0.0.tgz",
       "integrity": "sha512-g/99LI4vm5iOf5r1Gdxq5Xmu91zvjhEG5+yZDJW268AZELAu4J1EiFLnkSG3yuUsZyOipVOVUKoGPYwfsTymhw==",
-      "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "7.0.0"
       }
@@ -621,7 +560,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.0.0.tgz",
       "integrity": "sha512-L702YFy2EvirrR4shTj0g2xQp7aNwZoWNCkNu2mcoU0uyzMl0XRwDSwzB/xp6DSUFiBmEXuyAyEN16LsgVqGGQ==",
-      "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "7.0.0"
       }
@@ -630,7 +568,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.0.0.tgz",
       "integrity": "sha512-LFUToxiyS/WD+XEWpkx/XJBrUXKewSZpzX68s+yEOtIbdnsRjpryDw9U06gYc6klYEij/+KQVRnD3nz3AoKmjw==",
-      "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "7.0.0",
         "@babel/helper-regex": "7.0.0"
@@ -640,7 +577,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.0.0.tgz",
       "integrity": "sha512-vA6rkTCabRZu7Nbl9DfLZE1imj4tzdWcg5vtdQGvj+OH9itNNB6hxuRMHuIY8SGnEt1T9g5foqs9LnrHzsqEFg==",
-      "dev": true,
       "requires": {
         "@babel/helper-annotate-as-pure": "7.0.0",
         "@babel/helper-plugin-utils": "7.0.0"
@@ -650,7 +586,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.0.0.tgz",
       "integrity": "sha512-1r1X5DO78WnaAIvs5uC48t41LLckxsYklJrZjNKcevyz83sF2l4RHbw29qrCPr/6ksFsdfRpT/ZgxNWHXRnffg==",
-      "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "7.0.0"
       }
@@ -659,7 +594,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.0.0.tgz",
       "integrity": "sha512-uJBrJhBOEa3D033P95nPHu3nbFwFE9ZgXsfEitzoIXIwqAZWk7uXcg06yFKXz9FSxBH5ucgU/cYdX0IV8ldHKw==",
-      "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "7.0.0",
         "@babel/helper-regex": "7.0.0",
@@ -670,7 +604,6 @@
       "version": "7.1.6",
       "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.1.6.tgz",
       "integrity": "sha512-YIBfpJNQMBkb6MCkjz/A9J76SNCSuGVamOVBgoUkLzpJD/z8ghHi9I42LQ4pulVX68N/MmImz6ZTixt7Azgexw==",
-      "dev": true,
       "requires": {
         "@babel/helper-module-imports": "7.0.0",
         "@babel/helper-plugin-utils": "7.0.0",
@@ -719,7 +652,6 @@
           "version": "4.3.4",
           "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.3.4.tgz",
           "integrity": "sha512-u5iz+ijIMUlmV8blX82VGFrB9ecnUg5qEt55CMZ/YJEhha+d8qpBfOFuutJ6F/VKRXjZoD33b6uvarpPxcl3RA==",
-          "dev": true,
           "requires": {
             "caniuse-lite": "1.0.30000899",
             "electron-to-chromium": "1.3.82",
@@ -732,7 +664,6 @@
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.1.2.tgz",
       "integrity": "sha512-SY1MmplssORfFiLDcOETrW7fCLl+PavlwMh92rrGcikQaRq4iWPVH0MpwPpY3etVMx6RnDjXtr6VZYr/IbP/Ag==",
-      "dev": true,
       "requires": {
         "@babel/code-frame": "7.0.0",
         "@babel/parser": "7.1.6",
@@ -743,7 +674,6 @@
       "version": "7.1.6",
       "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.1.6.tgz",
       "integrity": "sha512-CXedit6GpISz3sC2k2FsGCUpOhUqKdyL0lqNrImQojagnUMXf8hex4AxYFRuMkNGcvJX5QAFGzB5WJQmSv8SiQ==",
-      "dev": true,
       "requires": {
         "@babel/code-frame": "7.0.0",
         "@babel/generator": "7.1.6",
@@ -760,7 +690,6 @@
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.0.tgz",
           "integrity": "sha512-heNPJUJIqC+xB6ayLAMHaIrmN9HKa7aQO8MGqKpvCA+uJYVcvR6l5kgdrhRuwPFHU7P5/A1w0BjByPHwpfTDKg==",
-          "dev": true,
           "requires": {
             "ms": "2.1.1"
           }
@@ -771,7 +700,6 @@
       "version": "7.1.6",
       "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.1.6.tgz",
       "integrity": "sha512-DMiUzlY9DSjVsOylJssxLHSgj6tWM9PRFJOGW/RaOglVOK9nzTxoOMfTfRQXGUCUQ/HmlG2efwC+XqUEJ5ay4w==",
-      "dev": true,
       "requires": {
         "esutils": "2.0.2",
         "lodash": "4.17.11",
@@ -1066,6 +994,12 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
       "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
+    },
+    "accessibility-developer-tools": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/accessibility-developer-tools/-/accessibility-developer-tools-2.12.0.tgz",
+      "integrity": "sha1-PaDM6dbsY3OWS4TzXbfPw996tRQ=",
+      "dev": true
     },
     "accord": {
       "version": "0.29.0",
@@ -1913,7 +1847,6 @@
       "version": "8.6.5",
       "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-8.6.5.tgz",
       "integrity": "sha512-PLWJN3Xo/rycNkx+mp8iBDMTm3FeWe4VmYaZDSqL5QQB9sLsQkG5k8n+LNDFnhh9kdq2K+egL/icpctOmDHwig==",
-      "dev": true,
       "requires": {
         "browserslist": "3.2.8",
         "caniuse-lite": "1.0.30000899",
@@ -1939,6 +1872,23 @@
       "integrity": "sha512-JyMXnHDuzr6hei+mINWsR/iEyPBFSjpgF4/lUijO7QDGVKtTmdpDxc2+7X/xW+rPIwhcd72euJ2UunbRXF+1Eg==",
       "dev": true
     },
+    "axe-webdriverjs": {
+      "version": "0.2.0",
+      "resolved": "http://registry.npmjs.org/axe-webdriverjs/-/axe-webdriverjs-0.2.0.tgz",
+      "integrity": "sha1-XjHtr26bozRCdiz9hd46B0c8EVU=",
+      "dev": true,
+      "requires": {
+        "axe-core": "1.1.1"
+      },
+      "dependencies": {
+        "axe-core": {
+          "version": "1.1.1",
+          "resolved": "http://registry.npmjs.org/axe-core/-/axe-core-1.1.1.tgz",
+          "integrity": "sha1-rp2l2oq08QQZB/H12N/jnJRqksU=",
+          "dev": true
+        }
+      }
+    },
     "axios": {
       "version": "0.17.1",
       "resolved": "https://registry.npmjs.org/axios/-/axios-0.17.1.tgz",
@@ -1948,12 +1898,6 @@
         "follow-redirects": "1.5.9",
         "is-buffer": "1.1.6"
       }
-    },
-    "babel-core": {
-      "version": "7.0.0-bridge.0",
-      "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-7.0.0-bridge.0.tgz",
-      "integrity": "sha512-poPX9mZH/5CSanm50Q+1toVci6pv5KSRv/5TWCwtzQS5XEwn40BcCrgIeMFWP9CKKIniKXNxoIOnOq4VVlGXhg==",
-      "dev": true
     },
     "babel-jest": {
       "version": "23.6.0",
@@ -1969,7 +1913,6 @@
       "version": "8.0.4",
       "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-8.0.4.tgz",
       "integrity": "sha512-fhBhNkUToJcW9nV46v8w87AJOwAJDz84c1CL57n3Stj73FANM/b9TbCUK4YhdOwEyZ+OxhYpdeZDNzSI29Firw==",
-      "dev": true,
       "requires": {
         "find-cache-dir": "1.0.0",
         "loader-utils": "1.1.0",
@@ -3270,7 +3213,6 @@
       "version": "3.2.8",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-3.2.8.tgz",
       "integrity": "sha512-WHVocJYavUwVgVViC0ORikPHQquXwVh939TaelZ4WDqpWgTX/FsGhl/+P4qBUAGcRvtOgDgC+xftNWWp2RUTAQ==",
-      "dev": true,
       "requires": {
         "caniuse-lite": "1.0.30000899",
         "electron-to-chromium": "1.3.82"
@@ -3535,8 +3477,7 @@
     "caniuse-lite": {
       "version": "1.0.30000899",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000899.tgz",
-      "integrity": "sha512-enC3zKfUCJxxwvUIsBkbHd54CtJw1KtIWvrK0JZxWD/fEN2knHaai45lndJ4xXAkyRAPyk60J3yagkKDWhfeMA==",
-      "dev": true
+      "integrity": "sha512-enC3zKfUCJxxwvUIsBkbHd54CtJw1KtIWvrK0JZxWD/fEN2knHaai45lndJ4xXAkyRAPyk60J3yagkKDWhfeMA=="
     },
     "capitalize": {
       "version": "1.0.0",
@@ -5961,8 +5902,7 @@
     "electron-to-chromium": {
       "version": "1.3.82",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.82.tgz",
-      "integrity": "sha512-NI4nB2IWGcU4JVT1AE8kBb/dFor4zjLHMLsOROPahppeHrR0FG5uslxMmkp/thO1MvPjM2xhlKoY29/I60s0ew==",
-      "dev": true
+      "integrity": "sha512-NI4nB2IWGcU4JVT1AE8kBb/dFor4zjLHMLsOROPahppeHrR0FG5uslxMmkp/thO1MvPjM2xhlKoY29/I60s0ew=="
     },
     "elem-dataset": {
       "version": "1.1.1",
@@ -8370,8 +8310,7 @@
     "globals": {
       "version": "11.9.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-11.9.0.tgz",
-      "integrity": "sha512-5cJVtyXWH8PiJPVLZzzoIizXx944O4OmRro5MWKx5fT4MgcN7OfaMutPeaTdJCCURwbWdhhcCWcKIffPnmTzBg==",
-      "dev": true
+      "integrity": "sha512-5cJVtyXWH8PiJPVLZzzoIizXx944O4OmRro5MWKx5fT4MgcN7OfaMutPeaTdJCCURwbWdhhcCWcKIffPnmTzBg=="
     },
     "globby": {
       "version": "6.1.0",
@@ -9934,7 +9873,6 @@
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
       "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
-      "dev": true,
       "requires": {
         "loose-envify": "1.4.0"
       }
@@ -11852,8 +11790,7 @@
     "js-levenshtein": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/js-levenshtein/-/js-levenshtein-1.1.4.tgz",
-      "integrity": "sha512-PxfGzSs0ztShKrUYPIn5r0MtyAhYcCwmndozzpz8YObbPnD1jFxzlBGbRnX2mIu6Z13xN6+PTu05TQFnZFlzow==",
-      "dev": true
+      "integrity": "sha512-PxfGzSs0ztShKrUYPIn5r0MtyAhYcCwmndozzpz8YObbPnD1jFxzlBGbRnX2mIu6Z13xN6+PTu05TQFnZFlzow=="
     },
     "js-library-detector": {
       "version": "5.1.0",
@@ -11864,8 +11801,7 @@
     "js-tokens": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
-      "dev": true
+      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
     },
     "js-yaml": {
       "version": "3.12.0",
@@ -11970,8 +11906,7 @@
     "jsesc": {
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
-      "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
-      "dev": true
+      "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA=="
     },
     "json-buffer": {
       "version": "3.0.0",
@@ -12890,7 +12825,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "dev": true,
       "requires": {
         "js-tokens": "3.0.2"
       }
@@ -13906,7 +13840,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.0.3.tgz",
       "integrity": "sha512-ZaZWMsbuDcetpHmYeKWPO6e63pSXLb50M7lJgCbcM2nC/nQC3daNifmtp5a2kp7EWwYfhuvH6zLPWkrF8IiDdw==",
-      "dev": true,
       "requires": {
         "semver": "5.6.0"
       }
@@ -13968,8 +13901,7 @@
     "normalize-range": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
-      "integrity": "sha1-LRDAa9/TEuqXd2laTShDlFa3WUI=",
-      "dev": true
+      "integrity": "sha1-LRDAa9/TEuqXd2laTShDlFa3WUI="
     },
     "normalize-url": {
       "version": "2.0.1",
@@ -14025,8 +13957,7 @@
     "num2fraction": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz",
-      "integrity": "sha1-b2gragJ6Tp3fpFZM0lidHU5mnt4=",
-      "dev": true
+      "integrity": "sha1-b2gragJ6Tp3fpFZM0lidHU5mnt4="
     },
     "number-is-nan": {
       "version": "1.0.1",
@@ -14918,8 +14849,7 @@
     "postcss-value-parser": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
-      "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
-      "dev": true
+      "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ=="
     },
     "prelude-ls": {
       "version": "1.1.2",
@@ -14970,8 +14900,7 @@
     "private": {
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
-      "integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg==",
-      "dev": true
+      "integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg=="
     },
     "process": {
       "version": "0.11.10",
@@ -15189,6 +15118,33 @@
             "semver": "5.6.0",
             "xml2js": "0.4.19"
           }
+        }
+      }
+    },
+    "protractor-accessibility-plugin": {
+      "version": "github:cfpb/protractor-accessibility-plugin#7319a881e222d9f3588f6d5d8a3d9848bc38c859",
+      "dev": true,
+      "requires": {
+        "accessibility-developer-tools": "2.12.0",
+        "axe-core": "2.6.1",
+        "axe-webdriverjs": "0.2.0",
+        "html-entities": "1.2.1",
+        "lodash": "3.10.1",
+        "q": "1.5.1",
+        "request": "2.88.0"
+      },
+      "dependencies": {
+        "axe-core": {
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-2.6.1.tgz",
+          "integrity": "sha512-QFfI3d+x/v92HJWGBaNfgrxdfon9/xXzd04YYfm5w5NJQOLex8qkJCctOt7+ky6e1l9zcQ5E7jsvbnTgQzyfTw==",
+          "dev": true
+        },
+        "lodash": {
+          "version": "3.10.1",
+          "resolved": "http://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+          "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
+          "dev": true
         }
       }
     },
@@ -16141,14 +16097,12 @@
     "regenerate": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.0.tgz",
-      "integrity": "sha512-1G6jJVDWrt0rK99kBjvEtziZNCICAuvIPkSiUFIQxVP06RCVpq3dmDo2oi6ABpYaDYaTRr67BEhL8r1wgEZZKg==",
-      "dev": true
+      "integrity": "sha512-1G6jJVDWrt0rK99kBjvEtziZNCICAuvIPkSiUFIQxVP06RCVpq3dmDo2oi6ABpYaDYaTRr67BEhL8r1wgEZZKg=="
     },
     "regenerate-unicode-properties": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-7.0.0.tgz",
       "integrity": "sha512-s5NGghCE4itSlUS+0WUj88G6cfMVMmH8boTPNvABf8od+2dhT9WDlWu8n01raQAJZMOK8Ch6jSexaRO7swd6aw==",
-      "dev": true,
       "requires": {
         "regenerate": "1.4.0"
       }
@@ -16162,7 +16116,6 @@
       "version": "0.13.3",
       "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.13.3.tgz",
       "integrity": "sha512-5ipTrZFSq5vU2YoGoww4uaRVAK4wyYC4TSICibbfEPOruUu8FFP7ErV0BjmbIOEpn3O/k9na9UEdYR/3m7N6uA==",
-      "dev": true,
       "requires": {
         "private": "0.1.8"
       }
@@ -16195,7 +16148,6 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.2.0.tgz",
       "integrity": "sha512-Z835VSnJJ46CNBttalHD/dB+Sj2ezmY6Xp38npwU87peK6mqOzOpV8eYktdkLTEkzzD+JsTcxd84ozd8I14+rw==",
-      "dev": true,
       "requires": {
         "regenerate": "1.4.0",
         "regenerate-unicode-properties": "7.0.0",
@@ -16227,14 +16179,12 @@
     "regjsgen": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.4.0.tgz",
-      "integrity": "sha512-X51Lte1gCYUdlwhF28+2YMO0U6WeN0GLpgpA7LK7mbdDnkQYiwvEpmpe0F/cv5L14EbxgrdayAG3JETBv0dbXA==",
-      "dev": true
+      "integrity": "sha512-X51Lte1gCYUdlwhF28+2YMO0U6WeN0GLpgpA7LK7mbdDnkQYiwvEpmpe0F/cv5L14EbxgrdayAG3JETBv0dbXA=="
     },
     "regjsparser": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.3.0.tgz",
       "integrity": "sha512-zza72oZBBHzt64G7DxdqrOo/30bhHkwMUoT0WqfGu98XLd7N+1tsy5MJ96Bk4MD0y74n629RhmrGW6XlnLLwCA==",
-      "dev": true,
       "requires": {
         "jsesc": "0.5.0"
       },
@@ -16242,8 +16192,7 @@
         "jsesc": {
           "version": "0.5.0",
           "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
-          "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
-          "dev": true
+          "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0="
         }
       }
     },
@@ -18702,8 +18651,7 @@
     "to-fast-properties": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
-      "dev": true
+      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
     },
     "to-object-path": {
       "version": "0.3.0",
@@ -18818,8 +18766,7 @@
     "trim-right": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
-      "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
-      "dev": true
+      "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM="
     },
     "tslib": {
       "version": "1.9.3",
@@ -19066,14 +19013,12 @@
     "unicode-canonical-property-names-ecmascript": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-1.0.4.tgz",
-      "integrity": "sha512-jDrNnXWHd4oHiTZnx/ZG7gtUTVp+gCcTTKr8L0HjlwphROEW3+Him+IpvC+xcJEFegapiMZyZe02CyuOnRmbnQ==",
-      "dev": true
+      "integrity": "sha512-jDrNnXWHd4oHiTZnx/ZG7gtUTVp+gCcTTKr8L0HjlwphROEW3+Him+IpvC+xcJEFegapiMZyZe02CyuOnRmbnQ=="
     },
     "unicode-match-property-ecmascript": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-1.0.4.tgz",
       "integrity": "sha512-L4Qoh15vTfntsn4P1zqnHulG0LdXgjSO035fEpdtp6YxXhMT51Q6vgM5lYdG/5X3MjS+k/Y9Xw4SFCY9IkR0rg==",
-      "dev": true,
       "requires": {
         "unicode-canonical-property-names-ecmascript": "1.0.4",
         "unicode-property-aliases-ecmascript": "1.0.4"
@@ -19082,14 +19027,12 @@
     "unicode-match-property-value-ecmascript": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-1.0.2.tgz",
-      "integrity": "sha512-Rx7yODZC1L/T8XKo/2kNzVAQaRE88AaMvI1EF/Xnj3GW2wzN6fop9DDWuFAKUVFH7vozkz26DzP0qyWLKLIVPQ==",
-      "dev": true
+      "integrity": "sha512-Rx7yODZC1L/T8XKo/2kNzVAQaRE88AaMvI1EF/Xnj3GW2wzN6fop9DDWuFAKUVFH7vozkz26DzP0qyWLKLIVPQ=="
     },
     "unicode-property-aliases-ecmascript": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-1.0.4.tgz",
-      "integrity": "sha512-2WSLa6OdYd2ng8oqiGIWnJqyFArvhn+5vgx5GTxMbUYjCYKUcuKS62YLFF0R/BDGlB1yzXjQOLtPAfHsgirEpg==",
-      "dev": true
+      "integrity": "sha512-2WSLa6OdYd2ng8oqiGIWnJqyFArvhn+5vgx5GTxMbUYjCYKUcuKS62YLFF0R/BDGlB1yzXjQOLtPAfHsgirEpg=="
     },
     "union-value": {
       "version": "1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1899,6 +1899,100 @@
         "is-buffer": "1.1.6"
       }
     },
+    "babel-code-frame": {
+      "version": "7.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-7.0.0-beta.3.tgz",
+      "integrity": "sha512-flMsJ9eSpShupt2Gwpka84DoMePvE4HlDObzdEc+1iNkacv3+NHlsJ7dMKmbnVA/AT22UhcGEBHwbJLoXWBO6Q==",
+      "dev": true,
+      "requires": {
+        "chalk": "2.4.1",
+        "esutils": "2.0.2",
+        "js-tokens": "3.0.2"
+      }
+    },
+    "babel-core": {
+      "version": "7.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-7.0.0-beta.3.tgz",
+      "integrity": "sha512-zdng6WxI4cUjvstvFo/ke+hxohXCi/vxrMTM1S/bsAqnvKb+C+pHx78T3ZdJlWC3bGGxYqUnmM4p9VMzJ0uVVg==",
+      "dev": true,
+      "requires": {
+        "babel-code-frame": "7.0.0-beta.3",
+        "babel-generator": "7.0.0-beta.3",
+        "babel-helpers": "7.0.0-beta.3",
+        "babel-template": "7.0.0-beta.3",
+        "babel-traverse": "7.0.0-beta.3",
+        "babel-types": "7.0.0-beta.3",
+        "babylon": "7.0.0-beta.27",
+        "convert-source-map": "1.6.0",
+        "debug": "3.2.6",
+        "json5": "0.5.1",
+        "lodash": "4.17.11",
+        "micromatch": "2.3.11",
+        "resolve": "1.8.1",
+        "source-map": "0.5.7"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true
+        }
+      }
+    },
+    "babel-generator": {
+      "version": "7.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-7.0.0-beta.3.tgz",
+      "integrity": "sha512-Bok77tKwQZUVaLBRnDGDEaMZ4xEeyvzsgnCRxlVgfKmgn+vPxuka//ug3nrMmmgZ8TAMVPoXzeaAcs47lExrPg==",
+      "dev": true,
+      "requires": {
+        "babel-types": "7.0.0-beta.3",
+        "jsesc": "2.5.2",
+        "lodash": "4.17.11",
+        "source-map": "0.5.7",
+        "trim-right": "1.0.1"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true
+        }
+      }
+    },
+    "babel-helper-function-name": {
+      "version": "7.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-7.0.0-beta.3.tgz",
+      "integrity": "sha512-iMWYqwDarQOVlEGcK1MfbtK9vrFGs5Z4UQsdASJUHdhBp918EM5kndwriiIbhUX8gr2B/CEV/udJkFTrHsjdMQ==",
+      "dev": true,
+      "requires": {
+        "babel-helper-get-function-arity": "7.0.0-beta.3",
+        "babel-template": "7.0.0-beta.3",
+        "babel-traverse": "7.0.0-beta.3",
+        "babel-types": "7.0.0-beta.3"
+      }
+    },
+    "babel-helper-get-function-arity": {
+      "version": "7.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-7.0.0-beta.3.tgz",
+      "integrity": "sha512-ZkYFRMWKx1c9fUW72YNM3eieBG701CMbLjmLLWmJTTPc0F0kddS9Fwok26EAmndUAgD6kFdh7ms3PH94MdGuGQ==",
+      "dev": true,
+      "requires": {
+        "babel-types": "7.0.0-beta.3"
+      }
+    },
+    "babel-helpers": {
+      "version": "7.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-7.0.0-beta.3.tgz",
+      "integrity": "sha512-zNX7FgdXT8645igxTyAVIArMbxUsFl1w3K+v+SKlGbDocIVjWMnRszRfgVwJflzI11yE0kY+fy6SNfulykW8CA==",
+      "dev": true,
+      "requires": {
+        "babel-template": "7.0.0-beta.3",
+        "babel-traverse": "7.0.0-beta.3",
+        "babel-types": "7.0.0-beta.3"
+      }
+    },
     "babel-jest": {
       "version": "23.6.0",
       "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-23.6.0.tgz",
@@ -2183,6 +2277,60 @@
         "core-js": "2.5.7",
         "regenerator-runtime": "0.11.1"
       }
+    },
+    "babel-template": {
+      "version": "7.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-7.0.0-beta.3.tgz",
+      "integrity": "sha512-urJduLja89kSDGqY8ryw8iIwQnMl30IvhMtMNmDD7vBX0l0oylaLgK+7df/9ODX9vR/PhXuif6HYl5HlzAKXMg==",
+      "dev": true,
+      "requires": {
+        "babel-code-frame": "7.0.0-beta.3",
+        "babel-traverse": "7.0.0-beta.3",
+        "babel-types": "7.0.0-beta.3",
+        "babylon": "7.0.0-beta.27",
+        "lodash": "4.17.11"
+      }
+    },
+    "babel-traverse": {
+      "version": "7.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-7.0.0-beta.3.tgz",
+      "integrity": "sha512-xyh/aPYuedMAfQlSj2kjHjsEmY5/Dpxs576L05DySAVMrV+ADX6l4mTOLysAEGwJfkePJlDLhFuS6SKaxv1V7w==",
+      "dev": true,
+      "requires": {
+        "babel-code-frame": "7.0.0-beta.3",
+        "babel-helper-function-name": "7.0.0-beta.3",
+        "babel-types": "7.0.0-beta.3",
+        "babylon": "7.0.0-beta.27",
+        "debug": "3.2.6",
+        "globals": "10.4.0",
+        "invariant": "2.2.4",
+        "lodash": "4.17.11"
+      },
+      "dependencies": {
+        "globals": {
+          "version": "10.4.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-10.4.0.tgz",
+          "integrity": "sha512-uNUtxIZpGyuaq+5BqGGQHsL4wUlJAXRqOm6g3Y48/CWNGTLONgBibI0lh6lGxjR2HljFYUfszb+mk4WkgMntsA==",
+          "dev": true
+        }
+      }
+    },
+    "babel-types": {
+      "version": "7.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-7.0.0-beta.3.tgz",
+      "integrity": "sha512-36k8J+byAe181OmCMawGhw+DtKO7AwexPVtsPXoMfAkjtZgoCX3bEuHWfdE5sYxRM8dojvtG/+O08M0Z/YDC6w==",
+      "dev": true,
+      "requires": {
+        "esutils": "2.0.2",
+        "lodash": "4.17.11",
+        "to-fast-properties": "2.0.0"
+      }
+    },
+    "babylon": {
+      "version": "7.0.0-beta.27",
+      "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.27.tgz",
+      "integrity": "sha512-ksRx+r8eFIfdt63MCgLc9VxGL7W3jcyveQvMpNMVHgW+eb9mq3Xbm45FLCNkw8h92RvoNp4uuiwzcCEwxjDBZg==",
+      "dev": true
     },
     "bach": {
       "version": "1.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1027,6 +1027,12 @@
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
       "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
     },
+    "accessibility-developer-tools": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/accessibility-developer-tools/-/accessibility-developer-tools-2.12.0.tgz",
+      "integrity": "sha1-PaDM6dbsY3OWS4TzXbfPw996tRQ=",
+      "dev": true
+    },
     "accord": {
       "version": "0.29.0",
       "resolved": "https://registry.npmjs.org/accord/-/accord-0.29.0.tgz",
@@ -1898,6 +1904,23 @@
       "resolved": "http://registry.npmjs.org/axe-core/-/axe-core-3.0.0-beta.2.tgz",
       "integrity": "sha512-JyMXnHDuzr6hei+mINWsR/iEyPBFSjpgF4/lUijO7QDGVKtTmdpDxc2+7X/xW+rPIwhcd72euJ2UunbRXF+1Eg==",
       "dev": true
+    },
+    "axe-webdriverjs": {
+      "version": "0.2.0",
+      "resolved": "http://registry.npmjs.org/axe-webdriverjs/-/axe-webdriverjs-0.2.0.tgz",
+      "integrity": "sha1-XjHtr26bozRCdiz9hd46B0c8EVU=",
+      "dev": true,
+      "requires": {
+        "axe-core": "1.1.1"
+      },
+      "dependencies": {
+        "axe-core": {
+          "version": "1.1.1",
+          "resolved": "http://registry.npmjs.org/axe-core/-/axe-core-1.1.1.tgz",
+          "integrity": "sha1-rp2l2oq08QQZB/H12N/jnJRqksU=",
+          "dev": true
+        }
+      }
     },
     "axios": {
       "version": "0.17.1",
@@ -14978,6 +15001,33 @@
             "semver": "5.6.0",
             "xml2js": "0.4.19"
           }
+        }
+      }
+    },
+    "protractor-accessibility-plugin": {
+      "version": "github:cfpb/protractor-accessibility-plugin#7319a881e222d9f3588f6d5d8a3d9848bc38c859",
+      "dev": true,
+      "requires": {
+        "accessibility-developer-tools": "2.12.0",
+        "axe-core": "2.6.1",
+        "axe-webdriverjs": "0.2.0",
+        "html-entities": "1.2.1",
+        "lodash": "3.10.1",
+        "q": "1.5.1",
+        "request": "2.88.0"
+      },
+      "dependencies": {
+        "axe-core": {
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-2.6.1.tgz",
+          "integrity": "sha512-QFfI3d+x/v92HJWGBaNfgrxdfon9/xXzd04YYfm5w5NJQOLex8qkJCctOt7+ky6e1l9zcQ5E7jsvbnTgQzyfTw==",
+          "dev": true
+        },
+        "lodash": {
+          "version": "3.10.1",
+          "resolved": "http://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+          "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
+          "dev": true
         }
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,260 @@
         "@babel/highlight": "7.0.0"
       }
     },
+    "@babel/core": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.1.2.tgz",
+      "integrity": "sha512-IFeSSnjXdhDaoysIlev//UzHZbdEmm7D0EIH2qtse9xK7mXEZQpYjs2P00XlP1qYsYvid79p+Zgg6tz1mp6iVw==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "7.0.0",
+        "@babel/generator": "7.1.3",
+        "@babel/helpers": "7.1.2",
+        "@babel/parser": "7.1.3",
+        "@babel/template": "7.1.2",
+        "@babel/traverse": "7.1.4",
+        "@babel/types": "7.1.3",
+        "convert-source-map": "1.6.0",
+        "debug": "3.2.6",
+        "json5": "0.5.1",
+        "lodash": "4.17.11",
+        "resolve": "1.8.1",
+        "semver": "5.6.0",
+        "source-map": "0.5.7"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true
+        }
+      }
+    },
+    "@babel/generator": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.1.3.tgz",
+      "integrity": "sha512-ZoCZGcfIJFJuZBqxcY9OjC1KW2lWK64qrX1o4UYL3yshVhwKFYgzpWZ0vvtGMNJdTlvkw0W+HR1VnYN8q3QPFQ==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "7.1.3",
+        "jsesc": "2.5.1",
+        "lodash": "4.17.11",
+        "source-map": "0.5.7",
+        "trim-right": "1.0.1"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true
+        }
+      }
+    },
+    "@babel/helper-annotate-as-pure": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.0.0.tgz",
+      "integrity": "sha512-3UYcJUj9kvSLbLbUIfQTqzcy5VX7GRZ/CCDrnOaZorFFM01aXp1+GJwuFGV4NDDoAS+mOUyHcO6UD/RfqOks3Q==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "7.1.3"
+      }
+    },
+    "@babel/helper-builder-binary-assignment-operator-visitor": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.1.0.tgz",
+      "integrity": "sha512-qNSR4jrmJ8M1VMM9tibvyRAHXQs2PmaksQF7c1CGJNipfe3D8p+wgNwgso/P2A2r2mdgBWAXljNWR0QRZAMW8w==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-explode-assignable-expression": "7.1.0",
+        "@babel/types": "7.1.3"
+      }
+    },
+    "@babel/helper-call-delegate": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-call-delegate/-/helper-call-delegate-7.1.0.tgz",
+      "integrity": "sha512-YEtYZrw3GUK6emQHKthltKNZwszBcHK58Ygcis+gVUrF4/FmTVr5CCqQNSfmvg2y+YDEANyYoaLz/SHsnusCwQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-hoist-variables": "7.0.0",
+        "@babel/traverse": "7.1.4",
+        "@babel/types": "7.1.3"
+      }
+    },
+    "@babel/helper-define-map": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.1.0.tgz",
+      "integrity": "sha512-yPPcW8dc3gZLN+U1mhYV91QU3n5uTbx7DUdf8NnPbjS0RMwBuHi9Xt2MUgppmNz7CJxTBWsGczTiEp1CSOTPRg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-function-name": "7.1.0",
+        "@babel/types": "7.1.3",
+        "lodash": "4.17.11"
+      }
+    },
+    "@babel/helper-explode-assignable-expression": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.1.0.tgz",
+      "integrity": "sha512-NRQpfHrJ1msCHtKjbzs9YcMmJZOg6mQMmGRB+hbamEdG5PNpaSm95275VD92DvJKuyl0s2sFiDmMZ+EnnvufqA==",
+      "dev": true,
+      "requires": {
+        "@babel/traverse": "7.1.4",
+        "@babel/types": "7.1.3"
+      }
+    },
+    "@babel/helper-function-name": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.1.0.tgz",
+      "integrity": "sha512-A95XEoCpb3TO+KZzJ4S/5uW5fNe26DjBGqf1o9ucyLyCmi1dXq/B3c8iaWTfBk3VvetUxl16e8tIrd5teOCfGw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-get-function-arity": "7.0.0",
+        "@babel/template": "7.1.2",
+        "@babel/types": "7.1.3"
+      }
+    },
+    "@babel/helper-get-function-arity": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0.tgz",
+      "integrity": "sha512-r2DbJeg4svYvt3HOS74U4eWKsUAMRH01Z1ds1zx8KNTPtpTL5JAsdFv8BNyOpVqdFhHkkRDIg5B4AsxmkjAlmQ==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "7.1.3"
+      }
+    },
+    "@babel/helper-hoist-variables": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.0.0.tgz",
+      "integrity": "sha512-Ggv5sldXUeSKsuzLkddtyhyHe2YantsxWKNi7A+7LeD12ExRDWTRk29JCXpaHPAbMaIPZSil7n+lq78WY2VY7w==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "7.1.3"
+      }
+    },
+    "@babel/helper-member-expression-to-functions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.0.0.tgz",
+      "integrity": "sha512-avo+lm/QmZlv27Zsi0xEor2fKcqWG56D5ae9dzklpIaY7cQMK5N8VSpaNVPPagiqmy7LrEjK1IWdGMOqPu5csg==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "7.1.3"
+      }
+    },
+    "@babel/helper-module-imports": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.0.0.tgz",
+      "integrity": "sha512-aP/hlLq01DWNEiDg4Jn23i+CXxW/owM4WpDLFUbpjxe4NS3BhLVZQ5i7E0ZrxuQ/vwekIeciyamgB1UIYxxM6A==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "7.1.3"
+      }
+    },
+    "@babel/helper-module-transforms": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.1.0.tgz",
+      "integrity": "sha512-0JZRd2yhawo79Rcm4w0LwSMILFmFXjugG3yqf+P/UsKsRS1mJCmMwwlHDlMg7Avr9LrvSpp4ZSULO9r8jpCzcw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-imports": "7.0.0",
+        "@babel/helper-simple-access": "7.1.0",
+        "@babel/helper-split-export-declaration": "7.0.0",
+        "@babel/template": "7.1.2",
+        "@babel/types": "7.1.3",
+        "lodash": "4.17.11"
+      }
+    },
+    "@babel/helper-optimise-call-expression": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.0.0.tgz",
+      "integrity": "sha512-u8nd9NQePYNQV8iPWu/pLLYBqZBa4ZaY1YWRFMuxrid94wKI1QNt67NEZ7GAe5Kc/0LLScbim05xZFWkAdrj9g==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "7.1.3"
+      }
+    },
+    "@babel/helper-plugin-utils": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0.tgz",
+      "integrity": "sha512-CYAOUCARwExnEixLdB6sDm2dIJ/YgEAKDM1MOeMeZu9Ld/bDgVo8aiWrXwcY7OBh+1Ea2uUcVRcxKk0GJvW7QA==",
+      "dev": true
+    },
+    "@babel/helper-regex": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.0.0.tgz",
+      "integrity": "sha512-TR0/N0NDCcUIUEbqV6dCO+LptmmSQFQ7q70lfcEB4URsjD0E1HzicrwUH+ap6BAQ2jhCX9Q4UqZy4wilujWlkg==",
+      "dev": true,
+      "requires": {
+        "lodash": "4.17.11"
+      }
+    },
+    "@babel/helper-remap-async-to-generator": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.1.0.tgz",
+      "integrity": "sha512-3fOK0L+Fdlg8S5al8u/hWE6vhufGSn0bN09xm2LXMy//REAF8kDCrYoOBKYmA8m5Nom+sV9LyLCwrFynA8/slg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-annotate-as-pure": "7.0.0",
+        "@babel/helper-wrap-function": "7.1.0",
+        "@babel/template": "7.1.2",
+        "@babel/traverse": "7.1.4",
+        "@babel/types": "7.1.3"
+      }
+    },
+    "@babel/helper-replace-supers": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.1.0.tgz",
+      "integrity": "sha512-BvcDWYZRWVuDeXTYZWxekQNO5D4kO55aArwZOTFXw6rlLQA8ZaDicJR1sO47h+HrnCiDFiww0fSPV0d713KBGQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-member-expression-to-functions": "7.0.0",
+        "@babel/helper-optimise-call-expression": "7.0.0",
+        "@babel/traverse": "7.1.4",
+        "@babel/types": "7.1.3"
+      }
+    },
+    "@babel/helper-simple-access": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.1.0.tgz",
+      "integrity": "sha512-Vk+78hNjRbsiu49zAPALxTb+JUQCz1aolpd8osOF16BGnLtseD21nbHgLPGUwrXEurZgiCOUmvs3ExTu4F5x6w==",
+      "dev": true,
+      "requires": {
+        "@babel/template": "7.1.2",
+        "@babel/types": "7.1.3"
+      }
+    },
+    "@babel/helper-split-export-declaration": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0.tgz",
+      "integrity": "sha512-MXkOJqva62dfC0w85mEf/LucPPS/1+04nmmRMPEBUB++hiiThQ2zPtX/mEWQ3mtzCEjIJvPY8nuwxXtQeQwUag==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "7.1.3"
+      }
+    },
+    "@babel/helper-wrap-function": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.1.0.tgz",
+      "integrity": "sha512-R6HU3dete+rwsdAfrOzTlE9Mcpk4RjU3aX3gi9grtmugQY0u79X7eogUvfXA5sI81Mfq1cn6AgxihfN33STjJA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-function-name": "7.1.0",
+        "@babel/template": "7.1.2",
+        "@babel/traverse": "7.1.4",
+        "@babel/types": "7.1.3"
+      }
+    },
+    "@babel/helpers": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.1.2.tgz",
+      "integrity": "sha512-Myc3pUE8eswD73aWcartxB16K6CGmHDv9KxOmD2CeOs/FaEAQodr3VYGmlvOmog60vNQ2w8QbatuahepZwrHiA==",
+      "dev": true,
+      "requires": {
+        "@babel/template": "7.1.2",
+        "@babel/traverse": "7.1.4",
+        "@babel/types": "7.1.3"
+      }
+    },
     "@babel/highlight": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0.tgz",
@@ -29,6 +283,481 @@
           "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
           "dev": true
         }
+      }
+    },
+    "@babel/parser": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.1.3.tgz",
+      "integrity": "sha512-gqmspPZOMW3MIRb9HlrnbZHXI1/KHTOroBwN1NcLL6pWxzqzEKGvRTq0W/PxS45OtQGbaFikSQpkS5zbnsQm2w==",
+      "dev": true
+    },
+    "@babel/plugin-proposal-async-generator-functions": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.1.0.tgz",
+      "integrity": "sha512-Fq803F3Jcxo20MXUSDdmZZXrPe6BWyGcWBPPNB/M7WaUYESKDeKMOGIxEzQOjGSmW/NWb6UaPZrtTB2ekhB/ew==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "7.0.0",
+        "@babel/helper-remap-async-to-generator": "7.1.0",
+        "@babel/plugin-syntax-async-generators": "7.0.0"
+      }
+    },
+    "@babel/plugin-proposal-json-strings": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.0.0.tgz",
+      "integrity": "sha512-kfVdUkIAGJIVmHmtS/40i/fg/AGnw/rsZBCaapY5yjeO5RA9m165Xbw9KMOu2nqXP5dTFjEjHdfNdoVcHv133Q==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "7.0.0",
+        "@babel/plugin-syntax-json-strings": "7.0.0"
+      }
+    },
+    "@babel/plugin-proposal-object-rest-spread": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.0.0.tgz",
+      "integrity": "sha512-14fhfoPcNu7itSen7Py1iGN0gEm87hX/B+8nZPqkdmANyyYWYMY2pjA3r8WXbWVKMzfnSNS0xY8GVS0IjXi/iw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "7.0.0",
+        "@babel/plugin-syntax-object-rest-spread": "7.0.0"
+      }
+    },
+    "@babel/plugin-proposal-optional-catch-binding": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.0.0.tgz",
+      "integrity": "sha512-JPqAvLG1s13B/AuoBjdBYvn38RqW6n1TzrQO839/sIpqLpbnXKacsAgpZHzLD83Sm8SDXMkkrAvEnJ25+0yIpw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "7.0.0",
+        "@babel/plugin-syntax-optional-catch-binding": "7.0.0"
+      }
+    },
+    "@babel/plugin-proposal-unicode-property-regex": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.0.0.tgz",
+      "integrity": "sha512-tM3icA6GhC3ch2SkmSxv7J/hCWKISzwycub6eGsDrFDgukD4dZ/I+x81XgW0YslS6mzNuQ1Cbzh5osjIMgepPQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "7.0.0",
+        "@babel/helper-regex": "7.0.0",
+        "regexpu-core": "4.2.0"
+      }
+    },
+    "@babel/plugin-syntax-async-generators": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.0.0.tgz",
+      "integrity": "sha512-im7ged00ddGKAjcZgewXmp1vxSZQQywuQXe2B1A7kajjZmDeY/ekMPmWr9zJgveSaQH0k7BcGrojQhcK06l0zA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "7.0.0"
+      }
+    },
+    "@babel/plugin-syntax-json-strings": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.0.0.tgz",
+      "integrity": "sha512-UlSfNydC+XLj4bw7ijpldc1uZ/HB84vw+U6BTuqMdIEmz/LDe63w/GHtpQMdXWdqQZFeAI9PjnHe/vDhwirhKA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "7.0.0"
+      }
+    },
+    "@babel/plugin-syntax-object-rest-spread": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.0.0.tgz",
+      "integrity": "sha512-5A0n4p6bIiVe5OvQPxBnesezsgFJdHhSs3uFSvaPdMqtsovajLZ+G2vZyvNe10EzJBWWo3AcHGKhAFUxqwp2dw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "7.0.0"
+      }
+    },
+    "@babel/plugin-syntax-optional-catch-binding": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.0.0.tgz",
+      "integrity": "sha512-Wc+HVvwjcq5qBg1w5RG9o9RVzmCaAg/Vp0erHCKpAYV8La6I94o4GQAmFYNmkzoMO6gzoOSulpKeSSz6mPEoZw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "7.0.0"
+      }
+    },
+    "@babel/plugin-transform-arrow-functions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.0.0.tgz",
+      "integrity": "sha512-2EZDBl1WIO/q4DIkIp4s86sdp4ZifL51MoIviLY/gG/mLSuOIEg7J8o6mhbxOTvUJkaN50n+8u41FVsr5KLy/w==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "7.0.0"
+      }
+    },
+    "@babel/plugin-transform-async-to-generator": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.1.0.tgz",
+      "integrity": "sha512-rNmcmoQ78IrvNCIt/R9U+cixUHeYAzgusTFgIAv+wQb9HJU4szhpDD6e5GCACmj/JP5KxuCwM96bX3L9v4ZN/g==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-imports": "7.0.0",
+        "@babel/helper-plugin-utils": "7.0.0",
+        "@babel/helper-remap-async-to-generator": "7.1.0"
+      }
+    },
+    "@babel/plugin-transform-block-scoped-functions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.0.0.tgz",
+      "integrity": "sha512-AOBiyUp7vYTqz2Jibe1UaAWL0Hl9JUXEgjFvvvcSc9MVDItv46ViXFw2F7SVt1B5k+KWjl44eeXOAk3UDEaJjQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "7.0.0"
+      }
+    },
+    "@babel/plugin-transform-block-scoping": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.0.0.tgz",
+      "integrity": "sha512-GWEMCrmHQcYWISilUrk9GDqH4enf3UmhOEbNbNrlNAX1ssH3MsS1xLOS6rdjRVPgA7XXVPn87tRkdTEoA/dxEg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "7.0.0",
+        "lodash": "4.17.11"
+      }
+    },
+    "@babel/plugin-transform-classes": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.1.0.tgz",
+      "integrity": "sha512-rNaqoD+4OCBZjM7VaskladgqnZ1LO6o2UxuWSDzljzW21pN1KXkB7BstAVweZdxQkHAujps5QMNOTWesBciKFg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-annotate-as-pure": "7.0.0",
+        "@babel/helper-define-map": "7.1.0",
+        "@babel/helper-function-name": "7.1.0",
+        "@babel/helper-optimise-call-expression": "7.0.0",
+        "@babel/helper-plugin-utils": "7.0.0",
+        "@babel/helper-replace-supers": "7.1.0",
+        "@babel/helper-split-export-declaration": "7.0.0",
+        "globals": "11.8.0"
+      }
+    },
+    "@babel/plugin-transform-computed-properties": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.0.0.tgz",
+      "integrity": "sha512-ubouZdChNAv4AAWAgU7QKbB93NU5sHwInEWfp+/OzJKA02E6Woh9RVoX4sZrbRwtybky/d7baTUqwFx+HgbvMA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "7.0.0"
+      }
+    },
+    "@babel/plugin-transform-destructuring": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.1.3.tgz",
+      "integrity": "sha512-Mb9M4DGIOspH1ExHOUnn2UUXFOyVTiX84fXCd+6B5iWrQg/QMeeRmSwpZ9lnjYLSXtZwiw80ytVMr3zue0ucYw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "7.0.0"
+      }
+    },
+    "@babel/plugin-transform-dotall-regex": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.0.0.tgz",
+      "integrity": "sha512-00THs8eJxOJUFVx1w8i1MBF4XH4PsAjKjQ1eqN/uCH3YKwP21GCKfrn6YZFZswbOk9+0cw1zGQPHVc1KBlSxig==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "7.0.0",
+        "@babel/helper-regex": "7.0.0",
+        "regexpu-core": "4.2.0"
+      }
+    },
+    "@babel/plugin-transform-duplicate-keys": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.0.0.tgz",
+      "integrity": "sha512-w2vfPkMqRkdxx+C71ATLJG30PpwtTpW7DDdLqYt2acXU7YjztzeWW2Jk1T6hKqCLYCcEA5UQM/+xTAm+QCSnuQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "7.0.0"
+      }
+    },
+    "@babel/plugin-transform-exponentiation-operator": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.1.0.tgz",
+      "integrity": "sha512-uZt9kD1Pp/JubkukOGQml9tqAeI8NkE98oZnHZ2qHRElmeKCodbTZgOEUtujSCSLhHSBWbzNiFSDIMC4/RBTLQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-builder-binary-assignment-operator-visitor": "7.1.0",
+        "@babel/helper-plugin-utils": "7.0.0"
+      }
+    },
+    "@babel/plugin-transform-for-of": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.0.0.tgz",
+      "integrity": "sha512-TlxKecN20X2tt2UEr2LNE6aqA0oPeMT1Y3cgz8k4Dn1j5ObT8M3nl9aA37LLklx0PBZKETC9ZAf9n/6SujTuXA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "7.0.0"
+      }
+    },
+    "@babel/plugin-transform-function-name": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.1.0.tgz",
+      "integrity": "sha512-VxOa1TMlFMtqPW2IDYZQaHsFrq/dDoIjgN098NowhexhZcz3UGlvPgZXuE1jEvNygyWyxRacqDpCZt+par1FNg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-function-name": "7.1.0",
+        "@babel/helper-plugin-utils": "7.0.0"
+      }
+    },
+    "@babel/plugin-transform-literals": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.0.0.tgz",
+      "integrity": "sha512-1NTDBWkeNXgpUcyoVFxbr9hS57EpZYXpje92zv0SUzjdu3enaRwF/l3cmyRnXLtIdyJASyiS6PtybK+CgKf7jA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "7.0.0"
+      }
+    },
+    "@babel/plugin-transform-modules-amd": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.1.0.tgz",
+      "integrity": "sha512-wt8P+xQ85rrnGNr2x1iV3DW32W8zrB6ctuBkYBbf5/ZzJY99Ob4MFgsZDFgczNU76iy9PWsy4EuxOliDjdKw6A==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-transforms": "7.1.0",
+        "@babel/helper-plugin-utils": "7.0.0"
+      }
+    },
+    "@babel/plugin-transform-modules-commonjs": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.1.0.tgz",
+      "integrity": "sha512-wtNwtMjn1XGwM0AXPspQgvmE6msSJP15CX2RVfpTSTNPLhKhaOjaIfBaVfj4iUZ/VrFSodcFedwtPg/NxwQlPA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-transforms": "7.1.0",
+        "@babel/helper-plugin-utils": "7.0.0",
+        "@babel/helper-simple-access": "7.1.0"
+      }
+    },
+    "@babel/plugin-transform-modules-systemjs": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.1.3.tgz",
+      "integrity": "sha512-PvTxgjxQAq4pvVUZF3mD5gEtVDuId8NtWkJsZLEJZMZAW3TvgQl1pmydLLN1bM8huHFVVU43lf0uvjQj9FRkKw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-hoist-variables": "7.0.0",
+        "@babel/helper-plugin-utils": "7.0.0"
+      }
+    },
+    "@babel/plugin-transform-modules-umd": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.1.0.tgz",
+      "integrity": "sha512-enrRtn5TfRhMmbRwm7F8qOj0qEYByqUvTttPEGimcBH4CJHphjyK1Vg7sdU7JjeEmgSpM890IT/efS2nMHwYig==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-transforms": "7.1.0",
+        "@babel/helper-plugin-utils": "7.0.0"
+      }
+    },
+    "@babel/plugin-transform-new-target": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.0.0.tgz",
+      "integrity": "sha512-yin069FYjah+LbqfGeTfzIBODex/e++Yfa0rH0fpfam9uTbuEeEOx5GLGr210ggOV77mVRNoeqSYqeuaqSzVSw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "7.0.0"
+      }
+    },
+    "@babel/plugin-transform-object-super": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.1.0.tgz",
+      "integrity": "sha512-/O02Je1CRTSk2SSJaq0xjwQ8hG4zhZGNjE8psTsSNPXyLRCODv7/PBozqT5AmQMzp7MI3ndvMhGdqp9c96tTEw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "7.0.0",
+        "@babel/helper-replace-supers": "7.1.0"
+      }
+    },
+    "@babel/plugin-transform-parameters": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.1.0.tgz",
+      "integrity": "sha512-vHV7oxkEJ8IHxTfRr3hNGzV446GAb+0hgbA7o/0Jd76s+YzccdWuTU296FOCOl/xweU4t/Ya4g41yWz80RFCRw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-call-delegate": "7.1.0",
+        "@babel/helper-get-function-arity": "7.0.0",
+        "@babel/helper-plugin-utils": "7.0.0"
+      }
+    },
+    "@babel/plugin-transform-regenerator": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.0.0.tgz",
+      "integrity": "sha512-sj2qzsEx8KDVv1QuJc/dEfilkg3RRPvPYx/VnKLtItVQRWt1Wqf5eVCOLZm29CiGFfYYsA3VPjfizTCV0S0Dlw==",
+      "dev": true,
+      "requires": {
+        "regenerator-transform": "0.13.3"
+      },
+      "dependencies": {
+        "regenerator-transform": {
+          "version": "0.13.3",
+          "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.13.3.tgz",
+          "integrity": "sha512-5ipTrZFSq5vU2YoGoww4uaRVAK4wyYC4TSICibbfEPOruUu8FFP7ErV0BjmbIOEpn3O/k9na9UEdYR/3m7N6uA==",
+          "dev": true,
+          "requires": {
+            "private": "0.1.8"
+          }
+        }
+      }
+    },
+    "@babel/plugin-transform-shorthand-properties": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.0.0.tgz",
+      "integrity": "sha512-g/99LI4vm5iOf5r1Gdxq5Xmu91zvjhEG5+yZDJW268AZELAu4J1EiFLnkSG3yuUsZyOipVOVUKoGPYwfsTymhw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "7.0.0"
+      }
+    },
+    "@babel/plugin-transform-spread": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.0.0.tgz",
+      "integrity": "sha512-L702YFy2EvirrR4shTj0g2xQp7aNwZoWNCkNu2mcoU0uyzMl0XRwDSwzB/xp6DSUFiBmEXuyAyEN16LsgVqGGQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "7.0.0"
+      }
+    },
+    "@babel/plugin-transform-sticky-regex": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.0.0.tgz",
+      "integrity": "sha512-LFUToxiyS/WD+XEWpkx/XJBrUXKewSZpzX68s+yEOtIbdnsRjpryDw9U06gYc6klYEij/+KQVRnD3nz3AoKmjw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "7.0.0",
+        "@babel/helper-regex": "7.0.0"
+      }
+    },
+    "@babel/plugin-transform-template-literals": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.0.0.tgz",
+      "integrity": "sha512-vA6rkTCabRZu7Nbl9DfLZE1imj4tzdWcg5vtdQGvj+OH9itNNB6hxuRMHuIY8SGnEt1T9g5foqs9LnrHzsqEFg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-annotate-as-pure": "7.0.0",
+        "@babel/helper-plugin-utils": "7.0.0"
+      }
+    },
+    "@babel/plugin-transform-typeof-symbol": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.0.0.tgz",
+      "integrity": "sha512-1r1X5DO78WnaAIvs5uC48t41LLckxsYklJrZjNKcevyz83sF2l4RHbw29qrCPr/6ksFsdfRpT/ZgxNWHXRnffg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "7.0.0"
+      }
+    },
+    "@babel/plugin-transform-unicode-regex": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.0.0.tgz",
+      "integrity": "sha512-uJBrJhBOEa3D033P95nPHu3nbFwFE9ZgXsfEitzoIXIwqAZWk7uXcg06yFKXz9FSxBH5ucgU/cYdX0IV8ldHKw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "7.0.0",
+        "@babel/helper-regex": "7.0.0",
+        "regexpu-core": "4.2.0"
+      }
+    },
+    "@babel/preset-env": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.1.0.tgz",
+      "integrity": "sha512-ZLVSynfAoDHB/34A17/JCZbyrzbQj59QC1Anyueb4Bwjh373nVPq5/HMph0z+tCmcDjXDe+DlKQq9ywQuvWrQg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-imports": "7.0.0",
+        "@babel/helper-plugin-utils": "7.0.0",
+        "@babel/plugin-proposal-async-generator-functions": "7.1.0",
+        "@babel/plugin-proposal-json-strings": "7.0.0",
+        "@babel/plugin-proposal-object-rest-spread": "7.0.0",
+        "@babel/plugin-proposal-optional-catch-binding": "7.0.0",
+        "@babel/plugin-proposal-unicode-property-regex": "7.0.0",
+        "@babel/plugin-syntax-async-generators": "7.0.0",
+        "@babel/plugin-syntax-object-rest-spread": "7.0.0",
+        "@babel/plugin-syntax-optional-catch-binding": "7.0.0",
+        "@babel/plugin-transform-arrow-functions": "7.0.0",
+        "@babel/plugin-transform-async-to-generator": "7.1.0",
+        "@babel/plugin-transform-block-scoped-functions": "7.0.0",
+        "@babel/plugin-transform-block-scoping": "7.0.0",
+        "@babel/plugin-transform-classes": "7.1.0",
+        "@babel/plugin-transform-computed-properties": "7.0.0",
+        "@babel/plugin-transform-destructuring": "7.1.3",
+        "@babel/plugin-transform-dotall-regex": "7.0.0",
+        "@babel/plugin-transform-duplicate-keys": "7.0.0",
+        "@babel/plugin-transform-exponentiation-operator": "7.1.0",
+        "@babel/plugin-transform-for-of": "7.0.0",
+        "@babel/plugin-transform-function-name": "7.1.0",
+        "@babel/plugin-transform-literals": "7.0.0",
+        "@babel/plugin-transform-modules-amd": "7.1.0",
+        "@babel/plugin-transform-modules-commonjs": "7.1.0",
+        "@babel/plugin-transform-modules-systemjs": "7.1.3",
+        "@babel/plugin-transform-modules-umd": "7.1.0",
+        "@babel/plugin-transform-new-target": "7.0.0",
+        "@babel/plugin-transform-object-super": "7.1.0",
+        "@babel/plugin-transform-parameters": "7.1.0",
+        "@babel/plugin-transform-regenerator": "7.0.0",
+        "@babel/plugin-transform-shorthand-properties": "7.0.0",
+        "@babel/plugin-transform-spread": "7.0.0",
+        "@babel/plugin-transform-sticky-regex": "7.0.0",
+        "@babel/plugin-transform-template-literals": "7.0.0",
+        "@babel/plugin-transform-typeof-symbol": "7.0.0",
+        "@babel/plugin-transform-unicode-regex": "7.0.0",
+        "browserslist": "4.3.4",
+        "invariant": "2.2.4",
+        "js-levenshtein": "1.1.4",
+        "semver": "5.6.0"
+      },
+      "dependencies": {
+        "browserslist": {
+          "version": "4.3.4",
+          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.3.4.tgz",
+          "integrity": "sha512-u5iz+ijIMUlmV8blX82VGFrB9ecnUg5qEt55CMZ/YJEhha+d8qpBfOFuutJ6F/VKRXjZoD33b6uvarpPxcl3RA==",
+          "dev": true,
+          "requires": {
+            "caniuse-lite": "1.0.30000899",
+            "electron-to-chromium": "1.3.82",
+            "node-releases": "1.0.3"
+          }
+        }
+      }
+    },
+    "@babel/template": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.1.2.tgz",
+      "integrity": "sha512-SY1MmplssORfFiLDcOETrW7fCLl+PavlwMh92rrGcikQaRq4iWPVH0MpwPpY3etVMx6RnDjXtr6VZYr/IbP/Ag==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "7.0.0",
+        "@babel/parser": "7.1.3",
+        "@babel/types": "7.1.3"
+      }
+    },
+    "@babel/traverse": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.1.4.tgz",
+      "integrity": "sha512-my9mdrAIGdDiSVBuMjpn/oXYpva0/EZwWL3sm3Wcy/AVWO2eXnsoZruOT9jOGNRXU8KbCIu5zsKnXcAJ6PcV6Q==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "7.0.0",
+        "@babel/generator": "7.1.3",
+        "@babel/helper-function-name": "7.1.0",
+        "@babel/helper-split-export-declaration": "7.0.0",
+        "@babel/parser": "7.1.3",
+        "@babel/types": "7.1.3",
+        "debug": "3.2.6",
+        "globals": "11.8.0",
+        "lodash": "4.17.11"
+      }
+    },
+    "@babel/types": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.1.3.tgz",
+      "integrity": "sha512-RpPOVfK+yatXyn8n4PB1NW6k9qjinrXrRR8ugBN8fD6hCy5RXI6PSbVqpOJBO9oSaY7Nom4ohj35feb0UR9hSA==",
+      "dev": true,
+      "requires": {
+        "esutils": "2.0.2",
+        "lodash": "4.17.11",
+        "to-fast-properties": "2.0.0"
       }
     },
     "@gulp-sourcemaps/identity-map": {
@@ -877,6 +1606,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
       "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+      "dev": true,
       "requires": {
         "arr-flatten": "1.1.0"
       }
@@ -998,7 +1728,8 @@
     "array-unique": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-      "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM="
+      "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
+      "dev": true
     },
     "arrify": {
       "version": "1.0.1",
@@ -1148,6 +1879,7 @@
       "version": "8.6.5",
       "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-8.6.5.tgz",
       "integrity": "sha512-PLWJN3Xo/rycNkx+mp8iBDMTm3FeWe4VmYaZDSqL5QQB9sLsQkG5k8n+LNDFnhh9kdq2K+egL/icpctOmDHwig==",
+      "dev": true,
       "requires": {
         "browserslist": "3.2.8",
         "caniuse-lite": "1.0.30000899",
@@ -1200,225 +1932,11 @@
         "is-buffer": "1.1.6"
       }
     },
-    "babel-code-frame": {
-      "version": "7.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-7.0.0-beta.3.tgz",
-      "integrity": "sha512-flMsJ9eSpShupt2Gwpka84DoMePvE4HlDObzdEc+1iNkacv3+NHlsJ7dMKmbnVA/AT22UhcGEBHwbJLoXWBO6Q==",
-      "requires": {
-        "chalk": "2.4.1",
-        "esutils": "2.0.2",
-        "js-tokens": "3.0.2"
-      }
-    },
     "babel-core": {
-      "version": "7.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-7.0.0-beta.3.tgz",
-      "integrity": "sha512-zdng6WxI4cUjvstvFo/ke+hxohXCi/vxrMTM1S/bsAqnvKb+C+pHx78T3ZdJlWC3bGGxYqUnmM4p9VMzJ0uVVg==",
-      "requires": {
-        "babel-code-frame": "7.0.0-beta.3",
-        "babel-generator": "7.0.0-beta.3",
-        "babel-helpers": "7.0.0-beta.3",
-        "babel-template": "7.0.0-beta.3",
-        "babel-traverse": "7.0.0-beta.3",
-        "babel-types": "7.0.0-beta.3",
-        "babylon": "7.0.0-beta.27",
-        "convert-source-map": "1.6.0",
-        "debug": "3.2.6",
-        "json5": "0.5.1",
-        "lodash": "4.17.11",
-        "micromatch": "2.3.11",
-        "resolve": "1.8.1",
-        "source-map": "0.5.7"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
-        }
-      }
-    },
-    "babel-generator": {
-      "version": "7.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-7.0.0-beta.3.tgz",
-      "integrity": "sha512-Bok77tKwQZUVaLBRnDGDEaMZ4xEeyvzsgnCRxlVgfKmgn+vPxuka//ug3nrMmmgZ8TAMVPoXzeaAcs47lExrPg==",
-      "requires": {
-        "babel-types": "7.0.0-beta.3",
-        "jsesc": "2.5.1",
-        "lodash": "4.17.11",
-        "source-map": "0.5.7",
-        "trim-right": "1.0.1"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
-        }
-      }
-    },
-    "babel-helper-annotate-as-pure": {
-      "version": "7.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/babel-helper-annotate-as-pure/-/babel-helper-annotate-as-pure-7.0.0-beta.3.tgz",
-      "integrity": "sha512-C6uYc7RmuPDZmkwTaV/ya0BGuZJFyuU/mAyDDqSfyuUZavk04eKdEWxjaKRGd3UA/fpzLNKViYO4aQgY4TsxCQ==",
-      "requires": {
-        "babel-types": "7.0.0-beta.3"
-      }
-    },
-    "babel-helper-builder-binary-assignment-operator-visitor": {
-      "version": "7.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-7.0.0-beta.3.tgz",
-      "integrity": "sha512-faPNvJ2w/YLRN0pD3mX3Ro/Og+uBNMdwPXg2bq5xXERQCyuYWzAmVbKnjGNaI4CLPDEbAZiZpq+AlMO3cT0QQA==",
-      "requires": {
-        "babel-helper-explode-assignable-expression": "7.0.0-beta.3",
-        "babel-types": "7.0.0-beta.3"
-      }
-    },
-    "babel-helper-call-delegate": {
-      "version": "7.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-7.0.0-beta.3.tgz",
-      "integrity": "sha512-omi9OEknlyt8LxZ46SRVMY/20EpwU2GMkXHcswcGNANNcaB3aiDcYQRAgtU0vrhjD/+fIGb9xl7+plpUnADKIw==",
-      "requires": {
-        "babel-helper-hoist-variables": "7.0.0-beta.3",
-        "babel-traverse": "7.0.0-beta.3",
-        "babel-types": "7.0.0-beta.3"
-      }
-    },
-    "babel-helper-define-map": {
-      "version": "7.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-7.0.0-beta.3.tgz",
-      "integrity": "sha512-F2DrZDfS4EIFi5HTK3eaL8ojJwM6jjEM26D/i7h1YAwlm6PytiOXlhcXNbOoSBv6767WesNWpLVDQoX68SjDrQ==",
-      "requires": {
-        "babel-helper-function-name": "7.0.0-beta.3",
-        "babel-types": "7.0.0-beta.3",
-        "lodash": "4.17.11"
-      }
-    },
-    "babel-helper-explode-assignable-expression": {
-      "version": "7.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-7.0.0-beta.3.tgz",
-      "integrity": "sha512-MugrfM38GSj7+8I/yFYjQwOEPSGmCLsJFNrWz7KVH4HA5Ntim19cMmdMUWSls30rTeGYQpLECjHNFv+ITbA7wA==",
-      "requires": {
-        "babel-traverse": "7.0.0-beta.3",
-        "babel-types": "7.0.0-beta.3"
-      }
-    },
-    "babel-helper-function-name": {
-      "version": "7.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-7.0.0-beta.3.tgz",
-      "integrity": "sha512-iMWYqwDarQOVlEGcK1MfbtK9vrFGs5Z4UQsdASJUHdhBp918EM5kndwriiIbhUX8gr2B/CEV/udJkFTrHsjdMQ==",
-      "requires": {
-        "babel-helper-get-function-arity": "7.0.0-beta.3",
-        "babel-template": "7.0.0-beta.3",
-        "babel-traverse": "7.0.0-beta.3",
-        "babel-types": "7.0.0-beta.3"
-      }
-    },
-    "babel-helper-get-function-arity": {
-      "version": "7.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-7.0.0-beta.3.tgz",
-      "integrity": "sha512-ZkYFRMWKx1c9fUW72YNM3eieBG701CMbLjmLLWmJTTPc0F0kddS9Fwok26EAmndUAgD6kFdh7ms3PH94MdGuGQ==",
-      "requires": {
-        "babel-types": "7.0.0-beta.3"
-      }
-    },
-    "babel-helper-hoist-variables": {
-      "version": "7.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-7.0.0-beta.3.tgz",
-      "integrity": "sha512-9XOLW0nN3154gYf0OrRpatRYpB5s5NkRAcFseGYn/sxf+450iURwq442O7USvg9dRl1WWBgH23fsQQ5+xjKsGw==",
-      "requires": {
-        "babel-types": "7.0.0-beta.3"
-      }
-    },
-    "babel-helper-module-imports": {
-      "version": "7.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/babel-helper-module-imports/-/babel-helper-module-imports-7.0.0-beta.3.tgz",
-      "integrity": "sha512-bdPrIXbUTYfREhRhjbN8SstwQaj0S4+rW4PKi1f2Wc5fizSh0hGYkfXUdiSSOgyTydm956tAyz4FrG61bqdQyw==",
-      "requires": {
-        "babel-types": "7.0.0-beta.3",
-        "lodash": "4.17.11"
-      }
-    },
-    "babel-helper-module-transforms": {
-      "version": "7.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/babel-helper-module-transforms/-/babel-helper-module-transforms-7.0.0-beta.3.tgz",
-      "integrity": "sha512-mnCAqH2fpcYny6LMyCg/bMif/D8FxER/at9R3xNWvfAv2N5x5Yhai0g8tBQZuINqZkAxQ4Tl7x/8ImviwKBQSA==",
-      "requires": {
-        "babel-helper-module-imports": "7.0.0-beta.3",
-        "babel-helper-simple-access": "7.0.0-beta.3",
-        "babel-template": "7.0.0-beta.3",
-        "babel-types": "7.0.0-beta.3",
-        "lodash": "4.17.11"
-      }
-    },
-    "babel-helper-optimise-call-expression": {
-      "version": "7.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-7.0.0-beta.3.tgz",
-      "integrity": "sha512-X614MCHT+to5dnH4uecU63VUmOs+4Hn8DfH6vT2090HHE9/swOuNFKpeNeI3hebt59eAYyoWb2iPGv7FTpIh3Q==",
-      "requires": {
-        "babel-types": "7.0.0-beta.3"
-      }
-    },
-    "babel-helper-regex": {
-      "version": "7.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-7.0.0-beta.3.tgz",
-      "integrity": "sha512-ZmM3LrVJec0WUzugRvEvoNkoGygkN7PGSB3ZS2XiACb39t2uQhFzaVuaucYTGupXNt3aZ71usE1vt55FlVEFqg==",
-      "requires": {
-        "lodash": "4.17.11"
-      }
-    },
-    "babel-helper-remap-async-to-generator": {
-      "version": "7.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-7.0.0-beta.3.tgz",
-      "integrity": "sha512-zTuzSAn4FM7WlduV9o/GoY7iU1Rfm6WqO6edwZ3LwexnJ/eGEa/46DNUYSUA2ApvXjRX/J7Ox9TRJHv2U4xbhg==",
-      "requires": {
-        "babel-helper-wrap-function": "7.0.0-beta.3",
-        "babel-template": "7.0.0-beta.3",
-        "babel-traverse": "7.0.0-beta.3",
-        "babel-types": "7.0.0-beta.3"
-      }
-    },
-    "babel-helper-replace-supers": {
-      "version": "7.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-7.0.0-beta.3.tgz",
-      "integrity": "sha512-ZkTdE7XBDW0PUQkKTeax+m1JpZqzo9ze3zbqjRxyt+x328NeGLD3edmNCIxmFt86njxIo3AFfZ00PKd4g/7jqg==",
-      "requires": {
-        "babel-helper-optimise-call-expression": "7.0.0-beta.3",
-        "babel-template": "7.0.0-beta.3",
-        "babel-traverse": "7.0.0-beta.3",
-        "babel-types": "7.0.0-beta.3"
-      }
-    },
-    "babel-helper-simple-access": {
-      "version": "7.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/babel-helper-simple-access/-/babel-helper-simple-access-7.0.0-beta.3.tgz",
-      "integrity": "sha512-4gaS4Eej6+qY35EWuwtkDQ47oKTRIBmGEGMzTigyDVjRfNltAlhN8lZPhNsIcKxG3zJ/UTOhtx7j8dmn757PUw==",
-      "requires": {
-        "babel-template": "7.0.0-beta.3",
-        "babel-types": "7.0.0-beta.3",
-        "lodash": "4.17.11"
-      }
-    },
-    "babel-helper-wrap-function": {
-      "version": "7.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/babel-helper-wrap-function/-/babel-helper-wrap-function-7.0.0-beta.3.tgz",
-      "integrity": "sha512-uje7ahcNwS0vn6/Uw+4zSycwOcasFIB/2ek5dMQ3K3OICsXPmeDn9cKaugot+q1TfsyN9wfU9qEAEIZvIllWNQ==",
-      "requires": {
-        "babel-helper-function-name": "7.0.0-beta.3",
-        "babel-template": "7.0.0-beta.3",
-        "babel-traverse": "7.0.0-beta.3",
-        "babel-types": "7.0.0-beta.3"
-      }
-    },
-    "babel-helpers": {
-      "version": "7.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-7.0.0-beta.3.tgz",
-      "integrity": "sha512-zNX7FgdXT8645igxTyAVIArMbxUsFl1w3K+v+SKlGbDocIVjWMnRszRfgVwJflzI11yE0kY+fy6SNfulykW8CA==",
-      "requires": {
-        "babel-template": "7.0.0-beta.3",
-        "babel-traverse": "7.0.0-beta.3",
-        "babel-types": "7.0.0-beta.3"
-      }
+      "version": "7.0.0-bridge.0",
+      "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-7.0.0-bridge.0.tgz",
+      "integrity": "sha512-poPX9mZH/5CSanm50Q+1toVci6pv5KSRv/5TWCwtzQS5XEwn40BcCrgIeMFWP9CKKIniKXNxoIOnOq4VVlGXhg==",
+      "dev": true
     },
     "babel-jest": {
       "version": "23.6.0",
@@ -1431,13 +1949,15 @@
       }
     },
     "babel-loader": {
-      "version": "7.1.5",
-      "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-7.1.5.tgz",
-      "integrity": "sha512-iCHfbieL5d1LfOQeeVJEUyD9rTwBcP/fcEbRCfempxTDuqrKpu0AZjLAQHEQa3Yqyj9ORKe2iHfoj4rHLf7xpw==",
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-8.0.4.tgz",
+      "integrity": "sha512-fhBhNkUToJcW9nV46v8w87AJOwAJDz84c1CL57n3Stj73FANM/b9TbCUK4YhdOwEyZ+OxhYpdeZDNzSI29Firw==",
+      "dev": true,
       "requires": {
         "find-cache-dir": "1.0.0",
         "loader-utils": "1.1.0",
-        "mkdirp": "0.5.1"
+        "mkdirp": "0.5.1",
+        "util.promisify": "1.0.0"
       }
     },
     "babel-messages": {
@@ -1448,11 +1968,6 @@
       "requires": {
         "babel-runtime": "6.26.0"
       }
-    },
-    "babel-plugin-check-es2015-constants": {
-      "version": "7.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-7.0.0-beta.3.tgz",
-      "integrity": "sha512-cosavMPmT+fz17Bugk2sK60k/U+AkniFntFWx09aOkidkRSL9gRAJaE7zg6A8J6uBbWDi7XKdm+47T9iia5KYw=="
     },
     "babel-plugin-istanbul": {
       "version": "4.1.6",
@@ -1479,359 +1994,6 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-23.2.0.tgz",
       "integrity": "sha1-5h+uBaHKiAGq3uV6bWa4zvr0QWc=",
       "dev": true
-    },
-    "babel-plugin-syntax-async-functions": {
-      "version": "7.0.0-beta.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-7.0.0-beta.0.tgz",
-      "integrity": "sha512-IKh5AA3LKrqluJVc3xVE0i4zD7OIW1Iyua4uZQ3PCwey5lv/pM668eYhIEQT3fj8SmdP3cXVquvKQ0IdMVgQxg=="
-    },
-    "babel-plugin-syntax-async-generators": {
-      "version": "7.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-generators/-/babel-plugin-syntax-async-generators-7.0.0-beta.3.tgz",
-      "integrity": "sha512-isPmqPGxMKOoXF+bzIlA+MjwhbLRhLrqc2mA/7HWFuu7fGtTWG9XGlFVd9aR7pTkGMh+cVcFsUCLhvEaojC9xA=="
-    },
-    "babel-plugin-syntax-exponentiation-operator": {
-      "version": "7.0.0-beta.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-7.0.0-beta.0.tgz",
-      "integrity": "sha512-qFH1aInJPJefgefIXekOtNkzyjlfC2TOIp+O27ya0jFhtuUAqfAmEgVTIjYSi0E5mCpT70IeCZ6J0Rz62F+uog=="
-    },
-    "babel-plugin-syntax-object-rest-spread": {
-      "version": "7.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-7.0.0-beta.3.tgz",
-      "integrity": "sha512-21/MnmUFduLr4JzxrKMm/MeF+Jjyi5UdZo38IqzrP0sLhmPbal5ZAUJ4HgWH4339SdjnYgENacbY5wfk/zxTGg=="
-    },
-    "babel-plugin-syntax-optional-catch-binding": {
-      "version": "7.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-optional-catch-binding/-/babel-plugin-syntax-optional-catch-binding-7.0.0-beta.3.tgz",
-      "integrity": "sha512-IDrRx+htXqZO0IvQ0Heru01LDfDvC2lIFeM19pVS0EHVLy4Bpj5Sg0o7joOjj1j8ewzgSJLC1FOXqj7zXVedkg=="
-    },
-    "babel-plugin-syntax-trailing-function-commas": {
-      "version": "7.0.0-beta.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-7.0.0-beta.0.tgz",
-      "integrity": "sha512-Xj9XuRuz3nTSbaTXWv3itLOcxyF4oPD8douBBmj7U9BBC6nEBYfyOJYQMf/8PJAFotC62UY5dFfIGEPr7WswzQ=="
-    },
-    "babel-plugin-transform-async-generator-functions": {
-      "version": "7.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-async-generator-functions/-/babel-plugin-transform-async-generator-functions-7.0.0-beta.3.tgz",
-      "integrity": "sha512-sIVkKihVjq930ONro7sMo080kyIznrEDdMmq4JX1OYtDVV9OiiUF/yrHnc2tBrldOzTYyD3iPeIskTDuRVAnfA==",
-      "requires": {
-        "babel-helper-remap-async-to-generator": "7.0.0-beta.3",
-        "babel-plugin-syntax-async-generators": "7.0.0-beta.3"
-      }
-    },
-    "babel-plugin-transform-async-to-generator": {
-      "version": "7.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-7.0.0-beta.3.tgz",
-      "integrity": "sha512-LDOTVxH72pFNl9l9KQic0Pi0owwxvolcTg9IbA5QzdLo49Y9oe5GwYQxqHNGbVDOlm62iJ8cYbRA2+gLJpAzwQ==",
-      "requires": {
-        "babel-helper-remap-async-to-generator": "7.0.0-beta.3",
-        "babel-plugin-syntax-async-functions": "7.0.0-beta.0"
-      }
-    },
-    "babel-plugin-transform-es2015-arrow-functions": {
-      "version": "7.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-7.0.0-beta.3.tgz",
-      "integrity": "sha512-zrdLNzy22R6hzRrlSTPJWmN6N0Z11S0GPHE6R8SpSeAN4p9REgOOmNgfdHn5Nw3hDxWyvrPnBXdYug9HpBt8Yg=="
-    },
-    "babel-plugin-transform-es2015-block-scoped-functions": {
-      "version": "7.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-7.0.0-beta.3.tgz",
-      "integrity": "sha512-IzUjWeIa5670asiCA/xsyuH5lQYdsTJf3+yYssp/7/4KkUX7yWhP+L+VAihBGK9QtoyHE7dopIbRo/In07VWcQ=="
-    },
-    "babel-plugin-transform-es2015-block-scoping": {
-      "version": "7.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-7.0.0-beta.3.tgz",
-      "integrity": "sha512-Jm4ozOLdFkZpMCXhJLQ0y/+Nh920jV0b5ORrKhSu1jW3uaokhINi6tCLgJrQ/CwKPbVHlra+JwPVN+pITJjE7w==",
-      "requires": {
-        "babel-template": "7.0.0-beta.3",
-        "babel-traverse": "7.0.0-beta.3",
-        "babel-types": "7.0.0-beta.3",
-        "lodash": "4.17.11"
-      }
-    },
-    "babel-plugin-transform-es2015-classes": {
-      "version": "7.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-7.0.0-beta.3.tgz",
-      "integrity": "sha512-4vH3pzhx3oZ6rphe3EDCkxFfMsWlJoEMSk8pIHnfXm4dOL+goij5mrxqoTAh7W/DcMzpakZOdKkgsgg+iujg8Q==",
-      "requires": {
-        "babel-helper-annotate-as-pure": "7.0.0-beta.3",
-        "babel-helper-define-map": "7.0.0-beta.3",
-        "babel-helper-function-name": "7.0.0-beta.3",
-        "babel-helper-optimise-call-expression": "7.0.0-beta.3",
-        "babel-helper-replace-supers": "7.0.0-beta.3",
-        "babel-template": "7.0.0-beta.3",
-        "babel-traverse": "7.0.0-beta.3",
-        "babel-types": "7.0.0-beta.3"
-      }
-    },
-    "babel-plugin-transform-es2015-computed-properties": {
-      "version": "7.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-7.0.0-beta.3.tgz",
-      "integrity": "sha512-HazW3EWODEav1LRA+FBPq3Oefpg0UOBN7yS1xV8HxNLwlWneg6g0dNnS2piVj8GJUk1N/wYa4SiMO0pOcgOcAA==",
-      "requires": {
-        "babel-template": "7.0.0-beta.3"
-      }
-    },
-    "babel-plugin-transform-es2015-destructuring": {
-      "version": "7.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-7.0.0-beta.3.tgz",
-      "integrity": "sha512-BDjEuIS7SCI7mGEO8lfvo4f3UAVLwZYjHwt1WqRNklc1Y0mcY0/UZzM3NHoa+eBxkNPl5XApwyha/rxW3XyLUQ=="
-    },
-    "babel-plugin-transform-es2015-duplicate-keys": {
-      "version": "7.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-7.0.0-beta.3.tgz",
-      "integrity": "sha512-JLLlw+1XnYrgnVSMS56QN4idRyZJWBREQf0HmaaJQEw3Em+TwO84Tvjgvv7GBxCbXvX4wY+Teuncs2tJd6yqjg==",
-      "requires": {
-        "babel-types": "7.0.0-beta.3"
-      }
-    },
-    "babel-plugin-transform-es2015-for-of": {
-      "version": "7.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-7.0.0-beta.3.tgz",
-      "integrity": "sha512-eaJ5ClU6XF9na+Fcle4sYfYEQtqBMy0CFg6H1dJbtmnWAkzYz4wnwR1unUe0vz5RPp5lA43ECWTTZE+1aH+e3A=="
-    },
-    "babel-plugin-transform-es2015-function-name": {
-      "version": "7.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-7.0.0-beta.3.tgz",
-      "integrity": "sha512-ioqyK/Y9/OlJ5L0pqYS9RosFh6PaIGFjT/zJdkoUKJgeK+H3ulEJ/YxqgLlSA0wuhPca0ztLD3xBEk5NR9Hwzw==",
-      "requires": {
-        "babel-helper-function-name": "7.0.0-beta.3",
-        "babel-types": "7.0.0-beta.3"
-      }
-    },
-    "babel-plugin-transform-es2015-literals": {
-      "version": "7.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-7.0.0-beta.3.tgz",
-      "integrity": "sha512-Zc+kpYJymHtHom+uw+NoNnnyPbxcbyFgeceMFVApavd49JtfdIj7pZS/XpRlxffjIAHSF2D/xDt+bRhq8zk69Q=="
-    },
-    "babel-plugin-transform-es2015-modules-amd": {
-      "version": "7.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-7.0.0-beta.3.tgz",
-      "integrity": "sha512-Fm1mLWiaDy4457O880czMMpu4IiYOdjr1Hy8gz39BvV722QPo5Y2mITo6vO4oNYtaBIc3L0XlwBWavXEDe8iRA==",
-      "requires": {
-        "babel-helper-module-transforms": "7.0.0-beta.3",
-        "babel-template": "7.0.0-beta.3"
-      }
-    },
-    "babel-plugin-transform-es2015-modules-commonjs": {
-      "version": "7.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-7.0.0-beta.3.tgz",
-      "integrity": "sha512-RcRIKOAerrm2M5+w8ITVoadLynjU4inaw+VtZwq1G10VBNn2bbik7hfXWdgnTUdHE8h3TGAafHX9Iw0Zxxuhrg==",
-      "requires": {
-        "babel-helper-module-transforms": "7.0.0-beta.3",
-        "babel-helper-simple-access": "7.0.0-beta.3",
-        "babel-types": "7.0.0-beta.3"
-      }
-    },
-    "babel-plugin-transform-es2015-modules-systemjs": {
-      "version": "7.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-7.0.0-beta.3.tgz",
-      "integrity": "sha512-i621ym8MDfuG3gmgq22uS6JLj+bIJl0mMsZDI/s3457aAPKDl5HwyWGjxcVZHw6WpSKGf4ulqvospsgXOMQ4bA==",
-      "requires": {
-        "babel-helper-hoist-variables": "7.0.0-beta.3",
-        "babel-template": "7.0.0-beta.3"
-      }
-    },
-    "babel-plugin-transform-es2015-modules-umd": {
-      "version": "7.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-7.0.0-beta.3.tgz",
-      "integrity": "sha512-sBn8Dtg2r8QCRmm8pT9kpNSn0qnOorN+gYy45gUwf9NBt6oGftncuecMlj1Mo3NCyRqHQ1WnwHLX4C3yDB5LPg==",
-      "requires": {
-        "babel-helper-module-transforms": "7.0.0-beta.3",
-        "babel-template": "7.0.0-beta.3"
-      }
-    },
-    "babel-plugin-transform-es2015-object-super": {
-      "version": "7.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-7.0.0-beta.3.tgz",
-      "integrity": "sha512-yNMxez22uwWZ17nKH+PbZl4sIq7VCqjbOXF8B7pItq2cGRDH2wTbdpRCkWWfIJyxoXR9JYftSj4g95Ev+ris5g==",
-      "requires": {
-        "babel-helper-replace-supers": "7.0.0-beta.3"
-      }
-    },
-    "babel-plugin-transform-es2015-parameters": {
-      "version": "7.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-7.0.0-beta.3.tgz",
-      "integrity": "sha512-0LdLhxyhIZz5y+1jfRSM7uBen5dCIft3KWwLbr/Wy3Amz9V4Mnfn1mr25BIBDL/RTNYpZGrJ2DWan7KD7DoHEA==",
-      "requires": {
-        "babel-helper-call-delegate": "7.0.0-beta.3",
-        "babel-helper-get-function-arity": "7.0.0-beta.3",
-        "babel-template": "7.0.0-beta.3",
-        "babel-traverse": "7.0.0-beta.3",
-        "babel-types": "7.0.0-beta.3"
-      }
-    },
-    "babel-plugin-transform-es2015-shorthand-properties": {
-      "version": "7.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-7.0.0-beta.3.tgz",
-      "integrity": "sha512-PuyQlEurcTfp7pCf3qLEeaDUNJdnxWJ70DjjNQbSW7Q4U2oLYnXrgNcnNfyUumdwMkJQnA6xI20plRT42AEmVw==",
-      "requires": {
-        "babel-types": "7.0.0-beta.3"
-      }
-    },
-    "babel-plugin-transform-es2015-spread": {
-      "version": "7.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-7.0.0-beta.3.tgz",
-      "integrity": "sha512-D6fi9kAvi+IMcdeOUxgJUFSRlfo0iG2Bn1ZiB43xbtgVgKrA/rerWwQxGuUHhp0lN5lbRSCEpV6tMx+vrYsp1w=="
-    },
-    "babel-plugin-transform-es2015-sticky-regex": {
-      "version": "7.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-7.0.0-beta.3.tgz",
-      "integrity": "sha512-ccZeHcyA0rs2L2OPbACECpHoYJa3nxLcAlNfabGfM/l8mPaZ+C/YDJMLRcGP/37eC3pTA+G9+jPK7i5wT/6QaA==",
-      "requires": {
-        "babel-helper-regex": "7.0.0-beta.3",
-        "babel-types": "7.0.0-beta.3"
-      }
-    },
-    "babel-plugin-transform-es2015-template-literals": {
-      "version": "7.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-7.0.0-beta.3.tgz",
-      "integrity": "sha512-7W++eDsz4JNm+V2T/KNfYXD5fjtUv4n1aqR1zl1jVoA7lbRWp3Y0ipWJqNHKhJg8Q5B9U/FOTPxJOBtHRp+HBQ=="
-    },
-    "babel-plugin-transform-es2015-typeof-symbol": {
-      "version": "7.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-7.0.0-beta.3.tgz",
-      "integrity": "sha512-tR3r8pdT4mW1lOMyoHDGbwp3wNlY1ks1K/fI0G/nZeZLQcRZm+XQEf8ia0DC17eUFCmrduJw/AyqC7Z6sCZb1A=="
-    },
-    "babel-plugin-transform-es2015-unicode-regex": {
-      "version": "7.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-7.0.0-beta.3.tgz",
-      "integrity": "sha512-Yov86wC/0ZcBEXzeFONacrDIkX/7cXQ/lJjH0ajP5scYOFzBji8DGAGW7mRn/OeY3c+/MBGkTNQhA+ojJsiFhA==",
-      "requires": {
-        "babel-helper-regex": "7.0.0-beta.3",
-        "regexpu-core": "4.2.0"
-      }
-    },
-    "babel-plugin-transform-exponentiation-operator": {
-      "version": "7.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-7.0.0-beta.3.tgz",
-      "integrity": "sha512-5RaRPN5I+vyL6gyxriauB8wOncBUmDJbcUUGy0V8agBrnakCG5Fr2uiLuVPzKXAoac7CS3dtmTv+vObyvcxAMg==",
-      "requires": {
-        "babel-helper-builder-binary-assignment-operator-visitor": "7.0.0-beta.3",
-        "babel-plugin-syntax-exponentiation-operator": "7.0.0-beta.0"
-      }
-    },
-    "babel-plugin-transform-new-target": {
-      "version": "7.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-new-target/-/babel-plugin-transform-new-target-7.0.0-beta.3.tgz",
-      "integrity": "sha512-zoezg2Z3OIIwtk1PrVpn6zLNgw3/Kff2ZMWLWMDkPGHS0s7f2Gy2HCC8DZqITFUDGujOOopEE2acqKi8P7wx0g=="
-    },
-    "babel-plugin-transform-object-rest-spread": {
-      "version": "7.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-7.0.0-beta.3.tgz",
-      "integrity": "sha512-NOlhrq1CmxyuI94vNsqMhRPMuL5VG2EKUOIJQ0bwNiXBiwWRLdPoWyPT+Irrx5g4g0PkFgA46tnRj7Dc4ZGsxg==",
-      "requires": {
-        "babel-plugin-syntax-object-rest-spread": "7.0.0-beta.3"
-      }
-    },
-    "babel-plugin-transform-optional-catch-binding": {
-      "version": "7.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-optional-catch-binding/-/babel-plugin-transform-optional-catch-binding-7.0.0-beta.3.tgz",
-      "integrity": "sha512-Gx4L2A1rXCboKxqdrwXq8HKU/e1xJkBYZJZ2b7ISE0KOp4CNQeX1+1MSWjC3e0habFIMRAATJ3UiKmqty3oOzA==",
-      "requires": {
-        "babel-plugin-syntax-optional-catch-binding": "7.0.0-beta.3"
-      }
-    },
-    "babel-plugin-transform-regenerator": {
-      "version": "7.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-7.0.0-beta.3.tgz",
-      "integrity": "sha512-25qxAISuEL+MtISK0cShFQ3T8MUh3rbWAVqqFORTezcxBaxr28SNQR75ZdwkiNINEDZ/r7klLcxjNDQgJ67+MA==",
-      "requires": {
-        "regenerator-transform": "0.11.1"
-      }
-    },
-    "babel-plugin-transform-unicode-property-regex": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-unicode-property-regex/-/babel-plugin-transform-unicode-property-regex-2.0.5.tgz",
-      "integrity": "sha512-Q3L4R7tGc5z7FIGNt9TqzIChsiMK3xn+4qkmluQtnWyUSwQyzzYmXKDOdOHVaCRAM/fDnZsG+TT5GxaVGACxiQ==",
-      "requires": {
-        "babel-helper-regex": "6.26.0",
-        "regexpu-core": "4.2.0"
-      },
-      "dependencies": {
-        "babel-helper-regex": {
-          "version": "6.26.0",
-          "resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.26.0.tgz",
-          "integrity": "sha1-MlxZ+QL4LyS3T6zu0DY5VPZJXnI=",
-          "requires": {
-            "babel-runtime": "6.26.0",
-            "babel-types": "6.26.0",
-            "lodash": "4.17.11"
-          }
-        },
-        "babel-types": {
-          "version": "6.26.0",
-          "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
-          "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
-          "requires": {
-            "babel-runtime": "6.26.0",
-            "esutils": "2.0.2",
-            "lodash": "4.17.11",
-            "to-fast-properties": "1.0.3"
-          }
-        },
-        "to-fast-properties": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
-          "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc="
-        }
-      }
-    },
-    "babel-preset-env": {
-      "version": "7.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/babel-preset-env/-/babel-preset-env-7.0.0-beta.3.tgz",
-      "integrity": "sha512-i7XlRdAxUyPeeaGzf2RxkHODE/N646ydnZ7sQe54rTlUjIdg7wEE/5t40Gf/by3er8fg3kEr8YBJo0f+A3v9qA==",
-      "requires": {
-        "babel-plugin-check-es2015-constants": "7.0.0-beta.3",
-        "babel-plugin-syntax-async-generators": "7.0.0-beta.3",
-        "babel-plugin-syntax-object-rest-spread": "7.0.0-beta.3",
-        "babel-plugin-syntax-optional-catch-binding": "7.0.0-beta.3",
-        "babel-plugin-syntax-trailing-function-commas": "7.0.0-beta.0",
-        "babel-plugin-transform-async-generator-functions": "7.0.0-beta.3",
-        "babel-plugin-transform-async-to-generator": "7.0.0-beta.3",
-        "babel-plugin-transform-es2015-arrow-functions": "7.0.0-beta.3",
-        "babel-plugin-transform-es2015-block-scoped-functions": "7.0.0-beta.3",
-        "babel-plugin-transform-es2015-block-scoping": "7.0.0-beta.3",
-        "babel-plugin-transform-es2015-classes": "7.0.0-beta.3",
-        "babel-plugin-transform-es2015-computed-properties": "7.0.0-beta.3",
-        "babel-plugin-transform-es2015-destructuring": "7.0.0-beta.3",
-        "babel-plugin-transform-es2015-duplicate-keys": "7.0.0-beta.3",
-        "babel-plugin-transform-es2015-for-of": "7.0.0-beta.3",
-        "babel-plugin-transform-es2015-function-name": "7.0.0-beta.3",
-        "babel-plugin-transform-es2015-literals": "7.0.0-beta.3",
-        "babel-plugin-transform-es2015-modules-amd": "7.0.0-beta.3",
-        "babel-plugin-transform-es2015-modules-commonjs": "7.0.0-beta.3",
-        "babel-plugin-transform-es2015-modules-systemjs": "7.0.0-beta.3",
-        "babel-plugin-transform-es2015-modules-umd": "7.0.0-beta.3",
-        "babel-plugin-transform-es2015-object-super": "7.0.0-beta.3",
-        "babel-plugin-transform-es2015-parameters": "7.0.0-beta.3",
-        "babel-plugin-transform-es2015-shorthand-properties": "7.0.0-beta.3",
-        "babel-plugin-transform-es2015-spread": "7.0.0-beta.3",
-        "babel-plugin-transform-es2015-sticky-regex": "7.0.0-beta.3",
-        "babel-plugin-transform-es2015-template-literals": "7.0.0-beta.3",
-        "babel-plugin-transform-es2015-typeof-symbol": "7.0.0-beta.3",
-        "babel-plugin-transform-es2015-unicode-regex": "7.0.0-beta.3",
-        "babel-plugin-transform-exponentiation-operator": "7.0.0-beta.3",
-        "babel-plugin-transform-new-target": "7.0.0-beta.3",
-        "babel-plugin-transform-object-rest-spread": "7.0.0-beta.3",
-        "babel-plugin-transform-optional-catch-binding": "7.0.0-beta.3",
-        "babel-plugin-transform-regenerator": "7.0.0-beta.3",
-        "babel-plugin-transform-unicode-property-regex": "2.0.5",
-        "browserslist": "2.11.3",
-        "invariant": "2.2.4",
-        "semver": "5.6.0"
-      },
-      "dependencies": {
-        "browserslist": {
-          "version": "2.11.3",
-          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-2.11.3.tgz",
-          "integrity": "sha512-yWu5cXT7Av6mVwzWc8lMsJMHWn4xyjSuGYi4IozbVTLUOEYPSagUB8kiMDUHA1fS3zjr8nkxkn9jdvug4BBRmA==",
-          "requires": {
-            "caniuse-lite": "1.0.30000899",
-            "electron-to-chromium": "1.3.82"
-          }
-        }
-      }
     },
     "babel-preset-jest": {
       "version": "23.2.0",
@@ -2061,48 +2223,6 @@
         "core-js": "2.5.7",
         "regenerator-runtime": "0.11.1"
       }
-    },
-    "babel-template": {
-      "version": "7.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-7.0.0-beta.3.tgz",
-      "integrity": "sha512-urJduLja89kSDGqY8ryw8iIwQnMl30IvhMtMNmDD7vBX0l0oylaLgK+7df/9ODX9vR/PhXuif6HYl5HlzAKXMg==",
-      "requires": {
-        "babel-code-frame": "7.0.0-beta.3",
-        "babel-traverse": "7.0.0-beta.3",
-        "babel-types": "7.0.0-beta.3",
-        "babylon": "7.0.0-beta.27",
-        "lodash": "4.17.11"
-      }
-    },
-    "babel-traverse": {
-      "version": "7.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-7.0.0-beta.3.tgz",
-      "integrity": "sha512-xyh/aPYuedMAfQlSj2kjHjsEmY5/Dpxs576L05DySAVMrV+ADX6l4mTOLysAEGwJfkePJlDLhFuS6SKaxv1V7w==",
-      "requires": {
-        "babel-code-frame": "7.0.0-beta.3",
-        "babel-helper-function-name": "7.0.0-beta.3",
-        "babel-types": "7.0.0-beta.3",
-        "babylon": "7.0.0-beta.27",
-        "debug": "3.2.6",
-        "globals": "10.4.0",
-        "invariant": "2.2.4",
-        "lodash": "4.17.11"
-      }
-    },
-    "babel-types": {
-      "version": "7.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-7.0.0-beta.3.tgz",
-      "integrity": "sha512-36k8J+byAe181OmCMawGhw+DtKO7AwexPVtsPXoMfAkjtZgoCX3bEuHWfdE5sYxRM8dojvtG/+O08M0Z/YDC6w==",
-      "requires": {
-        "esutils": "2.0.2",
-        "lodash": "4.17.11",
-        "to-fast-properties": "2.0.0"
-      }
-    },
-    "babylon": {
-      "version": "7.0.0-beta.27",
-      "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.27.tgz",
-      "integrity": "sha512-ksRx+r8eFIfdt63MCgLc9VxGL7W3jcyveQvMpNMVHgW+eb9mq3Xbm45FLCNkw8h92RvoNp4uuiwzcCEwxjDBZg=="
     },
     "bach": {
       "version": "1.2.0",
@@ -2476,51 +2596,87 @@
       }
     },
     "bin-version": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/bin-version/-/bin-version-2.0.0.tgz",
-      "integrity": "sha1-LMldg7Uive8umZeOdq61SRyBFP8=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/bin-version/-/bin-version-3.0.0.tgz",
+      "integrity": "sha512-Ekhwm6AUiMbZ1LgVCNMkgjovpMR30FyQN74laAW9gs0NPjZR5gdY0ARNB0YsQG8GOme3CsHbxmeyq/7Ofq6QYQ==",
       "optional": true,
       "requires": {
-        "execa": "0.1.1",
-        "find-versions": "2.0.0"
+        "execa": "1.0.0",
+        "find-versions": "3.0.0"
       },
       "dependencies": {
-        "execa": {
-          "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/execa/-/execa-0.1.1.tgz",
-          "integrity": "sha1-sJwqkwm8DvBQFHlHLbMYD41MPt0=",
+        "cross-spawn": {
+          "version": "6.0.5",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+          "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
           "optional": true,
           "requires": {
-            "cross-spawn-async": "2.2.5",
-            "object-assign": "4.1.1",
+            "nice-try": "1.0.5",
+            "path-key": "2.0.1",
+            "semver": "5.6.0",
+            "shebang-command": "1.2.0",
+            "which": "1.3.1"
+          }
+        },
+        "execa": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
+          "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
+          "optional": true,
+          "requires": {
+            "cross-spawn": "6.0.5",
+            "get-stream": "4.1.0",
+            "is-stream": "1.1.0",
+            "npm-run-path": "2.0.2",
+            "p-finally": "1.0.0",
+            "signal-exit": "3.0.2",
             "strip-eof": "1.0.0"
+          }
+        },
+        "get-stream": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+          "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+          "optional": true,
+          "requires": {
+            "pump": "3.0.0"
+          }
+        },
+        "pump": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+          "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+          "optional": true,
+          "requires": {
+            "end-of-stream": "1.4.1",
+            "once": "1.4.0"
           }
         }
       }
     },
     "bin-version-check": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/bin-version-check/-/bin-version-check-3.0.0.tgz",
-      "integrity": "sha1-4k6/prY8sDh8X8F0+G5cyBLKfMk=",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/bin-version-check/-/bin-version-check-4.0.0.tgz",
+      "integrity": "sha512-sR631OrhC+1f8Cvs8WyVWOA33Y8tgwjETNPyyD/myRBXLkfS/vl74FmH/lFcRl9KY3zwGh7jFhvyk9vV3/3ilQ==",
       "optional": true,
       "requires": {
-        "bin-version": "2.0.0",
+        "bin-version": "3.0.0",
         "semver": "5.6.0",
         "semver-truncate": "1.1.2"
       }
     },
     "bin-wrapper": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/bin-wrapper/-/bin-wrapper-4.0.1.tgz",
-      "integrity": "sha512-cqSVUeunxVzshCNl+YXYr2E+4fUZQEUgv5w05A58JOHUbC9UL2KjAlclS3nrfOFdTuL4oJzFjqiCZtRdQHfzqQ==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bin-wrapper/-/bin-wrapper-4.1.0.tgz",
+      "integrity": "sha512-hfRmo7hWIXPkbpi0ZltboCMVrU+0ClXR/JgbCKKjlDjQf6igXa7OwdqNcFWQZPZTgiY7ZpzE3+LjjkLiTN2T7Q==",
       "optional": true,
       "requires": {
         "bin-check": "4.1.0",
-        "bin-version-check": "3.0.0",
+        "bin-version-check": "4.0.0",
         "download": "7.1.0",
         "import-lazy": "3.1.0",
         "os-filter-obj": "2.0.0",
-        "pify": "3.0.0"
+        "pify": "4.0.1"
       },
       "dependencies": {
         "archive-type": {
@@ -2687,6 +2843,14 @@
             "make-dir": "1.3.0",
             "p-event": "2.1.0",
             "pify": "3.0.0"
+          },
+          "dependencies": {
+            "pify": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+              "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+              "optional": true
+            }
           }
         },
         "filename-reserved-regex": {
@@ -2738,6 +2902,14 @@
             "timed-out": "4.0.1",
             "url-parse-lax": "3.0.0",
             "url-to-options": "1.0.1"
+          },
+          "dependencies": {
+            "pify": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+              "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+              "optional": true
+            }
           }
         },
         "import-lazy": {
@@ -2760,6 +2932,12 @@
           "requires": {
             "p-timeout": "2.0.1"
           }
+        },
+        "pify": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+          "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+          "optional": true
         },
         "prepend-http": {
           "version": "2.0.0",
@@ -2971,6 +3149,7 @@
       "version": "1.8.5",
       "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
       "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+      "dev": true,
       "requires": {
         "expand-range": "1.8.2",
         "preserve": "0.2.0",
@@ -3074,6 +3253,7 @@
       "version": "3.2.8",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-3.2.8.tgz",
       "integrity": "sha512-WHVocJYavUwVgVViC0ORikPHQquXwVh939TaelZ4WDqpWgTX/FsGhl/+P4qBUAGcRvtOgDgC+xftNWWp2RUTAQ==",
+      "dev": true,
       "requires": {
         "caniuse-lite": "1.0.30000899",
         "electron-to-chromium": "1.3.82"
@@ -3338,7 +3518,8 @@
     "caniuse-lite": {
       "version": "1.0.30000899",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000899.tgz",
-      "integrity": "sha512-enC3zKfUCJxxwvUIsBkbHd54CtJw1KtIWvrK0JZxWD/fEN2knHaai45lndJ4xXAkyRAPyk60J3yagkKDWhfeMA=="
+      "integrity": "sha512-enC3zKfUCJxxwvUIsBkbHd54CtJw1KtIWvrK0JZxWD/fEN2knHaai45lndJ4xXAkyRAPyk60J3yagkKDWhfeMA==",
+      "dev": true
     },
     "capitalize": {
       "version": "1.0.0",
@@ -4253,16 +4434,6 @@
       "requires": {
         "lru-cache": "4.1.3",
         "shebang-command": "1.2.0",
-        "which": "1.3.1"
-      }
-    },
-    "cross-spawn-async": {
-      "version": "2.2.5",
-      "resolved": "http://registry.npmjs.org/cross-spawn-async/-/cross-spawn-async-2.2.5.tgz",
-      "integrity": "sha1-hF/wwINKPe2dFg2sptOQkGuyiMw=",
-      "optional": true,
-      "requires": {
-        "lru-cache": "4.1.3",
         "which": "1.3.1"
       }
     },
@@ -5714,7 +5885,8 @@
     "electron-to-chromium": {
       "version": "1.3.82",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.82.tgz",
-      "integrity": "sha512-NI4nB2IWGcU4JVT1AE8kBb/dFor4zjLHMLsOROPahppeHrR0FG5uslxMmkp/thO1MvPjM2xhlKoY29/I60s0ew=="
+      "integrity": "sha512-NI4nB2IWGcU4JVT1AE8kBb/dFor4zjLHMLsOROPahppeHrR0FG5uslxMmkp/thO1MvPjM2xhlKoY29/I60s0ew==",
+      "dev": true
     },
     "elem-dataset": {
       "version": "1.1.1",
@@ -6180,6 +6352,7 @@
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
       "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+      "dev": true,
       "requires": {
         "is-posix-bracket": "0.1.1"
       }
@@ -6188,6 +6361,7 @@
       "version": "1.8.2",
       "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
       "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
+      "dev": true,
       "requires": {
         "fill-range": "2.2.4"
       }
@@ -6270,6 +6444,7 @@
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
       "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+      "dev": true,
       "requires": {
         "is-extglob": "1.0.0"
       }
@@ -6678,7 +6853,8 @@
     "filename-regex": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
-      "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY="
+      "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=",
+      "dev": true
     },
     "filename-reserved-regex": {
       "version": "1.0.0",
@@ -6711,6 +6887,7 @@
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.4.tgz",
       "integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
+      "dev": true,
       "requires": {
         "is-number": "2.1.0",
         "isobject": "2.1.0",
@@ -6743,13 +6920,21 @@
       }
     },
     "find-versions": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/find-versions/-/find-versions-2.0.0.tgz",
-      "integrity": "sha1-KtkNSQ9oKMGqQCks9wmsMxghDDw=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/find-versions/-/find-versions-3.0.0.tgz",
+      "integrity": "sha512-IUvtItVFNmTtKoB0PRfbkR0zR9XMG5rWNO3qI1S8L0zdv+v2gqzM0pAunloxqbqAfT8w7bg8n/5gHzTXte8H5A==",
       "optional": true,
       "requires": {
-        "array-uniq": "1.0.3",
-        "semver-regex": "1.0.0"
+        "array-uniq": "2.0.0",
+        "semver-regex": "2.0.0"
+      },
+      "dependencies": {
+        "array-uniq": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-2.0.0.tgz",
+          "integrity": "sha512-O3QZEr+3wDj7otzF7PjNGs6CA3qmYMLvt5xGkjY/V0VxS+ovvqVo/5wKM/OVOAyuX4DTh9H31zE/yKtO66hTkg==",
+          "optional": true
+        }
       }
     },
     "findup-sync": {
@@ -7155,6 +7340,7 @@
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
       "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
+      "dev": true,
       "requires": {
         "for-in": "1.0.2"
       }
@@ -7261,21 +7447,25 @@
       "dependencies": {
         "abbrev": {
           "version": "1.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+          "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
           "optional": true
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
         },
         "aproba": {
           "version": "1.2.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
+          "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
           "optional": true
         },
         "are-we-there-yet": {
           "version": "1.1.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
+          "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
           "optional": true,
           "requires": {
             "delegates": "1.0.0",
@@ -7284,11 +7474,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
         },
         "brace-expansion": {
           "version": "1.1.11",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+          "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "requires": {
             "balanced-match": "1.0.0",
             "concat-map": "0.0.1"
@@ -7296,29 +7488,35 @@
         },
         "chownr": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.0.1.tgz",
+          "integrity": "sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE=",
           "optional": true
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
         },
         "core-util-is": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
           "optional": true
         },
         "debug": {
           "version": "2.6.9",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "optional": true,
           "requires": {
             "ms": "2.0.0"
@@ -7326,22 +7524,26 @@
         },
         "deep-extend": {
           "version": "0.5.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.5.1.tgz",
+          "integrity": "sha512-N8vBdOa+DF7zkRrDCsaOXoCs/E2fJfx9B9MrKnnSiHNh4ws7eSys6YQE4KvT1cecKmOASYQBhbKjeuDD9lT81w==",
           "optional": true
         },
         "delegates": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+          "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
           "optional": true
         },
         "detect-libc": {
           "version": "1.0.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
+          "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
           "optional": true
         },
         "fs-minipass": {
           "version": "1.2.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.5.tgz",
+          "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
           "optional": true,
           "requires": {
             "minipass": "2.2.4"
@@ -7349,12 +7551,14 @@
         },
         "fs.realpath": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+          "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
           "optional": true
         },
         "gauge": {
           "version": "2.7.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+          "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
           "optional": true,
           "requires": {
             "aproba": "1.2.0",
@@ -7369,7 +7573,8 @@
         },
         "glob": {
           "version": "7.1.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "optional": true,
           "requires": {
             "fs.realpath": "1.0.0",
@@ -7382,12 +7587,14 @@
         },
         "has-unicode": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+          "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
           "optional": true
         },
         "iconv-lite": {
           "version": "0.4.21",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.21.tgz",
+          "integrity": "sha512-En5V9za5mBt2oUA03WGD3TwDv0MKAruqsuxstbMUZaj9W9k/m1CV/9py3l0L5kw9Bln8fdHQmzHSYtvpvTLpKw==",
           "optional": true,
           "requires": {
             "safer-buffer": "2.1.2"
@@ -7395,7 +7602,8 @@
         },
         "ignore-walk": {
           "version": "3.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.1.tgz",
+          "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
           "optional": true,
           "requires": {
             "minimatch": "3.0.4"
@@ -7403,7 +7611,8 @@
         },
         "inflight": {
           "version": "1.0.6",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+          "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
           "optional": true,
           "requires": {
             "once": "1.4.0",
@@ -7412,39 +7621,46 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
         },
         "ini": {
           "version": "1.3.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+          "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
           "optional": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "requires": {
             "number-is-nan": "1.0.1"
           }
         },
         "isarray": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
           "optional": true
         },
         "minimatch": {
           "version": "3.0.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "requires": {
             "brace-expansion": "1.1.11"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
         },
         "minipass": {
           "version": "2.2.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.2.4.tgz",
+          "integrity": "sha512-hzXIWWet/BzWhYs2b+u7dRHlruXhwdgvlTMDKC6Cb1U7ps6Ac6yQlR39xsbjWJE377YTCtKwIXIpJ5oP+j5y8g==",
           "requires": {
             "safe-buffer": "5.1.1",
             "yallist": "3.0.2"
@@ -7452,7 +7668,8 @@
         },
         "minizlib": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.1.0.tgz",
+          "integrity": "sha512-4T6Ur/GctZ27nHfpt9THOdRZNgyJ9FZchYO1ceg5S8Q3DNLCKYy44nCZzgCJgcvx2UM8czmqak5BCxJMrq37lA==",
           "optional": true,
           "requires": {
             "minipass": "2.2.4"
@@ -7460,19 +7677,22 @@
         },
         "mkdirp": {
           "version": "0.5.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "requires": {
             "minimist": "0.0.8"
           }
         },
         "ms": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "optional": true
         },
         "needle": {
           "version": "2.2.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/needle/-/needle-2.2.0.tgz",
+          "integrity": "sha512-eFagy6c+TYayorXw/qtAdSvaUpEbBsDwDyxYFgLZ0lTojfH7K+OdBqAF7TAFwDokJaGpubpSGG0wO3iC0XPi8w==",
           "optional": true,
           "requires": {
             "debug": "2.6.9",
@@ -7482,7 +7702,8 @@
         },
         "node-pre-gyp": {
           "version": "0.10.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.10.0.tgz",
+          "integrity": "sha512-G7kEonQLRbcA/mOoFoxvlMrw6Q6dPf92+t/l0DFSMuSlDoWaI9JWIyPwK0jyE1bph//CUEL65/Fz1m2vJbmjQQ==",
           "optional": true,
           "requires": {
             "detect-libc": "1.0.3",
@@ -7499,7 +7720,8 @@
         },
         "nopt": {
           "version": "4.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
+          "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
           "optional": true,
           "requires": {
             "abbrev": "1.1.1",
@@ -7508,12 +7730,14 @@
         },
         "npm-bundled": {
           "version": "1.0.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.0.3.tgz",
+          "integrity": "sha512-ByQ3oJ/5ETLyglU2+8dBObvhfWXX8dtPZDMePCahptliFX2iIuhyEszyFk401PZUNQH20vvdW5MLjJxkwU80Ow==",
           "optional": true
         },
         "npm-packlist": {
           "version": "1.1.10",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.1.10.tgz",
+          "integrity": "sha512-AQC0Dyhzn4EiYEfIUjCdMl0JJ61I2ER9ukf/sLxJUcZHfo+VyEfz2rMJgLZSS1v30OxPQe1cN0LZA1xbcaVfWA==",
           "optional": true,
           "requires": {
             "ignore-walk": "3.0.1",
@@ -7522,7 +7746,8 @@
         },
         "npmlog": {
           "version": "4.1.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
+          "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
           "optional": true,
           "requires": {
             "are-we-there-yet": "1.1.4",
@@ -7533,33 +7758,39 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
         },
         "object-assign": {
           "version": "4.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
           "optional": true
         },
         "once": {
           "version": "1.4.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "requires": {
             "wrappy": "1.0.2"
           }
         },
         "os-homedir": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+          "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
           "optional": true
         },
         "os-tmpdir": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+          "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
           "optional": true
         },
         "osenv": {
           "version": "0.1.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
+          "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
           "optional": true,
           "requires": {
             "os-homedir": "1.0.2",
@@ -7568,17 +7799,20 @@
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+          "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
           "optional": true
         },
         "process-nextick-args": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+          "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
           "optional": true
         },
         "rc": {
           "version": "1.2.7",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.7.tgz",
+          "integrity": "sha512-LdLD8xD4zzLsAT5xyushXDNscEjB7+2ulnl8+r1pnESlYtlJtVSoCMBGr30eDRJ3+2Gq89jK9P9e4tCEH1+ywA==",
           "optional": true,
           "requires": {
             "deep-extend": "0.5.1",
@@ -7589,14 +7823,16 @@
           "dependencies": {
             "minimist": {
               "version": "1.2.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+              "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
               "optional": true
             }
           }
         },
         "readable-stream": {
           "version": "2.3.6",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "optional": true,
           "requires": {
             "core-util-is": "1.0.2",
@@ -7610,7 +7846,8 @@
         },
         "rimraf": {
           "version": "2.6.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
+          "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
           "optional": true,
           "requires": {
             "glob": "7.1.2"
@@ -7618,36 +7855,43 @@
         },
         "safe-buffer": {
           "version": "5.1.1",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+          "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
         },
         "safer-buffer": {
           "version": "2.1.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+          "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
           "optional": true
         },
         "sax": {
           "version": "1.2.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+          "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
           "optional": true
         },
         "semver": {
           "version": "5.5.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
+          "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
           "optional": true
         },
         "set-blocking": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+          "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
           "optional": true
         },
         "signal-exit": {
           "version": "3.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+          "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
           "optional": true
         },
         "string-width": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "requires": {
             "code-point-at": "1.1.0",
             "is-fullwidth-code-point": "1.0.0",
@@ -7656,7 +7900,8 @@
         },
         "string_decoder": {
           "version": "1.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "optional": true,
           "requires": {
             "safe-buffer": "5.1.1"
@@ -7664,19 +7909,22 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "requires": {
             "ansi-regex": "2.1.1"
           }
         },
         "strip-json-comments": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
           "optional": true
         },
         "tar": {
           "version": "4.4.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.1.tgz",
+          "integrity": "sha512-O+v1r9yN4tOsvl90p5HAP4AEqbYhx4036AGMm075fH9F8Qwi3oJ+v4u50FkT/KkvywNGtwkk0zRI+8eYm1X/xg==",
           "optional": true,
           "requires": {
             "chownr": "1.0.1",
@@ -7690,12 +7938,14 @@
         },
         "util-deprecate": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+          "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
           "optional": true
         },
         "wide-align": {
           "version": "1.1.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
+          "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
           "optional": true,
           "requires": {
             "string-width": "1.0.2"
@@ -7703,11 +7953,13 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
         },
         "yallist": {
           "version": "3.0.2",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.2.tgz",
+          "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k="
         }
       }
     },
@@ -7845,7 +8097,7 @@
       "optional": true,
       "requires": {
         "bin-build": "3.0.0",
-        "bin-wrapper": "4.0.1",
+        "bin-wrapper": "4.1.0",
         "execa": "1.0.0",
         "logalot": "2.1.0"
       },
@@ -7925,6 +8177,7 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
       "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
+      "dev": true,
       "requires": {
         "glob-parent": "2.0.0",
         "is-glob": "2.0.1"
@@ -7934,6 +8187,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
       "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+      "dev": true,
       "requires": {
         "is-glob": "2.0.1"
       }
@@ -8027,9 +8281,10 @@
       }
     },
     "globals": {
-      "version": "10.4.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-10.4.0.tgz",
-      "integrity": "sha512-uNUtxIZpGyuaq+5BqGGQHsL4wUlJAXRqOm6g3Y48/CWNGTLONgBibI0lh6lGxjR2HljFYUfszb+mk4WkgMntsA=="
+      "version": "11.8.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-11.8.0.tgz",
+      "integrity": "sha512-io6LkyPVuzCHBSQV9fmOwxZkUk6nIaGmxheLDgmuFv89j0fm2aqDbIXKAGfzCMHqz3HLF2Zf8WSG6VqMh2qFmA==",
+      "dev": true
     },
     "globby": {
       "version": "6.1.0",
@@ -8345,19 +8600,7 @@
       "requires": {
         "clean-css": "4.2.1",
         "plugin-error": "1.0.1",
-        "through2": "2.0.3",
         "vinyl-sourcemaps-apply": "0.2.1"
-      },
-      "dependencies": {
-        "through2": {
-          "version": "2.0.3",
-          "resolved": "http://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
-          "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
-          "requires": {
-            "readable-stream": "2.3.6",
-            "xtend": "4.0.1"
-          }
-        }
       }
     },
     "gulp-concat": {
@@ -9514,6 +9757,7 @@
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
       "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+      "dev": true,
       "requires": {
         "loose-envify": "1.4.0"
       }
@@ -9640,12 +9884,14 @@
     "is-dotfile": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
-      "integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE="
+      "integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE=",
+      "dev": true
     },
     "is-equal-shallow": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
       "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
+      "dev": true,
       "requires": {
         "is-primitive": "2.0.0"
       }
@@ -9658,7 +9904,8 @@
     "is-extglob": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-      "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+      "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+      "dev": true
     },
     "is-finite": {
       "version": "1.0.2",
@@ -9709,6 +9956,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
       "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+      "dev": true,
       "requires": {
         "is-extglob": "1.0.0"
       }
@@ -9756,6 +10004,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
       "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
+      "dev": true,
       "requires": {
         "kind-of": "3.2.2"
       }
@@ -9827,12 +10076,14 @@
     "is-posix-bracket": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
-      "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q="
+      "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=",
+      "dev": true
     },
     "is-primitive": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
-      "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU="
+      "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
+      "dev": true
     },
     "is-promise": {
       "version": "2.1.0",
@@ -10026,6 +10277,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
       "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+      "dev": true,
       "requires": {
         "isarray": "1.0.0"
       }
@@ -11411,7 +11663,7 @@
       "optional": true,
       "requires": {
         "bin-build": "3.0.0",
-        "bin-wrapper": "4.0.1",
+        "bin-wrapper": "4.1.0",
         "logalot": "2.1.0"
       }
     },
@@ -11419,6 +11671,12 @@
       "version": "2.4.9",
       "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.4.9.tgz",
       "integrity": "sha512-xcinL3AuDJk7VSzsHgb9DvvIXayBbadtMZ4HFPx8rUszbW1MuNMlwYVC4zzCZ6e1sqZpnNS5ZFYOhXqA39T7LQ=="
+    },
+    "js-levenshtein": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/js-levenshtein/-/js-levenshtein-1.1.4.tgz",
+      "integrity": "sha512-PxfGzSs0ztShKrUYPIn5r0MtyAhYcCwmndozzpz8YObbPnD1jFxzlBGbRnX2mIu6Z13xN6+PTu05TQFnZFlzow==",
+      "dev": true
     },
     "js-library-detector": {
       "version": "5.1.0",
@@ -11429,7 +11687,8 @@
     "js-tokens": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
+      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+      "dev": true
     },
     "js-yaml": {
       "version": "3.12.0",
@@ -11534,7 +11793,8 @@
     "jsesc": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.1.tgz",
-      "integrity": "sha1-5CGiqOINawgZ3yiQj3glJrlt0f4="
+      "integrity": "sha1-5CGiqOINawgZ3yiQj3glJrlt0f4=",
+      "dev": true
     },
     "json-buffer": {
       "version": "3.0.0",
@@ -12453,6 +12713,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dev": true,
       "requires": {
         "js-tokens": "3.0.2"
       }
@@ -12856,7 +13117,8 @@
     "math-random": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/math-random/-/math-random-1.0.1.tgz",
-      "integrity": "sha1-izqsWIuKZuSXXjzepn97sylgH6w="
+      "integrity": "sha1-izqsWIuKZuSXXjzepn97sylgH6w=",
+      "dev": true
     },
     "md5": {
       "version": "2.2.1",
@@ -12962,6 +13224,7 @@
       "version": "2.3.11",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
       "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+      "dev": true,
       "requires": {
         "arr-diff": "2.0.0",
         "array-unique": "0.2.1",
@@ -13451,6 +13714,15 @@
         "which": "1.3.1"
       }
     },
+    "node-releases": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.0.3.tgz",
+      "integrity": "sha512-ZaZWMsbuDcetpHmYeKWPO6e63pSXLb50M7lJgCbcM2nC/nQC3daNifmtp5a2kp7EWwYfhuvH6zLPWkrF8IiDdw==",
+      "dev": true,
+      "requires": {
+        "semver": "5.6.0"
+      }
+    },
     "node-status-codes": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/node-status-codes/-/node-status-codes-1.0.0.tgz",
@@ -13508,7 +13780,8 @@
     "normalize-range": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
-      "integrity": "sha1-LRDAa9/TEuqXd2laTShDlFa3WUI="
+      "integrity": "sha1-LRDAa9/TEuqXd2laTShDlFa3WUI=",
+      "dev": true
     },
     "normalize-url": {
       "version": "2.0.1",
@@ -13564,7 +13837,8 @@
     "num2fraction": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz",
-      "integrity": "sha1-b2gragJ6Tp3fpFZM0lidHU5mnt4="
+      "integrity": "sha1-b2gragJ6Tp3fpFZM0lidHU5mnt4=",
+      "dev": true
     },
     "number-is-nan": {
       "version": "1.0.1",
@@ -13701,6 +13975,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
       "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
+      "dev": true,
       "requires": {
         "for-own": "0.1.5",
         "is-extendable": "0.1.1"
@@ -13829,7 +14104,7 @@
       "optional": true,
       "requires": {
         "bin-build": "3.0.0",
-        "bin-wrapper": "4.0.1",
+        "bin-wrapper": "4.1.0",
         "logalot": "2.1.0"
       }
     },
@@ -14139,6 +14414,7 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
       "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
+      "dev": true,
       "requires": {
         "glob-base": "0.3.0",
         "is-dotfile": "1.0.3",
@@ -14454,7 +14730,8 @@
     "postcss-value-parser": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
-      "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ=="
+      "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
+      "dev": true
     },
     "prelude-ls": {
       "version": "1.1.2",
@@ -14470,7 +14747,8 @@
     "preserve": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
-      "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks="
+      "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
+      "dev": true
     },
     "pretty-bytes": {
       "version": "4.0.2",
@@ -14504,7 +14782,8 @@
     "private": {
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
-      "integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg=="
+      "integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg==",
+      "dev": true
     },
     "process": {
       "version": "0.11.10",
@@ -15227,6 +15506,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.1.1.tgz",
       "integrity": "sha512-TuDE5KxZ0J461RVjrJZCJc+J+zCkTb1MbH9AQUq68sMhOMcy9jLcb3BrZKgp9q9Ncltdg4QVqWrH02W2EFFVYw==",
+      "dev": true,
       "requires": {
         "is-number": "4.0.0",
         "kind-of": "6.0.2",
@@ -15236,12 +15516,14 @@
         "is-number": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
-          "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ=="
+          "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==",
+          "dev": true
         },
         "kind-of": {
           "version": "6.0.2",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+          "dev": true
         }
       }
     },
@@ -15698,12 +15980,14 @@
     "regenerate": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.0.tgz",
-      "integrity": "sha512-1G6jJVDWrt0rK99kBjvEtziZNCICAuvIPkSiUFIQxVP06RCVpq3dmDo2oi6ABpYaDYaTRr67BEhL8r1wgEZZKg=="
+      "integrity": "sha512-1G6jJVDWrt0rK99kBjvEtziZNCICAuvIPkSiUFIQxVP06RCVpq3dmDo2oi6ABpYaDYaTRr67BEhL8r1wgEZZKg==",
+      "dev": true
     },
     "regenerate-unicode-properties": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-7.0.0.tgz",
       "integrity": "sha512-s5NGghCE4itSlUS+0WUj88G6cfMVMmH8boTPNvABf8od+2dhT9WDlWu8n01raQAJZMOK8Ch6jSexaRO7swd6aw==",
+      "dev": true,
       "requires": {
         "regenerate": "1.4.0"
       }
@@ -15713,19 +15997,11 @@
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
       "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
     },
-    "regenerator-transform": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.11.1.tgz",
-      "integrity": "sha512-q8SAPMEyARQHzyXNWNrlz5oNnI6k4yo8ncEcvH1aXjUCqyVQ7TeV/AttqBLcySCReXVk/+fUydo/RaEIAOnRfA==",
-      "requires": {
-        "babel-types": "7.0.0-beta.3",
-        "private": "0.1.8"
-      }
-    },
     "regex-cache": {
       "version": "0.4.4",
       "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
       "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
+      "dev": true,
       "requires": {
         "is-equal-shallow": "0.1.3"
       }
@@ -15749,6 +16025,7 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.2.0.tgz",
       "integrity": "sha512-Z835VSnJJ46CNBttalHD/dB+Sj2ezmY6Xp38npwU87peK6mqOzOpV8eYktdkLTEkzzD+JsTcxd84ozd8I14+rw==",
+      "dev": true,
       "requires": {
         "regenerate": "1.4.0",
         "regenerate-unicode-properties": "7.0.0",
@@ -15780,12 +16057,14 @@
     "regjsgen": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.4.0.tgz",
-      "integrity": "sha512-X51Lte1gCYUdlwhF28+2YMO0U6WeN0GLpgpA7LK7mbdDnkQYiwvEpmpe0F/cv5L14EbxgrdayAG3JETBv0dbXA=="
+      "integrity": "sha512-X51Lte1gCYUdlwhF28+2YMO0U6WeN0GLpgpA7LK7mbdDnkQYiwvEpmpe0F/cv5L14EbxgrdayAG3JETBv0dbXA==",
+      "dev": true
     },
     "regjsparser": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.3.0.tgz",
       "integrity": "sha512-zza72oZBBHzt64G7DxdqrOo/30bhHkwMUoT0WqfGu98XLd7N+1tsy5MJ96Bk4MD0y74n629RhmrGW6XlnLLwCA==",
+      "dev": true,
       "requires": {
         "jsesc": "0.5.0"
       },
@@ -15793,7 +16072,8 @@
         "jsesc": {
           "version": "0.5.0",
           "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
-          "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0="
+          "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
+          "dev": true
         }
       }
     },
@@ -16646,9 +16926,9 @@
       }
     },
     "semver-regex": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/semver-regex/-/semver-regex-1.0.0.tgz",
-      "integrity": "sha1-kqSWkGX5xwxpR1PVUkj8aPj2Usk=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/semver-regex/-/semver-regex-2.0.0.tgz",
+      "integrity": "sha512-mUdIBBvdn0PLOeP3TEkMH7HHeUP3GjsXCwKarjv/kGmUFOYg1VqEemKhoQpWMu6X2I8kHeuVdGibLGkVK+/5Qw==",
       "optional": true
     },
     "semver-truncate": {
@@ -18218,7 +18498,8 @@
     "to-fast-properties": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
+      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+      "dev": true
     },
     "to-object-path": {
       "version": "0.3.0",
@@ -18322,7 +18603,8 @@
     "trim-right": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
-      "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM="
+      "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
+      "dev": true
     },
     "tslib": {
       "version": "1.9.3",
@@ -18569,12 +18851,14 @@
     "unicode-canonical-property-names-ecmascript": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-1.0.4.tgz",
-      "integrity": "sha512-jDrNnXWHd4oHiTZnx/ZG7gtUTVp+gCcTTKr8L0HjlwphROEW3+Him+IpvC+xcJEFegapiMZyZe02CyuOnRmbnQ=="
+      "integrity": "sha512-jDrNnXWHd4oHiTZnx/ZG7gtUTVp+gCcTTKr8L0HjlwphROEW3+Him+IpvC+xcJEFegapiMZyZe02CyuOnRmbnQ==",
+      "dev": true
     },
     "unicode-match-property-ecmascript": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-1.0.4.tgz",
       "integrity": "sha512-L4Qoh15vTfntsn4P1zqnHulG0LdXgjSO035fEpdtp6YxXhMT51Q6vgM5lYdG/5X3MjS+k/Y9Xw4SFCY9IkR0rg==",
+      "dev": true,
       "requires": {
         "unicode-canonical-property-names-ecmascript": "1.0.4",
         "unicode-property-aliases-ecmascript": "1.0.4"
@@ -18583,12 +18867,14 @@
     "unicode-match-property-value-ecmascript": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-1.0.2.tgz",
-      "integrity": "sha512-Rx7yODZC1L/T8XKo/2kNzVAQaRE88AaMvI1EF/Xnj3GW2wzN6fop9DDWuFAKUVFH7vozkz26DzP0qyWLKLIVPQ=="
+      "integrity": "sha512-Rx7yODZC1L/T8XKo/2kNzVAQaRE88AaMvI1EF/Xnj3GW2wzN6fop9DDWuFAKUVFH7vozkz26DzP0qyWLKLIVPQ==",
+      "dev": true
     },
     "unicode-property-aliases-ecmascript": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-1.0.4.tgz",
-      "integrity": "sha512-2WSLa6OdYd2ng8oqiGIWnJqyFArvhn+5vgx5GTxMbUYjCYKUcuKS62YLFF0R/BDGlB1yzXjQOLtPAfHsgirEpg=="
+      "integrity": "sha512-2WSLa6OdYd2ng8oqiGIWnJqyFArvhn+5vgx5GTxMbUYjCYKUcuKS62YLFF0R/BDGlB1yzXjQOLtPAfHsgirEpg==",
+      "dev": true
     },
     "union-value": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,8 @@
     "xdr": "0.5.3"
   },
   "devDependencies": {
-    "babel-core": "7.0.0-beta.3",
+    "babel-core": "7.0.0-bridge.0",
+    "babel-jest": "23.6.0",
     "chai": "4.2.0",
     "chai-as-promised": "7.1.1",
     "core-js": "2.5.7",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "cf-pagination": "5.0.1",
     "cf-tables": "5.0.0",
     "cf-typography": "5.0.1",
-    "cfpb-chart-builder": "4.0.3",
+    "cfpb-chart-builder": "5.0.0",
     "del": "3.0.0",
     "elem-dataset": "1.1.1",
     "glob-all": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,6 @@
   },
   "devDependencies": {
     "babel-core": "7.0.0-bridge.0",
-    "babel-jest": "23.6.0",
     "chai": "4.2.0",
     "chai-as-promised": "7.1.1",
     "core-js": "2.5.7",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,10 @@
     "node": ">=8.5.0"
   },
   "dependencies": {
+    "autoprefixer": "8.6.5",
+    "@babel/core": "7.1.6",
+    "@babel/preset-env": "7.1.6",
+    "babel-loader": "8.0.4",
     "cf-atomic-component": "2.0.0",
     "cf-buttons": "5.0.0",
     "cf-core": "4.7.0",
@@ -62,11 +66,6 @@
     "xdr": "0.5.3"
   },
   "devDependencies": {
-    "@babel/core": "7.1.6",
-    "@babel/preset-env": "7.1.6",
-    "autoprefixer": "8.6.5",
-    "babel-core": "^7.0.0-bridge.0",
-    "babel-loader": "8.0.4",
     "chai": "4.2.0",
     "chai-as-promised": "7.1.1",
     "core-js": "2.5.7",

--- a/package.json
+++ b/package.json
@@ -62,8 +62,8 @@
     "xdr": "0.5.3"
   },
   "devDependencies": {
-    "@babel/core": "7.1.2",
-    "@babel/preset-env": "^7.0.0",
+    "@babel/core": "7.1.6",
+    "@babel/preset-env": "7.1.6",
     "autoprefixer": "8.6.5",
     "babel-core": "^7.0.0-bridge.0",
     "babel-loader": "8.0.4",
@@ -86,8 +86,8 @@
     "psi": "3.1.0",
     "sauce-connect-tunnel": "0.2.1",
     "selenium-webdriver": "4.0.0-alpha.1",
-    "snyk": "1.108.0",
-    "through2": "2.0.4",
+    "snyk": "1.108.2",
+    "through2": "3.0.0",
     "wcag": "0.3.0"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -62,13 +62,14 @@
     "xdr": "0.5.3"
   },
   "devDependencies": {
-    "autoprefixer": "8.6.5",
     "@babel/core": "7.1.2",
     "@babel/preset-env": "^7.0.0",
+    "autoprefixer": "8.6.5",
     "babel-core": "^7.0.0-bridge.0",
     "babel-loader": "8.0.4",
     "chai": "4.2.0",
     "chai-as-promised": "7.1.1",
+    "core-js": "2.5.7",
     "cucumber": "5.0.2",
     "fancy-log": "1.3.2",
     "gulp-eslint": "5.0.0",

--- a/package.json
+++ b/package.json
@@ -16,10 +16,6 @@
     "node": ">=8.5.0"
   },
   "dependencies": {
-    "autoprefixer": "8.6.5",
-    "babel-core": "7.0.0-beta.3",
-    "babel-loader": "7.1.5",
-    "babel-preset-env": "^7.0.0-beta.3",
     "cf-atomic-component": "2.0.0",
     "cf-buttons": "5.0.0",
     "cf-core": "4.7.0",
@@ -66,6 +62,11 @@
     "xdr": "0.5.3"
   },
   "devDependencies": {
+    "autoprefixer": "8.6.5",
+    "@babel/core": "7.1.2",
+    "@babel/preset-env": "^7.0.0",
+    "babel-core": "^7.0.0-bridge.0",
+    "babel-loader": "8.0.4",
     "chai": "4.2.0",
     "chai-as-promised": "7.1.1",
     "cucumber": "5.0.2",

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "xdr": "0.5.3"
   },
   "devDependencies": {
+    "babel-core": "7.0.0-beta.3",
     "chai": "4.2.0",
     "chai-as-promised": "7.1.1",
     "core-js": "2.5.7",

--- a/test/unit_tests/apps/analytics-gtm/js/util/analytics-util-spec.js
+++ b/test/unit_tests/apps/analytics-gtm/js/util/analytics-util-spec.js
@@ -1,5 +1,4 @@
-const BASE_JS_PATH = '../../../../../../cfgov/unprocessed/apps/analytics-gtm/';
-const analyticsUtil = require( BASE_JS_PATH + 'js/util/analytics-util' );
+import * as analyticsUtil from '../../../../../../cfgov/unprocessed/apps/analytics-gtm/js/util/analytics-util';
 
 const HTML_SNIPPET = `
   <div id="test-elem"></div>

--- a/test/unit_tests/apps/financial-well-being/js/fwb-questions-spec.js
+++ b/test/unit_tests/apps/financial-well-being/js/fwb-questions-spec.js
@@ -1,8 +1,6 @@
-const BASE_JS_PATH = '../../../../../cfgov/unprocessed/apps/';
-
 import { simulateEvent } from '../../../../util/simulate-event';
+import * as fwbQuestions from '../../../../../cfgov/unprocessed/apps/financial-well-being/js/fwb-questions';
 
-let fwbQuestions;
 let formDom;
 let submitBtnDom;
 let radioButtonsDom;
@@ -22,112 +20,112 @@ const dataLayerEventSubmit = {
 };
 
 const HTML_SNIPPET = `
-  <form id="quiz-form"
-         action="/consumer-tools/financial-well-being/results/"
-         method="POST">
-    <div class="block">
-      <h2>Part 1: How well does this statement describe you
-          or your situation?</h2>
-      <div class="question-group">
-        <fieldset class="o-scale" id="question_1">
-          <h3 class="o-scale_header">
-            I could handle a major unexpected expense
-          </h3>
-          <div class="answer-prefix">This statement describes me</div>
-          <div class="m-form-field m-form-field__radio">
-            <input class="a-radio"
-                   type="radio"
-                   id="question_1-completely"
-                   name="question_1"
-                   value="4"
-                   data-gtm-action="Questionnaire Radio Button Clicked"
-                   data-gtm-label="I could handle a major unexpected expense"
-                   data-gtm-category="Financial Well-Being Tool Interaction">
-            <label class="a-label" for="question_1-completely">
-              Completely
-            </label>
-          </div>
-          <div class="m-form-field m-form-field__radio">
-            <input class="a-radio"
-                   type="radio"
-                   id="question_1-very-well"
-                   name="question_1"
-                   value="3"
-                   data-gtm-action="Questionnaire Radio Button Clicked"
-                   data-gtm-label="I could handle a major unexpected expense"
-                   data-gtm-category="Financial Well-Being Tool Interaction">
-            <label class="a-label" for="question_1-very-well">
-              Very well
-            </label>
-          </div>
-        </fieldset>
-      </div>
+<form id="quiz-form"
+       action="/consumer-tools/financial-well-being/results/"
+       method="POST">
+  <div class="block">
+    <h2>Part 1: How well does this statement describe you
+        or your situation?</h2>
+    <div class="question-group">
+      <fieldset class="o-scale" id="question_1">
+        <h3 class="o-scale_header">
+          I could handle a major unexpected expense
+        </h3>
+        <div class="answer-prefix">This statement describes me</div>
+        <div class="m-form-field m-form-field__radio">
+          <input class="a-radio"
+                 type="radio"
+                 id="question_1-completely"
+                 name="question_1"
+                 value="4"
+                 data-gtm-action="Questionnaire Radio Button Clicked"
+                 data-gtm-label="I could handle a major unexpected expense"
+                 data-gtm-category="Financial Well-Being Tool Interaction">
+          <label class="a-label" for="question_1-completely">
+            Completely
+          </label>
+        </div>
+        <div class="m-form-field m-form-field__radio">
+          <input class="a-radio"
+                 type="radio"
+                 id="question_1-very-well"
+                 name="question_1"
+                 value="3"
+                 data-gtm-action="Questionnaire Radio Button Clicked"
+                 data-gtm-label="I could handle a major unexpected expense"
+                 data-gtm-category="Financial Well-Being Tool Interaction">
+          <label class="a-label" for="question_1-very-well">
+            Very well
+          </label>
+        </div>
+      </fieldset>
     </div>
-    <div class="block u-mb30">
-      <h2>About you</h2>
-      <div class="question-group">
-        <fieldset class="o-form_fieldset" id="method">
-          <h3 class="o-scale_header">
-              Select how you completed the questionnaire.
-              This changes the scoring calculation.
-          </h3>
-          <ul class="m-list m-list__unstyled content-l">
-            <li class="content-l_col content-l_col-1-2">
-              <div class="m-form-field
-                          m-form-field__radio
-                          m-form-field__lg-target">
-                <input class="a-radio"
-                       type="radio"
-                       name="method"
-                       id="read-self"
-                       value="read-self"
-                       data-gtm-action="Questionnaire Radio Button Clicked"
-                       data-gtm-label="Select how you completed the
-                       questionnaire: I read and answered the questions myself"
-                       data-gtm-category="Financial Well-Being Tool
-                       Interaction"
-                       checked="">
-                <label class="a-label" for="read-self">
-                  I read and answered the questions myself
-                </label>
-              </div>
-            </li>
-            <li class="content-l_col content-l_col-1-2">
-              <div class="m-form-field
-                          m-form-field__radio
-                          m-form-field__lg-target">
-                <input class="a-radio"
-                       type="radio"
-                       name="method"
-                       id="read-to-me"
-                       value="read-to-me"
-                       data-gtm-action="Questionnaire Radio Button Clicked"
-                       data-gtm-label="Select how you completed the
-                       questionnaire: I read the questions to someone else
-                       and recorded their answers"
-                       data-gtm-category="Financial Well-Being Tool
-                       Interaction">
-                <label class="a-label" for="read-to-me">
-                  I read the questions to someone else
-                  and recorded their answers
-                </label>
-              </div>
-            </li>
-          </ul>
-        </fieldset>
-      </div>
+  </div>
+  <div class="block u-mb30">
+    <h2>About you</h2>
+    <div class="question-group">
+      <fieldset class="o-form_fieldset" id="method">
+        <h3 class="o-scale_header">
+            Select how you completed the questionnaire.
+            This changes the scoring calculation.
+        </h3>
+        <ul class="m-list m-list__unstyled content-l">
+          <li class="content-l_col content-l_col-1-2">
+            <div class="m-form-field
+                        m-form-field__radio
+                        m-form-field__lg-target">
+              <input class="a-radio"
+                     type="radio"
+                     name="method"
+                     id="read-self"
+                     value="read-self"
+                     data-gtm-action="Questionnaire Radio Button Clicked"
+                     data-gtm-label="Select how you completed the
+                     questionnaire: I read and answered the questions myself"
+                     data-gtm-category="Financial Well-Being Tool
+                     Interaction"
+                     checked="">
+              <label class="a-label" for="read-self">
+                I read and answered the questions myself
+              </label>
+            </div>
+          </li>
+          <li class="content-l_col content-l_col-1-2">
+            <div class="m-form-field
+                        m-form-field__radio
+                        m-form-field__lg-target">
+              <input class="a-radio"
+                     type="radio"
+                     name="method"
+                     id="read-to-me"
+                     value="read-to-me"
+                     data-gtm-action="Questionnaire Radio Button Clicked"
+                     data-gtm-label="Select how you completed the
+                     questionnaire: I read the questions to someone else
+                     and recorded their answers"
+                     data-gtm-category="Financial Well-Being Tool
+                     Interaction">
+              <label class="a-label" for="read-to-me">
+                I read the questions to someone else
+                and recorded their answers
+              </label>
+            </div>
+          </li>
+        </ul>
+      </fieldset>
     </div>
-    <div class="o-form_group">
-      <input class="submit-quiz a-btn"
-             id="submit-quiz"
-             type="submit"
-             value="Get my score"
-             title="Please answer all questions to get your score"
-             data-gtm-action="Questionnaire Submitted"
-             data-gtm-label="Get my score"
-             data-gtm-category="Financial Well-Being Tool Interaction">
-    </div>
-  </form>
+  </div>
+  <div class="o-form_group">
+    <input class="submit-quiz a-btn"
+           id="submit-quiz"
+           type="submit"
+           value="Get my score"
+           title="Please answer all questions to get your score"
+           data-gtm-action="Questionnaire Submitted"
+           data-gtm-label="Get my score"
+           data-gtm-category="Financial Well-Being Tool Interaction">
+  </div>
+</form>
 `;
 
 function fillOutForm() {
@@ -139,9 +137,6 @@ function fillOutForm() {
 
 describe( 'fwb-questions', () => {
   beforeEach( () => {
-    fwbQuestions = require(
-      BASE_JS_PATH + 'financial-well-being/js/fwb-questions'
-    );
     document.body.innerHTML = HTML_SNIPPET;
     window.dataLayer = [];
     window['google_tag_manager'] = {};

--- a/test/unit_tests/apps/financial-well-being/js/fwb-results-spec.js
+++ b/test/unit_tests/apps/financial-well-being/js/fwb-results-spec.js
@@ -1,13 +1,11 @@
-const BASE_JS_PATH = '../../../../../cfgov/unprocessed/apps/';
+import { simulateEvent } from '../../../../util/simulate-event';
+import * as fwbResults from '../../../../../cfgov/unprocessed/apps/financial-well-being/js/fwb-results';
 
 const SELECTED_CLASS = 'comparison-chart_toggle-button__selected';
 const HIDDEN_CLASS = 'u-hidden';
 
-import { simulateEvent } from '../../../../util/simulate-event';
-
 let expandableContent;
 let expandableTarget;
-let fwbResults;
 let toggleButtons;
 let dataPoint;
 
@@ -20,89 +18,86 @@ const dataLayerEvent = {
 };
 
 const HTML_SNIPPET = `
-  <div class="content">
-    <div class="o-expandable">
-      <button class="o-expandable_target">
-        <div class="o-expandable_header">
-          <span class="o-expandable_header-left o-expandable_label">
-          </span>
-          <span class="o-expandable_header-right o-expandable_link">
-            <span class="o-expandable_cue o-expandable_cue-open"></span>
-            <span class="o-expandable_cue o-expandable_cue-close"></span>
-          </span>
-        </div>
-      </button>
-      <div class="o-expandable_content">
-        <div class="o-expandable_content-animated"></div>
+<div class="content">
+  <div class="o-expandable">
+    <button class="o-expandable_target">
+      <div class="o-expandable_header">
+        <span class="o-expandable_header-left o-expandable_label">
+        </span>
+        <span class="o-expandable_header-right o-expandable_link">
+          <span class="o-expandable_cue o-expandable_cue-open"></span>
+          <span class="o-expandable_cue o-expandable_cue-close"></span>
+        </span>
       </div>
+    </button>
+    <div class="o-expandable_content">
+      <div class="o-expandable_content-animated"></div>
     </div>
-    <figure class="comparison-chart" id="comparison-chart">
-      <div class="comparison-chart_toggle u-js-only">
-        <h4>Compare by</h4>
-        <button class="a-btn
-                       comparison-chart_toggle-button
-                       comparison-chart_toggle-button__selected"
-                data-compare-by="age"
-                data-gtm-action="Compare By Button Clicked"
-                data-gtm-label="Age"
-                data-gtm-category="Financial Well-Being Tool Interaction">
-          Age
-        </button>
-        <button class="a-btn comparison-chart_toggle-button"
-                data-compare-by="income"
-                data-gtm-action="Compare By Button Clicked"
-                data-gtm-label="Household income"
-                data-gtm-category="Financial Well-Being Tool Interaction">
-          Household income
-        </button>
-        <button class="a-btn comparison-chart_toggle-button"
-                data-compare-by="employment"
-                data-gtm-action="Compare By Button Clicked"
-                data-gtm-label="Employment status"
-                data-gtm-category="Financial Well-Being Tool Interaction">
-          Employment status
-        </button>
-      </div>
-      <dl class="comparison-chart_list">
-        <dt><b>Your score</b></dt>
-        <dd>
-          <span style="left: 48.1481481481%; border-color: #a6a329;">
-            53
-          </span>
-        </dd>
-        <dt>U.S. average</dt>
-        <dd>
-          <span style="left: 49.3827160494%; border-color: #a6a329;">
-            54
-          </span>
-        </dd>
-        <dt class="comparison_data-point age_group">18-24 year olds</dt>
-        <dd class="comparison_data-point age_mean">
-          <span style="left: 45.6790123457%; border-color: #a6a329;">
-            51
-          </span>
-        </dd>
-        <dt class="comparison_data-point employment_group">Self-employed</dt>
-        <dd class="comparison_data-point employment_mean">
-          <span style="left: 49.3827160494%; border-color: #a6a329;">
-            54
-          </span>
-        </dd>
-        <dt class="comparison_data-point income_group">Less than $20,000</dt>
-        <dd class="comparison_data-point income_mean">
-          <span style="left: 39.5061728395%; border-color: #f9921c;">
-            46
-          </span>
-        </dd>
-      </dl>
-    </figure>
   </div>
+  <figure class="comparison-chart" id="comparison-chart">
+    <div class="comparison-chart_toggle u-js-only">
+      <h4>Compare by</h4>
+      <button class="a-btn
+                     comparison-chart_toggle-button
+                     comparison-chart_toggle-button__selected"
+              data-compare-by="age"
+              data-gtm-action="Compare By Button Clicked"
+              data-gtm-label="Age"
+              data-gtm-category="Financial Well-Being Tool Interaction">
+        Age
+      </button>
+      <button class="a-btn comparison-chart_toggle-button"
+              data-compare-by="income"
+              data-gtm-action="Compare By Button Clicked"
+              data-gtm-label="Household income"
+              data-gtm-category="Financial Well-Being Tool Interaction">
+        Household income
+      </button>
+      <button class="a-btn comparison-chart_toggle-button"
+              data-compare-by="employment"
+              data-gtm-action="Compare By Button Clicked"
+              data-gtm-label="Employment status"
+              data-gtm-category="Financial Well-Being Tool Interaction">
+        Employment status
+      </button>
+    </div>
+    <dl class="comparison-chart_list">
+      <dt><b>Your score</b></dt>
+      <dd>
+        <span style="left: 48.1481481481%; border-color: #a6a329;">
+          53
+        </span>
+      </dd>
+      <dt>U.S. average</dt>
+      <dd>
+        <span style="left: 49.3827160494%; border-color: #a6a329;">
+          54
+        </span>
+      </dd>
+      <dt class="comparison_data-point age_group">18-24 year olds</dt>
+      <dd class="comparison_data-point age_mean">
+        <span style="left: 45.6790123457%; border-color: #a6a329;">
+          51
+        </span>
+      </dd>
+      <dt class="comparison_data-point employment_group">Self-employed</dt>
+      <dd class="comparison_data-point employment_mean">
+        <span style="left: 49.3827160494%; border-color: #a6a329;">
+          54
+        </span>
+      </dd>
+      <dt class="comparison_data-point income_group">Less than $20,000</dt>
+      <dd class="comparison_data-point income_mean">
+        <span style="left: 39.5061728395%; border-color: #f9921c;">
+          46
+        </span>
+      </dd>
+    </dl>
+  </figure>
+</div>
 `;
 
 function initFwbResults() {
-  fwbResults = require(
-    BASE_JS_PATH + 'financial-well-being/js/fwb-results'
-  );
   fwbResults.init();
 }
 

--- a/test/unit_tests/apps/owning-a-home/js/dom-tools-spec.js
+++ b/test/unit_tests/apps/owning-a-home/js/dom-tools-spec.js
@@ -1,11 +1,10 @@
-const BASE_JS_PATH = '../../../../../cfgov/unprocessed/apps/owning-a-home/';
-const domTools = require( BASE_JS_PATH + 'js/dom-tools.js' ).default;
+import domTools from '../../../../../cfgov/unprocessed/apps/owning-a-home/js/dom-tools.js';
 
 const HTML_SNIPPET = `
-  <div id="test"></div>
-  <div id="test2" class="test"></div>
-  <div class="test"></div>
-  <div class="test"></div>
+<div id="test"></div>
+<div id="test2" class="test"></div>
+<div class="test"></div>
+<div class="test"></div>
 `;
 
 let testDom;

--- a/test/unit_tests/apps/owning-a-home/js/dropdown-utils-spec.js
+++ b/test/unit_tests/apps/owning-a-home/js/dropdown-utils-spec.js
@@ -1,12 +1,11 @@
-const BASE_JS_PATH = '../../../../../cfgov/unprocessed/apps/';
-const dropDownUtils = require( BASE_JS_PATH + 'owning-a-home/js/dropdown-utils.js' );
+import dropDownUtils from '../../../../../cfgov/unprocessed/apps/owning-a-home/js/dropdown-utils.js';
 
 const HTML_SNIPPET = `
-  <div class="foo">
-    <select id="foo">
-      <option value="baz"></option>
-    </select>
-  </div>
+<div class="foo">
+  <select id="foo">
+    <option value="baz"></option>
+  </select>
+</div>
 `;
 
 let dropDownDom;

--- a/test/unit_tests/apps/owning-a-home/js/explore-rates/RateCheckerChart-spec.js
+++ b/test/unit_tests/apps/owning-a-home/js/explore-rates/RateCheckerChart-spec.js
@@ -1,34 +1,33 @@
-const BASE_JS_PATH = '../../../../../../cfgov/unprocessed/apps/owning-a-home/';
-const RateCheckerChart = require( BASE_JS_PATH + 'js/explore-rates/RateCheckerChart' );
+import RateCheckerChart from '../../../../../../cfgov/unprocessed/apps/owning-a-home/js/explore-rates/RateCheckerChart';
 
 const HTML_SNIPPET = `
-  <section id="chart-section" class="chart">
+<section id="chart-section" class="chart">
 
-    <figure class="data-enabled loading">
-        <div id="chart" class="chart-area"></div>
-        <figcaption class="chart-caption">
-            <div class="caption-title">
-                Interest rates for your situation
-            </div>
-            <div class="rc-data-link">
-                <a href="#about" class="u-link-underline">
-                    About our data source
-                </a>
-            </div>
-        </figcaption>
-    </figure>
+  <figure class="data-enabled loading">
+      <div id="chart" class="chart-area"></div>
+      <figcaption class="chart-caption">
+          <div class="caption-title">
+              Interest rates for your situation
+          </div>
+          <div class="rc-data-link">
+              <a href="#about" class="u-link-underline">
+                  About our data source
+              </a>
+          </div>
+      </figcaption>
+  </figure>
 
-    <div id="chart-result-alert"
-         class="result-alert chart-alert u-hidden"
-         role="alert">
-    </div>
+  <div id="chart-result-alert"
+       class="result-alert chart-alert u-hidden"
+       role="alert">
+  </div>
 
-    <div id="chart-fail-alert"
-         class="result-alert chart-alert u-hidden"
-         role="alert">
-    </div>
+  <div id="chart-fail-alert"
+       class="result-alert chart-alert u-hidden"
+       role="alert">
+  </div>
 
-  </section>
+</section>
 `;
 
 let chart;

--- a/test/unit_tests/apps/owning-a-home/js/explore-rates/Slider-spec.js
+++ b/test/unit_tests/apps/owning-a-home/js/explore-rates/Slider-spec.js
@@ -1,18 +1,17 @@
-const BASE_JS_PATH = '../../../../../../cfgov/unprocessed/apps/owning-a-home/';
-const Slider = require( BASE_JS_PATH + 'js/explore-rates/Slider' );
+import Slider from '../../../../../../cfgov/unprocessed/apps/owning-a-home/js/explore-rates/Slider';
 let sliderDom;
 let slider;
 
 const HTML_SNIPPET = `
-  <div class="a-range">
-    <div class="a-range_labels">
-      <span class="a-range_labels-min"></span>
-      <span class="a-range_labels-max"></span>
-    </div>
-    <input type="range"
-           class="a-range_input">
-    <div class="a-range_text"></div>
+<div class="a-range">
+  <div class="a-range_labels">
+    <span class="a-range_labels-min"></span>
+    <span class="a-range_labels-max"></span>
   </div>
+  <input type="range"
+         class="a-range_input">
+  <div class="a-range_text"></div>
+</div>
 `;
 
 describe( 'explore-rates/Slider', () => {

--- a/test/unit_tests/apps/owning-a-home/js/explore-rates/rate-checker-spec.js
+++ b/test/unit_tests/apps/owning-a-home/js/explore-rates/rate-checker-spec.js
@@ -1,6 +1,4 @@
-const BASE_JS_PATH = '../../../../../../cfgov/unprocessed/apps/owning-a-home/';
-const rateChecker = require( BASE_JS_PATH + 'js/explore-rates/rate-checker' );
-
+import * as rateChecker from '../../../../../../cfgov/unprocessed/apps/owning-a-home/js/explore-rates/rate-checker';
 import { simulateEvent } from '../../../../../util/simulate-event';
 
 // Mock the XmlHttpRequest call from axios.
@@ -10,148 +8,148 @@ const mockResp = { data: 'mock data' };
 axios.get.mockImplementation( () => Promise.resolve( mockResp ) );
 
 const HTML_SNIPPET = `
-  <div class="rate-checker">
-    <div id="rate-results">
-      <div id="accessible-data-results">
-        <table id="accessible-data">
-          <tbody>
-            <tr class="table-head">
-              <th>Loan Rates</th>
-            </tr>
-            <tr class="table-body">
-              <td>number of corresponding rates</td>
-            </tr>
-          </tbody>
-        </table>
+<div class="rate-checker">
+  <div id="rate-results">
+    <div id="accessible-data-results">
+      <table id="accessible-data">
+        <tbody>
+          <tr class="table-head">
+            <th>Loan Rates</th>
+          </tr>
+          <tr class="table-body">
+            <td>number of corresponding rates</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+
+    <section id="chart-section" class="chart">
+
+      <figure class="data-enabled loading">
+          <div id="chart" class="chart-area"></div>
+          <figcaption class="chart-caption">
+              <div class="caption-title">
+                  Interest rates for your situation
+              </div>
+              <div class="rc-data-link">
+                  <a href="#about" class="u-link-underline">
+                      About our data source
+                  </a>
+              </div>
+          </figcaption>
+      </figure>
+
+      <div id="chart-result-alert"
+           class="result-alert chart-alert u-hidden"
+           role="alert">
       </div>
 
-      <section id="chart-section" class="chart">
+      <div id="chart-fail-alert"
+           class="result-alert chart-alert u-hidden"
+           role="alert">
+      </div>
 
-        <figure class="data-enabled loading">
-            <div id="chart" class="chart-area"></div>
-            <figcaption class="chart-caption">
-                <div class="caption-title">
-                    Interest rates for your situation
-                </div>
-                <div class="rc-data-link">
-                    <a href="#about" class="u-link-underline">
-                        About our data source
-                    </a>
-                </div>
-            </figcaption>
-        </figure>
+    </section>
+  </div>
+  <div class="result">
+    <div class="calculator">
 
-        <div id="chart-result-alert"
+      <section id="credit-score-container">
+        <div class="a-range" id="credit-score-range">
+          <div class="a-range_labels">
+            <span class="a-range_labels-min"></span>
+            <span class="a-range_labels-max"></span>
+          </div>
+          <input type="range"
+                 class="a-range_input">
+          <div class="a-range_text"></div>
+        </div>
+
+        <div id="credit-score-alert"
              class="result-alert chart-alert u-hidden"
              role="alert">
         </div>
-
-        <div id="chart-fail-alert"
-             class="result-alert chart-alert u-hidden"
-             role="alert">
-        </div>
-
       </section>
-    </div>
-    <div class="result">
-      <div class="calculator">
 
-        <section id="credit-score-container">
-          <div class="a-range" id="credit-score-range">
-            <div class="a-range_labels">
-              <span class="a-range_labels-min"></span>
-              <span class="a-range_labels-max"></span>
-            </div>
-            <input type="range"
-                   class="a-range_input">
-            <div class="a-range_text"></div>
+      <section class="calc-loan-amt" id="loan-amt-inputs">
+          <div class="house-price half-width-gt-1230">
+              <label for="house-price">House price</label>
+              <div class="dollar-input">
+                  <span class="unit">$</span>
+                  <input type="text" placeholder="200,000" name="house-price"
+                         class="recalc" id="house-price">
+              </div>
+          </div>
+          <div class="down-payment half-width-gt-1230">
+              <label for="down-payment">Down payment</label>
+              <div class="percent-input">
+                  <span class="unit">%</span>
+                  <input type="text" placeholder="10"
+                         name="percent-down" maxlength="2"
+                         class="recalc" id="percent-down">
+              </div>
+              <div class="dollar-input">
+                  <span class="unit">$</span>
+                  <input type="text" placeholder="20,000" name="down-payment"
+                         class="recalc" "="" id="down-payment" value="20000">
+              </div>
+          </div>
+          <div class="loan-amt-total half-width-gt-1230">
+              <label class="inline">Loan amount</label>
+              <span id="loan-amount-result">$180,000</span>
+          </div>
+          <div class="county half-width-gt-1230 u-hidden">
+              <label for="county">County</label>
+              <div class="select-content a-select">
+                  <select name="county" class="recalc" id="county">
+                  </select>
+              </div>
           </div>
 
-          <div id="credit-score-alert"
-               class="result-alert chart-alert u-hidden"
+          <div id="dp-alert"
+               class="downpayment-warning alert-alt col-7 u-hidden"
                role="alert">
+            Your down payment cannot be more than your house price.
           </div>
-        </section>
+      </section>
 
-        <section class="calc-loan-amt" id="loan-amt-inputs">
-            <div class="house-price half-width-gt-1230">
-                <label for="house-price">House price</label>
-                <div class="dollar-input">
-                    <span class="unit">$</span>
-                    <input type="text" placeholder="200,000" name="house-price"
-                           class="recalc" id="house-price">
-                </div>
+      <section class="calc-loan-details">
+
+        <div class="upper rate-structure half-width-gt-1230">
+            <label for="rate-structure">Rate type</label>
+            <div class="select-content a-select">
+                <select name="rate-structure" class="recalc" id="rate-structure">
+                    <option value="fixed">Fixed</option>
+                    <option value="arm">Adjustable</option>
+                </select>
             </div>
-            <div class="down-payment half-width-gt-1230">
-                <label for="down-payment">Down payment</label>
-                <div class="percent-input">
-                    <span class="unit">%</span>
-                    <input type="text" placeholder="10"
-                           name="percent-down" maxlength="2"
-                           class="recalc" id="percent-down">
-                </div>
-                <div class="dollar-input">
-                    <span class="unit">$</span>
-                    <input type="text" placeholder="20,000" name="down-payment"
-                           class="recalc" "="" id="down-payment" value="20000">
-                </div>
-            </div>
-            <div class="loan-amt-total half-width-gt-1230">
-                <label class="inline">Loan amount</label>
-                <span id="loan-amount-result">$180,000</span>
-            </div>
-            <div class="county half-width-gt-1230 u-hidden">
-                <label for="county">County</label>
-                <div class="select-content a-select">
-                    <select name="county" class="recalc" id="county">
-                    </select>
-                </div>
-            </div>
-
-            <div id="dp-alert"
-                 class="downpayment-warning alert-alt col-7 u-hidden"
-                 role="alert">
-              Your down payment cannot be more than your house price.
-            </div>
-        </section>
-
-        <section class="calc-loan-details">
-
-          <div class="upper rate-structure half-width-gt-1230">
-              <label for="rate-structure">Rate type</label>
-              <div class="select-content a-select">
-                  <select name="rate-structure" class="recalc" id="rate-structure">
-                      <option value="fixed">Fixed</option>
-                      <option value="arm">Adjustable</option>
-                  </select>
-              </div>
-          </div>
-
-          <div class="arm-type half-width-gt-1230 u-hidden">
-              <label for="arm-type">ARM type</label>
-              <div class="select-content a-select">
-                  <select name="arm-type" class="recalc" id="arm-type">
-                      <option value="3-1">3/1</option>
-                      <option value="5-1">5/1</option>
-                      <option value="7-1">7/1</option>
-                      <option value="10-1">10/1</option>
-                  </select>
-              </div>
-          </div>
-        </section>
-
-        <section class="form-sub warning u-hidden" id="arm-warning">
-          <p class="warning-text">While some lenders may offer FHA, VA, or 15-year adjustable-rate mortgages, they are rare. We don’t have enough data to display results for these combinations. Choose a fixed rate if you’d like to try these options.</p>
-        </section>
-      </div>
-    </div>
-    <div class="rc-results" id="rate-results" aria-live="polite">
-      <section class="compare wrapper data-enabled loaded">
-        <div id="rate-selects">
         </div>
+
+        <div class="arm-type half-width-gt-1230 u-hidden">
+            <label for="arm-type">ARM type</label>
+            <div class="select-content a-select">
+                <select name="arm-type" class="recalc" id="arm-type">
+                    <option value="3-1">3/1</option>
+                    <option value="5-1">5/1</option>
+                    <option value="7-1">7/1</option>
+                    <option value="10-1">10/1</option>
+                </select>
+            </div>
+        </div>
+      </section>
+
+      <section class="form-sub warning u-hidden" id="arm-warning">
+        <p class="warning-text">While some lenders may offer FHA, VA, or 15-year adjustable-rate mortgages, they are rare. We don’t have enough data to display results for these combinations. Choose a fixed rate if you’d like to try these options.</p>
       </section>
     </div>
   </div>
+  <div class="rc-results" id="rate-results" aria-live="polite">
+    <section class="compare wrapper data-enabled loaded">
+      <div id="rate-selects">
+      </div>
+    </section>
+  </div>
+</div>
 `;
 
 let downPaymentDom;

--- a/test/unit_tests/apps/owning-a-home/js/ratings-form-spec.js
+++ b/test/unit_tests/apps/owning-a-home/js/ratings-form-spec.js
@@ -1,78 +1,75 @@
-const BASE_JS_PATH = '../../../../../cfgov/unprocessed/apps/';
-
 import { simulateEvent } from '../../../../util/simulate-event';
+import * as ratingsForm from '../../../../../cfgov/unprocessed/apps/owning-a-home/js/ratings-form';
 
 let feedBackLinkElement;
 let ratingsInputs;
 
 const HTML_SNIPPET = `
-  <form method="post"
-        class="o-form
-               oah-ratings-form
-               block
-               block__bg
-               block__border
-               block__padded-top">
-      <fieldset class="o-form_fieldset u-reset">
-          <legend class="a-legend">
-              <span class="h4">Was this page helpful to you?</span>
-          </legend>
-          <div class="rating-inputs">
-              <ul class="content-l m-list m-list__unstyled">
-                  <li class="content-l_col content-l_col-1-3">
-                      <div class="m-form-field
-                                  m-form-field__radio
-                                  m-form-field__lg-target">
-                          <input class="a-radio"
-                                 id="is_helpful_0"
-                                 type="radio"
-                                 name="is_helpful"
-                                 value="0">
-                          <label class="a-label"
-                                 for="is_helpful_0">
-                              Yes
-                          </label>
-                      </div>
-                  </li>
-                  <li class="content-l_col content-l_col-1-3">
-                      <div class="m-form-field
-                                  m-form-field__radio
-                                  m-form-field__lg-target">
-                              <input class="a-radio"
-                                     id="is_helpful_1"
-                                     type="radio"
-                                     name="is_helpful"
-                                     value="1">
-                              <label class="a-label"
-                                     for="is_helpful_1">
-                                  No
-                              </label>
-                      </div>
-                  </li>
-                  <li class="content-l_col content-l_col-1-3">
-                      <div class="rating-message message-column">
-                          <span class="rating-message_text">
-                              Thank you for your feedback!
-                          </span>
-                      </div>
-                  </li>
-              </ul>
-              <a class="a-link a-link__jump feedback-link"
-                 href="/owning-a-home/feedback/">
-                  <span class="a-link_text">Provide additional feedback</span>
-              </a>
-          </div>
-      </fieldset>
-  </form>
+<form method="post"
+      class="o-form
+             oah-ratings-form
+             block
+             block__bg
+             block__border
+             block__padded-top">
+    <fieldset class="o-form_fieldset u-reset">
+        <legend class="a-legend">
+            <span class="h4">Was this page helpful to you?</span>
+        </legend>
+        <div class="rating-inputs">
+            <ul class="content-l m-list m-list__unstyled">
+                <li class="content-l_col content-l_col-1-3">
+                    <div class="m-form-field
+                                m-form-field__radio
+                                m-form-field__lg-target">
+                        <input class="a-radio"
+                               id="is_helpful_0"
+                               type="radio"
+                               name="is_helpful"
+                               value="0">
+                        <label class="a-label"
+                               for="is_helpful_0">
+                            Yes
+                        </label>
+                    </div>
+                </li>
+                <li class="content-l_col content-l_col-1-3">
+                    <div class="m-form-field
+                                m-form-field__radio
+                                m-form-field__lg-target">
+                            <input class="a-radio"
+                                   id="is_helpful_1"
+                                   type="radio"
+                                   name="is_helpful"
+                                   value="1">
+                            <label class="a-label"
+                                   for="is_helpful_1">
+                                No
+                            </label>
+                    </div>
+                </li>
+                <li class="content-l_col content-l_col-1-3">
+                    <div class="rating-message message-column">
+                        <span class="rating-message_text">
+                            Thank you for your feedback!
+                        </span>
+                    </div>
+                </li>
+            </ul>
+            <a class="a-link a-link__jump feedback-link"
+               href="/owning-a-home/feedback/">
+                <span class="a-link_text">Provide additional feedback</span>
+            </a>
+        </div>
+    </fieldset>
+</form>
 `;
 
 describe( 'ratings-form', () => {
 
   beforeEach( () => {
     document.body.innerHTML = HTML_SNIPPET;
-    require(
-      BASE_JS_PATH + 'owning-a-home/js/ratings-form'
-    ).init();
+    ratingsForm.init();
 
     ratingsInputs = document.querySelectorAll( '.rating-inputs input' );
     feedBackLinkElement = document.querySelector( '.feedback-link' );

--- a/test/unit_tests/apps/regulations3k/js/analytics-spec.js
+++ b/test/unit_tests/apps/regulations3k/js/analytics-spec.js
@@ -1,6 +1,4 @@
-const BASE_JS_PATH = '../../../../../cfgov/unprocessed/apps/regulations3k';
-
-const analytics = require( `${ BASE_JS_PATH }/js/analytics.js` );
+import * as analytics from '../../../../../cfgov/unprocessed/apps/regulations3k/js/analytics.js';
 
 /* eslint-disable max-lines-per-function, no-undefined */
 describe( 'The Regs3K analytics', () => {

--- a/test/unit_tests/apps/regulations3k/js/index-spec.js
+++ b/test/unit_tests/apps/regulations3k/js/index-spec.js
@@ -1,6 +1,4 @@
-const BASE_JS_PATH = '../../../../../cfgov/unprocessed/apps/regulations3k';
-
-const app = require( `${ BASE_JS_PATH }/js/index.js` );
+import app from '../../../../../cfgov/unprocessed/apps/regulations3k/js/index.js';
 
 describe( 'The app', () => {
 

--- a/test/unit_tests/js/modules/Analytics-spec.js
+++ b/test/unit_tests/js/modules/Analytics-spec.js
@@ -1,13 +1,10 @@
-const BASE_JS_PATH = '../../../../cfgov/unprocessed/js/';
-
-let Analytics;
+import Analytics from '../../../../cfgov/unprocessed/js/modules/Analytics';
 let dataLayerOptions;
 let getDataLayerOptions;
 let UNDEFINED;
 
 describe( 'Analytics', () => {
   beforeAll( () => {
-    Analytics = require( BASE_JS_PATH + 'modules/Analytics' );
     getDataLayerOptions = Analytics.getDataLayerOptions;
   } );
 

--- a/test/unit_tests/js/modules/BreakpointHandler-spec.js
+++ b/test/unit_tests/js/modules/BreakpointHandler-spec.js
@@ -1,5 +1,4 @@
-const BASE_JS_PATH = '../../../../cfgov/unprocessed/js/';
-let BreakpointHandler;
+import BreakpointHandler from '../../../../cfgov/unprocessed/js/modules/BreakpointHandler';
 let args;
 
 /**
@@ -23,8 +22,6 @@ describe( 'BreakpointHandler', () => {
       leave:      jest.fn(),
       breakpoint: 600
     };
-
-    BreakpointHandler = require( BASE_JS_PATH + 'modules/BreakpointHandler' );
   } );
 
   it( 'should throw an error if passed incomplete arguments', () => {

--- a/test/unit_tests/js/modules/ClearableInput-spec.js
+++ b/test/unit_tests/js/modules/ClearableInput-spec.js
@@ -1,6 +1,4 @@
-const BASE_JS_PATH = '../../../../cfgov/unprocessed/js/';
-const ClearableInput = require( BASE_JS_PATH + 'modules/ClearableInput' );
-
+import ClearableInput from '../../../../cfgov/unprocessed/js/modules/ClearableInput';
 import { simulateEvent } from '../../../util/simulate-event';
 
 let baseDom;
@@ -8,22 +6,22 @@ let clearBtnDom;
 let inputDom;
 
 const HTML_SNIPPET = `
-  <div class="o-form__input-w-btn_input-container">
-       <div class="m-btn-inside-input
-                   input-contains-label">
-           <label for="query" class="input-contains-label_before
-                                     input-contains-label_before__search">
-           </label>
-           <label for="query" class="input-contains-label_after
-                                     input-contains-label_after__clear">
-           </label>
-           <input type="text"
-                  title="Search the CFPB"
-                  class="a-text-input"
-                  value=""
-                  placeholder="Search the CFPB">
-       </div>
-  </div>
+<div class="o-form__input-w-btn_input-container">
+     <div class="m-btn-inside-input
+                 input-contains-label">
+         <label for="query" class="input-contains-label_before
+                                   input-contains-label_before__search">
+         </label>
+         <label for="query" class="input-contains-label_after
+                                   input-contains-label_after__clear">
+         </label>
+         <input type="text"
+                title="Search the CFPB"
+                class="a-text-input"
+                value=""
+                placeholder="Search the CFPB">
+     </div>
+</div>
 `;
 
 describe( 'ClearableInput', () => {

--- a/test/unit_tests/js/modules/ExternalSite-spec.js
+++ b/test/unit_tests/js/modules/ExternalSite-spec.js
@@ -1,5 +1,5 @@
-const BASE_JS_PATH = '../../../../cfgov/unprocessed/js/modules/';
-const ExternalSite = require( BASE_JS_PATH + 'ExternalSite' );
+import ExternalSite from '../../../../cfgov/unprocessed/js/modules/ExternalSite';
+
 const HTML_SNIPPET = `
 <main class="content external-site_container">
     <div class="wrapper content_wrapper">

--- a/test/unit_tests/js/modules/Tree-spec.js
+++ b/test/unit_tests/js/modules/Tree-spec.js
@@ -1,5 +1,4 @@
-const BASE_JS_PATH = '../../../../cfgov/unprocessed/js/';
-const Tree = require( BASE_JS_PATH + 'modules/Tree' );
+import Tree from '../../../../cfgov/unprocessed/js/modules/Tree';
 
 describe( 'Tree', () => {
   let tree;

--- a/test/unit_tests/js/modules/behavior/FlyoutMenu-spec.js
+++ b/test/unit_tests/js/modules/behavior/FlyoutMenu-spec.js
@@ -1,18 +1,16 @@
-const BASE_JS_PATH = '../../../../../cfgov/unprocessed/js/';
-const FlyoutMenu = require( BASE_JS_PATH + 'modules/behavior/FlyoutMenu' );
-const MoveTransition =
-  require( BASE_JS_PATH + 'modules/transition/MoveTransition' );
+import FlyoutMenu from '../../../../../cfgov/unprocessed/js/modules/behavior/FlyoutMenu';
+import MoveTransition from '../../../../../cfgov/unprocessed/js/modules/transition/MoveTransition';
 
 const HTML_SNIPPET = `
-  <div data-js-hook="behavior_flyout-menu">
-      <button data-js-hook="behavior_flyout-menu_trigger"
-              aria-haspopup="menu"
+<div data-js-hook="behavior_flyout-menu">
+    <button data-js-hook="behavior_flyout-menu_trigger"
+            aria-haspopup="menu"
+            aria-expanded="false"></button>
+    <div data-js-hook="behavior_flyout-menu_content" aria-expanded="false">
+      <button data-js-hook="behavior_flyout-menu_alt-trigger"
               aria-expanded="false"></button>
-      <div data-js-hook="behavior_flyout-menu_content" aria-expanded="false">
-        <button data-js-hook="behavior_flyout-menu_alt-trigger"
-                aria-expanded="false"></button>
-      </div>
-  </div>
+    </div>
+</div>
 `;
 
 describe( 'FlyoutMenu', () => {

--- a/test/unit_tests/js/modules/footer-button-spec.js
+++ b/test/unit_tests/js/modules/footer-button-spec.js
@@ -6,11 +6,11 @@ import { simulateEvent } from '../../../util/simulate-event';
 let footerBtnDom;
 
 const HTML_SNIPPET = `
-  <a class="a-btn a-btn__secondary o-footer_top-button"
-     data-gtm_ignore="true" data-js-hook="behavior_return-to-top"
-     href="#">
-      Back to top
-  </a>
+<a class="a-btn a-btn__secondary o-footer_top-button"
+   data-gtm_ignore="true" data-js-hook="behavior_return-to-top"
+   href="#">
+    Back to top
+</a>
 `;
 
 /**

--- a/test/unit_tests/js/modules/o-table-row-links-spec.js
+++ b/test/unit_tests/js/modules/o-table-row-links-spec.js
@@ -11,22 +11,22 @@ let nonLinkRowCellDom;
 let locationSpy;
 
 const HTML_SNIPPET = `
-  <table class="o-table__row-links">
-      <tbody>
-          <tr>
-              <th>cell1</th>
-              <th class="nonLinkRowCell">cell2</th>
-              <th>cell3</th>
-              <th>cell4</th>
-          </tr>
-          <tr>
-              <td><a href="https://www.example.com">linkCell5</a></td>
-              <td class="linkRowCell">cell6</td>
-              <td>cell7</td>
-              <td>cell8</td>
-          </tr>
-      </tbody>
-  </table>
+<table class="o-table__row-links">
+    <tbody>
+        <tr>
+            <th>cell1</th>
+            <th class="nonLinkRowCell">cell2</th>
+            <th>cell3</th>
+            <th>cell4</th>
+        </tr>
+        <tr>
+            <td><a href="https://www.example.com">linkCell5</a></td>
+            <td class="linkRowCell">cell6</td>
+            <td>cell7</td>
+            <td>cell8</td>
+        </tr>
+    </tbody>
+</table>
 `;
 
 describe( 'o-table-row-links', () => {

--- a/test/unit_tests/js/modules/transition/AlphaTransition-spec.js
+++ b/test/unit_tests/js/modules/transition/AlphaTransition-spec.js
@@ -1,6 +1,4 @@
-const BASE_JS_PATH = '../../../../../cfgov/unprocessed/js/';
-const AlphaTransition =
-  require( BASE_JS_PATH + 'modules/transition/AlphaTransition' );
+import AlphaTransition from '../../../../../cfgov/unprocessed/js/modules/transition/AlphaTransition';
 
 let transition;
 

--- a/test/unit_tests/js/modules/transition/BaseTransition-spec.js
+++ b/test/unit_tests/js/modules/transition/BaseTransition-spec.js
@@ -1,6 +1,4 @@
-const BASE_JS_PATH = '../../../../../cfgov/unprocessed/js/';
-const BaseTransition =
-  require( BASE_JS_PATH + 'modules/transition/BaseTransition' );
+import BaseTransition from '../../../../../cfgov/unprocessed/js/modules/transition/BaseTransition';
 
 let transition;
 

--- a/test/unit_tests/js/modules/transition/MoveTransition-spec.js
+++ b/test/unit_tests/js/modules/transition/MoveTransition-spec.js
@@ -1,6 +1,4 @@
-const BASE_JS_PATH = '../../../../../cfgov/unprocessed/js/';
-const MoveTransition =
-  require( BASE_JS_PATH + 'modules/transition/MoveTransition' );
+import MoveTransition from '../../../../../cfgov/unprocessed/js/modules/transition/MoveTransition';
 
 let transition;
 

--- a/test/unit_tests/js/modules/util/atomic-helpers-spec.js
+++ b/test/unit_tests/js/modules/util/atomic-helpers-spec.js
@@ -1,8 +1,10 @@
-const BASE_JS_PATH = '../../../../../cfgov/unprocessed/js/';
-const atomicHelpers = require( BASE_JS_PATH + 'modules/util/atomic-helpers' );
-const Footer = require(
-  BASE_JS_PATH + 'organisms/Footer'
-);
+import {
+  checkDom,
+  destroyInitFlag,
+  instantiateAll,
+  setInitFlag
+} from '../../../../../cfgov/unprocessed/js/modules/util/atomic-helpers';
+import Footer from '../../../../../cfgov/unprocessed/js/organisms/Footer';
 
 let containerDom;
 let componentDom;
@@ -27,7 +29,7 @@ describe( 'atomic-helpers', () => {
                      'Check that element is a DOM node with ' +
                      `class ".${ testClass }"`;
       function errFunc() {
-        atomicHelpers.checkDom( null, testClass );
+        checkDom( null, testClass );
       }
       expect( errFunc ).toThrow( Error, errMsg );
     } );
@@ -35,21 +37,21 @@ describe( 'atomic-helpers', () => {
     it( 'should throw an error if element class not found', () => {
       const errMsg = 'mock-class not found on or in passed DOM node.';
       function errFunc() {
-        atomicHelpers.checkDom( componentDom, 'mock-class' );
+        checkDom( componentDom, 'mock-class' );
       }
       expect( errFunc ).toThrow( Error, errMsg );
     } );
 
     it( 'should return the correct HTMLElement when direct element is searched',
       () => {
-        const dom = atomicHelpers.checkDom( componentDom, testClass );
+        const dom = checkDom( componentDom, testClass );
         expect( dom ).toStrictEqual( componentDom );
       }
     );
 
     it( 'should return the correct HTMLElement when parent element is searched',
       () => {
-        const dom = atomicHelpers.checkDom( containerDom, testClass );
+        const dom = checkDom( containerDom, testClass );
         expect( dom ).toStrictEqual( componentDom );
       }
     );
@@ -57,9 +59,7 @@ describe( 'atomic-helpers', () => {
 
   describe( '.instantiateAll()', () => {
     it( 'should return an array of instances', () => {
-      const instArr = atomicHelpers.instantiateAll(
-        `.${ testClass }`, Footer
-      );
+      const instArr = instantiateAll( `.${ testClass }`, Footer );
       expect( instArr ).toBeInstanceOf( Array );
       expect( instArr.length ).toBe( 2 );
     } );
@@ -67,28 +67,28 @@ describe( 'atomic-helpers', () => {
 
   describe( '.setInitFlag()', () => {
     it( 'should return true when init flag is set', () => {
-      expect( atomicHelpers.setInitFlag( componentDom ) ).toBe( true );
+      expect( setInitFlag( componentDom ) ).toBe( true );
     } );
 
     it( 'should return false when init flag is already set', () => {
-      atomicHelpers.setInitFlag( componentDom );
-      expect( atomicHelpers.setInitFlag( componentDom ) ).toBe( false );
+      setInitFlag( componentDom );
+      expect( setInitFlag( componentDom ) ).toBe( false );
     } );
   } );
 
   describe( '.destroyInitFlag()', () => {
 
     beforeEach( () => {
-      atomicHelpers.setInitFlag( componentDom );
+      setInitFlag( componentDom );
     } );
 
     it( 'should return true when init flag is removed', () => {
-      expect( atomicHelpers.destroyInitFlag( componentDom ) ).toBe( true );
+      expect( destroyInitFlag( componentDom ) ).toBe( true );
     } );
 
     it( 'should return false when init flag has already been removed', () => {
-      atomicHelpers.destroyInitFlag( componentDom );
-      expect( atomicHelpers.destroyInitFlag( componentDom ) ).toBe( false );
+      destroyInitFlag( componentDom );
+      expect( destroyInitFlag( componentDom ) ).toBe( false );
     } );
   } );
 } );

--- a/test/unit_tests/js/modules/util/breakpoint-state-spec.js
+++ b/test/unit_tests/js/modules/util/breakpoint-state-spec.js
@@ -1,20 +1,17 @@
-const BASE_JS_PATH = '../../../../../cfgov/unprocessed/js/';
-const breakpointState = require(
-  BASE_JS_PATH + 'modules/util/breakpoint-state'
-);
-const breakpointConfig = require( BASE_JS_PATH + 'config/breakpoints-config' );
+import * as breakpointState from '../../../../../cfgov/unprocessed/js/modules/util/breakpoint-state';
+import breakpointsConfig from '../../../../../cfgov/unprocessed/js/config/breakpoints-config';
 
 let configKeys;
 
 describe( 'breakpoint-state', () => {
   beforeEach( () => {
-    configKeys = Object.keys( breakpointConfig );
+    configKeys = Object.keys( breakpointsConfig );
   } );
 
   describe( '.get()', () => {
     it( 'should return an object with properties from config file', () => {
       const breakpointStatekeys =
-        Object.keys( breakpointConfig ).map( key => {
+        Object.keys( breakpointsConfig ).map( key => {
           key.replace( 'is', '' );
           key.charAt( 0 ).toLowerCase() + key.slice( 1 );
           return key;
@@ -42,11 +39,11 @@ describe( 'breakpoint-state', () => {
       let breakpointStateKey;
 
       // eslint-disable-next-line guard-for-in
-      for ( const rangeKey in breakpointConfig ) {
-        width = breakpointConfig[rangeKey].max ||
-                breakpointConfig[rangeKey].min;
+      for ( const rangeKey in breakpointsConfig ) {
+        width = breakpointsConfig[rangeKey].max ||
+                breakpointsConfig[rangeKey].min;
         breakpointStateKey =
-        'is' + rangeKey.charAt( 0 ).toUpperCase() + rangeKey.slice( 1 );
+          'is' + rangeKey.charAt( 0 ).toUpperCase() + rangeKey.slice( 1 );
 
         expect( breakpointState.get( width )[breakpointStateKey] ).toBe( true );
       }

--- a/test/unit_tests/js/modules/util/dom-manipulators-spec.js
+++ b/test/unit_tests/js/modules/util/dom-manipulators-spec.js
@@ -1,7 +1,4 @@
-const BASE_JS_PATH = '../../../../../cfgov/unprocessed/js/';
-const domManipulators = require(
-  BASE_JS_PATH + 'modules/util/dom-manipulators'
-);
+import * as domManipulators from '../../../../../cfgov/unprocessed/js/modules/util/dom-manipulators';
 
 describe( 'Dom Manipulators create', () => {
   beforeAll( () => {
@@ -38,7 +35,7 @@ describe( 'Dom Manipulators create', () => {
     expect( query.getAttribute( 'data-name' ) ).toBe( 'create-heading-data' );
   } );
 
-  it( 'should create an elem inside another', () => {
+  xit( 'should create an elem inside another', () => {
     const query = document.querySelector( 'span' );
 
     expect( query.textContent ).toBe( 'Heading Span' );
@@ -47,7 +44,7 @@ describe( 'Dom Manipulators create', () => {
     expect( query.getAttribute( 'data-name' ) ).toBe( 'create-span-data' );
   } );
 
-  it( 'should create an elem around another', () => {
+  xit( 'should create an elem around another', () => {
     const query = document.querySelector( 'div' );
 
     expect( query.id ).toBe( 'create-div-id' );

--- a/test/unit_tests/js/modules/util/dom-manipulators-spec.js
+++ b/test/unit_tests/js/modules/util/dom-manipulators-spec.js
@@ -35,7 +35,7 @@ describe( 'Dom Manipulators create', () => {
     expect( query.getAttribute( 'data-name' ) ).toBe( 'create-heading-data' );
   } );
 
-  xit( 'should create an elem inside another', () => {
+  it( 'should create an elem inside another', () => {
     const query = document.querySelector( 'span' );
 
     expect( query.textContent ).toBe( 'Heading Span' );
@@ -44,7 +44,7 @@ describe( 'Dom Manipulators create', () => {
     expect( query.getAttribute( 'data-name' ) ).toBe( 'create-span-data' );
   } );
 
-  xit( 'should create an elem around another', () => {
+  it( 'should create an elem around another', () => {
     const query = document.querySelector( 'div' );
 
     expect( query.id ).toBe( 'create-div-id' );

--- a/test/unit_tests/js/modules/util/js-loader-spec.js
+++ b/test/unit_tests/js/modules/util/js-loader-spec.js
@@ -1,5 +1,4 @@
-const BASE_JS_PATH = '../../../../../cfgov/unprocessed/js/';
-const jsLoader = require( BASE_JS_PATH + 'modules/util/js-loader' );
+import { loadScript } from '../../../../../cfgov/unprocessed/js/modules/util/js-loader';
 
 describe( 'loadScript method', () => {
 
@@ -11,7 +10,7 @@ describe( 'loadScript method', () => {
     // eslint-disable-next-line no-unused-vars
     const loaderPromise = new Promise( ( resolve, reject ) => {
       const scriptLocation = 'https://code.jquery.com/jquery-1.5.min.js';
-      jsLoader.loadScript( scriptLocation, () => {
+      loadScript( scriptLocation, () => {
         resolve( 'Callback called' );
       } );
     } );

--- a/test/unit_tests/js/modules/util/standard-type-spec.js
+++ b/test/unit_tests/js/modules/util/standard-type-spec.js
@@ -1,16 +1,19 @@
-const BASE_JS_PATH = '../../../../../cfgov/unprocessed/js/';
-const standardType = require( BASE_JS_PATH + 'modules/util/standard-type' );
+import {
+  JS_HOOK,
+  noopFunct,
+  UNDEFINED
+} from '../../../../../cfgov/unprocessed/js/modules/util/standard-type';
 
 describe( 'standard-type', () => {
   it( 'should include a standard JS data hook', () => {
-    expect( standardType.JS_HOOK ).toBe( 'data-js-hook' );
+    expect( JS_HOOK ).toBe( 'data-js-hook' );
   } );
 
   it( 'should include a non operational function', () => {
-    expect( standardType.noopFunct() ).toBeUndefined();
+    expect( noopFunct() ).toBeUndefined();
   } );
 
   it( 'should include a standard undefined reference', () => {
-    expect( standardType.UNDEFINED ).toBeUndefined();
+    expect( UNDEFINED ).toBeUndefined();
   } );
 } );

--- a/test/unit_tests/js/modules/util/standard-type-spec.js
+++ b/test/unit_tests/js/modules/util/standard-type-spec.js
@@ -1,7 +1,7 @@
 import {
   JS_HOOK,
-  noopFunct,
-  UNDEFINED
+  UNDEFINED,
+  noopFunct
 } from '../../../../../cfgov/unprocessed/js/modules/util/standard-type';
 
 describe( 'standard-type', () => {

--- a/test/unit_tests/js/modules/util/strings-spec.js
+++ b/test/unit_tests/js/modules/util/strings-spec.js
@@ -1,5 +1,4 @@
-const BASE_JS_PATH = '../../../../../cfgov/unprocessed/js/';
-const strings = require( BASE_JS_PATH + 'modules/util/strings' );
+import * as strings from '../../../../../cfgov/unprocessed/js/modules/util/strings';
 let string;
 let control;
 

--- a/test/unit_tests/js/modules/util/tree-traversal-spec.js
+++ b/test/unit_tests/js/modules/util/tree-traversal-spec.js
@@ -1,6 +1,5 @@
-const BASE_JS_PATH = '../../../../../cfgov/unprocessed/js/';
-const Tree = require( BASE_JS_PATH + 'modules/Tree' );
-const treeTraversal = require( BASE_JS_PATH + 'modules/util/tree-traversal' );
+import Tree from '../../../../../cfgov/unprocessed/js/modules/Tree';
+import * as treeTraversal from '../../../../../cfgov/unprocessed/js/modules/util/tree-traversal';
 
 describe( 'Tree traversal', () => {
 

--- a/test/unit_tests/js/modules/util/type-checkers-spec.js
+++ b/test/unit_tests/js/modules/util/type-checkers-spec.js
@@ -1,5 +1,4 @@
-const BASE_JS_PATH = '../../../../../cfgov/unprocessed/js/';
-const typeCheckers = require( BASE_JS_PATH + 'modules/util/type-checkers.js' );
+import * as typeCheckers from '../../../../../cfgov/unprocessed/js/modules/util/type-checkers.js';
 
 let undefinedVar;
 const blankVar = '';

--- a/test/unit_tests/js/modules/util/validators-spec.js
+++ b/test/unit_tests/js/modules/util/validators-spec.js
@@ -1,6 +1,5 @@
-const BASE_JS_PATH = '../../../../../cfgov/unprocessed/js/';
-const ERROR_MESSAGES = require( BASE_JS_PATH + 'config/error-messages-config' );
-const validators = require( BASE_JS_PATH + 'modules/util/validators.js' );
+import ERROR_MESSAGES from '../../../../../cfgov/unprocessed/js/config/error-messages-config';
+import * as validators from '../../../../../cfgov/unprocessed/js/modules/util/validators.js';
 let testField;
 let returnedObject;
 

--- a/test/unit_tests/js/molecules/Multiselect-spec.js
+++ b/test/unit_tests/js/molecules/Multiselect-spec.js
@@ -1,5 +1,4 @@
-const BASE_JS_PATH = '../../../../cfgov/unprocessed/js/';
-const Multiselect = require( BASE_JS_PATH + 'molecules/Multiselect' );
+import Multiselect from '../../../../cfgov/unprocessed/js/molecules/Multiselect';
 
 import { simulateEvent } from '../../../util/simulate-event';
 

--- a/test/unit_tests/js/molecules/Notification-spec.js
+++ b/test/unit_tests/js/molecules/Notification-spec.js
@@ -1,5 +1,4 @@
-const BASE_JS_PATH = '../../../../cfgov/unprocessed/js/';
-const Notification = require( BASE_JS_PATH + 'molecules/Notification' );
+import Notification from '../../../../cfgov/unprocessed/js/molecules/Notification';
 const BASE_CLASS = 'm-notification';
 const HTML_SNIPPET = `
   <div class="m-notification

--- a/test/unit_tests/js/organisms/EmailPopup-spec.js
+++ b/test/unit_tests/js/organisms/EmailPopup-spec.js
@@ -1,5 +1,4 @@
-const BASE_JS_PATH = '../../../../cfgov/unprocessed/js/';
-const EmailPopup = require( BASE_JS_PATH + 'organisms/EmailPopup' );
+import EmailPopup from '../../../../cfgov/unprocessed/js/organisms/EmailPopup';
 
 let emailPopup;
 

--- a/test/unit_tests/js/organisms/Footer-spec.js
+++ b/test/unit_tests/js/organisms/Footer-spec.js
@@ -1,5 +1,4 @@
-const BASE_JS_PATH = '../../../../cfgov/unprocessed/js/';
-const Footer = require( BASE_JS_PATH + 'organisms/Footer' );
+import Footer from '../../../../cfgov/unprocessed/js/organisms/Footer';
 
 let footer;
 

--- a/test/unit_tests/js/organisms/FormSubmit-spec.js
+++ b/test/unit_tests/js/organisms/FormSubmit-spec.js
@@ -1,56 +1,56 @@
-const BASE_JS_PATH = '../../../../cfgov/unprocessed/js/';
-const FormSubmit = require( BASE_JS_PATH + 'organisms/FormSubmit' );
+import FormSubmit from '../../../../cfgov/unprocessed/js/organisms/FormSubmit';
+
 const BASE_CLASS = 'o-email-signup';
 const HTML_SNIPPET = `
-  <div class="o-email-signup">
-    <header class="m-slug-header">
-      <h2 class="a-heading">
-        Stay informed
-      </h2>
-    </header>
+<div class="o-email-signup">
+  <header class="m-slug-header">
+    <h2 class="a-heading">
+      Stay informed
+    </h2>
+  </header>
 
-    <form id="o-email-signup_54"
-          class="o-form o-form__email-signup"
-          action="/subscriptions/new/"
-          method="POST"
-          enctype="application/x-www-form-urlencoded">
+  <form id="o-email-signup_54"
+        class="o-form o-form__email-signup"
+        action="/subscriptions/new/"
+        method="POST"
+        enctype="application/x-www-form-urlencoded">
 
-      <div class="u-mb15">
-        <div class="m-notification
-                    m-notification__success">
-          <div class="m-notification_content">
-            <div class="h4 m-notification_message"></div>
-          </div>
+    <div class="u-mb15">
+      <div class="m-notification
+                  m-notification__success">
+        <div class="m-notification_content">
+          <div class="h4 m-notification_message"></div>
         </div>
       </div>
+    </div>
 
-      <p>Subscribe to our email newsletter. We will update you on new blogs.</p>
+    <p>Subscribe to our email newsletter. We will update you on new blogs.</p>
 
-      <div class="m-form-field-with-button" data-qa-hook="formfield-with-button">
-        <div class="m-form-field">
-          <label class="a-label a-label__heading" for="form_3">
-            Email address
-          </label>
-          <input id="form_3"
-                 type="email"
-                 placeholder="example@mail.com"
-                 name="email"
-                 class="a-text-input a-text-input__full">
-        </div>
-        <p>
-          The information you provide will permit the Consumer Financial
-          Protection Bureau to process your request or
-          inquiry.&nbsp;<a class="" href="/privacy/privacy-policy/">See more</a>.
-        </p>
-        <input class="a-btn a-btn__full-on-xs" type="submit" value="Sign up">
+    <div class="m-form-field-with-button" data-qa-hook="formfield-with-button">
+      <div class="m-form-field">
+        <label class="a-label a-label__heading" for="form_3">
+          Email address
+        </label>
+        <input id="form_3"
+               type="email"
+               placeholder="example@mail.com"
+               name="email"
+               class="a-text-input a-text-input__full">
       </div>
+      <p>
+        The information you provide will permit the Consumer Financial
+        Protection Bureau to process your request or
+        inquiry.&nbsp;<a class="" href="/privacy/privacy-policy/">See more</a>.
+      </p>
+      <input class="a-btn a-btn__full-on-xs" type="submit" value="Sign up">
+    </div>
 
-      <div class="form-group">
-        <input type="hidden" name="code">
-      </div>
+    <div class="form-group">
+      <input type="hidden" name="code">
+    </div>
 
-    </form>
-  </div>
+  </form>
+</div>
 `;
 
 describe( 'FormSubmit', () => {

--- a/test/unit_tests/js/organisms/MegaMenu-spec.js
+++ b/test/unit_tests/js/organisms/MegaMenu-spec.js
@@ -1,7 +1,7 @@
 import { simulateEvent } from '../../../util/simulate-event';
 
-const BASE_JS_PATH = '../../../../cfgov/unprocessed/js/';
-const MegaMenu = require( BASE_JS_PATH + 'organisms/MegaMenu' );
+import MegaMenu from '../../../../cfgov/unprocessed/js/organisms/MegaMenu';
+
 const BASE_CLASS = 'o-mega-menu';
 const HTML_SNIPPET = `
 <nav class="o-mega-menu" data-js-hook="behavior_flyout-menu" aria-label="main menu">

--- a/test/unit_tests/js/organisms/MegaMenuMobile-spec.js
+++ b/test/unit_tests/js/organisms/MegaMenuMobile-spec.js
@@ -1,7 +1,7 @@
 import { simulateEvent } from '../../../util/simulate-event';
 
-const BASE_JS_PATH = '../../../../cfgov/unprocessed/js/';
-const MegaMenu = require( BASE_JS_PATH + 'organisms/MegaMenu' );
+import MegaMenu from '../../../../cfgov/unprocessed/js/organisms/MegaMenu';
+
 const BASE_CLASS = 'o-mega-menu';
 const HTML_SNIPPET = `
 <nav class="o-mega-menu" data-js-hook="behavior_flyout-menu" aria-label="main menu">

--- a/test/unit_tests/js/organisms/MortgagePerformanceTrends/actions/chart-spec.js
+++ b/test/unit_tests/js/organisms/MortgagePerformanceTrends/actions/chart-spec.js
@@ -1,6 +1,6 @@
 /* Disable the AJAX library used by the action creator
    Unfortunately, we can't place path variables into import statements. */
-import * as actions from '../../../../../../cfgov/unprocessed/js/organisms/MortgagePerformanceTrends/actions/chart.js';
+import actions from '../../../../../../cfgov/unprocessed/js/organisms/MortgagePerformanceTrends/actions/chart.js';
 
 jest.mock( 'xdr', () => jest.fn( () => ( { mock: 'data' } ) ) );
 jest.mock( '../../../../../../cfgov/unprocessed/js/organisms/MortgagePerformanceTrends/utils', () => ( {

--- a/test/unit_tests/js/organisms/MortgagePerformanceTrends/actions/map-spec.js
+++ b/test/unit_tests/js/organisms/MortgagePerformanceTrends/actions/map-spec.js
@@ -1,6 +1,6 @@
 /* Disable the AJAX library used by the action creator
    Unfortunately, we can't place path variables into import statements. */
-import * as actions from '../../../../../../cfgov/unprocessed/js/organisms/MortgagePerformanceTrends/actions/map.js';
+import actions from '../../../../../../cfgov/unprocessed/js/organisms/MortgagePerformanceTrends/actions/map.js';
 
 jest.mock( 'xdr', () => jest.fn( () => ( { mock: 'data' } ) ) );
 jest.mock( '../../../../../../cfgov/unprocessed/js/organisms/MortgagePerformanceTrends/utils', () => ( {

--- a/test/unit_tests/js/organisms/MortgagePerformanceTrends/stores/chart-spec.js
+++ b/test/unit_tests/js/organisms/MortgagePerformanceTrends/stores/chart-spec.js
@@ -1,7 +1,4 @@
-const BASE_JS_PATH = '../../../../../../cfgov/unprocessed/js/';
-const Store = require(
-  BASE_JS_PATH + 'organisms/MortgagePerformanceTrends/stores/chart.js'
-);
+import Store from '../../../../../../cfgov/unprocessed/js/organisms/MortgagePerformanceTrends/stores/chart.js';
 let store;
 
 describe( 'Mortgage Performance line chart store', () => {

--- a/test/unit_tests/js/organisms/MortgagePerformanceTrends/stores/map-spec.js
+++ b/test/unit_tests/js/organisms/MortgagePerformanceTrends/stores/map-spec.js
@@ -1,7 +1,4 @@
-const BASE_JS_PATH = '../../../../../../cfgov/unprocessed/js/';
-const Store = require(
-  BASE_JS_PATH + 'organisms/MortgagePerformanceTrends/stores/map.js'
-);
+import Store from '../../../../../../cfgov/unprocessed/js/organisms/MortgagePerformanceTrends/stores/map.js';
 let store;
 
 describe( 'Mortgage Performance map store', () => {

--- a/test/unit_tests/js/organisms/MortgagePerformanceTrends/utils-spec.js
+++ b/test/unit_tests/js/organisms/MortgagePerformanceTrends/utils-spec.js
@@ -1,11 +1,7 @@
-const BASE_JS_PATH = '../../../../../cfgov/unprocessed/js/';
-
 // Disable the AJAX library used by the action creator.
 jest.mock( 'xdr', () => jest.fn( () => ( { mock: 'data' } ) ) );
 
-const utils = require(
-  BASE_JS_PATH + 'organisms/MortgagePerformanceTrends/utils.js'
-);
+import utils from '../../../../../cfgov/unprocessed/js/organisms/MortgagePerformanceTrends/utils.js';
 
 let el;
 


### PR DESCRIPTION
## Changes

- Converts requires to ES6 import/exports (except in assets for some individual apps).
- Updates to cfpb-chart-builder 5.0.0, which upgrades highcharts dependency to 6.x.
- Updates babel to latest (including making babel-config not invisible).

## Testing

1. `./frontend.sh`
2. `gulp test` should pass.
3. Check pages and look for any `exports` error in dev console.
4. Pay particular attention to [Mortgage Performance Trends](https://www.consumerfinance.gov/data-research/mortgage-performance-trends/) and [CCT](https://www.consumerfinance.gov/data-research/consumer-credit-trends/), as this is a major update for those.

Should be checked in supported browsers.

## Note

- Charts likely won't render in IE in VirtualBox because of cross domain errors loading the data. Sauce labs connect should be used instead.