### PR TITLE
Rename format variable in housing counselor view

### DIFF
--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -322,7 +322,8 @@ STATIC_VERSION = ''
 
 MAPBOX_ACCESS_TOKEN = os.environ.get('MAPBOX_ACCESS_TOKEN')
 HOUSING_COUNSELOR_S3_PATH_TEMPLATE = (
-    'https://files.consumerfinance.gov/a/assets/hud/{format}s/{zipcode}.{format}'
+    'https://files.consumerfinance.gov'
+    '/a/assets/hud/{file_format}s/{zipcode}.{file_format}'
 )
 
 

--- a/cfgov/housing_counselor/views.py
+++ b/cfgov/housing_counselor/views.py
@@ -39,20 +39,20 @@ def requests_retry_session(
 class HousingCounselorS3URLMixin(object):
 
     @staticmethod
-    def s3_url(format, zipcode):
+    def s3_url(file_format, zipcode):
         path = settings.HOUSING_COUNSELOR_S3_PATH_TEMPLATE.format(
-            format=format,
+            file_format=file_format,
             zipcode=zipcode
         )
         return path
 
     @classmethod
     def s3_json_url(cls, zipcode):
-        return cls.s3_url(format='json', zipcode=zipcode)
+        return cls.s3_url(file_format='json', zipcode=zipcode)
 
     @classmethod
     def s3_pdf_url(cls, zipcode):
-        return cls.s3_url(format='pdf', zipcode=zipcode)
+        return cls.s3_url(file_format='pdf', zipcode=zipcode)
 
 
 class HousingCounselorView(TemplateView, HousingCounselorS3URLMixin):


### PR DESCRIPTION
Python contains a built-in [`format`](https://docs.python.org/3/library/functions.html#format) function:

```
>>> format(123, "06d")
'000123'
```

The use of `format` as a variable in [this method](https://github.com/cfpb/cfgov-refresh/blob/0b3986ca025eb2fe32d6f24057d9c2df94381f58/cfgov/housing_counselor/views.py#L42) confuses our static code analysis tool (Checkmarx) because of this. This commit changes that variable to something more specific, `file_format`.

## Testing

To test, visit [a housing counselor URL](http://localhost:8000/find-a-housing-counselor/?zipcode=22203) locally and confirm that the data continues to load properly. Also confirm that the "Save list as PDF" link continues to work properly.

## Notes

Thanks to Lamin for flagging this.

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [X] Passes all existing automated tests
- [X] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [X] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [X] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: