### PR TITLE
Restore search-by-tag for English Ask pages

### DIFF
--- a/cfgov/ask_cfpb/models/pages.py
+++ b/cfgov/ask_cfpb/models/pages.py
@@ -421,7 +421,10 @@ class TagResultsPage(RoutablePageMixin, AnswerResultsPage):
     def tag_search(self, request, **kwargs):
         tag = kwargs.get('tag').replace('_', ' ')
         self.answers = AnswerPage.objects.filter(
-            search_tags__contains=tag, language='es', live=True)
+            language=self.language,
+            search_tags__contains=tag,
+            redirect_to_page=None,
+            live=True)
         paginator = Paginator(self.answers, 20)
         page_number = validate_page_number(request, paginator)
         page = paginator.page(page_number)

--- a/cfgov/jinja2/v1/ask-cfpb/answer-search-results.html
+++ b/cfgov/jinja2/v1/ask-cfpb/answer-search-results.html
@@ -29,7 +29,7 @@
                 u-mb15">
         <h1>Ask CFPB</h1>
 
-        {{ ask_search_bar.render( 'right', '', 'block__bg-branded u-mt30 u-mb30', q=page.query ) }}
+        {{ ask_search_bar.render( 'right', '', 'block__bg-branded u-mt30 u-mb30', q=tag or page.query ) }}
 
         {% if results %}
             {% if flag_enabled('ASK_SEARCH_TYPOS', request) %}
@@ -58,10 +58,17 @@
 
                 <div class="question_list">
                 {% for question in results %}
+                {% if tag %}
+                    <article class="question_summary question_summary__full">
+                        <p class="question_title"><a href="{{ question.url }}" class="kbq">{{ question.question|safe }}</a></p>
+                        <p class="qans">{{ question.answer | safe | striptags | truncate }}</p>
+                    </article>
+                {% else %}
                     <article class="question_summary question_summary__full">
                         <p class="question_title"><a href="{{ question[0] }}" class="kbq">{{ question[1]|safe }}</a></p>
                         <p class="qans">{{ question[2] | safe | striptags | truncate }}</p>
                     </article>
+                {% endif %}
                 {% endfor %}
 
                 </div>


### PR DESCRIPTION
Search-by-tag results are used mainly for Spanish Ask pages, but they were available for English pages to capture legacy links, some of which, it turns out, were getting heavy traffic.

The English results pages were turned off in a recent migration. This restores them.

## Testing

This English tag-results link (a popular one) blanks out on our site:

<https://www.consumerfinance.gov/ask-cfpb/search-by-tag/credit_score/>

It should now render locally: 

<http://localhost:8000/ask-cfpb/search-by-tag/credit_score/>

cc @kimson
