### PR TITLE
Remove cf-icon-path variable

### DIFF
--- a/cfgov/unprocessed/css/main.less
+++ b/cfgov/unprocessed/css/main.less
@@ -20,9 +20,6 @@
 @import (less) 'cf-expandables.less';
 @import (less) 'cf-tables.less';
 
-// Icon font path
-@cf-icon-path: '/static/fonts';
-
 // Webfont variables
 // This is the path for self-hosted fonts.
 @cf-fonts-path: '/static/fonts';

--- a/cfgov/unprocessed/css/on-demand/footer.less
+++ b/cfgov/unprocessed/css/on-demand/footer.less
@@ -21,9 +21,6 @@
 }
 @import (less) 'cf-typography.less';
 
-// // Icon font path
-@cf-icon-path: '/static/fonts';
-
 // Webfont variables
 // This is the path for self-hosted fonts.
 @cf-fonts-path: '/static/fonts';

--- a/cfgov/unprocessed/css/on-demand/header.less
+++ b/cfgov/unprocessed/css/on-demand/header.less
@@ -21,9 +21,6 @@
     @import (less) 'cf-typography.less';
 }
 
-// Icon font path
-@cf-icon-path: '/static/fonts';
-
 // Webfont variables
 // This is the path for self-hosted fonts.
 @cf-fonts-path: '/static/fonts';


### PR DESCRIPTION
This variable should not be needed anymore, since v10 CF removes the cf-icon webfonts. CF complimentary PR here https://github.com/cfpb/capital-framework/pull/933

## Removals

- Remove cf-icon-path variable
