### PR TITLE
Make the data_research tests compatible with Python 3.6

### DIFF
--- a/cfgov/data_research/forms.py
+++ b/cfgov/data_research/forms.py
@@ -138,7 +138,7 @@ class ConferenceRegistrationForm(forms.Form):
             govdelivery_code=self.govdelivery_code
         )
 
-        return len(attendees.in_person()) >= self.capacity
+        return len(list(attendees.in_person())) >= self.capacity
 
     def save(self, commit=True):
         registration = ConferenceRegistration(

--- a/cfgov/data_research/mortgage_utilities/s3_utils.py
+++ b/cfgov/data_research/mortgage_utilities/s3_utils.py
@@ -1,7 +1,7 @@
 from __future__ import unicode_literals
 
 import datetime
-import StringIO
+from six import BytesIO
 
 from django.conf import settings
 
@@ -22,7 +22,7 @@ S3_SOURCE_FILE = 'latest_county_delinquency.csv'
 
 def read_in_s3_csv(url):
     response = requests.get(url)
-    f = StringIO.StringIO(response.content)
+    f = BytesIO(response.content)
     reader = unicodecsv.DictReader(f)
     return reader
 

--- a/cfgov/data_research/research_conference.py
+++ b/cfgov/data_research/research_conference.py
@@ -58,7 +58,7 @@ class ConferenceExporter(object):
             capacity=0
         )
 
-        return ['created'] + form.fields.keys()
+        return ['created'] + list(form.fields.keys())
 
     def save_xlsx(self, filename):
         with open(filename, 'wb') as f:
@@ -103,8 +103,8 @@ class ConferenceNotifier(object):
         exporter = ConferenceExporter(govdelivery_code)
 
         self.count = exporter.registrants.count()
-        self.count_in_person = len(exporter.registrants.in_person())
-        self.count_virtual = len(exporter.registrants.virtual())
+        self.count_in_person = len(list(exporter.registrants.in_person()))
+        self.count_virtual = len(list(exporter.registrants.virtual()))
         self.capacity = capacity
 
         if self.count:

--- a/cfgov/data_research/scripts/export_public_csvs.py
+++ b/cfgov/data_research/scripts/export_public_csvs.py
@@ -2,7 +2,7 @@ from __future__ import unicode_literals
 
 import datetime
 import logging
-from cStringIO import StringIO
+from six import BytesIO
 
 import unicodecsv
 from dateutil import parser
@@ -158,7 +158,7 @@ def export_downloadable_csv(geo_type, late_value):
         geo_type, LATE_VALUE_TITLE[late_value], thru_month)
     _map = geo_dict.get(geo_type)
     fips_list = _map['fips_list']
-    csvfile = StringIO()
+    csvfile = BytesIO()
     writer = unicodecsv.writer(csvfile)
     writer.writerow(_map['headings'] + date_list)
     nation_starter = [NATION_STARTER[heading]

--- a/cfgov/data_research/tests/test_scripts.py
+++ b/cfgov/data_research/tests/test_scripts.py
@@ -1,8 +1,8 @@
 from __future__ import unicode_literals
 
 import datetime
-import StringIO
 import unittest
+from six import BytesIO
 
 import django
 
@@ -89,7 +89,7 @@ class SourceToTableTest(django.test.TestCase):
 
     def test_dump_as_csv(self):
         m = mock_open()
-        with patch('__builtin__.open', m, create=True):
+        with patch('six.moves.builtins.open', m, create=True):
             dump_as_csv([self.data_row], '/tmp/mp_countydata')
         self.assertEqual(m.call_count, 1)
 
@@ -181,8 +181,9 @@ class DataLoadIntegrityTest(django.test.TestCase):
             valid=True)
 
         # real values from a base CSV row
-        self.data_header = 'date,fips,open,current,thirty,sixty,ninety,other\n'
-        self.data_row = '09/01/16,12081,1952,1905,21,5,10,11\n'
+        self.data_header = (b'date,fips,open,current,thirty,sixty,ninety,'
+                            b'other\n')
+        self.data_row = b'09/01/16,12081,1952,1905,21,5,10,11\n'
         self.data_row_dict = {'date': '09/01/16',
                               'fips': '12081',
                               'open': '1952',
@@ -203,7 +204,7 @@ class DataLoadIntegrityTest(django.test.TestCase):
         and that the object's calculated API values are correct.
         """
 
-        f = StringIO.StringIO(self.data_header + self.data_row)
+        f = BytesIO(self.data_header + self.data_row)
         reader = unicodecsv.DictReader(f)
         mock_read_csv.return_value = reader
         load_values()

--- a/cfgov/data_research/tests/test_views.py
+++ b/cfgov/data_research/tests/test_views.py
@@ -164,7 +164,7 @@ class TimeseriesViewTests(django.test.TestCase):
                 'data_research_api_metadata',
                 kwargs={'meta_name': 'xxx'}))
         self.assertEqual(response.status_code, 200)
-        self.assertIn('No metadata object found.', response.content)
+        self.assertContains(response, 'No metadata object found.')
 
     def test_national_timeseries_30_89(self):
         response = self.client.get(
@@ -219,7 +219,7 @@ class TimeseriesViewTests(django.test.TestCase):
                 kwargs={'fips': '16220',
                         'days_late': '90'}))
         self.assertEqual(response.status_code, 200)
-        self.assertIn('not valid', response.content)
+        self.assertContains(response, 'not valid')
 
     def test_non_msa_timeseries_30_89(self):
         response = self.client.get(
@@ -260,7 +260,7 @@ class TimeseriesViewTests(django.test.TestCase):
                 kwargs={'fips': '99999',
                         'days_late': '90'}))
         self.assertEqual(response.status_code, 200)
-        self.assertIn('FIPS code not found', response.content)
+        self.assertContains(response, 'FIPS code not found')
 
     def test_map_data_bad_date(self):
         response = self.client.get(
@@ -270,7 +270,7 @@ class TimeseriesViewTests(django.test.TestCase):
                         'days_late': '90',
                         'year_month': '0000-01'}))
         self.assertEqual(response.status_code, 200)
-        self.assertIn('Invalid year-month pair', response.content)
+        self.assertContains(response, 'Invalid year-month pair')
 
     def test_map_data_disallowed_delinquency_digit(self):
         with self.assertRaises(NoReverseMatch):
@@ -287,21 +287,21 @@ class TimeseriesViewTests(django.test.TestCase):
                     'days_late': '38-89',
                     'year_month': '2008-01'}))
         self.assertEqual(response.status_code, 200)
-        self.assertIn('Unknown delinquency range', response.content)
+        self.assertContains(response, 'Unknown delinquency range')
 
     def test_timeseries_disallowed_delinquency_range(self):
         response = self.client.get(reverse(
             'data_research_api_mortgage_timeseries',
             kwargs={'fips': '12081', 'days_late': '38-89'}))
         self.assertEqual(response.status_code, 200)
-        self.assertIn('Unknown delinquency range', response.content)
+        self.assertContains(response, 'Unknown delinquency range')
 
     def test_national_timeseries_disallowed_delinquency_range(self):
         response = self.client.get(reverse(
             'data_research_api_mortgage_timeseries_national',
             kwargs={'days_late': '38-89'}))
         self.assertEqual(response.status_code, 200)
-        self.assertIn('Unknown delinquency range', response.content)
+        self.assertContains(response, 'Unknown delinquency range')
 
     def test_map_data_unknown_geo(self):
         response = self.client.get(
@@ -311,7 +311,7 @@ class TimeseriesViewTests(django.test.TestCase):
                         'days_late': '90',
                         'year_month': '2008-01'}))
         self.assertEqual(response.status_code, 200)
-        self.assertIn('Unkown geographic unit', response.content)
+        self.assertContains(response, 'Unkown geographic unit')
 
     def test_county_map_data_30_89(self):
         response = self.client.get(
@@ -416,4 +416,4 @@ class TimeseriesViewTests(django.test.TestCase):
                 'data_research_api_mortgage_timeseries',
                 kwargs={'fips': '12081', 'days_late': '90'}))
         self.assertEqual(response.status_code, 200)
-        self.assertIn('County is below display threshold', response.content)
+        self.assertContains(response, 'County is below display threshold')


### PR DESCRIPTION
This PR makes it possible to run the `data_research` app's tests with Python 3.6. And, as a result, it starts nibbling around the edges of `v1`. 

## Testing

1. Run `tox -e unittest-py36-dj111-wag113-fast data_research`

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: