### PR TITLE
Fix imports on Spanish page and external site page

### DIFF
--- a/cfgov/unprocessed/js/routes/es/obtener-respuestas/single.js
+++ b/cfgov/unprocessed/js/routes/es/obtener-respuestas/single.js
@@ -1,6 +1,6 @@
 require( '../../on-demand/feedback-form' );
 require( '../../on-demand/ask-autocomplete' );
-const Analytics = require( '../../../modules/Analytics' );
+import Analytics from '../../../modules/Analytics';
 
 const analyticsDataEl = document.querySelector( '.analytics-data' );
 

--- a/cfgov/unprocessed/js/routes/external-site/index.js
+++ b/cfgov/unprocessed/js/routes/external-site/index.js
@@ -2,7 +2,6 @@
    Scripts for `/external-site/`.
    ========================================================================== */
 
-
-const ExternalSite = require( '../../modules/ExternalSite.js' );
+import ExternalSite from '../../modules/ExternalSite';
 const externalSite = new ExternalSite( document.querySelector( '.external-site_container' ) );
 externalSite.init();


### PR DESCRIPTION
https://github.com/cfpb/cfgov-refresh/pull/4635 missed converting these imports, which are showing up as errors in New Relic.

## Changes

- Convert `require` to `import` in Analytics modules.
- Convert `require` to `import` in ExternalSite module.

## Testing

1. Pull the branch down and `gulp clean && gulp build`
2. http://localhost:8000/es/obtener-respuestas/como-puedo-recuperar-mi-dinero-despues-de-descubrir-una-transaccion-no-autorizada-o-la-falta-de-dinero-de-mi-cuenta-bancaria-es-1017/ should have no errors related to addEventListener.
3. Visit http://localhost:8000/policy-compliance/rulemaking/regulations/ and click "introduction to regulations" and see that it goes to the external site page and counts down and redirects correctly without error.
