### PR TITLE
Set the html lang attribute based on the language variable

### DIFF
--- a/cfgov/jinja2/v1/_layouts/base-common.html
+++ b/cfgov/jinja2/v1/_layouts/base-common.html
@@ -23,10 +23,10 @@
 -->
 {% endif %}
 
-<!--[if IE 7]>         <html lang="{{  language  }}" class="no-js lt-ie9 lt-ie8"> <![endif]-->
-<!--[if IE 8]>         <html lang="{{  language  }}" class="no-js lt-ie10 lt-ie9"> <![endif]-->
-<!--[if IE 9]>         <html lang="{{  language  }}" class="no-js lt-ie10"> <![endif]-->
-<!--[if gt IE 8]><!--> <html lang="{{  language  }}" class="no-js"> <!--<![endif]-->
+<!--[if IE 7]>         <html lang="{{ language }}" class="no-js lt-ie9 lt-ie8"> <![endif]-->
+<!--[if IE 8]>         <html lang="{{ language }}" class="no-js lt-ie10 lt-ie9"> <![endif]-->
+<!--[if IE 9]>         <html lang="{{ language }}" class="no-js lt-ie10"> <![endif]-->
+<!--[if gt IE 8]><!--> <html lang="{{ language }}" class="no-js"> <!--<![endif]-->
 
 <head prefix="og: http://ogp.me/ns# fb: http://ogp.me/ns/fb# {% block og_article_prefix %}{% endblock %}">
 

--- a/cfgov/jinja2/v1/_layouts/base-common.html
+++ b/cfgov/jinja2/v1/_layouts/base-common.html
@@ -23,10 +23,10 @@
 -->
 {% endif %}
 
-<!--[if IE 7]>         <html lang="en" class="no-js lt-ie9 lt-ie8"> <![endif]-->
-<!--[if IE 8]>         <html lang="en" class="no-js lt-ie10 lt-ie9"> <![endif]-->
-<!--[if IE 9]>         <html lang="en" class="no-js lt-ie10"> <![endif]-->
-<!--[if gt IE 8]><!--> <html lang="en" class="no-js"> <!--<![endif]-->
+<!--[if IE 7]>         <html lang="{{  language  }}" class="no-js lt-ie9 lt-ie8"> <![endif]-->
+<!--[if IE 8]>         <html lang="{{  language  }}" class="no-js lt-ie10 lt-ie9"> <![endif]-->
+<!--[if IE 9]>         <html lang="{{  language  }}" class="no-js lt-ie10"> <![endif]-->
+<!--[if gt IE 8]><!--> <html lang="{{  language  }}" class="no-js"> <!--<![endif]-->
 
 <head prefix="og: http://ogp.me/ns# fb: http://ogp.me/ns/fb# {% block og_article_prefix %}{% endblock %}">
 


### PR DESCRIPTION
Closes GHE/2877

## Testing

 - Open your local instance of cfgov to the homepage and view the html element. It should have a `lang` attribute set to `en`.
 - Navigate to `localhost:8000/es` and view the html element. It should have a `lang` attribute set to `es`.