### PR TITLE
Remove unused feature flag

### DIFF
--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -703,9 +703,7 @@ FLAGS = {
     # Test financial well-being hub pages on Beta
     'FINANCIAL_WELLBEING_HUB': [('environment is', 'beta')],
 
-    # Test migrated HMDA content pages. Delete after HMDA content launch
-    'HMDA_LEGACY_REVIEW': [],
-    # Publish new HMDA content pages
+    # Publish new HMDA Explore page
     # Delete after HMDA API is deprecated (hopefully Summer 2019)
     'HMDA_LEGACY_PUBLISH': [],
 

--- a/cfgov/cfgov/urls.py
+++ b/cfgov/cfgov/urls.py
@@ -413,13 +413,6 @@ urlpatterns = [
 
     # Temporary: HMDA Legacy pages
     # Will be deleted when HMDA API is retired (hopefully Summer 2019)
-    url(r'data-research/hmda-new/explore$',
-        FlaggedTemplateView.as_view(
-            flag_name='HMDA_LEGACY_REVIEW',
-            template_name='hmda/orange-explorer.html'
-        ),
-        name='legacy_explorer_draft'
-    ),
     url(r'data-research/hmda/explore$',
         FlaggedTemplateView.as_view(
             flag_name='HMDA_LEGACY_PUBLISH',

--- a/cfgov/hmda/tests/test_legacy_pages.py
+++ b/cfgov/hmda/tests/test_legacy_pages.py
@@ -7,34 +7,15 @@ from django.test import TestCase, override_settings
 class LegacyHmdaPagesTest(TestCase):
 
     @override_settings(FLAGS={
-        'HMDA_LEGACY_REVIEW': [('boolean', True)],
-        'HMDA_LEGACY_PUBLISH': [('boolean', False)],
-    })
-    def test_legacy_explorer_review_phase(self):
-        response = self.client.get(reverse('legacy_explorer_draft'))
-        self.assertEqual(response.status_code, 200)
-
-        response2 = self.client.get(reverse('legacy_explorer_published'))
-        self.assertEqual(response2.status_code, 404)
-
-    @override_settings(FLAGS={
-        'HMDA_LEGACY_REVIEW': [('boolean', False)],
         'HMDA_LEGACY_PUBLISH': [('boolean', True)],
     })
     def test_legacy_explorer_after_publication(self):
         response = self.client.get(reverse('legacy_explorer_published'))
         self.assertEqual(response.status_code, 200)
 
-        response2 = self.client.get(reverse('legacy_explorer_draft'))
-        self.assertEqual(response2.status_code, 404)
-
     @override_settings(FLAGS={
-        'HMDA_LEGACY_REVIEW': [('boolean', False)],
         'HMDA_LEGACY_PUBLISH': [('boolean', False)],
     })
     def test_legacy_explorer_disabled(self):
         response = self.client.get(reverse('legacy_explorer_published'))
         self.assertEqual(response.status_code, 404)
-
-        response2 = self.client.get(reverse('legacy_explorer_draft'))
-        self.assertEqual(response2.status_code, 404)


### PR DESCRIPTION
We needed the  `HMDA_LEGACY_REVIEW` feature flag while preparing to launch new pages at `/hmda` and `/hmda/explore`. Now that the pages are launched, we no longer need to provide the content for review at an alternate URL, so the flag is not necessary.

## Removals

- The `HMDA_LEGACY_REVIEW` feature flag and all code that interacted with it.

## Testing

1. Running this branch, visit `/data-research/hmda/explore`.
    - It should 404 when the `HMDA_LEGACY_PUBLISH` flag is disabled.
    - It should show the orange Explore page when the flag is enabled.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
