### PR TITLE
Remove remaining references to letter_code

### DIFF
--- a/cfgov/regulations3k/jinja2/regulations3k/search-regulations-results.html
+++ b/cfgov/regulations3k/jinja2/regulations3k/search-regulations-results.html
@@ -27,7 +27,6 @@
         <div class="filters_tags">
             {% for reg in page.results.all_regs %}
                 {% if reg.selected %}
-                    {%- set reg_name = '(Reg<span class="u-hide-on-mobile">ulation</span> ' ~ reg.letter_code ~ ')' -%}
                     {%- set reg_name = '(' ~ reg.short_name | regs_hide_on_mobile ~ ')' -%}
                     {{ tag.render({
                         'label': reg.id ~ ' ' ~ reg_name | safe,

--- a/cfgov/regulations3k/jinja2/regulations3k/search-regulations.html
+++ b/cfgov/regulations3k/jinja2/regulations3k/search-regulations.html
@@ -103,8 +103,7 @@
                         <p> </p>
                         <ul class="m-list m-list__unstyled">
                         {% for reg in page.results.all_regs %}
-                            {%- set reg_name = '(Reg<span class="u-hide-on-tablet">ulation</span> ' ~ reg.letter_code ~ ')' -%}
-                            {%- set reg_name = '(' ~ reg.short_name ~ ')' -%}
+                            {%- set reg_name = '(' ~ reg.short_name | regs_hide_on_mobile ~ ')' -%}
                             <li>
                                 {{ checkbox.render({
                                     'label': reg.id ~ ' ' ~ reg_name | safe,


### PR DESCRIPTION
This change removes all remaining references to `letter_code` in the Regulations 3000 search templates. Both instances were mistakenly left in place.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: