### PR TITLE
Filterable Lists: Allow - or / as delimiter in date fields

### DIFF
--- a/cfgov/unprocessed/js/modules/util/validators.js
+++ b/cfgov/unprocessed/js/modules/util/validators.js
@@ -21,11 +21,22 @@ import * as typeCheckers from '../../modules/util/type-checkers';
 function date( field, currentStatus ) {
   const status = currentStatus || {};
 
-  /* Date regex matches date patterns allowed in cfgov/v1/forms.py FilterableDateField
-     https://regex101.com/r/JVKCf9/1 */
-  const dateRegex =
-    /^\d{4}$|^(?:\d{1}|\d{2})\/(?:\d{4}|\d{2})$|^(?:\d{1}|\d{2})\/(?:\d{1}|\d{2})\/(?:\d{4}|\d{2})$/;
-  if ( field.value && dateRegex.test( field.value ) === false ) {
+  /* Date regexes match the date patterns that are
+     allowed in cfgov/v1/forms.py FilterableDateField */
+
+  // https://regex101.com/r/M0ipdX/1
+  const yearRegex = /^\d{4}$/;
+  // https://regex101.com/r/PEa2se/1
+  const monthYearRegex = /^(?:\d{1}|\d{2})(?:\-|\/)(?:\d{4}|\d{2})$/;
+  // https://regex101.com/r/1SGTLF/1
+  const dayMonthYearRegex =
+    /^(?:\d{1}|\d{2})(?:\-|\/)(?:\d{1}|\d{2})(?:\-|\/)(?:\d{4}|\d{2})$/;
+
+  const inputIsValid = yearRegex.test( field.value ) ||
+    monthYearRegex.test( field.value ) ||
+    dayMonthYearRegex.test( field.value );
+
+  if ( field.value && !inputIsValid ) {
     status.msg = status.msg || '';
     status.msg += ERROR_MESSAGES.DATE.INVALID;
     status.date = false;

--- a/cfgov/v1/forms.py
+++ b/cfgov/v1/forms.py
@@ -20,9 +20,13 @@ class MultipleChoiceFieldNoValidation(forms.MultipleChoiceField):
 class FilterableDateField(forms.DateField):
     default_input_formats = (
         '%m/%d/%y',     # 10/25/16, 9/1/16
+        '%m-%d-%y',     # 10-25-16, 9-1-16
         '%m/%d/%Y',     # 10/25/2016, 9/1/2016
+        '%m-%d-%Y',     # 10-25-2016, 9-1-2016
         '%m/%Y',        # 10/2016, 7/2017
+        '%m-%Y',        # 10-2016, 7-2017
         '%m/%y',        # 10/16, 4/18
+        '%m-%y',        # 10-16, 4-18
         '%Y',           # 2016
     )
 

--- a/test/unit_tests/js/modules/util/validators-spec.js
+++ b/test/unit_tests/js/modules/util/validators-spec.js
@@ -2,6 +2,11 @@ import ERROR_MESSAGES from '../../../../../cfgov/unprocessed/js/config/error-mes
 import * as validators from '../../../../../cfgov/unprocessed/js/modules/util/validators.js';
 let testField;
 let returnedObject;
+const validDates = [ '1/22/2017', '11/4/09', '3-31-20', '1-1-1900',
+  '5/2018', '12/18', '05-2010', '1/17', '2016' ];
+
+const invalidDates = [ '305-20-2018', '8//2018', '90', '4/20000' ];
+
 
 describe( 'Validators', () => {
   describe( 'date field', () => {
@@ -16,26 +21,29 @@ describe( 'Validators', () => {
       expect( returnedObject ).toStrictEqual( {} );
     } );
 
-    it( 'should allow single digit for month', () => {
-      testField.value = '1/22/2017';
-      returnedObject = validators.date( testField );
-
-      expect( returnedObject ).toStrictEqual( {} );
-    } );
-
-    it( 'should allow single digit for day', () => {
-      testField.value = '11/2/2017';
-      returnedObject = validators.date( testField );
-
-      expect( returnedObject ).toStrictEqual( {} );
-    } );
-
     it( 'should return an error object for a malformed date', () => {
-      testField.value = '11-12-2007';
+      testField.value = '11.12.2007';
       returnedObject = validators.date( testField );
 
       expect( returnedObject['date'] ).toBe( false );
       expect( returnedObject['msg'] ).toBe( ERROR_MESSAGES.DATE.INVALID );
+    } );
+
+    it( 'should allow correctly formatted dates', () => {
+      for ( let i = 0, len = validDates.length; i < len; i++ ) {
+        testField.value = validDates[i];
+        returnedObject = validators.date( testField );
+        expect( returnedObject ).toStrictEqual( {} );
+      }
+    } );
+
+    it( 'should reject incorrectly formatted dates', () => {
+      for ( let i = 0, len = invalidDates.length; i < len; i++ ) {
+        testField.value = invalidDates[i];
+        returnedObject = validators.date( testField );
+        expect( returnedObject['date'] ).toBe( false );
+        expect( returnedObject['msg'] ).toBe( ERROR_MESSAGES.DATE.INVALID );
+      }
     } );
 
     it( 'should return an error object for a UTC date', () => {


### PR DESCRIPTION
Allow dashes or slashes as delimiter in date fields. This involved a minor refactor of front-end date validation to use shorter regexes, for readability and maintainability.

## Changes

- Allow dates with `/` or `-` (rather than just `/`) in the "to" and "from" filter fields in filterable lists.

## Testing

1. Running this branch, visit any filterable list. e.g. http://localhost:8000/about-us/newsroom/
2. Expand the filter controls, try putting several different date formats in the "to" and "from" date fields
    - Dates in these formats should not produce a "invalid date" error message: 1/22/2017, 11/4/09, 3-31-20, 1-1-1900, 5/2018, 12/18, 05-2010, 1/17, 2016
    - Date with these formats should prevent the form from submitting, and show a "invalid date" error message: 305-20-2018, 8//2018, 90, 4/20000

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist
No visual changes