### PR TITLE
Fix import sorting that Travis didn't catch

### DIFF
--- a/cfgov/v1/tests/util/test_util.py
+++ b/cfgov/v1/tests/util/test_util.py
@@ -1,7 +1,8 @@
-import mock
 from datetime import date
 
 from django.test import TestCase
+
+import mock
 
 from v1.models import BrowseFilterablePage, BrowsePage, CFGOVPage, HomePage
 from v1.tests.wagtail_pages import helpers


### PR DESCRIPTION
Travis's run of isort did not catch this, for some reason, so it broke the build on dev.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [x] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
