### PR TITLE
Bump retirement app to 0.7.6

### DIFF
--- a/requirements/optional-public.txt
+++ b/requirements/optional-public.txt
@@ -1,6 +1,6 @@
 https://github.com/cfpb/college-costs/releases/download/2.4.3/college_costs-2.4.3-py2-none-any.whl
 https://github.com/cfpb/owning-a-home-api/releases/download/0.11.3/owning_a_home_api-0.11.3-py2-none-any.whl
-https://github.com/cfpb/retirement/releases/download/0.7.5/retirement-0.7.5-py2-none-any.whl
+https://github.com/cfpb/retirement/releases/download/0.7.6/retirement-0.7.6-py2-none-any.whl
 https://github.com/cfpb/ccdb5-api/releases/download/v1.1.7/ccdb5_api-1.1.7-py2-none-any.whl
 https://github.com/cfpb/ccdb5-ui/releases/download/1.1.0/ccdb5_ui-1.1.0-py2-none-any.whl
 https://github.com/cfpb/django-college-costs-comparison/releases/download/1.8.0/comparisontool-1.8.0-py2-none-any.whl


### PR DESCRIPTION
## Changes

- Bumps retirement app to 0.7.6 to remove unused Capital Framework dependencies.
