### PR TITLE
Minor improvements to initial_data script

### DIFF
--- a/.env_SAMPLE
+++ b/.env_SAMPLE
@@ -7,9 +7,11 @@
 # Django Application Server.
 ############################
 
-export DJANGO_STAGING_HOSTNAME='content.localhost'
-#export DJANGO_STATIC_ROOT=<path_to_static_files>
+export DJANGO_STAGING_HOSTNAME=content.localhost
 export DJANGO_HTTP_PORT=8000
+export DJANGO_ADMIN_USERNAME=admin
+export DJANGO_ADMIN_PASSWORD=admin
+#export DJANGO_STATIC_ROOT=<path_to_static_files>
 
 ##################################
 # Django Media Storage (optional).

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Install third-party dependencies and build frontend assets:
 ./setup.sh
 ```
 
-Create a local database and add some basic pages:
+Create a local database, a Wagtail admin user, and a site homepage:
 
 ```sh
 ./initial-data.sh


### PR DESCRIPTION
This commit makes several minor changes to the initial_data Python script that lives at cfgov/scripts/initial_data.py and is runnable using

  ```sh
  cfgov/manage.py runscript initial_data
  ```

or, to run Django migrations first,

  ```sh
  ./initial-data.sh
  ```

This work is part of a larger effort to make this initial_data script run on each cf.gov deploy, to setup environment-specific variables in our different environments.

## Testing

To verify that this works as desired against an empty database, first completely delete your local database. If using Postgres, something like:

  ```sh
  dropdb cfgov && dropuser cfpb; createuser cfpb && createdb -O cfpb cfgov
  ```

If using SQLite, just delete the local sqlite database file.

Next, run the initial data script:

  ```sh
  ./initial-data.sh
  ```

You should see the following in the console output:

  ```
  Loading Initial Data...
  Running script initial_data
  Configuring superuser, username: admin
  Creating new cfgov home page
  Page created: "CFGov" id=3 content_type=v1.HomePage path=/cfgov/
  Configured default Wagtail Site: localhost:8000 [default]
  Deleting default Wagtail home page
  Page unpublished: "Welcome to your new Wagtail site!" id=2
  Page deleted: "Welcome to your new Wagtail site!" id=2
  Configured wagtail-sharing site: content.localhost:8000
  ```

Run your local server, and verify the following:

1. http://localhost:8000 shows the home page, without any megamenu content.
2. You can login to Wagtail at http://localhost:8000/admin/ using the credentials admin/admin (or whatever you have specified in your .env, see changes to .env_SAMPLE).
3. There should be only 1 page in Wagtail, the home page.
4. Under Settings, Sites you should see a single site, with domain "localhost" and port 8000, pointing to the CFGov home page.
5. Under Settings, Sharing Sites, you should see a single sharing site, pointing to the default Site, with hostname "content.localhost" and port 8000.
6. Visiting the sharing site at http://content.localhost:8000 in Chrome (or another browser that supports localhost subdomains) should show the homepage with the wagtail-sharing banner.

To verify that this works as desired against a production data dump, first refresh using

  ```sh
  ./refresh-data.sh
  ```

This also runs the initial data script as part of the refresh. You should see the following in the console output:

  ```
  Setting up initial data
  Running script initial_data
  Configuring superuser, username: admin
  Configured default Wagtail Site: www.consumerfinance.gov:8000 [default]
  Configured wagtail-sharing site: content.localhost:8000
  ```

Note that, unlike above, the existing home page is (correctly) not deleted and recreated if it already exists.

Run your local server, and verify the following:

1. http://localhost:8000 shows the home page, with proper megamenu content.
2. You can login to Wagtail at http://localhost:8000/admin/ using the credentials admin/admin (or whatever you have specified in your .env, see changes to .env_SAMPLE).
3. The full set of site pages should exist in Wagtail.
4. Under Settings, Sites you should see a single site, with domain "www.consumerfinance.gov" and port 8000, pointing to the CFGov home page.
5. Under Settings, Sharing Sites you should see a single sharing site, pointing to the default Site, with hostname "content.localhost" and port 8000.
6. Visiting the sharing site at http://content.localhost:8000 in Chrome (or another browser that supports localhost subdomains) should show the homepage with the wagtail-sharing banner.

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [X] Passes all existing automated tests
- [X] Any _change_ in functionality is tested
- [X] New functions are documented (with a description, list of inputs, and expected output)
- [X] Placeholder code is flagged / future todos are captured in comments
- [X] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [X] Project documentation has been updated
- [X] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: