### PR TITLE
Run Docker DFD build in Travis in detached mode

### DIFF
--- a/docker/drama-free-django/travis.sh
+++ b/docker/drama-free-django/travis.sh
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
 
-docker run \
-    -v `pwd`:/cfgov \
-    centos:6 \
-    /bin/bash -c "/cfgov/docker/drama-free-django/_build.sh && /cfgov/docker/drama-free-django/_test.sh"
+container_id=$(
+    docker run \
+        -d \
+        -v `pwd`:/cfgov \
+        centos:6 \
+        /bin/bash -c "/cfgov/docker/drama-free-django/_build.sh && /cfgov/docker/drama-free-django/_test.sh"
+)
+
+docker logs -f $container_id


### PR DESCRIPTION
The drama-free-django build using a Docker container that runs in Travis (introduced recently in #5110) seems to fail strangely sometimes, e.g.

https://travis-ci.org/cfpb/cfgov-refresh/jobs/560138901#L1314

This works locally. I suspect this is some kind of timeout, but am not sure. This change modifies the way that the Travis script works, so that it runs the container in detached mode and then attaches to the logs. I've verified that this works (at least once) on my fork.

This change is intended to fix the Travis failures currently happening on #5116.

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [X] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [X] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: