### PR TITLE
Filterable Lists: Improved date filter behavior

### DIFF
--- a/cfgov/v1/forms.py
+++ b/cfgov/v1/forms.py
@@ -1,4 +1,5 @@
 from collections import Counter
+from datetime import date
 
 from django import forms
 from django.db.models import Q
@@ -59,10 +60,6 @@ class FilterableToDateField(FilterableDateField):
         self.default_widget_attrs['class'] += ' js-filter_range-date__lte'
         super(FilterableToDateField, self).__init__(*args, **kwargs)
 
-    def to_python(self, value):
-        generated_date = super(FilterableToDateField, self).to_python(value)
-        return end_of_time_period(value, generated_date)
-
 
 class FilterableListForm(forms.Form):
     title_attrs = {
@@ -99,6 +96,7 @@ class FilterableListForm(forms.Form):
         choices=[],
         widget=widgets.SelectMultiple(attrs=authors_select_attrs)
     )
+    preferred_datetime_format = '%m/%d/%Y'
 
     def __init__(self, *args, **kwargs):
         self.filterable_pages = kwargs.pop('filterable_pages')
@@ -115,6 +113,10 @@ class FilterableListForm(forms.Form):
         return self.filterable_pages.filter(query).distinct().order_by(
             '-date_published'
         )
+
+    def first_page_date(self):
+        first_post = self.filterable_pages.order_by('date_published').first()
+        return first_post.date_published
 
     def prepare_options(self, arr):
         """
@@ -151,10 +153,18 @@ class FilterableListForm(forms.Form):
 
     def clean(self):
         cleaned_data = super(FilterableListForm, self).clean()
+        if self.errors.get('from_date') or self.errors.get('to_date'):
+            return cleaned_data
+        else:
+            ordered_dates = self.order_from_and_to_date_filters(cleaned_data)
+            transformed_dates = self.set_interpreted_date_values(ordered_dates)
+            return transformed_dates
+
+    def order_from_and_to_date_filters(self, cleaned_data):
         from_date = cleaned_data.get('from_date')
         to_date = cleaned_data.get('to_date')
-        # Check if both date_lte and date_gte are present
-        # If the 'start' date is after the 'end' date, swap them
+        # Check if both date_lte and date_gte are present.
+        # If the 'start' date is after the 'end' date, swap them.
         if (from_date and to_date) and to_date < from_date:
             data = dict(self.data)
             data_to_date = data['to_date']
@@ -164,6 +174,38 @@ class FilterableListForm(forms.Form):
                 to_date, data_to_date
             self.data = data
         return self.cleaned_data
+
+    def set_interpreted_date_values(self, cleaned_data):
+        from_date = cleaned_data.get('from_date')
+        to_date = cleaned_data.get('to_date')
+        # If from_ or to_ is filled in, fill them both with sensible values.
+        # If neither is filled in, leave them both blank.
+        if from_date or to_date:
+            if from_date:
+                self.data['from_date'] = date.strftime(
+                    cleaned_data['from_date'], self.preferred_datetime_format)
+            else:
+                # If there's a 'to_date' and no 'from_date',
+                #  use date of earliest possible filter result as 'from_date'.
+                earliest_results = self.first_page_date()
+                cleaned_data['from_date'] = earliest_results
+                self.data['from_date'] = date.strftime(
+                    earliest_results, self.preferred_datetime_format)
+
+            if to_date:
+                transformed_to_date = end_of_time_period(
+                    self.data['to_date'], cleaned_data['to_date'])
+                cleaned_data['to_date'] = transformed_to_date
+                self.data['to_date'] = date.strftime(
+                    transformed_to_date, self.preferred_datetime_format)
+            else:
+                # If there's a 'from_date' but no 'to_date', use today's date.
+                today = date.today()
+                cleaned_data['to_date'] = today
+                self.data['to_date'] = date.strftime(
+                    today, self.preferred_datetime_format)
+
+        return cleaned_data
 
     # Does the job of {{ field }}
     # In the template, you pass the field and the id and name you'd like to

--- a/cfgov/v1/forms.py
+++ b/cfgov/v1/forms.py
@@ -8,6 +8,7 @@ from taggit.models import Tag
 
 from v1.util import ERROR_MESSAGES, ref
 from v1.util.categories import clean_categories
+from v1.util.date_filter import end_of_time_period
 
 from .models.base import Feedback
 
@@ -57,6 +58,10 @@ class FilterableToDateField(FilterableDateField):
     def __init__(self, *args, **kwargs):
         self.default_widget_attrs['class'] += ' js-filter_range-date__lte'
         super(FilterableToDateField, self).__init__(*args, **kwargs)
+
+    def to_python(self, value):
+        generated_date = super(FilterableToDateField, self).to_python(value)
+        return end_of_time_period(value, generated_date)
 
 
 class FilterableListForm(forms.Form):

--- a/cfgov/v1/tests/test_forms.py
+++ b/cfgov/v1/tests/test_forms.py
@@ -33,42 +33,70 @@ class TestFilterableListForm(TestCase):
     @mock.patch('__builtin__.super')
     def test_clean_returns_cleaned_data_if_valid(self, mock_super, mock_init):
         mock_init.return_value = None
-        from_date = datetime.date.today()
+        from_date = datetime.date(2017, 7, 4)
         to_date = from_date + datetime.timedelta(days=1)
+        form_data = {'from_date': from_date, 'to_date': to_date}
 
         form = FilterableListForm()
-        mock_super().clean.return_value = {'from_date': from_date, 'to_date': to_date}
-        form.cleaned_data = {'from_date': from_date, 'to_date': to_date}
+        mock_super().clean.return_value = form_data
+        form.cleaned_data = form_data
+        form.data = {'from_date': '7/4/2017', 'to_date': '7/5/2017'}
+        form._errors = {}
 
         result = form.clean()
         assert result['from_date'] == from_date
+        assert result['to_date'] == to_date
+
+    @mock.patch('v1.forms.FilterableListForm.first_page_date')
+    @mock.patch('v1.forms.FilterableListForm.__init__')
+    @mock.patch('__builtin__.super')
+    def test_clean_uses_earliest_result_if_fromdate_field_is_empty(self, mock_super, mock_init, mock_pub_date):
+        mock_init.return_value = None
+        from_date = None
+        to_date = datetime.date(2017, 1, 15)
+        form_data = {'from_date': from_date, 'to_date': to_date}
+
+        form = FilterableListForm()
+        mock_super().clean.return_value = form_data
+        form.cleaned_data = form_data
+        form.data = {'to_date': '1-15-2017'}
+        form._errors = {}
+        mock_pub_date.return_value = datetime.date(1995, 1, 1)
+
+        result = form.clean()
+        assert result['from_date'] == datetime.date(1995, 1, 1)
         assert result['to_date'] == to_date
 
     @mock.patch('v1.forms.FilterableListForm.__init__')
     @mock.patch('__builtin__.super')
-    def test_clean_returns_cleaned_data_if_only_one_date_field_is_empty(self, mock_super, mock_init):
+    def test_clean_uses_today_if_todate_field_is_empty(self, mock_super, mock_init):
         mock_init.return_value = None
-        from_date = datetime.date.today()
-        to_date = ''
+        from_date = datetime.date(2016, 5, 15)
+        to_date = None
+        form_data = {'from_date': from_date, 'to_date': to_date}
 
         form = FilterableListForm()
-        mock_super().clean.return_value = {'from_date': from_date, 'to_date': to_date}
-        form.cleaned_data = {'from_date': from_date, 'to_date': to_date}
+        mock_super().clean.return_value = form_data
+        form.cleaned_data = form_data
+        form.data = {'from_date': '5-15-2016'}
+        form._errors = {}
 
         result = form.clean()
         assert result['from_date'] == from_date
-        assert result['to_date'] == to_date
+        assert result['to_date'] == datetime.date.today()
 
     @mock.patch('v1.forms.FilterableListForm.__init__')
     @mock.patch('__builtin__.super')
     def test_clean_returns_cleaned_data_if_both_date_fields_are_empty(self, mock_super, mock_init):
         mock_init.return_value = None
-        from_date = ''
-        to_date = ''
+        from_date = None
+        to_date = None
 
         form = FilterableListForm()
         mock_super().clean.return_value = {'from_date': from_date, 'to_date': to_date}
         form.cleaned_data = {'from_date': from_date, 'to_date': to_date}
+        form.data = {}
+        form._errors = {}
 
         result = form.clean()
         assert result['from_date'] == from_date
@@ -79,13 +107,14 @@ class TestFilterableListForm(TestCase):
     @mock.patch('__builtin__.super')
     def test_clean_switches_date_fields_if_todate_is_less_than_fromdate(self, mock_super, mock_init):
         mock_init.return_value = None
-        to_date = datetime.date.today()
+        to_date = datetime.date(2000, 3, 15)
         from_date = to_date + datetime.timedelta(days=1)
 
         form = FilterableListForm()
         mock_super().clean.return_value = {'from_date': from_date, 'to_date': to_date}
         form.cleaned_data = {'from_date': from_date, 'to_date': to_date}
-        form.data = {'from_date': from_date, 'to_date': to_date}
+        form.data = {'from_date': '3/16/2000', 'to_date': '3/15/2000'}
+        form._errors = {}
 
         result = form.clean()
         assert result['from_date'] == to_date

--- a/cfgov/v1/tests/util/test_date_filter.py
+++ b/cfgov/v1/tests/util/test_date_filter.py
@@ -1,0 +1,91 @@
+from datetime import date
+
+from django.test import TestCase
+
+from v1.util import date_filter
+
+
+class TestDateFilter(TestCase):
+    # end_of_time_period specs
+    def test_end_of_time_period_returns_same_full_date(self):
+        user_input = '4/29/2016'
+        date_input = date(2016, 4, 29)
+        result = date_filter.end_of_time_period(user_input, date_input)
+        expected = date(2016, 4, 29)
+        self.assertEqual(result, expected)
+
+    def test_end_of_time_period_returns_end_of_month_for_month_year_input(self):
+        user_input = '11/2016'
+        date_input = date(2016, 11, 1)
+        result = date_filter.end_of_time_period(user_input, date_input)
+        expected = date(2016, 11, 30)
+        self.assertEqual(result, expected)
+
+    def test_end_of_time_period_returns_end_of_year_for_year_input(self):
+        user_input = '2016'
+        date_input = date(2016, 3, 2)
+        result = date_filter.end_of_time_period(user_input, date_input)
+        expected = date(2016, 12, 31)
+        self.assertEqual(result, expected)
+
+    # end_of_year specs
+    def test_end_of_year_returns_dec_31(self):
+        input_date = date(1998, 1, 1)
+        expected_result = date(1998, 12, 31)
+        self.assertEqual(date_filter.end_of_year(input_date), expected_result)
+
+    def test_end_of_year_returns_dec_31_given_year(self):
+        input_date = date(2017, 3, 25)
+        expected_result = date(2017, 12, 31)
+        self.assertEqual(date_filter.end_of_year(input_date), expected_result)
+
+    # end_of_month specs
+    def test_end_of_month_returns_31_of_long_months(self):
+        input_date = date(2017, 3, 25)
+        expected_result = date(2017, 3, 31)
+        self.assertEqual(date_filter.end_of_month(input_date), expected_result)
+
+    def test_end_of_month_returns_end_of_shorter_month(self):
+        input_date = date(2019, 4, 25)
+        expected_result = date(2019, 4, 30)
+        self.assertEqual(date_filter.end_of_month(input_date), expected_result)
+
+    def test_end_of_month_handles_leap_day(self):
+        input_date = date(2000, 2, 1)
+        expected_result = date(2000, 2, 29)
+        self.assertEqual(date_filter.end_of_month(input_date), expected_result)
+
+    def test_end_of_month_handles_december(self):
+        input_date = date(2019, 12, 29)
+        expected_result = date(2019, 12, 31)
+        self.assertEqual(date_filter.end_of_month(input_date), expected_result)
+
+    # date_from_format specs
+    def test_date_from_pattern_returns_date_for_match(self):
+        result = date_filter.date_from_pattern(
+            '7/4/1776',
+            '%m/%d/%Y')
+        self.assertEqual(result, date(1776, 7, 4))
+
+    def test_date_from_pattern_returns_None_for_no_match(self):
+        result = date_filter.date_from_pattern(
+            '2016-5-12',
+            '%m/%d/%Y')
+        self.assertIsNone(result)
+
+    # determine_date_specificity specs
+    def test_determine_date_specificity_returns_month_year_style(self):
+        result = date_filter.determine_date_specificity('12/2017')
+        self.assertEqual(result, 'month_year')
+
+    def test_determine_date_specificity_returns_year_style(self):
+        result = date_filter.determine_date_specificity('2017')
+        self.assertEqual(result, 'year')
+
+    def test_determine_date_specificity_returns_full_date_style(self):
+        result = date_filter.determine_date_specificity('12/31/2017')
+        self.assertEqual(result, 'full')
+
+    def test_determine_date_specificity_returns_none_for_no_match(self):
+        result = date_filter.determine_date_specificity('12.31.2017')
+        self.assertEqual(result, None)

--- a/cfgov/v1/util/date_filter.py
+++ b/cfgov/v1/util/date_filter.py
@@ -1,0 +1,74 @@
+from datetime import date, datetime
+
+from dateutil.relativedelta import relativedelta
+
+
+# For more information on date formatting, see the python documentation here:
+# https://docs.python.org/2/library/datetime.html#strftime-and-strptime-behavior
+
+full_date_patterns = (
+    '%m/%d/%Y',     # 10/25/2016, 9/1/2016
+    '%m-%d-%Y',     # 10-25-2016, 9-1-2016
+    '%m/%d/%y',     # 10/25/16, 9/1/16
+    '%m-%d-%y',     # 10-25-16, 9-1-16
+)
+
+month_year_date_patterns = (
+    '%m/%Y',        # 10/2016, 7/2017
+    '%m-%Y',        # 10-2016, 7-2017
+    '%m/%y',        # 10/16, 4/18
+    '%m-%y',        # 10-16, 4-18
+)
+
+year_date_patterns = (
+    '%Y',           # 2016
+)
+
+
+def end_of_time_period(user_input, generated_date):
+    specificity = determine_date_specificity(user_input)
+    if specificity == 'full':
+        return generated_date
+    elif specificity == 'month_year':
+        return end_of_month(generated_date)
+    elif specificity == 'year':
+        return end_of_year(generated_date)
+    else:
+        return None
+
+
+def end_of_year(input_date):
+    year = input_date.year
+    end_date = date(year, 12, 31)
+    return end_date
+
+
+def end_of_month(input_date):
+    return input_date + relativedelta(day=31)
+
+
+def determine_date_specificity(user_input):
+    for pattern in full_date_patterns:
+        maybe_date = date_from_pattern(user_input, pattern)
+        if maybe_date is not None:
+            return 'full'
+
+    for pattern in month_year_date_patterns:
+        maybe_date = date_from_pattern(user_input, pattern)
+        if maybe_date is not None:
+            return 'month_year'
+
+    for pattern in year_date_patterns:
+        maybe_date = date_from_pattern(user_input, pattern)
+        if maybe_date is not None:
+            return 'year'
+
+    return None
+
+
+def date_from_pattern(date_str, pattern):
+    try:
+        date = datetime.strptime(date_str, pattern).date()
+        return date
+    except (ValueError, TypeError):
+        return None


### PR DESCRIPTION
Improve the user experience of the date filters on Filterable Lists pages by making the behavior more transparent and intuitive.
  - When the user enters an ambiguous date (e.g. "2017" or "6/18" instead of a full date), show what we've interpreted the date as by replacing their input in the form with the full date.
  - When the user enters an ambiguous date in the "from" field, interpret it as the beginning of the time period (e.g. "1/1/2017" or "6/1/2018" respectively)
  - When the user enters an ambiguous date in the "to" field, interpret it as the end of the time perod (e.g. "12/31/2018" or "6/30/2018" respectively)
  - When the user leaves the "from" field blank (but fills in the "to" field), use the publication date of the earliest possible search result as the "from".
  - When the user leaves the "to" field blank (but fills in the "from" field), use today's date as the "to".


## Additions

- A module to find ambiguous dates and translate them to the end of their respective time periods (and tests for this module)
- Code to replace the user's input in the form with unambiguous interpreted dates (and tests for the form behavior)

## Changes

- Instead of relying on python's default `date.strptime` behavior (which is to interpret an ambiguous date as the beginning of the time period) in the "to" field of the filters, use custom code to interpret it instead
- Instead of relying on django's default form behavior (which is to leave a user's input unchanged when re-rendering a form) in the date fields of the Filterable Lists, use custom code to replace the user's input with fully-specified dates.

## Testing

1. Running this branch, visit any filterable list, e.g.:
    - http://localhost:8000/policy-compliance/rulemaking/final-rules/
    - http://localhost:8000/about-us/newsroom/
    - https://localhost:8000/foia-requests/foia-electronic-reading-room/
2. Try several combinations of "from" and "to" dates, including
    - just a year ("2017")
    - month and year ("10/2018")
    - full date ("3/15/2011")
    - "to" and not "from"
    - "from" and not "to"
3. Ensure the behavior matches what's described at the top of this PR

For more information, ask me. I can point you to the ticket that describes the design in more detail. Also, this branch is deployed on a dev server, and I can point you to the running code.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Internet Explorer 8, 9, 10, and 11
- [ ] Edge
- [ ] iOS Safari
- [ ] Chrome for Android

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing