### PR TITLE
Filter: Fix default styling of notification

### DIFF
--- a/cfgov/unprocessed/js/organisms/FilterableListControls.js
+++ b/cfgov/unprocessed/js/organisms/FilterableListControls.js
@@ -131,7 +131,7 @@ function FilterableListControls( element ) {
 
     if ( validatedFields.invalid.length > 0 ) {
       _showNotification(
-        _notification.ERROR,
+        Notification.ERROR,
         _buildErrorMessage( validatedFields.invalid )
       );
     } else {


### PR DESCRIPTION
Fixes issue where the notification is shown in the default styling (error introduced in https://github.com/cfpb/cfgov-refresh/pull/4760)

## Changes

- Get notification state from class, not instance.

## Testing

1. http://localhost:8000/about-us/blog/?title=&from_date=asdf should show a red error notification, not a grey one.
