### PR TITLE
Removes pytz from project requirements

### DIFF
--- a/requirements/libraries.txt
+++ b/requirements/libraries.txt
@@ -26,7 +26,6 @@ ntplib==0.3.3
 openpyxl==2.5.8
 pyelasticsearch==0.6.1
 python-dateutil==2.7.3
-pytz
 # PyYAML is required by college-costs
 PyYAML==3.13
 requests==2.21.0


### PR DESCRIPTION
This commit removes the unpinned [pytz](https://pypi.org/project/pytz/) from our requirements. Pytz is installed by Django:

https://github.com/django/django/blob/1.11.18/setup.py#L50

And so we don't need to specify it explicitly.

## Notes

Note that pytz was unpinned and is unpinned by Django; this is intentional as it gets updated with every timezone change, which happens [quite frequently](https://github.com/stub42/pytz/blob/master/tz/NEWS).

See also [this excellent talk](https://www.youtube.com/watch?v=qabriMQ1SYs) from DjangoCon US 2018.

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [X] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [X] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: