### PR TITLE
Make seach terms safe by disallowing unsafe characters.

### DIFF
--- a/cfgov/ask_cfpb/models/search.py
+++ b/cfgov/ask_cfpb/models/search.py
@@ -1,14 +1,25 @@
-from haystack.inputs import Clean
 from haystack.query import SearchQuerySet
 
 from flags.state import flag_enabled
+
+
+UNSAFE_CHARACTERS = [
+    '#', '%', ';', '^', '~', '`', '|',
+    '<', '>', '[', ']', '{', '}', '\\'
+]
+
+
+def make_safe(term):
+    for char in UNSAFE_CHARACTERS:
+        term = term.replace(char, '')
+    return term
 
 
 class AskSearch:
     def __init__(self, search_term, query_base=None, language='en'):
         self.query_base = query_base or SearchQuerySet().filter(
             language=language)
-        self.search_term = Clean(search_term).query_string.strip()
+        self.search_term = make_safe(search_term).strip()
         self.queryset = self.query_base.filter(content=self.search_term)
         self.suggestion = None
 

--- a/cfgov/ask_cfpb/tests/test_views.py
+++ b/cfgov/ask_cfpb/tests/test_views.py
@@ -30,7 +30,7 @@ now = timezone.now()
 class AskSearchSafetyCase(unittest.TestCase):
 
     def test_make_safe(self):
-        test_phrase = 'Would you like green eggs and ^~`[]#<>;|\\{\\}\\?'
+        test_phrase = 'Would you like green eggs and ^~`[]#<>;|%\\{\\}\\?'
         self.assertEqual(
             make_safe(test_phrase),
             'Would you like green eggs and ?'

--- a/cfgov/ask_cfpb/tests/test_views.py
+++ b/cfgov/ask_cfpb/tests/test_views.py
@@ -1,6 +1,7 @@
 from __future__ import unicode_literals
 
 import json
+import unittest
 
 from django.apps import apps
 from django.core.urlresolvers import NoReverseMatch, reverse
@@ -17,12 +18,23 @@ from model_mommy import mommy
 from ask_cfpb.models import (
     ENGLISH_PARENT_SLUG, SPANISH_PARENT_SLUG, AnswerPage
 )
+from ask_cfpb.models.search import make_safe
 from ask_cfpb.tests.models.test_pages import mock_queryset
 from ask_cfpb.views import annotate_links, ask_search, redirect_ask_search
 from v1.util.migrations import get_or_create_page
 
 
 now = timezone.now()
+
+
+class AskSearchSafetyCase(unittest.TestCase):
+
+    def test_make_safe(self):
+        test_phrase = 'Would you like green eggs and ^~`[]#<>;|\\{\\}\\?'
+        self.assertEqual(
+            make_safe(test_phrase),
+            'Would you like green eggs and ?'
+        )
 
 
 class AnswerPagePreviewCase(TestCase):


### PR DESCRIPTION
Adding a list of unsafe characters and a function to remove them from queries.

This satisfies internal issue #50.

## Note
I removed the "Clean" import and usage from search.py, because Clean is [included by default](https://django-haystack.readthedocs.io/en/master/inputtypes.html#clean) when passing a string to SearchQuerySet.