### PR TITLE
Remove deprecated address package

### DIFF
--- a/requirements/libraries.txt
+++ b/requirements/libraries.txt
@@ -1,4 +1,3 @@
-address==0.1.1
 beautifulsoup4==4.6.0
 boto3==1.7.80
 dj-database-url==0.5.0


### PR DESCRIPTION
This commit removes inclusion of the third-party [address](https://pypi.org/project/address/) Python package. In the past we required this [as part of our django-hud satellite app](https://github.com/cfpb/django-hud/blob/cd5bce3c22c122251ee171af10d6910731969f63/setup.py#L22), but we no longer do.

Additionally, this package [appears to be Python 2 only](https://github.com/SwoopSearch/pyaddress/blob/master/setup.py#L18).

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [X] Passes all existing automated tests
- [X] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [X] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: