### PR TITLE
Remove leading slash from YES URL

### DIFF
--- a/cfgov/cfgov/urls.py
+++ b/cfgov/cfgov/urls.py
@@ -74,7 +74,7 @@ def empty_200_response(request, *args, **kwargs):
 
 
 urlpatterns = [
-    url(r'/resources-youth-employment-programs/transportation-tool/$',
+    url(r'^resources-youth-employment-programs/transportation-tool/$',
         TemplateView.as_view(
             template_name='youth_employment_success/index.html'),
             name='youth_employment_success'


### PR DESCRIPTION
The YES page introduced in #5176 introduces a Django warning due to a leading slash in the URL pattern. Using a leading slash in URL patterns is unnecessary and generates this Django warning:

```
WARNINGS:

?: (urls.W002) Your URL pattern '/resources-youth-employment-programs/transportation-tool/$' [name='youth_employment_success'] has a regex beginning with a '/'. Remove this slash as it is unnecessary. If this pattern is targeted in an include(), ensure the include() pattern has a trailing '/'.
```

(You can see this warning in the Travis run [here](https://travis-ci.org/cfpb/cfgov-refresh/jobs/575079458).)


## Testing

Running locally against this branch, confirm that you can still visit the YES page successfully: http://localhost:8000/resources-youth-employment-programs/transportation-tool/.

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [X] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [X] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: