### PR TITLE
Fix indexing for Ask CFPB answers

### DIFF
--- a/cfgov/ask_cfpb/search_indexes.py
+++ b/cfgov/ask_cfpb/search_indexes.py
@@ -1,4 +1,9 @@
+from __future__ import unicode_literals
+
+from django.utils.html import strip_tags
 from haystack import indexes
+
+import unidecode
 
 from ask_cfpb.models.pages import AnswerPage
 from search import fields
@@ -9,6 +14,8 @@ class AnswerPageIndex(indexes.SearchIndex, indexes.Indexable):
         document=True,
         use_template=True,
         boost=10.0)
+    answer_text = indexes.CharField()
+    answer_unaccented = indexes.CharField()
     autocomplete = indexes.EdgeNgramField(
         use_template=True)
     url = indexes.CharField(
@@ -22,12 +29,6 @@ class AnswerPageIndex(indexes.SearchIndex, indexes.Indexable):
     portal_categories = indexes.MultiValueField()
     suggestions = indexes.FacetCharField()
 
-    def prepare_answer(self, obj):
-        data = super(AnswerPageIndex, self).prepare(obj)
-        if obj.question.lower().startswith('what is'):
-            data['boost'] = 2.0
-        return data
-
     def prepare_tags(self, obj):
         return obj.clean_search_tags
 
@@ -36,6 +37,39 @@ class AnswerPageIndex(indexes.SearchIndex, indexes.Indexable):
 
     def prepare_portal_categories(self, obj):
         return [topic.heading for topic in obj.portal_category.all()]
+
+    def extract_raw_text(self, stream_data):
+        # We want answer text to come first, to show up in result snippets.
+        text_chunks = [
+            block.get('value').get('content')
+            for block in stream_data
+            if block.get('type') == 'text'
+        ]
+        extra_chunks = [
+            block.get('value').get('content')
+            for block in stream_data
+            if block.get('type') in ['tip', 'table']
+        ]
+        chunks = text_chunks + extra_chunks
+        return " ".join(chunks)
+
+    def prepare_answer_text(self, obj):
+        stream = obj.answer_content
+        raw_text = self.extract_raw_text(stream.stream_data)
+        return strip_tags(raw_text)
+
+    def prepare_answer_unaccented(self, obj):
+        text = ''
+        if obj.language == 'en':
+            return text
+        stream = obj.answer_content
+        raw_text = self.extract_raw_text(stream.stream_data)
+        stripped = strip_tags(raw_text)
+        try:
+            text = unidecode.unidecode(stripped)
+        except Exception:
+            pass
+        return text
 
     def prepare(self, obj):
         data = super(AnswerPageIndex, self).prepare(obj)

--- a/cfgov/ask_cfpb/search_indexes.py
+++ b/cfgov/ask_cfpb/search_indexes.py
@@ -1,12 +1,38 @@
 from __future__ import unicode_literals
 
 from django.utils.html import strip_tags
+from django.utils.text import Truncator
 from haystack import indexes
-
-import unidecode
 
 from ask_cfpb.models.pages import AnswerPage
 from search import fields
+
+
+def truncatissimo(text):
+    """Limit preview text to 40 words AND to 255 characters."""
+    word_limit = 40
+    while word_limit:
+        test = Truncator(text).words(word_limit, truncate=' ...')
+        if len(test) <= 255:
+            return test
+        else:
+            word_limit -= 1
+
+
+def extract_raw_text(stream_data):
+    # Extract text from stream_data, starting with the answer text.
+    text_chunks = [
+        block.get('value').get('content')
+        for block in stream_data
+        if block.get('type') == 'text'
+    ]
+    extra_chunks = [
+        block.get('value').get('content')
+        for block in stream_data
+        if block.get('type') in ['tip', 'table']
+    ]
+    chunks = text_chunks + extra_chunks
+    return " ".join(chunks)
 
 
 class AnswerPageIndex(indexes.SearchIndex, indexes.Indexable):
@@ -14,8 +40,6 @@ class AnswerPageIndex(indexes.SearchIndex, indexes.Indexable):
         document=True,
         use_template=True,
         boost=10.0)
-    answer_text = indexes.CharField()
-    answer_unaccented = indexes.CharField()
     autocomplete = indexes.EdgeNgramField(
         use_template=True)
     url = indexes.CharField(
@@ -28,53 +52,26 @@ class AnswerPageIndex(indexes.SearchIndex, indexes.Indexable):
     portal_topics = indexes.MultiValueField()
     portal_categories = indexes.MultiValueField()
     suggestions = indexes.FacetCharField()
+    preview = indexes.CharField(indexed=False)
 
-    def prepare_tags(self, obj):
-        return obj.clean_search_tags
+    def prepare_preview(self, page):
+        raw_text = extract_raw_text(page.answer_content.stream_data)
+        full_text = strip_tags(" ".join([page.short_answer, raw_text]))
+        return truncatissimo(full_text)
 
-    def prepare_portal_topics(self, obj):
-        return [topic.heading for topic in obj.portal_topic.all()]
+    def prepare_tags(self, page):
+        return page.clean_search_tags
 
-    def prepare_portal_categories(self, obj):
-        return [topic.heading for topic in obj.portal_category.all()]
+    def prepare_portal_topics(self, page):
+        return [topic.heading for topic in page.portal_topic.all()]
 
-    def extract_raw_text(self, stream_data):
-        # We want answer text to come first, to show up in result snippets.
-        text_chunks = [
-            block.get('value').get('content')
-            for block in stream_data
-            if block.get('type') == 'text'
-        ]
-        extra_chunks = [
-            block.get('value').get('content')
-            for block in stream_data
-            if block.get('type') in ['tip', 'table']
-        ]
-        chunks = text_chunks + extra_chunks
-        return " ".join(chunks)
+    def prepare_portal_categories(self, page):
+        return [topic.heading for topic in page.portal_category.all()]
 
-    def prepare_answer_text(self, obj):
-        stream = obj.answer_content
-        raw_text = self.extract_raw_text(stream.stream_data)
-        return strip_tags(raw_text)
-
-    def prepare_answer_unaccented(self, obj):
-        text = ''
-        if obj.language == 'en':
-            return text
-        stream = obj.answer_content
-        raw_text = self.extract_raw_text(stream.stream_data)
-        stripped = strip_tags(raw_text)
-        try:
-            text = unidecode.unidecode(stripped)
-        except Exception:
-            pass
-        return text
-
-    def prepare(self, obj):
-        data = super(AnswerPageIndex, self).prepare(obj)
-        data['suggestions'] = data['text']
-        return data
+    def prepare(self, page):
+        self.prepared_data = super(AnswerPageIndex, self).prepare(page)
+        self.prepared_data['suggestions'] = self.prepared_data['text']
+        return self.prepared_data
 
     def get_model(self):
         return AnswerPage

--- a/cfgov/ask_cfpb/templates/search/indexes/ask_cfpb/answerpage_text.txt
+++ b/cfgov/ask_cfpb/templates/search/indexes/ask_cfpb/answerpage_text.txt
@@ -1,8 +1,8 @@
 {% load accent_stripper %}
-{{ object.answer_content|striptags|safe }}
-{{ object.answer_content|striptags|stripaccents|safe }}
 {{ object.short_answer|striptags|safe }}
+{{ object.answer_text|safe }}
 {{ object.short_answer|striptags|stripaccents|safe }}
+{{ object.answer_unaccented|safe }}
 {{ object.question }}
 {{ object.question|stripaccents }}
 {% for tag in tags %}

--- a/cfgov/ask_cfpb/templates/search/indexes/ask_cfpb/answerpage_text.txt
+++ b/cfgov/ask_cfpb/templates/search/indexes/ask_cfpb/answerpage_text.txt
@@ -1,11 +1,23 @@
 {% load accent_stripper %}
-{{ object.short_answer|striptags|safe }}
-{{ object.answer_text|safe }}
-{{ object.short_answer|striptags|stripaccents|safe }}
-{{ object.answer_unaccented|safe }}
+{{ object.short_answer | striptags }}
+{% for block in object.answer_content %}
+{% if block.block_type == 'text' %}
+{{ block.value.content | striptags }}
+{% endif %}{% endfor %}
+{% for block in object.answer_content %}
+{% if block.block_type == 'tip' or block.block_type == 'table' %}
+{{ block.value.content | striptags }}
+{% endif %}{% endfor %}
 {{ object.question }}
-{{ object.question|stripaccents }}
+{% if object.language == 'es' %}
+{{ object.short_answer|striptags|stripaccents|safe }}
+{% for block in object.answer_content %}
+{% if block.block_type == 'text' %}
+{{ block.value.content | striptags | stripaccents }}
+{% endif %}{% endfor %}
+{{ object.question | stripaccents }}
+{% endif %}
 {% for tag in tags %}
 {{ tag }}
-{{tag|stripaccents}}
+{{tag | stripaccents}}
 {% endfor %}

--- a/cfgov/ask_cfpb/views.py
+++ b/cfgov/ask_cfpb/views.py
@@ -103,7 +103,8 @@ def ask_search(request, language='en', as_json=False):
                 {
                     'question': result.autocomplete,
                     'url': result.url,
-                    'text': result.text
+                    'text': result.text,
+                    'preview': result.preview,
                 }
                 for result in search.queryset
             ]
@@ -115,7 +116,7 @@ def ask_search(request, language='en', as_json=False):
     results_page.result_query = search.search_term
     results_page.suggestion = search.suggestion
     results_page.answers = [
-        (result.url, result.autocomplete, result.text)
+        (result.url, result.autocomplete, result.preview)
         for result in search.queryset
     ]
     return results_page.serve(request)

--- a/cfgov/jinja2/v1/ask-cfpb/answer-search-results.html
+++ b/cfgov/jinja2/v1/ask-cfpb/answer-search-results.html
@@ -50,7 +50,7 @@
                 {% else %}
                     <article class="question_summary question_summary__full">
                         <p class="question_title"><a href="{{ question[0] }}" class="kbq">{{ question[1]|safe }}</a></p>
-                        <p class="qans">{{ question[2] | safe | striptags | truncate }}</p>
+                        <p class="qans">{{ question[2] }}</p>
                     </article>
                 {% endif %}
                 {% endfor %}


### PR DESCRIPTION
Indexing broke when we moved answer content into streamfields.
This adjusts the indexing routine to extract content out of the streamfield blocks.

## Testing

With a recent db load (and a running elasticsearch instance), pull in
the branch and update the elasticsearch index:
```bash
./cfgov/manage.py update_index ask_cfpb --remove
```

The index run should complete, and you should get results on local search pages: 
- <http://localhost:8000/ask-cfpb/search/?q=negotiate>
- <http://localhost:8000/es/obtener-respuestas/buscar/?q=credito+meses>
