### PR TITLE
Ensure our data migrations migrate blocks that are children of other blocks

### DIFF
--- a/cfgov/v1/tests/util/test_migrations.py
+++ b/cfgov/v1/tests/util/test_migrations.py
@@ -95,7 +95,7 @@ class MigrationsUtilTestCase(TestCase):
             },
         ]
         result, migrated = migrate_stream_data(
-            self.page, ('not-migratory', 'migratory'), stream_data, mapper
+            self.page, ['not-migratory', 'migratory'], stream_data, mapper
         )
         self.assertTrue(migrated)
         self.assertEquals(
@@ -115,12 +115,19 @@ class MigrationsUtilTestCase(TestCase):
             },
         ]
         result, migrated = migrate_stream_data(
-            self.page, ('migratory', ), stream_data, mapper
+            self.page, ['migratory', ], stream_data, mapper
         )
         self.assertTrue(migrated)
         self.assertEquals(
             result[1]['value'], 'new text'
         )
+
+    def test_migrate_stream_data_empty_block_path(self):
+        mapper = mock.Mock(return_value='new text')
+        result, migrated = migrate_stream_data(
+            self.page, [], {}, mapper
+        )
+        self.assertFalse(migrated)
 
     def test_migrate_stream_field_page(self):
         """ Test that the migrate_stream_field function correctly gets

--- a/cfgov/v1/tests/util/test_migrations.py
+++ b/cfgov/v1/tests/util/test_migrations.py
@@ -12,7 +12,7 @@ import mock
 from v1.tests.wagtail_pages.helpers import save_new_page
 from v1.util.migrations import (
     get_stream_data, is_page, migrate_page_types_and_fields,
-    migrate_stream_data, migrate_stream_field, set_stream_data,
+    migrate_stream_data, migrate_stream_field, set_stream_data
 )
 
 
@@ -95,14 +95,14 @@ class MigrationsUtilTestCase(TestCase):
             },
         ]
         result, migrated = migrate_stream_data(
-            self.page, 'migratory', stream_data, mapper
+            self.page, ('not-migratory', 'migratory'), stream_data, mapper
         )
         self.assertTrue(migrated)
         self.assertEquals(
             result[0]['value'][0]['value'], 'new text'
         )
 
-    def test_migrate_stream_data_no_iterable_value(self):
+    def test_migrate_stream_data_flat(self):
         mapper = mock.Mock(return_value='new text')
         stream_data = [
             {
@@ -115,7 +115,7 @@ class MigrationsUtilTestCase(TestCase):
             },
         ]
         result, migrated = migrate_stream_data(
-            self.page, 'migratory', stream_data, mapper
+            self.page, ('migratory', ), stream_data, mapper
         )
         self.assertTrue(migrated)
         self.assertEquals(
@@ -195,4 +195,3 @@ class MigrationsUtilTestCase(TestCase):
                                                   'body',
                                                   'text',
                                                   mapper)
-

--- a/cfgov/v1/tests/util/test_migrations.py
+++ b/cfgov/v1/tests/util/test_migrations.py
@@ -48,10 +48,16 @@ class MigrationsUtilTestCase(TestCase):
     def test_get_stream_data_revision(self):
         """ Test that get_stream_data fetches the stream_data correctly
         from a revision object. """
-        stream_data = get_stream_data(self.revision.as_page_object(), 'body')
+        stream_data = get_stream_data(self.revision, 'body')
 
         self.assertEqual(stream_data[0]['type'], 'text')
         self.assertEqual(stream_data[0]['value'], 'some text')
+
+    def test_get_stream_data_revision_no_field(self):
+        """ Test that get an empty list for fields that don't exist on
+        revisions """
+        stream_data = get_stream_data(self.revision, 'notbody')
+        self.assertEqual(stream_data, [])
 
     def test_set_stream_data_page(self):
         """ Test that set_stream_data correctly sets stream data for a
@@ -93,14 +99,16 @@ class MigrationsUtilTestCase(TestCase):
                     },
                 ]
             },
+            {
+                'type': 'not-migratory',
+                'value': []
+            },
         ]
         result, migrated = migrate_stream_data(
             self.page, ['not-migratory', 'migratory'], stream_data, mapper
         )
         self.assertTrue(migrated)
-        self.assertEquals(
-            result[0]['value'][0]['value'], 'new text'
-        )
+        self.assertEquals(result[0]['value'][0]['value'], 'new text')
 
     def test_migrate_stream_data_flat(self):
         mapper = mock.Mock(return_value='new text')
@@ -118,9 +126,7 @@ class MigrationsUtilTestCase(TestCase):
             self.page, ['migratory', ], stream_data, mapper
         )
         self.assertTrue(migrated)
-        self.assertEquals(
-            result[1]['value'], 'new text'
-        )
+        self.assertEquals(result[1]['value'], 'new text')
 
     def test_migrate_stream_data_empty_block_path(self):
         mapper = mock.Mock(return_value='new text')

--- a/cfgov/v1/util/migrations.py
+++ b/cfgov/v1/util/migrations.py
@@ -128,8 +128,7 @@ def migrate_stream_data(page_or_revision, block_type, stream_data, mapper):
 
 
 def migrate_stream_field(page_or_revision, field_name, block_type, mapper):
-    """ Migrate blocks of the type within a StreamField of the name belonging
-    to the page or revision using the mapper function """
+    """ Run mapper on blocks within a StreamField on a page or revision. """
     stream_data = get_stream_data(page_or_revision, field_name)
 
     new_stream_data, migrated = migrate_stream_data(
@@ -144,10 +143,13 @@ def migrate_stream_field(page_or_revision, field_name, block_type, mapper):
 def migrate_page_types_and_fields(apps, page_types_and_fields, mapper):
     """ Migrate Wagtail StreamFields using the given mapper function.
         page_types_and_fields should be a list of 4-tuples
-        providing ('app', 'PageType', 'field_name', 'block type'). """
+        providing ('app', 'PageType', 'field_name', 'block_type').
+        'field_name' is the field on the 'PageType' model. 'block type' is the
+        StreamBlock type to migrate."""
     for app, page_type, field_name, block_type in page_types_and_fields:
         page_model = apps.get_model(app, page_type)
         revision_model = apps.get_model('wagtailcore.PageRevision')
+
         for page in page_model.objects.all():
             migrate_stream_field(page, field_name, block_type, mapper)
 

--- a/cfgov/v1/util/migrations.py
+++ b/cfgov/v1/util/migrations.py
@@ -110,8 +110,6 @@ def migrate_stream_data(page_or_revision, block_path, stream_data, mapper):
     if isinstance(block_path, six.string_types):
         block_path = [block_path, ]
 
-    block_path = list(block_path)
-
     if len(block_path) == 0:
         return stream_data, False
 


### PR DESCRIPTION
This PR adds some recursion to our Wagtail StreamField-specific data migration utilities to ensure that we can migrate blocks that are children of other blocks.

By way of illustration, [`FullWidthText` block](https://github.com/cfpb/cfgov-refresh/blob/master/cfgov/v1/atomic_elements/organisms.py#L712) itself contains a variety of other blocks that could also exist within a StreamField directly. So if we want to migrate all `EmailSignUp`s, we would previously have had to look inside the `FullWidthText` separately for its `EmailSignUp`. 

For example, `LearnPage` contains an `email_signup` `EmailSignUp` block in its `content` StreamField. `BlogPage` has both a `FullWidthText` and a `EmailSignUp` block in its `content` StreamField. If we wanted to perform the same migration on the `EmailSignUp` in both places, we'd have to extract the `EmailSignUp` block from the `FullWidthText` block first. Perhaps something like:

```python
def full_width_text_mapper(page_or_revision, data):
    email_signup = data['email_signup']
    data['email_signup'] = email_signup_mapper(page_or_revision, email_signup)
    return data

def email_signup_mapper(page_or_revision, data):
    # Mung mung
    return data

def forwards(apps, schema_editor):
    migrate_page_types_and_fields(
        apps,
        [(v1', 'BlogPage', 'header', 'email_signup'),],
        full_width_text_mapper
    )
    migrate_page_types_and_fields(
        apps,
        [(v1', 'BlogPage', 'content', 'full_width_text'),],
        full_width_text_mapper
    )
```

With this change, we just have to write one mapper function and have one call to `migrate_page_types_and_fields`, and include the path from parent to child block names in a list:

```python
def email_signup_mapper(page_or_revision, data):
    # Mung mung
    return data

def forwards(apps, schema_editor):
    migrate_page_types_and_fields(
        apps,
        [
            ('v1', 'BlogPage', 'content', ['email_signup', ]),
            ('v1', 'BlogPage', 'content', ['full_width_text', 'email_signup', ]),
        ]
        full_width_text_mapper
    )
```

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: