### PR TITLE
Bump retirement to 0.8.1

### DIFF
--- a/requirements/optional-public.txt
+++ b/requirements/optional-public.txt
@@ -1,6 +1,6 @@
 https://github.com/cfpb/college-costs/releases/download/2.6.2/college_costs-2.6.2-py2.py3-none-any.whl
 https://github.com/cfpb/owning-a-home-api/releases/download/0.12.1/owning_a_home_api-0.12.1-py2.py3-none-any.whl
-https://github.com/cfpb/retirement/releases/download/0.8.0/retirement-0.8.0-py2-none-any.whl
+https://github.com/cfpb/retirement/releases/download/0.8.1/retirement-0.8.1-py2-none-any.whl
 https://github.com/cfpb/ccdb5-api/releases/download/1.1.7/ccdb5_api-1.1.7-py2-none-any.whl
 https://github.com/cfpb/ccdb5-ui/releases/download/1.2.1/ccdb5_ui-1.2.1-py2.py3-none-any.whl
 https://github.com/cfpb/django-college-costs-comparison/releases/download/1.10.0/comparisontool-1.10.0-py2-none-any.whl


### PR DESCRIPTION
## Changes

- Bump retirement to 0.8.1

## Testing

1. `./backend.sh` should pass.
2. `pip install -r ./requirements/optional-public.txt` should pass.
