### PR TITLE
Use Akamai v3 API for purging the entire site

### DIFF
--- a/cfgov/v1/models/akamai_backend.py
+++ b/cfgov/v1/models/akamai_backend.py
@@ -68,22 +68,17 @@ class AkamaiBackend(BaseBackend):
         resp.raise_for_status()
 
     def purge_all(self):
-        payload = self.get_payload(
-            obj=os.environ['AKAMAI_OBJECT_ID']
-        )
-        payload['type'] = 'cpcode'
-        payload['domain'] = 'production'
-        payload['action'] = 'invalidate'
-
+        obj = os.environ['AKAMAI_OBJECT_ID']
         resp = requests.post(
             os.environ['AKAMAI_PURGE_ALL_URL'],
             headers=self.headers,
-            data=json.dumps(payload),
+            data=json.dumps(self.get_payload(obj=obj)),
             auth=self.auth
         )
         logger.info(
-            u'Initiated site-wide Akamai flush, '
+            u'Attempted to invalidate content provider {obj}, '
             'got back response {message}'.format(
+                obj=obj,
                 message=resp.text
             )
         )

--- a/docs/caching.md
+++ b/docs/caching.md
@@ -6,6 +6,33 @@ We use [Akamai](https://www.akamai.com/), a content delivery network, to cache t
 
 There are certain pages that do not live in Wagtail or are impacted by changes on another page (imagine our [newsroom page](https://www.consumerfinance.gov/about-us/newsroom/) that lists titles of other pages) or another process (imagine data from Socrata gets updated) and thus will display outdated content until the page's time to live (TTL) has expired, a deploy has happened, or if someone manually invalidates that page. Our default TTL is 24 hours.
 
+#### Checking the cache state of a URL
+
+To get the current cache state of a URL (perhaps to see if that URL has been invalidated), you can use the following `curl` command to check the `X-Cache` header:
+
+```shell
+curl -sI -H "Pragma: akamai-x-cache-on" https://beta.consumerfinance.gov | grep "X-Cache"
+```
+
+It will return something like:
+
+```
+X-Cache: TCP_HIT from a23-46-239-53.deploy.akamaitechnologies.com (AkamaiGHost/9.5.4-24580776) (-)
+```
+
+The possible cache state values are:
+
+- `TCP_HIT`: The object was fresh in cache and object from disk cache.
+- `TCP_MISS`: The object was not in cache, server fetched object from origin.
+- `TCP_REFRESH_HIT`: The object was stale in cache and we successfully refreshed with the origin on an If-modified-Since request.
+- `TCP_REFRESH_MISS`: Object was stale in cache and refresh obtained a new object from origin in response to our IF-Modified-Since request.
+- `TCP_REFRESH_FAIL_HIT`: Object was stale in cache and we failed on refresh (couldn't reach origin) so we served the stale object.
+- `TCP_IMS_HIT`: IF-Modified-Since request from client and object was fresh in cache and served.
+- `TCP_NEGATIVE_HIT`: Object previously returned a "not found" (or any other negatively cacheable response) and that cached response was a hit for this new request.
+- `TCP_MEM_HIT`: Object was on disk and in the memory cache. Server served it without hitting the disk.
+- `TCP_DENIED`: Denied access to the client for whatever reason.
+- `TCP_COOKIE_DENY`: Denied access on cookie authentication (if centralized or decentralized authorization feature is being used in config).
+
 ### Django caching
 
 Starting in December 2017, we use [template fragment caching](https://github.com/cfpb/cfgov-refresh/blob/master/cfgov/v1/fragment_cache_extension.py) to cache all or part of a template.  It is enabled on our "post previews", snippets of a page that we display on results of filterable pages (e.g. [our blog page](https://consumerfinance.gov/about-us/blog) & [research & reports](https://www.consumerfinance.gov/data-research/research-reports/)).


### PR DESCRIPTION
The Akamai v2 API that we used for full-site invalidation is being deprecated and will go away on March 1, 2019. This PR changes our Akamai backend's `purge_all` method to use the v3 API's CP (content provider) code invalidation instead.

Once this PR is merged we'll need to update the `akamai_purge_all_url` value in ansible-consumer-finance before deploying.

I've also added documentation for how to check the cache state of URLs to our cache document.

## Notes

The existing tests for `AkamaiBackend` do not include tests for `purge()` and `purge_all()`, and I'm of the opinion that this is fine — I'm not sure there's anything to test there except that the requests library properly constructs a request. But this means the coverage test for this PR's diff will fail at less than 100%.

## Testing

1. Check the current cache state of https://beta.consumerfinance.gov:

   ```shell
   curl -sI -H "Pragma: akamai-x-cache-on" https://beta.consumerfinance.gov | grep "X-Cache"
   ```

   The response should include `TCP_HIT`:

   ```
   X-Cache: TCP_HIT from a23-46-239-53.deploy.akamaitechnologies.com (AkamaiGHost/9.5.4-24580776) (-)
   ```

2. Set [`ENABLE_AKAMAI_CACHE_PURGE`](https://github.com/cfpb/cfgov-refresh/blob/master/.env_SAMPLE#L37) in your `.env` file 

3. Set [`AKAMAI_OBJECT_ID`](https://github.com/cfpb/cfgov-refresh/blob/master/.env_SAMPLE#L38) to the value of `akamai_object_id` from the beta vars in ansible-consumer-finance.

4. Set [the remaining Akamai variables in `.env`](https://github.com/cfpb/cfgov-refresh/blob/master/.env_SAMPLE#L39-L43) to their respective values in the ext vault in ansible-consumer-finance.

   For `AKAMAI_PURGE_ALL_URL`, replace the URL path of the existing value of `akamai_purge_all_url`, with `/ccu/v3/invalidate/cpcode/production`.

5. Run ` ./cfgov/manage.py  invalidate_all_pages`. The output should include an `httpStatus` of `201` and a `detail` of `"Request accepted"`, i.e.:

   ```
   Attempted to invalidate content provider 360700, got back response {"estimatedSeconds": 5, "purgeId": "69bd6bfd-306e-11e9-94c9-f559615b52bc", "supportId": "17PY1550158639006705-161658048", "httpStatus": 201, "detail": "Request accepted"}
   ```

6. Verify that the purge worked by checking the cache state of https://beta.consumerfinance.gov again:

   ```shell
   curl -sI -H "Pragma: akamai-x-cache-on" https://beta.consumerfinance.gov | grep "X-Cache"
   ```

   The response this time should include `TCP_REFRESH_HIT`:

   ```
   X-Cache: TCP_REFRESH_HIT from a23-46-239-53.deploy.akamaitechnologies.com (AkamaiGHost/9.5.4-24580776) (S)
   ```

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
