### PR TITLE
Add domain verification files for FB and Bing

### DIFF
--- a/cfgov/core/static/BingSiteAuth.xml
+++ b/cfgov/core/static/BingSiteAuth.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<users>
+	<user>2EBB86E3B1E6E544E74988A50B5C0038</user>
+</users>

--- a/cfgov/core/static/lln8595c61g9qnvuwvtlcwo1k6kem8.html
+++ b/cfgov/core/static/lln8595c61g9qnvuwvtlcwo1k6kem8.html
@@ -1,0 +1,1 @@
+lln8595c61g9qnvuwvtlcwo1k6kem8


### PR DESCRIPTION
This commit adds two domain verification files used by FB and Bing to confirm our ownership of this website. We already serve these files on cf.gov, but currently they come from another internal repository.

To verify, visit these URLs with a local server:

http://localhost:8000/static/BingSiteAuth.xml
http://localhost:8000/static/lln8595c61g9qnvuwvtlcwo1k6kem8.html

Our Apache configuration already contains Alias directives that will make these work at the site root:

https://www.consumerfinance.gov/BingSiteAuth.xml
https://www.consumerfinance.gov/lln8595c61g9qnvuwvtlcwo1k6kem8.html

## Notes

This follows the existing pattern of similar site-root files robots.txt and favicon.ico, which also live in cfgov/core/static.

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [X] Passes all existing automated tests
- [X] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [X] Project documentation has been updated
- [X] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: