### PR TITLE
Fixes typo in docs

### DIFF
--- a/docs/wagtail-pages.md
+++ b/docs/wagtail-pages.md
@@ -192,7 +192,7 @@ This is done by overriding the `template` attribute on the page model.
 For example, the [interactive regulations landing page](https://github.com/cfpb/cfgov-refresh/blob/master/cfgov/regulations3k/models/pages.py) 
 includes a customized list of recently issued notices that gets loaded dynamically from the Federal Register. 
 To do this it provides its own template that inherits from our base templates 
-and overrides the `content_sidebar` block to include a seperate `recent_notices` template:
+and overrides the `content_sidebar` block to include a separate `recent_notices` template:
 
 ```python
 from v1.models import CFGOVPage


### PR DESCRIPTION
Should be "separate" not "seperate".

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [X] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [X] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: