### PR TITLE
Update app browserlists to exclude IE10

### DIFF
--- a/cfgov/unprocessed/apps/find-a-housing-counselor/browserslist
+++ b/cfgov/unprocessed/apps/find-a-housing-counselor/browserslist
@@ -4,4 +4,4 @@
 
 last 2 versions
 not ie < 11
-not IE_Mob < 11
+not ie_mob < 11

--- a/cfgov/unprocessed/apps/find-a-housing-counselor/browserslist
+++ b/cfgov/unprocessed/apps/find-a-housing-counselor/browserslist
@@ -3,4 +3,5 @@
 # See https://github.com/browserslist/browserslist#config-file
 
 last 2 versions
-Explorer >= 9
+not ie < 11
+not IE_Mob < 11

--- a/cfgov/unprocessed/apps/owning-a-home/browserslist
+++ b/cfgov/unprocessed/apps/owning-a-home/browserslist
@@ -4,4 +4,4 @@
 
 last 2 versions
 not ie < 11
-not IE_Mob < 11
+not ie_mob < 11

--- a/cfgov/unprocessed/apps/regulations3k/browserslist
+++ b/cfgov/unprocessed/apps/regulations3k/browserslist
@@ -4,4 +4,4 @@
 
 last 2 versions
 not ie < 11
-not IE_Mob < 11
+not ie_mob < 11

--- a/cfgov/unprocessed/apps/regulations3k/browserslist
+++ b/cfgov/unprocessed/apps/regulations3k/browserslist
@@ -3,4 +3,5 @@
 # See https://github.com/browserslist/browserslist#config-file
 
 last 2 versions
-Explorer >= 9
+not ie < 11
+not IE_Mob < 11

--- a/config/browser-list-config.js
+++ b/config/browser-list-config.js
@@ -6,7 +6,7 @@ const LAST_2 = [
 const LAST_2_IE_11_UP = [
   'last 2 versions',
   'not ie < 11',
-  'not IE_Mob < 11'
+  'not ie_mob < 11'
 ];
 
 const LAST_2_IE_9_UP = [


### PR DESCRIPTION
IE10 gets the no-js treatment. This update aligns the find-a-housing counselor and regs3k browserlists to this support level.

## Changes

- Removes IE11 and below support from find-a-housing counselor and regs3k browserlists.
- Downcases `IE_Mob` to `ie_mob`

## Testing

1. `gulp clean && gulp build`
1. /find-a-housing-counselor should still work in IE10 (without a map) and should have a map in IE11.
1. /policy-compliance/rulemaking/regulations/ should still work in IE10 (with expanded expandables) and should have collapsed expandables in IE11.

## Notes

- I'm not super familiar with what to test in regs3k no-js/js functionality, so I've tagged you @contolini 
