### PR TITLE
Update parse links URL exclusion rules

### DIFF
--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -791,7 +791,7 @@ else:
 
 # See core.middleware.ParseLinksMiddleware. Normally all HTML responses get
 # processed by this middleware so that their link content gets the proper
-# markup (e.g. download icons). We want to exclude certain links from this
+# markup (e.g., download icons). We want to exclude certain pages from this
 # middleware. These two lists of regular expressions define a set of URLs
 # against which we don't want this logic to be run.
 #

--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -788,20 +788,31 @@ else:
         }
     }
 
-PARSE_LINKS_BLACKLIST = [
-    '/admin/',
-    '/django-admin/',
-    '/policy-compliance/rulemaking/regulations/1002/',
-    '/policy-compliance/rulemaking/regulations/1003/',
-    '/policy-compliance/rulemaking/regulations/1004/',
-    '/policy-compliance/rulemaking/regulations/1005/',
-    '/policy-compliance/rulemaking/regulations/1010/',
-    '/policy-compliance/rulemaking/regulations/1011/',
-    '/policy-compliance/rulemaking/regulations/1012/',
-    '/policy-compliance/rulemaking/regulations/1013/',
-    '/policy-compliance/rulemaking/regulations/1024/',
-    '/policy-compliance/rulemaking/regulations/1026/',
-    '/policy-compliance/rulemaking/regulations/1030/',
+
+# See core.middleware.ParseLinksMiddleware. Normally all HTML responses get
+# processed by this middleware so that their link content gets the proper
+# markup (e.g. download icons). We want to exclude certain links from this
+# middleware. These two lists of regular expressions define a set of URLs
+# against which we don't want this logic to be run.
+#
+# If a pattern matches against both the exclusion and inclusion list, the
+# inclusion list takes priority, and the middleware will process that response.
+PARSE_LINKS_EXCLUSION_LIST = [
+    # Wagtail admin pages
+    r'^/admin/',
+    # Django admin pages
+    r'^/django-admin/',
+    # Our custom login pages
+    r'^/login/',
+    # Regulations pages that have their own link markup
+    r'^/policy-compliance/rulemaking/regulations/\d+/'
+]
+
+PARSE_LINKS_INCLUSION_LIST = [
+    # Wagtail page preview view
+    r'^/admin/pages/\d+/edit/preview/',
+    # Wagtail page draft view
+    r'^/admin/pages/\d+/view_draft/',
 ]
 
 # Required by django-extensions to determine the execution directory used by

--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -792,27 +792,17 @@ else:
 # See core.middleware.ParseLinksMiddleware. Normally all HTML responses get
 # processed by this middleware so that their link content gets the proper
 # markup (e.g., download icons). We want to exclude certain pages from this
-# middleware. These two lists of regular expressions define a set of URLs
-# against which we don't want this logic to be run.
-#
-# If a pattern matches against both the exclusion and inclusion list, the
-# inclusion list takes priority, and the middleware will process that response.
+# middleware. This list of regular expressions defines a set of URLs against
+# which we don't want this logic to be run.
 PARSE_LINKS_EXCLUSION_LIST = [
-    # Wagtail admin pages
-    r'^/admin/',
+    # Wagtail admin pages, except preview and draft views
+    r'^/admin/(?!pages/\d+/(edit/preview|view_draft)/)',
     # Django admin pages
     r'^/django-admin/',
     # Our custom login pages
     r'^/login/',
     # Regulations pages that have their own link markup
     r'^/policy-compliance/rulemaking/regulations/\d+/'
-]
-
-PARSE_LINKS_INCLUSION_LIST = [
-    # Wagtail page preview view
-    r'^/admin/pages/\d+/edit/preview/',
-    # Wagtail page draft view
-    r'^/admin/pages/\d+/view_draft/',
 ]
 
 # Required by django-extensions to determine the execution directory used by

--- a/cfgov/core/middleware.py
+++ b/cfgov/core/middleware.py
@@ -69,14 +69,7 @@ class ParseLinksMiddleware(object):
         if settings.DEFAULT_CONTENT_TYPE not in response_content_type:
             return False
 
-        if cls.any_regexes_match(
-            settings.PARSE_LINKS_EXCLUSION_LIST,
-            request_path
-        ):
-                return False
-
-        return True
-
-    @staticmethod
-    def any_regexes_match(regexes, s):
-        return any(re.search(regex, s) for regex in regexes)
+        return not any(
+            re.search(regex, request_path)
+            for regex in settings.PARSE_LINKS_EXCLUSION_LIST
+        )

--- a/cfgov/core/middleware.py
+++ b/cfgov/core/middleware.py
@@ -61,10 +61,8 @@ class ParseLinksMiddleware(object):
 
         Returns True if
 
-        1. The response has the default content type AND
-        2. The request path
-            does not match settings.PARSE_LINKS_EXCLUSION_LIST OR
-            does match settings.PARSE_LINKS_INCLUSION_LIST
+        1. The response has the default content type (HTML) AND
+        2. The request path does not match settings.PARSE_LINKS_EXCLUSION_LIST
 
         Otherwise returns False.
         """
@@ -75,10 +73,6 @@ class ParseLinksMiddleware(object):
             settings.PARSE_LINKS_EXCLUSION_LIST,
             request_path
         ):
-            if not cls.any_regexes_match(
-                settings.PARSE_LINKS_INCLUSION_LIST,
-                request_path
-            ):
                 return False
 
         return True

--- a/cfgov/core/middleware.py
+++ b/cfgov/core/middleware.py
@@ -1,3 +1,4 @@
+import re
 from six import text_type as str
 
 from django.conf import settings
@@ -15,20 +16,6 @@ class DownstreamCacheControlMiddleware(object):
         if 'CSRF_COOKIE_USED' in request.META:
             response['Edge-Control'] = 'no-store'
         return response
-
-
-def should_parse_links(request_path, content_type):
-    """ Do not parse links for paths in the blacklist,
-    or for content that is not html
-    """
-    for path in settings.PARSE_LINKS_BLACKLIST:
-        if request_path.startswith(path):
-            return False
-
-    if settings.DEFAULT_CONTENT_TYPE not in content_type:
-        return False
-
-    return True
 
 
 def parse_links(html, encoding=None):
@@ -61,9 +48,41 @@ def parse_links(html, encoding=None):
 
 class ParseLinksMiddleware(object):
     def process_response(self, request, response):
-        if should_parse_links(request.path, response['content-type']):
+        if self.should_parse_links(request.path, response['content-type']):
             response.content = parse_links(
                 response.content,
                 encoding=response.charset
             )
         return response
+
+    @classmethod
+    def should_parse_links(cls, request_path, response_content_type):
+        """Determine if links should be parsed for a given request/response.
+
+        Returns True if
+
+        1. The response has the default content type AND
+        2. The request path
+            does not match settings.PARSE_LINKS_EXCLUSION_LIST OR
+            does match settings.PARSE_LINKS_INCLUSION_LIST
+
+        Otherwise returns False.
+        """
+        if settings.DEFAULT_CONTENT_TYPE not in response_content_type:
+            return False
+
+        if cls.any_regexes_match(
+            settings.PARSE_LINKS_EXCLUSION_LIST,
+            request_path
+        ):
+            if not cls.any_regexes_match(
+                settings.PARSE_LINKS_INCLUSION_LIST,
+                request_path
+            ):
+                return False
+
+        return True
+
+    @staticmethod
+    def any_regexes_match(regexes, s):
+        return any(re.search(regex, s) for regex in regexes)


### PR DESCRIPTION
We use a custom middleware (`core.middleware.ParseLinksMiddleware`) to, among other things, decorate external links with icons.

Currently this behavior is suppressed on any URLs that start with /admin/, which prevents link decoration from working on Wagtail page previews or draft links.

This change updates the middleware logic to use regular expressions as filters instead of URL prefixes. ~~It adds an inclusion list that takes priority over the exclusion list, allowing us to apply the middleware to child pages of /admin/.~~ Edit: I removed this based on feedback below.

To test, visit http://localhost:8000/login/welcome/ when logged in, and notice that link parsing (properly) does not occur. Try previewing a draft page that has an external link, and notice that link parsing (properly) does occur.

## Testing

With a recent production dump, you can use http://localhost:8000/admin/pages/187/edit/ as an example page to test. Visit that page and hit Preview to observe properly marked-up links. You can also visit http://localhost:8000/admin/pages/187/view_draft/ to see the same thing.

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [X] Passes all existing automated tests
- [X] Any _change_ in functionality is tested
- [X] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [X] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: