### PR TITLE
Run the Python 3.6 tests in Travis and tox by default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,6 @@ dist: trusty
 git:
   depth: 10
 
-python:
-  - "2.7"
-
 services:
   - postgresql
 
@@ -51,10 +48,17 @@ jobs:
     - stage: Run Tests
       env: RUNTEST=frontend
       if: type = pull_request
+      python: 2.7
     - env:
         - RUNTEST=backend
         - TEST_RUNNER=cfgov.test.StdoutCapturingTestRunner
       if: type = pull_request
+      python: 2.7
+    - env:
+        - RUNTEST=backend3
+        - TEST_RUNNER=cfgov.test.StdoutCapturingTestRunner
+      if: type = pull_request
+      python: 3.6
     - stage: Docs Deploy
       if: type != pull_request
       env: RUNTEST=docs

--- a/docs/python-unit-tests.md
+++ b/docs/python-unit-tests.md
@@ -18,10 +18,11 @@ make sure you are in the cfgov-refresh root and then run:
 tox
 ```
 
-This will run linting tests and unit tests with migrations. This is the same as running:
+This will run linting tests and unit tests with migrations in both Python 2.7 and Python 3.6. 
+This is the same as running:
 
 ```sh
-tox -e lint -e unittest-py27-dj111-wag113-slow
+tox -e lint -e unittest-py27-dj111-wag113-slow -e unittest-py36-dj111-wag113-slow
 ```
 
 By default this uses a local SQLite database for tests. To override this, you
@@ -32,13 +33,14 @@ If you haven't changed any Python dependencies and you don't need to test
 all migrations, you can run a much faster Python code test using:
 
 ```sh
-tox -e fast
-```
+# Python 2.7
+tox -e unittest-py27-dj111-wag113-fast
 
-To test against Python 3 without migrations:
-
-```sh
+# Python 3.6
 tox -e unittest-py36-dj111-wag113-fast
+
+# Both
+tox -e unittest-py27-dj111-wag113-fast -e unittest-py36-dj111-wag113-fast
 ```
 
 If you would like to run only a specific test, or the tests for a specific app, 

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 skipsdist=True
 tox_pip_extensions_ext_venv_update=True
 # Run these envs when tox is invoked without -e
-envlist=lint-py{27}, unittest-py{27}-dj{111}-wag{113}-slow
+envlist=lint-py{27}, unittest-py{27,36}-dj{111}-wag{113}-slow
 
 
 [testenv]

--- a/travis_install.sh
+++ b/travis_install.sh
@@ -21,6 +21,8 @@ if [ "$RUNTEST" == "frontend" ]; then
     backend
 elif [ "$RUNTEST" == "backend" ]; then
     backend
+elif [ "$RUNTEST" == "backend3" ]; then
+    backend
 elif [ "$RUNTEST" == "docs" ]; then
     docs
 fi

--- a/travis_run.sh
+++ b/travis_run.sh
@@ -13,8 +13,11 @@ if [ "$RUNTEST" == "frontend" ]; then
 elif [ "$RUNTEST" == "backend" ]; then
     tox -e lint
     tox -e missing-migrations
-    tox -e fast
+    tox -e unittest-py27-dj111-wag113-fast
     bash <(curl -s https://codecov.io/bash) -F backend
+elif [ "$RUNTEST" == "backend3" ]; then
+    tox -e lint-py36
+    tox -e unittest-py36-dj111-wag113-fast
 elif [ "$RUNTEST" == "docs" ]; then
     mkdocs build
 fi


### PR DESCRIPTION
This PR ensures that we're running all our tests that have been made to pass with Python 3.6 in Travis with every PR. As we make more tests compatible with Python 3.6, we'll add them. This is to ensure we don't backslide on any of the Python 3.6 compatibility work we've already done.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: