### PR TITLE
Restore new versions of Django and Wagtail Flags

### DIFF
--- a/requirements/libraries.txt
+++ b/requirements/libraries.txt
@@ -4,7 +4,7 @@ dj-database-url==0.5.0
 djangorestframework==3.6.4
 django-csp==3.4
 django-extensions==2.1.3
-django-flags==4.1.0
+django-flags==4.2.2
 django-haystack==2.7.0
 # django-js-asset is required by teachers-digital-platform
 django-js-asset==1.1.0
@@ -36,7 +36,7 @@ unicodecsv==0.14.1
 unipath>=1.1,<=2.0
 urllib3==1.25.2
 wagtail-autocomplete==0.1.1
-wagtail-flags==4.0.2
+wagtail-flags==4.1.0b2
 wagtail-inventory==0.7
 wagtail-sharing==0.7
 wagtail-treemodeladmin==1.0.4


### PR DESCRIPTION
Now that Django-Flags 4.1.2 is released and fixes the critical bug that broke our database flags, this change restores the latest versions.

This reverts the reversion in #5100.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
