### PR TITLE
Filter: Add 'of' to error message copy

### DIFF
--- a/cfgov/v1/forms.py
+++ b/cfgov/v1/forms.py
@@ -24,7 +24,7 @@ class FilterableDateField(forms.DateField):
     def validate_after_1900(date):
         strftime_earliest_year = 1900
         if date.year < strftime_earliest_year:
-            raise ValidationError("Please enter a date 1/1/1900 or later.")
+            raise ValidationError("Please enter a date of 1/1/1900 or later.")
 
     default_validators = [validate_after_1900]
 


### PR DESCRIPTION
Add 'of' to error message copy per @schaferjh approval.

## Changes

- Add 'of' to FilterableListControl date error message copy.

## Testing

1. Visit `http://localhost:8000/about-us/newsroom/?title=&from_date=1%2F1%2F1800` and note error message.
