### PR TITLE
Add support for running Apache with Python 3.6

### DIFF
--- a/cfgov/apache/conf.d/wsgi.conf
+++ b/cfgov/apache/conf.d/wsgi.conf
@@ -1,5 +1,7 @@
 ServerName consumerfinance.gov
 
+LoadModule wsgi_module modules/mod_${PYTHON_VERSION}-wsgi.so
+
 WSGIApplicationGroup %{GLOBAL}
 WSGIDaemonProcess django home=${CFGOV_CURRENT} python-home=${CFGOV_CURRENT}/venv processes=${APACHE_PROCESS_COUNT} threads=15 display-name=%{GROUP}
 WSGIProcessGroup django

--- a/cfgov/apache/conf.modules.d/00-base.conf
+++ b/cfgov/apache/conf.modules.d/00-base.conf
@@ -4,7 +4,6 @@
 #
 
 LoadModule mpm_event_module modules/mod_mpm_event.so
-LoadModule wsgi_module modules/mod_python27-wsgi.so
 LoadModule access_compat_module modules/mod_access_compat.so
 LoadModule actions_module modules/mod_actions.so
 LoadModule alias_module modules/mod_alias.so


### PR DESCRIPTION
Currently the Apache configuration is hardcoded to use the Python 2.7 version of mod_wsgi. We want to optionally support running with the Python 3.6 version instead.

Currently we install mod_wsgi using the python27-mod_wsgi package, which installs a `mod_python27-wsgi.so` module. If we also install the rh-python36-mod_wsgi package, it installs the Python 3.6-compatible version alongside, named `mod_rh-python36-wsgi.so`.

In order to toggle between these two, this change relies on the presence of a `PYTHON_VERSION` environment variable that needs to be passed to Apache. See internal Ansible repo PR 321 that adds this variable. This PR is blocked until that one is merged.

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [X] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [X] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: