### PR TITLE
Housing counselor: update markup semantics and CF importing

### DIFF
--- a/cfgov/housing_counselor/jinja2/housing_counselor/index.html
+++ b/cfgov/housing_counselor/jinja2/housing_counselor/index.html
@@ -183,61 +183,78 @@
                                     <td data-label="Agency">
                                         <ol start="{{ loop.index }}">
                                             <li>
-                                                <p>
+                                                <div class="u-mb15"
+                                                     itemscope
+                                                     itemtype="http://schema.org/PostalAddress">
+
                                                     {% if counselor.weburl %}
                                                     <a class="a-link a-link__icon"
                                                        href="{{ counselor.weburl }}">
                                                       <span class="a-link_text">
-                                                          <b>{{ counselor.nme }}</b>
+                                                          <b itemprop="name">{{ counselor.nme }}</b>
                                                       </span>
                                                       {{ svg_icon( 'external-link' ) }}
                                                     </a>
                                                     {% else %}
-                                                    <b>{{ counselor.nme }}</b>
+                                                    <b itemprop="name">{{ counselor.nme }}</b>
                                                     {% endif %}
 
                                                     <br>
-                                                    {{ counselor.adr1 }}
+
+                                                    <span itemprop="streetAddress">{{ counselor.adr1 }}</span>
                                                     {% if counselor.adr2 and counselor.adr2 != ' '  %}
                                                     <br>
-                                                    {{ counselor.adr2 }}
+                                                    <span itemprop="streetAddress">{{ counselor.adr2 }}</span>
                                                     {% endif %}
                                                     <br>
-                                                    {{ counselor.city }}, {{ counselor.statecd }} {{ counselor.zipcd }}
-                                                </p>
-                                                <p>
+                                                    <span itemprop="addressLocality">{{ counselor.city }}</span>,
+                                                    <span itemprop="addressRegion">{{ counselor.statecd }}</span>
+                                                    <span itemprop="postalCode">{{ counselor.zipcd }}</span>
+
+                                                </div>
+
+                                                <dl>
                                                     {% if counselor.weburl %}
-                                                    <b>Website:</b>
+                                                    <dt>Website:</dt>
+                                                    <dd>
                                                     <a class="a-link a-link__icon"
-                                                       href="{{ counselor.weburl }}">
+                                                       href="{{ counselor.weburl }}"
+                                                       itemprop="url">
                                                         <span class="a-link_text">
                                                             {{ counselor.weburl }}
                                                         </span>
                                                         {{ svg_icon( 'external-link' ) }}
                                                     </a>
-                                                    <br>
+                                                    </dd>
                                                     {% endif %}
 
                                                     {% if counselor.phone1 %}
-                                                    <b>Phone:</b>
-                                                    <a href="tel:+1-{{ counselor.phone1 }}">
-                                                        {{ counselor.phone1 }}
-                                                    </a>
-                                                    <br>
+                                                    <dt>Phone:</dt>
+                                                    <dd>
+                                                        <a href="tel:+1-{{ counselor.phone1 }}"
+                                                           itemprop="telephone">
+                                                            {{ counselor.phone1 }}
+                                                        </a>
+                                                    </dd>
                                                     {% endif %}
 
                                                     {% if counselor.email %}
-                                                    <b>Email Address:</b>
-                                                    <a href="mailto:{{ counselor.email }}">
-                                                        {{ counselor.email }}
-                                                    </a>
-                                                    <br>
+                                                    <dt>Email Address:</dt>
+                                                    <dd>
+                                                        <a href="mailto:{{ counselor.email }}"
+                                                           itemprop="email">
+                                                            {{ counselor.email }}
+                                                        </a>
+                                                    </dd>
                                                     {% endif %}
 
                                                     {% if counselor.languages %}
-                                                    <b>Languages:</b> {{ counselor.languages | join( ', ' ) }}
+                                                    <dt>Languages:</dt>
+                                                    <dd itemprop="knowsLanguage">
+                                                        {{ counselor.languages | join( ', ' ) }}
+                                                    </dd>
                                                     {% endif %}
-                                                </p>
+                                                </dt>
                                             </li>
                                         </ol>
                                     </td>

--- a/cfgov/unprocessed/apps/find-a-housing-counselor/css/main.less
+++ b/cfgov/unprocessed/apps/find-a-housing-counselor/css/main.less
@@ -1,5 +1,5 @@
 // Import required CF components.
-@import (less) 'cf-core.less';
+@import (reference) 'cf-core.less';
 
 @import (less) './hud.less';
 @import (less) './hud_print.css';


### PR DESCRIPTION
Fixes [GHE]/CFGOV/platform/issues/3200

CF should be imported by reference NOT directly or we end up with two copies!

We're going to stick with the default CF appearance for `dl`, instead of making the contact details look like before (e.g. have lowercase text). Checked this with @schaferjh 

## Changes

- Changes cf-core import to an import by reference.
- Changes paragraph to `dl` list markup.
- Adds schema.org microdata markup.

## Testing

1. Pull branch and visit http://localhost:8000/find-a-housing-counselor/?zipcode=20002
1. See changed contact details to result items.
1. Microdata can be tested by inspecting the DOM and copying a result entry HTML as a snippet and pasting into https://search.google.com/structured-data/testing-tool

## Screenshots

<img width="809" alt="screen shot 2018-12-14 at 1 54 22 pm" src="https://user-images.githubusercontent.com/704760/50022066-fed8a680-ffa8-11e8-8f3a-3bb44c0ba594.png">


Before:
<img width="291" alt="screen shot 2018-12-14 at 1 23 04 pm" src="https://user-images.githubusercontent.com/704760/50022049-f41e1180-ffa8-11e8-8c0a-e97a6501d750.png">

After:
<img width="317" alt="screen shot 2018-12-14 at 1 23 26 pm" src="https://user-images.githubusercontent.com/704760/50022057-f8e2c580-ffa8-11e8-8dea-41e8d8a17631.png">


