### PR TITLE
Update wagtail-inventory to 0.7

### DIFF
--- a/requirements/libraries.txt
+++ b/requirements/libraries.txt
@@ -36,6 +36,6 @@ unipath>=1.1,<=2.0
 urllib3==1.23
 wagtail-autocomplete==0.1.1
 wagtail-flags==4.0.2
-wagtail-inventory==0.5.1
+wagtail-inventory==0.7
 wagtail-sharing==0.7
 wagtail-treemodeladmin==1.0.4


### PR DESCRIPTION
This change upgrades our version of [wagtail-inventory](https://pypi.org/project/wagtail-inventory/) from 0.5.1 to 0.7. The later versions support more modern versions of Django (2.1, 2.2) and Wagtail (2.3, 2.4, 2.5).

This doesn't impact us as we're not on those versions yet but it's nice to keep up to date.

## Testing

To test, run a local server and visit http://localhost:8000/admin/inventory/ to verify that the inventory search still works.

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [X] Passes all existing automated tests
- [X] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [X] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [X] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: