### PR TITLE
YES tool — Adds new combo field view for transit time

### DIFF
--- a/cfgov/jinja2/v1/youth_employment_success/route-questions/average-total-cost.html
+++ b/cfgov/jinja2/v1/youth_employment_success/route-questions/average-total-cost.html
@@ -16,7 +16,7 @@
   }}
   {{
     render_radio({
-      'name': 'average-cost',
+      'name': "average-cost",
       'label': "Daily",
       'value': 'daily',
       'disabled': true
@@ -24,7 +24,7 @@
   }}
   {{
     render_radio({
-      'name': 'average-cost',
+      'name': "average-cost",
       'label': "Monthly",
       'value': 'monthly',
       'disabled': true

--- a/cfgov/jinja2/v1/youth_employment_success/route-questions/input.html
+++ b/cfgov/jinja2/v1/youth_employment_success/route-questions/input.html
@@ -47,7 +47,7 @@
           name="{{ id }}"
           type="{{ value.type }}"
           value="{{ value.value }}"
-          {{ 'data-js-name="' ~ value.data_js_name ~ '"' if value.data_js_name else '' }}
+          {{ 'data-js-name=' ~ value.data_js_name ~ '' if value.data_js_name else '' }}
           {{ 'required' if value.required else '' }}
           {{ 'disabled' if value.disabled else ''}}
           {{ 'aria-describedby="' ~ ht_id ~ '"' if value.helperText else '' }}

--- a/cfgov/jinja2/v1/youth_employment_success/route-questions/transit-time.html
+++ b/cfgov/jinja2/v1/youth_employment_success/route-questions/transit-time.html
@@ -1,7 +1,7 @@
 {% from 'atoms/checkbox.html' import render as render_checkbox with context %}
 {% from 'input.html' import render as render_input with context %}
 
-<div class="content-l content-l_col-2-3 block__sub-micro a-yes-question">
+<div class="content-l content-l_col-2-3 block__sub-micro m-yes-transit-time">
   <p class="a-label__heading">
     How long does it take to get to your destination?
   </p>
@@ -29,8 +29,8 @@
     render_checkbox({
       'class': 'u-js-only block__sub-micro',
       'label': "I'm not sure, add this to my to-do list to look up later ",
-      'name': "yes-miles-unsure",
       'disabled': true
+      'name': "timeToActionPlan"
      })
   }}
 </div>

--- a/cfgov/unprocessed/apps/youth-employment-success/css/main.less
+++ b/cfgov/unprocessed/apps/youth-employment-success/css/main.less
@@ -1,5 +1,12 @@
 @import (reference) '../../../css/main.less';
 
+/** 
+* This gets overwritten by media queries, so we need to make it important.
+*/
+.u-hidden {
+  display: none !important;
+}
+
 /**
 * Enchancement for the .block__sub class found at:
 * https://github.com/cfpb/capital-framework/blob/0b15295c00ba1972676b6f4c86f3b40dcf45289d/packages/cf-layout/src/cf-layout.less#L466

--- a/cfgov/unprocessed/apps/youth-employment-success/js/reducers/route-option-reducer.js
+++ b/cfgov/unprocessed/apps/youth-employment-success/js/reducers/route-option-reducer.js
@@ -9,7 +9,10 @@ const actionTypes = Object.freeze( {
   UPDATE_TRANSPORTATION: 'UPDATE_TRANSPORTATION',
   UPDATE_MILES: 'UPDATE_MILES',
   UPDATE_DAILY_COST: 'UPDATE_DAILY_COST',
-  UPDATE_DAYS_PER_WEEK: 'UPDATE_DAYS_PER_WEEK'
+  UPDATE_DAYS_PER_WEEK: 'UPDATE_DAYS_PER_WEEK',
+  UPDATE_TIME_TO_ACTION_PLAN: 'UPDATE_TIME_TO_ACTION_PLAN',
+  UPDATE_TRANSIT_TIME_HOURS: 'UPDATE_TRANSIT_TIME_HOURS',
+  UPDATE_TRANSIT_TIME_MINUTES: 'UPDATE_TRANSIT_TIME_MINUTES'
 } );
 
 const addRouteOptionAction = actionCreator(
@@ -26,6 +29,15 @@ const updateDaysPerWeekAction = actionCreator(
 );
 const updateDailyCostAction = actionCreator(
   actionTypes.UPDATE_DAILY_COST
+);
+const updateTimeToActionPlan = actionCreator(
+  actionTypes.UPDATE_TIME_TO_ACTION_PLAN
+);
+const updateTransitTimeHoursAction = actionCreator(
+  actionTypes.UPDATE_TRANSIT_TIME_HOURS
+);
+const updateTransitTimeMinutesAction = actionCreator(
+  actionTypes.UPDATE_TRANSIT_TIME_MINUTES
 );
 
 /**
@@ -108,6 +120,21 @@ function routeOptionReducer( state = initialState, action ) {
       } )
       );
     }
+    case actionTypes.UPDATE_TIME_TO_ACTION_PLAN: {
+      return assign( state, updateRouteData( state.routes, data.routeIndex, {
+        timeToActionPlan: data.value
+      } ) );
+    }
+    case actionTypes.UPDATE_TRANSIT_TIME_HOURS: {
+      return assign( state, updateRouteData( state.routes, data.routeIndex, {
+        transitTimeHours: data.value
+      } ) );
+    }
+    case actionTypes.UPDATE_TRANSIT_TIME_MINUTES: {
+      return assign( state, updateRouteData( state.routes, data.routeIndex, {
+        transitTimeMinutes: data.value
+      } ) );
+    }
     default:
       return state;
   }
@@ -120,7 +147,10 @@ export {
   updateTransportationAction,
   updateMilesAction,
   updateDaysPerWeekAction,
-  updateDailyCostAction
+  updateDailyCostAction,
+  updateTimeToActionPlan,
+  updateTransitTimeHoursAction,
+  updateTransitTimeMinutesAction
 };
 
 export default routeOptionReducer;

--- a/cfgov/unprocessed/apps/youth-employment-success/js/route-option-toggle-view.js
+++ b/cfgov/unprocessed/apps/youth-employment-success/js/route-option-toggle-view.js
@@ -4,9 +4,23 @@ const CLASSES = Object.freeze( {
   BUTTON: 'm-yes-route-option'
 } );
 
+/**
+ * RouteOptionToggleView
+ * @class
+ *
+ * @classdesc Initializes the organism.
+ *
+ * @param {HTMLNode} element The root DOM element for this view
+ * @param {object} props Additional properties to be supplied to the view
+ * @returns {Object} The view's public methods
+ */
 function routeOptionToggleView( element, { expandable, routeOptionForm } ) {
   const _dom = checkDom( element, CLASSES.BUTTON );
 
+  /**
+   * Show additional route option expandable, hiding the button
+   * Initialize the new route option form
+   */
   function _showRouteOption() {
     expandable.element.querySelector( '.o-expandable_target' ).click();
     expandable.element.classList.remove( 'u-hidden' );

--- a/cfgov/unprocessed/apps/youth-employment-success/js/route-option-view.js
+++ b/cfgov/unprocessed/apps/youth-employment-success/js/route-option-view.js
@@ -1,11 +1,13 @@
 import { checkDom, setInitFlag } from '../../../js/modules/util/atomic-helpers';
 import {
+  routeSelector,
   updateDailyCostAction,
   updateDaysPerWeekAction,
   updateMilesAction,
   updateTransportationAction
 } from './reducers/route-option-reducer';
 import inputView from './input-view';
+import transitTimeView from './views/transit-time';
 
 const CLASSES = Object.freeze( {
   FORM: 'o-yes-route-option',
@@ -18,6 +20,79 @@ const actionMap = Object.freeze( {
   daysPerWeek: updateDaysPerWeekAction,
   dailyCost: updateDailyCostAction
 } );
+
+/**
+ * Map of the fields this form manages that are hidden or shown conditionally,
+ * and the predicate functions that determine the field's state
+ */
+const toggleableFields = {
+  averageCost: ( { transportation } ) => transportation && transportation !== 'Drive',
+  miles: state => state.transportation === 'Drive',
+  daysPerWeek: state => state.transportation === 'Drive' || state.isCostPerDay
+};
+
+/**
+ * Hide an input and clear its value
+ * @param {HTMLElement} node dom element to be toggled
+ */
+function hideToggleableField( node ) {
+  // need to add an action to update the store somewhere
+  node.value = '';
+  node.classList.add( 'u-hidden' );
+}
+
+/**
+ ** Show an input
+ * @param {HTMLElement} node dom element to be toggled
+ */
+function showToggleableField( node ) {
+  node.classList.remove( 'u-hidden' );
+}
+
+/**
+ *
+ * @param {HTMLElement} node the node to be updated
+ * @param {boolean} flag indicates if node is hidden or shown
+ */
+function updateNode( node, flag ) {
+  if ( flag ) {
+    showToggleableField( node );
+  } else {
+    hideToggleableField( node );
+  }
+}
+
+/**
+ * Determine if value in store has changed since last state update
+ * @param {*} lastValue the old value of the state item
+ * @param {*} currentValue the new value of the state item
+ * @returns {boolean} Whether the value has changed
+ */
+function checkHasStateChanged( lastValue, currentValue ) {
+  return lastValue !== currentValue || ( !lastValue && !currentValue );
+}
+
+/**
+ * Updates togglebale inputs this view controls
+ * @param {object} inputs node names with ref to dom node as value
+ * @param {*} prevState previous state of the app
+ * @param {*} state current state of the app
+ */
+function updateVisibleInputs( inputs, prevState, state ) {
+  for ( const name in toggleableFields ) {
+    if ( toggleableFields.hasOwnProperty( name ) ) {
+      const predicate = toggleableFields[name];
+      const stateHasChanged = checkHasStateChanged(
+        prevState[name],
+        state[name]
+      );
+
+      if ( stateHasChanged ) {
+        updateNode( inputs[name], predicate( state ) );
+      }
+    }
+  }
+}
 
 /**
  * RouteOptionFormView
@@ -37,6 +112,17 @@ function RouteOptionFormView( element, { store, routeIndex } ) {
   const _textInputEls = Array.prototype.slice.call(
     _dom.querySelectorAll( `.${ CLASSES.QUESTION_INPUT }` )
   );
+  const _inputMap = _textInputEls.reduce( ( memo, node ) => {
+    const maybeNode = node.tagName === 'INPUT' ? node : node.querySelector( 'input' );
+
+    if ( !maybeNode ) {
+      return memo;
+    }
+
+    memo[maybeNode.getAttribute( 'data-js-name' )] = maybeNode;
+
+    return memo;
+  }, {} );
 
   /**
    * Updates form state from child input text nodes
@@ -89,11 +175,27 @@ function RouteOptionFormView( element, { store, routeIndex } ) {
     );
   }
 
+  const boundUpdate = updateVisibleInputs.bind( null, _inputMap );
+
   return {
     init() {
       if ( setInitFlag( _dom ) ) {
         _initRouteOptions();
         _initQuestions();
+        transitTimeView( _dom.querySelector( '.m-yes-transit-time' ), { store, routeIndex } ).init();
+
+        const currentState = routeSelector(
+          store.getState().routes, routeIndex
+        );
+
+        boundUpdate( currentState, currentState );
+
+        store.subscribe( ( prevState, nextState ) => {
+          boundUpdate(
+            routeSelector( prevState.routes, routeIndex ),
+            routeSelector( nextState.routes, routeIndex )
+          );
+        } );
       }
     }
   };

--- a/cfgov/unprocessed/apps/youth-employment-success/js/route.js
+++ b/cfgov/unprocessed/apps/youth-employment-success/js/route.js
@@ -8,10 +8,14 @@ import { assign } from './util';
  */
 function createRoute( route = {} ) {
   return assign( {}, {
+    averageCost: '',
     transportation: '',
     daysPerWeek: '',
     miles: '',
-    dailyCost: ''
+    dailyCost: '',
+    transitTimeHours: '',
+    transitTimeMinutes: '',
+    timeToActionPlan: false
   }, route );
 }
 

--- a/cfgov/unprocessed/apps/youth-employment-success/js/views/transit-time.js
+++ b/cfgov/unprocessed/apps/youth-employment-success/js/views/transit-time.js
@@ -1,0 +1,74 @@
+import { checkDom, setInitFlag } from '../../../../js/modules/util/atomic-helpers';
+import {
+  updateTimeToActionPlan,
+  updateTransitTimeHoursAction,
+  updateTransitTimeMinutesAction
+} from '../reducers/route-option-reducer';
+import inputView from '../input-view';
+
+const CLASSES = Object.freeze( {
+  CONTAINER: 'm-yes-transit-time'
+} );
+
+/**
+ * TransitTimeView
+ * @class
+ *
+ * @classdesc Initializes the organism.
+ *
+ * @param {HTMLNode} element The root DOM element for this view
+ * @param {object} props Additional properties to be supplied to the view
+ * @returns {Object} The view's public methods
+ */
+function transitTimeView( element, { store, routeIndex } ) {
+  const _dom = checkDom( element, CLASSES.CONTAINER );
+  const _inputs = Array.prototype.slice.call(
+    _dom.querySelectorAll( 'input' )
+  );
+  const _actionMap = {
+    timeToActionPlan: updateTimeToActionPlan,
+    transitTimeHours: updateTransitTimeHoursAction,
+    transitTimeMinutes: updateTransitTimeMinutesAction
+  };
+
+  /**
+   * Updates form state from child input text nodes
+   * @param {object} updateObject object with DOM event and field name
+   */
+  function _setResponse( { name, event } ) {
+    const method = _actionMap[name];
+    const type = event.target.type;
+    const value = type === 'checkbox' ? event.target.checked : event.target.value;
+
+    if ( method ) {
+      store.dispatch( method( {
+        routeIndex, value } ) );
+    }
+  }
+
+  /**
+   * Initialize the input elements this form manages
+   */
+  function _initInputs() {
+    _inputs.forEach( input => {
+      inputView( input, {
+        events: {
+          input: _setResponse
+        },
+        type: input.type === 'checkbox' ? 'checkbox' : 'text'
+      } ).init();
+    } );
+  }
+
+  return {
+    init() {
+      if ( setInitFlag( _dom ) ) {
+        _initInputs();
+      }
+    }
+  };
+}
+
+transitTimeView.CLASSES = CLASSES;
+
+export default transitTimeView;

--- a/test/unit_tests/apps/youth-employment-success/js/reducers/route-option-reducer-spec.js
+++ b/test/unit_tests/apps/youth-employment-success/js/reducers/route-option-reducer-spec.js
@@ -6,6 +6,9 @@ import routeOptionReducer, {
   updateDailyCostAction,
   updateDaysPerWeekAction,
   updateMilesAction,
+  updateTimeToActionPlan,
+  updateTransitTimeHoursAction,
+  updateTransitTimeMinutesAction,
   updateTransportationAction
 } from '../../../../../../cfgov/unprocessed/apps/youth-employment-success/js/reducers/route-option-reducer';
 import { UNDEFINED } from '../../../../../../cfgov/unprocessed/apps/youth-employment-success/js/util';
@@ -24,6 +27,18 @@ describe( 'routeOptionReducer', () => {
     const state = routeOptionReducer( UNDEFINED, addRouteOptionAction( {} ) );
 
     expect( state.routes.length ).toBe( 1 );
+  } );
+
+  it( 'exposes a selector to decouple state form state shape', () => {
+    const initialRoutes = routeOptionReducer( UNDEFINED, addRouteOptionAction( createRoute() ) );
+    const appState = {
+      routes: initialRoutes
+    };
+
+    expect( typeof routeSelector === 'function' ).toBeTruthy();
+    expect( routeSelector( appState.routes, 0 ) ).toEqual( initialRoutes.routes[0] );
+    expect( routeSelector( appState.routes, 1 ) ).toStrictEqual( {} );
+
   } );
 
   describe( 'updating a specific route', () => {
@@ -58,6 +73,7 @@ describe( 'routeOptionReducer', () => {
       const { daysPerWeek, ...rest } = state.routes[0];
 
       expect( daysPerWeek ).toBe( nextValue );
+
       Object.entries( rest ).forEach( ( [ key, value ] ) => expect( value ).toBe( initialState[key] )
       );
     } );
@@ -70,7 +86,9 @@ describe( 'routeOptionReducer', () => {
           value: nextValue } )
       );
       const { miles, ...rest } = state.routes[0];
+
       expect( miles ).toBe( nextValue );
+
       Object.entries( rest ).forEach( ( [ key, value ] ) => expect( value ).toBe( initialState[key] )
       );
     } );
@@ -107,6 +125,42 @@ describe( 'routeOptionReducer', () => {
 
       expect( state.routes[0].transportation ).toBe( transportationType );
       expect( state.routes[1].transportation ).toBe( '' );
+    } );
+
+    it( 'reduces the .updateTransitTimeHours action', () => {
+      const state = routeOptionReducer(
+        initial,
+        updateTransitTimeHoursAction( {
+          routeIndex: 0,
+          value: nextValue } )
+      );
+      const { transitTimeHours } = state.routes[0];
+
+      expect( transitTimeHours ).toBe( nextValue );
+    } );
+
+    it( 'reduces the .updateTransitTimeMinutes action', () => {
+      const state = routeOptionReducer(
+        initial,
+        updateTransitTimeMinutesAction( {
+          routeIndex: 0,
+          value: nextValue } )
+      );
+      const { transitTimeMinutes } = state.routes[0];
+
+      expect( transitTimeMinutes ).toBe( nextValue );
+    } );
+
+    it( 'reduces the .updateTimeToActionPlan action', () => {
+      const state = routeOptionReducer(
+        initial,
+        updateTimeToActionPlan( {
+          routeIndex: 0,
+          value: true } )
+      );
+      const { timeToActionPlan } = state.routes[0];
+
+      expect( timeToActionPlan ).toBeTruthy();
     } );
   } );
 } );

--- a/test/unit_tests/apps/youth-employment-success/js/route-option-view-spec.js
+++ b/test/unit_tests/apps/youth-employment-success/js/route-option-view-spec.js
@@ -9,11 +9,13 @@ import {
 
 const HTML = `
   <form class="o-yes-route-option">
-    <input type="text" name="miles" class="a-yes-question">
-    <input type="text" name="dailyCost" class="a-yes-question">
-    <input type="text" name="daysPerWeek" class="a-yes-question">
+    <input type="text" name="miles" data-js-name="miles" class="a-yes-question">
+    <input type="text" name="dailyCost" data-js-name="dailyCost" class="a-yes-question">
+    <input type="text" name="daysPerWeek" data-js-name="daysPerWeek" class="a-yes-question">
+    <input type="text" name="averageCost" data-js-name="averageCost" class="a-yes-question">
     <input type="radio" name="transpo" class="a-yes-route-mode" value="Bus">
     <input type="radio" name="transpo" class="a-yes-route-mode" value="Drive">
+    <div class="m-yes-transit-time"></div>
   </form>
 `;
 
@@ -22,7 +24,21 @@ describe( 'routeOptionFormView', () => {
   const dispatch = jest.fn();
   const mockStore = () => ( {
     dispatch,
-    subscribe: () => ( {} )
+    subscribe( fn ) {
+      return fn( {
+        routes: { routes: []}
+      }, {
+        routes: { routes: []
+        }
+      } );
+    },
+    getState() {
+      return {
+        routes: {
+          routes: []
+        }
+      };
+    }
   } );
   let view;
   let store;
@@ -92,5 +108,17 @@ describe( 'routeOptionFormView', () => {
 
     expect( mock.calls.length ).toBe( 1 );
     expect( mock.calls[0][0] ).toEqual( updateTransportationAction( { routeIndex: 0, value: radioEl.value } ) );
+  } );
+
+  describe( 'conditional fields', () => {
+    it( 'hides conditional fields on init', () => {
+      const averageCostEl = document.querySelector( 'input[name="averageCost"]' );
+      const milesEl = document.querySelector( 'input[name="miles"]' );
+      const daysPerWeekEl = document.querySelector( 'input[name="daysPerWeek"]' );
+
+      expect( averageCostEl.classList.contains( 'u-hidden' ) ).toBeTruthy();
+      expect( milesEl.classList.contains( 'u-hidden' ) ).toBeTruthy();
+      expect( daysPerWeekEl.classList.contains( 'u-hidden' ) ).toBeTruthy();
+    } );
   } );
 } );

--- a/test/unit_tests/apps/youth-employment-success/js/views/transit-time-spec.js
+++ b/test/unit_tests/apps/youth-employment-success/js/views/transit-time-spec.js
@@ -1,0 +1,106 @@
+import { simulateEvent } from '../../../../../util/simulate-event';
+import transitTimeView from '../../../../../../cfgov/unprocessed/apps/youth-employment-success/js/views/transit-time';
+import {
+  updateTransitTimeHoursAction,
+  updateTransitTimeMinutesAction,
+  updateTimeToActionPlan
+} from '../../../../../../cfgov/unprocessed/apps/youth-employment-success/js/reducers/route-option-reducer';
+
+const HTML = `
+  <div class="content-l content-l_col-2-3 block__sub-micro m-yes-transit-time">
+    <div class="form-l_col form-l_col-1-4">
+      <label class="a-label a-label__heading u-mb0" for="input_37ad90bd3b4790_hours">
+        Hours
+      </label>
+      <input id="input_37ad90bd3b4790_hours" name="input_37ad90bd3b4790_hours" type="text" value="" data-js-name="transitTimeHours">
+    </div>
+    <div class="form-l_col form-l_col-1-4">
+      <label class="a-label a-label__heading u-mb0" for="input_37ad90bd3b4ed4_minutes">
+        Minutes
+      </label>
+      <input id="input_37ad90bd3b4ed4_minutes" name="input_37ad90bd3b4ed4_minutes" type="text" value="" data-js-name="transitTimeMinutes">
+      
+    </div>
+    <div class="m-form-field m-form-field__checkbox block__sub-micro">
+      <input class="a-checkbox" type="checkbox" value="input_37ad90bd3b546a_i'm-not-sure-add-this-to-my-to-do-list-to-look-up-later-" id="input_37ad90bd3b546a_i'm-not-sure-add-this-to-my-to-do-list-to-look-up-later-" name="timeToActionPlan">
+      <label class="a-label" for="input_37ad90bd3b546a_i'm-not-sure-add-this-to-my-to-do-list-to-look-up-later-">
+        <span>I'm not sure, add this to my to-do list to look up later </span>
+      </label>
+    </div>
+  </div>
+`;
+
+describe('transitTimeView', () => {
+  const routeIndex = 0;
+  const CLASSES = transitTimeView.CLASSES;
+  const dispatch = jest.fn();
+  const mockStore = () => ( {
+    dispatch,
+    subscribe() { return {}; }
+  } );
+  let view;
+  let store;
+
+  beforeEach( () => {
+    document.body.innerHTML = HTML;
+    store = mockStore();
+    view = transitTimeView( document.querySelector( `.${ CLASSES.CONTAINER }` ), { store, routeIndex } );
+    view.init();
+  } );
+
+  afterEach( () => {
+    dispatch.mockReset();
+    view = null;
+  } );
+
+  it('dispatches the correct event when hours field is changed', () => {
+    const hoursEl = document.querySelector('[data-js-name="transitTimeHours"]');
+    const hours = '1';
+
+    hoursEl.value = hours;
+
+    simulateEvent('input', hoursEl);
+
+    const mock = store.dispatch.mock;
+
+    expect(mock.calls.length).toBe(1);
+    expect(mock.calls[0][0]).toEqual(
+      updateTransitTimeHoursAction({
+        routeIndex, value: hours
+      })
+    );
+  });
+
+  it('dispatches the correct event when the minutes field is updated', () => {
+    const minutesEl = document.querySelector('[data-js-name="transitTimeMinutes"]');
+    const minutes = '20';
+
+    minutesEl.value = minutes;
+
+    simulateEvent('input', minutesEl);
+
+    const mock = store.dispatch.mock;
+
+    expect(mock.calls.length).toBe(1);
+    expect(mock.calls[0][0]).toEqual(
+      updateTransitTimeMinutesAction({
+        routeIndex, value: minutes
+      })
+    );
+  });
+
+  it('dispatches the correct event when the not sure checkbox is clicked', () => {
+    const checkboxEl = document.querySelector('[name="timeToActionPlan"]');
+
+    simulateEvent('click', checkboxEl);
+
+    const mock = store.dispatch.mock;
+
+    expect(mock.calls.length).toBe(1);
+    expect(mock.calls[0][0]).toEqual(
+      updateTimeToActionPlan({
+        routeIndex, value: true
+      })
+    );
+  });
+});


### PR DESCRIPTION
This PR adds a new view to handle a group of input elements, in this case two text inputs and a checkbox.

## Additions

- View to control inputs related to transit times
- Additional properties to route and route reducer

## Removals

-

## Changes
- Fixes bug where input atom adds an extra set of "" to data-js attributes
- Adds override for `u-hidden` class

## Testing

1.

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [ ] Chrome on desktop
- [ ] Firefox
- [ ] Safari on macOS
- [ ] Edge
- [ ] Internet Explorer 9, 10, and 11
- [ ] Safari on iOS
- [ ] Chrome on Android

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
