### PR TITLE
Fix broken documentation link

### DIFF
--- a/docs/testing-be.md
+++ b/docs/testing-be.md
@@ -54,7 +54,7 @@ We use the `flake8` and `isort` tools to ensure compliance with
 [PEP8 style guide](https://www.python.org/dev/peps/pep-0008/),
 [Django coding style guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/writing-code/coding-style/),
 and the 
-[CFPB Python style guide](https://github.com/cfpb/development/blob/unittesting-django-wagtail/standards/python.md#linting).
+[CFPB Python style guide](https://github.com/cfpb/development/blob/master/standards/python.md#linting).
 
 Both `flake8` and `isort` can be run using the Tox `lint` environment:
 


### PR DESCRIPTION
One of the links on the backend testing page is broken, as it refers to a branch of the [cfpb/development](https://github.com/cfpb/development/) repo that no longer exists. That branch has been merged to master, so this PR updates the link.

## Testing

To test, run the docs locally and then visit http://localhost:8888/testing-be/#linting.

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [X] Passes all existing automated tests
- [X] Project documentation has been updated
- [X] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: