### PR TITLE
Add ability to log DB queries to console

### DIFF
--- a/cfgov/cfgov/settings/local.py
+++ b/cfgov/cfgov/settings/local.py
@@ -23,7 +23,7 @@ LOGGING = {
     'disable_existing_loggers': False,
     'handlers': {
         'console': {
-            'level': 'INFO',
+            'level': 'DEBUG',
             'class': 'logging.StreamHandler',
         }
     },
@@ -35,6 +35,14 @@ LOGGING = {
         }
     }
 }
+
+# Log database queries.
+if os.environ.get('ENABLE_SQL_LOGGING'):
+    LOGGING['loggers']['django.db.backends'] = {
+        'handlers': ['console'],
+        'level': 'DEBUG',
+        'propagate': False,
+    }
 
 # Django Debug Toolbar
 if os.environ.get('ENABLE_DEBUG_TOOLBAR'):

--- a/docs/development-tips.md
+++ b/docs/development-tips.md
@@ -97,3 +97,24 @@ $ ENABLE_DEBUG_TOOLBAR=1 ./runserver.sh
 This tool exposes various useful pieces of information about things like HTTP headers,
 Django settings, SQL queries, and template variables. Note that running with the toolbar on
 may have an impact on local server performance.
+
+To log database queries to the console when running locally,
+define the `ENABLE_SQL_LOGGING` environment variable:
+
+```sh
+$ ENABLE_SQL_LOGGING=1 cfgov/manage.py shell
+>>> from django.contrib.auth import get_user_model
+>>> User = get_user_model()
+>>> User.objects.count()
+(0.004) SELECT COUNT(*) AS "__count" FROM "auth_user"; args=()
+97
+```
+
+This will log any database queries (and time taken to execute them)
+to the console, and works with any Django code invoked from the shell,
+including the server and management commands:
+
+```sh
+$ ENABLE_SQL_LOGGING=1 ./runserver.sh
+$ ENABLE_SQL_LOGGING=1 cfgov/manage.py some_management_command
+```


### PR DESCRIPTION
This commit adds the ability to (optionally) log Django database queries to the console by defining a new `ENABLE_SQL_LOGGING` environment variable.

This is useful when trying to debug database interactions, and works against the Django server, interactive shell, and management commands.

The documentation on developer tips has been updated to include this ability.

## Screenshots

New documentation section:

<img width="741" alt="image" src="https://user-images.githubusercontent.com/654645/53270655-4f136980-36ba-11e9-9d43-bae75c23f5ae.png">

## Notes

This is similar to some functionality that [django-extensions](https://github.com/django-extensions/django-extensions) already provides through its `shell_plus` and `runserver_plus` commands, but doing it via our local settings lets us more easily turn this on globally for things like management commands.

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [X] Passes all existing automated tests
- [X] Any _change_ in functionality is tested
- [X] New functions are documented (with a description, list of inputs, and expected output)
- [X] Placeholder code is flagged / future todos are captured in comments
- [X] Project documentation has been updated
- [X] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: