### PR TITLE
Update browser testing checklist in PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -45,13 +45,13 @@
 
 ### Browsers
 
-- [ ] Chrome
+- [ ] Chrome on desktop
 - [ ] Firefox
-- [ ] Safari
-- [ ] Internet Explorer 8, 9, 10, and 11
+- [ ] Safari on macOS
 - [ ] Edge
-- [ ] iOS Safari
-- [ ] Chrome for Android
+- [ ] Internet Explorer 9, 10, and 11
+- [ ] Safari on iOS
+- [ ] Chrome on Android
 
 ### Accessibility
 


### PR DESCRIPTION
IE8 is no longer testable with Sauce Labs.