### PR TITLE
Add fourth note to Bureau Structure chart legend

### DIFF
--- a/cfgov/jinja2/v1/_includes/organisms/bureau-structure.html
+++ b/cfgov/jinja2/v1/_includes/organisms/bureau-structure.html
@@ -237,6 +237,13 @@
                 Position is not part of the Bureau director’s office
             </span>
         </li>
+        <li class="m-list_item">
+            <span class="o-bureau-structure_legend_symbol">****</span>
+            <span class="o-bureau-structure_legend_definition">
+                Position has direct reporting responsibilities to
+                the Policy Associate Director for External Affairs
+            </span>
+        </li>
 </section>
 {%- endmacro %}
 

--- a/cfgov/unprocessed/css/organisms/bureau-structure.less
+++ b/cfgov/unprocessed/css/organisms/bureau-structure.less
@@ -289,11 +289,12 @@
         display: block;
         width: @margin;
         float: left;
+        text-align: right;
     }
 
     &_definition {
         display: block;
-        margin-left: @margin;
+        margin-left: @margin * 1.25;
     }
 
     .respond-to-max( @bp-xs-max, {


### PR DESCRIPTION
One of the changes to the org chart requires a new note to be added to the legend. This does that.

## Additions

- Adds `**** Position has direct reporting responsibilities to the Policy Associate Director for External Affairs` to the Bureau Structure legend.

## Testing

1. Pull branch
1. `gulp clean && gulp build`
1. Visit http://localhost:8000/about-us/the-bureau/bureau-structure/ and scroll down to the legend

## Screenshots

![Screenshot of chart legend with new note added](https://user-images.githubusercontent.com/1044670/63456001-03990880-c41c-11e9-91f0-d1eddfd36714.png)

## Notes

- It'd be nice if these could be editable in Wagtail someday.
- Four asterisks is getting a little ridiculous. Should consider switching to alternate symbols or superscript numbers, perhaps.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [x] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
