### PR TITLE
Fix document cache invalidation

### DIFF
--- a/cfgov/v1/models/caching.py
+++ b/cfgov/v1/models/caching.py
@@ -103,7 +103,7 @@ def cloudfront_cache_invalidation(sender, instance, **kwargs):
 
     url = instance.file.url
 
-    logger.info("Invalidating cache for " + url)
+    logger.info('Purging {} from "files" cache'.format(url))
 
     batch = PurgeBatch()
     batch.add_url(url)

--- a/cfgov/v1/models/caching.py
+++ b/cfgov/v1/models/caching.py
@@ -1,7 +1,6 @@
 import json
 import logging
 import os
-from six.moves.urllib.parse import urljoin
 
 from django.conf import settings
 from django.contrib.auth.models import User
@@ -102,11 +101,7 @@ def cloudfront_cache_invalidation(sender, instance, **kwargs):
     if not instance.file:
         return
 
-    media_base = settings.MEDIA_URL
-    if hasattr(settings, 'AWS_S3_CUSTOM_DOMAIN'):
-        media_base = settings.AWS_S3_CUSTOM_DOMAIN
-
-    url = urljoin(media_base, instance.url)
+    url = instance.file.url
 
     logger.info("Invalidating cache for " + url)
 

--- a/cfgov/v1/tests/models/test_caching.py
+++ b/cfgov/v1/tests/models/test_caching.py
@@ -4,6 +4,9 @@ from django.test import TestCase, override_settings
 from wagtail.wagtaildocs.models import Document
 from wagtail.wagtailimages.tests.utils import get_test_image_file
 
+import boto3
+import moto
+
 from core.testutils.mock_cache_backend import CACHE_PURGED_URLS
 from v1.models.caching import AkamaiBackend, cloudfront_cache_invalidation
 from v1.models.images import CFGOVImage
@@ -41,17 +44,29 @@ class TestAkamaiBackend(TestCase):
 
 
 @override_settings(
-    ENABLE_CLOUDFRONT_CACHE_PURGE=True,
     WAGTAILFRONTENDCACHE={
         'files': {
             'BACKEND': 'core.testutils.mock_cache_backend.MockCacheBackend',
         },
-    }
+    },
+    AWS_LOCATION='root',
+    AWS_S3_CUSTOM_DOMAIN='test_s3_bucket_url',
+    AWS_S3_ACCESS_KEY_ID='test',
+    AWS_S3_SECRET_ACCESS_KEY='test',
+    AWS_STORAGE_BUCKET_NAME='test_s3_bucket',
+    DEFAULT_FILE_STORAGE='storages.backends.s3boto3.S3Boto3Storage'
 )
 class CloudfrontInvalidationTest(TestCase):
 
     def setUp(self):
+        self.mock_s3 = moto.mock_s3()
+        self.mock_s3.start()
+
+        s3 = boto3.client('s3')
+        s3.create_bucket(Bucket='test_s3_bucket')
+
         self.document = Document(title="Test document")
+        self.document_without_file = Document(title="Document without file")
         self.document.file.save(
             'example.txt',
             ContentFile("A boring example document")
@@ -60,29 +75,36 @@ class CloudfrontInvalidationTest(TestCase):
             title='test',
             file=get_test_image_file()
         )
+        self.rendition = self.image.get_rendition('original')
 
         CACHE_PURGED_URLS[:] = []
 
     def tearDown(self):
         self.document.file.delete()
-        pass
 
-    @override_settings(AWS_S3_CUSTOM_DOMAIN='https://foo/')
-    def test_rendition_saved_cache_invalidation_with_custom_domain(self):
-        rendition = self.image.get_rendition('original')
-        cloudfront_cache_invalidation(None, rendition)
-        self.assertIn('https://foo' + rendition.url, CACHE_PURGED_URLS)
+        self.mock_s3.stop()
 
-    def test_rendition_saved_cache_invalidation_without_custom_domain(self):
-        rendition = self.image.get_rendition('original')
-        cloudfront_cache_invalidation(None, rendition)
-        self.assertIn(rendition.url, CACHE_PURGED_URLS)
+    def test_rendition_saved_cache_purge_disabled(self):
+        cloudfront_cache_invalidation(None, self.rendition)
+        self.assertEqual(CACHE_PURGED_URLS, [])
 
-    @override_settings(AWS_S3_CUSTOM_DOMAIN='https://foo/')
-    def test_document_saved_cache_invalidation_with_custom_domain(self):
+    def test_document_saved_cache_purge_disabled(self):
         cloudfront_cache_invalidation(None, self.document)
-        self.assertIn('https://foo' + self.document.url, CACHE_PURGED_URLS)
+        self.assertEqual(CACHE_PURGED_URLS, [])
 
-    def test_document_saved_cache_invalidation_without_custom_domain(self):
+    @override_settings(ENABLE_CLOUDFRONT_CACHE_PURGE=True)
+    def test_document_saved_cache_purge_without_file(self):
+        cloudfront_cache_invalidation(None, self.document_without_file)
+        self.assertEqual(CACHE_PURGED_URLS, [])
+
+    @override_settings(ENABLE_CLOUDFRONT_CACHE_PURGE=True)
+    def test_rendition_saved_cache_invalidation(self):
+        cloudfront_cache_invalidation(None, self.rendition)
+        self.assertIn(self.rendition.file.url, CACHE_PURGED_URLS)
+        self.assertIn('https://test_s3_bucket_url/root', CACHE_PURGED_URLS[0])
+
+    @override_settings(ENABLE_CLOUDFRONT_CACHE_PURGE=True)
+    def test_document_saved_cache_invalidation(self):
         cloudfront_cache_invalidation(None, self.document)
-        self.assertIn(self.document.url, CACHE_PURGED_URLS)
+        self.assertIn(self.document.file.url, CACHE_PURGED_URLS)
+        self.assertIn('https://test_s3_bucket_url/root', CACHE_PURGED_URLS[0])

--- a/cfgov/v1/tests/models/test_caching.py
+++ b/cfgov/v1/tests/models/test_caching.py
@@ -49,22 +49,10 @@ class TestAkamaiBackend(TestCase):
             'BACKEND': 'core.testutils.mock_cache_backend.MockCacheBackend',
         },
     },
-    AWS_LOCATION='root',
-    AWS_S3_CUSTOM_DOMAIN='test_s3_bucket_url',
-    AWS_S3_ACCESS_KEY_ID='test',
-    AWS_S3_SECRET_ACCESS_KEY='test',
-    AWS_STORAGE_BUCKET_NAME='test_s3_bucket',
-    DEFAULT_FILE_STORAGE='storages.backends.s3boto3.S3Boto3Storage'
 )
 class CloudfrontInvalidationTest(TestCase):
 
     def setUp(self):
-        self.mock_s3 = moto.mock_s3()
-        self.mock_s3.start()
-
-        s3 = boto3.client('s3')
-        s3.create_bucket(Bucket='test_s3_bucket')
-
         self.document = Document(title="Test document")
         self.document_without_file = Document(title="Document without file")
         self.document.file.save(
@@ -81,8 +69,6 @@ class CloudfrontInvalidationTest(TestCase):
 
     def tearDown(self):
         self.document.file.delete()
-
-        self.mock_s3.stop()
 
     def test_rendition_saved_cache_purge_disabled(self):
         cloudfront_cache_invalidation(None, self.rendition)
@@ -101,10 +87,8 @@ class CloudfrontInvalidationTest(TestCase):
     def test_rendition_saved_cache_invalidation(self):
         cloudfront_cache_invalidation(None, self.rendition)
         self.assertIn(self.rendition.file.url, CACHE_PURGED_URLS)
-        self.assertIn('https://test_s3_bucket_url/root', CACHE_PURGED_URLS[0])
 
     @override_settings(ENABLE_CLOUDFRONT_CACHE_PURGE=True)
     def test_document_saved_cache_invalidation(self):
         cloudfront_cache_invalidation(None, self.document)
         self.assertIn(self.document.file.url, CACHE_PURGED_URLS)
-        self.assertIn('https://test_s3_bucket_url/root', CACHE_PURGED_URLS[0])


### PR DESCRIPTION
Automatic document cache invalidation based on our `post_save` signal receiver was not invalidating the correct URL. This PR changes it to invalidate the `document.file.url` instead of `document.url` (which was the Wagtail-served URL instead of the Django-Storages URL). The tests are updated to try to simulate production conditions as best as possible.

## Testing

I don't know that there is a good way to test this, since we don't have an S3 bucket dedicated to testing and we certainly don't have a Cloudfront distribution for testing. To properly test that the correct Cloudfront URLs are invalidated, we almost need to use the env vars from production, but that's inadvisable. 

Hopefully the tests populated with those env vars prove that this should work.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: