### PR TITLE
Make the optional not optional for tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -117,6 +117,7 @@ setenv=
     WAGTAIL_SHARING_HOSTNAME=content.localhost
 deps=
     -r{toxinidir}/requirements/libraries.txt
+    -r{toxinidir}/requirements/optional-public.txt
     -r{toxinidir}/requirements/postgres.txt
     -r{toxinidir}/requirements/test.txt
 commands=


### PR DESCRIPTION
This PR makes our "optional-public.txt" requirements non-optional for tests.

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
