### PR TITLE
Bump wagtail-flags to 4.1.0b2

### DIFF
--- a/requirements/libraries.txt
+++ b/requirements/libraries.txt
@@ -36,7 +36,7 @@ unicodecsv==0.14.1
 unipath>=1.1,<=2.0
 urllib3==1.25.2
 wagtail-autocomplete==0.1.1
-wagtail-flags==4.1.0b1
+wagtail-flags==4.1.0b2
 wagtail-inventory==0.7
 wagtail-sharing==0.7
 wagtail-treemodeladmin==1.0.4


### PR DESCRIPTION
Wagtail-Flags 4.1.0b1 did not include CSS files in the package. This caused errors with ManifestStaticFilesStorage when trying to access the Wagtail admin. This PR bumps Wagtail-Flags to 4.1.0b2 to fix this.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
