### PR TITLE
Revert overly aggressive condition simplification in FCM template

### DIFF
--- a/cfgov/jinja2/v1/_includes/organisms/featured-content.html
+++ b/cfgov/jinja2/v1/_includes/organisms/featured-content.html
@@ -68,7 +68,8 @@
         {% endif %}
         <h2>{{ value.heading }}</h2>
         {{ value.body | safe }}
-        {% if (value.show_post_link and value.post) or (value.links[0].text and value.links[0].url) %}
+        {% if (value.show_post_link and value.post)
+           or (value.links[0] and value.links[0].text and value.links[0].url) %}
             <ul class="m-list m-list__links">
                 {% if value.show_post_link and value.post_link_text and value.post %}
                     <li class="m-list_item">
@@ -77,7 +78,7 @@
                         </a>
                     </li>
                 {% endif %}
-                {% if value.links[0].text and value.links[0].url %}
+                {% if value.links[0] and value.links[0].text and value.links[0].url %}
                     {% for link in value.links %}
                         {% if link.text and link.url %}
                             <li class="m-list_item">


### PR DESCRIPTION
If you don't include `if value.links[0]`, the check won't resolve before getting to `[if] value.links[0].text` and you get an error that there is no `value.links[0]` to check for having a `text` property.

## Testing

1. Visit http://localhost:8000/adult-financial-education/ to see the error
1. Pull branch
1. Reload the page and see it working

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
