### PR TITLE
Remove the note about :443 in password reset links

### DIFF
--- a/cfgov/legacy/templates/common/reset_password_email.html
+++ b/cfgov/legacy/templates/common/reset_password_email.html
@@ -1,5 +1,4 @@
     {% load i18n wagtailadmin_tags %}{% base_url_setting as base_url %}
-    Note: Please change 'http' to 'https' and remove ':443' if these appear in the password reset link.
 
     {% trans "Please follow the link below to reset your password:" %}
     {% if base_url %}{{ base_url }}{% else %}{{ protocol }}://{{ domain }}{% endif %}{% url 'wagtailadmin_password_reset_confirm' uidb64=uid token=token %}


### PR DESCRIPTION
This PR modifies the password reset email template to remove the "Note" line about removing :443 and changing http to https in the link now that the underlying issue is mitigated.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
