### PR TITLE
Housing counselor: Polyfill parseInt for IE11

### DIFF
--- a/cfgov/unprocessed/apps/find-a-housing-counselor/js/common.js
+++ b/cfgov/unprocessed/apps/find-a-housing-counselor/js/common.js
@@ -78,6 +78,12 @@ function initializeMap() {
  * @returns {HTMLNode} The DOM node of the result item.
  */
 function queryMarkerDom( num ) {
+
+  // Polyfill parseInt on Number for IE11.
+  if ( typeof Number.parseInt === 'undefined' ) {
+    Number.parseInt = window.parseInt;
+  }
+
   const selector = '#hud-result-' + Number.parseInt( num, 10 );
   let cachedItem = markerDomCache[selector];
   if ( typeof cachedItem === 'undefined' ) {


### PR DESCRIPTION
IE11 doesn't support `parseInt` on the `Number` object, but instead only has the global `parseInt`. This adds a small polyfill to add it to the `Number` object.

## Changes

- Adds `Number.parseInt` polyfill to housing counselor script.

## Testing

1. `gulp clean && gulp build`
2. Perform a search on the housing counselor page in IE11.
3. Clicking a map icon should not produce an error and should scroll the page to a result list item.
