### PR TITLE
Add Information Quality Guidelines link to global footer

### DIFF
--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -663,9 +663,6 @@ FLAGS = {
     'EMAIL_POPUP_OAH': [('boolean', True)],
     'EMAIL_POPUP_DEBT': [('boolean', True)],
 
-    # The release of new Whistleblowers content/pages
-    'WHISTLEBLOWER_RELEASE': [],
-
     # Search.gov API-based site-search
     'SEARCH_DOTGOV_API': [],
 

--- a/cfgov/jinja2/v1/_includes/organisms/footer.html
+++ b/cfgov/jinja2/v1/_includes/organisms/footer.html
@@ -65,13 +65,11 @@
                             Careers
                         </a>
                     </li>
-                    {% if flag_enabled('WHISTLEBLOWER_RELEASE', request) %}
                     <li class="m-list_item">
                         <a class="m-list_link" href="/policy-compliance/enforcement/information-industry-whistleblowers/">
                             Industry Whistleblowers
                         </a>
                     </li>
-                    {% endif %}
                     <li class="m-list_item">
                         <a class="m-list_link" href="/cfpb-ombudsman/">
                             CFPB Ombudsman
@@ -121,6 +119,11 @@
                     <li class="m-list_item">
                         <a class="m-list_link" href="/open-government/">
                             Open Government
+                        </a>
+                    </li>
+                    <li class="m-list_item">
+                        <a class="m-list_link" href="/open-government/information-quality-guidelines/">
+                            Information Quality Guidelines
                         </a>
                     </li>
                 </ul>


### PR DESCRIPTION
Addresses https://GHE/CFGOV/platform/issues/3505

## Additions

- Adds Information Quality Guidelines link to global footer

## Removals

- Removes `WHISTLEBLOWER_RELEASE` flag that is no longer needed

## Testing

1. Pull branch
1. Visit http://localhost:8000/
1. See the new link and click through to the page

## Screenshots

![Screenshot showing global footer with new Information Quality Guidelines link below the existing Open Government link](https://user-images.githubusercontent.com/1044670/62068136-68898600-b203-11e9-9297-b169496e9947.png)

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [x] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
