### PR TITLE
Clean up flags that are no longer being checked

### DIFF
--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -651,10 +651,6 @@ FLAGS = {
     # When enabled, the top margin of full-width text insets is increased
     'INSET_TEST': [],
 
-    # When enabled, serves `/es/` pages from this
-    # repo ( excluding /obtener-respuestas/ pages ).
-    'ES_CONV_FLAG': [],
-
     # The next version of the public consumer complaint database
     'CCDB5_RELEASE': [],
 

--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -676,8 +676,6 @@ FLAGS = {
     # Ping google on page publication in production only
     'PING_GOOGLE_ON_PUBLISH': [('environment is', 'production')],
 
-    'LEGACY_HUD_API': [('environment is', 'production')],
-
     # SPLIT TESTING FLAGS
 
     # Ask CFPB page titles as H1s instead of H2s

--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -654,9 +654,6 @@ FLAGS = {
     # The next version of the public consumer complaint database
     'CCDB5_RELEASE': [],
 
-    # To be enabled when mortgage-performance data visualizations go live
-    'MORTGAGE_PERFORMANCE_RELEASE': [],
-
     # Google Optimize code snippets for A/B testing
     # When enabled this flag will add various Google Optimize code snippets.
     # Intended for use with path conditions.

--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -647,10 +647,6 @@ FLAGS = {
         {'condition': 'boolean', 'value': False}
     ],
 
-    # When enabled, use Wagtail for /company-signup/
-    # (instead of selfregistration app)
-    'WAGTAIL_COMPANY_SIGNUP': [],
-
     # IA changes to mega menu for user testing
     # When enabled, the mega menu under "Consumer Tools" is arranged by topic
     'IA_USER_TESTING_MENU': [],

--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -669,9 +669,6 @@ FLAGS = {
     # Search.gov API-based site-search
     'SEARCH_DOTGOV_API': [],
 
-    # The release of the new Financial Coaching pages
-    'FINANCIAL_COACHING': [],
-
     # Turbolinks is a JS library that speeds up page loads
     # https://github.com/turbolinks/turbolinks
     'TURBOLINKS': [],

--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -647,10 +647,6 @@ FLAGS = {
         {'condition': 'boolean', 'value': False}
     ],
 
-    # IA changes to mega menu for user testing
-    # When enabled, the mega menu under "Consumer Tools" is arranged by topic
-    'IA_USER_TESTING_MENU': [],
-
     # Fix for margin-top when using the text inset
     # When enabled, the top margin of full-width text insets is increased
     'INSET_TEST': [],


### PR DESCRIPTION
The flags removed in this PR are no longer evaluated in any code in cfgov-refresh (and I presume not in any of our satellite apps, either). Credit for the inspiration (or motivation by shame) for this PR to Caitlin Rubins excellent talk, ["Intentional Deployment: Best Practices for Feature Flag Management"](https://us.pycon.org/2019/schedule/presentation/183/) at PyCon 2019.

## Removals

- A half-dozen flag definitions:
  - `WAGTAIL_COMPANY_SIGNUP`
  - `IA_USER_TESTING_MENU`
  - `ES_CONV_FLAG`
  - `MORTGAGE_PERFORMANCE_RELEASE`
  - `FINANCIAL_COACHING`
  - `LEGACY_HUD_API`

## Testing

1. Search the cfgov-refresh codebase for references to any of the above flags
1. Find none

## Todos

- Found some other flags that are still being checked but can be deprecated, but will address them in their own PRs:
  - `INSET_TEST`: Requires some Less massaging
  - `CCDB5_RELEASE`: Convert `flagged_url`s to normal and test
  - `WHISTLEBLOWER_RELEASE`: Needs template conditional removed
  - `SEARCH_DOTGOV_API`: No longer needed with the death of i14n or whatever it was? Ask @rosskarchner or @mistergone 
  - `FINANCIAL_WELLBEING_HUB`: Needs `flagged_wagtail_only_view` to just be straight up removed? and tested

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: