### PR TITLE
Add a note that backward migrations are not required

### DIFF
--- a/docs/migrations.md
+++ b/docs/migrations.md
@@ -124,6 +124,10 @@ class Migration(migrations.Migration):
 The `forwards()` and `backwards()` functions are where any changes
 that need to happen to a model's data are made.
 
+!!! note
+    While backwards migrations are necessary in external libraries that we create, 
+    we do not require them in cfgov-refresh. 
+
 ### Wagtail-specific considerations
 
 Django data migrations with Wagtail can be challenging because

--- a/docs/migrations.md
+++ b/docs/migrations.md
@@ -126,7 +126,8 @@ that need to happen to a model's data are made.
 
 !!! note
     While backwards migrations are necessary in external libraries that we create, 
-    we do not require them in cfgov-refresh. 
+    we do not require them in cfgov-refresh 
+    because we prefer not to rollback migrations that have already been applied.
 
 ### Wagtail-specific considerations
 


### PR DESCRIPTION
Per a decision made by the backend team in our last huddle, backward data migrations are not required in cfgov-refresh. This change adds a note to that effect in the migration documentation.

## Screenshots

![image](https://user-images.githubusercontent.com/10562538/53249191-8ae00c00-3685-11e9-8ee4-98755e1b0cec.png)

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [x] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
