### PR TITLE
Add admin class for PFC contacts

### DIFF
--- a/cfgov/paying_for_college/admin.py
+++ b/cfgov/paying_for_college/admin.py
@@ -42,11 +42,15 @@ class NicknameAdmin(admin.ModelAdmin):
     search_fields = ['nickname']
 
 
+class ContactAdmin(admin.ModelAdmin):
+    list_display = ('name', 'contacts', 'endpoint')
+
+
 admin.site.register(ConstantRate, ConstantRateAdmin)
 admin.site.register(ConstantCap, ConstantCapAdmin)
 admin.site.register(School, SchoolAdmin)
 admin.site.register(Alias, AliasAdmin)
 admin.site.register(Feedback)
-admin.site.register(Contact)
+admin.site.register(Contact, ContactAdmin)
 admin.site.register(Nickname, NicknameAdmin)
 admin.site.register(Program)


### PR DESCRIPTION
The paying_for_college settlement disclosure tool had only two school systems
since launching in 2017, so contacts needed minimal management.

Now that original school system, EDMC, has broken apart, through a sale and
then a receivership, surviving schools are breaking away as
independent entities, requiring new contact entries.

This admin tweak makes it easier to see details of the school contacts in our system.