### PR TITLE
Simplify RateCheckerChartMenu and fix BAH linter warnings

### DIFF
--- a/cfgov/jinja2/v1/owning-a-home/explore-rates/index.html
+++ b/cfgov/jinja2/v1/owning-a-home/explore-rates/index.html
@@ -341,10 +341,10 @@ home price, down payment, and more can affect mortgage interest rates.
                                 Download chart
                             </button>
                             <ul class="chart-menu_options">
-                                <li data-export-type="0">PNG</li>
-                                <li data-export-type="1">SVG</li>
-                                <li data-export-type="2">JPEG</li>
-                                <li data-export-type="3">Print chart</li>
+                                <li>PNG</li>
+                                <li>SVG</li>
+                                <li>JPEG</li>
+                                <li>Print chart</li>
                             </ul>
                         </div>
                         <figure class="data-enabled loading">

--- a/cfgov/unprocessed/apps/owning-a-home/js/explore-rates/RateCheckerChart.js
+++ b/cfgov/unprocessed/apps/owning-a-home/js/explore-rates/RateCheckerChart.js
@@ -2,11 +2,17 @@ import {
   chartTooltipMultiple,
   chartTooltipSingle
 } from './template-loader';
+import { applyThemeTo } from './highcharts-theme';
 import Highcharts from 'highcharts';
 import RateCheckerChartMenu from './RateCheckerChartMenu';
 import highchartsExport from 'highcharts/modules/exporting';
-import { applyThemeTo } from './highcharts-theme';
 
+/**
+ * RateCheckerChart
+ * @class
+ * @classdesc Creates the left-hand side chart on /owning-a-home/explore-rates/
+ * @returns {RateCheckerChart} An instance.
+ */
 function RateCheckerChart() {
   let _highChart;
   let _containerDom;
@@ -23,6 +29,9 @@ function RateCheckerChart() {
   // Set some properties for the histogram.
   let isInitialized = false;
 
+  /**
+   * Initialize the chart variables and set the loading appearance.
+   */
   function init() {
     // Load and style highCharts library. https://www.highCharts.com/docs.
     highchartsExport( Highcharts );
@@ -37,6 +46,10 @@ function RateCheckerChart() {
     startLoading();
   }
 
+  /**
+   * Initialize and create highcharts-related instances.
+   * @returns {RateCheckerChartMenu} A menu instance.
+   */
   function _createHighcharts() {
     _highChart = new Highcharts.Chart( {
       chart: {
@@ -122,7 +135,7 @@ function RateCheckerChart() {
       }
     } );
 
-    new RateCheckerChartMenu( _highChart );
+    return new RateCheckerChartMenu( _highChart );
   }
 
   /**
@@ -168,6 +181,9 @@ function RateCheckerChart() {
     _currentState = state;
   }
 
+  /**
+   * Set the loading apperance of the chart.
+   */
   function startLoading() {
     setStatus( RateCheckerChart.STATUS_OKAY );
     _dataLoadedDom.classList.add( 'loading' );

--- a/cfgov/unprocessed/apps/owning-a-home/js/explore-rates/Slider.js
+++ b/cfgov/unprocessed/apps/owning-a-home/js/explore-rates/Slider.js
@@ -3,7 +3,6 @@ import { checkDom, setInitFlag }
   from '../../../../js/modules/util/atomic-helpers';
 import { UNDEFINED }
   from '../../../../js/modules/util/standard-type';
-import { getSelection } from './dom-values';
 import rangesliderJs from 'rangeslider-js';
 
 /**
@@ -20,8 +19,6 @@ function Slider( element ) {
   const BASE_CLASS = 'a-range';
   const _dom = checkDom( element, BASE_CLASS );
   const _inputDom = _dom.querySelector( `.${ BASE_CLASS }_input` );
-  const _labelMinDom = _dom.querySelector( `.${ BASE_CLASS }_labels-min` );
-  const _labelMaxDom = _dom.querySelector( `.${ BASE_CLASS }_labels-max` );
   const _labelDom = _dom.querySelector( `.${ BASE_CLASS }_text` );
 
   let _rangeSliderHandleDom;
@@ -80,7 +77,8 @@ function Slider( element ) {
    */
   function _updateValues() {
     const currentVal = Number( _inputDom.value );
-    const currentStep = Math.round( ( ( currentVal - _min ) + _lastValue ) / _options.step );
+    const numerator = ( currentVal - _min ) + _lastValue;
+    const currentStep = Math.round( numerator / _options.step );
 
     _valMin = _min + ( currentStep * UNITS_PER_STEP );
     _valMax = _valMin + UNITS_PER_STEP - 1;

--- a/cfgov/unprocessed/apps/owning-a-home/js/explore-rates/rate-checker.js
+++ b/cfgov/unprocessed/apps/owning-a-home/js/explore-rates/rate-checker.js
@@ -1,4 +1,5 @@
 import * as params from './params';
+import * as tab from './tab';
 import * as template from './template-loader';
 import {
   calcLoanAmount,
@@ -25,7 +26,6 @@ import jumbo from 'jumbo-mortgage';
 import median from 'median';
 import RateCheckerChart from './RateCheckerChart';
 import Slider from './Slider';
-import * as tab from './tab';
 import unFormatUSD from 'unformat-usd';
 
 // TODO: remove jquery.
@@ -129,8 +129,7 @@ function updateView() {
       // sort results by interest rate, ascending
       const sortedKeys = [];
       const sortedResults = {};
-      let key;
-      for ( key in results ) {
+      for ( const key in results ) {
         if ( results.hasOwnProperty( key ) ) {
           sortedKeys.push( key );
         }
@@ -224,7 +223,8 @@ function updateView() {
 function updateLanguage( totalVals ) {
   function renderLocation() {
     const stateDropDown = document.querySelector( '#location' );
-    const state = stateDropDown.options[stateDropDown.selectedIndex].textContent;
+    const selectedDropDown = stateDropDown.options[stateDropDown.selectedIndex];
+    const state = selectedDropDown.textContent;
     const locations = document.querySelectorAll( '.location' );
     // forEach could be used here, but it's not supported in IE11.
     for ( let i = 0, len = locations.length; i < len; i++ ) {

--- a/test/unit_tests/apps/owning-a-home/js/explore-rates/RateCheckerChartMenu-spec.js
+++ b/test/unit_tests/apps/owning-a-home/js/explore-rates/RateCheckerChartMenu-spec.js
@@ -7,10 +7,10 @@ const Highcharts = require(
   BASE_JS_PATH + 'node_modules/highcharts'
 );
 
-const simulateEvent =
-  require( '../../../../../util/simulate-event' ).simulateEvent;
+import { simulateEvent } from '../../../../../util/simulate-event';
 
-const STATES = RateCheckerChartMenu.STATES;
+const STATE_OPEN = 'open';
+const STATE_CLOSED = 'closed';
 
 let highCharts;
 let chartMenu;
@@ -18,29 +18,35 @@ let chartMenuDOM;
 let chartMenuBtnDOM;
 
 const HTML_SNIPPET = `
-  <section id="chart-section" class="chart">
-  </section>
-    <div class="chart-menu">
-      <button class="chart-menu_btn
-                     cf-icon
-                     cf-icon__after
-                     cf-icon-download">
-        Download chart
-      </button>
-      <ul class="chart-menu_options">
-        <li data-export-type="0">PNG</li>
-        <li data-export-type="1">SVG</li>
-        <li data-export-type="2">JPEG</li>
-        <li data-export-type="3">Print chart</li>
-      </ul>
-    </div>
+<section id="chart-section" class="chart">
+  <div class="chart-menu">
+    <button class="chart-menu_btn
+                    cf-icon
+                    cf-icon__after
+                    cf-icon-download">
+      Download chart
+    </button>
+    <ul class="chart-menu_options">
+      <li>PNG</li>
+      <li>SVG</li>
+      <li>JPEG</li>
+      <li>Print chart</li>
+    </ul>
+  </div>
+  <figure>
+    <div id="chart" class="chart-area"></div>
+  </figure>
+</section>
 `;
 
 describe( 'explore-rates/RateCheckerChartMenu', () => {
   beforeEach( () => {
     document.body.innerHTML = HTML_SNIPPET;
 
-    highCharts = new Highcharts.Chart( 'chart-section', {
+    highCharts = new Highcharts.Chart( {
+      chart: {
+        renderTo: document.querySelector( '#chart' )
+      },
       xAxis: {
         categories: [ 'Jan', 'Feb' ]
       },
@@ -59,7 +65,7 @@ describe( 'explore-rates/RateCheckerChartMenu', () => {
 
   describe( 'new RateCheckerChartMenu()', () => {
     it( 'should set the state to closed', () => {
-      expect( chartMenu.state ).toStrictEqual( { position: STATES.CLOSED } );
+      expect( chartMenu.state ).toStrictEqual( STATE_CLOSED );
     } );
 
     it( 'should set a reference to the highcharts instance', () => {
@@ -84,36 +90,23 @@ describe( 'explore-rates/RateCheckerChartMenu', () => {
   describe( 'open()', () => {
     it( 'should set the open state', () => {
       chartMenu.open();
-      expect( chartMenu.state ).toStrictEqual( { position: STATES.OPEN } );
+      expect( chartMenu.state ).toStrictEqual( STATE_OPEN );
     } );
   } );
 
   describe( 'close()', () => {
     it( 'should set the closed state', () => {
       chartMenu.close();
-      expect( chartMenu.state ).toStrictEqual( { position: STATES.CLOSED } );
+      expect( chartMenu.state ).toStrictEqual( STATE_CLOSED );
     } );
   } );
 
   describe( 'render()', () => {
     it( 'should set the proper classes on the menu DOM', () => {
       chartMenu.open();
+      expect( chartMenu.state ).toStrictEqual( STATE_OPEN );
       expect( chartMenuDOM.classList.contains( 'chart-menu__open' ) )
         .toStrictEqual( true );
-    } );
-  } );
-
-  describe( '_setState()', () => {
-    it( 'should set the state when passed an object', () => {
-      chartMenu._setState( { position: STATES.OPEN } );
-      expect( chartMenu.state ).toStrictEqual( { position: STATES.OPEN } );
-    } );
-
-    it( 'should maintain the state when an object isn\'t passed', () => {
-      chartMenu.open();
-      expect( chartMenu.state ).toStrictEqual( { position: STATES.OPEN } );
-      chartMenu._setState();
-      expect( chartMenu.state ).toStrictEqual( { position: STATES.OPEN } );
     } );
   } );
 
@@ -129,9 +122,9 @@ describe( 'explore-rates/RateCheckerChartMenu', () => {
 
     it( 'should set the proper state when the menu button is clicked', () => {
       simulateEvent( 'click', chartMenuBtnDOM );
-      expect( chartMenu.state ).toStrictEqual( { position: STATES.OPEN } );
+      expect( chartMenu.state ).toStrictEqual( STATE_OPEN );
       simulateEvent( 'click', chartMenuBtnDOM );
-      expect( chartMenu.state ).toStrictEqual( { position: STATES.CLOSED } );
+      expect( chartMenu.state ).toStrictEqual( STATE_CLOSED );
     } );
 
     it( 'should call exportChart when a menu export option is clicked', () => {
@@ -146,11 +139,13 @@ describe( 'explore-rates/RateCheckerChartMenu', () => {
 
   describe( 'exportChart()', () => {
     it( 'should call the appropriate highCharts.export method', () => {
-      chartMenu.exportChart( 1 );
+      chartMenu.exportChart( 'PNG' );
+      expect( highCharts.exportChart ).toBeCalledWith( { type: 'image/png' } );
+      chartMenu.exportChart( 'SVG' );
       expect( highCharts.exportChart ).toBeCalledWith( { type: 'image/svg+xml' } );
-      chartMenu.exportChart( 2 );
+      chartMenu.exportChart( 'JPEG' );
       expect( highCharts.exportChart ).toBeCalledWith( { type: 'image/jpeg' } );
-      chartMenu.exportChart( 3 );
+      chartMenu.exportChart( 'Print chart' );
       expect( highCharts.print ).toHaveBeenCalled();
     } );
   } );


### PR DESCRIPTION
## Additions

- Adds missing jsdocs to BAH methods.
- Adds missing MIME type for PNG in chart export.

## Removals

- Removes "RateCheckerChartMenu.STATES" export as it was only exported for the tests.
- Removes test of internal private method "_setState".
- Unused references in Slider.js.

## Changes

- Converts open/closed state of chart download menu to simple strings from an object to remove need for Object.assign.
- Converts logic stored in data- attributes to directly use textContent of list nodes in download menu.
- Removes complexity warning from exportChart method by converting switch into if/else and an object lookup hash.
- Update RateCheckerChartMenu test markup structure to follow that of production.

## Testing

1. Pull the branch and `gulp clean && gulp build`
2. The "Download chart" options in the upper-right of the chart on http://localhost:8000/owning-a-home/explore-rates/ should work (first three will download an image, last will open the print dialog box). Clicking the "Download chart" text will open/close the menu.
3. `gulp test:unit` should pass.

## Screenshots

<img width="206" alt="screen shot 2019-02-04 at 3 47 22 pm" src="https://user-images.githubusercontent.com/704760/52236208-3589b980-2894-11e9-8431-e7e74b086c14.png">
