### PR TITLE
Housing counselor: Update sharing text

### DIFF
--- a/cfgov/housing_counselor/jinja2/housing_counselor/index.html
+++ b/cfgov/housing_counselor/jinja2/housing_counselor/index.html
@@ -307,12 +307,12 @@
                                             block__flush-top
                                             block__padded-top">
                                     {{ social_media.render( {
-                                    "twitter_text": "Use the @CFPB’s interactive tool to double-check all the details of your Closing Disclosure.",
-                                    "email_title": "Get Closing Disclosure help from the CFPB",
-                                    "email_text": "The CFPB’s tool helps you double-check your closing disclosure:",
+                                    "twitter_text": "Use the @CFPB’s interactive tool to find a housing counselor.",
+                                    "email_title": "Find a housing counselor tool from CFPB",
+                                    "email_text": "The CFPB's tool helps you find a housing counselor:",
                                     "email_signature": "-- From the CFPB",
-                                    "linkedin_title": "Double-check your Closing Disclosure with the @CFPB",
-                                    "linkedin_text": "Use this tool from the @CFPB to double-check that all the details in your closing disclosure are correct. Via @CFPB"
+                                    "linkedin_title": "Find a housing counselor tool from @CFPB",
+                                    "linkedin_text": "Use the @CFPB’s interactive tool to find a housing counselor."
                                     } ) }}
                                 </div>
 


### PR DESCRIPTION
## Changes

- Adjusts erroneous sharing text in sharing buttons.

## Testing

1. Pull branch and visit http://localhost:8000/find-a-housing-counselor/?zipcode=20002
2. Click social media sharing links at the bottom of the page and check output. 

## Screenshots

<img width="835" alt="screen shot 2018-12-14 at 2 16 58 pm" src="https://user-images.githubusercontent.com/704760/50022663-eec1c680-ffaa-11e8-83a7-1a6c1e44a40e.png">

<img width="672" alt="screen shot 2018-12-14 at 2 17 40 pm" src="https://user-images.githubusercontent.com/704760/50022692-07ca7780-ffab-11e8-98ee-6fbf5e3b5a26.png">

## Notes

- I'm not logged into Facebook and Linkedin on my work machine so can't verify these. Anyone else logged in? I'll be able to check on another machine after this hits prod.
