### PR TITLE
Update Ask export script with latest updates to metadata fields

### DIFF
--- a/cfgov/ask_cfpb/scripts/export_ask_data.py
+++ b/cfgov/ask_cfpb/scripts/export_ask_data.py
@@ -8,7 +8,6 @@ from django.utils import html
 
 import unicodecsv
 
-from ask_cfpb.models.django import Answer
 from ask_cfpb.models.pages import AnswerPage
 
 
@@ -16,22 +15,18 @@ html_parser = HTMLParser.HTMLParser()
 
 HEADINGS = [
     'ASK_ID',
+    'PAGE_ID',
     'Question',
     'ShortAnswer',
     'Answer',
     'URL',
     'Live',
     'Redirect',
-    'SpanishQuestion',
-    'SpanishAnswer',
-    'SpanishURL',
-    'SpanishLive',
-    'SpanishRedirect',
-    'Topic',
-    'SubCategories',
-    'Audiences',
+    'PortalTopics',
+    'PortalCategories',
     'RelatedQuestions',
-    'RelatedResources',
+    'RelatedResource',
+    'Language'
 ]
 
 
@@ -41,76 +36,59 @@ def clean_and_strip(data):
 
 
 def assemble_output():
+
     prefetch_fields = (
-        'category__name',
-        'subcategory__name',
-        'audiences__name',
         'related_questions',
-        'next_step__title')
-    answers = list(Answer.objects.prefetch_related(*prefetch_fields).values(
-        'id', *prefetch_fields))
-
-    answer_pages = list(AnswerPage.objects.values(
-        'language', 'answer_base__id', 'url_path', 'live',
-        'redirect_to_id', 'question', 'answer', 'short_answer'
-    ))
-
+        'portal_topic__heading',
+        'portal_category__heading')
+    answer_pages = list(AnswerPage.objects.prefetch_related(
+        *prefetch_fields).order_by('language', '-answer_base__id').values(
+            'id', 'answer_base__id', 'question', 'short_answer',
+            'answer', 'url_path', 'live', 'redirect_to_id',
+            'related_resource__title', 'language', *prefetch_fields))
     output_rows = []
     seen = []
 
-    for answer in answers:
-        # There are duplicate answer_ids in here
+    for page in answer_pages:
+        # There are duplicate pages in here
         # because of the ManyToMany fields prefetched:
-        if answer['id'] in seen:
+        if page['id'] in seen:
             continue
-        seen.append(answer['id'])
+        seen.append(page['id'])
 
         output = {heading: '' for heading in HEADINGS}
-        output['ASK_ID'] = answer['id']
-        output['RelatedResources'] = answer['next_step__title']
-        output['Topic'] = answer['category__name']
-
-        for page in answer_pages:
-            if page['answer_base__id'] == answer['id']:
-                if page['language'] == 'en':
-                    output['Question'] = page['question']
-                    output['Answer'] = clean_and_strip(page['answer'])
-                    output['ShortAnswer'] = clean_and_strip(
-                        page['short_answer'])
-                    output['URL'] = page['url_path'].replace('/cfgov', '')
-                    output['Live'] = page['live']
-                    output['Redirect'] = page['redirect_to_id']
-                elif page['language'] == 'es':
-                    output['SpanishQuestion'] = page['question'].replace(
-                        '\x81', '')
-                    output['SpanishAnswer'] = clean_and_strip(
-                        page['answer']).replace('\x81', '')
-                    output['SpanishURL'] = page['url_path'].replace(
-                        '/cfgov', '')
-                    output['SpanishLive'] = page['live']
-                    output['SpanishRedirect'] = page['redirect_to_id']
+        output['ASK_ID'] = page['answer_base__id']
+        output['PAGE_ID'] = page['id']
+        output['Language'] = page['language']
+        output['RelatedResource'] = page['related_resource__title']
+        output['Question'] = page['question'].replace('\x81', '')
+        output['Answer'] = clean_and_strip(page['answer']).replace('\x81', '')
+        output['ShortAnswer'] = clean_and_strip(page['short_answer'])
+        output['URL'] = page['url_path'].replace('/cfgov', '')
+        output['Live'] = page['live']
+        output['Redirect'] = page['redirect_to_id']
 
         # Group the ManyToMany fields together:
-        audiences = []
         related_questions = []
-        subcategories = []
-        for a in answers:
-            if a['id'] == answer['id']:
-                if a['audiences__name']:
-                    audiences.append(a['audiences__name'])
-                if a['related_questions']:
-                    related_questions.append(str(a['related_questions']))
-                if a['subcategory__name']:
-                    subcategories.append(a['subcategory__name'])
+        portal_topics = []
+        portal_categories = []
+        for p in answer_pages:
+            if p['id'] == page['id']:
+                if p['related_questions']:
+                    related_questions.append(str(p['related_questions']))
+                if p['portal_topic__heading']:
+                    portal_topics.append(p['portal_topic__heading'])
+                if p['portal_category__heading']:
+                    portal_categories.append(p['portal_category__heading'])
 
         # Remove duplicates
-        audiences = list(set(audiences))
         related_questions = list(set(related_questions))
-        subcategories = list(set(subcategories))
+        portal_topics = list(set(portal_topics))
+        portal_categories = list(set(portal_categories))
 
-        output['Audiences'] = " | ".join(audiences)
         output['RelatedQuestions'] = " | ".join(related_questions)
-        output['SubCategories'] = " | ".join(subcategories)
+        output['PortalTopics'] = " | ".join(portal_topics)
+        output['PortalCategories'] = " | ".join(portal_categories)
         output_rows.append(output)
     return output_rows
 

--- a/cfgov/ask_cfpb/tests/models/test_pages.py
+++ b/cfgov/ask_cfpb/tests/models/test_pages.py
@@ -71,16 +71,13 @@ class ExportAskDataTests(TestCase, WagtailTestUtils):
     def setUp(self):
         self.mock_assemble_output_value = [{
             'ASK_ID': 123456,
+            'PAGE_ID': 56789,
             'Question': "Question",
             'ShortAnswer': "Short answer.",
             'Answer': "Long answer.",
             'URL': "fakeurl.com",
-            'SpanishQuestion': "Spanish question.",
-            'SpanishAnswer': "Spanish answer",
-            'SpanishURL': "fakespanishurl.com",
-            'Topic': "Category 5 Hurricane",
-            'SubCategories': "Subcat1 | Subcat2",
-            'Audiences': "Audience1 | Audience2",
+            'PortalTopics': "Category 5 Hurricane",
+            'PortalCategories': "Subcat1 | Subcat2",
             'RelatedQuestions': "1 | 2 | 3",
             'RelatedResources': "Owning a Home"}]
 
@@ -122,7 +119,8 @@ class ExportAskDataTests(TestCase, WagtailTestUtils):
         response = self.client.post('/admin/export-ask/')
         self.assertEqual(response.status_code, 200)
         # Check that fields from the mock value are included
-        self.assertContains(response, 'fakespanishurl.com')
+        self.assertContains(response, 'Category 5 Hurricane')
+        self.assertContains(response, '56789')
         self.assertContains(response, 'fakeurl.com')
 
     def test_export_from_admin_get(self):


### PR DESCRIPTION
## Overview

This PR brings the Ask CFPB spreadsheet export up to date with the latest code.

Currently, the export still refers to some fields on the `Answer` model that are now instead reflected on the `AnswerPage` (`related_questions` and `related_resource`) or are about to be deprecated (`category`, `subcategory` and `audiences`).  Additionally, we have added new metadata fields `portal_topic` and portal_category` onto the `AnswerPage` that should be reflected in the export.  

## Changes to the spreadsheet: 
cc @sephcoster for awareness 

- Since Spanish and English fields no longer exist side by side on the same AnswerPage, but instead each have their own page, they now are separate rows in the spreadsheet as well, as opposed to on a single row together.  I felt this looked cleaner and easier to navigate the spreadsheet, but if needed this can be updated in the future to look closer to how it used to be.  
- Related questions are now a set of AnswerPages instead of Answers, so instead of a set of Answer IDs we now display AnswerPage IDs.  We could continue to show Answer IDs but I felt like this would be more specific since it references the English or Spanish page directly. This is an easy change to make in the future if this doesn't work for CE.
- In addition to the changes to the metadata fields (noted above), I've added two columns: `PAGE_ID` for the AnswerPage IDs and `Language`.

## Screenshots
Currently the spreadsheet looks like this:
<img width="1272" alt="Screen Shot 2019-04-11 at 10 05 36 PM" src="https://user-images.githubusercontent.com/354591/56013528-f584ef80-5ca5-11e9-8a9e-d41781e48f55.png">
After this PR it will look like:
<img width="849" alt="Screen Shot 2019-04-11 at 10 20 44 PM" src="https://user-images.githubusercontent.com/354591/56013960-21a17000-5ca8-11e9-8fa1-0aa07ca4c84b.png">

