### PR TITLE
Switch ask search div to label and show outline on focus

### DIFF
--- a/cfgov/jinja2/v1/_includes/organisms/search-bar.html
+++ b/cfgov/jinja2/v1/_includes/organisms/search-bar.html
@@ -42,7 +42,7 @@
               {{ value.additional_classes }}">
     <form method="get" action="{{ value.action }}" class="content-l">
         {% if value.label %}
-        <label for="q" class="o-search-bar_label o-search-bar_col">
+        <label for="o-search-bar_query" class="o-search-bar_label o-search-bar_col">
             <h4 class="u-mb0">
                 {{ value.label | safe }}
             </h4>
@@ -51,7 +51,7 @@
         <div class="o-search-bar_input o-search-bar_col">
             <div class="input-with-btn input-with-btn__bar">
                 <div class="input-with-btn_input {% if value.autocomplete %} m-autocomplete{% endif %}">
-                    <input class="a-text-input" type="text" name="q" id="q" value="{{ value.q }}">
+                    <input class="a-text-input" type="text" name="o-search-bar_query" id="o-search-bar_query" value="{{ value.q }}">
                 </div>
                 <div class="input-with-btn_btn">
                     <button class="a-btn" name="btnSearch" id="btnSearch" type="submit">

--- a/cfgov/jinja2/v1/_includes/organisms/search-bar.html
+++ b/cfgov/jinja2/v1/_includes/organisms/search-bar.html
@@ -42,11 +42,11 @@
               {{ value.additional_classes }}">
     <form method="get" action="{{ value.action }}" class="content-l">
         {% if value.label %}
-        <div class="o-search-bar_label o-search-bar_col">
+        <label for="q" class="o-search-bar_label o-search-bar_col">
             <h4 class="u-mb0">
                 {{ value.label | safe }}
             </h4>
-        </div>
+        </label>
         {% endif %}
         <div class="o-search-bar_input o-search-bar_col">
             <div class="input-with-btn input-with-btn__bar">

--- a/cfgov/unprocessed/css/enhancements/forms.less
+++ b/cfgov/unprocessed/css/enhancements/forms.less
@@ -165,7 +165,6 @@ input {
 
         &:focus {
             box-shadow: 0 0 0 1px @pacific inset;
-            outline: none;
         }
     }
 }


### PR DESCRIPTION
Closes GHE/CFGOV/platform/issues/3131

## Additions

-

## Removals

- CSS rule disabling the default outline for `.input-with-btn input`

## Changes

- Moves ask search-bar_label to a true label

## Testing

1. Pull & yarn run gulp build
2. Navigate to /ask-cfpb/ and focus on the search bar. The default dotted outline should appear.
3. Note that stylistically the search-bar_label is unchanged (although now it is more semantically correct).

Slight caveat to point 3, you'll note that clicking on the label text will now focus on the search input. I think this is a feature, so I didn't disable this behavior, although it is different from live. Also note that the cursor remains `default` over the label rather than `text`. I think this makes sense as well (and seems to match other labels on the site) but is another slight difference from live.