### PR TITLE
Make the housing_counselor tests comptaible with Python 3.6

### DIFF
--- a/cfgov/housing_counselor/tests/test_views.py
+++ b/cfgov/housing_counselor/tests/test_views.py
@@ -32,8 +32,10 @@ class HousingCounselorViewTestCase(TestCase):
         self.assertNotIn('zipcode_valid', response.context_data)
         self.assertNotIn('api_json', response.context_data)
         self.assertNotIn('pdf_url', response.context_data)
-        self.assertIn(HousingCounselorView.invalid_zip_msg['error_message'],
-                      response.content)
+        self.assertContains(
+            response,
+            HousingCounselorView.invalid_zip_msg['error_message'],
+        )
 
     @mock.patch('housing_counselor.views.HousingCounselorView.get_counselors')
     def test_get_counselors_failed_s3_request(self, mock_get_counselors):
@@ -42,8 +44,10 @@ class HousingCounselorViewTestCase(TestCase):
         self.assertNotIn('zipcode_valid', response.context_data)
         self.assertNotIn('api_json', response.context_data)
         self.assertNotIn('pdf_url', response.context_data)
-        self.assertIn(HousingCounselorView.failed_fetch_msg['error_message'],
-                      response.content)
+        self.assertContains(
+            response,
+            HousingCounselorView.failed_fetch_msg['error_message']
+        )
 
     @mock.patch('housing_counselor.views.HousingCounselorView.get_counselors')
     def test_get_counselors_invalid_zipcode(self, mock_get_counselors):


### PR DESCRIPTION
This PR makes it possible to run the `data_research` app's tests with Python 3.6. And, as a result, it starts nibbling around the edges of `v1`. 

## Testing

1. Run `tox -e unittest-py36-dj111-wag113-fast housing_counselor`

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
