### PR TITLE
Fix college-costs wheel name

### DIFF
--- a/requirements/optional-public.txt
+++ b/requirements/optional-public.txt
@@ -1,4 +1,4 @@
-https://github.com/cfpb/college-costs/releases/download/2.6.2/college_costs-2.6.2-py2-none-any.whl
+https://github.com/cfpb/college-costs/releases/download/2.6.2/college_costs-2.6.2-py2.py3-none-any.whl
 https://github.com/cfpb/owning-a-home-api/releases/download/0.12.1/owning_a_home_api-0.12.1-py2.py3-none-any.whl
 https://github.com/cfpb/retirement/releases/download/0.8.0/retirement-0.8.0-py2-none-any.whl
 https://github.com/cfpb/ccdb5-api/releases/download/1.1.7/ccdb5_api-1.1.7-py2-none-any.whl


### PR DESCRIPTION
The new college-costs wheel name has `.py3` in it, our `optional-public.txt` requirements did not. This PR fixes that.

~~I'm not sure why Travis didn't fail on this in #5021.~~ I forget — Travis doesn't install our `optional-public.txt`.

## Checklist

- [x] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
