### PR TITLE
Bumps retirement satellite app to 0.7.5

### DIFF
--- a/requirements/optional-public.txt
+++ b/requirements/optional-public.txt
@@ -1,6 +1,6 @@
 https://github.com/cfpb/college-costs/releases/download/2.4.3/college_costs-2.4.3-py2-none-any.whl
 https://github.com/cfpb/owning-a-home-api/releases/download/0.11.3/owning_a_home_api-0.11.3-py2-none-any.whl
-https://github.com/cfpb/retirement/releases/download/0.7.4/retirement-0.7.4-py2-none-any.whl
+https://github.com/cfpb/retirement/releases/download/0.7.5/retirement-0.7.5-py2-none-any.whl
 https://github.com/cfpb/ccdb5-api/releases/download/1.1.0/ccdb5_api-1.1.0-py2-none-any.whl
 https://github.com/cfpb/ccdb5-ui/releases/download/1.1.0/ccdb5_ui-1.1.0-py2-none-any.whl
 https://github.com/cfpb/django-college-costs-comparison/releases/download/1.8.0/comparisontool-1.8.0-py2-none-any.whl


### PR DESCRIPTION
This change bumps the version of the optional [retirement](https://github.com/cfpb/retirement) satellite app from 0.7.4 to the latest [0.7.5](https://github.com/cfpb/retirement/releases/tag/0.7.5). This fixes a problem in the 0.7.4 release where the use of local webfonts was used as the default frontend configuration. This broke Django `collectstatic` when used with ManifestStaticFilesStorage.

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [X] Passes all existing automated tests
- [X] Any _change_ in functionality is tested
- [X] New functions are documented (with a description, list of inputs, and expected output)
- [X] Placeholder code is flagged / future todos are captured in comments
- [X] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [X] Project documentation has been updated
- [X] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: