### PR TITLE
Reference parent page relatively in backlink from spanish ask print page

### DIFF
--- a/cfgov/jinja2/v1/ask-cfpb/answer-page-spanish-printable.html
+++ b/cfgov/jinja2/v1/ask-cfpb/answer-page-spanish-printable.html
@@ -42,7 +42,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
         </div><!-- .brand -->
 
         <ul class="breadcrumb">
-            <li><a href="{{ slugurl(slug) }}" class="back">Regresar al respuesta</a></li>
+            <li><a href="../" class="back">Regresar al respuesta</a></li>
         </ul>
 
         <section class="content">


### PR DESCRIPTION
Greatly assists with GHE/CFGOV/platform/issues/2574 and GHE/CFGOV/platform/issues/3185
On spanish ask-cfpb print pages (which have mostly identical content but simpler styles), the back link is broken. This fixes it by setting the backlink url to the parent page `../` which will always be correct as the print page for a given `url` is generated at `url/imprimir`. Visiting `../` from `url/imprimir` returns you to `url`.

## Changes
- Instead of trying to get the appropriate page with a Wagtail `slugurl` call, just reference the parent page relatively.

## Testing

1. Visit any spanish ask page (eg /es/obtener-respuestas/despues-de-pagar-mi-hipoteca-en-total-como-reviso-si-el-gravamen-lien-fue-liberado-es-206/imprimir/) and the back link ("Regresar al respuesta") should return to the standard spanish ask page.
