### PR TITLE
Housing counselor: Fix heading

### DIFF
--- a/cfgov/housing_counselor/jinja2/housing_counselor/improved_index.html
+++ b/cfgov/housing_counselor/jinja2/housing_counselor/improved_index.html
@@ -247,7 +247,9 @@
                     <div class="block">
                         <div class="o-full-width-text-group">
                             <div class="m-full-width-text">
-                                <h3>Paperwork Reduction Act statement</h3>
+                                <h2 class="h3">
+                                    Paperwork Reduction Act statement
+                                </h2>
                                 <p class="block
                                           block__flush-top
                                           block__flush-bottom">


### PR DESCRIPTION
Fixes issue where heading level was skipped.

## Changes

- Changes h3 heading to h2 to fix heading order. 

## Testing

1. You can use the WAVE chrome plugin to see that "Paperwork Reduction Act statement"
