### PR TITLE
Update oah-api version to 0.12.1

### DIFF
--- a/requirements/optional-public.txt
+++ b/requirements/optional-public.txt
@@ -1,5 +1,5 @@
 https://github.com/cfpb/college-costs/releases/download/2.4.4/college_costs-2.4.4-py2-none-any.whl
-https://github.com/cfpb/owning-a-home-api/releases/download/0.11.3/owning_a_home_api-0.11.3-py2-none-any.whl
+https://github.com/cfpb/owning-a-home-api/releases/download/0.12.1/owning_a_home_api-0.12.1-py2.py3-none-any.whl
 https://github.com/cfpb/retirement/releases/download/0.7.6/retirement-0.7.6-py2-none-any.whl
 https://github.com/cfpb/ccdb5-api/releases/download/1.1.7/ccdb5_api-1.1.7-py2-none-any.whl
 https://github.com/cfpb/ccdb5-ui/releases/download/1.2.0/ccdb5_ui-1.2.0-py2.py3-none-any.whl


### PR DESCRIPTION
This includes python-3 compliance and updates countylimit data for 2019.
