### PR TITLE
Remove errant Ask entries on Spanish category pages

### DIFF
--- a/cfgov/ask_cfpb/tests/models/test_pages.py
+++ b/cfgov/ask_cfpb/tests/models/test_pages.py
@@ -879,7 +879,7 @@ class AnswerModelTestCase(TestCase):
             test_context['choices'].count(),
             self.category.subcategories.count())
 
-    def test_category_page_truncation(self):
+    def test_spanish_category_page_truncation(self):
         answer = self.answer1234
         answer.answer_es = ("We need an answer with more than 40 words to"
                             "prove that truncation is working as expected."
@@ -888,6 +888,7 @@ class AnswerModelTestCase(TestCase):
                             "40 words, which I have now managed to exceed.")
         answer.category.add(self.category)
         answer.save()
+        answer.spanish_page.get_latest_revision().publish()
         mock_site = mock.Mock()
         mock_site.hostname = 'localhost'
         mock_request = HttpRequest()


### PR DESCRIPTION
The two most recently created answers, 2094 and 2092, have Spanish content but no
created Spanish page. This creates some 404 errors on Spanish category pages,
which find Spanish content in the Answer model and assume there's a page.

### The affected category pages
- https://www.consumerfinance.gov/es/obtener-respuestas/categoria-ensenar-a-otros/
- https://www.consumerfinance.gov/es/obtener-respuestas/categoria-manejar-una-cuenta-bancaria/
- https://www.consumerfinance.gov/es/obtener-respuestas/categoria-enviar-dinero/

The top entry on each of those pages currently returns a 404.

### Testing
Visit the above pages locally, and the errant entries should be gone.
If they're not at the top of the list, they aren't there, because the
results are sorted by latest created, and the troublemaker pages are the
most recently created Answers.

- http://localhost:8000/es/obtener-respuestas/categoria-ensenar-a-otros/
- http://localhost:8000/es/obtener-respuestas/categoria-manejar-una-cuenta-bancaria/
- http://localhost:8000/es/obtener-respuestas/categoria-enviar-dinero/