### PR TITLE
Remove unnecessary code from financial-well-being and fix init logic

### DIFF
--- a/cfgov/unprocessed/apps/financial-well-being/js/fwb-questions.js
+++ b/cfgov/unprocessed/apps/financial-well-being/js/fwb-questions.js
@@ -169,4 +169,4 @@ function init() {
   setUpData();
 }
 
-export { init };
+export default { init };

--- a/cfgov/unprocessed/apps/financial-well-being/js/fwb-results.js
+++ b/cfgov/unprocessed/apps/financial-well-being/js/fwb-results.js
@@ -1,11 +1,11 @@
 import Analytics from '../../../js/modules/Analytics';
-
-require( 'cf-expandables/src/Expandable' ).init();
+const Expandable = require( 'cf-expandables/src/Expandable' );
 
 /**
  * Initialize the results interactions
  */
 function init() {
+  Expandable.init();
 
   const buttonsDom = document.querySelectorAll(
     '.comparison-chart_toggle-button'
@@ -98,4 +98,4 @@ function init() {
   setUpUI();
 }
 
-export { init };
+export default { init };

--- a/cfgov/unprocessed/js/routes/consumer-tools/financial-well-being/index.js
+++ b/cfgov/unprocessed/js/routes/consumer-tools/financial-well-being/index.js
@@ -1,7 +1,2 @@
-import * as fwbQuestions from '../../../../apps/financial-well-being/js/fwb-questions';
-
-/* TODO: This eventlistener may not be necessary and should probably be removed
-after it fires. */
-window.addEventListener( 'load', function() {
-  fwbQuestions.init();
-} );
+import fwbQuestions from '../../../../apps/financial-well-being/js/fwb-questions';
+fwbQuestions.init();

--- a/cfgov/unprocessed/js/routes/consumer-tools/financial-well-being/results/index.js
+++ b/cfgov/unprocessed/js/routes/consumer-tools/financial-well-being/results/index.js
@@ -1,3 +1,2 @@
-import * as fwbResults from '../../../../../apps/financial-well-being/js/fwb-results';
-
+import fwbResults from '../../../../../apps/financial-well-being/js/fwb-results';
 fwbResults.init();

--- a/test/unit_tests/apps/financial-well-being/js/fwb-questions-spec.js
+++ b/test/unit_tests/apps/financial-well-being/js/fwb-questions-spec.js
@@ -1,5 +1,5 @@
 import { simulateEvent } from '../../../../util/simulate-event';
-import * as fwbQuestions from '../../../../../cfgov/unprocessed/apps/financial-well-being/js/fwb-questions';
+import fwbQuestions from '../../../../../cfgov/unprocessed/apps/financial-well-being/js/fwb-questions';
 
 let formDom;
 let submitBtnDom;

--- a/test/unit_tests/apps/financial-well-being/js/fwb-results-spec.js
+++ b/test/unit_tests/apps/financial-well-being/js/fwb-results-spec.js
@@ -1,5 +1,5 @@
 import { simulateEvent } from '../../../../util/simulate-event';
-import * as fwbResults from '../../../../../cfgov/unprocessed/apps/financial-well-being/js/fwb-results';
+import fwbResults from '../../../../../cfgov/unprocessed/apps/financial-well-being/js/fwb-results';
 
 const SELECTED_CLASS = 'comparison-chart_toggle-button__selected';
 const HIDDEN_CLASS = 'u-hidden';


### PR DESCRIPTION
## Changes

- Updates fwb modules to support default exports.
- Removes fwb page load logic since the script is added in the footer.
- Initializes expandables in `init` function of fwb-results module, instead at module load-time.

## Testing

1. `gulp clean && gulp build`
2. http://localhost:8000/consumer-tools/financial-well-being/ should be able to be filled out and submitted and the results page expandable should work.
