### PR TITLE
Update portal-tag-migration to handle multiple topics

### DIFF
--- a/cfgov/ask_cfpb/fixtures/auto_loans.json
+++ b/cfgov/ask_cfpb/fixtures/auto_loans.json
@@ -1,814 +1,904 @@
 [
     {
+        "topics": [
+            1
+        ], 
         "ask_id": "2057", 
-        "see_all_ids": [
+        "categories": [
+            1, 
             2, 
-            4, 
-            1
+            4
         ], 
-        "portal_ids": [
-            1
-        ]
+        "primary_topic": 1
     }, 
     {
+        "topics": [
+            1
+        ], 
         "ask_id": "2047", 
-        "see_all_ids": [
+        "categories": [
             1, 
             2
         ], 
-        "portal_ids": [
-            1
-        ]
+        "primary_topic": 1
     }, 
     {
+        "topics": [
+            1
+        ], 
         "ask_id": "2045", 
-        "see_all_ids": [
-            3, 
-            1
-        ], 
-        "portal_ids": [
-            1
-        ]
-    }, 
-    {
-        "ask_id": "1207", 
-        "see_all_ids": [
-            2, 
-            1
-        ], 
-        "portal_ids": [
-            1
-        ]
-    }, 
-    {
-        "ask_id": "1205", 
-        "see_all_ids": [
-            2, 
-            1
-        ], 
-        "portal_ids": [
-            1
-        ]
-    }, 
-    {
-        "ask_id": "1201", 
-        "see_all_ids": [
-            2, 
-            1
-        ], 
-        "portal_ids": [
-            1
-        ]
-    }, 
-    {
-        "ask_id": "1195", 
-        "see_all_ids": [
-            1, 
-            2
-        ], 
-        "portal_ids": [
-            1
-        ]
-    }, 
-    {
-        "ask_id": "1191", 
-        "see_all_ids": [
-            2, 
-            1
-        ], 
-        "portal_ids": [
-            1
-        ]
-    }, 
-    {
-        "ask_id": "1187", 
-        "see_all_ids": [
-            2
-        ], 
-        "portal_ids": [
-            1
-        ]
-    }, 
-    {
-        "ask_id": "1185", 
-        "see_all_ids": [
-            2
-        ], 
-        "portal_ids": [
-            1
-        ]
-    }, 
-    {
-        "ask_id": "1181", 
-        "see_all_ids": [
-            2, 
-            1
-        ], 
-        "portal_ids": [
-            1
-        ]
-    }, 
-    {
-        "ask_id": "1171", 
-        "see_all_ids": [
-            2, 
-            1
-        ], 
-        "portal_ids": [
-            1
-        ]
-    }, 
-    {
-        "ask_id": "897", 
-        "see_all_ids": [
-            2
-        ], 
-        "portal_ids": [
-            1
-        ]
-    }, 
-    {
-        "ask_id": "895", 
-        "see_all_ids": [
-            2, 
-            1
-        ], 
-        "portal_ids": [
-            1
-        ]
-    }, 
-    {
-        "ask_id": "893", 
-        "see_all_ids": [
-            2, 
-            1
-        ], 
-        "portal_ids": [
-            1
-        ]
-    }, 
-    {
-        "ask_id": "891", 
-        "see_all_ids": [
-            1, 
-            3, 
-            2
-        ], 
-        "portal_ids": [
-            1
-        ]
-    }, 
-    {
-        "ask_id": "889", 
-        "see_all_ids": [
-            3, 
-            1, 
-            2
-        ], 
-        "portal_ids": [
-            1
-        ]
-    }, 
-    {
-        "ask_id": "887", 
-        "see_all_ids": [
-            4, 
-            1
-        ], 
-        "portal_ids": [
-            1
-        ]
-    }, 
-    {
-        "ask_id": "873", 
-        "see_all_ids": [
-            2, 
-            1
-        ], 
-        "portal_ids": [
-            1
-        ]
-    }, 
-    {
-        "ask_id": "871", 
-        "see_all_ids": [
-            1, 
-            2
-        ], 
-        "portal_ids": [
-            1
-        ]
-    }, 
-    {
-        "ask_id": "865", 
-        "see_all_ids": [
-            1
-        ], 
-        "portal_ids": [
-            1
-        ]
-    }, 
-    {
-        "ask_id": "861", 
-        "see_all_ids": [
-            2, 
-            1
-        ], 
-        "portal_ids": [
-            1
-        ]
-    }, 
-    {
-        "ask_id": "857", 
-        "see_all_ids": [
-            1, 
-            2
-        ], 
-        "portal_ids": [
-            1
-        ]
-    }, 
-    {
-        "ask_id": "853", 
-        "see_all_ids": [
-            1
-        ], 
-        "portal_ids": [
-            1
-        ]
-    }, 
-    {
-        "ask_id": "851", 
-        "see_all_ids": [
-            1
-        ], 
-        "portal_ids": [
-            1
-        ]
-    }, 
-    {
-        "ask_id": "849", 
-        "see_all_ids": [
+        "categories": [
             1, 
             3
         ], 
-        "portal_ids": [
-            1
-        ]
+        "primary_topic": 1
     }, 
     {
-        "ask_id": "845", 
-        "see_all_ids": [
+        "topics": [
             1
         ], 
-        "portal_ids": [
-            1
-        ]
+        "ask_id": "1207", 
+        "categories": [
+            1, 
+            2
+        ], 
+        "primary_topic": 1
     }, 
     {
-        "ask_id": "843", 
-        "see_all_ids": [
+        "topics": [
             1
         ], 
-        "portal_ids": [
-            1
-        ]
+        "ask_id": "1205", 
+        "categories": [
+            1, 
+            2
+        ], 
+        "primary_topic": 1
     }, 
     {
-        "ask_id": "841", 
-        "see_all_ids": [
+        "topics": [
+            1
+        ], 
+        "ask_id": "1201", 
+        "categories": [
+            1, 
+            2
+        ], 
+        "primary_topic": 1
+    }, 
+    {
+        "topics": [
+            1
+        ], 
+        "ask_id": "1195", 
+        "categories": [
+            1, 
+            2
+        ], 
+        "primary_topic": 1
+    }, 
+    {
+        "topics": [
+            1
+        ], 
+        "ask_id": "1191", 
+        "categories": [
+            1, 
+            2
+        ], 
+        "primary_topic": 1
+    }, 
+    {
+        "topics": [
+            1
+        ], 
+        "ask_id": "1187", 
+        "categories": [
+            2
+        ], 
+        "primary_topic": 1
+    }, 
+    {
+        "topics": [
+            1
+        ], 
+        "ask_id": "1185", 
+        "categories": [
+            2
+        ], 
+        "primary_topic": 1
+    }, 
+    {
+        "topics": [
+            1
+        ], 
+        "ask_id": "1181", 
+        "categories": [
+            1, 
+            2
+        ], 
+        "primary_topic": 1
+    }, 
+    {
+        "topics": [
+            1
+        ], 
+        "ask_id": "1171", 
+        "categories": [
+            1, 
+            2
+        ], 
+        "primary_topic": 1
+    }, 
+    {
+        "topics": [
+            1
+        ], 
+        "ask_id": "897", 
+        "categories": [
+            2
+        ], 
+        "primary_topic": 1
+    }, 
+    {
+        "topics": [
+            1
+        ], 
+        "ask_id": "895", 
+        "categories": [
+            1, 
+            2
+        ], 
+        "primary_topic": 1
+    }, 
+    {
+        "topics": [
+            1, 
+            3, 
+            9
+        ], 
+        "ask_id": "893", 
+        "categories": [
+            1, 
+            2
+        ], 
+        "primary_topic": 1
+    }, 
+    {
+        "topics": [
+            1
+        ], 
+        "ask_id": "891", 
+        "categories": [
+            1, 
+            2, 
+            3
+        ], 
+        "primary_topic": 1
+    }, 
+    {
+        "topics": [
+            1
+        ], 
+        "ask_id": "889", 
+        "categories": [
+            1, 
+            2, 
+            3
+        ], 
+        "primary_topic": 1
+    }, 
+    {
+        "topics": [
+            1
+        ], 
+        "ask_id": "887", 
+        "categories": [
             1, 
             4
         ], 
-        "portal_ids": [
-            1
-        ]
+        "primary_topic": 1
     }, 
     {
+        "topics": [
+            1
+        ], 
+        "ask_id": "873", 
+        "categories": [
+            1, 
+            2
+        ], 
+        "primary_topic": 1
+    }, 
+    {
+        "topics": [
+            1
+        ], 
+        "ask_id": "871", 
+        "categories": [
+            1, 
+            2
+        ], 
+        "primary_topic": 1
+    }, 
+    {
+        "topics": [
+            1
+        ], 
+        "ask_id": "865", 
+        "categories": [
+            1
+        ], 
+        "primary_topic": 1
+    }, 
+    {
+        "topics": [
+            1
+        ], 
+        "ask_id": "861", 
+        "categories": [
+            1, 
+            2
+        ], 
+        "primary_topic": 1
+    }, 
+    {
+        "topics": [
+            1
+        ], 
+        "ask_id": "857", 
+        "categories": [
+            1, 
+            2
+        ], 
+        "primary_topic": 1
+    }, 
+    {
+        "topics": [
+            1
+        ], 
+        "ask_id": "853", 
+        "categories": [
+            1
+        ], 
+        "primary_topic": 1
+    }, 
+    {
+        "topics": [
+            1
+        ], 
+        "ask_id": "851", 
+        "categories": [
+            1
+        ], 
+        "primary_topic": 1
+    }, 
+    {
+        "topics": [
+            1
+        ], 
+        "ask_id": "849", 
+        "categories": [
+            1, 
+            3
+        ], 
+        "primary_topic": 1
+    }, 
+    {
+        "topics": [
+            1
+        ], 
+        "ask_id": "845", 
+        "categories": [
+            1
+        ], 
+        "primary_topic": 1
+    }, 
+    {
+        "topics": [
+            1
+        ], 
+        "ask_id": "843", 
+        "categories": [
+            1
+        ], 
+        "primary_topic": 1
+    }, 
+    {
+        "topics": [
+            1
+        ], 
+        "ask_id": "841", 
+        "categories": [
+            1, 
+            4
+        ], 
+        "primary_topic": 1
+    }, 
+    {
+        "topics": [
+            1
+        ], 
         "ask_id": "839", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            1
-        ]
+        "primary_topic": 1
     }, 
     {
+        "topics": [
+            1
+        ], 
         "ask_id": "837", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            1
-        ]
+        "primary_topic": 1
     }, 
     {
+        "topics": [
+            1
+        ], 
         "ask_id": "835", 
-        "see_all_ids": [
+        "categories": [
             1, 
             2, 
             3
         ], 
-        "portal_ids": [
-            1
-        ]
+        "primary_topic": 1
     }, 
     {
+        "topics": [
+            1
+        ], 
         "ask_id": "833", 
-        "see_all_ids": [
+        "categories": [
             2
         ], 
-        "portal_ids": [
-            1
-        ]
+        "primary_topic": 1
     }, 
     {
+        "topics": [
+            1
+        ], 
         "ask_id": "831", 
-        "see_all_ids": [
+        "categories": [
             1, 
             2, 
             5
         ], 
-        "portal_ids": [
-            1
-        ]
+        "primary_topic": 1
     }, 
     {
+        "topics": [
+            1
+        ], 
         "ask_id": "827", 
-        "see_all_ids": [
+        "categories": [
             4
         ], 
-        "portal_ids": [
-            1
-        ]
+        "primary_topic": 1
     }, 
     {
+        "topics": [
+            1
+        ], 
         "ask_id": "825", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            1
-        ]
+        "primary_topic": 1
     }, 
     {
+        "topics": [
+            1
+        ], 
         "ask_id": "823", 
-        "see_all_ids": [
-            2, 
-            1
+        "categories": [
+            1, 
+            2
         ], 
-        "portal_ids": [
-            1
-        ]
+        "primary_topic": 1
     }, 
     {
+        "topics": [
+            1
+        ], 
         "ask_id": "821", 
-        "see_all_ids": [
+        "categories": [
             1, 
             4
         ], 
-        "portal_ids": [
-            1
-        ]
+        "primary_topic": 1
     }, 
     {
+        "topics": [
+            1
+        ], 
         "ask_id": "819", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            1
-        ]
+        "primary_topic": 1
     }, 
     {
+        "topics": [
+            1
+        ], 
         "ask_id": "817", 
-        "see_all_ids": [
-            4, 
+        "categories": [
             1, 
-            2
+            2, 
+            4
         ], 
-        "portal_ids": [
-            1
-        ]
+        "primary_topic": 1
     }, 
     {
+        "topics": [
+            1
+        ], 
         "ask_id": "815", 
-        "see_all_ids": [
-            4, 
-            1
+        "categories": [
+            1, 
+            4
         ], 
-        "portal_ids": [
-            1
-        ]
+        "primary_topic": 1
     }, 
     {
+        "topics": [
+            1, 
+            5
+        ], 
         "ask_id": "813", 
-        "see_all_ids": [
+        "categories": [
             1, 
             2
         ], 
-        "portal_ids": [
-            1
-        ]
+        "primary_topic": 1
     }, 
     {
+        "topics": [
+            1
+        ], 
         "ask_id": "811", 
-        "see_all_ids": [
-            4, 
+        "categories": [
+            1, 
             2, 
-            1
+            4
         ], 
-        "portal_ids": [
-            1
-        ]
+        "primary_topic": 1
     }, 
     {
+        "topics": [
+            1
+        ], 
         "ask_id": "809", 
-        "see_all_ids": [
-            3, 
-            1
+        "categories": [
+            1, 
+            3
         ], 
-        "portal_ids": [
-            1
-        ]
+        "primary_topic": 1
     }, 
     {
+        "topics": [
+            1
+        ], 
         "ask_id": "807", 
-        "see_all_ids": [
-            2, 
-            1
+        "categories": [
+            1, 
+            2
         ], 
-        "portal_ids": [
-            1
-        ]
+        "primary_topic": 1
     }, 
     {
+        "topics": [
+            1
+        ], 
         "ask_id": "805", 
-        "see_all_ids": [
-            2, 
-            1
+        "categories": [
+            1, 
+            2
         ], 
-        "portal_ids": [
-            1
-        ]
+        "primary_topic": 1
     }, 
     {
+        "topics": [
+            1
+        ], 
         "ask_id": "803", 
-        "see_all_ids": [
-            4, 
-            1
+        "categories": [
+            1, 
+            4
         ], 
-        "portal_ids": [
-            1
-        ]
+        "primary_topic": 1
     }, 
     {
+        "topics": [
+            1
+        ], 
         "ask_id": "799", 
-        "see_all_ids": [
-            4, 
+        "categories": [
             1, 
-            2
+            2, 
+            4
         ], 
-        "portal_ids": [
-            1
-        ]
+        "primary_topic": 1
     }, 
     {
+        "topics": [
+            1
+        ], 
         "ask_id": "797", 
-        "see_all_ids": [
-            4, 
+        "categories": [
+            1, 
             2, 
-            1
+            4
         ], 
-        "portal_ids": [
-            1
-        ]
+        "primary_topic": 1
     }, 
     {
+        "topics": [
+            1
+        ], 
         "ask_id": "795", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            1
-        ]
+        "primary_topic": 1
     }, 
     {
+        "topics": [
+            1
+        ], 
         "ask_id": "791", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            1
-        ]
+        "primary_topic": 1
     }, 
     {
+        "topics": [
+            1
+        ], 
         "ask_id": "789", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            1
-        ]
+        "primary_topic": 1
     }, 
     {
+        "topics": [
+            1, 
+            9, 
+            13
+        ], 
         "ask_id": "787", 
-        "see_all_ids": [
+        "categories": [
+            1, 
             2, 
-            4, 
-            1
+            4
         ], 
-        "portal_ids": [
-            1
-        ]
+        "primary_topic": 1
     }, 
     {
+        "topics": [
+            1
+        ], 
         "ask_id": "785", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            1
-        ]
+        "primary_topic": 1
     }, 
     {
+        "topics": [
+            1
+        ], 
         "ask_id": "783", 
-        "see_all_ids": [
-            4, 
-            1
+        "categories": [
+            1, 
+            4
         ], 
-        "portal_ids": [
-            1
-        ]
+        "primary_topic": 1
     }, 
     {
+        "topics": [
+            1
+        ], 
         "ask_id": "781", 
-        "see_all_ids": [
+        "categories": [
             1, 
             3
         ], 
-        "portal_ids": [
-            1
-        ]
+        "primary_topic": 1
     }, 
     {
+        "topics": [
+            1
+        ], 
         "ask_id": "779", 
-        "see_all_ids": [
+        "categories": [
             1, 
             3
         ], 
-        "portal_ids": [
-            1
-        ]
+        "primary_topic": 1
     }, 
     {
+        "topics": [
+            1
+        ], 
         "ask_id": "777", 
-        "see_all_ids": [
+        "categories": [
             1, 
             3
         ], 
-        "portal_ids": [
-            1
-        ]
+        "primary_topic": 1
     }, 
     {
+        "topics": [
+            1
+        ], 
         "ask_id": "773", 
-        "see_all_ids": [
-            4, 
-            1
-        ], 
-        "portal_ids": [
-            1
-        ]
-    }, 
-    {
-        "ask_id": "771", 
-        "see_all_ids": [
-            4, 
-            1
-        ], 
-        "portal_ids": [
-            1
-        ]
-    }, 
-    {
-        "ask_id": "769", 
-        "see_all_ids": [
-            4, 
-            1
-        ], 
-        "portal_ids": [
-            1
-        ]
-    }, 
-    {
-        "ask_id": "767", 
-        "see_all_ids": [
+        "categories": [
             1, 
-            4, 
-            2
+            4
         ], 
-        "portal_ids": [
-            1
-        ]
+        "primary_topic": 1
     }, 
     {
+        "topics": [
+            1
+        ], 
+        "ask_id": "771", 
+        "categories": [
+            1, 
+            4
+        ], 
+        "primary_topic": 1
+    }, 
+    {
+        "topics": [
+            1
+        ], 
+        "ask_id": "769", 
+        "categories": [
+            1, 
+            4
+        ], 
+        "primary_topic": 1
+    }, 
+    {
+        "topics": [
+            1
+        ], 
+        "ask_id": "767", 
+        "categories": [
+            1, 
+            2, 
+            4
+        ], 
+        "primary_topic": 1
+    }, 
+    {
+        "topics": [
+            1
+        ], 
         "ask_id": "765", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            1
-        ]
+        "primary_topic": 1
     }, 
     {
+        "topics": [
+            1
+        ], 
         "ask_id": "763", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            1
-        ]
+        "primary_topic": 1
     }, 
     {
+        "topics": [
+            1
+        ], 
         "ask_id": "761", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            1
-        ]
+        "primary_topic": 1
     }, 
     {
+        "topics": [
+            1
+        ], 
         "ask_id": "759", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            1
-        ]
+        "primary_topic": 1
     }, 
     {
+        "topics": [
+            1
+        ], 
         "ask_id": "757", 
-        "see_all_ids": [
-            4, 
-            1
+        "categories": [
+            1, 
+            4
         ], 
-        "portal_ids": [
-            1
-        ]
+        "primary_topic": 1
     }, 
     {
+        "topics": [
+            1
+        ], 
         "ask_id": "755", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            1
-        ]
+        "primary_topic": 1
     }, 
     {
+        "topics": [
+            1
+        ], 
         "ask_id": "753", 
-        "see_all_ids": [
+        "categories": [
             1, 
             3
         ], 
-        "portal_ids": [
-            1
-        ]
+        "primary_topic": 1
     }, 
     {
+        "topics": [
+            1
+        ], 
         "ask_id": "751", 
-        "see_all_ids": [
-            3, 
-            1
+        "categories": [
+            1, 
+            3
         ], 
-        "portal_ids": [
-            1
-        ]
+        "primary_topic": 1
     }, 
     {
+        "topics": [
+            1
+        ], 
         "ask_id": "749", 
-        "see_all_ids": [
-            4, 
-            1
+        "categories": [
+            1, 
+            4
         ], 
-        "portal_ids": [
-            1
-        ]
+        "primary_topic": 1
     }, 
     {
+        "topics": [
+            1
+        ], 
         "ask_id": "747", 
-        "see_all_ids": [
-            4, 
-            1
+        "categories": [
+            1, 
+            4
         ], 
-        "portal_ids": [
-            1
-        ]
+        "primary_topic": 1
     }, 
     {
+        "topics": [
+            1, 
+            9, 
+            13
+        ], 
         "ask_id": "745", 
-        "see_all_ids": [
+        "categories": [
             4
         ], 
-        "portal_ids": [
-            1
-        ]
+        "primary_topic": 1
     }, 
     {
+        "topics": [
+            1
+        ], 
         "ask_id": "743", 
-        "see_all_ids": [
+        "categories": [
             4
         ], 
-        "portal_ids": [
-            1
-        ]
+        "primary_topic": 1
     }, 
     {
+        "topics": [
+            1
+        ], 
         "ask_id": "739", 
-        "see_all_ids": [
+        "categories": [
             4
         ], 
-        "portal_ids": [
-            1
-        ]
+        "primary_topic": 1
     }, 
     {
+        "topics": [
+            1
+        ], 
         "ask_id": "733", 
-        "see_all_ids": [
-            4, 
+        "categories": [
+            2, 
+            4
+        ], 
+        "primary_topic": 1
+    }, 
+    {
+        "topics": [
+            1
+        ], 
+        "ask_id": "731", 
+        "categories": [
+            4
+        ], 
+        "primary_topic": 1
+    }, 
+    {
+        "topics": [
+            1
+        ], 
+        "ask_id": "729", 
+        "categories": [
+            1, 
+            4
+        ], 
+        "primary_topic": 1
+    }, 
+    {
+        "topics": [
+            1
+        ], 
+        "ask_id": "727", 
+        "categories": [
+            1, 
+            4
+        ], 
+        "primary_topic": 1
+    }, 
+    {
+        "topics": [
+            1
+        ], 
+        "ask_id": "725", 
+        "categories": [
+            1, 
+            4
+        ], 
+        "primary_topic": 1
+    }, 
+    {
+        "topics": [
+            1
+        ], 
+        "ask_id": "723", 
+        "categories": [
+            4
+        ], 
+        "primary_topic": 1
+    }, 
+    {
+        "topics": [
+            1
+        ], 
+        "ask_id": "721", 
+        "categories": [
+            4
+        ], 
+        "primary_topic": 1
+    }, 
+    {
+        "topics": [
+            1
+        ], 
+        "ask_id": "719", 
+        "categories": [
+            1, 
             2
         ], 
-        "portal_ids": [
-            1
-        ]
-    }, 
-    {
-        "ask_id": "731", 
-        "see_all_ids": [
-            4
-        ], 
-        "portal_ids": [
-            1
-        ]
-    }, 
-    {
-        "ask_id": "729", 
-        "see_all_ids": [
-            4, 
-            1
-        ], 
-        "portal_ids": [
-            1
-        ]
-    }, 
-    {
-        "ask_id": "727", 
-        "see_all_ids": [
-            4, 
-            1
-        ], 
-        "portal_ids": [
-            1
-        ]
-    }, 
-    {
-        "ask_id": "725", 
-        "see_all_ids": [
-            4, 
-            1
-        ], 
-        "portal_ids": [
-            1
-        ]
-    }, 
-    {
-        "ask_id": "723", 
-        "see_all_ids": [
-            4
-        ], 
-        "portal_ids": [
-            1
-        ]
-    }, 
-    {
-        "ask_id": "721", 
-        "see_all_ids": [
-            4
-        ], 
-        "portal_ids": [
-            1
-        ]
-    }, 
-    {
-        "ask_id": "719", 
-        "see_all_ids": [
-            2, 
-            1
-        ], 
-        "portal_ids": [
-            1
-        ]
+        "primary_topic": 1
     }
 ]

--- a/cfgov/ask_cfpb/fixtures/bank_accounts.json
+++ b/cfgov/ask_cfpb/fixtures/bank_accounts.json
@@ -1,1153 +1,1265 @@
 [
     {
+        "topics": [
+            2
+        ], 
         "ask_id": "2086", 
-        "see_all_ids": [
-            5, 
-            2
+        "categories": [
+            2, 
+            5
         ], 
-        "portal_ids": [
-            2
-        ]
+        "primary_topic": 2
     }, 
     {
+        "topics": [
+            2
+        ], 
         "ask_id": "2035", 
-        "see_all_ids": [
-            3, 
-            2
+        "categories": [
+            2, 
+            3
         ], 
-        "portal_ids": [
-            2
-        ]
+        "primary_topic": 2
     }, 
     {
+        "topics": [
+            2
+        ], 
         "ask_id": "2025", 
-        "see_all_ids": [
-            5, 
+        "categories": [
+            2, 
             3, 
-            2
+            5
         ], 
-        "portal_ids": [
-            2
-        ]
+        "primary_topic": 2
     }, 
     {
+        "topics": [
+            2
+        ], 
         "ask_id": "2023", 
-        "see_all_ids": [
-            5, 
+        "categories": [
+            2, 
             3, 
-            2
+            5
         ], 
-        "portal_ids": [
-            2
-        ]
+        "primary_topic": 2
     }, 
     {
+        "topics": [
+            2
+        ], 
         "ask_id": "2021", 
-        "see_all_ids": [
+        "categories": [
             1, 
             2
         ], 
-        "portal_ids": [
-            2
-        ]
+        "primary_topic": 2
     }, 
     {
+        "topics": [
+            2
+        ], 
         "ask_id": "1891", 
-        "see_all_ids": [
+        "categories": [
             4
         ], 
-        "portal_ids": [
-            2
-        ]
+        "primary_topic": 2
     }, 
     {
+        "topics": [
+            2
+        ], 
         "ask_id": "1781", 
-        "see_all_ids": [
+        "categories": [
             4
         ], 
-        "portal_ids": [
-            2
-        ]
+        "primary_topic": 2
     }, 
     {
+        "topics": [
+            2
+        ], 
         "ask_id": "1779", 
-        "see_all_ids": [
+        "categories": [
             4
         ], 
-        "portal_ids": [
-            2
-        ]
+        "primary_topic": 2
     }, 
     {
+        "topics": [
+            2
+        ], 
         "ask_id": "1775", 
-        "see_all_ids": [
+        "categories": [
             4
         ], 
-        "portal_ids": [
-            2
-        ]
+        "primary_topic": 2
     }, 
     {
+        "topics": [
+            2
+        ], 
         "ask_id": "1773", 
-        "see_all_ids": [
+        "categories": [
             4
         ], 
-        "portal_ids": [
-            2
-        ]
+        "primary_topic": 2
     }, 
     {
+        "topics": [
+            2
+        ], 
         "ask_id": "1771", 
-        "see_all_ids": [
-            5, 
-            3
+        "categories": [
+            3, 
+            5
         ], 
-        "portal_ids": [
-            2
-        ]
+        "primary_topic": 2
     }, 
     {
+        "topics": [
+            2
+        ], 
         "ask_id": "1769", 
-        "see_all_ids": [
-            4, 
-            3
+        "categories": [
+            3, 
+            4
         ], 
-        "portal_ids": [
-            2
-        ]
+        "primary_topic": 2
     }, 
     {
+        "topics": [
+            2
+        ], 
         "ask_id": "1717", 
-        "see_all_ids": [
-            5, 
-            2
+        "categories": [
+            2, 
+            5
         ], 
-        "portal_ids": [
-            2
-        ]
+        "primary_topic": 2
     }, 
     {
+        "topics": [
+            2
+        ], 
         "ask_id": "1715", 
-        "see_all_ids": [
-            5, 
-            2
+        "categories": [
+            2, 
+            5
         ], 
-        "portal_ids": [
-            2
-        ]
+        "primary_topic": 2
     }, 
     {
+        "topics": [
+            2
+        ], 
         "ask_id": "1637", 
-        "see_all_ids": [
+        "categories": [
             3
         ], 
-        "portal_ids": [
-            2
-        ]
+        "primary_topic": 2
     }, 
     {
+        "topics": [
+            2
+        ], 
         "ask_id": "1159", 
-        "see_all_ids": [
+        "categories": [
             3
         ], 
-        "portal_ids": [
-            2
-        ]
+        "primary_topic": 2
     }, 
     {
+        "topics": [
+            2, 
+            5
+        ], 
         "ask_id": "1157", 
-        "see_all_ids": [
+        "categories": [
             2, 
-            5, 
-            3
+            3, 
+            5
         ], 
-        "portal_ids": [
-            2
-        ]
+        "primary_topic": 2
     }, 
     {
+        "topics": [
+            2
+        ], 
         "ask_id": "1151", 
-        "see_all_ids": [
+        "categories": [
             5
         ], 
-        "portal_ids": [
-            2
-        ]
+        "primary_topic": 2
     }, 
     {
+        "topics": [
+            2
+        ], 
         "ask_id": "1149", 
-        "see_all_ids": [
-            4, 
-            2
+        "categories": [
+            2, 
+            4
         ], 
-        "portal_ids": [
-            2
-        ]
+        "primary_topic": 2
     }, 
     {
+        "topics": [
+            2
+        ], 
         "ask_id": "1145", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            2
-        ]
+        "primary_topic": 2
     }, 
     {
+        "topics": [
+            2
+        ], 
         "ask_id": "1143", 
-        "see_all_ids": [
+        "categories": [
             5
         ], 
-        "portal_ids": [
-            2
-        ]
+        "primary_topic": 2
     }, 
     {
+        "topics": [
+            2
+        ], 
         "ask_id": "1141", 
-        "see_all_ids": [
+        "categories": [
             5
         ], 
-        "portal_ids": [
-            2
-        ]
+        "primary_topic": 2
     }, 
     {
+        "topics": [
+            2
+        ], 
         "ask_id": "1139", 
-        "see_all_ids": [
+        "categories": [
             5
         ], 
-        "portal_ids": [
-            2
-        ]
+        "primary_topic": 2
     }, 
     {
+        "topics": [
+            2
+        ], 
         "ask_id": "1137", 
-        "see_all_ids": [
+        "categories": [
             5
         ], 
-        "portal_ids": [
-            2
-        ]
+        "primary_topic": 2
     }, 
     {
+        "topics": [
+            2
+        ], 
         "ask_id": "1135", 
-        "see_all_ids": [
+        "categories": [
             5
         ], 
-        "portal_ids": [
-            2
-        ]
+        "primary_topic": 2
     }, 
     {
+        "topics": [
+            2
+        ], 
         "ask_id": "1133", 
-        "see_all_ids": [
+        "categories": [
             5
         ], 
-        "portal_ids": [
-            2
-        ]
+        "primary_topic": 2
     }, 
     {
+        "topics": [
+            2
+        ], 
         "ask_id": "1131", 
-        "see_all_ids": [], 
-        "portal_ids": [
-            2
-        ]
+        "categories": [], 
+        "primary_topic": 2
     }, 
     {
+        "topics": [
+            2
+        ], 
         "ask_id": "1129", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            2
-        ]
+        "primary_topic": 2
     }, 
     {
+        "topics": [
+            2
+        ], 
         "ask_id": "1127", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            2
-        ]
+        "primary_topic": 2
     }, 
     {
+        "topics": [
+            2
+        ], 
         "ask_id": "1125", 
-        "see_all_ids": [
+        "categories": [
             5
         ], 
-        "portal_ids": [
-            2
-        ]
+        "primary_topic": 2
     }, 
     {
+        "topics": [
+            2
+        ], 
         "ask_id": "1123", 
-        "see_all_ids": [
+        "categories": [
             5
         ], 
-        "portal_ids": [
-            2
-        ]
+        "primary_topic": 2
     }, 
     {
-        "ask_id": "1119", 
-        "see_all_ids": [], 
-        "portal_ids": [
+        "topics": [
             2
-        ]
-    }, 
-    {
+        ], 
         "ask_id": "1113", 
-        "see_all_ids": [
-            5, 
+        "categories": [
             2, 
-            3
+            3, 
+            5
         ], 
-        "portal_ids": [
-            2
-        ]
+        "primary_topic": 2
     }, 
     {
+        "topics": [
+            2
+        ], 
         "ask_id": "1111", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            2
-        ]
+        "primary_topic": 2
     }, 
     {
+        "topics": [
+            2
+        ], 
         "ask_id": "1109", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            2
-        ]
+        "primary_topic": 2
     }, 
     {
+        "topics": [
+            2
+        ], 
         "ask_id": "1107", 
-        "see_all_ids": [
+        "categories": [
             3
         ], 
-        "portal_ids": [
-            2
-        ]
+        "primary_topic": 2
     }, 
     {
+        "topics": [
+            2
+        ], 
         "ask_id": "1105", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            2
-        ]
+        "primary_topic": 2
     }, 
     {
+        "topics": [
+            2
+        ], 
         "ask_id": "1103", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            2
-        ]
+        "primary_topic": 2
     }, 
     {
+        "topics": [
+            2
+        ], 
         "ask_id": "1101", 
-        "see_all_ids": [
+        "categories": [
             5
         ], 
-        "portal_ids": [
-            2
-        ]
+        "primary_topic": 2
     }, 
     {
+        "topics": [
+            2
+        ], 
         "ask_id": "1099", 
-        "see_all_ids": [
+        "categories": [
             5
         ], 
-        "portal_ids": [
-            2
-        ]
+        "primary_topic": 2
     }, 
     {
+        "topics": [
+            2
+        ], 
         "ask_id": "1097", 
-        "see_all_ids": [
+        "categories": [
             5
         ], 
-        "portal_ids": [
-            2
-        ]
+        "primary_topic": 2
     }, 
     {
+        "topics": [
+            2
+        ], 
         "ask_id": "1095", 
-        "see_all_ids": [
+        "categories": [
             5
         ], 
-        "portal_ids": [
-            2
-        ]
+        "primary_topic": 2
     }, 
     {
+        "topics": [
+            2
+        ], 
         "ask_id": "1093", 
-        "see_all_ids": [
+        "categories": [
             5
         ], 
-        "portal_ids": [
-            2
-        ]
+        "primary_topic": 2
     }, 
     {
+        "topics": [
+            2
+        ], 
         "ask_id": "1091", 
-        "see_all_ids": [
+        "categories": [
             5
         ], 
-        "portal_ids": [
-            2
-        ]
+        "primary_topic": 2
     }, 
     {
+        "topics": [
+            2
+        ], 
         "ask_id": "1089", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            2
-        ]
+        "primary_topic": 2
     }, 
     {
+        "topics": [
+            2
+        ], 
         "ask_id": "1087", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            2
-        ]
+        "primary_topic": 2
     }, 
     {
+        "topics": [
+            2
+        ], 
         "ask_id": "1085", 
-        "see_all_ids": [
+        "categories": [
             5
         ], 
-        "portal_ids": [
-            2
-        ]
+        "primary_topic": 2
     }, 
     {
+        "topics": [
+            2
+        ], 
         "ask_id": "1083", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            2
-        ]
+        "primary_topic": 2
     }, 
     {
+        "topics": [
+            2
+        ], 
         "ask_id": "1081", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            2
-        ]
+        "primary_topic": 2
     }, 
     {
+        "topics": [
+            2
+        ], 
         "ask_id": "1079", 
-        "see_all_ids": [
+        "categories": [
             5
         ], 
-        "portal_ids": [
-            2
-        ]
+        "primary_topic": 2
     }, 
     {
+        "topics": [
+            2
+        ], 
         "ask_id": "1077", 
-        "see_all_ids": [
+        "categories": [
             5
         ], 
-        "portal_ids": [
-            2
-        ]
+        "primary_topic": 2
     }, 
     {
+        "topics": [
+            2
+        ], 
         "ask_id": "1075", 
-        "see_all_ids": [
+        "categories": [
             5
         ], 
-        "portal_ids": [
-            2
-        ]
+        "primary_topic": 2
     }, 
     {
-        "ask_id": "1069", 
-        "see_all_ids": [], 
-        "portal_ids": [
+        "topics": [
             2
-        ]
-    }, 
-    {
+        ], 
         "ask_id": "1063", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            2
-        ]
+        "primary_topic": 2
     }, 
     {
+        "topics": [
+            2
+        ], 
         "ask_id": "1061", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            2
-        ]
+        "primary_topic": 2
     }, 
     {
+        "topics": [
+            2
+        ], 
         "ask_id": "1059", 
-        "see_all_ids": [
+        "categories": [
             1, 
             5
         ], 
-        "portal_ids": [
-            2
-        ]
+        "primary_topic": 2
     }, 
     {
+        "topics": [
+            2
+        ], 
         "ask_id": "1057", 
-        "see_all_ids": [
+        "categories": [
             1, 
             5
         ], 
-        "portal_ids": [
-            2
-        ]
+        "primary_topic": 2
     }, 
     {
+        "topics": [
+            2
+        ], 
         "ask_id": "1055", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            2
-        ]
+        "primary_topic": 2
     }, 
     {
+        "topics": [
+            2
+        ], 
         "ask_id": "1053", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            2
-        ]
+        "primary_topic": 2
     }, 
     {
+        "topics": [
+            2
+        ], 
         "ask_id": "1051", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            2
-        ]
+        "primary_topic": 2
     }, 
     {
-        "ask_id": "1049", 
-        "see_all_ids": [
-            1
-        ], 
-        "portal_ids": [
-            2
-        ]
-    }, 
-    {
-        "ask_id": "1047", 
-        "see_all_ids": [
-            1
-        ], 
-        "portal_ids": [
-            2
-        ]
-    }, 
-    {
-        "ask_id": "1045", 
-        "see_all_ids": [
-            1
-        ], 
-        "portal_ids": [
-            2
-        ]
-    }, 
-    {
-        "ask_id": "1043", 
-        "see_all_ids": [
-            1, 
-            5
-        ], 
-        "portal_ids": [
-            2
-        ]
-    }, 
-    {
-        "ask_id": "1041", 
-        "see_all_ids": [
-            1
-        ], 
-        "portal_ids": [
-            2
-        ]
-    }, 
-    {
-        "ask_id": "1039", 
-        "see_all_ids": [
-            1
-        ], 
-        "portal_ids": [
-            2
-        ]
-    }, 
-    {
-        "ask_id": "1037", 
-        "see_all_ids": [
-            5, 
-            2
-        ], 
-        "portal_ids": [
-            2
-        ]
-    }, 
-    {
-        "ask_id": "1035", 
-        "see_all_ids": [
-            4
-        ], 
-        "portal_ids": [
-            2
-        ]
-    }, 
-    {
-        "ask_id": "1033", 
-        "see_all_ids": [
-            1
-        ], 
-        "portal_ids": [
-            2
-        ]
-    }, 
-    {
-        "ask_id": "1031", 
-        "see_all_ids": [
-            5, 
-            2
-        ], 
-        "portal_ids": [
-            2
-        ]
-    }, 
-    {
-        "ask_id": "1029", 
-        "see_all_ids": [
-            5, 
-            2
-        ], 
-        "portal_ids": [
-            2
-        ]
-    }, 
-    {
-        "ask_id": "1027", 
-        "see_all_ids": [
-            1
-        ], 
-        "portal_ids": [
-            2
-        ]
-    }, 
-    {
-        "ask_id": "1025", 
-        "see_all_ids": [
-            1
-        ], 
-        "portal_ids": [
-            2
-        ]
-    }, 
-    {
-        "ask_id": "1023", 
-        "see_all_ids": [
-            1, 
-            4
-        ], 
-        "portal_ids": [
-            2
-        ]
-    }, 
-    {
-        "ask_id": "1021", 
-        "see_all_ids": [
-            2
-        ], 
-        "portal_ids": [
-            2
-        ]
-    }, 
-    {
-        "ask_id": "1019", 
-        "see_all_ids": [
-            1
-        ], 
-        "portal_ids": [
-            2
-        ]
-    }, 
-    {
-        "ask_id": "1015", 
-        "see_all_ids": [
-            1
-        ], 
-        "portal_ids": [
-            2
-        ]
-    }, 
-    {
-        "ask_id": "1013", 
-        "see_all_ids": [
-            5
-        ], 
-        "portal_ids": [
-            2
-        ]
-    }, 
-    {
-        "ask_id": "1011", 
-        "see_all_ids": [
-            5, 
-            2
-        ], 
-        "portal_ids": [
-            2
-        ]
-    }, 
-    {
-        "ask_id": "1009", 
-        "see_all_ids": [
-            5, 
-            2
-        ], 
-        "portal_ids": [
-            2
-        ]
-    }, 
-    {
-        "ask_id": "1007", 
-        "see_all_ids": [
-            1
-        ], 
-        "portal_ids": [
-            2
-        ]
-    }, 
-    {
-        "ask_id": "1005", 
-        "see_all_ids": [
-            1
-        ], 
-        "portal_ids": [
-            2
-        ]
-    }, 
-    {
-        "ask_id": "985", 
-        "see_all_ids": [
-            3
-        ], 
-        "portal_ids": [
-            2
-        ]
-    }, 
-    {
-        "ask_id": "983", 
-        "see_all_ids": [
-            3
-        ], 
-        "portal_ids": [
-            2
-        ]
-    }, 
-    {
-        "ask_id": "981", 
-        "see_all_ids": [
-            1
-        ], 
-        "portal_ids": [
-            2
-        ]
-    }, 
-    {
-        "ask_id": "979", 
-        "see_all_ids": [
-            3
-        ], 
-        "portal_ids": [
-            2
-        ]
-    }, 
-    {
-        "ask_id": "977", 
-        "see_all_ids": [
-            3
-        ], 
-        "portal_ids": [
-            2
-        ]
-    }, 
-    {
-        "ask_id": "975", 
-        "see_all_ids": [
-            1, 
-            2
-        ], 
-        "portal_ids": [
-            2
-        ]
-    }, 
-    {
-        "ask_id": "973", 
-        "see_all_ids": [
-            2
-        ], 
-        "portal_ids": [
-            2
-        ]
-    }, 
-    {
-        "ask_id": "971", 
-        "see_all_ids": [
-            2
-        ], 
-        "portal_ids": [
-            2
-        ]
-    }, 
-    {
-        "ask_id": "969", 
-        "see_all_ids": [
-            2
-        ], 
-        "portal_ids": [
-            2
-        ]
-    }, 
-    {
-        "ask_id": "967", 
-        "see_all_ids": [
-            1
-        ], 
-        "portal_ids": [
-            2
-        ]
-    }, 
-    {
-        "ask_id": "965", 
-        "see_all_ids": [
-            1
-        ], 
-        "portal_ids": [
-            2
-        ]
-    }, 
-    {
-        "ask_id": "963", 
-        "see_all_ids": [
-            2
-        ], 
-        "portal_ids": [
-            2
-        ]
-    }, 
-    {
-        "ask_id": "961", 
-        "see_all_ids": [
-            2
-        ], 
-        "portal_ids": [
-            2
-        ]
-    }, 
-    {
-        "ask_id": "959", 
-        "see_all_ids": [
-            5
-        ], 
-        "portal_ids": [
-            2
-        ]
-    }, 
-    {
-        "ask_id": "957", 
-        "see_all_ids": [
-            1
-        ], 
-        "portal_ids": [
-            2
-        ]
-    }, 
-    {
-        "ask_id": "955", 
-        "see_all_ids": [
-            1
-        ], 
-        "portal_ids": [
-            2
-        ]
-    }, 
-    {
-        "ask_id": "953", 
-        "see_all_ids": [
-            1
-        ], 
-        "portal_ids": [
-            2
-        ]
-    }, 
-    {
-        "ask_id": "951", 
-        "see_all_ids": [
-            1
-        ], 
-        "portal_ids": [
-            2
-        ]
-    }, 
-    {
-        "ask_id": "949", 
-        "see_all_ids": [
-            2
-        ], 
-        "portal_ids": [
-            2
-        ]
-    }, 
-    {
-        "ask_id": "947", 
-        "see_all_ids": [
-            1
-        ], 
-        "portal_ids": [
-            2
-        ]
-    }, 
-    {
-        "ask_id": "945", 
-        "see_all_ids": [
-            1
-        ], 
-        "portal_ids": [
-            2
-        ]
-    }, 
-    {
-        "ask_id": "943", 
-        "see_all_ids": [
-            1
-        ], 
-        "portal_ids": [
-            2
-        ]
-    }, 
-    {
-        "ask_id": "941", 
-        "see_all_ids": [
-            1
-        ], 
-        "portal_ids": [
-            2
-        ]
-    }, 
-    {
-        "ask_id": "939", 
-        "see_all_ids": [
-            1
-        ], 
-        "portal_ids": [
-            2
-        ]
-    }, 
-    {
-        "ask_id": "937", 
-        "see_all_ids": [
-            5, 
-            2
-        ], 
-        "portal_ids": [
-            2
-        ]
-    }, 
-    {
-        "ask_id": "935", 
-        "see_all_ids": [
-            5
-        ], 
-        "portal_ids": [
-            2
-        ]
-    }, 
-    {
-        "ask_id": "933", 
-        "see_all_ids": [
-            1
-        ], 
-        "portal_ids": [
-            2
-        ]
-    }, 
-    {
-        "ask_id": "931", 
-        "see_all_ids": [
-            1
-        ], 
-        "portal_ids": [
-            2
-        ]
-    }, 
-    {
-        "ask_id": "929", 
-        "see_all_ids": [
+        "topics": [
             2, 
+            3
+        ], 
+        "ask_id": "1049", 
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            2
-        ]
+        "primary_topic": 2
     }, 
     {
+        "topics": [
+            2, 
+            3
+        ], 
+        "ask_id": "1047", 
+        "categories": [
+            1
+        ], 
+        "primary_topic": 2
+    }, 
+    {
+        "topics": [
+            2
+        ], 
+        "ask_id": "1045", 
+        "categories": [
+            1
+        ], 
+        "primary_topic": 2
+    }, 
+    {
+        "topics": [
+            2
+        ], 
+        "ask_id": "1043", 
+        "categories": [
+            1, 
+            5
+        ], 
+        "primary_topic": 2
+    }, 
+    {
+        "topics": [
+            2
+        ], 
+        "ask_id": "1041", 
+        "categories": [
+            1
+        ], 
+        "primary_topic": 2
+    }, 
+    {
+        "topics": [
+            2
+        ], 
+        "ask_id": "1039", 
+        "categories": [
+            1
+        ], 
+        "primary_topic": 2
+    }, 
+    {
+        "topics": [
+            2
+        ], 
+        "ask_id": "1037", 
+        "categories": [
+            2, 
+            5
+        ], 
+        "primary_topic": 2
+    }, 
+    {
+        "topics": [
+            2
+        ], 
+        "ask_id": "1035", 
+        "categories": [
+            4
+        ], 
+        "primary_topic": 2
+    }, 
+    {
+        "topics": [
+            2
+        ], 
+        "ask_id": "1033", 
+        "categories": [
+            1
+        ], 
+        "primary_topic": 2
+    }, 
+    {
+        "topics": [
+            2
+        ], 
+        "ask_id": "1031", 
+        "categories": [
+            2, 
+            5
+        ], 
+        "primary_topic": 2
+    }, 
+    {
+        "topics": [
+            2
+        ], 
+        "ask_id": "1029", 
+        "categories": [
+            2, 
+            5
+        ], 
+        "primary_topic": 2
+    }, 
+    {
+        "topics": [
+            2
+        ], 
+        "ask_id": "1027", 
+        "categories": [
+            1
+        ], 
+        "primary_topic": 2
+    }, 
+    {
+        "topics": [
+            2
+        ], 
+        "ask_id": "1025", 
+        "categories": [
+            1
+        ], 
+        "primary_topic": 2
+    }, 
+    {
+        "topics": [
+            2
+        ], 
+        "ask_id": "1023", 
+        "categories": [
+            1, 
+            4
+        ], 
+        "primary_topic": 2
+    }, 
+    {
+        "topics": [
+            2
+        ], 
+        "ask_id": "1021", 
+        "categories": [
+            2
+        ], 
+        "primary_topic": 2
+    }, 
+    {
+        "topics": [
+            2
+        ], 
+        "ask_id": "1019", 
+        "categories": [
+            1
+        ], 
+        "primary_topic": 2
+    }, 
+    {
+        "topics": [
+            2
+        ], 
+        "ask_id": "1015", 
+        "categories": [
+            1
+        ], 
+        "primary_topic": 2
+    }, 
+    {
+        "topics": [
+            2
+        ], 
+        "ask_id": "1013", 
+        "categories": [
+            5
+        ], 
+        "primary_topic": 2
+    }, 
+    {
+        "topics": [
+            2
+        ], 
+        "ask_id": "1011", 
+        "categories": [
+            2, 
+            5
+        ], 
+        "primary_topic": 2
+    }, 
+    {
+        "topics": [
+            2
+        ], 
+        "ask_id": "1009", 
+        "categories": [
+            2, 
+            5
+        ], 
+        "primary_topic": 2
+    }, 
+    {
+        "topics": [
+            2
+        ], 
+        "ask_id": "1007", 
+        "categories": [
+            1
+        ], 
+        "primary_topic": 2
+    }, 
+    {
+        "topics": [
+            2
+        ], 
+        "ask_id": "1005", 
+        "categories": [
+            1
+        ], 
+        "primary_topic": 2
+    }, 
+    {
+        "topics": [
+            2
+        ], 
+        "ask_id": "985", 
+        "categories": [
+            3
+        ], 
+        "primary_topic": 2
+    }, 
+    {
+        "topics": [
+            2
+        ], 
+        "ask_id": "983", 
+        "categories": [
+            3
+        ], 
+        "primary_topic": 2
+    }, 
+    {
+        "topics": [
+            2
+        ], 
+        "ask_id": "981", 
+        "categories": [
+            1
+        ], 
+        "primary_topic": 2
+    }, 
+    {
+        "topics": [
+            2
+        ], 
+        "ask_id": "979", 
+        "categories": [
+            3
+        ], 
+        "primary_topic": 2
+    }, 
+    {
+        "topics": [
+            2
+        ], 
+        "ask_id": "977", 
+        "categories": [
+            3
+        ], 
+        "primary_topic": 2
+    }, 
+    {
+        "topics": [
+            2
+        ], 
+        "ask_id": "975", 
+        "categories": [
+            1, 
+            2
+        ], 
+        "primary_topic": 2
+    }, 
+    {
+        "topics": [
+            2
+        ], 
+        "ask_id": "973", 
+        "categories": [
+            2
+        ], 
+        "primary_topic": 2
+    }, 
+    {
+        "topics": [
+            2
+        ], 
+        "ask_id": "971", 
+        "categories": [
+            2
+        ], 
+        "primary_topic": 2
+    }, 
+    {
+        "topics": [
+            2
+        ], 
+        "ask_id": "969", 
+        "categories": [
+            2
+        ], 
+        "primary_topic": 2
+    }, 
+    {
+        "topics": [
+            2
+        ], 
+        "ask_id": "967", 
+        "categories": [
+            1
+        ], 
+        "primary_topic": 2
+    }, 
+    {
+        "topics": [
+            2
+        ], 
+        "ask_id": "965", 
+        "categories": [
+            1
+        ], 
+        "primary_topic": 2
+    }, 
+    {
+        "topics": [
+            2
+        ], 
+        "ask_id": "963", 
+        "categories": [
+            2
+        ], 
+        "primary_topic": 2
+    }, 
+    {
+        "topics": [
+            2
+        ], 
+        "ask_id": "961", 
+        "categories": [
+            2
+        ], 
+        "primary_topic": 2
+    }, 
+    {
+        "topics": [
+            2
+        ], 
+        "ask_id": "959", 
+        "categories": [
+            5
+        ], 
+        "primary_topic": 2
+    }, 
+    {
+        "topics": [
+            2
+        ], 
+        "ask_id": "957", 
+        "categories": [
+            1
+        ], 
+        "primary_topic": 2
+    }, 
+    {
+        "topics": [
+            2
+        ], 
+        "ask_id": "955", 
+        "categories": [
+            1
+        ], 
+        "primary_topic": 2
+    }, 
+    {
+        "topics": [
+            2
+        ], 
+        "ask_id": "953", 
+        "categories": [
+            1
+        ], 
+        "primary_topic": 2
+    }, 
+    {
+        "topics": [
+            2
+        ], 
+        "ask_id": "951", 
+        "categories": [
+            1
+        ], 
+        "primary_topic": 2
+    }, 
+    {
+        "topics": [
+            2
+        ], 
+        "ask_id": "949", 
+        "categories": [
+            2
+        ], 
+        "primary_topic": 2
+    }, 
+    {
+        "topics": [
+            2
+        ], 
+        "ask_id": "947", 
+        "categories": [
+            1
+        ], 
+        "primary_topic": 2
+    }, 
+    {
+        "topics": [
+            2
+        ], 
+        "ask_id": "945", 
+        "categories": [
+            1
+        ], 
+        "primary_topic": 2
+    }, 
+    {
+        "topics": [
+            2
+        ], 
+        "ask_id": "943", 
+        "categories": [
+            1
+        ], 
+        "primary_topic": 2
+    }, 
+    {
+        "topics": [
+            2
+        ], 
+        "ask_id": "941", 
+        "categories": [
+            1
+        ], 
+        "primary_topic": 2
+    }, 
+    {
+        "topics": [
+            2
+        ], 
+        "ask_id": "939", 
+        "categories": [
+            1
+        ], 
+        "primary_topic": 2
+    }, 
+    {
+        "topics": [
+            2
+        ], 
+        "ask_id": "937", 
+        "categories": [
+            2, 
+            5
+        ], 
+        "primary_topic": 2
+    }, 
+    {
+        "topics": [
+            2
+        ], 
+        "ask_id": "935", 
+        "categories": [
+            5
+        ], 
+        "primary_topic": 2
+    }, 
+    {
+        "topics": [
+            2
+        ], 
+        "ask_id": "933", 
+        "categories": [
+            1
+        ], 
+        "primary_topic": 2
+    }, 
+    {
+        "topics": [
+            2
+        ], 
+        "ask_id": "931", 
+        "categories": [
+            1
+        ], 
+        "primary_topic": 2
+    }, 
+    {
+        "topics": [
+            2
+        ], 
+        "ask_id": "929", 
+        "categories": [
+            1, 
+            2
+        ], 
+        "primary_topic": 2
+    }, 
+    {
+        "topics": [
+            2
+        ], 
         "ask_id": "927", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            2
-        ]
+        "primary_topic": 2
     }, 
     {
+        "topics": [
+            2
+        ], 
         "ask_id": "925", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            2
-        ]
+        "primary_topic": 2
     }, 
     {
+        "topics": [
+            2
+        ], 
         "ask_id": "923", 
-        "see_all_ids": [
+        "categories": [
             1, 
             4
         ], 
-        "portal_ids": [
-            2
-        ]
+        "primary_topic": 2
     }, 
     {
+        "topics": [
+            2
+        ], 
         "ask_id": "921", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            2
-        ]
+        "primary_topic": 2
     }, 
     {
+        "topics": [
+            2
+        ], 
         "ask_id": "919", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            2
-        ]
+        "primary_topic": 2
     }, 
     {
+        "topics": [
+            2
+        ], 
         "ask_id": "917", 
-        "see_all_ids": [
+        "categories": [
             1, 
             4
         ], 
-        "portal_ids": [
-            2
-        ]
+        "primary_topic": 2
     }, 
     {
+        "topics": [
+            2
+        ], 
         "ask_id": "915", 
-        "see_all_ids": [
+        "categories": [
             1, 
             4
         ], 
-        "portal_ids": [
-            2
-        ]
+        "primary_topic": 2
     }, 
     {
+        "topics": [
+            2
+        ], 
         "ask_id": "913", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            2
-        ]
+        "primary_topic": 2
     }, 
     {
+        "topics": [
+            2
+        ], 
         "ask_id": "911", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            2
-        ]
+        "primary_topic": 2
     }, 
     {
+        "topics": [
+            2
+        ], 
         "ask_id": "909", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            2
-        ]
+        "primary_topic": 2
     }, 
     {
+        "topics": [
+            2
+        ], 
         "ask_id": "907", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            2
-        ]
+        "primary_topic": 2
     }, 
     {
+        "topics": [
+            2
+        ], 
         "ask_id": "905", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            2
-        ]
+        "primary_topic": 2
     }, 
     {
+        "topics": [
+            2
+        ], 
         "ask_id": "903", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            2
-        ]
+        "primary_topic": 2
     }, 
     {
+        "topics": [
+            2
+        ], 
         "ask_id": "901", 
-        "see_all_ids": [
+        "categories": [
             1, 
             4
         ], 
-        "portal_ids": [
-            2
-        ]
+        "primary_topic": 2
     }
 ]

--- a/cfgov/ask_cfpb/fixtures/credit_cards.json
+++ b/cfgov/ask_cfpb/fixtures/credit_cards.json
@@ -1,891 +1,992 @@
 [
     {
+        "topics": [
+            3
+        ], 
         "ask_id": "2072", 
-        "see_all_ids": [
+        "categories": [
+            1, 
+            3
+        ], 
+        "primary_topic": 3
+    }, 
+    {
+        "topics": [
             3, 
-            1
-        ], 
-        "portal_ids": [
-            3
-        ]
-    }, 
-    {
-        "ask_id": "1485", 
-        "see_all_ids": [
-            5
-        ], 
-        "portal_ids": [
-            3
-        ]
-    }, 
-    {
-        "ask_id": "2043", 
-        "see_all_ids": [], 
-        "portal_ids": [
-            3
-        ]
-    }, 
-    {
-        "ask_id": "1969", 
-        "see_all_ids": [
-            3
-        ], 
-        "portal_ids": [
-            3
-        ]
-    }, 
-    {
-        "ask_id": "1861", 
-        "see_all_ids": [
-            1
-        ], 
-        "portal_ids": [
-            3
-        ]
-    }, 
-    {
-        "ask_id": "1859", 
-        "see_all_ids": [
-            1
-        ], 
-        "portal_ids": [
-            3
-        ]
-    }, 
-    {
-        "ask_id": "1827", 
-        "see_all_ids": [
-            1
-        ], 
-        "portal_ids": [
-            3
-        ]
-    }, 
-    {
-        "ask_id": "1697", 
-        "see_all_ids": [
-            1, 
-            3
-        ], 
-        "portal_ids": [
-            3
-        ]
-    }, 
-    {
-        "ask_id": "1543", 
-        "see_all_ids": [
-            3
-        ], 
-        "portal_ids": [
-            3
-        ]
-    }, 
-    {
-        "ask_id": "1541", 
-        "see_all_ids": [
-            1
-        ], 
-        "portal_ids": [
-            3
-        ]
-    }, 
-    {
-        "ask_id": "1527", 
-        "see_all_ids": [
-            5
-        ], 
-        "portal_ids": [
-            3
-        ]
-    }, 
-    {
-        "ask_id": "1377", 
-        "see_all_ids": [
-            1
-        ], 
-        "portal_ids": [
-            3
-        ]
-    }, 
-    {
-        "ask_id": "1239", 
-        "see_all_ids": [
-            1
-        ], 
-        "portal_ids": [
-            3
-        ]
-    }, 
-    {
-        "ask_id": "328", 
-        "see_all_ids": [
-            1
-        ], 
-        "portal_ids": [
-            3
-        ]
-    }, 
-    {
-        "ask_id": "98", 
-        "see_all_ids": [], 
-        "portal_ids": [
-            3
-        ]
-    }, 
-    {
-        "ask_id": "97", 
-        "see_all_ids": [], 
-        "portal_ids": [
-            3
-        ]
-    }, 
-    {
-        "ask_id": "96", 
-        "see_all_ids": [], 
-        "portal_ids": [
-            3
-        ]
-    }, 
-    {
-        "ask_id": "95", 
-        "see_all_ids": [], 
-        "portal_ids": [
-            3
-        ]
-    }, 
-    {
-        "ask_id": "94", 
-        "see_all_ids": [], 
-        "portal_ids": [
-            3
-        ]
-    }, 
-    {
-        "ask_id": "93", 
-        "see_all_ids": [], 
-        "portal_ids": [
-            3
-        ]
-    }, 
-    {
-        "ask_id": "92", 
-        "see_all_ids": [
-            1, 
-            2
-        ], 
-        "portal_ids": [
-            3
-        ]
-    }, 
-    {
-        "ask_id": "91", 
-        "see_all_ids": [
-            1
-        ], 
-        "portal_ids": [
-            3
-        ]
-    }, 
-    {
-        "ask_id": "88", 
-        "see_all_ids": [
-            1
-        ], 
-        "portal_ids": [
-            3
-        ]
-    }, 
-    {
-        "ask_id": "87", 
-        "see_all_ids": [
-            5
-        ], 
-        "portal_ids": [
-            3
-        ]
-    }, 
-    {
-        "ask_id": "86", 
-        "see_all_ids": [
-            3
-        ], 
-        "portal_ids": [
-            3
-        ]
-    }, 
-    {
-        "ask_id": "85", 
-        "see_all_ids": [
-            5, 
-            2
-        ], 
-        "portal_ids": [
-            3
-        ]
-    }, 
-    {
-        "ask_id": "84", 
-        "see_all_ids": [
-            1, 
-            3
-        ], 
-        "portal_ids": [
-            3
-        ]
-    }, 
-    {
-        "ask_id": "83", 
-        "see_all_ids": [
-            5
-        ], 
-        "portal_ids": [
-            3
-        ]
-    }, 
-    {
-        "ask_id": "82", 
-        "see_all_ids": [
-            5
-        ], 
-        "portal_ids": [
-            3
-        ]
-    }, 
-    {
-        "ask_id": "81", 
-        "see_all_ids": [
-            1
-        ], 
-        "portal_ids": [
-            3
-        ]
-    }, 
-    {
-        "ask_id": "80", 
-        "see_all_ids": [
-            5
-        ], 
-        "portal_ids": [
-            3
-        ]
-    }, 
-    {
-        "ask_id": "79", 
-        "see_all_ids": [
-            1
-        ], 
-        "portal_ids": [
-            3
-        ]
-    }, 
-    {
-        "ask_id": "78", 
-        "see_all_ids": [
-            1
-        ], 
-        "portal_ids": [
-            3
-        ]
-    }, 
-    {
-        "ask_id": "77", 
-        "see_all_ids": [
-            1
-        ], 
-        "portal_ids": [
-            3
-        ]
-    }, 
-    {
-        "ask_id": "76", 
-        "see_all_ids": [
-            1
-        ], 
-        "portal_ids": [
-            3
-        ]
-    }, 
-    {
-        "ask_id": "75", 
-        "see_all_ids": [
-            5
-        ], 
-        "portal_ids": [
-            3
-        ]
-    }, 
-    {
-        "ask_id": "74", 
-        "see_all_ids": [
-            1
-        ], 
-        "portal_ids": [
-            3
-        ]
-    }, 
-    {
-        "ask_id": "73", 
-        "see_all_ids": [
-            1
-        ], 
-        "portal_ids": [
-            3
-        ]
-    }, 
-    {
-        "ask_id": "72", 
-        "see_all_ids": [
-            5, 
-            2, 
-            3
-        ], 
-        "portal_ids": [
-            3
-        ]
-    }, 
-    {
-        "ask_id": "71", 
-        "see_all_ids": [
-            5, 
-            2
-        ], 
-        "portal_ids": [
-            3
-        ]
-    }, 
-    {
-        "ask_id": "70", 
-        "see_all_ids": [
-            1, 
-            2
-        ], 
-        "portal_ids": [
-            3
-        ]
-    }, 
-    {
-        "ask_id": "69", 
-        "see_all_ids": [
-            1
-        ], 
-        "portal_ids": [
-            3
-        ]
-    }, 
-    {
-        "ask_id": "68", 
-        "see_all_ids": [
-            1, 
-            2, 
-            5
-        ], 
-        "portal_ids": [
-            3
-        ]
-    }, 
-    {
-        "ask_id": "67", 
-        "see_all_ids": [
-            5
-        ], 
-        "portal_ids": [
-            3
-        ]
-    }, 
-    {
-        "ask_id": "65", 
-        "see_all_ids": [
-            5
-        ], 
-        "portal_ids": [
-            3
-        ]
-    }, 
-    {
-        "ask_id": "64", 
-        "see_all_ids": [
-            1
-        ], 
-        "portal_ids": [
-            3
-        ]
-    }, 
-    {
-        "ask_id": "63", 
-        "see_all_ids": [
-            1
-        ], 
-        "portal_ids": [
-            3
-        ]
-    }, 
-    {
-        "ask_id": "62", 
-        "see_all_ids": [
-            5
-        ], 
-        "portal_ids": [
-            3
-        ]
-    }, 
-    {
-        "ask_id": "61", 
-        "see_all_ids": [
-            3
-        ], 
-        "portal_ids": [
-            3
-        ]
-    }, 
-    {
-        "ask_id": "60", 
-        "see_all_ids": [
-            1
-        ], 
-        "portal_ids": [
-            3
-        ]
-    }, 
-    {
-        "ask_id": "59", 
-        "see_all_ids": [], 
-        "portal_ids": [
-            3
-        ]
-    }, 
-    {
-        "ask_id": "58", 
-        "see_all_ids": [
-            5
-        ], 
-        "portal_ids": [
-            3
-        ]
-    }, 
-    {
-        "ask_id": "57", 
-        "see_all_ids": [
-            5
-        ], 
-        "portal_ids": [
-            3
-        ]
-    }, 
-    {
-        "ask_id": "56", 
-        "see_all_ids": [
-            1
-        ], 
-        "portal_ids": [
-            3
-        ]
-    }, 
-    {
-        "ask_id": "55", 
-        "see_all_ids": [
-            5
-        ], 
-        "portal_ids": [
-            3
-        ]
-    }, 
-    {
-        "ask_id": "54", 
-        "see_all_ids": [
-            5
-        ], 
-        "portal_ids": [
-            3
-        ]
-    }, 
-    {
-        "ask_id": "53", 
-        "see_all_ids": [
             4, 
-            1
+            5
         ], 
-        "portal_ids": [
-            3
-        ]
+        "ask_id": "1485", 
+        "categories": [
+            5
+        ], 
+        "primary_topic": 3
     }, 
     {
-        "ask_id": "52", 
-        "see_all_ids": [
-            1
-        ], 
-        "portal_ids": [
+        "topics": [
             3
-        ]
+        ], 
+        "ask_id": "2043", 
+        "categories": [], 
+        "primary_topic": 3
     }, 
     {
-        "ask_id": "51", 
-        "see_all_ids": [
-            1
-        ], 
-        "portal_ids": [
+        "topics": [
             3
-        ]
+        ], 
+        "ask_id": "1969", 
+        "categories": [
+            3
+        ], 
+        "primary_topic": 3
     }, 
     {
-        "ask_id": "50", 
-        "see_all_ids": [
+        "topics": [
+            3
+        ], 
+        "ask_id": "1861", 
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            3
-        ]
+        "primary_topic": 3
     }, 
     {
-        "ask_id": "49", 
-        "see_all_ids": [
+        "topics": [
+            3
+        ], 
+        "ask_id": "1859", 
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            3
-        ]
+        "primary_topic": 3
     }, 
     {
-        "ask_id": "48", 
-        "see_all_ids": [
+        "topics": [
+            3
+        ], 
+        "ask_id": "1827", 
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            3
-        ]
+        "primary_topic": 3
     }, 
     {
-        "ask_id": "47", 
-        "see_all_ids": [
-            1
+        "topics": [
+            3
         ], 
-        "portal_ids": [
-            3
-        ]
-    }, 
-    {
-        "ask_id": "46", 
-        "see_all_ids": [
+        "ask_id": "1697", 
+        "categories": [
             1, 
-            4
-        ], 
-        "portal_ids": [
             3
-        ]
+        ], 
+        "primary_topic": 3
     }, 
     {
-        "ask_id": "45", 
-        "see_all_ids": [
+        "topics": [
+            3
+        ], 
+        "ask_id": "1543", 
+        "categories": [
+            3
+        ], 
+        "primary_topic": 3
+    }, 
+    {
+        "topics": [
+            3
+        ], 
+        "ask_id": "1541", 
+        "categories": [
+            1
+        ], 
+        "primary_topic": 3
+    }, 
+    {
+        "topics": [
+            3
+        ], 
+        "ask_id": "1527", 
+        "categories": [
+            5
+        ], 
+        "primary_topic": 3
+    }, 
+    {
+        "topics": [
+            3
+        ], 
+        "ask_id": "1377", 
+        "categories": [
+            1
+        ], 
+        "primary_topic": 3
+    }, 
+    {
+        "topics": [
+            3
+        ], 
+        "ask_id": "1239", 
+        "categories": [
+            1
+        ], 
+        "primary_topic": 3
+    }, 
+    {
+        "topics": [
+            3
+        ], 
+        "ask_id": "328", 
+        "categories": [
+            1
+        ], 
+        "primary_topic": 3
+    }, 
+    {
+        "topics": [
+            3
+        ], 
+        "ask_id": "98", 
+        "categories": [], 
+        "primary_topic": 3
+    }, 
+    {
+        "topics": [
+            3
+        ], 
+        "ask_id": "97", 
+        "categories": [], 
+        "primary_topic": 3
+    }, 
+    {
+        "topics": [
+            3
+        ], 
+        "ask_id": "96", 
+        "categories": [], 
+        "primary_topic": 3
+    }, 
+    {
+        "topics": [
+            3
+        ], 
+        "ask_id": "95", 
+        "categories": [], 
+        "primary_topic": 3
+    }, 
+    {
+        "topics": [
+            3
+        ], 
+        "ask_id": "94", 
+        "categories": [], 
+        "primary_topic": 3
+    }, 
+    {
+        "topics": [
+            3
+        ], 
+        "ask_id": "93", 
+        "categories": [], 
+        "primary_topic": 3
+    }, 
+    {
+        "topics": [
+            3
+        ], 
+        "ask_id": "92", 
+        "categories": [
             1, 
-            4
+            2
         ], 
-        "portal_ids": [
-            3
-        ]
+        "primary_topic": 3
     }, 
     {
-        "ask_id": "44", 
-        "see_all_ids": [
-            4
-        ], 
-        "portal_ids": [
+        "topics": [
             3
-        ]
-    }, 
-    {
-        "ask_id": "43", 
-        "see_all_ids": [
-            5
         ], 
-        "portal_ids": [
-            3
-        ]
-    }, 
-    {
-        "ask_id": "42", 
-        "see_all_ids": [
-            1, 
-            4
-        ], 
-        "portal_ids": [
-            3
-        ]
-    }, 
-    {
-        "ask_id": "41", 
-        "see_all_ids": [
-            5
-        ], 
-        "portal_ids": [
-            3
-        ]
-    }, 
-    {
-        "ask_id": "40", 
-        "see_all_ids": [
-            5
-        ], 
-        "portal_ids": [
-            3
-        ]
-    }, 
-    {
-        "ask_id": "39", 
-        "see_all_ids": [
-            5
-        ], 
-        "portal_ids": [
-            3
-        ]
-    }, 
-    {
-        "ask_id": "38", 
-        "see_all_ids": [
+        "ask_id": "91", 
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            3
-        ]
+        "primary_topic": 3
     }, 
     {
-        "ask_id": "37", 
-        "see_all_ids": [
+        "topics": [
+            3
+        ], 
+        "ask_id": "88", 
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            3
-        ]
+        "primary_topic": 3
     }, 
     {
-        "ask_id": "36", 
-        "see_all_ids": [
-            1
+        "topics": [
+            3
         ], 
-        "portal_ids": [
-            3
-        ]
-    }, 
-    {
-        "ask_id": "35", 
-        "see_all_ids": [
+        "ask_id": "87", 
+        "categories": [
             5
         ], 
-        "portal_ids": [
-            3
-        ]
+        "primary_topic": 3
     }, 
     {
-        "ask_id": "34", 
-        "see_all_ids": [
-            5
+        "topics": [
+            3
         ], 
-        "portal_ids": [
+        "ask_id": "86", 
+        "categories": [
             3
-        ]
-    }, 
-    {
-        "ask_id": "33", 
-        "see_all_ids": [
-            5
         ], 
-        "portal_ids": [
-            3
-        ]
+        "primary_topic": 3
     }, 
     {
-        "ask_id": "32", 
-        "see_all_ids": [
-            5
+        "topics": [
+            3
         ], 
-        "portal_ids": [
-            3
-        ]
-    }, 
-    {
-        "ask_id": "25", 
-        "see_all_ids": [
-            5
-        ], 
-        "portal_ids": [
-            3
-        ]
-    }, 
-    {
-        "ask_id": "24", 
-        "see_all_ids": [
-            2
-        ], 
-        "portal_ids": [
-            3
-        ]
-    }, 
-    {
-        "ask_id": "23", 
-        "see_all_ids": [
-            2
-        ], 
-        "portal_ids": [
-            3
-        ]
-    }, 
-    {
-        "ask_id": "22", 
-        "see_all_ids": [
-            2
-        ], 
-        "portal_ids": [
-            3
-        ]
-    }, 
-    {
-        "ask_id": "21", 
-        "see_all_ids": [
-            2
-        ], 
-        "portal_ids": [
-            3
-        ]
-    }, 
-    {
-        "ask_id": "20", 
-        "see_all_ids": [
-            2
-        ], 
-        "portal_ids": [
-            3
-        ]
-    }, 
-    {
-        "ask_id": "19", 
-        "see_all_ids": [
-            2
-        ], 
-        "portal_ids": [
-            3
-        ]
-    }, 
-    {
-        "ask_id": "18", 
-        "see_all_ids": [
+        "ask_id": "85", 
+        "categories": [
             2, 
             5
         ], 
-        "portal_ids": [
-            3
-        ]
+        "primary_topic": 3
     }, 
     {
-        "ask_id": "17", 
-        "see_all_ids": [], 
-        "portal_ids": [
+        "topics": [
             3
-        ]
+        ], 
+        "ask_id": "84", 
+        "categories": [
+            1, 
+            3
+        ], 
+        "primary_topic": 3
     }, 
     {
-        "ask_id": "16", 
-        "see_all_ids": [], 
-        "portal_ids": [
+        "topics": [
             3
-        ]
-    }, 
-    {
-        "ask_id": "15", 
-        "see_all_ids": [
+        ], 
+        "ask_id": "83", 
+        "categories": [
             5
         ], 
-        "portal_ids": [
-            3
-        ]
+        "primary_topic": 3
     }, 
     {
-        "ask_id": "14", 
-        "see_all_ids": [
+        "topics": [
+            3
+        ], 
+        "ask_id": "82", 
+        "categories": [
+            5
+        ], 
+        "primary_topic": 3
+    }, 
+    {
+        "topics": [
+            3
+        ], 
+        "ask_id": "81", 
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            3
-        ]
+        "primary_topic": 3
     }, 
     {
-        "ask_id": "13", 
-        "see_all_ids": [
+        "topics": [
+            3
+        ], 
+        "ask_id": "80", 
+        "categories": [
+            5
+        ], 
+        "primary_topic": 3
+    }, 
+    {
+        "topics": [
+            3
+        ], 
+        "ask_id": "79", 
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            3
-        ]
+        "primary_topic": 3
     }, 
     {
-        "ask_id": "12", 
-        "see_all_ids": [
-            5
+        "topics": [
+            3
         ], 
-        "portal_ids": [
-            3
-        ]
-    }, 
-    {
-        "ask_id": "11", 
-        "see_all_ids": [
-            5
-        ], 
-        "portal_ids": [
-            3
-        ]
-    }, 
-    {
-        "ask_id": "10", 
-        "see_all_ids": [
-            5
-        ], 
-        "portal_ids": [
-            3
-        ]
-    }, 
-    {
-        "ask_id": "9", 
-        "see_all_ids": [
+        "ask_id": "78", 
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            3
-        ]
+        "primary_topic": 3
     }, 
     {
-        "ask_id": "8", 
-        "see_all_ids": [
+        "topics": [
             3
         ], 
-        "portal_ids": [
-            3
-        ]
+        "ask_id": "77", 
+        "categories": [
+            1
+        ], 
+        "primary_topic": 3
     }, 
     {
-        "ask_id": "7", 
-        "see_all_ids": [
-            5, 
+        "topics": [
             3
         ], 
-        "portal_ids": [
-            3
-        ]
+        "ask_id": "76", 
+        "categories": [
+            1
+        ], 
+        "primary_topic": 3
     }, 
     {
-        "ask_id": "2", 
-        "see_all_ids": [
+        "topics": [
+            3
+        ], 
+        "ask_id": "75", 
+        "categories": [
             5
         ], 
-        "portal_ids": [
-            3
-        ]
+        "primary_topic": 3
     }, 
     {
-        "ask_id": "1", 
-        "see_all_ids": [
+        "topics": [
+            3
+        ], 
+        "ask_id": "74", 
+        "categories": [
+            1
+        ], 
+        "primary_topic": 3
+    }, 
+    {
+        "topics": [
+            3
+        ], 
+        "ask_id": "73", 
+        "categories": [
+            1
+        ], 
+        "primary_topic": 3
+    }, 
+    {
+        "topics": [
+            3
+        ], 
+        "ask_id": "72", 
+        "categories": [
+            2, 
+            3, 
+            5
+        ], 
+        "primary_topic": 3
+    }, 
+    {
+        "topics": [
+            3
+        ], 
+        "ask_id": "71", 
+        "categories": [
+            2, 
+            5
+        ], 
+        "primary_topic": 3
+    }, 
+    {
+        "topics": [
+            3
+        ], 
+        "ask_id": "70", 
+        "categories": [
+            1, 
+            2
+        ], 
+        "primary_topic": 3
+    }, 
+    {
+        "topics": [
+            3
+        ], 
+        "ask_id": "69", 
+        "categories": [
+            1
+        ], 
+        "primary_topic": 3
+    }, 
+    {
+        "topics": [
+            3
+        ], 
+        "ask_id": "68", 
+        "categories": [
+            1, 
+            2, 
+            5
+        ], 
+        "primary_topic": 3
+    }, 
+    {
+        "topics": [
+            3
+        ], 
+        "ask_id": "67", 
+        "categories": [
+            5
+        ], 
+        "primary_topic": 3
+    }, 
+    {
+        "topics": [
+            3
+        ], 
+        "ask_id": "65", 
+        "categories": [
+            5
+        ], 
+        "primary_topic": 3
+    }, 
+    {
+        "topics": [
+            3
+        ], 
+        "ask_id": "64", 
+        "categories": [
+            1
+        ], 
+        "primary_topic": 3
+    }, 
+    {
+        "topics": [
+            3
+        ], 
+        "ask_id": "63", 
+        "categories": [
+            1
+        ], 
+        "primary_topic": 3
+    }, 
+    {
+        "topics": [
+            3
+        ], 
+        "ask_id": "62", 
+        "categories": [
+            5
+        ], 
+        "primary_topic": 3
+    }, 
+    {
+        "topics": [
+            3
+        ], 
+        "ask_id": "61", 
+        "categories": [
+            3
+        ], 
+        "primary_topic": 3
+    }, 
+    {
+        "topics": [
+            3
+        ], 
+        "ask_id": "60", 
+        "categories": [
+            1
+        ], 
+        "primary_topic": 3
+    }, 
+    {
+        "topics": [
+            3
+        ], 
+        "ask_id": "59", 
+        "categories": [], 
+        "primary_topic": 3
+    }, 
+    {
+        "topics": [
+            3
+        ], 
+        "ask_id": "58", 
+        "categories": [
+            5
+        ], 
+        "primary_topic": 3
+    }, 
+    {
+        "topics": [
+            3
+        ], 
+        "ask_id": "57", 
+        "categories": [
+            5
+        ], 
+        "primary_topic": 3
+    }, 
+    {
+        "topics": [
+            3
+        ], 
+        "ask_id": "56", 
+        "categories": [
+            1
+        ], 
+        "primary_topic": 3
+    }, 
+    {
+        "topics": [
+            3
+        ], 
+        "ask_id": "55", 
+        "categories": [
+            5
+        ], 
+        "primary_topic": 3
+    }, 
+    {
+        "topics": [
+            3
+        ], 
+        "ask_id": "54", 
+        "categories": [
+            5
+        ], 
+        "primary_topic": 3
+    }, 
+    {
+        "topics": [
+            3
+        ], 
+        "ask_id": "53", 
+        "categories": [
             1, 
             4
         ], 
-        "portal_ids": [
+        "primary_topic": 3
+    }, 
+    {
+        "topics": [
             3
-        ]
+        ], 
+        "ask_id": "52", 
+        "categories": [
+            1
+        ], 
+        "primary_topic": 3
+    }, 
+    {
+        "topics": [
+            3
+        ], 
+        "ask_id": "51", 
+        "categories": [
+            1
+        ], 
+        "primary_topic": 3
+    }, 
+    {
+        "topics": [
+            3
+        ], 
+        "ask_id": "50", 
+        "categories": [
+            1
+        ], 
+        "primary_topic": 3
+    }, 
+    {
+        "topics": [
+            3
+        ], 
+        "ask_id": "49", 
+        "categories": [
+            1
+        ], 
+        "primary_topic": 3
+    }, 
+    {
+        "topics": [
+            3
+        ], 
+        "ask_id": "48", 
+        "categories": [
+            1
+        ], 
+        "primary_topic": 3
+    }, 
+    {
+        "topics": [
+            3
+        ], 
+        "ask_id": "47", 
+        "categories": [
+            1
+        ], 
+        "primary_topic": 3
+    }, 
+    {
+        "topics": [
+            3
+        ], 
+        "ask_id": "46", 
+        "categories": [
+            1, 
+            4
+        ], 
+        "primary_topic": 3
+    }, 
+    {
+        "topics": [
+            3
+        ], 
+        "ask_id": "45", 
+        "categories": [
+            1, 
+            4
+        ], 
+        "primary_topic": 3
+    }, 
+    {
+        "topics": [
+            3
+        ], 
+        "ask_id": "44", 
+        "categories": [
+            4
+        ], 
+        "primary_topic": 3
+    }, 
+    {
+        "topics": [
+            3
+        ], 
+        "ask_id": "43", 
+        "categories": [
+            5
+        ], 
+        "primary_topic": 3
+    }, 
+    {
+        "topics": [
+            3
+        ], 
+        "ask_id": "42", 
+        "categories": [
+            1, 
+            4
+        ], 
+        "primary_topic": 3
+    }, 
+    {
+        "topics": [
+            3
+        ], 
+        "ask_id": "41", 
+        "categories": [
+            5
+        ], 
+        "primary_topic": 3
+    }, 
+    {
+        "topics": [
+            3
+        ], 
+        "ask_id": "40", 
+        "categories": [
+            5
+        ], 
+        "primary_topic": 3
+    }, 
+    {
+        "topics": [
+            3
+        ], 
+        "ask_id": "39", 
+        "categories": [
+            5
+        ], 
+        "primary_topic": 3
+    }, 
+    {
+        "topics": [
+            3
+        ], 
+        "ask_id": "38", 
+        "categories": [
+            1
+        ], 
+        "primary_topic": 3
+    }, 
+    {
+        "topics": [
+            3
+        ], 
+        "ask_id": "37", 
+        "categories": [
+            1
+        ], 
+        "primary_topic": 3
+    }, 
+    {
+        "topics": [
+            3
+        ], 
+        "ask_id": "36", 
+        "categories": [
+            1
+        ], 
+        "primary_topic": 3
+    }, 
+    {
+        "topics": [
+            3
+        ], 
+        "ask_id": "35", 
+        "categories": [
+            5
+        ], 
+        "primary_topic": 3
+    }, 
+    {
+        "topics": [
+            3
+        ], 
+        "ask_id": "34", 
+        "categories": [
+            5
+        ], 
+        "primary_topic": 3
+    }, 
+    {
+        "topics": [
+            3
+        ], 
+        "ask_id": "33", 
+        "categories": [
+            5
+        ], 
+        "primary_topic": 3
+    }, 
+    {
+        "topics": [
+            3
+        ], 
+        "ask_id": "32", 
+        "categories": [
+            5
+        ], 
+        "primary_topic": 3
+    }, 
+    {
+        "topics": [
+            3
+        ], 
+        "ask_id": "25", 
+        "categories": [
+            5
+        ], 
+        "primary_topic": 3
+    }, 
+    {
+        "topics": [
+            3
+        ], 
+        "ask_id": "24", 
+        "categories": [
+            2
+        ], 
+        "primary_topic": 3
+    }, 
+    {
+        "topics": [
+            3
+        ], 
+        "ask_id": "23", 
+        "categories": [
+            2
+        ], 
+        "primary_topic": 3
+    }, 
+    {
+        "topics": [
+            3
+        ], 
+        "ask_id": "22", 
+        "categories": [
+            2
+        ], 
+        "primary_topic": 3
+    }, 
+    {
+        "topics": [
+            3
+        ], 
+        "ask_id": "21", 
+        "categories": [
+            2
+        ], 
+        "primary_topic": 3
+    }, 
+    {
+        "topics": [
+            3
+        ], 
+        "ask_id": "20", 
+        "categories": [
+            2
+        ], 
+        "primary_topic": 3
+    }, 
+    {
+        "topics": [
+            3
+        ], 
+        "ask_id": "19", 
+        "categories": [
+            2
+        ], 
+        "primary_topic": 3
+    }, 
+    {
+        "topics": [
+            3
+        ], 
+        "ask_id": "18", 
+        "categories": [
+            2, 
+            5
+        ], 
+        "primary_topic": 3
+    }, 
+    {
+        "topics": [
+            3
+        ], 
+        "ask_id": "17", 
+        "categories": [], 
+        "primary_topic": 3
+    }, 
+    {
+        "topics": [
+            3
+        ], 
+        "ask_id": "16", 
+        "categories": [], 
+        "primary_topic": 3
+    }, 
+    {
+        "topics": [
+            3
+        ], 
+        "ask_id": "15", 
+        "categories": [
+            5
+        ], 
+        "primary_topic": 3
+    }, 
+    {
+        "topics": [
+            3
+        ], 
+        "ask_id": "14", 
+        "categories": [
+            1
+        ], 
+        "primary_topic": 3
+    }, 
+    {
+        "topics": [
+            3
+        ], 
+        "ask_id": "13", 
+        "categories": [
+            1
+        ], 
+        "primary_topic": 3
+    }, 
+    {
+        "topics": [
+            3
+        ], 
+        "ask_id": "12", 
+        "categories": [
+            5
+        ], 
+        "primary_topic": 3
+    }, 
+    {
+        "topics": [
+            3
+        ], 
+        "ask_id": "11", 
+        "categories": [
+            5
+        ], 
+        "primary_topic": 3
+    }, 
+    {
+        "topics": [
+            3
+        ], 
+        "ask_id": "10", 
+        "categories": [
+            5
+        ], 
+        "primary_topic": 3
+    }, 
+    {
+        "topics": [
+            3
+        ], 
+        "ask_id": "9", 
+        "categories": [
+            1
+        ], 
+        "primary_topic": 3
+    }, 
+    {
+        "topics": [
+            3
+        ], 
+        "ask_id": "8", 
+        "categories": [
+            3
+        ], 
+        "primary_topic": 3
+    }, 
+    {
+        "topics": [
+            3
+        ], 
+        "ask_id": "7", 
+        "categories": [
+            3, 
+            5
+        ], 
+        "primary_topic": 3
+    }, 
+    {
+        "topics": [
+            3
+        ], 
+        "ask_id": "2", 
+        "categories": [
+            5
+        ], 
+        "primary_topic": 3
+    }, 
+    {
+        "topics": [
+            3
+        ], 
+        "ask_id": "1", 
+        "categories": [
+            1, 
+            4
+        ], 
+        "primary_topic": 3
     }
 ]

--- a/cfgov/ask_cfpb/fixtures/credit_reports.json
+++ b/cfgov/ask_cfpb/fixtures/credit_reports.json
@@ -1,853 +1,964 @@
 [
     {
+        "topics": [
+            4
+        ], 
         "ask_id": "2069", 
-        "see_all_ids": [
+        "categories": [
             4
         ], 
-        "portal_ids": [
-            4
-        ]
+        "primary_topic": 4
     }, 
     {
+        "topics": [
+            4
+        ], 
         "ask_id": "2029", 
-        "see_all_ids": [
+        "categories": [
             3
         ], 
-        "portal_ids": [
-            4
-        ]
+        "primary_topic": 4
     }, 
     {
+        "topics": [
+            4
+        ], 
         "ask_id": "1883", 
-        "see_all_ids": [
+        "categories": [
             4
         ], 
-        "portal_ids": [
-            4
-        ]
+        "primary_topic": 4
     }, 
     {
+        "topics": [
+            4
+        ], 
         "ask_id": "1871", 
-        "see_all_ids": [
-            5, 
-            3
-        ], 
-        "portal_ids": [
-            4
-        ]
-    }, 
-    {
-        "ask_id": "1869", 
-        "see_all_ids": [
-            5, 
-            3
-        ], 
-        "portal_ids": [
-            4
-        ]
-    }, 
-    {
-        "ask_id": "1867", 
-        "see_all_ids": [
-            5
-        ], 
-        "portal_ids": [
-            4
-        ]
-    }, 
-    {
-        "ask_id": "1865", 
-        "see_all_ids": [
-            3
-        ], 
-        "portal_ids": [
-            4
-        ]
-    }, 
-    {
-        "ask_id": "1863", 
-        "see_all_ids": [
-            1
-        ], 
-        "portal_ids": [
-            4
-        ]
-    }, 
-    {
-        "ask_id": "1837", 
-        "see_all_ids": [
+        "categories": [
             3, 
-            1
+            5
         ], 
-        "portal_ids": [
-            4
-        ]
+        "primary_topic": 4
     }, 
     {
+        "topics": [
+            4
+        ], 
+        "ask_id": "1869", 
+        "categories": [
+            3, 
+            5
+        ], 
+        "primary_topic": 4
+    }, 
+    {
+        "topics": [
+            4
+        ], 
+        "ask_id": "1867", 
+        "categories": [
+            5
+        ], 
+        "primary_topic": 4
+    }, 
+    {
+        "topics": [
+            4
+        ], 
+        "ask_id": "1865", 
+        "categories": [
+            3
+        ], 
+        "primary_topic": 4
+    }, 
+    {
+        "topics": [
+            3, 
+            4
+        ], 
+        "ask_id": "1863", 
+        "categories": [
+            1
+        ], 
+        "primary_topic": 4
+    }, 
+    {
+        "topics": [
+            4
+        ], 
+        "ask_id": "1837", 
+        "categories": [
+            1, 
+            3
+        ], 
+        "primary_topic": 4
+    }, 
+    {
+        "topics": [
+            4
+        ], 
         "ask_id": "1823", 
-        "see_all_ids": [
+        "categories": [
             5
         ], 
-        "portal_ids": [
-            4
-        ]
+        "primary_topic": 4
     }, 
     {
-        "ask_id": "1821", 
-        "see_all_ids": [
-            1
-        ], 
-        "portal_ids": [
-            4
-        ]
-    }, 
-    {
-        "ask_id": "1819", 
-        "see_all_ids": [
-            5, 
-            1
-        ], 
-        "portal_ids": [
-            4
-        ]
-    }, 
-    {
-        "ask_id": "1817", 
-        "see_all_ids": [
-            1
-        ], 
-        "portal_ids": [
-            4
-        ]
-    }, 
-    {
-        "ask_id": "1815", 
-        "see_all_ids": [
-            5
-        ], 
-        "portal_ids": [
-            4
-        ]
-    }, 
-    {
-        "ask_id": "1813", 
-        "see_all_ids": [
+        "topics": [
             1, 
-            4
-        ], 
-        "portal_ids": [
-            4
-        ]
-    }, 
-    {
-        "ask_id": "1693", 
-        "see_all_ids": [
-            5
-        ], 
-        "portal_ids": [
-            4
-        ]
-    }, 
-    {
-        "ask_id": "1383", 
-        "see_all_ids": [
-            4
-        ], 
-        "portal_ids": [
-            4
-        ]
-    }, 
-    {
-        "ask_id": "1373", 
-        "see_all_ids": [
-            5
-        ], 
-        "portal_ids": [
-            4
-        ]
-    }, 
-    {
-        "ask_id": "1371", 
-        "see_all_ids": [
-            5, 
-            2
-        ], 
-        "portal_ids": [
-            4
-        ]
-    }, 
-    {
-        "ask_id": "1367", 
-        "see_all_ids": [
-            5, 
-            2
-        ], 
-        "portal_ids": [
-            4
-        ]
-    }, 
-    {
-        "ask_id": "1365", 
-        "see_all_ids": [
-            4
-        ], 
-        "portal_ids": [
-            4
-        ]
-    }, 
-    {
-        "ask_id": "1363", 
-        "see_all_ids": [
-            1
-        ], 
-        "portal_ids": [
-            4
-        ]
-    }, 
-    {
-        "ask_id": "1361", 
-        "see_all_ids": [
-            1
-        ], 
-        "portal_ids": [
-            4
-        ]
-    }, 
-    {
-        "ask_id": "1357", 
-        "see_all_ids": [
-            5
-        ], 
-        "portal_ids": [
-            4
-        ]
-    }, 
-    {
-        "ask_id": "1351", 
-        "see_all_ids": [
-            1
-        ], 
-        "portal_ids": [
-            4
-        ]
-    }, 
-    {
-        "ask_id": "1349", 
-        "see_all_ids": [
-            5
-        ], 
-        "portal_ids": [
-            4
-        ]
-    }, 
-    {
-        "ask_id": "1345", 
-        "see_all_ids": [
-            5, 
-            2
-        ], 
-        "portal_ids": [
-            4
-        ]
-    }, 
-    {
-        "ask_id": "1343", 
-        "see_all_ids": [
-            5
-        ], 
-        "portal_ids": [
-            4
-        ]
-    }, 
-    {
-        "ask_id": "1341", 
-        "see_all_ids": [
-            1
-        ], 
-        "portal_ids": [
-            4
-        ]
-    }, 
-    {
-        "ask_id": "1339", 
-        "see_all_ids": [
-            1
-        ], 
-        "portal_ids": [
-            4
-        ]
-    }, 
-    {
-        "ask_id": "1337", 
-        "see_all_ids": [
-            1
-        ], 
-        "portal_ids": [
-            4
-        ]
-    }, 
-    {
-        "ask_id": "1335", 
-        "see_all_ids": [
-            5
-        ], 
-        "portal_ids": [
-            4
-        ]
-    }, 
-    {
-        "ask_id": "1333", 
-        "see_all_ids": [
-            1
-        ], 
-        "portal_ids": [
-            4
-        ]
-    }, 
-    {
-        "ask_id": "1331", 
-        "see_all_ids": [
-            1, 
-            5
-        ], 
-        "portal_ids": [
-            4
-        ]
-    }, 
-    {
-        "ask_id": "1327", 
-        "see_all_ids": [
-            1
-        ], 
-        "portal_ids": [
-            4
-        ]
-    }, 
-    {
-        "ask_id": "1323", 
-        "see_all_ids": [
-            1
-        ], 
-        "portal_ids": [
-            4
-        ]
-    }, 
-    {
-        "ask_id": "1317", 
-        "see_all_ids": [
-            4
-        ], 
-        "portal_ids": [
-            4
-        ]
-    }, 
-    {
-        "ask_id": "1307", 
-        "see_all_ids": [
-            1
-        ], 
-        "portal_ids": [
-            4
-        ]
-    }, 
-    {
-        "ask_id": "1305", 
-        "see_all_ids": [
-            1
-        ], 
-        "portal_ids": [
-            4
-        ]
-    }, 
-    {
-        "ask_id": "1303", 
-        "see_all_ids": [
-            1
-        ], 
-        "portal_ids": [
-            4
-        ]
-    }, 
-    {
-        "ask_id": "1297", 
-        "see_all_ids": [
-            1
-        ], 
-        "portal_ids": [
-            4
-        ]
-    }, 
-    {
-        "ask_id": "1295", 
-        "see_all_ids": [
-            1
-        ], 
-        "portal_ids": [
-            4
-        ]
-    }, 
-    {
-        "ask_id": "1293", 
-        "see_all_ids": [
-            1
-        ], 
-        "portal_ids": [
-            4
-        ]
-    }, 
-    {
-        "ask_id": "1291", 
-        "see_all_ids": [
-            1
-        ], 
-        "portal_ids": [
-            4
-        ]
-    }, 
-    {
-        "ask_id": "1289", 
-        "see_all_ids": [
-            1
-        ], 
-        "portal_ids": [
-            4
-        ]
-    }, 
-    {
-        "ask_id": "1285", 
-        "see_all_ids": [
-            1
-        ], 
-        "portal_ids": [
-            4
-        ]
-    }, 
-    {
-        "ask_id": "1283", 
-        "see_all_ids": [
-            1
-        ], 
-        "portal_ids": [
-            4
-        ]
-    }, 
-    {
-        "ask_id": "1281", 
-        "see_all_ids": [
-            1
-        ], 
-        "portal_ids": [
-            4
-        ]
-    }, 
-    {
-        "ask_id": "1279", 
-        "see_all_ids": [
-            1
-        ], 
-        "portal_ids": [
-            4
-        ]
-    }, 
-    {
-        "ask_id": "1275", 
-        "see_all_ids": [
-            5
-        ], 
-        "portal_ids": [
-            4
-        ]
-    }, 
-    {
-        "ask_id": "1271", 
-        "see_all_ids": [
-            1
-        ], 
-        "portal_ids": [
-            4
-        ]
-    }, 
-    {
-        "ask_id": "1269", 
-        "see_all_ids": [
-            1
-        ], 
-        "portal_ids": [
-            4
-        ]
-    }, 
-    {
-        "ask_id": "1267", 
-        "see_all_ids": [
-            1
-        ], 
-        "portal_ids": [
-            4
-        ]
-    }, 
-    {
-        "ask_id": "1265", 
-        "see_all_ids": [
-            1
-        ], 
-        "portal_ids": [
-            4
-        ]
-    }, 
-    {
-        "ask_id": "1263", 
-        "see_all_ids": [
-            1
-        ], 
-        "portal_ids": [
-            4
-        ]
-    }, 
-    {
-        "ask_id": "1261", 
-        "see_all_ids": [
-            1
-        ], 
-        "portal_ids": [
-            4
-        ]
-    }, 
-    {
-        "ask_id": "1257", 
-        "see_all_ids": [
-            5
-        ], 
-        "portal_ids": [
-            4
-        ]
-    }, 
-    {
-        "ask_id": "1255", 
-        "see_all_ids": [
-            5
-        ], 
-        "portal_ids": [
-            4
-        ]
-    }, 
-    {
-        "ask_id": "1253", 
-        "see_all_ids": [
-            5, 
-            3
-        ], 
-        "portal_ids": [
-            4
-        ]
-    }, 
-    {
-        "ask_id": "1251", 
-        "see_all_ids": [
-            1
-        ], 
-        "portal_ids": [
-            4
-        ]
-    }, 
-    {
-        "ask_id": "1249", 
-        "see_all_ids": [
-            1
-        ], 
-        "portal_ids": [
-            4
-        ]
-    }, 
-    {
-        "ask_id": "1247", 
-        "see_all_ids": [
-            1
-        ], 
-        "portal_ids": [
-            4
-        ]
-    }, 
-    {
-        "ask_id": "1245", 
-        "see_all_ids": [
-            1
-        ], 
-        "portal_ids": [
-            4
-        ]
-    }, 
-    {
-        "ask_id": "1237", 
-        "see_all_ids": [
-            1
-        ], 
-        "portal_ids": [
-            4
-        ]
-    }, 
-    {
-        "ask_id": "1235", 
-        "see_all_ids": [
-            1
-        ], 
-        "portal_ids": [
-            4
-        ]
-    }, 
-    {
-        "ask_id": "1233", 
-        "see_all_ids": [
-            1
-        ], 
-        "portal_ids": [
-            4
-        ]
-    }, 
-    {
-        "ask_id": "1231", 
-        "see_all_ids": [
-            1
-        ], 
-        "portal_ids": [
-            4
-        ]
-    }, 
-    {
-        "ask_id": "1229", 
-        "see_all_ids": [
-            1
-        ], 
-        "portal_ids": [
-            4
-        ]
-    }, 
-    {
-        "ask_id": "1227", 
-        "see_all_ids": [
-            1
-        ], 
-        "portal_ids": [
-            4
-        ]
-    }, 
-    {
-        "ask_id": "1225", 
-        "see_all_ids": [
-            1, 
-            3
-        ], 
-        "portal_ids": [
-            4
-        ]
-    }, 
-    {
-        "ask_id": "1223", 
-        "see_all_ids": [
-            1
-        ], 
-        "portal_ids": [
-            4
-        ]
-    }, 
-    {
-        "ask_id": "1221", 
-        "see_all_ids": [
-            1
-        ], 
-        "portal_ids": [
-            4
-        ]
-    }, 
-    {
-        "ask_id": "1121", 
-        "see_all_ids": [
-            1
-        ], 
-        "portal_ids": [
-            4
-        ]
-    }, 
-    {
-        "ask_id": "327", 
-        "see_all_ids": [
-            5
-        ], 
-        "portal_ids": [
-            4
-        ]
-    }, 
-    {
-        "ask_id": "325", 
-        "see_all_ids": [
-            5
-        ], 
-        "portal_ids": [
-            4
-        ]
-    }, 
-    {
-        "ask_id": "323", 
-        "see_all_ids": [
-            1
-        ], 
-        "portal_ids": [
-            4
-        ]
-    }, 
-    {
-        "ask_id": "322", 
-        "see_all_ids": [
-            1
-        ], 
-        "portal_ids": [
-            4
-        ]
-    }, 
-    {
-        "ask_id": "321", 
-        "see_all_ids": [
-            1
-        ], 
-        "portal_ids": [
-            4
-        ]
-    }, 
-    {
-        "ask_id": "320", 
-        "see_all_ids": [
-            1
-        ], 
-        "portal_ids": [
-            4
-        ]
-    }, 
-    {
-        "ask_id": "319", 
-        "see_all_ids": [
-            1
-        ], 
-        "portal_ids": [
-            4
-        ]
-    }, 
-    {
-        "ask_id": "318", 
-        "see_all_ids": [
-            1, 
-            3
-        ], 
-        "portal_ids": [
-            4
-        ]
-    }, 
-    {
-        "ask_id": "316", 
-        "see_all_ids": [
-            1, 
-            3
-        ], 
-        "portal_ids": [
-            4
-        ]
-    }, 
-    {
-        "ask_id": "315", 
-        "see_all_ids": [
-            4
-        ], 
-        "portal_ids": [
-            4
-        ]
-    }, 
-    {
-        "ask_id": "314", 
-        "see_all_ids": [
-            1
-        ], 
-        "portal_ids": [
-            4
-        ]
-    }, 
-    {
-        "ask_id": "313", 
-        "see_all_ids": [
-            1
-        ], 
-        "portal_ids": [
-            4
-        ]
-    }, 
-    {
-        "ask_id": "312", 
-        "see_all_ids": [
-            1
-        ], 
-        "portal_ids": [
-            4
-        ]
-    }, 
-    {
-        "ask_id": "311", 
-        "see_all_ids": [
-            1
-        ], 
-        "portal_ids": [
-            4
-        ]
-    }, 
-    {
-        "ask_id": "309", 
-        "see_all_ids": [
             4, 
+            9
+        ], 
+        "ask_id": "1821", 
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            4
-        ]
+        "primary_topic": 4
     }, 
     {
-        "ask_id": "66", 
-        "see_all_ids": [
-            1
+        "topics": [
+            4
         ], 
-        "portal_ids": [
-            4
-        ]
-    }, 
-    {
-        "ask_id": "6", 
-        "see_all_ids": [
+        "ask_id": "1819", 
+        "categories": [
+            1, 
             5
         ], 
-        "portal_ids": [
-            4
-        ]
+        "primary_topic": 4
     }, 
     {
+        "topics": [
+            4
+        ], 
+        "ask_id": "1817", 
+        "categories": [
+            1
+        ], 
+        "primary_topic": 4
+    }, 
+    {
+        "topics": [
+            4
+        ], 
+        "ask_id": "1815", 
+        "categories": [
+            5
+        ], 
+        "primary_topic": 4
+    }, 
+    {
+        "topics": [
+            4
+        ], 
+        "ask_id": "1813", 
+        "categories": [
+            1, 
+            4
+        ], 
+        "primary_topic": 4
+    }, 
+    {
+        "topics": [
+            4
+        ], 
+        "ask_id": "1693", 
+        "categories": [
+            5
+        ], 
+        "primary_topic": 4
+    }, 
+    {
+        "topics": [
+            4, 
+            5
+        ], 
+        "ask_id": "1383", 
+        "categories": [
+            4
+        ], 
+        "primary_topic": 4
+    }, 
+    {
+        "topics": [
+            4
+        ], 
+        "ask_id": "1373", 
+        "categories": [
+            5
+        ], 
+        "primary_topic": 4
+    }, 
+    {
+        "topics": [
+            4
+        ], 
+        "ask_id": "1371", 
+        "categories": [
+            2, 
+            5
+        ], 
+        "primary_topic": 4
+    }, 
+    {
+        "topics": [
+            4
+        ], 
+        "ask_id": "1367", 
+        "categories": [
+            2, 
+            5
+        ], 
+        "primary_topic": 4
+    }, 
+    {
+        "topics": [
+            4
+        ], 
+        "ask_id": "1365", 
+        "categories": [
+            4
+        ], 
+        "primary_topic": 4
+    }, 
+    {
+        "topics": [
+            4
+        ], 
+        "ask_id": "1363", 
+        "categories": [
+            1
+        ], 
+        "primary_topic": 4
+    }, 
+    {
+        "topics": [
+            4
+        ], 
+        "ask_id": "1361", 
+        "categories": [
+            1
+        ], 
+        "primary_topic": 4
+    }, 
+    {
+        "topics": [
+            4
+        ], 
+        "ask_id": "1357", 
+        "categories": [
+            5
+        ], 
+        "primary_topic": 4
+    }, 
+    {
+        "topics": [
+            4
+        ], 
+        "ask_id": "1351", 
+        "categories": [
+            1
+        ], 
+        "primary_topic": 4
+    }, 
+    {
+        "topics": [
+            4
+        ], 
+        "ask_id": "1349", 
+        "categories": [
+            5
+        ], 
+        "primary_topic": 4
+    }, 
+    {
+        "topics": [
+            4
+        ], 
+        "ask_id": "1345", 
+        "categories": [
+            2, 
+            5
+        ], 
+        "primary_topic": 4
+    }, 
+    {
+        "topics": [
+            4, 
+            7
+        ], 
+        "ask_id": "1343", 
+        "categories": [
+            5
+        ], 
+        "primary_topic": 4
+    }, 
+    {
+        "topics": [
+            4
+        ], 
+        "ask_id": "1341", 
+        "categories": [
+            1
+        ], 
+        "primary_topic": 4
+    }, 
+    {
+        "topics": [
+            4
+        ], 
+        "ask_id": "1339", 
+        "categories": [
+            1
+        ], 
+        "primary_topic": 4
+    }, 
+    {
+        "topics": [
+            4
+        ], 
+        "ask_id": "1337", 
+        "categories": [
+            1
+        ], 
+        "primary_topic": 4
+    }, 
+    {
+        "topics": [
+            3, 
+            4
+        ], 
+        "ask_id": "1335", 
+        "categories": [
+            5
+        ], 
+        "primary_topic": 4
+    }, 
+    {
+        "topics": [
+            4
+        ], 
+        "ask_id": "1333", 
+        "categories": [
+            1
+        ], 
+        "primary_topic": 4
+    }, 
+    {
+        "topics": [
+            4
+        ], 
+        "ask_id": "1331", 
+        "categories": [
+            1, 
+            5
+        ], 
+        "primary_topic": 4
+    }, 
+    {
+        "topics": [
+            4
+        ], 
+        "ask_id": "1327", 
+        "categories": [
+            1
+        ], 
+        "primary_topic": 4
+    }, 
+    {
+        "topics": [
+            4
+        ], 
+        "ask_id": "1323", 
+        "categories": [
+            1
+        ], 
+        "primary_topic": 4
+    }, 
+    {
+        "topics": [
+            4
+        ], 
+        "ask_id": "1317", 
+        "categories": [
+            4
+        ], 
+        "primary_topic": 4
+    }, 
+    {
+        "topics": [
+            4
+        ], 
+        "ask_id": "1307", 
+        "categories": [
+            1
+        ], 
+        "primary_topic": 4
+    }, 
+    {
+        "topics": [
+            4
+        ], 
+        "ask_id": "1305", 
+        "categories": [
+            1
+        ], 
+        "primary_topic": 4
+    }, 
+    {
+        "topics": [
+            4
+        ], 
+        "ask_id": "1303", 
+        "categories": [
+            1
+        ], 
+        "primary_topic": 4
+    }, 
+    {
+        "topics": [
+            4
+        ], 
+        "ask_id": "1297", 
+        "categories": [
+            1
+        ], 
+        "primary_topic": 4
+    }, 
+    {
+        "topics": [
+            4
+        ], 
+        "ask_id": "1295", 
+        "categories": [
+            1
+        ], 
+        "primary_topic": 4
+    }, 
+    {
+        "topics": [
+            4
+        ], 
+        "ask_id": "1293", 
+        "categories": [
+            1
+        ], 
+        "primary_topic": 4
+    }, 
+    {
+        "topics": [
+            4
+        ], 
+        "ask_id": "1291", 
+        "categories": [
+            1
+        ], 
+        "primary_topic": 4
+    }, 
+    {
+        "topics": [
+            3, 
+            4
+        ], 
+        "ask_id": "1289", 
+        "categories": [
+            1
+        ], 
+        "primary_topic": 4
+    }, 
+    {
+        "topics": [
+            4
+        ], 
+        "ask_id": "1285", 
+        "categories": [
+            1
+        ], 
+        "primary_topic": 4
+    }, 
+    {
+        "topics": [
+            4
+        ], 
+        "ask_id": "1283", 
+        "categories": [
+            1
+        ], 
+        "primary_topic": 4
+    }, 
+    {
+        "topics": [
+            4
+        ], 
+        "ask_id": "1281", 
+        "categories": [
+            1
+        ], 
+        "primary_topic": 4
+    }, 
+    {
+        "topics": [
+            4
+        ], 
+        "ask_id": "1279", 
+        "categories": [
+            1
+        ], 
+        "primary_topic": 4
+    }, 
+    {
+        "topics": [
+            4
+        ], 
+        "ask_id": "1275", 
+        "categories": [
+            5
+        ], 
+        "primary_topic": 4
+    }, 
+    {
+        "topics": [
+            4
+        ], 
+        "ask_id": "1271", 
+        "categories": [
+            1
+        ], 
+        "primary_topic": 4
+    }, 
+    {
+        "topics": [
+            4
+        ], 
+        "ask_id": "1269", 
+        "categories": [
+            1
+        ], 
+        "primary_topic": 4
+    }, 
+    {
+        "topics": [
+            4
+        ], 
+        "ask_id": "1267", 
+        "categories": [
+            1
+        ], 
+        "primary_topic": 4
+    }, 
+    {
+        "topics": [
+            4
+        ], 
+        "ask_id": "1265", 
+        "categories": [
+            1
+        ], 
+        "primary_topic": 4
+    }, 
+    {
+        "topics": [
+            1, 
+            3, 
+            4, 
+            9
+        ], 
+        "ask_id": "1263", 
+        "categories": [
+            1
+        ], 
+        "primary_topic": 4
+    }, 
+    {
+        "topics": [
+            4
+        ], 
+        "ask_id": "1261", 
+        "categories": [
+            1
+        ], 
+        "primary_topic": 4
+    }, 
+    {
+        "topics": [
+            4
+        ], 
+        "ask_id": "1257", 
+        "categories": [
+            5
+        ], 
+        "primary_topic": 4
+    }, 
+    {
+        "topics": [
+            4
+        ], 
+        "ask_id": "1255", 
+        "categories": [
+            5
+        ], 
+        "primary_topic": 4
+    }, 
+    {
+        "topics": [
+            4
+        ], 
+        "ask_id": "1253", 
+        "categories": [
+            3, 
+            5
+        ], 
+        "primary_topic": 4
+    }, 
+    {
+        "topics": [
+            4
+        ], 
+        "ask_id": "1251", 
+        "categories": [
+            1
+        ], 
+        "primary_topic": 4
+    }, 
+    {
+        "topics": [
+            4
+        ], 
+        "ask_id": "1249", 
+        "categories": [
+            1
+        ], 
+        "primary_topic": 4
+    }, 
+    {
+        "topics": [
+            4
+        ], 
+        "ask_id": "1247", 
+        "categories": [
+            1
+        ], 
+        "primary_topic": 4
+    }, 
+    {
+        "topics": [
+            4
+        ], 
+        "ask_id": "1245", 
+        "categories": [
+            1
+        ], 
+        "primary_topic": 4
+    }, 
+    {
+        "topics": [
+            4
+        ], 
+        "ask_id": "1237", 
+        "categories": [
+            1
+        ], 
+        "primary_topic": 4
+    }, 
+    {
+        "topics": [
+            4
+        ], 
+        "ask_id": "1235", 
+        "categories": [
+            1
+        ], 
+        "primary_topic": 4
+    }, 
+    {
+        "topics": [
+            4
+        ], 
+        "ask_id": "1233", 
+        "categories": [
+            1
+        ], 
+        "primary_topic": 4
+    }, 
+    {
+        "topics": [
+            4
+        ], 
+        "ask_id": "1231", 
+        "categories": [
+            1
+        ], 
+        "primary_topic": 4
+    }, 
+    {
+        "topics": [
+            4
+        ], 
+        "ask_id": "1229", 
+        "categories": [
+            1
+        ], 
+        "primary_topic": 4
+    }, 
+    {
+        "topics": [
+            4
+        ], 
+        "ask_id": "1227", 
+        "categories": [
+            1
+        ], 
+        "primary_topic": 4
+    }, 
+    {
+        "topics": [
+            4
+        ], 
+        "ask_id": "1225", 
+        "categories": [
+            1, 
+            3
+        ], 
+        "primary_topic": 4
+    }, 
+    {
+        "topics": [
+            4
+        ], 
+        "ask_id": "1223", 
+        "categories": [
+            1
+        ], 
+        "primary_topic": 4
+    }, 
+    {
+        "topics": [
+            4
+        ], 
+        "ask_id": "1221", 
+        "categories": [
+            1
+        ], 
+        "primary_topic": 4
+    }, 
+    {
+        "topics": [
+            4
+        ], 
+        "ask_id": "1121", 
+        "categories": [
+            1
+        ], 
+        "primary_topic": 4
+    }, 
+    {
+        "topics": [
+            4
+        ], 
+        "ask_id": "327", 
+        "categories": [
+            5
+        ], 
+        "primary_topic": 4
+    }, 
+    {
+        "topics": [
+            4
+        ], 
+        "ask_id": "325", 
+        "categories": [
+            5
+        ], 
+        "primary_topic": 4
+    }, 
+    {
+        "topics": [
+            4
+        ], 
+        "ask_id": "323", 
+        "categories": [
+            1
+        ], 
+        "primary_topic": 4
+    }, 
+    {
+        "topics": [
+            4, 
+            9
+        ], 
+        "ask_id": "322", 
+        "categories": [
+            1
+        ], 
+        "primary_topic": 4
+    }, 
+    {
+        "topics": [
+            1, 
+            4, 
+            9, 
+            13
+        ], 
+        "ask_id": "321", 
+        "categories": [
+            1
+        ], 
+        "primary_topic": 4
+    }, 
+    {
+        "topics": [
+            4
+        ], 
+        "ask_id": "320", 
+        "categories": [
+            1
+        ], 
+        "primary_topic": 4
+    }, 
+    {
+        "topics": [
+            4, 
+            9
+        ], 
+        "ask_id": "319", 
+        "categories": [
+            1
+        ], 
+        "primary_topic": 4
+    }, 
+    {
+        "topics": [
+            4
+        ], 
+        "ask_id": "318", 
+        "categories": [
+            1, 
+            3
+        ], 
+        "primary_topic": 4
+    }, 
+    {
+        "topics": [
+            4
+        ], 
+        "ask_id": "316", 
+        "categories": [
+            1, 
+            3
+        ], 
+        "primary_topic": 4
+    }, 
+    {
+        "topics": [
+            4
+        ], 
+        "ask_id": "315", 
+        "categories": [
+            4
+        ], 
+        "primary_topic": 4
+    }, 
+    {
+        "topics": [
+            4
+        ], 
+        "ask_id": "314", 
+        "categories": [
+            1
+        ], 
+        "primary_topic": 4
+    }, 
+    {
+        "topics": [
+            4
+        ], 
+        "ask_id": "313", 
+        "categories": [
+            1
+        ], 
+        "primary_topic": 4
+    }, 
+    {
+        "topics": [
+            4
+        ], 
+        "ask_id": "312", 
+        "categories": [
+            1
+        ], 
+        "primary_topic": 4
+    }, 
+    {
+        "topics": [
+            4
+        ], 
+        "ask_id": "311", 
+        "categories": [
+            1
+        ], 
+        "primary_topic": 4
+    }, 
+    {
+        "topics": [
+            4
+        ], 
+        "ask_id": "309", 
+        "categories": [
+            1, 
+            4
+        ], 
+        "primary_topic": 4
+    }, 
+    {
+        "topics": [
+            3, 
+            4
+        ], 
+        "ask_id": "66", 
+        "categories": [
+            1
+        ], 
+        "primary_topic": 4
+    }, 
+    {
+        "topics": [
+            4
+        ], 
+        "ask_id": "6", 
+        "categories": [
+            5
+        ], 
+        "primary_topic": 4
+    }, 
+    {
+        "topics": [
+            4
+        ], 
         "ask_id": "5", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            4
-        ]
+        "primary_topic": 4
     }, 
     {
+        "topics": [
+            3, 
+            4
+        ], 
         "ask_id": "4", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            4
-        ]
+        "primary_topic": 4
     }, 
     {
+        "topics": [
+            3, 
+            4
+        ], 
         "ask_id": "3", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            4
-        ]
+        "primary_topic": 4
     }
 ]

--- a/cfgov/ask_cfpb/fixtures/debt_collection.json
+++ b/cfgov/ask_cfpb/fixtures/debt_collection.json
@@ -1,540 +1,602 @@
 [
     {
+        "topics": [
+            5
+        ], 
         "ask_id": "2051", 
-        "see_all_ids": [
+        "categories": [
             3
         ], 
-        "portal_ids": [
-            5
-        ]
+        "primary_topic": 5
     }, 
     {
+        "topics": [
+            5
+        ], 
         "ask_id": "2037", 
-        "see_all_ids": [
+        "categories": [
             5
         ], 
-        "portal_ids": [
-            5
-        ]
+        "primary_topic": 5
     }, 
     {
+        "topics": [
+            5
+        ], 
         "ask_id": "1981", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            5
-        ]
+        "primary_topic": 5
     }, 
     {
+        "topics": [
+            5, 
+            7
+        ], 
         "ask_id": "1699", 
-        "see_all_ids": [
-            3, 
-            1
+        "categories": [
+            1, 
+            3
         ], 
-        "portal_ids": [
-            5
-        ]
+        "primary_topic": 5
     }, 
     {
+        "topics": [
+            5
+        ], 
         "ask_id": "1695", 
-        "see_all_ids": [
-            3, 
-            1
+        "categories": [
+            1, 
+            3
         ], 
-        "portal_ids": [
-            5
-        ]
+        "primary_topic": 5
     }, 
     {
+        "topics": [
+            5
+        ], 
         "ask_id": "1539", 
-        "see_all_ids": [
+        "categories": [
             1, 
             2
         ], 
-        "portal_ids": [
-            5
-        ]
+        "primary_topic": 5
     }, 
     {
+        "topics": [
+            5
+        ], 
         "ask_id": "1537", 
-        "see_all_ids": [
+        "categories": [
             1, 
             2
         ], 
-        "portal_ids": [
-            5
-        ]
+        "primary_topic": 5
     }, 
     {
+        "topics": [
+            5
+        ], 
         "ask_id": "1533", 
-        "see_all_ids": [
+        "categories": [
             1, 
             2
         ], 
-        "portal_ids": [
-            5
-        ]
+        "primary_topic": 5
     }, 
     {
+        "topics": [
+            5
+        ], 
         "ask_id": "1499", 
-        "see_all_ids": [
-            5, 
-            2
-        ], 
-        "portal_ids": [
+        "categories": [
+            2, 
             5
-        ]
+        ], 
+        "primary_topic": 5
     }, 
     {
+        "topics": [
+            5
+        ], 
         "ask_id": "1495", 
-        "see_all_ids": [
-            5, 
-            2
-        ], 
-        "portal_ids": [
+        "categories": [
+            2, 
             5
-        ]
+        ], 
+        "primary_topic": 5
     }, 
     {
+        "topics": [
+            4, 
+            5
+        ], 
         "ask_id": "1493", 
-        "see_all_ids": [
-            5, 
-            2
-        ], 
-        "portal_ids": [
+        "categories": [
+            2, 
             5
-        ]
+        ], 
+        "primary_topic": 5
     }, 
     {
+        "topics": [
+            5, 
+            7
+        ], 
         "ask_id": "1483", 
-        "see_all_ids": [
-            5, 
-            2
-        ], 
-        "portal_ids": [
+        "categories": [
+            2, 
             5
-        ]
+        ], 
+        "primary_topic": 5
     }, 
     {
+        "topics": [
+            5
+        ], 
         "ask_id": "1469", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            5
-        ]
+        "primary_topic": 5
     }, 
     {
+        "topics": [
+            5
+        ], 
         "ask_id": "1467", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            5
-        ]
+        "primary_topic": 5
     }, 
     {
+        "topics": [
+            5
+        ], 
         "ask_id": "1463", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            5
-        ]
+        "primary_topic": 5
     }, 
     {
+        "topics": [
+            5
+        ], 
         "ask_id": "1457", 
-        "see_all_ids": [
+        "categories": [
             1, 
             4
         ], 
-        "portal_ids": [
-            5
-        ]
+        "primary_topic": 5
     }, 
     {
+        "topics": [
+            5
+        ], 
         "ask_id": "1451", 
-        "see_all_ids": [
-            4, 
-            1
+        "categories": [
+            1, 
+            4
         ], 
-        "portal_ids": [
-            5
-        ]
+        "primary_topic": 5
     }, 
     {
+        "topics": [
+            5
+        ], 
         "ask_id": "1449", 
-        "see_all_ids": [
+        "categories": [
             1, 
             4
         ], 
-        "portal_ids": [
-            5
-        ]
+        "primary_topic": 5
     }, 
     {
+        "topics": [
+            5
+        ], 
         "ask_id": "1447", 
-        "see_all_ids": [
+        "categories": [
             3
         ], 
-        "portal_ids": [
-            5
-        ]
+        "primary_topic": 5
     }, 
     {
+        "topics": [
+            5
+        ], 
         "ask_id": "1445", 
-        "see_all_ids": [
+        "categories": [
             4
         ], 
-        "portal_ids": [
-            5
-        ]
+        "primary_topic": 5
     }, 
     {
+        "topics": [
+            5
+        ], 
         "ask_id": "1443", 
-        "see_all_ids": [
+        "categories": [
             1, 
             3
         ], 
-        "portal_ids": [
-            5
-        ]
+        "primary_topic": 5
     }, 
     {
+        "topics": [
+            5
+        ], 
         "ask_id": "1441", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            5
-        ]
+        "primary_topic": 5
     }, 
     {
+        "topics": [
+            5
+        ], 
         "ask_id": "1439", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            5
-        ]
+        "primary_topic": 5
     }, 
     {
+        "topics": [
+            5
+        ], 
         "ask_id": "1433", 
-        "see_all_ids": [
+        "categories": [
             3
         ], 
-        "portal_ids": [
-            5
-        ]
+        "primary_topic": 5
     }, 
     {
+        "topics": [
+            5
+        ], 
         "ask_id": "1427", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            5
-        ]
+        "primary_topic": 5
     }, 
     {
+        "topics": [
+            5
+        ], 
         "ask_id": "1425", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            5
-        ]
+        "primary_topic": 5
     }, 
     {
+        "topics": [
+            5
+        ], 
         "ask_id": "1423", 
-        "see_all_ids": [
+        "categories": [
             5
         ], 
-        "portal_ids": [
-            5
-        ]
+        "primary_topic": 5
     }, 
     {
+        "topics": [
+            5
+        ], 
         "ask_id": "1417", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            5
-        ]
+        "primary_topic": 5
     }, 
     {
+        "topics": [
+            5
+        ], 
         "ask_id": "1415", 
-        "see_all_ids": [], 
-        "portal_ids": [
-            5
-        ]
+        "categories": [], 
+        "primary_topic": 5
     }, 
     {
+        "topics": [
+            5
+        ], 
         "ask_id": "1413", 
-        "see_all_ids": [
+        "categories": [
             5
         ], 
-        "portal_ids": [
-            5
-        ]
+        "primary_topic": 5
     }, 
     {
+        "topics": [
+            5
+        ], 
         "ask_id": "1411", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            5
-        ]
+        "primary_topic": 5
     }, 
     {
+        "topics": [
+            5
+        ], 
         "ask_id": "1409", 
-        "see_all_ids": [
+        "categories": [
             2
         ], 
-        "portal_ids": [
-            5
-        ]
+        "primary_topic": 5
     }, 
     {
+        "topics": [
+            5
+        ], 
         "ask_id": "1405", 
-        "see_all_ids": [
+        "categories": [
             2
         ], 
-        "portal_ids": [
-            5
-        ]
+        "primary_topic": 5
     }, 
     {
+        "topics": [
+            5
+        ], 
         "ask_id": "1403", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            5
-        ]
+        "primary_topic": 5
     }, 
     {
+        "topics": [
+            5
+        ], 
         "ask_id": "1401", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            5
-        ]
+        "primary_topic": 5
     }, 
     {
+        "topics": [
+            5
+        ], 
         "ask_id": "1399", 
-        "see_all_ids": [
+        "categories": [
             5
         ], 
-        "portal_ids": [
-            5
-        ]
+        "primary_topic": 5
     }, 
     {
+        "topics": [
+            5
+        ], 
         "ask_id": "1397", 
-        "see_all_ids": [
+        "categories": [
             1, 
             2
         ], 
-        "portal_ids": [
-            5
-        ]
+        "primary_topic": 5
     }, 
     {
+        "topics": [
+            5
+        ], 
         "ask_id": "1395", 
-        "see_all_ids": [
+        "categories": [
             2
         ], 
-        "portal_ids": [
-            5
-        ]
+        "primary_topic": 5
     }, 
     {
+        "topics": [
+            5
+        ], 
         "ask_id": "1393", 
-        "see_all_ids": [
+        "categories": [
             4
         ], 
-        "portal_ids": [
-            5
-        ]
+        "primary_topic": 5
     }, 
     {
+        "topics": [
+            5
+        ], 
         "ask_id": "1391", 
-        "see_all_ids": [
+        "categories": [
             4
         ], 
-        "portal_ids": [
-            5
-        ]
+        "primary_topic": 5
     }, 
     {
+        "topics": [
+            5
+        ], 
         "ask_id": "1389", 
-        "see_all_ids": [
+        "categories": [
             4
         ], 
-        "portal_ids": [
-            5
-        ]
+        "primary_topic": 5
     }, 
     {
+        "topics": [
+            5
+        ], 
         "ask_id": "1387", 
-        "see_all_ids": [
+        "categories": [
             1, 
             4
         ], 
-        "portal_ids": [
-            5
-        ]
+        "primary_topic": 5
     }, 
     {
+        "topics": [
+            5
+        ], 
         "ask_id": "1385", 
-        "see_all_ids": [
+        "categories": [
             4
         ], 
-        "portal_ids": [
-            5
-        ]
+        "primary_topic": 5
     }, 
     {
+        "topics": [
+            5
+        ], 
         "ask_id": "1381", 
-        "see_all_ids": [
+        "categories": [
             4
         ], 
-        "portal_ids": [
-            5
-        ]
+        "primary_topic": 5
     }, 
     {
+        "topics": [
+            5
+        ], 
         "ask_id": "1355", 
-        "see_all_ids": [
+        "categories": [
             3
         ], 
-        "portal_ids": [
-            5
-        ]
+        "primary_topic": 5
     }, 
     {
+        "topics": [
+            5
+        ], 
         "ask_id": "855", 
-        "see_all_ids": [
+        "categories": [
             5
         ], 
-        "portal_ids": [
-            5
-        ]
+        "primary_topic": 5
     }, 
     {
+        "topics": [
+            5, 
+            13
+        ], 
         "ask_id": "655", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            5
-        ]
+        "primary_topic": 5
     }, 
     {
+        "topics": [
+            5
+        ], 
         "ask_id": "339", 
-        "see_all_ids": [
+        "categories": [
             2
         ], 
-        "portal_ids": [
-            5
-        ]
+        "primary_topic": 5
     }, 
     {
+        "topics": [
+            5
+        ], 
         "ask_id": "338", 
-        "see_all_ids": [
+        "categories": [
             2
         ], 
-        "portal_ids": [
-            5
-        ]
+        "primary_topic": 5
     }, 
     {
+        "topics": [
+            5
+        ], 
         "ask_id": "337", 
-        "see_all_ids": [
+        "categories": [
             2
         ], 
-        "portal_ids": [
-            5
-        ]
+        "primary_topic": 5
     }, 
     {
+        "topics": [
+            5
+        ], 
         "ask_id": "336", 
-        "see_all_ids": [
+        "categories": [
             1, 
             2
         ], 
-        "portal_ids": [
-            5
-        ]
+        "primary_topic": 5
     }, 
     {
+        "topics": [
+            5
+        ], 
         "ask_id": "335", 
-        "see_all_ids": [
+        "categories": [
             1, 
             2
         ], 
-        "portal_ids": [
-            5
-        ]
+        "primary_topic": 5
     }, 
     {
+        "topics": [
+            5
+        ], 
         "ask_id": "334", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            5
-        ]
+        "primary_topic": 5
     }, 
     {
+        "topics": [
+            5
+        ], 
         "ask_id": "333", 
-        "see_all_ids": [
+        "categories": [
             5
         ], 
-        "portal_ids": [
-            5
-        ]
+        "primary_topic": 5
     }, 
     {
+        "topics": [
+            5
+        ], 
         "ask_id": "332", 
-        "see_all_ids": [
+        "categories": [
             2
         ], 
-        "portal_ids": [
-            5
-        ]
+        "primary_topic": 5
     }, 
     {
+        "topics": [
+            5
+        ], 
         "ask_id": "331", 
-        "see_all_ids": [
+        "categories": [
             2
         ], 
-        "portal_ids": [
-            5
-        ]
+        "primary_topic": 5
     }, 
     {
+        "topics": [
+            5
+        ], 
         "ask_id": "330", 
-        "see_all_ids": [
-            4, 
-            1
+        "categories": [
+            1, 
+            4
         ], 
-        "portal_ids": [
-            5
-        ]
+        "primary_topic": 5
     }, 
     {
+        "topics": [
+            5
+        ], 
         "ask_id": "329", 
-        "see_all_ids": [
+        "categories": [
             2
         ], 
-        "portal_ids": [
-            5
-        ]
+        "primary_topic": 5
     }
 ]

--- a/cfgov/ask_cfpb/fixtures/fraud_and_scams.json
+++ b/cfgov/ask_cfpb/fixtures/fraud_and_scams.json
@@ -1,327 +1,398 @@
 [
     {
+        "topics": [
+            2, 
+            7
+        ], 
         "ask_id": "2094", 
-        "see_all_ids": [
+        "categories": [
             1, 
             3
         ], 
-        "portal_ids": [
-            7
-        ]
+        "primary_topic": 7
     }, 
     {
+        "topics": [
+            2, 
+            7
+        ], 
         "ask_id": "2092", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            7
-        ]
+        "primary_topic": 7
     }, 
     {
+        "topics": [
+            2, 
+            7
+        ], 
         "ask_id": "1777", 
-        "see_all_ids": [
-            5, 
-            3
+        "categories": [
+            3, 
+            5
         ], 
-        "portal_ids": [
-            7
-        ]
+        "primary_topic": 7
     }, 
     {
+        "topics": [
+            2, 
+            7, 
+            9
+        ], 
         "ask_id": "1529", 
-        "see_all_ids": [
+        "categories": [
             3
         ], 
-        "portal_ids": [
-            7
-        ]
+        "primary_topic": 7
     }, 
     {
+        "topics": [
+            2, 
+            7
+        ], 
         "ask_id": "1153", 
-        "see_all_ids": [
-            5, 
-            3
+        "categories": [
+            3, 
+            5
         ], 
-        "portal_ids": [
-            7
-        ]
+        "primary_topic": 7
     }, 
     {
+        "topics": [
+            2, 
+            7
+        ], 
         "ask_id": "1147", 
-        "see_all_ids": [
-            5, 
-            2
+        "categories": [
+            2, 
+            5
         ], 
-        "portal_ids": [
-            7
-        ]
+        "primary_topic": 7
     }, 
     {
+        "topics": [
+            2, 
+            7
+        ], 
         "ask_id": "1073", 
-        "see_all_ids": [
+        "categories": [
             5
         ], 
-        "portal_ids": [
-            7
-        ]
+        "primary_topic": 7
     }, 
     {
+        "topics": [
+            2, 
+            7
+        ], 
         "ask_id": "1071", 
-        "see_all_ids": [
+        "categories": [
             5
         ], 
-        "portal_ids": [
-            7
-        ]
+        "primary_topic": 7
     }, 
     {
+        "topics": [
+            2, 
+            7
+        ], 
         "ask_id": "1067", 
-        "see_all_ids": [
+        "categories": [
             1, 
             4
         ], 
-        "portal_ids": [
-            7
-        ]
+        "primary_topic": 7
     }, 
     {
+        "topics": [
+            2, 
+            7
+        ], 
         "ask_id": "1017", 
-        "see_all_ids": [
-            5, 
-            3
+        "categories": [
+            3, 
+            5
         ], 
-        "portal_ids": [
-            7
-        ]
+        "primary_topic": 7
     }, 
     {
+        "topics": [
+            2, 
+            7
+        ], 
         "ask_id": "1003", 
-        "see_all_ids": [
+        "categories": [
             5
         ], 
-        "portal_ids": [
-            7
-        ]
+        "primary_topic": 7
     }, 
     {
+        "topics": [
+            2, 
+            7
+        ], 
         "ask_id": "1001", 
-        "see_all_ids": [
+        "categories": [
             5
         ], 
-        "portal_ids": [
-            7
-        ]
+        "primary_topic": 7
     }, 
     {
+        "topics": [
+            2, 
+            7
+        ], 
         "ask_id": "999", 
-        "see_all_ids": [
+        "categories": [
             5
         ], 
-        "portal_ids": [
-            7
-        ]
+        "primary_topic": 7
     }, 
     {
+        "topics": [
+            2, 
+            7
+        ], 
         "ask_id": "997", 
-        "see_all_ids": [
+        "categories": [
             5
         ], 
-        "portal_ids": [
-            7
-        ]
+        "primary_topic": 7
     }, 
     {
+        "topics": [
+            2, 
+            7
+        ], 
         "ask_id": "995", 
-        "see_all_ids": [
-            5, 
-            2
+        "categories": [
+            2, 
+            5
         ], 
-        "portal_ids": [
-            7
-        ]
+        "primary_topic": 7
     }, 
     {
+        "topics": [
+            2, 
+            7
+        ], 
         "ask_id": "993", 
-        "see_all_ids": [
-            5, 
-            2
+        "categories": [
+            2, 
+            5
         ], 
-        "portal_ids": [
-            7
-        ]
+        "primary_topic": 7
     }, 
     {
+        "topics": [
+            2, 
+            7
+        ], 
         "ask_id": "991", 
-        "see_all_ids": [
-            5, 
-            2
+        "categories": [
+            2, 
+            5
         ], 
-        "portal_ids": [
-            7
-        ]
+        "primary_topic": 7
     }, 
     {
+        "topics": [
+            2, 
+            7
+        ], 
         "ask_id": "989", 
-        "see_all_ids": [
+        "categories": [
             5
         ], 
-        "portal_ids": [
-            7
-        ]
+        "primary_topic": 7
     }, 
     {
+        "topics": [
+            2, 
+            7
+        ], 
         "ask_id": "987", 
-        "see_all_ids": [
+        "categories": [
             5
         ], 
-        "portal_ids": [
-            7
-        ]
+        "primary_topic": 7
     }, 
     {
+        "topics": [
+            2, 
+            7
+        ], 
         "ask_id": "1935", 
-        "see_all_ids": [
+        "categories": [
             3
         ], 
-        "portal_ids": [
-            7
-        ]
+        "primary_topic": 7
     }, 
     {
+        "topics": [
+            2, 
+            7
+        ], 
         "ask_id": "1933", 
-        "see_all_ids": [
+        "categories": [
             3
         ], 
-        "portal_ids": [
-            7
-        ]
+        "primary_topic": 7
     }, 
     {
+        "topics": [
+            3, 
+            7
+        ], 
         "ask_id": "90", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            7
-        ]
+        "primary_topic": 7
     }, 
     {
+        "topics": [
+            3, 
+            7
+        ], 
         "ask_id": "89", 
-        "see_all_ids": [
+        "categories": [
             5
         ], 
-        "portal_ids": [
-            7
-        ]
+        "primary_topic": 7
     }, 
     {
+        "topics": [
+            3, 
+            7
+        ], 
         "ask_id": "63", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            7
-        ]
+        "primary_topic": 7
     }, 
     {
+        "topics": [
+            3, 
+            7
+        ], 
         "ask_id": "62", 
-        "see_all_ids": [
+        "categories": [
             5
         ], 
-        "portal_ids": [
-            7
-        ]
+        "primary_topic": 7
     }, 
     {
+        "topics": [
+            3, 
+            7
+        ], 
         "ask_id": "61", 
-        "see_all_ids": [
+        "categories": [
             3
         ], 
-        "portal_ids": [
-            7
-        ]
+        "primary_topic": 7
     }, 
     {
+        "topics": [
+            3, 
+            7
+        ], 
         "ask_id": "30", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            7
-        ]
+        "primary_topic": 7
     }, 
     {
+        "topics": [
+            3, 
+            7
+        ], 
         "ask_id": "29", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            7
-        ]
+        "primary_topic": 7
     }, 
     {
+        "topics": [
+            3, 
+            7
+        ], 
         "ask_id": "28", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            7
-        ]
+        "primary_topic": 7
     }, 
     {
+        "topics": [
+            3, 
+            7
+        ], 
         "ask_id": "26", 
-        "see_all_ids": [
+        "categories": [
             4
         ], 
-        "portal_ids": [
-            7
-        ]
+        "primary_topic": 7
     }, 
     {
+        "topics": [
+            3, 
+            7
+        ], 
         "ask_id": "27", 
-        "see_all_ids": [
+        "categories": [
             5
         ], 
-        "portal_ids": [
-            7
-        ]
+        "primary_topic": 7
     }, 
     {
+        "topics": [
+            4, 
+            7
+        ], 
         "ask_id": "31", 
-        "see_all_ids": [
+        "categories": [
             1, 
             3
         ], 
-        "portal_ids": [
-            7
-        ]
+        "primary_topic": 7
     }, 
     {
+        "topics": [
+            4, 
+            7
+        ], 
         "ask_id": "1243", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            7
-        ]
+        "primary_topic": 7
     }, 
     {
+        "topics": [
+            4, 
+            7
+        ], 
         "ask_id": "1359", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            7
-        ]
+        "primary_topic": 7
     }, 
     {
+        "topics": [
+            4, 
+            7
+        ], 
         "ask_id": "1369", 
-        "see_all_ids": [
+        "categories": [
             4
         ], 
-        "portal_ids": [
-            7
-        ]
+        "primary_topic": 7
     }
 ]

--- a/cfgov/ask_cfpb/fixtures/money_transfers.json
+++ b/cfgov/ask_cfpb/fixtures/money_transfers.json
@@ -1,356 +1,390 @@
 [
     {
+        "topics": [
+            8
+        ], 
         "ask_id": "1893", 
-        "see_all_ids": [
-            4, 
+        "categories": [
             1, 
+            4, 
             5
         ], 
-        "portal_ids": [
-            8
-        ]
+        "primary_topic": 8
     }, 
     {
+        "topics": [
+            8
+        ], 
         "ask_id": "1833", 
-        "see_all_ids": [
-            3, 
-            1
+        "categories": [
+            1, 
+            3
         ], 
-        "portal_ids": [
-            8
-        ]
+        "primary_topic": 8
     }, 
     {
+        "topics": [
+            8
+        ], 
         "ask_id": "1767", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            8
-        ]
+        "primary_topic": 8
     }, 
     {
+        "topics": [
+            8
+        ], 
         "ask_id": "1765", 
-        "see_all_ids": [
-            2, 
+        "categories": [
             1, 
+            2, 
             5
         ], 
-        "portal_ids": [
-            8
-        ]
+        "primary_topic": 8
     }, 
     {
+        "topics": [
+            8
+        ], 
         "ask_id": "1763", 
-        "see_all_ids": [
+        "categories": [
             1, 
             2, 
             5
         ], 
-        "portal_ids": [
-            8
-        ]
+        "primary_topic": 8
     }, 
     {
+        "topics": [
+            8
+        ], 
         "ask_id": "1761", 
-        "see_all_ids": [
+        "categories": [
             1, 
             5
         ], 
-        "portal_ids": [
-            8
-        ]
+        "primary_topic": 8
     }, 
     {
+        "topics": [
+            8
+        ], 
         "ask_id": "1759", 
-        "see_all_ids": [
+        "categories": [
             1, 
             5
         ], 
-        "portal_ids": [
-            8
-        ]
+        "primary_topic": 8
     }, 
     {
+        "topics": [
+            8
+        ], 
         "ask_id": "1757", 
-        "see_all_ids": [
+        "categories": [
             2, 
             5
         ], 
-        "portal_ids": [
-            8
-        ]
+        "primary_topic": 8
     }, 
     {
+        "topics": [
+            8
+        ], 
         "ask_id": "1755", 
-        "see_all_ids": [
-            5, 
+        "categories": [
+            1, 
             2, 
-            1
+            5
         ], 
-        "portal_ids": [
-            8
-        ]
+        "primary_topic": 8
     }, 
     {
+        "topics": [
+            8
+        ], 
         "ask_id": "1753", 
-        "see_all_ids": [
+        "categories": [
             3, 
             5
         ], 
-        "portal_ids": [
-            8
-        ]
+        "primary_topic": 8
     }, 
     {
+        "topics": [
+            8
+        ], 
         "ask_id": "1751", 
-        "see_all_ids": [
-            5, 
-            2
+        "categories": [
+            2, 
+            5
         ], 
-        "portal_ids": [
-            8
-        ]
+        "primary_topic": 8
     }, 
     {
+        "topics": [
+            8
+        ], 
         "ask_id": "1749", 
-        "see_all_ids": [
-            5, 
+        "categories": [
             2, 
-            3
+            3, 
+            5
         ], 
-        "portal_ids": [
-            8
-        ]
+        "primary_topic": 8
     }, 
     {
+        "topics": [
+            8
+        ], 
         "ask_id": "1747", 
-        "see_all_ids": [
+        "categories": [
             1, 
-            5, 
-            2
+            2, 
+            5
         ], 
-        "portal_ids": [
-            8
-        ]
+        "primary_topic": 8
     }, 
     {
+        "topics": [
+            8
+        ], 
         "ask_id": "1745", 
-        "see_all_ids": [
+        "categories": [
             1, 
             2, 
             5
         ], 
-        "portal_ids": [
-            8
-        ]
+        "primary_topic": 8
     }, 
     {
+        "topics": [
+            8
+        ], 
         "ask_id": "1743", 
-        "see_all_ids": [
-            5, 
+        "categories": [
+            1, 
             2, 
-            1
+            5
         ], 
-        "portal_ids": [
-            8
-        ]
+        "primary_topic": 8
     }, 
     {
+        "topics": [
+            8
+        ], 
         "ask_id": "1741", 
-        "see_all_ids": [
+        "categories": [
+            2, 
             3, 
-            5, 
-            2
+            5
         ], 
-        "portal_ids": [
-            8
-        ]
+        "primary_topic": 8
     }, 
     {
+        "topics": [
+            8
+        ], 
         "ask_id": "1739", 
-        "see_all_ids": [
+        "categories": [
             3, 
             5
         ], 
-        "portal_ids": [
-            8
-        ]
+        "primary_topic": 8
     }, 
     {
+        "topics": [
+            8
+        ], 
         "ask_id": "1737", 
-        "see_all_ids": [
+        "categories": [
             1, 
+            2, 
             3, 
-            2, 
             5
         ], 
-        "portal_ids": [
-            8
-        ]
+        "primary_topic": 8
     }, 
     {
+        "topics": [
+            8
+        ], 
         "ask_id": "1735", 
-        "see_all_ids": [
+        "categories": [
             1, 
             2, 
             5
         ], 
-        "portal_ids": [
-            8
-        ]
+        "primary_topic": 8
     }, 
     {
-        "ask_id": "1733", 
-        "see_all_ids": [
-            2, 
-            1
+        "topics": [
+            8
         ], 
-        "portal_ids": [
-            8
-        ]
-    }, 
-    {
-        "ask_id": "1731", 
-        "see_all_ids": [
+        "ask_id": "1733", 
+        "categories": [
+            1, 
             2
         ], 
-        "portal_ids": [
-            8
-        ]
+        "primary_topic": 8
     }, 
     {
+        "topics": [
+            8
+        ], 
+        "ask_id": "1731", 
+        "categories": [
+            2
+        ], 
+        "primary_topic": 8
+    }, 
+    {
+        "topics": [
+            8
+        ], 
         "ask_id": "1729", 
-        "see_all_ids": [
+        "categories": [
             1, 
             5
         ], 
-        "portal_ids": [
-            8
-        ]
+        "primary_topic": 8
     }, 
     {
+        "topics": [
+            8
+        ], 
         "ask_id": "1727", 
-        "see_all_ids": [
-            2, 
+        "categories": [
             1, 
-            5
-        ], 
-        "portal_ids": [
-            8
-        ]
-    }, 
-    {
-        "ask_id": "1725", 
-        "see_all_ids": [
             2, 
             5
         ], 
-        "portal_ids": [
-            8
-        ]
+        "primary_topic": 8
     }, 
     {
+        "topics": [
+            8
+        ], 
+        "ask_id": "1725", 
+        "categories": [
+            2, 
+            5
+        ], 
+        "primary_topic": 8
+    }, 
+    {
+        "topics": [
+            8
+        ], 
         "ask_id": "1723", 
-        "see_all_ids": [
+        "categories": [
             1, 
             3
         ], 
-        "portal_ids": [
-            8
-        ]
+        "primary_topic": 8
     }, 
     {
+        "topics": [
+            8
+        ], 
         "ask_id": "1721", 
-        "see_all_ids": [
-            4, 
+        "categories": [
             1, 
-            2
+            2, 
+            4
         ], 
-        "portal_ids": [
-            8
-        ]
+        "primary_topic": 8
     }, 
     {
+        "topics": [
+            8
+        ], 
         "ask_id": "1507", 
-        "see_all_ids": [
+        "categories": [
+            1, 
             2, 
-            4, 
-            1
+            4
         ], 
-        "portal_ids": [
-            8
-        ]
+        "primary_topic": 8
     }, 
     {
+        "topics": [
+            8
+        ], 
         "ask_id": "1505", 
-        "see_all_ids": [
+        "categories": [
             2, 
             5
         ], 
-        "portal_ids": [
-            8
-        ]
+        "primary_topic": 8
     }, 
     {
+        "topics": [
+            8
+        ], 
         "ask_id": "1169", 
-        "see_all_ids": [
+        "categories": [
             2, 
             5
         ], 
-        "portal_ids": [
-            8
-        ]
+        "primary_topic": 8
     }, 
     {
+        "topics": [
+            8
+        ], 
         "ask_id": "1167", 
-        "see_all_ids": [
+        "categories": [
             2, 
             5
         ], 
-        "portal_ids": [
-            8
-        ]
+        "primary_topic": 8
     }, 
     {
+        "topics": [
+            8
+        ], 
         "ask_id": "1165", 
-        "see_all_ids": [
+        "categories": [
             1, 
             2
         ], 
-        "portal_ids": [
-            8
-        ]
+        "primary_topic": 8
     }, 
     {
+        "topics": [
+            8
+        ], 
         "ask_id": "1163", 
-        "see_all_ids": [
-            4, 
-            2
+        "categories": [
+            2, 
+            4
         ], 
-        "portal_ids": [
-            8
-        ]
+        "primary_topic": 8
     }, 
     {
+        "topics": [
+            8
+        ], 
         "ask_id": "1161", 
-        "see_all_ids": [
-            4, 
+        "categories": [
             1, 
-            2
+            2, 
+            4
         ], 
-        "portal_ids": [
-            8
-        ]
+        "primary_topic": 8
     }, 
     {
-        "ask_id": "1065", 
-        "see_all_ids": [
-            4, 
-            1
-        ], 
-        "portal_ids": [
+        "topics": [
             8
-        ]
+        ], 
+        "ask_id": "1065", 
+        "categories": [
+            1, 
+            4
+        ], 
+        "primary_topic": 8
     }
 ]

--- a/cfgov/ask_cfpb/fixtures/mortgages.json
+++ b/cfgov/ask_cfpb/fixtures/mortgages.json
@@ -1,2310 +1,2560 @@
 [
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "2082", 
-        "see_all_ids": [
+        "categories": [
             5
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "2071", 
-        "see_all_ids": [
+        "categories": [
             2
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "2061", 
-        "see_all_ids": [
+        "categories": [
             2
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "2059", 
-        "see_all_ids": [
+        "categories": [
             2, 
             5
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            1, 
+            9
+        ], 
         "ask_id": "2057", 
-        "see_all_ids": [
+        "categories": [
             2
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "2011", 
-        "see_all_ids": [
+        "categories": [
             4
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "2009", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "2007", 
-        "see_all_ids": [
+        "categories": [
             5
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "2005", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "2003", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "2001", 
-        "see_all_ids": [
+        "categories": [
             4
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "1999", 
-        "see_all_ids": [
+        "categories": [
             4
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "1997", 
-        "see_all_ids": [
+        "categories": [
             4
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "1995", 
-        "see_all_ids": [
-            4, 
-            1
+        "categories": [
+            1, 
+            4
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "1993", 
-        "see_all_ids": [
+        "categories": [
             5
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "1991", 
-        "see_all_ids": [
-            5, 
-            2
+        "categories": [
+            2, 
+            5
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "1989", 
-        "see_all_ids": [
+        "categories": [
             5
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "1987", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "1985", 
-        "see_all_ids": [
+        "categories": [
             5
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "1983", 
-        "see_all_ids": [
+        "categories": [
             4
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "1979", 
-        "see_all_ids": [
+        "categories": [
             4
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "1965", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "1963", 
-        "see_all_ids": [
+        "categories": [
             3
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "1961", 
-        "see_all_ids": [
+        "categories": [
             3
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "1959", 
-        "see_all_ids": [
+        "categories": [
             4
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "1957", 
-        "see_all_ids": [
+        "categories": [
             1, 
             4
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "1955", 
-        "see_all_ids": [
+        "categories": [
             4
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "1953", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "1951", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "1949", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "1947", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "1945", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "1943", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "1941", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "1939", 
-        "see_all_ids": [
-            5, 
-            2
+        "categories": [
+            2, 
+            5
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "1937", 
-        "see_all_ids": [
-            5, 
-            2
+        "categories": [
+            2, 
+            5
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "1927", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "1925", 
-        "see_all_ids": [
+        "categories": [
             4
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "1923", 
-        "see_all_ids": [
+        "categories": [
             4
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "1921", 
-        "see_all_ids": [
+        "categories": [
             4
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "1919", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "1917", 
-        "see_all_ids": [
-            5, 
-            3
+        "categories": [
+            3, 
+            5
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "1913", 
-        "see_all_ids": [
-            5, 
-            3
+        "categories": [
+            3, 
+            5
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "1911", 
-        "see_all_ids": [
-            5, 
-            3
+        "categories": [
+            3, 
+            5
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "1907", 
-        "see_all_ids": [
+        "categories": [
             3
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "1905", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "1903", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "1877", 
-        "see_all_ids": [
+        "categories": [
             3
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "1875", 
-        "see_all_ids": [
+        "categories": [
             5
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "1855", 
-        "see_all_ids": [
+        "categories": [
             3, 
             5
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "1853", 
-        "see_all_ids": [
+        "categories": [
             5
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "1851", 
-        "see_all_ids": [
+        "categories": [
             5
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "1849", 
-        "see_all_ids": [
+        "categories": [
             5
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "1845", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "1843", 
-        "see_all_ids": [
+        "categories": [
             5
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "1841", 
-        "see_all_ids": [
-            5, 
-            2
+        "categories": [
+            2, 
+            5
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "1807", 
-        "see_all_ids": [
-            5, 
-            4
+        "categories": [
+            4, 
+            5
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "1805", 
-        "see_all_ids": [
+        "categories": [
             5
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "1803", 
-        "see_all_ids": [
-            5, 
-            2
+        "categories": [
+            2, 
+            5
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "1801", 
-        "see_all_ids": [
+        "categories": [
             5
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "1799", 
-        "see_all_ids": [
+        "categories": [
             5
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "1797", 
-        "see_all_ids": [
+        "categories": [
             1, 
             4
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "1795", 
-        "see_all_ids": [
+        "categories": [
             2
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "1793", 
-        "see_all_ids": [
+        "categories": [
             2, 
             5
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "1791", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "1789", 
-        "see_all_ids": [
+        "categories": [
             1, 
             4
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "1787", 
-        "see_all_ids": [
+        "categories": [
             2, 
             4
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "1545", 
-        "see_all_ids": [
-            5, 
+        "categories": [
+            2, 
             3, 
-            2
+            5
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "1531", 
-        "see_all_ids": [
+        "categories": [
             2, 
             4
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "1525", 
-        "see_all_ids": [
+        "categories": [
             5
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "1523", 
-        "see_all_ids": [
+        "categories": [
             5
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "1521", 
-        "see_all_ids": [
+        "categories": [
             3, 
             5
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "1519", 
-        "see_all_ids": [
+        "categories": [
             5
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "1517", 
-        "see_all_ids": [
+        "categories": [
             5
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "1515", 
-        "see_all_ids": [
+        "categories": [
             5
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "1513", 
-        "see_all_ids": [
+        "categories": [
             3, 
             5
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "363", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "360", 
-        "see_all_ids": [
+        "categories": [
             2, 
             5
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "359", 
-        "see_all_ids": [
+        "categories": [
             2, 
             5
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "358", 
-        "see_all_ids": [
+        "categories": [
             2, 
             5
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "357", 
-        "see_all_ids": [
+        "categories": [
             2, 
             5
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "356", 
-        "see_all_ids": [
+        "categories": [
             2
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "355", 
-        "see_all_ids": [
+        "categories": [
             2
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "354", 
-        "see_all_ids": [
-            5, 
-            1
+        "categories": [
+            1, 
+            5
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "353", 
-        "see_all_ids": [
+        "categories": [
             1, 
             2
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "352", 
-        "see_all_ids": [
+        "categories": [
             2, 
             5
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "351", 
-        "see_all_ids": [
+        "categories": [
             5
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "350", 
-        "see_all_ids": [
+        "categories": [
             2
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "349", 
-        "see_all_ids": [
+        "categories": [
             2
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "348", 
-        "see_all_ids": [
+        "categories": [
             2
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "347", 
-        "see_all_ids": [
+        "categories": [
             2
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "346", 
-        "see_all_ids": [
+        "categories": [
             2
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "345", 
-        "see_all_ids": [
+        "categories": [
             2, 
             5
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "344", 
-        "see_all_ids": [
+        "categories": [
             2, 
             5
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "343", 
-        "see_all_ids": [
+        "categories": [
             2
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "342", 
-        "see_all_ids": [
+        "categories": [
             2, 
             3
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "326", 
-        "see_all_ids": [
-            5, 
-            1
+        "categories": [
+            1, 
+            5
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "324", 
-        "see_all_ids": [
+        "categories": [
             5
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "308", 
-        "see_all_ids": [
+        "categories": [
             5
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "307", 
-        "see_all_ids": [
+        "categories": [
             5
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "306", 
-        "see_all_ids": [
+        "categories": [
             2
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "305", 
-        "see_all_ids": [
+        "categories": [
             1, 
             5
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "304", 
-        "see_all_ids": [
+        "categories": [
             5
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "302", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "298", 
-        "see_all_ids": [
+        "categories": [
             5
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "297", 
-        "see_all_ids": [
+        "categories": [
             5
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "296", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "295", 
-        "see_all_ids": [
-            5, 
-            3
+        "categories": [
+            3, 
+            5
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "294", 
-        "see_all_ids": [
+        "categories": [
             3
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "292", 
-        "see_all_ids": [
+        "categories": [
             5
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "291", 
-        "see_all_ids": [
+        "categories": [
             1, 
             4
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "290", 
-        "see_all_ids": [
+        "categories": [
             4
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "289", 
-        "see_all_ids": [
+        "categories": [
             1, 
             4
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "287", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "285", 
-        "see_all_ids": [
+        "categories": [
             5
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "281", 
-        "see_all_ids": [
+        "categories": [
             5
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "280", 
-        "see_all_ids": [
+        "categories": [
             5
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "278", 
-        "see_all_ids": [
+        "categories": [
             5
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "277", 
-        "see_all_ids": [
+        "categories": [
             2, 
             5
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "276", 
-        "see_all_ids": [
-            5, 
-            2
+        "categories": [
+            2, 
+            5
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "275", 
-        "see_all_ids": [
-            5, 
-            2
+        "categories": [
+            2, 
+            5
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "274", 
-        "see_all_ids": [
-            5, 
-            2
+        "categories": [
+            2, 
+            5
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "273", 
-        "see_all_ids": [
-            5, 
-            3
+        "categories": [
+            3, 
+            5
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "272", 
-        "see_all_ids": [
+        "categories": [
             5
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "270", 
-        "see_all_ids": [
-            5, 
-            4
+        "categories": [
+            4, 
+            5
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "269", 
-        "see_all_ids": [
+        "categories": [
             4
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "268", 
-        "see_all_ids": [
-            5, 
-            3
+        "categories": [
+            3, 
+            5
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "267", 
-        "see_all_ids": [
-            5, 
-            2
+        "categories": [
+            2, 
+            5
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "266", 
-        "see_all_ids": [
+        "categories": [
             5
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "263", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "261", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "260", 
-        "see_all_ids": [
-            5, 
-            2
+        "categories": [
+            2, 
+            5
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "256", 
-        "see_all_ids": [
+        "categories": [
             5
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "253", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "252", 
-        "see_all_ids": [
+        "categories": [
             5
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "251", 
-        "see_all_ids": [
-            5, 
-            2
+        "categories": [
+            2, 
+            5
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "250", 
-        "see_all_ids": [
-            5, 
-            2
+        "categories": [
+            2, 
+            5
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "249", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "248", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "247", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "246", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "223", 
-        "see_all_ids": [
+        "categories": [
             5
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "222", 
-        "see_all_ids": [
-            5, 
-            3
+        "categories": [
+            3, 
+            5
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "221", 
-        "see_all_ids": [
-            5, 
-            3
+        "categories": [
+            3, 
+            5
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "220", 
-        "see_all_ids": [
-            5, 
-            3
+        "categories": [
+            3, 
+            5
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "219", 
-        "see_all_ids": [
-            5, 
-            3
+        "categories": [
+            3, 
+            5
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "218", 
-        "see_all_ids": [
-            5, 
-            3
+        "categories": [
+            3, 
+            5
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "217", 
-        "see_all_ids": [
+        "categories": [
             3
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "216", 
-        "see_all_ids": [
-            5, 
-            2
+        "categories": [
+            2, 
+            5
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "215", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "214", 
-        "see_all_ids": [
+        "categories": [
             1, 
             3
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "213", 
-        "see_all_ids": [
+        "categories": [
             5
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "212", 
-        "see_all_ids": [
-            5, 
-            3
+        "categories": [
+            3, 
+            5
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "211", 
-        "see_all_ids": [
-            5, 
-            3
+        "categories": [
+            3, 
+            5
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "210", 
-        "see_all_ids": [
+        "categories": [
             3, 
             5
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "209", 
-        "see_all_ids": [
-            5, 
-            2
+        "categories": [
+            2, 
+            5
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "208", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "207", 
-        "see_all_ids": [
+        "categories": [
             1, 
             4
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "206", 
-        "see_all_ids": [
+        "categories": [
             3
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "205", 
-        "see_all_ids": [
+        "categories": [
             4
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "204", 
-        "see_all_ids": [
+        "categories": [
             2, 
             5
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "203", 
-        "see_all_ids": [
+        "categories": [
             5
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "202", 
-        "see_all_ids": [
+        "categories": [
             1, 
             2
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "201", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "200", 
-        "see_all_ids": [
+        "categories": [
             5
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "199", 
-        "see_all_ids": [
+        "categories": [
             1, 
             2
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "198", 
-        "see_all_ids": [
+        "categories": [
             1, 
             4
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "197", 
-        "see_all_ids": [
+        "categories": [
             5
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "196", 
-        "see_all_ids": [
+        "categories": [
             3
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "195", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "193", 
-        "see_all_ids": [
+        "categories": [
             1, 
             2
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "192", 
-        "see_all_ids": [
+        "categories": [
             2
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "190", 
-        "see_all_ids": [
-            5, 
-            2
+        "categories": [
+            2, 
+            5
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9, 
+            12
+        ], 
         "ask_id": "189", 
-        "see_all_ids": [
-            5, 
+        "categories": [
+            2, 
             3, 
-            2
+            5
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "188", 
-        "see_all_ids": [
+        "categories": [
             2, 
             5
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "187", 
-        "see_all_ids": [
+        "categories": [
             2, 
             5
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "186", 
-        "see_all_ids": [
-            5, 
-            2
+        "categories": [
+            2, 
+            5
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "185", 
-        "see_all_ids": [
-            5, 
-            2
+        "categories": [
+            2, 
+            5
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "184", 
-        "see_all_ids": [
+        "categories": [
             5
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "183", 
-        "see_all_ids": [
+        "categories": [
             5
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "182", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "181", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "180", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "179", 
-        "see_all_ids": [
+        "categories": [
             1, 
             2
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9, 
+            12
+        ], 
         "ask_id": "178", 
-        "see_all_ids": [
+        "categories": [
             4
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "177", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "176", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "175", 
-        "see_all_ids": [
+        "categories": [
             3
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "172", 
-        "see_all_ids": [
+        "categories": [
             1, 
             2
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "170", 
-        "see_all_ids": [
+        "categories": [
             5
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "168", 
-        "see_all_ids": [
+        "categories": [
             5
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "167", 
-        "see_all_ids": [
+        "categories": [
             1, 
             4
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "166", 
-        "see_all_ids": [
+        "categories": [
             4
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "164", 
-        "see_all_ids": [
-            4, 
-            1
+        "categories": [
+            1, 
+            4
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "163", 
-        "see_all_ids": [
-            4, 
-            1
+        "categories": [
+            1, 
+            4
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "162", 
-        "see_all_ids": [
-            4, 
-            1
+        "categories": [
+            1, 
+            4
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "161", 
-        "see_all_ids": [
+        "categories": [
             4
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "160", 
-        "see_all_ids": [
+        "categories": [
             4
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "159", 
-        "see_all_ids": [
+        "categories": [
             4
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "158", 
-        "see_all_ids": [
-            5, 
-            2
+        "categories": [
+            2, 
+            5
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "157", 
-        "see_all_ids": [
+        "categories": [
             4
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "155", 
-        "see_all_ids": [
+        "categories": [
             4
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "154", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "153", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "152", 
-        "see_all_ids": [
+        "categories": [
             4
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "148", 
-        "see_all_ids": [
+        "categories": [
             5
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "147", 
-        "see_all_ids": [
-            5, 
-            2
+        "categories": [
+            2, 
+            5
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "144", 
-        "see_all_ids": [
+        "categories": [
             3
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "143", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "141", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "140", 
-        "see_all_ids": [
-            4, 
-            1
+        "categories": [
+            1, 
+            4
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "137", 
-        "see_all_ids": [
+        "categories": [
             3
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "136", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "135", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "134", 
-        "see_all_ids": [
+        "categories": [
             3
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "133", 
-        "see_all_ids": [
+        "categories": [
             3
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "132", 
-        "see_all_ids": [
+        "categories": [
             5
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "131", 
-        "see_all_ids": [
+        "categories": [
             3
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "130", 
-        "see_all_ids": [
+        "categories": [
             1, 
             4
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "129", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "128", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "127", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "124", 
-        "see_all_ids": [
+        "categories": [
             5
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "123", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "122", 
-        "see_all_ids": [
-            4, 
-            1
-        ], 
-        "portal_ids": [
-            9
-        ]
-    }, 
-    {
-        "ask_id": "121", 
-        "see_all_ids": [
+        "categories": [
+            1, 
             4
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
+        "ask_id": "121", 
+        "categories": [
+            4
+        ], 
+        "primary_topic": 9
+    }, 
+    {
+        "topics": [
+            9
+        ], 
         "ask_id": "120", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "119", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "118", 
-        "see_all_ids": [
+        "categories": [
             3
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "117", 
-        "see_all_ids": [
+        "categories": [
             4
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "116", 
-        "see_all_ids": [
+        "categories": [
             4
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "115", 
-        "see_all_ids": [
+        "categories": [
             4
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "114", 
-        "see_all_ids": [
+        "categories": [
             4
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "113", 
-        "see_all_ids": [
+        "categories": [
             4
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "112", 
-        "see_all_ids": [
+        "categories": [
             4
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "111", 
-        "see_all_ids": [
+        "categories": [
             4
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "110", 
-        "see_all_ids": [
+        "categories": [
             4
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "108", 
-        "see_all_ids": [
+        "categories": [
             4
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "107", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "106", 
-        "see_all_ids": [
+        "categories": [
             1, 
             4
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "105", 
-        "see_all_ids": [
+        "categories": [
             1, 
             4
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "104", 
-        "see_all_ids": [
+        "categories": [
             4
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "103", 
-        "see_all_ids": [
+        "categories": [
             4
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "102", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "101", 
-        "see_all_ids": [
+        "categories": [
             4
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "100", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }, 
     {
+        "topics": [
+            9
+        ], 
         "ask_id": "99", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            9
-        ]
+        "primary_topic": 9
     }
 ]

--- a/cfgov/ask_cfpb/fixtures/payday_loans.json
+++ b/cfgov/ask_cfpb/fixtures/payday_loans.json
@@ -1,210 +1,240 @@
 [
     {
+        "topics": [
+            1, 
+            3, 
+            9, 
+            10
+        ], 
         "ask_id": "1785", 
-        "see_all_ids": [
+        "categories": [
             1, 
             2
         ], 
-        "portal_ids": [
-            10
-        ]
+        "primary_topic": 10
     }, 
     {
+        "topics": [
+            3, 
+            10
+        ], 
         "ask_id": "1783", 
-        "see_all_ids": [
+        "categories": [
             2
         ], 
-        "portal_ids": [
-            10
-        ]
+        "primary_topic": 10
     }, 
     {
-        "ask_id": "1631", 
-        "see_all_ids": [
-            2, 
-            1
+        "topics": [
+            10
         ], 
-        "portal_ids": [
-            10
-        ]
+        "ask_id": "1631", 
+        "categories": [
+            1, 
+            2
+        ], 
+        "primary_topic": 10
     }, 
     {
+        "topics": [
+            3, 
+            10
+        ], 
         "ask_id": "1625", 
-        "see_all_ids": [
-            4, 
+        "categories": [
             1, 
+            4, 
             5
         ], 
-        "portal_ids": [
-            10
-        ]
+        "primary_topic": 10
     }, 
     {
-        "ask_id": "1623", 
-        "see_all_ids": [
-            5, 
-            2
+        "topics": [
+            10
         ], 
-        "portal_ids": [
-            10
-        ]
+        "ask_id": "1623", 
+        "categories": [
+            2, 
+            5
+        ], 
+        "primary_topic": 10
     }, 
     {
+        "topics": [
+            10
+        ], 
         "ask_id": "1617", 
-        "see_all_ids": [
+        "categories": [
             1, 
             4
         ], 
-        "portal_ids": [
-            10
-        ]
+        "primary_topic": 10
     }, 
     {
+        "topics": [
+            10
+        ], 
         "ask_id": "1611", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            10
-        ]
+        "primary_topic": 10
     }, 
     {
+        "topics": [
+            10
+        ], 
         "ask_id": "1609", 
-        "see_all_ids": [
+        "categories": [
             1, 
-            4, 
-            2
+            2, 
+            4
         ], 
-        "portal_ids": [
-            10
-        ]
+        "primary_topic": 10
     }, 
     {
+        "topics": [
+            10
+        ], 
         "ask_id": "1605", 
-        "see_all_ids": [
+        "categories": [
             3, 
             5
         ], 
-        "portal_ids": [
-            10
-        ]
+        "primary_topic": 10
     }, 
     {
+        "topics": [
+            10
+        ], 
         "ask_id": "1603", 
-        "see_all_ids": [
+        "categories": [
             1, 
             5
         ], 
-        "portal_ids": [
-            10
-        ]
+        "primary_topic": 10
     }, 
     {
+        "topics": [
+            10
+        ], 
         "ask_id": "1601", 
-        "see_all_ids": [
+        "categories": [
             1, 
             5
         ], 
-        "portal_ids": [
-            10
-        ]
+        "primary_topic": 10
     }, 
     {
+        "topics": [
+            10
+        ], 
         "ask_id": "1599", 
-        "see_all_ids": [
+        "categories": [
             1, 
             5
         ], 
-        "portal_ids": [
-            10
-        ]
+        "primary_topic": 10
     }, 
     {
+        "topics": [
+            10
+        ], 
         "ask_id": "1597", 
-        "see_all_ids": [
-            3, 
-            1
-        ], 
-        "portal_ids": [
-            10
-        ]
-    }, 
-    {
-        "ask_id": "1595", 
-        "see_all_ids": [
-            1, 
-            5
-        ], 
-        "portal_ids": [
-            10
-        ]
-    }, 
-    {
-        "ask_id": "1593", 
-        "see_all_ids": [
-            1, 
-            5
-        ], 
-        "portal_ids": [
-            10
-        ]
-    }, 
-    {
-        "ask_id": "1589", 
-        "see_all_ids": [
-            1
-        ], 
-        "portal_ids": [
-            10
-        ]
-    }, 
-    {
-        "ask_id": "1583", 
-        "see_all_ids": [
-            1
-        ], 
-        "portal_ids": [
-            10
-        ]
-    }, 
-    {
-        "ask_id": "1575", 
-        "see_all_ids": [
-            1
-        ], 
-        "portal_ids": [
-            10
-        ]
-    }, 
-    {
-        "ask_id": "1573", 
-        "see_all_ids": [
-            1, 
-            5
-        ], 
-        "portal_ids": [
-            10
-        ]
-    }, 
-    {
-        "ask_id": "1569", 
-        "see_all_ids": [
+        "categories": [
             1, 
             3
         ], 
-        "portal_ids": [
-            10
-        ]
+        "primary_topic": 10
     }, 
     {
-        "ask_id": "1567", 
-        "see_all_ids": [
-            4, 
-            1, 
-            2
+        "topics": [
+            10, 
+            11
         ], 
-        "portal_ids": [
+        "ask_id": "1595", 
+        "categories": [
+            1, 
+            5
+        ], 
+        "primary_topic": 10
+    }, 
+    {
+        "topics": [
             10
-        ]
+        ], 
+        "ask_id": "1593", 
+        "categories": [
+            1, 
+            5
+        ], 
+        "primary_topic": 10
+    }, 
+    {
+        "topics": [
+            10, 
+            11
+        ], 
+        "ask_id": "1589", 
+        "categories": [
+            1
+        ], 
+        "primary_topic": 10
+    }, 
+    {
+        "topics": [
+            5, 
+            10
+        ], 
+        "ask_id": "1583", 
+        "categories": [
+            1
+        ], 
+        "primary_topic": 10
+    }, 
+    {
+        "topics": [
+            10
+        ], 
+        "ask_id": "1575", 
+        "categories": [
+            1
+        ], 
+        "primary_topic": 10
+    }, 
+    {
+        "topics": [
+            10
+        ], 
+        "ask_id": "1573", 
+        "categories": [
+            1, 
+            5
+        ], 
+        "primary_topic": 10
+    }, 
+    {
+        "topics": [
+            10
+        ], 
+        "ask_id": "1569", 
+        "categories": [
+            1, 
+            3
+        ], 
+        "primary_topic": 10
+    }, 
+    {
+        "topics": [
+            10, 
+            11
+        ], 
+        "ask_id": "1567", 
+        "categories": [
+            1, 
+            2, 
+            4
+        ], 
+        "primary_topic": 10
     }
 ]

--- a/cfgov/ask_cfpb/fixtures/prepaid_cards.json
+++ b/cfgov/ask_cfpb/fixtures/prepaid_cards.json
@@ -1,427 +1,473 @@
 [
     {
+        "topics": [
+            11
+        ], 
         "ask_id": "2084", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            11
-        ]
+        "primary_topic": 11
     }, 
     {
+        "topics": [
+            11
+        ], 
         "ask_id": "2055", 
-        "see_all_ids": [
-            5, 
-            3
+        "categories": [
+            3, 
+            5
         ], 
-        "portal_ids": [
-            11
-        ]
+        "primary_topic": 11
     }, 
     {
+        "topics": [
+            11
+        ], 
         "ask_id": "2053", 
-        "see_all_ids": [
+        "categories": [
             1, 
             4
         ], 
-        "portal_ids": [
-            11
-        ]
+        "primary_topic": 11
     }, 
     {
+        "topics": [
+            11
+        ], 
         "ask_id": "539", 
-        "see_all_ids": [
+        "categories": [
             1, 
             2
         ], 
-        "portal_ids": [
-            11
-        ]
+        "primary_topic": 11
     }, 
     {
+        "topics": [
+            11
+        ], 
         "ask_id": "537", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            11
-        ]
+        "primary_topic": 11
     }, 
     {
+        "topics": [
+            2, 
+            11
+        ], 
         "ask_id": "529", 
-        "see_all_ids": [
+        "categories": [
             1, 
             2
         ], 
-        "portal_ids": [
-            11
-        ]
+        "primary_topic": 11
     }, 
     {
+        "topics": [
+            11
+        ], 
         "ask_id": "523", 
-        "see_all_ids": [
+        "categories": [
             1, 
             3
         ], 
-        "portal_ids": [
-            11
-        ]
+        "primary_topic": 11
     }, 
     {
+        "topics": [
+            11
+        ], 
         "ask_id": "521", 
-        "see_all_ids": [
+        "categories": [
             1, 
             5
         ], 
-        "portal_ids": [
-            11
-        ]
+        "primary_topic": 11
     }, 
     {
+        "topics": [
+            11
+        ], 
         "ask_id": "515", 
-        "see_all_ids": [
+        "categories": [
             1, 
             5
         ], 
-        "portal_ids": [
-            11
-        ]
+        "primary_topic": 11
     }, 
     {
+        "topics": [
+            11
+        ], 
         "ask_id": "513", 
-        "see_all_ids": [
+        "categories": [
             1, 
             5
         ], 
-        "portal_ids": [
-            11
-        ]
+        "primary_topic": 11
     }, 
     {
+        "topics": [
+            11
+        ], 
         "ask_id": "509", 
-        "see_all_ids": [
+        "categories": [
             1, 
             3
         ], 
-        "portal_ids": [
-            11
-        ]
+        "primary_topic": 11
     }, 
     {
+        "topics": [
+            11
+        ], 
         "ask_id": "507", 
-        "see_all_ids": [
-            4, 
-            1
-        ], 
-        "portal_ids": [
-            11
-        ]
-    }, 
-    {
-        "ask_id": "505", 
-        "see_all_ids": [
-            1, 
-            3
-        ], 
-        "portal_ids": [
-            11
-        ]
-    }, 
-    {
-        "ask_id": "503", 
-        "see_all_ids": [
-            3, 
-            1
-        ], 
-        "portal_ids": [
-            11
-        ]
-    }, 
-    {
-        "ask_id": "501", 
-        "see_all_ids": [
-            1
-        ], 
-        "portal_ids": [
-            11
-        ]
-    }, 
-    {
-        "ask_id": "475", 
-        "see_all_ids": [
-            3, 
-            1
-        ], 
-        "portal_ids": [
-            11
-        ]
-    }, 
-    {
-        "ask_id": "473", 
-        "see_all_ids": [
-            1
-        ], 
-        "portal_ids": [
-            11
-        ]
-    }, 
-    {
-        "ask_id": "471", 
-        "see_all_ids": [
-            1, 
-            3
-        ], 
-        "portal_ids": [
-            11
-        ]
-    }, 
-    {
-        "ask_id": "465", 
-        "see_all_ids": [
-            1, 
-            3
-        ], 
-        "portal_ids": [
-            11
-        ]
-    }, 
-    {
-        "ask_id": "451", 
-        "see_all_ids": [
-            4, 
-            3, 
-            1
-        ], 
-        "portal_ids": [
-            11
-        ]
-    }, 
-    {
-        "ask_id": "449", 
-        "see_all_ids": [
-            1, 
-            3
-        ], 
-        "portal_ids": [
-            11
-        ]
-    }, 
-    {
-        "ask_id": "445", 
-        "see_all_ids": [
-            1, 
-            3
-        ], 
-        "portal_ids": [
-            11
-        ]
-    }, 
-    {
-        "ask_id": "443", 
-        "see_all_ids": [
-            1
-        ], 
-        "portal_ids": [
-            11
-        ]
-    }, 
-    {
-        "ask_id": "441", 
-        "see_all_ids": [
-            3
-        ], 
-        "portal_ids": [
-            11
-        ]
-    }, 
-    {
-        "ask_id": "439", 
-        "see_all_ids": [
-            1, 
-            5
-        ], 
-        "portal_ids": [
-            11
-        ]
-    }, 
-    {
-        "ask_id": "437", 
-        "see_all_ids": [
-            1
-        ], 
-        "portal_ids": [
-            11
-        ]
-    }, 
-    {
-        "ask_id": "433", 
-        "see_all_ids": [
-            1, 
-            2
-        ], 
-        "portal_ids": [
-            11
-        ]
-    }, 
-    {
-        "ask_id": "425", 
-        "see_all_ids": [
-            1, 
-            2
-        ], 
-        "portal_ids": [
-            11
-        ]
-    }, 
-    {
-        "ask_id": "423", 
-        "see_all_ids": [
-            1, 
-            2
-        ], 
-        "portal_ids": [
-            11
-        ]
-    }, 
-    {
-        "ask_id": "421", 
-        "see_all_ids": [
-            1
-        ], 
-        "portal_ids": [
-            11
-        ]
-    }, 
-    {
-        "ask_id": "417", 
-        "see_all_ids": [
-            4, 
-            1
-        ], 
-        "portal_ids": [
-            11
-        ]
-    }, 
-    {
-        "ask_id": "415", 
-        "see_all_ids": [
-            1, 
-            2
-        ], 
-        "portal_ids": [
-            11
-        ]
-    }, 
-    {
-        "ask_id": "411", 
-        "see_all_ids": [
-            1, 
-            5
-        ], 
-        "portal_ids": [
-            11
-        ]
-    }, 
-    {
-        "ask_id": "409", 
-        "see_all_ids": [
-            4, 
-            2, 
-            1
-        ], 
-        "portal_ids": [
-            11
-        ]
-    }, 
-    {
-        "ask_id": "407", 
-        "see_all_ids": [
-            1, 
-            5, 
-            2
-        ], 
-        "portal_ids": [
-            11
-        ]
-    }, 
-    {
-        "ask_id": "405", 
-        "see_all_ids": [
-            3, 
-            2, 
-            5
-        ], 
-        "portal_ids": [
-            11
-        ]
-    }, 
-    {
-        "ask_id": "403", 
-        "see_all_ids": [
-            1, 
-            2
-        ], 
-        "portal_ids": [
-            11
-        ]
-    }, 
-    {
-        "ask_id": "401", 
-        "see_all_ids": [
-            4, 
-            1
-        ], 
-        "portal_ids": [
-            11
-        ]
-    }, 
-    {
-        "ask_id": "395", 
-        "see_all_ids": [
-            3, 
-            1, 
-            2
-        ], 
-        "portal_ids": [
-            11
-        ]
-    }, 
-    {
-        "ask_id": "393", 
-        "see_all_ids": [
-            1
-        ], 
-        "portal_ids": [
-            11
-        ]
-    }, 
-    {
-        "ask_id": "383", 
-        "see_all_ids": [
-            1
-        ], 
-        "portal_ids": [
-            11
-        ]
-    }, 
-    {
-        "ask_id": "381", 
-        "see_all_ids": [
+        "categories": [
             1, 
             4
         ], 
-        "portal_ids": [
-            11
-        ]
+        "primary_topic": 11
     }, 
     {
-        "ask_id": "379", 
-        "see_all_ids": [
-            3, 
+        "topics": [
+            11
+        ], 
+        "ask_id": "505", 
+        "categories": [
+            1, 
+            3
+        ], 
+        "primary_topic": 11
+    }, 
+    {
+        "topics": [
+            11
+        ], 
+        "ask_id": "503", 
+        "categories": [
+            1, 
+            3
+        ], 
+        "primary_topic": 11
+    }, 
+    {
+        "topics": [
+            11
+        ], 
+        "ask_id": "501", 
+        "categories": [
             1
         ], 
-        "portal_ids": [
+        "primary_topic": 11
+    }, 
+    {
+        "topics": [
             11
-        ]
+        ], 
+        "ask_id": "475", 
+        "categories": [
+            1, 
+            3
+        ], 
+        "primary_topic": 11
+    }, 
+    {
+        "topics": [
+            11
+        ], 
+        "ask_id": "473", 
+        "categories": [
+            1
+        ], 
+        "primary_topic": 11
+    }, 
+    {
+        "topics": [
+            11
+        ], 
+        "ask_id": "471", 
+        "categories": [
+            1, 
+            3
+        ], 
+        "primary_topic": 11
+    }, 
+    {
+        "topics": [
+            11
+        ], 
+        "ask_id": "465", 
+        "categories": [
+            1, 
+            3
+        ], 
+        "primary_topic": 11
+    }, 
+    {
+        "topics": [
+            11
+        ], 
+        "ask_id": "451", 
+        "categories": [
+            1, 
+            3, 
+            4
+        ], 
+        "primary_topic": 11
+    }, 
+    {
+        "topics": [
+            11
+        ], 
+        "ask_id": "449", 
+        "categories": [
+            1, 
+            3
+        ], 
+        "primary_topic": 11
+    }, 
+    {
+        "topics": [
+            11
+        ], 
+        "ask_id": "445", 
+        "categories": [
+            1, 
+            3
+        ], 
+        "primary_topic": 11
+    }, 
+    {
+        "topics": [
+            11
+        ], 
+        "ask_id": "443", 
+        "categories": [
+            1
+        ], 
+        "primary_topic": 11
+    }, 
+    {
+        "topics": [
+            11
+        ], 
+        "ask_id": "441", 
+        "categories": [
+            3
+        ], 
+        "primary_topic": 11
+    }, 
+    {
+        "topics": [
+            11
+        ], 
+        "ask_id": "439", 
+        "categories": [
+            1, 
+            5
+        ], 
+        "primary_topic": 11
+    }, 
+    {
+        "topics": [
+            11
+        ], 
+        "ask_id": "437", 
+        "categories": [
+            1
+        ], 
+        "primary_topic": 11
+    }, 
+    {
+        "topics": [
+            3, 
+            11
+        ], 
+        "ask_id": "433", 
+        "categories": [
+            1, 
+            2
+        ], 
+        "primary_topic": 11
+    }, 
+    {
+        "topics": [
+            11
+        ], 
+        "ask_id": "425", 
+        "categories": [
+            1, 
+            2
+        ], 
+        "primary_topic": 11
+    }, 
+    {
+        "topics": [
+            11
+        ], 
+        "ask_id": "423", 
+        "categories": [
+            1, 
+            2
+        ], 
+        "primary_topic": 11
+    }, 
+    {
+        "topics": [
+            11
+        ], 
+        "ask_id": "421", 
+        "categories": [
+            1
+        ], 
+        "primary_topic": 11
+    }, 
+    {
+        "topics": [
+            11
+        ], 
+        "ask_id": "417", 
+        "categories": [
+            1, 
+            4
+        ], 
+        "primary_topic": 11
+    }, 
+    {
+        "topics": [
+            11
+        ], 
+        "ask_id": "415", 
+        "categories": [
+            1, 
+            2
+        ], 
+        "primary_topic": 11
+    }, 
+    {
+        "topics": [
+            11
+        ], 
+        "ask_id": "411", 
+        "categories": [
+            1, 
+            5
+        ], 
+        "primary_topic": 11
+    }, 
+    {
+        "topics": [
+            11
+        ], 
+        "ask_id": "409", 
+        "categories": [
+            1, 
+            2, 
+            4
+        ], 
+        "primary_topic": 11
+    }, 
+    {
+        "topics": [
+            11
+        ], 
+        "ask_id": "407", 
+        "categories": [
+            1, 
+            2, 
+            5
+        ], 
+        "primary_topic": 11
+    }, 
+    {
+        "topics": [
+            11
+        ], 
+        "ask_id": "405", 
+        "categories": [
+            2, 
+            3, 
+            5
+        ], 
+        "primary_topic": 11
+    }, 
+    {
+        "topics": [
+            11
+        ], 
+        "ask_id": "403", 
+        "categories": [
+            1, 
+            2
+        ], 
+        "primary_topic": 11
+    }, 
+    {
+        "topics": [
+            11
+        ], 
+        "ask_id": "401", 
+        "categories": [
+            1, 
+            4
+        ], 
+        "primary_topic": 11
+    }, 
+    {
+        "topics": [
+            11
+        ], 
+        "ask_id": "395", 
+        "categories": [
+            1, 
+            2, 
+            3
+        ], 
+        "primary_topic": 11
+    }, 
+    {
+        "topics": [
+            11
+        ], 
+        "ask_id": "393", 
+        "categories": [
+            1
+        ], 
+        "primary_topic": 11
+    }, 
+    {
+        "topics": [
+            11
+        ], 
+        "ask_id": "383", 
+        "categories": [
+            1
+        ], 
+        "primary_topic": 11
+    }, 
+    {
+        "topics": [
+            11
+        ], 
+        "ask_id": "381", 
+        "categories": [
+            1, 
+            4
+        ], 
+        "primary_topic": 11
+    }, 
+    {
+        "topics": [
+            3, 
+            11
+        ], 
+        "ask_id": "379", 
+        "categories": [
+            1, 
+            3
+        ], 
+        "primary_topic": 11
     }
 ]

--- a/cfgov/ask_cfpb/fixtures/reverse_mortgages.json
+++ b/cfgov/ask_cfpb/fixtures/reverse_mortgages.json
@@ -1,269 +1,327 @@
 [
     {
+        "topics": [
+            9, 
+            12
+        ], 
         "ask_id": "1719", 
-        "see_all_ids": [
+        "categories": [
             5
         ], 
-        "portal_ids": [
-            12
-        ]
+        "primary_topic": 12
     }, 
     {
+        "topics": [
+            9, 
+            12
+        ], 
         "ask_id": "1511", 
-        "see_all_ids": [
-            5, 
-            3
+        "categories": [
+            3, 
+            5
         ], 
-        "portal_ids": [
-            12
-        ]
+        "primary_topic": 12
     }, 
     {
+        "topics": [
+            9, 
+            12
+        ], 
         "ask_id": "1509", 
-        "see_all_ids": [
-            5, 
-            3
+        "categories": [
+            3, 
+            5
         ], 
-        "portal_ids": [
-            12
-        ]
+        "primary_topic": 12
     }, 
     {
+        "topics": [
+            9, 
+            12
+        ], 
         "ask_id": "1219", 
-        "see_all_ids": [
+        "categories": [
             5
         ], 
-        "portal_ids": [
-            12
-        ]
+        "primary_topic": 12
     }, 
     {
+        "topics": [
+            9, 
+            12
+        ], 
         "ask_id": "1217", 
-        "see_all_ids": [
+        "categories": [
             5
         ], 
-        "portal_ids": [
-            12
-        ]
+        "primary_topic": 12
     }, 
     {
+        "topics": [
+            9, 
+            12
+        ], 
         "ask_id": "1215", 
-        "see_all_ids": [
-            2, 
-            1
+        "categories": [
+            1, 
+            2
         ], 
-        "portal_ids": [
-            12
-        ]
+        "primary_topic": 12
     }, 
     {
+        "topics": [
+            9, 
+            12
+        ], 
         "ask_id": "1213", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            12
-        ]
+        "primary_topic": 12
     }, 
     {
+        "topics": [
+            9, 
+            12
+        ], 
         "ask_id": "1211", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            12
-        ]
+        "primary_topic": 12
     }, 
     {
+        "topics": [
+            9, 
+            12
+        ], 
         "ask_id": "245", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            12
-        ]
+        "primary_topic": 12
     }, 
     {
+        "topics": [
+            9, 
+            12
+        ], 
         "ask_id": "243", 
-        "see_all_ids": [
+        "categories": [
             5
         ], 
-        "portal_ids": [
-            12
-        ]
+        "primary_topic": 12
     }, 
     {
+        "topics": [
+            9, 
+            12
+        ], 
         "ask_id": "242", 
-        "see_all_ids": [
+        "categories": [
             5
         ], 
-        "portal_ids": [
-            12
-        ]
+        "primary_topic": 12
     }, 
     {
+        "topics": [
+            9, 
+            12
+        ], 
         "ask_id": "241", 
-        "see_all_ids": [
+        "categories": [
             5
         ], 
-        "portal_ids": [
-            12
-        ]
+        "primary_topic": 12
     }, 
     {
+        "topics": [
+            9, 
+            12
+        ], 
         "ask_id": "240", 
-        "see_all_ids": [
+        "categories": [
             2, 
             5
         ], 
-        "portal_ids": [
-            12
-        ]
+        "primary_topic": 12
     }, 
     {
+        "topics": [
+            9, 
+            12
+        ], 
         "ask_id": "239", 
-        "see_all_ids": [
+        "categories": [
             2, 
             5
         ], 
-        "portal_ids": [
-            12
-        ]
+        "primary_topic": 12
     }, 
     {
+        "topics": [
+            9, 
+            12
+        ], 
         "ask_id": "238", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            12
-        ]
+        "primary_topic": 12
     }, 
     {
+        "topics": [
+            9, 
+            12
+        ], 
         "ask_id": "237", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            12
-        ]
+        "primary_topic": 12
     }, 
     {
+        "topics": [
+            9, 
+            12
+        ], 
         "ask_id": "236", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            12
-        ]
+        "primary_topic": 12
     }, 
     {
+        "topics": [
+            9, 
+            12
+        ], 
         "ask_id": "235", 
-        "see_all_ids": [
+        "categories": [
             5
         ], 
-        "portal_ids": [
-            12
-        ]
+        "primary_topic": 12
     }, 
     {
+        "topics": [
+            9, 
+            12
+        ], 
         "ask_id": "234", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            12
-        ]
+        "primary_topic": 12
     }, 
     {
+        "topics": [
+            9, 
+            12
+        ], 
         "ask_id": "233", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            12
-        ]
+        "primary_topic": 12
     }, 
     {
+        "topics": [
+            9, 
+            12
+        ], 
         "ask_id": "232", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            12
-        ]
+        "primary_topic": 12
     }, 
     {
+        "topics": [
+            9, 
+            12
+        ], 
         "ask_id": "230", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            12
-        ]
+        "primary_topic": 12
     }, 
     {
+        "topics": [
+            9, 
+            12
+        ], 
         "ask_id": "229", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            12
-        ]
+        "primary_topic": 12
     }, 
     {
+        "topics": [
+            9, 
+            12
+        ], 
         "ask_id": "228", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            12
-        ]
+        "primary_topic": 12
     }, 
     {
+        "topics": [
+            9, 
+            12
+        ], 
         "ask_id": "227", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            12
-        ]
+        "primary_topic": 12
     }, 
     {
+        "topics": [
+            9, 
+            12
+        ], 
         "ask_id": "226", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            12
-        ]
+        "primary_topic": 12
     }, 
     {
+        "topics": [
+            9, 
+            12
+        ], 
         "ask_id": "225", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            12
-        ]
+        "primary_topic": 12
     }, 
     {
+        "topics": [
+            9, 
+            12
+        ], 
         "ask_id": "224", 
-        "see_all_ids": [
-            4, 
-            1
-        ], 
-        "portal_ids": [
-            12
-        ]
-    }, 
-    {
-        "ask_id": "146", 
-        "see_all_ids": [
+        "categories": [
+            1, 
             4
         ], 
-        "portal_ids": [
+        "primary_topic": 12
+    }, 
+    {
+        "topics": [
+            9, 
             12
-        ]
+        ], 
+        "ask_id": "146", 
+        "categories": [
+            4
+        ], 
+        "primary_topic": 12
     }
 ]

--- a/cfgov/ask_cfpb/fixtures/student_loans.json
+++ b/cfgov/ask_cfpb/fixtures/student_loans.json
@@ -1,904 +1,1014 @@
 [
     {
+        "topics": [
+            13
+        ], 
         "ask_id": "2088", 
-        "see_all_ids": [
+        "categories": [
             1, 
             5
         ], 
-        "portal_ids": [
-            13
-        ]
+        "primary_topic": 13
     }, 
     {
+        "topics": [
+            13
+        ], 
         "ask_id": "2041", 
-        "see_all_ids": [
+        "categories": [
             5
         ], 
-        "portal_ids": [
-            13
-        ]
+        "primary_topic": 13
     }, 
     {
+        "topics": [
+            13
+        ], 
         "ask_id": "1931", 
-        "see_all_ids": [
+        "categories": [
             5
         ], 
-        "portal_ids": [
-            13
-        ]
+        "primary_topic": 13
     }, 
     {
+        "topics": [
+            13
+        ], 
         "ask_id": "1929", 
-        "see_all_ids": [
-            5, 
-            1
+        "categories": [
+            1, 
+            5
         ], 
-        "portal_ids": [
-            13
-        ]
+        "primary_topic": 13
     }, 
     {
+        "topics": [
+            13
+        ], 
         "ask_id": "1901", 
-        "see_all_ids": [
+        "categories": [
             1, 
             5
         ], 
-        "portal_ids": [
-            13
-        ]
+        "primary_topic": 13
     }, 
     {
+        "topics": [
+            13
+        ], 
         "ask_id": "1899", 
-        "see_all_ids": [
+        "categories": [
             5
         ], 
-        "portal_ids": [
-            13
-        ]
+        "primary_topic": 13
     }, 
     {
+        "topics": [
+            13
+        ], 
         "ask_id": "1889", 
-        "see_all_ids": [
+        "categories": [
             5
         ], 
-        "portal_ids": [
-            13
-        ]
+        "primary_topic": 13
     }, 
     {
+        "topics": [
+            13
+        ], 
         "ask_id": "1887", 
-        "see_all_ids": [
+        "categories": [
             5
         ], 
-        "portal_ids": [
-            13
-        ]
+        "primary_topic": 13
     }, 
     {
+        "topics": [
+            13
+        ], 
         "ask_id": "1885", 
-        "see_all_ids": [
+        "categories": [
             5
         ], 
-        "portal_ids": [
-            13
-        ]
+        "primary_topic": 13
     }, 
     {
+        "topics": [
+            13
+        ], 
         "ask_id": "1713", 
-        "see_all_ids": [
+        "categories": [
             1, 
             3
         ], 
-        "portal_ids": [
-            13
-        ]
+        "primary_topic": 13
     }, 
     {
+        "topics": [
+            13
+        ], 
         "ask_id": "1707", 
-        "see_all_ids": [
+        "categories": [
             1, 
             5
         ], 
-        "portal_ids": [
-            13
-        ]
+        "primary_topic": 13
     }, 
     {
+        "topics": [
+            13
+        ], 
         "ask_id": "1691", 
-        "see_all_ids": [
+        "categories": [
             5
         ], 
-        "portal_ids": [
-            13
-        ]
+        "primary_topic": 13
     }, 
     {
+        "topics": [
+            13
+        ], 
         "ask_id": "1689", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            13
-        ]
+        "primary_topic": 13
     }, 
     {
+        "topics": [
+            13
+        ], 
         "ask_id": "1687", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            13
-        ]
+        "primary_topic": 13
     }, 
     {
+        "topics": [
+            9, 
+            13
+        ], 
         "ask_id": "1685", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            13
-        ]
+        "primary_topic": 13
     }, 
     {
+        "topics": [
+            13
+        ], 
         "ask_id": "1565", 
-        "see_all_ids": [
+        "categories": [
             3
         ], 
-        "portal_ids": [
-            13
-        ]
+        "primary_topic": 13
     }, 
     {
+        "topics": [
+            13
+        ], 
         "ask_id": "1563", 
-        "see_all_ids": [
-            5, 
-            3
+        "categories": [
+            3, 
+            5
         ], 
-        "portal_ids": [
-            13
-        ]
+        "primary_topic": 13
     }, 
     {
+        "topics": [
+            13
+        ], 
         "ask_id": "1561", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            13
-        ]
+        "primary_topic": 13
     }, 
     {
+        "topics": [
+            13
+        ], 
         "ask_id": "1559", 
-        "see_all_ids": [
+        "categories": [
             1, 
             5
         ], 
-        "portal_ids": [
-            13
-        ]
+        "primary_topic": 13
     }, 
     {
+        "topics": [
+            13
+        ], 
         "ask_id": "1557", 
-        "see_all_ids": [
-            5, 
-            2
+        "categories": [
+            2, 
+            5
         ], 
-        "portal_ids": [
-            13
-        ]
+        "primary_topic": 13
     }, 
     {
+        "topics": [
+            13
+        ], 
         "ask_id": "1555", 
-        "see_all_ids": [
-            4, 
-            1
+        "categories": [
+            1, 
+            4
         ], 
-        "portal_ids": [
-            13
-        ]
+        "primary_topic": 13
     }, 
     {
+        "topics": [
+            13
+        ], 
         "ask_id": "1553", 
-        "see_all_ids": [
+        "categories": [
             1, 
             4
         ], 
-        "portal_ids": [
-            13
-        ]
+        "primary_topic": 13
     }, 
     {
+        "topics": [
+            13
+        ], 
         "ask_id": "1551", 
-        "see_all_ids": [
+        "categories": [
             1, 
-            5, 
-            3
+            3, 
+            5
         ], 
-        "portal_ids": [
-            13
-        ]
+        "primary_topic": 13
     }, 
     {
+        "topics": [
+            1, 
+            3, 
+            9, 
+            13
+        ], 
         "ask_id": "1501", 
-        "see_all_ids": [
+        "categories": [
             5
         ], 
-        "portal_ids": [
-            13
-        ]
+        "primary_topic": 13
     }, 
     {
+        "topics": [
+            13
+        ], 
         "ask_id": "717", 
-        "see_all_ids": [
+        "categories": [
             5
         ], 
-        "portal_ids": [
-            13
-        ]
+        "primary_topic": 13
     }, 
     {
+        "topics": [
+            13
+        ], 
         "ask_id": "715", 
-        "see_all_ids": [
-            5, 
-            2
+        "categories": [
+            2, 
+            5
         ], 
-        "portal_ids": [
-            13
-        ]
+        "primary_topic": 13
     }, 
     {
+        "topics": [
+            1, 
+            9, 
+            13
+        ], 
         "ask_id": "713", 
-        "see_all_ids": [
-            5, 
-            2
+        "categories": [
+            2, 
+            5
         ], 
-        "portal_ids": [
-            13
-        ]
+        "primary_topic": 13
     }, 
     {
+        "topics": [
+            13
+        ], 
         "ask_id": "711", 
-        "see_all_ids": [
-            5, 
-            2
+        "categories": [
+            2, 
+            5
         ], 
-        "portal_ids": [
-            13
-        ]
+        "primary_topic": 13
     }, 
     {
+        "topics": [
+            13
+        ], 
         "ask_id": "709", 
-        "see_all_ids": [
-            5, 
-            2
+        "categories": [
+            2, 
+            5
         ], 
-        "portal_ids": [
-            13
-        ]
+        "primary_topic": 13
     }, 
     {
+        "topics": [
+            9, 
+            13
+        ], 
         "ask_id": "707", 
-        "see_all_ids": [
-            5, 
-            2
+        "categories": [
+            2, 
+            5
         ], 
-        "portal_ids": [
-            13
-        ]
+        "primary_topic": 13
     }, 
     {
+        "topics": [
+            13
+        ], 
         "ask_id": "705", 
-        "see_all_ids": [
-            5, 
-            2
+        "categories": [
+            2, 
+            5
         ], 
-        "portal_ids": [
-            13
-        ]
+        "primary_topic": 13
     }, 
     {
+        "topics": [
+            13
+        ], 
         "ask_id": "703", 
-        "see_all_ids": [
-            5, 
-            2
+        "categories": [
+            2, 
+            5
         ], 
-        "portal_ids": [
-            13
-        ]
+        "primary_topic": 13
     }, 
     {
+        "topics": [
+            13
+        ], 
         "ask_id": "701", 
-        "see_all_ids": [
+        "categories": [
             1, 
             2
         ], 
-        "portal_ids": [
-            13
-        ]
+        "primary_topic": 13
     }, 
     {
+        "topics": [
+            13
+        ], 
         "ask_id": "699", 
-        "see_all_ids": [
+        "categories": [
             1, 
             2
         ], 
-        "portal_ids": [
-            13
-        ]
+        "primary_topic": 13
     }, 
     {
+        "topics": [
+            13
+        ], 
         "ask_id": "697", 
-        "see_all_ids": [
+        "categories": [
             1, 
             2
         ], 
-        "portal_ids": [
-            13
-        ]
+        "primary_topic": 13
     }, 
     {
+        "topics": [
+            13
+        ], 
         "ask_id": "695", 
-        "see_all_ids": [
+        "categories": [
             1, 
             2
         ], 
-        "portal_ids": [
-            13
-        ]
+        "primary_topic": 13
     }, 
     {
+        "topics": [
+            13
+        ], 
         "ask_id": "693", 
-        "see_all_ids": [
+        "categories": [
             1, 
             2
         ], 
-        "portal_ids": [
-            13
-        ]
+        "primary_topic": 13
     }, 
     {
+        "topics": [
+            13
+        ], 
         "ask_id": "689", 
-        "see_all_ids": [
-            5, 
-            2
+        "categories": [
+            2, 
+            5
         ], 
-        "portal_ids": [
-            13
-        ]
+        "primary_topic": 13
     }, 
     {
+        "topics": [
+            13
+        ], 
         "ask_id": "687", 
-        "see_all_ids": [
+        "categories": [
             1, 
             3
         ], 
-        "portal_ids": [
-            13
-        ]
+        "primary_topic": 13
     }, 
     {
-        "ask_id": "685", 
-        "see_all_ids": [], 
-        "portal_ids": [
+        "topics": [
             13
-        ]
-    }, 
-    {
-        "ask_id": "679", 
-        "see_all_ids": [
-            5, 
-            3
         ], 
-        "portal_ids": [
-            13
-        ]
+        "ask_id": "685", 
+        "categories": [], 
+        "primary_topic": 13
     }, 
     {
+        "topics": [
+            13
+        ], 
+        "ask_id": "679", 
+        "categories": [
+            3, 
+            5
+        ], 
+        "primary_topic": 13
+    }, 
+    {
+        "topics": [
+            13
+        ], 
         "ask_id": "675", 
-        "see_all_ids": [], 
-        "portal_ids": [
-            13
-        ]
+        "categories": [], 
+        "primary_topic": 13
     }, 
     {
+        "topics": [
+            13
+        ], 
         "ask_id": "673", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            13
-        ]
+        "primary_topic": 13
     }, 
     {
+        "topics": [
+            13
+        ], 
         "ask_id": "671", 
-        "see_all_ids": [
+        "categories": [
             1, 
             5
         ], 
-        "portal_ids": [
-            13
-        ]
+        "primary_topic": 13
     }, 
     {
+        "topics": [
+            5, 
+            13
+        ], 
         "ask_id": "669", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            13
-        ]
+        "primary_topic": 13
     }, 
     {
+        "topics": [
+            5, 
+            13
+        ], 
         "ask_id": "667", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            13
-        ]
+        "primary_topic": 13
     }, 
     {
+        "topics": [
+            5, 
+            13
+        ], 
         "ask_id": "665", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            13
-        ]
+        "primary_topic": 13
     }, 
     {
+        "topics": [
+            5, 
+            13
+        ], 
         "ask_id": "663", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            13
-        ]
+        "primary_topic": 13
     }, 
     {
+        "topics": [
+            5, 
+            13
+        ], 
         "ask_id": "653", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            13
-        ]
+        "primary_topic": 13
     }, 
     {
+        "topics": [
+            5, 
+            13
+        ], 
         "ask_id": "649", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            13
-        ]
+        "primary_topic": 13
     }, 
     {
+        "topics": [
+            13
+        ], 
         "ask_id": "647", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            13
-        ]
+        "primary_topic": 13
     }, 
     {
+        "topics": [
+            13
+        ], 
         "ask_id": "645", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            13
-        ]
+        "primary_topic": 13
     }, 
     {
+        "topics": [
+            13
+        ], 
         "ask_id": "641", 
-        "see_all_ids": [
+        "categories": [
             1, 
-            4, 
-            3
+            3, 
+            4
         ], 
-        "portal_ids": [
-            13
-        ]
+        "primary_topic": 13
     }, 
     {
+        "topics": [
+            13
+        ], 
         "ask_id": "639", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            13
-        ]
+        "primary_topic": 13
     }, 
     {
+        "topics": [
+            13
+        ], 
         "ask_id": "637", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            13
-        ]
+        "primary_topic": 13
     }, 
     {
+        "topics": [
+            13
+        ], 
         "ask_id": "635", 
-        "see_all_ids": [
-            4, 
-            1
+        "categories": [
+            1, 
+            4
         ], 
-        "portal_ids": [
-            13
-        ]
+        "primary_topic": 13
     }, 
     {
+        "topics": [
+            13
+        ], 
         "ask_id": "633", 
-        "see_all_ids": [
+        "categories": [
             4
         ], 
-        "portal_ids": [
-            13
-        ]
+        "primary_topic": 13
     }, 
     {
+        "topics": [
+            13
+        ], 
         "ask_id": "631", 
-        "see_all_ids": [
+        "categories": [
             4
         ], 
-        "portal_ids": [
-            13
-        ]
+        "primary_topic": 13
     }, 
     {
+        "topics": [
+            13
+        ], 
         "ask_id": "629", 
-        "see_all_ids": [
+        "categories": [
             4
         ], 
-        "portal_ids": [
-            13
-        ]
+        "primary_topic": 13
     }, 
     {
+        "topics": [
+            13
+        ], 
         "ask_id": "625", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            13
-        ]
+        "primary_topic": 13
     }, 
     {
+        "topics": [
+            13
+        ], 
         "ask_id": "623", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            13
-        ]
+        "primary_topic": 13
     }, 
     {
+        "topics": [
+            13
+        ], 
         "ask_id": "621", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            13
-        ]
+        "primary_topic": 13
     }, 
     {
+        "topics": [
+            13
+        ], 
         "ask_id": "619", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            13
-        ]
+        "primary_topic": 13
     }, 
     {
+        "topics": [
+            13
+        ], 
         "ask_id": "617", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            13
-        ]
+        "primary_topic": 13
     }, 
     {
+        "topics": [
+            13
+        ], 
         "ask_id": "615", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            13
-        ]
+        "primary_topic": 13
     }, 
     {
+        "topics": [
+            13
+        ], 
         "ask_id": "613", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            13
-        ]
+        "primary_topic": 13
     }, 
     {
+        "topics": [
+            13
+        ], 
         "ask_id": "611", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            13
-        ]
+        "primary_topic": 13
     }, 
     {
+        "topics": [
+            13
+        ], 
         "ask_id": "609", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            13
-        ]
+        "primary_topic": 13
     }, 
     {
+        "topics": [
+            13
+        ], 
         "ask_id": "607", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            13
-        ]
+        "primary_topic": 13
     }, 
     {
+        "topics": [
+            13
+        ], 
         "ask_id": "605", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            13
-        ]
+        "primary_topic": 13
     }, 
     {
+        "topics": [
+            13
+        ], 
         "ask_id": "603", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            13
-        ]
+        "primary_topic": 13
     }, 
     {
+        "topics": [
+            13
+        ], 
         "ask_id": "601", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            13
-        ]
+        "primary_topic": 13
     }, 
     {
+        "topics": [
+            13
+        ], 
         "ask_id": "599", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            13
-        ]
+        "primary_topic": 13
     }, 
     {
+        "topics": [
+            13
+        ], 
         "ask_id": "595", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            13
-        ]
+        "primary_topic": 13
     }, 
     {
+        "topics": [
+            13
+        ], 
         "ask_id": "593", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            13
-        ]
+        "primary_topic": 13
     }, 
     {
+        "topics": [
+            13
+        ], 
         "ask_id": "591", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            13
-        ]
+        "primary_topic": 13
     }, 
     {
+        "topics": [
+            13
+        ], 
         "ask_id": "589", 
-        "see_all_ids": [
+        "categories": [
             4
         ], 
-        "portal_ids": [
-            13
-        ]
+        "primary_topic": 13
     }, 
     {
+        "topics": [
+            13
+        ], 
         "ask_id": "585", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            13
-        ]
+        "primary_topic": 13
     }, 
     {
+        "topics": [
+            13
+        ], 
         "ask_id": "583", 
-        "see_all_ids": [
+        "categories": [
             4
         ], 
-        "portal_ids": [
-            13
-        ]
+        "primary_topic": 13
     }, 
     {
+        "topics": [
+            13
+        ], 
         "ask_id": "581", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            13
-        ]
+        "primary_topic": 13
     }, 
     {
+        "topics": [
+            13
+        ], 
         "ask_id": "579", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            13
-        ]
+        "primary_topic": 13
     }, 
     {
+        "topics": [
+            13
+        ], 
         "ask_id": "577", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            13
-        ]
+        "primary_topic": 13
     }, 
     {
+        "topics": [
+            13
+        ], 
         "ask_id": "575", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            13
-        ]
+        "primary_topic": 13
     }, 
     {
+        "topics": [
+            13
+        ], 
         "ask_id": "573", 
-        "see_all_ids": [
+        "categories": [
             4
         ], 
-        "portal_ids": [
-            13
-        ]
+        "primary_topic": 13
     }, 
     {
+        "topics": [
+            13
+        ], 
         "ask_id": "571", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            13
-        ]
+        "primary_topic": 13
     }, 
     {
+        "topics": [
+            13
+        ], 
         "ask_id": "569", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            13
-        ]
+        "primary_topic": 13
     }, 
     {
+        "topics": [
+            13
+        ], 
         "ask_id": "567", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            13
-        ]
+        "primary_topic": 13
     }, 
     {
+        "topics": [
+            13
+        ], 
         "ask_id": "565", 
-        "see_all_ids": [
+        "categories": [
             1, 
             4
         ], 
-        "portal_ids": [
-            13
-        ]
+        "primary_topic": 13
     }, 
     {
+        "topics": [
+            13
+        ], 
         "ask_id": "563", 
-        "see_all_ids": [
+        "categories": [
             1, 
             4
         ], 
-        "portal_ids": [
-            13
-        ]
+        "primary_topic": 13
     }, 
     {
+        "topics": [
+            13
+        ], 
         "ask_id": "561", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            13
-        ]
+        "primary_topic": 13
     }, 
     {
+        "topics": [
+            13
+        ], 
         "ask_id": "559", 
-        "see_all_ids": [
+        "categories": [
             4
         ], 
-        "portal_ids": [
-            13
-        ]
+        "primary_topic": 13
     }, 
     {
+        "topics": [
+            13
+        ], 
         "ask_id": "553", 
-        "see_all_ids": [
+        "categories": [
             4
         ], 
-        "portal_ids": [
-            13
-        ]
+        "primary_topic": 13
     }, 
     {
+        "topics": [
+            13
+        ], 
         "ask_id": "551", 
-        "see_all_ids": [
+        "categories": [
             4
         ], 
-        "portal_ids": [
-            13
-        ]
+        "primary_topic": 13
     }, 
     {
+        "topics": [
+            13
+        ], 
         "ask_id": "549", 
-        "see_all_ids": [
+        "categories": [
             4
         ], 
-        "portal_ids": [
-            13
-        ]
+        "primary_topic": 13
     }, 
     {
+        "topics": [
+            13
+        ], 
         "ask_id": "547", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            13
-        ]
+        "primary_topic": 13
     }, 
     {
+        "topics": [
+            13
+        ], 
         "ask_id": "545", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            13
-        ]
+        "primary_topic": 13
     }, 
     {
+        "topics": [
+            13
+        ], 
         "ask_id": "543", 
-        "see_all_ids": [
+        "categories": [
             1
         ], 
-        "portal_ids": [
-            13
-        ]
+        "primary_topic": 13
     }
 ]

--- a/cfgov/ask_cfpb/scripts/migrate_tagging.py
+++ b/cfgov/ask_cfpb/scripts/migrate_tagging.py
@@ -140,7 +140,9 @@ def update_page(page, entry):
 
 
 def apply_tags(data, singleton=None):
-    """Apply tagging values to answer pages, or to a single Ask ID."""
+    """
+    Apply tags to all answer pages, or only to pages linked to a single Ask ID.
+    """
     if singleton:
         if singleton not in [d['ask_id'] for d in data]:
             return

--- a/cfgov/ask_cfpb/scripts/migrate_tagging.py
+++ b/cfgov/ask_cfpb/scripts/migrate_tagging.py
@@ -15,6 +15,18 @@ from v1.models import PortalCategory, PortalTopic
 PROJECT_ROOT = settings.PROJECT_ROOT
 FIXTURE_DIR = "{}/ask_cfpb/fixtures/".format(PROJECT_ROOT)
 CSV_BASE_DIR = os.getenv('ASK_CSV_BASE_DIR')
+CATEGORY_HEADINGS = [
+    'PrimaryCategoryTag',
+    'CategoryTag2',
+    'CategoryTag3',
+    'CategoryTag4'
+]
+SECONDARY_TOPIC_HEADINGS = [
+    'TopicTag2',
+    'TopicTag3',
+    'TopicTag4',
+    'TopicTag5'
+]
 # mapping of slugs to portal name variations, with the correct variation first
 SLUGS = {
     'auto_loans': ['Auto loans'],
@@ -34,15 +46,19 @@ SLUGS = {
 PORTAL_IDS = {
     'Auto loans': 1,
     'Bank accounts': 2,
+    'Bank accounts and services': 2,
     'Credit cards': 3,
     'Credit reports and scores': 4,
     'Debt collection': 5,
     'Fraud and scams': 7,
+    'Frauds and scams': 7,
+    'Fraud and Scams': 7,
     'Money transfers': 8,
     'Mortgages': 9,
     'Payday loans': 10,
     'Prepaid cards': 11,
     'Reverse mortgages': 12,
+    'reverse mortgages': 12,
     'Student loans': 13,
 }
 CATEGORY_IDS = {
@@ -52,6 +68,8 @@ CATEGORY_IDS = {
     'Key terms': 4,
     'Common issues': 5,
 }
+CATEGORY_OBJECTS = {obj.pk: obj for obj in PortalCategory.objects.all()}
+TOPIC_OBJECTS = {obj.pk: obj for obj in PortalTopic.objects.all()}
 
 
 # header = (
@@ -76,6 +94,7 @@ def run():
                 data = [
                     row for row in reader
                     if row['PrimaryTopicTag'] in SLUGS[slug]
+                    and row['ask_id'].isdigit()
                 ]
             output = transform_csv(data, portal_name)
             if not output:
@@ -84,8 +103,7 @@ def run():
             output_json(output, slug)
             print("Output {}.json".format(slug))
         apply_tags(output)
-        print("Tag migrations took {}".format(
-            datetime.datetime.now() - starter))
+    print("Tag migrations took {}".format(datetime.datetime.now() - starter))
 
 
 def update_feedback_default(stream_value):
@@ -98,25 +116,25 @@ def update_feedback_default(stream_value):
 
 def apply_tags(data):
     """Apply tagging values to answer pages."""
-    category_map = {obj.pk: obj for obj in PortalCategory.objects.all()}
     migration_user_pk = os.getenv('MIGRATION_USER_PK')
     user = User.objects.filter(id=migration_user_pk).first()  # default is None
     for entry in data:
         pages = AnswerPage.objects.filter(
-            answer_base__pk=entry.get('ask_id'))
+            redirect_to_page=None,
+            answer_base__pk=entry.get('ask_id')
+        )
         for page in pages:
             initial_status = page.status_string
-            page.get_latest_revision().publish()
             page.user_feedback = update_feedback_default(page.user_feedback)
-            portal_ids = entry.get('portal_ids')
-            category_ids = entry.get('see_all_ids')
-            for portal_id in portal_ids:
-                topic = PortalTopic.objects.get(pk=portal_id)
-                page.portal_topic.add(topic)
+            primary_topic = entry.get('primary_topic')
+            topic_ids = entry.get('topics')
+            category_ids = entry.get('categories')
+            if len(topic_ids) > 1:
+                page.primary_portal_topic = TOPIC_OBJECTS.get(primary_topic)
+            for topic_id in topic_ids:
+                page.portal_topic.add(TOPIC_OBJECTS.get(topic_id))
             for category_id in category_ids:
-                category_object = category_map.get(category_id)
-                if category_object:
-                    page.portal_category.add(category_object)
+                page.portal_category.add(CATEGORY_OBJECTS.get(category_id))
             page.save_revision(user=user).publish()
             if initial_status == 'draft':
                 page.unpublish()
@@ -127,24 +145,31 @@ def output_json(data, slug):
         f.write(json.dumps(data, indent=4))
 
 
+def valid_tags(row, headings, ids):
+    return [
+        row[heading].strip()
+        for heading in headings
+        if row[heading].strip()
+        and row[heading].strip() in ids
+    ]
+
+
 def transform_csv(dict_rows, portal):
     """Turn a CE spreadsheet into a json mapping file."""
     output = []
-    portal_pk = PORTAL_IDS.get(portal)
+    primary_portal_pk = PORTAL_IDS.get(portal)
     for row in dict_rows:
-        categories = [
-            tag.strip() for tag in [
-                row['PrimaryCategoryTag'],
-                row['CategoryTag2'],
-                row['CategoryTag3'],
-                row['CategoryTag4']]
-            if tag.strip()]
-        category_pks = [CATEGORY_IDS.get(tag) for tag in categories
-                        if CATEGORY_IDS.get(tag)]
+        category_strings = valid_tags(row, CATEGORY_HEADINGS, CATEGORY_IDS)
+        category_pks = [CATEGORY_IDS.get(tag) for tag in category_strings]
+        topic_strings = valid_tags(row, SECONDARY_TOPIC_HEADINGS, PORTAL_IDS)
+        topic_pks = [primary_portal_pk] + [
+            PORTAL_IDS.get(topic) for topic in topic_strings
+        ]
         entry = {
             'ask_id': row.get('ask_id'),
-            'portal_ids': [portal_pk],
-            'see_all_ids': category_pks,
+            'primary_topic': primary_portal_pk,
+            'categories': sorted(set(category_pks)),
+            'topics': sorted(set(topic_pks)),
         }
         output.append(entry)
     return output


### PR DESCRIPTION
CE identified Ask CFPB answer pages to tag with multiple portal topics,
and this brings them into the fold and marks a primary topic when needed.

## Testing
- Load the latest prod db and migrate portal tags:
```bash
./cfgov/manage.py runscript migrate_tagging
```
Then edit pages to see tags applied.

Pages with multiple portal topics (and thus a primary topic designated):
- http://localhost:8000/admin/pages/6224/edit/
- http://localhost:8000/admin/pages/7798/edit/

Pages with single topics (and thus no primary): 
- http://localhost:8000/admin/pages/5928/edit/
- http://localhost:8000/admin/pages/6588/edit/

The script also has an option to run against a single Ask ID.  
To test this option, pass `--script-args` and an Ask ID:

```bash
./cfgov/manage.py runscript migrate_tagging --script-args 321
```

This should migrate and publish two pages, the English and Spanish versions of 321.