### PR TITLE
(smoke tests) set the referer header when requesting static assets

### DIFF
--- a/cfgov/scripts/static_asset_smoke_test.py
+++ b/cfgov/scripts/static_asset_smoke_test.py
@@ -58,7 +58,9 @@ def check_static(url):
             final_url = "{}{}".format(CFPB_BASE, link)
         else:
             final_url = "{}{}".format(url, link)
-        code = requests.get(final_url).status_code
+        code = requests.get(
+            final_url,
+            headers={'referer': CFPB_BASE}).status_code
         if code == 200:
             logger.info("checked {}".format(final_url))
         else:


### PR DESCRIPTION
We've recently added referer checking to some of our static assets (fonts). This caused the static asset smoke test to throw warnings like:

`
Light FAIL!2 static links failed for https://www.consumerfinance.gov: [(u'/static/fonts/2cd55546-ec00-4af9-aeca-4a3cd186
da53.457e94a5b665.woff2', 403), (u'/static/fonts/627fbb5a-3bae-4cd9-b617-2f923e29d55e.24932ad03d18.woff2', 403)] 
`
This small tweak makes it so that the 'referer' header is set to an appropriate value when static assets are fetched/

## Changes

- we send a referer header when requesting static assets.

## Testing

1. `python cfgov/scripts/static_asset_smoke_test.py --base https://beta.consumerfinance.gov -v`
1. `python cfgov/scripts/static_asset_smoke_test.py -v`

(not the lack of "light failures"
## Screenshots


## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [ ] Chrome on desktop
- [ ] Firefox
- [ ] Safari on macOS
- [ ] Edge
- [ ] Internet Explorer 9, 10, and 11
- [ ] Safari on iOS
- [ ] Chrome on Android

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
