### PR TITLE
Fix const in for value for IE11

### DIFF
--- a/cfgov/unprocessed/apps/owning-a-home/js/explore-rates/data-loader.js
+++ b/cfgov/unprocessed/apps/owning-a-home/js/explore-rates/data-loader.js
@@ -35,7 +35,8 @@ function getData( fieldToFetch ) {
 
   const params = { decache: decache, cancelToken: _cancelToken };
   // This could use Object.assign, but it's not supported in IE11.
-  for ( const key in fieldToFetch ) {
+  let key;
+  for ( key in fieldToFetch ) {
     if ( Object.prototype.hasOwnProperty.call( fieldToFetch, key ) ) {
       params[key] = fieldToFetch[key];
     }

--- a/cfgov/unprocessed/apps/owning-a-home/js/explore-rates/params.js
+++ b/cfgov/unprocessed/apps/owning-a-home/js/explore-rates/params.js
@@ -59,7 +59,8 @@ function update() {
   _params.prevLocation = _params.location;
 
   let val;
-  for ( const param in _params ) {
+  let param;
+  for ( param in _params ) {
     if ( Object.prototype.hasOwnProperty.call( _params, param ) ) {
       val = domValues.getSelection( param );
       if ( param !== 'prevLoanType' &&

--- a/cfgov/unprocessed/apps/owning-a-home/js/explore-rates/rate-checker.js
+++ b/cfgov/unprocessed/apps/owning-a-home/js/explore-rates/rate-checker.js
@@ -129,7 +129,8 @@ function updateView() {
       // sort results by interest rate, ascending
       const sortedKeys = [];
       const sortedResults = {};
-      for ( const key in results ) {
+      let key;
+      for ( key in results ) {
         if ( results.hasOwnProperty( key ) ) {
           sortedKeys.push( key );
         }

--- a/cfgov/unprocessed/apps/owning-a-home/js/explore-rates/util.js
+++ b/cfgov/unprocessed/apps/owning-a-home/js/explore-rates/util.js
@@ -149,7 +149,8 @@ function renderLoanAmount( elem, loanAmount ) {
  */
 function setSelections( fields ) {
   let val;
-  for ( const key in fields ) {
+  let key;
+  for ( key in fields ) {
     if ( Object.prototype.hasOwnProperty.call( fields, key ) ) {
       val = fields[key];
       const el = document.querySelector( '#' + key );

--- a/cfgov/unprocessed/apps/regulations3k/js/search-utils.js
+++ b/cfgov/unprocessed/apps/regulations3k/js/search-utils.js
@@ -28,7 +28,8 @@ function getSearchValues( searchEl, filterEls ) {
  */
 function serializeFormFields( fields ) {
   fields = fields.map( field => {
-    for ( const key in field ) {
+    let key;
+    for ( key in field ) {
       field = `${ key }=${ field[key] }`;
     }
     return field;

--- a/cfgov/unprocessed/js/modules/transition/BaseTransition.js
+++ b/cfgov/unprocessed/js/modules/transition/BaseTransition.js
@@ -148,7 +148,8 @@ function BaseTransition( element, classes ) {
    * already been applied to this BaseTransition's target element.
    */
   function _flush() {
-    for ( const prop in _classes ) {
+    let prop;
+    for ( prop in _classes ) {
       if ( _classes.hasOwnProperty( prop ) &&
            _classes[prop] !== _classes.BASE_CLASS &&
            _dom.classList.contains( _classes[prop] ) ) {
@@ -219,7 +220,8 @@ function BaseTransition( element, classes ) {
       transition:       'transitionend'
     };
 
-    for ( const t in transitions ) {
+    let t;
+    for ( t in transitions ) {
       if ( transitions.hasOwnProperty( t ) &&
            typeof elem.style[t] !== 'undefined' ) {
         transition = transitions[t];

--- a/cfgov/unprocessed/js/modules/util/assign.js
+++ b/cfgov/unprocessed/js/modules/util/assign.js
@@ -27,7 +27,8 @@ function assign( destination ) {
   for ( let i = 1; i < arguments.length; i++ ) {
     const source = arguments[i] || {};
     hasOwnProp = Object.hasOwnProperty.bind( source );
-    for ( const key in source ) {
+    let key;
+    for ( key in source ) {
       if ( hasOwnProp( key ) ) {
         const value = source[key];
         if ( _isPlainObject( value ) ) {

--- a/cfgov/unprocessed/js/modules/util/breakpoint-state.js
+++ b/cfgov/unprocessed/js/modules/util/breakpoint-state.js
@@ -28,7 +28,8 @@ function get( width ) {
   width = width || getViewportDimensions().width;
 
   // eslint-disable-next-line guard-for-in
-  for ( const rangeKey in breakpointsConfig ) {
+  let rangeKey;
+  for ( rangeKey in breakpointsConfig ) {
     breakpointKey = 'is' + rangeKey.charAt( 0 ).toUpperCase() +
                     rangeKey.slice( 1 );
     breakpointState[breakpointKey] =

--- a/cfgov/unprocessed/js/modules/util/dom-events.js
+++ b/cfgov/unprocessed/js/modules/util/dom-events.js
@@ -6,7 +6,8 @@
 function bindEvent( elem, events ) {
   let callback;
 
-  for ( const event in events ) {
+  let event;
+  for ( event in events ) {
     if ( events.hasOwnProperty( event ) ) {
       callback = events[event];
       elem.addEventListener( event, callback );

--- a/cfgov/unprocessed/js/modules/util/dom-manipulators.js
+++ b/cfgov/unprocessed/js/modules/util/dom-manipulators.js
@@ -9,7 +9,8 @@ import { queryOne } from './dom-traverse';
 function create( tag, options ) {
   const elem = document.createElement( tag );
 
-  for ( const i in options ) {
+  let i;
+  for ( i in options ) {
     if ( options.hasOwnProperty( i ) ) {
       const val = options[i];
       let ref;

--- a/cfgov/unprocessed/js/organisms/FilterableListControls.js
+++ b/cfgov/unprocessed/js/organisms/FilterableListControls.js
@@ -173,7 +173,8 @@ function FilterableListControls( element ) {
 
       validatedField = _validateField( field );
 
-      for ( const prop in validatedField.status ) {
+      let prop;
+      for ( prop in validatedField.status ) {
         if ( validatedField.status[prop] === false ) {
           fieldIsValid = false;
         }

--- a/config/webpack-config.js
+++ b/config/webpack-config.js
@@ -178,7 +178,8 @@ const configExports = {
 
 if ( envvars.NODE_ENV === 'development' ) {
   // eslint-disable-next-line guard-for-in
-  for ( const key in configExports ) {
+  let key;
+  for ( key in configExports ) {
     Object.assign( configExports[key], devConf );
   }
 }

--- a/test/browser_tests/conf.js
+++ b/test/browser_tests/conf.js
@@ -165,7 +165,8 @@ function _copyParameters( params, capabilities ) { // eslint-disable-line comple
 
   for ( let i = 0, len = capabilities.length; i < len; i++ ) {
     capability = capabilities[i];
-    for ( const p in injectParams ) {
+    let p;
+    for ( p in injectParams ) {
       if ( injectParams.hasOwnProperty( p ) ) {
         capability[p] = injectParams[p];
       }

--- a/test/unit_tests/js/modules/util/breakpoint-state-spec.js
+++ b/test/unit_tests/js/modules/util/breakpoint-state-spec.js
@@ -27,7 +27,8 @@ describe( 'breakpoint-state', () => {
 
       const breakpointStateGet = breakpointState.get();
       // eslint-disable-next guard-for-in
-      for ( const stateKey in breakpointStateGet ) {
+      let stateKey;
+      for ( stateKey in breakpointStateGet ) {
         if ( breakpointStateGet[stateKey] === true ) trueValueCount++;
       }
 
@@ -39,7 +40,8 @@ describe( 'breakpoint-state', () => {
       let breakpointStateKey;
 
       // eslint-disable-next-line guard-for-in
-      for ( const rangeKey in breakpointsConfig ) {
+      let rangeKey;
+      for ( rangeKey in breakpointsConfig ) {
         width = breakpointsConfig[rangeKey].max ||
                 breakpointsConfig[rangeKey].min;
         breakpointStateKey =


### PR DESCRIPTION
Turns out IE11 does not support initialization of `const` within a for loop. This changes the code slightly to change `const` values that are initialized in for loops into `let` values before the loop.

<img width="275" alt="screen shot 2019-02-19 at 3 18 49 pm" src="https://user-images.githubusercontent.com/704760/53044966-6ce29380-345a-11e9-9985-330587db6940.png">

## Changes

- Change `const` value into `let` value for IE11 support.

## Testing

1. `gulp clean && gulp build` should pass.
2. This was appearing on /owning-a-home/closing-disclosure/ in IE11, but the values in CF would need to be fixed before you will see the error go away (this can be manually done by searching the cf node_modules for `( const` and replacing that line as shown in this PR.

## Todo

Needs to be fixed and released in CF too. PR here https://github.com/cfpb/capital-framework/pull/890