### PR TITLE
Start new Mouseflow capture when first expandable in a group is clicked

### DIFF
--- a/cfgov/unprocessed/apps/analytics-gtm/js/util/analytics-util.js
+++ b/cfgov/unprocessed/apps/analytics-gtm/js/util/analytics-util.js
@@ -26,6 +26,33 @@ function addEventListenerToElem( elem, event, callback ) {
 }
 
 /**
+ * Query a selector and remove listeners from returned elements.
+ * @param {string} selector - A dom selector.
+ * @param {string} event - An event string, probably a "MouseEvent."
+ * @param {Function} callback - The event handler.
+ */
+function removeEventListenerFromSelector( selector, event, callback ) {
+  const elems = document.querySelectorAll( selector );
+  for ( let i = 0, len = elems.length; i < len; i++ ) {
+    removeEventListenerFromElem( elems[i], event, callback );
+  }
+}
+
+/**
+ * Check if an element exists on the page, and if it does, remove listeners.
+ * @param {[type]}   elem     [description]
+ * @param {[type]}   event    [description]
+ * @param {Function} callback [description]
+ */
+function removeEventListenerFromElem( elem, event, callback ) {
+  if ( elem ) {
+    elem.removeEventListener( event, callback );
+  } else {
+    analyticsLog( `${ elem } doesn't exist!` );
+  }
+}
+
+/**
  * Log a message to the console if the `debug-gtm` URL parameter is set.
  * @param {string} msg - Message to load to the console.
  */
@@ -113,6 +140,8 @@ function getQueryParameter( key ) {
 module.exports = {
   addEventListenerToSelector,
   addEventListenerToElem,
+  removeEventListenerFromSelector,
+  removeEventListenerFromElem,
   analyticsLog,
   Delay,
   getQueryParameter,

--- a/cfgov/unprocessed/js/routes/on-demand/expandable-group.js
+++ b/cfgov/unprocessed/js/routes/on-demand/expandable-group.js
@@ -2,4 +2,45 @@
    Scripts for Expandable Group organism.
    ========================================================================== */
 
-require( 'cf-expandables/src/Expandable' ).init();
+import {
+  addEventListenerToSelector,
+  analyticsLog,
+  removeEventListenerFromSelector
+} from '../../../apps/analytics-gtm/js/util/analytics-util';
+
+import Expandable from 'cf-expandables/src/Expandable';
+Expandable.init();
+
+
+/**
+ * Tells Mouseflow to stop capturing, if it already is, and start a new capture.
+ */
+function stopStartMouseflow() {
+  console.log( 'stopStartMouseflow' );
+  if ( window.mouseflow ) {
+    // Stop any in-progress heatmap capturing.
+    window.mouseflow.stop();
+    // Start a new heatmap recording.
+    window.mouseflow.start();
+    analyticsLog( 'Mouseflow capture started!' );
+  }
+}
+
+/**
+ * @param {MouseEvent} event - Mouse event from the click.
+ */
+function handleExpandable() {
+  console.log( 'handleExpandable' );
+  removeEventListenerFromSelector(
+    Expandable.prototype.ui.target,
+    'click',
+    handleExpandable
+  );
+  const waitForTransition = window.setTimeout( stopStartMouseflow, 500 );
+}
+
+addEventListenerToSelector(
+  Expandable.prototype.ui.target,
+  'click',
+  handleExpandable
+);


### PR DESCRIPTION
Background: https://GHE/CFGOV/platform/issues/2908

Our analytics team would like to start a new Mouseflow capture once the first expandable in an expandable group is clicked, so that the screenshot shows more of the page, which provided better heatmap data.

Console logging left in for now to aid in testing. **On hold** until this can be tested in Mouseflow and logging statements are removed.

## Additions

- Event listener added to all expandable targets in an expandable group that triggers a new Mouseflow capture when the first one is clicked (listeners are removed after that first click)
- `removeEventListenerFromSelector` and `removeEventListenerFromElem` functions added along side their `add` counterparts in analytics module utils

## Testing

1. Pull branch
1. `gulp scripts`
1. Load a page with an expandable group, like http://localhost:8000/consumer-tools/getting-an-auto-loan/plan-to-shop-for-your-auto-loan/
1. Open the console
1. Click an expandable and see the logging statement
1. Click another one (or the same one) and see no logging statements (as the event listeners were removed)

## Notes

- The add/remove event listener utils aren't really analytics-specific. Should we move them out of that module into a more generic location?

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [ ] Chrome on desktop
- [ ] Firefox
- [ ] Safari on macOS
- [ ] Edge
- [ ] Internet Explorer 9, 10, and 11
- [ ] Safari on iOS
- [ ] Chrome on Android

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
