### PR TITLE
Add unprocessed/apps to gulp config trigger files

### DIFF
--- a/gulp/config.js
+++ b/gulp/config.js
@@ -47,6 +47,7 @@ module.exports = {
     src: paths.unprocessed + '/js/**/*.js',
     otherBuildTriggerFiles: [
       paths.unprocessed + '/js/**/*.js',
+      paths.unprocessed + '/apps/**/js/**/*.js',
       paths.modules,
       './config/**/*.js',
       './gulp/**/*.js'


### PR DESCRIPTION
This change will cause `gulp scripts` to add all files matching `cfgov/unprocessed/apps/**/js/*.js`to its `otherBuildTriggerFiles` setting. This will have the effect of causing all files in an app folder to be rebuilt when one file in that app's `/js/` directory, and thus the final compiled JavaScript files for that ap will have all changes to imported files correctly rebuilt.

## Additions
- Add unprocessed/apps to the gulp config file in the scripts section, under 'otherBuildTriggerFiles'

## Testing
1. Work on a JS file in one of the `/unprocessed/apps/` JavaScript directories
2. Run `gulp scripts`
3. Check to see if your changes were properly rebuilt

## Checklist
- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [x] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

### Other
- [x] No linting errors or warnings
- [x] JavaScript tests are passing
