### PR TITLE
Update headers on hardcoded BAH email signups

### DIFF
--- a/cfgov/jinja2/v1/_includes/organisms/email-popup/oah.html
+++ b/cfgov/jinja2/v1/_includes/organisms/email-popup/oah.html
@@ -2,6 +2,6 @@
 {% set mailing_list_code = "USCFPB_128" %}
 {% set popup_language = "en" %}
 {% set popup_content = "Sign up for our 2-week Get Homebuyer Ready boot camp. We’ll take you step-by-step through the entire homebuying process." %}
-{% set popup_headline = "Buying a home?" %}
+{% set popup_headline = "Buying a house?" %}
 {% set popup_image = "img/modal-house.png" %}
 {% set privacy_link_url = "/owning-a-home/privacy-act-statement/" %}

--- a/cfgov/jinja2/v1/owning-a-home/_templates/brand-footer.html
+++ b/cfgov/jinja2/v1/owning-a-home/_templates/brand-footer.html
@@ -38,7 +38,7 @@
         {% endfor %}
         <div class="brand-footer_container brand-footer_container-{{ links | length + 1 }}">
             {% set value = {
-                'heading': 'Buying a home?',
+                'heading': 'Buying a house?',
                 'default_heading': True,
                 'text': 'Sign up for our 2-week Get Homebuyer Ready boot camp. We’ll take you step-by-step through the entire homebuying process.',
                 'gd_code': 'USCFPB_127',


### PR DESCRIPTION
Making these headers consistent with the other updated sign-up modules.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [x] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
