### PR TITLE
Add richtext filter for answer page snippet

### DIFF
--- a/cfgov/jinja2/v1/ask-cfpb/answer-page.html
+++ b/cfgov/jinja2/v1/ask-cfpb/answer-page.html
@@ -58,7 +58,7 @@
                 <strong>
                     Answer:
                 </strong>
-                {{ page.snippet | safe }}
+                {{ page.snippet | richtext | safe }}
             </h3>
         {% endif %}
         <div data-qa-hook="expandable"


### PR DESCRIPTION
Some of the answer page snippets have internal links which aren't being output correctly

## Additions

- richtext filter on answer snippet in answer page template


## Testing

1. Check out branch
2. Navigate to [answer 1931](http://localhost:8000/admin/pages/5992/edit/)
3. Verify that link in snippet is output correctly


## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [ ] Chrome on desktop
- [ ] Firefox
- [ ] Safari on macOS
- [ ] Edge
- [ ] Internet Explorer 9, 10, and 11
- [ ] Safari on iOS
- [ ] Chrome on Android

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
