### PR TITLE
Bump ccdb5-ui to 1.2.0

### DIFF
--- a/requirements/optional-public.txt
+++ b/requirements/optional-public.txt
@@ -2,6 +2,6 @@ https://github.com/cfpb/college-costs/releases/download/2.4.4/college_costs-2.4.
 https://github.com/cfpb/owning-a-home-api/releases/download/0.11.3/owning_a_home_api-0.11.3-py2-none-any.whl
 https://github.com/cfpb/retirement/releases/download/0.7.6/retirement-0.7.6-py2-none-any.whl
 https://github.com/cfpb/ccdb5-api/releases/download/1.1.7/ccdb5_api-1.1.7-py2-none-any.whl
-https://github.com/cfpb/ccdb5-ui/releases/download/1.1.0/ccdb5_ui-1.1.0-py2-none-any.whl
+https://github.com/cfpb/ccdb5-ui/releases/download/1.2.0/ccdb5_ui-1.2.0-py2.py3-none-any.whl
 https://github.com/cfpb/django-college-costs-comparison/releases/download/1.9.1/comparisontool-1.9.1-py2-none-any.whl
 https://github.com/cfpb/teachers-digital-platform/releases/download/1.0.30/teachers_digital_platform-1.0.30-py2.py3-none-any.whl


### PR DESCRIPTION
This change bumps the version of the ccdb5-ui satellite app from 1.1.0 to 1.2.0.

[This release](https://github.com/cfpb/ccdb5-ui/releases/tag/1.2.0) adds support for Python 3, and fixes a minor pagination bug.

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [X] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [X] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: