### PR TITLE
Include highcharts directly

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9414,6 +9414,11 @@
         "minimalistic-assert": "1.0.1"
       }
     },
+    "highcharts": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/highcharts/-/highcharts-6.2.0.tgz",
+      "integrity": "sha512-A4E89MA+kto8giic7zyLU6ZxfXnVeCUlKOyzFsah3+n4BROx4bgonl92KIBtwLud/mIWir8ahqhuhe2by9LakQ=="
+    },
     "hmac-drbg": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -16,9 +16,9 @@
     "node": ">=8.5.0"
   },
   "dependencies": {
-    "autoprefixer": "8.6.5",
     "@babel/core": "7.1.6",
     "@babel/preset-env": "7.1.6",
+    "autoprefixer": "8.6.5",
     "babel-loader": "8.0.4",
     "cf-atomic-component": "2.0.0",
     "cf-buttons": "5.0.0",
@@ -52,6 +52,7 @@
     "gulp-replace": "1.0.0",
     "gulp-sourcemaps": "2.6.4",
     "gulp-uglify-es": "1.0.4",
+    "highcharts": "6.2.0",
     "less": "3.0.4",
     "lightbox2": "2.10.0",
     "lodash.throttle": "4.1.1",


### PR DESCRIPTION
## Changes

We already depend on highcharts transitively via cfpb-chart-builder. This PR just makes this dependency explicit which allows yarn & npm installs to generate `node_modules` with highcharts as a direct dependency (ie, `node_modules/highcharts` exists).

This allows us to [import highcharts directly](https://github.com/cfpb/cfpb-chart-builder/pull/156) in both npm and yarn.