### PR TITLE
Add link to credit card agreements for Q4 2018

### DIFF
--- a/cfgov/agreements/jinja2/agreements/index.html
+++ b/cfgov/agreements/jinja2/agreements/index.html
@@ -52,9 +52,18 @@
                 <ul class="m-list m-list__links u-mt15">
                     <li class="m-list m-list__links">
                         <a class="a-link a-link__icon"
+                        href="https://files.consumerfinance.gov/a/assets/Credit_Card_Agreements_2018_Q4.zip">
+                            <span class="a-link_text">
+                                Download all most recent agreements (Q4-2018)
+                            </span>
+                            {{ svg_icon('download') }}
+                        </a>
+                    </li>
+                    <li class="m-list m-list__links">
+                        <a class="a-link a-link__icon"
                         href="https://files.consumerfinance.gov/a/assets/Credit_Card_Agreements_2018_Q3.zip">
                             <span class="a-link_text">
-                                Download all most recent agreements (Q3-2018)
+                                Archived Q3-2018 agreements
                             </span>
                             {{ svg_icon('download') }}
                         </a>


### PR DESCRIPTION
The new agreements were just provided by RMR and uploaded to S3.

When this change is deployed, we should also run the script to load the new data.

## Additions

- Link to latest set of quarterly Credit Card Agreements data

## Screenshots

<img width="683" alt="Screen Shot 2019-06-21 at 3 13 34 PM" src="https://user-images.githubusercontent.com/4295388/59945976-2ff1d200-9437-11e9-9bdc-4e4d2f449caf.png">


## Todos

- When this change is deployed, I will run the `cf.gov-load-agreements-data` job to load the latest agreements into the finder.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: