### PR TITLE
Stop using drama-free-django empty virtual environment

### DIFF
--- a/cfgov/apache/conf.d/wsgi.conf
+++ b/cfgov/apache/conf.d/wsgi.conf
@@ -1,7 +1,7 @@
 ServerName consumerfinance.gov
 
 WSGIApplicationGroup %{GLOBAL}
-WSGIDaemonProcess django  python-home=${CFGOV_CURRENT}/empty_venv processes=${APACHE_PROCESS_COUNT} threads=15 display-name=%{GROUP} python-path=${CFGOV_CURRENT}/venv/lib/python2.7/site-packages:${CFGOV_CURRENT}/venv/lib64/python2.7/site-packages:${CFGOV_CURRENT} home=${CFGOV_CURRENT}
+WSGIDaemonProcess django home=${CFGOV_CURRENT} python-home=${CFGOV_CURRENT}/venv processes=${APACHE_PROCESS_COUNT} threads=15 display-name=%{GROUP}
 WSGIProcessGroup django
 WSGIScriptAlias / ${CFGOV_CURRENT}/wsgi.py
 


### PR DESCRIPTION
Currently drama-free-django [sets up two virtual environments](https://github.com/cfpb/drama-free-django/blob/113003e842ab93059b8f15de2828d24051f7e009/no_drama/build_skel/activate.sh#L13) for each deploy. One contains project requirements, and one is empty. To simplify a bit, this commit stops using the empty virtualenv, because we don't need the protection that it is intended to provide.

See mod_wsgi documentation [here](https://modwsgi.readthedocs.io/en/develop/user-guides/virtual-environments.html).

The empty virtual environment is only needed and recommended "when activating the Python virtual environment from within the WSGI script file". We don't do that. Because we don't have multiple WSGI apps being run within the same daemon process group, we can use a single virtual environment.

This simplifies the configuration a bit and also makes it less specific to drama-free-django, for example if we want to test using our Apache config and mod_wsgi-express without using a DFD build. It also removes a hardcoded `python2.7`, making the setup a bit more Python 3-ready.

## Testing

To test this change, you can build a DFD artifact using `docker/drama-free-django/build.sh` and then test it using the internal Ansible process.

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [X] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [X] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: