### PR TITLE
Fix Ask CFPB export script to work with new answer_content streamfield

### DIFF
--- a/cfgov/ask_cfpb/scripts/export_ask_data.py
+++ b/cfgov/ask_cfpb/scripts/export_ask_data.py
@@ -62,8 +62,20 @@ def assemble_output():
         output['Language'] = page['language']
         output['RelatedResource'] = page['related_resource__title']
         output['Question'] = page['question'].replace('\x81', '')
-        output['Answer'] = clean_and_strip(
-            page['answer_content']).replace('\x81', '')
+        answer_streamfield = page['answer_content'].stream_data
+        answer_text = filter(
+            lambda item: item['type'] == 'text', answer_streamfield)
+        if answer_text:
+            answer = answer_text[0].get('value').get('content')
+        else:
+            # If no text block is found,
+            # there is either a HowTo or FAQ schema block.
+            # Both define a description field, so we'll use that here.
+            answer_schema = filter(
+                lambda item: item['type'] == 'how_to_schema' or
+                item['type'] == 'faq_schema', answer_streamfield)
+            answer = answer_schema[0].get('value').get('description')
+        output['Answer'] = clean_and_strip(answer).replace('\x81', '')
         output['ShortAnswer'] = clean_and_strip(page['short_answer'])
         output['URL'] = page['url_path'].replace('/cfgov', '')
         output['Live'] = page['live']

--- a/cfgov/ask_cfpb/scripts/export_ask_data.py
+++ b/cfgov/ask_cfpb/scripts/export_ask_data.py
@@ -63,8 +63,8 @@ def assemble_output():
         output['RelatedResource'] = page['related_resource__title']
         output['Question'] = page['question'].replace('\x81', '')
         answer_streamfield = page['answer_content'].stream_data
-        answer_text = filter(
-            lambda item: item['type'] == 'text', answer_streamfield)
+        answer_text = list(filter(
+            lambda item: item['type'] == 'text', answer_streamfield))
         if answer_text:
             answer = answer_text[0].get('value').get('content')
         else:

--- a/cfgov/ask_cfpb/tests/models/test_pages.py
+++ b/cfgov/ask_cfpb/tests/models/test_pages.py
@@ -16,6 +16,7 @@ from haystack.models import SearchResult
 from haystack.query import SearchQuerySet
 
 from wagtail.tests.utils import WagtailTestUtils
+from wagtail.wagtailcore.blocks import StreamValue
 
 from model_mommy import mommy
 
@@ -107,6 +108,12 @@ class ExportAskDataTests(TestCase, WagtailTestUtils):
             title='Mock question1')
         page.answer_base = answer
         page.question = 'Mock question1'
+        page.answer_content = StreamValue(
+            page.answer_content.stream_block, [{
+                'type': 'text',
+                'value': 'Mock answer'
+            }], True
+        )
         helpers.publish_page(page)
 
         output = assemble_output()[0]


### PR DESCRIPTION
## Overview
In https://github.com/cfpb/cfgov-refresh/pull/4982, we introduced a new StreamField `answer_content`, to replace the RichTextField `answer` on an `AnswerPage`.  In https://github.com/cfpb/cfgov-refresh/pull/5024 we did some clean-up and removed the deprecated `answer` field.  However, the changes I made to the export script in that PR introduced a bug, since I wasn't parsing the streamfield properly.  This PR fixes that.

## Notes
There's not a great way to convert streamfields with many different possible blocks / fields into an easy-to-read cell in an Excel spreadsheet, so I decided to only grab the `text` block.  However, we have a few AnswerPages with FAQ and HowTo blocks that don't define `text`, so in those cases I needed to grab the `description` from those blocks.  

This might be a bit brittle as those blocks evolve or the streamfield is used in different ways, so I'd personally lean towards not including the answer content in the export at all - but for now this feels like a reasonable fix.