### PR TITLE
Move FCM class to organisms, convert rendering of it to include_block

### DIFF
--- a/cfgov/jinja2/v1/_includes/organisms/featured-content.html
+++ b/cfgov/jinja2/v1/_includes/organisms/featured-content.html
@@ -60,40 +60,43 @@
 <section class="o-featured-content-module
                 o-featured-content-module__center">
     <div class="o-featured-content-module_text">
-        <div class="a-heading a-heading__icon">
-            {{ category_icon.render( fcm_label(value.category) ) | safe }}
-            {{ fcm_label( value.category ) }}
-        </div>
+        {% if value.category %}
+            <div class="a-heading a-heading__icon">
+                {{ category_icon.render( fcm_label(value.category) ) | safe }}
+                {{ fcm_label( value.category ) }}
+            </div>
+        {% endif %}
         <h2>{{ value.heading }}</h2>
         {{ value.body | safe }}
-        {% if (value.show_post_link and value.post) or (value.links[0] and value.links[0].text) %}
+        {% if (value.show_post_link and value.post) or (value.links[0].text and value.links[0].url) %}
             <ul class="m-list m-list__links">
-                {% if value.show_post_link and value.post %}
+                {% if value.show_post_link and value.post_link_text and value.post %}
                     <li class="m-list_item">
                         <a class="m-list_link" href="{{ pageurl(value.post) }}">
                             {{ value.post_link_text }}
                         </a>
                     </li>
                 {% endif %}
-                {% if value.links[0] and value.links[0].text %}
+                {% if value.links[0].text and value.links[0].url %}
                     {% for link in value.links %}
-                        <li class="m-list_item">
-                            <a class="m-list_link" href="{{ link.url }}">
-                                {{ link.text }}
-                            </a>
-                        </li>
+                        {% if link.text and link.url %}
+                            <li class="m-list_item">
+                                <a class="m-list_link" href="{{ link.url }}">
+                                    {{ link.text }}
+                                </a>
+                            </li>
+                        {% endif %}
                     {% endfor %}
                 {% endif %}
             </ul>
         {% endif %}
     </div>
 
-    {% if value.video and
-          value.video.url and
+    {% if value.video.url and
           value.video.id %}
         {% import 'macros/video-player.html' as video_player with context %}
         {{ video_player.render(value) }}
-    {% elif value.image %}
+    {% elif value.image.upload %}
         <div class="o-featured-content-module_visual">
             {% set photo = image(value.image.upload, 'original') %}
             <img class="o-featured-content-module_img"

--- a/cfgov/jinja2/v1/_includes/organisms/featured-content.html
+++ b/cfgov/jinja2/v1/_includes/organisms/featured-content.html
@@ -1,6 +1,6 @@
 {# ==========================================================================
 
-   featured_content.render()
+   Template for v1.atomic_elements.organisms.FeaturedContent
 
    ==========================================================================
 
@@ -15,19 +15,22 @@
 
    value.body:            Body text.
 
-   value.show_post_link:  Boolean flag for whether to render the post link.
+   value.category:        String of a selected FCM category slug used by the
+                          fcm_label template tag to retrieve the proper
+                          string for output and for passing to the
+                          category_icon macro.
 
    value.post:            (Optional) Page being featured.
 
+   value.show_post_link:  Boolean flag for whether to render the post link.
+
    value.post_link_text:  String for the link text of the displayed post.
 
-   value.macro_link:      (Optional) Object used if the FCM is
-                          rendered outside of wagtail,
-                          this is a simpler way of adding a link.
+   value.image:           (Optional) An ImageBasic atom object containing:
 
-   value.macro_link.url:  String for URL of the link.
+   value.image.upload:    A CFGOVImage object.
 
-   value.macro_link.text: String for text of the link.
+   value.image.alt:       String for alt text for screenreaders.
 
    value.links:           If the FCM is rendered in wagtail,
                           this returns the array of links.
@@ -49,15 +52,9 @@
 
    value.video.id:        A String used to denote the id of the video.
 
-   value.image:           (Optional) An ImageBasic atom object containing:
-
-   value.image.upload:    A CFGOVImage object.
-
-   value.image.alt:       String for alt text for screenreaders.
 
    ========================================================================== #}
 
-{% macro render(value) %}
 {% import 'macros/category-icon.html' as category_icon %}
 
 <section class="o-featured-content-module
@@ -69,29 +66,26 @@
         </div>
         <h2>{{ value.heading }}</h2>
         {{ value.body | safe }}
-        <ul class="m-list m-list__links">
-            {% if value.show_post_link and value.post %}
-                <li class="m-list_item">
-                    <a class="m-list_link" href="{{ pageurl(value.post) }}">
-                        {{ value.post_link_text }}
-                    </a>
-                </li>
-            {% endif %}
-            {% if value.macro_link %}
-                <li class="m-list_item">
-                    <a class="m-list_link" href="{{ value.macro_link.url }}">
-                        {{ value.macro_link.text }}
-                    </a>
-                </li>
-            {% endif %}
-            {% for link in value.links %}
-                <li class="m-list_item">
-                    <a class="m-list_link" href="{{ link.url }}">
-                        {{ link.text }}
-                    </a>
-                </li>
-            {% endfor %}
-        </ul>
+        {% if (value.show_post_link and value.post) or (value.links[0] and value.links[0].text) %}
+            <ul class="m-list m-list__links">
+                {% if value.show_post_link and value.post %}
+                    <li class="m-list_item">
+                        <a class="m-list_link" href="{{ pageurl(value.post) }}">
+                            {{ value.post_link_text }}
+                        </a>
+                    </li>
+                {% endif %}
+                {% if value.links[0] and value.links[0].text %}
+                    {% for link in value.links %}
+                        <li class="m-list_item">
+                            <a class="m-list_link" href="{{ link.url }}">
+                                {{ link.text }}
+                            </a>
+                        </li>
+                    {% endfor %}
+                {% endif %}
+            </ul>
+        {% endif %}
     </div>
 
     {% if value.video and
@@ -108,4 +102,3 @@
         </div>
     {% endif %}
 </section>
-{% endmacro %}

--- a/cfgov/jinja2/v1/browse-basic/index.html
+++ b/cfgov/jinja2/v1/browse-basic/index.html
@@ -1,7 +1,6 @@
 {% extends 'layout-side-nav.html' %}
 
 {% import 'form_block.html' as form_block with context %}
-{% import 'organisms/featured-content.html' as featured_content with context %}
 {% import 'templates/render_block.html' as render_block with context %}
 {% import 'templates/streamfield-sidefoot.html' as streamfield_sidefoot with context %}
 
@@ -14,9 +13,9 @@
         {% if 'featured_content' in block.block_type %}
             <div class="block
                         block__border
-                        {{ 'u-mt0' if loop.index == 1 }}">
+                        {{ 'u-mt0' if loop.first }}">
                         {# u-mt0 is used instead of block__flush-top to keep top border #}
-                {{ featured_content.render(block.value) }}
+                {% include_block block %}
             </div>
         {% else %}
             {{ render_block.render(block, loop.index) }}

--- a/cfgov/jinja2/v1/browse-filterable/index.html
+++ b/cfgov/jinja2/v1/browse-filterable/index.html
@@ -1,7 +1,6 @@
 {% extends 'layout-side-nav.html' %}
 
 {% import 'form_block.html' as form_block with context %}
-{% import 'organisms/featured-content.html' as featured_content with context %}
 {% import 'organisms/filterable-list-controls.html' as flc with context %}
 {% import 'templates/render_block.html' as render_block with context %}
 {% import 'templates/streamfield-sidefoot.html' as streamfield_sidefoot with context %}
@@ -15,9 +14,9 @@
         {% if 'featured_content' in block.block_type %}
             <div class="block
                         block__border
-                        {{ 'u-mt0' if loop.index == 1 }}">
+                        {{ 'u-mt0' if loop.first }}">
                         {# u-mt0 is used instead of block__flush-top to keep top border #}
-                {{ featured_content.render(block.value) }}
+                {% include_block block %}
             </div>
         {% else %}
             {{ render_block.render(block, loop.index) }}

--- a/cfgov/jinja2/v1/newsroom/index.html
+++ b/cfgov/jinja2/v1/newsroom/index.html
@@ -1,6 +1,5 @@
 {% extends 'layout-side-nav.html' %}
 
-{% import 'organisms/featured-content.html' as featured_content with context %}
 {% import 'templates/streamfield-sidefoot.html' as streamfield_sidefoot with context %}
 
 {% block content_main_modifiers -%}
@@ -12,9 +11,9 @@
         {% if 'featured_content' in block.block_type %}
             <div class="block
                         block__border
-                        {{ 'u-mt0' if loop.index == 1 }}">
+                        {{ 'u-mt0' if loop.first }}">
                         {# u-mt0 is used instead of block__flush-top to keep top border #}
-                {{ featured_content.render(block.value) }}
+                {% include_block block %}
             </div>
         {% elif loop.index == 1 %}
         <div class="block

--- a/cfgov/jinja2/v1/sublanding-page/index.html
+++ b/cfgov/jinja2/v1/sublanding-page/index.html
@@ -1,7 +1,6 @@
 {% extends 'layout-2-1-bleedbar.html' %}
 
 {% import 'form_block.html' as form_block with context %}
-{% import 'organisms/featured-content.html' as featured_content with context %}
 {% import 'organisms/post-preview.html' as post_preview with context %}
 {% import 'templates/streamfield-sidefoot.html' as streamfield_sidefoot with context %}
 
@@ -26,9 +25,9 @@
         {% if 'featured_content' in block.block_type %}
             <div class="block
                         block__border
-                        {{ 'u-mt0' if loop.index == 1 }}">
+                        {{ 'u-mt0' if loop.first }}">
                         {# u-mt0 is used instead of block__flush-top to keep top border #}
-                {{ featured_content.render(block.value) }}
+                {% include_block block %}
             </div>
         {% elif block.block_type == 'feedback' %}
             {{- form_block.render(block, 'content', loop.index0) -}}

--- a/cfgov/regulations3k/jinja2/regulations3k/browse-regulation.html
+++ b/cfgov/regulations3k/jinja2/regulations3k/browse-regulation.html
@@ -1,7 +1,6 @@
 {% extends 'regulations3k/regulations3k-side-nav.html' %}
 
 {% import 'form_block.html' as form_block with context %}
-{% import 'organisms/featured-content.html' as featured_content with context %}
 {% import 'regulations3k-search-bar.html' as search_bar with context %}
 {% import 'templates/render_block.html' as render_block with context %}
 {% import 'templates/streamfield-sidefoot.html' as streamfield_sidefoot with context %}

--- a/cfgov/v1/atomic_elements/molecules.py
+++ b/cfgov/v1/atomic_elements/molecules.py
@@ -212,47 +212,6 @@ class FormFieldWithButton(blocks.StructBlock):
         template = '_includes/molecules/form-field-with-button.html'
 
 
-class FeaturedContent(blocks.StructBlock):
-    heading = blocks.CharBlock(required=False)
-    body = blocks.RichTextBlock(required=False)
-
-    category = blocks.ChoiceBlock(choices=ref.fcm_types, required=False)
-    post = blocks.PageChooserBlock(required=False)
-
-    show_post_link = blocks.BooleanBlock(required=False,
-                                         label="Render post link?")
-    post_link_text = blocks.CharBlock(required=False)
-
-    image = atoms.ImageBasic(required=False)
-    links = blocks.ListBlock(atoms.Hyperlink(required=False),
-                             label='Additional Links')
-
-    video = blocks.StructBlock([
-        ('id', blocks.CharBlock(
-            required=False,
-            label='ID',
-            help_text='E.g., in "https://www.youtube.com/watch?v=en0Iq8II4fA",'
-                      ' the ID is everything after the "?v=".')),
-        ('url', blocks.CharBlock(
-            required=False,
-            label='URL',
-            help_text='You must use the embed URL, e.g., '
-                      'https://www.youtube.com/embed/'
-                      'JPTg8ZB3j5c?autoplay=1&enablejsapi=1')),
-        ('height', blocks.CharBlock(default='320', required=False)),
-        ('width', blocks.CharBlock(default='568', required=False)),
-    ])
-
-    class Meta:
-        template = '_includes/molecules/featured-content.html'
-        icon = 'doc-full-inverse'
-        label = 'Featured Content'
-        classname = 'block__flush'
-
-    class Media:
-        js = ['video-player.js']
-
-
 class CallToAction(blocks.StructBlock):
     slug_text = blocks.CharBlock(required=False)
     paragraph_text = blocks.RichTextBlock(required=False)

--- a/cfgov/v1/atomic_elements/molecules.py
+++ b/cfgov/v1/atomic_elements/molecules.py
@@ -6,7 +6,6 @@ from wagtail.wagtailimages.blocks import ImageChooserBlock
 
 from v1.atomic_elements import atoms
 from v1.blocks import AnchorLink, HeadingBlock
-from v1.util import ref
 
 
 class HalfWidthLinkBlob(blocks.StructBlock):

--- a/cfgov/v1/atomic_elements/organisms.py
+++ b/cfgov/v1/atomic_elements/organisms.py
@@ -933,6 +933,47 @@ class VideoPlayer(blocks.StructBlock):
         js = ['video-player.js']
 
 
+class FeaturedContent(blocks.StructBlock):
+    heading = blocks.CharBlock(required=False)
+    body = blocks.RichTextBlock(required=False)
+    category = blocks.ChoiceBlock(choices=ref.fcm_types, required=False)
+
+    post = blocks.PageChooserBlock(required=False)
+    show_post_link = blocks.BooleanBlock(required=False,
+                                         label="Render post link?")
+    post_link_text = blocks.CharBlock(required=False)
+
+    image = atoms.ImageBasic(required=False)
+
+    links = blocks.ListBlock(atoms.Hyperlink(required=False),
+                             label='Additional Links')
+
+    video = blocks.StructBlock([
+        ('id', blocks.CharBlock(
+            required=False,
+            label='ID',
+            help_text='E.g., in "https://www.youtube.com/watch?v=en0Iq8II4fA",'
+                      ' the ID is everything after the "?v=".')),
+        ('url', blocks.CharBlock(
+            required=False,
+            label='URL',
+            help_text='You must use the embed URL, e.g., '
+                      'https://www.youtube.com/embed/'
+                      'JPTg8ZB3j5c?autoplay=1&enablejsapi=1')),
+        ('height', blocks.CharBlock(default='320', required=False)),
+        ('width', blocks.CharBlock(default='568', required=False)),
+    ])
+
+    class Meta:
+        template = '_includes/organisms/featured-content.html'
+        icon = 'doc-full-inverse'
+        label = 'Featured Content'
+        classname = 'block__flush'
+
+    class Media:
+        js = ['video-player.js']
+
+
 class HTMLBlock(blocks.StructBlock):
     html_url = blocks.RegexBlock(
         label='Source URL',

--- a/cfgov/v1/models/browse_filterable_page.py
+++ b/cfgov/v1/models/browse_filterable_page.py
@@ -19,7 +19,7 @@ class BrowseFilterablePage(FilterableFeedPageMixin,
                            CFGOVPage):
     header = StreamField([
         ('text_introduction', molecules.TextIntroduction()),
-        ('featured_content', molecules.FeaturedContent()),
+        ('featured_content', organisms.FeaturedContent()),
     ])
     content = StreamField([
         ('full_width_text', organisms.FullWidthText()),

--- a/cfgov/v1/models/browse_page.py
+++ b/cfgov/v1/models/browse_page.py
@@ -21,7 +21,7 @@ from v1.util.util import get_secondary_nav_items
 class BrowsePage(CFGOVPage):
     header = StreamField([
         ('text_introduction', molecules.TextIntroduction()),
-        ('featured_content', molecules.FeaturedContent()),
+        ('featured_content', organisms.FeaturedContent()),
     ], blank=True)
 
     content = StreamField([

--- a/cfgov/v1/models/sublanding_filterable_page.py
+++ b/cfgov/v1/models/sublanding_filterable_page.py
@@ -22,7 +22,7 @@ class SublandingFilterablePage(FilterableFeedPageMixin,
         ('text_introduction', molecules.TextIntroduction()),
         ('full_width_text', organisms.FullWidthText()),
         ('filter_controls', organisms.FilterControls()),
-        ('featured_content', molecules.FeaturedContent()),
+        ('featured_content', organisms.FeaturedContent()),
         ('feedback', v1_blocks.Feedback()),
     ])
 

--- a/cfgov/v1/models/sublanding_page.py
+++ b/cfgov/v1/models/sublanding_page.py
@@ -21,7 +21,7 @@ class SublandingPage(CFGOVPage):
     ], blank=True)
     content = StreamField([
         ('text_introduction', molecules.TextIntroduction()),
-        ('featured_content', molecules.FeaturedContent()),
+        ('featured_content', organisms.FeaturedContent()),
         ('info_unit_group', organisms.InfoUnitGroup()),
         ('full_width_text', organisms.FullWidthText()),
         ('post_preview_snapshot', organisms.PostPreviewSnapshot()),


### PR DESCRIPTION
This PR addresses a few things, most urgently the inability to compare revisions on any page that has an FCM (due to the outdated `FeaturedContent` `template` property). 

It moves the Python code to organisms to be consistent with that change in the front-end code, and removes the `macro`-based rendering setup to the more standard Wagtail `include_block` method. 

It also corrects a lingering template issue with empty link list markup when no link was set up.

## Changes

- Moves the `RelatedPosts` class from `molecules.py` to `organisms.py`
- Updates page templates to render `RelatedPosts` blocks via `include_block` instead of `macro.render()`
- Fixes `related-posts.html` template logic to not render empty link list markup if no links are present

## Removals

- Unused `macro_link` stuff in `related-posts.html`

## Testing

1. Pull branch
2. Visit pages of each type with an FCM and confirm that they are still working
   - Browse: http://localhost:8000/es/prepararse-para-comprar-casa/hipotecas/
   - Sublanding: http://localhost:8000/consumer-tools/auto-loans/
   - Sublanding Filterable: http://localhost:8000/consumer-tools/auto-loans/
   - Browse Filterable: One doesn't exist that uses an FCM. You can make your own.
   - Newsroom Landing: Doesn't currently uses an FCM. You can make your own.

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
