### PR TITLE
Recommend creation of cfpb Postgres schema

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -157,11 +157,12 @@ Once it's installed, you can configure it to run as a service:
 brew services start postgresql
 ```
 
-Then create the database and associated user:
+Then create the database, associated user, and schema for that user:
 
 ```bash
 dropdb --if-exists cfgov && dropuser --if-exists cfpb
 createuser cfpb && createdb -O cfpb cfgov
+psql postgres://cfpb@localhost/cfgov -c 'CREATE SCHEMA cfpb'
 ```
 
 If you absolutely need to use SQLite, you'll need to update your `.env` file


### PR DESCRIPTION
Our live cf.gov environments connect to AWS RDS Postgres instances that are configured with a "cfpb" user and also a "cfpb" schema. The existence of this schema means that all new database tables (e.g. ones created by Django) are created in this cfpb schema.

Production database dumps thus refer to tables named "cfpb.something", and include a statement to create the "cfpb" schema. When running the local refresh-data.sh script, that loads one of these dumps, tables are created in this schema.

On the other hand, if you run the initial-data.sh script, that attempts to create tables locally without using a production dump, if you don't have a "cfpb" schema, the tables are instead created in the "public" schema. See https://www.postgresql.org/docs/10/ddl-schemas.html for documentation on why this happens.

We want local development to be as consistent with production as possible, and we also want use of new cf.gov environments using initial-data.sh to work consistently with ones using production dumps.

For this reason, we should recommend and document the creation of a "cfpb" schema as part of our Postgres setup. This change adds that line to the documentation.

## Notes

I'm not quite sure what we should do for this with the Docker setup, either the current one @willbarton or the one being worked on by @rosskarchner in #5051. Would it be possible to add a statement like this there?

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [X] Passes all existing automated tests
- [X] Any _change_ in functionality is tested
- [X] Project documentation has been updated
- [X] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: