### PR TITLE
Add link to Credit Card Agremeents for Q3 2018

### DIFF
--- a/cfgov/agreements/templates/agreements/index.html
+++ b/cfgov/agreements/templates/agreements/index.html
@@ -66,10 +66,14 @@
         for agreement submission instructions.
     </p>
 
-
     <p id="dwnld">
+        <a href="https://files.consumerfinance.gov/a/assets/Credit_Card_Agreements_2018_Q3.zip">
+            Download all most recent agreements (Q3-2018)
+        </a>
+    </p>
+    <p>
         <a href="https://files.consumerfinance.gov/a/assets/Credit_Card_Agreements_2018_Q2.zip">
-            Download all most recent agreements (Q2-2018)
+            Archived Q2-2018 agreements
         </a>
     </p>
      <p>


### PR DESCRIPTION
This PR adds a link to the 2018 Q3 credit card agreements zip as the most recent and relegates 2018 Q2 to archived status.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
