### PR TITLE
Add "Contributing to Docs" doc

### DIFF
--- a/docs/contributing-docs.md
+++ b/docs/contributing-docs.md
@@ -1,6 +1,6 @@
 # Contributing to the Docs
 
-Our documentation is written as Markdown files and served in GitHub pages
+Our documentation is written as Markdown files and served via GitHub Pages
 by [MkDocs](https://www.mkdocs.org/).
 
 ## Writing the docs
@@ -23,7 +23,7 @@ In addition to standard Markdown, our documentation supports the following exten
     provides automatic linking for URLs in the Markdown text.
 
 - [SuperFences](https://facelessuser.github.io/pymdown-extensions/extensions/superfences/)
-    makes a number of improvements to standard Markdown fences.
+    makes a number of improvements to standard Markdown code fences.
 
 - [Tilde](https://facelessuser.github.io/pymdown-extensions/extensions/tilde/) 
     adds support for creating `<del></del>` tags with `~~`.
@@ -33,7 +33,7 @@ In addition to standard Markdown, our documentation supports the following exten
 
 When creating new documents, they should be added to the 
 [mkdocs.yml file](https://github.com/cfpb/cfgov-refresh/blob/master/mkdocs.yml) 
-in the appropriate place under `nav:` with its table of contents title. 
+in the appropriate place under `nav:` to get them to appear in the sidebar navigation. 
 For example:
 
 ```
@@ -45,7 +45,7 @@ nav:
 
 ### With Docker
 
-When running cfgov-refresh using [Docker-compose](https://cfpb.github.io/cfgov-refresh/installation/#docker-compose-installation)
+When running cfgov-refresh using [Docker-compose](https://cfpb.github.io/cfgov-refresh/installation/#docker-compose-installation),
 this documentation is running by default at http://localhost:8888.
 
 ### Manually
@@ -61,7 +61,7 @@ pip install -r requirements/docs.txt
 mkdocs serve -a :8888
 ```
 
-And access at http://localhost:8888.
+Once running, they are accessible at http://localhost:8888.
 
 ## Deploying the docs to GitHub Pages
 

--- a/docs/contributing-docs.md
+++ b/docs/contributing-docs.md
@@ -1,0 +1,85 @@
+# Contributing to the Docs
+
+Our documentation is written as Markdown files and served in GitHub pages
+by [MkDocs](https://www.mkdocs.org/).
+
+## Writing the docs
+
+As our documentation is written in Markdown, 
+the [base Markdown specification](https://daringfireball.net/projects/markdown/) 
+is a useful reference. MkDocs also includes 
+[some documentation to get you started writing in Markdown](https://www.mkdocs.org/user-guide/writing-your-docs/#writing-with-markdown).
+
+In addition to standard Markdown, our documentation supports the following extensions:
+
+- [Admonitions](https://python-markdown.github.io/extensions/admonition/)
+    adds specially called-out text anywhere within the document 
+    as notes, warnings, and other types.
+
+- [BetterEm](https://facelessuser.github.io/pymdown-extensions/extensions/betterem/) 
+    improves the handling of bold and italics.
+
+- [MagicLink](https://facelessuser.github.io/pymdown-extensions/extensions/magiclink/) 
+    provides automatic linking for URLs in the Markdown text.
+
+- [SuperFences](https://facelessuser.github.io/pymdown-extensions/extensions/superfences/)
+    makes a number of improvements to standard Markdown fences.
+
+- [Tilde](https://facelessuser.github.io/pymdown-extensions/extensions/tilde/) 
+    adds support for creating `<del></del>` tags with `~~`.
+
+- [Tables](https://python-markdown.github.io/extensions/tables/)
+    adds support for tables to standard Markdown.
+
+When creating new documents, they should be added to the 
+[mkdocs.yml file](https://github.com/cfpb/cfgov-refresh/blob/master/mkdocs.yml) 
+in the appropriate place under `nav:` with its table of contents title. 
+For example:
+
+```
+nav:
+- Introduction: index.md
+```
+
+## Running the docs locally
+
+### With Docker
+
+When running cfgov-refresh using [Docker-compose](https://cfpb.github.io/cfgov-refresh/installation/#docker-compose-installation)
+this documentation is running by default at http://localhost:8888.
+
+### Manually
+
+When using 
+[the stand-alone installation](http://localhost:8888/installation/#stand-alone-installation) 
+of cfgov-refresh, 
+you can run these docs with:
+
+```bash
+workon cfgov-refresh
+pip install -r requirements/docs.txt
+mkdocs serve -a :8888
+```
+
+And access at http://localhost:8888.
+
+## Deploying the docs to GitHub Pages
+
+Every time a PR is merged to master, 
+Travis will build and deploy the documentation to https://cfpb.github.io/cfgov-refresh. 
+See [How we use Travis CI](https://github.com/cfpb/cfgov-refresh/blob/master/docs/travis.md) 
+for more info.
+
+If you would like to deploy to a fork of cfgov-refresh owned by another user 
+you can provide the `-r` argument:
+
+```bash
+mkdocs gh-deploy -r USER
+```
+
+Where `USER` is the GitHub user. 
+The docs will then be available at https://USER.github.io/cfgov-refresh/ after a short period of time.
+
+See the 
+[the MkDocs documentation](https://www.mkdocs.org/user-guide/deploying-your-docs/)
+for more information.

--- a/docs/development-tips.md
+++ b/docs/development-tips.md
@@ -97,23 +97,3 @@ $ ENABLE_DEBUG_TOOLBAR=1 ./runserver.sh
 This tool exposes various useful pieces of information about things like HTTP headers,
 Django settings, SQL queries, and template variables. Note that running with the toolbar on
 may have an impact on local server performance.
-
-### TIP: Updating the documentation
-
-Our documentation is written as Markdown files and served in GitHub pages
-by [mkdocs](https://www.mkdocs.org/user-guide/deploying-your-docs/).
-
-Every time a PR is merged to master, Travis will build and deploy the documentation to https://cfpb.github.io/cfgov-refresh. See [How we use Travis CI](https://github.com/cfpb/cfgov-refresh/blob/master/docs/travis.md) for more info.
-
-To add new pages to the navigation, edit the [mkdocs.yml](https://github.com/cfpb/cfgov-refresh/blob/master/mkdocs.yml) file in the root directory.
-
-When running cfgov-refresh using [Docker-compose](https://cfpb.github.io/cfgov-refresh/installation/#docker-compose-installation)
-this documentation is running by default at http://localhost:8888.
-
-When not using Docker, you can run these docs with:
-
-```bash
-mkdocs serve -a :8888
-```
-
-And access on http://localhost:8888.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -29,6 +29,7 @@ nav:
     - Ask CFPB: ask-cfpb.md
     - Consumer complaints: consumer-complaint-database.md
     - HMDA data: hmda.md
+- Contributing to the docs: contributing-docs.md
 
 theme:
   name: 'readthedocs'
@@ -38,6 +39,7 @@ extra_css:
 markdown_extensions:
     - admonition
     - pymdownx.betterem
+    - pymdownx.highlight
     - pymdownx.magiclink
     - pymdownx.superfences
     - pymdownx.tilde


### PR DESCRIPTION
This PR moves the documentation documentation from the "Development Tips" document into its own document and fleshes that document out a bit with some links to our Markdown extensions and some information about how to build and run the documents.

The running documentation assumes that #4709 will be merged.

Rendered by GitHub: https://github.com/cfpb/cfgov-refresh/blob/contributing-docs/docs/contributing-docs.md

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [x] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
