### PR TITLE
Multiselect: Fix incorrect event dispatching error

### DIFF
--- a/cfgov/unprocessed/js/molecules/Multiselect.js
+++ b/cfgov/unprocessed/js/molecules/Multiselect.js
@@ -3,7 +3,6 @@ import * as arrayHelpers from '../modules/util/array-helpers';
 import * as atomicHelpers from '../modules/util/atomic-helpers';
 import { bindEvent } from '../modules/util/dom-events';
 import { create } from '../modules/util/dom-manipulators';
-import { queryOne } from '../modules/util/dom-traverse';
 import { UNDEFINED } from '../modules/util/standard-type';
 import { stringMatch } from '../modules/util/strings';
 import EventObserver from '../modules/util/EventObserver';
@@ -451,13 +450,19 @@ function Multiselect( element ) { // eslint-disable-line max-statements, inline-
       },
       keydown: function( event ) {
         const key = event.keyCode;
-        const checked = event.target.checked;
+        const target = event.target;
+        const checked = target.checked;
 
         if ( key === KEY_RETURN ) {
           event.preventDefault();
-          event.target.checked = !checked;
 
-          queryOne( event.target ).dispatchEvent( 'change' );
+          /* Programmatically checking a checkbox does not fire a change event
+          so we need to manually create an event and dispatch it from the input.
+          */
+          target.checked = !checked;
+          const evt = document.createEvent( 'HTMLEvents' );
+          evt.initEvent( 'change', false, true );
+          target.dispatchEvent( evt );
         } else if ( key === KEY_ESCAPE ) {
           _searchDom.focus();
           collapse();

--- a/test/unit_tests/js/molecules/Multiselect-spec.js
+++ b/test/unit_tests/js/molecules/Multiselect-spec.js
@@ -71,6 +71,15 @@ describe( 'Multiselect', () => {
   } );
 
   describe( 'interactions', () => {
+    it( 'should highlight the first item when keying down', function() {
+      multiselect.init();
+      const search = document.querySelector( '#test-select' );
+      search.click();
+      simulateEvent( 'keydown', search, { keyCode: 40 } );
+
+      expect( document.activeElement.id ).toBe( 'Debt collection' );
+    } );
+
     xit( 'should open when the search input is clicked', function() {
       multiselect.init();
       multiselectDom = document.querySelector( '.o-multiselect' );
@@ -82,15 +91,6 @@ describe( 'Multiselect', () => {
       expect( document.activeElement.id ).toBe( 'test-select' );
       expect( multiselectDom.className ).toBe( 'o-multiselect active' );
       expect( fieldset.getAttribute( 'aria-hidden' ) ).toBe( 'false' );
-    } );
-
-    xit( 'should highlight the first item when keying down', function() {
-      multiselect.init();
-      const search = document.querySelector( '#test-select' );
-      search.click();
-      simulateEvent( 'keydown', search, { keyCode: 40 } );
-
-      expect( document.activeElement.id ).toBe( 'Debt collection' );
     } );
 
     xit( 'should close when the body is clicked', function() {


### PR DESCRIPTION
Fixes https://[GHE]/CFGOV/platform/issues/3282
Introduced in https://github.com/cfpb/cfgov-refresh/pull/1684

## Changes

- Fixes issue where checkbox input was incorrectly dispatching a string as an event, not an event object.
- Removes `dom-traverse` dependency from Multiselect.
- Enabled keyboard interaction unit test.

## Testing

1. Visit /blog
2. Expand filter and click into Topic multiselect.
3. Open the dev console.
3. Hit "enter" key once.
4. Hit the "enter" key again.
5. There should be no error in the console and the checkbox should check and add a selection.

## Screenshots

Before:
![input-before](https://user-images.githubusercontent.com/704760/52669545-4b2a5f00-2ee4-11e9-86bf-64c368f31071.gif)

After:
![input-after](https://user-images.githubusercontent.com/704760/52669554-4ebde600-2ee4-11e9-9207-663f1064a986.gif)
