### PR TITLE
Enforce only one filterable list per page

### DIFF
--- a/cfgov/v1/models/browse_filterable_page.py
+++ b/cfgov/v1/models/browse_filterable_page.py
@@ -3,6 +3,7 @@ from django.db import models
 from wagtail.wagtailadmin.edit_handlers import (
     FieldPanel, ObjectList, StreamFieldPanel, TabbedInterface
 )
+from wagtail.wagtailcore.blocks import StreamBlock
 from wagtail.wagtailcore.fields import StreamField
 from wagtail.wagtailcore.models import PageManager
 from wagtail.wagtailsearch import index
@@ -14,6 +15,21 @@ from v1.models.base import CFGOVPage
 from v1.util.filterable_list import FilterableListMixin
 
 
+class BrowseFilterableContent(StreamBlock):
+    """Defines the StreamField blocks for BrowseFilterablePage content.
+
+    Pages can have at most one filterable list.
+    """
+    full_width_text = organisms.FullWidthText()
+    filter_controls = organisms.FilterControls()
+    feedback = v1_blocks.Feedback()
+
+    class Meta:
+        block_counts = {
+            'filter_controls': {'max_num': 1},
+        }
+
+
 class BrowseFilterablePage(FilterableFeedPageMixin,
                            FilterableListMixin,
                            CFGOVPage):
@@ -21,11 +37,7 @@ class BrowseFilterablePage(FilterableFeedPageMixin,
         ('text_introduction', molecules.TextIntroduction()),
         ('featured_content', organisms.FeaturedContent()),
     ])
-    content = StreamField([
-        ('full_width_text', organisms.FullWidthText()),
-        ('filter_controls', organisms.FilterControls()),
-        ('feedback', v1_blocks.Feedback()),
-    ])
+    content = StreamField(BrowseFilterableContent)
 
     secondary_nav_exclude_sibling_pages = models.BooleanField(default=False)
 

--- a/cfgov/v1/models/sublanding_filterable_page.py
+++ b/cfgov/v1/models/sublanding_filterable_page.py
@@ -1,6 +1,7 @@
 from wagtail.wagtailadmin.edit_handlers import (
     ObjectList, StreamFieldPanel, TabbedInterface
 )
+from wagtail.wagtailcore.blocks import StreamBlock
 from wagtail.wagtailcore.fields import StreamField
 from wagtail.wagtailcore.models import PageManager
 from wagtail.wagtailsearch import index
@@ -12,19 +13,30 @@ from v1.models.base import CFGOVPage
 from v1.util.filterable_list import FilterableListMixin
 
 
+class SublandingFilterableContent(StreamBlock):
+    """Defines the StreamField blocks for SublandingFilterablePage content.
+
+    Pages can have at most one filterable list.
+    """
+    text_introduction = molecules.TextIntroduction()
+    full_width_text = organisms.FullWidthText()
+    filter_controls = organisms.FilterControls()
+    featured_content = organisms.FeaturedContent()
+    feedback = v1_blocks.Feedback()
+
+    class Meta:
+        block_counts = {
+            'filter_controls': {'max_num': 1},
+        }
+
+
 class SublandingFilterablePage(FilterableFeedPageMixin,
                                FilterableListMixin,
                                CFGOVPage):
     header = StreamField([
         ('hero', molecules.Hero()),
     ], blank=True)
-    content = StreamField([
-        ('text_introduction', molecules.TextIntroduction()),
-        ('full_width_text', organisms.FullWidthText()),
-        ('filter_controls', organisms.FilterControls()),
-        ('featured_content', organisms.FeaturedContent()),
-        ('feedback', v1_blocks.Feedback()),
-    ])
+    content = StreamField(SublandingFilterableContent)
 
     # General content tab
     content_panels = CFGOVPage.content_panels + [


### PR DESCRIPTION
This change modifies the behavior of BrowseFilterablePage and SublandingFilterablePage to ensure that at most one FilterControls ~~or Feedback block~~ is entered into the page's content StreamField. Thanks to @anselmbradford for suggesting this change.

We only ever want at most one of these blocks on a page. After this change, trying to save a page with multiple blocks of these types will produce a validation error like this:

<img width="1150" alt="image" src="https://user-images.githubusercontent.com/654645/51039768-efd31d00-1583-11e9-9517-3a2c00abe44b.png">

Unfortunately there's currently no client-side validation in Wagtail, i.e. it still lets you add the block and only prevents saving. Client-side validation of block limits will be added as part of the Wagtail StreamField rewrite being done in https://github.com/wagtail/wagtail/issues/4473.

This logic could probably be expanded to other pages and blocks. I did an audit of all pages and we don't have duplicate filterable lists anywhere -- as far as I can tell, the exisiting logic won't work with multiple filterable lists anyway. It's a little harder to audit the Feedback blocks. @Scotchester, do you think it's a safe assumption to limit those to 1 per page? Could this also be expanded to include TextIntroductions, or do we sometimes have multiple of these on a page? Any other places you can think of to add a limit?

Aside: this implementation isn't particularly DRY, which makes me think there might be a way of consolidating how we've defined these pages and StreamFields.

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [X] Passes all existing automated tests
- [X] Any _change_ in functionality is tested
- [X] New functions are documented (with a description, list of inputs, and expected output)
- [X] Placeholder code is flagged / future todos are captured in comments
- [X] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [X] Project documentation has been updated
- [X] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: