### PR TITLE
Rename multi-select references multiselect

### DIFF
--- a/cfgov/unprocessed/css/main.less
+++ b/cfgov/unprocessed/css/main.less
@@ -102,7 +102,7 @@
 @import (less) "molecules/home-hero.less";
 @import (less) "molecules/info-unit.less";
 @import (less) "molecules/inset.less";
-@import (less) "molecules/multi-select.less";
+@import (less) "molecules/multiselect.less";
 @import (less) "molecules/nav-link.less";
 @import (less) "molecules/related-metadata.less";
 @import (less) "molecules/related-posts.less";

--- a/cfgov/unprocessed/css/molecules/multiselect.less
+++ b/cfgov/unprocessed/css/molecules/multiselect.less
@@ -1,4 +1,4 @@
-.cf-multi-select {
+.cf-multiselect {
     position: relative;
 
     &_header {
@@ -34,7 +34,7 @@
     }
 
      &.active {
-        .cf-multi-select_fieldset {
+        .cf-multiselect_fieldset {
             margin-top: 0;
             max-height: 140px;
 

--- a/cfgov/unprocessed/css/organisms/filterable-list-controls.less
+++ b/cfgov/unprocessed/css/organisms/filterable-list-controls.less
@@ -41,7 +41,7 @@
     }
 
     &.o-filterable-list-controls {
-        .cf-multi-select_fieldset {
+        .cf-multiselect_fieldset {
             position: relative;
         }
     }

--- a/cfgov/unprocessed/js/molecules/Multiselect.js
+++ b/cfgov/unprocessed/js/molecules/Multiselect.js
@@ -24,7 +24,7 @@ const closeIcon = require(
  */
 function Multiselect( element ) { // eslint-disable-line max-statements, inline-comments, max-len
 
-  const BASE_CLASS = 'cf-multi-select';
+  const BASE_CLASS = 'cf-multiselect';
   const LIST_CLASS = 'm-list';
   const CHECKBOX_INPUT_CLASS = 'a-checkbox';
   const TEXT_INPUT_CLASS = 'a-text-input';
@@ -71,7 +71,7 @@ function Multiselect( element ) { // eslint-disable-line max-statements, inline-
   let _instance;
 
   /**
-   * Set up and create the multi-select.
+   * Set up and create the multiselect.
    * @returns {Multiselect|undefined} An instance,
    *   or undefined if it was already initialized.
    */
@@ -105,7 +105,7 @@ function Multiselect( element ) { // eslint-disable-line max-statements, inline-
   }
 
   /**
-   * Expand the multi-select drop down.
+   * Expand the multiselect drop down.
    * @returns {Multiselect} An instance.
    */
   function expand() {
@@ -118,7 +118,7 @@ function Multiselect( element ) { // eslint-disable-line max-statements, inline-
   }
 
   /**
-   * Collapse the multi-select drop down.
+   * Collapse the multiselect drop down.
    * @returns {Multiselect} An instance.
    */
   function collapse() {
@@ -164,7 +164,7 @@ function Multiselect( element ) { // eslint-disable-line max-statements, inline-
   }
 
   /**
-   * Populates and injects the markup for the custom multi-select.
+   * Populates and injects the markup for the custom multiselect.
    * @returns {HTMLNode} Newly created <div> element to hold the multiselect.
    */
   function _populateMarkup() {

--- a/docs/testing-fe.md
+++ b/docs/testing-fe.md
@@ -16,7 +16,7 @@ and/or to run it in "fast" mode:
 
 ```sh
 gulp test:acceptance --suite=wagtail-admin ( runs just the wagtail-admin suite )
-gulp test:acceptance --specs=multi-select.feature ( runs just the multi-select feature )
+gulp test:acceptance --specs=multiselect.feature ( runs just the multiselect feature )
 gulp test:acceptance --tags=@mobile ( runs all scenarios tagged with @mobile )
 gulp test:acceptance --recreate ( runs the tests and recreates the virtual environment )
 ```
@@ -25,7 +25,7 @@ The same options can be used with tox (--omitted):
 
 ```sh
 tox -e acceptance suite=wagtail-admin
-tox -e acceptance specs=multi-select.feature
+tox -e acceptance specs=multiselect.feature
 tox -e acceptance tags=@mobile
 ```
 

--- a/test/browser_tests/cucumber/features/suites/default/multiselect.feature
+++ b/test/browser_tests/cucumber/features/suites/default/multiselect.feature
@@ -1,78 +1,78 @@
 
 Feature: MultiSelect Tags
   As a user of cf.gov
-  I should be able to select using the multi-select
+  I should be able to select using the multiselect
 
   Background:
     Given I goto a browse filterable page
     And I open the filterable list control
 
   Scenario: State on page load
-    Then the multi-select should be rendered
+    Then the multiselect should be rendered
     But no tags should be selected
-    And the multi-select dropdown shouldn't be visible
+    And the multiselect dropdown shouldn't be visible
 
   Scenario: Search input click
-    When I click on the multi-select search input
-    Then the multi-select dropdown should be visible
+    When I click on the multiselect search input
+    Then the multiselect dropdown should be visible
 
   Scenario: Search input focus
-    When I focus on the multi-select search input
-    Then the multi-select dropdown should be visible
+    When I focus on the multiselect search input
+    Then the multiselect dropdown should be visible
 
   Scenario: Search input blur
-    When I focus on the multi-select search input
+    When I focus on the multiselect search input
     And I click away from the search input
-    Then the multi-select dropdown shouldn't be visible
-    And the multi-select dropdown length should be 0
+    Then the multiselect dropdown shouldn't be visible
+    And the multiselect dropdown length should be 0
 
   Scenario: Typing in search input, returning matched results
     When I enter "tag0" in the search input
-    Then the multi-select dropdown should display "tag0"
-    And the multi-select dropdown length should be 1
+    Then the multiselect dropdown should display "tag0"
+    And the multiselect dropdown length should be 1
 
   Scenario: Typing in search input, not returning unmatched results
     When I enter "tag0" in the search input
-    Then the multi-select dropdown shouldn't display "tag2"
-    And the multi-select dropdown length should be 1
+    Then the multiselect dropdown shouldn't display "tag2"
+    And the multiselect dropdown length should be 1
 
   Scenario: Typing in search input, clearing the input and closing results
     When I enter "tag0" in the search input
     And I hit the escape button on the search input
-    Then the multi-select dropdown shouldn't be visible
-    And the multi-select dropdown length should be 0
+    Then the multiselect dropdown shouldn't be visible
+    And the multiselect dropdown length should be 0
     And the options field shouldn't contain the class "filtered"
 
   Scenario: Typing in search input, highlighting the first item
-    When I click on the multi-select search input
-    And I hit the down arrow on the multi-select
+    When I click on the multiselect search input
+    And I hit the down arrow on the multiselect
     Then the first option should be highlighted
 
   Scenario: Interacting with options list, adding option to choices
-    When I click on the multi-select search input
+    When I click on the multiselect search input
     And I click on the first option in the dropdown
     Then the choices element should contain the first option
 
   Scenario: Interacting with options list, removing option from choices
-    When I click on the multi-select search input
+    When I click on the multiselect search input
     And I click on the first option in the dropdown
     And I click on the first option in the dropdown again
     Then the choices length should be 0
 
   @undefined
   Scenario: XIT - Interacting with options list, add an option with RETURN key
-    When I click on the multi-select search input
-    And I hit the down arrow on the multi-select
+    When I click on the multiselect search input
+    And I hit the down arrow on the multiselect
     And I switch to the active element
 
   @undefined
   Scenario: XIT - Interacting with options list, remove an option with RETURN key
-    When I click on the multi-select search input
-    And I hit the down arrow on the multi-select
+    When I click on the multiselect search input
+    And I hit the down arrow on the multiselect
     And I switch to the active element
 
   Scenario: Interacting with choices list, remove an option from choices
-    When I click on the multi-select search input
+    When I click on the multiselect search input
     And I click on the first option in the dropdown
     And I click on the first choices element
     Then the choices length should be 0

--- a/test/browser_tests/cucumber/step_definitions/multiselect.js
+++ b/test/browser_tests/cucumber/step_definitions/multiselect.js
@@ -1,4 +1,4 @@
-const MultiSelect = require( '../../shared_objects/multi-select.js' );
+const MultiSelect = require( '../../shared_objects/multiselect' );
 const { Then, When, Before } = require( 'cucumber' );
 const chai = require( 'chai' );
 const expect = chai.expect;
@@ -13,7 +13,7 @@ Before( function() {
   multiSelect = new MultiSelect();
 } );
 
-When( /I (.*) on the multi-select search input/,
+When( /I (.*) on the multiselect search input/,
   async function( searchInputAction ) {
     await browser.wait( EC.visibilityOf( multiSelect.elements.search ) );
     await multiSelect.elements.search[searchInputAction]();
@@ -32,7 +32,7 @@ When( 'I hit the escape button on the search input', function() {
   return multiSelect.elements.search.sendKeys( protractor.Key.ESCAPE );
 } );
 
-When( /I hit the (.*) arrow on the multi-select/,
+When( /I hit the (.*) arrow on the multiselect/,
   function( arrowDirection ) {
     const directionConstant = protractor.Key[arrowDirection.toUpperCase()];
 
@@ -60,7 +60,7 @@ When( /I click on the first option in the dropdown(?:\s)?(?:again)?/,
   }
 );
 
-Then( 'the multi-select should be rendered', function() {
+Then( 'the multiselect should be rendered', function() {
 
   return expect( multiSelect.isRendered() )
     .to.eventually
@@ -74,7 +74,7 @@ Then( 'no tags should be selected', function() {
     .equal( false );
 } );
 
-Then( /the multi-select dropdown (should|shouldn't) be visible/,
+Then( /the multiselect dropdown (should|shouldn't) be visible/,
   function( shouldBeVisible ) {
     let dropdownIsDisplayed = true;
 
@@ -88,7 +88,7 @@ Then( /the multi-select dropdown (should|shouldn't) be visible/,
   }
 );
 
-Then( /the multi-select dropdown (should|shouldn't) display "(.*)"/,
+Then( /the multiselect dropdown (should|shouldn't) display "(.*)"/,
   function( shouldBeDisplayed, dropdownValue ) {
     let valueIsDisplayed = true;
 
@@ -102,7 +102,7 @@ Then( /the multi-select dropdown (should|shouldn't) display "(.*)"/,
   }
 );
 
-Then( /the multi-select dropdown length should be (.*)/,
+Then( /the multiselect dropdown length should be (.*)/,
   function( dropDownLength ) {
 
     return expect( multiSelect.getDropDownCount() )

--- a/test/browser_tests/page_objects/base-filterable-page.js
+++ b/test/browser_tests/page_objects/base-filterable-page.js
@@ -6,7 +6,7 @@ class BaseFilterablePage extends BasePage {
     this.results = await element.all( by.css( '.o-post-preview_content' ) );
     this.firstResult = this.results[0];
     this.lastResult = this.results[this.results.length - 1];
-    this.multiselect = await element.all( by.css( '.cf-multi-select' ) );
+    this.multiselect = await element.all( by.css( '.cf-multiselect' ) );
   }
 
   getResultsCount() {

--- a/test/browser_tests/shared_objects/filterable-list-control.js
+++ b/test/browser_tests/shared_objects/filterable-list-control.js
@@ -1,6 +1,6 @@
 const _oFilterableListControls =
   element( by.css( '.o-filterable-list-controls' ) );
-const multiselect = require( '../shared_objects/multi-select' );
+const multiselect = require( '../shared_objects/multiselect' );
 const EC = protractor.ExpectedConditions;
 
 

--- a/test/browser_tests/shared_objects/multiselect.js
+++ b/test/browser_tests/shared_objects/multiselect.js
@@ -1,4 +1,4 @@
-const _multiSelect = element.all( by.css( '.cf-multi-select' ) ).first();
+const _multiSelect = element.all( by.css( '.cf-multiselect' ) ).first();
 
 function _getMultiSelectElement( selector ) {
   return _multiSelect.element( by.css( selector ) );
@@ -6,11 +6,11 @@ function _getMultiSelectElement( selector ) {
 
 const elements = {
   base:     _multiSelect,
-  choices:  _getMultiSelectElement( '.cf-multi-select_choices' ),
-  header:   _getMultiSelectElement( '.cf-multi-select_header' ),
-  search:   _getMultiSelectElement( '.cf-multi-select_search' ),
-  fieldSet: _getMultiSelectElement( '.cf-multi-select_fieldset' ),
-  options:  _getMultiSelectElement( '.cf-multi-select_options' )
+  choices:  _getMultiSelectElement( '.cf-multiselect_choices' ),
+  header:   _getMultiSelectElement( '.cf-multiselect_header' ),
+  search:   _getMultiSelectElement( '.cf-multiselect_search' ),
+  fieldSet: _getMultiSelectElement( '.cf-multiselect_fieldset' ),
+  options:  _getMultiSelectElement( '.cf-multiselect_options' )
 };
 
 class MultiSelect {
@@ -55,25 +55,25 @@ class MultiSelect {
   }
 
   getChoiceElements() {
-    return element.all( by.css( '.cf-multi-select_choices label' ) );
+    return element.all( by.css( '.cf-multiselect_choices label' ) );
   }
 
   getChoiceElementsCount() {
-    return element.all( by.css( '.cf-multi-select_choices label' ) ).count();
+    return element.all( by.css( '.cf-multiselect_choices label' ) ).count();
   }
 
   getDropDownCount() {
-    return element.all( by.css( '.cf-multi-select .filter-match' ) ).count();
+    return element.all( by.css( '.cf-multiselect .filter-match' ) ).count();
   }
 
   getDropDownLabelElements() {
     return browser.element.all(
-      by.css( '.cf-multi-select_options li .cf-multi-select_label' )
+      by.css( '.cf-multiselect_options li .cf-multiselect_label' )
     );
   }
 
   getDisplayedTagElements() {
-    return element.all( by.css( '.cf-multi-select_choices li' ) );
+    return element.all( by.css( '.cf-multiselect_choices li' ) );
   }
 
   isRendered() {

--- a/test/unit_tests/js/molecules/Multiselect-spec.js
+++ b/test/unit_tests/js/molecules/Multiselect-spec.js
@@ -27,7 +27,7 @@ describe( 'Multiselect', () => {
     it( 'should initialize the Multiselect', () => {
       multiselect.init();
       selectDom = document.querySelectorAll( 'select[multiple]' );
-      multiselectDom = document.querySelectorAll( '.cf-multi-select' );
+      multiselectDom = document.querySelectorAll( '.cf-multiselect' );
 
       expect( selectDom.length ).toBe( 0 );
       expect( multiselectDom.length ).toBe( 1 );
@@ -38,7 +38,7 @@ describe( 'Multiselect', () => {
       option.defaultSelected = true;
       multiselect.init();
       const choices =
-          document.querySelectorAll( '.cf-multi-select_choices li' );
+          document.querySelectorAll( '.cf-multiselect_choices li' );
 
       expect( choices.length ).toBe( 1 );
       expect( choices[0].innerHTML ).toContain( 'Debt collection' );
@@ -53,7 +53,7 @@ describe( 'Multiselect', () => {
       option.value = 'Foo\'';
       multiselect.init();
       selectDom = document.querySelectorAll( 'select[multiple]' );
-      multiselectDom = document.querySelectorAll( '.cf-multi-select' );
+      multiselectDom = document.querySelectorAll( '.cf-multiselect' );
 
       expect( selectDom.length ).toBe( 1 );
       expect( multiselectDom.length ).toBe( 0 );
@@ -66,11 +66,11 @@ describe( 'Multiselect', () => {
     it( 'should open when the expand method is called', () => {
       multiselect.init();
       multiselect.expand();
-      multiselectDom = document.querySelector( '.cf-multi-select' );
+      multiselectDom = document.querySelector( '.cf-multiselect' );
       const fieldset =
-        multiselectDom.querySelector( '.cf-multi-select_fieldset' );
+        multiselectDom.querySelector( '.cf-multiselect_fieldset' );
 
-      expect( multiselectDom.className ).toBe( 'cf-multi-select active' );
+      expect( multiselectDom.className ).toBe( 'cf-multiselect active' );
       expect( fieldset.getAttribute( 'aria-hidden' ) ).toBe( 'false' );
     } );
 
@@ -78,11 +78,11 @@ describe( 'Multiselect', () => {
       multiselect.init();
       multiselect.expand();
       multiselect.collapse();
-      multiselectDom = document.querySelector( '.cf-multi-select' );
+      multiselectDom = document.querySelector( '.cf-multiselect' );
       const fieldset =
-        multiselectDom.querySelector( '.cf-multi-select_fieldset' );
+        multiselectDom.querySelector( '.cf-multiselect_fieldset' );
 
-      expect( multiselectDom.className ).toBe( 'cf-multi-select' );
+      expect( multiselectDom.className ).toBe( 'cf-multiselect' );
       expect( fieldset.getAttribute( 'aria-hidden' ) ).toBe( 'true' );
     } );
   } );
@@ -90,14 +90,14 @@ describe( 'Multiselect', () => {
   describe( 'interactions', () => {
     xit( 'should open when the search input is clicked', function() {
       multiselect.init();
-      multiselectDom = document.querySelector( '.cf-multi-select' );
+      multiselectDom = document.querySelector( '.cf-multiselect' );
       const fieldset =
-        multiselectDom.querySelector( '.cf-multi-select_fieldset' );
+        multiselectDom.querySelector( '.cf-multiselect_fieldset' );
       const search = document.querySelector( '#test-select' );
       search.click();
 
       expect( document.activeElement.id ).toBe( 'test-select' );
-      expect( multiselectDom.className ).toBe( 'cf-multi-select active' );
+      expect( multiselectDom.className ).toBe( 'cf-multiselect active' );
       expect( fieldset.getAttribute( 'aria-hidden' ) ).toBe( 'false' );
     } );
 
@@ -113,12 +113,12 @@ describe( 'Multiselect', () => {
     xit( 'should close when the body is clicked', function() {
       multiselect.init();
       multiselect.expand();
-      multiselectDom = document.querySelector( '.cf-multi-select' );
+      multiselectDom = document.querySelector( '.cf-multiselect' );
       const fieldset =
-        multiselectDom.querySelector( '.cf-multi-select_fieldset' );
+        multiselectDom.querySelector( '.cf-multiselect_fieldset' );
       document.click();
 
-      expect( multiselectDom.className ).toBe( 'cf-multi-select' );
+      expect( multiselectDom.className ).toBe( 'cf-multiselect' );
       expect( fieldset.getAttribute( 'aria-hidden' ) ).toBe( 'true' );
     } );
   } );


### PR DESCRIPTION
We have a mix of multi-select and multiselect. To standardize on the non-hyphen, this changes references and filenames to multi-select to multiselect.

## Changes

- Change references and filenames from "multi-select" to "multiselect"

## Testing

1. `gulp build && gulp test:unit` should pass. Also Travis should pass here.
