### PR TITLE
Expand our videos' iframe container on all screen sizes

### DIFF
--- a/cfgov/unprocessed/css/video-player.less
+++ b/cfgov/unprocessed/css/video-player.less
@@ -121,11 +121,20 @@
     margin: auto;
 }
 
+.video-player_iframe-container {
+    height: 100%;
+    margin: 0;
+}
+
+.video-player_video-actions-container {
+    right: 0;
+    left: auto;
+}
+
 .respond-to-min( @bp-sm-min, {
     .video-player_video-actions-container {
         position: absolute;
         top: 0;
-        left: @video-width__px;
     }
 
     .video-player .m-social-media,
@@ -210,20 +219,6 @@
         .u-flexible-container_inner();
     }
 } );
-
-
-.respond-to-min( @bp-xl-min, {
-    .video-player_iframe-container {
-        height: 100%;
-        margin: 0;
-    }
-
-    .video-player_video-actions-container {
-        right: 0;
-        left: auto;
-    }
-} );
-
 
 // Special styles for playing within an FCM
 .o-featured-content-module {

--- a/cfgov/unprocessed/css/video-player.less
+++ b/cfgov/unprocessed/css/video-player.less
@@ -33,8 +33,6 @@
 }
 
 .video-player.video-playing {
-    // @black not used because it's not totally black.
-    background-color: #000;
     overflow: visible;
 
     .hide-on_video-playing {
@@ -119,6 +117,8 @@
     opacity: 0;
     height: 0;
     margin: auto;
+    // @black not used because it's not totally black.
+    background-color: #000;
 }
 
 .video-player_iframe-container {
@@ -180,7 +180,8 @@
 .video-player_video-actions-container {
     .grid_wrapper();
 
-    margin: 1em 0;
+    padding-top: unit( @grid_gutter-width / 2 / @base-font-size-px, em );
+    padding-bottom: unit( @grid_gutter-width / 2 / @base-font-size-px, em );
     color: @white;
 
     .m-social-media_heading {
@@ -247,6 +248,12 @@
         margin-top: 36px;
     }
 }
+
+.respond-to-max( @bp-xs-max, {
+    .o-featured-content-module .video-player_video-actions-container {
+        display: none;
+    }
+} );
 
 .respond-to-min( @bp-sm-min, {
     .o-featured-content-module.video-playing {


### PR DESCRIPTION
For some reason we were only adjusting video iframe's height and video controls position on larger screens. They are now adjusted on all screen sizes.

I have tested these changes on a handful of FCM and non-FCM videos and it seems okay but I could use more eyes if anyone's able.

- http://0.0.0.0:8000/consumer-tools/managing-someone-elses-money/
- http://0.0.0.0:8000/about-us/blog/mortgage-closing-scams-how-protect-yourself-and-your-closing-funds/
- https://[mattermost]/cfpb/pl/841dszdrrtfx5dpamz7tq7j89h

**Before:**

<img width="924" alt="Screen Shot 2019-06-25 at 3 36 14 PM" src="https://user-images.githubusercontent.com/1060248/60127772-04385a00-975f-11e9-8780-06790f4f1da4.png">

**After:**

<img width="940" alt="Screen Shot 2019-06-25 at 3 35 08 PM" src="https://user-images.githubusercontent.com/1060248/60127781-08fd0e00-975f-11e9-9eff-90aa5634e402.png">
