### PR TITLE
Expose language value on blog pages.

### DIFF
--- a/cfgov/v1/models/learn_page.py
+++ b/cfgov/v1/models/learn_page.py
@@ -67,6 +67,7 @@ class AbstractFilterPage(CFGOVPage):
             FieldPanel('comments_close_by'),
         ], 'Relevant Dates', classname='collapsible'),
         MultiFieldPanel(Page.settings_panels, 'Scheduled Publishing'),
+        FieldPanel('language', 'Language'),
     ]
 
     # This page class cannot be created.


### PR DESCRIPTION
Blog pages' parent class, the AbstractFilterPage, hides a page's language
value. This may have been an oversight, but it's becoming an unfortunate choice
as we translate more site pages, including blogs, into other languages.

This PR just exposes the existing `language` field in the page admin,
allowing editors to set the proper language for a translated page.
This in turn will enable automatic translation of template labels and
other microcopy to match the chosen language.

Exposing `language` on the CONFIGURATION panel should have no immediate effects itself.

## Testing
Open a blog page, such as <http://localhost:8000/admin/pages/10404/edit/>, and scroll to the bottom of the page's CONFIGURATION tab. You should be able to see and change the language value.