### PR TITLE
Allows page type-specific post preview rendering

### DIFF
--- a/cfgov/jinja2/v1/_includes/organisms/filterable-list.html
+++ b/cfgov/jinja2/v1/_includes/organisms/filterable-list.html
@@ -31,6 +31,10 @@
 
    filter_data.page_set: Result set of posts from the filtered content.
 
+   show_post_dates: Whether to render a date in post previews.
+
+   show_post_tags: Whether to render the tags in post previews.
+
    ========================================================================== #}
 
 {% import 'organisms/filterable-list-controls.html' as filterable_list_controls with context %}
@@ -181,9 +185,14 @@
                         </div>
                     </div>
                 {% else %}
-                    {% import 'organisms/post-preview.html' as post_preview with context %}
+                    {% import 'organisms/post-preview.html' as post_preview without context %}
                     {% for post in posts %}
-                        {{ post_preview.render(post, value) }}
+                        {{ post_preview.render(
+                            post,
+                            value,
+                            show_date=show_post_dates|default(true),
+                            show_tags=show_post_tags|default(true)
+                        ) }}
                     {% endfor %}
                 {% endif %}
 

--- a/cfgov/jinja2/v1/_includes/organisms/filterable-list.html
+++ b/cfgov/jinja2/v1/_includes/organisms/filterable-list.html
@@ -190,8 +190,8 @@
                         {{ post_preview.render(
                             post,
                             value,
-                            show_date=show_post_dates|default(true),
-                            show_tags=show_post_tags|default(true)
+                            show_date=show_post_dates | default(true),
+                            show_tags=show_post_tags | default(true)
                         ) }}
                     {% endfor %}
                 {% endif %}

--- a/cfgov/jinja2/v1/_includes/organisms/post-preview-snapshot.html
+++ b/cfgov/jinja2/v1/_includes/organisms/post-preview-snapshot.html
@@ -1,0 +1,33 @@
+{# ==========================================================================
+
+   Post preview snapshot
+
+   ==========================================================================
+
+   Description:
+
+   Render a list of post previews for a page when given:
+
+   value: Data object from an instance of the PostPreviewControls StreamField
+          block.
+
+   value.limit: Number of posts to show.
+
+   value.post_date_description: Text to display next to date, e.g. "Published".
+
+   ========================================================================== #}
+
+{% import 'organisms/post-preview.html' as post_preview with context %}
+
+<div class="block">
+{% set num_posts = value.limit | int %}
+{% set posts = page.get_browsefilterable_posts(num_posts) if page else [] %}
+{% for post in posts %}
+    {{ post_preview.render(
+        post,
+        controls=none, 
+        url=pageurl(post.parent()),
+        post_date_description=value.post_date_description
+    ) }}
+{% endfor %}
+</div>

--- a/cfgov/jinja2/v1/_includes/organisms/post-preview.html
+++ b/cfgov/jinja2/v1/_includes/organisms/post-preview.html
@@ -46,7 +46,8 @@
    post.preview_link_text:  A string with the description text of an external link.
    post.preview_link_url:   A string with the url of an external link.
 
-   controls:                       An object with specific article information.
+   controls:                       Data object from an instance of the
+                                   FilterableList StreamField block.
    controls.post_date_description: A string of the post publication description.
    controls.categories:            An array with the categories for the post.
 
@@ -55,16 +56,28 @@
 
    post_date_description:   A string of the post publication description.
 
+   show_date: Whether to render a date for this post.
+
+   show_tags: Whether to render the tags for this post.
+
    ========================================================================== #}
 
 {% import 'macros/time.html' as time %}
 
-{% macro render(post, controls, url='', post_date_description='') %}
+{% macro render(
+    post,
+    controls,
+    url='',
+    post_date_description='',
+    show_date=true,
+    show_tags=true
+) %}
     {% set date_desc = controls.post_date_description or post_date_description or 'Published' %}
     {% set cat_controls = controls.categories %}
     {% set show_categories = cat_controls.show_preview_categories if cat_controls is defined else true %}
     <article class="o-post-preview">
         <div class="m-meta-header">
+            {% if show_date %}
             <div class="m-meta-header_right">
                 <span class="a-date">
                     {{ date_desc }}
@@ -75,6 +88,7 @@
                     {% endif %}
                 </span>
             </div>
+            {% endif %}
             <div class="m-meta-header_left">
                 {# Newsroom Blog category logic #}
                 {% if show_categories %}
@@ -178,7 +192,7 @@
             {% endfor %}
             </div>
 
-            {% if post.tags.exists() %}
+            {% if show_tags and post.tags.exists() %}
                 {%- import 'tags.html' as tags %}
                 {{ tags.render(post.related_metadata_tags(), hide_heading=true, is_wagtail=True) }}
             {% endif %}

--- a/cfgov/jinja2/v1/sublanding-page/index.html
+++ b/cfgov/jinja2/v1/sublanding-page/index.html
@@ -32,14 +32,7 @@
         {% elif block.block_type == 'feedback' %}
             {{- form_block.render(block, 'content', loop.index0) -}}
         {% elif 'post_preview_snapshot' in block.block_type %}
-            <div class="block
-                        {{ block.block.meta.classname if block.block.meta.classname else '' }}">
-                {% set limit = block.value.limit | int %}
-                {% set posts = page.get_browsefilterable_posts(limit) %}
-                {% for post in posts %}
-                    {{ post_preview.render(post, controls=none, url=pageurl(post.parent()), post_date_description=block.value.post_date_description) }}
-                {% endfor %}
-             </div>
+            {% include_block block %}
         {% elif 'filter_controls' in block.block_type %}
             <div class="block block__flush-top">
                 {% include_block block %}

--- a/cfgov/v1/atomic_elements/organisms.py
+++ b/cfgov/v1/atomic_elements/organisms.py
@@ -218,6 +218,7 @@ class PostPreviewSnapshot(blocks.StructBlock):
 
     class Meta:
         icon = 'order'
+        template = '_includes/organisms/post-preview-snapshot.html'
 
 
 class EmailSignUp(blocks.StructBlock):
@@ -913,6 +914,37 @@ class FilterableList(BaseExpandable):
 
     class Media:
         js = ['filterable-list.js']
+
+    def get_context(self, value, parent_context=None):
+        context = super(FilterableList, self).get_context(
+            value,
+            parent_context=parent_context
+        )
+
+        # Different instances of FilterableList need to render their post
+        # previews differently depending on the page type they live on. By
+        # default post dates and tags are always shown.
+        context.update({
+            'show_post_dates': True,
+            'show_post_tags': True,
+        })
+
+        # Pull out the page type selected when the FilterableList was
+        # configured in the page editor, if one was specified. See the
+        # 'categories' block definition above. The page type choices are
+        # defined in v1.util.ref.page_types.
+        page_type = value['categories'].get('page_type')
+
+        # Pending a much-needed refactor of that code, this logic is being
+        # placed here to keep FilterableList logic in one place. It would be
+        # better if this kind of configuration lived on custom Page models.
+        page_type_overrides = {
+            'cfpb-researchers': {'show_post_dates': False},
+            'foia-freq-req-record': {'show_post_tags': False},
+        }
+
+        context.update(page_type_overrides.get(page_type, {}))
+        return context
 
 
 class VideoPlayer(blocks.StructBlock):

--- a/cfgov/v1/util/ref.py
+++ b/cfgov/v1/util/ref.py
@@ -46,6 +46,7 @@ page_types = [
     ('rule-under-dev', 'Rule Under Development'),
     ('story', 'Story'),
     ('ask', 'Ask CFPB'),
+    ('cfpb-researchers', 'CFPB Researchers'),
 ]
 
 fcm_types = [


### PR DESCRIPTION
This change proposes an alternative to #4772 and #4790.

This change makes it possible to disable the rendering of post preview tags and dates when rendered as part of a filterable list. This is now possible via [code in the `FilterableList` StreamField block](https://github.com/chosak/cfgov-refresh/blob/98b59e44bdb6783005dc0f87f30e7c904dbad6f3/cfgov/v1/atomic_elements/organisms.py#L918), and is dependent on the "page_type" set on the FL, which is an optional setting that a page editor can define.

This change adds a new page type of "cfpb-researchers" and disables rendering of post preview dates for it (#4790). It also disables rendering of post preview tags for the "foia-freq-req-record" page type (#4772).

A side effect of this change is to add a proper Wagtail StreamField block template for the `PostPreviewSnapshot` block type.

## Additions

- Creates new template for `PostPreviewSnapshot` StreamField blocks, extracting the existing code in the `SublandingPage` template, which is the only place these blocks can be placed. This allows this block to be rendered using Wagtail's built-in `{% include_block %}` syntax, and, in future, to be placed on other pages if desired.
- Adds a new FilterableList page type for "CFPB Researchers", that does not display post dates.

## Changes

- Modifies the rendering of FilterableLists set to the "FOIA Frequently Requested Record" so that post previews do not show tags.

## Testing

1. To verify default functioning of FilterableLists shows dates and tags, visit [the Newsroom locally](http://localhost:8000/about-us/newsroom/) and compare with [the version in production](https://www.consumerfinance.gov/about-us/newsroom/).
2. To see the changed behavior of the FOIA page, compare [its local version](http://localhost:8000/foia-requests/foia-electronic-reading-room/) with [the version in production](https://www.consumerfinance.gov/foia-requests/foia-electronic-reading-room/) and confirm that tags no longer appear.
3. To see the behavior for the new CFPB Researchers tag, [edit the page locally](http://localhost:8000/admin/pages/4833/edit/) and set its FilterableList page type to "CFPB Researchers". Preview the page (you may need to set a "Post date description", which will be ignored) and compare its local version to [the version in production](https://www.consumerfinance.gov/data-research/cfpb-researchers/) and confirm that dates no longer appear.
4. To confirm proper functioning of the new `PostPreviewSnapshot` block template, test the two Sublanding pages that currently use that block to verify that the local page version matches the version in production. Note especially that the HTML rendering and tag links are the same.

    1. Amicus program: [local](http://localhost:8000/policy-compliance/amicus/), [production](https://www.consumerfinance.gov/policy-compliance/amicus/)
    2. Notice and opportunities to comment: [local](http://localhost:8000/policy-compliance/notice-opportunities-comment/), [production](https://www.consumerfinance.gov/policy-compliance/notice-opportunities-comment)

## Notes

This change attempts to make `PostPreviewSnapshot` into a proper Wagtail StreamField block. We don't currently have a `PostPreview` block -- we have a template, but it's not a StreamField block. For this reason, it seemed more straightforward to add `show_date` and `show_tags` as parameters to that template's top-level macro than to try to add it to an existing structure or create a whole new structure for display settings.

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [X] Passes all existing automated tests
- [X] Any _change_ in functionality is tested
- [X] New functions are documented (with a description, list of inputs, and expected output)
- [X] Placeholder code is flagged / future todos are captured in comments
- [X] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [X] Project documentation has been updated
- [X] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: