### PR TITLE
Filters: fix incorrect multiselect initialization logic and remove unused macro

### DIFF
--- a/cfgov/jinja2/v1/_includes/organisms/filterable-list-controls.html
+++ b/cfgov/jinja2/v1/_includes/organisms/filterable-list-controls.html
@@ -33,13 +33,6 @@
     </li>
 {% endmacro %}
 
-{% macro _filter_option(label_text, value) %}
-    <option value="{{ value }}"
-            {{ 'selected' if is_filter_selected(label_text, value) else '' }}>
-        {{ label_text }}
-    </option>
-{% endmacro %}
-
 {% macro _render_filter_fields(controls, form) -%}
     {% if controls.title %}
         {% set field_id = 'title' %}

--- a/cfgov/unprocessed/js/organisms/FilterableListControls.js
+++ b/cfgov/unprocessed/js/organisms/FilterableListControls.js
@@ -64,8 +64,9 @@ function FilterableListControls( element ) {
     const _expandables = Expandable.init();
     _expandable = _expandables[0];
 
-    if ( _dom.classList.contains( 'o-filterable-list-controls' ) ) {
-      multiSelects.forEach( function( multiSelect ) {
+    // If Multiselects exist on the form, initialize them.
+    if ( multiSelects.length > 0 ) {
+      multiSelects.forEach( multiSelect => {
         multiSelect.addEventListener( 'expandBegin', function refresh() {
           window.setTimeout(
             _expandable.transition.expand.bind( _expandable.transition ),

--- a/cfgov/unprocessed/js/organisms/FilterableListControls.js
+++ b/cfgov/unprocessed/js/organisms/FilterableListControls.js
@@ -64,24 +64,22 @@ function FilterableListControls( element ) {
     const _expandables = Expandable.init();
     _expandable = _expandables[0];
 
-    // If Multiselects exist on the form, initialize them.
-    if ( multiSelects.length > 0 ) {
-      multiSelects.forEach( multiSelect => {
-        multiSelect.addEventListener( 'expandBegin', function refresh() {
-          window.setTimeout(
-            _expandable.transition.expand.bind( _expandable.transition ),
-            250
-          );
-        } );
-
-        multiSelect.addEventListener( 'expandEnd', function refresh() {
-          window.setTimeout(
-            _expandable.transition.expand.bind( _expandable.transition ),
-            250
-          );
-        } );
+    // If multiselects exist on the form, iterate over them.
+    multiSelects.forEach( multiSelect => {
+      multiSelect.addEventListener( 'expandBegin', function refresh() {
+        window.setTimeout(
+          _expandable.transition.expand.bind( _expandable.transition ),
+          250
+        );
       } );
-    }
+
+      multiSelect.addEventListener( 'expandEnd', function refresh() {
+        window.setTimeout(
+          _expandable.transition.expand.bind( _expandable.transition ),
+          250
+        );
+      } );
+    } );
 
     _notification = new Notification( _dom );
     _notification.init();

--- a/test/unit_tests/js/modules/util/atomic-helpers-spec.js
+++ b/test/unit_tests/js/modules/util/atomic-helpers-spec.js
@@ -63,6 +63,12 @@ describe( 'atomic-helpers', () => {
       expect( instArr ).toBeInstanceOf( Array );
       expect( instArr.length ).toBe( 2 );
     } );
+
+    it( 'should return an empty array if no instances found', () => {
+      const instArr = instantiateAll( `.missing-class`, Footer );
+      expect( instArr ).toBeInstanceOf( Array );
+      expect( instArr.length ).toBe( 0 );
+    } );
   } );
 
   describe( '.setInitFlag()', () => {

--- a/test/unit_tests/js/modules/util/atomic-helpers-spec.js
+++ b/test/unit_tests/js/modules/util/atomic-helpers-spec.js
@@ -65,7 +65,7 @@ describe( 'atomic-helpers', () => {
     } );
 
     it( 'should return an empty array if no instances found', () => {
-      const instArr = instantiateAll( `.missing-class`, Footer );
+      const instArr = instantiateAll( '.missing-class', Footer );
       expect( instArr ).toBeInstanceOf( Array );
       expect( instArr.length ).toBe( 0 );
     } );


### PR DESCRIPTION
Multiselect initialization was scoped inside `if ( _dom.classList.contains( 'o-filterable-list-controls' ) ) {`, however, the `checkDom` utility already checks this, so this will always evaluate to true. Instead the length of the initialized multiselects array should be checked, but in that case since the if statement encloses a forEach loop, we can just call the loop and if it's empty it won't run.

## Removals

- Unused `_filter_option` macro.
- Unneeded if statement.

## Changes

- Add test to `instantiateAll` that ensures it returns an empty array when nothing to initialize is found.

## Testing

1. `gulp clean && gulp build`
2. `gulp test:unit` passes.
2. http://localhost:8000/about-us/blog/ should work as before.
