### PR TITLE
Update documentation .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,7 +85,9 @@ vendor/
 
 # Documentation #
 #################
-docs/scripts
+# MkDocs compiles documentation to this directory.
+# This should not be committed because it gets built by Travis.
+site/
 
 # Django #
 ##########


### PR DESCRIPTION
This commit removes a deprecated `.gitignore` entry for `docs/scripts` (because there are no scripts in this location) but adds one for `site/`, the [target directory for the MkDocs build](https://www.mkdocs.org/#building-the-site).

Because Travis builds the documentation from the source Markdown files, and creates its own `site/` directory which then gets pushed to gh-pages, local changes to `site/` should never be committed. Adding this directory to the `.gitignore` means that local documentation builds won't show up in a `git diff`.

## Testing

1. `pip install -r requirements/docs.txt` to install documentation requirements.
2. `mkdocs build` to build the documentation locally.
3. `git status` - note no local changes detected.

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [X] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [X] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: