### PR TITLE
Untangle BAH apps and routes paths

### DIFF
--- a/cfgov/jinja2/v1/owning-a-home/closing-disclosure/index.html
+++ b/cfgov/jinja2/v1/owning-a-home/closing-disclosure/index.html
@@ -23,7 +23,8 @@
         !function(){
           {# Include site-wide JavaScript. #}
           var s = [
-            '{{ static('apps/owning-a-home/js/common.js') }}'
+            '{{ static('apps/owning-a-home/js/common.js') }}',
+            '{{ static('apps/owning-a-home/js/form-explainer/index.js') }}'
           ];
           jsl(s);
         }()

--- a/cfgov/jinja2/v1/owning-a-home/loan-estimate/index.html
+++ b/cfgov/jinja2/v1/owning-a-home/loan-estimate/index.html
@@ -23,7 +23,10 @@
       if ( document.body.parentElement.className.indexOf( 'no-js' ) === -1 ) {
         !function(){
           {# Include site-wide JavaScript. #}
-          var s = [ '/static/apps/owning-a-home/js/common.js' ];
+          var s = [
+            '{{ static('apps/owning-a-home/js/common.js') }}',
+            '{{ static('apps/owning-a-home/js/form-explainer/index.js') }}'
+          ];
           jsl(s);
         }()
       }

--- a/cfgov/unprocessed/apps/owning-a-home/js/form-explainer/dom-tools.js
+++ b/cfgov/unprocessed/apps/owning-a-home/js/form-explainer/dom-tools.js
@@ -26,6 +26,12 @@ function applyAll( elements, applyFn ) {
   return false;
 }
 
+/**
+ * Bind a collection of events to a collection of elements.
+ * @param {Array|string} elements - Collection of elements.
+ * @param {Array|Object} events - Collection of events.
+ * @param {Function} callback - Function to call when events fire.
+ */
 function bindEvents( elements, events, callback = NO_OP ) {
   if ( Array.isArray( events ) === false ) {
     events = [ events ];
@@ -127,11 +133,16 @@ function getEl( selector ) {
 function getPreviousEls( element, filter = '*' ) {
   const previousSiblings = [];
   let prevEl = element.previousElementSibling;
+
+  /**
+   * @param {HTMLNode} el - An HTML element.
+   * @returns {Function} The browser's Element.matches() method.
+   */
   function _getMatches( el ) {
     return el.matches ||
-             el.webkitMatchesSelector ||
-             el.mozMatchesSelector ||
-             el.msMatchesSelector;
+           el.webkitMatchesSelector ||
+           el.mozMatchesSelector ||
+           el.msMatchesSelector;
   }
   const _matchesMethod = _getMatches( element );
 

--- a/cfgov/unprocessed/apps/owning-a-home/js/form-explainer/form-explainer.js
+++ b/cfgov/unprocessed/apps/owning-a-home/js/form-explainer/form-explainer.js
@@ -1,10 +1,10 @@
-import { elementInView, scrollIntoView, scrollTo }
-  from '../../../js/modules/util/scroll';
+import {
+  scrollIntoView,
+  scrollTo
+} from '../../../../js/modules/util/scroll';
+import { assign } from '../../../../js/modules/util/assign';
+import { closest } from '../../../../js/modules/util/dom-traverse';
 import DT from './dom-tools';
-
-import { assign } from '../../../js/modules/util/assign';
-import { closest } from '../../../js/modules/util/dom-traverse';
-import { instantiateAll } from '../../../js/modules/util/atomic-helpers';
 import throttle from 'lodash.throttle';
 
 const EXPLAIN_TYPES = {
@@ -19,7 +19,7 @@ const CSS = {
   HOVER_HAS_ATTENTION:   'hover-has-attention'
 };
 
-const NO_OP = function( ) {
+const NO_OP = () => {
   // Placeholder function meant to be overridden.
 };
 
@@ -42,13 +42,21 @@ class FormExplainer {
     this.elements.base = element;
     this.pageName = 'form';
     this.resized = false;
+  }
 
+  /**
+   * Initialize the FormExplainer.
+   * @returns {FormExplainer} An instance.
+   */
+  init() {
     this.setPageCount();
     this.setCurrentPage( this.currentPage, UNDEFINED, false );
     this.setUIElements();
     this.setTabIndex();
     this.initializeUI( this.elements );
     this.initializeEvents();
+
+    return this;
   }
 
   /**

--- a/cfgov/unprocessed/apps/owning-a-home/js/form-explainer/index.js
+++ b/cfgov/unprocessed/apps/owning-a-home/js/form-explainer/index.js
@@ -1,0 +1,4 @@
+import FormExplainer from './form-explainer';
+const formExplainerElement = document.querySelector( '.form-explainer' );
+const formExplainer = new FormExplainer( formExplainerElement );
+formExplainer.init();

--- a/cfgov/unprocessed/js/routes/owning-a-home/closing-disclosure/index.js
+++ b/cfgov/unprocessed/js/routes/owning-a-home/closing-disclosure/index.js
@@ -1,7 +1,0 @@
-import FormExplainer from '../../../../apps/owning-a-home/js/form-explainer';
-
-const formExplainerElement = document.querySelector( '.form-explainer' );
-
-if ( formExplainerElement ) {
-  const formExplainer = new FormExplainer( formExplainerElement );
-}

--- a/cfgov/unprocessed/js/routes/owning-a-home/loan-estimate/index.js
+++ b/cfgov/unprocessed/js/routes/owning-a-home/loan-estimate/index.js
@@ -1,7 +1,0 @@
-import FormExplainer from '../../../../apps/owning-a-home/js/form-explainer';
-
-const formExplainerElement = document.querySelector( '.form-explainer' );
-
-if ( formExplainerElement ) {
-  const formExplainer = new FormExplainer( formExplainerElement );
-}

--- a/cfgov/unprocessed/js/routes/owning-a-home/mortgage-estimate/index.js
+++ b/cfgov/unprocessed/js/routes/owning-a-home/mortgage-estimate/index.js
@@ -1,0 +1,1 @@
+require( '../../../modules/util/add-email-popup' );

--- a/test/unit_tests/apps/owning-a-home/js/form-explainer/dom-tools-spec.js
+++ b/test/unit_tests/apps/owning-a-home/js/form-explainer/dom-tools-spec.js
@@ -1,4 +1,4 @@
-import domTools from '../../../../../cfgov/unprocessed/apps/owning-a-home/js/dom-tools.js';
+import domTools from '../../../../../../cfgov/unprocessed/apps/owning-a-home/js/form-explainer/dom-tools';
 
 const HTML_SNIPPET = `
 <div id="test"></div>


### PR DESCRIPTION
It appears that the BAH landing page and the mortgage-estimate page should be showing [a popup](https://github.com/cfpb/cfgov-refresh/blob/master/cfgov/cfgov/settings/base.py#L724-L725), however, mortgage-estimate is not showing a popup.

Also, the page-specific form-explainer initialization code in the /routes/ path can be consolidated in the BAH apps code, since those pages have their own templates and /routes/ is only for pages that don't have specific templates.

## Additions

- Adds add-email-popup initialization code to BAH landing page and mortgage-estimate page.

## Changes

- Move form-explainer initialization code to BAH apps code and imports into the closing-disclosures and loan-estimate templates.
- Minor linter fixes.

## Testing

1. `gulp clean && gulp build` should pass.
2. http://localhost:8000/owning-a-home/ and http://localhost:8000/owning-a-home/mortgage-estimate/ should both show the email popup when scrolling down the page (you'll need to "Clear site data" in the Application tab in dev console between visits).
3. Visit http://localhost:8000/owning-a-home/loan-estimate/, http://localhost:8000/owning-a-home/closing-disclosure/, and http://localhost:8000/owning-a-home/explore-rates/ and see that those tools work. Check that the email signup works.

## Screenshots

<img width="1238" alt="screen shot 2019-02-05 at 4 10 57 pm" src="https://user-images.githubusercontent.com/704760/52304374-a0082b80-2960-11e9-8a56-9fc668069e65.png">
