### PR TITLE
Fix exports error in financial well-being

### DIFF
--- a/cfgov/unprocessed/apps/financial-well-being/js/fwb-questions.js
+++ b/cfgov/unprocessed/apps/financial-well-being/js/fwb-questions.js
@@ -169,4 +169,4 @@ function init() {
   setUpData();
 }
 
-module.exports = { init: init };
+export { init };

--- a/cfgov/unprocessed/js/routes/consumer-tools/financial-well-being/index.js
+++ b/cfgov/unprocessed/js/routes/consumer-tools/financial-well-being/index.js
@@ -1,7 +1,7 @@
-const fwbQuestions = require(
-  '../../../../apps/financial-well-being/js/fwb-questions'
-);
+import * as fwbQuestions from '../../../../apps/financial-well-being/js/fwb-questions';
 
+/* TODO: This eventlistener may not be necessary and should probably be removed
+after it fires. */
 window.addEventListener( 'load', function() {
   fwbQuestions.init();
 } );

--- a/cfgov/unprocessed/js/routes/consumer-tools/financial-well-being/results/index.js
+++ b/cfgov/unprocessed/js/routes/consumer-tools/financial-well-being/results/index.js
@@ -1,5 +1,3 @@
-const fwbResults = require(
-  '../../../../../apps/financial-well-being/js/fwb-results'
-);
+import * as fwbResults from '../../../../../apps/financial-well-being/js/fwb-results';
 
 fwbResults.init();


### PR DESCRIPTION
Missed in https://github.com/cfpb/cfgov-refresh/pull/4635

## Changes

- Converts missed financial well-being exports to es6 modules.

## Testing

1. `gulp clean && gulp build` and visit http://localhost:8000/consumer-tools/financial-well-being/
and see that there is not a `'exports' of object '#<Object>'` error in the dev console.
