### PR TITLE
Adds reducer and specs for routeOptionReducer

### DIFF
--- a/cfgov/cfgov/urls.py
+++ b/cfgov/cfgov/urls.py
@@ -305,7 +305,7 @@ urlpatterns = [
             RedirectView.as_view(
                 url='/consumer-tools/money-as-you-grow/%(path)s',
                 permanent=True)),
-    url(r'^resources-youth-employment-programs/transportation-tool/$',
+    url(r'^practitioner-resources/resources-youth-employment-programs/transportation-tool/$',  # noqa: E501
         FlaggedTemplateView.as_view(
             flag_name='YOUTH_EMPLOYMENT_SUCCESS',
             template_name='youth_employment_success/index.html'

--- a/cfgov/unprocessed/apps/youth-employment-success/js/reducers/budget-reducer.js
+++ b/cfgov/unprocessed/apps/youth-employment-success/js/reducers/budget-reducer.js
@@ -1,4 +1,4 @@
-import { assign } from '../util';
+import { actionCreator, assign } from '../util';
 
 export const initialState = {
   earned: '',
@@ -10,13 +10,8 @@ export const actionTypes = {
   UPDATE_SPENT: 'UPDATE_SPENT'
 };
 
-const updateAction = actionType => amount => ( {
-  type: actionType,
-  data: amount
-} );
-
-export const updateEarnedAction = updateAction( actionTypes.UPDATE_EARNED );
-export const updateSpentAction = updateAction( actionTypes.UPDATE_SPENT );
+export const updateEarnedAction = actionCreator( actionTypes.UPDATE_EARNED );
+export const updateSpentAction = actionCreator( actionTypes.UPDATE_SPENT );
 
 /**
  *

--- a/cfgov/unprocessed/apps/youth-employment-success/js/reducers/route-option-reducer.js
+++ b/cfgov/unprocessed/apps/youth-employment-success/js/reducers/route-option-reducer.js
@@ -1,0 +1,86 @@
+import { actionCreator, assign } from '../util';
+
+const initialState = {
+  selectedTransportation: [],
+  daysPerWeek: '',
+  miles: '',
+  dailyCost: ''
+};
+const actionTypes = {
+  UPDATE_TRANSPORTATION: 'UPDATE_TRANSPORTATION',
+  UPDATE_MILES: 'UPDATE_MILES',
+  UPDATE_DAILY_COST: 'UPDATE_DAILY_COST',
+  UPDATE_DAYS_PER_WEEK: 'UPDATE_DAYS_PER_WEEK'
+};
+
+const updateTransportationAction = actionCreator(
+  actionTypes.UPDATE_TRANSPORTATION
+);
+const updateMilesAction = actionCreator(
+  actionTypes.UPDATE_MILES
+);
+const updateDaysPerWeekAction = actionCreator(
+  actionTypes.UPDATE_DAYS_PER_WEEK
+);
+const updateDailyCostAction = actionCreator(
+  actionTypes.UPDATE_DAILY_COST
+);
+
+/**
+ *
+ * @param {object} state the current state of the reducer
+ * @param {string} nextSelection the item to add or remove from the
+ *  array of selected transportation options
+ * @returns {array} the new transportation option array
+ */
+function updateTransportation( state, nextSelection ) {
+  const { selectedTransportation: transportation } = state;
+  const index = transportation.indexOf( nextSelection );
+
+  if ( index > -1 ) {
+    transportation.splice( index, 1 );
+  } else {
+    transportation.push( nextSelection );
+  }
+
+  return transportation;
+}
+
+/**
+ *
+ * @param {object} state the current values for this slice of app state
+ * @param {object} action instructs reducer which state update to apply
+ * @returns {object} the updated state object
+ */
+function routeOptionReducer( state = initialState, action ) {
+  const { type, data } = action;
+
+  switch ( type ) {
+    case actionTypes.UPDATE_DAILY_COST: {
+      return assign( state, { dailyCost: data } );
+    }
+    case actionTypes.UPDATE_DAYS_PER_WEEK: {
+      return assign( state, { daysPerWeek: data } );
+    }
+    case actionTypes.UPDATE_MILES: {
+      return assign( state, { miles: data } );
+    }
+    case actionTypes.UPDATE_TRANSPORTATION: {
+      return assign( state, {
+        selectedTransportation: updateTransportation( state, data )
+      } );
+    }
+    default:
+      return state;
+  }
+}
+
+export {
+  initialState,
+  updateTransportationAction,
+  updateMilesAction,
+  updateDaysPerWeekAction,
+  updateDailyCostAction
+};
+
+export default routeOptionReducer;

--- a/cfgov/unprocessed/apps/youth-employment-success/js/util.js
+++ b/cfgov/unprocessed/apps/youth-employment-success/js/util.js
@@ -1,7 +1,22 @@
 let UNDEFINED;
 
 const REDUCER_RETURN_ERROR = 'Reducer must return a state object';
-const INVALID_ARG_ERROR = 'reducers argument must be an object, where each value is a reducer function';
+const INVALID_ARG_ERROR = 'The "reducers" argument must be an object, where each value is a reducer function';
+
+/**
+ * Helper method to generate an action creator
+ * @param {string} actionType The name of the action to be dispatched
+ * @returns {function} Curried action creator function that accepts a
+ *   data argument and returns an action
+ */
+function actionCreator( actionType ) {
+  return function( data ) {
+    return {
+      type: actionType,
+      data
+    };
+  };
+}
 
 /**
  *
@@ -59,7 +74,7 @@ const processStateFromReducers = reducers => (
   return hasChanged ? finalState : state;
 };
 
-export const combineReducers = reducers => {
+const combineReducers = reducers => {
   if ( reducers && typeof reducers !== 'object' ) {
     throw new TypeError( INVALID_ARG_ERROR );
   }
@@ -105,6 +120,8 @@ function assign( output = {}, source ) {
 }
 
 export {
+  actionCreator,
   assign,
+  combineReducers,
   UNDEFINED
 };

--- a/test/unit_tests/apps/youth-employment-success/js/reducers/route-option-reducer-spec.js
+++ b/test/unit_tests/apps/youth-employment-success/js/reducers/route-option-reducer-spec.js
@@ -1,0 +1,81 @@
+import routeOptionReducer, {
+  initialState,
+  updateDailyCostAction,
+  updateDaysPerWeekAction,
+  updateMilesAction,
+  updateTransportationAction
+} from '../../../../../../cfgov/unprocessed/apps/youth-employment-success/js/reducers/route-option-reducer';
+import { UNDEFINED } from '../../../../../../cfgov/unprocessed/apps/youth-employment-success/js/util';
+
+// Arbitrary value to ensure reducer is updating properly
+const nextValue = '15';
+
+describe( 'routeOptionReducer', () => {
+  it( 'returns an initial state when it recevives an unsupported action type', () => {
+    const state = routeOptionReducer( UNDEFINED, { type: null } );
+
+    expect( state ).toEqual( initialState );
+  } );
+
+  it( 'reduces .updateDailyCostAction', () => {
+    const state = routeOptionReducer(
+      UNDEFINED,
+      updateDailyCostAction( nextValue )
+    );
+    const { dailyCost, ...rest } = state;
+
+    expect( dailyCost ).toBe( nextValue );
+    Object.entries( rest ).forEach( ( [ key, value ] ) => expect( value ).toBe( initialState[key] )
+    );
+  } );
+
+  it( 'reduces .updateDaysPerWeekAction', () => {
+    const state = routeOptionReducer(
+      UNDEFINED,
+      updateDaysPerWeekAction( nextValue )
+    );
+    const { daysPerWeek, ...rest } = state;
+
+    expect( daysPerWeek ).toBe( nextValue );
+    Object.entries( rest ).forEach( ( [ key, value ] ) => expect( value ).toBe( initialState[key] )
+    );
+  } );
+
+  it( 'reduces .updateMilesAction', () => {
+    const state = routeOptionReducer(
+      UNDEFINED,
+      updateMilesAction( nextValue )
+    );
+    const { miles, ...rest } = state;
+    expect( miles ).toBe( nextValue );
+    Object.entries( rest ).forEach( ( [ key, value ] ) => expect( value ).toBe( initialState[key] )
+    );
+  } );
+
+  it( 'reduces .updateTransportation', () => {
+    let state = routeOptionReducer(
+      initialState,
+      updateTransportationAction( 'Walk' )
+    );
+    const { selectedTransportation: transportation } = state;
+
+    expect( transportation.length ).toBe( 1 );
+    expect( transportation[0] ).toBe( 'Walk' );
+
+    state = routeOptionReducer(
+      state,
+      updateTransportationAction( 'Drive' )
+    );
+
+    expect( transportation.length ).toBe( 2 );
+    expect( transportation[1] ).toBe( 'Drive' );
+
+    state = routeOptionReducer(
+      state,
+      updateTransportationAction( 'Walk' )
+    );
+
+    expect( transportation.length ).toBe( 1 );
+    expect( transportation[0] ).toBe( 'Drive' );
+  } );
+} );

--- a/test/unit_tests/apps/youth-employment-success/js/util-spec.js
+++ b/test/unit_tests/apps/youth-employment-success/js/util-spec.js
@@ -1,5 +1,6 @@
 import {
   UNDEFINED,
+  actionCreator,
   assign,
   combineReducers
 } from '../../../../../cfgov/unprocessed/apps/youth-employment-success/js/util';
@@ -42,6 +43,22 @@ const reducerB = ( () => ( state = reducerStateB, action ) => {
 } )();
 
 describe( 'YES utility functions', () => {
+  describe( 'action', () => {
+    const actionType = 'MY_ACTION';
+
+    it( 'returns a curried function', () => {
+      expect( typeof actionCreator( actionType ) === 'function' ).toBeTruthy();
+    } );
+
+    it( 'returns an action object when the curried fn is called', () => {
+      const data = 'hello';
+      const actionObj = actionCreator( actionType )( data );
+
+      expect( actionObj.type ).toBe( actionType );
+      expect( actionObj.data ).toBe( data );
+    } );
+  } );
+
   describe( 'assign', () => {
     const originalObject = {
       agency: 'CFPB'


### PR DESCRIPTION
[Short description explaining the high-level reason for the pull request]

## Additions

- Specs for `routeOptionReducer`
- Specs for `actionCreator` utility function

## Removals
N/A

## Changes

- Adds proper path to YES url

## Testing

1. If the YES flag is enabled, the following URL should serve the in progress transportation tool page:  `practitioner-resources/resources-youth-employment-programs/transportation-tool/`

## Screenshots
N/A

## Notes
N/A

## Todos
N/A

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [ ] Chrome on desktop
- [ ] Firefox
- [ ] Safari on macOS
- [ ] Edge
- [ ] Internet Explorer 9, 10, and 11
- [ ] Safari on iOS
- [ ] Chrome on Android

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
