### PR TITLE
Remove outdated docs on simple static templates

### DIFF
--- a/docs/development-tips.md
+++ b/docs/development-tips.md
@@ -76,14 +76,6 @@ Otherwise, if not using Docker, follow these guidelines:
     After running `gulp build` the site's assets are copied over to `cfgov\static_built`,
     ready to be served by Django.
 
-#### Simple static template setup
-
-By default, Django will render pages with accordance to the URL pattern defined
-for it. For example, going to `http://localhost:8000/the-bureau/index.html`
-(or `http://localhost:8000/the-bureau/`) renders `/the-bureau/index.html` from
-the `cfgov` app folder's `jinja2/v1` templates folder as processed
-by the [Jinja2](http://jinja.pocoo.org/docs) templating engine.
-
 ### TIP: Debugging site performance
 
 When running locally it is possible to enable the


### PR DESCRIPTION
This section of the development tips page is outdated and incorrect.

Django doesn't do this kind of global template matching by default unless the urls.py has been configured that way. We don't have that set up -- Wagtail handles any URLs that aren't otherwise specified in urls.py.

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [X] Passes all existing automated tests
- [X] Project documentation has been updated
- [X] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: