### PR TITLE
Update jinja2 to 2.10.1

### DIFF
--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -1,7 +1,7 @@
 backports-abc==0.5
 Click==7.0
 futures==3.1.1
-Jinja2==2.10
+Jinja2==2.10.1
 livereload==2.6.0
 Markdown==2.6.11
 MarkupSafe==1.1.0

--- a/requirements/libraries.txt
+++ b/requirements/libraries.txt
@@ -17,7 +17,7 @@ django-watchman==0.15.0
 edgegrid-python==1.0.10
 elasticsearch==2.4.1
 govdelivery==1.2
-Jinja2==2.10
+Jinja2==2.10.1
 jsonfield==2.0.2
 lxml==4.2.5
 Markdown==2.6.11


### PR DESCRIPTION
GitHub makes two security alerts for Jinja2 https://github.com/cfpb/cfgov-refresh/network/alerts
This patch version fixes those alerts https://github.com/pallets/jinja/blob/master/CHANGES.rst#version-2101 

## Changes

- Updates `Jinja2` to `2.10.1` from `2.10`.

## Testing

1. Run `./backend.sh`
2. Run `./runserver` and check that site pages load.
