### PR TITLE
Multiselect: Add model

### DIFF
--- a/cfgov/unprocessed/css/molecules/multiselect.less
+++ b/cfgov/unprocessed/css/molecules/multiselect.less
@@ -58,11 +58,11 @@ select.o-multiselect {
             margin-bottom: 0;
         }
 
-        &.filtered li:not( .filter-match ) {
+        &.u-filtered li:not( .u-filter-match ) {
             display: none;
         }
 
-        &.no-results,
+        &.u-no-results,
         &.max-selections {
             li {
                 display: none;
@@ -73,7 +73,7 @@ select.o-multiselect {
             }
         }
 
-        &.no-results:after {
+        &.u-no-results:after {
             content: 'No results found';
         }
 

--- a/cfgov/unprocessed/js/molecules/Multiselect.js
+++ b/cfgov/unprocessed/js/molecules/Multiselect.js
@@ -7,6 +7,7 @@ import { queryOne } from '../modules/util/dom-traverse';
 import { UNDEFINED } from '../modules/util/standard-type';
 import { stringMatch } from '../modules/util/strings';
 import EventObserver from '../modules/util/EventObserver';
+import MultiselectModel from './MultiselectModel';
 
 const closeIcon = require(
   'svg-inline-loader!../../../../node_modules/cf-icons/src/icons/close.svg'
@@ -46,20 +47,14 @@ function Multiselect( element ) { // eslint-disable-line max-statements, inline-
   const KEY_DOWN = 40;
   const KEY_TAB = 9;
 
-  // Search settings.
-  const MIN_CHARS = 3;
-  const MAX_SELECTIONS = 5;
-
   // Internal vars.
   let _dom = atomicHelpers.checkDom( element, BASE_CLASS );
-  let _index = -1;
   let _isBlurSkipped = false;
-  let _selectionsCount = 0;
   let _name;
+  let _placeholder;
+  let _model;
   let _options;
   let _optionsData;
-  let _filteredData;
-  let _placeholder;
 
   // Markup elems, conver this to templating engine in the future.
   let _containerDom;
@@ -68,6 +63,7 @@ function Multiselect( element ) { // eslint-disable-line max-statements, inline-
   let _searchDom;
   let _fieldsetDom;
   let _optionsDom;
+  const _optionItemDoms = [];
   let _instance;
 
   /**
@@ -82,11 +78,12 @@ function Multiselect( element ) { // eslint-disable-line max-statements, inline-
 
     _instance = this;
     _name = _dom.name;
-    _options = _dom.options || [];
     _placeholder = _dom.getAttribute( 'placeholder' );
-    _filteredData = _optionsData = _formatOptions( _options );
+    _options = _dom.options || [];
 
-    if ( _optionsData.length > 0 ) {
+    if ( _options.length > 0 ) {
+      _model = new MultiselectModel( _options ).init();
+      _optionsData = _model.getOptions();
       const newDom = _populateMarkup();
 
       /* Removes <select> element,
@@ -125,32 +122,10 @@ function Multiselect( element ) { // eslint-disable-line max-statements, inline-
     _containerDom.classList.remove( 'active' );
     _fieldsetDom.classList.add( 'u-invisible' );
     _fieldsetDom.setAttribute( 'aria-hidden', true );
-    _index = -1;
+    _model.resetIndex();
     _instance.dispatchEvent( 'expandEnd', { target: _instance } );
 
     return _instance;
-  }
-
-  /**
-   * Formats the list of options.
-   * @param   {Array} list The options from the parent select elem.
-   * @returns {Array}      An array of option objects.
-   */
-  function _formatOptions( list ) {
-    let item;
-    const cleaned = [];
-
-    for ( let i = 0, len = list.length; i < len; i++ ) {
-      item = list[i];
-
-      cleaned.push( {
-        value:   item.value,
-        text:    item.text,
-        checked: item.defaultSelected
-      } );
-    }
-
-    return cleaned;
   }
 
   /**
@@ -220,6 +195,7 @@ function Multiselect( element ) { // eslint-disable-line max-statements, inline-
         'inside':      _optionsItemDom
       } );
 
+      _optionItemDoms.push( _optionsItemDom );
       _optionsDom.appendChild( _optionsItemDom );
 
       if ( option.checked ) {
@@ -236,7 +212,6 @@ function Multiselect( element ) { // eslint-disable-line max-statements, inline-
         } );
 
         _selectionsDom.appendChild( selectionsItemDom );
-        _selectionsCount += 1;
       }
     } );
 
@@ -253,16 +228,21 @@ function Multiselect( element ) { // eslint-disable-line max-statements, inline-
    *                           current focus.
    */
   function _highlight( direction ) {
-    const count = _filteredData.length;
-
-    if ( direction === DIR_NEXT && _index < count - 1 ) {
-      _index += 1;
-    } else if ( direction === DIR_PREV && _index > -1 ) {
-      _index -= 1;
+    if ( direction === DIR_NEXT ) {
+      _model.setIndex( _model.getIndex() + 1 );
+    } else if ( direction === DIR_PREV ) {
+      _model.setIndex( _model.getIndex() - 1 );
     }
 
-    if ( _index > -1 ) {
-      const value = _filteredData[_index].value;
+    const index = _model.getIndex();
+    if ( index > -1 ) {
+      let filteredIndex = index;
+      const filterIndices = _model.getFilterIndices();
+      if ( filterIndices.length > 0 ) {
+        filteredIndex = filterIndices[index];
+      }
+      const option = _model.getOption( filteredIndex );
+      const value = option.value;
       const item = _optionsDom.querySelector( '[data-option="' + value + '"]' );
       const input = item.querySelector( 'input' );
 
@@ -279,9 +259,12 @@ function Multiselect( element ) { // eslint-disable-line max-statements, inline-
    * @param {string} value The value of the option the user has chosen.
    */
   function _updateSelections( value ) {
-    const optionIndex =
-      arrayHelpers.indexOfObject( _optionsData, 'value', value );
-    const option = _optionsData[optionIndex] || _optionsData[_index];
+    const optionIndex = arrayHelpers.indexOfObject(
+      _optionsData,
+      'value',
+      value
+    );
+    const option = _optionsData[optionIndex] || _optionsData[_model.getIndex()];
 
     if ( option ) {
       let _selectionsItemDom;
@@ -297,8 +280,6 @@ function Multiselect( element ) { // eslint-disable-line max-statements, inline-
         if ( _selectionsItemDom ) {
           _selectionsDom.removeChild( _selectionsItemDom );
         }
-        option.checked = false;
-        _selectionsCount -= 1;
       } else {
         _selectionsItemDom = create( 'li', {
           'data-option': option.value
@@ -312,19 +293,17 @@ function Multiselect( element ) { // eslint-disable-line max-statements, inline-
 
         _selectionsDom.appendChild( _selectionsItemDom );
         _selectionsItemDom.appendChild( _selectionsItemLabelDom );
+      }
+      _model.toggleOption( optionIndex );
 
-        option.checked = true;
-        _selectionsCount += 1;
-
-        if ( _selectionsCount >= MAX_SELECTIONS ) {
-          _optionsDom.classList.add( 'max-selections' );
-        }
+      if ( _model.isAtMaxSelections() ) {
+        _optionsDom.classList.add( 'max-selections' );
       }
 
       _instance.dispatchEvent( 'selectionsUpdated', { target: _instance } );
     }
 
-    _index = -1;
+    _model.resetIndex();
     _isBlurSkipped = false;
 
     if ( _fieldsetDom.getAttribute( 'aria-hidden' ) === 'false' ) {
@@ -339,16 +318,9 @@ function Multiselect( element ) { // eslint-disable-line max-statements, inline-
    */
   function _evaluate( value ) {
     _resetFilter();
-
-    if ( value.length >= MIN_CHARS && _optionsData.length > 0 ) {
-      _index = -1;
-
-      _filteredData = _optionsData.filter( function( item ) {
-        return stringMatch( item.text, value );
-      } );
-
-      _filterResults();
-    }
+    _model.resetIndex();
+    const matchedIndices = _model.filterIndices( value );
+    _filterList( matchedIndices );
   }
 
   /**
@@ -360,44 +332,61 @@ function Multiselect( element ) { // eslint-disable-line max-statements, inline-
   }
 
   /**
-   * Resets the filtered option list.
+   * Filter the options list.
+   * Every time we filter we have two lists of indices:
+   * - The matching options (filterIndices).
+   * - The matching options of the last filter (_lastFilterIndices).
+   * We need to turn off the filter for any of the last filter matches
+   * that are not in the new set, and turn on the filter for the matches
+   * that are not in the last set.
+   * @param {Array} filterIndices - List of indices to filter from the options.
+   * @returns {boolean} True if options are filtered, false otherwise.
    */
-  function _resetFilter() {
-    _optionsDom.classList.remove( 'filtered', 'no-results' );
-
-    for ( let i = 0, len = _optionsDom.children.length; i < len; i++ ) {
-      _optionsDom.children[i].classList.remove( 'filter-match' );
+  function _filterList( filterIndices = [] ) {
+    if ( filterIndices.length > 0 ) {
+      _filterMatches( filterIndices );
+      return true;
     }
 
-    _filteredData = _optionsData;
+    _filterNoMatches();
+    return false;
   }
 
   /**
-   * Filters the list of options based on the results of the evaluate function.
+   * Resets the filtered option list.
    */
-  function _filterResults() {
-    _optionsDom.classList.add( 'filtered' );
-    let _optionsItemDom;
+  function _resetFilter() {
+    _optionsDom.classList.remove( 'u-filtered', 'u-no-results' );
 
-    if ( _filteredData.length > 0 ) {
-      _filteredData.forEach( function( option ) {
-        _optionsItemDom =
-          _optionsDom.querySelector( '[data-option="' + option.value + '"]' );
-
-        _optionsItemDom.classList.add( 'filter-match' );
-      } );
-    } else {
-      _noResults();
+    for ( let i = 0, len = _optionsDom.children.length; i < len; i++ ) {
+      _optionsDom.children[i].classList.remove( 'u-filter-match' );
     }
+
+    _model.clearFilter();
+  }
+
+  /**
+   * Set the filtered matched state.
+   * @param {Array} filterIndices - List of indices to filter from the options.
+   */
+  function _filterMatches( filterIndices ) {
+    _optionsDom.classList.remove( 'u-no-results' );
+    _optionsDom.classList.add( 'u-filtered' );
+    _model.getLastFilterIndices().forEach( index => {
+      _optionItemDoms[index].classList.remove( 'u-filter-match' );
+    } );
+    _model.getFilterIndices().forEach( index => {
+      _optionItemDoms[index].classList.add( 'u-filter-match' );
+    } );
   }
 
   /**
    * Updates the list of options to show the user there
    * are no matching results.
    */
-  function _noResults() {
-    _optionsDom.classList.add( 'no-results' );
-    _optionsDom.classList.remove( 'filtered' );
+  function _filterNoMatches() {
+    _optionsDom.classList.add( 'u-no-results' );
+    _optionsDom.classList.remove( 'u-filtered' );
   }
 
   /**

--- a/cfgov/unprocessed/js/molecules/MultiselectModel.js
+++ b/cfgov/unprocessed/js/molecules/MultiselectModel.js
@@ -1,0 +1,196 @@
+import { stringMatch } from '../modules/util/strings';
+
+// Undefined return value for void methods.
+let UNDEFINED;
+
+// How many options may be checked.
+const MAX_SELECTIONS = 5;
+
+/**
+ * @class
+ * MultiselectModel
+ * @param {HTMLOptionsCollection} options -
+ *   Set of options from a <select> element.
+ */
+function MultiselectModel( options ) {
+  const _options = options;
+  let _optionsData = [];
+
+  let _selectedIndices = [];
+  let _filterIndices = [];
+
+  /* When the options list is filtered, we store a list of filtered indices
+  so that when the filter changes we can reset the last matched options. */
+  let _lastFilterIndices = [];
+
+  // Which option is in focus. -1 means the focus is on the search input.
+  let _index = -1;
+
+  /**
+   * @returns {MultiselectModel} An instance.
+   */
+  function init() {
+    _optionsData = _formatOptions( _options );
+
+    return this;
+  }
+
+  /**
+   * Cleans up a list of options for saving to memory.
+   * @param {HTMLOptionsCollection} list - The options from a select element.
+   * @returns {Array} An array of option objects.
+   */
+  function _formatOptions( list ) {
+    let item;
+    const cleaned = [];
+
+    let isChecked = false;
+    for ( let i = 0, len = list.length; i < len; i++ ) {
+      item = list[i];
+      isChecked = item.defaultSelected;
+      cleaned.push( {
+        value:   item.value,
+        text:    item.text,
+        checked: isChecked
+      } );
+
+      // If an option is initially checked, we need to record it.
+      if ( isChecked ) {
+        _selectedIndices.push( i );
+      }
+    }
+
+    return cleaned;
+  }
+
+  /**
+   * Toggle checked value of an option.
+   * @param {number} index - The index position of the option in the list.
+   * @returns {boolean} A value of true is checked and false is unchecked.
+   */
+  function toggleOption( index ) {
+    _optionsData[index].checked = !_optionsData[index].checked;
+
+    if ( _selectedIndices.length < MAX_SELECTIONS &&
+         _optionsData[index].checked ) {
+      _selectedIndices.push( index );
+      _selectedIndices.sort();
+
+      return true;
+    }
+    // We're over the max selections, reverse the check of the option.
+    _optionsData[index].checked = false;
+    _selectedIndices = _selectedIndices.filter(
+      currIndex => currIndex !== index
+    );
+
+    return false;
+  }
+
+  /**
+   * @returns {boolean}
+   *   True if the maximum number of options are checked, false otherwise.
+   */
+  function isAtMaxSelections() {
+    return _selectedIndices.length === MAX_SELECTIONS;
+  }
+
+  /**
+   * Search for a query string in the options text and return the indices of
+   * the matching positions in the options array.
+   * @param {string} query - A query string.
+   * @returns {Array} List of indices of the matching entries from the options.
+   */
+  function filterIndices( query ) {
+    _lastFilterIndices = _filterIndices;
+    if ( _optionsData.length > 0 ) {
+      _filterIndices = _optionsData.reduce(
+        ( acc, item, index ) => _searchAggregator( acc, item, index, query ),
+        []
+      );
+    }
+    // Reset index position.
+    _index = -1;
+
+    return _filterIndices;
+  }
+
+  /**
+   * Retrieve an option object from the options list.
+   * @param {number} index - The index position in the options list.
+   * @returns {Object} The option object with text, value, and checked value.
+   */
+  function getOption( index ) {
+    return _optionsData[index];
+  }
+
+  /**
+   * Utility function for Array.reduce() used in searchIndices.
+   * @param {Array} aggregate - The reducer's accumulator.
+   * @param {Object} item - Each item in the collection.
+   * @param {number} index - The index of item in the collection.
+   * @param {string} value - The value of item in the collection.
+   * @returns {Array} The reducer's accumulator.
+   */
+  function _searchAggregator( aggregate, item, index, value ) {
+    if ( stringMatch( item.text, value ) ) {
+      aggregate.push( index );
+    }
+    return aggregate;
+  }
+
+  /**
+   * Set the index of the collection (represents the highlighted option).
+   * @param {number} value - The index to set.
+   */
+  function setIndex( value ) {
+    const filterCount = _filterIndices.length;
+    const count = filterCount === 0 ? _optionsData.length : filterCount;
+    if ( value < 0 ) {
+      _index = -1;
+    } else if ( value >= count ) {
+      _index = count - 1;
+    } else {
+      _index = value;
+    }
+  }
+
+  /**
+   * @returns {number} The current index (highlighted option).
+   */
+  function getIndex() {
+    return _index;
+  }
+
+  this.init = init;
+
+  // This is used to check an item in the collection.
+  this.toggleOption = toggleOption;
+  this.getSelectedIndices = () => _selectedIndices;
+  this.isAtMaxSelections = isAtMaxSelections;
+
+  // This is used to search the items in the collection.
+  this.filterIndices = filterIndices;
+  this.clearFilter = () => {
+    _filterIndices = _lastFilterIndices = [];
+    return UNDEFINED;
+  };
+  this.getFilterIndices = () => _filterIndices;
+  this.getLastFilterIndices = () => _lastFilterIndices;
+
+  // These are used to highlight items in the collection.
+  this.getIndex = getIndex;
+  this.setIndex = setIndex;
+  this.resetIndex = () => {
+    _index = -1;
+    return _index;
+  };
+
+  // This is used to retrieve items from the collection.
+  this.getOption = getOption;
+  this.getOptions = () => _optionsData;
+
+  return this;
+}
+
+export default MultiselectModel;

--- a/test/browser_tests/shared_objects/multiselect.js
+++ b/test/browser_tests/shared_objects/multiselect.js
@@ -48,7 +48,7 @@ class MultiSelect {
   }
 
   async dropDownHasValue( value ) {
-    const selector = `li[data-option="${ value }"].filter-match`;
+    const selector = `li[data-option="${ value }"].u-filter-match`;
     const selectedTagsCount = await element.all( by.css( selector ) ).count();
 
     return selectedTagsCount > 0;
@@ -63,7 +63,7 @@ class MultiSelect {
   }
 
   getDropDownCount() {
-    return element.all( by.css( '.o-multiselect .filter-match' ) ).count();
+    return element.all( by.css( '.o-multiselect .u-filter-match' ) ).count();
   }
 
   getDropDownLabelElements() {

--- a/test/unit_tests/js/molecules/Multiselect-spec.js
+++ b/test/unit_tests/js/molecules/Multiselect-spec.js
@@ -31,6 +31,9 @@ describe( 'Multiselect', () => {
 
       expect( selectDom.length ).toBe( 0 );
       expect( multiselectDom.length ).toBe( 1 );
+
+      // Return undefined if we've already initialized.
+      expect( multiselect.init() ).toBeUndefined();
     } );
 
     it( 'should autocheck any selected options (form submitted pages)', () => {

--- a/test/unit_tests/js/molecules/MultiselectModel-spec.js
+++ b/test/unit_tests/js/molecules/MultiselectModel-spec.js
@@ -1,0 +1,240 @@
+import MultiselectModel from '../../../../cfgov/unprocessed/js/molecules/MultiselectModel';
+
+const HTML_SNIPPET = `
+<select class="o-multiselect" multiple>
+  <option value="mortgages">
+    Mortgages
+  </option>
+  <option value="financial-education" selected>
+    Financial education
+  </option>
+  <option value="financial-well-being">
+    Financial well-being
+  </option>
+  <option value="student-loans">
+    Student loans
+  </option>
+  <option value="rulemaking">
+    Rulemaking
+  </option>
+  <option value="banking">
+    Banking
+  </option>
+</select>
+`;
+
+let multiselectModel;
+let selectDom;
+
+describe( 'MultiselectModel', () => {
+  beforeEach( () => {
+    document.body.innerHTML = HTML_SNIPPET;
+
+    selectDom = document.querySelector( 'select[multiple]' );
+    multiselectModel = new MultiselectModel( selectDom.options ).init();
+  } );
+
+  describe( 'init()', () => {
+    it( 'should correctly initialize when given valid options', () => {
+      multiselectModel = new MultiselectModel( selectDom.options ).init();
+      expect( multiselectModel.constructor ).toBe( MultiselectModel );
+    } );
+  } );
+
+  describe( 'toggleOption()', () => {
+    it( 'should toggle checked value of option', () => {
+      expect( multiselectModel.getOption( 0 ).checked ).toBe( false );
+      expect( multiselectModel.toggleOption( 0 ) ).toBe( true );
+      expect( multiselectModel.getOption( 0 ).checked ).toBe( true );
+
+      expect( multiselectModel.getOption( 1 ).checked ).toBe( true );
+      expect( multiselectModel.toggleOption( 1 ) ).toBe( false );
+      expect( multiselectModel.getOption( 1 ).checked ).toBe( false );
+
+      expect( multiselectModel.getOption( 2 ).checked ).toBe( false );
+      expect( multiselectModel.toggleOption( 2 ) ).toBe( true );
+      expect( multiselectModel.getOption( 2 ).checked ).toBe( true );
+
+      expect( multiselectModel.getOption( 3 ).checked ).toBe( false );
+      expect( multiselectModel.toggleOption( 3 ) ).toBe( true );
+      expect( multiselectModel.getOption( 3 ).checked ).toBe( true );
+
+      expect( multiselectModel.getOption( 4 ).checked ).toBe( false );
+      expect( multiselectModel.toggleOption( 4 ) ).toBe( true );
+      expect( multiselectModel.getOption( 4 ).checked ).toBe( true );
+
+      expect( multiselectModel.getOption( 5 ).checked ).toBe( false );
+      expect( multiselectModel.toggleOption( 5 ) ).toBe( true );
+      expect( multiselectModel.getOption( 5 ).checked ).toBe( true );
+
+      // Try to push beyond maximum selections.
+      expect( multiselectModel.toggleOption( 1 ) ).toBe( false );
+      expect( multiselectModel.getOption( 1 ).checked ).toBe( false );
+      expect( multiselectModel.toggleOption( 2 ) ).toBe( false );
+      expect( multiselectModel.getOption( 2 ).checked ).toBe( false );
+      expect( multiselectModel.toggleOption( 1 ) ).toBe( true );
+      expect( multiselectModel.getOption( 1 ).checked ).toBe( true );
+    } );
+  } );
+
+  describe( 'getSelectedIndices()', () => {
+    it( 'should get the indices of the checked options', () => {
+      expect( multiselectModel.getSelectedIndices()[0] ).toBe( 1 );
+      multiselectModel.toggleOption( 0 );
+      expect( multiselectModel.getSelectedIndices()[0] ).toBe( 0 );
+      expect( multiselectModel.getSelectedIndices()[1] ).toBe( 1 );
+    } );
+  } );
+
+  describe( 'isAtMaxSelections()', () => {
+    it( 'should toggle checked value of option', () => {
+      expect( multiselectModel.isAtMaxSelections() ).toBe( false );
+
+      multiselectModel.toggleOption( 0 );
+      expect( multiselectModel.isAtMaxSelections() ).toBe( false );
+
+      // No need to toggle the second option because it's already checked.
+
+      multiselectModel.toggleOption( 2 );
+      expect( multiselectModel.isAtMaxSelections() ).toBe( false );
+
+      multiselectModel.toggleOption( 3 );
+      expect( multiselectModel.isAtMaxSelections() ).toBe( false );
+
+      multiselectModel.toggleOption( 4 );
+      expect( multiselectModel.isAtMaxSelections() ).toBe( true );
+
+      multiselectModel.toggleOption( 5 );
+      expect( multiselectModel.isAtMaxSelections() ).toBe( true );
+
+      multiselectModel.toggleOption( 5 );
+      expect( multiselectModel.isAtMaxSelections() ).toBe( true );
+
+      expect( multiselectModel.toggleOption( 4 ) ).toBe( false );
+      expect( multiselectModel.isAtMaxSelections() ).toBe( false );
+    } );
+  } );
+
+  describe( 'filterIndices()', () => {
+    it( 'should return indices of matched options in a search', () => {
+      expect( multiselectModel.filterIndices( 'mo' ).length ).toBe( 1 );
+      expect( multiselectModel.filterIndices( 'mort' ).length ).toBe( 1 );
+      expect( multiselectModel.filterIndices( 'mort' )[0] ).toBe( 0 );
+      expect( multiselectModel.filterIndices( 'fin' ).length ).toBe( 2 );
+      expect( multiselectModel.filterIndices( 'fin' )[0] ).toBe( 1 );
+      expect( multiselectModel.filterIndices( 'fin' )[1] ).toBe( 2 );
+      expect( multiselectModel.filterIndices( 'being' ).length ).toBe( 1 );
+      expect( multiselectModel.filterIndices( 'being' )[0] ).toBe( 2 );
+    } );
+  } );
+
+  describe( 'clearFilter()', () => {
+    it( 'should clear current and last matched options in a search', () => {
+      multiselectModel.filterIndices( 'fin' );
+      expect( multiselectModel.getLastFilterIndices().length ).toBe( 0 );
+      expect( multiselectModel.getFilterIndices().length ).toBe( 2 );
+      multiselectModel.filterIndices( 'mo' );
+      expect( multiselectModel.getLastFilterIndices().length ).toBe( 2 );
+      expect( multiselectModel.getFilterIndices().length ).toBe( 1 );
+      multiselectModel.clearFilter();
+      expect( multiselectModel.getLastFilterIndices().length ).toBe( 0 );
+      expect( multiselectModel.getFilterIndices().length ).toBe( 0 );
+    } );
+  } );
+
+  describe( 'getFilterIndices()', () => {
+    it( 'should return current indices of matched options in a search', () => {
+      expect( multiselectModel.getFilterIndices().length ).toBe( 0 );
+      multiselectModel.filterIndices( 'fin' );
+      expect( multiselectModel.getFilterIndices().length ).toBe( 2 );
+      expect( multiselectModel.getFilterIndices()[0] ).toBe( 1 );
+      expect( multiselectModel.getFilterIndices()[1] ).toBe( 2 );
+    } );
+  } );
+
+  describe( 'getLastFilterIndices()', () => {
+    it( 'should return indices of the last matched options in a search', () => {
+      expect( multiselectModel.getLastFilterIndices().length ).toBe( 0 );
+      multiselectModel.filterIndices( 'fin' );
+      expect( multiselectModel.getLastFilterIndices().length ).toBe( 0 );
+      multiselectModel.filterIndices( 'mo' );
+      expect( multiselectModel.getLastFilterIndices().length ).toBe( 2 );
+      expect( multiselectModel.getLastFilterIndices()[0] ).toBe( 1 );
+      expect( multiselectModel.getLastFilterIndices()[1] ).toBe( 2 );
+      multiselectModel.filterIndices( 'being' );
+      expect( multiselectModel.getLastFilterIndices().length ).toBe( 1 );
+      expect( multiselectModel.getLastFilterIndices()[0] ).toBe( 0 );
+    } );
+  } );
+
+  describe( 'getIndex()', () => {
+    it( 'should get correct index when no filter results', () => {
+      expect( multiselectModel.getIndex() ).toBe( -1 );
+      multiselectModel.setIndex( 2 );
+      expect( multiselectModel.getIndex() ).toBe( 2 );
+      multiselectModel.filterIndices( 'asdf' );
+      expect( multiselectModel.getIndex() ).toBe( -1 );
+    } );
+
+    it( 'should get reset index when options are filtered', () => {
+      expect( multiselectModel.getIndex() ).toBe( -1 );
+      multiselectModel.setIndex( 2 );
+      expect( multiselectModel.getIndex() ).toBe( 2 );
+      multiselectModel.filterIndices( 'mo' );
+      expect( multiselectModel.getIndex() ).toBe( -1 );
+    } );
+  } );
+
+  describe( 'setIndex()', () => {
+    it( 'should set index within available option range', () => {
+      expect( multiselectModel.getIndex() ).toBe( -1 );
+      multiselectModel.setIndex( 0 );
+      expect( multiselectModel.getIndex() ).toBe( 0 );
+      multiselectModel.setIndex( 1 );
+      expect( multiselectModel.getIndex() ).toBe( 1 );
+      multiselectModel.setIndex( 2 );
+      expect( multiselectModel.getIndex() ).toBe( 2 );
+      multiselectModel.setIndex( 10 );
+      expect( multiselectModel.getIndex() ).toBe( 5 );
+      multiselectModel.setIndex( -2 );
+      expect( multiselectModel.getIndex() ).toBe( -1 );
+    } );
+
+    it( 'should set index within filtered option range', () => {
+      expect( multiselectModel.getIndex() ).toBe( -1 );
+      multiselectModel.filterIndices( 'fin' );
+      multiselectModel.setIndex( 0 );
+      expect( multiselectModel.getIndex() ).toBe( 0 );
+      expect( multiselectModel.getFilterIndices()[multiselectModel.getIndex()] )
+        .toBe( 1 );
+      multiselectModel.setIndex( 1 );
+      expect( multiselectModel.getIndex() ).toBe( 1 );
+      multiselectModel.setIndex( 2 );
+      expect( multiselectModel.getIndex() ).toBe( 1 );
+    } );
+  } );
+
+  describe( 'resetIndex()', () => {
+    it( 'should return -1 for index when called', () => {
+      expect( multiselectModel.resetIndex() ).toBe( -1 );
+    } );
+  } );
+
+  describe( 'getOption()', () => {
+    it( 'should return the correct option when requested', () => {
+      expect( multiselectModel.getOption( 2 ).text ).toBe( 'Financial well-being' );
+      expect( multiselectModel.getOption( 2 ).value ).toBe( 'financial-well-being' );
+      expect( multiselectModel.getOption( 2 ).checked ).toBe( false );
+      expect( multiselectModel.getOption( 1 ).checked ).toBe( true );
+    } );
+  } );
+
+  describe( 'getOptions()', () => {
+    it( 'should return the full options list', () => {
+      expect( multiselectModel.getOptions().length ).toBe( 6 );
+      multiselectModel.filterIndices( 'asdf' );
+      expect( multiselectModel.getOptions().length ).toBe( 6 );
+    } );
+  } );
+
+} );


### PR DESCRIPTION
Fixes https://[GHE]/CFGOV/hmda-migration/issues/16

## Additions

- Adds MultiselectModel for managing state of the multiselect items, including filtering, selection, and highlighting.

## Changes

- Changes the search behavior to remove the minimum characters needed to perform a search (was 3, now it's 1).
- Prefixes multiselect filter utility classes with `u-`.

## Testing

1. `gulp test:unit --specs=js/molecules/MultiselectModel-spec.js` should have 100% passing coverage.
2. No errors in `gulp test:unit`.
3. `gulp clean && gulp build`
4. Compare filter on http://localhost:8000/about-us/newsroom/ to production. The one difference should be that when you start typing into the input, the list filters, whereas on production it will only filter after minimum of three characters are entered. Try hitting "enter" and tabbing and using the up/down arrows in the list, while being aware of existing known issues (https://github.cfpb.gov/CFGOV/platform/issues/3282, https://github.cfpb.gov/CFGOV/platform/issues/3283).

## Screenshots

![filter-search](https://user-images.githubusercontent.com/704760/52599233-0fc95b00-2e26-11e9-847f-52af5437b5d1.gif)
