### PR TITLE
FilterableListControl: Removed unused selector logic

### DIFF
--- a/cfgov/unprocessed/js/organisms/FilterableListControls.js
+++ b/cfgov/unprocessed/js/organisms/FilterableListControls.js
@@ -170,33 +170,32 @@ function FilterableListControls( element ) {
     return msg || ERROR_MESSAGES.DEFAULT;
   }
 
-  /* eslint-disable complexity */
-  // TODO: Reduce complexity
   /**
-   * Validate the fields of our form.
+   * Get the text associated with a form field's label.
    * @param {HTMLNode} field A form field.
-   * @param {string} selector Selector used to retreive the dom element.
    * @param {boolean} isInGroup Flag used determine if field is in group.
    * @returns {string} The label of the field.
    */
-  function _getLabelText( field, selector, isInGroup ) {
+  function _getLabelText( field, isInGroup ) {
     let labelText = '';
     let labelDom;
 
-    if ( isInGroup && !selector ) {
+    if ( isInGroup ) {
       labelDom = getClosestElement( field, 'fieldset' );
-      if ( labelDom ) labelDom = labelDom.querySelector( 'legend' );
+      if ( labelDom ) {
+        labelDom = labelDom.querySelector( 'legend' );
+      }
     } else {
-      selector = selector ||
-                 'label[for="' + field.getAttribute( 'id' ) + '"]';
+      const selector = `label[for="${ field.getAttribute( 'id' ) }"]`;
       labelDom = _form.querySelector( selector );
     }
 
-    if ( labelDom ) labelText = labelDom.textContent.trim();
+    if ( labelDom ) {
+      labelText = labelDom.textContent.trim();
+    }
 
     return labelText;
   }
-  /* eslint-enable complexity */
 
   /**
    * Set the notification type, msg, and visibility.
@@ -298,7 +297,7 @@ function FilterableListControls( element ) {
     const validation = {
       field:  field,
       // TODO: Change layout of field groups to use fieldset.
-      label:  _getLabelText( field, '', false || isInGroup ),
+      label:  _getLabelText( field, false || isInGroup ),
       msg:    '',
       status: null
     };


### PR DESCRIPTION
`_getLabelText` method is used internally within the FilterableListControl organism and has an argument of `selector`, but it is unused. Since this method is internal, this logic can be removed.

## Removals

- `selector` argument from the FilterableListControl organism's `_getLabelText` method.

## Testing

1. `gulp clean && gulp build`
2. Filters, such as on http://localhost:8000/about-us/blog/, should work as before.
