### PR TITLE
Bugfix: When there are no filterable pages, use reasonable default

### DIFF
--- a/cfgov/v1/forms.py
+++ b/cfgov/v1/forms.py
@@ -116,7 +116,10 @@ class FilterableListForm(forms.Form):
 
     def first_page_date(self):
         first_post = self.filterable_pages.order_by('date_published').first()
-        return first_post.date_published
+        if first_post:
+            return first_post.date_published
+        else:
+            return date(2010, 1, 1)
 
     def prepare_options(self, arr):
         """


### PR DESCRIPTION
Fix a `500` error that is currently happening on the [Events page](https://www.consumerfinance.gov/about-us/events/) when the user enters a "to" date but not a "from" date in the filter controls. 

Since there are no upcoming events scheduled, the set of upcoming events is empty. We try to use the date of the first page in the filterable page list to fill in the "from" date field, which doesn't work when the first page was `None`.

## Additions

- Default the "from" date to 1/1/2010 when there isn't an actual "first post" whose date we can use.

## Testing

1. Running this branch, visit http://localhost:8000/about-us/events/
2. If your data is up-to-date, the list of Events on the page will be empty
3. In the filter controls, enter a "to" date but not a "from" date

See that you don't receive a `500` error, though you would before.


## Notes

- I thought 1/1/2010 was a reasonable default (and it'll only show up in rare circumstances anyway). I'm open to alternative ideas if anyone disagrees.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: