### PR TITLE
Pin django-js-asset package to match TDP

### DIFF
--- a/requirements/libraries.txt
+++ b/requirements/libraries.txt
@@ -6,6 +6,8 @@ django-csp==3.4
 django-extensions==2.1.3
 django-flags==4.1.0
 django-haystack==2.7.0
+# django-js-asset is required by teachers-digital-platform
+django-js-asset==1.1.0
 django-localflavor==1.6.2
 # django-mptt is required by teachers-digital-platform
 django-mptt==0.9.0


### PR DESCRIPTION
The [TDP satellite app](https://github.com/cfpb/teachers-digital-platform/) includes pinned package dependencies for `django-mptt==0.9.0` and `django-js-asset==1.1.0`. Currently cfgov-refresh only includes the pinned dependency on django-mptt.

The django-mptt dependency includes [an unpinned dependency](https://github.com/django-mptt/django-mptt/blob/615cd547625bef2ce86c46d7e071787f194ac924/setup.py#L20) on django-js-asset. There have been [several releases](https://pypi.org/project/django-js-asset/#history) of django-js-asset since the 1.1.0 version. This means that, depending on how the cfgov-refresh and TDP dependencies are installed, you might end up with a later version of django-js-asset, that doesn't match what is specified in TDP.

For this reason, this PR fixes the django-js-asset here in cfgov-refresh, to ensure that it always matches what is specified in TDP.

## Testing

Create a virtualenv using Python 3 and try doing

```sh
$ pip install -r requirements/local.txt -r requirements/optional-public.txt
```

Doing this produces a warning on master (`ERROR: teachers-digital-platform 1.0.33 has requirement django-js-asset==1.1.0, but you'll have django-js-asset 1.2.2 which is incompatible.`) but none on this branch.

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [X] Passes all existing automated tests
- [X] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: