### PR TITLE
Stop redirects for Ask search

### DIFF
--- a/cfgov/jinja2/v1/_includes/ask/ask-search.html
+++ b/cfgov/jinja2/v1/_includes/ask/ask-search.html
@@ -20,7 +20,7 @@
 
 {% macro render(q='', language='en', show_label=True, autocomplete=True) %}
 <aside class="o-search-bar">
-    <form method="get" action="{{ _('/ask-cfpb/search') }}">
+    <form method="get" action="{{ _('/ask-cfpb/search/') }}">
         {% if show_label %}
         <label for="o-search-bar_query">
             <h3>{{ _('Search for your question') }}</h3>


### PR DESCRIPTION
Our ask-search.html template makes a search request without a trailing slash,
which invokes Django's [APPEND_SLASH](https://docs.djangoproject.com/en/dev/ref/settings/#append-slash) default setting.
The result is a redirect for every base search request.

Adding a slash to the template stops the 301s.

## Testing
- Pull in the branch locally and go to <http://localhost:8000/es/obtener-respuestas/> 
- Open dev tools to the network panel, then enter a search term on the page (such as `credito`) and enter.

The network panel should show a 200 response, not 301 as happens currently on the live page.

## Note
- The search URL in the template is translated for Spanish pages, but we don't need to touch the django.po file because there was already a translation for the search URL that included the slash.
- Thanks to @lfatty for spotting this.
