### PR TITLE
Fix subcategory query to stop redirect leak

### DIFF
--- a/cfgov/ask_cfpb/models/pages.py
+++ b/cfgov/ask_cfpb/models/pages.py
@@ -282,7 +282,7 @@ class AnswerCategoryPage(RoutablePageMixin, SecondaryNavigationJSMixin,
         context = super(
             AnswerCategoryPage, self).get_context(request, *args, **kwargs)
         answers = self.ask_category.answerpage_set.filter(
-            language=self.language, redirect_to=None, live=True).values(
+            language=self.language, redirect_to_page=None, live=True).values(
                 'answer_id', 'question', 'slug', 'answer')
         if self.language == 'es':
             for a in answers:
@@ -338,7 +338,7 @@ class AnswerCategoryPage(RoutablePageMixin, SecondaryNavigationJSMixin,
             raise Http404
         context = self.get_context(request)
         answers = self.ask_subcategory.answerpage_set.filter(
-            language=self.language)
+            language=self.language, live=True, redirect_to_page=None)
         paginator = Paginator(answers, 20)
         page_number = validate_page_number(request, paginator)
         page = paginator.page(page_number)

--- a/cfgov/ask_cfpb/search_indexes.py
+++ b/cfgov/ask_cfpb/search_indexes.py
@@ -40,7 +40,5 @@ class AnswerBaseIndex(indexes.SearchIndex, indexes.Indexable):
         return AnswerPage
 
     def index_queryset(self, using=None):
-        ids = [record.id for record in self.get_model().objects.all()
-               if record.live is True
-               and record.redirect_to is None]
-        return self.get_model().objects.filter(id__in=ids)
+        return self.get_model().objects.filter(
+            live=True, redirect_to_page=None)


### PR DESCRIPTION
Our refactoring of category/subcategory handling allowed redirected pages to leak into subcategory answer listings. This stops the leak and fixes some errant usages of `redirect_to` that should be `redirect_to_page`.

## Testing

Answer 59 should not show up in the answer results on the 'fees' subcategory for credit cards.

To test, search for 'I was charged an overlimit fee last month' on these pages:

- The subcategory page on www: <https://www.consumerfinance.gov/ask-cfpb/category-credit-cards/fees-credit-cards/> (or on master locally).
- The same page locally, using the `stop-redirect-leak` branch: <http://localhost:8000/ask-cfpb/category-credit-cards/fees-credit-cards/>

