### PR TITLE
Bump retirement from 0.9.0 to 0.10.0

### DIFF
--- a/requirements/optional-public.txt
+++ b/requirements/optional-public.txt
@@ -1,6 +1,6 @@
 https://github.com/cfpb/college-costs/releases/download/2.7.4/college_costs-2.7.4-py2.py3-none-any.whl
 https://github.com/cfpb/owning-a-home-api/releases/download/0.12.1/owning_a_home_api-0.12.1-py2.py3-none-any.whl
-https://github.com/cfpb/retirement/releases/download/0.9.0/retirement-0.9.0-py2-none-any.whl
+https://github.com/cfpb/retirement/releases/download/0.10.0/retirement-0.10.0-py2.py3-none-any.whl
 https://github.com/cfpb/ccdb5-api/releases/download/1.1.7/ccdb5_api-1.1.7-py2-none-any.whl
 https://github.com/cfpb/ccdb5-ui/releases/download/1.3.2/ccdb5_ui-1.3.2-py2.py3-none-any.whl
 https://github.com/cfpb/django-college-costs-comparison/releases/download/1.11.2/comparisontool-1.11.2-py2-none-any.whl


### PR DESCRIPTION
This change bumps the retirement satellite app to the newest release [0.10.0](https://github.com/cfpb/retirement/releases/tag/0.10.0).

This adds Python 3 support to this package. 🍰 🍟 

## Testing

To test, visit http://localhost:8000/consumer-tools/retirement/before-you-claim/ locally.

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [X] Passes all existing automated tests
- [X] Any _change_ in functionality is tested
- [X] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [X] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: