### PR TITLE
Fix answer page links on Spanish Ask category template

### DIFF
--- a/cfgov/jinja2/v1/ask-cfpb/category-page-spanish.html
+++ b/cfgov/jinja2/v1/ask-cfpb/category-page-spanish.html
@@ -34,7 +34,7 @@
                     {% if questions %}
                     {% for question in questions %}
                         {% if question.question %}
-                        <a href="/es/obtener-respuestas/{{ question.slug_es }} " class="ac-qa-summary">
+                        <a href="/es/obtener-respuestas/{{ question.slug }}" class="ac-qa-summary">
     						<article>
     						    <h3 class="ac-qa-question">{{ question.question|safe }}</h3>
     						    <div class="ac-qa-answer">


### PR DESCRIPTION
Currently the links to Spanish answers on category pages are constructed using `slug_es` instead of `slug`, so they all go to the main `Obtener respuestas` page.

## Changes

- Use `slug` instead of `slug_es` to construct Spanish answer page links

## Testing

1. Check out branch
2. Navigate to a [Spanish category page](http://localhost:8000/es/obtener-respuestas/categoria-comprar-un-vehiculo/)
3. Verify that answer previews link to answer pages

## Screenshots

### Production
<img width="800" alt="Screen Shot 2019-03-28 at 1 21 17 PM" src="https://user-images.githubusercontent.com/778171/55190084-6f709100-515c-11e9-9989-8d2740b2a20a.png">


### Local

<img width="787" alt="Screen Shot 2019-03-28 at 1 20 56 PM" src="https://user-images.githubusercontent.com/778171/55190090-726b8180-515c-11e9-804f-e7291621b144.png">


