### PR TITLE
Add more robust fallback for incomplete data in v1 migration 0142

### DIFF
--- a/cfgov/v1/migrations/0142_migrate_pas_link_data_to_pagechooserblock.py
+++ b/cfgov/v1/migrations/0142_migrate_pas_link_data_to_pagechooserblock.py
@@ -15,6 +15,18 @@ from v1.util.util import get_page_from_path
 
 
 def forward_mapper(page_or_revision, data):
+    # Set the default disclaimer_page_id, which corresponds to
+    # the Generic Email Sign-Up Privacy Act Statement.
+    disclaimer_page_id = 1189
+    data['disclaimer_page'] = disclaimer_page_id
+
+    if not data.get('form_field'):
+        return data
+    elif not data['form_field']:
+        return data
+    elif not data['form_field'][0].get('info'):
+        return data
+
     old_disclaimer = data['form_field'][0]['info']
 
     # First look to see if there is an internal Wagtail link in the field.
@@ -24,7 +36,7 @@ def forward_mapper(page_or_revision, data):
     if match:
         # If there was a match for the internal link regex, set page_id to the
         # value of the link's id attribute.
-        page_id = int(match.group(1))
+        disclaimer_page_id = int(match.group(1))
     else:
         # If there was not an internal link, look for an "external" link (a
         # link where the path or full URL was entered by hand).
@@ -33,29 +45,21 @@ def forward_mapper(page_or_revision, data):
 
         if match:
             # If there was a match for the internal link regex, get the page
-            # that corresponds to the path and set page_id to its pk
+            # that corresponds to the path and set disclaimer_page_id to its pk
             # value of the link's id attribute.
             path = urlparse(match.group(1)).path
             page = get_page_from_path(path)
 
             if page:
-                page_id = page.pk
-            else:
-                # If the path doesn't actually point to a page in Wagtail,
-                # fall back on the Generic Email Sign-Up Privacy Act Statement
-                page_id = 1189  # Generic Email Sign-Up Privacy Act Statement
-        else:
-            # Fall back on the Generic Email Sign-Up Privacy Act Statement if
-            # no link was found in the disclaimer field.
-            page_id = 1189
+                disclaimer_page_id = page.pk
 
-    if page_id == 558 or page_id == 571:
+    if disclaimer_page_id == 558 or disclaimer_page_id == 571:
         # Convert links to /privacy/privacy-policy/ and
         # /privacy/website-privacy-policy/ to the
         # Generic Email Sign-Up Privacy Act Statement
-        page_id = 1189
+        disclaimer_page_id = 1189
 
-    data['disclaimer_page'] = page_id
+    data['disclaimer_page'] = disclaimer_page_id
 
     return data
 

--- a/cfgov/v1/migrations/0142_migrate_pas_link_data_to_pagechooserblock.py
+++ b/cfgov/v1/migrations/0142_migrate_pas_link_data_to_pagechooserblock.py
@@ -22,8 +22,6 @@ def forward_mapper(page_or_revision, data):
 
     if not data.get('form_field'):
         return data
-    elif not data['form_field']:
-        return data
     elif not data['form_field'][0].get('info'):
         return data
 

--- a/cfgov/v1/tests/migrations/test_0142_migrate_pas_link_data_to_pagechooserblock.py
+++ b/cfgov/v1/tests/migrations/test_0142_migrate_pas_link_data_to_pagechooserblock.py
@@ -138,6 +138,87 @@ class TestMigration0142(TestCase):
             }]
         })
 
+    def test_forward_mapper_no_info_gets_generic(self):
+        data = {
+            'text': u'Our email newsletter has tips and info to help you ...',
+            'gd_code': u'USCFPB_127',
+            'heading': u'Buying a home?',
+            'form_field': [{
+                'inline_info': True,
+                'required': True,
+                'label': u'Email address',
+                'btn_text': u'Sign up',
+                'placeholder': u'example@mail.com',
+                'type': u'email'
+            }],
+            'default_heading': False
+        }
+
+        migrated = self.migration.forward_mapper(
+            'unused param',
+            data
+        )
+
+        self.assertEqual(migrated, {
+            'heading': u'Buying a home?',
+            'default_heading': False,
+            'text': u'Our email newsletter has tips and info to help you ...',
+            'gd_code': u'USCFPB_127',
+            'disclaimer_page': 1189,
+            'form_field': [{
+                'type': u'email',
+                'inline_info': True,
+                'btn_text': u'Sign up',
+                'label': u'Email address',
+                'required': True,
+                'placeholder': u'example@mail.com'
+            }]
+        })
+
+    def test_forward_mapper_empty_form_field_gets_generic(self):
+        data = {
+            'text': u'Our email newsletter has tips and info to help you ...',
+            'gd_code': u'USCFPB_127',
+            'heading': u'Buying a home?',
+            'form_field': [],
+            'default_heading': False
+        }
+
+        migrated = self.migration.forward_mapper(
+            'unused param',
+            data
+        )
+
+        self.assertEqual(migrated, {
+            'heading': u'Buying a home?',
+            'default_heading': False,
+            'text': u'Our email newsletter has tips and info to help you ...',
+            'gd_code': u'USCFPB_127',
+            'disclaimer_page': 1189,
+            'form_field': []
+        })
+
+    def test_forward_mapper_no_form_field_gets_generic(self):
+        data = {
+            'text': u'Our email newsletter has tips and info to help you ...',
+            'gd_code': u'USCFPB_127',
+            'heading': u'Buying a home?',
+            'default_heading': False
+        }
+
+        migrated = self.migration.forward_mapper(
+            'unused param',
+            data
+        )
+
+        self.assertEqual(migrated, {
+            'heading': u'Buying a home?',
+            'default_heading': False,
+            'text': u'Our email newsletter has tips and info to help you ...',
+            'gd_code': u'USCFPB_127',
+            'disclaimer_page': 1189,
+        })
+
     def test_forward_mapper_wrong_generic_links_get_correct_generic_link(self):
         self.maxDiff = None
 


### PR DESCRIPTION
This should fix the deployments to Build.

1. Pull branch
1. `./refresh-data.sh` to reapply the migrations to last night's database dump and confirm all still works
1. `tox -e fast v1.tests.migrations.test_0142_migrate_pas_link_data_to_pagechooserblock` to confirm that the migration will work for any possible state of `form_field`.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [x] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
