### PR TITLE
Use standard feedback module

### DIFF
--- a/cfgov/ask_cfpb/models/__init__.py
+++ b/cfgov/ask_cfpb/models/__init__.py
@@ -1,7 +1,7 @@
 # flake8: noqa F401
 from ask_cfpb.models.django import (
     ENGLISH_PARENT_SLUG, SPANISH_PARENT_SLUG, Answer, Audience, Category,
-    NextStep, SubCategory, generate_short_slug, get_feedback_stream_value
+    NextStep, SubCategory, generate_short_slug
 )
 from ask_cfpb.models.pages import (
     ABOUT_US_SNIPPET_TITLE, CONSUMER_TOOLS_PORTAL_PAGES,

--- a/cfgov/ask_cfpb/models/django.py
+++ b/cfgov/ask_cfpb/models/django.py
@@ -21,30 +21,6 @@ ENGLISH_PARENT_SLUG = 'ask-cfpb'
 SPANISH_PARENT_SLUG = 'obtener-respuestas'
 
 
-def get_feedback_stream_value(page):
-    """Delivers a basic feedback module with yes/no buttons and comment box"""
-    translation_text = {
-        'helpful': {'es': '¿Fue útil esta respuesta?',
-                    'en': 'Was this page helpful to you?'},
-        'button': {'es': 'Enviar',
-                   'en': 'Submit'}
-    }
-    stream_value = [
-        {'type': 'feedback',
-         'value': {
-             'was_it_helpful_text': translation_text['helpful'][page.language],
-             'button_text': translation_text['button'][page.language],
-             'intro_text': '',
-             'question_text': '',
-             'radio_intro': '',
-             'radio_text': ('This information helps us '
-                            'understand your question better.'),
-             'radio_question_1': 'How soon do you expect to buy a home?',
-             'radio_question_2': 'Do you currently own a home?',
-             'contact_advisory': ''}}]
-    return stream_value
-
-
 def generate_short_slug(slug_string):
     """Limits a slug to around 100 characters, using full words"""
     if len(slug_string) < 100:

--- a/cfgov/ask_cfpb/models/pages.py
+++ b/cfgov/ask_cfpb/models/pages.py
@@ -16,7 +16,6 @@ from wagtail.wagtailadmin.edit_handlers import (
 )
 from wagtail.wagtailcore.fields import RichTextField, StreamField
 from wagtail.wagtailcore.models import Page
-from wagtail.wagtailimages.edit_handlers import ImageChooserPanel
 from wagtail.wagtailsearch import index
 from wagtail.wagtailsnippets.edit_handlers import SnippetChooserPanel
 
@@ -594,6 +593,7 @@ class AnswerPage(CFGOVPage):
             heading="Metadata",
             classname="collapsible"),
         AutocompletePanel('redirect_to_page', page_type='ask_cfpb.AnswerPage'),
+        StreamFieldPanel('content'),
     ]
 
     sidebar = StreamField([

--- a/cfgov/jinja2/v1/_includes/blocks/feedback.html
+++ b/cfgov/jinja2/v1/_includes/blocks/feedback.html
@@ -7,17 +7,17 @@
 {# JS-disabled result handling #}
 
 <div class="o-feedback block">
-	<form method="post"
-	      action="."
-	      class="o-form
-	      		 {% if value.was_it_helpful_text %}
-	      		 block
-		         block__bg
-		       	 block__border
-		       	 block__padded-top
-	       		 {% endif %}"
-	      novalidate>
-	<div class="u-mb15">
+  <form method="post"
+        action="."
+        class="o-form
+             {% if value.was_it_helpful_text %}
+             block
+             block__bg
+             block__border
+             block__padded-top
+             {% endif %}"
+        novalidate>
+  <div class="u-mb15">
         {% if get_messages(request) %}
         {% for message in get_messages(request) %}
             {{ notification.render(message.tags.split(' ')[0], true, message.message) }}
@@ -94,7 +94,7 @@
             </label>
             <p class="u-mb15"><small><em>
                 {% if page.language == 'es' %}
-                    Nota: No incluya información confidencial, como su nombre, información de contacto, número de cuenta o número de seguro social en este campo.
+                    No incluya información confidencial, como su nombre, información de contacto, número de cuenta o número de seguro social en este campo.
                 {% else %}
                     Please do not share any personally identifiable information (PII), including, but not limited to: your name, address, phone number, email address, Social Security number, account information, or any other information of a sensitive nature.
                 {% endif %}
@@ -190,7 +190,7 @@
     </div>
     {% endif %}
 
-    <button class="a-btn" type="submit">{{ value.button_text }}</button>
+    <button class="a-btn" type="submit">{% if page.language == 'es' %}Enviar{% else %}{{ value.button_text }}{% endif %}</button>
   </form>
 </div>
 {% endmacro %}


### PR DESCRIPTION
With a tweak to the v1 feedback template, we can use the
standard feedback module without any customization.

Current pages will pick up the content changes in the
v1 feedback forms.

For new pages, editors will need to add a feedback module, but they
won't have to change any values.

Code coverage is back to 100%!