### PR TITLE
Bump Django-Flags to 4.0.3

### DIFF
--- a/requirements/libraries.txt
+++ b/requirements/libraries.txt
@@ -5,7 +5,7 @@ dj-database-url==0.5.0
 djangorestframework==3.6.4
 django-csp==3.4
 django-extensions==2.1.3
-django-flags==4.0.2
+django-flags==4.0.3
 django-haystack==2.7.0
 django-localflavor==1.6.2
 # django-mptt is required by teachers-digital-platform


### PR DESCRIPTION
This release of Django-Flags fixes a problem where `ProgrammingError`s and `OperationalErrors` could occur during the Django system checks when Django-Flags migrations hadn't been run yet (including when trying to run them for the first time).

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
