### PR TITLE
Fix missing else block in FCM logic

### DIFF
--- a/cfgov/jinja2/v1/sublanding-page/index.html
+++ b/cfgov/jinja2/v1/sublanding-page/index.html
@@ -32,7 +32,7 @@
         {% elif 'featured_content' in block.block_type %}
             <div class="block
                         block__border
-                        {{ 'u-mt0' if loop.first }}">
+                        {{ 'u-mt0' if loop.first else '' }}">
                         {# u-mt0 is used instead of block__flush-top to keep top border #}
                 {% include_block block %}
             </div>


### PR DESCRIPTION
FCM contained an if statement without an else block, which led to this error in markup if the FCM was not the first component on the page:
<img width="634" alt="screen shot 2019-03-07 at 10 22 41 am" src="https://user-images.githubusercontent.com/704760/53968493-28473100-40c5-11e9-972c-d62fee15ca33.png">

## Changes

- Adds else block to FCM if statement.

## Testing

1. Add a sublanding page and add a FCM and any component before it.
2. Preview the page and inspect the markup and see that there is no error message in the markup for the FCM's container.
