### PR TITLE
Updated OAH/BAH to align IE10 support

### DIFF
--- a/cfgov/jinja2/v1/owning-a-home/_templates/no_js.html
+++ b/cfgov/jinja2/v1/owning-a-home/_templates/no_js.html
@@ -5,7 +5,7 @@
     <div class="m-notification_content">
         <div class="h4 m-notification_message">
             This tool is not supported in your browser.
-            Please try a newer browser and check that JavaScript is enabled.
+            Please try a newer browser or confirm that JavaScript is enabled.
         </div>
      </div>
 </div>

--- a/cfgov/jinja2/v1/owning-a-home/_templates/no_js.html
+++ b/cfgov/jinja2/v1/owning-a-home/_templates/no_js.html
@@ -4,13 +4,8 @@
     {{ svg_icon('error-round') }}
     <div class="m-notification_content">
         <div class="h4 m-notification_message">
-            You must have JavaScript to use the tools on this page.
+            This tool is not supported in your browser.
+            Please try a newer browser and check that JavaScript is enabled.
         </div>
-        <p class="m-notification_explanation">
-            To improve your experience, please
-            <a href="https://www.enable-javascript.com/" class="go-link">
-                enable JavaScript in your browser.
-            </a>
-        </p>
      </div>
 </div>

--- a/cfgov/jinja2/v1/owning-a-home/_templates/ratings-form.html
+++ b/cfgov/jinja2/v1/owning-a-home/_templates/ratings-form.html
@@ -1,9 +1,10 @@
 <form method="post"
-      class="o-form
-             oah-ratings-form
+      class="oah-ratings-form
+             o-form
              block
              block__bg
-             block__border">
+             block__border
+             u-mb15">
     <fieldset class="o-form_fieldset u-reset">
         <legend class="a-legend">
             <span class="h4">Was this page helpful to you?</span>

--- a/cfgov/jinja2/v1/owning-a-home/closing-disclosure/index.html
+++ b/cfgov/jinja2/v1/owning-a-home/closing-disclosure/index.html
@@ -39,47 +39,55 @@
         </nav>
     </div>
     <div class="content_wrapper">
-        <div class="form-explainer content_main u-pb0">
-            <div class="page-intro content-l">
-                <div class="content-l_col-2-3">
-                    <h1 class="page-title">Closing Disclosure Explainer</h1>
-                    <p class="lead">Use this tool to double-check that all the details about your loan are correct on your Closing Disclosure. Lenders are required to provide your Closing Disclosure three business days before your scheduled closing. Use these days wisely&mdash;now is the time to resolve problems. If something looks different from what you expected, ask why.</p>
-                    <div class="block
-                                block__flush-top
-                                block__padded-top
-                                block__flush-bottom
-                                u-right-on-desktop">
-                        {{ social_media.render( {
-                        "twitter_text": "Use the @CFPB’s interactive tool to double-check all the details of your Closing Disclosure.",
-                        "email_title": "Get Closing Disclosure help from the CFPB",
-                        "email_text": "The CFPB’s tool helps you double-check your closing disclosure:",
-                        "email_signature": "-- From the CFPB",
-                        "linkedin_title": "Double-check your Closing Disclosure with the @CFPB",
-                        "linkedin_text": "Use this tool from the @CFPB to double-check that all the details in your closing disclosure are correct. Via @CFPB"
-                        } ) }}
+        <div class="content_main">
+
+            {% include "_templates/no_js.html" %}
+
+            <div class="form-explainer">
+
+                <div class="page-intro content-l">
+                    <div class="content-l_col-2-3">
+                        <h1 class="page-title">Closing Disclosure Explainer</h1>
+                        <p class="lead">Use this tool to double-check that all the details about your loan are correct on your Closing Disclosure. Lenders are required to provide your Closing Disclosure three business days before your scheduled closing. Use these days wisely&mdash;now is the time to resolve problems. If something looks different from what you expected, ask why.</p>
+                        <div class="block
+                                    block__flush-top
+                                    block__padded-top
+                                    block__flush-bottom
+                                    u-right-on-desktop">
+                            {{ social_media.render( {
+                            "twitter_text": "Use the @CFPB’s interactive tool to double-check all the details of your Closing Disclosure.",
+                            "email_title": "Get Closing Disclosure help from the CFPB",
+                            "email_text": "The CFPB’s tool helps you double-check your closing disclosure:",
+                            "email_signature": "-- From the CFPB",
+                            "linkedin_title": "Double-check your Closing Disclosure with the @CFPB",
+                            "linkedin_text": "Use this tool from the @CFPB to double-check that all the details in your closing disclosure are correct. Via @CFPB"
+                            } ) }}
+                        </div>
+                    </div>
+                    <div class="content-l_col-1-3">
+                        <img src="{{ static('img/ill-form-explainer-closing-disc.png') }}"
+                            alt=""
+                            class="illustration">
                     </div>
                 </div>
-                <div class="content-l_col-1-3">
-                    <img src="{{ static('img/ill-form-explainer-closing-disc.png') }}"
-                         alt=""
-                         class="illustration">
+
+                {# Import the form explainer macros #}
+                {% import "_templates/form-explainer.html" as form_explainer %}
+                {# Import the data to use with form explainer #}
+                {% from "closing-disclosure-1-data.html" import data as page_1 %}
+                {% from "closing-disclosure-2-data.html" import data as page_2 %}
+                {% from "closing-disclosure-3-data.html" import data as page_3 %}
+                {% from "closing-disclosure-4-data.html" import data as page_4 %}
+                {% from "closing-disclosure-5-data.html" import data as page_5 %}
+                {# Render form explainer with the data for this form #}
+                <div class="col-12">
+                    {{ form_explainer.render([ page_1, page_2, page_3, page_4, page_5 ]) }}
+                </div>
+                <div class="col-12">
+                    {% include "_templates/ratings-form.html" %}
                 </div>
             </div>
-            {# Import the form explainer macros #}
-            {% import "_templates/form-explainer.html" as form_explainer %}
-            {# Import the data to use with form explainer #}
-            {% from "closing-disclosure-1-data.html" import data as page_1 %}
-            {% from "closing-disclosure-2-data.html" import data as page_2 %}
-            {% from "closing-disclosure-3-data.html" import data as page_3 %}
-            {% from "closing-disclosure-4-data.html" import data as page_4 %}
-            {% from "closing-disclosure-5-data.html" import data as page_5 %}
-            {# Render form explainer with the data for this form #}
-            <div class="col-12">
-                {{ form_explainer.render([ page_1, page_2, page_3, page_4, page_5 ]) }}
-            </div>
-            <div class="col-12">
-                {% include "_templates/ratings-form.html" %}
-            </div>
+
         </div>
     </div>
     {% import "_templates/brand-footer.html" as brand_footer %}

--- a/cfgov/jinja2/v1/owning-a-home/explore-rates/index.html
+++ b/cfgov/jinja2/v1/owning-a-home/explore-rates/index.html
@@ -43,8 +43,11 @@ home price, down payment, and more can affect mortgage interest rates.
         </nav>
     </div>
     <div class="content_wrapper">
-        <div class="rate-checker content_main u-pb0">
-            <div class="result">
+        <div class="content_main u-pb0">
+
+            {% include "_templates/no_js.html" %}
+
+            <div class="rate-checker">
                 <section class="page-intro content-l">
                     <div class="content-l_col content-l_col-2-3">
                         <h1 class="page-title">Explore interest rates</h1>
@@ -611,7 +614,6 @@ home price, down payment, and more can affect mortgage interest rates.
                 <!-- /.about -->
             </div>
             <!-- END .rate-checker -->
-            {% include "_templates/no_js.html" %}
         </div>
         <!-- /.content_main -->
     </div>

--- a/cfgov/jinja2/v1/owning-a-home/loan-estimate/index.html
+++ b/cfgov/jinja2/v1/owning-a-home/loan-estimate/index.html
@@ -38,48 +38,53 @@
         </nav>
     </div>
     <div class="content_wrapper">
-        <div class="form-explainer
-                    content_main
-                    {% if subnav %}col-9{% endif %}">
-            <div class="page-intro content-l">
-                <div class="content-l_col-2-3">
-                    <h1 class="page-title">Loan Estimate Explainer</h1>
-                    <p class="lead">A Loan Estimate tells you important details about a mortgage loan you have requested. Use this tool to review your Loan Estimate to make sure it reflects what you discussed with the lender. If something looks different from what you expected, ask why. Request multiple Loan Estimates from different lenders so you can compare and choose the loan that's right for you.</p>
-                    <div class="block
-                              block__flush-top
-                              block__padded-top
-                              block__flush-bottom
-                              u-right-on-desktop">
-                        {{ social_media.render( {
-                              "twitter_text": "Use the @CFPB's interactive tool to review your Loan Estimate and get definitions for unfamiliar terms.",
-                              "email_title": "Review your Loan Estimate with the CFPB",
-                              "email_text": "Check the details on your mortgage Loan Estimate and get definitions with this interactive tool from the CFPB.",
-                              "email_signature": "-- From the CFPB",
-                              "linkedin_title": "Learn the lingo of Loan Estimates with the @CFPB.",
-                              "linkedin_text": "The @CFPB has a helpful tool to review your mortgage Loan Estimate and get definitions for unfamiliar terms. Via @CFPB"
-                        } ) }}
+            <div class="content_main">
+
+                {% include "_templates/no_js.html" %}
+
+                <div class="form-explainer
+                            {% if subnav %}col-9{% endif %}">
+                    <div class="page-intro content-l">
+                        <div class="content-l_col-2-3">
+                            <h1 class="page-title">Loan Estimate Explainer</h1>
+                            <p class="lead">A Loan Estimate tells you important details about a mortgage loan you have requested. Use this tool to review your Loan Estimate to make sure it reflects what you discussed with the lender. If something looks different from what you expected, ask why. Request multiple Loan Estimates from different lenders so you can compare and choose the loan that's right for you.</p>
+                            <div class="block
+                                    block__flush-top
+                                    block__padded-top
+                                    block__flush-bottom
+                                    u-right-on-desktop">
+                                {{ social_media.render( {
+                                    "twitter_text": "Use the @CFPB's interactive tool to review your Loan Estimate and get definitions for unfamiliar terms.",
+                                    "email_title": "Review your Loan Estimate with the CFPB",
+                                    "email_text": "Check the details on your mortgage Loan Estimate and get definitions with this interactive tool from the CFPB.",
+                                    "email_signature": "-- From the CFPB",
+                                    "linkedin_title": "Learn the lingo of Loan Estimates with the @CFPB.",
+                                    "linkedin_text": "The @CFPB has a helpful tool to review your mortgage Loan Estimate and get definitions for unfamiliar terms. Via @CFPB"
+                                } ) }}
+                            </div>
+                        </div>
+                        <div class="content-l_col-1-3">
+                            <img src="{{ static('apps/owning-a-home/img/ill-form-explainer-loan-est.png') }}"
+                                alt=""
+                                class="illustration">
+                        </div>
                     </div>
-                </div>
-                <div class="content-l_col-1-3">
-                    <img src="{{ static('apps/owning-a-home/img/ill-form-explainer-loan-est.png') }}"
-                         alt=""
-                         class="illustration">
-                </div>
+                    {# Import the form explainer macros #}
+                    {% import "_templates/form-explainer.html" as form_explainer %}
+                    {# Import the data to use with form explainer #}
+                    {% from "loan-estimate-1-data.html" import data as page_1 %}
+                    {% from "loan-estimate-2-data.html" import data as page_2 %}
+                    {% from "loan-estimate-3-data.html" import data as page_3 %}
+                    {# Render form explainer with the data for this form #}
+                    <div class="col-12">
+                        {{ form_explainer.render([ page_1, page_2, page_3 ]) }}
+                    </div>
+                    <div class="col-12">
+                        {% include "_templates/ratings-form.html" %}
+                    </div>
+                </div><!-- /.form-explainer -->
             </div>
-            {# Import the form explainer macros #}
-            {% import "_templates/form-explainer.html" as form_explainer %}
-            {# Import the data to use with form explainer #}
-            {% from "loan-estimate-1-data.html" import data as page_1 %}
-            {% from "loan-estimate-2-data.html" import data as page_2 %}
-            {% from "loan-estimate-3-data.html" import data as page_3 %}
-            {# Render form explainer with the data for this form #}
-            <div class="col-12">
-                {{ form_explainer.render([ page_1, page_2, page_3 ]) }}
-            </div>
-            <div class="col-12">
-                {% include "_templates/ratings-form.html" %}
-            </div>
-        </div><!-- /.form-explainer -->
+        </div>
     </div>
     {% import "_templates/brand-footer.html" as brand_footer %}
     {% set footer_links = [

--- a/cfgov/jinja2/v1/owning-a-home/loan-estimate/index.html
+++ b/cfgov/jinja2/v1/owning-a-home/loan-estimate/index.html
@@ -38,52 +38,52 @@
         </nav>
     </div>
     <div class="content_wrapper">
-            <div class="content_main">
+        <div class="content_main">
 
-                {% include "_templates/no_js.html" %}
+            {% include "_templates/no_js.html" %}
 
-                <div class="form-explainer
-                            {% if subnav %}col-9{% endif %}">
-                    <div class="page-intro content-l">
-                        <div class="content-l_col-2-3">
-                            <h1 class="page-title">Loan Estimate Explainer</h1>
-                            <p class="lead">A Loan Estimate tells you important details about a mortgage loan you have requested. Use this tool to review your Loan Estimate to make sure it reflects what you discussed with the lender. If something looks different from what you expected, ask why. Request multiple Loan Estimates from different lenders so you can compare and choose the loan that's right for you.</p>
-                            <div class="block
-                                    block__flush-top
-                                    block__padded-top
-                                    block__flush-bottom
-                                    u-right-on-desktop">
-                                {{ social_media.render( {
-                                    "twitter_text": "Use the @CFPB's interactive tool to review your Loan Estimate and get definitions for unfamiliar terms.",
-                                    "email_title": "Review your Loan Estimate with the CFPB",
-                                    "email_text": "Check the details on your mortgage Loan Estimate and get definitions with this interactive tool from the CFPB.",
-                                    "email_signature": "-- From the CFPB",
-                                    "linkedin_title": "Learn the lingo of Loan Estimates with the @CFPB.",
-                                    "linkedin_text": "The @CFPB has a helpful tool to review your mortgage Loan Estimate and get definitions for unfamiliar terms. Via @CFPB"
-                                } ) }}
-                            </div>
-                        </div>
-                        <div class="content-l_col-1-3">
-                            <img src="{{ static('apps/owning-a-home/img/ill-form-explainer-loan-est.png') }}"
-                                alt=""
-                                class="illustration">
+            <div class="form-explainer
+                        {% if subnav %}col-9{% endif %}">
+                <div class="page-intro content-l">
+                    <div class="content-l_col-2-3">
+                        <h1 class="page-title">Loan Estimate Explainer</h1>
+                        <p class="lead">A Loan Estimate tells you important details about a mortgage loan you have requested. Use this tool to review your Loan Estimate to make sure it reflects what you discussed with the lender. If something looks different from what you expected, ask why. Request multiple Loan Estimates from different lenders so you can compare and choose the loan that's right for you.</p>
+                        <div class="block
+                                block__flush-top
+                                block__padded-top
+                                block__flush-bottom
+                                u-right-on-desktop">
+                            {{ social_media.render( {
+                                "twitter_text": "Use the @CFPB's interactive tool to review your Loan Estimate and get definitions for unfamiliar terms.",
+                                "email_title": "Review your Loan Estimate with the CFPB",
+                                "email_text": "Check the details on your mortgage Loan Estimate and get definitions with this interactive tool from the CFPB.",
+                                "email_signature": "-- From the CFPB",
+                                "linkedin_title": "Learn the lingo of Loan Estimates with the @CFPB.",
+                                "linkedin_text": "The @CFPB has a helpful tool to review your mortgage Loan Estimate and get definitions for unfamiliar terms. Via @CFPB"
+                            } ) }}
                         </div>
                     </div>
-                    {# Import the form explainer macros #}
-                    {% import "_templates/form-explainer.html" as form_explainer %}
-                    {# Import the data to use with form explainer #}
-                    {% from "loan-estimate-1-data.html" import data as page_1 %}
-                    {% from "loan-estimate-2-data.html" import data as page_2 %}
-                    {% from "loan-estimate-3-data.html" import data as page_3 %}
-                    {# Render form explainer with the data for this form #}
-                    <div class="col-12">
-                        {{ form_explainer.render([ page_1, page_2, page_3 ]) }}
+                    <div class="content-l_col-1-3">
+                        <img src="{{ static('apps/owning-a-home/img/ill-form-explainer-loan-est.png') }}"
+                            alt=""
+                            class="illustration">
                     </div>
-                    <div class="col-12">
-                        {% include "_templates/ratings-form.html" %}
-                    </div>
-                </div><!-- /.form-explainer -->
+                </div>
+                {# Import the form explainer macros #}
+                {% import "_templates/form-explainer.html" as form_explainer %}
+                {# Import the data to use with form explainer #}
+                {% from "loan-estimate-1-data.html" import data as page_1 %}
+                {% from "loan-estimate-2-data.html" import data as page_2 %}
+                {% from "loan-estimate-3-data.html" import data as page_3 %}
+                {# Render form explainer with the data for this form #}
+                <div class="col-12">
+                    {{ form_explainer.render([ page_1, page_2, page_3 ]) }}
+                </div>
+                <div class="col-12">
+                    {% include "_templates/ratings-form.html" %}
+                </div>
             </div>
+
         </div>
     </div>
     {% import "_templates/brand-footer.html" as brand_footer %}

--- a/cfgov/unprocessed/apps/owning-a-home/browserslist
+++ b/cfgov/unprocessed/apps/owning-a-home/browserslist
@@ -3,4 +3,5 @@
 # See https://github.com/browserslist/browserslist#config-file
 
 last 2 versions
-Explorer >= 9
+not ie < 11
+not IE_Mob < 11

--- a/cfgov/unprocessed/apps/owning-a-home/css/no-js.less
+++ b/cfgov/unprocessed/apps/owning-a-home/css/no-js.less
@@ -4,13 +4,11 @@
 	/* Show the no-js notification when Javascript is disabled. */
     .m-notification__no-js {
         display: block;
-        position: absolute;
-        top: -150px;
-        width: 100%;
      }
 
-     /* Hide the rate checker when JavaScript is disabled. */
-     .rate-checker .result {
+     /* Hide rate checker and form explainers when JavaScript is disabled. */
+     .rate-checker,
+     .form-explainer {
         display: none;
      }
 }


### PR DESCRIPTION
https://consumerfinance.gov/owning-a-home/explore-rates/ has a no-js banner in IE10, but the text is erroneous (see [GHE]/CFGOV/platform/issues/3045). 

https://www.consumerfinance.gov/owning-a-home/closing-disclosure/ and https://www.consumerfinance.gov/owning-a-home/loan-estimate/ are accessible in IE10, but do not work. Additionally, the bottom gap below the feedback form on these two pages differs.

This PR updates to the OAH/BAH no-js state banner to be applicable to both when JS is turned off and also when a legacy browser is used. 

## Changes

- Updates markup structure so the rate-explorer and form-explainers are in their own div container and aren't mixed with `content_main`.
- Updates no-js notification text to "This tool is not supported in your browser. Please try a newer browser and check that JavaScript is enabled."
- Moves notification banner below the breadcrumb into the content area of the page.
- Updates the browserlist to exclude IE9 and 10.

## Testing

1. `gulp clean && gulp build`
2. Visit:
  - /owning-a-home/loan-estimate/
  - /owning-a-home/closing-disclosure/
  - /owning-a-home/explore-rates/
and compare to production on IE10 and modern browsers.

## Screenshots

<img width="1245" alt="screen shot 2019-01-22 at 7 44 10 pm" src="https://user-images.githubusercontent.com/704760/51575103-b7361c00-1e7e-11e9-9d82-d957996aa954.png">

<img width="173" alt="screen shot 2019-01-22 at 7 46 09 pm" src="https://user-images.githubusercontent.com/704760/51575108-bbfad000-1e7e-11e9-897f-ad7e47dd6d0b.png">
