### PR TITLE
Fix broken filter usage in Python 3

### DIFF
--- a/cfgov/v1/models/menu_item.py
+++ b/cfgov/v1/models/menu_item.py
@@ -89,8 +89,11 @@ class MenuItem(models.Model):
         and structure it for display in menu template.
         """
         cols = [getattr(self, 'column_' + str(i)) for i in range(1, 5)]
-        self.nav_groups = filter(None, [self.get_active_block(col, draft)
-                                        for col in cols])
+
+        self.nav_groups = list(filter(
+            None,
+            [self.get_active_block(col, draft) for col in cols]
+        ))
         self.featured_content = self.nav_groups.pop() if len(self.nav_groups) \
             and self.nav_groups[-1].block_type == 'featured_content' else None
         footer = self.get_active_block(self.nav_footer, draft)


### PR DESCRIPTION
This minor change fixes some (untested) logic in the MenuItem class that assumes that filter() returns a list, which it does in Python 2, but not in Python 3.

This change allows us to load the site in a local Django server running Python 3!

## Testing

Set up a cfgov-refresh virtual environment using Python 3. Try running the local server and load the home page. It'll fail on master, but work on this branch.

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [X] Passes all existing automated tests
- [X] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [X] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [X] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: