### PR TITLE
add mod-wsgi to deployment requirements

### DIFF
--- a/requirements/deployment.txt
+++ b/requirements/deployment.txt
@@ -1,3 +1,4 @@
 -r base.txt
 -r postgres.txt
+mod-wsgi==4.6.7
 newrelic==4.18.0.118


### PR DESCRIPTION
This is to support a Ship it Better initiative to install mod-wsgi as a python requirement, instead of as a yum/RHEL requirement.



## Additions

- mod-wsgi==4.6.7 in deployment.txt

## Todos

- Once this is incorporated in releases, we'll be able to adjust our deployment scripts to use this mod_wsgi.

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [ ] Chrome on desktop
- [ ] Firefox
- [ ] Safari on macOS
- [ ] Edge
- [ ] Internet Explorer 9, 10, and 11
- [ ] Safari on iOS
- [ ] Chrome on Android

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
