### PR TITLE
Fix iRegs notification typo

### DIFF
--- a/cfgov/regulations3k/jinja2/regulations3k/browse-regulation.html
+++ b/cfgov/regulations3k/jinja2/regulations3k/browse-regulation.html
@@ -164,7 +164,7 @@
         {%- endfor %}
 
         {% if requested_version != current_version %}
-        <div class="block block__flush-regs3k u-mb60">
+        <div class="block block__flush-regs3k">
             <div class="m-full-width-text
                         m-notification
                         m-notification__visible

--- a/cfgov/regulations3k/jinja2/regulations3k/browse-regulation.html
+++ b/cfgov/regulations3k/jinja2/regulations3k/browse-regulation.html
@@ -71,10 +71,10 @@
                         <div class="h4 m-notification_message">This version is not the current regulation.</div>
                         <p class="m-notification_explanation">
                         {% if requested_version.effective_date < current_version.effective_date %}
-                            You are viewing a previous version of this regulation with ammendments that went into effect on
+                            You are viewing a previous version of this regulation with amendments that went into effect on
                         {% endif %}
                         {% if requested_version.effective_date > current_version.effective_date %}
-                            You are viewing a future version of this regulation with ammendments that will go into effect on
+                            You are viewing a future version of this regulation with amendments that will go into effect on
                         {% endif %}
                         {{ ap_date(requested_version.effective_date) }}. <a class="m-list_link" href="{{ routablepageurl(page, 'versions', section_label=section.label) }}">View all versions of this regulation</a>
                         </p>
@@ -164,7 +164,7 @@
         {%- endfor %}
 
         {% if requested_version != current_version %}
-        <div class="block block__flush-regs3k">
+        <div class="block block__flush-regs3k u-mb60">
             <div class="m-full-width-text
                         m-notification
                         m-notification__visible
@@ -174,10 +174,10 @@
                     <div class="h4 m-notification_message">This version is not the current regulation.</div>
                     <p class="m-notification_explanation">
                         {% if requested_version.effective_date < current_version.effective_date %}
-                            You are viewing a previous version of this regulation with ammendments that went into effect on {{ ap_date(requested_version.effective_date) }}.
+                            You are viewing a previous version of this regulation with amendments that went into effect on {{ ap_date(requested_version.effective_date) }}.
                         {% endif %}
                         {% if requested_version.effective_date > current_version.effective_date %}
-                            You are viewing a future version of this regulation with ammendments that will go into effect on {{ ap_date(requested_version.effective_date) }}.
+                            You are viewing a future version of this regulation with amendments that will go into effect on {{ ap_date(requested_version.effective_date) }}.
                         {% endif %}
                     </p>
                 </div>


### PR DESCRIPTION
Fix a typo and missing margin in the iRegs notification

## Changes

- Fixed the typo: "ammendments" is now "amendments"

## Testing

1. Go to any previous or future version of any regulation, like the previous version of Reg C at http://localhost:8000/policy-compliance/rulemaking/regulations/1003/2018-01-01/
2. Make sure "amendments" is spelled correctly in the notification box and that the notification box is separated from the view links by 30px
3. Hit "view this version" to go to the first page of the regulation
4. Make sure "amendments" is spelled correctly in the notification box (the box was already separated from the content by the correct amount, so no need to test that)

## Screenshots

Current | Fixed
---- | ----
![current](https://user-images.githubusercontent.com/1862695/62640585-e2aac080-b90f-11e9-9588-9b9b3c66bea8.png) | ![fixed](https://user-images.githubusercontent.com/1862695/62640588-e6d6de00-b90f-11e9-80c3-f37929a8d368.png)

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [x] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [x] Chrome on desktop
- [x] Firefox
- [x] Safari on macOS
- [x] Edge
- [x] Internet Explorer 9, 10, and 11
- [x] Safari on iOS
- [x] Chrome on Android

### Accessibility

- [x] Keyboard friendly
- [x] Screen reader friendly

### Other

- [x] Is useable without CSS
- [x] Is useable without JS
- [x] Flexible from small to large screens
- [x] No linting errors or warnings
- [x] JavaScript tests are passing