### PR TITLE
Filters: Convert fieldCache object hash to a Map

### DIFF
--- a/cfgov/unprocessed/js/modules/util/FormModel.js
+++ b/cfgov/unprocessed/js/modules/util/FormModel.js
@@ -25,7 +25,7 @@ function FormModel( form ) {
     ]
   };
 
-  const _fieldCache = {};
+  const _fieldCache = new Map();
 
   /**
    * @returns {FormModel} An instance.
@@ -84,15 +84,18 @@ function FormModel( form ) {
         }
       }
 
-      _fieldCache[element] = {
-        type: type,
-        label: _getLabelText( element, false || isInGroup ),
-        isInGroup: isInGroup
-      };
+      _fieldCache.set(
+        element,
+        {
+          type: type,
+          label: _getLabelText( element, false || isInGroup ),
+          isInGroup: isInGroup
+        }
+      );
     }
-    _fieldCache.elements = rawElements;
-    _fieldCache.validateableElements = validateableElements;
-    _fieldCache.fieldGroups = fieldGroups;
+    _fieldCache.set( 'elements', rawElements );
+    _fieldCache.set( 'validateableElements', validateableElements );
+    _fieldCache.set( 'fieldGroups', fieldGroups );
   }
 
   /**

--- a/cfgov/unprocessed/js/organisms/FilterableListControls.js
+++ b/cfgov/unprocessed/js/organisms/FilterableListControls.js
@@ -133,7 +133,7 @@ function FilterableListControls( element ) {
    */
   function _formSubmitted() {
     const validatedFields = _validateFields(
-      _formModel.getModel().validateableElements
+      _formModel.getModel().get( 'validateableElements' )
     );
 
     if ( validatedFields.invalid.length > 0 ) {
@@ -214,7 +214,7 @@ function FilterableListControls( element ) {
    */
   function _validateField( field ) {
     let fieldset;
-    const fieldModel = _formModel.getModel()[field];
+    const fieldModel = _formModel.getModel().get( field );
     const validation = {
       field:  field,
       // TODO: Change layout of field groups to use fieldset.

--- a/test/unit_tests/js/modules/util/FormModel-spec.js
+++ b/test/unit_tests/js/modules/util/FormModel-spec.js
@@ -60,10 +60,10 @@ describe( 'FormModel', () => {
       const modelInst = new FormModel( document.forms[0] ).init();
       const model = modelInst.getModel();
 
-      expect( model.elements.length ).toBe( 15 );
-      expect( model.validateableElements.length ).toBe( 13 );
-      expect( model.fieldGroups.length ).toBe( 1 );
-      expect( model.fieldGroups[0] ).toBe( 'categories' );
+      expect( model.get( 'elements' ).length ).toBe( 15 );
+      expect( model.get( 'validateableElements' ).length ).toBe( 13 );
+      expect( model.get( 'fieldGroups' ).length ).toBe( 1 );
+      expect( model.get( 'fieldGroups' )[0] ).toBe( 'categories' );
     } );
 
   } );


### PR DESCRIPTION
`fieldCache` object was using HTMLNodes as keys, which get converted to strings, which aren't unique across instances of HTMLNodes, leading to some values overwriting others. Maps are restricted to strings as keys, which solves the issue (all credit to @wpears)

## Changes

- Convert `fieldCache` object to Map.

## Testing

1. `gulp test:unit` should pass.
2. `gulp clean && gulp build` and test adding and applying a filter, like on /about-us/newsroom/
