### PR TITLE
Fix invalidate_all_pages AkamaiBackend import

### DIFF
--- a/cfgov/v1/management/commands/invalidate_all_pages.py
+++ b/cfgov/v1/management/commands/invalidate_all_pages.py
@@ -1,7 +1,7 @@
 from django.conf import settings
 from django.core.management.base import BaseCommand
 
-from v1.models.akamai_backend import AkamaiBackend
+from v1.models.caching import AkamaiBackend
 
 
 class Command(BaseCommand):

--- a/cfgov/v1/tests/management/commands/test_invalidate_all_pages.py
+++ b/cfgov/v1/tests/management/commands/test_invalidate_all_pages.py
@@ -1,0 +1,20 @@
+from django.core.management import call_command
+from django.test import TestCase, override_settings
+
+import mock
+
+
+@override_settings(WAGTAILFRONTENDCACHE={
+    'akamai': {
+        'BACKEND': 'v1.models.caching.AkamaiBackend',
+        'CLIENT_TOKEN': 'fake',
+        'CLIENT_SECRET': 'fake',
+        'ACCESS_TOKEN': 'fake'
+    }
+})
+class InvalidateAllPagesTestCase(TestCase):
+
+    @mock.patch('v1.models.caching.AkamaiBackend.purge_all')
+    def test_submission_with_url_akamai(self, mock_purge_all):
+        call_command('invalidate_all_pages')
+        mock_purge_all.assert_any_call()


### PR DESCRIPTION
#4905 moved the `AkamaiBackend` class and broke our `invalidate_all_pages` management command. This PR fixes that import and adds a simple test to ensure that the management command is tested.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: