### PR TITLE
Buying-a-house: Remove webfont mixins

### DIFF
--- a/cfgov/unprocessed/apps/owning-a-home/css/explore-rates.less
+++ b/cfgov/unprocessed/apps/owning-a-home/css/explore-rates.less
@@ -46,7 +46,6 @@
         .grid_push( 8 );
 
         background: @gray-5;
-        .u-webfont-regular();
 
         p:last-child,
         section p:last-child {
@@ -54,7 +53,7 @@
         }
 
         label {
-            .u-webfont-medium();
+            font-weight: 500;
 
             display: block;
             margin-bottom: unit( 4px / @base-font-size-px, em );
@@ -281,8 +280,6 @@
         Compare interest rate costs
         --------------------------- */
     .compare {
-        .u-webfont-regular();
-
         margin-top: unit( 30px / @base-font-size-px, em );
         label {
             .u-visually-hidden;
@@ -378,8 +375,6 @@
     }
 
     .arm-info-comparison {
-        .u-webfont-regular();
-
         position: absolute;
         display: block;
         width: 200%;
@@ -407,7 +402,6 @@
     .next-steps-heading {
         margin-bottom: 1em;
         font-size: 1.125em;
-        .u-webfont-regular();
     }
 
 
@@ -453,7 +447,6 @@
         top: 30%;
         padding: 1em 2em 1em 3em;
         background: @white;
-        .u-webfont-regular();
     }
 
     .chart-menu {

--- a/cfgov/unprocessed/apps/owning-a-home/css/form-explainer.less
+++ b/cfgov/unprocessed/apps/owning-a-home/css/form-explainer.less
@@ -3,8 +3,6 @@
    ========================================================================== */
 
 .form-explainer {
-    .u-webfont-regular();
-
     .u-right-on-desktop {
         .respond-to-min( 801px, {
             text-align: right;

--- a/cfgov/unprocessed/apps/owning-a-home/css/helpers.less
+++ b/cfgov/unprocessed/apps/owning-a-home/css/helpers.less
@@ -21,8 +21,6 @@
 
 // alert containers have a background color but no border
 .alert-container {
-     .u-webfont-regular();
-
     padding: unit( 20px / @base-font-size-px, em );
     background: @gray-5;
 
@@ -51,10 +49,8 @@
     margin-top: 2em;
 }
 
-/* lead paragrapgs are typically the first paragraph in a content area */
+/* lead paragraphs are typically the first paragraph in a content area */
 .lead {
-    .u-webfont-regular();
-
     margin-bottom: unit( 30px / @base-font-size-px, em );
     font-size: 1.125em;
 }
@@ -76,8 +72,6 @@
 
 /* notes are subtle call out boxes with top and bottom borders */
 .note {
-    .u-webfont-regular();
-
     color: @black;
     padding: 20px 10px;
     margin: 1em 0;
@@ -103,10 +97,8 @@
 
 /* use sans-serif typeface */
 .sans {
-    .u-webfont-regular();
-
     strong {
-        .u-webfont-demi();
+        font-weight: 600;
     }
 }
 

--- a/cfgov/unprocessed/apps/owning-a-home/css/hero.less
+++ b/cfgov/unprocessed/apps/owning-a-home/css/hero.less
@@ -6,7 +6,6 @@
   padding: 40px 0;
 
   p {
-    .u-webfont-regular();
     text-transform: uppercase;
     color: #909294;
     text-align: center;

--- a/cfgov/unprocessed/apps/owning-a-home/css/tab.less
+++ b/cfgov/unprocessed/apps/owning-a-home/css/tab.less
@@ -16,7 +16,6 @@
         position: relative;
         display: block;
         padding: 28px 20px;
-        .u-webfont-regular();
         font-size: unit( 22px / @base-font-size-px, em );
         text-align: left;
         z-index: 1;


### PR DESCRIPTION
Owning a home still used some webfont mixins that are removed in https://github.com/cfpb/capital-framework/pull/907

## Changes

- Remove webfont mixins in owning a home and replace with `font-weight` where needed.

## Testing

1. Pull branch and run a local server.
2. http://localhost:8000/owning-a-home/closing-disclosure/ and http://localhost:8000/owning-a-home/explore-rates/ should be unchanged, other than bolding changes noted below in the screenshots.

## Screenshots

Before:
<img width="596" alt="Screen Shot 2019-05-17 at 1 26 23 PM" src="https://user-images.githubusercontent.com/704760/57946373-25797100-78aa-11e9-84ac-32a8962961be.png">

<img width="934" alt="Screen Shot 2019-05-17 at 1 30 35 PM" src="https://user-images.githubusercontent.com/704760/57946345-15619180-78aa-11e9-932c-14acb6ca3ba2.png">

After:
<img width="604" alt="Screen Shot 2019-05-17 at 1 30 02 PM" src="https://user-images.githubusercontent.com/704760/57946388-2dd1ac00-78aa-11e9-8234-058678480378.png">

<img width="931" alt="Screen Shot 2019-05-17 at 1 31 41 PM" src="https://user-images.githubusercontent.com/704760/57946355-1b577280-78aa-11e9-99c0-627465b46b79.png">

