### PR TITLE
Fix missing preview images on 50/50-style filterable lists

### DIFF
--- a/cfgov/jinja2/v1/_includes/organisms/filterable-list.html
+++ b/cfgov/jinja2/v1/_includes/organisms/filterable-list.html
@@ -150,9 +150,6 @@
                             <div class="content-l_col
                                         content-l_col-1-2">
                                 {% set post_url = pageurl(post) %}
-                                {% if post.preview_image %}
-                                    {% set photo = image(post.preview_image, 'original') %}
-                                {% endif %}
                                 {% set heading = '<a href="' ~ post_url ~ '"><h2 class="h3">' ~
                                                 post.preview_title ~
                                                 '</h2></a>'
@@ -171,9 +168,9 @@
                                 {% endif %}
                                 {{ info_unit( {
                                     'image': {
-                                        'url': photo.url if photo else '/',
+                                        'upload': post.preview_image,
                                         'alt': post.preview_image.alt if post.preview_image.alt else '',
-                                    },
+                                    } if post.preview_image else {},
                                     'heading': heading,
                                     'sub_heading': sub_heading,
                                     'body': post.preview_description,


### PR DESCRIPTION
Preview images in 50/50-style filterable lists unfortunately got lost in the shuffle when we broke out the controls template from the list template. This PR fixes that problem.

## Changes

- Corrects the image data being passed to the info unit template by the filterable list template

## Testing

1. Load up http://localhost:8000/consumer-tools/everyone-has-a-story/ and see no images
1. Pull branch
1. Reload the page and see empty space where the images would appear, if they were uploaded to your local Wagtail instance
   - If you want to double-check things, you can upload a new preview image (on the Configuration tab) to one of the listed stories, then reload the list page and see that it appears.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [x] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
