### PR TITLE
Switches email-popup close widget from an anchor to a button.

### DIFF
--- a/cfgov/jinja2/v1/_includes/organisms/email-popup/base.html
+++ b/cfgov/jinja2/v1/_includes/organisms/email-popup/base.html
@@ -15,7 +15,7 @@
      lang="{{ popup_language }}">
     <div class="o-email-popup_header u-clearfix">
         <div class="close">
-            <button>Close {{ svg_icon('delete') }}</button>
+            <button class="a-btn a-btn__link">Close {{ svg_icon('delete') }}</button>
         </div>
     </div>
     <div class="o-email-popup_body"

--- a/cfgov/jinja2/v1/_includes/organisms/email-popup/base.html
+++ b/cfgov/jinja2/v1/_includes/organisms/email-popup/base.html
@@ -15,7 +15,7 @@
      lang="{{ popup_language }}">
     <div class="o-email-popup_header u-clearfix">
         <div class="close">
-            <a>Close {{ svg_icon('delete') }}</a>
+            <button>Close {{ svg_icon('delete') }}</button>
         </div>
     </div>
     <div class="o-email-popup_body"

--- a/cfgov/unprocessed/css/organisms/email-popup.less
+++ b/cfgov/unprocessed/css/organisms/email-popup.less
@@ -40,24 +40,6 @@
           top: unit( (@grid_gutter-width / 3) / @base-font-size-px, em);
           right: unit( (@grid_gutter-width / 2) / @base-font-size-px, em);
           cursor: pointer;
-
-          button {
-              background: none;
-              border: none;
-              color: @link-text;
-
-              &:hover {
-                  color: @link-text-hover;
-              }
-
-              &:focus {
-                  outline: thin dotted;
-              }
-
-              &:active {
-                  color: @link-text-active;
-              }
-          }
       }
   }
 

--- a/cfgov/unprocessed/css/organisms/email-popup.less
+++ b/cfgov/unprocessed/css/organisms/email-popup.less
@@ -40,6 +40,24 @@
           top: unit( (@grid_gutter-width / 3) / @base-font-size-px, em);
           right: unit( (@grid_gutter-width / 2) / @base-font-size-px, em);
           cursor: pointer;
+
+          button {
+              background: none;
+              border: none;
+              color: @link-text;
+
+              &:hover {
+                  color: @link-text-hover;
+              }
+
+              &:focus {
+                  outline: thin dotted;
+              }
+
+              &:active {
+                  color: @link-text-active;
+              }
+          }
       }
   }
 

--- a/cfgov/unprocessed/css/organisms/email-popup.less
+++ b/cfgov/unprocessed/css/organisms/email-popup.less
@@ -40,6 +40,10 @@
           top: unit( (@grid_gutter-width / 3) / @base-font-size-px, em);
           right: unit( (@grid_gutter-width / 2) / @base-font-size-px, em);
           cursor: pointer;
+
+          button {
+            border: none;
+          }
       }
   }
 

--- a/cfgov/unprocessed/css/organisms/email-popup.less
+++ b/cfgov/unprocessed/css/organisms/email-popup.less
@@ -40,10 +40,6 @@
           top: unit( (@grid_gutter-width / 3) / @base-font-size-px, em);
           right: unit( (@grid_gutter-width / 2) / @base-font-size-px, em);
           cursor: pointer;
-
-          button {
-            border: none;
-          }
       }
   }
 


### PR DESCRIPTION
Closes GHE/CFGOV/platform/issues/3129

## Changes
 - Switches close button to an actual button. This inserts it into the tab index and is more semantically correct.
 - Adjusts styling to match current anchor styling

## Testing

1. Pull branch and `yarn run gulp styles`
2. Go to http://localhost:8000/owning-a-home
 - You may need to localStorage.clear() and refresh if the "Buying A House?" popup doesn't activate on scroll.
3. Once the popup is activated, you should be able to tab to the close button and close the popup with enter.
4. Styling of the close button should match the one at https://consumerfinance.gov/owning-a-home