### PR TITLE
Minor improvement to initial_data script

### DIFF
--- a/cfgov/scripts/initial_data.py
+++ b/cfgov/scripts/initial_data.py
@@ -69,12 +69,16 @@ def run():
             logger.info('Deleting default Wagtail home page')
             hello_world.delete()
 
-    # Configure the default Wagtail Site to point to the proper home page
-    # with the desired port.
-    default_site.root_page_id = home_page.id
-    default_site.port = http_port
-    default_site.save()
-    logger.info('Configured default Wagtail Site: {}'.format(default_site))
+    # If needed, configure the default Wagtail Site to point to the proper
+    # home page with the desired port.
+    if (
+        default_site.root_page_id != home_page.id or
+        default_site.port != http_port
+    ):
+        default_site.root_page_id = home_page.id
+        default_site.port = http_port
+        default_site.save()
+        logger.info('Configured default Wagtail Site: {}'.format(default_site))
 
     # Setup a sharing site for the default Wagtail site if a sharing hostname
     # has been configured in the environment.


### PR DESCRIPTION
The initial_data script doesn't need to update the default site unless its current state doesn't match the desired state. This minor change removes an unnecessary database write and logging statement from this script when it's not needed, which is most of the time.

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [X] Passes all existing automated tests
- [X] Any _change_ in functionality is tested
- [X] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: