### PR TITLE
Update migration script so that it's working off of latest revision

### DIFF
--- a/cfgov/ask_cfpb/scripts/answer_to_answerpage_migration.py
+++ b/cfgov/ask_cfpb/scripts/answer_to_answerpage_migration.py
@@ -72,10 +72,9 @@ def run():
             for related_question in page.answer_base.related_questions.all():
                 page.related_questions.add(related_question.english_page)
 
-        # Save & unpublish the draft page
+        # Save & publish our changes
+        page.save_revision(user=user).publish()
+
+        # Unpublish pages that were originally draft only
         if draft:
-            page.save_revision(user=user)
             page.unpublish()
-        # Save & re-publish 'live' and 'live + draft' pages
-        else:
-            page.save_revision(user=user).publish()

--- a/cfgov/ask_cfpb/scripts/replace_unsupported_characters.py
+++ b/cfgov/ask_cfpb/scripts/replace_unsupported_characters.py
@@ -3,31 +3,49 @@ from __future__ import unicode_literals
 from ask_cfpb.models.pages import AnswerPage
 
 
-unsupported = ['\x92', '\x93', '\x94', '\x96']
+unsupported = [
+    '\x91', '\x92', '\x93',
+    '\x94', '\x95', '\x96',
+    '\x97', '\x98', '\x99',
+    '\xac', '\u200b', '\u25e6',
+    '\u25cb', '\uf0a7',
+]
+
+# A dictionary for swapping misencodings with valid unicode code points
+unicode_swaps = {
+    '\x91': '\u2018',  # Left Single Quotation Mark
+    '\x92': '\u2019',  # Right Single Quotation Mark
+    '\x93': '\u201C',  # Left Double Quotation Mark
+    '\x94': '\u201D',  # Right Double Quotation Mark
+    '\x95': '\u2022',  # Bullet
+    '\x96': '\u2013',  # En Dash
+    '\x97': '\u2014',  # Em Dash
+    '\x98': '\u02DC',  # Small Tilde
+    '\x99': '\u2122',  # Trade Mark Sign
+    '\xac': '-',       # Not Sign (a dash with a hook on end)
+    '\u200b': '',      # Zero Width Space (We neve want this)
+    '\u25e6': '- ',    # White Bullet
+    '\u25cb': '- ',    # White Circle
+    '\uf0a7': ' ',     # misencoding (no such code point)
+}
 
 
-def fix(text):
-    text = text.replace('\x92', "'")
-    text = text.replace('\x93', '"')
-    text = text.replace('\x94', '"')
-    text = text.replace('\x96', '-')
-    return text
+def fix(text, string):
+    return text.replace(string, unicode_swaps[string])
 
 
 def run():
-    for page in AnswerPage.objects.all():
+    for page in AnswerPage.objects.filter(live=True):
         fixed = False
-
         for string in unsupported:
             if string in page.question:
-                page.question = fix(page.question)
+                page.question = fix(page.question, string)
                 fixed = True
             if string in page.answer:
-                page.answer = fix(page.answer)
+                page.answer = fix(page.answer, string)
                 fixed = True
             if string in page.snippet:
-                page.snippet = fix(page.snippet)
+                page.snippet = fix(page.snippet, string)
                 fixed = True
-
         if fixed:
             page.save_revision().publish()


### PR DESCRIPTION
Currently, the script is skipping any draft revisions that exist, since by default querying for a page gives back the live version.  This fixes that. 

I've included an updated sanitization script as well.