### PR TITLE
Turn off upstream URLs for hard-coded Spanish pages.

### DIFF
--- a/cfgov/ask_cfpb/models/pages.py
+++ b/cfgov/ask_cfpb/models/pages.py
@@ -164,7 +164,7 @@ class AnswerLandingPage(LandingPage):
                 if topic_page:
                     url = topic_page.url
                 else:
-                    continue
+                    continue  # pragma: no cover
             portal_cards.append({
                 'topic': topic,
                 'title': topic.title(self.language),

--- a/cfgov/cfgov/urls.py
+++ b/cfgov/cfgov/urls.py
@@ -364,9 +364,6 @@ urlpatterns = [
     url(r'^es/nuestra-historia/$', TemplateView.as_view(
                  template_name='es/nuestra-historia/index.html')),
 
-    url(r'^es/presentar-una-queja/$', TemplateView.as_view(
-                 template_name='es/presentar-una-queja/index.html')),
-
     url(r'^es/quienes-somos/$', TemplateView.as_view(
                  template_name='es/quienes-somos/index.html')),
 

--- a/cfgov/cfgov/urls.py
+++ b/cfgov/cfgov/urls.py
@@ -355,9 +355,6 @@ urlpatterns = [
     url(r'^(?P<language>es)/obtener-respuestas/api/autocomplete/$',
         ask_autocomplete, name='ask-autocomplete-es'),
 
-    url(r'^es/nuestra-historia/$', TemplateView.as_view(
-                 template_name='es/nuestra-historia/index.html')),
-
     url(r'^_status/', include_if_app_enabled('watchman', 'watchman.urls')),
 
     url(

--- a/cfgov/cfgov/urls.py
+++ b/cfgov/cfgov/urls.py
@@ -355,17 +355,8 @@ urlpatterns = [
     url(r'^(?P<language>es)/obtener-respuestas/api/autocomplete/$',
         ask_autocomplete, name='ask-autocomplete-es'),
 
-    url(r'^es/$', TemplateView.as_view(
-                 template_name='/es/index.html')),
-
-    url(r'^es/comprar-casa/$', TemplateView.as_view(
-                 template_name='es/comprar-casa/index.html')),
-
     url(r'^es/nuestra-historia/$', TemplateView.as_view(
                  template_name='es/nuestra-historia/index.html')),
-
-    url(r'^es/quienes-somos/$', TemplateView.as_view(
-                 template_name='es/quienes-somos/index.html')),
 
     url(r'^_status/', include_if_app_enabled('watchman', 'watchman.urls')),
 

--- a/cfgov/jinja2/v1/_includes/organisms/_vars-mega-menu-spanish.html
+++ b/cfgov/jinja2/v1/_includes/organisms/_vars-mega-menu-spanish.html
@@ -21,7 +21,7 @@
         ],
     },
     {
-        'link_text': 'Quienes somos',
+        'link_text': 'Quiénes somos',
         'external_link': '/es/quienes-somos/',
         'order': 4,
         'nav_groups': [

--- a/cfgov/jinja2/v1/_includes/organisms/footer.html
+++ b/cfgov/jinja2/v1/_includes/organisms/footer.html
@@ -41,7 +41,7 @@
                         <a class="m-list_link" href="/es/obtener-respuestas/">Obtener respuestas</a>
                     </li>
                     <li class="m-list_item">
-                        <a class="m-list_link" href="/es/presentar-una-queja/">Presentar una queja</a>
+                        <a class="m-list_link" href="/es/enviar-una-queja/">Enviar una queja</a>
                     </li>
                     <li class="m-list_item">
                         <a class="m-list_link" href="/es/quienes-somos/">Quiénes somos</a>


### PR DESCRIPTION
As part of the Ask CFPB update, we are moving a number of formerly hard-coded
Spanish pages in to Wagtail.

This PR turns off the upstream URL conf that intercepted the hard-coded page URLs
before they fell through to Wagtail. We're now ready to let Wagtail take over.

This can be merged and deployed when hard-coded pages are ready to roll.

Here's our running URL list:

Current URL | Wagtail URL | Redirect
:----------- | :-------- | :---------
/es/ | /es/ | | 
/es/presentar-una-queja/ | /es/enviar-una-queja/  | √
/es/quienes-somos/ | /es/quienes-somos/ |
/es/nuestra-historia/ | NONE | √ (/es/quienes-somos/)
/es/comprar-casa/ | /es/comprar-casa/ |
