### PR TITLE
Add some styling and new allowed HTML markup to RichTextField to support schema markup

### DIFF
--- a/cfgov/ask_cfpb/tests/test_hooks.py
+++ b/cfgov/ask_cfpb/tests/test_hooks.py
@@ -10,7 +10,7 @@ from ask_cfpb.wagtail_hooks import (
     Answer, AnswerModelAdmin, AnswerModelAdminSaveUserEditView, Audience,
     AudienceModelAdmin, Category, CategoryModelAdmin, NextStep,
     NextStepModelAdmin, SubCategory, SubCategoryModelAdmin, editor_css,
-    editor_js, whitelister_element_rules
+    editor_js
 )
 
 
@@ -27,8 +27,6 @@ class TestAskHooks(TestCase):
     def test_js_functions(self):
         self.assertIn("registerHalloPlugin('editHtmlButton')", editor_js())
         self.assertIn("css/question-tips.css", editor_css())
-        self.assertIn('aside', whitelister_element_rules().keys())
-        self.assertIn('table', whitelister_element_rules().keys())
 
     def test_AnswerModelAdminSaveUserEditView(self):
         mock_admin = mock.Mock()

--- a/cfgov/ask_cfpb/wagtail_hooks.py
+++ b/cfgov/ask_cfpb/wagtail_hooks.py
@@ -132,10 +132,16 @@ def editor_css():
 
 
 def whitelister_element_rules():
-    allow_html_class = attribute_rule({'class': True})
+    allow_html_class = attribute_rule({
+        'class': True,
+        'itemprop': True,
+        'itemscope': True,
+        'itemtype': True,
+    })
 
-    allowed_tags = ['aside', 'table', 'tr', 'th', 'td', 'tbody', 'thead',
-                    'tfoot', 'col', 'colgroup']
+    allowed_tags = ['aside', 'div', 'h4', 'p', 'span',
+                    'table', 'tr', 'th', 'td', 'tbody', 'thead', 'tfoot',
+                    'col', 'colgroup']
 
     return {tag: allow_html_class for tag in allowed_tags}
 

--- a/cfgov/ask_cfpb/wagtail_hooks.py
+++ b/cfgov/ask_cfpb/wagtail_hooks.py
@@ -14,7 +14,6 @@ from wagtail.contrib.modeladmin.options import (
 from wagtail.contrib.modeladmin.views import EditView
 from wagtail.wagtailadmin.menu import MenuItem
 from wagtail.wagtailcore import hooks
-from wagtail.wagtailcore.whitelist import attribute_rule
 
 from ask_cfpb.models import Answer, Audience, Category, NextStep, SubCategory
 from ask_cfpb.scripts import export_ask_data
@@ -131,25 +130,8 @@ def editor_css():
         'css/question-tips.css">\n')
 
 
-def whitelister_element_rules():
-    allow_html_class = attribute_rule({
-        'class': True,
-        'itemprop': True,
-        'itemscope': True,
-        'itemtype': True,
-    })
-
-    allowed_tags = ['aside', 'div', 'h4', 'p', 'span',
-                    'table', 'tr', 'th', 'td', 'tbody', 'thead', 'tfoot',
-                    'col', 'colgroup']
-
-    return {tag: allow_html_class for tag in allowed_tags}
-
-
 hooks.register('insert_editor_js', editor_js)
 hooks.register('insert_editor_css', editor_css)
-hooks.register(
-    'construct_whitelister_element_rules', whitelister_element_rules)
 
 
 @hooks.register('register_admin_menu_item')

--- a/cfgov/unprocessed/css/rich-text.less
+++ b/cfgov/unprocessed/css/rich-text.less
@@ -11,3 +11,12 @@
         margin-bottom: 0;
     }
 }
+
+.schema-container {
+    display: block;
+    margin-bottom: unit( @grid_gutter-width / @base-font-size-px, em );
+
+    &:last-child {
+        margin-bottom: 0;
+    }
+}

--- a/cfgov/v1/tests/test_wagtail_hooks.py
+++ b/cfgov/v1/tests/test_wagtail_hooks.py
@@ -4,8 +4,11 @@ from django.test import TestCase, override_settings
 from wagtail.tests.testapp.models import SimplePage
 from wagtail.tests.utils import WagtailTestUtils
 from wagtail.wagtailcore.models import Site
+from wagtail.wagtailcore.rich_text import DbWhitelister
+from wagtail.wagtailcore.whitelist import Whitelister
 
 import mock
+from bs4 import BeautifulSoup
 
 from v1.models.base import CFGOVPage
 from v1.models.menu_item import MenuItem
@@ -247,3 +250,100 @@ class TestResourceTagsFilter(TestCase, WagtailTestUtils):
             response.context['object_list'][1].title,
             'Test resource Banana'
         )
+
+
+class TestWhitelistOverride(TestCase):
+    # Borrowed from https://github.com/wagtail/wagtail/blob/v1.13.4/wagtail
+    # /wagtailcore/tests/test_dbwhitelister.py
+    def assertHtmlEqual(self, str1, str2):
+        """
+        Assert that two HTML strings are equal at the DOM level
+        (necessary because we can't guarantee the order that attributes are
+        output in)
+
+        Note: I don't understand why this doesn't also account for whitespace
+        differences, but it doesn't, hence the ugly expected output for the
+        second assertion below. -SC
+        """
+        self.assertEqual(
+            BeautifulSoup(str1, 'html5lib'),
+            BeautifulSoup(str2, 'html5lib')
+        )
+
+    def setUp(self):
+        self.input_html = (
+            '<span class="schema-container"'
+            '      itemprop="step"'
+            '      itemscope'
+            '      itemtype="http://schema.org/HowToSection">'
+            '    <h4 itemprop="name">Step 1: Learn about the debt</h4>'
+            '    <span class="schema-container" itemprop="itemListElement">'
+            '        <table>'
+            '            <thead>'
+            '                <tr>'
+            '                    <th>Col 1 header</th>'
+            '                    <th>Col 2 header</th>'
+            '                </tr>'
+            '            </thead>'
+            '            <tbody>'
+            '                <tr>'
+            '                    <td>Row 1 Col 1</td>'
+            '                    <td>Row 1 Col 2</td>'
+            '                </tr>'
+            '                <tr>'
+            '                    <td>Row 2 Col 1</td>'
+            '                    <td>Row 2 Col 2</td>'
+            '                </tr>'
+            '            </tbody>'
+            '        </table>'
+            '    </span>'
+            '</span>'
+        )
+
+    def test_whitelist_hooks(self):
+        # v1.wagtail_hooks overrides the whitelist to permit some new elements
+        # and attributes
+        output_html = DbWhitelister.clean(self.input_html)
+        expected = (
+            '<span class="schema-container"'
+            '      itemprop="step"'
+            '      itemscope'
+            '      itemtype="http://schema.org/HowToSection">'
+            '    <h4 itemprop="name">Step 1: Learn about the debt</h4>'
+            '    <span class="schema-container" itemprop="itemListElement">'
+            '        <table>'
+            '            <thead>'
+            '                <tr>'
+            '                    <th>Col 1 header</th>'
+            '                    <th>Col 2 header</th>'
+            '                </tr>'
+            '            </thead>'
+            '            <tbody>'
+            '                <tr>'
+            '                    <td>Row 1 Col 1</td>'
+            '                    <td>Row 1 Col 2</td>'
+            '                </tr>'
+            '                <tr>'
+            '                    <td>Row 2 Col 1</td>'
+            '                    <td>Row 2 Col 2</td>'
+            '                </tr>'
+            '            </tbody>'
+            '        </table>'
+            '    </span>'
+            '</span>'
+        )
+        self.assertHtmlEqual(expected, output_html)
+
+        # check that the base Whitelister class is unaffected by these custom
+        # whitelist rules
+        output_html = Whitelister.clean(self.input_html)
+        expected = (
+            '<h4>Step 1: Learn about the debt</h4>                            '
+            '                                Col 1 header                    C'
+            'ol 2 header                                                      '
+            '                      Row 1 Col 1                    Row 1 Col 2 '
+            '                                                   Row 2 Col 1   '
+            '                 Row 2 Col 2                                     '
+            '   '
+        )
+        self.assertHtmlEqual(expected, output_html)

--- a/cfgov/v1/wagtail_hooks.py
+++ b/cfgov/v1/wagtail_hooks.py
@@ -14,6 +14,7 @@ from wagtail.contrib.modeladmin.options import (
 )
 from wagtail.wagtailadmin.menu import MenuItem
 from wagtail.wagtailcore import hooks
+from wagtail.wagtailcore.whitelist import attribute_rule
 
 from v1.admin_views import manage_cdn
 from v1.models.menu_item import MenuItem as MegaMenuItem
@@ -252,3 +253,20 @@ modeladmin_register(SnippetModelAdminGroup)
 def hide_snippets_menu_item(request, menu_items):
     menu_items[:] = [item for item in menu_items
                      if item.url != reverse('wagtailsnippets:index')]
+
+
+# Override list of allowed tags in a RichTextField
+@hooks.register('construct_whitelister_element_rules')
+def whitelister_element_rules():
+    allow_html_class = attribute_rule({
+        'class': True,
+        'itemprop': True,
+        'itemscope': True,
+        'itemtype': True,
+    })
+
+    allowed_tags = ['aside', 'h4', 'p', 'span',
+                    'table', 'tr', 'th', 'td', 'tbody', 'thead', 'tfoot',
+                    'col', 'colgroup']
+
+    return {tag: allow_html_class for tag in allowed_tags}


### PR DESCRIPTION
This is needed to experiment with some schema markup to improve search result formatting.

## Additions

- New allowed HTML elements in rich text fields: `div`, `h4`, `p`, `span`
- New allowed HTML attributes in rich text fields: `itemprop`, `itemscope`, `itemtype`

## Testing

1. Open an Ask CFPB answer for editing
1. Click the HTML editor button in its rich text field
1. Add in some of the new elements and attributes
1. Save the answer
1. Reopen the HTML editor in the RTF to see that the new stuff has not been stripped
1. Go to the answer's page and preview it
1. Inspect the answer content to see the elements are present on the rendered page

## Notes

- ~~Though I have added `div` here, for reasons I don't understand, `div` elements still get stripped~~ Explained below.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [x] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: