### PR TITLE
Only download database dump it neccessary

### DIFF
--- a/refresh-data.sh
+++ b/refresh-data.sh
@@ -28,9 +28,9 @@ download_data() {
     prod_archive="$refresh_dump_name"
     if test -e "$prod_archive"
 	    then 
-		    curl -o "$prod_archive" -z "$prod_archive" "$CFGOV_PROD_DB_LOCATION"
+		    curl -R -o "$prod_archive" -z "$prod_archive" "$CFGOV_PROD_DB_LOCATION"
 	    else
-		    curl -o "$prod_archive" "$CFGOV_PROD_DB_LOCATION"
+		    curl -R -o "$prod_archive" "$CFGOV_PROD_DB_LOCATION"
 	    fi
 }
 

--- a/refresh-data.sh
+++ b/refresh-data.sh
@@ -27,11 +27,11 @@ download_data() {
     echo 'Downloading fresh production Django database dump...'
     prod_archive="$refresh_dump_name"
     if test -e "$prod_archive"
-	    then 
-		    curl -R -o "$prod_archive" -z "$prod_archive" "$CFGOV_PROD_DB_LOCATION"
-	    else
-		    curl -R -o "$prod_archive" "$CFGOV_PROD_DB_LOCATION"
-	    fi
+       then 
+           curl -R -o "$prod_archive" -z "$prod_archive" "$CFGOV_PROD_DB_LOCATION"
+       else
+           curl -R -o "$prod_archive" "$CFGOV_PROD_DB_LOCATION"
+       fi
 }
 
 refresh_data() {

--- a/refresh-data.sh
+++ b/refresh-data.sh
@@ -26,7 +26,12 @@ EOF
 download_data() {
     echo 'Downloading fresh production Django database dump...'
     prod_archive="$refresh_dump_name"
-    curl -o "$prod_archive" "$CFGOV_PROD_DB_LOCATION"
+    if test -e "$prod_archive"
+	    then 
+		    curl -o "$prod_archive" -z "$prod_archive" "$CFGOV_PROD_DB_LOCATION"
+	    else
+		    curl -o "$prod_archive" "$CFGOV_PROD_DB_LOCATION"
+	    fi
 }
 
 refresh_data() {


### PR DESCRIPTION
- adds the -z flag to to the curl command in refresh-data.sh, which will make it compare the timestamps of the remote and local file, and only download if the remote file is newer.
- also adds the -R flag to preserve the remote timestamp

```
-z, --time-cond <time>

(HTTP FTP) Request a file that has been modified later than the given time and date,
or one that has been modified before that time. The <date expression> can be all sorts
of date strings or if it doesn't match any internal ones, it is taken as a filename
and tries to get the modification date (mtime) from <file> instead. 
See the curl_getdate(3) man pages for date expression details.

Start the date expression with a dash (-) to make it request for a document that is
older than the given date/time, default is a document that is newer than the
specified date/time.

If this option is used several times, the last one will be used.

-R, --remote-time

When used, this will make curl attempt to figure out the timestamp of the remote file,
and if that is available make the local file get that same timestamp.
```


## Additions

- -Z and -R flags as described above

## Removals

-

## Changes

-

## Testing

1.

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [ ] Chrome on desktop
- [ ] Firefox
- [ ] Safari on macOS
- [ ] Edge
- [ ] Internet Explorer 9, 10, and 11
- [ ] Safari on iOS
- [ ] Chrome on Android

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
