### PR TITLE
Raise exceptions on New Relic status check failure

### DIFF
--- a/cfgov/alerts/newrelic_alerts.py
+++ b/cfgov/alerts/newrelic_alerts.py
@@ -21,6 +21,7 @@ class NewRelicAlertViolations(object):
         violations_url = (self.newrelic_url +
                           'alerts_violations.json?only_open=true')
         r = requests.get(violations_url, headers=headers)
+        r.raise_for_status()
         response_json = r.json()
 
         # Filter on the policy name


### PR DESCRIPTION
The send_new_relic_messages_to_sqs script used in our cf.gov-alerts-poll-newrelic job doesn't check to make sure that the API call to New Relic succeeds before it tries to access its JSON. We've seen quite a few job failures with unhelpful error messages ("ValueError: No JSON object could be decoded") and it would be more helpful to actually see what happens when this request fails.

This change uses the built-in [`raise_for_status()`](https://2.python-requests.org/en/master/user/quickstart/#json-response-content) method to first ensure that the response was successful.

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [X] Passes all existing automated tests
- [X] Any _change_ in functionality is tested
- [X] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: