### PR TITLE
Expand tags inside a link that don't get an icon

### DIFF
--- a/cfgov/core/tests/test_middleware.py
+++ b/cfgov/core/tests/test_middleware.py
@@ -136,6 +136,20 @@ class TestParseLinks(TestCase):
         self.assertIn('external-site', output)
         self.assertNotIn('cf-icon-svg', output)
 
+    def test_external_link_with_background_img(self):
+        s = ('<a href="https://somewhere/foo"><span>'
+             '<div style="background-image: url(\'some.png\')"></div>'
+             '</span></a>')
+        output = parse_links(s)
+        self.assertIn('external-site', output)
+        self.assertNotIn('cf-icon-svg', output)
+
+    def test_external_link_with_header(self):
+        s = '<a href="https://somewhere/foo"><h3>Header</h3></a>'
+        output = parse_links(s)
+        self.assertIn('external-site', output)
+        self.assertNotIn('cf-icon-svg', output)
+
     def test_multiline_external_gov_link(self):
         s = '''<a class="m-list_link a-link"
         href="https://usa.gov/">

--- a/cfgov/core/utils.py
+++ b/cfgov/core/utils.py
@@ -31,7 +31,7 @@ A_TAG = re.compile(
     # And match everything inside
     r'.+?'
     # As long as it's not a </a>, then match '</a>'
-    '(?=</a>)</a>'
+    r'(?=</a>)</a>'
     # Make '.' match new lines, ignore case
     r'(?s)(?i)'
 )


### PR DESCRIPTION
This change refactors the way `<img>` tags were being matched in links to prevent icons being added for external links. Instead of matching an `img` tag name in a `for` loop, it uses BeautifulSoup's CSS `select()` method. 

(As a personal aside, I'm much happier with this as a way to filter the links.)

This change also adds additional elements that can be contained within a link that do not get icons. That list is currently, `img`, `svg`, `div`, `h1`, `h2`, `h3`, `h4`, `h5`, and `h6`.

This is intended to fix this issue on production:

<img width="805" alt="image" src="https://user-images.githubusercontent.com/10562538/61952749-b2b00480-af82-11e9-8f6c-9673dd24cc3a.png">
https://www.consumerfinance.gov/equifax-settlement/

On localhost, without the image file itself, this looks like:

<img width="791" alt="image" src="https://user-images.githubusercontent.com/10562538/61953696-10455080-af85-11e9-9ba6-64a369436418.png">

http://localhost:8000/equifax-settlement/

With this change:

<img width="796" alt="image" src="https://user-images.githubusercontent.com/10562538/61953632-e7bd5680-af84-11e9-9585-545ef9e1bdf4.png">

http://localhost:8000/equifax-settlement/


## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
