### PR TITLE
Fix URL encoding in email share

### DIFF
--- a/cfgov/jinja2/v1/_includes/molecules/social-media.html
+++ b/cfgov/jinja2/v1/_includes/molecules/social-media.html
@@ -52,7 +52,7 @@
 {% set is_share_view = value.is_share_view | default( true ) %}
 {% set email_title = value.email_title or blurb %}
 {% set email_text = value.email_text or 'Check out this page from the CFPB - ' %}
-{% set email_signature = '%0A%0A' + value.email_signature if value.email_signature else '' %}
+{% set email_signature = ' ' + value.email_signature if value.email_signature else '' %}
 {% set email_share_url = 'mailto:?subject=' ~ email_title | urlencode ~ '&body=' ~ email_text | urlencode ~ '%20' ~ parsed_url ~ email_signature | urlencode %}
 
 {% set linkedin_title = ( value.linkedin_title or blurb ) | urlencode %}


### PR DESCRIPTION
Fixes [GHE]/CFGOV/platform/issues/3196

## Removals

- Converts urlencoded spaces `%0A%0A` to actual spaces. They get urlencoded further on at https://github.com/cfpb/cfgov-refresh/blob/master/cfgov/jinja2/v1/_includes/molecules/social-media.html#L56

## Testing

1. Visit https://consumerfinance.gov/find-a-housing-counselor/ and click the share via email link at the bottom and check the email that's produced. There will be `%0A%0A` at the end of the URL in the email body.
2. Pull this branch and visit http://localhost:8000/find-a-housing-counselor/ and click the share via email link at the bottom and check the email that's produced. There will be no urlencoded things in the email body.
 
## Screenshots

Before:
<img width="827" alt="screen shot 2018-12-12 at 10 15 32 am" src="https://user-images.githubusercontent.com/704760/49879417-ed03d180-fdf7-11e8-833c-f67ff22549cc.png">

After:
<img width="834" alt="screen shot 2018-12-12 at 10 23 25 am" src="https://user-images.githubusercontent.com/704760/49879456-0573ec00-fdf8-11e8-8cd6-e7a280e6fc21.png">

