### PR TITLE
Add "Events" category label in Recent Updates section of homepage

### DIFF
--- a/cfgov/jinja2/v1/index.html
+++ b/cfgov/jinja2/v1/index.html
@@ -197,6 +197,8 @@
                                 <h3 class="h4">
                                     {% if is_blog(post) %}
                                         {{ category_slug.render(category='blog', href=page_url) }}
+                                    {% elif is_event(post) %}
+                                        {{ category_slug.render(category='Events', href=page_url) }}
                                     {% elif is_report(post) %}
                                         {{ category_slug.render(category='report', href=page_url) }}
                                     {% else %}

--- a/cfgov/v1/jinja2tags/__init__.py
+++ b/cfgov/v1/jinja2tags/__init__.py
@@ -106,6 +106,7 @@ class V1Extension(Extension):
             'hmda_outage_banner': hmda_outage_banner,
             'image_alt_value': image_alt_value,
             'is_blog': ref.is_blog,
+            'is_event': ref.is_event,
             'is_report': ref.is_report,
             'is_filter_selected': contextfunction(is_filter_selected),
             'render_stream_child': contextfunction(render_stream_child),

--- a/cfgov/v1/util/ref.py
+++ b/cfgov/v1/util/ref.py
@@ -262,6 +262,11 @@ def is_blog(page):
         return True
 
 
+def is_event(page):
+    if 'Event' in page.specific_class.__name__:
+        return True
+
+
 def is_report(page):
     for category in page.categories.all():
         for choice in choices_for_page_type('research-reports'):


### PR DESCRIPTION
In the "Recent Updates" section of the homepage, posts that are Events weren't getting the correct header and icon above them.

## Additions

- A method, used in the index template, to check whether a "recent update" post is an event

## Testing

1. Running this branch, enter the Wagtail admin and create a new `EventPage` under Events
2. Visit the http://localhost:8000.
3. The event you created should show up in the "Recent Updates" section, and it should be visually consistent with the other posts in that section, including a header that says "Events", with a calendar icon.

## Screenshots
![Screen Shot 2019-05-09 at 11 07 27 AM](https://user-images.githubusercontent.com/4295388/57466408-938cbb00-724e-11e9-88ff-05a9ee28d95e.png)


## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: