### PR TITLE
Fix email popup close buttons

### DIFF
--- a/cfgov/jinja2/v1/_includes/organisms/email-popup/base.html
+++ b/cfgov/jinja2/v1/_includes/organisms/email-popup/base.html
@@ -20,58 +20,60 @@
 
 {% set form_id = get_unique_id() %}
 
-{# The .o-email-signup class below is necessary for the form to be properly
-   initialized by on-demand/email-signup.js.
-
-   An EmailSignup component is, in turn, required to be present elsewhere on
-   the page, so that on-demand/email-signup.js will be included and run. #}
-<div class="o-email-popup o-email-signup"
+<div class="o-email-popup"
      data-popup-label="{{ popup_label }}"
      lang="{{ popup_language }}">
-    <div class="o-email-popup_header u-clearfix">
-        <div class="close">
-            <button class="a-btn a-btn__link">Close {{ svg_icon('delete') }}</button>
+    {# The .o-email-signup class below is necessary for the form to be properly
+       initialized by on-demand/email-signup.js.
+
+       An EmailSignup component is, in turn, required to be present elsewhere on
+       the page, so that on-demand/email-signup.js will be included and run. #}
+    <div class="o-email-signup">
+        <div class="o-email-popup_header u-clearfix">
+            <div class="close">
+                <button class="a-btn a-btn__link">Close {{ svg_icon('delete') }}</button>
+            </div>
         </div>
-    </div>
 
-    <div class="o-email-popup_body"
-         style="background-image: url('{{ static(popup_image) }}')">
-        <h2>{{ popup_headline }}</h2>
-        <p>{{ popup_content }}</p>
-        <form class="o-form o-form__email-signup u-clearfix"
-              id="{{ 'o-email-signup_' ~ form_id }}"
-              method="POST"
-              action="{{ url('govdelivery') }}"
-              enctype="application/x-www-form-urlencoded"
-              novalidate>
-            <div class="m-form-field">
-                <label class="u-visually-hidden" for="{{ 'email_' ~ form_id }}">
-                    Email address
-                </label>
-                <input class="a-text-input a-text-input__full"
-                       id="{{ 'email_' ~ form_id }}"
-                       name="email"
-                       type="email"
-                       placeholder="Enter your email address"
-                       required>
-            </div>
+        <div class="o-email-popup_body"
+             style="background-image: url('{{ static(popup_image) }}')">
+            <h2>{{ popup_headline }}</h2>
+            <p>{{ popup_content }}</p>
+            <form class="o-form o-form__email-signup u-clearfix"
+                  id="{{ 'o-email-signup_' ~ form_id }}"
+                  method="POST"
+                  action="{{ url('govdelivery') }}"
+                  enctype="application/x-www-form-urlencoded"
+                  novalidate>
+                <div class="m-form-field">
+                    <label class="u-visually-hidden" for="{{ 'email_' ~ form_id }}">
+                        Email address
+                    </label>
+                    <input class="a-text-input a-text-input__full"
+                           id="{{ 'email_' ~ form_id }}"
+                           name="email"
+                           type="email"
+                           placeholder="Enter your email address"
+                           required>
+                </div>
 
-            <div class="m-btn-group">
-                <button class="a-btn a-btn__full-on-xs">Sign up</button>
-                <a class="a-btn a-btn__link a-btn__secondary"
-                   href="{{ privacy_link_url }}"
-                   target="_blank"
-                   rel="noopener noreferrer">
-                    See Privacy Act statement
-                </a>
-            </div>
+                <div class="m-btn-group">
+                    <button class="a-btn a-btn__full-on-xs">Sign up</button>
+                    <a class="a-btn a-btn__link a-btn__secondary"
+                       href="{{ privacy_link_url }}"
+                       target="_blank"
+                       rel="noopener noreferrer">
+                        See Privacy Act statement
+                    </a>
+                </div>
 
-            <input type="hidden" name="code" value="{{ mailing_list_code }}">
-        </form>
-    </div>
+                <input type="hidden" name="code" value="{{ mailing_list_code }}">
+            </form>
+        </div>
 
-    <div class="o-email-popup_footer">
-        {% import 'molecules/notification.html' as notification with context %}
-        {{ notification.render('default', false, '') }}
+        <div class="o-email-popup_footer">
+            {% import 'molecules/notification.html' as notification with context %}
+            {{ notification.render('default', false, '') }}
+        </div>
     </div>
 </div>


### PR DESCRIPTION
Fixes the bug that I recently introduced that prevented the close button on email popups from working.

## Changes

- Restores the separation of `.o-email-signup` and `.o-email-popup` DOM nodes so that their components' JS does not try to initialize on the same node

## Testing

1. Load a page with the email popup on it, e.g., http://localhost:8000/owning-a-home/
   - You may need to erase your local storage for localhost to get the popup to appear, if you've previously seen it.
1. Scroll down to reveal the popup
1. Observe the close button not working
1. Pull branch
1. Clear local storage and refresh the page
1. Scroll down to reveal the popup
1. Observe that the close button now works

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [x] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [x] Chrome on desktop
- [x] Firefox
- [x] Safari on macOS
- [x] Edge
- [x] Internet Explorer 9, 10, and 11
- [x] Safari on iOS
- [x] Chrome on Android