### PR TITLE
Don't cache the dfd install in the dfd docker build

### DIFF
--- a/docker/drama-free-django/Dockerfile
+++ b/docker/drama-free-django/Dockerfile
@@ -30,7 +30,7 @@ RUN yum install -y centos-release-scl && \
 # Set cache-busting arg, a unique value should be provided when the build is invoked
 ARG CACHEBUST
 
-RUN pip install -U git+https://github.com/cfpb/drama-free-django.git
+RUN source /etc/profile && pip install -U git+https://github.com/cfpb/drama-free-django.git
 COPY _build.sh _test.sh docker-entrypoint.sh ./
 
 ENTRYPOINT ["./docker-entrypoint.sh"]

--- a/docker/drama-free-django/Dockerfile
+++ b/docker/drama-free-django/Dockerfile
@@ -25,9 +25,12 @@ RUN yum install -y centos-release-scl && \
     yum install -y ${SCL_PYTHON_VERSION} gcc git nodejs yarn && \
     echo "source scl_source enable ${SCL_PYTHON_VERSION}" > /etc/profile.d/scl_python.sh && \
     source /etc/profile && \
-    pip install --no-cache-dir -U pip && \
-    pip install -U git+https://github.com/cfpb/drama-free-django.git
+    pip install --no-cache-dir -U pip
 
+# Set cache-busting arg, a unique value should be provided when the build is invoked
+ARG CACHEBUST
+
+RUN pip install -U git+https://github.com/cfpb/drama-free-django.git
 COPY _build.sh _test.sh docker-entrypoint.sh ./
 
 ENTRYPOINT ["./docker-entrypoint.sh"]

--- a/docker/drama-free-django/build.sh
+++ b/docker/drama-free-django/build.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-docker build -t cfgov-dfd-builder docker/drama-free-django
+docker build --build-arg "CACHEBUST=$(date)" -t cfgov-dfd-builder docker/drama-free-django
 
 docker run \
   --rm \

--- a/docker/drama-free-django/test.sh
+++ b/docker/drama-free-django/test.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-docker build -t cfgov-dfd-builder docker/drama-free-django
+docker build --build-arg "CACHEBUST=$(date)" -t cfgov-dfd-builder docker/drama-free-django
 
 docker run \
   --rm \


### PR DESCRIPTION
This addresses the problem andy described in https://github.com/cfpb/cfgov-refresh/pull/5173, but with a **COOL HACK** that allows us to use most of the cache while always getting fresh code from drama-free-django.

## Testing:
Follow the instructions [here](https://github.com/cfpb/cfgov-refresh/tree/master/docker/drama-free-django) two times in a row. You'll note that for at least the second attempt, the first 9 steps should use the cache, but no others (depending on if you've run these commands before the first 8 images will likely be cached on your first run as well). 