### PR TITLE
Bump Django-Flags to 4.0.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,6 +51,7 @@ env:
     - DJANGO_STAGING_HOSTNAME=content.localhost
     - COVERALLS_PARALLEL=true
     - PGPORT=5433
+    - TEST_DATABASE_URL=postgres://travis:travis@localhost:5433/travis
 
 jobs:
   fast_finish: true

--- a/cfgov/cfgov/settings/test.py
+++ b/cfgov/cfgov/settings/test.py
@@ -49,3 +49,7 @@ STATICFILES_DIRS += [
 MOCK_STATICFILES_PATTERNS = {
     'icons/*.svg': 'icons/placeholder.svg',
 }
+
+FLAG_SOURCES = (
+    'flags.sources.SettingsFlagsSource',
+)

--- a/requirements/libraries.txt
+++ b/requirements/libraries.txt
@@ -5,7 +5,7 @@ dj-database-url==0.5.0
 djangorestframework==3.6.4
 django-csp==3.4
 django-extensions==2.1.3
-django-flags==4.0.1
+django-flags==4.0.2
 django-haystack==2.7.0
 django-localflavor==1.6.2
 # django-mptt is required by teachers-digital-platform

--- a/travis_run.sh
+++ b/travis_run.sh
@@ -13,7 +13,7 @@ if [ "$RUNTEST" == "frontend" ]; then
 elif [ "$RUNTEST" == "backend" ]; then
     tox -e lint
     tox -e missing-migrations
-    TEST_DATABASE_URL=postgres://travis:travis@localhost:5433/travis tox -e fast
+    tox -e fast
     bash <(curl -s https://codecov.io/bash) -F backend
 elif [ "$RUNTEST" == "docs" ]; then
     mkdocs build


### PR DESCRIPTION
Per cfpb/django-flags#16, this PR uses the latest release of Django-Flags to stop repeated `No condition registered for name "site" ` messages in favor of a Django system check. Now if there are non-existent conditions (like "site") they will be reported only when Django starts up. You should be able to see this with a recent database dump, i.e.:

```
Performing system checks...

System check identified some issues:

WARNINGS:
?: (flags.E001) Flag MOSAIC_CCDB has non-existent condition "site"
	HINT: Register "site" as a Django-Flags condition.
?: (flags.E001) Flag MOSAIC_CCDB has non-existent condition "site"
	HINT: Register "site" as a Django-Flags condition.
?: (flags.E001) Flag MOSAIC_COMPLAINTS has non-existent condition "site"
	HINT: Register "site" as a Django-Flags condition.
?: (flags.E001) Flag MOSAIC_COMPLAINTS has non-existent condition "site"
	HINT: Register "site" as a Django-Flags condition.
?: (flags.E001) Flag OAA_FOOTER_LINK has non-existent condition "site"
	HINT: Register "site" as a Django-Flags condition.
?: (flags.E001) Flag OAA_FOOTER_LINK has non-existent condition "site"
	HINT: Register "site" as a Django-Flags condition.
?: (flags.E001) Flag PING_GOOGLE_ON_PUBLISH has non-existent condition "site"
	HINT: Register "site" as a Django-Flags condition.
?: (flags.E001) Flag TDP_RELEASE has non-existent condition "site"
	HINT: Register "site" as a Django-Flags condition.
?: (flags.E001) Flag WAGTAIL_DOING_BUSINESS_WITH_US has non-existent condition "site"
	HINT: Register "site" as a Django-Flags condition.
?: (flags.E001) Flag WAGTAIL_DOING_BUSINESS_WITH_US has non-existent condition "site"
	HINT: Register "site" as a Django-Flags condition.

System check identified 10 issues (0 silenced).
```

As a side-note, I'm fairly certain all of the above flags are orphaned.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: