### PR TITLE
Update code comments to reference hubcap, where possible

### DIFF
--- a/cfgov/jinja2/v1/_includes/organisms/chart.html
+++ b/cfgov/jinja2/v1/_includes/organisms/chart.html
@@ -7,13 +7,12 @@
 
    Description:
 
-   Create a chart organism with data.
-   See [GHE]/flapjack/Modules-V1/wiki/Chart
+   Create a chart organism with data when given:
 
-   value.has_top_rule_line:        Boolean for whether or not to add top
-                                   border to chart.
-                                   Used in 'render_block.html' to modify
-                                   classes on wrapping 'div.block'.
+   value.has_top_rule_line: Boolean for whether or not to add top
+                            border to chart.
+                            Used in 'render_block.html' to modify
+                            classes on wrapping 'div.block'.
 
    ========================================================================== #}
 

--- a/cfgov/jinja2/v1/_includes/organisms/email-signup.html
+++ b/cfgov/jinja2/v1/_includes/organisms/email-signup.html
@@ -1,10 +1,12 @@
 {# ==========================================================================
 
-   email_signup.render()
+   Email signup
 
    ==========================================================================
 
    Description:
+
+   See http://cfpb.github.io/design-manual/page-components/email-sign-up.html
 
    Creates an email sign up form when given:
 

--- a/cfgov/jinja2/v1/_includes/organisms/featured-content.html
+++ b/cfgov/jinja2/v1/_includes/organisms/featured-content.html
@@ -6,8 +6,9 @@
 
    Description:
 
-   Create a featured content molecule.
-   See [GHE]/flapjack/Modules-V1/wiki/Featured-Content-Module
+   See [GHE]/CFPB/hubcap/wiki/Featured-Content-Module
+
+   Create a featured content molecule when given:   
 
    value:                 Object defined from a StreamField block.
 

--- a/cfgov/jinja2/v1/_includes/organisms/full-width-text.html
+++ b/cfgov/jinja2/v1/_includes/organisms/full-width-text.html
@@ -7,8 +7,9 @@
 
    Description:
 
+   See [GHE]/CFPB/hubcap/wiki/Full-Width-Text
+
    Create a full width text organism.
-   See [GHE]/flapjack/Modules-V1/wiki/Full-Width-Copy
 
    ========================================================================== #}
 

--- a/cfgov/jinja2/v1/_includes/organisms/image-text-25-75-group.html
+++ b/cfgov/jinja2/v1/_includes/organisms/image-text-25-75-group.html
@@ -1,3 +1,30 @@
+
+{# ==========================================================================
+
+   Image and Text 25/75 Group
+
+   ==========================================================================
+
+   Description:
+
+   See [GHE]/CFPB/hubcap/wiki/25-75-Info-unit-group
+
+   Create an info-unit-group organism when given:
+
+   value: Object defined from a StreamField block.
+
+   value.heading: A string containing title of module.
+
+   value.image_texts: TODO: add description for this.
+
+   value.link_image_and_heading: TODO: add description for this.
+
+   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+   NOTE: THIS ORGANISM IS DEPRECATED. USE info-unit-group-2.html INSTEAD.
+   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+   ========================================================================== #}
+
 <div class="o-info-unit-group" data-qa-hook="image-text-25-75">
     {% if value.heading %}
     <h2>{{ value.heading }}</h2>

--- a/cfgov/jinja2/v1/_includes/organisms/image-text-50-50-group.html
+++ b/cfgov/jinja2/v1/_includes/organisms/image-text-50-50-group.html
@@ -1,3 +1,34 @@
+
+{# ==========================================================================
+
+   Image and Text 50/50 Group
+
+   ==========================================================================
+
+   Description:
+
+   See [GHE]/CFPB/hubcap/wiki/50-50-Info-unit-group
+
+   Create an info-unit-group organism when given:
+
+   value: Object defined from a StreamField block.
+
+   value.heading: A string containing title of module.
+
+   value.image_texts: TODO: add description for this.
+
+   value.link_image_and_heading: TODO: add description for this.
+
+   value.sharing.shareable: TODO: add description for this.
+
+   value.sharing.share_blurb: TODO: add description for this.
+
+   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+   NOTE: THIS ORGANISM IS DEPRECATED. USE info-unit-group-2.html INSTEAD.
+   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+   ========================================================================== #}
+
 <div class="o-info-unit-group" data-qa-hook="image-text-50-50">
     {% if value.heading %}
     <h2>{{ value.heading }}</h2>

--- a/cfgov/jinja2/v1/_includes/organisms/mortgage-performance-downloads.html
+++ b/cfgov/jinja2/v1/_includes/organisms/mortgage-performance-downloads.html
@@ -8,7 +8,6 @@
    Description:
 
    A full width organism for automating display of mortgage data archives.
-   See [GHE]/flapjack/Modules-V1/wiki/Data-downloads
 
    ========================================================================== #}
 {% set archive_30_60 = download_files[thru_month]['percent_30_60'] %}
@@ -47,7 +46,7 @@
             <td>
                 <p><a aria-label="Download latest CSV file of mortgages 30 to 60 days delinquent by state"
                         href="{{ archive_30_60['State']['url'] }}">
-                    CSV</a> 
+                    CSV</a>
                     ({{ archive_30_60['State']['size'] }})
                 </p>
             </td>
@@ -61,7 +60,7 @@
                         href="{{ archive_30_60['County']['url'] }}">
                     CSV</a> ({{ archive_30_60['County']['size'] }})</p>
             </td>
-        </tr>                
+        </tr>
         <tr>
             <td>
                 <p>Mortgages 90 or more days delinquent</p>
@@ -140,7 +139,7 @@
                     href="{{ archive_30_60['County']['url'] }}">
                 CSV</a> ({{ archive_30_60['County']['size'] }})</p>
             </td>
-        </tr>                
+        </tr>
         <tr>
             <td>
                 <p>Mortgages 90 or more days delinquent</p>

--- a/cfgov/jinja2/v1/_includes/organisms/sidebar-breakout.html
+++ b/cfgov/jinja2/v1/_includes/organisms/sidebar-breakout.html
@@ -8,24 +8,25 @@
 
    Creates Sidebar Breakout markup when given:
 
-   page.content:                   An object used to customize the markup.
+   page.content: An object used to customize the markup.
 
-   page.content.text_introduction  An object containing the text intro molecule
+   page.content.text_introduction: An object containing the text intro molecule.
 
-   page.sidebar_breakout:          An object used to customize the markup.
+   page.sidebar_breakout: An object used to customize the markup.
 
-   page.sidebar_breakout.heading:  A string containing heading text. (Optional)
+   page.sidebar_breakout.heading: (Optional) A string containing heading text.
 
-   page.sidebar_breakout.image:    An object used to customize the image
-                                    markup. (Optional)
+   page.sidebar_breakout.image: (Optional) An object used to customize the image
+                                markup.
 
-   page.sidebar_breakout.intro.body:  A string containing body text. (Optional)
 
-   page.sidebar_breakout.intro.heading: A string containing heading text.
-                                          (Optional)
+   page.sidebar_breakout.intro.body: (Optional) A string containing body text.
 
-   page.sidebar_breakout.related_posts: An object used to customize the related
-                                          posts markup. (Optional)
+   page.sidebar_breakout.intro.heading: (Optional) A string containing heading
+                                        text.
+
+   page.sidebar_breakout.related_posts: (Optional) An object used to customize
+                                        the related posts markup.
 
    ========================================================================== #}
 

--- a/cfgov/jinja2/v1/_includes/organisms/video-player.html
+++ b/cfgov/jinja2/v1/_includes/organisms/video-player.html
@@ -6,11 +6,11 @@
 
    Description:
 
-   Create a video player for the Wagtail Video Player module.
+   Create a video player for the Wagtail Video Player module when given:
 
-   value:                  Object defined from a StreamField block.
+   value: Object defined from a StreamField block.
 
-   value.video_url:        A string containing the YouTube embed URL to use.
+   value.video_url: A string containing the YouTube embed URL to use.
 
    ========================================================================== #}
 


### PR DESCRIPTION
Code comments reference deprecated component wiki docs on flapjack repo. This updates those comments to point to the hubcap docs, where those equivalent docs exist.

Missing equivalents are:
[GHE]/flapjack/Modules-V1/wiki/Item-Introduction (is found in design manual)
[GHE]/flapjack/Modules-V1/wiki/Contact-Information-(Main-Content-Area)
[GHE]/flapjack/Modules-V1/wiki/Mortgage-Chart
[GHE]/flapjack/Modules-V1/wiki/Mortgage-Map
[GHE]/flapjack/Modules-V1/wiki/Contact-Information-(Sidebar)
[GHE]/flapjack/Modules-V1/wiki/Tables (is found in design manual)
[GHE]/flapjack/Modules-V1/wiki/Well (is found in design manual)

## Changes

- Changes links from flapjack to hubcap repo, where there are equivalent pages.
- Fixes some wonky whitespace.