### PR TITLE
enable DEBUG mode if environment variable DJANGO_DEBUG is 'True'

### DIFF
--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -21,6 +21,9 @@ SECRET_KEY = os.environ.get('SECRET_KEY', os.urandom(32))
 # Deploy environment
 DEPLOY_ENVIRONMENT = os.getenv('DEPLOY_ENVIRONMENT')
 
+# In certain environments, we allow DEBUG to be enabled
+DEBUG = os.environ.get('DJANGO_DEBUG') == 'True'
+
 # signal that tells us that this is a proxied HTTPS request
 # effects how request.is_secure() responds
 SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')


### PR DESCRIPTION
We're working to allow debug mode to be turned out when users are deploying to internal dev environments. You can see how it will be enabled at:

GHE/cfpb-infra/ansible-consumer-finance/pull/277


## Additions

- if DJANGO_DEBUG is in os.environ, and set to the literal string 'True', then enable Django's debug mode.


## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [ ] Chrome on desktop
- [ ] Firefox
- [ ] Safari on macOS
- [ ] Edge
- [ ] Internet Explorer 9, 10, and 11
- [ ] Safari on iOS
- [ ] Chrome on Android

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
