### PR TITLE
Add flag and endpoint to signal when Beta is in use for testing

### DIFF
--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -702,7 +702,12 @@ FLAGS = {
     # such as: is enabled when path matches ^/ask-cfpb/what-is-an-ach-en-1065/
     # Delete after Google schema pilot completes and schema usage is
     # discontinued or implemented with a toggle in answer page admin.
-    'HOW_TO_SCHEMA': []
+    'HOW_TO_SCHEMA': [],
+
+    # Manually enabled when Beta is being used for an external test.
+    # Controls the /beta_external_testing endpoint, which Jenkins jobs
+    # query to determine whether to refresh Beta database.
+    'BETA_EXTERNAL_TESTING': [],
 }
 
 

--- a/cfgov/cfgov/tests/test_urls.py
+++ b/cfgov/cfgov/tests/test_urls.py
@@ -128,3 +128,14 @@ class HandleErrorTestCase(TestCase):
         mock_render.assert_called_with(
             request, '404.html', context={'request': request}, status=404
         )
+
+
+class TestBetaRefreshEndpoint(TestCase):
+    def test_beta_testing_endpoint_returns_404_when_disabled(self):
+        response = self.client.get('/beta_external_testing/')
+        self.assertEqual(response.status_code, 404)
+
+    @override_settings(FLAGS={'BETA_EXTERNAL_TESTING': [('boolean', True)]})
+    def test_beta_testing_endpoint_returns_200_when_enabled(self):
+        response = self.client.get('/beta_external_testing/')
+        self.assertEqual(response.status_code, 200)

--- a/cfgov/cfgov/urls.py
+++ b/cfgov/cfgov/urls.py
@@ -69,6 +69,10 @@ def flagged_wagtail_only_view(flag_name, regex_path, url_name=None):
     )
 
 
+def empty_200_response(request, *args, **kwargs):
+    return HttpResponse(status=200)
+
+
 urlpatterns = [
     url(r'^documents/(?P<document_id>\d+)/(?P<document_filename>.*)$',
         DocumentServeView.as_view(),
@@ -383,6 +387,13 @@ urlpatterns = [
 
     # Explicitly redirect eRegulations URLs to Regulations3000
     url(r'^eregulations/.*', redirect_eregs, name='eregs-redirect'),
+
+    # Manually enabled when Beta is being used for an external test.
+    # Jenkins job check this endpoint to determine whether to refresh
+    # Beta database.
+    flagged_url('BETA_EXTERNAL_TESTING',
+            r'^beta_external_testing/',
+            empty_200_response),
 
     # put financial well-being pages behind feature flag for testing
     flagged_wagtail_only_view(


### PR DESCRIPTION
This flag will allow us to set up automatic refreshes of the Beta database, like so:
1. Someone on M&R manually enables the `BETA_EXTERNAL_TESTING` feature flag when Beta is being used for a test.
2. The flag controls the `/beta_external_testing` endpoint on cf.gov, which returns a 200 when enabled and a 404 when disabled.
3. The Beta refresh Jenkins job checks the endpoint whenever it runs. If the endpoint returns 404, refresh Beta. If 200, Beta is in use, so don't refresh.

This way, the Jenkins job can run automatically on a schedule (e.g. daily), and not overwrite the testing environment when it's in use.

## Additions

- `BETA_EXTERNAL_TESTING` feature flag
- `/beta_external_testing` endpoint

## Testing

1. Run this branch
2. From a terminal, `curl -I localhost:8000/beta_external_testing/`
    - Should return HTTP status code 404
3. From the Wagtail admin, enable the `BETA_EXTERNAL_TESTING` feature flag
4. `curl -I localhost:8000/beta_external_testing/` again
    - Should now return HTTP status code 200


## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: