### PR TITLE
Remove blog posts from the Newsroom page

### DIFF
--- a/cfgov/v1/models/browse_filterable_page.py
+++ b/cfgov/v1/models/browse_filterable_page.py
@@ -88,7 +88,7 @@ class EventArchivePage(BrowseFilterablePage):
 
 class NewsroomLandingPage(BrowseFilterablePage):
     template = 'newsroom/index.html'
-    filterable_categories = ('Blog', 'Newsroom')
+    filterable_categories = ['Newsroom']
     filterable_children_only = False
 
     objects = PageManager()

--- a/cfgov/v1/tests/models/test_browse_filterable_page.py
+++ b/cfgov/v1/tests/models/test_browse_filterable_page.py
@@ -29,12 +29,8 @@ class TestNewsroomLandingPage(TestCase):
         self.assertEqual(
             get_category_children(NewsroomLandingPage.filterable_categories),
             [
-                'at-the-cfpb',
-                'data-research-reports',
                 'directors-notebook',
-                'info-for-consumers',
                 'op-ed',
-                'policy_compliance',
                 'press-release',
                 'speech',
                 'testimony',

--- a/cfgov/v1/util/ref.py
+++ b/cfgov/v1/util/ref.py
@@ -217,7 +217,6 @@ def page_type_choices():
             ('raj-date', 'Raj Date'),
             ('elizabeth-warren', 'Elizabeth Warren'))),
         ('Newsroom', (
-            ('blog', 'Blog'),
             ('op-ed', 'Op-ed'),
             ('press-release', 'Press release'),
             ('directors-notebook', "Director's notebook"),


### PR DESCRIPTION
Remove blog posts from the Newsroom page, by request from Comms.

## Removals

- Remove blog posts from the list of posts included in the Newsroom
- Remove the "Blog" category from the Newsroom Filterable List control

## Testing

1. Running this branch, visit http://localhost:8000/about-us/newsroom/
    - There should be no posts labeled "blog" in the results

## Screenshots

"Blog" was removed from the category list:

![Screen Shot 2019-04-25 at 3 38 02 PM](https://user-images.githubusercontent.com/4295388/56763608-d6d82b80-6770-11e9-978b-7c4d46963e5e.png)


## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: