### PR TITLE
Add explicit note about using a full URL when clearing the cache

### DIFF
--- a/cfgov/v1/templates/cdnadmin/index.html
+++ b/cfgov/v1/templates/cdnadmin/index.html
@@ -2,6 +2,7 @@
 {% load i18n %}
 {% load gravatar %}
 {% load humanize %}
+
 {% block titletag %}{% trans "CDN Manager" %}{% endblock %}
 
 {% block content %}
@@ -11,51 +12,55 @@
     <div class="nice-padding">
         <h2>Flush Akamai</h2>
 
-        {% if user_can_purge %}
+    {% if user_can_purge %}
         <div class="help-block help-info">
-            <p>Enter a URL to flush it from the cache, or leave it blank to
-            flush the entire site cache</p>
+            <p>
+                Enter a full URL (e.g., <code>https://www.consumerfinance.gov/about-us/</code>)
+                to flush it from the cache, or leave it blank to flush the entire site cache.
+            </p>
         </div>
         <form method="post" id="flush_site">
             {% csrf_token %}
             <ul class="fields">
                 <li>
-            <div class="field url_field url_input">
-            <div class="input">
-            {{ form.url }}
-            </div>
-            </div>
-            </li>
-        </ul>
-        <button type="submit" name="flush" class="button" form="flush_site" />
-        Flush cache 
-        </button>
+                    <div class="field url_field url_input">
+                        <div class="input">
+                        {{ form.url }}
+                        </div>
+                    </div>
+                </li>
+            </ul>
+            <button type="submit" name="flush" class="button">Flush cache</button>
         </form>
-        {% else %}
+    {% else %}
         <div class="help-block help-info">
-            <p>You do not have permission to submit purge requests, but you
-            are welcome to view the history</p>
+            <p>
+                You do not have permission to submit purge requests,
+                but you are welcome to view the history.
+            </p>
         </div>
-        {% endif %}
-        <h2> History </h2>
+    {% endif %}
+
+        <h2>History</h2>
 
         <table class="listing">
             <thead>
-            <tr>
-                <td> When </td>
-                <td> Who </td>
-                <td> Result </td>
-            </tr>
+                <tr>
+                    <th>When</th>
+                    <th>Who</th>
+                    <th>Result</th>
+                </tr>
             </thead>
             <tbody>
             {% for history_item in history %}
-            <tr>
-                <td> {{ history_item.created | naturaltime }} </td>
-                <td> {{ history_item.user }} </td>
-                <td> {{ history_item.message }} </td>
-            </tr>
+                <tr>
+                    <td>{{ history_item.created | naturaltime }}</td>
+                    <td>{{ history_item.user }}</td>
+                    <td>{{ history_item.message }}</td>
+                </tr>
             {% endfor %}
             </tbody>
+        </table>
     </div>
 
 {% endblock %}

--- a/cfgov/v1/tests/test_admin_views.py
+++ b/cfgov/v1/tests/test_admin_views.py
@@ -86,7 +86,7 @@ class TestCDNManagementView(TestCase):
         self.client.login(username='cdn', password='password')
         response = self.client.get(reverse('manage-cdn'))
         self.assertEqual(response.status_code, 200)
-        self.assertContains(response, "Enter a URL to flush it")
+        self.assertContains(response, "Enter a full URL")
 
     @mock.patch('v1.models.akamai_backend.AkamaiBackend.purge')
     def test_submission_with_url(self, mock_purge):


### PR DESCRIPTION
We should be more clear that when flushing Akamai for a specific page, it is necessary to enter a full URL.

Also includes some formatting cleanup.

## Testing

1. Pull branch
1. Replace your [Akamai settings in `cfgov/cfgov/settings/base.py`](https://github.com/cfpb/cfgov-refresh/blob/Scotchester-patch-1/cfgov/cfgov/settings/base.py#L479-L489) with:

   ```py
   # Akamai
   ENABLE_AKAMAI_CACHE_PURGE = True
   if ENABLE_AKAMAI_CACHE_PURGE:
       WAGTAILFRONTENDCACHE = {
           'akamai': {
               'BACKEND': 'v1.models.akamai_backend.AkamaiBackend',
               'CLIENT_TOKEN': 'fake',
               'CLIENT_SECRET': 'fake',
               'ACCESS_TOKEN': 'fake',
           },
       }
   ```
1. Visit http://localhost:8000/admin/cdn/ and see the updated message.

## Screenshots

![screen shot 2019-01-09 at 12 53 06](https://user-images.githubusercontent.com/1044670/50918253-b7a9ce00-140d-11e9-93c0-1618c2fe55d6.png)

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
