### PR TITLE
Add helper text to HMDA data download form fields

### DIFF
--- a/cfgov/hmda/jinja2/hmda/hmda-explorer-controls.html
+++ b/cfgov/hmda/jinja2/hmda/hmda-explorer-controls.html
@@ -31,7 +31,18 @@
                {% for radio in form.records %}
                 <div class="m-form-field m-form-field__radio m-form-field__lg-target">
                     <input class="a-radio" name="{{ radio.data.name }}" type="radio" id="{{ radio.id_for_label }}" value="{{ radio.data.value }}" {% if radio.data.selected %} checked{% endif %}>
-                    <label class="a-label" for="{{ radio.id_for_label }}">{{ radio.choice_label}}</label>
+                    <label class="a-label" for="{{ radio.id_for_label }}">
+                        {{ radio.choice_label}}
+                        {% if radio.data.value == 'first-lien-owner-occupied-1-4-family-records' %}
+                            <small class="a-label_helper">
+                                Most people start with this option
+                            </small>
+                        {% elif radio.data.value == 'all-records' %}
+                            <small class="a-label_helper">
+                                Includes applications, denials, originations, institution purchases
+                            </small>
+                        {% endif %}
+                    </label>
                 </div>
                {% endfor %}
             </fieldset>
@@ -43,8 +54,15 @@
                 </legend>
                {% for radio in form.field_descriptions %}
                   <div class="m-form-field m-form-field__radio m-form-field__lg-target">
-                     <input class="a-radio" name="{{ radio.data.name }}" type="radio" id="{{ radio.id_for_label }}" value="{{ radio.data.value }}" {% if radio.data.selected %} checked{% endif %}>
-                     <label class="a-label" for="{{ radio.id_for_label }}">{{ radio.choice_label }}</label>
+                      <input class="a-radio" name="{{ radio.data.name }}" type="radio" id="{{ radio.id_for_label }}" value="{{ radio.data.value }}" {% if radio.data.selected %} checked{% endif %}>
+                      <label class="a-label" for="{{ radio.id_for_label }}">
+                          {{ radio.choice_label }}
+                          {% if radio.data.value == 'codes' %}
+                              <small class="a-label_helper">
+                                  Choose only if you're already familiar with the HMDA reporting codes
+                              </small>
+                          {% endif %}
+                      </label>
                   </div>
                {% endfor %}
             </fieldset>

--- a/cfgov/hmda/jinja2/hmda/hmda-explorer-institutions.html
+++ b/cfgov/hmda/jinja2/hmda/hmda-explorer-institutions.html
@@ -13,58 +13,58 @@
                 <tbody>
                     <tr>
                         <td data-label="Year">2017</td>
-                        <td data-label="Transmittal sheet"><a href="https://files.consumerfinance.gov/hmda-historic-institution-data/hmda_2017_transmittal_sheet.zip" aria-label="2017 transmittal sheet CSV file">CSV</a> (272 KB)</td>
-                        <td data-label="Panel"><a href="https://files.consumerfinance.gov/hmda-historic-institution-data/hmda_2017_panel.zip" aria-label="2017 panel CSV file">CSV</a> (229 KB)</td>
+                        <td data-label="Transmittal sheet"><a aria-label="2017 transmittal sheet CSV file" href="https://files.consumerfinance.gov/hmda-historic-institution-data/hmda_2017_transmittal_sheet.zip">CSV</a> (272 KB)</td>
+                        <td data-label="Panel"><a aria-label="2017 panel CSV file" href="https://files.consumerfinance.gov/hmda-historic-institution-data/hmda_2017_panel.zip">CSV</a> (229 KB)</td>
                     </tr>
                     <tr>
                         <td data-label="Year">2016</td>
-                        <td data-label="Transmittal sheet"><a href="https://files.consumerfinance.gov/hmda-historic-institution-data/hmda_2016_transmittal_sheet.zip" aria-label="2016 transmittal sheet CSV file">CSV</a> (347 KB)</td>
-                        <td data-label="Panel"><a href="https://files.consumerfinance.gov/hmda-historic-institution-data/hmda_2016_panel.zip" aria-label="2016 panel CSV file">CSV</a> (295 KB)</td>
+                        <td data-label="Transmittal sheet"><a aria-label="2016 transmittal sheet CSV file" href="https://files.consumerfinance.gov/hmda-historic-institution-data/hmda_2016_transmittal_sheet.zip">CSV</a> (347 KB)</td>
+                        <td data-label="Panel"><a aria-label="2016 panel CSV file" href="https://files.consumerfinance.gov/hmda-historic-institution-data/hmda_2016_panel.zip">CSV</a> (295 KB)</td>
                     </tr>
                     <tr>
                         <td data-label="Year">2015</td>
-                        <td data-label="Transmittal sheet"><a href="https://files.consumerfinance.gov/hmda-historic-institution-data/hmda_2015_transmittal_sheet.zip" aria-label="2015 transmittal sheet CSV file">CSV</a> (355 KB)</td>
-                        <td data-label="Panel"><a href="https://files.consumerfinance.gov/hmda-historic-institution-data/hmda_2015_panel.zip" aria-label="2015 panel CSV file">CSV</a> (301 KB)</td>
+                        <td data-label="Transmittal sheet"><a aria-label="2015 transmittal sheet CSV file" href="https://files.consumerfinance.gov/hmda-historic-institution-data/hmda_2015_transmittal_sheet.zip">CSV</a> (355 KB)</td>
+                        <td data-label="Panel"><a aria-label="2015 panel CSV file" href="https://files.consumerfinance.gov/hmda-historic-institution-data/hmda_2015_panel.zip">CSV</a> (301 KB)</td>
                     </tr>
                     <tr>
                         <td data-label="Year">2014</td>
-                        <td data-label="Transmittal sheet"><a href="https://files.consumerfinance.gov/hmda-historic-institution-data/hmda_2014_transmittal_sheet.zip" aria-label="2014 transmittal sheet CSV file">CSV</a> (363 KB)</td>
-                        <td data-label="Panel"><a href="https://files.consumerfinance.gov/hmda-historic-institution-data/hmda_2014_panel.zip" aria-label="2014 panel CSV file">CSV</a> (307 KB)</td>
+                        <td data-label="Transmittal sheet"><a aria-label="2014 transmittal sheet CSV file" href="https://files.consumerfinance.gov/hmda-historic-institution-data/hmda_2014_transmittal_sheet.zip">CSV</a> (363 KB)</td>
+                        <td data-label="Panel"><a aria-label="2014 panel CSV file" href="https://files.consumerfinance.gov/hmda-historic-institution-data/hmda_2014_panel.zip">CSV</a> (307 KB)</td>
                     </tr>
                     <tr>
                         <td data-label="Year">2013</td>
-                        <td data-label="Transmittal sheet"><a href="https://files.consumerfinance.gov/hmda-historic-institution-data/hmda_2013_transmittal_sheet.zip" aria-label="2013 transmittal sheet CSV file">CSV</a> (369 KB)</td>
-                        <td data-label="Panel"><a href="https://files.consumerfinance.gov/hmda-historic-institution-data/hmda_2013_panel.zip" aria-label="2013 panel CSV file">CSV</a> (314 KB)</td>
+                        <td data-label="Transmittal sheet"><a aria-label="2013 transmittal sheet CSV file" href="https://files.consumerfinance.gov/hmda-historic-institution-data/hmda_2013_transmittal_sheet.zip">CSV</a> (369 KB)</td>
+                        <td data-label="Panel"><a aria-label="2013 panel CSV file" href="https://files.consumerfinance.gov/hmda-historic-institution-data/hmda_2013_panel.zip">CSV</a> (314 KB)</td>
                     </tr>
                     <tr>
                         <td data-label="Year">2012</td>
-                        <td data-label="Transmittal sheet"><a href="https://files.consumerfinance.gov/hmda-historic-institution-data/hmda_2012_transmittal_sheet.zip" aria-label="2012 transmittal sheet CSV file">CSV</a> (379 KB)</td>
-                        <td data-label="Panel"><a href="https://files.consumerfinance.gov/hmda-historic-institution-data/hmda_2012_panel.zip" aria-label="2012 panel CSV file">CSV</a> (320 KB)</td>
+                        <td data-label="Transmittal sheet"><a aria-label="2012 transmittal sheet CSV file" href="https://files.consumerfinance.gov/hmda-historic-institution-data/hmda_2012_transmittal_sheet.zip">CSV</a> (379 KB)</td>
+                        <td data-label="Panel"><a aria-label="2012 panel CSV file" href="https://files.consumerfinance.gov/hmda-historic-institution-data/hmda_2012_panel.zip">CSV</a> (320 KB)</td>
                     </tr>
                     <tr>
                         <td data-label="Year">2011</td>
-                        <td data-label="Transmittal sheet"><a href="https://files.consumerfinance.gov/hmda-historic-institution-data/hmda_2011_transmittal_sheet.zip" aria-label="2011 transmittal sheet CSV file">CSV</a> (388 KB)</td>
-                        <td data-label="Panel"><a href="https://files.consumerfinance.gov/hmda-historic-institution-data/hmda_2011_panel.zip" aria-label="2011 panel CSV file">CSV</a> (330 KB)</td>
+                        <td data-label="Transmittal sheet"><a aria-label="2011 transmittal sheet CSV file" href="https://files.consumerfinance.gov/hmda-historic-institution-data/hmda_2011_transmittal_sheet.zip">CSV</a> (388 KB)</td>
+                        <td data-label="Panel"><a aria-label="2011 panel CSV file" href="https://files.consumerfinance.gov/hmda-historic-institution-data/hmda_2011_panel.zip">CSV</a> (330 KB)</td>
                     </tr>
                     <tr>
                         <td data-label="Year">2010</td>
-                        <td data-label="Transmittal sheet"><a href="https://files.consumerfinance.gov/hmda-historic-institution-data/hmda_2010_transmittal_sheet.zip" aria-label="2010 transmittal sheet CSV file">CSV</a> (405 KB)</td>
-                        <td data-label="Panel"><a href="https://files.consumerfinance.gov/hmda-historic-institution-data/hmda_2010_panel.zip" aria-label="2010 panel CSV file">CSV</a> (343 KB)</td>
+                        <td data-label="Transmittal sheet"><a aria-label="2010 transmittal sheet CSV file" href="https://files.consumerfinance.gov/hmda-historic-institution-data/hmda_2010_transmittal_sheet.zip">CSV</a> (405 KB)</td>
+                        <td data-label="Panel"><a aria-label="2010 panel CSV file" href="https://files.consumerfinance.gov/hmda-historic-institution-data/hmda_2010_panel.zip">CSV</a> (343 KB)</td>
                     </tr>
                     <tr>
                         <td data-label="Year">2009</td>
-                        <td data-label="Transmittal sheet"><a href="https://files.consumerfinance.gov/hmda-historic-institution-data/hmda_2009_transmittal_sheet.zip" aria-label="2009 transmittal sheet CSV file">CSV</a> (413 KB)</td>
-                        <td data-label="Panel"><a href="https://files.consumerfinance.gov/hmda-historic-institution-data/hmda_2009_panel.zip" aria-label="2009 panel CSV file">CSV</a> (381 KB)</td>
+                        <td data-label="Transmittal sheet"><a aria-label="2009 transmittal sheet CSV file" href="https://files.consumerfinance.gov/hmda-historic-institution-data/hmda_2009_transmittal_sheet.zip">CSV</a> (413 KB)</td>
+                        <td data-label="Panel"><a aria-label="2009 panel CSV file" href="https://files.consumerfinance.gov/hmda-historic-institution-data/hmda_2009_panel.zip">CSV</a> (381 KB)</td>
                     </tr>
                     <tr>
                         <td data-label="Year">2008</td>
-                        <td data-label="Transmittal sheet"><a href="https://files.consumerfinance.gov/hmda-historic-institution-data/hmda_2008_transmittal_sheet.zip" aria-label="2008 transmittal sheet CSV file">CSV</a> (428 KB)</td>
-                        <td data-label="Panel"><a href="https://files.consumerfinance.gov/hmda-historic-institution-data/hmda_2008_panel.zip" aria-label="2008 panel CSV file">CSV</a> (393 KB)</td>
+                        <td data-label="Transmittal sheet"><a aria-label="2008 transmittal sheet CSV file" href="https://files.consumerfinance.gov/hmda-historic-institution-data/hmda_2008_transmittal_sheet.zip">CSV</a> (428 KB)</td>
+                        <td data-label="Panel"><a aria-label="2008 panel CSV file" href="https://files.consumerfinance.gov/hmda-historic-institution-data/hmda_2008_panel.zip">CSV</a> (393 KB)</td>
                     </tr>
                     <tr>
                         <td data-label="Year">2007</td>
-                        <td data-label="Transmittal sheet"><a href="https://files.consumerfinance.gov/hmda-historic-institution-data/hmda_2007_transmittal_sheet.zip" aria-label="2007 transmittal sheet CSV file">CSV</a> (440 KB)</td>
-                        <td data-label="Panel"><a href="https://files.consumerfinance.gov/hmda-historic-institution-data/hmda_2007_panel.zip" aria-label="2007 panel CSV file">CSV</a> (404 KB)</td>
+                        <td data-label="Transmittal sheet"><a aria-label="2007 transmittal sheet CSV file" href="https://files.consumerfinance.gov/hmda-historic-institution-data/hmda_2007_transmittal_sheet.zip">CSV</a> (440 KB)</td>
+                        <td data-label="Panel"><a aria-label="2007 panel CSV file" href="https://files.consumerfinance.gov/hmda-historic-institution-data/hmda_2007_panel.zip">CSV</a> (404 KB)</td>
                     </tr>
                 </tbody>
             </table>

--- a/cfgov/hmda/jinja2/hmda/hmda-explorer-institutions.html
+++ b/cfgov/hmda/jinja2/hmda/hmda-explorer-institutions.html
@@ -69,8 +69,8 @@
                 </tbody>
             </table>
         </div>
-        <p class="u-mt10 u-mb5">Panel data documentation: <a href="https://www.ffiec.gov/hmdarawdata/FORMATS/2009HMDAReporterPanel.pdf">2007-2009</a> and <a href="https://s3.amazonaws.com/cfpb-hmda-public/prod/snapshot-data/2017_publicstatic_dataformat.zip">2010-2017</a>.</p>
-        <p>Transmittal sheet documentation: <a href="https://www.ffiec.gov/hmdarawdata/FORMATS/2015HMDAInstitutionRecordFormat.pdf">2007-2016</a> and <a href="https://s3.amazonaws.com/cfpb-hmda-public/prod/snapshot-data/2017_publicstatic_dataformat.zip">2017</a>.</p>
+        <p class="u-mt10 u-mb5">Panel data documentation: <a href="https://files.consumerfinance.gov/hmda-historic-data-dictionaries/panel_2007-2009.pdf">2007-2009</a> and <a href="https://files.consumerfinance.gov/hmda-historic-data-dictionaries/panel_2010-2017.pdf">2010-2017</a>.</p>
+        <p>Transmittal sheet documentation: <a href="https://files.consumerfinance.gov/hmda-historic-data-dictionaries/transmittal_sheet_2007-2016.pdf">2007-2016</a> and <a href="https://files.consumerfinance.gov/hmda-historic-data-dictionaries/transmittal_sheet_2017.pdf">2017</a>.</p>
     </div>
 {% endmacro %}
 

--- a/cfgov/hmda/jinja2/hmda/hmda-explorer-institutions.html
+++ b/cfgov/hmda/jinja2/hmda/hmda-explorer-institutions.html
@@ -13,58 +13,58 @@
                 <tbody>
                     <tr>
                         <td data-label="Year">2017</td>
-                        <td data-label="Transmittal sheet"><a href="https://files.consumerfinance.gov/hmda-historic-institution-data/hmda_2017_transmittal_sheet.zip">CSV</a> (272 KB)</td>
-                        <td data-label="Panel"><a href="https://files.consumerfinance.gov/hmda-historic-institution-data/hmda_2017_panel.zip">CSV</a> (229 KB)</td>
+                        <td data-label="Transmittal sheet"><a href="https://files.consumerfinance.gov/hmda-historic-institution-data/hmda_2017_transmittal_sheet.zip" aria-label="2017 transmittal sheet CSV file">CSV</a> (272 KB)</td>
+                        <td data-label="Panel"><a href="https://files.consumerfinance.gov/hmda-historic-institution-data/hmda_2017_panel.zip" aria-label="2017 panel CSV file">CSV</a> (229 KB)</td>
                     </tr>
                     <tr>
                         <td data-label="Year">2016</td>
-                        <td data-label="Transmittal sheet"><a href="https://files.consumerfinance.gov/hmda-historic-institution-data/hmda_2016_transmittal_sheet.zip">CSV</a> (347 KB)</td>
-                        <td data-label="Panel"><a href="https://files.consumerfinance.gov/hmda-historic-institution-data/hmda_2016_panel.zip">CSV</a> (295 KB)</td>
+                        <td data-label="Transmittal sheet"><a href="https://files.consumerfinance.gov/hmda-historic-institution-data/hmda_2016_transmittal_sheet.zip" aria-label="2016 transmittal sheet CSV file">CSV</a> (347 KB)</td>
+                        <td data-label="Panel"><a href="https://files.consumerfinance.gov/hmda-historic-institution-data/hmda_2016_panel.zip" aria-label="2016 panel CSV file">CSV</a> (295 KB)</td>
                     </tr>
                     <tr>
                         <td data-label="Year">2015</td>
-                        <td data-label="Transmittal sheet"><a href="https://files.consumerfinance.gov/hmda-historic-institution-data/hmda_2015_transmittal_sheet.zip">CSV</a> (355 KB)</td>
-                        <td data-label="Panel"><a href="https://files.consumerfinance.gov/hmda-historic-institution-data/hmda_2015_panel.zip">CSV</a> (301 KB)</td>
+                        <td data-label="Transmittal sheet"><a href="https://files.consumerfinance.gov/hmda-historic-institution-data/hmda_2015_transmittal_sheet.zip" aria-label="2015 transmittal sheet CSV file">CSV</a> (355 KB)</td>
+                        <td data-label="Panel"><a href="https://files.consumerfinance.gov/hmda-historic-institution-data/hmda_2015_panel.zip" aria-label="2015 panel CSV file">CSV</a> (301 KB)</td>
                     </tr>
                     <tr>
                         <td data-label="Year">2014</td>
-                        <td data-label="Transmittal sheet"><a href="https://files.consumerfinance.gov/hmda-historic-institution-data/hmda_2014_transmittal_sheet.zip">CSV</a> (363 KB)</td>
-                        <td data-label="Panel"><a href="https://files.consumerfinance.gov/hmda-historic-institution-data/hmda_2014_panel.zip">CSV</a> (307 KB)</td>
+                        <td data-label="Transmittal sheet"><a href="https://files.consumerfinance.gov/hmda-historic-institution-data/hmda_2014_transmittal_sheet.zip" aria-label="2014 transmittal sheet CSV file">CSV</a> (363 KB)</td>
+                        <td data-label="Panel"><a href="https://files.consumerfinance.gov/hmda-historic-institution-data/hmda_2014_panel.zip" aria-label="2014 panel CSV file">CSV</a> (307 KB)</td>
                     </tr>
                     <tr>
                         <td data-label="Year">2013</td>
-                        <td data-label="Transmittal sheet"><a href="https://files.consumerfinance.gov/hmda-historic-institution-data/hmda_2013_transmittal_sheet.zip">CSV</a> (369 KB)</td>
-                        <td data-label="Panel"><a href="https://files.consumerfinance.gov/hmda-historic-institution-data/hmda_2013_panel.zip">CSV</a> (314 KB)</td>
+                        <td data-label="Transmittal sheet"><a href="https://files.consumerfinance.gov/hmda-historic-institution-data/hmda_2013_transmittal_sheet.zip" aria-label="2013 transmittal sheet CSV file">CSV</a> (369 KB)</td>
+                        <td data-label="Panel"><a href="https://files.consumerfinance.gov/hmda-historic-institution-data/hmda_2013_panel.zip" aria-label="2013 panel CSV file">CSV</a> (314 KB)</td>
                     </tr>
                     <tr>
                         <td data-label="Year">2012</td>
-                        <td data-label="Transmittal sheet"><a href="https://files.consumerfinance.gov/hmda-historic-institution-data/hmda_2012_transmittal_sheet.zip">CSV</a> (379 KB)</td>
-                        <td data-label="Panel"><a href="https://files.consumerfinance.gov/hmda-historic-institution-data/hmda_2012_panel.zip">CSV</a> (320 KB)</td>
+                        <td data-label="Transmittal sheet"><a href="https://files.consumerfinance.gov/hmda-historic-institution-data/hmda_2012_transmittal_sheet.zip" aria-label="2012 transmittal sheet CSV file">CSV</a> (379 KB)</td>
+                        <td data-label="Panel"><a href="https://files.consumerfinance.gov/hmda-historic-institution-data/hmda_2012_panel.zip" aria-label="2012 panel CSV file">CSV</a> (320 KB)</td>
                     </tr>
                     <tr>
                         <td data-label="Year">2011</td>
-                        <td data-label="Transmittal sheet"><a href="https://files.consumerfinance.gov/hmda-historic-institution-data/hmda_2011_transmittal_sheet.zip">CSV</a> (388 KB)</td>
-                        <td data-label="Panel"><a href="https://files.consumerfinance.gov/hmda-historic-institution-data/hmda_2011_panel.zip">CSV</a> (330 KB)</td>
+                        <td data-label="Transmittal sheet"><a href="https://files.consumerfinance.gov/hmda-historic-institution-data/hmda_2011_transmittal_sheet.zip" aria-label="2011 transmittal sheet CSV file">CSV</a> (388 KB)</td>
+                        <td data-label="Panel"><a href="https://files.consumerfinance.gov/hmda-historic-institution-data/hmda_2011_panel.zip" aria-label="2011 panel CSV file">CSV</a> (330 KB)</td>
                     </tr>
                     <tr>
                         <td data-label="Year">2010</td>
-                        <td data-label="Transmittal sheet"><a href="https://files.consumerfinance.gov/hmda-historic-institution-data/hmda_2010_transmittal_sheet.zip">CSV</a> (405 KB)</td>
-                        <td data-label="Panel"><a href="https://files.consumerfinance.gov/hmda-historic-institution-data/hmda_2010_panel.zip">CSV</a> (343 KB)</td>
+                        <td data-label="Transmittal sheet"><a href="https://files.consumerfinance.gov/hmda-historic-institution-data/hmda_2010_transmittal_sheet.zip" aria-label="2010 transmittal sheet CSV file">CSV</a> (405 KB)</td>
+                        <td data-label="Panel"><a href="https://files.consumerfinance.gov/hmda-historic-institution-data/hmda_2010_panel.zip" aria-label="2010 panel CSV file">CSV</a> (343 KB)</td>
                     </tr>
                     <tr>
                         <td data-label="Year">2009</td>
-                        <td data-label="Transmittal sheet"><a href="https://files.consumerfinance.gov/hmda-historic-institution-data/hmda_2009_transmittal_sheet.zip">CSV</a> (413 KB)</td>
-                        <td data-label="Panel"><a href="https://files.consumerfinance.gov/hmda-historic-institution-data/hmda_2009_panel.zip">CSV</a> (381 KB)</td>
+                        <td data-label="Transmittal sheet"><a href="https://files.consumerfinance.gov/hmda-historic-institution-data/hmda_2009_transmittal_sheet.zip" aria-label="2009 transmittal sheet CSV file">CSV</a> (413 KB)</td>
+                        <td data-label="Panel"><a href="https://files.consumerfinance.gov/hmda-historic-institution-data/hmda_2009_panel.zip" aria-label="2009 panel CSV file">CSV</a> (381 KB)</td>
                     </tr>
                     <tr>
                         <td data-label="Year">2008</td>
-                        <td data-label="Transmittal sheet"><a href="https://files.consumerfinance.gov/hmda-historic-institution-data/hmda_2008_transmittal_sheet.zip">CSV</a> (428 KB)</td>
-                        <td data-label="Panel"><a href="https://files.consumerfinance.gov/hmda-historic-institution-data/hmda_2008_panel.zip">CSV</a> (393 KB)</td>
+                        <td data-label="Transmittal sheet"><a href="https://files.consumerfinance.gov/hmda-historic-institution-data/hmda_2008_transmittal_sheet.zip" aria-label="2008 transmittal sheet CSV file">CSV</a> (428 KB)</td>
+                        <td data-label="Panel"><a href="https://files.consumerfinance.gov/hmda-historic-institution-data/hmda_2008_panel.zip" aria-label="2008 panel CSV file">CSV</a> (393 KB)</td>
                     </tr>
                     <tr>
                         <td data-label="Year">2007</td>
-                        <td data-label="Transmittal sheet"><a href="https://files.consumerfinance.gov/hmda-historic-institution-data/hmda_2007_transmittal_sheet.zip">CSV</a> (440 KB)</td>
-                        <td data-label="Panel"><a href="https://files.consumerfinance.gov/hmda-historic-institution-data/hmda_2007_panel.zip">CSV</a> (404 KB)</td>
+                        <td data-label="Transmittal sheet"><a href="https://files.consumerfinance.gov/hmda-historic-institution-data/hmda_2007_transmittal_sheet.zip" aria-label="2007 transmittal sheet CSV file">CSV</a> (440 KB)</td>
+                        <td data-label="Panel"><a href="https://files.consumerfinance.gov/hmda-historic-institution-data/hmda_2007_panel.zip" aria-label="2007 panel CSV file">CSV</a> (404 KB)</td>
                     </tr>
                 </tbody>
             </table>

--- a/cfgov/hmda/jinja2/hmda/hmda-explorer-institutions.html
+++ b/cfgov/hmda/jinja2/hmda/hmda-explorer-institutions.html
@@ -13,63 +13,64 @@
                 <tbody>
                     <tr>
                         <td data-label="Year">2017</td>
-                        <td data-label="Transmittal sheet"><a href="https://files.consumerfinance.gov/hmda-historic-institution-data/hmda_2017_transmittal_sheet.csv">CSV</a> (272 KB)</td>
-                        <td data-label="Panel"><a href="https://files.consumerfinance.gov/hmda-historic-institution-data/hmda_2017_panel.csv">CSV</a> (229 KB)</td>
+                        <td data-label="Transmittal sheet"><a href="https://files.consumerfinance.gov/hmda-historic-institution-data/hmda_2017_transmittal_sheet.zip">CSV</a> (272 KB)</td>
+                        <td data-label="Panel"><a href="https://files.consumerfinance.gov/hmda-historic-institution-data/hmda_2017_panel.zip">CSV</a> (229 KB)</td>
                     </tr>
                     <tr>
                         <td data-label="Year">2016</td>
-                        <td data-label="Transmittal sheet"><a href="https://files.consumerfinance.gov/hmda-historic-institution-data/hmda_2016_transmittal_sheet.csv">CSV</a> (347 KB)</td>
-                        <td data-label="Panel"><a href="https://files.consumerfinance.gov/hmda-historic-institution-data/hmda_2016_panel.csv">CSV</a> (295 KB)</td>
+                        <td data-label="Transmittal sheet"><a href="https://files.consumerfinance.gov/hmda-historic-institution-data/hmda_2016_transmittal_sheet.zip">CSV</a> (347 KB)</td>
+                        <td data-label="Panel"><a href="https://files.consumerfinance.gov/hmda-historic-institution-data/hmda_2016_panel.zip">CSV</a> (295 KB)</td>
                     </tr>
                     <tr>
                         <td data-label="Year">2015</td>
-                        <td data-label="Transmittal sheet"><a href="https://files.consumerfinance.gov/hmda-historic-institution-data/hmda_2015_transmittal_sheet.csv">CSV</a> (355 KB)</td>
-                        <td data-label="Panel"><a href="https://files.consumerfinance.gov/hmda-historic-institution-data/hmda_2015_panel.csv">CSV</a> (301 KB)</td>
+                        <td data-label="Transmittal sheet"><a href="https://files.consumerfinance.gov/hmda-historic-institution-data/hmda_2015_transmittal_sheet.zip">CSV</a> (355 KB)</td>
+                        <td data-label="Panel"><a href="https://files.consumerfinance.gov/hmda-historic-institution-data/hmda_2015_panel.zip">CSV</a> (301 KB)</td>
                     </tr>
                     <tr>
                         <td data-label="Year">2014</td>
-                        <td data-label="Transmittal sheet"><a href="https://files.consumerfinance.gov/hmda-historic-institution-data/hmda_2014_transmittal_sheet.csv">CSV</a> (363 KB)</td>
-                        <td data-label="Panel"><a href="https://files.consumerfinance.gov/hmda-historic-institution-data/hmda_2014_panel.csv">CSV</a> (307 KB)</td>
+                        <td data-label="Transmittal sheet"><a href="https://files.consumerfinance.gov/hmda-historic-institution-data/hmda_2014_transmittal_sheet.zip">CSV</a> (363 KB)</td>
+                        <td data-label="Panel"><a href="https://files.consumerfinance.gov/hmda-historic-institution-data/hmda_2014_panel.zip">CSV</a> (307 KB)</td>
                     </tr>
                     <tr>
                         <td data-label="Year">2013</td>
-                        <td data-label="Transmittal sheet"><a href="https://files.consumerfinance.gov/hmda-historic-institution-data/hmda_2013_transmittal_sheet.csv">CSV</a> (369 KB)</td>
-                        <td data-label="Panel"><a href="https://files.consumerfinance.gov/hmda-historic-institution-data/hmda_2013_panel.csv">CSV</a> (314 KB)</td>
+                        <td data-label="Transmittal sheet"><a href="https://files.consumerfinance.gov/hmda-historic-institution-data/hmda_2013_transmittal_sheet.zip">CSV</a> (369 KB)</td>
+                        <td data-label="Panel"><a href="https://files.consumerfinance.gov/hmda-historic-institution-data/hmda_2013_panel.zip">CSV</a> (314 KB)</td>
                     </tr>
                     <tr>
                         <td data-label="Year">2012</td>
-                        <td data-label="Transmittal sheet"><a href="https://files.consumerfinance.gov/hmda-historic-institution-data/hmda_2012_transmittal_sheet.csv">CSV</a> (379 KB)</td>
-                        <td data-label="Panel"><a href="https://files.consumerfinance.gov/hmda-historic-institution-data/hmda_2012_panel.csv">CSV</a> (320 KB)</td>
+                        <td data-label="Transmittal sheet"><a href="https://files.consumerfinance.gov/hmda-historic-institution-data/hmda_2012_transmittal_sheet.zip">CSV</a> (379 KB)</td>
+                        <td data-label="Panel"><a href="https://files.consumerfinance.gov/hmda-historic-institution-data/hmda_2012_panel.zip">CSV</a> (320 KB)</td>
                     </tr>
                     <tr>
                         <td data-label="Year">2011</td>
-                        <td data-label="Transmittal sheet"><a href="https://files.consumerfinance.gov/hmda-historic-institution-data/hmda_2011_transmittal_sheet.csv">CSV</a> (388 KB)</td>
-                        <td data-label="Panel"><a href="https://files.consumerfinance.gov/hmda-historic-institution-data/hmda_2011_panel.csv">CSV</a> (330 KB)</td>
+                        <td data-label="Transmittal sheet"><a href="https://files.consumerfinance.gov/hmda-historic-institution-data/hmda_2011_transmittal_sheet.zip">CSV</a> (388 KB)</td>
+                        <td data-label="Panel"><a href="https://files.consumerfinance.gov/hmda-historic-institution-data/hmda_2011_panel.zip">CSV</a> (330 KB)</td>
                     </tr>
                     <tr>
                         <td data-label="Year">2010</td>
-                        <td data-label="Transmittal sheet"><a href="https://files.consumerfinance.gov/hmda-historic-institution-data/hmda_2010_transmittal_sheet.csv">CSV</a> (405 KB)</td>
-                        <td data-label="Panel"><a href="https://files.consumerfinance.gov/hmda-historic-institution-data/hmda_2010_panel.csv">CSV</a> (343 KB)</td>
+                        <td data-label="Transmittal sheet"><a href="https://files.consumerfinance.gov/hmda-historic-institution-data/hmda_2010_transmittal_sheet.zip">CSV</a> (405 KB)</td>
+                        <td data-label="Panel"><a href="https://files.consumerfinance.gov/hmda-historic-institution-data/hmda_2010_panel.zip">CSV</a> (343 KB)</td>
                     </tr>
                     <tr>
                         <td data-label="Year">2009</td>
-                        <td data-label="Transmittal sheet"><a href="https://files.consumerfinance.gov/hmda-historic-institution-data/hmda_2009_transmittal_sheet.csv">CSV</a> (413 KB)</td>
-                        <td data-label="Panel"><a href="https://files.consumerfinance.gov/hmda-historic-institution-data/hmda_2009_panel.csv">CSV</a> (381 KB)</td>
+                        <td data-label="Transmittal sheet"><a href="https://files.consumerfinance.gov/hmda-historic-institution-data/hmda_2009_transmittal_sheet.zip">CSV</a> (413 KB)</td>
+                        <td data-label="Panel"><a href="https://files.consumerfinance.gov/hmda-historic-institution-data/hmda_2009_panel.zip">CSV</a> (381 KB)</td>
                     </tr>
                     <tr>
                         <td data-label="Year">2008</td>
-                        <td data-label="Transmittal sheet"><a href="https://files.consumerfinance.gov/hmda-historic-institution-data/hmda_2008_transmittal_sheet.csv">CSV</a> (428 KB)</td>
-                        <td data-label="Panel"><a href="https://files.consumerfinance.gov/hmda-historic-institution-data/hmda_2008_panel.csv">CSV</a> (393 KB)</td>
+                        <td data-label="Transmittal sheet"><a href="https://files.consumerfinance.gov/hmda-historic-institution-data/hmda_2008_transmittal_sheet.zip">CSV</a> (428 KB)</td>
+                        <td data-label="Panel"><a href="https://files.consumerfinance.gov/hmda-historic-institution-data/hmda_2008_panel.zip">CSV</a> (393 KB)</td>
                     </tr>
                     <tr>
                         <td data-label="Year">2007</td>
-                        <td data-label="Transmittal sheet"><a href="https://files.consumerfinance.gov/hmda-historic-institution-data/hmda_2007_transmittal_sheet.csv">CSV</a> (440 KB)</td>
-                        <td data-label="Panel"><a href="https://files.consumerfinance.gov/hmda-historic-institution-data/hmda_2007_panel.csv">CSV</a> (404 KB)</td>
+                        <td data-label="Transmittal sheet"><a href="https://files.consumerfinance.gov/hmda-historic-institution-data/hmda_2007_transmittal_sheet.zip">CSV</a> (440 KB)</td>
+                        <td data-label="Panel"><a href="https://files.consumerfinance.gov/hmda-historic-institution-data/hmda_2007_panel.zip">CSV</a> (404 KB)</td>
                     </tr>
                 </tbody>
             </table>
         </div>
-        <p class="u-mt10">See the documentation for the <a href="#">transmittal sheet</a> and <a href="#">panel data</a>.</p>
+        <p class="u-mt10 u-mb5">Panel data documentation: <a href="#">2007-2009</a> and <a href="#">2010-2017</a>.</p>
+        <p>Transmittal sheet documentation: <a href="#">2007-2016</a> and <a href="#">2017</a>.</p>
     </div>
 {% endmacro %}
 

--- a/cfgov/hmda/jinja2/hmda/hmda-explorer-institutions.html
+++ b/cfgov/hmda/jinja2/hmda/hmda-explorer-institutions.html
@@ -69,8 +69,8 @@
                 </tbody>
             </table>
         </div>
-        <p class="u-mt10 u-mb5">Panel data documentation: <a href="#">2007-2009</a> and <a href="#">2010-2017</a>.</p>
-        <p>Transmittal sheet documentation: <a href="#">2007-2016</a> and <a href="#">2017</a>.</p>
+        <p class="u-mt10 u-mb5">Panel data documentation: <a href="https://www.ffiec.gov/hmdarawdata/FORMATS/2009HMDAReporterPanel.pdf">2007-2009</a> and <a href="https://s3.amazonaws.com/cfpb-hmda-public/prod/snapshot-data/2017_publicstatic_dataformat.zip">2010-2017</a>.</p>
+        <p>Transmittal sheet documentation: <a href="https://www.ffiec.gov/hmdarawdata/FORMATS/2015HMDAInstitutionRecordFormat.pdf">2007-2016</a> and <a href="https://s3.amazonaws.com/cfpb-hmda-public/prod/snapshot-data/2017_publicstatic_dataformat.zip">2017</a>.</p>
     </div>
 {% endmacro %}
 

--- a/cfgov/hmda/jinja2/hmda/hmda-explorer-results.html
+++ b/cfgov/hmda/jinja2/hmda/hmda-explorer-results.html
@@ -20,7 +20,7 @@
                             {{ "{:,.0f}".format(csv.number_of_records | int) }}
                           </div>
                         </td>
-                        <td data-label="Download"><a href="https://files.consumerfinance.gov/hmda-historic-loan-data/{{ csv.file_name }}" aria-label="{{ csv.file_size }} CSV containing HMDA loan application records for {{ geo }} in {{ year }}">CSV</a> ({{ csv.file_size }})</td>
+                        <td data-label="Download"><a href="https://files.consumerfinance.gov/hmda-historic-loan-data/{{ csv.file_name }}" aria-label="{{ csv.file_size }} CSV containing HMDA loan application records for {{ year }}">CSV</a> ({{ csv.file_size }})</td>
                     </tr>
                     {% endfor %}
                 </tbody>

--- a/cfgov/hmda/jinja2/hmda/hmda-explorer-results.html
+++ b/cfgov/hmda/jinja2/hmda/hmda-explorer-results.html
@@ -26,7 +26,7 @@
                 </tbody>
             </table>
         </div>
-        <p class="u-mt10">For an explanation of each field <a href="https://www.ffiec.gov/hmdarawdata/FORMATS/2016HMDALARRecordFormat.pdf">review the variable list</a> or <a href="https://www.ffiec.gov/hmdarawdata/FORMATS/2016HMDACodeSheet.pdf">find code explanations</a>.</p>
+        <p class="u-mt10">For an explanation of each field <a href="https://files.consumerfinance.gov/hmda-historic-data-dictionaries/lar_record_format.pdf">review the variable list</a> or <a href="https://files.consumerfinance.gov/hmda-historic-data-dictionaries/lar_record_codes.pdf">find code explanations</a>.</p>
     </div>
 {% endmacro %}
 

--- a/cfgov/hmda/jinja2/hmda/hmda-explorer-results.html
+++ b/cfgov/hmda/jinja2/hmda/hmda-explorer-results.html
@@ -26,7 +26,7 @@
                 </tbody>
             </table>
         </div>
-        <p class="u-mt10">For an explanation of each field <a href="#">review the variable list</a> or <a href="#">find code explanations</a>.</p>
+        <p class="u-mt10">For an explanation of each field <a href="https://www.ffiec.gov/hmdarawdata/FORMATS/2016HMDALARRecordFormat.pdf">review the variable list</a> or <a href="https://www.ffiec.gov/hmdarawdata/FORMATS/2016HMDACodeSheet.pdf">find code explanations</a>.</p>
     </div>
 {% endmacro %}
 

--- a/cfgov/hmda/jinja2/hmda/hmda-explorer-results.html
+++ b/cfgov/hmda/jinja2/hmda/hmda-explorer-results.html
@@ -20,7 +20,7 @@
                             {{ "{:,.0f}".format(csv.number_of_records | int) }}
                           </div>
                         </td>
-                        <td data-label="Download"><a href="https://files.consumerfinance.gov/hmda-historic-loan-data/{{ csv.file_name }}" aria-label="{{ csv.file_size }} CSV containing HMDA loan application records for {{ year }}">CSV</a> ({{ csv.file_size }})</td>
+                        <td data-label="Download"><a href="https://files.consumerfinance.gov/hmda-historic-loan-data/{{ csv.file_name }}" aria-label="{{ csv.file_size }} CSV file containing HMDA loan application records for {{ year }}">CSV</a> ({{ csv.file_size }})</td>
                     </tr>
                     {% endfor %}
                 </tbody>

--- a/cfgov/hmda/jinja2/hmda/hmda-explorer-results.html
+++ b/cfgov/hmda/jinja2/hmda/hmda-explorer-results.html
@@ -20,7 +20,7 @@
                             {{ "{:,.0f}".format(csv.number_of_records | int) }}
                           </div>
                         </td>
-                        <td data-label="Download"><a href="https://files.consumerfinance.gov/hmda-historic-loan-data/{{ csv.file_name }}" aria-label="{{ csv.file_size }} CSV file containing HMDA loan application records for {{ year }}">CSV</a> ({{ csv.file_size }})</td>
+                        <td data-label="Download"><a aria-label="{{ csv.file_size }} CSV file containing HMDA loan application records for {{ year }}" href="https://files.consumerfinance.gov/hmda-historic-loan-data/{{ csv.file_name }}">CSV</a> ({{ csv.file_size }})</td>
                     </tr>
                     {% endfor %}
                 </tbody>

--- a/cfgov/hmda/resources/hmda_data_options.py
+++ b/cfgov/hmda/resources/hmda_data_options.py
@@ -1,7 +1,7 @@
 # All lists have their default value listed first
 HMDA_RECORDS_OPTIONS = [
     ('first-lien-owner-occupied-1-4-family-records',
-        'Originated mortgages for first lien, owner-occupied, 1-4 family homes'),  # noqa E501
+        'Mortgages for first lien, owner-occupied, 1-4 family homes'),
     ('originated-records', 'All originated mortgages'),
     ('all-records', 'All records'),
 ]

--- a/cfgov/hmda/tests/test_pages.py
+++ b/cfgov/hmda/tests/test_pages.py
@@ -18,7 +18,7 @@ class TestHmdaHistoricDataPage(TestCase):
 
         self.assertEqual(test_context['title'], 'Showing nationwide records')
         self.assertEqual(test_context['subtitle'],
-            'Originated mortgages for first lien, owner-occupied, 1-4 family homes')  # noqa E501
+            'Mortgages for first lien, owner-occupied, 1-4 family homes')
         years = [item[0] for item in test_context['files']]
         self.assertEqual(years, self.expected_years)
 

--- a/cfgov/hmda/tests/test_pages.py
+++ b/cfgov/hmda/tests/test_pages.py
@@ -17,7 +17,8 @@ class TestHmdaHistoricDataPage(TestCase):
         test_context = page.get_context(self.factory.get('/'))
 
         self.assertEqual(test_context['title'], 'Showing nationwide records')
-        self.assertEqual(test_context['subtitle'],
+        self.assertEqual(
+            test_context['subtitle'],
             'Mortgages for first lien, owner-occupied, 1-4 family homes')
         years = [item[0] for item in test_context['files']]
         self.assertEqual(years, self.expected_years)


### PR DESCRIPTION
We need subtitles under three of the HMDA data download fields. Instead of creating a custom form field type with a custom widget, it's easier to conditionally add the text in the template.

## Changes

- Adds subtitles to several of the HMDA data download fields.
- Fixes the institution links to point to zips instead of CSVs.
- Adds aria labels to institution files.
- Couple language corrections.

## Testing

1. Create a `Hmda historic data page` page.
1. Optionally add any content to the page.
1. Publish the page and you should see the subtitles under three of the form fields.

## Screenshots

<img width="692" alt="Screen Shot 2019-04-01 at 6 26 52 PM" src="https://user-images.githubusercontent.com/1060248/55363707-edf66700-54ab-11e9-9088-d505fc4aea88.png">

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [x] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [x] Chrome on desktop
- [x] Firefox
- [x] Safari on macOS
- [x] Edge
- [x] Internet Explorer 9, 10, and 11
- [x] Safari on iOS
- [x] Chrome on Android

### Accessibility

- [x] Keyboard friendly
- [x] Screen reader friendly

### Other

- [x] Is useable without CSS
- [x] Is useable without JS
- [x] Flexible from small to large screens
- [x] No linting errors or warnings
- [x] JavaScript tests are passing
