### PR TITLE
Fix migration dependency errors

### DIFF
--- a/cfgov/v1/migrations/0119_rename_image_inset_data.py
+++ b/cfgov/v1/migrations/0119_rename_image_inset_data.py
@@ -57,6 +57,7 @@ def backwards(apps, schema_editor):
 
 class Migration(migrations.Migration):
     dependencies = [
+        ('regulations3k', '0013_add_image_to_fullwidthtext'),
         ('v1', '0118_add_image_to_fullwidthtext')
     ]
     operations = [

--- a/cfgov/v1/migrations/0142_migrate_pas_link_data_to_pagechooserblock.py
+++ b/cfgov/v1/migrations/0142_migrate_pas_link_data_to_pagechooserblock.py
@@ -113,6 +113,11 @@ def forwards(apps, schema_editor):
 
 class Migration(migrations.Migration):
     dependencies = [
+        ('ask_cfpb', '0019_add_disclaimer_pagechooserblock_to_emailsignup'),
+        (
+            'regulations3k',
+            '0019_add_disclaimer_pagechooserblock_to_emailsignup'
+        ),
         ('v1', '0141_add_disclaimer_pagechooserblock_to_emailsignup')
     ]
     operations = [


### PR DESCRIPTION
The email sign-up standardization issue seems to have altered the order in which Django tries to execute migrations when they are all run. According to @chosak, this is because the migration executor tries to optimize the order of the migrations it runs. This started causing our back-end test suite in Jenkins, which runs all migrations front-to-back, to fail.

This PR should rectify that.

## Testing

1. Prior to pulling this branch, run `tox -e unittest-py27-dj111-wag113-slow` against the latest master to observe the issue.
1. Pull branch
1. Run `tox -e unittest-py27-dj111-wag113-slow` again and see that it passes.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
