### PR TITLE
Update Ask CFPB export fields 

### DIFF
--- a/cfgov/ask_cfpb/scripts/replace_unsupported_characters.py
+++ b/cfgov/ask_cfpb/scripts/replace_unsupported_characters.py
@@ -1,0 +1,33 @@
+from __future__ import unicode_literals
+
+from ask_cfpb.models.pages import AnswerPage
+
+
+unsupported = ['\x92', '\x93', '\x94', '\x96']
+
+
+def fix(text):
+    text = text.replace('\x92', "'")
+    text = text.replace('\x93', '"')
+    text = text.replace('\x94', '"')
+    text = text.replace('\x96', '-')
+    return text
+
+
+def run():
+    for page in AnswerPage.objects.all():
+        fixed = False
+
+        for string in unsupported:
+            if string in page.question:
+                page.question = fix(page.question)
+                fixed = True
+            if string in page.answer:
+                page.answer = fix(page.answer)
+                fixed = True
+            if string in page.snippet:
+                page.snippet = fix(page.snippet)
+                fixed = True
+
+        if fixed:
+            page.save_revision().publish()

--- a/cfgov/ask_cfpb/tests/models/test_pages.py
+++ b/cfgov/ask_cfpb/tests/models/test_pages.py
@@ -89,6 +89,21 @@ class ExportAskDataTests(TestCase, WagtailTestUtils):
             'RelatedQuestions': "1 | 2 | 3",
             'RelatedResources': "Owning a Home"}]
 
+    def test_export_script_assemble_output(self):
+        answer = Answer(id=1234)
+        answer.save()
+        page = AnswerPage(
+            slug='mock-question1-en-1234',
+            title='Mock question1')
+        page.answer_base = answer
+        page.question = 'Mock question1'
+        helpers.publish_page(page)
+
+        output = assemble_output()[0]
+        self.assertEqual(output.get('ASK_ID'), 1234)
+        self.assertEqual(output.get('URL'), '/mock-question1-en-1234/')
+        self.assertEqual(output.get('Question'), 'Mock question1')
+
     def test_clean_and_strip(self):
         raw_data = "<p>If you have been scammed, file a complaint.</p>"
         clean_data = "If you have been scammed, file a complaint."
@@ -237,16 +252,6 @@ class AnswerModelTestCase(TestCase):
         self.page2.answer_base = self.answer5678
         self.page2.parent = self.english_parent_page
         self.page2.save()
-
-    def test_export_script_assemble_output(self):
-        expected_urls = ['/ask-cfpb/mock-question1-en-1234/',
-                         '/ask-cfpb/mock-answer-page-en-5678/']
-        expected_questions = ['Mock question1', 'Mock question2']
-        test_output = assemble_output()
-        for obj in test_output:
-            self.assertIn(obj.get('ASK_ID'), [1234, 5678])
-            self.assertIn(obj.get('URL'), expected_urls)
-            self.assertIn(obj.get('Question'), expected_questions)
 
     def test_spanish_print_page(self):
         response = self.client.get(reverse(


### PR DESCRIPTION
## Overview

See GHE issue GHE/CFGOV/Ask-Evo/issues/40

Now that https://github.com/cfpb/cfgov-refresh/pull/4818 has been merged (!!), we need to update the Ask export to pull certain fields from the `AnswerPage` instead of the `Answer` (specifically, `answer`, `question`, and `snippet`).  We will further update this with upcoming work to migrate all fields to the `AnswerPage`, but for now we need to do this so that the export continues to be accurate and up-to-date.

## Changes

I've updated the `test_export_script_assemble_output` test so that it lives with the rest of the `ExportAskDataTests` tests, both for improved readability and to minimize conflicts with the setUp data in the `AnswerModelTestCase`. 

The only functional change this introduces is that the export will now output live versions of what's on a page, whereas previously since it was querying directly from the Answer, it exported the latest revision. We have a pending to-do to clarify with CE whether this will be an issue or if we need to make this return draft content (which will likely slow the script down), but in the meantime, I wanted to get this in so that we have something working at least with the live content.

Lastly, this PR introduces a one-time script* we need to run in order to fix certain unsupported characters that are causing issues in the export (they may have made their way in from Word copy + paste.)  We plan to address these unicode issues more widely with a future migration, but for now I'm tackling the characters that specifically cause the export to choke.  As noted in the GHE issue, this impacts only 14 pages which are safe to publish.

*I will open a PR to remove this script once it runs on production. I am open to suggestions on how else to run this but would like to avoid copying and pasting code into terminal :) 


## Local testing

If you'd like to test this out locally, you can pull down this branch and import a relatively recent database dump.

From http://localhost:8000/admin/export-ask, you can attempt to download the csv, but it will fail - you should see this error in the browser:
<img width="670" alt="screen shot 2019-02-25 at 5 48 52 pm" src="https://user-images.githubusercontent.com/354591/53381508-d9133a80-3925-11e9-8683-28fc331ce584.png">

You'll need to run the script that takes care of the problematic characters, by running:
```
python cfgov/manage.py runscript replace_unsupported_characters
```
This should impact 14 pages.

Now, if you try to download the csv again, it should work. Hooray!

For extra testing, you can confirm that (published) changes you've made to an AnswerPage get reflected in the csv.

