### PR TITLE
Corrected file extension for HMDA downloads

### DIFF
--- a/cfgov/hmda/jinja2/hmda/hmda-explorer-institutions.html
+++ b/cfgov/hmda/jinja2/hmda/hmda-explorer-institutions.html
@@ -13,58 +13,58 @@
                 <tbody>
                     <tr>
                         <td data-label="Year">2017</td>
-                        <td data-label="Transmittal sheet"><a href="https://files.consumerfinance.gov/hmda-historic-institution-data/hmda_2017_transmittal_sheet.csv">CSV</a> (272 KB)</td>
-                        <td data-label="Panel"><a href="https://files.consumerfinance.gov/hmda-historic-institution-data/hmda_2017_panel.csv">CSV</a> (229 KB)</td>
+                        <td data-label="Transmittal sheet"><a href="https://files.consumerfinance.gov/hmda-historic-institution-data/hmda_2017_transmittal_sheet.zip">CSV</a> (272 KB)</td>
+                        <td data-label="Panel"><a href="https://files.consumerfinance.gov/hmda-historic-institution-data/hmda_2017_panel.zip">CSV</a> (229 KB)</td>
                     </tr>
                     <tr>
                         <td data-label="Year">2016</td>
-                        <td data-label="Transmittal sheet"><a href="https://files.consumerfinance.gov/hmda-historic-institution-data/hmda_2016_transmittal_sheet.csv">CSV</a> (347 KB)</td>
-                        <td data-label="Panel"><a href="https://files.consumerfinance.gov/hmda-historic-institution-data/hmda_2016_panel.csv">CSV</a> (295 KB)</td>
+                        <td data-label="Transmittal sheet"><a href="https://files.consumerfinance.gov/hmda-historic-institution-data/hmda_2016_transmittal_sheet.zip">CSV</a> (347 KB)</td>
+                        <td data-label="Panel"><a href="https://files.consumerfinance.gov/hmda-historic-institution-data/hmda_2016_panel.zip">CSV</a> (295 KB)</td>
                     </tr>
                     <tr>
                         <td data-label="Year">2015</td>
-                        <td data-label="Transmittal sheet"><a href="https://files.consumerfinance.gov/hmda-historic-institution-data/hmda_2015_transmittal_sheet.csv">CSV</a> (355 KB)</td>
-                        <td data-label="Panel"><a href="https://files.consumerfinance.gov/hmda-historic-institution-data/hmda_2015_panel.csv">CSV</a> (301 KB)</td>
+                        <td data-label="Transmittal sheet"><a href="https://files.consumerfinance.gov/hmda-historic-institution-data/hmda_2015_transmittal_sheet.zip">CSV</a> (355 KB)</td>
+                        <td data-label="Panel"><a href="https://files.consumerfinance.gov/hmda-historic-institution-data/hmda_2015_panel.zip">CSV</a> (301 KB)</td>
                     </tr>
                     <tr>
                         <td data-label="Year">2014</td>
-                        <td data-label="Transmittal sheet"><a href="https://files.consumerfinance.gov/hmda-historic-institution-data/hmda_2014_transmittal_sheet.csv">CSV</a> (363 KB)</td>
-                        <td data-label="Panel"><a href="https://files.consumerfinance.gov/hmda-historic-institution-data/hmda_2014_panel.csv">CSV</a> (307 KB)</td>
+                        <td data-label="Transmittal sheet"><a href="https://files.consumerfinance.gov/hmda-historic-institution-data/hmda_2014_transmittal_sheet.zip">CSV</a> (363 KB)</td>
+                        <td data-label="Panel"><a href="https://files.consumerfinance.gov/hmda-historic-institution-data/hmda_2014_panel.zip">CSV</a> (307 KB)</td>
                     </tr>
                     <tr>
                         <td data-label="Year">2013</td>
-                        <td data-label="Transmittal sheet"><a href="https://files.consumerfinance.gov/hmda-historic-institution-data/hmda_2013_transmittal_sheet.csv">CSV</a> (369 KB)</td>
-                        <td data-label="Panel"><a href="https://files.consumerfinance.gov/hmda-historic-institution-data/hmda_2013_panel.csv">CSV</a> (314 KB)</td>
+                        <td data-label="Transmittal sheet"><a href="https://files.consumerfinance.gov/hmda-historic-institution-data/hmda_2013_transmittal_sheet.zip">CSV</a> (369 KB)</td>
+                        <td data-label="Panel"><a href="https://files.consumerfinance.gov/hmda-historic-institution-data/hmda_2013_panel.zip">CSV</a> (314 KB)</td>
                     </tr>
                     <tr>
                         <td data-label="Year">2012</td>
-                        <td data-label="Transmittal sheet"><a href="https://files.consumerfinance.gov/hmda-historic-institution-data/hmda_2012_transmittal_sheet.csv">CSV</a> (379 KB)</td>
-                        <td data-label="Panel"><a href="https://files.consumerfinance.gov/hmda-historic-institution-data/hmda_2012_panel.csv">CSV</a> (320 KB)</td>
+                        <td data-label="Transmittal sheet"><a href="https://files.consumerfinance.gov/hmda-historic-institution-data/hmda_2012_transmittal_sheet.zip">CSV</a> (379 KB)</td>
+                        <td data-label="Panel"><a href="https://files.consumerfinance.gov/hmda-historic-institution-data/hmda_2012_panel.zip">CSV</a> (320 KB)</td>
                     </tr>
                     <tr>
                         <td data-label="Year">2011</td>
-                        <td data-label="Transmittal sheet"><a href="https://files.consumerfinance.gov/hmda-historic-institution-data/hmda_2011_transmittal_sheet.csv">CSV</a> (388 KB)</td>
-                        <td data-label="Panel"><a href="https://files.consumerfinance.gov/hmda-historic-institution-data/hmda_2011_panel.csv">CSV</a> (330 KB)</td>
+                        <td data-label="Transmittal sheet"><a href="https://files.consumerfinance.gov/hmda-historic-institution-data/hmda_2011_transmittal_sheet.zip">CSV</a> (388 KB)</td>
+                        <td data-label="Panel"><a href="https://files.consumerfinance.gov/hmda-historic-institution-data/hmda_2011_panel.zip">CSV</a> (330 KB)</td>
                     </tr>
                     <tr>
                         <td data-label="Year">2010</td>
-                        <td data-label="Transmittal sheet"><a href="https://files.consumerfinance.gov/hmda-historic-institution-data/hmda_2010_transmittal_sheet.csv">CSV</a> (405 KB)</td>
-                        <td data-label="Panel"><a href="https://files.consumerfinance.gov/hmda-historic-institution-data/hmda_2010_panel.csv">CSV</a> (343 KB)</td>
+                        <td data-label="Transmittal sheet"><a href="https://files.consumerfinance.gov/hmda-historic-institution-data/hmda_2010_transmittal_sheet.zip">CSV</a> (405 KB)</td>
+                        <td data-label="Panel"><a href="https://files.consumerfinance.gov/hmda-historic-institution-data/hmda_2010_panel.zip">CSV</a> (343 KB)</td>
                     </tr>
                     <tr>
                         <td data-label="Year">2009</td>
-                        <td data-label="Transmittal sheet"><a href="https://files.consumerfinance.gov/hmda-historic-institution-data/hmda_2009_transmittal_sheet.csv">CSV</a> (413 KB)</td>
-                        <td data-label="Panel"><a href="https://files.consumerfinance.gov/hmda-historic-institution-data/hmda_2009_panel.csv">CSV</a> (381 KB)</td>
+                        <td data-label="Transmittal sheet"><a href="https://files.consumerfinance.gov/hmda-historic-institution-data/hmda_2009_transmittal_sheet.zip">CSV</a> (413 KB)</td>
+                        <td data-label="Panel"><a href="https://files.consumerfinance.gov/hmda-historic-institution-data/hmda_2009_panel.zip">CSV</a> (381 KB)</td>
                     </tr>
                     <tr>
                         <td data-label="Year">2008</td>
-                        <td data-label="Transmittal sheet"><a href="https://files.consumerfinance.gov/hmda-historic-institution-data/hmda_2008_transmittal_sheet.csv">CSV</a> (428 KB)</td>
-                        <td data-label="Panel"><a href="https://files.consumerfinance.gov/hmda-historic-institution-data/hmda_2008_panel.csv">CSV</a> (393 KB)</td>
+                        <td data-label="Transmittal sheet"><a href="https://files.consumerfinance.gov/hmda-historic-institution-data/hmda_2008_transmittal_sheet.zip">CSV</a> (428 KB)</td>
+                        <td data-label="Panel"><a href="https://files.consumerfinance.gov/hmda-historic-institution-data/hmda_2008_panel.zip">CSV</a> (393 KB)</td>
                     </tr>
                     <tr>
                         <td data-label="Year">2007</td>
-                        <td data-label="Transmittal sheet"><a href="https://files.consumerfinance.gov/hmda-historic-institution-data/hmda_2007_transmittal_sheet.csv">CSV</a> (440 KB)</td>
-                        <td data-label="Panel"><a href="https://files.consumerfinance.gov/hmda-historic-institution-data/hmda_2007_panel.csv">CSV</a> (404 KB)</td>
+                        <td data-label="Transmittal sheet"><a href="https://files.consumerfinance.gov/hmda-historic-institution-data/hmda_2007_transmittal_sheet.zip">CSV</a> (440 KB)</td>
+                        <td data-label="Panel"><a href="https://files.consumerfinance.gov/hmda-historic-institution-data/hmda_2007_panel.zip">CSV</a> (404 KB)</td>
                     </tr>
                 </tbody>
             </table>


### PR DESCRIPTION
The HMDA Historic Data page (set to launch at the end of this project cycle) had incorrect links for downloading institution data. This PR corrects the links, so users can download the data files directly from s3.

## Changes

- `.csv` -> `.zip`

## Testing

1. Running this branch, enter the wagtail admin and create a page with the `HmdaHistoricDataPage` type.
2. Publish and visit the page
3. Scroll down to the section called "Related nationwide institution data"
4. Click on any of the 22 CSV links in this section. They should now download a zipped CSV directly from files.consumerfinance.gov.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

Makes no visual changes.