### PR TITLE
Regulations3k: Make draft version permission depend on model permissions not pages

### DIFF
--- a/cfgov/regulations3k/models/pages.py
+++ b/cfgov/regulations3k/models/pages.py
@@ -251,8 +251,10 @@ class RegulationPage(RoutablePageMixin, SecondaryNavigationJSMixin, CFGOVPage):
         )
 
         if effective_version.draft:
-            page_perms = self.permissions_for_user(request.user)
-            if not page_perms.can_edit():
+            perms = request.user.get_all_permissions()
+
+            if (not request.user.is_superuser and
+               'regulations3k.change_section' not in perms):
                 raise PermissionDenied
 
         return effective_version


### PR DESCRIPTION
To view draft versions of a regulation using our "View Draft" button, we had been requiring permission to edit the regulation's routable page in Wagtail. The way we configure permissions for regulations editors however is not to give them permission to the Wagtail pages, but just the regulation models.

This PR changes the "View Draft" permission to depend on section edit permission, rather than page edit permission.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
