### PR TITLE
Help symlinked wsgi.py find New Relic config file

### DIFF
--- a/cfgov/cfgov/wsgi.py
+++ b/cfgov/cfgov/wsgi.py
@@ -14,7 +14,7 @@ def initialize_new_relic():
     if os.getenv('NEW_RELIC_LICENSE_KEY'):
         new_relic_config_file = os.path.abspath(
             os.path.join(
-                os.path.dirname(os.path.abspath(__file__)),
+                os.path.dirname(os.path.realpath(__file__)),
                 '../newrelic.ini'
             )
         )


### PR DESCRIPTION
Our wsgi.py file points to a New Relic config file using a relative path, based on our knowledge of where these two files are related to each other in the file tree.

Using the new deployable zipfile functionality recently introduced in #5179, we put a symlink from a wsgi.py file in the root of the deploy directory pointing to the real wsgi.py. This means that when wsgi.py is accessed, its `__file__` may be a symlink. This causes the relative location of the New Relic configuration file to be wrong, which can prevent the website from working right when NR is enabled.

This change modifies an [`os.path.abspath`](https://docs.python.org/2/library/os.path.html#os.path.abspath) call to change it to an [`os.path.realpath`](https://docs.python.org/2/library/os.path.html#os.path.realpath) call, letting us always use the "real" location of wsgi.py when locating newrelic.ini.

## Testing

Testing this essentially relies running a full deploy against a server configured with New Relic. I've done this successfully against our internal DEV4 server.

Another way to confirm the behavior of these Python calls:

```
>>> import os
>>> os.path.abspath('/srv/cfgov/current/wsgi.py')
'/srv/cfgov/current/wsgi.py'
>>> os.path.realpath('/srv/cfgov/current/wsgi.py')
'/srv/cfgov/versions/20190822165051/current/cfgov/cfgov/wsgi.py'
```

The latter properly returns the real path, without the symlink.

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [X] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [X] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: