### PR TITLE
Housing counselor: Hides map in no-js state

### DIFF
--- a/cfgov/unprocessed/apps/find-a-housing-counselor/css/hud.less
+++ b/cfgov/unprocessed/apps/find-a-housing-counselor/css/hud.less
@@ -29,3 +29,17 @@
 .o-table tr {
     vertical-align: top;
 }
+
+.no-js {
+    .o-featured-content-module {
+        min-height: auto;
+
+        &_text {
+            width: auto;
+        }
+    }
+
+    #hud_hca_api_map_container {
+        display: none;
+    }
+}


### PR DESCRIPTION
All credit to @niqjohnson !

## Changes

- Adds `no-js` styles to `hud.less` for hiding the map when JS is not available and changing the ZIP code input box layout.

## Testing

1. `gulp clean && gulp build`
2. Open http://localhost:8000/find-a-housing-counselor/
3. Open dev console and go to the `Settings` and check `Disable JavaScript`
4. Reload the page and see that you can still retrieve a list of housing counselors without JS.

## Screenshots

<img width="828" alt="screen shot 2018-11-23 at 11 58 25 am" src="https://user-images.githubusercontent.com/704760/48954352-16c38a00-ef17-11e8-9d04-50bfb1caec57.png">
