### PR TITLE
Fix beta banner by marking notification safe

### DIFF
--- a/cfgov/jinja2/v1/_includes/organisms/header.html
+++ b/cfgov/jinja2/v1/_includes/organisms/header.html
@@ -28,7 +28,7 @@
                 'This beta site is a work in progress.',
                 'We’re prototyping new designs. Things may not work as expected.
                 Our regular site continues to be at
-                <a href="https://www.consumerfinance.gov/">www.consumerfinance.gov</a>.'
+                <a href="https://www.consumerfinance.gov/">www.consumerfinance.gov</a>.' | safe
             ) }}
         </div>
     </div>


### PR DESCRIPTION
This commit fixes a problem with the beta notification banner where the link to the real site shows up as HTML tags instead of as a proper link. This was caused by the change in #4879 that removed a `|safe` tag from the notification module.

To fix this, we just apply `|safe` directly to the string being passed to the notification.

To test, run this locally and confirm that the banner looks correct on this branch but wrong on master:

```sh
$ DEPLOY_ENVIRONMENT=beta ./runserver.sh
```

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [X] Passes all existing automated tests
- [X] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [X] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [X] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: