### PR TITLE
Remove deprecated admin URL redirects

### DIFF
--- a/cfgov/cfgov/urls.py
+++ b/cfgov/cfgov/urls.py
@@ -447,13 +447,6 @@ if settings.ALLOW_ADMIN_URL:
                                  permanent=True,
                                  query_string=True)),
 
-        url(r'^d/admin/(?P<path>.*)$',
-            RedirectView.as_view(url='/django-admin/%(path)s',
-                                 permanent=True)),
-
-        url(r'^tasks/(?P<path>.*)$',
-            RedirectView.as_view(url='/admin/cdn/%(path)s', permanent=True)),
-
         url(r'^django-admin/password_change',
             change_password,
             name='django_admin_account_change_password'),


### PR DESCRIPTION
This change removes two deprecated admin URL redirects:

/tasks/foo -> /admin/cdn/foo
/d/admin/foo -> /django-admin/foo

I believe that these redirects are obsolete; /tasks went away with Picard. I don't know of anything that (still) uses /d/admin. This looks to have been a legacy way of accessing the Django admin.

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [X] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [X] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: