### PR TITLE
Housing counselor: Check for missing data

### DIFF
--- a/cfgov/housing_counselor/jinja2/housing_counselor/improved_index.html
+++ b/cfgov/housing_counselor/jinja2/housing_counselor/improved_index.html
@@ -207,17 +207,28 @@
                                                 {{ counselor.city }}, {{ counselor.statecd }} {{ counselor.zipcd }}
                                             </p>
                                             <p>
+                                                {% if counselor.weburl %}
                                                 <b>Website:</b>
                                                 <a class="a-link a-link__icon" href="{{ counselor.weburl }}">
                                                     <span class="a-link_text">{{ counselor.weburl }}</span>
                                                     {{ svg_icon( 'external-link' ) }}
                                                 </a>
                                                 <br>
+                                                {% endif %}
+
+                                                {% if counselor.phone1 %}
                                                 <b>Phone:</b> {{ counselor.phone1 }}
                                                 <br>
+                                                {% endif %}
+
+                                                {% if counselor.email %}
                                                 <b>Email Address:</b> {{ counselor.email }}
                                                 <br>
+                                                {% endif %}
+
+                                                {% if counselor.languages %}
                                                 <b>Languages:</b> {{ counselor.languages | join( ', ' ) }}
+                                                {% endif %}
                                             </p>
                                         </div>
                                     </td>


### PR DESCRIPTION
Fixes [GHE]/CFGOV/platform/issues/3188

## Changes

- Check for existence of data in the results before displaying website, phone, email, and languages entries.

## Testing

1. Visit https://www.consumerfinance.gov/find-a-housing-counselor/?zipcode=12047 and see that website and email list "None" for some results.
2. Pull this branch and visit http://localhost:8000/find-a-housing-counselor/?zipcode=12047 and see that website and emails that are "None" do not show in the results list.

## Screenshots

### Before

<img width="574" alt="screen shot 2018-12-11 at 9 31 02 am" src="https://user-images.githubusercontent.com/704760/49807255-9b8c1180-fd27-11e8-8864-975aa8dedd28.png">

### After

<img width="603" alt="screen shot 2018-12-11 at 9 30 40 am" src="https://user-images.githubusercontent.com/704760/49807265-a050c580-fd27-11e8-8dd0-0ae5c10a7dbc.png">

## Note

I didn't see any results with missing languages, but that block contains some logic that expects an array so probably best to check that it exists.