### PR TITLE
[TDP] consolidate urls remove feature flags

### DIFF
--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -656,18 +656,6 @@ FLAGS = {
     # The release of the new Financial Coaching pages
     'FINANCIAL_COACHING': {},
 
-    # Teacher's Digital Platform Customer Review Tool
-    'TDP_CRTOOL': {'environment is': 'beta'},
-
-    # Teacher's Digital Platform Search Interface Tool
-    'TDP_SEARCH_INTERFACE': {'environment is': 'beta'},
-
-    # Teacher's Digital Platform Static Pages
-    'TDP_STATIC_PAGE': {'environment is': 'beta'},
-
-    # Teacher's Digital Platform Building Blocks Tool
-    'TDP_BB_TOOL': {'environment is': 'beta'},
-
     # Turbolinks is a JS library that speeds up page loads
     # https://github.com/turbolinks/turbolinks
     'TURBOLINKS': {},

--- a/cfgov/cfgov/urls.py
+++ b/cfgov/cfgov/urls.py
@@ -387,49 +387,11 @@ urlpatterns = [
                 r'^search/',
                 include('search.urls')),
 
-    flagged_wagtail_only_view(
-        'TDP_SEARCH_INTERFACE',
-        r'^practitioner-resources/youth-financial-education/teach/activities/',
-        'tdp_search'),
-
-    flagged_wagtail_only_view(
-        'TDP_STATIC_PAGE',
-        r'^practitioner-resources/youth-financial-education/teach/'),
-
-    flagged_wagtail_only_view(
-        'TDP_STATIC_PAGE',
-        r'^practitioner-resources/youth-financial-education/learn/'),
-
-    flagged_wagtail_only_view(
-        'TDP_STATIC_PAGE',
-        r'practitioner-resources/youth-financial-education2/'),
-
-    flagged_wagtail_only_view(
-        'TDP_STATIC_PAGE',
-        r'^practitioner-resources/youth-financial-education/glossary-financial-terms/'),  # noqa: E501
-
-    flagged_wagtail_only_view(
-        'TDP_STATIC_PAGE',
-        r'^practitioner-resources/youth-financial-education/resources-research/'),  # noqa: E501
-
-    flagged_url('TDP_CRTOOL',
-        r'^practitioner-resources/youth-financial-education/curriculum-review/tool/',  # noqa: E501
+    url(
+        r'^practitioner-resources/youth-financial-education/',
         include_if_app_enabled('teachers_digital_platform',
-                               'teachers_digital_platform.tool_urls')),
-
-    flagged_url('TDP_CRTOOL',
-        r'^practitioner-resources/youth-financial-education/curriculum-review/before-you-begin/',  # noqa: E501
-        include_if_app_enabled('teachers_digital_platform',
-                                'teachers_digital_platform.begin_urls')),
-
-    flagged_wagtail_only_view(
-        'TDP_CRTOOL',
-        r'^practitioner-resources/youth-financial-education/curriculum-review/$'),  # noqa: E501
-
-    flagged_url('TDP_BB_TOOL',
-        r'^practitioner-resources/youth-financial-education/journey',  # noqa: E501
-        include_if_app_enabled('teachers_digital_platform',
-                                    'teachers_digital_platform.bb_urls')),
+                               'teachers_digital_platform.urls')
+    ),
 
     url(
         r'^regulations3k-service-worker.js',

--- a/requirements/optional-public.txt
+++ b/requirements/optional-public.txt
@@ -4,4 +4,4 @@ https://github.com/cfpb/retirement/releases/download/0.7.5/retirement-0.7.5-py2-
 https://github.com/cfpb/ccdb5-api/releases/download/1.1.5/ccdb5_api-1.1.5-py2-none-any.whl
 https://github.com/cfpb/ccdb5-ui/releases/download/1.1.0/ccdb5_ui-1.1.0-py2-none-any.whl
 https://github.com/cfpb/django-college-costs-comparison/releases/download/1.8.0/comparisontool-1.8.0-py2-none-any.whl
-https://github.com/cfpb/teachers-digital-platform/releases/download/1.0.26/teachers_digital_platform-1.0.26-py2-none-any.whl
+https://github.com/cfpb/teachers-digital-platform/releases/download/1.0.27/teachers_digital_platform-1.0.27-py2-none-any.whl


### PR DESCRIPTION
Step one of two for consolidating TDP URL files and removing TDP feature flags.

## Removals

- TDP related feature flags have been removed

## Changes

- Started the process of consolidating the TDP URL files. Once this branch is merged into master,
I can go back and remove the extraneous bb_url, begin_url, and tool_url files.
- Bumped the version of TDP to 1.0.27

## Testing

All the following URLs should continue working as expected.
 
practitioner-resources/youth-financial-education/learn/
practitioner-resources/youth-financial-education/teach/
practitioner-resources/youth-financial-education/teach/activities/
practitioner-resources/youth-financial-education/glossary/
practitioner-resources/youth-financial-education/resources-research/
practitioner-resources/youth-financial-education/curriculum-review/
practitioner-resources/youth-financial-education/curriculum-review/tool/
practitioner-resources/youth-financial-education/curriculum-review/before-you-begin/
practitioner-resources/youth-financial-education/journey

## Reviewers

@Scotchester @willbarton @chosak  @higs4281 
