### PR TITLE
Fix placement of the download icon for a job's pay scale PDF

### DIFF
--- a/cfgov/jinja2/v1/job-description-page/index.html
+++ b/cfgov/jinja2/v1/job-description-page/index.html
@@ -53,8 +53,8 @@
                           a-link__icon
                           pay-grade-link"
                    href="https://files.consumerfinance.gov/f/documents/cfpb_pay_scales.pdf">
-                    {{ svg_icon('download') }}
                     <span class="a-link_text">See information on grades and base pay ranges</span>
+                    {{ svg_icon('download') }}
                 </a>
             </dd>
             {% if usajobs_links %}


### PR DESCRIPTION
The download icon for the pay scale PDF is currently misplaced.

## Changes

- Corrects the placement of the pay scale PDF's download icon

## Testing

1. Pull branch
1. Ensure you have a recent database dump
1. Load up a current opening, like http://localhost:8000/about-us/careers/current-openings/chief-experience-officer-175-176p/
1. Observe that the icon is now on the right

## Screenshots

### Before

![](https://user-images.githubusercontent.com/1044670/61140347-4ec51080-a499-11e9-8e79-627d568b7978.png)

### After

![](https://user-images.githubusercontent.com/1044670/61140390-5edcf000-a499-11e9-923f-6f909b549184.png)


## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [x] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
