### PR TITLE
Remove deprecated URL from smoke tests

### DIFF
--- a/cfgov/scripts/http_smoke_test.py
+++ b/cfgov/scripts/http_smoke_test.py
@@ -111,7 +111,6 @@ FULL_RUN = [
     '/about-us/careers/',
     '/about-us/careers/current-openings/',
     '/about-us/doing-business-with-us/',
-    '/about-us/advisory-groups/',
     '/about-us/innovation/',
     '/about-us/contact-us/',
     '/eregulations/',
@@ -179,7 +178,6 @@ SHORT_RUN = [
     # '/about-us/careers/',
     '/about-us/careers/current-openings/',
     # '/about-us/doing-business-with-us/',
-    # '/about-us/advisory-groups/',
     # '/about-us/innovation/',
     # '/about-us/contact-us/',
 ]


### PR DESCRIPTION
The page https://www.consumerfinance.gov/about-us/advisory-groups/
no longer exists, which causes the smoke tests to fail when run with `--full` option.

To test, run this command from within a cf.gov Python environment:

```sh
$ python cfgov/scripts/http_smoke_test.py --base https://www.consumerfinance.gov --full -v
```

It will fail on master because of this page, but pass with the change proposed here.

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [X] Passes all existing automated tests
- [X] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [X] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: