### PR TITLE
Add option to Export Ask data from Wagtail admin

### DIFF
--- a/cfgov/ask_cfpb/templates/admin/export.html
+++ b/cfgov/ask_cfpb/templates/admin/export.html
@@ -1,0 +1,22 @@
+{% extends "wagtailadmin/base.html" %}
+{% load i18n %}
+{% block titletag %}{% trans "Export Ask data" %}{% endblock %}
+
+{% block content %}
+
+    {% include "wagtailadmin/shared/header.html" with title="Ask CFPB Export" icon="download" %}
+
+    <div class="nice-padding">
+        <h3>
+            Download a spreadsheet of all Ask CFPB answers. <br>
+            This may take up to a minute or so to complete.
+        </h3>
+        <form method="post">
+            {% csrf_token %}
+            <button type="submit" class="button">
+                Download CSV
+            </button>
+        </form>
+    </div>
+
+{% endblock %}

--- a/cfgov/ask_cfpb/wagtail_hooks.py
+++ b/cfgov/ask_cfpb/wagtail_hooks.py
@@ -1,7 +1,10 @@
 from __future__ import unicode_literals
 
 from django.conf import settings
+from django.conf.urls import url
 from django.contrib.auth.decorators import login_required
+from django.core.urlresolvers import reverse
+from django.shortcuts import render
 from django.utils.decorators import method_decorator
 from django.utils.html import format_html, format_html_join
 
@@ -9,10 +12,12 @@ from wagtail.contrib.modeladmin.options import (
     ModelAdmin, ModelAdminGroup, modeladmin_register
 )
 from wagtail.contrib.modeladmin.views import EditView
+from wagtail.wagtailadmin.menu import MenuItem
 from wagtail.wagtailcore import hooks
 from wagtail.wagtailcore.whitelist import attribute_rule
 
 from ask_cfpb.models import Answer, Audience, Category, NextStep, SubCategory
+from ask_cfpb.scripts import export_ask_data
 
 
 class AnswerModelAdminSaveUserEditView(EditView):
@@ -93,6 +98,12 @@ class MyModelAdminGroup(ModelAdminGroup):
         NextStepModelAdmin)
 
 
+def export_data(request):
+    if request.method == 'POST':
+        return export_ask_data.export_questions(http_response=True)
+    return render(request, 'admin/export.html')
+
+
 def editor_js():
     js_files = [
         'js/html_editor.js',
@@ -133,3 +144,18 @@ hooks.register('insert_editor_js', editor_js)
 hooks.register('insert_editor_css', editor_css)
 hooks.register(
     'construct_whitelister_element_rules', whitelister_element_rules)
+
+
+@hooks.register('register_admin_menu_item')
+def register_export_menu_item():
+    return MenuItem(
+        'Export Ask data',
+        reverse('export-ask'),
+        classnames='icon icon-download',
+        order=99999,
+    )
+
+
+@hooks.register('register_admin_urls')
+def register_export_url():
+    return [url('export-ask', export_data, name='export-ask')]


### PR DESCRIPTION
This introduces a self-service option for downloading Ask CFPB data.  See GHE/CFGOV/enhanced-cms/issues/86 for more context.

Currently, this is done by a developer via a management script, and the spreadsheet is then shared with the team requesting it.  This PR adds a self-service option via the Wagtail admin. The spreadsheet produced will remain the same. 

## Screenshots
- Download interface
<img width="518" alt="screen shot 2019-01-02 at 3 16 56 pm" src="https://user-images.githubusercontent.com/354591/50617340-8aa36b80-0ea1-11e9-93bd-cf7462a81330.png">

## TODO
- Add test coverage
