### PR TITLE
Add multiple route options to reducer

### DIFF
--- a/cfgov/jinja2/v1/youth_employment_success/index.html
+++ b/cfgov/jinja2/v1/youth_employment_success/index.html
@@ -17,7 +17,7 @@
       {% include "budget-form.html" %}
       <div class="yes-routes o-expandable-group o-expandable-group__accordion">
         <div class="content-l">
-          {% for i in range(3) %}
+          {% for i in range(2) %}
             {% with id=i+1 %}
               {% include "route-option.html" %}
             {% endwith %}

--- a/cfgov/unprocessed/apps/youth-employment-success/js/index.js
+++ b/cfgov/unprocessed/apps/youth-employment-success/js/index.js
@@ -1,32 +1,33 @@
 import Expandable from 'cf-expandables/src/Expandable';
+import { addRouteOptionAction } from './reducers/route-option-reducer';
 import budgetFormView from './budget-form-view';
+import createRoute from './route.js';
 import routeOptionFormView from './route-option-view';
 import store from './store';
+
 
 const BUDGET_CLASSES = budgetFormView.CLASSES;
 const OPTION_CLASSES = routeOptionFormView.CLASSES;
 
 const budgetFormEl = document.querySelector( `.${ BUDGET_CLASSES.FORM }` );
 const budgetForm = budgetFormView( budgetFormEl, { store } );
-
-const routeOptionsEl = document.querySelector( `.${ OPTION_CLASSES.FORM }` );
-const routeOptionsForm = routeOptionFormView( routeOptionsEl, { store } );
-
 budgetForm.init();
+
 const expandables = Expandable.init();
-routeOptionsForm.init();
+const routeOptionForms = expandables.map( ( expandable, index ) => {
+  store.dispatch( addRouteOptionAction( createRoute() ) );
 
-expandables.reverse().forEach( expandable => {
-  expandable.element.querySelector( '.o-expandable_target' ).click();
-
-  /* why doesn't this work properly?
-     expandable.toggleTargetState(
-     expandable.element.querySelector('.o-expandable_target')
-     )
-     expandable.toggleTargetState(
-     expandable.element.querySelector('.o-expandable_content')
-     ) */
+  const routeOptionsEl = expandable.element.querySelector( `.${ OPTION_CLASSES.FORM }` );
+  return routeOptionFormView( routeOptionsEl, { store, routeIndex: index } );
 } );
+
+/* only initialize the first form, the other gets initialized when
+   the user clicks the add another option button */
+routeOptionForms[0].init();
+
+expandables[0].element.querySelector( '.o-expandable_target' ).click();
+// target the last element, reverse is destructive
+expandables[1].element.classList.add( 'u-hidden' );
 
 window.onbeforeunload = () => {
   budgetForm.destroy();

--- a/cfgov/unprocessed/apps/youth-employment-success/js/reducers/route-option-reducer.js
+++ b/cfgov/unprocessed/apps/youth-employment-success/js/reducers/route-option-reducer.js
@@ -1,18 +1,20 @@
 import { actionCreator, assign } from '../util';
 
 const initialState = {
-  transportation: '',
-  daysPerWeek: '',
-  miles: '',
-  dailyCost: ''
+  routes: []
 };
-const actionTypes = {
+
+const actionTypes = Object.freeze( {
+  ADD_ROUTE_OPTION: 'ADD_ROUTE_OPTION',
   UPDATE_TRANSPORTATION: 'UPDATE_TRANSPORTATION',
   UPDATE_MILES: 'UPDATE_MILES',
   UPDATE_DAILY_COST: 'UPDATE_DAILY_COST',
   UPDATE_DAYS_PER_WEEK: 'UPDATE_DAYS_PER_WEEK'
-};
+} );
 
+const addRouteOptionAction = actionCreator(
+  actionTypes.ADD_ROUTE_OPTION
+);
 const updateTransportationAction = actionCreator(
   actionTypes.UPDATE_TRANSPORTATION
 );
@@ -28,6 +30,48 @@ const updateDailyCostAction = actionCreator(
 
 /**
  *
+ * @param {object} state the current state of this reducer
+ * @param {number} index the index of the route we want to retrieve
+ * @returns {object} the route object at the desired index
+ */
+function routeSelector( state, index ) {
+  return state.routes[index] || {};
+}
+
+/**
+ *
+ * @param {array} routes Route options the user has created
+ * @param {object} nextRoute a route model object
+ * @returns {array} the array of routes with the most recent route added
+ */
+function addRouteOption( routes, nextRoute ) {
+  return routes.concat( nextRoute );
+}
+
+/**
+ *
+ * @param {array} routes the array of routes in the reducer's state
+ * @param {number} routeIndex the index of the route object we want to update
+ * @param {object} data object describing the updates we want to make
+ *  to the route object's proeprties
+ * @returns {object} the next state of the reducer
+ */
+function updateRouteData( routes, routeIndex, data ) {
+  const computedState = {
+    routes: routes.map( ( route, index ) => {
+      if ( index !== routeIndex ) {
+        return route;
+      }
+
+      return assign( route, data );
+    } )
+  };
+
+  return computedState;
+}
+
+/**
+ *
  * @param {object} state the current values for this slice of app state
  * @param {object} action instructs reducer which state update to apply
  * @returns {object} the updated state object
@@ -36,19 +80,33 @@ function routeOptionReducer( state = initialState, action ) {
   const { type, data } = action;
 
   switch ( type ) {
+    case actionTypes.ADD_ROUTE_OPTION: {
+      return assign( state, {
+        routes: addRouteOption( state.routes, data )
+      } );
+    }
     case actionTypes.UPDATE_DAILY_COST: {
-      return assign( state, { dailyCost: data } );
+      return assign( state, updateRouteData(
+        state.routes,
+        data.routeIndex,
+        { dailyCost: data.value } )
+      );
     }
     case actionTypes.UPDATE_DAYS_PER_WEEK: {
-      return assign( state, { daysPerWeek: data } );
+      return assign( state, updateRouteData( state.routes, data.routeIndex, {
+        daysPerWeek: data.value
+      } ) );
     }
     case actionTypes.UPDATE_MILES: {
-      return assign( state, { miles: data } );
+      return assign( state, updateRouteData( state.routes, data.routeIndex, {
+        miles: data.value
+      } ) );
     }
     case actionTypes.UPDATE_TRANSPORTATION: {
-      return assign( state, {
-        transportation: data
-      } );
+      return assign( state, updateRouteData( state.routes, data.routeIndex, {
+        transportation: data.value
+      } )
+      );
     }
     default:
       return state;
@@ -57,6 +115,8 @@ function routeOptionReducer( state = initialState, action ) {
 
 export {
   initialState,
+  addRouteOptionAction,
+  routeSelector,
   updateTransportationAction,
   updateMilesAction,
   updateDaysPerWeekAction,

--- a/cfgov/unprocessed/apps/youth-employment-success/js/route-option-view.js
+++ b/cfgov/unprocessed/apps/youth-employment-success/js/route-option-view.js
@@ -1,6 +1,7 @@
 import { checkDom, destroyInitFlag, setInitFlag } from '../../../js/modules/util/atomic-helpers';
 import inputView from './input-view';
 import {
+  routeSelector,
   updateDailyCostAction,
   updateDaysPerWeekAction,
   updateMilesAction,
@@ -29,12 +30,12 @@ const actionMap = Object.freeze( {
  *  The root DOM element for this view
  * @returns {Object} The view's public methods
  */
-function RouteOptionFormView( element, { store } ) {
+function RouteOptionFormView( element, { store, routeIndex } ) {
   const _dom = checkDom( element, CLASSES.FORM );
-  const _transportationTypes = Array.prototype.slice.call(
+  const _transportationOptionEls = Array.prototype.slice.call(
     _dom.querySelectorAll( `.${ CLASSES.TRANSPORTATION_CHECKBOX }` )
   );
-  const _textInputs = Array.prototype.slice.call(
+  const _textInputEls = Array.prototype.slice.call(
     _dom.querySelectorAll( `.${ CLASSES.QUESTION_INPUT }` )
   );
 
@@ -43,29 +44,35 @@ function RouteOptionFormView( element, { store } ) {
    * @param {object} updateObject object with DOM event and field name
    */
   function _setQuestionResponse( { name, event } ) {
-    const method = actionMap[name];
+    const action = actionMap[name];
+    const { target: { value } } = event;
 
-    if ( method ) {
-      store.dispatch( method( event.target.value ) );
+    if ( action ) {
+      store.dispatch( action( {
+        routeIndex,
+        value
+      } ) );
     }
   }
 
   /**
-   * Updates state from child input checkbox nodes
+   * Updates state from child input radio nodes
    * @param {object} updateObject object with DOM event and field name
    */
-  function _setChecked( { event } ) {
-    const { target: { value }} = event;
+  function _setSelected( { event } ) {
+    const { target: { value } } = event;
 
-    store.dispatch( updateTransportationAction( value ) );
+    store.dispatch( updateTransportationAction( {
+      routeIndex,
+      value } ) );
   }
 
   /**
    * Initialize checkbox nodes this form view manages
    */
   function _initRouteOptions() {
-    _transportationTypes.forEach( node => inputView( node, {
-      events: { click: _setChecked },
+    _transportationOptionEls.forEach( node => inputView( node, {
+      events: { click: _setSelected },
       type: 'radio'
     } )
       .init()
@@ -76,7 +83,7 @@ function RouteOptionFormView( element, { store } ) {
    * Initialize input nodes this form view manages
    */
   function _initQuestions() {
-    _textInputs.forEach( node => inputView( node, {
+    _textInputEls.forEach( node => inputView( node, {
       events: { input: _setQuestionResponse }
     } )
       .init()

--- a/cfgov/unprocessed/apps/youth-employment-success/js/route.js
+++ b/cfgov/unprocessed/apps/youth-employment-success/js/route.js
@@ -1,0 +1,18 @@
+import { assign } from './util';
+
+/**
+ * Factory function for creating a route object. Designed to be used in conjunction
+ * with the routeOptionReducer
+ * @param {object} [route] object describing the values of the route object
+ * @returns {object} a new route object
+ */
+function createRoute( route = {} ) {
+  return assign( {}, {
+    transportation: '',
+    daysPerWeek: '',
+    miles: '',
+    dailyCost: ''
+  }, route );
+}
+
+export default createRoute;

--- a/cfgov/unprocessed/apps/youth-employment-success/js/store.js
+++ b/cfgov/unprocessed/apps/youth-employment-success/js/store.js
@@ -1,7 +1,7 @@
-import { combineReducers } from './util';
-import budgetReducer from './reducers/budget-reducer';
-import routeOptionReducer from './reducers/route-option-reducer';
 import YesStore from './yes-store';
+import budgetReducer from './reducers/budget-reducer';
+import { combineReducers } from './util';
+import routeOptionReducer from './reducers/route-option-reducer';
 
 /**
  * Function to create a new store instance
@@ -11,7 +11,7 @@ function configureStore() {
   return new YesStore(
     combineReducers( {
       budget: budgetReducer,
-      route: routeOptionReducer
+      routes: routeOptionReducer
     } )
   );
 }

--- a/test/unit_tests/apps/youth-employment-success/js/reducers/route-option-reducer-spec.js
+++ b/test/unit_tests/apps/youth-employment-success/js/reducers/route-option-reducer-spec.js
@@ -1,5 +1,8 @@
+import createRoute from '../../../../../../cfgov/unprocessed/apps/youth-employment-success/js/route';
 import routeOptionReducer, {
+  addRouteOptionAction,
   initialState,
+  routeSelector,
   updateDailyCostAction,
   updateDaysPerWeekAction,
   updateMilesAction,
@@ -17,54 +20,103 @@ describe( 'routeOptionReducer', () => {
     expect( state ).toEqual( initialState );
   } );
 
-  it( 'reduces .updateDailyCostAction', () => {
-    const state = routeOptionReducer(
-      UNDEFINED,
-      updateDailyCostAction( nextValue )
-    );
-    const { dailyCost, ...rest } = state;
+  it( 'reduces .addRouteOptionAction', () => {
+    const state = routeOptionReducer( UNDEFINED, addRouteOptionAction( {} ) );
 
-    expect( dailyCost ).toBe( nextValue );
-    Object.entries( rest ).forEach( ( [ key, value ] ) => expect( value ).toBe( initialState[key] )
-    );
+    expect( state.routes.length ).toBe( 1 );
   } );
 
-  it( 'reduces .updateDaysPerWeekAction', () => {
-    const state = routeOptionReducer(
-      UNDEFINED,
-      updateDaysPerWeekAction( nextValue )
+  it( 'does not reduce routes for which it did not receive an index', () => {
+    const transportationType = 'Walk';
+    const state = routeOptionReducer( {
+      routes: [ createRoute(), createRoute() ]
+    },
+    updateTransportationAction( { routeIndex: 0, value: transportationType } )
     );
-    const { daysPerWeek, ...rest } = state;
 
-    expect( daysPerWeek ).toBe( nextValue );
-    Object.entries( rest ).forEach( ( [ key, value ] ) => expect( value ).toBe( initialState[key] )
-    );
+    expect( state.routes[0].transportation ).toBe( transportationType );
+    expect( state.routes[1].transportation ).toBe( '' );
   } );
 
-  it( 'reduces .updateMilesAction', () => {
-    const state = routeOptionReducer(
-      UNDEFINED,
-      updateMilesAction( nextValue )
+  it( 'exposes a selector to decouple data from reducer shape', () => {
+    const state = routeOptionReducer( {
+      routes: [ createRoute(), createRoute( { transportation: 'Walk' } ) ]
+    },
+    { type: null }
     );
-    const { miles, ...rest } = state;
-    expect( miles ).toBe( nextValue );
-    Object.entries( rest ).forEach( ( [ key, value ] ) => expect( value ).toBe( initialState[key] )
-    );
+
+    expect( routeSelector( state, 1 ).transportation ).toBe( 'Walk' );
   } );
 
-  it( 'reduces .updateTransportation', () => {
-    let state = routeOptionReducer(
-      initialState,
-      updateTransportationAction( 'Walk' )
-    );
+  describe( 'updating a specific route', () => {
+    let initial;
 
-    expect( state.transportation ).toBe( 'Walk' );
+    beforeEach( () => {
+      initial = routeOptionReducer( UNDEFINED, addRouteOptionAction( {} ) );
+    } );
 
-    state = routeOptionReducer(
-      state,
-      updateTransportationAction( 'Drive' )
-    );
+    it( 'reduces .updateDailyCostAction', () => {
+      const state = routeOptionReducer(
+        initial,
+        updateDailyCostAction( {
+          routeIndex: 0,
+          value: nextValue
+        } )
+      );
+      const { dailyCost, ...rest } = state.routes[0];
 
-    expect( state.transportation ).toBe( 'Drive' );
+      expect( dailyCost ).toBe( nextValue );
+      Object.entries( rest ).forEach( ( [ key, value ] ) => expect( value ).toBe( initialState[key] )
+      );
+    } );
+
+    it( 'reduces .updateDaysPerWeekAction', () => {
+      const state = routeOptionReducer(
+        initial,
+        updateDaysPerWeekAction( {
+          routeIndex: 0,
+          value: nextValue } )
+      );
+      const { daysPerWeek, ...rest } = state.routes[0];
+
+      expect( daysPerWeek ).toBe( nextValue );
+      Object.entries( rest ).forEach( ( [ key, value ] ) => expect( value ).toBe( initialState[key] )
+      );
+    } );
+
+    it( 'reduces .updateMilesAction', () => {
+      const state = routeOptionReducer(
+        initial,
+        updateMilesAction( {
+          routeIndex: 0,
+          value: nextValue } )
+      );
+      const { miles, ...rest } = state.routes[0];
+      expect( miles ).toBe( nextValue );
+      Object.entries( rest ).forEach( ( [ key, value ] ) => expect( value ).toBe( initialState[key] )
+      );
+    } );
+
+    it( 'reduces .updateTransportation', () => {
+      let state = routeOptionReducer(
+        initial,
+        updateTransportationAction( {
+          routeIndex: 0,
+          value: 'Walk' } )
+      );
+
+      let route = state.routes[0];
+      expect( route.transportation ).toBe( 'Walk' );
+
+      state = routeOptionReducer(
+        state,
+        updateTransportationAction( {
+          routeIndex: 0,
+          value: 'Drive' } )
+      );
+
+      route = state.routes[0];
+      expect( route.transportation ).toBe( 'Drive' );
+    } );
   } );
 } );

--- a/test/unit_tests/apps/youth-employment-success/js/route-option-view-spec.js
+++ b/test/unit_tests/apps/youth-employment-success/js/route-option-view-spec.js
@@ -1,6 +1,7 @@
 import { simulateEvent } from '../../../../util/simulate-event';
 import routeOptionFormView from '../../../../../cfgov/unprocessed/apps/youth-employment-success/js/route-option-view';
 import {
+  addRouteOptionAction,
   updateDailyCostAction,
   updateDaysPerWeekAction,
   updateMilesAction,
@@ -21,7 +22,8 @@ describe( 'routeOptionFormView', () => {
   const CLASSES = routeOptionFormView.CLASSES;
   const dispatch = jest.fn();
   const mockStore = () => ( {
-    dispatch
+    dispatch,
+    subscribe: () => ( {} )
   } );
   let view;
   let store;
@@ -29,7 +31,7 @@ describe( 'routeOptionFormView', () => {
   beforeEach( () => {
     document.body.innerHTML = HTML;
     store = mockStore();
-    view = routeOptionFormView( document.querySelector( `.${ CLASSES.FORM }` ), { store } );
+    view = routeOptionFormView( document.querySelector( `.${ CLASSES.FORM }` ), { store, routeIndex: 0 } );
     view.init();
   } );
 
@@ -49,7 +51,9 @@ describe( 'routeOptionFormView', () => {
     const mock = store.dispatch.mock;
 
     expect( mock.calls.length ).toBe( 1 );
-    expect( mock.calls[0][0] ).toEqual( updateMilesAction( value ) );
+    expect( mock.calls[0][0] ).toEqual( updateMilesAction( {
+      routeIndex: 0,
+      value } ) );
   } );
 
   it( 'dispatches an action to update `dailyCost` input', () => {
@@ -63,7 +67,7 @@ describe( 'routeOptionFormView', () => {
     const mock = store.dispatch.mock;
 
     expect( mock.calls.length ).toBe( 1 );
-    expect( mock.calls[0][0] ).toEqual( updateDailyCostAction( value ) );
+    expect( mock.calls[0][0] ).toEqual( updateDailyCostAction( { routeIndex: 0, value } ) );
   } );
 
   it( 'dispatches an action to update `daysPerWeek` input', () => {
@@ -77,7 +81,7 @@ describe( 'routeOptionFormView', () => {
     const mock = store.dispatch.mock;
 
     expect( mock.calls.length ).toBe( 1 );
-    expect( mock.calls[0][0] ).toEqual( updateDaysPerWeekAction( value ) );
+    expect( mock.calls[0][0] ).toEqual( updateDaysPerWeekAction( { routeIndex: 0, value } ) );
   } );
 
   it( 'dispatches an action to update `transportation` with checkbox selection', () => {
@@ -88,6 +92,6 @@ describe( 'routeOptionFormView', () => {
     const mock = store.dispatch.mock;
 
     expect( mock.calls.length ).toBe( 1 );
-    expect( mock.calls[0][0] ).toEqual( updateTransportationAction( radioEl.value ) );
+    expect( mock.calls[0][0] ).toEqual( updateTransportationAction( { routeIndex: 0, value: radioEl.value } ) );
   } );
 } );

--- a/test/unit_tests/apps/youth-employment-success/js/route-spec.js
+++ b/test/unit_tests/apps/youth-employment-success/js/route-spec.js
@@ -1,0 +1,21 @@
+import createRoute from '../../../../../cfgov/unprocessed/apps/youth-employment-success/js/route';
+
+describe( 'route factory function', () => {
+  it( 'constructs a route object', () => {
+    const newRoute = createRoute();
+
+    [ 'transportation', 'daysPerWeek', 'miles', 'dailyCost' ].forEach( prop => {
+      expect( newRoute[prop] ).toBeDefined();
+    } );
+  } );
+
+  it( 'constructs a route object with supplied data', () => {
+    const props = { transportation: 'Drive', miles: '20' };
+    const newRoute = createRoute( props );
+
+    expect( newRoute.transportation ).toBe( props.transportation );
+    expect( newRoute.miles ).toBe( props.miles );
+    expect( newRoute.daysPerWeek ).toBe( '' );
+    expect( newRoute.dailyCost ).toBe( '' );
+  } );
+} );


### PR DESCRIPTION
This pull request add support for multiple routes in the route option reducer. Each `routeOptionView` gets passed the index of the route it is responsible for.

## Additions

- Add a route factory function to build new route data objects

## Removals

-

## Changes

- Since the tool will only allow for two routes for now, explicitly initialize
each view and expandable in `index.js`
- Update reducer to handle multiple route objects

## Testing

1. Just unit tests at this point

## Screenshots


## Notes

- I don't love all the manual selecting of `expandables` and `views` in the `index.js` file, but we only need two route options for the tool and this is the simplest way to ensure that all the data goes to the right places and all the JS objects get initialized correctly

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [ ] Chrome on desktop
- [ ] Firefox
- [ ] Safari on macOS
- [ ] Edge
- [ ] Internet Explorer 9, 10, and 11
- [ ] Safari on iOS
- [ ] Chrome on Android

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
