### PR TITLE
Deploy docs on all builds on master instead of just tagged releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,6 +54,7 @@ jobs:
         - RUNTEST=backend
         - TEST_RUNNER=cfgov.test.StdoutCapturingTestRunner
     - stage: Docs Deploy
+      if: type != pull_request
       env: RUNTEST=docs
       deploy:
         provider: pages

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,6 @@ install:
 branches:
   only:
     - master
-    - /^\d+\.\d+(\.\d+)?(-\S*)?$/
 
 before_script:
   - psql -c "ALTER USER travis WITH PASSWORD 'travis';"
@@ -55,7 +54,6 @@ jobs:
         - RUNTEST=backend
         - TEST_RUNNER=cfgov.test.StdoutCapturingTestRunner
     - stage: Docs Deploy
-      if: tag IS present
       env: RUNTEST=docs
       deploy:
         provider: pages


### PR DESCRIPTION
Instead of just limiting the docs to deploy when we do a release to production, we want the docs to be in sync with the latest codebase on master. Anytime someone PRs then merges to master a documentation change, the doc site will deploy those changes.

## Additions

- add condition to docs deployment to only run if the build is not triggered by a pull request. this is so the docs don't deploy when pull requests are created! but they should when master branch build is triggered.

## Removals

- builds on tagged releases (the regex) - with this change, Travis builds will run on the master branch only when Travis Setting "Build pushed branches" is on. Pushes to other branches should not trigger Travis builds. Since yesterday this is true for master AND tags. With this PR, it will only be true for master.
- limiting doc deployment to condition of tag present only - [this change](https://github.com/cfpb/cfgov-refresh/commit/ee28288b71aed0cc3f29636856f450d755baca34) is what seems to have broken the docs build along with a later decision to turn off "Build pushed branches" on Travis to improve speed of Travis tests. 

## Changes

-

## Testing

1.

## Screenshots


## Notes

-

## Todos

- after this PR, we will test that the Travis builds on master are deploying the latest documentation changes to gh-pages as expected.
- a future PR will attempt to limit Travis builds on master to only deploying the docs and not running our tests, to improve Travis speed for pull requests

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Internet Explorer 8, 9, 10, and 11
- [ ] Edge
- [ ] iOS Safari
- [ ] Chrome for Android

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
