### PR TITLE
More minor improvements to initial_data script

### DIFF
--- a/.env_SAMPLE
+++ b/.env_SAMPLE
@@ -7,7 +7,6 @@
 # Django Application Server.
 ############################
 
-export DJANGO_STAGING_HOSTNAME=content.localhost
 export DJANGO_HTTP_PORT=8000
 export DJANGO_ADMIN_USERNAME=admin
 export DJANGO_ADMIN_PASSWORD=admin
@@ -18,6 +17,15 @@ export DJANGO_ADMIN_PASSWORD=admin
 ##################################
 
 # export MEDIA_ROOT=<path_to_media_root>
+
+######################################################
+# Wagtail-Sharing - for sharing unpublished drafts.
+#
+# Used in initial_data script to set sharing hostname.
+# See https://github.com/cfpb/wagtail-sharing.
+#####################################################
+export WAGTAIL_SHARING_HOSTNAME=content.localhost
+
 
 ########################################
 # Application feature related variables.

--- a/.env_SAMPLE
+++ b/.env_SAMPLE
@@ -26,7 +26,6 @@ export DJANGO_ADMIN_PASSWORD=admin
 #####################################################
 export WAGTAIL_SHARING_HOSTNAME=content.localhost
 
-
 ########################################
 # Application feature related variables.
 ########################################

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,8 +43,6 @@ script:
 
 env:
   global:
-    - DJANGO_SETTINGS_MODULE=cfgov.settings.test
-    - DJANGO_STAGING_HOSTNAME=content.localhost
     - COVERALLS_PARALLEL=true
     - PGPORT=5433
     - TEST_DATABASE_URL=postgres://travis:travis@localhost:5433/travis

--- a/cfgov/scripts/initial_data.py
+++ b/cfgov/scripts/initial_data.py
@@ -19,24 +19,27 @@ def run():
     logger.info('Running script initial_data')
     default_site = Site.objects.get(is_default_site=True)
 
-    admin_username = os.getenv('DJANGO_ADMIN_USERNAME', 'admin')
-    admin_password = os.getenv('DJANGO_ADMIN_PASSWORD', 'admin')
+    admin_username = os.getenv('DJANGO_ADMIN_USERNAME')
+    admin_password = os.getenv('DJANGO_ADMIN_PASSWORD')
     http_port = int(os.getenv('DJANGO_HTTP_PORT', default_site.port))
 
-    staging_hostname = os.getenv('DJANGO_STAGING_HOSTNAME')
+    wagtail_sharing_hostname = os.getenv('WAGTAIL_SHARING_HOSTNAME')
 
-    # Create admin user if it doesn't exist already.
-    # Update existing one with admin password and active state.
-    logger.info('Configuring superuser, username: {}'.format(admin_username))
-    User.objects.update_or_create(
-        username=admin_username,
-        defaults={
-            'password': make_password(admin_password),
-            'is_superuser': True,
-            'is_staff': True,
-            'is_active': True,
-        }
-    )
+    # If specified in the environment, create or activate superuser.
+    if admin_username and admin_password:
+        logger.info('Configuring superuser, username: {}'.format(
+            admin_username
+        ))
+
+        User.objects.update_or_create(
+            username=admin_username,
+            defaults={
+                'password': make_password(admin_password),
+                'is_superuser': True,
+                'is_staff': True,
+                'is_active': True,
+            }
+        )
 
     # Create home page if it doesn't exist already.
     try:
@@ -55,6 +58,17 @@ def run():
         root_page = Page.objects.get(slug='root')
         root_page.add_child(instance=home_page)
 
+        # Delete the legacy Wagtail "hello world" page, if it exists.
+        # This page is created as part of the default Wagtail install.
+        # https://github.com/wagtail/wagtail/blob/v1.13.4/wagtail/wagtailcore/migrations/0002_initial_data.py#L33
+        try:
+            hello_world = Page.objects.get(slug='home', url_path='/home/')
+        except Page.DoesNotExist:
+            pass
+        else:
+            logger.info('Deleting default Wagtail home page')
+            hello_world.delete()
+
     # Configure the default Wagtail Site to point to the proper home page
     # with the desired port.
     default_site.root_page_id = home_page.id
@@ -62,24 +76,13 @@ def run():
     default_site.save()
     logger.info('Configured default Wagtail Site: {}'.format(default_site))
 
-    # Delete the legacy Wagtail "hello world" page, if it exists.
-    # This page is created as part of the default Wagtail install.
-    # https://github.com/wagtail/wagtail/blob/v1.13.4/wagtail/wagtailcore/migrations/0002_initial_data.py#L33
-    try:
-        hello_world = Page.objects.get(slug='home', url_path='/home/')
-    except Page.DoesNotExist:
-        pass
-    else:
-        logger.info('Deleting default Wagtail home page')
-        hello_world.delete()
-
-    # Setup a sharing site for the default Wagtail site if a staging hostname
+    # Setup a sharing site for the default Wagtail site if a sharing hostname
     # has been configured in the environment.
-    if staging_hostname:
+    if wagtail_sharing_hostname:
         sharing_site, _ = SharingSite.objects.update_or_create(
             site=default_site,
             defaults={
-                'hostname': staging_hostname,
+                'hostname': wagtail_sharing_hostname,
                 'port': http_port,
             }
         )

--- a/config/environment.js
+++ b/config/environment.js
@@ -10,7 +10,6 @@
 const envvars = {
 
   /* eslint-disable no-process-env */
-  DJANGO_STAGING_HOSTNAME: process.env.DJANGO_STAGING_HOSTNAME,
   NODE_ENV:                process.env.NODE_ENV,
   TEST_HTTP_HOST:          process.env.TEST_HTTP_HOST,
   TEST_HTTP_PORT:          process.env.DJANGO_HTTP_PORT,

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -327,7 +327,7 @@ with a slug of `cfgov`.
 set to 80.
 - If it doesn't already exist, creates a new
 [wagtail-sharing](https://github.com/cfpb/wagtail-sharing) `SharingSite` with
-a hostname and port defined by the `DJANGO_STAGING_HOSTNAME` and
+a hostname and port defined by the `WAGTAIL_SHARING_HOSTNAME` and
 `DJANGO_HTTP_PORT` environment variables.
 
 ### Load a database dump

--- a/tox.ini
+++ b/tox.ini
@@ -110,9 +110,11 @@ passenv=
 # Set DJANGO_SETTINGS_MODULE based on {with,no}-migrations
 setenv=
     GOVDELIVERY_ACCOUNT_CODE=fake_account_code
-    DJANGO_STAGING_HOSTNAME=content.localhost
+    DJANGO_ADMIN_USERNAME=admin
+    DJANGO_ADMIN_PASSWORD=admin
     LANG=en_US.UTF-8
     LC_ALL=en_US.UTF-8
+    WAGTAIL_SHARING_HOSTNAME=content.localhost
 deps=
     -r{toxinidir}/requirements/libraries.txt
     -r{toxinidir}/requirements/postgres.txt


### PR DESCRIPTION
This followup to #5039 makes additional minor changes to the initial_data script. We want to be able to run this against any cf.gov environment, including production, so this change makes superuser
creation optional. A superuser will only be created if the `DJANGO_ADMIN_USERNAME` and `DJANGO_ADMIN_PASSWORD` environment variables are set ([as we suggest](https://github.com/cfpb/cfgov-refresh/blob/c62699d4097ad410d95c3d251a180d819314e0c3/.env_SAMPLE#L12) in our .env_SAMPLE file).

This commit also updates the environment variable used to define the sharing hostname, from `DJANGO_STAGING_HOSTNAME` to a more descriptive `WAGTAIL_SHARING_HOSTNAME`.

Additionally, this change slightly modifies when the legacy Wagtail "hello world" page is deleted. This should only be necessary once, the single time that we need to create a CFGov homepage.

## Testing

See testing instructions on #5039. Additionally, note that all frontend/acceptance tests continue to pass with the various environment variable changes.

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [X] Passes all existing automated tests
- [X] Any _change_ in functionality is tested
- [X] New functions are documented (with a description, list of inputs, and expected output)
- [X] Placeholder code is flagged / future todos are captured in comments
- [X] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [X] Project documentation has been updated
- [X] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: