### PR TITLE
Change init method to return consistent type

### DIFF
--- a/cfgov/unprocessed/apps/owning-a-home/js/explore-rates/Slider.js
+++ b/cfgov/unprocessed/apps/owning-a-home/js/explore-rates/Slider.js
@@ -37,13 +37,11 @@ function Slider( element ) {
   /**
    * @param {Object} options - Options to pass to rangeslider-js
    *   (see https://github.com/stbaer/rangeslider-js#options).
-   * @returns {Slider|undefined} An instance,
-   *   or undefined if it was already initialized.
+   * @returns {Slider} An instance.
    */
   function init( options ) {
     if ( !setInitFlag( _dom ) ) {
-      let UNDEFINED;
-      return UNDEFINED;
+      return this;
     }
 
     _options = options;

--- a/cfgov/unprocessed/js/molecules/Autocomplete.js
+++ b/cfgov/unprocessed/js/molecules/Autocomplete.js
@@ -1,6 +1,6 @@
 // Required modules.
 import { assign } from '../modules/util/assign';
-import * as atomicHelpers from '../modules/util/atomic-helpers';
+import { checkDom, setInitFlag } from '../modules/util/atomic-helpers';
 import { ajaxRequest } from '../modules/util/ajax-request';
 import { bindEvent } from '../modules/util/dom-events';
 import * as throttle from 'lodash.throttle';
@@ -40,7 +40,7 @@ function Autocomplete( element, opts ) {
   let _selection;
 
   // Autocomplete elements
-  const _dom = atomicHelpers.checkDom( element, BASE_CLASS );
+  const _dom = checkDom( element, BASE_CLASS );
   const _input = _dom.querySelector( 'input' );
 
   // Settings
@@ -84,9 +84,8 @@ function Autocomplete( element, opts ) {
    *   or undefined if it was already initialized.
    */
   function init() {
-    if ( !atomicHelpers.setInitFlag( _dom ) ) {
-      let UNDEFINED;
-      return UNDEFINED;
+    if ( !setInitFlag( _dom ) ) {
+      return this;
     }
 
     _autocomplete = _addContainer();

--- a/cfgov/unprocessed/js/molecules/GlobalSearch.js
+++ b/cfgov/unprocessed/js/molecules/GlobalSearch.js
@@ -1,5 +1,5 @@
 // Required modules.
-import * as atomicHelpers from '../modules/util/atomic-helpers';
+import { checkDom, setInitFlag } from '../modules/util/atomic-helpers';
 import * as breakpointState from '../modules/util/breakpoint-state';
 import ClearableInput from '../modules/ClearableInput';
 import EventObserver from '../modules/util/EventObserver';
@@ -20,7 +20,7 @@ import TabTrigger from '../modules/TabTrigger';
 function GlobalSearch( element ) { // eslint-disable-line max-statements, no-inline-comments, max-len
 
   const BASE_CLASS = 'm-global-search';
-  const _dom = atomicHelpers.checkDom( element, BASE_CLASS );
+  const _dom = checkDom( element, BASE_CLASS );
   const _contentDom = _dom.querySelector( '.' + BASE_CLASS + '_content' );
   const _flyoutMenu = new FlyoutMenu( _dom );
   let _searchInputDom;
@@ -32,13 +32,11 @@ function GlobalSearch( element ) { // eslint-disable-line max-statements, no-inl
   const _tabTrigger = new TabTrigger( _dom );
 
   /**
-   * @returns {GlobalSearch|undefined} An instance,
-   *   or undefined if it was already initialized.
+   * @returns {GlobalSearch} An instance.
    */
   function init() {
-    if ( !atomicHelpers.setInitFlag( _dom ) ) {
-      let UNDEFINED;
-      return UNDEFINED;
+    if ( !setInitFlag( _dom ) ) {
+      return this;
     }
 
     // Set initial appearance.

--- a/cfgov/unprocessed/js/molecules/Multiselect.js
+++ b/cfgov/unprocessed/js/molecules/Multiselect.js
@@ -1,6 +1,6 @@
 // Required modules.
 import * as arrayHelpers from '../modules/util/array-helpers';
-import * as atomicHelpers from '../modules/util/atomic-helpers';
+import { checkDom, setInitFlag } from '../modules/util/atomic-helpers';
 import EventObserver from '../modules/util/EventObserver';
 import MultiselectModel from './MultiselectModel';
 import { bindEvent } from '../modules/util/dom-events';
@@ -46,7 +46,7 @@ function Multiselect( element ) { // eslint-disable-line max-statements, inline-
   const KEY_TAB = 9;
 
   // Internal vars.
-  let _dom = atomicHelpers.checkDom( element, BASE_CLASS );
+  let _dom = checkDom( element, BASE_CLASS );
   let _isBlurSkipped = false;
   let _name;
   let _placeholder;
@@ -66,13 +66,11 @@ function Multiselect( element ) { // eslint-disable-line max-statements, inline-
 
   /**
    * Set up and create the multiselect.
-   * @returns {Multiselect|undefined} An instance,
-   *   or undefined if it was already initialized.
+   * @returns {Multiselect} An instance.
    */
   function init() {
-    if ( !atomicHelpers.setInitFlag( _dom ) ) {
-      let UNDEFINED;
-      return UNDEFINED;
+    if ( !setInitFlag( _dom ) ) {
+      return this;
     }
 
     _instance = this;
@@ -92,7 +90,7 @@ function Multiselect( element ) { // eslint-disable-line max-statements, inline-
 
       /* We need to set init flag again since we've created a new <div>
          to replace the <select> element. */
-      atomicHelpers.setInitFlag( _dom );
+      setInitFlag( _dom );
 
       _bindEvents();
     }

--- a/cfgov/unprocessed/js/molecules/Notification.js
+++ b/cfgov/unprocessed/js/molecules/Notification.js
@@ -43,13 +43,11 @@ function Notification( element ) {
   let _currentType;
 
   /**
-   * @returns {Notification|undefined} An instance,
-   *   or undefined if it was already initialized.
+   * @returns {Notification} An instance.
    */
   function init() {
     if ( !setInitFlag( _dom ) ) {
-      let UNDEFINED;
-      return UNDEFINED;
+      return this;
     }
 
     // Check and set default type of notification.

--- a/cfgov/unprocessed/js/organisms/EmailPopup.js
+++ b/cfgov/unprocessed/js/organisms/EmailPopup.js
@@ -80,13 +80,11 @@ function EmailPopup( element ) {
 
   /**
    * Function used to instatiate and initialize components.
-   * @returns {EmailPopup|undefined} An instance,
-   *   or undefined if it was already initialized.
+   * @returns {EmailPopup} An instance.
    */
   function init() {
     if ( !setInitFlag( _dom ) ) {
-      let UNDEFINED;
-      return UNDEFINED;
+      return this;
     }
 
     // Ensure EmailPopup is definitely hidden on initialization.

--- a/cfgov/unprocessed/js/organisms/FilterableList.js
+++ b/cfgov/unprocessed/js/organisms/FilterableList.js
@@ -27,13 +27,11 @@ function FilterableList( element ) {
   let _resultsContainer;
 
   /**
-   * @returns {FilterableListControls|undefined} An instance,
-   *   or undefined if it was already initialized.
+   * @returns {FilterableListControls} An instance.
    */
   function init() {
     if ( !setInitFlag( _dom ) ) {
-      let UNDEFINED;
-      return UNDEFINED;
+      return this;
     }
 
     _filterableListControls = new FilterableListControls(

--- a/cfgov/unprocessed/js/organisms/Footer.js
+++ b/cfgov/unprocessed/js/organisms/Footer.js
@@ -19,13 +19,11 @@ function Footer( element ) {
   const _dom = checkDom( element, BASE_CLASS );
 
   /**
-   * @returns {Footer|undefined} An instance,
-   *   or undefined if it was already initialized.
+   * @returns {Footer} An instance.
    */
   function init() {
     if ( !setInitFlag( _dom ) ) {
-      let UNDEFINED;
-      return UNDEFINED;
+      return this;
     }
 
     footerButton.init();

--- a/cfgov/unprocessed/js/organisms/FormSubmit.js
+++ b/cfgov/unprocessed/js/organisms/FormSubmit.js
@@ -24,7 +24,6 @@ const FORM_MESSAGES = ERROR_MESSAGES.FORM.SUBMISSION;
  */
 function FormSubmit( element, baseClass, opts ) {
   opts = opts || {};
-  let UNDEFINED;
   const _baseElement = checkDom( element, baseClass );
   const _formElement = _baseElement.querySelector( 'form' );
   const _notificationElement = _baseElement.querySelector(
@@ -39,12 +38,11 @@ function FormSubmit( element, baseClass, opts ) {
   this.dispatchEvent = eventObserver.dispatchEvent;
 
   /**
-   * @returns {FormSubmit|undefined} An instance,
-   *   or undefined if it was already initialized.
+   * @returns {FormSubmit} An instance.
    */
   function init() {
     if ( !setInitFlag( _baseElement ) ) {
-      return UNDEFINED;
+      return this;
     }
     _cachedFields = _cacheFields();
     _formElement.addEventListener( 'submit', _onSubmit );
@@ -80,6 +78,7 @@ function FormSubmit( element, baseClass, opts ) {
     if ( typeof opts.validator === 'function' ) {
       return opts.validator( _cachedFields );
     }
+    let UNDEFINED;
     return UNDEFINED;
   }
 

--- a/cfgov/unprocessed/js/organisms/Header.js
+++ b/cfgov/unprocessed/js/organisms/Header.js
@@ -26,13 +26,11 @@ function Header( element ) {
   /**
    * @param {HTMLNode} overlay
    *   Overlay to show/hide when mobile mega menu is shown.
-   * @returns {Header|undefined} An instance,
-   *   or undefined if it was already initialized.
+   * @returns {Header} An instance.
    */
   function init( overlay ) {
     if ( !setInitFlag( _dom ) ) {
-      let UNDEFINED;
-      return UNDEFINED;
+      return this;
     }
 
     // Semi-opaque overlay that shows over the content when the menu flies out.

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -51,8 +51,8 @@ function requireTask( taskPath ) {
  * @returns {string|undefined} File name that exists, otherwise undefined.
  */
 function fileExists( filePattern ) {
-  let UNDEFINED;
   if ( !filePattern ) {
+    let UNDEFINED;
     return UNDEFINED;
   }
   const checkFile = `${ TASK_PATH }${ filePattern }.js`;

--- a/test/unit_tests/apps/owning-a-home/js/explore-rates/Slider-spec.js
+++ b/test/unit_tests/apps/owning-a-home/js/explore-rates/Slider-spec.js
@@ -27,13 +27,9 @@ describe( 'explore-rates/Slider', () => {
   } );
 
   describe( 'init()', () => {
-    it( 'should return Slider instance if initialized', () => {
+    it( 'should return instance when initialized', () => {
       expect( slider ).toBeInstanceOf( Slider );
-    } );
-
-    it( 'should return undefined if already initialized', () => {
-      const initAgain = slider.init();
-      expect( initAgain ).toBeUndefined();
+      expect( slider.init() ).toBeInstanceOf( Slider );
     } );
 
     it( 'should initialize rangeslider class', () => {

--- a/test/unit_tests/js/molecules/Multiselect-spec.js
+++ b/test/unit_tests/js/molecules/Multiselect-spec.js
@@ -32,8 +32,7 @@ describe( 'Multiselect', () => {
       expect( selectDom.length ).toBe( 0 );
       expect( multiselectDom.length ).toBe( 1 );
 
-      // Return undefined if we've already initialized.
-      expect( multiselect.init() ).toBeUndefined();
+      expect( multiselect.init() ).toBeInstanceOf( Multiselect );
     } );
 
     it( 'should autocheck any selected options (form submitted pages)', () => {

--- a/test/unit_tests/js/molecules/Notification-spec.js
+++ b/test/unit_tests/js/molecules/Notification-spec.js
@@ -22,15 +22,10 @@ describe( 'Notification', () => {
   } );
 
   describe( 'init()', () => {
-    it( 'should return the Notification instance when initialized', () => {
-      expect( typeof notification.init() ).toBe( 'object' );
+    it( 'should return the instance when initialized', () => {
+      expect( notification.init() ).toBeInstanceOf( Notification );
       expect( notificationElem.dataset.jsHook ).toBe( 'state_atomic_init' );
-    } );
-
-    it( 'should return undefined if already initialized', () => {
-      notification.init();
-
-      expect( notification.init() ).toBeUndefined();
+      expect( notification.init() ).toBeInstanceOf( Notification );
     } );
 
     it( 'should return the Notification instance if it has a success class',

--- a/test/unit_tests/js/organisms/EmailPopup-spec.js
+++ b/test/unit_tests/js/organisms/EmailPopup-spec.js
@@ -62,8 +62,8 @@ describe( 'EmailPopup', () => {
   } );
 
   describe( 'init()', () => {
-    it( 'should return undefined if already initialized', () => {
-      expect( emailPopup.init() ).toBeUndefined();
+    it( 'should return the instance when initialized', () => {
+      expect( emailPopup.init() ).toBeInstanceOf( EmailPopup );
     } );
   } );
 

--- a/test/unit_tests/js/organisms/Footer-spec.js
+++ b/test/unit_tests/js/organisms/Footer-spec.js
@@ -13,9 +13,10 @@ describe( 'Footer', () => {
   } );
 
   describe( 'init()', () => {
-    it( 'should return undefined if already initialized', () => {
-      footer.init();
-      expect( footer.init() ).toBeUndefined();
+    it( 'should return the instance when initialized', () => {
+      expect( footer.init() ).toBeInstanceOf( Footer );
+      // Check that an instance is returned on the second call.
+      expect( footer.init() ).toBeInstanceOf( Footer );
     } );
   } );
 } );

--- a/test/unit_tests/js/organisms/FormSubmit-spec.js
+++ b/test/unit_tests/js/organisms/FormSubmit-spec.js
@@ -64,10 +64,7 @@ describe( 'FormSubmit', () => {
     it( 'should return the FormSubmit instance when initialized', () => {
       expect( typeof thisFormSubmit ).toStrictEqual( 'object' );
       expect( signupForm.dataset.jsHook ).toStrictEqual( 'state_atomic_init' );
-    } );
-
-    it( 'should return undefined if already initialized', () => {
-      expect( formSubmit.init() ).toBeUndefined();
+      expect( formSubmit.init() ).toBeInstanceOf( FormSubmit );
     } );
   } );
 } );


### PR DESCRIPTION
The  atomic component `init()` method would return `undefined` if it was called a second time. This allows checking in tests whether `init` has been run already. However, I'm thinking it's better to have a [consistent return](https://eslint.org/docs/rules/consistent-return), and if we wanted to verify that `init` has already been called, check whether the attribute `data-js-hook="state_atomic_init"` is set. This was originally set up so logic could check whether initialization was already called, but we don't do that anywhere and could add a `isInitialized()` method if that was needed.

## Changes

- Make `init()` method of atomic components return the component instances on all calls to the method.

## Testing

1. `gulp test:unit` should pass.
2. `gulp clean && gulp build` should pass.
