### PR TITLE
Removes unnecessary code from BAH email signup

### DIFF
--- a/cfgov/jinja2/v1/owning-a-home/_templates/brand-footer.html
+++ b/cfgov/jinja2/v1/owning-a-home/_templates/brand-footer.html
@@ -37,7 +37,8 @@
         {% endif %}
         {% endfor %}
         <div class="brand-footer_container brand-footer_container-{{ links | length + 1 }}">
-            {% include "_templates/oah-email-signup.html" %}
+            {% import "_templates/email-signup.html" as email_signup %}
+            {{ email_signup.render() }}
         </div>
     </div>
 </footer>

--- a/cfgov/jinja2/v1/owning-a-home/_templates/email-signup.html
+++ b/cfgov/jinja2/v1/owning-a-home/_templates/email-signup.html
@@ -6,63 +6,60 @@
 
    Description:
 
-   Creates an email sign up form when given:
-
-   value:         An object used to customize the markup.
-
-   value.heading: A string with the title for the header slug.
-
-   value.text:    The text used within the description markup.
-
-   value.gd_code: A GovDelivery code for a specified mailing list.
+   Creates an email sign up form.
 
    ========================================================================== #}
 
-{% macro render(value) %}
-    {% set value = value or {
-        'heading': 'Buying a home?',
-        'text': 'Sign up for email tips and info to help you through the process.',
-        'gd_code': 'USCFPB_127'
-      }
-    %}
-    {% set form_id = get_unique_id() %}
-    <div class="o-email-signup">
-    {% if value.heading %}
-        <header class="m-slug-header">
-            <h2 class="a-heading">
-                {{ value.heading }}
-            </h2>
-        </header>
-    {% endif %}
-    <form id="o-form {{ value.id or 'o-form__email-signup_' ~ form_id }}"
-          class="o-form o-form__email-signup"
-          action="/subscriptions/new/"
-          method="POST"
-          enctype="application/x-www-form-urlencoded">
+{% macro render() %}
+{#
+Settings are as follows:
+
+value.heading: A string with the title for the header slug.
+value.text: The text used within the description markup.
+value.gd_code: A GovDelivery code for a specified mailing list.
+#}
+{% set value = {
+    'heading': 'Buying a home?',
+    'text': 'Sign up for email tips and info to help you through the process.',
+    'gd_code': 'USCFPB_127'
+    }
+%}
+{% set form_id = get_unique_id() %}
+<div class="o-email-signup">
+
+    <header class="m-slug-header">
+        <h2 class="a-heading">
+            {{ value.heading }}
+        </h2>
+    </header>
+
+    <form id="o-form {{ 'o-form__email-signup_' ~ form_id }}"
+        class="o-form o-form__email-signup"
+        action="/subscriptions/new/"
+        method="POST"
+        enctype="application/x-www-form-urlencoded">
         <div class="u-mb15">
             {% import 'molecules/notification.html' as notification with context %}
             {{ notification.render('default', false, '') }}
         </div>
-        {% if value.text %}
         <p>
             {{ value.text }}
         </p>
-        {% endif %}
         <div class="m-form-field-with-button" data-qa-hook="formfield-with-button">
             <div class="m-form-field">
                 <label class="a-label a-label__heading"
-                       for="{{ 'form_' ~ form_id }}">
+                    for="{{ 'form_' ~ form_id }}">
                     <b>Email address</b>
                 </label>
 
                 <input id="{{ 'form_' ~ form_id }}"
-                       type="email"
-                       placeholder="mail@example.com"
-                       name="email"
-                       class="a-text-input a-text-input__full"
-                       required>
+                    type="email"
+                    placeholder="mail@example.com"
+                    name="email"
+                    class="a-text-input a-text-input__full"
+                    required>
             </div>
-            <p>
+            <p class="m-form-field-with-button_info">
                 <a class="a-link a-link__jump" href="/owning-a-home/privacy-act-statement/">
                     <span class="a-link_text">Privacy Act statement</span>
                 </a>
@@ -71,5 +68,5 @@
         </div>
         <input type="hidden" name="code" value="{{ value.gd_code }}">
     </form>
-    </div>
+</div>
 {% endmacro %}

--- a/cfgov/jinja2/v1/owning-a-home/_templates/oah-email-signup.html
+++ b/cfgov/jinja2/v1/owning-a-home/_templates/oah-email-signup.html
@@ -1,7 +1,0 @@
-{% import "_templates/email-signup.html" as email_signup %}
-{% set data = {
- 	'heading': 'Buying a home?',
-  	'text':    'Sign up for email tips and info to help you through the process.',
-  	'gd_code': 'USCFPB_127'
-} %}
-{{ email_signup.render(data) }}

--- a/test/unit_tests/js/organisms/FormSubmit-spec.js
+++ b/test/unit_tests/js/organisms/FormSubmit-spec.js
@@ -33,7 +33,7 @@ const HTML_SNIPPET = `
         </label>
         <input id="form_3"
                type="email"
-               placeholder="example@mail.com"
+               placeholder="mail@example.com"
                name="email"
                class="a-text-input a-text-input__full">
       </div>


### PR DESCRIPTION
Buying a home had a duplicate email signup template that contained the same values. It also had a padding issue.

## Removals

- Redundant oah-email-signup template.

## Changes

- Hardcodes values in BAH email-signup template.
- Adds `m-form-field-with-button_info` class to privacy link to fix missing padding.
- Minor fix of email address in HTML snippet in FormSubmit-spec.js

## Testing

1. Visit http://localhost:8000/owning-a-home/loan-estimate/ and check email signup in the footer. Enter an incorrect and a correct email address and see that notifications appear.

## Screenshots

Before:

<img width="331" alt="screen shot 2019-02-05 at 5 06 39 pm" src="https://user-images.githubusercontent.com/704760/52307372-6c310400-2968-11e9-98b3-9722668d4f6d.png">

After:

<img width="321" alt="screen shot 2019-02-05 at 5 06 43 pm" src="https://user-images.githubusercontent.com/704760/52307379-705d2180-2968-11e9-91ad-65ef72d45687.png">
