### PR TITLE
JS view to manage showing second route option

### DIFF
--- a/cfgov/jinja2/v1/youth_employment_success/index.html
+++ b/cfgov/jinja2/v1/youth_employment_success/index.html
@@ -15,7 +15,7 @@
     <section class="content_main">
       <h1>Plan options for getting to work</h1>
       {% include "budget-form.html" %}
-      <div class="yes-routes o-expandable-group o-expandable-group__accordion">
+      <div class="yes-routes">
         <div class="content-l">
           {% for i in range(2) %}
             {% with id=i+1 %}
@@ -23,6 +23,7 @@
             {% endwith %}
           {% endfor %}
         </div>
+        <button class="m-yes-route-option">Show me another option</button>
       </div>
     </section>
   </div>

--- a/cfgov/jinja2/v1/youth_employment_success/route-option.html
+++ b/cfgov/jinja2/v1/youth_employment_success/route-option.html
@@ -5,8 +5,8 @@
   'label': option,
   'is_expanded': false,
   'is_midtone': true,
-  'hide_cue_label': true,
-  'is_bordered': true
+  'hide_cue_label': false,
+  'is_bordered': false
 } %}
 <div class="block__sub">
   {% call() expandable(expandable_settings) %}

--- a/cfgov/unprocessed/apps/youth-employment-success/js/index.js
+++ b/cfgov/unprocessed/apps/youth-employment-success/js/index.js
@@ -3,11 +3,13 @@ import { addRouteOptionAction } from './reducers/route-option-reducer';
 import budgetFormView from './budget-form-view';
 import createRoute from './route.js';
 import routeOptionFormView from './route-option-view';
+import routeOptionToggleView from './route-option-toggle-view';
 import store from './store';
 
 
 const BUDGET_CLASSES = budgetFormView.CLASSES;
 const OPTION_CLASSES = routeOptionFormView.CLASSES;
+const OPTION_TOGGLE_CLASSES = routeOptionToggleView.CLASSES;
 
 const budgetFormEl = document.querySelector( `.${ BUDGET_CLASSES.FORM }` );
 const budgetForm = budgetFormView( budgetFormEl, { store } );
@@ -22,8 +24,14 @@ const routeOptionForms = expandables.map( ( expandable, index ) => {
 } );
 
 /* only initialize the first form, the other gets initialized when
-   the user clicks the add another option button */
+   the user clicks 'add another option' button */
 routeOptionForms[0].init();
+routeOptionToggleView(
+  document.querySelector( `.${ OPTION_TOGGLE_CLASSES.BUTTON }` ), {
+    expandable: expandables[1],
+    routeOptionForm: routeOptionForms[1]
+  }
+).init();
 
 expandables[0].element.querySelector( '.o-expandable_target' ).click();
 // target the last element, reverse is destructive

--- a/cfgov/unprocessed/apps/youth-employment-success/js/route-option-toggle-view.js
+++ b/cfgov/unprocessed/apps/youth-employment-success/js/route-option-toggle-view.js
@@ -1,0 +1,29 @@
+import { checkDom, setInitFlag } from '../../../js/modules/util/atomic-helpers';
+
+const CLASSES = Object.freeze( {
+  BUTTON: 'm-yes-route-option'
+} );
+
+function routeOptionToggleView( element, { expandable, routeOptionForm } ) {
+  const _dom = checkDom( element, CLASSES.BUTTON );
+
+  function _showRouteOption() {
+    expandable.element.querySelector( '.o-expandable_target' ).click();
+    expandable.element.classList.remove( 'u-hidden' );
+    _dom.classList.add( 'u-hidden' );
+    _dom.removeEventListener( 'click', _showRouteOption );
+    routeOptionForm.init();
+  }
+
+  return {
+    init() {
+      if ( setInitFlag( _dom ) ) {
+        _dom.addEventListener( 'click', _showRouteOption );
+      }
+    }
+  };
+}
+
+routeOptionToggleView.CLASSES = CLASSES;
+
+export default routeOptionToggleView;

--- a/cfgov/unprocessed/apps/youth-employment-success/js/route-option-view.js
+++ b/cfgov/unprocessed/apps/youth-employment-success/js/route-option-view.js
@@ -1,12 +1,11 @@
-import { checkDom, destroyInitFlag, setInitFlag } from '../../../js/modules/util/atomic-helpers';
-import inputView from './input-view';
+import { checkDom, setInitFlag } from '../../../js/modules/util/atomic-helpers';
 import {
-  routeSelector,
   updateDailyCostAction,
   updateDaysPerWeekAction,
   updateMilesAction,
   updateTransportationAction
 } from './reducers/route-option-reducer';
+import inputView from './input-view';
 
 const CLASSES = Object.freeze( {
   FORM: 'o-yes-route-option',

--- a/test/unit_tests/apps/youth-employment-success/js/reducers/route-option-reducer-spec.js
+++ b/test/unit_tests/apps/youth-employment-success/js/reducers/route-option-reducer-spec.js
@@ -26,28 +26,6 @@ describe( 'routeOptionReducer', () => {
     expect( state.routes.length ).toBe( 1 );
   } );
 
-  it( 'does not reduce routes for which it did not receive an index', () => {
-    const transportationType = 'Walk';
-    const state = routeOptionReducer( {
-      routes: [ createRoute(), createRoute() ]
-    },
-    updateTransportationAction( { routeIndex: 0, value: transportationType } )
-    );
-
-    expect( state.routes[0].transportation ).toBe( transportationType );
-    expect( state.routes[1].transportation ).toBe( '' );
-  } );
-
-  it( 'exposes a selector to decouple data from reducer shape', () => {
-    const state = routeOptionReducer( {
-      routes: [ createRoute(), createRoute( { transportation: 'Walk' } ) ]
-    },
-    { type: null }
-    );
-
-    expect( routeSelector( state, 1 ).transportation ).toBe( 'Walk' );
-  } );
-
   describe( 'updating a specific route', () => {
     let initial;
 
@@ -117,6 +95,18 @@ describe( 'routeOptionReducer', () => {
 
       route = state.routes[0];
       expect( route.transportation ).toBe( 'Drive' );
+    } );
+
+    it( 'does not reduce routes for which it did not receive an index', () => {
+      const transportationType = 'Walk';
+      const state = routeOptionReducer( {
+        routes: [ createRoute(), createRoute() ]
+      },
+      updateTransportationAction( { routeIndex: 0, value: transportationType } )
+      );
+
+      expect( state.routes[0].transportation ).toBe( transportationType );
+      expect( state.routes[1].transportation ).toBe( '' );
     } );
   } );
 } );

--- a/test/unit_tests/apps/youth-employment-success/js/route-option-toggle-view-spec.js
+++ b/test/unit_tests/apps/youth-employment-success/js/route-option-toggle-view-spec.js
@@ -1,0 +1,66 @@
+import { simulateEvent } from '../../../../util/simulate-event';
+import routeOptionToggleView from '../../../../../cfgov/unprocessed/apps/youth-employment-success/js/route-option-toggle-view';
+
+const HTML = `
+  <button class="${ routeOptionToggleView.CLASSES.BUTTON }"></buton>
+`;
+
+const initMock = jest.fn();
+const mockExpandable = () => ( {
+  element: ( () => {
+    const container = document.createElement( 'div' );
+    const target = document.createElement( 'div' );
+
+
+    target.classList.add( 'o-expandable_target' );
+    container.classList.add( 'u-hidden' );
+
+    container.appendChild( target );
+
+    return container;
+  } )()
+} );
+const mockRouteForm = {
+  init: initMock
+};
+
+describe( 'routeOptionToggleView', () => {
+  let expandable;
+  let view;
+  let el;
+
+  beforeEach( () => {
+    document.body.innerHTML = HTML;
+    expandable = mockExpandable();
+
+    el = document.querySelector( `.${ routeOptionToggleView.CLASSES.BUTTON }` );
+    view = routeOptionToggleView( el, {
+      expandable,
+      routeOptionForm: mockRouteForm
+    } );
+
+    mockRouteForm.init.mockReset();
+
+    view.init();
+  } );
+
+  it( 'hides itself on click', () => {
+    simulateEvent( 'click', el );
+
+    expect( el.classList.contains( 'u-hidden' ) ).toBeTruthy();
+  } );
+
+  it( 'shows its expandable on click', () => {
+    expect( expandable.element.classList.contains( 'u-hidden' ) ).toBeTruthy();
+
+    simulateEvent( 'click', el );
+
+    expect( expandable.element.classList.contains( 'u-hidden' ) ).toBeFalsy();
+  } );
+
+  it( 'calls .init on associated route form', () => {
+    expect( mockRouteForm.init.mock.calls.length ).toBe( 0 );
+    simulateEvent( 'click', el );
+    expect( mockRouteForm.init.mock.calls.length ).toBe( 1 );
+  } );
+} );

--- a/test/unit_tests/apps/youth-employment-success/js/route-option-view-spec.js
+++ b/test/unit_tests/apps/youth-employment-success/js/route-option-view-spec.js
@@ -1,7 +1,6 @@
 import { simulateEvent } from '../../../../util/simulate-event';
 import routeOptionFormView from '../../../../../cfgov/unprocessed/apps/youth-employment-success/js/route-option-view';
 import {
-  addRouteOptionAction,
   updateDailyCostAction,
   updateDaysPerWeekAction,
   updateMilesAction,


### PR DESCRIPTION
So the user can compare two routes and find the most cost-effective one, add a button that shows the second route form.

## Additions

- Button to handle toggling the second route
- JS view to manage button and expandable

## Removals

- Expandable route options no longer function like an accordion, the user may have both open at once if they want

## Changes

-

## Testing

1.

## Screenshots


## Notes

- ~Depends on #5196~ 
- The toggle view being responsible for an expandable and a form is a little backwards.
Ideally, I'll refactor this to follow a structure similar to the below code block. Sorry for using `JSX` syntax, but I think it is a genuinely helpful way to expose the hierarchical relationships between JS views of DOM elements
```
<TransportationView>
  <ExpandableView> -> this wraps the exposed expandable api
    <RouteOptionFormView />
  </ExpandableView>
  <ExpandableView2 />
  <ToggleButton>
</TransportationView>
```

With this structure, the top-level view can accept the expandable views as arguments, and the expandable views can accept route form views.When the toggle button is clicked, it can call an event handler supplied by the top-level view, which in turn can call `init` on the expandable view. That `init` call would initialize the route form view component, if necessary

## Todos

- [x] Initialize `routeOptionView` on button click
- [x] add specs

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [ ] Chrome on desktop
- [ ] Firefox
- [ ] Safari on macOS
- [ ] Edge
- [ ] Internet Explorer 9, 10, and 11
- [ ] Safari on iOS
- [ ] Chrome on Android

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
