### PR TITLE
Removes unneeded attributes on pagination

### DIFF
--- a/cfgov/agreements/jinja2/agreements/search.html
+++ b/cfgov/agreements/jinja2/agreements/search.html
@@ -96,8 +96,6 @@
                                         type="number"
                                         min="1"
                                         max="999"
-                                        pattern="[0-9]*"
-                                        inputmode="numeric"
                                         value="{{ page.number }}">
                                 of {{ page.paginator.num_pages }}
                             </label>

--- a/cfgov/jinja2/v1/_includes/molecules/pagination.html
+++ b/cfgov/jinja2/v1/_includes/molecules/pagination.html
@@ -85,8 +85,6 @@
                    type="number"
                    min="1"
                    max="{{ total_pages }}"
-                   pattern="[0-9]*"
-                   inputmode="numeric"
                    value="{{ current_page }}">
             <span class="m-pagination_label">
                 {{- ' ' ~ _('of') ~ ' ' -}} {{- total_pages -}}


### PR DESCRIPTION
[This PR](https://github.com/cfpb/cfgov-refresh/pull/1909) added `pattern="[0-9]*"` and `inputmode="numeric"` to pagination inputs. However, this fails HTML validation. Additionally, `type="number"` should infer the intent both these attributes are providing.

> When inputmode is unspecified (or is in a state not supported by the user agent), the user agent should determine the default virtual keyboard to be shown. Contextual information such as the input type or pattern attributes should be used to determine which type of virtual keyboard should be presented to the user.

<img width="947" alt="Screen Shot 2019-07-23 at 3 07 12 PM" src="https://user-images.githubusercontent.com/704760/61740188-ff65c680-ad5b-11e9-87d8-ba5a75355ebf.png">

<img width="927" alt="Screen Shot 2019-07-23 at 3 06 44 PM" src="https://user-images.githubusercontent.com/704760/61740187-ff65c680-ad5b-11e9-84e9-ca59a8399dfe.png">



## Removals

- `pattern` and `inputmode` attributes from the pagination input.

## Testing

1. Visit https://validator.w3.org/nu/?doc=https%3A%2F%2Fwww.consumerfinance.gov%2Factivity-log%2F (Note: there are other errors in the style tags and featured content modules).
