### PR TITLE
Improve logging of drama-free-django builds

### DIFF
--- a/docker/drama-free-django/_build.sh
+++ b/docker/drama-free-django/_build.sh
@@ -3,6 +3,9 @@
 # Fail when any command fails.
 set -e
 
+# Echo commands.
+set -x
+
 artifact_name=cfgov
 artifact_label=current
 artifact_release=build

--- a/docker/drama-free-django/_test.sh
+++ b/docker/drama-free-django/_test.sh
@@ -3,6 +3,9 @@
 # Fail when any command fails.
 set -e
 
+# Echo commands.
+set -x
+
 artifact_filename=cfgov_current_build.zip
 artifact_volume=/cfgov
 

--- a/docker/drama-free-django/travis.sh
+++ b/docker/drama-free-django/travis.sh
@@ -1,11 +1,7 @@
 #!/usr/bin/env bash
 
-container_id=$(
-    docker run \
-        -d \
-        -v `pwd`:/cfgov \
-        centos:6 \
-        /bin/bash -c "/cfgov/docker/drama-free-django/_build.sh && /cfgov/docker/drama-free-django/_test.sh"
-)
-
-docker logs -f $container_id
+docker run \
+    -v `pwd`:/cfgov \
+    -e PYTHONUNBUFFERED=1 \
+    centos:6 \
+    /bin/bash -c "/cfgov/docker/drama-free-django/_build.sh && /cfgov/docker/drama-free-django/_test.sh"


### PR DESCRIPTION
This commit moves the Docker-based drama-free-django build on Travis out of detached mode, but tries to set `PYTHONUNBUFFERED` to hopefully allow the logs to be properly reported.

It also adds `set -x` to the scripts so that the commands are helpfully echoed for better debugging.

This is a followup to #5110 and #5117. See conversation starting [here](https://github.com/cfpb/cfgov-refresh/pull/5117#pullrequestreview-263302819) for motivation behind this change. Hopefully this should provide better debugging for any future DFD build failures on Travis.

I tested this on a fork and it passed Travis [here](https://travis-ci.org/chosak/cfgov-refresh/jobs/560182676#L7815); this doesn't guarantee this will never fail, because the original #5110 passed and I'm not sure why Travis was failing on #5116. But this should at least hopefully help debugging in the future.

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [X] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [X] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: