### PR TITLE
YES tool — Disable all inputs by default

### DIFF
--- a/cfgov/jinja2/v1/_includes/atoms/checkbox.html
+++ b/cfgov/jinja2/v1/_includes/atoms/checkbox.html
@@ -23,6 +23,8 @@
 
    el_wrapper:  Element to wrap the checkbox in. Defaults to div.
 
+   disabled:    Whether the field is disabled. Defaults to false.
+
    ========================================================================== #}
 {% from 'macros/util/format/url.html' import slugify as slugify %}
 
@@ -42,7 +44,8 @@
            id="{{ id }}"
            name="{{ name }}"
            {{ behavior }}
-           {{ checked }}>
+           {{ checked }}
+           {{ 'disabled' if value.disabled else ''}}>
     <label class="a-label"
            for="{{ id }}">
         <span>{{ value.label }}</span>

--- a/cfgov/jinja2/v1/_includes/atoms/radio-button.html
+++ b/cfgov/jinja2/v1/_includes/atoms/radio-button.html
@@ -21,6 +21,8 @@
 
    el_wrapper:  Element to wrap the radio in. Defaults to div.
 
+   disabled:    Whether the field is disabled. Defaults to false.
+
    ========================================================================== #}
 {% from 'macros/util/format/url.html' import slugify as slugify %}
 
@@ -38,7 +40,8 @@
            value="{{ val }}"
            id="{{ id }}"
            name="{{ name }}"
-           {{ checked }}>
+           {{ checked }}
+           {{ 'disabled' if value.disabled else ''}}>
     <label class="a-label"
            for="{{ id }}">
         {{ value.label }}

--- a/cfgov/jinja2/v1/youth_employment_success/budget-form.html
+++ b/cfgov/jinja2/v1/youth_employment_success/budget-form.html
@@ -19,7 +19,7 @@
         </div>
       </div>
       <div class="content-l_col content-l_col-2-3">
-        <input type="text" id="yes-money-earned" name="money-earned" class="a-text-input o-yes-budget-earned">
+        <input type="text" id="yes-money-earned" name="money-earned" class="a-text-input o-yes-budget-earned" disabled>
       </div>
     </div>
 
@@ -42,7 +42,7 @@
       
       <div class="content-l_col content-l_col-2-3">
         <span><b>(-)</b></span>
-        <input type="text" id="yes-money-spent" name="money-spent" class="a-text-input o-yes-budget-spent">
+        <input type="text" id="yes-money-spent" name="money-spent" class="a-text-input o-yes-budget-spent" disabled>
       </div>
     </div>
   </form>

--- a/cfgov/jinja2/v1/youth_employment_success/route-option-form.html
+++ b/cfgov/jinja2/v1/youth_employment_success/route-option-form.html
@@ -15,7 +15,8 @@
           'class': 'content-l_col-1-2 m-form-field__lg-target a-yes-route-mode',
           'name':  "yes-transportation-option",
           'label': label[0],
-          'value': label[0]
+          'value': label[0],
+          'disabled': true
         })
       }}
 
@@ -25,7 +26,8 @@
             'class': 'content-l_col-1-2 m-form-field__lg-target a-yes-route-mode',
             'name': "yes-transportation-option",
             'label': label[1],
-            'value': label[1]
+            'value': label[1],
+            'disabled': true
           })
         }}
       {% endif %}

--- a/cfgov/jinja2/v1/youth_employment_success/route-questions/average-daily-cost.html
+++ b/cfgov/jinja2/v1/youth_employment_success/route-questions/average-daily-cost.html
@@ -8,7 +8,8 @@
       'label': 'Average daily cost',
       'size': '1-4',
       'type': 'text',
-      'value': ''
+      'value': '',
+      'disabled': true
     })
   }}
 </div>

--- a/cfgov/jinja2/v1/youth_employment_success/route-questions/average-total-cost.html
+++ b/cfgov/jinja2/v1/youth_employment_success/route-questions/average-total-cost.html
@@ -10,28 +10,32 @@
       'label': "What's the average cost?",
       'size': '1-4',
       'type': 'text',
-      'value': ''
+      'value': '',
+      'disabled': true
     })
   }}
   {{
     render_radio({
       'name': 'average-cost',
       'label': "Daily",
-      'value': 'daily'
+      'value': 'daily',
+      'disabled': true
     })
   }}
   {{
     render_radio({
       'name': 'average-cost',
       'label': "Monthly",
-      'value': 'monthly'
+      'value': 'monthly',
+      'disabled': true
     })
   }}
   {{ 
     render_checkbox({
       'class': 'block__sub-micro',
       'label': "I'm not sure, add this to my to-do list to look up later",
-      'name': "yes-miles-unsure"
+      'name': "yes-miles-unsure",
+      'disabled': true
      })
   }}
 </div>

--- a/cfgov/jinja2/v1/youth_employment_success/route-questions/days-per-week.html
+++ b/cfgov/jinja2/v1/youth_employment_success/route-questions/days-per-week.html
@@ -8,14 +8,16 @@
       'label': "How many days per week will you make this trip?",
       'size': '1-4',
       'type': 'text',
-      'value': ''
+      'value': '',
+      'disabled': true
     })
   }}
   {{
     render_checkbox({
       'class': 'block__sub-micro',
       'label': "I'm not sure. Look up later",
-      'name': "yes-route-days-unsure"
+      'name': "yes-route-days-unsure",
+      'disabled': true
     })
   }}
 </div>

--- a/cfgov/jinja2/v1/youth_employment_success/route-questions/miles.html
+++ b/cfgov/jinja2/v1/youth_employment_success/route-questions/miles.html
@@ -9,14 +9,16 @@
       'label': 'How many miles do you expect to drive each day?',
       'size': '1-4',
       'type': 'text',
-      'value': ''
+      'value': '',
+      'disabled': true
     })
   }}
   {{ 
     render_checkbox({
       'class': 'block__sub-micro',
       'label': "I'm not sure, add this to my to-do list to look up later ",
-      'name': "yes-miles-unsure"
+      'name': "yes-miles-unsure",
+      'disabled': true
      })
   }}
 </div>

--- a/cfgov/jinja2/v1/youth_employment_success/route-questions/transit-time.html
+++ b/cfgov/jinja2/v1/youth_employment_success/route-questions/transit-time.html
@@ -11,7 +11,8 @@
       'label': 'Hours',
       'size': '1-4',
       'type': 'text',
-      'value': ''
+      'value': '',
+      'disabled': true
     })
   }}
   {{
@@ -20,14 +21,16 @@
       'label': 'Minutes',
       'size': '1-4',
       'type': 'text',
-      'value': ''
+      'value': '',
+      'disabled': true
     })
   }}
   {{ 
     render_checkbox({
       'class': 'block__sub-micro',
       'label': "I'm not sure, add this to my to-do list to look up later ",
-      'name': "yes-miles-unsure"
+      'name': "yes-miles-unsure",
+      'disabled': true
      })
   }}
 </div>

--- a/cfgov/unprocessed/apps/youth-employment-success/js/index.js
+++ b/cfgov/unprocessed/apps/youth-employment-success/js/index.js
@@ -6,6 +6,11 @@ import routeOptionFormView from './route-option-view';
 import routeOptionToggleView from './route-option-toggle-view';
 import store from './store';
 
+Array.prototype.slice.call(
+  document.querySelectorAll( 'input' )
+).forEach( input => {
+  input.disabled = false;
+} );
 
 const BUDGET_CLASSES = budgetFormView.CLASSES;
 const OPTION_CLASSES = routeOptionFormView.CLASSES;

--- a/cfgov/unprocessed/apps/youth-employment-success/js/index.js
+++ b/cfgov/unprocessed/apps/youth-employment-success/js/index.js
@@ -9,7 +9,7 @@ import store from './store';
 Array.prototype.slice.call(
   document.querySelectorAll( 'input' )
 ).forEach( input => {
-  input.disabled = false;
+  input.removeAttribute( 'disabled' );
 } );
 
 const BUDGET_CLASSES = budgetFormView.CLASSES;

--- a/cfgov/unprocessed/apps/youth-employment-success/js/route-option-view.js
+++ b/cfgov/unprocessed/apps/youth-employment-success/js/route-option-view.js
@@ -44,7 +44,7 @@ function RouteOptionFormView( element, { store, routeIndex } ) {
    */
   function _setQuestionResponse( { name, event } ) {
     const action = actionMap[name];
-    const { target: { value } } = event;
+    const { target: { value }} = event;
 
     if ( action ) {
       store.dispatch( action( {
@@ -59,7 +59,7 @@ function RouteOptionFormView( element, { store, routeIndex } ) {
    * @param {object} updateObject object with DOM event and field name
    */
   function _setSelected( { event } ) {
-    const { target: { value } } = event;
+    const { target: { value }} = event;
 
     store.dispatch( updateTransportationAction( {
       routeIndex,


### PR DESCRIPTION
To facilitate a no-js compatible experience, we are disabling all input elements on page load. The inputs will be enabled if a supported level of JS is detected. 

## Additions

-

## Removals

-

## Changes

- Disable all form fields by default
- Add the `disabled` property to `checkbox.html` and `radio.html`

## Testing

1.

## Screenshots


## Notes

- This will be used in conjunction will a button and message encouraging users to print the page

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [ ] Chrome on desktop
- [ ] Firefox
- [ ] Safari on macOS
- [ ] Edge
- [ ] Internet Explorer 9, 10, and 11
- [ ] Safari on iOS
- [ ] Chrome on Android

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
