### PR TITLE
bump comparisontool requirement

### DIFF
--- a/requirements/optional-public.txt
+++ b/requirements/optional-public.txt
@@ -3,5 +3,5 @@ https://github.com/cfpb/owning-a-home-api/releases/download/0.11.3/owning_a_home
 https://github.com/cfpb/retirement/releases/download/0.7.6/retirement-0.7.6-py2-none-any.whl
 https://github.com/cfpb/ccdb5-api/releases/download/1.1.7/ccdb5_api-1.1.7-py2-none-any.whl
 https://github.com/cfpb/ccdb5-ui/releases/download/1.1.0/ccdb5_ui-1.1.0-py2-none-any.whl
-https://github.com/cfpb/django-college-costs-comparison/releases/download/1.8.1/comparisontool-1.8.1-py2-none-any.whl
+https://github.com/cfpb/django-college-costs-comparison/releases/download/1.9.0/comparisontool-1.9.0-py2-none-any.whl
 https://github.com/cfpb/teachers-digital-platform/releases/download/1.0.28/teachers_digital_platform-1.0.28-py2-none-any.whl


### PR DESCRIPTION
comparisontool-1.9.0 removes feedback code so that Wagtail can handle feedback duties.
