### PR TITLE
Pass answer id to Ask answer page template

### DIFF
--- a/cfgov/ask_cfpb/models/pages.py
+++ b/cfgov/ask_cfpb/models/pages.py
@@ -627,6 +627,7 @@ class AnswerPage(CFGOVPage):
         context['related_questions'] = self.related_questions.all()
         context['description'] = self.snippet if self.snippet \
             else Truncator(self.answer).words(40, truncate=' ...')
+        context['answer_id'] = self.answer_base.id
         if self.language == 'es':
             context['search_tags'] = self.clean_search_tags
             context['tweet_text'] = Truncator(self.question).chars(


### PR DESCRIPTION
## Additions
- add `answer_id` to answer page context 

## Testing

1. Check out branch
2. Navigate to [English](http://localhost:8000/ask-cfpb/what-was-the-national-mortgage-settlement-en-2071/) or [Spanish](http://localhost:8000/es/obtener-respuestas/que-es-el-acuerdo-hipotecario-nacional-es-2071/) answer page
3. View page source and verify that `data-answer-id` value is populated on `analytics-data`div


## Screenshots

### Production

<img width="341" alt="Screen Shot 2019-03-20 at 10 38 01 AM" src="https://user-images.githubusercontent.com/778171/54711336-ef687c80-4b06-11e9-99d8-f3dccf995e0a.png">


### Local
<img width="298" alt="Screen Shot 2019-03-20 at 10 38 35 AM" src="https://user-images.githubusercontent.com/778171/54711053-46ba1d00-4b06-11e9-9cec-dc376755fbfe.png">

## Notes
- this data is passed to analytics in a virtual pageview event