### PR TITLE
Allow blob images via csp

### DIFF
--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -568,6 +568,7 @@ CSP_IMG_SRC = (
     'api.mapbox.com',
     '*.tiles.mapbox.com',
     'stats.search.usa.gov',
+    'blob:',
     'data:',
     'www.facebook.com',
     'www.gravatar.com',


### PR DESCRIPTION
Closes GHE/CFGOV/ship-it-better/issues/173

Currently wagtail image upload preview is broken due to the image being injected as a `blob:` url. This change allows images to be injected as blobs, which doesn't create any additional risk (blobs have to be created at the same-origin where they are accessed, meaning if someone is running arbitrary code to generate a blob: url for an image, they already have script access!)