### PR TITLE
Housing counselor: cache the map marker DOM lookups

### DIFF
--- a/cfgov/unprocessed/apps/find-a-housing-counselor/js/common.js
+++ b/cfgov/unprocessed/apps/find-a-housing-counselor/js/common.js
@@ -34,7 +34,7 @@ function initializeMap() {
  * happen every time a map marker is clicked. The lookup happens on the first
  * click and then is stored in the markerDomCache object.
  * @param  {number} num - The index of the result item.
- * @return {HTMLNode} The DOM node of the result item.
+ * @returns {HTMLNode} The DOM node of the result item.
  */
 function queryMarkerDom( num ) {
   const selector = '#hud-result-' + Number.parseInt( num, 10 );

--- a/cfgov/unprocessed/apps/find-a-housing-counselor/js/common.js
+++ b/cfgov/unprocessed/apps/find-a-housing-counselor/js/common.js
@@ -40,7 +40,6 @@ function queryMarkerDom( num ) {
   const selector = '#hud-result-' + Number.parseInt( num, 10 );
   let cachedItem = markerDomCache[selector];
   if ( typeof cachedItem === 'undefined' ) {
-    console.log( 'looking up the item!' );
     cachedItem = document.querySelector( selector );
     markerDomCache[selector] = cachedItem;
   }

--- a/cfgov/unprocessed/apps/find-a-housing-counselor/js/common.js
+++ b/cfgov/unprocessed/apps/find-a-housing-counselor/js/common.js
@@ -28,10 +28,24 @@ function initializeMap() {
   }
 }
 
+let markerDomCache = {};
+function queryMarkerDom( num ) {
+  const selector = '#hud-result-' + Number.parseInt( num, 10 );
+  let cachedItem = markerDomCache[selector];
+  if ( typeof cachedItem === 'undefined' ) {
+    console.log( 'looking up the item!' );
+    cachedItem = document.querySelector( selector );
+    markerDomCache[selector] = cachedItem;
+  }
+
+  return cachedItem;
+}
+
 /* generate_google_map(data) takes the data and plots the markers, etc, on
 the google map. It's called by get_counselors_by_zip(). */
 function updateMap( data ) {
   // reset the map
+  markerDomCache = {};
   for ( let i = 0; i < marker_array.length; i++ ) {
     map.removeLayer( marker_array[i] );
   }
@@ -84,9 +98,7 @@ function updateMap( data ) {
       marker_array[i] = marker;
 
       marker.on( 'click', function() {
-        const resultEntryDom = document.querySelector(
-          '#hud-result-' + Number.parseInt( number, 10 )
-        );
+        const resultEntryDom = queryMarkerDom( number );
         resultEntryDom.scrollIntoView( {
           behavior: 'smooth',
           block: 'start'

--- a/cfgov/unprocessed/apps/find-a-housing-counselor/js/common.js
+++ b/cfgov/unprocessed/apps/find-a-housing-counselor/js/common.js
@@ -16,6 +16,7 @@ if ( printPageLink ) {
 let map;
 let marker_array = [];
 let zip_marker = null;
+let markerDomCache = {};
 
 /* initialize_map() sets options and creates the map */
 function initializeMap() {
@@ -28,7 +29,13 @@ function initializeMap() {
   }
 }
 
-let markerDomCache = {};
+/**
+ * Cache the map marker result item DOM references so that a DOM lookup doesn't
+ * happen every time a map marker is clicked. The lookup happens on the first
+ * click and then is stored in the markerDomCache object.
+ * @param  {number} num - The index of the result item.
+ * @return {HTMLNode} The DOM node of the result item.
+ */
 function queryMarkerDom( num ) {
   const selector = '#hud-result-' + Number.parseInt( num, 10 );
   let cachedItem = markerDomCache[selector];

--- a/cfgov/unprocessed/js/modules/util/validators.js
+++ b/cfgov/unprocessed/js/modules/util/validators.js
@@ -21,8 +21,9 @@ const typeCheckers = require( '../../modules/util/type-checkers' );
  */
 function date( field, currentStatus ) {
   const status = currentStatus || {};
-  // Date regex matches date patterns allowed in cfgov/v1/forms.py FilterableDateField
-  // https://regex101.com/r/JVKCf9/1
+
+  /* Date regex matches date patterns allowed in cfgov/v1/forms.py FilterableDateField
+     https://regex101.com/r/JVKCf9/1 */
   const dateRegex =
     /^\d{4}$|^(?:\d{1}|\d{2})\/(?:\d{4}|\d{2})$|^(?:\d{1}|\d{2})\/(?:\d{1}|\d{2})\/(?:\d{4}|\d{2})$/;
   if ( field.value && dateRegex.test( field.value ) === false ) {


### PR DESCRIPTION
A DOM lookup was happening every time a map marker was clicked. This caches the lookups so they only happen on the first time the item is clicked.

## Changes

- Cache result list item DOM references when the map markers are clicked.

## Testing

1. `gulp clean && gulp build`
2. Visit http://localhost:8000/find-a-housing-counselor/
3. Enter a ZIP and find results.
4. Click on a map marker to scroll to the results list item.
5. Click on the same map marker again.
6. Click on a different map marker.
7. Search for a different ZIP code.
8. Click on a marker and see that it scrolls to the results list item.

If you want, you can add a `console.log` where the DOM lookup happens and see that it will only be called once per ZIP code query.
