### PR TITLE
Move request.path handling from base template to template tags

### DIFF
--- a/cfgov/jinja2/v1/_layouts/base.html
+++ b/cfgov/jinja2/v1/_layouts/base.html
@@ -120,7 +120,7 @@
       {% endmacro %}
       {% set js_source = page_js() | trim %}
       {% if js_source | length > 0 %}
-        s.push( '{{ static('js/routes/' + page_url(request) + 'index.js') }}' );
+        s.push( '{{ static('js/routes/' + app_page_url(request) + 'index.js') }}' );
       {% endif %}
       {% if flag_enabled('TURBOLINKS', request) %}
         s.push( '{{ static('js/routes/on-demand/turbolinks.js') }}' );

--- a/cfgov/jinja2/v1/_layouts/base.html
+++ b/cfgov/jinja2/v1/_layouts/base.html
@@ -92,11 +92,11 @@
         and JavaScript appears in unprocessed/js/routes/[app-url]/single.js.
       #}
       {% macro template_js() %}
-         {% include 'js/routes/' + request.path.split('/')[1] + '/single.js' ignore missing %}
+         {% include 'js/routes/' + app_url(request) + '/single.js' ignore missing %}
       {% endmacro %}
       {% set js_source = template_js() | trim %}
       {% if js_source | length > 0 %}
-        s.push( '{{ static('js/routes/' + request.path.split('/')[1] + '/single.js') }}' );
+        s.push( '{{ static('js/routes/' + app_url(request) + '/single.js') }}' );
       {% endif %}
       {#
         Check and include component-level JavaScript.
@@ -116,11 +116,11 @@
         and JavaScript appears in unprocessed/js/routes/[app-url]/index.js.
       #}
       {% macro page_js() %}
-         {% include 'js/routes/' + request.path[1:] + 'index.js' ignore missing %}
+         {% include 'js/routes/' + app_page_url(request) + 'index.js' ignore missing %}
       {% endmacro %}
       {% set js_source = page_js() | trim %}
       {% if js_source | length > 0 %}
-        s.push( '{{ static('js/routes/' + request.path[1:] + 'index.js') }}' );
+        s.push( '{{ static('js/routes/' + page_url(request) + 'index.js') }}' );
       {% endif %}
       {% if flag_enabled('TURBOLINKS', request) %}
         s.push( '{{ static('js/routes/on-demand/turbolinks.js') }}' );

--- a/cfgov/v1/jinja2tags/__init__.py
+++ b/cfgov/v1/jinja2tags/__init__.py
@@ -9,6 +9,7 @@ from hmda.templatetags.hmda_banners import hmda_outage_banner
 from v1.jinja2tags.datetimes import DatetimesExtension
 from v1.jinja2tags.fragment_cache import FragmentCacheExtension
 from v1.models import CFGOVRendition
+from v1.templatetags.app_urls import app_page_url, app_url
 from v1.templatetags.complaint_banners import (
     complaint_issue_banner, complaint_maintenance_banner
 )
@@ -108,6 +109,8 @@ class V1Extension(Extension):
             'is_report': ref.is_report,
             'is_filter_selected': contextfunction(is_filter_selected),
             'render_stream_child': contextfunction(render_stream_child),
+            'app_url': app_url,
+            'app_page_url': app_page_url,
         })
 
 

--- a/cfgov/v1/templatetags/app_urls.py
+++ b/cfgov/v1/templatetags/app_urls.py
@@ -1,0 +1,14 @@
+from django import template
+
+
+register = template.Library()
+
+
+@register.simple_tag
+def app_url(request):
+    return request.path.split('/')[1].encode('ascii', 'ignore')
+
+
+@register.simple_tag
+def app_page_url(request):
+    return request.path[1:].encode('ascii', 'ignore')

--- a/cfgov/v1/templatetags/app_urls.py
+++ b/cfgov/v1/templatetags/app_urls.py
@@ -1,3 +1,5 @@
+import six
+
 from django import template
 
 
@@ -6,9 +8,15 @@ register = template.Library()
 
 @register.simple_tag
 def app_url(request):
-    return request.path.split('/')[1].encode('ascii', 'ignore')
+    if six.PY2:  # pragma: no cover
+        return request.path.split('/')[1].encode('ascii', 'ignore')
+
+    return request.path.split('/')[1]
 
 
 @register.simple_tag
 def app_page_url(request):
-    return request.path[1:].encode('ascii', 'ignore')
+    if six.PY2:  # pragma: no cover
+        return request.path[1:].encode('ascii', 'ignore')
+
+    return request.path[1:]

--- a/cfgov/v1/tests/templatetags/test_app_urls.py
+++ b/cfgov/v1/tests/templatetags/test_app_urls.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+from django.template import Context, Template
+from django.test import RequestFactory, TestCase
+
+
+class TestAppUrlTags(TestCase):
+    def setUp(self):
+        self.factory = RequestFactory()
+
+    def test_app_url(self):
+        template = Template('{% load app_urls %}{% app_url request %}')
+        request = RequestFactory().get('/app/path')
+        response = template.render(Context({'request': request}))
+        self.assertEqual(response, 'app')
+
+    def test_app_url_unicode(self):
+        template = Template('{% load app_urls %}{% app_url request %}')
+        request = RequestFactory().get('/äpp/path')
+        response = template.render(Context({'request': request}))
+        self.assertEqual(response, 'pp')
+
+    def test_app_page_url(self):
+        template = Template('{% load app_urls %}{% app_page_url request %}')
+        request = RequestFactory().get('/app/with/page/path')
+        response = template.render(Context({'request': request}))
+        self.assertEqual(response, 'app/with/page/path')
+
+    def test_app_page_url_unicode(self):
+        template = Template('{% load app_urls %}{% app_page_url request %}')
+        request = RequestFactory().get('/ápp/with/päge/path')
+        response = template.render(Context({'request': request}))
+        self.assertEqual(response, 'pp/with/pge/path')

--- a/cfgov/v1/tests/templatetags/test_app_urls.py
+++ b/cfgov/v1/tests/templatetags/test_app_urls.py
@@ -1,4 +1,7 @@
 # -*- coding: utf-8 -*-
+import six
+from unittest import skipIf
+
 from django.template import Context, Template
 from django.test import RequestFactory, TestCase
 
@@ -13,6 +16,7 @@ class TestAppUrlTags(TestCase):
         response = template.render(Context({'request': request}))
         self.assertEqual(response, 'app')
 
+    @skipIf(six.PY3, "Unicode workaround is unnecessary")
     def test_app_url_unicode(self):
         template = Template('{% load app_urls %}{% app_url request %}')
         request = RequestFactory().get('/äpp/path')
@@ -25,6 +29,7 @@ class TestAppUrlTags(TestCase):
         response = template.render(Context({'request': request}))
         self.assertEqual(response, 'app/with/page/path')
 
+    @skipIf(six.PY3, "Unicode workaround is unnecessary")
     def test_app_page_url_unicode(self):
         template = Template('{% load app_urls %}{% app_page_url request %}')
         request = RequestFactory().get('/ápp/with/päge/path')


### PR DESCRIPTION
This PR moves `request.path` splitting from inside the base template to template tags. It also forces ascii-encoding on the result of the splitting to avoid issues where paths have non-ascii characters and subsequent template lookups based on those paths cause encoding errors resulting in a 500 for end-users. See discussion in the cfgov-alerts channel.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
