### PR TITLE
Raise a 404 if an effective version doesn't exist, not a 500

### DIFF
--- a/cfgov/regulations3k/tests/test_models.py
+++ b/cfgov/regulations3k/tests/test_models.py
@@ -8,7 +8,7 @@ import unittest
 from django.contrib.auth.models import AnonymousUser, User
 from django.core.exceptions import PermissionDenied, ValidationError
 from django.core.paginator import Paginator
-from django.http import HttpRequest, QueryDict  # Http404, HttpResponse
+from django.http import Http404, HttpRequest, QueryDict
 from django.test import (
     RequestFactory, TestCase as DjangoTestCase, override_settings
 )
@@ -515,6 +515,13 @@ class RegModelTests(DjangoTestCase):
         with self.assertRaises(PermissionDenied):
             self.reg_page.get_effective_version(
                 request, '2020-01-01'
+            )
+
+    def test_get_effective_version_dne(self):
+        request = self.get_request()
+        with self.assertRaises(Http404):
+            self.reg_page.get_effective_version(
+                request, '2050-01-01'
             )
 
     def test_index_page_with_effective_date(self):

--- a/cfgov/regulations3k/tests/test_search_indexes.py
+++ b/cfgov/regulations3k/tests/test_search_indexes.py
@@ -17,7 +17,7 @@ class RegulationIndexTestCase(TestCase):
     index = RegulationParagraphIndex()
 
     def setUp(self):
-        Section.objects.first().extract_graphs()
+        Section.objects.order_by('pk').first().extract_graphs()
 
     def test_extract_paragraphs(self):
         self.assertEqual(SectionParagraph.objects.count(), 13)


### PR DESCRIPTION
Prior to this change, trying to access a version of a regulation that does not exist would cause a 500 error. This PR makes it raise a 404 instead.

Fixes CFGOV/cfgov-alerts/issues/3571

## Testing

1. Visit http://localhost:8000/policy-compliance/rulemaking/regulations/1026/2019-10-31/17/ to see a 500
2. Check out this branch.
3. Visit http://localhost:8000/policy-compliance/rulemaking/regulations/1026/2019-10-31/17/ again to see a 404

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
