### PR TITLE
Stop use of "current" subdirectory in deploy zipfiles

### DIFF
--- a/cfgov/deployable_zipfile/extract.py
+++ b/cfgov/deployable_zipfile/extract.py
@@ -8,10 +8,6 @@ from zipfile import ZipFile
 
 
 def extract_zipfile(zipfile_filename, extract_location):
-    # This supports legacy drama-free-django behavior. The zipfile is always
-    # extracted into a subdirectory of the specified extract location.
-    extract_location = os.path.join(extract_location, 'current')
-
     ZipFile(zipfile_filename).extractall(extract_location)
 
     # Create a new virtual environment with pip and setuptools from the

--- a/cfgov/deployable_zipfile/tests/test_extract.py
+++ b/cfgov/deployable_zipfile/tests/test_extract.py
@@ -24,8 +24,6 @@ class TestExtractZipFile(TestCase):
         extract_location = os.path.join(self.tempdir, 'extracted')
         extract_zipfile(test_zip, extract_location)
 
-        extract_location = os.path.join(extract_location, 'current')
-
         # Verify that all files are extracted properly.
         six.assertCountEqual(
             self,


### PR DESCRIPTION
The old drama-free-django-based deploys would always extract the release zip into a "current" subdirectory on the target server.

For example, if a deploy zipfile were extracted by running:

```
/tmp/cfgov.zip -d /srv/cfgov/versions/20190828171038
```

then the zipfile contents would be extracted under a `/srv/cfgov/versions/20190828171038/current` subdirectory, not under `/srv/cfgov/versions/20190828171038` as one might expect. This would mean, for example, that the virtualenv was at `/srv/cfgov/versions/20190828171038/current/venv`, etc.

To simplify the zipfile code, and its deployment, this change stops extracting to a "current" subdirectory.

This PR is **held** until our Ansible code is modified to support it; see internal Ansible PR 323.

## Testing

To test this independently, the best way is to generate a new deploy zipfile using `docker/deployable-zipfile/build.sh`. This will generate a `cfgov_current_build.zip` in your local directory.

Extract it somewhere by running something like `./cfgov_current_build.zip -d /tmp/extract_location` (inside a Python environment that has virtualenv installed). You'll note that the contents of the zip get extracted directly into the target location, e.g. `/tmp/extract_location/venv`, without a "current" subdirectory to be seen.

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [X] Passes all existing automated tests
- [X] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [X] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: