### PR TITLE
Remove tags from FOIA reports page

### DIFF
--- a/cfgov/jinja2/v1/_includes/organisms/post-preview.html
+++ b/cfgov/jinja2/v1/_includes/organisms/post-preview.html
@@ -178,7 +178,7 @@
             {% endfor %}
             </div>
 
-            {% if post.tags.exists() %}
+            {% if post.tags.exists() and controls.categories.page_type != 'foia-freq-req-record' %}
                 {%- import 'tags.html' as tags %}
                 {{ tags.render(post.related_metadata_tags(), hide_heading=true, is_wagtail=True) }}
             {% endif %}

--- a/cfgov/jinja2/v1/_includes/organisms/post-preview.html
+++ b/cfgov/jinja2/v1/_includes/organisms/post-preview.html
@@ -63,6 +63,7 @@
     {% set date_desc = controls.post_date_description or post_date_description or 'Published' %}
     {% set cat_controls = controls.categories %}
     {% set show_categories = cat_controls.show_preview_categories if cat_controls is defined else true %}
+    {% set display_settings = get_fl_display_settings(controls.categories.page_type) if cat_controls is defined else get_fl_display_settings('None') %}
     <article class="o-post-preview">
         <div class="m-meta-header">
             <div class="m-meta-header_right">
@@ -176,9 +177,8 @@
                       </a>
                 {% endif %}
             {% endfor %}
-            </div>
 
-            {% if post.tags.exists() and controls.categories.page_type != 'foia-freq-req-record' %}
+            {% if post.tags.exists() and display_settings.show_tags %}
                 {%- import 'tags.html' as tags %}
                 {{ tags.render(post.related_metadata_tags(), hide_heading=true, is_wagtail=True) }}
             {% endif %}

--- a/cfgov/jinja2/v1/_includes/organisms/post-preview.html
+++ b/cfgov/jinja2/v1/_includes/organisms/post-preview.html
@@ -63,7 +63,7 @@
     {% set date_desc = controls.post_date_description or post_date_description or 'Published' %}
     {% set cat_controls = controls.categories %}
     {% set show_categories = cat_controls.show_preview_categories if cat_controls is defined else true %}
-    {% set display_settings = get_fl_display_settings(controls.categories.page_type) if cat_controls is defined else get_fl_display_settings('None') %}
+    {% set display_settings = get_fl_display_settings(controls.categories.page_type) if controls.categories is defined else get_fl_display_settings('None') %}
     <article class="o-post-preview">
         <div class="m-meta-header">
             <div class="m-meta-header_right">
@@ -177,7 +177,7 @@
                       </a>
                 {% endif %}
             {% endfor %}
-
+            </div>
             {% if post.tags.exists() and display_settings.show_tags %}
                 {%- import 'tags.html' as tags %}
                 {{ tags.render(post.related_metadata_tags(), hide_heading=true, is_wagtail=True) }}

--- a/cfgov/v1/jinja2tags/__init__.py
+++ b/cfgov/v1/jinja2tags/__init__.py
@@ -103,6 +103,7 @@ class V1Extension(Extension):
             'is_report': ref.is_report,
             'is_filter_selected': contextfunction(is_filter_selected),
             'render_stream_child': contextfunction(render_stream_child),
+            'get_fl_display_settings': ref.get_fl_display_settings,
         })
 
 

--- a/cfgov/v1/util/__init__.py
+++ b/cfgov/v1/util/__init__.py
@@ -6,7 +6,7 @@ from v1.util.password_policy import (
 from v1.util.ref import (
     category_label, choices_for_page_type, fcm_label,
     filterable_list_page_types, is_blog, is_report, page_type_choices,
-    related_posts_category_lookup
+    related_posts_category_lookup, get_fl_display_settings
 )
 from v1.util.util import (
     ERROR_MESSAGES, all_valid_destinations_for_request,

--- a/cfgov/v1/util/ref.py
+++ b/cfgov/v1/util/ref.py
@@ -267,6 +267,7 @@ def get_category_children(category_names):
         for category in category_names
     )))
 
+
 def get_fl_display_settings(filterable_page_type):
     settings = {
         'page_type': filterable_page_type,

--- a/cfgov/v1/util/ref.py
+++ b/cfgov/v1/util/ref.py
@@ -266,3 +266,12 @@ def get_category_children(category_names):
         dict(categories_dict[category]).keys()
         for category in category_names
     )))
+
+def get_fl_display_settings(filterable_page_type):
+    settings = {
+        'page_type': filterable_page_type,
+        'show_tags': True,
+        }
+    if "foia-freq-req-record" in filterable_page_type:
+        settings['show_tags'] = False
+    return settings


### PR DESCRIPTION
The new designs for filtered list results require the removal of tags from the FOIA reports page (all results are tagged FOIA and only tagged FOIA).

## Changes
- Adds a conditional to post-preview.html that negates the generation of tag markup when the `page_type` is `foia-freq-req-record`


## Testing

1. Pull down this branch.
2. Check out http://localhost:8000/foia-requests/foia-electronic-reading-room/
3. There shouldn't be topic tags!

## Notes
- After a lengthy discussion amongst the UI Improvements Team, we recommend that we use `controls.categories.page_type` to control the generation of markup in the `post-preview.html` template, which will allow some flexibility in the design between filtered list results pages.

## Checklist
- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [x] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [x] Chrome
- [x] Firefox
- [x] Safari
- [x] Internet Explorer 8, 9, 10, and 11
- [x] Edge
- [x] iOS Safari
- [x] Chrome for Android

### Accessibility
- [x] Keyboard friendly
- [x] Screen reader friendly

### Other
- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
