### PR TITLE
new docker stage that builds and collects frontend assets

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,9 +3,9 @@ develop-apps
 collectstatic
 *.sql
 .github
-gulp
 node_modules
 docs
 .vendor
 html
 .git
+.zip

--- a/Dockerfile
+++ b/Dockerfile
@@ -76,10 +76,11 @@ COPY jest.config.js .
 COPY cfgov/ ./cfgov/
 COPY static.in ./static.in
 
-ENV DJANGO_SETTINGS_MODULE=cfgov.settings.minimal_collectstatic
+ENV DJANGO_SETTINGS_MODULE=cfgov.settings.production
 ENV ALLOWED_HOSTS='["*"]'
-ENTRYPOINT []
 
 RUN sh ./frontend.sh production
 
 RUN DJANGO_STATIC_ROOT=/var/www/html/static cfgov/manage.py collectstatic
+
+ENTRYPOINT []

--- a/Dockerfile
+++ b/Dockerfile
@@ -57,7 +57,7 @@ FROM cfgov-develop as cfgov-build
 
 # add node and yarn repos
 RUN curl -sL https://rpm.nodesource.com/setup_10.x | bash -
-RUN curl --silent --location https://dl.yarnpkg.com/rpm/yarn.repo | tee /etc/yum.repos.d/yarn.repo
+RUN curl -sL https://dl.yarnpkg.com/rpm/yarn.repo | tee /etc/yum.repos.d/yarn.repo
 
 RUN yum install -y nodejs yarn  && \
     yum clean all && rm -rf /var/cache/yum
@@ -69,7 +69,7 @@ COPY gulp ./gulp
 COPY static.in ./static.in
 COPY scripts ./scripts
 
-COPY frontend.sh gulpfile.js jest.config.js package.json yarn.lock /src/cfgov-refresh/
+COPY docker-entrypoint.sh frontend.sh gulpfile.js jest.config.js package.json yarn.lock /src/cfgov-refresh/
 
 ENV DJANGO_SETTINGS_MODULE=cfgov.settings.production
 ENV DJANGO_STATIC_ROOT=/var/www/html/static

--- a/cfgov/cfgov/settings/minimal_collectstatic.py
+++ b/cfgov/cfgov/settings/minimal_collectstatic.py
@@ -1,7 +1,0 @@
-from unipath import DIRS
-
-from .base import *
-from .production import STATICFILES_STORAGE, STATIC_ROOT
-
-
-# STATICFILES_DIRS += [str(d) for d in REPOSITORY_ROOT.child('static.in').listdir(filter=DIRS)]

--- a/cfgov/cfgov/settings/minimal_collectstatic.py
+++ b/cfgov/cfgov/settings/minimal_collectstatic.py
@@ -1,0 +1,7 @@
+from unipath import DIRS
+
+from .base import *
+from .production import STATICFILES_STORAGE, STATIC_ROOT
+
+
+# STATICFILES_DIRS += [str(d) for d in REPOSITORY_ROOT.child('static.in').listdir(filter=DIRS)]


### PR DESCRIPTION
This adds an additional stage to the Dockerfile that installs Node 10, yarn, runs the front-end build, and runs collectstatic in production mode (putting the resulting files in /var/www/html/static )

This will not change life for docker-compose users, since the python containers are [pinned to to the cfgov-dev stage](https://github.com/cfpb/cfgov-refresh/blob/docker-multistage/docker-compose.yml#L25)

## Additions

- cfgov-build docker stage

## Testing

`docker build . --build-arg scl_python_version=rh-python36 --target cfgov-build -t tmp && docker run -it tmp:latest bash` should run the whole build, and drop you in a shell session where you can inspect the results. You can see the built (and post-processed) static files in /var/www/html/static

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [ ] Chrome on desktop
- [ ] Firefox
- [ ] Safari on macOS
- [ ] Edge
- [ ] Internet Explorer 9, 10, and 11
- [ ] Safari on iOS
- [ ] Chrome on Android

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
