### PR TITLE
Allow X-Forwarded-Port

### DIFF
--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -25,11 +25,7 @@ DEPLOY_ENVIRONMENT = os.getenv('DEPLOY_ENVIRONMENT')
 # effects how request.is_secure() responds
 SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
 USE_X_FORWARDED_HOST = True
-
-# in some environments, we want to respect X-Forwarded-Port
-
-if 'USE_X_FORWARDED_PORT' in os.environ:
-    USE_X_FORWARDED_PORT = True
+USE_X_FORWARDED_PORT = True
 
 # Use the django default password hashing
 PASSWORD_HASHERS = global_settings.PASSWORD_HASHERS

--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -25,7 +25,11 @@ DEPLOY_ENVIRONMENT = os.getenv('DEPLOY_ENVIRONMENT')
 # effects how request.is_secure() responds
 SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
 USE_X_FORWARDED_HOST = True
-USE_X_FORWARDED_PORT = True
+
+# in some environments, we want to respect X-Forwarded-Port
+
+if 'USE_X_FORWARDED_PORT' in os.environ:
+    USE_X_FORWARDED_PORT = True
 
 # Use the django default password hashing
 PASSWORD_HASHERS = global_settings.PASSWORD_HASHERS

--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -28,8 +28,7 @@ USE_X_FORWARDED_HOST = True
 
 # in some environments, we want to respect X-Forwarded-Port
 
-if 'USE_X_FORWARDED_PORT' in os.environ:
-    USE_X_FORWARDED_PORT = True
+USE_X_FORWARDED_PORT = os.environ.get('USE_X_FORWARDED_PORT') == 'True'
 
 # Use the django default password hashing
 PASSWORD_HASHERS = global_settings.PASSWORD_HASHERS

--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -27,7 +27,6 @@ SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
 USE_X_FORWARDED_HOST = True
 
 # in some environments, we want to respect X-Forwarded-Port
-
 USE_X_FORWARDED_PORT = os.environ.get('USE_X_FORWARDED_PORT') == 'True'
 
 # Use the django default password hashing

--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -26,6 +26,11 @@ DEPLOY_ENVIRONMENT = os.getenv('DEPLOY_ENVIRONMENT')
 SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
 USE_X_FORWARDED_HOST = True
 
+# in some environments, we want to respect X-Forwarded-Port
+
+if 'USE_X_FORWARDED_PORT' in os.environ:
+    USE_X_FORWARDED_PORT = True
+
 # Use the django default password hashing
 PASSWORD_HASHERS = global_settings.PASSWORD_HASHERS
 


### PR DESCRIPTION
This is to allow wagtail-sharing to recognize when requests are coming in on the sharing domain, originating on port 443. See discussion on internal PR SoftwareDevelopment/dynamic_proxy/pull/131 for background.


## Additions

- `USE_X_FORWARDED_PORT = True` in settings.base


## Testing

1.

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [ ] Chrome on desktop
- [ ] Firefox
- [ ] Safari on macOS
- [ ] Edge
- [ ] Internet Explorer 9, 10, and 11
- [ ] Safari on iOS
- [ ] Chrome on Android

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
