### PR TITLE
Make clear search label say "clear search" instead of "close"

### DIFF
--- a/cfgov/jinja2/v1/_includes/molecules/global-search.html
+++ b/cfgov/jinja2/v1/_includes/molecules/global-search.html
@@ -69,7 +69,7 @@
                                      input-contains-label_after__clear
                                      u-hidden">
                             {{ svg_icon('delete') }}
-                            <span class="u-visually-hidden">{{ _('Close') }}</span>
+                            <span class="u-visually-hidden">{{ _('Clear search') }}</span>
                        </label>
                    </div>
                </div>


### PR DESCRIPTION
Partial fix for  https://GHE/CFGOV/platform/issues/2655

## Additions

-

## Removals

-

## Changes

- There is a label on mobile that when clicked on, clears any typed text inside the search field. This label currently says "Close" which is not that it does. This PR makes it say "Clear search" instead. This is helpful for screen reader users, who will hear the text read out loud.

## Testing

1. Resize your browser window to mobile layout size
1. tab to the search field 
1. You can't actually tab to the "Clear search" button right now (that's another PR coming) but you can right click, inspect the text to make sure the label says "Clear search" inside it.

## Screenshots
![Screen Shot 2019-07-23 at 11 20 27 AM](https://user-images.githubusercontent.com/702526/61724402-e3522d00-ad3b-11e9-991c-e6863bb44173.png)


## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [ ] Chrome on desktop
- [ ] Firefox
- [ ] Safari on macOS
- [ ] Edge
- [ ] Internet Explorer 9, 10, and 11
- [ ] Safari on iOS
- [ ] Chrome on Android

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
