### PR TITLE
Validate regulation part numbers in GET request params

### DIFF
--- a/cfgov/regulations3k/models/pages.py
+++ b/cfgov/regulations3k/models/pages.py
@@ -66,10 +66,8 @@ class RegulationsSearchPage(RoutablePageMixin, CFGOVPage):
     @route(r'^results/')
     def regulation_results_page(self, request):
         all_regs = Part.objects.order_by('part_number')
-        regs = []
+        regs = validate_regs_list(request)
         order = request.GET.get('order', 'relevance')
-        if 'regs' in request.GET and request.GET.get('regs'):
-            regs = request.GET.getlist('regs')
         search_query = request.GET.get('q', '').strip()
         payload = {
             'search_query': search_query,
@@ -592,3 +590,16 @@ def validate_page_number(request, paginator):
     except InvalidPage:
         page_number = 1
     return page_number
+
+
+def validate_regs_list(request):
+    """
+    A utility for validating a RegulationsSearchPage request.
+
+    Validates that a list of regulation part numbers is alphanumeric.
+    """
+    if 'regs' in request.GET and request.GET.get('regs'):
+        regs_input_list = request.GET.getlist('regs')
+        return [reg for reg in regs_input_list if reg.isalnum()]
+    else:
+        return []

--- a/cfgov/regulations3k/tests/test_models.py
+++ b/cfgov/regulations3k/tests/test_models.py
@@ -26,7 +26,8 @@ from regulations3k.models.django import (
 from regulations3k.models.pages import (
     RegulationLandingPage, RegulationPage, RegulationsSearchPage,
     get_next_section, get_previous_section, get_secondary_nav_items,
-    get_section_url, validate_num_results, validate_page_number
+    get_section_url, validate_num_results, validate_page_number,
+    validate_regs_list
 )
 
 
@@ -711,3 +712,16 @@ class SectionNavTests(unittest.TestCase):
         request = HttpRequest()
         request.GET.update({'results': '10'})
         self.assertEqual(validate_num_results(request), 25)
+
+    def test_validate_regs_input_list(self):
+        request = HttpRequest()
+        request.GET.update(QueryDict('regs=one&regs=2&regs=three33'))
+        self.assertEqual(validate_regs_list(request), ['one', '2', 'three33'])
+        request2 = HttpRequest()
+        request2.GET.update(QueryDict('regs=1@#$5567'))
+        self.assertEqual(validate_regs_list(request2), [])
+        request3 = HttpRequest()
+        request3.GET.update(QueryDict('regs=one&regs=734^*^&regs=2'))
+        self.assertEqual(validate_regs_list(request3), ['one', '2'])
+        request4 = HttpRequest()
+        self.assertEqual(validate_regs_list(request4), [])


### PR DESCRIPTION
This resolves a potential vulnerability found by Checkmarx.

## Changes

- Sanitize the list of regulation IDs before processing the search request

## Testing

1. Running this branch, visit http://localhost:8000/policy-compliance/rulemaking/regulations/search-regulations/results/?regs=1003
2. Enter a search term and press "search". Check different check boxes under "Regulation" and search again. The search should work as normal. (If you don't have elasticsearch running, "as normal" will still mean "no results". That's okay)
3. Try manually updating the `?regs=<regID>` part of the URL and put weird stuff in it, like symbols. The page should ignore that param and work as normal.


## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: