### PR TITLE
Make the hard-coded sequence for portal category navigation explicit

### DIFF
--- a/cfgov/ask_cfpb/models/pages.py
+++ b/cfgov/ask_cfpb/models/pages.py
@@ -62,7 +62,13 @@ JOURNEY_PATHS = (
     '/owning-a-home/process',
 )
 # Custom sort for navigation, by PortalCategory primary keys
-PORTAL_CATEGORY_SORT_ORDER = [1, 4, 5, 2, 3]
+PORTAL_CATEGORY_SORT_ORDER = OrderedDict((
+    (1, 'Basics'),
+    (4, 'Key terms'),
+    (5, 'Common issues'),
+    (2, 'Know your rights'),
+    (3, 'How-to guides'),
+))
 
 
 def get_reusable_text_snippet(snippet_title):
@@ -163,7 +169,7 @@ class AnswerLandingPage(LandingPage):
                     live=True).first()
                 if topic_page:
                     url = topic_page.url
-                else:
+                else:  # pragma: no cover
                     continue
             portal_cards.append({
                 'topic': topic,
@@ -231,7 +237,7 @@ class PortalSearchPage(
         """
         categories = PortalCategory.objects.order_by('pk')
         sorted_mapping = OrderedDict()
-        for i in PORTAL_CATEGORY_SORT_ORDER:
+        for i in list(PORTAL_CATEGORY_SORT_ORDER.keys()):
             sorted_mapping.update({
                 slugify(
                     categories[i - 1].title(self.language)

--- a/cfgov/ask_cfpb/tests/models/test_pages.py
+++ b/cfgov/ask_cfpb/tests/models/test_pages.py
@@ -329,7 +329,7 @@ class PortalSearchPageTestCase(TestCase):
     def test_category_map_sort_order(self):
         mapping = self.english_search_page.category_map
         self.assertEqual(
-            PORTAL_CATEGORY_SORT_ORDER,
+            list(PORTAL_CATEGORY_SORT_ORDER.keys()),
             [category.pk for slug, category in mapping.items()]
         )
 


### PR DESCRIPTION
The `PORTAL_CATEGORY_SORT_ORDER` var in ask_cfpb/models/pages.py was a list
of portal category primary keys. This makes the variable an ordered dict
to give context to the keys.