### PR TITLE
Stop using drama-free-django to use static.in

### DIFF
--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -4,7 +4,7 @@ from django.conf import global_settings
 from django.utils.translation import ugettext_lazy as _
 
 import dj_database_url
-from unipath import Path
+from unipath import DIRS, Path
 
 from cfgov.util import admin_emails
 
@@ -260,6 +260,8 @@ STATICFILES_DIRS = [
     PROJECT_ROOT.child('templates', 'wagtailadmin')
 ]
 
+# Also include any directories under static.in.
+STATICFILES_DIRS += REPOSITORY_ROOT.child('static.in').listdir(filter=DIRS)
 
 ALLOWED_HOSTS = ['*']
 

--- a/cfgov/cfgov/settings/local.py
+++ b/cfgov/cfgov/settings/local.py
@@ -13,7 +13,6 @@ INSTALLED_APPS += (
 )
 
 STATIC_ROOT = REPOSITORY_ROOT.child('collectstatic')
-STATICFILES_DIRS += [str(d) for d in REPOSITORY_ROOT.child('static.in').listdir(filter=DIRS)]
 
 ALLOW_ADMIN_URL = DEBUG or os.environ.get('ALLOW_ADMIN_URL', False)
 

--- a/docker/drama-free-django/_build.sh
+++ b/docker/drama-free-django/_build.sh
@@ -48,8 +48,8 @@ no-drama build "${build_args[@]}"
 # This is just a placeholder that gets replaced by Ansible.
 echo "{}" > ./dfd_env.json
 
-# Disable DFD override of Django settings.STATIC_ROOT.
-echo '{"static_out": null}' > ./dfd_paths.json
+# Disable DFD override of staticfiles-related Django settings.
+echo '{"build_static_in": null, "static_in": null, "static_out": null}' > ./dfd_paths.json
 
 no-drama release \
     "./$build_artifact" \


### PR DESCRIPTION
This project currently includes a static.in subdirectory for specifying additional staticfiles directories for Django besides those explicitly listed in settings. This is currently used only when using settings.local.

In production, this same directory is configured via some behavior in drama-free-django. To reduce dependence on drama-free-django, this commit instead modifies settings.base so that static.in is always included, both in local and production settings.

This change depends on https://github.com/cfpb/drama-free-django/pull/27 which allows DFD to be used while skipping its static.in behavior.

## Testing

This change can best be tested using a version of drama-free-django with the changes in https://github.com/cfpb/drama-free-django/pull/27 merged in, either by waiting until that PR is merged or by making a temporary edit to use the fork:

```diff
diff --git a/docker/drama-free-django/Dockerfile b/docker/drama-free-django/Dockerfile
index f593374..0472524 100644
--- a/docker/drama-free-django/Dockerfile
+++ b/docker/drama-free-django/Dockerfile
@@ -26,7 +26,7 @@ RUN yum install -y centos-release-scl && \
     echo "source scl_source enable ${SCL_PYTHON_VERSION}" > /etc/profile.d/scl_python.sh && \
     source /etc/profile && \
     pip install --no-cache-dir -U pip && \
-    pip install -U git+https://github.com/cfpb/drama-free-django.git
+    pip install -U git+https://github.com/chosak/drama-free-django.git@optional-static-in
 
 COPY _build.sh _test.sh docker-entrypoint.sh ./
```

In either case, you can use the local DFD build process in this repository by running

```
$ docker/drama-free-django/build.sh
```

This will create a DFD release called cfgov_current_build.zip in your local directory ([as documented here](https://github.com/cfpb/cfgov-refresh/blob/master/docker/drama-free-django/README.md)). This can then be used with our internal repository to test against a real Ansible deploy.

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [X] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [X] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: