### PR TITLE
Bump owning-a-home-api version to 0.12

### DIFF
--- a/requirements/optional-public.txt
+++ b/requirements/optional-public.txt
@@ -1,5 +1,5 @@
 https://github.com/cfpb/college-costs/releases/download/2.4.4/college_costs-2.4.4-py2-none-any.whl
-https://github.com/cfpb/owning-a-home-api/releases/download/0.11.3/owning_a_home_api-0.11.3-py2-none-any.whl
+https://github.com/cfpb/owning-a-home-api/releases/download/0.12/owning_a_home_api-0.12-py2.py3-none-any.whl
 https://github.com/cfpb/retirement/releases/download/0.7.6/retirement-0.7.6-py2-none-any.whl
 https://github.com/cfpb/ccdb5-api/releases/download/1.1.7/ccdb5_api-1.1.7-py2-none-any.whl
 https://github.com/cfpb/ccdb5-ui/releases/download/1.1.0/ccdb5_ui-1.1.0-py2-none-any.whl


### PR DESCRIPTION
This change bumps the version of the owning-a-home-api satellite app from 0.11.3 to 0.12.

This release adds support for Python 3.

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [X] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [X] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: