### PR TITLE
Restore org chart download

### DIFF
--- a/cfgov/jinja2/v1/_includes/organisms/bureau-structure.html
+++ b/cfgov/jinja2/v1/_includes/organisms/bureau-structure.html
@@ -267,11 +267,13 @@
                 Download a printable, PDF copy of this organizational chart. This version
                 is expanded to show all offices.
             </p>
-            <b>
-                <i>
-                    Currently under revision
-                </i>
-            </b>
+            <a class="a-btn"
+               href="{{ download_image_url }}">
+                <span class="a-btn_icon a-btn_icon__on-left">
+                    {{ svg_icon('save') }}
+                </span>
+                Download PDF
+             </a>
         </div>
         <div class="content-l_col content-l_col-1-2">
             <h2 class="h3">Request speaking info</h2>


### PR DESCRIPTION
Opening on behalf of @niqjohnson.

The Bureau wishes to restore the PDF download capability for our org chart, now that it has stabilized for a while.

## Changes

- Replaces placeholder statement with a new download button.

## Testing

1. Pull branch
1. View http://localhost:8000/about-us/the-bureau/bureau-structure/ and verify that the download button shows. If it does not, you may need to either get a fresh database dump, or just choose a file in the "Download image" field on http://localhost:8000/admin/pages/4611/edit/

## Screenshots

![](https://user-images.githubusercontent.com/1044670/63378936-3df19f80-c361-11e9-95e2-93db63ef7b53.png)

## Notes

- It might be nice to make the `download_image` field optional, and output a similar "Currently under revision" message if it's not present. That would prevent needing PRs like this or the one that came before if we have a similar situation in the future.

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
