### PR TITLE
Fix issue with feedback form replacement and add acceptance tests

### DIFF
--- a/cfgov/scripts/test_data.py
+++ b/cfgov/scripts/test_data.py
@@ -113,6 +113,23 @@ def add_reusable_text_snippet(slug, cls):
     publish_page(page)
 
 
+def add_feedback_form(slug, cls):
+    feedback_form = {
+        'type': 'feedback',
+        'value': []
+    }
+    page = cls(
+        title=slug,
+        slug=slug,
+    )
+    page.content = StreamValue(
+        page.content.stream_block,
+        [feedback_form],
+        True,
+    )
+    publish_page(page)
+
+
 def add_menu_item_snippet():
     nav_group_block = {
         'type': 'nav_group',
@@ -159,6 +176,10 @@ def run():
     )
     add_reusable_text_snippet(
         slug='rts',
+        cls=BrowsePage,
+    )
+    add_feedback_form(
+        slug='feedback',
         cls=BrowsePage,
     )
     add_menu_item_snippet()

--- a/cfgov/unprocessed/js/organisms/FormSubmit.js
+++ b/cfgov/unprocessed/js/organisms/FormSubmit.js
@@ -6,7 +6,6 @@ import BaseTransition from '../modules/transition/BaseTransition';
 import ERROR_MESSAGES from '../config/error-messages-config';
 import Notification from '../molecules/Notification';
 import EventObserver from '../modules/util/EventObserver';
-
 const FORM_MESSAGES = ERROR_MESSAGES.FORM.SUBMISSION;
 
 /**
@@ -29,7 +28,7 @@ function FormSubmit( element, baseClass, opts ) {
   const _baseElement = checkDom( element, baseClass );
   const _formElement = _baseElement.querySelector( 'form' );
   const _notificationElement = _baseElement.querySelector(
-    Notification.BASE_CLASS
+    `.${ Notification.BASE_CLASS }`
   );
   let _notification;
   let _cachedFields;
@@ -162,7 +161,7 @@ function FormSubmit( element, baseClass, opts ) {
     }
 
     function fadeInMessage() {
-      _notification.update( _notification.SUCCESS, message );
+      _notification.update( Notification.SUCCESS, message );
       _notification.show();
       _baseElement.replaceChild( _notificationElement, _formElement );
       transition.removeEventListener( BaseTransition.END_EVENT, fadeInMessage );

--- a/test/browser_tests/cucumber/features/suites/default/feedback-form.feature
+++ b/test/browser_tests/cucumber/features/suites/default/feedback-form.feature
@@ -1,0 +1,27 @@
+Feature: Feedback form
+  As a user of cf.gov
+  I should be able to use the feedback form
+  to submit feedback
+
+  Scenario: Submit form without feedback
+    Given I goto URL "/feedback"
+    When I click the feedback form submit button
+    Then the notification element should be displayed
+    And the notification should report an error
+    And the feedback form should be present
+
+  Scenario: Submit form with radio selection
+    Given I goto URL "/feedback"
+    When I select a feedback radio button
+    And I click the feedback form submit button
+    Then the notification element should be displayed
+    And the notification should report success
+    And the feedback form should no longer be present
+
+  Scenario: Submit form with comment
+    Given I goto URL "/feedback"
+    When I enter a comment
+    And I click the feedback form submit button
+    Then the notification element should be displayed
+    And the notification should report success
+    And the feedback form should no longer be present

--- a/test/browser_tests/cucumber/step_definitions/feedback-form.js
+++ b/test/browser_tests/cucumber/step_definitions/feedback-form.js
@@ -29,24 +29,24 @@ Before( function() {
 When( 'I select a feedback radio button',
   function() {
     return browser.executeScript(
-      "arguments[0].click();",
+      'arguments[0].click();',
       _dom.radioButton1.getWebElement()
     );
   }
-)
+);
 
 When( 'I enter a comment',
   function() {
     return _dom.commentField.sendKeys( 'comment text' );
   }
-)
+);
 
 When( 'I click the feedback form submit button',
   async function() {
     _dom.submitButton.click();
     return await browser.sleep( 500 );
   }
-)
+);
 
 Then( 'the notification element should be displayed',
   function( ) {

--- a/test/browser_tests/cucumber/step_definitions/feedback-form.js
+++ b/test/browser_tests/cucumber/step_definitions/feedback-form.js
@@ -1,0 +1,90 @@
+const { Then, When, Before } = require( 'cucumber' );
+const chai = require( 'chai' );
+const expect = chai.expect;
+const chaiAsPromised = require( 'chai-as-promised' );
+
+const BASE_SEL = '.o-feedback';
+const FORM = BASE_SEL + ' .o-form';
+const COMMENT_FIELD = BASE_SEL + ' #comment';
+const RADIO_BUTTON_1 = BASE_SEL + ' #is_helpful_1';
+const SUBMIT_BUTTON = BASE_SEL + ' [type="submit"]';
+const NOTIFICATION = BASE_SEL + ' .m-notification';
+const SUCCESS_CLASS = 'm-notification__success';
+const ERROR_CLASS = 'm-notification__error';
+
+chai.use( chaiAsPromised );
+
+let _dom;
+
+Before( function() {
+  _dom = {
+    radioButton1:     element( by.css( RADIO_BUTTON_1 ) ),
+    commentField:     element( by.css( COMMENT_FIELD ) ),
+    submitButton:     element( by.css( SUBMIT_BUTTON ) ),
+    form:             element( by.css( FORM ) ),
+    notification:     element( by.css( NOTIFICATION ) )
+  };
+} );
+
+When( 'I select a feedback radio button',
+  function() {
+    return browser.executeScript(
+      "arguments[0].click();",
+      _dom.radioButton1.getWebElement()
+    );
+  }
+)
+
+When( 'I enter a comment',
+  function() {
+    return _dom.commentField.sendKeys( 'comment text' );
+  }
+)
+
+When( 'I click the feedback form submit button',
+  async function() {
+    _dom.submitButton.click();
+    return await browser.sleep( 500 );
+  }
+)
+
+Then( 'the notification element should be displayed',
+  function( ) {
+    return expect( _dom.notification.isDisplayed() )
+      .to.eventually.equal( true );
+  }
+);
+
+Then( 'the notification should report an error',
+  function( ) {
+    const notificationClasses =
+      _dom.notification.getAttribute( 'class' );
+    return expect( notificationClasses )
+      .to.eventually
+      .contain( ERROR_CLASS );
+  }
+);
+
+Then( 'the notification should report success',
+  function( ) {
+    const notificationClasses =
+      _dom.notification.getAttribute( 'class' );
+    return expect( notificationClasses )
+      .to.eventually
+      .contain( SUCCESS_CLASS );
+  }
+);
+
+Then( 'the feedback form should be present',
+  function( ) {
+    return expect( _dom.form.isPresent() )
+      .to.eventually.equal( true );
+  }
+);
+
+Then( 'the feedback form should no longer be present',
+  function( ) {
+    return expect( _dom.form.isPresent() )
+      .to.eventually.equal( false );
+  }
+);


### PR DESCRIPTION
A couple of Notification module references in `FormSubmit.js` are breaking feedback form replacement on production -- the form can be submitted, but an error prevents its replacement with a success notification, leaving a large blank space where the form had been (see an [Ask CFPB question](https://www.consumerfinance.gov/ask-cfpb/i-would-like-to-be-able-to-have-my-friend-or-family-member-help-with-my-bill-paying-and-banking-what-are-my-options-en-1145/) for an example). This PR updates the references and adds acceptance tests for feedback form notifications and replacement.

## Additions

- Acceptance tests for feedback form replacement

## Changes

- Notification module references in `FormSubmit.js`

## Testing

1. Check out branch and run `gulp scripts`
2. Navigate to [an Ask CFPB answer page](http://localhost:8000/ask-cfpb/i-would-like-to-be-able-to-have-my-friend-or-family-member-help-with-my-bill-paying-and-banking-what-are-my-options-en-1145/) locally and verify that its feedback form is replaced with a success message when submitted with a radio option selected
3. Run `gulp test:acceptance` and verify that tests pass

## Screenshots

### Production
<img width="996" alt="screen shot 2019-01-15 at 9 23 18 pm" src="https://user-images.githubusercontent.com/778171/51228167-39b55d80-190c-11e9-9cae-2ce55685a65e.png">


### Local

<img width="814" alt="screen shot 2019-01-15 at 9 26 17 pm" src="https://user-images.githubusercontent.com/778171/51228163-34f0a980-190c-11e9-9780-b35703ea0b9a.png">


## Todos

- Form is still displayed after page refresh when feedback is successfully submitted with javascript disabled

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Internet Explorer 8, 9, 10, and 11
- [ ] Edge
- [ ] iOS Safari
- [ ] Chrome for Android

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
