### PR TITLE
restore the admin access to PFC constants

### DIFF
--- a/cfgov/paying_for_college/admin.py
+++ b/cfgov/paying_for_college/admin.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python
+from __future__ import absolute_import
+
+from django.contrib import admin
+
+from paying_for_college.models import (
+    Alias, ConstantCap, ConstantRate, Contact, Feedback, Nickname, Program,
+    School
+)
+
+
+class ConstantRateAdmin(admin.ModelAdmin):
+    list_display = ('name', 'slug', 'note', 'value', 'updated')
+    list_editable = ['value']
+
+
+class ConstantCapAdmin(admin.ModelAdmin):
+    list_display = ('name', 'slug', 'note', 'value', 'updated')
+    list_editable = ['value']
+
+
+class SchoolAdmin(admin.ModelAdmin):
+    list_display = ('primary_alias',
+                    'school_id',
+                    'operating',
+                    'city',
+                    'state',
+                    'settlement_school')
+    list_filter = ('settlement_school', 'operating', 'state')
+    list_editable = ('settlement_school',)
+    search_fields = ['school_id', 'city', 'state']
+    ordering = ['state']
+
+
+class AliasAdmin(admin.ModelAdmin):
+    list_display = ('alias', 'institution', 'is_primary')
+    search_fields = ['alias']
+
+
+class NicknameAdmin(admin.ModelAdmin):
+    list_display = ('nickname', 'institution', 'is_female')
+    search_fields = ['nickname']
+
+
+admin.site.register(ConstantRate, ConstantRateAdmin)
+admin.site.register(ConstantCap, ConstantCapAdmin)
+admin.site.register(School, SchoolAdmin)
+admin.site.register(Alias, AliasAdmin)
+admin.site.register(Feedback)
+admin.site.register(Contact)
+admin.site.register(Nickname, NicknameAdmin)
+admin.site.register(Program)


### PR DESCRIPTION
When college-costs was ported to cfgov-refresh, I neglected to include the admin file so that product owners could edit some of the constant values we use on the page.

This restores the admin file.