### PR TITLE
Bump ccdb5-api from version 1.1.9 to 1.1.10

### DIFF
--- a/requirements/optional-public.txt
+++ b/requirements/optional-public.txt
@@ -1,6 +1,6 @@
 https://github.com/cfpb/owning-a-home-api/releases/download/0.12.1/owning_a_home_api-0.12.1-py2.py3-none-any.whl
 https://github.com/cfpb/retirement/releases/download/0.10.0/retirement-0.10.0-py2.py3-none-any.whl
-https://github.com/cfpb/ccdb5-api/releases/download/1.1.9/ccdb5_api-1.1.9-py2.py3-none-any.whl
+https://github.com/cfpb/ccdb5-api/releases/download/1.1.10/ccdb5_api-1.1.10-py2.py3-none-any.whl
 https://github.com/cfpb/ccdb5-ui/releases/download/1.3.4/ccdb5_ui-1.3.4-py2.py3-none-any.whl
 https://github.com/cfpb/django-college-costs-comparison/releases/download/1.12.0/comparisontool-1.12.0-py2.py3-none-any.whl
 https://github.com/cfpb/teachers-digital-platform/releases/download/1.1.3/teachers_digital_platform-1.1.3-py2.py3-none-any.whl


### PR DESCRIPTION
This PR bumps the version of the optional ccdb5-api package from 1.1.9 to the new [1.1.10](https://github.com/cfpb/ccdb5-api/releases/tag/1.1.10) release. This release makes only minor changes including one required to fix a failing test to support #5083.

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [X] Passes all existing automated tests
- [X] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [X] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [X] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: