### PR TITLE
Regs3k: Serve draft regulation versions on the Wagtail-Sharing site

### DIFF
--- a/cfgov/regulations3k/jinja2/regulations3k/browse-regulation.html
+++ b/cfgov/regulations3k/jinja2/regulations3k/browse-regulation.html
@@ -111,6 +111,8 @@
 
                 {% if version.effective_date == page.regulation.effective_version.effective_date %}
                 (current regulation)
+                {% elif version.draft %}
+                (draft)
                 {% endif %}
             </li>
         {% endfor %}

--- a/cfgov/v1/tests/test_wagtail_hooks.py
+++ b/cfgov/v1/tests/test_wagtail_hooks.py
@@ -1,5 +1,5 @@
 from django.core.cache import caches
-from django.test import SimpleTestCase, TestCase, override_settings
+from django.test import RequestFactory, SimpleTestCase, TestCase, override_settings
 
 from wagtail.tests.testapp.models import SimplePage
 from wagtail.tests.utils import WagtailTestUtils
@@ -12,7 +12,8 @@ from v1.models.base import CFGOVPage
 from v1.models.menu_item import MenuItem
 from v1.models.resources import Resource
 from v1.wagtail_hooks import (
-    check_permissions, form_module_handlers, get_resource_tags
+    check_permissions, form_module_handlers, get_resource_tags,
+    set_served_by_wagtail_sharing
 )
 
 
@@ -290,3 +291,14 @@ class TestWhitelistOverride(SimpleTestCase):
         '''
         output_html = DbWhitelister.clean(input_html)
         self.assertHTMLEqual(input_html, output_html)
+
+
+class TestSetServedByWagtailSharing(TestCase):
+
+    def setUp(self):
+        self.factory = RequestFactory()
+
+    def test_set_served_by_wagtail_sharing(self):
+        request = self.factory.get('/an-url')
+        set_served_by_wagtail_sharing(None, request, [], {})
+        self.assertTrue(request.served_by_wagtail_sharing)

--- a/cfgov/v1/tests/test_wagtail_hooks.py
+++ b/cfgov/v1/tests/test_wagtail_hooks.py
@@ -1,5 +1,7 @@
 from django.core.cache import caches
-from django.test import RequestFactory, SimpleTestCase, TestCase, override_settings
+from django.test import (
+    RequestFactory, SimpleTestCase, TestCase, override_settings
+)
 
 from wagtail.tests.testapp.models import SimplePage
 from wagtail.tests.utils import WagtailTestUtils

--- a/cfgov/v1/wagtail_hooks.py
+++ b/cfgov/v1/wagtail_hooks.py
@@ -282,3 +282,8 @@ def whitelister_element_rules():
                     'col', 'colgroup']
 
     return {tag: allow_html_class for tag in allowed_tags}
+
+
+@hooks.register('before_serve_shared_page')
+def set_served_by_wagtail_sharing(page, request, args, kwargs):
+    setattr(request, 'served_by_wagtail_sharing', True)


### PR DESCRIPTION
This PR does two things:

- Adds a `served_by_wagtail_sharing` attribute to the `request` object when the latest Wagtail revision is being served by Wagtail-Sharing. This means all Wagtail requests on the sharing site have this attribute.
- Uses that attribute to serve draft regulation content on the Wagtail-Sharing site. 

Previously, draft content was only visible to superusers and users with edit permissions on regulation sections. This lets anyone browse draft regulation content on the sharing site like any other draft wagtail content. 

## Testing

Compare http://localhost:8000/policy-compliance/rulemaking/regulations/1002/ and http://content.localhost:8000/policy-compliance/rulemaking/regulations/1002/. There should be three additional draft versions available in addition to the live version when viewing the second link (the default local sharing site).

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
