### PR TITLE
Housing counselor: Moves social media out of full-width-text organism

### DIFF
--- a/cfgov/housing_counselor/jinja2/housing_counselor/index.html
+++ b/cfgov/housing_counselor/jinja2/housing_counselor/index.html
@@ -279,7 +279,7 @@
 
                     {% endif %}
 
-                    <div class="block">
+                    <div class="block block__flush-bottom">
                         <div class="o-full-width-text-group">
                             <div class="m-full-width-text">
                                 <h2 class="h3">
@@ -320,23 +320,21 @@
                                     Washington, DC 20552, or by email to
                                     <a href="mailto:PRA@cfpb.gov">PRA@cfpb.gov</a>.
                                 </p>
-
-                                <div class="block
-                                            block__flush-bottom
-                                            block__flush-top
-                                            block__padded-top">
-                                    {{ social_media.render( {
-                                    "twitter_text": "Use the @CFPB’s interactive tool to find a housing counselor.",
-                                    "email_title": "Find a housing counselor tool from CFPB",
-                                    "email_text": "The CFPB's tool helps you find a housing counselor:",
-                                    "email_signature": "-- From the CFPB",
-                                    "linkedin_title": "Find a housing counselor tool from @CFPB",
-                                    "linkedin_text": "Use the @CFPB’s interactive tool to find a housing counselor."
-                                    } ) }}
-                                </div>
-
                             </div>
                         </div>
+                    </div>
+
+                    <div class="block
+                                block__flush-top
+                                block__padded-top">
+                        {{ social_media.render( {
+                        "twitter_text": "Use the @CFPB’s interactive tool to find a housing counselor.",
+                        "email_title": "Find a housing counselor tool from CFPB",
+                        "email_text": "The CFPB's tool helps you find a housing counselor:",
+                        "email_signature": "-- From the CFPB",
+                        "linkedin_title": "Find a housing counselor tool from @CFPB",
+                        "linkedin_text": "Use the @CFPB’s interactive tool to find a housing counselor."
+                        } ) }}
                     </div>
                 </section>
             </div>


### PR DESCRIPTION
Social media molecule was inside full-width-text organism, however, the [template for full-width-text organism](https://github.com/cfpb/cfgov-refresh/blob/master/cfgov/jinja2/v1/_includes/organisms/full-width-text.html) does not contain a social media molecule.

This change fixes [GHE]/CFGOV/platform/issues/3205 in Safari.

## Changes

- Moves social media molecule outside of the full width text organism.

## Testing

1. Check bottom of https://www.consumerfinance.gov/find-a-housing-counselor/ in Safari 12.0.1 and see extra scrollbar.
2. Check this branch in http://localhost:8000/find-a-housing-counselor/ in Safari 12.0.1 and see that extra scrollbar is absent and otherwise page is the same.
