### PR TITLE
Bump django-college-costs-comparison to 1.8.1

### DIFF
--- a/requirements/optional-public.txt
+++ b/requirements/optional-public.txt
@@ -3,5 +3,5 @@ https://github.com/cfpb/owning-a-home-api/releases/download/0.11.3/owning_a_home
 https://github.com/cfpb/retirement/releases/download/0.7.6/retirement-0.7.6-py2-none-any.whl
 https://github.com/cfpb/ccdb5-api/releases/download/1.1.7/ccdb5_api-1.1.7-py2-none-any.whl
 https://github.com/cfpb/ccdb5-ui/releases/download/1.1.0/ccdb5_ui-1.1.0-py2-none-any.whl
-https://github.com/cfpb/django-college-costs-comparison/releases/download/1.8.0/comparisontool-1.8.0-py2-none-any.whl
+https://github.com/cfpb/django-college-costs-comparison/releases/download/1.8.1/comparisontool-1.8.1-py2-none-any.whl
 https://github.com/cfpb/teachers-digital-platform/releases/download/1.0.28/teachers_digital_platform-1.0.28-py2-none-any.whl


### PR DESCRIPTION
This change bumps the version of the optional django-college-costs-comparison satellite app from 1.8.0 to 1.8.1.

This fixes a 500 error related to invalid POSTs to a certain API endpoint.

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [X] Passes all existing automated tests
- [X] Any _change_ in functionality is tested
- [X] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: