### PR TITLE
Create featured-content-module.js

### DIFF
--- a/cfgov/unprocessed/js/modules/VideoPlayer.js
+++ b/cfgov/unprocessed/js/modules/VideoPlayer.js
@@ -6,8 +6,8 @@ import * as jsLoader from './util/js-loader';
 
 import ERROR_MESSAGES from '../config/error-messages-config';
 import { assign } from './util/assign';
-import { closest } from './util/dom-traverse';
 import { noopFunct } from './util/standard-type';
+import EventObserver from '../modules/util/EventObserver';
 
 const DOM_INVALID = ERROR_MESSAGES.DOM.INVALID;
 
@@ -18,8 +18,7 @@ const CLASSES = Object.freeze( {
   IFRAME_CLASS_NAME:         'o-video-player_iframe',
   IFRAME_CONTAINER_SELECTOR: '.o-video-player_iframe-container',
   PLAY_BTN_SELECTOR:         '.o-video-player_play-btn',
-  CLOSE_BTN_SELECTOR:        '.o-video-player_close-btn',
-  FCM_CONTAINER_SELECTOR:    '.o-featured-content-module'
+  CLOSE_BTN_SELECTOR:        '.o-video-player_close-btn'
 } );
 
 
@@ -39,10 +38,16 @@ let _this;
  * @param {Object} options - attributes used to extend the video player
  */
 function VideoPlayer( element, options ) {
+
+  // Attach event methods.
+  const eventObserver = new EventObserver();
+  this.addEventListener = eventObserver.addEventListener;
+  this.dispatchEvent = eventObserver.dispatchEvent;
+  this.removeEventListener = eventObserver.removeEventListener;
+
   _this = this;
   options = options || {};
   this.baseElement = _ensureElement( element, options.createIFrame );
-  this.fcmElement = closest( this.baseElement, CLASSES.FCM_CONTAINER_SELECTOR );
   this.iFrameProperties = assign(
     {},
     this.baseElement.dataset,
@@ -285,9 +290,6 @@ const API = {
    * Function used to play the video player.
    */
   play: function play( ) {
-    if ( this.fcmElement ) {
-      this.fcmElement.classList.add( CLASSES.VIDEO_PLAYING_STATE );
-    }
     this.baseElement.classList.add( CLASSES.VIDEO_PLAYING_STATE );
     this.state.setIsVideoPlaying( true );
   },
@@ -296,9 +298,6 @@ const API = {
    * Function used to stop the video player.
    */
   stop: function stop( ) {
-    if ( this.fcmElement ) {
-      this.fcmElement.classList.remove( CLASSES.VIDEO_PLAYING_STATE );
-    }
     this.baseElement.classList.remove( CLASSES.VIDEO_PLAYING_STATE );
     this.state.setIsVideoStopped( true );
   }

--- a/cfgov/unprocessed/js/modules/YoutubePlayer.js
+++ b/cfgov/unprocessed/js/modules/YoutubePlayer.js
@@ -5,6 +5,7 @@
 
 import { noopFunct } from './util/standard-type';
 import VideoPlayer from './VideoPlayer';
+
 let YoutubePlayer;
 
 const CLASSES = Object.freeze( {
@@ -135,6 +136,7 @@ const API = {
    * Action function used to play the Youtube video.
    */
   play: function() {
+    this.dispatchEvent( 'onPlay' );
     this._super.play.call( this );
     if ( this.state.isPlayerInitialized && this.player ) {
       this.player.seekTo( 0 );
@@ -148,6 +150,7 @@ const API = {
    * Action function used to play the Youtube video.
    */
   stop: function() {
+    this.dispatchEvent( 'onStop' );
     this._super.stop.call( this );
     if ( this.state.isPlayerInitialized && this.player ) {
       this.player.stopVideo();

--- a/cfgov/unprocessed/js/organisms/FeaturedContentModule.js
+++ b/cfgov/unprocessed/js/organisms/FeaturedContentModule.js
@@ -1,0 +1,61 @@
+/* ==========================================================================
+   Featured Content Module Class
+   ========================================================================== */
+
+// Required modules.
+import { checkDom, setInitFlag } from '../modules/util/atomic-helpers';
+import YoutubePlayer from '../modules/YoutubePlayer';
+
+const BASE_CLASS = 'o-featured-content-module';
+
+let _dom;
+let _videoPlayer;
+
+/**
+ * FeaturedContentModule
+ * @class
+ *
+ * @classdesc Initializes a new FeaturedContentModule organism.
+ *
+ * @param {HTMLNode} element
+ *   The DOM element within which to search for the organism.
+ * @returns {FeaturedContentModule} An instance.
+ */
+function FeaturedContentModule( element ) {
+  _dom = checkDom( element, BASE_CLASS );
+
+  this.init = init;
+
+  return this;
+}
+
+/**
+ * @returns {FeaturedContentModule} An instance.
+ */
+function init() {
+  setInitFlag( _dom );
+
+  _videoPlayer = YoutubePlayer.init( '.o-video-player' );
+  _videoPlayer.addEventListener( 'onPlay', _videoPlayHandler );
+  _videoPlayer.addEventListener( 'onStop', _videoStopHandler );
+
+  return this;
+}
+
+/**
+ * Event handler for when video has begun playing.
+ */
+function _videoPlayHandler() {
+  _dom.classList.add( 'video-playing' );
+}
+
+/**
+ * Event handler for when video has stopped playing.
+ */
+function _videoStopHandler() {
+  _dom.classList.remove( 'video-playing' );
+}
+
+FeaturedContentModule.BASE_CLASS = BASE_CLASS;
+
+export default FeaturedContentModule;

--- a/cfgov/unprocessed/js/routes/on-demand/featured-content-module.js
+++ b/cfgov/unprocessed/js/routes/on-demand/featured-content-module.js
@@ -1,0 +1,13 @@
+/* ==========================================================================
+   Initialization script for Featured Content Module.
+   ========================================================================== */
+
+import FeaturedContentModule from '../../organisms/FeaturedContentModule';
+
+const featuredContentModuleDom = document.querySelector(
+  `.${ FeaturedContentModule.BASE_CLASS }`
+);
+const featuredContentModule = new FeaturedContentModule(
+  featuredContentModuleDom
+);
+featuredContentModule.init();

--- a/cfgov/v1/atomic_elements/organisms.py
+++ b/cfgov/v1/atomic_elements/organisms.py
@@ -954,7 +954,7 @@ class FeaturedContent(blocks.StructBlock):
         classname = 'block__flush'
 
     class Media:
-        js = ['video-player.js']
+        js = ['featured-content-module.js']
 
 
 class ChartBlock(blocks.StructBlock):


### PR DESCRIPTION
Components shouldn't reach upward into their parent's dom. This creates a FeaturedContentModule that includes a VideoPlayer, as opposed to a VideoPlayer that's aware of FeaturedContentModule classes.

## Additions

- Adds `FeaturedContentModule` and `featured-content-module`.

## Changes

- Makes VideoPlayer dispatch `onPlay` and `onStop` events.

## Testing

1. Pull branch
1. `./frontend.sh`
1. Visit a bunch of different video/FCM pages:
   a. Standard static image FCM: http://localhost:8000/practitioner-resources/your-money-your-goals/
   b. Video FCM: http://localhost:8000/prepaid-rule/
   c. Standalone video: http://localhost:8000/data-research/prepaid-accounts/issuer-instructions/
   d. Event video: localhost:8000/about-us/events/archive-past-events/fall-2018-bcfp-advisory-committee-meetings-washington-dc/


## Notes

- This is spun off work from re-working the video player module.
