### PR TITLE
Stop using drama-free-django to set static root

### DIFF
--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -239,9 +239,6 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/1.11/howto/static-files/
 STATIC_URL = '/static/'
 
-# Absolute path to the directory static files should be collected to.
-STATIC_ROOT = os.environ.get('DJANGO_STATIC_ROOT', '/var/www/html/static')
-
 MEDIA_ROOT = os.environ.get('MEDIA_ROOT',
                             os.path.join(PROJECT_ROOT, 'f'))
 MEDIA_URL = '/f/'

--- a/cfgov/cfgov/settings/production.py
+++ b/cfgov/cfgov/settings/production.py
@@ -84,6 +84,8 @@ EMAIL_HOST = os.getenv('EMAIL_HOST')
 
 STATICFILES_STORAGE = 'django.contrib.staticfiles.storage.ManifestStaticFilesStorage'
 
+STATIC_ROOT = os.environ['DJANGO_STATIC_ROOT']
+
 CACHES.update({
     'default': {
         'BACKEND': 'django.core.cache.backends.filebased.FileBasedCache',

--- a/docker/drama-free-django/_build.sh
+++ b/docker/drama-free-django/_build.sh
@@ -48,8 +48,8 @@ no-drama build "${build_args[@]}"
 # This is just a placeholder that gets replaced by Ansible.
 echo "{}" > ./dfd_env.json
 
-# This is used by DFD to set Django's settings.STATIC_ROOT.
-echo '{"static_out": "../../../static"}' > ./dfd_paths.json
+# Disable DFD override of Django settings.STATIC_ROOT.
+echo '{"static_out": null}' > ./dfd_paths.json
 
 no-drama release \
     "./$build_artifact" \


### PR DESCRIPTION
We want to instead set the Django static root through a simple environment variable read into cfgov-refresh settings.

This PR depends on some other internal PRs, including https://github.com/cfpb/drama-free-django/pull/26.

## Notes

In the local/test settings, [we use an alternate local path for `STATIC_ROOT`](https://github.com/cfpb/cfgov-refresh/blob/ef52570d709dbb831a607e7ab2a77619438ceb1c/cfgov/cfgov/settings/local.py#L15). This change makes the production setting more explicit.

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [X] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [X] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: