### PR TITLE
[HOLD] CFPB-Researchers date fix

### DIFF
--- a/cfgov/jinja2/v1/_includes/organisms/post-preview.html
+++ b/cfgov/jinja2/v1/_includes/organisms/post-preview.html
@@ -178,7 +178,7 @@
             {% endfor %}
             </div>
 
-            {% if post.tags.exists() %}
+            {% if post.tags.exists() and controls.categories.page_type != 'foia-freq-req-record' %}
                 {%- import 'tags.html' as tags %}
                 {{ tags.render(post.related_metadata_tags(), hide_heading=true, is_wagtail=True) }}
             {% endif %}

--- a/cfgov/jinja2/v1/_includes/organisms/post-preview.html
+++ b/cfgov/jinja2/v1/_includes/organisms/post-preview.html
@@ -66,6 +66,7 @@
     {% set display_settings = get_fl_display_settings(controls.categories.page_type) if controls.categories is defined else get_fl_display_settings('None') %}
     <article class="o-post-preview">
         <div class="m-meta-header">
+            {% if display_settings.show_date %}
             <div class="m-meta-header_right">
                 <span class="a-date">
                     {{ date_desc }}
@@ -76,6 +77,7 @@
                     {% endif %}
                 </span>
             </div>
+            {% endif %}
             <div class="m-meta-header_left">
                 {# Newsroom Blog category logic #}
                 {% if show_categories %}

--- a/cfgov/jinja2/v1/_includes/organisms/post-preview.html
+++ b/cfgov/jinja2/v1/_includes/organisms/post-preview.html
@@ -63,6 +63,7 @@
     {% set date_desc = controls.post_date_description or post_date_description or 'Published' %}
     {% set cat_controls = controls.categories %}
     {% set show_categories = cat_controls.show_preview_categories if cat_controls is defined else true %}
+    {% set display_settings = get_fl_display_settings(controls.categories.page_type) if cat_controls is defined else get_fl_display_settings('None') %}
     <article class="o-post-preview">
         <div class="m-meta-header">
             <div class="m-meta-header_right">
@@ -176,9 +177,8 @@
                       </a>
                 {% endif %}
             {% endfor %}
-            </div>
 
-            {% if post.tags.exists() and controls.categories.page_type != 'foia-freq-req-record' %}
+            {% if post.tags.exists() and display_settings.show_tags %}
                 {%- import 'tags.html' as tags %}
                 {{ tags.render(post.related_metadata_tags(), hide_heading=true, is_wagtail=True) }}
             {% endif %}

--- a/cfgov/jinja2/v1/_includes/organisms/post-preview.html
+++ b/cfgov/jinja2/v1/_includes/organisms/post-preview.html
@@ -63,7 +63,7 @@
     {% set date_desc = controls.post_date_description or post_date_description or 'Published' %}
     {% set cat_controls = controls.categories %}
     {% set show_categories = cat_controls.show_preview_categories if cat_controls is defined else true %}
-    {% set display_settings = get_fl_display_settings(controls.categories.page_type) if cat_controls is defined else get_fl_display_settings('None') %}
+    {% set display_settings = get_fl_display_settings(controls.categories.page_type) if controls.categories is defined else get_fl_display_settings('None') %}
     <article class="o-post-preview">
         <div class="m-meta-header">
             <div class="m-meta-header_right">
@@ -177,7 +177,7 @@
                       </a>
                 {% endif %}
             {% endfor %}
-
+            </div>
             {% if post.tags.exists() and display_settings.show_tags %}
                 {%- import 'tags.html' as tags %}
                 {{ tags.render(post.related_metadata_tags(), hide_heading=true, is_wagtail=True) }}

--- a/cfgov/v1/jinja2tags/__init__.py
+++ b/cfgov/v1/jinja2tags/__init__.py
@@ -103,6 +103,7 @@ class V1Extension(Extension):
             'is_report': ref.is_report,
             'is_filter_selected': contextfunction(is_filter_selected),
             'render_stream_child': contextfunction(render_stream_child),
+            'get_fl_display_settings': ref.get_fl_display_settings,
         })
 
 

--- a/cfgov/v1/util/__init__.py
+++ b/cfgov/v1/util/__init__.py
@@ -6,7 +6,7 @@ from v1.util.password_policy import (
 from v1.util.ref import (
     category_label, choices_for_page_type, fcm_label,
     filterable_list_page_types, is_blog, is_report, page_type_choices,
-    related_posts_category_lookup
+    related_posts_category_lookup, get_fl_display_settings
 )
 from v1.util.util import (
     ERROR_MESSAGES, all_valid_destinations_for_request,

--- a/cfgov/v1/util/ref.py
+++ b/cfgov/v1/util/ref.py
@@ -267,6 +267,7 @@ def get_category_children(category_names):
         for category in category_names
     )))
 
+
 def get_fl_display_settings(filterable_page_type):
     settings = {
         'page_type': filterable_page_type,

--- a/cfgov/v1/util/ref.py
+++ b/cfgov/v1/util/ref.py
@@ -45,6 +45,7 @@ page_types = [
     ('rule-under-dev', 'Rule Under Development'),
     ('story', 'Story'),
     ('ask', 'Ask CFPB'),
+    ('cfpb-researchers', 'CFPB Researchers'),
 ]
 
 fcm_types = [
@@ -272,7 +273,10 @@ def get_fl_display_settings(filterable_page_type):
     settings = {
         'page_type': filterable_page_type,
         'show_tags': True,
+        'show_date': True,
         }
     if "foia-freq-req-record" in filterable_page_type:
         settings['show_tags'] = False
+    elif "cfpb-researchers" in filterable_page_type:
+        settings['show_date'] = False
     return settings

--- a/cfgov/v1/util/ref.py
+++ b/cfgov/v1/util/ref.py
@@ -266,3 +266,12 @@ def get_category_children(category_names):
         dict(categories_dict[category]).keys()
         for category in category_names
     )))
+
+def get_fl_display_settings(filterable_page_type):
+    settings = {
+        'page_type': filterable_page_type,
+        'show_tags': True,
+        }
+    if "foia-freq-req-record" in filterable_page_type:
+        settings['show_tags'] = False
+    return settings


### PR DESCRIPTION
__HOLD:__ This PR will wait for the work in #4772 

This PR adds a display setting (in the `get_fl_display_settings` function in `ref.py`) that allows for hiding dates in filtered lists. This is a specific need for the CFPB Researchers page, where the date is irrelevant to the viewer (although it is used in the back-end as a sorting mechanism).

To use this option, the CFPB Researchers page must be edited so that the filtered list uses the "CFPB Researchers" page type in the filterable list options.

## Additions
- Add `cfpb-researchers` to `page_types`
- Add an option to `get_fl_display_settings` for `show_date`
- Add logic to hide the date when `show_date` is `False`

## Testing
1. Pull down this branch and get it running!
2. Go into Wagtail, find the 'CFPB Researchers' page, scroll down, and under "FILTERABLE LIST" options, use the Page Type dropdown to select "CFPB Researchers."
3. Check out http://localhost:8000/data-research/cfpb-researchers/ and make sure there are no dates.
4. Check out other filterable list pages and make sure they have dates as expected.

## Screenshots
<img width="1409" alt="screen shot 2019-01-29 at 11 48 13 am" src="https://user-images.githubusercontent.com/1490703/51924886-e3d8bf00-23bb-11e9-872c-2ff3f557e4f2.png">

## Notes
-

## Todos
-

## Checklist
- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Internet Explorer 8, 9, 10, and 11
- [ ] Edge
- [ ] iOS Safari
- [ ] Chrome for Android

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
