### PR TITLE
Rename the "development playbook" checkbox link for consistency

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -32,7 +32,7 @@
 - [ ] PR has an informative and human-readable title
 - [ ] Changes are limited to a single goal (no scope creep)
 - [ ] Code can be automatically merged (no conflicts)
-- [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
+- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
 - [ ] Passes all existing automated tests
 - [ ] Any _change_ in functionality is tested
 - [ ] New functions are documented (with a description, list of inputs, and expected output)


### PR DESCRIPTION
This PR changes the name of the link in the PR template checkbox for code changes that meet our standards to be consistent with how we refer to the target of that link elsewhere. It is now "CFPB development guidelines" instead of "development playbook."

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
