### PR TITLE
Housing counselor: Hide print list button on no-js state

### DIFF
--- a/cfgov/housing_counselor/jinja2/housing_counselor/index.html
+++ b/cfgov/housing_counselor/jinja2/housing_counselor/index.html
@@ -136,8 +136,11 @@
                                        m-list__horizontal
                                        hud_hca_api_results_actions">
                                 <li class="m-list_item">
-                                    <a class="a-link a-link__icon"
-                                       id="hud_print-page-link" href="#">
+                                    <a class="a-link
+                                              a-link__icon
+                                              u-hidden"
+                                       id="hud_print-page-link"
+                                       href="#">
                                         <span class="a-link_text">
                                             Print list
                                         </span>

--- a/cfgov/housing_counselor/jinja2/housing_counselor/index.html
+++ b/cfgov/housing_counselor/jinja2/housing_counselor/index.html
@@ -137,8 +137,7 @@
                                        hud_hca_api_results_actions">
                                 <li class="m-list_item">
                                     <a class="a-link
-                                              a-link__icon
-                                              u-hidden"
+                                              a-link__icon"
                                        id="hud_print-page-link"
                                        href="#">
                                         <span class="a-link_text">

--- a/cfgov/unprocessed/apps/find-a-housing-counselor/css/hud.less
+++ b/cfgov/unprocessed/apps/find-a-housing-counselor/css/hud.less
@@ -45,7 +45,8 @@
         }
     }
 
-    #hud_hca_api_map_container {
+    #hud_hca_api_map_container,
+    #hud_print-page-link {
         display: none;
     }
 }

--- a/cfgov/unprocessed/apps/find-a-housing-counselor/js/common.js
+++ b/cfgov/unprocessed/apps/find-a-housing-counselor/js/common.js
@@ -14,7 +14,6 @@ API queries. -wernerc */
 // Set up print results list button functionality, if it exists.
 const printPageLink = document.querySelector( '#hud_print-page-link' );
 if ( printPageLink ) {
-  printPageLink.classList.remove( 'u-hidden' );
   printPageLink.addEventListener( 'click', evt => {
     evt.preventDefault();
     window.print();

--- a/cfgov/unprocessed/apps/find-a-housing-counselor/js/common.js
+++ b/cfgov/unprocessed/apps/find-a-housing-counselor/js/common.js
@@ -14,6 +14,7 @@ API queries. -wernerc */
 // Set up print results list button functionality, if it exists.
 const printPageLink = document.querySelector( '#hud_print-page-link' );
 if ( printPageLink ) {
+  printPageLink.classList.remove( 'u-hidden' );
   printPageLink.addEventListener( 'click', evt => {
     evt.preventDefault();
     window.print();


### PR DESCRIPTION
"Print list" link was showing when JS was turned off, which is non-functional without JavaScript. ~~This PR hides that link and shows it via JS.~~

## Changes

- Makes housing counselor "print list" link hidden via CSS in `no-js` state.

## Testing

1. Pull this branch and `gulp clean && gulp build`
2. Load http://localhost:8000/find-a-housing-counselor/?zipcode=12345 and see that "Print list" link is visible.
3. Go into dev console settings and disable JS and reload the page. See that the "Print list" link is hidden.

<img width="265" alt="screen shot 2018-12-27 at 1 30 44 pm" src="https://user-images.githubusercontent.com/704760/50490550-ae673d00-09db-11e9-8d8e-61890e4f5aa9.png">
<img width="255" alt="screen shot 2018-12-27 at 1 30 50 pm" src="https://user-images.githubusercontent.com/704760/50490551-ae673d00-09db-11e9-953a-275aedf629be.png">

