### PR TITLE
Add a docs Docker container that serves the docs on port 8888

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,3 +33,20 @@ services:
         working_dir: /src/cfgov-refresh
         stdin_open: true
         tty: true
+    docs:
+        build:
+            context: ./
+            dockerfile: ./docker/docs/Dockerfile
+        ports:
+            - "8888:8888"
+        environment:
+            LANG: en_US.utf8
+            LC_ALL: en_US.utf8
+        volumes:
+            - ./:/src/cfgov-refresh
+        entrypoint:
+            - sh
+            - /src/cfgov-refresh/docker/docs/entrypoint.sh
+        working_dir: /src/cfgov-refresh
+        stdin_open: true
+        tty: true

--- a/docker/docs/Dockerfile
+++ b/docker/docs/Dockerfile
@@ -1,0 +1,7 @@
+FROM centos:7
+RUN yum install -y which gcc gcc-c++ kernel-devel make epel-release && \
+    yum install -y python36 && \
+    yum clean all
+ADD  https://bootstrap.pypa.io/get-pip.py /src/get-pip.py
+COPY requirements /src/requirements
+RUN python3.6 /src/get-pip.py && pip install -r /src/requirements/docs.txt

--- a/docker/docs/Dockerfile
+++ b/docker/docs/Dockerfile
@@ -2,6 +2,7 @@ FROM centos:7
 RUN yum install -y which gcc gcc-c++ kernel-devel make epel-release && \
     yum install -y python36 && \
     yum clean all
-ADD  https://bootstrap.pypa.io/get-pip.py /src/get-pip.py
 COPY requirements /src/requirements
-RUN python3.6 /src/get-pip.py && pip install -r /src/requirements/docs.txt
+RUN python3.6 -m ensurepip
+RUN pip3 install -U pip
+RUN pip3 install -r /src/requirements/docs.txt

--- a/docker/docs/entrypoint.sh
+++ b/docker/docs/entrypoint.sh
@@ -1,0 +1,1 @@
+mkdocs serve -a 0.0.0.0:8888

--- a/docs/development-tips.md
+++ b/docs/development-tips.md
@@ -109,3 +109,11 @@ To add new pages to the navigation, edit the [mkdocs.yml](https://github.com/cfp
 
 When running cfgov-refresh using [Docker-compose](https://cfpb.github.io/cfgov-refresh/installation/#docker-compose-installation)
 this documentation is running by default at http://localhost:8888.
+
+When not using Docker, you can run these docs with:
+
+```bash
+mkdocs serve -a :8888
+```
+
+And access on http://localhost:8888.

--- a/docs/development-tips.md
+++ b/docs/development-tips.md
@@ -106,3 +106,6 @@ by [mkdocs](https://www.mkdocs.org/user-guide/deploying-your-docs/).
 Every time a PR is merged to master, Travis will build and deploy the documentation to https://cfpb.github.io/cfgov-refresh. See [How we use Travis CI](https://github.com/cfpb/cfgov-refresh/blob/master/docs/travis.md) for more info.
 
 To add new pages to the navigation, edit the [mkdocs.yml](https://github.com/cfpb/cfgov-refresh/blob/master/mkdocs.yml) file in the root directory.
+
+When running cfgov-refresh using [Docker-compose](https://cfpb.github.io/cfgov-refresh/installation/#docker-compose-installation)
+this documentation is running by default at http://localhost:8888.

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -1,6 +1,6 @@
 backports-abc==0.5
 Click==7.0
-futures==3.2.0
+futures==3.1.1
 Jinja2==2.10
 livereload==2.6.0
 Markdown==2.6.11


### PR DESCRIPTION
This PR adds another Docker container called "docs" that will run `mkdocs serve` on port 8888. This means that we always have a running copy of the docs along side the running cfgov-refresh on port 8000.

The "docs" container runs Python 3.6 to run MkDocs.

Because of the version of Python 3.6 (3.6.6 from EPEL), I had to downgrade the "futures" requirement. That does not seem to cause any problems for MkDocs or other pacakges.

This is a proof-of-concept PR for your consideration.

## Testing

1.  Run `docker-compose up`. The "docs" container should get built along with the others.
2. View cfgov-refresh at http://localhost:8000/ as usual
3. View docs at http://localhost:8888/ 


## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
