### PR TITLE
Fix missing YouTube video preview images

### DIFF
--- a/cfgov/unprocessed/js/modules/VideoPlayer.js
+++ b/cfgov/unprocessed/js/modules/VideoPlayer.js
@@ -40,8 +40,9 @@ function VideoPlayer( element, options ) {
   _this = this;
   options = options || {};
   this.baseElement = _ensureElement( element, options.createIFrame );
+  const baseDataset = assign( {}, this.baseElement.dataset );
   this.iFrameProperties = assign(
-    this.baseElement.dataset,
+    baseDataset,
     this.iFrameProperties
   );
 

--- a/cfgov/unprocessed/js/modules/VideoPlayer.js
+++ b/cfgov/unprocessed/js/modules/VideoPlayer.js
@@ -40,9 +40,9 @@ function VideoPlayer( element, options ) {
   _this = this;
   options = options || {};
   this.baseElement = _ensureElement( element, options.createIFrame );
-  const baseDataset = assign( {}, this.baseElement.dataset );
   this.iFrameProperties = assign(
-    baseDataset,
+    {},
+    this.baseElement.dataset,
     this.iFrameProperties
   );
 


### PR DESCRIPTION
This PR addresses https://GHE/CFGOV/platform/issues/3287, which reports that YouTube videos are no longer showing their correct preview images, but instead are all showing the fallback CFPB logo.

I traced the cause back to [this change](https://github.com/cfpb/cfgov-refresh/commit/50170057f0fc808d2b6aebc9984b9650d378af31#diff-75e5fea40be00a78d02194824cce179aR44). As noted by [our `assign` util's JSDoc description](https://github.com/cfpb/cfgov-refresh/blob/fix-youtube-thumbnails/cfgov/unprocessed/js/modules/util/assign.js#L17-L19), "fields of every next source will override same named fields of previous sources", so by removing the placeholder `dataSet` variable that was in place prior to that change, the `id` of `this.iFrameProperties` was replacing the `id` in `this.baseElement.dataset`, and thus in the `data-id` attribute of the `baseElement` markup, which is in turn used to generate the URL for the preview image.

## Changes

- Fix `VideoPlayer` JS so that it no longer accidentally overwrites data attributes on `baseElement`

## Testing

1. Load up any page with a video (like http://localhost:8000/prepaid-rule/) and see that it shows the CFPB logo, not a proper image preview
1. Pull branch
1. `gulp scripts`
1. Reload the page and see the thumbnail now appears

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [x] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [x] Chrome on desktop
- [x] Firefox
- [x] Safari on macOS
- [x] Edge
- [x] Internet Explorer ~~9, 10, and~~ 11
- [x] Safari on iOS
- [x] Chrome on Android
