### PR TITLE
Fix livereload conflict with docs requirements

### DIFF
--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -1,8 +1,6 @@
 backports-abc==0.5
-beautifulsoup4==4.6.3
-certifi==2018.11.29
 Click==7.0
-django-livereload==1.7
+futures==3.2.0
 Jinja2==2.10
 livereload==2.6.0
 Markdown==2.6.11

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -1,8 +1,6 @@
 -r base.txt
 -r postgres.txt
 django-debug-toolbar==1.7
-django-livereload==1.2
 django-sslserver==0.20
 tox-pip-extensions==1.1.0
 tox==2.9.1
-Werkzeug==0.10.4


### PR DESCRIPTION
The current project requirements included some dependencies on the [django-livereload](https://pypi.org/project/django-livereload/) project, which gets installed as the `livereload` package. This conflicts with the [livereload](https://pypi.org/project/livereload/) package, which also gets installed as `livereload`, and is needed by the latest version of MkDocs.

This conflict means that if, as part of setting up your environment, django-livereload gets installed second, doc building doesn't work:

```sh
$ mkdocs serve
INFO    -  Building documentation... 
INFO    -  Cleaning site directory 
Traceback (most recent call last):
...
  File "/Users/me/.virtualenvs/cfgov-refresh/lib/python2.7/site-packages/mkdocs/commands/serve.py", line 36, in _livereload
    from livereload import Server
ImportError: cannot import name Server
```

Luckily, our use of django-livereload is deprecated. This was added back in #1058 to support some functionality that is no longer needed by this project. I've removed this from the requirements along with some other deprecated requirements. The addition of `futures` is caused by freezing the requirements after installing MkDocs and its extensions.

## Testing

1. `pip install -r requirements/docs.txt`
2. `mkdocs serve`

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [X] Passes all existing automated tests
- [X] Any _change_ in functionality is tested
- [X] Project documentation has been updated
- [X] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: