### PR TITLE
BAH: Loan explainer, remove col-9 logic

### DIFF
--- a/cfgov/jinja2/v1/owning-a-home/closing-disclosure/index.html
+++ b/cfgov/jinja2/v1/owning-a-home/closing-disclosure/index.html
@@ -44,7 +44,6 @@
             {% include "_templates/no_js.html" %}
 
             <div class="form-explainer">
-
                 <div class="page-intro content-l">
                     <div class="content-l_col-2-3">
                         <h1 class="page-title">Closing Disclosure Explainer</h1>

--- a/cfgov/jinja2/v1/owning-a-home/loan-estimate/index.html
+++ b/cfgov/jinja2/v1/owning-a-home/loan-estimate/index.html
@@ -42,8 +42,7 @@
 
             {% include "_templates/no_js.html" %}
 
-            <div class="form-explainer
-                        {% if subnav %}col-9{% endif %}">
+            <div class="form-explainer">
                 <div class="page-intro content-l">
                     <div class="content-l_col-2-3">
                         <h1 class="page-title">Loan Estimate Explainer</h1>


### PR DESCRIPTION
Unreferenced or documented `subnav` variable appears to be unused in this template and is not present in the sibling template at https://github.com/cfpb/cfgov-refresh/blob/master/cfgov/jinja2/v1/owning-a-home/closing-disclosure/index.html#L46

## Removals

- Remove logic to add `col-9` class when `subnav` variable is present in the template.
- Remove unnecessary newline.

## Testing

1. http://localhost:8000/owning-a-home/loan-estimate/ should work like production.
