### PR TITLE
Finding housing counselor: Fix results behavior

### DIFF
--- a/cfgov/housing_counselor/jinja2/housing_counselor/improved_index.html
+++ b/cfgov/housing_counselor/jinja2/housing_counselor/improved_index.html
@@ -119,10 +119,7 @@
                         </section>
 
                     </div>
-                    {% if zipcode %}
-                    {% if not zipcode_valid %}
-
-                    {% else %}
+                    {% if zipcode and zipcode_valid %}
                     <div class="block">
                         <div class="results-header">
                             <ul class="m-list
@@ -223,7 +220,6 @@
                         </table>
                     </div>
 
-                    {% endif %}
                     {% endif %}
 
                     <div class="block">

--- a/cfgov/housing_counselor/jinja2/housing_counselor/improved_index.html
+++ b/cfgov/housing_counselor/jinja2/housing_counselor/improved_index.html
@@ -21,7 +21,30 @@
                     <div class="block block__flush-top block__flush-top">
                         <h1>Find a housing counselor</h1>
                         <div class="rich-text">
-                            <p>Housing counselors throughout the country can provide advice on buying a home, renting, defaults, foreclosures, and credit issues. Using the search box below, you can find one near you. The counseling agencies on this list are approved by the U.S. Department of Housing and Urban Development (HUD) and they can offer independent advice about whether a particular set of mortgage loan terms is a good fit based on your objectives and circumstances, often at little or no cost to you. This list will show you several approved agencies in your area. There is also a <a class="a-link a-link__icon" href="https://apps.hud.gov/offices/hsg/sfh/hcc/hcs.cfm"><span class="a-link_text">list of nationwide HUD-approved counseling agencies</span> {{ svg_icon( 'external-link' ) }}</a>.</p>
+                            <p>
+                                Housing counselors throughout the country can
+                                provide advice on buying a home, renting,
+                                defaults, foreclosures, and credit issues.
+                                Using the search box below,
+                                you can find one near you.
+                                The counseling agencies on this list are
+                                approved by the U.S. Department of Housing
+                                and Urban Development (HUD) and they can
+                                offer independent advice about whether a
+                                particular set of mortgage loan terms is a
+                                good fit based on your objectives and
+                                circumstances, often at little
+                                or no cost to you. This list will show you
+                                several approved agencies in your area.
+                                There is also a
+                                <a class="a-link a-link__icon"
+                                   href="https://apps.hud.gov/offices/hsg/sfh/hcc/hcs.cfm">
+                                   <span class="a-link_text">
+                                       list of nationwide
+                                       HUD-approved counseling agencies
+                                   </span>
+                                   {{ svg_icon( 'external-link' ) }}</a>.
+                            </p>
                         </div>
                     </div>
                     <div class="block block__border">

--- a/cfgov/housing_counselor/jinja2/housing_counselor/improved_index.html
+++ b/cfgov/housing_counselor/jinja2/housing_counselor/improved_index.html
@@ -226,7 +226,38 @@
                         <div class="o-full-width-text-group">
                             <div class="m-full-width-text">
                                 <h3>Paperwork Reduction Act statement</h3>
-                                <p class="u-mb0">According to the Paperwork Reduction Act of 1995, an agency may not conduct or sponsor, and a person is not required to respond to a collection of information unless it displays a valid OMB control number. The OMB control number for this collection is <a class="a-link a-link__icon" href="https://www.reginfo.gov/public/do/PRAOMBHistory?ombControlNumber=3170-0025"><span class="a-link_text">3170-0025</span> {{ svg_icon( 'external-link' ) }}</a>. It expires on 04/30/2016. Using this tool to generate a list of HUD-Approved Housing Counseling Agencies is voluntary however, if you are an entity subject to 12 CFR § 1024 (78 FR 6856 (Jan. 31, 2013)), you are required to provide this list as specified in the regulation. Comments regarding this collection of information, including suggestions for improving the usefulness of the information, or suggestions for reducing the burden to respond to this collection should be submitted to the Bureau of Consumer Financial Protection (Attention: PRA Office), 1700 G Street NW, Washington, DC 20552, or by email to <a href="mailto:PRA@cfpb.gov">PRA@cfpb.gov</a>.<br></p>
+                                <p class="u-mb0">
+                                    According to the Paperwork Reduction
+                                    Act of 1995, an agency may not conduct or
+                                    sponsor, and a person is not required to
+                                    respond to a collection of information
+                                    unless it displays a valid OMB control
+                                    number. The OMB control number for this
+                                    collection is
+                                    <a class="a-link a-link__icon"
+                                       href="https://www.reginfo.gov/public/do/PRAOMBHistory?ombControlNumber=3170-0025">
+                                       <span class="a-link_text">
+                                           3170-0025
+                                       </span>
+                                       {{ svg_icon( 'external-link' ) }}</a>.
+                                    It expires on 04/30/2016. Using this tool
+                                    to generate a list of HUD-Approved Housing
+                                    Counseling Agencies is voluntary however,
+                                    if you are an entity subject to 12 CFR §
+                                    1024 (78 FR 6856 (Jan. 31, 2013)),
+                                    you are required to provide this list as
+                                    specified in the regulation.
+                                    Comments regarding this collection of
+                                    information, including suggestions for
+                                    improving the usefulness of the information,
+                                    or suggestions for reducing the burden to
+                                    respond to this collection should be
+                                    submitted to the
+                                    Bureau of Consumer Financial Protection
+                                    (Attention: PRA Office), 1700 G Street NW,
+                                    Washington, DC 20552, or by email to
+                                    <a href="mailto:PRA@cfpb.gov">PRA@cfpb.gov</a>.
+                                </p>
 
                                 <div class="block
                                             block__flush-bottom

--- a/cfgov/housing_counselor/jinja2/housing_counselor/improved_index.html
+++ b/cfgov/housing_counselor/jinja2/housing_counselor/improved_index.html
@@ -69,10 +69,10 @@
                                                     {{ svg_icon( 'warning-round' ) }}
                                                     <div class="m-notification_content" role="alert">
                                                         <div class="h4 m-notification_message">
-                                                            You have entered an invalid ZIP code.
+                                                            Sorry, you have entered an invalid ZIP code.
                                                         </div>
                                                         <div class="m-notification_explanation">
-                                                            Enter a valid five-digit ZIP code.
+                                                            Please enter a valid five-digit ZIP code below.
                                                         </div>
                                                     </div>
                                                 </div>
@@ -126,23 +126,27 @@
                                        m-list__horizontal
                                        hud_hca_api_results_actions">
                                 <li class="m-list_item">
-                                    <button class="a-btn a-btn__link"
-                                       id="hud_print-page-link">
-                                        Print list
+                                    <a class="a-link a-link__icon"
+                                       id="hud_print-page-link" href="#">
+                                        <span class="a-link_text">
+                                            Print list
+                                        </span>
                                         {{ svg_icon( 'print' ) }}
-                                    </button>
+                                    </a>
                                 </li>
                                 <li class="m-list_item">
-                                    <a class="a-btn a-btn__link"
+                                    <a class="a-link a-link__icon"
                                        id="generate-pdf-link"
                                        href="{{ pdf_url }}"
                                        target="_blank"
                                        rel="noopener noreferrer">
-                                        Save list as
-                                        <abbr title="Portable Document Format">
-                                          PDF
-                                        </abbr>
-                                        {{ svg_icon( 'save' ) }}
+                                        <span class="a-link_text">
+                                            Save list as
+                                            <abbr title="Portable Document Format">
+                                              PDF
+                                            </abbr>
+                                        </span>
+                                        {{ svg_icon( 'download' ) }}
                                     </a>
                                 </li>
                             </ul>

--- a/cfgov/housing_counselor/jinja2/housing_counselor/improved_index.html
+++ b/cfgov/housing_counselor/jinja2/housing_counselor/improved_index.html
@@ -21,7 +21,7 @@
                     <div class="block block__flush-top block__flush-top">
                         <h1>Find a housing counselor</h1>
                         <div class="rich-text">
-                            <p>Housing counselors throughout the country can provide advice on buying a home, renting, defaults, foreclosures, and credit issues. Using the search box below, you can find one near you. The counseling agencies on this list are approved by the U.S. Department of Housing and Urban Development (HUD) and they can offer independent advice about whether a particular set of mortgage loan terms is a good fit based on your objectives and circumstances, often at little or no cost to you. This list will show you several approved agencies in your area. There is also a <a class="a-link a-link__icon" href="https://apps.hud.gov/offices/hsg/sfh/hcc/hcs.cfm"><span class="a-link_text">list of nationwide HUD-approved counseling agencies</span> {{ svg_icon('external-link') }}</a>.</p>
+                            <p>Housing counselors throughout the country can provide advice on buying a home, renting, defaults, foreclosures, and credit issues. Using the search box below, you can find one near you. The counseling agencies on this list are approved by the U.S. Department of Housing and Urban Development (HUD) and they can offer independent advice about whether a particular set of mortgage loan terms is a good fit based on your objectives and circumstances, often at little or no cost to you. This list will show you several approved agencies in your area. There is also a <a class="a-link a-link__icon" href="https://apps.hud.gov/offices/hsg/sfh/hcc/hcs.cfm"><span class="a-link_text">list of nationwide HUD-approved counseling agencies</span> {{ svg_icon( 'external-link' ) }}</a>.</p>
                         </div>
                     </div>
                     <div class="block block__border">
@@ -31,17 +31,39 @@
                             <div class="o-featured-content-module_text">
                                 <form class="o-form" action="#">
                                     <div class="m-form-field-with-button">
+
                                         <div class="m-form-field">
                                             <label class="a-label a-label__heading" for="hud_hca_api_query">
                                                 Search by ZIP code:
                                             </label>
+
+                                            {% if zipcode and not zipcode_valid %}
+                                            <div class="u-mb15">
+                                                <div class="m-notification
+                                                            m-notification__default
+                                                            m-notification__error
+                                                            m-notification__visible">
+                                                    {{ svg_icon( 'warning-round' ) }}
+                                                    <div class="m-notification_content" role="alert">
+                                                        <div class="h4 m-notification_message">
+                                                            You have entered an invalid ZIP code.
+                                                        </div>
+                                                        <div class="m-notification_explanation">
+                                                            Enter a valid five-digit ZIP code.
+                                                        </div>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                            {% endif %}
+
                                             <input id="hud_hca_api_query"
                                                    type="text"
                                                    name="zipcode"
                                                    class="a-text-input a-text-input__full"
                                                    value="{% if zipcode == false %}{{ zipcode }}{% endif %}"
-                                                   placeholder="Please enter a 5-digit ZIP code">
+                                                   placeholder="Please enter a five-digit ZIP code">
                                         </div>
+
                                         <div class="m-form-field-with-button_wrapper">
                                             <button class="a-btn a-btn__full-on-xs" type="submit">Find a counselor</button>
                                             <div class="m-form-field-with-button_info">
@@ -50,7 +72,7 @@
                                                     <a class="a-link a-link__icon"
                                                        href="https://data.hud.gov/housing_counseling.html">
                                                     <span class="a-link_text">HUD's</span>
-                                                    {{ svg_icon('external-link') }}</a> official list of housing counselors.
+                                                    {{ svg_icon( 'external-link' ) }}</a> official list of housing counselors.
                                                 </p>
                                                 <p>
                                                     If you notice errors in the housing counselor data,
@@ -75,17 +97,42 @@
 
                     </div>
                     {% if zipcode %}
+                    {% if not zipcode_valid %}
+
+                    {% else %}
                     <div class="block">
                         <div class="results-header">
-                            <h2 class="h4">Displaying the 10 locations closest to ZIP code 52246</h2>
-                            <div class="action-buttons">
-                                <button class="a-btn a-btn__link">
-                                    Print list
-                                </button>
-                                <button class="a-btn a-btn__link">
-                                    Save list as PDF
-                                </button>
-                            </div>
+                            <ul class="m-list
+                                       m-list__horizontal
+                                       hud_hca_api_results_actions">
+                                <li class="m-list_item">
+                                    <button class="a-btn a-btn__link"
+                                       id="hud_print-page-link">
+                                        Print list
+                                        {{ svg_icon( 'print' ) }}
+                                    </button>
+                                </li>
+                                <li class="m-list_item">
+                                    <a class="a-btn a-btn__link"
+                                       id="generate-pdf-link"
+                                       href="{{ pdf_url }}"
+                                       target="_blank"
+                                       rel="noopener noreferrer">
+                                        Save list as
+                                        <abbr title="Portable Document Format">
+                                          PDF
+                                        </abbr>
+                                        {{ svg_icon( 'save' ) }}
+                                    </a>
+                                </li>
+                            </ul>
+
+                            <h2 class="h4">
+                              Displaying the
+                              {{ api_json.counseling_agencies | length }}
+                              locations closest to ZIP code
+                              {{ zipcode | escape }}
+                            </h2>
                         </div>
                         <table class="o-table o-table__stack-on-small u-w100pct">
                             <thead>
@@ -115,7 +162,7 @@
                                             <p>
                                                 <span class="result-number">{{ loop.index }}.</span>
                                                 <a class="a-link a-link__icon" href="{{ counselor.weburl }}"><span class="a-link_text">{{ counselor.nme }}</span>
-                                                  {{ svg_icon('external-link') }}</a><b><br></b>{{ counselor.adr1 }}
+                                                  {{ svg_icon( 'external-link' ) }}</a><b><br></b>{{ counselor.adr1 }}
                                             {% if counselor.adr2 and counselor.adr2 != ' '  %}
                                                 <br>{{ counselor.adr2 }}
                                             {% endif %}<br>
@@ -123,7 +170,7 @@
                                             </p>
                                             <p><b>Website:</b>
                                                 <a class="a-link a-link__icon" href="{{ counselor.weburl }}">
-                                                    <span class="a-link_text">{{ counselor.weburl }}</span> {{ svg_icon('external-link') }}
+                                                    <span class="a-link_text">{{ counselor.weburl }}</span> {{ svg_icon( 'external-link' ) }}
                                                 </a><br>
                                                 <b>Phone:</b> {{ counselor.phone1 }}<br>
                                                 <b>Email Address:</b> {{ counselor.email }}<br>
@@ -148,16 +195,19 @@
                                     </td>
                                 </tr>
                                 {% endfor %}
-                            {% endif %}
 
                             </tbody>
                         </table>
                     </div>
+
+                    {% endif %}
+                    {% endif %}
+
                     <div class="block">
                         <div class="o-full-width-text-group">
                             <div class="m-full-width-text">
                                 <h3>Paperwork Reduction Act statement</h3>
-                                <p class="u-mb0">According to the Paperwork Reduction Act of 1995, an agency may not conduct or sponsor, and a person is not required to respond to a collection of information unless it displays a valid OMB control number. The OMB control number for this collection is <a class="a-link a-link__icon" href="https://www.reginfo.gov/public/do/PRAOMBHistory?ombControlNumber=3170-0025"><span class="a-link_text">3170-0025</span> {{ svg_icon('external-link') }}</a>. It expires on 04/30/2016. Using this tool to generate a list of HUD-Approved Housing Counseling Agencies is voluntary however, if you are an entity subject to 12 CFR § 1024 (78 FR 6856 (Jan. 31, 2013)), you are required to provide this list as specified in the regulation. Comments regarding this collection of information, including suggestions for improving the usefulness of the information, or suggestions for reducing the burden to respond to this collection should be submitted to the Bureau of Consumer Financial Protection (Attention: PRA Office), 1700 G Street NW, Washington, DC 20552, or by email to <a href="mailto:PRA@cfpb.gov">PRA@cfpb.gov</a>.<br></p>
+                                <p class="u-mb0">According to the Paperwork Reduction Act of 1995, an agency may not conduct or sponsor, and a person is not required to respond to a collection of information unless it displays a valid OMB control number. The OMB control number for this collection is <a class="a-link a-link__icon" href="https://www.reginfo.gov/public/do/PRAOMBHistory?ombControlNumber=3170-0025"><span class="a-link_text">3170-0025</span> {{ svg_icon( 'external-link' ) }}</a>. It expires on 04/30/2016. Using this tool to generate a list of HUD-Approved Housing Counseling Agencies is voluntary however, if you are an entity subject to 12 CFR § 1024 (78 FR 6856 (Jan. 31, 2013)), you are required to provide this list as specified in the regulation. Comments regarding this collection of information, including suggestions for improving the usefulness of the information, or suggestions for reducing the burden to respond to this collection should be submitted to the Bureau of Consumer Financial Protection (Attention: PRA Office), 1700 G Street NW, Washington, DC 20552, or by email to <a href="mailto:PRA@cfpb.gov">PRA@cfpb.gov</a>.<br></p>
 
                                 <div class="block
                                             block__flush-bottom

--- a/cfgov/unprocessed/apps/find-a-housing-counselor/css/hud.less
+++ b/cfgov/unprocessed/apps/find-a-housing-counselor/css/hud.less
@@ -179,7 +179,8 @@ a:hover, a:focus {
 .hud_hca_api_results_actions {
     text-align: right;
 
-    & abbr {
+    & abbr,
+    & svg {
       border-bottom: none;
       text-decoration: none;
     }

--- a/cfgov/unprocessed/apps/find-a-housing-counselor/css/hud.less
+++ b/cfgov/unprocessed/apps/find-a-housing-counselor/css/hud.less
@@ -168,8 +168,6 @@ a:hover, a:focus {
 
 .hud_hca_api_results_actions {
     float: right;
-    margin-top: 1em;
-    width: 48.75%;
 }
 
 .hud_hca_api_results_total p {
@@ -178,11 +176,13 @@ a:hover, a:focus {
     padding: 0 1em;
 }
 
-.hud_hca_api_results_actions p {
-    font-size: 0.875em;
-    line-height: 1.85;
-    padding: 0 1em;
+.hud_hca_api_results_actions {
     text-align: right;
+
+    & abbr {
+      border-bottom: none;
+      text-decoration: none;
+    }
 }
 
 .hud_hca_api_results_print {

--- a/cfgov/unprocessed/apps/find-a-housing-counselor/css/main.less
+++ b/cfgov/unprocessed/apps/find-a-housing-counselor/css/main.less
@@ -1,2 +1,2 @@
-@import (less) './hud.css';
+@import (less) './hud.less';
 @import (less) './hud_print.css';

--- a/cfgov/unprocessed/apps/find-a-housing-counselor/js/hud.js
+++ b/cfgov/unprocessed/apps/find-a-housing-counselor/js/hud.js
@@ -39,6 +39,12 @@ function checkHudData( data ) {
   return true;
 }
 
+const printPageLink = document.querySelector( '#hud_print-page-link' );
+printPageLink.addEventListener( 'click', evt => {
+  evt.preventDefault();
+  window.print();
+} );
+
 ( function( $, L ) { // start jQuery capsule
 
   let map;
@@ -148,41 +154,6 @@ function checkHudData( data ) {
   }
 
   $( document ).ready( function() {
-
-    // On click of the print link, open print dialog
-    $( '.hud_hca_api_no_js_print_text' ).remove();
-    $( '.hud_hca_api_results_print' ).append( '<a class="hud-hca-api-print" href="#print">Print list</a>' );
-    $( '.hud_hca_api_results_print a.hud-hca-api-print' ).click( function() {
-      window.print();
-      return false;
-    } );
-
-    // Provide a fallback for HTML5 placeholder for older browsers
-    $( '#hud_hca_api_query', function() {
-      const input = document.createElement( 'input' );
-      if ( ( 'placeholder' in input ) === false ) {
-        // eslint-disable-next-line max-nested-callbacks
-        $( '[placeholder]' ).focus( function() {
-          const i = $( this );
-          if ( i.val() === i.attr( 'placeholder' ) ) {
-            i.val( '' ).removeClass( 'placeholder' );
-          }
-        // eslint-disable-next-line max-nested-callbacks
-        } ).blur( function() {
-          const i = $( this );
-          if ( i.val() === '' || i.val() === i.attr( 'placeholder' ) ) {
-            i.addClass( 'placeholder' ).val( i.attr( 'placeholder' ) );
-          }
-        // eslint-disable-next-line max-nested-callbacks
-        } ).blur().parents( 'form' ).submit( function() {
-          // eslint-disable-next-line max-nested-callbacks
-          $( this ).find( '[placeholder]' ).each( function() {
-            const i = $( this );
-            if ( i.val() === i.attr( 'placeholder' ) ) i.val( '' );
-          } );
-        } );
-      }
-    } );
 
     // If there is a GET value for zip, load that zip immediately.
     const getzip = getUrlZip();

--- a/cfgov/unprocessed/apps/find-a-housing-counselor/js/hud.js
+++ b/cfgov/unprocessed/apps/find-a-housing-counselor/js/hud.js
@@ -39,11 +39,14 @@ function checkHudData( data ) {
   return true;
 }
 
+// Set up print results list button functionality, if it exists.
 const printPageLink = document.querySelector( '#hud_print-page-link' );
-printPageLink.addEventListener( 'click', evt => {
-  evt.preventDefault();
-  window.print();
-} );
+if ( printPageLink ) {
+  printPageLink.addEventListener( 'click', evt => {
+    evt.preventDefault();
+    window.print();
+  } );
+}
 
 ( function( $, L ) { // start jQuery capsule
 


### PR DESCRIPTION
Results list had hardcoded results count and non-functional PDF and print buttons. It also didn't work with invalid zipcode values.

Error message should close out [GHE]/CFGOV/platform/issues/2580

## Changes

- Make results list summary text dynamic based on result count and zip code.
- Update print button JS to remove jQuery.
- Update hud.css to hud.less and add less rule for abbr tag wrapping PDF.
- Wrap long paragraphs.
- Remove unused CSS.
- Updates "5-digit" copy to "five-digit".
- Updates "zip code" to "ZIP code" per our style guides.

## Testing

1. `gulp clean && gulp build`
2. Visit http://localhost:8000/find-a-housing-counselor/
3. Enter a valid ZIP code.
4. Click "Print list" button and see that print dialog shows up.
5. Click "Save list as PDF" link and see that PDF saves.
6. Enter an invalid ZIP code.
7. See that error notification shows up and results list does not appear.

## Screenshots

<img width="769" alt="screen shot 2018-11-20 at 2 57 01 pm" src="https://user-images.githubusercontent.com/704760/48799223-99a8d280-ecd4-11e8-8cf7-c5b8eba54f45.png">

---

<img width="783" alt="screen shot 2018-11-20 at 2 57 15 pm" src="https://user-images.githubusercontent.com/704760/48799224-99a8d280-ecd4-11e8-944f-32732a929c91.png">
