### PR TITLE
Skip over left side nav when using skip link on pages with left side nav

### DIFF
--- a/cfgov/jinja2/v1/_layouts/base.html
+++ b/cfgov/jinja2/v1/_layouts/base.html
@@ -33,7 +33,10 @@
 <div class="a-overlay u-hidden"></div>
 
 <div class="skip-nav">
-    <a href="#main" class="skip-nav_link">Skip to main content</a>
+    <a class="skip-nav_link"
+       href="{% block skip_nav_target %}#main{% endblock %}">
+        Skip to main content
+    </a>
 </div>
 
 {% block header %}

--- a/cfgov/jinja2/v1/_layouts/content-base-sidebar-first.html
+++ b/cfgov/jinja2/v1/_layouts/content-base-sidebar-first.html
@@ -1,5 +1,12 @@
 {% extends 'content-base.html' %}
 
+{% block skip_nav_target -%}
+    {# Overrides the default skip nav target of #main so that we skip over the
+       left side nav on pages that extend this template and go right to the
+       main content area. #}
+    #content_main
+{%- endblock %}
+
 {% block pre_content scoped -%}
     {# TODO: Remove non-wagtail logic once old pages have been converted #}
     {% if page %}
@@ -27,7 +34,8 @@
     <aside class="content_sidebar {% block content_sidebar_modifiers -%}{%- endblock %}">
         {% block content_sidebar scoped -%}{%- endblock %}
     </aside>
-    <div class="content_main {% block content_main_modifiers -%}{%- endblock %}">
+    <div class="content_main {% block content_main_modifiers -%}{%- endblock %}"
+         id="content_main">
         {% block content_main scoped -%}{%- endblock %}
     </div>
 </div>


### PR DESCRIPTION
Skip links are currently all skipping to `#main`. On pages with left side nav, this means that they weren't skipping over that nav. This change skips them to `#content_main` on pages with a left sidebar.

Fixes GHE/CFGOV/platform/issues/2704

## Additions

- Added `id="content_main"` to the `div` with the class of the same
- Added a new template block of `skip_nav_target` wrapping the `href` value in the skip link in `base.html`, which is overridden in the `content-base-sidebar-first.html` template to point to `#content_main`

## Testing

1. Pull branch
1. Visit a page with left side nav, e.g., http://localhost:8000/about-us/newsroom/
1. Press Tab to reveal the skip link and Enter to activate it
1. Confirm that it targets `#content_main` instead of `#main`
1. Try it on any other type of page and see that it still targets `#main`

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [ ] Chrome on desktop
- [ ] Firefox
- [ ] Safari on macOS
- [ ] Edge
- [ ] Internet Explorer 9, 10, and 11
- [ ] Safari on iOS
- [ ] Chrome on Android

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
