### PR TITLE
Update ccdb5-api to 1.1.9 for Python 3 support

### DIFF
--- a/requirements/optional-public.txt
+++ b/requirements/optional-public.txt
@@ -1,7 +1,7 @@
 https://github.com/cfpb/college-costs/releases/download/2.7.4/college_costs-2.7.4-py2.py3-none-any.whl
 https://github.com/cfpb/owning-a-home-api/releases/download/0.12.1/owning_a_home_api-0.12.1-py2.py3-none-any.whl
 https://github.com/cfpb/retirement/releases/download/0.10.0/retirement-0.10.0-py2.py3-none-any.whl
-https://github.com/cfpb/ccdb5-api/releases/download/1.1.7/ccdb5_api-1.1.7-py2-none-any.whl
+https://github.com/cfpb/ccdb5-api/releases/download/1.1.9/ccdb5_api-1.1.9-py2.py3-none-any.whl
 https://github.com/cfpb/ccdb5-ui/releases/download/1.3.2/ccdb5_ui-1.3.2-py2.py3-none-any.whl
 https://github.com/cfpb/django-college-costs-comparison/releases/download/1.11.2/comparisontool-1.11.2-py2-none-any.whl
 https://github.com/cfpb/teachers-digital-platform/releases/download/1.1.2/teachers_digital_platform-1.1.2-py2.py3-none-any.whl


### PR DESCRIPTION
This change will update the ccdb5-api package to version 1.1.9, which brings Python 3.6 support with it.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

# ~~✅ PR UPDATES THE LAST SATELLITE APP TO PYTHON 3!~~