### PR TITLE
Add symlinked requirements files that Snyk.io can pick up

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,4 +1,0 @@
-# This file's purpose is to be checked for vulnerabilities by Snyk,
-# which requires a file named requirements.txt
-
--r deployment.txt

--- a/requirements/snyk/README.md
+++ b/requirements/snyk/README.md
@@ -1,0 +1,12 @@
+# Requirements files for Snyk
+
+The files in the subdirectories of this one are symlinks back to the original
+requirements files in the main `requirements/` directory
+(this directory's parent).
+They are needed for the current version of the Snyk.io service
+to be able to check the requirements, since (as of March 6, 2019) it
+can only check files named exactly `requirements.txt` and it
+cannot follow `-r` references to other requirements files.
+
+[This symlink-based setup was suggested by a Snyk maintainer](https://github.com/snyk/snyk-python-plugin/issues/21#issuecomment-463514410)
+as a workaround until they add those features to their service.

--- a/requirements/snyk/django/requirements.txt
+++ b/requirements/snyk/django/requirements.txt
@@ -1,0 +1,1 @@
+../django.txt

--- a/requirements/snyk/django/requirements.txt
+++ b/requirements/snyk/django/requirements.txt
@@ -1,1 +1,1 @@
-../django.txt
+../../django.txt

--- a/requirements/snyk/libraries/requirements.txt
+++ b/requirements/snyk/libraries/requirements.txt
@@ -1,0 +1,1 @@
+../libraries.txt

--- a/requirements/snyk/libraries/requirements.txt
+++ b/requirements/snyk/libraries/requirements.txt
@@ -1,1 +1,1 @@
-../libraries.txt
+../../libraries.txt

--- a/requirements/snyk/postgres/requirements.txt
+++ b/requirements/snyk/postgres/requirements.txt
@@ -1,1 +1,1 @@
-../postgres.txt
+../../postgres.txt

--- a/requirements/snyk/postgres/requirements.txt
+++ b/requirements/snyk/postgres/requirements.txt
@@ -1,0 +1,1 @@
+../postgres.txt

--- a/requirements/snyk/wagtail/requirements.txt
+++ b/requirements/snyk/wagtail/requirements.txt
@@ -1,1 +1,1 @@
-../wagtail.txt
+../../wagtail.txt

--- a/requirements/snyk/wagtail/requirements.txt
+++ b/requirements/snyk/wagtail/requirements.txt
@@ -1,0 +1,1 @@
+../wagtail.txt


### PR DESCRIPTION
As discussed in https://GHE/CFGOV/platform/issues/3289, this implements [the workaround suggested by the Snyk VP of Engineering](https://github.com/snyk/snyk-python-plugin/issues/21#issuecomment-463514410) for monitoring Python requirements files: creating symlinks that link back to the original requirements files.

The files in the subdirectories of the `requirements/snyk/` directory are symlinks back to the original requirements files in the main `requirements/` directory. They are needed for the current version of the Snyk.io service to be able to check the requirements, since (as of today) it
can only check files named exactly `requirements.txt` and it cannot follow `-r` references to other requirements files.


## Additions

- Four symlinked `requirements.txt` files for our production Python dependencies that can be read by the Snyk.io GitHub integration

## Removals

- The previous attempt to use a single `requirements.txt` file with `-r` references in it.

## Testing

1. Merge this and add the new files to the cfgov-refresh setup in Snyk.io

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [x] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
