### PR TITLE
Fix 500 error on Financial Wellbeing page

### DIFF
--- a/cfgov/cfgov/urls.py
+++ b/cfgov/cfgov/urls.py
@@ -7,7 +7,6 @@ from django.contrib import admin
 from django.contrib.auth import views as auth_views
 from django.http import Http404, HttpResponse
 from django.shortcuts import render
-from django.views.defaults import page_not_found
 from django.views.generic.base import RedirectView, TemplateView
 
 from wagtail.contrib.wagtailsitemaps.views import sitemap
@@ -406,12 +405,10 @@ urlpatterns = [
     url(r'^eregulations/.*', redirect_eregs, name='eregs-redirect'),
 
     # put financial well-being pages behind feature flag for testing
-    flagged_url(
+    flagged_wagtail_only_view(
         'FINANCIAL_WELLBEING_HUB',
         r'^practitioner-resources/financial-well-being-resources/',
-        lambda request: ServeView.as_view()(request, request.path),
-        fallback=page_not_found,
-        name='financial-well-being-resources'
+        'financial-well-being-resources'
     )
 
 ]


### PR DESCRIPTION
`/practitioner-resources/financial-well-being-resources/` should show a 404 page, but instead it is causing a 500 error. This PR fixes the bug that was causing the error.

The issue was that the code used `fallback=page_not_found`, which doesn't work. Instead, we can use a convenience method called `flagged_wagtail_only_view`, which has the correct fallback as the default.

## Changes

 - Use `flagged_wagtail_only_view` to conditionally show Wagtail content when a flag is enabled, rather than duplicating its code.

## Testing

1. Running this branch, visit http://localhost:8000/practitioner-resources/financial-well-being-resources/
2. If you have `debug = True` in your Django settings, you'll see a 404 page with the message "flag FINANCIAL_WELLBEING_HUB not set". You won't see a 500 error page.

(optional steps)
3. visit http://localhost:8000/admin, log in with `admin`/`admin`
4. Navigate to "Settings" > "Flags"
5. Press the "add flag condition" (at the bottom)
6. Enter the following in the form: "Flag `FINANCIAL_WELLBEING_HUB` is enabled when `boolean` is `True`". Submit the page.
7. Visit http://localhost:8000/practitioner-resources/financial-well-being-resources/ again
8. You'll still see a 404 page, but it won't have the "flag not set" message

## Notes/Todos

- When testing this, in step 8 (above) I expected to see content served from Wagtail. Instead, I saw nothing. I have the latest database dump. Should there be content in Wagtail at that URL? @ielerol 

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
