### PR TITLE
Video player: Prevent cursor interaction on a hidden image

### DIFF
--- a/cfgov/unprocessed/css/video-player.less
+++ b/cfgov/unprocessed/css/video-player.less
@@ -40,6 +40,7 @@
     .hide-on_video-playing {
         opacity: 0;
         height: 0;
+        pointer-events: none;
     }
 
     .show-on_video-playing {


### PR DESCRIPTION
When a video is playing there is an invisible image on the page that overlays content. This prevents any links in that content from being clickable.

<img width="561" alt="Screen Shot 2019-06-25 at 9 09 49 AM" src="https://user-images.githubusercontent.com/704760/60101889-92461d80-972a-11e9-8892-b40823ac0231.png">

## Changes

- Add `pointer-events: none;` to hidden image's container.

## Testing

1. `gulp build` should pass. I'm not sure how to test this without a livestream happening.
