### PR TITLE
Find a Housing Counselor Improvements: Add iteration of results

### DIFF
--- a/cfgov/housing_counselor/jinja2/housing_counselor/improved_index.html
+++ b/cfgov/housing_counselor/jinja2/housing_counselor/improved_index.html
@@ -14,10 +14,6 @@
 {% endblock %}
 
 {% block hero %}
-<script type="text/javascript">
-    var string = "{{ api_json}}";
-    console.log( string );
-</script>
 
 <section class="m-hero">
     <div class="m-hero_wrapper wrapper">

--- a/cfgov/housing_counselor/jinja2/housing_counselor/improved_index.html
+++ b/cfgov/housing_counselor/jinja2/housing_counselor/improved_index.html
@@ -49,8 +49,7 @@
                     <div class="block block__flush-top block__flush-top">
                         <h1>Find a housing counselor</h1>
                         <div class="rich-text">
-                            <p>Housing counselors throughout the country can provide advice on buying a home, renting, defaults, foreclosures, and credit issues. Using the search box below, you can find one near you. The counseling agencies on this list are approved by the U.S. Department of Housing and Urban Development (HUD) and they can offer independent advice about whether a particular set of mortgage loan terms is a good fit based on your objectives and circumstances, often at little or no cost to you. This list will show you several approved agencies in your area. There is also a <a class="a-link a-link__icon" href="https://apps.hud.gov/offices/hsg/sfh/hcc/hcs.cfm"><span class="a-link_text">list of nationwide HUD-approved counseling agencies</span> <svg class="cf-icon-svg" viewbox="0 0 790.1 1200" xmlns="http://www.w3.org/2000/svg">
-                            <path d="M740.1 178.8H449.5c-27.6 0-50 22.4-50 50s22.4 50 50 50h169.9L518.2 379.9c-14.7-6.2-30.5-9.4-46.4-9.4H120c-66.2.1-119.9 53.8-120 120v351.8c.1 66.2 53.8 119.9 120 120h351.8c66.2-.1 119.9-53.8 120-120V490.6c0-12.6-2-25-5.8-37l104.1-104.1v169.9c0 27.6 22.4 50 50 50s50-22.4 50-50V228.8c0-27.7-22.4-50-50-50zM491.8 842.3c-.1 11-9 19.9-20 20H120c-11-.1-19.9-9-20-20V490.6c.1-11 9-19.9 20-20h307.5L267 631.1c-19.4 19.6-19.3 51.3.3 70.7 19.5 19.3 50.9 19.3 70.4 0l154-154 .1 294.5z"></path></svg></a>.</p>
+                            <p>Housing counselors throughout the country can provide advice on buying a home, renting, defaults, foreclosures, and credit issues. Using the search box below, you can find one near you. The counseling agencies on this list are approved by the U.S. Department of Housing and Urban Development (HUD) and they can offer independent advice about whether a particular set of mortgage loan terms is a good fit based on your objectives and circumstances, often at little or no cost to you. This list will show you several approved agencies in your area. There is also a <a class="a-link a-link__icon" href="https://apps.hud.gov/offices/hsg/sfh/hcc/hcs.cfm"><span class="a-link_text">list of nationwide HUD-approved counseling agencies</span> {{ svg_icon('external-link') }}</a>.</p>
                         </div>
                     </div>
                     <div class="block">
@@ -69,7 +68,7 @@
                                                 <input class="a-btn a-btn__full-on-xs" type="submit" value="Find a counselor">
                                                 <div class="m-form-field-with-button_info">
                                                     <p>
-                                                        This tool is powered by <a class="a-link a-link__icon" href="https://data.hud.gov/housing_counseling.html"><span class="a-link_text">HUD's</span> <svg class="cf-icon-svg" viewBox="0 0 790.1 1200" xmlns="http://www.w3.org/2000/svg"> <path d="M740.1 178.8H449.5c-27.6 0-50 22.4-50 50s22.4 50 50 50h169.9L518.2 379.9c-14.7-6.2-30.5-9.4-46.4-9.4H120c-66.2.1-119.9 53.8-120 120v351.8c.1 66.2 53.8 119.9 120 120h351.8c66.2-.1 119.9-53.8 120-120V490.6c0-12.6-2-25-5.8-37l104.1-104.1v169.9c0 27.6 22.4 50 50 50s50-22.4 50-50V228.8c0-27.7-22.4-50-50-50zM491.8 842.3c-.1 11-9 19.9-20 20H120c-11-.1-19.9-9-20-20V490.6c.1-11 9-19.9 20-20h307.5L267 631.1c-19.4 19.6-19.3 51.3.3 70.7 19.5 19.3 50.9 19.3 70.4 0l154-154 .1 294.5z"></path></svg></a> official list of housing counselors.
+                                                        This tool is powered by <a class="a-link a-link__icon" href="https://data.hud.gov/housing_counseling.html"><span class="a-link_text">HUD's</span> {{ svg_icon('external-link') }}</a> official list of housing counselors.
                                                     </p>
                                                     <p>
                                                         If you notice errors in the housing counselor data, contact <a href="mailto:housing.counseling@hud.gov">housing.counseling@hud.gov</a>.
@@ -132,18 +131,20 @@
                                             <p>
                                                 <span class="result-number">{{ loop.index }}.</span>
                                                 <a class="a-link a-link__icon" href="{{ counselor.weburl }}"><span class="a-link_text">{{ counselor.nme }}</span>
-                                                  <svg class="cf-icon-svg" viewbox="0 0 790.1 1200" xmlns="http://www.w3.org/2000/svg">
-                                            <path d="M740.1 178.8H449.5c-27.6 0-50 22.4-50 50s22.4 50 50 50h169.9L518.2 379.9c-14.7-6.2-30.5-9.4-46.4-9.4H120c-66.2.1-119.9 53.8-120 120v351.8c.1 66.2 53.8 119.9 120 120h351.8c66.2-.1 119.9-53.8 120-120V490.6c0-12.6-2-25-5.8-37l104.1-104.1v169.9c0 27.6 22.4 50 50 50s50-22.4 50-50V228.8c0-27.7-22.4-50-50-50zM491.8 842.3c-.1 11-9 19.9-20 20H120c-11-.1-19.9-9-20-20V490.6c.1-11 9-19.9 20-20h307.5L267 631.1c-19.4 19.6-19.3 51.3.3 70.7 19.5 19.3 50.9 19.3 70.4 0l154-154 .1 294.5z"></path></svg></a><b><br></b>{{ counselor.adr1 }}
+                                                  {{ svg_icon('external-link') }}</a><b><br></b>{{ counselor.adr1 }}
                                             {% if counselor.adr2 and counselor.adr2 != ' '  %}
                                                 <br>{{ counselor.adr2 }}
                                             {% endif %}<br>
                                             {{ counselor.city }}, {{ counselor.statecd }} {{ counselor.zipcd }}
                                             </p>
-                                            <p><b>Website:</b> <a class="a-link a-link__icon" href="{{ counselor.weburl }}"><span class="a-link_text">{{ counselor.weburl }}</span> <svg class="cf-icon-svg" viewbox="0 0 790.1 1200" xmlns="http://www.w3.org/2000/svg">
-                                            <path d="M740.1 178.8H449.5c-27.6 0-50 22.4-50 50s22.4 50 50 50h169.9L518.2 379.9c-14.7-6.2-30.5-9.4-46.4-9.4H120c-66.2.1-119.9 53.8-120 120v351.8c.1 66.2 53.8 119.9 120 120h351.8c66.2-.1 119.9-53.8 120-120V490.6c0-12.6-2-25-5.8-37l104.1-104.1v169.9c0 27.6 22.4 50 50 50s50-22.4 50-50V228.8c0-27.7-22.4-50-50-50zM491.8 842.3c-.1 11-9 19.9-20 20H120c-11-.1-19.9-9-20-20V490.6c.1-11 9-19.9 20-20h307.5L267 631.1c-19.4 19.6-19.3 51.3.3 70.7 19.5 19.3 50.9 19.3 70.4 0l154-154 .1 294.5z"></path></svg></a><br>
-                                            <b>Phone:</b> {{ counselor.phone1 }}<br>
-                                            <b>Email Address:</b> {{ counselor.email }}<br>
-                                            <b>Languages:</b> {{ counselor.languages|join(', ') }}</p>
+                                            <p><b>Website:</b>
+                                                <a class="a-link a-link__icon" href="{{ counselor.weburl }}">
+                                                    <span class="a-link_text">{{ counselor.weburl }}</span> {{ svg_icon('external-link') }}
+                                                </a><br>
+                                                <b>Phone:</b> {{ counselor.phone1 }}<br>
+                                                <b>Email Address:</b> {{ counselor.email }}<br>
+                                                <b>Languages:</b> {{ counselor.languages|join(', ') }}
+                                            </p>
                                         </div>
                                     </td>
                                     <td data-label="Services">
@@ -172,8 +173,7 @@
                         <div class="o-full-width-text-group">
                             <div class="m-full-width-text">
                                 <h3>Paperwork Reduction Act statement</h3>
-                                <p class="u-mb0">According to the Paperwork Reduction Act of 1995, an agency may not conduct or sponsor, and a person is not required to respond to a collection of information unless it displays a valid OMB control number. The OMB control number for this collection is <a class="a-link a-link__icon" href="https://www.reginfo.gov/public/do/PRAOMBHistory?ombControlNumber=3170-0025"><span class="a-link_text">3170-0025</span> <svg class="cf-icon-svg" viewbox="0 0 790.1 1200" xmlns="http://www.w3.org/2000/svg">
-                                <path d="M740.1 178.8H449.5c-27.6 0-50 22.4-50 50s22.4 50 50 50h169.9L518.2 379.9c-14.7-6.2-30.5-9.4-46.4-9.4H120c-66.2.1-119.9 53.8-120 120v351.8c.1 66.2 53.8 119.9 120 120h351.8c66.2-.1 119.9-53.8 120-120V490.6c0-12.6-2-25-5.8-37l104.1-104.1v169.9c0 27.6 22.4 50 50 50s50-22.4 50-50V228.8c0-27.7-22.4-50-50-50zM491.8 842.3c-.1 11-9 19.9-20 20H120c-11-.1-19.9-9-20-20V490.6c.1-11 9-19.9 20-20h307.5L267 631.1c-19.4 19.6-19.3 51.3.3 70.7 19.5 19.3 50.9 19.3 70.4 0l154-154 .1 294.5z"></path></svg></a>. It expires on 04/30/2016. Using this tool to generate a list of HUD-Approved Housing Counseling Agencies is voluntary however, if you are an entity subject to 12 CFR § 1024 (78 FR 6856 (Jan. 31, 2013)), you are required to provide this list as specified in the regulation. Comments regarding this collection of information, including suggestions for improving the usefulness of the information, or suggestions for reducing the burden to respond to this collection should be submitted to the Bureau of Consumer Financial Protection (Attention: PRA Office), 1700 G Street NW, Washington, DC 20552, or by email to <a href="mailto:PRA@cfpb.gov">PRA@cfpb.gov</a>.<br></p>
+                                <p class="u-mb0">According to the Paperwork Reduction Act of 1995, an agency may not conduct or sponsor, and a person is not required to respond to a collection of information unless it displays a valid OMB control number. The OMB control number for this collection is <a class="a-link a-link__icon" href="https://www.reginfo.gov/public/do/PRAOMBHistory?ombControlNumber=3170-0025"><span class="a-link_text">3170-0025</span> {{ svg_icon('external-link') }}</a>. It expires on 04/30/2016. Using this tool to generate a list of HUD-Approved Housing Counseling Agencies is voluntary however, if you are an entity subject to 12 CFR § 1024 (78 FR 6856 (Jan. 31, 2013)), you are required to provide this list as specified in the regulation. Comments regarding this collection of information, including suggestions for improving the usefulness of the information, or suggestions for reducing the burden to respond to this collection should be submitted to the Bureau of Consumer Financial Protection (Attention: PRA Office), 1700 G Street NW, Washington, DC 20552, or by email to <a href="mailto:PRA@cfpb.gov">PRA@cfpb.gov</a>.<br></p>
 
                                 <div class="block
                                             block__flush-bottom

--- a/cfgov/housing_counselor/jinja2/housing_counselor/improved_index.html
+++ b/cfgov/housing_counselor/jinja2/housing_counselor/improved_index.html
@@ -143,7 +143,7 @@
                                                 </a><br>
                                                 <b>Phone:</b> {{ counselor.phone1 }}<br>
                                                 <b>Email Address:</b> {{ counselor.email }}<br>
-                                                <b>Languages:</b> {{ counselor.languages|join(', ') }}
+                                                <b>Languages:</b> {{ counselor.languages | join( ', ' ) }}
                                             </p>
                                         </div>
                                     </td>
@@ -159,7 +159,7 @@
                                     </td>
                                     <td data-label="Distance">
                                         <div class="rich-text">
-                                            <p>{{ counselor.distance|round( 1 ) }} miles</p>
+                                            <p>{{ counselor.distance | round( 1 ) }} miles</p>
                                         </div>
                                     </td>
                                 </tr>

--- a/cfgov/housing_counselor/jinja2/housing_counselor/improved_index.html
+++ b/cfgov/housing_counselor/jinja2/housing_counselor/improved_index.html
@@ -14,6 +14,11 @@
 {% endblock %}
 
 {% block hero %}
+<script type="text/javascript">
+    var string = "{{ api_json}}";
+    console.log( string );
+</script>
+
 <section class="m-hero">
     <div class="m-hero_wrapper wrapper">
         <div class="m-hero_text">
@@ -59,7 +64,7 @@
                                     <form class="o-form" action="#">
                                         <div class="m-form-field-with-button">
                                             <div class="m-form-field">
-                                                <label class="a-label a-label__heading" for="zip">
+                                                <label class="a-label a-label__heading" for="zipcode">
                                                     Search by ZIP code:
                                                 </label>
                                                 <input id="zip" type="text" name="zipcode" class="a-text-input a-text-input__full" value="52246">
@@ -90,6 +95,7 @@
                             </div>
                         </div>
                     </div>
+                    {% if zipcode %}
                     <div class="block">
                         <div class="results-header">
                             <h2 class="h4">Displaying the 10 locations closest to ZIP code 52246</h2>
@@ -123,41 +129,46 @@
                                 </tr>
                             </thead>
                             <tbody>
+                                {% for counselor in api_json.counseling_agencies %}
                                 <tr>
                                     <td data-label="Agency">
                                         <div class="rich-text">
                                             <p>
-                                                <span class="result-number">1.</span>
-                                                <a class="a-link a-link__icon" href=""><span class="a-link_text">Name</span>
+                                                <span class="result-number">{{ loop.index }}.</span>
+                                                <a class="a-link a-link__icon" href="{{ counselor.weburl }}"><span class="a-link_text">{{ counselor.nme }}</span>
                                                   <svg class="cf-icon-svg" viewbox="0 0 790.1 1200" xmlns="http://www.w3.org/2000/svg">
-                                            <path d="M740.1 178.8H449.5c-27.6 0-50 22.4-50 50s22.4 50 50 50h169.9L518.2 379.9c-14.7-6.2-30.5-9.4-46.4-9.4H120c-66.2.1-119.9 53.8-120 120v351.8c.1 66.2 53.8 119.9 120 120h351.8c66.2-.1 119.9-53.8 120-120V490.6c0-12.6-2-25-5.8-37l104.1-104.1v169.9c0 27.6 22.4 50 50 50s50-22.4 50-50V228.8c0-27.7-22.4-50-50-50zM491.8 842.3c-.1 11-9 19.9-20 20H120c-11-.1-19.9-9-20-20V490.6c.1-11 9-19.9 20-20h307.5L267 631.1c-19.4 19.6-19.3 51.3.3 70.7 19.5 19.3 50.9 19.3 70.4 0l154-154 .1 294.5z"></path></svg></a><b><br></b>Address<br>
-                                            Iowa City, IA 52240-8132</p>
-                                            <p><b>Website:</b> <a class="a-link a-link__icon" href=""><span class="a-link_text">http://www.example.com</span> <svg class="cf-icon-svg" viewbox="0 0 790.1 1200" xmlns="http://www.w3.org/2000/svg">
+                                            <path d="M740.1 178.8H449.5c-27.6 0-50 22.4-50 50s22.4 50 50 50h169.9L518.2 379.9c-14.7-6.2-30.5-9.4-46.4-9.4H120c-66.2.1-119.9 53.8-120 120v351.8c.1 66.2 53.8 119.9 120 120h351.8c66.2-.1 119.9-53.8 120-120V490.6c0-12.6-2-25-5.8-37l104.1-104.1v169.9c0 27.6 22.4 50 50 50s50-22.4 50-50V228.8c0-27.7-22.4-50-50-50zM491.8 842.3c-.1 11-9 19.9-20 20H120c-11-.1-19.9-9-20-20V490.6c.1-11 9-19.9 20-20h307.5L267 631.1c-19.4 19.6-19.3 51.3.3 70.7 19.5 19.3 50.9 19.3 70.4 0l154-154 .1 294.5z"></path></svg></a><b><br></b>{{ counselor.adr1 }}
+                                            {% if counselor.adr2 and counselor.adr2 != ' '  %}
+                                                <br>{{ counselor.adr2 }}
+                                            {% endif %}<br>
+                                            {{ counselor.city }}, {{ counselor.statecd }} {{ counselor.zipcd }}
+                                            </p>
+                                            <p><b>Website:</b> <a class="a-link a-link__icon" href="{{ counselor.weburl }}"><span class="a-link_text">{{ counselor.weburl }}</span> <svg class="cf-icon-svg" viewbox="0 0 790.1 1200" xmlns="http://www.w3.org/2000/svg">
                                             <path d="M740.1 178.8H449.5c-27.6 0-50 22.4-50 50s22.4 50 50 50h169.9L518.2 379.9c-14.7-6.2-30.5-9.4-46.4-9.4H120c-66.2.1-119.9 53.8-120 120v351.8c.1 66.2 53.8 119.9 120 120h351.8c66.2-.1 119.9-53.8 120-120V490.6c0-12.6-2-25-5.8-37l104.1-104.1v169.9c0 27.6 22.4 50 50 50s50-22.4 50-50V228.8c0-27.7-22.4-50-50-50zM491.8 842.3c-.1 11-9 19.9-20 20H120c-11-.1-19.9-9-20-20V490.6c.1-11 9-19.9 20-20h307.5L267 631.1c-19.4 19.6-19.3 51.3.3 70.7 19.5 19.3 50.9 19.3 70.4 0l154-154 .1 294.5z"></path></svg></a><br>
-                                            <b>Phone:</b> 000-000-0000<br>
-                                            <b>Email Address:</b> example@example.com<br>
-                                            <b>Languages:</b> English</p>
+                                            <b>Phone:</b> {{ counselor.phone1 }}<br>
+                                            <b>Email Address:</b> {{ counselor.email }}<br>
+                                            <b>Languages:</b> {{ counselor.languages|join(', ') }}</p>
                                         </div>
                                     </td>
                                     <td data-label="Services">
                                         <div class="rich-text">
                                             <ul>
-                                                <li>Mortgage Delinquency and Default Resolution Counse<br></li>
-                                                <li>Financial Management/Budget Counseling<br></li>
-                                                <li>Services for Homeless Counseling<br></li>
-                                                <li>Pre-purchase Counseling<br></li>
-                                                <li>Pre-purchase Homebuyer Education Workshops<br></li>
-                                                <li>Rental Housing Counseling<br></li>
+                                                {% for service in counselor.services %}
+                                                <li>{{ service }}</li>
+                                                {% endfor %}
                                             </ul>
                                             <p></p>
                                         </div>
                                     </td>
                                     <td data-label="Distance">
                                         <div class="rich-text">
-                                            <p>3.1 miles</p>
+                                            <p>{{ counselor.distance|round( 1 ) }} miles</p>
                                         </div>
                                     </td>
                                 </tr>
+                                {% endfor %}
+                            {% endif %}
+                                
                             </tbody>
                         </table>
                     </div>

--- a/cfgov/housing_counselor/templates/housing_counselor/index.html
+++ b/cfgov/housing_counselor/templates/housing_counselor/index.html
@@ -178,7 +178,7 @@ Find a housing counselor
                                                     <div class="hud_hca_api_num">{{ forloop.counter }}.</div>
                                                     <div class="hud_hca_api_counselor_info_container">
                                                         <div class="hud_hca_api_counselor">
-                                                            {% if valid_url %}<a href="{{ signed_url }}" class="icon-link icon-link__external-link">{% endif %}
+                                                            {% if valid_url %}<a href="????" class="icon-link icon-link__external-link">{% endif %}
                                                             <span class="icon-link_text">{{ counselor.nme }}</span>
                                                             {% if valid_url %}</a>{% endif %}
                                                         </div>

--- a/cfgov/housing_counselor/templates/housing_counselor/index.html
+++ b/cfgov/housing_counselor/templates/housing_counselor/index.html
@@ -178,7 +178,7 @@ Find a housing counselor
                                                     <div class="hud_hca_api_num">{{ forloop.counter }}.</div>
                                                     <div class="hud_hca_api_counselor_info_container">
                                                         <div class="hud_hca_api_counselor">
-                                                            {% if valid_url %}<a href="????" class="icon-link icon-link__external-link">{% endif %}
+                                                            {% if valid_url %}<a href="{{ signed_url }}" class="icon-link icon-link__external-link">{% endif %}
                                                             <span class="icon-link_text">{{ counselor.nme }}</span>
                                                             {% if valid_url %}</a>{% endif %}
                                                         </div>

--- a/cfgov/unprocessed/apps/owning-a-home/package-lock.json
+++ b/cfgov/unprocessed/apps/owning-a-home/package-lock.json
@@ -164,7 +164,7 @@
       "dependencies": {
         "async": {
           "version": "0.2.10",
-          "resolved": "http://registry.npmjs.org/async/-/async-0.2.10.tgz",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
           "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E="
         }
       }


### PR DESCRIPTION
Update the work-in-progress improvements to Find a Housing Counselor by adding iteration that creates the list of the 10 closest housing counselors.

## Additions
- Add iteration through results, which creates HTML structure for the results of the search

## Testing
1. This only works if the `HUD_TOOL_IMPROVEMENTS` flag is on.
2. Check results at, for example, http://localhost:8000/find-a-housing-counselor/?zipcode=52246
3. Also check the search box

## Screenshots
<img width="1177" alt="screen shot 2018-11-16 at 4 30 44 pm" src="https://user-images.githubusercontent.com/1490703/48648347-01051080-e9bd-11e8-9211-8b03aa3de292.png">

## Checklist
- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [ ] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

