### PR TITLE
Fix bug in portal search-page routable URL handling

### DIFF
--- a/cfgov/ask_cfpb/models/pages.py
+++ b/cfgov/ask_cfpb/models/pages.py
@@ -417,6 +417,8 @@ class PortalSearchPage(
     @route(r'^(?P<category>[^/]+)/$')
     def portal_category_page(self, request, **kwargs):
         category_slug = kwargs.get('category')
+        if category_slug not in self.category_map:
+            raise Http404
         self.portal_category = self.category_map.get(category_slug)
         self.query_base = SearchQuerySet().filter(
             portal_topics=self.portal_topic.heading,

--- a/cfgov/ask_cfpb/tests/models/test_pages.py
+++ b/cfgov/ask_cfpb/tests/models/test_pages.py
@@ -247,6 +247,13 @@ class PortalSearchPageTestCase(TestCase):
             primary_portal_topic_id=1,
         )
 
+    def test_bad_category_value_raises_404(self):
+        page = self.english_search_page
+        url = page.url + page.reverse_subpage(
+            'portal_category_page', kwargs={'category': 'how-to-gui'})
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 404)
+
     def test_get_ask_breadcrumbs_with_portal(self):
         with override_settings(
                 FLAGS={'ASK_CATEGORIES_OFF': [('boolean', True)]}):


### PR DESCRIPTION
It's possible to manually enter a bad portal category in a portal see-all URL
and produce a server error. These URLs are normally generated by our code,
but a manually introuced typo should be caught and return a 404,
rather than cause a server error.

We already have a dictionary of category slugs available on the page,
so the fix is easy: Check any incoming category slug against the
white list before proceeding, and raise 404 if there's a mismatch.

## Testing
Try this URL locally before and after loading this branch:

<http://localhost:8000/consumer-tools/debt-collection/answers/know-your-righ/>

Before: You should get a server error.
After: You should get a 404 page.
