### PR TITLE
Add "Edit on GitHub" link to docs

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,4 +1,7 @@
 site_name: cfgov-refresh
+
+repo_url: https://github.com/cfpb/cfgov-refresh
+
 nav:
 - Introduction: index.md
 - Installation: installation.md


### PR DESCRIPTION
As a followup to #4688, this adds an "Edit on GitHub" link to the documentation to make it easier for people to maintain this documentation.

## Testing

1. `pip install -r requirements/docs.txt`
2. `mkdocs serve`
3. http://localhost:8000/

## Screenshots

![image](https://user-images.githubusercontent.com/654645/49947749-f9ebf800-febf-11e8-98aa-8dc5a3d3e3bc.png)

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [X] Passes all existing automated tests
- [X] Any _change_ in functionality is tested
- [X] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [X] Project documentation has been updated
- [X] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: