### PR TITLE
Update comparisontool from 1.11.2 to 1.12.0

### DIFF
--- a/requirements/optional-public.txt
+++ b/requirements/optional-public.txt
@@ -3,5 +3,5 @@ https://github.com/cfpb/owning-a-home-api/releases/download/0.12.1/owning_a_home
 https://github.com/cfpb/retirement/releases/download/0.10.0/retirement-0.10.0-py2.py3-none-any.whl
 https://github.com/cfpb/ccdb5-api/releases/download/1.1.9/ccdb5_api-1.1.9-py2.py3-none-any.whl
 https://github.com/cfpb/ccdb5-ui/releases/download/1.3.2/ccdb5_ui-1.3.2-py2.py3-none-any.whl
-https://github.com/cfpb/django-college-costs-comparison/releases/download/1.11.2/comparisontool-1.11.2-py2-none-any.whl
+https://github.com/cfpb/django-college-costs-comparison/releases/download/1.12.0/comparisontool-1.12.0-py2.py3-none-any.whl
 https://github.com/cfpb/teachers-digital-platform/releases/download/1.1.2/teachers_digital_platform-1.1.2-py2.py3-none-any.whl


### PR DESCRIPTION
Uses new universal wheel for Python 2/3 support.

## Testing

Visit http://localhost:8000/paying-for-college/compare-financial-aid-and-college-cost/. For search to work you'll have to populate your local search index using the instructions [here](https://github.com/cfpb/django-college-costs-comparison#installation).

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [X] Passes all existing automated tests
- [X] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [X] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: