### PR TITLE
Remove non-wagtail newsroom logic from utils.py

### DIFF
--- a/cfgov/v1/util/util.py
+++ b/cfgov/v1/util/util.py
@@ -55,27 +55,6 @@ def get_secondary_nav_items(request, current_page):
     # children
     has_children = False
 
-    # Handle the Newsroom page specially.
-    # TODO: Remove this ASAP once Press Resources gets its own Wagtail page
-    if page.slug == 'newsroom':
-        return [
-            {
-                'title': page.title,
-                'slug': page.slug,
-                'url': page.relative_url(request.site),
-                'children': [
-                    {
-                        'title': 'Press Resources',
-                        'slug': 'press-resources',
-                        'url': '/newsroom/press-resources/',
-                    }
-                ],
-                'active': True,
-                'expanded': True,
-            }
-        ], True
-    # END TODO
-
     if page.secondary_nav_exclude_sibling_pages:
         pages = [page]
     else:


### PR DESCRIPTION
Since the structure of newsroom/press resources is identical to events/request a speaker, it looks like we can follow the structure there and fix the issue where "Press resources" doesn't get highlighted in the side navigation menu.

## Removals

- Legacy logic for the secondary navigation menu when the newsroom page was not in wagtail.

## Testing

1. Visit your local wagtail admin and set the following:
  - On the "newsroom" page in Wagtail, check this setting in the sidefoot:
<img width="353" alt="screen shot 2019-01-22 at 7 04 47 pm" src="https://user-images.githubusercontent.com/704760/51574029-04fc5580-1e7a-11e9-8edb-91df6f6029a5.png">
  - On the "press resources" page in Wagtail, uncheck this setting in the config:
<img width="573" alt="screen shot 2019-01-22 at 7 11 21 pm" src="https://user-images.githubusercontent.com/704760/51574048-1fceca00-1e7a-11e9-863f-71c52e9fd83c.png">

Publishing both pages should show a menu like below…

## Screenshots

<img width="253" alt="screen shot 2019-01-22 at 7 18 16 pm" src="https://user-images.githubusercontent.com/704760/51574119-80f69d80-1e7a-11e9-9167-fc5f4d552061.png">

<img width="236" alt="screen shot 2019-01-22 at 7 18 20 pm" src="https://user-images.githubusercontent.com/704760/51574120-80f69d80-1e7a-11e9-8d90-572f4dfdd764.png">

## Todos

- When this goes to production the wagtail steps in the "testing" section above need to be performed. I'm not certain what the best way to do this is?