### PR TITLE
smoke test cleanup

### DIFF
--- a/cfgov/scripts/http_smoke_test.py
+++ b/cfgov/scripts/http_smoke_test.py
@@ -39,8 +39,20 @@ ALLOWED_TIMEOUTS = 1
 FULL = False
 BASE = 'https://www.consumerfinance.gov'
 
-FULL_RUN = [
+# These are URL's that exist in a fresh copy of the site
+# after migrations and initial_data are run
+SHORT_RUN = [
     '/',
+    '/your-story/',
+    '/find-a-housing-counselor/',
+    '/know-before-you-owe/',
+    '/fair-lending/',
+    '/data-research/consumer-complaints/',
+]
+
+# These are URL's that are expected to be present in production
+# or a site running a recent dump of production data
+FULL_RUN = [
     '/es/',
     ('/es/obtener-respuestas/buscar'
      '?selected_facets=category_exact:enviar-dinero'),
@@ -55,9 +67,7 @@ FULL_RUN = [
     '/askcfpb/1791/',
     '/askcfpb/316/',
     '/askcfpb/44/',
-    '/your-story/',
     '/students/',
-    '/find-a-housing-counselor/',
     '/servicemembers/',
     '/consumer-tools/auto-loans/',
     '/paying-for-college/',
@@ -69,9 +79,7 @@ FULL_RUN = [
     '/consumer-tools/credit-reports-and-scores/',
     '/consumer-tools/debt-collection/',
     '/consumer-tools/prepaid-cards/',
-    '/know-before-you-owe/',
     '/mortgagehelp/',
-    '/fair-lending/',
     '/sending-money/',
     '/practitioner-resources/your-money-your-goals/',
     '/adult-financial-education/',
@@ -117,71 +125,6 @@ FULL_RUN = [
     '/eregulations/1026',
 ]
 
-# TODO: Document the logic for what gets included/excluded in short-run tests
-SHORT_RUN = [
-    '/',
-    '/es/',
-    # ('/es/obtener-respuestas/buscar'
-    #  '?selected_facets=category_exact:enviar-dinero'),'/complaint/',
-    '/learnmore/',
-    # '/complaint/'
-    '/ask-cfpb/',
-    '/your-story/',
-    '/students/',
-    '/find-a-housing-counselor/',
-    # '/servicemembers/',
-    '/consumer-tools/auto-loans/',
-    '/paying-for-college/',
-    ('/paying-for-college2/understanding-your-financial-aid-offer/'
-     'about-this-tool/'),
-    '/owning-a-home/',
-    '/retirement/before-you-claim/',
-    # '/retirement/before-you-claim/es/',
-    # '/consumer-tools/credit-reports-and-scores/',
-    # '/consumer-tools/debt-collection/',
-    # '/consumer-tools/prepaid-cards/',
-    '/know-before-you-owe/',
-    # '/mortgagehelp/',
-    '/fair-lending/',
-    '/sending-money/',
-    # '/educational-resources/your-money-your-goals/',
-    '/adult-financial-education/',
-    # '/educational-resources/youth-financial-education/',
-    '/practitioner-resources/library-resources/',
-    # '/educational-resources/tax-preparer-resources/',
-    '/consumer-tools/money-as-you-grow/',
-    # '/empowerment/',
-    '/practitioner-resources/resources-for-older-adults/',
-    # '/data-research/',
-    # '/data-research/research-reports/',
-    # '/data-research/cfpb-research-conference/',
-    '/data-research/consumer-complaints/',
-    '/data-research/hmda/',
-    # '/data-research/consumer-credit-trends/',
-    # '/data-research/credit-card-data/',
-    # '/data-research/cfpb-researchers/',
-    '/policy-compliance/',
-    # '/policy-compliance/rulemaking/',
-    # '/policy-compliance/guidance/',
-    # '/policy-compliance/guidance/implementation-guidance/',
-    # '/policy-compliance/enforcement/',
-    # '/policy-compliance/notice-opportunities-comment/',
-    # '/policy-compliance/amicus/',
-    '/about-us/',
-    # '/about-us/the-bureau/',
-    # '/about-us/budget-strategy/',
-    # '/about-us/payments-harmed-consumers/',
-    # '/about-us/blog/',
-    '/about-us/newsroom/',
-    # '/about-us/events/',
-    '/activity-log/',
-    # '/about-us/careers/',
-    '/about-us/careers/current-openings/',
-    # '/about-us/doing-business-with-us/',
-    # '/about-us/innovation/',
-    # '/about-us/contact-us/',
-]
-
 
 def check_urls(base, full=False):
     """
@@ -195,7 +138,7 @@ def check_urls(base, full=False):
     failures = []
     starter = time.time()
     if full:
-        url_list = FULL_RUN
+        url_list = SHORT_RUN + FULL_RUN
     else:
         url_list = SHORT_RUN
     for url_suffix in url_list:

--- a/cfgov/scripts/tests/test_smoke_tests.py
+++ b/cfgov/scripts/tests/test_smoke_tests.py
@@ -50,7 +50,9 @@ class HttpTests(unittest.TestCase):
         mock_response.status_code = 200
         mock_get.return_value = mock_response
         http_smoke_test.check_urls('pro1', full=True)
-        self.assertEqual(mock_get.call_count, len(http_smoke_test.FULL_RUN))
+        self.assertEqual(mock_get.call_count,
+                         len(http_smoke_test.SHORT_RUN +
+                             http_smoke_test.FULL_RUN))
 
     @mock.patch('scripts.http_smoke_test.requests.get')
     def test_http_fail_short(self, mock_get):
@@ -66,7 +68,9 @@ class HttpTests(unittest.TestCase):
         mock_response.status_code = 404
         mock_get.return_value = mock_response
         http_smoke_test.check_urls('pro1', full=True)
-        self.assertEqual(mock_get.call_count, len(http_smoke_test.FULL_RUN))
+        self.assertEqual(mock_get.call_count,
+                         len(http_smoke_test.SHORT_RUN +
+                             http_smoke_test.FULL_RUN))
 
     @mock.patch('scripts.http_smoke_test.requests.get')
     def test_http_fail_timeout_short(self, mock_get):
@@ -78,7 +82,9 @@ class HttpTests(unittest.TestCase):
     def test_http_fail_timeout_full(self, mock_get):
         mock_get.side_effect = requests.exceptions.Timeout
         http_smoke_test.check_urls('pro1', full=True)
-        self.assertEqual(mock_get.call_count, len(http_smoke_test.FULL_RUN))
+        self.assertEqual(mock_get.call_count,
+                         len(http_smoke_test.SHORT_RUN +
+                             http_smoke_test.FULL_RUN))
 
     @mock.patch('scripts.http_smoke_test.requests.get')
     def test_allowed_timeouts(self, mock_get):


### PR DESCRIPTION
This pares down the SHORT_RUN list to just URLs that resolve in a brand new site database (post migrations and after running initial_data, removes a bunch of commented-out URLs, and slightly re-organizes the script itself.

This effort was only subtractive-- I did not go looking for new URLs to add.

Open question: is short list still useful at this point?

## Removals

- URL's that 404 when run against a fresh site database have been removed from SHORT_RUN
- A bunch of commented-out URLs
- URL's that exist in both lists, have been removed from FULL_RUN. Running with `--full` now tests the URLs in both lists.

## Changes

- Running with `--full` now tests the URLs in both lists, meaning we don't need to duplicate URLs.

## Testing

`python http_smoke_test.py --base http://localhost:8000 -v` and 
`python http_smoke_test.py --base http://localhost:8000 -v --full` should be enough to tell you that the script is functioning as intended.

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [ ] Chrome on desktop
- [ ] Firefox
- [ ] Safari on macOS
- [ ] Edge
- [ ] Internet Explorer 9, 10, and 11
- [ ] Safari on iOS
- [ ] Chrome on Android

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
