### PR TITLE
Bump ccdb5-api version to 1.1.7

### DIFF
--- a/requirements/optional-public.txt
+++ b/requirements/optional-public.txt
@@ -1,7 +1,7 @@
 https://github.com/cfpb/college-costs/releases/download/2.4.3/college_costs-2.4.3-py2-none-any.whl
 https://github.com/cfpb/owning-a-home-api/releases/download/0.11.3/owning_a_home_api-0.11.3-py2-none-any.whl
 https://github.com/cfpb/retirement/releases/download/0.7.5/retirement-0.7.5-py2-none-any.whl
-https://github.com/cfpb/ccdb5-api/releases/download/v1.1.6/ccdb5_api-1.1.6-py2-none-any.whl
+https://github.com/cfpb/ccdb5-api/releases/download/v1.1.7/ccdb5_api-1.1.7-py2-none-any.whl
 https://github.com/cfpb/ccdb5-ui/releases/download/1.1.0/ccdb5_ui-1.1.0-py2-none-any.whl
 https://github.com/cfpb/django-college-costs-comparison/releases/download/1.8.0/comparisontool-1.8.0-py2-none-any.whl
 https://github.com/cfpb/teachers-digital-platform/releases/download/1.0.27/teachers_digital_platform-1.0.27-py2-none-any.whl


### PR DESCRIPTION
Updating the version of satellite app `ccdb5-api` to version 1.1.7

## Changes

- Updated version in `optional-public.txt`

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Internet Explorer 8, 9, 10, and 11
- [ ] Edge
- [ ] iOS Safari
- [ ] Chrome for Android

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
