### PR TITLE
Add validator for regulations search order

### DIFF
--- a/cfgov/regulations3k/models/pages.py
+++ b/cfgov/regulations3k/models/pages.py
@@ -67,7 +67,7 @@ class RegulationsSearchPage(RoutablePageMixin, CFGOVPage):
     def regulation_results_page(self, request):
         all_regs = Part.objects.order_by('part_number')
         regs = validate_regs_list(request)
-        order = request.GET.get('order', 'relevance')
+        order = validate_order(request)
         search_query = request.GET.get('q', '').strip()
         payload = {
             'search_query': search_query,
@@ -603,3 +603,10 @@ def validate_regs_list(request):
         return [reg for reg in regs_input_list if reg.isalnum()]
     else:
         return []
+
+
+def validate_order(request):
+    order = request.GET.get('order')
+    if order not in ('relevance', 'regulation'):
+        order = 'relevance'
+    return order

--- a/cfgov/regulations3k/tests/test_models.py
+++ b/cfgov/regulations3k/tests/test_models.py
@@ -26,8 +26,8 @@ from regulations3k.models.django import (
 from regulations3k.models.pages import (
     RegulationLandingPage, RegulationPage, RegulationsSearchPage,
     get_next_section, get_previous_section, get_secondary_nav_items,
-    get_section_url, validate_num_results, validate_page_number,
-    validate_regs_list
+    get_section_url, validate_num_results, validate_order,
+    validate_page_number, validate_regs_list
 )
 
 
@@ -654,6 +654,12 @@ class RegModelTests(DjangoTestCase):
     def test_reg_page_num_versions_off_sharing(self):
         test_context = self.reg_page.get_context(self.get_request())
         self.assertEqual(test_context['num_versions'], 2)
+
+    def test_validate_order(self):
+        request = HttpRequest()
+        self.assertEqual(validate_order(request), 'relevance')
+        request.GET.update({'order': 'regulation'})
+        self.assertEqual(validate_order(request), 'regulation')
 
 
 class SectionNavTests(unittest.TestCase):


### PR DESCRIPTION
This PR resolves a potential vulnerability found by Checkmarx by validating the `order` parameter for interactive regulations search.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: