### PR TITLE
Mortgage performance processing pipeline improvements

### DIFF
--- a/cfgov/data_research/mortgage_utilities/s3_utils.py
+++ b/cfgov/data_research/mortgage_utilities/s3_utils.py
@@ -13,7 +13,7 @@ import unicodecsv
 # bake_to_s3 functions require S3 secrets to be stored in the env
 BASE_BUCKET = settings.AWS_STORAGE_BUCKET_NAME
 MORTGAGE_SUB_BUCKET = "data/mortgage-performance"
-PUBLIC_ACCESS_BASE = 'https://{}/{}'.format(
+PUBLIC_ACCESS_BASE = 'https://s3.amazonaws.com/{}/{}'.format(
     BASE_BUCKET, MORTGAGE_SUB_BUCKET)
 S3_MORTGAGE_DOWNLOADS_BASE = '{}/downloads'.format(PUBLIC_ACCESS_BASE)
 S3_SOURCE_BUCKET = '{}/source'.format(PUBLIC_ACCESS_BASE)

--- a/cfgov/data_research/scripts/process_mortgage_data.py
+++ b/cfgov/data_research/scripts/process_mortgage_data.py
@@ -41,7 +41,7 @@ def dump_as_csv(rows_out, dump_slug):
     Sample output row:
     1,01001,2008-01-01,268,260,4,1,0,3,2891
     """
-    with open('{}.csv'.format(dump_slug), 'w') as f:
+    with open('{}.csv'.format(dump_slug), 'wb') as f:
         writer = unicodecsv.writer(f)
         for row in rows_out:
             writer.writerow(row)

--- a/cfgov/data_research/scripts/process_mortgage_data.py
+++ b/cfgov/data_research/scripts/process_mortgage_data.py
@@ -106,21 +106,23 @@ def process_source(
                     (datetime.datetime.now() - starter),
                     len(new_objects)))
     if dump_slug:
-        rows = []
-        for obj in new_objects:
-            rows.append([
-                obj.pk,
-                obj.fips,
-                "{}".format(obj.date),
-                obj.total,
-                obj.current,
-                obj.thirty,
-                obj.sixty,
-                obj.ninety,
-                obj.other,
-                county.pk
-            ])
-        dump_as_csv(rows, dump_slug)
+        dump_as_csv(
+            (
+                (
+                    obj.pk,
+                    obj.fips,
+                    "{}".format(obj.date),
+                    obj.total,
+                    obj.current,
+                    obj.thirty,
+                    obj.sixty,
+                    obj.ninety,
+                    obj.other,
+                    obj.county.pk,
+                ) for obj in new_objects
+            ),
+            dump_slug
+        )
 
 
 def run(*args):

--- a/cfgov/data_research/tests/test_scripts.py
+++ b/cfgov/data_research/tests/test_scripts.py
@@ -10,7 +10,6 @@ import django
 import mock
 import unicodecsv
 from dateutil import parser
-from mock import mock_open, patch
 from model_mommy import mommy
 
 from data_research.models import (

--- a/cfgov/data_research/tests/test_scripts.py
+++ b/cfgov/data_research/tests/test_scripts.py
@@ -1,6 +1,7 @@
 from __future__ import unicode_literals
 
 import datetime
+import tempfile
 import unittest
 from six import BytesIO
 
@@ -88,10 +89,12 @@ class SourceToTableTest(django.test.TestCase):
             new_date)
 
     def test_dump_as_csv(self):
-        m = mock_open()
-        with patch('six.moves.builtins.open', m, create=True):
-            dump_as_csv([self.data_row], '/tmp/mp_countydata')
-        self.assertEqual(m.call_count, 1)
+        with tempfile.NamedTemporaryFile(suffix='.csv') as f:
+            # dump_as_csv appends .csv to the destination file.
+            dump_as_csv([self.data_row], f.name[:-4])
+
+            content = open(f.name).read()
+            self.assertEqual(content.strip(), ','.join(self.data_row))
 
     @mock.patch('data_research.scripts.process_mortgage_data.'
                 'read_in_s3_csv')


### PR DESCRIPTION
As part of reviewing #4866, I tried running the process_mortgage_data script under Python 3, both to verify that it still works properly but also to educate myself on how it works. I found a couple of minor issues that I've opened this PR to address. See specific commits for more details on what was changed.

## Testing

For the record, I used this command to test:

```sh
$ cfgov/manage.py runscript process_mortgage_data --script-args 2018-09-01 /tmp/mp_countydata
```

Note that you should make sure that your `AWS_STORAGE_BUCKET_NAME` environment variable is **not** pointing to the production S3 bucket when running this! One of the changes in this PR makes it possible to run this script against an alternate bucket. You'll also need to set the appropriate S3 credentials in your environment as well.

Interestingly, this script is significantly faster on Python 3 than 2 for me.

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [X] Passes all existing automated tests
- [X] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [X] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [X] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: