### PR TITLE
Bump wagtail-flags dependency to version 4.0.2

### DIFF
--- a/requirements/libraries.txt
+++ b/requirements/libraries.txt
@@ -35,7 +35,7 @@ six==1.11.0
 unicodecsv==0.14.1
 unipath>=1.1,<=2.0
 urllib3==1.23
-wagtail-flags==4.0.1
+wagtail-flags==4.0.2
 wagtail-inventory==0.5.1
 wagtail-sharing==0.7
 wagtail-treemodeladmin==1.0.4


### PR DESCRIPTION
This change bumps the version of [wagtail-flags](https://github.com/cfpb/wagtail-flags) used by this project from 4.0.1 to [4.0.2](https://github.com/cfpb/wagtail-flags/releases/tag/4.0.2). This adds a fix that auto-registers the "site" condition, eliminating numerous warnings that currently appear when running the Django shell and local server.

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [X] Passes all existing automated tests
- [X] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [X] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: