### PR TITLE
Add feature flag to publish new financial well-being hub to Beta

### DIFF
--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -672,6 +672,9 @@ FLAGS = {
     'ASK_CFPB_H1': {
         'in split testing cluster': 'ASK_CFPB_H1'
     },
+
+    # Test financial well-being hub pages on Beta
+    'FINANCIAL_WELLBEING_HUB': {},
 }
 
 

--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -674,7 +674,7 @@ FLAGS = {
     },
 
     # Test financial well-being hub pages on Beta
-    'FINANCIAL_WELLBEING_HUB': {},
+    'FINANCIAL_WELLBEING_HUB': {'environment is': 'beta'},
 }
 
 

--- a/cfgov/cfgov/urls.py
+++ b/cfgov/cfgov/urls.py
@@ -7,6 +7,7 @@ from django.contrib import admin
 from django.contrib.auth import views as auth_views
 from django.http import Http404, HttpResponse
 from django.shortcuts import render
+from django.views.defaults import page_not_found
 from django.views.generic.base import RedirectView, TemplateView
 
 from wagtail.contrib.wagtailsitemaps.views import sitemap
@@ -403,6 +404,15 @@ urlpatterns = [
 
     # Explicitly redirect eRegulations URLs to Regulations3000
     url(r'^eregulations/.*', redirect_eregs, name='eregs-redirect'),
+
+    # put financial well-being pages behind feature flag for testing
+    flagged_url(
+        'FINANCIAL_WELLBEING_HUB',
+        r'^practitioner-resources/financial-well-being-resources/',
+        lambda request: ServeView.as_view()(request, request.path),
+        fallback=page_not_found,
+        name='financial-well-being-resources'
+    )
 
 ]
 


### PR DESCRIPTION
Add a feature flag, FINANCIAL_WELLBEING_HUB so we can run user testing the week of January 2nd, before launching the pages. When the flag is enabled, the new financial well-being hub will be published only the Beta server. 

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Internet Explorer 8, 9, 10, and 11
- [ ] Edge
- [ ] iOS Safari
- [ ] Chrome for Android

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
