### PR TITLE
Change map layout to use featured content module

### DIFF
--- a/cfgov/housing_counselor/jinja2/housing_counselor/improved_index.html
+++ b/cfgov/housing_counselor/jinja2/housing_counselor/improved_index.html
@@ -52,34 +52,40 @@
                             <p>Housing counselors throughout the country can provide advice on buying a home, renting, defaults, foreclosures, and credit issues. Using the search box below, you can find one near you. The counseling agencies on this list are approved by the U.S. Department of Housing and Urban Development (HUD) and they can offer independent advice about whether a particular set of mortgage loan terms is a good fit based on your objectives and circumstances, often at little or no cost to you. This list will show you several approved agencies in your area. There is also a <a class="a-link a-link__icon" href="https://apps.hud.gov/offices/hsg/sfh/hcc/hcs.cfm"><span class="a-link_text">list of nationwide HUD-approved counseling agencies</span> {{ svg_icon('external-link') }}</a>.</p>
                         </div>
                     </div>
-                    <div class="block">
-                        <div class="o-full-width-text-group content-l">
-                            <div class="col-3">
-                                <div class="o-well">
-                                    <form class="o-form" action="#">
-                                        <div class="m-form-field-with-button">
-                                            <div class="m-form-field">
-                                                <label class="a-label a-label__heading" for="zipcode">
-                                                    Search by ZIP code:
-                                                </label>
-                                                <input id="zip" type="text" name="zipcode" class="a-text-input a-text-input__full" value="52246">
-                                            </div>
-                                            <div class="m-form-field-with-button_wrapper">
-                                                <input class="a-btn a-btn__full-on-xs" type="submit" value="Find a counselor">
-                                                <div class="m-form-field-with-button_info">
-                                                    <p>
-                                                        This tool is powered by <a class="a-link a-link__icon" href="https://data.hud.gov/housing_counseling.html"><span class="a-link_text">HUD's</span> {{ svg_icon('external-link') }}</a> official list of housing counselors.
-                                                    </p>
-                                                    <p>
-                                                        If you notice errors in the housing counselor data, contact <a href="mailto:housing.counseling@hud.gov">housing.counseling@hud.gov</a>.
-                                                    </p>
-                                                </div>
+                    <div class="block block__border">
+
+                        <section class="o-featured-content-module
+                                        o-featured-content-module__right">
+                            <div class="o-featured-content-module_text">
+                                <form class="o-form" action="#">
+                                    <div class="m-form-field-with-button">
+                                        <div class="m-form-field">
+                                            <label class="a-label a-label__heading" for="zipcode">
+                                                Search by ZIP code:
+                                            </label>
+                                            <input id="zip" type="text" name="zipcode" class="a-text-input a-text-input__full" value="52246">
+                                        </div>
+                                        <div class="m-form-field-with-button_wrapper">
+                                            <input class="a-btn a-btn__full-on-xs" type="submit" value="Find a counselor">
+                                            <div class="m-form-field-with-button_info">
+                                                <p>
+                                                    This tool is powered by
+                                                    <a class="a-link a-link__icon"
+                                                       href="https://data.hud.gov/housing_counseling.html">
+                                                    <span class="a-link_text">HUD's</span>
+                                                    {{ svg_icon('external-link') }}</a> official list of housing counselors.
+                                                </p>
+                                                <p>
+                                                    If you notice errors in the housing counselor data,
+                                                    contact <a href="mailto:housing.counseling@hud.gov">housing.counseling@hud.gov</a>.
+                                                </p>
                                             </div>
                                         </div>
-                                    </form>
-                                </div>
+                                    </div>
+                                </form>
+
                             </div>
-                            <div class="col-9">
+                            <div class="o-featured-content-module_visual">
                                 <!-- Mapbox map is ignored during voiceover navigation
                                      as set by aria-hidden. -->
                                 <div id="hud_hca_api_map_container"
@@ -88,7 +94,8 @@
                                     <div id="hud_hca_api_map_canvas"></div>
                                 </div><!-- end .hud_hca_api_map -->
                             </div>
-                        </div>
+                        </section>
+
                     </div>
                     {% if zipcode %}
                     <div class="block">
@@ -165,7 +172,7 @@
                                 </tr>
                                 {% endfor %}
                             {% endif %}
-                                
+
                             </tbody>
                         </table>
                     </div>

--- a/cfgov/housing_counselor/jinja2/housing_counselor/improved_index.html
+++ b/cfgov/housing_counselor/jinja2/housing_counselor/improved_index.html
@@ -32,10 +32,15 @@
                                 <form class="o-form" action="#">
                                     <div class="m-form-field-with-button">
                                         <div class="m-form-field">
-                                            <label class="a-label a-label__heading" for="zipcode">
+                                            <label class="a-label a-label__heading" for="hud_hca_api_query">
                                                 Search by ZIP code:
                                             </label>
-                                            <input id="zip" type="text" name="zipcode" class="a-text-input a-text-input__full" value="52246">
+                                            <input id="hud_hca_api_query"
+                                                   type="text"
+                                                   name="zipcode"
+                                                   class="a-text-input a-text-input__full"
+                                                   value="{% if zipcode == false %}{{ zipcode }}{% endif %}"
+                                                   placeholder="Please enter a 5-digit ZIP code">
                                         </div>
                                         <div class="m-form-field-with-button_wrapper">
                                             <button class="a-btn a-btn__full-on-xs" type="submit">Find a counselor</button>

--- a/cfgov/housing_counselor/jinja2/housing_counselor/improved_index.html
+++ b/cfgov/housing_counselor/jinja2/housing_counselor/improved_index.html
@@ -38,7 +38,7 @@
                                             <input id="zip" type="text" name="zipcode" class="a-text-input a-text-input__full" value="52246">
                                         </div>
                                         <div class="m-form-field-with-button_wrapper">
-                                            <input class="a-btn a-btn__full-on-xs" type="submit" value="Find a counselor">
+                                            <button class="a-btn a-btn__full-on-xs" type="submit">Find a counselor</button>
                                             <div class="m-form-field-with-button_info">
                                                 <p>
                                                     This tool is powered by

--- a/cfgov/housing_counselor/jinja2/housing_counselor/improved_index.html
+++ b/cfgov/housing_counselor/jinja2/housing_counselor/improved_index.html
@@ -13,34 +13,6 @@
       href="{{ static('apps/find-a-housing-counselor/css/main.css') }}">
 {% endblock %}
 
-{% block hero %}
-
-<section class="m-hero">
-    <div class="m-hero_wrapper wrapper">
-        <div class="m-hero_text">
-            <h1 class="m-hero_heading">Find a Housing Counselor</h1>
-            <div class="m-hero_subhead">
-                {% if zipcode %}
-                    <div>
-                      <h2>Context:</h2>
-                      <p><b>zipcode</b>: {{ zipcode }}</p>
-                      <p><b>pdf_url</b>: {{ pdf_url }}</p>
-                      <p><b>api_json</b>: {{ api_json }}</p>
-                    </div>
-                    <br>
-                {% else %}
-                    <p> Lorem ipsum dolor amet Lomo dreamcatcher roof party tofu vegan woke four dollar toast whatever readymade 3 wolf moon kinfolk intelligentsia mixtape. Keffiyeh palo santo pickled, you probably haven't heard of them cray venmo portland bushwick. Drinking vinegar readymade pinterest brunch fanny pack occupy narwhal humblebrag four dollar toast. Four loko iceland tumblr, master cleanse williamsburg live-edge iPhone freegan fashion axe banh mi semiotics.
-                    </p>
-                {% endif %}
-            </div>
-        </div>
-        <div class="m-hero_image-wrapper">
-            <div class="m-hero_image"></div>
-        </div>
-    </div>
-</section>
-{% endblock %}
-
 {% block content %}
     <main class="content" id="main" lang="en">
         <div class="wrapper content_wrapper">

--- a/cfgov/unprocessed/apps/find-a-housing-counselor/js/hud.js
+++ b/cfgov/unprocessed/apps/find-a-housing-counselor/js/hud.js
@@ -7,7 +7,7 @@ HUD Counselors by zip code. See hud_api_replace for more details on the
 API queries. -wernerc */
 
 /* checkZip() is an easy, useful function that takes a string
-and returns a valid zip code, or returns false.
+and returns true if it's a valid zip code, or returns false.
 NOTE: 'Valid' means 5 numeric characters,
 not necessarily 'existant' and 'actually addressable.' */
 function checkZip( zip ) {

--- a/cfgov/unprocessed/apps/find-a-housing-counselor/js/hud.js
+++ b/cfgov/unprocessed/apps/find-a-housing-counselor/js/hud.js
@@ -6,49 +6,38 @@ let UNDEFINED;
 HUD Counselors by zip code. See hud_api_replace for more details on the
 API queries. -wernerc */
 
-/* This class represents a namespace of functions that should be exposed
-for testing purposes. */
-const cfpb_hud_hca = ( function() {
-  /* check_zip() is an easy, useful function that takes a string and returns a valid zip code, or returns false.
-  NOTE: 'Valid' means 5 numeric characters, not necessarily 'existant' and 'actually addressable.' */
-  const check_zip = function( zip ) {
-    if ( ( zip === null ) || ( zip === UNDEFINED ) || ( zip === false ) ) {
-      return false;
-    }
-
-    zip = zip.toString().replace( /[^0-9]+/g, '' );
-    zip = zip.slice( 0, 5 );
-    if ( zip.length === 5 ) {
-      return zip;
-    }
-
+/* checkZip() is an easy, useful function that takes a string
+and returns a valid zip code, or returns false.
+NOTE: 'Valid' means 5 numeric characters,
+not necessarily 'existant' and 'actually addressable.' */
+function checkZip( zip ) {
+  if ( zip === null || zip === UNDEFINED || zip === false ) {
     return false;
+  }
 
-
-  };
-
-  /* check_data_structure() just makes sure your data has the correct structure before you start
-  requesting properties that don't exist in generate_html() and update_map() */
-  const check_hud_data = function( data ) {
-    if ( ( data === null ) || ( data === 0 ) || ( data === UNDEFINED ) ) {
-      return false;
-    } else if ( data.hasOwnProperty( 'error' ) ) {
-      return 'error';
-    } else if ( !data.hasOwnProperty( 'counseling_agencies' ) ) {
-      return false;
-    } else if ( !data.hasOwnProperty( 'zip' ) ) {
-      return false;
-    }
-
+  zip = zip.toString().replace( /[^0-9]+/g, '' );
+  zip = zip.slice( 0, 5 );
+  if ( zip.length === 5 ) {
     return true;
+  }
 
-  };
+  return false;
+}
 
-  return {
-    check_zip: check_zip,
-    check_hud_data: check_hud_data
-  };
-} )();
+/* checkHudData() just makes sure your data has the correct structure
+before you start requesting properties that don't exist in
+generate_html() and update_map() */
+function checkHudData( data ) {
+  if ( data === null || data === 0 || data === UNDEFINED ) {
+    return false;
+  } else if ( data.hasOwnProperty( 'error' ) ||
+              !data.hasOwnProperty( 'counseling_agencies' ) ||
+              !data.hasOwnProperty( 'zip' ) ) {
+    return false;
+  }
+
+  return true;
+}
 
 ( function( $, L ) { // start jQuery capsule
 
@@ -56,18 +45,24 @@ const cfpb_hud_hca = ( function() {
   let marker_array = [];
   let zip_marker = null;
 
-
-  /* get_url_zip() is a simple function to retrieve the zip variable from the URL */
-  function get_url_zip() {
+  /* getUrlZip() is a simple function to retrieve the zip variable from the URL */
+  function getUrlZip() {
     let zip = '';
     const keyvals = window.location.href.slice( window.location.href.indexOf( '?' ) + 1 ).split( '&' );
+    const addressRegex = new RegExp( '^[0-9]{5}(?:-[0-9]{4})?', 'g' );
     $.each( keyvals, function( i, val ) {
       const parts = val.split( '=' );
-      if ( parts[0] === 'zip' ) {
+      if ( parts[0] === 'zipcode' ) {
         zip = parts[1];
+        // Pick zipcode out of query parameter value. Strips off '#' if present.
+        zip = addressRegex.exec( zip );
+        if ( zip !== null && zip.length > 0 ) {
+          zip = zip[0];
+        }
       }
     } );
-    return cfpb_hud_hca.check_zip( zip );
+
+    return checkZip( zip ) ? zip : '';
   }
 
   /* initialize_map() sets options and creates the map */
@@ -98,7 +93,7 @@ const cfpb_hud_hca = ( function() {
     map.setZoom( 2 );
     map.setView( [ 40, -80 ] );
 
-    if ( cfpb_hud_hca.check_hud_data( data ) === true ) {
+    if ( checkHudData( data ) === true ) {
       const lat = data.zip.lat;
       const lng = data.zip.lng;
       const ziplatlng = [ lat, lng ];
@@ -190,7 +185,7 @@ const cfpb_hud_hca = ( function() {
     } );
 
     // If there is a GET value for zip, load that zip immediately.
-    const getzip = get_url_zip();
+    const getzip = getUrlZip();
     if ( getzip !== '' ) {
       $( '#hud_hca_api_query' ).val( getzip );
       $( '.hud_hca_api_form_button' ).trigger( 'click' );
@@ -199,3 +194,8 @@ const cfpb_hud_hca = ( function() {
   } );
 
 } )( jQuery, window.L ); // end anonymous function capsule
+
+module.exports = {
+  checkZip,
+  checkHudData
+};

--- a/test/unit_tests/apps/find-a-housing-counselor/js/hud-spec.js
+++ b/test/unit_tests/apps/find-a-housing-counselor/js/hud-spec.js
@@ -1,0 +1,30 @@
+const BASE_JS_PATH = '../../../../../cfgov/unprocessed/apps/';
+const hud = require( BASE_JS_PATH + 'find-a-housing-counselor/js/hud.js' );
+
+let UNDEFINED;
+
+describe( 'hud', () => {
+
+  describe( 'checkZip', () => {
+    it( 'Should return true on a valid zipcode, false otherwise.', () => {
+      expect( hud.checkZip( '05201' ) ).toBe( true );
+      expect( hud.checkZip( '' ) ).toBe( false );
+      expect( hud.checkZip( null ) ).toBe( false );
+      expect( hud.checkZip( UNDEFINED ) ).toBe( false );
+      expect( hud.checkZip( false ) ).toBe( false );
+    } );
+  } );
+
+  describe( 'checkHudData', () => {
+    it( 'Should return true on a valid HUD data, false otherwise.', () => {
+      const mockData = {
+        counseling_agencies: [ { } ],
+        zip: { }
+      };
+      expect( hud.checkHudData( mockData ) ).toBe( true );
+      expect( hud.checkHudData( '' ) ).toBe( false );
+      expect( hud.checkHudData( null ) ).toBe( false );
+    } );
+  } );
+
+} );


### PR DESCRIPTION
## Changes

Housing counselor: 
- Updates zipcode input form and map to use featured content module.
- Removes hero block in jinja template.
- Exports utility methods from hud.js and adds unit test coverage for those methods. Also adjusts their logic to return consistent types.

## Testing

1. `gulp clean && gulp build`
1. Visit http://localhost:8000/find-a-housing-counselor/ and resize window to see how zipcode form and map stack.
2. `gulp test:unit` should pass.

## Screenshots

<img width="1084" alt="screen shot 2018-11-19 at 10 59 35 am" src="https://user-images.githubusercontent.com/704760/48718936-54a87180-ebea-11e8-8c33-afa0c180dc4f.png">
<img width="555" alt="screen shot 2018-11-19 at 10 59 45 am" src="https://user-images.githubusercontent.com/704760/48718937-54a87180-ebea-11e8-9490-81fe30d30909.png">
