### PR TITLE
Fixes flake8 E117 over-indentation errors

### DIFF
--- a/cfgov/ask_cfpb/scripts/export_ask_data.py
+++ b/cfgov/ask_cfpb/scripts/export_ask_data.py
@@ -146,8 +146,7 @@ def write_questions_to_csv(csvfile):
     writer = unicodecsv.writer(csvfile, encoding='windows-1252')
     writer.writerow(HEADINGS)
     for row in assemble_output():
-            writer.writerow(
-                [row.get(key) for key in HEADINGS])
+        writer.writerow([row.get(key) for key in HEADINGS])
 
 
 def run(*args):

--- a/cfgov/v1/util/password_policy.py
+++ b/cfgov/v1/util/password_policy.py
@@ -22,21 +22,22 @@ def validate_password_age(user):
         current_password_data = user.passwordhistoryitem_set.latest()
 
         if not current_password_data.can_change_password():
-            raise ValidationError("You can not change passwords more"
-                                  " than once in 24 hours")
+            raise ValidationError(
+                "You can not change passwords more than once in 24 hours"
+            )
     except ObjectDoesNotExist:
         pass
 
 
 def validate_password_history(user, password):
-        queryset = user.passwordhistoryitem_set.order_by('-created')[:10]
+    queryset = user.passwordhistoryitem_set.order_by('-created')[:10]
 
-        checker = functools.partial(hashers.check_password, password)
+    checker = functools.partial(hashers.check_password, password)
 
-        if any([checker(pass_hist.encrypted_password)
-                for pass_hist in queryset]):
-            raise ValidationError("You may not re-use any of your last 10"
-                                  " passwords")
+    if any(checker(pass_hist.encrypted_password) for pass_hist in queryset):
+        raise ValidationError(
+            "You may not re-use any of your last 10 passwords"
+        )
 
 
 def _check_passwords(password, user, password_field):


### PR DESCRIPTION
Flake8 seemingly got more restrictive as of the 3.7.0 release.

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [X] Passes all existing automated tests
- [X] Any _change_ in functionality is tested
- [X] New functions are documented (with a description, list of inputs, and expected output)
- [X] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [X] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: