### PR TITLE
Video player styles cleanup

### DIFF
--- a/cfgov/jinja2/v1/_includes/macros/video-player.html
+++ b/cfgov/jinja2/v1/_includes/macros/video-player.html
@@ -47,21 +47,21 @@
     {% endif %}
     {% set button_pos   = options.button_pos or 'center' %}
     {% set is_flexible  = ( options.video.width or options.video.height ) is not defined %}
-    <div class="video-player
-                video-player__youtube
+    <div class="o-video-player
+                o-video-player__youtube
                 {{ 'o-featured-content-module_visual' if is_flexible == false else '' }}"
          data-id="{{ video_id }}"
          data-src="{{ video_url }}"
          data-width="{{ options.video.width if options.video.width else '' }}"
          data-height="{{ options.video.height if options.video.height else '' }}">
         {{ caller() | safe if caller else '' }}
-        <div class="video-player_video-container
+        <div class="o-video-player_video-container
                     show-on_video-playing
-                    {{ 'video-player_video-container__flexible' if is_flexible else '' }}">
-            <div class="video-player_iframe-container"></div>
-            <div class="video-player_video-actions-container">
-                <div class="video-player_video-actions">
-                    <button class="a-btn video-player_close-btn" href="/">
+                    {{ 'o-video-player_video-container__flexible' if is_flexible else '' }}">
+            <div class="o-video-player_iframe-container"></div>
+            <div class="o-video-player_video-actions-container">
+                <div class="o-video-player_video-actions">
+                    <button class="a-btn o-video-player_close-btn" href="/">
                         Close {{ svg_icon('close-round') }}
                     </button>
                 </div>
@@ -77,9 +77,9 @@
                 {% endif %}
             </div>
         </div>
-        <div class="video-player_image-container
+        <div class="o-video-player_image-container
                     hide-on_video-playing">
-            <button class="video-player_play-btn video-player_play-btn__{{ button_pos }}"
+            <button class="o-video-player_play-btn o-video-player_play-btn__{{ button_pos }}"
                href="{{ video_url }}"
                target="_blank"
                rel="noopener noreferrer">
@@ -88,7 +88,7 @@
                    in hidden element below for screen readers. #}
                 <span class="u-visually-hidden">Play video</span>
             </button>
-            <img class="video-player_image
+            <img class="o-video-player_image
                         {{ image_loaded_class | default }}
                         {{ 'o-featured-content-module_img' if is_flexible == false else '' }}"
                  alt=""

--- a/cfgov/unprocessed/css/pages/ask.less
+++ b/cfgov/unprocessed/css/pages/ask.less
@@ -45,7 +45,7 @@
             }
         } );
     }
-    
+
     .search-bar {
         margin-top: unit( @grid_gutter-width / @base-font-size-px, em );
 
@@ -153,7 +153,7 @@
         .video_player-row + .row,
         .table_block-row + .row,
         .row + .row > .o-table:first-child,
-        .row + .row > .video-player:first-child {
+        .row + .row > .o-video-player:first-child {
           margin-top: unit( @grid_gutter-width / @base-font-size-px, em );
         }
 
@@ -181,7 +181,7 @@
         .schema-block > .schema-block_item:first-child > h2:first-child {
             margin-top:0;
         }
-    }  
+    }
 
     .respond-to-max(@bp-xs-max, {
         .inset-row {
@@ -197,7 +197,7 @@
         .related-questions {
             margin: unit( @grid_gutter-width / @base-font-size-px, em ) 0;
         }
-    } ); 
+    } );
 
     .o-sidebar-content {
         .about-us-text,
@@ -230,7 +230,7 @@
         }
 
     }
-    
+
 
     .m-list_item__last {
         padding-top: unit( 7px / @base-font-size-px, em );
@@ -308,7 +308,7 @@
         .m-hero {
             border-bottom: 1px solid @block__border;
         }
-           
+
     } );
     .question-categories {
         .respond-to-min( @bp-sm-min, {
@@ -331,7 +331,7 @@
 
                     span {
                         display: table-cell;
-                        
+
                         &:first-child {
                             padding-right: @grid_gutter-width / 4;
                         }
@@ -382,7 +382,7 @@
 
     .question_summary {
         border-bottom: 1px solid @block__border-bottom;
-    }    
+    }
 }
 
 .ask-cfpb-page__search {
@@ -438,7 +438,7 @@
         .article-sections {
             margin-top: unit( @grid_gutter-width * 2 / @base-font-size-px, em );
         }
-    } ); 
+    } );
 
     .respond-to-max(@bp-xs-max, {
         .lead-paragraph {
@@ -453,6 +453,6 @@
                 margin-top: unit( @grid_gutter-width * 1.5 / @base-font-size-px, em );
             }
         }
-    } ); 
+    } );
 }
 

--- a/cfgov/unprocessed/css/video-player.less
+++ b/cfgov/unprocessed/css/video-player.less
@@ -1,7 +1,7 @@
 
 /* ==========================================================================
    cfgov-refresh
-   video-player
+   o-video-player
    ========================================================================== */
 
 /* topdoc
@@ -20,19 +20,15 @@
 // Variable used to set the size of the play button's SVG icon.
 @play-btn-icon-size: 1.875em;
 
-// Variable used to help center the video container.
-@share-width__px: 130px;
+// Magic number: height of standard button.
+@standard-btn-height__px: 36px;
 
-// Variable used for positioning of share icons
-@video-width__px: 568px;
-
-
-.video-player {
+.o-video-player {
     overflow: hidden;
     background: @white;
 }
 
-.video-player.video-playing {
+.o-video-player.video-playing {
     overflow: visible;
 
     .hide-on_video-playing {
@@ -50,7 +46,7 @@
 
 // Video image related styles
 
-.video-player_image-container {
+.o-video-player_image-container {
     position: relative;
     // @black not used because it's not totally black.
     background-color: #000;
@@ -59,8 +55,8 @@
     width: 100%;
 }
 
-.video-player_image {
-    // Remove space below image created by inline display spacing
+.o-video-player_image {
+    // Remove space below image created by inline display spacing.
     display: block;
     opacity: 0;
     transition: opacity .25s;
@@ -71,25 +67,25 @@
     }
 }
 
-.video-player_play-btn {
+.o-video-player_play-btn {
     width: @play-btn-size__px;
     height: @play-btn-size__px;
     border: 2px solid @gray-5;
     border-radius: 100%;
     position: absolute;
     z-index: 3;
-    background-color: rgba(16, 24, 32, 0.75); // CFPB Black (#101820) at 80% opacity
+    background-color: rgba( 16, 24, 32, 0.75 ); // CFPB Black (#101820) at 80% opacity
     color: @white;
     font-size: @play-btn-icon-size;
 
     &:hover {
-        background-color: rgba(0, 114, 206, 0.75); // Pacific (#0072ce) at 80% opacity
+        background-color: rgba( 0, 114, 206, 0.75 ); // Pacific (#0072ce) at 80% opacity
     }
 
     &__center {
         left: 50%;
         top: 50%;
-        transform: translate(-50%, -50%);
+        transform: translate( -50%, -50% );
     }
 
     &__bottomRight {
@@ -108,12 +104,12 @@
 }
 
 .lt-ie9 {
-    .video-player_play-btn {
+    .o-video-player_play-btn {
         margin-left: -1 * @play-btn-size__px;
     }
 }
 
-.video-player_video-container {
+.o-video-player_video-container {
     opacity: 0;
     height: 0;
     margin: auto;
@@ -121,39 +117,39 @@
     background-color: #000;
 }
 
-.video-player_iframe-container {
+.o-video-player_iframe-container {
     height: 100%;
     margin: 0;
 }
 
-.video-player_video-actions-container {
+.o-video-player_video-actions-container {
     right: 0;
     left: auto;
 }
 
 .respond-to-min( @bp-sm-min, {
-    .video-player_video-actions-container {
+    .o-video-player_video-actions-container {
         position: absolute;
         top: 0;
     }
 
-    .video-player .m-social-media,
-    .video-player_video-actions {
+    .o-video-player .m-social-media,
+    .o-video-player_video-actions {
         margin-bottom: @grid_gutter-width;
     }
 } );
 
-.video-player_video-container__flexible {
-    .video-player_iframe-container {
+.o-video-player_video-container__flexible {
+    .o-video-player_iframe-container {
         width: auto;
         .u-flexible-container();
     }
 
-    .video-player_iframe {
+    .o-video-player_iframe {
         .u-flexible-container_inner();
     }
 
-    .video-player_video-actions-container {
+    .o-video-player_video-actions-container {
         position: relative;
         top: 0;
         left: 0;
@@ -167,7 +163,7 @@
     }
 
     .m-social-media,
-    .video-player_video-actions {
+    .o-video-player_video-actions {
         margin-bottom: 0;
         .grid_column(6);
 
@@ -177,7 +173,7 @@
     }
 }
 
-.video-player_video-actions-container {
+.o-video-player_video-actions-container {
     .grid_wrapper();
 
     padding-top: unit( @grid_gutter-width / 2 / @base-font-size-px, em );
@@ -193,7 +189,7 @@
     }
 }
 
-.video-player .m-social-media {
+.o-video-player .m-social-media {
     .cf-icon-svg {
         fill: @white;
     }
@@ -204,53 +200,51 @@
     }
 }
 
-.video-player .m-social-media,
-.video-player_video-actions {
+.o-video-player .m-social-media,
+.o-video-player_video-actions {
     .respond-to-max( @bp-xs-max, {
         margin-top: unit( @grid_gutter-width / 2 / @base-font-size-px, em );
     } );
 }
 
 .respond-to-max( @bp-xs-max, {
-    .video-player_iframe-container {
+    .o-video-player_iframe-container {
         .u-flexible-container();
     }
 
-    .video-player_iframe {
+    .o-video-player_iframe {
         .u-flexible-container_inner();
     }
 } );
 
-// Special styles for playing within an FCM
+// Special styles for playing within a Featured Content Module (FCM).
 .o-featured-content-module {
-    .video-player_video-actions-container {
+    .o-video-player_video-actions-container {
         margin: 0;
         padding: 0;
-        // Magic number: height of standard button + 1px border around FCM.
-        top: -37px;
+        // Magic number: height of standard button and 1px border around FCM.
+        top: ( @standard-btn-height__px + 1px ) * -1;
     }
 
-    .video-player_video-actions {
+    .o-video-player_video-actions {
         // These properties are required to create a masked window for the
         // close button to animate up into.
-        // Magic number: height of standard button.
-        height: 36px;
+        height: @standard-btn-height__px;
         margin: 0;
         overflow: hidden;
     }
 
-    .video-player_close-btn {
+    .o-video-player_close-btn {
         border-bottom-right-radius: 0;
         border-bottom-left-radius: 0;
         display: block;
         // Pushes button out of masked window when not playing.
-        // Magic number: height of standard button.
-        margin-top: 36px;
+        margin-top: @standard-btn-height__px;
     }
 }
 
 .respond-to-max( @bp-xs-max, {
-    .o-featured-content-module .video-player_video-actions-container {
+    .o-featured-content-module .o-video-player_video-actions-container {
         display: none;
     }
 } );
@@ -261,14 +255,14 @@
         transition: 0.5s all ease-out;
         min-height: 0;
 
-        .video-player_close-btn {
+        .o-video-player_close-btn {
             // Moves button up into the masked window when playing.
             margin-top: 0;
             transition: 0.5s margin-top ease-out;
         }
     }
 
-    .o-featured-content-module_visual .video-player_iframe {
+    .o-featured-content-module_visual .o-video-player_iframe {
         opacity: 0;
         transition-delay: 0.5s;
         transition-duration: 0s;
@@ -281,7 +275,7 @@
         width: 100%;
         transition: 0.5s all ease-out;
 
-        .video-player_iframe {
+        .o-video-player_iframe {
             height: 100%;
             width: 100%;
             opacity: 1;

--- a/cfgov/unprocessed/js/modules/VideoPlayer.js
+++ b/cfgov/unprocessed/js/modules/VideoPlayer.js
@@ -12,13 +12,13 @@ import { noopFunct } from './util/standard-type';
 const DOM_INVALID = ERROR_MESSAGES.DOM.INVALID;
 
 const CLASSES = Object.freeze( {
-  VIDEO_PLAYER_SELECTOR:     '.video-player',
+  VIDEO_PLAYER_SELECTOR:     '.o-video-player',
   VIDEO_PLAYING_STATE:       'video-playing',
-  IMAGE_SELECTOR:            '.video-player_image',
-  IFRAME_CLASS_NAME:         'video-player_iframe',
-  IFRAME_CONTAINER_SELECTOR: '.video-player_iframe-container',
-  PLAY_BTN_SELECTOR:         '.video-player_play-btn',
-  CLOSE_BTN_SELECTOR:        '.video-player_close-btn',
+  IMAGE_SELECTOR:            '.o-video-player_image',
+  IFRAME_CLASS_NAME:         'o-video-player_iframe',
+  IFRAME_CONTAINER_SELECTOR: '.o-video-player_iframe-container',
+  PLAY_BTN_SELECTOR:         '.o-video-player_play-btn',
+  CLOSE_BTN_SELECTOR:        '.o-video-player_close-btn',
   FCM_CONTAINER_SELECTOR:    '.o-featured-content-module'
 } );
 

--- a/cfgov/unprocessed/js/modules/YoutubePlayer.js
+++ b/cfgov/unprocessed/js/modules/YoutubePlayer.js
@@ -8,9 +8,9 @@ import VideoPlayer from './VideoPlayer';
 let YoutubePlayer;
 
 const CLASSES = Object.freeze( {
-  VIDEO_PLAYER_SELECTOR: '.video-player__youtube',
-  IFRAME_CLASS_NAME:     'video-player_iframe__youtube',
-  IMAGE_LOADED_STATE:    'video-player_image-loaded'
+  VIDEO_PLAYER_SELECTOR: '.o-video-player__youtube',
+  IFRAME_CLASS_NAME:     'o-video-player_iframe__youtube',
+  IMAGE_LOADED_STATE:    'o-video-player_image-loaded'
 } );
 
 const API = {

--- a/cfgov/unprocessed/js/routes/on-demand/video-player.js
+++ b/cfgov/unprocessed/js/routes/on-demand/video-player.js
@@ -3,4 +3,4 @@
    ========================================================================== */
 
 import YoutubePlayer from '../../modules/YoutubePlayer';
-YoutubePlayer.init( '.video-player__youtube' );
+YoutubePlayer.init( '.o-video-player__youtube' );

--- a/test/browser_tests/shared_objects/video-player.js
+++ b/test/browser_tests/shared_objects/video-player.js
@@ -1,4 +1,4 @@
-const videoPlayer = element( by.css( '.video-player' ) );
+const videoPlayer = element( by.css( '.o-video-player' ) );
 
 function _videoPlayerElement( selector ) {
   return videoPlayer.element( by.css( selector ) );
@@ -6,22 +6,22 @@ function _videoPlayerElement( selector ) {
 
 const VideoPlayer = {
 
-  videoPlayerCloseButton: _videoPlayerElement( '.video-player_close-btn' ),
+  videoPlayerCloseButton: _videoPlayerElement( '.o-video-player_close-btn' ),
 
   videoPlayerVideoContainer:
-    _videoPlayerElement( '.video-player_video-container' ),
+    _videoPlayerElement( '.o-video-player_video-container' ),
 
   videoPlayerIframeContainer:
-    _videoPlayerElement( '.video-player_iframe-container' ),
+    _videoPlayerElement( '.o-video-player_iframe-container' ),
 
   getVideoPlayerIframe: function getVideoPlayerIframe() {
-    return _videoPlayerElement( '.video-player_iframe' );
+    return _videoPlayerElement( '.o-video-player_iframe' );
   },
 
   videoPlayerImageContainer:
-    _videoPlayerElement( '.video-player_image-container' ),
+    _videoPlayerElement( '.o-video-player_image-container' ),
 
-  videoPlayerPlayButton: _videoPlayerElement( '.video-player_play-btn' ),
+  videoPlayerPlayButton: _videoPlayerElement( '.o-video-player_play-btn' ),
 
   videoPlayer: videoPlayer
 


### PR DESCRIPTION
## Additions

- Video player: Adds `@standard-btn-height__px` variable for "standard" button height magic number.

## Removals

-  Video player: Removes seemingly unused `@share-width__px` and `@video-width__px` variables.

## Changes

-  Video player: updates class name to have `o-` prefix for consistency with how other organism's CSS is formatted.
- Adds space in parentheses and removes some extraneous whitespace. Minor comment updates too (missing period, spelling out FCM acronym).

## Testing

1. `gulp clean && gulp build` should pass. Videos should work as before.
