### PR TITLE
Remove UNDEFINED from standard-type

### DIFF
--- a/cfgov/unprocessed/apps/owning-a-home/js/explore-rates/Slider.js
+++ b/cfgov/unprocessed/apps/owning-a-home/js/explore-rates/Slider.js
@@ -1,8 +1,8 @@
 // Required modules.
-import { checkDom, setInitFlag }
-  from '../../../../js/modules/util/atomic-helpers';
-import { UNDEFINED }
-  from '../../../../js/modules/util/standard-type';
+import {
+  checkDom,
+  setInitFlag
+} from '../../../../js/modules/util/atomic-helpers';
 import rangesliderJs from 'rangeslider-js';
 
 /**
@@ -42,6 +42,7 @@ function Slider( element ) {
    */
   function init( options ) {
     if ( !setInitFlag( _dom ) ) {
+      let UNDEFINED;
       return UNDEFINED;
     }
 

--- a/cfgov/unprocessed/js/modules/behavior/FlyoutMenu.js
+++ b/cfgov/unprocessed/js/modules/behavior/FlyoutMenu.js
@@ -6,7 +6,6 @@ import EventObserver from '../../modules/util/EventObserver';
 import {
   BEHAVIOR_PREFIX,
   JS_HOOK,
-  UNDEFINED,
   noopFunct
 } from '../../modules/util/standard-type';
 
@@ -383,6 +382,8 @@ function FlyoutMenu( element ) { // eslint-disable-line max-statements, no-inlin
     if ( transition ) { transition.remove(); }
     transition = getTransition( FlyoutMenu.COLLAPSE_TYPE );
     if ( transition ) { transition.remove(); }
+
+    let UNDEFINED;
 
     _expandTransition = UNDEFINED;
     _expandTransitionMethod = UNDEFINED;

--- a/cfgov/unprocessed/js/modules/util/standard-type.js
+++ b/cfgov/unprocessed/js/modules/util/standard-type.js
@@ -54,12 +54,9 @@ function noopFunct() {
   // Placeholder function meant to be overridden.
 }
 
-let UNDEFINED;
-
 export {
   BEHAVIOR_PREFIX,
   JS_HOOK,
   noopFunct,
-  STATE_PREFIX,
-  UNDEFINED
+  STATE_PREFIX
 };

--- a/cfgov/unprocessed/js/molecules/Autocomplete.js
+++ b/cfgov/unprocessed/js/molecules/Autocomplete.js
@@ -3,7 +3,6 @@ import { assign } from '../modules/util/assign';
 import * as atomicHelpers from '../modules/util/atomic-helpers';
 import { ajaxRequest } from '../modules/util/ajax-request';
 import { bindEvent } from '../modules/util/dom-events';
-import { UNDEFINED } from '../modules/util/standard-type';
 import * as throttle from 'lodash.throttle';
 
 /**
@@ -86,6 +85,7 @@ function Autocomplete( element, opts ) {
    */
   function init() {
     if ( !atomicHelpers.setInitFlag( _dom ) ) {
+      let UNDEFINED;
       return UNDEFINED;
     }
 

--- a/cfgov/unprocessed/js/molecules/GlobalSearch.js
+++ b/cfgov/unprocessed/js/molecules/GlobalSearch.js
@@ -5,7 +5,6 @@ import ClearableInput from '../modules/ClearableInput';
 import EventObserver from '../modules/util/EventObserver';
 import FlyoutMenu from '../modules/behavior/FlyoutMenu';
 import MoveTransition from '../modules/transition/MoveTransition';
-import { UNDEFINED } from '../modules/util/standard-type';
 import TabTrigger from '../modules/TabTrigger';
 
 /**
@@ -38,6 +37,7 @@ function GlobalSearch( element ) { // eslint-disable-line max-statements, no-inl
    */
   function init() {
     if ( !atomicHelpers.setInitFlag( _dom ) ) {
+      let UNDEFINED;
       return UNDEFINED;
     }
 

--- a/cfgov/unprocessed/js/molecules/Multiselect.js
+++ b/cfgov/unprocessed/js/molecules/Multiselect.js
@@ -4,7 +4,6 @@ import * as atomicHelpers from '../modules/util/atomic-helpers';
 import { bindEvent } from '../modules/util/dom-events';
 import { create } from '../modules/util/dom-manipulators';
 import { queryOne } from '../modules/util/dom-traverse';
-import { UNDEFINED } from '../modules/util/standard-type';
 import { stringMatch } from '../modules/util/strings';
 import EventObserver from '../modules/util/EventObserver';
 
@@ -77,6 +76,7 @@ function Multiselect( element ) { // eslint-disable-line max-statements, inline-
    */
   function init() {
     if ( !atomicHelpers.setInitFlag( _dom ) ) {
+      let UNDEFINED;
       return UNDEFINED;
     }
 

--- a/cfgov/unprocessed/js/molecules/Notification.js
+++ b/cfgov/unprocessed/js/molecules/Notification.js
@@ -1,6 +1,5 @@
 // Required modules.
 import { checkDom, setInitFlag } from '../modules/util/atomic-helpers';
-import { UNDEFINED } from '../modules/util/standard-type';
 const SUCCESS_ICON = require(
   'svg-inline-loader!../../../../node_modules/cf-icons/src/icons/check-round.svg'
 );
@@ -49,6 +48,7 @@ function Notification( element ) {
    */
   function init() {
     if ( !setInitFlag( _dom ) ) {
+      let UNDEFINED;
       return UNDEFINED;
     }
 

--- a/cfgov/unprocessed/js/organisms/EmailPopup.js
+++ b/cfgov/unprocessed/js/organisms/EmailPopup.js
@@ -1,6 +1,5 @@
 import FormSubmit from './FormSubmit.js';
 import { checkDom, setInitFlag } from '../modules/util/atomic-helpers';
-import { UNDEFINED } from '../modules/util/standard-type';
 import * as validators from '../modules/util/validators';
 import * as emailHelpers from '../modules/util/email-popup-helpers';
 
@@ -86,6 +85,7 @@ function EmailPopup( element ) {
    */
   function init() {
     if ( !setInitFlag( _dom ) ) {
+      let UNDEFINED;
       return UNDEFINED;
     }
 

--- a/cfgov/unprocessed/js/organisms/FilterableList.js
+++ b/cfgov/unprocessed/js/organisms/FilterableList.js
@@ -2,7 +2,6 @@
 import { checkDom, setInitFlag } from '../modules/util/atomic-helpers';
 import FilterableListControls from './FilterableListControls';
 import Notification from '../molecules/Notification';
-import { UNDEFINED } from '../modules/util/standard-type';
 
 const BASE_CLASS = 'o-filterable-list';
 
@@ -33,6 +32,7 @@ function FilterableList( element ) {
    */
   function init() {
     if ( !setInitFlag( _dom ) ) {
+      let UNDEFINED;
       return UNDEFINED;
     }
 

--- a/cfgov/unprocessed/js/organisms/FilterableListControls.js
+++ b/cfgov/unprocessed/js/organisms/FilterableListControls.js
@@ -11,7 +11,6 @@ import EventObserver from '../modules/util/EventObserver';
 import Expandable from 'cf-expandables/src/Expandable';
 import FormModel from '../modules/util/FormModel';
 import Multiselect from '../molecules/Multiselect';
-import { UNDEFINED } from '../modules/util/standard-type';
 
 const BASE_CLASS = 'o-filterable-list-controls';
 
@@ -37,6 +36,7 @@ function FilterableListControls( element ) {
    */
   function init() {
     if ( !setInitFlag( _dom ) ) {
+      let UNDEFINED;
       return UNDEFINED;
     }
 

--- a/cfgov/unprocessed/js/organisms/Footer.js
+++ b/cfgov/unprocessed/js/organisms/Footer.js
@@ -1,7 +1,6 @@
 // Required modules.
 import { checkDom, setInitFlag } from '../modules/util/atomic-helpers';
 import * as footerButton from '../modules/footer-button';
-import { UNDEFINED } from '../modules/util/standard-type';
 
 /**
  * Footer
@@ -25,6 +24,7 @@ function Footer( element ) {
    */
   function init() {
     if ( !setInitFlag( _dom ) ) {
+      let UNDEFINED;
       return UNDEFINED;
     }
 

--- a/cfgov/unprocessed/js/organisms/Header.js
+++ b/cfgov/unprocessed/js/organisms/Header.js
@@ -2,7 +2,6 @@
 import { checkDom, setInitFlag } from '../modules/util/atomic-helpers';
 import GlobalSearch from '../molecules/GlobalSearch.js';
 import MegaMenu from '../organisms/MegaMenu.js';
-import { UNDEFINED } from '../modules/util/standard-type';
 
 /**
  * Header
@@ -32,6 +31,7 @@ function Header( element ) {
    */
   function init( overlay ) {
     if ( !setInitFlag( _dom ) ) {
+      let UNDEFINED;
       return UNDEFINED;
     }
 

--- a/cfgov/unprocessed/js/organisms/MegaMenu.js
+++ b/cfgov/unprocessed/js/organisms/MegaMenu.js
@@ -9,7 +9,6 @@ import MegaMenuMobile from '../organisms/MegaMenuMobile';
 import MoveTransition from '../modules/transition/MoveTransition';
 import TabTrigger from '../modules/TabTrigger';
 import Tree from '../modules/Tree';
-import { UNDEFINED } from '../modules/util/standard-type';
 
 /**
  * MegaMenu
@@ -43,6 +42,7 @@ function MegaMenu( element ) {
    */
   function init() {
     if ( !setInitFlag( _dom ) ) {
+      let UNDEFINED;
       return UNDEFINED;
     }
 

--- a/test/unit_tests/js/modules/util/standard-type-spec.js
+++ b/test/unit_tests/js/modules/util/standard-type-spec.js
@@ -1,6 +1,5 @@
 import {
   JS_HOOK,
-  UNDEFINED,
   noopFunct
 } from '../../../../../cfgov/unprocessed/js/modules/util/standard-type';
 
@@ -11,9 +10,5 @@ describe( 'standard-type', () => {
 
   it( 'should include a non operational function', () => {
     expect( noopFunct() ).toBeUndefined();
-  } );
-
-  it( 'should include a standard undefined reference', () => {
-    expect( UNDEFINED ).toBeUndefined();
   } );
 } );


### PR DESCRIPTION
Our linter flags `undefined` values because of the https://eslint.org/docs/rules/no-undefined rule. 
To get around this we utilize an uninitialized variable to hold the value of `undefined`. However, we inconsistently handle this, sometimes defining a `let UNDEFINED` variable in a module and sometimes importing the standard-type module and referencing the one in there. While it may make sense to always use the one from the standard-type module, the additional dependency complexity of doing that versus the cost of creating a new variable each time does not make sense, at very least from a pure number-of-lines-of-code perspective.

## Removals

- Removes `UNDEFINED` value from the `standard-type` module.

## Testing

1. Tests should pass and site should load error-free.
