### PR TITLE
Fix Python 3-incompatible code in Related Posts

### DIFF
--- a/cfgov/jinja2/v1/_includes/molecules/related-posts.html
+++ b/cfgov/jinja2/v1/_includes/molecules/related-posts.html
@@ -94,7 +94,7 @@
             </h2>
         </header>
     {% endif %}
-    {% for post_type, post_type_list in posts.iteritems() %}
+    {% for post_type, post_type_list in posts.items() %}
         {% set title, icon = (post_type, category_icon.render(post_type)) or ("Blog", category_icon.render('blog')) %}
         <div class="m-related-posts_list-container">
             {% if value.show_heading %}


### PR DESCRIPTION
This change changes a use of [`iteritems()` to `items()`](https://python-future.org/compatible_idioms.html#iterating-through-dict-keys-values-items) to make the related posts template compatible with both Python 2 and Python 3. 

Currently the related posts module doesn't work in Python 3 because of this. I've added a test case to cover this behavior.

In Python 2, going from `iteritems()` (an iterator) to `items()` (a list) could in theory be slightly slower, but in practice the related posts module only has a maximum of 9 items, so this shouldn't have a big impact on performance.

## Testing

See new unit test. Also visit [any page](http://localhost:8000/about-us/blog/protect-yourself-credit-card-fraud-register/) locally that has a related posts module in the sidebar.

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [X] Passes all existing automated tests
- [X] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [X] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [X] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: