### PR TITLE
Bumps chart builder to 5.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3679,9 +3679,9 @@
       }
     },
     "cfpb-chart-builder": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/cfpb-chart-builder/-/cfpb-chart-builder-5.0.0.tgz",
-      "integrity": "sha512-3kpMHckSx4a7WAqLoP1tUS4JoE15F9Fpd8JdHT0jW1gi1Fu+wox2wiZRX8rhfiNTU8pT5E8oV7xaHfjTAoD80Q==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/cfpb-chart-builder/-/cfpb-chart-builder-5.1.0.tgz",
+      "integrity": "sha512-ugiiTtwUCMir1akCex2dZxL7IsKknColuoizBNNse8V0l1Yvsa59nqUnyJRnJfz9tujPYiHvWvtZz21iixISbQ==",
       "requires": {
         "cf-core": "4.10.0",
         "cf-layout": "5.0.0",
@@ -3698,11 +3698,6 @@
             "normalize-css": "2.3.1",
             "normalize-legacy-addon": "0.1.0"
           }
-        },
-        "highcharts": {
-          "version": "6.2.0",
-          "resolved": "https://registry.npmjs.org/highcharts/-/highcharts-6.2.0.tgz",
-          "integrity": "sha512-A4E89MA+kto8giic7zyLU6ZxfXnVeCUlKOyzFsah3+n4BROx4bgonl92KIBtwLud/mIWir8ahqhuhe2by9LakQ=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "cf-pagination": "5.0.1",
     "cf-tables": "5.0.0",
     "cf-typography": "5.0.1",
-    "cfpb-chart-builder": "5.0.0",
+    "cfpb-chart-builder": "5.1.0",
     "del": "3.0.0",
     "elem-dataset": "1.1.1",
     "glob-all": "3.1.0",


### PR DESCRIPTION
## Changes

- Bumps chart builder to 5.1.0, giving us full yarn/npm compat via https://github.com/cfpb/cfpb-chart-builder/pull/156